### PR TITLE
Use SWC as the default compiler

### DIFF
--- a/dotcom-rendering/scripts/webpack/bundles.js
+++ b/dotcom-rendering/scripts/webpack/bundles.js
@@ -4,6 +4,9 @@
  * Set this to `true` if you want to serve a server-side experiment against
  * the `dcrJavascriptBundle` A/B test.
  *
+ * Ensure Sentry sampling in sentry/index.ts is adjusted for the sample
+ * size of the test
+ *
  * @type {boolean} prevent TS from narrowing this to its current value
  */
 const BUILD_VARIANT = false;

--- a/dotcom-rendering/scripts/webpack/webpack.config.browser.js
+++ b/dotcom-rendering/scripts/webpack/webpack.config.browser.js
@@ -6,6 +6,48 @@ const GuStatsReportPlugin = require('./plugins/gu-stats-report-plugin');
 
 const DEV = process.env.NODE_ENV === 'development';
 
+// switch in case we need to revert quickly
+const USE_SWC = true;
+
+const babelLoader = [
+	{
+		loader: 'babel-loader',
+		options: {
+			presets: [
+				'@babel/preset-react',
+				[
+					'@babel/preset-env',
+					{
+						bugfixes: true,
+						targets: 'extends @guardian/browserslist-config',
+					},
+				],
+			],
+			compact: true,
+		},
+	},
+	{
+		loader: 'ts-loader',
+		options: {
+			configFile: 'tsconfig.build.json',
+			transpileOnly: true,
+		},
+	},
+];
+
+const swcLoader = [
+	{
+		loader: 'swc-loader',
+		options: {
+			...swcConfig,
+			env: {
+				dynamicImport: true,
+				targets: getBrowserTargets(),
+			},
+		},
+	},
+];
+
 /**
  * @param {'legacy' | 'modern' | 'variant' | 'apps'} bundle
  * @returns {string}
@@ -49,47 +91,6 @@ const getLoaders = (bundle) => {
 					},
 				},
 			];
-		case 'variant':
-			return [
-				{
-					loader: 'swc-loader',
-					options: {
-						...swcConfig,
-						env: {
-							// debug: true,
-							dynamicImport: true,
-							targets: getBrowserTargets(),
-						},
-					},
-				},
-			];
-		case 'modern':
-			return [
-				{
-					loader: 'babel-loader',
-					options: {
-						presets: [
-							'@babel/preset-react',
-							[
-								'@babel/preset-env',
-								{
-									bugfixes: true,
-									targets:
-										'extends @guardian/browserslist-config',
-								},
-							],
-						],
-						compact: true,
-					},
-				},
-				{
-					loader: 'ts-loader',
-					options: {
-						configFile: 'tsconfig.build.json',
-						transpileOnly: true,
-					},
-				},
-			];
 		case 'apps':
 			return [
 				{
@@ -116,6 +117,9 @@ const getLoaders = (bundle) => {
 					},
 				},
 			];
+		case 'variant':
+		case 'modern':
+			return USE_SWC ? swcLoader : babelLoader;
 	}
 };
 

--- a/dotcom-rendering/scripts/webpack/webpack.config.browser.js
+++ b/dotcom-rendering/scripts/webpack/webpack.config.browser.js
@@ -6,7 +6,7 @@ const GuStatsReportPlugin = require('./plugins/gu-stats-report-plugin');
 
 const DEV = process.env.NODE_ENV === 'development';
 
-// switch in case we need to revert quickly
+// switch in case we need to revert
 const USE_SWC = true;
 
 const babelLoader = [

--- a/dotcom-rendering/scripts/webpack/webpack.config.server.js
+++ b/dotcom-rendering/scripts/webpack/webpack.config.server.js
@@ -6,7 +6,7 @@ const GuStatsReportPlugin = require('./plugins/gu-stats-report-plugin');
 const DEV = process.env.NODE_ENV === 'development';
 const nodeVersion = process.versions.node;
 
-// temporary switch in case we need to revert quickly
+// switch in case we need to revert quickly
 const USE_SWC = true;
 
 const babelLoader = [

--- a/dotcom-rendering/scripts/webpack/webpack.config.server.js
+++ b/dotcom-rendering/scripts/webpack/webpack.config.server.js
@@ -6,7 +6,7 @@ const GuStatsReportPlugin = require('./plugins/gu-stats-report-plugin');
 const DEV = process.env.NODE_ENV === 'development';
 const nodeVersion = process.versions.node;
 
-// switch in case we need to revert quickly
+// switch in case we need to revert
 const USE_SWC = true;
 
 const babelLoader = [

--- a/dotcom-rendering/src/web/browser/sentryLoader/index.test.ts
+++ b/dotcom-rendering/src/web/browser/sentryLoader/index.test.ts
@@ -33,15 +33,6 @@ describe('Enable Sentry when it passes loading conditions', () => {
 				randomCentile: 1,
 			}),
 		).toEqual(true);
-		// The sample rate is currently 20% but we want to maintain a 1% sample rate so sample 5% of 20%
-		expect(
-			isSentryEnabled({
-				isDev: false,
-				enableSentryReporting: true,
-				isInBrowserVariantTest: true,
-				randomCentile: 6,
-			}),
-		).toEqual(false);
 	});
 	it('does enable Sentry for 1% of users', () => {
 		expect(

--- a/dotcom-rendering/src/web/browser/sentryLoader/index.ts
+++ b/dotcom-rendering/src/web/browser/sentryLoader/index.ts
@@ -19,10 +19,12 @@ const isSentryEnabled = ({
 }: IsSentryEnabled): boolean => {
 	// We don't send errors on the dev server, or if the enableSentryReporting switch is off
 	if (isDev || !enableSentryReporting) return false;
-	// We want to log all errors for users in the bundle variant AB test regardless of
-	// the sample rate. Please ensure that the test sample rate is low.
-	// The sample rate is currently 20% but we want to maintain a 1% sample rate so sample 5% of 20%
-	if (isInBrowserVariantTest && randomCentile <= 5) return true;
+	// We want to log all errors for users in the bundle variant AB test.
+	// Please ensure that the test sample rate is low.
+	// If the sample size of the variant test is > 1% adjust the sample rates for _both_
+	// the variant and control so they each represent 1% of the overall traffic.
+	// This will allow a like for like comparison in Sentry.
+	if (isInBrowserVariantTest) return true;
 	// Sentry lets you configure sampleRate to reduce the volume of events sent
 	// but this filter only happens _after_ the library is loaded. The Guardian
 	// measures page views in the billions so we only want to log 1% of errors that


### PR DESCRIPTION
## What does this change?

Switch to use [SWC](https://swc.rs/) as the default compiler following successful completion of an AB test.

## Why?

Reduce dev build times from ~50s to ~5-7s

Reduce prod build times from ~90s to ~50s (legacy build is still Babel)

More details here: https://github.com/guardian/dotcom-rendering/pull/6578



