### PR TITLE
feat: Record JSON parse, Enhance, and Render times in Request logger

### DIFF
--- a/dotcom-rendering/src/server/index.article.amp.tsx
+++ b/dotcom-rendering/src/server/index.article.amp.tsx
@@ -11,13 +11,18 @@ import { extractScripts } from '../lib/scripts.amp';
 import { findBySubsection } from '../model/article-sections';
 import { extractNAV } from '../model/extract-nav';
 import { validateAsArticleType } from '../model/validate';
-import { recordTypeAndPlatform } from '../server/lib/logging-store';
+import {
+	recordTimeStart,
+	recordTimeStop,
+	recordTypeAndPlatform,
+} from '../server/lib/logging-store';
 import { getAmpExperimentCache } from './AMPExperimentCache.amp';
 import { renderArticle } from './render.article.amp';
 
 export const handleAMPArticle: RequestHandler = ({ body }, res, next) => {
 	(async () => {
 		recordTypeAndPlatform('article', 'amp');
+		recordTimeStart('enhance');
 		const article = validateAsArticleType(body);
 		const { linkedData } = article;
 		const { config } = article;
@@ -66,7 +71,8 @@ export const handleAMPArticle: RequestHandler = ({ body }, res, next) => {
 			description: article.trailText,
 			canonicalURL: article.webURL,
 		};
-
+		recordTimeStop('enhance');
+		recordTimeStart('render');
 		const resp = renderArticle({
 			linkedData,
 			scripts,
@@ -83,6 +89,7 @@ export const handleAMPArticle: RequestHandler = ({ body }, res, next) => {
 				/>
 			),
 		});
+		recordTimeStop('render');
 
 		res.status(200).send(resp);
 	})().catch(next);

--- a/dotcom-rendering/src/server/index.article.apps.ts
+++ b/dotcom-rendering/src/server/index.article.apps.ts
@@ -1,13 +1,21 @@
 import type { RequestHandler } from 'express';
-import { recordTypeAndPlatform } from '../server/lib/logging-store';
+import {
+	recordTimeStart,
+	recordTimeStop,
+	recordTypeAndPlatform,
+} from '../server/lib/logging-store';
 import { enhanceArticleType } from './index.article.web';
 import { makePrefetchHeader } from './lib/header';
 import { renderArticle } from './render.article.apps';
 
 export const handleAppsArticle: RequestHandler = ({ body }, res) => {
 	recordTypeAndPlatform('article', 'apps');
+	recordTimeStart('enhance');
 	const article = enhanceArticleType(body);
+	recordTimeStop('enhance');
+	recordTimeStart('render');
 	const { html, clientScripts } = renderArticle(article);
+	recordTimeStop('render');
 
 	// The Android app will cache these assets to enable offline reading
 	res.set('Link', makePrefetchHeader(clientScripts)).send(html);

--- a/dotcom-rendering/src/server/index.front.web.ts
+++ b/dotcom-rendering/src/server/index.front.web.ts
@@ -10,7 +10,11 @@ import { groupTrailsByDates } from '../model/groupTrailsByDates';
 import { injectMpuIntoGroupedTrails } from '../model/injectMpuIntoGroupedTrails';
 import { getSpeedFromTrails } from '../model/slowOrFastByTrails';
 import { validateAsFrontType, validateAsTagFrontType } from '../model/validate';
-import { recordTypeAndPlatform } from '../server/lib/logging-store';
+import {
+	recordTimeStart,
+	recordTimeStop,
+	recordTypeAndPlatform,
+} from '../server/lib/logging-store';
 import type { DCRFrontType, FEFrontType } from '../types/front';
 import type { DCRTagFrontType, FETagFrontType } from '../types/tagFront';
 import { makePrefetchHeader } from './lib/header';
@@ -91,10 +95,14 @@ const enhanceTagFront = (body: unknown): DCRTagFrontType => {
 
 export const handleFront: RequestHandler = ({ body }, res) => {
 	recordTypeAndPlatform('front');
+	recordTimeStart('enhance');
 	const front = enhanceFront(body);
+	recordTimeStop('enhance');
+	recordTimeStart('render');
 	const { html, clientScripts } = renderFront({
 		front,
 	});
+	recordTimeStop('render');
 	res.status(200).set('Link', makePrefetchHeader(clientScripts)).send(html);
 };
 
@@ -104,10 +112,14 @@ export const handleFrontJson: RequestHandler = ({ body }, res) => {
 
 export const handleTagFront: RequestHandler = ({ body }, res) => {
 	recordTypeAndPlatform('tagFront');
+	recordTimeStart('enhance');
 	const tagFront = enhanceTagFront(body);
+	recordTimeStop('enhance');
+	recordTimeStart('render');
 	const { html, clientScripts } = renderTagFront({
 		tagFront,
 	});
+	recordTimeStop('render');
 	res.status(200).set('Link', makePrefetchHeader(clientScripts)).send(html);
 };
 

--- a/dotcom-rendering/src/server/lib/logging-middleware.ts
+++ b/dotcom-rendering/src/server/lib/logging-middleware.ts
@@ -42,7 +42,7 @@ export const loggingStoreMiddleware: RequestHandler = (req, res, next) => {
 			method: req.method,
 		},
 		timing: {
-			total: Date.now(),
+			total: performance.now(),
 		},
 	};
 

--- a/dotcom-rendering/src/server/lib/logging-middleware.ts
+++ b/dotcom-rendering/src/server/lib/logging-middleware.ts
@@ -42,7 +42,9 @@ export const loggingStoreMiddleware: RequestHandler = (req, res, next) => {
 			method: req.method,
 		},
 		timing: {
-			total: performance.now(),
+			total: {
+				start: performance.now(),
+			},
 		},
 	};
 

--- a/dotcom-rendering/src/server/lib/logging-middleware.ts
+++ b/dotcom-rendering/src/server/lib/logging-middleware.ts
@@ -25,7 +25,9 @@ export const timedExpressJsonMiddleware: RequestHandler = (req, res, next) => {
 	recordTimeStart('json');
 
 	// Pass a wrapper around Express's next() callback which record when expressJsonMiddleware calls next()
+	logger.info('Checkpoint 3');
 	expressJsonMiddleware(req, res, () => {
+		logger.info('Checkpoint 4');
 		recordTimeStop('json');
 		next();
 	});
@@ -48,9 +50,12 @@ export const loggingStoreMiddleware: RequestHandler = (req, res, next) => {
 		},
 	};
 
-	loggingStore.run(loggerState, () => {
-		next();
-	});
+	logger.info('Checkpoint 1');
+
+	// loggingStore.run(loggerState, () => {
+	logger.info('Checkpoint 2');
+	next();
+	// });
 };
 
 /**
@@ -59,8 +64,10 @@ export const loggingStoreMiddleware: RequestHandler = (req, res, next) => {
 export const requestLoggerMiddleware: RequestHandler = (req, res, next) => {
 	// We don't have access to the page ID until after the express.json() middleware runs.
 	recordPageId(hasPageId(req.body) ? req.body.pageId : 'no-page-id-found');
+	logger.info('Checkpoint 5');
 
 	res.on('finish', () => {
+		logger.info('Checkpoint 6');
 		recordTimeStop('total');
 
 		logger.info('Rendered page', {

--- a/dotcom-rendering/src/server/lib/logging-middleware.ts
+++ b/dotcom-rendering/src/server/lib/logging-middleware.ts
@@ -1,6 +1,12 @@
 import type { RequestHandler } from 'express';
+import express from 'express';
 import { logger } from './logging';
-import { loggingStore } from './logging-store';
+import {
+	loggingStore,
+	recordPageId,
+	recordTimeStart,
+	recordTimeStop,
+} from './logging-store';
 
 const hasPageId = (body: unknown): body is { pageId: string } => {
 	return (
@@ -12,38 +18,56 @@ const hasPageId = (body: unknown): body is { pageId: string } => {
 };
 
 /**
- * An Express middleware which handles creating our logger store and logging requests after they've
- * completed.
+ * An Express middleware which wraps the inbuilt json() body-parser middleware to record execution time.
  */
-export const requestLoggerMiddleware: RequestHandler = (req, res, next) => {
+const expressJsonMiddleware = express.json();
+export const timedExpressJsonMiddleware: RequestHandler = (req, res, next) => {
+	recordTimeStart('json');
+
+	// Pass a wrapper around Express's next() callback which record when expressJsonMiddleware calls next()
+	expressJsonMiddleware(req, res, () => {
+		recordTimeStop('json');
+		next();
+	});
+};
+
+/**
+ * An Express middleware which handles creating a logger store to save information to be logged in the request logger.
+ */
+export const loggingStoreMiddleware: RequestHandler = (req, res, next) => {
 	const loggerState = {
 		request: {
-			pageId: hasPageId(req.body) ? req.body.pageId : 'no-page-id-found',
+			pageId: 'before-request-logger-middleware',
 			path: req.path,
 			method: req.method,
 		},
-		timing: {},
+		timing: {
+			total: Date.now(),
+		},
 	};
 
-	res.on('finish', () => {
-		const { request, error } = loggingStore.getStore() ?? {};
+	loggingStore.run(loggerState, () => {
+		next();
+	});
+};
 
-		if (!request?.type) return;
+/**
+ * An Express middleware which handles logging requests and their associated details after they have been completed.
+ */
+export const requestLoggerMiddleware: RequestHandler = (req, res, next) => {
+	// We don't have access to the page ID until after the express.json() middleware runs.
+	recordPageId(hasPageId(req.body) ? req.body.pageId : 'no-page-id-found');
+
+	res.on('finish', () => {
+		recordTimeStop('total');
 
 		logger.info('Rendered page', {
 			response: {
 				status: res.statusCode,
 			},
-			// Anything could extend the error type and have all sorts of fields.
-			// We should be explicit in which fields we're looking for.
-			error: {
-				message: error?.message,
-				stack: error?.stack,
-			},
+			...loggingStore.getStore(),
 		});
 	});
 
-	loggingStore.run(loggerState, () => {
-		next();
-	});
+	next();
 };

--- a/dotcom-rendering/src/server/lib/logging-store.ts
+++ b/dotcom-rendering/src/server/lib/logging-store.ts
@@ -19,6 +19,7 @@ type DCRLoggingStore = {
 		type?: string;
 		platform?: string;
 	};
+	timing: { [key: string]: number };
 	error?: {
 		message?: string;
 		stack?: string;
@@ -36,6 +37,32 @@ export const recordTypeAndPlatform = (
 	if (request) {
 		request.type = type;
 		request.platform = platform;
+	}
+};
+
+export const recordPageId = (pageId: string): void => {
+	const { request } = loggingStore.getStore() ?? {};
+
+	if (request) {
+		request.pageId = pageId;
+	}
+};
+
+type RecordablePeriod = 'total' | 'json' | 'enhance' | 'render';
+
+export const recordTimeStart = (metric: RecordablePeriod): void => {
+	const { timing } = loggingStore.getStore() ?? {};
+
+	if (timing) {
+		timing[metric] = Date.now();
+	}
+};
+
+export const recordTimeStop = (metric: RecordablePeriod): void => {
+	const { timing } = loggingStore.getStore() ?? {};
+
+	if (timing) {
+		timing[metric] = timing[metric] ?? 0 - Date.now();
 	}
 };
 

--- a/dotcom-rendering/src/server/lib/logging-store.ts
+++ b/dotcom-rendering/src/server/lib/logging-store.ts
@@ -57,7 +57,7 @@ export const recordTimeStart = (metric: RecordablePeriod): void => {
 
 	if (timing) {
 		timing[metric] = {
-			start: performance.now(),
+			start: Date.now(),
 		};
 	}
 };
@@ -67,8 +67,8 @@ export const recordTimeStop = (metric: RecordablePeriod): void => {
 	const time = timing?.[metric];
 
 	if (time) {
-		time.stop = performance.now();
-		time.duration = time.start - time.stop;
+		time.stop = Date.now();
+		time.duration = time.stop - time.start;
 	}
 };
 

--- a/dotcom-rendering/src/server/lib/logging-store.ts
+++ b/dotcom-rendering/src/server/lib/logging-store.ts
@@ -54,7 +54,7 @@ export const recordTimeStart = (metric: RecordablePeriod): void => {
 	const { timing } = loggingStore.getStore() ?? {};
 
 	if (timing) {
-		timing[metric] = Date.now();
+		timing[metric] = performance.now();
 	}
 };
 
@@ -62,7 +62,7 @@ export const recordTimeStop = (metric: RecordablePeriod): void => {
 	const { timing } = loggingStore.getStore() ?? {};
 
 	if (timing) {
-		timing[metric] = timing[metric] ?? 0 - Date.now();
+		timing[metric] = timing[metric] ?? 0 - performance.now();
 	}
 };
 

--- a/dotcom-rendering/src/server/lib/logging-store.ts
+++ b/dotcom-rendering/src/server/lib/logging-store.ts
@@ -19,7 +19,9 @@ type DCRLoggingStore = {
 		type?: string;
 		platform?: string;
 	};
-	timing: { [key: string]: number };
+	timing: {
+		[key: string]: { start: number; stop?: number; duration?: number };
+	};
 	error?: {
 		message?: string;
 		stack?: string;
@@ -54,15 +56,19 @@ export const recordTimeStart = (metric: RecordablePeriod): void => {
 	const { timing } = loggingStore.getStore() ?? {};
 
 	if (timing) {
-		timing[metric] = performance.now();
+		timing[metric] = {
+			start: performance.now(),
+		};
 	}
 };
 
 export const recordTimeStop = (metric: RecordablePeriod): void => {
 	const { timing } = loggingStore.getStore() ?? {};
+	const time = timing?.[metric];
 
-	if (timing) {
-		timing[metric] = timing[metric] ?? 0 - performance.now();
+	if (time) {
+		time.stop = performance.now();
+		time.duration = time.start - time.stop;
 	}
 };
 

--- a/dotcom-rendering/src/server/prod-server.ts
+++ b/dotcom-rendering/src/server/prod-server.ts
@@ -37,6 +37,16 @@ export const prodServer = (): void => {
 
 	const app = express();
 
+	/**
+	 * The order of these middleware is important for correctly collecting statistics
+	 *
+	 * - loggingStoreMiddleware needs to be the first middleware to run in order to
+	 *   setup the logging store before timedExpressJsonMiddleware and to record when
+	 *   the request has started.
+	 *
+	 * - requestLoggerMiddleware needs access to the parsed request body meaning it
+	 *	 has to run after the timedExpressJsonMiddleware
+	 */
 	app.use(loggingStoreMiddleware);
 	app.use(timedExpressJsonMiddleware);
 	app.use(requestLoggerMiddleware);


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Adds timing metrics to our request logger. This will tell us how long DCR spends on Parsing JSON, Enhancing Data, and Rendering (seperately).

## Why?

For the fronts migration we're particularly interested in seeing how long it takes for DCR to parse the JSON payload it receives. Fronts payloads are pretty massive so we want to know how long it takes to parse.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
