### PR TITLE
Use `lint-staged` to prettify commits

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# don't run this on CI
+# https://typicode.github.io/husky/#/?id=with-env-variables
+[ -n "$CI" ] && exit 0
+
+. "$(dirname "$0")/_/husky.sh"
+
+yarn workspace @guardian/dotcom-rendering lint-staged

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -9,5 +9,4 @@ then
 	exit 1
 fi
 
-yarn workspace @guardian/dotcom-rendering prettier:check
 yarn workspace @guardian/dotcom-rendering tsc

--- a/dotcom-rendering/makefile
+++ b/dotcom-rendering/makefile
@@ -152,9 +152,6 @@ bundlesize: clear clean-dist install build
 validate: clean-dist install tsc lint stylelint test validate-build
 	$(call log, "everything seems 👌")
 
-validate-prepush:
-	@run-p tsc prettier:check lint-staged "test:ci -- --verbose --onlyChanged"
-
 validate-ci: install tsc lint stylelint test-ci bundlesize
 	$(call log, "everything seems 👌")
 

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -31,7 +31,7 @@
 	},
 	"bundlesize": [],
 	"lint-staged": {
-		"*": "lint"
+		"*.{js,jsx,ts,tsx,cjs,mjs,cts,mts,json,css,html,md,mdx}": "prettier --write"
 	},
 	"dependencies": {
 		"@aws-sdk/client-cloudwatch": "^3.279.0",


### PR DESCRIPTION
## What does this change?

- runs `prettier` on just the current changes at the point of committing
- stops running `prettier` on the entire code base at the point of pushing

## Why?

prettifying a small change is near enough instant, while doing the whole code base before pushing adds 2-10 secs of delay (on my machine) by checking files you haven't touched.

combined with #7353 it should shorten `push` commands by 50-90% (to ~2 secs on my machine) without affecting what you could have pushed.

## Screenshots

<img width="175" alt="image" src="https://user-images.githubusercontent.com/867233/223488609-dd2ea06a-4a36-40e1-aba7-8c2b2d461dc3.png">

<img width="288" alt="image" src="https://user-images.githubusercontent.com/867233/223488708-31797ce9-e6e3-4771-bc73-665dc853a7e9.png">
