### PR TITLE
SSR `TopicFilterBank`

### DIFF
--- a/dotcom-rendering/src/web/components/FilterLink.stories.tsx
+++ b/dotcom-rendering/src/web/components/FilterLink.stories.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
 import { breakpoints } from '@guardian/source-foundations';
-import { FilterButton } from './FilterButton.importable';
+import { FilterLink } from './FilterLink';
 
 const Wrapper = ({ children }: { children: React.ReactNode }) => (
 	<div
@@ -20,8 +20,8 @@ const format = {
 };
 
 export default {
-	component: FilterButton,
-	title: 'Components/FilterButton',
+	component: FilterLink,
+	title: 'Components/FilterLink',
 	parameters: {
 		// Set the viewports in Chromatic at a component level.
 		chromatic: {
@@ -36,13 +36,13 @@ export default {
 
 export const DefaultStory = () => (
 	<Wrapper>
-		<FilterButton
+		<FilterLink
 			isActive={false}
 			type="ORG"
 			value="nhs"
 			count={21}
 			format={format}
-			onClick={() => {}}
+			href={'?#'}
 		/>
 	</Wrapper>
 );
@@ -51,13 +51,13 @@ DefaultStory.story = { name: 'Default' };
 
 export const ActiveStory = () => (
 	<Wrapper>
-		<FilterButton
+		<FilterLink
 			isActive={true}
 			type="ORG"
 			value="nhs"
 			count={21}
 			format={format}
-			onClick={() => {}}
+			href={'?#'}
 		/>
 	</Wrapper>
 );
@@ -66,13 +66,13 @@ ActiveStory.story = { name: 'Active' };
 
 export const TruncatedStory = () => (
 	<Wrapper>
-		<FilterButton
+		<FilterLink
 			isActive={false}
 			type="ORG"
 			value="Something thats too long to fit"
 			count={21}
 			format={format}
-			onClick={() => {}}
+			href={'?#'}
 		/>
 	</Wrapper>
 );
@@ -81,13 +81,13 @@ TruncatedStory.story = { name: 'Truncated' };
 
 export const TruncatedActiveStory = () => (
 	<Wrapper>
-		<FilterButton
+		<FilterLink
 			isActive={true}
 			type="ORG"
 			value="Something thats too long to fit"
 			count={21}
 			format={format}
-			onClick={() => {}}
+			href={'?#'}
 		/>
 	</Wrapper>
 );
@@ -96,11 +96,11 @@ TruncatedActiveStory.story = { name: 'TruncatedActive' };
 
 export const FilterKeyEventsStory = () => (
 	<Wrapper>
-		<FilterButton
+		<FilterLink
 			isActive={false}
 			value="Filter Key Events"
 			format={format}
-			onClick={() => {}}
+			href={'?#'}
 		/>
 	</Wrapper>
 );
@@ -109,11 +109,11 @@ FilterKeyEventsStory.story = { name: 'FilterKeyEvents' };
 
 export const FilterKeyEventsActiveStory = () => (
 	<Wrapper>
-		<FilterButton
+		<FilterLink
 			isActive={true}
 			value="Filter Key Events"
 			format={format}
-			onClick={() => {}}
+			href={'?#'}
 		/>
 	</Wrapper>
 );

--- a/dotcom-rendering/src/web/components/FilterLink.tsx
+++ b/dotcom-rendering/src/web/components/FilterLink.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import { space, textSans } from '@guardian/source-foundations';
-import { Button, SvgCross } from '@guardian/source-react-components';
+import { LinkButton, SvgCross } from '@guardian/source-react-components';
 import type { Palette } from '../../types/palette';
 import { decidePalette } from '../lib/decidePalette';
 
@@ -15,7 +15,7 @@ interface ButtonProps {
 	count?: number;
 	format: ArticleFormat;
 	isActive: boolean;
-	onClick: (...args: unknown[]) => void;
+	href: string;
 }
 
 const buttonStyles = (palette: Palette) => css`
@@ -76,51 +76,45 @@ const Label = ({ value, count }: LabelProps) => (
 );
 
 /**
- * # Filter Button
+ * # Filter Link
  *
  * A child of `TopicFilterBank`
- *
- * ## Why does this need to be an Island?
- *
- * ⚠️ It does not need to be! ⚠️
- *
- * (It is embedded within `TopicFilterBank`)
  *
  * ---
  *
  * [`FilterButton` on Chromatic](https://www.chromatic.com/component?appId=63e251470cfbe61776b0ef19&csfId=components-filterbutton)
  */
-export const FilterButton = ({
+export const FilterLink = ({
 	type,
 	value,
 	count,
 	isActive,
 	format,
-	onClick,
+	href,
 }: ButtonProps) => {
 	const palette = decidePalette(format);
 
 	const dataLinkName = type ? `${type}:${value}` : value;
 
 	return isActive ? (
-		<Button
+		<LinkButton
 			cssOverrides={[buttonStyles(palette), activeStyles(palette)]}
-			onClick={onClick}
+			href={href}
 			icon={<SvgCross />}
 			iconSide="right"
 			aria-label={`Deactivate ${value} filter`}
 			data-link-name={`${dataLinkName} | filter off`}
 		>
 			<Label value={value} count={count} />
-		</Button>
+		</LinkButton>
 	) : (
-		<Button
+		<LinkButton
 			cssOverrides={buttonStyles(palette)}
-			onClick={onClick}
+			href={href}
 			aria-label={`Activate ${value} filter`}
 			data-link-name={`${dataLinkName} | filter on`}
 		>
 			<Label value={value} count={count} />
-		</Button>
+		</LinkButton>
 	);
 };

--- a/dotcom-rendering/src/web/components/TopicFilterBank.stories.tsx
+++ b/dotcom-rendering/src/web/components/TopicFilterBank.stories.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
-import { TopicFilterBank } from './TopicFilterBank.importable';
+import { TopicFilterBank } from './TopicFilterBank';
 
 const availableTopics: Topic[] = [
 	{ type: 'GPE', value: 'London', count: 16 },

--- a/dotcom-rendering/src/web/components/TopicFilterBank.test.tsx
+++ b/dotcom-rendering/src/web/components/TopicFilterBank.test.tsx
@@ -1,4 +1,4 @@
-import { hasRelevantTopics } from './TopicFilterBank.importable';
+import { hasRelevantTopics } from './TopicFilterBank';
 
 describe('hasRelevantTopics', () => {
 	describe('should be false', () => {

--- a/dotcom-rendering/src/web/components/TopicFilterBank.tsx
+++ b/dotcom-rendering/src/web/components/TopicFilterBank.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/react';
 import { from, headline, space, textSans } from '@guardian/source-foundations';
 import type { Palette } from '../../types/palette';
 import { decidePalette } from '../lib/decidePalette';
-import { FilterButton } from './FilterButton.importable';
+import { FilterLink } from './FilterLink';
 
 type Props = {
 	availableTopics?: Topic[];
@@ -41,34 +41,24 @@ const topicStyles = css`
 	}
 `;
 
-const handleTopicClick = (
-	isActive: boolean,
-	buttonParams: string,
-	id: string,
-) => {
-	const urlParams = new URLSearchParams(window.location.search);
+const getTopicLink = (isActive: boolean, topics: string, id: Props['id']) => {
+	const urlParams = new URLSearchParams(
+		isActive
+			? {
+					topics,
+			  }
+			: {},
+	);
 
-	if (!isActive) {
-		urlParams.set('topics', buttonParams);
-	} else {
-		urlParams.delete('topics');
-	}
-	urlParams.delete('page'); // direct to the first page
-	urlParams.delete('filterKeyEvents');
-
-	window.location.hash = id;
-	window.location.search = urlParams.toString();
+	return `?${urlParams.toString()}#${id}`;
 };
 
-const handleKeyEventClick = (filterKeyEvents: boolean, id: string) => {
-	const urlParams = new URLSearchParams(window.location.search);
+const getKeyEventLink = (filterKeyEvents: boolean, id: Props['id']) => {
+	const urlParams = new URLSearchParams({
+		filterKeyEvents: filterKeyEvents ? 'false' : 'true',
+	});
 
-	urlParams.set('filterKeyEvents', filterKeyEvents ? 'false' : 'true');
-	urlParams.delete('page'); // direct to the first page
-	urlParams.delete('topics');
-
-	window.location.hash = id;
-	window.location.search = urlParams.toString();
+	return `?${urlParams.toString()}#${id}`;
 };
 
 const isEqual = (selectedTopic: Topic, availableTopic: Topic) =>
@@ -87,13 +77,7 @@ export const hasRelevantTopics = (availableTopics?: Topic[]) => {
 /**
  * # Topic Filter Bank
  *
- * A wrapper of Filter Buttons.
- *
- * ## Why does this need to be an Island?
- *
- * ⚠️ It does not need to be! ⚠️
- *
- * Redirecting to a URL should not require us to have a click handler.
+ * A wrapper of filter links.
  *
  * ---
  *
@@ -130,32 +114,28 @@ export const TopicFilterBank = ({
 			</div>
 			<div css={topicStyles}>
 				{keyEvents?.length ? (
-					<FilterButton
+					<FilterLink
 						value={'Key events'}
 						count={keyEvents.length}
 						format={format}
 						isActive={filterKeyEvents}
-						onClick={() => {
-							handleKeyEventClick(filterKeyEvents, id);
-						}}
+						href={getKeyEventLink(filterKeyEvents, id)}
 					/>
 				) : null}
 
 				{topFiveTopics.map((topic) => {
-					const buttonParams = `${topic.type}:${topic.value}`;
+					const linkParams = `${topic.type}:${topic.value}`;
 					const isActive =
 						!!selectedTopic && isEqual(selectedTopic, topic);
 
 					return (
-						<FilterButton
+						<FilterLink
 							value={topic.value}
 							type={topic.type}
 							count={topic.count}
 							format={format}
 							isActive={isActive}
-							onClick={() =>
-								handleTopicClick(isActive, buttonParams, id)
-							}
+							href={getTopicLink(isActive, linkParams, id)}
 							key={`filter-${topic.value}`}
 						/>
 					);

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -55,7 +55,7 @@ import { SubNav } from '../components/SubNav.importable';
 import {
 	hasRelevantTopics,
 	TopicFilterBank,
-} from '../components/TopicFilterBank.importable';
+} from '../components/TopicFilterBank';
 import { getContributionsServiceUrl } from '../lib/contributions';
 import { decidePalette } from '../lib/decidePalette';
 import { decideTrail } from '../lib/decideTrail';
@@ -741,26 +741,22 @@ export const LiveLayout = ({ article, NAV, format }: Props) => {
 								{showTopicFilterBank && (
 									<Hide until="desktop">
 										<div css={sidePaddingDesktop}>
-											<Island>
-												<TopicFilterBank
-													availableTopics={
-														article.availableTopics
-													}
-													selectedTopics={
-														article.selectedTopics
-													}
-													format={format}
-													keyEvents={
-														article.keyEvents
-													}
-													filterKeyEvents={
-														article.filterKeyEvents
-													}
-													id={
-														'key-events-carousel-desktop'
-													}
-												/>
-											</Island>
+											<TopicFilterBank
+												availableTopics={
+													article.availableTopics
+												}
+												selectedTopics={
+													article.selectedTopics
+												}
+												format={format}
+												keyEvents={article.keyEvents}
+												filterKeyEvents={
+													article.filterKeyEvents
+												}
+												id={
+													'key-events-carousel-desktop'
+												}
+											/>
 										</div>
 									</Hide>
 								)}

--- a/dotcom-rendering/src/web/lib/LiveBlogRenderer.tsx
+++ b/dotcom-rendering/src/web/lib/LiveBlogRenderer.tsx
@@ -12,7 +12,7 @@ import { PinnedPost } from '../components/PinnedPost';
 import {
 	hasRelevantTopics,
 	TopicFilterBank,
-} from '../components/TopicFilterBank.importable';
+} from '../components/TopicFilterBank';
 
 type Props = {
 	format: ArticleFormat;
@@ -121,16 +121,14 @@ export const LiveBlogRenderer = ({
 			{switches.automaticFilters &&
 				hasRelevantTopics(availableTopics) && (
 					<Hide above="desktop">
-						<Island>
-							<TopicFilterBank
-								availableTopics={availableTopics}
-								selectedTopics={selectedTopics}
-								format={format}
-								keyEvents={keyEvents}
-								filterKeyEvents={filterKeyEvents}
-								id={'key-events-carousel-mobile'}
-							/>
-						</Island>
+						<TopicFilterBank
+							availableTopics={availableTopics}
+							selectedTopics={selectedTopics}
+							format={format}
+							keyEvents={keyEvents}
+							filterKeyEvents={filterKeyEvents}
+							id={'key-events-carousel-mobile'}
+						/>
 					</Hide>
 				)}
 			<div id="top-of-blog" />


### PR DESCRIPTION
## What does this change?

Convert `TopicFilterBank` into a server-side only component, no longer and Island. Instead of parsing a page’s URL, it simply links to the current path with the adequate parameters, e.g. `<a href="?filterKeyEvents=true">Filter Key Events</a>`

Depends on #7166 for these buttons to work in development.

## Why?

This component can simply be a `LinkButton` with an href. This was discovered as part of the auditing of existing Islands in #7124 

It was originally introduced in #5247 – we plan on doing futher investigation on why it was chosen to make this an Island in the first place.