### PR TITLE
Ad free fixed small slow v mpu layout

### DIFF
--- a/dotcom-rendering/src/web/components/FixedSmallSlowVMPU.stories.tsx
+++ b/dotcom-rendering/src/web/components/FixedSmallSlowVMPU.stories.tsx
@@ -23,6 +23,7 @@ export const FourCards = () => (
 			trails={trails.slice(0, 4)}
 			showAge={true}
 			index={1}
+			renderAds={true}
 		/>
 	</FrontSection>
 );
@@ -35,6 +36,7 @@ export const ThreeCards = () => (
 			trails={trails.slice(0, 3)}
 			showAge={true}
 			index={1}
+			renderAds={true}
 		/>
 	</FrontSection>
 );
@@ -47,6 +49,7 @@ export const TwoCards = () => (
 			trails={trails.slice(0, 2)}
 			showAge={true}
 			index={1}
+			renderAds={true}
 		/>
 	</FrontSection>
 );
@@ -59,8 +62,22 @@ export const OneCard = () => (
 			trails={trails.slice(0, 1)}
 			showAge={true}
 			index={1}
+			renderAds={true}
 		/>
 	</FrontSection>
 );
 
 OneCard.story = { name: 'With 1 card' };
+
+export const AdfreeFixedSmallSlowVMPU = () => (
+	<FrontSection title="Fixed Small Slow V MPU" centralBorder="partial">
+		<FixedSmallSlowVMPU
+			trails={trails.slice(0, 4)}
+			showAge={true}
+			index={1}
+			renderAds={false}
+		/>
+	</FrontSection>
+);
+
+AdfreeFixedSmallSlowVMPU.story = { name: 'Ad-free Fixed Small Slow V MPU' };

--- a/dotcom-rendering/src/web/components/FixedSmallSlowVMPU.tsx
+++ b/dotcom-rendering/src/web/components/FixedSmallSlowVMPU.tsx
@@ -1,6 +1,10 @@
 import { Hide } from '@guardian/source-react-components';
 import type { DCRContainerPalette, DCRFrontCard } from '../../types/front';
-import { Card33Media33Tall, CardDefault } from '../lib/cardWrappers';
+import {
+	Card25Media25SmallHeadline,
+	Card33Media33Tall,
+	CardDefault,
+} from '../lib/cardWrappers';
 import { AdSlot } from './AdSlot';
 import { LI } from './Card/components/LI';
 import { UL } from './Card/components/UL';
@@ -10,6 +14,7 @@ type Props = {
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
 	index: number;
+	renderAds: boolean;
 };
 
 export const FixedSmallSlowVMPU = ({
@@ -17,49 +22,71 @@ export const FixedSmallSlowVMPU = ({
 	containerPalette,
 	showAge,
 	index,
+	renderAds,
 }: Props) => {
 	const firstSlice33 = trails.slice(0, 1);
 	const remaining = trails.slice(1, 4);
-
-	return (
-		<UL direction="row">
-			{firstSlice33.map((trail) => (
-				<LI percentage="33.333%" padSides={true} key={trail.url}>
-					<Card33Media33Tall
-						trail={trail}
-						containerPalette={containerPalette}
-						showAge={showAge}
-					/>
+	{
+		return renderAds ? (
+			<UL direction="row">
+				{firstSlice33.map((trail) => (
+					<LI percentage="33.333%" padSides={true} key={trail.url}>
+						<Card33Media33Tall
+							trail={trail}
+							containerPalette={containerPalette}
+							showAge={showAge}
+						/>
+					</LI>
+				))}
+				<LI
+					percentage="33.333%"
+					padSides={true}
+					showDivider={true}
+					containerPalette={containerPalette}
+				>
+					<UL direction="column">
+						{remaining.map((trail) => (
+							<LI key={trail.url}>
+								<CardDefault
+									trail={trail}
+									containerPalette={containerPalette}
+									showAge={showAge}
+								/>
+							</LI>
+						))}
+					</UL>
 				</LI>
-			))}
-			<LI
-				percentage="33.333%"
-				padSides={true}
-				showDivider={true}
-				containerPalette={containerPalette}
-			>
-				<UL direction="column">
-					{remaining.map((trail) => (
-						<LI key={trail.url}>
-							<CardDefault
-								trail={trail}
+				<LI
+					percentage="33.333%"
+					padSides={true}
+					showDivider={true}
+					containerPalette={containerPalette}
+				>
+					<Hide until="tablet">
+						<AdSlot position="inline" index={index} />
+					</Hide>
+				</LI>
+			</UL>
+		) : (
+			<UL direction="row" padBottom={true}>
+				{trails.slice(0, 4).map((card, cardIndex) => {
+					return (
+						<LI
+							padSides={true}
+							percentage="25%"
+							showDivider={cardIndex > 0}
+							containerPalette={containerPalette}
+							key={card.url}
+						>
+							<Card25Media25SmallHeadline
+								trail={card}
 								containerPalette={containerPalette}
 								showAge={showAge}
 							/>
 						</LI>
-					))}
-				</UL>
-			</LI>
-			<LI
-				percentage="33.333%"
-				padSides={true}
-				showDivider={true}
-				containerPalette={containerPalette}
-			>
-				<Hide until="tablet">
-					<AdSlot position="inline" index={index} />
-				</Hide>
-			</LI>
-		</UL>
-	);
+					);
+				})}
+			</UL>
+		);
+	}
 };

--- a/dotcom-rendering/src/web/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FrontLayout.tsx
@@ -407,6 +407,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 									showAge={
 										collection.displayName === 'Headlines'
 									}
+									renderAds={renderAds}
 								/>
 								{collection.canShowMore && (
 									<Island deferUntil="interaction">
@@ -429,14 +430,16 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 									</Island>
 								)}
 							</FrontSection>
-							{decideAdSlot(
-								index,
-								front.isNetworkFront,
-								front.pressedPage.collections.length,
-								front.pressedPage.frontProperties.isPaidContent,
-								format.display,
-								mobileAdPositions,
-							)}
+							{renderAds &&
+								decideAdSlot(
+									index,
+									front.isNetworkFront,
+									front.pressedPage.collections.length,
+									front.pressedPage.frontProperties
+										.isPaidContent,
+									format.display,
+									mobileAdPositions,
+								)}
 						</>
 					);
 				})}

--- a/dotcom-rendering/src/web/lib/DecideContainer.tsx
+++ b/dotcom-rendering/src/web/lib/DecideContainer.tsx
@@ -29,6 +29,7 @@ type Props = {
 	containerType: DCRContainerType;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
+	renderAds: boolean;
 };
 
 export const DecideContainer = ({
@@ -38,6 +39,7 @@ export const DecideContainer = ({
 	containerType,
 	containerPalette,
 	showAge,
+	renderAds,
 }: Props) => {
 	switch (containerType) {
 		case 'dynamic/fast':
@@ -96,6 +98,7 @@ export const DecideContainer = ({
 					containerPalette={containerPalette}
 					showAge={showAge}
 					index={index}
+					renderAds={renderAds}
 				/>
 			);
 		case 'fixed/small/slow-III':


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

This enables the Fixed Small Slow V MPU container (e.g. the "Guardian View" container found on the "Comment is Free" front) to know if it should be rendering ads. If it should, it will render as it does at the moment, with an ad slot. If the page should be ad-free, e.g. if the user is signed in, then it will display the cards in a line, similar to the lower rows of a FixedLargeSlowXIV container.

## Why?

Part of resolving https://github.com/guardian/dotcom-rendering/issues/7303 and leading to increased fronts coverage.

## Screenshots

| Frontend Ad-free      | DCR Ad-free      |
|-------------|------------|
| ![frontendadfree][] | ![dcradfree][] |

[frontendadfree]: ![image](https://user-images.githubusercontent.com/102960844/223205751-02a15321-82fc-4f4c-b83f-20944b8f953d.png)
[dcradfree]: ![image](https://user-images.githubusercontent.com/102960844/223206469-61035f6f-0189-44c1-a545-95cd0bea7ce2.png)

