### PR TITLE
CP scott desktop and below styles

### DIFF
--- a/dotcom-rendering/src/web/components/CpscottComponent.tsx
+++ b/dotcom-rendering/src/web/components/CpscottComponent.tsx
@@ -1,7 +1,6 @@
 import { css } from '@emotion/react';
-import { headline, neutral } from '@guardian/source-foundations';
+import { headline, neutral, until } from '@guardian/source-foundations';
 import { Link } from '@guardian/source-react-components';
-import { Hide } from './Hide';
 import { QuoteIcon } from './QuoteIcon';
 
 const scottAvatarStyles = css`
@@ -10,6 +9,9 @@ const scottAvatarStyles = css`
 	border-radius: 100%;
 	overflow: hidden;
 	background-color: #fcebde;
+	${until.mobileLandscape} {
+		margin-top: 5px;
+	}
 `;
 
 const scottPortraitStyles = css`
@@ -20,16 +22,39 @@ const scottTextStyles = css`
 	${headline.xxxsmall()}
 	font-size: 14px;
 	line-height: 16px;
+	${until.leftCol} {
+		margin-right: 10px;
+	}
+	${until.mobileLandscape} {
+		margin-top: 35px;
+	}
 `;
 
 const quoteLineStyles = css`
 	color: ${neutral[46]};
 `;
 
+const containerStyles = css`
+	${until.leftCol} {
+		display: flex;
+		flex-direction: row-reverse;
+		margin-top: -35px;
+		${until.mobileLandscape} {
+			justify-content: space-between;
+		}
+	}
+`;
+
+const textWrapStyle = css`
+	${until.mobileLandscape} {
+		display: inline-block;
+	}
+`;
+
 export const CPScottComponent = () => {
 	return (
 		<>
-			<Hide when="below" breakpoint="leftCol">
+			<div css={containerStyles}>
 				<div css={scottAvatarStyles}>
 					<img
 						css={scottPortraitStyles}
@@ -39,11 +64,11 @@ export const CPScottComponent = () => {
 				</div>
 				<div css={scottTextStyles}>
 					<div css={quoteLineStyles}>
-						<div>
+						<div css={textWrapStyle}>
 							<QuoteIcon colour={neutral[46]} />
 							Comment is free&hellip;
 						</div>
-						<div>but facts are sacred</div>
+						<div css={textWrapStyle}>but facts are sacred</div>
 					</div>
 					<Link
 						href={
@@ -58,7 +83,7 @@ export const CPScottComponent = () => {
 						CP Scott, 1921 Guardian editor
 					</Link>
 				</div>
-			</Hide>
+			</div>
 		</>
 	);
 };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Adds proper styling for smaller breakpoints
## Why?
Parity with frontend
## Screenshots

| Frontend tablet      | DCR tablet     |
|-------------|------------|
| ![before][] | ![after][] |
| Frontend mobile      | DCR mobile      |
|-------------|------------|
| ![before2][] | ![after2][] |

[before]: https://user-images.githubusercontent.com/110032454/230409705-b4ade757-0158-45c0-918f-167c69d17277.png
[after]: https://user-images.githubusercontent.com/110032454/230408451-18b684c1-d80d-4e3d-856c-821403902e31.png
[before2]: https://user-images.githubusercontent.com/110032454/230409864-4f89f15f-519e-484c-81f9-eaa95ac3898f.png
[after2]: https://user-images.githubusercontent.com/110032454/230408965-3d0c054c-ff2c-4b89-88cf-fc31aa33beb0.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->


<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
