### PR TITLE
Remove Usages Of `storybook/addon-knobs`

### DIFF
--- a/apps-rendering/src/components/Anchor/Anchor.stories.tsx
+++ b/apps-rendering/src/components/Anchor/Anchor.stories.tsx
@@ -1,17 +1,14 @@
 // ----- Imports ----- //
 
 import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
-import { text, withKnobs } from '@storybook/addon-knobs';
 import { getAllThemes, getThemeNameAsString } from 'fixtures/article';
 import type { FC } from 'react';
 import Anchor from './';
 
 // ----- Setup ----- //
 
-const link = (): string => text('Link', 'https://theguardian.com');
-
-const copy = (): string =>
-	text('Copy', '“everything that was recommended was done”.');
+const link = 'https://theguardian.com';
+const copy = '“everything that was recommended was done”.';
 
 // ----- Stories ----- //
 
@@ -22,9 +19,9 @@ const Default: FC = () => (
 			display: ArticleDisplay.Standard,
 			theme: ArticlePillar.News,
 		}}
-		href={link()}
+		href={link}
 	>
-		{copy()}
+		{copy}
 	</Anchor>
 );
 
@@ -43,9 +40,9 @@ const Liveblock: FC = () => {
 							display: ArticleDisplay.Standard,
 							theme: format.theme,
 						}}
-						href={link()}
+						href={link}
 					>
-						{copy()}
+						{copy}
 					</Anchor>
 					<br />
 					<br />
@@ -60,7 +57,6 @@ const Liveblock: FC = () => {
 export default {
 	component: Anchor,
 	title: 'AR/Anchor',
-	decorators: [withKnobs],
 };
 
 export { Default, Liveblock };

--- a/apps-rendering/src/components/Byline/Byline.stories.tsx
+++ b/apps-rendering/src/components/Byline/Byline.stories.tsx
@@ -6,8 +6,6 @@ import {
 	ArticlePillar,
 	ArticleSpecial,
 } from '@guardian/libs';
-import type { Option } from '@guardian/types';
-import { text, withKnobs } from '@storybook/addon-knobs';
 import { parse } from 'client/parser';
 import { getAllThemes, getThemeNameAsString } from 'fixtures/article';
 import type { FC } from 'react';
@@ -18,17 +16,13 @@ import Byline from './';
 const parser = new DOMParser();
 const parseByline = parse(parser);
 
-const profileLink = (): string =>
-	text('Profile Link', 'https://theguardian.com');
+const profileLink = 'https://theguardian.com';
+const byline = 'Jane Smith';
+const job = 'Editor of things';
 
-const byline = (): string => text('Byline', 'Jane Smith');
-
-const job = (): string => text('Job Title', 'Editor of things');
-
-const mockBylineHtml = (): Option<DocumentFragment> =>
-	parseByline(
-		`<a href="${profileLink()}">${byline()}</a> ${job()}`,
-	).toOption();
+const mockBylineHtml = parseByline(
+	`<a href="${profileLink}">${byline}</a> ${job}`,
+).toOption();
 
 // ----- Stories ----- //
 
@@ -37,7 +31,7 @@ const Default: FC = () => (
 		theme={ArticlePillar.News}
 		design={ArticleDesign.Standard}
 		display={ArticleDisplay.Standard}
-		bylineHtml={mockBylineHtml()}
+		bylineHtml={mockBylineHtml}
 	/>
 );
 
@@ -46,7 +40,7 @@ const Analysis: FC = () => (
 		theme={ArticlePillar.News}
 		design={ArticleDesign.Analysis}
 		display={ArticleDisplay.Standard}
-		bylineHtml={mockBylineHtml()}
+		bylineHtml={mockBylineHtml}
 	/>
 );
 
@@ -55,7 +49,7 @@ const Comment: FC = () => (
 		theme={ArticlePillar.Opinion}
 		design={ArticleDesign.Comment}
 		display={ArticleDisplay.Standard}
-		bylineHtml={mockBylineHtml()}
+		bylineHtml={mockBylineHtml}
 	/>
 );
 
@@ -64,7 +58,7 @@ const Labs: FC = () => (
 		theme={ArticleSpecial.Labs}
 		design={ArticleDesign.Standard}
 		display={ArticleDisplay.Standard}
-		bylineHtml={mockBylineHtml()}
+		bylineHtml={mockBylineHtml}
 	/>
 );
 
@@ -81,7 +75,7 @@ const Deadblog: FC = () => {
 						theme={format.theme}
 						design={ArticleDesign.DeadBlog}
 						display={ArticleDisplay.Standard}
-						bylineHtml={mockBylineHtml()}
+						bylineHtml={mockBylineHtml}
 					/>
 					<br />
 				</div>
@@ -95,7 +89,6 @@ const Deadblog: FC = () => {
 export default {
 	component: Byline,
 	title: 'AR/Byline',
-	decorators: [withKnobs],
 };
 
 export { Default, Comment, Labs, Deadblog, Analysis };

--- a/apps-rendering/src/components/CommentCount/CommentCount.stories.tsx
+++ b/apps-rendering/src/components/CommentCount/CommentCount.stories.tsx
@@ -3,7 +3,6 @@
 import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
 import { breakpoints } from '@guardian/source-foundations';
 import { some } from '@guardian/types';
-import { boolean, number, withKnobs } from '@storybook/addon-knobs';
 import { getAllThemes, getThemeNameAsString } from 'fixtures/article';
 import type { FC, ReactElement } from 'react';
 import CommentCount from './';
@@ -12,11 +11,11 @@ import CommentCount from './';
 
 const Default: FC = () => (
 	<CommentCount
-		count={some(number('Count', 1234, { min: 0 }))}
+		count={some(1234)}
 		theme={ArticlePillar.News}
 		design={ArticleDesign.Standard}
 		display={ArticleDisplay.Standard}
-		commentable={boolean('Commentable', true)}
+		commentable={true}
 	/>
 );
 
@@ -30,11 +29,11 @@ const Deadblogs = (): ReactElement => {
 				<div key={format.theme}>
 					<p>{getThemeNameAsString(format)}</p>
 					<CommentCount
-						count={some(number('Count', 1234, { min: 0 }))}
+						count={some(1234)}
 						theme={format.theme}
 						design={ArticleDesign.DeadBlog}
 						display={ArticleDisplay.Standard}
-						commentable={boolean('Commentable', true)}
+						commentable={true}
 					/>
 					<br />
 				</div>
@@ -56,7 +55,6 @@ Deadblogs.story = {
 export default {
 	component: CommentCount,
 	title: 'AR/CommentCount',
-	decorators: [withKnobs],
 };
 
 export { Default, Deadblogs };

--- a/apps-rendering/src/components/Dateline/Dateline.stories.tsx
+++ b/apps-rendering/src/components/Dateline/Dateline.stories.tsx
@@ -3,7 +3,6 @@
 import { Edition } from '@guardian/apps-rendering-api-models/edition';
 import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
 import { some } from '@guardian/types';
-import { date, withKnobs } from '@storybook/addon-knobs';
 import type { FC } from 'react';
 import Dateline from './';
 
@@ -16,9 +15,7 @@ const Default: FC = () => (
 			display: ArticleDisplay.Standard,
 			theme: ArticlePillar.Opinion,
 		}}
-		date={some(
-			new Date(date('Publish Date', new Date('2019-12-17T03:24:00'))),
-		)}
+		date={some(new Date('2019-12-17T03:24:00'))}
 		edition={Edition.UK}
 	/>
 );
@@ -30,9 +27,7 @@ const LiveBlogDateline: FC = () => (
 			display: ArticleDisplay.Standard,
 			theme: ArticlePillar.News,
 		}}
-		date={some(
-			new Date(date('Publish Date', new Date('2019-12-17T03:24:00'))),
-		)}
+		date={some(new Date('2019-12-17T03:24:00'))}
 		edition={Edition.US}
 	/>
 );
@@ -44,9 +39,7 @@ const DeadBlogDateline: FC = () => (
 			display: ArticleDisplay.Standard,
 			theme: ArticlePillar.Culture,
 		}}
-		date={some(
-			new Date(date('Publish Date', new Date('2019-12-17T03:24:00'))),
-		)}
+		date={some(new Date('2019-12-17T03:24:00'))}
 		edition={Edition.AU}
 	/>
 );
@@ -56,7 +49,6 @@ const DeadBlogDateline: FC = () => (
 export default {
 	component: Dateline,
 	title: 'AR/Dateline',
-	decorators: [withKnobs],
 };
 
 export { Default, LiveBlogDateline, DeadBlogDateline };

--- a/apps-rendering/src/components/FootballScores/FootballScores.stories.tsx
+++ b/apps-rendering/src/components/FootballScores/FootballScores.stories.tsx
@@ -1,31 +1,14 @@
 // ----- Imports ----- //
 
-import { select, text, withKnobs } from '@storybook/addon-knobs';
 import type { FC } from 'react';
 import FootballScores, { MatchStatusKind } from './';
-
-// ----- Helpers ----- //
-
-const matchStatusOptions = {
-	KickOff: MatchStatusKind.KickOff,
-	FirstHalf: MatchStatusKind.FirstHalf,
-	HalfTime: MatchStatusKind.HalfTime,
-	SecondHalf: MatchStatusKind.SecondHalf,
-	FullTime: MatchStatusKind.FullTime,
-	ExtraTime: MatchStatusKind.ExtraTime,
-	Penalties: MatchStatusKind.Penalties,
-	Suspended: MatchStatusKind.Suspended,
-};
-
-const selectMatchStatus = (): MatchStatusKind =>
-	select('Match Status', matchStatusOptions, MatchStatusKind.KickOff);
 
 // ----- Stories ----- //
 
 const Default: FC = () => (
 	<FootballScores
-		league={text('League', 'Premier League')}
-		stadium={text('Stadium', 'Etihad Stadium')}
+		league="Premier League"
+		stadium="Etihad Stadium"
 		homeTeam={{
 			id: '1006',
 			name: 'Arsenal',
@@ -54,7 +37,7 @@ const Default: FC = () => (
 				},
 			],
 		}}
-		status={{ kind: selectMatchStatus(), time: '20:00' }}
+		status={{ kind: MatchStatusKind.KickOff, time: '20:00' }}
 	/>
 );
 
@@ -63,7 +46,6 @@ const Default: FC = () => (
 export default {
 	component: FootballScores,
 	title: 'AR/FootballScores',
-	decorators: [withKnobs],
 };
 
 export { Default };

--- a/apps-rendering/src/components/Headline/Headline.stories.tsx
+++ b/apps-rendering/src/components/Headline/Headline.stories.tsx
@@ -2,14 +2,9 @@
 
 import { ArticleDisplay, ArticlePillar } from '@guardian/libs';
 import { some } from '@guardian/types';
-import { boolean, radios, withKnobs } from '@storybook/addon-knobs';
 import { analysis, article, feature, labs, review } from 'fixtures/item';
 import type { ReactElement } from 'react';
 import Headline from './';
-
-// ----- Setup ----- //
-
-const starRating = { 0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5 };
 
 // ----- Stories ----- //
 
@@ -17,9 +12,7 @@ const Default = (): ReactElement => (
 	<Headline
 		item={{
 			...article,
-			display: boolean('Immersive', false)
-				? ArticleDisplay.Immersive
-				: ArticleDisplay.Standard,
+			display: ArticleDisplay.Standard,
 		}}
 	/>
 );
@@ -28,9 +21,7 @@ const Analysis = (): ReactElement => (
 	<Headline
 		item={{
 			...analysis,
-			display: boolean('Immersive', false)
-				? ArticleDisplay.Immersive
-				: ArticleDisplay.Standard,
+			display: ArticleDisplay.Standard,
 			theme: ArticlePillar.News,
 		}}
 	/>
@@ -40,9 +31,7 @@ const Feature = (): ReactElement => (
 	<Headline
 		item={{
 			...feature,
-			display: boolean('Immersive', false)
-				? ArticleDisplay.Immersive
-				: ArticleDisplay.Standard,
+			display: ArticleDisplay.Standard,
 			theme: ArticlePillar.News,
 		}}
 	/>
@@ -52,10 +41,8 @@ const Review = (): ReactElement => (
 	<Headline
 		item={{
 			...review,
-			starRating: some(radios('Rating', starRating, 3)),
-			display: boolean('Immersive', false)
-				? ArticleDisplay.Immersive
-				: ArticleDisplay.Standard,
+			starRating: some(3),
+			display: ArticleDisplay.Standard,
 		}}
 	/>
 );
@@ -74,7 +61,6 @@ const Labs = (): ReactElement => (
 export default {
 	component: Headline,
 	title: 'AR/Headline',
-	decorators: [withKnobs],
 };
 
 export { Default, Analysis, Feature, Review, Labs };

--- a/apps-rendering/src/components/RichLink/RichLink.stories.tsx
+++ b/apps-rendering/src/components/RichLink/RichLink.stories.tsx
@@ -1,7 +1,6 @@
 import { css } from '@emotion/react';
 import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
 import { from, remSpace } from '@guardian/source-foundations';
-import { text, withKnobs } from '@storybook/addon-knobs';
 import type { FC } from 'react';
 import RichLink, { richLinkWidth } from './';
 
@@ -11,13 +10,8 @@ const overrideStyle = css`
 	}
 `;
 
-const url = (): string => text('Link', 'https://theguardian.com');
-
-const linkText = (): string =>
-	text(
-		'Link Text',
-		'Axolotls in crisis: the fight to save the water monster of Mexico City.',
-	);
+const url = 'https://theguardian.com';
+const linkText = 'Axolotls in crisis: the fight to save the water monster of Mexico City.';
 
 const Default: FC = () => (
 	<section css={overrideStyle}>
@@ -27,8 +21,8 @@ const Default: FC = () => (
 				display: ArticleDisplay.Standard,
 				theme: ArticlePillar.News,
 			}}
-			linkText={linkText()}
-			url={url()}
+			linkText={linkText}
+			url={url}
 		></RichLink>
 	</section>
 );
@@ -36,7 +30,6 @@ const Default: FC = () => (
 export default {
 	component: RichLink,
 	title: 'AR/Rich Link',
-	decorators: [withKnobs],
 };
 
 const Analysis: FC = () => (
@@ -54,8 +47,8 @@ const Analysis: FC = () => (
 					display: ArticleDisplay.Standard,
 					theme: ArticlePillar.News,
 				}}
-				linkText={linkText()}
-				url={url()}
+				linkText={linkText}
+				url={url}
 			></RichLink>
 		</section>
 	</div>

--- a/apps-rendering/src/components/Standfirst/Standfirst.stories.tsx
+++ b/apps-rendering/src/components/Standfirst/Standfirst.stories.tsx
@@ -1,7 +1,6 @@
 // ----- Imports ----- //
 
 import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
-import { boolean, withKnobs } from '@storybook/addon-knobs';
 import { getAllThemes, getThemeNameAsString } from 'fixtures/article';
 import {
 	analysis,
@@ -22,9 +21,7 @@ const Default = (): ReactElement => (
 	<Standfirst
 		item={{
 			...article,
-			display: boolean('Immersive', false)
-				? ArticleDisplay.Immersive
-				: ArticleDisplay.Standard,
+			display: ArticleDisplay.Standard,
 			theme: ArticlePillar.News,
 		}}
 	/>
@@ -34,9 +31,7 @@ const Review = (): ReactElement => (
 	<Standfirst
 		item={{
 			...review,
-			display: boolean('Immersive', false)
-				? ArticleDisplay.Immersive
-				: ArticleDisplay.Standard,
+			display: ArticleDisplay.Standard,
 			theme: ArticlePillar.Culture,
 		}}
 	/>
@@ -46,9 +41,7 @@ const Feature = (): ReactElement => (
 	<Standfirst
 		item={{
 			...feature,
-			display: boolean('Immersive', false)
-				? ArticleDisplay.Immersive
-				: ArticleDisplay.Standard,
+			display: ArticleDisplay.Standard,
 			theme: ArticlePillar.Sport,
 		}}
 	/>
@@ -58,9 +51,7 @@ const Comment = (): ReactElement => (
 	<Standfirst
 		item={{
 			...comment,
-			display: boolean('Immersive', false)
-				? ArticleDisplay.Immersive
-				: ArticleDisplay.Standard,
+			display: ArticleDisplay.Standard,
 			theme: ArticlePillar.Opinion,
 		}}
 	/>
@@ -102,9 +93,7 @@ const Analysis = (): ReactElement => (
 	<AnalysisStandfirst
 		item={{
 			...analysis,
-			display: boolean('Immersive', false)
-				? ArticleDisplay.Immersive
-				: ArticleDisplay.Standard,
+			display: ArticleDisplay.Standard,
 			theme: ArticlePillar.Culture,
 		}}
 	/>
@@ -115,7 +104,6 @@ const Analysis = (): ReactElement => (
 export default {
 	component: Standfirst,
 	title: 'AR/Standfirst',
-	decorators: [withKnobs],
 };
 
 export { Default, Review, Feature, Comment, Link, Deadblog, Analysis };

--- a/apps-rendering/src/components/StarRating/StarRating.stories.tsx
+++ b/apps-rendering/src/components/StarRating/StarRating.stories.tsx
@@ -1,14 +1,9 @@
 // ----- Imports ----- //
 
 import { some } from '@guardian/types';
-import { radios, withKnobs } from '@storybook/addon-knobs';
 import { article, review } from 'fixtures/item';
 import type { ReactElement } from 'react';
 import StarRating from './';
-
-// ----- Setup ----- //
-
-const starRating = { 0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5 };
 
 // ----- Stories ----- //
 
@@ -16,7 +11,7 @@ const Default = (): ReactElement => (
 	<StarRating
 		item={{
 			...review,
-			starRating: some(radios('Rating', starRating, 3)),
+			starRating: some(3),
 		}}
 	/>
 );
@@ -28,7 +23,6 @@ const NotReview = (): ReactElement => <StarRating item={article} />;
 export default {
 	component: StarRating,
 	title: 'AR/Star Rating',
-	decorators: [withKnobs],
 };
 
 export { Default, NotReview };

--- a/apps-rendering/src/components/editions/byline/byline.stories.tsx
+++ b/apps-rendering/src/components/editions/byline/byline.stories.tsx
@@ -2,8 +2,6 @@
 
 import { ArticleDisplay, ArticlePillar } from '@guardian/libs';
 import { none, some } from '@guardian/types';
-import type { Option } from '@guardian/types';
-import { boolean, text, withKnobs } from '@storybook/addon-knobs';
 import { parse } from 'client/parser';
 import type { Contributor } from 'contributor';
 import {
@@ -50,25 +48,13 @@ const contributors: Contributor[] = [
 const parser = new DOMParser();
 const parseByline = parse(parser);
 
-const profileLink = (): string =>
-	text('Profile Link', 'https://theguardian.com');
+const profileLink = 'https://theguardian.com';
+const byline = 'Jane Smith';
+const job = 'Editor of things';
 
-const byline = (): string => text('Byline', 'Jane Smith');
-
-const job = (): string => text('Job Title', 'Editor of things');
-
-const mockBylineHtml = (): Option<DocumentFragment> =>
-	parseByline(
-		`<a href="${profileLink()}">${byline()}</a> ${job()}`,
-	).toOption();
-
-const isImmersive = (): { display: ArticleDisplay } => {
-	return {
-		display: boolean('Immersive', false)
-			? ArticleDisplay.Immersive
-			: ArticleDisplay.Standard,
-	};
-};
+const mockBylineHtml = parseByline(
+	`<a href="${profileLink}">${byline}</a> ${job}`,
+).toOption();
 
 // ----- Stories ----- //
 
@@ -77,7 +63,7 @@ const Default = (): ReactElement => (
 		item={{
 			...article,
 			display: ArticleDisplay.Standard,
-			bylineHtml: mockBylineHtml(),
+			bylineHtml: mockBylineHtml,
 			theme: ArticlePillar.News,
 		}}
 	/>
@@ -87,8 +73,7 @@ const Analysis = (): ReactElement => (
 	<Byline
 		item={{
 			...analysis,
-			...isImmersive(),
-			bylineHtml: mockBylineHtml(),
+			bylineHtml: mockBylineHtml,
 			theme: ArticlePillar.News,
 		}}
 	/>
@@ -98,8 +83,7 @@ const Feature = (): ReactElement => (
 	<Byline
 		item={{
 			...feature,
-			...isImmersive(),
-			bylineHtml: mockBylineHtml(),
+			bylineHtml: mockBylineHtml,
 			theme: ArticlePillar.News,
 		}}
 	/>
@@ -109,7 +93,7 @@ const Review = (): ReactElement => (
 	<Byline
 		item={{
 			...review,
-			bylineHtml: mockBylineHtml(),
+			bylineHtml: mockBylineHtml,
 			theme: ArticlePillar.News,
 		}}
 	/>
@@ -120,7 +104,7 @@ const Showcase = (): ReactElement => (
 		item={{
 			...article,
 			display: ArticleDisplay.Showcase,
-			bylineHtml: mockBylineHtml(),
+			bylineHtml: mockBylineHtml,
 			theme: ArticlePillar.News,
 		}}
 	/>
@@ -130,8 +114,7 @@ const Interview = (): ReactElement => (
 	<Byline
 		item={{
 			...interview,
-			...isImmersive(),
-			bylineHtml: mockBylineHtml(),
+			bylineHtml: mockBylineHtml,
 			theme: ArticlePillar.News,
 		}}
 	/>
@@ -146,8 +129,7 @@ const Comment = (): ReactElement => (
 		<Byline
 			item={{
 				...comment,
-				...isImmersive(),
-				bylineHtml: mockBylineHtml(),
+				bylineHtml: mockBylineHtml,
 				theme: ArticlePillar.News,
 				contributors: contributors,
 			}}
@@ -160,7 +142,6 @@ const Comment = (): ReactElement => (
 export default {
 	component: Byline,
 	title: 'AR/Editions/Byline',
-	decorators: [withKnobs],
 };
 
 export { Default, Analysis, Feature, Review, Showcase, Interview, Comment };

--- a/apps-rendering/src/components/editions/footballScores/footballScores.stories.tsx
+++ b/apps-rendering/src/components/editions/footballScores/footballScores.stories.tsx
@@ -1,6 +1,5 @@
 // ----- Imports ----- //
 
-import { text, withKnobs } from '@storybook/addon-knobs';
 import type { FC } from 'react';
 import FootballScores from './index';
 
@@ -10,7 +9,7 @@ import FootballScores from './index';
 
 const Default: FC = () => (
 	<FootballScores
-		league={text('League', 'Premier League')}
+		league="Premier League"
 		stadium="Elland road"
 		homeTeam={{
 			id: '1006',
@@ -48,7 +47,6 @@ const Default: FC = () => (
 export default {
 	component: FootballScores,
 	title: 'AR/Editions/FootballScores',
-	decorators: [withKnobs],
 };
 
 export { Default };

--- a/apps-rendering/src/components/editions/headline/headline.stories.tsx
+++ b/apps-rendering/src/components/editions/headline/headline.stories.tsx
@@ -6,7 +6,6 @@ import {
 	ArticlePillar,
 } from '@guardian/libs';
 import { none, some } from '@guardian/types';
-import { boolean, withKnobs } from '@storybook/addon-knobs';
 import type { Contributor } from 'contributor';
 import {
 	analysis,
@@ -50,27 +49,12 @@ const contributors: Contributor[] = [
 	},
 ];
 
-const hasContributor = (): { contributors: Contributor[] } => {
-	return {
-		contributors: boolean('Contributors', true) ? contributors : [],
-	};
-};
-
-const isImmersive = (): { display: ArticleDisplay } => {
-	return {
-		display: boolean('Immersive', false)
-			? ArticleDisplay.Immersive
-			: ArticleDisplay.Standard,
-	};
-};
-
 // ----- Stories ----- //
 
 const Default = (): ReactElement => (
 	<Headline
 		item={{
 			...article,
-			...isImmersive(),
 			theme: ArticlePillar.News,
 		}}
 	/>
@@ -80,7 +64,6 @@ const Analysis = (): ReactElement => (
 	<Headline
 		item={{
 			...analysis,
-			...isImmersive(),
 			theme: ArticlePillar.News,
 		}}
 	/>
@@ -90,7 +73,6 @@ const Feature = (): ReactElement => (
 	<Headline
 		item={{
 			...feature,
-			...isImmersive(),
 			theme: ArticlePillar.News,
 		}}
 	/>
@@ -109,7 +91,6 @@ const Showcase = (): ReactElement => (
 	<Headline
 		item={{
 			...review,
-			...isImmersive(),
 			display: ArticleDisplay.Showcase,
 			theme: ArticlePillar.News,
 		}}
@@ -120,7 +101,6 @@ const Interview = (): ReactElement => (
 	<Headline
 		item={{
 			...interview,
-			...isImmersive(),
 			theme: ArticlePillar.News,
 		}}
 	/>
@@ -130,8 +110,7 @@ const Comment = (): ReactElement => (
 	<Headline
 		item={{
 			...comment,
-			...isImmersive(),
-			...hasContributor(),
+			contributors,
 			theme: ArticlePillar.News,
 		}}
 	/>
@@ -151,7 +130,6 @@ const Media = (): ReactElement => (
 export default {
 	component: Headline,
 	title: 'AR/Editions/Headline',
-	decorators: [withKnobs],
 };
 
 export {

--- a/apps-rendering/src/components/editions/layout/layout.stories.tsx
+++ b/apps-rendering/src/components/editions/layout/layout.stories.tsx
@@ -7,7 +7,6 @@ import {
 } from '@guardian/libs';
 import { breakpoints } from '@guardian/source-foundations';
 import { none, some } from '@guardian/types';
-import { boolean, withKnobs } from '@storybook/addon-knobs';
 import type { Contributor } from 'contributor';
 import {
 	analysis,
@@ -56,26 +55,6 @@ const contributors: Contributor[] = [
 	},
 ];
 
-const hasContributor = (): { contributors: Contributor[] } => {
-	return {
-		contributors: boolean('Contributors', true) ? contributors : [],
-	};
-};
-
-const isImmersive = (): { display: ArticleDisplay } => {
-	return {
-		display: boolean('Immersive', false)
-			? ArticleDisplay.Immersive
-			: ArticleDisplay.Standard,
-	};
-};
-
-const hasShareIcon = (): { webUrl: string } => {
-	return {
-		webUrl: boolean('ShareIcon', true) ? 'www.guardian.com' : '',
-	};
-};
-
 const getTag = (id: string, webTitle: string): Tag => ({
 	id,
 	type: 6,
@@ -92,8 +71,7 @@ const Default = (): ReactElement => (
 	<Layout
 		item={{
 			...article,
-			...isImmersive(),
-			...hasShareIcon(),
+			webUrl: 'https://www.theguardian.com',
 			theme: ArticlePillar.News,
 		}}
 	/>
@@ -103,9 +81,7 @@ const Analysis = (): ReactElement => (
 	<Layout
 		item={{
 			...analysis,
-			...isImmersive(),
-			...hasShareIcon(),
-
+			webUrl: 'https://www.theguardian.com',
 			tags: [getTag('tone/analysis', 'View from the Guardian ')],
 			theme: ArticlePillar.Lifestyle,
 		}}
@@ -117,9 +93,7 @@ const Editorial = (): ReactElement => (
 		item={{
 			...editorial,
 			tags: [getTag('tone/editorials', 'View from the Guardian ')],
-			...isImmersive(),
-			...hasShareIcon(),
-
+			webUrl: 'https://www.theguardian.com',
 			theme: ArticlePillar.Opinion,
 		}}
 	/>
@@ -129,9 +103,7 @@ const Feature = (): ReactElement => (
 	<Layout
 		item={{
 			...feature,
-			...isImmersive(),
-			...hasShareIcon(),
-
+			webUrl: 'https://www.theguardian.com',
 			theme: ArticlePillar.Sport,
 		}}
 	/>
@@ -141,8 +113,7 @@ const Review = (): ReactElement => (
 	<Layout
 		item={{
 			...review,
-			...hasShareIcon(),
-
+			webUrl: 'https://www.theguardian.com',
 			theme: ArticlePillar.Culture,
 		}}
 	/>
@@ -152,8 +123,7 @@ const Showcase = (): ReactElement => (
 	<Layout
 		item={{
 			...article,
-			...hasShareIcon(),
-
+			webUrl: 'https://www.theguardian.com',
 			display: ArticleDisplay.Showcase,
 			theme: ArticlePillar.News,
 		}}
@@ -164,9 +134,7 @@ const Interview = (): ReactElement => (
 	<Layout
 		item={{
 			...interview,
-			...hasShareIcon(),
-
-			...isImmersive(),
+			webUrl: 'https://www.theguardian.com',
 			theme: ArticlePillar.Sport,
 		}}
 	/>
@@ -176,9 +144,8 @@ const Comment = (): ReactElement => (
 	<Layout
 		item={{
 			...comment,
-			...hasShareIcon(),
-			...hasContributor(),
-			...isImmersive(),
+			webUrl: 'https://www.theguardian.com',
+			contributors,
 			theme: ArticlePillar.News,
 		}}
 	/>
@@ -188,7 +155,7 @@ const Letter = (): ReactElement => (
 	<Layout
 		item={{
 			...letter,
-			...hasShareIcon(),
+			webUrl: 'https://www.theguardian.com',
 			tags: [getTag('tone/letters', 'Letters ')],
 			theme: ArticlePillar.Opinion,
 		}}
@@ -214,7 +181,7 @@ const MatchReport = (): ReactElement => (
 	<Layout
 		item={{
 			...matchReport,
-			...hasShareIcon(),
+			webUrl: 'https://www.theguardian.com',
 			tags: [getTag('tone/sport', 'Sport ')],
 			theme: ArticlePillar.Sport,
 		}}
@@ -225,7 +192,7 @@ const Cartoon = (): ReactElement => (
 	<Layout
 		item={{
 			...cartoon,
-			...hasShareIcon(),
+			webUrl: 'https://www.theguardian.com',
 			tags: [getTag('type/picture', 'cartoon')],
 		}}
 	/>
@@ -235,7 +202,7 @@ const Gallery = (): ReactElement => (
 	<Layout
 		item={{
 			...media,
-			...hasShareIcon(),
+			webUrl: 'https://www.theguardian.com',
 			theme: ArticlePillar.News,
 		}}
 	/>
@@ -253,7 +220,6 @@ Gallery.parameters = {
 export default {
 	component: Layout,
 	title: 'Editions/Layouts',
-	decorators: [withKnobs],
 	parameters: {
 		layout: 'fullscreen',
 		chromatic: {

--- a/apps-rendering/src/components/editions/starRating/starRating.stories.tsx
+++ b/apps-rendering/src/components/editions/starRating/starRating.stories.tsx
@@ -1,14 +1,9 @@
 // ----- Imports ----- //
 
 import { some } from '@guardian/types';
-import { radios, withKnobs } from '@storybook/addon-knobs';
 import { article, review } from 'fixtures/item';
 import type { ReactElement } from 'react';
 import StarRating from '.';
-
-// ----- Setup ----- //
-
-const starRating = { 0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5 };
 
 // ----- Stories ----- //
 
@@ -16,7 +11,7 @@ const Default = (): ReactElement => (
 	<StarRating
 		item={{
 			...review,
-			starRating: some(radios('Rating', starRating, 3)),
+			starRating: some(3),
 		}}
 	/>
 );
@@ -28,7 +23,6 @@ const NotReview = (): ReactElement => <StarRating item={article} />;
 export default {
 	component: StarRating,
 	title: 'AR/Editions/Star Rating',
-	decorators: [withKnobs],
 };
 
 export { Default, NotReview };


### PR DESCRIPTION
## Why?

Part of #7505. Breaking the changes up into parts to make PRs easier to review, this PR removes all usages of `storybook/addon-knobs`.
