### PR TITLE
Bork FCP: set body to _almost_ transparent

### DIFF
--- a/dotcom-rendering/src/web/server/pageTemplate.ts
+++ b/dotcom-rendering/src/web/server/pageTemplate.ts
@@ -360,7 +360,7 @@ https://workforus.theguardian.com/careers/product-engineering/
 						}
 					}
   					html.bork-fcp body {
-						opacity: 0;
+						opacity: 0.001;
 						animation-duration: var(--bork-fcp-amount);
 						animation-name: bork-fcp-paint;
 						animation-timing-function: steps(1);


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

set the body to not-quite-zero opacity when artificially increasing FCP (see #7641).

## Why?

CWV vitals measurements break if it thinks _nothing_ has been painted. this seems to be enough for it to run as normal, but I (at least) see the same effect.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| <img width="231" alt="image" src="https://user-images.githubusercontent.com/867233/236455843-6dffed72-f45e-44ae-b74d-6db3a9e3e774.png"> | <img width="229" alt="image" src="https://user-images.githubusercontent.com/867233/236456649-9295fe76-f9ea-4fc7-a3d8-49f60cd305db.png"> |



<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
