### PR TITLE
Scope the webpack rules to just the file we are importing

### DIFF
--- a/dotcom-rendering/cypress/plugins/index.js
+++ b/dotcom-rendering/cypress/plugins/index.js
@@ -30,7 +30,10 @@ module.exports = (on, config) => {
 		require('../../scripts/webpack/webpack.config.browser').babelExclude;
 
 	rules.push({
-		test: /\.ts$/,
+		test: path.resolve(
+			__dirname,
+			`../../fixtures/generated/articles/Standard.ts`,
+		),
 		exclude: ['/node_modules/'],
 		loader: 'ts-loader',
 		options: {


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Updates the webpack config to specify just the one file we are importing from source code for the cypress tests.

## Why?
So that we are only importing what is needed for the test
