### PR TITLE
Special Report Alt: Dateline

### DIFF
--- a/apps-rendering/src/components/Dateline/index.tsx
+++ b/apps-rendering/src/components/Dateline/index.tsx
@@ -3,15 +3,16 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import type { Edition } from '@guardian/apps-rendering-api-models/edition';
-import { ArticleDesign, ArticlePillar } from '@guardian/libs';
+import { ArticleDesign } from '@guardian/libs';
 import type { ArticleFormat } from '@guardian/libs';
-import { from, neutral, text, textSans } from '@guardian/source-foundations';
+import { from, neutral, textSans } from '@guardian/source-foundations';
 import { map, withDefault } from '@guardian/types';
 import type { Option } from '@guardian/types';
 import { datetimeFormat } from 'datetime';
 import { pipe } from 'lib';
 import type { FC, ReactElement } from 'react';
-import { darkModeCss as darkMode } from 'styles';
+import { darkModeCss } from 'styles';
+import { text } from 'palette';
 
 // ----- Component ----- //
 
@@ -21,22 +22,13 @@ interface Props {
 	edition: Edition;
 }
 
-const darkStyles = darkMode`
-    color: ${neutral[60]};
-`;
-
-const defaultStyles = css`
+const defaultStyles = (format: ArticleFormat): SerializedStyles => css`
 	${textSans.xsmall()}
-	color: ${text.supporting};
+	color: ${text.dateline(format)};
 
-	${darkStyles}
-`;
-
-const commentDatelineStyles = css`
-	${textSans.xsmall()}
-	color: ${neutral[20]};
-
-	${darkStyles}
+	${darkModeCss`
+		color: ${text.datelineDark(format)};
+	`}
 `;
 
 const getStyles = (
@@ -51,7 +43,7 @@ const getStyles = (
 		color: ${desktopColour};
 	}
 
-	${darkMode`
+	${darkModeCss`
     	color: ${neutral[93]};
 		${from.desktop} {
 			color: ${neutral[60]};
@@ -68,12 +60,7 @@ const getDatelineStyles = (format: ArticleFormat): SerializedStyles => {
 		case ArticleDesign.DeadBlog:
 			return getStyles(neutral[20], neutral[20]);
 		default:
-			switch (format.theme) {
-				case ArticlePillar.Opinion:
-					return commentDatelineStyles;
-				default:
-					return defaultStyles;
-			}
+			return defaultStyles(format);
 	}
 };
 

--- a/apps-rendering/src/components/Dateline/index.tsx
+++ b/apps-rendering/src/components/Dateline/index.tsx
@@ -10,9 +10,9 @@ import { map, withDefault } from '@guardian/types';
 import type { Option } from '@guardian/types';
 import { datetimeFormat } from 'datetime';
 import { pipe } from 'lib';
+import { text } from 'palette';
 import type { FC, ReactElement } from 'react';
 import { darkModeCss } from 'styles';
-import { text } from 'palette';
 
 // ----- Component ----- //
 

--- a/apps-rendering/src/palette/text.ts
+++ b/apps-rendering/src/palette/text.ts
@@ -1697,6 +1697,63 @@ const headingTwoDark = (_format: ArticleFormat): string => {
 	return neutral[86];
 };
 
+const dateline = ({ design, theme }: ArticleFormat): string => {
+	switch (design) {
+		case ArticleDesign.Comment:
+		case ArticleDesign.Editorial:
+		case ArticleDesign.Letter:
+			switch (theme) {
+				case ArticleSpecial.SpecialReportAlt:
+					return palette.specialReportAlt[100];
+				default:
+					return neutral[20];
+			}
+		case ArticleDesign.Analysis:
+		case ArticleDesign.Explainer:
+		case ArticleDesign.Feature:
+		case ArticleDesign.FullPageInteractive:
+		case ArticleDesign.Interactive:
+		case ArticleDesign.Interview:
+		case ArticleDesign.NewsletterSignup:
+		case ArticleDesign.PhotoEssay:
+		case ArticleDesign.Review:
+		case ArticleDesign.Standard:
+			switch (theme) {
+				case ArticleSpecial.SpecialReportAlt:
+					return palette.specialReportAlt[100];
+				default:
+					return neutral[46];
+			}
+		default:
+			return neutral[46];
+	}
+}
+
+const datelineDark = ({ design, theme }: ArticleFormat): string => {
+	switch (design) {
+		case ArticleDesign.Standard:
+		case ArticleDesign.Review:
+		case ArticleDesign.Explainer:
+		case ArticleDesign.Feature:
+		case ArticleDesign.Interview:
+		case ArticleDesign.Interactive:
+		case ArticleDesign.PhotoEssay:
+		case ArticleDesign.FullPageInteractive:
+		case ArticleDesign.NewsletterSignup:
+		case ArticleDesign.Comment:
+		case ArticleDesign.Letter:
+		case ArticleDesign.Editorial:
+			switch (theme) {
+				case ArticleSpecial.SpecialReportAlt:
+					return neutral[93];
+				default:
+					return neutral[60];
+			}
+		default:
+			return neutral[60];
+	}
+}
+
 // ----- API ----- //
 
 const text = {
@@ -1717,6 +1774,8 @@ const text = {
 	commentCount,
 	commentCountDark,
 	commentCountWide,
+	dateline,
+	datelineDark,
 	dropCap,
 	dropCapDark,
 	figCaption,

--- a/apps-rendering/src/palette/text.ts
+++ b/apps-rendering/src/palette/text.ts
@@ -1727,7 +1727,7 @@ const dateline = ({ design, theme }: ArticleFormat): string => {
 		default:
 			return neutral[46];
 	}
-}
+};
 
 const datelineDark = ({ design, theme }: ArticleFormat): string => {
 	switch (design) {
@@ -1752,7 +1752,7 @@ const datelineDark = ({ design, theme }: ArticleFormat): string => {
 		default:
 			return neutral[60];
 	}
-}
+};
 
 // ----- API ----- //
 


### PR DESCRIPTION
## Why?

Building out the special report alt designs in AR, as covered in #6203. I've broken this up into stages to make the PRs easier to review. This PR deals with the dateline.

**Note:** The screenshots below show the final result of all changes, some of which aren't included in this PR.

## Changes

- Updated the `dateline` colours in light and dark mode
- Refactored the `Dateline` component to simplify and use the palette

## Screenshots

| | Light | Dark |
| - | - | - |
| Standard | ![dateline-standard-light] | ![dateline-standard-dark] |
| Analysis | ![dateline-analysis-light] | ![dateline-analysis-dark] |

[dateline-standard-dark]: https://user-images.githubusercontent.com/53781962/220355241-79834c1b-9b72-4925-a692-4407ba743f24.jpg
[dateline-standard-light]: https://user-images.githubusercontent.com/53781962/220355243-fc30f957-59af-4300-9073-474efcb43ab2.jpg
[dateline-analysis-dark]: https://user-images.githubusercontent.com/53781962/220604679-957d3e43-ec1b-4cd5-8fd6-a3f3503bb841.jpg
[dateline-analysis-light]: https://user-images.githubusercontent.com/53781962/220604683-0a67d7a9-77cb-4a61-b8b4-283ebd544066.jpg
