### PR TITLE
Catch and ignore FontFaceSet InvalidModificationError

### DIFF
--- a/dotcom-rendering/src/web/components/SecureSignupIframe.importable.tsx
+++ b/dotcom-rendering/src/web/components/SecureSignupIframe.importable.tsx
@@ -330,10 +330,6 @@ export const SecureSignupIframe = ({
 			} catch (error) {
 				// Safari throws an InvalidModificationError
 				// https://developer.mozilla.org/en-US/docs/Web/API/FontFaceSet/add#exceptions
-				window.guardian.modules.sentry.reportError(
-					error instanceof Error ? error : new Error(String(error)),
-					'secure-signup-iframe',
-				);
 			}
 		});
 	};


### PR DESCRIPTION
## What does this change?

`InvalidModificationError: The object can not be modified in this way` is the most frequent error in Sentry (~300K per month / ~35%):

Following #7285 it is confirmed that all these errors are coming from:

- DCR articles
- Safari browsers
- `SecureSignupIframe.importable.tsx` and the section of code that attempts to add font faces to an iframe

Once we started using `reportError` with a tag all errors:
- that were previously reported under `client-side-prod` moved to `dotcom-rendering`
- had a stack-trace pointing to this section of code

<img width="1255" alt="Screenshot 2023-03-01 at 16 42 38" src="https://user-images.githubusercontent.com/7014230/222208366-fdd17d85-2fb7-4e93-8c2e-77db94788f29.png">

<img width="1257" alt="Screenshot 2023-03-01 at 16 42 53" src="https://user-images.githubusercontent.com/7014230/222208382-1480068a-2e1c-4f2c-a89a-c337ed65f31b.png">

<img width="1015" alt="Screenshot 2023-03-01 at 16 57 34" src="https://user-images.githubusercontent.com/7014230/222209127-afed56da-8044-46b7-974b-d36a87e802e7.png">

This change removes the `reportError` so that we catch and ignore the error and hence it is not reported to Sentry.

## Next steps

@dblatcher I noticed you have worked on this component previously so pinging fyi. I was wondering if you could load the required fonts directly in the iframe? I think the browser will load them from the cache of the main page if the iframe is on the same domain (but please verify).