### PR TITLE
Remove `discussion-rendering` From AR

### DIFF
--- a/apps-rendering/package.json
+++ b/apps-rendering/package.json
@@ -106,7 +106,6 @@
 		"react": "^17.0.2",
 		"react-dom": "^17.0.2",
 		"react-test-renderer": "^17.0.2",
-		"regenerator-runtime": "^0.13.9",
 		"require-from-string": "^2.0.2",
 		"source-map-support": "^0.5.21",
 		"thrift": "^0.16.0",

--- a/apps-rendering/package.json
+++ b/apps-rendering/package.json
@@ -47,7 +47,6 @@
 		"@guardian/cdk": "^47.3.3",
 		"@guardian/content-api-models": "^17.4.2",
 		"@guardian/content-atom-model": "^3.4.0",
-		"@guardian/discussion-rendering": "^10.1.1",
 		"@guardian/eslint-config-typescript": "^0.7.0",
 		"@guardian/eslint-plugin-source-react-components": "^9.0.0",
 		"@guardian/libs": "^12.0.0",

--- a/apps-rendering/src/capi.test.ts
+++ b/apps-rendering/src/capi.test.ts
@@ -8,7 +8,7 @@ describe('server logic runs as expected', () => {
 		const capiUrl = capiEndpoint(articleId, key);
 
 		expect(capiUrl).toEqual(
-			'https://content.guardianapis.com/cities/2019/sep/13/reclaimed-lakes-and-giant-airports-how-mexico-city-might-have-looked?format=thrift&api-key=TEST_KEY&show-atoms=all&show-fields=headline%2Cstandfirst%2CbylineHtml%2CfirstPublicationDate%2CshouldHideAdverts%2CshouldHideReaderRevenue%2CdisplayHint%2CstarRating%2Ccommentable%2CinternalShortId%2CliveBloggingNow%2ClastModified%2CisInappropriateForSponsorship%2CshowTableOfContents&show-tags=all&show-blocks=all&show-elements=all&show-related=true&show-references=all',
+			'https://content.guardianapis.com/cities/2019/sep/13/reclaimed-lakes-and-giant-airports-how-mexico-city-might-have-looked?format=thrift&api-key=TEST_KEY&show-atoms=all&show-fields=headline%2Cstandfirst%2CbylineHtml%2CfirstPublicationDate%2CshouldHideAdverts%2CshouldHideReaderRevenue%2CdisplayHint%2CstarRating%2Ccommentable%2CliveBloggingNow%2ClastModified%2CisInappropriateForSponsorship%2CshowTableOfContents&show-tags=all&show-blocks=all&show-elements=all&show-related=true&show-references=all',
 		);
 	});
 });

--- a/apps-rendering/src/capi.ts
+++ b/apps-rendering/src/capi.ts
@@ -157,7 +157,6 @@ const getThirdPartyEmbeds = (content: Content): ThirdPartyEmbeds => {
 
 const requiresInlineStyles = (renderingRequest: RenderingRequest): boolean => {
 	// return !!(
-	//	   content.fields?.commentable ??
 	//	   content.atoms?.quizzes ??
 	//	   content.atoms?.audios ??
 	//	   content.atoms?.charts

--- a/apps-rendering/src/capi.ts
+++ b/apps-rendering/src/capi.ts
@@ -189,7 +189,6 @@ const capiEndpoint = (articleId: string, key: string): string => {
 		'displayHint',
 		'starRating',
 		'commentable',
-		'internalShortId',
 		'liveBloggingNow',
 		'lastModified',
 		'isInappropriateForSponsorship',

--- a/apps-rendering/src/client/article.ts
+++ b/apps-rendering/src/client/article.ts
@@ -4,10 +4,7 @@ import './liveblog';
 
 import 'regenerator-runtime/runtime.js';
 import { AudioAtom } from '@guardian/atoms-rendering';
-import type { ICommentResponse as CommentResponse } from '@guardian/bridget';
 import { Topic } from '@guardian/bridget/Topic';
-import { App } from '@guardian/discussion-rendering/build/App';
-import { getPillarFromId } from 'articleFormat';
 import {
 	ads,
 	getAdSlots,
@@ -25,12 +22,10 @@ import { handleErrors, isObject } from 'lib';
 import {
 	acquisitionsClient,
 	commercialClient,
-	discussionClient,
 	navigationClient,
 	notificationsClient,
 	userClient,
 } from 'native/nativeApi';
-import { Optional } from 'optional';
 import type { ReactElement } from 'react';
 import { createElement as h } from 'react';
 import ReactDOM from 'react-dom';
@@ -148,68 +143,6 @@ function insertEpic(): void {
 				}
 			})
 			.catch((error) => console.error(error));
-	}
-}
-
-function renderComments(): void {
-	const commentContainer = document.getElementById('comments');
-	const pillar = Optional.fromNullable(
-		commentContainer?.getAttribute('data-pillar'),
-	).flatMap(getPillarFromId);
-	const shortUrl = commentContainer?.getAttribute('data-short-id');
-	const isClosedForComments = !!commentContainer?.getAttribute('pillar');
-
-	if (pillar.isSome() && shortUrl) {
-		const user = {
-			userId: 'abc123',
-			displayName: 'Jane Smith',
-			webUrl: '',
-			apiUrl: '',
-			secureAvatarUrl: '',
-			avatar: '',
-			badge: [],
-		};
-
-		const additionalHeaders = {};
-
-		const props = {
-			shortUrl,
-			baseUrl: 'https://discussion.theguardian.com/discussion-api',
-			pillar: pillar.value,
-			user,
-			isClosedForComments,
-			additionalHeaders,
-			expanded: false,
-			apiKey: 'ios',
-			onPermalinkClick: (commentId: number): void => {
-				console.log(commentId);
-			},
-			onRecommend: (commentId: number): Promise<boolean> => {
-				return discussionClient.recommend(commentId);
-			},
-			onComment: (
-				shortUrl: string,
-				body: string,
-			): Promise<CommentResponse & { status: 'ok' | 'error' }> => {
-				return discussionClient
-					.comment(shortUrl, body)
-					.then((response) => ({ ...response, status: 'ok' }));
-			},
-			onReply: (
-				shortUrl: string,
-				body: string,
-				parentCommentId: number,
-			): Promise<CommentResponse & { status: 'ok' | 'error' }> => {
-				return discussionClient
-					.reply(shortUrl, body, parentCommentId)
-					.then((response) => ({ ...response, status: 'ok' }));
-			},
-			onPreview: (body: string): Promise<string> => {
-				return discussionClient.preview(body);
-			},
-		};
-
-		ReactDOM.render(h(App, props), commentContainer);
 	}
 }
 
@@ -359,7 +292,6 @@ slideshow();
 footerInit();
 insertEpic();
 callouts();
-renderComments();
 hasSeenCards();
 initAudioAtoms();
 hydrateAtoms();

--- a/apps-rendering/src/client/article.ts
+++ b/apps-rendering/src/client/article.ts
@@ -2,7 +2,6 @@
 
 import './liveblog';
 
-import 'regenerator-runtime/runtime.js';
 import { AudioAtom } from '@guardian/atoms-rendering';
 import { Topic } from '@guardian/bridget/Topic';
 import {

--- a/apps-rendering/src/components/Layout/StandardLayout.tsx
+++ b/apps-rendering/src/components/Layout/StandardLayout.tsx
@@ -9,8 +9,6 @@ import {
 	DottedLines,
 	StraightLines,
 } from '@guardian/source-react-components-development-kitchen';
-import { map, withDefault } from '@guardian/types';
-import { pillarToId, themeToPillar } from 'articleFormat';
 import Body from 'components/ArticleBody';
 import Epic from 'components/Epic';
 import FootballScores from 'components/FootballScores';
@@ -43,7 +41,7 @@ import type {
 	Review,
 	Standard,
 } from 'item';
-import { maybeRender, pipe } from 'lib';
+import { maybeRender } from 'lib';
 import { Optional } from 'optional';
 import { background } from 'palette';
 import type { FC } from 'react';
@@ -109,26 +107,6 @@ const StandardLayout: FC<Props> = ({ item }) => {
 		</div>
 	);
 
-	const commentContainer = item.commentable
-		? pipe(
-				item.internalShortId,
-				map((id) => (
-					<section
-						css={onwardStyles}
-						id="comments"
-						data-closed={false}
-						data-pillar={pipe(
-							item.theme,
-							themeToPillar,
-							pillarToId,
-						)}
-						data-short-id={id}
-					></section>
-				)),
-				withDefault(<></>),
-		  )
-		: null;
-
 	const matchScores: Optional<MatchScores> =
 		'football' in item ? item.football : Optional.none();
 	return (
@@ -191,7 +169,6 @@ const StandardLayout: FC<Props> = ({ item }) => {
 			<section css={onwardStyles}>
 				<RelatedContent item={item} />
 			</section>
-			{commentContainer}
 			<Footer isCcpa={false} format={item} />
 		</main>
 	);

--- a/apps-rendering/src/fixtures/item.ts
+++ b/apps-rendering/src/fixtures/item.ts
@@ -429,7 +429,6 @@ const fields = {
 		sponsorName: 'Judith Nielson Institute',
 		sponsorUri: 'https://jninstitute.org/',
 	}),
-	internalShortId: none,
 	commentCount: none,
 	relatedContent: relatedContent,
 	footballContent: none,

--- a/apps-rendering/src/fixtures/live.ts
+++ b/apps-rendering/src/fixtures/live.ts
@@ -259,7 +259,6 @@ const fields = {
 		sponsorName: 'Judith Nielson Institute',
 		sponsorUri: 'https://jninstitute.org/',
 	}),
-	internalShortId: none,
 	commentCount: some(1223),
 	relatedContent: none,
 	footballContent: none,

--- a/apps-rendering/src/item.ts
+++ b/apps-rendering/src/item.ts
@@ -67,7 +67,6 @@ interface Fields extends ArticleFormat {
 	tags: Tag[];
 	shouldHideReaderRevenue: boolean;
 	branding: Option<Branding>;
-	internalShortId: Option<string>;
 	commentCount: Option<number>;
 	relatedContent: Option<ResizedRelatedContent>;
 	logo: Option<Logo>;
@@ -341,7 +340,6 @@ const parseItemFields = (
 		shouldHideReaderRevenue:
 			content.fields?.shouldHideReaderRevenue ?? false,
 		branding: getBranding(request),
-		internalShortId: fromNullable(content.fields?.internalShortId),
 		commentCount: fromNullable(commentCount),
 		relatedContent: pipe(
 			relatedContent,

--- a/apps-rendering/src/native/nativeApi.ts
+++ b/apps-rendering/src/native/nativeApi.ts
@@ -1,7 +1,6 @@
 import * as Acquisitions from '@guardian/bridget/Acquisitions';
 import * as Analytics from '@guardian/bridget/Analytics';
 import * as Commercial from '@guardian/bridget/Commercial';
-import * as Discussion from '@guardian/bridget/Discussion';
 import * as Environment from '@guardian/bridget/Environment';
 import * as Gallery from '@guardian/bridget/Gallery';
 import * as Metrics from '@guardian/bridget/Metrics';
@@ -40,9 +39,6 @@ const videoClient: Video.Client<void> = createAppClient<Video.Client<void>>(
 const metricsClient: Metrics.Client<void> = createAppClient<
 	Metrics.Client<void>
 >(Metrics.Client, 'buffered', 'compact');
-const discussionClient: Discussion.Client<void> = createAppClient<
-	Discussion.Client<void>
->(Discussion.Client, 'buffered', 'compact');
 
 const analyticsClient: Analytics.Client<void> = createAppClient<
 	Analytics.Client<void>
@@ -65,7 +61,6 @@ export {
 	galleryClient,
 	videoClient,
 	metricsClient,
-	discussionClient,
 	analyticsClient,
 	navigationClient,
 	newslettersClient,

--- a/apps-rendering/src/server/csp.ts
+++ b/apps-rendering/src/server/csp.ts
@@ -114,7 +114,7 @@ const buildCsp = (
 			: ''
 	};
     font-src 'self' https://interactive.guim.co.uk;
-    connect-src 'self' https://discussion.theguardian.com/discussion-api/ https://callouts.code.dev-guardianapis.com/formstack-campaign/submit https://interactive.guim.co.uk https://sf-hs-sg.ibytedtos.com/ https://gdn-cdn.s3.amazonaws.com/;
+    connect-src 'self' https://callouts.code.dev-guardianapis.com/formstack-campaign/submit https://interactive.guim.co.uk https://sf-hs-sg.ibytedtos.com/ https://gdn-cdn.s3.amazonaws.com/;
     media-src 'self' https://audio.guim.co.uk/
 `.trim();
 
@@ -146,7 +146,7 @@ function buildCspEditions(
 			: ''
 	};
 	font-src 'self' https://interactive.guim.co.uk https://editions-published-code.s3.eu-west-1.amazonaws.com https://editions-published-prod.s3.eu-west-1.amazonaws.com;
-	connect-src 'self' https://discussion.theguardian.com/discussion-api/ https://callouts.code.dev-guardianapis.com/formstack-campaign/submit https://interactive.guim.co.uk https://sf-hs-sg.ibytedtos.com/ https://gdn-cdn.s3.amazonaws.com/;
+	connect-src 'self' https://callouts.code.dev-guardianapis.com/formstack-campaign/submit https://interactive.guim.co.uk https://sf-hs-sg.ibytedtos.com/ https://gdn-cdn.s3.amazonaws.com/;
 	media-src 'self' https://audio.guim.co.uk/
 	`;
 }

--- a/apps-rendering/yarn.lock
+++ b/apps-rendering/yarn.lock
@@ -11790,7 +11790,7 @@ regenerate@^1.4.2:
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.2.tgz#b9346d8827e8f5a32f7ba29637d398b69014848a"
   integrity sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==
 
-regenerator-runtime@^0.13.10, regenerator-runtime@^0.13.11, regenerator-runtime@^0.13.4, regenerator-runtime@^0.13.7, regenerator-runtime@^0.13.9:
+regenerator-runtime@^0.13.10, regenerator-runtime@^0.13.11, regenerator-runtime@^0.13.4, regenerator-runtime@^0.13.7:
   version "0.13.11"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
   integrity sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==

--- a/apps-rendering/yarn.lock
+++ b/apps-rendering/yarn.lock
@@ -1649,15 +1649,6 @@
     node-int64 "^0.4.0"
     thrift "^0.15.0"
 
-"@guardian/discussion-rendering@^10.1.1":
-  version "10.1.1"
-  resolved "https://registry.yarnpkg.com/@guardian/discussion-rendering/-/discussion-rendering-10.1.1.tgz#7613046322253bdcbd18b2a96647911df27fce25"
-  integrity sha512-HHAIkVw+CnJizYESYCm8Dt3rlLVVVmbRMaVqCT1E09uio7Zg5ShXMcv2rjJ/WzsjCGGtBTJ66v5x+dkZqWeZqA==
-  dependencies:
-    babel-plugin-emotion "^10.0.33"
-    customize-cra "^1.0.0"
-    timeago.js "^4.0.2"
-
 "@guardian/eslint-config-typescript@^0.7.0":
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@guardian/eslint-config-typescript/-/eslint-config-typescript-0.7.0.tgz#9b675639377bd71bc42f33741ea3bbbf20525c4a"
@@ -4670,7 +4661,7 @@ babel-plugin-apply-mdx-type-prop@1.6.22:
     "@babel/helper-plugin-utils" "7.10.4"
     "@mdx-js/util" "1.6.22"
 
-babel-plugin-emotion@^10.0.27, babel-plugin-emotion@^10.0.33:
+babel-plugin-emotion@^10.0.27:
   version "10.2.2"
   resolved "https://registry.yarnpkg.com/babel-plugin-emotion/-/babel-plugin-emotion-10.2.2.tgz#a1fe3503cff80abfd0bdda14abd2e8e57a79d17d"
   integrity sha512-SMSkGoqTbTyUTDeuVuPIWifPdUGkTk1Kf9BWRiXIOIcuyMfsdp2EjeiiFvOzX8NOBvEh/ypKYvUh2rkgAJMCLA==
@@ -6078,13 +6069,6 @@ currently-unhandled@^0.4.1:
   integrity sha512-/fITjgjGU50vjQ4FH6eUoYu+iUoUKIXws2hL15JJpIR+BbTxaXQsMuuyjtNh2WqsSBS5nsaZHFsFecyw5CCAng==
   dependencies:
     array-find-index "^1.0.1"
-
-customize-cra@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/customize-cra/-/customize-cra-1.0.0.tgz#73286563631aa08127ad4d30a2e3c89cf4e93c8d"
-  integrity sha512-DbtaLuy59224U+xCiukkxSq8clq++MOtJ1Et7LED1fLszWe88EoblEYFBJ895sB1mC6B4uu3xPT/IjClELhMbA==
-  dependencies:
-    lodash.flow "^3.5.0"
 
 cyclist@^1.0.1:
   version "1.0.1"
@@ -9744,11 +9728,6 @@ lodash.flatten@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"
   integrity sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==
 
-lodash.flow@^3.5.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.flow/-/lodash.flow-3.5.0.tgz#87bf40292b8cf83e4e8ce1a3ae4209e20071675a"
-  integrity sha512-ff3BX/tSioo+XojX4MOsOMhJw0nZoUEF011LX8g8d3gvjVbxd89cCio4BCXronjxcTUIJUoqKEUA+n4CqvvRPw==
-
 lodash.isequal@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
@@ -13133,11 +13112,6 @@ thunky@^1.0.2:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/thunky/-/thunky-1.1.0.tgz#5abaf714a9405db0504732bbccd2cedd9ef9537d"
   integrity sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==
-
-timeago.js@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/timeago.js/-/timeago.js-4.0.2.tgz#724e8c8833e3490676c7bb0a75f5daf20e558028"
-  integrity sha512-a7wPxPdVlQL7lqvitHGGRsofhdwtkoSXPGATFuSOA2i1ZNQEPLrGnj68vOp2sOJTCFAQVXPeNMX/GctBaO9L2w==
 
 timers-browserify@^2.0.4:
   version "2.0.12"


### PR DESCRIPTION
## Why?

The AR codebase imports and uses the `discussion-rendering` library, but the feature is not yet in front of users. We're now unlikely to roll out support for discussion in AR, instead unlocking this feature as part of the move to DCR for apps. Furthermore, the presence of `discussion-rendering` in the AR codebase increases the complexity of maintenance tasks like #7358. Removing it simplifies the maintenance of AR without causing a negative impact on users.

**Note:** Many of the changes in this PR are the inverse of changes made in https://github.com/guardian/apps-rendering/pull/472

## Changes

- Removed the `discussion-rendering` dependency
- Removed `regenerator-runtime`, which was originally introduced for `discussion-rendering`
- Removed the setup code for the Bridget `discussionClient`; this will be reintroduced as part of DCR
- Removed discussion-related code from the CSP
- Removed `internalShortId` from `Item` and CAPI requests
