### PR TITLE
Switch off sign in gate copy test

### DIFF
--- a/dotcom-rendering/src/web/experiments/tests/sign-in-gate-copy-test-variants.ts
+++ b/dotcom-rendering/src/web/experiments/tests/sign-in-gate-copy-test-variants.ts
@@ -6,7 +6,7 @@ export const signInGateCopyTestJan2023: ABTest = {
 	expiry: '2025-12-01',
 	author: 'Lindsey Dew',
 	description: 'Test varying the copy in the call to action for sign in gate',
-	audience: 0.1,
+	audience: 0.0,
 	audienceOffset: 0.0,
 	successMeasure: 'Users sign in or create a Guardian account',
 	audienceCriteria:

--- a/dotcom-rendering/src/web/experiments/tests/sign-in-gate-main-variant.ts
+++ b/dotcom-rendering/src/web/experiments/tests/sign-in-gate-main-variant.ts
@@ -7,8 +7,8 @@ export const signInGateMainVariant: ABTest = {
 	author: 'Mahesh Makani',
 	description:
 		'Show sign in gate to 100% of users on 3rd article view of simple article templates, and show a further 5 times after the first dismissal, with higher priority over banners and epic. Main/Variant Audience.',
-	audience: 0.8,
-	audienceOffset: 0.1,
+	audience: 0.9,
+	audienceOffset: 0.0,
 	successMeasure: 'Users sign in or create a Guardian account',
 	audienceCriteria:
 		'3rd article of the day, lower priority than consent banner, simple articles (not gallery, live etc.), not signed in, not shown after dismiss, not on help, info sections etc. Exclude iOS 9 and guardian-live-australia. Suppresses other banners, and appears over epics',


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This sets the audience offset of the sign in gate copy test to zero and puts the sign in gate main variant test back to 90% of the audience. Since we are planning to run a very similar test to try out new copy, I have left the code that configures the test in the code base for now. 

## Why?
We have concluded the sign in gate copy variations tests now, and so we are able to switch it off. 

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->


<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
