### PR TITLE
refactor: AMP real time config

### DIFF
--- a/dotcom-rendering/src/amp/components/Ad.tsx
+++ b/dotcom-rendering/src/amp/components/Ad.tsx
@@ -78,7 +78,6 @@ export const Ad = ({
 	// Secondary ad sizes
 	const multiSizes = adSizes.map((e) => `${e.width}x${e.height}`).join(',');
 
-	// TODO compute RTC directly in here!
 	const rtcConfig = realTimeConfig(
 		usePrebid,
 		usePermutive,

--- a/dotcom-rendering/src/amp/components/Ad.tsx
+++ b/dotcom-rendering/src/amp/components/Ad.tsx
@@ -52,8 +52,9 @@ const pubmaticRealTimeConfig = (
 	usePrebid: boolean,
 	usePermutive: boolean,
 	useAmazon: boolean,
-	{ profileId, pubId }: RTCParameters,
+	adType: AdType,
 ): string => {
+	const { profileId, pubId } = getRTCParameters(adType);
 	const pubmaticConfig = {
 		openwrap: {
 			PROFILE_ID: profileId,
@@ -107,7 +108,7 @@ export const Ad = ({
 		usePrebid,
 		usePermutive,
 		useAmazon,
-		getRTCParameters(adType),
+		adType,
 	);
 
 	return (

--- a/dotcom-rendering/src/amp/components/Ad.tsx
+++ b/dotcom-rendering/src/amp/components/Ad.tsx
@@ -1,11 +1,7 @@
 import type { CommercialProperties } from '../../types/commercial';
 import type { EditionId } from '../../web/lib/edition';
 import { adJson, stringify } from '../lib/ad-json';
-import {
-	AdType,
-	getRTCParameters,
-	RTCParameters,
-} from '../lib/real-time-config';
+import type { AdType } from '../lib/real-time-config';
 import { realTimeConfig } from '../lib/real-time-config';
 
 // Largest size first
@@ -48,27 +44,6 @@ const mapAdTargeting = (adTargeting: AdTargeting): AdTargetParam[] => {
 	return adTargetingMapped;
 };
 
-const pubmaticRealTimeConfig = (
-	usePrebid: boolean,
-	usePermutive: boolean,
-	useAmazon: boolean,
-	adType: AdType,
-): string => {
-	const { profileId, pubId } = getRTCParameters(adType);
-	const pubmaticConfig = {
-		openwrap: {
-			PROFILE_ID: profileId,
-			PUB_ID: pubId,
-		},
-	};
-
-	return realTimeConfig({
-		vendors: usePrebid ? pubmaticConfig : {},
-		usePermutive,
-		useAmazon,
-	});
-};
-
 interface CommercialConfig {
 	usePrebid: boolean;
 	usePermutive: boolean;
@@ -104,7 +79,7 @@ export const Ad = ({
 	const multiSizes = adSizes.map((e) => `${e.width}x${e.height}`).join(',');
 
 	// TODO compute RTC directly in here!
-	const rtcConfig = pubmaticRealTimeConfig(
+	const rtcConfig = realTimeConfig(
 		usePrebid,
 		usePermutive,
 		useAmazon,

--- a/dotcom-rendering/src/amp/components/Ad.tsx
+++ b/dotcom-rendering/src/amp/components/Ad.tsx
@@ -65,7 +65,6 @@ const pubmaticRealTimeConfig = (
 		vendors: usePrebid ? pubmaticConfig : {},
 		usePermutive,
 		useAmazon,
-		timeoutMillis: 1000,
 	});
 };
 

--- a/dotcom-rendering/src/amp/components/Ad.tsx
+++ b/dotcom-rendering/src/amp/components/Ad.tsx
@@ -1,7 +1,11 @@
 import type { CommercialProperties } from '../../types/commercial';
 import type { EditionId } from '../../web/lib/edition';
 import { adJson, stringify } from '../lib/ad-json';
-import type { RTCParameters } from '../lib/real-time-config';
+import {
+	AdType,
+	getRTCParameters,
+	RTCParameters,
+} from '../lib/real-time-config';
 import { realTimeConfig } from '../lib/real-time-config';
 
 // Largest size first
@@ -81,31 +85,30 @@ export interface BaseAdProps {
 }
 
 interface AdProps extends BaseAdProps {
-	isSticky?: boolean;
-	rtcParameters: RTCParameters;
+	adType: AdType;
 }
 
 export const Ad = ({
-	isSticky = false,
 	editionId,
 	section,
 	contentType,
 	commercialProperties,
 	adTargeting,
 	config: { useAmazon, usePrebid, usePermutive },
-	rtcParameters,
+	adType,
 }: AdProps) => {
-	const adSizes = isSticky ? stickySizes : inlineSizes;
+	const adSizes = adType.isSticky ? stickySizes : inlineSizes;
 	// Set Primary ad size as first element (should be the largest)
 	const [{ width, height }] = adSizes;
 	// Secondary ad sizes
 	const multiSizes = adSizes.map((e) => `${e.width}x${e.height}`).join(',');
 
+	// TODO compute RTC directly in here!
 	const rtcConfig = pubmaticRealTimeConfig(
 		usePrebid,
 		usePermutive,
 		useAmazon,
-		rtcParameters,
+		getRTCParameters(adType),
 	);
 
 	return (

--- a/dotcom-rendering/src/amp/components/RegionalAd.tsx
+++ b/dotcom-rendering/src/amp/components/RegionalAd.tsx
@@ -1,5 +1,4 @@
 import { ClassNames } from '@emotion/react';
-import { getRTCParameters } from '../lib/real-time-config';
 import { adRegions, regionClasses } from '../lib/region-classes';
 import type { BaseAdProps } from './Ad';
 import { Ad } from './Ad';
@@ -31,14 +30,13 @@ export const RegionalAd = ({
 						)}
 					>
 						<Ad
-							isSticky={false}
 							editionId={editionId}
 							section={section}
 							contentType={contentType}
 							commercialProperties={commercialProperties}
 							config={config}
-							rtcParameters={getRTCParameters({ adRegion })}
 							adTargeting={adTargeting}
+							adType={{ adRegion }}
 						/>
 					</div>
 				)}

--- a/dotcom-rendering/src/amp/components/StickyAd.tsx
+++ b/dotcom-rendering/src/amp/components/StickyAd.tsx
@@ -1,5 +1,4 @@
 import { text, textSans } from '@guardian/source-foundations';
-import { getRTCParameters } from '../lib/real-time-config';
 import type { BaseAdProps } from './Ad';
 import { Ad } from './Ad';
 
@@ -28,14 +27,13 @@ export const StickyAd = ({
 	return (
 		<amp-sticky-ad layout="nodisplay">
 			<Ad
-				isSticky={true}
 				editionId={editionId}
 				section={section}
 				contentType={contentType}
 				commercialProperties={commercialProperties}
 				config={config}
 				adTargeting={adTargeting}
-				rtcParameters={getRTCParameters({ isSticky: true })}
+				adType={{ isSticky: true }}
 			/>
 		</amp-sticky-ad>
 	);

--- a/dotcom-rendering/src/amp/lib/real-time-config.ts
+++ b/dotcom-rendering/src/amp/lib/real-time-config.ts
@@ -5,7 +5,7 @@ import type { AdRegion } from './region-classes';
  *
  * These values determine the computed RTC parameters
  */
-type AdType =
+export type AdType =
 	| { isSticky: true }
 	| {
 			isSticky?: false;

--- a/dotcom-rendering/src/amp/lib/real-time-config.ts
+++ b/dotcom-rendering/src/amp/lib/real-time-config.ts
@@ -18,32 +18,32 @@ export type AdType =
  * These can be computed from the Config type above
  */
 export type RTCParameters = {
-	profileId: string;
-	pubId: string;
+	PROFILE_ID: string;
+	PUB_ID: string;
 };
 
 /**
  * Determine the pub id and profile id required by Pubmatic to construct an RTC vendor
  *
  */
-export const getRTCParameters = (adType: AdType): RTCParameters => {
+export const pubmaticRtcParameters = (adType: AdType): RTCParameters => {
 	if (
 		adType.isSticky ||
 		adType.adRegion === 'UK' ||
 		adType.adRegion === 'INT'
 	) {
 		return {
-			profileId: '6611',
-			pubId: '157207',
+			PROFILE_ID: '6611',
+			PUB_ID: '157207',
 		};
 	}
 
 	if (adType.adRegion === 'AU') {
-		return { profileId: '6697', pubId: '157203' };
+		return { PROFILE_ID: '6697', PUB_ID: '157203' };
 	}
 
 	// ad region is US
-	return { profileId: '6696', pubId: '157206' };
+	return { PROFILE_ID: '6696', PUB_ID: '157206' };
 };
 
 const permutiveURL = 'amp-script:permutiveCachedTargeting.ct';
@@ -52,31 +52,24 @@ const amazonConfig = {
 	aps: { PUB_ID: '3722', PARAMS: { amp: '1' } },
 };
 
-const notUndefined = <T>(x: T | undefined): x is T => x !== undefined;
-
 /**
  * Build a generic Real Time Config string from a possible URL,
  * optional vendors and whether to enable Permutive and Amazon
  */
-export const realTimeConfig = ({
-	vendors = {},
-	url = undefined,
-	usePermutive = false,
-	useAmazon = false,
-}: {
-	vendors?: Record<string, unknown>;
-	url?: string;
-	usePermutive?: boolean;
-	useAmazon?: boolean;
-}): string => {
-	const urls = [url, usePermutive ? permutiveURL : undefined].filter(
-		notUndefined,
-	);
+export const realTimeConfig = (
+	usePrebid: boolean,
+	usePermutive: boolean,
+	useAmazon: boolean,
+	adType: AdType,
+): string => {
+	const pubmaticConfig = {
+		openwrap: pubmaticRtcParameters(adType),
+	};
 
 	const data = {
-		urls,
+		urls: usePermutive ? [permutiveURL] : [],
 		vendors: {
-			...vendors,
+			...(usePrebid ? pubmaticConfig : {}),
 			...(useAmazon ? amazonConfig : {}),
 		},
 		timeoutMillis: 1000,

--- a/dotcom-rendering/src/amp/lib/real-time-config.ts
+++ b/dotcom-rendering/src/amp/lib/real-time-config.ts
@@ -63,19 +63,15 @@ export const realTimeConfig = ({
 	url = undefined,
 	usePermutive = false,
 	useAmazon = false,
-	timeoutMillis,
 }: {
 	vendors?: Record<string, unknown>;
 	url?: string;
 	usePermutive?: boolean;
 	useAmazon?: boolean;
-	timeoutMillis?: number;
 }): string => {
 	const urls = [url, usePermutive ? permutiveURL : undefined].filter(
 		notUndefined,
 	);
-
-	const options = timeoutMillis ? { timeoutMillis } : {};
 
 	const data = {
 		urls,
@@ -83,7 +79,7 @@ export const realTimeConfig = ({
 			...vendors,
 			...(useAmazon ? amazonConfig : {}),
 		},
-		...options,
+		timeoutMillis: 1000,
 	};
 	return JSON.stringify(data);
 };


### PR DESCRIPTION
## What does this change?

This is a refactor of how [AMP RTC](https://github.com/ampproject/amphtml/blob/main/extensions/amp-a4a/rtc-documentation.md) (real time config) parameters are computed for ads.

This shouldn't have any effect on the resulting ads (note the tests in `RegionalAd.test.tsx` are unaffected).

Broadly, we now drill all of the props required to build the RTC object down into the ad component, and compute all of the necessary parameters at the point we build the config.

## Why?

There was some unnecessary indirection here, that is left over from the fact we used to select between two different Prebid servers (see https://github.com/guardian/dotcom-rendering/pull/4207). Removing this now will simplify later work, where'd we'd like to run against multiple Prebid servers simultaneously.