### PR TITLE
Add `TypeError: Load failed` to Sentry ignore list

### DIFF
--- a/dotcom-rendering/src/web/browser/sentryLoader/sentry.ts
+++ b/dotcom-rendering/src/web/browser/sentryLoader/sentry.ts
@@ -26,6 +26,7 @@ const ignoreErrors = [
 	'UnknownError',
 	'TypeError: Failed to fetch',
 	'TypeError: NetworkError when attempting to fetch resource',
+	'TypeError: Load failed',
 	'The quota has been exceeded',
 ];
 

--- a/dotcom-rendering/src/web/browser/sentryLoader/sentry.ts
+++ b/dotcom-rendering/src/web/browser/sentryLoader/sentry.ts
@@ -14,20 +14,23 @@ const allowUrls: BrowserOptions['allowUrls'] = [
 ];
 
 // Ignore these errors
+// https://docs.sentry.io/platforms/javascript/#decluttering-sentry
 const ignoreErrors = [
-	// https://docs.sentry.io/platforms/javascript/#decluttering-sentry
 	"Can't execute code from a freed script",
 	/InvalidStateError/gi,
+	'This video is no longer available.',
+	'UnknownError',
+	'The quota has been exceeded',
+	// Browsers throw exceptions for cancelled network requests
+	// https://stackoverflow.com/questions/55738408/javascript-typeerror-cancelled-error-when-calling-fetch-on-ios/70452078#70452078
+	// https://request-cancellation-test.vercel.app/
 	/Fetch error:/gi,
 	'Network request failed',
 	'NetworkError',
 	'Failed to fetch',
-	'This video is no longer available.',
-	'UnknownError',
 	'TypeError: Failed to fetch',
 	'TypeError: NetworkError when attempting to fetch resource',
 	'TypeError: Load failed',
-	'The quota has been exceeded',
 ];
 
 const { config } = window.guardian;


### PR DESCRIPTION
## What does this change?

Add `TypeError: Load failed` to Sentry's ignore list.

It currently accounts for ~5% of all errors and is adding a lot of noise to valid `TypeError` errors.

## Why?

This particular `TypeError` is only reported by Safari and afaics is a generic error thrown when a network request fails due to cancellation by the browser.

https://stackoverflow.com/a/70452078

https://request-cancellation-test.vercel.app/ (try in Safari to reproduce)

The requests that it fails on are visible in the console log breadcrumbs and are a wide variety of URLs which point to an issue with device connectivity, navigating away or blocked requests rather than a problem with the app.

## Screenshots

<img width="292" alt="Screenshot 2023-02-06 at 17 39 37" src="https://user-images.githubusercontent.com/7014230/217044961-41c62789-657a-4ec7-b5ba-0ca724eeed03.png">


<img width="1056" alt="Screenshot 2023-02-05 at 23 36 26" src="https://user-images.githubusercontent.com/7014230/217044291-b79f0618-382b-4602-ae21-49b142a42497.png">

<img width="1052" alt="Screenshot 2023-02-05 at 23 35 04" src="https://user-images.githubusercontent.com/7014230/217044361-77bc8952-ae27-4fa2-a894-e32276e997fd.png">


<img width="1056" alt="Screenshot 2023-02-05 at 23 33 25" src="https://user-images.githubusercontent.com/7014230/217044397-ba6901ed-d2fb-4417-93f4-19509dab2ff0.png">
