### PR TITLE
Do not load the commercial bundle for ad free users

### DIFF
--- a/dotcom-rendering/src/web/server/articleToHtml.tsx
+++ b/dotcom-rendering/src/web/server/articleToHtml.tsx
@@ -1,4 +1,4 @@
-import { ArticleDesign, ArticlePillar } from '@guardian/libs';
+import { ArticleDesign, ArticlePillar, isString } from '@guardian/libs';
 import {
 	BUILD_VARIANT,
 	dcrJavascriptBundle,
@@ -98,18 +98,22 @@ export const articleToHtml = ({ article }: Props): string => {
 	 * Please talk to the dotcom platform team before adding more.
 	 * Scripts will be executed in the order they appear in this array
 	 */
+	const loadCommercial = !article.isAdFreeUser && !article.shouldHideAds;
 	const scriptTags = generateScriptTags(
 		[
 			polyfillIO,
 			...getScriptArrayFromFile('frameworks.js'),
 			...getScriptArrayFromFile('index.js'),
-			process.env.COMMERCIAL_BUNDLE_URL ??
-				article.config.commercialBundleUrl,
+			loadCommercial &&
+				(process.env.COMMERCIAL_BUNDLE_URL ??
+					article.config.commercialBundleUrl),
 			pageHasNonBootInteractiveElements &&
 				`${ASSET_ORIGIN}static/frontend/js/curl-with-js-and-domReady.js`,
-		].map((script) =>
-			offerHttp3 && script ? getHttp3Url(script) : script,
-		),
+		]
+			.filter(isString)
+			.map((script) =>
+				offerHttp3 && script ? getHttp3Url(script) : script,
+			),
 	);
 
 	/**

--- a/dotcom-rendering/src/web/server/frontToHtml.tsx
+++ b/dotcom-rendering/src/web/server/frontToHtml.tsx
@@ -1,3 +1,4 @@
+import { isString } from '@guardian/libs';
 import {
 	BUILD_VARIANT,
 	dcrJavascriptBundle,
@@ -53,14 +54,18 @@ export const frontToHtml = ({ front }: Props): string => {
 	 * Please talk to the dotcom platform team before adding more.
 	 * Scripts will be executed in the order they appear in this array
 	 */
+	const loadCommercial = !front.isAdFreeUser;
 	const scriptTags = generateScriptTags(
 		[
 			polyfillIO,
 			...getScriptArrayFromFile('frameworks.js'),
 			...getScriptArrayFromFile('index.js'),
-			process.env.COMMERCIAL_BUNDLE_URL ??
-				front.config.commercialBundleUrl,
-		].map((script) => (offerHttp3 ? getHttp3Url(script) : script)),
+			loadCommercial &&
+				(process.env.COMMERCIAL_BUNDLE_URL ??
+					front.config.commercialBundleUrl),
+		]
+			.filter(isString)
+			.map((script) => (offerHttp3 ? getHttp3Url(script) : script)),
 	);
 
 	/**


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

stop the commercial bundle loading at all for ad-free (i.e. paying) users

## Why?

we know on the server that we won't run the code, but we still force people to download it. the commercial code in turn still loads further libraries we also know we won't run. if we're not going to run, let's not load it.

## Screenshots

| CWV      | Before      | After      |
|-------------|-------------|------------|
| Total Blocking Time | 4.438s | 3.192s |
| Total bytes | 1,223kB | 1,117kB |

## WebPageTest Comparison

_blue is no-bundle version_
<img width="732" alt="image" src="https://user-images.githubusercontent.com/867233/220142118-707d7e02-4325-4a5e-8cb7-cbdd0a426241.png">


https://www.webpagetest.org/video/compare.php?tests=230220_BiDc6G_APR,230220_BiDc8R_APK

## Frontend

frontend equivalent PR is at https://github.com/guardian/frontend/pull/25909