### PR TITLE
Lower distance between ads for server-side liveblog ads AB test 3

### DIFF
--- a/dotcom-rendering/src/web/lib/liveblogAdSlots.test.ts
+++ b/dotcom-rendering/src/web/lib/liveblogAdSlots.test.ts
@@ -138,11 +138,11 @@ describe('shouldDisplayAd', () => {
 	});
 
 	describe('inserting further ad slots', () => {
-		it('should display ad if number of pixels without an ad is more than 1600', () => {
+		it('should display ad if number of pixels without an ad is more than 1500', () => {
 			const block = 5;
 			const totalBlocks = 10;
 			const numAdsInserted = 1;
-			const numPixelsWithoutAdvert = 1650;
+			const numPixelsWithoutAdvert = 1550;
 
 			const result = shouldDisplayAd(
 				block,
@@ -154,11 +154,11 @@ describe('shouldDisplayAd', () => {
 			expect(result).toBeTruthy();
 		});
 
-		it('should NOT display ad if number of pixels without an ad is less than 1600', () => {
+		it('should NOT display ad if number of pixels without an ad is less than 1500', () => {
 			const block = 5;
 			const totalBlocks = 10;
 			const numAdsInserted = 1;
-			const numPixelsWithoutAdvert = 1550;
+			const numPixelsWithoutAdvert = 1450;
 
 			const result = shouldDisplayAd(
 				block,

--- a/dotcom-rendering/src/web/lib/liveblogAdSlots.ts
+++ b/dotcom-rendering/src/web/lib/liveblogAdSlots.ts
@@ -17,7 +17,7 @@ const MAX_INLINE_ADS = 8;
 /**
  * Minimum amount of space in pixels between any pair of inline ads.
  */
-const MIN_SPACE_BETWEEN_ADS = 1_600;
+const MIN_SPACE_BETWEEN_ADS = 1_500;
 
 /**
  * Estimated margin associated with an element.
@@ -49,7 +49,7 @@ type BlockElementHeightData = { heightExcludingText: number } & (
 /**
  * All known element types that are used in a liveblog block. There are other elements that
  * it is possible to use (see FEElement type), but these other elements have not been
- * sighted in a liveblog page, so are not considered.
+ * sighted in a liveblog page (and there's lots of them), so they are not considered for now.
  */
 type KnownBlockElementType =
 	| 'model.dotcomrendering.pageElements.BlockquoteBlockElement'
@@ -201,7 +201,7 @@ const calculateApproximateBlockHeight = (elements: FEElement[]): number => {
 };
 
 /**
- * Determines whether an ad should be inserted after the next content block
+ * Determines whether an ad should be inserted AFTER the next content block
  */
 const shouldDisplayAd = (
 	block: number,
@@ -214,6 +214,7 @@ const shouldDisplayAd = (
 		return false;
 	}
 
+	// Always show an advert after the first content block
 	const isFirstAd = block === 1;
 	if (isFirstAd) {
 		return true;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Sets the distance between ads to approx 1500px.

## Why?

The [previous AB test](https://github.com/guardian/dotcom-rendering/pull/7206) recorded an increases in desktop ad-ratio of 29.26% and a decrease in mobile ad-ratio of 16.79%. We'd like (2 * change in mobile ad-ratio) + change in mobile ad-ratio > 0, so we slightly lower the gap between ads for the next AB test.
