### PR TITLE
Smaller Non-PROD AR Instances

### DIFF
--- a/apps-rendering/cdk/bin/cdk.ts
+++ b/apps-rendering/cdk/bin/cdk.ts
@@ -1,6 +1,7 @@
 import 'source-map-support/register';
 import { App } from 'aws-cdk-lib';
 import { MobileAppsRendering } from '../lib/mobile-apps-rendering';
+import { InstanceSize } from 'aws-cdk-lib/aws-ec2';
 
 const app = new App();
 
@@ -13,6 +14,7 @@ new MobileAppsRendering(app, 'MobileAppsRendering-CODE', {
 		minimumInstances: 1,
 		maximumInstances: 2,
 	},
+	instanceSize: InstanceSize.MICRO,
 	appsRenderingDomain: 'mobile-aws.code.dev-guardianapis.com',
 	hostedZoneId: 'Z6PRU8YR6TQDK',
 	targetCpuUtilisation: 20,
@@ -27,6 +29,7 @@ new MobileAppsRendering(app, 'MobileAppsRendering-PROD', {
 		minimumInstances: 6,
 		maximumInstances: 24,
 	},
+	instanceSize: InstanceSize.SMALL,
 	appsRenderingDomain: 'mobile-aws.guardianapis.com',
 	hostedZoneId: 'Z1EYB4AREPXE3B',
 	targetCpuUtilisation: 20,
@@ -41,6 +44,7 @@ new MobileAppsRendering(app, 'MobileAppsRenderingPreview-CODE', {
 		minimumInstances: 1,
 		maximumInstances: 2,
 	},
+	instanceSize: InstanceSize.MICRO,
 	appsRenderingDomain: 'mobile-aws.code.dev-guardianapis.com',
 	hostedZoneId: 'Z6PRU8YR6TQDK',
 	targetCpuUtilisation: 20,
@@ -55,6 +59,7 @@ new MobileAppsRendering(app, 'MobileAppsRenderingPreview-PROD', {
 		minimumInstances: 1,
 		maximumInstances: 2,
 	},
+	instanceSize: InstanceSize.MICRO,
 	appsRenderingDomain: 'mobile-aws.guardianapis.com',
 	hostedZoneId: 'Z1EYB4AREPXE3B',
 	targetCpuUtilisation: 20,

--- a/apps-rendering/cdk/lib/__snapshots__/mobile-apps-rendering.test.ts.snap
+++ b/apps-rendering/cdk/lib/__snapshots__/mobile-apps-rendering.test.ts.snap
@@ -1074,7 +1074,7 @@ Object {
         "ImageId": Object {
           "Ref": "AMIMobileappsrendering",
         },
-        "InstanceType": "t4g.small",
+        "InstanceType": "t4g.micro",
         "MetadataOptions": Object {
           "HttpTokens": "required",
         },

--- a/apps-rendering/cdk/lib/mobile-apps-rendering.test.ts
+++ b/apps-rendering/cdk/lib/mobile-apps-rendering.test.ts
@@ -1,5 +1,6 @@
 import { App } from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
+import { InstanceSize } from 'aws-cdk-lib/aws-ec2';
 import { MobileAppsRendering } from './mobile-apps-rendering';
 
 describe('The MobileAppsRendering stack', () => {
@@ -13,6 +14,7 @@ describe('The MobileAppsRendering stack', () => {
 				minimumInstances: 1,
 				maximumInstances: 2,
 			},
+			instanceSize: InstanceSize.SMALL,
 			appsRenderingDomain: 'mobile-aws.code.dev-guardianapis.com',
 			hostedZoneId: 'TEST-HOSTED-ZONE-ID',
 			targetCpuUtilisation: 10,
@@ -36,6 +38,7 @@ describe('The MobileAppsRenderingPreview stack', () => {
 					minimumInstances: 1,
 					maximumInstances: 2,
 				},
+				instanceSize: InstanceSize.MICRO,
 				appsRenderingDomain: 'mobile-aws.code.dev-guardianapis.com',
 				hostedZoneId: 'TEST-HOSTED-ZONE-ID',
 				targetCpuUtilisation: 10,

--- a/apps-rendering/cdk/lib/mobile-apps-rendering.ts
+++ b/apps-rendering/cdk/lib/mobile-apps-rendering.ts
@@ -6,12 +6,8 @@ import { GuAllowPolicy } from '@guardian/cdk/lib/constructs/iam';
 import type { GuAsgCapacity } from '@guardian/cdk/lib/types';
 import type { App, CfnElement } from 'aws-cdk-lib';
 import { Duration } from 'aws-cdk-lib';
-import {
-	InstanceClass,
-	InstanceSize,
-	InstanceType,
-	Peer,
-} from 'aws-cdk-lib/aws-ec2';
+import type { InstanceSize } from 'aws-cdk-lib/aws-ec2';
+import { InstanceClass, InstanceType, Peer } from 'aws-cdk-lib/aws-ec2';
 import {
 	HostedZone,
 	RecordSet,

--- a/apps-rendering/cdk/lib/mobile-apps-rendering.ts
+++ b/apps-rendering/cdk/lib/mobile-apps-rendering.ts
@@ -26,6 +26,7 @@ interface AppsStackProps extends GuStackProps {
 	appsRenderingDomain: string;
 	hostedZoneId: string;
 	targetCpuUtilisation: number;
+	instanceSize: InstanceSize;
 }
 
 export class MobileAppsRendering extends GuStack {
@@ -58,7 +59,7 @@ export class MobileAppsRendering extends GuStack {
 			},
 			instanceType: InstanceType.of(
 				InstanceClass.T4G,
-				InstanceSize.SMALL,
+				props.instanceSize,
 			),
 			certificateProps: {
 				domainName,


### PR DESCRIPTION
## Why?

Closes #5966; more information in #5913. Recently we increased the AR instance size to `t4g.small`, to better handle traffic levels we were seeing in production. However, due to the way the AR stack is defined in CDK, this meant increasing the instance size for everything in AR: mobile PROD, mobile CODE, mobile-preview PROD and mobile-preview CODE.

Given that the traffic level increase is only something we'd expect to affect mobile PROD, we may be able to remain on the `t4g.micro` instance size for the other environments. Smaller instances use fewer resources and are cheaper.

This PR changes the way the CDK stack is defined, allowing an `instanceSize` prop to be specified for each environment. That prop is set to `t4g.small` for mobile PROD, but `t4g.micro` for all other environments.

## Changes

- Added `instanceSize` prop to AR CDK stack
- Set all non-PROD stacks to smaller `micro` instances
- Updated the CDK tests
