### PR TITLE
remove flexbox fallback for ie11

### DIFF
--- a/dotcom-rendering/src/web/components/MainMedia.tsx
+++ b/dotcom-rendering/src/web/components/MainMedia.tsx
@@ -8,13 +8,6 @@ import { RenderArticleElement } from '../lib/renderElement';
 
 const mainMedia = css`
 	height: 100%;
-	min-height: 1px;
-	/*
-    Thank you IE11, broken in stasis for all eternity.
-
-    https://github.com/philipwalton/flexbugs/issues/75#issuecomment-161800607
-    */
-
 	${until.tablet} {
 		margin: 0;
 		order: 2;


### PR DESCRIPTION
## What does this change?

- Removes a flexbox fallback for IE 11 in `MainMedia` as we no longer support IE 11


## Why?

Tidying up