### PR TITLE
chore(riffraff): look up apps-rendering bucket name from ssm

### DIFF
--- a/apps-rendering/riff-raff.yaml
+++ b/apps-rendering/riff-raff.yaml
@@ -38,7 +38,8 @@ deployments:
   mobile-assets:
     type: aws-s3
     parameters:
-      bucket: mobile-apps-rendering-assets
+      bucketSsmLookup: true
+      bucketSsmKey: /account/services/apps-rendering-static.bucket
       cacheControl: public, max-age=315360000
       prefixStack: false
       publicReadAcl: false


### PR DESCRIPTION
## What does this change?

- Looks up Apps Rendering's static assets S3 bucket from SSM

## Why?

- To clear the warnings in RiffRaff and adhere to best practices of [treating bucket names as sensitive information](https://github.com/guardian/recommendations/blob/f5eed892527b9f5ed0095d5e9fc4ac9209a8f4f1/github.md?plain=1#L91)

## How to test?

- [x] tested on CODE