### PR TITLE
BlockquoteBlockComponentAdd support for H2, S & I

### DIFF
--- a/dotcom-rendering/src/web/components/BlockquoteBlockComponent.tsx
+++ b/dotcom-rendering/src/web/components/BlockquoteBlockComponent.tsx
@@ -103,6 +103,7 @@ const textElement =
 			case '#text':
 			case 'SPAN':
 				return text;
+			case 'H2':
 			case 'B':
 			case 'EM':
 			case 'BR':
@@ -112,6 +113,8 @@ const textElement =
 			case 'MARK':
 			case 'SUB':
 			case 'SUP':
+			case 'S':
+			case 'I':
 				return jsx(node.nodeName, {
 					key,
 					children,


### PR DESCRIPTION
Adds some elements we've seen being used by CAPI that we don't currently support:

<img width="1375" alt="image" src="https://user-images.githubusercontent.com/9575458/235143776-c9ef282e-6d9a-410e-8dd6-311f5b5e10f4.png">
