### PR TITLE
bump `@guardian/commercial-core` to `5.4.3`

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -60,7 +60,7 @@
 		"@guardian/atoms-rendering": "^25.1.5",
 		"@guardian/braze-components": "^9.0.2",
 		"@guardian/browserslist-config": "^2.0.3",
-		"@guardian/commercial-core": "5.4.2",
+		"@guardian/commercial-core": "5.4.3",
 		"@guardian/consent-management-platform": "11.0.0",
 		"@guardian/core-web-vitals": "^2.0.1",
 		"@guardian/discussion-rendering": "^12.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2240,10 +2240,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/browserslist-config/-/browserslist-config-2.0.3.tgz#1c8b832ab564b257f8146ca1b3183b7683026ec9"
   integrity sha512-mALAjz+4Hb2zLxfVz11PSKp6410boWqf0FFYhgzMKOhby0bZjfEKsQIH//U15M5ELibIMG1ryHSP/SFV4C2ovg==
 
-"@guardian/commercial-core@5.4.2":
-  version "5.4.2"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-5.4.2.tgz#1c07bf0655d5dadc015ef6d54e7f40a864e83562"
-  integrity sha512-jy59ewwnJ3210gh7OSuYe2E0z6wQcWcDvDzG96tfvhvKaA0j35YW3Mex7/WkvBIRgOoBIGFLi3pvEjIja5Qa4Q==
+"@guardian/commercial-core@5.4.3":
+  version "5.4.3"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-5.4.3.tgz#054d4cfe9cf026e54e73b099ba3cc088cca9ee85"
+  integrity sha512-6uAzzALVa/KQoYu0xpS/IQ6PwIX9S0X3MDkhEwyuVgX33ptO8vGPxJHAuSc9wp0Q3s+nYlSa4xaWGMkiEGcbDQ==
   dependencies:
     type-fest "2.12.2"
 


### PR DESCRIPTION
contains a bug fix (https://github.com/guardian/commercial-core/pull/803) for offline counting

frontend equivalent: https://github.com/guardian/frontend/pull/25929