### PR TITLE
Ad-free layout for FixedMediumSlowXIIMPU

### DIFF
--- a/dotcom-rendering/src/web/components/FixedMediumSlowXIIMPU.stories.tsx
+++ b/dotcom-rendering/src/web/components/FixedMediumSlowXIIMPU.stories.tsx
@@ -23,6 +23,7 @@ export const OneTrail = () => (
 			trails={trails.slice(0, 1)}
 			showAge={true}
 			index={1}
+			renderAds={true}
 		/>
 	</FrontSection>
 );
@@ -34,6 +35,7 @@ export const TwoTrails = () => (
 			trails={trails.slice(0, 2)}
 			showAge={true}
 			index={1}
+			renderAds={true}
 		/>
 	</FrontSection>
 );
@@ -45,6 +47,7 @@ export const ThreeTrails = () => (
 			trails={trails.slice(0, 3)}
 			showAge={true}
 			index={1}
+			renderAds={true}
 		/>
 	</FrontSection>
 );
@@ -56,6 +59,7 @@ export const FourTrails = () => (
 			trails={trails.slice(0, 4)}
 			showAge={true}
 			index={1}
+			renderAds={true}
 		/>
 	</FrontSection>
 );
@@ -67,6 +71,7 @@ export const FiveTrails = () => (
 			trails={trails.slice(0, 5)}
 			showAge={true}
 			index={1}
+			renderAds={true}
 		/>
 	</FrontSection>
 );
@@ -78,6 +83,7 @@ export const SixTrails = () => (
 			trails={trails.slice(0, 6)}
 			showAge={true}
 			index={1}
+			renderAds={true}
 		/>
 	</FrontSection>
 );
@@ -89,6 +95,7 @@ export const SevenTrails = () => (
 			trails={trails.slice(0, 7)}
 			showAge={true}
 			index={1}
+			renderAds={true}
 		/>
 	</FrontSection>
 );
@@ -100,6 +107,7 @@ export const EightTrails = () => (
 			trails={trails.slice(0, 8)}
 			showAge={true}
 			index={1}
+			renderAds={true}
 		/>
 	</FrontSection>
 );
@@ -111,7 +119,20 @@ export const NineTrails = () => (
 			trails={trails.slice(0, 9)}
 			showAge={true}
 			index={1}
+			renderAds={true}
 		/>
 	</FrontSection>
 );
 NineTrails.story = { name: 'with nine trails' };
+
+export const EightTrailsNoAds = () => (
+	<FrontSection title="Fixed Medium Slow XII MPU" centralBorder="partial">
+		<FixedMediumSlowXIIMPU
+			trails={trails.slice(0, 8)}
+			showAge={true}
+			index={1}
+			renderAds={false}
+		/>
+	</FrontSection>
+);
+EightTrailsNoAds.story = { name: 'with eight trails and no ad slot' };

--- a/dotcom-rendering/src/web/components/FixedMediumSlowXIIMPU.tsx
+++ b/dotcom-rendering/src/web/components/FixedMediumSlowXIIMPU.tsx
@@ -15,6 +15,14 @@ type Props = {
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
 	index: number;
+	renderAds: boolean;
+};
+
+type MPUSliceProps = {
+	trails: DCRFrontCard[];
+	containerPalette?: DCRContainerPalette;
+	showAge?: boolean;
+	index: number;
 };
 
 /* .___________.___________.___________.
@@ -66,6 +74,71 @@ const Card33_Card33_Card33 = ({
 };
 
 /**
+ * Slice with ad slot
+ *
+ *  ┌───────┬───────┬───────┐
+    │       │       │       │
+    ├───────┼───────┤       │
+    │       │       │  MPU  │
+    ├───────┴───────┤       │
+    │               │       │
+    └───────────────┴───────┘
+ */
+const ThreeColumnSliceWithAdSlot = ({
+	trails,
+	containerPalette,
+	showAge,
+	index,
+}: MPUSliceProps) => {
+	return (
+		<UL direction="row">
+			<LI percentage="66.666%">
+				{/*
+				 *	This pattern of using wrapCards on the UL + percentage=50 and stretch=true
+				 * on the LI creates a dynamic list of cards over two columns. Crucially,
+				 * cards align horizontally in rows. If the number of trails is odd the last
+				 * card stretches full width.
+				 *
+				 * E.g:
+				 * .___________.___________.
+				 * |___________|___________|
+				 * |___________|___________|
+				 * |_______________________|
+				 */}
+				<UL direction="row" wrapCards={true}>
+					{trails.map((trail, trailIndex, { length }) => (
+						<LI
+							padSides={true}
+							offsetBottomPaddingOnDivider={shouldPadWrappableRows(
+								trailIndex,
+								length - (length % 2),
+								2,
+							)}
+							showDivider={trailIndex % 2 !== 0}
+							containerPalette={containerPalette}
+							percentage="50%"
+							stretch={true}
+							key={trail.url}
+						>
+							<CardDefault
+								trail={trail}
+								containerPalette={containerPalette}
+								showAge={showAge}
+							/>
+						</LI>
+					))}
+				</UL>
+			</LI>
+			<LI percentage="33.333%" showDivider={true}>
+				<Hide until="tablet">
+					<AdSlot position="inline" index={index} />
+				</Hide>
+			</LI>
+		</UL>
+	);
+};
+
+/**
  * FixedMediumSlowXIIMPU
  *
  */
@@ -74,6 +147,7 @@ export const FixedMediumSlowXIIMPU = ({
 	containerPalette,
 	showAge,
 	index,
+	renderAds,
 }: Props) => {
 	const firstSlice = trails.slice(0, 3);
 	const remaining = trails.slice(3, 9);
@@ -85,50 +159,42 @@ export const FixedMediumSlowXIIMPU = ({
 				showAge={showAge}
 				padBottom={true}
 			/>
-			<UL direction="row">
-				<LI percentage="66.666%">
-					{/*
-					 *	This pattern of using wrapCards on the UL + percentage=50 and stretch=true
-					 * on the LI creates a dynamic list of cards over two columns. Crucially,
-					 * cards align horizontally in rows. If the number of trails is odd the last
-					 * card stretches full width.
-					 *
-					 * E.g:
-					 * .___________.___________.
-					 * |___________|___________|
-					 * |___________|___________|
-					 * |_______________________|
-					 */}
-					<UL direction="row" wrapCards={true}>
-						{remaining.map((trail, trailIndex, { length }) => (
-							<LI
-								padSides={true}
-								offsetBottomPaddingOnDivider={shouldPadWrappableRows(
-									trailIndex,
-									length - (length % 2),
-									2,
-								)}
-								showDivider={trailIndex % 2 !== 0}
+			{renderAds ? (
+				<ThreeColumnSliceWithAdSlot
+					trails={remaining}
+					containerPalette={containerPalette}
+					showAge={showAge}
+					index={index}
+				/>
+			) : (
+				/**
+				 * If `renderAds` is false then we should just render a
+				 * wrapping three-column layout instead.
+				 */
+				<UL direction="row" wrapCards={true}>
+					{remaining.map((trail, trailIndex) => (
+						<LI
+							padSides={true}
+							offsetBottomPaddingOnDivider={shouldPadWrappableRows(
+								trailIndex,
+								remaining.length - (remaining.length % 3),
+								3,
+							)}
+							showDivider={trailIndex % 3 !== 0}
+							containerPalette={containerPalette}
+							percentage="33.333%"
+							stretch={true}
+							key={trail.url}
+						>
+							<CardDefault
+								trail={trail}
 								containerPalette={containerPalette}
-								percentage="50%"
-								stretch={true}
-								key={trail.url}
-							>
-								<CardDefault
-									trail={trail}
-									containerPalette={containerPalette}
-									showAge={showAge}
-								/>
-							</LI>
-						))}
-					</UL>
-				</LI>
-				<LI percentage="33.333%" showDivider={true}>
-					<Hide until="tablet">
-						<AdSlot position="inline" index={index} />
-					</Hide>
-				</LI>
-			</UL>
+								showAge={showAge}
+							/>
+						</LI>
+					))}
+				</UL>
+			)}
 		</>
 	);
 };

--- a/dotcom-rendering/src/web/lib/DecideContainer.tsx
+++ b/dotcom-rendering/src/web/lib/DecideContainer.tsx
@@ -148,6 +148,7 @@ export const DecideContainer = ({
 					trails={trails}
 					containerPalette={containerPalette}
 					showAge={showAge}
+					renderAds={renderAds}
 					index={index}
 				/>
 			);


### PR DESCRIPTION
If `renderAds` is false, render the second slice of the container with a
regular 3-column layout instead of having an AdSlot in the third column.

The MPU layout for the second slice is pulled into a separate component,
and the new slice should be using a well-established pattern (3 column
layout of `DefaultCard` components).

Part of https://github.com/guardian/dotcom-rendering/issues/7303