### PR TITLE
WIP refactor personalisation of component id for sign in gate

### DIFF
--- a/dotcom-rendering/src/web/components/SignInGate/gates/main-variant.tsx
+++ b/dotcom-rendering/src/web/components/SignInGate/gates/main-variant.tsx
@@ -38,7 +38,6 @@ const SignInGateMainCheckoutComplete = React.lazy(() => {
  * admin tools, and depending on the state of that switch will determine which variant of the
  * gate to show.
  */
-
 export const signInGateComponent: SignInGateComponent = {
 	gate: ({
 		ophanComponentId,
@@ -63,7 +62,6 @@ export const signInGateComponent: SignInGateComponent = {
 							checkoutCompleteCookieData={
 								checkoutCompleteCookieData
 							}
-							personaliseSignInGateAfterCheckoutSwitch={true}
 						/>
 					) : (
 						<SignInGateMain


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

## Why?

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->


<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
