### PR TITLE
Hide empty ad slots for `poorDeviceConnectivityVariant`

### DIFF
--- a/dotcom-rendering/src/web/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/CommentLayout.tsx
@@ -48,6 +48,7 @@ import { getContributionsServiceUrl } from '../lib/contributions';
 import { decidePalette } from '../lib/decidePalette';
 import { decideTrail } from '../lib/decideTrail';
 import { getCurrentPillar } from '../lib/layoutHelpers';
+import { canRenderAds } from '../lib/canRenderAds';
 import { BannerWrapper, SendToBack, Stuck } from './lib/stickiness';
 
 const StandardGrid = ({
@@ -303,7 +304,7 @@ export const CommentLayout = ({ article, NAV, format }: Props) => {
 
 	const contributionsServiceUrl = getContributionsServiceUrl(article);
 
-	const renderAds = !article.isAdFreeUser && !article.shouldHideAds;
+	const renderAds = canRenderAds(article);
 
 	return (
 		<>

--- a/dotcom-rendering/src/web/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FrontLayout.tsx
@@ -25,6 +25,7 @@ import { SubNav } from '../components/SubNav.importable';
 import { TrendingTopics } from '../components/TrendingTopics';
 import { DecideContainer } from '../lib/DecideContainer';
 import { decidePalette } from '../lib/decidePalette';
+import { canRenderAds } from '../lib/canRenderAds';
 import { Stuck } from './lib/stickiness';
 
 interface Props {
@@ -172,7 +173,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 	/**
 	 * This property currently only applies to the header and merchandising slots
 	 */
-	const renderAds = !front.isAdFreeUser;
+	const renderAds = canRenderAds(front);
 
 	const mobileAdPositions = renderAds
 		? getMobileAdPositions(

--- a/dotcom-rendering/src/web/layouts/FullPageInteractiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FullPageInteractiveLayout.tsx
@@ -34,6 +34,7 @@ import { getZIndex } from '../lib/getZIndex';
 import { decideLanguage, decideLanguageDirection } from '../lib/lang';
 import { getCurrentPillar } from '../lib/layoutHelpers';
 import { renderElement } from '../lib/renderElement';
+import { canRenderAds } from '../lib/canRenderAds';
 import { interactiveGlobalStyles } from './lib/interactiveLegacyStyling';
 import { BannerWrapper, Stuck } from './lib/stickiness';
 
@@ -139,7 +140,7 @@ const NavHeader = ({ article, NAV, format }: Props) => {
 	/**
 	 * This property currently only applies to the header and merchandising slots
 	 */
-	const renderAds = !article.isAdFreeUser && !article.shouldHideAds;
+	const renderAds = canRenderAds(article);
 
 	const isInEuropeTest =
 		article.config.abTests.europeNetworkFrontVariant === 'variant';

--- a/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
@@ -55,6 +55,7 @@ import { decideTrail } from '../lib/decideTrail';
 import { getZIndex } from '../lib/getZIndex';
 import { LABS_HEADER_HEIGHT } from '../lib/labs-constants';
 import { getCurrentPillar } from '../lib/layoutHelpers';
+import { canRenderAds } from '../lib/canRenderAds';
 import { BannerWrapper, Stuck } from './lib/stickiness';
 
 const ImmersiveGrid = ({ children }: { children: React.ReactNode }) => (
@@ -328,7 +329,7 @@ export const ImmersiveLayout = ({ article, NAV, format }: Props) => {
 		</div>
 	);
 
-	const renderAds = !article.isAdFreeUser && !article.shouldHideAds;
+	const renderAds = canRenderAds(article);
 
 	return (
 		<>

--- a/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
@@ -48,6 +48,7 @@ import { SubNav } from '../components/SubNav.importable';
 import { getContributionsServiceUrl } from '../lib/contributions';
 import { decidePalette } from '../lib/decidePalette';
 import { decideTrail } from '../lib/decideTrail';
+import { canRenderAds } from '../lib/canRenderAds';
 import { getCurrentPillar } from '../lib/layoutHelpers';
 import {
 	interactiveGlobalStyles,
@@ -235,7 +236,7 @@ export const InteractiveLayout = ({ article, NAV, format }: Props) => {
 	/**
 	 * This property currently only applies to the header and merchandising slots
 	 */
-	const renderAds = !article.isAdFreeUser && !article.shouldHideAds;
+	const renderAds = canRenderAds(article);
 
 	return (
 		<>

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -61,6 +61,7 @@ import { decidePalette } from '../lib/decidePalette';
 import { decideTrail } from '../lib/decideTrail';
 import { getZIndex } from '../lib/getZIndex';
 import { getCurrentPillar } from '../lib/layoutHelpers';
+import { canRenderAds } from '../lib/canRenderAds';
 import { BannerWrapper, SendToBack, Stuck } from './lib/stickiness';
 
 const HeadlineGrid = ({ children }: { children: React.ReactNode }) => (
@@ -296,7 +297,7 @@ export const LiveLayout = ({ article, NAV, format }: Props) => {
 	const hasKeyEvents = !!article.keyEvents.length;
 	const showKeyEventsToggle = !showTopicFilterBank && hasKeyEvents;
 
-	const renderAds = !article.isAdFreeUser && !article.shouldHideAds;
+	const renderAds = canRenderAds(article);
 
 	return (
 		<>

--- a/dotcom-rendering/src/web/layouts/NewsletterSignupLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/NewsletterSignupLayout.tsx
@@ -48,6 +48,7 @@ import { decidePalette } from '../lib/decidePalette';
 import { decideTrail } from '../lib/decideTrail';
 import { isValidUrl } from '../lib/isValidUrl';
 import { getCurrentPillar } from '../lib/layoutHelpers';
+import { canRenderAds } from '../lib/canRenderAds';
 import { BannerWrapper, Stuck } from './lib/stickiness';
 
 type Props = {
@@ -226,7 +227,7 @@ export const NewsletterSignupLayout = ({ article, NAV, format }: Props) => {
 	/**
 	 * This property currently only applies to the header and merchandising slots
 	 */
-	const renderAds = !article.isAdFreeUser && !article.shouldHideAds;
+	const renderAds = canRenderAds(article);
 
 	return (
 		<>

--- a/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
@@ -48,9 +48,10 @@ import { SubNav } from '../components/SubNav.importable';
 import { getContributionsServiceUrl } from '../lib/contributions';
 import { decidePalette } from '../lib/decidePalette';
 import { decideTrail } from '../lib/decideTrail';
-import { getCurrentPillar } from '../lib/layoutHelpers';
-import { BannerWrapper, SendToBack, Stuck } from './lib/stickiness';
 import { decideLanguage, decideLanguageDirection } from '../lib/lang';
+import { getCurrentPillar } from '../lib/layoutHelpers';
+import { canRenderAds } from '../lib/canRenderAds';
+import { BannerWrapper, SendToBack, Stuck } from './lib/stickiness';
 
 const ShowcaseGrid = ({ children }: { children: React.ReactNode }) => (
 	<div
@@ -242,7 +243,7 @@ export const ShowcaseLayout = ({ article, NAV, format }: Props) => {
 
 	const contributionsServiceUrl = getContributionsServiceUrl(article);
 
-	const renderAds = !article.isAdFreeUser && !article.shouldHideAds;
+	const renderAds = canRenderAds(article);
 
 	const isLabs = format.theme === ArticleSpecial.Labs;
 

--- a/dotcom-rendering/src/web/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/StandardLayout.tsx
@@ -56,6 +56,7 @@ import { getContributionsServiceUrl } from '../lib/contributions';
 import { decidePalette } from '../lib/decidePalette';
 import { decideTrail } from '../lib/decideTrail';
 import { getCurrentPillar } from '../lib/layoutHelpers';
+import { canRenderAds } from '../lib/canRenderAds';
 import { BannerWrapper, Stuck } from './lib/stickiness';
 
 const StandardGrid = ({
@@ -340,7 +341,7 @@ export const StandardLayout = ({ article, NAV, format }: Props) => {
 
 	const contributionsServiceUrl = getContributionsServiceUrl(article);
 
-	const renderAds = !article.isAdFreeUser && !article.shouldHideAds;
+	const renderAds = canRenderAds(article);
 
 	const isLabs = format.theme === ArticleSpecial.Labs;
 

--- a/dotcom-rendering/src/web/lib/canRenderAds.test.ts
+++ b/dotcom-rendering/src/web/lib/canRenderAds.test.ts
@@ -1,0 +1,29 @@
+import { Standard as standardPage } from '../../../fixtures/generated/articles/Standard';
+import { canRenderAds } from './canRenderAds';
+
+describe('canRenderAds', () => {
+	it('shows ads by default', () => {
+		expect(canRenderAds(standardPage)).toBe(true);
+	});
+
+	it('does not show ads if user is ad-free', () => {
+		const adFreePage = Object.assign({}, standardPage);
+		adFreePage.isAdFreeUser = true;
+
+		expect(canRenderAds(adFreePage)).toBe(false);
+	});
+
+	it('does not show ads if page should not display them', () => {
+		const adFreePage = Object.assign({}, standardPage);
+		adFreePage.shouldHideAds = true;
+
+		expect(canRenderAds(adFreePage)).toBe(false);
+	});
+
+	it('does not show ads if user is in the PDC test variant', () => {
+		const adFreePage = Object.assign({}, standardPage);
+		adFreePage.config.abTests.poorDeviceConnectivityVariant = 'variant';
+
+		expect(canRenderAds(adFreePage)).toBe(false);
+	});
+});

--- a/dotcom-rendering/src/web/lib/canRenderAds.ts
+++ b/dotcom-rendering/src/web/lib/canRenderAds.ts
@@ -1,0 +1,25 @@
+import type { DCRFrontType } from '../../types/front';
+import type { FEArticleType } from '../../types/frontend';
+
+/**
+ * Checks the page for a number of conditions that should
+ * prevent ads from being displayed.
+ */
+export const canRenderAds = (
+	pageData: FEArticleType | DCRFrontType,
+): boolean => {
+	if (pageData.isAdFreeUser) {
+		return false;
+	}
+
+	// DCRFrontType doesn't have a shouldHideAds property
+	if ('shouldHideAds' in pageData && pageData.shouldHideAds) {
+		return false;
+	}
+
+	if (pageData.config.abTests.poorDeviceConnectivityVariant === 'variant') {
+		return false;
+	}
+
+	return true;
+};

--- a/dotcom-rendering/src/web/server/articleToHtml.tsx
+++ b/dotcom-rendering/src/web/server/articleToHtml.tsx
@@ -21,6 +21,7 @@ import { decideFormat } from '../lib/decideFormat';
 import { decideTheme } from '../lib/decideTheme';
 import { renderToStringWithEmotion } from '../lib/emotion';
 import { getHttp3Url } from '../lib/getHttp3Url';
+import { canRenderAds } from '../lib/canRenderAds';
 import { pageTemplate } from './pageTemplate';
 import { recipeSchema } from './temporaryRecipeStructuredData';
 
@@ -99,10 +100,7 @@ export const articleToHtml = ({ article }: Props): string => {
 	 * Please talk to the dotcom platform team before adding more.
 	 * Scripts will be executed in the order they appear in this array
 	 */
-	const loadCommercial =
-		!article.isAdFreeUser &&
-		!article.shouldHideAds &&
-		article.config.abTests.poorDeviceConnectivityVariant !== 'variant';
+	const loadCommercial = canRenderAds(article);
 	const scriptTags = generateScriptTags(
 		[
 			polyfillIO,

--- a/dotcom-rendering/src/web/server/frontToHtml.tsx
+++ b/dotcom-rendering/src/web/server/frontToHtml.tsx
@@ -11,6 +11,7 @@ import type { DCRFrontType } from '../../types/front';
 import { FrontPage } from '../components/FrontPage';
 import { renderToStringWithEmotion } from '../lib/emotion';
 import { getHttp3Url } from '../lib/getHttp3Url';
+import { canRenderAds } from '../lib/canRenderAds';
 import { pageTemplate } from './pageTemplate';
 
 interface Props {
@@ -55,9 +56,7 @@ export const frontToHtml = ({ front }: Props): string => {
 	 * Please talk to the dotcom platform team before adding more.
 	 * Scripts will be executed in the order they appear in this array
 	 */
-	const loadCommercial =
-		!front.isAdFreeUser &&
-		front.config.abTests.poorDeviceConnectivityVariant !== 'variant';
+	const loadCommercial = canRenderAds(front);
 	const scriptTags = generateScriptTags(
 		[
 			polyfillIO,


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

- extracts the logic for checking whether ads should show to a new `canRenderAds` method
- adds a check for being in `poorDeviceConnectivityVariant` experiment variant
- uses it in the templates to decide whether to render ad slots and load the commercial JS

## Why?

in #7340 i forgot to hide slots if they weren't needed. this adds a check for that, and puts all the checks in one place, so there's only one place to add the logic.

