### PR TITLE
Enforce a minium accessibility score of 98

### DIFF
--- a/dotcom-rendering/lighthouserc.js
+++ b/dotcom-rendering/lighthouserc.js
@@ -47,7 +47,7 @@ module.exports = {
 						],
 						'categories:accessibility': [
 							'error',
-							{ minScore: 0.97 },
+							{ minScore: 0.98 },
 						],
 					},
 				},
@@ -60,7 +60,7 @@ module.exports = {
 						],
 						'categories:accessibility': [
 							'warn',
-							{ minScore: 0.97 },
+							{ minScore: 0.98 },
 						],
 					},
 				},


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Enforce a minimum Lighthouse accessibility score on article and fronts of 98.

## Why?

This has been the baseline [for months](https://github.com/guardian/dotcom-rendering/pull/6731#issuecomment-1343003427).