### PR TITLE
feat(compress): only report on modern

### DIFF
--- a/.github/workflows/compress.yml
+++ b/.github/workflows/compress.yml
@@ -29,3 +29,7 @@ jobs:
           # https://github.com/preactjs/compressed-size-action#dealing-with-hashed-filenames
           # The default hash digest is set to 20 chars in Webpack
           strip-hash: "\\.(\\w{20})\\.js$"
+
+          # reporting on “legacy” and “variant” bundles muddies the water
+          # https://github.com/preactjs/compressed-size-action#customizing-the-list-of-files
+          pattern: "dotcom-rendering/dist/*.modern.*.js"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Stop considering legacy and variant bundle sizes for our [preactjs/compressed-size-action](https://github.com/preactjs/compressed-size-action#customizing-the-list-of-files)

## Why?

The “legacy“ and “variant” bundles are not what the majority of our users see, and reporting on them muddies the water by preventing a meaningful total bundle size.

## ~Screenshots~

[See below!](https://github.com/guardian/dotcom-rendering/pull/7205#issuecomment-1431260233)