### PR TITLE
Record all core web vitals for PDC cohort

### DIFF
--- a/dotcom-rendering/src/web/components/Metrics.importable.tsx
+++ b/dotcom-rendering/src/web/components/Metrics.importable.tsx
@@ -36,6 +36,8 @@ const serverSideTestsToForceMetrics: ServerSideTestNames[] = [
 	'dcrFrontsVariant',
 	'serverSideLiveblogInlineAdsVariant',
 	'serverSideLiveblogInlineAdsControl',
+	'poorDeviceConnectivityVariant',
+	'poorDeviceConnectivityControl',
 ];
 
 export const Metrics = ({ commercialMetricsEnabled }: Props) => {


### PR DESCRIPTION
## What does this change?

Start recording all core web vitals for users in the poor device connectivity variant.

## Why?

Forgot to do so in #7340 

Sibling Frontend PR: https://github.com/guardian/frontend/pull/25997