### PR TITLE
Use bucketSsmKey for static assets

### DIFF
--- a/dotcom-rendering/scripts/deploy/riff-raff.yaml
+++ b/dotcom-rendering/scripts/deploy/riff-raff.yaml
@@ -30,7 +30,7 @@ deployments:
   frontend-static:
     type: aws-s3
     parameters:
-      bucket: aws-frontend-static
+      bucketSsmKey: /account/services/dotcom-static.bucket
       cacheControl: public, max-age=315360000, immutable
       prefixStack: false
       publicReadAcl: false


### PR DESCRIPTION
## What does this change?

Uses `bucketSsmKey` field to look up the destination for static assets, as per DevX recommendations now that it's available for this resource type (see this [comment on a previous attempt to implement it](https://github.com/guardian/frontend/pull/25708#discussion_r1030592952) and also #7098).
