### PR TITLE
refactor(Emotion 11): back to basics

### DIFF
--- a/dotcom-rendering/src/web/components/BlockquoteBlockComponent.tsx
+++ b/dotcom-rendering/src/web/components/BlockquoteBlockComponent.tsx
@@ -1,4 +1,4 @@
-import { ClassNames } from '@emotion/react';
+import { css } from '@emotion/react';
 import { body } from '@guardian/source-foundations';
 import { renderToString } from 'react-dom/server';
 import { unwrapHtml } from '../../model/unwrapHtml';
@@ -12,78 +12,74 @@ type Props = {
 	quoted?: boolean;
 };
 
-export const BlockquoteBlockComponent = ({ html, palette, quoted }: Props) => (
-	<ClassNames>
-		{({ css }) => {
-			const baseBlockquoteStyles = css`
-				margin-bottom: 16px;
-				${body.medium()};
-				font-style: italic;
-				p {
-					margin-bottom: 8px;
-				}
-			`;
+const baseBlockquoteStyles = css`
+	margin-bottom: 16px;
+	${body.medium()};
+	font-style: italic;
+	p {
+		margin-bottom: 8px;
+	}
+`;
 
-			const simpleBlockquoteStyles = css`
-				${baseBlockquoteStyles}
-				margin-top: 16px;
-				margin-right: 0;
-				margin-bottom: 16px;
-				margin-left: 33px;
-			`;
+const simpleBlockquoteStyles = css`
+	${baseBlockquoteStyles}
+	margin-top: 16px;
+	margin-right: 0;
+	margin-bottom: 16px;
+	margin-left: 33px;
+`;
 
-			const quotedBlockquoteStyles = css`
-				${baseBlockquoteStyles}
-				color: ${palette.text.blockquote};
-			`;
+const quotedBlockquoteStyles = (palette: Palette) => css`
+	${baseBlockquoteStyles}
+	color: ${palette.text.blockquote};
+`;
 
-			const {
-				willUnwrap: isUnwrapped,
-				unwrappedHtml,
-				unwrappedElement,
-			} = unwrapHtml({
-				fixes: [
-					{ prefix: '<p>', suffix: '</p>', unwrappedElement: 'p' },
-					{
-						prefix: '<blockquote>',
-						suffix: '</blockquote>',
-						unwrappedElement: 'blockquote',
-					},
-					{
-						prefix: '<blockquote class="quoted">',
-						suffix: '</blockquote>',
-						unwrappedElement: 'div',
-					},
-				],
-				html,
-			});
+export const BlockquoteBlockComponent = ({ html, palette, quoted }: Props) => {
+	const {
+		willUnwrap: isUnwrapped,
+		unwrappedHtml,
+		unwrappedElement,
+	} = unwrapHtml({
+		fixes: [
+			{ prefix: '<p>', suffix: '</p>', unwrappedElement: 'p' },
+			{
+				prefix: '<blockquote>',
+				suffix: '</blockquote>',
+				unwrappedElement: 'blockquote',
+			},
+			{
+				prefix: '<blockquote class="quoted">',
+				suffix: '</blockquote>',
+				unwrappedElement: 'div',
+			},
+		],
+		html,
+	});
 
-			if (quoted) {
-				const htmlWithIcon = unwrappedHtml
-					.trim()
-					.replace(
-						'<p>',
-						`<p>${renderToString(
-							<QuoteIcon colour={palette.fill.blockquoteIcon} />,
-						)}`,
-					);
-				return (
-					<RewrappedComponent
-						isUnwrapped={isUnwrapped}
-						html={htmlWithIcon}
-						tagName="blockquote"
-						elCss={quotedBlockquoteStyles}
-					/>
-				);
-			}
-			return (
-				<RewrappedComponent
-					isUnwrapped={isUnwrapped}
-					html={unwrappedHtml}
-					elCss={simpleBlockquoteStyles}
-					tagName={unwrappedElement}
-				/>
+	if (quoted) {
+		const htmlWithIcon = unwrappedHtml
+			.trim()
+			.replace(
+				'<p>',
+				`<p>${renderToString(
+					<QuoteIcon colour={palette.fill.blockquoteIcon} />,
+				)}`,
 			);
-		}}
-	</ClassNames>
-);
+		return (
+			<RewrappedComponent
+				isUnwrapped={isUnwrapped}
+				html={htmlWithIcon}
+				tagName="blockquote"
+				elCss={quotedBlockquoteStyles(palette)}
+			/>
+		);
+	}
+	return (
+		<RewrappedComponent
+			isUnwrapped={isUnwrapped}
+			html={unwrappedHtml}
+			elCss={simpleBlockquoteStyles}
+			tagName={unwrappedElement}
+		/>
+	);
+};

--- a/dotcom-rendering/src/web/components/HighlightBlockComponent.tsx
+++ b/dotcom-rendering/src/web/components/HighlightBlockComponent.tsx
@@ -1,5 +1,5 @@
-import { ClassNames } from '@emotion/react';
-import { background, body } from '@guardian/source-foundations';
+import { css } from '@emotion/react';
+import { body, neutral } from '@guardian/source-foundations';
 import { unwrapHtml } from '../../model/unwrapHtml';
 import { RewrappedComponent } from './RewrappedComponent';
 
@@ -7,41 +7,37 @@ type Props = {
 	html: string;
 };
 
-export const HighlightBlockComponent = ({ html }: Props) => (
-	<ClassNames>
-		{({ css }) => {
-			const {
-				willUnwrap: isUnwrapped,
-				unwrappedHtml,
-				unwrappedElement,
-			} = unwrapHtml({
-				fixes: [
-					{ prefix: '<p>', suffix: '</p>', unwrappedElement: 'p' },
-					{
-						prefix: '<blockquote>',
-						suffix: '</blockquote>',
-						unwrappedElement: 'blockquote',
-					},
-				],
-				html,
-			});
+export const HighlightBlockComponent = ({ html }: Props) => {
+	const {
+		willUnwrap: isUnwrapped,
+		unwrappedHtml,
+		unwrappedElement,
+	} = unwrapHtml({
+		fixes: [
+			{ prefix: '<p>', suffix: '</p>', unwrappedElement: 'p' },
+			{
+				prefix: '<blockquote>',
+				suffix: '</blockquote>',
+				unwrappedElement: 'blockquote',
+			},
+		],
+		html,
+	});
 
-			return (
-				<RewrappedComponent
-					isUnwrapped={isUnwrapped}
-					html={unwrappedHtml}
-					elCss={css`
-						${body.medium({ lineHeight: 'tight' })};
-						background-color: ${background.secondary};
-						padding-top: 8px;
-						padding-bottom: 16px;
-						padding-left: 12px;
-						padding-right: 12px;
-						margin-bottom: 16px;
-					`}
-					tagName={unwrappedElement}
-				/>
-			);
-		}}
-	</ClassNames>
-);
+	return (
+		<RewrappedComponent
+			isUnwrapped={isUnwrapped}
+			html={unwrappedHtml}
+			elCss={css`
+				${body.medium({ lineHeight: 'tight' })};
+				background-color: ${neutral[97]};
+				padding-top: 8px;
+				padding-bottom: 16px;
+				padding-left: 12px;
+				padding-right: 12px;
+				margin-bottom: 16px;
+			`}
+			tagName={unwrappedElement}
+		/>
+	);
+};

--- a/dotcom-rendering/src/web/components/RewrappedComponent.tsx
+++ b/dotcom-rendering/src/web/components/RewrappedComponent.tsx
@@ -1,6 +1,5 @@
-import { ClassNames } from '@emotion/react';
-// @ts-expect-error -- we’re actually using preact
-import { jsx as _jsx } from 'react/jsx-runtime';
+import type { SerializedStyles } from '@emotion/react';
+import { css, jsx } from '@emotion/react';
 import { unescapeData } from '../../lib/escapeData';
 import type { HTMLTag } from '../../model/unwrapHtml';
 import { logger } from '../../server/lib/logging';
@@ -22,44 +21,37 @@ export const RewrappedComponent = ({
 }: {
 	isUnwrapped: boolean;
 	html: string;
-	elCss?: string;
+	elCss?: SerializedStyles;
 	tagName: HTMLTag;
-}) => (
-	<ClassNames>
-		{({ css }) => {
-			if (!isUnwrapped) {
-				const isDev = process.env.NODE_ENV !== 'production';
-				logger.warn(
-					'RewrappedComponent called with isUnwrapped === false',
-					{
-						isDev,
-						html,
-						tagName,
-					},
-				);
-			}
+}) => {
+	if (!isUnwrapped) {
+		const isDev = process.env.NODE_ENV !== 'production';
+		logger.warn('RewrappedComponent called with isUnwrapped === false', {
+			isDev,
+			html,
+			tagName,
+		});
+	}
 
-			const element: HTMLTag = isUnwrapped ? tagName : 'span';
+	const element: HTMLTag = isUnwrapped ? tagName : 'span';
 
-			// If we implement a span, we want to apply the CSS to the inner element
-			// to ensure we still style correctly
-			const innerElCss = css`
-				${tagName} {
-					${elCss}
-				}
-			`;
+	// If we implement a span, we want to apply the CSS to the inner element
+	// to ensure we still style correctly
+	const innerElCss = css`
+		${tagName} {
+			${elCss}
+		}
+	`;
 
-			const style = isUnwrapped ? elCss : innerElCss;
+	const style = isUnwrapped ? elCss : innerElCss;
 
-			// Create a react element from the tagName passed in OR
-			// default to <span> if we've not been able to unwrap based on prefix & suffix
-			return _jsx(element, {
-				// if style is `undefined`, it will be omitted
-				className: style,
-				dangerouslySetInnerHTML: {
-					__html: unescapeData(html),
-				},
-			});
-		}}
-	</ClassNames>
-);
+	// Create a react element from the tagName passed in OR
+	// default to <span> if we've not been able to unwrap based on prefix & suffix
+	return jsx(element, {
+		// if style is `undefined`, it will be omitted
+		css: style,
+		dangerouslySetInnerHTML: {
+			__html: unescapeData(html),
+		},
+	});
+};

--- a/dotcom-rendering/src/web/components/TextBlockComponent.tsx
+++ b/dotcom-rendering/src/web/components/TextBlockComponent.tsx
@@ -1,4 +1,4 @@
-import { ClassNames } from '@emotion/react';
+import { css } from '@emotion/react';
 import type { ArticleFormat } from '@guardian/libs';
 import { ArticleDesign, ArticleDisplay, ArticleSpecial } from '@guardian/libs';
 import {
@@ -124,148 +124,142 @@ const sanitiserOptions: IOptions = {
 	},
 };
 
+const styles = (format: ArticleFormat) => css`
+	margin-bottom: 16px;
+	word-break: break-word;
+	${format.theme === ArticleSpecial.Labs ? textSans.medium() : body.medium()};
+
+	ul {
+		margin-bottom: 12px;
+	}
+
+	${from.tablet} {
+		ul {
+			margin-bottom: 16px;
+		}
+	}
+
+	li {
+		margin-bottom: 6px;
+		padding-left: 20px;
+		display: flow-root;
+
+		p {
+			display: inline;
+		}
+	}
+
+	li:before {
+		display: inline-block;
+		content: '';
+		border-radius: 50%;
+		height: 13px;
+		width: 13px;
+		background-color: ${neutral[86]};
+		margin-left: -20px;
+		margin-right: 7px;
+	}
+
+	/* Subscript and Superscript styles */
+	sub {
+		bottom: -0.25em;
+	}
+
+	sup {
+		top: -0.5em;
+	}
+
+	sub,
+	sup {
+		font-size: 75%;
+		line-height: 0;
+		position: relative;
+		vertical-align: baseline;
+	}
+
+	[data-dcr-style='bullet'] {
+		display: inline-block;
+		content: '';
+		border-radius: 50%;
+		height: 13px;
+		width: 13px;
+		margin-right: 0.2px;
+		background-color: ${decidePalette(format).background.bullet};
+	}
+
+	${until.tablet} {
+		/* 	To stop long words going outside of the view port.
+					For compatibility */
+		overflow-wrap: anywhere;
+		word-wrap: break-word;
+	}
+`;
+
 export const TextBlockComponent = ({
 	html,
 	format,
 	forceDropCap,
 	isFirstParagraph,
-}: Props) => (
-	<ClassNames>
-		{({ css }) => {
-			const paraStyles = css`
-				margin-bottom: 16px;
-				word-break: break-word;
-				${format.theme === ArticleSpecial.Labs
-					? textSans.medium()
-					: body.medium()};
+}: Props) => {
+	const paraStyles = styles(format);
+	const {
+		willUnwrap: isUnwrapped,
+		unwrappedHtml,
+		unwrappedElement,
+	} = unwrapHtml({
+		fixes: [
+			{
+				unwrappedElement: 'p',
+				prefix: '<p>',
+				suffix: '</p>',
+			},
+			{
+				unwrappedElement: 'ul',
+				prefix: '<ul>',
+				suffix: '</ul>',
+			},
+			{
+				unwrappedElement: 'h3',
+				prefix: '<h3>',
+				suffix: '</h3>',
+			},
+		],
+		html,
+	});
 
-				ul {
-					margin-bottom: 12px;
-				}
+	const firstLetter = decideDropCapLetter(unwrappedHtml);
+	const remainingLetters = firstLetter
+		? unwrappedHtml.substr(firstLetter.length)
+		: unwrappedHtml;
 
-				${from.tablet} {
-					ul {
-						margin-bottom: 16px;
-					}
-				}
-
-				li {
-					margin-bottom: 6px;
-					padding-left: 20px;
-					display: flow-root;
-
-					p {
-						display: inline;
-					}
-				}
-
-				li:before {
-					display: inline-block;
-					content: '';
-					border-radius: 50%;
-					height: 13px;
-					width: 13px;
-					background-color: ${neutral[86]};
-					margin-left: -20px;
-					margin-right: 7px;
-				}
-
-				/* Subscript and Superscript styles */
-				sub {
-					bottom: -0.25em;
-				}
-
-				sup {
-					top: -0.5em;
-				}
-
-				sub,
-				sup {
-					font-size: 75%;
-					line-height: 0;
-					position: relative;
-					vertical-align: baseline;
-				}
-
-				[data-dcr-style='bullet'] {
-					display: inline-block;
-					content: '';
-					border-radius: 50%;
-					height: 13px;
-					width: 13px;
-					margin-right: 0.2px;
-					background-color: ${decidePalette(format).background
-						.bullet};
-				}
-
-				${until.tablet} {
-					/* 	To stop long words going outside of the view port.
-					For compatibility */
-					overflow-wrap: anywhere;
-					word-wrap: break-word;
-				}
-			`;
-
-			const {
-				willUnwrap: isUnwrapped,
-				unwrappedHtml,
-				unwrappedElement,
-			} = unwrapHtml({
-				fixes: [
-					{
-						unwrappedElement: 'p',
-						prefix: '<p>',
-						suffix: '</p>',
-					},
-					{
-						unwrappedElement: 'ul',
-						prefix: '<ul>',
-						suffix: '</ul>',
-					},
-					{
-						unwrappedElement: 'h3',
-						prefix: '<h3>',
-						suffix: '</h3>',
-					},
-				],
-				html,
-			});
-
-			const firstLetter = decideDropCapLetter(unwrappedHtml);
-			const remainingLetters = firstLetter
-				? unwrappedHtml.substr(firstLetter.length)
-				: unwrappedHtml;
-
-			if (
-				shouldShowDropCap({
-					format,
-					isFirstParagraph,
-					forceDropCap,
-				}) &&
-				firstLetter &&
-				isLongEnough(remainingLetters)
-			) {
-				return (
-					<p css={paraStyles}>
-						<DropCap letter={firstLetter} format={format} />
-						<RewrappedComponent
-							isUnwrapped={isUnwrapped}
-							html={sanitise(remainingLetters, sanitiserOptions)}
-							elCss={paraStyles}
-							tagName="span"
-						/>
-					</p>
-				);
-			}
-
-			return (
+	if (
+		shouldShowDropCap({
+			format,
+			isFirstParagraph,
+			forceDropCap,
+		}) &&
+		firstLetter &&
+		isLongEnough(remainingLetters)
+	) {
+		return (
+			<p css={paraStyles}>
+				<DropCap letter={firstLetter} format={format} />
 				<RewrappedComponent
 					isUnwrapped={isUnwrapped}
-					html={sanitise(unwrappedHtml, sanitiserOptions)}
+					html={sanitise(remainingLetters, sanitiserOptions)}
 					elCss={paraStyles}
-					tagName={unwrappedElement || 'p'}
+					tagName="span"
 				/>
-			);
-		}}
-	</ClassNames>
-);
+			</p>
+		);
+	}
+
+	return (
+		<RewrappedComponent
+			isUnwrapped={isUnwrapped}
+			html={sanitise(unwrappedHtml, sanitiserOptions)}
+			elCss={paraStyles}
+			tagName={unwrappedElement || 'p'}
+		/>
+	);
+};


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Revert most of the changes in #3022

## Why?

Some of the unorthodox hoops jumped for the Emotion 11 update can be simplified in favour of using directly the @emotion/react’s `css` and `jsx` implementations:

- BlockquoteBlockComponent
- TextBlockComponent
- HighlightBlockComponent

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/76776/223690892-49b32da0-2017-4797-9aa0-7235923d022c.png
[after]: https://user-images.githubusercontent.com/76776/221837603-d552c68e-2301-4a87-b631-2fd008bc308a.png
