### PR TITLE
fix(Picture): fix aspect ratio

### DIFF
--- a/dotcom-rendering/src/web/components/Figure.tsx
+++ b/dotcom-rendering/src/web/components/Figure.tsx
@@ -15,6 +15,7 @@ type Props = {
 
 const roleCss = {
 	inline: css`
+		clear: left;
 		margin-top: ${space[3]}px;
 		margin-bottom: ${space[3]}px;
 	`,

--- a/dotcom-rendering/src/web/components/LiveBlock.stories.tsx
+++ b/dotcom-rendering/src/web/components/LiveBlock.stories.tsx
@@ -321,6 +321,11 @@ export const ImageRoles = () => {
 				role: 'halfWidth',
 				title: 'Half width',
 			},
+			{
+				_type: 'model.dotcomrendering.pageElements.BlockquoteBlockElement',
+				elementId: 'abcdef-012345',
+				html: 'On Liveblogs, the only allowed roles are “inline” and “thumbnail”, see <code>updateRole</code> in <code>renderElement</code>',
+			},
 		],
 	};
 	return (

--- a/dotcom-rendering/src/web/components/Picture.tsx
+++ b/dotcom-rendering/src/web/components/Picture.tsx
@@ -210,7 +210,7 @@ const descendingByBreakpoint = (a: ImageWidthType, b: ImageWidthType) => {
 
 /**
  * Used on `picture` and `img` to prevent having a line-height,
- * as these elements are which are `inline` by default.
+ * as these elements are `inline` by default.
  *
  * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#styling_with_css
  */

--- a/dotcom-rendering/src/web/components/Picture.tsx
+++ b/dotcom-rendering/src/web/components/Picture.tsx
@@ -218,6 +218,12 @@ const block = css`
 	display: block;
 `;
 
+const absolute = css`
+	position: absolute;
+	top: 0;
+	left: 0;
+`;
+
 type ImageSource = {
 	breakpoint: number;
 	width: number;
@@ -289,7 +295,17 @@ export const Picture = ({
 	const fallbackSource = getFallbackSource(sources);
 
 	return (
-		<picture css={block}>
+		<picture
+			css={[
+				block,
+				// When support for the aspect-ratio CSS property is larger,
+				// we may want to switch:
+				// https://caniuse.com/mdn-css_properties_aspect-ratio
+				css`
+					padding-top: ${100 * ratio}%;
+				`,
+			]}
+		>
 			{/* Immersive Main Media images get additional sources specifically for when in portrait orientation */}
 			{format.display === ArticleDisplay.Immersive && isMainMedia && (
 				<>
@@ -348,12 +364,10 @@ export const Picture = ({
 			<img
 				alt={alt}
 				src={fallbackSource.lowResUrl}
-				width={fallbackSource.width}
-				height={fallbackSource.width * ratio}
 				loading={
 					isLazy && !Picture.disableLazyLoading ? 'lazy' : undefined
 				}
-				css={block}
+				css={[block, absolute]}
 			/>
 		</picture>
 	);


### PR DESCRIPTION
## What does this change?

Enforce a consistent aspect ratio on `Picture` elements.

This will especially impact users on slower networks.

## Why?

Even if the `<img />` inside a `<picture />` having defined width and height is supposed to create a fixed aspect-ratio, [in practice this is not the case](https://www.webpagetest.org/results/23/02/16/AiDcSY/CX2/video_2/ms_002800.jpg), so we set this ratio explicitly using a padding-top property on the <picture />.

I believe that the issue lies in the fact that the image has both an explicit `width` & `height` and a CSS declaring it should be 100% of it’s parent in both axis, making it hard for the browser to know what it’s aspect ratio is until it starts downloading it. I have [isolated the issue in a CodePen](https://codepen.io/mxdvl/full/BaONYdj) to illustrate.

Padding percentages are calculated relative to their containing block, so a value of 60% is equivalent to a ratio of 5 / 3.
5 / 3 = 10 / 6 → height is 60% of width.

Fixes #7233 

## Why not `aspect-ratio`?

We may consider it in the future, and [I did leave a comment to that effect](https://github.com/guardian/dotcom-rendering/pull/7234/files#diff-96d89f5d21c12f46cef650cf58a400655f384dcfaf56fcc478a27e89af96b04cR301-R303). At present, [browsers do not support `aspect-ratio` well enough yet](https://caniuse.com/mdn-css_properties_aspect-ratio), whereas it [support for `padding` is much better](https://caniuse.com/mdn-css_properties_padding).

We also wrap our `img` tag inside a `picture`, so we're not introducing any new wrapper that's not already present, making the padding-top approach no more complex than the more modern approach.

## Screenshots

No visual difference, once images have loaded.

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/76776/219640862-795f7b7a-2034-461b-9ca4-740659d4ac70.png
[after]: https://user-images.githubusercontent.com/76776/219640839-a8f201e5-47e4-4221-8f40-45cc2393610d.png
