### PR TITLE
Group statistics files 

### DIFF
--- a/.github/workflows/bundle-analyser.yml
+++ b/.github/workflows/bundle-analyser.yml
@@ -28,17 +28,17 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: bundle-analyser-report-modern
-          path: dotcom-rendering/dist/browser.modern-bundles.html
+          path: dotcom-rendering/dist/stats/browser.modern-bundles.html
           if-no-files-found: error
       - name: Archive code coverage results for legacy bundle
         uses: actions/upload-artifact@v3
         with:
           name: bundle-analyser-report-modern
-          path: dotcom-rendering/dist/browser.legacy-bundles.html
+          path: dotcom-rendering/dist/stats/browser.legacy-bundles.html
           if-no-files-found: error
       - name: Archive code coverage results for variant bundle
         uses: actions/upload-artifact@v3
         with:
           name: bundle-analyser-report-variant
-          path: dotcom-rendering/dist/browser.variant-bundles.html
+          path: dotcom-rendering/dist/stats/browser.variant-bundles.html
           if-no-files-found: warn # Variant bundle only exists when an active experiment is going on

--- a/dotcom-rendering/scripts/deploy/build-riffraff-bundle.js
+++ b/dotcom-rendering/scripts/deploy/build-riffraff-bundle.js
@@ -50,7 +50,7 @@ const copyStatic = () => {
 const copyDist = () => {
 	log(' - copying dist');
 	return cpy(
-		['**/*.!(html|json)'],
+		['**/*.!(html|json)', 'stats/*'],
 		path.resolve(target, 'frontend-static', 'assets'),
 		{
 			cwd: path.resolve(__dirname, '../../dist'),

--- a/dotcom-rendering/scripts/islands/island-descriptions.mjs
+++ b/dotcom-rendering/scripts/islands/island-descriptions.mjs
@@ -11,6 +11,8 @@ import remarkRehype from 'remark-rehype';
 import { unified } from 'unified';
 import * as zod from 'zod';
 
+const dir = resolve(fileURLToPath(import.meta.url), '../../../dist/stats');
+
 /**
  * This regex is dynamic so we can find the precise JSDoc for
  * the Island that has the name of the file it is in.
@@ -41,13 +43,7 @@ const chunk = zod.object({
 
 /** Sorted by gzipSize */
 const getBundleReport = () =>
-	readFile(
-		resolve(
-			fileURLToPath(import.meta.url),
-			'../../../dist/browser.modern-bundles.json',
-		),
-		'utf-8',
-	)
+	readFile(resolve(dir, '/browser.modern-bundles.json'), 'utf-8')
 		.then((bundle_data) => zod.array(chunk).parse(JSON.parse(bundle_data)))
 		.then((report) => report.sort((a, b) => b.gzipSize - a.gzipSize));
 
@@ -173,14 +169,7 @@ const generateIslandDescriptions = async () => {
 		const islands = await getIslands(report);
 		const html = await getHtml(islands);
 
-		await writeFile(
-			resolve(
-				fileURLToPath(import.meta.url),
-				'../../../dist',
-				'islands.html',
-			),
-			html,
-		);
+		await writeFile(resolve(dir, 'islands.html'), html);
 
 		console.info('Succesfully generated Island report card:');
 		console.info('dist/islands.html');

--- a/dotcom-rendering/scripts/webpack/webpack.config.js
+++ b/dotcom-rendering/scripts/webpack/webpack.config.js
@@ -85,6 +85,7 @@ const commonConfigs = ({ platform }) => ({
 					new BundleAnalyzerPlugin({
 						reportFilename: path.join(
 							dist,
+							'stats',
 							`${platform}-bundles.html`,
 						),
 						analyzerMode: 'static',
@@ -94,6 +95,7 @@ const commonConfigs = ({ platform }) => ({
 					new BundleAnalyzerPlugin({
 						reportFilename: path.join(
 							dist,
+							'stats',
 							`${platform}-bundles.json`,
 						),
 						analyzerMode: 'json',


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Put all the stats file into their own folder, to formalise the process of publishing.

## Why?

Currently, there’s a glob pattern that is meant to prevent html and json files from being copied over, but it fails to capture the bundle analyser output: https://assets.guim.co.uk/assets/browser.modern-bundles.json & https://assets.guim.co.uk/assets/browser.modern-bundles.html. It did, however, prevent `islands.html` in #7201 from being published.

This makes it explicit that any file in `dist/stats` will be published, regardless of its extension.