### PR TITLE
Remove network front MPUs and mobile ads when in fronts test

### DIFF
--- a/dotcom-rendering/src/web/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FrontLayout.tsx
@@ -394,6 +394,8 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 										collection.displayName === 'Headlines'
 									}
 									renderAds={renderAds}
+									isNetworkFront={front.isNetworkFront}
+									isInFrontsBannerTest={true}
 								/>
 							</FrontSection>
 							{renderAds &&

--- a/dotcom-rendering/src/web/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FrontLayout.tsx
@@ -395,7 +395,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 									}
 									renderAds={renderAds}
 									isNetworkFront={front.isNetworkFront}
-									isInFrontsBannerTest={true}
+									isInFrontsBannerTest={isInFrontsBannerTest}
 								/>
 							</FrontSection>
 							{renderAds &&

--- a/dotcom-rendering/src/web/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FrontLayout.tsx
@@ -87,16 +87,18 @@ const decideAdSlot = (
 			);
 		}
 	} else if (mobileAdPositions.includes(index)) {
-		return (
-			<Hide from="tablet">
-				<AdSlot
-					index={index}
-					data-print-layout="hide"
-					position="mobile-front"
-					display={format}
-				/>
-			</Hide>
-		);
+		if (!(isInFrontsBannerTest && isNetworkFront)) {
+			return (
+				<Hide from="tablet">
+					<AdSlot
+						index={index}
+						data-print-layout="hide"
+						position="mobile-front"
+						display={format}
+					/>
+				</Hide>
+			);
+		}
 	}
 	return null;
 };

--- a/dotcom-rendering/src/web/lib/DecideContainer.tsx
+++ b/dotcom-rendering/src/web/lib/DecideContainer.tsx
@@ -30,6 +30,8 @@ type Props = {
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
 	renderAds: boolean;
+	isNetworkFront: boolean;
+	isInFrontsBannerTest: boolean;
 };
 
 export const DecideContainer = ({
@@ -40,7 +42,11 @@ export const DecideContainer = ({
 	containerPalette,
 	showAge,
 	renderAds,
+	isNetworkFront,
+	isInFrontsBannerTest,
 }: Props) => {
+	const shouldShowMPU =
+		!(isNetworkFront && isInFrontsBannerTest) && renderAds;
 	switch (containerType) {
 		case 'dynamic/fast':
 			return (
@@ -65,7 +71,7 @@ export const DecideContainer = ({
 					containerPalette={containerPalette}
 					showAge={showAge}
 					index={index}
-					renderAds={renderAds}
+					renderAds={shouldShowMPU}
 					trails={trails}
 				/>
 			);
@@ -100,7 +106,7 @@ export const DecideContainer = ({
 					containerPalette={containerPalette}
 					showAge={showAge}
 					index={index}
-					renderAds={renderAds}
+					renderAds={shouldShowMPU}
 				/>
 			);
 		case 'fixed/small/slow-III':
@@ -149,7 +155,7 @@ export const DecideContainer = ({
 					trails={trails}
 					containerPalette={containerPalette}
 					showAge={showAge}
-					renderAds={renderAds}
+					renderAds={shouldShowMPU}
 					index={index}
 				/>
 			);


### PR DESCRIPTION
## What does this change?
When in the fronts-banner-ads server side test, MPUs and mobile ads will not be shown on network fronts rendered by DCR.

## Why?
This is part of our trials of new ad layouts on fronts, following the removal of merchandising slots for network fronts in the fronts-banner-ads-test: https://github.com/guardian/dotcom-rendering/pull/7710

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| <img width="310" alt="Screenshot 2023-05-10 at 12 29 43" src="https://github.com/guardian/dotcom-rendering/assets/108270776/8aa0f61a-3808-4382-90db-3311dc87a7fd"> | <img width="323" alt="Screenshot 2023-05-10 at 12 30 14" src="https://github.com/guardian/dotcom-rendering/assets/108270776/edd29789-ad04-4638-8ecd-257ed66ce07c"> |

