### PR TITLE
Use PascalCase for SecureDrop

### DIFF
--- a/dotcom-rendering/src/amp/components/Footer.tsx
+++ b/dotcom-rendering/src/amp/components/Footer.tsx
@@ -31,7 +31,7 @@ export const footerLinks: Link[][] = [
 			url: 'https://www.theguardian.com/info/complaints-and-corrections',
 		},
 		{
-			title: 'Securedrop',
+			title: 'SecureDrop',
 			url: 'https://www.theguardian.com/securedrop',
 		},
 		{


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Fixes the typo in SecureDrop ([taken from official page](https://www.theguardian.com/securedrop))

