### PR TITLE
Update font-family and font-size

### DIFF
--- a/dotcom-rendering/src/web/components/TrendingTopics.tsx
+++ b/dotcom-rendering/src/web/components/TrendingTopics.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { neutral } from '@guardian/source-foundations';
+import { neutral, textSans } from '@guardian/source-foundations';
 import { StraightLines } from '@guardian/source-react-components-development-kitchen';
 import type { FETagType } from '../../types/tag';
 
@@ -8,16 +8,12 @@ type Props = {
 };
 
 const linkStyle = css`
-	font-family: 'Guardian Text Sans Web', 'Helvetica Neue', Helvetica, Arial,
-		'Lucida Grande', sans-serif;
+	${textSans.xsmall({ lineHeight: 'loose' })}
 	text-decoration: none;
-	font-size: 14px;
 	top: 0;
-	line-height: 14px;
 	color: ${neutral[7]};
 	&:after {
 		color: ${neutral[86]};
-		font-size: 16px;
 		pointer-events: none;
 		margin: 2.56px;
 		content: '/';
@@ -30,8 +26,7 @@ const linkStyle = css`
 `;
 
 const topicLabel = css`
-	font-size: 13.6px;
-	line-height: 22px;
+	${textSans.xxsmall({ lineHeight: 'regular' })}
 	color: ${neutral[60]};
 `;
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Updates the font-family and font-size
## Why?
Parity with frontend
## Screenshots

| Frontend    | DCR (this pr)      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/110032454/220626039-eb80b5f5-e748-454b-8829-850cc904d15b.png
[after]: https://user-images.githubusercontent.com/110032454/220625980-77dfb008-4e26-4ded-bdd0-0ac961981d1f.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->


<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
