### PR TITLE
Fix labeller job permissions

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -4,6 +4,9 @@ on:
 
 jobs:
   triage:
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/labeler@v4


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Fixes the permissions [as per the docs](https://github.com/marketplace/actions/labeler#create-workflow).

## Why?

It’s been [broken a lot recently](https://github.com/guardian/dotcom-rendering/actions/workflows/labeler.yml).

## Further notes

The hint about fixing permissions came from https://sjramblings.io/github-actions-resource-not-accessible-by-integration