### PR TITLE
Fronts TBT budget 716 -> 450

### DIFF
--- a/dotcom-rendering/lighthouserc.js
+++ b/dotcom-rendering/lighthouserc.js
@@ -53,7 +53,7 @@ module.exports = {
 					assertions: {
 						'total-blocking-time': [
 							'warn',
-							{ maxNumericValue: 716 },
+							{ maxNumericValue: 450 },
 						],
 						'categories:accessibility': [
 							'warn',


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Reduces the Lighthouse budget for Total Blocking Time on fronts.


## Why?

We seem to be consistently below 450 at the moment, so lowering the budget makes it more likely that we'll catch regressions.

**Update**: Of course this PR would end up with a TBT that's above 450 🙃 Might collect more data and update the budget, e.g. to 500..