### PR TITLE
Improve request logging for DCR 

### DIFF
--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -276,27 +276,7 @@ interface FENavType {
 type StageType = 'DEV' | 'CODE' | 'PROD';
 
 /**
- * BlocksRequest is the expected body format for POST requests made to /Blocks
- */
-interface FEBlocksRequest {
-	blocks: Block[];
-	format: FEFormat;
-	host?: string;
-	pageId: string;
-	webTitle: string;
-	ajaxUrl: string;
-	isAdFreeUser: boolean;
-	isSensitive: boolean;
-	edition: string;
-	section: string;
-	sharedAdTargeting: Record<string, unknown>;
-	adUnit: string;
-	videoDuration?: number;
-	switches: { [key: string]: boolean };
-	keywordIds: string;
-}
-
-/**
+ * @deprecated We aren't using this - we should remove it.
  * KeyEventsRequest is the expected body format for POST requests made to /KeyEvents
  */
 interface FEKeyEventsRequest {

--- a/dotcom-rendering/src/types/blocksRequest.ts
+++ b/dotcom-rendering/src/types/blocksRequest.ts
@@ -1,0 +1,21 @@
+import type { BaseRequestBody } from './request';
+
+/**
+ * BlocksRequest is the expected body format for POST requests made to /Blocks
+ */
+export interface FEBlocksRequest extends BaseRequestBody {
+	blocks: Block[];
+	format: FEFormat;
+	host?: string;
+	webTitle: string;
+	ajaxUrl: string;
+	isAdFreeUser: boolean;
+	isSensitive: boolean;
+	edition: string;
+	section: string;
+	sharedAdTargeting: Record<string, unknown>;
+	adUnit: string;
+	videoDuration?: number;
+	switches: { [key: string]: boolean };
+	keywordIds: string;
+}

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -2,16 +2,16 @@ import type { ArticlePillar, ArticleSpecial } from '@guardian/libs';
 import type { EditionId } from '../web/lib/edition';
 import type { ServerSideTests, Switches } from './config';
 import type { FooterType } from './footer';
+import type { BaseRequestBody } from './request';
 import type { FETagType } from './tag';
 import type { FETrailType, TrailType } from './trails';
 
-export interface FEFrontType {
+export interface FEFrontType extends BaseRequestBody {
 	pressedPage: FEPressedPageType;
 	nav: FENavType;
 	editionId: EditionId;
 	editionLongForm: string;
 	guardianBaseURL: string;
-	pageId: string;
 	webTitle: string;
 	webURL: string;
 	config: FEFrontConfigType;

--- a/dotcom-rendering/src/types/frontend.ts
+++ b/dotcom-rendering/src/types/frontend.ts
@@ -5,6 +5,7 @@ import type { ConfigType } from './config';
 import type { FEElement, Newsletter } from './content';
 import type { FooterType } from './footer';
 import type { FEOnwards } from './onwards';
+import type { BaseRequestBody } from './request';
 import type { TagType } from './tag';
 import type { FETrailType } from './trails';
 
@@ -15,7 +16,7 @@ import type { FETrailType } from './trails';
  * WARNING: run `gen-schema` task if changing this to update the associated JSON
  * schema definition.
  */
-export interface FEArticleType {
+export interface FEArticleType extends BaseRequestBody {
 	headline: string;
 	standfirst: string;
 	webTitle: string;
@@ -38,7 +39,6 @@ export interface FEArticleType {
 	webPublicationSecondaryDateDisplay: string;
 	editionLongForm: string;
 	editionId: EditionId;
-	pageId: string;
 	version: number; // TODO: check who uses?
 	tags: TagType[];
 	format: FEFormat;

--- a/dotcom-rendering/src/types/request.ts
+++ b/dotcom-rendering/src/types/request.ts
@@ -1,0 +1,3 @@
+export type BaseRequestBody = {
+	pageId: string;
+};

--- a/dotcom-rendering/src/web/server/blocksToHtml.tsx
+++ b/dotcom-rendering/src/web/server/blocksToHtml.tsx
@@ -1,4 +1,5 @@
 import { buildAdTargeting } from '../../lib/ad-targeting';
+import type { FEBlocksRequest } from '../../types/blocksRequest';
 import { decideFormat } from '../lib/decideFormat';
 import { renderToStringWithEmotion } from '../lib/emotion';
 import { LiveBlogRenderer } from '../lib/LiveBlogRenderer';

--- a/dotcom-rendering/src/web/server/index.ts
+++ b/dotcom-rendering/src/web/server/index.ts
@@ -10,6 +10,7 @@ import {
 	validateAsArticleType,
 	validateAsFrontType,
 } from '../../model/validate';
+import type { FEBlocksRequest } from '../../types/blocksRequest';
 import type { DCRFrontType, FEFrontType } from '../../types/front';
 import type { FEArticleType } from '../../types/frontend';
 import { decideTrail } from '../lib/decideTrail';


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

## Why?

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->


<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
