### PR TITLE
Fix Horizontal Scrolling On Galleries

### DIFF
--- a/apps-rendering/src/components/Footer/GalleryFooter.tsx
+++ b/apps-rendering/src/components/Footer/GalleryFooter.tsx
@@ -67,6 +67,11 @@ const footerStyles = (format: ArticleFormat): SerializedStyles => css`
 		${grid.between('centre-column-start', 'right-column-end')}
 	}
 
+	${from.wide} {
+		margin: 0;
+		width: unset;
+	}
+
 	${darkModeCss`
 		background-color: ${background.articleContentDark(format)};
 		color: ${text.galleryDark(format)};

--- a/apps-rendering/src/components/RelatedContent/GalleryRelatedContent.tsx
+++ b/apps-rendering/src/components/RelatedContent/GalleryRelatedContent.tsx
@@ -62,15 +62,15 @@ const headingStyles = (format: ArticleFormat): SerializedStyles => css`
 		${grid.column.left}
 		position: relative;
 		grid-row: 1;
-	}
 
-	&::after {
-		content: '';
-		position: absolute;
-		top: 0;
-		bottom: 0;
-		border-left: 1px solid ${neutral[86]};
-		right: -10px;
+		&::after {
+			content: '';
+			position: absolute;
+			top: 0;
+			bottom: 0;
+			border-left: 1px solid ${neutral[86]};
+			right: -10px;
+		}
 	}
 
 	${darkModeCss`


### PR DESCRIPTION
## Why?

Fixes two horizontal scrolling bugs on galleries (i.e. a problem where the page is wider than the viewport, causing horizontal scrollbars):

1. On breakpoints lower than `leftCol`, as reported by @mxdvl . This was caused by an `after` element being present on all breakpoints, when it was only needed from `leftCol`.
2. On the `wide` breakpoint. This was caused by the footer having a large fixed width (1300px).

## Changes

- Made sure the `after` element only appears from `leftCol`
- Removed the fixed width and corresponding margins for footers on galleries
