### PR TITLE
Special Report Alt: Headline

### DIFF
--- a/apps-rendering/src/palette/background.ts
+++ b/apps-rendering/src/palette/background.ts
@@ -135,7 +135,31 @@ const headlineByline = ({ design, theme }: ArticleFormat): Colour => {
 	}
 };
 
-const headlineBylineDark = (_format: ArticleFormat): Colour => brandAlt[200];
+const headlineBylineDark = ({ design, theme }: ArticleFormat): Colour => {
+	switch (design) {
+		case ArticleDesign.Analysis:
+		case ArticleDesign.Comment:
+		case ArticleDesign.Editorial:
+		case ArticleDesign.Explainer:
+		case ArticleDesign.Feature:
+		case ArticleDesign.FullPageInteractive:
+		case ArticleDesign.Interactive:
+		case ArticleDesign.Interview:
+		case ArticleDesign.Letter:
+		case ArticleDesign.NewsletterSignup:
+		case ArticleDesign.PhotoEssay:
+		case ArticleDesign.Review:
+		case ArticleDesign.Standard:
+			switch (theme) {
+				case ArticleSpecial.SpecialReportAlt:
+					return palette.specialReportAlt[800];
+				default:
+					return brandAlt[200];
+			}
+		default:
+			return brandAlt[200];
+	}
+};
 
 const headlineDark = ({ design, display, theme }: ArticleFormat): Colour => {
 	if (display === ArticleDisplay.Immersive) {

--- a/apps-rendering/src/palette/background.ts
+++ b/apps-rendering/src/palette/background.ts
@@ -133,7 +133,7 @@ const headlineByline = ({ design, theme }: ArticleFormat): Colour => {
 		default:
 			return brandAlt[400];
 	}
-}
+};
 
 const headlineBylineDark = (_format: ArticleFormat): Colour => brandAlt[200];
 

--- a/apps-rendering/src/palette/background.ts
+++ b/apps-rendering/src/palette/background.ts
@@ -109,7 +109,31 @@ const headline = ({ design, display, theme }: ArticleFormat): Colour => {
 	}
 };
 
-const headlineByline = (_format: ArticleFormat): Colour => brandAlt[400];
+const headlineByline = ({ design, theme }: ArticleFormat): Colour => {
+	switch (design) {
+		case ArticleDesign.Analysis:
+		case ArticleDesign.Comment:
+		case ArticleDesign.Editorial:
+		case ArticleDesign.Explainer:
+		case ArticleDesign.Feature:
+		case ArticleDesign.FullPageInteractive:
+		case ArticleDesign.Interactive:
+		case ArticleDesign.Interview:
+		case ArticleDesign.Letter:
+		case ArticleDesign.NewsletterSignup:
+		case ArticleDesign.PhotoEssay:
+		case ArticleDesign.Review:
+		case ArticleDesign.Standard:
+			switch (theme) {
+				case ArticleSpecial.SpecialReportAlt:
+					return palette.specialReportAlt[700];
+				default:
+					return brandAlt[400];
+			}
+		default:
+			return brandAlt[400];
+	}
+}
 
 const headlineBylineDark = (_format: ArticleFormat): Colour => brandAlt[200];
 
@@ -154,7 +178,6 @@ const headlineDark = ({ design, display, theme }: ArticleFormat): Colour => {
 		case ArticleDesign.Comment:
 		case ArticleDesign.Letter:
 		case ArticleDesign.Editorial:
-		case ArticleDesign.Analysis:
 			switch (theme) {
 				case ArticleSpecial.SpecialReportAlt:
 					return palette.specialReportAlt[100];
@@ -457,7 +480,6 @@ const articleContentDark = ({ design, theme }: ArticleFormat): Colour => {
 		case ArticleDesign.Comment:
 		case ArticleDesign.Letter:
 		case ArticleDesign.Editorial:
-		case ArticleDesign.Analysis:
 			switch (theme) {
 				case ArticleSpecial.SpecialReportAlt:
 					return palette.specialReportAlt[100];

--- a/apps-rendering/src/palette/text.ts
+++ b/apps-rendering/src/palette/text.ts
@@ -258,54 +258,71 @@ const dropCapDark = (format: ArticleFormat): Colour => {
 	}
 };
 
-const headline = (format: ArticleFormat): Colour => {
-	if (
-		format.display === ArticleDisplay.Immersive ||
-		format.design === ArticleDesign.Gallery ||
-		format.design === ArticleDesign.Audio ||
-		format.design === ArticleDesign.Video ||
-		format.design === ArticleDesign.LiveBlog
-	) {
-		return neutral[100];
-	}
+const headline = ({ design, display, theme }: ArticleFormat): Colour => {
+	switch (design) {
+		case ArticleDesign.Gallery:
+		case ArticleDesign.Audio:
+		case ArticleDesign.Video:
+		case ArticleDesign.LiveBlog:
+		case ArticleDesign.Interview:
+			return neutral[100];
+		case ArticleDesign.DeadBlog:
+			return neutral[7];
+		case ArticleDesign.Feature:
+		case ArticleDesign.Review:
+			if (display === ArticleDisplay.Immersive) {
+				return neutral[100];
+			}
 
-	if (format.design === ArticleDesign.DeadBlog) {
-		return neutral[7];
-	}
+			switch (theme) {
+				case ArticlePillar.Opinion:
+					return opinion[300];
+				case ArticlePillar.Sport:
+					return sport[300];
+				case ArticlePillar.Culture:
+					return culture[300];
+				case ArticlePillar.Lifestyle:
+					return lifestyle[300];
+				case ArticleSpecial.SpecialReportAlt:
+					return neutral[7];
+				default:
+					return news[300];
+			}
+		default:
+			if (display === ArticleDisplay.Immersive) {
+				return neutral[100];
+			}
 
-	if (
-		format.design === ArticleDesign.Feature ||
-		format.design === ArticleDesign.Review
-	) {
-		switch (format.theme) {
-			case ArticlePillar.Opinion:
-				return opinion[300];
-			case ArticlePillar.Sport:
-				return sport[300];
-			case ArticlePillar.Culture:
-				return culture[300];
-			case ArticlePillar.Lifestyle:
-				return lifestyle[300];
-			default:
-				return news[300];
-		}
+			return neutral[7];
 	}
-
-	if (format.design === ArticleDesign.Interview) {
-		return neutral[100];
-	}
-
-	return neutral[7];
 };
 
-const headlineDark = (format: ArticleFormat): Colour => {
-	switch (format.design) {
+const headlineDark = ({ design, theme }: ArticleFormat): Colour => {
+	switch (design) {
 		case ArticleDesign.LiveBlog:
-			return format.theme === ArticlePillar.Culture
+			return theme === ArticlePillar.Culture
 				? neutral[86]
 				: neutral[93];
 		case ArticleDesign.DeadBlog:
 			return neutral[93];
+		case ArticleDesign.Standard:
+		case ArticleDesign.Review:
+		case ArticleDesign.Explainer:
+		case ArticleDesign.Feature:
+		case ArticleDesign.Interview:
+		case ArticleDesign.Interactive:
+		case ArticleDesign.PhotoEssay:
+		case ArticleDesign.FullPageInteractive:
+		case ArticleDesign.NewsletterSignup:
+		case ArticleDesign.Comment:
+		case ArticleDesign.Letter:
+		case ArticleDesign.Editorial:
+			switch (theme) {
+				case ArticleSpecial.SpecialReportAlt:
+					return neutral[93];
+				default:
+					return neutral[86];
+			}
 		default:
 			return neutral[86];
 	}

--- a/apps-rendering/src/palette/text.ts
+++ b/apps-rendering/src/palette/text.ts
@@ -300,9 +300,7 @@ const headline = ({ design, display, theme }: ArticleFormat): Colour => {
 const headlineDark = ({ design, theme }: ArticleFormat): Colour => {
 	switch (design) {
 		case ArticleDesign.LiveBlog:
-			return theme === ArticlePillar.Culture
-				? neutral[86]
-				: neutral[93];
+			return theme === ArticlePillar.Culture ? neutral[86] : neutral[93];
 		case ArticleDesign.DeadBlog:
 			return neutral[93];
 		case ArticleDesign.Standard:


### PR DESCRIPTION
## Why?

Building out the special report alt designs in AR, as covered in #6203. I've broken this up into stages to make the PRs easier to review. This PR deals with the headline.

**Note:** The screenshots below show the final result of all changes, some of which aren't included in this PR.

## Changes

- Updated the `headline` colours in light and dark mode
- Updated the `headlineByline` colours used for interview bylines

## Screenshots

| | Light | Dark |
| - | - | - |
| Standard | ![headline-standard-light] | ![headline-standard-dark] |
| Immersive |  ![headline-immersive-light] | ![headline-immersive-dark] |
| Feature | ![headline-feature-light] | ![headline-feature-dark] |
| Interview |  ![headline-interview-light] | ![headline-interview-dark] |
| Comment | ![headline-comment-light] | ![headline-comment-dark] |


[headline-standard-light]: https://user-images.githubusercontent.com/53781962/218732840-efbefc2f-8bff-44de-ad8f-f2cc0246f4c9.jpg
[headline-immersive-light]: https://user-images.githubusercontent.com/53781962/218732844-af639bfd-cfc3-4ebf-8bae-a4ba3be642f8.jpg
[headline-feature-light]: https://user-images.githubusercontent.com/53781962/218732848-a7d33737-6e9e-4686-abe3-90564bdc6685.jpg
[headline-standard-dark]: https://user-images.githubusercontent.com/53781962/218732850-17f0712b-357e-4bec-bccc-a8f2df8693bb.jpg
[headline-immersive-dark]: https://user-images.githubusercontent.com/53781962/218732852-654866c8-debe-4c63-9203-aad663a8ade4.jpg
[headline-interview-light]: https://user-images.githubusercontent.com/53781962/218732853-555659b8-895d-4b93-9c1d-10a99daf1d62.jpg
[headline-feature-dark]: https://user-images.githubusercontent.com/53781962/218732860-1103f063-1fe8-4b66-a72e-29d191d1a95e.jpg
[headline-interview-dark]: https://user-images.githubusercontent.com/53781962/218732861-d9658402-1286-4081-be04-f54b79c1b6d4.jpg
[headline-comment-light]: https://user-images.githubusercontent.com/53781962/218732863-b59949b8-80f6-4ffe-88e0-635dc9a56d30.jpg
[headline-comment-dark]: https://user-images.githubusercontent.com/53781962/218732865-db9eb44f-f1a5-46cc-990f-97bd1c5f1b6a.jpg
