### PR TITLE
Update subscribe cta masthead interactive article

### DIFF
--- a/dotcom-rendering/src/web/components/InteractiveSupportButton.importable.tsx
+++ b/dotcom-rendering/src/web/components/InteractiveSupportButton.importable.tsx
@@ -1,20 +1,25 @@
-import {Hide} from "./Hide";
-import {css, ThemeProvider} from "@emotion/react";
-import {buttonThemeReaderRevenue} from "@guardian/source-react-components";
+import { Hide } from './Hide';
+import { css, ThemeProvider } from '@emotion/react';
+import { buttonThemeReaderRevenue } from '@guardian/source-react-components';
 import {
 	LinkButton,
 	SvgArrowRightStraight,
 } from '@guardian/source-react-components';
-import { space} from "@guardian/source-foundations";
+import { space } from '@guardian/source-foundations';
 import {
-	HIDE_SUPPORT_MESSAGING_COOKIE, isRecentOneOffContributor, RECURRING_CONTRIBUTOR_COOKIE,
+	HIDE_SUPPORT_MESSAGING_COOKIE,
+	isRecentOneOffContributor,
+	RECURRING_CONTRIBUTOR_COOKIE,
 	shouldHideSupportMessaging,
-	shouldShowSupportMessaging
-} from "../lib/contributions";
-import {getCookie,} from "@guardian/libs";
-import {EditionId} from "../lib/edition";
+	shouldShowSupportMessaging,
+} from '../lib/contributions';
+import { getCookie } from '@guardian/libs';
+import { EditionId } from '../lib/edition';
 
-type InteractiveSupportButtonProps={editionId:EditionId,subscribeUrl:string};
+type InteractiveSupportButtonProps = {
+	editionId: EditionId;
+	subscribeUrl: string;
+};
 
 const PositionButton = ({ children }: { children: React.ReactNode }) => (
 	<div
@@ -27,22 +32,27 @@ const PositionButton = ({ children }: { children: React.ReactNode }) => (
 	</div>
 );
 
-
-export const InteractiveSupportButton =  ({editionId,subscribeUrl} : InteractiveSupportButtonProps) => {
+export const InteractiveSupportButton = ({
+	editionId,
+	subscribeUrl,
+}: InteractiveSupportButtonProps) => {
 	// useEffect(() => {
 	//
 	// });
 
 	const hideSupportMessaging = shouldHideSupportMessaging();
 
-
-	console.log("shouldShowSupportMessaging()", shouldShowSupportMessaging())
-	console.log("isRecurringContributor(isSignedIn)",getCookie({ name: RECURRING_CONTRIBUTOR_COOKIE }) === 'true')
-	console.log("isRecentOneOffContributor()", isRecentOneOffContributor())
-	console.log("hideSupportMessaging", hideSupportMessaging)
-	console.log("GEtCookie",getCookie({ name: HIDE_SUPPORT_MESSAGING_COOKIE }))
-
-
+	console.log('shouldShowSupportMessaging()', shouldShowSupportMessaging());
+	console.log(
+		'isRecurringContributor(isSignedIn)',
+		getCookie({ name: RECURRING_CONTRIBUTOR_COOKIE }) === 'true',
+	);
+	console.log('isRecentOneOffContributor()', isRecentOneOffContributor());
+	console.log('hideSupportMessaging', hideSupportMessaging);
+	console.log(
+		'GEtCookie',
+		getCookie({ name: HIDE_SUPPORT_MESSAGING_COOKIE }),
+	);
 
 	if (!hideSupportMessaging) {
 		return (
@@ -53,7 +63,7 @@ export const InteractiveSupportButton =  ({editionId,subscribeUrl} : Interactive
 							priority="primary"
 							size="small"
 							iconSide="right"
-							icon={<SvgArrowRightStraight/>}
+							icon={<SvgArrowRightStraight />}
 							data-link-name="nav2 : support-cta"
 							data-edition={editionId}
 							href={subscribeUrl}
@@ -63,8 +73,7 @@ export const InteractiveSupportButton =  ({editionId,subscribeUrl} : Interactive
 					</PositionButton>
 				</ThemeProvider>
 			</Hide>
-		)
+		);
 	}
 	return null;
-
 };

--- a/dotcom-rendering/src/web/components/InteractiveSupportButton.importable.tsx
+++ b/dotcom-rendering/src/web/components/InteractiveSupportButton.importable.tsx
@@ -6,14 +6,7 @@ import {
 	SvgArrowRightStraight,
 } from '@guardian/source-react-components';
 import { space } from '@guardian/source-foundations';
-import {
-	HIDE_SUPPORT_MESSAGING_COOKIE,
-	isRecentOneOffContributor,
-	RECURRING_CONTRIBUTOR_COOKIE,
-	shouldHideSupportMessaging,
-	shouldShowSupportMessaging,
-} from '../lib/contributions';
-import { getCookie } from '@guardian/libs';
+import { shouldHideSupportMessaging } from '../lib/contributions';
 import { EditionId } from '../lib/edition';
 
 type InteractiveSupportButtonProps = {
@@ -36,23 +29,7 @@ export const InteractiveSupportButton = ({
 	editionId,
 	subscribeUrl,
 }: InteractiveSupportButtonProps) => {
-	// useEffect(() => {
-	//
-	// });
-
 	const hideSupportMessaging = shouldHideSupportMessaging();
-
-	console.log('shouldShowSupportMessaging()', shouldShowSupportMessaging());
-	console.log(
-		'isRecurringContributor(isSignedIn)',
-		getCookie({ name: RECURRING_CONTRIBUTOR_COOKIE }) === 'true',
-	);
-	console.log('isRecentOneOffContributor()', isRecentOneOffContributor());
-	console.log('hideSupportMessaging', hideSupportMessaging);
-	console.log(
-		'GEtCookie',
-		getCookie({ name: HIDE_SUPPORT_MESSAGING_COOKIE }),
-	);
 
 	if (!hideSupportMessaging) {
 		return (

--- a/dotcom-rendering/src/web/components/InteractiveSupportButton.importable.tsx
+++ b/dotcom-rendering/src/web/components/InteractiveSupportButton.importable.tsx
@@ -1,0 +1,70 @@
+import {Hide} from "./Hide";
+import {css, ThemeProvider} from "@emotion/react";
+import {buttonThemeReaderRevenue} from "@guardian/source-react-components";
+import {
+	LinkButton,
+	SvgArrowRightStraight,
+} from '@guardian/source-react-components';
+import { space} from "@guardian/source-foundations";
+import {
+	HIDE_SUPPORT_MESSAGING_COOKIE, isRecentOneOffContributor, RECURRING_CONTRIBUTOR_COOKIE,
+	shouldHideSupportMessaging,
+	shouldShowSupportMessaging
+} from "../lib/contributions";
+import {getCookie,} from "@guardian/libs";
+import {EditionId} from "../lib/edition";
+
+type InteractiveSupportButtonProps={editionId:EditionId,subscribeUrl:string};
+
+const PositionButton = ({ children }: { children: React.ReactNode }) => (
+	<div
+		css={css`
+			margin-top: ${space[1]}px;
+			margin-left: ${space[2]}px;
+		`}
+	>
+		{children}
+	</div>
+);
+
+
+export const InteractiveSupportButton =  ({editionId,subscribeUrl} : InteractiveSupportButtonProps) => {
+	// useEffect(() => {
+	//
+	// });
+
+	const hideSupportMessaging = shouldHideSupportMessaging();
+
+
+	console.log("shouldShowSupportMessaging()", shouldShowSupportMessaging())
+	console.log("isRecurringContributor(isSignedIn)",getCookie({ name: RECURRING_CONTRIBUTOR_COOKIE }) === 'true')
+	console.log("isRecentOneOffContributor()", isRecentOneOffContributor())
+	console.log("hideSupportMessaging", hideSupportMessaging)
+	console.log("GEtCookie",getCookie({ name: HIDE_SUPPORT_MESSAGING_COOKIE }))
+
+
+
+	if (!hideSupportMessaging) {
+		return (
+			<Hide when="above" breakpoint="tablet">
+				<ThemeProvider theme={buttonThemeReaderRevenue}>
+					<PositionButton>
+						<LinkButton
+							priority="primary"
+							size="small"
+							iconSide="right"
+							icon={<SvgArrowRightStraight/>}
+							data-link-name="nav2 : support-cta"
+							data-edition={editionId}
+							href={subscribeUrl}
+						>
+							Support us
+						</LinkButton>
+					</PositionButton>
+				</ThemeProvider>
+			</Hide>
+		)
+	}
+	return null;
+
+};

--- a/dotcom-rendering/src/web/components/Nav/Nav.tsx
+++ b/dotcom-rendering/src/web/components/Nav/Nav.tsx
@@ -50,7 +50,6 @@ const PositionRoundel = ({ children }: { children: React.ReactNode }) => (
 	</div>
 );
 
-
 export const Nav = ({
 	format,
 	nav,
@@ -176,9 +175,12 @@ export const Nav = ({
 				]}
 				data-component="nav2"
 			>
-				{format.display === ArticleDisplay.Immersive &&  (
+				{format.display === ArticleDisplay.Immersive && (
 					<Island deferUntil="visible" clientOnly={true}>
-						<InteractiveSupportButton editionId={editionId} subscribeUrl={subscribeUrl}/>
+						<InteractiveSupportButton
+							editionId={editionId}
+							subscribeUrl={subscribeUrl}
+						/>
 					</Island>
 					// <Hide when="above" breakpoint="tablet">
 					// 	<ThemeProvider theme={buttonThemeReaderRevenue}>

--- a/dotcom-rendering/src/web/components/Nav/Nav.tsx
+++ b/dotcom-rendering/src/web/components/Nav/Nav.tsx
@@ -1,19 +1,15 @@
-import { css, Global, ThemeProvider } from '@emotion/react';
+import { css, Global } from '@emotion/react';
 import { ArticleDisplay, ArticleSpecial } from '@guardian/libs';
-import { space, until, visuallyHidden } from '@guardian/source-foundations';
-import {
-	buttonThemeReaderRevenue,
-	LinkButton,
-	SvgArrowRightStraight,
-} from '@guardian/source-react-components';
+import { until, visuallyHidden } from '@guardian/source-foundations';
 import { clearFix } from '../../../lib/mixins';
 import type { NavType } from '../../../model/extract-nav';
 import type { EditionId } from '../../lib/edition';
 import { GuardianRoundel } from '../GuardianRoundel';
-import { Hide } from '../Hide';
 import { Pillars } from '../Pillars';
 import { navInputCheckboxId, showMoreButtonId, veggieBurgerId } from './config';
 import { ExpandedMenu } from './ExpandedMenu/ExpandedMenu';
+import { InteractiveSupportButton } from '../InteractiveSupportButton.importable';
+import { Island } from '../Island';
 
 type Props = {
 	format: ArticleFormat;
@@ -54,16 +50,6 @@ const PositionRoundel = ({ children }: { children: React.ReactNode }) => (
 	</div>
 );
 
-const PositionButton = ({ children }: { children: React.ReactNode }) => (
-	<div
-		css={css`
-			margin-top: ${space[1]}px;
-			margin-left: ${space[2]}px;
-		`}
-	>
-		{children}
-	</div>
-);
 
 export const Nav = ({
 	format,
@@ -190,24 +176,27 @@ export const Nav = ({
 				]}
 				data-component="nav2"
 			>
-				{format.display === ArticleDisplay.Immersive && (
-					<Hide when="above" breakpoint="tablet">
-						<ThemeProvider theme={buttonThemeReaderRevenue}>
-							<PositionButton>
-								<LinkButton
-									priority="primary"
-									size="small"
-									iconSide="right"
-									icon={<SvgArrowRightStraight />}
-									data-link-name="nav2 : support-cta"
-									data-edition={editionId}
-									href={subscribeUrl}
-								>
-									Support us
-								</LinkButton>
-							</PositionButton>
-						</ThemeProvider>
-					</Hide>
+				{format.display === ArticleDisplay.Immersive &&  (
+					<Island deferUntil="visible" clientOnly={true}>
+						<InteractiveSupportButton editionId={editionId} subscribeUrl={subscribeUrl}/>
+					</Island>
+					// <Hide when="above" breakpoint="tablet">
+					// 	<ThemeProvider theme={buttonThemeReaderRevenue}>
+					// 		<PositionButton>
+					// 			<LinkButton
+					// 				priority="primary"
+					// 				size="small"
+					// 				iconSide="right"
+					// 				icon={<SvgArrowRightStraight />}
+					// 				data-link-name="nav2 : support-cta"
+					// 				data-edition={editionId}
+					// 				href={subscribeUrl}
+					// 			>
+					// 				Support us
+					// 			</LinkButton>
+					// 		</PositionButton>
+					// 	</ThemeProvider>
+					// </Hide>
 				)}
 				{/*
                 IMPORTANT NOTE:

--- a/dotcom-rendering/src/web/components/Nav/Nav.tsx
+++ b/dotcom-rendering/src/web/components/Nav/Nav.tsx
@@ -182,23 +182,6 @@ export const Nav = ({
 							subscribeUrl={subscribeUrl}
 						/>
 					</Island>
-					// <Hide when="above" breakpoint="tablet">
-					// 	<ThemeProvider theme={buttonThemeReaderRevenue}>
-					// 		<PositionButton>
-					// 			<LinkButton
-					// 				priority="primary"
-					// 				size="small"
-					// 				iconSide="right"
-					// 				icon={<SvgArrowRightStraight />}
-					// 				data-link-name="nav2 : support-cta"
-					// 				data-edition={editionId}
-					// 				href={subscribeUrl}
-					// 			>
-					// 				Support us
-					// 			</LinkButton>
-					// 		</PositionButton>
-					// 	</ThemeProvider>
-					// </Hide>
 				)}
 				{/*
                 IMPORTANT NOTE:

--- a/dotcom-rendering/src/web/components/Nav/Nav.tsx
+++ b/dotcom-rendering/src/web/components/Nav/Nav.tsx
@@ -191,24 +191,24 @@ export const Nav = ({
 			>
 				{/* eslint-disable-next-line @typescript-eslint/strict-boolean-expressions */}
 				{format.display === ArticleDisplay.Immersive && (
-						<Hide when="above" breakpoint="tablet">
-							<ThemeProvider theme={buttonThemeReaderRevenue}>
-								<PositionButton>
-									<LinkButton
-										priority="primary"
-										size="small"
-										iconSide="right"
-										icon={<SvgArrowRightStraight />}
-										data-link-name="nav2 : support-cta"
-										data-edition={editionId}
-										href={subscribeUrl}
-									>
-										Support us
-									</LinkButton>
-								</PositionButton>
-							</ThemeProvider>
-						</Hide>
-					)}
+					<Hide when="above" breakpoint="tablet">
+						<ThemeProvider theme={buttonThemeReaderRevenue}>
+							<PositionButton>
+								<LinkButton
+									priority="primary"
+									size="small"
+									iconSide="right"
+									icon={<SvgArrowRightStraight />}
+									data-link-name="nav2 : support-cta"
+									data-edition={editionId}
+									href={subscribeUrl}
+								>
+									Support us
+								</LinkButton>
+							</PositionButton>
+						</ThemeProvider>
+					</Hide>
+				)}
 				{/*
                 IMPORTANT NOTE:
                 It is important to have the input as the 1st sibling for NoJS to work

--- a/dotcom-rendering/src/web/components/Nav/Nav.tsx
+++ b/dotcom-rendering/src/web/components/Nav/Nav.tsx
@@ -75,7 +75,6 @@ export const Nav = ({
 	const displayRoundel =
 		format.display === ArticleDisplay.Immersive ||
 		format.theme === ArticleSpecial.Labs;
-
 	return (
 		<div css={rowStyles}>
 			<Global
@@ -190,25 +189,26 @@ export const Nav = ({
 				]}
 				data-component="nav2"
 			>
+				{/* eslint-disable-next-line @typescript-eslint/strict-boolean-expressions */}
 				{format.display === ArticleDisplay.Immersive && (
-					<Hide when="above" breakpoint="tablet">
-						<ThemeProvider theme={buttonThemeReaderRevenue}>
-							<PositionButton>
-								<LinkButton
-									priority="primary"
-									size="small"
-									iconSide="right"
-									icon={<SvgArrowRightStraight />}
-									data-link-name="nav2 : support-cta"
-									data-edition={editionId}
-									href={subscribeUrl}
-								>
-									Subscribe
-								</LinkButton>
-							</PositionButton>
-						</ThemeProvider>
-					</Hide>
-				)}
+						<Hide when="above" breakpoint="tablet">
+							<ThemeProvider theme={buttonThemeReaderRevenue}>
+								<PositionButton>
+									<LinkButton
+										priority="primary"
+										size="small"
+										iconSide="right"
+										icon={<SvgArrowRightStraight />}
+										data-link-name="nav2 : support-cta"
+										data-edition={editionId}
+										href={subscribeUrl}
+									>
+										Support us
+									</LinkButton>
+								</PositionButton>
+							</ThemeProvider>
+						</Hide>
+					)}
 				{/*
                 IMPORTANT NOTE:
                 It is important to have the input as the 1st sibling for NoJS to work

--- a/dotcom-rendering/src/web/components/Nav/Nav.tsx
+++ b/dotcom-rendering/src/web/components/Nav/Nav.tsx
@@ -75,6 +75,7 @@ export const Nav = ({
 	const displayRoundel =
 		format.display === ArticleDisplay.Immersive ||
 		format.theme === ArticleSpecial.Labs;
+
 	return (
 		<div css={rowStyles}>
 			<Global
@@ -189,7 +190,6 @@ export const Nav = ({
 				]}
 				data-component="nav2"
 			>
-				{/* eslint-disable-next-line @typescript-eslint/strict-boolean-expressions */}
 				{format.display === ArticleDisplay.Immersive && (
 					<Hide when="above" breakpoint="tablet">
 						<ThemeProvider theme={buttonThemeReaderRevenue}>

--- a/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
@@ -353,7 +353,7 @@ export const ImmersiveLayout = ({ article, NAV, format }: Props) => {
 						}}
 						nav={NAV}
 						subscribeUrl={
-							article.nav.readerRevenueLinks.header.subscribe
+							article.nav.readerRevenueLinks.header.contribute
 						}
 						editionId={article.editionId}
 						headerTopBarSwitch={

--- a/dotcom-rendering/src/web/lib/contributions.ts
+++ b/dotcom-rendering/src/web/lib/contributions.ts
@@ -34,7 +34,7 @@ export const MODULES_VERSION = 'v3';
 // including but not limited to recurring & one-off contributions,
 // paper & digital subscriptions, as well as user tiers (GU supporters/staff/partners/patrons).
 // https://github.com/guardian/members-data-api/blob/3a72dc00b9389968d91e5930686aaf34d8040c52/membership-attribute-service/app/models/Attributes.scala
-export const shouldShowSupportMessaging = (): boolean => {
+const shouldShowSupportMessaging = (): boolean => {
 	const hideSupportMessaging =
 		getCookie({ name: HIDE_SUPPORT_MESSAGING_COOKIE }) === 'true';
 

--- a/dotcom-rendering/src/web/lib/contributions.ts
+++ b/dotcom-rendering/src/web/lib/contributions.ts
@@ -34,7 +34,7 @@ export const MODULES_VERSION = 'v3';
 // including but not limited to recurring & one-off contributions,
 // paper & digital subscriptions, as well as user tiers (GU supporters/staff/partners/patrons).
 // https://github.com/guardian/members-data-api/blob/3a72dc00b9389968d91e5930686aaf34d8040c52/membership-attribute-service/app/models/Attributes.scala
-const shouldShowSupportMessaging = (): boolean => {
+export const shouldShowSupportMessaging = (): boolean => {
 	const hideSupportMessaging =
 		getCookie({ name: HIDE_SUPPORT_MESSAGING_COOKIE }) === 'true';
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Update "subscribe" CTA in masthead on interactive articles on www.theguardian.com

Trello card :https://trello.com/c/ozsh88AN/1110-update-subscribe-cta-in-masthead-on-interactive-articles-on-wwwtheguardiancom
## Why?

Interactive article: [Grief and defiance in Kyiv on first anniversary of war in Ukraine](https://www.theguardian.com/world/2023/feb/24/grief-and-defiance-in-kyiv-on-first-anniversary-of-war-in-ukraine)
The "subscribe" link goes to print, it feels like a left over from the pre-prop header where we used to have a 'subscribe' button.
This is the compact navigation used on interactive articles. This has been missed, it looks like this CTA isn't configured from the RRCP, it's hardcoded in the nav. First thing we should do is update the hardcoded CTA to be a "Support" CTA, then we should look at hiding it for those users who shouldn't see supporter messaging.

## Screenshots

###Before
  <img width="903" alt="image" src="https://user-images.githubusercontent.com/73653255/224108033-660a48fc-42d4-4059-b77a-102035886477.png">


###After 
<img width="993" alt="image" src="https://user-images.githubusercontent.com/73653255/224108640-d5bed6eb-2026-41c6-a9be-30dcc9be32a4.png">

OnClick Support us CTA takes user to https://support.theguardian.com/uk/contribute page and it would be hidden if gu_hide_support_messaging cookie is set to true for logged in users