### PR TITLE
Updating braze-components dependency to v9.0.1

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -65,7 +65,7 @@
 		"@emotion/server": "^11.4.0",
 		"@guardian/ab-core": "^2.0.0",
 		"@guardian/atoms-rendering": "^25.1.5",
-		"@guardian/braze-components": "^8.1.3",
+		"@guardian/braze-components": "^9.0.1",
 		"@guardian/browserslist-config": "^2.0.3",
 		"@guardian/commercial-core": "^5.2.1",
 		"@guardian/consent-management-platform": "11.0.0",

--- a/dotcom-rendering/src/web/components/SlotBodyEnd/BrazeEpic.stories.tsx
+++ b/dotcom-rendering/src/web/components/SlotBodyEnd/BrazeEpic.stories.tsx
@@ -165,7 +165,9 @@ BrazeEpic_DefaultWithReminder_Component.args = {
 	remindMeConfirmationHeaderText: 'Thank you! Your reminder is set.',
 };
 
-BrazeEpic_DefaultWithReminder_Component.story = { name: 'Default Epic with reminder' };
+BrazeEpic_DefaultWithReminder_Component.story = {
+	name: 'Default Epic with reminder',
+};
 
 // Braze Epic with special header
 // ---------------------------------------
@@ -306,7 +308,9 @@ BrazeNewsletterEpic_UK_MorningBriefing_Component.args = {
 	ophanComponentId: 'example_ophan_component_id',
 };
 
-BrazeNewsletterEpic_UK_MorningBriefing_Component.story = { name: 'Newsletter - UK - Morning Briefing' };
+BrazeNewsletterEpic_UK_MorningBriefing_Component.story = {
+	name: 'Newsletter - UK - Morning Briefing',
+};
 
 // Braze Newsletter Epic - US - FirstThing
 // ---------------------------------------
@@ -371,7 +375,9 @@ BrazeEpicNewsletter_US_FirstThing_Component.args = {
 	ophanComponentId: 'example_ophan_component_id',
 };
 
-BrazeEpicNewsletter_US_FirstThing_Component.story = { name: 'Newsletter - US - First Thing' };
+BrazeEpicNewsletter_US_FirstThing_Component.story = {
+	name: 'Newsletter - US - First Thing',
+};
 
 // Braze Newsletter Epic - AUS - MorningMail
 // ---------------------------------------
@@ -436,7 +442,9 @@ BrazeEpicNewsletter_AUS_MorningMail_Component.args = {
 	ophanComponentId: 'example_ophan_component_id',
 };
 
-BrazeEpicNewsletter_AUS_MorningMail_Component.story = { name: 'Newsletter - AUS - Morning Mail' };
+BrazeEpicNewsletter_AUS_MorningMail_Component.story = {
+	name: 'Newsletter - AUS - Morning Mail',
+};
 
 // Braze Newsletter Epic - AUS - MorningMail
 // ---------------------------------------
@@ -490,18 +498,20 @@ export const BrazeEpicNewsletter_AUS_AfteernoonUpdate_Component = (
 };
 
 BrazeEpicNewsletter_AUS_AfteernoonUpdate_Component.args = {
-    slotName: 'EndOfArticle',
-    header: `Sign up for Guardian Australia's Afternoon Update`,
-    frequency: 'Every weekday',
-    paragraph1:
-        'Our Australian afternoon update breaks down the key stories of the day, telling you what’s happening and why it matters.',
-    paragraph2:
-        'We thought you should know this newsletter may contain information about Guardian products and services.',
-    componentName: 'EpicNewsletter_AU_AfternoonUpdate',
-    ophanComponentId: 'example_ophan_component_id',
+	slotName: 'EndOfArticle',
+	header: `Sign up for Guardian Australia's Afternoon Update`,
+	frequency: 'Every weekday',
+	paragraph1:
+		'Our Australian afternoon update breaks down the key stories of the day, telling you what’s happening and why it matters.',
+	paragraph2:
+		'We thought you should know this newsletter may contain information about Guardian products and services.',
+	componentName: 'EpicNewsletter_AU_AfternoonUpdate',
+	ophanComponentId: 'example_ophan_component_id',
 };
 
-BrazeEpicNewsletter_AUS_AfteernoonUpdate_Component.story = { name: 'Newsletter - AUS - Morning Mail' };
+BrazeEpicNewsletter_AUS_AfteernoonUpdate_Component.story = {
+	name: 'Newsletter - AUS - Morning Mail',
+};
 
 // Braze Newsletter Epic - DownToEarth
 // ---------------------------------------
@@ -622,14 +632,15 @@ export const BrazeEpicNewsletter_TheGuide_Component = (
 };
 
 BrazeEpicNewsletter_TheGuide_Component.args = {
-    slotName: 'EndOfArticle',
-    header: `Sign up for The Guide`,
-    frequency: 'Weekly',
-    paragraph1: 'Get our weekly pop culture email, free in your inbox every Friday.',
-    paragraph2:
-        'We thought you should know this newsletter may contain information about Guardian products and services.',
-    componentName: 'EpicNewsletter_TheGuide',
-    ophanComponentId: 'example_ophan_component_id',
+	slotName: 'EndOfArticle',
+	header: `Sign up for The Guide`,
+	frequency: 'Weekly',
+	paragraph1:
+		'Get our weekly pop culture email, free in your inbox every Friday.',
+	paragraph2:
+		'We thought you should know this newsletter may contain information about Guardian products and services.',
+	componentName: 'EpicNewsletter_TheGuide',
+	ophanComponentId: 'example_ophan_component_id',
 };
 
 BrazeEpicNewsletter_TheGuide_Component.story = {

--- a/dotcom-rendering/src/web/components/SlotBodyEnd/BrazeEpic.stories.tsx
+++ b/dotcom-rendering/src/web/components/SlotBodyEnd/BrazeEpic.stories.tsx
@@ -11,9 +11,9 @@ export default {
 	title: 'Components/SlotBodyEnd/BrazeEpics',
 };
 
-// Braze Epic
+// Braze Epic - Default
 // ---------------------------------------
-export const BrazeEpicComponent = (
+export const BrazeEpic_Default_Component = (
 	args: BrazeMessageProps & { componentName: string },
 ): ReactElement => {
 	const [BrazeMessage, setBrazeMessage] =
@@ -67,7 +67,7 @@ export const BrazeEpicComponent = (
 	return <div>Loading...</div>;
 };
 
-BrazeEpicComponent.args = {
+BrazeEpic_Default_Component.args = {
 	heading: 'Since you’re here...',
 	paragraph1:
 		'... we have a small favour to ask. More people, <a href="https://example.com">like you</a>, are reading and supporting the Guardian’s independent, investigative journalism than ever before. And unlike many news organisations, we made the choice to keep our reporting open for all, regardless of where they live or what they can afford to pay.',
@@ -87,11 +87,11 @@ BrazeEpicComponent.args = {
 	componentName: 'Epic',
 };
 
-BrazeEpicComponent.story = { name: 'Epic' };
+BrazeEpic_Default_Component.story = { name: 'Default Epic' };
 
 // Braze Epic with Reminder CTA
 // ---------------------------------------
-export const BrazeEpicWithReminderComponent = (
+export const BrazeEpic_DefaultWithReminder_Component = (
 	args: BrazeMessageProps & { componentName: string },
 ): ReactElement => {
 	const [BrazeMessage, setBrazeMessage] =
@@ -146,7 +146,7 @@ export const BrazeEpicWithReminderComponent = (
 	return <div>Loading...</div>;
 };
 
-BrazeEpicWithReminderComponent.args = {
+BrazeEpic_DefaultWithReminder_Component.args = {
 	heading: 'Since you’re here...',
 	paragraph1:
 		'... we have a small favour to ask. More people, <a href="https://example.com">like you</a>, are reading and supporting the Guardian’s independent, investigative journalism than ever before. And unlike many news organisations, we made the choice to keep our reporting open for all, regardless of where they live or what they can afford to pay.',
@@ -165,11 +165,11 @@ BrazeEpicWithReminderComponent.args = {
 	remindMeConfirmationHeaderText: 'Thank you! Your reminder is set.',
 };
 
-BrazeEpicWithReminderComponent.story = { name: 'Epic with reminder' };
+BrazeEpic_DefaultWithReminder_Component.story = { name: 'Default Epic with reminder' };
 
 // Braze Epic with special header
 // ---------------------------------------
-export const BrazeEpicSpecialHeaderComponent = (
+export const BrazeEpic_SpecialHeader_Component = (
 	args: BrazeMessageProps & { componentName: string },
 ): ReactElement => {
 	const [BrazeMessage, setBrazeMessage] =
@@ -222,7 +222,7 @@ export const BrazeEpicSpecialHeaderComponent = (
 	return <div>Loading...</div>;
 };
 
-BrazeEpicSpecialHeaderComponent.args = {
+BrazeEpic_SpecialHeader_Component.args = {
 	paragraph1:
 		'... we have a small favour to ask. More people, <a href="https://example.com">like you</a>, are reading and supporting the Guardian’s independent, investigative journalism than ever before. And unlike many news organisations, we made the choice to keep our reporting open for all, regardless of where they live or what they can afford to pay.',
 	paragraph2:
@@ -241,11 +241,11 @@ BrazeEpicSpecialHeaderComponent.args = {
 	componentName: 'EpicWithSpecialHeader',
 };
 
-BrazeEpicSpecialHeaderComponent.story = { name: 'Epic with special header' };
+BrazeEpic_SpecialHeader_Component.story = { name: 'Epic with special header' };
 
-// Braze UK Newsletter Epic
+// Braze Newsletter Epic - UK - MorningBriefing
 // ---------------------------------------
-export const BrazeUKNewsletterEpicComponent = (
+export const BrazeNewsletterEpic_UK_MorningBriefing_Component = (
 	args: BrazeMessageProps & { componentName: string },
 ): ReactElement => {
 	const [BrazeMessage, setBrazeMessage] =
@@ -294,7 +294,7 @@ export const BrazeUKNewsletterEpicComponent = (
 	return <div>Loading...</div>;
 };
 
-BrazeUKNewsletterEpicComponent.args = {
+BrazeNewsletterEpic_UK_MorningBriefing_Component.args = {
 	slotName: 'EndOfArticle',
 	header: 'The Morning Briefing',
 	frequency: 'Every day',
@@ -306,11 +306,11 @@ BrazeUKNewsletterEpicComponent.args = {
 	ophanComponentId: 'example_ophan_component_id',
 };
 
-BrazeUKNewsletterEpicComponent.story = { name: 'UK newsletter Epic' };
+BrazeNewsletterEpic_UK_MorningBriefing_Component.story = { name: 'Newsletter - UK - Morning Briefing' };
 
-// Braze US Newsletter Epic
+// Braze Newsletter Epic - US - FirstThing
 // ---------------------------------------
-export const BrazeUSNewsletterEpicComponent = (
+export const BrazeEpicNewsletter_US_FirstThing_Component = (
 	args: BrazeMessageProps & { componentName: string },
 ): ReactElement => {
 	const [BrazeMessage, setBrazeMessage] =
@@ -359,7 +359,7 @@ export const BrazeUSNewsletterEpicComponent = (
 	return <div>Loading...</div>;
 };
 
-BrazeUSNewsletterEpicComponent.args = {
+BrazeEpicNewsletter_US_FirstThing_Component.args = {
 	slotName: 'EndOfArticle',
 	header: 'First Thing',
 	frequency: 'Daily',
@@ -371,11 +371,11 @@ BrazeUSNewsletterEpicComponent.args = {
 	ophanComponentId: 'example_ophan_component_id',
 };
 
-BrazeUSNewsletterEpicComponent.story = { name: 'US newsletter Epic' };
+BrazeEpicNewsletter_US_FirstThing_Component.story = { name: 'Newsletter - US - First Thing' };
 
-// Braze Australia Newsletter Epic
+// Braze Newsletter Epic - AUS - MorningMail
 // ---------------------------------------
-export const BrazeAUNewsletterEpicComponent = (
+export const BrazeEpicNewsletter_AUS_MorningMail_Component = (
 	args: BrazeMessageProps & { componentName: string },
 ): ReactElement => {
 	const [BrazeMessage, setBrazeMessage] =
@@ -424,7 +424,7 @@ export const BrazeAUNewsletterEpicComponent = (
 	return <div>Loading...</div>;
 };
 
-BrazeAUNewsletterEpicComponent.args = {
+BrazeEpicNewsletter_AUS_MorningMail_Component.args = {
 	slotName: 'EndOfArticle',
 	header: `Guardian Australia's Morning Mail`,
 	frequency: 'Every weekday',
@@ -436,11 +436,11 @@ BrazeAUNewsletterEpicComponent.args = {
 	ophanComponentId: 'example_ophan_component_id',
 };
 
-BrazeAUNewsletterEpicComponent.story = { name: 'Australia newsletter Epic' };
+BrazeEpicNewsletter_AUS_MorningMail_Component.story = { name: 'Newsletter - AUS - Morning Mail' };
 
-// Braze DownToEarth Newsletter Epic
+// Braze Newsletter Epic - AUS - MorningMail
 // ---------------------------------------
-export const BrazeDownToEarthNewsletterEpicComponent = (
+export const BrazeEpicNewsletter_AUS_AfteernoonUpdate_Component = (
 	args: BrazeMessageProps & { componentName: string },
 ): ReactElement => {
 	const [BrazeMessage, setBrazeMessage] =
@@ -489,7 +489,72 @@ export const BrazeDownToEarthNewsletterEpicComponent = (
 	return <div>Loading...</div>;
 };
 
-BrazeDownToEarthNewsletterEpicComponent.args = {
+BrazeEpicNewsletter_AUS_AfteernoonUpdate_Component.args = {
+    slotName: 'EndOfArticle',
+    header: `Sign up for Guardian Australia's Afternoon Update`,
+    frequency: 'Every weekday',
+    paragraph1:
+        'Our Australian afternoon update breaks down the key stories of the day, telling you what’s happening and why it matters.',
+    paragraph2:
+        'We thought you should know this newsletter may contain information about Guardian products and services.',
+    componentName: 'EpicNewsletter_AU_AfternoonUpdate',
+    ophanComponentId: 'example_ophan_component_id',
+};
+
+BrazeEpicNewsletter_AUS_AfteernoonUpdate_Component.story = { name: 'Newsletter - AUS - Morning Mail' };
+
+// Braze Newsletter Epic - DownToEarth
+// ---------------------------------------
+export const BrazeEpicNewsletter_DownToEarth_Component = (
+	args: BrazeMessageProps & { componentName: string },
+): ReactElement => {
+	const [BrazeMessage, setBrazeMessage] =
+		useState<typeof BrazeEndOfArticleComponent>();
+
+	useEffect(() => {
+		import('@guardian/braze-components')
+			.then((module) => {
+				setBrazeMessage(() => module.BrazeEndOfArticleComponent);
+			})
+			.catch((e) =>
+				console.error(
+					`braze-components dynamic import - error: ${String(e)}`,
+				),
+			);
+	}, []);
+
+	if (BrazeMessage) {
+		const brazeMessageProps: BrazeMessageProps = {
+			header: args.header,
+			frequency: args.frequency,
+			paragraph1: args.paragraph1,
+			paragraph2: args.paragraph2,
+			ophanComponentId: args.ophanComponentId,
+		};
+
+		return (
+			<BrazeMessage
+				componentName={args.componentName}
+				subscribeToNewsletter={() => Promise.resolve()}
+				logButtonClickWithBraze={(internalButtonId) => {
+					console.log(
+						`Button with internal ID ${internalButtonId} clicked`,
+					);
+				}}
+				submitComponentEvent={(componentEvent) => {
+					console.log(
+						'submitComponentEvent called with: ',
+						componentEvent,
+					);
+				}}
+				brazeMessageProps={brazeMessageProps}
+			/>
+		);
+	}
+	return <div>Loading...</div>;
+};
+
+BrazeEpicNewsletter_DownToEarth_Component.args = {
 	slotName: 'EndOfArticle',
 	header: 'Down To Earth',
 	frequency: 'Weekly',
@@ -501,6 +566,72 @@ BrazeDownToEarthNewsletterEpicComponent.args = {
 	ophanComponentId: 'example_ophan_component_id',
 };
 
-BrazeDownToEarthNewsletterEpicComponent.story = {
-	name: 'Down To Earth newsletter Epic',
+BrazeEpicNewsletter_DownToEarth_Component.story = {
+	name: 'Newsletter - Down To Earth',
+};
+
+// Braze Newsletter Epic - The Guide
+// ---------------------------------------
+export const BrazeEpicNewsletter_TheGuide_Component = (
+	args: BrazeMessageProps & { componentName: string },
+): ReactElement => {
+	const [BrazeMessage, setBrazeMessage] =
+		useState<typeof BrazeEndOfArticleComponent>();
+
+	useEffect(() => {
+		import('@guardian/braze-components')
+			.then((module) => {
+				setBrazeMessage(() => module.BrazeEndOfArticleComponent);
+			})
+			.catch((e) =>
+				console.error(
+					`braze-components dynamic import - error: ${String(e)}`,
+				),
+			);
+	}, []);
+
+	if (BrazeMessage) {
+		const brazeMessageProps: BrazeMessageProps = {
+			header: args.header,
+			frequency: args.frequency,
+			paragraph1: args.paragraph1,
+			paragraph2: args.paragraph2,
+			ophanComponentId: args.ophanComponentId,
+		};
+
+		return (
+			<BrazeMessage
+				componentName={args.componentName}
+				subscribeToNewsletter={() => Promise.resolve()}
+				logButtonClickWithBraze={(internalButtonId) => {
+					console.log(
+						`Button with internal ID ${internalButtonId} clicked`,
+					);
+				}}
+				submitComponentEvent={(componentEvent) => {
+					console.log(
+						'submitComponentEvent called with: ',
+						componentEvent,
+					);
+				}}
+				brazeMessageProps={brazeMessageProps}
+			/>
+		);
+	}
+	return <div>Loading...</div>;
+};
+
+BrazeEpicNewsletter_TheGuide_Component.args = {
+    slotName: 'EndOfArticle',
+    header: `Sign up for The Guide`,
+    frequency: 'Weekly',
+    paragraph1: 'Get our weekly pop culture email, free in your inbox every Friday.',
+    paragraph2:
+        'We thought you should know this newsletter may contain information about Guardian products and services.',
+    componentName: 'EpicNewsletter_TheGuide',
+    ophanComponentId: 'example_ophan_component_id',
+};
+
+BrazeEpicNewsletter_TheGuide_Component.story = {
+	name: 'Newsletter - The Guide',
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2256,10 +2256,10 @@
   dependencies:
     is-mobile "^3.1.1"
 
-"@guardian/braze-components@^8.1.3":
-  version "8.1.3"
-  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-8.1.3.tgz#47adc4892716904a62afa62da66f31eae059d56b"
-  integrity sha512-Tol4O7A3ErmzgCd9YtkajJUfCps/1RCNXhtaUBwgT8u0OUPRmfk4jjD7cS3nok5gDTEUVemKwT2yysx1CxfWaw==
+"@guardian/braze-components@^9.0.1":
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-9.0.1.tgz#c6c53de37d677eeb6e19037aca05be22758a5379"
+  integrity sha512-bVNhC5+jEjM0LKMgtX9fE4I1eHTNX7UMpdf7P4cBfY37kcT1ULFsw83/k3uvD1ondvSNmngurugBGY790ZoKqg==
 
 "@guardian/browserslist-config@^2.0.3":
   version "2.0.3"


### PR DESCRIPTION
## What does this change?
Updates `braze-components` repo dependency to `v9.0.1`

Also updates Storybook Braze Epic stories

## Why?
We need to update this dependency because we are introducing two new Braze Epic Newsletter promotion templates for use by Marketing colleagues in upcoming campaigns

+ Guardian Australia'a Afternoon Update
+ The Guide

## Screenshots
These are new templates, so no `before` images:

![Screenshot 2023-02-03 at 14 46 31](https://user-images.githubusercontent.com/5357530/216964142-74ec4c56-911d-4cb6-8054-1dc8d83b24e1.png)

![Screenshot 2023-02-03 at 14 46 44](https://user-images.githubusercontent.com/5357530/216964178-fb0987a5-065d-4c3a-a30c-9b8332722c1e.png)

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
