### PR TITLE
Do not show Epic on Taylor Report articles on AMP

### DIFF
--- a/dotcom-rendering/src/amp/components/BodyArticle.tsx
+++ b/dotcom-rendering/src/amp/components/BodyArticle.tsx
@@ -188,9 +188,13 @@ export const Body = ({ data, config }: Props) => {
 		</>
 	);
 
-	const epic = data.shouldHideReaderRevenue ? null : (
-		<Epic webURL={data.webURL} />
-	);
+	const epic =
+		data.shouldHideReaderRevenue ||
+		data.tags.some(
+			(tag) => tag.id === 'us-news/series/cotton-capital',
+		) ? null : (
+			<Epic webURL={data.webURL} />
+		);
 
 	return (
 		<div css={[body(pillar, design), innerContainerStyles]}>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Explicitly suppress Epic from showing on Taylor Report AMP articles.

## Why?
There is currently no functionality to target AMP Epic by tag on the RRCP/SDC side, so for this use case we are suppressing it directly on DCR.

## Screenshots
Tested locally with this article: https://amp.theguardian.com/world/2013/jun/09/edward-snowden-nsa-whistleblower-surveillance, and suppressing Epic on tag `us-news/nsa`
| Before      | After      |
|-------------|------------|
| ![before](https://user-images.githubusercontent.com/99180049/227244640-989ab718-8426-4103-a8b9-d3f16fcc894c.png) | ![after](https://user-images.githubusercontent.com/99180049/227244807-7b1cacae-b798-4795-8d17-a7e02d710c7e.png) |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->


<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
