### PR TITLE
Add Ozone Prebid server to AMP

### DIFF
--- a/dotcom-rendering/src/amp/components/Ad.tsx
+++ b/dotcom-rendering/src/amp/components/Ad.tsx
@@ -53,6 +53,7 @@ interface CommercialConfig {
 }
 
 export interface BaseAdProps {
+	id: 'ad-sticky' | `ad-${number}`;
 	editionId: EditionId;
 	section: string;
 	contentType: string;
@@ -66,6 +67,7 @@ interface AdProps extends BaseAdProps {
 }
 
 export const Ad = ({
+	id,
 	editionId,
 	section,
 	contentType,
@@ -92,6 +94,7 @@ export const Ad = ({
 		useOzonePrebid,
 		usePermutive,
 		useAmazon,
+		id,
 		adType,
 	);
 

--- a/dotcom-rendering/src/amp/components/Ad.tsx
+++ b/dotcom-rendering/src/amp/components/Ad.tsx
@@ -47,6 +47,7 @@ const mapAdTargeting = (adTargeting: AdTargeting): AdTargetParam[] => {
 interface CommercialConfig {
 	usePubmaticPrebid: boolean;
 	useCriteoPrebid: boolean;
+	useOzonePrebid: boolean;
 	usePermutive: boolean;
 	useAmazon: boolean;
 }
@@ -70,7 +71,13 @@ export const Ad = ({
 	contentType,
 	commercialProperties,
 	adTargeting,
-	config: { useAmazon, usePubmaticPrebid, useCriteoPrebid, usePermutive },
+	config: {
+		useAmazon,
+		usePubmaticPrebid,
+		useCriteoPrebid,
+		useOzonePrebid,
+		usePermutive,
+	},
 	adType,
 }: AdProps) => {
 	const adSizes = adType.isSticky ? stickySizes : inlineSizes;
@@ -82,6 +89,7 @@ export const Ad = ({
 	const rtcConfig = realTimeConfig(
 		usePubmaticPrebid,
 		useCriteoPrebid,
+		useOzonePrebid,
 		usePermutive,
 		useAmazon,
 		adType,

--- a/dotcom-rendering/src/amp/components/Blocks.tsx
+++ b/dotcom-rendering/src/amp/components/Blocks.tsx
@@ -8,7 +8,7 @@ import { blockLink } from '../lib/block-link';
 import { findBlockAdSlots } from '../lib/find-adslots';
 import { isOnOzoneTestPage } from '../lib/real-time-config';
 import { Elements } from './Elements';
-import { RegionalAd } from './RegionalAd';
+import { InlineAd } from './InlineAd';
 
 const adStyle = css`
 	background: ${neutral[93]};
@@ -158,7 +158,7 @@ export const Blocks = ({
 								data-sort-time="1"
 								css={adStyle}
 							>
-								<RegionalAd
+								<InlineAd
 									editionId={editionId}
 									section={section ?? ''}
 									contentType={contentType}

--- a/dotcom-rendering/src/amp/components/Blocks.tsx
+++ b/dotcom-rendering/src/amp/components/Blocks.tsx
@@ -6,6 +6,7 @@ import type { Switches } from '../../types/config';
 import type { EditionId } from '../../web/lib/edition';
 import { blockLink } from '../lib/block-link';
 import { findBlockAdSlots } from '../lib/find-adslots';
+import { isOnOzoneTestPage } from '../lib/real-time-config';
 import { Elements } from './Elements';
 import { RegionalAd } from './RegionalAd';
 
@@ -131,6 +132,7 @@ export const Blocks = ({
 		switches: {
 			ampPrebidPubmatic: !!switches.ampPrebidPubmatic,
 			ampPrebidCriteo: !!switches.ampPrebidCriteo,
+			ampPrebidOzone: !!switches.ampPrebidOzone,
 			permutive: !!switches.permutive,
 			ampAmazon: !!switches.ampAmazon,
 		},
@@ -139,6 +141,8 @@ export const Blocks = ({
 	const adConfig = {
 		usePubmaticPrebid: adInfo.switches.ampPrebidPubmatic,
 		useCriteoPrebid: adInfo.switches.ampPrebidCriteo,
+		useOzonePrebid:
+			adInfo.switches.ampPrebidOzone && isOnOzoneTestPage(pageId),
 		usePermutive: adInfo.switches.permutive,
 		useAmazon: adInfo.switches.ampAmazon,
 	};

--- a/dotcom-rendering/src/amp/components/Blocks.tsx
+++ b/dotcom-rendering/src/amp/components/Blocks.tsx
@@ -150,15 +150,13 @@ export const Blocks = ({
 		<>
 			{liveBlogBlocks.map((item, i) => {
 				if (slotIndexes.includes(i)) {
+					const adSlotId = `ad-${i + 1}` as const;
 					return (
 						<>
 							{item}
-							<div
-								id={`ad-${i + 1}`}
-								data-sort-time="1"
-								css={adStyle}
-							>
+							<div id={adSlotId} data-sort-time="1" css={adStyle}>
 								<InlineAd
+									id={adSlotId}
 									editionId={editionId}
 									section={section ?? ''}
 									contentType={contentType}

--- a/dotcom-rendering/src/amp/components/BodyArticle.tsx
+++ b/dotcom-rendering/src/amp/components/BodyArticle.tsx
@@ -19,6 +19,7 @@ import type { ConfigType } from '../../types/config';
 import { decideDesign } from '../../web/lib/decideDesign';
 import { decideTheme } from '../../web/lib/decideTheme';
 import { findAdSlots } from '../lib/find-adslots';
+import { isOnOzoneTestPage } from '../lib/real-time-config';
 import type { ArticleModel } from '../types/ArticleModel';
 import { Elements } from './Elements';
 import { TextBlockComponent } from './elements/TextBlockComponent';
@@ -135,6 +136,7 @@ export const Body = ({ data, config }: Props) => {
 		switches: {
 			ampPrebidPubmatic: !!config.switches.ampPrebidPubmatic,
 			ampPrebidCriteo: !!config.switches.ampPrebidCriteo,
+			ampPrebidOzone: !!config.switches.ampPrebidOzone,
 			permutive: !!config.switches.permutive,
 			ampAmazon: !!config.switches.ampAmazon,
 		},
@@ -143,6 +145,8 @@ export const Body = ({ data, config }: Props) => {
 	const adConfig = {
 		usePubmaticPrebid: adInfo.switches.ampPrebidPubmatic,
 		useCriteoPrebid: adInfo.switches.ampPrebidCriteo,
+		useOzonePrebid:
+			adInfo.switches.ampPrebidOzone && isOnOzoneTestPage(config.pageId),
 		usePermutive: adInfo.switches.permutive,
 		useAmazon: adInfo.switches.ampAmazon,
 	};

--- a/dotcom-rendering/src/amp/components/BodyArticle.tsx
+++ b/dotcom-rendering/src/amp/components/BodyArticle.tsx
@@ -156,15 +156,13 @@ export const Body = ({ data, config }: Props) => {
 		<>
 			{elementsWithoutAds.map((item, i) => {
 				if (slotIndexes.includes(i)) {
+					const adSlotId = `ad-${i + 1}` as const;
 					return (
 						<React.Fragment key={item.key}>
 							{item}
-							<div
-								id={`ad-${i + 1}`}
-								data-sort-time="1"
-								css={adStyle}
-							>
+							<div id={adSlotId} data-sort-time="1" css={adStyle}>
 								<InlineAd
+									id={adSlotId}
 									editionId={data.editionId}
 									section={data.sectionName ?? ''}
 									contentType={adInfo.contentType}
@@ -218,6 +216,7 @@ export const Body = ({ data, config }: Props) => {
 			{epic}
 
 			<StickyAd
+				id="ad-sticky"
 				editionId={data.editionId}
 				section={data.sectionName ?? ''}
 				contentType={adInfo.contentType}

--- a/dotcom-rendering/src/amp/components/BodyArticle.tsx
+++ b/dotcom-rendering/src/amp/components/BodyArticle.tsx
@@ -24,7 +24,7 @@ import type { ArticleModel } from '../types/ArticleModel';
 import { Elements } from './Elements';
 import { TextBlockComponent } from './elements/TextBlockComponent';
 import { Epic } from './Epic';
-import { RegionalAd } from './RegionalAd';
+import { InlineAd } from './InlineAd';
 import { StickyAd } from './StickyAd';
 import { SubMeta } from './SubMeta';
 import { TopMeta } from './topMeta/TopMeta';
@@ -164,7 +164,7 @@ export const Body = ({ data, config }: Props) => {
 								data-sort-time="1"
 								css={adStyle}
 							>
-								<RegionalAd
+								<InlineAd
 									editionId={data.editionId}
 									section={data.sectionName ?? ''}
 									contentType={adInfo.contentType}

--- a/dotcom-rendering/src/amp/components/InlineAd.test.tsx
+++ b/dotcom-rendering/src/amp/components/InlineAd.test.tsx
@@ -38,6 +38,7 @@ describe('RegionalAd', () => {
 		const { container } = render(
 			<ContentABTestProvider pageId="" switches={{}}>
 				<InlineAd
+					id="ad-1"
 					editionId="UK"
 					section=""
 					contentType=""
@@ -89,6 +90,7 @@ describe('RegionalAd', () => {
 		const { container } = render(
 			<ContentABTestProvider pageId="" switches={{}}>
 				<InlineAd
+					id="ad-1"
 					editionId="UK"
 					section=""
 					contentType=""
@@ -140,6 +142,7 @@ describe('RegionalAd', () => {
 		const { container } = render(
 			<ContentABTestProvider pageId="" switches={{}}>
 				<InlineAd
+					id="ad-1"
 					editionId="UK"
 					section=""
 					contentType=""
@@ -186,6 +189,7 @@ describe('RegionalAd', () => {
 		const { container } = render(
 			<ContentABTestProvider pageId="" switches={{}}>
 				<InlineAd
+					id="ad-1"
 					editionId="UK"
 					section=""
 					contentType=""
@@ -232,6 +236,7 @@ describe('RegionalAd', () => {
 		const { container } = render(
 			<ContentABTestProvider pageId="" switches={{}}>
 				<InlineAd
+					id="ad-1"
 					editionId="UK"
 					section=""
 					contentType=""

--- a/dotcom-rendering/src/amp/components/InlineAd.test.tsx
+++ b/dotcom-rendering/src/amp/components/InlineAd.test.tsx
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/react';
 import { ContentABTestProvider } from './ContentABTest';
-import { RegionalAd } from './RegionalAd';
+import { InlineAd } from './InlineAd';
 
 describe('RegionalAd', () => {
 	const permutiveURL = 'amp-script:permutiveCachedTargeting.ct';
@@ -37,7 +37,7 @@ describe('RegionalAd', () => {
 	it('rtc-config contains just a permutive URL and prebid object when `usePermutive` and `usePubmaticPrebid` flags are set to true', () => {
 		const { container } = render(
 			<ContentABTestProvider pageId="" switches={{}}>
-				<RegionalAd
+				<InlineAd
 					editionId="UK"
 					section=""
 					contentType=""
@@ -88,7 +88,7 @@ describe('RegionalAd', () => {
 	it('rtc-config contains just a prebid object when `usePubmaticPrebid` is true and other flags are false', () => {
 		const { container } = render(
 			<ContentABTestProvider pageId="" switches={{}}>
-				<RegionalAd
+				<InlineAd
 					editionId="UK"
 					section=""
 					contentType=""
@@ -139,7 +139,7 @@ describe('RegionalAd', () => {
 	it('rtc-config contains just the permutive URL when `usePermutive` is true and other flags are false', () => {
 		const { container } = render(
 			<ContentABTestProvider pageId="" switches={{}}>
-				<RegionalAd
+				<InlineAd
 					editionId="UK"
 					section=""
 					contentType=""
@@ -185,7 +185,7 @@ describe('RegionalAd', () => {
 	it('rtc-config contains the correct vendor config when just `useAmazon` flag is set to true', () => {
 		const { container } = render(
 			<ContentABTestProvider pageId="" switches={{}}>
-				<RegionalAd
+				<InlineAd
 					editionId="UK"
 					section=""
 					contentType=""
@@ -231,7 +231,7 @@ describe('RegionalAd', () => {
 	it('rtc-config contains no vendor config when all flags are set to false', () => {
 		const { container } = render(
 			<ContentABTestProvider pageId="" switches={{}}>
-				<RegionalAd
+				<InlineAd
 					editionId="UK"
 					section=""
 					contentType=""

--- a/dotcom-rendering/src/amp/components/InlineAd.tsx
+++ b/dotcom-rendering/src/amp/components/InlineAd.tsx
@@ -4,13 +4,16 @@ import type { BaseAdProps } from './Ad';
 import { Ad } from './Ad';
 
 /**
- * Ad slot component whose config differs based on region.
- * For each adRegion, create an Ad component with styling so that all but the component for the
- * user's region are hidden
- * @param RegionalAdProps
+ * Component for an advert that appears inline in articles / liveblogs
+ *
+ * To allow for differing the configuration of our advertising based on region,
+ * for each region we create an `Ad` component with styling so that only the
+ * component for the user's region (as indicated by the AMP geo runtime) are hidden
+ *
+ * @param {BaseAdProps} props
  * @returns an Ad component per region
  */
-export const RegionalAd = ({
+export const InlineAd = ({
 	editionId,
 	section,
 	contentType,

--- a/dotcom-rendering/src/amp/components/InlineAd.tsx
+++ b/dotcom-rendering/src/amp/components/InlineAd.tsx
@@ -14,6 +14,7 @@ import { Ad } from './Ad';
  * @returns an Ad component per region
  */
 export const InlineAd = ({
+	id,
 	editionId,
 	section,
 	contentType,
@@ -33,6 +34,7 @@ export const InlineAd = ({
 						)}
 					>
 						<Ad
+							id={id}
 							editionId={editionId}
 							section={section}
 							contentType={contentType}

--- a/dotcom-rendering/src/amp/components/RegionalAd.test.tsx
+++ b/dotcom-rendering/src/amp/components/RegionalAd.test.tsx
@@ -44,6 +44,7 @@ describe('RegionalAd', () => {
 					config={{
 						usePubmaticPrebid: true,
 						useCriteoPrebid: false,
+						useOzonePrebid: false,
 						usePermutive: true,
 						useAmazon: false,
 					}}
@@ -94,6 +95,7 @@ describe('RegionalAd', () => {
 					config={{
 						usePubmaticPrebid: true,
 						useCriteoPrebid: false,
+						useOzonePrebid: false,
 						usePermutive: false,
 						useAmazon: false,
 					}}
@@ -144,6 +146,7 @@ describe('RegionalAd', () => {
 					config={{
 						usePubmaticPrebid: false,
 						useCriteoPrebid: false,
+						useOzonePrebid: false,
 						usePermutive: true,
 						useAmazon: false,
 					}}
@@ -189,6 +192,7 @@ describe('RegionalAd', () => {
 					config={{
 						usePubmaticPrebid: false,
 						useCriteoPrebid: false,
+						useOzonePrebid: false,
 						usePermutive: false,
 						useAmazon: true,
 					}}
@@ -234,6 +238,7 @@ describe('RegionalAd', () => {
 					config={{
 						usePubmaticPrebid: false,
 						useCriteoPrebid: false,
+						useOzonePrebid: false,
 						usePermutive: false,
 						useAmazon: false,
 					}}

--- a/dotcom-rendering/src/amp/components/StickyAd.tsx
+++ b/dotcom-rendering/src/amp/components/StickyAd.tsx
@@ -17,6 +17,7 @@ amp-sticky-ad:before {
 }`;
 
 export const StickyAd = ({
+	id,
 	editionId,
 	section,
 	contentType,
@@ -27,6 +28,7 @@ export const StickyAd = ({
 	return (
 		<amp-sticky-ad layout="nodisplay">
 			<Ad
+				id={id}
 				editionId={editionId}
 				section={section}
 				contentType={contentType}

--- a/dotcom-rendering/src/amp/lib/real-time-config.ts
+++ b/dotcom-rendering/src/amp/lib/real-time-config.ts
@@ -83,7 +83,10 @@ export const criteoRTCParamters = (adType: AdType): CriteoRTCParameters => {
 	}
 };
 
-export const ozoneRTCParameters = (adType: AdType): OzoneRTCParameters => {
+export const ozoneRTCParameters = (
+	adType: AdType,
+	id: string,
+): OzoneRTCParameters => {
 	const rowPlacementId = '1500000083';
 	const ukPlacementId = '0420420507';
 
@@ -97,7 +100,7 @@ export const ozoneRTCParameters = (adType: AdType): OzoneRTCParameters => {
 		SITE_ID: '4204204209',
 		TAG_ID: '1000000000',
 		PLACEMENT_ID: placementId,
-		AD_UNIT_CODE: 'xxxx',
+		AD_UNIT_CODE: id,
 	};
 };
 
@@ -117,6 +120,7 @@ export const realTimeConfig = (
 	useOzonePrebid: boolean,
 	usePermutive: boolean,
 	useAmazon: boolean,
+	id: string,
 	adType: AdType,
 ): string => {
 	const pubmaticConfig = {
@@ -128,7 +132,7 @@ export const realTimeConfig = (
 	};
 
 	const ozoneConfig = {
-		ozone: ozoneRTCParameters(adType),
+		ozone: ozoneRTCParameters(adType, id),
 	};
 
 	const data = {

--- a/dotcom-rendering/src/amp/lib/real-time-config.ts
+++ b/dotcom-rendering/src/amp/lib/real-time-config.ts
@@ -19,6 +19,14 @@ type PubmaticRTCParameters = {
 
 type CriteoRTCParameters = { ZONE_ID: string };
 
+type OzoneRTCParameters = {
+	PUBLISHER_ID: string;
+	SITE_ID: string;
+	TAG_ID: string;
+	PLACEMENT_ID: string;
+	AD_UNIT_CODE: string;
+};
+
 /**
  * Determine the pub id and profile id required by Pubmatic to construct an RTC vendor
  *
@@ -75,6 +83,24 @@ export const criteoRTCParamters = (adType: AdType): CriteoRTCParameters => {
 	}
 };
 
+export const ozoneRTCParameters = (adType: AdType): OzoneRTCParameters => {
+	const rowPlacementId = '1500000083';
+	const ukPlacementId = '0420420507';
+
+	const placementId =
+		adType.isSticky || adType.adRegion === 'UK'
+			? ukPlacementId
+			: rowPlacementId;
+
+	return {
+		PUBLISHER_ID: 'OZONEGMG0001',
+		SITE_ID: '4204204209',
+		TAG_ID: '1000000000',
+		PLACEMENT_ID: placementId,
+		AD_UNIT_CODE: 'xxxx',
+	};
+};
+
 const permutiveURL = 'amp-script:permutiveCachedTargeting.ct';
 
 const amazonConfig = {
@@ -88,6 +114,7 @@ const amazonConfig = {
 export const realTimeConfig = (
 	usePubmaticPrebid: boolean,
 	useCriteoPrebid: boolean,
+	useOzonePrebid: boolean,
 	usePermutive: boolean,
 	useAmazon: boolean,
 	adType: AdType,
@@ -100,14 +127,26 @@ export const realTimeConfig = (
 		criteo: criteoRTCParamters(adType),
 	};
 
+	const ozoneConfig = {
+		ozone: ozoneRTCParameters(adType),
+	};
+
 	const data = {
 		urls: usePermutive ? [permutiveURL] : [],
 		vendors: {
 			...(usePubmaticPrebid ? pubmaticConfig : {}),
 			...(useCriteoPrebid ? criteoConfig : {}),
+			...(useOzonePrebid ? ozoneConfig : {}),
 			...(useAmazon ? amazonConfig : {}),
 		},
 		timeoutMillis: 1000,
 	};
 	return JSON.stringify(data);
 };
+
+/**
+ *
+ * For testing purposes, only enable Ozone on a single page with a known id
+ */
+export const isOnOzoneTestPage = (pageId: string): boolean =>
+	pageId === 'science/grrlscientist/2012/may/27/9';


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Add Ozone, a new Prebid [RTC](https://github.com/ampproject/amphtml/blob/main/extensions/amp-a4a/rtc-documentation.md) (real time config) third-party server integration, to our AMP ads. This follows the same rough structure as our previous integration for Criteo (see #7202).

The main changes include adding a new set of real-time-config parameters to our ad slots. These parameters are shipped to Ozone in order to look up stored bid requests (which are setup by them).

As before, we restrict the Ozone integration to a single test page [science/grrlscientist/2012/may/27/9](https://amp.theguardian.com/science/grrlscientist/2012/may/27/9), so that it can be tested by Ozone before we roll out to any more users.

One other significant change in this PR is ensuring all of our ads are enclosed in divs with `id` properties set. We pass these down into the `Ad` component so that we can set an ad unit code in the Ozone parameters (they asked us to set it up this way). `RegionalAd` has also been renamed to `InlineAd` to better reflect its location in the content, with a clarification on how regions are used in the TSDoc for this component.

## Why?

This should open us up to more demand via Prebid, and therefore a potential increase in revenue.
