### PR TITLE
Improve match stats legibility

### DIFF
--- a/dotcom-rendering/src/web/components/Doughnut.stories.tsx
+++ b/dotcom-rendering/src/web/components/Doughnut.stories.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import { palette } from '@guardian/source-foundations';
 import { Doughnut } from './Doughnut';
 
 export default {
@@ -58,6 +59,24 @@ const threeSections = [
 	},
 ];
 
+const identicalColours = [
+	{
+		value: 55,
+		label: 'Orange',
+		color: palette.opinion[400],
+	},
+	{
+		value: 35,
+		label: 'Tangerine',
+		color: palette.opinion[400],
+	},
+	{
+		value: 10,
+		label: 'Mandarin',
+		color: palette.opinion[400],
+	},
+];
+
 const Wrapper = ({ children }: { children: React.ReactNode }) => (
 	<div
 		css={css`
@@ -104,6 +123,15 @@ export const Three = () => {
 	);
 };
 Three.story = { name: 'with three sections' };
+
+export const Identical = () => {
+	return (
+		<Wrapper>
+			<Doughnut sections={identicalColours} />
+		</Wrapper>
+	);
+};
+Three.story = { name: 'with three identical colours' };
 
 export const Smaller = () => {
 	return (

--- a/dotcom-rendering/src/web/components/Doughnut.tsx
+++ b/dotcom-rendering/src/web/components/Doughnut.tsx
@@ -1,5 +1,10 @@
 import { css } from '@emotion/react';
-import { headline, text, textSans } from '@guardian/source-foundations';
+import {
+	headline,
+	palette,
+	text,
+	textSans,
+} from '@guardian/source-foundations';
 import { isLight } from '../lib/isLight';
 
 type Props = {
@@ -32,6 +37,11 @@ const labelStyles = (background: string) => css`
 	${textSans.small()}
 	fill: ${isLight(background) ? text.ctaSecondary : text.ctaPrimary};
 	text-anchor: middle;
+`;
+
+const lineStyles = css`
+	stroke-width: 2;
+	stroke: ${palette.neutral[97]};
 `;
 
 const withoutZeroSections = (sections: SectionType[]) =>
@@ -69,6 +79,12 @@ export const Doughnut = ({
 		value: number;
 	}[] = [];
 
+	/**
+	 * These lines help distinguish segments.
+	 * Only shown for 2 segments or more.
+	 */
+	const separatingLines: { label: string; d: string }[] = [];
+
 	let angleStart = -quarterTurn;
 	for (const { color, label, value } of withoutZeroSections(sections)) {
 		const angleLength = (value / totalValue) * tau;
@@ -103,6 +119,20 @@ export const Doughnut = ({
 			color,
 		});
 
+		const x = Math.cos(angleEnd);
+		const y = Math.sin(angleEnd);
+
+		separatingLines.push({
+			label,
+			d: [
+				`M${center},${center}`,
+				`m${x * innerRadius},${y * innerRadius}`, // start the line from inner radius
+				`l${x * (outerRadius - innerRadius)},${
+					y * (outerRadius - innerRadius)
+				}`, // stop it at the outer radius
+			].join(' '),
+		});
+
 		angleStart = angleEnd;
 	}
 
@@ -132,6 +162,10 @@ export const Doughnut = ({
 					</text>
 				</g>
 			))}
+			{separatingLines.length >= 2 &&
+				separatingLines.map(({ d, label }) => (
+					<path key={label} css={lineStyles} d={d} />
+				))}
 			<text
 				css={unitStyles}
 				transform={`translate(${center}, ${center})`}

--- a/dotcom-rendering/src/web/components/GoalAttempts.tsx
+++ b/dotcom-rendering/src/web/components/GoalAttempts.tsx
@@ -20,6 +20,7 @@ const Row = ({ children }: { children: React.ReactNode }) => (
 		css={css`
 			display: flex;
 			flex-direction: row;
+			gap: 2px;
 		`}
 	>
 		{children}


### PR DESCRIPTION
## What does this change?

Make some improvements in legiblity of code and the stats displayed on the site.

## Why?

- The intent with [`radial-gradient`](https://developer.mozilla.org/en-US/docs/Web/CSS/gradient/radial-gradient) is clearer and the payload smaller
- Teams with [very similar colours](https://www.theguardian.com/football/match/2023/mar/04/arsenal-v-bournemouth) are easier to distinguish

The original issue was raised by @dskamiotis in a chat channel about [the Aresenal v Bournemouth match](https://www.theguardian.com/football/match/2023/mar/04/arsenal-v-bournemouth). Worth noting that these match reports are rendered from frontend, so one might have to push these changes back upstream, or ensure that they get rendered by DCR.

![image](https://user-images.githubusercontent.com/76776/223979714-73cc2564-a61d-4e85-aedb-9c0d034b7d8c.png)

## Disclaimer

I know very little about football, but quite a lot about visual representation. I would love a knowledgable individual to chime in ⚽ !

The approach to separate the sections of the doughnut does not handle background other than `palette.neutral[97]`, as doing so would require a larger and possibly much more complex refactor ([`clip-path`](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/clip-path), or more involved trigonometry)

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/76776/223978057-0d61c5f3-7d8f-4fab-ae83-51445ace3ded.png
[after]: https://user-images.githubusercontent.com/76776/223978010-1ab6d742-6311-4728-9c49-cbb2d1e56e70.png

