### PR TITLE
Update @guardian/ab-core to v3.1.0

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -63,7 +63,7 @@
 		"@emotion/cache": "^11.4.0",
 		"@emotion/react": "^11.4.1",
 		"@emotion/server": "^11.4.0",
-		"@guardian/ab-core": "^2.0.0",
+		"@guardian/ab-core": "^3.1.0",
 		"@guardian/atoms-rendering": "^25.1.5",
 		"@guardian/braze-components": "^9.0.2",
 		"@guardian/browserslist-config": "^2.0.3",

--- a/dotcom-rendering/src/web/components/SetABTests.importable.tsx
+++ b/dotcom-rendering/src/web/components/SetABTests.importable.tsx
@@ -1,5 +1,5 @@
 import { AB } from '@guardian/ab-core';
-import type { CoreAPIConfig } from '@guardian/ab-core/dist/types';
+import type { CoreAPIConfig } from '@guardian/ab-core';
 import { getCookie, log } from '@guardian/libs';
 import type { ABTestSwitches } from '../../model/enhance-switches';
 import { getOphanRecordFunction } from '../browser/ophan/ophan';

--- a/dotcom-rendering/src/web/experiments/lib/ab-participations.ts
+++ b/dotcom-rendering/src/web/experiments/lib/ab-participations.ts
@@ -1,4 +1,4 @@
-import type { Participations, Runnable } from '@guardian/ab-core';
+import type { ABTest, Participations, Runnable } from '@guardian/ab-core';
 import { isObject, isString } from '@guardian/libs';
 
 const isParticipations = (
@@ -11,7 +11,7 @@ const isParticipations = (
 	);
 
 const runnableTestsToParticipations = (
-	runnableTests: readonly Runnable[],
+	runnableTests: readonly Runnable<ABTest>[],
 ): Participations =>
 	runnableTests.reduce(
 		(participations: Participations, { id: testId, variantToRun }) => ({

--- a/dotcom-rendering/src/web/lib/useSignInGateSelector.ts
+++ b/dotcom-rendering/src/web/lib/useSignInGateSelector.ts
@@ -1,4 +1,4 @@
-import type { Runnable } from '@guardian/ab-core';
+import type { ABTest, Runnable } from '@guardian/ab-core';
 import {
 	signInGateTests,
 	signInGateTestVariantToGateMapping,
@@ -20,7 +20,7 @@ export const useSignInGateSelector = ():
 	const ab = useAB()?.api;
 	if (!ab) return undefined;
 
-	const test: Runnable | null = ab.firstRunnableTest(signInGateTests);
+	const test: Runnable<ABTest> | null = ab.firstRunnableTest(signInGateTests);
 
 	if (!test) {
 		return [null, null];

--- a/yarn.lock
+++ b/yarn.lock
@@ -2225,10 +2225,10 @@
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"
   integrity sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==
 
-"@guardian/ab-core@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@guardian/ab-core/-/ab-core-2.0.0.tgz#d8a9408d5a66ff1f8c684ed458c99517bbee15b1"
-  integrity sha512-E5p6l0l37hY0GNFaZmA5/22TlVuavzlMHR3OeweD5eDcY2gB3nGgzPK/d3M67dkbDAJkGjB4a0W84Z5N2YScvQ==
+"@guardian/ab-core@^2.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@guardian/ab-core/-/ab-core-3.1.0.tgz#8974bc0a0a25f6f47d946252cc410657801372b2"
+  integrity sha512-DGyDH1NrQEkyudUN2HlIb+BuEQNL4ftSG4DvDd+SPhcqCKH/41k2JMnchVM4KTO6ctHTw7D3AD9POhr+3Xm/YA==
 
 "@guardian/atoms-rendering@^25.1.5":
   version "25.1.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2225,7 +2225,7 @@
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"
   integrity sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==
 
-"@guardian/ab-core@^2.1.0":
+"@guardian/ab-core@^3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@guardian/ab-core/-/ab-core-3.1.0.tgz#8974bc0a0a25f6f47d946252cc410657801372b2"
   integrity sha512-DGyDH1NrQEkyudUN2HlIb+BuEQNL4ftSG4DvDd+SPhcqCKH/41k2JMnchVM4KTO6ctHTw7D3AD9POhr+3Xm/YA==


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Updates @guardian/ab-core to v3.1.0 and fixes some existing errors.

## Why?

We were seeing related TS errors.

