### PR TITLE
Fix showhide button by correcting its sectionId

### DIFF
--- a/dotcom-rendering/src/web/components/FrontSection.tsx
+++ b/dotcom-rendering/src/web/components/FrontSection.tsx
@@ -524,23 +524,23 @@ export const FrontSection = ({
 				/>
 				{leftContent}
 			</div>
-			{isToggleable && (
-				<div css={sectionShowHide}>
-					<ShowHideButton
-						sectionId={sectionId}
-						overrideContainerToggleColour={
-							overrides?.text.containerToggle
-						}
-					/>
-				</div>
-			)}
 			{isToggleable ? (
-				<div
-					css={childrenContainerStyles}
-					id={`container-${sectionId}`}
-				>
-					{children}
-				</div>
+				<>
+					<div css={sectionShowHide}>
+						<ShowHideButton
+							sectionId={sectionId}
+							overrideContainerToggleColour={
+								overrides?.text.containerToggle
+							}
+						/>
+					</div>
+					<div
+						css={childrenContainerStyles}
+						id={`container-${sectionId}`}
+					>
+						{children}
+					</div>
+				</>
 			) : (
 				<div css={childrenContainerStyles}>{children}</div>
 			)}

--- a/dotcom-rendering/src/web/components/FrontSection.tsx
+++ b/dotcom-rendering/src/web/components/FrontSection.tsx
@@ -524,23 +524,23 @@ export const FrontSection = ({
 				/>
 				{leftContent}
 			</div>
+			{isToggleable && (
+				<div css={sectionShowHide}>
+					<ShowHideButton
+						sectionId={sectionId}
+						overrideContainerToggleColour={
+							overrides?.text.containerToggle
+						}
+					/>
+				</div>
+			)}
 			{isToggleable ? (
-				<>
-					<div css={sectionShowHide}>
-						<ShowHideButton
-							sectionId={`container-${sectionId}`}
-							overrideContainerToggleColour={
-								overrides?.text.containerToggle
-							}
-						/>
-					</div>
-					<div
-						css={childrenContainerStyles}
-						id={`container-${sectionId}`}
-					>
-						{children}
-					</div>
-				</>
+				<div
+					css={childrenContainerStyles}
+					id={`container-${sectionId}`}
+				>
+					{children}
+				</div>
 			) : (
 				<div css={childrenContainerStyles}>{children}</div>
 			)}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Correctly assigns the ShowHideButton component's sectionId property as `sectionId` instead of `container-${sectionId} 

(please ignore the first commit to the branch, that was an attempt at an alternative solution).

## Why?

Fixes the show/hide functionality which got broken in the frontsection PR (#7195). 


