### PR TITLE
Load commercial bundle in ad-free

### DIFF
--- a/dotcom-rendering/src/web/server/articleToHtml.tsx
+++ b/dotcom-rendering/src/web/server/articleToHtml.tsx
@@ -21,7 +21,6 @@ import { decideFormat } from '../lib/decideFormat';
 import { decideTheme } from '../lib/decideTheme';
 import { renderToStringWithEmotion } from '../lib/emotion';
 import { getHttp3Url } from '../lib/getHttp3Url';
-import { canRenderAds } from '../lib/canRenderAds';
 import { pageTemplate } from './pageTemplate';
 import { recipeSchema } from './temporaryRecipeStructuredData';
 
@@ -100,15 +99,13 @@ export const articleToHtml = ({ article }: Props): string => {
 	 * Please talk to the dotcom platform team before adding more.
 	 * Scripts will be executed in the order they appear in this array
 	 */
-	const loadCommercial = canRenderAds(article);
 	const scriptTags = generateScriptTags(
 		[
 			polyfillIO,
 			...getScriptArrayFromFile('frameworks.js'),
 			...getScriptArrayFromFile('index.js'),
-			loadCommercial &&
-				(process.env.COMMERCIAL_BUNDLE_URL ??
-					article.config.commercialBundleUrl),
+			process.env.COMMERCIAL_BUNDLE_URL ??
+				article.config.commercialBundleUrl,
 			pageHasNonBootInteractiveElements &&
 				`${ASSET_ORIGIN}static/frontend/js/curl-with-js-and-domReady.js`,
 		]

--- a/dotcom-rendering/src/web/server/frontToHtml.tsx
+++ b/dotcom-rendering/src/web/server/frontToHtml.tsx
@@ -11,7 +11,6 @@ import type { DCRFrontType } from '../../types/front';
 import { FrontPage } from '../components/FrontPage';
 import { renderToStringWithEmotion } from '../lib/emotion';
 import { getHttp3Url } from '../lib/getHttp3Url';
-import { canRenderAds } from '../lib/canRenderAds';
 import { pageTemplate } from './pageTemplate';
 
 interface Props {
@@ -56,15 +55,13 @@ export const frontToHtml = ({ front }: Props): string => {
 	 * Please talk to the dotcom platform team before adding more.
 	 * Scripts will be executed in the order they appear in this array
 	 */
-	const loadCommercial = canRenderAds(front);
 	const scriptTags = generateScriptTags(
 		[
 			polyfillIO,
 			...getScriptArrayFromFile('frameworks.js'),
 			...getScriptArrayFromFile('index.js'),
-			loadCommercial &&
-				(process.env.COMMERCIAL_BUNDLE_URL ??
-					front.config.commercialBundleUrl),
+			process.env.COMMERCIAL_BUNDLE_URL ??
+				front.config.commercialBundleUrl,
 		]
 			.filter(isString)
 			.map((script) => (offerHttp3 ? getHttp3Url(script) : script)),


### PR DESCRIPTION
## What does this change?

Include the commercial bundle on all DCR-rendered articles and fronts, regardless of whether `canRenderAds(…)` returns true or false.

See also the [corresponding Frontend PR](https://github.com/guardian/frontend/pull/26063).

## Why?

This change was introduced in [here](https://github.com/guardian/dotcom-rendering/pull/7312) as a perf optimisation, to reduce the amount of JS an ad-free user has to download and parse. Since we know ad-free status server-side, we can make the decision of whether to ship the commercial bundle to users there.

However, this means that ad-free users don’t receive any of the modules in the commercial bundle, even those we expect to run, [for example here](https://github.com/guardian/commercial/blob/50f40ac5cab0111160e045069ba7bbc96eb63e44/bundle/src/bootstraps/standalone.commercial.ts#L81-L89). This causes issues such as:
- Not running Ipsos Mori and Comscore for ad-free users (whilst a user can be ad-free, they may still have consented to these vendors).
- Not being able to enter the Opt Out advertising AB test. This is important as we approach launch.
- Not being able to view ads by Accepting All having already Rejected All in the consent banner. This is because ad free users now no longer receive the JS that’s responsible for managing the ad free cookie.

## Next steps

We’d like to re-introducing this perf improvement if possible, and are looking at options such as:
- Decide server-side whether to supply a commercial bundle or an ad-free bundle, trying to minimise the amount of JS supplied to ad-free users in this new bundle.
- More effective code splitting in the commercial bundle - so ad-free users receive a minimal commercial bundle. This could have a performance impact on commercial users, since they’d have to make subsequent requests for additional bundles.
- Shake out as much JS as possible from the commercial bundle.