### PR TITLE
set `lang` and `dir` attrs on showcase and full page interactive layouts

### DIFF
--- a/dotcom-rendering/src/web/components/ArticleBody.tsx
+++ b/dotcom-rendering/src/web/components/ArticleBody.tsx
@@ -13,6 +13,7 @@ import { revealStyles } from '../lib/revealStyles';
 import { Island } from './Island';
 import { RecipeMultiplier } from './RecipeMultiplier.importable';
 import { TableOfContents } from './TableOfContents.importable';
+import { decideLanguage, decideLanguageDirection } from '../lib/lang';
 
 type Props = {
 	format: ArticleFormat;
@@ -115,16 +116,6 @@ const globalLinkStyles = (palette: Palette) => css`
 
 const isRecipe = (tags: TagType[]): boolean =>
 	tags.some(({ id }) => id === 'tone/recipes');
-
-// CAPI only supports certain languages. If CAPI doesn't recognise the language,
-// it defaults to `en`. We should filter out `en` so we don't set an incorrect value.
-// See https://github.com/guardian/content-api/blob/main/porter/src/main/scala/com.gu.contentapi.porter/integration/LanguageDetector.scala#L17
-const decideLanguage = (language = ''): string | undefined =>
-	language != 'en' ? language : undefined;
-
-const decideLanguageDirection = (
-	isRightToLeftLang = false,
-): 'rtl' | undefined => (isRightToLeftLang ? 'rtl' : undefined);
 
 export const ArticleBody = ({
 	format,

--- a/dotcom-rendering/src/web/layouts/FullPageInteractiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FullPageInteractiveLayout.tsx
@@ -31,6 +31,7 @@ import { StickyBottomBanner } from '../components/StickyBottomBanner.importable'
 import { SubNav } from '../components/SubNav.importable';
 import { decidePalette } from '../lib/decidePalette';
 import { getZIndex } from '../lib/getZIndex';
+import { decideLanguage, decideLanguageDirection } from '../lib/lang';
 import { getCurrentPillar } from '../lib/layoutHelpers';
 import { renderElement } from '../lib/renderElement';
 import { interactiveGlobalStyles } from './lib/interactiveLegacyStyling';
@@ -326,7 +327,11 @@ export const FullPageInteractiveLayout = ({ article, NAV, format }: Props) => {
 				backgroundColour={palette.background.article}
 				element="main"
 			>
-				<article id="maincontent">
+				<article
+					id="maincontent"
+					lang={decideLanguage(article.lang)}
+					dir={decideLanguageDirection(article.isRightToLeftLang)}
+				>
 					<Renderer
 						format={format}
 						elements={

--- a/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
@@ -50,6 +50,7 @@ import { decidePalette } from '../lib/decidePalette';
 import { decideTrail } from '../lib/decideTrail';
 import { getCurrentPillar } from '../lib/layoutHelpers';
 import { BannerWrapper, SendToBack, Stuck } from './lib/stickiness';
+import { decideLanguage, decideLanguageDirection } from '../lib/lang';
 
 const ShowcaseGrid = ({ children }: { children: React.ReactNode }) => (
 	<div
@@ -414,7 +415,12 @@ export const ShowcaseLayout = ({ article, NAV, format }: Props) => {
 				</>
 			)}
 
-			<main data-layout="ShowcaseLayout" id="maincontent">
+			<main
+				data-layout="ShowcaseLayout"
+				id="maincontent"
+				lang={decideLanguage(article.lang)}
+				dir={decideLanguageDirection(article.isRightToLeftLang)}
+			>
 				<Section
 					fullWidth={true}
 					showTopBorder={false}

--- a/dotcom-rendering/src/web/lib/lang.test.ts
+++ b/dotcom-rendering/src/web/lib/lang.test.ts
@@ -1,0 +1,19 @@
+import { decideLanguage, decideLanguageDirection } from './lang';
+
+describe('decideLanguage', () => {
+	test('returns undefined if input is "en"', () => {
+		expect(decideLanguage('en')).toBe(undefined);
+	});
+
+	test('returns input if it is not "en"', () => {
+		expect(decideLanguage('at')).toBe('at');
+		expect(decideLanguage('fr')).toBe('fr');
+	});
+});
+
+describe('describeLanguageDirection', () => {
+	test('returns rtl if input is true', () => {
+		expect(decideLanguageDirection(true)).toBe('rtl');
+		expect(decideLanguageDirection(false)).toBe(undefined);
+	});
+});

--- a/dotcom-rendering/src/web/lib/lang.ts
+++ b/dotcom-rendering/src/web/lib/lang.ts
@@ -1,0 +1,9 @@
+// CAPI only supports certain languages. If CAPI doesn't recognise the language,
+// it defaults to `en`. We should filter out `en` so we don't set an incorrect value.
+// See https://github.com/guardian/content-api/blob/main/porter/src/main/scala/com.gu.contentapi.porter/integration/LanguageDetector.scala#L17
+export const decideLanguage = (language = ''): string | undefined =>
+	language != 'en' ? language : undefined;
+
+export const decideLanguageDirection = (
+	isRightToLeftLang = false,
+): 'rtl' | undefined => (isRightToLeftLang ? 'rtl' : undefined);


### PR DESCRIPTION
## What does this change?

- Moves the utility functions for language handling to their own module
- Adds some light testing
- Adds `lang` and `dir` attributes to `#maincontent` in Showcase layout and immersive interactive

## Why?

- the Showcase and Immersive Interactive layouts don't use the `ArticleBody` component, where `lang`/`dir` is also being set, so we need to add it to these layouts too