### PR TITLE
DCR bundles for apps pages

### DIFF
--- a/dotcom-rendering/scripts/webpack/webpack.config.js
+++ b/dotcom-rendering/scripts/webpack/webpack.config.js
@@ -19,7 +19,7 @@ const sessionId = uuidv4();
 let builds = 0;
 
 /**
- * @param {{ platform: 'server' | 'browser.legacy' | 'browser.modern' | 'browser.variant'}} options
+ * @param {{ platform: 'server' | 'browser.legacy' | 'browser.modern' | 'browser.variant' | 'browser.apps'}} options
  * @returns {import('webpack').Configuration}
  */
 const commonConfigs = ({ platform }) => ({
@@ -128,6 +128,15 @@ module.exports = [
 		}),
 		require(`./webpack.config.browser`)({
 			bundle: 'modern',
+			sessionId,
+		}),
+	),
+	merge(
+		commonConfigs({
+			platform: 'browser.apps',
+		}),
+		require(`./webpack.config.browser`)({
+			bundle: 'apps',
 			sessionId,
 		}),
 	),

--- a/dotcom-rendering/src/lib/assets.test.ts
+++ b/dotcom-rendering/src/lib/assets.test.ts
@@ -1,4 +1,5 @@
 import {
+	APPS_SCRIPT,
 	decideAssetOrigin,
 	LEGACY_SCRIPT,
 	MODERN_SCRIPT,
@@ -58,6 +59,9 @@ describe('regular expression to match files', () => {
 		expect(
 			'https://assets.guim.co.uk/assets/ophan.legacy.eb74205c979f58659ed7.js',
 		).toMatch(LEGACY_SCRIPT);
+		expect(
+			'https://assets.guim.co.uk/assets/ophan.apps.eb74205c979f58659ed7.js',
+		).toMatch(APPS_SCRIPT);
 	});
 
 	it('should handle http3 query param', () => {

--- a/dotcom-rendering/src/lib/assets.ts
+++ b/dotcom-rendering/src/lib/assets.ts
@@ -60,11 +60,17 @@ const getManifest = (path: string): AssetHash => {
 };
 
 const getManifestPaths = (
-	manifests: 'control' | 'variant',
-): [ManifestPath, ManifestPath] =>
-	manifests === 'variant'
-		? ['./manifest.variant.json', './manifest.legacy.json']
-		: ['./manifest.modern.json', './manifest.legacy.json'];
+	manifests: 'control' | 'variant' | 'apps',
+): [ManifestPath, ManifestPath] | [ManifestPath] => {
+	switch (manifests) {
+		case 'apps':
+			return ['./manifest.apps.json'];
+		case 'variant':
+			return ['./manifest.variant.json', './manifest.legacy.json'];
+		case 'control':
+			return ['./manifest.modern.json', './manifest.legacy.json'];
+	}
+};
 
 type ManifestPath = `./manifest.${string}.json`;
 
@@ -76,6 +82,9 @@ const getScripts = (
 		throw new Error('Invalid filename: extension must be .js');
 
 	if (isDev) {
+		if (manifestPaths.every((path) => path.includes('.apps.'))) {
+			return [`${ASSET_ORIGIN}assets/${file.replace('.js', '.apps.js')}`];
+		}
 		return [
 			`${ASSET_ORIGIN}assets/${file.replace('.js', '.modern.js')}`,
 			`${ASSET_ORIGIN}assets/${file.replace('.js', '.legacy.js')}`,
@@ -101,12 +110,23 @@ const getScripts = (
  * an array of scripts found in the manifests.
  */
 export const getScriptsFromManifest =
-	(shouldServeVariantBundle: boolean) =>
-	(file: `${string}.js`): ReturnType<typeof getScripts> =>
-		getScripts(
-			getManifestPaths(shouldServeVariantBundle ? 'variant' : 'control'),
-			file,
-		);
+	(
+		opts:
+			| { platform: 'apps' }
+			| { platform: 'web'; shouldServeVariantBundle: boolean },
+	) =>
+	(file: `${string}.js`): ReturnType<typeof getScripts> => {
+		if (opts.platform === 'apps') {
+			return getScripts(getManifestPaths('apps'), file);
+		} else {
+			return getScripts(
+				getManifestPaths(
+					opts.shouldServeVariantBundle ? 'variant' : 'control',
+				),
+				file,
+			);
+		}
+	};
 
 /** To ensure this only applies to guardian scripts,
  * we check that it is served from a asset/ directory
@@ -114,22 +134,24 @@ export const getScriptsFromManifest =
  * with an optional hash for local development
  * and stripped query parameters.
  */
-const getScriptRegex = (bundle: 'modern' | 'legacy' | 'variant') =>
+const getScriptRegex = (bundle: 'modern' | 'legacy' | 'variant' | 'apps') =>
 	new RegExp(`assets\\/\\w+\\.${bundle}\\.(\\w{20}\\.)?js(\\?.*)?$`);
 
 export const LEGACY_SCRIPT = getScriptRegex('legacy');
 export const MODERN_SCRIPT = getScriptRegex('modern');
 export const VARIANT_SCRIPT = getScriptRegex('variant');
+export const APPS_SCRIPT = getScriptRegex('apps');
 
 export const generateScriptTags = (scripts: Array<string | false>): string[] =>
 	scripts.filter(isString).map((script) => {
 		if (script.match(LEGACY_SCRIPT)) {
 			return `<script defer nomodule src="${script}"></script>`;
 		}
-		if (script.match(MODERN_SCRIPT)) {
-			return `<script type="module" src="${script}"></script>`;
-		}
-		if (script.match(VARIANT_SCRIPT)) {
+		if (
+			script.match(MODERN_SCRIPT) ||
+			script.match(VARIANT_SCRIPT) ||
+			script.match(APPS_SCRIPT)
+		) {
 			return `<script type="module" src="${script}"></script>`;
 		}
 

--- a/dotcom-rendering/src/server/dev-server.ts
+++ b/dotcom-rendering/src/server/dev-server.ts
@@ -14,6 +14,8 @@ import {
 const ARTICLE_URL = /\/\d{4}\/[a-z]{3}\/\d{2}\//;
 /** fronts are a series of lowercase strings, dashes and forward slashes */
 const FRONT_URL = /^\/[a-z-/]+/;
+/** assets are paths like /assets/index.xxx.js */
+const ASSETS_URL = /assets\/.*\.js/;
 
 // see https://www.npmjs.com/package/webpack-hot-server-middleware
 // for more info
@@ -39,6 +41,9 @@ export const devServer = (): Handler => {
 			case '/FrontJSON':
 				return handleFrontJson(req, res, next);
 			default: {
+				// Do not redirect assets urls
+				if (req.url.match(ASSETS_URL)) return next();
+
 				if (req.url.match(ARTICLE_URL)) {
 					const url = new URL(
 						req.url,

--- a/dotcom-rendering/src/web/server/articleToHtml.tsx
+++ b/dotcom-rendering/src/web/server/articleToHtml.tsx
@@ -87,9 +87,10 @@ export const articleToHtml = ({ article }: Props): string => {
 	 *
 	 * @see getScriptsFromManifest
 	 */
-	const getScriptArrayFromFile = getScriptsFromManifest(
+	const getScriptArrayFromFile = getScriptsFromManifest({
+		platform: 'web',
 		shouldServeVariantBundle,
-	);
+	});
 
 	/**
 	 * The highest priority scripts.

--- a/dotcom-rendering/src/web/server/frontToHtml.tsx
+++ b/dotcom-rendering/src/web/server/frontToHtml.tsx
@@ -42,9 +42,10 @@ export const frontToHtml = ({ front }: Props): string => {
 	 *
 	 * @see getScriptsFromManifest
 	 */
-	const getScriptArrayFromFile = getScriptsFromManifest(
+	const getScriptArrayFromFile = getScriptsFromManifest({
+		platform: 'web',
 		shouldServeVariantBundle,
-	);
+	});
 
 	/**
 	 * The highest priority scripts.


### PR DESCRIPTION
Closes https://github.com/guardian/dotcom-rendering/issues/7130

## What does this change?

Creates a 'single file' apps bundle as part of the DCAR migration.

To allow DCR to render for apps, we need to output the client-side code as a single bundle. This is because the apps allow for offline reading - we want all the javascript to be cached on our readers phones/tablets, so that any page downloaded for offline reading can render & work as expected without the need for an internet connection (nb. some client side code will still need connections for making API requests, etc).

This PR creates an 'apps' bundle which uses the `LimitChunkCountPlugin` to force webpack to output just a single chunk (file). We also add `Buffer` to the build using the `ProvidePlugin` as this will be required for [bridget in the future](https://github.com/guardian/dotcom-rendering/milestone/74).

We also modify `assets.ts` to allow us to include the apps bundle into a page in the future (https://github.com/guardian/dotcom-rendering/issues/7058), this involved slightly modifying the interface to allow for multiple platforms

```ts
/* Before (only for web) */
const getScriptArrayFromFile = getScriptsFromManifest(
	shouldServeVariantBundle,
);

getScriptArrayFromFile('index.js') // output: ["index.modern.xxx.js", "index.legacy.xxx.js"]

/* After (supports apps & web) */
/* Web */
const getScriptArrayFromFile = getScriptsFromManifest({
	platform: 'web'
	shouldServeVariantBundle,
});

getScriptArrayFromFile('index.js') // output: ["index.modern.xxx.js", "index.legacy.xxx.js"]


/* Apps */
const getScriptArrayFromFile = getScriptsFromManifest({
	platform: 'apps'
	/* Trying to add 'shouldServeVariantBundle' would error here */ 
});

getScriptArrayFromFile('index.js') // output:  ["index.apps.xxx.js"]
```

### Should we support 'variant' builds in the app?

In short? Maybe, but I haven't added it yet.

Lots of the use of the 'variant' build in DCR is related to optimising for CWV, which will be less of a priority in the apps - where JS will almost always be cached, and search engines aren't ranking us on performance.

That said, if we were to make other changes to our build system, being able to test them and monitor sentry for errors from the app would be useful. 

Given that we likely won't be doing this anytime soon, I've left this functionality out for now, though it would be relatively trivial to add it in the future. Perhaps this just adds more complexity, so I'd be interested on feedback for this point.




