### PR TITLE
Remove Unused `withKnobs` Decorators

### DIFF
--- a/apps-rendering/src/components/EmbedWrapper/EmbedWrapper.stories.tsx
+++ b/apps-rendering/src/components/EmbedWrapper/EmbedWrapper.stories.tsx
@@ -2,7 +2,6 @@
 
 import { EmbedTracksType } from '@guardian/content-api-models/v1/embedTracksType';
 import { some } from '@guardian/types';
-import { withKnobs } from '@storybook/addon-knobs';
 import { EmbedKind } from 'embed';
 import EmbedComponentWrapper from './';
 
@@ -188,7 +187,6 @@ Instagram.story = {
 export default {
 	component: EmbedComponentWrapper,
 	title: 'AR/EmbedComponentWrapper',
-	decorators: [withKnobs],
 };
 
 export { Generic, Youtube, Spotify, Instagram };

--- a/apps-rendering/src/components/Footer/Footer.stories.tsx
+++ b/apps-rendering/src/components/Footer/Footer.stories.tsx
@@ -1,6 +1,5 @@
 // ----- Imports ----- //
 
-import { withKnobs } from '@storybook/addon-knobs';
 import { article } from 'fixtures/item';
 import type { FC } from 'react';
 import Footer from './';
@@ -16,7 +15,6 @@ const Default: FC = () => <Footer isCcpa={false} format={article} />;
 export default {
 	component: Footer,
 	title: 'AR/Footer',
-	decorators: [withKnobs],
 };
 
 export { Default, WithCcpa };

--- a/apps-rendering/src/components/Tags/Tags.stories.tsx
+++ b/apps-rendering/src/components/Tags/Tags.stories.tsx
@@ -1,7 +1,6 @@
 // ----- Imports ----- //
 
 import type { ArticleFormat } from '@guardian/libs';
-import { withKnobs } from '@storybook/addon-knobs';
 import { article } from 'fixtures/item';
 import Tags from './';
 
@@ -14,7 +13,6 @@ const Default = (format: ArticleFormat): JSX.Element => <Tags item={article} />;
 export default {
 	component: Tags,
 	title: 'AR/Tags',
-	decorators: [withKnobs],
 };
 
 export { Default };

--- a/apps-rendering/src/components/editions/avatar/avatar.stories.tsx
+++ b/apps-rendering/src/components/editions/avatar/avatar.stories.tsx
@@ -1,7 +1,6 @@
 // ----- Imports ----- //
 
 import { none, some } from '@guardian/types';
-import { withKnobs } from '@storybook/addon-knobs';
 import type { Contributor } from 'contributor';
 import { article } from 'fixtures/item';
 import type { Image } from 'image';
@@ -53,7 +52,6 @@ const Default = (): ReactElement => (
 export default {
 	component: Avatar,
 	title: 'AR/Editions/Avatar',
-	decorators: [withKnobs],
 };
 
 export { Default };


### PR DESCRIPTION
## Why?

There are no usages of `storybook/addon-knobs` in these stories, so the decorator is not needed. Part of #7505.
