### PR TITLE
Add page id to callout submission

### DIFF
--- a/dotcom-rendering/fixtures/manual/calloutCampaign.ts
+++ b/dotcom-rendering/fixtures/manual/calloutCampaign.ts
@@ -22,6 +22,7 @@ export const calloutCampaign: CalloutBlockElement = {
 			id: '91884886',
 			type: 'text',
 			required: true,
+			hidden: false,
 		},
 		{
 			name: 'share_your_experiences_here',
@@ -31,6 +32,7 @@ export const calloutCampaign: CalloutBlockElement = {
 			id: '91884874',
 			type: 'textarea',
 			required: true,
+			hidden: false,
 		},
 		{
 			name: 'you_can_upload_a_photo_here_if_you_think_it_will_add_to_your_story',
@@ -39,6 +41,7 @@ export const calloutCampaign: CalloutBlockElement = {
 			id: '91884877',
 			type: 'file',
 			required: false,
+			hidden: false,
 		},
 		{
 			name: 'can_we_publish_your_response',
@@ -65,6 +68,7 @@ export const calloutCampaign: CalloutBlockElement = {
 			id: '91884878',
 			type: 'radio',
 			required: true,
+			hidden: false,
 		},
 		{
 			name: 'can_we_publish_your_response',
@@ -91,6 +95,7 @@ export const calloutCampaign: CalloutBlockElement = {
 			id: '918848785',
 			type: 'checkbox',
 			required: true,
+			hidden: false,
 		},
 		{
 			name: 'do_you_have_anything_else_to_add',
@@ -117,6 +122,7 @@ export const calloutCampaign: CalloutBlockElement = {
 				},
 			],
 			required: false,
+			hidden: false,
 		},
 	],
 };
@@ -143,6 +149,7 @@ export const calloutCampaignOnlyTwoRadio: CalloutBlockElement = {
 			id: '91884886',
 			type: 'text',
 			required: true,
+			hidden: false,
 		},
 		{
 			name: 'share_your_experiences_here',
@@ -152,6 +159,7 @@ export const calloutCampaignOnlyTwoRadio: CalloutBlockElement = {
 			id: '91884874',
 			type: 'textarea',
 			required: true,
+			hidden: false,
 		},
 		{
 			name: 'you_can_upload_a_photo_here_if_you_think_it_will_add_to_your_story',
@@ -160,6 +168,7 @@ export const calloutCampaignOnlyTwoRadio: CalloutBlockElement = {
 			id: '91884877',
 			type: 'file',
 			required: false,
+			hidden: false,
 		},
 		{
 			name: 'can_we_publish_your_response',
@@ -178,6 +187,7 @@ export const calloutCampaignOnlyTwoRadio: CalloutBlockElement = {
 			id: '91884878',
 			type: 'radio',
 			required: true,
+			hidden: false,
 		},
 		{
 			name: 'can_we_publish_your_response',
@@ -204,6 +214,7 @@ export const calloutCampaignOnlyTwoRadio: CalloutBlockElement = {
 			id: '918848785',
 			type: 'checkbox',
 			required: true,
+			hidden: false,
 		},
 		{
 			name: 'do_you_have_anything_else_to_add',
@@ -230,6 +241,7 @@ export const calloutCampaignOnlyTwoRadio: CalloutBlockElement = {
 				},
 			],
 			required: false,
+			hidden: false,
 		},
 	],
 };

--- a/dotcom-rendering/fixtures/manual/calloutCampaignV2.ts
+++ b/dotcom-rendering/fixtures/manual/calloutCampaignV2.ts
@@ -17,6 +17,16 @@ export const calloutCampaign: CalloutBlockElementV2 = {
 		'<p>We’d like to hear how people are being affected, whether they’re applying for a mortgage or refixing an existing one. Are you on a variable rate mortgage, or a fixed rate that is about to expire? How will it impact you financially? </p> <p> We’re also interested in how people, particularly first-time buyers, have been affected by disappearing mortgage deals. </p> ',
 	formFields: [
 		{
+			name: 'referrer',
+			description: 'This field is hidden and is not rendered',
+			hideLabel: false,
+			label: 'referrer',
+			id: 'referrer',
+			type: 'text',
+			required: true,
+			hidden: true,
+		},
+		{
 			name: 'your_name',
 			description: 'How should we refer to you?',
 			hideLabel: false,
@@ -24,6 +34,7 @@ export const calloutCampaign: CalloutBlockElementV2 = {
 			id: 'name',
 			type: 'text',
 			required: true,
+			hidden: false,
 		},
 		{
 			name: 'where_do_you_live',
@@ -33,6 +44,7 @@ export const calloutCampaign: CalloutBlockElementV2 = {
 			id: 'live',
 			type: 'text',
 			required: true,
+			hidden: false,
 		},
 		{
 			name: 'tell_us_a_bit_about_yourself',
@@ -42,6 +54,7 @@ export const calloutCampaign: CalloutBlockElementV2 = {
 			id: 'about',
 			type: 'text',
 			required: true,
+			hidden: false,
 		},
 		{
 			name: 'share_your_experiences',
@@ -51,6 +64,7 @@ export const calloutCampaign: CalloutBlockElementV2 = {
 			id: 'experience',
 			type: 'textarea',
 			required: true,
+			hidden: false,
 		},
 		{
 			name: 'what_events_did_you_attend',
@@ -60,6 +74,7 @@ export const calloutCampaign: CalloutBlockElementV2 = {
 			id: 'events',
 			type: 'checkbox',
 			required: false,
+			hidden: false,
 			options: [
 				{
 					label: '1st Dec',
@@ -84,6 +99,7 @@ export const calloutCampaign: CalloutBlockElementV2 = {
 			id: 'upload',
 			type: 'file',
 			required: false,
+			hidden: false,
 		},
 		{
 			name: 'can_we_publish_your_response',
@@ -110,6 +126,7 @@ export const calloutCampaign: CalloutBlockElementV2 = {
 			id: 'permissions',
 			type: 'select',
 			required: true,
+			hidden: false,
 		},
 		{
 			name: 'your_phone_number',
@@ -120,6 +137,7 @@ export const calloutCampaign: CalloutBlockElementV2 = {
 			id: 'phone',
 			type: 'text',
 			required: true,
+			hidden: false,
 		},
 		{
 			name: 'your_email_address',
@@ -130,6 +148,7 @@ export const calloutCampaign: CalloutBlockElementV2 = {
 			id: 'email',
 			type: 'text',
 			required: true,
+			hidden: false,
 		},
 		{
 			name: 'additional_information',
@@ -139,6 +158,7 @@ export const calloutCampaign: CalloutBlockElementV2 = {
 			id: 'additional',
 			type: 'textarea',
 			required: false,
+			hidden: false,
 		},
 	],
 	contacts: [

--- a/dotcom-rendering/src/model/article-schema.json
+++ b/dotcom-rendering/src/model/article-schema.json
@@ -881,11 +881,15 @@
                 "hideLabel": {
                     "type": "boolean"
                 },
+                "hidden": {
+                    "type": "boolean"
+                },
                 "label": {
                     "type": "string"
                 }
             },
             "required": [
+                "hidden",
                 "hideLabel",
                 "id",
                 "label",
@@ -921,11 +925,15 @@
                 "hideLabel": {
                     "type": "boolean"
                 },
+                "hidden": {
+                    "type": "boolean"
+                },
                 "label": {
                     "type": "string"
                 }
             },
             "required": [
+                "hidden",
                 "hideLabel",
                 "id",
                 "label",
@@ -961,11 +969,15 @@
                 "hideLabel": {
                     "type": "boolean"
                 },
+                "hidden": {
+                    "type": "boolean"
+                },
                 "label": {
                     "type": "string"
                 }
             },
             "required": [
+                "hidden",
                 "hideLabel",
                 "id",
                 "label",
@@ -1019,11 +1031,15 @@
                 "hideLabel": {
                     "type": "boolean"
                 },
+                "hidden": {
+                    "type": "boolean"
+                },
                 "label": {
                     "type": "string"
                 }
             },
             "required": [
+                "hidden",
                 "hideLabel",
                 "id",
                 "label",
@@ -1078,11 +1094,15 @@
                 "hideLabel": {
                     "type": "boolean"
                 },
+                "hidden": {
+                    "type": "boolean"
+                },
                 "label": {
                     "type": "string"
                 }
             },
             "required": [
+                "hidden",
                 "hideLabel",
                 "id",
                 "label",
@@ -1137,11 +1157,15 @@
                 "hideLabel": {
                     "type": "boolean"
                 },
+                "hidden": {
+                    "type": "boolean"
+                },
                 "label": {
                     "type": "string"
                 }
             },
             "required": [
+                "hidden",
                 "hideLabel",
                 "id",
                 "label",

--- a/dotcom-rendering/src/types/content.ts
+++ b/dotcom-rendering/src/types/content.ts
@@ -737,6 +737,7 @@ interface CampaignField {
 	required: boolean;
 	textSize?: number;
 	hideLabel: boolean;
+	hidden: boolean;
 	label: string;
 }
 

--- a/dotcom-rendering/src/web/components/Callout/Callout.tsx
+++ b/dotcom-rendering/src/web/components/Callout/Callout.tsx
@@ -51,6 +51,7 @@ export interface CalloutBlockProps {
 	isExpired: boolean;
 	isNonCollapsible: boolean;
 	contacts?: CalloutContactType[];
+	pageId: string;
 }
 
 export const CalloutBlock = ({
@@ -61,10 +62,10 @@ export const CalloutBlock = ({
 	submissionURL,
 	isNonCollapsible,
 	contacts,
+	pageId,
 }: CalloutBlockProps) => {
 	const [selectedTab, setSelectedTab] = useState('form');
 	const shouldShowContacts = contacts && contacts.length > 0;
-
 	const tabsContent = [
 		{
 			id: 'form',
@@ -74,6 +75,7 @@ export const CalloutBlock = ({
 					formFields={formFields}
 					submissionURL={submissionURL}
 					formID={formId}
+					pageId={pageId}
 				/>
 			),
 		},

--- a/dotcom-rendering/src/web/components/Callout/Form.tsx
+++ b/dotcom-rendering/src/web/components/Callout/Form.tsx
@@ -63,9 +63,15 @@ type FormProps = {
 	formFields: CampaignFieldType[];
 	submissionURL: string;
 	formID: string;
+	pageId: string;
 };
 
-export const Form = ({ formFields, submissionURL, formID }: FormProps) => {
+export const Form = ({
+	formFields,
+	submissionURL,
+	formID,
+	pageId,
+}: FormProps) => {
 	const [formData, setFormData] = useState<FormDataType>({});
 	const [validationErrors, setValidationErrors] = useState<{
 		[key in string]: string;
@@ -230,16 +236,19 @@ export const Form = ({ formFields, submissionURL, formID }: FormProps) => {
 						`}
 					/>
 				)}
-				{formFields.map((formField) => (
-					<div css={formFieldWrapperStyles} key={formField.id}>
-						<FormField
-							formField={formField}
-							formData={formData}
-							setFieldInFormData={setFieldInFormData}
-							validationErrors={validationErrors}
-						/>
-					</div>
-				))}
+				{formFields.map((formField) => {
+					return (
+						<div css={formFieldWrapperStyles} key={formField.id}>
+							<FormField
+								formField={formField}
+								formData={formData}
+								setFieldInFormData={setFieldInFormData}
+								validationErrors={validationErrors}
+								pageId={pageId}
+							/>
+						</div>
+					);
+				})}
 				<div css={textStyles}>
 					One of our journalists will be in contact before we publish
 					your information, so please do leave contact details.

--- a/dotcom-rendering/src/web/components/Callout/Form.tsx
+++ b/dotcom-rendering/src/web/components/Callout/Form.tsx
@@ -39,10 +39,10 @@ const formStyles = css`
 	justify-content: space-between;
 `;
 
-const formFieldWrapperStyles = css`
+const formFieldWrapperStyles = (hidden: boolean) => css`
 	display: flex;
 	flex-direction: column;
-	margin-bottom: ${space[4]}px;
+	margin-bottom: ${hidden ? 0 : space[4]}px;
 `;
 const submitButtonStyles = css`
 	margin: 20px 0px;
@@ -238,7 +238,10 @@ export const Form = ({
 				)}
 				{formFields.map((formField) => {
 					return (
-						<div css={formFieldWrapperStyles} key={formField.id}>
+						<div
+							css={formFieldWrapperStyles(formField.hidden)}
+							key={formField.id}
+						>
 							<FormField
 								formField={formField}
 								formData={formData}

--- a/dotcom-rendering/src/web/components/Callout/FormField.tsx
+++ b/dotcom-rendering/src/web/components/Callout/FormField.tsx
@@ -1,3 +1,4 @@
+import { css } from '@emotion/react';
 import {
 	Checkbox,
 	CheckboxGroup,
@@ -9,6 +10,7 @@ import {
 	TextInput,
 } from '@guardian/source-react-components';
 import { FileInput } from '@guardian/source-react-components-development-kitchen';
+import { useEffect, useRef } from 'react';
 import type { CampaignFieldType } from '../../../types/content';
 
 type FormDataType = { [key in string]: any };
@@ -17,6 +19,7 @@ type FormFieldProp = {
 	validationErrors: { [key in string]: string };
 	formField: CampaignFieldType;
 	formData: FormDataType;
+	pageId: string;
 	setFieldInFormData: (
 		id: string,
 		data: string | string[] | undefined,
@@ -27,6 +30,7 @@ export const FormField = ({
 	formField,
 	formData,
 	setFieldInFormData,
+	pageId,
 	validationErrors,
 }: FormFieldProp) => {
 	const { type, label, hideLabel, description, required, id } = formField;
@@ -36,10 +40,24 @@ export const FormField = ({
 		formField.id in formData ? (formData[formField.id] as string) : '';
 	const fieldError = validationErrors[formField.id];
 
+	const firstUpdate = useRef(true);
+
+	useEffect(() => {
+		if (
+			firstUpdate.current &&
+			formField.hidden &&
+			formField.type === 'text'
+		) {
+			setFieldInFormData(formField.id, pageId);
+			firstUpdate.current = false;
+		}
+	}, [formField, pageId, setFieldInFormData]);
+
 	switch (formField.type) {
 		case 'phone':
 		case 'email':
 		case 'text': {
+			if (formField.hidden) return null;
 			return (
 				<TextInput
 					name={name}
@@ -173,7 +191,7 @@ export const FormField = ({
 				<RadioGroup
 					label={formField.label}
 					supporting={formField.description}
-					error={validationErrors?.[formField.id]}
+					error={validationErrors[formField.id]}
 					name={formField.name}
 					orientation={
 						formField.options.length > 2 ? 'vertical' : 'horizontal'

--- a/dotcom-rendering/src/web/components/Callout/FormField.tsx
+++ b/dotcom-rendering/src/web/components/Callout/FormField.tsx
@@ -1,4 +1,3 @@
-import { css } from '@emotion/react';
 import {
 	Checkbox,
 	CheckboxGroup,

--- a/dotcom-rendering/src/web/components/CalloutBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/web/components/CalloutBlockComponent.importable.tsx
@@ -6,8 +6,10 @@ import { Deadline } from './Callout/Deadline';
 
 export const CalloutBlockComponent = ({
 	callout,
+	pageId,
 }: {
 	callout: CalloutBlockElementV2;
+	pageId: string;
 }) => {
 	const {
 		title,
@@ -55,6 +57,7 @@ export const CalloutBlockComponent = ({
 							isExpired={isExpired(activeUntil)}
 							isNonCollapsible={isNonCollapsible}
 							contacts={contacts}
+							pageId={pageId}
 						/>
 					</ExpandingWrapper>
 				</aside>
@@ -68,6 +71,7 @@ export const CalloutBlockComponent = ({
 					isExpired={isExpired(activeUntil)}
 					isNonCollapsible={isNonCollapsible}
 					contacts={contacts}
+					pageId={pageId}
 				/>
 			)}
 		</>

--- a/dotcom-rendering/src/web/components/CalloutBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/web/components/CalloutBlockComponent.stories.tsx
@@ -4,6 +4,8 @@ import { CalloutBlockComponent } from './CalloutBlockComponent.importable';
 
 const tomorrow = new Date().setDate(new Date().getDate() + 1) / 1000;
 const yesterday = new Date().setDate(new Date().getDate() - 1) / 1000;
+const pageId =
+	'world/2023/mar/01/tell-us-have-you-been-affected-by-the-train-crash-in-greece';
 
 const goodRequest = () => {
 	fetchMock
@@ -43,6 +45,7 @@ export const Collapsible = () => {
 				isNonCollapsible: false,
 				activeUntil: tomorrow,
 			}}
+			pageId={pageId}
 		/>
 	);
 };
@@ -54,6 +57,7 @@ export const NonCollapsible = () => {
 	return (
 		<CalloutBlockComponent
 			callout={{ ...calloutCampaignV2, activeUntil: tomorrow }}
+			pageId={pageId}
 		/>
 	);
 };
@@ -65,6 +69,7 @@ export const SubmissionFailure = () => {
 	return (
 		<CalloutBlockComponent
 			callout={{ ...calloutCampaignV2, activeUntil: tomorrow }}
+			pageId={pageId}
 		/>
 	);
 };
@@ -75,6 +80,7 @@ export const Expired = () => {
 	return (
 		<CalloutBlockComponent
 			callout={{ ...calloutCampaignV2, activeUntil: yesterday }}
+			pageId={pageId}
 		/>
 	);
 };

--- a/dotcom-rendering/src/web/components/CalloutEmbed/Form.test.tsx
+++ b/dotcom-rendering/src/web/components/CalloutEmbed/Form.test.tsx
@@ -18,6 +18,7 @@ const textField: CampaignFieldText = {
 	id: '91884886',
 	type: 'text',
 	required: true,
+	hidden: false,
 };
 
 const textAreaField: CampaignFieldTextArea = {
@@ -28,6 +29,7 @@ const textAreaField: CampaignFieldTextArea = {
 	id: '91884874',
 	type: 'textarea',
 	required: true,
+	hidden: false,
 };
 
 const fileField: CampaignFieldFile = {
@@ -37,6 +39,7 @@ const fileField: CampaignFieldFile = {
 	id: '91884877',
 	type: 'file',
 	required: false,
+	hidden: false,
 };
 
 const firstRadioOption = {
@@ -62,6 +65,7 @@ const radioField: CampaignFieldRadio = {
 	id: '91884878',
 	type: 'radio',
 	required: true,
+	hidden: false,
 };
 
 const firstCheckboxOption = {
@@ -87,6 +91,7 @@ const checkboxField: CampaignFieldCheckbox = {
 	id: '91884871',
 	type: 'checkbox',
 	required: true,
+	hidden: false,
 };
 
 const selectField: CampaignFieldSelect = {
@@ -106,6 +111,7 @@ const selectField: CampaignFieldSelect = {
 		},
 	],
 	required: false,
+	hidden: false,
 };
 
 describe('Callout from', () => {

--- a/dotcom-rendering/src/web/lib/renderElement.tsx
+++ b/dotcom-rendering/src/web/lib/renderElement.tsx
@@ -187,7 +187,10 @@ export const renderElement = ({
 			if (switches.callouts) {
 				return (
 					<Island deferUntil="visible">
-						<CalloutBlockComponent callout={element} />
+						<CalloutBlockComponent
+							callout={element}
+							pageId={pageId}
+						/>
 					</Island>
 				);
 			}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR adds support for the `hidden` property for the callout form fields. If field is hodden, it won't be rendered in the page. If the hidden field is a text field, the page id is added as the field value and will be submitted to formstack.

Previous PRs that introduced this change in targeting and frontend:
- targeting https://github.com/guardian/targeting/pull/175
- frontend https://github.com/guardian/frontend/pull/25935

## Why?
Since a callout can be used in several articles, community team is interested to know where the source of the responses are. 

## Screenshots
No UI change