### PR TITLE
feat(apps): add apps article endpoints to dev and prod servers

### DIFF
--- a/dotcom-rendering/src/apps/server/index.ts
+++ b/dotcom-rendering/src/apps/server/index.ts
@@ -1,0 +1,12 @@
+import { RequestHandler } from 'express';
+
+const getStack = (e: unknown): string =>
+	e instanceof Error ? e.stack ?? 'No error stack' : 'Unknown error';
+
+export const handleAppsArticle: RequestHandler = (_req, res) => {
+	try {
+		res.status(200).send('<pre>Not supported</pre>');
+	} catch (e) {
+		res.status(500).send(`<pre>${getStack(e)}`);
+	}
+};

--- a/dotcom-rendering/src/server/dev-index.html
+++ b/dotcom-rendering/src/server/dev-index.html
@@ -64,7 +64,7 @@
 				>)
 			</li>
 			<li>
-				<a href="/apps/Article?url=https://www.theguardian.com/money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software"
+				<a href="/AppsArticle?url=https://www.theguardian.com/money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software"
 					>📱 Apps Article</a
 				>
 			</li>

--- a/dotcom-rendering/src/server/dev-index.html
+++ b/dotcom-rendering/src/server/dev-index.html
@@ -63,6 +63,11 @@
 					>Enhanced JSON</a
 				>)
 			</li>
+			<li>
+				<a href="/apps/Article?url=https://www.theguardian.com/money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software"
+					>📱 Apps Article</a
+				>
+			</li>
 		</ul>
 
 		<h2>Test Articles By Content Type</h2>

--- a/dotcom-rendering/src/server/dev-server.ts
+++ b/dotcom-rendering/src/server/dev-server.ts
@@ -1,5 +1,6 @@
 import type { Handler } from 'express';
 import { handleAMPArticle } from '../amp/server';
+import { handleAppsArticle } from '../apps/server';
 import {
 	handleArticle,
 	handleArticleJson,
@@ -38,6 +39,8 @@ export const devServer = (): Handler => {
 				return handleFront(req, res, next);
 			case '/FrontJSON':
 				return handleFrontJson(req, res, next);
+			case '/apps/Article':
+				return handleAppsArticle(req, res, next);
 			default: {
 				if (req.url.match(ARTICLE_URL)) {
 					const url = new URL(

--- a/dotcom-rendering/src/server/dev-server.ts
+++ b/dotcom-rendering/src/server/dev-server.ts
@@ -39,7 +39,7 @@ export const devServer = (): Handler => {
 				return handleFront(req, res, next);
 			case '/FrontJSON':
 				return handleFrontJson(req, res, next);
-			case '/apps/Article':
+			case '/AppsArticle':
 				return handleAppsArticle(req, res, next);
 			default: {
 				if (req.url.match(ARTICLE_URL)) {

--- a/dotcom-rendering/src/server/prod-server.ts
+++ b/dotcom-rendering/src/server/prod-server.ts
@@ -88,7 +88,7 @@ export const prodServer = (): void => {
 	);
 
 	app.get(
-		'/apps/Article',
+		'/AppsArticle',
 		logRenderTime,
 		getContentFromURLMiddleware,
 		handleAppsArticle,

--- a/dotcom-rendering/src/server/prod-server.ts
+++ b/dotcom-rendering/src/server/prod-server.ts
@@ -61,7 +61,7 @@ export const prodServer = (): void => {
 	app.post('/KeyEvents', logRenderTime, handleKeyEvents);
 	app.post('/Front', logRenderTime, handleFront);
 	app.post('/FrontJSON', logRenderTime, handleFrontJson);
-	app.post('/apps/Article', logRenderTime, handleAppsArticle);
+	app.post('/AppsArticle', logRenderTime, handleAppsArticle);
 
 	// These GET's are for checking any given URL directly from PROD
 	app.get(

--- a/dotcom-rendering/src/server/prod-server.ts
+++ b/dotcom-rendering/src/server/prod-server.ts
@@ -7,6 +7,7 @@ import {
 	handlePerfTest as handleAMPArticlePerfTest,
 } from '../amp/server';
 import type { FEArticleType } from '../types/frontend';
+import { handleAppsArticle } from '../apps/server';
 import {
 	handleArticle,
 	handleArticleJson,
@@ -60,6 +61,7 @@ export const prodServer = (): void => {
 	app.post('/KeyEvents', logRenderTime, handleKeyEvents);
 	app.post('/Front', logRenderTime, handleFront);
 	app.post('/FrontJSON', logRenderTime, handleFrontJson);
+	app.post('/apps/Article', logRenderTime, handleAppsArticle);
 
 	// These GET's are for checking any given URL directly from PROD
 	app.get(
@@ -83,6 +85,13 @@ export const prodServer = (): void => {
 		logRenderTime,
 		getContentFromURLMiddleware,
 		handleFrontJson,
+	);
+
+	app.get(
+		'/apps/Article',
+		logRenderTime,
+		getContentFromURLMiddleware,
+		handleAppsArticle,
 	);
 
 	app.use('/ArticlePerfTest', handleArticlePerfTest);


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

- Adds a route handler for apps articles. This is hardcoded to return a "Not supported" response
- Adds routes for rendering apps articles to the dev and prod servers
  - The dev server supports:
    - GET `/AppsArticle`
  - The prod server supports:
    - POST `/AppsArticle`
    - GET `/AppsArticle`
- Adds a link to the dev server index page 

## Why?

- To close #7058  
