### PR TITLE
Reduce `OnwardsUpper` complexity and fix bug

### DIFF
--- a/dotcom-rendering/src/web/components/OnwardsUpper.importable.test.tsx
+++ b/dotcom-rendering/src/web/components/OnwardsUpper.importable.test.tsx
@@ -1,0 +1,34 @@
+import { firstPopularTag } from './OnwardsUpper.importable';
+
+describe('firstPopularTag', () => {
+	it('finds a matching tag', () => {
+		const keywordIds = [
+			'sport/cricket',
+			'football/championsleague',
+			'football/tottenham-hotspur',
+		].join(',');
+
+		expect(firstPopularTag(keywordIds, false)).toBe('sport/cricket');
+	});
+
+	it('finds a matching tag of higher importance at the end of a list', () => {
+		const keywordIds = [
+			'football/tottenham-hotspur',
+			'football/championsleague',
+			'sport/cricket',
+		].join(',');
+
+		expect(firstPopularTag(keywordIds, false)).toBe('sport/cricket');
+	});
+
+	it('returns the first tag for paid content', () => {
+		const keywordIds = [
+			'some/tag',
+			'sport/cricket',
+			'football/championsleague',
+			'football/tottenham-hotspur',
+		].join(',');
+
+		expect(firstPopularTag(keywordIds, true)).toBe('some/tag');
+	});
+});

--- a/dotcom-rendering/src/web/components/OnwardsUpper.importable.tsx
+++ b/dotcom-rendering/src/web/components/OnwardsUpper.importable.tsx
@@ -13,9 +13,12 @@ type PillarForContainer =
 	| 'culture'
 	| 'lifestyle';
 
-// This list is a direct copy from https://github.com/guardian/frontend/blob/6da0b3d8bfd58e8e20f80fc738b070fb23ed154e/static/src/javascripts/projects/common/modules/onward/related.js#L27
-// If you change this list then you should also update ^
-// order matters here (first match wins)
+/**
+ * This list is a direct copy from [`frontend`](https://github.com/guardian/frontend/blob/6da0b3d8bfd58e8e20f80fc738b070fb23ed154e/static/src/javascripts/projects/common/modules/onward/related.js#L27).
+ * If you change this list then you should also update `frontend`.
+ *
+ * Order matters here (first match wins).
+ */
 const ALLOWED_TAGS = [
 	// sport tags
 	'sport/cricket',
@@ -45,28 +48,17 @@ const ALLOWED_TAGS = [
 	'football/manchestercity',
 	'football/tottenham-hotspur',
 	'football/liverpool',
-];
+] as const;
+const isAllowedTag = (tag: string): tag is (typeof ALLOWED_TAGS)[number] =>
+	ALLOWED_TAGS.map(String).includes(tag);
 
-/** This function looks for the first tag in pageTags, that also exists in our allowlist */
-const firstPopularTag = (
-	pageTags: string | string[],
-	isPaidContent: boolean,
-): string | undefined => {
-	// The problem here is keywordIds is sometimes a string and sometimes an array of strings. Fun times.
-	let tags;
-	if (typeof pageTags === 'string') {
-		tags = pageTags.split(',');
-	} else {
-		tags = pageTags;
-	}
-
-	const firstTagInAllowedList = tags.find((tag: string) =>
-		ALLOWED_TAGS.includes(tag),
-	);
+/** This function looks for the first tag in keywordIds, that also exists in our allowlist */
+const firstPopularTag = (keywordIds: string, isPaidContent: boolean) => {
+	const tags = keywordIds.split(',');
 
 	// For paid content we just return the first tag, otherwise we
 	// filter for the first tag in the allowlist
-	return isPaidContent ? tags[0] : firstTagInAllowedList;
+	return isPaidContent ? tags[0] : tags.find(isAllowedTag);
 };
 
 const onwardsWrapper = css`
@@ -170,7 +162,7 @@ type Props = {
 	pageId: string;
 	isPaidContent: boolean;
 	showRelatedContent: boolean;
-	keywordIds: string | string[];
+	keywordIds: string;
 	contentType: string;
 	tags: TagType[];
 	format: ArticleFormat;

--- a/dotcom-rendering/src/web/components/OnwardsUpper.importable.tsx
+++ b/dotcom-rendering/src/web/components/OnwardsUpper.importable.tsx
@@ -49,16 +49,16 @@ const ALLOWED_TAGS = [
 	'football/tottenham-hotspur',
 	'football/liverpool',
 ] as const;
-const isAllowedTag = (tag: string): tag is (typeof ALLOWED_TAGS)[number] =>
-	ALLOWED_TAGS.map(String).includes(tag);
 
-/** This function looks for the first tag in keywordIds, that also exists in our allowlist */
+/** This function looks for item in our allowlist that is present in our keywordIds */
 const firstPopularTag = (keywordIds: string, isPaidContent: boolean) => {
 	const tags = keywordIds.split(',');
 
-	// For paid content we just return the first tag, otherwise we
-	// filter for the first tag in the allowlist
-	return isPaidContent ? tags[0] : tags.find(isAllowedTag);
+	// For paid content we just return the first tag,
+	// otherwise we find the allowlist tag that matches
+	return isPaidContent
+		? tags[0]
+		: ALLOWED_TAGS.find((tag) => tags.includes(tag));
 };
 
 const onwardsWrapper = css`
@@ -305,3 +305,5 @@ export const OnwardsUpper = ({
 		</div>
 	);
 };
+
+export { firstPopularTag };


### PR DESCRIPTION
## What does this change?

Refactor `firstPopularInTag` and [fix a 5 year old bug](https://github.com/guardian/dotcom-rendering/pull/1078#issuecomment-1446489263), with an added test.

## Why?

- `keywordIds` is always a string, so we can reduce
the amount of branches by always splitting on a comma: ","

- if we’re in the paid content branch calculating the first tag
in the allowlist is complete overhead, so we can lazily evaluate
this value in the ternary

- the current implementation is not a valid port of `frontend`, the comment mentioning that order matters is not true, so this fixes it.