### PR TITLE
fix: use SetABTests on FrontPage

### DIFF
--- a/dotcom-rendering/src/web/components/FrontPage.tsx
+++ b/dotcom-rendering/src/web/components/FrontPage.tsx
@@ -1,6 +1,7 @@
 import { css, Global } from '@emotion/react';
 import { brandAlt, focusHalo, neutral } from '@guardian/source-foundations';
 import { StrictMode } from 'react';
+import { filterABTestSwitches } from '../../model/enhance-switches';
 import type { NavType } from '../../model/extract-nav';
 import type { DCRFrontType } from '../../types/front';
 import { FrontLayout } from '../layouts/FrontLayout';
@@ -10,6 +11,7 @@ import { FetchCommentCounts } from './FetchCommentCounts.importable';
 import { FocusStyles } from './FocusStyles.importable';
 import { Island } from './Island';
 import { Metrics } from './Metrics.importable';
+import { SetABTests } from './SetABTests.importable';
 import { ShowHideContainers } from './ShowHideContainers.importable';
 import { SkipTo } from './SkipTo';
 
@@ -65,6 +67,13 @@ export const FrontPage = ({ front, NAV }: Props) => {
 			</Island>
 			<Island clientOnly={true}>
 				<ShowHideContainers />
+			</Island>
+			<Island clientOnly={true}>
+				<SetABTests
+					abTestSwitches={filterABTestSwitches(front.config.switches)}
+					pageIsSensitive={front.config.isSensitive}
+					isDev={!!front.config.isDev}
+				/>
 			</Island>
 			<FrontLayout front={front} NAV={NAV} />
 		</StrictMode>


### PR DESCRIPTION
## What does this change?
Adds the `<SetABTests />` component to the `<FrontPage />` to ensure that the `useAB()` works on fronts, specifically in [`Metrics.importable`](https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/src/web/components/Metrics.importable.tsx#L42).

Without this, the [`dep`](https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/src/web/components/Metrics.importable.tsx#L88) in the `useOnce` of that component doesn't resolve as it's `undefined`, and thus don't collect those metrics on fronts.

[This follows in the footsteps of `ArticlePage` ](https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/src/web/components/ArticlePage.tsx#L86-L94).

Why? We need those metrics on fronts.

I'll think of a test and potentially some other logging or refactoring to make this more clear.

That will be post this as we need this data for our currently running fronts test.

## How'd you realise this?
No data was coming through on any fronts in the performance metrics from dcr, and I started digging. This is where I landed up.