### PR TITLE
Don't use `bahmutov/npm-install@v1` in githu workflows

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -1,30 +1,29 @@
 name: DCR Build Check
 on:
-    push:
-        paths-ignore:
-            - "apps-rendering/**"
-            - "dotcom-rendering/docs/**"
+  push:
+    paths-ignore:
+      - 'apps-rendering/**'
+      - 'dotcom-rendering/docs/**'
 
 jobs:
-    build_check:
-        name: DCR Build Check
-        runs-on: ubuntu-latest
-        steps:
-            - name: Checkout code
-              uses: actions/checkout@v3
+  build_check:
+    name: DCR Build Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
 
-            - uses: actions/setup-node@v3
-              with:
-                node-version-file: '.nvmrc'
-                cache: 'yarn'
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
 
-            # Cache npm dependencies using https://github.com/bahmutov/npm-install
-            - uses: bahmutov/npm-install@v1
+      - run: yarn install --frozen-lockfile
 
-            - name: Generate production build
-              run: make build
-              working-directory: dotcom-rendering
+      - name: Generate production build
+        run: make build
+        working-directory: dotcom-rendering
 
-            - name: Validate Build
-              run: make buildCheck
-              working-directory: dotcom-rendering
+      - name: Validate Build
+        run: make buildCheck
+        working-directory: dotcom-rendering

--- a/.github/workflows/bundle-analyser.yml
+++ b/.github/workflows/bundle-analyser.yml
@@ -17,8 +17,7 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'yarn'
 
-      # Cache npm dependencies using https://github.com/bahmutov/npm-install
-      - uses: bahmutov/npm-install@v1
+      - run: yarn install --frozen-lockfile
 
       - name: Generate production build
         run: make build

--- a/.github/workflows/dcr-chromatic.yml
+++ b/.github/workflows/dcr-chromatic.yml
@@ -30,9 +30,8 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'yarn'
 
-      # Cache npm dependencies using https://github.com/bahmutov/npm-install
       # Root yarn installs all workspaces (root, dotcom)
-      - uses: bahmutov/npm-install@v1
+      - run: yarn install --frozen-lockfile
 
       - name: Chromatic - DCR Non Dependency PR / main
         uses: chromaui/action@v1

--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -1,24 +1,23 @@
 name: DCR jest 🤔
 on:
-    push:
-        paths-ignore:
-            - "apps-rendering/**"
-            - "dotcom-rendering/docs/**"
+  push:
+    paths-ignore:
+      - 'apps-rendering/**'
+      - 'dotcom-rendering/docs/**'
 
 jobs:
-    jest:
-        name: DCR Jest
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v3
-            - uses: actions/setup-node@v3
-              with:
-                node-version-file: '.nvmrc'
-                cache: 'yarn'
+  jest:
+    name: DCR Jest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
 
-            # Cache npm dependencies using https://github.com/bahmutov/npm-install
-            - uses: bahmutov/npm-install@v1
+      - run: yarn install --frozen-lockfile
 
-            - name: Run Jest
-              run: CI=true yarn test
-              working-directory: dotcom-rendering
+      - name: Run Jest
+        run: CI=true yarn test
+        working-directory: dotcom-rendering

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -33,7 +33,7 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'yarn'
       # Make sure we install dependencies in the root directory
-      - uses: bahmutov/npm-install@v1
+      - run: yarn install --frozen-lockfile
       - run: make build
         working-directory: dotcom-rendering
       - name: Install and run Lighthouse CI

--- a/.github/workflows/pr-deployment.yml
+++ b/.github/workflows/pr-deployment.yml
@@ -1,34 +1,34 @@
 name: DCR PR deployment
 on:
-    pull_request:
-        types: [labeled]
-        paths-ignore:
-            - "apps-rendering/**"
+  pull_request:
+    types: [labeled]
+    paths-ignore:
+      - 'apps-rendering/**'
 
 jobs:
-    pr_deployment:
-        # We only want to run the app if the PR Deployment label has been added
-        if: ${{ github.event.label.id == 2500798832 }}
+  pr_deployment:
+    # We only want to run the app if the PR Deployment label has been added
+    if: ${{ github.event.label.id == 2500798832 }}
 
-        name: Start server
-        runs-on: ubuntu-latest
-        steps:
-            - name: Checkout code
-              uses: actions/checkout@v3
+    name: Start server
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
 
-            - uses: actions/setup-node@v3
-              with:
-                node-version-file: .nvmrc
-                cache: 'yarn'
-            # Make sure we install dependencies in the root directory
-            - uses: bahmutov/npm-install@v1
-            - run: make build
-              working-directory: dotcom-rendering
-            - name: Boot server and run ngrok
-              run: |
-                  npm install -g ngrok
-                  NODE_ENV=production DISABLE_LOGGING_AND_METRICS=true node dotcom-rendering/dist/frontend.server.js &
-                  timeout 5h ngrok http 9000 -log=stdout | \
-                    grep --line-buffered -o 'https://.*' | \
-                    xargs -L1 -I{} -t \
-                      curl -X POST -H 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' https://api.github.com/repos/${{ github.repository }}/statuses/${{ github.event.pull_request.head.sha }} -d "{\"state\":\"success\", \"target_url\":\"{}\", \"context\":\"PR deployment\", \"description\":\"This PR is now live until `date -d "+5 hour" "+%a %H:%M"`. Click details to access it ->\"}"
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: .nvmrc
+          cache: 'yarn'
+      # Make sure we install dependencies in the root directory
+      - run: yarn install --frozen-lockfile
+      - run: make build
+        working-directory: dotcom-rendering
+      - name: Boot server and run ngrok
+        run: |
+          npm install -g ngrok
+          NODE_ENV=production DISABLE_LOGGING_AND_METRICS=true node dotcom-rendering/dist/frontend.server.js &
+          timeout 5h ngrok http 9000 -log=stdout | \
+            grep --line-buffered -o 'https://.*' | \
+            xargs -L1 -I{} -t \
+              curl -X POST -H 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' https://api.github.com/repos/${{ github.repository }}/statuses/${{ github.event.pull_request.head.sha }} -d "{\"state\":\"success\", \"target_url\":\"{}\", \"context\":\"PR deployment\", \"description\":\"This PR is now live until `date -d "+5 hour" "+%a %H:%M"`. Click details to access it ->\"}"

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -1,23 +1,23 @@
 name: DCR prettier 💅
 on:
-    push:
-        paths-ignore:
-            - "apps-rendering/**"
+  push:
+    paths-ignore:
+      - 'apps-rendering/**'
 
 jobs:
-    lint:
-        name: DCR Prettier
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v3
-            - uses: actions/setup-node@v3
-              with:
-                node-version-file: '.nvmrc'
-                cache: 'yarn'
+  lint:
+    name: DCR Prettier
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
 
-            # Cache npm dependencies using https://github.com/bahmutov/npm-install
-            - uses: bahmutov/npm-install@v1
+      # Cache npm dependencies using https://github.com/bahmutov/npm-install
+      - run: yarn install --frozen-lockfile
 
-            - name: Prettier check
-              run: yarn prettier:check
-              working-directory: dotcom-rendering
+      - name: Prettier check
+        run: yarn prettier:check
+        working-directory: dotcom-rendering

--- a/.github/workflows/schema-check.yml
+++ b/.github/workflows/schema-check.yml
@@ -2,8 +2,8 @@ name: DCR Schema Check
 on:
   push:
     paths-ignore:
-      - "apps-rendering/**"
-      - "dotcom-rendering/docs/**"
+      - 'apps-rendering/**'
+      - 'dotcom-rendering/docs/**'
 
 jobs:
   build_check:
@@ -18,8 +18,7 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'yarn'
 
-      # Cache npm dependencies using https://github.com/bahmutov/npm-install
-      - uses: bahmutov/npm-install@v1
+      - run: yarn install --frozen-lockfile
 
       - name: Run check-schema script
         run: make check-schema

--- a/.github/workflows/stories-check.yml
+++ b/.github/workflows/stories-check.yml
@@ -3,7 +3,7 @@ on:
   push:
     paths-ignore:
       - 'apps-rendering/**'
-      - "dotcom-rendering/docs/**"
+      - 'dotcom-rendering/docs/**'
 
 jobs:
   build_check:
@@ -18,8 +18,7 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'yarn'
 
-      # Cache npm dependencies using https://github.com/bahmutov/npm-install
-      - uses: bahmutov/npm-install@v1
+      - run: yarn install --frozen-lockfile
 
       - name: Run check-stories script
         run: make check-stories

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -1,24 +1,23 @@
 name: DCR typescript 🕵‍♀
 on:
-    push:
-        paths-ignore:
-            - "apps-rendering/**"
-            - "dotcom-rendering/docs/**"
+  push:
+    paths-ignore:
+      - 'apps-rendering/**'
+      - 'dotcom-rendering/docs/**'
 
 jobs:
-    typescript:
-        name: Typescript
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v3
-            - uses: actions/setup-node@v3
-              with:
-                node-version-file: .nvmrc
-                cache: 'yarn'
+  typescript:
+    name: Typescript
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: .nvmrc
+          cache: 'yarn'
 
-            # Cache npm dependencies using https://github.com/bahmutov/npm-install
-            - uses: bahmutov/npm-install@v1
+      - run: yarn install --frozen-lockfile
 
-            - name: Check typescript
-              run: yarn tsc
-              working-directory: dotcom-rendering
+      - name: Check typescript
+        run: yarn tsc
+        working-directory: dotcom-rendering


### PR DESCRIPTION
## What does this change?

uses `yarn` directly in DCR github workflows

## Why?

the value of `bahmutov/npm-install` was the dependency caching, but npm deps are cached by `actions/setup-node@v3` already now

_n.b. the `.editorconfig` specifies different indent rules than the current files use, so my editor has automatically added a load of whitespace changes..._

https://github.com/guardian/dotcom-rendering/blob/87ed5f25bbe7e91d5ce2f607a8f346881f0e59f1/.editorconfig#L21-L23