### PR TITLE
Fix unstyled text in container description

### DIFF
--- a/dotcom-rendering/src/web/components/ContainerTitle.tsx
+++ b/dotcom-rendering/src/web/components/ContainerTitle.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react';
 import {
 	between,
+	body,
 	headline,
 	neutral,
 	news,
@@ -39,7 +40,7 @@ const headerStyles = (fontColour?: string) => css`
 `;
 
 const descriptionStyles = (fontColour?: string) => css`
-	${headline.xxxsmall({ fontWeight: 'medium' })};
+	${body.xsmall({ fontWeight: 'medium' })};
 	color: ${fontColour ?? neutral[46]};
 	p {
 		/* Handle paragraphs in the description */
@@ -101,7 +102,7 @@ export const ContainerTitle = ({
 				<h2 css={headerStyles(fontColour)}>{title}</h2>
 			)}
 			{!!description && (
-				<p
+				<span
 					css={[descriptionStyles(fontColour), bottomMargin]}
 					dangerouslySetInnerHTML={{ __html: description }}
 				/>

--- a/dotcom-rendering/src/web/components/ContainerTitle.tsx
+++ b/dotcom-rendering/src/web/components/ContainerTitle.tsx
@@ -1,6 +1,5 @@
 import { css } from '@emotion/react';
 import {
-	between,
 	body,
 	headline,
 	neutral,

--- a/dotcom-rendering/src/web/components/ContainerTitle.tsx
+++ b/dotcom-rendering/src/web/components/ContainerTitle.tsx
@@ -102,7 +102,7 @@ export const ContainerTitle = ({
 				<h2 css={headerStyles(fontColour)}>{title}</h2>
 			)}
 			{!!description && (
-				<span
+				<div
 					css={[descriptionStyles(fontColour), bottomMargin]}
 					dangerouslySetInnerHTML={{ __html: description }}
 				/>


### PR DESCRIPTION
Co-authored-by: Mario Savarese <mario.savarese@guardian.co.uk>

<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

This is an example of the description field in the crosswords blog container taken from the json response on a crossword page: 
`"description": "</br> <small> <strong>Contact the crossword editors</strong>  <p><stong>Quick, Cryptic, Prize, Quiptic and Genius</strong></br>  Email <a href=\"mailto:guardian.crosswords@theguardian.com\">guardian.crosswords&ZeroWidthSpace;@theguardian.com</a></p>     <p><stong>Speedy, Everyman and Azed</strong></br>   Email <a href=\"mailto:observer.crosswords@theguardian.com\">observer.crosswords&ZeroWidthSpace;@theguardian.com</a>   </br> For technical problems email <a href=\"mailto:userhelp@theguardian.com\">userhelp@theguardian.com</a></p></small>"`

Aside from the notable `<stong>` typo, this includes a couple of `<p>` tags, which are processed by the [ContainerTitle component](https://github.com/guardian/dotcom-rendering/blob/4dd60c3e74de345b0d1695aff330f6e573e47026/dotcom-rendering/src/web/components/ContainerTitle.tsx#L106) through `dangerouslySetInnerHTML`. It seems the `<p>` tags in the description are being interpreted as being separate from the `<p>` tag set by the ContainerTitle component, and so aren't receiving the styling that's being applied to it. Modifying the ContainerTitle to generate a `span` tag instead seems to resolve this. 



## Why?

Fixes #7292 

## Screenshots

| Frontend      | DCR Before      | DCR After
|-------------|------------|------------|
| ![Frontend][] | ![DCR Before][] | ![DCR After][] |

[Frontend]: 
https://user-images.githubusercontent.com/102960844/221690004-ab3c4169-4dc6-4713-a1fd-df33032bc1a7.png

[DCR Before]: https://user-images.githubusercontent.com/102960844/221691789-9a4c4fff-f05e-4340-a5bc-8231ecd26c6c.png

[DCR After]: https://user-images.githubusercontent.com/102960844/221692808-9935c14f-8b9a-4aee-b2a1-21f54d97b65c.png


The typography is also adjusted to use `body.xsmall` instead of `headline.xxxsmall`. Using the latter sets the font to look like this: 

<img width="229" alt="image" src="https://user-images.githubusercontent.com/102960844/221693651-405c4923-183d-41bd-ab84-80e60e2fac7d.png">
The former is more in keeping with frontend; the alternative would be to set a specific px amount, which doesn't feel like the ideal solution.