### PR TITLE
Don't load commercial JS for users with poor device connectivity

### DIFF
--- a/dotcom-rendering/src/web/server/articleToHtml.tsx
+++ b/dotcom-rendering/src/web/server/articleToHtml.tsx
@@ -99,7 +99,10 @@ export const articleToHtml = ({ article }: Props): string => {
 	 * Please talk to the dotcom platform team before adding more.
 	 * Scripts will be executed in the order they appear in this array
 	 */
-	const loadCommercial = !article.isAdFreeUser && !article.shouldHideAds;
+	const loadCommercial =
+		!article.isAdFreeUser &&
+		!article.shouldHideAds &&
+		article.config.abTests.poorDeviceConnectivityVariant !== 'variant';
 	const scriptTags = generateScriptTags(
 		[
 			polyfillIO,

--- a/dotcom-rendering/src/web/server/frontToHtml.tsx
+++ b/dotcom-rendering/src/web/server/frontToHtml.tsx
@@ -55,7 +55,9 @@ export const frontToHtml = ({ front }: Props): string => {
 	 * Please talk to the dotcom platform team before adding more.
 	 * Scripts will be executed in the order they appear in this array
 	 */
-	const loadCommercial = !front.isAdFreeUser;
+	const loadCommercial =
+		!front.isAdFreeUser &&
+		front.config.abTests.poorDeviceConnectivityVariant !== 'variant';
 	const scriptTags = generateScriptTags(
 		[
 			polyfillIO,


### PR DESCRIPTION
## What does this change?

- prevents the commercial JS loading for users identified as having poor device connectivity (PDC)

in reality, the PDC cohort is currently a server-side experiment test group whose behaviour @guardian/open-journalism want to observe. 

we'll be adding/removing features to see if/how they influence behaviour, from a perf point of view.

