### PR TITLE
fix: Immersive headline displaying too far down

### DIFF
--- a/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
@@ -16,7 +16,7 @@ import { StraightLines } from '@guardian/source-react-components-development-kit
 import { buildAdTargeting } from '../../lib/ad-targeting';
 import { parse } from '../../lib/slot-machine-flags';
 import type { NavType } from '../../model/extract-nav';
-import type { ImageBlockElement } from '../../types/content';
+import type { FEElement } from '../../types/content';
 import type { FEArticleType } from '../../types/frontend';
 import type { Palette } from '../../types/palette';
 import { AdSlot, MobileStickyContainer } from '../components/AdSlot';
@@ -188,16 +188,20 @@ interface Props {
 	format: ArticleFormat;
 }
 
-const decideCaption = (mainMedia: ImageBlockElement | undefined): string => {
+const decideCaption = (mainMedia: FEElement | undefined): string => {
 	const caption = [];
-	// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- because sometimes mainMedia isn't an image
-	if (mainMedia?.data?.caption) {
-		caption.push(mainMedia.data.caption);
-	}
 
-	// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- because sometimes mainMedia isn't an image
-	if (mainMedia?.displayCredit && mainMedia?.data?.credit) {
-		caption.push(mainMedia.data.credit);
+	if (
+		mainMedia?._type ===
+		'model.dotcomrendering.pageElements.ImageBlockElement'
+	) {
+		if (mainMedia.data.caption) {
+			caption.push(mainMedia.data.caption);
+		}
+
+		if (mainMedia.displayCredit && mainMedia.data.credit) {
+			caption.push(mainMedia.data.credit);
+		}
 	}
 
 	return caption.join(' ');
@@ -265,12 +269,7 @@ export const ImmersiveLayout = ({ article, NAV, format }: Props) => {
 
 	const showComments = article.isCommentable;
 
-	const mainMedia =
-		article.mainMediaElements[0] &&
-		article.mainMediaElements[0]._type ===
-			'model.dotcomrendering.pageElements.ImageBlockElement'
-			? article.mainMediaElements[0]
-			: undefined;
+	const mainMedia = article.mainMediaElements[0];
 
 	const captionText = decideCaption(mainMedia);
 	const HEADLINE_OFFSET = mainMedia ? 120 : 0;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Fixes headlines being too low on Immersives with videos as their main media element.

## Why?

We're strictly checking for ImageBlockElement in ImmersiveLayout, however the Main media element could be a variety of different elements such as VideoBlockElement and EmbedBlockElement

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/21217225/232047397-414d5f44-5242-42ca-86ff-e5d330433bfe.png
[after]: https://user-images.githubusercontent.com/21217225/232046686-d1866f07-507d-4b2c-ae3c-b7fe2bb77727.png


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->


<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
