### PR TITLE
Special Report Alt: Series

### DIFF
--- a/apps-rendering/src/components/Series/ImmersiveSeries.tsx
+++ b/apps-rendering/src/components/Series/ImmersiveSeries.tsx
@@ -39,6 +39,7 @@ const linkStyles = (format: ArticleFormat): SerializedStyles => css`
 	padding-right: ${remSpace[3]};
 
 	${darkModeCss`
+		color: ${text.seriesTitleDark(format)};
         background-color: ${background.seriesDark(format)};
     `}
 

--- a/apps-rendering/src/palette/background.ts
+++ b/apps-rendering/src/palette/background.ts
@@ -687,55 +687,148 @@ const supportBannerDark = (_format: ArticleFormat): Colour => {
 	return brandAlt[200];
 };
 
-const series = (format: ArticleFormat): Colour => {
-	if (
-		format.display === ArticleDisplay.Immersive ||
-		format.design === ArticleDesign.Gallery
-	) {
-		switch (format.theme) {
-			case ArticlePillar.Sport:
-				return sport[400];
-			case ArticlePillar.Culture:
-				return culture[400];
-			case ArticlePillar.Opinion:
-				return opinion[400];
-			case ArticlePillar.Lifestyle:
-				return lifestyle[400];
-			case ArticleSpecial.Labs:
-				return labs[400];
-			case ArticleSpecial.SpecialReport:
-				return brandAlt[400];
-			case ArticlePillar.News:
-			default:
-				return news[400];
-		}
-	}
+const series = ({ design, display, theme }: ArticleFormat): Colour => {
+	switch (design) {
+		case ArticleDesign.Gallery:
+			switch (theme) {
+				case ArticlePillar.Sport:
+					return sport[400];
+				case ArticlePillar.Culture:
+					return culture[400];
+				case ArticlePillar.Opinion:
+					return opinion[400];
+				case ArticlePillar.Lifestyle:
+					return lifestyle[400];
+				case ArticleSpecial.Labs:
+					return labs[400];
+				case ArticleSpecial.SpecialReport:
+					return brandAlt[400];
+				case ArticlePillar.News:
+				default:
+					return news[400];
+			}
+		case ArticleDesign.Analysis:
+		case ArticleDesign.Comment:
+		case ArticleDesign.Editorial:
+		case ArticleDesign.Explainer:
+		case ArticleDesign.Feature:
+		case ArticleDesign.FullPageInteractive:
+		case ArticleDesign.Interactive:
+		case ArticleDesign.Interview:
+		case ArticleDesign.Letter:
+		case ArticleDesign.NewsletterSignup:
+		case ArticleDesign.PhotoEssay:
+		case ArticleDesign.Review:
+		case ArticleDesign.Standard:
+			if (display === ArticleDisplay.Immersive) {
+				switch (theme) {
+					case ArticlePillar.Sport:
+						return sport[400];
+					case ArticlePillar.Culture:
+						return culture[400];
+					case ArticlePillar.Opinion:
+						return opinion[400];
+					case ArticlePillar.Lifestyle:
+						return lifestyle[400];
+					case ArticleSpecial.Labs:
+						return labs[400];
+					case ArticleSpecial.SpecialReport:
+						return brandAlt[400];
+					case ArticleSpecial.SpecialReportAlt:
+						return palette.specialReportAlt[300];
+					case ArticlePillar.News:
+					default:
+						return news[400];
+				}
+			}
 
-	return neutral[100];
+			return neutral[100];
+		default:
+			if (display === ArticleDisplay.Immersive) {
+				switch (theme) {
+					case ArticlePillar.Sport:
+						return sport[400];
+					case ArticlePillar.Culture:
+						return culture[400];
+					case ArticlePillar.Opinion:
+						return opinion[400];
+					case ArticlePillar.Lifestyle:
+						return lifestyle[400];
+					case ArticleSpecial.Labs:
+						return labs[400];
+					case ArticleSpecial.SpecialReport:
+						return brandAlt[400];
+					case ArticlePillar.News:
+					default:
+						return news[400];
+				}
+			}
+
+			return neutral[100];
+	}
 };
 
-const seriesDark = (format: ArticleFormat): Colour => {
-	if (format.display === ArticleDisplay.Immersive) {
-		switch (format.theme) {
-			case ArticlePillar.Sport:
-				return sport[400];
-			case ArticlePillar.Culture:
-				return culture[400];
-			case ArticlePillar.Opinion:
-				return opinion[400];
-			case ArticlePillar.Lifestyle:
-				return lifestyle[400];
-			case ArticleSpecial.Labs:
-				return labs[400];
-			case ArticleSpecial.SpecialReport:
-				return brandAlt[400];
-			case ArticlePillar.News:
-			default:
-				return news[400];
-		}
-	}
+const seriesDark = ({ design, display, theme }: ArticleFormat): Colour => {
+	switch (design) {
+		case ArticleDesign.Standard:
+		case ArticleDesign.Review:
+		case ArticleDesign.Explainer:
+		case ArticleDesign.Feature:
+		case ArticleDesign.Interview:
+		case ArticleDesign.Interactive:
+		case ArticleDesign.PhotoEssay:
+		case ArticleDesign.FullPageInteractive:
+		case ArticleDesign.NewsletterSignup:
+		case ArticleDesign.Comment:
+		case ArticleDesign.Letter:
+		case ArticleDesign.Editorial:
+		case ArticleDesign.Analysis:
+			if (display === ArticleDisplay.Immersive) {
+				switch (theme) {
+					case ArticlePillar.Sport:
+						return sport[400];
+					case ArticlePillar.Culture:
+						return culture[400];
+					case ArticlePillar.Opinion:
+						return opinion[400];
+					case ArticlePillar.Lifestyle:
+						return lifestyle[400];
+					case ArticleSpecial.Labs:
+						return labs[400];
+					case ArticleSpecial.SpecialReport:
+						return brandAlt[400];
+					case ArticleSpecial.SpecialReportAlt:
+						return palette.specialReportAlt[200];
+					case ArticlePillar.News:
+					default:
+						return news[400];
+				}
+			}
 
-	return neutral[10];
+			return neutral[10];
+		default:
+			if (display === ArticleDisplay.Immersive) {
+				switch (theme) {
+					case ArticlePillar.Sport:
+						return sport[400];
+					case ArticlePillar.Culture:
+						return culture[400];
+					case ArticlePillar.Opinion:
+						return opinion[400];
+					case ArticlePillar.Lifestyle:
+						return lifestyle[400];
+					case ArticleSpecial.Labs:
+						return labs[400];
+					case ArticleSpecial.SpecialReport:
+						return brandAlt[400];
+					case ArticlePillar.News:
+					default:
+						return news[400];
+				}
+			}
+
+			return neutral[10];
+	}
 };
 
 const tag = (format: ArticleFormat): Colour => {

--- a/apps-rendering/src/palette/text.ts
+++ b/apps-rendering/src/palette/text.ts
@@ -15,6 +15,7 @@ import {
 	neutral,
 	news,
 	opinion,
+	palette,
 	specialReport,
 	sport,
 } from '@guardian/source-foundations';
@@ -864,16 +865,12 @@ const editionsKicker = (format: ArticleFormat): Colour => {
 	}
 };
 
-const seriesTitle = (format: ArticleFormat): Colour => {
-	if (format.display === ArticleDisplay.Immersive) {
-		return neutral[100];
-	}
-
-	switch (format.design) {
+const seriesTitle = ({ design, display, theme }: ArticleFormat): Colour => {
+	switch (design) {
 		case ArticleDesign.Gallery:
 			return neutral[100];
 		case ArticleDesign.DeadBlog:
-			switch (format.theme) {
+			switch (theme) {
 				case ArticlePillar.News:
 					return news[400];
 				case ArticlePillar.Lifestyle:
@@ -891,9 +888,8 @@ const seriesTitle = (format: ArticleFormat): Colour => {
 				case ArticleSpecial.SpecialReportAlt:
 					return news[400];
 			}
-
 		case ArticleDesign.LiveBlog:
-			switch (format.theme) {
+			switch (theme) {
 				case ArticlePillar.News:
 					return news[600];
 				case ArticlePillar.Lifestyle:
@@ -911,24 +907,69 @@ const seriesTitle = (format: ArticleFormat): Colour => {
 				case ArticleSpecial.SpecialReportAlt:
 					return news[600];
 			}
-	}
-	switch (format.theme) {
-		case ArticlePillar.News:
-			return news[400];
-		case ArticlePillar.Lifestyle:
-			return lifestyle[400];
-		case ArticlePillar.Sport:
-			return sport[400];
-		case ArticlePillar.Culture:
-			return culture[400];
-		case ArticlePillar.Opinion:
-			return opinion[400];
-		case ArticleSpecial.Labs:
-			return labs[300];
-		case ArticleSpecial.SpecialReport:
-			return specialReport[400];
-		case ArticleSpecial.SpecialReportAlt:
-			return news[400];
+		case ArticleDesign.Analysis:
+		case ArticleDesign.Comment:
+		case ArticleDesign.Editorial:
+		case ArticleDesign.Explainer:
+		case ArticleDesign.Feature:
+		case ArticleDesign.FullPageInteractive:
+		case ArticleDesign.Interactive:
+		case ArticleDesign.Interview:
+		case ArticleDesign.Letter:
+		case ArticleDesign.NewsletterSignup:
+		case ArticleDesign.PhotoEssay:
+		case ArticleDesign.Review:
+		case ArticleDesign.Standard:
+			if (display === ArticleDisplay.Immersive) {
+				switch (theme) {
+					case ArticleSpecial.SpecialReportAlt:
+						return palette.specialReportAlt[100];
+					default:
+						return neutral[100];
+				}
+			}
+
+			switch (theme) {
+				case ArticlePillar.News:
+					return news[400];
+				case ArticlePillar.Lifestyle:
+					return lifestyle[400];
+				case ArticlePillar.Sport:
+					return sport[400];
+				case ArticlePillar.Culture:
+					return culture[400];
+				case ArticlePillar.Opinion:
+					return opinion[400];
+				case ArticleSpecial.Labs:
+					return labs[300];
+				case ArticleSpecial.SpecialReport:
+					return specialReport[400];
+				case ArticleSpecial.SpecialReportAlt:
+					return palette.specialReportAlt[100];
+			}
+		default:
+			if (display === ArticleDisplay.Immersive) {
+				return neutral[100];
+			}
+
+			switch (theme) {
+				case ArticlePillar.News:
+					return news[400];
+				case ArticlePillar.Lifestyle:
+					return lifestyle[400];
+				case ArticlePillar.Sport:
+					return sport[400];
+				case ArticlePillar.Culture:
+					return culture[400];
+				case ArticlePillar.Opinion:
+					return opinion[400];
+				case ArticleSpecial.Labs:
+					return labs[300];
+				case ArticleSpecial.SpecialReport:
+					return specialReport[400];
+				case ArticleSpecial.SpecialReportAlt:
+					return news[400];
+			}
 	}
 };
 
@@ -989,28 +1030,71 @@ const richLinkAnchorDark = (_format: ArticleFormat): Colour => {
 	return neutral[60];
 };
 
-const seriesTitleDark = (format: ArticleFormat): Colour => {
-	if (format.display === ArticleDisplay.Immersive) {
-		return neutral[100];
-	}
+const seriesTitleDark = ({ design, display, theme }: ArticleFormat): Colour => {
+	switch (design) {
+		case ArticleDesign.Standard:
+		case ArticleDesign.Review:
+		case ArticleDesign.Explainer:
+		case ArticleDesign.Feature:
+		case ArticleDesign.Interview:
+		case ArticleDesign.Interactive:
+		case ArticleDesign.PhotoEssay:
+		case ArticleDesign.FullPageInteractive:
+		case ArticleDesign.NewsletterSignup:
+		case ArticleDesign.Comment:
+		case ArticleDesign.Letter:
+		case ArticleDesign.Editorial:
+		case ArticleDesign.Analysis:
+			if (display === ArticleDisplay.Immersive) {
+				switch (theme) {
+					case ArticleSpecial.SpecialReportAlt:
+						return palette.specialReportAlt[800];
+					default:
+						return neutral[100];
+				}
+			}
 
-	switch (format.theme) {
-		case ArticlePillar.News:
-			return news[500];
-		case ArticlePillar.Lifestyle:
-			return lifestyle[500];
-		case ArticlePillar.Sport:
-			return sport[500];
-		case ArticlePillar.Culture:
-			return culture[500];
-		case ArticlePillar.Opinion:
-			return opinion[500];
-		case ArticleSpecial.Labs:
-			return labs[400];
-		case ArticleSpecial.SpecialReport:
-			return specialReport[500];
-		case ArticleSpecial.SpecialReportAlt:
-			return news[500];
+			switch (theme) {
+				case ArticlePillar.News:
+					return news[500];
+				case ArticlePillar.Lifestyle:
+					return lifestyle[500];
+				case ArticlePillar.Sport:
+					return sport[500];
+				case ArticlePillar.Culture:
+					return culture[500];
+				case ArticlePillar.Opinion:
+					return opinion[500];
+				case ArticleSpecial.Labs:
+					return labs[400];
+				case ArticleSpecial.SpecialReport:
+					return specialReport[500];
+				case ArticleSpecial.SpecialReportAlt:
+					return palette.specialReportAlt[700];
+			}
+		default:
+			if (display === ArticleDisplay.Immersive) {
+				return neutral[100];
+			}
+
+			switch (theme) {
+				case ArticlePillar.News:
+					return news[500];
+				case ArticlePillar.Lifestyle:
+					return lifestyle[500];
+				case ArticlePillar.Sport:
+					return sport[500];
+				case ArticlePillar.Culture:
+					return culture[500];
+				case ArticlePillar.Opinion:
+					return opinion[500];
+				case ArticleSpecial.Labs:
+					return labs[400];
+				case ArticleSpecial.SpecialReport:
+					return specialReport[500];
+				case ArticleSpecial.SpecialReportAlt:
+					return news[500];
+			}
 	}
 };
 


### PR DESCRIPTION
## Why?

Building out the special report alt designs in AR, as covered in #6203. I've broken this up into stages to make the PRs easier to review. This PR deals with the series.

**Note:** The screenshots below show the final result of all changes, some of which aren't included in this PR.

## Changes

- Added special report alt colours for series in light and dark mode
- Updated immersive series to use the palette colour in dark mode

## Screenshots

| | Light | Dark |
| - | - | - |
| Standard | ![series-standard-light] | ![series-standard-dark] |
| Immersive |  ![series-immersive-light] | ![series-immersive-dark] |
| Comment | ![series-comment-light] | ![series-comment-dark] |

[series-standard-light]: https://user-images.githubusercontent.com/53781962/218732840-efbefc2f-8bff-44de-ad8f-f2cc0246f4c9.jpg
[series-immersive-light]: https://user-images.githubusercontent.com/53781962/218732844-af639bfd-cfc3-4ebf-8bae-a4ba3be642f8.jpg
[series-standard-dark]: https://user-images.githubusercontent.com/53781962/218732850-17f0712b-357e-4bec-bccc-a8f2df8693bb.jpg
[series-immersive-dark]: https://user-images.githubusercontent.com/53781962/218732852-654866c8-debe-4c63-9203-aad663a8ade4.jpg
[series-comment-light]: https://user-images.githubusercontent.com/53781962/218732863-b59949b8-80f6-4ffe-88e0-635dc9a56d30.jpg
[series-comment-dark]: https://user-images.githubusercontent.com/53781962/218732865-db9eb44f-f1a5-46cc-990f-97bd1c5f1b6a.jpg
