### PR TITLE
Use `.storyName` To Name Stories: Story Objects

### DIFF
--- a/dotcom-rendering/src/web/components/ArticleHeadline.stories.tsx
+++ b/dotcom-rendering/src/web/components/ArticleHeadline.stories.tsx
@@ -721,8 +721,8 @@ export const LiveBlog = () => {
 		</Section>
 	);
 };
+LiveBlog.storyName = 'LiveBlog';
 LiveBlog.story = {
-	name: 'LiveBlog',
 	parameters: {
 		backgrounds: {
 			default: 'red',

--- a/dotcom-rendering/src/web/components/Caption.stories.tsx
+++ b/dotcom-rendering/src/web/components/Caption.stories.tsx
@@ -234,8 +234,8 @@ export const VideoCaption = () => (
 		/>
 	</Section>
 );
+VideoCaption.storyName = 'for videos';
 VideoCaption.story = {
-	name: 'for videos',
 	parameters: {
 		chromatic: {
 			viewports: [

--- a/dotcom-rendering/src/web/components/CardHeadline.stories.tsx
+++ b/dotcom-rendering/src/web/components/CardHeadline.stories.tsx
@@ -187,8 +187,8 @@ export const MobileSize = () => (
 		))}
 	</>
 );
+MobileSize.storyName = 'MobileSize';
 MobileSize.story = {
-	name: 'MobileSize',
 	parameters: {
 		chromatic: {
 			viewports: [breakpoints.mobile],

--- a/dotcom-rendering/src/web/components/EmailSignup.stories.tsx
+++ b/dotcom-rendering/src/web/components/EmailSignup.stories.tsx
@@ -81,20 +81,20 @@ export const IrregularFrequency = ({
 	/>
 );
 
+Default.storyName = 'default';
 Default.story = {
-	name: 'default',
 	args: {
 		hidePrivacyMessage: false,
 	},
 };
+NewsTheme.storyName = 'news theme';
 NewsTheme.story = {
-	name: 'news theme',
 	args: {
 		hidePrivacyMessage: false,
 	},
 };
+IrregularFrequency.storyName = 'irregular frequency';
 IrregularFrequency.story = {
-	name: 'irregular frequency',
 	args: {
 		hidePrivacyMessage: false,
 	},

--- a/dotcom-rendering/src/web/components/Footer.stories.tsx
+++ b/dotcom-rendering/src/web/components/Footer.stories.tsx
@@ -60,8 +60,8 @@ export const Footers = () => (
 		))}
 	</ul>
 );
+Footers.storyName = 'Footer for all editions';
 Footers.story = {
-	name: 'Footer for all editions',
 	parameters: {
 		chromatic: {
 			viewports: Object.values(breakpoints),

--- a/dotcom-rendering/src/web/components/FrontSection.stories.tsx
+++ b/dotcom-rendering/src/web/components/FrontSection.stories.tsx
@@ -155,8 +155,8 @@ export const MultipleStory = () => {
 		</>
 	);
 };
+MultipleStory.storyName = 'with multiple FrontGrids';
 MultipleStory.story = {
-	name: 'with multiple FrontGrids',
 	parameters: {
 		chromatic: {
 			viewports: [

--- a/dotcom-rendering/src/web/components/ImageBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/web/components/ImageBlockComponent.stories.tsx
@@ -231,8 +231,8 @@ export const InlineTitle = () => {
 		</Wrapper>
 	);
 };
+InlineTitle.storyName = 'with title and role inline';
 InlineTitle.story = {
-	name: 'with title and role inline',
 	parameters: {
 		viewport: { defaultViewport: 'desktop' },
 		chromatic: { viewports: [1300] },
@@ -265,8 +265,8 @@ export const InlineTitleMobile = () => {
 		</Wrapper>
 	);
 };
+InlineTitleMobile.storyName = 'with title and role inline on mobile';
 InlineTitleMobile.story = {
-	name: 'with title and role inline on mobile',
 	parameters: {
 		viewport: { defaultViewport: 'mobileMedium' },
 		chromatic: { viewports: [375] },
@@ -327,8 +327,8 @@ export const ShowcaseTitle = () => {
 		</Wrapper>
 	);
 };
+ShowcaseTitle.storyName = 'with title and role showcase';
 ShowcaseTitle.story = {
-	name: 'with title and role showcase',
 	parameters: {
 		viewport: { defaultViewport: 'desktop' },
 		chromatic: { viewports: [980] },
@@ -395,8 +395,8 @@ export const HalfWidth = () => {
 		</Wrapper>
 	);
 };
+HalfWidth.storyName = 'with role halfWidth on desktop';
 HalfWidth.story = {
-	name: 'with role halfWidth on desktop',
 	parameters: {
 		viewport: { defaultViewport: 'desktop' },
 		chromatic: { viewports: [980] },
@@ -463,8 +463,8 @@ export const HalfWidthMobile = () => {
 		</Wrapper>
 	);
 };
+HalfWidthMobile.storyName = 'with role halfWidth on mobile';
 HalfWidthMobile.story = {
-	name: 'with role halfWidth on mobile',
 	parameters: {
 		viewport: { defaultViewport: 'mobileMedium' },
 		chromatic: { viewports: [375] },
@@ -531,8 +531,8 @@ export const HalfWidthWide = () => {
 		</Wrapper>
 	);
 };
+HalfWidthWide.storyName = 'with role halfWidth';
 HalfWidthWide.story = {
-	name: 'with role halfWidth',
 	parameters: {
 		viewport: { defaultViewport: 'wide' },
 		chromatic: { disable: true },

--- a/dotcom-rendering/src/web/components/ReaderRevenueLinks.stories.tsx
+++ b/dotcom-rendering/src/web/components/ReaderRevenueLinks.stories.tsx
@@ -44,8 +44,8 @@ export const Header = () => {
 		</Wrapper>
 	);
 };
+Header.storyName = 'Header - desktop';
 Header.story = {
-	name: 'Header - desktop',
 	parameters: {
 		viewport: { defaultViewport: 'desktop' },
 		chromatic: { viewports: [1300] },
@@ -66,8 +66,8 @@ export const HeaderMobile = () => {
 		</Wrapper>
 	);
 };
+HeaderMobile.storyName = 'Header - mobileMedium';
 HeaderMobile.story = {
-	name: 'Header - mobileMedium',
 	parameters: {
 		viewport: { defaultViewport: 'mobileMedium' },
 		chromatic: { viewports: [380] },
@@ -88,8 +88,8 @@ export const Footer = () => {
 		</Wrapper>
 	);
 };
+Footer.storyName = 'Footer - desktop';
 Footer.story = {
-	name: 'Footer - desktop',
 	parameters: {
 		viewport: { defaultViewport: 'desktop' },
 		chromatic: { viewports: [1300] },
@@ -110,8 +110,8 @@ export const FooterMobile = () => {
 		</Wrapper>
 	);
 };
+FooterMobile.storyName = 'Footer - mobileMedium';
 FooterMobile.story = {
-	name: 'Footer - mobileMedium',
 	parameters: {
 		viewport: { defaultViewport: 'mobileMedium' },
 		chromatic: { viewports: [380] },

--- a/dotcom-rendering/src/web/components/Section.stories.tsx
+++ b/dotcom-rendering/src/web/components/Section.stories.tsx
@@ -263,8 +263,8 @@ export const MultipleStory = () => {
 		</>
 	);
 };
+MultipleStory.storyName = 'with multiple sections';
 MultipleStory.story = {
-	name: 'with multiple sections',
 	parameters: {
 		chromatic: {
 			viewports: [

--- a/dotcom-rendering/src/web/components/Standfirst.stories.tsx
+++ b/dotcom-rendering/src/web/components/Standfirst.stories.tsx
@@ -123,8 +123,8 @@ export const LiveBlog = () => {
 		</Section>
 	);
 };
+LiveBlog.storyName = 'LiveBlog';
 LiveBlog.story = {
-	name: 'LiveBlog',
 	parameters: {
 		backgrounds: {
 			default: 'red',

--- a/dotcom-rendering/src/web/components/Toast.stories.tsx
+++ b/dotcom-rendering/src/web/components/Toast.stories.tsx
@@ -41,8 +41,8 @@ export const Default = () => {
 		</Wrapper>
 	);
 };
+Default.storyName = 'with 3 updates';
 Default.story = {
-	name: 'with 3 updates',
 	parameters: {
 		viewport: { defaultViewport: 'desktop' },
 	},
@@ -63,8 +63,8 @@ export const Sport = () => {
 		</Wrapper>
 	);
 };
+Sport.storyName = 'with sport theme';
 Sport.story = {
-	name: 'with sport theme',
 	parameters: {
 		viewport: { defaultViewport: 'desktop' },
 	},
@@ -85,8 +85,8 @@ export const Special = () => {
 		</Wrapper>
 	);
 };
+Special.storyName = 'with special report theme';
 Special.story = {
-	name: 'with special report theme',
 	parameters: {
 		viewport: { defaultViewport: 'desktop' },
 	},
@@ -107,8 +107,8 @@ export const One = () => {
 		</Wrapper>
 	);
 };
+One.storyName = 'with only one update';
 One.story = {
-	name: 'with only one update',
 	parameters: {
 		viewport: { defaultViewport: 'desktop' },
 	},
@@ -129,8 +129,8 @@ export const Lots = () => {
 		</Wrapper>
 	);
 };
+Lots.storyName = 'with many updates';
 Lots.story = {
-	name: 'with many updates',
 	parameters: {
 		viewport: { defaultViewport: 'desktop' },
 	},
@@ -151,8 +151,8 @@ export const Mobile = () => {
 		</Wrapper>
 	);
 };
+Mobile.storyName = 'with mobile viewport';
 Mobile.story = {
-	name: 'with mobile viewport',
 	parameters: {
 		viewport: { defaultViewport: 'mobileMedium' },
 		chromatic: {

--- a/dotcom-rendering/src/web/components/VideoFacebookBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/web/components/VideoFacebookBlockComponent.stories.tsx
@@ -41,8 +41,8 @@ export const largeAspectRatio = () => {
 		</Wrapper>
 	);
 };
+largeAspectRatio.storyName = 'with large aspect ratio';
 largeAspectRatio.story = {
-	name: 'with large aspect ratio',
 	chromatic: { disable: true },
 };
 

--- a/dotcom-rendering/src/web/components/VimeoBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/web/components/VimeoBlockComponent.stories.tsx
@@ -64,8 +64,8 @@ export const largeAspectRatio = () => {
 		</Wrapper>
 	);
 };
+largeAspectRatio.storyName = 'with large aspect ratio';
 largeAspectRatio.story = {
-	name: 'with large aspect ratio',
 	chromatic: { disable: true },
 };
 


### PR DESCRIPTION
## Why?

Some stories have an object in their `.story` field with multiple properties, one of which is the `name` property. This moves the `name` property to a `.storyName` field directly on the story itself. The previous way doesn't match the documentation[^1] and doesn't seem to work in storybook 7.

Having other properties in the `.story` object does seem to work in storybook 7, so these have not been changed.

After this PR there should now be no more stories that are setting their name using the `.story.name` pattern.

Follows on from #7560.

## Changes

- Replaced usages of `.story.name` with `.storyName` across stories where the `.story` object also had other properties.

[^1]: https://storybook.js.org/docs/6.5/react/writing-stories/introduction#snippet-button-story-rename-story
