### PR TITLE
Don't log to sentry for GA script loading errors

### DIFF
--- a/dotcom-rendering/src/web/browser/ga/index.ts
+++ b/dotcom-rendering/src/web/browser/ga/index.ts
@@ -22,7 +22,16 @@ export const ga = (): Promise<void> => {
 					init();
 					sendPageView();
 				})
-				.catch((e) => console.error(`GA - error: ${String(e)}`));
+				.catch((e) => {
+					// We don't need to log script loading errors (these will mostly be adblock, etc),
+					if (!String(e).includes('Error loading script')) {
+						// This is primarily for logging errors with our GA code.
+						window.guardian.modules.sentry.reportError(
+							e instanceof Error ? e : new Error(e),
+							'ga',
+						);
+					}
+				});
 		} else {
 			// Disable Google Analytics
 			// @ts-expect-error -- We should never be able to directly set things to the global window object


### PR DESCRIPTION
Co-Authored-By: Ioanna Kokkini <ioannakok@users.noreply.github.com>

<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Don't log the 'load script errors' from loading the GA script:

<img width="1100" alt="image" src="https://user-images.githubusercontent.com/9575458/218516549-db2e6052-9bfb-4058-b216-39aa6e491d2f.png">


## Why?

These will most likely be network failures from adblock etc, so they don't provide value to us to have in sentry

