### PR TITLE
Rerun Chromatic against AR on push when `run_chromatic` label present

### DIFF
--- a/.github/workflows/ar-chromatic.yml
+++ b/.github/workflows/ar-chromatic.yml
@@ -40,7 +40,7 @@ jobs:
         # pushing to `main`. Skip if this is a Dependabot PR as this is handled
         # by the subsequent job.
         if: |
-          (github.event.label.name == 'run_chromatic' ||  github.ref == 'refs/heads/main') &&
+          (contains(github.event.pull_request.labels.*.name, 'run_chromatic') ||  github.ref == 'refs/heads/main') &&
           (!contains(github.event.pull_request.labels.*.name, 'dependencies') &&
           github.event.pull_request.user.login != 'dependabot')
         with:


### PR DESCRIPTION
## What does this change?

- Updates the AR Chromatic action so that Chromatic is run when the `run_chromatic` label is first applied _and_ on subsequent pushes.

## Why?

- #7576 updated the AR and DCR actions so that Chromatic only runs when the `run_chromatic` label has been applied in order to minimise the creation of unnecessary Chromatic snapshots.
- To improve the developer experience the behaviour was tweaked to match that of the CSNX repo so that subsequent pushes to a branch would also trigger a Chromatic run once the label had been added. Prior to this change you would have to remove and add the label again in order to run Chromatic again. This tweak was only applied to the DCR action so AR still requires removing and adding the label. This small change ensures consistent behaviour for AR and DCR.