### PR TITLE
Don't server side render the `exclusion` ad slot

### DIFF
--- a/dotcom-rendering/src/web/components/AdSlot.tsx
+++ b/dotcom-rendering/src/web/components/AdSlot.tsx
@@ -13,9 +13,11 @@ import {
 import { getZIndex } from '../lib/getZIndex';
 import { TopRightAdSlot } from './TopRightAdSlot.importable';
 
+type InlinePosition = 'inline' | 'liveblog-inline' | 'mobile-front';
+
 type InlineProps = {
 	display?: ArticleDisplay;
-	position: 'inline' | 'liveblog-inline' | 'mobile-front';
+	position: InlinePosition;
 	index: number;
 	shouldHideReaderRevenue?: boolean;
 	isPaidContent?: boolean;
@@ -23,7 +25,7 @@ type InlineProps = {
 
 type NonInlineProps = {
 	display?: ArticleDisplay;
-	position: Exclude<SlotName, 'inline' | 'liveblog-inline' | 'mobile-front'>;
+	position: Exclude<SlotName, InlinePosition>;
 	index?: never;
 	shouldHideReaderRevenue?: boolean;
 	isPaidContent?: boolean;
@@ -513,17 +515,6 @@ export const AdSlot = ({
 						aria-hidden="true"
 					/>
 				</div>
-			);
-		}
-		case 'exclusion': {
-			return (
-				<div
-					id={'dfp-ad--exclusion'}
-					className={['js-ad-slot', 'ad-slot'].join(' ')}
-					data-name="exclusion"
-					aria-hidden="true"
-					data-label="false"
-				/>
 			);
 		}
 		default:

--- a/dotcom-rendering/src/web/components/HeaderAdSlot.tsx
+++ b/dotcom-rendering/src/web/components/HeaderAdSlot.tsx
@@ -40,15 +40,6 @@ const adSlotContainer = css`
 
 export const HeaderAdSlot = ({ display }: Props) => (
 	<div css={headerWrapper}>
-		{/*
-			This is a special type of ad which, when filled, blocks
-			all other ads on the page. This allows us to run "exclusion
-			campaigns" against certain breaking news pages. Exclusion
-			ads are used for consentless advertising only. They are
-			ignored by GAM, which has a different mechanism to achieve
-			the same thing.
-		 */}
-		<AdSlot position="exclusion" />
 		<Global
 			styles={css`
 				/**


### PR DESCRIPTION
## What does this change?

Don't SSRing the `exclusion` ad slot.

See also https://github.com/guardian/frontend/pull/26070.

## Why?

Opt Out has a special slot called the `exclusion` which can be used to remotely disable advertising for entire pages in the Opt Out dashboard. It does not serve any actual advertising, and has to be ignored by Google Ad Manager.

We currently render an exclusion slot on every page, regardless of ad server we're using. We can avoid this by only inserting the slot client-side once we know we'll be serving Opt Out advertising.