### PR TITLE
Sentry - Ignore blocked scripts

### DIFF
--- a/dotcom-rendering/src/web/browser/sentryLoader/sentry.ts
+++ b/dotcom-rendering/src/web/browser/sentryLoader/sentry.ts
@@ -33,6 +33,9 @@ const ignoreErrors = [
 	'TypeError: Load failed',
 	'TypeError: Importing a module script failed',
 	'TypeError: error loading dynamically imported module',
+	// Ignore load script errors for ad and tracking scripts as they can be blocked by browsers and ad blockers
+	// google publisher tag
+	/Error loading script.*googletagservices.com\/tag\/js\/gpt.js/gi,
 ];
 
 const { config } = window.guardian;

--- a/dotcom-rendering/src/web/browser/sentryLoader/sentry.ts
+++ b/dotcom-rendering/src/web/browser/sentryLoader/sentry.ts
@@ -36,6 +36,8 @@ const ignoreErrors = [
 	// Ignore load script errors for ad and tracking scripts as they can be blocked by browsers and ad blockers
 	// google publisher tag
 	/Error loading script.*googletagservices.com\/tag\/js\/gpt.js/gi,
+	// ipsos mori
+	/Error loading script.*script.dotmetrics.net\/door.js/gi,
 ];
 
 const { config } = window.guardian;


### PR DESCRIPTION
## What does this change?

Since #7119 we now have specific errors from `loadScript`

This PR adds to the Sentry ignore list:

`Error loading script: src: //www.googletagservices.com/tag/js/gpt.js...` (Google publisher tag)
`Error loading script: src: https://[*]script.dotmetrics.net/door.js...` (Ipsos mori)

## Why?

Reduce noise from ad and tracking blockers in Sentry

Looking at the tag breakdown this error is primarily coming from Safari and DuckDuckGo browsers.

<img width="642" src="https://user-images.githubusercontent.com/7014230/220336410-a9d5a04f-d223-4ee1-8c83-eb6035355d65.png">
