### PR TITLE
Record metrics for all server-side experiments

### DIFF
--- a/dotcom-rendering/cypress/e2e/parallel-1/sign-in-gate.cy.js
+++ b/dotcom-rendering/cypress/e2e/parallel-1/sign-in-gate.cy.js
@@ -114,7 +114,7 @@ describe('Sign In Gate Tests', function () {
 			cy.get('[data-cy=sign-in-gate-main]').should('not.exist');
 		});
 
-		it('should not load the sign in gate if the user is signed in', function (done) {
+		it('should not load the sign in gate if the user is signed in', function () {
 			// use GU_U cookie to determine if user is signed in
 			cy.setCookie(
 				'GU_U',
@@ -123,14 +123,6 @@ describe('Sign In Gate Tests', function () {
 			);
 
 			visitArticleAndScrollToGateForLazyLoad();
-
-			// when using GU_U cookie, there is an issue with the commercial.dcr.js bundle
-			// causing a URI Malformed error in cypress
-			// we use this uncaught exception in this test to catch this and continue the rest of the test
-			cy.on('uncaught:exception', () => {
-				done();
-				return false;
-			});
 
 			cy.get('[data-cy=sign-in-gate-main]').should('not.exist');
 		});

--- a/dotcom-rendering/src/web/components/Metrics.importable.tsx
+++ b/dotcom-rendering/src/web/components/Metrics.importable.tsx
@@ -8,8 +8,6 @@ import {
 	initCoreWebVitals,
 } from '@guardian/core-web-vitals';
 import { getCookie } from '@guardian/libs';
-import { dcrJavascriptBundle } from '../../../scripts/webpack/bundles';
-import type { ServerSideTestNames } from '../../types/config';
 import { eagerPrebid } from '../experiments/tests/eager-prebid';
 import { integrateIma } from '../experiments/tests/integrate-ima';
 import { useAB } from '../lib/useAB';
@@ -31,17 +29,6 @@ const clientSideTestsToForceMetrics: ABTest[] = [
 	eagerPrebid,
 ];
 
-const serverSideTestsToForceMetrics: ServerSideTestNames[] = [
-	/* linter, please keep this array multi-line */
-	dcrJavascriptBundle('Variant'),
-	dcrJavascriptBundle('Control'),
-	'dcrFrontsVariant',
-	'serverSideLiveblogInlineAdsVariant',
-	'serverSideLiveblogInlineAdsControl',
-	'poorDeviceConnectivityVariant',
-	'poorDeviceConnectivityControl',
-];
-
 export const Metrics = ({ commercialMetricsEnabled }: Props) => {
 	const abTestApi = useAB()?.api;
 	const adBlockerInUse = useAdBlockInUse();
@@ -55,14 +42,12 @@ export const Metrics = ({ commercialMetricsEnabled }: Props) => {
 		window.location.hostname === (process.env.HOSTNAME ?? 'localhost') ||
 		window.location.hostname === 'preview.gutools.co.uk';
 
-	const userInServerSideTestToForceMetrics =
-		serverSideTestsToForceMetrics.some((test) =>
-			Object.keys(window.guardian.config.tests).includes(test),
-		);
+	const userInServerSideTest =
+		Object.keys(window.guardian.config.tests).length > 0;
 
 	const shouldBypassSampling = (api: ABTestAPI) =>
 		willRecordCoreWebVitals ||
-		userInServerSideTestToForceMetrics ||
+		userInServerSideTest ||
 		clientSideTestsToForceMetrics.some((test) => api.runnableTest(test));
 
 	useOnce(


### PR DESCRIPTION
## What does this change?

Record metrics for all page views that are in a server-side experiment, either in the `control` or `variant`.

See also https://github.com/guardian/frontend/pull/26004

## Why?

When running a server-side test, we always need to ensure that the experiment does not negatively affect our metrics and they should always be measured.

Teams frequently forget to set this value, which leads to test having to run longer to capture significant metrics.

## Questions

We would like to estimate the potential cost of this change. See [internal Google Sheet for estimate](https://docs.google.com/spreadsheets/d/1uO89f4bj80M0fTtvs9drDtrHXG9lGVTZBoWTS56TvlI/edit#gid=0). Maybe people from @guardian/fastly?
- [Answer #1 below](#issuecomment-1479908851)