### PR TITLE
braze-components v13

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -60,7 +60,7 @@
 		"@emotion/server": "^11.4.0",
 		"@guardian/ab-core": "^4.0.0",
 		"@guardian/atoms-rendering": "^27.0.0",
-		"@guardian/braze-components": "^12.1.0",
+		"@guardian/braze-components": "^13.0.0",
 		"@guardian/bridget": "^2.3.0",
 		"@guardian/browserslist-config": "^4.0.0",
 		"@guardian/cdk": "^49.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2208,10 +2208,10 @@
   dependencies:
     is-mobile "3.1.1"
 
-"@guardian/braze-components@^12.1.0":
-  version "12.1.0"
-  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-12.1.0.tgz#41ddcf08e374c36c5d80e7c9141e508ae630fff6"
-  integrity sha512-NvjmamSUypaPoK3plyRpSWWmeMvmnhhOeWNNKielP2/4Je0AjkezIA8Fj2CnOD3Nkv5/aCc+/avWyAFj9md3yQ==
+"@guardian/braze-components@^13.0.0":
+  version "13.0.0"
+  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-13.0.0.tgz#af0839b56ebd4fb1180cbc45efe2ddd66a968bcb"
+  integrity sha512-M8fi4YuAxLRgifE0gI6HDC9Sq3q8+mypSbUF6jRZMT0fzngV9NSjdaLhkR7sYkc1aKB9Cdi3IqpfBiFO1qee5w==
 
 "@guardian/bridget@^2.3.0":
   version "2.3.0"


### PR DESCRIPTION
This version prepares braze-components for react 18 - https://github.com/guardian/braze-components/pull/408