### PR TITLE
AR Designs For Immersive Comment Pieces

### DIFF
--- a/apps-rendering/src/components/Layout/Layout.stories.tsx
+++ b/apps-rendering/src/components/Layout/Layout.stories.tsx
@@ -8,6 +8,7 @@ import {
 	analysis,
 	article,
 	comment,
+	commentImmersive,
 	editorial,
 	explainer,
 	feature,
@@ -176,6 +177,12 @@ export const CommentStandardSpecialReportAlt = pipe(
 	comment,
 	setSpecialReportAlt,
 	commentLayoutStory,
+);
+export const CommentImmersiveOpinion = immersiveLayoutStory(commentImmersive);
+export const CommentImmersiveSpecialReportAlt = pipe(
+	commentImmersive,
+	setSpecialReportAlt,
+	immersiveLayoutStory,
 );
 
 export const LetterStandardNews = letterLayoutStory(letter);

--- a/apps-rendering/src/components/Layout/index.tsx
+++ b/apps-rendering/src/components/Layout/index.tsx
@@ -55,6 +55,10 @@ const Layout: FC<Props> = ({ item }) => {
 		item.design === ArticleDesign.Comment ||
 		item.design === ArticleDesign.Editorial
 	) {
+		if (item.display === ArticleDisplay.Immersive) {
+			return <ImmersiveLayout item={item} />;
+		}
+
 		return <CommentLayout item={item} />;
 	}
 

--- a/apps-rendering/src/components/WithAgeWarning/index.tsx
+++ b/apps-rendering/src/components/WithAgeWarning/index.tsx
@@ -104,6 +104,10 @@ export const warningStyles = (
 			`;
 		case ArticleDesign.Comment:
 		case ArticleDesign.Editorial:
+			if (format.display === ArticleDisplay.Immersive) {
+				return immersiveStyle(isSeries);
+			}
+
 			return css`
 				${articleWidthStyles}
 				padding-top: ${remSpace[2]};

--- a/apps-rendering/src/fixtures/item.ts
+++ b/apps-rendering/src/fixtures/item.ts
@@ -573,6 +573,13 @@ const standardImmersive: Standard = {
 	outline: fromBodyElements(fields.body),
 };
 
+const commentImmersive: Comment = {
+	design: ArticleDesign.Comment,
+	...fields,
+	display: ArticleDisplay.Immersive,
+	theme: ArticlePillar.Opinion,
+};
+
 const gallery: Gallery = {
 	design: ArticleDesign.Gallery,
 	...fields,
@@ -604,6 +611,7 @@ export {
 	explainer,
 	newsletterSignUp,
 	standardImmersive,
+	commentImmersive,
 	gallery,
 	parseHtml,
 	setTheme,


### PR DESCRIPTION
## Why?

AR previously used the comment layout for all comment (`ArticleDesign.Comment`) pieces, including those that were immersive (`ArticleDisplay.Immersive`). This caused some design clashes with subcomponents (such as the headline) that were applying immersive styles, as these didn't fit well into the comment layout.

This PR switches immersive comment pieces over to the immersive layout that's used for other `ArticleDesign`s, such as `ArticleDesign.Standard` (DCR also does this).

## Changes

- Updated `Layout` component to use `ImmersiveLayout` for immersive comment/editorial pieces
- Updated `AgeWarning` component to use immersive styles for immersive comment/editorial pieces
- Added fixtures and stories for immersive comment pieces

## Screenshots

| Before | After |
| - | - |
| ![immersive-before] | ![immersive-after] |

[immersive-before]: https://user-images.githubusercontent.com/53781962/228847044-1938fcff-c979-425b-b7dd-10f74ddefa25.jpg
[immersive-after]: https://user-images.githubusercontent.com/53781962/228847450-6801c3ce-62e4-465e-b0f9-05a90243d5b1.jpg
