### PR TITLE
add format to FrontPage

### DIFF
--- a/dotcom-rendering/src/web/components/FrontPage.tsx
+++ b/dotcom-rendering/src/web/components/FrontPage.tsx
@@ -18,6 +18,7 @@ import { SkipTo } from './SkipTo';
 type Props = {
 	front: DCRFrontType;
 	NAV: NavType;
+	format: ArticleFormat;
 };
 
 /**
@@ -27,8 +28,9 @@ type Props = {
  * @param {Props} props
  * @param {DCRFrontType} props.front - The article JSON data
  * @param {NAVType} props.NAV - The article JSON data
+ * @param {ArticleFormat} props.format - The format model for the article
  * */
-export const FrontPage = ({ front, NAV }: Props) => {
+export const FrontPage = ({ front, NAV, format }: Props) => {
 	return (
 		<StrictMode>
 			<Global
@@ -75,7 +77,7 @@ export const FrontPage = ({ front, NAV }: Props) => {
 					isDev={!!front.config.isDev}
 				/>
 			</Island>
-			<FrontLayout front={front} NAV={NAV} />
+			<FrontLayout front={front} NAV={NAV} format={format} />
 		</StrictMode>
 	);
 };

--- a/dotcom-rendering/src/web/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FrontLayout.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
+import type { ArticleDisplay } from '@guardian/libs';
 import {
 	brandBackground,
 	brandBorder,
@@ -23,14 +23,15 @@ import { ShowMore } from '../components/ShowMore.importable';
 import { Snap } from '../components/Snap';
 import { SubNav } from '../components/SubNav.importable';
 import { TrendingTopics } from '../components/TrendingTopics';
+import { canRenderAds } from '../lib/canRenderAds';
 import { DecideContainer } from '../lib/DecideContainer';
 import { decidePalette } from '../lib/decidePalette';
-import { canRenderAds } from '../lib/canRenderAds';
 import { Stuck } from './lib/stickiness';
 
 interface Props {
 	front: DCRFrontType;
 	NAV: NavType;
+	format: ArticleFormat;
 }
 
 const spaces = / /g;
@@ -152,7 +153,7 @@ const decideAdSlot = (
 	return null;
 };
 
-export const FrontLayout = ({ front, NAV }: Props) => {
+export const FrontLayout = ({ front, NAV, format }: Props) => {
 	const {
 		config: { isPaidContent },
 	} = front;
@@ -160,15 +161,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 	const isInEuropeTest =
 		front.config.abTests.europeNetworkFrontVariant === 'variant';
 
-	const format = {
-		display: ArticleDisplay.Standard,
-		design: ArticleDesign.Standard,
-		theme: ArticlePillar.News,
-	};
-
 	const palette = decidePalette(format);
-
-	// const contributionsServiceUrl = getContributionsServiceUrl(front);
 
 	/**
 	 * This property currently only applies to the header and merchandising slots


### PR DESCRIPTION
## What does this change?
Adds `format: ArticleFormat` to `FrontPage.props`.

## Why?
The navigation on fronts isn't working as we currently [hardcode the format in FrontLayout](https://github.com/guardian/dotcom-rendering/blob/f1ee33d3ea335b65cc0259b612f7f0695583a042/dotcom-rendering/src/web/layouts/FrontLayout.tsx#L178-L182).

This is because [the `<Pillars />` component uses the `format.theme` to determine the selected pillar](https://github.com/guardian/dotcom-rendering/blob/f1ee33d3ea335b65cc0259b612f7f0695583a042/dotcom-rendering/src/web/components/Pillars.tsx#L259).

## Screenshots

On `/uk/sport`.

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/31692/233612755-b83f846f-c440-4a0e-abfe-6fbf027e4524.png

[after]: https://user-images.githubusercontent.com/31692/233612784-3586eb90-742e-46a2-a01f-9a7206951e5a.png

## Talking points

TBD