### PR TITLE
fix: Use classname to target CMP Manage cookies button instead of button text

### DIFF
--- a/dotcom-rendering/cypress/e2e/parallel-5/atom.video.cy.js
+++ b/dotcom-rendering/cypress/e2e/parallel-5/atom.video.cy.js
@@ -119,7 +119,7 @@ describe('YouTube Atom', function () {
 			'/Article/https://www.theguardian.com/uk-news/2020/dec/04/edinburgh-hit-by-thundersnow-as-sonic-boom-wakes-residents',
 		);
 		cmpIframe().contains("It's your choice");
-		cmpIframe().find("[title='Manage my cookies']").click();
+		cmpIframe().find('button.sp_choice_type_12').click();
 		privacySettingsIframe().contains('Privacy settings');
 		privacySettingsIframe()
 			.find("[title='Accept all']", { timeout: 12000 })
@@ -169,7 +169,7 @@ describe('YouTube Atom', function () {
 			'/Article/https://www.theguardian.com/environment/2021/oct/05/volcanoes-are-life-how-the-ocean-is-enriched-by-eruptions-devastating-on-land',
 		);
 		cmpIframe().contains("It's your choice");
-		cmpIframe().find("[title='Manage my cookies']").click();
+		cmpIframe().find('button.sp_choice_type_12').click();
 		privacySettingsIframe().contains('Privacy settings');
 		privacySettingsIframe()
 			.find("[title='Accept all']", { timeout: 12000 })
@@ -216,7 +216,7 @@ describe('YouTube Atom', function () {
 			'/Article/https://www.theguardian.com/world/live/2022/mar/28/russia-ukraine-war-latest-news-zelenskiy-putin-live-updates?dcr=true',
 		);
 		cmpIframe().contains("It's your choice");
-		cmpIframe().find("[title='Manage my cookies']").click();
+		cmpIframe().find('button.sp_choice_type_12').click();
 		privacySettingsIframe().contains('Privacy settings');
 		privacySettingsIframe()
 			.find("[title='Accept all']", { timeout: 12000 })
@@ -322,7 +322,7 @@ describe('YouTube Atom', function () {
 			'/Article/https://www.theguardian.com/environment/2021/oct/05/volcanoes-are-life-how-the-ocean-is-enriched-by-eruptions-devastating-on-land',
 		);
 		cmpIframe().contains("It's your choice");
-		cmpIframe().find("[title='Manage my cookies']").click();
+		cmpIframe().find('button.sp_choice_type_12').click();
 		privacySettingsIframe().contains('Privacy settings');
 		privacySettingsIframe()
 			.find("[title='Reject all']", { timeout: 12000 })
@@ -369,7 +369,7 @@ describe('YouTube Atom', function () {
 			'/Article/https://www.theguardian.com/world/live/2022/mar/28/russia-ukraine-war-latest-news-zelenskiy-putin-live-updates?dcr=true',
 		);
 		cmpIframe().contains("It's your choice");
-		cmpIframe().find("[title='Manage my cookies']").click();
+		cmpIframe().find('button.sp_choice_type_12').click();
 		privacySettingsIframe().contains('Privacy settings');
 		privacySettingsIframe()
 			.find("[title='Accept all']", { timeout: 12000 })

--- a/dotcom-rendering/cypress/e2e/parallel-6/commercial.cy.js
+++ b/dotcom-rendering/cypress/e2e/parallel-6/commercial.cy.js
@@ -16,7 +16,7 @@ describe('Commercial E2E tests', function () {
 		);
 
 		cmpIframe().contains("It's your choice");
-		cmpIframe().find("[title='Manage my cookies']").click();
+		cmpIframe().find('button.sp_choice_type_12').click();
 		privacySettingsIframe().contains('Privacy settings');
 		privacySettingsIframe()
 			.find("[title='Accept all']", { timeout: 12000 })

--- a/dotcom-rendering/cypress/e2e/parallel-6/consent.cy.js
+++ b/dotcom-rendering/cypress/e2e/parallel-6/consent.cy.js
@@ -18,7 +18,7 @@ describe('Consent tests', function () {
 		cy.window().its('ga').should('not.exist');
 		// Open the Privacy setting dialogue
 		cmpIframe().contains("It's your choice");
-		cmpIframe().find("[title='Manage my cookies']").click();
+		cmpIframe().find('button.sp_choice_type_12').click();
 		// Accept tracking cookies
 		privacySettingsIframe().contains('Privacy settings');
 		privacySettingsIframe().find("[title='Accept all']").click();
@@ -40,7 +40,7 @@ describe('Consent tests', function () {
 		cy.window().its('ga').should('not.exist');
 		// Open the Privacy setting dialogue
 		cmpIframe().contains("It's your choice");
-		cmpIframe().find("[title='Manage my cookies']").click();
+		cmpIframe().find('button.sp_choice_type_12').click();
 		// Reject tracking cookies
 		privacySettingsIframe().contains('Privacy settings');
 		privacySettingsIframe().find("[title='Reject all']").click();

--- a/dotcom-rendering/cypress/e2e/parallel-6/paid.content.cy.js
+++ b/dotcom-rendering/cypress/e2e/parallel-6/paid.content.cy.js
@@ -18,7 +18,7 @@ describe('Paid content tests', function () {
 
 		// Open the Privacy setting dialogue
 		cmpIframe().contains("It's your choice");
-		cmpIframe().find("[title='Manage my cookies']").click();
+		cmpIframe().find('button.sp_choice_type_12').click();
 
 		// Accept tracking cookies
 		privacySettingsIframe().contains('Privacy settings');
@@ -59,7 +59,7 @@ describe('Paid content tests', function () {
 
 		// Open the Privacy setting dialogue
 		cmpIframe().contains("It's your choice");
-		cmpIframe().find("[title='Manage my cookies']").click();
+		cmpIframe().find('button.sp_choice_type_12').click();
 
 		// Accept tracking cookies
 		privacySettingsIframe().contains('Privacy settings');


### PR DESCRIPTION
## What does this change?

Alternative to https://github.com/guardian/dotcom-rendering/pull/7647 using CSS classnames to target the Manage cookies.

## Why?

The CSS classname seems like it might be a bit more stable than the button text. Commercial also uses this approach: https://github.com/guardian/commercial/blob/ec551e696cf9a73de6e3e51e414bb0f910fd56f8/e2e/cypress/support/commands.ts#L33-L58
