### PR TITLE
Add request context to our logger

### DIFF
--- a/dotcom-rendering/src/apps/server/index.ts
+++ b/dotcom-rendering/src/apps/server/index.ts
@@ -1,4 +1,9 @@
 import { RequestHandler } from 'express';
+import {
+	recordEnhanceTime,
+	recordRenderTime,
+	recordTypeAndPlatform,
+} from '../../server/lib/logging-store';
 import { enhanceArticleType } from '../../web/server';
 import { articleToHtml } from './articleToHtml';
 
@@ -18,8 +23,11 @@ const makePrefetchHeader = (scriptPaths: string[]): string =>
 
 export const handleAppsArticle: RequestHandler = ({ body }, res) => {
 	try {
-		const article = enhanceArticleType(body);
-		const { html, clientScripts } = articleToHtml(article);
+		recordTypeAndPlatform('article', 'apps');
+		const article = recordEnhanceTime(() => enhanceArticleType(body));
+		const { html, clientScripts } = recordRenderTime(() =>
+			articleToHtml(article),
+		);
 
 		// The Android app will cache these assets to enable offline reading
 		res.set('Link', makePrefetchHeader(clientScripts)).send(html);

--- a/dotcom-rendering/src/server/lib/logging-middleware.ts
+++ b/dotcom-rendering/src/server/lib/logging-middleware.ts
@@ -1,0 +1,39 @@
+import { RequestHandler } from 'express';
+import { logger } from './logging';
+import { loggingStore } from './logging-store';
+
+const hasPageId = (body: any): body is { pageId: string } => {
+	return body && 'pageId' in body && typeof body.pageId === 'string';
+};
+
+/**
+ * An Express middleware which handles creating our logger store and logging requests after they've
+ * completed.
+ */
+export const requestLoggerMiddleware: RequestHandler = (req, res, next) => {
+	const loggerState = {
+		request: {
+			pageId: hasPageId(req.body) ? req.body.pageId : 'no-page-id-found',
+			path: req.path,
+			method: req.method,
+		},
+		timing: {},
+	};
+
+	res.on('finish', () => {
+		const { timing, request } = loggingStore.getStore() ?? {};
+
+		if (!request?.type) return;
+
+		logger.info('Rendered page', {
+			response: {
+				status: res.statusCode,
+			},
+			timing,
+		});
+	});
+
+	loggingStore.run(loggerState, () => {
+		next();
+	});
+};

--- a/dotcom-rendering/src/server/lib/logging-store.ts
+++ b/dotcom-rendering/src/server/lib/logging-store.ts
@@ -1,0 +1,75 @@
+/**
+ * This module allows data about requests to be passed down to our logger without having to rely on prop drilling.
+ *
+ * This makes it easy for us to log info in a component deep in our component tree and have data such as the pageId and platform
+ * without the hassle of trying to get that data to it.
+ *
+ * We also take care of recording timings for data enhancement, and render time from this module and logging per request.
+ *
+ * For simplicity we're using Node 16's AsyncLocalStorage to handle state instead of any 3rd party dependency like Redux or React Context.
+ */
+
+import { AsyncLocalStorage } from 'async_hooks';
+
+type DCRLoggingStore = {
+	request: {
+		pageId: string;
+		path: string;
+		method: string;
+		type?: string;
+		platform?: string;
+	};
+	timing: {
+		enhance?: number;
+		render?: number;
+		total?: number;
+	};
+};
+
+export const loggingStore = new AsyncLocalStorage<DCRLoggingStore>();
+
+export const recordEnhanceTime = <T>(parse: () => T): T => {
+	const { timing } = loggingStore.getStore() ?? {};
+	const start = Date.now();
+
+	const result = parse();
+
+	if (timing) {
+		timing.enhance = Date.now() - start;
+	}
+
+	return result;
+};
+
+export const recordRenderTime = <T>(parse: () => T): T => {
+	const { timing } = loggingStore.getStore() ?? {};
+	const start = Date.now();
+
+	const result = parse();
+
+	if (timing) {
+		timing.render = Date.now() - start;
+	}
+
+	return result;
+};
+
+export const recordTotalTime = (time: number): void => {
+	const { timing } = loggingStore.getStore() ?? {};
+
+	if (timing) {
+		timing.total = time;
+	}
+};
+
+export const recordTypeAndPlatform = (
+	type: string,
+	platform?: string,
+): void => {
+	const { request } = loggingStore.getStore() ?? {};
+
+	if (request) {
+		request.type = type;
+		request.platform = platform;
+	}
+};

--- a/dotcom-rendering/src/server/lib/logging.ts
+++ b/dotcom-rendering/src/server/lib/logging.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 import type { LoggingEvent } from 'log4js';
 import { addLayout, configure, getLogger, shutdown } from 'log4js';
+import { loggingStore } from './logging-store';
 
 const logLocation =
 	process.env.NODE_ENV === 'production' &&
@@ -14,6 +15,10 @@ const stage =
 		: 'DEV';
 
 const logFields = (logEvent: LoggingEvent): unknown => {
+	const { request } = loggingStore.getStore() ?? {
+		request: { pageId: 'outside-request-context' },
+	};
+
 	const coreFields = {
 		stack: 'frontend',
 		app: 'dotcom-rendering',
@@ -22,6 +27,7 @@ const logFields = (logEvent: LoggingEvent): unknown => {
 		'@version': 1,
 		level: logEvent.level.levelStr,
 		level_value: logEvent.level.level,
+		request,
 	};
 	// log4js uses any[] to type data but we want to coerce it here
 	// because we now depend on the type to log the result properly
@@ -59,7 +65,7 @@ const enableLog4j = {
 		fileAppender: {
 			type: 'file',
 			filename: logLocation,
-			maxLogSize: 10000,
+			maxLogSize: '5M',
 			backups: 5,
 			compress: true,
 			layout: { type: 'json', separator: ',' },


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

This PR makes use of Node 16's new AsyncLocalStorage library to create a per-request context that can be used for adding various bits of information to our logger such as pageId, request timings, request info, etc without having to prop drill this information into any component that needs to use the logger.

The ultimate goal is to allow us to use `logger.info()` anywhere we want in our server side code and still have information such as the path and page ID attached to our log entries.

An example of where this might be useful is with our [script that checks for iframe title](https://github.com/guardian/dotcom-rendering/blob/main/scripts/deno/iframe-titles.ts), instead of a seperate deno script that scans all recent articles published we could instead add a `logger.info()` into our DCR Interactive embed component which logs whenever it tries to render a title-less iframe.

## But we avoid context in DCR!

Context is usually a pattern that we try to avoid in DCR due to the complexity it adds. I'm hoping that by limiting this context to purely logging that we avoid that complexity and we avoid setting a precedent that we're going to be using context in our critical rendering paths.

## What information is being added to logs?

This PR is currently adding page ID, page type, platform, path, and method. It also adds time taken to enhance data, and time taken to render, and overall total time. I wanted to add JSON parse time but it turns out thats not trivial to measure as it is handled by a middleware.

In production JSON parse time can very roughly be calculated as `Total Time - Render Time - Enhance Time` 

## Example Request Log

```
{
  "message": "Rendered page",
  "stack": "frontend",
  "app": "dotcom-rendering",
  "stage": "DEV",
  "@timestamp": "2023-04-05T17:27:50.409Z",
  "@version": 1,
  "level": "INFO",
  "level_value": 20000,
  "request": {
    "pageId": "no-page-id-found",
    "path": "/Front/https://www.theguardian.com/us",
    "method": "GET",
    "type": "front"
  },
  "response": { "status": 200 },
  "timing": { "enhance": 20, "render": 140, "total": 933.655625 }
}
```

## An example use case

I'd love to be able to find all instances of containers with less than their normal number of cards, with this new way of logging it would be very easy to add a info log in a container and search for it in Elasticsearch.

```js
// file: FixedMediumSlowVIIMPU.ts
if (cards.length < 12) {
    logger.info(`Incorrect number of cards in container ${title}, expected 12 but got ${cards.length}`);
}
```
    
Which would give us a log similar to this

```
{
  "message": "Incorrect number of cards in Spotlight, expected 12 but got 11",
  "stack": "frontend",
  "app": "dotcom-rendering",
  "stage": "DEV",
  "@timestamp": "2023-04-05T17:27:50.409Z",
  "@version": 1,
  "level": "INFO",
  "level_value": 20000,
  "request": {
    "pageId": "us/commentisfree",
    "path": "/Front",
    "method": "POST",
    "type": "front"
  }
}
```

That can easily be searched for / alerted on in Elasticsearch or Grafana and which immediately tells us which front to look for it on.
