### PR TITLE
Fix broken links 

### DIFF
--- a/dotcom-rendering/src/web/components/BlockquoteBlockComponent.tsx
+++ b/dotcom-rendering/src/web/components/BlockquoteBlockComponent.tsx
@@ -90,7 +90,7 @@ const textElement =
 				});
 			case 'A':
 				return jsx('A', {
-					href: getAttrs(node)?.getNamedItem('href'),
+					href: getAttrs(node)?.getNamedItem('href')?.value,
 					key,
 					children,
 				});


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Fixes broken links by returning the value. 
## Why?
Was returning for example https://www.theguardian.com/business/live/2023/may/11/[object+Attr]
## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: 
https://github.com/guardian/dotcom-rendering/assets/110032454/1d406df3-e8fc-4c99-aa15-f0a13bccf85f

[after]: https://github.com/guardian/dotcom-rendering/assets/110032454/5f476576-10b0-481c-a419-11ed31b472cc

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
