### PR TITLE
feat: add optional contacts field to callout model

### DIFF
--- a/dotcom-rendering/src/model/article-schema.json
+++ b/dotcom-rendering/src/model/article-schema.json
@@ -1212,6 +1212,12 @@
                 },
                 "isNonCollapsible": {
                     "type": "boolean"
+                },
+                "contacts": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Contact"
+                    }
                 }
             },
             "required": [
@@ -1227,6 +1233,28 @@
                 "isNonCollapsible",
                 "tagName",
                 "title"
+            ]
+        },
+        "Contact": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "value": {
+                    "type": "string"
+                },
+                "urlPrefix": {
+                    "type": "string"
+                },
+                "guidance": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "name",
+                "urlPrefix",
+                "value"
             ]
         },
         "ChartAtomBlockElement": {

--- a/dotcom-rendering/src/types/content.ts
+++ b/dotcom-rendering/src/types/content.ts
@@ -78,6 +78,7 @@ export interface CalloutBlockElementV2 {
 	formFields: CampaignFieldType[];
 	role?: RoleType;
 	isNonCollapsible: boolean;
+	contacts?: Contact[];
 }
 
 interface ChartAtomBlockElement {
@@ -730,6 +731,13 @@ interface CampaignField {
 	textSize?: number;
 	hideLabel: boolean;
 	label: string;
+}
+
+interface Contact {
+	name: string;
+	value: string;
+	urlPrefix: string;
+	guidance?: string;
 }
 
 export interface CampaignFieldText extends CampaignField {


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Extends the callout model to include the new optional contacts array. 

## Why?
To provide editorial with more control, callouts has an optional message us tab that is driven by an optional contacts array. This change was made in Frontend [here](https://github.com/guardian/frontend/pull/25889) and this is the accompanying PR to expect the new field in DCR.

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->


<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
