### PR TITLE
Don't run Percy as part of CI

### DIFF
--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -1,8 +1,8 @@
 name: Percy
-on:
-  push:
-    paths-ignore:
-      - "apps-rendering/**"
+on: workflow_dispatch
+  # push:
+  #   paths-ignore:
+  #     - "apps-rendering/**"
 jobs:
   percy:
     name: Percy


### PR DESCRIPTION
## What does this change?

Change the `percy.yml` workflow to run as a manual `workflow_dispatch` instead of every CI run.

I've left the Percy tests and workflow in place pending a decision on whether it will be used by Webex or not.

## Why?

Webex is not currently using Percy visual testing so we can heat the planet a little less.

