### PR TITLE
Rollout callouts on DCR and AR

### DIFF
--- a/apps-rendering/src/bodyElement.ts
+++ b/apps-rendering/src/bodyElement.ts
@@ -13,7 +13,7 @@ import type { Option } from '@guardian/types';
 import { fromNullable } from '@guardian/types';
 import { parseAtom } from 'atoms';
 import { ElementKind } from 'bodyElementKind';
-// import { getCallout } from 'campaign';
+import { getCallout } from 'campaign';
 import { formatDate } from 'date';
 import { parseAudio, parseGeneric, parseInstagram, parseVideo } from 'embed';
 import type { Embed } from 'embed';
@@ -346,46 +346,41 @@ const parse =
 			}
 
 			case ElementType.CALLOUT: {
-				/* Temporarily remove the callout implementation.
-				    This will be re-implemented after the A/B test in DCR is complete */
-				return Result.err(
-					'Callouts have not been implemented in Apps Rendering',
-				);
-				// const {
-				// 	campaignId: campaignId,
-				// 	isNonCollapsible: isNonCollapsible,
-				// } = element.calloutTypeData ?? {};
-				// if (
-				// 	campaignId === undefined ||
-				// 	campaignId === '' ||
-				// 	isNonCollapsible === undefined
-				// ) {
-				// 	return Result.err(
-				// 		'No valid campaignId or isNonCollapsible field on calloutTypeData',
-				// 	);
-				// }
+				const {
+					campaignId: campaignId,
+					isNonCollapsible: isNonCollapsible,
+				} = element.calloutTypeData ?? {};
+				if (
+					campaignId === undefined ||
+					campaignId === '' ||
+					isNonCollapsible === undefined
+				) {
+					return Result.err(
+						'No valid campaignId or isNonCollapsible field on calloutTypeData',
+					);
+				}
 
-				// return getCallout(campaignId, campaigns)
-				// 	.map(({ callout, name, activeUntil }) =>
-				// 		Result.ok<string, Callout>({
-				// 			kind: ElementKind.Callout,
-				// 			isNonCollapsible,
-				// 			heading: callout.callout,
-				// 			formFields: callout.formFields,
-				// 			formId: callout.formId,
-				// 			description: context.docParser(
-				// 				callout.description ?? '',
-				// 			),
-				// 			name: name,
-				// 			activeUntil: activeUntil,
-				// 			contacts: callout.contacts,
-				// 		}),
-				// 	)
-				// 	.withDefault(
-				// 		Result.err<string, Callout>(
-				// 			'This piece contains a callout but no matching campaign',
-				// 		),
-				// );
+				return getCallout(campaignId, campaigns)
+					.map(({ callout, name, activeUntil }) =>
+						Result.ok<string, Callout>({
+							kind: ElementKind.Callout,
+							isNonCollapsible,
+							heading: callout.callout,
+							formFields: callout.formFields,
+							formId: callout.formId,
+							description: context.docParser(
+								callout.description ?? '',
+							),
+							name: name,
+							activeUntil: activeUntil,
+							contacts: callout.contacts,
+						}),
+					)
+					.withDefault(
+						Result.err<string, Callout>(
+							'This piece contains a callout but no matching campaign',
+						),
+					);
 			}
 
 			case ElementType.EMBED: {

--- a/dotcom-rendering/src/web/lib/renderElement.tsx
+++ b/dotcom-rendering/src/web/lib/renderElement.tsx
@@ -184,10 +184,7 @@ export const renderElement = ({
 				</Island>
 			);
 		case 'model.dotcomrendering.pageElements.CalloutBlockElementV2':
-			if (
-				switches.callouts &&
-				abTests?.calloutElementsVariant === 'variant'
-			) {
+			if (switches.callouts) {
 				return (
 					<Island deferUntil="visible">
 						<CalloutBlockComponent callout={element} />


### PR DESCRIPTION
# DO NOT MERGE UNTIL 13/02/23

<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR turns on the new callout across DCR and AR. To do this, it removes the temporary callout AB test from DCR so this is only controlled by a switch. It also uncomments the relevant code in AR so that we render callouts on AR articles. 
## Why?

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

| Before AR     | After AR   |
|-------------|------------|
| ![before2][] | ![after2][] |


[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png


<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
