### PR TITLE
Adjust dynamicslowmpu if adfree

### DIFF
--- a/dotcom-rendering/src/web/components/DynamicSlowMPU.stories.tsx
+++ b/dotcom-rendering/src/web/components/DynamicSlowMPU.stories.tsx
@@ -162,7 +162,7 @@ export const AllBigs = () => (
 AllBigs.story = { name: 'with lots of bigs and no standards' };
 
 export const AdfreeDynamicSlowMPU = () => (
-	<Section title="DynamicSlowMPU" padContent={false} centralBorder="partial">
+	<FrontSection title="DynamicSlowMPU" centralBorder="partial">
 		<DynamicSlowMPU
 			groupedTrails={{
 				snap: [],
@@ -176,6 +176,6 @@ export const AdfreeDynamicSlowMPU = () => (
 			renderAds={false}
 			trails={trails}
 		/>
-	</Section>
+	</FrontSection>
 );
 AdfreeDynamicSlowMPU.story = { name: 'Ad-free dynamic slow MPU' };

--- a/dotcom-rendering/src/web/components/DynamicSlowMPU.stories.tsx
+++ b/dotcom-rendering/src/web/components/DynamicSlowMPU.stories.tsx
@@ -32,6 +32,8 @@ export const NoBigs = () => (
 			}}
 			showAge={true}
 			index={1}
+			renderAds={true}
+			trails={trails}
 		/>
 	</Section>
 );
@@ -49,6 +51,8 @@ export const OneBig = () => (
 			}}
 			showAge={true}
 			index={1}
+			renderAds={true}
+			trails={trails}
 		/>
 	</Section>
 );
@@ -66,6 +70,8 @@ export const TwoBigs = () => (
 			}}
 			showAge={true}
 			index={1}
+			renderAds={true}
+			trails={trails}
 		/>
 	</Section>
 );
@@ -87,6 +93,8 @@ export const FirstBigBoosted = () => (
 			}}
 			showAge={true}
 			index={1}
+			renderAds={true}
+			trails={trails}
 		/>
 	</Section>
 );
@@ -108,6 +116,8 @@ export const SecondBigBoosted = () => (
 			}}
 			showAge={true}
 			index={1}
+			renderAds={true}
+			trails={trails}
 		/>
 	</Section>
 );
@@ -125,6 +135,8 @@ export const ThreeBigs = () => (
 			}}
 			showAge={true}
 			index={1}
+			renderAds={true}
+			trails={trails}
 		/>
 	</Section>
 );
@@ -142,7 +154,28 @@ export const AllBigs = () => (
 			}}
 			showAge={true}
 			index={1}
+			renderAds={true}
+			trails={trails}
 		/>
 	</Section>
 );
 AllBigs.story = { name: 'with lots of bigs and no standards' };
+
+export const AdfreeDynamicSlowMPU = () => (
+	<Section title="DynamicSlowMPU" padContent={false} centralBorder="partial">
+		<DynamicSlowMPU
+			groupedTrails={{
+				snap: [],
+				huge: [],
+				veryBig: [],
+				big: standards,
+				standard: [],
+			}}
+			showAge={true}
+			index={1}
+			renderAds={false}
+			trails={trails}
+		/>
+	</Section>
+);
+AdfreeDynamicSlowMPU.story = { name: 'Ad-free dynamic slow MPU' };

--- a/dotcom-rendering/src/web/components/DynamicSlowMPU.tsx
+++ b/dotcom-rendering/src/web/components/DynamicSlowMPU.tsx
@@ -5,6 +5,7 @@ import type {
 	DCRGroupedTrails,
 } from '../../types/front';
 import {
+	Card25Media25SmallHeadline,
 	Card33Media33,
 	CardDefault,
 	CardDefaultMediaMobile,
@@ -24,7 +25,13 @@ type Props = {
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
 	index: number;
+	renderAds: boolean;
+	trails: DCRFrontCard[];
 };
+
+type MPUProps = Omit<Props, `renderAds` | `trails`>;
+
+type NonMPUProps = Omit<Props, `groupedTrails` | `index` | `renderAds`>;
 
 /* .___________.___________.___________.
  * |###########|___________|           |
@@ -48,7 +55,12 @@ const Card33_ColumnOfThree33_Ad33 = ({
 	return (
 		<UL direction="row">
 			{card33.map((card) => (
-				<LI percentage="33.333%" padSides={true} key={card.url}>
+				<LI
+					percentage="33.333%"
+					padSides={true}
+					key={card.url}
+					stretch={true}
+				>
 					<Card33Media33
 						trail={card}
 						containerPalette={containerPalette}
@@ -125,26 +137,12 @@ const ColumnOfThree50_Ad50 = ({
 	);
 };
 
-/**
- * DynamicSlowMPU
- *
- * This container only allows big and standard cards (from groupedTrails)
- *
- * Layout is dynamic deopending on the number of big cards. You're only
- * allowed to have 2 or 3 big cards. If you pass 1 a standard card will
- * get promoted to make two bigs. If you pass more than 3 bigs then the
- * extras will get demoted to standard.
- *
- * If you pass no bigs at all the top slice will not render and a special
- * 3 column layout is used for the remaining slice.
- *
- */
-export const DynamicSlowMPU = ({
+const RenderMPU = ({
 	groupedTrails,
 	containerPalette,
 	showAge,
 	index,
-}: Props) => {
+}: MPUProps) => {
 	let layout:
 		| 'noBigs'
 		| 'twoBigs'
@@ -276,4 +274,66 @@ export const DynamicSlowMPU = ({
 			);
 		}
 	}
+};
+
+const RenderNonMPU = ({ trails, containerPalette, showAge }: NonMPUProps) => {
+	return (
+		<UL direction="row" padBottom={true}>
+			{trails.slice(0, 4).map((card, cardIndex) => {
+				return (
+					<LI
+						padSides={true}
+						percentage="25%"
+						showDivider={cardIndex > 0}
+						containerPalette={containerPalette}
+						key={card.url}
+					>
+						<Card25Media25SmallHeadline
+							trail={card}
+							containerPalette={containerPalette}
+							showAge={showAge}
+						/>
+					</LI>
+				);
+			})}
+		</UL>
+	);
+};
+
+/**
+ * DynamicSlowMPU
+ *
+ * This container only allows big and standard cards (from groupedTrails)
+ *
+ * Layout is dynamic deopending on the number of big cards. You're only
+ * allowed to have 2 or 3 big cards. If you pass 1 a standard card will
+ * get promoted to make two bigs. If you pass more than 3 bigs then the
+ * extras will get demoted to standard.
+ *
+ * If you pass no bigs at all the top slice will not render and a special
+ * 3 column layout is used for the remaining slice.
+ *
+ */
+export const DynamicSlowMPU = ({
+	groupedTrails,
+	containerPalette,
+	showAge,
+	index,
+	renderAds,
+	trails,
+}: Props) => {
+	return renderAds ? (
+		<RenderMPU
+			groupedTrails={groupedTrails}
+			containerPalette={containerPalette}
+			showAge={showAge}
+			index={index}
+		/>
+	) : (
+		<RenderNonMPU
+			trails={trails}
+			containerPalette={containerPalette}
+			showAge={showAge}
+		/>
+	);
 };

--- a/dotcom-rendering/src/web/components/DynamicSlowMPU.tsx
+++ b/dotcom-rendering/src/web/components/DynamicSlowMPU.tsx
@@ -55,12 +55,7 @@ const Card33_ColumnOfThree33_Ad33 = ({
 	return (
 		<UL direction="row">
 			{card33.map((card) => (
-				<LI
-					percentage="33.333%"
-					padSides={true}
-					key={card.url}
-					stretch={true}
-				>
+				<LI percentage="33.333%" padSides={true} key={card.url}>
 					<Card33Media33
 						trail={card}
 						containerPalette={containerPalette}

--- a/dotcom-rendering/src/web/components/DynamicSlowMPU.tsx
+++ b/dotcom-rendering/src/web/components/DynamicSlowMPU.tsx
@@ -29,10 +29,6 @@ type Props = {
 	trails: DCRFrontCard[];
 };
 
-type MPUProps = Omit<Props, `renderAds` | `trails`>;
-
-type NonMPUProps = Omit<Props, `groupedTrails` | `index` | `renderAds`>;
-
 /* .___________.___________.___________.
  * |###########|___________|           |
  * |           |___________|    MPU    |
@@ -132,7 +128,14 @@ const ColumnOfThree50_Ad50 = ({
 	);
 };
 
-const RenderMPU = ({
+type MPUProps = {
+	groupedTrails: DCRGroupedTrails;
+	containerPalette?: DCRContainerPalette;
+	showAge?: boolean;
+	index: number;
+};
+
+const MPUSlice = ({
 	groupedTrails,
 	containerPalette,
 	showAge,
@@ -271,7 +274,13 @@ const RenderMPU = ({
 	}
 };
 
-const RenderNonMPU = ({ trails, containerPalette, showAge }: NonMPUProps) => {
+type NonMPUProps = {
+	containerPalette?: DCRContainerPalette;
+	showAge?: boolean;
+	trails: DCRFrontCard[];
+};
+
+const NonMPUSlice = ({ trails, containerPalette, showAge }: NonMPUProps) => {
 	return (
 		<UL direction="row" padBottom={true}>
 			{trails.slice(0, 4).map((card, cardIndex) => {
@@ -318,14 +327,14 @@ export const DynamicSlowMPU = ({
 	trails,
 }: Props) => {
 	return renderAds ? (
-		<RenderMPU
+		<MPUSlice
 			groupedTrails={groupedTrails}
 			containerPalette={containerPalette}
 			showAge={showAge}
 			index={index}
 		/>
 	) : (
-		<RenderNonMPU
+		<NonMPUSlice
 			trails={trails}
 			containerPalette={containerPalette}
 			showAge={showAge}

--- a/dotcom-rendering/src/web/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FrontLayout.tsx
@@ -430,14 +430,16 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 									</Island>
 								)}
 							</Section>
-							{decideAdSlot(
-								index,
-								front.isNetworkFront,
-								front.pressedPage.collections.length,
-								front.pressedPage.frontProperties.isPaidContent,
-								format.display,
-								mobileAdPositions,
-							)}
+							{renderAds &&
+								decideAdSlot(
+									index,
+									front.isNetworkFront,
+									front.pressedPage.collections.length,
+									front.pressedPage.frontProperties
+										.isPaidContent,
+									format.display,
+									mobileAdPositions,
+								)}
 						</>
 					);
 				})}

--- a/dotcom-rendering/src/web/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FrontLayout.tsx
@@ -407,6 +407,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 									showAge={
 										collection.displayName === 'Headlines'
 									}
+									renderAds={renderAds}
 								/>
 								{collection.canShowMore && (
 									<Island deferUntil="interaction">

--- a/dotcom-rendering/src/web/lib/DecideContainer.tsx
+++ b/dotcom-rendering/src/web/lib/DecideContainer.tsx
@@ -29,6 +29,7 @@ type Props = {
 	containerType: DCRContainerType;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
+	renderAds: boolean;
 };
 
 export const DecideContainer = ({
@@ -38,6 +39,7 @@ export const DecideContainer = ({
 	containerType,
 	containerPalette,
 	showAge,
+	renderAds,
 }: Props) => {
 	switch (containerType) {
 		case 'dynamic/fast':
@@ -63,6 +65,8 @@ export const DecideContainer = ({
 					containerPalette={containerPalette}
 					showAge={showAge}
 					index={index}
+					renderAds={renderAds}
+					trails={trails}
 				/>
 			);
 		case 'dynamic/package':


### PR DESCRIPTION
Co-authored-by: Pete Faulconbrige <pete.faulconbridge@guardian.co.uk>

## What does this change?

This enables the Dynamic Slow MPU container (e.g. the "Guardian View" container found on the "Comment is Free" front) to know if it should be rendering ads. If it should, it will render as it does at the moment, with an ad slot. If the page should be ad-free, e.g. if the user is signed in, then it will display the cards in a line, similar to the lower rows of a FixedLargeSlowXIV container.

## Why?

Resolves #7303 and enables the 1% test.

## Screenshots

| Frontend Ad-free      | DCR Ad-free      | 
|-------------|------------|
| ![frontendadfree][] | ![dcradfree][] | 

[frontendadfree]: https://user-images.githubusercontent.com/102960844/222497977-3dbaacea-28bc-43f1-b462-5d97310f064e.png
[dcradfree]: https://user-images.githubusercontent.com/102960844/222499152-16e8da44-2e58-4ee3-be85-2e4cbd40b3d4.png

For reference, this is the container with ads (i.e. as it is at the moment).
![DCRwithAds](https://user-images.githubusercontent.com/102960844/222497701-17d780f0-21af-46fa-9c19-95f90fff5cfa.png)