### PR TITLE
fix selected filter colour issue caused by global styles

### DIFF
--- a/dotcom-rendering/src/web/components/FilterLink.tsx
+++ b/dotcom-rendering/src/web/components/FilterLink.tsx
@@ -104,6 +104,7 @@ export const FilterLink = ({
 			iconSide="right"
 			aria-label={`Deactivate ${value} filter`}
 			data-link-name={`${dataLinkName} | filter off`}
+			data-ignore="global-link-styling"
 		>
 			<Label value={value} count={count} />
 		</LinkButton>
@@ -113,6 +114,7 @@ export const FilterLink = ({
 			href={href}
 			aria-label={`Activate ${value} filter`}
 			data-link-name={`${dataLinkName} | filter on`}
+			data-ignore="global-link-styling"
 		>
 			<Label value={value} count={count} />
 		</LinkButton>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Fixes a bug where the selected filter colour was overwritten by global styles 

## Why?

## Screenshots

| Before      | After      |
|-------------|------------|
| ![image](https://user-images.githubusercontent.com/15894063/233660909-b02aba14-249d-4634-82ae-21b82cab8838.png) | ![image](https://user-images.githubusercontent.com/15894063/233660810-6cd834cc-c7ad-49ad-b8ab-ea02534b5b1e.png) |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->


<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
