### PR TITLE
Make cypress github action more efficient

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -22,7 +22,7 @@ jobs:
         working-directory: dotcom-rendering
 
       - name: Upload build
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: build
           path: dotcom-rendering/dist
@@ -44,7 +44,7 @@ jobs:
           cache: 'yarn'
 
       - name: Download build
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: build
           path: dotcom-rendering/dist

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -2,16 +2,12 @@ name: DCR cypress
 on:
   push:
     paths-ignore:
-      - "apps-rendering/**"
-      - "dotcom-rendering/docs/**"
+      - 'apps-rendering/**'
+      - 'dotcom-rendering/docs/**'
 jobs:
-  cypress:
-    name: DCR Cypress
+  build:
+    name: Build
     runs-on: ubuntu-20.04
-    strategy:
-      fail-fast: false
-      matrix:
-        group: [1, 2, 3, 4, 5, 6]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -25,12 +21,40 @@ jobs:
         run: make build
         working-directory: dotcom-rendering
 
+      - name: Upload build
+        uses: actions/upload-artifact@v2
+        with:
+          name: build
+          path: dotcom-rendering/dist
+  cypress:
+    name: DCR Cypress
+    runs-on: ubuntu-20.04
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        group: [1, 2, 3, 4, 5, 6]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+
+      - name: Download build
+        uses: actions/download-artifact@v2
+        with:
+          name: build
+          path: dotcom-rendering/dist
+
       - name: Cypress run
         uses: cypress-io/github-action@v4
         with:
           start: make start-ci
           working-directory: dotcom-rendering
-          wait-on: "http://localhost:9000"
+          wait-on: 'http://localhost:9000'
           wait-on-timeout: 30
           browser: chrome
           spec: cypress/e2e/parallel-${{ matrix.group }}/*.js


### PR DESCRIPTION
👋 Hey WebEx, small optimisation for you! This won't save any time probably, but does use less github action minutes

## What does this change?
Build DCR in a new job that the cypress jobs will depend on, using the same build for each cypress run

## Why?
Each of the matrixed jobs were compiling their own build, **napkin maths:** so if it's move to a dependent job will save 5 min build * 6 = 30 github actions minutes per push

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/1731150/221162183-c3a552af-4f61-49e6-834e-62257e1e8859.png

[after]: https://user-images.githubusercontent.com/1731150/221162205-116fbda8-f0b4-4ddc-b1de-f2eaf12dab98.png


<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
