### PR TITLE
Overlap text on image treat and embolden first span

### DIFF
--- a/dotcom-rendering/src/model/enhanceTreats.ts
+++ b/dotcom-rendering/src/model/enhanceTreats.ts
@@ -20,8 +20,8 @@ const PLATFORM_TREATS: TreatType[] = [
 		links: [
 			{
 				linkTo: '/info/2015/dec/08/daily-email-us?INTCMP=gdnwb_treat_election_today_us',
-				text: 'Guardian Today US:',
-				textSlice: ' Get the headlines & more in a daily email',
+				title: 'Guardian Today US: ',
+				text: 'Get the headlines & more in a daily email',
 			},
 		],
 		theme: ArticlePillar.News,

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -470,7 +470,7 @@ export type DCRSupportingContent = {
 };
 
 export type TreatType = {
-	links: { text: string; textSlice?: string; linkTo: string }[];
+	links: { text: string; title?: string; linkTo: string }[];
 	theme?: ArticlePillar | ArticleSpecial;
 	editionId?: EditionId;
 	imageUrl?: string;

--- a/dotcom-rendering/src/web/components/Treats.tsx
+++ b/dotcom-rendering/src/web/components/Treats.tsx
@@ -53,7 +53,7 @@ const ImageTreat = ({
 	backgroundColour,
 }: {
 	imageUrl: string;
-	links: { text: string; textSlice?: string; linkTo: string }[];
+	links: { text: string; title?: string; linkTo: string }[];
 	altText?: string;
 	backgroundColour: string;
 }) => {
@@ -147,9 +147,9 @@ const ImageTreat = ({
 										font-weight: bold;
 									`}
 								>
-									{link.text}
+									{link.title}
 								</span>
-								{link.textSlice}
+								{link.text}
 							</span>
 						</div>
 					</a>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Overlaps text on image treat and makes first span bold

Resolves https://github.com/guardian/dotcom-rendering/issues/7144
## Why?
Parity with frontend
## Screenshots

|  (Frontend wide)     |    (DCR wide)   |
|-------------|------------|
| ![before][] | ![after][] |
|  (Frontend leftcol)     |  (DCR leftcol)     |
|-------------|------------|
| ![before2][] | ![after2][] |

[before]: https://user-images.githubusercontent.com/110032454/230100365-e6ba906f-7801-486e-8335-51fe9d4087e2.png
[after]: https://user-images.githubusercontent.com/110032454/230099849-2507b3a6-6c50-4d2d-a1c9-fadfdfb37e21.png
[before2]: https://user-images.githubusercontent.com/110032454/230100490-b58ea281-a1f6-4294-ba98-ab5b03ea5619.png
[after2]: https://user-images.githubusercontent.com/110032454/230099942-083c3bbc-c1cc-4024-b842-d5335aad22af.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->


<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
