### PR TITLE
Add perf logging for enhanceFront

### DIFF
--- a/dotcom-rendering/src/web/server/index.ts
+++ b/dotcom-rendering/src/web/server/index.ts
@@ -1,3 +1,4 @@
+import { log } from '@guardian/libs';
 import type { RequestHandler } from 'express';
 import { Standard as ExampleArticle } from '../../../fixtures/generated/articles/Standard';
 import { enhanceBlocks } from '../../model/enhanceBlocks';
@@ -12,6 +13,7 @@ import {
 } from '../../model/validate';
 import type { DCRFrontType, FEFrontType } from '../../types/front';
 import type { FEArticleType } from '../../types/frontend';
+import { initPerf } from '../browser/initPerf';
 import { decideTrail } from '../lib/decideTrail';
 import { articleToHtml } from './articleToHtml';
 import { blocksToHtml } from './blocksToHtml';
@@ -185,8 +187,12 @@ export const handleKeyEvents: RequestHandler = ({ body }, res) => {
 };
 
 export const handleFront: RequestHandler = ({ body }, res) => {
+	const { start: enhanceStart, end: enhanceEnd } = initPerf(`enhance-front`);
 	try {
+		enhanceStart();
 		const front = enhanceFront(body);
+		const enhanceDuration = enhanceEnd();
+		log('dotcom', `Enhanced ${front.webTitle} in ${enhanceDuration}ms`);
 		const html = frontToHtml({
 			front,
 		});


### PR DESCRIPTION
## What does this change?

Use `initPerf` to log the time taken to run `enhanceFront` in the DCR rendering path.

## Why?

There are a few potentially costly operations happening within `enhanceFront`. But ahead of trying to optimise any of these we should collect some data on how long it actually takes to run.


cc. @mxdvl I've largely adapted this from the code you added to log perf for island hydration so it would be great to hear your thoughts on whether I've implemented it correctly here if you have time!