### PR TITLE
Pass edition to most viewed footer data

### DIFF
--- a/dotcom-rendering/src/web/components/MostViewedFooter.test.tsx
+++ b/dotcom-rendering/src/web/components/MostViewedFooter.test.tsx
@@ -30,6 +30,7 @@ describe('MostViewedFooterData', () => {
 					display: ArticleDisplay.Standard,
 				}}
 				ajaxUrl="https://api.nextgen.guardianapps.co.uk"
+				edition="UK"
 			/>,
 		);
 
@@ -66,6 +67,7 @@ describe('MostViewedFooterData', () => {
 					theme: ArticlePillar.News,
 				}}
 				ajaxUrl="https://api.nextgen.guardianapps.co.uk"
+				edition="UK"
 			/>,
 		);
 
@@ -122,6 +124,7 @@ describe('MostViewedFooterData', () => {
 					theme: ArticlePillar.News,
 				}}
 				ajaxUrl="https://api.nextgen.guardianapps.co.uk"
+				edition="UK"
 			/>,
 		);
 
@@ -163,6 +166,7 @@ describe('MostViewedFooterData', () => {
 					theme: ArticlePillar.News,
 				}}
 				ajaxUrl="https://api.nextgen.guardianapps.co.uk"
+				edition="UK"
 			/>,
 		);
 
@@ -181,6 +185,7 @@ describe('MostViewedFooterData', () => {
 					theme: ArticlePillar.News,
 				}}
 				ajaxUrl="https://api.nextgen.guardianapps.co.uk"
+				edition="UK"
 			/>,
 		);
 

--- a/dotcom-rendering/src/web/components/MostViewedFooterData.importable.tsx
+++ b/dotcom-rendering/src/web/components/MostViewedFooterData.importable.tsx
@@ -7,6 +7,7 @@ import type {
 import { abTestTest } from '../experiments/tests/ab-test-test';
 import { decidePalette } from '../lib/decidePalette';
 import { decideTrail } from '../lib/decideTrail';
+import type { EditionId } from '../lib/edition';
 import { useAB } from '../lib/useAB';
 import { useApi } from '../lib/useApi';
 import { MostViewedFooter } from './MostViewedFooter.importable';
@@ -15,15 +16,22 @@ interface Props {
 	sectionName?: string;
 	format: ArticleFormat;
 	ajaxUrl: string;
+	edition: EditionId;
 }
 
-function buildSectionUrl(ajaxUrl: string, sectionName?: string) {
+function buildSectionUrl(
+	ajaxUrl: string,
+	edition: EditionId,
+	sectionName?: string,
+) {
 	const sectionsWithoutPopular = ['info', 'global'];
 	const hasSection =
 		sectionName !== undefined &&
 		!sectionsWithoutPopular.includes(sectionName);
-	const endpoint = `/most-read${hasSection ? `/${sectionName}` : ''}.json`;
-	return joinUrl(ajaxUrl, `${endpoint}?dcr=true`);
+	const endpoint = `/most-read${
+		hasSection ? `/${sectionName}` : ''
+	}.json?_edition=${edition}`;
+	return joinUrl(ajaxUrl, `${endpoint}&dcr=true`);
 }
 
 function transformTabs(tabs: FETrailTabType[]): TrailTabType[] {
@@ -43,6 +51,7 @@ export const MostViewedFooterData = ({
 	sectionName,
 	format,
 	ajaxUrl,
+	edition,
 }: Props) => {
 	const palette = decidePalette(format);
 	// Example usage of AB Tests
@@ -58,7 +67,7 @@ export const MostViewedFooterData = ({
 	const runnableTest = ABTestAPI?.runnableTest(abTestTest);
 	const variantFromRunnable = runnableTest?.variantToRun.id ?? 'not-runnable';
 
-	const url = buildSectionUrl(ajaxUrl, sectionName);
+	const url = buildSectionUrl(ajaxUrl, edition, sectionName);
 	const { data, error } = useApi<
 		MostViewedFooterPayloadType | FETrailTabType[]
 	>(url);

--- a/dotcom-rendering/src/web/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/CommentLayout.tsx
@@ -44,11 +44,11 @@ import { Standfirst } from '../components/Standfirst';
 import { StickyBottomBanner } from '../components/StickyBottomBanner.importable';
 import { SubMeta } from '../components/SubMeta';
 import { SubNav } from '../components/SubNav.importable';
+import { canRenderAds } from '../lib/canRenderAds';
 import { getContributionsServiceUrl } from '../lib/contributions';
 import { decidePalette } from '../lib/decidePalette';
 import { decideTrail } from '../lib/decideTrail';
 import { getCurrentPillar } from '../lib/layoutHelpers';
-import { canRenderAds } from '../lib/canRenderAds';
 import { BannerWrapper, SendToBack, Stuck } from './lib/stickiness';
 
 const StandardGrid = ({
@@ -808,6 +808,7 @@ export const CommentLayout = ({ article, NAV, format }: Props) => {
 									sectionName={article.sectionName}
 									format={format}
 									ajaxUrl={article.config.ajaxUrl}
+									edition={article.editionId}
 								/>
 							</Island>
 						</MostViewedFooterLayout>

--- a/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
@@ -49,13 +49,13 @@ import { Standfirst } from '../components/Standfirst';
 import { StickyBottomBanner } from '../components/StickyBottomBanner.importable';
 import { SubMeta } from '../components/SubMeta';
 import { SubNav } from '../components/SubNav.importable';
+import { canRenderAds } from '../lib/canRenderAds';
 import { getContributionsServiceUrl } from '../lib/contributions';
 import { decidePalette } from '../lib/decidePalette';
 import { decideTrail } from '../lib/decideTrail';
 import { getZIndex } from '../lib/getZIndex';
 import { LABS_HEADER_HEIGHT } from '../lib/labs-constants';
 import { getCurrentPillar } from '../lib/layoutHelpers';
-import { canRenderAds } from '../lib/canRenderAds';
 import { BannerWrapper, Stuck } from './lib/stickiness';
 
 const ImmersiveGrid = ({ children }: { children: React.ReactNode }) => (
@@ -841,6 +841,7 @@ export const ImmersiveLayout = ({ article, NAV, format }: Props) => {
 									sectionName={article.sectionName}
 									format={format}
 									ajaxUrl={article.config.ajaxUrl}
+									edition={article.editionId}
 								/>
 							</Island>
 						</MostViewedFooterLayout>

--- a/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
@@ -45,10 +45,10 @@ import { StarRating } from '../components/StarRating/StarRating';
 import { StickyBottomBanner } from '../components/StickyBottomBanner.importable';
 import { SubMeta } from '../components/SubMeta';
 import { SubNav } from '../components/SubNav.importable';
+import { canRenderAds } from '../lib/canRenderAds';
 import { getContributionsServiceUrl } from '../lib/contributions';
 import { decidePalette } from '../lib/decidePalette';
 import { decideTrail } from '../lib/decideTrail';
-import { canRenderAds } from '../lib/canRenderAds';
 import { getCurrentPillar } from '../lib/layoutHelpers';
 import {
 	interactiveGlobalStyles,
@@ -707,6 +707,7 @@ export const InteractiveLayout = ({ article, NAV, format }: Props) => {
 									sectionName={article.sectionName}
 									format={format}
 									ajaxUrl={article.config.ajaxUrl}
+									edition={article.editionId}
 								/>
 							</Island>
 						</MostViewedFooterLayout>

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -56,12 +56,12 @@ import {
 	hasRelevantTopics,
 	TopicFilterBank,
 } from '../components/TopicFilterBank';
+import { canRenderAds } from '../lib/canRenderAds';
 import { getContributionsServiceUrl } from '../lib/contributions';
 import { decidePalette } from '../lib/decidePalette';
 import { decideTrail } from '../lib/decideTrail';
 import { getZIndex } from '../lib/getZIndex';
 import { getCurrentPillar } from '../lib/layoutHelpers';
-import { canRenderAds } from '../lib/canRenderAds';
 import { BannerWrapper, SendToBack, Stuck } from './lib/stickiness';
 
 const HeadlineGrid = ({ children }: { children: React.ReactNode }) => (
@@ -1238,6 +1238,7 @@ export const LiveLayout = ({ article, NAV, format }: Props) => {
 										sectionName={article.sectionName}
 										format={format}
 										ajaxUrl={article.config.ajaxUrl}
+										edition={article.editionId}
 									/>
 								</Island>
 							</MostViewedFooterLayout>

--- a/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
@@ -45,12 +45,12 @@ import { Standfirst } from '../components/Standfirst';
 import { StickyBottomBanner } from '../components/StickyBottomBanner.importable';
 import { SubMeta } from '../components/SubMeta';
 import { SubNav } from '../components/SubNav.importable';
+import { canRenderAds } from '../lib/canRenderAds';
 import { getContributionsServiceUrl } from '../lib/contributions';
 import { decidePalette } from '../lib/decidePalette';
 import { decideTrail } from '../lib/decideTrail';
 import { decideLanguage, decideLanguageDirection } from '../lib/lang';
 import { getCurrentPillar } from '../lib/layoutHelpers';
-import { canRenderAds } from '../lib/canRenderAds';
 import { BannerWrapper, SendToBack, Stuck } from './lib/stickiness';
 
 const ShowcaseGrid = ({ children }: { children: React.ReactNode }) => (
@@ -756,6 +756,7 @@ export const ShowcaseLayout = ({ article, NAV, format }: Props) => {
 									sectionName={article.sectionName}
 									format={format}
 									ajaxUrl={article.config.ajaxUrl}
+									edition={article.editionId}
 								/>
 							</Island>
 						</MostViewedFooterLayout>

--- a/dotcom-rendering/src/web/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/StandardLayout.tsx
@@ -52,11 +52,11 @@ import { StarRating } from '../components/StarRating/StarRating';
 import { StickyBottomBanner } from '../components/StickyBottomBanner.importable';
 import { SubMeta } from '../components/SubMeta';
 import { SubNav } from '../components/SubNav.importable';
+import { canRenderAds } from '../lib/canRenderAds';
 import { getContributionsServiceUrl } from '../lib/contributions';
 import { decidePalette } from '../lib/decidePalette';
 import { decideTrail } from '../lib/decideTrail';
 import { getCurrentPillar } from '../lib/layoutHelpers';
-import { canRenderAds } from '../lib/canRenderAds';
 import { BannerWrapper, Stuck } from './lib/stickiness';
 
 const StandardGrid = ({
@@ -878,6 +878,7 @@ export const StandardLayout = ({ article, NAV, format }: Props) => {
 									sectionName={article.sectionName}
 									format={format}
 									ajaxUrl={article.config.ajaxUrl}
+									edition={article.editionId}
 								/>
 							</Island>
 						</MostViewedFooterLayout>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

This brings editionalised data to the accross the guardian tab most viewed  footer data.

The edition is passed via url params which seems to be how this is done in weather api calls.

This resolves https://github.com/guardian/dotcom-rendering/issues/7272

## Why?

This is the desired data

## Screenshots

| UK edition     | (This PR) UK edition      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/110032454/221913129-c231ac34-4074-428e-b1ed-29aca67fae3b.png
[after]: https://user-images.githubusercontent.com/110032454/221913203-b4f8d72e-4025-4dd8-b73f-aaf472290342.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->


<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
