### PR TITLE
Create 0% Elements Manager AB test

### DIFF
--- a/dotcom-rendering/docs/development/ab-testing-in-dcr.md
+++ b/dotcom-rendering/docs/development/ab-testing-in-dcr.md
@@ -11,7 +11,7 @@ The library docs above explain the integration and the API.
 3. Add your test to [concurrent tests](https://github.com/guardian/frontend/blob/main/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts) on _Frontend_.
 4. Copy the JS file into DCR (and update to TS types) in [web/experiments/tests](https://github.com/guardian/dotcom-rendering/tree/main/dotcom-rendering/src/web/experiments/tests)
 5. Add it to the test array in [src/web/experiments/ab-tests.ts](https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/src/web/experiments/ab-tests.ts)
-6. Use the [A/B test API](https://github.com/guardian/ab-testing#the-api)
+6. Use the [A/B test API](https://github.com/guardian/csnx/tree/main/libs/%40guardian/ab-core#the-api)
 7. Force the A/B test (ignoring canRun of A/B test and variant) with the URL opt-in http://local...#ab-yourTest=yourVariant
 8. Set a GU_mvt_id or GU_mvt_id_local cookie with the MVT ID that matches the test Audience and Audience Offset ([Use this calculator](https://ab-tests.netlify.app/))
 9. Check the network tab for the Ophan request _abTestRegister_ has your test and variant

--- a/dotcom-rendering/src/web/experiments/ab-tests.ts
+++ b/dotcom-rendering/src/web/experiments/ab-tests.ts
@@ -2,6 +2,7 @@ import type { ABTest } from '@guardian/ab-core';
 import { abTestTest } from './tests/ab-test-test';
 import { billboardsInMerch } from './tests/billboards-in-merch';
 import { consentlessAds } from './tests/consentless-ads';
+import { elementsManager } from './tests/elements-manager';
 import { integrateIma } from './tests/integrate-ima';
 import {
 	newsletterMerchUnitLighthouseControl,
@@ -25,4 +26,5 @@ export const tests: ABTest[] = [
 	integrateIma,
 	billboardsInMerch,
 	noCarrotAdsNearNewsletterSignupBlocks,
+	elementsManager,
 ];

--- a/dotcom-rendering/src/web/experiments/tests/elements-manager.ts
+++ b/dotcom-rendering/src/web/experiments/tests/elements-manager.ts
@@ -1,0 +1,18 @@
+import type { ABTest } from '@guardian/ab-core';
+
+export const elementsManager: ABTest = {
+	id: 'ElementsManager',
+	author: '@commercial-dev',
+	start: '2023-02-23',
+	expiry: '2023-06-30',
+	audience: 0 / 100,
+	audienceOffset: 0 / 100,
+	audienceCriteria: 'Opt in only',
+	successMeasure: 'Able to serve GEM assets in ad slots on page',
+	description: 'Test serving GEM assets in ad slots on page',
+	variants: [
+		{ id: 'control', test: (): void => {} },
+		{ id: 'variant', test: (): void => {} },
+	],
+	canRun: () => true,
+};


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Creates a 0% AB test to use for Guardian Elements Manager.

[Frontend PR](https://github.com/guardian/frontend/pull/25940)

## Why?

So that we can incrementally add features to Elements Manager.