### PR TITLE
add description and remove assignees from bug ISSUE_TEMPLATE

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,7 +1,7 @@
 name: 🐞 Bug Report
+description: Let us know about something unexpected that has happened
 title: "[Bug]: "
 labels: ["bug", "needs-triage"]
-assignees: ''
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Turns out [assignees cannot be an empty string](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/common-validation-errors-when-creating-issue-forms#key-must-be-a-string), but is optional, and description is required:

![Screenshot 2023-02-15 at 14 33 39](https://user-images.githubusercontent.com/31692/219057049-930ebc4b-d547-48c7-909e-e1aefd8f1dfd.png)