### PR TITLE
Fix missing mobile ads on DCR Fronts

### DIFF
--- a/dotcom-rendering/src/web/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FrontLayout.tsx
@@ -174,10 +174,12 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 	 */
 	const renderAds = !front.isAdFreeUser;
 
-	const mobileAdPositions = getMobileAdPositions(
+	const mobileAdPositions = renderAds
+		? getMobileAdPositions(
 				front.isNetworkFront,
 				front.pressedPage.collections,
-		  );
+		  )
+		: [];
 
 	return (
 		<>

--- a/dotcom-rendering/src/web/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FrontLayout.tsx
@@ -174,12 +174,10 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 	 */
 	const renderAds = !front.isAdFreeUser;
 
-	const mobileAdPositions = front.isNetworkFront
-		? getMobileAdPositions(
+	const mobileAdPositions = getMobileAdPositions(
 				front.isNetworkFront,
 				front.pressedPage.collections,
-		  )
-		: [];
+		  );
 
 	return (
 		<>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Calculate mobile ad positions for all fronts not just network fronts.

## Why?
We noticed a large reduction in mobile ads on DCR fronts, there's a condition to only calculate mobile ad positions for network fronts, going by this comment I found https://github.com/guardian/dotcom-rendering/pull/6071/files#r993581086 it could be there as a miss-understanding that this conditional is true for all fronts not network fronts?
