### PR TITLE
Special Report Alt: Byline

### DIFF
--- a/apps-rendering/src/components/Byline/AnalysisByline.tsx
+++ b/apps-rendering/src/components/Byline/AnalysisByline.tsx
@@ -26,6 +26,10 @@ const styles = (format: ArticleFormat): SerializedStyles => css`
 		})}
 	}
 	padding-bottom: ${remSpace[6]};
+
+	${darkModeCss`
+		color: ${text.bylineDark(format)};
+	`}
 `;
 
 const anchorStyles = (format: ArticleFormat): SerializedStyles => css`

--- a/apps-rendering/src/components/Byline/Byline.defaults.tsx
+++ b/apps-rendering/src/components/Byline/Byline.defaults.tsx
@@ -1,7 +1,7 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import type { ArticleFormat } from '@guardian/libs';
-import { headline, neutral } from '@guardian/source-foundations';
+import { headline } from '@guardian/source-foundations';
 import { withDefault } from '@guardian/types';
 import type { Option } from '@guardian/types';
 import { maybeRender } from 'lib';
@@ -10,12 +10,12 @@ import type { ReactNode } from 'react';
 import { getHref } from 'renderer';
 import { darkModeCss } from 'styles';
 
-export const defaultStyles = (kicker: string): SerializedStyles => css`
+export const defaultStyles = (format: ArticleFormat): SerializedStyles => css`
 	${headline.xxxsmall({ fontStyle: 'italic' })}
-	color: ${kicker};
+	color: ${text.byline(format)};
 
 	${darkModeCss`
-        color: ${neutral[60]};
+        color: ${text.bylineDark(format)};
     `}
 `;
 

--- a/apps-rendering/src/components/Byline/CommentByline.tsx
+++ b/apps-rendering/src/components/Byline/CommentByline.tsx
@@ -8,21 +8,25 @@ import { darkModeCss } from 'styles';
 import { DefaultByline } from './Byline.defaults';
 
 const commentStyles = (format: ArticleFormat): SerializedStyles => css`
-	color: ${text.bylineLeftColumn(format)};
+	color: ${text.byline(format)};
 	width: 75%;
 	${headline.medium({ fontWeight: 'light', fontStyle: 'italic' })}
 
 	${between.mobile.and.phablet} {
 		width: 68%;
 	}
+
+	${darkModeCss`
+		color: ${text.bylineDark(format)};
+	`}
 `;
 
 const commentAnchorStyles = (format: ArticleFormat): SerializedStyles => css`
-	color: ${text.bylineLeftColumn(format)};
+	color: ${text.bylineAnchor(format)};
 	text-decoration: none;
 
 	${darkModeCss`
-        color: ${text.bylineDark(format)};
+        color: ${text.bylineAnchorDark(format)};
     `}
 `;
 

--- a/apps-rendering/src/components/Byline/index.tsx
+++ b/apps-rendering/src/components/Byline/index.tsx
@@ -2,7 +2,6 @@
 import { ArticleDesign, ArticleSpecial } from '@guardian/libs';
 import type { ArticleFormat } from '@guardian/libs';
 import type { Option } from '@guardian/types';
-import { text } from 'palette';
 import type { FC } from 'react';
 import AnalysisByline from './AnalysisByline';
 import {
@@ -45,7 +44,7 @@ const Byline: FC<Props> = ({ bylineHtml, ...format }) => {
 			return (
 				<DefaultByline
 					bylineHtml={bylineHtml}
-					styles={defaultStyles(text.bylineLeftColumn(format))}
+					styles={defaultStyles(format)}
 					anchorStyles={defaultAnchorStyles(format)}
 					format={format}
 				/>

--- a/apps-rendering/src/palette/text.ts
+++ b/apps-rendering/src/palette/text.ts
@@ -73,86 +73,257 @@ const brandingDark = (_format: ArticleFormat): Colour => {
 	return neutral[86];
 };
 
-const byline = (_format: ArticleFormat): Colour => {
-	return neutral[46];
+const byline = ({ design, theme }: ArticleFormat): Colour => {
+	switch (design) {
+		case ArticleDesign.Analysis:
+			return neutral[46];
+		case ArticleDesign.Comment:
+		case ArticleDesign.Editorial:
+			switch (theme) {
+				case ArticlePillar.News:
+					return news[400];
+				case ArticlePillar.Lifestyle:
+					return lifestyle[400];
+				case ArticlePillar.Sport:
+					return sport[400];
+				case ArticlePillar.Culture:
+					return culture[400];
+				case ArticlePillar.Opinion:
+					return opinion[300];
+				case ArticleSpecial.Labs:
+					return labs[400];
+				case ArticleSpecial.SpecialReport:
+					return specialReport[400];
+				case ArticleSpecial.SpecialReportAlt:
+					return neutral[46];
+			}
+		case ArticleDesign.Explainer:
+		case ArticleDesign.Feature:
+		case ArticleDesign.FullPageInteractive:
+		case ArticleDesign.Interactive:
+		case ArticleDesign.Interview:
+		case ArticleDesign.NewsletterSignup:
+		case ArticleDesign.PhotoEssay:
+		case ArticleDesign.Review:
+		case ArticleDesign.Letter:
+		case ArticleDesign.Standard:
+			switch (theme) {
+				case ArticlePillar.News:
+					return news[400];
+				case ArticlePillar.Lifestyle:
+					return lifestyle[400];
+				case ArticlePillar.Sport:
+					return sport[400];
+				case ArticlePillar.Culture:
+					return culture[400];
+				case ArticlePillar.Opinion:
+					return opinion[300];
+				case ArticleSpecial.Labs:
+					return labs[400];
+				case ArticleSpecial.SpecialReport:
+					return specialReport[400];
+				case ArticleSpecial.SpecialReportAlt:
+					return palette.specialReportAlt[100];
+			}
+		default:
+			switch (theme) {
+				case ArticlePillar.News:
+					return news[400];
+				case ArticlePillar.Lifestyle:
+					return lifestyle[400];
+				case ArticlePillar.Sport:
+					return sport[400];
+				case ArticlePillar.Culture:
+					return culture[400];
+				case ArticlePillar.Opinion:
+					return opinion[300];
+				case ArticleSpecial.Labs:
+					return labs[400];
+				case ArticleSpecial.SpecialReport:
+					return specialReport[400];
+				case ArticleSpecial.SpecialReportAlt:
+					return news[400];
+			}
+	}
 };
 
-const bylineAnchor = (format: ArticleFormat): Colour => {
-	if (format.design === ArticleDesign.Analysis) {
-		switch (format.theme) {
-			case ArticlePillar.Sport:
-				return sport[300];
-			case ArticlePillar.Culture:
-				return culture[300];
-			case ArticlePillar.Opinion:
-				return opinion[300];
-			case ArticlePillar.Lifestyle:
-				return lifestyle[300];
-			case ArticleSpecial.Labs:
-				return labs[300];
-			case ArticleSpecial.SpecialReport:
-				return brandAlt[300];
-			case ArticleSpecial.SpecialReportAlt:
-				return news[300];
-			case ArticlePillar.News:
-			default:
-				return news[300];
-		}
-	}
-	switch (format.theme) {
-		case ArticlePillar.News:
-			return news[400];
-		case ArticlePillar.Lifestyle:
-			return lifestyle[400];
-		case ArticlePillar.Sport:
-			return sport[400];
-		case ArticlePillar.Culture:
-			return culture[400];
-		case ArticlePillar.Opinion:
-			return opinion[400];
-		case ArticleSpecial.Labs:
-			return labs[300];
-		case ArticleSpecial.SpecialReport:
-			return specialReport[400];
-		case ArticleSpecial.SpecialReportAlt:
-			return news[400];
+const bylineAnchor = ({ design, theme }: ArticleFormat): Colour => {
+	switch (design) {
+		case ArticleDesign.Analysis:
+			switch (theme) {
+				case ArticlePillar.Sport:
+					return sport[300];
+				case ArticlePillar.Culture:
+					return culture[300];
+				case ArticlePillar.Opinion:
+					return opinion[300];
+				case ArticlePillar.Lifestyle:
+					return lifestyle[300];
+				case ArticleSpecial.Labs:
+					return labs[300];
+				case ArticleSpecial.SpecialReport:
+					return brandAlt[300];
+				case ArticleSpecial.SpecialReportAlt:
+					return palette.specialReportAlt[100];
+				case ArticlePillar.News:
+				default:
+					return news[300];
+			}
+		case ArticleDesign.Comment:
+		case ArticleDesign.Editorial:
+			switch (theme) {
+				case ArticlePillar.News:
+					return news[400];
+				case ArticlePillar.Lifestyle:
+					return lifestyle[400];
+				case ArticlePillar.Sport:
+					return sport[400];
+				case ArticlePillar.Culture:
+					return culture[400];
+				case ArticlePillar.Opinion:
+					return opinion[400];
+				case ArticleSpecial.Labs:
+					return labs[300];
+				case ArticleSpecial.SpecialReport:
+					return specialReport[400];
+				case ArticleSpecial.SpecialReportAlt:
+					return palette.specialReportAlt[200];
+			}
+		case ArticleDesign.Explainer:
+		case ArticleDesign.Feature:
+		case ArticleDesign.FullPageInteractive:
+		case ArticleDesign.Interactive:
+		case ArticleDesign.Interview:
+		case ArticleDesign.Letter:
+		case ArticleDesign.NewsletterSignup:
+		case ArticleDesign.PhotoEssay:
+		case ArticleDesign.Review:
+		case ArticleDesign.Standard:
+			switch (theme) {
+				case ArticlePillar.News:
+					return news[400];
+				case ArticlePillar.Lifestyle:
+					return lifestyle[400];
+				case ArticlePillar.Sport:
+					return sport[400];
+				case ArticlePillar.Culture:
+					return culture[400];
+				case ArticlePillar.Opinion:
+					return opinion[400];
+				case ArticleSpecial.Labs:
+					return labs[300];
+				case ArticleSpecial.SpecialReport:
+					return specialReport[400];
+				case ArticleSpecial.SpecialReportAlt:
+					return palette.specialReportAlt[100];
+			}
+		default:
+			switch (theme) {
+				case ArticlePillar.News:
+					return news[400];
+				case ArticlePillar.Lifestyle:
+					return lifestyle[400];
+				case ArticlePillar.Sport:
+					return sport[400];
+				case ArticlePillar.Culture:
+					return culture[400];
+				case ArticlePillar.Opinion:
+					return opinion[400];
+				case ArticleSpecial.Labs:
+					return labs[300];
+				case ArticleSpecial.SpecialReport:
+					return specialReport[400];
+				case ArticleSpecial.SpecialReportAlt:
+					return news[400];
+			}
 	}
 };
 
-const bylineAnchorDark = (format: ArticleFormat): Colour => {
-	if (format.design === ArticleDesign.Analysis) {
-		switch (format.theme) {
-			case ArticlePillar.Sport:
-				return sport[500];
-			case ArticlePillar.Culture:
-				return culture[500];
-			case ArticlePillar.Opinion:
-				return opinion[500];
-			case ArticlePillar.Lifestyle:
-				return lifestyle[500];
-			case ArticlePillar.News:
-			default:
-				return news[500];
-		}
-	}
-
-	switch (format.theme) {
-		case ArticlePillar.News:
-			return news[500];
-		case ArticlePillar.Lifestyle:
-			return lifestyle[500];
-		case ArticlePillar.Sport:
-			return sport[500];
-		case ArticlePillar.Culture:
-			return culture[500];
-		case ArticlePillar.Opinion:
-			return opinion[500];
-		case ArticleSpecial.Labs:
-			return labs[400];
-		case ArticleSpecial.SpecialReport:
-			return specialReport[500];
-		case ArticleSpecial.SpecialReportAlt:
-			return news[500];
+const bylineAnchorDark = ({ design, theme }: ArticleFormat): Colour => {
+	switch (design) {
+		case ArticleDesign.Analysis:
+			switch (theme) {
+				case ArticlePillar.Sport:
+					return sport[500];
+				case ArticlePillar.Culture:
+					return culture[500];
+				case ArticlePillar.Opinion:
+					return opinion[500];
+				case ArticlePillar.Lifestyle:
+					return lifestyle[500];
+				case ArticleSpecial.SpecialReportAlt:
+					return palette.specialReportAlt[700];
+				case ArticlePillar.News:
+				default:
+					return news[500];
+			}
+		case ArticleDesign.Standard:
+		case ArticleDesign.Review:
+		case ArticleDesign.Explainer:
+		case ArticleDesign.Feature:
+		case ArticleDesign.Interview:
+		case ArticleDesign.Interactive:
+		case ArticleDesign.PhotoEssay:
+		case ArticleDesign.FullPageInteractive:
+		case ArticleDesign.NewsletterSignup:
+		case ArticleDesign.Letter:
+			switch (theme) {
+				case ArticlePillar.News:
+					return news[500];
+				case ArticlePillar.Lifestyle:
+					return lifestyle[500];
+				case ArticlePillar.Sport:
+					return sport[500];
+				case ArticlePillar.Culture:
+					return culture[500];
+				case ArticlePillar.Opinion:
+					return opinion[500];
+				case ArticleSpecial.Labs:
+					return labs[400];
+				case ArticleSpecial.SpecialReport:
+					return specialReport[500];
+				case ArticleSpecial.SpecialReportAlt:
+					return palette.specialReportAlt[700];
+			}
+		case ArticleDesign.Comment:
+		case ArticleDesign.Editorial:
+			switch (theme) {
+				case ArticlePillar.News:
+					return news[500];
+				case ArticlePillar.Lifestyle:
+					return lifestyle[500];
+				case ArticlePillar.Sport:
+					return sport[500];
+				case ArticlePillar.Culture:
+					return culture[500];
+				case ArticlePillar.Opinion:
+					return opinion[500];
+				case ArticleSpecial.Labs:
+					return labs[400];
+				case ArticleSpecial.SpecialReport:
+					return specialReport[500];
+				case ArticleSpecial.SpecialReportAlt:
+					return palette.specialReportAlt[300];
+			}
+		default:
+			switch (theme) {
+				case ArticlePillar.News:
+					return news[500];
+				case ArticlePillar.Lifestyle:
+					return lifestyle[500];
+				case ArticlePillar.Sport:
+					return sport[500];
+				case ArticlePillar.Culture:
+					return culture[500];
+				case ArticlePillar.Opinion:
+					return opinion[500];
+				case ArticleSpecial.Labs:
+					return labs[400];
+				case ArticleSpecial.SpecialReport:
+					return specialReport[500];
+				case ArticleSpecial.SpecialReportAlt:
+					return news[500];
+			}
 	}
 };
 
@@ -436,24 +607,7 @@ const bylineLeftColumn = (format: ArticleFormat): Colour => {
 					return news[300];
 			}
 		default:
-			switch (format.theme) {
-				case ArticlePillar.News:
-					return news[400];
-				case ArticlePillar.Lifestyle:
-					return lifestyle[400];
-				case ArticlePillar.Sport:
-					return sport[400];
-				case ArticlePillar.Culture:
-					return culture[400];
-				case ArticlePillar.Opinion:
-					return opinion[300];
-				case ArticleSpecial.Labs:
-					return labs[400];
-				case ArticleSpecial.SpecialReport:
-					return specialReport[400];
-				case ArticleSpecial.SpecialReportAlt:
-					return news[400];
-			}
+			return neutral[7];
 	}
 };
 
@@ -612,24 +766,26 @@ const followDark = (format: ArticleFormat): Colour => {
 	}
 };
 
-const bylineDark = (format: ArticleFormat): Colour => {
-	switch (format.theme) {
-		case ArticlePillar.News:
-			return news[500];
-		case ArticlePillar.Lifestyle:
-			return lifestyle[500];
-		case ArticlePillar.Sport:
-			return sport[500];
-		case ArticlePillar.Culture:
-			return culture[500];
-		case ArticlePillar.Opinion:
-			return opinion[500];
-		case ArticleSpecial.Labs:
-			return specialReport[500];
-		case ArticleSpecial.SpecialReport:
-			return specialReport[500];
-		case ArticleSpecial.SpecialReportAlt:
-			return news[500];
+const bylineDark = ({ design, theme }: ArticleFormat): Colour => {
+	switch (design) {
+		case ArticleDesign.Standard:
+		case ArticleDesign.Review:
+		case ArticleDesign.Explainer:
+		case ArticleDesign.Feature:
+		case ArticleDesign.Interview:
+		case ArticleDesign.Interactive:
+		case ArticleDesign.PhotoEssay:
+		case ArticleDesign.FullPageInteractive:
+		case ArticleDesign.NewsletterSignup:
+		case ArticleDesign.Letter:
+			switch (theme) {
+				case ArticleSpecial.SpecialReportAlt:
+					return palette.specialReportAlt[700];
+				default:
+					return neutral[60];
+			}
+		default:
+			return neutral[60];
 	}
 };
 


### PR DESCRIPTION
## Why?

Building out the special report alt designs in AR, as covered in #6203. I've broken this up into stages to make the PRs easier to review. This PR deals with the byline.

**Note:** The screenshots below show the final result of all changes, some of which aren't included in this PR.

## Changes

- Updated the `byline` and `bylineAnchor` colours in light and dark mode
- Made sure the palette colours are used in more places
- Reduced the scope of `bylineLeftColumn`; it should only be used in blogs

## Screenshots

| | Light | Dark |
| - | - | - |
| Standard | ![standard-light] | ![standard-dark] |
| Comment | ![comment-light] | ![comment-dark] |
| Analysis | ![analysis-light] | ![analysis-dark] |

[comment-dark]: https://user-images.githubusercontent.com/53781962/220355235-45d671f2-7465-426b-934d-79eee20a2b93.jpg
[comment-light]: https://user-images.githubusercontent.com/53781962/220355239-eca0ac19-6a9b-4862-ac81-9b80ab7a3af6.jpg
[standard-dark]: https://user-images.githubusercontent.com/53781962/220355241-79834c1b-9b72-4925-a692-4407ba743f24.jpg
[standard-light]: https://user-images.githubusercontent.com/53781962/220355243-fc30f957-59af-4300-9073-474efcb43ab2.jpg
[analysis-dark]: https://user-images.githubusercontent.com/53781962/220355244-ca7804c1-18e2-4a51-94b4-84365c55e02e.jpg
[analysis-light]: https://user-images.githubusercontent.com/53781962/220355246-4a54a49e-0812-4a03-a02e-22c97a0f9710.jpg
