### PR TITLE
refactor topicFilterBank to avoid mutating the array

### DIFF
--- a/dotcom-rendering/src/web/components/TopicFilterBank.test.tsx
+++ b/dotcom-rendering/src/web/components/TopicFilterBank.test.tsx
@@ -34,7 +34,7 @@ describe('hasRelevantTopics', () => {
 });
 
 describe('getTopFiveIncludingSelected', () => {
-	const avaiableTopics: Topic[] = [
+	const availableTopics: Topic[] = [
 		{ type: 'PERSON', value: 'test topic 1', count: 6 },
 		{ type: 'PERSON', value: 'test topic 2', count: 5 },
 		{ type: 'PERSON', value: 'test topic 3', count: 5 },
@@ -52,7 +52,7 @@ describe('getTopFiveIncludingSelected', () => {
 
 			const res = getTopFiveIncludingSelected(
 				selectedTopic,
-				avaiableTopics,
+				availableTopics,
 			);
 
 			const expected = [
@@ -74,7 +74,7 @@ describe('getTopFiveIncludingSelected', () => {
 
 			const res = getTopFiveIncludingSelected(
 				selectedTopic,
-				avaiableTopics,
+				availableTopics,
 			);
 
 			const expected = [
@@ -120,7 +120,7 @@ describe('getTopFiveIncludingSelected', () => {
 			};
 			const res = getTopFiveIncludingSelected(
 				selectedTopic,
-				avaiableTopics,
+				availableTopics,
 			);
 
 			const expected = [

--- a/dotcom-rendering/src/web/components/TopicFilterBank.test.tsx
+++ b/dotcom-rendering/src/web/components/TopicFilterBank.test.tsx
@@ -1,4 +1,7 @@
-import { hasRelevantTopics } from './TopicFilterBank';
+import {
+	getTopFiveIncludingSelected,
+	hasRelevantTopics,
+} from './TopicFilterBank';
 
 describe('hasRelevantTopics', () => {
 	describe('should be false', () => {
@@ -26,6 +29,109 @@ describe('hasRelevantTopics', () => {
 					{ type: 'PERSON', value: 'Anne-Marie Trevelyan', count: 1 },
 				]),
 			).toBe(true);
+		});
+	});
+});
+
+describe('getTopFiveIncludingSelected', () => {
+	const avaiableTopics: Topic[] = [
+		{ type: 'PERSON', value: 'test topic 1', count: 6 },
+		{ type: 'PERSON', value: 'test topic 2', count: 5 },
+		{ type: 'PERSON', value: 'test topic 3', count: 5 },
+		{ type: 'PERSON', value: 'test topic 4', count: 4 },
+		{ type: 'PERSON', value: 'test topic 5', count: 4 },
+		{ type: 'PERSON', value: 'test topic 6', count: 3 },
+	];
+	describe('should return the top 5 topics with count over 2, including the selected topic', () => {
+		it('given selected is not within top 5', () => {
+			const selectedTopic: Topic = {
+				type: 'PERSON',
+				value: 'test topic 6',
+				count: 3,
+			};
+
+			const res = getTopFiveIncludingSelected(
+				selectedTopic,
+				avaiableTopics,
+			);
+
+			const expected = [
+				{ type: 'PERSON', value: 'test topic 1', count: 6 },
+				{ type: 'PERSON', value: 'test topic 2', count: 5 },
+				{ type: 'PERSON', value: 'test topic 3', count: 5 },
+				{ type: 'PERSON', value: 'test topic 4', count: 4 },
+				{ type: 'PERSON', value: 'test topic 6', count: 3 },
+			];
+
+			expect(res).toEqual(expected);
+		});
+		it('given selected topic is within top 5', () => {
+			const selectedTopic: Topic = {
+				type: 'PERSON',
+				value: 'test topic 2',
+				count: 5,
+			};
+
+			const res = getTopFiveIncludingSelected(
+				selectedTopic,
+				avaiableTopics,
+			);
+
+			const expected = [
+				{ type: 'PERSON', value: 'test topic 1', count: 6 },
+				{ type: 'PERSON', value: 'test topic 2', count: 5 },
+				{ type: 'PERSON', value: 'test topic 3', count: 5 },
+				{ type: 'PERSON', value: 'test topic 4', count: 4 },
+				{ type: 'PERSON', value: 'test topic 5', count: 4 },
+			];
+
+			expect(res).toEqual(expected);
+		});
+		it('given less than 5 items have count over 2 and selected is within them', () => {
+			const topics: Topic[] = [
+				{ type: 'PERSON', value: 'test topic 1', count: 6 },
+				{ type: 'PERSON', value: 'test topic 2', count: 5 },
+				{ type: 'PERSON', value: 'test topic 3', count: 5 },
+			];
+			const selectedTopic: Topic = {
+				type: 'PERSON',
+				value: 'test topic 2',
+				count: 5,
+			};
+
+			const res = getTopFiveIncludingSelected(selectedTopic, topics);
+
+			const expected = [
+				{ type: 'PERSON', value: 'test topic 1', count: 6 },
+				{ type: 'PERSON', value: 'test topic 2', count: 5 },
+				{ type: 'PERSON', value: 'test topic 3', count: 5 },
+			];
+
+			expect(res).toEqual(expected);
+		});
+	});
+
+	describe('should return top 4 excluding the selected', () => {
+		it('given selected does not match any of the topics', () => {
+			const selectedTopic: Topic = {
+				type: 'PERSON',
+				value: 'random',
+				count: 5,
+			};
+			const res = getTopFiveIncludingSelected(
+				selectedTopic,
+				avaiableTopics,
+			);
+
+			const expected = [
+				{ type: 'PERSON', value: 'test topic 1', count: 6 },
+				{ type: 'PERSON', value: 'test topic 2', count: 5 },
+				{ type: 'PERSON', value: 'test topic 3', count: 5 },
+				{ type: 'PERSON', value: 'test topic 4', count: 4 },
+				{ type: 'PERSON', value: 'test topic 5', count: 4 },
+			];
+
+			expect(res).toEqual(expected);
 		});
 	});
 });

--- a/dotcom-rendering/src/web/components/TopicFilterBank.tsx
+++ b/dotcom-rendering/src/web/components/TopicFilterBank.tsx
@@ -62,13 +62,9 @@ const getKeyEventLink = (filterKeyEvents: boolean, id: Props['id']) => {
 	return `?${urlParams.toString()}#${id}`;
 };
 
-const isEqual = (selectedTopic: Topic | undefined, availableTopic: Topic) => {
-	if (!selectedTopic) return false;
-	return (
-		availableTopic.type === selectedTopic.type &&
-		availableTopic.value === selectedTopic.value
-	);
-};
+const isEqual = (selectedTopic: Topic, availableTopic: Topic) =>
+	availableTopic.type === selectedTopic.type &&
+	availableTopic.value === selectedTopic.value;
 
 // get top 5 only if they occur in more than 2 blocks
 const getTopFiveTopics = (availableTopics: Topic[]) => {
@@ -87,9 +83,11 @@ export const getTopFiveIncludingSelected = (
 ) => {
 	const topFiveTopics = getTopFiveTopics(availableTopics);
 
-	const selectedIndex = availableTopics.findIndex((availableTopic) =>
-		isEqual(selectedTopic, availableTopic),
-	);
+	const selectedIndex = selectedTopic
+		? availableTopics.findIndex((availableTopic) =>
+				isEqual(selectedTopic, availableTopic),
+		  )
+		: -1;
 
 	// if selected topic is not within the top 5,
 	// replacing the last topic of top 5 with the selected topic

--- a/dotcom-rendering/src/web/components/TopicFilterBank.tsx
+++ b/dotcom-rendering/src/web/components/TopicFilterBank.tsx
@@ -62,17 +62,43 @@ const getKeyEventLink = (filterKeyEvents: boolean, id: Props['id']) => {
 	return `?${urlParams.toString()}#${id}`;
 };
 
-const isEqual = (selectedTopic: Topic, availableTopic: Topic) =>
-	availableTopic.type === selectedTopic.type &&
-	availableTopic.value === selectedTopic.value;
+const isEqual = (selectedTopic: Topic | undefined, availableTopic: Topic) => {
+	if (!selectedTopic) return false;
+	return (
+		availableTopic.type === selectedTopic.type &&
+		availableTopic.value === selectedTopic.value
+	);
+};
 
-const getTopFiveTopics = (availableTopics: Topic[]) =>
-	availableTopics
+const getTopFiveTopics = (availableTopics: Topic[]) => {
+	return availableTopics
 		.slice(0, 5)
 		.filter((topic) => topic.count !== undefined && topic.count > 2);
+};
 
 export const hasRelevantTopics = (availableTopics?: Topic[]) => {
 	return !!(availableTopics && getTopFiveTopics(availableTopics).length);
+};
+
+export const getTopFiveIncludingSelected = (
+	selectedTopic: Topic | undefined,
+	availableTopics: Topic[],
+) => {
+	const topFiveTopics = getTopFiveTopics(availableTopics);
+
+	const selectedIndex = availableTopics.findIndex((availableTopic) =>
+		isEqual(selectedTopic, availableTopic),
+	);
+
+	if (selectedIndex > 4) {
+		const remaining = topFiveTopics.slice(0, topFiveTopics.length - 1);
+
+		const selected = availableTopics[selectedIndex];
+
+		if (selected) return remaining.concat([selected]);
+	}
+
+	return topFiveTopics;
 };
 
 /**
@@ -97,18 +123,10 @@ export const TopicFilterBank = ({
 	if (!hasRelevantTopics(availableTopics) && !hasKeyEvents) return null;
 	const palette = decidePalette(format);
 	const selectedTopic = selectedTopics?.[0];
-	const topFiveTopics = getTopFiveTopics(availableTopics);
-
-	if (selectedTopic) {
-		const selectedIndex = availableTopics.findIndex((availableTopic) =>
-			isEqual(selectedTopic, availableTopic),
-		);
-
-		const topicAtIndex = availableTopics[selectedIndex];
-		if (selectedIndex > 4 && topicAtIndex) {
-			topFiveTopics.splice(4, 1, topicAtIndex);
-		}
-	}
+	const topFiveTopics = getTopFiveIncludingSelected(
+		selectedTopic,
+		availableTopics,
+	);
 
 	return (
 		<div css={containerStyles}>

--- a/dotcom-rendering/src/web/components/TopicFilterBank.tsx
+++ b/dotcom-rendering/src/web/components/TopicFilterBank.tsx
@@ -70,6 +70,7 @@ const isEqual = (selectedTopic: Topic | undefined, availableTopic: Topic) => {
 	);
 };
 
+// get top 5 only if they occur in more than 2 blocks
 const getTopFiveTopics = (availableTopics: Topic[]) => {
 	return availableTopics
 		.slice(0, 5)
@@ -90,6 +91,8 @@ export const getTopFiveIncludingSelected = (
 		isEqual(selectedTopic, availableTopic),
 	);
 
+	// if selected topic is not within the top 5,
+	// replacing the last topic of top 5 with the selected topic
 	if (selectedIndex > 4) {
 		const remaining = topFiveTopics.slice(0, topFiveTopics.length - 1);
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR refactors `TopicFilterBank` to avoid mutating the `availableTopics` array parameter and use array functions that would return a new array rather than mutating. 

Thanks @mxdvl for proposing this refactoring in here https://github.com/guardian/dotcom-rendering/pull/5290#discussion_r1029092623

## Why?
To improve code quality and reduce bug probability 
