### PR TITLE
Update styling for standalone callouts 

### DIFF
--- a/dotcom-rendering/src/web/components/Callout/Callout.tsx
+++ b/dotcom-rendering/src/web/components/Callout/Callout.tsx
@@ -10,18 +10,17 @@ import { CalloutDescription, CalloutShare } from './CalloutComponents';
 import { Form } from './Form';
 import { conditionallyRenderContactIcon, MessageUs } from './MessageUs';
 
-const wrapperStyles = css`
-	background-color: ${neutral[97]};
-`;
-
-const summaryContentWrapper = css`
+const summaryContentWrapper = (isNonCollapsible: boolean) => css`
 	visibility: visible;
-	padding: 2px ${space[2]}px ${space[6]}px ${space[2]}px;
+	padding-top: 2px;
+	padding-bottom: ${space[6]}px;
+	padding-left: ${isNonCollapsible ? 0 : space[2]}px;
+	padding-right: ${isNonCollapsible ? 0 : space[2]}px;
 `;
 
-const titleStyles = css`
+const promptStyles = (isNonCollapsible: boolean) => css`
 	${headline.xxsmall({ fontWeight: 'bold' })};
-	color: ${brand[500]};
+	color: ${isNonCollapsible ? neutral[7] : brand[500]};
 `;
 
 const subtitleTextHeaderStyles = css`
@@ -53,6 +52,7 @@ export interface CalloutBlockProps {
 	isNonCollapsible: boolean;
 	contacts?: CalloutContactType[];
 	pageId: string;
+	format: ArticleFormat;
 }
 
 export const CalloutBlock = ({
@@ -65,6 +65,7 @@ export const CalloutBlock = ({
 	isNonCollapsible,
 	contacts,
 	pageId,
+	format,
 }: CalloutBlockProps) => {
 	const [selectedTab, setSelectedTab] = useState('form');
 	const shouldShowContacts = contacts && contacts.length > 0;
@@ -103,16 +104,26 @@ export const CalloutBlock = ({
 	}
 
 	return (
-		<div id={formId} css={wrapperStyles}>
-			<div css={summaryContentWrapper}>
-				{!!prompt && <div css={titleStyles}>{prompt}</div>}
+		<div id={formId}>
+			<div css={summaryContentWrapper(isNonCollapsible)}>
+				{!!prompt && (
+					<div css={promptStyles(isNonCollapsible)}>{prompt}</div>
+				)}
 				{shouldShowHeading && (
 					<h4 css={subtitleTextHeaderStyles}>{heading}</h4>
 				)}
 				{!!description && (
-					<CalloutDescription description={description} />
+					<CalloutDescription
+						description={description}
+						useBrandColour={isNonCollapsible}
+					/>
 				)}
-				<CalloutShare title={heading} urlAnchor={formId} />
+				<CalloutShare
+					title={heading}
+					urlAnchor={formId}
+					useBrandColour={isNonCollapsible}
+					format={format}
+				/>
 			</div>
 			<Tabs
 				tabsLabel="Tell us via online form or message us using your phone"

--- a/dotcom-rendering/src/web/components/Callout/CalloutComponents.tsx
+++ b/dotcom-rendering/src/web/components/Callout/CalloutComponents.tsx
@@ -14,6 +14,8 @@ import {
 	SvgTickRound,
 } from '@guardian/source-react-components';
 import { useState } from 'react';
+import type { Palette } from '../../../types/palette';
+import { decidePalette } from '../../lib/decidePalette';
 
 /* stylelint-disable-next-line color-no-hex */
 const linkDecorationColour = '#12121240';
@@ -30,8 +32,8 @@ export const calloutLinkStyles = css`
 	}
 `;
 
-const descriptionStyles = css`
-	${calloutLinkStyles}
+const descriptionStyles = (useBrandColour: boolean) => css`
+	${!useBrandColour && calloutLinkStyles}
 	padding-bottom: ${space[4]}px;
 	${body.medium()}
 
@@ -42,30 +44,35 @@ const descriptionStyles = css`
 
 export const CalloutDescription = ({
 	description,
+	useBrandColour,
 }: {
 	description: string;
+	useBrandColour: boolean;
 }) => {
-	// this data-ignore attribute ensures correct formatting for links in the description
+	// this data-ignore attribute ensures correct formatting for links when the callout is collapsible
 	const htmlSplit = description.split('href');
 	const withDataIgnore = htmlSplit.join(
 		'data-ignore="global-link-styling" href',
 	);
-
 	return (
-		<div css={descriptionStyles}>
-			<div dangerouslySetInnerHTML={{ __html: withDataIgnore }}></div>
+		<div css={descriptionStyles(useBrandColour)}>
+			<div
+				dangerouslySetInnerHTML={{
+					__html: useBrandColour ? description : withDataIgnore,
+				}}
+			></div>
 			<div>
 				Please share your story if you are 18 or over, anonymously if
 				you wish. For more information please see our{' '}
 				<a
-					data-ignore="global-link-styling"
+					data-ignore={!useBrandColour && 'global-link-styling'}
 					href="https://www.theguardian.com/help/terms-of-service"
 				>
 					terms of service
 				</a>{' '}
 				and{' '}
 				<a
-					data-ignore="global-link-styling"
+					data-ignore={!useBrandColour && 'global-link-styling'}
 					href="https://www.theguardian.com/help/privacy-policy"
 				>
 					privacy policy
@@ -111,14 +118,21 @@ const shareCalloutTextStyles = css`
 	${textSans.xsmall()}
 `;
 
-const shareCalloutLinkStyles = css`
+const shareCalloutLinkStyles = (
+	useBrandColour: boolean,
+	brandPalette: Palette,
+) => css`
 	${textSans.xsmall()}
-	color: ${brand[500]};
+	color: ${useBrandColour ? brandPalette.text.articleLink : brand[500]};
 	border-bottom: 1px solid ${linkDecorationColour};
 	text-decoration: none;
+	transition: none;
 	:hover,
 	:active {
-		border-bottom: 1px solid ${brand[500]};
+		border-bottom: 1px solid
+			${useBrandColour
+				? brandPalette.border.articleLinkHover
+				: brand[500]};
 	}
 `;
 
@@ -141,24 +155,30 @@ const sharePopupStyles = css`
 		fill: ${success[400]};
 	}
 `;
-const shareIconStyles = css`
+const shareIconStyles = (useBrandColour: boolean, brandPalette: Palette) => css`
 	display: inline-flex;
 	margin-right: ${space[2]}px;
 	border-radius: 50%;
-	border: 1px solid ${brand[500]};
+	border: 1px solid
+		${useBrandColour ? brandPalette.text.articleLink : brand[500]};
 	box-sizing: border-box;
-	fill: ${brand[500]};
+	fill: ${useBrandColour ? brandPalette.text.articleLink : brand[500]};
 	padding: 0.5px 0;
 `;
 
 export const CalloutShare = ({
 	title,
 	urlAnchor,
+	useBrandColour,
+	format,
 }: {
 	title?: string;
 	urlAnchor: string;
+	useBrandColour: boolean;
+	format: ArticleFormat;
 }) => {
 	const [isCopied, setIsCopied] = useState(false);
+	const brandPalette = decidePalette(format);
 
 	const onShare = async () => {
 		const url = window.location.href;
@@ -194,7 +214,7 @@ export const CalloutShare = ({
 	return (
 		<>
 			<div css={shareCalloutStyles}>
-				<span css={shareIconStyles}>
+				<span css={shareIconStyles(useBrandColour, brandPalette)}>
 					<SvgShare size="small" />
 				</span>
 				<div css={shareCalloutTextStyles}>
@@ -203,7 +223,10 @@ export const CalloutShare = ({
 						size="xsmall"
 						priority="subdued"
 						onClick={onShare}
-						cssOverrides={shareCalloutLinkStyles}
+						cssOverrides={shareCalloutLinkStyles(
+							useBrandColour,
+							brandPalette,
+						)}
 					>
 						Please share this callout.
 					</Button>

--- a/dotcom-rendering/src/web/components/CalloutBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/web/components/CalloutBlockComponent.importable.tsx
@@ -1,15 +1,23 @@
+import { css } from '@emotion/react';
+import { palette } from '@guardian/source-foundations';
 import { ExpandingWrapper } from '@guardian/source-react-components-development-kitchen';
 import type { CalloutBlockElementV2 } from '../../types/content';
 import { CalloutBlock } from './Callout/Callout';
 import { CalloutExpired } from './Callout/CalloutComponents';
 import { Deadline } from './Callout/Deadline';
 
+const collapsibleCalloutStyle = css`
+	background-color: ${palette.neutral[97]};
+`;
+
 export const CalloutBlockComponent = ({
 	callout,
 	pageId,
+	format,
 }: {
 	callout: CalloutBlockElementV2;
 	pageId: string;
+	format: ArticleFormat;
 }) => {
 	const {
 		prompt,
@@ -49,18 +57,21 @@ export const CalloutBlockComponent = ({
 						renderExtra={() => <Deadline until={activeUntil} />}
 						collapsedHeight={'160px'}
 					>
-						<CalloutBlock
-							formId={id}
-							prompt={prompt}
-							heading={title}
-							description={description}
-							formFields={formFields}
-							submissionURL={calloutsUrl}
-							isExpired={isExpired(activeUntil)}
-							isNonCollapsible={isNonCollapsible}
-							contacts={contacts}
-							pageId={pageId}
-						/>
+						<div css={collapsibleCalloutStyle}>
+							<CalloutBlock
+								formId={id}
+								prompt={prompt}
+								heading={title}
+								description={description}
+								formFields={formFields}
+								submissionURL={calloutsUrl}
+								isExpired={isExpired(activeUntil)}
+								isNonCollapsible={isNonCollapsible}
+								contacts={contacts}
+								pageId={pageId}
+								format={format}
+							/>
+						</div>
 					</ExpandingWrapper>
 				</aside>
 			) : (
@@ -75,6 +86,7 @@ export const CalloutBlockComponent = ({
 					isNonCollapsible={isNonCollapsible}
 					contacts={contacts}
 					pageId={pageId}
+					format={format}
 				/>
 			)}
 		</>

--- a/dotcom-rendering/src/web/components/CalloutBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/web/components/CalloutBlockComponent.stories.tsx
@@ -1,3 +1,4 @@
+import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
 import fetchMock from 'fetch-mock';
 import { calloutCampaign as calloutCampaignV2 } from '../../../fixtures/manual/calloutCampaignV2';
 import { CalloutBlockComponent } from './CalloutBlockComponent.importable';
@@ -46,6 +47,11 @@ export const Collapsible = () => {
 				activeUntil: tomorrow,
 			}}
 			pageId={pageId}
+			format={{
+				display: ArticleDisplay.Standard,
+				design: ArticleDesign.Standard,
+				theme: ArticlePillar.News,
+			}}
 		/>
 	);
 };
@@ -58,6 +64,11 @@ export const NonCollapsible = () => {
 		<CalloutBlockComponent
 			callout={{ ...calloutCampaignV2, activeUntil: tomorrow }}
 			pageId={pageId}
+			format={{
+				display: ArticleDisplay.Standard,
+				design: ArticleDesign.Standard,
+				theme: ArticlePillar.News,
+			}}
 		/>
 	);
 };
@@ -70,6 +81,11 @@ export const SubmissionFailure = () => {
 		<CalloutBlockComponent
 			callout={{ ...calloutCampaignV2, activeUntil: tomorrow }}
 			pageId={pageId}
+			format={{
+				display: ArticleDisplay.Standard,
+				design: ArticleDesign.Standard,
+				theme: ArticlePillar.News,
+			}}
 		/>
 	);
 };
@@ -81,6 +97,11 @@ export const Expired = () => {
 		<CalloutBlockComponent
 			callout={{ ...calloutCampaignV2, activeUntil: yesterday }}
 			pageId={pageId}
+			format={{
+				display: ArticleDisplay.Standard,
+				design: ArticleDesign.Standard,
+				theme: ArticlePillar.News,
+			}}
 		/>
 	);
 };
@@ -103,6 +124,11 @@ export const MinimalCallout = () => {
 					description: '',
 				}}
 				pageId={pageId}
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.News,
+				}}
 			/>
 		</>
 	);

--- a/dotcom-rendering/src/web/lib/renderElement.tsx
+++ b/dotcom-rendering/src/web/lib/renderElement.tsx
@@ -190,6 +190,7 @@ export const renderElement = ({
 						<CalloutBlockComponent
 							callout={element}
 							pageId={pageId}
+							format={format}
 						/>
 					</Island>
 				);


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Updates the styling for standalone callouts, so they look more like an article
 - Removes description padding
 - Description background is no longer grey
 - Prompt is black rather than blue
 - Updates the description links & icons to use the pillar colour

## Why?
This looks more like an article, which is more accurate for a standalone callout

## Screenshots

| | Before      | After      |
|-------------|-------------|------------|
| Collapsible callout (same styling) | <img width="892" alt="image" src="https://user-images.githubusercontent.com/26366706/232499461-f945fb96-c89a-4c1c-b1e5-e80259ad25a8.png"> | <img width="892" alt="image" src="https://user-images.githubusercontent.com/26366706/232499372-1df939e0-5815-4059-a2e7-69228b349684.png"> |
| Standalone News Callout | <img width="871" alt="image" src="https://user-images.githubusercontent.com/26366706/232498920-dca86ed9-006d-4b17-9d52-095ac2d05992.png"> | <img width="873" alt="image" src="https://user-images.githubusercontent.com/26366706/232499771-b0fe4ca7-b4c0-4bae-936d-ae1b2d96146e.png"> |
| Standalone Culture Callout | <img width="892" alt="image" src="https://user-images.githubusercontent.com/26366706/232499117-6596d7c0-5f52-43ab-aa81-466f4e006349.png"> | <img width="893" alt="image" src="https://user-images.githubusercontent.com/26366706/232500006-2b318d1f-fee0-494e-b443-fc338c652366.png"> |
| Standalone Finance Callout | <img width="825" alt="image" src="https://user-images.githubusercontent.com/26366706/232500255-10bd9709-b3a1-49ef-ab5f-beab7f6db183.png"> | <img width="825" alt="image" src="https://user-images.githubusercontent.com/26366706/232500373-26cbd36e-e3d0-4d90-9f34-f62a300266d6.png"> |

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
