### PR TITLE
Draft: Combined standard layout for apps and web

### DIFF
--- a/dotcom-rendering/src/apps/components/ArticlePage.tsx
+++ b/dotcom-rendering/src/apps/components/ArticlePage.tsx
@@ -1,12 +1,13 @@
 import { css, Global } from '@emotion/react';
-import { ArticleDesign } from '@guardian/libs';
 import { brandAlt, focusHalo, neutral } from '@guardian/source-foundations';
 import { StrictMode } from 'react';
 import type { FEArticleType } from '../../types/frontend';
+import type { NavType } from '../../model/extract-nav';
 import { DecideLayout } from '../layouts/DecideLayout';
 
 type Props = {
 	article: FEArticleType;
+	NAV: NavType;
 	format: ArticleFormat;
 };
 
@@ -18,7 +19,7 @@ type Props = {
  * @param {FEArticleType} props.article - The article JSON data
  * @param {ArticleFormat} props.format - The format model for the article
  * */
-export const ArticlePage = ({ article, format }: Props) => {
+export const ArticlePage = ({ article, NAV, format }: Props) => {
 	return (
 		<StrictMode>
 			<Global
@@ -33,7 +34,7 @@ export const ArticlePage = ({ article, format }: Props) => {
 					}
 				`}
 			/>
-			<DecideLayout article={article} format={format} />
+			<DecideLayout article={article} NAV={NAV} format={format} />
 		</StrictMode>
 	);
 };

--- a/dotcom-rendering/src/apps/components/ArticlePage.tsx
+++ b/dotcom-rendering/src/apps/components/ArticlePage.tsx
@@ -1,8 +1,8 @@
 import { css, Global } from '@emotion/react';
 import { brandAlt, focusHalo, neutral } from '@guardian/source-foundations';
 import { StrictMode } from 'react';
-import type { FEArticleType } from '../../types/frontend';
 import type { NavType } from '../../model/extract-nav';
+import type { FEArticleType } from '../../types/frontend';
 import { DecideLayout } from '../layouts/DecideLayout';
 
 type Props = {

--- a/dotcom-rendering/src/apps/components/ArticlePage.tsx
+++ b/dotcom-rendering/src/apps/components/ArticlePage.tsx
@@ -1,0 +1,39 @@
+import { css, Global } from '@emotion/react';
+import { ArticleDesign } from '@guardian/libs';
+import { brandAlt, focusHalo, neutral } from '@guardian/source-foundations';
+import { StrictMode } from 'react';
+import type { FEArticleType } from '../../types/frontend';
+import { DecideLayout } from '../layouts/DecideLayout';
+
+type Props = {
+	article: FEArticleType;
+	format: ArticleFormat;
+};
+
+/**
+ * @description
+ * Article is a high level wrapper for article pages on Dotcom. Sets strict mode and some globals
+ *
+ * @param {Props} props
+ * @param {FEArticleType} props.article - The article JSON data
+ * @param {ArticleFormat} props.format - The format model for the article
+ * */
+export const ArticlePage = ({ article, format }: Props) => {
+	return (
+		<StrictMode>
+			<Global
+				styles={css`
+					/* Crude but effective mechanism. Specific components may need to improve on this behaviour. */
+					*:focus {
+						${focusHalo}
+					}
+					::selection {
+						background: ${brandAlt[400]};
+						color: ${neutral[7]};
+					}
+				`}
+			/>
+			<DecideLayout article={article} format={format} />
+		</StrictMode>
+	);
+};

--- a/dotcom-rendering/src/apps/layouts/DecideLayout.tsx
+++ b/dotcom-rendering/src/apps/layouts/DecideLayout.tsx
@@ -11,7 +11,6 @@ type Props = {
 
 export const DecideLayout = ({ article, NAV, format }: Props) => {
 	// TODO we can probably better express this as data
-
 	return (
 		<StandardLayout
 			article={article}

--- a/dotcom-rendering/src/apps/layouts/DecideLayout.tsx
+++ b/dotcom-rendering/src/apps/layouts/DecideLayout.tsx
@@ -1,0 +1,8 @@
+const NotSupported = () => <pre>Not supported</pre>;
+
+export const DecideLayout = () => {
+	switch (true) {
+		default:
+			return <NotSupported />;
+	}
+};

--- a/dotcom-rendering/src/apps/layouts/DecideLayout.tsx
+++ b/dotcom-rendering/src/apps/layouts/DecideLayout.tsx
@@ -1,8 +1,23 @@
-const NotSupported = () => <pre>Not supported</pre>;
+import type { ArticleFormat } from '@guardian/libs';
+import type { NavType } from '../../model/extract-nav';
+import type { FEArticleType } from '../../types/frontend';
+import { StandardLayout } from '../../web/layouts/StandardLayout';
 
-export const DecideLayout = () => {
-	switch (true) {
-		default:
-			return <NotSupported />;
-	}
+type Props = {
+	article: FEArticleType;
+	NAV: NavType;
+	format: ArticleFormat;
+};
+
+export const DecideLayout = ({ article, NAV, format }: Props) => {
+	// TODO we can probably better express this as data
+
+	return (
+		<StandardLayout
+			article={article}
+			NAV={NAV}
+			format={format}
+			renderingTarget="Apps"
+		/>
+	);
 };

--- a/dotcom-rendering/src/apps/server/articleToHtml.tsx
+++ b/dotcom-rendering/src/apps/server/articleToHtml.tsx
@@ -1,4 +1,5 @@
-import { getScriptsFromManifest } from '../../lib/assets';
+import { isString } from '@guardian/libs';
+import { generateScriptTags, getScriptsFromManifest } from '../../lib/assets';
 import { escapeData } from '../../lib/escapeData';
 import { extractNAV } from '../../model/extract-nav';
 import { makeWindowGuardian } from '../../model/window-guardian';
@@ -27,6 +28,9 @@ export const articleToHtml = (
 	});
 
 	const clientScripts = getScriptArrayFromFile('index.js');
+	const scriptTags = generateScriptTags(
+		[...getScriptArrayFromFile('index.js')].filter(isString),
+	);
 
 	/**
 	 * We escape windowGuardian here to prevent errors when the data
@@ -58,7 +62,7 @@ export const articleToHtml = (
 		css: extractedCss,
 		html,
 		title: article.webTitle,
-		clientScripts,
+		scriptTags,
 		windowGuardian,
 	});
 	return {

--- a/dotcom-rendering/src/apps/server/articleToHtml.tsx
+++ b/dotcom-rendering/src/apps/server/articleToHtml.tsx
@@ -1,8 +1,11 @@
 import { getScriptsFromManifest } from '../../lib/assets';
 import { escapeData } from '../../lib/escapeData';
+import { extractNAV } from '../../model/extract-nav';
 import { makeWindowGuardian } from '../../model/window-guardian';
 import type { FEArticleType } from '../../types/frontend';
+import { decideFormat } from '../../web/lib/decideFormat';
 import { renderToStringWithEmotion } from '../../web/lib/emotion';
+import { ArticlePage } from '../components/ArticlePage';
 import { pageTemplate } from './pageTemplate';
 
 export const articleToHtml = (
@@ -11,7 +14,13 @@ export const articleToHtml = (
 	clientScripts: string[];
 	html: string;
 } => {
-	const { html, extractedCss } = renderToStringWithEmotion(<></>);
+	const NAV = extractNAV(article.nav);
+
+	const format: ArticleFormat = decideFormat(article.format);
+
+	const { html, extractedCss } = renderToStringWithEmotion(
+		<ArticlePage format={format} article={article} NAV={NAV} />,
+	);
 
 	const getScriptArrayFromFile = getScriptsFromManifest({
 		platform: 'apps',

--- a/dotcom-rendering/src/apps/server/pageTemplate.ts
+++ b/dotcom-rendering/src/apps/server/pageTemplate.ts
@@ -5,13 +5,13 @@ export const pageTemplate = ({
 	css,
 	html,
 	title = 'The Guardian',
-	clientScripts,
+	scriptTags,
 	windowGuardian,
 }: {
 	css: string;
 	html: string;
 	title?: string;
-	clientScripts: string[];
+	scriptTags: string[];
 	windowGuardian: string;
 }): string => {
 	const favicon =
@@ -72,9 +72,7 @@ export const pageTemplate = ({
 					window.guardian.mustardCut = true;
 				</script>
 
-				${clientScripts
-					.map((scriptSrc) => `<script src="${scriptSrc}"></script>`)
-					.join('\n')}
+				${scriptTags.join('\n')}
 
                 <style>${resets.resetCSS}</style>
 				${css}

--- a/dotcom-rendering/src/web/components/ArticleBody.tsx
+++ b/dotcom-rendering/src/web/components/ArticleBody.tsx
@@ -8,12 +8,12 @@ import type { Palette } from '../../types/palette';
 import type { TagType } from '../../types/tag';
 import { ArticleRenderer } from '../lib/ArticleRenderer';
 import { decidePalette } from '../lib/decidePalette';
+import { decideLanguage, decideLanguageDirection } from '../lib/lang';
 import { LiveBlogRenderer } from '../lib/LiveBlogRenderer';
 import { revealStyles } from '../lib/revealStyles';
 import { Island } from './Island';
 import { RecipeMultiplier } from './RecipeMultiplier.importable';
 import { TableOfContents } from './TableOfContents.importable';
-import { decideLanguage, decideLanguageDirection } from '../lib/lang';
 
 type Props = {
 	format: ArticleFormat;

--- a/dotcom-rendering/src/web/layouts/DecideLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/DecideLayout.tsx
@@ -131,6 +131,7 @@ export const DecideLayout = ({ article, NAV, format }: Props) => {
 							article={article}
 							NAV={NAV}
 							format={format}
+							renderingTarget={'Web'}
 						/>
 					);
 			}

--- a/dotcom-rendering/src/web/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/StandardLayout.tsx
@@ -289,9 +289,15 @@ interface Props {
 	article: FEArticleType;
 	NAV: NavType;
 	format: ArticleFormat;
+	renderingTarget: string;
 }
 
-export const StandardLayout = ({ article, NAV, format }: Props) => {
+export const StandardLayout = ({
+	article,
+	NAV,
+	format,
+	renderingTarget,
+}: Props) => {
 	const {
 		config: { isPaidContent, host },
 	} = article;
@@ -967,6 +973,11 @@ export const StandardLayout = ({ article, NAV, format }: Props) => {
 				</Island>
 			</BannerWrapper>
 			<MobileStickyContainer data-print-layout="hide" />
+			{renderingTarget === 'Apps' && (
+				<div>
+					<p>TEST</p>
+				</div>
+			)}
 		</>
 	);
 };

--- a/dotcom-rendering/src/web/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/StandardLayout.tsx
@@ -351,111 +351,119 @@ export const StandardLayout = ({
 
 	const isLabs = format.theme === ArticleSpecial.Labs;
 
+	const isWeb = renderingTarget === 'Web';
+
 	return (
 		<>
-			<div data-print-layout="hide" id="bannerandheader">
-				<>
-					{renderAds && (
-						<Stuck>
+			{isWeb && (
+				<div data-print-layout="hide" id="bannerandheader">
+					<>
+						{renderAds && (
+							<Stuck>
+								<Section
+									fullWidth={true}
+									showTopBorder={false}
+									showSideBorders={false}
+									padSides={false}
+									shouldCenter={false}
+								>
+									<HeaderAdSlot display={format.display} />
+								</Section>
+							</Stuck>
+						)}
+						{!isLabs && (
 							<Section
 								fullWidth={true}
 								showTopBorder={false}
 								showSideBorders={false}
 								padSides={false}
 								shouldCenter={false}
+								backgroundColour={brandBackground.primary}
+								element="header"
 							>
-								<HeaderAdSlot display={format.display} />
+								<Header
+									editionId={article.editionId}
+									idUrl={article.config.idUrl}
+									mmaUrl={article.config.mmaUrl}
+									discussionApiUrl={
+										article.config.discussionApiUrl
+									}
+									urls={article.nav.readerRevenueLinks.header}
+									remoteHeader={
+										!!article.config.switches.remoteHeader
+									}
+									contributionsServiceUrl={
+										contributionsServiceUrl
+									}
+									idApiUrl={article.config.idApiUrl}
+									isInEuropeTest={isInEuropeTest}
+									headerTopBarSearchCapiSwitch={
+										!!article.config.switches
+											.headerTopBarSearchCapi
+									}
+								/>
 							</Section>
-						</Stuck>
-					)}
-					{!isLabs && (
+						)}
 						<Section
 							fullWidth={true}
+							borderColour={brandLine.primary}
 							showTopBorder={false}
-							showSideBorders={false}
 							padSides={false}
-							shouldCenter={false}
 							backgroundColour={brandBackground.primary}
-							element="header"
+							element="nav"
 						>
-							<Header
+							<Nav
+								nav={NAV}
+								format={formatForNav}
+								subscribeUrl={
+									article.nav.readerRevenueLinks.header
+										.subscribe
+								}
 								editionId={article.editionId}
-								idUrl={article.config.idUrl}
-								mmaUrl={article.config.mmaUrl}
-								discussionApiUrl={
-									article.config.discussionApiUrl
-								}
-								urls={article.nav.readerRevenueLinks.header}
-								remoteHeader={
-									!!article.config.switches.remoteHeader
-								}
-								contributionsServiceUrl={
-									contributionsServiceUrl
-								}
-								idApiUrl={article.config.idApiUrl}
-								isInEuropeTest={isInEuropeTest}
-								headerTopBarSearchCapiSwitch={
-									!!article.config.switches
-										.headerTopBarSearchCapi
+								headerTopBarSwitch={
+									!!article.config.switches.headerTopNav
 								}
 							/>
 						</Section>
-					)}
-					<Section
-						fullWidth={true}
-						borderColour={brandLine.primary}
-						showTopBorder={false}
-						padSides={false}
-						backgroundColour={brandBackground.primary}
-						element="nav"
-					>
-						<Nav
-							nav={NAV}
-							format={formatForNav}
-							subscribeUrl={
-								article.nav.readerRevenueLinks.header.subscribe
-							}
-							editionId={article.editionId}
-							headerTopBarSwitch={
-								!!article.config.switches.headerTopNav
-							}
-						/>
-					</Section>
-					{NAV.subNavSections && !isLabs && (
-						<>
-							<Section
-								fullWidth={true}
-								backgroundColour={palette.background.article}
-								padSides={false}
-								element="aside"
-							>
-								<Island deferUntil="idle">
-									<SubNav
-										subNavSections={NAV.subNavSections}
-										currentNavLink={NAV.currentNavLink}
-										format={format}
+						{NAV.subNavSections && !isLabs && (
+							<>
+								<Section
+									fullWidth={true}
+									backgroundColour={
+										palette.background.article
+									}
+									padSides={false}
+									element="aside"
+								>
+									<Island deferUntil="idle">
+										<SubNav
+											subNavSections={NAV.subNavSections}
+											currentNavLink={NAV.currentNavLink}
+											format={format}
+										/>
+									</Island>
+								</Section>
+								<Section
+									fullWidth={true}
+									backgroundColour={
+										palette.background.article
+									}
+									padSides={false}
+									showTopBorder={false}
+								>
+									<StraightLines
+										count={4}
+										cssOverrides={css`
+											display: block;
+										`}
+										color={palette.border.secondary}
 									/>
-								</Island>
-							</Section>
-							<Section
-								fullWidth={true}
-								backgroundColour={palette.background.article}
-								padSides={false}
-								showTopBorder={false}
-							>
-								<StraightLines
-									count={4}
-									cssOverrides={css`
-										display: block;
-									`}
-									color={palette.border.secondary}
-								/>
-							</Section>
-						</>
-					)}
-				</>
-			</div>
-
+								</Section>
+							</>
+						)}
+					</>
+				</div>
+			)}
 			{format.theme === ArticleSpecial.Labs && (
 				<Stuck>
 					<Section
@@ -935,7 +943,7 @@ export const StandardLayout = ({
 				showSideBorders={false}
 				element="footer"
 			>
-				{renderingTarget === 'Web' && (
+				{isWeb && (
 					<Footer
 						pageFooter={article.pageFooter}
 						pillar={format.theme}
@@ -978,13 +986,13 @@ export const StandardLayout = ({
 			</BannerWrapper>
 			<MobileStickyContainer data-print-layout="hide" />
 			{/* TODO: Remove this test */}
-			{renderingTarget === 'Apps' ? (
+			{isWeb ? (
 				<div>
-					<p>App test</p>
+					<p>Web test</p>
 				</div>
 			) : (
 				<div>
-					<p>Must be web test</p>
+					<p>Must be app test</p>
 				</div>
 			)}
 		</>

--- a/dotcom-rendering/src/web/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/StandardLayout.tsx
@@ -935,14 +935,18 @@ export const StandardLayout = ({
 				showSideBorders={false}
 				element="footer"
 			>
-				<Footer
-					pageFooter={article.pageFooter}
-					pillar={format.theme}
-					pillars={NAV.pillars}
-					urls={article.nav.readerRevenueLinks.header}
-					editionId={article.editionId}
-					contributionsServiceUrl={article.contributionsServiceUrl}
-				/>
+				{renderingTarget === 'Web' && (
+					<Footer
+						pageFooter={article.pageFooter}
+						pillar={format.theme}
+						pillars={NAV.pillars}
+						urls={article.nav.readerRevenueLinks.header}
+						editionId={article.editionId}
+						contributionsServiceUrl={
+							article.contributionsServiceUrl
+						}
+					/>
+				)}
 			</Section>
 
 			<BannerWrapper data-print-layout="hide">
@@ -973,9 +977,14 @@ export const StandardLayout = ({
 				</Island>
 			</BannerWrapper>
 			<MobileStickyContainer data-print-layout="hide" />
-			{renderingTarget === 'Apps' && (
+			{/* TODO: Remove this test */}
+			{renderingTarget === 'Apps' ? (
 				<div>
-					<p>TEST</p>
+					<p>App test</p>
+				</div>
+			) : (
+				<div>
+					<p>Must be web test</p>
 				</div>
 			)}
 		</>

--- a/dotcom-rendering/src/web/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/StandardLayout.tsx
@@ -347,11 +347,10 @@ export const StandardLayout = ({
 
 	const contributionsServiceUrl = getContributionsServiceUrl(article);
 
-	const renderAds = canRenderAds(article);
-
 	const isLabs = format.theme === ArticleSpecial.Labs;
 
 	const isWeb = renderingTarget === 'Web';
+	const renderAds = isWeb && canRenderAds(article);
 
 	return (
 		<>
@@ -916,74 +915,79 @@ export const StandardLayout = ({
 					</Section>
 				)}
 			</main>
+			{isWeb && (
+				<>
+					{NAV.subNavSections && (
+						<Section
+							fullWidth={true}
+							data-print-layout="hide"
+							padSides={false}
+							element="aside"
+						>
+							<Island deferUntil="visible">
+								<SubNav
+									subNavSections={NAV.subNavSections}
+									currentNavLink={NAV.currentNavLink}
+									format={format}
+								/>
+							</Island>
+						</Section>
+					)}
 
-			{NAV.subNavSections && (
-				<Section
-					fullWidth={true}
-					data-print-layout="hide"
-					padSides={false}
-					element="aside"
-				>
-					<Island deferUntil="visible">
-						<SubNav
-							subNavSections={NAV.subNavSections}
-							currentNavLink={NAV.currentNavLink}
-							format={format}
+					<Section
+						fullWidth={true}
+						data-print-layout="hide"
+						padSides={false}
+						backgroundColour={brandBackground.primary}
+						borderColour={brandBorder.primary}
+						showSideBorders={false}
+						element="footer"
+					>
+						<Footer
+							pageFooter={article.pageFooter}
+							pillar={format.theme}
+							pillars={NAV.pillars}
+							urls={article.nav.readerRevenueLinks.header}
+							editionId={article.editionId}
+							contributionsServiceUrl={
+								article.contributionsServiceUrl
+							}
 						/>
-					</Island>
-				</Section>
+					</Section>
+
+					<BannerWrapper data-print-layout="hide">
+						<Island deferUntil="idle" clientOnly={true}>
+							<StickyBottomBanner
+								contentType={article.contentType}
+								contributionsServiceUrl={
+									contributionsServiceUrl
+								}
+								idApiUrl={article.config.idApiUrl}
+								isMinuteArticle={
+									article.pageType.isMinuteArticle
+								}
+								isPaidContent={article.pageType.isPaidContent}
+								isPreview={!!article.config.isPreview}
+								isSensitive={article.config.isSensitive}
+								keywordIds={article.config.keywordIds}
+								pageId={article.pageId}
+								section={article.config.section}
+								sectionName={article.sectionName}
+								shouldHideReaderRevenue={
+									article.shouldHideReaderRevenue
+								}
+								remoteBannerSwitch={
+									!!article.config.switches.remoteBanner
+								}
+								puzzleBannerSwitch={
+									!!article.config.switches.puzzlesBanner
+								}
+								tags={article.tags}
+							/>
+						</Island>
+					</BannerWrapper>
+				</>
 			)}
-
-			<Section
-				fullWidth={true}
-				data-print-layout="hide"
-				padSides={false}
-				backgroundColour={brandBackground.primary}
-				borderColour={brandBorder.primary}
-				showSideBorders={false}
-				element="footer"
-			>
-				{isWeb && (
-					<Footer
-						pageFooter={article.pageFooter}
-						pillar={format.theme}
-						pillars={NAV.pillars}
-						urls={article.nav.readerRevenueLinks.header}
-						editionId={article.editionId}
-						contributionsServiceUrl={
-							article.contributionsServiceUrl
-						}
-					/>
-				)}
-			</Section>
-
-			<BannerWrapper data-print-layout="hide">
-				<Island deferUntil="idle" clientOnly={true}>
-					<StickyBottomBanner
-						contentType={article.contentType}
-						contributionsServiceUrl={contributionsServiceUrl}
-						idApiUrl={article.config.idApiUrl}
-						isMinuteArticle={article.pageType.isMinuteArticle}
-						isPaidContent={article.pageType.isPaidContent}
-						isPreview={!!article.config.isPreview}
-						isSensitive={article.config.isSensitive}
-						keywordIds={article.config.keywordIds}
-						pageId={article.pageId}
-						section={article.config.section}
-						sectionName={article.sectionName}
-						shouldHideReaderRevenue={
-							article.shouldHideReaderRevenue
-						}
-						remoteBannerSwitch={
-							!!article.config.switches.remoteBanner
-						}
-						puzzleBannerSwitch={
-							!!article.config.switches.puzzlesBanner
-						}
-						tags={article.tags}
-					/>
-				</Island>
-			</BannerWrapper>
 			<MobileStickyContainer data-print-layout="hide" />
 			{/* TODO: Remove this test */}
 			{isWeb ? (

--- a/dotcom-rendering/src/web/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/StandardLayout.tsx
@@ -18,6 +18,7 @@ import { buildAdTargeting } from '../../lib/ad-targeting';
 import { parse } from '../../lib/slot-machine-flags';
 import type { NavType } from '../../model/extract-nav';
 import type { FEArticleType } from '../../types/frontend';
+import type { RenderingTarget } from '../../types/renderingTarget';
 import { AdSlot, MobileStickyContainer } from '../components/AdSlot';
 import { ArticleBody } from '../components/ArticleBody';
 import { ArticleContainer } from '../components/ArticleContainer';
@@ -289,7 +290,7 @@ interface Props {
 	article: FEArticleType;
 	NAV: NavType;
 	format: ArticleFormat;
-	renderingTarget: string;
+	renderingTarget: RenderingTarget;
 }
 
 export const StandardLayout = ({
@@ -356,111 +357,104 @@ export const StandardLayout = ({
 		<>
 			{isWeb && (
 				<div data-print-layout="hide" id="bannerandheader">
-					<>
-						{renderAds && (
-							<Stuck>
-								<Section
-									fullWidth={true}
-									showTopBorder={false}
-									showSideBorders={false}
-									padSides={false}
-									shouldCenter={false}
-								>
-									<HeaderAdSlot display={format.display} />
-								</Section>
-							</Stuck>
-						)}
-						{!isLabs && (
+					{renderAds && (
+						<Stuck>
 							<Section
 								fullWidth={true}
 								showTopBorder={false}
 								showSideBorders={false}
 								padSides={false}
 								shouldCenter={false}
-								backgroundColour={brandBackground.primary}
-								element="header"
 							>
-								<Header
-									editionId={article.editionId}
-									idUrl={article.config.idUrl}
-									mmaUrl={article.config.mmaUrl}
-									discussionApiUrl={
-										article.config.discussionApiUrl
-									}
-									urls={article.nav.readerRevenueLinks.header}
-									remoteHeader={
-										!!article.config.switches.remoteHeader
-									}
-									contributionsServiceUrl={
-										contributionsServiceUrl
-									}
-									idApiUrl={article.config.idApiUrl}
-									isInEuropeTest={isInEuropeTest}
-									headerTopBarSearchCapiSwitch={
-										!!article.config.switches
-											.headerTopBarSearchCapi
-									}
-								/>
+								<HeaderAdSlot display={format.display} />
 							</Section>
-						)}
+						</Stuck>
+					)}
+					{!isLabs && (
 						<Section
 							fullWidth={true}
-							borderColour={brandLine.primary}
 							showTopBorder={false}
+							showSideBorders={false}
 							padSides={false}
+							shouldCenter={false}
 							backgroundColour={brandBackground.primary}
-							element="nav"
+							element="header"
 						>
-							<Nav
-								nav={NAV}
-								format={formatForNav}
-								subscribeUrl={
-									article.nav.readerRevenueLinks.header
-										.subscribe
-								}
+							<Header
 								editionId={article.editionId}
-								headerTopBarSwitch={
-									!!article.config.switches.headerTopNav
+								idUrl={article.config.idUrl}
+								mmaUrl={article.config.mmaUrl}
+								discussionApiUrl={
+									article.config.discussionApiUrl
+								}
+								urls={article.nav.readerRevenueLinks.header}
+								remoteHeader={
+									!!article.config.switches.remoteHeader
+								}
+								contributionsServiceUrl={
+									contributionsServiceUrl
+								}
+								idApiUrl={article.config.idApiUrl}
+								isInEuropeTest={isInEuropeTest}
+								headerTopBarSearchCapiSwitch={
+									!!article.config.switches
+										.headerTopBarSearchCapi
 								}
 							/>
 						</Section>
-						{NAV.subNavSections && !isLabs && (
-							<>
-								<Section
-									fullWidth={true}
-									backgroundColour={
-										palette.background.article
-									}
-									padSides={false}
-									element="aside"
-								>
-									<Island deferUntil="idle">
-										<SubNav
-											subNavSections={NAV.subNavSections}
-											currentNavLink={NAV.currentNavLink}
-											format={format}
-										/>
-									</Island>
-								</Section>
-								<Section
-									fullWidth={true}
-									backgroundColour={
-										palette.background.article
-									}
-									padSides={false}
-									showTopBorder={false}
-								>
-									<StraightLines
-										count={4}
-										cssOverrides={css`
-											display: block;
-										`}
-										color={palette.border.secondary}
+					)}
+					<Section
+						fullWidth={true}
+						borderColour={brandLine.primary}
+						showTopBorder={false}
+						padSides={false}
+						backgroundColour={brandBackground.primary}
+						element="nav"
+					>
+						<Nav
+							nav={NAV}
+							format={formatForNav}
+							subscribeUrl={
+								article.nav.readerRevenueLinks.header.subscribe
+							}
+							editionId={article.editionId}
+							headerTopBarSwitch={
+								!!article.config.switches.headerTopNav
+							}
+						/>
+					</Section>
+					{NAV.subNavSections && !isLabs && (
+						<>
+							<Section
+								fullWidth={true}
+								backgroundColour={palette.background.article}
+								padSides={false}
+								element="aside"
+							>
+								<Island deferUntil="idle">
+									<SubNav
+										subNavSections={NAV.subNavSections}
+										currentNavLink={NAV.currentNavLink}
+										format={format}
 									/>
-								</Section>
-							</>
-						)}
-					</>
+								</Island>
+							</Section>
+							<Section
+								fullWidth={true}
+								backgroundColour={palette.background.article}
+								padSides={false}
+								showTopBorder={false}
+							>
+								<StraightLines
+									count={4}
+									cssOverrides={css`
+										display: block;
+									`}
+									color={palette.border.secondary}
+								/>
+							</Section>
+						</>
+					)}
 				</div>
 			)}
 			{format.theme === ArticleSpecial.Labs && (
@@ -827,92 +821,106 @@ export const StandardLayout = ({
 					</Section>
 				)}
 
-				<Island
-					clientOnly={true}
-					deferUntil="visible"
-					placeholderHeight={600}
-				>
-					<OnwardsUpper
-						ajaxUrl={article.config.ajaxUrl}
-						hasRelated={article.hasRelated}
-						hasStoryPackage={article.hasStoryPackage}
-						isAdFreeUser={article.isAdFreeUser}
-						pageId={article.pageId}
-						isPaidContent={!!article.config.isPaidContent}
-						showRelatedContent={article.config.showRelatedContent}
-						keywordIds={article.config.keywordIds}
-						contentType={article.contentType}
-						tags={article.tags}
-						format={format}
-						pillar={format.theme}
-						editionId={article.editionId}
-						shortUrlId={article.config.shortUrlId}
-					/>
-				</Island>
+				{isWeb && (
+					<>
+						<Island
+							clientOnly={true}
+							deferUntil="visible"
+							placeholderHeight={600}
+						>
+							<OnwardsUpper
+								ajaxUrl={article.config.ajaxUrl}
+								hasRelated={article.hasRelated}
+								hasStoryPackage={article.hasStoryPackage}
+								isAdFreeUser={article.isAdFreeUser}
+								pageId={article.pageId}
+								isPaidContent={!!article.config.isPaidContent}
+								showRelatedContent={
+									article.config.showRelatedContent
+								}
+								keywordIds={article.config.keywordIds}
+								contentType={article.contentType}
+								tags={article.tags}
+								format={format}
+								pillar={format.theme}
+								editionId={article.editionId}
+								shortUrlId={article.config.shortUrlId}
+							/>
+						</Island>
 
-				{!isPaidContent && showComments && (
-					<Section
-						fullWidth={true}
-						sectionId="comments"
-						data-print-layout="hide"
-						element="section"
-					>
-						<DiscussionLayout
-							discussionApiUrl={article.config.discussionApiUrl}
-							shortUrlId={article.config.shortUrlId}
-							format={format}
-							discussionD2Uid={article.config.discussionD2Uid}
-							discussionApiClientHeader={
-								article.config.discussionApiClientHeader
-							}
-							enableDiscussionSwitch={
-								!!article.config.switches.enableDiscussionSwitch
-							}
-							isAdFreeUser={article.isAdFreeUser}
-							shouldHideAds={article.shouldHideAds}
-							idApiUrl={article.config.idApiUrl}
-						/>
-					</Section>
-				)}
-
-				{!isPaidContent && (
-					<Section
-						title="Most viewed"
-						padContent={false}
-						verticalMargins={false}
-						element="aside"
-						data-print-layout="hide"
-						data-link-name="most-popular"
-						data-component="most-popular"
-					>
-						<MostViewedFooterLayout>
-							<Island clientOnly={true} deferUntil="visible">
-								<MostViewedFooterData
-									sectionName={article.sectionName}
+						{!isPaidContent && showComments && (
+							<Section
+								fullWidth={true}
+								sectionId="comments"
+								data-print-layout="hide"
+								element="section"
+							>
+								<DiscussionLayout
+									discussionApiUrl={
+										article.config.discussionApiUrl
+									}
+									shortUrlId={article.config.shortUrlId}
 									format={format}
-									ajaxUrl={article.config.ajaxUrl}
-									edition={article.editionId}
+									discussionD2Uid={
+										article.config.discussionD2Uid
+									}
+									discussionApiClientHeader={
+										article.config.discussionApiClientHeader
+									}
+									enableDiscussionSwitch={
+										!!article.config.switches
+											.enableDiscussionSwitch
+									}
+									isAdFreeUser={article.isAdFreeUser}
+									shouldHideAds={article.shouldHideAds}
+									idApiUrl={article.config.idApiUrl}
 								/>
-							</Island>
-						</MostViewedFooterLayout>
-					</Section>
-				)}
+							</Section>
+						)}
 
-				{renderAds && !isLabs && (
-					<Section
-						fullWidth={true}
-						data-print-layout="hide"
-						padSides={false}
-						showTopBorder={false}
-						showSideBorders={false}
-						backgroundColour={neutral[93]}
-						element="aside"
-					>
-						<AdSlot
-							position="merchandising"
-							display={format.display}
-						/>
-					</Section>
+						{!isPaidContent && (
+							<Section
+								title="Most viewed"
+								padContent={false}
+								verticalMargins={false}
+								element="aside"
+								data-print-layout="hide"
+								data-link-name="most-popular"
+								data-component="most-popular"
+							>
+								<MostViewedFooterLayout>
+									<Island
+										clientOnly={true}
+										deferUntil="visible"
+									>
+										<MostViewedFooterData
+											sectionName={article.sectionName}
+											format={format}
+											ajaxUrl={article.config.ajaxUrl}
+											edition={article.editionId}
+										/>
+									</Island>
+								</MostViewedFooterLayout>
+							</Section>
+						)}
+
+						{renderAds && !isLabs && (
+							<Section
+								fullWidth={true}
+								data-print-layout="hide"
+								padSides={false}
+								showTopBorder={false}
+								showSideBorders={false}
+								backgroundColour={neutral[93]}
+								element="aside"
+							>
+								<AdSlot
+									position="merchandising"
+									display={format.display}
+								/>
+							</Section>
+						)}
+					</>
 				)}
 			</main>
 			{isWeb && (
@@ -933,7 +941,6 @@ export const StandardLayout = ({
 							</Island>
 						</Section>
 					)}
-
 					<Section
 						fullWidth={true}
 						data-print-layout="hide"
@@ -954,7 +961,6 @@ export const StandardLayout = ({
 							}
 						/>
 					</Section>
-
 					<BannerWrapper data-print-layout="hide">
 						<Island deferUntil="idle" clientOnly={true}>
 							<StickyBottomBanner
@@ -986,18 +992,8 @@ export const StandardLayout = ({
 							/>
 						</Island>
 					</BannerWrapper>
+					<MobileStickyContainer data-print-layout="hide" />
 				</>
-			)}
-			<MobileStickyContainer data-print-layout="hide" />
-			{/* TODO: Remove this test */}
-			{isWeb ? (
-				<div>
-					<p>Web test</p>
-				</div>
-			) : (
-				<div>
-					<p>Must be app test</p>
-				</div>
 			)}
 		</>
 	);


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

**Combined component approach for standard layout** - one option for #7421 

This adds a `renderingTarget` props to the StandardLayout component (currently in src>web>layouts) and uses it to establish an `isWeb` boolean, which then gets checked ahead of web-only elements, e.g.:

```
{isWeb && (
				<div data-print-layout="hide" id="bannerandheader">
					{renderAds && (
						<Stuck>
							<Section ...
``` 

The same type of logic could be used for app-specific or elements which need to be on both web and apps: 

```
{isWeb && (
	<div>
	        <p>Web test</p>
	</div>
)}
{isApps && (
	<div>
		<p>Must be app test</p>
	</div>
)}
{isWeb && isApps && (
	<div>
		<p>Gotta be on both</p>
	</div>
)}
```

## Screenshots

Resulting rendered apps article (have pared down the body of the article to demonstrate):
![image](https://user-images.githubusercontent.com/102960844/231811834-9d6abb23-3eb2-41f8-8545-dff4bc17af14.png)

