### PR TITLE
fix: add ad label styles for mobile front ads

### DIFF
--- a/dotcom-rendering/src/web/components/AdSlot.tsx
+++ b/dotcom-rendering/src/web/components/AdSlot.tsx
@@ -486,31 +486,33 @@ export const AdSlot = ({
 		case 'mobile-front': {
 			const advertId = `inline${index}`;
 			return (
-				<div
-					id={`dfp-ad--${advertId}--mobile`}
-					className={[
-						'js-ad-slot',
-						'ad-slot',
-						`ad-slot--${advertId}`,
-						'ad-slot--container-inline',
-						'ad-slot--mobile',
-						'mobile-only',
-						'ad-slot--rendered',
-					].join(' ')}
-					css={[
-						css`
-							position: relative;
-							min-height: 274px;
-							min-width: 300px;
-							width: 300px;
-							margin: 12px auto;
-						`,
-						adStyles,
-					]}
-					data-link-name={`ad slot ${advertId}`}
-					data-name={advertId}
-					aria-hidden="true"
-				/>
+				<div className="ad-slot-container" css={[adStyles]}>
+					<div
+						id={`dfp-ad--${advertId}--mobile`}
+						className={[
+							'js-ad-slot',
+							'ad-slot',
+							`ad-slot--${advertId}`,
+							'ad-slot--container-inline',
+							'ad-slot--mobile',
+							'mobile-only',
+							'ad-slot--rendered',
+						].join(' ')}
+						css={[
+							css`
+								position: relative;
+								min-height: 274px;
+								min-width: 300px;
+								width: 300px;
+								margin: 12px auto;
+							`,
+							adStyles,
+						]}
+						data-link-name={`ad slot ${advertId}`}
+						data-name={advertId}
+						aria-hidden="true"
+					/>
+				</div>
 			);
 		}
 		case 'exclusion': {


### PR DESCRIPTION
## Why?
Ads on mobile fronts rendered by DCR were not displaying ad labels. This PR resolves that by wrapping the ads in an ad container and importing the required styles.

## Screenshots

| Before      | After      |
|-------------|------------|
| <img width="200" alt="Screenshot 2023-04-05 at 15 02 29" src="https://user-images.githubusercontent.com/108270776/230151088-1c5705e7-3877-4191-9c00-48d3dd5381e0.png"> |  <img width="200" alt="Screenshot 2023-04-05 at 17 51 25" src="https://user-images.githubusercontent.com/108270776/230151250-4270e4cd-9192-4b3d-a7e5-a973b7845719.png"> |


