### PR TITLE
Add this-is-europe badge

### DIFF
--- a/dotcom-rendering/src/web/components/FrontSection.tsx
+++ b/dotcom-rendering/src/web/components/FrontSection.tsx
@@ -1,6 +1,8 @@
 import { css, jsx } from '@emotion/react';
+import type { EmotionJSX } from '@emotion/react/types/jsx-namespace';
 import type { ArticleFormat } from '@guardian/libs';
 import { from, neutral, space, until } from '@guardian/source-foundations';
+import { Hide } from '@guardian/source-react-components';
 import type { DCRContainerPalette, TreatType } from '../../types/front';
 import { decideContainerOverrides } from '../lib/decideContainerOverrides';
 import type { EditionId } from '../lib/edition';
@@ -76,6 +78,7 @@ type Props = {
 	editionId?: EditionId;
 	/** A list of related links that appear in the bottom of the left column on fronts */
 	treats?: TreatType[];
+	badge?: EmotionJSX.Element;
 };
 
 const width = (columns: number, columnWidth: number, columnGap: number) =>
@@ -460,6 +463,7 @@ export const FrontSection = ({
 	treats,
 	url,
 	verticalMargins = true,
+	badge,
 }: Props) => {
 	const overrides =
 		containerPalette && decideContainerOverrides(containerPalette);
@@ -519,7 +523,9 @@ export const FrontSection = ({
 					centralBorder === 'partial' && headlineContainerBorders,
 				]}
 			>
+				<Hide until="leftCol">{badge}</Hide>
 				<div css={titleStyle}>
+					<Hide from="leftCol">{badge}</Hide>
 					<ContainerTitle
 						title={title}
 						fontColour={fontColour ?? overrides?.text.container}

--- a/dotcom-rendering/src/web/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FrontLayout.tsx
@@ -28,6 +28,7 @@ import { canRenderAds } from '../lib/canRenderAds';
 import { DecideContainer } from '../lib/DecideContainer';
 import { decidePalette } from '../lib/decidePalette';
 import { Stuck } from './lib/stickiness';
+import { Badge } from '../components/Badge';
 
 interface Props {
 	front: DCRFrontType;
@@ -151,6 +152,19 @@ const decideAdSlot = (
 		);
 	}
 	return null;
+};
+
+const showBadge = (displayName: string) => {
+	if (displayName === 'This is Europe')
+		return (
+			<Badge
+				imageUrl={
+					'https://assets.guim.co.uk/images/badges/768d8d7999510d6d05aa2d865640803c/this-is-europe.svg'
+				}
+				seriesTag={'world/series/this-is-europe'}
+			/>
+		);
+	return undefined;
 };
 
 export const FrontLayout = ({ front, NAV }: Props) => {
@@ -400,6 +414,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 										<CPScottHeader />
 									)
 								}
+								badge={showBadge(collection.displayName)}
 								sectionId={ophanName}
 								showDateHeader={
 									collection.config.showDateHeader


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Adds this-is-europe badge
## Why?
Parity with frontend resolves https://github.com/guardian/dotcom-rendering/issues/7558
## Screenshots
Above desktop
| Frontend      | DCR (this pr)      |
|-------------|------------|
| ![before][] | ![after][] |
Below desktop
| Frontend      | DCR (this pr)      |
|-------------|------------|
| ![before2][] | ![after2][] |

[before]: https://user-images.githubusercontent.com/110032454/232543925-a05cbbe9-5d4b-4a53-b6b6-5cb69037c56a.png
[after]:https://user-images.githubusercontent.com/110032454/232543808-97736d21-c9c2-4c67-9ba1-0f54e34b76ae.png
[before2]: https://user-images.githubusercontent.com/110032454/232544157-213ddc78-6c73-48ab-9d49-c6523d52dbc8.png
[after2]: https://user-images.githubusercontent.com/110032454/232544065-c1397d9a-8fd8-4345-a563-07fdb53255e0.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->


<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
