### PR TITLE
Only show quotes on headline if showQuotedHeadline is true

### DIFF
--- a/dotcom-rendering/fixtures/manual/trails.ts
+++ b/dotcom-rendering/fixtures/manual/trails.ts
@@ -121,7 +121,7 @@ export const trails: [
 			display: ArticleDisplay.Standard,
 		},
 		dataLinkName: 'news | group-0 | card-@4',
-		showQuotedHeadline: false,
+		showQuotedHeadline: true,
 		showMainVideo: false,
 		isExternalLink: false,
 	},

--- a/dotcom-rendering/src/web/components/Card/Card.stories.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.stories.tsx
@@ -434,6 +434,22 @@ export const WithQuotes = () => {
 	);
 };
 
+export const CommentThemeWithoutQuotes = () => {
+	return (
+		<CardWrapper>
+			<Card
+				{...basicCardProps}
+				kickerText="No quotes"
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Comment,
+					theme: ArticlePillar.Opinion,
+				}}
+			/>
+		</CardWrapper>
+	);
+};
+
 export const WithQuotesSpecialReportAlt = () => {
 	return (
 		<CardWrapper>
@@ -487,6 +503,7 @@ export const WhenVerticalAndThemeOpinion = () => {
 						theme: ArticlePillar.Opinion,
 					}}
 					imagePosition="top"
+					showQuotedHeadline={true}
 				/>
 			</CardWrapper>
 		</>
@@ -522,6 +539,7 @@ export const WithSublinksWhenVerticalAndOpinion = () => {
 							kickerText: 'Kicker',
 						},
 					]}
+					showQuotedHeadline={true}
 				/>
 			</CardWrapper>
 		</>
@@ -540,6 +558,7 @@ export const WhenHorizontalAndOpinion = () => {
 						theme: ArticlePillar.Opinion,
 					}}
 					imagePosition="right"
+					showQuotedHeadline={true}
 				/>
 			</CardWrapper>
 			<CardWrapper>
@@ -572,6 +591,7 @@ export const WhenHorizontalAndOpinion = () => {
 							kickerText: 'Kicker',
 						},
 					]}
+					showQuotedHeadline={true}
 				/>
 			</CardWrapper>
 			<CardWrapper>
@@ -591,6 +611,7 @@ export const WhenHorizontalAndOpinion = () => {
 							kickerText: 'Kicker',
 						},
 					]}
+					showQuotedHeadline={true}
 				/>
 			</CardWrapper>
 		</>
@@ -640,6 +661,7 @@ export const WhenHorizontalOpinionWithSmallImage = () => {
 					}}
 					imagePosition="left"
 					imageSize="small"
+					showQuotedHeadline={true}
 				/>
 			</CardWrapper>
 			<CardWrapper>
@@ -673,6 +695,7 @@ export const WhenHorizontalOpinionWithSmallImage = () => {
 							kickerText: 'Kicker',
 						},
 					]}
+					showQuotedHeadline={true}
 				/>
 			</CardWrapper>
 		</>
@@ -692,6 +715,7 @@ export const WhenHorizontalOpinionWithMediumImage = () => {
 					}}
 					imagePosition="left"
 					imageSize="medium"
+					showQuotedHeadline={true}
 				/>
 			</CardWrapper>
 			<CardWrapper>
@@ -725,6 +749,7 @@ export const WhenHorizontalOpinionWithMediumImage = () => {
 							kickerText: 'Kicker',
 						},
 					]}
+					showQuotedHeadline={true}
 				/>
 			</CardWrapper>
 		</>
@@ -744,6 +769,7 @@ export const WhenHorizontalOpinionWithLargeImage = () => {
 					}}
 					imagePosition="left"
 					imageSize="large"
+					showQuotedHeadline={true}
 				/>
 			</CardWrapper>
 			<CardWrapper>
@@ -777,6 +803,7 @@ export const WhenHorizontalOpinionWithLargeImage = () => {
 							kickerText: 'Kicker',
 						},
 					]}
+					showQuotedHeadline={true}
 				/>
 			</CardWrapper>
 		</>
@@ -796,6 +823,7 @@ export const WhenHorizontalOpinionWithJumboImage = () => {
 					}}
 					imagePosition="left"
 					imageSize="jumbo"
+					showQuotedHeadline={true}
 				/>
 			</CardWrapper>
 			<CardWrapper>
@@ -829,6 +857,7 @@ export const WhenHorizontalOpinionWithJumboImage = () => {
 							kickerText: 'Kicker',
 						},
 					]}
+					showQuotedHeadline={true}
 				/>
 			</CardWrapper>
 		</>
@@ -867,6 +896,7 @@ export const WhenOpinionWithImageAtBottom = () => {
 							kickerText: 'Kicker',
 						},
 					]}
+					showQuotedHeadline={true}
 				/>
 			</CardWrapper>
 		</>

--- a/dotcom-rendering/src/web/components/Card/Card.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.tsx
@@ -268,8 +268,7 @@ export const Card = ({
 		supportingContentAlignment,
 	);
 
-	const showQuotes =
-		!!showQuotedHeadline || format.design === ArticleDesign.Comment;
+	const showQuotes = !!showQuotedHeadline;
 
 	const isOpinion =
 		format.design === ArticleDesign.Comment ||


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Remove the logic which adds quotes to headlines if `ArticleDesign.Comment` is `true`.

## Why?

There are a number of places where DCR is rendering quotes in the headline of a card, where Frontend isn't, e.g. #7296.

Checking for `ArticleDesign.Comment` was clearly an intentional choice, and it has been in the codebase for some time. But at the same time, I haven't been able to find any cases yet where Frontend is rendering quote marks for a Comment article that doesn't _also_ have `showQuotedHeadline=true` (and see the code here, too: https://github.com/guardian/frontend/blob/0657f594e2fd51125d28df9048c48d6eede26bb6/common/app/layout/FaciaCardHeader.scala#L30).

When digging around, I noticed that the `showQuotedHeadline` check [was implemented in DCR _after_ the logic which checks for Comment design](https://github.com/guardian/dotcom-rendering/commit/91f27e29a006df96092b54e42addb1230d523b26#diff-ac1ab1ec71014ea358a00d13f4f7833055efeffa0e68d1a231d5853f2b3a1096R35). So my hypothesis is that perhaps `ArticleDesign` was initially used as a proxy for showing the quotes, because we didn't realise that we had `showQuotedHeadline` available in the model. Then when it was added in, it wasn't realised that this is the _only_ value we should look at, and hence that the design check should be removed.

This is just a hypothesis though; I haven't been able to confirm it yet, but thought it would be best to check if anyone has any context here before I go down too much of a rabbit hole!

## Chromatic diffs

This change initially created a lot of Chromatic diffs, because there was a card in the fixtures which had Comment design but had `showQuotedHeadline` as false. I don't think that these fixtures were designed to test this case, so I've updated the fixture to `showQuotedHeadline: true` to reduce noise in the diff history.

I've done the same for the affected `Card` stories, because I think the main point here is to get coverage of the design. But I've added a new story which is `CommentThemeWithoutQuotes` to illustrate that the quote behaviour is decoupled from it being a Comment story within our rendering logic.

## Screenshots

| Before (Frontend)     | Before (DCR)      | After (DCR) |
|-------------|------------| --|
|![image](https://user-images.githubusercontent.com/37048459/221911668-c68fb9fc-7e2d-49e3-ac8f-d22d083a94d8.png)|![image](https://user-images.githubusercontent.com/37048459/221911772-a28e4b62-6395-4f34-a053-a3473cc550e7.png)|![image](https://user-images.githubusercontent.com/37048459/221911862-b16d602a-18f4-475b-bd79-77b722213e84.png)|

