### PR TITLE
Docs: Fix descent into `dotcom-rendering` folders in `Running instructions`

### DIFF
--- a/dotcom-rendering/README.md
+++ b/dotcom-rendering/README.md
@@ -48,8 +48,9 @@ Clone the repo, run `yarn` in the root, then CD into the `dotcom-rendering` subd
 
 ```
 $ git clone git@github.com:guardian/dotcom-rendering.git
+$ cd dotcom-rendering
 $ yarn install
-$ cd dotcom-rendering/dotcom-rendering
+$ cd dotcom-rendering
 $ make dev
 ```
 


### PR DESCRIPTION
You can't run `yarn install` until you're in the top-level `dotcom-rendering` folder, and if you are, you can't execute `cd dotcom-rendering/dotcom-rendering` in the penultimate step!
