### PR TITLE
Add phone and email support to callouts

### DIFF
--- a/dotcom-rendering/src/model/article-schema.json
+++ b/dotcom-rendering/src/model/article-schema.json
@@ -856,10 +856,12 @@
             "type": "object",
             "properties": {
                 "type": {
-                    "type": "string",
                     "enum": [
+                        "email",
+                        "phone",
                         "text"
-                    ]
+                    ],
+                    "type": "string"
                 },
                 "id": {
                     "type": "string"

--- a/dotcom-rendering/src/types/content.ts
+++ b/dotcom-rendering/src/types/content.ts
@@ -741,7 +741,7 @@ interface CampaignField {
 }
 
 export interface CampaignFieldText extends CampaignField {
-	type: 'text';
+	type: 'text' | 'email' | 'phone';
 }
 
 export interface CampaignFieldTextArea extends CampaignField {

--- a/dotcom-rendering/src/web/components/Callout/FormField.tsx
+++ b/dotcom-rendering/src/web/components/Callout/FormField.tsx
@@ -37,6 +37,8 @@ export const FormField = ({
 	const fieldError = validationErrors[formField.id];
 
 	switch (formField.type) {
+		case 'phone':
+		case 'email':
 		case 'text': {
 			return (
 				<TextInput


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Adds support for the Phone and Email callout types. These render as a standard text field. 
## Why?
Editorial include these types in formstack fields but there is currently no support and so they don't render.  This is forcing editorial to use other field types to capture email and phone data which is sub optimal.

The accompanying frontend pr is https://github.com/guardian/frontend/pull/25933
## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/20416599/221843664-335c4e3a-2b7e-47ad-8ec4-68853c7a73c8.png
[after]: https://user-images.githubusercontent.com/20416599/221843502-42e4ee0f-d2d1-4595-935c-c65f2bdfe485.png



<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->


<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
