### PR TITLE
Fix Problem With Some Onward Content Images Not Loading

### DIFF
--- a/apps-rendering/src/image.test.ts
+++ b/apps-rendering/src/image.test.ts
@@ -52,11 +52,11 @@ const roleTestCases = [
 	},
 ];
 const expectedSrcset =
-	'https://i.guim.co.uk/img/theguardian/?width=140&quality=85&fit=bounds&s=ac6b008b5309f7949d1087af108c1d03 140w, https://i.guim.co.uk/img/theguardian/?width=500&quality=85&fit=bounds&s=4b9b01008452c65efcb547bd5f8ae12b 500w, https://i.guim.co.uk/img/theguardian/?width=1000&quality=85&fit=bounds&s=9b5034dd81e916d352709a20f6635448 1000w, https://i.guim.co.uk/img/theguardian/?width=1500&quality=85&fit=bounds&s=2c439ea2daa935d4a2a268ef7a2a9146 1500w, https://i.guim.co.uk/img/theguardian/?width=2000&quality=85&fit=bounds&s=3877ef3c2ed016cccf1ab7b6e6001841 2000w, https://i.guim.co.uk/img/theguardian/?width=2500&quality=85&fit=bounds&s=81d2b2f5b95615f1d47d61f64f5e61a6 2500w, https://i.guim.co.uk/img/theguardian/?width=3000&quality=85&fit=bounds&s=b362f368e5f123ce2c7b45dedee361db 3000w';
+	'https://i.guim.co.uk/img/media/?width=140&quality=85&fit=bounds&s=ac6b008b5309f7949d1087af108c1d03 140w, https://i.guim.co.uk/img/media/?width=500&quality=85&fit=bounds&s=4b9b01008452c65efcb547bd5f8ae12b 500w, https://i.guim.co.uk/img/media/?width=1000&quality=85&fit=bounds&s=9b5034dd81e916d352709a20f6635448 1000w, https://i.guim.co.uk/img/media/?width=1500&quality=85&fit=bounds&s=2c439ea2daa935d4a2a268ef7a2a9146 1500w, https://i.guim.co.uk/img/media/?width=2000&quality=85&fit=bounds&s=3877ef3c2ed016cccf1ab7b6e6001841 2000w, https://i.guim.co.uk/img/media/?width=2500&quality=85&fit=bounds&s=81d2b2f5b95615f1d47d61f64f5e61a6 2500w, https://i.guim.co.uk/img/media/?width=3000&quality=85&fit=bounds&s=b362f368e5f123ce2c7b45dedee361db 3000w';
 const expectedDpr2Srcset =
-	'https://i.guim.co.uk/img/theguardian/?width=140&quality=45&fit=bounds&s=7c3b49aa008fdd8970b8666fa745b172 140w, https://i.guim.co.uk/img/theguardian/?width=500&quality=45&fit=bounds&s=88ff17dc42cac7e76d0670385a7755ee 500w, https://i.guim.co.uk/img/theguardian/?width=1000&quality=45&fit=bounds&s=5a22db10fa466232189124d82bcb0ee5 1000w, https://i.guim.co.uk/img/theguardian/?width=1500&quality=45&fit=bounds&s=8214d581fb7adf78b3c6ff1aa780124d 1500w, https://i.guim.co.uk/img/theguardian/?width=2000&quality=45&fit=bounds&s=686301d1879e13b008002cf9b089aa74 2000w, https://i.guim.co.uk/img/theguardian/?width=2500&quality=45&fit=bounds&s=623e18ec906f4d4b6d3cbabf675e9c4f 2500w, https://i.guim.co.uk/img/theguardian/?width=3000&quality=45&fit=bounds&s=63534271489a79fe83497057e7c8f158 3000w';
+	'https://i.guim.co.uk/img/media/?width=140&quality=45&fit=bounds&s=7c3b49aa008fdd8970b8666fa745b172 140w, https://i.guim.co.uk/img/media/?width=500&quality=45&fit=bounds&s=88ff17dc42cac7e76d0670385a7755ee 500w, https://i.guim.co.uk/img/media/?width=1000&quality=45&fit=bounds&s=5a22db10fa466232189124d82bcb0ee5 1000w, https://i.guim.co.uk/img/media/?width=1500&quality=45&fit=bounds&s=8214d581fb7adf78b3c6ff1aa780124d 1500w, https://i.guim.co.uk/img/media/?width=2000&quality=45&fit=bounds&s=686301d1879e13b008002cf9b089aa74 2000w, https://i.guim.co.uk/img/media/?width=2500&quality=45&fit=bounds&s=623e18ec906f4d4b6d3cbabf675e9c4f 2500w, https://i.guim.co.uk/img/media/?width=3000&quality=45&fit=bounds&s=63534271489a79fe83497057e7c8f158 3000w';
 const expectedSrc =
-	'https://i.guim.co.uk/img/theguardian/?width=500&quality=85&fit=bounds&s=4b9b01008452c65efcb547bd5f8ae12b';
+	'https://i.guim.co.uk/img/media/?width=500&quality=85&fit=bounds&s=4b9b01008452c65efcb547bd5f8ae12b';
 
 // ----- Tests ----- //
 
@@ -81,7 +81,7 @@ describe('parseImage', () => {
 
 		asset = {
 			type: AssetType.IMAGE,
-			file: 'https://theguardian.com',
+			file: 'https://media.guim.co.uk/',
 			typeData: assetTypeData,
 		};
 
@@ -152,11 +152,11 @@ describe('parseImage', () => {
 	});
 
 	test('uses secureFile rather than asset file for srcsets if it exists', () => {
-		assetTypeData.secureFile = 'https://secure-theguardian.com';
+		assetTypeData.secureFile = 'https://static-secure.guim.co.uk/';
 		const expectedSecureDpr2Srcset =
-			'https://i.guim.co.uk/img/secure-theguardian/?width=140&quality=45&fit=bounds&s=7c3b49aa008fdd8970b8666fa745b172 140w, https://i.guim.co.uk/img/secure-theguardian/?width=500&quality=45&fit=bounds&s=88ff17dc42cac7e76d0670385a7755ee 500w, https://i.guim.co.uk/img/secure-theguardian/?width=1000&quality=45&fit=bounds&s=5a22db10fa466232189124d82bcb0ee5 1000w, https://i.guim.co.uk/img/secure-theguardian/?width=1500&quality=45&fit=bounds&s=8214d581fb7adf78b3c6ff1aa780124d 1500w, https://i.guim.co.uk/img/secure-theguardian/?width=2000&quality=45&fit=bounds&s=686301d1879e13b008002cf9b089aa74 2000w, https://i.guim.co.uk/img/secure-theguardian/?width=2500&quality=45&fit=bounds&s=623e18ec906f4d4b6d3cbabf675e9c4f 2500w, https://i.guim.co.uk/img/secure-theguardian/?width=3000&quality=45&fit=bounds&s=63534271489a79fe83497057e7c8f158 3000w';
+			'https://i.guim.co.uk/img/static/?width=140&quality=45&fit=bounds&s=7c3b49aa008fdd8970b8666fa745b172 140w, https://i.guim.co.uk/img/static/?width=500&quality=45&fit=bounds&s=88ff17dc42cac7e76d0670385a7755ee 500w, https://i.guim.co.uk/img/static/?width=1000&quality=45&fit=bounds&s=5a22db10fa466232189124d82bcb0ee5 1000w, https://i.guim.co.uk/img/static/?width=1500&quality=45&fit=bounds&s=8214d581fb7adf78b3c6ff1aa780124d 1500w, https://i.guim.co.uk/img/static/?width=2000&quality=45&fit=bounds&s=686301d1879e13b008002cf9b089aa74 2000w, https://i.guim.co.uk/img/static/?width=2500&quality=45&fit=bounds&s=623e18ec906f4d4b6d3cbabf675e9c4f 2500w, https://i.guim.co.uk/img/static/?width=3000&quality=45&fit=bounds&s=63534271489a79fe83497057e7c8f158 3000w';
 		const expectedSecureSrcset =
-			'https://i.guim.co.uk/img/secure-theguardian/?width=140&quality=85&fit=bounds&s=ac6b008b5309f7949d1087af108c1d03 140w, https://i.guim.co.uk/img/secure-theguardian/?width=500&quality=85&fit=bounds&s=4b9b01008452c65efcb547bd5f8ae12b 500w, https://i.guim.co.uk/img/secure-theguardian/?width=1000&quality=85&fit=bounds&s=9b5034dd81e916d352709a20f6635448 1000w, https://i.guim.co.uk/img/secure-theguardian/?width=1500&quality=85&fit=bounds&s=2c439ea2daa935d4a2a268ef7a2a9146 1500w, https://i.guim.co.uk/img/secure-theguardian/?width=2000&quality=85&fit=bounds&s=3877ef3c2ed016cccf1ab7b6e6001841 2000w, https://i.guim.co.uk/img/secure-theguardian/?width=2500&quality=85&fit=bounds&s=81d2b2f5b95615f1d47d61f64f5e61a6 2500w, https://i.guim.co.uk/img/secure-theguardian/?width=3000&quality=85&fit=bounds&s=b362f368e5f123ce2c7b45dedee361db 3000w';
+			'https://i.guim.co.uk/img/static/?width=140&quality=85&fit=bounds&s=ac6b008b5309f7949d1087af108c1d03 140w, https://i.guim.co.uk/img/static/?width=500&quality=85&fit=bounds&s=4b9b01008452c65efcb547bd5f8ae12b 500w, https://i.guim.co.uk/img/static/?width=1000&quality=85&fit=bounds&s=9b5034dd81e916d352709a20f6635448 1000w, https://i.guim.co.uk/img/static/?width=1500&quality=85&fit=bounds&s=2c439ea2daa935d4a2a268ef7a2a9146 1500w, https://i.guim.co.uk/img/static/?width=2000&quality=85&fit=bounds&s=3877ef3c2ed016cccf1ab7b6e6001841 2000w, https://i.guim.co.uk/img/static/?width=2500&quality=85&fit=bounds&s=81d2b2f5b95615f1d47d61f64f5e61a6 2500w, https://i.guim.co.uk/img/static/?width=3000&quality=85&fit=bounds&s=b362f368e5f123ce2c7b45dedee361db 3000w';
 
 		const parsedImage =
 			parseImage(context)(imageBlock).withDefault(defaultImage);
@@ -212,7 +212,7 @@ describe('parseCardImage', () => {
 			salt: 'mockSalt',
 		};
 		cardImage = {
-			url: 'https://theguardian.com',
+			url: 'https://media.guim.co.uk',
 			height: 20,
 			width: 10,
 			altText: 'someAltText',

--- a/apps-rendering/src/image/srcsets.test.ts
+++ b/apps-rendering/src/image/srcsets.test.ts
@@ -1,25 +1,67 @@
 // ----- Imports ----- //
 
-import { Dpr, srcset } from "./srcsets";
+import { Dpr, src, srcset } from "./srcsets";
+
+// ----- Setup ----- //
+
+const imagePath = '948ad0a2ebe6d931d8827ea89ac184986af76c1b/0_22_1313_788/master/1313.jpg';
+const staticDomain = 'https://static.guim.co.uk';
+const mediaDomain = 'https://media.guim.co.uk';
+const uploadsDomain = 'https://uploads.guim.co.uk';
+const staticSecureDomain = 'https://static-secure.guim.co.uk';
 
 // ----- Tests ----- //
 
 describe("srcsets", () => {
-  test("show lower quality when DPR is 2", () => {
-    const src = srcset(
-      "https://media.guim.co.uk/img/media/948ad0a2ebe6d931d8827ea89ac184986af76c1b/0_22_1313_788/master/1313.jpg",
-      "",
-      Dpr.Two
-    );
-    expect(src).toContain("quality=45");
+  describe('srcset', () => {
+    test("show lower quality when DPR is 2", () => {
+      const result = srcset(
+        `${mediaDomain}/${imagePath}`,
+        "",
+        Dpr.Two
+      );
+      expect(result).toContain("quality=45");
+    });
+
+    test("show higher quality when DPR is 1", () => {
+      const result = srcset(
+        `${mediaDomain}/${imagePath}`,
+        "",
+        Dpr.One
+      );
+      expect(result).toContain("quality=85");
+    });
   });
 
-  test("show higher quality when DPR is 1", () => {
-    const src = srcset(
-      "https://media.guim.co.uk/img/media/948ad0a2ebe6d931d8827ea89ac184986af76c1b/0_22_1313_788/master/1313.jpg",
-      "",
-      Dpr.One
-    );
-    expect(src).toContain("quality=85");
+  describe('src', () => {
+    test('provide a valid URL for "static" assets', () => {
+      const result = new URL(src('', `${staticDomain}/${imagePath}`, 500, Dpr.One));
+
+      expect(result.pathname).toBe(`/img/static/${imagePath}`);
+    });
+
+    test('provide a valid URL for "media" assets', () => {
+      const result = new URL(src('', `${mediaDomain}/${imagePath}`, 500, Dpr.One));
+
+      expect(result.pathname).toBe(`/img/media/${imagePath}`);
+    });
+
+    test('provide a valid URL for "uploads" assets', () => {
+      const result = new URL(src('', `${uploadsDomain}/${imagePath}`, 500, Dpr.One));
+
+      expect(result.pathname).toBe(`/img/uploads/${imagePath}`);
+    });
+
+    test('provide a valid URL for "static-secure" assets', () => {
+      const result = new URL(src('', `${staticSecureDomain}/${imagePath}`, 500, Dpr.One));
+
+      expect(result.pathname).toBe(`/img/static/${imagePath}`);
+    });
+
+    test('attempt to use a media URL for unrecognised assets', () => {
+      const result = new URL(src('', `https://invalid.guim.co.uk/${imagePath}`, 500, Dpr.One));
+
+      expect(result.pathname).toBe(`/img/media/${imagePath}`);
+    });
   });
 });

--- a/apps-rendering/src/image/srcsets.ts
+++ b/apps-rendering/src/image/srcsets.ts
@@ -27,7 +27,26 @@ interface Srcsets {
 
 // ----- Functions ----- //
 
-const getSubdomain = (domain: string): string => domain.split('.')[0];
+/**
+ * Get the resizing source for a given CAPI asset
+ * 
+ * @param url The asset URL from CAPI
+ * @returns An image resizer source
+ */
+const getSource = (url: URL): string => {
+	const subdomain = url.hostname.split('.')[0];
+
+	switch (subdomain) {
+		case 'static':
+		case 'static-secure':
+			return 'static';
+		case 'uploads':
+			return 'uploads';
+		case 'media':
+		default:
+			return 'media';
+	}
+}
 
 const sign = (salt: string, path: string): string =>
 	createHash('md5')
@@ -38,7 +57,7 @@ function src(salt: string, input: string, width: number, dpr: Dpr): string {
 	return Result.fromUnsafe(() => new URL(input), 'invalid url').either(
 		(_err) => input,
 		(url) => {
-			const service = getSubdomain(url.hostname);
+			const service = getSource(url);
 
 			const params = new URLSearchParams({
 				width: width.toString(),

--- a/apps-rendering/src/image/srcsets.ts
+++ b/apps-rendering/src/image/srcsets.ts
@@ -29,7 +29,7 @@ interface Srcsets {
 
 /**
  * Get the resizing source for a given CAPI asset
- * 
+ *
  * @param url The asset URL from CAPI
  * @returns An image resizer source
  */
@@ -46,7 +46,7 @@ const getSource = (url: URL): string => {
 		default:
 			return 'media';
 	}
-}
+};
 
 const sign = (salt: string, path: string): string =>
 	createHash('md5')

--- a/apps-rendering/src/image/srcsets.ts
+++ b/apps-rendering/src/image/srcsets.ts
@@ -25,6 +25,8 @@ interface Srcsets {
 	dpr2Srcset: string;
 }
 
+type ResizerSource = 'static' | 'uploads' | 'media';
+
 // ----- Functions ----- //
 
 /**
@@ -33,7 +35,7 @@ interface Srcsets {
  * @param url The asset URL from CAPI
  * @returns An image resizer source
  */
-const getSource = (url: URL): string => {
+const getSource = (url: URL): ResizerSource => {
 	const subdomain = url.hostname.split('.')[0];
 
 	switch (subdomain) {


### PR DESCRIPTION
## Why?

Fixes #6274. Some image URLs in onward content are provided on the `static-secure` subdomain. This needs to be translated to the `static` source when building URLs for the Fastly image resizer.

Tested in CODE.

## Changes

- Created image resizer paths with `static`, `uploads` and `media` only
- Added tests for the `src` function
- Updated image tests to use valid domains
