### PR TITLE
Don't add merchandising slots for DCR network fronts in the fronts banner test

### DIFF
--- a/dotcom-rendering/src/web/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FrontLayout.tsx
@@ -70,19 +70,22 @@ const decideAdSlot = (
 	isPaidContent: boolean | undefined,
 	format: ArticleDisplay,
 	mobileAdPositions: (number | undefined)[],
+	isInFrontsBannerTest: boolean,
 ) => {
 	const minContainers = isPaidContent ? 1 : 2;
 	if (
 		collectionCount > minContainers &&
 		index === getMerchHighPosition(collectionCount, isNetworkFront)
 	) {
-		return (
-			<AdSlot
-				data-print-layout="hide"
-				position="merchandising-high"
-				display={format}
-			/>
-		);
+		if (!(isInFrontsBannerTest && isNetworkFront)) {
+			return (
+				<AdSlot
+					data-print-layout="hide"
+					position="merchandising-high"
+					display={format}
+				/>
+			);
+		}
 	} else if (mobileAdPositions.includes(index)) {
 		return (
 			<Hide from="tablet">
@@ -118,6 +121,9 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 
 	const isInEuropeTest =
 		front.config.abTests.europeNetworkFrontVariant === 'variant';
+
+	const isInFrontsBannerTest =
+		front.config.abTests.frontsBannerAdsVariant === 'variant';
 
 	const format = {
 		display: ArticleDisplay.Standard,
@@ -276,6 +282,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 										.isPaidContent,
 									format.display,
 									mobileAdPositions,
+									isInFrontsBannerTest,
 								)}
 							</>
 						);
@@ -327,6 +334,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 										.isPaidContent,
 									format.display,
 									mobileAdPositions,
+									isInFrontsBannerTest,
 								)}
 							</>
 						);
@@ -397,6 +405,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 										.isPaidContent,
 									format.display,
 									mobileAdPositions,
+									isInFrontsBannerTest,
 								)}
 						</>
 					);
@@ -418,7 +427,9 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 				backgroundColour={neutral[93]}
 				element="aside"
 			>
-				<AdSlot position="merchandising" display={format.display} />
+				{!(isInFrontsBannerTest && front.isNetworkFront) && (
+					<AdSlot position="merchandising" display={format.display} />
+				)}
 			</Section>
 
 			{NAV.subNavSections && (

--- a/dotcom-rendering/src/web/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FrontLayout.tsx
@@ -418,19 +418,19 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 			>
 				<TrendingTopics trendingTopics={front.trendingTopics} />
 			</Section>
-			<Section
-				fullWidth={true}
-				data-print-layout="hide"
-				padSides={false}
-				showTopBorder={false}
-				showSideBorders={false}
-				backgroundColour={neutral[93]}
-				element="aside"
-			>
-				{!(isInFrontsBannerTest && front.isNetworkFront) && (
+			{!(isInFrontsBannerTest && front.isNetworkFront) && (
+				<Section
+					fullWidth={true}
+					data-print-layout="hide"
+					padSides={false}
+					showTopBorder={false}
+					showSideBorders={false}
+					backgroundColour={neutral[93]}
+					element="aside"
+				>
 					<AdSlot position="merchandising" display={format.display} />
-				)}
-			</Section>
+				</Section>
+			)}
 
 			{NAV.subNavSections && (
 				<Section


### PR DESCRIPTION
## What does this change?
This PR removes merchandising and merchandising-high ad slots for network fronts rendered by DCR that are in the FrontsBannerAds 0% server side test. Anywhere that would have shown a merchandising or merchandising-high slot will now not show any ad slot.

## Why?
We're using the FrontsBannerAds test to trial some alternative ad layouts for fronts. This PR removes the merchandising-high and merchandising ad slots for DCR network fronts which are in the test. Different ad slots will be added to this test to replace them in future work.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| <img width="600" alt="Screenshot 2023-05-09 at 16 45 42" src="https://github.com/guardian/dotcom-rendering/assets/108270776/0b0d66a4-d2c1-4349-b9ec-2a813e7df8ef"> | <img width="600" alt="Screenshot 2023-05-09 at 16 46 22" src="https://github.com/guardian/dotcom-rendering/assets/108270776/78dc03d6-bb76-468f-8239-443c0b363127"> |