### PR TITLE
Use Ozone Prebid server across all AMP content

### DIFF
--- a/dotcom-rendering/src/amp/components/Blocks.tsx
+++ b/dotcom-rendering/src/amp/components/Blocks.tsx
@@ -6,7 +6,6 @@ import type { Switches } from '../../types/config';
 import type { EditionId } from '../../web/lib/edition';
 import { blockLink } from '../lib/block-link';
 import { findBlockAdSlots } from '../lib/find-adslots';
-import { isOnOzoneTestPage } from '../lib/real-time-config';
 import { Elements } from './Elements';
 import { InlineAd } from './InlineAd';
 
@@ -141,8 +140,7 @@ export const Blocks = ({
 	const adConfig = {
 		usePubmaticPrebid: adInfo.switches.ampPrebidPubmatic,
 		useCriteoPrebid: adInfo.switches.ampPrebidCriteo,
-		useOzonePrebid:
-			adInfo.switches.ampPrebidOzone && isOnOzoneTestPage(pageId),
+		useOzonePrebid: adInfo.switches.ampPrebidOzone,
 		usePermutive: adInfo.switches.permutive,
 		useAmazon: adInfo.switches.ampAmazon,
 	};

--- a/dotcom-rendering/src/amp/components/BodyArticle.tsx
+++ b/dotcom-rendering/src/amp/components/BodyArticle.tsx
@@ -19,7 +19,6 @@ import type { ConfigType } from '../../types/config';
 import { decideDesign } from '../../web/lib/decideDesign';
 import { decideTheme } from '../../web/lib/decideTheme';
 import { findAdSlots } from '../lib/find-adslots';
-import { isOnOzoneTestPage } from '../lib/real-time-config';
 import type { ArticleModel } from '../types/ArticleModel';
 import { Elements } from './Elements';
 import { TextBlockComponent } from './elements/TextBlockComponent';
@@ -145,8 +144,7 @@ export const Body = ({ data, config }: Props) => {
 	const adConfig = {
 		usePubmaticPrebid: adInfo.switches.ampPrebidPubmatic,
 		useCriteoPrebid: adInfo.switches.ampPrebidCriteo,
-		useOzonePrebid:
-			adInfo.switches.ampPrebidOzone && isOnOzoneTestPage(config.pageId),
+		useOzonePrebid: adInfo.switches.ampPrebidOzone,
 		usePermutive: adInfo.switches.permutive,
 		useAmazon: adInfo.switches.ampAmazon,
 	};

--- a/dotcom-rendering/src/amp/lib/real-time-config.ts
+++ b/dotcom-rendering/src/amp/lib/real-time-config.ts
@@ -147,10 +147,3 @@ export const realTimeConfig = (
 	};
 	return JSON.stringify(data);
 };
-
-/**
- *
- * For testing purposes, only enable Ozone on a single page with a known id
- */
-export const isOnOzoneTestPage = (pageId: string): boolean =>
-	pageId === 'science/grrlscientist/2012/may/27/9';


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Remove the `isOnOzoneTestPage` check, in effect enabling the Ozone Prebid server integration across all AMP content.

This was originally setup in #7279, but constrained to just a single page for testing purposes.

## Why?

We originally constrained the Ozone integration to a single test page so that we could find and fix any issues with the setup. Now this looks to be working, we can release it across all content.

## Screenshots

![Screenshot 2023-03-24 at 13 00 53](https://user-images.githubusercontent.com/8000415/227923622-79b0452f-d0b1-4d11-9c28-1a682e1582fc.png)
