### PR TITLE
exclude the editions chunk from the generated static assets file

### DIFF
--- a/apps-rendering/webpack.config.ts
+++ b/apps-rendering/webpack.config.ts
@@ -217,6 +217,7 @@ const clientConfigProduction = {
 	plugins: [
 		new WebpackManifestPlugin({}),
 		new HtmlWebpackPlugin({
+			excludeChunks: ['editions'],
 			meta: {
 				'Content-Security-Policy': {
 					'http-equiv': 'Content-Security-Policy',


### PR DESCRIPTION

## What does this change?

- Excludes the `editions` chunk from the generated static assets file, because the Editions app does not use this mechanism for caching. The iOS app does use this mechanism for caching, but it does not need to cache the editions chunk