### PR TITLE
Transform static-secure to static to fix broken image

### DIFF
--- a/dotcom-rendering/src/web/components/Picture.tsx
+++ b/dotcom-rendering/src/web/components/Picture.tsx
@@ -162,6 +162,12 @@ const decideImageWidths = ({
 	}
 };
 
+const getServiceFromUrl = (url: URL): string => {
+	const serviceName = url.hostname.split('.')[0] ?? '';
+	if (serviceName === 'static-secure') return 'static';
+	else return serviceName;
+};
+
 /**
  * Generates a URL for calling the Fastly Image Optimiser.
  *
@@ -183,10 +189,6 @@ const generateImageURL = ({
 	// In CODE, we do not generate optimised replacement images
 	if (url.hostname === 's3-eu-west-1.amazonaws.com') return url.href;
 
-	const parts = url.hostname.split('.');
-	//should convert static-secure to static
-	const service = parts[0] === 'static-secure' ? 'static' : parts[0] ?? '';
-
 	const params = new URLSearchParams({
 		width: imageWidth.toString(),
 		// Why 45 and 85?
@@ -199,7 +201,7 @@ const generateImageURL = ({
 		s: 'none',
 	});
 
-	return `https://i.guim.co.uk/img/${service}${
+	return `https://i.guim.co.uk/img/${getServiceFromUrl(url)}${
 		url.pathname
 	}?${params.toString()}`;
 };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
This transforms the url from 'static-secure' to 'static' to fix broken images as in frontend
## Why?
Parity with frontend.

![image](https://github.com/guardian/dotcom-rendering/assets/110032454/da68c063-0f19-4a13-8f88-234e26aaf3bb)


## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/110032454/449a6203-f261-4c4d-ba9a-24271ea3a17a
[after]: https://github.com/guardian/dotcom-rendering/assets/110032454/83ef0980-b1d7-45c6-ad53-b09c5ccd96ed

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
