### PR TITLE
Special Report Alt: Avatar And Follow

### DIFF
--- a/apps-rendering/src/palette/background.ts
+++ b/apps-rendering/src/palette/background.ts
@@ -519,24 +519,58 @@ const articleContentDark = ({ design, theme }: ArticleFormat): Colour => {
 	}
 };
 
-const avatar = (format: ArticleFormat): string => {
-	switch (format.theme) {
-		case ArticleSpecial.SpecialReport:
-			return specialReport[800];
-		case ArticleSpecial.SpecialReportAlt:
-			return news[500];
-		case ArticleSpecial.Labs:
-			return labs[400];
-		case ArticlePillar.Opinion:
-			return opinion[300];
-		case ArticlePillar.Culture:
-			return culture[500];
-		case ArticlePillar.Lifestyle:
-			return lifestyle[500];
-		case ArticlePillar.Sport:
-			return sport[500];
-		case ArticlePillar.News:
-			return news[500];
+const avatar = ({ design, theme }: ArticleFormat): string => {
+	switch (design) {
+		case ArticleDesign.Standard:
+		case ArticleDesign.Review:
+		case ArticleDesign.Explainer:
+		case ArticleDesign.Feature:
+		case ArticleDesign.Interview:
+		case ArticleDesign.Interactive:
+		case ArticleDesign.PhotoEssay:
+		case ArticleDesign.FullPageInteractive:
+		case ArticleDesign.NewsletterSignup:
+		case ArticleDesign.Comment:
+		case ArticleDesign.Letter:
+		case ArticleDesign.Editorial:
+		case ArticleDesign.Analysis:
+			switch (theme) {
+				case ArticleSpecial.SpecialReport:
+					return specialReport[800];
+				case ArticleSpecial.SpecialReportAlt:
+					return palette.specialReportAlt[700];
+				case ArticleSpecial.Labs:
+					return labs[400];
+				case ArticlePillar.Opinion:
+					return opinion[300];
+				case ArticlePillar.Culture:
+					return culture[500];
+				case ArticlePillar.Lifestyle:
+					return lifestyle[500];
+				case ArticlePillar.Sport:
+					return sport[500];
+				case ArticlePillar.News:
+					return news[500];
+			}
+		default:
+			switch (theme) {
+				case ArticleSpecial.SpecialReport:
+					return specialReport[800];
+				case ArticleSpecial.SpecialReportAlt:
+					return news[500];
+				case ArticleSpecial.Labs:
+					return labs[400];
+				case ArticlePillar.Opinion:
+					return opinion[300];
+				case ArticlePillar.Culture:
+					return culture[500];
+				case ArticlePillar.Lifestyle:
+					return lifestyle[500];
+				case ArticlePillar.Sport:
+					return sport[500];
+				case ArticlePillar.News:
+					return news[500];
+			}
 	}
 };
 
@@ -554,14 +588,13 @@ const avatarDark = ({ design, theme }: ArticleFormat): Colour => {
 		case ArticleDesign.Comment:
 		case ArticleDesign.Letter:
 		case ArticleDesign.Editorial:
-		case ArticleDesign.Analysis: {
+		case ArticleDesign.Analysis:
 			switch (theme) {
 				case ArticleSpecial.SpecialReportAlt:
 					return neutral[46];
 				default:
 					return neutral[20];
 			}
-		}
 		default:
 			return neutral[20];
 	}

--- a/apps-rendering/src/palette/text.ts
+++ b/apps-rendering/src/palette/text.ts
@@ -707,33 +707,81 @@ const designTagDark = ({ design, theme }: ArticleFormat): Colour => {
 	}
 };
 
-const follow = (format: ArticleFormat): Colour => {
-	if (format.design === ArticleDesign.Gallery) {
-		return neutral[86];
-	}
-
-	switch (format.theme) {
-		case ArticlePillar.News:
-			switch (format.design) {
-				case ArticleDesign.Analysis:
+const follow = ({ design, theme }: ArticleFormat): Colour => {
+	switch (design) {
+		case ArticleDesign.Gallery:
+			return neutral[86];
+		case ArticleDesign.Analysis: {
+			switch (theme) {
+				case ArticlePillar.News:
 					return news[300];
-				default:
+				case ArticlePillar.Lifestyle:
+					return lifestyle[300];
+				case ArticlePillar.Sport:
+					return sport[300];
+				case ArticlePillar.Culture:
+					return culture[300];
+				case ArticlePillar.Opinion:
+					return opinion[200];
+				case ArticleSpecial.Labs:
+					return labs[300];
+				case ArticleSpecial.SpecialReport:
+					return specialReport[300];
+				case ArticleSpecial.SpecialReportAlt:
+					return palette.specialReportAlt[100];
+			}
+		}
+		case ArticleDesign.Comment:
+		case ArticleDesign.Editorial:
+		case ArticleDesign.Explainer:
+		case ArticleDesign.Feature:
+		case ArticleDesign.FullPageInteractive:
+		case ArticleDesign.Interactive:
+		case ArticleDesign.Interview:
+		case ArticleDesign.Letter:
+		case ArticleDesign.NewsletterSignup:
+		case ArticleDesign.PhotoEssay:
+		case ArticleDesign.Review:
+		case ArticleDesign.Standard: {
+			switch (theme) {
+				case ArticlePillar.News:
+					return news[400];
+				case ArticlePillar.Lifestyle:
+					return lifestyle[300];
+				case ArticlePillar.Sport:
+					return sport[300];
+				case ArticlePillar.Culture:
+					return culture[300];
+				case ArticlePillar.Opinion:
+					return opinion[200];
+				case ArticleSpecial.Labs:
+					return labs[300];
+				case ArticleSpecial.SpecialReport:
+					return specialReport[300];
+				case ArticleSpecial.SpecialReportAlt:
+					return palette.specialReportAlt[100];
+			}
+		}
+		default: {
+			switch (theme) {
+				case ArticlePillar.News:
+					return news[400];
+				case ArticlePillar.Lifestyle:
+					return lifestyle[300];
+				case ArticlePillar.Sport:
+					return sport[300];
+				case ArticlePillar.Culture:
+					return culture[300];
+				case ArticlePillar.Opinion:
+					return opinion[200];
+				case ArticleSpecial.Labs:
+					return labs[300];
+				case ArticleSpecial.SpecialReport:
+					return specialReport[300];
+				case ArticleSpecial.SpecialReportAlt:
 					return news[400];
 			}
-		case ArticlePillar.Lifestyle:
-			return lifestyle[300];
-		case ArticlePillar.Sport:
-			return sport[300];
-		case ArticlePillar.Culture:
-			return culture[300];
-		case ArticlePillar.Opinion:
-			return opinion[200];
-		case ArticleSpecial.Labs:
-			return labs[300];
-		case ArticleSpecial.SpecialReport:
-			return specialReport[300];
-		case ArticleSpecial.SpecialReportAlt:
-			return news[400];
+		}
 	}
 };
 
@@ -744,6 +792,55 @@ const followDark = (format: ArticleFormat): Colour => {
 			return neutral[100];
 		case ArticleDesign.Gallery:
 			return neutral[86];
+		case ArticleDesign.Analysis:
+			switch (format.theme) {
+				case ArticlePillar.News:
+					return news[500];
+				case ArticlePillar.Lifestyle:
+					return lifestyle[500];
+				case ArticlePillar.Sport:
+					return sport[500];
+				case ArticlePillar.Culture:
+					return culture[500];
+				case ArticlePillar.Opinion:
+					return opinion[500];
+				case ArticleSpecial.Labs:
+					return specialReport[500];
+				case ArticleSpecial.SpecialReport:
+					return specialReport[500];
+				case ArticleSpecial.SpecialReportAlt:
+					return neutral[60];
+			}
+		case ArticleDesign.Standard:
+		case ArticleDesign.Review:
+		case ArticleDesign.Explainer:
+		case ArticleDesign.Feature:
+		case ArticleDesign.Interview:
+		case ArticleDesign.Interactive:
+		case ArticleDesign.PhotoEssay:
+		case ArticleDesign.FullPageInteractive:
+		case ArticleDesign.NewsletterSignup:
+		case ArticleDesign.Comment:
+		case ArticleDesign.Letter:
+		case ArticleDesign.Editorial:
+			switch (format.theme) {
+				case ArticlePillar.News:
+					return news[500];
+				case ArticlePillar.Lifestyle:
+					return lifestyle[500];
+				case ArticlePillar.Sport:
+					return sport[500];
+				case ArticlePillar.Culture:
+					return culture[500];
+				case ArticlePillar.Opinion:
+					return opinion[500];
+				case ArticleSpecial.Labs:
+					return specialReport[500];
+				case ArticleSpecial.SpecialReport:
+					return specialReport[500];
+				case ArticleSpecial.SpecialReportAlt:
+					return palette.specialReportAlt[700];
+			}
 		default:
 			switch (format.theme) {
 				case ArticlePillar.News:


### PR DESCRIPTION
## Why?

Building out the special report alt designs in AR, as covered in #6203. I've broken this up into stages to make the PRs easier to review. This PR deals with the avatar image and follow button.

**Note:** The screenshots below show the final result of all changes, some of which aren't included in this PR.

## Changes

- Updated the `avatar` colours in light and dark mode
- Updated the `follow` colours in light and dark mode

## Screenshots

| | Light | Dark |
| - | - | - |
| Standard | ![dateline-standard-light] | ![dateline-standard-dark] |
| Analysis | ![dateline-analysis-light] | ![dateline-analysis-dark] |

[dateline-standard-dark]: https://user-images.githubusercontent.com/53781962/220355241-79834c1b-9b72-4925-a692-4407ba743f24.jpg
[dateline-standard-light]: https://user-images.githubusercontent.com/53781962/220355243-fc30f957-59af-4300-9073-474efcb43ab2.jpg
[dateline-analysis-dark]: https://user-images.githubusercontent.com/53781962/220604679-957d3e43-ec1b-4cd5-8fd6-a3f3503bb841.jpg
[dateline-analysis-light]: https://user-images.githubusercontent.com/53781962/220604683-0a67d7a9-77cb-4a61-b8b4-283ebd544066.jpg
