### PR TITLE
ShowMore button `small` -> `xsmall`

### DIFF
--- a/dotcom-rendering/src/web/components/ShowMore.importable.tsx
+++ b/dotcom-rendering/src/web/components/ShowMore.importable.tsx
@@ -152,7 +152,7 @@ export const ShowMore = ({
 				`}
 			>
 				<Button
-					size="small"
+					size="xsmall"
 					icon={isOpen ? <SvgCross /> : <SvgPlus />}
 					isLoading={loading}
 					iconSide="left"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Uses the `xsmall` option on the Source `<Button>` component for show more.

## Why?

Requested as part of the DCR fronts design review. (Closes #7298.)

## Screenshots

Before and after (both DCR)

<img width="1469" alt="image" src="https://user-images.githubusercontent.com/37048459/221603560-4707ba1a-4acc-457b-9212-7668cfcf0e8b.png">

