### PR TITLE
Special Report Alt: Dark Mode Background

### DIFF
--- a/apps-rendering/src/components/Avatar/index.tsx
+++ b/apps-rendering/src/components/Avatar/index.tsx
@@ -11,6 +11,7 @@ import type { Contributor } from 'contributor';
 import { pipe } from 'lib';
 import { background } from 'palette';
 import type { FC, ReactElement } from 'react';
+import { darkModeCss } from 'styles';
 
 // ----- Setup ----- //
 
@@ -30,6 +31,10 @@ const styles = (format: ArticleFormat): SerializedStyles => css`
 	background: ${background.avatar(format)};
 	margin-right: ${remSpace[3]};
 	margin-top: ${remSpace[1]};
+
+	${darkModeCss`
+		background-color: ${background.avatarDark(format)};
+	`}
 `;
 
 const Avatar: FC<Props> = ({ contributors, ...format }: Props) => {

--- a/apps-rendering/src/components/LiveBlockContainer/index.tsx
+++ b/apps-rendering/src/components/LiveBlockContainer/index.tsx
@@ -84,6 +84,10 @@ const BlockByline: FC<{
 							height: 2.25rem;
 							width: 2.25rem;
 							background-color: ${background.avatar(format)};
+
+							${darkModeCss`
+								background-color: ${background.avatarDark(format)};
+							`}
 						`}
 					/>
 				</div>

--- a/apps-rendering/src/palette/background.ts
+++ b/apps-rendering/src/palette/background.ts
@@ -137,7 +137,12 @@ const headlineDark = ({ design, display, theme }: ArticleFormat): Colour => {
 			}
 		}
 		case ArticleDesign.Interview:
-			return neutral[20];
+			switch (theme) {
+				case ArticleSpecial.SpecialReportAlt:
+					return neutral[7];
+				default:
+					return neutral[20];
+			}
 		case ArticleDesign.Standard:
 		case ArticleDesign.Review:
 		case ArticleDesign.Explainer:
@@ -485,6 +490,33 @@ const avatar = (format: ArticleFormat): string => {
 	}
 };
 
+const avatarDark = ({ design, theme }: ArticleFormat): Colour => {
+	switch (design) {
+		case ArticleDesign.Standard:
+		case ArticleDesign.Review:
+		case ArticleDesign.Explainer:
+		case ArticleDesign.Feature:
+		case ArticleDesign.Interview:
+		case ArticleDesign.Interactive:
+		case ArticleDesign.PhotoEssay:
+		case ArticleDesign.FullPageInteractive:
+		case ArticleDesign.NewsletterSignup:
+		case ArticleDesign.Comment:
+		case ArticleDesign.Letter:
+		case ArticleDesign.Editorial:
+		case ArticleDesign.Analysis: {
+			switch (theme) {
+				case ArticleSpecial.SpecialReportAlt:
+					return neutral[46];
+				default:
+					return neutral[20];
+			}
+		}
+		default:
+			return neutral[20];
+	}
+}
+
 const relatedCardBylineImage = (format: ArticleFormat): string => {
 	switch (format.theme) {
 		case ArticlePillar.Opinion:
@@ -800,6 +832,7 @@ const background = {
 	analysisContrastColour,
 	analysisContrastHoverColour,
 	avatar,
+	avatarDark,
 	bullet,
 	bulletDark,
 	footer,


### PR DESCRIPTION
## Why?

The existing background colours of interview headlines and avatars didn't sit well on the new special report alt background in dark mode. This updates those colours; see the screenshots for a comparison.

## Screenshots

| Before | After |
| - | - |
| ![background-before] | ![background-after] |

[background-before]: https://user-images.githubusercontent.com/53781962/217613282-7a16ef31-653c-4071-9485-a1f702abceb7.jpg
[background-after]: https://user-images.githubusercontent.com/53781962/217613298-e35e1337-c3c7-45b5-b0f2-2dd33836e1df.jpg
