### PR TITLE
fix: Obtain consent for commercial Cypress test

### DIFF
--- a/dotcom-rendering/cypress/e2e/parallel-6/commercial.cy.js
+++ b/dotcom-rendering/cypress/e2e/parallel-6/commercial.cy.js
@@ -1,10 +1,13 @@
 import { cmpIframe } from '../../lib/cmpIframe.js';
 import { privacySettingsIframe } from '../../lib/privacySettingsIframe';
 import { setLocalBaseUrl } from '../../lib/setLocalBaseUrl.js';
+import { storage } from '@guardian/libs';
 
 describe('Commercial E2E tests', function () {
 	beforeEach(function () {
 		setLocalBaseUrl();
+		// Fix the geo so that we know we're interacting with a TCF-framework CMP UI
+		storage.local.set('gu.geo.override', 'GB');
 	});
 
 	it(`It should load the expected number of ad slots`, function () {

--- a/dotcom-rendering/cypress/e2e/parallel-6/commercial.cy.js
+++ b/dotcom-rendering/cypress/e2e/parallel-6/commercial.cy.js
@@ -1,9 +1,9 @@
-import { disableCMP } from '../../lib/disableCMP';
+import { cmpIframe } from '../../lib/cmpIframe.js';
+import { privacySettingsIframe } from '../../lib/privacySettingsIframe';
 import { setLocalBaseUrl } from '../../lib/setLocalBaseUrl.js';
 
 describe('Commercial E2E tests', function () {
 	beforeEach(function () {
-		disableCMP();
 		setLocalBaseUrl();
 	});
 
@@ -11,6 +11,13 @@ describe('Commercial E2E tests', function () {
 		cy.visit(
 			`/Article/https://www.theguardian.com/environment/2020/oct/13/maverick-rewilders-endangered-species-extinction-conservation-uk-wildlife`,
 		);
+
+		cmpIframe().contains("It's your choice");
+		cmpIframe().find("[title='Manage my cookies']").click();
+		privacySettingsIframe().contains('Privacy settings');
+		privacySettingsIframe()
+			.find("[title='Accept all']", { timeout: 12000 })
+			.click();
 
 		cy.scrollTo('bottom', { duration: 500 });
 


### PR DESCRIPTION
## What does this change?

Modify the commercial end-to-end test to obtain "Accept all" consent, rather than simply disabling the CMP. To do this, we take inspiration from [atom.video.cy.js](https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/cypress/e2e/parallel-5/atom.video.cy.js#L121-L126). Note we also set the Geo override to GB, so we know we'll be interacting with a TCF framework UI, regardless of the location of the machine running the test.

## Why?

Fix a failing Cypress test.
