### PR TITLE
Add Profile and Timeline to design type

### DIFF
--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -49,7 +49,9 @@ type FEDesign =
 	| 'PrintShopDesign'
 	| 'ObituaryDesign'
 	| 'FullPageInteractiveDesign'
-	| 'NewsletterSignupDesign';
+	| 'NewsletterSignupDesign'
+	| 'TimelineDesign'
+	| 'ProfileDesign';
 
 // FEDisplay is the display information passed through from frontend (originating in the capi scala client) and dictates the displaystyle of the content e.g. Immersive
 // https://github.com/guardian/content-api-scala-client/blob/master/client/src/main/scala/com.gu.contentapi.client/utils/format/Display.scala

--- a/dotcom-rendering/src/model/article-schema.json
+++ b/dotcom-rendering/src/model/article-schema.json
@@ -2491,9 +2491,11 @@
                 "ObituaryDesign",
                 "PhotoEssayDesign",
                 "PrintShopDesign",
+                "ProfileDesign",
                 "QuizDesign",
                 "RecipeDesign",
                 "ReviewDesign",
+                "TimelineDesign",
                 "VideoDesign"
             ],
             "type": "string"

--- a/dotcom-rendering/src/model/front-schema.json
+++ b/dotcom-rendering/src/model/front-schema.json
@@ -2678,9 +2678,11 @@
                 "ObituaryDesign",
                 "PhotoEssayDesign",
                 "PrintShopDesign",
+                "ProfileDesign",
                 "QuizDesign",
                 "RecipeDesign",
                 "ReviewDesign",
+                "TimelineDesign",
                 "VideoDesign"
             ],
             "type": "string"

--- a/dotcom-rendering/src/web/lib/decideDesign.ts
+++ b/dotcom-rendering/src/web/lib/decideDesign.ts
@@ -58,6 +58,10 @@ export const decideDesign = ({
 			return ArticleDesign.NewsletterSignup;
 		case 'ExplainerDesign':
 			return ArticleDesign.Explainer;
+		case 'TimelineDesign':
+			return ArticleDesign.Timeline;
+		case 'ProfileDesign':
+			return ArticleDesign.Profile;
 		default:
 			return ArticleDesign.Standard;
 	}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Adds Profile and Timeline into the article design types and regenerates schemas.

This PR also unblocks https://github.com/guardian/frontend/pull/25908
## Why?
This will allow us to visually differentiate these articles via their design type as per the editorial design team request.

This PR does not implement any new designs.