### PR TITLE
Add labels to inline ads on fronts, and fix padding

### DIFF
--- a/dotcom-rendering/src/web/components/AdSlot.tsx
+++ b/dotcom-rendering/src/web/components/AdSlot.tsx
@@ -433,25 +433,27 @@ export const AdSlot = ({
 		case 'inline': {
 			const advertId = `inline${index}`;
 			return (
-				<div
-					id={`dfp-ad--${advertId}`}
-					className={[
-						'js-ad-slot',
-						'ad-slot',
-						`ad-slot--${advertId}`,
-						'ad-slot--container-inline',
-						'ad-slot--rendered',
-					].join(' ')}
-					css={[
-						css`
-							position: relative;
-						`,
-						adStyles,
-					]}
-					data-link-name={`ad slot ${advertId}`}
-					data-name={advertId}
-					aria-hidden="true"
-				/>
+				<div className="ad-slot-container" css={[adStyles]}>
+					<div
+						id={`dfp-ad--${advertId}`}
+						className={[
+							'js-ad-slot',
+							'ad-slot',
+							`ad-slot--${advertId}`,
+							'ad-slot--container-inline',
+							'ad-slot--rendered',
+						].join(' ')}
+						css={[
+							css`
+								position: relative;
+							`,
+							adStyles,
+						]}
+						data-link-name={`ad slot ${advertId}`}
+						data-name={advertId}
+						aria-hidden="true"
+					/>
+				</div>
 			);
 		}
 		case 'liveblog-inline': {

--- a/dotcom-rendering/src/web/components/DynamicSlowMPU.tsx
+++ b/dotcom-rendering/src/web/components/DynamicSlowMPU.tsx
@@ -77,7 +77,7 @@ const Card33_ColumnOfThree33_Ad33 = ({
 					))}
 				</UL>
 			</LI>
-			<LI percentage="33.333%">
+			<LI percentage="33.333%" padSides={true} showDivider={true}>
 				<Hide until="tablet">
 					<AdSlot position="inline" index={index} />
 				</Hide>
@@ -119,7 +119,7 @@ const ColumnOfThree50_Ad50 = ({
 					))}
 				</UL>
 			</LI>
-			<LI percentage="50%">
+			<LI percentage="50%" padSides={true} showDivider={true}>
 				<Hide until="tablet">
 					<AdSlot position="inline" index={index} />
 				</Hide>

--- a/dotcom-rendering/src/web/components/FixedMediumSlowXIIMPU.tsx
+++ b/dotcom-rendering/src/web/components/FixedMediumSlowXIIMPU.tsx
@@ -129,7 +129,7 @@ const ThreeColumnSliceWithAdSlot = ({
 					))}
 				</UL>
 			</LI>
-			<LI percentage="33.333%" showDivider={true}>
+			<LI percentage="33.333%" padSides={true} showDivider={true}>
 				<Hide until="tablet">
 					<AdSlot position="inline" index={index} />
 				</Hide>


### PR DESCRIPTION
We noticed that inline ads on DCR fronts didn't have ad labels, so a wrapper div has been added to inline ads to make sure that they inherit the label styles. The padding was also not consistent with the frontend fronts, so this has been corrected as well.

Before:
<img width="1051" alt="Screenshot 2023-03-08 at 11 42 03" src="https://user-images.githubusercontent.com/108270776/223705053-4a52a6e2-2380-4088-b8cd-d269f34d973d.png">

After:
<img width="1041" alt="Screenshot 2023-03-08 at 11 42 45" src="https://user-images.githubusercontent.com/108270776/223705091-e9f6fe42-c38c-48c2-a721-deb3996d455b.png">
