### PR TITLE
Special Report Alt: Figcaption

### DIFF
--- a/apps-rendering/src/components/ArticleBody/index.tsx
+++ b/apps-rendering/src/components/ArticleBody/index.tsx
@@ -36,10 +36,6 @@ const styles = (format: ArticleFormat): SerializedStyles => css`
 		background: ${background.articleContentDark(format)};
 		color: ${neutral[86]};
 
-		figcaption {
-			color: ${neutral[60]};
-		}
-
 		p:last-child {
 			margin-bottom: 0;
 		}

--- a/apps-rendering/src/palette/text.ts
+++ b/apps-rendering/src/palette/text.ts
@@ -1363,9 +1363,56 @@ const pullquoteDark = ({ design, theme }: ArticleFormat): Colour => {
 	}
 };
 
-const figCaption = (_format: ArticleFormat): Colour => neutral[46];
+const figCaption = ({ design, theme }: ArticleFormat): Colour => {
+	switch (design) {
+		case ArticleDesign.Analysis:
+		case ArticleDesign.Comment:
+		case ArticleDesign.Editorial:
+		case ArticleDesign.Explainer:
+		case ArticleDesign.Feature:
+		case ArticleDesign.FullPageInteractive:
+		case ArticleDesign.Interactive:
+		case ArticleDesign.Interview:
+		case ArticleDesign.Letter:
+		case ArticleDesign.NewsletterSignup:
+		case ArticleDesign.PhotoEssay:
+		case ArticleDesign.Review:
+		case ArticleDesign.Standard:
+			switch (theme) {
+				case ArticleSpecial.SpecialReportAlt:
+					return palette.specialReportAlt[100];
+				default:
+					return neutral[46];
+			}
+		default:
+			return neutral[46];
+	}
+};
 
-const figCaptionDark = (_format: ArticleFormat): Colour => neutral[60];
+const figCaptionDark = ({ design, theme }: ArticleFormat): Colour => {
+	switch (design) {
+		case ArticleDesign.Standard:
+		case ArticleDesign.Review:
+		case ArticleDesign.Explainer:
+		case ArticleDesign.Feature:
+		case ArticleDesign.Interview:
+		case ArticleDesign.Interactive:
+		case ArticleDesign.PhotoEssay:
+		case ArticleDesign.FullPageInteractive:
+		case ArticleDesign.NewsletterSignup:
+		case ArticleDesign.Comment:
+		case ArticleDesign.Letter:
+		case ArticleDesign.Editorial:
+			switch (theme) {
+				case ArticleSpecial.SpecialReportAlt:
+					return palette.specialReportAlt[700];
+				default:
+					return neutral[60];
+			}
+		default:
+			return neutral[60];
+	}
+};
 
 const tag = (format: ArticleFormat): Colour => {
 	switch (format.design) {


### PR DESCRIPTION
## Why?

Building out the special report alt designs in AR, as covered in #6203. I've broken this up into stages to make the PRs easier to review. This PR deals with figcaptions.

**Note:** The screenshots below show the final result of all changes, some of which aren't included in this PR.

## Changes

- Updated the figcaption colours in light and dark mode

## Screenshots

| Light | Dark |
| - | - |
| ![figcaption-light] | ![figcaption-dark] |

[figcaption-light]: https://user-images.githubusercontent.com/53781962/220125679-8d704e30-6c66-440c-94fd-44bf0fd65452.jpg
[figcaption-dark]: https://user-images.githubusercontent.com/53781962/220125683-21ae9657-1560-4cdc-8386-723458da73a1.jpg
