### PR TITLE
Added vertical dividers to  FixedMedium SlowVI and FastXII containers

### DIFF
--- a/dotcom-rendering/src/web/components/FixedMediumFastXII.tsx
+++ b/dotcom-rendering/src/web/components/FixedMediumFastXII.tsx
@@ -20,13 +20,13 @@ export const FixedMediumFastXII = ({
 	return (
 		<>
 			<UL direction="row" padBottom={true}>
-				{firstSlice25.map((trail) => {
+				{firstSlice25.map((trail, index) => {
 					return (
 						<LI
 							key={trail.url}
 							padSides={true}
 							percentage="25%"
-							showDivider={true}
+							showDivider={index > 0}
 						>
 							<Card25Media25
 								trail={trail}
@@ -38,13 +38,13 @@ export const FixedMediumFastXII = ({
 				})}
 			</UL>
 			<UL direction="row" padBottom={true} wrapCards={true}>
-				{remaining.map((trail) => {
+				{remaining.map((trail, index) => {
 					return (
 						<LI
 							key={trail.url}
 							padSides={true}
 							percentage="25%"
-							showDivider={true}
+							showDivider={index != 0 && index != 4}
 						>
 							<CardDefault
 								trail={trail}

--- a/dotcom-rendering/src/web/components/FixedMediumFastXII.tsx
+++ b/dotcom-rendering/src/web/components/FixedMediumFastXII.tsx
@@ -22,7 +22,12 @@ export const FixedMediumFastXII = ({
 			<UL direction="row" padBottom={true}>
 				{firstSlice25.map((trail) => {
 					return (
-						<LI key={trail.url} padSides={true} percentage="25%">
+						<LI
+							key={trail.url}
+							padSides={true}
+							percentage="25%"
+							showDivider={true}
+						>
 							<Card25Media25
 								trail={trail}
 								containerPalette={containerPalette}
@@ -35,7 +40,12 @@ export const FixedMediumFastXII = ({
 			<UL direction="row" padBottom={true} wrapCards={true}>
 				{remaining.map((trail) => {
 					return (
-						<LI key={trail.url} padSides={true} percentage="25%">
+						<LI
+							key={trail.url}
+							padSides={true}
+							percentage="25%"
+							showDivider={true}
+						>
 							<CardDefault
 								trail={trail}
 								containerPalette={containerPalette}

--- a/dotcom-rendering/src/web/components/FixedMediumSlowVI.tsx
+++ b/dotcom-rendering/src/web/components/FixedMediumSlowVI.tsx
@@ -34,11 +34,11 @@ export const FixedMediumSlowVI = ({
 						/>
 					</LI>
 				))}
-				{firstSlice25.map((trail, index) => (
+				{firstSlice25.map((trail) => (
 					<LI
 						key={trail.url}
 						padSides={true}
-						showDivider={index > 0}
+						showDivider={true}
 						containerPalette={containerPalette}
 						percentage={'25%'}
 					>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Sets the required showDivider property on the FixedMediumFastXII container; also amends the property on the top row of the SlowVI container (which wasn't flagged but I'm assuming the divider should be there)

## Why?

Parity with frontend, resolves #7302 

## Screenshots

**FixedMediumFastXII:**

Frontend: 
<img width="1372" alt="image" src="https://user-images.githubusercontent.com/102960844/223479878-97fd1627-7f25-49ef-adf1-439dd0a00a8f.png">

DCR without: <img width="1434" alt="image" src="https://user-images.githubusercontent.com/102960844/223479393-abfb5341-e044-4fc7-bd46-6bf1664dd579.png">

DCR with dividers: <img width="1353" alt="image" src="https://user-images.githubusercontent.com/102960844/223479489-ba9b0aee-7203-4a17-808e-2f35e556ba3d.png">

**SlowVI:

Frontend: 
<img width="1360" alt="image" src="https://user-images.githubusercontent.com/102960844/223491989-d543ca12-1229-4df5-aecf-6e276a878cb5.png">


DCR without: 

<img width="1348" alt="image" src="https://user-images.githubusercontent.com/102960844/223492174-bfede3f4-40c0-4568-be97-294ea6bae5c7.png">


DCR with dividers: 
<img width="1370" alt="image" src="https://user-images.githubusercontent.com/102960844/223492333-d2444b8e-db15-45f3-9585-62895c1eb93f.png">
