### PR TITLE
Fix callout checkbox group

### DIFF
--- a/apps-rendering/package.json
+++ b/apps-rendering/package.json
@@ -54,7 +54,7 @@
 		"@guardian/node-riffraff-artifact": "^0.3.2",
 		"@guardian/renditions": "^0.2.0",
 		"@guardian/source-foundations": "^7.0.1",
-		"@guardian/source-react-components": "^11.2.0",
+		"@guardian/source-react-components": "^11.4.0",
 		"@guardian/source-react-components-development-kitchen": "9.2.0",
 		"@guardian/types": "^9.0.1",
 		"@storybook/addon-knobs": "^6.4.0",

--- a/apps-rendering/src/components/Callout/calloutForm.tsx
+++ b/apps-rendering/src/components/Callout/calloutForm.tsx
@@ -81,6 +81,14 @@ const CalloutForm: FC<CalloutFormProps> = ({ id, fields }) => {
 		return Object.keys(errors).length === 0;
 	};
 
+	const cleanFormData = (data: undefined | string | string[]) => {
+		if (Array.isArray(data)) {
+			return data.join('\n');
+		}
+
+		return data;
+	};
+
 	const onSubmit = async (formData: FormDataType): Promise<void> => {
 		// Reset error for new submission attempt
 		setSubmissionError('');
@@ -91,7 +99,7 @@ const CalloutForm: FC<CalloutFormProps> = ({ id, fields }) => {
 		const formDataWithFieldPrefix = Object.keys(formData).reduce(
 			(acc, cur): SubmitDataType => ({
 				...acc,
-				[`field_${cur}`]: formData[cur],
+				[`field_${cur}`]: cleanFormData(formData[cur]),
 			}),
 			{},
 		);

--- a/apps-rendering/src/components/Callout/calloutForm.tsx
+++ b/apps-rendering/src/components/Callout/calloutForm.tsx
@@ -81,7 +81,9 @@ const CalloutForm: FC<CalloutFormProps> = ({ id, fields }) => {
 		return Object.keys(errors).length === 0;
 	};
 
-	const cleanFormData = (data: undefined | string | string[]) => {
+	const cleanFormData = (
+		data: undefined | string | string[],
+	): string | undefined => {
 		if (Array.isArray(data)) {
 			return data.join('\n');
 		}

--- a/apps-rendering/src/components/Callout/formFields.tsx
+++ b/apps-rendering/src/components/Callout/formFields.tsx
@@ -131,6 +131,7 @@ export const FormField: FC<FormFieldProp> = ({
 						id in formData ? (formData[id] as string[]) : []
 					}
 					setFieldInFormData={setFieldInFormData}
+					optional={!mandatory}
 					cssOverrides={fieldInput}
 					error={fieldError}
 				/>

--- a/apps-rendering/src/components/CheckboxInput/index.tsx
+++ b/apps-rendering/src/components/CheckboxInput/index.tsx
@@ -10,6 +10,7 @@ interface CheckboxInputProps {
 		id: string,
 		data: string | string[] | undefined,
 	) => void;
+	optional?: boolean;
 	error?: string;
 	cssOverrides?: SerializedStyles;
 }
@@ -18,6 +19,7 @@ const CheckboxInput = ({
 	formField,
 	selectedCheckboxes,
 	setFieldInFormData,
+	optional,
 	error,
 	cssOverrides,
 }: CheckboxInputProps): ReactElement => {
@@ -27,6 +29,7 @@ const CheckboxInput = ({
 			id={name}
 			label={label}
 			name={name}
+			optional={optional}
 			supporting={description}
 			cssOverrides={cssOverrides}
 			error={error ? error : undefined}

--- a/apps-rendering/yarn.lock
+++ b/apps-rendering/yarn.lock
@@ -1723,10 +1723,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/source-react-components-development-kitchen/-/source-react-components-development-kitchen-9.2.0.tgz#c141b39ec16f883ae2a28e17eada7a7856d1d8d7"
   integrity sha512-yNOq4u7lZOCbv1fGRXXzrFDCHZEs8jfzt7OxL6qQVY2+hGnEhTBD26FtsBjs0SpzmneaazAlxAR9dg2BjUbKlw==
 
-"@guardian/source-react-components@^11.2.0":
-  version "11.2.0"
-  resolved "https://registry.yarnpkg.com/@guardian/source-react-components/-/source-react-components-11.2.0.tgz#4732c2ab994af5c585cf5d6e8f28d4d3e2de1ab8"
-  integrity sha512-xwvKAFThOlu1F5kyHkWv3i7Fa7oxK+XJc9b7TVE/WCt7qJJrVRsSBfLIz4C68YWctbvQ34XDgk2dB0GI8/wKFg==
+"@guardian/source-react-components@^11.4.0":
+  version "11.4.0"
+  resolved "https://registry.yarnpkg.com/@guardian/source-react-components/-/source-react-components-11.4.0.tgz#e08b07cdfdc55158282273613c346299b1042785"
+  integrity sha512-dDOSOFRnvopVebMYcNx1a/6oNRtaO7WMbN6r1yk+X17f4evZCK3g+9D1bNaqIVKqEZuKVKx4caHQYmbrm4gs/g==
 
 "@guardian/story-packages-model@^2.2.0":
   version "2.2.0"

--- a/dotcom-rendering/src/web/components/Callout/Form.tsx
+++ b/dotcom-rendering/src/web/components/Callout/Form.tsx
@@ -134,6 +134,14 @@ export const Form = ({
 		return Object.keys(errors).length === 0;
 	};
 
+	const cleanFormData = (data: undefined | string | string[]) => {
+		if (Array.isArray(data)) {
+			return data.join('\n');
+		}
+
+		return data;
+	};
+
 	const submitForm = async (form: FormDataType) => {
 		setNetworkError('');
 
@@ -145,7 +153,7 @@ export const Form = ({
 		const formDataWithFieldPrefix = Object.keys(formData).reduce(
 			(acc, cur) => ({
 				...acc,
-				[`field_${cur}`]: form[cur],
+				[`field_${cur}`]: cleanFormData(form[cur]),
 			}),
 			{},
 		);

--- a/dotcom-rendering/src/web/components/Callout/FormField.tsx
+++ b/dotcom-rendering/src/web/components/Callout/FormField.tsx
@@ -141,6 +141,7 @@ export const FormField = ({
 					label={label}
 					hideLabel={hideLabel}
 					supporting={description}
+					optional={!required}
 					error={fieldError ? fieldError : undefined}
 					data-testid={`form-field-${formField.id}`}
 				>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

This PR does the 2 following:
- Updaye `source-react-coimponents` version to `11.4.0`
- Adds the new optional field for the CheckboxGroup elements
- Also fixes the bug for the CheckBox submission form data


While working on adding the optional label for non-mandatory checkbox group, I realised that the form data we are submitting for checkbox is not accepted by formstack and as a result, the field stays empty in formstack submissions. This was because we were sending the multiple choices as an array, but formstack was expecting a string where every item is on a new line. 

`"['option1', 'option2']"` should have been `"option1\noption2"`

## Why?


## Screenshots
### DCR
| Before      | After      |
|-------------|------------|
| ![image](https://user-images.githubusercontent.com/15894063/223379389-511edd3e-e9c6-4a53-875d-512c6031b3d4.png) | ![image](https://user-images.githubusercontent.com/15894063/223378703-80f3dd8a-aaa2-43f7-9380-5787fec21f88.png) |
### AR
| Before      | After      |
|-------------|------------|
| ![image](https://user-images.githubusercontent.com/15894063/223379389-511edd3e-e9c6-4a53-875d-512c6031b3d4.png) | ![image](https://user-images.githubusercontent.com/15894063/223379506-6fcb7eca-1366-4113-a863-480e28f90453.png) |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->


<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
