### PR TITLE
Don't output commercial placeholders on the server when user is ad-free

### DIFF
--- a/dotcom-rendering/src/web/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/CommentLayout.tsx
@@ -303,9 +303,6 @@ export const CommentLayout = ({ article, NAV, format }: Props) => {
 
 	const contributionsServiceUrl = getContributionsServiceUrl(article);
 
-	/**
-	 * This property currently only applies to the header and merchandising slots
-	 */
 	const renderAds = !article.isAdFreeUser && !article.shouldHideAds;
 
 	return (
@@ -683,7 +680,7 @@ export const CommentLayout = ({ article, NAV, format }: Props) => {
 								`}
 							>
 								<RightColumn>
-									{!article.shouldHideAds && (
+									{renderAds && (
 										<AdSlot
 											position="right"
 											display={format.display}

--- a/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
@@ -322,6 +322,8 @@ export const ImmersiveLayout = ({ article, NAV, format }: Props) => {
 		</div>
 	);
 
+	const renderAds = !article.isAdFreeUser && !article.shouldHideAds;
+
 	return (
 		<>
 			<div
@@ -713,13 +715,13 @@ export const ImmersiveLayout = ({ article, NAV, format }: Props) => {
 							>
 								<RightColumn>
 									<>
-										{mainMedia && (
+										{mainMedia && renderAds && (
 											<div
 												css={css`
 													margin-top: ${space[4]}px;
 												`}
 											>
-												{!article.shouldHideAds && (
+												{
 													<AdSlot
 														position="right"
 														display={format.display}
@@ -731,7 +733,7 @@ export const ImmersiveLayout = ({ article, NAV, format }: Props) => {
 																.isPaidContent
 														}
 													/>
-												)}
+												}
 											</div>
 										)}
 									</>
@@ -740,7 +742,7 @@ export const ImmersiveLayout = ({ article, NAV, format }: Props) => {
 						</GridItem>
 					</ImmersiveGrid>
 				</Section>
-				{!isLabs && (
+				{!isLabs && renderAds && (
 					<Section
 						fullWidth={true}
 						padSides={false}
@@ -838,7 +840,7 @@ export const ImmersiveLayout = ({ article, NAV, format }: Props) => {
 						</MostViewedFooterLayout>
 					</Section>
 				)}
-				{!isLabs && (
+				{!isLabs && renderAds && (
 					<Section
 						fullWidth={true}
 						padSides={false}
@@ -912,7 +914,7 @@ export const ImmersiveLayout = ({ article, NAV, format }: Props) => {
 					/>
 				</Island>
 			</BannerWrapper>
-			<MobileStickyContainer />
+			{renderAds && <MobileStickyContainer />}
 		</>
 	);
 };

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -294,9 +294,6 @@ export const LiveLayout = ({ article, NAV, format }: Props) => {
 	const hasKeyEvents = !!article.keyEvents.length;
 	const showKeyEventsToggle = !showTopicFilterBank && hasKeyEvents;
 
-	/**
-	 * This property currently only applies to the header and merchandising slots
-	 */
 	const renderAds = !article.isAdFreeUser && !article.shouldHideAds;
 
 	return (
@@ -1119,7 +1116,7 @@ export const LiveLayout = ({ article, NAV, format }: Props) => {
 									`}
 								>
 									<RightColumn>
-										{!article.shouldHideAds && (
+										{renderAds && (
 											<AdSlot
 												position="right"
 												display={format.display}

--- a/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
@@ -241,9 +241,6 @@ export const ShowcaseLayout = ({ article, NAV, format }: Props) => {
 
 	const contributionsServiceUrl = getContributionsServiceUrl(article);
 
-	/**
-	 * This property currently only applies to the header and merchandising slots
-	 */
 	const renderAds = !article.isAdFreeUser && !article.shouldHideAds;
 
 	const isLabs = format.theme === ArticleSpecial.Labs;
@@ -625,7 +622,7 @@ export const ShowcaseLayout = ({ article, NAV, format }: Props) => {
 								`}
 							>
 								<RightColumn>
-									{!article.shouldHideAds && (
+									{renderAds && (
 										<AdSlot
 											position="right"
 											display={format.display}

--- a/dotcom-rendering/src/web/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/StandardLayout.tsx
@@ -338,9 +338,6 @@ export const StandardLayout = ({ article, NAV, format }: Props) => {
 
 	const contributionsServiceUrl = getContributionsServiceUrl(article);
 
-	/**
-	 * This property currently only applies to the header and merchandising slots
-	 */
 	const renderAds = !article.isAdFreeUser && !article.shouldHideAds;
 
 	const isLabs = format.theme === ArticleSpecial.Labs;
@@ -749,7 +746,7 @@ export const StandardLayout = ({ article, NAV, format }: Props) => {
 								`}
 							>
 								<RightColumn>
-									{!article.shouldHideAds && (
+									{renderAds && (
 										<AdSlot
 											position="right"
 											display={format.display}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

We no longer output any (hopefully!) slots/containers for commercial to put things in when the user is ad free

## Why?

#7223 revealed that some commercial targets were still being rendered server side, but then hidden client-side. If we don't run the commercial JS then these sit empty and look broken.

Since we know ahead of time we won't be using them, we shouldn't render them.

Then we should be able to revert #7251 (which reverted #7223)

