### PR TITLE
Enable synthetically delaying FID

### DIFF
--- a/dotcom-rendering/src/web/bork/fid.ts
+++ b/dotcom-rendering/src/web/bork/fid.ts
@@ -1,0 +1,44 @@
+/** synthetically bork FID https://web.dev/fid/ */
+export const fid = (): void => {
+	try {
+		/** @see https://github.com/GoogleChrome/web-vitals/blob/v3.1.1/src/lib/polyfills/firstInputPolyfill.ts#L172 */
+		const eventTypes = [
+			'mousedown',
+			'keydown',
+			'touchstart',
+			'pointerdown',
+		];
+
+		const key = 'bork-fid-';
+		const hash = window.location.hash.slice(1);
+		if (
+			hash.startsWith(key) &&
+			typeof window.performance === 'object' &&
+			typeof window.performance.now === 'function'
+		) {
+			const delay = parseInt(hash.replace(key, ''), 10);
+			if (isNaN(delay)) return;
+
+			const bork = () => {
+				// eslint-disable-next-line no-console -- we want to apologise, in the name of science!
+				console.info(
+					'🍊 Delaying first click by ' + String(delay) + 'ms, sorry',
+				);
+
+				const now = performance.now();
+				eventTypes.forEach((eventType) => {
+					removeEventListener(eventType, bork);
+				});
+				while (performance.now() - now < delay) {
+					// throttling
+				}
+			};
+
+			eventTypes.forEach((eventType) => {
+				addEventListener(eventType, bork);
+			});
+		}
+	} catch (_) {
+		// do nothing
+	}
+};

--- a/dotcom-rendering/src/web/server/allEditorialNewslettersPageToHtml.tsx
+++ b/dotcom-rendering/src/web/server/allEditorialNewslettersPageToHtml.tsx
@@ -105,5 +105,6 @@ export const allEditorialNewslettersPageToHtml = ({
 		windowGuardian,
 		keywords: '',
 		offerHttp3,
+		bork: !!newslettersPage.config.switches.borkWebVitals,
 	});
 };

--- a/dotcom-rendering/src/web/server/articleToHtml.tsx
+++ b/dotcom-rendering/src/web/server/articleToHtml.tsx
@@ -226,5 +226,6 @@ window.twttr = (function(d, s, id) {
 		recipeMarkup,
 		offerHttp3,
 		canonicalUrl,
+		bork: !!article.config.switches.borkWebVitals,
 	});
 };

--- a/dotcom-rendering/src/web/server/frontToHtml.tsx
+++ b/dotcom-rendering/src/web/server/frontToHtml.tsx
@@ -106,5 +106,6 @@ export const frontToHtml = ({ front }: Props): string => {
 		windowGuardian,
 		keywords,
 		offerHttp3,
+		bork: !!front.config.switches.borkWebVitals,
 	});
 };

--- a/dotcom-rendering/src/web/server/pageTemplate.ts
+++ b/dotcom-rendering/src/web/server/pageTemplate.ts
@@ -2,6 +2,7 @@ import { brandBackground, resets } from '@guardian/source-foundations';
 import he from 'he';
 import { ASSET_ORIGIN } from '../../lib/assets';
 import { getFontsCss } from '../../lib/fonts-css';
+import { fid } from '../bork/fid';
 import { islandNoscriptStyles } from '../components/Island';
 import { getHttp3Url } from '../lib/getHttp3Url';
 
@@ -21,6 +22,7 @@ export const pageTemplate = ({
 	initTwitter,
 	recipeMarkup,
 	canonicalUrl,
+	bork,
 }: {
 	css: string;
 	html: string;
@@ -37,6 +39,7 @@ export const pageTemplate = ({
 	initTwitter?: string;
 	recipeMarkup?: string;
 	canonicalUrl?: string;
+	bork: boolean;
 }): string => {
 	const favicon =
 		process.env.NODE_ENV === 'production'
@@ -296,6 +299,7 @@ https://workforus.theguardian.com/careers/product-engineering/
 					window.curl = window.curlConfig;
 				</script>
 
+				${bork ? `<script>(${fid.toString()})()</script>` : ''}
 
 				${initTwitter ?? ''}
 


### PR DESCRIPTION
## What does this change?

Sythetically prevent input from being registered in a timely fashion.

Behind a hash flag `#fid-borked-xxx` where `xxx` is the delay to add on first input. 

## Why?

This will allow us to test various input delays

100ms - needs improvement
300ms - poor