### PR TITLE
refactor: Remove un-used props from FrontSection

### DIFF
--- a/dotcom-rendering/src/web/components/DynamicFast.stories.tsx
+++ b/dotcom-rendering/src/web/components/DynamicFast.stories.tsx
@@ -31,7 +31,6 @@ const defaultGroupedTrails: DCRGroupedTrails = {
 export const OneHugeTwoBigsSixStandards = () => (
 	<FrontSection
 		title="Dynamic Fast"
-		centralBorder="partial"
 		description={`first slice: oneHuge</br>second slice: twoBigs`}
 	>
 		<DynamicFast
@@ -50,7 +49,6 @@ OneHugeTwoBigsSixStandards.storyName = 'With 1 huge card, 2 bigs, 6 standards';
 export const OneVeryBigTwoBigsSixStandards = () => (
 	<FrontSection
 		title="Dynamic Fast"
-		centralBorder="partial"
 		description={`first slice: oneVeryBig</br>second slice: twoBigs`}
 	>
 		<DynamicFast
@@ -70,7 +68,6 @@ OneVeryBigTwoBigsSixStandards.storyName =
 export const TwoVeryBigsTwoBigsSixStandards = () => (
 	<FrontSection
 		title="Dynamic Fast"
-		centralBorder="partial"
 		description={`first slice: twoVeryBigs</br>second slice: twoBigs`}
 	>
 		<DynamicFast
@@ -90,7 +87,6 @@ TwoVeryBigsTwoBigsSixStandards.storyName =
 export const TwoVeryBigs1stBoostedTwoBigsSixStandards = () => (
 	<FrontSection
 		title="Dynamic Fast"
-		centralBorder="partial"
 		description={`first slice: twoVeryBigsFirstBoosted</br>second slice: twoBigs`}
 	>
 		<DynamicFast
@@ -110,7 +106,6 @@ TwoVeryBigs1stBoostedTwoBigsSixStandards.storyName =
 export const TwoVeryBigs2ndBoostedTwoBigsSixStandards = () => (
 	<FrontSection
 		title="Dynamic Fast"
-		centralBorder="partial"
 		description={`first slice: twoVeryBigsSecondBoosted</br>second slice: twoBigs`}
 	>
 		<DynamicFast
@@ -132,7 +127,6 @@ TwoVeryBigs2ndBoostedTwoBigsSixStandards.storyName =
 export const TwoVeryBigsTwelveStandards = () => (
 	<FrontSection
 		title="Dynamic Fast"
-		centralBorder="partial"
 		description={`first slice: twoVeryBigs</br>second slice: noBigs`}
 	>
 		<DynamicFast
@@ -151,7 +145,6 @@ TwoVeryBigsTwelveStandards.storyName = 'with 2 very big cards, 12 standards';
 export const TwoVeryBigsOneBigEightStandards = () => (
 	<FrontSection
 		title="Dynamic Fast"
-		centralBorder="partial"
 		description={`first slice: twoVeryBigs</br>second slice: oneBig`}
 	>
 		<DynamicFast
@@ -172,7 +165,6 @@ TwoVeryBigsOneBigEightStandards.storyName =
 export const TwoVeryBigsOneBigBoostedSixStandards = () => (
 	<FrontSection
 		title="Dynamic Fast"
-		centralBorder="partial"
 		description={`first slice: twoVeryBigs</br>second slice: oneBigBoosted`}
 	>
 		<DynamicFast
@@ -193,7 +185,6 @@ TwoVeryBigsOneBigBoostedSixStandards.storyName =
 export const TwoVeryBigsTwoBigsFiveStandards = () => (
 	<FrontSection
 		title="Dynamic Fast"
-		centralBorder="partial"
 		description={`first slice: twoVeryBigs</br>second slice: twoBigs`}
 	>
 		<DynamicFast
@@ -214,7 +205,6 @@ TwoVeryBigsTwoBigsFiveStandards.storyName =
 export const TwoVeryBigsTwoBigsFirstBoostedEightStandards = () => (
 	<FrontSection
 		title="Dynamic Fast"
-		centralBorder="partial"
 		description={`first slice: twoVeryBigs</br>second slice: twoOrMoreBigsFirstBoosted`}
 	>
 		<DynamicFast
@@ -235,7 +225,6 @@ TwoVeryBigsTwoBigsFirstBoostedEightStandards.storyName =
 export const TwoVeryBigsThreeBigsThreeStandards = () => (
 	<FrontSection
 		title="Dynamic Fast"
-		centralBorder="partial"
 		description={`first slice: twoVeryBigs</br>second slice: threeBigs`}
 	>
 		<DynamicFast
@@ -256,7 +245,6 @@ TwoVeryBigsThreeBigsThreeStandards.storyName =
 export const TwoVeryBigsFourBigs = () => (
 	<FrontSection
 		title="Dynamic Fast"
-		centralBorder="partial"
 		description={`first slice: twoVeryBigs</br>second slice: fourBigs`}
 	>
 		<DynamicFast
@@ -279,7 +267,6 @@ TwoVeryBigsFourBigs.storyName = 'with 2 very big cards, 4 bigs';
 export const OneHugeOneVeryBig7Standards = () => (
 	<FrontSection
 		title="Dynamic Fast"
-		centralBorder="partial"
 		description={`first slice: oneHuge</br>second slice: oneBig`}
 	>
 		<DynamicFast
@@ -300,7 +287,6 @@ OneHugeOneVeryBig7Standards.storyName = 'with 1 huge, 1 very big, 7 standards';
 export const ThreeVeryBigsFourBigs = () => (
 	<FrontSection
 		title="Dynamic Fast"
-		centralBorder="partial"
 		description={`first slice: twoVeryBigs</br>second slice: fourBigs`}
 	>
 		<DynamicFast
@@ -320,7 +306,6 @@ OneHugeOneVeryBig7Standards.storyName = 'with 1 huge, 1 very big, 7 standards';
 export const TwoBigsFourStandards = () => (
 	<FrontSection
 		title="Dynamic Fast"
-		centralBorder="partial"
 		description={`first slice: undefined</br>second slice: twoBigs`}
 	>
 		<DynamicFast
@@ -341,7 +326,6 @@ TwoBigsFourStandards.storyName = 'with 2 bigs, 4 standards';
 export const OneVeryBigTwoBigs = () => (
 	<FrontSection
 		title="Dynamic Fast"
-		centralBorder="partial"
 		description={`first slice: oneVeryBig</br>second slice: twoBigs`}
 	>
 		<DynamicFast
@@ -361,7 +345,6 @@ OneVeryBigTwoBigs.storyName = 'with 1 very big, 2 bigs';
 export const OneVeryBig = () => (
 	<FrontSection
 		title="Dynamic Fast"
-		centralBorder="partial"
 		description={`first slice: oneVeryBig</br>second slice: noBigs`}
 	>
 		<DynamicFast
@@ -380,7 +363,6 @@ OneVeryBig.storyName = 'with 1 very big';
 export const TwoVeryBigsFourBigsFirstBoostedThreeStandards = () => (
 	<FrontSection
 		title="Dynamic Fast"
-		centralBorder="partial"
 		description={`first slice: twoVeryBigs</br>second slice: twoOrMoreBigsFirstBoosted`}
 	>
 		<DynamicFast

--- a/dotcom-rendering/src/web/components/DynamicPackage.stories.tsx
+++ b/dotcom-rendering/src/web/components/DynamicPackage.stories.tsx
@@ -27,11 +27,7 @@ export default {
 };
 
 export const One = () => (
-	<FrontSection
-		title="Dynamic Package"
-		showTopBorder={true}
-		centralBorder="partial"
-	>
+	<FrontSection title="Dynamic Package" showTopBorder={true}>
 		<DynamicPackage
 			groupedTrails={{
 				...defaultGroupedTrails,
@@ -45,11 +41,7 @@ export const One = () => (
 One.storyName = 'With one standard card';
 
 export const Two = () => (
-	<FrontSection
-		title="Dynamic Package"
-		showTopBorder={true}
-		centralBorder="partial"
-	>
+	<FrontSection title="Dynamic Package" showTopBorder={true}>
 		<DynamicPackage
 			groupedTrails={{
 				...defaultGroupedTrails,
@@ -63,7 +55,7 @@ export const Two = () => (
 Two.storyName = 'With two standard cards';
 
 export const Three = () => (
-	<FrontSection title="Dynamic Package" centralBorder="partial">
+	<FrontSection title="Dynamic Package">
 		<DynamicPackage
 			groupedTrails={{
 				...defaultGroupedTrails,
@@ -77,7 +69,7 @@ export const Three = () => (
 Three.storyName = 'With three standard cards';
 
 export const Four = () => (
-	<FrontSection title="Dynamic Package" centralBorder="partial">
+	<FrontSection title="Dynamic Package">
 		<DynamicPackage
 			groupedTrails={{
 				...defaultGroupedTrails,
@@ -91,7 +83,7 @@ export const Four = () => (
 Four.storyName = 'With four standard cards';
 
 export const Five = () => (
-	<FrontSection title="Dynamic Package" centralBorder="partial">
+	<FrontSection title="Dynamic Package">
 		<DynamicPackage
 			groupedTrails={{
 				...defaultGroupedTrails,
@@ -105,11 +97,7 @@ export const Five = () => (
 Five.storyName = 'With five standard cards';
 
 export const Six = () => (
-	<FrontSection
-		title="Dynamic Package"
-		showTopBorder={true}
-		centralBorder="partial"
-	>
+	<FrontSection title="Dynamic Package" showTopBorder={true}>
 		<DynamicPackage
 			groupedTrails={{
 				...defaultGroupedTrails,
@@ -123,11 +111,7 @@ export const Six = () => (
 Six.storyName = 'With six standard cards';
 
 export const Seven = () => (
-	<FrontSection
-		title="Dynamic Package"
-		showTopBorder={true}
-		centralBorder="partial"
-	>
+	<FrontSection title="Dynamic Package" showTopBorder={true}>
 		<DynamicPackage
 			groupedTrails={{
 				...defaultGroupedTrails,
@@ -141,11 +125,7 @@ export const Seven = () => (
 Seven.storyName = 'With seven standard cards';
 
 export const Eight = () => (
-	<FrontSection
-		title="Dynamic Package"
-		showTopBorder={true}
-		centralBorder="partial"
-	>
+	<FrontSection title="Dynamic Package" showTopBorder={true}>
 		<DynamicPackage
 			groupedTrails={{
 				...defaultGroupedTrails,
@@ -159,12 +139,7 @@ export const Eight = () => (
 Eight.storyName = 'With eight standard cards';
 
 export const Nine = () => (
-	<FrontSection
-		title="Dynamic Package"
-		showTopBorder={true}
-		showSideBorders={true}
-		centralBorder="partial"
-	>
+	<FrontSection title="Dynamic Package" showTopBorder={true}>
 		<DynamicPackage
 			groupedTrails={{
 				...defaultGroupedTrails,
@@ -181,11 +156,7 @@ export const Boosted1 = () => {
 	const primary = trails[0];
 
 	return (
-		<FrontSection
-			title="Dynamic Package"
-			showTopBorder={true}
-			centralBorder="partial"
-		>
+		<FrontSection title="Dynamic Package" showTopBorder={true}>
 			<DynamicPackage
 				groupedTrails={{
 					...defaultGroupedTrails,
@@ -205,11 +176,7 @@ export const Boosted2 = () => {
 	const remaining = trails.slice(1, 2);
 
 	return (
-		<FrontSection
-			title="Dynamic Package"
-			showTopBorder={true}
-			centralBorder="partial"
-		>
+		<FrontSection title="Dynamic Package" showTopBorder={true}>
 			<DynamicPackage
 				groupedTrails={{
 					...defaultGroupedTrails,
@@ -229,7 +196,7 @@ export const Boosted3 = () => {
 	const remaining = trails.slice(1, 3);
 
 	return (
-		<FrontSection title="Dynamic Package" centralBorder="partial">
+		<FrontSection title="Dynamic Package">
 			<DynamicPackage
 				groupedTrails={{
 					...defaultGroupedTrails,
@@ -249,7 +216,7 @@ export const Boosted4 = () => {
 	const remaining = trails.slice(1, 4);
 
 	return (
-		<FrontSection title="Dynamic Package" centralBorder="partial">
+		<FrontSection title="Dynamic Package">
 			<DynamicPackage
 				groupedTrails={{
 					...defaultGroupedTrails,
@@ -269,7 +236,7 @@ export const Boosted5 = () => {
 	const remaining = trails.slice(1, 5);
 
 	return (
-		<FrontSection title="Dynamic Package" centralBorder="partial">
+		<FrontSection title="Dynamic Package">
 			<DynamicPackage
 				groupedTrails={{
 					...defaultGroupedTrails,
@@ -289,11 +256,7 @@ export const Boosted8 = () => {
 	const remaining = trails.slice(1, 8);
 
 	return (
-		<FrontSection
-			title="Dynamic Package"
-			showTopBorder={true}
-			centralBorder="partial"
-		>
+		<FrontSection title="Dynamic Package" showTopBorder={true}>
 			<DynamicPackage
 				groupedTrails={{
 					...defaultGroupedTrails,
@@ -313,11 +276,7 @@ export const Boosted9 = () => {
 	const remaining = trails.slice(1, 9);
 
 	return (
-		<FrontSection
-			title="Dynamic Package"
-			showTopBorder={true}
-			centralBorder="partial"
-		>
+		<FrontSection title="Dynamic Package" showTopBorder={true}>
 			<DynamicPackage
 				groupedTrails={{
 					...defaultGroupedTrails,
@@ -333,7 +292,7 @@ export const Boosted9 = () => {
 Boosted9.storyName = 'With nine standard cards - boosted';
 
 export const OneSnapThreeStandard = () => (
-	<FrontSection title="Dynamic Package" centralBorder="partial">
+	<FrontSection title="Dynamic Package">
 		<DynamicPackage
 			groupedTrails={{
 				...defaultGroupedTrails,
@@ -347,7 +306,7 @@ export const OneSnapThreeStandard = () => (
 OneSnapThreeStandard.storyName = 'With one snap - three standard cards';
 
 export const ThreeSnapTwoStandard = () => (
-	<FrontSection title="Dynamic Package" centralBorder="partial">
+	<FrontSection title="Dynamic Package">
 		<DynamicPackage
 			groupedTrails={{
 				...defaultGroupedTrails,
@@ -361,7 +320,7 @@ export const ThreeSnapTwoStandard = () => (
 ThreeSnapTwoStandard.storyName = 'With three snaps - two standard cards';
 
 export const ThreeSnapTwoStandard2ndBoosted = () => (
-	<FrontSection title="Dynamic Package" centralBorder="partial">
+	<FrontSection title="Dynamic Package">
 		<DynamicPackage
 			groupedTrails={{
 				...defaultGroupedTrails,

--- a/dotcom-rendering/src/web/components/DynamicSlow.stories.tsx
+++ b/dotcom-rendering/src/web/components/DynamicSlow.stories.tsx
@@ -43,7 +43,7 @@ export const Avatar = () => {
 		};
 	});
 	return (
-		<FrontSection title="Dynamic Slow" centralBorder="partial">
+		<FrontSection title="Dynamic Slow">
 			<DynamicSlow
 				groupedTrails={{
 					...defaultGroupedTrails,
@@ -66,7 +66,6 @@ Avatar.storyName = 'With avatars';
 export const OneHugeTwoBigsFourStandards = () => (
 	<FrontSection
 		title="Dynamic Slow"
-		centralBorder="partial"
 		description={`first slice: oneHuge</br>second slice: twoBigs`}
 	>
 		<DynamicSlow
@@ -85,7 +84,6 @@ OneHugeTwoBigsFourStandards.storyName = 'With 1 huge card, 2 bigs, 4 standards';
 export const OneVeryBigTwoBigsFourStandards = () => (
 	<FrontSection
 		title="Dynamic Slow"
-		centralBorder="partial"
 		description={`first slice: oneVeryBig</br>second slice: twoBigs`}
 	>
 		<DynamicSlow
@@ -105,7 +103,6 @@ OneVeryBigTwoBigsFourStandards.storyName =
 export const TwoVeryBigsTwoBigsFourStandards = () => (
 	<FrontSection
 		title="Dynamic Slow"
-		centralBorder="partial"
 		description={`first slice: twoVeryBigs</br>second slice: twoBigs`}
 	>
 		<DynamicSlow
@@ -125,7 +122,6 @@ TwoVeryBigsTwoBigsFourStandards.storyName =
 export const TwoVeryBigs1stBoostedTwoBigsFourStandards = () => (
 	<FrontSection
 		title="Dynamic Slow"
-		centralBorder="partial"
 		description={`first slice: twoVeryBigsFirstBoosted</br>second slice: twoBigs`}
 	>
 		<DynamicSlow
@@ -145,7 +141,6 @@ TwoVeryBigs1stBoostedTwoBigsFourStandards.storyName =
 export const TwoVeryBigs2ndBoostedTwoBigsFourStandards = () => (
 	<FrontSection
 		title="Dynamic Slow"
-		centralBorder="partial"
 		description={`first slice: twoVeryBigsSecondBoosted</br>second slice: twoBigs`}
 	>
 		<DynamicSlow
@@ -166,7 +161,6 @@ TwoVeryBigs2ndBoostedTwoBigsFourStandards.storyName =
 export const TwoVeryBigs8Standards = () => (
 	<FrontSection
 		title="Dynamic Slow"
-		centralBorder="partial"
 		description={`first slice: twoVeryBigs</br>second slice: noBigs`}
 	>
 		<DynamicSlow
@@ -184,7 +178,6 @@ TwoVeryBigs8Standards.storyName = 'with 2 very bigs, 8 standards';
 export const TwoVeryBigsOneBig4Standards = () => (
 	<FrontSection
 		title="Dynamic Slow"
-		centralBorder="partial"
 		description={`first slice: twoVeryBigs</br>second slice: oneBig`}
 	>
 		<DynamicSlow
@@ -204,7 +197,6 @@ TwoVeryBigsOneBig4Standards.storyName = 'with 2 very bigs, 1 big, 8 standards';
 export const TwoVeryBigsTwoBigs4Standards = () => (
 	<FrontSection
 		title="Dynamic Slow"
-		centralBorder="partial"
 		description={`first slice: twoVeryBigs</br>second slice: twoBigs`}
 	>
 		<DynamicSlow
@@ -227,7 +219,6 @@ TwoVeryBigsTwoBigs4Standards.storyName =
 export const TwoVeryBigsFiveStandards = () => (
 	<FrontSection
 		title="Dynamic Slow"
-		centralBorder="partial"
 		description={`first slice: twoVeryBigs</br>second slice: noBigs`}
 	>
 		<DynamicSlow
@@ -246,7 +237,6 @@ TwoVeryBigsFiveStandards.storyName = 'with 2 very bigs, 5 standards';
 export const ThreeVeryBigsFiveStandards = () => (
 	<FrontSection
 		title="Dynamic Slow"
-		centralBorder="partial"
 		description={`first slice: twoVeryBigs</br>second slice: oneBig`}
 	>
 		<DynamicSlow
@@ -265,7 +255,6 @@ ThreeVeryBigsFiveStandards.storyName = 'with 3 very bigs, 5 standards';
 export const TwoVeryBigsOneBig = () => (
 	<FrontSection
 		title="Dynamic Slow"
-		centralBorder="partial"
 		description={`first slice: twoVeryBigs</br>second slice: oneBig`}
 	>
 		<DynamicSlow
@@ -284,7 +273,6 @@ TwoVeryBigsOneBig.storyName = 'with 2 very bigs, 1 big';
 export const TwoBigsThreeStandards = () => (
 	<FrontSection
 		title="Dynamic Slow"
-		centralBorder="partial"
 		description={`first slice: undefined</br>second slice: twoBigs`}
 	>
 		<DynamicSlow
@@ -303,7 +291,6 @@ TwoBigsThreeStandards.storyName = 'with 2 bigs, 3 standards';
 export const OneVeryBigTwoBigsOneStandard = () => (
 	<FrontSection
 		title="Dynamic Slow"
-		centralBorder="partial"
 		description={`first slice: twoVeryBigs</br>second slice: twoBigs`}
 	>
 		<DynamicSlow

--- a/dotcom-rendering/src/web/components/DynamicSlowMPU.stories.tsx
+++ b/dotcom-rendering/src/web/components/DynamicSlowMPU.stories.tsx
@@ -21,7 +21,7 @@ const bigs = trails.slice(0, 3);
 const standards = trails.slice(3);
 
 export const NoBigs = () => (
-	<FrontSection title="Dynamic Slow MPU" centralBorder="partial">
+	<FrontSection title="Dynamic Slow MPU">
 		<DynamicSlowMPU
 			groupedTrails={{
 				snap: [],
@@ -40,7 +40,7 @@ export const NoBigs = () => (
 NoBigs.storyName = 'with no big cards, only standard';
 
 export const OneBig = () => (
-	<FrontSection title="Dynamic Slow MPU" centralBorder="partial">
+	<FrontSection title="Dynamic Slow MPU">
 		<DynamicSlowMPU
 			groupedTrails={{
 				snap: [],
@@ -59,7 +59,7 @@ export const OneBig = () => (
 OneBig.storyName = 'with just one big';
 
 export const TwoBigs = () => (
-	<FrontSection title="Dynamic Slow MPU" centralBorder="partial">
+	<FrontSection title="Dynamic Slow MPU">
 		<DynamicSlowMPU
 			groupedTrails={{
 				snap: [],
@@ -78,7 +78,7 @@ export const TwoBigs = () => (
 TwoBigs.storyName = 'with two bigs';
 
 export const FirstBigBoosted = () => (
-	<FrontSection title="Dynamic Slow MPU" centralBorder="partial">
+	<FrontSection title="Dynamic Slow MPU">
 		<DynamicSlowMPU
 			groupedTrails={{
 				snap: [],
@@ -101,7 +101,7 @@ export const FirstBigBoosted = () => (
 FirstBigBoosted.storyName = 'with the first of two bigs boosted';
 
 export const SecondBigBoosted = () => (
-	<FrontSection title="Dynamic Slow MPU" centralBorder="partial">
+	<FrontSection title="Dynamic Slow MPU">
 		<DynamicSlowMPU
 			groupedTrails={{
 				snap: [],
@@ -124,7 +124,7 @@ export const SecondBigBoosted = () => (
 SecondBigBoosted.storyName = 'with the second of two bigs boosted';
 
 export const ThreeBigs = () => (
-	<FrontSection title="Dynamic Slow MPU" centralBorder="partial">
+	<FrontSection title="Dynamic Slow MPU">
 		<DynamicSlowMPU
 			groupedTrails={{
 				snap: [],
@@ -143,7 +143,7 @@ export const ThreeBigs = () => (
 ThreeBigs.storyName = 'with three bigs';
 
 export const AllBigs = () => (
-	<FrontSection title="Dynamic Slow MPU" centralBorder="partial">
+	<FrontSection title="Dynamic Slow MPU">
 		<DynamicSlowMPU
 			groupedTrails={{
 				snap: [],
@@ -162,7 +162,7 @@ export const AllBigs = () => (
 AllBigs.storyName = 'with lots of bigs and no standards';
 
 export const AdfreeDynamicSlowMPU = () => (
-	<FrontSection title="DynamicSlowMPU" centralBorder="partial">
+	<FrontSection title="DynamicSlowMPU">
 		<DynamicSlowMPU
 			groupedTrails={{
 				snap: [],

--- a/dotcom-rendering/src/web/components/FixedLargeSlowXIV.stories.tsx
+++ b/dotcom-rendering/src/web/components/FixedLargeSlowXIV.stories.tsx
@@ -18,7 +18,7 @@ export default {
 };
 
 export const Default = () => (
-	<FrontSection title="Fixed Large Slow XIV" centralBorder="partial">
+	<FrontSection title="Fixed Large Slow XIV">
 		<FixedLargeSlowXIV trails={trails} showAge={true} />
 	</FrontSection>
 );

--- a/dotcom-rendering/src/web/components/FixedMediumFastXI.stories.tsx
+++ b/dotcom-rendering/src/web/components/FixedMediumFastXI.stories.tsx
@@ -18,77 +18,77 @@ export default {
 };
 
 export const OneTrail = () => (
-	<FrontSection title="Fixed Medium Fast XI" centralBorder="partial">
+	<FrontSection title="Fixed Medium Fast XI">
 		<FixedMediumFastXI trails={trails.slice(0, 1)} />
 	</FrontSection>
 );
 OneTrail.storyName = 'with one trail';
 
 export const TwoTrails = () => (
-	<FrontSection title="Fixed Medium Fast XI" centralBorder="partial">
+	<FrontSection title="Fixed Medium Fast XI">
 		<FixedMediumFastXI trails={trails.slice(0, 2)} />
 	</FrontSection>
 );
 TwoTrails.storyName = 'with two trails';
 
 export const ThreeTrails = () => (
-	<FrontSection title="Fixed Medium Fast XI" centralBorder="partial">
+	<FrontSection title="Fixed Medium Fast XI">
 		<FixedMediumFastXI trails={trails.slice(0, 3)} />
 	</FrontSection>
 );
 ThreeTrails.storyName = 'with three trails';
 
 export const FourTrails = () => (
-	<FrontSection title="Fixed Medium Fast XI" centralBorder="partial">
+	<FrontSection title="Fixed Medium Fast XI">
 		<FixedMediumFastXI trails={trails.slice(0, 4)} />
 	</FrontSection>
 );
 FourTrails.storyName = 'with four trails';
 
 export const FiveTrails = () => (
-	<FrontSection title="Fixed Medium Fast XI" centralBorder="partial">
+	<FrontSection title="Fixed Medium Fast XI">
 		<FixedMediumFastXI trails={trails.slice(0, 5)} />
 	</FrontSection>
 );
 FiveTrails.storyName = 'with five trails';
 
 export const SixTrails = () => (
-	<FrontSection title="Fixed Medium Fast XI" centralBorder="partial">
+	<FrontSection title="Fixed Medium Fast XI">
 		<FixedMediumFastXI trails={trails.slice(0, 6)} />
 	</FrontSection>
 );
 SixTrails.storyName = 'with six trails';
 
 export const SevenTrails = () => (
-	<FrontSection title="Fixed Medium Fast XI" centralBorder="partial">
+	<FrontSection title="Fixed Medium Fast XI">
 		<FixedMediumFastXI trails={trails.slice(0, 7)} />
 	</FrontSection>
 );
 SevenTrails.storyName = 'with seven trails';
 
 export const EightTrails = () => (
-	<FrontSection title="Fixed Medium Fast XI" centralBorder="partial">
+	<FrontSection title="Fixed Medium Fast XI">
 		<FixedMediumFastXI trails={trails.slice(0, 8)} />
 	</FrontSection>
 );
 EightTrails.storyName = 'with eight trails';
 
 export const NineTrails = () => (
-	<FrontSection title="Fixed Medium Fast XI" centralBorder="partial">
+	<FrontSection title="Fixed Medium Fast XI">
 		<FixedMediumFastXI trails={trails.slice(0, 9)} />
 	</FrontSection>
 );
 NineTrails.storyName = 'with nine trails';
 
 export const TenTrails = () => (
-	<FrontSection title="Fixed Medium Fast XI" centralBorder="partial">
+	<FrontSection title="Fixed Medium Fast XI">
 		<FixedMediumFastXI trails={trails.slice(0, 10)} />
 	</FrontSection>
 );
 TenTrails.storyName = 'with ten trails';
 
 export const ElevenTrails = () => (
-	<FrontSection title="Fixed Medium Fast XI" centralBorder="partial">
+	<FrontSection title="Fixed Medium Fast XI">
 		<FixedMediumFastXI trails={trails.slice(0, 11)} />
 	</FrontSection>
 );

--- a/dotcom-rendering/src/web/components/FixedMediumFastXII.stories.tsx
+++ b/dotcom-rendering/src/web/components/FixedMediumFastXII.stories.tsx
@@ -18,7 +18,7 @@ export default {
 };
 
 export const Default = () => (
-	<FrontSection title="Fixed Medium Fast XII" centralBorder="partial">
+	<FrontSection title="Fixed Medium Fast XII">
 		<FixedMediumFastXII trails={trails} showAge={true} />
 	</FrontSection>
 );

--- a/dotcom-rendering/src/web/components/FixedMediumSlowVI.stories.tsx
+++ b/dotcom-rendering/src/web/components/FixedMediumSlowVI.stories.tsx
@@ -18,7 +18,7 @@ export default {
 };
 
 export const Default = () => (
-	<FrontSection title="Fixed Medium Slow VI" centralBorder="partial">
+	<FrontSection title="Fixed Medium Slow VI">
 		<FixedMediumSlowVI trails={trails} showAge={true} />
 	</FrontSection>
 );

--- a/dotcom-rendering/src/web/components/FixedMediumSlowVII.stories.tsx
+++ b/dotcom-rendering/src/web/components/FixedMediumSlowVII.stories.tsx
@@ -18,12 +18,7 @@ export default {
 };
 
 export const Default = () => (
-	<FrontSection
-		title="Fixed Medium Slow VII"
-		showTopBorder={true}
-		showSideBorders={true}
-		centralBorder="partial"
-	>
+	<FrontSection title="Fixed Medium Slow VII" showTopBorder={true}>
 		<FixedMediumSlowVII trails={trails} showAge={true} />
 	</FrontSection>
 );

--- a/dotcom-rendering/src/web/components/FixedMediumSlowXIIMPU.stories.tsx
+++ b/dotcom-rendering/src/web/components/FixedMediumSlowXIIMPU.stories.tsx
@@ -18,7 +18,7 @@ export default {
 };
 
 export const OneTrail = () => (
-	<FrontSection title="Fixed Medium Slow XII MPU" centralBorder="partial">
+	<FrontSection title="Fixed Medium Slow XII MPU">
 		<FixedMediumSlowXIIMPU
 			trails={trails.slice(0, 1)}
 			showAge={true}
@@ -30,7 +30,7 @@ export const OneTrail = () => (
 OneTrail.storyName = 'with one trail';
 
 export const TwoTrails = () => (
-	<FrontSection title="Fixed Medium Slow XII MPU" centralBorder="partial">
+	<FrontSection title="Fixed Medium Slow XII MPU">
 		<FixedMediumSlowXIIMPU
 			trails={trails.slice(0, 2)}
 			showAge={true}
@@ -42,7 +42,7 @@ export const TwoTrails = () => (
 TwoTrails.storyName = 'with two trails';
 
 export const ThreeTrails = () => (
-	<FrontSection title="Fixed Medium Slow XII MPU" centralBorder="partial">
+	<FrontSection title="Fixed Medium Slow XII MPU">
 		<FixedMediumSlowXIIMPU
 			trails={trails.slice(0, 3)}
 			showAge={true}
@@ -54,7 +54,7 @@ export const ThreeTrails = () => (
 ThreeTrails.storyName = 'with three trails';
 
 export const FourTrails = () => (
-	<FrontSection title="Fixed Medium Slow XII MPU" centralBorder="partial">
+	<FrontSection title="Fixed Medium Slow XII MPU">
 		<FixedMediumSlowXIIMPU
 			trails={trails.slice(0, 4)}
 			showAge={true}
@@ -66,7 +66,7 @@ export const FourTrails = () => (
 FourTrails.storyName = 'with four trails';
 
 export const FiveTrails = () => (
-	<FrontSection title="Fixed Medium Slow XII MPU" centralBorder="partial">
+	<FrontSection title="Fixed Medium Slow XII MPU">
 		<FixedMediumSlowXIIMPU
 			trails={trails.slice(0, 5)}
 			showAge={true}
@@ -78,7 +78,7 @@ export const FiveTrails = () => (
 FiveTrails.storyName = 'with five trails';
 
 export const SixTrails = () => (
-	<FrontSection title="Fixed Medium Slow XII MPU" centralBorder="partial">
+	<FrontSection title="Fixed Medium Slow XII MPU">
 		<FixedMediumSlowXIIMPU
 			trails={trails.slice(0, 6)}
 			showAge={true}
@@ -90,7 +90,7 @@ export const SixTrails = () => (
 SixTrails.storyName = 'with six trails';
 
 export const SevenTrails = () => (
-	<FrontSection title="Fixed Medium Slow XII MPU" centralBorder="partial">
+	<FrontSection title="Fixed Medium Slow XII MPU">
 		<FixedMediumSlowXIIMPU
 			trails={trails.slice(0, 7)}
 			showAge={true}
@@ -102,7 +102,7 @@ export const SevenTrails = () => (
 SevenTrails.storyName = 'with seven trails';
 
 export const EightTrails = () => (
-	<FrontSection title="Fixed Medium Slow XII MPU" centralBorder="partial">
+	<FrontSection title="Fixed Medium Slow XII MPU">
 		<FixedMediumSlowXIIMPU
 			trails={trails.slice(0, 8)}
 			showAge={true}
@@ -114,7 +114,7 @@ export const EightTrails = () => (
 EightTrails.storyName = 'with eight trails';
 
 export const NineTrails = () => (
-	<FrontSection title="Fixed Medium Slow XII MPU" centralBorder="partial">
+	<FrontSection title="Fixed Medium Slow XII MPU">
 		<FixedMediumSlowXIIMPU
 			trails={trails.slice(0, 9)}
 			showAge={true}
@@ -126,7 +126,7 @@ export const NineTrails = () => (
 NineTrails.storyName = 'with nine trails';
 
 export const EightTrailsNoAds = () => (
-	<FrontSection title="Fixed Medium Slow XII MPU" centralBorder="partial">
+	<FrontSection title="Fixed Medium Slow XII MPU">
 		<FixedMediumSlowXIIMPU
 			trails={trails.slice(0, 8)}
 			showAge={true}

--- a/dotcom-rendering/src/web/components/FixedSmallFastVIII.stories.tsx
+++ b/dotcom-rendering/src/web/components/FixedSmallFastVIII.stories.tsx
@@ -18,12 +18,7 @@ export default {
 };
 
 export const Default = () => (
-	<FrontSection
-		title="Fixed Small Fast VIII"
-		showTopBorder={true}
-		showSideBorders={true}
-		centralBorder="partial"
-	>
+	<FrontSection title="Fixed Small Fast VIII" showTopBorder={true}>
 		<FixedSmallFastVIII trails={trails} showAge={true} />
 	</FrontSection>
 );

--- a/dotcom-rendering/src/web/components/FixedSmallSlowI.stories.tsx
+++ b/dotcom-rendering/src/web/components/FixedSmallSlowI.stories.tsx
@@ -18,7 +18,7 @@ export default {
 };
 
 export const Default = () => (
-	<FrontSection title="Fixed Small Slow I" centralBorder="partial">
+	<FrontSection title="Fixed Small Slow I">
 		<FixedSmallSlowI trails={trails} showAge={true} />
 	</FrontSection>
 );

--- a/dotcom-rendering/src/web/components/FixedSmallSlowIII.stories.tsx
+++ b/dotcom-rendering/src/web/components/FixedSmallSlowIII.stories.tsx
@@ -18,7 +18,7 @@ export default {
 };
 
 export const Default = () => (
-	<FrontSection title="Fixed Small Slow III" centralBorder="partial">
+	<FrontSection title="Fixed Small Slow III">
 		<FixedSmallSlowIII trails={trails} showAge={true} />
 	</FrontSection>
 );

--- a/dotcom-rendering/src/web/components/FixedSmallSlowIV.stories.tsx
+++ b/dotcom-rendering/src/web/components/FixedSmallSlowIV.stories.tsx
@@ -18,7 +18,7 @@ export default {
 };
 
 export const Default = () => (
-	<FrontSection title="Fixed Small Slow IV" centralBorder="partial">
+	<FrontSection title="Fixed Small Slow IV">
 		<FixedSmallSlowIV trails={trails} showAge={true} />
 	</FrontSection>
 );

--- a/dotcom-rendering/src/web/components/FixedSmallSlowVMPU.stories.tsx
+++ b/dotcom-rendering/src/web/components/FixedSmallSlowVMPU.stories.tsx
@@ -18,7 +18,7 @@ export default {
 };
 
 export const FourCards = () => (
-	<FrontSection title="Fixed Small Slow V MPU" centralBorder="partial">
+	<FrontSection title="Fixed Small Slow V MPU">
 		<FixedSmallSlowVMPU
 			trails={trails.slice(0, 4)}
 			showAge={true}
@@ -31,7 +31,7 @@ export const FourCards = () => (
 FourCards.storyName = 'With 4 cards';
 
 export const ThreeCards = () => (
-	<FrontSection title="Fixed Small Slow V MPU" centralBorder="partial">
+	<FrontSection title="Fixed Small Slow V MPU">
 		<FixedSmallSlowVMPU
 			trails={trails.slice(0, 3)}
 			showAge={true}
@@ -44,7 +44,7 @@ export const ThreeCards = () => (
 ThreeCards.storyName = 'With 3 cards';
 
 export const TwoCards = () => (
-	<FrontSection title="Fixed Small Slow V MPU" centralBorder="partial">
+	<FrontSection title="Fixed Small Slow V MPU">
 		<FixedSmallSlowVMPU
 			trails={trails.slice(0, 2)}
 			showAge={true}
@@ -57,7 +57,7 @@ export const TwoCards = () => (
 TwoCards.storyName = 'With 2 cards';
 
 export const OneCard = () => (
-	<FrontSection title="Fixed Small Slow V MPU" centralBorder="partial">
+	<FrontSection title="Fixed Small Slow V MPU">
 		<FixedSmallSlowVMPU
 			trails={trails.slice(0, 1)}
 			showAge={true}
@@ -70,7 +70,7 @@ export const OneCard = () => (
 OneCard.storyName = 'With 1 card';
 
 export const AdfreeFixedSmallSlowVMPU = () => (
-	<FrontSection title="Fixed Small Slow V MPU" centralBorder="partial">
+	<FrontSection title="Fixed Small Slow V MPU">
 		<FixedSmallSlowVMPU
 			trails={trails.slice(0, 4)}
 			showAge={true}

--- a/dotcom-rendering/src/web/components/FixedSmallSlowVThird.stories.tsx
+++ b/dotcom-rendering/src/web/components/FixedSmallSlowVThird.stories.tsx
@@ -18,7 +18,7 @@ export default {
 };
 
 export const Default = () => (
-	<FrontSection title="Fixed Small Slow V Third" centralBorder="partial">
+	<FrontSection title="Fixed Small Slow V Third">
 		<FixedSmallSlowVThird trails={trails} showAge={true} />
 	</FrontSection>
 );

--- a/dotcom-rendering/src/web/components/FrontSection.stories.tsx
+++ b/dotcom-rendering/src/web/components/FrontSection.stories.tsx
@@ -1,10 +1,5 @@
 import { css } from '@emotion/react';
-import {
-	brand,
-	brandAlt,
-	breakpoints,
-	neutral,
-} from '@guardian/source-foundations';
+import { breakpoints } from '@guardian/source-foundations';
 import { LI } from './Card/components/LI';
 import { FrontSection } from './FrontSection';
 
@@ -78,11 +73,7 @@ const LeftColPlaceholder = ({
 
 export const ContainerStory = () => {
 	return (
-		<FrontSection
-			title="Default Container"
-			showTopBorder={false}
-			showSideBorders={false}
-		>
+		<FrontSection title="Default Container" showTopBorder={false}>
 			<Placeholder />
 		</FrontSection>
 	);
@@ -91,27 +82,26 @@ ContainerStory.storyName = 'default container';
 
 export const NoTitleStory = () => {
 	return (
-		<FrontSection showTopBorder={false} showSideBorders={false}>
+		<FrontSection showTopBorder={false}>
 			<Placeholder />
 		</FrontSection>
 	);
 };
 NoTitleStory.storyName = 'with no title';
 
-export const BordersStory = () => {
+export const TopBorderStory = () => {
 	return (
-		<FrontSection title="Borders" centralBorder="full">
+		<FrontSection title="Borders">
 			<Placeholder />
 		</FrontSection>
 	);
 };
-BordersStory.storyName = 'with all borders';
+TopBorderStory.storyName = 'with all borders';
 
 export const LeftContentStory = () => {
 	return (
 		<FrontSection
-			title="Borders"
-			centralBorder="full"
+			title="LeftContent"
 			leftContent={
 				<LeftColPlaceholder text="LeftCol" heightInPixels={200} />
 			}
@@ -122,96 +112,6 @@ export const LeftContentStory = () => {
 };
 LeftContentStory.storyName = 'with an element passed into the left column';
 
-export const BackgroundStory = () => {
-	return (
-		<FrontSection
-			title="Background Colour"
-			description="About this content"
-			fontColour={neutral[100]}
-			centralBorder="full"
-			backgroundColour={brand[400]}
-			borderColour={brand[600]}
-		>
-			<Placeholder />
-		</FrontSection>
-	);
-};
-BackgroundStory.storyName = 'with a blue background';
-
-export const InnerBackgroundStory = () => {
-	return (
-		<FrontSection
-			title="Inner Background"
-			description="About this content"
-			fontColour={neutral[100]}
-			centralBorder="full"
-			innerBackgroundColour={brand[400]}
-			borderColour={brand[300]}
-		>
-			<Placeholder />
-		</FrontSection>
-	);
-};
-InnerBackgroundStory.storyName = 'with a blue inner background';
-
-export const DifferentBackgrounds = () => {
-	return (
-		<FrontSection
-			title="Tip us off"
-			centralBorder="full"
-			backgroundColour="#FFF280"
-			borderColour={brand[300]}
-			innerBackgroundColour="#FFE501"
-		>
-			<h1>
-				👀 Share stories with the Guardian securely and confidentially
-			</h1>
-		</FrontSection>
-	);
-};
-DifferentBackgrounds.storyName =
-	'with inner background different to main background';
-
-export const StretchRightStory = () => {
-	return (
-		<FrontSection
-			title="Stretched Right"
-			description="About this content"
-			centralBorder="full"
-			stretchRight={true}
-		>
-			<Placeholder />
-		</FrontSection>
-	);
-};
-StretchRightStory.storyName = 'with content stretched to the right (no margin)';
-
-export const PartialStory = () => {
-	return (
-		<FrontSection
-			title="Borders"
-			showTopBorder={false}
-			centralBorder="partial"
-		>
-			<Placeholder />
-		</FrontSection>
-	);
-};
-PartialStory.storyName = 'with a partial border divider';
-
-export const SidesStory = () => {
-	return (
-		<FrontSection
-			title="NoSides"
-			showTopBorder={false}
-			centralBorder="full"
-		>
-			<Placeholder />
-		</FrontSection>
-	);
-};
-SidesStory.storyName = 'with a full border divider';
-
 export const ToggleableStory = () => {
 	return (
 		<FrontSection
@@ -219,7 +119,6 @@ export const ToggleableStory = () => {
 			toggleable={true}
 			sectionId="section-id"
 			showTopBorder={false}
-			showSideBorders={false}
 		>
 			<Placeholder />
 		</FrontSection>
@@ -227,70 +126,29 @@ export const ToggleableStory = () => {
 };
 ToggleableStory.storyName = 'toggleable container';
 
-export const MarginsStory = () => {
-	return (
-		<>
-			<FrontSection
-				title="No Vertical Margins"
-				centralBorder="full"
-				verticalMargins={false}
-			>
-				<Placeholder />
-			</FrontSection>
-			<FrontSection
-				title="No Vertical Margins"
-				centralBorder="full"
-				verticalMargins={false}
-			>
-				<Placeholder />
-			</FrontSection>
-			<FrontSection
-				title="No Vertical Margins"
-				centralBorder="full"
-				verticalMargins={false}
-			>
-				<Placeholder />
-			</FrontSection>
-		</>
-	);
-};
-MarginsStory.storyName = 'with no vertical margins';
-
 export const MultipleStory = () => {
 	return (
 		<>
 			<FrontSection title="Page Title" showTopBorder={false} />
-			<FrontSection title="Headlines" centralBorder="partial">
+			<FrontSection title="Headlines">
 				<Placeholder />
 			</FrontSection>
-			<FrontSection title="Useful links" centralBorder="partial" />
+			<FrontSection title="Useful links" />
 			<FrontSection
 				title="Around the World - I'm a link"
 				url="https://www.theguardian.com/world"
-				centralBorder="partial"
 			>
 				<Placeholder />
 			</FrontSection>
-			<FrontSection
-				showTopBorder={false}
-				showSideBorders={false}
-				backgroundColour={brandAlt[400]}
-			>
+			<FrontSection showTopBorder={false}>
 				<h2>Insert call to action here</h2>
 			</FrontSection>
-			<FrontSection
-				title="Videos"
-				fontColour="white"
-				showTopBorder={false}
-				backgroundColour="black"
-				showSideBorders={false}
-			>
+			<FrontSection title="Videos" showTopBorder={false}>
 				<Placeholder />
 			</FrontSection>
 			<FrontSection
 				title="Coronavirus"
 				description="A collection of stories about Coronavirus"
-				centralBorder="partial"
 			>
 				<Placeholder />
 			</FrontSection>
@@ -335,7 +193,6 @@ export const TreatsStory = () => {
 				},
 			]}
 			showTopBorder={false}
-			showSideBorders={false}
 			showDateHeader={true}
 			editionId="UK"
 		>

--- a/dotcom-rendering/src/web/components/FrontSection.tsx
+++ b/dotcom-rendering/src/web/components/FrontSection.tsx
@@ -23,13 +23,10 @@ type Props = {
 	sectionId?: string;
 	/** Defaults to `true`. If we should render the left and right borders */
 	showSideBorders?: boolean;
-	centralBorder?: 'partial' | 'full';
 	/** Defaults to `true`. If we should render the top border */
 	showTopBorder?: boolean;
 	/** Defaults to `true`. Adds margins to the top and bottom */
 	verticalMargins?: boolean;
-	/** The colour of borders can be overriden */
-	borderColour?: string;
 	/** A React component can be passed to be inserted inside the left column */
 	leftContent?: React.ReactNode;
 	children?: React.ReactNode;
@@ -428,8 +425,6 @@ const titleStyle = css`
 export const FrontSection = ({
 	title,
 	children,
-	borderColour,
-	centralBorder,
 	containerName,
 	containerPalette,
 	description,
@@ -462,7 +457,6 @@ export const FrontSection = ({
 	const childrenContainerStyles = [
 		sectionContent,
 		sectionContentPadded,
-		centralBorder === 'full' && sectionContentBorder,
 		verticalMargins && paddings,
 	];
 
@@ -500,12 +494,7 @@ export const FrontSection = ({
 					]}
 				/>
 			)}
-			<div
-				css={[
-					headlineContainerStyles,
-					centralBorder === 'partial' && headlineContainerBorders,
-				]}
-			>
+			<div css={[headlineContainerStyles, headlineContainerBorders]}>
 				<Hide until="leftCol">{badge}</Hide>
 				<div css={titleStyle}>
 					<Hide from="leftCol">{badge}</Hide>
@@ -546,9 +535,7 @@ export const FrontSection = ({
 				<div css={[sectionTreats, verticalMargins && paddings]}>
 					<Treats
 						treats={treats}
-						borderColour={
-							borderColour ?? overrides?.border.container
-						}
+						borderColour={overrides?.border.container}
 					/>
 				</div>
 			)}

--- a/dotcom-rendering/src/web/components/FrontSection.tsx
+++ b/dotcom-rendering/src/web/components/FrontSection.tsx
@@ -26,16 +26,6 @@ type Props = {
 	centralBorder?: 'partial' | 'full';
 	/** Defaults to `true`. If we should render the top border */
 	showTopBorder?: boolean;
-	/** The html tag used by Section defaults to `section` but can be overridden here */
-	element?:
-		| 'div'
-		| 'article'
-		| 'aside'
-		| 'nav'
-		| 'main'
-		| 'header'
-		| 'section'
-		| 'footer';
 	/** Defaults to `true`. Adds margins to the top and bottom */
 	verticalMargins?: boolean;
 	/** Applies a background colour to the entire width */
@@ -438,7 +428,6 @@ const titleStyle = css`
  *
  */
 export const FrontSection = ({
-	element = 'section',
 	title,
 	children,
 	backgroundColour,
@@ -480,18 +469,17 @@ export const FrontSection = ({
 		verticalMargins && paddings,
 	];
 
-	return jsx(
-		element,
-		{
-			/**
-			 * id is being used to set the containerId in @see {ShowMore.importable.tsx}
-			 * this id pre-existed showMore so is probably also being used for something else.
-			 */
-			id: sectionId,
-			'data-link-name': ophanComponentLink,
-			'data-component': ophanComponentName,
-			'data-container-name': containerName,
-			css: [
+	/**
+	 * id is being used to set the containerId in @see {ShowMore.importable.tsx}
+	 * this id pre-existed showMore so is probably also being used for something else.
+	 */
+	return (
+		<section
+			id={sectionId}
+			data-link-name={ophanComponentLink}
+			data-component={ophanComponentName}
+			data-container-name={containerName}
+			css={[
 				fallbackStyles,
 				containerStyles,
 				leftColSize === 'wide' && wideLeftColumn,
@@ -501,9 +489,8 @@ export const FrontSection = ({
 					background-color: ${backgroundColour ??
 					overrides?.background.container};
 				`,
-			],
-		},
-		<>
+			]}
+		>
 			{showDecoration && (
 				<div
 					css={[
@@ -569,6 +556,6 @@ export const FrontSection = ({
 					/>
 				</div>
 			)}
-		</>,
+		</section>
 	);
 };

--- a/dotcom-rendering/src/web/components/FrontSection.tsx
+++ b/dotcom-rendering/src/web/components/FrontSection.tsx
@@ -13,8 +13,6 @@ import { Treats } from './Treats';
 type Props = {
 	/** This text will be used as the h2 shown in the left column for the section */
 	title?: string;
-	/** Allows the colour of the title to be changed */
-	fontColour?: string;
 	/** This text shows below the title */
 	description?: string;
 	/** The title can be made into a link using this property */
@@ -429,7 +427,6 @@ export const FrontSection = ({
 	containerPalette,
 	description,
 	editionId,
-	fontColour,
 	innerBackgroundColour,
 	leftColSize = 'compact',
 	leftContent,
@@ -500,7 +497,7 @@ export const FrontSection = ({
 					<Hide from="leftCol">{badge}</Hide>
 					<ContainerTitle
 						title={title}
-						fontColour={fontColour ?? overrides?.text.container}
+						fontColour={overrides?.text.container}
 						description={description}
 						url={url}
 						containerPalette={containerPalette}

--- a/dotcom-rendering/src/web/components/FrontSection.tsx
+++ b/dotcom-rendering/src/web/components/FrontSection.tsx
@@ -30,8 +30,6 @@ type Props = {
 	children?: React.ReactNode;
 	/** Defaults to `false`. If true, `children` is rendered all the way right */
 	stretchRight?: boolean;
-	/** Defaults to `compact`. Some page types have a different left column width */
-	leftColSize?: LeftColSize;
 	/** @deprecated no longer used */
 	format?: ArticleFormat;
 	/** The string used to set the `data-component` Ophan attribute */
@@ -169,20 +167,6 @@ const containerStyles = css`
 	}
 `;
 
-const wideLeftColumn = css`
-	${from.leftCol} {
-		grid-template-columns:
-			[viewport-start] minmax(0, 1fr)
-			[title-start]
-			repeat(3, 60px)
-			[title-end content-start]
-			repeat(10, 60px)
-			[hide-start]
-			60px
-			[hide-end content-end] minmax(0, 1fr) [viewport-end];
-	}
-`;
-
 const sectionContentStretchedRight = css`
 	${from.wide} {
 		grid-template-columns:
@@ -260,23 +244,6 @@ const sectionContent = css`
 	}
 	${from.wide} {
 		grid-row-end: -1;
-	}
-`;
-
-const sectionContentBorder = css`
-	position: relative;
-
-	${from.leftCol} {
-		::before {
-			content: '';
-			display: block;
-			width: 1px;
-			top: 0;
-			bottom: 0;
-			left: -10px;
-			position: absolute;
-			background-color: ${neutral[86]};
-		}
 	}
 `;
 
@@ -425,7 +392,6 @@ export const FrontSection = ({
 	containerPalette,
 	description,
 	editionId,
-	leftColSize = 'compact',
 	leftContent,
 	ophanComponentLink,
 	ophanComponentName,
@@ -466,7 +432,6 @@ export const FrontSection = ({
 			css={[
 				fallbackStyles,
 				containerStyles,
-				leftColSize === 'wide' && wideLeftColumn,
 				isToggleable && containerStylesToggleable,
 				stretchRight && sectionContentStretchedRight,
 				css`

--- a/dotcom-rendering/src/web/components/FrontSection.tsx
+++ b/dotcom-rendering/src/web/components/FrontSection.tsx
@@ -1,6 +1,5 @@
-import { css, jsx } from '@emotion/react';
+import { css } from '@emotion/react';
 import type { EmotionJSX } from '@emotion/react/types/jsx-namespace';
-import type { ArticleFormat } from '@guardian/libs';
 import { from, neutral, space, until } from '@guardian/source-foundations';
 import { Hide } from '@guardian/source-react-components';
 import type { DCRContainerPalette, TreatType } from '../../types/front';
@@ -24,8 +23,6 @@ type Props = {
 	/** A React component can be passed to be inserted inside the left column */
 	leftContent?: React.ReactNode;
 	children?: React.ReactNode;
-	/** @deprecated no longer used */
-	format?: ArticleFormat;
 	/** The string used to set the `data-component` Ophan attribute */
 	ophanComponentName?: string;
 	/** The string used to set the `data-link-name` Ophan attribute */
@@ -158,21 +155,6 @@ const containerStyles = css`
 
 	${from.leftCol} {
 		grid-template-rows: [content-start] repeat(2, auto);
-	}
-`;
-
-const sectionContentStretchedRight = css`
-	${from.wide} {
-		grid-template-columns:
-			[viewport-start] minmax(0, 1fr)
-			[title-start]
-			repeat(3, 60px)
-			[title-end content-start]
-			repeat(12, 60px)
-			[hide-start]
-			60px
-			[hide-end content-end]
-			minmax(0, 1fr) [viewport-end];
 	}
 `;
 

--- a/dotcom-rendering/src/web/components/FrontSection.tsx
+++ b/dotcom-rendering/src/web/components/FrontSection.tsx
@@ -51,8 +51,6 @@ type Props = {
 	 * to be collapsed
 	 */
 	toggleable?: boolean;
-	/** Applies a background colour only to the content inside the left and right borders */
-	innerBackgroundColour?: string;
 	/** Defaults to `false`. If true and `editionId` is also passed, then a date string is
 	 * shown under the title. Typically only used on Headlines containers on fronts
 	 */
@@ -427,7 +425,6 @@ export const FrontSection = ({
 	containerPalette,
 	description,
 	editionId,
-	innerBackgroundColour,
 	leftColSize = 'compact',
 	leftContent,
 	ophanComponentLink,
@@ -448,8 +445,7 @@ export const FrontSection = ({
 
 	const isToggleable = toggleable && !!sectionId;
 
-	const showDecoration =
-		showTopBorder || showSideBorders || !!innerBackgroundColour;
+	const showDecoration = showTopBorder || showSideBorders;
 
 	const childrenContainerStyles = [
 		sectionContent,
@@ -484,10 +480,6 @@ export const FrontSection = ({
 						decoration,
 						showSideBorders && sideBorders,
 						showTopBorder && topBorder,
-						innerBackgroundColour &&
-							css`
-								background-color: ${innerBackgroundColour};
-							`,
 					]}
 				/>
 			)}

--- a/dotcom-rendering/src/web/components/FrontSection.tsx
+++ b/dotcom-rendering/src/web/components/FrontSection.tsx
@@ -26,8 +26,6 @@ type Props = {
 	/** A React component can be passed to be inserted inside the left column */
 	leftContent?: React.ReactNode;
 	children?: React.ReactNode;
-	/** Defaults to `false`. If true, `children` is rendered all the way right */
-	stretchRight?: boolean;
 	/** @deprecated no longer used */
 	format?: ArticleFormat;
 	/** The string used to set the `data-component` Ophan attribute */
@@ -370,18 +368,6 @@ const titleStyle = css`
  * │Treat│▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒  │
  * └─────┴─────────────────────────┘
  *
- * on `wide` (1300) with `stretchRight`
- *
- *  1 2 3 4 5 6 7 8 9 a b c d e f g (16)
- * ┌─────┬─────────────────────────┐
- * │Title│▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒│
- * │Date │▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒│
- * ├─────┤▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒│
- * │     │▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒│
- * │     │▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒│
- * │Treat│▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒│
- * └─────┴─────────────────────────┘
- *
  */
 export const FrontSection = ({
 	title,
@@ -396,7 +382,6 @@ export const FrontSection = ({
 	sectionId,
 	showDateHeader = false,
 	showTopBorder = true,
-	stretchRight = false,
 	toggleable = false,
 	treats,
 	url,
@@ -428,7 +413,6 @@ export const FrontSection = ({
 				fallbackStyles,
 				containerStyles,
 				isToggleable && containerStylesToggleable,
-				stretchRight && sectionContentStretchedRight,
 				css`
 					background-color: ${overrides?.background.container};
 				`,

--- a/dotcom-rendering/src/web/components/FrontSection.tsx
+++ b/dotcom-rendering/src/web/components/FrontSection.tsx
@@ -19,8 +19,6 @@ type Props = {
 	url?: string;
 	/** The html `id` property of the element */
 	sectionId?: string;
-	/** Defaults to `true`. If we should render the left and right borders */
-	showSideBorders?: boolean;
 	/** Defaults to `true`. If we should render the top border */
 	showTopBorder?: boolean;
 	/** Defaults to `true`. Adds margins to the top and bottom */
@@ -397,7 +395,6 @@ export const FrontSection = ({
 	ophanComponentName,
 	sectionId,
 	showDateHeader = false,
-	showSideBorders = true,
 	showTopBorder = true,
 	stretchRight = false,
 	toggleable = false,
@@ -410,8 +407,6 @@ export const FrontSection = ({
 		containerPalette && decideContainerOverrides(containerPalette);
 
 	const isToggleable = toggleable && !!sectionId;
-
-	const showDecoration = showTopBorder || showSideBorders;
 
 	const childrenContainerStyles = [
 		sectionContent,
@@ -439,15 +434,8 @@ export const FrontSection = ({
 				`,
 			]}
 		>
-			{showDecoration && (
-				<div
-					css={[
-						decoration,
-						showSideBorders && sideBorders,
-						showTopBorder && topBorder,
-					]}
-				/>
-			)}
+			<div css={[decoration, sideBorders, showTopBorder && topBorder]} />
+
 			<div css={[headlineContainerStyles, headlineContainerBorders]}>
 				<Hide until="leftCol">{badge}</Hide>
 				<div css={titleStyle}>
@@ -464,6 +452,7 @@ export const FrontSection = ({
 				</div>
 				{leftContent}
 			</div>
+
 			{isToggleable ? (
 				<>
 					<div css={sectionShowHide}>

--- a/dotcom-rendering/src/web/components/FrontSection.tsx
+++ b/dotcom-rendering/src/web/components/FrontSection.tsx
@@ -21,8 +21,6 @@ type Props = {
 	sectionId?: string;
 	/** Defaults to `true`. If we should render the top border */
 	showTopBorder?: boolean;
-	/** Defaults to `true`. Adds margins to the top and bottom */
-	verticalMargins?: boolean;
 	/** A React component can be passed to be inserted inside the left column */
 	leftContent?: React.ReactNode;
 	children?: React.ReactNode;
@@ -385,7 +383,6 @@ export const FrontSection = ({
 	toggleable = false,
 	treats,
 	url,
-	verticalMargins = true,
 	badge,
 }: Props) => {
 	const overrides =
@@ -396,7 +393,7 @@ export const FrontSection = ({
 	const childrenContainerStyles = [
 		sectionContent,
 		sectionContentPadded,
-		verticalMargins && paddings,
+		paddings,
 	];
 
 	/**
@@ -459,7 +456,7 @@ export const FrontSection = ({
 			)}
 
 			{treats && (
-				<div css={[sectionTreats, verticalMargins && paddings]}>
+				<div css={[sectionTreats, paddings]}>
 					<Treats
 						treats={treats}
 						borderColour={overrides?.border.container}

--- a/dotcom-rendering/src/web/components/FrontSection.tsx
+++ b/dotcom-rendering/src/web/components/FrontSection.tsx
@@ -28,8 +28,6 @@ type Props = {
 	showTopBorder?: boolean;
 	/** Defaults to `true`. Adds margins to the top and bottom */
 	verticalMargins?: boolean;
-	/** Applies a background colour to the entire width */
-	backgroundColour?: string;
 	/** The colour of borders can be overriden */
 	borderColour?: string;
 	/** A React component can be passed to be inserted inside the left column */
@@ -430,7 +428,6 @@ const titleStyle = css`
 export const FrontSection = ({
 	title,
 	children,
-	backgroundColour,
 	borderColour,
 	centralBorder,
 	containerName,
@@ -486,8 +483,7 @@ export const FrontSection = ({
 				isToggleable && containerStylesToggleable,
 				stretchRight && sectionContentStretchedRight,
 				css`
-					background-color: ${backgroundColour ??
-					overrides?.background.container};
+					background-color: ${overrides?.background.container};
 				`,
 			]}
 		>

--- a/dotcom-rendering/src/web/components/NavList.stories.tsx
+++ b/dotcom-rendering/src/web/components/NavList.stories.tsx
@@ -18,14 +18,14 @@ export default {
 };
 
 export const Default = () => (
-	<FrontSection title="NavList" centralBorder="partial">
+	<FrontSection title="NavList">
 		<NavList trails={trails} showImage={false} />
 	</FrontSection>
 );
 Default.storyName = 'NavList';
 
 export const DefaultWithImages = () => (
-	<FrontSection title="Nav Media List" centralBorder="partial">
+	<FrontSection title="Nav Media List">
 		<NavList trails={trails} showImage={true} />
 	</FrontSection>
 );

--- a/dotcom-rendering/src/web/components/Palettes.stories.tsx
+++ b/dotcom-rendering/src/web/components/Palettes.stories.tsx
@@ -25,7 +25,6 @@ const groupedTrails = {
 export const EventPalette = () => (
 	<FrontSection
 		title="Event Palette"
-		centralBorder="partial"
 		containerPalette="EventPalette"
 		showDateHeader={true}
 		editionId={'UK'}
@@ -52,7 +51,6 @@ EventPalette.story = {
 export const EventAltPalette = () => (
 	<FrontSection
 		title="Event Alt Palette"
-		centralBorder="partial"
 		containerPalette="EventAltPalette"
 		showDateHeader={true}
 		editionId={'UK'}
@@ -68,7 +66,6 @@ export const EventAltPalette = () => (
 export const SombrePalette = () => (
 	<FrontSection
 		title="Sombre Palette"
-		centralBorder="partial"
 		containerPalette="SombrePalette"
 		showDateHeader={true}
 		editionId={'UK'}
@@ -84,7 +81,6 @@ export const SombrePalette = () => (
 export const SombreAltPalette = () => (
 	<FrontSection
 		title="Sombre Alt Palette"
-		centralBorder="partial"
 		containerPalette="SombreAltPalette"
 		showDateHeader={true}
 		editionId={'UK'}
@@ -100,7 +96,6 @@ export const SombreAltPalette = () => (
 export const BreakingPalette = () => (
 	<FrontSection
 		title="Breaking Palette"
-		centralBorder="partial"
 		containerPalette="BreakingPalette"
 		showDateHeader={true}
 		editionId={'UK'}
@@ -116,7 +111,6 @@ export const BreakingPalette = () => (
 export const LongRunningPalette = () => (
 	<FrontSection
 		title="Long Running Palette"
-		centralBorder="partial"
 		containerPalette="LongRunningPalette"
 		showDateHeader={true}
 		editionId={'UK'}
@@ -132,7 +126,6 @@ export const LongRunningPalette = () => (
 export const LongRunningAltPalette = () => (
 	<FrontSection
 		title="Long Running Alt Palette"
-		centralBorder="partial"
 		containerPalette="LongRunningAltPalette"
 		showDateHeader={true}
 		editionId={'UK'}
@@ -148,7 +141,6 @@ export const LongRunningAltPalette = () => (
 export const InvestigationPalette = () => (
 	<FrontSection
 		title="Investigation Palette"
-		centralBorder="partial"
 		containerPalette="InvestigationPalette"
 		showDateHeader={true}
 		editionId={'UK'}
@@ -164,7 +156,6 @@ export const InvestigationPalette = () => (
 export const SpecialReportAltPalette = () => (
 	<FrontSection
 		title="Special Report Alt Palette"
-		centralBorder="partial"
 		containerPalette="SpecialReportAltPalette"
 		showDateHeader={true}
 		editionId={'UK'}

--- a/dotcom-rendering/src/web/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FrontLayout.tsx
@@ -394,7 +394,6 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 								title={collection.displayName}
 								description={collection.description}
 								showTopBorder={index > 0}
-								centralBorder="partial"
 								url={collection.href}
 								ophanComponentLink={ophanComponentLink}
 								ophanComponentName={ophanName}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Removes a lot of un-used (or only used in stories) props from FrontSection in an effort to clean the component up a bit. I suspect a lot of these props are remnants from when FrontSection was copied from Section

## Why?

I was getting confused in https://github.com/guardian/dotcom-rendering/pull/7564 due to how big the FrontSection component is.
