### PR TITLE
feat(Metrics): near-zero sampling

### DIFF
--- a/dotcom-rendering/src/web/components/Metrics.importable.tsx
+++ b/dotcom-rendering/src/web/components/Metrics.importable.tsx
@@ -66,11 +66,17 @@ export const Metrics = ({ commercialMetricsEnabled }: Props) => {
 				? shouldBypassSampling(abTestApi)
 				: false;
 
+			/**
+			 * We rely on `bypassSampling` rather than the built-in sampling,
+			 * but set the value to greater than 0 to avoid console warnings.
+			 */
+			const nearZeroSampling = Number.MIN_VALUE;
+
 			void initCoreWebVitals({
 				browserId,
 				pageViewId,
 				isDev,
-				sampling: 0, // we rely on `bypassSampling` instead
+				sampling: nearZeroSampling,
 				team: 'dotcom',
 			});
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Set the sampling to the lowest value above 0.

## Why?

So we stop getting console warnings about the sampling:

“Core Web Vitals are sampled at 0%”

Raised by @jon-kearnesLC 

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/76776/220618818-90ada884-64f0-4db6-9f10-a72387477187.png
[after]: https://user-images.githubusercontent.com/76776/220618680-3096cb32-2670-44c1-9504-a97b91ae8afc.png