### PR TITLE
Personalise copy in the sign in gate based on checkout behaviour

### DIFF
--- a/dotcom-rendering/cypress/e2e/parallel-1/sign-in-gate.cy.js
+++ b/dotcom-rendering/cypress/e2e/parallel-1/sign-in-gate.cy.js
@@ -30,6 +30,14 @@ describe('Sign In Gate Tests', function () {
 		});
 	};
 
+	const setGuCOCompleteCookie = (userType, productType) => {
+		cy.setCookie(
+			'GU_CO_COMPLETE',
+			encodeURIComponent(
+				`{"userType":"${userType}","product":"${productType}"}`,
+			),
+		);
+	};
 	// helper method over the cypress visit method to avoid having to repeat the same url by setting a default
 	// can override the parameter if required
 	const visitArticle = (
@@ -187,6 +195,211 @@ describe('Sign In Gate Tests', function () {
 			cy.get('[data-cy=sign-in-gate-main_privacy]').click();
 
 			cy.contains('privacy settings');
+		});
+
+		describe('Sign in gate should personalise based on the GU_CO_COMPLETE cookie', function () {
+			it('should show the main sign in gate if GU_CO_COMPLETE if not present', function () {
+				visitArticleAndScrollToGateForLazyLoad();
+				cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
+				cy.get('[data-cy=sign-in-gate-main]').contains(
+					'You need to register to keep reading',
+				);
+				cy.get('[data-cy=sign-in-gate-main]').contains(
+					'It’s still free to read – this is not a paywall',
+				);
+				cy.get('[data-cy=sign-in-gate-main]').contains(
+					'We’re committed to keeping our quality reporting open.',
+				);
+				cy.get('[data-cy=sign-in-gate-main_register]').contains(
+					'Register for free',
+				);
+			});
+			it('should show the main sign in gate if GU_CO_COMPLETE is present but flag is false', function () {
+				setGuCOCompleteCookie('new', 'DigitalPack');
+				scrollToGateForLazyLoading();
+
+				cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
+				cy.get('[data-cy=sign-in-gate-main]').contains(
+					'You need to register to keep reading',
+				);
+			});
+
+			describe('Sign in gate should show personalised copy if GU_CO_COMPLETE is present', function () {
+				// HEADER TEXT
+				const SUBSCRIPTION_HEADER = 'Thank you for subscribing';
+				const SUPPORTER_HEADER = 'Thank you for your support';
+
+				// SUBHEADER TEXT
+				const SIGN_IN_PROMPT =
+					'Remember to sign in for a better experience.';
+
+				// BODY TEXT
+				const SIGN_IN_INCENTIVES_DIGITAL = [
+					'Supporter rewards – unlock the benefits of your support',
+					'Incisive analysis and original reporting direct to your inbox, with our newsletters',
+					'Get involved in the discussion – comment on stories',
+				];
+
+				const SIGN_IN_INCENTIVES_NON_DIGITAL = [
+					'Fewer interruptions',
+					'Incisive analysis and original reporting direct to your inbox, with our newsletters',
+					'Get involved in the discussion – comment on stories',
+				];
+				// BUTTON TEXT
+				const COMPLETE_REGISTRATION_BUTTON = 'Complete registration';
+				const SIGN_IN_BUTTON = 'Sign in';
+
+				it('user is new and has a digital subscription', function () {
+					setGuCOCompleteCookie('new', 'DigitalPack');
+					visitArticleAndScrollToGateForLazyLoad();
+
+					cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
+					cy.get('[data-cy=sign-in-gate-main]').contains(
+						SUBSCRIPTION_HEADER,
+					);
+					cy.get('[data-cy=sign-in-gate-main]').contains(
+						SIGN_IN_PROMPT,
+					);
+					SIGN_IN_INCENTIVES_DIGITAL.forEach((item) => {
+						cy.get('[data-cy=sign-in-gate-main]').contains(item);
+					});
+					cy.get('[data-cy=sign-in-gate-main_register]').contains(
+						COMPLETE_REGISTRATION_BUTTON,
+					);
+					cy.get('[data-cy=sign-in-gate-main_register]').should(
+						'have.attr',
+						'href',
+					);
+				});
+
+				it('user is new and has a paper subscription', function () {
+					setGuCOCompleteCookie('guest', 'Paper');
+					visitArticleAndScrollToGateForLazyLoad();
+
+					cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
+					cy.get('[data-cy=sign-in-gate-main]').contains(
+						SUBSCRIPTION_HEADER,
+					);
+					cy.get('[data-cy=sign-in-gate-main]').contains(
+						SIGN_IN_PROMPT,
+					);
+					SIGN_IN_INCENTIVES_NON_DIGITAL.forEach((item) => {
+						cy.get('[data-cy=sign-in-gate-main]').contains(item);
+					});
+					cy.get('[data-cy=sign-in-gate-main_register]').contains(
+						COMPLETE_REGISTRATION_BUTTON,
+					);
+					cy.get('[data-cy=sign-in-gate-main_register]').should(
+						'have.attr',
+						'href',
+					);
+				});
+
+				it('user is new and is a contributor', function () {
+					setGuCOCompleteCookie('new', 'Contribution');
+					visitArticleAndScrollToGateForLazyLoad();
+
+					cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
+					cy.get('[data-cy=sign-in-gate-main]').contains(
+						SUPPORTER_HEADER,
+					);
+					cy.get('[data-cy=sign-in-gate-main]').contains(
+						SIGN_IN_PROMPT,
+					);
+					SIGN_IN_INCENTIVES_NON_DIGITAL.forEach((item) => {
+						cy.get('[data-cy=sign-in-gate-main]').contains(item);
+					});
+					cy.get('[data-cy=sign-in-gate-main_register]').contains(
+						COMPLETE_REGISTRATION_BUTTON,
+					);
+					cy.get('[data-cy=sign-in-gate-main_register]').should(
+						'have.attr',
+						'href',
+					);
+				});
+
+				it('user is existing and has a digital subscription', function () {
+					setGuCOCompleteCookie('current', 'DigitalPack');
+					visitArticleAndScrollToGateForLazyLoad();
+
+					cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
+					cy.get('[data-cy=sign-in-gate-main]').contains(
+						SUBSCRIPTION_HEADER,
+					);
+					cy.get('[data-cy=sign-in-gate-main]').contains(
+						SIGN_IN_PROMPT,
+					);
+					SIGN_IN_INCENTIVES_DIGITAL.forEach((item) => {
+						cy.get('[data-cy=sign-in-gate-main]').contains(item);
+					});
+					cy.get('[data-cy=sign-in-gate-main_register]').contains(
+						SIGN_IN_BUTTON,
+					);
+					cy.get('[data-cy=sign-in-gate-main_register]').should(
+						'have.attr',
+						'href',
+					);
+				});
+
+				it('user is existing and has a paper subscription', function () {
+					setGuCOCompleteCookie('current', 'Paper');
+					visitArticleAndScrollToGateForLazyLoad();
+
+					cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
+					cy.get('[data-cy=sign-in-gate-main]').contains(
+						SUBSCRIPTION_HEADER,
+					);
+					cy.get('[data-cy=sign-in-gate-main]').contains(
+						SIGN_IN_PROMPT,
+					);
+					SIGN_IN_INCENTIVES_NON_DIGITAL.forEach((item) => {
+						cy.get('[data-cy=sign-in-gate-main]').contains(item);
+					});
+					cy.get('[data-cy=sign-in-gate-main_register]').contains(
+						SIGN_IN_BUTTON,
+					);
+					cy.get('[data-cy=sign-in-gate-main_register]').should(
+						'have.attr',
+						'href',
+					);
+				});
+
+				it('user is existing and is a contributor', function () {
+					setGuCOCompleteCookie('current', 'Contribution');
+					visitArticleAndScrollToGateForLazyLoad();
+
+					cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
+					cy.get('[data-cy=sign-in-gate-main]').contains(
+						SUPPORTER_HEADER,
+					);
+					cy.get('[data-cy=sign-in-gate-main]').contains(
+						SIGN_IN_PROMPT,
+					);
+					SIGN_IN_INCENTIVES_NON_DIGITAL.forEach((item) => {
+						cy.get('[data-cy=sign-in-gate-main]').contains(item);
+					});
+					cy.get('[data-cy=sign-in-gate-main_register]').contains(
+						SIGN_IN_BUTTON,
+					);
+					cy.get('[data-cy=sign-in-gate-main_register]').should(
+						'have.attr',
+						'href',
+					);
+				});
+			});
+
+			describe('GU_CO_COMPLETE is present, with invalid contents should show the main sign in gate', function () {
+				it('invalid userType', function () {
+					setGuCOCompleteCookie('invalid', 'Contribution');
+
+					visitArticleAndScrollToGateForLazyLoad();
+
+					cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
+					cy.get('[data-cy=sign-in-gate-main]').contains(
+						'You need to register to keep reading',
+					);
+				});
+			});
 		});
 	});
 });

--- a/dotcom-rendering/cypress/e2e/parallel-1/sign-in-gate.cy.js
+++ b/dotcom-rendering/cypress/e2e/parallel-1/sign-in-gate.cy.js
@@ -266,10 +266,13 @@ describe('Sign In Gate Tests', function () {
 					cy.get('[data-cy=sign-in-gate-main_register]').contains(
 						COMPLETE_REGISTRATION_BUTTON,
 					);
-					cy.get('[data-cy=sign-in-gate-main_register]').should(
-						'have.attr',
-						'href',
-					);
+					cy.get('[data-cy=sign-in-gate-main_register]')
+						.should('have.attr', 'href')
+						.and('contains', '/register?returnUrl=')
+						.and(
+							'match',
+							/componentId%3Dmain_variant_\d_personalised_new_DigitalPack/,
+						);
 				});
 
 				it('user is new and has a paper subscription', function () {
@@ -289,10 +292,13 @@ describe('Sign In Gate Tests', function () {
 					cy.get('[data-cy=sign-in-gate-main_register]').contains(
 						COMPLETE_REGISTRATION_BUTTON,
 					);
-					cy.get('[data-cy=sign-in-gate-main_register]').should(
-						'have.attr',
-						'href',
-					);
+					cy.get('[data-cy=sign-in-gate-main_register]')
+						.should('have.attr', 'href')
+						.and('contains', '/register?returnUrl=')
+						.and(
+							'match',
+							/componentId%3Dmain_variant_\d_personalised_guest_Paper/,
+						);
 				});
 
 				it('user is new and is a contributor', function () {
@@ -312,10 +318,13 @@ describe('Sign In Gate Tests', function () {
 					cy.get('[data-cy=sign-in-gate-main_register]').contains(
 						COMPLETE_REGISTRATION_BUTTON,
 					);
-					cy.get('[data-cy=sign-in-gate-main_register]').should(
-						'have.attr',
-						'href',
-					);
+					cy.get('[data-cy=sign-in-gate-main_register]')
+						.should('have.attr', 'href')
+						.and('contains', '/register?returnUrl=')
+						.and(
+							'match',
+							/componentId%3Dmain_variant_\d_personalised_new_Contribution/,
+						);
 				});
 
 				it('user is existing and has a digital subscription', function () {
@@ -335,10 +344,13 @@ describe('Sign In Gate Tests', function () {
 					cy.get('[data-cy=sign-in-gate-main_register]').contains(
 						SIGN_IN_BUTTON,
 					);
-					cy.get('[data-cy=sign-in-gate-main_register]').should(
-						'have.attr',
-						'href',
-					);
+					cy.get('[data-cy=sign-in-gate-main_register]')
+						.should('have.attr', 'href')
+						.and('contains', '/signin?returnUrl=')
+						.and(
+							'match',
+							/componentId%3Dmain_variant_\d_personalised_current_DigitalPack/,
+						);
 				});
 
 				it('user is existing and has a paper subscription', function () {
@@ -358,10 +370,13 @@ describe('Sign In Gate Tests', function () {
 					cy.get('[data-cy=sign-in-gate-main_register]').contains(
 						SIGN_IN_BUTTON,
 					);
-					cy.get('[data-cy=sign-in-gate-main_register]').should(
-						'have.attr',
-						'href',
-					);
+					cy.get('[data-cy=sign-in-gate-main_register]')
+						.should('have.attr', 'href')
+						.and('contains', '/signin?returnUrl=')
+						.and(
+							'match',
+							/componentId%3Dmain_variant_\d_personalised_current_Paper/,
+						);
 				});
 
 				it('user is existing and is a contributor', function () {
@@ -381,10 +396,14 @@ describe('Sign In Gate Tests', function () {
 					cy.get('[data-cy=sign-in-gate-main_register]').contains(
 						SIGN_IN_BUTTON,
 					);
-					cy.get('[data-cy=sign-in-gate-main_register]').should(
-						'have.attr',
-						'href',
-					);
+
+					cy.get('[data-cy=sign-in-gate-main_register]')
+						.should('have.attr', 'href')
+						.and('contains', '/signin?returnUrl=')
+						.and(
+							'match',
+							/componentId%3Dmain_variant_\d_personalised_current_Contribution/,
+						);
 				});
 			});
 
@@ -398,6 +417,13 @@ describe('Sign In Gate Tests', function () {
 					cy.get('[data-cy=sign-in-gate-main]').contains(
 						'You need to register to keep reading',
 					);
+					cy.get('[data-cy=sign-in-gate-main_register]')
+						.should('have.attr', 'href')
+						.and('contains', '/signin?returnUrl=')
+						.and(
+							'not.match',
+							/componentId%3Dmain_variant_\d_personalised/,
+						);
 				});
 			});
 		});

--- a/dotcom-rendering/cypress/plugins/index.js
+++ b/dotcom-rendering/cypress/plugins/index.js
@@ -7,6 +7,7 @@
 // You can read more here:
 // https://on.cypress.io/plugins-guide
 // ***********************************************************
+import path from 'path';
 
 const webpackPreprocessor = require('cypress-webpack-preprocessor-v5');
 
@@ -14,9 +15,27 @@ module.exports = (on, config) => {
 	config.env = { ...config.env, ...process.env };
 
 	const webpackConfig = webpackPreprocessor.defaultOptions;
-	webpackConfig.webpackOptions.module.rules[0].exclude =
+	// Adding this here so that we can use a module from source code in the cypress tests
+	webpackConfig.webpackOptions.resolve = {
+		extensions: ['.ts', '.js'],
+		alias: {
+			src: path.resolve(__dirname, `../../src`),
+		},
+	};
+	const rules = webpackConfig.webpackOptions.module.rules;
+	rules[0].exclude =
 		require('../../scripts/webpack/webpack.config.browser').babelExclude;
 
+	rules.push({
+		test: /\.ts$/,
+		exclude: ['/node_modules/'],
+		loader: 'ts-loader',
+		options: {
+			compilerOptions: {
+				noEmit: false,
+			},
+		},
+	});
 	on('file:preprocessor', webpackPreprocessor(webpackConfig));
 	return config;
 };

--- a/dotcom-rendering/src/web/components/SignInGate/SignInGate.stories.tsx
+++ b/dotcom-rendering/src/web/components/SignInGate/SignInGate.stories.tsx
@@ -3,6 +3,9 @@ import { SignInGateSelector } from '../SignInGateSelector.importable';
 import { SignInGateCopyTestJan2023 } from './gateDesigns/SignInGateCopyTestJan2023';
 import { SignInGateFakeSocial } from './gateDesigns/SignInGateFakeSocial';
 import { SignInGateMain } from './gateDesigns/SignInGateMain';
+import { SignInGateMainCheckoutComplete } from './gateDesigns/SignInGateMainCheckoutComplete';
+import type { CheckoutCompleteCookieData } from './types';
+import { ALL_PRODUCTS, ALL_USER_TYPES } from './types';
 
 export default {
 	component: SignInGateSelector,
@@ -20,25 +23,12 @@ export const mainStandalone = () => {
 				signInUrl="https://profile.theguardian.com/"
 				dismissGate={() => {}}
 				ophanComponentId="test"
+				personaliseSignInAfterCheckoutSwitch={false}
 			/>
 		</Section>
 	);
 };
 mainStandalone.story = { name: 'main_standalone' };
-
-export const mainStandaloneComment = () => {
-	return (
-		<Section fullWidth={true}>
-			<SignInGateMain
-				guUrl="https://theguardian.com"
-				signInUrl="https://profile.theguardian.com/"
-				dismissGate={() => {}}
-				ophanComponentId="test"
-			/>
-		</Section>
-	);
-};
-mainStandaloneComment.story = { name: 'main_standalone_comment' };
 
 export const mainStandaloneMandatory = () => {
 	return (
@@ -49,28 +39,12 @@ export const mainStandaloneMandatory = () => {
 				dismissGate={() => {}}
 				ophanComponentId="test"
 				isMandatory={true}
+				personaliseSignInAfterCheckoutSwitch={false}
 			/>
 		</Section>
 	);
 };
 mainStandaloneMandatory.story = { name: 'main_standalone_mandatory' };
-
-export const mainStandaloneMandatoryComment = () => {
-	return (
-		<Section fullWidth={true}>
-			<SignInGateMain
-				guUrl="https://theguardian.com"
-				signInUrl="https://profile.theguardian.com/"
-				dismissGate={() => {}}
-				ophanComponentId="test"
-				isMandatory={true}
-			/>
-		</Section>
-	);
-};
-mainStandaloneMandatoryComment.story = {
-	name: 'main_standalone_mandatory_comment',
-};
 
 export const fakeSocialStandalone = () => {
 	return (
@@ -80,6 +54,7 @@ export const fakeSocialStandalone = () => {
 				signInUrl="https://profile.theguardian.com/"
 				dismissGate={() => {}}
 				ophanComponentId="test"
+				personaliseSignInAfterCheckoutSwitch={false}
 			/>
 		</Section>
 	);
@@ -99,6 +74,7 @@ export const fakeSocialStandaloneVertical = () => {
 					name: 'fake-social-test',
 					variant: 'fake-social-variant-vertical',
 				}}
+				personaliseSignInAfterCheckoutSwitch={false}
 			/>
 		</Section>
 	);
@@ -120,11 +96,50 @@ export const signInGateCopyTest = () => {
 					name: 'sign-in-gate-copy-test-jan-2023',
 					variant: 'quick-and-easy',
 				}}
+				personaliseSignInAfterCheckoutSwitch={false}
 			/>
 		</Section>
 	);
 };
-
 signInGateCopyTest.story = {
 	name: 'sign_in_gate_copy_test',
+};
+
+export const signInGateMainCheckoutCompletePersonalisedCopy = (
+	args: CheckoutCompleteCookieData,
+) => {
+	return (
+		<Section fullWidth={true}>
+			<SignInGateMainCheckoutComplete
+				guUrl="https://theguardian.com"
+				signInUrl="https://profile.theguardian.com/signin?" // this is personalised
+				dismissGate={() => {}}
+				ophanComponentId="test"
+				checkoutCompleteCookieData={args}
+				personaliseSignInAfterCheckoutSwitch={true}
+			/>
+		</Section>
+	);
+};
+signInGateMainCheckoutCompletePersonalisedCopy.story = {
+	name: 'main_checkout_complete_personalised',
+};
+
+const defaultCheckoutCompleteCookieData: CheckoutCompleteCookieData = {
+	userType: 'new',
+	product: 'DigitalPack',
+};
+
+signInGateMainCheckoutCompletePersonalisedCopy.args =
+	defaultCheckoutCompleteCookieData;
+
+signInGateMainCheckoutCompletePersonalisedCopy.argTypes = {
+	userType: {
+		options: ALL_USER_TYPES,
+		control: { type: 'radio' },
+	},
+	product: {
+		options: ALL_PRODUCTS,
+		control: { type: 'radio' },
+	},
 };

--- a/dotcom-rendering/src/web/components/SignInGate/gateDesigns/SignInGateMainCheckoutComplete.tsx
+++ b/dotcom-rendering/src/web/components/SignInGate/gateDesigns/SignInGateMainCheckoutComplete.tsx
@@ -1,0 +1,252 @@
+import { css } from '@emotion/react';
+import {
+	brand,
+	from,
+	headline,
+	neutral,
+	space,
+} from '@guardian/source-foundations';
+import { Button, Link, LinkButton } from '@guardian/source-react-components';
+import { trackLink } from '../componentEventTracking';
+import type {
+	Product,
+	SignInGatePropsWithCheckoutCompleteCookieData,
+	UserType,
+} from '../types';
+import {
+	firstParagraphOverlay,
+	hideElementsCss,
+	registerButton,
+	signInGateContainer,
+} from './shared';
+
+const personalisedHeadingStyles = css`
+	${headline.small({ fontWeight: 'bold' })};
+	border-top: 2px ${brand[400]} solid;
+	${from.phablet} {
+		padding-right: 160px;
+		${headline.medium({ fontWeight: 'bold' })};
+	}
+	padding-bottom: ${space[2]}px;
+`;
+
+const personalisedBodyBold = css`
+	${headline.xxsmall({ fontWeight: 'bold', lineHeight: 'regular' })}
+	${from.phablet} {
+		padding-right: 130px;
+	}
+	color: ${brand[400]};
+`;
+
+const bulletStyles = css`
+	margin-bottom: ${space[4]}px;
+	${headline.xxsmall({ fontWeight: 'medium' })};
+	color: ${neutral[100]};
+	display: flex;
+	flex-direction: column;
+	li:not(:first-of-type) {
+		margin-top: 10px;
+	}
+	li::before {
+		content: '';
+		display: inline-block;
+		width: 15px;
+		height: 15px;
+		margin-right: ${space[4]}px;
+		background: ${brand[400]};
+		border-radius: 50%;
+	}
+`;
+
+const personalisedBodyTextList = css`
+	${headline.xxsmall({ fontWeight: 'regular', lineHeight: 'regular' })}
+	padding-bottom: ${space[1]}px;
+	color: black;
+`;
+
+const personalisedActionButtons = css`
+	display: flex;
+	flex-direction: row;
+	justify-content: flex-start;
+	margin-bottom: 20px;
+
+	> a {
+		/* stylelint-disable-next-line declaration-no-important */
+		margin-right: ${space[4]}px !important;
+
+		${from.mobileMedium} {
+			/* stylelint-disable-next-line declaration-no-important */
+			margin-right: ${space[9]}px !important;
+		}
+
+		/* stylelint-disable-next-line declaration-no-important */
+		text-decoration: none !important;
+	}
+`;
+
+const notNowButton = css`
+	/* stylelint-disable-next-line declaration-no-important */
+	color: ${brand[400]} !important;
+	text-decoration: none;
+`;
+
+const faqPersonalised = css`
+	padding-bottom: 18px;
+	margin-top: ${space[3]}px;
+	& a {
+		display: block;
+		margin-top: ${space[6]}px;
+		margin-bottom: ${space[4]}px;
+		color: ${brand[500]};
+		text-decoration-color: ${brand[500]};
+		text-underline-position: under;
+	}
+
+	& a:hover {
+		color: ${brand[500]};
+		text-decoration-color: ${brand[500]};
+	}
+`;
+
+export const bodySpacing = css`
+	padding-top: ${space[2]}px;
+	padding-bottom: ${space[2]}px;
+`;
+
+// HEADER TEXT
+const SUBSCRIPTION_HEADER = 'Thank you for subscribing';
+const SUPPORTER_HEADER = 'Thank you for your support';
+
+// SUBHEADER TEXT
+const SIGN_IN_PROMPT = 'Remember to sign in for a better experience.';
+
+// BODY TEXT
+const SIGN_IN_INCENTIVES_DIGITAL = [
+	'Supporter rewards – unlock the benefits of your support',
+	'Incisive analysis and original reporting direct to your inbox, with our newsletters',
+	'Get involved in the discussion – comment on stories',
+];
+
+const SIGN_IN_INCENTIVES_NON_DIGITAL = [
+	'Fewer interruptions',
+	'Incisive analysis and original reporting direct to your inbox, with our newsletters',
+	'Get involved in the discussion – comment on stories',
+];
+
+// BUTTON TEXT
+const COMPLETE_REGISTRATION_BUTTON = 'Complete registration';
+const SIGN_IN_BUTTON = 'Sign in';
+
+const getHeadingText: (product: Product) => string = (product) => {
+	const headingMap: Record<Product, string> = {
+		DigitalPack: SUBSCRIPTION_HEADER,
+		Paper: SUBSCRIPTION_HEADER,
+		GuardianWeekly: SUBSCRIPTION_HEADER,
+		Contribution: SUPPORTER_HEADER,
+	};
+	return headingMap[product];
+};
+
+const getButtonText: (userType: UserType) => string = (userType) => {
+	const buttonMap: Record<UserType, string> = {
+		new: COMPLETE_REGISTRATION_BUTTON,
+		guest: COMPLETE_REGISTRATION_BUTTON,
+		current: SIGN_IN_BUTTON,
+	};
+	return buttonMap[userType];
+};
+
+const getBodyText: (product: Product) => string[] = (product) => {
+	const bodyTextMap: Record<Product, string[]> = {
+		DigitalPack: SIGN_IN_INCENTIVES_DIGITAL,
+		Paper: SIGN_IN_INCENTIVES_NON_DIGITAL,
+		GuardianWeekly: SIGN_IN_INCENTIVES_NON_DIGITAL,
+		Contribution: SIGN_IN_INCENTIVES_NON_DIGITAL,
+	};
+	return bodyTextMap[product];
+};
+
+export const SignInGateMainCheckoutComplete = ({
+	signInUrl,
+	guUrl,
+	dismissGate,
+	abTest,
+	ophanComponentId,
+	isMandatory = false,
+	checkoutCompleteCookieData,
+}: SignInGatePropsWithCheckoutCompleteCookieData) => {
+	const { userType, product } = checkoutCompleteCookieData;
+
+	return (
+		<div css={signInGateContainer} data-cy="sign-in-gate-main">
+			<style>{hideElementsCss}</style>
+			<div css={firstParagraphOverlay} />
+			<h1 css={personalisedHeadingStyles}>{getHeadingText(product)}</h1>
+			<div css={bodySpacing}>
+				<p css={personalisedBodyBold}>{SIGN_IN_PROMPT}</p>
+				<p css={personalisedBodyBold}>This includes: </p>
+			</div>
+			<ul css={bulletStyles}>
+				{getBodyText(product).map((item) => {
+					return (
+						<li css={personalisedBodyTextList} key={item}>
+							{item}
+						</li>
+					);
+				})}
+			</ul>
+			<div css={personalisedActionButtons}>
+				<LinkButton
+					data-cy="sign-in-gate-main_register"
+					data-ignore="global-link-styling"
+					css={registerButton}
+					priority="primary"
+					size="small"
+					href={signInUrl}
+					onClick={() => {
+						trackLink(ophanComponentId, 'register-link', abTest);
+					}}
+				>
+					{getButtonText(userType)}
+				</LinkButton>
+				{!isMandatory && (
+					<Button
+						data-cy="sign-in-gate-main_dismiss"
+						data-ignore="global-link-styling"
+						css={notNowButton}
+						priority="subdued"
+						size="small"
+						onClick={() => {
+							dismissGate();
+							trackLink(ophanComponentId, 'not-now', abTest);
+						}}
+					>
+						Not now
+					</Button>
+				)}
+			</div>
+
+			<div css={faqPersonalised}>
+				<Link
+					data-ignore="global-link-styling"
+					href={`${guUrl}/info/2014/nov/03/why-your-data-matters-to-us-full-text`}
+					onClick={() => {
+						trackLink(ophanComponentId, 'why-link', abTest);
+					}}
+				>
+					How will my information & data be used?
+				</Link>
+
+				<Link
+					data-ignore="global-link-styling"
+					href={`${guUrl}/help/identity-faq`}
+					onClick={() => {
+						trackLink(ophanComponentId, 'help-link', abTest);
+					}}
+				>
+					Get help with registering or signing in
+				</Link>
+			</div>
+		</div>
+	);
+};

--- a/dotcom-rendering/src/web/components/SignInGate/gateDesigns/SignInGateMainCheckoutComplete.tsx
+++ b/dotcom-rendering/src/web/components/SignInGate/gateDesigns/SignInGateMainCheckoutComplete.tsx
@@ -177,6 +177,16 @@ export const SignInGateMainCheckoutComplete = ({
 }: SignInGatePropsWithCheckoutCompleteCookieData) => {
 	const { userType, product } = checkoutCompleteCookieData;
 
+	// send new/guest userType to the /register page instead of /signin
+	const personaliseSignInURl = (url: string): string => {
+		if (userType === 'new' || userType == 'guest') {
+			const regex = /\/(signin)/;
+			const substitution = `/register`;
+			return url.replace(regex, substitution);
+		}
+		return url;
+	};
+
 	return (
 		<div css={signInGateContainer} data-cy="sign-in-gate-main">
 			<style>{hideElementsCss}</style>
@@ -202,7 +212,7 @@ export const SignInGateMainCheckoutComplete = ({
 					css={registerButton}
 					priority="primary"
 					size="small"
-					href={signInUrl}
+					href={personaliseSignInURl(signInUrl)}
 					onClick={() => {
 						trackLink(ophanComponentId, 'register-link', abTest);
 					}}

--- a/dotcom-rendering/src/web/components/SignInGate/gates/fake-social-variant.tsx
+++ b/dotcom-rendering/src/web/components/SignInGate/gates/fake-social-variant.tsx
@@ -16,7 +16,14 @@ const SignInGateFakeSocial = React.lazy(() => {
 });
 
 export const signInGateComponent: SignInGateComponent = {
-	gate: ({ ophanComponentId, dismissGate, guUrl, signInUrl, abTest }) => (
+	gate: ({
+		ophanComponentId,
+		dismissGate,
+		guUrl,
+		signInUrl,
+		abTest,
+		personaliseSignInAfterCheckoutSwitch,
+	}) => (
 		<Lazy margin={300}>
 			<Suspense fallback={<></>}>
 				<SignInGateFakeSocial
@@ -25,6 +32,9 @@ export const signInGateComponent: SignInGateComponent = {
 					guUrl={guUrl}
 					signInUrl={signInUrl}
 					abTest={abTest}
+					personaliseSignInAfterCheckoutSwitch={
+						personaliseSignInAfterCheckoutSwitch
+					}
 				/>
 			</Suspense>
 		</Lazy>

--- a/dotcom-rendering/src/web/components/SignInGate/gates/main-mandatory-variant.tsx
+++ b/dotcom-rendering/src/web/components/SignInGate/gates/main-mandatory-variant.tsx
@@ -26,6 +26,7 @@ export const signInGateMandatoryComponent: SignInGateComponent = {
 					signInUrl={signInUrl}
 					abTest={abTest}
 					isMandatory={true}
+					personaliseSignInAfterCheckoutSwitch={false}
 				/>
 			</Suspense>
 		</Lazy>

--- a/dotcom-rendering/src/web/components/SignInGate/gates/main-variant.tsx
+++ b/dotcom-rendering/src/web/components/SignInGate/gates/main-variant.tsx
@@ -15,19 +15,65 @@ const SignInGateMain = React.lazy(() => {
 	});
 });
 
+const SignInGateMainCheckoutComplete = React.lazy(() => {
+	const { start, end } = initPerf('SignInGateMainCheckoutComplete');
+	start();
+	return import(
+		/* webpackChunkName: "SignInGateMain" */ '../gateDesigns/SignInGateMainCheckoutComplete'
+	).then((module) => {
+		end();
+		return { default: module.SignInGateMainCheckoutComplete };
+	});
+});
+
+/**
+ * GATE PERSONALISATION:
+ *
+ * If the GU_CO_COMPLETE cookie is present, personalise the sign in gate based on the userType
+ * and product information in the cookie value.
+ * AB tracking will be registered as part of the main gate AB test, but the component Id string
+ * in Ophan ComponentEventTracking will have `_personalised_${userType}_${product}` appended.
+ * This occurs in the SignInGateSelector.importable.tsx file
+ * There is a feature switch called `personaliseSignInAfterCheckout` which can be set in the
+ * admin tools, and depending on the state of that switch will determine which variant of the
+ * gate to show.
+ */
+
 export const signInGateComponent: SignInGateComponent = {
-	gate: ({ ophanComponentId, dismissGate, guUrl, signInUrl, abTest }) => (
-		<Lazy margin={300}>
-			<Suspense fallback={<></>}>
-				<SignInGateMain
-					ophanComponentId={ophanComponentId}
-					dismissGate={dismissGate}
-					guUrl={guUrl}
-					signInUrl={signInUrl}
-					abTest={abTest}
-				/>
-			</Suspense>
-		</Lazy>
-	),
+	gate: ({
+		ophanComponentId,
+		dismissGate,
+		guUrl,
+		signInUrl,
+		abTest,
+		checkoutCompleteCookieData,
+	}) => {
+		return (
+			<Lazy margin={300}>
+				<Suspense fallback={<></>}>
+					{checkoutCompleteCookieData ? (
+						<SignInGateMainCheckoutComplete
+							ophanComponentId={ophanComponentId}
+							dismissGate={dismissGate}
+							guUrl={guUrl}
+							signInUrl={signInUrl}
+							abTest={abTest}
+							checkoutCompleteCookieData={
+								checkoutCompleteCookieData
+							}
+						/>
+					) : (
+						<SignInGateMain
+							ophanComponentId={ophanComponentId}
+							dismissGate={dismissGate}
+							guUrl={guUrl}
+							signInUrl={signInUrl}
+							abTest={abTest}
+						/>
+					)}
+				</Suspense>
+			</Lazy>
+		);
+	},
 	canShow: canShowSignInGate,
 };

--- a/dotcom-rendering/src/web/components/SignInGate/gates/main-variant.tsx
+++ b/dotcom-rendering/src/web/components/SignInGate/gates/main-variant.tsx
@@ -47,11 +47,13 @@ export const signInGateComponent: SignInGateComponent = {
 		signInUrl,
 		abTest,
 		checkoutCompleteCookieData,
+		personaliseSignInAfterCheckoutSwitch,
 	}) => {
 		return (
 			<Lazy margin={300}>
 				<Suspense fallback={<></>}>
-					{checkoutCompleteCookieData ? (
+					{personaliseSignInAfterCheckoutSwitch &&
+					checkoutCompleteCookieData ? (
 						<SignInGateMainCheckoutComplete
 							ophanComponentId={ophanComponentId}
 							dismissGate={dismissGate}
@@ -61,6 +63,7 @@ export const signInGateComponent: SignInGateComponent = {
 							checkoutCompleteCookieData={
 								checkoutCompleteCookieData
 							}
+							personaliseSignInAfterCheckoutSwitch={true}
 						/>
 					) : (
 						<SignInGateMain
@@ -69,6 +72,7 @@ export const signInGateComponent: SignInGateComponent = {
 							guUrl={guUrl}
 							signInUrl={signInUrl}
 							abTest={abTest}
+							personaliseSignInAfterCheckoutSwitch={false}
 						/>
 					)}
 				</Suspense>

--- a/dotcom-rendering/src/web/components/SignInGate/gates/sign-in-gate-copy-test-jan2023.tsx
+++ b/dotcom-rendering/src/web/components/SignInGate/gates/sign-in-gate-copy-test-jan2023.tsx
@@ -25,6 +25,7 @@ export const signInGateCopyTestJan2023Component: SignInGateComponent = {
 					guUrl={guUrl}
 					signInUrl={signInUrl}
 					abTest={abTest}
+					personaliseSignInAfterCheckoutSwitch={false}
 				/>
 			</Suspense>
 		</Lazy>

--- a/dotcom-rendering/src/web/components/SignInGate/types.ts
+++ b/dotcom-rendering/src/web/components/SignInGate/types.ts
@@ -64,6 +64,7 @@ export interface SignInGateProps {
 	abTest?: CurrentSignInGateABTest;
 	isMandatory?: boolean;
 	checkoutCompleteCookieData?: CheckoutCompleteCookieData;
+	personaliseSignInAfterCheckoutSwitch: boolean;
 }
 
 // Type with checkoutCompleteCookieData non optional
@@ -72,6 +73,7 @@ export type SignInGatePropsWithCheckoutCompleteCookieData = WithRequired<
 	SignInGateProps,
 	'checkoutCompleteCookieData'
 >;
+
 export type CurrentSignInGateABTest = {
 	name: string;
 	variant: string;

--- a/dotcom-rendering/src/web/components/SignInGate/types.ts
+++ b/dotcom-rendering/src/web/components/SignInGate/types.ts
@@ -18,6 +18,44 @@ export type SignInGateComponent = {
 	}: CanShowGateProps) => Promise<boolean>;
 };
 
+// Taking this approach for validating whether a specific
+// string is in a union type as per the advice of this blog:
+// https://dev.to/hansott/how-to-check-if-string-is-member-of-union-type-1j4m
+// Other option is to use an enum, though there are downside to this:
+// https://dev.to/azure/the-dangers-of-typescript-enums-55pd
+
+export const ALL_USER_TYPES = ['new', 'guest', 'current'] as const;
+type UserTypeTuple = typeof ALL_USER_TYPES;
+export type UserType = UserTypeTuple[number];
+
+export function isUserType(value: unknown): value is UserType {
+	return ALL_USER_TYPES.includes(value as UserType);
+}
+
+export const ALL_PRODUCTS = [
+	'Contribution',
+	'DigitalPack',
+	'Paper',
+	'GuardianWeekly',
+] as const;
+type ProductTuple = typeof ALL_PRODUCTS;
+export type Product = ProductTuple[number];
+
+export function isProduct(value: unknown): value is Product {
+	return ALL_PRODUCTS.includes(value as Product);
+}
+export interface CheckoutCompleteCookieData {
+	userType: UserType;
+	product: Product;
+}
+
+export function isCheckoutCompleteCookieData(
+	obj: unknown,
+): obj is CheckoutCompleteCookieData {
+	// TODO - validate whether this type casting here is ok
+	const castObj = obj as CheckoutCompleteCookieData;
+	return isUserType(castObj.userType) && isProduct(castObj.product);
+}
 export interface SignInGateProps {
 	signInUrl: string;
 	guUrl: string;
@@ -25,8 +63,15 @@ export interface SignInGateProps {
 	ophanComponentId: string;
 	abTest?: CurrentSignInGateABTest;
 	isMandatory?: boolean;
+	checkoutCompleteCookieData?: CheckoutCompleteCookieData;
 }
 
+// Type with checkoutCompleteCookieData non optional
+type WithRequired<T, K extends keyof T> = T & { [P in K]-?: T[P] };
+export type SignInGatePropsWithCheckoutCompleteCookieData = WithRequired<
+	SignInGateProps,
+	'checkoutCompleteCookieData'
+>;
 export type CurrentSignInGateABTest = {
 	name: string;
 	variant: string;

--- a/dotcom-rendering/src/web/components/SignInGateSelector.importable.tsx
+++ b/dotcom-rendering/src/web/components/SignInGateSelector.importable.tsx
@@ -65,12 +65,14 @@ const generateSignInUrl = ({
 	idUrl,
 	host,
 	currentTest,
+	componentId,
 }: {
 	pageId: string;
 	pageViewId: string;
 	idUrl: string;
 	host: string;
 	currentTest: CurrentSignInGateABTest;
+	componentId?: string;
 }) => {
 	// url of the article, return user here after sign in/registration
 	const returnUrl = `${host}/${pageId}`;
@@ -78,7 +80,7 @@ const generateSignInUrl = ({
 	// set the component event params to be included in the query
 	const queryParams: ComponentEventParams = {
 		componentType: 'signingate',
-		componentId: signInGateTestIdToComponentId[currentTest.id],
+		componentId,
 		abTestName: currentTest.name,
 		abTestVariant: currentTest.variant,
 		browserId:
@@ -222,13 +224,28 @@ export const SignInGateSelector = ({
 		return null;
 	}
 
-	const componentId = signInGateTestIdToComponentId[currentTest.id];
+	const personalisedComponentId = (
+		id?: string,
+		checkoutCompleteCookieData?: CheckoutCompleteCookieData,
+	): string | undefined => {
+		if (!id) return undefined;
+		if (!checkoutCompleteCookieData) return id;
+		const { userType, product } = checkoutCompleteCookieData;
+		return `${id}_personalised_${userType}_${product}`;
+	};
+
+	const componentId = personalisedComponentId(
+		signInGateTestIdToComponentId[currentTest.id],
+		checkoutCompleteCookieData,
+	);
+
 	const signInUrl = generateSignInUrl({
 		pageId,
 		host,
 		pageViewId,
 		idUrl,
 		currentTest,
+		componentId,
 	});
 
 	return (

--- a/dotcom-rendering/src/web/components/SignInGateSelector.importable.tsx
+++ b/dotcom-rendering/src/web/components/SignInGateSelector.importable.tsx
@@ -2,6 +2,7 @@ import { getCookie } from '@guardian/libs';
 import { useEffect, useState } from 'react';
 import { constructQuery } from '../../lib/querystring';
 import type { TagType } from '../../types/tag';
+import { parseCheckoutCompleteCookieData } from '../lib/parser/parseCheckoutOutCookieData';
 import { useOnce } from '../lib/useOnce';
 import { useSignInGateSelector } from '../lib/useSignInGateSelector';
 import type { ComponentEventParams } from './SignInGate/componentEventTracking';
@@ -15,6 +16,7 @@ import {
 } from './SignInGate/dismissGate';
 import { signInGateTestIdToComponentId } from './SignInGate/signInGate';
 import type {
+	CheckoutCompleteCookieData,
 	CurrentSignInGateABTest,
 	SignInGateComponent,
 } from './SignInGate/types';
@@ -40,6 +42,7 @@ interface ShowSignInGateProps {
 	signInUrl: string;
 	gateVariant: SignInGateComponent;
 	host: string;
+	checkoutComplete?: CheckoutCompleteCookieData;
 }
 
 const dismissGate = (
@@ -99,6 +102,7 @@ const ShowSignInGate = ({
 	signInUrl,
 	gateVariant,
 	host,
+	checkoutComplete: checkoutCompleteCookieData,
 }: ShowSignInGateProps) => {
 	// use effect hook to fire view event tracking only on initial render
 	useEffect(() => {
@@ -121,6 +125,7 @@ const ShowSignInGate = ({
 			},
 			abTest,
 			ophanComponentId: componentId,
+			checkoutCompleteCookieData,
 		});
 	}
 	// return nothing if no gate needs to be shown
@@ -141,6 +146,16 @@ export const SignInGateSelector = ({
 	idUrl = 'https://profile.theguardian.com',
 }: Props) => {
 	const isSignedIn = !!getCookie({ name: 'GU_U', shouldMemoize: true });
+	// START: Checkout Complete Personalisation
+	const checkOutCompleteString = getCookie({
+		name: 'GU_CO_COMPLETE',
+		shouldMemoize: true,
+	});
+	const checkoutCompleteCookieData: CheckoutCompleteCookieData | undefined =
+		checkOutCompleteString !== null
+			? parseCheckoutCompleteCookieData(checkOutCompleteString)
+			: undefined;
+	// END: Checkout Complete Personalisation
 	const [isGateDismissed, setIsGateDismissed] = useState<boolean | undefined>(
 		undefined,
 	);
@@ -228,6 +243,7 @@ export const SignInGateSelector = ({
 					signInUrl={signInUrl}
 					gateVariant={gateVariant}
 					host={host}
+					checkoutComplete={checkoutCompleteCookieData}
 				/>
 			)}
 		</>

--- a/dotcom-rendering/src/web/components/SignInGateSelector.importable.tsx
+++ b/dotcom-rendering/src/web/components/SignInGateSelector.importable.tsx
@@ -1,4 +1,4 @@
-import { getCookie } from '@guardian/libs';
+import { getCookie, getSwitches } from '@guardian/libs';
 import { useEffect, useState } from 'react';
 import { constructQuery } from '../../lib/querystring';
 import type { TagType } from '../../types/tag';
@@ -43,6 +43,7 @@ interface ShowSignInGateProps {
 	gateVariant: SignInGateComponent;
 	host: string;
 	checkoutComplete?: CheckoutCompleteCookieData;
+	personaliseSignInAfterCheckoutSwitch: boolean;
 }
 
 const dismissGate = (
@@ -105,6 +106,7 @@ const ShowSignInGate = ({
 	gateVariant,
 	host,
 	checkoutComplete: checkoutCompleteCookieData,
+	personaliseSignInAfterCheckoutSwitch,
 }: ShowSignInGateProps) => {
 	// use effect hook to fire view event tracking only on initial render
 	useEffect(() => {
@@ -128,6 +130,7 @@ const ShowSignInGate = ({
 			abTest,
 			ophanComponentId: componentId,
 			checkoutCompleteCookieData,
+			personaliseSignInAfterCheckoutSwitch,
 		});
 	}
 	// return nothing if no gate needs to be shown
@@ -158,6 +161,7 @@ export const SignInGateSelector = ({
 			? parseCheckoutCompleteCookieData(checkOutCompleteString)
 			: undefined;
 	// END: Checkout Complete Personalisation
+
 	const [isGateDismissed, setIsGateDismissed] = useState<boolean | undefined>(
 		undefined,
 	);
@@ -168,6 +172,7 @@ export const SignInGateSelector = ({
 		CurrentSignInGateABTest | undefined
 	>(undefined);
 	const [canShowGate, setCanShowGate] = useState(false);
+	const [personaliseSwitch, setPersonaliseSwitch] = useState(false);
 	const gateSelector = useSignInGateSelector();
 
 	const { pageViewId } = window.guardian.config.ophan;
@@ -209,6 +214,12 @@ export const SignInGateSelector = ({
 				})
 				.then(setCanShowGate);
 		}
+		// eslint-disable-next-line @typescript-eslint/no-floating-promises
+		getSwitches().then((switches) => {
+			if (switches.personaliseSignInAfterCheckout) {
+				setPersonaliseSwitch(switches.personaliseSignInAfterCheckout);
+			} else setPersonaliseSwitch(false);
+		});
 	}, [
 		currentTest,
 		gateVariant,
@@ -261,6 +272,7 @@ export const SignInGateSelector = ({
 					gateVariant={gateVariant}
 					host={host}
 					checkoutComplete={checkoutCompleteCookieData}
+					personaliseSignInAfterCheckoutSwitch={personaliseSwitch}
 				/>
 			)}
 		</>

--- a/dotcom-rendering/src/web/lib/parser/jsonParser.ts
+++ b/dotcom-rendering/src/web/lib/parser/jsonParser.ts
@@ -1,0 +1,16 @@
+export const safeJsonParse =
+	<T>(guard: (o: unknown) => o is T) =>
+	(text: string): ParseResult<T> => {
+		try {
+			const parsed = JSON.parse(text) as unknown;
+			return guard(parsed)
+				? { parsed, hasError: false }
+				: { hasError: true };
+		} catch (_) {
+			return { hasError: true };
+		}
+	};
+
+type ParseResult<T> =
+	| { parsed: T; hasError: false; error?: undefined }
+	| { parsed?: undefined; hasError: true; error?: unknown };

--- a/dotcom-rendering/src/web/lib/parser/parseCheckoutOutCookieData.test.ts
+++ b/dotcom-rendering/src/web/lib/parser/parseCheckoutOutCookieData.test.ts
@@ -1,0 +1,67 @@
+import { parseCheckoutCompleteCookieData } from './parseCheckoutOutCookieData';
+
+describe('parseCheckoutCompleteCookieData', () => {
+	const encodeCheckoutCompleteCookieDataObj = (
+		userType: string,
+		product: string,
+	) =>
+		encodeURIComponent(`{"userType":"${userType}","product":"${product}"}`);
+
+	describe('successful parse', () => {
+		it('should successfully parse a url encoded json object with a valid userType and product valid field', () => {
+			const cookieString = encodeCheckoutCompleteCookieDataObj(
+				'new',
+				'DigitalPack',
+			);
+			expect(parseCheckoutCompleteCookieData(cookieString)).toStrictEqual(
+				{
+					userType: 'new',
+					product: 'DigitalPack',
+				},
+			);
+		});
+	});
+
+	describe('unsuccessful parse should return undefined', () => {
+		it('invalid user type', () => {
+			const cookieString = encodeCheckoutCompleteCookieDataObj(
+				'invalid',
+				'DigitalPack',
+			);
+			expect(parseCheckoutCompleteCookieData(cookieString)).toBe(
+				undefined,
+			);
+		});
+		it('invalid product type', () => {
+			const cookieString = encodeCheckoutCompleteCookieDataObj(
+				'new',
+				'undefined',
+			);
+			expect(parseCheckoutCompleteCookieData(cookieString)).toBe(
+				undefined,
+			);
+		});
+		it('invalid field', () => {
+			const cookieString = encodeURIComponent(
+				`{"invalid":"new", "product": "DigitalPack"}`,
+			);
+			expect(parseCheckoutCompleteCookieData(cookieString)).toBe(
+				undefined,
+			);
+		});
+		it('invalid json structure', () => {
+			const cookieString = encodeURIComponent(
+				`{"userType":"new", "product": "DigitalPack"`,
+			);
+			expect(parseCheckoutCompleteCookieData(cookieString)).toBe(
+				undefined,
+			);
+		});
+		it('plain string', () => {
+			const cookieString = `{"userType":"new", "product": "DigitalPack"}`;
+			expect(parseCheckoutCompleteCookieData(cookieString)).toBe(
+				undefined,
+			);
+		});
+	});
+});

--- a/dotcom-rendering/src/web/lib/parser/parseCheckoutOutCookieData.ts
+++ b/dotcom-rendering/src/web/lib/parser/parseCheckoutOutCookieData.ts
@@ -1,0 +1,14 @@
+import type { CheckoutCompleteCookieData } from '../../components/SignInGate/types';
+import { isCheckoutCompleteCookieData } from '../../components/SignInGate/types';
+import { safeJsonParse } from './jsonParser';
+
+export const parseCheckoutCompleteCookieData = (
+	checkoutCompleteStr: string,
+): CheckoutCompleteCookieData | undefined => {
+	const decodedCookieString = decodeURIComponent(checkoutCompleteStr);
+	if (decodedCookieString === checkoutCompleteStr) return undefined;
+	const parseResult = safeJsonParse(isCheckoutCompleteCookieData)(
+		decodeURIComponent(checkoutCompleteStr),
+	);
+	return !parseResult.hasError ? parseResult.parsed : undefined;
+};


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

This adds personalised copy to the sign in gate, based on information set in the GU_CO_COMPLETE cookie, which is information we get after a user either buys a subscription or makes a contribution.

## Why?

The hypothesis is that copy that is personalised to how a user is already interacting with the Guardian is more likely to increase sign-ins compared to the blanket copy.


## Screenshots

To follow after a design review

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->


<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
