### PR TITLE
Potentially fix dependency PRs not having lockfiles

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,13 @@ updates:
           interval: 'daily'
       # Set to minimise the number of chromatic runs.
       rebase-strategy: "disabled"
+
+      ignore:
+        # The version of the aws-cdk[-lib] & constructs dependencies should match exactly the version specified by @guardian/cdk
+        - dependency-name: 'aws-cdk'
+        - dependency-name: 'aws-cdk-lib'
+        - dependency-name: 'constructs'
+      open-pull-requests-limit: 10
     - package-ecosystem: 'npm'
       directory: '/apps-rendering'
       schedule:
@@ -24,14 +31,6 @@ updates:
         - dependency-name: 'aws-cdk-lib'
         - dependency-name: 'constructs'
       open-pull-requests-limit: 7
-    - package-ecosystem: "npm"
-      directory: "/dotcom-rendering"
-      schedule:
-        interval: "daily"
-      labels:
-        - "DCR Dependency"
-      open-pull-requests-limit: 10
-      rebase-strategy: "disabled"
     - package-ecosystem: 'github-actions'
       directory: '/'
       schedule:


### PR DESCRIPTION
## What does this change?

Removes the configuration for the DCR subfolder from dependabot. Dependabot seems to have trouble understanding yarn workspaces if it doesn't have access to the root yarn package files (such as the case in the DCR config). See https://github.com/dependabot/feedback/issues/740

I'm hoping this will allow Dependabot to keep updating DCR dependencies and still play nicely with AR, but I'm not entirely sure it will. Theres no way to tell Dependabot to ignore the AR folder when updating our root yarn workspace.

Also adds AWS libs to the list of ignored dependencies for DCR as we're using CDK in DCR too now.

## Open prs at time of writting with no lockfiles

https://github.com/guardian/dotcom-rendering/pull/7568
https://github.com/guardian/dotcom-rendering/pull/7535
https://github.com/guardian/dotcom-rendering/pull/7424
https://github.com/guardian/dotcom-rendering/pull/7377
https://github.com/guardian/dotcom-rendering/pull/5649
https://github.com/guardian/dotcom-rendering/pull/5167 @mxdvl

Basically any PR with the "DCR Dependency" label.
