### PR TITLE
Special Report Alt: Tags

### DIFF
--- a/apps-rendering/src/palette/background.ts
+++ b/apps-rendering/src/palette/background.ts
@@ -949,8 +949,8 @@ const seriesDark = ({ design, display, theme }: ArticleFormat): Colour => {
 	}
 };
 
-const tag = (format: ArticleFormat): Colour => {
-	switch (format.design) {
+const tag = ({ design, theme }: ArticleFormat): Colour => {
+	switch (design) {
 		case ArticleDesign.Gallery:
 			return neutral[10];
 		case ArticleDesign.Editorial:
@@ -960,13 +960,57 @@ const tag = (format: ArticleFormat): Colour => {
 		case ArticleDesign.LiveBlog:
 			return neutral[93];
 		case ArticleDesign.Analysis:
-			return neutral[100];
+			switch (theme) {
+				case ArticleSpecial.SpecialReportAlt:
+					return neutral[86];
+				default:
+					return neutral[100];
+			}
+		case ArticleDesign.Explainer:
+		case ArticleDesign.Feature:
+		case ArticleDesign.FullPageInteractive:
+		case ArticleDesign.Interactive:
+		case ArticleDesign.Interview:
+		case ArticleDesign.NewsletterSignup:
+		case ArticleDesign.PhotoEssay:
+		case ArticleDesign.Review:
+		case ArticleDesign.Standard:
+			switch (theme) {
+				case ArticleSpecial.SpecialReportAlt:
+					return neutral[86];
+				default:
+					return neutral[97];
+			}
 		default:
 			return neutral[97];
 	}
 };
 
-const tagDark = (_format: ArticleFormat): Colour => neutral[20];
+const tagDark = ({ design, theme }: ArticleFormat): Colour => {
+	switch (design) {
+		case ArticleDesign.Standard:
+		case ArticleDesign.Review:
+		case ArticleDesign.Explainer:
+		case ArticleDesign.Feature:
+		case ArticleDesign.Interview:
+		case ArticleDesign.Interactive:
+		case ArticleDesign.PhotoEssay:
+		case ArticleDesign.FullPageInteractive:
+		case ArticleDesign.NewsletterSignup:
+		case ArticleDesign.Comment:
+		case ArticleDesign.Letter:
+		case ArticleDesign.Editorial:
+		case ArticleDesign.Analysis:
+			switch (theme) {
+				case ArticleSpecial.SpecialReportAlt:
+					return neutral[7];
+				default:
+					return neutral[20];
+			}
+		default:
+			return neutral[20];
+	}
+}
 
 const pinnedPost = (format: ArticleFormat): string => {
 	switch (format.theme) {

--- a/apps-rendering/src/palette/background.ts
+++ b/apps-rendering/src/palette/background.ts
@@ -1010,7 +1010,7 @@ const tagDark = ({ design, theme }: ArticleFormat): Colour => {
 		default:
 			return neutral[20];
 	}
-}
+};
 
 const pinnedPost = (format: ArticleFormat): string => {
 	switch (format.theme) {


### PR DESCRIPTION
## Why?

Building out the special report alt designs in AR, as covered in #6203. I've broken this up into stages to make the PRs easier to review. This PR deals with the tags.

**Note:** The screenshots below show the final result of all changes, some of which aren't included in this PR.

## Changes

- Updated the dropcap colours in light and dark mode

## Screenshots

| Light | Dark |
| - | - |
| ![tags-light] | ![tags-dark] |

[tags-dark]: https://user-images.githubusercontent.com/53781962/220115107-99bc9f29-234c-4f86-bc60-cc01b674060b.jpg
[tags-light]: https://user-images.githubusercontent.com/53781962/220115110-5c35a762-1abe-4bd3-9e0a-620a20a28081.jpg
