### PR TITLE
Remove Babel loaders from Webpack

### DIFF
--- a/dotcom-rendering/scripts/webpack/browser-targets.js
+++ b/dotcom-rendering/scripts/webpack/browser-targets.js
@@ -3,31 +3,14 @@
  * 1) derive browser targets from @guardian/browserslist-config
  * 2) upgrade any unsupported browsers as described below.
  */
-const path = require('path');
-const browserslist = require('browserslist');
 const getTargetsFromBrowsersList =
 	require('@babel/helper-compilation-targets').default;
+const browserslist = require('browserslist');
 
 /**
- * An explanation in case you see the following build error:
- *
- * Error: Cannot find module '@guardian/browserslist-config'
- *
- * We use the Browserslists extends syntax:
- *
- * `extends @guardian/browserslist-config`
- *
  * Browserslist tries to resolve the stats file relative to the working directory.
- *
  * https://github.com/browserslist/browserslist/blob/74dbf959874e3c05adec93adab98832db35cb66b/node.js#L197-L200
- *
- * @guardian/browserslist-config is not hoisted so when webpack runs the working directory must be the local workspace:
- *
- * 'dotcom-rendering/dotcom-rendering'
- *
- * This is primarily a concern for tools like Storybook that may run webpack from a different directory.
- *
- * Such tools should set the working directory to the local workspace - as is currently the case.
+ * @guardian/browserslist-config is not hoisted so when webpack runs the working directory must be the local workspace
  */
 const browsers = browserslist('extends @guardian/browserslist-config');
 

--- a/dotcom-rendering/scripts/webpack/webpack.config.browser.js
+++ b/dotcom-rendering/scripts/webpack/webpack.config.browser.js
@@ -6,35 +6,6 @@ const GuStatsReportPlugin = require('./plugins/gu-stats-report-plugin');
 
 const DEV = process.env.NODE_ENV === 'development';
 
-// switch in case we need to revert
-const USE_SWC = true;
-
-const babelLoader = [
-	{
-		loader: 'babel-loader',
-		options: {
-			presets: [
-				'@babel/preset-react',
-				[
-					'@babel/preset-env',
-					{
-						bugfixes: true,
-						targets: 'extends @guardian/browserslist-config',
-					},
-				],
-			],
-			compact: true,
-		},
-	},
-	{
-		loader: 'ts-loader',
-		options: {
-			configFile: 'tsconfig.build.json',
-			transpileOnly: true,
-		},
-	},
-];
-
 const swcLoader = (targets) => [
 	{
 		loader: 'swc-loader',
@@ -95,7 +66,7 @@ const getLoaders = (bundle) => {
 			return swcLoader(['android >= 5', 'ios >= 12']);
 		case 'variant':
 		case 'modern':
-			return USE_SWC ? swcLoader(getBrowserTargets()) : babelLoader;
+			return swcLoader(getBrowserTargets());
 	}
 };
 
@@ -196,7 +167,6 @@ module.exports.babelExclude = {
 	not: [
 		// Include all @guardian modules, except automat-modules
 		/@guardian\/(?!(automat-modules))/,
-
 		// Include the dynamic-import-polyfill
 		/dynamic-import-polyfill/,
 	],

--- a/dotcom-rendering/scripts/webpack/webpack.config.server.js
+++ b/dotcom-rendering/scripts/webpack/webpack.config.server.js
@@ -16,8 +16,6 @@ const swcLoader = [
 				targets: {
 					node: nodeVersion,
 				},
-				// fix for @guardian/libs storage.ts class properties
-				include: ['transform-class-properties'],
 			},
 		},
 	},

--- a/dotcom-rendering/scripts/webpack/webpack.config.server.js
+++ b/dotcom-rendering/scripts/webpack/webpack.config.server.js
@@ -6,37 +6,6 @@ const GuStatsReportPlugin = require('./plugins/gu-stats-report-plugin');
 const DEV = process.env.NODE_ENV === 'development';
 const nodeVersion = process.versions.node;
 
-// switch in case we need to revert
-const USE_SWC = true;
-
-const babelLoader = [
-	{
-		loader: 'babel-loader',
-		options: {
-			presets: [
-				// TODO: remove @babel/preset-react once we stop using JSX in server folder
-				'@babel/preset-react',
-				[
-					'@babel/preset-env',
-					{
-						targets: {
-							node: 'current',
-						},
-					},
-				],
-			],
-			compact: true,
-		},
-	},
-	{
-		loader: 'ts-loader',
-		options: {
-			configFile: 'tsconfig.build.json',
-			transpileOnly: true,
-		},
-	},
-];
-
 const swcLoader = [
 	{
 		loader: 'swc-loader',
@@ -44,7 +13,6 @@ const swcLoader = [
 			...swcConfig,
 			minify: DEV ? false : true,
 			env: {
-				// debug: true,
 				targets: {
 					node: nodeVersion,
 				},
@@ -121,8 +89,8 @@ module.exports = ({ sessionId }) => ({
 					and: [/node_modules/],
 					not: [/@guardian/, /dynamic-import-polyfill/],
 				},
-				// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- temporary switch
-				use: USE_SWC ? swcLoader : babelLoader,
+
+				use: swcLoader,
 			},
 			// TODO: find a way to remove
 			{


### PR DESCRIPTION
## What does this change?

Since switching to [SWC compiler](https://github.com/guardian/dotcom-rendering/pull/7221) no issues have been observed so we can drop the failover switch and old Babel loaders.

