### PR TITLE
add favicon and title to dev server index

### DIFF
--- a/dotcom-rendering/src/server/dev-index.html
+++ b/dotcom-rendering/src/server/dev-index.html
@@ -1,6 +1,11 @@
 <!DOCTYPE html>
 <html>
 	<head>
+		<link
+			rel="icon"
+			href="https://static.guim.co.uk/images/favicon-32x32-dev-yellow.ico"
+		/>
+		<title>DCR Development Server</title>
 		<style>
 			html {
 				font-family: Arial, Helvetica, sans-serif;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

- Adds a title to the dev server index
- Adds a favicon to the dev server index. This prevents the dev server erroring when the browser requests `/favicon.ico`

## Screenshots

<img width="265" alt="image" src="https://user-images.githubusercontent.com/705427/237061196-670b8203-c460-4304-8858-08a2d1c5f722.png">
