### PR TITLE
'CAPI' prefixed types ❌ 'FE' prefixed types ✅

### DIFF
--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -1,5 +1,5 @@
 // ------------------------  //
-// CAPIArticleType and its subtypes //
+// Frontend format types     //
 // ------------------------- //
 
 // Pillars are used for styling
@@ -22,11 +22,11 @@ type ThemePillar =
 	| 'LifestylePillar';
 
 type ThemeSpecial = 'SpecialReportTheme' | 'Labs' | 'SpecialReportAltTheme';
-type CAPITheme = ThemePillar | ThemeSpecial;
+type FETheme = ThemePillar | ThemeSpecial;
 
-// CAPIDesign is what CAPI gives us on the Format field
+// FEDesign is what frontend gives (originating in the capi scala client) us on the Format field
 // https://github.com/guardian/content-api-scala-client/blob/master/client/src/main/scala/com.gu.contentapi.client/utils/format/Design.scala
-type CAPIDesign =
+type FEDesign =
 	| 'ArticleDesign'
 	| 'GalleryDesign'
 	| 'AudioDesign'
@@ -51,21 +51,21 @@ type CAPIDesign =
 	| 'FullPageInteractiveDesign'
 	| 'NewsletterSignupDesign';
 
-// CAPIDisplay is the display information passed through from CAPI and dictates the displaystyle of the content e.g. Immersive
+// FEDisplay is the display information passed through from frontend (originating in the capi scala client) and dictates the displaystyle of the content e.g. Immersive
 // https://github.com/guardian/content-api-scala-client/blob/master/client/src/main/scala/com.gu.contentapi.client/utils/format/Display.scala
-type CAPIDisplay =
+type FEDisplay =
 	| 'StandardDisplay'
 	| 'ImmersiveDisplay'
 	| 'ShowcaseDisplay'
 	| 'NumberedListDisplay';
 
-// CAPIFormat is the stringified version of Format passed through from CAPI.
+// FEFormat is the stringified version of Format passed through from Frontend.
 // It gets converted to the @guardian/libs format on platform
 
-type CAPIFormat = {
-	design: CAPIDesign;
-	theme: CAPITheme;
-	display: CAPIDisplay;
+type FEFormat = {
+	design: FEDesign;
+	theme: FETheme;
+	display: FEDisplay;
 };
 
 type ArticleDisplay = import('@guardian/libs').ArticleDisplay;
@@ -153,7 +153,7 @@ interface BlockContributor {
 
 interface Block {
 	id: string;
-	elements: import('./src/types/content').CAPIElement[];
+	elements: import('./src/types/content').FEElement[];
 	attributes: Attributes;
 	blockCreatedOn?: number;
 	blockCreatedOnDisplay?: string;
@@ -241,32 +241,34 @@ type CricketMatch = {
 };
 
 // Data types for the API request bodies from clients that require
-// transformation before internal use. If we use the data as-is, we avoid the
-// CAPI prefix. Note also, the 'CAPI' prefix naming convention is a bit
-// misleading - the model is *not* the same as the Content API content models.
+// transformation before internal use.
+// Where data types are coming from Frontend we try to use the 'FE' prefix.
+//
+// Prior to this we used 'CAPI' as a prefix which wasn't entirely accurate,
+// and some data structures never received the prefix, meaning some are still missing it.
 
-interface CAPILinkType {
+interface FELinkType {
 	url: string;
 	title: string;
 	longTitle?: string;
 	iconName?: string;
-	children?: CAPILinkType[];
+	children?: FELinkType[];
 	pillar?: LegacyPillar;
 	more?: boolean;
 	classList?: string[];
 }
 
-interface CAPINavType {
+interface FENavType {
 	currentUrl: string;
-	pillars: CAPILinkType[];
-	otherLinks: CAPILinkType[];
-	brandExtensions: CAPILinkType[];
-	currentNavLink?: CAPILinkType;
+	pillars: FELinkType[];
+	otherLinks: FELinkType[];
+	brandExtensions: FELinkType[];
+	currentNavLink?: FELinkType;
 	currentNavLinkTitle?: string;
 	currentPillarTitle?: string;
 	subNavSections?: {
-		parent?: CAPILinkType;
-		links: CAPILinkType[];
+		parent?: FELinkType;
+		links: FELinkType[];
 	};
 	readerRevenueLinks: ReaderRevenuePositions;
 }
@@ -276,9 +278,9 @@ type StageType = 'DEV' | 'CODE' | 'PROD';
 /**
  * BlocksRequest is the expected body format for POST requests made to /Blocks
  */
-interface BlocksRequest {
+interface FEBlocksRequest {
 	blocks: Block[];
-	format: CAPIFormat;
+	format: FEFormat;
 	host?: string;
 	pageId: string;
 	webTitle: string;
@@ -297,9 +299,9 @@ interface BlocksRequest {
 /**
  * KeyEventsRequest is the expected body format for POST requests made to /KeyEvents
  */
-interface KeyEventsRequest {
+interface FEKeyEventsRequest {
 	keyEvents: Block[];
-	format: CAPIFormat;
+	format: FEFormat;
 	filterKeyEvents: boolean;
 }
 

--- a/dotcom-rendering/src/amp/components/BodyArticle.tsx
+++ b/dotcom-rendering/src/amp/components/BodyArticle.tsx
@@ -107,7 +107,7 @@ type Props = {
 };
 
 export const Body = ({ data, config }: Props) => {
-	const capiElements = data.blocks[0] ? data.blocks[0].elements : [];
+	const bodyElements = data.blocks[0] ? data.blocks[0].elements : [];
 	const adTargeting: AdTargeting = buildAdTargeting({
 		isAdFreeUser: data.isAdFreeUser,
 		isSensitive: config.isSensitive,
@@ -120,12 +120,12 @@ export const Body = ({ data, config }: Props) => {
 	const design = decideDesign(data.format);
 	const pillar = decideTheme(data.format);
 	const elementsWithoutAds = Elements(
-		capiElements,
+		bodyElements,
 		pillar,
 		data.isImmersive,
 		adTargeting,
 	);
-	const slotIndexes = findAdSlots(capiElements);
+	const slotIndexes = findAdSlots(bodyElements);
 	const adInfo = {
 		adUnit: config.adUnit,
 		section: data.sectionName,

--- a/dotcom-rendering/src/amp/components/Elements.tsx
+++ b/dotcom-rendering/src/amp/components/Elements.tsx
@@ -1,6 +1,6 @@
 import { NotRenderableInDCR } from '../../lib/errors/not-renderable-in-dcr';
 import type { Switches } from '../../types/config';
-import type { CAPIElement } from '../../types/content';
+import type { FEElement } from '../../types/content';
 import type { TagType } from '../../types/tag';
 import { enhance } from '../lib/enhance';
 import { AudioAtomBlockComponent } from './elements/AudioAtomBlockComponent';
@@ -67,9 +67,9 @@ export const isAmpSupported = ({
 	switches,
 	main,
 }: {
-	format: CAPIFormat;
+	format: FEFormat;
 	tags: TagType[];
-	elements: CAPIElement[];
+	elements: FEElement[];
 	switches: Switches;
 	main: string;
 }): boolean => {
@@ -104,7 +104,7 @@ export const isAmpSupported = ({
 };
 
 export const Elements = (
-	elements: CAPIElement[],
+	elements: FEElement[],
 	pillar: ArticleTheme,
 	isImmersive: boolean,
 	adTargeting?: AdTargeting,

--- a/dotcom-rendering/src/amp/components/MainMedia.tsx
+++ b/dotcom-rendering/src/amp/components/MainMedia.tsx
@@ -5,7 +5,7 @@ import {
 	visuallyHidden,
 } from '@guardian/source-foundations';
 import InfoIcon from '../../static/icons/info.svg';
-import type { CAPIElement, ImageBlockElement } from '../../types/content';
+import type { FEElement, ImageBlockElement } from '../../types/content';
 import { bestFitImage, heightEstimate } from '../lib/image-fit';
 import { scrsetStringFromImagesSources } from '../lib/srcset-utils';
 import { YoutubeBlockComponentAMP } from './elements/YoutubeBlockComponentAMP';
@@ -125,7 +125,7 @@ const expanded = css`
 `;
 
 const asComponent = (
-	element: CAPIElement,
+	element: FEElement,
 	pillar: ArticleTheme,
 	adTargeting?: any,
 ) => {
@@ -146,7 +146,7 @@ const asComponent = (
 };
 
 type Props = {
-	element: CAPIElement;
+	element: FEElement;
 	pillar: ArticleTheme;
 	adTargeting?: any;
 };

--- a/dotcom-rendering/src/amp/lib/enhance.ts
+++ b/dotcom-rendering/src/amp/lib/enhance.ts
@@ -1,6 +1,6 @@
 import { minify } from 'html-minifier';
 import { sanitiseHTML } from '../../model/sanitise';
-import { CAPIElement } from '../../types/content';
+import type { FEElement } from '../../types/content';
 
 // We don't represent lists in InCopy, so things will just come across with bullet characters.
 // These may also be used for emphasis, so bullet characters don't mean list.
@@ -21,7 +21,7 @@ const clean = (html: string) => {
 	});
 };
 
-export const enhance = (elements: CAPIElement[]): CAPIElement[] => {
+export const enhance = (elements: FEElement[]): FEElement[] => {
 	return elements.map((element) => {
 		if (
 			element._type ===

--- a/dotcom-rendering/src/amp/lib/find-adslots.test.ts
+++ b/dotcom-rendering/src/amp/lib/find-adslots.test.ts
@@ -1,5 +1,5 @@
 import type {
-	CAPIElement,
+	FEElement,
 	ImageBlockElement,
 	TextBlockElement,
 } from '../../types/content';
@@ -40,7 +40,7 @@ describe('ampadslots', () => {
 		});
 
 		it('adds an advert after 700 chars', () => {
-			const data: CAPIElement[] = [
+			const data: FEElement[] = [
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					elementId: 'mockId',

--- a/dotcom-rendering/src/amp/lib/find-adslots.ts
+++ b/dotcom-rendering/src/amp/lib/find-adslots.ts
@@ -17,10 +17,10 @@
  * around the ad and it can be placed.
  */
 
-import type { CAPIElement } from '../../types/content';
+import type { FEElement } from '../../types/content';
 
 interface ElementWithLength {
-	element: CAPIElement;
+	element: FEElement;
 	length: number;
 }
 
@@ -29,11 +29,11 @@ export const SMALL_PARA_CHARS = 50;
 const NONTEXT_BUFFER_FORWARD = 300;
 const NONTEXT_BUFFER_BACKWARD = 200;
 
-const isTextElement = (e: CAPIElement): boolean => {
+const isTextElement = (e: FEElement): boolean => {
 	return e._type === 'model.dotcomrendering.pageElements.TextBlockElement';
 };
 
-export const getElementLength = (element: CAPIElement): number => {
+export const getElementLength = (element: FEElement): number => {
 	switch (element._type) {
 		case 'model.dotcomrendering.pageElements.TextBlockElement':
 			// we don't want to count html characters
@@ -44,9 +44,7 @@ export const getElementLength = (element: CAPIElement): number => {
 	}
 };
 
-const getElementsWithLength = (
-	elements: CAPIElement[],
-): ElementWithLength[] => {
+const getElementsWithLength = (elements: FEElement[]): ElementWithLength[] => {
 	return elements.map((e) => {
 		return {
 			element: e,
@@ -141,7 +139,7 @@ const hasSpaceForAd = (
 };
 
 // Returns index of items to place ads *after*
-export const findAdSlots = (elements: CAPIElement[]): number[] => {
+export const findAdSlots = (elements: FEElement[]): number[] => {
 	let charsSinceLastAd = 0;
 	let paragraphsSinceLastAd = 0;
 	let adCount = 0;

--- a/dotcom-rendering/src/amp/lib/scripts.ts
+++ b/dotcom-rendering/src/amp/lib/scripts.ts
@@ -1,12 +1,12 @@
-import type { CAPIElement } from '../../types/content';
+import type { FEElement } from '../../types/content';
 
 const notEmpty = (value: string | null): value is string => value !== null;
 const unique = (value: string | null, index: number, self: (string | null)[]) =>
 	value && self.indexOf(value) === index;
 
 export const extractScripts: (
-	elements: CAPIElement[],
-	mainMediaElements: CAPIElement[],
+	elements: FEElement[],
+	mainMediaElements: FEElement[],
 ) => string[] = (elements, mainMediaElements) => {
 	return [...new Set([...elements, ...mainMediaElements].map((e) => e._type))]
 		.map((t) => {

--- a/dotcom-rendering/src/amp/types/ArticleModel.tsx
+++ b/dotcom-rendering/src/amp/types/ArticleModel.tsx
@@ -1,5 +1,5 @@
 import type { CommercialProperties } from '../../types/commercial';
-import type { CAPIElement } from '../../types/content';
+import type { FEElement } from '../../types/content';
 import type { TagType } from '../../types/tag';
 import type { EditionId } from '../../web/lib/edition';
 
@@ -8,7 +8,7 @@ export interface ArticleModel {
 	headline: string;
 	standfirst: string;
 	webTitle: string;
-	mainMediaElements: CAPIElement[];
+	mainMediaElements: FEElement[];
 	keyEvents: Block[]; // liveblog-specific
 	pagination?: Pagination;
 	blocks: Block[];
@@ -16,7 +16,7 @@ export interface ArticleModel {
 	webPublicationDateDeprecated: string;
 	webPublicationDateDisplay: string;
 	pageId: string;
-	format: CAPIFormat;
+	format: FEFormat;
 
 	// Include pillar and designType until we remove them upstream
 	// We type designType as `string` for now so that the field is present,
@@ -29,8 +29,8 @@ export interface ArticleModel {
 	sectionUrl?: string;
 	sectionName?: string;
 	tags: TagType[];
-	subMetaSectionLinks: CAPILinkType[];
-	subMetaKeywordLinks: CAPILinkType[];
+	subMetaSectionLinks: FELinkType[];
+	subMetaKeywordLinks: FELinkType[];
 	webURL: string;
 	shouldHideAds: boolean;
 	shouldHideReaderRevenue: boolean;

--- a/dotcom-rendering/src/amp/types/ArticleModel.tsx
+++ b/dotcom-rendering/src/amp/types/ArticleModel.tsx
@@ -3,7 +3,7 @@ import type { FEElement } from '../../types/content';
 import type { TagType } from '../../types/tag';
 import type { EditionId } from '../../web/lib/edition';
 
-// This is a subset of CAPIArticleType for use in AMP and as a result there needs to be parity between the types of shared fields.
+// This is a subset of FEArticleType for use in AMP and as a result there needs to be parity between the types of shared fields.
 export interface ArticleModel {
 	headline: string;
 	standfirst: string;

--- a/dotcom-rendering/src/model/article-schema.json
+++ b/dotcom-rendering/src/model/article-schema.json
@@ -256,13 +256,13 @@
             "type": "object",
             "properties": {
                 "design": {
-                    "$ref": "#/definitions/CAPIDesign"
+                    "$ref": "#/definitions/FEDesign"
                 },
                 "theme": {
-                    "$ref": "#/definitions/CAPITheme"
+                    "$ref": "#/definitions/FETheme"
                 },
                 "display": {
-                    "$ref": "#/definitions/CAPIDisplay"
+                    "$ref": "#/definitions/FEDisplay"
                 }
             },
             "required": [
@@ -292,13 +292,13 @@
         "subMetaSectionLinks": {
             "type": "array",
             "items": {
-                "$ref": "#/definitions/CAPILinkType"
+                "$ref": "#/definitions/FELinkType"
             }
         },
         "subMetaKeywordLinks": {
             "type": "array",
             "items": {
-                "$ref": "#/definitions/CAPILinkType"
+                "$ref": "#/definitions/FELinkType"
             }
         },
         "shouldHideAds": {
@@ -359,7 +359,7 @@
                 "trails": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/CAPITrailType"
+                        "$ref": "#/definitions/FETrailType"
                     }
                 },
                 "heading": {
@@ -383,7 +383,7 @@
                     "trails": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/definitions/CAPITrailType"
+                            "$ref": "#/definitions/FETrailType"
                         }
                     },
                     "description": {
@@ -399,13 +399,13 @@
                         "type": "object",
                         "properties": {
                             "design": {
-                                "$ref": "#/definitions/CAPIDesign"
+                                "$ref": "#/definitions/FEDesign"
                             },
                             "theme": {
-                                "$ref": "#/definitions/CAPITheme"
+                                "$ref": "#/definitions/FETheme"
                             },
                             "display": {
-                                "$ref": "#/definitions/CAPIDisplay"
+                                "$ref": "#/definitions/FEDisplay"
                             }
                         },
                         "required": [
@@ -445,7 +445,7 @@
             "$ref": "#/definitions/BadgeType"
         },
         "nav": {
-            "$ref": "#/definitions/CAPINavType"
+            "$ref": "#/definitions/FENavType"
         },
         "pageFooter": {
             "$ref": "#/definitions/FooterType"
@@ -2418,13 +2418,13 @@
                     "type": "object",
                     "properties": {
                         "design": {
-                            "$ref": "#/definitions/CAPIDesign"
+                            "$ref": "#/definitions/FEDesign"
                         },
                         "theme": {
-                            "$ref": "#/definitions/CAPITheme"
+                            "$ref": "#/definitions/FETheme"
                         },
                         "display": {
-                            "$ref": "#/definitions/CAPIDisplay"
+                            "$ref": "#/definitions/FEDisplay"
                         }
                     },
                     "required": [
@@ -2442,7 +2442,7 @@
                 "position"
             ]
         },
-        "CAPIDesign": {
+        "FEDesign": {
             "enum": [
                 "AnalysisDesign",
                 "ArticleDesign",
@@ -2470,7 +2470,7 @@
             ],
             "type": "string"
         },
-        "CAPITheme": {
+        "FETheme": {
             "enum": [
                 "CulturePillar",
                 "Labs",
@@ -2483,7 +2483,7 @@
             ],
             "type": "string"
         },
-        "CAPIDisplay": {
+        "FEDisplay": {
             "enum": [
                 "ImmersiveDisplay",
                 "NumberedListDisplay",
@@ -3963,7 +3963,7 @@
             ],
             "type": "string"
         },
-        "CAPILinkType": {
+        "FELinkType": {
             "type": "object",
             "properties": {
                 "url": {
@@ -3981,7 +3981,7 @@
                 "children": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/CAPILinkType"
+                        "$ref": "#/definitions/FELinkType"
                     }
                 },
                 "pillar": {
@@ -4210,20 +4210,20 @@
             ],
             "type": "string"
         },
-        "CAPITrailType": {
+        "FETrailType": {
             "type": "object",
             "properties": {
                 "format": {
                     "type": "object",
                     "properties": {
                         "design": {
-                            "$ref": "#/definitions/CAPIDesign"
+                            "$ref": "#/definitions/FEDesign"
                         },
                         "theme": {
-                            "$ref": "#/definitions/CAPITheme"
+                            "$ref": "#/definitions/FETheme"
                         },
                         "display": {
-                            "$ref": "#/definitions/CAPIDisplay"
+                            "$ref": "#/definitions/FEDisplay"
                         }
                     },
                     "required": [
@@ -4548,7 +4548,7 @@
                 "seriesTag"
             ]
         },
-        "CAPINavType": {
+        "FENavType": {
             "type": "object",
             "properties": {
                 "currentUrl": {
@@ -4557,23 +4557,23 @@
                 "pillars": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/CAPILinkType"
+                        "$ref": "#/definitions/FELinkType"
                     }
                 },
                 "otherLinks": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/CAPILinkType"
+                        "$ref": "#/definitions/FELinkType"
                     }
                 },
                 "brandExtensions": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/CAPILinkType"
+                        "$ref": "#/definitions/FELinkType"
                     }
                 },
                 "currentNavLink": {
-                    "$ref": "#/definitions/CAPILinkType"
+                    "$ref": "#/definitions/FELinkType"
                 },
                 "currentNavLinkTitle": {
                     "type": "string"
@@ -4585,12 +4585,12 @@
                     "type": "object",
                     "properties": {
                         "parent": {
-                            "$ref": "#/definitions/CAPILinkType"
+                            "$ref": "#/definitions/FELinkType"
                         },
                         "links": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/CAPILinkType"
+                                "$ref": "#/definitions/FELinkType"
                             }
                         }
                     },

--- a/dotcom-rendering/src/model/enhance-H2s.ts
+++ b/dotcom-rendering/src/model/enhance-H2s.ts
@@ -1,8 +1,8 @@
 import { JSDOM } from 'jsdom';
-import type { CAPIElement, SubheadingBlockElement } from '../types/content';
+import type { FEElement, SubheadingBlockElement } from '../types/content';
 import { isLegacyTableOfContents } from './isLegacyTableOfContents';
 
-const shouldUseLegacyIDs = (elements: CAPIElement[]): boolean => {
+const shouldUseLegacyIDs = (elements: FEElement[]): boolean => {
 	return elements.some(
 		(element) =>
 			element._type ===
@@ -61,9 +61,9 @@ const generateId = (element: SubheadingBlockElement, existingIds: string[]) => {
  * If our h2 element is a subheading then we want to insert a humanised slug of the header text as its ID.
  * We make sure to store each slug inside an array so that we can verify if this slug already exists as an id. If it does, we add the number of times it appears on the page to make sure the id is always unique.
  */
-const enhance = (elements: CAPIElement[]): CAPIElement[] => {
+const enhance = (elements: FEElement[]): FEElement[] => {
 	const slugifiedIds: string[] = [];
-	const enhanced: CAPIElement[] = [];
+	const enhanced: FEElement[] = [];
 	const shouldUseElementId = shouldUseLegacyIDs(elements);
 	elements.forEach((element) => {
 		if (

--- a/dotcom-rendering/src/model/enhance-H3s.ts
+++ b/dotcom-rendering/src/model/enhance-H3s.ts
@@ -1,14 +1,12 @@
 import { JSDOM } from 'jsdom';
-import type { CAPIElement, TextBlockElement } from '../types/content';
+import type { FEElement, TextBlockElement } from '../types/content';
 import { sanitiseHTML } from './sanitise';
 
 /**
  * Checks if this element is a 'false h3' based on the convention: <p><strong>H3 text</strong></p>
  */
 
-const isTextBlockElement = (
-	element: CAPIElement,
-): element is TextBlockElement =>
+const isTextBlockElement = (element: FEElement): element is TextBlockElement =>
 	element._type === 'model.dotcomrendering.pageElements.TextBlockElement';
 
 const isFalseH3 = (element: TextBlockElement): element is FalseH3 => {
@@ -50,7 +48,7 @@ const extractH3 = (element: FalseH3): string => {
  * you insert <p><strong>Faux H3!</strong>,</p> then we replace it with a h3 tag
  * instead.
  */
-const enhance = (elements: CAPIElement[]): CAPIElement[] =>
+const enhance = (elements: FEElement[]): FEElement[] =>
 	elements.map((thisElement) => {
 		if (isTextBlockElement(thisElement) && isFalseH3(thisElement)) {
 			const h3Text = extractH3(thisElement);
@@ -64,7 +62,7 @@ const enhance = (elements: CAPIElement[]): CAPIElement[] =>
 		}
 	});
 
-export const enhanceH3s = (blocks: Block[], format: CAPIFormat): Block[] => {
+export const enhanceH3s = (blocks: Block[], format: FEFormat): Block[] => {
 	const hasChapteredUI =
 		format.display === 'NumberedListDisplay' ||
 		format.design === 'AnalysisDesign' ||

--- a/dotcom-rendering/src/model/enhance-blockquotes.test.ts
+++ b/dotcom-rendering/src/model/enhance-blockquotes.test.ts
@@ -5,7 +5,7 @@ import { enhanceBlockquotes } from './enhance-blockquotes';
 
 const example: FEArticleType = ExampleArticle;
 
-const formatIsPhotoEssay: CAPIFormat = {
+const formatIsPhotoEssay: FEFormat = {
 	...example.format,
 	design: 'PhotoEssayDesign',
 };

--- a/dotcom-rendering/src/model/enhance-blockquotes.ts
+++ b/dotcom-rendering/src/model/enhance-blockquotes.ts
@@ -1,5 +1,5 @@
 import { JSDOM } from 'jsdom';
-import type { BlockquoteBlockElement, CAPIElement } from '../types/content';
+import type { BlockquoteBlockElement, FEElement } from '../types/content';
 
 const isQuoted = (element: BlockquoteBlockElement): boolean => {
 	// A quoted blockquote: <blockquote class="quoted"><p>I think therefore I am</p></blockquote>
@@ -7,12 +7,9 @@ const isQuoted = (element: BlockquoteBlockElement): boolean => {
 	return !!frag.querySelector('.quoted');
 };
 
-const enhance = (
-	elements: CAPIElement[],
-	isPhotoEssay: boolean,
-): CAPIElement[] => {
+const enhance = (elements: FEElement[], isPhotoEssay: boolean): FEElement[] => {
 	// Loops the array of article elements looking for BlockquoteBlockElements to enhance
-	const enhanced: CAPIElement[] = [];
+	const enhanced: FEElement[] = [];
 	elements.forEach((element) => {
 		switch (element._type) {
 			case 'model.dotcomrendering.pageElements.BlockquoteBlockElement':
@@ -47,7 +44,7 @@ const enhance = (
 
 export const enhanceBlockquotes = (
 	blocks: Block[],
-	format: CAPIFormat,
+	format: FEFormat,
 ): Block[] => {
 	const isPhotoEssay = format.design === 'PhotoEssayDesign';
 

--- a/dotcom-rendering/src/model/enhance-dividers.ts
+++ b/dotcom-rendering/src/model/enhance-dividers.ts
@@ -1,7 +1,7 @@
 import { JSDOM } from 'jsdom';
-import type { CAPIElement } from '../types/content';
+import type { FEElement } from '../types/content';
 
-const isDinkus = (element: CAPIElement): boolean => {
+const isDinkus = (element: FEElement): boolean => {
 	// Classic dinkus do not trigger dropcaps
 	if (
 		element._type !==
@@ -21,12 +21,12 @@ const isDinkus = (element: CAPIElement): boolean => {
 	);
 };
 
-const checkForDividers = (elements: CAPIElement[]): CAPIElement[] => {
+const checkForDividers = (elements: FEElement[]): FEElement[] => {
 	// checkForDividers loops the array of article elements looking for star flags and
 	// enhancing the data accordingly. In short, if a h2 tag is equal to * * * then we
 	// insert a divider and any the text element immediately afterwards should have dropCap
 	// set to true
-	const enhanced: CAPIElement[] = [];
+	const enhanced: FEElement[] = [];
 	elements.forEach((element, i) => {
 		const previous = elements[i - 1];
 

--- a/dotcom-rendering/src/model/enhance-dots.ts
+++ b/dotcom-rendering/src/model/enhance-dots.ts
@@ -1,9 +1,9 @@
-import type { CAPIElement } from '../types/content';
+import type { FEElement } from '../types/content';
 import { transformDots } from './transformDots';
 
-const checkForDots = (elements: CAPIElement[]): CAPIElement[] => {
+const checkForDots = (elements: FEElement[]): FEElement[] => {
 	// Loop over elements and check if a dot is in the TextBlockElement
-	const enhanced: CAPIElement[] = [];
+	const enhanced: FEElement[] = [];
 	elements.forEach((element, i) => {
 		if (
 			element._type ===

--- a/dotcom-rendering/src/model/enhance-embeds.ts
+++ b/dotcom-rendering/src/model/enhance-embeds.ts
@@ -1,8 +1,8 @@
 import { JSDOM } from 'jsdom';
-import type { CAPIElement } from '../types/content';
+import type { FEElement } from '../types/content';
 
-const addTitleToIframe = (elements: CAPIElement[]): CAPIElement[] => {
-	const enhanced: CAPIElement[] = [];
+const addTitleToIframe = (elements: FEElement[]): FEElement[] => {
+	const enhanced: FEElement[] = [];
 	elements.forEach((element) => {
 		switch (element._type) {
 			case 'model.dotcomrendering.pageElements.EmbedBlockElement':

--- a/dotcom-rendering/src/model/enhance-images.ts
+++ b/dotcom-rendering/src/model/enhance-images.ts
@@ -1,6 +1,6 @@
 import { JSDOM } from 'jsdom';
 import type {
-	CAPIElement,
+	FEElement,
 	ImageBlockElement,
 	MultiImageBlockElement,
 	SubheadingBlockElement,
@@ -12,7 +12,7 @@ interface HalfWidthImageBlockElement extends ImageBlockElement {
 }
 
 const isHalfWidthImage = (
-	element?: CAPIElement,
+	element?: FEElement,
 ): element is HalfWidthImageBlockElement => {
 	if (!element) return false;
 	return (
@@ -23,7 +23,7 @@ const isHalfWidthImage = (
 };
 
 const isMultiImage = (
-	element?: CAPIElement,
+	element?: FEElement,
 ): element is MultiImageBlockElement => {
 	if (!element) return false;
 	return (
@@ -32,14 +32,14 @@ const isMultiImage = (
 	);
 };
 
-const isImage = (element?: CAPIElement): element is ImageBlockElement => {
+const isImage = (element?: FEElement): element is ImageBlockElement => {
 	if (!element) return false;
 	return (
 		element._type === 'model.dotcomrendering.pageElements.ImageBlockElement'
 	);
 };
 
-const isTitle = (element?: CAPIElement): element is SubheadingBlockElement => {
+const isTitle = (element?: FEElement): element is SubheadingBlockElement => {
 	if (!element) return false;
 	// Checks if this element is a 'title' based on the convention: <h2>Title text</h2>
 	if (
@@ -65,7 +65,7 @@ const extractTitle = (element: SubheadingBlockElement): string => {
 	return '';
 };
 
-const isCaption = (element?: CAPIElement): element is TextBlockElement => {
+const isCaption = (element?: FEElement): element is TextBlockElement => {
 	if (!element) return false;
 	// Checks if this element is a 'caption' based on the convention: <ul><li><Caption text</li></ul>
 	if (
@@ -120,8 +120,8 @@ const constructMultiImageElement = (
 	};
 };
 
-const addMultiImageElements = (elements: CAPIElement[]): CAPIElement[] => {
-	const withMultiImageElements: CAPIElement[] = [];
+const addMultiImageElements = (elements: FEElement[]): FEElement[] => {
+	const withMultiImageElements: FEElement[] = [];
 	elements.forEach((thisElement, i) => {
 		const nextElement = elements[i + 1];
 		if (isHalfWidthImage(thisElement) && isHalfWidthImage(nextElement)) {
@@ -139,8 +139,8 @@ const addMultiImageElements = (elements: CAPIElement[]): CAPIElement[] => {
 	return withMultiImageElements;
 };
 
-const addTitles = (elements: CAPIElement[]): CAPIElement[] => {
-	const withTitles: CAPIElement[] = [];
+const addTitles = (elements: FEElement[]): FEElement[] => {
+	const withTitles: FEElement[] = [];
 	elements.forEach((thisElement, i) => {
 		const nextElement = elements[i + 1];
 		const subsequentElement = elements[i + 2];
@@ -172,8 +172,8 @@ const addTitles = (elements: CAPIElement[]): CAPIElement[] => {
 	return withTitles;
 };
 
-const addCaptionsToImages = (elements: CAPIElement[]): CAPIElement[] => {
-	const withSpecialCaptions: CAPIElement[] = [];
+const addCaptionsToImages = (elements: FEElement[]): FEElement[] => {
+	const withSpecialCaptions: FEElement[] = [];
 	elements.forEach((thisElement, i) => {
 		const nextElement = elements[i + 1];
 		const subsequentElement = elements[i + 2];
@@ -211,8 +211,8 @@ const addCaptionsToImages = (elements: CAPIElement[]): CAPIElement[] => {
 	return withSpecialCaptions;
 };
 
-const addCaptionsToMultis = (elements: CAPIElement[]): CAPIElement[] => {
-	const withSpecialCaptions: CAPIElement[] = [];
+const addCaptionsToMultis = (elements: FEElement[]): FEElement[] => {
+	const withSpecialCaptions: FEElement[] = [];
 	elements.forEach((thisElement, i) => {
 		const nextElement = elements[i + 1];
 		const subsequentElement = elements[i + 2];
@@ -242,9 +242,9 @@ const addCaptionsToMultis = (elements: CAPIElement[]): CAPIElement[] => {
 	return withSpecialCaptions;
 };
 
-const stripCaptions = (elements: CAPIElement[]): CAPIElement[] => {
+const stripCaptions = (elements: FEElement[]): FEElement[] => {
 	// Remove all captions from all images
-	const withoutCaptions: CAPIElement[] = [];
+	const withoutCaptions: FEElement[] = [];
 	elements.forEach((thisElement) => {
 		if (
 			thisElement._type ===
@@ -266,9 +266,9 @@ const stripCaptions = (elements: CAPIElement[]): CAPIElement[] => {
 	return withoutCaptions;
 };
 
-const removeCredit = (elements: CAPIElement[]): CAPIElement[] => {
+const removeCredit = (elements: FEElement[]): FEElement[] => {
 	// Remove credit from all images
-	const withoutCredit: CAPIElement[] = [];
+	const withoutCredit: FEElement[] = [];
 	elements.forEach((thisElement) => {
 		if (
 			thisElement._type ===
@@ -291,9 +291,9 @@ const removeCredit = (elements: CAPIElement[]): CAPIElement[] => {
 };
 
 class Enhancer {
-	elements: CAPIElement[];
+	elements: FEElement[];
 
-	constructor(elements: CAPIElement[]) {
+	constructor(elements: FEElement[]) {
 		this.elements = elements;
 	}
 
@@ -348,10 +348,7 @@ class Enhancer {
 	}
 }
 
-const enhance = (
-	elements: CAPIElement[],
-	isPhotoEssay: boolean,
-): CAPIElement[] => {
+const enhance = (elements: FEElement[], isPhotoEssay: boolean): FEElement[] => {
 	if (isPhotoEssay) {
 		return new Enhancer(elements)
 			.stripCaptions()
@@ -372,7 +369,7 @@ const enhance = (
 	);
 };
 
-export const enhanceImages = (blocks: Block[], format: CAPIFormat): Block[] => {
+export const enhanceImages = (blocks: Block[], format: FEFormat): Block[] => {
 	const isPhotoEssay = format.design === 'PhotoEssayDesign';
 
 	return blocks.map((block: Block) => {

--- a/dotcom-rendering/src/model/enhance-interactive-contents-elements.ts
+++ b/dotcom-rendering/src/model/enhance-interactive-contents-elements.ts
@@ -1,9 +1,9 @@
-import type { CAPIElement, SubheadingBlockElement } from '../types/content';
+import type { FEElement, SubheadingBlockElement } from '../types/content';
 import { isLegacyTableOfContents } from './isLegacyTableOfContents';
 import { stripHTML } from './sanitise';
 
-const enhance = (elements: CAPIElement[]): CAPIElement[] => {
-	const updatedElements: CAPIElement[] = [];
+const enhance = (elements: FEElement[]): FEElement[] => {
+	const updatedElements: FEElement[] = [];
 	const hasInteractiveContentsBlockElement = elements.some((element) =>
 		isLegacyTableOfContents(element),
 	);

--- a/dotcom-rendering/src/model/enhance-numbered-lists.ts
+++ b/dotcom-rendering/src/model/enhance-numbered-lists.ts
@@ -1,11 +1,11 @@
 import { JSDOM } from 'jsdom';
 import type {
-	CAPIElement,
+	FEElement,
 	ImageBlockElement,
 	TextBlockElement,
 } from '../types/content';
 
-const isFalseH3 = (element: CAPIElement): boolean => {
+const isFalseH3 = (element: FEElement): boolean => {
 	if (!element) return false;
 	// Checks if this element is a 'false h3' based on the convention: <p><strong><H3 text</strong></p>
 	if (
@@ -35,7 +35,7 @@ const isFalseH3 = (element: CAPIElement): boolean => {
 	);
 };
 
-const extractH3 = (element: CAPIElement): string => {
+const extractH3 = (element: FEElement): string => {
 	// Extract the text based on the convention: <p><strong><H3 text</strong></p>
 	const textElement = element as TextBlockElement;
 	const frag = JSDOM.fragment(textElement.html);
@@ -51,7 +51,7 @@ const extractH3 = (element: CAPIElement): string => {
 	return '';
 };
 
-const isStarRating = (element: CAPIElement): boolean => {
+const isStarRating = (element: FEElement): boolean => {
 	const isStar = (charactor: string): boolean => {
 		return charactor === '★' || charactor === '☆';
 	};
@@ -71,7 +71,7 @@ const isStarRating = (element: CAPIElement): boolean => {
 	return hasPTags && hasFiveStars;
 };
 
-const extractStarCount = (element: CAPIElement): number => {
+const extractStarCount = (element: FEElement): number => {
 	const isSelectedStar = (charactor: string): boolean => {
 		return charactor === '★';
 	};
@@ -87,7 +87,7 @@ const extractStarCount = (element: CAPIElement): number => {
 	return starCount;
 };
 
-const isStarableImage = (element: CAPIElement | undefined): boolean => {
+const isStarableImage = (element: FEElement | undefined): boolean => {
 	return (
 		element?._type ===
 			'model.dotcomrendering.pageElements.ImageBlockElement' &&
@@ -95,8 +95,8 @@ const isStarableImage = (element: CAPIElement | undefined): boolean => {
 	);
 };
 
-const starifyImages = (elements: CAPIElement[]): CAPIElement[] => {
-	const starified: CAPIElement[] = [];
+const starifyImages = (elements: FEElement[]): FEElement[] => {
+	const starified: FEElement[] = [];
 	let previousRating: number | undefined;
 	elements.forEach((thisElement, index) => {
 		switch (thisElement._type) {
@@ -136,8 +136,8 @@ const starifyImages = (elements: CAPIElement[]): CAPIElement[] => {
 	return starified;
 };
 
-const inlineStarRatings = (elements: CAPIElement[]): CAPIElement[] => {
-	const withStars: CAPIElement[] = [];
+const inlineStarRatings = (elements: FEElement[]): FEElement[] => {
+	const withStars: FEElement[] = [];
 	elements.forEach((thisElement) => {
 		if (
 			thisElement._type ===
@@ -160,8 +160,8 @@ const inlineStarRatings = (elements: CAPIElement[]): CAPIElement[] => {
 	return withStars;
 };
 
-const makeThumbnailsRound = (elements: CAPIElement[]): CAPIElement[] => {
-	const inlined: CAPIElement[] = [];
+const makeThumbnailsRound = (elements: FEElement[]): FEElement[] => {
+	const inlined: FEElement[] = [];
 	elements.forEach((thisElement) => {
 		if (
 			thisElement._type ===
@@ -181,7 +181,7 @@ const makeThumbnailsRound = (elements: CAPIElement[]): CAPIElement[] => {
 	return inlined;
 };
 
-const isItemLink = (element: CAPIElement): boolean => {
+const isItemLink = (element: FEElement): boolean => {
 	if (!element) return false;
 	// Checks if this element is a 'item link' based on the convention: <ul> <li>...</li> </ul>
 	if (
@@ -200,7 +200,7 @@ const isItemLink = (element: CAPIElement): boolean => {
 	return hasULWrapper && hasOnlyOneChild && hasLINestedWrapper;
 };
 
-const removeGlobalH2Styles = (elements: CAPIElement[]): CAPIElement[] => {
+const removeGlobalH2Styles = (elements: FEElement[]): FEElement[] => {
 	/**
 	 * Article pages come with some global style rules, one of which affects h2
 	 * tags. But for numbered lists we don't want these styles because we use
@@ -211,7 +211,7 @@ const removeGlobalH2Styles = (elements: CAPIElement[]): CAPIElement[] => {
 	 * All h2 tags inside an article of Design: NumberedList have this attirbute
 	 * set.
 	 */
-	const withH2StylesIgnored: CAPIElement[] = [];
+	const withH2StylesIgnored: FEElement[] = [];
 	elements.forEach((thisElement) => {
 		if (
 			thisElement._type ===
@@ -232,7 +232,7 @@ const removeGlobalH2Styles = (elements: CAPIElement[]): CAPIElement[] => {
 	return withH2StylesIgnored;
 };
 
-const addH3s = (elements: CAPIElement[]): CAPIElement[] => {
+const addH3s = (elements: FEElement[]): FEElement[] => {
 	/**
 	 * Why not just add H3s in Composer?
 	 * Truth is, you can't. So to get around this there's a convention that says if
@@ -243,8 +243,8 @@ const addH3s = (elements: CAPIElement[]): CAPIElement[] => {
 	 * a 'fauxH3' class for this. In DCR we add `globalH3Styles` which was added at
 	 * the same time as this code.
 	 */
-	const withH3s: CAPIElement[] = [];
-	let previousItem: CAPIElement | undefined;
+	const withH3s: FEElement[] = [];
+	let previousItem: FEElement | undefined;
 	elements.forEach((thisElement) => {
 		if (
 			thisElement._type ===
@@ -280,8 +280,8 @@ const addH3s = (elements: CAPIElement[]): CAPIElement[] => {
 	return withH3s;
 };
 
-const addItemLinks = (elements: CAPIElement[]): CAPIElement[] => {
-	const withItemLink: CAPIElement[] = [];
+const addItemLinks = (elements: FEElement[]): FEElement[] => {
+	const withItemLink: FEElement[] = [];
 	elements.forEach((thisElement) => {
 		if (
 			thisElement._type ===
@@ -307,10 +307,7 @@ const addItemLinks = (elements: CAPIElement[]): CAPIElement[] => {
 	return withItemLink;
 };
 
-const addTitles = (
-	elements: CAPIElement[],
-	format: CAPIFormat,
-): CAPIElement[] => {
+const addTitles = (elements: FEElement[], format: FEFormat): FEElement[] => {
 	/**
 	 * Why not just add H3s in Composer?
 	 * Truth is, you can't. So to get around this there's a convention that says if
@@ -321,7 +318,7 @@ const addTitles = (
 	 * a 'fauxH3' class for this. In DCR we add `globalH3Styles` which was added at
 	 * the same time as this code.
 	 */
-	const withTitles: CAPIElement[] = [];
+	const withTitles: FEElement[] = [];
 	let position = 1;
 	elements.forEach((thisElement) => {
 		if (
@@ -353,11 +350,11 @@ const addTitles = (
 };
 
 class Enhancer {
-	elements: CAPIElement[];
+	elements: FEElement[];
 
-	format: CAPIFormat;
+	format: FEFormat;
 
-	constructor(elements: CAPIElement[], format: CAPIFormat) {
+	constructor(elements: FEElement[], format: FEFormat) {
 		this.elements = elements;
 		this.format = format;
 	}
@@ -398,10 +395,7 @@ class Enhancer {
 	}
 }
 
-const enhance = (
-	elements: CAPIElement[],
-	format: CAPIFormat,
-): CAPIElement[] => {
+const enhance = (elements: FEElement[], format: FEFormat): FEElement[] => {
 	return (
 		new Enhancer(elements, format)
 			// Add the data-ignore='global-h2-styling' attribute
@@ -423,7 +417,7 @@ const enhance = (
 
 export const enhanceNumberedLists = (
 	blocks: Block[],
-	format: CAPIFormat,
+	format: FEFormat,
 ): Block[] => {
 	const isNumberedList = format.display === 'NumberedListDisplay';
 

--- a/dotcom-rendering/src/model/enhance-tweets.ts
+++ b/dotcom-rendering/src/model/enhance-tweets.ts
@@ -1,7 +1,7 @@
-import { CAPIElement } from '../types/content';
+import type { FEElement } from '../types/content';
 
-const removeTweetClass = (elements: CAPIElement[]): CAPIElement[] => {
-	const enhanced: CAPIElement[] = [];
+const removeTweetClass = (elements: FEElement[]): FEElement[] => {
+	const enhanced: FEElement[] = [];
 	elements.forEach((element) => {
 		switch (element._type) {
 			case 'model.dotcomrendering.pageElements.TweetBlockElement':

--- a/dotcom-rendering/src/model/enhanceBlocks.ts
+++ b/dotcom-rendering/src/model/enhanceBlocks.ts
@@ -18,11 +18,11 @@ import { insertPromotedNewsletter } from './insertPromotedNewsletter';
 class BlockEnhancer {
 	blocks: Block[];
 
-	format: CAPIFormat;
+	format: FEFormat;
 
 	options: Options;
 
-	constructor(blocks: Block[], format: CAPIFormat, options: Options) {
+	constructor(blocks: Block[], format: FEFormat, options: Options) {
 		this.blocks = blocks;
 		this.format = format;
 		this.options = options;
@@ -99,7 +99,7 @@ type Options = {
 // as they both effect SubheadingBlockElement
 export const enhanceBlocks = (
 	blocks: Block[],
-	format: CAPIFormat,
+	format: FEFormat,
 	options?: Options,
 ): Block[] => {
 	const { promotedNewsletter } = options ?? {};

--- a/dotcom-rendering/src/model/enhanceTableOfContents.ts
+++ b/dotcom-rendering/src/model/enhanceTableOfContents.ts
@@ -1,8 +1,8 @@
 import { JSDOM } from 'jsdom';
-import type { CAPIElement, SubheadingBlockElement } from '../types/content';
+import type { FEElement, SubheadingBlockElement } from '../types/content';
 import type { TableOfContentsItem } from '../types/frontend';
 
-const isH2 = (element: CAPIElement): element is SubheadingBlockElement => {
+const isH2 = (element: FEElement): element is SubheadingBlockElement => {
 	return (
 		element._type ===
 			'model.dotcomrendering.pageElements.SubheadingBlockElement' ||
@@ -34,7 +34,7 @@ const hasInteractiveContentsElement = (blocks: Block[]): boolean => {
 };
 
 export const enhanceTableOfContents = (
-	format: CAPIFormat,
+	format: FEFormat,
 	blocks: Block[],
 ): TableOfContentsItem[] | undefined => {
 	if (hasInteractiveContentsElement(blocks)) {

--- a/dotcom-rendering/src/model/extract-ga.test.ts
+++ b/dotcom-rendering/src/model/extract-ga.test.ts
@@ -21,7 +21,7 @@ const base = {
 		"Ticket touts face unlimited fines for using 'bots' to buy in bulk",
 };
 
-const CAPIArticle = {
+const article = {
 	...ExampleArticle,
 	tags: [
 		...ExampleArticle.tags,
@@ -36,6 +36,6 @@ const CAPIArticle = {
 
 describe('Google Analytics extracts and formats CAPIArticle response correctly', () => {
 	it('GA Extract returns correctly formatted GA response', () => {
-		expect(extractGA(CAPIArticle)).toEqual(base);
+		expect(extractGA(article)).toEqual(base);
 	});
 });

--- a/dotcom-rendering/src/model/extract-ga.ts
+++ b/dotcom-rendering/src/model/extract-ga.ts
@@ -30,7 +30,7 @@ const getCommissioningDesk = (
 	return tag?.title ?? '';
 };
 
-const convertToLegacyPillar = (theme: CAPITheme): LegacyPillar => {
+const convertToLegacyPillar = (theme: FETheme): LegacyPillar => {
 	switch (theme) {
 		case 'NewsPillar':
 			return 'news';
@@ -61,7 +61,7 @@ export const extractGA = ({
 	beaconURL,
 }: {
 	webTitle: string;
-	format: CAPIFormat;
+	format: FEFormat;
 	sectionName?: string;
 	contentType: string;
 	tags: TagType[];

--- a/dotcom-rendering/src/model/extract-nav.ts
+++ b/dotcom-rendering/src/model/extract-nav.ts
@@ -1,6 +1,5 @@
 import { ArticlePillar } from '@guardian/libs';
-import { EditionId } from '../web/lib/edition';
-
+import type { EditionId } from '../web/lib/edition';
 import { findPillar } from './find-pillar';
 
 export interface BaseLinkType {
@@ -46,7 +45,7 @@ export interface NavType extends BaseNavType {
 	pillars: PillarType[];
 }
 
-const getLink = (data: CAPILinkType): LinkType => {
+const getLink = (data: FELinkType): LinkType => {
 	const { title, longTitle = title, url } = data;
 	return {
 		title,
@@ -58,7 +57,7 @@ const getLink = (data: CAPILinkType): LinkType => {
 	};
 };
 
-const getPillar = (data: CAPILinkType): PillarType => ({
+const getPillar = (data: FELinkType): PillarType => ({
 	...getLink(data),
 	pillar: findPillar(data.title) ?? ArticlePillar.News,
 });
@@ -79,7 +78,7 @@ const buildRRLinkCategories = (
 
 const buildRRLinkModel = ({
 	readerRevenueLinks,
-}: CAPINavType): ReaderRevenuePositions => ({
+}: FENavType): ReaderRevenuePositions => ({
 	header: buildRRLinkCategories(readerRevenueLinks, 'header'),
 	footer: buildRRLinkCategories(readerRevenueLinks, 'footer'),
 	sideMenu: buildRRLinkCategories(readerRevenueLinks, 'sideMenu'),
@@ -87,7 +86,7 @@ const buildRRLinkModel = ({
 	ampFooter: buildRRLinkCategories(readerRevenueLinks, 'ampFooter'),
 });
 
-export const extractNAV = (data: CAPINavType): NavType => {
+export const extractNAV = (data: FENavType): NavType => {
 	const pillars = data.pillars.map(getPillar);
 
 	const { subNavSections: subnav, currentNavLinkTitle: currentNavLink = '' } =

--- a/dotcom-rendering/src/model/front-schema.json
+++ b/dotcom-rendering/src/model/front-schema.json
@@ -5,7 +5,7 @@
             "$ref": "#/definitions/FEPressedPageType"
         },
         "nav": {
-            "$ref": "#/definitions/CAPINavType"
+            "$ref": "#/definitions/FENavType"
         },
         "editionId": {
             "$ref": "#/definitions/EditionId"
@@ -379,14 +379,14 @@
         "mostViewed": {
             "type": "array",
             "items": {
-                "$ref": "#/definitions/CAPITrailType"
+                "$ref": "#/definitions/FETrailType"
             }
         },
         "mostCommented": {
-            "$ref": "#/definitions/CAPITrailType"
+            "$ref": "#/definitions/FETrailType"
         },
         "mostShared": {
-            "$ref": "#/definitions/CAPITrailType"
+            "$ref": "#/definitions/FETrailType"
         }
     },
     "required": [
@@ -613,13 +613,13 @@
                                                                     "type": "object",
                                                                     "properties": {
                                                                         "design": {
-                                                                            "$ref": "#/definitions/CAPIDesign"
+                                                                            "$ref": "#/definitions/FEDesign"
                                                                         },
                                                                         "theme": {
-                                                                            "$ref": "#/definitions/CAPITheme"
+                                                                            "$ref": "#/definitions/FETheme"
                                                                         },
                                                                         "display": {
-                                                                            "$ref": "#/definitions/CAPIDisplay"
+                                                                            "$ref": "#/definitions/FEDisplay"
                                                                         }
                                                                     },
                                                                     "required": [
@@ -1022,13 +1022,13 @@
                                             "type": "object",
                                             "properties": {
                                                 "design": {
-                                                    "$ref": "#/definitions/CAPIDesign"
+                                                    "$ref": "#/definitions/FEDesign"
                                                 },
                                                 "theme": {
-                                                    "$ref": "#/definitions/CAPITheme"
+                                                    "$ref": "#/definitions/FETheme"
                                                 },
                                                 "display": {
-                                                    "$ref": "#/definitions/CAPIDisplay"
+                                                    "$ref": "#/definitions/FEDisplay"
                                                 }
                                             },
                                             "required": [
@@ -1107,13 +1107,13 @@
                                                         "type": "object",
                                                         "properties": {
                                                             "design": {
-                                                                "$ref": "#/definitions/CAPIDesign"
+                                                                "$ref": "#/definitions/FEDesign"
                                                             },
                                                             "theme": {
-                                                                "$ref": "#/definitions/CAPITheme"
+                                                                "$ref": "#/definitions/FETheme"
                                                             },
                                                             "display": {
-                                                                "$ref": "#/definitions/CAPIDisplay"
+                                                                "$ref": "#/definitions/FEDisplay"
                                                             }
                                                         },
                                                         "required": [
@@ -1293,13 +1293,13 @@
                                                                     "type": "object",
                                                                     "properties": {
                                                                         "design": {
-                                                                            "$ref": "#/definitions/CAPIDesign"
+                                                                            "$ref": "#/definitions/FEDesign"
                                                                         },
                                                                         "theme": {
-                                                                            "$ref": "#/definitions/CAPITheme"
+                                                                            "$ref": "#/definitions/FETheme"
                                                                         },
                                                                         "display": {
-                                                                            "$ref": "#/definitions/CAPIDisplay"
+                                                                            "$ref": "#/definitions/FEDisplay"
                                                                         }
                                                                     },
                                                                     "required": [
@@ -1702,13 +1702,13 @@
                                             "type": "object",
                                             "properties": {
                                                 "design": {
-                                                    "$ref": "#/definitions/CAPIDesign"
+                                                    "$ref": "#/definitions/FEDesign"
                                                 },
                                                 "theme": {
-                                                    "$ref": "#/definitions/CAPITheme"
+                                                    "$ref": "#/definitions/FETheme"
                                                 },
                                                 "display": {
-                                                    "$ref": "#/definitions/CAPIDisplay"
+                                                    "$ref": "#/definitions/FEDisplay"
                                                 }
                                             },
                                             "required": [
@@ -1787,13 +1787,13 @@
                                                         "type": "object",
                                                         "properties": {
                                                             "design": {
-                                                                "$ref": "#/definitions/CAPIDesign"
+                                                                "$ref": "#/definitions/FEDesign"
                                                             },
                                                             "theme": {
-                                                                "$ref": "#/definitions/CAPITheme"
+                                                                "$ref": "#/definitions/FETheme"
                                                             },
                                                             "display": {
-                                                                "$ref": "#/definitions/CAPIDisplay"
+                                                                "$ref": "#/definitions/FEDisplay"
                                                             }
                                                         },
                                                         "required": [
@@ -1973,13 +1973,13 @@
                                                                     "type": "object",
                                                                     "properties": {
                                                                         "design": {
-                                                                            "$ref": "#/definitions/CAPIDesign"
+                                                                            "$ref": "#/definitions/FEDesign"
                                                                         },
                                                                         "theme": {
-                                                                            "$ref": "#/definitions/CAPITheme"
+                                                                            "$ref": "#/definitions/FETheme"
                                                                         },
                                                                         "display": {
-                                                                            "$ref": "#/definitions/CAPIDisplay"
+                                                                            "$ref": "#/definitions/FEDisplay"
                                                                         }
                                                                     },
                                                                     "required": [
@@ -2382,13 +2382,13 @@
                                             "type": "object",
                                             "properties": {
                                                 "design": {
-                                                    "$ref": "#/definitions/CAPIDesign"
+                                                    "$ref": "#/definitions/FEDesign"
                                                 },
                                                 "theme": {
-                                                    "$ref": "#/definitions/CAPITheme"
+                                                    "$ref": "#/definitions/FETheme"
                                                 },
                                                 "display": {
-                                                    "$ref": "#/definitions/CAPIDisplay"
+                                                    "$ref": "#/definitions/FEDisplay"
                                                 }
                                             },
                                             "required": [
@@ -2467,13 +2467,13 @@
                                                         "type": "object",
                                                         "properties": {
                                                             "design": {
-                                                                "$ref": "#/definitions/CAPIDesign"
+                                                                "$ref": "#/definitions/FEDesign"
                                                             },
                                                             "theme": {
-                                                                "$ref": "#/definitions/CAPITheme"
+                                                                "$ref": "#/definitions/FETheme"
                                                             },
                                                             "display": {
-                                                                "$ref": "#/definitions/CAPIDisplay"
+                                                                "$ref": "#/definitions/FEDisplay"
                                                             }
                                                         },
                                                         "required": [
@@ -2657,7 +2657,7 @@
         "Record<string,unknown>": {
             "type": "object"
         },
-        "CAPIDesign": {
+        "FEDesign": {
             "enum": [
                 "AnalysisDesign",
                 "ArticleDesign",
@@ -2685,7 +2685,7 @@
             ],
             "type": "string"
         },
-        "CAPITheme": {
+        "FETheme": {
             "enum": [
                 "CulturePillar",
                 "Labs",
@@ -2698,7 +2698,7 @@
             ],
             "type": "string"
         },
-        "CAPIDisplay": {
+        "FEDisplay": {
             "enum": [
                 "ImmersiveDisplay",
                 "NumberedListDisplay",
@@ -2773,7 +2773,7 @@
             ],
             "type": "string"
         },
-        "CAPINavType": {
+        "FENavType": {
             "type": "object",
             "properties": {
                 "currentUrl": {
@@ -2782,23 +2782,23 @@
                 "pillars": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/CAPILinkType"
+                        "$ref": "#/definitions/FELinkType"
                     }
                 },
                 "otherLinks": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/CAPILinkType"
+                        "$ref": "#/definitions/FELinkType"
                     }
                 },
                 "brandExtensions": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/CAPILinkType"
+                        "$ref": "#/definitions/FELinkType"
                     }
                 },
                 "currentNavLink": {
-                    "$ref": "#/definitions/CAPILinkType"
+                    "$ref": "#/definitions/FELinkType"
                 },
                 "currentNavLinkTitle": {
                     "type": "string"
@@ -2810,12 +2810,12 @@
                     "type": "object",
                     "properties": {
                         "parent": {
-                            "$ref": "#/definitions/CAPILinkType"
+                            "$ref": "#/definitions/FELinkType"
                         },
                         "links": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/CAPILinkType"
+                                "$ref": "#/definitions/FELinkType"
                             }
                         }
                     },
@@ -2835,7 +2835,7 @@
                 "readerRevenueLinks"
             ]
         },
-        "CAPILinkType": {
+        "FELinkType": {
             "type": "object",
             "properties": {
                 "url": {
@@ -2853,7 +2853,7 @@
                 "children": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/CAPILinkType"
+                        "$ref": "#/definitions/FELinkType"
                     }
                 },
                 "pillar": {
@@ -2991,20 +2991,20 @@
                 "url"
             ]
         },
-        "CAPITrailType": {
+        "FETrailType": {
             "type": "object",
             "properties": {
                 "format": {
                     "type": "object",
                     "properties": {
                         "design": {
-                            "$ref": "#/definitions/CAPIDesign"
+                            "$ref": "#/definitions/FEDesign"
                         },
                         "theme": {
-                            "$ref": "#/definitions/CAPITheme"
+                            "$ref": "#/definitions/FETheme"
                         },
                         "display": {
-                            "$ref": "#/definitions/CAPIDisplay"
+                            "$ref": "#/definitions/FEDisplay"
                         }
                     },
                     "required": [

--- a/dotcom-rendering/src/model/insertPromotedNewsletter.ts
+++ b/dotcom-rendering/src/model/insertPromotedNewsletter.ts
@@ -1,5 +1,5 @@
 import { logger } from '../server/lib/logging';
-import type { CAPIElement, Newsletter } from '../types/content';
+import type { FEElement, Newsletter } from '../types/content';
 
 type PlaceInArticle = {
 	position: number;
@@ -83,13 +83,13 @@ const MAXIMUM_DISTANCE_AFTER_FLOATING_ELEMENT = 4;
  */
 const MAXIMUM_DISTANCE_FROM_MIDDLE = 4;
 
-const checkIfAfterText = (index: number, elements: CAPIElement[]): boolean =>
+const checkIfAfterText = (index: number, elements: FEElement[]): boolean =>
 	elements[index - 1]?._type ===
 	'model.dotcomrendering.pageElements.TextBlockElement';
 
 const getDistanceAfterFloating = (
 	index: number,
-	elements: CAPIElement[],
+	elements: FEElement[],
 ): number => {
 	const lastFloatingElementBeforePlace = elements
 		.slice(0, index)
@@ -146,7 +146,7 @@ const sortPlaces = (placeA: PlaceInArticle, placeB: PlaceInArticle): number => {
  * @param elements the elements in the article block
  * @returns the index or null if no suitable place found
  */
-const findInsertPosition = (elements: CAPIElement[]): number | null => {
+const findInsertPosition = (elements: FEElement[]): number | null => {
 	// Aim for the middle
 	const targetPosition = Math.floor(elements.length / 2);
 	const places = elements.map((_, index) => ({
@@ -174,9 +174,9 @@ const findInsertPosition = (elements: CAPIElement[]): number | null => {
  */
 const tryToInsert = (
 	promotedNewsletter: Newsletter,
-	elements: CAPIElement[],
+	elements: FEElement[],
 	blockId: string,
-): CAPIElement[] => {
+): FEElement[] => {
 	const insertPosition = findInsertPosition(elements);
 
 	if (insertPosition === null) {
@@ -199,7 +199,7 @@ const tryToInsert = (
 
 export const insertPromotedNewsletter = (
 	blocks: Block[],
-	format: CAPIFormat,
+	format: FEFormat,
 	promotedNewsletter: Newsletter,
 ): Block[] => {
 	switch (format.design) {

--- a/dotcom-rendering/src/model/isLegacyTableOfContents.ts
+++ b/dotcom-rendering/src/model/isLegacyTableOfContents.ts
@@ -1,4 +1,4 @@
-import { CAPIElement } from '../types/content';
+import type { FEElement } from '../types/content';
 
 const scriptUrls = [
 	'https://interactive.guim.co.uk/page-enhancers/nav/boot.js',
@@ -8,7 +8,7 @@ const scriptUrls = [
 	'https://uploads.guim.co.uk/2021/10/15/boot.js',
 ];
 
-export const isLegacyTableOfContents = (element: CAPIElement): boolean =>
+export const isLegacyTableOfContents = (element: FEElement): boolean =>
 	element._type ===
 		'model.dotcomrendering.pageElements.InteractiveBlockElement' &&
 	!!element.scriptUrl &&

--- a/dotcom-rendering/src/model/validate.test.ts
+++ b/dotcom-rendering/src/model/validate.test.ts
@@ -1,5 +1,5 @@
 import fetch from 'node-fetch';
-import { validateAsCAPIType } from './validate';
+import { validateAsArticleType } from './validate';
 
 // TODO avoid fetch, write script to fetch new version in gen-schema.js and store as fixture files
 const urlsToTest = [
@@ -14,7 +14,7 @@ const urlsToTest = [
 describe('validate', () => {
 	it('throws on invalid data', () => {
 		const data = { foo: 'bar' };
-		expect(() => validateAsCAPIType(data)).toThrowError(TypeError);
+		expect(() => validateAsArticleType(data)).toThrowError(TypeError);
 	});
 
 	urlsToTest.forEach((url) => {
@@ -22,7 +22,7 @@ describe('validate', () => {
 			return fetch(`${url}&purge=${Date.now()}`)
 				.then((response) => response.json())
 				.then((myJson) => {
-					expect(validateAsCAPIType(myJson)).toBe(myJson);
+					expect(validateAsArticleType(myJson)).toBe(myJson);
 				});
 		});
 	});

--- a/dotcom-rendering/src/model/validate.ts
+++ b/dotcom-rendering/src/model/validate.ts
@@ -20,7 +20,7 @@ addFormats(ajv);
 const validateArticle = ajv.compile<FEArticleType>(articleSchema);
 const validateFront = ajv.compile<FEFrontType>(frontSchema);
 
-export const validateAsCAPIType = (data: unknown): FEArticleType => {
+export const validateAsArticleType = (data: unknown): FEArticleType => {
 	if (validateArticle(data)) return data;
 
 	const url =

--- a/dotcom-rendering/src/types/content.ts
+++ b/dotcom-rendering/src/types/content.ts
@@ -321,7 +321,7 @@ interface NumberedTitleBlockElement {
 	elementId: string;
 	position: number;
 	html: string;
-	format: CAPIFormat;
+	format: FEFormat;
 }
 
 export interface InteractiveContentsBlockElement {
@@ -586,7 +586,7 @@ interface WitnessTypeBlockElement extends ThirdPartyEmbeddedContent {
 		| WitnessTypeDataText;
 }
 
-export type CAPIElement =
+export type FEElement =
 	| AudioAtomBlockElement
 	| AudioBlockElement
 	| BlockquoteBlockElement

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -3,11 +3,11 @@ import type { EditionId } from '../web/lib/edition';
 import type { ServerSideTests, Switches } from './config';
 import type { FooterType } from './footer';
 import type { FETagType } from './tag';
-import type { CAPITrailType, TrailType } from './trails';
+import type { FETrailType, TrailType } from './trails';
 
 export interface FEFrontType {
 	pressedPage: FEPressedPageType;
-	nav: CAPINavType;
+	nav: FENavType;
 	editionId: EditionId;
 	editionLongForm: string;
 	guardianBaseURL: string;
@@ -19,14 +19,14 @@ export interface FEFrontType {
 	pageFooter: FooterType;
 	isAdFreeUser: boolean;
 	isNetworkFront: boolean;
-	mostViewed: CAPITrailType[];
-	mostCommented?: CAPITrailType;
-	mostShared?: CAPITrailType;
+	mostViewed: FETrailType[];
+	mostCommented?: FETrailType;
+	mostShared?: FETrailType;
 }
 
 export interface DCRFrontType {
 	pressedPage: DCRPressedPageType;
-	nav: CAPINavType;
+	nav: FENavType;
 	editionId: EditionId;
 	webTitle: string;
 	config: FEFrontConfigType;
@@ -149,7 +149,7 @@ export type FEFrontCard = {
 				webUrl: string;
 				type: string;
 				sectionId?: { value: string };
-				format: CAPIFormat;
+				format: FEFormat;
 			};
 			fields: {
 				main: string;
@@ -229,7 +229,7 @@ export type FEFrontCard = {
 		imageHide: boolean;
 		showLivePlayable: boolean;
 	};
-	format?: CAPIFormat;
+	format?: FEFormat;
 	enriched?: FESnapType;
 	supportingContent?: FESupportingContent[];
 	cardStyle?: {
@@ -457,7 +457,7 @@ export type FESupportingContent = {
 		headline: string;
 		url: string;
 	};
-	format?: CAPIFormat;
+	format?: FEFormat;
 };
 
 export type DCRSupportingContent = {

--- a/dotcom-rendering/src/types/frontend.ts
+++ b/dotcom-rendering/src/types/frontend.ts
@@ -2,11 +2,11 @@ import type { EditionId } from '../web/lib/edition';
 import type { BadgeType } from './badge';
 import type { CommercialProperties } from './commercial';
 import type { ConfigType } from './config';
-import type { CAPIElement, Newsletter } from './content';
+import type { FEElement, Newsletter } from './content';
 import type { FooterType } from './footer';
-import type { CAPIOnwards } from './onwards';
+import type { FEOnwards } from './onwards';
 import type { TagType } from './tag';
-import type { CAPITrailType } from './trails';
+import type { FETrailType } from './trails';
 
 /**
  * This type is what we receive from `frontend`,
@@ -19,7 +19,7 @@ export interface FEArticleType {
 	headline: string;
 	standfirst: string;
 	webTitle: string;
-	mainMediaElements: CAPIElement[];
+	mainMediaElements: FEElement[];
 	main: string;
 	keyEvents: Block[];
 	blocks: Block[];
@@ -41,7 +41,7 @@ export interface FEArticleType {
 	pageId: string;
 	version: number; // TODO: check who uses?
 	tags: TagType[];
-	format: CAPIFormat;
+	format: FEFormat;
 
 	// Include pillar and designType until we remove them upstream
 	// We type designType as `string` for now so that the field is present,
@@ -54,8 +54,8 @@ export interface FEArticleType {
 	sectionLabel: string;
 	sectionUrl: string;
 	sectionName?: string;
-	subMetaSectionLinks: CAPILinkType[];
-	subMetaKeywordLinks: CAPILinkType[];
+	subMetaSectionLinks: FELinkType[];
+	subMetaKeywordLinks: FELinkType[];
 	shouldHideAds: boolean;
 	isAdFreeUser: boolean;
 	openGraphData: { [key: string]: string };
@@ -74,10 +74,10 @@ export interface FEArticleType {
 	publication: string; // TODO: check who uses?
 	hasStoryPackage: boolean;
 	storyPackage?: {
-		trails: CAPITrailType[];
+		trails: FETrailType[];
 		heading: string;
 	};
-	onwards?: CAPIOnwards[];
+	onwards?: FEOnwards[];
 	beaconURL: string;
 	isCommentable: boolean;
 	commercialProperties: CommercialProperties;
@@ -85,7 +85,7 @@ export interface FEArticleType {
 	trailText: string;
 	badge?: BadgeType;
 
-	nav: CAPINavType; // TODO move this out as most code uses a different internal NAV model.
+	nav: FENavType; // TODO move this out as most code uses a different internal NAV model.
 
 	pageFooter: FooterType;
 

--- a/dotcom-rendering/src/types/onwards.ts
+++ b/dotcom-rendering/src/types/onwards.ts
@@ -1,15 +1,15 @@
-import type { CAPITrailType } from './trails';
+import type { FETrailType } from './trails';
 
 /**
  * Onwards
  */
-export type CAPIOnwards = {
+export type FEOnwards = {
 	heading: string;
-	trails: CAPITrailType[];
+	trails: FETrailType[];
 	description?: string;
 	url?: string;
 	onwardsSource: OnwardsSource;
-	format: CAPIFormat;
+	format: FEFormat;
 	isCuratedContent?: boolean;
 };
 

--- a/dotcom-rendering/src/types/trails.ts
+++ b/dotcom-rendering/src/types/trails.ts
@@ -43,8 +43,8 @@ export interface TrailType extends BaseTrailType {
 	isBoosted?: boolean;
 }
 
-export interface CAPITrailType extends BaseTrailType {
-	format: CAPIFormat;
+export interface FETrailType extends BaseTrailType {
+	format: FEFormat;
 	/**
 	 * @deprecated This type must exist as it's passed by frontend, but we shouldn't use it.
 	 * We should remove this property upstream in the future
@@ -65,7 +65,7 @@ export interface TrailTabType {
 	trails: TrailType[];
 }
 
-export interface CAPITrailTabType {
+export interface FETrailTabType {
 	heading: string;
-	trails: CAPITrailType[];
+	trails: FETrailType[];
 }

--- a/dotcom-rendering/src/web/components/ArticleHeadline.mocks.ts
+++ b/dotcom-rendering/src/web/components/ArticleHeadline.mocks.ts
@@ -1,6 +1,6 @@
-import { CAPIElement } from '../../types/content';
+import { FEElement } from '../../types/content';
 
-export const mainMediaElements: CAPIElement[] = [
+export const mainMediaElements: FEElement[] = [
 	{
 		role: 'showcase',
 		elementId: 'mockId',

--- a/dotcom-rendering/src/web/components/ArticlePage.tsx
+++ b/dotcom-rendering/src/web/components/ArticlePage.tsx
@@ -17,7 +17,7 @@ import { SetABTests } from './SetABTests.importable';
 import { SkipTo } from './SkipTo';
 
 type Props = {
-	CAPIArticle: FEArticleType;
+	article: FEArticleType;
 	NAV: NavType;
 	format: ArticleFormat;
 };
@@ -27,11 +27,11 @@ type Props = {
  * Article is a high level wrapper for article pages on Dotcom. Sets strict mode and some globals
  *
  * @param {Props} props
- * @param {FEArticleType} props.CAPIArticle - The article JSON data
+ * @param {FEArticleType} props.article - The article JSON data
  * @param {NAVType} props.NAV - The article JSON data
  * @param {ArticleFormat} props.format - The format model for the article
  * */
-export const ArticlePage = ({ CAPIArticle, NAV, format }: Props) => {
+export const ArticlePage = ({ article, NAV, format }: Props) => {
 	return (
 		<StrictMode>
 			<Global
@@ -62,18 +62,16 @@ export const ArticlePage = ({ CAPIArticle, NAV, format }: Props) => {
 			<Island clientOnly={true} deferUntil="idle">
 				<Metrics
 					commercialMetricsEnabled={
-						!!CAPIArticle.config.switches.commercialMetrics
+						!!article.config.switches.commercialMetrics
 					}
 				/>
 			</Island>
 			<Island clientOnly={true} deferUntil="idle">
-				<BrazeMessaging idApiUrl={CAPIArticle.config.idApiUrl} />
+				<BrazeMessaging idApiUrl={article.config.idApiUrl} />
 			</Island>
 			<Island clientOnly={true} deferUntil="idle">
 				<ReaderRevenueDev
-					shouldHideReaderRevenue={
-						CAPIArticle.shouldHideReaderRevenue
-					}
+					shouldHideReaderRevenue={article.shouldHideReaderRevenue}
 				/>
 			</Island>
 			<Island clientOnly={true} deferUntil="idle">
@@ -82,13 +80,13 @@ export const ArticlePage = ({ CAPIArticle, NAV, format }: Props) => {
 			<Island clientOnly={true}>
 				<SetABTests
 					abTestSwitches={filterABTestSwitches(
-						CAPIArticle.config.switches,
+						article.config.switches,
 					)}
-					pageIsSensitive={CAPIArticle.config.isSensitive}
-					isDev={!!CAPIArticle.config.isDev}
+					pageIsSensitive={article.config.isSensitive}
+					isDev={!!article.config.isDev}
 				/>
 			</Island>
-			<DecideLayout CAPIArticle={CAPIArticle} NAV={NAV} format={format} />
+			<DecideLayout article={article} NAV={NAV} format={format} />
 		</StrictMode>
 	);
 };

--- a/dotcom-rendering/src/web/components/ArticleTitle.stories.tsx
+++ b/dotcom-rendering/src/web/components/ArticleTitle.stories.tsx
@@ -18,7 +18,7 @@ const Wrapper = ({ children }: { children: React.ReactNode }) => (
 		{children}
 	</div>
 );
-const CAPIArticle = {
+const FEArticle = {
 	tags: [],
 	guardianBaseURL: 'https://theguardian.com',
 	inLeftCol: true,
@@ -26,8 +26,8 @@ const CAPIArticle = {
 	sectionLabel: 'Section label',
 	sectionUrl: '/section_url',
 };
-const brexitCAPI = {
-	...CAPIArticle,
+const FEBrexit = {
+	...FEArticle,
 	...{
 		sectionLabel: 'Brexit',
 		sectionUrl: '/brexit',
@@ -39,8 +39,8 @@ const brexitCAPI = {
 	},
 };
 
-const beyondTheBladeCAPI = {
-	...CAPIArticle,
+const FEBeyondTheBlade = {
+	...FEArticle,
 	...{
 		sectionLabel: 'Beyond the blade',
 		sectionUrl: '/beyond-the-blade',
@@ -61,7 +61,7 @@ export const defaultStory = () => {
 	return (
 		<Wrapper>
 			<ArticleTitle
-				{...brexitCAPI}
+				{...FEBrexit}
 				format={{
 					display: ArticleDisplay.Standard,
 					theme: ArticlePillar.Sport,
@@ -77,7 +77,7 @@ export const beyondTheBlade = () => {
 	return (
 		<Wrapper>
 			<ArticleTitle
-				{...beyondTheBladeCAPI}
+				{...FEBeyondTheBlade}
 				format={{
 					display: ArticleDisplay.Standard,
 					theme: ArticlePillar.News,
@@ -98,7 +98,7 @@ export const immersiveComment = () => {
 			`}
 		>
 			<ArticleTitle
-				{...brexitCAPI}
+				{...FEBrexit}
 				format={{
 					display: ArticleDisplay.Immersive,
 					theme: ArticlePillar.Sport,
@@ -119,7 +119,7 @@ export const immersiveCommentTag = () => {
 			`}
 		>
 			<ArticleTitle
-				{...CAPIArticle}
+				{...FEArticle}
 				format={{
 					display: ArticleDisplay.Immersive,
 					theme: ArticlePillar.Sport,
@@ -142,7 +142,7 @@ export const ImmersiveSeriesTag = () => {
 	return (
 		<Wrapper>
 			<ArticleTitle
-				{...CAPIArticle}
+				{...FEArticle}
 				format={{
 					display: ArticleDisplay.Immersive,
 					theme: ArticlePillar.Sport,
@@ -165,7 +165,7 @@ export const ArticleBlogTag = () => {
 	return (
 		<Wrapper>
 			<ArticleTitle
-				{...CAPIArticle}
+				{...FEArticle}
 				format={{
 					display: ArticleDisplay.Standard,
 					theme: ArticlePillar.Sport,
@@ -194,7 +194,7 @@ export const LiveblogTitle = () => {
 				`}
 			>
 				<ArticleTitle
-					{...CAPIArticle}
+					{...FEArticle}
 					format={{
 						display: ArticleDisplay.Standard,
 						theme: ArticlePillar.Sport,
@@ -216,7 +216,7 @@ export const LiveblogTitle = () => {
 				`}
 			>
 				<ArticleTitle
-					{...CAPIArticle}
+					{...FEArticle}
 					format={{
 						display: ArticleDisplay.Standard,
 						theme: ArticlePillar.Sport,
@@ -241,7 +241,7 @@ export const ArticleOpinionTag = () => {
 	return (
 		<Wrapper>
 			<ArticleTitle
-				{...CAPIArticle}
+				{...FEArticle}
 				format={{
 					display: ArticleDisplay.Standard,
 					theme: ArticlePillar.Sport,
@@ -264,7 +264,7 @@ export const ArticleSeriesTag = () => {
 	return (
 		<Wrapper>
 			<ArticleTitle
-				{...CAPIArticle}
+				{...FEArticle}
 				format={{
 					display: ArticleDisplay.Standard,
 					theme: ArticlePillar.Sport,
@@ -287,7 +287,7 @@ export const SpecialReportTitle = () => {
 	return (
 		<Wrapper>
 			<ArticleTitle
-				{...CAPIArticle}
+				{...FEArticle}
 				format={{
 					display: ArticleDisplay.Standard,
 					theme: ArticleSpecial.SpecialReport,
@@ -310,7 +310,7 @@ export const SpecialReportAlt = () => {
 	return (
 		<Wrapper>
 			<ArticleTitle
-				{...CAPIArticle}
+				{...FEArticle}
 				format={{
 					display: ArticleDisplay.Standard,
 					theme: ArticleSpecial.SpecialReportAlt,
@@ -333,7 +333,7 @@ export const ArticleNoTags = () => {
 	return (
 		<Wrapper>
 			<ArticleTitle
-				{...CAPIArticle}
+				{...FEArticle}
 				format={{
 					display: ArticleDisplay.Standard,
 					theme: ArticlePillar.Culture,
@@ -349,7 +349,7 @@ export const LabsStory = () => {
 	return (
 		<Wrapper>
 			<ArticleTitle
-				{...CAPIArticle}
+				{...FEArticle}
 				format={{
 					display: ArticleDisplay.Standard,
 					theme: ArticleSpecial.Labs,
@@ -372,7 +372,7 @@ export const LongStory = () => {
 	return (
 		<Wrapper>
 			<ArticleTitle
-				{...CAPIArticle}
+				{...FEArticle}
 				format={{
 					display: ArticleDisplay.Standard,
 					theme: ArticlePillar.News,
@@ -395,7 +395,7 @@ export const LongWord = () => {
 	return (
 		<Wrapper>
 			<ArticleTitle
-				{...CAPIArticle}
+				{...FEArticle}
 				format={{
 					display: ArticleDisplay.Standard,
 					theme: ArticlePillar.News,
@@ -424,7 +424,7 @@ export const ArticleDeadBlogTitle = () => {
 				<div key={JSON.stringify(format)}>
 					<p>{getThemeNameAsString(format)}</p>
 					<ArticleTitle
-						{...CAPIArticle}
+						{...FEArticle}
 						format={format}
 						tags={[
 							{

--- a/dotcom-rendering/src/web/components/FetchOnwardsData.importable.tsx
+++ b/dotcom-rendering/src/web/components/FetchOnwardsData.importable.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import { useEffect } from 'react';
 import type { OnwardsSource } from '../../types/onwards';
-import type { CAPITrailType, TrailType } from '../../types/trails';
+import type { FETrailType, TrailType } from '../../types/trails';
 import { decideTrail } from '../lib/decideTrail';
 import { revealStyles } from '../lib/revealStyles';
 import { useApi } from '../lib/useApi';
@@ -16,7 +16,7 @@ type Props = {
 };
 
 type OnwardsResponse = {
-	trails: CAPITrailType[];
+	trails: FETrailType[];
 	heading: string;
 	displayname: string;
 	description: string;
@@ -35,7 +35,7 @@ export const FetchOnwardsData = ({
 	const { data, loading, error } = useApi<OnwardsResponse>(url);
 
 	const buildTrails = (
-		trails: CAPITrailType[],
+		trails: FETrailType[],
 		trailLimit: number,
 	): TrailType[] => {
 		return trails.slice(0, trailLimit).map(decideTrail);

--- a/dotcom-rendering/src/web/components/Figure.tsx
+++ b/dotcom-rendering/src/web/components/Figure.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import { ArticleDesign } from '@guardian/libs';
 import { from, space, until } from '@guardian/source-foundations';
-import type { CAPIElement, RoleType } from '../../types/content';
+import type { FEElement, RoleType } from '../../types/content';
 
 type Props = {
 	children: React.ReactNode;
@@ -10,7 +10,7 @@ type Props = {
 	role?: RoleType | 'richLink';
 	id?: string;
 	className?: string;
-	type?: CAPIElement['_type'];
+	type?: FEElement['_type'];
 };
 
 const roleCss = {

--- a/dotcom-rendering/src/web/components/MainMedia.tsx
+++ b/dotcom-rendering/src/web/components/MainMedia.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/react';
 import { ArticleDesign, ArticleDisplay } from '@guardian/libs';
 import { until } from '@guardian/source-foundations';
 import type { Switches } from '../../types/config';
-import type { CAPIElement } from '../../types/content';
+import type { FEElement } from '../../types/content';
 import { getZIndex } from '../lib/getZIndex';
 import { RenderArticleElement } from '../lib/renderElement';
 
@@ -70,7 +70,7 @@ const chooseWrapper = (format: ArticleFormat) => {
 
 type Props = {
 	format: ArticleFormat;
-	elements: CAPIElement[];
+	elements: FEElement[];
 	hideCaption?: boolean;
 	adTargeting?: AdTargeting;
 	starRating?: number;

--- a/dotcom-rendering/src/web/components/MostViewed.mocks.ts
+++ b/dotcom-rendering/src/web/components/MostViewed.mocks.ts
@@ -1,6 +1,6 @@
-import type { CAPITrailTabType } from '../../types/trails';
+import type { FETrailTabType } from '../../types/trails';
 
-export const mockTab1: CAPITrailTabType = {
+export const mockTab1: FETrailTabType = {
 	heading: 'Across The Guardian',
 	trails: [
 		{
@@ -177,7 +177,7 @@ export const mockTab1: CAPITrailTabType = {
 	],
 };
 
-export const mockTab2: CAPITrailTabType = {
+export const mockTab2: FETrailTabType = {
 	heading: 'in Music',
 	trails: [
 		{
@@ -385,14 +385,14 @@ export const mockMostShared = {
 	ageWarning: '1 year old',
 };
 
-const twoTabs: [CAPITrailTabType, CAPITrailTabType] = [mockTab1, mockTab2];
+const twoTabs: [FETrailTabType, FETrailTabType] = [mockTab1, mockTab2];
 export const responseWithTwoTabs = {
 	tabs: twoTabs,
 	mostCommented: mockMostCommented,
 	mostShared: mockMostShared,
 };
 
-const oneTab: [CAPITrailTabType] = [mockTab1];
+const oneTab: [FETrailTabType] = [mockTab1];
 export const responseWithOneTab = {
 	tabs: oneTab,
 	mostCommented: mockMostCommented,

--- a/dotcom-rendering/src/web/components/MostViewedFooterData.importable.tsx
+++ b/dotcom-rendering/src/web/components/MostViewedFooterData.importable.tsx
@@ -1,7 +1,7 @@
 import { joinUrl } from '@guardian/libs';
 import type {
-	CAPITrailTabType,
-	CAPITrailType,
+	FETrailTabType,
+	FETrailType,
 	TrailTabType,
 } from '../../types/trails';
 import { abTestTest } from '../experiments/tests/ab-test-test';
@@ -25,7 +25,7 @@ function buildSectionUrl(ajaxUrl: string, sectionName?: string) {
 	return joinUrl(ajaxUrl, `${endpoint}?dcr=true`);
 }
 
-function transformTabs(tabs: CAPITrailTabType[]): TrailTabType[] {
+function transformTabs(tabs: FETrailTabType[]): TrailTabType[] {
 	return tabs.map((tab) => ({
 		...tab,
 		trails: tab.trails.map((trail) => decideTrail(trail)),
@@ -33,9 +33,9 @@ function transformTabs(tabs: CAPITrailTabType[]): TrailTabType[] {
 }
 
 interface MostViewedFooterPayloadType {
-	tabs: CAPITrailTabType[];
-	mostCommented: CAPITrailType;
-	mostShared: CAPITrailType;
+	tabs: FETrailTabType[];
+	mostCommented: FETrailType;
+	mostShared: FETrailType;
 }
 
 export const MostViewedFooterData = ({
@@ -59,7 +59,7 @@ export const MostViewedFooterData = ({
 
 	const url = buildSectionUrl(ajaxUrl, sectionName);
 	const { data, error } = useApi<
-		MostViewedFooterPayloadType | CAPITrailTabType[]
+		MostViewedFooterPayloadType | FETrailTabType[]
 	>(url);
 
 	if (error) {

--- a/dotcom-rendering/src/web/components/MostViewedRight.tsx
+++ b/dotcom-rendering/src/web/components/MostViewedRight.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import { headline } from '@guardian/source-foundations';
 import { StraightLines } from '@guardian/source-react-components-development-kitchen';
-import type { CAPITrailTabType, TrailType } from '../../types/trails';
+import type { FETrailTabType, TrailType } from '../../types/trails';
 import { decideTrail } from '../lib/decideTrail';
 import { useApi } from '../lib/useApi';
 import { MostViewedRightItem } from './MostViewedRightItem';
@@ -36,7 +36,7 @@ export const MostViewedRight = ({
 }: Props) => {
 	const endpointUrl =
 		'https://api.nextgen.guardianapps.co.uk/most-read-geo.json?dcr=true';
-	const { data, error } = useApi<CAPITrailTabType>(endpointUrl);
+	const { data, error } = useApi<FETrailTabType>(endpointUrl);
 
 	if (error) {
 		window.guardian.modules.sentry.reportError(error, 'most-viewed-right');

--- a/dotcom-rendering/src/web/components/NumberedTitleBlockComponent.tsx
+++ b/dotcom-rendering/src/web/components/NumberedTitleBlockComponent.tsx
@@ -7,7 +7,7 @@ import { decidePalette } from '../lib/decidePalette';
 type Props = {
 	position: number;
 	html: string;
-	format: CAPIFormat;
+	format: FEFormat;
 };
 
 const titleStyles = (palette: Palette) => css`

--- a/dotcom-rendering/src/web/components/RichLinkComponent.importable.tsx
+++ b/dotcom-rendering/src/web/components/RichLinkComponent.importable.tsx
@@ -1,5 +1,5 @@
 import { ArticleDesign, ArticleDisplay, ArticleSpecial } from '@guardian/libs';
-import { RichLinkBlockElement } from '../../types/content';
+import type { RichLinkBlockElement } from '../../types/content';
 import type { TagType } from '../../types/tag';
 import { decideFormat } from '../lib/decideFormat';
 import { useApi } from '../lib/useApi';
@@ -13,7 +13,7 @@ type Props = {
 	format: ArticleFormat;
 };
 
-interface CAPIRichLinkType {
+interface FERichLinkType {
 	cardStyle: RichLinkCardType;
 	thumbnailUrl: string;
 	headline: string;
@@ -59,7 +59,7 @@ export const RichLinkComponent = ({
 	format,
 }: Props) => {
 	const url = buildUrl(element, ajaxUrl);
-	const { data, error } = useApi<CAPIRichLinkType>(url);
+	const { data, error } = useApi<FERichLinkType>(url);
 
 	if (error) {
 		// Send the error to Sentry

--- a/dotcom-rendering/src/web/components/RichLinkComponent.importable.tsx
+++ b/dotcom-rendering/src/web/components/RichLinkComponent.importable.tsx
@@ -21,7 +21,7 @@ interface CAPIRichLinkType {
 	url: string;
 	tags: TagType[];
 	sponsorName: string;
-	format: CAPIFormat;
+	format: FEFormat;
 	starRating?: number;
 	contributorImage?: string;
 	imageAsset?: ImageAsset;

--- a/dotcom-rendering/src/web/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/CommentLayout.tsx
@@ -259,55 +259,54 @@ const mainMediaWrapper = css`
 `;
 
 interface Props {
-	CAPIArticle: FEArticleType;
+	article: FEArticleType;
 	NAV: NavType;
 	format: ArticleFormat;
 }
 
-export const CommentLayout = ({ CAPIArticle, NAV, format }: Props) => {
+export const CommentLayout = ({ article, NAV, format }: Props) => {
 	const {
 		config: { isPaidContent, host },
-	} = CAPIArticle;
+	} = article;
 
 	const isInEuropeTest =
-		CAPIArticle.config.abTests.europeNetworkFrontVariant === 'variant';
+		article.config.abTests.europeNetworkFrontVariant === 'variant';
 
 	const adTargeting: AdTargeting = buildAdTargeting({
-		isAdFreeUser: CAPIArticle.isAdFreeUser,
-		isSensitive: CAPIArticle.config.isSensitive,
-		videoDuration: CAPIArticle.config.videoDuration,
-		edition: CAPIArticle.config.edition,
-		section: CAPIArticle.config.section,
-		sharedAdTargeting: CAPIArticle.config.sharedAdTargeting,
-		adUnit: CAPIArticle.config.adUnit,
+		isAdFreeUser: article.isAdFreeUser,
+		isSensitive: article.config.isSensitive,
+		videoDuration: article.config.videoDuration,
+		edition: article.config.edition,
+		section: article.config.section,
+		sharedAdTargeting: article.config.sharedAdTargeting,
+		adUnit: article.config.adUnit,
 	});
 
 	const showBodyEndSlot =
-		parse(CAPIArticle.slotMachineFlags ?? '').showBodyEnd ||
-		CAPIArticle.config.switches.slotBodyEnd;
+		parse(article.slotMachineFlags ?? '').showBodyEnd ||
+		article.config.switches.slotBodyEnd;
 
 	// TODO:
 	// 1) Read 'forceEpic' value from URL parameter and use it to force the slot to render
-	// 2) Otherwise, ensure slot only renders if `CAPIArticle.config.shouldHideReaderRevenue` equals false.
+	// 2) Otherwise, ensure slot only renders if `article.config.shouldHideReaderRevenue` equals false.
 
-	const showComments = CAPIArticle.isCommentable;
+	const showComments = article.isCommentable;
 
 	const avatarUrl = getSoleContributor(
-		CAPIArticle.tags,
-		CAPIArticle.byline,
+		article.tags,
+		article.byline,
 	)?.bylineLargeImageUrl;
 
-	const { branding } =
-		CAPIArticle.commercialProperties[CAPIArticle.editionId];
+	const { branding } = article.commercialProperties[article.editionId];
 
 	const palette = decidePalette(format);
 
-	const contributionsServiceUrl = getContributionsServiceUrl(CAPIArticle);
+	const contributionsServiceUrl = getContributionsServiceUrl(article);
 
 	/**
 	 * This property currently only applies to the header and merchandising slots
 	 */
-	const renderAds = !CAPIArticle.isAdFreeUser && !CAPIArticle.shouldHideAds;
+	const renderAds = !article.isAdFreeUser && !article.shouldHideAds;
 
 	return (
 		<>
@@ -338,23 +337,23 @@ export const CommentLayout = ({ CAPIArticle, NAV, format }: Props) => {
 							element="header"
 						>
 							<Header
-								editionId={CAPIArticle.editionId}
-								idUrl={CAPIArticle.config.idUrl}
-								mmaUrl={CAPIArticle.config.mmaUrl}
+								editionId={article.editionId}
+								idUrl={article.config.idUrl}
+								mmaUrl={article.config.mmaUrl}
 								discussionApiUrl={
-									CAPIArticle.config.discussionApiUrl
+									article.config.discussionApiUrl
 								}
-								urls={CAPIArticle.nav.readerRevenueLinks.header}
+								urls={article.nav.readerRevenueLinks.header}
 								remoteHeader={
-									!!CAPIArticle.config.switches.remoteHeader
+									!!article.config.switches.remoteHeader
 								}
 								contributionsServiceUrl={
 									contributionsServiceUrl
 								}
-								idApiUrl={CAPIArticle.config.idApiUrl}
+								idApiUrl={article.config.idApiUrl}
 								isInEuropeTest={isInEuropeTest}
 								headerTopBarSearchCapiSwitch={
-									!!CAPIArticle.config.switches
+									!!article.config.switches
 										.headerTopBarSearchCapi
 								}
 							/>
@@ -373,15 +372,14 @@ export const CommentLayout = ({ CAPIArticle, NAV, format }: Props) => {
 							nav={NAV}
 							format={{
 								...format,
-								theme: getCurrentPillar(CAPIArticle),
+								theme: getCurrentPillar(article),
 							}}
 							subscribeUrl={
-								CAPIArticle.nav.readerRevenueLinks.header
-									.subscribe
+								article.nav.readerRevenueLinks.header.subscribe
 							}
-							editionId={CAPIArticle.editionId}
+							editionId={article.editionId}
 							headerTopBarSwitch={
-								!!CAPIArticle.config.switches.headerTopNav
+								!!article.config.switches.headerTopNav
 							}
 						/>
 					</Section>
@@ -431,11 +429,11 @@ export const CommentLayout = ({ CAPIArticle, NAV, format }: Props) => {
 						<GridItem area="title" element="aside">
 							<ArticleTitle
 								format={format}
-								tags={CAPIArticle.tags}
-								sectionLabel={CAPIArticle.sectionLabel}
-								sectionUrl={CAPIArticle.sectionUrl}
-								guardianBaseURL={CAPIArticle.guardianBaseURL}
-								badge={CAPIArticle.badge}
+								tags={article.tags}
+								sectionLabel={article.sectionLabel}
+								sectionUrl={article.sectionUrl}
+								guardianBaseURL={article.guardianBaseURL}
+								badge={article.badge}
 							/>
 						</GridItem>
 						<GridItem area="border">
@@ -452,14 +450,14 @@ export const CommentLayout = ({ CAPIArticle, NAV, format }: Props) => {
 									{/* TOP - we position content in groups here using flex */}
 									<ArticleHeadline
 										format={format}
-										headlineString={CAPIArticle.headline}
-										tags={CAPIArticle.tags}
-										byline={CAPIArticle.byline}
+										headlineString={article.headline}
+										tags={article.tags}
+										byline={article.byline}
 										webPublicationDateDeprecated={
-											CAPIArticle.webPublicationDateDeprecated
+											article.webPublicationDateDeprecated
 										}
 										hasStarRating={
-											typeof CAPIArticle.starRating ===
+											typeof article.starRating ===
 											'number'
 										}
 										hasAvatar={!!avatarUrl}
@@ -471,7 +469,7 @@ export const CommentLayout = ({ CAPIArticle, NAV, format }: Props) => {
 												<ContributorAvatar
 													imageSrc={avatarUrl}
 													imageAlt={
-														CAPIArticle.byline ?? ''
+														article.byline ?? ''
 													}
 												/>
 											</div>
@@ -503,7 +501,7 @@ export const CommentLayout = ({ CAPIArticle, NAV, format }: Props) => {
 						<GridItem area="standfirst">
 							<Standfirst
 								format={format}
-								standfirst={CAPIArticle.standfirst}
+								standfirst={article.standfirst}
 							/>
 						</GridItem>
 						<GridItem area="media">
@@ -516,22 +514,22 @@ export const CommentLayout = ({ CAPIArticle, NAV, format }: Props) => {
 							>
 								<MainMedia
 									format={format}
-									elements={CAPIArticle.mainMediaElements}
+									elements={article.mainMediaElements}
 									adTargeting={adTargeting}
 									starRating={
 										format.design ===
 											ArticleDesign.Review &&
-										CAPIArticle.starRating
-											? CAPIArticle.starRating
+										article.starRating
+											? article.starRating
 											: undefined
 									}
 									host={host}
-									pageId={CAPIArticle.pageId}
-									webTitle={CAPIArticle.webTitle}
-									ajaxUrl={CAPIArticle.config.ajaxUrl}
-									switches={CAPIArticle.config.switches}
-									isAdFreeUser={CAPIArticle.isAdFreeUser}
-									isSensitive={CAPIArticle.config.isSensitive}
+									pageId={article.pageId}
+									webTitle={article.webTitle}
+									ajaxUrl={article.config.ajaxUrl}
+									switches={article.config.switches}
+									isAdFreeUser={article.isAdFreeUser}
+									isSensitive={article.config.isSensitive}
 								/>
 							</div>
 						</GridItem>
@@ -540,24 +538,24 @@ export const CommentLayout = ({ CAPIArticle, NAV, format }: Props) => {
 								<ArticleMeta
 									branding={branding}
 									format={format}
-									pageId={CAPIArticle.pageId}
-									webTitle={CAPIArticle.webTitle}
-									byline={CAPIArticle.byline}
-									tags={CAPIArticle.tags}
+									pageId={article.pageId}
+									webTitle={article.webTitle}
+									byline={article.byline}
+									tags={article.tags}
 									primaryDateline={
-										CAPIArticle.webPublicationDateDisplay
+										article.webPublicationDateDisplay
 									}
 									secondaryDateline={
-										CAPIArticle.webPublicationSecondaryDateDisplay
+										article.webPublicationSecondaryDateDisplay
 									}
-									isCommentable={CAPIArticle.isCommentable}
+									isCommentable={article.isCommentable}
 									discussionApiUrl={
-										CAPIArticle.config.discussionApiUrl
+										article.config.discussionApiUrl
 									}
-									shortUrlId={CAPIArticle.config.shortUrlId}
-									ajaxUrl={CAPIArticle.config.ajaxUrl}
+									shortUrlId={article.config.shortUrlId}
+									ajaxUrl={article.config.ajaxUrl}
 									showShareCount={
-										!!CAPIArticle.config.switches
+										!!article.config.switches
 											.serverShareCounts
 									}
 								/>
@@ -568,79 +566,72 @@ export const CommentLayout = ({ CAPIArticle, NAV, format }: Props) => {
 								<div css={maxWidth}>
 									<ArticleBody
 										format={format}
-										blocks={CAPIArticle.blocks}
+										blocks={article.blocks}
 										adTargeting={adTargeting}
 										host={host}
-										pageId={CAPIArticle.pageId}
-										webTitle={CAPIArticle.webTitle}
-										ajaxUrl={CAPIArticle.config.ajaxUrl}
-										switches={CAPIArticle.config.switches}
-										isSensitive={
-											CAPIArticle.config.isSensitive
-										}
-										isAdFreeUser={CAPIArticle.isAdFreeUser}
-										section={CAPIArticle.config.section}
+										pageId={article.pageId}
+										webTitle={article.webTitle}
+										ajaxUrl={article.config.ajaxUrl}
+										switches={article.config.switches}
+										isSensitive={article.config.isSensitive}
+										isAdFreeUser={article.isAdFreeUser}
+										section={article.config.section}
 										shouldHideReaderRevenue={
-											CAPIArticle.shouldHideReaderRevenue
+											article.shouldHideReaderRevenue
 										}
-										tags={CAPIArticle.tags}
+										tags={article.tags}
 										isPaidContent={
-											!!CAPIArticle.config.isPaidContent
+											!!article.config.isPaidContent
 										}
 										contributionsServiceUrl={
 											contributionsServiceUrl
 										}
-										contentType={CAPIArticle.contentType}
-										sectionName={
-											CAPIArticle.sectionName ?? ''
-										}
-										isPreview={CAPIArticle.config.isPreview}
-										idUrl={CAPIArticle.config.idUrl ?? ''}
-										isDev={!!CAPIArticle.config.isDev}
-										keywordIds={
-											CAPIArticle.config.keywordIds
-										}
-										abTests={CAPIArticle.config.abTests}
+										contentType={article.contentType}
+										sectionName={article.sectionName ?? ''}
+										isPreview={article.config.isPreview}
+										idUrl={article.config.idUrl ?? ''}
+										isDev={!!article.config.isDev}
+										keywordIds={article.config.keywordIds}
+										abTests={article.config.abTests}
 										tableOfContents={
-											CAPIArticle.tableOfContents
+											article.tableOfContents
 										}
 									/>
 									{showBodyEndSlot && (
 										<Island clientOnly={true}>
 											<SlotBodyEnd
 												contentType={
-													CAPIArticle.contentType
+													article.contentType
 												}
 												contributionsServiceUrl={
 													contributionsServiceUrl
 												}
 												idApiUrl={
-													CAPIArticle.config.idApiUrl
+													article.config.idApiUrl
 												}
 												isMinuteArticle={
-													CAPIArticle.pageType
+													article.pageType
 														.isMinuteArticle
 												}
 												isPaidContent={
-													CAPIArticle.pageType
+													article.pageType
 														.isPaidContent
 												}
 												keywordIds={
-													CAPIArticle.config
-														.keywordIds
+													article.config.keywordIds
 												}
-												pageId={CAPIArticle.pageId}
+												pageId={article.pageId}
 												sectionId={
-													CAPIArticle.config.section
+													article.config.section
 												}
 												sectionName={
-													CAPIArticle.sectionName
+													article.sectionName
 												}
 												shouldHideReaderRevenue={
-													CAPIArticle.shouldHideReaderRevenue
+													article.shouldHideReaderRevenue
 												}
-												stage={CAPIArticle.config.stage}
-												tags={CAPIArticle.tags}
+												stage={article.config.stage}
+												tags={article.tags}
 											/>
 										</Island>
 									)}
@@ -654,18 +645,18 @@ export const CommentLayout = ({ CAPIArticle, NAV, format }: Props) => {
 									<SubMeta
 										format={format}
 										subMetaKeywordLinks={
-											CAPIArticle.subMetaKeywordLinks
+											article.subMetaKeywordLinks
 										}
 										subMetaSectionLinks={
-											CAPIArticle.subMetaSectionLinks
+											article.subMetaSectionLinks
 										}
-										pageId={CAPIArticle.pageId}
-										webUrl={CAPIArticle.webURL}
-										webTitle={CAPIArticle.webTitle}
+										pageId={article.pageId}
+										webUrl={article.webURL}
+										webTitle={article.webTitle}
 										showBottomSocialButtons={
-											CAPIArticle.showBottomSocialButtons
+											article.showBottomSocialButtons
 										}
-										badge={CAPIArticle.badge}
+										badge={article.badge}
 									/>
 								</div>
 							</ArticleContainer>
@@ -688,16 +679,15 @@ export const CommentLayout = ({ CAPIArticle, NAV, format }: Props) => {
 								`}
 							>
 								<RightColumn>
-									{!CAPIArticle.shouldHideAds && (
+									{!article.shouldHideAds && (
 										<AdSlot
 											position="right"
 											display={format.display}
 											shouldHideReaderRevenue={
-												CAPIArticle.shouldHideReaderRevenue
+												article.shouldHideReaderRevenue
 											}
 											isPaidContent={
-												CAPIArticle.pageType
-													.isPaidContent
+												article.pageType.isPaidContent
 											}
 										/>
 									)}
@@ -709,7 +699,7 @@ export const CommentLayout = ({ CAPIArticle, NAV, format }: Props) => {
 										>
 											<MostViewedRightWrapper
 												isAdFreeUser={
-													CAPIArticle.isAdFreeUser
+													article.isAdFreeUser
 												}
 											/>
 										</Island>
@@ -738,12 +728,12 @@ export const CommentLayout = ({ CAPIArticle, NAV, format }: Props) => {
 					</Section>
 				)}
 
-				{CAPIArticle.storyPackage && (
+				{article.storyPackage && (
 					<Section fullWidth={true}>
 						<Island deferUntil="visible">
 							<Carousel
-								heading={CAPIArticle.storyPackage.heading}
-								trails={CAPIArticle.storyPackage.trails.map(
+								heading={article.storyPackage.heading}
+								trails={article.storyPackage.trails.map(
 									decideTrail,
 								)}
 								onwardsSource="more-on-this-story"
@@ -759,22 +749,20 @@ export const CommentLayout = ({ CAPIArticle, NAV, format }: Props) => {
 					placeholderHeight={600}
 				>
 					<OnwardsUpper
-						ajaxUrl={CAPIArticle.config.ajaxUrl}
-						hasRelated={CAPIArticle.hasRelated}
-						hasStoryPackage={CAPIArticle.hasStoryPackage}
-						isAdFreeUser={CAPIArticle.isAdFreeUser}
-						pageId={CAPIArticle.pageId}
-						isPaidContent={!!CAPIArticle.config.isPaidContent}
-						showRelatedContent={
-							CAPIArticle.config.showRelatedContent
-						}
-						keywordIds={CAPIArticle.config.keywordIds}
-						contentType={CAPIArticle.contentType}
-						tags={CAPIArticle.tags}
+						ajaxUrl={article.config.ajaxUrl}
+						hasRelated={article.hasRelated}
+						hasStoryPackage={article.hasStoryPackage}
+						isAdFreeUser={article.isAdFreeUser}
+						pageId={article.pageId}
+						isPaidContent={!!article.config.isPaidContent}
+						showRelatedContent={article.config.showRelatedContent}
+						keywordIds={article.config.keywordIds}
+						contentType={article.contentType}
+						tags={article.tags}
 						format={format}
 						pillar={format.theme}
-						editionId={CAPIArticle.editionId}
-						shortUrlId={CAPIArticle.config.shortUrlId}
+						editionId={article.editionId}
+						shortUrlId={article.config.shortUrlId}
 					/>
 				</Island>
 
@@ -785,22 +773,19 @@ export const CommentLayout = ({ CAPIArticle, NAV, format }: Props) => {
 						element="aside"
 					>
 						<DiscussionLayout
-							discussionApiUrl={
-								CAPIArticle.config.discussionApiUrl
-							}
-							shortUrlId={CAPIArticle.config.shortUrlId}
+							discussionApiUrl={article.config.discussionApiUrl}
+							shortUrlId={article.config.shortUrlId}
 							format={format}
-							discussionD2Uid={CAPIArticle.config.discussionD2Uid}
+							discussionD2Uid={article.config.discussionD2Uid}
 							discussionApiClientHeader={
-								CAPIArticle.config.discussionApiClientHeader
+								article.config.discussionApiClientHeader
 							}
 							enableDiscussionSwitch={
-								!!CAPIArticle.config.switches
-									.enableDiscussionSwitch
+								!!article.config.switches.enableDiscussionSwitch
 							}
-							isAdFreeUser={CAPIArticle.isAdFreeUser}
-							shouldHideAds={CAPIArticle.shouldHideAds}
-							idApiUrl={CAPIArticle.config.idApiUrl}
+							isAdFreeUser={article.isAdFreeUser}
+							shouldHideAds={article.shouldHideAds}
+							idApiUrl={article.config.idApiUrl}
 						/>
 					</Section>
 				)}
@@ -818,9 +803,9 @@ export const CommentLayout = ({ CAPIArticle, NAV, format }: Props) => {
 						<MostViewedFooterLayout>
 							<Island clientOnly={true} deferUntil="visible">
 								<MostViewedFooterData
-									sectionName={CAPIArticle.sectionName}
+									sectionName={article.sectionName}
 									format={format}
-									ajaxUrl={CAPIArticle.config.ajaxUrl}
+									ajaxUrl={article.config.ajaxUrl}
 								/>
 							</Island>
 						</MostViewedFooterLayout>
@@ -865,41 +850,39 @@ export const CommentLayout = ({ CAPIArticle, NAV, format }: Props) => {
 				element="footer"
 			>
 				<Footer
-					pageFooter={CAPIArticle.pageFooter}
+					pageFooter={article.pageFooter}
 					pillar={format.theme}
 					pillars={NAV.pillars}
-					urls={CAPIArticle.nav.readerRevenueLinks.header}
-					editionId={CAPIArticle.editionId}
-					contributionsServiceUrl={
-						CAPIArticle.contributionsServiceUrl
-					}
+					urls={article.nav.readerRevenueLinks.header}
+					editionId={article.editionId}
+					contributionsServiceUrl={article.contributionsServiceUrl}
 				/>
 			</Section>
 
 			<BannerWrapper>
 				<Island deferUntil="idle" clientOnly={true}>
 					<StickyBottomBanner
-						contentType={CAPIArticle.contentType}
+						contentType={article.contentType}
 						contributionsServiceUrl={contributionsServiceUrl}
-						idApiUrl={CAPIArticle.config.idApiUrl}
-						isMinuteArticle={CAPIArticle.pageType.isMinuteArticle}
-						isPaidContent={CAPIArticle.pageType.isPaidContent}
-						isPreview={!!CAPIArticle.config.isPreview}
-						isSensitive={CAPIArticle.config.isSensitive}
-						keywordIds={CAPIArticle.config.keywordIds}
-						pageId={CAPIArticle.pageId}
-						section={CAPIArticle.config.section}
-						sectionName={CAPIArticle.sectionName}
+						idApiUrl={article.config.idApiUrl}
+						isMinuteArticle={article.pageType.isMinuteArticle}
+						isPaidContent={article.pageType.isPaidContent}
+						isPreview={!!article.config.isPreview}
+						isSensitive={article.config.isSensitive}
+						keywordIds={article.config.keywordIds}
+						pageId={article.pageId}
+						section={article.config.section}
+						sectionName={article.sectionName}
 						shouldHideReaderRevenue={
-							CAPIArticle.shouldHideReaderRevenue
+							article.shouldHideReaderRevenue
 						}
 						remoteBannerSwitch={
-							!!CAPIArticle.config.switches.remoteBanner
+							!!article.config.switches.remoteBanner
 						}
 						puzzleBannerSwitch={
-							!!CAPIArticle.config.switches.puzzlesBanner
+							!!article.config.switches.puzzlesBanner
 						}
-						tags={CAPIArticle.tags}
+						tags={article.tags}
 					/>
 				</Island>
 			</BannerWrapper>

--- a/dotcom-rendering/src/web/layouts/DecideLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/DecideLayout.tsx
@@ -12,12 +12,12 @@ import { ShowcaseLayout } from './ShowcaseLayout';
 import { StandardLayout } from './StandardLayout';
 
 type Props = {
-	CAPIArticle: FEArticleType;
+	article: FEArticleType;
 	NAV: NavType;
 	format: ArticleFormat;
 };
 
-export const DecideLayout = ({ CAPIArticle, NAV, format }: Props) => {
+export const DecideLayout = ({ article, NAV, format }: Props) => {
 	// TODO we can probably better express this as data
 	switch (format.display) {
 		case ArticleDisplay.Immersive: {
@@ -29,7 +29,7 @@ export const DecideLayout = ({ CAPIArticle, NAV, format }: Props) => {
 					// if published before.
 					return (
 						<FullPageInteractiveLayout
-							CAPIArticle={CAPIArticle}
+							article={article}
 							NAV={NAV}
 							format={format}
 						/>
@@ -38,7 +38,7 @@ export const DecideLayout = ({ CAPIArticle, NAV, format }: Props) => {
 				default: {
 					return (
 						<ImmersiveLayout
-							CAPIArticle={CAPIArticle}
+							article={article}
 							NAV={NAV}
 							format={format}
 						/>
@@ -53,7 +53,7 @@ export const DecideLayout = ({ CAPIArticle, NAV, format }: Props) => {
 				case ArticleDesign.DeadBlog:
 					return (
 						<LiveLayout
-							CAPIArticle={CAPIArticle}
+							article={article}
 							NAV={NAV}
 							format={format}
 						/>
@@ -63,7 +63,7 @@ export const DecideLayout = ({ CAPIArticle, NAV, format }: Props) => {
 				case ArticleDesign.Letter:
 					return (
 						<CommentLayout
-							CAPIArticle={CAPIArticle}
+							article={article}
 							NAV={NAV}
 							format={format}
 						/>
@@ -71,7 +71,7 @@ export const DecideLayout = ({ CAPIArticle, NAV, format }: Props) => {
 				default:
 					return (
 						<ShowcaseLayout
-							CAPIArticle={CAPIArticle}
+							article={article}
 							NAV={NAV}
 							format={format}
 						/>
@@ -84,7 +84,7 @@ export const DecideLayout = ({ CAPIArticle, NAV, format }: Props) => {
 				case ArticleDesign.Interactive:
 					return (
 						<InteractiveLayout
-							CAPIArticle={CAPIArticle}
+							article={article}
 							NAV={NAV}
 							format={format}
 						/>
@@ -92,7 +92,7 @@ export const DecideLayout = ({ CAPIArticle, NAV, format }: Props) => {
 				case ArticleDesign.FullPageInteractive: {
 					return (
 						<FullPageInteractiveLayout
-							CAPIArticle={CAPIArticle}
+							article={article}
 							NAV={NAV}
 							format={format}
 						/>
@@ -102,7 +102,7 @@ export const DecideLayout = ({ CAPIArticle, NAV, format }: Props) => {
 				case ArticleDesign.DeadBlog:
 					return (
 						<LiveLayout
-							CAPIArticle={CAPIArticle}
+							article={article}
 							NAV={NAV}
 							format={format}
 						/>
@@ -112,7 +112,7 @@ export const DecideLayout = ({ CAPIArticle, NAV, format }: Props) => {
 				case ArticleDesign.Letter:
 					return (
 						<CommentLayout
-							CAPIArticle={CAPIArticle}
+							article={article}
 							NAV={NAV}
 							format={format}
 						/>
@@ -120,7 +120,7 @@ export const DecideLayout = ({ CAPIArticle, NAV, format }: Props) => {
 				case ArticleDesign.NewsletterSignup:
 					return (
 						<NewsletterSignupLayout
-							CAPIArticle={CAPIArticle}
+							article={article}
 							NAV={NAV}
 							format={format}
 						/>
@@ -128,7 +128,7 @@ export const DecideLayout = ({ CAPIArticle, NAV, format }: Props) => {
 				default:
 					return (
 						<StandardLayout
-							CAPIArticle={CAPIArticle}
+							article={article}
 							NAV={NAV}
 							format={format}
 						/>

--- a/dotcom-rendering/src/web/layouts/FullPageInteractiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FullPageInteractiveLayout.tsx
@@ -13,7 +13,7 @@ import {
 } from '@guardian/source-foundations';
 import type { NavType } from '../../model/extract-nav';
 import type { Switches } from '../../types/config';
-import type { CAPIElement } from '../../types/content';
+import type { FEElement } from '../../types/content';
 import type { FEArticleType } from '../../types/frontend';
 import {
 	adCollapseStyles,
@@ -37,14 +37,14 @@ import { interactiveGlobalStyles } from './lib/interactiveLegacyStyling';
 import { BannerWrapper, Stuck } from './lib/stickiness';
 
 interface Props {
-	CAPIArticle: FEArticleType;
+	article: FEArticleType;
 	NAV: NavType;
 	format: ArticleFormat;
 }
 
 type RendererProps = {
 	format: ArticleFormat;
-	elements: CAPIElement[];
+	elements: FEElement[];
 	host?: string;
 	pageId: string;
 	webTitle: string;
@@ -128,20 +128,20 @@ const Renderer = ({
 	return <div css={adStyles}>{output}</div>;
 };
 
-const NavHeader = ({ CAPIArticle, NAV, format }: Props) => {
+const NavHeader = ({ article, NAV, format }: Props) => {
 	// Typically immersives use the slim nav, but this switch is used to force
 	// the full nav - typically during special events such as Project 200, or
 	// the Euros. The motivation is to better onboard new visitors; interactives
 	// often reach readers who are less familiar with the Guardian.
-	const isSlimNav = !CAPIArticle.config.switches.interactiveFullHeaderSwitch;
+	const isSlimNav = !article.config.switches.interactiveFullHeaderSwitch;
 
 	/**
 	 * This property currently only applies to the header and merchandising slots
 	 */
-	const renderAds = !CAPIArticle.isAdFreeUser && !CAPIArticle.shouldHideAds;
+	const renderAds = !article.isAdFreeUser && !article.shouldHideAds;
 
 	const isInEuropeTest =
-		CAPIArticle.config.abTests.europeNetworkFrontVariant === 'variant';
+		article.config.abTests.europeNetworkFrontVariant === 'variant';
 
 	if (isSlimNav) {
 		return (
@@ -163,15 +163,15 @@ const NavHeader = ({ CAPIArticle, NAV, format }: Props) => {
 						format={{
 							display: format.display,
 							design: format.design,
-							theme: getCurrentPillar(CAPIArticle),
+							theme: getCurrentPillar(article),
 						}}
 						nav={NAV}
 						subscribeUrl={
-							CAPIArticle.nav.readerRevenueLinks.header.subscribe
+							article.nav.readerRevenueLinks.header.subscribe
 						}
-						editionId={CAPIArticle.editionId}
+						editionId={article.editionId}
 						headerTopBarSwitch={
-							!!CAPIArticle.config.switches.headerTopNav
+							!!article.config.switches.headerTopNav
 						}
 					/>
 				</Section>
@@ -216,24 +216,21 @@ const NavHeader = ({ CAPIArticle, NAV, format }: Props) => {
 						element="header"
 					>
 						<Header
-							editionId={CAPIArticle.editionId}
-							idUrl={CAPIArticle.config.idUrl}
-							mmaUrl={CAPIArticle.config.mmaUrl}
-							discussionApiUrl={
-								CAPIArticle.config.discussionApiUrl
-							}
-							urls={CAPIArticle.nav.readerRevenueLinks.header}
+							editionId={article.editionId}
+							idUrl={article.config.idUrl}
+							mmaUrl={article.config.mmaUrl}
+							discussionApiUrl={article.config.discussionApiUrl}
+							urls={article.nav.readerRevenueLinks.header}
 							remoteHeader={
-								!!CAPIArticle.config.switches.remoteHeader
+								!!article.config.switches.remoteHeader
 							}
 							contributionsServiceUrl={
-								CAPIArticle.contributionsServiceUrl
+								article.contributionsServiceUrl
 							}
-							idApiUrl={CAPIArticle.config.idApiUrl}
+							idApiUrl={article.config.idApiUrl}
 							isInEuropeTest={isInEuropeTest}
 							headerTopBarSearchCapiSwitch={
-								!!CAPIArticle.config.switches
-									.headerTopBarSearchCapi
+								!!article.config.switches.headerTopBarSearchCapi
 							}
 						/>
 					</Section>
@@ -252,16 +249,14 @@ const NavHeader = ({ CAPIArticle, NAV, format }: Props) => {
 					format={{
 						display: ArticleDisplay.Standard,
 						design: format.design,
-						theme: getCurrentPillar(CAPIArticle),
+						theme: getCurrentPillar(article),
 					}}
 					nav={NAV}
 					subscribeUrl={
-						CAPIArticle.nav.readerRevenueLinks.header.subscribe
+						article.nav.readerRevenueLinks.header.subscribe
 					}
-					editionId={CAPIArticle.editionId}
-					headerTopBarSwitch={
-						!!CAPIArticle.config.switches.headerTopNav
-					}
+					editionId={article.editionId}
+					headerTopBarSwitch={!!article.config.switches.headerTopNav}
 				/>
 			</Section>
 
@@ -285,20 +280,16 @@ const NavHeader = ({ CAPIArticle, NAV, format }: Props) => {
 	);
 };
 
-export const FullPageInteractiveLayout = ({
-	CAPIArticle,
-	NAV,
-	format,
-}: Props) => {
+export const FullPageInteractiveLayout = ({ article, NAV, format }: Props) => {
 	const {
 		config: { host },
-	} = CAPIArticle;
+	} = article;
 
 	const palette = decidePalette(format);
 
 	return (
 		<>
-			{CAPIArticle.isLegacyInteractive && (
+			{article.isLegacyInteractive && (
 				<Global styles={interactiveGlobalStyles} />
 			)}
 			<header
@@ -306,11 +297,7 @@ export const FullPageInteractiveLayout = ({
 					background-color: ${palette.background.article};
 				`}
 			>
-				<NavHeader
-					CAPIArticle={CAPIArticle}
-					NAV={NAV}
-					format={format}
-				/>
+				<NavHeader article={article} NAV={NAV} format={format} />
 
 				{format.theme === ArticleSpecial.Labs && (
 					<Stuck>
@@ -343,17 +330,15 @@ export const FullPageInteractiveLayout = ({
 					<Renderer
 						format={format}
 						elements={
-							CAPIArticle.blocks[0]
-								? CAPIArticle.blocks[0].elements
-								: []
+							article.blocks[0] ? article.blocks[0].elements : []
 						}
 						host={host}
-						pageId={CAPIArticle.pageId}
-						webTitle={CAPIArticle.webTitle}
-						ajaxUrl={CAPIArticle.config.ajaxUrl}
-						switches={CAPIArticle.config.switches}
-						isAdFreeUser={CAPIArticle.isAdFreeUser}
-						isSensitive={CAPIArticle.config.isSensitive}
+						pageId={article.pageId}
+						webTitle={article.webTitle}
+						ajaxUrl={article.config.ajaxUrl}
+						switches={article.config.switches}
+						isAdFreeUser={article.isAdFreeUser}
+						isSensitive={article.config.isSensitive}
 					/>
 				</article>
 			</Section>
@@ -384,43 +369,41 @@ export const FullPageInteractiveLayout = ({
 				element="footer"
 			>
 				<Footer
-					pageFooter={CAPIArticle.pageFooter}
+					pageFooter={article.pageFooter}
 					pillar={format.theme}
 					pillars={NAV.pillars}
-					urls={CAPIArticle.nav.readerRevenueLinks.header}
-					editionId={CAPIArticle.editionId}
-					contributionsServiceUrl={
-						CAPIArticle.contributionsServiceUrl
-					}
+					urls={article.nav.readerRevenueLinks.header}
+					editionId={article.editionId}
+					contributionsServiceUrl={article.contributionsServiceUrl}
 				/>
 			</Section>
 
 			<BannerWrapper>
 				<Island deferUntil="idle" clientOnly={true}>
 					<StickyBottomBanner
-						contentType={CAPIArticle.contentType}
+						contentType={article.contentType}
 						contributionsServiceUrl={
-							CAPIArticle.contributionsServiceUrl
+							article.contributionsServiceUrl
 						}
-						idApiUrl={CAPIArticle.config.idApiUrl}
-						isMinuteArticle={CAPIArticle.pageType.isMinuteArticle}
-						isPaidContent={CAPIArticle.pageType.isPaidContent}
-						isPreview={!!CAPIArticle.config.isPreview}
-						isSensitive={CAPIArticle.config.isSensitive}
-						keywordIds={CAPIArticle.config.keywordIds}
-						pageId={CAPIArticle.pageId}
-						section={CAPIArticle.config.section}
-						sectionName={CAPIArticle.sectionName}
+						idApiUrl={article.config.idApiUrl}
+						isMinuteArticle={article.pageType.isMinuteArticle}
+						isPaidContent={article.pageType.isPaidContent}
+						isPreview={!!article.config.isPreview}
+						isSensitive={article.config.isSensitive}
+						keywordIds={article.config.keywordIds}
+						pageId={article.pageId}
+						section={article.config.section}
+						sectionName={article.sectionName}
 						shouldHideReaderRevenue={
-							CAPIArticle.shouldHideReaderRevenue
+							article.shouldHideReaderRevenue
 						}
 						remoteBannerSwitch={
-							!!CAPIArticle.config.switches.remoteBanner
+							!!article.config.switches.remoteBanner
 						}
 						puzzleBannerSwitch={
-							!!CAPIArticle.config.switches.puzzlesBanner
+							!!article.config.switches.puzzlesBanner
 						}
-						tags={CAPIArticle.tags}
+						tags={article.tags}
 					/>
 				</Island>
 			</BannerWrapper>

--- a/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
@@ -182,7 +182,7 @@ const stretchLines = css`
 `;
 
 interface Props {
-	CAPIArticle: FEArticleType;
+	article: FEArticleType;
 	NAV: NavType;
 	format: ArticleFormat;
 }
@@ -239,38 +239,37 @@ const Box = ({
 	</div>
 );
 
-export const ImmersiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
+export const ImmersiveLayout = ({ article, NAV, format }: Props) => {
 	const {
 		config: { isPaidContent, host },
-	} = CAPIArticle;
+	} = article;
 
 	const adTargeting: AdTargeting = buildAdTargeting({
-		isAdFreeUser: CAPIArticle.isAdFreeUser,
-		isSensitive: CAPIArticle.config.isSensitive,
-		videoDuration: CAPIArticle.config.videoDuration,
-		edition: CAPIArticle.config.edition,
-		section: CAPIArticle.config.section,
-		sharedAdTargeting: CAPIArticle.config.sharedAdTargeting,
-		adUnit: CAPIArticle.config.adUnit,
+		isAdFreeUser: article.isAdFreeUser,
+		isSensitive: article.config.isSensitive,
+		videoDuration: article.config.videoDuration,
+		edition: article.config.edition,
+		section: article.config.section,
+		sharedAdTargeting: article.config.sharedAdTargeting,
+		adUnit: article.config.adUnit,
 	});
 
 	const showBodyEndSlot =
-		parse(CAPIArticle.slotMachineFlags ?? '').showBodyEnd ||
-		CAPIArticle.config.switches.slotBodyEnd;
+		parse(article.slotMachineFlags ?? '').showBodyEnd ||
+		article.config.switches.slotBodyEnd;
 
 	// TODO:
 	// 1) Read 'forceEpic' value from URL parameter and use it to force the slot to render
-	// 2) Otherwise, ensure slot only renders if `CAPIArticle.config.shouldHideReaderRevenue` equals false.
+	// 2) Otherwise, ensure slot only renders if `article.config.shouldHideReaderRevenue` equals false.
 
-	const showComments = CAPIArticle.isCommentable;
+	const showComments = article.isCommentable;
 
-	const mainMedia = CAPIArticle.mainMediaElements[0] as ImageBlockElement;
+	const mainMedia = article.mainMediaElements[0] as ImageBlockElement;
 	const captionText = decideCaption(mainMedia);
 	const HEADLINE_OFFSET = mainMedia ? 120 : 0;
-	const { branding } =
-		CAPIArticle.commercialProperties[CAPIArticle.editionId];
+	const { branding } = article.commercialProperties[article.editionId];
 
-	const contributionsServiceUrl = getContributionsServiceUrl(CAPIArticle);
+	const contributionsServiceUrl = getContributionsServiceUrl(article);
 
 	const palette = decidePalette(format);
 
@@ -342,15 +341,15 @@ export const ImmersiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 					<Nav
 						format={{
 							...format,
-							theme: getCurrentPillar(CAPIArticle),
+							theme: getCurrentPillar(article),
 						}}
 						nav={NAV}
 						subscribeUrl={
-							CAPIArticle.nav.readerRevenueLinks.header.subscribe
+							article.nav.readerRevenueLinks.header.subscribe
 						}
-						editionId={CAPIArticle.editionId}
+						editionId={article.editionId}
 						headerTopBarSwitch={
-							!!CAPIArticle.config.switches.headerTopNav
+							!!article.config.switches.headerTopNav
 						}
 					/>
 				</Section>
@@ -388,22 +387,22 @@ export const ImmersiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 				>
 					<MainMedia
 						format={format}
-						elements={CAPIArticle.mainMediaElements}
+						elements={article.mainMediaElements}
 						adTargeting={adTargeting}
 						starRating={
 							format.design === ArticleDesign.Review &&
-							CAPIArticle.starRating
-								? CAPIArticle.starRating
+							article.starRating
+								? article.starRating
 								: undefined
 						}
 						host={host}
 						hideCaption={true}
-						pageId={CAPIArticle.pageId}
-						webTitle={CAPIArticle.webTitle}
-						ajaxUrl={CAPIArticle.config.ajaxUrl}
-						switches={CAPIArticle.config.switches}
-						isAdFreeUser={CAPIArticle.isAdFreeUser}
-						isSensitive={CAPIArticle.config.isSensitive}
+						pageId={article.pageId}
+						webTitle={article.webTitle}
+						ajaxUrl={article.config.ajaxUrl}
+						switches={article.config.switches}
+						isAdFreeUser={article.isAdFreeUser}
+						isSensitive={article.config.isSensitive}
 					/>
 				</div>
 				{mainMedia && (
@@ -430,13 +429,11 @@ export const ImmersiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 							>
 								<ArticleTitle
 									format={format}
-									tags={CAPIArticle.tags}
-									sectionLabel={CAPIArticle.sectionLabel}
-									sectionUrl={CAPIArticle.sectionUrl}
-									guardianBaseURL={
-										CAPIArticle.guardianBaseURL
-									}
-									badge={CAPIArticle.badge}
+									tags={article.tags}
+									sectionLabel={article.sectionLabel}
+									sectionUrl={article.sectionUrl}
+									guardianBaseURL={article.guardianBaseURL}
+									badge={article.badge}
 								/>
 							</Section>
 							<Box palette={palette}>
@@ -449,15 +446,15 @@ export const ImmersiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 								>
 									<ArticleHeadline
 										format={format}
-										headlineString={CAPIArticle.headline}
-										tags={CAPIArticle.tags}
-										byline={CAPIArticle.byline}
+										headlineString={article.headline}
+										tags={article.tags}
+										byline={article.byline}
 										webPublicationDateDeprecated={
-											CAPIArticle.webPublicationDateDeprecated
+											article.webPublicationDateDeprecated
 										}
 										hasStarRating={
-											!!CAPIArticle.starRating ||
-											CAPIArticle.starRating === 0
+											!!article.starRating ||
+											article.starRating === 0
 										}
 									/>
 								</Section>
@@ -509,15 +506,13 @@ export const ImmersiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 									>
 										<ArticleTitle
 											format={format}
-											tags={CAPIArticle.tags}
-											sectionLabel={
-												CAPIArticle.sectionLabel
-											}
-											sectionUrl={CAPIArticle.sectionUrl}
+											tags={article.tags}
+											sectionLabel={article.sectionLabel}
+											sectionUrl={article.sectionUrl}
 											guardianBaseURL={
-												CAPIArticle.guardianBaseURL
+												article.guardianBaseURL
 											}
-											badge={CAPIArticle.badge}
+											badge={article.badge}
 										/>
 									</div>
 								)}
@@ -529,16 +524,14 @@ export const ImmersiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 									<div css={maxWidth}>
 										<ArticleHeadline
 											format={format}
-											headlineString={
-												CAPIArticle.headline
-											}
-											tags={CAPIArticle.tags}
-											byline={CAPIArticle.byline}
+											headlineString={article.headline}
+											tags={article.tags}
+											byline={article.byline}
 											webPublicationDateDeprecated={
-												CAPIArticle.webPublicationDateDeprecated
+												article.webPublicationDateDeprecated
 											}
 											hasStarRating={
-												typeof CAPIArticle.starRating ===
+												typeof article.starRating ===
 												'number'
 											}
 										/>
@@ -549,15 +542,15 @@ export const ImmersiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 						<GridItem area="standfirst">
 							<Standfirst
 								format={format}
-								standfirst={CAPIArticle.standfirst}
+								standfirst={article.standfirst}
 							/>
 						</GridItem>
 						<GridItem area="byline">
-							{!!CAPIArticle.byline && (
+							{!!article.byline && (
 								<HeadlineByline
 									format={format}
-									tags={CAPIArticle.tags}
-									byline={CAPIArticle.byline}
+									tags={article.tags}
+									byline={article.byline}
 								/>
 							)}
 						</GridItem>
@@ -589,24 +582,24 @@ export const ImmersiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 								<ArticleMeta
 									branding={branding}
 									format={format}
-									pageId={CAPIArticle.pageId}
-									webTitle={CAPIArticle.webTitle}
-									byline={CAPIArticle.byline}
-									tags={CAPIArticle.tags}
+									pageId={article.pageId}
+									webTitle={article.webTitle}
+									byline={article.byline}
+									tags={article.tags}
 									primaryDateline={
-										CAPIArticle.webPublicationDateDisplay
+										article.webPublicationDateDisplay
 									}
 									secondaryDateline={
-										CAPIArticle.webPublicationSecondaryDateDisplay
+										article.webPublicationSecondaryDateDisplay
 									}
-									isCommentable={CAPIArticle.isCommentable}
+									isCommentable={article.isCommentable}
 									discussionApiUrl={
-										CAPIArticle.config.discussionApiUrl
+										article.config.discussionApiUrl
 									}
-									shortUrlId={CAPIArticle.config.shortUrlId}
-									ajaxUrl={CAPIArticle.config.ajaxUrl}
+									shortUrlId={article.config.shortUrlId}
+									ajaxUrl={article.config.ajaxUrl}
 									showShareCount={
-										!!CAPIArticle.config.switches
+										!!article.config.switches
 											.serverShareCounts
 									}
 								/>
@@ -616,72 +609,60 @@ export const ImmersiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 							<ArticleContainer format={format}>
 								<ArticleBody
 									format={format}
-									blocks={CAPIArticle.blocks}
+									blocks={article.blocks}
 									adTargeting={adTargeting}
 									host={host}
-									pageId={CAPIArticle.pageId}
-									webTitle={CAPIArticle.webTitle}
-									ajaxUrl={CAPIArticle.config.ajaxUrl}
-									switches={CAPIArticle.config.switches}
-									isSensitive={CAPIArticle.config.isSensitive}
-									isAdFreeUser={CAPIArticle.isAdFreeUser}
-									section={CAPIArticle.config.section}
+									pageId={article.pageId}
+									webTitle={article.webTitle}
+									ajaxUrl={article.config.ajaxUrl}
+									switches={article.config.switches}
+									isSensitive={article.config.isSensitive}
+									isAdFreeUser={article.isAdFreeUser}
+									section={article.config.section}
 									shouldHideReaderRevenue={
-										CAPIArticle.shouldHideReaderRevenue
+										article.shouldHideReaderRevenue
 									}
-									tags={CAPIArticle.tags}
+									tags={article.tags}
 									isPaidContent={
-										!!CAPIArticle.config.isPaidContent
+										!!article.config.isPaidContent
 									}
-									keywordIds={CAPIArticle.config.keywordIds}
+									keywordIds={article.config.keywordIds}
 									contributionsServiceUrl={
 										contributionsServiceUrl
 									}
-									contentType={CAPIArticle.contentType}
-									sectionName={CAPIArticle.sectionName ?? ''}
-									isPreview={CAPIArticle.config.isPreview}
-									idUrl={CAPIArticle.config.idUrl ?? ''}
-									isDev={!!CAPIArticle.config.isDev}
-									abTests={CAPIArticle.config.abTests}
-									tableOfContents={
-										CAPIArticle.tableOfContents
-									}
+									contentType={article.contentType}
+									sectionName={article.sectionName ?? ''}
+									isPreview={article.config.isPreview}
+									idUrl={article.config.idUrl ?? ''}
+									isDev={!!article.config.isDev}
+									abTests={article.config.abTests}
+									tableOfContents={article.tableOfContents}
 								/>
 								{showBodyEndSlot && (
 									<Island clientOnly={true}>
 										<SlotBodyEnd
-											contentType={
-												CAPIArticle.contentType
-											}
+											contentType={article.contentType}
 											contributionsServiceUrl={
 												contributionsServiceUrl
 											}
-											idApiUrl={
-												CAPIArticle.config.idApiUrl
-											}
+											idApiUrl={article.config.idApiUrl}
 											isMinuteArticle={
-												CAPIArticle.pageType
-													.isMinuteArticle
+												article.pageType.isMinuteArticle
 											}
 											isPaidContent={
-												CAPIArticle.pageType
-													.isPaidContent
+												article.pageType.isPaidContent
 											}
 											keywordIds={
-												CAPIArticle.config.keywordIds
+												article.config.keywordIds
 											}
-											pageId={CAPIArticle.pageId}
-											sectionId={
-												CAPIArticle.config.section
-											}
-											sectionName={
-												CAPIArticle.sectionName
-											}
+											pageId={article.pageId}
+											sectionId={article.config.section}
+											sectionName={article.sectionName}
 											shouldHideReaderRevenue={
-												CAPIArticle.shouldHideReaderRevenue
+												article.shouldHideReaderRevenue
 											}
-											stage={CAPIArticle.config.stage}
-											tags={CAPIArticle.tags}
+											stage={article.config.stage}
+											tags={article.tags}
 										/>
 									</Island>
 								)}
@@ -694,18 +675,18 @@ export const ImmersiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 								<SubMeta
 									format={format}
 									subMetaKeywordLinks={
-										CAPIArticle.subMetaKeywordLinks
+										article.subMetaKeywordLinks
 									}
 									subMetaSectionLinks={
-										CAPIArticle.subMetaSectionLinks
+										article.subMetaSectionLinks
 									}
-									pageId={CAPIArticle.pageId}
-									webUrl={CAPIArticle.webURL}
-									webTitle={CAPIArticle.webTitle}
+									pageId={article.pageId}
+									webUrl={article.webURL}
+									webTitle={article.webTitle}
 									showBottomSocialButtons={
-										CAPIArticle.showBottomSocialButtons
+										article.showBottomSocialButtons
 									}
-									badge={CAPIArticle.badge}
+									badge={article.badge}
 								/>
 							</ArticleContainer>
 						</GridItem>
@@ -734,15 +715,15 @@ export const ImmersiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 													margin-top: ${space[4]}px;
 												`}
 											>
-												{!CAPIArticle.shouldHideAds && (
+												{!article.shouldHideAds && (
 													<AdSlot
 														position="right"
 														display={format.display}
 														shouldHideReaderRevenue={
-															CAPIArticle.shouldHideReaderRevenue
+															article.shouldHideReaderRevenue
 														}
 														isPaidContent={
-															CAPIArticle.pageType
+															article.pageType
 																.isPaidContent
 														}
 													/>
@@ -771,12 +752,12 @@ export const ImmersiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 					</Section>
 				)}
 
-				{CAPIArticle.storyPackage && (
+				{article.storyPackage && (
 					<Section fullWidth={true}>
 						<Island deferUntil="visible">
 							<Carousel
-								heading={CAPIArticle.storyPackage.heading}
-								trails={CAPIArticle.storyPackage.trails.map(
+								heading={article.storyPackage.heading}
+								trails={article.storyPackage.trails.map(
 									decideTrail,
 								)}
 								onwardsSource="more-on-this-story"
@@ -792,24 +773,20 @@ export const ImmersiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 					placeholderHeight={600}
 				>
 					<OnwardsUpper
-						ajaxUrl={CAPIArticle.config.ajaxUrl}
-						hasRelated={CAPIArticle.hasRelated}
-						hasStoryPackage={CAPIArticle.hasStoryPackage}
-						isAdFreeUser={CAPIArticle.isAdFreeUser}
-						pageId={CAPIArticle.pageId}
-						isPaidContent={
-							CAPIArticle.config.isPaidContent ?? false
-						}
-						showRelatedContent={
-							CAPIArticle.config.showRelatedContent
-						}
-						keywordIds={CAPIArticle.config.keywordIds}
-						contentType={CAPIArticle.contentType}
-						tags={CAPIArticle.tags}
+						ajaxUrl={article.config.ajaxUrl}
+						hasRelated={article.hasRelated}
+						hasStoryPackage={article.hasStoryPackage}
+						isAdFreeUser={article.isAdFreeUser}
+						pageId={article.pageId}
+						isPaidContent={article.config.isPaidContent ?? false}
+						showRelatedContent={article.config.showRelatedContent}
+						keywordIds={article.config.keywordIds}
+						contentType={article.contentType}
+						tags={article.tags}
 						format={format}
 						pillar={format.theme}
-						editionId={CAPIArticle.editionId}
-						shortUrlId={CAPIArticle.config.shortUrlId}
+						editionId={article.editionId}
+						shortUrlId={article.config.shortUrlId}
 					/>
 				</Island>
 
@@ -820,22 +797,19 @@ export const ImmersiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 						element="aside"
 					>
 						<DiscussionLayout
-							discussionApiUrl={
-								CAPIArticle.config.discussionApiUrl
-							}
-							shortUrlId={CAPIArticle.config.shortUrlId}
+							discussionApiUrl={article.config.discussionApiUrl}
+							shortUrlId={article.config.shortUrlId}
 							format={format}
-							discussionD2Uid={CAPIArticle.config.discussionD2Uid}
+							discussionD2Uid={article.config.discussionD2Uid}
 							discussionApiClientHeader={
-								CAPIArticle.config.discussionApiClientHeader
+								article.config.discussionApiClientHeader
 							}
 							enableDiscussionSwitch={
-								!!CAPIArticle.config.switches
-									.enableDiscussionSwitch
+								!!article.config.switches.enableDiscussionSwitch
 							}
-							isAdFreeUser={CAPIArticle.isAdFreeUser}
-							shouldHideAds={CAPIArticle.shouldHideAds}
-							idApiUrl={CAPIArticle.config.idApiUrl}
+							isAdFreeUser={article.isAdFreeUser}
+							shouldHideAds={article.shouldHideAds}
+							idApiUrl={article.config.idApiUrl}
 						/>
 					</Section>
 				)}
@@ -852,9 +826,9 @@ export const ImmersiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 						<MostViewedFooterLayout>
 							<Island clientOnly={true} deferUntil="visible">
 								<MostViewedFooterData
-									sectionName={CAPIArticle.sectionName}
+									sectionName={article.sectionName}
 									format={format}
-									ajaxUrl={CAPIArticle.config.ajaxUrl}
+									ajaxUrl={article.config.ajaxUrl}
 								/>
 							</Island>
 						</MostViewedFooterLayout>
@@ -898,41 +872,39 @@ export const ImmersiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 				element="footer"
 			>
 				<Footer
-					pageFooter={CAPIArticle.pageFooter}
+					pageFooter={article.pageFooter}
 					pillar={format.theme}
 					pillars={NAV.pillars}
-					urls={CAPIArticle.nav.readerRevenueLinks.header}
-					editionId={CAPIArticle.editionId}
-					contributionsServiceUrl={
-						CAPIArticle.contributionsServiceUrl
-					}
+					urls={article.nav.readerRevenueLinks.header}
+					editionId={article.editionId}
+					contributionsServiceUrl={article.contributionsServiceUrl}
 				/>
 			</Section>
 
 			<BannerWrapper>
 				<Island deferUntil="idle" clientOnly={true}>
 					<StickyBottomBanner
-						contentType={CAPIArticle.contentType}
+						contentType={article.contentType}
 						contributionsServiceUrl={contributionsServiceUrl}
-						idApiUrl={CAPIArticle.config.idApiUrl}
-						isMinuteArticle={CAPIArticle.pageType.isMinuteArticle}
-						isPaidContent={CAPIArticle.pageType.isPaidContent}
-						isPreview={!!CAPIArticle.config.isPreview}
-						isSensitive={CAPIArticle.config.isSensitive}
-						keywordIds={CAPIArticle.config.keywordIds}
-						pageId={CAPIArticle.pageId}
-						section={CAPIArticle.config.section}
-						sectionName={CAPIArticle.sectionName}
+						idApiUrl={article.config.idApiUrl}
+						isMinuteArticle={article.pageType.isMinuteArticle}
+						isPaidContent={article.pageType.isPaidContent}
+						isPreview={!!article.config.isPreview}
+						isSensitive={article.config.isSensitive}
+						keywordIds={article.config.keywordIds}
+						pageId={article.pageId}
+						section={article.config.section}
+						sectionName={article.sectionName}
 						shouldHideReaderRevenue={
-							CAPIArticle.shouldHideReaderRevenue
+							article.shouldHideReaderRevenue
 						}
 						remoteBannerSwitch={
-							!!CAPIArticle.config.switches.remoteBanner
+							!!article.config.switches.remoteBanner
 						}
 						puzzleBannerSwitch={
-							!!CAPIArticle.config.switches.puzzlesBanner
+							!!article.config.switches.puzzlesBanner
 						}
-						tags={CAPIArticle.tags}
+						tags={article.tags}
 					/>
 				</Island>
 			</BannerWrapper>

--- a/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
@@ -201,46 +201,45 @@ const starWrapper = css`
 `;
 
 interface Props {
-	CAPIArticle: FEArticleType;
+	article: FEArticleType;
 	NAV: NavType;
 	format: ArticleFormat;
 }
 
-export const InteractiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
+export const InteractiveLayout = ({ article, NAV, format }: Props) => {
 	const {
 		config: { isPaidContent, host },
-	} = CAPIArticle;
+	} = article;
 
 	const isInEuropeTest =
-		CAPIArticle.config.abTests.europeNetworkFrontVariant === 'variant';
+		article.config.abTests.europeNetworkFrontVariant === 'variant';
 
 	const adTargeting: AdTargeting = buildAdTargeting({
-		isAdFreeUser: CAPIArticle.isAdFreeUser,
-		isSensitive: CAPIArticle.config.isSensitive,
-		videoDuration: CAPIArticle.config.videoDuration,
-		edition: CAPIArticle.config.edition,
-		section: CAPIArticle.config.section,
-		sharedAdTargeting: CAPIArticle.config.sharedAdTargeting,
-		adUnit: CAPIArticle.config.adUnit,
+		isAdFreeUser: article.isAdFreeUser,
+		isSensitive: article.config.isSensitive,
+		videoDuration: article.config.videoDuration,
+		edition: article.config.edition,
+		section: article.config.section,
+		sharedAdTargeting: article.config.sharedAdTargeting,
+		adUnit: article.config.adUnit,
 	});
 
-	const showComments = CAPIArticle.isCommentable;
+	const showComments = article.isCommentable;
 
-	const { branding } =
-		CAPIArticle.commercialProperties[CAPIArticle.editionId];
+	const { branding } = article.commercialProperties[article.editionId];
 
 	const palette = decidePalette(format);
 
-	const contributionsServiceUrl = getContributionsServiceUrl(CAPIArticle);
+	const contributionsServiceUrl = getContributionsServiceUrl(article);
 
 	/**
 	 * This property currently only applies to the header and merchandising slots
 	 */
-	const renderAds = !CAPIArticle.isAdFreeUser && !CAPIArticle.shouldHideAds;
+	const renderAds = !article.isAdFreeUser && !article.shouldHideAds;
 
 	return (
 		<>
-			{CAPIArticle.isLegacyInteractive && (
+			{article.isLegacyInteractive && (
 				<Global styles={interactiveGlobalStyles} />
 			)}
 
@@ -273,23 +272,23 @@ export const InteractiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 							element="header"
 						>
 							<Header
-								editionId={CAPIArticle.editionId}
-								idUrl={CAPIArticle.config.idUrl}
-								mmaUrl={CAPIArticle.config.mmaUrl}
+								editionId={article.editionId}
+								idUrl={article.config.idUrl}
+								mmaUrl={article.config.mmaUrl}
 								discussionApiUrl={
-									CAPIArticle.config.discussionApiUrl
+									article.config.discussionApiUrl
 								}
-								urls={CAPIArticle.nav.readerRevenueLinks.header}
+								urls={article.nav.readerRevenueLinks.header}
 								remoteHeader={
-									!!CAPIArticle.config.switches.remoteHeader
+									!!article.config.switches.remoteHeader
 								}
 								contributionsServiceUrl={
 									contributionsServiceUrl
 								}
-								idApiUrl={CAPIArticle.config.idApiUrl}
+								idApiUrl={article.config.idApiUrl}
 								isInEuropeTest={isInEuropeTest}
 								headerTopBarSearchCapiSwitch={
-									!!CAPIArticle.config.switches
+									!!article.config.switches
 										.headerTopBarSearchCapi
 								}
 							/>
@@ -309,14 +308,14 @@ export const InteractiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 						nav={NAV}
 						format={{
 							...format,
-							theme: getCurrentPillar(CAPIArticle),
+							theme: getCurrentPillar(article),
 						}}
 						subscribeUrl={
-							CAPIArticle.nav.readerRevenueLinks.header.subscribe
+							article.nav.readerRevenueLinks.header.subscribe
 						}
-						editionId={CAPIArticle.editionId}
+						editionId={article.editionId}
 						headerTopBarSwitch={
-							!!CAPIArticle.config.switches.headerTopNav
+							!!article.config.switches.headerTopNav
 						}
 					/>
 				</Section>
@@ -371,7 +370,7 @@ export const InteractiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 				</Stuck>
 			)}
 
-			{renderAds && CAPIArticle.config.switches.surveys && (
+			{renderAds && article.config.switches.surveys && (
 				<AdSlot position="survey" display={format.display} />
 			)}
 			<main data-layout="InteractiveLayout">
@@ -394,13 +393,13 @@ export const InteractiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 								>
 									<ArticleTitle
 										format={format}
-										tags={CAPIArticle.tags}
-										sectionLabel={CAPIArticle.sectionLabel}
-										sectionUrl={CAPIArticle.sectionUrl}
+										tags={article.tags}
+										sectionLabel={article.sectionLabel}
+										sectionUrl={article.sectionUrl}
 										guardianBaseURL={
-											CAPIArticle.guardianBaseURL
+											article.guardianBaseURL
 										}
-										badge={CAPIArticle.badge}
+										badge={article.badge}
 									/>
 								</div>
 							</GridItem>
@@ -415,23 +414,23 @@ export const InteractiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 								<div css={maxWidth}>
 									<ArticleHeadline
 										format={format}
-										headlineString={CAPIArticle.headline}
-										tags={CAPIArticle.tags}
-										byline={CAPIArticle.byline}
+										headlineString={article.headline}
+										tags={article.tags}
+										byline={article.byline}
 										webPublicationDateDeprecated={
-											CAPIArticle.webPublicationDateDeprecated
+											article.webPublicationDateDeprecated
 										}
 										hasStarRating={
-											typeof CAPIArticle.starRating ===
+											typeof article.starRating ===
 											'number'
 										}
 									/>
 								</div>
-								{CAPIArticle.starRating ||
-								CAPIArticle.starRating === 0 ? (
+								{article.starRating ||
+								article.starRating === 0 ? (
 									<div css={starWrapper}>
 										<StarRating
-											rating={CAPIArticle.starRating}
+											rating={article.starRating}
 											size="large"
 										/>
 									</div>
@@ -442,24 +441,22 @@ export const InteractiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 							<GridItem area="standfirst">
 								<Standfirst
 									format={format}
-									standfirst={CAPIArticle.standfirst}
+									standfirst={article.standfirst}
 								/>
 							</GridItem>
 							<GridItem area="media">
 								<div css={maxWidth}>
 									<MainMedia
 										format={format}
-										elements={CAPIArticle.mainMediaElements}
+										elements={article.mainMediaElements}
 										adTargeting={adTargeting}
 										host={host}
-										pageId={CAPIArticle.pageId}
-										webTitle={CAPIArticle.webTitle}
-										ajaxUrl={CAPIArticle.config.ajaxUrl}
-										switches={CAPIArticle.config.switches}
-										isAdFreeUser={CAPIArticle.isAdFreeUser}
-										isSensitive={
-											CAPIArticle.config.isSensitive
-										}
+										pageId={article.pageId}
+										webTitle={article.webTitle}
+										ajaxUrl={article.config.ajaxUrl}
+										switches={article.config.switches}
+										isAdFreeUser={article.isAdFreeUser}
+										isSensitive={article.config.isSensitive}
 									/>
 								</div>
 							</GridItem>
@@ -475,28 +472,24 @@ export const InteractiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 									<ArticleMeta
 										branding={branding}
 										format={format}
-										pageId={CAPIArticle.pageId}
-										webTitle={CAPIArticle.webTitle}
-										byline={CAPIArticle.byline}
-										tags={CAPIArticle.tags}
+										pageId={article.pageId}
+										webTitle={article.webTitle}
+										byline={article.byline}
+										tags={article.tags}
 										primaryDateline={
-											CAPIArticle.webPublicationDateDisplay
+											article.webPublicationDateDisplay
 										}
 										secondaryDateline={
-											CAPIArticle.webPublicationSecondaryDateDisplay
+											article.webPublicationSecondaryDateDisplay
 										}
-										isCommentable={
-											CAPIArticle.isCommentable
-										}
+										isCommentable={article.isCommentable}
 										discussionApiUrl={
-											CAPIArticle.config.discussionApiUrl
+											article.config.discussionApiUrl
 										}
-										shortUrlId={
-											CAPIArticle.config.shortUrlId
-										}
-										ajaxUrl={CAPIArticle.config.ajaxUrl}
+										shortUrlId={article.config.shortUrlId}
+										ajaxUrl={article.config.ajaxUrl}
 										showShareCount={
-											!!CAPIArticle.config.switches
+											!!article.config.switches
 												.serverShareCounts
 										}
 									/>
@@ -506,40 +499,34 @@ export const InteractiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 								<ArticleContainer format={format}>
 									<ArticleBody
 										format={format}
-										blocks={CAPIArticle.blocks}
+										blocks={article.blocks}
 										adTargeting={adTargeting}
 										host={host}
-										pageId={CAPIArticle.pageId}
-										webTitle={CAPIArticle.webTitle}
-										ajaxUrl={CAPIArticle.config.ajaxUrl}
-										switches={CAPIArticle.config.switches}
-										isSensitive={
-											CAPIArticle.config.isSensitive
-										}
-										isAdFreeUser={CAPIArticle.isAdFreeUser}
-										section={CAPIArticle.config.section}
+										pageId={article.pageId}
+										webTitle={article.webTitle}
+										ajaxUrl={article.config.ajaxUrl}
+										switches={article.config.switches}
+										isSensitive={article.config.isSensitive}
+										isAdFreeUser={article.isAdFreeUser}
+										section={article.config.section}
 										shouldHideReaderRevenue={
-											CAPIArticle.shouldHideReaderRevenue
+											article.shouldHideReaderRevenue
 										}
-										tags={CAPIArticle.tags}
+										tags={article.tags}
 										isPaidContent={
-											!!CAPIArticle.config.isPaidContent
+											!!article.config.isPaidContent
 										}
 										contributionsServiceUrl={
 											contributionsServiceUrl
 										}
-										contentType={CAPIArticle.contentType}
-										sectionName={
-											CAPIArticle.sectionName ?? ''
-										}
-										isPreview={CAPIArticle.config.isPreview}
-										idUrl={CAPIArticle.config.idUrl ?? ''}
-										isDev={!!CAPIArticle.config.isDev}
-										keywordIds={
-											CAPIArticle.config.keywordIds
-										}
+										contentType={article.contentType}
+										sectionName={article.sectionName ?? ''}
+										isPreview={article.config.isPreview}
+										idUrl={article.config.idUrl ?? ''}
+										isDev={!!article.config.isDev}
+										keywordIds={article.config.keywordIds}
 										tableOfContents={
-											CAPIArticle.tableOfContents
+											article.tableOfContents
 										}
 									/>
 								</ArticleContainer>
@@ -562,26 +549,24 @@ export const InteractiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 					>
 						<Island clientOnly={true}>
 							<SlotBodyEnd
-								contentType={CAPIArticle.contentType}
+								contentType={article.contentType}
 								contributionsServiceUrl={
 									contributionsServiceUrl
 								}
-								idApiUrl={CAPIArticle.config.idApiUrl}
+								idApiUrl={article.config.idApiUrl}
 								isMinuteArticle={
-									CAPIArticle.pageType.isMinuteArticle
+									article.pageType.isMinuteArticle
 								}
-								isPaidContent={
-									CAPIArticle.pageType.isPaidContent
-								}
-								keywordIds={CAPIArticle.config.keywordIds}
-								pageId={CAPIArticle.pageId}
-								sectionId={CAPIArticle.config.section}
-								sectionName={CAPIArticle.sectionName}
+								isPaidContent={article.pageType.isPaidContent}
+								keywordIds={article.config.keywordIds}
+								pageId={article.pageId}
+								sectionId={article.config.section}
+								sectionName={article.sectionName}
 								shouldHideReaderRevenue={
-									CAPIArticle.shouldHideReaderRevenue
+									article.shouldHideReaderRevenue
 								}
-								stage={CAPIArticle.config.stage}
-								tags={CAPIArticle.tags}
+								stage={article.config.stage}
+								tags={article.tags}
 							/>
 						</Island>
 					</div>
@@ -609,15 +594,15 @@ export const InteractiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 				>
 					<SubMeta
 						format={format}
-						subMetaKeywordLinks={CAPIArticle.subMetaKeywordLinks}
-						subMetaSectionLinks={CAPIArticle.subMetaSectionLinks}
-						pageId={CAPIArticle.pageId}
-						webUrl={CAPIArticle.webURL}
-						webTitle={CAPIArticle.webTitle}
+						subMetaKeywordLinks={article.subMetaKeywordLinks}
+						subMetaSectionLinks={article.subMetaSectionLinks}
+						pageId={article.pageId}
+						webUrl={article.webURL}
+						webTitle={article.webTitle}
 						showBottomSocialButtons={
-							CAPIArticle.showBottomSocialButtons
+							article.showBottomSocialButtons
 						}
-						badge={CAPIArticle.badge}
+						badge={article.badge}
 					/>
 				</Section>
 				{renderAds && (
@@ -638,12 +623,12 @@ export const InteractiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 					</Section>
 				)}
 
-				{CAPIArticle.storyPackage && (
+				{article.storyPackage && (
 					<Section fullWidth={true} showTopBorder={false}>
 						<Island deferUntil="visible">
 							<Carousel
-								heading={CAPIArticle.storyPackage.heading}
-								trails={CAPIArticle.storyPackage.trails.map(
+								heading={article.storyPackage.heading}
+								trails={article.storyPackage.trails.map(
 									decideTrail,
 								)}
 								onwardsSource="more-on-this-story"
@@ -659,22 +644,20 @@ export const InteractiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 					placeholderHeight={600}
 				>
 					<OnwardsUpper
-						ajaxUrl={CAPIArticle.config.ajaxUrl}
-						hasRelated={CAPIArticle.hasRelated}
-						hasStoryPackage={CAPIArticle.hasStoryPackage}
-						isAdFreeUser={CAPIArticle.isAdFreeUser}
-						pageId={CAPIArticle.pageId}
-						isPaidContent={!!CAPIArticle.config.isPaidContent}
-						showRelatedContent={
-							CAPIArticle.config.showRelatedContent
-						}
-						keywordIds={CAPIArticle.config.keywordIds}
-						contentType={CAPIArticle.contentType}
-						tags={CAPIArticle.tags}
+						ajaxUrl={article.config.ajaxUrl}
+						hasRelated={article.hasRelated}
+						hasStoryPackage={article.hasStoryPackage}
+						isAdFreeUser={article.isAdFreeUser}
+						pageId={article.pageId}
+						isPaidContent={!!article.config.isPaidContent}
+						showRelatedContent={article.config.showRelatedContent}
+						keywordIds={article.config.keywordIds}
+						contentType={article.contentType}
+						tags={article.tags}
 						format={format}
 						pillar={format.theme}
-						editionId={CAPIArticle.editionId}
-						shortUrlId={CAPIArticle.config.shortUrlId}
+						editionId={article.editionId}
+						shortUrlId={article.config.shortUrlId}
 					/>
 				</Island>
 
@@ -686,22 +669,19 @@ export const InteractiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 						element="section"
 					>
 						<DiscussionLayout
-							discussionApiUrl={
-								CAPIArticle.config.discussionApiUrl
-							}
-							shortUrlId={CAPIArticle.config.shortUrlId}
+							discussionApiUrl={article.config.discussionApiUrl}
+							shortUrlId={article.config.shortUrlId}
 							format={format}
-							discussionD2Uid={CAPIArticle.config.discussionD2Uid}
+							discussionD2Uid={article.config.discussionD2Uid}
 							discussionApiClientHeader={
-								CAPIArticle.config.discussionApiClientHeader
+								article.config.discussionApiClientHeader
 							}
 							enableDiscussionSwitch={
-								!!CAPIArticle.config.switches
-									.enableDiscussionSwitch
+								!!article.config.switches.enableDiscussionSwitch
 							}
-							isAdFreeUser={CAPIArticle.isAdFreeUser}
-							shouldHideAds={CAPIArticle.shouldHideAds}
-							idApiUrl={CAPIArticle.config.idApiUrl}
+							isAdFreeUser={article.isAdFreeUser}
+							shouldHideAds={article.shouldHideAds}
+							idApiUrl={article.config.idApiUrl}
 						/>
 					</Section>
 				)}
@@ -719,9 +699,9 @@ export const InteractiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 						<MostViewedFooterLayout>
 							<Island clientOnly={true} deferUntil="visible">
 								<MostViewedFooterData
-									sectionName={CAPIArticle.sectionName}
+									sectionName={article.sectionName}
 									format={format}
-									ajaxUrl={CAPIArticle.config.ajaxUrl}
+									ajaxUrl={article.config.ajaxUrl}
 								/>
 							</Island>
 						</MostViewedFooterLayout>
@@ -773,41 +753,39 @@ export const InteractiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 				element="footer"
 			>
 				<Footer
-					pageFooter={CAPIArticle.pageFooter}
+					pageFooter={article.pageFooter}
 					pillar={format.theme}
 					pillars={NAV.pillars}
-					urls={CAPIArticle.nav.readerRevenueLinks.header}
-					editionId={CAPIArticle.editionId}
-					contributionsServiceUrl={
-						CAPIArticle.contributionsServiceUrl
-					}
+					urls={article.nav.readerRevenueLinks.header}
+					editionId={article.editionId}
+					contributionsServiceUrl={article.contributionsServiceUrl}
 				/>
 			</Section>
 
 			<BannerWrapper data-print-layout="hide">
 				<Island deferUntil="idle" clientOnly={true}>
 					<StickyBottomBanner
-						contentType={CAPIArticle.contentType}
+						contentType={article.contentType}
 						contributionsServiceUrl={contributionsServiceUrl}
-						idApiUrl={CAPIArticle.config.idApiUrl}
-						isMinuteArticle={CAPIArticle.pageType.isMinuteArticle}
-						isPaidContent={CAPIArticle.pageType.isPaidContent}
-						isPreview={!!CAPIArticle.config.isPreview}
-						isSensitive={CAPIArticle.config.isSensitive}
-						keywordIds={CAPIArticle.config.keywordIds}
-						pageId={CAPIArticle.pageId}
-						section={CAPIArticle.config.section}
-						sectionName={CAPIArticle.sectionName}
+						idApiUrl={article.config.idApiUrl}
+						isMinuteArticle={article.pageType.isMinuteArticle}
+						isPaidContent={article.pageType.isPaidContent}
+						isPreview={!!article.config.isPreview}
+						isSensitive={article.config.isSensitive}
+						keywordIds={article.config.keywordIds}
+						pageId={article.pageId}
+						section={article.config.section}
+						sectionName={article.sectionName}
 						shouldHideReaderRevenue={
-							CAPIArticle.shouldHideReaderRevenue
+							article.shouldHideReaderRevenue
 						}
 						remoteBannerSwitch={
-							!!CAPIArticle.config.switches.remoteBanner
+							!!article.config.switches.remoteBanner
 						}
 						puzzleBannerSwitch={
-							!!CAPIArticle.config.switches.puzzlesBanner
+							!!article.config.switches.puzzlesBanner
 						}
-						tags={CAPIArticle.tags}
+						tags={article.tags}
 					/>
 				</Island>
 			</BannerWrapper>

--- a/dotcom-rendering/src/web/layouts/Layout.stories.tsx
+++ b/dotcom-rendering/src/web/layouts/Layout.stories.tsx
@@ -58,9 +58,13 @@ const Fixtures: { [key: string]: FEArticleType } = {
 
 mockRESTCalls();
 
-const HydratedLayout = ({ ServerCAPI }: { ServerCAPI: FEArticleType }) => {
-	const NAV = extractNAV(ServerCAPI.nav);
-	const format: ArticleFormat = decideFormat(ServerCAPI.format);
+const HydratedLayout = ({
+	serverArticle,
+}: {
+	serverArticle: FEArticleType;
+}) => {
+	const NAV = extractNAV(serverArticle.nav);
+	const format: ArticleFormat = decideFormat(serverArticle.format);
 	useEffect(() => {
 		embedIframe().catch((e) =>
 			console.error(`HydratedLayout embedIframe - error: ${String(e)}`),
@@ -68,9 +72,9 @@ const HydratedLayout = ({ ServerCAPI }: { ServerCAPI: FEArticleType }) => {
 		// Manually updates the footer DOM because it's not hydrated
 		injectPrivacySettingsLink();
 		doStorybookHydration();
-	}, [ServerCAPI]);
+	}, [serverArticle]);
 
-	return <DecideLayout CAPIArticle={ServerCAPI} NAV={NAV} format={format} />;
+	return <DecideLayout article={serverArticle} NAV={NAV} format={format} />;
 };
 
 // HydratedLayout is used here to simulated the hydration that happens after we init react on
@@ -87,16 +91,16 @@ export const HydratedLayoutWrapper = ({
 }) => {
 	const fixture = Fixtures[designName] ?? Standard;
 
-	const serverCAPI = {
+	const serverArticle = {
 		...fixture,
 		format: {
-			display: `${displayName}Display` as CAPIDisplay,
-			design: `${designName}Design` as CAPIDesign,
-			theme: theme as CAPITheme,
+			display: `${displayName}Display` as FEDisplay,
+			design: `${designName}Design` as FEDesign,
+			theme: theme as FETheme,
 		},
 	};
 
-	return <HydratedLayout ServerCAPI={serverCAPI} />;
+	return <HydratedLayout serverArticle={serverArticle} />;
 };
 
 export default {
@@ -115,7 +119,7 @@ export default {
 export const Liveblog = () => {
 	return (
 		<HydratedLayout
-			ServerCAPI={{
+			serverArticle={{
 				...Live,
 				keyEvents: [],
 			}}

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -232,7 +232,7 @@ const starWrapper = css`
 `;
 
 interface Props {
-	CAPIArticle: FEArticleType;
+	article: FEArticleType;
 	NAV: NavType;
 	format: ArticleFormat;
 }
@@ -247,58 +247,57 @@ const paddingBody = css`
 	}
 `;
 
-export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
+export const LiveLayout = ({ article, NAV, format }: Props) => {
 	const {
 		config: { isPaidContent, host },
-	} = CAPIArticle;
+	} = article;
 
 	const isInEuropeTest =
-		CAPIArticle.config.abTests.europeNetworkFrontVariant === 'variant';
+		article.config.abTests.europeNetworkFrontVariant === 'variant';
 
 	const adTargeting: AdTargeting = buildAdTargeting({
-		isAdFreeUser: CAPIArticle.isAdFreeUser,
-		isSensitive: CAPIArticle.config.isSensitive,
-		videoDuration: CAPIArticle.config.videoDuration,
-		edition: CAPIArticle.config.edition,
-		section: CAPIArticle.config.section,
-		sharedAdTargeting: CAPIArticle.config.sharedAdTargeting,
-		adUnit: CAPIArticle.config.adUnit,
+		isAdFreeUser: article.isAdFreeUser,
+		isSensitive: article.config.isSensitive,
+		videoDuration: article.config.videoDuration,
+		edition: article.config.edition,
+		section: article.config.section,
+		sharedAdTargeting: article.config.sharedAdTargeting,
+		adUnit: article.config.adUnit,
 	});
 
 	// TODO:
 	// 1) Read 'forceEpic' value from URL parameter and use it to force the slot to render
-	// 2) Otherwise, ensure slot only renders if `CAPIArticle.config.shouldHideReaderRevenue` equals false.
+	// 2) Otherwise, ensure slot only renders if `article.config.shouldHideReaderRevenue` equals false.
 
 	// Set a default pagination if it is missing from CAPI
-	const pagination: Pagination = CAPIArticle.pagination ?? {
+	const pagination: Pagination = article.pagination ?? {
 		currentPage: 1,
 		totalPages: 1,
 	};
 
-	const contributionsServiceUrl = getContributionsServiceUrl(CAPIArticle);
+	const contributionsServiceUrl = getContributionsServiceUrl(article);
 
-	const { branding } =
-		CAPIArticle.commercialProperties[CAPIArticle.editionId];
+	const { branding } = article.commercialProperties[article.editionId];
 
 	const palette = decidePalette(format);
 
 	const footballMatchUrl =
-		CAPIArticle.matchType === 'FootballMatchType' && CAPIArticle.matchUrl;
+		article.matchType === 'FootballMatchType' && article.matchUrl;
 
 	const cricketMatchUrl =
-		CAPIArticle.matchType === 'CricketMatchType' && CAPIArticle.matchUrl;
+		article.matchType === 'CricketMatchType' && article.matchUrl;
 
 	const showTopicFilterBank =
-		!!CAPIArticle.config.switches.automaticFilters &&
-		hasRelevantTopics(CAPIArticle.availableTopics);
+		!!article.config.switches.automaticFilters &&
+		hasRelevantTopics(article.availableTopics);
 
-	const hasKeyEvents = !!CAPIArticle.keyEvents.length;
+	const hasKeyEvents = !!article.keyEvents.length;
 	const showKeyEventsToggle = !showTopicFilterBank && hasKeyEvents;
 
 	/**
 	 * This property currently only applies to the header and merchandising slots
 	 */
-	const renderAds = !CAPIArticle.isAdFreeUser && !CAPIArticle.shouldHideAds;
+	const renderAds = !article.isAdFreeUser && !article.shouldHideAds;
 
 	return (
 		<>
@@ -328,22 +327,19 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 						element="header"
 					>
 						<Header
-							editionId={CAPIArticle.editionId}
-							idUrl={CAPIArticle.config.idUrl}
-							mmaUrl={CAPIArticle.config.mmaUrl}
-							discussionApiUrl={
-								CAPIArticle.config.discussionApiUrl
-							}
-							urls={CAPIArticle.nav.readerRevenueLinks.header}
+							editionId={article.editionId}
+							idUrl={article.config.idUrl}
+							mmaUrl={article.config.mmaUrl}
+							discussionApiUrl={article.config.discussionApiUrl}
+							urls={article.nav.readerRevenueLinks.header}
 							remoteHeader={
-								!!CAPIArticle.config.switches.remoteHeader
+								!!article.config.switches.remoteHeader
 							}
 							contributionsServiceUrl={contributionsServiceUrl}
-							idApiUrl={CAPIArticle.config.idApiUrl}
+							idApiUrl={article.config.idApiUrl}
 							isInEuropeTest={isInEuropeTest}
 							headerTopBarSearchCapiSwitch={
-								!!CAPIArticle.config.switches
-									.headerTopBarSearchCapi
+								!!article.config.switches.headerTopBarSearchCapi
 							}
 						/>
 					</Section>
@@ -360,15 +356,14 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 							nav={NAV}
 							format={{
 								...format,
-								theme: getCurrentPillar(CAPIArticle),
+								theme: getCurrentPillar(article),
 							}}
 							subscribeUrl={
-								CAPIArticle.nav.readerRevenueLinks.header
-									.subscribe
+								article.nav.readerRevenueLinks.header.subscribe
 							}
-							editionId={CAPIArticle.editionId}
+							editionId={article.editionId}
 							headerTopBarSwitch={
-								!!CAPIArticle.config.switches.headerTopNav
+								!!article.config.switches.headerTopNav
 							}
 						/>
 					</Section>
@@ -417,11 +412,11 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 						leftContent={
 							<ArticleTitle
 								format={format}
-								tags={CAPIArticle.tags}
-								sectionLabel={CAPIArticle.sectionLabel}
-								sectionUrl={CAPIArticle.sectionUrl}
-								guardianBaseURL={CAPIArticle.guardianBaseURL}
-								badge={CAPIArticle.badge}
+								tags={article.tags}
+								sectionLabel={article.sectionLabel}
+								sectionUrl={article.sectionUrl}
+								guardianBaseURL={article.guardianBaseURL}
+								badge={article.badge}
 								isMatch={true}
 							/>
 						}
@@ -432,11 +427,11 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 						<Hide above="leftCol">
 							<ArticleTitle
 								format={format}
-								tags={CAPIArticle.tags}
-								sectionLabel={CAPIArticle.sectionLabel}
-								sectionUrl={CAPIArticle.sectionUrl}
-								guardianBaseURL={CAPIArticle.guardianBaseURL}
-								badge={CAPIArticle.badge}
+								tags={article.tags}
+								sectionLabel={article.sectionLabel}
+								sectionUrl={article.sectionUrl}
+								guardianBaseURL={article.guardianBaseURL}
+								badge={article.badge}
 								isMatch={true}
 							/>
 						</Hide>
@@ -449,10 +444,10 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 							<GetMatchNav
 								matchUrl={footballMatchUrl}
 								format={format}
-								headlineString={CAPIArticle.headline}
-								tags={CAPIArticle.tags}
+								headlineString={article.headline}
+								tags={article.tags}
 								webPublicationDateDeprecated={
-									CAPIArticle.webPublicationDateDeprecated
+									article.webPublicationDateDeprecated
 								}
 							/>
 						</Island>
@@ -468,13 +463,11 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 							<GridItem area="title">
 								<ArticleTitle
 									format={format}
-									tags={CAPIArticle.tags}
-									sectionLabel={CAPIArticle.sectionLabel}
-									sectionUrl={CAPIArticle.sectionUrl}
-									guardianBaseURL={
-										CAPIArticle.guardianBaseURL
-									}
-									badge={CAPIArticle.badge}
+									tags={article.tags}
+									sectionLabel={article.sectionLabel}
+									sectionUrl={article.sectionUrl}
+									guardianBaseURL={article.guardianBaseURL}
+									badge={article.badge}
 								/>
 							</GridItem>
 							<GridItem area="headline">
@@ -482,26 +475,24 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 									{!footballMatchUrl && (
 										<ArticleHeadline
 											format={format}
-											headlineString={
-												CAPIArticle.headline
-											}
-											tags={CAPIArticle.tags}
-											byline={CAPIArticle.byline}
+											headlineString={article.headline}
+											tags={article.tags}
+											byline={article.byline}
 											webPublicationDateDeprecated={
-												CAPIArticle.webPublicationDateDeprecated
+												article.webPublicationDateDeprecated
 											}
 											hasStarRating={
-												typeof CAPIArticle.starRating ===
+												typeof article.starRating ===
 												'number'
 											}
 										/>
 									)}
 								</div>
-								{CAPIArticle.starRating ||
-								CAPIArticle.starRating === 0 ? (
+								{article.starRating ||
+								article.starRating === 0 ? (
 									<div css={starWrapper}>
 										<StarRating
-											rating={CAPIArticle.starRating}
+											rating={article.starRating}
 											size="large"
 										/>
 									</div>
@@ -523,17 +514,16 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 						<GridItem area="standfirst">
 							<Standfirst
 								format={format}
-								standfirst={CAPIArticle.standfirst}
+								standfirst={article.standfirst}
 							/>
 						</GridItem>
 						<GridItem area="lastupdated">
 							<Hide until="desktop">
-								{!!CAPIArticle.blocks[0]?.blockLastUpdated && (
+								{!!article.blocks[0]?.blockLastUpdated && (
 									<ArticleLastUpdated
 										format={format}
 										lastUpdated={
-											CAPIArticle.blocks[0]
-												.blockLastUpdated
+											article.blocks[0].blockLastUpdated
 										}
 									/>
 								)}
@@ -560,28 +550,24 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 									<ArticleMeta
 										branding={branding}
 										format={format}
-										pageId={CAPIArticle.pageId}
-										webTitle={CAPIArticle.webTitle}
-										byline={CAPIArticle.byline}
-										tags={CAPIArticle.tags}
+										pageId={article.pageId}
+										webTitle={article.webTitle}
+										byline={article.byline}
+										tags={article.tags}
 										primaryDateline={
-											CAPIArticle.webPublicationDateDisplay
+											article.webPublicationDateDisplay
 										}
 										secondaryDateline={
-											CAPIArticle.webPublicationSecondaryDateDisplay
+											article.webPublicationSecondaryDateDisplay
 										}
-										isCommentable={
-											CAPIArticle.isCommentable
-										}
+										isCommentable={article.isCommentable}
 										discussionApiUrl={
-											CAPIArticle.config.discussionApiUrl
+											article.config.discussionApiUrl
 										}
-										shortUrlId={
-											CAPIArticle.config.shortUrlId
-										}
-										ajaxUrl={CAPIArticle.config.ajaxUrl}
+										shortUrlId={article.config.shortUrlId}
+										ajaxUrl={article.config.ajaxUrl}
 										showShareCount={
-											!!CAPIArticle.config.switches
+											!!article.config.switches
 												.serverShareCounts
 										}
 									/>
@@ -602,10 +588,8 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 						<Hide until={'desktop'}>
 							<Island>
 								<KeyEventsCarousel
-									keyEvents={CAPIArticle.keyEvents}
-									filterKeyEvents={
-										CAPIArticle.filterKeyEvents
-									}
+									keyEvents={article.keyEvents}
+									filterKeyEvents={article.filterKeyEvents}
 									format={format}
 									id={'key-events-carousel-desktop'}
 								/>
@@ -645,26 +629,23 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 							/>
 							<Island clientOnly={true} deferUntil="idle">
 								<Liveness
-									pageId={CAPIArticle.pageId}
-									webTitle={CAPIArticle.webTitle}
-									ajaxUrl={CAPIArticle.config.ajaxUrl}
-									filterKeyEvents={
-										CAPIArticle.filterKeyEvents
-									}
+									pageId={article.pageId}
+									webTitle={article.webTitle}
+									ajaxUrl={article.config.ajaxUrl}
+									filterKeyEvents={article.filterKeyEvents}
 									format={format}
 									enhanceTweetsSwitch={
-										!!CAPIArticle.config.switches
-											.enhanceTweets
+										!!article.config.switches.enhanceTweets
 									}
 									onFirstPage={pagination.currentPage === 1}
-									webURL={CAPIArticle.webURL}
+									webURL={article.webURL}
 									// We default to string here because the property is optional but we
 									// know it will exist for all blogs
 									mostRecentBlockId={
-										CAPIArticle.mostRecentBlockId ?? ''
+										article.mostRecentBlockId ?? ''
 									}
-									hasPinnedPost={!!CAPIArticle.pinnedPost}
-									selectedTopics={CAPIArticle.selectedTopics}
+									hasPinnedPost={!!article.pinnedPost}
+									selectedTopics={article.selectedTopics}
 								/>
 							</Island>
 						</>
@@ -704,17 +685,15 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 									)}
 									<MainMedia
 										format={format}
-										elements={CAPIArticle.mainMediaElements}
+										elements={article.mainMediaElements}
 										adTargeting={adTargeting}
 										host={host}
-										pageId={CAPIArticle.pageId}
-										webTitle={CAPIArticle.webTitle}
-										ajaxUrl={CAPIArticle.config.ajaxUrl}
-										switches={CAPIArticle.config.switches}
-										isSensitive={
-											CAPIArticle.config.isSensitive
-										}
-										isAdFreeUser={CAPIArticle.isAdFreeUser}
+										pageId={article.pageId}
+										webTitle={article.webTitle}
+										ajaxUrl={article.config.ajaxUrl}
+										switches={article.config.switches}
+										isSensitive={article.config.isSensitive}
+										isAdFreeUser={article.isAdFreeUser}
 									/>
 								</div>
 							</GridItem>
@@ -731,29 +710,28 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 										<ArticleMeta
 											branding={branding}
 											format={format}
-											pageId={CAPIArticle.pageId}
-											webTitle={CAPIArticle.webTitle}
-											byline={CAPIArticle.byline}
-											tags={CAPIArticle.tags}
+											pageId={article.pageId}
+											webTitle={article.webTitle}
+											byline={article.byline}
+											tags={article.tags}
 											primaryDateline={
-												CAPIArticle.webPublicationDateDisplay
+												article.webPublicationDateDisplay
 											}
 											secondaryDateline={
-												CAPIArticle.webPublicationSecondaryDateDisplay
+												article.webPublicationSecondaryDateDisplay
 											}
 											isCommentable={
-												CAPIArticle.isCommentable
+												article.isCommentable
 											}
 											discussionApiUrl={
-												CAPIArticle.config
-													.discussionApiUrl
+												article.config.discussionApiUrl
 											}
 											shortUrlId={
-												CAPIArticle.config.shortUrlId
+												article.config.shortUrlId
 											}
-											ajaxUrl={CAPIArticle.config.ajaxUrl}
+											ajaxUrl={article.config.ajaxUrl}
 											showShareCount={
-												!!CAPIArticle.config.switches
+												!!article.config.switches
 													.serverShareCounts
 											}
 										/>
@@ -766,17 +744,17 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 											<Island>
 												<TopicFilterBank
 													availableTopics={
-														CAPIArticle.availableTopics
+														article.availableTopics
 													}
 													selectedTopics={
-														CAPIArticle.selectedTopics
+														article.selectedTopics
 													}
 													format={format}
 													keyEvents={
-														CAPIArticle.keyEvents
+														article.keyEvents
 													}
 													filterKeyEvents={
-														CAPIArticle.filterKeyEvents
+														article.filterKeyEvents
 													}
 													id={
 														'key-events-carousel-desktop'
@@ -807,7 +785,7 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 											<Island deferUntil="visible">
 												<FilterKeyEventsToggle
 													filterKeyEvents={
-														CAPIArticle.filterKeyEvents
+														article.filterKeyEvents
 													}
 													id="filter-toggle-desktop"
 												/>
@@ -841,88 +819,80 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 												)}
 												<ArticleBody
 													format={format}
-													blocks={CAPIArticle.blocks}
+													blocks={article.blocks}
 													pinnedPost={
-														CAPIArticle.pinnedPost
+														article.pinnedPost
 													}
 													adTargeting={adTargeting}
 													host={host}
-													pageId={CAPIArticle.pageId}
-													webTitle={
-														CAPIArticle.webTitle
-													}
+													pageId={article.pageId}
+													webTitle={article.webTitle}
 													ajaxUrl={
-														CAPIArticle.config
-															.ajaxUrl
+														article.config.ajaxUrl
 													}
 													section={
-														CAPIArticle.config
-															.section
+														article.config.section
 													}
 													switches={
-														CAPIArticle.config
-															.switches
+														article.config.switches
 													}
 													isSensitive={
-														CAPIArticle.config
+														article.config
 															.isSensitive
 													}
 													isAdFreeUser={
-														CAPIArticle.isAdFreeUser
+														article.isAdFreeUser
 													}
 													shouldHideReaderRevenue={
-														CAPIArticle.shouldHideReaderRevenue
+														article.shouldHideReaderRevenue
 													}
-													tags={CAPIArticle.tags}
+													tags={article.tags}
 													isPaidContent={
-														!!CAPIArticle.config
+														!!article.config
 															.isPaidContent
 													}
 													contributionsServiceUrl={
 														contributionsServiceUrl
 													}
 													contentType={
-														CAPIArticle.contentType
+														article.contentType
 													}
 													sectionName={
-														CAPIArticle.sectionName ??
+														article.sectionName ??
 														''
 													}
 													isPreview={
-														CAPIArticle.config
-															.isPreview
+														article.config.isPreview
 													}
 													idUrl={
-														CAPIArticle.config
-															.idUrl ?? ''
+														article.config.idUrl ??
+														''
 													}
 													isDev={
-														!!CAPIArticle.config
-															.isDev
+														!!article.config.isDev
 													}
 													onFirstPage={
 														pagination.currentPage ===
 														1
 													}
 													keyEvents={
-														CAPIArticle.keyEvents
+														article.keyEvents
 													}
 													filterKeyEvents={
-														CAPIArticle.filterKeyEvents
+														article.filterKeyEvents
 													}
 													availableTopics={
-														CAPIArticle.availableTopics
+														article.availableTopics
 													}
 													selectedTopics={
-														CAPIArticle.selectedTopics
+														article.selectedTopics
 													}
 													keywordIds={
-														CAPIArticle.config
+														article.config
 															.keywordIds
 													}
 													isInLiveblogAdSlotTest={
-														CAPIArticle.config
-															.abTests
+														article.config.abTests
 															.serverSideLiveblogInlineAdsVariant ===
 														'variant'
 													}
@@ -956,20 +926,18 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 												<SubMeta
 													format={format}
 													subMetaKeywordLinks={
-														CAPIArticle.subMetaKeywordLinks
+														article.subMetaKeywordLinks
 													}
 													subMetaSectionLinks={
-														CAPIArticle.subMetaSectionLinks
+														article.subMetaSectionLinks
 													}
-													pageId={CAPIArticle.pageId}
-													webUrl={CAPIArticle.webURL}
-													webTitle={
-														CAPIArticle.webTitle
-													}
+													pageId={article.pageId}
+													webUrl={article.webURL}
+													webTitle={article.webTitle}
 													showBottomSocialButtons={
-														CAPIArticle.showBottomSocialButtons
+														article.showBottomSocialButtons
 													}
-													badge={CAPIArticle.badge}
+													badge={article.badge}
 												/>
 											</ArticleContainer>
 										</div>
@@ -1001,88 +969,80 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 												)}
 												<ArticleBody
 													format={format}
-													blocks={CAPIArticle.blocks}
+													blocks={article.blocks}
 													pinnedPost={
-														CAPIArticle.pinnedPost
+														article.pinnedPost
 													}
 													adTargeting={adTargeting}
 													host={host}
-													pageId={CAPIArticle.pageId}
-													webTitle={
-														CAPIArticle.webTitle
-													}
+													pageId={article.pageId}
+													webTitle={article.webTitle}
 													ajaxUrl={
-														CAPIArticle.config
-															.ajaxUrl
+														article.config.ajaxUrl
 													}
 													section={
-														CAPIArticle.config
-															.section
+														article.config.section
 													}
 													switches={
-														CAPIArticle.config
-															.switches
+														article.config.switches
 													}
 													isSensitive={
-														CAPIArticle.config
+														article.config
 															.isSensitive
 													}
 													isAdFreeUser={
-														CAPIArticle.isAdFreeUser
+														article.isAdFreeUser
 													}
 													shouldHideReaderRevenue={
-														CAPIArticle.shouldHideReaderRevenue
+														article.shouldHideReaderRevenue
 													}
-													tags={CAPIArticle.tags}
+													tags={article.tags}
 													isPaidContent={
-														!!CAPIArticle.config
+														!!article.config
 															.isPaidContent
 													}
 													contributionsServiceUrl={
 														contributionsServiceUrl
 													}
 													contentType={
-														CAPIArticle.contentType
+														article.contentType
 													}
 													sectionName={
-														CAPIArticle.sectionName ??
+														article.sectionName ??
 														''
 													}
 													isPreview={
-														CAPIArticle.config
-															.isPreview
+														article.config.isPreview
 													}
 													idUrl={
-														CAPIArticle.config
-															.idUrl ?? ''
+														article.config.idUrl ??
+														''
 													}
 													isDev={
-														!!CAPIArticle.config
-															.isDev
+														!!article.config.isDev
 													}
 													onFirstPage={
 														pagination.currentPage ===
 														1
 													}
 													keyEvents={
-														CAPIArticle.keyEvents
+														article.keyEvents
 													}
 													filterKeyEvents={
-														CAPIArticle.filterKeyEvents
+														article.filterKeyEvents
 													}
 													availableTopics={
-														CAPIArticle.availableTopics
+														article.availableTopics
 													}
 													selectedTopics={
-														CAPIArticle.selectedTopics
+														article.selectedTopics
 													}
 													keywordIds={
-														CAPIArticle.config
+														article.config
 															.keywordIds
 													}
 													isInLiveblogAdSlotTest={
-														CAPIArticle.config
-															.abTests
+														article.config.abTests
 															.serverSideLiveblogInlineAdsVariant ===
 														'variant'
 													}
@@ -1116,20 +1076,18 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 												<SubMeta
 													format={format}
 													subMetaKeywordLinks={
-														CAPIArticle.subMetaKeywordLinks
+														article.subMetaKeywordLinks
 													}
 													subMetaSectionLinks={
-														CAPIArticle.subMetaSectionLinks
+														article.subMetaSectionLinks
 													}
-													pageId={CAPIArticle.pageId}
-													webUrl={CAPIArticle.webURL}
-													webTitle={
-														CAPIArticle.webTitle
-													}
+													pageId={article.pageId}
+													webUrl={article.webURL}
+													webTitle={article.webTitle}
 													showBottomSocialButtons={
-														CAPIArticle.showBottomSocialButtons
+														article.showBottomSocialButtons
 													}
-													badge={CAPIArticle.badge}
+													badge={article.badge}
 												/>
 											</ArticleContainer>
 										</Accordion>
@@ -1157,15 +1115,15 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 									`}
 								>
 									<RightColumn>
-										{!CAPIArticle.shouldHideAds && (
+										{!article.shouldHideAds && (
 											<AdSlot
 												position="right"
 												display={format.display}
 												shouldHideReaderRevenue={
-													CAPIArticle.shouldHideReaderRevenue
+													article.shouldHideReaderRevenue
 												}
 												isPaidContent={
-													CAPIArticle.pageType
+													article.pageType
 														.isPaidContent
 												}
 											/>
@@ -1194,12 +1152,12 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 						</Section>
 					)}
 
-					{CAPIArticle.storyPackage && (
+					{article.storyPackage && (
 						<Section fullWidth={true}>
 							<Island deferUntil="visible">
 								<Carousel
-									heading={CAPIArticle.storyPackage.heading}
-									trails={CAPIArticle.storyPackage.trails.map(
+									heading={article.storyPackage.heading}
+									trails={article.storyPackage.trails.map(
 										decideTrail,
 									)}
 									onwardsSource="more-on-this-story"
@@ -1215,26 +1173,26 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 						placeholderHeight={600}
 					>
 						<OnwardsUpper
-							ajaxUrl={CAPIArticle.config.ajaxUrl}
-							hasRelated={CAPIArticle.hasRelated}
-							hasStoryPackage={CAPIArticle.hasStoryPackage}
-							isAdFreeUser={CAPIArticle.isAdFreeUser}
-							pageId={CAPIArticle.pageId}
-							isPaidContent={!!CAPIArticle.config.isPaidContent}
+							ajaxUrl={article.config.ajaxUrl}
+							hasRelated={article.hasRelated}
+							hasStoryPackage={article.hasStoryPackage}
+							isAdFreeUser={article.isAdFreeUser}
+							pageId={article.pageId}
+							isPaidContent={!!article.config.isPaidContent}
 							showRelatedContent={
-								CAPIArticle.config.showRelatedContent
+								article.config.showRelatedContent
 							}
-							keywordIds={CAPIArticle.config.keywordIds}
-							contentType={CAPIArticle.contentType}
-							tags={CAPIArticle.tags}
+							keywordIds={article.config.keywordIds}
+							contentType={article.contentType}
+							tags={article.tags}
 							format={format}
 							pillar={format.theme}
-							editionId={CAPIArticle.editionId}
-							shortUrlId={CAPIArticle.config.shortUrlId}
+							editionId={article.editionId}
+							shortUrlId={article.config.shortUrlId}
 						/>
 					</Island>
 
-					{!isPaidContent && CAPIArticle.isCommentable && (
+					{!isPaidContent && article.isCommentable && (
 						<Section
 							fullWidth={true}
 							showTopBorder={false}
@@ -1244,23 +1202,21 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 						>
 							<DiscussionLayout
 								discussionApiUrl={
-									CAPIArticle.config.discussionApiUrl
+									article.config.discussionApiUrl
 								}
-								shortUrlId={CAPIArticle.config.shortUrlId}
+								shortUrlId={article.config.shortUrlId}
 								format={format}
-								discussionD2Uid={
-									CAPIArticle.config.discussionD2Uid
-								}
+								discussionD2Uid={article.config.discussionD2Uid}
 								discussionApiClientHeader={
-									CAPIArticle.config.discussionApiClientHeader
+									article.config.discussionApiClientHeader
 								}
 								enableDiscussionSwitch={
-									!!CAPIArticle.config.switches
+									!!article.config.switches
 										.enableDiscussionSwitch
 								}
-								isAdFreeUser={CAPIArticle.isAdFreeUser}
-								shouldHideAds={CAPIArticle.shouldHideAds}
-								idApiUrl={CAPIArticle.config.idApiUrl}
+								isAdFreeUser={article.isAdFreeUser}
+								shouldHideAds={article.shouldHideAds}
+								idApiUrl={article.config.idApiUrl}
 							/>
 						</Section>
 					)}
@@ -1279,9 +1235,9 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 							<MostViewedFooterLayout>
 								<Island clientOnly={true} deferUntil="visible">
 									<MostViewedFooterData
-										sectionName={CAPIArticle.sectionName}
+										sectionName={article.sectionName}
 										format={format}
-										ajaxUrl={CAPIArticle.config.ajaxUrl}
+										ajaxUrl={article.config.ajaxUrl}
 									/>
 								</Island>
 							</MostViewedFooterLayout>
@@ -1334,41 +1290,39 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 				element="footer"
 			>
 				<Footer
-					pageFooter={CAPIArticle.pageFooter}
+					pageFooter={article.pageFooter}
 					pillar={format.theme}
 					pillars={NAV.pillars}
-					urls={CAPIArticle.nav.readerRevenueLinks.header}
-					editionId={CAPIArticle.editionId}
-					contributionsServiceUrl={
-						CAPIArticle.contributionsServiceUrl
-					}
+					urls={article.nav.readerRevenueLinks.header}
+					editionId={article.editionId}
+					contributionsServiceUrl={article.contributionsServiceUrl}
 				/>
 			</Section>
 
 			<BannerWrapper data-print-layout="hide">
 				<Island deferUntil="idle" clientOnly={true}>
 					<StickyBottomBanner
-						contentType={CAPIArticle.contentType}
+						contentType={article.contentType}
 						contributionsServiceUrl={contributionsServiceUrl}
-						idApiUrl={CAPIArticle.config.idApiUrl}
-						isMinuteArticle={CAPIArticle.pageType.isMinuteArticle}
-						isPaidContent={CAPIArticle.pageType.isPaidContent}
-						isPreview={!!CAPIArticle.config.isPreview}
-						isSensitive={CAPIArticle.config.isSensitive}
-						keywordIds={CAPIArticle.config.keywordIds}
-						pageId={CAPIArticle.pageId}
-						section={CAPIArticle.config.section}
-						sectionName={CAPIArticle.sectionName}
+						idApiUrl={article.config.idApiUrl}
+						isMinuteArticle={article.pageType.isMinuteArticle}
+						isPaidContent={article.pageType.isPaidContent}
+						isPreview={!!article.config.isPreview}
+						isSensitive={article.config.isSensitive}
+						keywordIds={article.config.keywordIds}
+						pageId={article.pageId}
+						section={article.config.section}
+						sectionName={article.sectionName}
 						shouldHideReaderRevenue={
-							CAPIArticle.shouldHideReaderRevenue
+							article.shouldHideReaderRevenue
 						}
 						remoteBannerSwitch={
-							!!CAPIArticle.config.switches.remoteBanner
+							!!article.config.switches.remoteBanner
 						}
 						puzzleBannerSwitch={
-							!!CAPIArticle.config.switches.puzzlesBanner
+							!!article.config.switches.puzzlesBanner
 						}
-						tags={CAPIArticle.tags}
+						tags={article.tags}
 					/>
 				</Island>
 			</BannerWrapper>

--- a/dotcom-rendering/src/web/layouts/NewsletterSignupLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/NewsletterSignupLayout.tsx
@@ -51,7 +51,7 @@ import { getCurrentPillar } from '../lib/layoutHelpers';
 import { BannerWrapper, Stuck } from './lib/stickiness';
 
 type Props = {
-	CAPIArticle: FEArticleType;
+	article: FEArticleType;
 	NAV: NavType;
 	format: ArticleFormat;
 };
@@ -182,34 +182,32 @@ const regionalFocusDivStyle = css`
 	margin-bottom: ${space[2]}px;
 `;
 
-const getMainMediaCaptions = (
-	CAPIArticle: FEArticleType,
-): (string | undefined)[] =>
-	CAPIArticle.mainMediaElements.map((el) =>
+const getMainMediaCaptions = (article: FEArticleType): (string | undefined)[] =>
+	article.mainMediaElements.map((el) =>
 		el._type === 'model.dotcomrendering.pageElements.ImageBlockElement'
 			? el.data.caption
 			: undefined,
 	);
 
-export const NewsletterSignupLayout = ({ CAPIArticle, NAV, format }: Props) => {
+export const NewsletterSignupLayout = ({ article, NAV, format }: Props) => {
 	const {
 		promotedNewsletter,
 		config: { host },
-	} = CAPIArticle;
+	} = article;
 
 	const isInEuropeTest =
-		CAPIArticle.config.abTests.europeNetworkFrontVariant === 'variant';
+		article.config.abTests.europeNetworkFrontVariant === 'variant';
 
 	const adTargeting: AdTargeting = buildAdTargeting({
-		isAdFreeUser: CAPIArticle.isAdFreeUser,
-		isSensitive: CAPIArticle.config.isSensitive,
-		videoDuration: CAPIArticle.config.videoDuration,
-		edition: CAPIArticle.config.edition,
-		section: CAPIArticle.config.section,
-		sharedAdTargeting: CAPIArticle.config.sharedAdTargeting,
-		adUnit: CAPIArticle.config.adUnit,
+		isAdFreeUser: article.isAdFreeUser,
+		isSensitive: article.config.isSensitive,
+		videoDuration: article.config.videoDuration,
+		edition: article.config.edition,
+		section: article.config.section,
+		sharedAdTargeting: article.config.sharedAdTargeting,
+		adUnit: article.config.adUnit,
 	});
-	const contributionsServiceUrl = getContributionsServiceUrl(CAPIArticle);
+	const contributionsServiceUrl = getContributionsServiceUrl(article);
 
 	const palette = decidePalette(format);
 
@@ -219,7 +217,7 @@ export const NewsletterSignupLayout = ({ CAPIArticle, NAV, format }: Props) => {
 	const showRegionalFocus = Boolean(regionalFocusText);
 
 	/**	Newsletter preview will be linked if the caption of the main media is a URL */
-	const captions = getMainMediaCaptions(CAPIArticle);
+	const captions = getMainMediaCaptions(article);
 	const newsletterPreviewUrl = captions
 		.filter(Boolean)
 		.find((caption) => !!caption && isValidUrl(caption));
@@ -228,7 +226,7 @@ export const NewsletterSignupLayout = ({ CAPIArticle, NAV, format }: Props) => {
 	/**
 	 * This property currently only applies to the header and merchandising slots
 	 */
-	const renderAds = !CAPIArticle.isAdFreeUser && !CAPIArticle.shouldHideAds;
+	const renderAds = !article.isAdFreeUser && !article.shouldHideAds;
 
 	return (
 		<>
@@ -257,19 +255,17 @@ export const NewsletterSignupLayout = ({ CAPIArticle, NAV, format }: Props) => {
 					element="header"
 				>
 					<Header
-						editionId={CAPIArticle.editionId}
-						idUrl={CAPIArticle.config.idUrl}
-						mmaUrl={CAPIArticle.config.mmaUrl}
-						discussionApiUrl={CAPIArticle.config.discussionApiUrl}
-						urls={CAPIArticle.nav.readerRevenueLinks.header}
-						remoteHeader={
-							!!CAPIArticle.config.switches.remoteHeader
-						}
+						editionId={article.editionId}
+						idUrl={article.config.idUrl}
+						mmaUrl={article.config.mmaUrl}
+						discussionApiUrl={article.config.discussionApiUrl}
+						urls={article.nav.readerRevenueLinks.header}
+						remoteHeader={!!article.config.switches.remoteHeader}
 						contributionsServiceUrl={contributionsServiceUrl}
-						idApiUrl={CAPIArticle.config.idApiUrl}
+						idApiUrl={article.config.idApiUrl}
 						isInEuropeTest={isInEuropeTest}
 						headerTopBarSearchCapiSwitch={
-							!!CAPIArticle.config.switches.headerTopBarSearchCapi
+							!!article.config.switches.headerTopBarSearchCapi
 						}
 					/>
 				</Section>
@@ -286,14 +282,14 @@ export const NewsletterSignupLayout = ({ CAPIArticle, NAV, format }: Props) => {
 						nav={NAV}
 						format={{
 							...format,
-							theme: getCurrentPillar(CAPIArticle),
+							theme: getCurrentPillar(article),
 						}}
 						subscribeUrl={
-							CAPIArticle.nav.readerRevenueLinks.header.subscribe
+							article.nav.readerRevenueLinks.header.subscribe
 						}
-						editionId={CAPIArticle.editionId}
+						editionId={article.editionId}
 						headerTopBarSwitch={
-							!!CAPIArticle.config.switches.headerTopNav
+							!!article.config.switches.headerTopNav
 						}
 					/>
 				</Section>
@@ -332,7 +328,7 @@ export const NewsletterSignupLayout = ({ CAPIArticle, NAV, format }: Props) => {
 				)}
 			</div>
 
-			{renderAds && !!CAPIArticle.config.switches.surveys && (
+			{renderAds && !!article.config.switches.surveys && (
 				<AdSlot position="survey" display={format.display} />
 			)}
 
@@ -395,16 +391,16 @@ export const NewsletterSignupLayout = ({ CAPIArticle, NAV, format }: Props) => {
 							)}
 							<ArticleHeadline
 								format={format}
-								headlineString={CAPIArticle.headline}
-								tags={CAPIArticle.tags}
-								byline={CAPIArticle.byline}
+								headlineString={article.headline}
+								tags={article.tags}
+								byline={article.byline}
 								webPublicationDateDeprecated={
-									CAPIArticle.webPublicationDateDeprecated
+									article.webPublicationDateDeprecated
 								}
 							/>
 							<Standfirst
 								format={format}
-								standfirst={CAPIArticle.standfirst}
+								standfirst={article.standfirst}
 							/>
 							{showNewsletterPreview && (
 								<div css={previewButtonWrapperStyle}>
@@ -426,8 +422,8 @@ export const NewsletterSignupLayout = ({ CAPIArticle, NAV, format }: Props) => {
 									Tell your friends
 								</span>
 								<ShareIcons
-									pageId={CAPIArticle.pageId}
-									webTitle={CAPIArticle.webTitle}
+									pageId={article.pageId}
+									webTitle={article.webTitle}
 									format={format}
 									displayIcons={[
 										'facebook',
@@ -486,15 +482,15 @@ export const NewsletterSignupLayout = ({ CAPIArticle, NAV, format }: Props) => {
 
 								<MainMedia
 									format={format}
-									elements={CAPIArticle.mainMediaElements}
+									elements={article.mainMediaElements}
 									adTargeting={adTargeting}
 									host={host}
-									pageId={CAPIArticle.pageId}
-									webTitle={CAPIArticle.webTitle}
-									ajaxUrl={CAPIArticle.config.ajaxUrl}
-									switches={CAPIArticle.config.switches}
-									isAdFreeUser={CAPIArticle.isAdFreeUser}
-									isSensitive={CAPIArticle.config.isSensitive}
+									pageId={article.pageId}
+									webTitle={article.webTitle}
+									ajaxUrl={article.config.ajaxUrl}
+									switches={article.config.switches}
+									isAdFreeUser={article.isAdFreeUser}
+									isSensitive={article.config.isSensitive}
 									hideCaption={true}
 								/>
 							</div>
@@ -508,12 +504,12 @@ export const NewsletterSignupLayout = ({ CAPIArticle, NAV, format }: Props) => {
 					</Hide>
 				</Section>
 
-				{CAPIArticle.storyPackage && (
+				{article.storyPackage && (
 					<Section fullWidth={true}>
 						<Island deferUntil="visible">
 							<Carousel
-								heading={CAPIArticle.storyPackage.heading}
-								trails={CAPIArticle.storyPackage.trails.map(
+								heading={article.storyPackage.heading}
+								trails={article.storyPackage.trails.map(
 									decideTrail,
 								)}
 								onwardsSource="more-on-this-story"
@@ -529,24 +525,20 @@ export const NewsletterSignupLayout = ({ CAPIArticle, NAV, format }: Props) => {
 					placeholderHeight={600}
 				>
 					<OnwardsUpper
-						ajaxUrl={CAPIArticle.config.ajaxUrl}
-						hasRelated={CAPIArticle.hasRelated}
-						hasStoryPackage={CAPIArticle.hasStoryPackage}
-						isAdFreeUser={CAPIArticle.isAdFreeUser}
-						pageId={CAPIArticle.pageId}
-						isPaidContent={
-							CAPIArticle.config.isPaidContent ?? false
-						}
-						showRelatedContent={
-							CAPIArticle.config.showRelatedContent
-						}
-						keywordIds={CAPIArticle.config.keywordIds}
-						contentType={CAPIArticle.contentType}
-						tags={CAPIArticle.tags}
+						ajaxUrl={article.config.ajaxUrl}
+						hasRelated={article.hasRelated}
+						hasStoryPackage={article.hasStoryPackage}
+						isAdFreeUser={article.isAdFreeUser}
+						pageId={article.pageId}
+						isPaidContent={article.config.isPaidContent ?? false}
+						showRelatedContent={article.config.showRelatedContent}
+						keywordIds={article.config.keywordIds}
+						contentType={article.contentType}
+						tags={article.tags}
 						format={format}
 						pillar={format.theme}
-						editionId={CAPIArticle.editionId}
-						shortUrlId={CAPIArticle.config.shortUrlId}
+						editionId={article.editionId}
+						shortUrlId={article.config.shortUrlId}
 					/>
 				</Island>
 			</main>
@@ -562,14 +554,12 @@ export const NewsletterSignupLayout = ({ CAPIArticle, NAV, format }: Props) => {
 				element="footer"
 			>
 				<Footer
-					pageFooter={CAPIArticle.pageFooter}
+					pageFooter={article.pageFooter}
 					pillar={format.theme}
 					pillars={NAV.pillars}
-					urls={CAPIArticle.nav.readerRevenueLinks.header}
-					editionId={CAPIArticle.editionId}
-					contributionsServiceUrl={
-						CAPIArticle.contributionsServiceUrl
-					}
+					urls={article.nav.readerRevenueLinks.header}
+					editionId={article.editionId}
+					contributionsServiceUrl={article.contributionsServiceUrl}
 				/>
 			</Section>
 

--- a/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
@@ -202,50 +202,49 @@ const PositionHeadline = ({
 };
 
 interface Props {
-	CAPIArticle: FEArticleType;
+	article: FEArticleType;
 	NAV: NavType;
 	format: ArticleFormat;
 }
 
-export const ShowcaseLayout = ({ CAPIArticle, NAV, format }: Props) => {
+export const ShowcaseLayout = ({ article, NAV, format }: Props) => {
 	const {
 		config: { isPaidContent, host },
-	} = CAPIArticle;
+	} = article;
 
 	const isInEuropeTest =
-		CAPIArticle.config.abTests.europeNetworkFrontVariant === 'variant';
+		article.config.abTests.europeNetworkFrontVariant === 'variant';
 
 	const adTargeting: AdTargeting = buildAdTargeting({
-		isAdFreeUser: CAPIArticle.isAdFreeUser,
-		isSensitive: CAPIArticle.config.isSensitive,
-		videoDuration: CAPIArticle.config.videoDuration,
-		edition: CAPIArticle.config.edition,
-		section: CAPIArticle.config.section,
-		sharedAdTargeting: CAPIArticle.config.sharedAdTargeting,
-		adUnit: CAPIArticle.config.adUnit,
+		isAdFreeUser: article.isAdFreeUser,
+		isSensitive: article.config.isSensitive,
+		videoDuration: article.config.videoDuration,
+		edition: article.config.edition,
+		section: article.config.section,
+		sharedAdTargeting: article.config.sharedAdTargeting,
+		adUnit: article.config.adUnit,
 	});
 
 	const showBodyEndSlot =
-		parse(CAPIArticle.slotMachineFlags ?? '').showBodyEnd ||
-		CAPIArticle.config.switches.slotBodyEnd;
+		parse(article.slotMachineFlags ?? '').showBodyEnd ||
+		article.config.switches.slotBodyEnd;
 
 	// TODO:
 	// 1) Read 'forceEpic' value from URL parameter and use it to force the slot to render
-	// 2) Otherwise, ensure slot only renders if `CAPIArticle.config.shouldHideReaderRevenue` equals false.
+	// 2) Otherwise, ensure slot only renders if `article.config.shouldHideReaderRevenue` equals false.
 
-	const showComments = CAPIArticle.isCommentable;
+	const showComments = article.isCommentable;
 
-	const { branding } =
-		CAPIArticle.commercialProperties[CAPIArticle.editionId];
+	const { branding } = article.commercialProperties[article.editionId];
 
 	const palette = decidePalette(format);
 
-	const contributionsServiceUrl = getContributionsServiceUrl(CAPIArticle);
+	const contributionsServiceUrl = getContributionsServiceUrl(article);
 
 	/**
 	 * This property currently only applies to the header and merchandising slots
 	 */
-	const renderAds = !CAPIArticle.isAdFreeUser && !CAPIArticle.shouldHideAds;
+	const renderAds = !article.isAdFreeUser && !article.shouldHideAds;
 
 	const isLabs = format.theme === ArticleSpecial.Labs;
 
@@ -278,27 +277,23 @@ export const ShowcaseLayout = ({ CAPIArticle, NAV, format }: Props) => {
 								element="header"
 							>
 								<Header
-									editionId={CAPIArticle.editionId}
-									idUrl={CAPIArticle.config.idUrl}
-									mmaUrl={CAPIArticle.config.mmaUrl}
+									editionId={article.editionId}
+									idUrl={article.config.idUrl}
+									mmaUrl={article.config.mmaUrl}
 									discussionApiUrl={
-										CAPIArticle.config.discussionApiUrl
+										article.config.discussionApiUrl
 									}
-									urls={
-										CAPIArticle.nav.readerRevenueLinks
-											.header
-									}
+									urls={article.nav.readerRevenueLinks.header}
 									remoteHeader={
-										!!CAPIArticle.config.switches
-											.remoteHeader
+										!!article.config.switches.remoteHeader
 									}
 									contributionsServiceUrl={
 										contributionsServiceUrl
 									}
-									idApiUrl={CAPIArticle.config.idApiUrl}
+									idApiUrl={article.config.idApiUrl}
 									isInEuropeTest={isInEuropeTest}
 									headerTopBarSearchCapiSwitch={
-										!!CAPIArticle.config.switches
+										!!article.config.switches
 											.headerTopBarSearchCapi
 									}
 								/>
@@ -315,16 +310,15 @@ export const ShowcaseLayout = ({ CAPIArticle, NAV, format }: Props) => {
 									nav={NAV}
 									format={{
 										...format,
-										theme: getCurrentPillar(CAPIArticle),
+										theme: getCurrentPillar(article),
 									}}
 									subscribeUrl={
-										CAPIArticle.nav.readerRevenueLinks
-											.header.subscribe
+										article.nav.readerRevenueLinks.header
+											.subscribe
 									}
-									editionId={CAPIArticle.editionId}
+									editionId={article.editionId}
 									headerTopBarSwitch={
-										!!CAPIArticle.config.switches
-											.headerTopNav
+										!!article.config.switches.headerTopNav
 									}
 								/>
 							</Section>
@@ -393,16 +387,15 @@ export const ShowcaseLayout = ({ CAPIArticle, NAV, format }: Props) => {
 									nav={NAV}
 									format={{
 										...format,
-										theme: getCurrentPillar(CAPIArticle),
+										theme: getCurrentPillar(article),
 									}}
 									subscribeUrl={
-										CAPIArticle.nav.readerRevenueLinks
-											.header.subscribe
+										article.nav.readerRevenueLinks.header
+											.subscribe
 									}
-									editionId={CAPIArticle.editionId}
+									editionId={article.editionId}
 									headerTopBarSwitch={
-										!!CAPIArticle.config.switches
-											.headerTopNav
+										!!article.config.switches.headerTopNav
 									}
 								/>
 							</Section>
@@ -435,11 +428,11 @@ export const ShowcaseLayout = ({ CAPIArticle, NAV, format }: Props) => {
 						<GridItem area="title" element="aside">
 							<ArticleTitle
 								format={format}
-								tags={CAPIArticle.tags}
-								sectionLabel={CAPIArticle.sectionLabel}
-								sectionUrl={CAPIArticle.sectionUrl}
-								guardianBaseURL={CAPIArticle.guardianBaseURL}
-								badge={CAPIArticle.badge}
+								tags={article.tags}
+								sectionLabel={article.sectionLabel}
+								sectionUrl={article.sectionUrl}
+								guardianBaseURL={article.guardianBaseURL}
+								badge={article.badge}
 							/>
 						</GridItem>
 						<GridItem area="border">
@@ -449,15 +442,14 @@ export const ShowcaseLayout = ({ CAPIArticle, NAV, format }: Props) => {
 							<PositionHeadline design={format.design}>
 								<ArticleHeadline
 									format={format}
-									headlineString={CAPIArticle.headline}
-									tags={CAPIArticle.tags}
-									byline={CAPIArticle.byline}
+									headlineString={article.headline}
+									tags={article.tags}
+									byline={article.byline}
 									webPublicationDateDeprecated={
-										CAPIArticle.webPublicationDateDeprecated
+										article.webPublicationDateDeprecated
 									}
 									hasStarRating={
-										typeof CAPIArticle.starRating ===
-										'number'
+										typeof article.starRating === 'number'
 									}
 								/>
 							</PositionHeadline>
@@ -466,29 +458,29 @@ export const ShowcaseLayout = ({ CAPIArticle, NAV, format }: Props) => {
 							<div css={mainMediaWrapper}>
 								<MainMedia
 									format={format}
-									elements={CAPIArticle.mainMediaElements}
+									elements={article.mainMediaElements}
 									adTargeting={adTargeting}
 									starRating={
 										format.design ===
 											ArticleDesign.Review &&
-										CAPIArticle.starRating
-											? CAPIArticle.starRating
+										article.starRating
+											? article.starRating
 											: undefined
 									}
 									host={host}
-									pageId={CAPIArticle.pageId}
-									webTitle={CAPIArticle.webTitle}
-									ajaxUrl={CAPIArticle.config.ajaxUrl}
-									switches={CAPIArticle.config.switches}
-									isAdFreeUser={CAPIArticle.isAdFreeUser}
-									isSensitive={CAPIArticle.config.isSensitive}
+									pageId={article.pageId}
+									webTitle={article.webTitle}
+									ajaxUrl={article.config.ajaxUrl}
+									switches={article.config.switches}
+									isAdFreeUser={article.isAdFreeUser}
+									isSensitive={article.config.isSensitive}
 								/>
 							</div>
 						</GridItem>
 						<GridItem area="standfirst">
 							<Standfirst
 								format={format}
-								standfirst={CAPIArticle.standfirst}
+								standfirst={article.standfirst}
 							/>
 						</GridItem>
 						<GridItem area="lines">
@@ -503,24 +495,24 @@ export const ShowcaseLayout = ({ CAPIArticle, NAV, format }: Props) => {
 								<ArticleMeta
 									branding={branding}
 									format={format}
-									pageId={CAPIArticle.pageId}
-									webTitle={CAPIArticle.webTitle}
-									byline={CAPIArticle.byline}
-									tags={CAPIArticle.tags}
+									pageId={article.pageId}
+									webTitle={article.webTitle}
+									byline={article.byline}
+									tags={article.tags}
 									primaryDateline={
-										CAPIArticle.webPublicationDateDisplay
+										article.webPublicationDateDisplay
 									}
 									secondaryDateline={
-										CAPIArticle.webPublicationSecondaryDateDisplay
+										article.webPublicationSecondaryDateDisplay
 									}
-									isCommentable={CAPIArticle.isCommentable}
+									isCommentable={article.isCommentable}
 									discussionApiUrl={
-										CAPIArticle.config.discussionApiUrl
+										article.config.discussionApiUrl
 									}
-									shortUrlId={CAPIArticle.config.shortUrlId}
-									ajaxUrl={CAPIArticle.config.ajaxUrl}
+									shortUrlId={article.config.shortUrlId}
+									ajaxUrl={article.config.ajaxUrl}
 									showShareCount={
-										!!CAPIArticle.config.switches
+										!!article.config.switches
 											.serverShareCounts
 									}
 								/>
@@ -530,72 +522,60 @@ export const ShowcaseLayout = ({ CAPIArticle, NAV, format }: Props) => {
 							<ArticleContainer format={format}>
 								<ArticleBody
 									format={format}
-									blocks={CAPIArticle.blocks}
+									blocks={article.blocks}
 									adTargeting={adTargeting}
 									host={host}
-									pageId={CAPIArticle.pageId}
-									webTitle={CAPIArticle.webTitle}
-									ajaxUrl={CAPIArticle.config.ajaxUrl}
-									switches={CAPIArticle.config.switches}
-									isSensitive={CAPIArticle.config.isSensitive}
-									isAdFreeUser={CAPIArticle.isAdFreeUser}
-									section={CAPIArticle.config.section}
+									pageId={article.pageId}
+									webTitle={article.webTitle}
+									ajaxUrl={article.config.ajaxUrl}
+									switches={article.config.switches}
+									isSensitive={article.config.isSensitive}
+									isAdFreeUser={article.isAdFreeUser}
+									section={article.config.section}
 									shouldHideReaderRevenue={
-										CAPIArticle.shouldHideReaderRevenue
+										article.shouldHideReaderRevenue
 									}
-									tags={CAPIArticle.tags}
+									tags={article.tags}
 									isPaidContent={
-										!!CAPIArticle.config.isPaidContent
+										!!article.config.isPaidContent
 									}
 									contributionsServiceUrl={
 										contributionsServiceUrl
 									}
-									contentType={CAPIArticle.contentType}
-									sectionName={CAPIArticle.sectionName ?? ''}
-									isPreview={CAPIArticle.config.isPreview}
-									idUrl={CAPIArticle.config.idUrl ?? ''}
-									isDev={!!CAPIArticle.config.isDev}
-									keywordIds={CAPIArticle.config.keywordIds}
-									abTests={CAPIArticle.config.abTests}
-									tableOfContents={
-										CAPIArticle.tableOfContents
-									}
+									contentType={article.contentType}
+									sectionName={article.sectionName ?? ''}
+									isPreview={article.config.isPreview}
+									idUrl={article.config.idUrl ?? ''}
+									isDev={!!article.config.isDev}
+									keywordIds={article.config.keywordIds}
+									abTests={article.config.abTests}
+									tableOfContents={article.tableOfContents}
 								/>
 								{showBodyEndSlot && (
 									<Island clientOnly={true}>
 										<SlotBodyEnd
-											contentType={
-												CAPIArticle.contentType
-											}
+											contentType={article.contentType}
 											contributionsServiceUrl={
 												contributionsServiceUrl
 											}
-											idApiUrl={
-												CAPIArticle.config.idApiUrl
-											}
+											idApiUrl={article.config.idApiUrl}
 											isMinuteArticle={
-												CAPIArticle.pageType
-													.isMinuteArticle
+												article.pageType.isMinuteArticle
 											}
 											isPaidContent={
-												CAPIArticle.pageType
-													.isPaidContent
+												article.pageType.isPaidContent
 											}
 											keywordIds={
-												CAPIArticle.config.keywordIds
+												article.config.keywordIds
 											}
-											pageId={CAPIArticle.pageId}
-											sectionId={
-												CAPIArticle.config.section
-											}
-											sectionName={
-												CAPIArticle.sectionName
-											}
+											pageId={article.pageId}
+											sectionId={article.config.section}
+											sectionName={article.sectionName}
 											shouldHideReaderRevenue={
-												CAPIArticle.shouldHideReaderRevenue
+												article.shouldHideReaderRevenue
 											}
-											stage={CAPIArticle.config.stage}
-											tags={CAPIArticle.tags}
+											stage={article.config.stage}
+											tags={article.tags}
 										/>
 									</Island>
 								)}
@@ -608,18 +588,18 @@ export const ShowcaseLayout = ({ CAPIArticle, NAV, format }: Props) => {
 								<SubMeta
 									format={format}
 									subMetaKeywordLinks={
-										CAPIArticle.subMetaKeywordLinks
+										article.subMetaKeywordLinks
 									}
 									subMetaSectionLinks={
-										CAPIArticle.subMetaSectionLinks
+										article.subMetaSectionLinks
 									}
-									pageId={CAPIArticle.pageId}
-									webUrl={CAPIArticle.webURL}
-									webTitle={CAPIArticle.webTitle}
+									pageId={article.pageId}
+									webUrl={article.webURL}
+									webTitle={article.webTitle}
 									showBottomSocialButtons={
-										CAPIArticle.showBottomSocialButtons
+										article.showBottomSocialButtons
 									}
-									badge={CAPIArticle.badge}
+									badge={article.badge}
 								/>
 							</ArticleContainer>
 						</GridItem>
@@ -641,16 +621,15 @@ export const ShowcaseLayout = ({ CAPIArticle, NAV, format }: Props) => {
 								`}
 							>
 								<RightColumn>
-									{!CAPIArticle.shouldHideAds && (
+									{!article.shouldHideAds && (
 										<AdSlot
 											position="right"
 											display={format.display}
 											shouldHideReaderRevenue={
-												CAPIArticle.shouldHideReaderRevenue
+												article.shouldHideReaderRevenue
 											}
 											isPaidContent={
-												CAPIArticle.pageType
-													.isPaidContent
+												article.pageType.isPaidContent
 											}
 										/>
 									)}
@@ -662,7 +641,7 @@ export const ShowcaseLayout = ({ CAPIArticle, NAV, format }: Props) => {
 										>
 											<MostViewedRightWrapper
 												isAdFreeUser={
-													CAPIArticle.isAdFreeUser
+													article.isAdFreeUser
 												}
 											/>
 										</Island>
@@ -691,12 +670,12 @@ export const ShowcaseLayout = ({ CAPIArticle, NAV, format }: Props) => {
 					</Section>
 				)}
 
-				{CAPIArticle.storyPackage && (
+				{article.storyPackage && (
 					<Section fullWidth={true}>
 						<Island deferUntil="visible">
 							<Carousel
-								heading={CAPIArticle.storyPackage.heading}
-								trails={CAPIArticle.storyPackage.trails.map(
+								heading={article.storyPackage.heading}
+								trails={article.storyPackage.trails.map(
 									decideTrail,
 								)}
 								onwardsSource="more-on-this-story"
@@ -712,22 +691,20 @@ export const ShowcaseLayout = ({ CAPIArticle, NAV, format }: Props) => {
 					placeholderHeight={600}
 				>
 					<OnwardsUpper
-						ajaxUrl={CAPIArticle.config.ajaxUrl}
-						hasRelated={CAPIArticle.hasRelated}
-						hasStoryPackage={CAPIArticle.hasStoryPackage}
-						isAdFreeUser={CAPIArticle.isAdFreeUser}
-						pageId={CAPIArticle.pageId}
-						isPaidContent={!!CAPIArticle.config.isPaidContent}
-						showRelatedContent={
-							CAPIArticle.config.showRelatedContent
-						}
-						keywordIds={CAPIArticle.config.keywordIds}
-						contentType={CAPIArticle.contentType}
-						tags={CAPIArticle.tags}
+						ajaxUrl={article.config.ajaxUrl}
+						hasRelated={article.hasRelated}
+						hasStoryPackage={article.hasStoryPackage}
+						isAdFreeUser={article.isAdFreeUser}
+						pageId={article.pageId}
+						isPaidContent={!!article.config.isPaidContent}
+						showRelatedContent={article.config.showRelatedContent}
+						keywordIds={article.config.keywordIds}
+						contentType={article.contentType}
+						tags={article.tags}
 						format={format}
 						pillar={format.theme}
-						editionId={CAPIArticle.editionId}
-						shortUrlId={CAPIArticle.config.shortUrlId}
+						editionId={article.editionId}
+						shortUrlId={article.config.shortUrlId}
 					/>
 				</Island>
 
@@ -738,22 +715,19 @@ export const ShowcaseLayout = ({ CAPIArticle, NAV, format }: Props) => {
 						element="section"
 					>
 						<DiscussionLayout
-							discussionApiUrl={
-								CAPIArticle.config.discussionApiUrl
-							}
-							shortUrlId={CAPIArticle.config.shortUrlId}
+							discussionApiUrl={article.config.discussionApiUrl}
+							shortUrlId={article.config.shortUrlId}
 							format={format}
-							discussionD2Uid={CAPIArticle.config.discussionD2Uid}
+							discussionD2Uid={article.config.discussionD2Uid}
 							discussionApiClientHeader={
-								CAPIArticle.config.discussionApiClientHeader
+								article.config.discussionApiClientHeader
 							}
 							enableDiscussionSwitch={
-								!!CAPIArticle.config.switches
-									.enableDiscussionSwitch
+								!!article.config.switches.enableDiscussionSwitch
 							}
-							isAdFreeUser={CAPIArticle.isAdFreeUser}
-							shouldHideAds={CAPIArticle.shouldHideAds}
-							idApiUrl={CAPIArticle.config.idApiUrl}
+							isAdFreeUser={article.isAdFreeUser}
+							shouldHideAds={article.shouldHideAds}
+							idApiUrl={article.config.idApiUrl}
 						/>
 					</Section>
 				)}
@@ -771,9 +745,9 @@ export const ShowcaseLayout = ({ CAPIArticle, NAV, format }: Props) => {
 						<MostViewedFooterLayout>
 							<Island clientOnly={true} deferUntil="visible">
 								<MostViewedFooterData
-									sectionName={CAPIArticle.sectionName}
+									sectionName={article.sectionName}
 									format={format}
-									ajaxUrl={CAPIArticle.config.ajaxUrl}
+									ajaxUrl={article.config.ajaxUrl}
 								/>
 							</Island>
 						</MostViewedFooterLayout>
@@ -818,41 +792,39 @@ export const ShowcaseLayout = ({ CAPIArticle, NAV, format }: Props) => {
 				element="footer"
 			>
 				<Footer
-					pageFooter={CAPIArticle.pageFooter}
+					pageFooter={article.pageFooter}
 					pillar={format.theme}
 					pillars={NAV.pillars}
-					urls={CAPIArticle.nav.readerRevenueLinks.header}
-					editionId={CAPIArticle.editionId}
-					contributionsServiceUrl={
-						CAPIArticle.contributionsServiceUrl
-					}
+					urls={article.nav.readerRevenueLinks.header}
+					editionId={article.editionId}
+					contributionsServiceUrl={article.contributionsServiceUrl}
 				/>
 			</Section>
 
 			<BannerWrapper>
 				<Island deferUntil="idle" clientOnly={true}>
 					<StickyBottomBanner
-						contentType={CAPIArticle.contentType}
+						contentType={article.contentType}
 						contributionsServiceUrl={contributionsServiceUrl}
-						idApiUrl={CAPIArticle.config.idApiUrl}
-						isMinuteArticle={CAPIArticle.pageType.isMinuteArticle}
-						isPaidContent={CAPIArticle.pageType.isPaidContent}
-						isPreview={!!CAPIArticle.config.isPreview}
-						isSensitive={CAPIArticle.config.isSensitive}
-						keywordIds={CAPIArticle.config.keywordIds}
-						pageId={CAPIArticle.pageId}
-						section={CAPIArticle.config.section}
-						sectionName={CAPIArticle.sectionName}
+						idApiUrl={article.config.idApiUrl}
+						isMinuteArticle={article.pageType.isMinuteArticle}
+						isPaidContent={article.pageType.isPaidContent}
+						isPreview={!!article.config.isPreview}
+						isSensitive={article.config.isSensitive}
+						keywordIds={article.config.keywordIds}
+						pageId={article.pageId}
+						section={article.config.section}
+						sectionName={article.sectionName}
 						shouldHideReaderRevenue={
-							CAPIArticle.shouldHideReaderRevenue
+							article.shouldHideReaderRevenue
 						}
 						remoteBannerSwitch={
-							!!CAPIArticle.config.switches.remoteBanner
+							!!article.config.switches.remoteBanner
 						}
 						puzzleBannerSwitch={
-							!!CAPIArticle.config.switches.puzzlesBanner
+							!!article.config.switches.puzzlesBanner
 						}
-						tags={CAPIArticle.tags}
+						tags={article.tags}
 					/>
 				</Island>
 			</BannerWrapper>

--- a/dotcom-rendering/src/web/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/StandardLayout.tsx
@@ -285,47 +285,46 @@ const starWrapper = css`
 `;
 
 interface Props {
-	CAPIArticle: FEArticleType;
+	article: FEArticleType;
 	NAV: NavType;
 	format: ArticleFormat;
 }
 
-export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
+export const StandardLayout = ({ article, NAV, format }: Props) => {
 	const {
 		config: { isPaidContent, host },
-	} = CAPIArticle;
+	} = article;
 
 	const isInEuropeTest =
-		CAPIArticle.config.abTests.europeNetworkFrontVariant === 'variant';
+		article.config.abTests.europeNetworkFrontVariant === 'variant';
 
 	const adTargeting: AdTargeting = buildAdTargeting({
-		isAdFreeUser: CAPIArticle.isAdFreeUser,
-		isSensitive: CAPIArticle.config.isSensitive,
-		videoDuration: CAPIArticle.config.videoDuration,
-		edition: CAPIArticle.config.edition,
-		section: CAPIArticle.config.section,
-		sharedAdTargeting: CAPIArticle.config.sharedAdTargeting,
-		adUnit: CAPIArticle.config.adUnit,
+		isAdFreeUser: article.isAdFreeUser,
+		isSensitive: article.config.isSensitive,
+		videoDuration: article.config.videoDuration,
+		edition: article.config.edition,
+		section: article.config.section,
+		sharedAdTargeting: article.config.sharedAdTargeting,
+		adUnit: article.config.adUnit,
 	});
 
 	const showBodyEndSlot =
-		parse(CAPIArticle.slotMachineFlags ?? '').showBodyEnd ||
-		CAPIArticle.config.switches.slotBodyEnd;
+		parse(article.slotMachineFlags ?? '').showBodyEnd ||
+		article.config.switches.slotBodyEnd;
 
 	// TODO:
 	// 1) Read 'forceEpic' value from URL parameter and use it to force the slot to render
-	// 2) Otherwise, ensure slot only renders if `CAPIArticle.config.shouldHideReaderRevenue` equals false.
+	// 2) Otherwise, ensure slot only renders if `article.config.shouldHideReaderRevenue` equals false.
 
 	const footballMatchUrl =
-		CAPIArticle.matchType === 'FootballMatchType' && CAPIArticle.matchUrl;
+		article.matchType === 'FootballMatchType' && article.matchUrl;
 
 	const isMatchReport =
 		format.design === ArticleDesign.MatchReport && !!footballMatchUrl;
 
-	const showComments = CAPIArticle.isCommentable;
+	const showComments = article.isCommentable;
 
-	const { branding } =
-		CAPIArticle.commercialProperties[CAPIArticle.editionId];
+	const { branding } = article.commercialProperties[article.editionId];
 
 	const palette = decidePalette(format);
 
@@ -334,15 +333,15 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 			? format
 			: {
 					...format,
-					theme: getCurrentPillar(CAPIArticle),
+					theme: getCurrentPillar(article),
 			  };
 
-	const contributionsServiceUrl = getContributionsServiceUrl(CAPIArticle);
+	const contributionsServiceUrl = getContributionsServiceUrl(article);
 
 	/**
 	 * This property currently only applies to the header and merchandising slots
 	 */
-	const renderAds = !CAPIArticle.isAdFreeUser && !CAPIArticle.shouldHideAds;
+	const renderAds = !article.isAdFreeUser && !article.shouldHideAds;
 
 	const isLabs = format.theme === ArticleSpecial.Labs;
 
@@ -374,23 +373,23 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 							element="header"
 						>
 							<Header
-								editionId={CAPIArticle.editionId}
-								idUrl={CAPIArticle.config.idUrl}
-								mmaUrl={CAPIArticle.config.mmaUrl}
+								editionId={article.editionId}
+								idUrl={article.config.idUrl}
+								mmaUrl={article.config.mmaUrl}
 								discussionApiUrl={
-									CAPIArticle.config.discussionApiUrl
+									article.config.discussionApiUrl
 								}
-								urls={CAPIArticle.nav.readerRevenueLinks.header}
+								urls={article.nav.readerRevenueLinks.header}
 								remoteHeader={
-									!!CAPIArticle.config.switches.remoteHeader
+									!!article.config.switches.remoteHeader
 								}
 								contributionsServiceUrl={
 									contributionsServiceUrl
 								}
-								idApiUrl={CAPIArticle.config.idApiUrl}
+								idApiUrl={article.config.idApiUrl}
 								isInEuropeTest={isInEuropeTest}
 								headerTopBarSearchCapiSwitch={
-									!!CAPIArticle.config.switches
+									!!article.config.switches
 										.headerTopBarSearchCapi
 								}
 							/>
@@ -408,12 +407,11 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 							nav={NAV}
 							format={formatForNav}
 							subscribeUrl={
-								CAPIArticle.nav.readerRevenueLinks.header
-									.subscribe
+								article.nav.readerRevenueLinks.header.subscribe
 							}
-							editionId={CAPIArticle.editionId}
+							editionId={article.editionId}
 							headerTopBarSwitch={
-								!!CAPIArticle.config.switches.headerTopNav
+								!!article.config.switches.headerTopNav
 							}
 						/>
 					</Section>
@@ -469,7 +467,7 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 				</Stuck>
 			)}
 
-			{renderAds && CAPIArticle.config.switches.surveys && (
+			{renderAds && article.config.switches.surveys && (
 				<AdSlot position="survey" display={format.display} />
 			)}
 
@@ -486,11 +484,11 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 						<GridItem area="title" element="aside">
 							<ArticleTitle
 								format={format}
-								tags={CAPIArticle.tags}
-								sectionLabel={CAPIArticle.sectionLabel}
-								sectionUrl={CAPIArticle.sectionUrl}
-								guardianBaseURL={CAPIArticle.guardianBaseURL}
-								badge={CAPIArticle.badge}
+								tags={article.tags}
+								sectionLabel={article.sectionLabel}
+								sectionUrl={article.sectionUrl}
+								guardianBaseURL={article.guardianBaseURL}
+								badge={article.badge}
 								isMatch={!!footballMatchUrl}
 							/>
 						</GridItem>
@@ -512,12 +510,10 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 										<GetMatchNav
 											matchUrl={footballMatchUrl}
 											format={format}
-											headlineString={
-												CAPIArticle.headline
-											}
-											tags={CAPIArticle.tags}
+											headlineString={article.headline}
+											tags={article.tags}
 											webPublicationDateDeprecated={
-												CAPIArticle.webPublicationDateDeprecated
+												article.webPublicationDateDeprecated
 											}
 										/>
 									</Island>
@@ -543,25 +539,23 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 							<div css={maxWidth}>
 								<ArticleHeadline
 									format={format}
-									headlineString={CAPIArticle.headline}
-									tags={CAPIArticle.tags}
-									byline={CAPIArticle.byline}
+									headlineString={article.headline}
+									tags={article.tags}
+									byline={article.byline}
 									webPublicationDateDeprecated={
-										CAPIArticle.webPublicationDateDeprecated
+										article.webPublicationDateDeprecated
 									}
 									hasStarRating={
-										typeof CAPIArticle.starRating ===
-										'number'
+										typeof article.starRating === 'number'
 									}
 								/>
 							</div>
 						</GridItem>
 						<GridItem area="standfirst">
-							{CAPIArticle.starRating ||
-							CAPIArticle.starRating === 0 ? (
+							{article.starRating || article.starRating === 0 ? (
 								<div css={starWrapper}>
 									<StarRating
-										rating={CAPIArticle.starRating}
+										rating={article.starRating}
 										size="large"
 									/>
 								</div>
@@ -570,22 +564,22 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 							)}
 							<Standfirst
 								format={format}
-								standfirst={CAPIArticle.standfirst}
+								standfirst={article.standfirst}
 							/>
 						</GridItem>
 						<GridItem area="media">
 							<div css={maxWidth}>
 								<MainMedia
 									format={format}
-									elements={CAPIArticle.mainMediaElements}
+									elements={article.mainMediaElements}
 									adTargeting={adTargeting}
 									host={host}
-									pageId={CAPIArticle.pageId}
-									webTitle={CAPIArticle.webTitle}
-									ajaxUrl={CAPIArticle.config.ajaxUrl}
-									switches={CAPIArticle.config.switches}
-									isAdFreeUser={CAPIArticle.isAdFreeUser}
-									isSensitive={CAPIArticle.config.isSensitive}
+									pageId={article.pageId}
+									webTitle={article.webTitle}
+									ajaxUrl={article.config.ajaxUrl}
+									switches={article.config.switches}
+									isAdFreeUser={article.isAdFreeUser}
+									isSensitive={article.config.isSensitive}
 								/>
 							</div>
 						</GridItem>
@@ -608,24 +602,24 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 								<ArticleMeta
 									branding={branding}
 									format={format}
-									pageId={CAPIArticle.pageId}
-									webTitle={CAPIArticle.webTitle}
-									byline={CAPIArticle.byline}
-									tags={CAPIArticle.tags}
+									pageId={article.pageId}
+									webTitle={article.webTitle}
+									byline={article.byline}
+									tags={article.tags}
 									primaryDateline={
-										CAPIArticle.webPublicationDateDisplay
+										article.webPublicationDateDisplay
 									}
 									secondaryDateline={
-										CAPIArticle.webPublicationSecondaryDateDisplay
+										article.webPublicationSecondaryDateDisplay
 									}
-									isCommentable={CAPIArticle.isCommentable}
+									isCommentable={article.isCommentable}
 									discussionApiUrl={
-										CAPIArticle.config.discussionApiUrl
+										article.config.discussionApiUrl
 									}
-									shortUrlId={CAPIArticle.config.shortUrlId}
-									ajaxUrl={CAPIArticle.config.ajaxUrl}
+									shortUrlId={article.config.shortUrlId}
+									ajaxUrl={article.config.ajaxUrl}
 									showShareCount={
-										!!CAPIArticle.config.switches
+										!!article.config.switches
 											.serverShareCounts
 									}
 								/>
@@ -635,37 +629,35 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 							<ArticleContainer format={format}>
 								<ArticleBody
 									format={format}
-									blocks={CAPIArticle.blocks}
-									pinnedPost={CAPIArticle.pinnedPost}
+									blocks={article.blocks}
+									pinnedPost={article.pinnedPost}
 									adTargeting={adTargeting}
 									host={host}
-									pageId={CAPIArticle.pageId}
-									webTitle={CAPIArticle.webTitle}
-									ajaxUrl={CAPIArticle.config.ajaxUrl}
-									switches={CAPIArticle.config.switches}
-									isSensitive={CAPIArticle.config.isSensitive}
-									isAdFreeUser={CAPIArticle.isAdFreeUser}
-									section={CAPIArticle.config.section}
+									pageId={article.pageId}
+									webTitle={article.webTitle}
+									ajaxUrl={article.config.ajaxUrl}
+									switches={article.config.switches}
+									isSensitive={article.config.isSensitive}
+									isAdFreeUser={article.isAdFreeUser}
+									section={article.config.section}
 									shouldHideReaderRevenue={
-										CAPIArticle.shouldHideReaderRevenue
+										article.shouldHideReaderRevenue
 									}
-									tags={CAPIArticle.tags}
+									tags={article.tags}
 									isPaidContent={
-										!!CAPIArticle.config.isPaidContent
+										!!article.config.isPaidContent
 									}
 									contributionsServiceUrl={
 										contributionsServiceUrl
 									}
-									contentType={CAPIArticle.contentType}
-									sectionName={CAPIArticle.sectionName ?? ''}
-									isPreview={CAPIArticle.config.isPreview}
-									idUrl={CAPIArticle.config.idUrl ?? ''}
-									isDev={!!CAPIArticle.config.isDev}
-									keywordIds={CAPIArticle.config.keywordIds}
-									abTests={CAPIArticle.config.abTests}
-									tableOfContents={
-										CAPIArticle.tableOfContents
-									}
+									contentType={article.contentType}
+									sectionName={article.sectionName ?? ''}
+									isPreview={article.config.isPreview}
+									idUrl={article.config.idUrl ?? ''}
+									isDev={!!article.config.isDev}
+									keywordIds={article.config.keywordIds}
+									abTests={article.config.abTests}
+									tableOfContents={article.tableOfContents}
 								/>
 								{format.design === ArticleDesign.MatchReport &&
 									!!footballMatchUrl && (
@@ -684,38 +676,28 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 								{showBodyEndSlot && (
 									<Island clientOnly={true}>
 										<SlotBodyEnd
-											contentType={
-												CAPIArticle.contentType
-											}
+											contentType={article.contentType}
 											contributionsServiceUrl={
 												contributionsServiceUrl
 											}
-											idApiUrl={
-												CAPIArticle.config.idApiUrl
-											}
+											idApiUrl={article.config.idApiUrl}
 											isMinuteArticle={
-												CAPIArticle.pageType
-													.isMinuteArticle
+												article.pageType.isMinuteArticle
 											}
 											isPaidContent={
-												CAPIArticle.pageType
-													.isPaidContent
+												article.pageType.isPaidContent
 											}
 											keywordIds={
-												CAPIArticle.config.keywordIds
+												article.config.keywordIds
 											}
-											pageId={CAPIArticle.pageId}
-											sectionId={
-												CAPIArticle.config.section
-											}
-											sectionName={
-												CAPIArticle.sectionName
-											}
+											pageId={article.pageId}
+											sectionId={article.config.section}
+											sectionName={article.sectionName}
 											shouldHideReaderRevenue={
-												CAPIArticle.shouldHideReaderRevenue
+												article.shouldHideReaderRevenue
 											}
-											stage={CAPIArticle.config.stage}
-											tags={CAPIArticle.tags}
+											stage={article.config.stage}
+											tags={article.tags}
 										/>
 									</Island>
 								)}
@@ -730,18 +712,18 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 								<SubMeta
 									format={format}
 									subMetaKeywordLinks={
-										CAPIArticle.subMetaKeywordLinks
+										article.subMetaKeywordLinks
 									}
 									subMetaSectionLinks={
-										CAPIArticle.subMetaSectionLinks
+										article.subMetaSectionLinks
 									}
-									pageId={CAPIArticle.pageId}
-									webUrl={CAPIArticle.webURL}
-									webTitle={CAPIArticle.webTitle}
+									pageId={article.pageId}
+									webUrl={article.webURL}
+									webTitle={article.webTitle}
 									showBottomSocialButtons={
-										CAPIArticle.showBottomSocialButtons
+										article.showBottomSocialButtons
 									}
-									badge={CAPIArticle.badge}
+									badge={article.badge}
 								/>
 							</ArticleContainer>
 						</GridItem>
@@ -763,16 +745,15 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 								`}
 							>
 								<RightColumn>
-									{!CAPIArticle.shouldHideAds && (
+									{!article.shouldHideAds && (
 										<AdSlot
 											position="right"
 											display={format.display}
 											shouldHideReaderRevenue={
-												CAPIArticle.shouldHideReaderRevenue
+												article.shouldHideReaderRevenue
 											}
 											isPaidContent={
-												CAPIArticle.pageType
-													.isPaidContent
+												article.pageType.isPaidContent
 											}
 										/>
 									)}
@@ -783,7 +764,7 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 										>
 											<MostViewedRightWrapper
 												isAdFreeUser={
-													CAPIArticle.isAdFreeUser
+													article.isAdFreeUser
 												}
 											/>
 										</Island>
@@ -814,12 +795,12 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 					</Section>
 				)}
 
-				{CAPIArticle.storyPackage && (
+				{article.storyPackage && (
 					<Section fullWidth={true}>
 						<Island deferUntil="visible">
 							<Carousel
-								heading={CAPIArticle.storyPackage.heading}
-								trails={CAPIArticle.storyPackage.trails.map(
+								heading={article.storyPackage.heading}
+								trails={article.storyPackage.trails.map(
 									decideTrail,
 								)}
 								onwardsSource="more-on-this-story"
@@ -835,22 +816,20 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 					placeholderHeight={600}
 				>
 					<OnwardsUpper
-						ajaxUrl={CAPIArticle.config.ajaxUrl}
-						hasRelated={CAPIArticle.hasRelated}
-						hasStoryPackage={CAPIArticle.hasStoryPackage}
-						isAdFreeUser={CAPIArticle.isAdFreeUser}
-						pageId={CAPIArticle.pageId}
-						isPaidContent={!!CAPIArticle.config.isPaidContent}
-						showRelatedContent={
-							CAPIArticle.config.showRelatedContent
-						}
-						keywordIds={CAPIArticle.config.keywordIds}
-						contentType={CAPIArticle.contentType}
-						tags={CAPIArticle.tags}
+						ajaxUrl={article.config.ajaxUrl}
+						hasRelated={article.hasRelated}
+						hasStoryPackage={article.hasStoryPackage}
+						isAdFreeUser={article.isAdFreeUser}
+						pageId={article.pageId}
+						isPaidContent={!!article.config.isPaidContent}
+						showRelatedContent={article.config.showRelatedContent}
+						keywordIds={article.config.keywordIds}
+						contentType={article.contentType}
+						tags={article.tags}
 						format={format}
 						pillar={format.theme}
-						editionId={CAPIArticle.editionId}
-						shortUrlId={CAPIArticle.config.shortUrlId}
+						editionId={article.editionId}
+						shortUrlId={article.config.shortUrlId}
 					/>
 				</Island>
 
@@ -862,22 +841,19 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 						element="section"
 					>
 						<DiscussionLayout
-							discussionApiUrl={
-								CAPIArticle.config.discussionApiUrl
-							}
-							shortUrlId={CAPIArticle.config.shortUrlId}
+							discussionApiUrl={article.config.discussionApiUrl}
+							shortUrlId={article.config.shortUrlId}
 							format={format}
-							discussionD2Uid={CAPIArticle.config.discussionD2Uid}
+							discussionD2Uid={article.config.discussionD2Uid}
 							discussionApiClientHeader={
-								CAPIArticle.config.discussionApiClientHeader
+								article.config.discussionApiClientHeader
 							}
 							enableDiscussionSwitch={
-								!!CAPIArticle.config.switches
-									.enableDiscussionSwitch
+								!!article.config.switches.enableDiscussionSwitch
 							}
-							isAdFreeUser={CAPIArticle.isAdFreeUser}
-							shouldHideAds={CAPIArticle.shouldHideAds}
-							idApiUrl={CAPIArticle.config.idApiUrl}
+							isAdFreeUser={article.isAdFreeUser}
+							shouldHideAds={article.shouldHideAds}
+							idApiUrl={article.config.idApiUrl}
 						/>
 					</Section>
 				)}
@@ -895,9 +871,9 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 						<MostViewedFooterLayout>
 							<Island clientOnly={true} deferUntil="visible">
 								<MostViewedFooterData
-									sectionName={CAPIArticle.sectionName}
+									sectionName={article.sectionName}
 									format={format}
-									ajaxUrl={CAPIArticle.config.ajaxUrl}
+									ajaxUrl={article.config.ajaxUrl}
 								/>
 							</Island>
 						</MostViewedFooterLayout>
@@ -949,41 +925,39 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 				element="footer"
 			>
 				<Footer
-					pageFooter={CAPIArticle.pageFooter}
+					pageFooter={article.pageFooter}
 					pillar={format.theme}
 					pillars={NAV.pillars}
-					urls={CAPIArticle.nav.readerRevenueLinks.header}
-					editionId={CAPIArticle.editionId}
-					contributionsServiceUrl={
-						CAPIArticle.contributionsServiceUrl
-					}
+					urls={article.nav.readerRevenueLinks.header}
+					editionId={article.editionId}
+					contributionsServiceUrl={article.contributionsServiceUrl}
 				/>
 			</Section>
 
 			<BannerWrapper data-print-layout="hide">
 				<Island deferUntil="idle" clientOnly={true}>
 					<StickyBottomBanner
-						contentType={CAPIArticle.contentType}
+						contentType={article.contentType}
 						contributionsServiceUrl={contributionsServiceUrl}
-						idApiUrl={CAPIArticle.config.idApiUrl}
-						isMinuteArticle={CAPIArticle.pageType.isMinuteArticle}
-						isPaidContent={CAPIArticle.pageType.isPaidContent}
-						isPreview={!!CAPIArticle.config.isPreview}
-						isSensitive={CAPIArticle.config.isSensitive}
-						keywordIds={CAPIArticle.config.keywordIds}
-						pageId={CAPIArticle.pageId}
-						section={CAPIArticle.config.section}
-						sectionName={CAPIArticle.sectionName}
+						idApiUrl={article.config.idApiUrl}
+						isMinuteArticle={article.pageType.isMinuteArticle}
+						isPaidContent={article.pageType.isPaidContent}
+						isPreview={!!article.config.isPreview}
+						isSensitive={article.config.isSensitive}
+						keywordIds={article.config.keywordIds}
+						pageId={article.pageId}
+						section={article.config.section}
+						sectionName={article.sectionName}
 						shouldHideReaderRevenue={
-							CAPIArticle.shouldHideReaderRevenue
+							article.shouldHideReaderRevenue
 						}
 						remoteBannerSwitch={
-							!!CAPIArticle.config.switches.remoteBanner
+							!!article.config.switches.remoteBanner
 						}
 						puzzleBannerSwitch={
-							!!CAPIArticle.config.switches.puzzlesBanner
+							!!article.config.switches.puzzlesBanner
 						}
-						tags={CAPIArticle.tags}
+						tags={article.tags}
 					/>
 				</Island>
 			</BannerWrapper>

--- a/dotcom-rendering/src/web/lib/ArticleRenderer.tsx
+++ b/dotcom-rendering/src/web/lib/ArticleRenderer.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/react';
 import type { ArticleFormat } from '@guardian/libs';
 import { ArticleDesign } from '@guardian/libs';
 import type { ServerSideTests, Switches } from '../../types/config';
-import type { CAPIElement } from '../../types/content';
+import type { FEElement } from '../../types/content';
 import type { TagType } from '../../types/tag';
 import {
 	adCollapseStyles,
@@ -29,7 +29,7 @@ const adStylesDynamic = css`
 
 type Props = {
 	format: ArticleFormat;
-	elements: CAPIElement[];
+	elements: FEElement[];
 	adTargeting?: AdTargeting;
 	host?: string;
 	pageId: string;

--- a/dotcom-rendering/src/web/lib/contributions.ts
+++ b/dotcom-rendering/src/web/lib/contributions.ts
@@ -260,9 +260,8 @@ export const lazyFetchEmailWithTimeout =
 		});
 	};
 
-export const getContributionsServiceUrl = (
-	CAPIArticle: FEArticleType,
-): string => process.env.SDC_URL ?? CAPIArticle.contributionsServiceUrl;
+export const getContributionsServiceUrl = (article: FEArticleType): string =>
+	process.env.SDC_URL ?? article.contributionsServiceUrl;
 
 type PurchaseInfo = HeaderPayload['targeting']['purchaseInfo'];
 export const getPurchaseInfo = (): PurchaseInfo => {

--- a/dotcom-rendering/src/web/lib/decideDesign.ts
+++ b/dotcom-rendering/src/web/lib/decideDesign.ts
@@ -7,7 +7,7 @@ import { ArticleDesign } from '@guardian/libs';
 export const decideDesign = ({
 	design,
 	display,
-}: Partial<CAPIFormat>): ArticleDesign => {
+}: Partial<FEFormat>): ArticleDesign => {
 	switch (design) {
 		case 'ArticleDesign':
 			return ArticleDesign.Standard;

--- a/dotcom-rendering/src/web/lib/decideDisplay.ts
+++ b/dotcom-rendering/src/web/lib/decideDisplay.ts
@@ -2,7 +2,7 @@ import { ArticleDisplay } from '@guardian/libs';
 
 export const decideDisplay = ({
 	display,
-}: Partial<CAPIFormat>): ArticleDisplay => {
+}: Partial<FEFormat>): ArticleDisplay => {
 	switch (display) {
 		case 'StandardDisplay':
 			return ArticleDisplay.Standard;

--- a/dotcom-rendering/src/web/lib/decideFormat.ts
+++ b/dotcom-rendering/src/web/lib/decideFormat.ts
@@ -2,7 +2,7 @@ import { decideDesign } from './decideDesign';
 import { decideDisplay } from './decideDisplay';
 import { decideTheme } from './decideTheme';
 
-export const decideFormat = (format: Partial<CAPIFormat>): ArticleFormat => ({
+export const decideFormat = (format: Partial<FEFormat>): ArticleFormat => ({
 	display: decideDisplay(format),
 	theme: decideTheme(format),
 	design: decideDesign(format),

--- a/dotcom-rendering/src/web/lib/decideTheme.ts
+++ b/dotcom-rendering/src/web/lib/decideTheme.ts
@@ -1,6 +1,6 @@
 import { ArticlePillar, ArticleSpecial } from '@guardian/libs';
 
-export const decideTheme = ({ theme }: Partial<CAPIFormat>): ArticleTheme => {
+export const decideTheme = ({ theme }: Partial<FEFormat>): ArticleTheme => {
 	switch (theme) {
 		case 'NewsPillar':
 			return ArticlePillar.News;

--- a/dotcom-rendering/src/web/lib/decideTrail.ts
+++ b/dotcom-rendering/src/web/lib/decideTrail.ts
@@ -1,8 +1,8 @@
-import type { CAPITrailType, TrailType } from '../../types/trails';
+import type { FETrailType, TrailType } from '../../types/trails';
 import { decideFormat } from './decideFormat';
 import { getDataLinkNameCard } from './getDataLinkName';
 
-export const decideTrail = (trail: CAPITrailType, index = 0): TrailType => {
+export const decideTrail = (trail: FETrailType, index = 0): TrailType => {
 	const format: ArticleFormat = decideFormat(trail.format);
 
 	return {

--- a/dotcom-rendering/src/web/lib/layoutHelpers.ts
+++ b/dotcom-rendering/src/web/lib/layoutHelpers.ts
@@ -1,10 +1,10 @@
 import type { FEArticleType } from '../../types/frontend';
 import { decideNavTheme } from './decideNavTheme';
 
-export const getCurrentPillar = (CAPIArticle: FEArticleType): ArticleTheme => {
+export const getCurrentPillar = (article: FEArticleType): ArticleTheme => {
 	const currentPillar =
-		(CAPIArticle.nav.currentPillarTitle &&
-			(CAPIArticle.nav.currentPillarTitle.toLowerCase() as LegacyPillar)) ||
-		CAPIArticle.pillar;
+		(article.nav.currentPillarTitle &&
+			(article.nav.currentPillarTitle.toLowerCase() as LegacyPillar)) ||
+		article.pillar;
 	return decideNavTheme(currentPillar);
 };

--- a/dotcom-rendering/src/web/lib/liveblogAdSlots.test.ts
+++ b/dotcom-rendering/src/web/lib/liveblogAdSlots.test.ts
@@ -1,11 +1,11 @@
-import type { CAPIElement } from '../../types/content';
+import type { FEElement } from '../../types/content';
 import {
 	calculateApproximateBlockHeight,
 	shouldDisplayAd,
 } from './liveblogAdSlots';
 
 describe('calculateApproximateBlockHeight', () => {
-	const textElementOneLine: CAPIElement[] = [
+	const textElementOneLine: FEElement[] = [
 		{
 			elementId: '1',
 			_type: 'model.dotcomrendering.pageElements.TextBlockElement',
@@ -13,7 +13,7 @@ describe('calculateApproximateBlockHeight', () => {
 		},
 	];
 
-	const textElementTwoLines: CAPIElement[] = [
+	const textElementTwoLines: FEElement[] = [
 		{
 			elementId: '1',
 			_type: 'model.dotcomrendering.pageElements.TextBlockElement',
@@ -21,7 +21,7 @@ describe('calculateApproximateBlockHeight', () => {
 		},
 	];
 
-	const multipleTextElements: CAPIElement[] = [
+	const multipleTextElements: FEElement[] = [
 		{
 			elementId: '1',
 			_type: 'model.dotcomrendering.pageElements.TextBlockElement',
@@ -34,7 +34,7 @@ describe('calculateApproximateBlockHeight', () => {
 		},
 	];
 
-	const youtubeElement: CAPIElement[] = [
+	const youtubeElement: FEElement[] = [
 		{
 			_type: 'model.dotcomrendering.pageElements.YoutubeBlockElement',
 			id: '1',

--- a/dotcom-rendering/src/web/lib/liveblogAdSlots.ts
+++ b/dotcom-rendering/src/web/lib/liveblogAdSlots.ts
@@ -1,7 +1,7 @@
 import type {
 	BlockquoteBlockElement,
-	CAPIElement,
 	CommentBlockElement,
+	FEElement,
 	ImageBlockElement,
 	RichLinkBlockElement,
 	SubheadingBlockElement,
@@ -44,7 +44,7 @@ type BlockElementTextData = {
 type BlockElementHeightData = { heightExcludingText: number } & (
 	| {
 			textHeight: BlockElementTextData;
-			text: (element: CAPIElement) => string;
+			text: (element: FEElement) => string;
 	  }
 	| {
 			textHeight?: never;
@@ -54,7 +54,7 @@ type BlockElementHeightData = { heightExcludingText: number } & (
 
 /**
  * All known element types that are used in a liveblog block. There are other elements that
- * it is possible to use (see CAPIElement type), but these other elements have not been
+ * it is possible to use (see FEElement type), but these other elements have not been
  * sighted in a liveblog page, so are not considered.
  */
 type KnownBlockElementType =
@@ -162,7 +162,7 @@ const elementHeightDataMap: {
 };
 
 export const calculateApproximateElementHeight = (
-	element: CAPIElement,
+	element: FEElement,
 ): number => {
 	// Is there a height estimate for this element type?
 	const isElementTypeKnown = Object.keys(elementHeightDataMap).includes(
@@ -196,7 +196,7 @@ export const calculateApproximateElementHeight = (
  * A block is a list of Elements that make up one liveblog update
  * An element can be a few paragraphs of text, an image, a twitter embed, etc.
  */
-const calculateApproximateBlockHeight = (elements: CAPIElement[]): number => {
+const calculateApproximateBlockHeight = (elements: FEElement[]): number => {
 	if (!elements.length) return 0;
 
 	const defaultBlockHeight = BLOCK_HEADER + BLOCK_FOOTER + BLOCK_SPACING;

--- a/dotcom-rendering/src/web/lib/renderElement.tsx
+++ b/dotcom-rendering/src/web/lib/renderElement.tsx
@@ -8,7 +8,7 @@ import type { ArticleFormat } from '@guardian/libs';
 import { ArticleDesign } from '@guardian/libs';
 import { getSharingUrls } from '../../lib/sharing-urls';
 import type { ServerSideTests, Switches } from '../../types/config';
-import type { CAPIElement, RoleType } from '../../types/content';
+import type { FEElement, RoleType } from '../../types/content';
 import { AudioAtomWrapper } from '../components/AudioAtomWrapper.importable';
 import { BlockquoteBlockComponent } from '../components/BlockquoteBlockComponent';
 import { CalloutBlockComponent } from '../components/CalloutBlockComponent.importable';
@@ -70,7 +70,7 @@ import { decidePalette } from './decidePalette';
 
 type Props = {
 	format: ArticleFormat;
-	element: CAPIElement;
+	element: FEElement;
 	adTargeting?: AdTargeting;
 	host?: string;
 	index: number;
@@ -89,7 +89,7 @@ type Props = {
 
 // updateRole modifies the role of an element in a way appropriate for most
 // article types.
-const updateRole = (el: CAPIElement, format: ArticleFormat): CAPIElement => {
+const updateRole = (el: FEElement, format: ArticleFormat): FEElement => {
 	const isBlog =
 		format.design === ArticleDesign.LiveBlog ||
 		format.design === ArticleDesign.DeadBlog;
@@ -118,7 +118,7 @@ const updateRole = (el: CAPIElement, format: ArticleFormat): CAPIElement => {
 	}
 };
 
-// renderElement converts a CAPI element to JSX. A boolean 'ok' flag is returned
+// renderElement converts a Frontend element to JSX. A boolean 'ok' flag is returned
 // along with the element to indicate if the element is null, in which case
 // callers can e.g. avoid further work/wrapping as required. Unfortunately,
 // there is no straightforward way to tell if a React element is null by direct
@@ -763,7 +763,7 @@ export const renderElement = ({
 // bareElements is the set of element types that don't get wrapped in a Figure
 // for most article types, either because they don't need it or because they
 // add the figure themselves.
-const bareElements = new Set<CAPIElement['_type']>([
+const bareElements = new Set<FEElement['_type']>([
 	'model.dotcomrendering.pageElements.BlockquoteBlockElement',
 	'model.dotcomrendering.pageElements.CaptionBlockElement',
 	'model.dotcomrendering.pageElements.CodeBlockElement',

--- a/dotcom-rendering/src/web/server/articleToHtml.tsx
+++ b/dotcom-rendering/src/web/server/articleToHtml.tsx
@@ -13,7 +13,7 @@ import { escapeData } from '../../lib/escapeData';
 import { extractGA } from '../../model/extract-ga';
 import { extractNAV } from '../../model/extract-nav';
 import { makeWindowGuardian } from '../../model/window-guardian';
-import type { CAPIElement } from '../../types/content';
+import type { FEElement } from '../../types/content';
 import type { FEArticleType } from '../../types/frontend';
 import type { TagType } from '../../types/tag';
 import { ArticlePage } from '../components/ArticlePage';
@@ -46,12 +46,12 @@ export const articleToHtml = ({ article }: Props): string => {
 	const format: ArticleFormat = decideFormat(article.format);
 
 	const { html, extractedCss } = renderToStringWithEmotion(
-		<ArticlePage format={format} CAPIArticle={article} NAV={NAV} />,
+		<ArticlePage format={format} article={article} NAV={NAV} />,
 	);
 
 	// We want to only insert script tags for the elements or main media elements on this page view
 	// so we need to check what elements we have and use the mapping to the the chunk name
-	const CAPIElements: CAPIElement[] = article.blocks
+	const elements: FEElement[] = article.blocks
 		.map((block) => block.elements)
 		.flat();
 
@@ -62,7 +62,7 @@ export const articleToHtml = ({ article }: Props): string => {
 	const polyfillIO =
 		'https://assets.guim.co.uk/polyfill.io/v3/polyfill.min.js?rum=0&features=es6,es7,es2017,es2018,es2019,default-3.6,HTMLPictureElement,IntersectionObserver,IntersectionObserverEntry,URLSearchParams,fetch,NodeList.prototype.forEach,navigator.sendBeacon,performance.now,Promise.allSettled&flags=gated&callback=guardianPolyfilled&unknown=polyfill&cacheClear=1';
 
-	const pageHasNonBootInteractiveElements = CAPIElements.some(
+	const pageHasNonBootInteractiveElements = elements.some(
 		(element) =>
 			element._type ===
 				'model.dotcomrendering.pageElements.InteractiveBlockElement' &&
@@ -70,7 +70,7 @@ export const articleToHtml = ({ article }: Props): string => {
 				'https://interactive.guim.co.uk/embed/iframe-wrapper/0.1/boot.js', // We have rewritten this standard behaviour into Dotcom Rendering
 	);
 
-	const pageHasTweetElements = CAPIElements.some(
+	const pageHasTweetElements = elements.some(
 		(element) =>
 			element._type ===
 			'model.dotcomrendering.pageElements.TweetBlockElement',

--- a/dotcom-rendering/src/web/server/blocksToHtml.tsx
+++ b/dotcom-rendering/src/web/server/blocksToHtml.tsx
@@ -11,7 +11,7 @@ import { LiveBlogRenderer } from '../lib/LiveBlogRenderer';
  */
 export const blocksToHtml = ({
 	blocks,
-	format: CAPIFormat,
+	format: FEFormat,
 	host,
 	pageId,
 	webTitle,
@@ -25,8 +25,8 @@ export const blocksToHtml = ({
 	adUnit,
 	switches,
 	keywordIds,
-}: BlocksRequest): string => {
-	const format: ArticleFormat = decideFormat(CAPIFormat);
+}: FEBlocksRequest): string => {
+	const format: ArticleFormat = decideFormat(FEFormat);
 
 	const adTargeting: AdTargeting = buildAdTargeting({
 		isAdFreeUser,

--- a/dotcom-rendering/src/web/server/index.ts
+++ b/dotcom-rendering/src/web/server/index.ts
@@ -5,7 +5,10 @@ import { enhanceCollections } from '../../model/enhanceCollections';
 import { enhanceCommercialProperties } from '../../model/enhanceCommercialProperties';
 import { enhanceStandfirst } from '../../model/enhanceStandfirst';
 import { enhanceTableOfContents } from '../../model/enhanceTableOfContents';
-import { validateAsCAPIType, validateAsFrontType } from '../../model/validate';
+import {
+	validateAsArticleType,
+	validateAsFrontType,
+} from '../../model/validate';
 import type { DCRFrontType, FEFrontType } from '../../types/front';
 import type { FEArticleType } from '../../types/frontend';
 import { decideTrail } from '../lib/decideTrail';
@@ -14,18 +17,18 @@ import { blocksToHtml } from './blocksToHtml';
 import { frontToHtml } from './frontToHtml';
 import { keyEventsToHtml } from './keyEventsToHtml';
 
-function enhancePinnedPost(format: CAPIFormat, block?: Block) {
+function enhancePinnedPost(format: FEFormat, block?: Block) {
 	return block ? enhanceBlocks([block], format)[0] : block;
 }
 
-const enhanceCAPIType = (body: unknown): FEArticleType => {
-	const data = validateAsCAPIType(body);
+const enhanceArticleType = (body: unknown): FEArticleType => {
+	const data = validateAsArticleType(body);
 
 	const enhancedBlocks = enhanceBlocks(data.blocks, data.format, {
 		promotedNewsletter: data.promotedNewsletter,
 	});
 
-	const CAPIArticle: FEArticleType = {
+	return {
 		...data,
 		blocks: enhancedBlocks,
 		pinnedPost: enhancePinnedPost(data.format, data.pinnedPost),
@@ -37,7 +40,6 @@ const enhanceCAPIType = (body: unknown): FEArticleType => {
 			? enhanceTableOfContents(data.format, enhancedBlocks)
 			: undefined,
 	};
-	return CAPIArticle;
 };
 
 const getStack = (e: unknown): string =>
@@ -69,7 +71,7 @@ const enhanceFront = (body: unknown): DCRFrontType => {
 
 export const handleArticle: RequestHandler = ({ body }, res) => {
 	try {
-		const article = enhanceCAPIType(body);
+		const article = enhanceArticleType(body);
 		const resp = articleToHtml({
 			article,
 		});
@@ -82,10 +84,12 @@ export const handleArticle: RequestHandler = ({ body }, res) => {
 
 export const handleArticleJson: RequestHandler = ({ body }, res) => {
 	try {
-		const CAPIArticle = enhanceCAPIType(body);
+		const article = enhanceArticleType(body);
 		const resp = {
 			data: {
-				CAPIArticle,
+				// TODO: We should rename this to 'article' or 'FEArticle', but first we need to investigate
+				// where/if this is used.
+				CAPIArticle: article,
 			},
 		};
 
@@ -102,7 +106,7 @@ export const handlePerfTest: RequestHandler = (req, res, next) => {
 
 export const handleInteractive: RequestHandler = ({ body }, res) => {
 	try {
-		const article = enhanceCAPIType(body);
+		const article = enhanceArticleType(body);
 		const resp = articleToHtml({
 			article,
 		});
@@ -133,7 +137,7 @@ export const handleBlocks: RequestHandler = ({ body }, res) => {
 			keywordIds,
 		} =
 			// The content if body is not checked
-			body as BlocksRequest;
+			body as FEBlocksRequest;
 
 		const enhancedBlocks = enhanceBlocks(blocks, format);
 		const html = blocksToHtml({
@@ -164,7 +168,7 @@ export const handleKeyEvents: RequestHandler = ({ body }, res) => {
 	try {
 		const { keyEvents, format, filterKeyEvents } =
 			// The content if body is not checked
-			body as KeyEventsRequest;
+			body as FEKeyEventsRequest;
 
 		const html = keyEventsToHtml({
 			keyEvents,

--- a/dotcom-rendering/src/web/server/keyEventsToHtml.tsx
+++ b/dotcom-rendering/src/web/server/keyEventsToHtml.tsx
@@ -10,13 +10,13 @@ import { decideFormat } from '../lib/decideFormat';
  */
 export const keyEventsToHtml = ({
 	keyEvents,
-	format: CAPIFormat,
+	format: FEFormat,
 	filterKeyEvents,
-}: KeyEventsRequest): string => {
+}: FEKeyEventsRequest): string => {
 	const html = renderToString(
 		<KeyEventsContainer
 			keyEvents={keyEvents}
-			format={decideFormat(CAPIFormat)}
+			format={decideFormat(FEFormat)}
 			filterKeyEvents={filterKeyEvents}
 		/>,
 	);


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## Background

`CAPIType` started out with DCR all the way back in 2018, at least with PR https://github.com/guardian/dotcom-rendering/pull/158, but probably earlier. Since then, it was renamed to `CAPIArticleType`, and most recently `FEArticleType`.

Why has this changed over time? Using `CAPI` in our types presents a skewed view of the data structures which DCR uses. While these pieces of data do originate from CAPI, most if not all are modified by Frontend before making it to DCR. Over time, we've made small changes to try and more accurately reflect the data structures in their names.

As a DCR developer, you might mistakenly think that the data you are working with reflects the CAPI data structure, when really the data is more of a reflection of Frontends internal data sets, often modified explicitly for DCR as well.

## What does this PR do?

Despite the progression of `CAPIType` to `FEArticleType`, `CAPI` prefixed types, and associated `CAPI` prefixed functions and variable names are very prevalent in DCR. This PR is a full sweep of DCR, looking for any references to CAPI and updating them to have more appropriate names.

For the most part these are changing type names, e.g
`CAPIFormat` -> `FEFormat`
`CAPILinkType` -> `FELinkType`
`CAPIElement` -> `FEElement`

Additional changes include things like:
- Layouts now take an `article` prop instead of `CAPIArticle`
- `validateAsCAPIType` -> `validateAsArticleType`

## Why is this valuable?

This change _should_ help provide clarity to DCR developers, with types hopefully being more accurately named based on their data structure.

This should also support plans to begin to use actual CAPI data in DCR in the future - where we would want to be able to use the `CAPI` prefix for data types which do match the structure of CAPI.

