### PR TITLE
Remove Final Usages Of `bahmutov/npm-install`

### DIFF
--- a/.github/workflows/amp-validation.yml
+++ b/.github/workflows/amp-validation.yml
@@ -18,8 +18,7 @@ jobs:
                 node-version-file: '.nvmrc'
                 cache: 'yarn'
 
-            # Cache npm dependencies using https://github.com/bahmutov/npm-install
-            - uses: bahmutov/npm-install@v1
+            - run: yarn install --frozen-lockfile
 
             - name: Validate AMP
               run: make ampValidation

--- a/.github/workflows/ar-chromatic.yml
+++ b/.github/workflows/ar-chromatic.yml
@@ -30,9 +30,8 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'yarn'
 
-      # Cache npm dependencies using https://github.com/bahmutov/npm-install
       # Root yarn installs all workspaces (root, dotcom)
-      - uses: bahmutov/npm-install@v1
+      - run: yarn install --frozen-lockfile
 
       - name: Chromatic - Apps Rendering Non Dependency PR / main
         uses: chromaui/action@v1

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -15,7 +15,6 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'yarn'
 
-      # Cache npm dependencies using https://github.com/bahmutov/npm-install
       - run: yarn install --frozen-lockfile
 
       - name: Prettier check


### PR DESCRIPTION
## Why?

Following on from #7352, there was one more use of this action in an AR workflow and another in a DCR workflow. This removes both; we should now be relying entirely on the `setup-node` action.

## Changes

- Switched to `yarn install` for amp validation
- Switched to `yarn install` for AR chromatic
- Removed comment that was no longer needed
