### PR TITLE
Add dynamic import / module loading failure to sentry ignores

### DIFF
--- a/dotcom-rendering/src/web/browser/sentryLoader/sentry.ts
+++ b/dotcom-rendering/src/web/browser/sentryLoader/sentry.ts
@@ -31,6 +31,8 @@ const ignoreErrors = [
 	'TypeError: Failed to fetch',
 	'TypeError: NetworkError when attempting to fetch resource',
 	'TypeError: Load failed',
+	'TypeError: Importing a module script failed',
+	'TypeError: error loading dynamically imported module',
 ];
 
 const { config } = window.guardian;


### PR DESCRIPTION
Co-Authored-By: Ioanna Kokkini <ioannakok@users.noreply.github.com>

<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Ignore these two errors messages from sentry:
- `TypeError: Importing a module script failed`
- `TypeError: error loading dynamically imported module`

## Why?

These _seem_ to occur when the network request fails for these modules, which is something we typically ignore in sentry

