### PR TITLE
Remove Cypress exception handling

### DIFF
--- a/dotcom-rendering/cypress/e2e/parallel-1/sign-in-gate.cy.js
+++ b/dotcom-rendering/cypress/e2e/parallel-1/sign-in-gate.cy.js
@@ -114,7 +114,7 @@ describe('Sign In Gate Tests', function () {
 			cy.get('[data-cy=sign-in-gate-main]').should('not.exist');
 		});
 
-		it('should not load the sign in gate if the user is signed in', function (done) {
+		it('should not load the sign in gate if the user is signed in', function () {
 			// use GU_U cookie to determine if user is signed in
 			cy.setCookie(
 				'GU_U',
@@ -123,14 +123,6 @@ describe('Sign In Gate Tests', function () {
 			);
 
 			visitArticleAndScrollToGateForLazyLoad();
-
-			// when using GU_U cookie, there is an issue with the commercial.dcr.js bundle
-			// causing a URI Malformed error in cypress
-			// we use this uncaught exception in this test to catch this and continue the rest of the test
-			cy.on('uncaught:exception', () => {
-				done();
-				return false;
-			});
 
 			cy.get('[data-cy=sign-in-gate-main]').should('not.exist');
 		});


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Remove an exception handling in the Cypress sign-in gate test.

## Why?

It is no longer thrown, so we need to remove the handling for the tests to pass, otherwise the `done` callback is never fired. 

Originally introduced in https://github.com/guardian/dotcom-rendering/pull/1740/files#diff-1c4e1b064a72f3b58ce4d292fc390c7ae1be4e3f147acd8c8f4deee9031fb676R68-R71