### PR TITLE
Add Fronts Support To `grid` API

### DIFF
--- a/apps-rendering/src/components/BodyImage/GalleryBodyImage.tsx
+++ b/apps-rendering/src/components/BodyImage/GalleryBodyImage.tsx
@@ -15,7 +15,7 @@ import { getDefaultImgStyles } from './BodyImage.defaults';
 import type { BodyImageProps } from './BodyImage.defaults';
 
 const figureStyles = css`
-	${grid.container}
+	${grid.container.article}
 	width: 100%;
 	margin: 0;
 

--- a/apps-rendering/src/components/Footer/GalleryFooter.tsx
+++ b/apps-rendering/src/components/Footer/GalleryFooter.tsx
@@ -13,7 +13,7 @@ import DefaultFooter, { defaultStyles } from './Footer.defaults';
 // ----- Component ----- //
 
 const styles = (format: ArticleFormat): SerializedStyles => css`
-	${grid.container}
+	${grid.container.article}
 	background-color: ${background.footer(format)};
 
 	${darkModeCss`

--- a/apps-rendering/src/components/Footer/ImmersiveFooter.tsx
+++ b/apps-rendering/src/components/Footer/ImmersiveFooter.tsx
@@ -14,7 +14,7 @@ import DefaultFooter, { defaultStyles } from './Footer.defaults';
 // ----- Component ----- //
 
 const styles = (format: ArticleFormat): SerializedStyles => css`
-	${grid.container}
+	${grid.container.article}
 	background-color: ${background.footer(format)};
 
 	${darkModeCss`

--- a/apps-rendering/src/components/Layout/GalleryLayout.tsx
+++ b/apps-rendering/src/components/Layout/GalleryLayout.tsx
@@ -24,7 +24,7 @@ import { darkModeCss } from 'styles';
 // ----- Component ----- //
 
 const headerStyles = (format: ArticleFormat): SerializedStyles => css`
-	${grid.container}
+	${grid.container.article}
 	background-color: ${background.articleContent(format)};
 	border-bottom: 1px solid ${border.galleryImage(format)};
 

--- a/apps-rendering/src/components/Layout/ImmersiveLayout.tsx
+++ b/apps-rendering/src/components/Layout/ImmersiveLayout.tsx
@@ -28,7 +28,7 @@ import { darkModeCss } from 'styles';
 // ----- Component ----- //
 
 const headerStyles = (format: ArticleFormat): SerializedStyles => css`
-	${grid.container}
+	${grid.container.article}
 
 	${darkModeCss`
 		background-color: ${background.articleContentDark(format)}
@@ -36,7 +36,7 @@ const headerStyles = (format: ArticleFormat): SerializedStyles => css`
 `;
 
 const mainContentStyles = (format: ArticleFormat): SerializedStyles => css`
-	${grid.container}
+	${grid.container.article}
 
 	${darkModeCss`
 		background-color: ${background.articleContentDark(format)}

--- a/apps-rendering/src/components/Layout/NewsletterSignUpLayout.tsx
+++ b/apps-rendering/src/components/Layout/NewsletterSignUpLayout.tsx
@@ -37,7 +37,7 @@ const backgroundStyles = (format: ArticleFormat): SerializedStyles => css`
 `;
 
 const gridContainerStyles = css`
-	${grid.container}
+	${grid.container.article}
 `;
 
 const imageRow = css`

--- a/apps-rendering/src/components/RelatedContent/GalleryRelatedContent.tsx
+++ b/apps-rendering/src/components/RelatedContent/GalleryRelatedContent.tsx
@@ -23,7 +23,7 @@ import {
 // ----- Component ----- //
 
 const styles = (format: ArticleFormat): SerializedStyles => css`
-	${grid.container}
+	${grid.container.article}
 	background-color: ${background.onwardContent(format)};
 
 	${darkModeCss`

--- a/apps-rendering/src/components/RelatedContent/ImmersiveRelatedContent.tsx
+++ b/apps-rendering/src/components/RelatedContent/ImmersiveRelatedContent.tsx
@@ -18,7 +18,7 @@ import DefaultRelatedContent, {
 // ----- Component ----- //
 
 const styles = (format: ArticleFormat): SerializedStyles => css`
-	${grid.container}
+	${grid.container.article}
 	background-color: ${background.onwardContent(format)};
 
 	${darkModeCss`

--- a/apps-rendering/src/components/Tags/GalleryTags.tsx
+++ b/apps-rendering/src/components/Tags/GalleryTags.tsx
@@ -14,7 +14,7 @@ import { defaultStyles, DefaultTags } from './Tags.defaults';
 // ----- Component ----- //
 
 const containerStyles = css`
-	${grid.container}
+	${grid.container.article}
 `;
 
 const leftColStyles = (format: ArticleFormat): SerializedStyles => css`

--- a/apps-rendering/src/grid/grid.ts
+++ b/apps-rendering/src/grid/grid.ts
@@ -156,7 +156,8 @@ const grid = {
 	 *
 	 * - **Centre** exists for all breakpoints
 	 * - **Left** exists from the `leftCol` breakpoint up
-	 * - **Right** exists from the `desktop` breakpoint up
+	 * - **Right** exists from the `desktop` breakpoint up for articles, and
+	 * `wide` for fronts
 	 * - **All** means take up the entire width of the viewport, "all" columns,
 	 * and exists for every breakpoint
 	 */

--- a/apps-rendering/src/grid/grid.ts
+++ b/apps-rendering/src/grid/grid.ts
@@ -22,18 +22,25 @@ const mobileColumns =
 	'[viewport-start] 0px [centre-column-start] repeat(4, 1fr) [centre-column-end] 0px [viewport-end]';
 const tabletColumns =
 	'[viewport-start] 1fr [centre-column-start] repeat(12, 40px) [centre-column-end] 1fr [viewport-end]';
-const desktopColumns =
+const articleDesktopColumns =
 	'[viewport-start] 1fr [centre-column-start] repeat(8, 60px) [centre-column-end right-column-start] repeat(4, 60px) [right-column-end] 1fr [viewport-end]';
-const leftColColumns =
+const frontsDesktopColumns =
+	'[viewport-start] 1fr [centre-column-start] repeat(12, 60px) [centre-column-end] 1fr [viewport-end]';
+const articleLeftColColumns =
 	'[viewport-start] 1fr [left-column-start] repeat(2, 60px) [left-column-end centre-column-start] repeat(8, 60px) [centre-column-end right-column-start] repeat(4, 60px) [right-column-end] 1fr [viewport-end]';
-const wideColumns =
+const frontsLeftColColumns =
+	'[viewport-start] 1fr [left-column-start] repeat(2, 60px) [left-column-end centre-column-start] repeat(12, 60px) [centre-column-end] 1fr [viewport-end]';
+const articleWideColumns =
 	'[viewport-start] 1fr [left-column-start] repeat(3, 60px) [left-column-end centre-column-start] repeat(8, 60px) [centre-column-end] 60px [right-column-start] repeat(4, 60px) [right-column-end] 1fr [viewport-end]';
+const frontsWideColumns =
+	'[viewport-start] 1fr [left-column-start] repeat(3, 60px) [left-column-end centre-column-start] repeat(12, 60px) [centre-column-end right-column-start] 60px [right-column-end] 1fr [viewport-end]';
+
 const mobileColumnGap = '12px';
 const columnGap = '20px';
 
 // ----- Grid Styles ----- //
 
-const container = `
+const articleContainer = `
     display: grid;
     grid-template-columns: ${mobileColumns};
     column-gap: ${mobileColumnGap};
@@ -47,15 +54,41 @@ const container = `
     }
 
     ${from.desktop} {
-        grid-template-columns: ${desktopColumns};
+        grid-template-columns: ${articleDesktopColumns};
     }
 
     ${from.leftCol} {
-        grid-template-columns: ${leftColColumns};
+        grid-template-columns: ${articleLeftColColumns};
     }
 
     ${from.wide} {
-        grid-template-columns: ${wideColumns};
+        grid-template-columns: ${articleWideColumns};
+    }
+`;
+
+const frontsContainer = `
+    display: grid;
+    grid-template-columns: ${mobileColumns};
+    column-gap: ${mobileColumnGap};
+
+    ${from.mobileLandscape} {
+        column-gap: ${columnGap};
+    }
+
+    ${from.tablet} {
+        grid-template-columns: ${tabletColumns};
+    }
+
+    ${from.desktop} {
+        grid-template-columns: ${frontsDesktopColumns};
+    }
+
+    ${from.leftCol} {
+        grid-template-columns: ${frontsLeftColColumns};
+    }
+
+    ${from.wide} {
+        grid-template-columns: ${frontsWideColumns};
     }
 `;
 
@@ -108,12 +141,15 @@ const grid = {
 	 *
 	 * @example
 	 * const Component = () =>
-	 *   <div css={css`${grid.container}`}>
+	 *   <div css={css`${grid.container.article}`}>
 	 *     <h1 css={css`grid-row: 1;`}>Headline</h1>
 	 *     <p css={css`grid-row: 2;`}>Standfirst</p>
 	 *   </div>
 	 */
-	container,
+	container: {
+		article: articleContainer,
+		fronts: frontsContainer,
+	},
 	/**
 	 * Place the element into one of the common Guardian layout columns. The
 	 * breakpoints at which they're available are as follows:
@@ -137,7 +173,7 @@ const grid = {
 		left: between('left-column-start', 'left-column-end'),
 		/**
 		 * Place the element into the right column. Available for `desktop`
-		 * and above breakpoints.
+		 * and above breakpoints for articles, and `wide` breakpoint for fronts.
 		 */
 		right: between('right-column-start', 'right-column-end'),
 		/**


### PR DESCRIPTION
## Why?

The three-column layout on fronts is different to that on articles. While the behaviour of the left column is the same, the centre and right columns are different. On articles a right column appears from `desktop`; it's several grid columns wide with a one-column space between it and the centre column. By contrast, on fronts the right column only appears for `wide`; it's only a single grid column in width and there's no space between it and the centre column.

### API Changes

This PR introduces a small change to the way `container` in the grid API is used. When setting up the container you now specify whether you'd like the article variant or the fronts variant, with `grid.container.article` and `grid.container.fronts`. There are no other changes to the API, and any existing usages of `grid.container` will work as before if updated to `grid.container.article`. When using `grid.container.fronts`, the API will automatically make use of the new fronts columns. For example, `grid.column.right` will only apply from `wide`, `grid.column.centre` will use the larger fronts centre column, and lines in `span` and `between` will refer to fronts lines positions rather than article ones.

### Before

```ts
const styles = css`
    ${grid.container}
`;
```

### After

```ts
const styles = css`
    ${grid.container.article}
`;
```

```ts
const styles = css`
    ${grid.container.fronts}
`;
```

## Changes

- Created a new fronts grid container with fronts-specific columns
- Updated `grid.container` to have two variants: `grid.container.article` and `grid.container.fronts`
- Updated docs
- Updated existing usages of `container`
