### PR TITLE
Front containers using CSS grid

### DIFF
--- a/dotcom-rendering/src/web/components/FrontContainer.stories.tsx
+++ b/dotcom-rendering/src/web/components/FrontContainer.stories.tsx
@@ -1,0 +1,328 @@
+import { css } from '@emotion/react';
+import {
+	brand,
+	brandAlt,
+	breakpoints,
+	neutral,
+} from '@guardian/source-foundations';
+import { FrontContainer } from './FrontContainer';
+
+export default {
+	component: FrontContainer,
+	title: 'Components/FrontGrid',
+	parameters: {
+		viewport: {
+			// This has the effect of turning off the viewports addon by default
+			defaultViewport: 'doesNotExist',
+		},
+		chromatic: {
+			viewports: [
+				breakpoints.mobile,
+				breakpoints.tablet,
+				breakpoints.desktop,
+				breakpoints.leftCol,
+				breakpoints.wide,
+			],
+		},
+	},
+};
+
+const Placeholder = ({
+	heightInPixels = 400,
+	text = 'Placeholder Content',
+}: {
+	heightInPixels?: number;
+	text?: string;
+}) => (
+	<div
+		css={css`
+			background-color: lightgrey;
+			width: 100%;
+			height: ${heightInPixels}px;
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			font-size: 2em;
+			font-weight: 200;
+		`}
+	>
+		{text}
+	</div>
+);
+
+export const ContainerStory = () => {
+	return (
+		<FrontContainer
+			title="Default Container"
+			showTopBorder={false}
+			showSideBorders={false}
+		>
+			<Placeholder />
+		</FrontContainer>
+	);
+};
+ContainerStory.story = { name: 'default container' };
+
+export const NoTitleStory = () => {
+	return (
+		<FrontContainer showTopBorder={false} showSideBorders={false}>
+			<Placeholder />
+		</FrontContainer>
+	);
+};
+NoTitleStory.story = { name: 'with no title' };
+
+export const BordersStory = () => {
+	return (
+		<FrontContainer title="Borders" centralBorder="full">
+			<Placeholder />
+		</FrontContainer>
+	);
+};
+BordersStory.story = { name: 'with all borders' };
+
+export const LeftContentStory = () => {
+	return (
+		<FrontContainer
+			title="Borders"
+			centralBorder="full"
+			leftContent={<Placeholder text="LeftCol" heightInPixels={200} />}
+		>
+			<Placeholder />
+		</FrontContainer>
+	);
+};
+LeftContentStory.story = {
+	name: 'with an element passed into the left column',
+};
+
+export const BackgroundStory = () => {
+	return (
+		<FrontContainer
+			title="Background Colour"
+			description="About this content"
+			fontColour={neutral[100]}
+			centralBorder="full"
+			backgroundColour={brand[400]}
+			borderColour={brand[600]}
+		>
+			<Placeholder />
+		</FrontContainer>
+	);
+};
+BackgroundStory.story = { name: 'with a blue background' };
+
+export const InnerBackgroundStory = () => {
+	return (
+		<FrontContainer
+			title="Inner Background"
+			description="About this content"
+			fontColour={neutral[100]}
+			centralBorder="full"
+			innerBackgroundColour={brand[400]}
+			borderColour={brand[300]}
+		>
+			<Placeholder />
+		</FrontContainer>
+	);
+};
+InnerBackgroundStory.story = {
+	name: 'with a blue inner background',
+};
+
+export const DifferentBackgrounds = () => {
+	return (
+		<FrontContainer
+			title="Tip us off"
+			centralBorder="full"
+			backgroundColour="#FFF280"
+			borderColour={brand[300]}
+			innerBackgroundColour="#FFE501"
+		>
+			<h1>
+				👀 Share stories with the Guardian securely and confidentially
+			</h1>
+		</FrontContainer>
+	);
+};
+DifferentBackgrounds.story = {
+	name: 'with inner background different to main background',
+};
+
+export const StretchRightStory = () => {
+	return (
+		<FrontContainer
+			title="Stretched Right"
+			description="About this content"
+			centralBorder="full"
+			stretchRight={true}
+		>
+			<Placeholder />
+		</FrontContainer>
+	);
+};
+StretchRightStory.story = {
+	name: 'with content stretched to the right (no margin)',
+};
+
+export const PartialStory = () => {
+	return (
+		<FrontContainer
+			title="Borders"
+			showTopBorder={false}
+			centralBorder="partial"
+		>
+			<Placeholder />
+		</FrontContainer>
+	);
+};
+PartialStory.story = { name: 'with a partial border divider' };
+
+export const SidesStory = () => {
+	return (
+		<FrontContainer
+			title="NoSides"
+			showTopBorder={false}
+			centralBorder="full"
+			padContent={false}
+		>
+			<Placeholder />
+		</FrontContainer>
+	);
+};
+SidesStory.story = { name: 'with a full border divider' };
+
+export const ToggleableStory = () => {
+	return (
+		<FrontContainer
+			title="Toggleable Container"
+			toggleable={true}
+			sectionId="section-id"
+			showTopBorder={false}
+			showSideBorders={false}
+		>
+			<Placeholder />
+		</FrontContainer>
+	);
+};
+ToggleableStory.story = { name: 'toggleable container' };
+
+export const MarginsStory = () => {
+	return (
+		<>
+			<FrontContainer
+				title="No Vertical Margins"
+				centralBorder="full"
+				verticalMargins={false}
+			>
+				<Placeholder />
+			</FrontContainer>
+			<FrontContainer
+				title="No Vertical Margins"
+				centralBorder="full"
+				verticalMargins={false}
+			>
+				<Placeholder />
+			</FrontContainer>
+			<FrontContainer
+				title="No Vertical Margins"
+				centralBorder="full"
+				verticalMargins={false}
+			>
+				<Placeholder />
+			</FrontContainer>
+		</>
+	);
+};
+MarginsStory.story = { name: 'with no vertical margins' };
+
+export const MultipleStory = () => {
+	return (
+		<>
+			<FrontContainer title="Page Title" showTopBorder={false} />
+			<FrontContainer title="Headlines" centralBorder="partial">
+				<Placeholder />
+			</FrontContainer>
+			<FrontContainer title="Useful links" centralBorder="partial" />
+			<FrontContainer
+				title="Around the World - I'm a link"
+				url="https://www.theguardian.com/world"
+				centralBorder="partial"
+			>
+				<Placeholder />
+			</FrontContainer>
+			<FrontContainer
+				showTopBorder={false}
+				showSideBorders={false}
+				backgroundColour={brandAlt[400]}
+			>
+				<h2>Insert call to action here</h2>
+			</FrontContainer>
+			<FrontContainer
+				title="Videos"
+				fontColour="white"
+				showTopBorder={false}
+				backgroundColour="black"
+				showSideBorders={false}
+			>
+				<Placeholder />
+			</FrontContainer>
+			<FrontContainer
+				title="Coronavirus"
+				description="A collection of stories about Coronavirus"
+				centralBorder="partial"
+			>
+				<Placeholder />
+			</FrontContainer>
+		</>
+	);
+};
+MultipleStory.story = {
+	name: 'with multiple FrontGrids',
+	parameters: {
+		chromatic: {
+			viewports: [
+				breakpoints.mobile,
+				breakpoints.leftCol,
+				breakpoints.wide,
+			],
+		},
+	},
+};
+
+export const TreatsStory = () => {
+	return (
+		<FrontContainer
+			title="Treats and Date Header"
+			treats={[
+				{
+					links: [
+						{
+							text: 'The treat text',
+							linkTo: '',
+						},
+					],
+					editionId: 'UK',
+				},
+				{
+					links: [
+						{
+							text: 'Another piece of text',
+							linkTo: '',
+						},
+					],
+					editionId: 'UK',
+				},
+			]}
+			showTopBorder={false}
+			showSideBorders={false}
+			showDateHeader={true}
+			editionId="UK"
+		>
+			<Placeholder />
+		</FrontContainer>
+	);
+};
+TreatsStory.story = {
+	name: 'with treats and date header',
+};

--- a/dotcom-rendering/src/web/components/FrontContainer.stories.tsx
+++ b/dotcom-rendering/src/web/components/FrontContainer.stories.tsx
@@ -9,7 +9,7 @@ import { FrontContainer } from './FrontContainer';
 
 export default {
 	component: FrontContainer,
-	title: 'Components/FrontGrid',
+	title: 'Components/FrontContainer',
 	parameters: {
 		viewport: {
 			// This has the effect of turning off the viewports addon by default

--- a/dotcom-rendering/src/web/components/FrontContainer.tsx
+++ b/dotcom-rendering/src/web/components/FrontContainer.tsx
@@ -1,0 +1,555 @@
+import { css, jsx } from '@emotion/react';
+import type { ArticleFormat } from '@guardian/libs';
+import { from, neutral, space } from '@guardian/source-foundations';
+import type { DCRContainerPalette, TreatType } from '../../types/front';
+import { decideContainerOverrides } from '../lib/decideContainerOverrides';
+import type { EditionId } from '../lib/edition';
+import { ContainerTitle } from './ContainerTitle';
+import { ShowHideButton } from './ShowHideButton';
+import { Treats } from './Treats';
+
+type Props = {
+	/** This text will be used as the h2 shown in the left column for the section */
+	title?: string;
+	/** Allows the colour of the title to be changed */
+	fontColour?: string;
+	/** This text shows below the title */
+	description?: string;
+	/** The title can be made into a link using this property */
+	url?: string;
+	/** The html `id` property of the element */
+	sectionId?: string;
+	/** Defaults to `true`. If we should render the left and right borders */
+	showSideBorders?: boolean;
+	centralBorder?: 'partial' | 'full';
+	/** Defaults to `true`. If we should render the top border */
+	showTopBorder?: boolean;
+	/** Defaults to `false`. If we should add padding to the sides of `children` */
+	padContent?: boolean;
+	/** The html tag used by Section defaults to `section` but can be overridden here */
+	element?:
+		| 'div'
+		| 'article'
+		| 'aside'
+		| 'nav'
+		| 'main'
+		| 'header'
+		| 'section'
+		| 'footer';
+	/** Defaults to `true`. Adds margins to the top and bottom */
+	verticalMargins?: boolean;
+	/** Applies a background colour to the entire width */
+	backgroundColour?: string;
+	/** The colour of borders can be overriden */
+	borderColour?: string;
+	/** A React component can be passed to be inserted inside the left column */
+	leftContent?: React.ReactNode;
+	children?: React.ReactNode;
+	/** Defaults to `false`. If true, `children` is rendered all the way right */
+	stretchRight?: boolean;
+	/** Defaults to `compact`. Some page types have a different left column width */
+	leftColSize?: LeftColSize;
+	/** @deprecated no longer used */
+	format?: ArticleFormat;
+	/** The string used to set the `data-component` Ophan attribute */
+	ophanComponentName?: string;
+	/** The string used to set the `data-link-name` Ophan attribute */
+	ophanComponentLink?: string;
+	/**
+	 * 🛠️ DEBUG ONLY 🛠️
+	 * Used to highlight the name of a container when DCR debug mode is enabled
+	 *
+	 * @see https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/src/web/browser/debug/README.md
+	 */
+	containerName?: string;
+	/** Fronts containers can have their styling overridden using a `containerPalette` */
+	containerPalette?: DCRContainerPalette;
+	/** Defaults to `false`. If true a Hide button is show top right allowing this section
+	 * to be collapsed
+	 */
+	toggleable?: boolean;
+	/** Applies a background colour only to the content inside the left and right borders */
+	innerBackgroundColour?: string;
+	/** Defaults to `false`. If true and `editionId` is also passed, then a date string is
+	 * shown under the title. Typically only used on Headlines containers on fronts
+	 */
+	showDateHeader?: boolean;
+	/** Used in partnership with `showDateHeader` to localise the date string */
+	editionId?: EditionId;
+	/** A list of related links that appear in the bottom of the left column on fronts */
+	treats?: TreatType[];
+};
+
+const width = (columns: number, columnWidth: number, columnGap: number) =>
+	`width: ${columns * columnWidth + (columns - 1) * columnGap}px;`;
+
+/** Not all browsers support CSS grid, so we set explicit width as a fallback */
+const fallbackStyles = css`
+	padding: 0 12px;
+	margin: 0 auto;
+
+	${from.mobileLandscape} {
+		padding: 0 20px;
+	}
+
+	${from.tablet} {
+		${width(12, 40, 20)}
+	}
+
+	${from.desktop} {
+		${width(12, 60, 20)}
+	}
+
+	${from.leftCol} {
+		${width(14, 60, 20)}
+	}
+
+	${from.wide} {
+		${width(16, 60, 20)}
+	}
+
+	@supports (display: grid) {
+		width: 100%;
+		padding: 0;
+		margin: 0;
+	}
+`;
+
+const containerStyles = css`
+	display: grid;
+	grid-template-columns:
+		[viewport-start] 0px
+		[content-start title-start]
+		repeat(3, minmax(0, 1fr))
+		[title-end hide-start]
+		minmax(0, 1fr)
+		[content-end hide-end]
+		0px [viewport-end];
+	column-gap: 10px;
+
+	${from.mobileLandscape} {
+		column-gap: 20px;
+	}
+
+	${from.tablet} {
+		grid-template-columns:
+			[viewport-start] minmax(0, 1fr)
+			[content-start title-start]
+			repeat(11, 40px)
+			[title-end hide-start]
+			40px
+			[content-end hide-end]
+			minmax(0, 1fr) [viewport-end];
+	}
+
+	${from.desktop} {
+		grid-template-columns:
+			[viewport-start] minmax(0, 1fr)
+			[content-start title-start]
+			repeat(11, 60px)
+			[title-end hide-start]
+			60px
+			[content-end hide-end]
+			minmax(0, 1fr) [viewport-end];
+	}
+
+	${from.leftCol} {
+		grid-template-columns:
+			[viewport-start] minmax(0, 1fr)
+			[title-start]
+			repeat(2, 60px)
+			[title-end content-start]
+			repeat(11, 60px)
+			[hide-start]
+			60px
+			[hide-end content-end]
+			minmax(0, 1fr) [viewport-end];
+	}
+
+	${from.wide} {
+		grid-template-columns:
+			[viewport-start] minmax(0, 1fr)
+			[title-start]
+			repeat(3, 60px)
+			[title-end content-start]
+			repeat(12, 60px)
+			[content-end hide-start]
+			60px
+			[hide-end]
+			minmax(0, 1fr) [viewport-end];
+	}
+
+	grid-auto-flow: dense;
+	grid-template-rows: auto [content-start] auto;
+
+	${from.leftCol} {
+		grid-template-rows: [content-start] repeat(2, auto);
+	}
+`;
+
+const wideLeftColumn = css`
+	${from.leftCol} {
+		grid-template-columns:
+			[viewport-start] minmax(0, 1fr)
+			[title-start]
+			repeat(3, 60px)
+			[title-end content-start]
+			repeat(10, 60px)
+			[hide-start]
+			60px
+			[hide-end content-end] minmax(0, 1fr) [viewport-end];
+	}
+`;
+
+const sectionContentStretchedRight = css`
+	${from.wide} {
+		grid-template-columns:
+			[viewport-start] minmax(0, 1fr)
+			[title-start]
+			repeat(3, 60px)
+			[title-end content-start]
+			repeat(12, 60px)
+			[hide-start]
+			60px
+			[hide-end content-end]
+			minmax(0, 1fr) [viewport-end];
+	}
+`;
+
+const containerStylesToggleable = css`
+	${from.leftCol} {
+		grid-template-rows: auto [content-start] repeat(2, auto);
+	}
+	${from.wide} {
+		grid-template-rows: [content-start] repeat(3, auto);
+	}
+`;
+
+const headlineContainerStyles = css`
+	grid-row-start: 1;
+	grid-column: title;
+	${from.leftCol} {
+		grid-row-end: span 2;
+	}
+
+	display: flex;
+	flex-direction: column;
+`;
+
+const headlineContainerBorders = css`
+	${from.leftCol} {
+		position: relative;
+		::after {
+			content: '';
+			display: block;
+			width: 1px;
+			top: 0;
+			height: 1.875rem;
+			right: -10px;
+			position: absolute;
+			background-color: ${neutral[86]};
+		}
+	}
+`;
+
+const paddings = css`
+	padding-top: ${space[2]}px;
+	padding-bottom: ${space[9]}px;
+`;
+
+const sectionShowHide = css`
+	grid-row-start: 1;
+	grid-column: hide;
+	justify-self: end;
+`;
+
+const sectionContent = css`
+	margin: 0;
+
+	.hidden > & {
+		display: none;
+	}
+
+	grid-column: content;
+
+	grid-row-start: content-start;
+	${from.leftCol} {
+		grid-row-end: span 2;
+	}
+	${from.wide} {
+		grid-row-end: -1;
+	}
+`;
+
+const sectionContentBorder = css`
+	position: relative;
+
+	${from.leftCol} {
+		::before {
+			content: '';
+			display: block;
+			width: 1px;
+			top: 0;
+			bottom: 0;
+			left: -10px;
+			position: absolute;
+			background-color: ${neutral[86]};
+		}
+	}
+`;
+
+const sectionContentPadded = css`
+	${from.tablet} {
+		margin-left: -10px;
+		margin-right: -10px;
+	}
+`;
+
+const sectionTreats = css`
+	display: none;
+
+	${from.leftCol} {
+		display: block;
+		align-self: end;
+		grid-row-start: -2;
+		grid-column: title;
+	}
+
+	.hidden > & {
+		display: none;
+	}
+`;
+
+/** element which contains border and inner background colour, if set */
+const decoration = css`
+	grid-row: 1 / -1;
+
+	grid-column: 1 / -1;
+	${from.tablet} {
+		grid-column: 2 / -2;
+	}
+
+	border-width: 1px;
+	border-color: ${neutral[86]};
+	border-style: none;
+`;
+
+/** only visible once content stops sticking to left and right edges */
+const sideBorders = css`
+	${from.tablet} {
+		margin: 0 -20px;
+		border-left-style: solid;
+		border-right-style: solid;
+	}
+`;
+
+const topBorder = css`
+	border-top-style: solid;
+`;
+
+/**
+ * # Front Container
+ *
+ * A container for fronts, which generally contains sets of cards.
+ *
+ * Provides borders, spacing, colours, a title and features specific to fronts
+ * such as show/hide toggle button. Content slotted as `children` is placed
+ * in the centre. Extra elements can be passed to `leftContent`, which will
+ * automatically fall into the left column on larger breakpoints.
+ *
+ * Defaults to an HTML `section`, but the specific tag can be set.
+ *
+ * @example
+ *
+ * from `mobile` (320) to `phablet` (660)
+ *  1 2 3 4
+ * ┌─────┬─┐
+ * │Title│X│
+ * ├─────┴─┤
+ * │▒▒▒▒▒▒▒│
+ * │▒▒▒▒▒▒▒│
+ * └───────┘
+ *
+ * from `tablet` (740) to `desktop` (980)
+ *
+ *  1 2 3 4 5 6 7 8 9 a b c (12)
+ * ┌─────────────────────┬─┐
+ * │Title                │X│
+ * │Date                 │ │
+ * ├─────────────────────┴─┤
+ * │▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒│
+ * │▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒│
+ * └───────────────────────┘
+ *
+ * on `leftCol` (1140) if component is toggleable
+ *
+ *  1 2 3 4 5 6 7 8 9 a b c d e (14)
+ * ┌───┬───────────────────┬─┐
+ * │Tit│                   │X│
+ * │Dat├───────────────────┴─┤
+ * ├───┤▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒│
+ * │   │▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒│
+ * │Tre│▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒│
+ * │ats│▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒│
+ * └───┴─────────────────────┘
+ *
+ * on `leftCol` (1140) if component is not toggleable
+ *
+ *  1 2 3 4 5 6 7 8 9 a b c d e (14)
+ * ┌───┬──────────────────────┐
+ * │Tit│▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒│
+ * │Dat│▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒│
+ * ├───┤▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒│
+ * │   │▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒│
+ * │Tre│▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒│
+ * │ats│▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒│
+ * └───┴──────────────────────┘
+ *
+ * on `wide` (1300)
+ *
+ *  1 2 3 4 5 6 7 8 9 a b c d e f g (16)
+ * ┌─────┬───────────────────────┬─┐
+ * │Title│▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒│X│
+ * │Date │▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒└─┤
+ * ├─────┤▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒  │
+ * │     │▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒  │
+ * │     │▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒  │
+ * │Treat│▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒  │
+ * └─────┴─────────────────────────┘
+ *
+ * on `wide` (1300) with `stretchRight`
+ *
+ *  1 2 3 4 5 6 7 8 9 a b c d e f g (16)
+ * ┌─────┬─────────────────────────┐
+ * │Title│▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒│
+ * │Date │▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒│
+ * ├─────┤▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒│
+ * │     │▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒│
+ * │     │▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒│
+ * │Treat│▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒│
+ * └─────┴─────────────────────────┘
+ *
+ */
+export const FrontContainer = ({
+	element = 'section',
+	title,
+	children,
+	backgroundColour,
+	borderColour,
+	centralBorder,
+	containerName,
+	containerPalette,
+	description,
+	editionId,
+	fontColour,
+	innerBackgroundColour,
+	leftColSize = 'compact',
+	leftContent,
+	ophanComponentLink,
+	ophanComponentName,
+	padContent = false,
+	sectionId,
+	showDateHeader = false,
+	showSideBorders = true,
+	showTopBorder = true,
+	stretchRight = false,
+	toggleable = false,
+	treats,
+	url,
+	verticalMargins = true,
+}: Props) => {
+	const overrides =
+		containerPalette && decideContainerOverrides(containerPalette);
+
+	const isToggleable = toggleable && !!sectionId;
+
+	const showDecoration =
+		showTopBorder || showSideBorders || !!innerBackgroundColour;
+
+	return jsx(
+		element,
+		{
+			/**
+			 * id is being used to set the containerId in @see {ShowMore.importable.tsx}
+			 * this id pre-existed showMore so is probably also being used for something else.
+			 */
+			id: sectionId,
+			'data-link-name': ophanComponentLink,
+			'data-component': ophanComponentName,
+			'data-container-name': containerName,
+			css: [
+				fallbackStyles,
+				containerStyles,
+				leftColSize === 'wide' && wideLeftColumn,
+				isToggleable && containerStylesToggleable,
+				stretchRight && sectionContentStretchedRight,
+				css`
+					background-color: ${backgroundColour ??
+					overrides?.background.container};
+				`,
+			],
+		},
+		<>
+			{showDecoration && (
+				<div
+					css={[
+						decoration,
+						showSideBorders && sideBorders,
+						showTopBorder && topBorder,
+						innerBackgroundColour &&
+							css`
+								background-color: ${innerBackgroundColour};
+							`,
+					]}
+				/>
+			)}
+			<div
+				css={[
+					headlineContainerStyles,
+					centralBorder === 'partial' && headlineContainerBorders,
+				]}
+			>
+				<ContainerTitle
+					title={title}
+					fontColour={fontColour ?? overrides?.text.container}
+					description={description}
+					url={url}
+					containerPalette={containerPalette}
+					showDateHeader={showDateHeader}
+					editionId={editionId}
+				/>
+				{leftContent}
+			</div>
+			{isToggleable && (
+				<div css={sectionShowHide}>
+					<ShowHideButton
+						sectionId={sectionId}
+						overrideContainerToggleColour={
+							overrides?.text.containerToggle
+						}
+					/>
+				</div>
+			)}
+			<div
+				css={[
+					sectionContent,
+					padContent && sectionContentPadded,
+					centralBorder === 'full' && sectionContentBorder,
+					verticalMargins && paddings,
+				]}
+			>
+				{children}
+			</div>
+			{treats && (
+				<div css={[sectionTreats, verticalMargins && paddings]}>
+					<Treats
+						treats={treats}
+						borderColour={
+							borderColour ?? overrides?.border.container
+						}
+					/>
+				</div>
+			)}
+		</>,
+	);
+};


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

A replacement for Section, which uses CSS grid over flex. The grid layout algorithm’s API is much closer to our designs, making it a more optimal choice for consistent and predictable outputs. Grids also lead to a shallower DOM, which improves paint performance.

## Why?

Rather than replacing Section in one go, this new component enables adoption on Fronts without having to handle all Article edge cases. See #7146 for the reverted previous attempt 

On browsers that do no support grid, we fall back to the flow layout algorithm, setting a specific width for each breakpoint;

## Screenshots

None yet.