### PR TITLE
Handle SecureSignUpIframe FontFaceSet InvalidModificationError

### DIFF
--- a/dotcom-rendering/src/web/components/SecureSignupIframe.importable.tsx
+++ b/dotcom-rendering/src/web/components/SecureSignupIframe.importable.tsx
@@ -325,11 +325,7 @@ export const SecureSignupIframe = ({
 
 		// add the fonts to the iframe
 		requiredFonts.forEach((font) => {
-			// it shouldn't be necessary to test for the add method again
-			// but still ts considers it possibily undefined
-			if (iframeFontFaceSet.add) {
-				iframeFontFaceSet.add(font);
-			}
+			iframeFontFaceSet.add(font);
 		});
 	};
 

--- a/dotcom-rendering/src/web/components/SecureSignupIframe.importable.tsx
+++ b/dotcom-rendering/src/web/components/SecureSignupIframe.importable.tsx
@@ -328,6 +328,8 @@ export const SecureSignupIframe = ({
 			try {
 				iframeFontFaceSet.add(font);
 			} catch (error) {
+				// Safari throws an InvalidModificationError
+				// https://developer.mozilla.org/en-US/docs/Web/API/FontFaceSet/add#exceptions
 				window.guardian.modules.sentry.reportError(
 					error instanceof Error ? error : new Error(String(error)),
 					'secure-signup-iframe',

--- a/dotcom-rendering/src/web/components/SecureSignupIframe.importable.tsx
+++ b/dotcom-rendering/src/web/components/SecureSignupIframe.importable.tsx
@@ -325,7 +325,14 @@ export const SecureSignupIframe = ({
 
 		// add the fonts to the iframe
 		requiredFonts.forEach((font) => {
-			iframeFontFaceSet.add(font);
+			try {
+				iframeFontFaceSet.add(font);
+			} catch (error) {
+				window.guardian.modules.sentry.reportError(
+					error instanceof Error ? error : new Error(String(error)),
+					'secure-signup-iframe',
+				);
+			}
 		});
 	};
 


### PR DESCRIPTION
## What does this change?

### Problem

`InvalidModificationError: The object can not be modified in this way` is the most frequent error in the client-side-prod project in Sentry (~300K per month / ~35%):

<img width="100%" alt="ime-01" src="https://user-images.githubusercontent.com/7014230/221448959-d9158104-a3ec-4142-bf1c-346356f88989.png">

There is no stack-trace but the tag breakdown shows it is coming from:
- DCR articles (why this is reported under `client-side-prod` I'll look at separately)
- Safari browsers
- looking at the URLs indicates articles where a newsletter sign up form is displayed

<img width="1427" src="https://user-images.githubusercontent.com/7014230/221449377-95aca7c5-da88-4285-b5eb-749fb7bb913f.png">

Debugging in Safari leads to `SecureSignupIframe.importable.tsx` and the section of code that attempts to add font faces to an iframe which can be replicated in the console:

<img width="1335" src="https://user-images.githubusercontent.com/7014230/221450668-89f5cd97-8788-4adf-9474-3465bdfb6743.png">

### This Change

This change catches errors from `FontFaceSet.add()` and uses `reportError` with the tag `secure-signup-iframe`.

This will not prevent the error but it should give more insight into the the error from this section of code and determine its overall contribution to `InvalidModificationError`.

We can then make a decision on whether to fix or ignore.
