### PR TITLE
Drop `?url=` query in favour of paths

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -23,8 +23,8 @@ jobs:
       fail-fast: false
       matrix:
         group:
-          - 'http://localhost:9000/Article?url=https://www.theguardian.com/commentisfree/2020/feb/08/hungary-now-for-the-new-right-what-venezuela-once-was-for-the-left#noads'
-          - 'http://localhost:9000/Front?url=https://www.theguardian.com/uk'
+          - 'http://localhost:9000/Article/https://www.theguardian.com/commentisfree/2020/feb/08/hungary-now-for-the-new-right-what-venezuela-once-was-for-the-left#noads'
+          - 'http://localhost:9000/Front/https://www.theguardian.com/uk'
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/dotcom-rendering/README.md
+++ b/dotcom-rendering/README.md
@@ -58,7 +58,7 @@ $ make dev
 
 Visit the [root path of the dev server](http://localhost:3030) for some example URLs to visit.
 
-You can render a specific article by [specifying the production URL in the query string](http://localhost:3030/Article?url=https://www.theguardian.com/sport/2019/jul/28/tour-de-france-key-moments-egan-bernal-yellow-jersey).
+You can render a specific article by [specifying the production URL in the query string](http://localhost:3030/Article/https://www.theguardian.com/sport/2019/jul/28/tour-de-france-key-moments-egan-bernal-yellow-jersey).
 
 You can view the JSON representation of an article, as per the model sent to the renderer on the server, by going to
 

--- a/dotcom-rendering/cypress/e2e/parallel-1/article.e2e.cy.js
+++ b/dotcom-rendering/cypress/e2e/parallel-1/article.e2e.cy.js
@@ -18,7 +18,7 @@ describe('E2E Page rendering', function () {
 					'ab-CuratedContainerTest2': 'control',
 				},
 			);
-			cy.visit(`/Article?url=${url}`);
+			cy.visit(`/Article/${url}`);
 			const roughLoadPositionOfMostView = 1400;
 			cy.scrollTo(0, roughLoadPositionOfMostView, { duration: 500 });
 			cy.contains('Lifestyle');
@@ -85,7 +85,7 @@ describe('E2E Page rendering', function () {
 			});
 
 			cy.visit(
-				'Article?url=https://www.theguardian.com/sport/blog/2015/dec/02/the-joy-of-six-sports-radio-documentaries',
+				'/Article/https://www.theguardian.com/sport/blog/2015/dec/02/the-joy-of-six-sports-radio-documentaries',
 			);
 
 			cy.get('gu-island[name=MostViewedFooterData]', { timeout: 30000 })
@@ -111,7 +111,7 @@ describe('E2E Page rendering', function () {
 			});
 
 			cy.visit(
-				'Article?url=https://www.theguardian.com/sport/blog/2015/dec/02/the-joy-of-six-sports-radio-documentaries',
+				'/Article/https://www.theguardian.com/sport/blog/2015/dec/02/the-joy-of-six-sports-radio-documentaries',
 			);
 
 			cy.get('gu-island[name=MostViewedFooterData]', { timeout: 30000 })
@@ -136,7 +136,7 @@ describe('E2E Page rendering', function () {
 				// Prevent the Privacy consent banner from obscuring snapshots
 				cy.setCookie('GU_TK', 'true');
 
-				cy.visit(`/AMPArticle?url=${url}`);
+				cy.visit(`/AMPArticle/${url}`);
 				cy.contains('Opinion');
 			});
 		});

--- a/dotcom-rendering/cypress/e2e/parallel-1/article.elements.cy.js
+++ b/dotcom-rendering/cypress/e2e/parallel-1/article.elements.cy.js
@@ -27,7 +27,7 @@ describe('Elements', function () {
 
 		it('should render the corona interactive atom embed', function () {
 			cy.visit(
-				'AMPArticle?url=https://www.theguardian.com/world/2020/apr/24/new-mother-dies-of-coronavirus-six-days-after-giving-birth',
+				'/AMPArticle/https://www.theguardian.com/world/2020/apr/24/new-mother-dies-of-coronavirus-six-days-after-giving-birth',
 			);
 
 			getAmpIframeBody('amp-iframe[data-cy="atom-embed-url"] > iframe', {
@@ -37,7 +37,7 @@ describe('Elements', function () {
 
 		it('should render the counted interactive embed', function () {
 			cy.visit(
-				'AMPArticle?url=https://www.theguardian.com/us-news/2015/nov/05/police-tasers-deaths-the-counted',
+				'/AMPArticle/https://www.theguardian.com/us-news/2015/nov/05/police-tasers-deaths-the-counted',
 			);
 
 			const ampIframeSelector =
@@ -61,7 +61,7 @@ describe('Elements', function () {
 			let hasElementTooWide = false;
 
 			cy.visit(
-				'Article?url=https://www.theguardian.com/politics/2022/jan/21/blackmail-allegations-need-to-be-investigated-says-kwasi-kwarteng',
+				'/Article/https://www.theguardian.com/politics/2022/jan/21/blackmail-allegations-need-to-be-investigated-says-kwasi-kwarteng',
 			);
 
 			const pageHasXOverflow = (docWidth) => {
@@ -105,7 +105,7 @@ describe('Elements', function () {
 			};
 
 			cy.visit(
-				'Article?url=https://www.theguardian.com/sport/blog/2015/dec/02/the-joy-of-six-sports-radio-documentaries',
+				'/Article/https://www.theguardian.com/sport/blog/2015/dec/02/the-joy-of-six-sports-radio-documentaries',
 			);
 
 			cy.scrollTo(0, 4500);
@@ -141,7 +141,7 @@ describe('Elements', function () {
 			};
 
 			cy.visit(
-				'Article?url=https://www.theguardian.com/sport/2019/nov/15/forget-a-super-bowl-slump-the-la-rams-have-a-jared-goff-problem',
+				'/Article/https://www.theguardian.com/sport/2019/nov/15/forget-a-super-bowl-slump-the-la-rams-have-a-jared-goff-problem',
 			);
 
 			getIframeBody().contains('The Rams’ dead cap numbers for 2020');
@@ -174,7 +174,7 @@ describe('Elements', function () {
 			};
 
 			cy.visit(
-				'Article?url=https://www.theguardian.com/us-news/2017/jan/17/donald-trump-america-great-again-northampton-county-pennsylvania',
+				'/Article/https://www.theguardian.com/us-news/2017/jan/17/donald-trump-america-great-again-northampton-county-pennsylvania',
 			);
 			getIframeBody().contains('Switching parties');
 		});
@@ -188,7 +188,7 @@ describe('Elements', function () {
 					.then(cy.wrap);
 			};
 			cy.visit(
-				'Article?url=https://www.theguardian.com/music/2020/jan/31/elon-musk-edm-artist-first-track-dont-doubt-ur-vibe',
+				'/Article/https://www.theguardian.com/music/2020/jan/31/elon-musk-edm-artist-first-track-dont-doubt-ur-vibe',
 			);
 
 			getIframeBody();
@@ -202,7 +202,7 @@ describe('Elements', function () {
 					.then(cy.wrap);
 			};
 			cy.visit(
-				'Article?url=https://www.theguardian.com/football/2020/jun/10/premier-league-restart-preview-no-5-burnley',
+				'/Article/https://www.theguardian.com/football/2020/jun/10/premier-league-restart-preview-no-5-burnley',
 			);
 
 			getBody().contains('Liverpool');
@@ -216,7 +216,7 @@ describe('Elements', function () {
 					.then(cy.wrap);
 			};
 			cy.visit(
-				'Article?url=https://www.theguardian.com/music/2020/jun/15/pet-shop-boys-where-to-start-in-their-back-catalogue',
+				'/Article/https://www.theguardian.com/music/2020/jun/15/pet-shop-boys-where-to-start-in-their-back-catalogue',
 			);
 
 			getBody().contains('affiliate links');

--- a/dotcom-rendering/cypress/e2e/parallel-1/sign-in-gate.cy.js
+++ b/dotcom-rendering/cypress/e2e/parallel-1/sign-in-gate.cy.js
@@ -35,7 +35,7 @@ describe('Sign In Gate Tests', function () {
 	const visitArticle = (
 		url = 'https://www.theguardian.com/games/2018/aug/23/nier-automata-yoko-taro-interview',
 	) => {
-		cy.visit(`/Article?url=${url}`);
+		cy.visit(`/Article/${url}`);
 	};
 
 	// as the sign in gate is lazy loaded, we need to scroll to the rough position where it
@@ -135,7 +135,7 @@ describe('Sign In Gate Tests', function () {
 		it('should not load the sign in gate on a device with an ios9 user agent string', function () {
 			// can't use visitArticleAndScrollToGateForLazyLoad for this method as overriding user agent
 			cy.visit(
-				'Article?url=https://www.theguardian.com/games/2018/aug/23/nier-automata-yoko-taro-interview',
+				'/Article/https://www.theguardian.com/games/2018/aug/23/nier-automata-yoko-taro-interview',
 				{
 					onBeforeLoad: (win) => {
 						Object.defineProperty(win.navigator, 'userAgent', {

--- a/dotcom-rendering/cypress/e2e/parallel-2/banner.e2e.cy.js
+++ b/dotcom-rendering/cypress/e2e/parallel-2/banner.e2e.cy.js
@@ -19,7 +19,7 @@ describe('The banner', function () {
 			req.reply({});
 		}).as('rrBannerRequest');
 
-		cy.visit(`/Article?url=${articleUrl}`);
+		cy.visit(`/Article/${articleUrl}`);
 		cy.wait('@rrBannerRequest');
 	});
 });

--- a/dotcom-rendering/cypress/e2e/parallel-2/braze.cy.js
+++ b/dotcom-rendering/cypress/e2e/parallel-2/braze.cy.js
@@ -46,7 +46,7 @@ describe('Braze messaging', function () {
 		storage.local.set('gu.geo.override', 'GB');
 
 		cy.visit(
-			'/Article?url=https://theguardian.com/games/2018/aug/23/nier-automata-yoko-taro-interview',
+			'/Article/https://theguardian.com/games/2018/aug/23/nier-automata-yoko-taro-interview',
 		);
 		cy.intercept('POST', '**/choice/gdpr/**').as('tcfRequest');
 		// Open the Privacy setting dialogue
@@ -55,7 +55,7 @@ describe('Braze messaging', function () {
 		// eslint-disable-next-line cypress/no-unnecessary-waiting
 		cy.wait('@tcfRequest');
 		cy.visit(
-			'/Article?url=https://theguardian.com/games/2018/aug/23/nier-automata-yoko-taro-interview',
+			'/Article/https://theguardian.com/games/2018/aug/23/nier-automata-yoko-taro-interview',
 		);
 		cy.waitUntil(() => localStorage.getItem('gu.brazeUserSet') === 'true', {
 			errorMsg: 'Error waiting for gu.brazeUserSet to be "true"',
@@ -77,7 +77,7 @@ describe('Braze messaging', function () {
 
 		storage.local.set('gu.geo.override', 'GB');
 		cy.visit(
-			'/Article?url=https://theguardian.com/games/2018/aug/23/nier-automata-yoko-taro-interview',
+			'/Article/https://theguardian.com/games/2018/aug/23/nier-automata-yoko-taro-interview',
 		);
 
 		cy.intercept('POST', '**/choice/gdpr/**').as('tcfRequest');

--- a/dotcom-rendering/cypress/e2e/parallel-3/article.interactivity.cy.js
+++ b/dotcom-rendering/cypress/e2e/parallel-3/article.interactivity.cy.js
@@ -16,7 +16,7 @@ describe('Interactivity', function () {
 
 	describe('Verify elements have been hydrated', function () {
 		it('should open the edition dropdown menu when clicked and hide when expected', function () {
-			cy.visit(`/Article?url=${articleUrl}`);
+			cy.visit(`/Article/${articleUrl}`);
 			cy.get('[data-cy=dropdown-options]').should('not.be.visible');
 			// Open it
 			cy.get('[data-cy=dropdown-button]').click();
@@ -33,12 +33,12 @@ describe('Interactivity', function () {
 		});
 		// eslint-disable-next-line mocha/no-skipped-tests
 		it.skip('should display the share count for an article', function () {
-			cy.visit(`/Article?url=${articleUrl}`);
+			cy.visit(`/Article/${articleUrl}`);
 			cy.get('[data-cy=share-counts]').should('exist');
 		});
 		it('loads the discussion when you click the comment count', function () {
 			cy.visit(
-				`/Article?url=https://www.theguardian.com/commentisfree/2022/jan/20/uk-government-yemen-war-saudi-arabia-westminster`,
+				`/Article/https://www.theguardian.com/commentisfree/2022/jan/20/uk-government-yemen-war-saudi-arabia-westminster`,
 			);
 			cy.get('[data-cy=comment-counts]').should('exist');
 			// The discusion is not yet loaded
@@ -49,7 +49,7 @@ describe('Interactivity', function () {
 		});
 		it('loads the discussion immediately when you use a url ending in #comments', function () {
 			cy.visit(
-				`/Article?url=https://www.theguardian.com/commentisfree/2022/jan/20/uk-government-yemen-war-saudi-arabia-westminster#comments`,
+				`/Article/https://www.theguardian.com/commentisfree/2022/jan/20/uk-government-yemen-war-saudi-arabia-westminster#comments`,
 			);
 			cy.get('[data-cy=discussion]').should('exist');
 		});
@@ -57,7 +57,7 @@ describe('Interactivity', function () {
 		it('loads the discussion immediately when you use a permalink', function () {
 			// The permalink feature is not currently working but once it does we want this test ready to go
 			cy.visit(
-				`/Article?url=https://www.theguardian.com/commentisfree/2022/jan/20/uk-government-yemen-war-saudi-arabia-westminster#comment-154433663`,
+				`/Article/https://www.theguardian.com/commentisfree/2022/jan/20/uk-government-yemen-war-saudi-arabia-westminster#comment-154433663`,
 			);
 			cy.get('gu-island[name=DiscussionContainer]').should(
 				'have.attr',
@@ -67,13 +67,13 @@ describe('Interactivity', function () {
 			cy.get('[id=comment-154433663]').should('be.visible');
 		});
 		it('loads the most viwed list only after starting to scroll the page', function () {
-			cy.visit(`/Article?url=${articleUrl}`);
+			cy.visit(`/Article/${articleUrl}`);
 			cy.get('[data-component=geo-most-popular]').should('not.exist');
 			cy.scrollTo('center', { duration: 300 });
 			cy.get('[data-component=geo-most-popular]').should('exist');
 		});
 		it('should display and hydrate all the rich links for an article', function () {
-			cy.visit(`/Article?url=${articleUrl}`);
+			cy.visit(`/Article/${articleUrl}`);
 			// Verify two links were server rendered
 			cy.get('[data-component=rich-link]')
 				.should('exist')
@@ -87,7 +87,7 @@ describe('Interactivity', function () {
 		describe('When most viewed is mocked', function () {
 			beforeEach(mockApi);
 			it('should change the list of most viewed items when a tab is clicked', function () {
-				cy.visit(`/Article?url=${articleUrl}`);
+				cy.visit(`/Article/${articleUrl}`);
 				cy.contains('Lifestyle');
 				// Make sure the most viewed html isn't even in the dom yet
 				cy.get('[data-cy=mostviewed-footer]').should('not.exist');
@@ -112,7 +112,7 @@ describe('Interactivity', function () {
 			});
 		});
 		it('should render the reader revenue links in the header', function () {
-			cy.visit(`/Article?url=${articleUrl}`);
+			cy.visit(`/Article/${articleUrl}`);
 			cy.scrollTo('bottom', { duration: 300 });
 			cy.get('header')
 				.contains(READER_REVENUE_TITLE_TEXT)
@@ -122,7 +122,7 @@ describe('Interactivity', function () {
 
 	describe('Navigating the pillar menu', function () {
 		it('should expand and close the desktop pillar menu when More is clicked', function () {
-			cy.visit(`/Article?url=${articleUrl}`);
+			cy.visit(`/Article/${articleUrl}`);
 			cy.get('[data-cy=nav-show-more-button]').click();
 			cy.get('[data-cy=expanded-menu]').within(() => {
 				cy.contains('Columnists').should('be.visible');
@@ -144,7 +144,7 @@ describe('Interactivity', function () {
 		describe('On mobile', function () {
 			it('should expand the mobile pillar menu when the VeggieBurger is clicked', function () {
 				cy.viewport('iphone-x');
-				cy.visit(`/Article?url=${articleUrl}`);
+				cy.visit(`/Article/${articleUrl}`);
 				cy.get('[data-cy=veggie-burger]').click();
 				cy.contains('Crosswords');
 				cy.get('[data-cy=column-collapse-Opinion]').click();
@@ -158,21 +158,21 @@ describe('Interactivity', function () {
 
 			it('should transfer focus to the sub nav when tabbing from the veggie burger without opening the menu', function () {
 				cy.viewport('iphone-x');
-				cy.visit(`/Article?url=${articleUrl}`);
+				cy.visit(`/Article/${articleUrl}`);
 				cy.get('[data-cy=veggie-burger]').focus().tab();
 				cy.get('[data-cy=sub-nav] a').first().should('have.focus');
 			});
 
 			it('should immediately focus on the News menu item when the menu first opens', function () {
 				cy.viewport('iphone-x');
-				cy.visit(`/Article?url=${articleUrl}`);
+				cy.visit(`/Article/${articleUrl}`);
 				cy.get('[data-cy=veggie-burger]').click();
 				cy.get('[data-cy=column-collapse-News]').should('have.focus');
 			});
 
 			it('should transfer focus to sub menu items when tabbing from section header', function () {
 				cy.viewport('iphone-x');
-				cy.visit(`/Article?url=${articleUrl}`);
+				cy.visit(`/Article/${articleUrl}`);
 				cy.get('[data-cy=veggie-burger]').click();
 				cy.focused().type('{enter}').tab();
 				// get the first column (news column)
@@ -186,7 +186,7 @@ describe('Interactivity', function () {
 
 			it('should let reader traverse section titles using keyboard', function () {
 				cy.viewport('iphone-x');
-				cy.visit(`/Article?url=${articleUrl}`);
+				cy.visit(`/Article/${articleUrl}`);
 				cy.get('[data-cy=veggie-burger]').type('{enter}');
 				// Close the news menu
 				cy.focused().type('{enter}').tab();
@@ -206,7 +206,7 @@ describe('Interactivity', function () {
 
 			it('should expand the subnav when "More" is clicked', function () {
 				cy.viewport('iphone-x');
-				cy.visit(`/Article?url=${articleUrl}`);
+				cy.visit(`/Article/${articleUrl}`);
 				// Wait for hydration
 				cy.get('gu-island[name=SubNav]')
 					.first()

--- a/dotcom-rendering/cypress/e2e/parallel-3/article.metaAndOphan.e2e.cy.js
+++ b/dotcom-rendering/cypress/e2e/parallel-3/article.metaAndOphan.e2e.cy.js
@@ -9,7 +9,7 @@ describe('The web document renders with the correct meta and analytics elements 
 
 	it(`The page is structured as expected`, function () {
 		cy.visit(
-			`/Article?url=https://www.theguardian.com/lifeandstyle/2021/jan/21/never-conduct-any-business-naked-how-to-work-from-bed-without-getting-sacked`,
+			`/Article/https://www.theguardian.com/lifeandstyle/2021/jan/21/never-conduct-any-business-naked-how-to-work-from-bed-without-getting-sacked`,
 		);
 
 		cy.get(`head`).should('have.length', 1);
@@ -49,7 +49,7 @@ describe('The web document renders with the correct meta and analytics elements 
 
 	it('Subnav links exists with correct values', function () {
 		cy.visit(
-			`/Article?url=https://www.theguardian.com/lifeandstyle/2021/jan/21/never-conduct-any-business-naked-how-to-work-from-bed-without-getting-sacked`,
+			`/Article/https://www.theguardian.com/lifeandstyle/2021/jan/21/never-conduct-any-business-naked-how-to-work-from-bed-without-getting-sacked`,
 		);
 		// Pillar ophan data-link-name exists with correct value
 		cy.get(`a[data-link-name="nav2 : primary : Opinion"]`).should(
@@ -69,7 +69,7 @@ describe('The web document renders with the correct meta and analytics elements 
 
 	it('Meta ophan data-attributes exist, content and attributes are correct', function () {
 		cy.visit(
-			`/Article?url=https://www.theguardian.com/lifeandstyle/2021/jan/21/never-conduct-any-business-naked-how-to-work-from-bed-without-getting-sacked`,
+			`/Article/https://www.theguardian.com/lifeandstyle/2021/jan/21/never-conduct-any-business-naked-how-to-work-from-bed-without-getting-sacked`,
 		);
 		cy.get(`address[data-component="meta-byline"]`).should(
 			'have.length',
@@ -89,7 +89,7 @@ describe('The web document renders with the correct meta and analytics elements 
 
 	it('Section, Footer and Series ophan data-attributes exist', function () {
 		cy.visit(
-			`/Article?url=https://www.theguardian.com/lifeandstyle/2021/jan/21/never-conduct-any-business-naked-how-to-work-from-bed-without-getting-sacked`,
+			`/Article/https://www.theguardian.com/lifeandstyle/2021/jan/21/never-conduct-any-business-naked-how-to-work-from-bed-without-getting-sacked`,
 		);
 		cy.get(`[data-component="section"]`).should('have.length', 1);
 

--- a/dotcom-rendering/cypress/e2e/parallel-3/epic.interactivity.cy.js
+++ b/dotcom-rendering/cypress/e2e/parallel-3/epic.interactivity.cy.js
@@ -27,7 +27,7 @@ describe('Epics', function () {
 	it('should render the liveblog epic in the list of blocks', function () {
 		stubUpdates();
 		storage.local.set('gu.geo.override', 'GB');
-		cy.visit(`/Article?url=${blogUrl}?live=true&force-liveblog-epic=true`);
+		cy.visit(`/Article/${blogUrl}?live=true&force-liveblog-epic=true`);
 
 		// Wait for hydration of the Epic
 		cy.get('gu-island[name=LiveBlogEpic]')

--- a/dotcom-rendering/cypress/e2e/parallel-4/atom.interactivity.cy.js
+++ b/dotcom-rendering/cypress/e2e/parallel-4/atom.interactivity.cy.js
@@ -28,12 +28,12 @@ const atomExpandableTests = (type, url) => {
 		});
 
 		it('should render', function () {
-			cy.visit(`/Article?url=${url}`);
+			cy.visit(`/Article/${url}`);
 			cy.get(`[data-snippet-type=${type}]`).should('be.visible');
 		});
 
 		it('should expand on click', function () {
-			cy.visit(`/Article?url=${url}`);
+			cy.visit(`/Article/${url}`);
 			cy.get(`[data-snippet-type=${type}]`).should('be.visible');
 			cy.get(`[data-snippet-type=${type}]`)
 				.contains('Show')
@@ -45,7 +45,7 @@ const atomExpandableTests = (type, url) => {
 		});
 
 		it('should expand then contract on second click', function () {
-			cy.visit(`/Article?url=${url}`);
+			cy.visit(`/Article/${url}`);
 			cy.get(`[data-snippet-type=${type}]`).should('be.visible');
 			cy.get(`[data-snippet-type=${type}]`)
 				.contains('Show')
@@ -61,14 +61,14 @@ const atomExpandableTests = (type, url) => {
 		});
 
 		it('should show feedback message when like is clicked', function () {
-			cy.visit(`/Article?url=${url}`);
+			cy.visit(`/Article/${url}`);
 			cy.get(`[data-snippet-type=${type}]`).click();
 			cy.get('[data-testid="like"]').click();
 			cy.get('[data-testid="feedback"]').should('be.visible');
 		});
 
 		it('should show feedback message when dislike is clicked', function () {
-			cy.visit(`/Article?url=${url}`);
+			cy.visit(`/Article/${url}`);
 			cy.get(`[data-snippet-type=${type}]`).click();
 			cy.get('[data-testid="dislike"]').click();
 			cy.get('[data-testid="feedback"]').should('be.visible');
@@ -83,7 +83,7 @@ const atomGenericTests = (type, url) => {
 		});
 
 		it('should render', function () {
-			cy.visit(`/Article?url=${url}`);
+			cy.visit(`/Article/${url}`);
 			cy.get(`[data-snippet-type=${type}]`).should('be.visible');
 		});
 	});
@@ -101,7 +101,7 @@ describe('Why do wombats do square poos?', function () {
 	});
 
 	it('when I get the answer wrong, it should display the right answer when I click Reveal', function () {
-		cy.visit(`/Article?url=${quizAtomUrl}`);
+		cy.visit(`/Article/${quizAtomUrl}`);
 		// Wait for hydration
 		cy.get('gu-island[name=KnowledgeQuizAtomWrapper]')
 			.first()
@@ -128,7 +128,7 @@ describe('Why do wombats do square poos?', function () {
 	});
 
 	it('when I get the answer right, it should commend my skills when I click Reveal', function () {
-		cy.visit(`/Article?url=${quizAtomUrl}`);
+		cy.visit(`/Article/${quizAtomUrl}`);
 		// Wait for hydration
 		cy.get('gu-island[name=KnowledgeQuizAtomWrapper]')
 			.first()

--- a/dotcom-rendering/cypress/e2e/parallel-4/signedin.cy.js
+++ b/dotcom-rendering/cypress/e2e/parallel-4/signedin.cy.js
@@ -36,7 +36,7 @@ describe('Signed in readers', function () {
 			'**/profile/me?strict_sanctions_check=false',
 			profileResponse,
 		).as('profileMe');
-		cy.visit(`Article?url=${articleUrl}`);
+		cy.visit(`/Article/${articleUrl}`);
 		cy.wait('@profileMe');
 		// This text is shown in the header for signed in users
 		cy.contains('My account');
@@ -56,7 +56,7 @@ describe('Signed in readers', function () {
 			'**/profile/me?strict_sanctions_check=false',
 			profileResponse,
 		).as('profileMe');
-		cy.visit(`Article?url=${articleUrl}`);
+		cy.visit(`/Article/${articleUrl}`);
 		cy.wait('@profileMe');
 
 		cy.get('a[data-link-name="nav3 : topbar : printsubs"]')
@@ -77,7 +77,7 @@ describe('Signed in readers', function () {
 	});
 
 	it('should not display signed in texts when users are not signed in', function () {
-		cy.visit(`Article?url=${articleUrl}`);
+		cy.visit(`/Article/${articleUrl}`);
 		cy.scrollTo('bottom', { duration: 300 });
 		// We need this second call to fix flakiness where content loads in pushing the page
 		// down and preventing the scroll request to actually reach the bottom. We will fix

--- a/dotcom-rendering/cypress/e2e/parallel-5/atom.video.cy.js
+++ b/dotcom-rendering/cypress/e2e/parallel-5/atom.video.cy.js
@@ -116,7 +116,7 @@ describe('YouTube Atom', function () {
 
 	it('plays main media videos', function () {
 		cy.visit(
-			'/Article?url=https://www.theguardian.com/uk-news/2020/dec/04/edinburgh-hit-by-thundersnow-as-sonic-boom-wakes-residents',
+			'/Article/https://www.theguardian.com/uk-news/2020/dec/04/edinburgh-hit-by-thundersnow-as-sonic-boom-wakes-residents',
 		);
 		cmpIframe().contains("It's your choice");
 		cmpIframe().find("[title='Manage my cookies']").click();
@@ -166,7 +166,7 @@ describe('YouTube Atom', function () {
 
 	it('plays in body videos', function () {
 		cy.visit(
-			'/Article?url=https://www.theguardian.com/environment/2021/oct/05/volcanoes-are-life-how-the-ocean-is-enriched-by-eruptions-devastating-on-land',
+			'/Article/https://www.theguardian.com/environment/2021/oct/05/volcanoes-are-life-how-the-ocean-is-enriched-by-eruptions-devastating-on-land',
 		);
 		cmpIframe().contains("It's your choice");
 		cmpIframe().find("[title='Manage my cookies']").click();
@@ -213,7 +213,7 @@ describe('YouTube Atom', function () {
 
 	it('plays when the same video exists both in body and in main media of the blog', function () {
 		cy.visit(
-			'/Article?url=https://www.theguardian.com/world/live/2022/mar/28/russia-ukraine-war-latest-news-zelenskiy-putin-live-updates?dcr=true',
+			'/Article/https://www.theguardian.com/world/live/2022/mar/28/russia-ukraine-war-latest-news-zelenskiy-putin-live-updates?dcr=true',
 		);
 		cmpIframe().contains("It's your choice");
 		cmpIframe().find("[title='Manage my cookies']").click();
@@ -319,7 +319,7 @@ describe('YouTube Atom', function () {
 
 	it('plays the video if the reader rejects consent', function () {
 		cy.visit(
-			'/Article?url=https://www.theguardian.com/environment/2021/oct/05/volcanoes-are-life-how-the-ocean-is-enriched-by-eruptions-devastating-on-land',
+			'/Article/https://www.theguardian.com/environment/2021/oct/05/volcanoes-are-life-how-the-ocean-is-enriched-by-eruptions-devastating-on-land',
 		);
 		cmpIframe().contains("It's your choice");
 		cmpIframe().find("[title='Manage my cookies']").click();
@@ -366,7 +366,7 @@ describe('YouTube Atom', function () {
 
 	it('video is sticky when the user plays a video then scrolls the video out of the viewport', function () {
 		cy.visit(
-			'/Article?url=https://www.theguardian.com/world/live/2022/mar/28/russia-ukraine-war-latest-news-zelenskiy-putin-live-updates?dcr=true',
+			'/Article/https://www.theguardian.com/world/live/2022/mar/28/russia-ukraine-war-latest-news-zelenskiy-putin-live-updates?dcr=true',
 		);
 		cmpIframe().contains("It's your choice");
 		cmpIframe().find("[title='Manage my cookies']").click();

--- a/dotcom-rendering/cypress/e2e/parallel-5/liveblog.interactivity.cy.js
+++ b/dotcom-rendering/cypress/e2e/parallel-5/liveblog.interactivity.cy.js
@@ -43,7 +43,7 @@ describe('Liveblogs', function () {
 
 	it('should show the toast, incrementing the count as new updates are sent', function () {
 		stubUpdates();
-		cy.visit(`/Article?url=${blogUrl}?live=true`);
+		cy.visit(`/Article/${blogUrl}?live=true`);
 		// Wait for hydration
 		cy.get('gu-island[name=Liveness]')
 			.first()
@@ -71,7 +71,7 @@ describe('Liveblogs', function () {
 
 	it('should insert the html from the update call', function () {
 		stubUpdates();
-		cy.visit(`/Article?url=${blogUrl}?live=true`);
+		cy.visit(`/Article/${blogUrl}?live=true`);
 		// Wait for hydration
 		cy.get('gu-island[name=Liveness]')
 			.first()
@@ -88,7 +88,7 @@ describe('Liveblogs', function () {
 
 	it('should scroll the page to the top and reveal content when the toast is clicked', function () {
 		stubUpdates();
-		cy.visit(`/Article?url=${blogUrl}?live=true`);
+		cy.visit(`/Article/${blogUrl}?live=true`);
 		// Wait for hydration
 		cy.get('gu-island[name=Liveness]', { timeout: 30000 })
 			.first()
@@ -118,7 +118,7 @@ describe('Liveblogs', function () {
 				.then(cy.wrap);
 		};
 		stubUpdates();
-		cy.visit(`/Article?url=${blogUrl}?live=true`);
+		cy.visit(`/Article/${blogUrl}?live=true`);
 		// Wait for hydration
 		cy.get('gu-island[name=Liveness]')
 			.first()
@@ -151,7 +151,7 @@ describe('Liveblogs', function () {
 			},
 		).as('updateCall');
 		cy.visit(
-			`/Article?url=${blogUrl}?live=true&page=with:block-6214732b8f08f86d89ef68d6&filterKeyEvents=false#liveblog-navigation`,
+			`/Article/${blogUrl}?live=true&page=with:block-6214732b8f08f86d89ef68d6&filterKeyEvents=false#liveblog-navigation`,
 		);
 		cy.wait('@updateCall');
 	});
@@ -159,7 +159,7 @@ describe('Liveblogs', function () {
 	it('should handle when the toast is clicked from the second page', function () {
 		stubUpdates();
 		cy.visit(
-			`/Article?url=${blogUrl}?live=true&page=with:block-6214732b8f08f86d89ef68d6&filterKeyEvents=false#liveblog-navigation`,
+			`/Article/${blogUrl}?live=true&page=with:block-6214732b8f08f86d89ef68d6&filterKeyEvents=false#liveblog-navigation`,
 		);
 		// Wait for hydration
 		cy.get('gu-island[name=Liveness]', { timeout: 30000 })
@@ -187,7 +187,7 @@ describe('Liveblogs', function () {
 
 	it('should initially hide new blocks, only revealing them when the top of blog is in view', function () {
 		stubUpdates();
-		cy.visit(`/Article?url=${blogUrl}?live=true`);
+		cy.visit(`/Article/${blogUrl}?live=true`);
 		// Wait for hydration
 		cy.get('gu-island[name=Liveness]')
 			.first()
@@ -221,7 +221,7 @@ describe('Liveblogs', function () {
 	it.skip('should render live score updates to a cricketblog', function () {
 		// Get article with ?live to force the article to be 'live'
 		cy.visit(
-			'/Article?url=https://theguardian.com/sport/live/2022/mar/27/west-indies-v-england-third-test-day-four-live?live',
+			'/Article/https://theguardian.com/sport/live/2022/mar/27/west-indies-v-england-third-test-day-four-live?live',
 		);
 
 		// Initial request for the cricket data

--- a/dotcom-rendering/cypress/e2e/parallel-6/commercial.cy.js
+++ b/dotcom-rendering/cypress/e2e/parallel-6/commercial.cy.js
@@ -9,7 +9,7 @@ describe('Commercial E2E tests', function () {
 
 	it(`It should load the expected number of ad slots`, function () {
 		cy.visit(
-			`Article?url=https://www.theguardian.com/environment/2020/oct/13/maverick-rewilders-endangered-species-extinction-conservation-uk-wildlife`,
+			`/Article/https://www.theguardian.com/environment/2020/oct/13/maverick-rewilders-endangered-species-extinction-conservation-uk-wildlife`,
 		);
 
 		cy.scrollTo('bottom', { duration: 500 });

--- a/dotcom-rendering/cypress/e2e/parallel-6/consent.cy.js
+++ b/dotcom-rendering/cypress/e2e/parallel-6/consent.cy.js
@@ -14,7 +14,7 @@ describe('Consent tests', function () {
 	});
 
 	it('should make calls to Google Analytics after the reader consents', function () {
-		cy.visit(`Article?url=${firstPage}`);
+		cy.visit(`/Article/${firstPage}`);
 		cy.window().its('ga').should('not.exist');
 		// Open the Privacy setting dialogue
 		cmpIframe().contains("It's your choice");
@@ -36,7 +36,7 @@ describe('Consent tests', function () {
 				return false;
 			}
 		});
-		cy.visit(`Article?url=${firstPage}`);
+		cy.visit(`/Article/${firstPage}`);
 		cy.window().its('ga').should('not.exist');
 		// Open the Privacy setting dialogue
 		cmpIframe().contains("It's your choice");

--- a/dotcom-rendering/cypress/paid.content.cy.js
+++ b/dotcom-rendering/cypress/paid.content.cy.js
@@ -15,7 +15,7 @@ if (!Cypress.env('isInTeamCity')) {
 		});
 
 		it('should send Google Analytics message on click of sponsor logo in metadata', function () {
-			cy.visit(`Article?url=${paidContentPage}`);
+			cy.visit(`/Article/${paidContentPage}`);
 
 			// Open the Privacy setting dialogue
 			cmpIframe().contains("It's your choice");
@@ -56,7 +56,7 @@ if (!Cypress.env('isInTeamCity')) {
 		});
 
 		it('should send Google Analytics message on click of sponsor logo in onwards section', function () {
-			cy.visit(`Article?url=${paidContentPage}`);
+			cy.visit(`/Article/${paidContentPage}`);
 
 			// Open the Privacy setting dialogue
 			cmpIframe().contains("It's your choice");

--- a/dotcom-rendering/cypress/snapshot/standard-layout.e2e.cy.js
+++ b/dotcom-rendering/cypress/snapshot/standard-layout.e2e.cy.js
@@ -11,7 +11,7 @@ describe('Visual regression', function () {
 
 	it('Snapshot all breakpoints', function () {
 		cy.visit(
-			'/Article?url=https://www.theguardian.com/uk-news/2020/dec/04/edinburgh-hit-by-thundersnow-as-sonic-boom-wakes-residents',
+			'/Article/https://www.theguardian.com/uk-news/2020/dec/04/edinburgh-hit-by-thundersnow-as-sonic-boom-wakes-residents',
 		);
 
 		cy.hydrate();

--- a/dotcom-rendering/docs/contributing/detailed-setup-guide.md
+++ b/dotcom-rendering/docs/contributing/detailed-setup-guide.md
@@ -32,6 +32,7 @@ This high level diagram shows the difference between the data flow when DCR is u
 The only things you need to make sure you have installed before you get going are Node and yarn.
 
 #### Node.js
+
 We recommend using a tool to help manage multiple versions of Node.js on on machine.
 [fnm](https://github.com/Schniz/fnm) is popular in the department at the moment, although
 [nvm](https://github.com/creationix/nvm) and [asdf](https://github.com/asdf-vm/asdf) are
@@ -43,6 +44,7 @@ If you prefer to [install Node.js manually](https://nodejs.org),
 check the [.nvmrc](https://github.com/guardian/dotcom-rendering/blob/main/.nvmrc) for the current required version.
 
 #### Yarn
+
 Node packages for this project are managed using the 'classic' version of [Yarn](https://classic.yarnpkg.com/).
 Currently [the recommended way to install Yarn](https://classic.yarnpkg.com/lang/en/docs/install/)
 is with npm, which should be available if you have already installed Node.js. To install Yarn
@@ -77,23 +79,23 @@ This will start the development server on port 3030: [http://localhost:3030](htt
 
 ### Previewing article on local
 
-You can preview an article from `theguardian.com` by appending the query string parameter `url` to your localhost article page. For example:
+You can preview an article from `theguardian.com` by appending the full URL to the path of your localhost article page. For example:
 
-http://localhost:3030/Article?url=https://www.theguardian.com/world/2013/jun/09/edward-snowden-nsa-whistleblower-surveillance
+http://localhost:3030/Article/https://www.theguardian.com/world/2013/jun/09/edward-snowden-nsa-whistleblower-surveillance
 
 You can use this technique to integrate with a locally running instance of `frontend`. This is especially useful for testing changes to the data model:
 
-http://localhost:3030/Article?url=http://localhost:9000/world/2013/jun/09/edward-snowden-nsa-whistleblower-surveillance
+http://localhost:3030/Article/http://localhost:9000/world/2013/jun/09/edward-snowden-nsa-whistleblower-surveillance
 
 ### Previewing AMP on local
 
 You can preview an AMP page similarly to an article, as follows
 
-http://localhost:3030/AMPArticle?url=https://amp.theguardian.com/world/2013/jun/09/edward-snowden-nsa-whistleblower-surveillance
+http://localhost:3030/AMPArticle/https://amp.theguardian.com/world/2013/jun/09/edward-snowden-nsa-whistleblower-surveillance
 
 or, connecting to a locally running instance of frontend,
 
-http://localhost:3030/AMPArticle?url=http://localhost:9000/world/2013/jun/09/edward-snowden-nsa-whistleblower-surveillance
+http://localhost:3030/AMPArticle/http://localhost:9000/world/2013/jun/09/edward-snowden-nsa-whistleblower-surveillance
 
 ### Note on rebasing vs merging
 

--- a/dotcom-rendering/docs/development/run-prod-bundle-locally.md
+++ b/dotcom-rendering/docs/development/run-prod-bundle-locally.md
@@ -18,7 +18,7 @@ You can then use the provided GET endpoints for testing:
 Similar to the dev server, both endpoints support a `url` parameter to customise
 the article used. E.g.
 
-    GET /Article?url=https://www.theguardian.com/my-test-article.
+    GET /Article/https://www.theguardian.com/my-test-article.
 
 *Note, PROD Frontend doesn't use these endpoints. Instead, it `POSTs` data to
 DCR and receives a JSON response. A tool like Postman can help if you want to

--- a/dotcom-rendering/lighthouserc.js
+++ b/dotcom-rendering/lighthouserc.js
@@ -36,7 +36,7 @@ module.exports = {
 					},
 				},
 				{
-					matchingUrlPattern: 'http://localhost:9000/Article?.+',
+					matchingUrlPattern: 'http://localhost:9000/Article/.+',
 					assertions: {
 						'total-blocking-time': [
 							'warn',
@@ -49,7 +49,7 @@ module.exports = {
 					},
 				},
 				{
-					matchingUrlPattern: 'http://localhost:9000/Front?.+',
+					matchingUrlPattern: 'http://localhost:9000/Front/.+',
 					assertions: {
 						'total-blocking-time': [
 							'warn',

--- a/dotcom-rendering/scripts/test/amp-validation.js
+++ b/dotcom-rendering/scripts/test/amp-validation.js
@@ -67,7 +67,7 @@ amphtmlValidator.getInstance().then((validator) => {
 	].map((url) => {
 		// COPIED DIRECTLY FROM https://www.npmjs.com/package/amphtml-validator
 		http.get(
-			`${domain}/AmpArticle?url=https://www.theguardian.com/${url}`,
+			`${domain}/AMPArticle/https://www.theguardian.com/${url}`,
 			(res) => {
 				let data = '';
 				res.on('data', function (chunk) {

--- a/dotcom-rendering/src/server/dev-index.html
+++ b/dotcom-rendering/src/server/dev-index.html
@@ -32,39 +32,39 @@
 		<ul id="default-endpoints">
 			<li>
 				<a
-					href="/Article?url=https://www.theguardian.com/money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software"
+					href="/Article/https://www.theguardian.com/money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software"
 					>Article</a
 				>
 			</li>
 			<li>
 				<a
-					href="/AMPArticle?url=https://amp.theguardian.com/world/2013/jun/09/edward-snowden-nsa-whistleblower-surveillance"
+					href="/AMPArticle/https://amp.theguardian.com/world/2013/jun/09/edward-snowden-nsa-whistleblower-surveillance"
 					>⚡️Article</a
 				>
 			</li>
 			<li>
 				<a
-					href="/Interactive?url=theguardian.com/global-development/ng-interactive/2022/jun/09/the-black-sea-blockade-mapping-the-impact-of-war-in-ukraine-on-the-worlds-food-supply-interactive"
+					href="/Interactive/www.theguardian.com/global-development/ng-interactive/2022/jun/09/the-black-sea-blockade-mapping-the-impact-of-war-in-ukraine-on-the-worlds-food-supply-interactive"
 					>Interactive</a
 				>
 			</li>
 			<li>
 				<a
-					href="/AMPInteractive?url=https://www.theguardian.com/world/2021/mar/24/how-a-container-ship-blocked-the-suez-canal-visual-guide"
+					href="/AMPInteractive/https://www.theguardian.com/world/2021/mar/24/how-a-container-ship-blocked-the-suez-canal-visual-guide"
 					>⚡️Interactive</a
 				>
 			</li>
 			<li>
-				<a href="/Front?url=https://www.theguardian.com/international"
+				<a href="/Front/https://www.theguardian.com/international"
 					>International Front</a
 				>
 				(<a
-					href="/FrontJSON?url=https://www.theguardian.com/international"
+					href="/FrontJSON/https://www.theguardian.com/international"
 					>Enhanced JSON</a
 				>)
 			</li>
 			<li>
-				<a href="/AppsArticle?url=https://www.theguardian.com/money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software"
+				<a href="/AppsArticle/https://www.theguardian.com/money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software"
 					>📱 Apps Article</a
 				>
 			</li>
@@ -380,7 +380,7 @@
 
 						const pageType = getPageType(text);
 
-						a.setAttribute('href', `/${pageType}?url=${text}`);
+						a.setAttribute('href', `/${pageType}/${text}`);
 						a.innerText = `📋 ${pageType} from clipboard: /${slug}…`;
 
 						li.appendChild(a);
@@ -389,7 +389,7 @@
 							const aJSON = document.createElement('a');
 							aJSON.setAttribute(
 								'href',
-								`/${pageType}JSON?url=${text}`,
+								`/${pageType}JSON/${text}`,
 							);
 							aJSON.innerHTML = 'Enhanced JSON';
 							li.append(' (', aJSON, ')');
@@ -411,8 +411,8 @@
 			const makeTestArticle = (a) => `
 			             <div class="test-article">
 			                 <span>${a.name}</span>
-			                 <span><a href="/Article?url=https://www.theguardian.com${a.article}">🔗</a> <a href="/Article?url=http://localhost:9000${a.article}">🔗(local FE)</a></span>
-			                 <span><a href="/AMPArticle?url=https://www.theguardian.com${a.article}">🔗</a> <a href="/AMPArticle?url=http://localhost:9000${a.article}">🔗(local FE)</a></span>
+			                 <span><a href="/Article/https://www.theguardian.com${a.article}">🔗</a> <a href="/Article/http://localhost:9000${a.article}">🔗(local FE)</a></span>
+			                 <span><a href="/AMPArticle/https://www.theguardian.com${a.article}">🔗</a> <a href="/AMPArticle/http://localhost:9000${a.article}">🔗(local FE)</a></span>
 			                 <span><a href="https://www.theguardian.com${a.article}">example</a></span>
 			                 <span><a href="https://amp.theguardian.com${a.article}">example</a></span>
 			             </div>

--- a/dotcom-rendering/src/server/dev-server.ts
+++ b/dotcom-rendering/src/server/dev-server.ts
@@ -24,6 +24,13 @@ export const devServer = (): Handler => {
 	return (req, res, next) => {
 		const path = req.path.split('/')[1];
 
+		// handle urls with the ?url=… query param
+		const url = new URL(req.url, `http://localhost:3030/`);
+		const sourceUrl = url.searchParams.get('url');
+		if (sourceUrl !== null) {
+			return res.redirect(url.pathname + '/' + sourceUrl);
+		}
+
 		switch (path) {
 			case 'Article':
 				return handleArticle(req, res, next);

--- a/dotcom-rendering/src/server/dev-server.ts
+++ b/dotcom-rendering/src/server/dev-server.ts
@@ -22,26 +22,28 @@ const ASSETS_URL = /assets\/.*\.js/;
 // for more info
 export const devServer = (): Handler => {
 	return (req, res, next) => {
-		switch (req.path) {
-			case '/Article':
+		const path = req.path.split('/')[1];
+
+		switch (path) {
+			case 'Article':
 				return handleArticle(req, res, next);
-			case '/ArticleJson':
+			case 'ArticleJson':
 				return handleArticleJson(req, res, next);
-			case '/AMPArticle':
+			case 'AMPArticle':
 				return handleAMPArticle(req, res, next);
-			case '/Interactive':
+			case 'Interactive':
 				return handleInteractive(req, res, next);
-			case '/AMPInteractive':
+			case 'AMPInteractive':
 				return handleAMPArticle(req, res, next);
-			case '/Blocks':
+			case 'Blocks':
 				return handleBlocks(req, res, next);
-			case '/KeyEvents':
+			case 'KeyEvents':
 				return handleKeyEvents(req, res, next);
-			case '/Front':
+			case 'Front':
 				return handleFront(req, res, next);
-			case '/FrontJSON':
+			case 'FrontJSON':
 				return handleFrontJson(req, res, next);
-			case '/AppsArticle':
+			case 'AppsArticle':
 				return handleAppsArticle(req, res, next);
 			default: {
 				// Do not redirect assets urls
@@ -53,7 +55,7 @@ export const devServer = (): Handler => {
 						'https://www.theguardian.com/',
 					).toString();
 					console.info('redirecting to Article:', url);
-					return res.redirect(`/Article?url=${url}`);
+					return res.redirect(`/Article/${url}`);
 				}
 
 				if (req.url.match(FRONT_URL)) {
@@ -62,7 +64,7 @@ export const devServer = (): Handler => {
 						'https://www.theguardian.com/',
 					).toString();
 					console.info('redirecting to Front:', url);
-					return res.redirect(`/Front?url=${url}`);
+					return res.redirect(`/Front/${url}`);
 				}
 
 				next();

--- a/dotcom-rendering/src/server/lib/get-content-from-url.js
+++ b/dotcom-rendering/src/server/lib/get-content-from-url.js
@@ -1,3 +1,5 @@
+const { URLSearchParams } = require('url');
+
 // @ts-check
 const fetch = require('node-fetch').default;
 
@@ -49,64 +51,24 @@ async function getContentFromURL(_url, _headers) {
 exports.default = getContentFromURL;
 
 /**
- * @param {string} requestURL
- * @param {string} requestPath
+ * @param {string} requestUrl
+ * @returns {string}
  */
-const parseURL = (requestURL, requestPath) => {
-	/**
-	 * We use string manipulation on the raw value of req.url
-	 * here instead of the url property of the req.query object
-	 * because we want to capture any *other* query params that
-	 * might be being used. Eg.
-	 *
-	 * If my original url is:
-	 *
-	 * http://localhost:3030/Article?url=https://www.theguardian.com/my/article?filterKeyEvents=true
-	 *
-	 * then req.query.url is:
-	 *
-	 * https://www.theguardian.com/my/article
-	 *
-	 * and req.query.filterKeyEvents is:
-	 *
-	 * true
-	 *
-	 * This happens because the url query param isn't serialised. But we actually want everything
-	 * after 'url=' including '?filterKeyEvents=true' and we'd rather not serialise so we just
-	 * split the string instead
-	 *
-	 *
-	 * When in DEV, any params after 'url' are considered additional params and so are preceded by an ampersand.
-	 * If our url includes an '&' but not a '?' then we are within the DEV environment and the first ampersand
-	 * should be replaced by a question mark to indicate the start of the query string.
-	 * In order to achieve this, we are first decoding the URL so that we can read any special characters.
-	 *
-	 */
+const parseURL = (requestUrl) => {
+	const url = decodeURIComponent(requestUrl.split('/').slice(2).join('/'));
 
-	let url = requestURL.includes('url=')
-		? requestURL.split('url=')[1] ?? requestURL
-		: requestURL;
-
-	url = decodeURIComponent(url);
-
-	if (url.includes('&') && !url.includes('?')) {
-		url = url.replace('&', '?');
-	}
-	if (requestPath.startsWith('/AMP')) {
-		url = url.replace('www', 'amp');
-	}
-	return url;
+	return requestUrl.startsWith('/AMP') ? url.replace('www', 'amp') : url;
 };
 
 exports.parseURL = parseURL;
 
 /** @type {import('webpack-dev-server').ExpressRequestHandler} */
 exports.getContentFromURLMiddleware = async (req, res, next) => {
-	if (req.query.url) {
-		const url = parseURL(req.url, req.path);
+	if (req.path.split('/').length > 2) {
+		const sourceURL = parseURL(req.originalUrl);
 
 		try {
-			req.body = await getContentFromURL(url, req.headers);
+			req.body = await getContentFromURL(sourceURL, req.headers);
 		} catch (error) {
 			console.error(error);
 			next(error);

--- a/dotcom-rendering/src/server/lib/get-content-from-url.test.ts
+++ b/dotcom-rendering/src/server/lib/get-content-from-url.test.ts
@@ -1,65 +1,38 @@
 import { parseURL } from './get-content-from-url';
 
 describe('URL parser', () => {
-	test('parse DEV URL when one query is present', async () => {
+	test('parse DEV URL when one query is present', () => {
 		const req = {
-			url: '/Article?url=https%3A%2F%2Fwww.theguardian.com%2Fpolitics%2Flive%2F2022%2Fapr%2F13%2Fboris-johnson-uk-politics-live-rishi-sunak-partygate-lockdown&filterKeyEvents=true',
-			path: '/Article',
+			path: '/Article/https%3A%2F%2Fwww.theguardian.com%2Fpolitics%2Flive%2F2022%2Fapr%2F13%2Fboris-johnson-uk-politics-live-rishi-sunak-partygate-lockdown?filterKeyEvents=true',
 		};
 		const parsedURL =
 			'https://www.theguardian.com/politics/live/2022/apr/13/boris-johnson-uk-politics-live-rishi-sunak-partygate-lockdown?filterKeyEvents=true';
 
-		const url = parseURL(req.url, req.path);
+		const url = parseURL(req.path);
 
 		expect(url).toEqual(parsedURL);
 	});
 
-	test('parse DEV URL when multiple queries are present', async () => {
+	test('parse DEV URL when multiple queries are present', () => {
 		const req = {
-			url: '/Article?url=https%3A%2F%2Fwww.theguardian.com%2Fpolitics%2Flive%2F2022%2Fapr%2F13%2Fboris-johnson-uk-politics-live-rishi-sunak-partygate-lockdown&filterKeyEvents=true&dcr=true&live=true',
-			path: '/Article',
+			path: '/Article/https%3A%2F%2Fwww.theguardian.com%2Fpolitics%2Flive%2F2022%2Fapr%2F13%2Fboris-johnson-uk-politics-live-rishi-sunak-partygate-lockdown?filterKeyEvents=true&dcr=true&live=true',
 		};
 		const parsedURL =
 			'https://www.theguardian.com/politics/live/2022/apr/13/boris-johnson-uk-politics-live-rishi-sunak-partygate-lockdown?filterKeyEvents=true&dcr=true&live=true';
 
-		const url = parseURL(req.url, req.path);
+		const url = parseURL(req.path);
 
 		expect(url).toEqual(parsedURL);
 	});
 
-	test('parse URL when there are 2 query string', async () => {
+	test('parse URL when there are no queries', () => {
 		const req = {
-			url: '/Article?url=https%3A%2F%2Fwww.theguardian.com%2Fpolitics%2Flive%2F2022%2Fapr%2F13%2Fboris-johnson-uk-politics-live-rishi-sunak-partygate-lockdown?filterKeyEvents=true',
-			path: '/Article',
-		};
-		const parsedURL =
-			'https://www.theguardian.com/politics/live/2022/apr/13/boris-johnson-uk-politics-live-rishi-sunak-partygate-lockdown?filterKeyEvents=true';
-
-		const url = parseURL(req.url, req.path);
-		expect(url).toEqual(parsedURL);
-	});
-
-	test('parse URL when there is a query but no query string', async () => {
-		const req = {
-			url: 'https%3A%2F%2Fwww.theguardian.com%2Fpolitics%2Flive%2F2022%2Fapr%2F13%2Fboris-johnson-uk-politics-live-rishi-sunak-partygate-lockdown&filterKeyEvents=true&dcr=true&live=true',
-			path: '',
-		};
-		const parsedURL =
-			'https://www.theguardian.com/politics/live/2022/apr/13/boris-johnson-uk-politics-live-rishi-sunak-partygate-lockdown?filterKeyEvents=true&dcr=true&live=true';
-
-		const url = parseURL(req.url, req.path);
-		expect(url).toEqual(parsedURL);
-	});
-
-	test('parse URL when there are no queries', async () => {
-		const req = {
-			url: 'https%3A%2F%2Fwww.theguardian.com%2Fpolitics%2Flive%2F2022%2Fapr%2F13%2Fboris-johnson-uk-politics-live-rishi-sunak-partygate-lockdown',
-			path: '',
+			path: '/Article/https%3A%2F%2Fwww.theguardian.com%2Fpolitics%2Flive%2F2022%2Fapr%2F13%2Fboris-johnson-uk-politics-live-rishi-sunak-partygate-lockdown',
 		};
 		const parsedURL =
 			'https://www.theguardian.com/politics/live/2022/apr/13/boris-johnson-uk-politics-live-rishi-sunak-partygate-lockdown';
 
-		const url = parseURL(req.url, req.path);
+		const url = parseURL(req.path);
 
 		expect(url).toEqual(parsedURL);
 	});

--- a/dotcom-rendering/src/server/prod-server.ts
+++ b/dotcom-rendering/src/server/prod-server.ts
@@ -6,8 +6,8 @@ import {
 	handleAMPArticle,
 	handlePerfTest as handleAMPArticlePerfTest,
 } from '../amp/server';
-import type { FEArticleType } from '../types/frontend';
 import { handleAppsArticle } from '../apps/server';
+import type { FEArticleType } from '../types/frontend';
 import {
 	handleArticle,
 	handleArticleJson,
@@ -65,37 +65,42 @@ export const prodServer = (): void => {
 
 	// These GET's are for checking any given URL directly from PROD
 	app.get(
-		'/Article',
+		'/Article/*',
 		logRenderTime,
 		getContentFromURLMiddleware,
 		handleArticle,
 	);
-	app.use('/ArticleJson', handleArticleJson);
+	app.use('/ArticleJson/*', handleArticleJson);
 
 	app.get(
-		'/AMPArticle',
+		'/AMPArticle/*',
 		logRenderTime,
 		getContentFromURLMiddleware,
 		handleAMPArticle,
 	);
 
-	app.get('/Front', logRenderTime, getContentFromURLMiddleware, handleFront);
 	app.get(
-		'/FrontJSON',
+		'/Front/*',
+		logRenderTime,
+		getContentFromURLMiddleware,
+		handleFront,
+	);
+	app.get(
+		'/FrontJSON/*',
 		logRenderTime,
 		getContentFromURLMiddleware,
 		handleFrontJson,
 	);
 
 	app.get(
-		'/AppsArticle',
+		'/AppsArticle/*',
 		logRenderTime,
 		getContentFromURLMiddleware,
 		handleAppsArticle,
 	);
 
-	app.use('/ArticlePerfTest', handleArticlePerfTest);
-	app.use('/AMPArticlePerfTest', handleAMPArticlePerfTest);
+	app.use('/ArticlePerfTest/*', handleArticlePerfTest);
+	app.use('/AMPArticlePerfTest/*', handleAMPArticlePerfTest);
 
 	app.get('/', (req, res) => {
 		try {

--- a/scripts/deno/surface-lighthouse-results.ts
+++ b/scripts/deno/surface-lighthouse-results.ts
@@ -98,10 +98,8 @@ const generateAuditTable = (results: AssertionResult[]): string => {
 			)} | ${expected} | ${formatNumber(expected, actual)} |`,
 	);
 
-	const testedUrl = testUrl.searchParams.get('url') ?? '😪';
-
 	const table = [
-		`> tested url \`${testedUrl}\``,
+		`> tested url \`${testUrl}\``,
 		'',
 		'| Category | Status | Expected | Actual |',
 		'| --- | --- | --- | --- |',
@@ -118,7 +116,7 @@ const createLighthouseResultsMd = (): string => {
 	return [
 		IDENTIFIER_COMMENT,
 		`## ⚡️ Lighthouse report for the changes in this PR`,
-		`### [Report for ${testUrl.pathname}](${reportURL})`,
+		`### [Report for ${testUrl.pathname.split('/').at(1)}](${reportURL})`,
 		failedAuditCount > 0
 			? `⚠️ Budget exceeded for ${failedAuditCount} of ${auditCount} audits.`
 			: 'All audits passed',


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Remove the `?url=` pattern from our development and prod servers, in favour of `/`.

- this `/Article?url=https://www.theguardian.com/sport/blog/2015/dec/02/the-joy-of-six-sports-radio-documentaries`
- becomes `/Article/https://www.theguardian.com/sport/blog/2015/dec/02/the-joy-of-six-sports-radio-documentaries`

## Why?

This aligns the behaviour of our dev server more closely to our production builds, where pages are fully qualified paths. This means that `TopicFilterBank` could stop being an Island, as all its logic can be decided client-side. The complex logic of `parseURL`, which tries to reinsert query parameters, can be drastically simplified.

The ways in which DCR previously serves pages:
- `POST` to prod server (mainly `frontend`): send data of the top endpoints (Article, AMPArticle, Fronts, …)
- `GET` to dev & prod server (mainly CI and developement): a top endpoint (Article, AMPArticle, Fronts, …) with a `url` query param from which to fetch content
- `GET` to fastly (on the production website): a fully qualified path is turned into an id to fetch data from CAPI that is then sent via `frontend`.

With this change, there’s only two ways:

- `POST` to prod server (mainly `frontend`): send data of the top endpoints (Article, AMPArticle, Fronts, …)
- `GET` to fastly, dev & prod server: a fully qualified path that automatically* discovers where to get the data from.

*: the automatic transformation is different. We cannot do exactly the same as www.theguardian.com as we would otherwise be unable to use `frontend` / localhost:3000 as the source of for the data. This may be revisited in the future.

> **Note**
> If this looks odd to you, the Wayback machine also uses fully qualified URLs in paths, e.g. https://web.archive.org/web/20000301105534/http://google.com/ h/t @georgeblahblah 
 