### PR TITLE
Switch off the variant build

### DIFF
--- a/dotcom-rendering/scripts/webpack/bundles.js
+++ b/dotcom-rendering/scripts/webpack/bundles.js
@@ -6,7 +6,7 @@
  *
  * @type {boolean} prevent TS from narrowing this to its current value
  */
-const BUILD_VARIANT = true;
+const BUILD_VARIANT = false;
 
 /**
  * Server-side test names for `dcr-javascript-bundle`.


### PR DESCRIPTION
## What does this change?

The SWC bundle experiment has concluded so we can switch off the variant build

