### PR TITLE
fix(TopicFilterBank): correct link logic

### DIFF
--- a/dotcom-rendering/src/web/components/TopicFilterBank.tsx
+++ b/dotcom-rendering/src/web/components/TopicFilterBank.tsx
@@ -42,15 +42,16 @@ const topicStyles = css`
 `;
 
 const getTopicLink = (isActive: boolean, topics: string, id: Props['id']) => {
-	const urlParams = new URLSearchParams(
-		isActive
-			? {
-					topics,
-			  }
-			: {},
-	);
+	const urlParams = isActive
+		? // if active, the button links to the the page without the params
+		  ''
+		: // we only add the link if the topic is *inactive*
+		  '?' +
+		  new URLSearchParams({
+				topics,
+		  }).toString();
 
-	return `?${urlParams.toString()}#${id}`;
+	return `${urlParams}#${id}`;
 };
 
 const getKeyEventLink = (filterKeyEvents: boolean, id: Props['id']) => {


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Fix the `TopicFilterBank` logic.

## Why?

- if the link is already active, the button links to the page without the topic.
- if the link is inactive, the button links to the page with the topic added as a query

Follow-up on #7173 

## Screenshots

<img width="203" alt="image" src="https://user-images.githubusercontent.com/76776/220594136-e4d209da-6cbe-43f0-867c-f2ffa173f55f.png">
