### PR TITLE
Dependabot: ignore @types/node major & minor

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,6 +30,11 @@ updates:
         - dependency-name: 'aws-cdk'
         - dependency-name: 'aws-cdk-lib'
         - dependency-name: 'constructs'
+        # Types should match major and minor versions of the package being used.
+        - dependency-name: "@types/node"
+          update-types:
+            - "version-update:semver-major"
+            - "version-update:semver-minor"
       open-pull-requests-limit: 7
     - package-ecosystem: 'github-actions'
       directory: '/'


### PR DESCRIPTION
For DefinitelyTyped types, the major and minor versions of the type package should match the major and minor versions of the package being typed. Dependabot knows this for packages where the main package is installed via npm, but it doesn't know this for node itself.

This should stop Dependabot from raising unneeded PRs for `@types/node` in `/apps-rendering`.
