### PR TITLE
Bump @guardian/braze-components@^12.0.0

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -60,7 +60,7 @@
 		"@emotion/server": "^11.4.0",
 		"@guardian/ab-core": "^4.0.0",
 		"@guardian/atoms-rendering": "^27.0.0",
-		"@guardian/braze-components": "^11.0.0",
+		"@guardian/braze-components": "^12.0.0",
 		"@guardian/bridget": "^2.3.0",
 		"@guardian/browserslist-config": "^4.0.0",
 		"@guardian/cdk": "^49.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2208,10 +2208,10 @@
   dependencies:
     is-mobile "3.1.1"
 
-"@guardian/braze-components@^11.0.0":
-  version "11.0.0"
-  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-11.0.0.tgz#2800fd98aefbea532799c5df158710980e9f7596"
-  integrity sha512-xEaYvsSvfs9J5mxibS6FUD4AqqjVS89m/KSI/652uWf7MfT6qJvxIedFGg3vkompXhF7oNXMLQSL8eNiKUqW7g==
+"@guardian/braze-components@^12.0.0":
+  version "12.0.0"
+  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-12.0.0.tgz#1260d566b306f38248a0909d90a0dfd6b324c8d3"
+  integrity sha512-IvGrICcRejWW+VIvarxy4xfT+AJGOjSs71qH+7JAjVn7+VJ3ASSADx/KyLdCxCamTSaOA9Umk11mtRzoSnmDRg==
 
 "@guardian/bridget@^2.3.0":
   version "2.3.0"


### PR DESCRIPTION
## What does this change?

Bump [@guardian/braze-components@^12.0.0](https://github.com/guardian/braze-components/releases/tag/v12.0.0)

## Why?

Following a trail of dep alignment for https://github.com/guardian/frontend/pull/25892

