### PR TITLE
DRAFT: Build out /EmailNewsletter page with DCR structures

### DIFF
--- a/dotcom-rendering/scripts/json-schema/check-schema.js
+++ b/dotcom-rendering/scripts/json-schema/check-schema.js
@@ -1,8 +1,12 @@
-const path = require('path');
 const fs = require('fs');
+const path = require('path');
 
 const root = path.resolve(__dirname, '..', '..');
-const { getArticleSchema, getFrontSchema } = require('./get-schema');
+const {
+	getArticleSchema,
+	getFrontSchema,
+	getNewsletterPageSchema,
+} = require('./get-schema');
 
 const existingArticleSchema = fs.readFileSync(
 	`${root}/src/model/article-schema.json`,
@@ -12,13 +16,19 @@ const existingFrontSchema = fs.readFileSync(
 	`${root}/src/model/front-schema.json`,
 	{ encoding: 'utf-8' },
 );
+const existingNewsletterSchema = fs.readFileSync(
+	`${root}/src/model/front-schema.json`,
+	{ encoding: 'utf-8' },
+);
 
 const articleSchema = getArticleSchema();
 const frontSchema = getFrontSchema();
+const newsletterSchema = getNewsletterPageSchema();
 
 if (
 	existingArticleSchema !== articleSchema ||
-	existingFrontSchema !== frontSchema
+	existingFrontSchema !== frontSchema ||
+	existingNewsletterSchema !== newsletterSchema
 ) {
 	throw new Error('Schemas do not match ... please run "make gen-schema"');
 } else {

--- a/dotcom-rendering/scripts/json-schema/gen-schema.js
+++ b/dotcom-rendering/scripts/json-schema/gen-schema.js
@@ -2,10 +2,15 @@ const path = require('path');
 
 const root = path.resolve(__dirname, '..', '..');
 const fs = require('fs');
-const { getArticleSchema, getFrontSchema } = require('./get-schema');
+const {
+	getArticleSchema,
+	getFrontSchema,
+	getNewsletterPageSchema,
+} = require('./get-schema');
 
 const articleSchema = getArticleSchema();
 const frontSchema = getFrontSchema();
+const newsletterPageSchema = getNewsletterPageSchema();
 
 fs.writeFile(
 	`${root}/src/model/article-schema.json`,
@@ -22,6 +27,18 @@ fs.writeFile(
 fs.writeFile(
 	`${root}/src/model/front-schema.json`,
 	frontSchema,
+	'utf8',
+	(err) => {
+		if (err) {
+			// eslint-disable-next-line @typescript-eslint/tslint/config
+			console.log(err);
+		}
+	},
+);
+
+fs.writeFile(
+	`${root}/src/model/newsletter-page-schema.json`,
+	newsletterPageSchema,
 	'utf8',
 	(err) => {
 		if (err) {

--- a/dotcom-rendering/scripts/json-schema/get-schema.js
+++ b/dotcom-rendering/scripts/json-schema/get-schema.js
@@ -7,6 +7,7 @@ const program = TJS.getProgramFromFiles(
 	[
 		path.resolve(`${root}/index.d.ts`),
 		path.resolve(`${root}/src/types/frontend.ts`),
+		path.resolve(`${root}/src/types/newslettersPage.ts`),
 	],
 	{
 		skipLibCheck: true,
@@ -26,6 +27,13 @@ module.exports = {
 	getFrontSchema: () => {
 		return JSON.stringify(
 			TJS.generateSchema(program, 'FEFrontType', settings),
+			null,
+			4,
+		);
+	},
+	getNewsletterPageSchema: () => {
+		return JSON.stringify(
+			TJS.generateSchema(program, 'FENewslettersPageType', settings),
 			null,
 			4,
 		);

--- a/dotcom-rendering/src/model/newsletter-page-schema.json
+++ b/dotcom-rendering/src/model/newsletter-page-schema.json
@@ -1,0 +1,483 @@
+{
+    "type": "object",
+    "properties": {
+        "id": {
+            "type": "string"
+        },
+        "newsletters": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "listId": {
+                        "type": "number"
+                    },
+                    "identityName": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "frequency": {
+                        "type": "string"
+                    },
+                    "successDescription": {
+                        "type": "string"
+                    },
+                    "theme": {
+                        "type": "string"
+                    },
+                    "group": {
+                        "type": "string"
+                    },
+                    "regionFocus": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "description",
+                    "frequency",
+                    "group",
+                    "identityName",
+                    "listId",
+                    "name",
+                    "successDescription",
+                    "theme"
+                ]
+            }
+        },
+        "editionId": {
+            "$ref": "#/definitions/EditionId"
+        },
+        "subscribeUrl": {
+            "type": "string"
+        },
+        "contributionsServiceUrl": {
+            "type": "string"
+        },
+        "beaconURL": {
+            "type": "string"
+        },
+        "webTitle": {
+            "type": "string"
+        },
+        "description": {
+            "type": "string"
+        },
+        "config": {
+            "type": "object",
+            "properties": {
+                "ajaxUrl": {
+                    "type": "string"
+                },
+                "sentryPublicApiKey": {
+                    "type": "string"
+                },
+                "sentryHost": {
+                    "type": "string"
+                },
+                "dcrSentryDsn": {
+                    "type": "string"
+                },
+                "switches": {
+                    "$ref": "#/definitions/Switches"
+                },
+                "abTests": {
+                    "description": "This type is not support by JSON-schema, it evaluates as `object`",
+                    "type": "object",
+                    "additionalProperties": {
+                        "enum": [
+                            "control",
+                            "variant"
+                        ],
+                        "type": "string"
+                    }
+                },
+                "dfpAccountId": {
+                    "type": "string"
+                },
+                "commercialBundleUrl": {
+                    "type": "string"
+                },
+                "revisionNumber": {
+                    "type": "string"
+                },
+                "isDev": {
+                    "type": "boolean"
+                },
+                "googletagUrl": {
+                    "type": "string"
+                },
+                "stage": {
+                    "$ref": "#/definitions/StageType"
+                },
+                "frontendAssetsFullURL": {
+                    "type": "string"
+                },
+                "adUnit": {
+                    "type": "string"
+                },
+                "isSensitive": {
+                    "type": "boolean"
+                },
+                "videoDuration": {
+                    "type": "number"
+                },
+                "edition": {
+                    "$ref": "#/definitions/EditionId"
+                },
+                "section": {
+                    "type": "string"
+                },
+                "sharedAdTargeting": {
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "idApiUrl": {
+                    "type": "string"
+                },
+                "discussionApiUrl": {
+                    "type": "string"
+                },
+                "discussionD2Uid": {
+                    "type": "string"
+                },
+                "discussionApiClientHeader": {
+                    "type": "string"
+                },
+                "isPhotoEssay": {
+                    "type": "boolean"
+                },
+                "references": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "host": {
+                    "type": "string"
+                },
+                "idUrl": {
+                    "type": "string"
+                },
+                "mmaUrl": {
+                    "type": "string"
+                },
+                "brazeApiKey": {
+                    "type": "string"
+                },
+                "ipsosTag": {
+                    "type": "string"
+                },
+                "isLiveBlog": {
+                    "type": "boolean"
+                },
+                "isLive": {
+                    "type": "boolean"
+                },
+                "isPreview": {
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "abTests",
+                "adUnit",
+                "ajaxUrl",
+                "commercialBundleUrl",
+                "dcrSentryDsn",
+                "dfpAccountId",
+                "discussionApiClientHeader",
+                "discussionApiUrl",
+                "discussionD2Uid",
+                "edition",
+                "frontendAssetsFullURL",
+                "googletagUrl",
+                "idApiUrl",
+                "isSensitive",
+                "revisionNumber",
+                "section",
+                "sentryHost",
+                "sentryPublicApiKey",
+                "sharedAdTargeting",
+                "stage",
+                "switches"
+            ]
+        },
+        "twitterData": {
+            "type": "object",
+            "additionalProperties": {
+                "type": "string"
+            }
+        },
+        "openGraphData": {
+            "type": "object",
+            "additionalProperties": {
+                "type": "string"
+            }
+        },
+        "nav": {
+            "$ref": "#/definitions/FENavType"
+        },
+        "pageFooter": {
+            "$ref": "#/definitions/FooterType"
+        },
+        "canonicalUrl": {
+            "type": "string"
+        },
+        "isAdFreeUser": {
+            "type": "boolean"
+        }
+    },
+    "required": [
+        "beaconURL",
+        "canonicalUrl",
+        "config",
+        "contributionsServiceUrl",
+        "description",
+        "editionId",
+        "id",
+        "isAdFreeUser",
+        "nav",
+        "newsletters",
+        "pageFooter",
+        "subscribeUrl",
+        "webTitle"
+    ],
+    "definitions": {
+        "EditionId": {
+            "enum": [
+                "AU",
+                "EUR",
+                "INT",
+                "UK",
+                "US"
+            ],
+            "type": "string"
+        },
+        "Switches": {
+            "type": "object",
+            "additionalProperties": {
+                "type": "boolean"
+            }
+        },
+        "StageType": {
+            "enum": [
+                "CODE",
+                "DEV",
+                "PROD"
+            ],
+            "type": "string"
+        },
+        "FENavType": {
+            "type": "object",
+            "properties": {
+                "currentUrl": {
+                    "type": "string"
+                },
+                "pillars": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/FELinkType"
+                    }
+                },
+                "otherLinks": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/FELinkType"
+                    }
+                },
+                "brandExtensions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/FELinkType"
+                    }
+                },
+                "currentNavLink": {
+                    "$ref": "#/definitions/FELinkType"
+                },
+                "currentNavLinkTitle": {
+                    "type": "string"
+                },
+                "currentPillarTitle": {
+                    "type": "string"
+                },
+                "subNavSections": {
+                    "type": "object",
+                    "properties": {
+                        "parent": {
+                            "$ref": "#/definitions/FELinkType"
+                        },
+                        "links": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/FELinkType"
+                            }
+                        }
+                    },
+                    "required": [
+                        "links"
+                    ]
+                },
+                "readerRevenueLinks": {
+                    "$ref": "#/definitions/ReaderRevenuePositions"
+                }
+            },
+            "required": [
+                "brandExtensions",
+                "currentUrl",
+                "otherLinks",
+                "pillars",
+                "readerRevenueLinks"
+            ]
+        },
+        "FELinkType": {
+            "type": "object",
+            "properties": {
+                "url": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "longTitle": {
+                    "type": "string"
+                },
+                "iconName": {
+                    "type": "string"
+                },
+                "children": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/FELinkType"
+                    }
+                },
+                "pillar": {
+                    "$ref": "#/definitions/LegacyPillar"
+                },
+                "more": {
+                    "type": "boolean"
+                },
+                "classList": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "title",
+                "url"
+            ]
+        },
+        "LegacyPillar": {
+            "enum": [
+                "culture",
+                "labs",
+                "lifestyle",
+                "news",
+                "opinion",
+                "sport"
+            ],
+            "type": "string"
+        },
+        "ReaderRevenuePositions": {
+            "type": "object",
+            "properties": {
+                "header": {
+                    "$ref": "#/definitions/ReaderRevenueCategories"
+                },
+                "footer": {
+                    "$ref": "#/definitions/ReaderRevenueCategories"
+                },
+                "sideMenu": {
+                    "$ref": "#/definitions/ReaderRevenueCategories"
+                },
+                "ampHeader": {
+                    "$ref": "#/definitions/ReaderRevenueCategories"
+                },
+                "ampFooter": {
+                    "$ref": "#/definitions/ReaderRevenueCategories"
+                }
+            },
+            "required": [
+                "ampFooter",
+                "ampHeader",
+                "footer",
+                "header",
+                "sideMenu"
+            ]
+        },
+        "ReaderRevenueCategories": {
+            "type": "object",
+            "properties": {
+                "contribute": {
+                    "type": "string"
+                },
+                "subscribe": {
+                    "type": "string"
+                },
+                "support": {
+                    "type": "string"
+                },
+                "supporter": {
+                    "type": "string"
+                },
+                "gifting": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "contribute",
+                "subscribe",
+                "support",
+                "supporter"
+            ]
+        },
+        "FooterType": {
+            "type": "object",
+            "properties": {
+                "footerLinks": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/definitions/FooterLink"
+                        }
+                    }
+                }
+            },
+            "required": [
+                "footerLinks"
+            ]
+        },
+        "FooterLink": {
+            "type": "object",
+            "properties": {
+                "text": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                },
+                "dataLinkName": {
+                    "type": "string"
+                },
+                "extraClasses": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "dataLinkName",
+                "text",
+                "url"
+            ]
+        }
+    },
+    "$schema": "http://json-schema.org/draft-07/schema#"
+}

--- a/dotcom-rendering/src/model/validate.ts
+++ b/dotcom-rendering/src/model/validate.ts
@@ -4,8 +4,10 @@ import Ajv from 'ajv';
 import addFormats from 'ajv-formats';
 import type { FEFrontType } from '../../src/types/front';
 import type { FEArticleType } from '../types/frontend';
+import type { FENewslettersPageType } from '../types/newslettersPage';
 import articleSchema from './article-schema.json';
 import frontSchema from './front-schema.json';
+import newslettersPageSchema from './newsletter-page-schema.json';
 
 const options: Options = {
 	verbose: false,
@@ -19,6 +21,9 @@ addFormats(ajv);
 
 const validateArticle = ajv.compile<FEArticleType>(articleSchema);
 const validateFront = ajv.compile<FEFrontType>(frontSchema);
+const validateNewslettersPage = ajv.compile<FENewslettersPageType>(
+	newslettersPageSchema,
+);
 
 export const validateAsArticleType = (data: unknown): FEArticleType => {
 	if (validateArticle(data)) return data;
@@ -41,5 +46,15 @@ export const validateAsFrontType = (data: unknown): FEFrontType => {
 	throw new TypeError(
 		`Unable to validate request body for url ${url}.\n
             ${JSON.stringify(validateFront.errors, null, 2)}`,
+	);
+};
+
+export const validateAsNewslettersPageType = (
+	data: unknown,
+): FENewslettersPageType => {
+	if (validateNewslettersPage(data)) return data;
+	throw new TypeError(
+		`Unable to validate request body for newsletters page.\n
+		${JSON.stringify(validateNewslettersPage.errors, null, 2)}`,
 	);
 };

--- a/dotcom-rendering/src/server/dev-server.ts
+++ b/dotcom-rendering/src/server/dev-server.ts
@@ -8,6 +8,7 @@ import {
 	handleFrontJson,
 	handleInteractive,
 	handleKeyEvents,
+	handleNewslettersPage,
 } from '../web/server';
 
 /** article URLs contain a part that looks like “2022/nov/25” */
@@ -38,6 +39,8 @@ export const devServer = (): Handler => {
 				return handleFront(req, res, next);
 			case '/FrontJSON':
 				return handleFrontJson(req, res, next);
+			case '/EmailNewsletters':
+				return handleNewslettersPage(req, res, next);
 			default: {
 				if (req.url.match(ARTICLE_URL)) {
 					const url = new URL(

--- a/dotcom-rendering/src/server/prod-server.ts
+++ b/dotcom-rendering/src/server/prod-server.ts
@@ -16,6 +16,7 @@ import {
 	handleFrontJson,
 	handleInteractive,
 	handleKeyEvents,
+	handleNewslettersPage,
 } from '../web/server';
 import { recordBaselineCloudWatchMetrics } from './lib/aws/metrics-baseline';
 import { getContentFromURLMiddleware } from './lib/get-content-from-url';
@@ -60,6 +61,7 @@ export const prodServer = (): void => {
 	app.post('/KeyEvents', logRenderTime, handleKeyEvents);
 	app.post('/Front', logRenderTime, handleFront);
 	app.post('/FrontJSON', logRenderTime, handleFrontJson);
+	app.post('/EmailNewsletter', logRenderTime, handleNewslettersPage);
 
 	// These GET's are for checking any given URL directly from PROD
 	app.get(
@@ -83,6 +85,13 @@ export const prodServer = (): void => {
 		logRenderTime,
 		getContentFromURLMiddleware,
 		handleFrontJson,
+	);
+
+	app.get(
+		'/EmailNewsletter',
+		logRenderTime,
+		getContentFromURLMiddleware,
+		handleNewslettersPage,
 	);
 
 	app.use('/ArticlePerfTest', handleArticlePerfTest);

--- a/dotcom-rendering/src/types/newslettersPage.ts
+++ b/dotcom-rendering/src/types/newslettersPage.ts
@@ -1,0 +1,69 @@
+import type { EditionId } from '../web/lib/edition';
+import type { ServerSideTests, Switches } from './config';
+import type { Newsletter } from './content';
+import type { FooterType } from './footer';
+import type { TagType } from './tag';
+
+type FENewslettersConfigType = {
+	ajaxUrl: string;
+	sentryPublicApiKey: string;
+	sentryHost: string;
+	dcrSentryDsn: string;
+	switches: Switches;
+	abTests: ServerSideTests;
+	dfpAccountId: string;
+	commercialBundleUrl: string;
+	revisionNumber: string;
+	isDev?: boolean;
+	googletagUrl: string;
+	stage: StageType;
+	frontendAssetsFullURL: string;
+	adUnit: string;
+	isSensitive: boolean;
+	videoDuration?: number;
+	edition: EditionId;
+	section: string;
+	sharedAdTargeting: { [key: string]: any };
+	idApiUrl: string;
+	discussionApiUrl: string;
+	discussionD2Uid: string;
+	discussionApiClientHeader: string;
+	isPhotoEssay?: boolean;
+	references?: { [key: string]: string }[];
+	host?: string;
+	idUrl?: string;
+	mmaUrl?: string;
+	brazeApiKey?: string;
+	ipsosTag?: string;
+	isLiveBlog?: boolean;
+	isLive?: boolean;
+	isPreview?: boolean;
+};
+
+export interface FENewslettersPageType {
+	id: string;
+	newsletters: Newsletter[];
+	editionId: EditionId;
+	subscribeUrl: string;
+	contributionsServiceUrl: string;
+	beaconURL: string;
+	webTitle: string;
+	description: string;
+	config: FENewslettersConfigType;
+	twitterData?: {
+		[key: string]: string;
+	};
+	openGraphData?: {
+		[key: string]: string;
+	};
+	nav: FENavType;
+	pageFooter: FooterType;
+	canonicalUrl: string;
+	isAdFreeUser: boolean;
+}
+
+export type DCRNewslettersPageType = FENewslettersPageType & {
+	sectionName?: string;
+	format?: FEFormat;
+	tags?: TagType[];
+};

--- a/dotcom-rendering/src/web/components/NewsletterList.tsx
+++ b/dotcom-rendering/src/web/components/NewsletterList.tsx
@@ -1,0 +1,66 @@
+import { css } from '@emotion/react';
+import { brandAlt, headline, space } from '@guardian/source-foundations';
+import { LinkButton } from '@guardian/source-react-components';
+import type { Newsletter } from '../../types/content';
+import type { EditionId } from '../lib/edition';
+import { getEditionFromId } from '../lib/edition';
+import { NewsletterPrivacyMessage } from './NewsletterPrivacyMessage';
+import { Section } from './Section';
+
+export interface NewslettersListProps {
+	newsletters: Newsletter[];
+	headingText: string;
+	mmaUrl?: string;
+	editionId: EditionId;
+}
+
+export const NewslettersList = ({
+	newsletters,
+	headingText,
+	mmaUrl,
+	editionId,
+}: NewslettersListProps) => {
+	const edition = getEditionFromId(editionId);
+
+	return (
+		<>
+			<Section fullWidth={true} element="header" padBottom={true}>
+				<h1
+					css={css`
+						${headline.large()}
+					`}
+				>
+					{headingText}
+				</h1>
+				<div
+					css={css`
+						${headline.small()}
+					`}
+				>
+					{edition.longTitle}
+				</div>
+
+				{!!mmaUrl && (
+					<LinkButton href={`${mmaUrl}/email-prefs`} size={'small'}>
+						Manage my newsletters
+					</LinkButton>
+				)}
+			</Section>
+
+			<Section fullWidth={true} padBottom={true}>
+				<div
+					css={css`
+						background-color: ${brandAlt[400]};
+						padding: ${space[2]}px ${space[4]}px;
+					`}
+				>
+					<NewsletterPrivacyMessage />
+				</div>
+			</Section>
+
+			{newsletters.map((newsletter) => {
+				return <p key={newsletter.name}>{newsletter.name}</p>;
+			})}
+		</>
+	);
+};

--- a/dotcom-rendering/src/web/components/NewsletterList.tsx
+++ b/dotcom-rendering/src/web/components/NewsletterList.tsx
@@ -58,9 +58,11 @@ export const NewslettersList = ({
 				</div>
 			</Section>
 
-			{newsletters.map((newsletter) => {
-				return <p key={newsletter.name}>{newsletter.name}</p>;
-			})}
+			<Section fullWidth={true} padBottom={true}>
+				{newsletters.map((newsletter) => {
+					return <p key={newsletter.name}>{newsletter.name}</p>;
+				})}
+			</Section>
 		</>
 	);
 };

--- a/dotcom-rendering/src/web/components/NewslettersPage.tsx
+++ b/dotcom-rendering/src/web/components/NewslettersPage.tsx
@@ -1,0 +1,63 @@
+import { css, Global } from '@emotion/react';
+import { brandAlt, focusHalo, neutral } from '@guardian/source-foundations';
+import { StrictMode } from 'react';
+import type { NavType } from '../../model/extract-nav';
+import type { DCRNewslettersPageType } from '../../types/newslettersPage';
+import { NewslettersPageLayout } from '../layouts/NewslettersPageLayout';
+import { AlreadyVisited } from './AlreadyVisited.importable';
+import { FocusStyles } from './FocusStyles.importable';
+import { Island } from './Island';
+import { Metrics } from './Metrics.importable';
+import { SkipTo } from './SkipTo';
+
+type Props = {
+	newslettersPage: DCRNewslettersPageType;
+	NAV: NavType;
+};
+
+/**
+ * @description
+ * FrontPage is a high level wrapper for front pages on Dotcom. Sets strict mode and some globals
+ *
+ * @param {Props} props
+ * @param {DCRFrontType} props.front - The article JSON data
+ * @param {NAVType} props.NAV - The article JSON data
+ * */
+export const NewslettersPage = ({ newslettersPage, NAV }: Props) => {
+	return (
+		<StrictMode>
+			<Global
+				styles={css`
+					/* Crude but effective mechanism. Specific components may need to improve on this behaviour. */
+					/* The not(.src...) selector is to work with Source's FocusStyleManager. */
+					*:focus {
+						${focusHalo}
+					}
+					::selection {
+						background: ${brandAlt[400]};
+						color: ${neutral[7]};
+					}
+				`}
+			/>
+			<SkipTo id="maincontent" label="Skip to main content" />
+			<SkipTo id="navigation" label="Skip to navigation" />
+			<Island clientOnly={true} deferUntil="idle">
+				<AlreadyVisited />
+			</Island>
+			<Island clientOnly={true} deferUntil="idle">
+				<FocusStyles />
+			</Island>
+			<Island clientOnly={true} deferUntil="idle">
+				<Metrics
+					commercialMetricsEnabled={
+						!!newslettersPage.config.switches.commercialMetrics
+					}
+				/>
+			</Island>
+			<NewslettersPageLayout
+				newslettersPage={newslettersPage}
+				NAV={NAV}
+			/>
+		</StrictMode>
+	);
+};

--- a/dotcom-rendering/src/web/layouts/NewslettersPageLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/NewslettersPageLayout.tsx
@@ -1,0 +1,178 @@
+import { css } from '@emotion/react';
+import {
+	brandBackground,
+	brandBorder,
+	brandLine,
+	palette,
+} from '@guardian/source-foundations';
+import { StraightLines } from '@guardian/source-react-components-development-kitchen';
+import type { NavType } from '../../model/extract-nav';
+import type { DCRNewslettersPageType } from '../../types/newslettersPage';
+import { Footer } from '../components/Footer';
+import { Header } from '../components/Header';
+import { HeaderAdSlot } from '../components/HeaderAdSlot';
+import { Island } from '../components/Island';
+import { Nav } from '../components/Nav/Nav';
+import { NewslettersList } from '../components/NewsletterList';
+import { Section } from '../components/Section';
+import { SubNav } from '../components/SubNav.importable';
+import { decideFormat } from '../lib/decideFormat';
+import { Stuck } from './lib/stickiness';
+
+type Props = {
+	newslettersPage: DCRNewslettersPageType;
+	NAV: NavType;
+};
+
+/**
+ * @description
+ * Article is a high level wrapper for stand alone pages on Dotcom. Sets strict mode and some globals
+ *
+ * */
+export const NewslettersPageLayout = ({ newslettersPage, NAV }: Props) => {
+	const {
+		subscribeUrl,
+		editionId,
+		pageFooter,
+		format,
+		contributionsServiceUrl: pageContributionsServiceUrl,
+		config,
+		isAdFreeUser,
+	} = newslettersPage;
+	const articleFormat: ArticleFormat = decideFormat(format ?? {});
+
+	const renderAds = !isAdFreeUser;
+
+	const isInEuropeTest =
+		config.abTests.europeNetworkFrontVariant === 'variant';
+
+	const contributionsServiceUrl =
+		process.env.SDC_URL ?? pageContributionsServiceUrl;
+
+	return (
+		<>
+			<div data-print-layout="hide" id="bannerandheader">
+				<>
+					{renderAds && (
+						<Stuck>
+							<Section
+								fullWidth={true}
+								showTopBorder={false}
+								showSideBorders={false}
+								padSides={false}
+								shouldCenter={false}
+							>
+								<HeaderAdSlot display={articleFormat.display} />
+							</Section>
+						</Stuck>
+					)}
+					<Section
+						fullWidth={true}
+						shouldCenter={false}
+						showTopBorder={false}
+						showSideBorders={false}
+						padSides={false}
+						backgroundColour={brandBackground.primary}
+						element="header"
+					>
+						<Header
+							editionId={newslettersPage.editionId}
+							idUrl={newslettersPage.config.idUrl}
+							mmaUrl={newslettersPage.config.mmaUrl}
+							discussionApiUrl={
+								newslettersPage.config.discussionApiUrl
+							}
+							urls={newslettersPage.nav.readerRevenueLinks.header}
+							remoteHeader={
+								!!newslettersPage.config.switches.remoteHeader
+							}
+							contributionsServiceUrl={contributionsServiceUrl}
+							idApiUrl={config.idApiUrl}
+							isInEuropeTest={isInEuropeTest}
+							headerTopBarSearchCapiSwitch={
+								!!newslettersPage.config.switches
+									.headerTopBarSearchCapi
+							}
+						/>
+					</Section>
+					<Section
+						fullWidth={true}
+						borderColour={brandLine.primary}
+						showTopBorder={false}
+						padSides={false}
+						backgroundColour={brandBackground.primary}
+						element="nav"
+					>
+						<Nav
+							headerTopBarSwitch={false}
+							nav={NAV}
+							format={articleFormat}
+							subscribeUrl={subscribeUrl}
+							editionId={editionId}
+						/>
+					</Section>
+					{NAV.subNavSections && (
+						<>
+							<Section
+								fullWidth={true}
+								backgroundColour={palette.neutral[100]}
+								padSides={false}
+								element="aside"
+							>
+								<Island deferUntil="idle">
+									<SubNav
+										subNavSections={NAV.subNavSections}
+										currentNavLink={NAV.currentNavLink}
+										format={articleFormat}
+									/>
+								</Island>
+							</Section>
+							<Section
+								fullWidth={true}
+								backgroundColour={palette.neutral[100]}
+								padSides={false}
+								showTopBorder={false}
+							>
+								<StraightLines
+									count={4}
+									cssOverrides={css`
+										display: block;
+									`}
+									color={palette.brand[400]}
+								/>
+							</Section>
+						</>
+					)}
+				</>
+			</div>
+
+			<main data-layout="NewsletterPage" id="maincontent">
+				<NewslettersList
+					newsletters={newslettersPage.newsletters}
+					mmaUrl={newslettersPage.config.mmaUrl}
+					editionId={newslettersPage.editionId}
+					headingText={newslettersPage.webTitle}
+				/>
+			</main>
+
+			<Section
+				fullWidth={true}
+				data-print-layout="hide"
+				padSides={false}
+				backgroundColour={brandBackground.primary}
+				borderColour={brandBorder.primary}
+				showSideBorders={false}
+				element="footer"
+			>
+				<Footer
+					pageFooter={pageFooter}
+					pillar={articleFormat.theme}
+					pillars={NAV.pillars}
+					urls={NAV.readerRevenueLinks.header}
+					editionId={editionId}
+					contributionsServiceUrl={contributionsServiceUrl}
+				/>
+			</Section>
+		</>
+	);
+};

--- a/dotcom-rendering/src/web/server/index.ts
+++ b/dotcom-rendering/src/web/server/index.ts
@@ -8,14 +8,17 @@ import { enhanceTableOfContents } from '../../model/enhanceTableOfContents';
 import {
 	validateAsArticleType,
 	validateAsFrontType,
+	validateAsNewslettersPageType,
 } from '../../model/validate';
 import type { DCRFrontType, FEFrontType } from '../../types/front';
 import type { FEArticleType } from '../../types/frontend';
+import type { DCRNewslettersPageType } from '../../types/newslettersPage';
 import { decideTrail } from '../lib/decideTrail';
 import { articleToHtml } from './articleToHtml';
 import { blocksToHtml } from './blocksToHtml';
 import { frontToHtml } from './frontToHtml';
 import { keyEventsToHtml } from './keyEventsToHtml';
+import { newsletterPageToHtml } from './newslettersPageToHtml';
 
 function enhancePinnedPost(format: FEFormat, block?: Block) {
 	return block ? enhanceBlocks([block], format)[0] : block;
@@ -196,4 +199,21 @@ export const handleFront: RequestHandler = ({ body }, res) => {
 
 export const handleFrontJson: RequestHandler = ({ body }, res) => {
 	res.json(enhanceFront(body));
+};
+
+const enhanceNewslettersPage = (body: unknown): DCRNewslettersPageType => {
+	const newsletterData = validateAsNewslettersPageType(body);
+	return {
+		...newsletterData,
+	};
+};
+
+export const handleNewslettersPage: RequestHandler = ({ body }, res) => {
+	try {
+		const newslettersPage = enhanceNewslettersPage(body);
+		const html = newsletterPageToHtml({ newslettersPage });
+		res.status(200).send(html);
+	} catch (e) {
+		res.status(500).send(`<pre>${getStack(e)}</pre>`);
+	}
 };

--- a/dotcom-rendering/src/web/server/newslettersPageToHtml.tsx
+++ b/dotcom-rendering/src/web/server/newslettersPageToHtml.tsx
@@ -1,0 +1,103 @@
+import {
+	BUILD_VARIANT,
+	dcrJavascriptBundle,
+} from '../../../scripts/webpack/bundles';
+import { generateScriptTags, getScriptsFromManifest } from '../../lib/assets';
+import { escapeData } from '../../lib/escapeData';
+import { extractNAV } from '../../model/extract-nav';
+import { makeWindowGuardian } from '../../model/window-guardian';
+import type { DCRNewslettersPageType } from '../../types/newslettersPage';
+import { NewslettersPage } from '../components/NewslettersPage';
+import { renderToStringWithEmotion } from '../lib/emotion';
+import { getHttp3Url } from '../lib/getHttp3Url';
+import { pageTemplate } from './pageTemplate';
+
+interface Props {
+	newslettersPage: DCRNewslettersPageType;
+}
+
+export const newsletterPageToHtml = ({ newslettersPage }: Props): string => {
+	const title = newslettersPage.webTitle;
+	const NAV = extractNAV(newslettersPage.nav);
+
+	const { html, extractedCss } = renderToStringWithEmotion(
+		<NewslettersPage newslettersPage={newslettersPage} NAV={NAV} />,
+	);
+
+	// Evaluating the performance of HTTP3 over HTTP2
+	// See: https://github.com/guardian/dotcom-rendering/pull/5394
+	const { offerHttp3 = false } = newslettersPage.config.switches;
+
+	const polyfillIO =
+		'https://assets.guim.co.uk/polyfill.io/v3/polyfill.min.js?rum=0&features=es6,es7,es2017,es2018,es2019,default-3.6,HTMLPictureElement,IntersectionObserver,IntersectionObserverEntry,URLSearchParams,fetch,NodeList.prototype.forEach,navigator.sendBeacon,performance.now,Promise.allSettled&flags=gated&callback=guardianPolyfilled&unknown=polyfill&cacheClear=1';
+
+	const shouldServeVariantBundle: boolean = [
+		BUILD_VARIANT,
+		newslettersPage.config.abTests[dcrJavascriptBundle('Variant')] ===
+			'variant',
+	].every(Boolean);
+
+	/**
+	 * This function returns an array of files found in the manifests
+	 * defined by `manifestPaths`.
+	 *
+	 * @see getScriptsFromManifest
+	 */
+	const getScriptArrayFromFile = getScriptsFromManifest(
+		shouldServeVariantBundle,
+	);
+
+	/**
+	 * The highest priority scripts.
+	 * These scripts have a considerable impact on site performance.
+	 * Only scripts critical to application execution may go in here.
+	 * Please talk to the dotcom platform team before adding more.
+	 * Scripts will be executed in the order they appear in this array
+	 */
+	const scriptTags = generateScriptTags(
+		[
+			polyfillIO,
+			...getScriptArrayFromFile('frameworks.js'),
+			...getScriptArrayFromFile('index.js'),
+			process.env.COMMERCIAL_BUNDLE_URL ??
+				newslettersPage.config.commercialBundleUrl,
+		].map((script) => (offerHttp3 ? getHttp3Url(script) : script)),
+	);
+
+	/**
+	 * We escape windowGuardian here to prevent errors when the data
+	 * is placed in a script tag on the page
+	 */
+	const windowGuardian = escapeData(
+		JSON.stringify(
+			makeWindowGuardian({
+				editionId: newslettersPage.editionId,
+				stage: newslettersPage.config.stage,
+				frontendAssetsFullURL:
+					newslettersPage.config.frontendAssetsFullURL,
+				revisionNumber: newslettersPage.config.revisionNumber,
+				sentryPublicApiKey: newslettersPage.config.sentryPublicApiKey,
+				sentryHost: newslettersPage.config.sentryHost,
+				keywordIds: '', // TODO: Check for implications of having this be just a string
+				dfpAccountId: newslettersPage.config.dfpAccountId,
+				adUnit: newslettersPage.config.adUnit,
+				ajaxUrl: newslettersPage.config.ajaxUrl,
+				googletagUrl: newslettersPage.config.googletagUrl,
+				switches: newslettersPage.config.switches,
+				abTests: newslettersPage.config.abTests,
+				brazeApiKey: newslettersPage.config.brazeApiKey,
+			}),
+		),
+	);
+
+	return pageTemplate({
+		scriptTags,
+		css: extractedCss,
+		html,
+		title,
+		description: newslettersPage.description,
+		windowGuardian,
+		keywords: '',
+		offerHttp3,
+	});
+};


### PR DESCRIPTION
Co-Authored-By: David Blatcher <30567854+dblatcher@users.noreply.github.com>

<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

## Why?

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->


<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
