### PR TITLE
Message Us - Fix contrast on submission success

### DIFF
--- a/dotcom-rendering/src/web/components/SendAMessage.importable.tsx
+++ b/dotcom-rendering/src/web/components/SendAMessage.importable.tsx
@@ -1,4 +1,5 @@
-import { css, SerializedStyles } from '@emotion/react';
+import type { SerializedStyles } from '@emotion/react';
+import { css } from '@emotion/react';
 import {
 	focusHalo,
 	from,
@@ -40,7 +41,9 @@ const textStyles = css`
 
 const successStyles = css`
 	${textSans.xsmall()};
-	color: ${neutral[100]};
+	${until.desktop} {
+		color: ${neutral[100]};
+	}
 `;
 
 const tickBoxStyles = css`
@@ -52,6 +55,7 @@ const errorTextStyles = css`
 	color: ${palette.error[400]};
 	${textSans.medium({ fontWeight: 'bold' })};
 	display: flex;
+	padding-bottom: ${space[2]}px;
 `;
 
 const formStyles = css`

--- a/dotcom-rendering/src/web/components/SendAMessage.stories.tsx
+++ b/dotcom-rendering/src/web/components/SendAMessage.stories.tsx
@@ -1,7 +1,8 @@
-import { SendAMessage } from './SendAMessage.importable';
-import { Section } from './Section';
+import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
+import fetchMock from 'fetch-mock';
 import { MessageForm } from '../../../fixtures/manual/message-us-form';
-import { ArticleDisplay, ArticleDesign, ArticlePillar } from '@guardian/libs';
+import { Section } from './Section';
+import { SendAMessage } from './SendAMessage.importable';
 
 export default {
 	component: SendAMessage,
@@ -17,7 +18,46 @@ const defaultFormat = {
 	theme: ArticlePillar.News,
 };
 
+const goodRequest = () => {
+	fetchMock
+		.restore()
+		.post(
+			'https://callouts.code.dev-guardianapis.com/formstack-campaign/submit',
+			{
+				status: 201,
+				body: null,
+			},
+		);
+};
+
+const badRequest = () => {
+	fetchMock
+		.restore()
+		.post(
+			'https://callouts.code.dev-guardianapis.com/formstack-campaign/submit',
+			{
+				status: 400,
+				body: null,
+			},
+		);
+};
+
 export const Default = () => {
+	goodRequest();
+	return (
+		<Section>
+			<SendAMessage
+				formFields={MessageForm.formFields}
+				formId={MessageForm.formId}
+				format={defaultFormat}
+				pageId=""
+			/>
+		</Section>
+	);
+};
+
+export const SubmissionFailure = () => {
+	badRequest();
 	return (
 		<Section>
 			<SendAMessage


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

- Updates the contrast for the submission success message
- Also adds a mocked request to the MessageUs stories so we can view the success/failure state in storybook


## Screenshots

| Before      | After      |
|-------------|------------|
| ![image](https://user-images.githubusercontent.com/26366706/227181277-5e92c852-4c09-4a2c-9c3e-b41f000bc06b.png)| (on desktop) <img width="282" alt="image" src="https://user-images.githubusercontent.com/26366706/227181245-c953ec78-4366-4bcc-8162-f3c666f4a379.png"> (and on mobile) <img width="696" alt="image" src="https://user-images.githubusercontent.com/26366706/227182491-3f44c927-b48f-4c49-8a6b-95d29513de0b.png">|


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->


<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
