### PR TITLE
Tidying up some fronts issues

### DIFF
--- a/dotcom-rendering/src/web/components/Byline.tsx
+++ b/dotcom-rendering/src/web/components/Byline.tsx
@@ -20,6 +20,27 @@ const bylineStyles = (size: SmallHeadlineSize, format: ArticleFormat) => {
 	`;
 
 	switch (size) {
+		case 'ginormous':
+		case 'huge':
+			if (format.theme === ArticleSpecial.Labs) {
+				return css`
+					${baseStyles};
+					${textSans.xlarge()};
+					font-size: 24px;
+					line-height: 24px;
+					${until.desktop} {
+						${textSans.xlarge()};
+						line-height: 20px;
+					}
+				`;
+			}
+			return css`
+				${baseStyles};
+				${headline.small()};
+				${until.desktop} {
+					${headline.xsmall()};
+				}
+			`;
 		case 'large': {
 			if (format.theme === ArticleSpecial.Labs) {
 				return css`

--- a/dotcom-rendering/src/web/components/FixedLargeSlowXIV.tsx
+++ b/dotcom-rendering/src/web/components/FixedLargeSlowXIV.tsx
@@ -8,7 +8,6 @@ import {
 import { shouldPadWrappableRows } from '../lib/dynamicSlices';
 import { LI } from './Card/components/LI';
 import { UL } from './Card/components/UL';
-import { FrontCard } from './FrontCard';
 
 type Props = {
 	trails: DCRFrontCard[];

--- a/dotcom-rendering/src/web/components/FixedLargeSlowXIV.tsx
+++ b/dotcom-rendering/src/web/components/FixedLargeSlowXIV.tsx
@@ -92,7 +92,11 @@ export const FixedLargeSlowXIV = ({
 							)}
 							key={card.url}
 						>
-							<CardDefault trail={card} />
+							<CardDefault
+								trail={card}
+								showAge={showAge}
+								containerPalette={containerPalette}
+							/>
 						</LI>
 					);
 				})}

--- a/dotcom-rendering/src/web/components/FixedLargeSlowXIV.tsx
+++ b/dotcom-rendering/src/web/components/FixedLargeSlowXIV.tsx
@@ -1,13 +1,14 @@
 import type { DCRContainerPalette, DCRFrontCard } from '../../types/front';
-import { shouldPadWrappableRows } from '../lib/dynamicSlices';
-import { LI } from './Card/components/LI';
-import { UL } from './Card/components/UL';
-import { FrontCard } from './FrontCard';
 import {
 	Card25Media25,
 	Card25Media25SmallHeadline,
 	Card75Media50Right,
+	CardDefault,
 } from '../lib/cardWrappers';
+import { shouldPadWrappableRows } from '../lib/dynamicSlices';
+import { LI } from './Card/components/LI';
+import { UL } from './Card/components/UL';
+import { FrontCard } from './FrontCard';
 
 type Props = {
 	trails: DCRFrontCard[];
@@ -92,14 +93,7 @@ export const FixedLargeSlowXIV = ({
 							)}
 							key={card.url}
 						>
-							<FrontCard
-								trail={card}
-								starRating={card.starRating}
-								containerPalette={containerPalette}
-								showAge={showAge}
-								headlineSize="small"
-								imageUrl={undefined}
-							/>
+							<CardDefault trail={card} />
 						</LI>
 					);
 				})}

--- a/dotcom-rendering/src/web/components/FixedSmallSlowVMPU.tsx
+++ b/dotcom-rendering/src/web/components/FixedSmallSlowVMPU.tsx
@@ -1,6 +1,6 @@
 import { Hide } from '@guardian/source-react-components';
 import type { DCRContainerPalette, DCRFrontCard } from '../../types/front';
-import { Card33Media33Tall, CardDefaultNoAvatar } from '../lib/cardWrappers';
+import { Card33Media33Tall, CardDefault } from '../lib/cardWrappers';
 import { AdSlot } from './AdSlot';
 import { LI } from './Card/components/LI';
 import { UL } from './Card/components/UL';
@@ -41,7 +41,7 @@ export const FixedSmallSlowVMPU = ({
 				<UL direction="column">
 					{remaining.map((trail) => (
 						<LI key={trail.url}>
-							<CardDefaultNoAvatar
+							<CardDefault
 								trail={trail}
 								containerPalette={containerPalette}
 								showAge={showAge}

--- a/dotcom-rendering/src/web/components/Treats.tsx
+++ b/dotcom-rendering/src/web/components/Treats.tsx
@@ -151,7 +151,7 @@ export const Treats = ({
 					// treat has this exact url then an svg of a crossword
 					// is displayed above the text
 					return (
-						<>
+						<Fragment key={link.linkTo}>
 							<li>
 								<a href={link.linkTo}>
 									<SvgCrossword />
@@ -165,7 +165,7 @@ export const Treats = ({
 									borderColour={borderColour}
 								/>
 							))}
-						</>
+						</Fragment>
 					);
 				}
 

--- a/dotcom-rendering/src/web/lib/cardWrappers.tsx
+++ b/dotcom-rendering/src/web/lib/cardWrappers.tsx
@@ -601,39 +601,9 @@ export const CardDefault = ({
 			containerPalette={containerPalette}
 			showAge={showAge}
 			imageUrl={undefined}
-			headlineSize="small"
-			headlineSizeOnMobile="small"
-		/>
-	);
-};
-
-/**
- * ┏━━━━━━━━━━━━━━━━━━┱┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┐
- * ┃                  ┃  Any% Remaining  ┊
- * ┗━━━━━━━━━━━━━━━━━━┹┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┘
- * Card designed to take up any width of container, with no media and no avatar
- *
- * Options:
- *  - Small headline (small on mobile)
- *  - No image / media
- *  - No trail text
- *  - No supporting content
- *  - No avatar
- */
-export const CardDefaultNoAvatar = ({
-	trail,
-	showAge,
-	containerPalette,
-}: TrailProps) => {
-	return (
-		<FrontCard
-			trail={trail}
-			containerPalette={containerPalette}
-			showAge={showAge}
-			imageUrl={undefined}
-			headlineSize="small"
-			headlineSizeOnMobile="small"
 			avatarUrl={undefined}
+			headlineSize="small"
+			headlineSizeOnMobile="small"
 		/>
 	);
 };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Tidy up some bugs I ran into
- Fix avatars showing when they shouldn't
- Fix byline text being too small on huge/ginormous headline sizes
- Add a key where one was missing

## Screenshots

| Before      | After      | Frontend 
|-------------|------------|------------|
| ![before][] | ![after][] | ![frontend][] |
| ![before2][] | ![after2][] | ![frontend2][] |
| ![before3][] | ![after3][] | ![frontend3][] |



[before]: https://user-images.githubusercontent.com/9575458/219433673-84abbe5a-6db0-40c2-aeef-a85ff5f0a811.png
[after]: https://user-images.githubusercontent.com/9575458/219433708-8deb658a-c5e4-4899-9793-cc813638469f.png
[frontend]: https://user-images.githubusercontent.com/9575458/219433879-62898098-876c-416a-906d-accbd99d368c.png

[before2]: https://user-images.githubusercontent.com/9575458/219434303-9a7d05f8-c9ea-470d-a5e4-f4097b7c77d6.png
[after2]: https://user-images.githubusercontent.com/9575458/219434341-462b97e7-768a-46fa-b0fa-5f80674f1814.png
[frontend2]: https://user-images.githubusercontent.com/9575458/219434408-e435fb15-0ac6-492f-b1bb-bca54cb81f36.png


[before3]: https://user-images.githubusercontent.com/9575458/219434573-e4269db4-a4f3-4848-aba6-affe7fa4ef19.png
[after3]: https://user-images.githubusercontent.com/9575458/219434618-0d6ee7ec-e845-4e56-8390-9b331a85c76c.png
[frontend3]: https://user-images.githubusercontent.com/9575458/219434677-bdfd6280-58cd-42a5-bb06-a6d452aace62.png


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

-->


<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
