### PR TITLE
add dev-debug target to the makefile

### DIFF
--- a/dotcom-rendering/makefile
+++ b/dotcom-rendering/makefile
@@ -88,7 +88,7 @@ dev-legacy: clear clean-dist install
 dev-debug: clear clean-dist install
 	$(call log, "starting DEV server and debugger")
 	$(call log, "Open chrome://inspect in Chrome to attach to the debugger")
-	@NODE_ENV=development SKIP_LEGACY=true node --inspect ../node_modules/webpack/bin/webpack.js serve --config ./scripts/webpack/webpack.config.js
+	@NODE_ENV=development SKIP_LEGACY=true NODE_OPTIONS="--inspect" webpack serve --config ./scripts/webpack/webpack.config.js
 
 # tests #####################################
 

--- a/dotcom-rendering/makefile
+++ b/dotcom-rendering/makefile
@@ -85,6 +85,11 @@ dev-legacy: clear clean-dist install
 	$(call log, "starting DEV server")
 	@NODE_ENV=development webpack serve --config ./scripts/webpack/webpack.config.js
 
+dev-debug: clear clean-dist install
+	$(call log, "starting DEV server and debugger")
+	$(call log, "Open chrome://inspect in Chrome to attach to the debugger")
+	@NODE_ENV=development SKIP_LEGACY=true node --inspect ../node_modules/webpack/bin/webpack.js serve --config ./scripts/webpack/webpack.config.js
+
 # tests #####################################
 
 cypress: clear clean-dist install build


### PR DESCRIPTION
## What does this change?

- adds a `dev-debug` target to the makefile
  - run with `make dev-debug`
  - you can then attach Chrome's DevTools to the debug port by visiting `chrome://inspect` and clicking "Open dedicated DevTools for Node"

## Why?

- Just a convenience really. It was already possible to debug browser modules in the browser's inspector. This makes it easier to debug server modules

## Screenshots

<img width="1511" alt="Screenshot 2023-02-10 at 16 45 19" src="https://user-images.githubusercontent.com/705427/218147915-2e6cbb58-3638-4747-b6e0-65666222c210.png">
