### PR TITLE
Server side ad slots on liveblogs. 2nd 0% AB test 

### DIFF
--- a/dotcom-rendering/src/web/lib/liveblogAdSlots.test.ts
+++ b/dotcom-rendering/src/web/lib/liveblogAdSlots.test.ts
@@ -120,8 +120,8 @@ describe('shouldDisplayAd', () => {
 	});
 
 	describe('inserting the first ad slot', () => {
-		it('should display ad if no ad slots have been inserted and the number of pixels without an ad is more than 500', () => {
-			const block = 5;
+		it('should display ad if this is the first block', () => {
+			const block = 0;
 			const totalBlocks = 10;
 			const numAdsInserted = 0;
 			const numPixelsWithoutAdvert = 550;
@@ -135,30 +135,14 @@ describe('shouldDisplayAd', () => {
 
 			expect(result).toBeTruthy();
 		});
-
-		it('should NOT display ad if number of pixels without an ad is less than 500', () => {
-			const block = 5;
-			const totalBlocks = 10;
-			const numAdsInserted = 0;
-			const numPixelsWithoutAdvert = 450;
-
-			const result = shouldDisplayAd(
-				block,
-				totalBlocks,
-				numAdsInserted,
-				numPixelsWithoutAdvert,
-			);
-
-			expect(result).toBeFalsy();
-		});
 	});
 
 	describe('inserting further ad slots', () => {
-		it('should display ad if number of pixels without an ad is more than 1800', () => {
+		it('should display ad if number of pixels without an ad is more than 1600', () => {
 			const block = 5;
 			const totalBlocks = 10;
 			const numAdsInserted = 1;
-			const numPixelsWithoutAdvert = 1850;
+			const numPixelsWithoutAdvert = 1650;
 
 			const result = shouldDisplayAd(
 				block,
@@ -170,11 +154,11 @@ describe('shouldDisplayAd', () => {
 			expect(result).toBeTruthy();
 		});
 
-		it('should NOT display ad if number of pixels without an ad is less than 1800', () => {
+		it('should NOT display ad if number of pixels without an ad is less than 1600', () => {
 			const block = 5;
 			const totalBlocks = 10;
 			const numAdsInserted = 1;
-			const numPixelsWithoutAdvert = 1750;
+			const numPixelsWithoutAdvert = 1550;
 
 			const result = shouldDisplayAd(
 				block,

--- a/dotcom-rendering/src/web/lib/liveblogAdSlots.test.ts
+++ b/dotcom-rendering/src/web/lib/liveblogAdSlots.test.ts
@@ -121,7 +121,7 @@ describe('shouldDisplayAd', () => {
 
 	describe('inserting the first ad slot', () => {
 		it('should display ad if this is the first block', () => {
-			const block = 0;
+			const block = 1;
 			const totalBlocks = 10;
 			const numAdsInserted = 0;
 			const numPixelsWithoutAdvert = 550;

--- a/dotcom-rendering/src/web/lib/liveblogAdSlots.ts
+++ b/dotcom-rendering/src/web/lib/liveblogAdSlots.ts
@@ -214,7 +214,7 @@ const shouldDisplayAd = (
 		return false;
 	}
 
-	const isFirstAd = block === 0;
+	const isFirstAd = block === 1;
 	if (isFirstAd) {
 		return true;
 	}

--- a/dotcom-rendering/src/web/lib/liveblogAdSlots.ts
+++ b/dotcom-rendering/src/web/lib/liveblogAdSlots.ts
@@ -15,15 +15,9 @@ import type {
 const MAX_INLINE_ADS = 8;
 
 /**
- * Minimum amount of space in pixels between the top of
- * the liveblog container and the highest inline ad.
- */
-const MIN_SPACE_BEFORE_FIRST_AD = 500;
-
-/**
  * Minimum amount of space in pixels between any pair of inline ads.
  */
-const MIN_SPACE_BETWEEN_ADS = 1_800;
+const MIN_SPACE_BETWEEN_ADS = 1_600;
 
 /**
  * Estimated margin associated with an element.
@@ -220,13 +214,12 @@ const shouldDisplayAd = (
 		return false;
 	}
 
-	const isFirstAd = numAdsInserted === 0;
+	const isFirstAd = block === 0;
+	if (isFirstAd) {
+		return true;
+	}
 
-	const minSpaceToShowAd = isFirstAd
-		? MIN_SPACE_BEFORE_FIRST_AD
-		: MIN_SPACE_BETWEEN_ADS;
-
-	return numPixelsWithoutAdvert > minSpaceToShowAd;
+	return numPixelsWithoutAdvert > MIN_SPACE_BETWEEN_ADS;
 };
 
 export { calculateApproximateBlockHeight, shouldDisplayAd };


### PR DESCRIPTION
## What does this change?

A second attempt at testing the effects of moving the the ad slot insertion logic to the server. This AB test is set to 0% for now.

The difference between this test and [the previous test](https://github.com/guardian/dotcom-rendering/pull/6574), is that this test will insert the first ad slot after the first content block. This is currently existing behaviour in client-side Spacefinder ad-slot insertion.

The minimum space between blocks has been changed from 1800 to 1600.

## Why?

We previously ran an AB test to find out what the effect was from moving the insertion of inline ad slots on liveblog pages from the client to the server. The results were more or less expected _except_ for desktop revenue in the variant, which was much lower than expected.

> Insert the first ad after the first content block

As a part of this first test, we tested the effects of two distinct changes: moving the ad slot insertion logic to the server and moving down the position of the first ad slot. In this test, we will only test the change of moving the ad slot insertion logic to the server, so we can understand what caused the drop in revenue better.

> Change the minimum space between blocks from 1800 to 1600

Desktop ad-slot ratio decreased by 22.7% and mobile ad-ratio increased by 20.3%. Since we have more mobile users than desktop, we need a slight higher ad-ratio to approximately "even out" in terms of ad-ratio.
