### PR TITLE
Revert "feat: add disable AMP test"

### DIFF
--- a/dotcom-rendering/src/web/server/articleToHtml.tsx
+++ b/dotcom-rendering/src/web/server/articleToHtml.tsx
@@ -3,7 +3,6 @@ import {
 	BUILD_VARIANT,
 	dcrJavascriptBundle,
 } from '../../../scripts/webpack/bundles';
-import { getGroup } from '../../amp/components/ContentABTest';
 import { isAmpSupported } from '../../amp/components/Elements';
 import {
 	ASSET_ORIGIN,
@@ -18,11 +17,11 @@ import type { FEElement } from '../../types/content';
 import type { FEArticleType } from '../../types/frontend';
 import type { TagType } from '../../types/tag';
 import { ArticlePage } from '../components/ArticlePage';
-import { canRenderAds } from '../lib/canRenderAds';
 import { decideFormat } from '../lib/decideFormat';
 import { decideTheme } from '../lib/decideTheme';
 import { renderToStringWithEmotion } from '../lib/emotion';
 import { getHttp3Url } from '../lib/getHttp3Url';
+import { canRenderAds } from '../lib/canRenderAds';
 import { pageTemplate } from './pageTemplate';
 import { recipeSchema } from './temporaryRecipeStructuredData';
 
@@ -174,27 +173,8 @@ export const articleToHtml = ({ article }: Props): string => {
 		return `https://amp.theguardian.com/${article.pageId}`;
 	};
 
-	// I would have like to have had this closer to the implementation
-	// but we don't have `pageId` available in `pageTemplate.ts`, so this
-	// was as close as I could get it. It's a test and will be removed anywho.
-
-	// We are only including recently published articles to help with data normalisation
-	// hopefully we merge soon so we don't need to keep changing this.
-	const isNewArticle =
-		new Date(article.webPublicationDate) > new Date('2023-03-29');
-
-	// 0-5: control - don't disable link
-	// 6-11: variable - disable link
-	const disableAmpLinkGroup = getGroup(article.pageId);
-
-	const { disableAmpTest: inDisableAmpTest = false } =
-		article.config.switches;
-
-	const disableAmpLink =
-		isNewArticle && inDisableAmpTest && disableAmpLinkGroup > 5;
-
 	// Only include AMP link for interactives which have the 'ampinteractive' tag
-	const ampLink = disableAmpLink ? undefined : getAmpLink(article.tags);
+	const ampLink = getAmpLink(article.tags);
 
 	const { openGraphData } = article;
 	const { twitterData } = article;


### PR DESCRIPTION
Reverts guardian/dotcom-rendering#7489

Ends the Amp test. We will wait for the results from D&I and update the issue.