### PR TITLE
Achieve parity with frontend on merchandise high and mobile ads

### DIFF
--- a/dotcom-rendering/src/web/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FrontLayout.tsx
@@ -11,6 +11,7 @@ import { StraightLines } from '@guardian/source-react-components-development-kit
 import type { NavType } from '../../model/extract-nav';
 import type { DCRCollectionType, DCRFrontType } from '../../types/front';
 import { AdSlot } from '../components/AdSlot';
+import { Badge } from '../components/Badge';
 import { CPScottHeader } from '../components/CPScottHeader';
 import { Footer } from '../components/Footer';
 import { FrontMostViewed } from '../components/FrontMostViewed';
@@ -27,8 +28,11 @@ import { TrendingTopics } from '../components/TrendingTopics';
 import { canRenderAds } from '../lib/canRenderAds';
 import { DecideContainer } from '../lib/DecideContainer';
 import { decidePalette } from '../lib/decidePalette';
+import {
+	getMerchHighPosition,
+	getMobileAdPositions,
+} from '../lib/getAdPositions';
 import { Stuck } from './lib/stickiness';
-import { Badge } from '../components/Badge';
 
 interface Props {
 	front: DCRFrontType;
@@ -58,65 +62,6 @@ const isToggleable = (
 			!isNavList(collection)
 		);
 	} else return index != 0 && !isNavList(collection);
-};
-
-const getMerchHighPosition = (
-	collectionCount: number,
-	isNetworkFront: boolean | undefined,
-) => {
-	if (collectionCount < 4) {
-		return 2;
-	} else if (isNetworkFront) {
-		return 5;
-	} else {
-		return 4;
-	}
-};
-
-/**
- * On mobile, we remove the first container if it is a thrasher
- * and remove a container if it, or the next sibling, is a commercial container
- * we also exclude any containers that are directly before a thrasher
- * then we take every other container, up to a maximum of 10, for targeting MPU insertion
- */
-
-const getMobileAdPositions = (
-	isNetworkFront: boolean | undefined,
-	collections: DCRCollectionType[],
-) => {
-	const merchHighPosition = getMerchHighPosition(
-		collections.length,
-		isNetworkFront,
-	);
-
-	const positions: number[] = collections
-		.map((collection, collectionIndex) => {
-			const isThrasher = collection.collectionType === 'fixed/thrasher';
-			const isFirst = collectionIndex === 0;
-			const isNearMerchandising =
-				collectionIndex === merchHighPosition ||
-				collectionIndex + 1 === merchHighPosition;
-			const isNearThrasher =
-				collections[collectionIndex + 1]?.collectionType ===
-				'fixed/thrasher';
-			if (isFirst && isThrasher) return false;
-			if (isNearMerchandising) return false;
-			if (isNearThrasher) return false;
-			else if (
-				collectionIndex % 2 === 0 &&
-				collectionIndex < collections.length - 1
-			) {
-				return true;
-			}
-			return false;
-		})
-		.map((shouldDisplayAd, collectionIndex) =>
-			shouldDisplayAd ? collectionIndex : undefined,
-		)
-		.filter((index): index is number => typeof index === 'number')
-		// Should insert no more than 10 ads
-		.slice(0, 10);
-	return positions;
 };
 
 const decideAdSlot = (
@@ -183,7 +128,10 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 
 	const palette = decidePalette(format);
 
-	// const contributionsServiceUrl = getContributionsServiceUrl(front);
+	const merchHighPosition = getMerchHighPosition(
+		front.pressedPage.collections.length,
+		front.isNetworkFront,
+	);
 
 	/**
 	 * This property currently only applies to the header and merchandising slots
@@ -191,10 +139,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 	const renderAds = canRenderAds(front);
 
 	const mobileAdPositions = renderAds
-		? getMobileAdPositions(
-				front.isNetworkFront,
-				front.pressedPage.collections,
-		  )
+		? getMobileAdPositions(front.pressedPage.collections, merchHighPosition)
 		: [];
 
 	return (

--- a/dotcom-rendering/src/web/lib/getAdPositions.test.ts
+++ b/dotcom-rendering/src/web/lib/getAdPositions.test.ts
@@ -1,0 +1,213 @@
+import type { DCRCollectionType } from '../../types/front';
+import { getMobileAdPositions } from './getAdPositions';
+
+const defaultTestCollections: Pick<DCRCollectionType, 'collectionType'>[] = [
+	...Array<number>(12),
+].map(() => ({
+	collectionType: 'fixed/large/slow-XIV',
+}));
+
+describe('Mobile Ads', () => {
+	it(`Should not insert ad after container if it's the first one and it's a thrasher`, () => {
+		const merchHighPosition = 2;
+		const testCollections = [...defaultTestCollections];
+		testCollections.unshift({ collectionType: 'fixed/thrasher' });
+
+		const mobileAdPositions = getMobileAdPositions(
+			testCollections,
+			merchHighPosition,
+		);
+
+		expect(mobileAdPositions).not.toContain(0);
+	});
+
+	// MerchandiseHigh is in position:
+	// 3: when it's a network front and collections are equal or more than 4
+	// 2: when collections are equal or more than 4 and is not a network front
+	// 0: when collections are less than 4
+	it.each([3, 2, 0])(
+		`should not insert ad when merchandise high is in position %i`,
+		(merchHighPosition) => {
+			const mobileAdPositions = getMobileAdPositions(
+				defaultTestCollections,
+				merchHighPosition,
+			);
+			expect(mobileAdPositions).not.toContain(merchHighPosition);
+		},
+	);
+
+	it('Should not insert ad after a thrasher container', () => {
+		const merchHighPosition = 2;
+		const testCollections = [...defaultTestCollections];
+		testCollections.splice(6, 0, { collectionType: 'fixed/thrasher' });
+		testCollections.splice(9, 0, { collectionType: 'fixed/thrasher' });
+
+		const mobileAdPositions = getMobileAdPositions(
+			testCollections,
+			merchHighPosition,
+		);
+
+		expect(mobileAdPositions).not.toContain(7);
+		expect(mobileAdPositions).not.toContain(10);
+	});
+
+	// We used https://www.theguardian.com/uk/commentisfree as a blueprint
+	it('Non-network front, with more than 4 collections, without thrashers', () => {
+		const merchHighPosition = 2;
+		const testCollections: Pick<DCRCollectionType, 'collectionType'>[] = [
+			{ collectionType: 'fixed/large/slow-XIV' },
+			{ collectionType: 'fixed/medium/slow-VI' },
+			{ collectionType: 'fixed/small/slow-IV' },
+			{ collectionType: 'fixed/small/slow-IV' },
+			{ collectionType: 'fixed/small/slow-IV' },
+			{ collectionType: 'dynamic/slow-mpu' },
+			{ collectionType: 'fixed/small/slow-I' },
+			{ collectionType: 'fixed/medium/slow-VI' },
+			{ collectionType: 'fixed/small/slow-IV' },
+			{ collectionType: 'fixed/small/slow-III' },
+			{ collectionType: 'fixed/medium/fast-XII' },
+			{ collectionType: 'fixed/small/fast-VIII' },
+			{ collectionType: 'news/most-popular' },
+		];
+
+		const mobileAdPositions = getMobileAdPositions(
+			testCollections,
+			merchHighPosition,
+		);
+
+		expect(mobileAdPositions).toEqual([0, 3, 5, 7, 9, 11]);
+	});
+
+	// We used https://www.theguardian.com/uk as a blueprint
+	it('UK Network Front, with more than 4 collections, with thrashers at various places', () => {
+		const merchHighPosition = 3;
+		const testCollections: Pick<DCRCollectionType, 'collectionType'>[] = [
+			{ collectionType: 'dynamic/fast' },
+			{ collectionType: 'fixed/small/slow-IV' },
+			{ collectionType: 'dynamic/slow' },
+			{ collectionType: 'dynamic/slow' },
+			{ collectionType: 'fixed/small/slow-V-mpu' },
+			{ collectionType: 'dynamic/slow' },
+			{ collectionType: 'fixed/thrasher' },
+			{ collectionType: 'fixed/small/slow-IV' },
+			{ collectionType: 'fixed/thrasher' },
+			{ collectionType: 'dynamic/fast' },
+			{ collectionType: 'dynamic/fast' },
+			{ collectionType: 'fixed/thrasher' },
+			{ collectionType: 'dynamic/slow-mpu' },
+			{ collectionType: 'fixed/small/slow-IV' },
+			{ collectionType: 'fixed/thrasher' },
+			{ collectionType: 'dynamic/slow-mpu' },
+			{ collectionType: 'fixed/thrasher' },
+			{ collectionType: 'fixed/video' },
+			{ collectionType: 'fixed/small/slow-IV' },
+			{ collectionType: 'fixed/small/slow-IV' },
+			{ collectionType: 'dynamic/slow-mpu' },
+			{ collectionType: 'fixed/small/slow-IV' },
+			{ collectionType: 'fixed/medium/slow-VI' },
+			{ collectionType: 'news/most-popular' },
+		];
+
+		const mobileAdPositions = getMobileAdPositions(
+			testCollections,
+			merchHighPosition,
+		);
+
+		expect(mobileAdPositions).toEqual([0, 2, 6, 9, 12, 16, 18, 20, 22]);
+	});
+
+	// We used https://www.theguardian.com/us as a blueprint
+	it('US Network Front, with more than 4 collections, with thrashers at various places', () => {
+		const merchHighPosition = 3;
+		const testCollections: Pick<DCRCollectionType, 'collectionType'>[] = [
+			{ collectionType: 'dynamic/fast' },
+			{ collectionType: 'fixed/small/slow-IV' },
+			{ collectionType: 'fixed/small/slow-IV' },
+			{ collectionType: 'dynamic/slow-mpu' },
+			{ collectionType: 'fixed/thrasher' },
+			{ collectionType: 'dynamic/slow' },
+			{ collectionType: 'dynamic/slow' },
+			{ collectionType: 'fixed/thrasher' },
+			{ collectionType: 'fixed/small/slow-III' },
+			{ collectionType: 'fixed/thrasher' },
+			{ collectionType: 'fixed/small/slow-IV' },
+			{ collectionType: 'dynamic/fast' },
+			{ collectionType: 'fixed/thrasher' },
+			{ collectionType: 'fixed/medium/slow-VI' },
+			{ collectionType: 'dynamic/fast' },
+			{ collectionType: 'dynamic/fast' },
+			{ collectionType: 'fixed/small/slow-V-mpu' },
+			{ collectionType: 'fixed/video' },
+			{ collectionType: 'fixed/small/slow-III' },
+			{ collectionType: 'fixed/thrasher' },
+			{ collectionType: 'news/most-popular' },
+		];
+
+		const mobileAdPositions = getMobileAdPositions(
+			testCollections,
+			merchHighPosition,
+		);
+
+		expect(mobileAdPositions).toEqual([0, 2, 5, 9, 12, 14, 16, 19]);
+	});
+
+	// We used https://www.theguardian.com/uk/lifeandstyle as a blueprint
+	it('Lifeandstyle front, with more than 4 collections, with thrashers at various places', () => {
+		const merchHighPosition = 2;
+
+		const testCollections: Pick<DCRCollectionType, 'collectionType'>[] = [
+			{ collectionType: 'dynamic/slow' },
+			{ collectionType: 'fixed/medium/slow-VI' },
+			{ collectionType: 'fixed/thrasher' },
+			{ collectionType: 'fixed/medium/slow-VI' },
+			{ collectionType: 'fixed/small/slow-V-third' },
+			{ collectionType: 'fixed/small/slow-IV' },
+			{ collectionType: 'fixed/thrasher' },
+			{ collectionType: 'fixed/small/slow-IV' },
+			{ collectionType: 'fixed/thrasher' },
+			{ collectionType: 'fixed/medium/slow-VI' },
+			{ collectionType: 'fixed/medium/slow-XII-mpu' },
+			{ collectionType: 'fixed/small/fast-VIII' },
+			{ collectionType: 'fixed/thrasher' },
+			{ collectionType: 'fixed/small/slow-III' },
+			{ collectionType: 'fixed/small/slow-I' },
+			{ collectionType: 'news/most-popular' },
+		];
+
+		const mobileAdPositions = getMobileAdPositions(
+			testCollections,
+			merchHighPosition,
+		);
+
+		expect(mobileAdPositions).toEqual([0, 4, 8, 10, 13]);
+	});
+
+	// We used https://www.theguardian.com/tone/recipes as a blueprint
+	it('Recipes front, with more than 4 collections, with thrasher at the first position', () => {
+		const merchHighPosition = 2;
+
+		const testCollections: Pick<DCRCollectionType, 'collectionType'>[] = [
+			{ collectionType: 'fixed/thrasher' },
+			{ collectionType: 'fixed/medium/slow-VI' },
+			{ collectionType: 'fixed/small/slow-V-third' },
+			{ collectionType: 'fixed/medium/slow-XII-mpu' },
+			{ collectionType: 'fixed/medium/fast-XII' },
+			{ collectionType: 'fixed/small/slow-V-third' },
+			{ collectionType: 'fixed/small/fast-VIII' },
+			{ collectionType: 'fixed/medium/fast-XI' },
+			{ collectionType: 'fixed/small/slow-III' },
+			{ collectionType: 'fixed/small/slow-IV' },
+			{ collectionType: 'fixed/small/slow-V-half' },
+			{ collectionType: 'fixed/small/slow-V-third' },
+			{ collectionType: 'fixed/small/fast-VIII' },
+			{ collectionType: 'news/most-popular' },
+		];
+
+		const mobileAdPositions = getMobileAdPositions(
+			testCollections,
+			merchHighPosition,
+		);
+
+		expect(mobileAdPositions).toEqual([1, 4, 6, 8, 10, 12]);
+	});
+});

--- a/dotcom-rendering/src/web/lib/getAdPositions.ts
+++ b/dotcom-rendering/src/web/lib/getAdPositions.ts
@@ -1,0 +1,75 @@
+import type { DCRCollectionType } from '../../types/front';
+
+type AdCandidate = Pick<DCRCollectionType, 'collectionType'>;
+
+export const getMerchHighPosition = (
+	collectionCount: number,
+	isNetworkFront: boolean | undefined,
+): number => {
+	if (collectionCount >= 4) {
+		if (isNetworkFront === true) {
+			return 3;
+		} else {
+			return 2;
+		}
+	} else {
+		return 0;
+	}
+};
+
+// This happens on the recipes front, where the first container is a thrasher see: https://github.com/guardian/frontend/pull/20617
+const hasFirstContainerThrasher = (collectionType: string, index: number) =>
+	index === 0 && collectionType === 'fixed/thrasher';
+
+const hasAdjacentCommercialContainer = (
+	collectionIndex: number,
+	merchHighPosition: number,
+) => collectionIndex === merchHighPosition;
+
+const hasAdjacentThrasher = (index: number, collections: AdCandidate[]) =>
+	collections[index + 1]?.collectionType === 'fixed/thrasher';
+
+const isMostViewedContainer = (collection: AdCandidate) =>
+	collection.collectionType === 'news/most-popular';
+
+const shouldInsertAd =
+	(merchHighPosition: number) =>
+	(
+		collection: AdCandidate,
+		collectionIndex: number,
+		collections: AdCandidate[],
+	) =>
+		!(
+			hasFirstContainerThrasher(
+				collection.collectionType,
+				collectionIndex,
+			) ||
+			hasAdjacentCommercialContainer(
+				collectionIndex,
+				merchHighPosition,
+			) ||
+			hasAdjacentThrasher(collectionIndex, collections) ||
+			isMostViewedContainer(collection)
+		);
+
+const isEvenIndex = (_collection: unknown, index: number) => index % 2 === 0;
+
+/**
+ * We do not insert mobile ads:
+ * a. after the first container if it is a thrasher
+ * b. after a commercial container (e.g. merchandise high)
+ * c. between a regular container and a thrasher
+ * d. after the Most Viewed container.
+ * After we've filtered out the containers next to which we can insert an ad,
+ * we take every other container, up to a maximum of 10, for targeting MPU insertion.
+ */
+export const getMobileAdPositions = (
+	collections: AdCandidate[],
+	merchHighPosition: number,
+): number[] =>
+	collections
+		.filter(shouldInsertAd(merchHighPosition))
+		.filter(isEvenIndex)
+		.map((collection: AdCandidate) => collections.indexOf(collection))
+		// Should insert no more than 10 ads
+		.slice(0, 10);


### PR DESCRIPTION
Hopefully closes #7526 🤞 

Co-authored-by: Parisa Tork <47482049+ParisaTork@users.noreply.github.com>
Co-authored-by: Ioanna Kokkini <ioannakok@users.noreply.github.com><!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## Why?
After rendering DCR fronts to 20% of our users the data analysts of the Commercial team [noticed a consistent lower ad ratio in DCR fronts vs frontend](https://docs.google.com/spreadsheets/d/1I9Ss0RH0v4_6owyOgTxgkN8NQetCaKe6J1sQOE2THco/edit#gid=2117712738).(
See period 07-03-2023 until 22-04-2023). It's worth noting that there hasn't been any impact on the revenue, possibly because DCR performs better in general so that overcomes the lower ad ratio. 

After this PR gets merged we are going to monitor the ad ratio closely. If it gets fixed and our assumption that revenue hasn't been impacted because of the general better DCR performance, we might as well see an increase in the revenue!

## What does this change?

This PR is an attempt to fix the ad ratio by making sure we're having parity with frontend on:
1. Merchandise high position. See [frontend logic](https://github.com/guardian/frontend/blob/main/common/app/views/support/HtmlCleaner.scala#L827-L864). 
2. Mobile ads. See [frontend logic](https://github.com/guardian/frontend/blob/main/common/app/views/support/HtmlCleaner.scala#L769-L825). As a result of these changes the total number of mobile ads now increases as well as their positions.

## Challenges
The biggest challenge we faced while working on this PR is that while we have to achieve parity with frontend / replicate its logic the arrays of containers over which frontend and DCR iterate in order to apply an (already complicated) logic and insert the ads differ. We're going to use `/uk` as an example to demonstrate the problem.

### Frontend array of containers

Frontend fetches the list of containers by [looking at the DOM](https://github.com/guardian/frontend/blob/main/common/app/views/support/HtmlCleaner.scala#L789): 

```
val containers: List[Element] = document.getElementsByClass("fc-container").asScala.toList
```

So it applies the ads and merchandise high logic to an array of 27 elements which contain:
1. The palettes "hidden" container
2. The Commercial containers (i.e. merchandise high and low at positions 4 and 26)
3. The regular containers (containers with cards & thrashers)

<img width="1104" alt="image" src="https://user-images.githubusercontent.com/19683595/234269157-8af8ee36-ba49-4ed5-9633-79e579006075.png">


### Array of containers DCR receives
DCR receives 25 containers in the JSON, so the initial array does not include the two commercial containers.

<img width="1678" alt="image" src="https://user-images.githubusercontent.com/19683595/234269777-785569e7-c82b-4b1c-acc9-bbe37e968a21.png">


### Array of containers DCR iterates over and inserts ads

In network fronts it ends up iterating over 24 containers (only the containers with cards & thrashers) because very early on it [filters out the palettes container](https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/src/model/enhanceCollections.ts#L8-L22). This is not the case with non-network fronts where DCR will apply the ads logic over the same list of containers it will receive in the JSON.

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->


<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
