### PR TITLE
fix: Hydrate client side only islands correctly

### DIFF
--- a/dotcom-rendering/src/web/browser/islands/doHydration.tsx
+++ b/dotcom-rendering/src/web/browser/islands/doHydration.tsx
@@ -39,7 +39,9 @@ export const doHydration = async (
 		.then((module) => {
 			/** The duration of importing the module for this island */
 			const importDuration = importEnd();
-			const clientOnly = element.getAttribute('clientOnly') === 'true';
+			const clientOnly =
+				element.hasAttribute('clientonly') &&
+				element.getAttribute('clientonly') !== 'false';
 
 			const { start: islandStart, end: islandEnd } = initPerf(
 				`island-${name}`,


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Check if the clientside attribute is present, not just if the value is "true"  when hydrating islands. This fixes clientside only islands looking really weird because we weren't removing the placeholder CSS when they get hydrated.

## Why?

Looks like the React 18 upgrade has caused boolean attributes to be rendered differently. The value `true` is rendered as `<gu-island clientside>` instead of `<gu-island clientside="true">`

Technically React isn't doing anything wrong, this is valid HTML syntax, if you want to represent a boolean value its usually perfectly valid to just have an attribute with no value. https://developer.mozilla.org/en-US/docs/Glossary/Boolean/HTML 
