### PR TITLE
Add ad slot containers

### DIFF
--- a/dotcom-rendering/src/web/components/AdSlot.tsx
+++ b/dotcom-rendering/src/web/components/AdSlot.tsx
@@ -287,7 +287,7 @@ export const AdSlot = ({
 			}
 		case 'comments': {
 			return (
-				<div css={[adStyles]}>
+				<div className="ad-slot-container" css={[adStyles]}>
 					<div
 						id="dfp-ad--comments"
 						className={[
@@ -350,7 +350,7 @@ export const AdSlot = ({
 		}
 		case 'mostpop': {
 			return (
-				<div css={[adStyles]}>
+				<div className="ad-slot-container" css={[adStyles]}>
 					<div
 						id="dfp-ad--mostpop"
 						className={[

--- a/dotcom-rendering/src/web/components/AdSlot.tsx
+++ b/dotcom-rendering/src/web/components/AdSlot.tsx
@@ -317,7 +317,7 @@ export const AdSlot = ({
 			`;
 			const topAboveNavContainerStyles = css`
 				width: 100%;
-				&[child-ad-rendered] {
+				&[top-above-nav-ad-rendered] {
 					margin: 0 auto;
 					width: fit-content;
 				}

--- a/dotcom-rendering/src/web/components/AdSlot.tsx
+++ b/dotcom-rendering/src/web/components/AdSlot.tsx
@@ -316,12 +316,8 @@ export const AdSlot = ({
 				min-width: 728px;
 			`;
 			const topAboveNavContainerStyles = css`
-				:has(div.ad-slot--fluid) {
-					margin: 0 auto;
-					width: fit-content;
-				}
-
-				:has(div[data-label-show='true']) {
+				width: 100%;
+				&[child-ad-rendered] {
 					margin: 0 auto;
 					width: fit-content;
 				}

--- a/dotcom-rendering/src/web/components/AdSlot.tsx
+++ b/dotcom-rendering/src/web/components/AdSlot.tsx
@@ -253,7 +253,7 @@ export const AdSlot = ({
 				case ArticleDisplay.Showcase:
 				case ArticleDisplay.NumberedList: {
 					return (
-						<div css={[adStyles]} className="ad-slot-container">
+						<div className="ad-slot-container" css={[adStyles]}>
 							<div
 								id="dfp-ad--right"
 								className={[
@@ -355,6 +355,7 @@ export const AdSlot = ({
 		case 'merchandising-high': {
 			return (
 				<div
+					className="ad-slot-container"
 					css={[
 						css`
 							display: flex;
@@ -362,7 +363,6 @@ export const AdSlot = ({
 						`,
 						adStyles,
 					]}
-					className="ad-slot-container"
 				>
 					<div
 						id="dfp-ad--merchandising-high"
@@ -386,6 +386,7 @@ export const AdSlot = ({
 		case 'merchandising': {
 			return (
 				<div
+					className="ad-slot-container"
 					css={[
 						css`
 							display: flex;
@@ -393,7 +394,6 @@ export const AdSlot = ({
 						`,
 						adStyles,
 					]}
-					className="ad-slot-container"
 				>
 					<div
 						id="dfp-ad--merchandising"

--- a/dotcom-rendering/src/web/components/AdSlot.tsx
+++ b/dotcom-rendering/src/web/components/AdSlot.tsx
@@ -315,33 +315,21 @@ export const AdSlot = ({
 				display: block;
 				min-width: 728px;
 			`;
-			const topAboveNavContainerStyles = css`
-				width: 100%;
-				&[top-above-nav-ad-rendered] {
-					margin: 0 auto;
-					width: fit-content;
-				}
-			`;
 			return (
 				<div
-					className="ad-slot-container"
-					css={topAboveNavContainerStyles}
-				>
-					<div
-						id="dfp-ad--top-above-nav"
-						className={[
-							'js-ad-slot',
-							'ad-slot',
-							'ad-slot--top-above-nav',
-							'ad-slot--mpu-banner-ad',
-							'ad-slot--rendered',
-						].join(' ')}
-						css={[adStyles, fluidFullWidthAdStyles, adSlotAboveNav]}
-						data-link-name="ad slot top-above-nav"
-						data-name="top-above-nav"
-						aria-hidden="true"
-					></div>
-				</div>
+					id="dfp-ad--top-above-nav"
+					className={[
+						'js-ad-slot',
+						'ad-slot',
+						'ad-slot--top-above-nav',
+						'ad-slot--mpu-banner-ad',
+						'ad-slot--rendered',
+					].join(' ')}
+					css={[adStyles, fluidFullWidthAdStyles, adSlotAboveNav]}
+					data-link-name="ad slot top-above-nav"
+					data-name="top-above-nav"
+					aria-hidden="true"
+				></div>
 			);
 		}
 		case 'mostpop': {

--- a/dotcom-rendering/src/web/components/AdSlot.tsx
+++ b/dotcom-rendering/src/web/components/AdSlot.tsx
@@ -253,7 +253,7 @@ export const AdSlot = ({
 				case ArticleDisplay.Showcase:
 				case ArticleDisplay.NumberedList: {
 					return (
-						<div css={[adStyles]}>
+						<div css={[adStyles]} className="ad-slot-container">
 							<div
 								id="dfp-ad--right"
 								className={[
@@ -378,6 +378,7 @@ export const AdSlot = ({
 						`,
 						adStyles,
 					]}
+					className="ad-slot-container"
 				>
 					<div
 						id="dfp-ad--merchandising-high"
@@ -408,6 +409,7 @@ export const AdSlot = ({
 						`,
 						adStyles,
 					]}
+					className="ad-slot-container"
 				>
 					<div
 						id="dfp-ad--merchandising"

--- a/dotcom-rendering/src/web/components/AdSlot.tsx
+++ b/dotcom-rendering/src/web/components/AdSlot.tsx
@@ -315,21 +315,37 @@ export const AdSlot = ({
 				display: block;
 				min-width: 728px;
 			`;
+			const topAboveNavContainerStyles = css`
+				:has(div.ad-slot--fluid) {
+					margin: 0 auto;
+					width: fit-content;
+				}
+
+				:has(div[data-label-show='true']) {
+					margin: 0 auto;
+					width: fit-content;
+				}
+			`;
 			return (
 				<div
-					id="dfp-ad--top-above-nav"
-					className={[
-						'js-ad-slot',
-						'ad-slot',
-						'ad-slot--top-above-nav',
-						'ad-slot--mpu-banner-ad',
-						'ad-slot--rendered',
-					].join(' ')}
-					css={[adStyles, fluidFullWidthAdStyles, adSlotAboveNav]}
-					data-link-name="ad slot top-above-nav"
-					data-name="top-above-nav"
-					aria-hidden="true"
-				></div>
+					className="ad-slot-container"
+					css={topAboveNavContainerStyles}
+				>
+					<div
+						id="dfp-ad--top-above-nav"
+						className={[
+							'js-ad-slot',
+							'ad-slot',
+							'ad-slot--top-above-nav',
+							'ad-slot--mpu-banner-ad',
+							'ad-slot--rendered',
+						].join(' ')}
+						css={[adStyles, fluidFullWidthAdStyles, adSlotAboveNav]}
+						data-link-name="ad slot top-above-nav"
+						data-name="top-above-nav"
+						aria-hidden="true"
+					></div>
+				</div>
 			);
 		}
 		case 'mostpop': {

--- a/dotcom-rendering/src/web/components/HeaderAdSlot.tsx
+++ b/dotcom-rendering/src/web/components/HeaderAdSlot.tsx
@@ -29,6 +29,10 @@ const headerAdWrapper = css`
 
 	position: sticky;
 	top: 0;
+
+	&[top-above-nav-ad-rendered] {
+		width: fit-content;
+	}
 `;
 
 export const HeaderAdSlot = ({ display }: Props) => (

--- a/dotcom-rendering/src/web/components/TopRightAdSlot.importable.tsx
+++ b/dotcom-rendering/src/web/components/TopRightAdSlot.importable.tsx
@@ -19,6 +19,7 @@ export const TopRightAdSlot = ({
 	return (
 		<div
 			id="top-right-ad-slot"
+			className="ad-slot-container"
 			css={[
 				css`
 					position: static;
@@ -26,7 +27,6 @@ export const TopRightAdSlot = ({
 				`,
 				adStyles,
 			]}
-			className="ad-slot-container"
 		>
 			<div
 				id="dfp-ad--right"

--- a/dotcom-rendering/src/web/components/TopRightAdSlot.importable.tsx
+++ b/dotcom-rendering/src/web/components/TopRightAdSlot.importable.tsx
@@ -26,6 +26,7 @@ export const TopRightAdSlot = ({
 				`,
 				adStyles,
 			]}
+			className="ad-slot-container"
 		>
 			<div
 				id="dfp-ad--right"


### PR DESCRIPTION
Adds containers to fixed ad slots rendered by dotcom-rendering. This provides a div that we can use in future work. You can find the corresponding frontend ticket [here](https://github.com/guardian/frontend/pull/25891).