### PR TITLE
Set height of Most Viewed island to its content

### DIFF
--- a/dotcom-rendering/src/web/components/MostViewedRightWrapper.importable.tsx
+++ b/dotcom-rendering/src/web/components/MostViewedRightWrapper.importable.tsx
@@ -12,21 +12,14 @@ type Props = {
 // Minimum height needed to render MostViewedRight is its own outer height.
 const HEIGHT_REQUIRED = 482 + 24 + 24;
 
-const MOSTVIEWED_STICKY_HEIGHT = 1059;
+const SHADY_PIE_HEIGHT = 400;
+const TOP_RIGHT_AD_HEIGHT = 1059;
 
 // Wrapping MostViewedRight so we can determine whether or not there's enough vertical space in the container to render it.
 export const MostViewedRightWrapper = ({ limitItems, isAdFreeUser }: Props) => {
 	const adBlockerDetected = useAdBlockInUse();
 	const bodyRef = useRef<HTMLDivElement>(null);
 	const [heightIsAvailable, setHeightIsAvailable] = useState<boolean>(false);
-
-	// Styling the data island root so it stretches to cover the full height available in the container.
-	// Requires us to subtract the height of its sibling in the container (StickyAd).
-	const stretchWrapperHeight = css`
-		height: ${adBlockerDetected
-			? `calc(100% - 400px)`
-			: `calc(100% - ${MOSTVIEWED_STICKY_HEIGHT}px)`};
-	`;
 
 	useEffect(() => {
 		const checkHeight = (ref: RefObject<HTMLDivElement>) => {
@@ -50,15 +43,32 @@ export const MostViewedRightWrapper = ({ limitItems, isAdFreeUser }: Props) => {
 		});
 	}, [heightIsAvailable]);
 
+	const rightAdvertHeight = adBlockerDetected
+		? SHADY_PIE_HEIGHT
+		: TOP_RIGHT_AD_HEIGHT;
+
+	// Styling the data island root so it stretches to cover the full height available in the container.
+	// Requires us to subtract the height of its sibling in the container (Sticky top right ad slot).
+	const availableSpaceHeight = css`
+		height: calc(100% - ${rightAdvertHeight}px);
+	`;
+
+	if (!heightIsAvailable) {
+		return <div ref={bodyRef} css={availableSpaceHeight} />;
+	}
+
 	return (
-		<div ref={bodyRef} css={stretchWrapperHeight}>
-			{heightIsAvailable ? (
-				<MostViewedRight
-					limitItems={limitItems}
-					isAdFreeUser={isAdFreeUser}
-					adBlockerDetected={!!adBlockerDetected}
-				/>
-			) : null}
+		<div
+			ref={bodyRef}
+			css={css`
+				height: auto;
+			`}
+		>
+			<MostViewedRight
+				limitItems={limitItems}
+				isAdFreeUser={isAdFreeUser}
+				adBlockerDetected={!!adBlockerDetected}
+			/>
 		</div>
 	);
 };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Sets the height of the Most Viewed island to fit-content once the content has been loaded. Before, the height of this island was the remainder of the right column, below the top-right-ad-slot.

## Why?

Commercial would like to position inline2+ ads in the right-hand slot using flexbox. Currently, we position inline2+ ads above paragraphs and use floats to move them out so they appear to be in the right column. This is the source of many bugs, including inline2 overlapping the Most Viewed island.

The Most Viewed island currently takes up the remainder of the right column. This PR will ensure that it only takes up the space it needs to, so that we can insert an ads container underneath it (when there is room).

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/9574885/219643920-e83a0bc5-f7d6-415c-a7e5-b00623f55477.png
[after]: https://user-images.githubusercontent.com/9574885/219643948-6ed874ec-15c6-49c4-8fd7-bca4ecc82c80.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->


<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
