### PR TITLE
Add path to logRendertime function

### DIFF
--- a/dotcom-rendering/src/server/prod-server.ts
+++ b/dotcom-rendering/src/server/prod-server.ts
@@ -24,11 +24,12 @@ import { logger } from './lib/logging';
 // Middleware to track route performance using 'response-time' lib
 // Usage: app.post('/Article', logRenderTime, renderArticle);
 const logRenderTime = responseTime(
-	({ body }: Request, _: Response, time: number) => {
+	({ body, path }: Request, _: Response, renderTime: number) => {
 		const { pageId = 'no-page-id-found' } = body as FEArticleType;
 		logger.info('Page render time', {
+			path,
 			pageId,
-			renderTime: time,
+			renderTime,
 		});
 	},
 );


### PR DESCRIPTION
Co-authored-by: James Gorrie <james.gorrie@guardian.co.uk>

<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Adds the path (e.g. `/Article`) to the renderTime logging function that gets sent to logs.gutools.

## Why?

This should help with investigating performance issues by grouping requests by the broader path getting requested (e.g. articles, fronts, interactives).