### PR TITLE
Distinguish `collectionId` from `containerId` in `ShowMore.importable`

### DIFF
--- a/dotcom-rendering/src/web/components/ShowMore.stories.tsx
+++ b/dotcom-rendering/src/web/components/ShowMore.stories.tsx
@@ -14,8 +14,18 @@ const play = ({ canvasElement }: { canvasElement: HTMLElement }) => {
 
 const containerTitle = 'Opinion';
 const path = 'uk/lifestyle';
-const containerId = '5011-3940-8793-33a9';
+const collectionId = '5011-3940-8793-33a9';
 const baseUrl = 'https://api.nextgen.guardianapps.co.uk';
+const containerElementId = 'container-id';
+
+const defaultProps = {
+	containerTitle,
+	baseUrl,
+	path,
+	collectionId,
+	containerElementId,
+	showAge: false,
+};
 
 export default {
 	component: ShowMore,
@@ -25,18 +35,12 @@ export default {
 export const ShowMoreSuccess = () => {
 	fetchMock
 		.restore()
-		.get(`${baseUrl}/${path}/show-more/${containerId}.json?dcr=true`, {
+		.get(`${baseUrl}/${path}/show-more/${collectionId}.json?dcr=true`, {
 			status: 200,
 			body: trails.slice(0, 6),
 		});
 
-	return ShowMore({
-		containerTitle,
-		path,
-		containerId,
-		showAge: false,
-		baseUrl,
-	});
+	return ShowMore(defaultProps);
 };
 
 ShowMoreSuccess.play = play;
@@ -45,18 +49,12 @@ ShowMoreSuccess.story = { name: 'ShowMore button, success' };
 export const ShowMoreError = () => {
 	fetchMock
 		.restore()
-		.get(`${baseUrl}/${path}/show-more/${containerId}.json?dcr`, {
+		.get(`${baseUrl}/${path}/show-more/${collectionId}.json?dcr`, {
 			status: 404,
 			body: null,
 		});
 
-	return ShowMore({
-		containerTitle,
-		path,
-		containerId,
-		showAge: false,
-		baseUrl,
-	});
+	return ShowMore(defaultProps);
 };
 
 ShowMoreError.play = play;

--- a/dotcom-rendering/src/web/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FrontLayout.tsx
@@ -414,7 +414,8 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 											containerTitle={
 												collection.displayName
 											}
-											containerId={ophanName}
+											collectionId={collection.id}
+											containerElementId={ophanName}
 											path={front.pressedPage.id}
 											baseUrl={front.config.ajaxUrl}
 											containerPalette={


### PR DESCRIPTION
## What's changed? 

- Rename the `containerId` prop to `collectionId`.
- Add a new prop, `containerElementId`.
- Update usages of the `ShowMore.importable` component accordingly.
- Add documentation of these properties.
- Pass-by refactor of the story -- having more props now makes it harder to confirm visually that the two stories are using the same props.

Previously, `containerId` was being used for two purposes:

1. to build the URL for the `show-more/` API endpoint
2. to select the main container for the collection on the client side

## Why?

As of [#7108](https://github.com/guardian/dotcom-rendering/pull/7108) the container element's id is being set to the `ophanName`, meaning we couldn't use the same prop value for both of the above purposes, and the API call was failing because it was using the wrong id value. This PR distinguishes two separate props for the two roles, and documents the differences between them.

Closes #7288.

