### PR TITLE
Use `.storyName` To Name Stories

### DIFF
--- a/dotcom-rendering/src/amp/components/topMeta/Byline.stories.tsx
+++ b/dotcom-rendering/src/amp/components/topMeta/Byline.stories.tsx
@@ -63,6 +63,5 @@ export const MultipleDuplicateByline = () => (
 	/>
 );
 
-MultipleDuplicateByline.story = {
-	name: 'Byline w/ contributors with identical names',
-};
+MultipleDuplicateByline.storyName =
+	'Byline w/ contributors with identical names';

--- a/dotcom-rendering/src/web/components/ArticleHeadline.stories.tsx
+++ b/dotcom-rendering/src/web/components/ArticleHeadline.stories.tsx
@@ -158,9 +158,8 @@ export const ShowcaseInterviewNobyline = () => {
 		</Section>
 	);
 };
-ShowcaseInterviewNobyline.story = {
-	name: 'Interview (with showcase and NO BYLINE)',
-};
+ShowcaseInterviewNobyline.storyName =
+	'Interview (with showcase and NO BYLINE)';
 
 export const Interview = () => {
 	const format = {
@@ -244,9 +243,8 @@ export const InterviewSpecialReport = () => {
 		</Section>
 	);
 };
-InterviewSpecialReport.story = {
-	name: 'Interview Special Report (without showcase)',
-};
+InterviewSpecialReport.storyName =
+	'Interview Special Report (without showcase)';
 
 export const InterviewNoByline = () => {
 	const format = {
@@ -288,9 +286,8 @@ export const InterviewNoByline = () => {
 		</Section>
 	);
 };
-InterviewNoByline.story = {
-	name: 'Interview (without showcase with NO BYLINE)',
-};
+InterviewNoByline.storyName =
+	'Interview (without showcase with NO BYLINE)';
 
 export const Comment = () => {
 	const format = {

--- a/dotcom-rendering/src/web/components/ArticleMeta.stories.tsx
+++ b/dotcom-rendering/src/web/components/ArticleMeta.stories.tsx
@@ -184,9 +184,8 @@ export const FeatureWithMismatchedContributor = () => {
 		</Wrapper>
 	);
 };
-FeatureWithMismatchedContributor.story = {
-	name: 'Feature with a byline mismatching the contributor tag',
-};
+FeatureWithMismatchedContributor.storyName =
+	'Feature with a byline mismatching the contributor tag';
 
 export const FeatureStoryWithSmallBylineImage = () => {
 	return (
@@ -212,9 +211,8 @@ export const FeatureStoryWithSmallBylineImage = () => {
 		</Wrapper>
 	);
 };
-FeatureStoryWithSmallBylineImage.story = {
-	name: 'Feature with Small Byline Image',
-};
+FeatureStoryWithSmallBylineImage.storyName =
+	'Feature with Small Byline Image';
 
 export const SpecialReportStory = () => {
 	return (

--- a/dotcom-rendering/src/web/components/CaptionBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/web/components/CaptionBlockComponent.stories.tsx
@@ -61,9 +61,8 @@ export const StandardArticle = () => {
 		</Wrapper>
 	);
 };
-StandardArticle.story = {
-	name: 'with defaults',
-};
+StandardArticle.storyName =
+	'with defaults';
 
 export const PhotoEssay = () => {
 	return (
@@ -84,9 +83,8 @@ export const PhotoEssay = () => {
 		</Wrapper>
 	);
 };
-PhotoEssay.story = {
-	name: 'PhotoEssay',
-};
+PhotoEssay.storyName =
+	'PhotoEssay';
 
 export const PhotoEssayHTML = () => {
 	return (
@@ -107,9 +105,8 @@ export const PhotoEssayHTML = () => {
 		</Wrapper>
 	);
 };
-PhotoEssayHTML.story = {
-	name: 'PhotoEssay using html',
-};
+PhotoEssayHTML.storyName =
+	'PhotoEssay using html';
 
 export const Padded = () => {
 	return (
@@ -130,9 +127,8 @@ export const Padded = () => {
 		</Wrapper>
 	);
 };
-Padded.story = {
-	name: 'when padded',
-};
+Padded.storyName =
+	'when padded';
 
 export const WidthLimited = () => {
 	return (
@@ -153,9 +149,8 @@ export const WidthLimited = () => {
 		</Wrapper>
 	);
 };
-WidthLimited.story = {
-	name: 'with width limited',
-};
+WidthLimited.storyName =
+	'with width limited';
 
 export const Credited = () => {
 	return (
@@ -176,9 +171,8 @@ export const Credited = () => {
 		</Wrapper>
 	);
 };
-Credited.story = {
-	name: 'with credit',
-};
+Credited.storyName =
+	'with credit';
 
 export const Overlaid = () => {
 	return (
@@ -199,6 +193,5 @@ export const Overlaid = () => {
 		</Wrapper>
 	);
 };
-Overlaid.story = {
-	name: 'when overlaid',
-};
+Overlaid.storyName =
+	'when overlaid';

--- a/dotcom-rendering/src/web/components/Card/Card.stories.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.stories.tsx
@@ -1073,9 +1073,8 @@ export const WithLetterDesign = () => {
 	);
 };
 
-WithLetterDesign.story = {
-	name: 'WithLetterDesign',
-};
+WithLetterDesign.storyName =
+	'WithLetterDesign';
 
 export const WithLetterDesignAndShowQuotedHeadline = () => {
 	return (
@@ -1095,6 +1094,5 @@ export const WithLetterDesignAndShowQuotedHeadline = () => {
 	);
 };
 
-WithLetterDesignAndShowQuotedHeadline.story = {
-	name: 'WithLetterDesignAndShowQuotedHeadline',
-};
+WithLetterDesignAndShowQuotedHeadline.storyName =
+	'WithLetterDesignAndShowQuotedHeadline';

--- a/dotcom-rendering/src/web/components/ClickToView.stories.tsx
+++ b/dotcom-rendering/src/web/components/ClickToView.stories.tsx
@@ -677,9 +677,8 @@ export const EmbedBlockComponentStory = () => {
 		</Section>
 	);
 };
-EmbedBlockComponentStory.story = {
-	name: 'Click to view wrapping EmbedBlockComponent',
-};
+EmbedBlockComponentStory.storyName =
+	'Click to view wrapping EmbedBlockComponent';
 
 export const UnsafeEmbedBlockComponentStory = () => {
 	return (
@@ -835,9 +834,8 @@ export const UnsafeEmbedBlockComponentStory = () => {
 		</Section>
 	);
 };
-UnsafeEmbedBlockComponentStory.story = {
-	name: 'Click to view wrapping UnsafeEmbedBlockComponent',
-};
+UnsafeEmbedBlockComponentStory.storyName =
+	'Click to view wrapping UnsafeEmbedBlockComponent';
 
 export const VimeoBlockComponentStory = () => {
 	return (
@@ -898,9 +896,8 @@ export const VimeoBlockComponentStory = () => {
 		</Section>
 	);
 };
-VimeoBlockComponentStory.story = {
-	name: 'Click to view wrapping VimeoBlockComponent',
-};
+VimeoBlockComponentStory.storyName =
+	'Click to view wrapping VimeoBlockComponent';
 
 export const DocumentBlockComponentStory = () => {
 	return (
@@ -955,9 +952,8 @@ export const DocumentBlockComponentStory = () => {
 		</Section>
 	);
 };
-DocumentBlockComponentStory.story = {
-	name: 'Click to view wrapping DocumentBlockComponentStory',
-};
+DocumentBlockComponentStory.storyName =
+	'Click to view wrapping DocumentBlockComponentStory';
 
 export const SoundCloudBlockComponentStory = () => {
 	return (
@@ -1034,9 +1030,8 @@ export const SoundCloudBlockComponentStory = () => {
 		</Section>
 	);
 };
-SoundCloudBlockComponentStory.story = {
-	name: 'Click to view wrapping SoundCloudBlockComponent',
-};
+SoundCloudBlockComponentStory.storyName =
+	'Click to view wrapping SoundCloudBlockComponent';
 
 export const SpotifyBlockComponentStory = () => {
 	return (
@@ -1100,9 +1095,8 @@ export const SpotifyBlockComponentStory = () => {
 	);
 };
 
-SpotifyBlockComponentStory.story = {
-	name: 'Click to view wrapping SpotifyBlockComponent',
-};
+SpotifyBlockComponentStory.storyName =
+	'Click to view wrapping SpotifyBlockComponent';
 
 export const TweetBlockComponentStory = () => {
 	return (
@@ -1150,9 +1144,8 @@ export const TweetBlockComponentStory = () => {
 		</Section>
 	);
 };
-TweetBlockComponentStory.story = {
-	name: 'Click to view wrapping TweetBlockComponent',
-};
+TweetBlockComponentStory.storyName =
+	'Click to view wrapping TweetBlockComponent';
 export const InstagramBlockComponentStory = () => {
 	return (
 		<Section
@@ -1197,9 +1190,8 @@ export const InstagramBlockComponentStory = () => {
 		</Section>
 	);
 };
-InstagramBlockComponentStory.story = {
-	name: 'Click to view wrapping InstagramBlockComponent',
-};
+InstagramBlockComponentStory.storyName =
+	'Click to view wrapping InstagramBlockComponent';
 export const MapBlockComponentStory = () => {
 	return (
 		<Section
@@ -1260,9 +1252,8 @@ export const MapBlockComponentStory = () => {
 		</Section>
 	);
 };
-MapBlockComponentStory.story = {
-	name: 'Click to view wrapping MapEmbedBlockComponent',
-};
+MapBlockComponentStory.storyName =
+	'Click to view wrapping MapEmbedBlockComponent';
 export const VineBlockComponentStory = () => {
 	return (
 		<Section
@@ -1312,6 +1303,5 @@ export const VineBlockComponentStory = () => {
 		</Section>
 	);
 };
-VineBlockComponentStory.story = {
-	name: 'Click to view wrapping VineBlockComponent',
-};
+VineBlockComponentStory.storyName =
+	'Click to view wrapping VineBlockComponent';

--- a/dotcom-rendering/src/web/components/CodeBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/web/components/CodeBlockComponent.stories.tsx
@@ -20,6 +20,5 @@ sudo gor --input-raw :80 --output-http http://apiv2.code.co.uk
 		</Section>
 	);
 };
-CodeStory.story = {
-	name: 'default',
-};
+CodeStory.storyName =
+	'default';

--- a/dotcom-rendering/src/web/components/CommentBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/web/components/CommentBlockComponent.stories.tsx
@@ -60,6 +60,5 @@ export const embeddedBlockquoteStory = () => {
 		</div>
 	);
 };
-embeddedBlockquoteStory.story = {
-	name: 'Comment block which contains a blockquote',
-};
+embeddedBlockquoteStory.storyName =
+	'Comment block which contains a blockquote';

--- a/dotcom-rendering/src/web/components/DynamicFast.stories.tsx
+++ b/dotcom-rendering/src/web/components/DynamicFast.stories.tsx
@@ -45,9 +45,8 @@ export const OneHugeTwoBigsSixStandards = () => (
 		/>
 	</FrontSection>
 );
-OneHugeTwoBigsSixStandards.story = {
-	name: 'With 1 huge card, 2 bigs, 6 standards',
-};
+OneHugeTwoBigsSixStandards.storyName =
+	'With 1 huge card, 2 bigs, 6 standards';
 
 export const OneVeryBigTwoBigsSixStandards = () => (
 	<FrontSection
@@ -66,9 +65,8 @@ export const OneVeryBigTwoBigsSixStandards = () => (
 		/>
 	</FrontSection>
 );
-OneVeryBigTwoBigsSixStandards.story = {
-	name: 'with 1 very big card, 2 bigs, 6 standards',
-};
+OneVeryBigTwoBigsSixStandards.storyName =
+	'with 1 very big card, 2 bigs, 6 standards';
 
 export const TwoVeryBigsTwoBigsSixStandards = () => (
 	<FrontSection
@@ -87,9 +85,8 @@ export const TwoVeryBigsTwoBigsSixStandards = () => (
 		/>
 	</FrontSection>
 );
-TwoVeryBigsTwoBigsSixStandards.story = {
-	name: 'with 2 very big cards, 2 bigs, 6 standards',
-};
+TwoVeryBigsTwoBigsSixStandards.storyName =
+	'with 2 very big cards, 2 bigs, 6 standards';
 
 export const TwoVeryBigs1stBoostedTwoBigsSixStandards = () => (
 	<FrontSection
@@ -108,9 +105,8 @@ export const TwoVeryBigs1stBoostedTwoBigsSixStandards = () => (
 		/>
 	</FrontSection>
 );
-TwoVeryBigs1stBoostedTwoBigsSixStandards.story = {
-	name: 'with 2 very big cards (1st boosted), 2 bigs, 6 standards',
-};
+TwoVeryBigs1stBoostedTwoBigsSixStandards.storyName =
+	'with 2 very big cards (1st boosted), 2 bigs, 6 standards';
 
 export const TwoVeryBigs2ndBoostedTwoBigsSixStandards = () => (
 	<FrontSection
@@ -129,9 +125,8 @@ export const TwoVeryBigs2ndBoostedTwoBigsSixStandards = () => (
 		/>
 	</FrontSection>
 );
-TwoVeryBigs2ndBoostedTwoBigsSixStandards.story = {
-	name: 'with 2 very big cards (2nd boosted), 2 bigs, 6 standards',
-};
+TwoVeryBigs2ndBoostedTwoBigsSixStandards.storyName =
+	'with 2 very big cards (2nd boosted), 2 bigs, 6 standards';
 
 /* Second Slice variants */
 
@@ -152,9 +147,8 @@ export const TwoVeryBigsTwelveStandards = () => (
 	</FrontSection>
 );
 
-TwoVeryBigsTwelveStandards.story = {
-	name: 'with 2 very big cards, 12 standards',
-};
+TwoVeryBigsTwelveStandards.storyName =
+	'with 2 very big cards, 12 standards';
 
 export const TwoVeryBigsOneBigEightStandards = () => (
 	<FrontSection
@@ -174,9 +168,8 @@ export const TwoVeryBigsOneBigEightStandards = () => (
 	</FrontSection>
 );
 
-TwoVeryBigsOneBigEightStandards.story = {
-	name: 'with 2 very big cards, 1 big, 8 standards',
-};
+TwoVeryBigsOneBigEightStandards.storyName =
+	'with 2 very big cards, 1 big, 8 standards';
 
 export const TwoVeryBigsOneBigBoostedSixStandards = () => (
 	<FrontSection
@@ -196,9 +189,8 @@ export const TwoVeryBigsOneBigBoostedSixStandards = () => (
 	</FrontSection>
 );
 
-TwoVeryBigsOneBigBoostedSixStandards.story = {
-	name: 'with 2 very big cards, 1 big (boosted), 6 standards',
-};
+TwoVeryBigsOneBigBoostedSixStandards.storyName =
+	'with 2 very big cards, 1 big (boosted), 6 standards';
 
 export const TwoVeryBigsTwoBigsFiveStandards = () => (
 	<FrontSection
@@ -218,9 +210,8 @@ export const TwoVeryBigsTwoBigsFiveStandards = () => (
 	</FrontSection>
 );
 
-TwoVeryBigsTwoBigsFiveStandards.story = {
-	name: 'with 2 very big cards, 2 bigs, 5 standards',
-};
+TwoVeryBigsTwoBigsFiveStandards.storyName =
+	'with 2 very big cards, 2 bigs, 5 standards';
 
 export const TwoVeryBigsTwoBigsFirstBoostedEightStandards = () => (
 	<FrontSection
@@ -240,9 +231,8 @@ export const TwoVeryBigsTwoBigsFirstBoostedEightStandards = () => (
 	</FrontSection>
 );
 
-TwoVeryBigsTwoBigsFirstBoostedEightStandards.story = {
-	name: 'with 2 very big cards, 2 bigs (first boosted), 8 standards',
-};
+TwoVeryBigsTwoBigsFirstBoostedEightStandards.storyName =
+	'with 2 very big cards, 2 bigs (first boosted), 8 standards';
 
 export const TwoVeryBigsThreeBigsThreeStandards = () => (
 	<FrontSection
@@ -262,9 +252,8 @@ export const TwoVeryBigsThreeBigsThreeStandards = () => (
 	</FrontSection>
 );
 
-TwoVeryBigsThreeBigsThreeStandards.story = {
-	name: 'with 2 very big cards, 3 bigs, 3 standards',
-};
+TwoVeryBigsThreeBigsThreeStandards.storyName =
+	'with 2 very big cards, 3 bigs, 3 standards';
 
 export const TwoVeryBigsFourBigs = () => (
 	<FrontSection
@@ -283,9 +272,8 @@ export const TwoVeryBigsFourBigs = () => (
 	</FrontSection>
 );
 
-TwoVeryBigsFourBigs.story = {
-	name: 'with 2 very big cards, 4 bigs',
-};
+TwoVeryBigsFourBigs.storyName =
+	'with 2 very big cards, 4 bigs';
 
 /* Edge cases */
 
@@ -309,9 +297,8 @@ export const OneHugeOneVeryBig7Standards = () => (
 	</FrontSection>
 );
 
-OneHugeOneVeryBig7Standards.story = {
-	name: 'with 1 huge, 1 very big, 7 standards',
-};
+OneHugeOneVeryBig7Standards.storyName =
+	'with 1 huge, 1 very big, 7 standards';
 
 // Second test: 3 very bigs (& the last big is not shown)
 export const ThreeVeryBigsFourBigs = () => (
@@ -331,9 +318,8 @@ export const ThreeVeryBigsFourBigs = () => (
 	</FrontSection>
 );
 
-OneHugeOneVeryBig7Standards.story = {
-	name: 'with 1 huge, 1 very big, 7 standards',
-};
+OneHugeOneVeryBig7Standards.storyName =
+	'with 1 huge, 1 very big, 7 standards';
 
 // No first slice is provided
 export const TwoBigsFourStandards = () => (
@@ -353,9 +339,8 @@ export const TwoBigsFourStandards = () => (
 	</FrontSection>
 );
 
-TwoBigsFourStandards.story = {
-	name: 'with 2 bigs, 4 standards',
-};
+TwoBigsFourStandards.storyName =
+	'with 2 bigs, 4 standards';
 
 // No standards are provided
 // First test: there are some (2) bigs
@@ -376,9 +361,8 @@ export const OneVeryBigTwoBigs = () => (
 	</FrontSection>
 );
 
-OneVeryBigTwoBigs.story = {
-	name: 'with 1 very big, 2 bigs',
-};
+OneVeryBigTwoBigs.storyName =
+	'with 1 very big, 2 bigs';
 
 // Second test: There are no bigs (first slice only)
 export const OneVeryBig = () => (
@@ -397,9 +381,8 @@ export const OneVeryBig = () => (
 	</FrontSection>
 );
 
-OneVeryBig.story = {
-	name: 'with 1 very big',
-};
+OneVeryBig.storyName =
+	'with 1 very big';
 
 // Bigs are demoted in twoOrMoreBigsFirstBoosted layout
 export const TwoVeryBigsFourBigsFirstBoostedThreeStandards = () => (
@@ -420,6 +403,5 @@ export const TwoVeryBigsFourBigsFirstBoostedThreeStandards = () => (
 	</FrontSection>
 );
 
-TwoVeryBigsFourBigsFirstBoostedThreeStandards.story = {
-	name: 'with 2 very big cards, 4 bigs (first boosted), 3 standards',
-};
+TwoVeryBigsFourBigsFirstBoostedThreeStandards.storyName =
+	'with 2 very big cards, 4 bigs (first boosted), 3 standards';

--- a/dotcom-rendering/src/web/components/DynamicPackage.stories.tsx
+++ b/dotcom-rendering/src/web/components/DynamicPackage.stories.tsx
@@ -42,9 +42,8 @@ export const One = () => (
 		/>
 	</FrontSection>
 );
-One.story = {
-	name: 'With one standard card',
-};
+One.storyName =
+	'With one standard card';
 
 export const Two = () => (
 	<FrontSection
@@ -62,9 +61,8 @@ export const Two = () => (
 		/>
 	</FrontSection>
 );
-Two.story = {
-	name: 'With two standard cards',
-};
+Two.storyName =
+	'With two standard cards';
 
 export const Three = () => (
 	<FrontSection title="Dynamic Package" centralBorder="partial">
@@ -78,9 +76,8 @@ export const Three = () => (
 		/>
 	</FrontSection>
 );
-Three.story = {
-	name: 'With three standard cards',
-};
+Three.storyName =
+	'With three standard cards';
 
 export const Four = () => (
 	<FrontSection title="Dynamic Package" centralBorder="partial">
@@ -94,9 +91,8 @@ export const Four = () => (
 		/>
 	</FrontSection>
 );
-Four.story = {
-	name: 'With four standard cards',
-};
+Four.storyName =
+	'With four standard cards';
 
 export const Five = () => (
 	<FrontSection title="Dynamic Package" centralBorder="partial">
@@ -110,9 +106,8 @@ export const Five = () => (
 		/>
 	</FrontSection>
 );
-Five.story = {
-	name: 'With five standard cards',
-};
+Five.storyName =
+	'With five standard cards';
 
 export const Six = () => (
 	<FrontSection
@@ -130,9 +125,8 @@ export const Six = () => (
 		/>
 	</FrontSection>
 );
-Six.story = {
-	name: 'With six standard cards',
-};
+Six.storyName =
+	'With six standard cards';
 
 export const Seven = () => (
 	<FrontSection
@@ -150,9 +144,8 @@ export const Seven = () => (
 		/>
 	</FrontSection>
 );
-Seven.story = {
-	name: 'With seven standard cards',
-};
+Seven.storyName =
+	'With seven standard cards';
 
 export const Eight = () => (
 	<FrontSection
@@ -170,9 +163,8 @@ export const Eight = () => (
 		/>
 	</FrontSection>
 );
-Eight.story = {
-	name: 'With eight standard cards',
-};
+Eight.storyName =
+	'With eight standard cards';
 
 export const Nine = () => (
 	<FrontSection
@@ -191,9 +183,8 @@ export const Nine = () => (
 		/>
 	</FrontSection>
 );
-Nine.story = {
-	name: 'With nine standard cards',
-};
+Nine.storyName =
+	'With nine standard cards';
 
 export const Boosted1 = () => {
 	const primary = trails[0];
@@ -216,9 +207,8 @@ export const Boosted1 = () => {
 		</FrontSection>
 	);
 };
-Boosted1.story = {
-	name: 'With one standard card - boosted',
-};
+Boosted1.storyName =
+	'With one standard card - boosted';
 
 export const Boosted2 = () => {
 	const primary = trails[0];
@@ -242,9 +232,8 @@ export const Boosted2 = () => {
 		</FrontSection>
 	);
 };
-Boosted2.story = {
-	name: 'With two standard cards - boosted',
-};
+Boosted2.storyName =
+	'With two standard cards - boosted';
 
 export const Boosted3 = () => {
 	const primary = trails[0];
@@ -264,9 +253,8 @@ export const Boosted3 = () => {
 		</FrontSection>
 	);
 };
-Boosted3.story = {
-	name: 'With three standard cards - boosted',
-};
+Boosted3.storyName =
+	'With three standard cards - boosted';
 
 export const Boosted4 = () => {
 	const primary = trails[0];
@@ -286,9 +274,8 @@ export const Boosted4 = () => {
 		</FrontSection>
 	);
 };
-Boosted4.story = {
-	name: 'With four standard cards - boosted',
-};
+Boosted4.storyName =
+	'With four standard cards - boosted';
 
 export const Boosted5 = () => {
 	const primary = trails[0];
@@ -308,9 +295,8 @@ export const Boosted5 = () => {
 		</FrontSection>
 	);
 };
-Boosted5.story = {
-	name: 'With five standard cards - boosted',
-};
+Boosted5.storyName =
+	'With five standard cards - boosted';
 
 export const Boosted8 = () => {
 	const primary = trails[0];
@@ -334,9 +320,8 @@ export const Boosted8 = () => {
 		</FrontSection>
 	);
 };
-Boosted8.story = {
-	name: 'With eight standard cards - boosted',
-};
+Boosted8.storyName =
+	'With eight standard cards - boosted';
 
 export const Boosted9 = () => {
 	const primary = trails[0];
@@ -360,9 +345,8 @@ export const Boosted9 = () => {
 		</FrontSection>
 	);
 };
-Boosted9.story = {
-	name: 'With nine standard cards - boosted',
-};
+Boosted9.storyName =
+	'With nine standard cards - boosted';
 
 export const OneSnapThreeStandard = () => (
 	<FrontSection title="Dynamic Package" centralBorder="partial">
@@ -376,9 +360,8 @@ export const OneSnapThreeStandard = () => (
 		/>
 	</FrontSection>
 );
-OneSnapThreeStandard.story = {
-	name: 'With one snap - three standard cards',
-};
+OneSnapThreeStandard.storyName =
+	'With one snap - three standard cards';
 
 export const ThreeSnapTwoStandard = () => (
 	<FrontSection title="Dynamic Package" centralBorder="partial">
@@ -392,9 +375,8 @@ export const ThreeSnapTwoStandard = () => (
 		/>
 	</FrontSection>
 );
-ThreeSnapTwoStandard.story = {
-	name: 'With three snaps - two standard cards',
-};
+ThreeSnapTwoStandard.storyName =
+	'With three snaps - two standard cards';
 
 export const ThreeSnapTwoStandard2ndBoosted = () => (
 	<FrontSection title="Dynamic Package" centralBorder="partial">
@@ -408,6 +390,5 @@ export const ThreeSnapTwoStandard2ndBoosted = () => (
 		/>
 	</FrontSection>
 );
-ThreeSnapTwoStandard2ndBoosted.story = {
-	name: 'With three snaps (2nd boosted) - two standard cards',
-};
+ThreeSnapTwoStandard2ndBoosted.storyName =
+	'With three snaps (2nd boosted) - two standard cards';

--- a/dotcom-rendering/src/web/components/DynamicSlow.stories.tsx
+++ b/dotcom-rendering/src/web/components/DynamicSlow.stories.tsx
@@ -80,9 +80,8 @@ export const OneHugeTwoBigsFourStandards = () => (
 		/>
 	</FrontSection>
 );
-OneHugeTwoBigsFourStandards.story = {
-	name: 'With 1 huge card, 2 bigs, 4 standards',
-};
+OneHugeTwoBigsFourStandards.storyName =
+	'With 1 huge card, 2 bigs, 4 standards';
 
 export const OneVeryBigTwoBigsFourStandards = () => (
 	<FrontSection
@@ -101,9 +100,8 @@ export const OneVeryBigTwoBigsFourStandards = () => (
 		/>
 	</FrontSection>
 );
-OneVeryBigTwoBigsFourStandards.story = {
-	name: 'with 1 very big card, 2 bigs, 4 standards',
-};
+OneVeryBigTwoBigsFourStandards.storyName =
+	'with 1 very big card, 2 bigs, 4 standards';
 
 export const TwoVeryBigsTwoBigsFourStandards = () => (
 	<FrontSection
@@ -122,9 +120,8 @@ export const TwoVeryBigsTwoBigsFourStandards = () => (
 		/>
 	</FrontSection>
 );
-TwoVeryBigsTwoBigsFourStandards.story = {
-	name: 'with 2 very big cards, 2 bigs, 4 standards',
-};
+TwoVeryBigsTwoBigsFourStandards.storyName =
+	'with 2 very big cards, 2 bigs, 4 standards';
 
 export const TwoVeryBigs1stBoostedTwoBigsFourStandards = () => (
 	<FrontSection
@@ -143,9 +140,8 @@ export const TwoVeryBigs1stBoostedTwoBigsFourStandards = () => (
 		/>
 	</FrontSection>
 );
-TwoVeryBigs1stBoostedTwoBigsFourStandards.story = {
-	name: 'with 2 very big cards (1st boosted), 2 bigs, 4 standards',
-};
+TwoVeryBigs1stBoostedTwoBigsFourStandards.storyName =
+	'with 2 very big cards (1st boosted), 2 bigs, 4 standards';
 
 export const TwoVeryBigs2ndBoostedTwoBigsFourStandards = () => (
 	<FrontSection
@@ -164,9 +160,8 @@ export const TwoVeryBigs2ndBoostedTwoBigsFourStandards = () => (
 		/>
 	</FrontSection>
 );
-TwoVeryBigs2ndBoostedTwoBigsFourStandards.story = {
-	name: 'with 2 very big cards (2nd boosted), 2 bigs, 4 standards',
-};
+TwoVeryBigs2ndBoostedTwoBigsFourStandards.storyName =
+	'with 2 very big cards (2nd boosted), 2 bigs, 4 standards';
 
 /* Second Slice Variants */
 export const TwoVeryBigs8Standards = () => (
@@ -185,9 +180,8 @@ export const TwoVeryBigs8Standards = () => (
 		/>
 	</FrontSection>
 );
-TwoVeryBigs8Standards.story = {
-	name: 'with 2 very bigs, 8 standards',
-};
+TwoVeryBigs8Standards.storyName =
+	'with 2 very bigs, 8 standards';
 
 export const TwoVeryBigsOneBig4Standards = () => (
 	<FrontSection
@@ -207,9 +201,8 @@ export const TwoVeryBigsOneBig4Standards = () => (
 	</FrontSection>
 );
 
-TwoVeryBigsOneBig4Standards.story = {
-	name: 'with 2 very bigs, 1 big, 8 standards',
-};
+TwoVeryBigsOneBig4Standards.storyName =
+	'with 2 very bigs, 1 big, 8 standards';
 
 export const TwoVeryBigsTwoBigs4Standards = () => (
 	<FrontSection
@@ -228,9 +221,8 @@ export const TwoVeryBigsTwoBigs4Standards = () => (
 		/>
 	</FrontSection>
 );
-TwoVeryBigsTwoBigs4Standards.story = {
-	name: 'with 2 very bigs, 2 bigs, 8 standards',
-};
+TwoVeryBigsTwoBigs4Standards.storyName =
+	'with 2 very bigs, 2 bigs, 8 standards';
 
 /* Edge cases */
 
@@ -251,9 +243,8 @@ export const TwoVeryBigsFiveStandards = () => (
 		/>
 	</FrontSection>
 );
-TwoVeryBigsFiveStandards.story = {
-	name: 'with 2 very bigs, 5 standards',
-};
+TwoVeryBigsFiveStandards.storyName =
+	'with 2 very bigs, 5 standards';
 
 // Demote a very big to a big & fifth standard is not shown
 export const ThreeVeryBigsFiveStandards = () => (
@@ -272,9 +263,8 @@ export const ThreeVeryBigsFiveStandards = () => (
 		/>
 	</FrontSection>
 );
-ThreeVeryBigsFiveStandards.story = {
-	name: 'with 3 very bigs, 5 standards',
-};
+ThreeVeryBigsFiveStandards.storyName =
+	'with 3 very bigs, 5 standards';
 
 // No standards were provided
 export const TwoVeryBigsOneBig = () => (
@@ -293,9 +283,8 @@ export const TwoVeryBigsOneBig = () => (
 		/>
 	</FrontSection>
 );
-TwoVeryBigsOneBig.story = {
-	name: 'with 2 very bigs, 1 big',
-};
+TwoVeryBigsOneBig.storyName =
+	'with 2 very bigs, 1 big';
 
 // No first slice
 export const TwoBigsThreeStandards = () => (
@@ -314,9 +303,8 @@ export const TwoBigsThreeStandards = () => (
 		/>
 	</FrontSection>
 );
-TwoBigsThreeStandards.story = {
-	name: 'with 2 bigs, 3 standards',
-};
+TwoBigsThreeStandards.storyName =
+	'with 2 bigs, 3 standards';
 
 // Just 1 standard
 export const OneVeryBigTwoBigsOneStandard = () => (
@@ -336,6 +324,5 @@ export const OneVeryBigTwoBigsOneStandard = () => (
 		/>
 	</FrontSection>
 );
-OneVeryBigTwoBigsOneStandard.story = {
-	name: 'with 2 very bigs, two bigs, 1 standard',
-};
+OneVeryBigTwoBigsOneStandard.storyName =
+	'with 2 very bigs, two bigs, 1 standard';

--- a/dotcom-rendering/src/web/components/FrontSection.stories.tsx
+++ b/dotcom-rendering/src/web/components/FrontSection.stories.tsx
@@ -120,9 +120,8 @@ export const LeftContentStory = () => {
 		</FrontSection>
 	);
 };
-LeftContentStory.story = {
-	name: 'with an element passed into the left column',
-};
+LeftContentStory.storyName =
+	'with an element passed into the left column';
 
 export const BackgroundStory = () => {
 	return (
@@ -154,9 +153,8 @@ export const InnerBackgroundStory = () => {
 		</FrontSection>
 	);
 };
-InnerBackgroundStory.story = {
-	name: 'with a blue inner background',
-};
+InnerBackgroundStory.storyName =
+	'with a blue inner background';
 
 export const DifferentBackgrounds = () => {
 	return (
@@ -173,9 +171,8 @@ export const DifferentBackgrounds = () => {
 		</FrontSection>
 	);
 };
-DifferentBackgrounds.story = {
-	name: 'with inner background different to main background',
-};
+DifferentBackgrounds.storyName =
+	'with inner background different to main background';
 
 export const StretchRightStory = () => {
 	return (
@@ -189,9 +186,8 @@ export const StretchRightStory = () => {
 		</FrontSection>
 	);
 };
-StretchRightStory.story = {
-	name: 'with content stretched to the right (no margin)',
-};
+StretchRightStory.storyName =
+	'with content stretched to the right (no margin)';
 
 export const PartialStory = () => {
 	return (
@@ -350,6 +346,5 @@ export const TreatsStory = () => {
 		</FrontSection>
 	);
 };
-TreatsStory.story = {
-	name: 'with treats and date header',
-};
+TreatsStory.storyName =
+	'with treats and date header';

--- a/dotcom-rendering/src/web/components/HeaderTopBarMyAccount.stories.tsx
+++ b/dotcom-rendering/src/web/components/HeaderTopBarMyAccount.stories.tsx
@@ -20,9 +20,8 @@ export const defaultStory = () => {
 	);
 };
 
-defaultStory.story = {
-	name: 'not signed in',
-};
+defaultStory.storyName =
+	'not signed in';
 
 export const signedInStory = () => {
 	return (
@@ -36,6 +35,5 @@ export const signedInStory = () => {
 	);
 };
 
-signedInStory.story = {
-	name: 'signed in',
-};
+signedInStory.storyName =
+	'signed in';

--- a/dotcom-rendering/src/web/components/HeadlineByline.stories.tsx
+++ b/dotcom-rendering/src/web/components/HeadlineByline.stories.tsx
@@ -186,9 +186,8 @@ export const MultipleDuplicateStory = () => {
 		/>
 	);
 };
-MultipleDuplicateStory.story = {
-	name: 'Immersive with multiple contributors with distinct tags but identical names',
-};
+MultipleDuplicateStory.storyName =
+	'Immersive with multiple contributors with distinct tags but identical names';
 
 export const noBylineStory = () => {
 	return (

--- a/dotcom-rendering/src/web/components/ImageBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/web/components/ImageBlockComponent.stories.tsx
@@ -72,9 +72,8 @@ export const StandardArticle = () => {
 		</Wrapper>
 	);
 };
-StandardArticle.story = {
-	name: 'with role inline',
-};
+StandardArticle.storyName =
+	'with role inline';
 
 export const Immersive = () => {
 	return (
@@ -100,9 +99,8 @@ export const Immersive = () => {
 		</Wrapper>
 	);
 };
-Immersive.story = {
-	name: 'with role immersive',
-};
+Immersive.storyName =
+	'with role immersive';
 
 export const Showcase = () => {
 	return (
@@ -128,9 +126,8 @@ export const Showcase = () => {
 		</Wrapper>
 	);
 };
-Showcase.story = {
-	name: 'with role showcase',
-};
+Showcase.storyName =
+	'with role showcase';
 
 export const Thumbnail = () => {
 	return (
@@ -156,9 +153,8 @@ export const Thumbnail = () => {
 		</Wrapper>
 	);
 };
-Thumbnail.story = {
-	name: 'with role thumbnail',
-};
+Thumbnail.storyName =
+	'with role thumbnail';
 
 export const Supporting = () => {
 	return (
@@ -184,9 +180,8 @@ export const Supporting = () => {
 		</Wrapper>
 	);
 };
-Supporting.story = {
-	name: 'with role supporting',
-};
+Supporting.storyName =
+	'with role supporting';
 
 export const HideCaption = () => {
 	return (
@@ -213,9 +208,8 @@ export const HideCaption = () => {
 		</Wrapper>
 	);
 };
-HideCaption.story = {
-	name: 'with hideCaption true',
-};
+HideCaption.storyName =
+	'with hideCaption true';
 
 export const InlineTitle = () => {
 	return (
@@ -311,9 +305,8 @@ export const ImmersiveTitle = () => {
 		</Wrapper>
 	);
 };
-ImmersiveTitle.story = {
-	name: 'with title and role immersive',
-};
+ImmersiveTitle.storyName =
+	'with title and role immersive';
 
 export const ShowcaseTitle = () => {
 	return (

--- a/dotcom-rendering/src/web/components/LiveBlock.stories.tsx
+++ b/dotcom-rendering/src/web/components/LiveBlock.stories.tsx
@@ -468,9 +468,8 @@ export const Updated = () => {
 		</Wrapper>
 	);
 };
-Updated.story = {
-	name: 'with updated time showing',
-};
+Updated.storyName =
+	'with updated time showing';
 
 export const Contributor = () => {
 	const block: Block = {

--- a/dotcom-rendering/src/web/components/MostViewedRight.stories.tsx
+++ b/dotcom-rendering/src/web/components/MostViewedRight.stories.tsx
@@ -109,6 +109,5 @@ export const outsideContextStory = () => {
 		</Section>
 	);
 };
-outsideContextStory.story = {
-	name: 'inside responsive wrapper',
-};
+outsideContextStory.storyName =
+	'inside responsive wrapper';

--- a/dotcom-rendering/src/web/components/MultiImageBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/web/components/MultiImageBlockComponent.stories.tsx
@@ -27,9 +27,8 @@ export const SingleImage = () => {
 		</Section>
 	);
 };
-SingleImage.story = {
-	name: 'single image',
-};
+SingleImage.storyName =
+	'single image';
 
 export const SingleImageWithCaption = () => {
 	return (
@@ -46,9 +45,8 @@ export const SingleImageWithCaption = () => {
 		</Section>
 	);
 };
-SingleImageWithCaption.story = {
-	name: 'single image with caption',
-};
+SingleImageWithCaption.storyName =
+	'single image with caption';
 
 export const SideBySide = () => {
 	return (
@@ -64,9 +62,8 @@ export const SideBySide = () => {
 		</Section>
 	);
 };
-SideBySide.story = {
-	name: 'side by side',
-};
+SideBySide.storyName =
+	'side by side';
 
 export const SideBySideWithCaption = () => {
 	return (
@@ -83,9 +80,8 @@ export const SideBySideWithCaption = () => {
 		</Section>
 	);
 };
-SideBySideWithCaption.story = {
-	name: 'side by side with caption',
-};
+SideBySideWithCaption.storyName =
+	'side by side with caption';
 
 export const OneAboveTwo = () => {
 	return (
@@ -101,9 +97,8 @@ export const OneAboveTwo = () => {
 		</Section>
 	);
 };
-OneAboveTwo.story = {
-	name: 'one above two',
-};
+OneAboveTwo.storyName =
+	'one above two';
 
 export const OneAboveTwoWithCaption = () => {
 	return (
@@ -120,9 +115,8 @@ export const OneAboveTwoWithCaption = () => {
 		</Section>
 	);
 };
-OneAboveTwoWithCaption.story = {
-	name: 'one above two with caption',
-};
+OneAboveTwoWithCaption.storyName =
+	'one above two with caption';
 
 export const GridOfFour = () => {
 	return (
@@ -138,9 +132,8 @@ export const GridOfFour = () => {
 		</Section>
 	);
 };
-GridOfFour.story = {
-	name: 'grid of four',
-};
+GridOfFour.storyName =
+	'grid of four';
 
 export const GridOfFourWithCaption = () => {
 	return (
@@ -157,6 +150,5 @@ export const GridOfFourWithCaption = () => {
 		</Section>
 	);
 };
-GridOfFourWithCaption.story = {
-	name: 'grid of four with caption',
-};
+GridOfFourWithCaption.storyName =
+	'grid of four with caption';

--- a/dotcom-rendering/src/web/components/Pagination.stories.tsx
+++ b/dotcom-rendering/src/web/components/Pagination.stories.tsx
@@ -30,9 +30,8 @@ export const notFirstPage = () => (
 	</>
 );
 
-notFirstPage.story = {
-	name: 'Not first page',
-};
+notFirstPage.storyName =
+	'Not first page';
 
 export const firstPageStory = () => (
 	<>
@@ -47,6 +46,5 @@ export const firstPageStory = () => (
 	</>
 );
 
-firstPageStory.story = {
-	name: 'First page',
-};
+firstPageStory.storyName =
+	'First page';

--- a/dotcom-rendering/src/web/components/PullQuoteBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/web/components/PullQuoteBlockComponent.stories.tsx
@@ -48,9 +48,8 @@ export const SportInline = () => {
 		</Section>
 	);
 };
-SportInline.story = {
-	name: 'Sport, inline, Article',
-};
+SportInline.storyName =
+	'Sport, inline, Article';
 
 export const LabsInline = () => {
 	const format = {
@@ -74,9 +73,8 @@ export const LabsInline = () => {
 		</Section>
 	);
 };
-LabsInline.story = {
-	name: 'Labs, inline, Article',
-};
+LabsInline.storyName =
+	'Labs, inline, Article';
 
 export const LifestyleInline = () => {
 	const format = {
@@ -100,9 +98,8 @@ export const LifestyleInline = () => {
 		</Section>
 	);
 };
-LifestyleInline.story = {
-	name: 'Lifestyle, inline, Article',
-};
+LifestyleInline.storyName =
+	'Lifestyle, inline, Article';
 
 export const CultureInline = () => {
 	const format = {
@@ -126,9 +123,8 @@ export const CultureInline = () => {
 		</Section>
 	);
 };
-CultureInline.story = {
-	name: 'Culture, inline, Article',
-};
+CultureInline.storyName =
+	'Culture, inline, Article';
 
 export const NewsInline = () => {
 	return (
@@ -147,9 +143,8 @@ export const NewsInline = () => {
 		</Section>
 	);
 };
-NewsInline.story = {
-	name: 'News, inline, Article',
-};
+NewsInline.storyName =
+	'News, inline, Article';
 
 export const OpinionInline = () => {
 	const format = {
@@ -174,9 +169,8 @@ export const OpinionInline = () => {
 		</Section>
 	);
 };
-OpinionInline.story = {
-	name: 'Opinion, inline, Comment',
-};
+OpinionInline.storyName =
+	'Opinion, inline, Comment';
 
 export const SpecialReportInline = () => {
 	const format = {
@@ -200,9 +194,8 @@ export const SpecialReportInline = () => {
 		</Section>
 	);
 };
-SpecialReportInline.story = {
-	name: 'SpecialReport, inline, Article',
-};
+SpecialReportInline.storyName =
+	'SpecialReport, inline, Article';
 
 // Supporting
 export const SportSupporting = () => {
@@ -227,9 +220,8 @@ export const SportSupporting = () => {
 		</Section>
 	);
 };
-SportSupporting.story = {
-	name: 'Sport, supporting, Article',
-};
+SportSupporting.storyName =
+	'Sport, supporting, Article';
 
 export const LabsSupporting = () => {
 	const format = {
@@ -253,9 +245,8 @@ export const LabsSupporting = () => {
 		</Section>
 	);
 };
-LabsSupporting.story = {
-	name: 'Labs, supporting, Article',
-};
+LabsSupporting.storyName =
+	'Labs, supporting, Article';
 
 export const LifestyleSupporting = () => {
 	const format = {
@@ -279,9 +270,8 @@ export const LifestyleSupporting = () => {
 		</Section>
 	);
 };
-LifestyleSupporting.story = {
-	name: 'Lifestyle, supporting, Article',
-};
+LifestyleSupporting.storyName =
+	'Lifestyle, supporting, Article';
 
 export const CultureSupporting = () => {
 	const format = {
@@ -305,9 +295,8 @@ export const CultureSupporting = () => {
 		</Section>
 	);
 };
-CultureSupporting.story = {
-	name: 'Culture, supporting, Article',
-};
+CultureSupporting.storyName =
+	'Culture, supporting, Article';
 
 export const NewsSupporting = () => {
 	return (
@@ -326,9 +315,8 @@ export const NewsSupporting = () => {
 		</Section>
 	);
 };
-NewsSupporting.story = {
-	name: 'News, supporting, Article',
-};
+NewsSupporting.storyName =
+	'News, supporting, Article';
 
 export const OpinionSupporting = () => {
 	const format = {
@@ -353,9 +341,8 @@ export const OpinionSupporting = () => {
 		</Section>
 	);
 };
-OpinionSupporting.story = {
-	name: 'Opinion, supporting, Comment',
-};
+OpinionSupporting.storyName =
+	'Opinion, supporting, Comment';
 
 export const SpecialReportSupporting = () => {
 	const format = {
@@ -379,9 +366,8 @@ export const SpecialReportSupporting = () => {
 		</Section>
 	);
 };
-SpecialReportSupporting.story = {
-	name: 'SpecialReport, supporting, Article',
-};
+SpecialReportSupporting.storyName =
+	'SpecialReport, supporting, Article';
 
 export const SpecialReportAltInline = () => {
 	const format = {
@@ -405,9 +391,8 @@ export const SpecialReportAltInline = () => {
 		</Section>
 	);
 };
-SpecialReportAltInline.story = {
-	name: 'SpecialReportAlt, inline, Article',
-};
+SpecialReportAltInline.storyName =
+	'SpecialReportAlt, inline, Article';
 
 export const SpecialReportAltSupporting = () => {
 	const format = {
@@ -431,9 +416,8 @@ export const SpecialReportAltSupporting = () => {
 		</Section>
 	);
 };
-SpecialReportAltSupporting.story = {
-	name: 'SpecialReportAlt, supporting, Article',
-};
+SpecialReportAltSupporting.storyName =
+	'SpecialReportAlt, supporting, Article';
 
 // PhotoEssay
 export const PhotoEssayInline = () => {
@@ -453,9 +437,8 @@ export const PhotoEssayInline = () => {
 		</Section>
 	);
 };
-PhotoEssayInline.story = {
-	name: 'News, inline, PhotoEssay',
-};
+PhotoEssayInline.storyName =
+	'News, inline, PhotoEssay';
 
 export const PhotoEssaySupporting = () => {
 	return (
@@ -474,6 +457,5 @@ export const PhotoEssaySupporting = () => {
 		</Section>
 	);
 };
-PhotoEssaySupporting.story = {
-	name: 'News, supporting, PhotoEssay',
-};
+PhotoEssaySupporting.storyName =
+	'News, supporting, PhotoEssay';

--- a/dotcom-rendering/src/web/components/RichLink.stories.tsx
+++ b/dotcom-rendering/src/web/components/RichLink.stories.tsx
@@ -131,9 +131,8 @@ export const SectionStory = () => {
 		</Section>
 	);
 };
-SectionStory.story = {
-	name: 'Section',
-};
+SectionStory.storyName =
+	'Section';
 
 export const Inline = () => {
 	return (
@@ -159,9 +158,8 @@ export const Inline = () => {
 		</Section>
 	);
 };
-Inline.story = {
-	name: 'Inline',
-};
+Inline.storyName =
+	'Inline';
 
 export const ImageContent = () => {
 	return (

--- a/dotcom-rendering/src/web/components/Section.stories.tsx
+++ b/dotcom-rendering/src/web/components/Section.stories.tsx
@@ -88,9 +88,8 @@ export const LeftContentStory = () => {
 		</Section>
 	);
 };
-LeftContentStory.story = {
-	name: 'with an element passed into the left column',
-};
+LeftContentStory.storyName =
+	'with an element passed into the left column';
 
 export const BackgroundStory = () => {
 	return (
@@ -122,9 +121,8 @@ export const InnerBackgroundStory = () => {
 		</Section>
 	);
 };
-InnerBackgroundStory.story = {
-	name: 'with a blue inner background',
-};
+InnerBackgroundStory.storyName =
+	'with a blue inner background';
 
 export const DifferentBackgrounds = () => {
 	return (
@@ -141,9 +139,8 @@ export const DifferentBackgrounds = () => {
 		</Section>
 	);
 };
-DifferentBackgrounds.story = {
-	name: 'with inner background different to main background',
-};
+DifferentBackgrounds.storyName =
+	'with inner background different to main background';
 
 export const StretchRightStory = () => {
 	return (
@@ -157,9 +154,8 @@ export const StretchRightStory = () => {
 		</Section>
 	);
 };
-StretchRightStory.story = {
-	name: 'with content stretched to the right (no margin)',
-};
+StretchRightStory.storyName =
+	'with content stretched to the right (no margin)';
 
 export const PartialStory = () => {
 	return (
@@ -316,6 +312,5 @@ export const TreatsStory = () => {
 		</Section>
 	);
 };
-TreatsStory.story = {
-	name: 'with treats and date header',
-};
+TreatsStory.storyName =
+	'with treats and date header';

--- a/dotcom-rendering/src/web/components/ShadyPie.stories.tsx
+++ b/dotcom-rendering/src/web/components/ShadyPie.stories.tsx
@@ -12,6 +12,5 @@ export const Default = () => {
 		</div>
 	);
 };
-Default.story = {
-	name: 'Default',
-};
+Default.storyName =
+	'Default';

--- a/dotcom-rendering/src/web/components/SignInGate/SignInGate.stories.tsx
+++ b/dotcom-rendering/src/web/components/SignInGate/SignInGate.stories.tsx
@@ -75,9 +75,8 @@ export const fakeSocialStandaloneVertical = () => {
 		</Section>
 	);
 };
-fakeSocialStandaloneVertical.story = {
-	name: 'fake_social_standalone_vertical',
-};
+fakeSocialStandaloneVertical.storyName =
+	'fake_social_standalone_vertical';
 
 export const signInGateCopyTest = () => {
 	return (
@@ -96,9 +95,8 @@ export const signInGateCopyTest = () => {
 		</Section>
 	);
 };
-signInGateCopyTest.story = {
-	name: 'sign_in_gate_copy_test',
-};
+signInGateCopyTest.storyName =
+	'sign_in_gate_copy_test';
 
 export const signInGateMainCheckoutCompletePersonalisedCopy = (
 	args: CheckoutCompleteCookieData,
@@ -116,9 +114,8 @@ export const signInGateMainCheckoutCompletePersonalisedCopy = (
 		</Section>
 	);
 };
-signInGateMainCheckoutCompletePersonalisedCopy.story = {
-	name: 'main_checkout_complete_personalised',
-};
+signInGateMainCheckoutCompletePersonalisedCopy.storyName =
+	'main_checkout_complete_personalised';
 
 const defaultCheckoutCompleteCookieData: CheckoutCompleteCookieData = {
 	userType: 'new',

--- a/dotcom-rendering/src/web/components/SignedInAs.stories.tsx
+++ b/dotcom-rendering/src/web/components/SignedInAs.stories.tsx
@@ -133,9 +133,8 @@ export const NotSignedIn = () => {
 		</Wrapper>
 	);
 };
-NotSignedIn.story = {
-	name: 'when the discussion is open but user is not signed in',
-};
+NotSignedIn.storyName =
+	'when the discussion is open but user is not signed in';
 
 export const DiscussionClosed = () => {
 	return (
@@ -154,9 +153,8 @@ export const DiscussionClosed = () => {
 		</Wrapper>
 	);
 };
-DiscussionClosed.story = {
-	name: 'when the discussion is closed and the user is signed in',
-};
+DiscussionClosed.storyName =
+	'when the discussion is closed and the user is signed in';
 
 export const DiscussionClosedSignedOut = () => {
 	return (
@@ -174,9 +172,8 @@ export const DiscussionClosedSignedOut = () => {
 		</Wrapper>
 	);
 };
-DiscussionClosedSignedOut.story = {
-	name: 'when the discussion is closed and the user is signed out',
-};
+DiscussionClosedSignedOut.storyName =
+	'when the discussion is closed and the user is signed out';
 
 export const DiscussionDisabled = () => {
 	return (
@@ -195,9 +192,8 @@ export const DiscussionDisabled = () => {
 		</Wrapper>
 	);
 };
-DiscussionDisabled.story = {
-	name: 'with discussion disabled sitewide and the user signed in',
-};
+DiscussionDisabled.storyName =
+	'with discussion disabled sitewide and the user signed in';
 
 export const DiscussionDisabledSignedOut = () => {
 	return (
@@ -215,6 +211,5 @@ export const DiscussionDisabledSignedOut = () => {
 		</Wrapper>
 	);
 };
-DiscussionDisabledSignedOut.story = {
-	name: 'with discussion disabled sitewide and the user signed out',
-};
+DiscussionDisabledSignedOut.storyName =
+	'with discussion disabled sitewide and the user signed out';

--- a/dotcom-rendering/src/web/components/SlotBodyEnd/BrazeEpic.stories.tsx
+++ b/dotcom-rendering/src/web/components/SlotBodyEnd/BrazeEpic.stories.tsx
@@ -165,9 +165,8 @@ BrazeEpic_DefaultWithReminder_Component.args = {
 	remindMeConfirmationHeaderText: 'Thank you! Your reminder is set.',
 };
 
-BrazeEpic_DefaultWithReminder_Component.story = {
-	name: 'Default Epic with reminder',
-};
+BrazeEpic_DefaultWithReminder_Component.storyName =
+	'Default Epic with reminder';
 
 // Braze Epic with special header
 // ---------------------------------------
@@ -308,9 +307,8 @@ BrazeNewsletterEpic_UK_MorningBriefing_Component.args = {
 	ophanComponentId: 'example_ophan_component_id',
 };
 
-BrazeNewsletterEpic_UK_MorningBriefing_Component.story = {
-	name: 'Newsletter - UK - Morning Briefing',
-};
+BrazeNewsletterEpic_UK_MorningBriefing_Component.storyName =
+	'Newsletter - UK - Morning Briefing';
 
 // Braze Newsletter Epic - US - FirstThing
 // ---------------------------------------
@@ -375,9 +373,8 @@ BrazeEpicNewsletter_US_FirstThing_Component.args = {
 	ophanComponentId: 'example_ophan_component_id',
 };
 
-BrazeEpicNewsletter_US_FirstThing_Component.story = {
-	name: 'Newsletter - US - First Thing',
-};
+BrazeEpicNewsletter_US_FirstThing_Component.storyName =
+	'Newsletter - US - First Thing';
 
 // Braze Newsletter Epic - AUS - MorningMail
 // ---------------------------------------
@@ -442,9 +439,8 @@ BrazeEpicNewsletter_AUS_MorningMail_Component.args = {
 	ophanComponentId: 'example_ophan_component_id',
 };
 
-BrazeEpicNewsletter_AUS_MorningMail_Component.story = {
-	name: 'Newsletter - AUS - Morning Mail',
-};
+BrazeEpicNewsletter_AUS_MorningMail_Component.storyName =
+	'Newsletter - AUS - Morning Mail';
 
 // Braze Newsletter Epic - AUS - MorningMail
 // ---------------------------------------
@@ -509,9 +505,8 @@ BrazeEpicNewsletter_AUS_AfteernoonUpdate_Component.args = {
 	ophanComponentId: 'example_ophan_component_id',
 };
 
-BrazeEpicNewsletter_AUS_AfteernoonUpdate_Component.story = {
-	name: 'Newsletter - AUS - Morning Mail',
-};
+BrazeEpicNewsletter_AUS_AfteernoonUpdate_Component.storyName =
+	'Newsletter - AUS - Morning Mail';
 
 // Braze Newsletter Epic - DownToEarth
 // ---------------------------------------
@@ -576,9 +571,8 @@ BrazeEpicNewsletter_DownToEarth_Component.args = {
 	ophanComponentId: 'example_ophan_component_id',
 };
 
-BrazeEpicNewsletter_DownToEarth_Component.story = {
-	name: 'Newsletter - Down To Earth',
-};
+BrazeEpicNewsletter_DownToEarth_Component.storyName =
+	'Newsletter - Down To Earth';
 
 // Braze Newsletter Epic - The Guide
 // ---------------------------------------
@@ -643,6 +637,5 @@ BrazeEpicNewsletter_TheGuide_Component.args = {
 	ophanComponentId: 'example_ophan_component_id',
 };
 
-BrazeEpicNewsletter_TheGuide_Component.story = {
-	name: 'Newsletter - The Guide',
-};
+BrazeEpicNewsletter_TheGuide_Component.storyName =
+	'Newsletter - The Guide';

--- a/dotcom-rendering/src/web/components/StickyBottomBanner/BrazeBanner.stories.tsx
+++ b/dotcom-rendering/src/web/components/StickyBottomBanner/BrazeBanner.stories.tsx
@@ -219,6 +219,5 @@ BrazeNewsletterBannerComponent.args = {
 		'https://i.guim.co.uk/img/media/568c6031be78dab6f6c28336010884f3ebd0f97c/0_0_1936_1936/master/1936.png?width=196&quality=45&auto=format&s=2a3630e9625620d5726c31c5cdbf4772',
 };
 
-BrazeNewsletterBannerComponent.story = {
-	name: 'BannerNewsletter',
-};
+BrazeNewsletterBannerComponent.storyName =
+	'BannerNewsletter';

--- a/dotcom-rendering/src/web/components/TopicFilterBank.stories.tsx
+++ b/dotcom-rendering/src/web/components/TopicFilterBank.stories.tsx
@@ -77,9 +77,8 @@ export const topicBank = () => {
 		</Wrapper>
 	);
 };
-topicBank.story = {
-	name: 'topicBank',
-};
+topicBank.storyName =
+	'topicBank';
 
 export const topicBankSelectedIsNotInTop5 = () => {
 	return (
@@ -101,9 +100,8 @@ export const topicBankSelectedIsNotInTop5 = () => {
 		</Wrapper>
 	);
 };
-topicBankSelectedIsNotInTop5.story = {
-	name: 'topicBankSelectedIsNotInTop5',
-};
+topicBankSelectedIsNotInTop5.storyName =
+	'topicBankSelectedIsNotInTop5';
 
 export const notShowingTopicsWithLowerCounts = () => {
 	return (
@@ -125,9 +123,8 @@ export const notShowingTopicsWithLowerCounts = () => {
 		</Wrapper>
 	);
 };
-notShowingTopicsWithLowerCounts.story = {
-	name: 'notShowingTopicsWithLowerCounts',
-};
+notShowingTopicsWithLowerCounts.storyName =
+	'notShowingTopicsWithLowerCounts';
 
 export const doesNotRenderWhenNoKeyEventsOrRelevantTopics = () => {
 	return (
@@ -143,6 +140,5 @@ export const doesNotRenderWhenNoKeyEventsOrRelevantTopics = () => {
 		</Wrapper>
 	);
 };
-doesNotRenderWhenNoKeyEventsOrRelevantTopics.story = {
-	name: 'doesNotRenderWhenNoKeyEventsOrRelevantTopics',
-};
+doesNotRenderWhenNoKeyEventsOrRelevantTopics.storyName =
+	'doesNotRenderWhenNoKeyEventsOrRelevantTopics';


### PR DESCRIPTION
## Why?

This switches from `.story.name` to `.storyName` as the way to name stories. The previous way doesn't match the documentation and doesn't seem to work in storybook 7.

**Note:** This is the first batch, there are still more to do, hence the draft PR.

## Changes

- Replaced usages of `.story.name` with `.storyName`
