### PR TITLE
Proposal: Add all fronts config to `window.guardian.config.page`

### DIFF
--- a/dotcom-rendering/src/model/window-guardian.ts
+++ b/dotcom-rendering/src/model/window-guardian.ts
@@ -1,5 +1,5 @@
 import type { ConfigType, ServerSideTests, Switches } from '../types/config';
-import { EditionId } from '../web/lib/edition';
+import type { EditionId } from '../web/lib/edition';
 
 export interface WindowGuardianConfig {
 	isDotcomRendering: boolean;
@@ -125,8 +125,8 @@ export const makeWindowGuardian = ({
 				adUnit,
 				showRelatedContent: true,
 				ajaxUrl,
-				shouldHideReaderRevenue: shouldHideReaderRevenue ?? false,
-				isPaidContent: isPaidContent ?? false,
+				shouldHideReaderRevenue: !!shouldHideReaderRevenue,
+				isPaidContent: !!isPaidContent,
 				brazeApiKey,
 			}),
 			libs: {

--- a/dotcom-rendering/src/web/server/articleToHtml.tsx
+++ b/dotcom-rendering/src/web/server/articleToHtml.tsx
@@ -149,8 +149,8 @@ export const articleToHtml = ({ article }: Props): string => {
 					editionId: article.editionId,
 					beaconURL: article.beaconURL,
 				}),
-				// This is a temporary measure until we understand exactly what
-				// config we need to make available client-side
+				// Until we understand exactly what config we need to make available client-side,
+				// add everything we haven't explicitly typed as unknown config
 				unknownConfig: article.config,
 			}),
 		),

--- a/dotcom-rendering/src/web/server/articleToHtml.tsx
+++ b/dotcom-rendering/src/web/server/articleToHtml.tsx
@@ -149,6 +149,8 @@ export const articleToHtml = ({ article }: Props): string => {
 					editionId: article.editionId,
 					beaconURL: article.beaconURL,
 				}),
+				// This is a temporary measure until we understand exactly what
+				// config we need to make available client-side
 				unknownConfig: article.config,
 			}),
 		),

--- a/dotcom-rendering/src/web/server/frontToHtml.tsx
+++ b/dotcom-rendering/src/web/server/frontToHtml.tsx
@@ -90,6 +90,9 @@ export const frontToHtml = ({ front }: Props): string => {
 				switches: front.config.switches,
 				abTests: front.config.abTests,
 				brazeApiKey: front.config.brazeApiKey,
+				// This is a temporary measure until we understand exactly what
+				// config we need to make available client-side
+				unknownConfig: front.config,
 			}),
 		),
 	);

--- a/dotcom-rendering/src/web/server/frontToHtml.tsx
+++ b/dotcom-rendering/src/web/server/frontToHtml.tsx
@@ -90,8 +90,8 @@ export const frontToHtml = ({ front }: Props): string => {
 				switches: front.config.switches,
 				abTests: front.config.abTests,
 				brazeApiKey: front.config.brazeApiKey,
-				// This is a temporary measure until we understand exactly what
-				// config we need to make available client-side
+				// Until we understand exactly what config we need to make available client-side,
+				// add everything we haven't explicitly typed as unknown config
 				unknownConfig: front.config,
 			}),
 		),


### PR DESCRIPTION
## What does this change?

This PR is an attempt to better align the page configs provided on articles and fronts.

We are missing some page config properties on fronts compared to articles. Unfortunately, this config contains properties that are necessary for running the commercial script on the site. 

In `articleToHTML.tsx` we stuff all of the config that we haven't explicitly typed into `window.guardian.config.page`. On fronts, no doubt as an attempt to gain a better handle on the config we provide, this isn't the case. As a means of fixing some bugs where this config is expected but is not defined, this PR does the same as we do on articles and inserts the entire front config as `unknownConfig`, which is applied to `window.guardian.config.page`.

This should resolve the issues we're experiencing, at the unfortunate cost of bloating the config.

## Why?

Fix issues in the commercial codebase where some page properties are expected to be defined on fronts but are not.

**As mentioned above, this does bloat the config and make it harder to reason about what's available on the page. I personally think we should do some work to remediate this later, once we have as much of the commercial code working on fronts as we can reasonably expect from this small change.**