### PR TITLE
Special Report Alt: Links

### DIFF
--- a/apps-rendering/src/fixtures/item.ts
+++ b/apps-rendering/src/fixtures/item.ts
@@ -101,8 +101,8 @@ const docFixture = (): Node => {
 
 	const el = document.createElement('p');
 
-	el.innerText =
-		'Readers of Prospect magazine recently voted him the world’s fourth-best thinker. And right now he is thinking about 3 November, and whether the United States will reject or endorse Donald Trump. No one knows what will happen; not even West, not least because in the US he sees contradictions that even he can’t fully explain.';
+	el.innerHTML =
+		'Readers of Prospect magazine recently voted him the world’s fourth-best thinker. And right now he is <a href="https://www.theguardian.com">thinking</a> about 3 November, and whether the United States will reject or endorse Donald Trump. No one knows what will happen; not even West, not least because in the US he sees contradictions that even he can’t fully explain.';
 
 	doc.appendChild(el);
 

--- a/apps-rendering/src/palette/text.ts
+++ b/apps-rendering/src/palette/text.ts
@@ -789,24 +789,58 @@ const bylineDark = ({ design, theme }: ArticleFormat): Colour => {
 	}
 };
 
-const linkDark = (format: ArticleFormat): Colour => {
-	switch (format.theme) {
-		case ArticlePillar.News:
-			return news[500];
-		case ArticlePillar.Lifestyle:
-			return lifestyle[500];
-		case ArticlePillar.Sport:
-			return sport[500];
-		case ArticlePillar.Culture:
-			return culture[500];
-		case ArticlePillar.Opinion:
-			return opinion[500];
-		case ArticleSpecial.Labs:
-			return specialReport[500];
-		case ArticleSpecial.SpecialReport:
-			return specialReport[500];
-		case ArticleSpecial.SpecialReportAlt:
-			return news[500];
+const linkDark = ({ design, theme }: ArticleFormat): Colour => {
+	switch (design) {
+		case ArticleDesign.Standard:
+		case ArticleDesign.Review:
+		case ArticleDesign.Explainer:
+		case ArticleDesign.Feature:
+		case ArticleDesign.Interview:
+		case ArticleDesign.Interactive:
+		case ArticleDesign.PhotoEssay:
+		case ArticleDesign.FullPageInteractive:
+		case ArticleDesign.NewsletterSignup:
+		case ArticleDesign.Comment:
+		case ArticleDesign.Letter:
+		case ArticleDesign.Editorial:
+		case ArticleDesign.Analysis:
+			switch (theme) {
+				case ArticlePillar.News:
+					return news[500];
+				case ArticlePillar.Lifestyle:
+					return lifestyle[500];
+				case ArticlePillar.Sport:
+					return sport[500];
+				case ArticlePillar.Culture:
+					return culture[500];
+				case ArticlePillar.Opinion:
+					return opinion[500];
+				case ArticleSpecial.Labs:
+					return specialReport[500];
+				case ArticleSpecial.SpecialReport:
+					return specialReport[500];
+				case ArticleSpecial.SpecialReportAlt:
+					return palette.specialReportAlt[700];
+			}
+		default:
+			switch (theme) {
+				case ArticlePillar.News:
+					return news[500];
+				case ArticlePillar.Lifestyle:
+					return lifestyle[500];
+				case ArticlePillar.Sport:
+					return sport[500];
+				case ArticlePillar.Culture:
+					return culture[500];
+				case ArticlePillar.Opinion:
+					return opinion[500];
+				case ArticleSpecial.Labs:
+					return specialReport[500];
+				case ArticleSpecial.SpecialReport:
+					return specialReport[500];
+				case ArticleSpecial.SpecialReportAlt:
+					return news[500];
+			}
 	}
 };
 
@@ -834,6 +868,37 @@ const articleLink = (format: ArticleFormat): Colour => {
 			}
 		case ArticleDesign.Gallery:
 			return neutral[86];
+		case ArticleDesign.Analysis:
+		case ArticleDesign.Comment:
+		case ArticleDesign.Editorial:
+		case ArticleDesign.Explainer:
+		case ArticleDesign.Feature:
+		case ArticleDesign.FullPageInteractive:
+		case ArticleDesign.Interactive:
+		case ArticleDesign.Interview:
+		case ArticleDesign.Letter:
+		case ArticleDesign.NewsletterSignup:
+		case ArticleDesign.PhotoEssay:
+		case ArticleDesign.Review:
+		case ArticleDesign.Standard:
+			switch (format.theme) {
+				case ArticlePillar.News:
+					return news[300];
+				case ArticlePillar.Lifestyle:
+					return lifestyle[300];
+				case ArticlePillar.Sport:
+					return sport[300];
+				case ArticlePillar.Culture:
+					return culture[300];
+				case ArticlePillar.Opinion:
+					return opinion[300];
+				case ArticleSpecial.Labs:
+					return specialReport[300];
+				case ArticleSpecial.SpecialReport:
+					return specialReport[300];
+				case ArticleSpecial.SpecialReportAlt:
+					return palette.specialReportAlt[200];
+			}
 		default:
 			switch (format.theme) {
 				case ArticlePillar.News:


### PR DESCRIPTION
## Why?

Building out the special report alt designs in AR, as covered in #6203. I've broken this up into stages to make the PRs easier to review. This PR deals with links.

**Note:** The screenshots below show the final result of all changes, some of which aren't included in this PR.

## Changes

- Updated the link colours in light and dark mode
- Added link to fixture body text

## Screenshots

| Light | Dark |
| - | - |
| ![link-light] | ![link-dark] |

[link-dark]: https://user-images.githubusercontent.com/53781962/220625631-c4e46c6e-b6dd-45f5-92f0-53800c65c97f.jpg
[link-light]: https://user-images.githubusercontent.com/53781962/220625637-7ec73c2e-792c-4341-b3ec-929d38b12918.jpg
