### PR TITLE
`make dev-web` and refactor build flags

### DIFF
--- a/dotcom-rendering/README.md
+++ b/dotcom-rendering/README.md
@@ -73,7 +73,6 @@ http://localhost:3030/ArticleJson?url=https://www.theguardian.com/sport/2019/jul
 | `GU_STAGE`                    | `PROD` or `DEV`. Typically used to decide if DCR should call Production downstream API's or CODE downstream API's                              |
 | `GU_PUBLIC`                   | Any value, undefined will disable. Toggles serving assets on the `/assets/` endpoint                                                           |
 | `DISABLE_LOGGING_AND_METRICS` | Boolean. Toggle for enabling Log4js                                                                                                            |
-| `SKIP_LEGACY`                 | Boolean. Toggles building Legacy browser bundles                                                                                               |
 
 Most of these variables are set by our make scripts and you don't need to worry about setting them.
 

--- a/dotcom-rendering/makefile
+++ b/dotcom-rendering/makefile
@@ -81,9 +81,9 @@ dev: clear clean-dist install
 	$(call log, "starting DEV server")
 	@NODE_ENV=development webpack serve --config ./scripts/webpack/webpack.config.js
 
-dev-apps: clear clean-dist install
+dev-web: clear clean-dist install
 	$(call log, "starting DEV server")
-	@NODE_ENV=development BUILD_APPS=true webpack serve --config ./scripts/webpack/webpack.config.js
+	@NODE_ENV=development BUILD_APPS=false webpack serve --config ./scripts/webpack/webpack.config.js
 
 dev-variant: clear clean-dist install
 	$(call log, "starting DEV server")

--- a/dotcom-rendering/makefile
+++ b/dotcom-rendering/makefile
@@ -81,6 +81,10 @@ dev: clear clean-dist install
 	$(call log, "starting DEV server")
 	@NODE_ENV=development SKIP_LEGACY=true webpack serve --config ./scripts/webpack/webpack.config.js
 
+dev-apps: clear clean-dist install
+	$(call log, "starting DEV server")
+	@NODE_ENV=development SKIP_LEGACY=true BUILD_APPS=true webpack serve --config ./scripts/webpack/webpack.config.js
+
 dev-legacy: clear clean-dist install
 	$(call log, "starting DEV server")
 	@NODE_ENV=development webpack serve --config ./scripts/webpack/webpack.config.js

--- a/dotcom-rendering/makefile
+++ b/dotcom-rendering/makefile
@@ -37,7 +37,7 @@ build: clean-dist install
 
 build-ci: clean-dist install
 	$(call log, "building production bundles")
-	@NODE_ENV=production SKIP_LEGACY=true webpack --config ./scripts/webpack/webpack.config.js
+	@NODE_ENV=production webpack --config ./scripts/webpack/webpack.config.js
 
 start-ci: install
 	$(call log, "starting PROD server...")
@@ -79,24 +79,24 @@ run-ci: stop build-ci start-ci
 
 dev: clear clean-dist install
 	$(call log, "starting DEV server")
-	@NODE_ENV=development SKIP_LEGACY=true webpack serve --config ./scripts/webpack/webpack.config.js
+	@NODE_ENV=development webpack serve --config ./scripts/webpack/webpack.config.js
 
 dev-apps: clear clean-dist install
 	$(call log, "starting DEV server")
-	@NODE_ENV=development SKIP_LEGACY=true BUILD_APPS=true webpack serve --config ./scripts/webpack/webpack.config.js
+	@NODE_ENV=development BUILD_APPS=true webpack serve --config ./scripts/webpack/webpack.config.js
 
 dev-variant: clear clean-dist install
 	$(call log, "starting DEV server")
-	@NODE_ENV=development SKIP_LEGACY=true BUILD_VARIANT=true webpack serve --config ./scripts/webpack/webpack.config.js
+	@NODE_ENV=development BUILD_VARIANT=true webpack serve --config ./scripts/webpack/webpack.config.js
 
 dev-legacy: clear clean-dist install
 	$(call log, "starting DEV server")
-	@NODE_ENV=development webpack serve --config ./scripts/webpack/webpack.config.js
+	@NODE_ENV=development BUILD_LEGACY=true webpack serve --config ./scripts/webpack/webpack.config.js
 
 dev-debug: clear clean-dist install
 	$(call log, "starting DEV server and debugger")
 	$(call log, "Open chrome://inspect in Chrome to attach to the debugger")
-	@NODE_ENV=development SKIP_LEGACY=true NODE_OPTIONS="--inspect" webpack serve --config ./scripts/webpack/webpack.config.js
+	@NODE_ENV=development NODE_OPTIONS="--inspect" webpack serve --config ./scripts/webpack/webpack.config.js
 
 # tests #####################################
 

--- a/dotcom-rendering/makefile
+++ b/dotcom-rendering/makefile
@@ -85,6 +85,10 @@ dev-apps: clear clean-dist install
 	$(call log, "starting DEV server")
 	@NODE_ENV=development SKIP_LEGACY=true BUILD_APPS=true webpack serve --config ./scripts/webpack/webpack.config.js
 
+dev-variant: clear clean-dist install
+	$(call log, "starting DEV server")
+	@NODE_ENV=development SKIP_LEGACY=true BUILD_VARIANT=true webpack serve --config ./scripts/webpack/webpack.config.js
+
 dev-legacy: clear clean-dist install
 	$(call log, "starting DEV server")
 	@NODE_ENV=development webpack serve --config ./scripts/webpack/webpack.config.js

--- a/dotcom-rendering/scripts/webpack/webpack.config.js
+++ b/dotcom-rendering/scripts/webpack/webpack.config.js
@@ -100,7 +100,6 @@ const commonConfigs = ({ platform }) => ({
 });
 
 module.exports = [
-	// server bundle config
 	merge(
 		commonConfigs({
 			platform: 'server',
@@ -108,7 +107,15 @@ module.exports = [
 		require(`./webpack.config.server`)({ sessionId }),
 		DEV ? require(`./webpack.config.dev-server`) : {},
 	),
-	// browser bundle configs
+	merge(
+		commonConfigs({
+			platform: 'browser.modern',
+		}),
+		require(`./webpack.config.browser`)({
+			bundle: 'modern',
+			sessionId,
+		}),
+	),
 	// TODO: ignore static files for legacy compilation
 	...(INCLUDE_LEGACY
 		? [
@@ -123,15 +130,6 @@ module.exports = [
 				),
 		  ]
 		: []),
-	merge(
-		commonConfigs({
-			platform: 'browser.modern',
-		}),
-		require(`./webpack.config.browser`)({
-			bundle: 'modern',
-			sessionId,
-		}),
-	),
 	...(PROD || BUILD_APPS
 		? [
 				merge(

--- a/dotcom-rendering/scripts/webpack/webpack.config.js
+++ b/dotcom-rendering/scripts/webpack/webpack.config.js
@@ -7,15 +7,15 @@ const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
 const FilterWarningsPlugin = require('webpack-filter-warnings-plugin');
 const { merge } = require('webpack-merge');
 const WebpackMessages = require('webpack-messages');
+const { BUILD_VARIANT: BUILD_VARIANT_SWITCH } = require('./bundles');
 
 const dist = path.resolve(__dirname, '..', '..', 'dist');
 const PROD = process.env.NODE_ENV === 'production';
 const DEV = process.env.NODE_ENV === 'development';
 
-const INCLUDE_LEGACY = process.env.SKIP_LEGACY !== 'true';
+const BUILD_LEGACY = process.env.BUILD_LEGACY === 'true';
 const BUILD_APPS = process.env.BUILD_APPS === 'true';
 const BUILD_VARIANT = process.env.BUILD_VARIANT === 'true';
-const { BUILD_VARIANT: BUILD_VARIANT_SWITCH } = require('./bundles');
 
 const sessionId = uuidv4();
 
@@ -145,7 +145,7 @@ module.exports = [
 		  ]
 		: []),
 	// TODO: ignore static files for legacy compilation
-	...(INCLUDE_LEGACY
+	...(PROD || BUILD_LEGACY
 		? [
 				merge(
 					commonConfigs({

--- a/dotcom-rendering/scripts/webpack/webpack.config.js
+++ b/dotcom-rendering/scripts/webpack/webpack.config.js
@@ -12,6 +12,7 @@ const { BUILD_VARIANT } = require('./bundles');
 const PROD = process.env.NODE_ENV === 'production';
 const DEV = process.env.NODE_ENV === 'development';
 const INCLUDE_LEGACY = process.env.SKIP_LEGACY !== 'true';
+const BUILD_APPS = process.env.BUILD_APPS === 'true';
 const dist = path.resolve(__dirname, '..', '..', 'dist');
 
 const sessionId = uuidv4();
@@ -131,15 +132,19 @@ module.exports = [
 			sessionId,
 		}),
 	),
-	merge(
-		commonConfigs({
-			platform: 'browser.apps',
-		}),
-		require(`./webpack.config.browser`)({
-			bundle: 'apps',
-			sessionId,
-		}),
-	),
+	...(PROD || BUILD_APPS
+		? [
+				merge(
+					commonConfigs({
+						platform: 'browser.apps',
+					}),
+					require(`./webpack.config.browser`)({
+						bundle: 'apps',
+						sessionId,
+					}),
+				),
+		  ]
+		: []),
 	// Only build the variant if in production mode
 	// Use `make build` or remove the PROD check temporarily to build the variant in development
 	...(PROD && BUILD_VARIANT

--- a/dotcom-rendering/scripts/webpack/webpack.config.js
+++ b/dotcom-rendering/scripts/webpack/webpack.config.js
@@ -15,6 +15,8 @@ const DEV = process.env.NODE_ENV === 'development';
 
 const BUILD_LEGACY = process.env.BUILD_LEGACY === 'true';
 const BUILD_VARIANT = process.env.BUILD_VARIANT === 'true';
+// always true unless explicitly set to 'false'
+const BUILD_APPS = process.env.BUILD_APPS !== 'false';
 
 const sessionId = uuidv4();
 
@@ -117,15 +119,19 @@ module.exports = [
 			sessionId,
 		}),
 	),
-	merge(
-		commonConfigs({
-			platform: 'browser.apps',
-		}),
-		require(`./webpack.config.browser`)({
-			bundle: 'apps',
-			sessionId,
-		}),
-	),
+	...(BUILD_APPS
+		? [
+				merge(
+					commonConfigs({
+						platform: 'browser.apps',
+					}),
+					require(`./webpack.config.browser`)({
+						bundle: 'apps',
+						sessionId,
+					}),
+				),
+		  ]
+		: []),
 	...((PROD && BUILD_VARIANT_SWITCH) || BUILD_VARIANT
 		? [
 				merge(

--- a/dotcom-rendering/scripts/webpack/webpack.config.js
+++ b/dotcom-rendering/scripts/webpack/webpack.config.js
@@ -131,7 +131,7 @@ module.exports = [
 				),
 		  ]
 		: []),
-	...(PROD || (BUILD_VARIANT_SWITCH && BUILD_VARIANT)
+	...((PROD && BUILD_VARIANT_SWITCH) || BUILD_VARIANT
 		? [
 				merge(
 					commonConfigs({

--- a/dotcom-rendering/scripts/webpack/webpack.config.js
+++ b/dotcom-rendering/scripts/webpack/webpack.config.js
@@ -14,7 +14,6 @@ const PROD = process.env.NODE_ENV === 'production';
 const DEV = process.env.NODE_ENV === 'development';
 
 const BUILD_LEGACY = process.env.BUILD_LEGACY === 'true';
-const BUILD_APPS = process.env.BUILD_APPS === 'true';
 const BUILD_VARIANT = process.env.BUILD_VARIANT === 'true';
 
 const sessionId = uuidv4();
@@ -118,19 +117,15 @@ module.exports = [
 			sessionId,
 		}),
 	),
-	...(PROD || BUILD_APPS
-		? [
-				merge(
-					commonConfigs({
-						platform: 'browser.apps',
-					}),
-					require(`./webpack.config.browser`)({
-						bundle: 'apps',
-						sessionId,
-					}),
-				),
-		  ]
-		: []),
+	merge(
+		commonConfigs({
+			platform: 'browser.apps',
+		}),
+		require(`./webpack.config.browser`)({
+			bundle: 'apps',
+			sessionId,
+		}),
+	),
 	...((PROD && BUILD_VARIANT_SWITCH) || BUILD_VARIANT
 		? [
 				merge(


### PR DESCRIPTION
## What does this change?

Since #7200 the app build is running as part of `make dev`.

This has the side effect of slowing down the dev build e.g. ~2s to ~15s (post SWC + Node 16)

This change adds a new make task `make dev-web` for when you're very sure that your local work is web only.

Also the following additional refactors:
- add new make tasks for each optional build i.e. `make dev-legacy` & `make dev-variant`
- where applicable change build checks to `PROD || BUILD_X` for improved readability
- PROD and hence CI runs all builds
- change SKIP_LEGACY to BUILD_LEGACY

## Why?

build times for `make dev-web`:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/7014230/220169593-2e378511-4447-4c8a-ad1c-70a90a1d9e9b.png
[after]: https://user-images.githubusercontent.com/7014230/220170431-0ff4cef3-fe63-4a54-969d-22a69ea04e37.png

