### PR TITLE
Do not load the commercial bundle for ad free users (take 2)

### DIFF
--- a/dotcom-rendering/src/web/server/articleToHtml.tsx
+++ b/dotcom-rendering/src/web/server/articleToHtml.tsx
@@ -1,4 +1,4 @@
-import { ArticleDesign, ArticlePillar } from '@guardian/libs';
+import { ArticleDesign, ArticlePillar, isString } from '@guardian/libs';
 import {
 	BUILD_VARIANT,
 	dcrJavascriptBundle,
@@ -99,19 +99,20 @@ export const articleToHtml = ({ article }: Props): string => {
 	 * Please talk to the dotcom platform team before adding more.
 	 * Scripts will be executed in the order they appear in this array
 	 */
+	const loadCommercial = !article.isAdFreeUser && !article.shouldHideAds;
 	const scriptTags = generateScriptTags(
 		[
 			polyfillIO,
 			...getScriptArrayFromFile('frameworks.js'),
 			...getScriptArrayFromFile('index.js'),
-			process.env.COMMERCIAL_BUNDLE_URL ??
-				article.config.commercialBundleUrl,
-			pageHasNonBootInteractiveElements
-				? `${ASSET_ORIGIN}static/frontend/js/curl-with-js-and-domReady.js`
-				: undefined,
-		].map((script) =>
-			offerHttp3 && script ? getHttp3Url(script) : script,
-		),
+			loadCommercial &&
+				(process.env.COMMERCIAL_BUNDLE_URL ??
+					article.config.commercialBundleUrl),
+			pageHasNonBootInteractiveElements &&
+				`${ASSET_ORIGIN}static/frontend/js/curl-with-js-and-domReady.js`,
+		]
+			.filter(isString)
+			.map((script) => (offerHttp3 ? getHttp3Url(script) : script)),
 	);
 
 	/**

--- a/dotcom-rendering/src/web/server/frontToHtml.tsx
+++ b/dotcom-rendering/src/web/server/frontToHtml.tsx
@@ -1,3 +1,4 @@
+import { isString } from '@guardian/libs';
 import {
 	BUILD_VARIANT,
 	dcrJavascriptBundle,
@@ -54,14 +55,18 @@ export const frontToHtml = ({ front }: Props): string => {
 	 * Please talk to the dotcom platform team before adding more.
 	 * Scripts will be executed in the order they appear in this array
 	 */
+	const loadCommercial = !front.isAdFreeUser;
 	const scriptTags = generateScriptTags(
 		[
 			polyfillIO,
 			...getScriptArrayFromFile('frameworks.js'),
 			...getScriptArrayFromFile('index.js'),
-			process.env.COMMERCIAL_BUNDLE_URL ??
-				front.config.commercialBundleUrl,
-		].map((script) => (offerHttp3 ? getHttp3Url(script) : script)),
+			loadCommercial &&
+				(process.env.COMMERCIAL_BUNDLE_URL ??
+					front.config.commercialBundleUrl),
+		]
+			.filter(isString)
+			.map((script) => (offerHttp3 ? getHttp3Url(script) : script)),
 	);
 
 	/**


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

stop the commercial bundle loading at all for ad-free (i.e. paying) users (again, hopefully)

_reverts #7251 which reverted #7223_

## Why?

we know on the server that we won't run the code, but we still force people to download it. the commercial code in turn still loads further libraries we also know we won't run. if we're not going to run, let's not load it.

_#7257 should have fixed zombie slots on DCR articles showing when the commercial JS didn't run_

---

corollary of https://github.com/guardian/frontend/pull/25931

