### PR TITLE
Remove `phar.gu-web.net` prefetch

### DIFF
--- a/dotcom-rendering/src/web/server/pageTemplate.ts
+++ b/dotcom-rendering/src/web/server/pageTemplate.ts
@@ -106,7 +106,6 @@ export const pageTemplate = ({
 		`https://api.nextgen.guardianapps.co.uk`,
 		`https://hits-secure.theguardian.com`,
 		`https://interactive.guim.co.uk`,
-		`https://phar.gu-web.net`,
 		`https://static.theguardian.com`,
 		`https://support.theguardian.com`,
 	];


### PR DESCRIPTION
## What does this change?

Remove `phar.gu-web.net` prefetch

Looks like the backed infra was removed in this PR chain: https://github.com/guardian/frontend/pull/24205

## Why?

The domain no longer resolves

Will need the core team to verify if `beaconURL` config is still required.

## Screenshots

<img width="398" alt="Screenshot 2023-02-08 at 13 00 28" src="https://user-images.githubusercontent.com/7014230/217536680-7b5a04bb-25aa-440b-8525-f7a85f5831ad.png">

