### PR TITLE
Remove `ad` from the most viewed container attribute

### DIFF
--- a/dotcom-rendering/src/web/components/MostViewedRightWithAd.tsx
+++ b/dotcom-rendering/src/web/components/MostViewedRightWithAd.tsx
@@ -22,7 +22,7 @@ export const MostViewedRightWithAd = ({
 	renderAds,
 	shouldHideReaderRevenue,
 }: Props) => {
-	const componentDataAttribute = 'most-viewed-right-with-ad';
+	const componentDataAttribute = 'most-viewed-right-container';
 	return (
 		<div
 			// This attribute is necessary so that most viewed wrapper


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Change the attribute we use to measure the most viewed and right ad container, from `most-viewed-right-with-ad` to `most-viewed-right-container`.

## Why?

It's possible including `ad` in the attribute is causing the container to be removed by certain ad-blockers.
