### PR TITLE
Support the DCR apps article route in AR's server

### DIFF
--- a/.github/workflows/ar-pr-deployment.yml
+++ b/.github/workflows/ar-pr-deployment.yml
@@ -29,7 +29,7 @@ jobs:
               run: |
                   npm install -g ngrok
                   npm run watch &
-                  timeout 1h ngrok http 8080 -log=stdout -host-header=rewrite | \
+                  timeout 1h ngrok http 3030 -log=stdout -host-header=rewrite | \
                     grep --line-buffered -o 'https://.*' | \
                     xargs -L1 -I{} -t \
                       curl -X POST -H 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' https://api.github.com/repos/${{ github.repository }}/statuses/${{ github.event.pull_request.head.sha }} -d "{\"state\":\"success\", \"target_url\":\"{}\", \"context\":\"PR deployment\", \"description\":\"This PR is now live until `date -d "+1 hour" "+%a %H:%M"`. Click details to access it ->\"}"

--- a/apps-rendering/README.md
+++ b/apps-rendering/README.md
@@ -45,8 +45,8 @@ the device simulator) with `yarn watch:simulator`. The development server
 also supports a specific route for
 testing with the device simulator:
 
-- `/AppsArticle?url=https://www.theguardian.com/food/2020/mar/15/easter-taste-test-dan-lepard-hot-cross-bun-milk-dark-chocolate-mini-eggs-bunny-sloth`
-  - e.g [http://localhost:3030/AppsArticle?url=https://www.theguardian.com/food/2020/mar/15/easter-taste-test-dan-lepard-hot-cross-bun-milk-dark-chocolate-mini-eggs-bunny-sloth](http://localhost:3030/AppsArticle?url=https://www.theguardian.com/food/2020/mar/15/easter-taste-test-dan-lepard-hot-cross-bun-milk-dark-chocolate-mini-eggs-bunny-sloth)
+- `/AppsArticle/https://www.theguardian.com/food/2020/mar/15/easter-taste-test-dan-lepard-hot-cross-bun-milk-dark-chocolate-mini-eggs-bunny-sloth`
+  - e.g [http://localhost:3030/AppsArticle/https://www.theguardian.com/food/2020/mar/15/easter-taste-test-dan-lepard-hot-cross-bun-milk-dark-chocolate-mini-eggs-bunny-sloth](http://localhost:3030/AppsArticle/https://www.theguardian.com/food/2020/mar/15/easter-taste-test-dan-lepard-hot-cross-bun-milk-dark-chocolate-mini-eggs-bunny-sloth)
 
 This route matches the one implemented by DCR for rendering apps articles.
 

--- a/apps-rendering/README.md
+++ b/apps-rendering/README.md
@@ -22,28 +22,26 @@ This is the simplest way to get started, but will intermingle all the logs toget
 yarn watch
 ```
 
-View in a browser at http://localhost:8080 (standard port for [webpack-dev-server](https://webpack.js.org/configuration/dev-server/#devserverport)).
+View in a browser at http://localhost:3030.
 
 The Apps Rendering development server supports the following routes for testing
 articles in the browser:
 
 - `/path/to/content`
-  - e.g [http://localhost:8080/food/2020/mar/15/easter-taste-test-dan-lepard-hot-cross-bun-milk-dark-chocolate-mini-eggs-bunny-sloth](http://localhost:8080/food/2020/mar/15/easter-taste-test-dan-lepard-hot-cross-bun-milk-dark-chocolate-mini-eggs-bunny-sloth)
+  - e.g [http://localhost:3030/food/2020/mar/15/easter-taste-test-dan-lepard-hot-cross-bun-milk-dark-chocolate-mini-eggs-bunny-sloth](http://localhost:3030/food/2020/mar/15/easter-taste-test-dan-lepard-hot-cross-bun-milk-dark-chocolate-mini-eggs-bunny-sloth)
 - `/(uk|us|au|international)/path/to/content`
-  - e.g [http://localhost:8080/au/food/2020/mar/15/easter-taste-test-dan-lepard-hot-cross-bun-milk-dark-chocolate-mini-eggs-bunny-sloth](http://localhost:8080/au/food/2020/mar/15/easter-taste-test-dan-lepard-hot-cross-bun-milk-dark-chocolate-mini-eggs-bunny-sloth)
+  - e.g [http://localhost:3030/au/food/2020/mar/15/easter-taste-test-dan-lepard-hot-cross-bun-milk-dark-chocolate-mini-eggs-bunny-sloth](http://localhost:3030/au/food/2020/mar/15/easter-taste-test-dan-lepard-hot-cross-bun-milk-dark-chocolate-mini-eggs-bunny-sloth)
 - `/rendered-items/path/to/content`
-  - e.g [http://localhost:8080/rendered-items/food/2020/mar/15/easter-taste-test-dan-lepard-hot-cross-bun-milk-dark-chocolate-mini-eggs-bunny-sloth](http://localhost:8080/rendered-items/food/2020/mar/15/easter-taste-test-dan-lepard-hot-cross-bun-milk-dark-chocolate-mini-eggs-bunny-sloth)
+  - e.g [http://localhost:3030/rendered-items/food/2020/mar/15/easter-taste-test-dan-lepard-hot-cross-bun-milk-dark-chocolate-mini-eggs-bunny-sloth](http://localhost:3030/rendered-items/food/2020/mar/15/easter-taste-test-dan-lepard-hot-cross-bun-milk-dark-chocolate-mini-eggs-bunny-sloth)
 - `/(uk|us|au|international)/rendered-items/path/to/content`
-  - e.g [http://localhost:8080/au/rendered-items/food/2020/mar/15/easter-taste-test-dan-lepard-hot-cross-bun-milk-dark-chocolate-mini-eggs-bunny-sloth](http://localhost:8080/au/rendered-items/food/2020/mar/15/easter-taste-test-dan-lepard-hot-cross-bun-milk-dark-chocolate-mini-eggs-bunny-sloth)
+  - e.g [http://localhost:3030/au/rendered-items/food/2020/mar/15/easter-taste-test-dan-lepard-hot-cross-bun-milk-dark-chocolate-mini-eggs-bunny-sloth](http://localhost:3030/au/rendered-items/food/2020/mar/15/easter-taste-test-dan-lepard-hot-cross-bun-milk-dark-chocolate-mini-eggs-bunny-sloth)
 
 Additionally, each route above can take a `?editions` query parameter to render
 the article as for the Editions app.
 
 We also recommend testing articles in the mobile device simulators.
-You can start the development server on port `3030` (the port number expected by
-the device simulator) with `yarn watch:simulator`. The development server
-also supports a specific route for
-testing with the device simulator:
+The development server also supports a specific route for testing with the
+device simulator:
 
 - `/AppsArticle/https://www.theguardian.com/food/2020/mar/15/easter-taste-test-dan-lepard-hot-cross-bun-milk-dark-chocolate-mini-eggs-bunny-sloth`
   - e.g [http://localhost:3030/AppsArticle/https://www.theguardian.com/food/2020/mar/15/easter-taste-test-dan-lepard-hot-cross-bun-milk-dark-chocolate-mini-eggs-bunny-sloth](http://localhost:3030/AppsArticle/https://www.theguardian.com/food/2020/mar/15/easter-taste-test-dan-lepard-hot-cross-bun-milk-dark-chocolate-mini-eggs-bunny-sloth)
@@ -68,7 +66,7 @@ To start the client:
 yarn watch:client
 ```
 
-View in a browser at http://localhost:8080 (standard port for [webpack-dev-server](https://webpack.js.org/configuration/dev-server/#devserverport))
+View in a browser at http://localhost:3030
 
 _**Note**: You will need to refresh the page to see any changes you make to the server code. Any changes to client code should reload automatically._
 

--- a/apps-rendering/README.md
+++ b/apps-rendering/README.md
@@ -24,7 +24,8 @@ yarn watch
 
 View in a browser at http://localhost:8080 (standard port for [webpack-dev-server](https://webpack.js.org/configuration/dev-server/#devserverport)).
 
-The Apps Rendering development server supports the following routes for testing articles:
+The Apps Rendering development server supports the following routes for testing
+articles in the browser:
 
 - `/path/to/content`
   - e.g [http://localhost:8080/food/2020/mar/15/easter-taste-test-dan-lepard-hot-cross-bun-milk-dark-chocolate-mini-eggs-bunny-sloth](http://localhost:8080/food/2020/mar/15/easter-taste-test-dan-lepard-hot-cross-bun-milk-dark-chocolate-mini-eggs-bunny-sloth)
@@ -35,7 +36,19 @@ The Apps Rendering development server supports the following routes for testing 
 - `/(uk|us|au|international)/rendered-items/path/to/content`
   - e.g [http://localhost:8080/au/rendered-items/food/2020/mar/15/easter-taste-test-dan-lepard-hot-cross-bun-milk-dark-chocolate-mini-eggs-bunny-sloth](http://localhost:8080/au/rendered-items/food/2020/mar/15/easter-taste-test-dan-lepard-hot-cross-bun-milk-dark-chocolate-mini-eggs-bunny-sloth)
 
-Additionally, each route above can take a `?editions` query parameter to render the article as for the Editions app.
+Additionally, each route above can take a `?editions` query parameter to render
+the article as for the Editions app.
+
+We also recommend testing articles in the mobile device simulators.
+You can start the development server on port `3030` (the port number expected by
+the device simulator) with `yarn watch:device-simulator`. The development server
+also supports a specific route for
+testing with the device simulator:
+
+- `/AppsArticle?url=https://www.theguardian.com/food/2020/mar/15/easter-taste-test-dan-lepard-hot-cross-bun-milk-dark-chocolate-mini-eggs-bunny-sloth`
+  - e.g [http://localhost:3030/AppsArticle?url=https://www.theguardian.com/food/2020/mar/15/easter-taste-test-dan-lepard-hot-cross-bun-milk-dark-chocolate-mini-eggs-bunny-sloth](http://localhost:3030/AppsArticle?url=https://www.theguardian.com/food/2020/mar/15/easter-taste-test-dan-lepard-hot-cross-bun-milk-dark-chocolate-mini-eggs-bunny-sloth)
+
+This route matches the one implemented by DCR for rendering apps articles.
 
 _**Note**: You will need to refresh the page to see any changes you make to the server code. Any changes to client code should reload automatically._
 

--- a/apps-rendering/README.md
+++ b/apps-rendering/README.md
@@ -41,7 +41,7 @@ the article as for the Editions app.
 
 We also recommend testing articles in the mobile device simulators.
 You can start the development server on port `3030` (the port number expected by
-the device simulator) with `yarn watch:device-simulator`. The development server
+the device simulator) with `yarn watch:simulator`. The development server
 also supports a specific route for
 testing with the device simulator:
 

--- a/apps-rendering/package.json
+++ b/apps-rendering/package.json
@@ -20,7 +20,7 @@
 		"watch:client": "webpack serve --config webpack.config.ts --config-name client",
 		"watch:cdk": "tsc -w -p config/tsconfig.cdk.json",
 		"watch": "yarn watch:server & yarn watch:client",
-		"watch:device-simulator": "PORT=3030 yarn watch",
+		"watch:simulator": "PORT=3030 yarn watch",
 		"build:server": "webpack --config webpack.config.ts --config-name server",
 		"build:client": "webpack --config webpack.config.ts --config-name client",
 		"build:cdk": "tsc -p config/tsconfig.cdk.json",

--- a/apps-rendering/package.json
+++ b/apps-rendering/package.json
@@ -20,6 +20,7 @@
 		"watch:client": "webpack serve --config webpack.config.ts --config-name client",
 		"watch:cdk": "tsc -w -p config/tsconfig.cdk.json",
 		"watch": "yarn watch:server & yarn watch:client",
+		"watch:device-simulator": "PORT=3030 yarn watch",
 		"build:server": "webpack --config webpack.config.ts --config-name server",
 		"build:client": "webpack --config webpack.config.ts --config-name client",
 		"build:cdk": "tsc -p config/tsconfig.cdk.json",

--- a/apps-rendering/package.json
+++ b/apps-rendering/package.json
@@ -20,7 +20,6 @@
 		"watch:client": "webpack serve --config webpack.config.ts --config-name client",
 		"watch:cdk": "tsc -w -p config/tsconfig.cdk.json",
 		"watch": "yarn watch:server & yarn watch:client",
-		"watch:simulator": "PORT=3030 yarn watch",
 		"build:server": "webpack --config webpack.config.ts --config-name server",
 		"build:client": "webpack --config webpack.config.ts --config-name client",
 		"build:cdk": "tsc -p config/tsconfig.cdk.json",

--- a/apps-rendering/src/server/server.ts
+++ b/apps-rendering/src/server/server.ts
@@ -430,7 +430,7 @@ app.get(
 	(req, res, next) => {
 		const urlQueryParam = req.query.url?.toString();
 		if (!urlQueryParam) {
-			return res.status(404).send('Missing url query parameter');
+			return res.status(400).send('Missing url query parameter');
 		}
 
 		const articleId = new URL(urlQueryParam).pathname;

--- a/apps-rendering/src/server/server.ts
+++ b/apps-rendering/src/server/server.ts
@@ -425,15 +425,11 @@ The DCR route follows the pattern:
 /AppsArticle?url=https://www.theguardian.com/cities/2019/sep/13/reclaimed-lakes-and-giant-airports-how-mexico-city-might-have-looked
 */
 app.get(
-	'/AppsArticle',
+	'/AppsArticle/*',
 	express.raw(),
 	(req, res, next) => {
-		const urlQueryParam = req.query.url?.toString();
-		if (!urlQueryParam) {
-			return res.status(400).send('Missing url query parameter');
-		}
-
-		const articleId = new URL(urlQueryParam).pathname;
+		const contentWebUrl = req.params[0];
+		const articleId = new URL(contentWebUrl).pathname;
 		req.params = {
 			0: articleId,
 		};

--- a/apps-rendering/src/server/server.ts
+++ b/apps-rendering/src/server/server.ts
@@ -418,6 +418,31 @@ app.get('/healthcheck', (_req, res) => res.send('Ok'));
 app.get('/favicon.ico', (_, res) => res.status(404).end());
 app.get('/fontSize.css', (_, res) => res.status(404).end());
 
+/**
+To enable testing in the mobile device emulators,
+this route handler adds compatability with DCR's route for apps articles.
+The DCR route follows the pattern:
+/AppsArticle?url=https://www.theguardian.com/cities/2019/sep/13/reclaimed-lakes-and-giant-airports-how-mexico-city-might-have-looked
+*/
+app.get(
+	'/AppsArticle',
+	express.raw(),
+	(req, res, next) => {
+		const urlQueryParam = req.query.url?.toString();
+		if (!urlQueryParam) {
+			return res.status(404).send('Missing url query parameter');
+		}
+
+		const articleId = new URL(urlQueryParam).pathname;
+		req.params = {
+			0: articleId,
+		};
+
+		next();
+	},
+	serveArticleGet,
+);
+
 app.get(
 	'/:edition(uk|us|au|europe|international)?/rendered-items/*',
 	express.raw(),

--- a/apps-rendering/src/server/server.ts
+++ b/apps-rendering/src/server/server.ts
@@ -422,7 +422,7 @@ app.get('/fontSize.css', (_, res) => res.status(404).end());
 To enable testing in the mobile device emulators,
 this route handler adds compatability with DCR's route for apps articles.
 The DCR route follows the pattern:
-/AppsArticle?url=https://www.theguardian.com/cities/2019/sep/13/reclaimed-lakes-and-giant-airports-how-mexico-city-might-have-looked
+/AppsArticle/https://www.theguardian.com/cities/2019/sep/13/reclaimed-lakes-and-giant-airports-how-mexico-city-might-have-looked
 */
 app.get(
 	'/AppsArticle/*',

--- a/apps-rendering/src/server/server.ts
+++ b/apps-rendering/src/server/server.ts
@@ -458,6 +458,6 @@ app.listen(port, () => {
 	if (process.env.NODE_ENV === 'production') {
 		logger.info(`Server listening on port ${port}!`);
 	} else {
-		logger.info(`Webpack dev server is listening on port 8080`);
+		logger.info(`Webpack dev server is listening on port 3030`);
 	}
 });

--- a/apps-rendering/webpack.config.ts
+++ b/apps-rendering/webpack.config.ts
@@ -162,6 +162,7 @@ export const clientConfig: Configuration = {
 		devMiddleware: {
 			publicPath: '/assets/',
 		},
+		port: process.env.PORT ?? 8080,
 		proxy: {
 			'**': 'http://localhost:3040',
 		},

--- a/apps-rendering/webpack.config.ts
+++ b/apps-rendering/webpack.config.ts
@@ -162,7 +162,7 @@ export const clientConfig: Configuration = {
 		devMiddleware: {
 			publicPath: '/assets/',
 		},
-		port: process.env.PORT ?? 8080,
+		port: 3030,
 		proxy: {
 			'**': 'http://localhost:3040',
 		},


### PR DESCRIPTION
## What does this change?

This change makes it easier to test an article rendered by DCR or AR in the mobile device simulators by supporting the DCR apps path (`/AppsArticle/https://www.theguardian.com/...`) in AR, related to #7067 

### Before this change

For a given article: https://www.theguardian.com/food/2020/mar/15/easter-taste-test-dan-lepard-hot-cross-bun-milk-dark-chocolate-mini-eggs-bunny-sloth

- The Android device simulator fetched a locally rendered article from `http://local-ip:3040/food/2020/mar/15/easter-taste-test-dan-lepard-hot-cross-bun-milk-dark-chocolate-mini-eggs-bunny-sloth` 
  - this contains a small bug. Although the `express` server is [running on port `3040`](https://github.com/guardian/dotcom-rendering/blob/main/apps-rendering/src/server/server.ts#L436), Webpack's dev server is running on the default port `8080` which [proxies to the express server](https://github.com/guardian/dotcom-rendering/blob/main/apps-rendering/webpack.config.ts#L166) on port `3040`. Bypassing the webpack dev server by directly making requests to the `express` server on port `3040` meant that assets (like the client bundle) did not load correctly
- The iOS device simulator fetched a locally rendered article from `http://localhost:8080/food/2020/mar/15/easter-taste-test-dan-lepard-hot-cross-bun-milk-dark-chocolate-mini-eggs-bunny-sloth`

### After this change

- Support DCR's apps article route (https://github.com/guardian/dotcom-rendering/pull/7228) in AR's server
- Set the default dev server port to `3030` to align with DCR's dev server
- Update the AR README to include details of the new route and default dev server port

There are two corresponding PRs to support this change in the apps:
- Android (https://github.com/guardian/android-news-app/pull/8433)
- iOS (https://github.com/guardian/ios-live/pull/6816)