### PR TITLE
Enable synthetically delaying FCP

### DIFF
--- a/dotcom-rendering/src/web/bork/fcp.ts
+++ b/dotcom-rendering/src/web/bork/fcp.ts
@@ -1,0 +1,16 @@
+export const fcp = (): void => {
+	try {
+		const hashKey = 'bork-fcp-';
+		const hash = window.location.hash.substring(1);
+		if (hash.startsWith(hashKey)) {
+			const root = document.documentElement;
+			root.style.setProperty(
+				'--bork-fcp-amount',
+				hash.replace(hashKey, '') + 'ms',
+			);
+			document.documentElement.classList.add('bork-fcp');
+		}
+	} catch (e) {
+		// do nothing
+	}
+};

--- a/dotcom-rendering/src/web/bork/fcp.ts
+++ b/dotcom-rendering/src/web/bork/fcp.ts
@@ -2,7 +2,10 @@ export const fcp = (): void => {
 	try {
 		const hashKey = 'bork-fcp-';
 		const hash = window.location.hash.substring(1);
-		if (hash.startsWith(hashKey)) {
+		if (
+			hash.startsWith(hashKey) &&
+			CSS.supports('animation-duration', 'var(--fake-var)')
+		) {
 			const root = document.documentElement;
 			root.style.setProperty(
 				'--bork-fcp-amount',

--- a/dotcom-rendering/src/web/bork/fcp.ts
+++ b/dotcom-rendering/src/web/bork/fcp.ts
@@ -11,7 +11,7 @@ export const fcp = (): void => {
 				'--bork-fcp-amount',
 				hash.replace(hashKey, '') + 'ms',
 			);
-			document.documentElement.classList.add('bork-fcp');
+			root.classList.add('bork-fcp');
 		}
 	} catch (e) {
 		// do nothing

--- a/dotcom-rendering/src/web/bork/fcp.ts
+++ b/dotcom-rendering/src/web/bork/fcp.ts
@@ -1,3 +1,4 @@
+/** synthetically bork FCP https://web.dev/fcp/ */
 export const fcp = (): void => {
 	try {
 		const hashKey = 'bork-fcp-';

--- a/dotcom-rendering/src/web/server/pageTemplate.ts
+++ b/dotcom-rendering/src/web/server/pageTemplate.ts
@@ -242,10 +242,6 @@ https://workforus.theguardian.com/careers/product-engineering/
                     window.addEventListener('offline', function incrementOfflineCount () { window.guardian.offlineCount++ });
                 </script>
 
-				<script>
-					(${fcp.toString()})();
-				</script>
-
                 <script>
                     // this is a global that's called at the bottom of the pf.io response,
                     // once the polyfills have run. This may be useful for debugging.
@@ -305,9 +301,9 @@ https://workforus.theguardian.com/careers/product-engineering/
 				</script>
 
 				${bork ? `<script>(${fid.toString()})()</script>` : ''}
+				${bork ? `<script>(${fcp.toString()})();</script>` : ''}
 
 				${initTwitter ?? ''}
-
 
                 <noscript>
                     <img src="https://sb.scorecardresearch.com/p?${new URLSearchParams(

--- a/dotcom-rendering/src/web/server/pageTemplate.ts
+++ b/dotcom-rendering/src/web/server/pageTemplate.ts
@@ -301,7 +301,7 @@ https://workforus.theguardian.com/careers/product-engineering/
 				</script>
 
 				${bork ? `<script>(${fid.toString()})()</script>` : ''}
-				${bork ? `<script>(${fcp.toString()})();</script>` : ''}
+				${bork ? `<script>(${fcp.toString()})()</script>` : ''}
 
 				${initTwitter ?? ''}
 

--- a/dotcom-rendering/src/web/server/pageTemplate.ts
+++ b/dotcom-rendering/src/web/server/pageTemplate.ts
@@ -2,6 +2,7 @@ import { brandBackground, resets } from '@guardian/source-foundations';
 import he from 'he';
 import { ASSET_ORIGIN } from '../../lib/assets';
 import { getFontsCss } from '../../lib/fonts-css';
+import { fcp } from '../bork/fcp';
 import { fid } from '../bork/fid';
 import { islandNoscriptStyles } from '../components/Island';
 import { getHttp3Url } from '../lib/getHttp3Url';
@@ -241,6 +242,10 @@ https://workforus.theguardian.com/careers/product-engineering/
                     window.addEventListener('offline', function incrementOfflineCount () { window.guardian.offlineCount++ });
                 </script>
 
+				<script>
+					(${fcp.toString()})();
+				</script>
+
                 <script>
                     // this is a global that's called at the bottom of the pf.io response,
                     // once the polyfills have run. This may be useful for debugging.
@@ -323,6 +328,21 @@ https://workforus.theguardian.com/careers/product-engineering/
                 <style>${resets.resetCSS}</style>
 				${css}
 				<link rel="stylesheet" media="print" href="${ASSET_ORIGIN}static/frontend/css/print.css">
+  				<style>
+					@keyframes show-me {
+						to {
+							opacity: 1;
+						}
+					}
+  					html.bork-fcp body {
+						opacity: 0;
+						animation-duration: var(--bork-fcp-amount);
+						animation-name: show-me;
+						animation-timing-function: steps(1);
+						animation-iteration-count: 1;
+						animation-fill-mode: forwards;
+					}
+				</style>
 			</head>
 
 			<body>

--- a/dotcom-rendering/src/web/server/pageTemplate.ts
+++ b/dotcom-rendering/src/web/server/pageTemplate.ts
@@ -324,8 +324,11 @@ https://workforus.theguardian.com/careers/product-engineering/
                 <style>${resets.resetCSS}</style>
 				${css}
 				<link rel="stylesheet" media="print" href="${ASSET_ORIGIN}static/frontend/css/print.css">
-  				<style>
-					@keyframes bork-fcp-show-me {
+				${
+					bork
+						? `
+				<style>
+					@keyframes bork-fcp-paint {
 						to {
 							opacity: 1;
 						}
@@ -333,12 +336,15 @@ https://workforus.theguardian.com/careers/product-engineering/
   					html.bork-fcp body {
 						opacity: 0;
 						animation-duration: var(--bork-fcp-amount);
-						animation-name: show-me;
+						animation-name: bork-fcp-paint;
 						animation-timing-function: steps(1);
 						animation-iteration-count: 1;
 						animation-fill-mode: forwards;
 					}
-				</style>
+				</style>`
+						: ''
+				}
+
 			</head>
 
 			<body>

--- a/dotcom-rendering/src/web/server/pageTemplate.ts
+++ b/dotcom-rendering/src/web/server/pageTemplate.ts
@@ -329,7 +329,7 @@ https://workforus.theguardian.com/careers/product-engineering/
 				${css}
 				<link rel="stylesheet" media="print" href="${ASSET_ORIGIN}static/frontend/css/print.css">
   				<style>
-					@keyframes show-me {
+					@keyframes bork-fcp-show-me {
 						to {
 							opacity: 1;
 						}


### PR DESCRIPTION
_n.b. relies on #7639..._

## What does this change?

Enables synthetically delaying rendering of a page by adding a `#bork-fcp-xxx` hash flag, where `xxx` is the time in ms by which to delay showing the body.

## Why?

This will allow us to test various FCP slowdowns