### PR TITLE
Install exact versions by default

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -4,3 +4,5 @@
 
 lastUpdateCheck 1641478836503
 yarn-path ".yarn/releases/yarn-1.22.19.cjs"
+
+save-exact true


### PR DESCRIPTION
## What does this change?

Install exact packages instead of versions by default.

## Why?

Follow-up on #7655 