### PR TITLE
Special Report Alt: Design Tag

### DIFF
--- a/apps-rendering/src/palette/background.ts
+++ b/apps-rendering/src/palette/background.ts
@@ -598,45 +598,113 @@ const keyEventsDark = (_format: ArticleFormat): Colour => neutral[10];
 
 const keyEventsWideDark = articleContentDark;
 
-const designTag = (format: ArticleFormat): Colour => {
-	switch (format.theme) {
-		case ArticleSpecial.SpecialReport:
-			return specialReport[300];
-		case ArticleSpecial.Labs:
-			return labs[300];
-		case ArticlePillar.Opinion:
-			return opinion[300];
-		case ArticlePillar.Culture:
-			return culture[300];
-		case ArticlePillar.Lifestyle:
-			return lifestyle[300];
-		case ArticlePillar.Sport:
-			return sport[300];
-		case ArticlePillar.News:
-			return news[300];
-		case ArticleSpecial.SpecialReportAlt:
-			return news[300];
+const designTag = ({ design, theme }: ArticleFormat): Colour => {
+	switch (design) {
+		case ArticleDesign.Standard:
+		case ArticleDesign.Review:
+		case ArticleDesign.Explainer:
+		case ArticleDesign.Feature:
+		case ArticleDesign.Interview:
+		case ArticleDesign.Interactive:
+		case ArticleDesign.PhotoEssay:
+		case ArticleDesign.FullPageInteractive:
+		case ArticleDesign.NewsletterSignup:
+		case ArticleDesign.Comment:
+		case ArticleDesign.Letter:
+		case ArticleDesign.Editorial:
+		case ArticleDesign.Analysis:
+			switch (theme) {
+				case ArticleSpecial.SpecialReport:
+					return specialReport[300];
+				case ArticleSpecial.Labs:
+					return labs[300];
+				case ArticlePillar.Opinion:
+					return opinion[300];
+				case ArticlePillar.Culture:
+					return culture[300];
+				case ArticlePillar.Lifestyle:
+					return lifestyle[300];
+				case ArticlePillar.Sport:
+					return sport[300];
+				case ArticlePillar.News:
+					return news[300];
+				case ArticleSpecial.SpecialReportAlt:
+					return palette.specialReportAlt[100];
+			}
+		default:
+			switch (theme) {
+				case ArticleSpecial.SpecialReport:
+					return specialReport[300];
+				case ArticleSpecial.Labs:
+					return labs[300];
+				case ArticlePillar.Opinion:
+					return opinion[300];
+				case ArticlePillar.Culture:
+					return culture[300];
+				case ArticlePillar.Lifestyle:
+					return lifestyle[300];
+				case ArticlePillar.Sport:
+					return sport[300];
+				case ArticlePillar.News:
+					return news[300];
+				case ArticleSpecial.SpecialReportAlt:
+					return news[300];
+			}
 	}
 };
 
-const designTagDark = (format: ArticleFormat): Colour => {
-	switch (format.theme) {
-		case ArticlePillar.News:
-			return news[500];
-		case ArticlePillar.Lifestyle:
-			return lifestyle[500];
-		case ArticlePillar.Sport:
-			return sport[500];
-		case ArticlePillar.Culture:
-			return culture[500];
-		case ArticlePillar.Opinion:
-			return opinion[500];
-		case ArticleSpecial.Labs:
-			return labs[300];
-		case ArticleSpecial.SpecialReport:
-			return specialReport[500];
-		case ArticleSpecial.SpecialReportAlt:
-			return news[500];
+const designTagDark = ({ design, theme }: ArticleFormat): Colour => {
+	switch (design) {
+		case ArticleDesign.Standard:
+		case ArticleDesign.Review:
+		case ArticleDesign.Explainer:
+		case ArticleDesign.Feature:
+		case ArticleDesign.Interview:
+		case ArticleDesign.Interactive:
+		case ArticleDesign.PhotoEssay:
+		case ArticleDesign.FullPageInteractive:
+		case ArticleDesign.NewsletterSignup:
+		case ArticleDesign.Comment:
+		case ArticleDesign.Letter:
+		case ArticleDesign.Editorial:
+		case ArticleDesign.Analysis:
+			switch (theme) {
+				case ArticlePillar.News:
+					return news[500];
+				case ArticlePillar.Lifestyle:
+					return lifestyle[500];
+				case ArticlePillar.Sport:
+					return sport[500];
+				case ArticlePillar.Culture:
+					return culture[500];
+				case ArticlePillar.Opinion:
+					return opinion[500];
+				case ArticleSpecial.Labs:
+					return labs[300];
+				case ArticleSpecial.SpecialReport:
+					return specialReport[500];
+				case ArticleSpecial.SpecialReportAlt:
+					return palette.specialReportAlt[700];
+			}
+		default:
+			switch (theme) {
+				case ArticlePillar.News:
+					return news[500];
+				case ArticlePillar.Lifestyle:
+					return lifestyle[500];
+				case ArticlePillar.Sport:
+					return sport[500];
+				case ArticlePillar.Culture:
+					return culture[500];
+				case ArticlePillar.Opinion:
+					return opinion[500];
+				case ArticleSpecial.Labs:
+					return labs[300];
+				case ArticleSpecial.SpecialReport:
+					return specialReport[500];
+				case ArticleSpecial.SpecialReportAlt:
+					return news[500];
+			}
 	}
 };
 

--- a/apps-rendering/src/palette/text.ts
+++ b/apps-rendering/src/palette/text.ts
@@ -434,9 +434,57 @@ const bylineInlineDark = (format: ArticleFormat): Colour => {
 	}
 };
 
-const designTag = (_format: ArticleFormat): Colour => neutral[100];
+const designTagDark = ({ design, theme }: ArticleFormat): Colour => {
+	switch (design) {
+		case ArticleDesign.Standard:
+		case ArticleDesign.Review:
+		case ArticleDesign.Explainer:
+		case ArticleDesign.Feature:
+		case ArticleDesign.Interview:
+		case ArticleDesign.Interactive:
+		case ArticleDesign.PhotoEssay:
+		case ArticleDesign.FullPageInteractive:
+		case ArticleDesign.NewsletterSignup:
+		case ArticleDesign.Comment:
+		case ArticleDesign.Letter:
+		case ArticleDesign.Editorial:
+			switch (theme) {
+				case ArticleSpecial.SpecialReportAlt:
+					return palette.specialReportAlt[100];
+				default:
+					return neutral[10];
+			}
+		default:
+			return neutral[10];
+	}
+}
 
-const designTagDark = (_format: ArticleFormat): Colour => neutral[10];
+const designTag = ({ design, theme }: ArticleFormat): Colour => {
+	switch (design) {
+		case ArticleDesign.Standard:
+		case ArticleDesign.Review:
+		case ArticleDesign.Explainer:
+		case ArticleDesign.Feature:
+		case ArticleDesign.Interview:
+		case ArticleDesign.Interactive:
+		case ArticleDesign.PhotoEssay:
+		case ArticleDesign.FullPageInteractive:
+		case ArticleDesign.NewsletterSignup:
+		case ArticleDesign.Comment:
+		case ArticleDesign.Letter:
+		case ArticleDesign.Editorial:
+		case ArticleDesign.Analysis:
+			switch (theme) {
+				case ArticleSpecial.SpecialReportAlt:
+					return palette.specialReportAlt[800];
+				default:
+					return neutral[100];
+			}
+		default:
+			return neutral[100];
+	}
+}
+
 
 const follow = (format: ArticleFormat): Colour => {
 	if (format.design === ArticleDesign.Gallery) {

--- a/apps-rendering/src/palette/text.ts
+++ b/apps-rendering/src/palette/text.ts
@@ -434,31 +434,6 @@ const bylineInlineDark = (format: ArticleFormat): Colour => {
 	}
 };
 
-const designTagDark = ({ design, theme }: ArticleFormat): Colour => {
-	switch (design) {
-		case ArticleDesign.Standard:
-		case ArticleDesign.Review:
-		case ArticleDesign.Explainer:
-		case ArticleDesign.Feature:
-		case ArticleDesign.Interview:
-		case ArticleDesign.Interactive:
-		case ArticleDesign.PhotoEssay:
-		case ArticleDesign.FullPageInteractive:
-		case ArticleDesign.NewsletterSignup:
-		case ArticleDesign.Comment:
-		case ArticleDesign.Letter:
-		case ArticleDesign.Editorial:
-			switch (theme) {
-				case ArticleSpecial.SpecialReportAlt:
-					return palette.specialReportAlt[100];
-				default:
-					return neutral[10];
-			}
-		default:
-			return neutral[10];
-	}
-}
-
 const designTag = ({ design, theme }: ArticleFormat): Colour => {
 	switch (design) {
 		case ArticleDesign.Standard:
@@ -485,6 +460,30 @@ const designTag = ({ design, theme }: ArticleFormat): Colour => {
 	}
 }
 
+const designTagDark = ({ design, theme }: ArticleFormat): Colour => {
+	switch (design) {
+		case ArticleDesign.Standard:
+		case ArticleDesign.Review:
+		case ArticleDesign.Explainer:
+		case ArticleDesign.Feature:
+		case ArticleDesign.Interview:
+		case ArticleDesign.Interactive:
+		case ArticleDesign.PhotoEssay:
+		case ArticleDesign.FullPageInteractive:
+		case ArticleDesign.NewsletterSignup:
+		case ArticleDesign.Comment:
+		case ArticleDesign.Letter:
+		case ArticleDesign.Editorial:
+			switch (theme) {
+				case ArticleSpecial.SpecialReportAlt:
+					return palette.specialReportAlt[100];
+				default:
+					return neutral[10];
+			}
+		default:
+			return neutral[10];
+	}
+}
 
 const follow = (format: ArticleFormat): Colour => {
 	if (format.design === ArticleDesign.Gallery) {

--- a/apps-rendering/src/palette/text.ts
+++ b/apps-rendering/src/palette/text.ts
@@ -458,7 +458,7 @@ const designTag = ({ design, theme }: ArticleFormat): Colour => {
 		default:
 			return neutral[100];
 	}
-}
+};
 
 const designTagDark = ({ design, theme }: ArticleFormat): Colour => {
 	switch (design) {
@@ -483,7 +483,7 @@ const designTagDark = ({ design, theme }: ArticleFormat): Colour => {
 		default:
 			return neutral[10];
 	}
-}
+};
 
 const follow = (format: ArticleFormat): Colour => {
 	if (format.design === ArticleDesign.Gallery) {


### PR DESCRIPTION
## Why?

Building out the special report alt designs in AR, as covered in #6203. I've broken this up into stages to make the PRs easier to review. This PR deals with the design tag.

**Note:** The screenshots below show the final result of all changes, some of which aren't included in this PR.

## Changes

- Added special report alt colours for design tag in light and dark mode

## Screenshots

| | Light | Dark |
| - | - | - |
| Explainer | ![design-tag-explainer-light] | ![design-tag-explainer-dark] |
| Letters |  ![design-tag-letters-light] | ![design-tag-letters-dark] |
| Analysis | ![design-tag-analysis-light] | ![design-tag-analysis-dark] |

[design-tag-explainer-dark]: https://user-images.githubusercontent.com/53781962/218759884-6e3a05de-0df2-400c-ab9d-8ba7fa30e04b.jpg
[design-tag-explainer-light]: https://user-images.githubusercontent.com/53781962/218759888-fc6db3c6-d09f-47c3-afba-da5b1c5df63f.jpg
[design-tag-letters-dark]: https://user-images.githubusercontent.com/53781962/218759890-be5263af-e1ca-46b5-a2e0-1c3a209ef2fb.jpg
[design-tag-letters-light]: https://user-images.githubusercontent.com/53781962/218759892-76847324-becd-4acc-a3d6-629238b35f19.jpg
[design-tag-analysis-dark]: https://user-images.githubusercontent.com/53781962/218759897-e1b95216-79ce-4e98-8394-07c01de7c65e.jpg
[design-tag-analysis-light]: https://user-images.githubusercontent.com/53781962/218759898-eb134d68-acab-4a31-83e2-3adc3da26143.jpg
