### PR TITLE
Update Braze-components dependency to v13.1.0

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -60,7 +60,7 @@
 		"@emotion/server": "^11.4.0",
 		"@guardian/ab-core": "^4.0.0",
 		"@guardian/atoms-rendering": "^27.0.0",
-		"@guardian/braze-components": "^13.0.0",
+		"@guardian/braze-components": "^13.1.0",
 		"@guardian/bridget": "^2.3.0",
 		"@guardian/browserslist-config": "^4.0.0",
 		"@guardian/cdk": "^49.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2208,10 +2208,10 @@
   dependencies:
     is-mobile "3.1.1"
 
-"@guardian/braze-components@^13.0.0":
-  version "13.0.0"
-  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-13.0.0.tgz#af0839b56ebd4fb1180cbc45efe2ddd66a968bcb"
-  integrity sha512-M8fi4YuAxLRgifE0gI6HDC9Sq3q8+mypSbUF6jRZMT0fzngV9NSjdaLhkR7sYkc1aKB9Cdi3IqpfBiFO1qee5w==
+"@guardian/braze-components@^13.1.0":
+  version "13.1.0"
+  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-13.1.0.tgz#7af08f1586fdc9876c52aec27c6ca842b0ef9182"
+  integrity sha512-Gntd5xbf2dg9bKYtXPvSDD7hbedZgS19ONXcRNgBcFGyqEHp2i73/P4Les75Q2kW6jQPUVKmjaNMY6m/0kXj5g==
 
 "@guardian/bridget@^2.3.0":
   version "2.3.0"


### PR DESCRIPTION
## What does this change?
We've updated the braze-components repo to make the authored epic easier to manage and self-serve by Marketing colleagues

## Screenshots
Theres no visible changes in the component (in DCR Storybook), and the functionality of the component itself has not changed.

## Unexplained Chromatic diffs
To check