### PR TITLE
Add redhat yaml plugin to vscode recs

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -10,6 +10,7 @@
         "stylelint.vscode-stylelint",
         "eamodio.gitlens",
         "streetsidesoftware.code-spell-checker",
-        "denoland.vscode-deno"
+        "denoland.vscode-deno",
+		"redhat.vscode-yaml"
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,28 +2,45 @@
 	"deno.enablePaths": ["scripts/deno"],
 	"deno.lint": true,
 	"deno.unstable": false,
-    "eslint.validate": ["typescript", "typescriptreact"],
-    "editor.codeActionsOnSave": {
-        "source.fixAll.eslint": true
-    },
-    "eslint.workingDirectories": [
-        "./dotcom-rendering"
-	],
-    "files.watcherExclude": {
-        "**/target": true
-    },
-    "workbench.colorCustomizations": {
-        "titleBar.activeBackground": "#648FFF",
-        "titleBar.activeForeground": "#000000"
+	"eslint.validate": ["typescript", "typescriptreact"],
+	"editor.codeActionsOnSave": {
+		"source.fixAll.eslint": true
+	},
+	"eslint.workingDirectories": ["./dotcom-rendering"],
+	"files.watcherExclude": {
+		"**/target": true
+	},
+	"workbench.colorCustomizations": {
+		"titleBar.activeBackground": "#648FFF",
+		"titleBar.activeForeground": "#000000"
 	},
 	"jest.jestCommandLine": "yarn workspaces run test",
-    "typescript.tsdk": "node_modules/typescript/lib",
-    "gitlens.advanced.blame.customArguments": [
-        "--ignore-revs-file",
-        ".git-blame-ignore-revs"
-    ],
-    "git.branchProtection": [
-        "main"
+	"typescript.tsdk": "node_modules/typescript/lib",
+	"gitlens.advanced.blame.customArguments": [
+		"--ignore-revs-file",
+		".git-blame-ignore-revs"
 	],
-	"javascript.preferences.importModuleSpecifier": "relative"
+	"git.branchProtection": ["main"],
+	"javascript.preferences.importModuleSpecifier": "relative",
+	"yaml.customTags": [
+		"!Base64 scalar",
+		"!Cidr scalar",
+		"!And sequence",
+		"!Equals sequence",
+		"!If sequence",
+		"!Not sequence",
+		"!Or sequence",
+		"!Condition scalar",
+		"!FindInMap sequence",
+		"!GetAtt scalar",
+		"!GetAtt sequence",
+		"!GetAZs scalar",
+		"!ImportValue scalar",
+		"!Join sequence",
+		"!Select sequence",
+		"!Split sequence",
+		"!Sub scalar",
+		"!Transform mapping",
+		"!Ref scalar"
+	]
 }

--- a/dotcom-rendering/cloudformation.yml
+++ b/dotcom-rendering/cloudformation.yml
@@ -1,3 +1,7 @@
+# yaml-language-server: $schema=./cloudformation.yml
+# ^ this setting effectively prevents the redhat.vscode-yaml from
+# trying (and failing) to validate this against the Cloudformation YAML schema
+# @see: https://github.com/redhat-developer/vscode-yaml/issues/245#issuecomment-885803310
 AWSTemplateFormatVersion: '2010-09-09'
 Description: Frontend rendering service
 Parameters:

--- a/dotcom-rendering/cloudformation.yml
+++ b/dotcom-rendering/cloudformation.yml
@@ -1,5 +1,5 @@
 # yaml-language-server: $schema=./cloudformation.yml
-# ^ this setting effectively prevents the redhat.vscode-yaml from
+# ^ this setting effectively prevents the redhat.vscode-yaml extension from
 # trying (and failing) to validate this against the Cloudformation YAML schema
 # @see: https://github.com/redhat-developer/vscode-yaml/issues/245#issuecomment-885803310
 AWSTemplateFormatVersion: '2010-09-09'


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Adds Redhat's [YAML Language Support extension](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml) to our list of recommended VSCode plugins.


## Why?

The extension provides linting for YAML syntax. It also integrates with the JSON schema store to provide context-specific linting and type hints for common YAML schemas, e.g. Github Actions workflow files.

## Testing

It seems to work well across the GHA files that we have in `dotcom-rendering`.

Schema validation for Cloudformation config seems to have [well-known problems](https://github.com/redhat-developer/vscode-yaml/issues/669), and the documented workarounds don't work on our cf config without refactoring the file. I've added some Cloudformation-specific tags to the `settings.json` file, and have added a magic comment to make the file its own schema, which effectively removes schema validation from this file (but keeps syntax linting).

We might think that incomplete validation is less helpful than no validation, in which case I'm happy to close this. But my sense is that it's worthwhile insofar as it seems to be very helpful for the more commonly edited GHA files, and given that we will hopefully be migrating our CF config to the CDK before too long.

## Screenshots

Highlighting and hints for YAML syntax in general:
<img width="400" alt="image" src="https://user-images.githubusercontent.com/37048459/219696866-cae2f5eb-5fbc-4994-80a7-8e5f6363a442.png">

GHA-specific hinting:
<img width="400" alt="image" src="https://user-images.githubusercontent.com/37048459/219696755-b1f27ce1-3503-4959-a5df-19133ab3a6d1.png">
