### PR TITLE
feat: Support `fixed/small/slow-V-half` container

### DIFF
--- a/dotcom-rendering/src/web/components/FixedSmallSlowVHalf.stories.tsx
+++ b/dotcom-rendering/src/web/components/FixedSmallSlowVHalf.stories.tsx
@@ -1,0 +1,25 @@
+import { breakpoints } from '@guardian/source-foundations';
+import { trails } from '../../../fixtures/manual/trails';
+import { FrontSection } from './FrontSection';
+import { FixedSmallSlowVHalf } from './FixedSmallSlowVHalf';
+
+export default {
+	component: FixedSmallSlowVHalf,
+	title: 'Components/FixedSmallSlowVHalf',
+	parameters: {
+		chromatic: {
+			viewports: [
+				breakpoints.mobile,
+				breakpoints.tablet,
+				breakpoints.wide,
+			],
+		},
+	},
+};
+
+export const Default = () => (
+	<FrontSection title="Fixed Small Slow V Half">
+		<FixedSmallSlowVHalf trails={trails} showAge={true} />
+	</FrontSection>
+);
+Default.storyName = 'FixedSmallSlowVHalf';

--- a/dotcom-rendering/src/web/components/FixedSmallSlowVHalf.tsx
+++ b/dotcom-rendering/src/web/components/FixedSmallSlowVHalf.tsx
@@ -1,0 +1,56 @@
+import type { DCRContainerPalette, DCRFrontCard } from '../../types/front';
+import { Card50Media50, CardDefaultMediaMobile } from '../lib/cardWrappers';
+import { LI } from './Card/components/LI';
+import { UL } from './Card/components/UL';
+
+type Props = {
+	trails: DCRFrontCard[];
+	containerPalette?: DCRContainerPalette;
+	showAge?: boolean;
+};
+
+export const FixedSmallSlowVHalf = ({
+	trails,
+	containerPalette,
+	showAge,
+}: Props) => {
+	const firstSlice50 = trails.slice(0, 1);
+	const remaining = trails.slice(1, 5);
+
+	return (
+		<UL direction="row-reverse">
+			{firstSlice50.map((trail, index) => {
+				return (
+					<LI
+						key={trail.url}
+						padSides={true}
+						showDivider={true}
+						containerPalette={containerPalette}
+						percentage="50%"
+					>
+						<Card50Media50
+							trail={trail}
+							containerPalette={containerPalette}
+							showAge={showAge}
+						/>
+					</LI>
+				);
+			})}
+			<LI containerPalette={containerPalette} percentage="50%">
+				<UL direction="column">
+					{remaining.map((trail) => {
+						return (
+							<LI key={trail.url} padSides={true}>
+								<CardDefaultMediaMobile
+									trail={trail}
+									containerPalette={containerPalette}
+									showAge={showAge}
+								/>
+							</LI>
+						);
+					})}
+				</UL>
+			</LI>
+		</UL>
+	);
+};

--- a/dotcom-rendering/src/web/lib/DecideContainer.tsx
+++ b/dotcom-rendering/src/web/lib/DecideContainer.tsx
@@ -18,6 +18,7 @@ import { FixedSmallFastVIII } from '../components/FixedSmallFastVIII';
 import { FixedSmallSlowI } from '../components/FixedSmallSlowI';
 import { FixedSmallSlowIII } from '../components/FixedSmallSlowIII';
 import { FixedSmallSlowIV } from '../components/FixedSmallSlowIV';
+import { FixedSmallSlowVHalf } from '../components/FixedSmallSlowVHalf';
 import { FixedSmallSlowVMPU } from '../components/FixedSmallSlowVMPU';
 import { FixedSmallSlowVThird } from '../components/FixedSmallSlowVThird';
 import { NavList } from '../components/NavList';
@@ -122,6 +123,14 @@ export const DecideContainer = ({
 		case 'fixed/small/slow-V-third':
 			return (
 				<FixedSmallSlowVThird
+					trails={trails}
+					containerPalette={containerPalette}
+					showAge={showAge}
+				/>
+			);
+		case 'fixed/small/slow-V-half':
+			return (
+				<FixedSmallSlowVHalf
 					trails={trails}
 					containerPalette={containerPalette}
 					showAge={showAge}


### PR DESCRIPTION
## What does this change?

Adds support for `fixed/small/slow-V-half`! I'm not entirely sure why this wasn't done when we first started the fronts migration!

Part of #5148

## Why?

More containers = more supported pages

## Screenshots

| Frontend      | DCR      |
| ----------- | ---------- |
| ![before_desktop][] | ![after_desktop][] |
| ![before_mobile][] | ![after_mobile][] |

[before_desktop]: https://github.com/guardian/dotcom-rendering/assets/21217225/bb5d7ff2-826f-42ca-b99c-588aa323d3c9
[after_desktop]: https://github.com/guardian/dotcom-rendering/assets/21217225/bab7d9c4-cc26-433b-ab79-65f74c6f5227
[before_mobile]: https://github.com/guardian/dotcom-rendering/assets/21217225/043dd3a4-d6d8-4e1a-a9b9-4f4dcbfec184
[after_mobile]: https://github.com/guardian/dotcom-rendering/assets/21217225/8e2b8be1-a934-4497-be61-d4476ab07bfe

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
