### PR TITLE
Align treats to bottom of the container

### DIFF
--- a/dotcom-rendering/src/web/components/FrontSection.tsx
+++ b/dotcom-rendering/src/web/components/FrontSection.tsx
@@ -6,7 +6,9 @@ import type { DCRContainerPalette, TreatType } from '../../types/front';
 import { decideContainerOverrides } from '../lib/decideContainerOverrides';
 import type { EditionId } from '../lib/edition';
 import { ContainerTitle } from './ContainerTitle';
+import { Island } from './Island';
 import { ShowHideButton } from './ShowHideButton';
+import { ShowMore } from './ShowMore.importable';
 import { Treats } from './Treats';
 
 type Props = {
@@ -18,6 +20,8 @@ type Props = {
 	url?: string;
 	/** The html `id` property of the element */
 	sectionId?: string;
+	collectionId?: string;
+	pageId?: string;
 	/** Defaults to `true`. If we should render the top border */
 	showTopBorder?: boolean;
 	/** A React component can be passed to be inserted inside the left column */
@@ -49,6 +53,9 @@ type Props = {
 	/** A list of related links that appear in the bottom of the left column on fronts */
 	treats?: TreatType[];
 	badge?: EmotionJSX.Element;
+	/** Enable the "Show More" button on this container to allow readers to load more cards */
+	canShowMore?: boolean;
+	ajaxUrl?: string;
 };
 
 const width = (columns: number, columnWidth: number, columnGap: number) =>
@@ -56,38 +63,41 @@ const width = (columns: number, columnWidth: number, columnGap: number) =>
 
 /** Not all browsers support CSS grid, so we set explicit width as a fallback */
 const fallbackStyles = css`
-	padding: 0 12px;
-	margin: 0 auto;
+	@supports not (display: grid) {
+		padding: 0 12px;
+		margin: 0 auto;
 
-	${from.mobileLandscape} {
-		padding: 0 20px;
-	}
+		${from.mobileLandscape} {
+			padding: 0 20px;
+		}
 
-	${from.tablet} {
-		${width(12, 40, 20)}
-	}
+		${from.tablet} {
+			${width(12, 40, 20)}
+		}
 
-	${from.desktop} {
-		${width(12, 60, 20)}
-	}
+		${from.desktop} {
+			${width(12, 60, 20)}
+		}
 
-	${from.leftCol} {
-		${width(14, 60, 20)}
-	}
+		${from.leftCol} {
+			${width(14, 60, 20)}
+		}
 
-	${from.wide} {
-		${width(16, 60, 20)}
-	}
-
-	@supports (display: grid) {
-		width: 100%;
-		padding: 0;
-		margin: 0;
+		${from.wide} {
+			${width(16, 60, 20)}
+		}
 	}
 `;
 
 const containerStyles = css`
 	display: grid;
+
+	grid-template-rows:
+		[headline-start show-hide-start] auto
+		[show-hide-end headline-end content-toggleable-start content-start] auto
+		[content-end content-toggleable-end show-more-start] auto
+		[show-more-end];
+
 	grid-template-columns:
 		[viewport-start] 0px
 		[content-start title-start]
@@ -96,6 +106,8 @@ const containerStyles = css`
 		minmax(0, 1fr)
 		[content-end title-end hide-end]
 		0px [viewport-end];
+
+	grid-auto-flow: dense;
 	column-gap: 10px;
 
 	${from.mobileLandscape} {
@@ -125,6 +137,13 @@ const containerStyles = css`
 	}
 
 	${from.leftCol} {
+		grid-template-rows:
+			[headline-start show-hide-start content-start] auto
+			[show-hide-end content-toggleable-start] auto
+			[headline-end treats-start] auto
+			[content-end content-toggleable-end treats-end show-more-start] auto
+			[show-more-end];
+
 		grid-template-columns:
 			[viewport-start] minmax(0, 1fr)
 			[title-start]
@@ -138,6 +157,13 @@ const containerStyles = css`
 	}
 
 	${from.wide} {
+		grid-template-rows:
+			[headline-start content-start content-toggleable-start show-hide-start] auto
+			[show-hide-end] auto
+			[headline-end treats-start] auto
+			[content-end content-toggleable-end treats-end show-more-start] auto
+			[show-more-end];
+
 		grid-template-columns:
 			[viewport-start] minmax(0, 1fr)
 			[title-start]
@@ -149,36 +175,15 @@ const containerStyles = css`
 			[hide-end]
 			minmax(0, 1fr) [viewport-end];
 	}
-
-	grid-auto-flow: dense;
-	grid-template-rows: auto [content-start] auto;
-
-	${from.leftCol} {
-		grid-template-rows: [content-start] repeat(2, auto);
-	}
 `;
 
-const containerStylesToggleable = css`
-	${from.leftCol} {
-		grid-template-rows: auto [content-start] repeat(2, auto);
-	}
-	${from.wide} {
-		grid-template-rows: [content-start] repeat(3, auto);
-	}
-`;
-
-const headlineContainerStyles = css`
-	grid-row-start: 1;
+const sectionHeadline = css`
+	grid-row: headline;
 	grid-column: title;
-	${from.leftCol} {
-		grid-row-end: span 2;
-	}
 
 	display: flex;
 	flex-direction: column;
-`;
 
-const headlineContainerBorders = css`
 	${from.leftCol} {
 		position: relative;
 		::after {
@@ -196,11 +201,10 @@ const headlineContainerBorders = css`
 
 const paddings = css`
 	padding-top: ${space[2]}px;
-	padding-bottom: ${space[9]}px;
 `;
 
 const sectionShowHide = css`
-	grid-row-start: 1;
+	grid-row: show-hide;
 	grid-column: hide;
 	justify-self: end;
 `;
@@ -213,14 +217,10 @@ const sectionContent = css`
 	}
 
 	grid-column: content;
+`;
 
-	grid-row-start: content-start;
-	${from.leftCol} {
-		grid-row-end: span 2;
-	}
-	${from.wide} {
-		grid-row-end: -1;
-	}
+const sectionContentRow = (toggleable: boolean) => css`
+	grid-row: ${toggleable ? 'content-toggleable' : 'content'};
 `;
 
 const sectionContentPadded = css`
@@ -230,13 +230,19 @@ const sectionContentPadded = css`
 	}
 `;
 
+const sectionShowMore = css`
+	grid-row: show-more;
+	grid-column: content;
+`;
+
 const sectionTreats = css`
 	display: none;
 
 	${from.leftCol} {
 		display: block;
 		align-self: end;
-		grid-row-start: -2;
+
+		grid-row: treats;
 		grid-column: title;
 	}
 
@@ -248,8 +254,8 @@ const sectionTreats = css`
 /** element which contains border and inner background colour, if set */
 const decoration = css`
 	grid-row: 1 / -1;
-
 	grid-column: 1 / -1;
+
 	${from.tablet} {
 		grid-column: 2 / -2;
 	}
@@ -270,6 +276,10 @@ const sideBorders = css`
 
 const topBorder = css`
 	border-top-style: solid;
+`;
+
+const bottomPadding = css`
+	padding-bottom: ${space[9]}px;
 `;
 
 const titleStyle = css`
@@ -299,6 +309,9 @@ const titleStyle = css`
  * ├───────┤
  * │▒▒▒▒▒▒▒│
  * │▒▒▒▒▒▒▒│
+ * ├───────┤
+ * │Show   │
+ * |More   │
  * └───────┘
  *
  * from `tablet` (740) to `desktop` (980)
@@ -310,6 +323,8 @@ const titleStyle = css`
  * ├───────────────────────┤
  * │▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒│
  * │▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒│
+ * ├───────────────────────┤
+ * │Show More              │
  * └───────────────────────┘
  *
  * on `leftCol` (1140) if component is toggleable
@@ -322,6 +337,8 @@ const titleStyle = css`
  * │   │▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒│
  * │Tre│▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒│
  * │ats│▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒│
+ * ├───┼─────────────────────┤
+ * │   │Show More            │
  * └───┴─────────────────────┘
  *
  * on `leftCol` (1140) if component is not toggleable
@@ -334,6 +351,8 @@ const titleStyle = css`
  * │   │▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒│
  * │Tre│▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒│
  * │ats│▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒│
+ * ├───┼──────────────────────┤
+ * │   │Show More             │
  * └───┴──────────────────────┘
  *
  * on `wide` (1300)
@@ -346,6 +365,8 @@ const titleStyle = css`
  * │     │▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒  │
  * │     │▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒  │
  * │Treat│▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒  │
+ * ├─────┼─────────────────────────┤
+ * │     │Show More                │
  * └─────┴─────────────────────────┘
  *
  */
@@ -359,24 +380,29 @@ export const FrontSection = ({
 	leftContent,
 	ophanComponentLink,
 	ophanComponentName,
-	sectionId,
+	sectionId = '',
+	collectionId,
+	pageId,
 	showDateHeader = false,
 	showTopBorder = true,
 	toggleable = false,
 	treats,
 	url,
 	badge,
+	canShowMore,
+	ajaxUrl,
 }: Props) => {
 	const overrides =
 		containerPalette && decideContainerOverrides(containerPalette);
 
 	const isToggleable = toggleable && !!sectionId;
-
-	const childrenContainerStyles = [
-		sectionContent,
-		sectionContentPadded,
-		paddings,
-	];
+	const showMore =
+		canShowMore &&
+		!!title &&
+		!!sectionId &&
+		!!collectionId &&
+		!!pageId &&
+		!!ajaxUrl;
 
 	/**
 	 * id is being used to set the containerId in @see {ShowMore.importable.tsx}
@@ -391,7 +417,6 @@ export const FrontSection = ({
 			css={[
 				fallbackStyles,
 				containerStyles,
-				isToggleable && containerStylesToggleable,
 				css`
 					background-color: ${overrides?.background.container};
 				`,
@@ -399,7 +424,7 @@ export const FrontSection = ({
 		>
 			<div css={[decoration, sideBorders, showTopBorder && topBorder]} />
 
-			<div css={[headlineContainerStyles, headlineContainerBorders]}>
+			<div css={[sectionHeadline]}>
 				<Hide until="leftCol">{badge}</Hide>
 				<div css={titleStyle}>
 					<Hide from="leftCol">{badge}</Hide>
@@ -416,26 +441,44 @@ export const FrontSection = ({
 				{leftContent}
 			</div>
 
-			{isToggleable ? (
-				<>
-					<div css={sectionShowHide}>
-						<ShowHideButton
-							sectionId={sectionId}
-							overrideContainerToggleColour={
-								overrides?.text.containerToggle
-							}
-						/>
-					</div>
-					<div
-						css={childrenContainerStyles}
-						id={`container-${sectionId}`}
-					>
-						{children}
-					</div>
-				</>
-			) : (
-				<div css={childrenContainerStyles}>{children}</div>
+			{isToggleable && (
+				<div css={sectionShowHide}>
+					<ShowHideButton
+						sectionId={sectionId}
+						overrideContainerToggleColour={
+							overrides?.text.containerToggle
+						}
+					/>
+				</div>
 			)}
+
+			<div
+				css={[
+					sectionContent,
+					sectionContentPadded,
+					sectionContentRow(toggleable),
+					paddings,
+				]}
+				id={`container-${sectionId}`}
+			>
+				{children}
+			</div>
+
+			<div css={[sectionContentPadded, sectionShowMore, bottomPadding]}>
+				{showMore && (
+					<Island deferUntil="interaction">
+						<ShowMore
+							title={title}
+							sectionId={sectionId}
+							collectionId={collectionId}
+							pageId={pageId}
+							ajaxUrl={ajaxUrl}
+							containerPalette={containerPalette}
+							showAge={title === 'Headlines'}
+						/>
+					</Island>
+				)}
+			</div>
 
 			{treats && (
 				<div css={[sectionTreats, paddings]}>

--- a/dotcom-rendering/src/web/components/ShowMore.importable.tsx
+++ b/dotcom-rendering/src/web/components/ShowMore.importable.tsx
@@ -24,20 +24,20 @@ import { FrontCard } from './FrontCard';
 function decideButtonText({
 	isOpen,
 	loading,
-	containerTitle,
+	title,
 }: {
 	isOpen: boolean;
 	loading: boolean;
-	containerTitle: string;
+	title: string;
 }) {
 	if (isOpen && loading) return 'Loading';
-	if (isOpen) return `Less ${containerTitle}`;
-	return `More ${containerTitle}`;
+	if (isOpen) return `Less ${title}`;
+	return `More ${title}`;
 }
 
 type Props = {
-	containerTitle: string;
-	path: string;
+	title: string;
+	pageId: string;
 	/**
 	 * `collectionId` is the id of the collection as it figures in the fronts
 	 * config. It is used to generate the URL for the show-more API endpoint.
@@ -51,19 +51,19 @@ type Props = {
 	 * in the main container. (This can happen due to a lag between when the page is SSRd
 	 * and when the user clicks the 'show more' button.)
 	 */
-	containerElementId: string;
+	sectionId: string;
 	showAge: boolean;
-	baseUrl: string;
+	ajaxUrl: string;
 	containerPalette?: DCRContainerPalette;
 };
 
 export const ShowMore = ({
-	containerTitle,
-	path,
+	title,
+	pageId,
+	sectionId,
 	collectionId,
-	containerElementId,
 	showAge,
-	baseUrl,
+	ajaxUrl,
 	containerPalette,
 }: Props) => {
 	const [existingCardLinks, setExistingCardLinks] = useState<string[]>([]);
@@ -75,7 +75,7 @@ export const ShowMore = ({
 	 * 'show-more' endpoint.
 	 */
 	useOnce(() => {
-		const container = document.getElementById(containerElementId);
+		const container = document.getElementById(`container-${sectionId}`);
 		const containerLinks = Array.from(
 			container?.querySelectorAll('a') ?? [],
 		)
@@ -91,17 +91,17 @@ export const ShowMore = ({
 	 *   @see https://swr.vercel.app/docs/conditional-fetching#conditional
 	 */
 	const url = isOpen
-		? `${baseUrl}/${path}/show-more/${collectionId}.json?dcr=true`
+		? `${ajaxUrl}/${pageId}/show-more/${collectionId}.json?dcr=true`
 		: undefined;
 	const { data, error, loading } = useApi<FEFrontCard[]>(url);
 
-	const filteredData =
+	const cards =
 		data &&
 		enhanceCards(data).filter(
 			(card) => !existingCardLinks.includes(card.url),
 		);
 
-	const showMoreContainerId = `show-more-${containerElementId}`;
+	const showMoreContainerId = `show-more-${collectionId}`;
 
 	useEffect(() => {
 		/**
@@ -110,7 +110,7 @@ export const ShowMore = ({
 		 * `false` then `filteredData` will be `undefined`.
 		 * */
 
-		const [card] = filteredData ?? [];
+		const [card] = cards ?? [];
 		if (card) {
 			const maybeFirstCard = document.querySelector(
 				`#${showMoreContainerId} [data-link-name="${card.dataLinkName}"]`,
@@ -119,34 +119,31 @@ export const ShowMore = ({
 				maybeFirstCard.focus();
 			}
 		}
-	}, [filteredData, showMoreContainerId]);
+	}, [cards, showMoreContainerId]);
 
 	return (
 		<>
 			<div id={showMoreContainerId} aria-live="polite">
-				{filteredData && (
-					<>
-						<div
-							css={css`
-								height: ${space[3]}px;
-							`}
-						/>
+				{cards && (
+					<div
+						css={css`
+							padding-top: ${space[2]}px;
+						`}
+					>
 						<UL direction="row" wrapCards={true}>
-							{filteredData.map((card, cardIndex) => {
+							{cards.map((card, cardIndex) => {
 								const columns = 3;
 								return (
 									<LI
 										key={card.url}
 										percentage="33.333%"
-										stretch={
-											filteredData.length % columns !== 1
-										}
+										stretch={cards.length % columns !== 1}
 										padSides={true}
 										showDivider={cardIndex % columns !== 0}
 										offsetBottomPaddingOnDivider={shouldPadWrappableRows(
 											cardIndex,
-											filteredData.length -
-												(filteredData.length % columns),
+											cards.length -
+												(cards.length % columns),
 											columns,
 										)}
 									>
@@ -162,13 +159,15 @@ export const ShowMore = ({
 								);
 							})}
 						</UL>
-					</>
+					</div>
 				)}
 			</div>
 			<div
-				css={css`
-					display: flex;
-				`}
+				css={[
+					css`
+						display: flex;
+					`,
+				]}
 			>
 				<Button
 					size="xsmall"
@@ -192,16 +191,16 @@ export const ShowMore = ({
 					`}
 					aria-controls={showMoreContainerId}
 					aria-expanded={isOpen && !loading}
-					aria-describedby={`show-more-button-${containerElementId}-description`}
+					aria-describedby={`show-more-button-${collectionId}-description`}
 				>
 					{decideButtonText({
 						isOpen,
 						loading,
-						containerTitle,
+						title,
 					})}
 				</Button>
 				<span
-					id={`show-more-button-${containerElementId}-description`}
+					id={`show-more-button-${collectionId}-description`}
 					css={css`
 						${visuallyHidden}
 					`}

--- a/dotcom-rendering/src/web/components/ShowMore.stories.tsx
+++ b/dotcom-rendering/src/web/components/ShowMore.stories.tsx
@@ -12,18 +12,18 @@ const play = ({ canvasElement }: { canvasElement: HTMLElement }) => {
 	userEvent.click(canvas.getByRole('button'));
 };
 
-const containerTitle = 'Opinion';
-const path = 'uk/lifestyle';
+const title = 'Opinion';
+const pageId = 'uk/lifestyle';
 const collectionId = '5011-3940-8793-33a9';
-const baseUrl = 'https://api.nextgen.guardianapps.co.uk';
-const containerElementId = 'container-id';
+const ajaxUrl = 'https://api.nextgen.guardianapps.co.uk';
+const sectionId = 'container-id';
 
 const defaultProps = {
-	containerTitle,
-	baseUrl,
-	path,
+	title,
+	ajaxUrl,
+	pageId,
 	collectionId,
-	containerElementId,
+	sectionId,
 	showAge: false,
 };
 
@@ -35,7 +35,7 @@ export default {
 export const ShowMoreSuccess = () => {
 	fetchMock
 		.restore()
-		.get(`${baseUrl}/${path}/show-more/${collectionId}.json?dcr=true`, {
+		.get(`${ajaxUrl}/${pageId}/show-more/${collectionId}.json?dcr=true`, {
 			status: 200,
 			body: trails.slice(0, 6),
 		});
@@ -49,7 +49,7 @@ ShowMoreSuccess.storyName = 'ShowMore button, success';
 export const ShowMoreError = () => {
 	fetchMock
 		.restore()
-		.get(`${baseUrl}/${path}/show-more/${collectionId}.json?dcr`, {
+		.get(`${ajaxUrl}/${pageId}/show-more/${collectionId}.json?dcr`, {
 			status: 404,
 			body: null,
 		});

--- a/dotcom-rendering/src/web/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FrontLayout.tsx
@@ -21,7 +21,6 @@ import { HeaderAdSlot } from '../components/HeaderAdSlot';
 import { Island } from '../components/Island';
 import { Nav } from '../components/Nav/Nav';
 import { Section } from '../components/Section';
-import { ShowMore } from '../components/ShowMore.importable';
 import { Snap } from '../components/Snap';
 import { SubNav } from '../components/SubNav.importable';
 import { TrendingTopics } from '../components/TrendingTopics';
@@ -364,11 +363,15 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 								}
 								badge={showBadge(collection.displayName)}
 								sectionId={ophanName}
+								collectionId={collection.id}
+								pageId={front.pressedPage.id}
 								showDateHeader={
 									collection.config.showDateHeader
 								}
 								editionId={front.editionId}
 								treats={collection.treats}
+								canShowMore={collection.canShowMore}
+								ajaxUrl={front.config.ajaxUrl}
 							>
 								<DecideContainer
 									trails={trails}
@@ -383,26 +386,6 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 									}
 									renderAds={renderAds}
 								/>
-								{collection.canShowMore && (
-									<Island deferUntil="interaction">
-										<ShowMore
-											containerTitle={
-												collection.displayName
-											}
-											collectionId={collection.id}
-											containerElementId={ophanName}
-											path={front.pressedPage.id}
-											baseUrl={front.config.ajaxUrl}
-											containerPalette={
-												collection.containerPalette
-											}
-											showAge={
-												collection.displayName ===
-												'Headlines'
-											}
-										/>
-									</Island>
-								)}
 							</FrontSection>
 							{renderAds &&
 								decideAdSlot(


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

- Cleans up unnecessary CSS.
- Use more named areas for rows instead of relying on magic numbers.
- Create a new area for show-more, and move Show More into FrontSection
- Align Treats to the bottom of the content row fixes https://github.com/guardian/dotcom-rendering/issues/7291
- Rename props to match parent component prop names


## Screenshots

| Before              | After              |
|---------------------|--------------------|
| ![before-mobile][]  | ![after-mobile][]  |
| ![before-leftCol][] | ![after-leftCol][] |
| ![before-wide][]    | ![after-wide][]    |

[before-mobile]: https://user-images.githubusercontent.com/21217225/233687270-7d569ecc-2112-4682-a323-9f3930914bff.png

[after-mobile]: https://user-images.githubusercontent.com/21217225/233691138-5f1bb8fe-89af-42d4-b107-43b1856057ce.png


[before-leftCol]: https://user-images.githubusercontent.com/21217225/233687287-479d5c2e-0e49-43c5-a63e-15be45557394.png

[after-leftCol]: https://user-images.githubusercontent.com/21217225/233691179-e9ae78d5-d068-438b-b59a-c516a0cbbcef.png

[before-wide]: https://user-images.githubusercontent.com/21217225/233687303-691bbae6-2ff8-4237-a5fa-2fb8ae85ffc9.png

[after-wide]: https://user-images.githubusercontent.com/21217225/233691220-21d5a9f2-9bd1-4b3c-b017-2190b7f79a92.png




<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->


<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->

Fixes https://github.com/guardian/dotcom-rendering/pull/7564
