### PR TITLE
fix: Fix cypress not being able to find manage cookies button after CMP update

### DIFF
--- a/dotcom-rendering/cypress/e2e/parallel-5/atom.video.cy.js
+++ b/dotcom-rendering/cypress/e2e/parallel-5/atom.video.cy.js
@@ -119,7 +119,7 @@ describe('YouTube Atom', function () {
 			'/Article/https://www.theguardian.com/uk-news/2020/dec/04/edinburgh-hit-by-thundersnow-as-sonic-boom-wakes-residents',
 		);
 		cmpIframe().contains("It's your choice");
-		cmpIframe().find("[title='Manage my cookies']").click();
+		cmpIframe().find("[title='Manage or reject cookies']").click();
 		privacySettingsIframe().contains('Privacy settings');
 		privacySettingsIframe()
 			.find("[title='Accept all']", { timeout: 12000 })
@@ -169,7 +169,7 @@ describe('YouTube Atom', function () {
 			'/Article/https://www.theguardian.com/environment/2021/oct/05/volcanoes-are-life-how-the-ocean-is-enriched-by-eruptions-devastating-on-land',
 		);
 		cmpIframe().contains("It's your choice");
-		cmpIframe().find("[title='Manage my cookies']").click();
+		cmpIframe().find("[title='Manage or reject cookies']").click();
 		privacySettingsIframe().contains('Privacy settings');
 		privacySettingsIframe()
 			.find("[title='Accept all']", { timeout: 12000 })
@@ -216,7 +216,7 @@ describe('YouTube Atom', function () {
 			'/Article/https://www.theguardian.com/world/live/2022/mar/28/russia-ukraine-war-latest-news-zelenskiy-putin-live-updates?dcr=true',
 		);
 		cmpIframe().contains("It's your choice");
-		cmpIframe().find("[title='Manage my cookies']").click();
+		cmpIframe().find("[title='Manage or reject cookies']").click();
 		privacySettingsIframe().contains('Privacy settings');
 		privacySettingsIframe()
 			.find("[title='Accept all']", { timeout: 12000 })
@@ -322,7 +322,7 @@ describe('YouTube Atom', function () {
 			'/Article/https://www.theguardian.com/environment/2021/oct/05/volcanoes-are-life-how-the-ocean-is-enriched-by-eruptions-devastating-on-land',
 		);
 		cmpIframe().contains("It's your choice");
-		cmpIframe().find("[title='Manage my cookies']").click();
+		cmpIframe().find("[title='Manage or reject cookies']").click();
 		privacySettingsIframe().contains('Privacy settings');
 		privacySettingsIframe()
 			.find("[title='Reject all']", { timeout: 12000 })
@@ -369,7 +369,7 @@ describe('YouTube Atom', function () {
 			'/Article/https://www.theguardian.com/world/live/2022/mar/28/russia-ukraine-war-latest-news-zelenskiy-putin-live-updates?dcr=true',
 		);
 		cmpIframe().contains("It's your choice");
-		cmpIframe().find("[title='Manage my cookies']").click();
+		cmpIframe().find("[title='Manage or reject cookies']").click();
 		privacySettingsIframe().contains('Privacy settings');
 		privacySettingsIframe()
 			.find("[title='Accept all']", { timeout: 12000 })

--- a/dotcom-rendering/cypress/e2e/parallel-6/commercial.cy.js
+++ b/dotcom-rendering/cypress/e2e/parallel-6/commercial.cy.js
@@ -16,7 +16,7 @@ describe('Commercial E2E tests', function () {
 		);
 
 		cmpIframe().contains("It's your choice");
-		cmpIframe().find("[title='Manage my cookies']").click();
+		cmpIframe().find("[title='Manage or reject cookies']").click();
 		privacySettingsIframe().contains('Privacy settings');
 		privacySettingsIframe()
 			.find("[title='Accept all']", { timeout: 12000 })

--- a/dotcom-rendering/cypress/e2e/parallel-6/consent.cy.js
+++ b/dotcom-rendering/cypress/e2e/parallel-6/consent.cy.js
@@ -18,7 +18,7 @@ describe('Consent tests', function () {
 		cy.window().its('ga').should('not.exist');
 		// Open the Privacy setting dialogue
 		cmpIframe().contains("It's your choice");
-		cmpIframe().find("[title='Manage my cookies']").click();
+		cmpIframe().find("[title='Manage or reject cookies']").click();
 		// Accept tracking cookies
 		privacySettingsIframe().contains('Privacy settings');
 		privacySettingsIframe().find("[title='Accept all']").click();
@@ -40,7 +40,7 @@ describe('Consent tests', function () {
 		cy.window().its('ga').should('not.exist');
 		// Open the Privacy setting dialogue
 		cmpIframe().contains("It's your choice");
-		cmpIframe().find("[title='Manage my cookies']").click();
+		cmpIframe().find("[title='Manage or reject cookies']").click();
 		// Reject tracking cookies
 		privacySettingsIframe().contains('Privacy settings');
 		privacySettingsIframe().find("[title='Reject all']").click();

--- a/dotcom-rendering/cypress/e2e/parallel-6/paid.content.cy.js
+++ b/dotcom-rendering/cypress/e2e/parallel-6/paid.content.cy.js
@@ -18,7 +18,7 @@ describe('Paid content tests', function () {
 
 		// Open the Privacy setting dialogue
 		cmpIframe().contains("It's your choice");
-		cmpIframe().find("[title='Manage my cookies']").click();
+		cmpIframe().find("[title='Manage or reject cookies']").click();
 
 		// Accept tracking cookies
 		privacySettingsIframe().contains('Privacy settings');
@@ -59,7 +59,7 @@ describe('Paid content tests', function () {
 
 		// Open the Privacy setting dialogue
 		cmpIframe().contains("It's your choice");
-		cmpIframe().find("[title='Manage my cookies']").click();
+		cmpIframe().find("[title='Manage or reject cookies']").click();
 
 		// Accept tracking cookies
 		privacySettingsIframe().contains('Privacy settings');


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

The text on the "Manage my cookies" button in the CMP banner was changed to "Manage or reject cookies"

We've replaced the lookup for text with a lookup for a class name which we believe might be more stable than the button text.

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->


<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
