### PR TITLE
Update kicker design for action front cards

### DIFF
--- a/dotcom-rendering/fixtures/manual/trails.ts
+++ b/dotcom-rendering/fixtures/manual/trails.ts
@@ -70,6 +70,7 @@ export const trails: [
 		],
 		showMainVideo: false,
 		isExternalLink: false,
+		isActionCard: false,
 	},
 	{
 		url: 'https://www.theguardian.com/environment/2019/dec/02/migration-v-climate-europes-new-political-divide',
@@ -89,6 +90,7 @@ export const trails: [
 		showQuotedHeadline: false,
 		showMainVideo: false,
 		isExternalLink: false,
+		isActionCard: false,
 	},
 	{
 		url: 'https://www.theguardian.com/world/2019/nov/28/eu-parliament-declares-climate-emergency',
@@ -107,6 +109,7 @@ export const trails: [
 		showQuotedHeadline: false,
 		showMainVideo: false,
 		isExternalLink: false,
+		isActionCard: false,
 	},
 	{
 		url: 'https://www.theguardian.com/environment/2019/nov/27/climate-emergency-world-may-have-crossed-tipping-points',
@@ -124,6 +127,7 @@ export const trails: [
 		showQuotedHeadline: true,
 		showMainVideo: false,
 		isExternalLink: false,
+		isActionCard: false,
 	},
 	{
 		url: 'https://www.theguardian.com/world/2019/nov/26/european-parliament-split-on-declaring-climate-emergency',
@@ -141,6 +145,7 @@ export const trails: [
 		showQuotedHeadline: false,
 		showMainVideo: false,
 		isExternalLink: false,
+		isActionCard: false,
 	},
 	{
 		url: 'https://www.theguardian.com/world/2019/nov/23/north-pole-explorers-on-thin-ice-as-climate-change-hits-expedition',
@@ -159,6 +164,7 @@ export const trails: [
 		showQuotedHeadline: false,
 		showMainVideo: false,
 		isExternalLink: false,
+		isActionCard: false,
 	},
 	{
 		url: 'https://www.theguardian.com/environment/2019/oct/25/scientists-glacial-rivers-absorb-carbon-faster-rainforests',
@@ -178,6 +184,7 @@ export const trails: [
 		showQuotedHeadline: false,
 		showMainVideo: false,
 		isExternalLink: false,
+		isActionCard: false,
 	},
 	{
 		url: 'https://www.theguardian.com/business/2019/oct/20/uk-urges-world-bank-to-channel-more-money-into-tackling-climate-crisis',
@@ -196,6 +203,7 @@ export const trails: [
 		showQuotedHeadline: false,
 		showMainVideo: false,
 		isExternalLink: false,
+		isActionCard: false,
 	},
 
 	{
@@ -216,6 +224,7 @@ export const trails: [
 		showQuotedHeadline: false,
 		showMainVideo: false,
 		isExternalLink: false,
+		isActionCard: false,
 	},
 	{
 		url: 'https://www.theguardian.com/world/2021/feb/17/uk-to-begin-worlds-first-covid-human-challenge-study-within-weeks',
@@ -235,6 +244,7 @@ export const trails: [
 		showQuotedHeadline: false,
 		showMainVideo: false,
 		isExternalLink: false,
+		isActionCard: false,
 	},
 	{
 		url: 'https://www.theguardian.com/world/2021/feb/17/scottish-government-inadequately-prepared-for-covid-audit-scotland-report',
@@ -254,6 +264,7 @@ export const trails: [
 		showQuotedHeadline: false,
 		showMainVideo: false,
 		isExternalLink: false,
+		isActionCard: false,
 	},
 	{
 		url: 'https://www.theguardian.com/society/2021/feb/16/encouraging-signs-covid-vaccine-over-80s-deaths-fall-england',
@@ -273,6 +284,7 @@ export const trails: [
 		showQuotedHeadline: false,
 		showMainVideo: false,
 		isExternalLink: false,
+		isActionCard: false,
 	},
 	{
 		url: 'https://www.theguardian.com/world/2021/feb/16/contact-tracing-alone-has-little-impact-on-curbing-covid-spread-report-finds',
@@ -292,6 +304,7 @@ export const trails: [
 		showQuotedHeadline: false,
 		showMainVideo: false,
 		isExternalLink: false,
+		isActionCard: false,
 	},
 	{
 		url: 'https://www.theguardian.com/world/2021/feb/16/covid-almost-2m-more-people-asked-shield-england',
@@ -311,6 +324,7 @@ export const trails: [
 		showQuotedHeadline: false,
 		showMainVideo: false,
 		isExternalLink: false,
+		isActionCard: false,
 	},
 	{
 		url: 'https://www.theguardian.com/politics/live/2021/feb/16/uk-covid-live-coronavirus-sturgeon-return-scottish-schools-latest-updates',
@@ -330,6 +344,7 @@ export const trails: [
 		showQuotedHeadline: false,
 		showMainVideo: false,
 		isExternalLink: false,
+		isActionCard: false,
 	},
 	{
 		url: 'https://www.theguardian.com/uk-news/2021/feb/16/qcovid-how-improved-algorithm-can-identify-more-higher-risk-adults',
@@ -349,6 +364,7 @@ export const trails: [
 		showQuotedHeadline: false,
 		showMainVideo: false,
 		isExternalLink: false,
+		isActionCard: false,
 	},
 	{
 		url: 'https://www.theguardian.com/world/2019/nov/28/eu-parliament-declares-climate-emergency',
@@ -366,5 +382,6 @@ export const trails: [
 		showQuotedHeadline: false,
 		showMainVideo: false,
 		isExternalLink: false,
+		isActionCard: false,
 	},
 ];

--- a/dotcom-rendering/src/model/enhanceCards.ts
+++ b/dotcom-rendering/src/model/enhanceCards.ts
@@ -194,6 +194,11 @@ export const enhanceCards = (
 				? faciaCard.properties.href
 				: faciaCard.header.url;
 
+		// Action card is a new card type that invites users to take action as opposed to merely
+		// read, view, watch or listen.
+		const isActionCard =
+			tags.filter((tag) => tag.id === 'tone/callout').length > 0;
+
 		return {
 			format,
 			dataLinkName,
@@ -242,5 +247,6 @@ export const enhanceCards = (
 					?.duration,
 			showMainVideo: faciaCard.properties.showMainVideo,
 			isExternalLink: faciaCard.card.cardStyle.type === 'ExternalLink',
+			isActionCard,
 		};
 	});

--- a/dotcom-rendering/src/model/enhanceCards.ts
+++ b/dotcom-rendering/src/model/enhanceCards.ts
@@ -195,7 +195,7 @@ export const enhanceCards = (
 				: faciaCard.header.url;
 
 		// Action card is a new card type that invites users to take action as opposed to merely
-		// read, view, watch or listen.
+		// read, view, watch or listen
 		const isActionCard =
 			tags.filter((tag) => tag.id === 'tone/callout').length > 0;
 

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -263,6 +263,7 @@ export type DCRFrontCard = {
 	mediaDuration?: number;
 	showMainVideo: boolean;
 	isExternalLink: boolean;
+	isActionCard: boolean;
 };
 
 export type FESnapType = {

--- a/dotcom-rendering/src/types/palette.ts
+++ b/dotcom-rendering/src/types/palette.ts
@@ -58,6 +58,7 @@ export type Palette = {
 		filterButtonActive: Colour;
 		betaLabel: Colour;
 		designTag: Colour;
+		kickerLabel: Colour;
 		dateLine: Colour;
 		tableOfContents: Colour;
 	};
@@ -95,6 +96,7 @@ export type Palette = {
 		filterButtonActive: Colour;
 		treat: Colour;
 		designTag: Colour;
+		kickerLabel: Colour;
 		pullQuote: Colour;
 		messageForm: Colour;
 	};

--- a/dotcom-rendering/src/web/components/Card/Card.stories.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.stories.tsx
@@ -230,21 +230,6 @@ export const WithActionKickerWithDifferentHeadlineSizes = () => {
 	return (
 		<>
 			<CardGroup>
-				{/* <CardWrapper>
-					<Card
-						{...basicCardProps}
-						kickerText="Kicker"
-						headlineSize="tiny"
-						headlineText="Heading tiny"
-						isActionCard={true}
-						byline="Byline text"
-						showByline={true}
-						format={newsTheme}
-					/>
-					<br></br>
-					<div>Heading size: 14px</div>
-					<div>Kicker size: 12px</div>
-				</CardWrapper> */}
 				<CardWrapper>
 					<Card
 						{...basicCardProps}
@@ -324,28 +309,6 @@ export const WithActionKickerWithDifferentHeadlineSizes = () => {
 					<div>Heading size: 28px</div>
 					<div>Kicker size: 20px</div>
 				</CardWrapper>
-				{/* <CardWrapper>
-					<Card
-						{...basicCardProps}
-						kickerText="Kicker"
-						headlineSize="ginormous"
-						headlineText="Heading ginormous"
-						isActionCard={true}
-						format={sportTheme}
-					/>
-					<br></br>
-					<div>
-						<strong>Until desktop</strong>
-					</div>
-					<div>Heading size: 42px</div>
-					<div>Kicker size: 20px</div>
-					<br></br>
-					<div>
-						<strong>From desktop</strong>
-					</div>
-					<div>Heading size: 50px</div>
-					<div>Kicker size: 20px</div>
-				</CardWrapper> */}
 			</CardGroup>
 		</>
 	);
@@ -354,21 +317,6 @@ export const WithActionKickerWithDifferentHeadlineSizes = () => {
 export const WithLongActionKickerWithDifferentHeadlineSizes = () => {
 	return (
 		<CardGroup>
-			{/* <CardWrapper>
-				<Card
-					{...basicCardProps}
-					kickerText="this is a gggg very long kicker that"
-					headlineSize="tiny"
-					headlineText="tiny"
-					isActionCard={true}
-					byline="Byline text"
-					showByline={true}
-					format={newsTheme}
-				/>
-				<br></br>
-				<div>Heading size: 14px</div>
-				<div>Kicker size: 12px</div>
-			</CardWrapper> */}
 			<CardWrapper>
 				<Card
 					{...basicCardProps}
@@ -448,28 +396,6 @@ export const WithLongActionKickerWithDifferentHeadlineSizes = () => {
 				<div>Heading size: 28px</div>
 				<div>Kicker size: 20px</div>
 			</CardWrapper>
-			{/* <CardWrapper>
-				<Card
-					{...basicCardProps}
-					kickerText="this is a gggg very long kicker that"
-					headlineSize="ginormous"
-					headlineText="ginormous"
-					isActionCard={true}
-					format={sportTheme}
-				/>
-				<br></br>
-				<div>
-					<strong>Until desktop</strong>
-				</div>
-				<div>Heading size: 42px</div>
-				<div>Kicker size: 20px</div>
-				<br></br>
-				<div>
-					<strong>From desktop</strong>
-				</div>
-				<div>Heading size: 50px</div>
-				<div>Kicker size: 20px</div>
-			</CardWrapper> */}
 		</CardGroup>
 	);
 };

--- a/dotcom-rendering/src/web/components/Card/Card.stories.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.stories.tsx
@@ -232,7 +232,7 @@ export const WithActionKickerWithDifferentHeadlineSizes = () => {
 			<CardWrapper>
 				<Card
 					{...basicCardProps}
-					kickerText="this is a very long kicker"
+					kickerText="kicker"
 					headlineSize="tiny"
 					headlineText="tiny"
 					isActionCard={true}
@@ -264,7 +264,7 @@ export const WithActionKickerWithDifferentHeadlineSizes = () => {
 			<CardWrapper>
 				<Card
 					{...basicCardProps}
-					kickerText="this is a very long kicker"
+					kickerText="kicker"
 					headlineSize="large"
 					headlineText="large"
 					isActionCard={true}
@@ -277,6 +277,85 @@ export const WithActionKickerWithDifferentHeadlineSizes = () => {
 					kickerText="kicker"
 					headlineSize="huge"
 					headlineText="huge"
+					isActionCard={true}
+					format={sportTheme}
+				/>
+			</CardWrapper>
+			<CardWrapper>
+				<Card
+					{...basicCardProps}
+					kickerText="kicker"
+					headlineSize="ginormous"
+					headlineText="ginormous"
+					isActionCard={true}
+					format={sportTheme}
+				/>
+			</CardWrapper>
+		</CardGroup>
+	);
+};
+
+export const WithLongActionKickerWithDifferentHeadlineSizes = () => {
+	return (
+		<CardGroup>
+			<CardWrapper>
+				<Card
+					{...basicCardProps}
+					kickerText="this is a gggg very long kicker that"
+					headlineSize="tiny"
+					headlineText="tiny"
+					isActionCard={true}
+					byline="Byline text"
+					showByline={true}
+					format={newsTheme}
+				/>
+			</CardWrapper>
+			<CardWrapper>
+				<Card
+					{...basicCardProps}
+					kickerText="this is a gggg very long kicker that"
+					headlineSize="small"
+					headlineText="small"
+					isActionCard={true}
+					format={opinionTheme}
+				/>
+			</CardWrapper>
+			<CardWrapper>
+				<Card
+					{...basicCardProps}
+					kickerText="this is a gggg very long kicker that"
+					headlineSize="medium"
+					headlineText="medium"
+					isActionCard={true}
+					format={cultureTheme}
+				/>
+			</CardWrapper>
+			<CardWrapper>
+				<Card
+					{...basicCardProps}
+					kickerText="this is a gggg very long kicker that"
+					headlineSize="large"
+					headlineText="large"
+					isActionCard={true}
+					format={lifestyleTheme}
+				/>
+			</CardWrapper>
+			<CardWrapper>
+				<Card
+					{...basicCardProps}
+					kickerText="this is a gggg very long kicker that"
+					headlineSize="huge"
+					headlineText="huge"
+					isActionCard={true}
+					format={sportTheme}
+				/>
+			</CardWrapper>
+			<CardWrapper>
+				<Card
+					{...basicCardProps}
+					kickerText="this is a gggg very long kicker that"
+					headlineSize="ginormous"
+					headlineText="ginormous"
 					isActionCard={true}
 					format={sportTheme}
 				/>

--- a/dotcom-rendering/src/web/components/Card/Card.stories.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.stories.tsx
@@ -13,13 +13,39 @@ import { Card } from './Card';
 import { LI } from './components/LI';
 import { UL } from './components/UL';
 
+const newsTheme = {
+	display: ArticleDisplay.Standard,
+	design: ArticleDesign.Standard,
+	theme: ArticlePillar.News,
+};
+
+const opinionTheme = {
+	display: ArticleDisplay.Standard,
+	design: ArticleDesign.Standard,
+	theme: ArticlePillar.Opinion,
+};
+
+const sportTheme = {
+	display: ArticleDisplay.Standard,
+	design: ArticleDesign.Standard,
+	theme: ArticlePillar.Sport,
+};
+
+const cultureTheme = {
+	display: ArticleDisplay.Standard,
+	design: ArticleDesign.Standard,
+	theme: ArticlePillar.Culture,
+};
+
+const lifestyleTheme = {
+	display: ArticleDisplay.Standard,
+	design: ArticleDesign.Standard,
+	theme: ArticlePillar.Lifestyle,
+};
+
 const basicCardProps: CardProps = {
 	linkTo: '',
-	format: {
-		display: ArticleDisplay.Standard,
-		design: ArticleDesign.Standard,
-		theme: ArticlePillar.News,
-	},
+	format: newsTheme,
 	headlineText: 'Headline text',
 	trailText:
 		'The 29-year-old source behind the biggest intelligence leak in the NSA’s history explains his motives',
@@ -31,16 +57,13 @@ const basicCardProps: CardProps = {
 	imagePosition: 'top',
 	showAge: true,
 	isExternalLink: false,
+	isActionCard: false,
 };
 
 const aBasicLink = {
 	headline: 'Headline',
 	url: 'https://www.theguardian.com',
-	format: {
-		display: ArticleDisplay.Standard,
-		design: ArticleDesign.Standard,
-		theme: ArticlePillar.News,
-	},
+	format: newsTheme,
 };
 
 const CardWrapper = ({ children }: { children: React.ReactNode }) => {
@@ -197,6 +220,65 @@ export const WithDifferentHeadlineSizes = () => {
 					{...basicCardProps}
 					headlineSize="large"
 					headlineText="large"
+				/>
+			</CardWrapper>
+		</CardGroup>
+	);
+};
+
+export const WithActionKickerWithDifferentHeadlineSizes = () => {
+	return (
+		<CardGroup>
+			<CardWrapper>
+				<Card
+					{...basicCardProps}
+					kickerText="this is a very long kicker"
+					headlineSize="tiny"
+					headlineText="tiny"
+					isActionCard={true}
+					byline="Byline text"
+					showByline={true}
+					format={newsTheme}
+				/>
+			</CardWrapper>
+			<CardWrapper>
+				<Card
+					{...basicCardProps}
+					kickerText="kicker"
+					headlineSize="small"
+					headlineText="small"
+					isActionCard={true}
+					format={opinionTheme}
+				/>
+			</CardWrapper>
+			<CardWrapper>
+				<Card
+					{...basicCardProps}
+					kickerText="kicker"
+					headlineSize="medium"
+					headlineText="medium"
+					isActionCard={true}
+					format={cultureTheme}
+				/>
+			</CardWrapper>
+			<CardWrapper>
+				<Card
+					{...basicCardProps}
+					kickerText="this is a very long kicker"
+					headlineSize="large"
+					headlineText="large"
+					isActionCard={true}
+					format={lifestyleTheme}
+				/>
+			</CardWrapper>
+			<CardWrapper>
+				<Card
+					{...basicCardProps}
+					kickerText="kicker"
+					headlineSize="huge"
+					headlineText="huge"
+					isActionCard={true}
+					format={sportTheme}
 				/>
 			</CardWrapper>
 		</CardGroup>

--- a/dotcom-rendering/src/web/components/Card/Card.stories.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.stories.tsx
@@ -228,70 +228,126 @@ export const WithDifferentHeadlineSizes = () => {
 
 export const WithActionKickerWithDifferentHeadlineSizes = () => {
 	return (
-		<CardGroup>
-			<CardWrapper>
-				<Card
-					{...basicCardProps}
-					kickerText="kicker"
-					headlineSize="tiny"
-					headlineText="tiny"
-					isActionCard={true}
-					byline="Byline text"
-					showByline={true}
-					format={newsTheme}
-				/>
-			</CardWrapper>
-			<CardWrapper>
-				<Card
-					{...basicCardProps}
-					kickerText="kicker"
-					headlineSize="small"
-					headlineText="small"
-					isActionCard={true}
-					format={opinionTheme}
-				/>
-			</CardWrapper>
-			<CardWrapper>
-				<Card
-					{...basicCardProps}
-					kickerText="kicker"
-					headlineSize="medium"
-					headlineText="medium"
-					isActionCard={true}
-					format={cultureTheme}
-				/>
-			</CardWrapper>
-			<CardWrapper>
-				<Card
-					{...basicCardProps}
-					kickerText="kicker"
-					headlineSize="large"
-					headlineText="large"
-					isActionCard={true}
-					format={lifestyleTheme}
-				/>
-			</CardWrapper>
-			<CardWrapper>
-				<Card
-					{...basicCardProps}
-					kickerText="kicker"
-					headlineSize="huge"
-					headlineText="huge"
-					isActionCard={true}
-					format={sportTheme}
-				/>
-			</CardWrapper>
-			<CardWrapper>
-				<Card
-					{...basicCardProps}
-					kickerText="kicker"
-					headlineSize="ginormous"
-					headlineText="ginormous"
-					isActionCard={true}
-					format={sportTheme}
-				/>
-			</CardWrapper>
-		</CardGroup>
+		<>
+			<CardGroup>
+				<CardWrapper>
+					<Card
+						{...basicCardProps}
+						kickerText="kicker"
+						headlineSize="tiny"
+						headlineText="tiny"
+						isActionCard={true}
+						byline="Byline text"
+						showByline={true}
+						format={newsTheme}
+					/>
+					<br></br>
+					<div>Heading size: 14px</div>
+					<div>Kicker size: 12px</div>
+				</CardWrapper>
+				<CardWrapper>
+					<Card
+						{...basicCardProps}
+						kickerText="kicker"
+						headlineSize="small"
+						headlineText="small"
+						isActionCard={true}
+						format={opinionTheme}
+					/>
+					<br></br>
+					<div>Heading size: 17px</div>
+					<div>Kicker size: 14px</div>
+				</CardWrapper>
+				<CardWrapper>
+					<Card
+						{...basicCardProps}
+						kickerText="kicker"
+						headlineSize="medium"
+						headlineText="medium"
+						isActionCard={true}
+						format={cultureTheme}
+					/>
+					<br></br>
+					<div>
+						<strong>Until desktop</strong>
+					</div>
+					<div>Heading size: 17px</div>
+					<div>Kicker size: 14px</div>
+					<br></br>
+					<div>
+						<strong>From desktop</strong>
+					</div>
+					<div>Heading size: 20px</div>
+					<div>Kicker size: 15px</div>
+				</CardWrapper>
+				<CardWrapper>
+					<Card
+						{...basicCardProps}
+						kickerText="kicker"
+						headlineSize="large"
+						headlineText="large"
+						isActionCard={true}
+						format={lifestyleTheme}
+					/>
+					<br></br>
+					<div>
+						<strong>Until desktop</strong>
+					</div>
+					<div>Heading size: 20px</div>
+					<div>Kicker size: 15px</div>
+					<br></br>
+					<div>
+						<strong>From desktop</strong>
+					</div>
+					<div>Heading size: 24px</div>
+					<div>Kicker size: 17px</div>
+				</CardWrapper>
+				<CardWrapper>
+					<Card
+						{...basicCardProps}
+						kickerText="kicker"
+						headlineSize="huge"
+						headlineText="huge"
+						isActionCard={true}
+						format={sportTheme}
+					/>
+					<br></br>
+					<div>
+						<strong>Until desktop</strong>
+					</div>
+					<div>Heading size: 20px</div>
+					<div>Kicker size: 17px</div>
+					<br></br>
+					<div>
+						<strong>From desktop</strong>
+					</div>
+					<div>Heading size: 24px</div>
+					<div>Kicker size: 17px</div>
+				</CardWrapper>
+				<CardWrapper>
+					<Card
+						{...basicCardProps}
+						kickerText="kicker"
+						headlineSize="ginormous"
+						headlineText="ginormous"
+						isActionCard={true}
+						format={sportTheme}
+					/>
+					<br></br>
+					<div>
+						<strong>Until desktop</strong>
+					</div>
+					<div>Heading size: 42px</div>
+					<div>Kicker size: 20px</div>
+					<br></br>
+					<div>
+						<strong>From desktop</strong>
+					</div>
+					<div>Heading size: 50px</div>
+					<div>Kicker size: 20px</div>
+				</CardWrapper>
+			</CardGroup>
+		</>
 	);
 };
 
@@ -309,6 +365,9 @@ export const WithLongActionKickerWithDifferentHeadlineSizes = () => {
 					showByline={true}
 					format={newsTheme}
 				/>
+				<br></br>
+				<div>Heading size: 14px</div>
+				<div>Kicker size: 12px</div>
 			</CardWrapper>
 			<CardWrapper>
 				<Card
@@ -319,6 +378,9 @@ export const WithLongActionKickerWithDifferentHeadlineSizes = () => {
 					isActionCard={true}
 					format={opinionTheme}
 				/>
+				<br></br>
+				<div>Heading size: 17px</div>
+				<div>Kicker size: 14px</div>
 			</CardWrapper>
 			<CardWrapper>
 				<Card
@@ -329,6 +391,18 @@ export const WithLongActionKickerWithDifferentHeadlineSizes = () => {
 					isActionCard={true}
 					format={cultureTheme}
 				/>
+				<br></br>
+				<div>
+					<strong>Until desktop</strong>
+				</div>
+				<div>Heading size: 17px</div>
+				<div>Kicker size: 14px</div>
+				<br></br>
+				<div>
+					<strong>From desktop</strong>
+				</div>
+				<div>Heading size: 20px</div>
+				<div>Kicker size: 15px</div>
 			</CardWrapper>
 			<CardWrapper>
 				<Card
@@ -339,6 +413,18 @@ export const WithLongActionKickerWithDifferentHeadlineSizes = () => {
 					isActionCard={true}
 					format={lifestyleTheme}
 				/>
+				<br></br>
+				<div>
+					<strong>Until desktop</strong>
+				</div>
+				<div>Heading size: 20px</div>
+				<div>Kicker size: 15px</div>
+				<br></br>
+				<div>
+					<strong>From desktop</strong>
+				</div>
+				<div>Heading size: 24px</div>
+				<div>Kicker size: 17px</div>
 			</CardWrapper>
 			<CardWrapper>
 				<Card
@@ -349,6 +435,18 @@ export const WithLongActionKickerWithDifferentHeadlineSizes = () => {
 					isActionCard={true}
 					format={sportTheme}
 				/>
+				<br></br>
+				<div>
+					<strong>Until desktop</strong>
+				</div>
+				<div>Heading size: 20px</div>
+				<div>Kicker size: 17px</div>
+				<br></br>
+				<div>
+					<strong>From desktop</strong>
+				</div>
+				<div>Heading size: 24px</div>
+				<div>Kicker size: 17px</div>
 			</CardWrapper>
 			<CardWrapper>
 				<Card
@@ -359,6 +457,18 @@ export const WithLongActionKickerWithDifferentHeadlineSizes = () => {
 					isActionCard={true}
 					format={sportTheme}
 				/>
+				<br></br>
+				<div>
+					<strong>Until desktop</strong>
+				</div>
+				<div>Heading size: 42px</div>
+				<div>Kicker size: 20px</div>
+				<br></br>
+				<div>
+					<strong>From desktop</strong>
+				</div>
+				<div>Heading size: 50px</div>
+				<div>Kicker size: 20px</div>
 			</CardWrapper>
 		</CardGroup>
 	);

--- a/dotcom-rendering/src/web/components/Card/Card.stories.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.stories.tsx
@@ -230,12 +230,12 @@ export const WithActionKickerWithDifferentHeadlineSizes = () => {
 	return (
 		<>
 			<CardGroup>
-				<CardWrapper>
+				{/* <CardWrapper>
 					<Card
 						{...basicCardProps}
-						kickerText="kicker"
+						kickerText="Kicker"
 						headlineSize="tiny"
-						headlineText="tiny"
+						headlineText="Heading tiny"
 						isActionCard={true}
 						byline="Byline text"
 						showByline={true}
@@ -244,13 +244,13 @@ export const WithActionKickerWithDifferentHeadlineSizes = () => {
 					<br></br>
 					<div>Heading size: 14px</div>
 					<div>Kicker size: 12px</div>
-				</CardWrapper>
+				</CardWrapper> */}
 				<CardWrapper>
 					<Card
 						{...basicCardProps}
-						kickerText="kicker"
+						kickerText="Kicker"
 						headlineSize="small"
-						headlineText="small"
+						headlineText="Heading small"
 						isActionCard={true}
 						format={opinionTheme}
 					/>
@@ -261,9 +261,9 @@ export const WithActionKickerWithDifferentHeadlineSizes = () => {
 				<CardWrapper>
 					<Card
 						{...basicCardProps}
-						kickerText="kicker"
+						kickerText="Kicker"
 						headlineSize="medium"
-						headlineText="medium"
+						headlineText="Heading medium"
 						isActionCard={true}
 						format={cultureTheme}
 					/>
@@ -283,9 +283,9 @@ export const WithActionKickerWithDifferentHeadlineSizes = () => {
 				<CardWrapper>
 					<Card
 						{...basicCardProps}
-						kickerText="kicker"
+						kickerText="Kicker"
 						headlineSize="large"
-						headlineText="large"
+						headlineText="Heading large"
 						isActionCard={true}
 						format={lifestyleTheme}
 					/>
@@ -305,9 +305,9 @@ export const WithActionKickerWithDifferentHeadlineSizes = () => {
 				<CardWrapper>
 					<Card
 						{...basicCardProps}
-						kickerText="kicker"
+						kickerText="Kicker"
 						headlineSize="huge"
-						headlineText="huge"
+						headlineText="Heading Huge"
 						isActionCard={true}
 						format={sportTheme}
 					/>
@@ -315,21 +315,21 @@ export const WithActionKickerWithDifferentHeadlineSizes = () => {
 					<div>
 						<strong>Until desktop</strong>
 					</div>
-					<div>Heading size: 20px</div>
+					<div>Heading size: 24px</div>
 					<div>Kicker size: 17px</div>
 					<br></br>
 					<div>
 						<strong>From desktop</strong>
 					</div>
-					<div>Heading size: 24px</div>
-					<div>Kicker size: 17px</div>
+					<div>Heading size: 28px</div>
+					<div>Kicker size: 20px</div>
 				</CardWrapper>
-				<CardWrapper>
+				{/* <CardWrapper>
 					<Card
 						{...basicCardProps}
-						kickerText="kicker"
+						kickerText="Kicker"
 						headlineSize="ginormous"
-						headlineText="ginormous"
+						headlineText="Heading ginormous"
 						isActionCard={true}
 						format={sportTheme}
 					/>
@@ -345,7 +345,7 @@ export const WithActionKickerWithDifferentHeadlineSizes = () => {
 					</div>
 					<div>Heading size: 50px</div>
 					<div>Kicker size: 20px</div>
-				</CardWrapper>
+				</CardWrapper> */}
 			</CardGroup>
 		</>
 	);
@@ -354,7 +354,7 @@ export const WithActionKickerWithDifferentHeadlineSizes = () => {
 export const WithLongActionKickerWithDifferentHeadlineSizes = () => {
 	return (
 		<CardGroup>
-			<CardWrapper>
+			{/* <CardWrapper>
 				<Card
 					{...basicCardProps}
 					kickerText="this is a gggg very long kicker that"
@@ -368,7 +368,7 @@ export const WithLongActionKickerWithDifferentHeadlineSizes = () => {
 				<br></br>
 				<div>Heading size: 14px</div>
 				<div>Kicker size: 12px</div>
-			</CardWrapper>
+			</CardWrapper> */}
 			<CardWrapper>
 				<Card
 					{...basicCardProps}
@@ -439,16 +439,16 @@ export const WithLongActionKickerWithDifferentHeadlineSizes = () => {
 				<div>
 					<strong>Until desktop</strong>
 				</div>
-				<div>Heading size: 20px</div>
+				<div>Heading size: 24px</div>
 				<div>Kicker size: 17px</div>
 				<br></br>
 				<div>
 					<strong>From desktop</strong>
 				</div>
-				<div>Heading size: 24px</div>
-				<div>Kicker size: 17px</div>
+				<div>Heading size: 28px</div>
+				<div>Kicker size: 20px</div>
 			</CardWrapper>
-			<CardWrapper>
+			{/* <CardWrapper>
 				<Card
 					{...basicCardProps}
 					kickerText="this is a gggg very long kicker that"
@@ -469,7 +469,7 @@ export const WithLongActionKickerWithDifferentHeadlineSizes = () => {
 				</div>
 				<div>Heading size: 50px</div>
 				<div>Kicker size: 20px</div>
-			</CardWrapper>
+			</CardWrapper> */}
 		</CardGroup>
 	);
 };

--- a/dotcom-rendering/src/web/components/Card/Card.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.tsx
@@ -27,7 +27,7 @@ import { CardAge } from './components/CardAge';
 import { CardBranding } from './components/CardBranding';
 import { CardFooter } from './components/CardFooter';
 import { CardLayout } from './components/CardLayout';
-//import { CardLink } from './components/CardLink';
+import { CardLink } from './components/CardLink';
 import { CardWrapper } from './components/CardWrapper';
 import { ContentWrapper } from './components/ContentWrapper';
 import { HeadlineWrapper } from './components/HeadlineWrapper';
@@ -359,12 +359,12 @@ export const Card = ({
 			containerType={containerType}
 			isDynamo={isDynamo}
 		>
-			{/* <CardLink
+			<CardLink
 				linkTo={linkTo}
 				headlineText={headlineText}
 				dataLinkName={dataLinkName}
 				isExternalLink={isExternalLink}
-			/> */}
+			/>
 			<CardLayout
 				imagePosition={imagePosition}
 				imagePositionOnMobile={imagePositionOnMobile}

--- a/dotcom-rendering/src/web/components/Card/Card.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.tsx
@@ -27,6 +27,7 @@ import { CardAge } from './components/CardAge';
 import { CardBranding } from './components/CardBranding';
 import { CardFooter } from './components/CardFooter';
 import { CardLayout } from './components/CardLayout';
+import { CardLink } from './components/CardLink';
 import { CardWrapper } from './components/CardWrapper';
 import { ContentWrapper } from './components/ContentWrapper';
 import { HeadlineWrapper } from './components/HeadlineWrapper';
@@ -358,13 +359,12 @@ export const Card = ({
 			containerType={containerType}
 			isDynamo={isDynamo}
 		>
-			{/* temparily removed this to select the inner elements ion dev tool more easily */}
-			{/* <CardLink
+			<CardLink
 				linkTo={linkTo}
 				headlineText={headlineText}
 				dataLinkName={dataLinkName}
 				isExternalLink={isExternalLink}
-			/> */}
+			/>
 			<CardLayout
 				imagePosition={imagePosition}
 				imagePositionOnMobile={imagePositionOnMobile}

--- a/dotcom-rendering/src/web/components/Card/Card.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.tsx
@@ -74,6 +74,7 @@ export type Props = {
 	/** The first card in a dynamic package is ”Dynamo” and gets special styling */
 	isDynamo?: true;
 	isExternalLink: boolean;
+	isActionCard: boolean;
 };
 
 const StarRatingComponent = ({
@@ -258,6 +259,7 @@ export const Card = ({
 	isDynamo,
 	isCrossword,
 	isExternalLink,
+	isActionCard,
 }: Props) => {
 	const palette = decidePalette(format, containerPalette);
 
@@ -433,6 +435,7 @@ export const Card = ({
 							showByline={showByline}
 							isDynamo={isDynamo}
 							isExternalLink={isExternalLink}
+							isActionCard={isActionCard}
 						/>
 						{starRating !== undefined ? (
 							<StarRatingComponent

--- a/dotcom-rendering/src/web/components/Card/Card.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.tsx
@@ -27,7 +27,7 @@ import { CardAge } from './components/CardAge';
 import { CardBranding } from './components/CardBranding';
 import { CardFooter } from './components/CardFooter';
 import { CardLayout } from './components/CardLayout';
-import { CardLink } from './components/CardLink';
+//import { CardLink } from './components/CardLink';
 import { CardWrapper } from './components/CardWrapper';
 import { ContentWrapper } from './components/ContentWrapper';
 import { HeadlineWrapper } from './components/HeadlineWrapper';
@@ -359,12 +359,12 @@ export const Card = ({
 			containerType={containerType}
 			isDynamo={isDynamo}
 		>
-			<CardLink
+			{/* <CardLink
 				linkTo={linkTo}
 				headlineText={headlineText}
 				dataLinkName={dataLinkName}
 				isExternalLink={isExternalLink}
-			/>
+			/> */}
 			<CardLayout
 				imagePosition={imagePosition}
 				imagePositionOnMobile={imagePositionOnMobile}

--- a/dotcom-rendering/src/web/components/Card/Card.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.tsx
@@ -27,7 +27,6 @@ import { CardAge } from './components/CardAge';
 import { CardBranding } from './components/CardBranding';
 import { CardFooter } from './components/CardFooter';
 import { CardLayout } from './components/CardLayout';
-import { CardLink } from './components/CardLink';
 import { CardWrapper } from './components/CardWrapper';
 import { ContentWrapper } from './components/ContentWrapper';
 import { HeadlineWrapper } from './components/HeadlineWrapper';
@@ -359,12 +358,13 @@ export const Card = ({
 			containerType={containerType}
 			isDynamo={isDynamo}
 		>
-			<CardLink
+			{/* temparily removed this to select the inner elements ion dev tool more easily */}
+			{/* <CardLink
 				linkTo={linkTo}
 				headlineText={headlineText}
 				dataLinkName={dataLinkName}
 				isExternalLink={isExternalLink}
-			/>
+			/> */}
 			<CardLayout
 				imagePosition={imagePosition}
 				imagePositionOnMobile={imagePositionOnMobile}

--- a/dotcom-rendering/src/web/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/web/components/CardHeadline.tsx
@@ -7,10 +7,16 @@ import {
 	from,
 	headline,
 	space,
+	palette as srcPallet,
 	textSans,
 	until,
 } from '@guardian/source-foundations';
-import { Link, SvgExternal } from '@guardian/source-react-components';
+import {
+	Button,
+	Link,
+	SvgArrowRightStraight,
+	SvgExternal,
+} from '@guardian/source-react-components';
 import React from 'react';
 import type { DCRContainerPalette } from '../../types/front';
 import type { Palette } from '../../types/palette';
@@ -36,6 +42,7 @@ type Props = {
 	linkTo?: string; // If provided, the headline is wrapped in a link
 	isDynamo?: true;
 	isExternalLink?: boolean;
+	isActionCard?: boolean;
 };
 
 const fontStyles = ({
@@ -193,6 +200,16 @@ const lineStyles = (palette: Palette) => css`
 	}
 `;
 
+const tellUsButtonStyles = css`
+	margin: 8px 0px;
+	display: flex;
+	color: ${srcPallet.neutral[7]};
+	border-color: ${srcPallet.neutral[0]};
+	svg {
+		color: ${srcPallet.neutral[0]};
+	}
+`;
+
 const dynamoStyles = css`
 	display: block;
 	font-weight: ${fontWeights.medium};
@@ -241,6 +258,7 @@ export const CardHeadline = ({
 	linkTo,
 	isDynamo,
 	isExternalLink,
+	isActionCard,
 }: Props) => {
 	const palette = decidePalette(format, containerPalette);
 	const kickerColour = isDynamo
@@ -275,6 +293,9 @@ export const CardHeadline = ({
 								color={kickerColour}
 								showPulsingDot={showPulsingDot}
 								hideLineBreak={hideLineBreak}
+								isAction={isActionCard}
+								format={format}
+								size={size}
 							/>
 						</>
 					)}
@@ -308,6 +329,19 @@ export const CardHeadline = ({
 					size={size}
 					isCard={true}
 				/>
+			)}
+			{isActionCard ? (
+				<Button
+					priority="tertiary"
+					size="xsmall"
+					icon={<SvgArrowRightStraight />}
+					iconSide="right"
+					cssOverrides={tellUsButtonStyles}
+				>
+					Tell us
+				</Button>
+			) : (
+				<></>
 			)}
 		</>
 	);

--- a/dotcom-rendering/src/web/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/web/components/CardHeadline.tsx
@@ -296,6 +296,7 @@ export const CardHeadline = ({
 								isAction={isActionCard}
 								format={format}
 								size={size}
+								sizeOnMobile={sizeOnMobile}
 							/>
 						</>
 					)}

--- a/dotcom-rendering/src/web/components/Carousel.importable.tsx
+++ b/dotcom-rendering/src/web/components/Carousel.importable.tsx
@@ -380,6 +380,7 @@ const CarouselCard = ({
 			discussionId={discussionId}
 			branding={branding}
 			isExternalLink={false}
+			isActionCard={false}
 		/>
 	</LI>
 );

--- a/dotcom-rendering/src/web/components/FrontCard.tsx
+++ b/dotcom-rendering/src/web/components/FrontCard.tsx
@@ -47,6 +47,7 @@ export const FrontCard = (props: Props) => {
 		avatarUrl: trail.avatarUrl,
 		showMainVideo: trail.showMainVideo,
 		isExternalLink: trail.isExternalLink,
+		isActionCard: trail.isActionCard,
 	};
 
 	return Card({ ...defaultProps, ...cardProps });

--- a/dotcom-rendering/src/web/components/Kicker.tsx
+++ b/dotcom-rendering/src/web/components/Kicker.tsx
@@ -172,7 +172,7 @@ export const Kicker = ({
 }: Props) => {
 	const palette = decidePalette(format);
 
-	if (isAction) {
+	if (!isAction) {
 		return (
 			<div
 				css={[

--- a/dotcom-rendering/src/web/components/Kicker.tsx
+++ b/dotcom-rendering/src/web/components/Kicker.tsx
@@ -51,37 +51,38 @@ const actionKickerFontStyles = (size: SmallHeadlineSize) => {
 			`;
 		case 'huge':
 			return css`
-				margin-bottom: 4.5px;
-				margin-top: -1px;
+				margin-bottom: 3.5px;
+				margin-top: -2px;
 				span {
 					font-size: 20px;
-					padding: 3px 5px 4px 5px;
+					padding: 2px 5px 3px 5px;
 				}
 			`;
 		case 'large':
 			return css`
-				margin-bottom: 3px;
+				margin-bottom: 1px;
 				margin-top: -1px;
 				span {
 					font-size: 17px;
-					padding: 2px 5px 3px 5px;
+					padding: 2px 5px 2px 5px;
 				}
 			`;
 		case 'medium':
 			return css`
-				margin-bottom: 2px;
+				margin-bottom: 1px;
+				margin-top: -1px;
 				span {
 					font-size: 15px;
-					padding: 2px 4px 2px 4px;
+					padding: 1px 4px 2px 4px;
 				}
 			`;
 		case 'small':
 			return css`
-				margin-top: 1px;
+				margin-top: 0;
 				margin-bottom: 2.5px;
 				span {
 					font-size: 14px;
-					padding: 2px 4px 2px 4px;
+					padding: 1px 4px 2px 4px;
 				}
 			`;
 		case 'tiny':
@@ -112,12 +113,12 @@ const actionKickerFontStylesOnMobile = (size: SmallHeadlineSize) => {
 		case 'huge':
 			return css`
 				${until.desktop} {
-					margin-bottom: 3.5px;
+					margin-bottom: 1.5px;
 					margin-top: -1px;
 				}
 				span {
 					${until.desktop} {
-						padding: 2px 5px 3px 5px;
+						padding: 2px 5px 2px 5px;
 						font-size: 17px;
 					}
 				}
@@ -125,12 +126,12 @@ const actionKickerFontStylesOnMobile = (size: SmallHeadlineSize) => {
 		case 'large':
 			return css`
 				${until.desktop} {
-					margin-bottom: 2px;
+					margin-bottom: 1px;
 					margin-top: -1px;
 				}
 				span {
 					${until.desktop} {
-						padding: 2px 4px 2px 4px;
+						padding: 1px 4px 2px 4px;
 						font-size: 15px;
 					}
 				}
@@ -138,8 +139,8 @@ const actionKickerFontStylesOnMobile = (size: SmallHeadlineSize) => {
 		case 'medium':
 			return css`
 				${until.desktop} {
-					margin-top: 1px;
-					margin-bottom: 2px;
+					margin-top: 0px;
+					margin-bottom: 3px;
 				}
 				span {
 					${until.desktop} {

--- a/dotcom-rendering/src/web/components/Kicker.tsx
+++ b/dotcom-rendering/src/web/components/Kicker.tsx
@@ -1,4 +1,6 @@
 import { css } from '@emotion/react';
+import type { Palette } from '../../types/palette';
+import { decidePalette } from '../lib/decidePalette';
 import { PulsingDot } from './PulsingDot';
 
 // Defines a prefix to be used with a headline (e.g. 'Live /')
@@ -7,10 +9,71 @@ type Props = {
 	color: string;
 	showPulsingDot?: boolean;
 	hideLineBreak?: boolean;
+	isAction?: boolean;
+	format: ArticleFormat;
+	size?: SmallHeadlineSize;
 };
 
 const kickerStyles = (colour: string) => css`
 	color: ${colour};
+	font-weight: 700;
+	margin-right: 4px;
+`;
+
+const actionWrapperStyles = (size: SmallHeadlineSize) => {
+	switch (size) {
+		case 'ginormous':
+			return css`
+				margin-top: 2px;
+				overflow: hidden;
+			`;
+		case 'huge':
+			return css`
+				margin-top: 2px;
+				overflow: hidden;
+			`;
+		case 'large':
+			return css`
+				margin-top: 2px;
+				overflow: hidden;
+			`;
+		case 'medium':
+		case 'small':
+		case 'tiny':
+			return css`
+				margin-top: 1px;
+				padding-top: 2px;
+				overflow: hidden;
+			`;
+	}
+};
+
+const actionKickerPaddingStyles = (size: SmallHeadlineSize) => {
+	switch (size) {
+		case 'ginormous':
+			return css`
+				padding: 3px 5px 4px 5px;
+			`;
+		case 'huge':
+			return css`
+				padding: 2px 5px 3px 5px;
+			`;
+		case 'large':
+		case 'medium':
+		case 'small':
+		case 'tiny':
+			return css`
+				padding: 2px 4px 2px 4px;
+			`;
+	}
+};
+
+const tagStyles = (palette: Palette) => css`
+	background-color: ${palette.background.kickerLabel};
+	color: ${palette.text.kickerLabel};
+	-webkit-box-decoration-break: clone;
+	box-decoration-break: clone;
+	line-height: 1.35em;
 	font-weight: 700;
 	margin-right: 4px;
 `;
@@ -20,7 +83,31 @@ export const Kicker = ({
 	color,
 	showPulsingDot,
 	hideLineBreak,
+	isAction,
+	format,
+	size = 'medium',
 }: Props) => {
+	const palette = decidePalette(format);
+
+	if (isAction) {
+		return (
+			<div css={actionWrapperStyles(size)}>
+				<span
+					css={[
+						[tagStyles(palette), actionKickerPaddingStyles(size)],
+						hideLineBreak &&
+							css`
+								display: inline-block;
+							`,
+					]}
+				>
+					{showPulsingDot && <PulsingDot colour={color} />}
+					{text}
+				</span>
+			</div>
+		);
+	}
+
 	return (
 		<div
 			css={[

--- a/dotcom-rendering/src/web/components/Kicker.tsx
+++ b/dotcom-rendering/src/web/components/Kicker.tsx
@@ -1,4 +1,6 @@
 import { css } from '@emotion/react';
+import type { FontScaleArgs } from '@guardian/source-foundations';
+import { between, from, headline, until } from '@guardian/source-foundations';
 import type { Palette } from '../../types/palette';
 import { decidePalette } from '../lib/decidePalette';
 import { PulsingDot } from './PulsingDot';
@@ -12,6 +14,7 @@ type Props = {
 	isAction?: boolean;
 	format: ArticleFormat;
 	size?: SmallHeadlineSize;
+	sizeOnMobile?: SmallHeadlineSize;
 };
 
 const kickerStyles = (colour: string) => css`
@@ -20,52 +23,8 @@ const kickerStyles = (colour: string) => css`
 	margin-right: 4px;
 `;
 
-const actionWrapperStyles = (size: SmallHeadlineSize) => {
-	switch (size) {
-		case 'ginormous':
-			return css`
-				margin-top: 2px;
-				overflow: hidden;
-			`;
-		case 'huge':
-			return css`
-				margin-top: 2px;
-				overflow: hidden;
-			`;
-		case 'large':
-			return css`
-				margin-top: 2px;
-				overflow: hidden;
-			`;
-		case 'medium':
-		case 'small':
-		case 'tiny':
-			return css`
-				margin-top: 1px;
-				padding-top: 2px;
-				overflow: hidden;
-			`;
-	}
-};
-
-const actionKickerPaddingStyles = (size: SmallHeadlineSize) => {
-	switch (size) {
-		case 'ginormous':
-			return css`
-				padding: 3px 5px 4px 5px;
-			`;
-		case 'huge':
-			return css`
-				padding: 2px 5px 3px 5px;
-			`;
-		case 'large':
-		case 'medium':
-		case 'small':
-		case 'tiny':
-			return css`
-				padding: 2px 4px 2px 4px;
-			`;
-	}
+const actionWrapperStyles = () => {
+	return css``;
 };
 
 const tagStyles = (palette: Palette) => css`
@@ -73,10 +32,113 @@ const tagStyles = (palette: Palette) => css`
 	color: ${palette.text.kickerLabel};
 	-webkit-box-decoration-break: clone;
 	box-decoration-break: clone;
-	line-height: 1.35em;
+	line-height: 115%;
 	font-weight: 700;
 	margin-right: 4px;
 `;
+
+const fontStyles = (size: SmallHeadlineSize) => {
+	const options: FontScaleArgs = { fontWeight: 'bold' };
+	switch (size) {
+		case 'ginormous':
+			return css`
+				span {
+					${from.desktop} {
+						font-size: 50px;
+						font-weight: 700;
+						padding: 3px 5px 4px 5px;
+					}
+				}
+			`;
+		case 'huge':
+			return css`
+				span {
+					${headline.xxsmall(options)};
+					font-weight: 700;
+					padding: 3px 5px 4px 5px;
+				}
+			`;
+		case 'large':
+			return css`
+				span {
+					${headline.xxxsmall(options)};
+					font-weight: 700;
+					padding: 2px 5px 3px 5px;
+				}
+			`;
+		case 'medium':
+			return css`
+				span {
+					font-size: 15px;
+					font-weight: 700;
+					padding: 2px 4px 2px 4px;
+				}
+			`;
+		case 'small':
+			return css`
+				span {
+					font-size: 14px;
+					font-weight: 700;
+					padding: 2px 4px 2px 4px;
+				}
+			`;
+		case 'tiny':
+			return css`
+				span {
+					font-size: 12px;
+					font-weight: 700;
+					padding: 2px 4px 2px 4px;
+				}
+			`;
+	}
+};
+
+const fontStylesOnMobile = (size: SmallHeadlineSize) => {
+	switch (size) {
+		case 'ginormous':
+			return css`
+				span {
+					${until.mobileLandscape} {
+						${headline.xsmall()};
+						font-weight: 700;
+					}
+					${between.mobileLandscape.and.desktop} {
+						${headline.small()};
+						font-weight: 700;
+					}
+				}
+			`;
+		case 'huge':
+			return css`
+				span {
+					${until.desktop} {
+						${headline.xxxsmall()};
+						font-weight: 700;
+					}
+				}
+			`;
+		case 'large':
+			return css`
+				span {
+					${until.desktop} {
+						font-weight: 700;
+						font-size: 15px;
+					}
+				}
+			`;
+		case 'medium':
+			return css`
+				span {
+					${until.desktop} {
+						font-weight: 700;
+						font-size: 15px;
+					}
+				}
+			`;
+		default:
+			return undefined;
+	}
+};
 
 export const Kicker = ({
 	text,
@@ -86,15 +148,22 @@ export const Kicker = ({
 	isAction,
 	format,
 	size = 'medium',
+	sizeOnMobile,
 }: Props) => {
 	const palette = decidePalette(format);
 
 	if (isAction) {
 		return (
-			<div css={actionWrapperStyles(size)}>
+			<div
+				css={[
+					actionWrapperStyles(),
+					fontStyles(size),
+					fontStylesOnMobile(sizeOnMobile ?? size),
+				]}
+			>
 				<span
 					css={[
-						[tagStyles(palette), actionKickerPaddingStyles(size)],
+						[tagStyles(palette)],
 						hideLineBreak &&
 							css`
 								display: inline-block;

--- a/dotcom-rendering/src/web/components/Kicker.tsx
+++ b/dotcom-rendering/src/web/components/Kicker.tsx
@@ -39,18 +39,19 @@ const actionKickerFontStyles = (size: SmallHeadlineSize) => {
 	switch (size) {
 		case 'ginormous':
 			return css`
-				margin-top: -5px;
-				margin-bottom: 10px;
+				margin-top: -23px;
+				margin-bottom: 2px;
 				span {
-					padding: 6px 5px 10px 5px;
+					padding: 3px 5px 4px 5px;
+					font-size: 20px;
 					${from.desktop} {
-						font-size: 34px;
+						font-size: 20px;
 					}
 				}
 			`;
 		case 'huge':
 			return css`
-				margin-bottom: 5px;
+				margin-bottom: 4.5px;
 				margin-top: -1px;
 				span {
 					font-size: 20px;
@@ -59,10 +60,11 @@ const actionKickerFontStyles = (size: SmallHeadlineSize) => {
 			`;
 		case 'large':
 			return css`
-				margin-bottom: 4px;
+				margin-bottom: 3px;
+				margin-top: -1px;
 				span {
 					font-size: 17px;
-					padding: 3px 5px 4px 5px;
+					padding: 2px 5px 3px 5px;
 				}
 			`;
 		case 'medium':
@@ -70,13 +72,13 @@ const actionKickerFontStyles = (size: SmallHeadlineSize) => {
 				margin-bottom: 2px;
 				span {
 					font-size: 15px;
-					padding: 2px 4px 4px 4px;
+					padding: 2px 4px 2px 4px;
 				}
 			`;
 		case 'small':
 			return css`
 				margin-top: 1px;
-				margin-bottom: 2px;
+				margin-bottom: 2.5px;
 				span {
 					font-size: 14px;
 					padding: 2px 4px 2px 4px;
@@ -84,11 +86,11 @@ const actionKickerFontStyles = (size: SmallHeadlineSize) => {
 			`;
 		case 'tiny':
 			return css`
-				margin-top: 0;
-				margin-bottom: 2px;
+				margin-top: 2px;
+				margin-bottom: 3px;
 				span {
 					font-size: 12px;
-					padding: 0 4px 2px 4px;
+					padding: 2px 4px 2px 4px;
 				}
 			`;
 	}
@@ -99,30 +101,23 @@ const actionKickerFontStylesOnMobile = (size: SmallHeadlineSize) => {
 		case 'ginormous':
 			return css`
 				${until.mobileLandscape} {
-					margin-top: -1px;
-					margin-bottom: 12px;
+					margin-top: -7px;
+					margin-bottom: 5px;
 				}
 				${between.mobileLandscape.and.desktop} {
-					margin-top: -4px;
-					margin-bottom: 12px;
-				}
-				span {
-					${until.mobileLandscape} {
-						font-size: 24px;
-					}
-					${between.mobileLandscape.and.desktop} {
-						font-size: 28px;
-					}
+					margin-top: -15px;
+					margin-bottom: 3px;
 				}
 			`;
 		case 'huge':
 			return css`
 				${until.desktop} {
-					margin-bottom: 4px;
-					margin-top: 0;
+					margin-bottom: 3.5px;
+					margin-top: -1px;
 				}
 				span {
 					${until.desktop} {
+						padding: 2px 5px 3px 5px;
 						font-size: 17px;
 					}
 				}
@@ -130,11 +125,12 @@ const actionKickerFontStylesOnMobile = (size: SmallHeadlineSize) => {
 		case 'large':
 			return css`
 				${until.desktop} {
-					margin-bottom: 4px;
-					margin-top: 1px;
+					margin-bottom: 2px;
+					margin-top: -1px;
 				}
 				span {
 					${until.desktop} {
+						padding: 2px 4px 2px 4px;
 						font-size: 15px;
 					}
 				}
@@ -142,8 +138,13 @@ const actionKickerFontStylesOnMobile = (size: SmallHeadlineSize) => {
 		case 'medium':
 			return css`
 				${until.desktop} {
-					margin-top: 3px;
-					margin-bottom: 4px;
+					margin-top: 1px;
+					margin-bottom: 2px;
+				}
+				span {
+					${until.desktop} {
+						font-size: 14px;
+					}
 				}
 			`;
 		default:
@@ -172,9 +173,7 @@ export const Kicker = ({
 					actionKickerFontStylesOnMobile(sizeOnMobile ?? size),
 				]}
 			>
-				<span css={[[kickerLabelStyles(palette)]]}>
-					{'a very lggg kicker is here'}
-				</span>
+				<span css={[[kickerLabelStyles(palette)]]}>{text}</span>
 			</div>
 		);
 	}

--- a/dotcom-rendering/src/web/components/Kicker.tsx
+++ b/dotcom-rendering/src/web/components/Kicker.tsx
@@ -10,8 +10,8 @@ type Props = {
 	color: string;
 	showPulsingDot?: boolean;
 	hideLineBreak?: boolean;
-	isAction?: boolean;
 	format: ArticleFormat;
+	isAction?: boolean;
 	size?: SmallHeadlineSize;
 	sizeOnMobile?: SmallHeadlineSize;
 };
@@ -165,14 +165,14 @@ export const Kicker = ({
 	color,
 	showPulsingDot,
 	hideLineBreak,
-	isAction,
 	format,
+	isAction,
 	size = 'medium',
 	sizeOnMobile,
 }: Props) => {
 	const palette = decidePalette(format);
 
-	if (!isAction) {
+	if (isAction) {
 		return (
 			<div
 				css={[

--- a/dotcom-rendering/src/web/components/Kicker.tsx
+++ b/dotcom-rendering/src/web/components/Kicker.tsx
@@ -39,20 +39,20 @@ const actionKickerFontStyles = (size: SmallHeadlineSize) => {
 	switch (size) {
 		case 'ginormous':
 			return css`
-				margin-top: -23px;
-				margin-bottom: 2px;
+				margin-top: -7px;
+				margin-bottom: 7px;
 				span {
 					padding: 3px 5px 4px 5px;
 					font-size: 20px;
 					${from.desktop} {
-						font-size: 20px;
+						font-size: 34px;
 					}
 				}
 			`;
 		case 'huge':
 			return css`
-				margin-bottom: 3.5px;
-				margin-top: -2px;
+				margin-bottom: 2.5px;
+				margin-top: -3px;
 				span {
 					font-size: 20px;
 					padding: 2px 5px 3px 5px;
@@ -60,11 +60,11 @@ const actionKickerFontStyles = (size: SmallHeadlineSize) => {
 			`;
 		case 'large':
 			return css`
-				margin-bottom: 1px;
-				margin-top: -1px;
+				margin-bottom: 2px;
+				margin-top: -2px;
 				span {
 					font-size: 17px;
-					padding: 2px 5px 2px 5px;
+					padding: 1px 4px 2px 4px;
 				}
 			`;
 		case 'medium':
@@ -78,20 +78,20 @@ const actionKickerFontStyles = (size: SmallHeadlineSize) => {
 			`;
 		case 'small':
 			return css`
-				margin-top: 0;
-				margin-bottom: 2.5px;
+				margin-top: -1px;
+				margin-bottom: 1.5px;
 				span {
 					font-size: 14px;
-					padding: 1px 4px 2px 4px;
+					padding: 0 3px 1px 3px;
 				}
 			`;
 		case 'tiny':
 			return css`
-				margin-top: 2px;
-				margin-bottom: 3px;
+				margin-top: -1px;
+				margin-bottom: 1px;
 				span {
 					font-size: 12px;
-					padding: 2px 4px 2px 4px;
+					padding: 0px 2px 0px 2px;
 				}
 			`;
 	}
@@ -102,23 +102,29 @@ const actionKickerFontStylesOnMobile = (size: SmallHeadlineSize) => {
 		case 'ginormous':
 			return css`
 				${until.mobileLandscape} {
-					margin-top: -7px;
-					margin-bottom: 5px;
+					margin-top: -6px;
+					margin-bottom: 6px;
+					span {
+						font-size: 24px;
+					}
 				}
 				${between.mobileLandscape.and.desktop} {
-					margin-top: -15px;
-					margin-bottom: 3px;
+					margin-top: -6px;
+					margin-bottom: 6px;
+					span {
+						font-size: 28px;
+					}
 				}
 			`;
 		case 'huge':
 			return css`
 				${until.desktop} {
-					margin-bottom: 1.5px;
-					margin-top: -1px;
+					margin-bottom: 2.5px;
+					margin-top: -2px;
 				}
 				span {
 					${until.desktop} {
-						padding: 2px 5px 2px 5px;
+						padding: 1px 4px 2px 4px;
 						font-size: 17px;
 					}
 				}
@@ -139,11 +145,12 @@ const actionKickerFontStylesOnMobile = (size: SmallHeadlineSize) => {
 		case 'medium':
 			return css`
 				${until.desktop} {
-					margin-top: 0px;
-					margin-bottom: 3px;
+					margin-top: -1px;
+					margin-bottom: 1px;
 				}
 				span {
 					${until.desktop} {
+						padding: 0 3px 1px 3px;
 						font-size: 14px;
 					}
 				}

--- a/dotcom-rendering/src/web/components/Kicker.tsx
+++ b/dotcom-rendering/src/web/components/Kicker.tsx
@@ -1,6 +1,5 @@
 import { css } from '@emotion/react';
-import type { FontScaleArgs } from '@guardian/source-foundations';
-import { between, from, headline, until } from '@guardian/source-foundations';
+import { between, from, until } from '@guardian/source-foundations';
 import type { Palette } from '../../types/palette';
 import { decidePalette } from '../lib/decidePalette';
 import { PulsingDot } from './PulsingDot';
@@ -23,11 +22,11 @@ const kickerStyles = (colour: string) => css`
 	margin-right: 4px;
 `;
 
-const actionWrapperStyles = () => {
-	return css``;
-};
+const actionWrapperStyles = css`
+	font-weight: 700;
+`;
 
-const tagStyles = (palette: Palette) => css`
+const kickerLabelStyles = (palette: Palette) => css`
 	background-color: ${palette.background.kickerLabel};
 	color: ${palette.text.kickerLabel};
 	-webkit-box-decoration-break: clone;
@@ -37,102 +36,115 @@ const tagStyles = (palette: Palette) => css`
 	margin-right: 4px;
 `;
 
-const fontStyles = (size: SmallHeadlineSize) => {
-	const options: FontScaleArgs = { fontWeight: 'bold' };
+const actionKickerFontStyles = (size: SmallHeadlineSize) => {
 	switch (size) {
 		case 'ginormous':
 			return css`
+				margin-top: -5px;
+				margin-bottom: 10px;
 				span {
+					padding: 6px 5px 10px 5px;
 					${from.desktop} {
-						font-size: 50px;
-						font-weight: 700;
-						padding: 3px 5px 4px 5px;
+						font-size: 34px;
 					}
 				}
 			`;
 		case 'huge':
 			return css`
+				margin-bottom: 5px;
+				margin-top: -1px;
 				span {
-					${headline.xxsmall(options)};
-					font-weight: 700;
+					font-size: 20px;
 					padding: 3px 5px 4px 5px;
 				}
 			`;
 		case 'large':
 			return css`
+				margin-bottom: 4px;
 				span {
-					${headline.xxxsmall(options)};
-					font-weight: 700;
-					padding: 2px 5px 3px 5px;
+					font-size: 17px;
+					padding: 3px 5px 4px 5px;
 				}
 			`;
 		case 'medium':
 			return css`
+				margin-bottom: 2px;
 				span {
 					font-size: 15px;
-					font-weight: 700;
-					padding: 2px 4px 2px 4px;
+					padding: 2px 4px 4px 4px;
 				}
 			`;
 		case 'small':
 			return css`
+				margin-top: 1px;
+				margin-bottom: 2px;
 				span {
 					font-size: 14px;
-					font-weight: 700;
 					padding: 2px 4px 2px 4px;
 				}
 			`;
 		case 'tiny':
 			return css`
+				margin-top: 0;
+				margin-bottom: 2px;
 				span {
 					font-size: 12px;
-					font-weight: 700;
-					padding: 2px 4px 2px 4px;
+					padding: 0 4px 2px 4px;
 				}
 			`;
 	}
 };
 
-const fontStylesOnMobile = (size: SmallHeadlineSize) => {
+const actionKickerFontStylesOnMobile = (size: SmallHeadlineSize) => {
 	switch (size) {
 		case 'ginormous':
 			return css`
+				${until.mobileLandscape} {
+					margin-top: -1px;
+					margin-bottom: 12px;
+				}
+				${between.mobileLandscape.and.desktop} {
+					margin-top: -4px;
+					margin-bottom: 12px;
+				}
 				span {
 					${until.mobileLandscape} {
-						${headline.xsmall()};
-						font-weight: 700;
+						font-size: 24px;
 					}
 					${between.mobileLandscape.and.desktop} {
-						${headline.small()};
-						font-weight: 700;
+						font-size: 28px;
 					}
 				}
 			`;
 		case 'huge':
 			return css`
+				${until.desktop} {
+					margin-bottom: 4px;
+					margin-top: 0;
+				}
 				span {
 					${until.desktop} {
-						${headline.xxxsmall()};
-						font-weight: 700;
+						font-size: 17px;
 					}
 				}
 			`;
 		case 'large':
 			return css`
+				${until.desktop} {
+					margin-bottom: 4px;
+					margin-top: 1px;
+				}
 				span {
 					${until.desktop} {
-						font-weight: 700;
 						font-size: 15px;
 					}
 				}
 			`;
 		case 'medium':
 			return css`
-				span {
-					${until.desktop} {
-						font-weight: 700;
-						font-size: 15px;
-					}
+				${until.desktop} {
+					margin-top: 3px;
+					margin-bottom: 4px;
 				}
 			`;
 		default:
@@ -156,23 +168,12 @@ export const Kicker = ({
 		return (
 			<div
 				css={[
-					actionWrapperStyles(),
-					fontStyles(size),
-					fontStylesOnMobile(sizeOnMobile ?? size),
+					actionWrapperStyles,
+					actionKickerFontStyles(size),
+					actionKickerFontStylesOnMobile(sizeOnMobile ?? size),
 				]}
 			>
-				<span
-					css={[
-						[tagStyles(palette)],
-						hideLineBreak &&
-							css`
-								display: inline-block;
-							`,
-					]}
-				>
-					{showPulsingDot && <PulsingDot colour={color} />}
-					{text}
-				</span>
+				<span css={[[kickerLabelStyles(palette)]]}>{text}</span>
 			</div>
 		);
 	}

--- a/dotcom-rendering/src/web/components/Kicker.tsx
+++ b/dotcom-rendering/src/web/components/Kicker.tsx
@@ -29,7 +29,6 @@ const actionWrapperStyles = css`
 const kickerLabelStyles = (palette: Palette) => css`
 	background-color: ${palette.background.kickerLabel};
 	color: ${palette.text.kickerLabel};
-	-webkit-box-decoration-break: clone;
 	box-decoration-break: clone;
 	line-height: 115%;
 	font-weight: 700;
@@ -173,7 +172,9 @@ export const Kicker = ({
 					actionKickerFontStylesOnMobile(sizeOnMobile ?? size),
 				]}
 			>
-				<span css={[[kickerLabelStyles(palette)]]}>{text}</span>
+				<span css={[[kickerLabelStyles(palette)]]}>
+					{'a very lggg kicker is here'}
+				</span>
 			</div>
 		);
 	}

--- a/dotcom-rendering/src/web/components/LinkHeadline.tsx
+++ b/dotcom-rendering/src/web/components/LinkHeadline.tsx
@@ -86,6 +86,7 @@ export const LinkHeadline = ({
 					color={palette.text.linkKicker}
 					showPulsingDot={showPulsingDot}
 					hideLineBreak={hideLineBreak}
+					format={format}
 				/>
 			)}
 			{showQuotes && <QuoteIcon colour={palette.text.linkKicker} />}

--- a/dotcom-rendering/src/web/components/SupportingContent.stories.tsx
+++ b/dotcom-rendering/src/web/components/SupportingContent.stories.tsx
@@ -31,6 +31,7 @@ const basicCardProps: CardProps = {
 		'https://media.guim.co.uk/6537e163c9164d25ec6102641f6a04fa5ba76560/0_0_5472_3648/master/5472.jpg',
 	imagePosition: 'top',
 	isExternalLink: false,
+	isActionCard: false,
 };
 
 const aBasicLink = {

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -1802,6 +1802,10 @@ const textDateLine = (format: ArticleFormat): string => {
 	return neutral[46];
 };
 
+const textKickerLabel = (): string => {
+	return palette.neutral[100];
+};
+
 const textTableOfContents = (): string => {
 	return palette.neutral[7];
 };
@@ -1984,6 +1988,27 @@ const backgroundDesignTag = (format: ArticleFormat): string => {
 	}
 };
 
+const backgroundKickerLabel = (format: ArticleFormat): string => {
+	switch (format.theme) {
+		case ArticlePillar.News:
+			return palette.news[400];
+		case ArticlePillar.Sport:
+			return palette.sport[400];
+		case ArticlePillar.Lifestyle:
+			return palette.lifestyle[400];
+		case ArticlePillar.Culture:
+			return palette.culture[400];
+		case ArticlePillar.Opinion:
+			return palette.opinion[400];
+		case ArticleSpecial.Labs:
+			return palette.labs[400];
+		case ArticleSpecial.SpecialReport:
+			return palette.specialReport[400];
+		case ArticleSpecial.SpecialReportAlt:
+			return palette.specialReportAlt[100];
+	}
+};
+
 const hoverKeyEventLink = (format: ArticleFormat): string => {
 	switch (format.theme) {
 		case ArticlePillar.News:
@@ -2117,6 +2142,7 @@ export const decidePalette = (
 			filterButtonActive: textFilterButtonActive(),
 			betaLabel: textBetaLabel(),
 			designTag: textDesignTag(format),
+			kickerLabel: textKickerLabel(),
 			dateLine: textDateLine(format),
 			tableOfContents: textTableOfContents(),
 		},
@@ -2154,6 +2180,7 @@ export const decidePalette = (
 			filterButtonActive: backgroundFilterButtonActive(format),
 			treat: backgroundTreat(format),
 			designTag: backgroundDesignTag(format),
+			kickerLabel: backgroundKickerLabel(format),
 			pullQuote: backgroundPullQuote(format),
 			messageForm: backgroundMessageForm(format),
 		},


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR updates the design for actionable card where user can take an action by opening the article, e.g. filling in a callout form.

The kicker font size and its position in the card is related to the heading font size, and it has to be very accurate because these cards could be located next to a non-actionable card, therefore, the headings of these 2 cards should be **aligned**.

Also there has to be support for long kickers where it ends up in multiple lines. But obviously, when the kickers are multi-line, the card heading could be dis-aligned from the heading of the neighbouring card. This is acceptable as it's a rare case.

Also, in bigger cards, when the kicker is multi-line there could be a gap between the 2 lines. This is also acceptable (discussed with @benwuersching )

## Why?
Currently, there is not a very clear way of visually setting apart what is a "callout" article on fronts. Because of this, some of our users currently think callout articles are actual articles. This ambiguity could be having a negative impact on our users' experience. Additionally, we think that if we can make it clearer to our users that an article is a callout, we could drive user engagement in our callout campaigns.

<img width="965" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/15894063/f5d7989c-33ac-4e28-94ff-a2811cad239d">

## Screenshots

| Before      | 
|-------------|
| ![image](https://user-images.githubusercontent.com/15894063/233136352-8d121228-5aca-4390-bcbf-69fa73dec764.png) | 

| After      |
|------------|
| ![image](https://user-images.githubusercontent.com/15894063/233136090-7ee7ed5e-f3d8-46a5-babd-c0f5c2f1a353.png) |


| Long kicker Before      | 
|-------------|
| ![image](https://user-images.githubusercontent.com/15894063/233138625-74dd2668-0ac8-47a9-858d-c55c3d0b98db.png) | 

| Long kicker After      |
|------------|
| ![image](https://user-images.githubusercontent.com/15894063/233138824-a5ad2660-0aed-4df5-a10e-ac10ef5a3d53.png) |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->


<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
