### PR TITLE
Don't display age warning for cotton capital series

### DIFF
--- a/dotcom-rendering/src/lib/age-warning.ts
+++ b/dotcom-rendering/src/lib/age-warning.ts
@@ -12,7 +12,7 @@ export const getAgeWarning = (
 	let message;
 
 	// Only show an age warning for news or opinion pieces
-	if (isNews || (isOpinion && !isCottonCapital)) {
+	if ((isNews || isOpinion) && !isCottonCapital) {
 		const warnLimitDays = 30;
 		const currentDate = new Date();
 		const dateThreshold = new Date();


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Stops displaying age warning if 'news/series/cotton-capital' tag is present.

## Why?

Requested by @HarryFischer 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/110032454/5a62e1d5-fbcc-4884-844b-1e221595ed4b
[after]: https://github.com/guardian/dotcom-rendering/assets/110032454/45c551c2-3af5-4e97-84aa-ae2bfeeb64c1

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
