### PR TITLE
adjust width and height if video is vertical

### DIFF
--- a/dotcom-rendering/src/web/components/ArticleContainer.tsx
+++ b/dotcom-rendering/src/web/components/ArticleContainer.tsx
@@ -73,6 +73,7 @@ const adStyles = css`
 	}
 
 	.ad-slot-container {
+		clear: both;
 		margin: ${space[3]}px auto;
 		/* this is centring the ad iframe as they are display: inline; elements by default */
 		text-align: center;

--- a/dotcom-rendering/src/web/components/YoutubeBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/web/components/YoutubeBlockComponent.importable.tsx
@@ -35,8 +35,8 @@ type Props = {
 	isVertical?: boolean;
 };
 
-const VERTICAL_WIDTH = 393;
-const VERTICAL_HEIGHT = 698;
+const VERTICAL_WIDTH = 306;
+const VERTICAL_HEIGHT = 544;
 
 const expiredOverlayStyles = (overrideImage?: string) =>
 	overrideImage

--- a/dotcom-rendering/src/web/components/YoutubeBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/web/components/YoutubeBlockComponent.importable.tsx
@@ -35,6 +35,9 @@ type Props = {
 	isVertical?: boolean;
 };
 
+const VERTICAL_WIDTH = 393;
+const VERTICAL_HEIGHT = 698;
+
 const expiredOverlayStyles = (overrideImage?: string) =>
 	overrideImage
 		? css`
@@ -73,10 +76,11 @@ const expiredSVGWrapperStyles = css`
 `;
 
 const verticalVideoStyles = css`
-	width: 393px;
-	height: 698px;
+	width: ${VERTICAL_WIDTH}px;
+	height: ${VERTICAL_HEIGHT}px;
 	float: left;
 	margin-right: 13px;
+	margin-bottom: 30px;
 `;
 
 export const YoutubeBlockComponent = ({
@@ -229,8 +233,8 @@ export const YoutubeBlockComponent = ({
 				alt={altText ?? mediaTitle ?? ''}
 				adTargeting={adTargeting}
 				consentState={consentState}
-				height={isVertical ? 698 : height}
-				width={isVertical ? 393 : width}
+				height={isVertical ? VERTICAL_HEIGHT : height}
+				width={isVertical ? VERTICAL_WIDTH : width}
 				title={mediaTitle}
 				duration={duration}
 				eventEmitters={[ophanTracking, gaTracking]}

--- a/dotcom-rendering/src/web/components/YoutubeBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/web/components/YoutubeBlockComponent.importable.tsx
@@ -196,7 +196,7 @@ export const YoutubeBlockComponent = ({
 
 	return (
 		<div
-			css={verticalVideoStyles}
+			css={isVertical && verticalVideoStyles}
 			data-chromatic="ignore"
 			data-component="youtube-atom"
 		>

--- a/dotcom-rendering/src/web/components/YoutubeBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/web/components/YoutubeBlockComponent.importable.tsx
@@ -75,6 +75,8 @@ const expiredSVGWrapperStyles = css`
 const verticalVideoStyles = css`
 	width: 393px;
 	height: 698px;
+	float: left;
+	margin-right: 13px;
 `;
 
 export const YoutubeBlockComponent = ({

--- a/dotcom-rendering/src/web/components/YoutubeBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/web/components/YoutubeBlockComponent.importable.tsx
@@ -32,6 +32,7 @@ type Props = {
 	duration?: number; // in seconds
 	origin?: string;
 	stickyVideos: boolean;
+	isVertical?: boolean;
 };
 
 const expiredOverlayStyles = (overrideImage?: string) =>
@@ -71,6 +72,11 @@ const expiredSVGWrapperStyles = css`
 	}
 `;
 
+const verticalVideoStyles = css`
+	width: 393px;
+	height: 698px;
+`;
+
 export const YoutubeBlockComponent = ({
 	id,
 	elementId,
@@ -90,6 +96,7 @@ export const YoutubeBlockComponent = ({
 	duration,
 	origin,
 	stickyVideos,
+	isVertical,
 }: Props) => {
 	const [consentState, setConsentState] = useState<ConsentState | undefined>(
 		undefined,
@@ -182,12 +189,16 @@ export const YoutubeBlockComponent = ({
 	};
 
 	return (
-		<div data-chromatic="ignore" data-component="youtube-atom">
+		<div
+			css={verticalVideoStyles}
+			data-chromatic="ignore"
+			data-component="youtube-atom"
+		>
 			<YoutubeAtom
 				elementId={elementId}
 				videoId={assetId}
 				overrideImage={
-					overrideImage
+					overrideImage && !isVertical
 						? [
 								{
 									srcSet: [
@@ -201,7 +212,7 @@ export const YoutubeBlockComponent = ({
 						: undefined
 				}
 				posterImage={
-					posterImage
+					posterImage && !isVertical
 						? [
 								{
 									srcSet: posterImage.map((img) => ({
@@ -216,8 +227,8 @@ export const YoutubeBlockComponent = ({
 				alt={altText ?? mediaTitle ?? ''}
 				adTargeting={adTargeting}
 				consentState={consentState}
-				height={height}
-				width={width}
+				height={isVertical ? 698 : height}
+				width={isVertical ? 393 : width}
 				title={mediaTitle}
 				duration={duration}
 				eventEmitters={[ophanTracking, gaTracking]}

--- a/dotcom-rendering/src/web/lib/ArticleRenderer.tsx
+++ b/dotcom-rendering/src/web/lib/ArticleRenderer.tsx
@@ -71,7 +71,8 @@ export const ArticleRenderer = ({
 	abTests,
 	renderingTarget,
 }: Props) => {
-	const isVertical = tags.filter((x) => x.title == 'TestTopic').length > 0;
+	const isVertical =
+		tags.filter((x) => x.title == 'vertical-video').length > 0;
 
 	const renderedElements = elements.map((element, index) => {
 		return (

--- a/dotcom-rendering/src/web/lib/ArticleRenderer.tsx
+++ b/dotcom-rendering/src/web/lib/ArticleRenderer.tsx
@@ -71,6 +71,8 @@ export const ArticleRenderer = ({
 	abTests,
 	renderingTarget,
 }: Props) => {
+	const isVertical = tags.filter((x) => x.title == 'TestTopic').length > 0;
+
 	const renderedElements = elements.map((element, index) => {
 		return (
 			<RenderArticleElement
@@ -89,6 +91,7 @@ export const ArticleRenderer = ({
 				isSensitive={isSensitive}
 				switches={switches}
 				abTests={abTests}
+				isVertical={isVertical}
 			/>
 		);
 	});

--- a/dotcom-rendering/src/web/lib/renderElement.tsx
+++ b/dotcom-rendering/src/web/lib/renderElement.tsx
@@ -85,6 +85,7 @@ type Props = {
 	switches: Switches;
 	isPinnedPost?: boolean;
 	abTests?: ServerSideTests;
+	isVertical?: boolean;
 };
 
 // updateRole modifies the role of an element in a way appropriate for most
@@ -140,6 +141,7 @@ export const renderElement = ({
 	isSensitive,
 	isPinnedPost,
 	abTests,
+	isVertical,
 }: Props) => {
 	const palette = decidePalette(format);
 
@@ -749,6 +751,7 @@ export const renderElement = ({
 						altText={element.altText}
 						origin={host}
 						stickyVideos={!!(isBlog && switches.stickyVideos)}
+						isVertical={isVertical}
 					/>
 				</Island>
 			);
@@ -798,6 +801,7 @@ export const RenderArticleElement = ({
 	switches,
 	isPinnedPost,
 	abTests,
+	isVertical,
 }: Props) => {
 	const withUpdatedRole = updateRole(element, format);
 
@@ -818,6 +822,7 @@ export const RenderArticleElement = ({
 		switches,
 		isPinnedPost,
 		abTests,
+		isVertical,
 	});
 
 	const needsFigure = !bareElements.has(element._type);


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
