### PR TITLE
Special Report Alt Atom

### DIFF
--- a/apps-rendering/src/atoms.test.ts
+++ b/apps-rendering/src/atoms.test.ts
@@ -157,6 +157,21 @@ describe('parseAtom', () => {
 				}),
 			);
 		});
+
+		it('returns SpecialReportAltAtom element if atom has correct id', () => {
+			const element = {
+				type: ElementType.CONTENTATOM,
+				assets: [],
+				contentAtomTypeData: {
+					atomId: 'interactives/2022/10/tr/default-about-the-series',
+					atomType: 'interactive',
+				},
+			};
+
+			expect(parseAtom(element, atoms, docParser)).toEqual(
+				Result.ok({ kind: ElementKind.SpecialReportAltAtom }),
+			);
+		});
 	});
 
 	describe('guide', () => {

--- a/apps-rendering/src/atoms.ts
+++ b/apps-rendering/src/atoms.ts
@@ -28,6 +28,10 @@ function parseAtom(
 
 	const id = element.contentAtomTypeData.atomId;
 
+	if (id === 'SpecialReportAltAtom') {
+		return Result.ok({ kind: ElementKind.SpecialReportAltAtom });
+	}
+
 	switch (element.contentAtomTypeData.atomType) {
 		case 'interactive': {
 			const atom = atoms.interactives?.find(

--- a/apps-rendering/src/atoms.ts
+++ b/apps-rendering/src/atoms.ts
@@ -28,7 +28,7 @@ function parseAtom(
 
 	const id = element.contentAtomTypeData.atomId;
 
-	if (id === 'SpecialReportAltAtom') {
+	if (id === 'interactives/2022/10/tr/default-about-the-series') {
 		return Result.ok({ kind: ElementKind.SpecialReportAltAtom });
 	}
 

--- a/apps-rendering/src/bodyElement.ts
+++ b/apps-rendering/src/bodyElement.ts
@@ -139,6 +139,10 @@ type Callout = {
 	contacts?: Contact[];
 };
 
+type SpecialReportAltAtom = {
+	kind: ElementKind.SpecialReportAltAtom;
+}
+
 type BodyElement =
 	| Text
 	| HeadingTwo
@@ -184,7 +188,8 @@ type BodyElement =
 	| AudioAtom
 	| KnowledgeQuizAtom
 	| PersonalityQuizAtom
-	| NewsletterSignUp;
+	| NewsletterSignUp
+	| SpecialReportAltAtom;
 
 type Elements = BlockElement[] | undefined;
 

--- a/apps-rendering/src/bodyElementKind.ts
+++ b/apps-rendering/src/bodyElementKind.ts
@@ -24,6 +24,7 @@ const enum ElementKind {
 	NewsletterSignUp,
 	HeadingTwo,
 	HeadingThree,
+	SpecialReportAltAtom,
 }
 
 // ----- Exports ----- //

--- a/apps-rendering/src/components/SpecialReportAltAtom/SpecialReportAltAtom.stories.tsx
+++ b/apps-rendering/src/components/SpecialReportAltAtom/SpecialReportAltAtom.stories.tsx
@@ -1,0 +1,24 @@
+// ----- Imports ----- //
+
+import { ArticleDesign, ArticleDisplay, ArticleSpecial } from '@guardian/libs';
+import type { FC } from 'react';
+import SpecialReportAltAtom from '.';
+
+// ----- Stories ----- //
+
+const Default: FC = () => (
+    <SpecialReportAltAtom format={{
+        design: ArticleDesign.Standard,
+        display: ArticleDisplay.Standard,
+        theme: ArticleSpecial.SpecialReportAlt,
+    }} />
+);
+
+// ----- Exports ----- //
+
+export default {
+	component: SpecialReportAltAtom,
+	title: 'AR/SpecialReportAltAtom',
+};
+
+export { Default };

--- a/apps-rendering/src/components/SpecialReportAltAtom/index.tsx
+++ b/apps-rendering/src/components/SpecialReportAltAtom/index.tsx
@@ -1,6 +1,7 @@
 // ----- Imports ----- //
 
-import { css, SerializedStyles } from '@emotion/react';
+import type { SerializedStyles } from '@emotion/react';
+import { css } from '@emotion/react';
 import type { FC } from 'react';
 import { body } from '@guardian/source-foundations';
 import { LinkButton } from '@guardian/source-react-components';

--- a/apps-rendering/src/components/SpecialReportAltAtom/index.tsx
+++ b/apps-rendering/src/components/SpecialReportAltAtom/index.tsx
@@ -1,0 +1,88 @@
+// ----- Imports ----- //
+
+import { css, SerializedStyles } from '@emotion/react';
+import type { FC } from 'react';
+import { body } from '@guardian/source-foundations';
+import { LinkButton } from '@guardian/source-react-components';
+import { background, border, hover, text } from 'palette';
+import type { ArticleFormat } from '@guardian/libs';
+import { darkModeCss } from 'styles';
+
+// ----- Component ----- //
+
+const styles = (format: ArticleFormat): SerializedStyles => css`
+    padding: 2rem 0;
+    color: ${text.paragraph(format)};
+
+    ${darkModeCss`
+        color: ${text.paragraphDark(format)};
+    `}
+`;
+
+const hrStyles = (format: ArticleFormat): SerializedStyles => css`
+    width: 3rem;
+    margin: 0 0 0.5rem 0;
+    border: 1px solid ${border.specialReportAltAtom(format)};
+
+    ${darkModeCss`
+        border-color: ${border.specialReportAltAtomDark(format)};
+    `}
+`;
+
+const headingStyles = css`
+    ${body.medium({ fontWeight: 'bold' })}
+    text-transform: uppercase;
+`;
+
+const textStyles = css`
+    ${body.medium()}
+    padding-bottom: 0.5rem;
+`;
+
+const buttonStyles = (format: ArticleFormat): SerializedStyles => css`
+    color: ${text.specialReportAltButton(format)};
+    background-color: ${background.specialReportAltButton(format)};
+
+    &:hover {
+        background-color: ${hover.specialReportAltButton(format)};
+    }
+
+    ${darkModeCss`
+        color: ${text.specialReportAltButtonDark(format)};
+        background-color: ${background.specialReportAltButtonDark(format)};
+        border: 1px solid ${border.specialReportAltButtonDark(format)};
+
+        &:hover {
+            background-color: ${hover.specialReportAltButtonDark(format)};
+        }
+    `}
+`;
+
+type Props = {
+    format: ArticleFormat;
+}
+
+const SpecialReportAltAtom: FC<Props> = ({ format }) => (
+    <aside css={styles(format)}>
+        <hr css={hrStyles(format)} />
+        <h2 css={headingStyles}>What is the Special Report Alt?</h2>
+        <p css={textStyles}>
+            Lorem ipsum dolor sit, amet consectetur adipisicing elit. Quaerat
+            sit eveniet autem nemo magnam esse nostrum repudiandae dolorem, ab
+            delectus explicabo voluptatibus dolores reiciendis voluptas aliquam
+            illo maxime? Debitis, molestias?
+        </p>
+        <LinkButton
+            href="https://www.theguardian.com"
+            size="small"
+            priority="secondary"
+            cssOverrides={buttonStyles(format)}
+        >
+            Find out more
+        </LinkButton>
+    </aside>
+);
+
+// ----- Exports ----- //
+
+export default SpecialReportAltAtom;

--- a/apps-rendering/src/components/SpecialReportAltAtom/index.tsx
+++ b/apps-rendering/src/components/SpecialReportAltAtom/index.tsx
@@ -12,7 +12,7 @@ import { darkModeCss } from 'styles';
 // ----- Component ----- //
 
 const styles = (format: ArticleFormat): SerializedStyles => css`
-    padding: 2rem 0;
+    padding: 1rem 0;
     color: ${text.paragraph(format)};
 
     ${darkModeCss`
@@ -21,9 +21,9 @@ const styles = (format: ArticleFormat): SerializedStyles => css`
 `;
 
 const hrStyles = (format: ArticleFormat): SerializedStyles => css`
-    width: 3rem;
     margin: 0 0 0.5rem 0;
-    border: 1px solid ${border.specialReportAltAtom(format)};
+    border: none;
+    border-top: 1px solid ${border.specialReportAltAtom(format)};
 
     ${darkModeCss`
         border-color: ${border.specialReportAltAtomDark(format)};
@@ -43,6 +43,7 @@ const textStyles = css`
 const buttonStyles = (format: ArticleFormat): SerializedStyles => css`
     color: ${text.specialReportAltButton(format)};
     background-color: ${background.specialReportAltButton(format)};
+    margin-bottom: 1rem;
 
     &:hover {
         background-color: ${hover.specialReportAltButton(format)};
@@ -81,6 +82,7 @@ const SpecialReportAltAtom: FC<Props> = ({ format }) => (
         >
             Find out more
         </LinkButton>
+        <hr css={hrStyles(format)} />
     </aside>
 );
 

--- a/apps-rendering/src/fixtures/item.ts
+++ b/apps-rendering/src/fixtures/item.ts
@@ -232,6 +232,9 @@ const body: Body = [
 		imageSubtype: Optional.some(ImageSubtype.Jpeg),
 	},
 	{
+		kind: ElementKind.SpecialReportAltAtom,
+	},
+	{
 		kind: ElementKind.Text,
 		doc,
 	},

--- a/apps-rendering/src/palette/background.ts
+++ b/apps-rendering/src/palette/background.ts
@@ -1111,6 +1111,34 @@ const editionsCameraIcon = (format: ArticleFormat): Colour => {
 	}
 };
 
+const specialReportAltButton = (_format: ArticleFormat): Colour =>
+	palette.specialReportAlt[200];
+
+const specialReportAltButtonDark = ({ design, theme }: ArticleFormat): Colour => {
+	switch (design) {
+		case ArticleDesign.Standard:
+		case ArticleDesign.Review:
+		case ArticleDesign.Explainer:
+		case ArticleDesign.Feature:
+		case ArticleDesign.Interview:
+		case ArticleDesign.Interactive:
+		case ArticleDesign.PhotoEssay:
+		case ArticleDesign.FullPageInteractive:
+		case ArticleDesign.NewsletterSignup:
+		case ArticleDesign.Comment:
+		case ArticleDesign.Letter:
+		case ArticleDesign.Editorial:
+			switch (theme) {
+				case ArticleSpecial.SpecialReportAlt:
+					return palette.specialReportAlt[100];
+				default:
+					return neutral[10];
+			}
+		default:
+			return neutral[10];
+	}
+}
+
 // ----- API ----- //
 
 const background = {
@@ -1160,6 +1188,8 @@ const background = {
 	articleContent,
 	newsletterSignUpFormDark,
 	editionsCameraIcon,
+	specialReportAltButton,
+	specialReportAltButtonDark,
 };
 
 // ----- Exports ----- //

--- a/apps-rendering/src/palette/border.ts
+++ b/apps-rendering/src/palette/border.ts
@@ -275,7 +275,7 @@ const tableOfContentsHoverDark = (_format: ArticleFormat): string => {
 };
 
 const specialReportAltAtom = (_format: ArticleFormat): string => {
-	return neutral[10];
+	return neutral[46];
 };
 
 const specialReportAltAtomDark = (_format: ArticleFormat): string => {

--- a/apps-rendering/src/palette/border.ts
+++ b/apps-rendering/src/palette/border.ts
@@ -9,6 +9,7 @@ import {
 	neutral,
 	news,
 	opinion,
+	palette,
 	specialReport,
 	sport,
 } from '@guardian/source-foundations';
@@ -273,6 +274,22 @@ const tableOfContentsHoverDark = (_format: ArticleFormat): string => {
 	return neutral[86];
 };
 
+const specialReportAltAtom = (_format: ArticleFormat): string => {
+	return neutral[10];
+};
+
+const specialReportAltAtomDark = (_format: ArticleFormat): string => {
+	return neutral[86];
+};
+
+const specialReportAltButton = (_format: ArticleFormat): string => {
+	return palette.specialReportAlt[200];
+};
+
+const specialReportAltButtonDark = (_format: ArticleFormat): string => {
+	return neutral[86];
+};
+
 // ----- API ----- //
 
 const border = {
@@ -308,6 +325,10 @@ const border = {
 	tableOfContentsHover,
 	tableOfContentsDark,
 	tableOfContentsHoverDark,
+	specialReportAltAtom,
+	specialReportAltAtomDark,
+	specialReportAltButton,
+	specialReportAltButtonDark,
 };
 
 // ----- Exports ----- //

--- a/apps-rendering/src/palette/hover.ts
+++ b/apps-rendering/src/palette/hover.ts
@@ -9,6 +9,7 @@ import {
 	neutral,
 	news,
 	opinion,
+	palette,
 	specialReport,
 	sport,
 } from '@guardian/source-foundations';
@@ -42,12 +43,20 @@ const newsletterSignUpFormButton = (_format: ArticleFormat): Colour =>
 const newsletterSignUpFormButtonDark = (_format: ArticleFormat): Colour =>
 	neutral[86];
 
+const specialReportAltButton = (_format: ArticleFormat): Colour =>
+	palette.specialReportAlt[300];
+
+const specialReportAltButtonDark = (_format: ArticleFormat): Colour =>
+	neutral[20];
+
 // ----- API ----- //
 
 const hover = {
 	pagination,
 	newsletterSignUpFormButton,
 	newsletterSignUpFormButtonDark,
+	specialReportAltButton,
+	specialReportAltButtonDark,
 };
 
 // ----- Exports ----- //

--- a/apps-rendering/src/palette/hover.ts
+++ b/apps-rendering/src/palette/hover.ts
@@ -44,7 +44,7 @@ const newsletterSignUpFormButtonDark = (_format: ArticleFormat): Colour =>
 	neutral[86];
 
 const specialReportAltButton = (_format: ArticleFormat): Colour =>
-	palette.specialReportAlt[300];
+	palette.specialReportAlt[100];
 
 const specialReportAltButtonDark = (_format: ArticleFormat): Colour =>
 	neutral[20];

--- a/apps-rendering/src/palette/text.ts
+++ b/apps-rendering/src/palette/text.ts
@@ -1916,6 +1916,12 @@ const datelineDark = ({ design, theme }: ArticleFormat): string => {
 	}
 };
 
+const specialReportAltButton = (_format: ArticleFormat): Colour =>
+	neutral[100];
+
+const specialReportAltButtonDark = (_format: ArticleFormat): Colour =>
+	neutral[86];
+
 // ----- API ----- //
 
 const text = {
@@ -1990,6 +1996,8 @@ const text = {
 	tableOfContentsTitle,
 	tableOfContentsTitleDark,
 	headingTwoDark,
+	specialReportAltButton,
+	specialReportAltButtonDark,
 };
 
 // ----- Exports ----- //

--- a/apps-rendering/src/renderer.ts
+++ b/apps-rendering/src/renderer.ts
@@ -735,7 +735,7 @@ const renderElement =
 					element,
 					skipLinkIdSuffix: key.toString(),
 				});
-			
+
 			case ElementKind.SpecialReportAltAtom:
 				return h(SpecialReportAltAtom, { format });
 		}

--- a/apps-rendering/src/renderer.ts
+++ b/apps-rendering/src/renderer.ts
@@ -68,6 +68,7 @@ import OrderedList from 'components/OrderedList';
 import Paragraph from 'components/Paragraph';
 import Pullquote from 'components/Pullquote';
 import RichLink from 'components/RichLink';
+import SpecialReportAltAtom from 'components/SpecialReportAltAtom';
 import { isElement, pipe } from 'lib';
 import { Optional } from 'optional';
 import { border, text } from 'palette';
@@ -734,6 +735,9 @@ const renderElement =
 					element,
 					skipLinkIdSuffix: key.toString(),
 				});
+			
+			case ElementKind.SpecialReportAltAtom:
+				return h(SpecialReportAltAtom, { format });
 		}
 	};
 


### PR DESCRIPTION
## Why?

AR doesn't support atoms, so in cases where special report alt pieces have an atom we generate a custom element replicating its functionality.

**Note:** While this PR is in draft form the `id` and content of the atom are mocked. They will be replaced with the correct id and content when we know what they are.

## Changes

- Created a custom `SpecialReportAltAtom` element
- Added stories for the new element
- Added a fixture for the new element to the main article fixtures, so it appears in layout stories

## Screenshots

| Light | Dark |
| - | - |
| ![atom-light] | ![atom-dark] |

[atom-light]: https://user-images.githubusercontent.com/53781962/226374234-95bc529b-38ed-4c1d-a482-25506ea0905a.jpg
[atom-dark]: https://user-images.githubusercontent.com/53781962/226374246-306b688a-0cc3-414a-b587-53869ecbc338.jpg
