### PR TITLE
Fix the Island report card input location

### DIFF
--- a/dotcom-rendering/scripts/islands/island-descriptions.mjs
+++ b/dotcom-rendering/scripts/islands/island-descriptions.mjs
@@ -43,7 +43,7 @@ const chunk = zod.object({
 
 /** Sorted by gzipSize */
 const getBundleReport = () =>
-	readFile(resolve(dir, '/browser.modern-bundles.json'), 'utf-8')
+	readFile(resolve(dir, 'browser.modern-bundles.json'), 'utf-8')
 		.then((bundle_data) => zod.array(chunk).parse(JSON.parse(bundle_data)))
 		.then((report) => report.sort((a, b) => b.gzipSize - a.gzipSize));
 
@@ -172,10 +172,10 @@ const generateIslandDescriptions = async () => {
 		await writeFile(resolve(dir, 'islands.html'), html);
 
 		console.info('Succesfully generated Island report card:');
-		console.info('dist/islands.html');
+		console.info(dir + '/islands.html');
 	} catch (err) {
 		console.error('Failed to produce the Island description page');
-		console.error(err);
+		throw err;
 	}
 };
 


### PR DESCRIPTION

<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Third time’s the charm! #7201 

## Why?

The modern bundle report’s JSON could not be found.