### PR TITLE
Fix loading of images on smaller viewports

### DIFF
--- a/dotcom-rendering/src/web/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/CommentLayout.tsx
@@ -426,6 +426,35 @@ export const CommentLayout = ({ article, NAV, format }: Props) => {
 					element="article"
 				>
 					<StandardGrid display={format.display}>
+						<GridItem area="media">
+							<div
+								css={
+									format.display === ArticleDisplay.Showcase
+										? mainMediaWrapper
+										: maxWidth
+								}
+							>
+								<MainMedia
+									format={format}
+									elements={article.mainMediaElements}
+									adTargeting={adTargeting}
+									starRating={
+										format.design ===
+											ArticleDesign.Review &&
+										article.starRating
+											? article.starRating
+											: undefined
+									}
+									host={host}
+									pageId={article.pageId}
+									webTitle={article.webTitle}
+									ajaxUrl={article.config.ajaxUrl}
+									switches={article.config.switches}
+									isAdFreeUser={article.isAdFreeUser}
+									isSensitive={article.config.isSensitive}
+								/>
+							</div>
+						</GridItem>
 						<GridItem area="title" element="aside">
 							<ArticleTitle
 								format={format}
@@ -503,35 +532,6 @@ export const CommentLayout = ({ article, NAV, format }: Props) => {
 								format={format}
 								standfirst={article.standfirst}
 							/>
-						</GridItem>
-						<GridItem area="media">
-							<div
-								css={
-									format.display === ArticleDisplay.Showcase
-										? mainMediaWrapper
-										: maxWidth
-								}
-							>
-								<MainMedia
-									format={format}
-									elements={article.mainMediaElements}
-									adTargeting={adTargeting}
-									starRating={
-										format.design ===
-											ArticleDesign.Review &&
-										article.starRating
-											? article.starRating
-											: undefined
-									}
-									host={host}
-									pageId={article.pageId}
-									webTitle={article.webTitle}
-									ajaxUrl={article.config.ajaxUrl}
-									switches={article.config.switches}
-									isAdFreeUser={article.isAdFreeUser}
-									isSensitive={article.config.isSensitive}
-								/>
-							</div>
 						</GridItem>
 						<GridItem area="meta" element="aside">
 							<div css={maxWidth}>

--- a/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
@@ -387,6 +387,22 @@ export const InteractiveLayout = ({ article, NAV, format }: Props) => {
 						className={interactiveLegacyClasses.contentInteractive}
 					>
 						<InteractiveGrid>
+							<GridItem area="media">
+								<div css={maxWidth}>
+									<MainMedia
+										format={format}
+										elements={article.mainMediaElements}
+										adTargeting={adTargeting}
+										host={host}
+										pageId={article.pageId}
+										webTitle={article.webTitle}
+										ajaxUrl={article.config.ajaxUrl}
+										switches={article.config.switches}
+										isAdFreeUser={article.isAdFreeUser}
+										isSensitive={article.config.isSensitive}
+									/>
+								</div>
+							</GridItem>
 							<GridItem area="title" element="aside">
 								<div
 									className={`${interactiveLegacyClasses.contentLabels} ${interactiveLegacyClasses.contentLabelsNotImmersive}`}
@@ -444,22 +460,7 @@ export const InteractiveLayout = ({ article, NAV, format }: Props) => {
 									standfirst={article.standfirst}
 								/>
 							</GridItem>
-							<GridItem area="media">
-								<div css={maxWidth}>
-									<MainMedia
-										format={format}
-										elements={article.mainMediaElements}
-										adTargeting={adTargeting}
-										host={host}
-										pageId={article.pageId}
-										webTitle={article.webTitle}
-										ajaxUrl={article.config.ajaxUrl}
-										switches={article.config.switches}
-										isAdFreeUser={article.isAdFreeUser}
-										isSensitive={article.config.isSensitive}
-									/>
-								</div>
-							</GridItem>
+
 							<GridItem area="lines">
 								<div css={maxWidth}>
 									<div css={stretchLines}>

--- a/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
@@ -425,6 +425,29 @@ export const ShowcaseLayout = ({ article, NAV, format }: Props) => {
 					element="article"
 				>
 					<ShowcaseGrid>
+						<GridItem area="media">
+							<div css={mainMediaWrapper}>
+								<MainMedia
+									format={format}
+									elements={article.mainMediaElements}
+									adTargeting={adTargeting}
+									starRating={
+										format.design ===
+											ArticleDesign.Review &&
+										article.starRating
+											? article.starRating
+											: undefined
+									}
+									host={host}
+									pageId={article.pageId}
+									webTitle={article.webTitle}
+									ajaxUrl={article.config.ajaxUrl}
+									switches={article.config.switches}
+									isAdFreeUser={article.isAdFreeUser}
+									isSensitive={article.config.isSensitive}
+								/>
+							</div>
+						</GridItem>
 						<GridItem area="title" element="aside">
 							<ArticleTitle
 								format={format}
@@ -453,29 +476,6 @@ export const ShowcaseLayout = ({ article, NAV, format }: Props) => {
 									}
 								/>
 							</PositionHeadline>
-						</GridItem>
-						<GridItem area="media">
-							<div css={mainMediaWrapper}>
-								<MainMedia
-									format={format}
-									elements={article.mainMediaElements}
-									adTargeting={adTargeting}
-									starRating={
-										format.design ===
-											ArticleDesign.Review &&
-										article.starRating
-											? article.starRating
-											: undefined
-									}
-									host={host}
-									pageId={article.pageId}
-									webTitle={article.webTitle}
-									ajaxUrl={article.config.ajaxUrl}
-									switches={article.config.switches}
-									isAdFreeUser={article.isAdFreeUser}
-									isSensitive={article.config.isSensitive}
-								/>
-							</div>
 						</GridItem>
 						<GridItem area="standfirst">
 							<Standfirst

--- a/dotcom-rendering/src/web/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/StandardLayout.tsx
@@ -481,24 +481,6 @@ export const StandardLayout = ({ article, NAV, format }: Props) => {
 					element="article"
 				>
 					<StandardGrid isMatchReport={isMatchReport}>
-						<GridItem area="title" element="aside">
-							<ArticleTitle
-								format={format}
-								tags={article.tags}
-								sectionLabel={article.sectionLabel}
-								sectionUrl={article.sectionUrl}
-								guardianBaseURL={article.guardianBaseURL}
-								badge={article.badge}
-								isMatch={!!footballMatchUrl}
-							/>
-						</GridItem>
-						<GridItem area="border">
-							{format.theme === ArticleSpecial.Labs ? (
-								<></>
-							) : (
-								<Border format={format} />
-							)}
-						</GridItem>
 						<GridItem area="matchNav" element="aside">
 							<div css={maxWidth}>
 								{isMatchReport && (
@@ -535,6 +517,40 @@ export const StandardLayout = ({ article, NAV, format }: Props) => {
 								)}
 							</div>
 						</GridItem>
+						<GridItem area="media">
+							<div css={maxWidth}>
+								<MainMedia
+									format={format}
+									elements={article.mainMediaElements}
+									adTargeting={adTargeting}
+									host={host}
+									pageId={article.pageId}
+									webTitle={article.webTitle}
+									ajaxUrl={article.config.ajaxUrl}
+									switches={article.config.switches}
+									isAdFreeUser={article.isAdFreeUser}
+									isSensitive={article.config.isSensitive}
+								/>
+							</div>
+						</GridItem>
+						<GridItem area="title" element="aside">
+							<ArticleTitle
+								format={format}
+								tags={article.tags}
+								sectionLabel={article.sectionLabel}
+								sectionUrl={article.sectionUrl}
+								guardianBaseURL={article.guardianBaseURL}
+								badge={article.badge}
+								isMatch={!!footballMatchUrl}
+							/>
+						</GridItem>
+						<GridItem area="border">
+							{format.theme === ArticleSpecial.Labs ? (
+								<></>
+							) : (
+								<Border format={format} />
+							)}
+						</GridItem>
 						<GridItem area="headline">
 							<div css={maxWidth}>
 								<ArticleHeadline
@@ -566,22 +582,6 @@ export const StandardLayout = ({ article, NAV, format }: Props) => {
 								format={format}
 								standfirst={article.standfirst}
 							/>
-						</GridItem>
-						<GridItem area="media">
-							<div css={maxWidth}>
-								<MainMedia
-									format={format}
-									elements={article.mainMediaElements}
-									adTargeting={adTargeting}
-									host={host}
-									pageId={article.pageId}
-									webTitle={article.webTitle}
-									ajaxUrl={article.config.ajaxUrl}
-									switches={article.config.switches}
-									isAdFreeUser={article.isAdFreeUser}
-									isSensitive={article.config.isSensitive}
-								/>
-							</div>
 						</GridItem>
 						<GridItem area="lines">
 							<div css={maxWidth}>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Reorder the position of the the `MainMedia` in all layouts so it occupies the correct place in the DOM on mobile devices.

## Why?

Currently, the position of the main media in the DOM is aligned to the desktop version, where it comes below the article headline and standfirst. However, on mobile, the main media comes above the headline and standfirst, but below match stats and tabs. This prevents mobile browser from reserving the right amound of space for the first row of the article grid.

By placing the image in the right location, the browser is able to reserve space earlier.

Closes #7233

## Demonstration

https://codepen.io/mxdvl/pen/mdGJzJg