### PR TITLE
feat: add stories showing DropCaps on single and double letter words

### DIFF
--- a/apps-rendering/src/renderer.test.ts
+++ b/apps-rendering/src/renderer.test.ts
@@ -598,14 +598,8 @@ describe('Shows drop caps', () => {
 		design: ArticleDesign.Interview,
 	};
 
-	test('Shows drop cap if the paragraph is at least 200 characters long, the first word is longer than three chars, and the article has the correct design', () => {
+	test('Shows drop cap if the paragraph is at least 200 characters long, and the article has the correct design', () => {
 		const showDropCap = shouldShowDropCap(paragraph, format, !isEditions);
-		expect(showDropCap).toBe(true);
-	});
-
-	test('Shows drop cap if the first word is at least three characters long', () => {
-		const threeChars = `One ${paragraph}`;
-		const showDropCap = shouldShowDropCap(threeChars, format, !isEditions);
 		expect(showDropCap).toBe(true);
 	});
 
@@ -617,28 +611,6 @@ describe('Shows drop caps', () => {
 			!isEditions,
 		);
 		expect(showDropCap).toBe(true);
-	});
-
-	test('Does not show drop cap if the paragraph starts with an "I", despite being at least 200 characters long', () => {
-		const startsWithI = `Inevitably, ${paragraph}`;
-		const showDropCap = shouldShowDropCap(startsWithI, format, !isEditions);
-		expect(showDropCap).toBe(false);
-	});
-
-	test('Does not show drop cap if the first word is shorter than three characters', () => {
-		const twoChars = `On ${paragraph}`;
-		const showDropCap = shouldShowDropCap(twoChars, format, !isEditions);
-		expect(showDropCap).toBe(false);
-	});
-
-	test('Does not show drop cap if the first word is shorter than three characters (ignoring quotation mark)', () => {
-		const twoCharsWithQuotationMark = `“On ${paragraph}`;
-		const showDropCap = shouldShowDropCap(
-			twoCharsWithQuotationMark,
-			format,
-			!isEditions,
-		);
-		expect(showDropCap).toBe(false);
 	});
 
 	test('Does not show drop cap if the paragraph is shorter than 200 characters', () => {

--- a/apps-rendering/src/renderer.ts
+++ b/apps-rendering/src/renderer.ts
@@ -195,26 +195,6 @@ const plainTextElement = (node: Node, key: number): ReactNode => {
 	}
 };
 
-/**
- * This regular expression checks that a string begins with a word that is at least
- * three characters long, ignoring the initial quotation mark.
- *
- *  The regex can be broken down as follows:
- *
- * - `["'\u2018\u201c]?` matches an optional quotation mark, apostrophe, open single quote
- * or open double quote.
- *
- * - `(?!I)` is a negative lookahead checking that the first letter is not "I".
- *
- * - The rest of the expression matches 3 or more characters in the Latin-1 Unicode block,
- * which includes diacritics (e.g. å, č, Ë, etc.).
- *
- * The regex sits outside the rendering function so it is only compiled once
- * for better performance.
- */
-const dropCapRegex =
-	/^["'\u2018\u201c]?(?!I)[a-zA-Z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u024F]{3,}/;
-
 const shouldShowDropCap = (
 	text: string,
 	format: ArticleFormat,
@@ -223,9 +203,7 @@ const shouldShowDropCap = (
 	if (isEditions) {
 		return false;
 	}
-	return (
-		allowsDropCaps(format) && text.length >= 200 && dropCapRegex.test(text)
-	);
+	return allowsDropCaps(format) && text.length >= 200;
 };
 
 const textElement =

--- a/dotcom-rendering/src/web/components/TextBlockComponent.tsx
+++ b/dotcom-rendering/src/web/components/TextBlockComponent.tsx
@@ -35,33 +35,43 @@ const isOpenQuote = (t: string): boolean => {
 	].includes(t);
 };
 
-const isLongEnough = (html: string): boolean => {
-	// Only show a dropcap if the block of text is 200 characters or
-	// longer. But we first need to strip any markup from our html string so
-	// that we accurately measure the length that the reader will see. Eg. remove
-	// link tag html.
+const stripHtmlFromString = (html: string): string => {
 	// https://stackoverflow.com/questions/822452/strip-html-from-text-javascript is
 	// a good discussion on how this can be done. Of the two approaches, regex and
 	// DOM, both have unikely failure scenarios but the impact for failure with DOM
 	// manipulation carries a potential security risk so we're using a regex.
-	return html.replace(/(<([^>]+)>)/gi, '').length >= 199;
+	return html.replace(/(<([^>]+)>)/gi, '');
 };
 
-const decideDropCapLetter = (html: string): string => {
-	const first = html.substr(0, 1);
-	if (isOpenQuote(first)) {
-		const second = html.substr(1, 1);
+const getDropCappedSentence = (
+	html: string,
+): { dropCap: string; restOfSentence: string } | undefined => {
+	const first = html.substring(0, 1);
 
-		if (!isLetter(second)) {
-			return '';
+	// If it starts with a quote and a letter, drop "“A"
+	if (isOpenQuote(first)) {
+		const second = html.substring(1, 2);
+
+		if (isLetter(second)) {
+			return {
+				dropCap: `${first}${second}`,
+				restOfSentence: html.substring(2),
+			};
 		}
-		return `${first}${second}`;
 	}
 
-	return isLetter(first) ? first : '';
+	// Or just drop if the first is a letter
+	if (isLetter(first)) {
+		return {
+			dropCap: first,
+			restOfSentence: html.substring(1),
+		};
+	}
+
+	return;
 };
 
-const allowsDropCaps = (format: ArticleFormat) => {
+const isValidFormatForDropCap = (format: ArticleFormat) => {
 	if (format.theme === ArticleSpecial.Labs) return false;
 	if (format.display === ArticleDisplay.Immersive) return true;
 	switch (format.design) {
@@ -77,23 +87,27 @@ const allowsDropCaps = (format: ArticleFormat) => {
 	}
 };
 
-const shouldShowDropCap = ({
-	format,
-	isFirstParagraph,
-	forceDropCap,
-}: {
-	format: ArticleFormat;
-	isFirstParagraph: boolean;
-	forceDropCap?: boolean;
-}): boolean => {
-	if (allowsDropCaps(format)) {
+const shouldShowDropCaps = (
+	html: string,
+	format: ArticleFormat,
+	isFirstParagraph: boolean,
+	forceDropCap?: boolean,
+) => {
+	const validDropCapFormat = isValidFormatForDropCap(format);
+	// We need to strip any markup from our html string so that we accurately measure
+	// the length that the reader will see. Eg. remove link tag html.
+	const isLongEnough = stripHtmlFromString(html).length >= 200;
+
+	if (validDropCapFormat && isLongEnough) {
 		// When dropcaps are allowed, we always mark the first paragraph as a drop cap
 		if (isFirstParagraph) return true;
+
 		// For subsequent blocks of text, we only add a dropcap if a dinkus was inserted
 		// prior to it in the article body (Eg: * * *), causing the forceDropCap flag to
 		// be set
 		if (forceDropCap) return true;
 	}
+
 	return false;
 };
 
@@ -198,8 +212,8 @@ const styles = (format: ArticleFormat) => css`
 export const TextBlockComponent = ({
 	html,
 	format,
-	forceDropCap,
 	isFirstParagraph,
+	forceDropCap,
 }: Props) => {
 	const paraStyles = styles(format);
 	const {
@@ -227,26 +241,24 @@ export const TextBlockComponent = ({
 		html,
 	});
 
-	const firstLetter = decideDropCapLetter(unwrappedHtml);
-	const remainingLetters = firstLetter
-		? unwrappedHtml.substr(firstLetter.length)
-		: unwrappedHtml;
+	const showDropCaps = shouldShowDropCaps(
+		html,
+		format,
+		isFirstParagraph,
+		forceDropCap,
+	);
+	const dropCappedSentence = showDropCaps
+		? getDropCappedSentence(unwrappedHtml)
+		: undefined;
 
-	if (
-		shouldShowDropCap({
-			format,
-			isFirstParagraph,
-			forceDropCap,
-		}) &&
-		firstLetter &&
-		isLongEnough(remainingLetters)
-	) {
+	if (dropCappedSentence) {
+		const { dropCap, restOfSentence } = dropCappedSentence;
 		return (
 			<p css={paraStyles}>
-				<DropCap letter={firstLetter} format={format} />
+				<DropCap letter={dropCap} format={format} />
 				<RewrappedComponent
 					isUnwrapped={isUnwrapped}
-					html={sanitise(remainingLetters, sanitiserOptions)}
+					html={sanitise(restOfSentence, sanitiserOptions)}
 					elCss={paraStyles}
 					tagName="span"
 				/>


### PR DESCRIPTION
Part of https://github.com/guardian/dotcom-rendering/issues/4725

## What does this change?
Drop caps on all the things - including AR. 

* ~Added the stories so people can see what this looks like (thanks @ajbreuer for taking a look).~ I've removed these as I realised they were better captured in the [`TextBlockComponent` stories](https://63e251470cfbe61776b0ef19-crcjoyskzg.chromatic.com/?path=/story/components-textblockcomponent--default-story).
* Replaced`.substr` with `.substring` as [it's deprecated](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr#sect1).
* Removed the rules around first word length and if it starts with an "I" from apps-rendering. This was run past design and the relevant documentation from Central Production will be updated. The reasoning was we don't have these limits in print, nor when we do interactives, so this adds more consistency across the board.
* There's a mostly renaming refactor, i've left notes in the PR to describe why I made them

## Why?
Consistency

## Screenshots

### Removal of apps-rendering rules

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/31692/229069187-a17bf3a6-f24c-433e-bc39-1d73e3b4ccca.png

[after]: https://user-images.githubusercontent.com/31692/229069218-31d44491-c943-4137-bb70-51fc95d2711a.png


### What it looks like with "I" and shorter than 3 letters
<img width="624" alt="Screenshot 2023-03-29 at 15 01 05" src="https://user-images.githubusercontent.com/31692/228563583-410494a9-050f-40de-b995-143d97b4ff51.png">
<img width="622" alt="Screenshot 2023-03-29 at 15 01 12" src="https://user-images.githubusercontent.com/31692/228563593-52d1c05d-781e-4677-99ed-0b395f4d1e54.png">
<img width="623" alt="Screenshot 2023-03-29 at 15 01 18" src="https://user-images.githubusercontent.com/31692/228563602-e36f8f83-e85b-43f3-b2d4-b609a520a2fd.png">
<img width="639" alt="Screenshot 2023-03-29 at 15 46 31" src="https://user-images.githubusercontent.com/31692/228576917-9ac8bc81-a096-48ce-aff1-49d9f93849bc.png">
<img width="643" alt="Screenshot 2023-03-29 at 17 00 52" src="https://user-images.githubusercontent.com/31692/228598360-7476d99e-75ce-430d-a99b-acd7d00db688.png">
