### PR TITLE
Configure switches for test

### DIFF
--- a/dotcom-rendering/cypress/e2e/parallel-1/sign-in-gate.cy.js
+++ b/dotcom-rendering/cypress/e2e/parallel-1/sign-in-gate.cy.js
@@ -1,80 +1,9 @@
 import { disableCMP } from '../../lib/disableCMP';
 import { setLocalBaseUrl } from '../../lib/setLocalBaseUrl.js';
 import { config } from '../../../fixtures/config';
+import { makeWindowGuardian } from '../../../src/model/window-guardian';
 /* eslint-disable no-undef */
 /* eslint-disable func-names */
-
-const makeWindowGuardian = ({
-	stage,
-	frontendAssetsFullURL,
-	revisionNumber,
-	sentryPublicApiKey,
-	sentryHost,
-	keywordIds,
-	dfpAccountId,
-	adUnit,
-	ajaxUrl,
-	shouldHideReaderRevenue,
-	isPaidContent,
-	googletagUrl,
-	switches,
-	abTests,
-	editionId,
-	contentType,
-	brazeApiKey,
-	GAData,
-	unknownConfig = {},
-}) => {
-	return {
-		config: {
-			// This indicates to the client side code that we are running a dotcom-rendering rendered page.
-			isDotcomRendering: true,
-			isDev: process.env.NODE_ENV !== 'production',
-			stage,
-			frontendAssetsFullURL,
-			page: Object.assign(unknownConfig, {
-				dcrCouldRender: true,
-				contentType: contentType ? contentType : '',
-				edition: editionId,
-				revisionNumber,
-				dcrSentryDsn:
-					'https://1937ab71c8804b2b8438178dfdd6468f@sentry.io/1377847',
-				sentryPublicApiKey,
-				sentryHost,
-				keywordIds,
-				dfpAccountId,
-				adUnit,
-				showRelatedContent: true,
-				ajaxUrl,
-				shouldHideReaderRevenue: shouldHideReaderRevenue
-					? shouldHideReaderRevenue
-					: false,
-				isPaidContent: isPaidContent ? isPaidContent : false,
-				brazeApiKey,
-			}),
-			libs: {
-				googletag: googletagUrl,
-			},
-			switches,
-			tests: abTests,
-			ophan: {
-				pageViewId: '',
-				browserId: '',
-			},
-		},
-		polyfilled: false,
-		adBlockers: {
-			active: undefined,
-			onDetect: [],
-		},
-		modules: {
-			sentry: {
-				reportError: () => null,
-			},
-		},
-		GAData,
-	};
-};
 
 const switchOverride = (config, switchName, value) => {
 	return {

--- a/dotcom-rendering/cypress/plugins/index.js
+++ b/dotcom-rendering/cypress/plugins/index.js
@@ -18,11 +18,11 @@ module.exports = (on, config) => {
 	// Adding this here so that we can use a module from source code in the cypress tests
 	webpackConfig.webpackOptions.resolve = {
 		extensions: ['.ts', '.js'],
-        alias: {
-           'src': path.resolve(__dirname, `../../src`)
-        }
-	}
-	const rules = webpackConfig.webpackOptions.module.rules
+		alias: {
+			src: path.resolve(__dirname, `../../src`),
+		},
+	};
+	const rules = webpackConfig.webpackOptions.module.rules;
 	rules[0].exclude =
 		require('../../scripts/webpack/webpack.config.browser').babelExclude;
 
@@ -32,10 +32,10 @@ module.exports = (on, config) => {
 		loader: 'ts-loader',
 		options: {
 			compilerOptions: {
-			  noEmit: false,
+				noEmit: false,
 			},
 		},
-	})
+	});
 	on('file:preprocessor', webpackPreprocessor(webpackConfig));
 	return config;
 };

--- a/dotcom-rendering/cypress/plugins/index.js
+++ b/dotcom-rendering/cypress/plugins/index.js
@@ -7,6 +7,7 @@
 // You can read more here:
 // https://on.cypress.io/plugins-guide
 // ***********************************************************
+import path from 'path';
 
 const webpackPreprocessor = require('cypress-webpack-preprocessor-v5');
 
@@ -14,9 +15,27 @@ module.exports = (on, config) => {
 	config.env = { ...config.env, ...process.env };
 
 	const webpackConfig = webpackPreprocessor.defaultOptions;
-	webpackConfig.webpackOptions.module.rules[0].exclude =
+	// Adding this here so that we can use a module from source code in the cypress tests
+	webpackConfig.webpackOptions.resolve = {
+		extensions: ['.ts', '.js'],
+        alias: {
+           'src': path.resolve(__dirname, `../../src`)
+        }
+	}
+	const rules = webpackConfig.webpackOptions.module.rules
+	rules[0].exclude =
 		require('../../scripts/webpack/webpack.config.browser').babelExclude;
 
+	rules.push({
+		test: /\.ts$/,
+		exclude: ['/node_modules/'],
+		loader: 'ts-loader',
+		options: {
+			compilerOptions: {
+			  noEmit: false,
+			},
+		},
+	})
 	on('file:preprocessor', webpackPreprocessor(webpackConfig));
 	return config;
 };

--- a/dotcom-rendering/src/web/components/SignInGateSelector.importable.tsx
+++ b/dotcom-rendering/src/web/components/SignInGateSelector.importable.tsx
@@ -148,11 +148,9 @@ export const SignInGateSelector = ({
 	idUrl = 'https://profile.theguardian.com',
 }: Props) => {
 	const isSignedIn = !!getCookie({ name: 'GU_U', shouldMemoize: true });
-
 	// START: Checkout Complete Personalisation
-	// TODO - add a check for switches
-	// const switches  = window.guardian.config.switches;
-	// const isSwitchedOn = switches.personaliseSignInAfterCheckout;
+	const switches = window.guardian.config.switches;
+	const isSwitchedOn = switches.personaliseSignInAfterCheckout;
 
 	const checkOutCompleteString = getCookie({
 		name: 'GU_CO_COMPLETE',

--- a/dotcom-rendering/src/web/components/SignInGateSelector.importable.tsx
+++ b/dotcom-rendering/src/web/components/SignInGateSelector.importable.tsx
@@ -157,7 +157,7 @@ export const SignInGateSelector = ({
 		shouldMemoize: true,
 	});
 	const checkoutCompleteCookieData: CheckoutCompleteCookieData | undefined =
-		checkOutCompleteString !== null
+		isSwitchedOn && checkOutCompleteString !== null
 			? parseCheckoutCompleteCookieData(checkOutCompleteString)
 			: undefined;
 	// END: Checkout Complete Personalisation

--- a/dotcom-rendering/src/web/lib/ArticleRenderer.tsx
+++ b/dotcom-rendering/src/web/lib/ArticleRenderer.tsx
@@ -121,7 +121,6 @@ export const ArticleRenderer = ({
 				host,
 				pageId,
 				idUrl,
-				switches,
 				isSensitive,
 				isDev,
 			})}

--- a/dotcom-rendering/src/web/lib/withSignInGateSlot.tsx
+++ b/dotcom-rendering/src/web/lib/withSignInGateSlot.tsx
@@ -19,7 +19,6 @@ type Props = {
 	host?: string;
 	pageId: string;
 	idUrl: string;
-	switches: Switches;
 	isSensitive: boolean;
 	isDev: boolean;
 };

--- a/dotcom-rendering/src/web/lib/withSignInGateSlot.tsx
+++ b/dotcom-rendering/src/web/lib/withSignInGateSlot.tsx
@@ -2,7 +2,6 @@
 // if the SignInGateSelector determines a gate should be rendered.
 
 import React from 'react';
-import type { Switches } from '../../types/config';
 import type { TagType } from '../../types/tag';
 import { Island } from '../components/Island';
 import { SignInGateSelector } from '../components/SignInGateSelector.importable';


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

## Why?

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->


<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
