### PR TITLE
Special Report Alt: Lines

### DIFF
--- a/apps-rendering/src/components/Layout/AnalysisLayout.tsx
+++ b/apps-rendering/src/components/Layout/AnalysisLayout.tsx
@@ -73,7 +73,7 @@ const AnalysisLayout: FC<Props> = ({ item }) => {
 							<Byline {...item} />
 							<Standfirst item={item} />
 							<StraightLines
-								cssOverrides={lineStyles}
+								cssOverrides={lineStyles(format)}
 								count={4}
 							/>
 							<Metadata item={item} />

--- a/apps-rendering/src/components/Layout/CommentLayout.tsx
+++ b/apps-rendering/src/components/Layout/CommentLayout.tsx
@@ -97,7 +97,7 @@ const CommentLayout: FC<Props> = ({ item }) => {
 						format={item}
 					/>
 					<StraightLines
-						cssOverrides={[commentLineStylePosition, lineStyles]}
+						cssOverrides={[commentLineStylePosition, lineStyles(format)]}
 						count={8}
 					/>
 					<div css={articleWidthStyles}>

--- a/apps-rendering/src/components/Layout/CommentLayout.tsx
+++ b/apps-rendering/src/components/Layout/CommentLayout.tsx
@@ -97,7 +97,10 @@ const CommentLayout: FC<Props> = ({ item }) => {
 						format={item}
 					/>
 					<StraightLines
-						cssOverrides={[commentLineStylePosition, lineStyles(format)]}
+						cssOverrides={[
+							commentLineStylePosition,
+							lineStyles(format),
+						]}
 						count={8}
 					/>
 					<div css={articleWidthStyles}>

--- a/apps-rendering/src/components/Layout/LabsLayout.tsx
+++ b/apps-rendering/src/components/Layout/LabsLayout.tsx
@@ -79,7 +79,7 @@ const LabsLayout: FC<Props> = ({ item }) => {
 							<Standfirst item={item} />
 						</div>
 					</div>
-					<DottedLines count={1} cssOverrides={lineStyles} />
+					<DottedLines count={1} cssOverrides={lineStyles(format)} />
 					<section css={articleWidthStyles}>
 						<Metadata item={item} />
 						{pipe(

--- a/apps-rendering/src/components/Layout/LetterLayout.tsx
+++ b/apps-rendering/src/components/Layout/LetterLayout.tsx
@@ -75,7 +75,7 @@ const LetterLayout: FC<Props> = ({ item }) => {
 						format={item}
 					/>
 					<StraightLines
-						cssOverrides={[linePosition, lineStyles]}
+						cssOverrides={[linePosition, lineStyles(format)]}
 						count={8}
 					/>
 					<div css={articleWidthStyles}>

--- a/apps-rendering/src/components/Layout/StandardLayout.tsx
+++ b/apps-rendering/src/components/Layout/StandardLayout.tsx
@@ -162,7 +162,7 @@ const StandardLayout: FC<Props> = ({ item }) => {
 					<div css={articleWidthStyles}>
 						<Standfirst item={item} />
 					</div>
-					{decideLines(item, lineStyles)}
+					{decideLines(item, lineStyles(format))}
 					<section css={articleWidthStyles}>
 						<Metadata item={item} />
 						<Logo item={item} />

--- a/apps-rendering/src/palette/fill.ts
+++ b/apps-rendering/src/palette/fill.ts
@@ -328,7 +328,7 @@ const linesDark = ({ design, theme }: ArticleFormat): Colour => {
 		default:
 			return neutral[20];
 	}
-}
+};
 
 const newsletterSignUpFormButton = (_format: ArticleFormat): Colour =>
 	neutral[7];

--- a/apps-rendering/src/palette/fill.ts
+++ b/apps-rendering/src/palette/fill.ts
@@ -305,7 +305,30 @@ const richLinkSvgPreloadDark = (_format: ArticleFormat): Colour => {
 
 const lines = (_format: ArticleFormat): Colour => neutral[86];
 
-const linesDark = (_format: ArticleFormat): Colour => neutral[20];
+const linesDark = ({ design, theme }: ArticleFormat): Colour => {
+	switch (design) {
+		case ArticleDesign.Standard:
+		case ArticleDesign.Review:
+		case ArticleDesign.Explainer:
+		case ArticleDesign.Feature:
+		case ArticleDesign.Interview:
+		case ArticleDesign.Interactive:
+		case ArticleDesign.PhotoEssay:
+		case ArticleDesign.FullPageInteractive:
+		case ArticleDesign.NewsletterSignup:
+		case ArticleDesign.Comment:
+		case ArticleDesign.Letter:
+		case ArticleDesign.Editorial:
+			switch (theme) {
+				case ArticleSpecial.SpecialReportAlt:
+					return neutral[46];
+				default:
+					return neutral[20];
+			}
+		default:
+			return neutral[20];
+	}
+}
 
 const newsletterSignUpFormButton = (_format: ArticleFormat): Colour =>
 	neutral[7];

--- a/apps-rendering/src/styles.ts
+++ b/apps-rendering/src/styles.ts
@@ -11,6 +11,7 @@ import {
 import type { Option } from '@guardian/types';
 import { map, none, some, withDefault } from '@guardian/types';
 import { pipe } from 'lib';
+import { fill } from 'palette';
 
 export const sidePadding = css`
 	padding-left: ${remSpace[3]};
@@ -81,7 +82,7 @@ export const liveblogWidthStyles: SerializedStyles = css`
 	}
 `;
 
-export const lineStyles = css`
+export const lineStyles = (format: ArticleFormat): SerializedStyles => css`
 	display: block;
 
 	${from.wide} {
@@ -93,12 +94,12 @@ export const lineStyles = css`
 	${darkModeCss`
 		// Straight, Dashed, Squiggly
 		&[stroke], defs pattern[stroke], defs pattern g[stroke] {
-			stroke: ${neutral[20]};
+			stroke: ${fill.linesDark(format)};
 		}
 
 		// Dotted
 		defs pattern circle[fill]  {
-			fill: ${neutral[20]};
+			fill: ${fill.linesDark(format)};
 		}
     `}
 `;


### PR DESCRIPTION
## Why?

Building out the special report alt designs in AR, as covered in #6203. I've broken this up into stages to make the PRs easier to review. This PR deals with the metadata lines.

**Note:** The screenshots below show the final result of all changes, some of which aren't included in this PR.

## Changes

- Updated the metadata lines colours in light and dark mode

## Screenshots

| Light | Dark |
| - | - |
| ![lines-light] | ![lines-dark] |

[lines-dark]: https://user-images.githubusercontent.com/53781962/220117988-80d69ca2-5658-4db3-8de6-c5efecb8afb1.jpg
[lines-light]: https://user-images.githubusercontent.com/53781962/220117990-b557055b-5dad-419c-91e7-2d1369839301.jpg
