### PR TITLE
feat: add action to build container image

### DIFF
--- a/.github/workflows/dcr-container.yml
+++ b/.github/workflows/dcr-container.yml
@@ -1,0 +1,52 @@
+name: DCR Build Container Image
+
+on:
+  push:
+    paths-ignore:
+      - "apps-rendering/**"
+
+jobs:
+  image:
+    runs-on: ubuntu-latest
+
+    permissions:
+      packages: write
+
+    outputs:
+      container-image: ${{ steps.push.outputs.registry-path }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Inject slug/short variables
+        uses: rlespinasse/github-slug-action@3.5.1
+
+      - name: Install Node
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+
+      - name: Generate production build
+        run: make build
+        working-directory: dotcom-rendering
+
+      - name: Build Container Image
+        id: build_image
+        uses: redhat-actions/buildah-build@v2.11
+        with:
+          image: dotcom-rendering
+          tags: ${{ github.sha }} ${{ env.GITHUB_REF_SLUG }}
+          context: ./
+          containerfiles: ./dotcom-rendering/Containerfile
+
+      - name: Push Image To GHCR
+        uses: redhat-actions/push-to-registry@v2.7
+        id: push
+        with:
+          image: ${{ steps.build_image.outputs.image }}
+          tags: ${{ steps.build_image.outputs.tags }}
+          registry: ghcr.io/guardian
+          username: ${{ github.actor }}
+          password: ${{ github.token }}

--- a/dotcom-rendering/Containerfile
+++ b/dotcom-rendering/Containerfile
@@ -1,0 +1,19 @@
+# This container is used in our CICD pipelines for running E2E and regression tests.
+FROM node:16.19.0-alpine AS dependencies
+
+COPY ./node_modules /opt/app/dotcom-rendering/node_modules
+COPY ./dotcom-rendering/node_modules /opt/app/dotcom-rendering/dotcom-rendering/node_modules
+
+# Seperate dependencies into their own layer to allow for better caching
+FROM dependencies
+
+WORKDIR /opt/app/dotcom-rendering/dotcom-rendering
+
+COPY ./dotcom-rendering/dist /opt/app/dotcom-rendering/dotcom-rendering/dist
+
+EXPOSE 9000
+
+ENV DISABLE_LOGGING_AND_METRICS=true
+ENV NODE_ENV=production
+
+ENTRYPOINT ["node", "dist/frontend.server.js"]


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Extracts the action to build a DCR container into its own PR. Details of why we're doing this in #6951 