### PR TITLE
Bump @guardian/eslint-plugin-source-react-components 10.x -> 14.0.0

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -65,7 +65,7 @@
 		"@guardian/discussion-rendering": "^12.0.0",
 		"@guardian/eslint-config": "^2.0.3",
 		"@guardian/eslint-config-typescript": "^2.0.0",
-		"@guardian/eslint-plugin-source-react-components": "^10.0.0",
+		"@guardian/eslint-plugin-source-react-components": "^14.0.0",
 		"@guardian/libs": "^13.1.0",
 		"@guardian/prettier": "^2.1.5",
 		"@guardian/shimport": "^1.0.2",

--- a/dotcom-rendering/src/web/components/Callout/MessageUs.tsx
+++ b/dotcom-rendering/src/web/components/Callout/MessageUs.tsx
@@ -138,7 +138,7 @@ const MessageUs: FC<{ contacts: CalloutContactType[] }> = ({ contacts }) => {
 						priority="primary"
 						href={`${contact.urlPrefix}${contact.value}`}
 						target="_blank"
-						rel="noreferrer noopener"
+						rel="noreferrer"
 						icon={conditionallyRenderContactIcon(contact.name)}
 					>
 						Message us on {formatContactType(contact.name)}

--- a/dotcom-rendering/src/web/components/Callout/MessageUs.tsx
+++ b/dotcom-rendering/src/web/components/Callout/MessageUs.tsx
@@ -138,7 +138,7 @@ const MessageUs: FC<{ contacts: CalloutContactType[] }> = ({ contacts }) => {
 						priority="primary"
 						href={`${contact.urlPrefix}${contact.value}`}
 						target="_blank"
-						rel="noopener"
+						rel="noreferrer noopener"
 						icon={conditionallyRenderContactIcon(contact.name)}
 					>
 						Message us on {formatContactType(contact.name)}

--- a/dotcom-rendering/src/web/components/CalloutEmbed/Form.tsx
+++ b/dotcom-rendering/src/web/components/CalloutEmbed/Form.tsx
@@ -178,7 +178,7 @@ export const Form = ({ onSubmit, formFields, error }: FormProps) => {
 					<Link
 						priority="secondary"
 						target="_blank"
-						rel="noreferrer noopener"
+						rel="noreferrer"
 						href="https://www.theguardian.com/help/terms-of-service"
 						cssOverrides={css`
 							text-decoration: none;

--- a/dotcom-rendering/src/web/components/CalloutEmbed/Form.tsx
+++ b/dotcom-rendering/src/web/components/CalloutEmbed/Form.tsx
@@ -178,6 +178,7 @@ export const Form = ({ onSubmit, formFields, error }: FormProps) => {
 					<Link
 						priority="secondary"
 						target="_blank"
+						rel="noreferrer noopener"
 						href="https://www.theguardian.com/help/terms-of-service"
 						cssOverrides={css`
 							text-decoration: none;

--- a/dotcom-rendering/src/web/components/NewsletterPrivacyMessage.tsx
+++ b/dotcom-rendering/src/web/components/NewsletterPrivacyMessage.tsx
@@ -16,11 +16,7 @@ type LegalLinkProps = { href: PolicyUrl; children: string };
 
 /** Link component fixed with data-ignore and rel attributes for consistency in this file only */
 const LegalLink = ({ href, children }: LegalLinkProps) => (
-	<Link
-		data-ignore="global-link-styling"
-		href={href}
-		rel="noopener noreferrer"
-	>
+	<Link data-ignore="global-link-styling" href={href} rel="noreferrer">
 		{children}
 	</Link>
 );

--- a/dotcom-rendering/src/web/components/SecureSignupIframe.importable.tsx
+++ b/dotcom-rendering/src/web/components/SecureSignupIframe.importable.tsx
@@ -44,7 +44,11 @@ const ErrorMessageWithAdvice = ({ text }: { text?: string }) => (
 	<InlineError>
 		<span>
 			{text} Please try again or contact{' '}
-			<Link href="mailto:customer.help@theguardian.com" target="_blank">
+			<Link
+				href="mailto:customer.help@theguardian.com"
+				target="_blank"
+				rel="noopener noreferrer"
+			>
 				customer.help@theguardian.com
 			</Link>
 		</span>

--- a/dotcom-rendering/src/web/components/SecureSignupIframe.importable.tsx
+++ b/dotcom-rendering/src/web/components/SecureSignupIframe.importable.tsx
@@ -47,7 +47,7 @@ const ErrorMessageWithAdvice = ({ text }: { text?: string }) => (
 			<Link
 				href="mailto:customer.help@theguardian.com"
 				target="_blank"
-				rel="noopener noreferrer"
+				rel="noreferrer"
 			>
 				customer.help@theguardian.com
 			</Link>

--- a/dotcom-rendering/src/web/components/SubMeta.tsx
+++ b/dotcom-rendering/src/web/components/SubMeta.tsx
@@ -256,7 +256,7 @@ export const SubMeta = ({
 									webUrl,
 								)}&type=article&internalpagecode=${pageId}`}
 								target="_blank"
-								rel="noopener noreferrer"
+								rel="noreferrer"
 								title="Reuse this content"
 							>
 								Reuse this content

--- a/dotcom-rendering/src/web/components/SubMeta.tsx
+++ b/dotcom-rendering/src/web/components/SubMeta.tsx
@@ -256,7 +256,7 @@ export const SubMeta = ({
 									webUrl,
 								)}&type=article&internalpagecode=${pageId}`}
 								target="_blank"
-								rel="noopener"
+								rel="noopener noreferrer"
 								title="Reuse this content"
 							>
 								Reuse this content

--- a/dotcom-rendering/src/web/layouts/NewsletterSignupLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/NewsletterSignupLayout.tsx
@@ -409,7 +409,7 @@ export const NewsletterSignupLayout = ({ article, NAV, format }: Props) => {
 										iconSide="left"
 										href={newsletterPreviewUrl}
 										target="_blank"
-										rel="noopener noreferrer"
+										rel="noreferrer"
 										priority="tertiary"
 										size="xsmall"
 									>

--- a/dotcom-rendering/src/web/layouts/NewsletterSignupLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/NewsletterSignupLayout.tsx
@@ -409,6 +409,7 @@ export const NewsletterSignupLayout = ({ article, NAV, format }: Props) => {
 										iconSide="left"
 										href={newsletterPreviewUrl}
 										target="_blank"
+										rel="noopener noreferrer"
 										priority="tertiary"
 										size="xsmall"
 									>
@@ -473,6 +474,7 @@ export const NewsletterSignupLayout = ({ article, NAV, format }: Props) => {
 											target="_blank"
 											icon={<SvgEye size="medium" />}
 											priority="secondary"
+											rel="noreferrer"
 										>
 											Click here to see the latest version
 											of this newsletter

--- a/yarn.lock
+++ b/yarn.lock
@@ -2246,13 +2246,13 @@
     eslint-plugin-eslint-comments "3.2.0"
     eslint-plugin-import "2.26.0"
 
-"@guardian/eslint-plugin-source-react-components@^10.0.0":
-  version "10.0.4"
-  resolved "https://registry.yarnpkg.com/@guardian/eslint-plugin-source-react-components/-/eslint-plugin-source-react-components-10.0.4.tgz#4b51b55869e27facd12cdae667669ed8f877ecf2"
-  integrity sha512-xoFzANU+s9wqyB7EFMIf1alW4dqm4WGVfKTfv+RdbueiAXQdwDM1rImFSw5vyuKQwd7wrTWYpuMhqsZ+X/CVNw==
+"@guardian/eslint-plugin-source-react-components@^14.0.0":
+  version "14.0.0"
+  resolved "https://registry.yarnpkg.com/@guardian/eslint-plugin-source-react-components/-/eslint-plugin-source-react-components-14.0.0.tgz#d13cddbf9b4ec85743cd047f97d3cc75e70eb930"
+  integrity sha512-dhhPD1ml7OqiyBukURGtTMS8sHFWMHOjJfJcrHjhRXw7B6UAl9xEkQv6H94+INDdsWz3GMv2XwQlyMMihuEmSQ==
   dependencies:
-    "@typescript-eslint/eslint-plugin" "5.45.0"
-    "@typescript-eslint/parser" "5.45.0"
+    "@typescript-eslint/eslint-plugin" "5.46.1"
+    "@typescript-eslint/parser" "5.46.1"
 
 "@guardian/libs@^13.1.0":
   version "13.1.0"
@@ -5002,6 +5002,21 @@
     semver "^7.3.7"
     tsutils "^3.21.0"
 
+"@typescript-eslint/eslint-plugin@5.46.1":
+  version "5.46.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.46.1.tgz#098abb4c9354e19f460d57ab18bff1f676a6cff0"
+  integrity sha512-YpzNv3aayRBwjs4J3oz65eVLXc9xx0PDbIRisHj+dYhvBn02MjYOD96P8YGiWEIFBrojaUjxvkaUpakD82phsA==
+  dependencies:
+    "@typescript-eslint/scope-manager" "5.46.1"
+    "@typescript-eslint/type-utils" "5.46.1"
+    "@typescript-eslint/utils" "5.46.1"
+    debug "^4.3.4"
+    ignore "^5.2.0"
+    natural-compare-lite "^1.4.0"
+    regexpp "^3.2.0"
+    semver "^7.3.7"
+    tsutils "^3.21.0"
+
 "@typescript-eslint/eslint-plugin@^5":
   version "5.52.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.52.0.tgz#5fb0d43574c2411f16ea80f5fc335b8eaa7b28a8"
@@ -5035,6 +5050,16 @@
     "@typescript-eslint/typescript-estree" "5.45.0"
     debug "^4.3.4"
 
+"@typescript-eslint/parser@5.46.1":
+  version "5.46.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.46.1.tgz#1fc8e7102c1141eb64276c3b89d70da8c0ba5699"
+  integrity sha512-RelQ5cGypPh4ySAtfIMBzBGyrNerQcmfA1oJvPj5f+H4jI59rl9xxpn4bonC0tQvUKOEN7eGBFWxFLK3Xepneg==
+  dependencies:
+    "@typescript-eslint/scope-manager" "5.46.1"
+    "@typescript-eslint/types" "5.46.1"
+    "@typescript-eslint/typescript-estree" "5.46.1"
+    debug "^4.3.4"
+
 "@typescript-eslint/parser@^5", "@typescript-eslint/parser@^5.10.0":
   version "5.52.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.52.0.tgz#73c136df6c0133f1d7870de7131ccf356f5be5a4"
@@ -5052,6 +5077,14 @@
   dependencies:
     "@typescript-eslint/types" "5.45.0"
     "@typescript-eslint/visitor-keys" "5.45.0"
+
+"@typescript-eslint/scope-manager@5.46.1":
+  version "5.46.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.46.1.tgz#70af8425c79bbc1178b5a63fb51102ddf48e104a"
+  integrity sha512-iOChVivo4jpwUdrJZyXSMrEIM/PvsbbDOX1y3UCKjSgWn+W89skxWaYXACQfxmIGhPVpRWK/VWPYc+bad6smIA==
+  dependencies:
+    "@typescript-eslint/types" "5.46.1"
+    "@typescript-eslint/visitor-keys" "5.46.1"
 
 "@typescript-eslint/scope-manager@5.52.0":
   version "5.52.0"
@@ -5071,6 +5104,16 @@
     debug "^4.3.4"
     tsutils "^3.21.0"
 
+"@typescript-eslint/type-utils@5.46.1":
+  version "5.46.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.46.1.tgz#195033e4b30b51b870dfcf2828e88d57b04a11cc"
+  integrity sha512-V/zMyfI+jDmL1ADxfDxjZ0EMbtiVqj8LUGPAGyBkXXStWmCUErMpW873zEHsyguWCuq2iN4BrlWUkmuVj84yng==
+  dependencies:
+    "@typescript-eslint/typescript-estree" "5.46.1"
+    "@typescript-eslint/utils" "5.46.1"
+    debug "^4.3.4"
+    tsutils "^3.21.0"
+
 "@typescript-eslint/type-utils@5.52.0":
   version "5.52.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.52.0.tgz#9fd28cd02e6f21f5109e35496df41893f33167aa"
@@ -5086,6 +5129,11 @@
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.45.0.tgz#794760b9037ee4154c09549ef5a96599621109c5"
   integrity sha512-QQij+u/vgskA66azc9dCmx+rev79PzX8uDHpsqSjEFtfF2gBUTRCpvYMh2gw2ghkJabNkPlSUCimsyBEQZd1DA==
 
+"@typescript-eslint/types@5.46.1":
+  version "5.46.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.46.1.tgz#4e9db2107b9a88441c4d5ecacde3bb7a5ebbd47e"
+  integrity sha512-Z5pvlCaZgU+93ryiYUwGwLl9AQVB/PQ1TsJ9NZ/gHzZjN7g9IAn6RSDkpCV8hqTwAiaj6fmCcKSQeBPlIpW28w==
+
 "@typescript-eslint/types@5.52.0":
   version "5.52.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.52.0.tgz#19e9abc6afb5bd37a1a9bea877a1a836c0b3241b"
@@ -5098,6 +5146,19 @@
   dependencies:
     "@typescript-eslint/types" "5.45.0"
     "@typescript-eslint/visitor-keys" "5.45.0"
+    debug "^4.3.4"
+    globby "^11.1.0"
+    is-glob "^4.0.3"
+    semver "^7.3.7"
+    tsutils "^3.21.0"
+
+"@typescript-eslint/typescript-estree@5.46.1":
+  version "5.46.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.46.1.tgz#5358088f98a8f9939355e0996f9c8f41c25eced2"
+  integrity sha512-j9W4t67QiNp90kh5Nbr1w92wzt+toiIsaVPnEblB2Ih2U9fqBTyqV9T3pYWZBRt6QoMh/zVWP59EpuCjc4VRBg==
+  dependencies:
+    "@typescript-eslint/types" "5.46.1"
+    "@typescript-eslint/visitor-keys" "5.46.1"
     debug "^4.3.4"
     globby "^11.1.0"
     is-glob "^4.0.3"
@@ -5131,6 +5192,20 @@
     eslint-utils "^3.0.0"
     semver "^7.3.7"
 
+"@typescript-eslint/utils@5.46.1":
+  version "5.46.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.46.1.tgz#7da3c934d9fd0eb4002a6bb3429f33298b469b4a"
+  integrity sha512-RBdBAGv3oEpFojaCYT4Ghn4775pdjvwfDOfQ2P6qzNVgQOVrnSPe5/Pb88kv7xzYQjoio0eKHKB9GJ16ieSxvA==
+  dependencies:
+    "@types/json-schema" "^7.0.9"
+    "@types/semver" "^7.3.12"
+    "@typescript-eslint/scope-manager" "5.46.1"
+    "@typescript-eslint/types" "5.46.1"
+    "@typescript-eslint/typescript-estree" "5.46.1"
+    eslint-scope "^5.1.1"
+    eslint-utils "^3.0.0"
+    semver "^7.3.7"
+
 "@typescript-eslint/utils@5.52.0":
   version "5.52.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.52.0.tgz#b260bb5a8f6b00a0ed51db66bdba4ed5e4845a72"
@@ -5151,6 +5226,14 @@
   integrity sha512-jc6Eccbn2RtQPr1s7th6jJWQHBHI6GBVQkCHoJFQ5UreaKm59Vxw+ynQUPPY2u2Amquc+7tmEoC2G52ApsGNNg==
   dependencies:
     "@typescript-eslint/types" "5.45.0"
+    eslint-visitor-keys "^3.3.0"
+
+"@typescript-eslint/visitor-keys@5.46.1":
+  version "5.46.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.46.1.tgz#126cc6fe3c0f83608b2b125c5d9daced61394242"
+  integrity sha512-jczZ9noovXwy59KjRTk1OftT78pwygdcmCuBf8yMoWt/8O8l+6x2LSEze0E4TeepXK4MezW3zGSyoDRZK7Y9cg==
+  dependencies:
+    "@typescript-eslint/types" "5.46.1"
     eslint-visitor-keys "^3.3.0"
 
 "@typescript-eslint/visitor-keys@5.52.0":
@@ -17887,10 +17970,6 @@ streamroller@^3.1.1:
   version "3.1.4"
   resolved "https://registry.yarnpkg.com/streamroller/-/streamroller-3.1.4.tgz#844a18e795d39c1089a8216e66a1cf1151271df0"
   integrity sha512-Ha1Ccw2/N5C/IF8Do6zgNe8F3jQo8MPBnMBGvX0QjNv/I97BcNRzK6/mzOpZHHK7DjMLTI3c7Xw7Y1KvdChkvw==
-  dependencies:
-    date-format "^4.0.14"
-    debug "^4.3.4"
-    fs-extra "^8.1.0"
 
 string-argv@^0.3.1:
   version "0.3.1"


### PR DESCRIPTION
Bump `@guardian/eslint-plugin-source-react-components` to 14.0.0.

v.13 introduced a `linkComponents` setting, which enabled eslint in DCR to apply the `jsx-no-target-blank` rule to `<Link>` and `<LinkButton>` components from Source. This PR also fixes the errors raised by this rule.

The other major version changes come from dependencies changes, which I think we satisfy already?
