### PR TITLE
Add Criteo Prebid server

### DIFF
--- a/dotcom-rendering/src/amp/components/Ad.tsx
+++ b/dotcom-rendering/src/amp/components/Ad.tsx
@@ -45,7 +45,8 @@ const mapAdTargeting = (adTargeting: AdTargeting): AdTargetParam[] => {
 };
 
 interface CommercialConfig {
-	usePrebid: boolean;
+	usePubmaticPrebid: boolean;
+	useCriteoPrebid: boolean;
 	usePermutive: boolean;
 	useAmazon: boolean;
 }
@@ -69,7 +70,7 @@ export const Ad = ({
 	contentType,
 	commercialProperties,
 	adTargeting,
-	config: { useAmazon, usePrebid, usePermutive },
+	config: { useAmazon, usePubmaticPrebid, useCriteoPrebid, usePermutive },
 	adType,
 }: AdProps) => {
 	const adSizes = adType.isSticky ? stickySizes : inlineSizes;
@@ -79,7 +80,8 @@ export const Ad = ({
 	const multiSizes = adSizes.map((e) => `${e.width}x${e.height}`).join(',');
 
 	const rtcConfig = realTimeConfig(
-		usePrebid,
+		usePubmaticPrebid,
+		useCriteoPrebid,
 		usePermutive,
 		useAmazon,
 		adType,

--- a/dotcom-rendering/src/amp/components/Blocks.tsx
+++ b/dotcom-rendering/src/amp/components/Blocks.tsx
@@ -6,6 +6,7 @@ import type { Switches } from '../../types/config';
 import type { EditionId } from '../../web/lib/edition';
 import { blockLink } from '../lib/block-link';
 import { findBlockAdSlots } from '../lib/find-adslots';
+import { isOnCriteoTestPage } from '../lib/real-time-config';
 import { Elements } from './Elements';
 import { RegionalAd } from './RegionalAd';
 
@@ -70,6 +71,7 @@ type Props = {
 	url: string;
 	shouldHideAds: boolean;
 	adTargeting: AdTargeting;
+	pageId: string;
 };
 
 // TODO ad handling (currently done in elements, which is wrong, so let's lift
@@ -85,6 +87,7 @@ export const Blocks = ({
 	url,
 	shouldHideAds,
 	adTargeting,
+	pageId,
 }: Props) => {
 	// TODO add last updated for blocks to show here
 	const liveBlogBlocks = blocks.map((block) => {
@@ -127,14 +130,17 @@ export const Blocks = ({
 		contentType,
 		commercialProperties,
 		switches: {
-			ampPrebid: !!switches.ampPrebid,
+			ampPrebidPubmatic: !!switches.ampPrebidPubmatic,
+			ampPrebidCriteo: !!switches.ampPrebidCriteo,
 			permutive: !!switches.permutive,
 			ampAmazon: !!switches.ampAmazon,
 		},
 	};
 
 	const adConfig = {
-		usePrebid: adInfo.switches.ampPrebid,
+		usePubmaticPrebid: adInfo.switches.ampPrebidPubmatic,
+		useCriteoPrebid:
+			adInfo.switches.ampPrebidCriteo && isOnCriteoTestPage(pageId),
 		usePermutive: adInfo.switches.permutive,
 		useAmazon: adInfo.switches.ampAmazon,
 	};

--- a/dotcom-rendering/src/amp/components/BodyArticle.tsx
+++ b/dotcom-rendering/src/amp/components/BodyArticle.tsx
@@ -19,6 +19,7 @@ import type { ConfigType } from '../../types/config';
 import { decideDesign } from '../../web/lib/decideDesign';
 import { decideTheme } from '../../web/lib/decideTheme';
 import { findAdSlots } from '../lib/find-adslots';
+import { isOnCriteoTestPage } from '../lib/real-time-config';
 import type { ArticleModel } from '../types/ArticleModel';
 import { Elements } from './Elements';
 import { TextBlockComponent } from './elements/TextBlockComponent';
@@ -133,14 +134,18 @@ export const Body = ({ data, config }: Props) => {
 		contentType: data.contentType,
 		commercialProperties: data.commercialProperties,
 		switches: {
-			ampPrebid: !!config.switches.ampPrebid,
+			ampPrebidPubmatic: !!config.switches.ampPrebidPubmatic,
+			ampPrebidCriteo: !!config.switches.ampPrebidCriteo,
 			permutive: !!config.switches.permutive,
 			ampAmazon: !!config.switches.ampAmazon,
 		},
 	};
 
 	const adConfig = {
-		usePrebid: adInfo.switches.ampPrebid,
+		usePubmaticPrebid: adInfo.switches.ampPrebidPubmatic,
+		useCriteoPrebid:
+			adInfo.switches.ampPrebidCriteo &&
+			isOnCriteoTestPage(config.pageId),
 		usePermutive: adInfo.switches.permutive,
 		useAmazon: adInfo.switches.ampAmazon,
 	};

--- a/dotcom-rendering/src/amp/components/BodyLiveblog.tsx
+++ b/dotcom-rendering/src/amp/components/BodyLiveblog.tsx
@@ -131,6 +131,7 @@ export const Body = ({ data, config }: Props) => {
 						url={url}
 						shouldHideAds={data.shouldHideAds}
 						adTargeting={adTargeting}
+						pageId={data.pageId}
 					/>
 				</div>
 			</amp-live-list>

--- a/dotcom-rendering/src/amp/components/RegionalAd.test.tsx
+++ b/dotcom-rendering/src/amp/components/RegionalAd.test.tsx
@@ -34,7 +34,7 @@ describe('RegionalAd', () => {
 		},
 	};
 
-	it('rtc-config contains just a permutive URL and prebid object when `usePermutive` and `usePrebid` flags are set to true', () => {
+	it('rtc-config contains just a permutive URL and prebid object when `usePermutive` and `usePubmaticPrebid` flags are set to true', () => {
 		const { container } = render(
 			<ContentABTestProvider pageId="" switches={{}}>
 				<RegionalAd
@@ -42,7 +42,8 @@ describe('RegionalAd', () => {
 					section=""
 					contentType=""
 					config={{
-						usePrebid: true,
+						usePubmaticPrebid: true,
+						useCriteoPrebid: false,
 						usePermutive: true,
 						useAmazon: false,
 					}}
@@ -83,7 +84,7 @@ describe('RegionalAd', () => {
 		expect(int?.vendors).toEqual(intPubmaticVendorObj);
 	});
 
-	it('rtc-config contains just a prebid object when `usePrebid` is true and other flags are false', () => {
+	it('rtc-config contains just a prebid object when `usePubmaticPrebid` is true and other flags are false', () => {
 		const { container } = render(
 			<ContentABTestProvider pageId="" switches={{}}>
 				<RegionalAd
@@ -91,7 +92,8 @@ describe('RegionalAd', () => {
 					section=""
 					contentType=""
 					config={{
-						usePrebid: true,
+						usePubmaticPrebid: true,
+						useCriteoPrebid: false,
 						usePermutive: false,
 						useAmazon: false,
 					}}
@@ -140,7 +142,8 @@ describe('RegionalAd', () => {
 					section=""
 					contentType=""
 					config={{
-						usePrebid: false,
+						usePubmaticPrebid: false,
+						useCriteoPrebid: false,
 						usePermutive: true,
 						useAmazon: false,
 					}}
@@ -184,7 +187,8 @@ describe('RegionalAd', () => {
 					section=""
 					contentType=""
 					config={{
-						usePrebid: false,
+						usePubmaticPrebid: false,
+						useCriteoPrebid: false,
 						usePermutive: false,
 						useAmazon: true,
 					}}
@@ -228,7 +232,8 @@ describe('RegionalAd', () => {
 					section=""
 					contentType=""
 					config={{
-						usePrebid: false,
+						usePubmaticPrebid: false,
+						useCriteoPrebid: false,
 						usePermutive: false,
 						useAmazon: false,
 					}}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

This PR introduces a new [Prebid server](https://docs.prebid.org/prebid-server/use-cases/pbs-amp.html) to our AMP site. The steps to do this are broadly:

- Stop using the generic Prebid switch and instead use `ampPrebidPubmatic` for our exisiting Prebid server and `ampPrebidCriteo` for this new one. These switches were introduced in https://github.com/guardian/frontend/pull/25881.

- Add an additional gate around the Criteo logic by checking that we're on one specific test page - in this case it's [/science/grrlscientist/2012/may/25/5](https://amp.code.dev-theguardian.com/science/grrlscientist/2012/may/25/5). **The Criteo Prebid server will only be called on this test page.** This will allow us to share the test page and verify the setup is correct before we release it to 100% (because this is AMP we can't use opt-in links).

- Setup the necessary configuration based on ad type / region that will be shipped to the Prebid server. This consists of using zone ids supplied to us by Criteo.

Note that for now we just assume Criteo isn't enabled in any of the unit tests. When we roll out beyond the test page we can add tests to ensure it's generating the correct RTC config.

## Why?

Should unlock more demand from bidders.
