### PR TITLE
Add descriptions for toc, callouts and send a message components

### DIFF
--- a/dotcom-rendering/src/web/components/CalloutBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/web/components/CalloutBlockComponent.importable.tsx
@@ -10,6 +10,19 @@ const collapsibleCalloutStyle = css`
 	background-color: ${palette.neutral[97]};
 `;
 
+/**
+ * # Callout Block Component
+ *
+ * A callout to readers to share their stories.
+ * This is the updated version of the CalloutEmbedBlockComponent.
+ *
+ * ## Why does this need to be an Island?
+ *
+ * We are responding to user interactions on the page,
+ * and submitting a form.
+ *
+ */
+
 export const CalloutBlockComponent = ({
 	callout,
 	pageId,

--- a/dotcom-rendering/src/web/components/SendAMessage.importable.tsx
+++ b/dotcom-rendering/src/web/components/SendAMessage.importable.tsx
@@ -394,6 +394,18 @@ const summaryStyles = css`
 	}
 `;
 
+/**
+ * # Send a Message Component
+ *
+ * A callout for readers to get in touch with a liveblogger directly.
+ *
+ * ## Why does this need to be an Island?
+ *
+ * We are responding to user interactions on the page,
+ * and submitting a form.
+ *
+ */
+
 export const SendAMessage = ({ formFields, formId, format, pageId }: Props) => {
 	return (
 		<details css={detailsStyles}>

--- a/dotcom-rendering/src/web/components/TableOfContents.importable.tsx
+++ b/dotcom-rendering/src/web/components/TableOfContents.importable.tsx
@@ -107,6 +107,18 @@ const verticalStyle = css`
 	transition: 0.3s all ease;
 `;
 
+/**
+ * # Table of Contents Component
+ *
+ * A table of contents, shown at the top of an article
+ * to allow readers to quickly navigate though articles.
+ *
+ * ## Why does this need to be an Island?
+ *
+ * We are responding to user interactions on the page.
+ *
+ */
+
 export const TableOfContents = ({ tableOfContents, format }: Props) => {
 	const palette = decidePalette(format);
 	const [open, setOpen] = useState(tableOfContents.length < 5);


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Adds some descriptions for the following Islands
- Table of contents
- Callouts
- Send a Message

## Why?
These descriptions are used by https://assets.guim.co.uk/assets/stats/islands.html
