### PR TITLE
Disable braze messages if not Taylor report

### DIFF
--- a/dotcom-rendering/src/web/components/SlotBodyEnd.importable.tsx
+++ b/dotcom-rendering/src/web/components/SlotBodyEnd.importable.tsx
@@ -62,6 +62,7 @@ const buildBrazeEpicConfig = (
 	idApiUrl: string,
 	contentType: string,
 	brazeArticleContext: BrazeArticleContext,
+	tags: TagType[],
 ): CandidateConfig<any> => {
 	return {
 		candidate: {
@@ -71,6 +72,7 @@ const buildBrazeEpicConfig = (
 					brazeMessages,
 					brazeArticleContext,
 					contentType,
+					tags,
 				),
 			show: (meta: any) => () =>
 				(
@@ -158,6 +160,7 @@ export const SlotBodyEnd = ({
 			idApiUrl,
 			contentType,
 			brazeArticleContext,
+			tags,
 		);
 		const epicConfig: SlotConfig = {
 			candidates: [brazeEpic, readerRevenueEpic],

--- a/dotcom-rendering/src/web/components/SlotBodyEnd/BrazeEpic.tsx
+++ b/dotcom-rendering/src/web/components/SlotBodyEnd/BrazeEpic.tsx
@@ -10,6 +10,8 @@ import { getBrazeMetaFromUrlFragment } from '../../lib/braze/forceBrazeMessage';
 import type { CanShowResult } from '../../lib/messagePicker';
 import { useIsInView } from '../../lib/useIsInView';
 import { useOnce } from '../../lib/useOnce';
+import { suppressForTaylorReport } from '../../lib/braze/taylorReport';
+import { TagType } from '../../../types/tag';
 
 const wrapperMargins = css`
 	margin: 18px 0;
@@ -33,6 +35,7 @@ export const canShowBrazeEpic = async (
 	brazeMessages: BrazeMessagesInterface,
 	brazeArticleContext: BrazeArticleContext,
 	contentType: string,
+	tags: TagType[],
 ): Promise<CanShowResult<Meta>> => {
 	if (contentType.toLowerCase() === 'interactive') {
 		return { show: false };
@@ -44,6 +47,10 @@ export const canShowBrazeEpic = async (
 			show: true,
 			meta: forcedBrazeMeta,
 		};
+	}
+
+	if (suppressForTaylorReport(tags)) {
+		return { show: false };
 	}
 
 	try {

--- a/dotcom-rendering/src/web/components/StickyBottomBanner.importable.tsx
+++ b/dotcom-rendering/src/web/components/StickyBottomBanner.importable.tsx
@@ -192,10 +192,12 @@ const buildReaderRevenueBannerConfig = (isEnabled: boolean) =>
 const buildBrazeBanner = (
 	brazeMessages: BrazeMessagesInterface,
 	brazeArticleContext: BrazeArticleContext,
+	tags: TagType[],
 ): CandidateConfig<any> => ({
 	candidate: {
 		id: 'braze-banner',
-		canShow: () => canShowBrazeBanner(brazeMessages, brazeArticleContext),
+		canShow: () =>
+			canShowBrazeBanner(brazeMessages, brazeArticleContext, tags),
 		show: (meta: any) => () => <BrazeBanner meta={meta} />,
 	},
 	timeoutMillis: DEFAULT_BANNER_TIMEOUT_MILLIS,
@@ -287,6 +289,7 @@ export const StickyBottomBanner = ({
 		const brazeBanner = buildBrazeBanner(
 			brazeMessages as BrazeMessagesInterface,
 			brazeArticleContext,
+			tags,
 		);
 		const bannerConfig: SlotConfig = {
 			candidates: [CMP, puzzlesBanner, readerRevenue, brazeBanner],

--- a/dotcom-rendering/src/web/components/StickyBottomBanner/BrazeBanner.tsx
+++ b/dotcom-rendering/src/web/components/StickyBottomBanner/BrazeBanner.tsx
@@ -9,6 +9,8 @@ import { submitComponentEvent } from '../../browser/ophan/ophan';
 import { getBrazeMetaFromUrlFragment } from '../../lib/braze/forceBrazeMessage';
 import { getZIndex } from '../../lib/getZIndex';
 import type { CanShowResult } from '../../lib/messagePicker';
+import { suppressForTaylorReport } from '../../lib/braze/taylorReport';
+import { TagType } from '../../../types/tag';
 
 type Meta = {
 	dataFromBraze: { [key: string]: string };
@@ -41,6 +43,7 @@ const containerStyles = css`
 export const canShowBrazeBanner = async (
 	brazeMessages: BrazeMessagesInterface,
 	brazeArticleContext: BrazeArticleContext,
+	tags: TagType[],
 ): Promise<CanShowResult<Meta>> => {
 	const forcedBrazeMeta = getBrazeMetaFromUrlFragment();
 	if (forcedBrazeMeta) {
@@ -48,6 +51,10 @@ export const canShowBrazeBanner = async (
 			show: true,
 			meta: forcedBrazeMeta,
 		};
+	}
+
+	if (suppressForTaylorReport(tags)) {
+		return { show: false };
 	}
 
 	try {

--- a/dotcom-rendering/src/web/lib/braze/taylorReport.ts
+++ b/dotcom-rendering/src/web/lib/braze/taylorReport.ts
@@ -4,4 +4,4 @@ const tagId = 'environment/environment'; //TODO
 
 export const suppressForTaylorReport = (tags: TagType[]): boolean =>
 	window.guardian.config.switches.brazeTaylorReport === true &&
-	!!tags.find((tag) => tag.id === tagId);
+	!tags.find((tag) => tag.id === tagId);

--- a/dotcom-rendering/src/web/lib/braze/taylorReport.ts
+++ b/dotcom-rendering/src/web/lib/braze/taylorReport.ts
@@ -1,12 +1,7 @@
 import { TagType } from '../../../types/tag';
 
-const taylorReportIsLive = (now: Date): boolean => {
-	const start = Date.parse('2023-03-24');
-	const end = Date.parse('2023-04-05');
-	return now.valueOf() >= start && now.valueOf() < end;
-};
-
 const tagId = ''; //TODO
 
 export const suppressForTaylorReport = (tags: TagType[]): boolean =>
-	taylorReportIsLive(new Date()) && !!tags.find((tag) => tag.id === tagId);
+	window.guardian.config.switches.brazeTaylorReport === true &&
+	!!tags.find((tag) => tag.id === tagId);

--- a/dotcom-rendering/src/web/lib/braze/taylorReport.ts
+++ b/dotcom-rendering/src/web/lib/braze/taylorReport.ts
@@ -1,6 +1,6 @@
 import { TagType } from '../../../types/tag';
 
-const tagId = 'environment/environment'; //TODO
+const tagId = 'news/series/cotton-capital';
 
 export const suppressForTaylorReport = (tags: TagType[]): boolean =>
 	window.guardian.config.switches.brazeTaylorReport === true &&

--- a/dotcom-rendering/src/web/lib/braze/taylorReport.ts
+++ b/dotcom-rendering/src/web/lib/braze/taylorReport.ts
@@ -1,6 +1,6 @@
 import { TagType } from '../../../types/tag';
 
-const tagId = ''; //TODO
+const tagId = 'environment/environment'; //TODO
 
 export const suppressForTaylorReport = (tags: TagType[]): boolean =>
 	window.guardian.config.switches.brazeTaylorReport === true &&

--- a/dotcom-rendering/src/web/lib/braze/taylorReport.ts
+++ b/dotcom-rendering/src/web/lib/braze/taylorReport.ts
@@ -1,0 +1,12 @@
+import { TagType } from '../../../types/tag';
+
+const taylorReportIsLive = (now: Date): boolean => {
+	const start = Date.parse('2023-03-24');
+	const end = Date.parse('2023-04-05');
+	return now.valueOf() >= start && now.valueOf() < end;
+};
+
+const tagId = ''; //TODO
+
+export const suppressForTaylorReport = (tags: TagType[]): boolean =>
+	taylorReportIsLive(new Date()) && !!tags.find((tag) => tag.id === tagId);


### PR DESCRIPTION
Frontend PR: https://github.com/guardian/frontend/pull/25968

When the `brazeTaylorReport` switch is enabled, braze epics + banners are only allowed on articles with the `news/series/cotton-capital` tag.