### PR TITLE
[Sentry] Don't log to sentry when window.ga doesn't exist

### DIFF
--- a/dotcom-rendering/src/web/browser/ga/ga.ts
+++ b/dotcom-rendering/src/web/browser/ga/ga.ts
@@ -81,6 +81,10 @@ export const sendPageView = (): void => {
 	const userCookie = getCookie({ name: 'GU_U', shouldMemoize: true });
 	const { ga } = window;
 
+	if (!ga) {
+		return;
+	}
+
 	ga(set, 'forceSSL', true);
 	ga(set, 'title', GAData.webTitle);
 	ga(set, 'anonymizeIp', true);
@@ -175,38 +179,28 @@ export const sendPageView = (): void => {
 
 export const trackNonClickInteraction = (actionName: string): void => {
 	const { ga } = window;
-
-	if (ga) {
-		ga(send, 'event', 'Interaction', actionName, {
-			/**
-			 * set nonInteraction to avoid affecting bounce rate
-			 * https://support.google.com/analytics/answer/1033068#NonInteractionEvents
-			 */
-			nonInteraction: true,
-		});
-	} else {
-		const error = new Error("window.ga doesn't exist");
-		window.guardian.modules.sentry.reportError(
-			error,
-			'trackNonClickInteraction',
-		);
+	if (!ga) {
+		return;
 	}
+
+	ga(send, 'event', 'Interaction', actionName, {
+		/**
+		 * set nonInteraction to avoid affecting bounce rate
+		 * https://support.google.com/analytics/answer/1033068#NonInteractionEvents
+		 */
+		nonInteraction: true,
+	});
 };
 
 export const trackSponsorLogoLinkClick = (sponsorName: string): void => {
 	const { ga } = window;
-
-	if (ga) {
-		ga(send, 'event', 'click', 'sponsor logo', sponsorName, {
-			nonInteraction: true,
-		});
-	} else {
-		const error = new Error("window.ga doesn't exist");
-		window.guardian.modules.sentry.reportError(
-			error,
-			'trackSponsorLogoLinkClick',
-		);
+	if (!ga) {
+		return;
 	}
+
+	ga(send, 'event', 'click', 'sponsor logo', sponsorName, {
+		nonInteraction: true,
+	});
 };
 
 export const trackVideoInteraction = ({


### PR DESCRIPTION
Co-Authored-By: Ioanna Kokkini <ioannakok@users.noreply.github.com>

## What are we doing

Removing the log message `window.ga doesn't exist` introduced in https://github.com/guardian/dotcom-rendering/pull/1759. We don't think we're using this data for anything, so there isn't any value to logging it.

We should double check with RR team before merging

<img width="1811" alt="image" src="https://user-images.githubusercontent.com/9575458/218504951-44c6e242-ec67-4852-aa9e-0a1f4faa3822.png">



