### PR TITLE
Fix Lighthouse reports (again)

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -51,7 +51,12 @@ jobs:
           deno-version: v1.x
 
       - name: Surface Lighthouse Results
-        run: deno run --no-check --allow-net=api.github.com --allow-env="GITHUB_TOKEN","GITHUB_EVENT_PATH","LHCI_URL" --allow-read scripts/deno/surface-lighthouse-results.ts
+        run: |
+          deno run \
+            --allow-read \
+            --allow-net=api.github.com \
+            --allow-env=HOME,GITHUB_TOKEN,GITHUB_EVENT_PATH,LHCI_URL \
+            scripts/deno/surface-lighthouse-results.ts
         env:
           LHCI_URL: ${{ matrix.group }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Fix the surfacing of lighthouse reports, by allowing the reading of `HOME`, which is required for npm specifiers in Deno.

## Why?

This script is broken as a result of combining the following PRs:
- #7203
- #7217 