### PR TITLE
refactor: one archive

### DIFF
--- a/.github/workflows/bundle-analyser.yml
+++ b/.github/workflows/bundle-analyser.yml
@@ -27,18 +27,18 @@ jobs:
       - name: Archive code coverage results for modern bundle
         uses: actions/upload-artifact@v3
         with:
-          name: bundle-analyser-report-modern
+          name: bundle-analyser-report
           path: dotcom-rendering/dist/stats/browser.modern-bundles.html
           if-no-files-found: error
       - name: Archive code coverage results for legacy bundle
         uses: actions/upload-artifact@v3
         with:
-          name: bundle-analyser-report-modern
+          name: bundle-analyser-report
           path: dotcom-rendering/dist/stats/browser.legacy-bundles.html
           if-no-files-found: error
       - name: Archive code coverage results for variant bundle
         uses: actions/upload-artifact@v3
         with:
-          name: bundle-analyser-report-variant
+          name: bundle-analyser-report
           path: dotcom-rendering/dist/stats/browser.variant-bundles.html
           if-no-files-found: warn # Variant bundle only exists when an active experiment is going on


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Share the artefact name between all bundle analyser outputs: `bundle-analyser-report`.

## Why?

When artifacts share the same name, they will form an archive containing all folders.

This is already what is happening for the the modern and legacy bundles.

## Screenshots

| before  | after  |
|---------|--------|
|![before]|![after]|

[before]: https://user-images.githubusercontent.com/76776/220392281-134c6ac6-23c5-40af-8142-80987d041200.png

[after]: https://user-images.githubusercontent.com/76776/220395124-246bab18-970d-4a5c-b8b5-6f1984f36835.png
