### PR TITLE
First banner ad on front

### DIFF
--- a/dotcom-rendering/src/web/components/AdSlot.tsx
+++ b/dotcom-rendering/src/web/components/AdSlot.tsx
@@ -2,14 +2,7 @@ import { css } from '@emotion/react';
 import { adSizes } from '@guardian/commercial-core';
 import type { SlotName } from '@guardian/commercial-core';
 import { ArticleDisplay } from '@guardian/libs';
-import {
-	border,
-	from,
-	neutral,
-	space,
-	text,
-	textSans,
-} from '@guardian/source-foundations';
+import { from, palette, space, textSans } from '@guardian/source-foundations';
 import { getZIndex } from '../lib/getZIndex';
 import { TopRightAdSlot } from './TopRightAdSlot.importable';
 
@@ -44,10 +37,10 @@ export const individualLabelCSS = css`
 	${textSans.xxsmall()};
 	height: ${labelHeight}px;
 	max-height: ${labelHeight}px;
-	background-color: ${neutral[97]};
-	padding: 0 8px;
-	border-top: 1px solid ${border.secondary};
-	color: ${text.supporting};
+	background-color: ${palette.neutral[97]};
+	padding: 0 ${space[2]}px 1px;
+	border-top: 1px solid ${palette.neutral[86]};
+	color: ${palette.neutral[46]};
 	text-align: left;
 	box-sizing: border-box;
 `;
@@ -87,8 +80,9 @@ export const labelStyles = css`
 
 	.ad-slot[data-label-show='true']:not(.ad-slot--interscroller)::before {
 		content: attr(ad-label-text);
-		display: block;
 		position: relative;
+		display: flex;
+		align-items: center;
 		${individualLabelCSS}
 	}
 
@@ -209,8 +203,8 @@ const mobileStickyAdStyles = css`
 	.ad-slot__close-button svg {
 		height: 0.75rem;
 		width: 0.75rem;
-		stroke: ${neutral[7]};
-		fill: ${neutral[7]};
+		stroke: ${palette.neutral[7]};
+		fill: ${palette.neutral[7]};
 		stroke-linecap: round;
 		stroke-width: 0;
 		text-align: center;
@@ -219,7 +213,7 @@ const mobileStickyAdStyles = css`
 		display: block;
 	}
 	.ad-slot__close-button__x {
-		stroke: ${neutral[7]};
+		stroke: ${palette.neutral[7]};
 		fill: transparent;
 		stroke-linecap: round;
 		stroke-width: 2;
@@ -276,10 +270,7 @@ export const AdSlot = ({
 				}
 				case ArticleDisplay.Standard: {
 					return (
-						<TopRightAdSlot
-							isPaidContent={isPaidContent}
-							adStyles={adStyles}
-						/>
+						<TopRightAdSlot isPaidContent={isPaidContent} adStyles={adStyles} />
 					);
 				}
 				default:
@@ -371,11 +362,7 @@ export const AdSlot = ({
 							'ad-slot',
 							'ad-slot--merchandising-high',
 						].join(' ')}
-						css={[
-							merchandisingAdStyles,
-							adStyles,
-							fluidFullWidthAdStyles,
-						]}
+						css={[merchandisingAdStyles, adStyles, fluidFullWidthAdStyles]}
 						data-link-name="ad slot merchandising-high"
 						data-name="merchandising-high"
 						aria-hidden="true"
@@ -397,16 +384,10 @@ export const AdSlot = ({
 				>
 					<div
 						id="dfp-ad--merchandising"
-						className={[
-							'js-ad-slot',
-							'ad-slot',
-							'ad-slot--merchandising',
-						].join(' ')}
-						css={[
-							merchandisingAdStyles,
-							adStyles,
-							fluidFullWidthAdStyles,
-						]}
+						className={['js-ad-slot', 'ad-slot', 'ad-slot--merchandising'].join(
+							' ',
+						)}
+						css={[merchandisingAdStyles, adStyles, fluidFullWidthAdStyles]}
 						data-link-name="ad slot merchandising"
 						data-name="merchandising"
 						aria-hidden="true"
@@ -418,11 +399,7 @@ export const AdSlot = ({
 			return (
 				<div
 					id="dfp-ad--survey"
-					className={[
-						'js-ad-slot',
-						'ad-slot',
-						'ad-slot--survey',
-					].join(' ')}
+					className={['js-ad-slot', 'ad-slot', 'ad-slot--survey'].join(' ')}
 					css={outOfPageStyles}
 					data-link-name="ad slot survey"
 					data-name="survey"
@@ -523,7 +500,5 @@ export const AdSlot = ({
 };
 
 export const MobileStickyContainer = () => {
-	return (
-		<div className="mobilesticky-container" css={mobileStickyAdStyles} />
-	);
+	return <div className="mobilesticky-container" css={mobileStickyAdStyles} />;
 };

--- a/dotcom-rendering/src/web/components/AdSlot.tsx
+++ b/dotcom-rendering/src/web/components/AdSlot.tsx
@@ -6,7 +6,11 @@ import { from, palette, space, textSans } from '@guardian/source-foundations';
 import { getZIndex } from '../lib/getZIndex';
 import { TopRightAdSlot } from './TopRightAdSlot.importable';
 
-type InlinePosition = 'inline' | 'liveblog-inline' | 'mobile-front';
+type InlinePosition =
+	| 'inline'
+	| 'liveblog-inline'
+	| 'mobile-front'
+	| 'fronts-banner';
 
 type InlineProps = {
 	display?: ArticleDisplay;
@@ -102,6 +106,33 @@ export const adCollapseStyles = css`
 	& .ad-slot.ad-slot--collapse {
 		display: none;
 	}
+`;
+
+const topAboveNavStyles = css`
+	position: relative;
+	margin: 0 auto;
+	min-height: ${adSizes.leaderboard.height}px;
+	min-width: ${adSizes.leaderboard.width}px;
+	text-align: left;
+	display: block;
+`;
+
+const bannerAdStyles = css`
+	position: relative;
+	margin: auto;
+	min-height: ${adSizes.leaderboard.height + labelHeight}px;
+	width: fit-content;
+`;
+
+const bannerPaddingBottom = space[4];
+const bannerAdContainerStyles = css`
+	width: 100%;
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	background-color: ${palette.neutral[97]};
+	min-height: ${250 + labelHeight + bannerPaddingBottom}px;
+	padding-bottom: ${bannerPaddingBottom}px;
 `;
 
 const merchandisingAdStyles = css`
@@ -298,14 +329,6 @@ export const AdSlot = ({
 			);
 		}
 		case 'top-above-nav': {
-			const adSlotAboveNav = css`
-				position: relative;
-				margin: 0 auto;
-				min-height: ${adSizes.leaderboard.height}px;
-				text-align: left;
-				display: block;
-				min-width: 728px;
-			`;
 			return (
 				<div
 					id="dfp-ad--top-above-nav"
@@ -316,11 +339,35 @@ export const AdSlot = ({
 						'ad-slot--mpu-banner-ad',
 						'ad-slot--rendered',
 					].join(' ')}
-					css={[adStyles, fluidFullWidthAdStyles, adSlotAboveNav]}
+					css={[adStyles, fluidFullWidthAdStyles, topAboveNavStyles]}
 					data-link-name="ad slot top-above-nav"
 					data-name="top-above-nav"
 					aria-hidden="true"
 				></div>
+			);
+		}
+		case 'fronts-banner': {
+			const advertId = `fronts-banner-${index}`;
+			return (
+				<div
+					className="ad-slot-container"
+					css={[adStyles, bannerAdContainerStyles]}
+				>
+					<div
+						id={`dfp-ad--${advertId}`}
+						className={[
+							'js-ad-slot',
+							'ad-slot',
+							'ad-slot--fronts-banner',
+							`ad-slot--${advertId}`,
+							'ad-slot--rendered',
+						].join(' ')}
+						css={[adStyles, fluidFullWidthAdStyles, bannerAdStyles]}
+						data-link-name={`ad slot ${advertId}`}
+						data-name="fronts-banner"
+						aria-hidden="true"
+					/>
+				</div>
 			);
 		}
 		case 'mostpop': {

--- a/dotcom-rendering/src/web/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FrontLayout.tsx
@@ -70,7 +70,17 @@ const decideAdSlot = (
 	isPaidContent: boolean | undefined,
 	format: ArticleDisplay,
 	mobileAdPositions: (number | undefined)[],
+	isUkNetworkFront?: boolean,
+	sectionName?: string,
 ) => {
+	if (isUkNetworkFront && sectionName?.toLocaleLowerCase() === 'spotlight') {
+		return (
+			<Hide until="desktop">
+				<AdSlot position="fronts-banner" index={1} />
+			</Hide>
+		);
+	}
+
 	const minContainers = isPaidContent ? 1 : 2;
 	if (
 		collectionCount > minContainers &&
@@ -194,13 +204,9 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 						<Nav
 							nav={NAV}
 							format={format}
-							subscribeUrl={
-								front.nav.readerRevenueLinks.header.subscribe
-							}
+							subscribeUrl={front.nav.readerRevenueLinks.header.subscribe}
 							editionId={front.editionId}
-							headerTopBarSwitch={
-								!!front.config.switches.headerTopNav
-							}
+							headerTopBarSwitch={!!front.config.switches.headerTopNav}
 							isInEuropeTest={isInEuropeTest}
 						/>
 					</Section>
@@ -242,9 +248,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 			<main data-layout="FrontLayout" id="maincontent">
 				{front.pressedPage.collections.map((collection, index) => {
 					// Backfills should be added to the end of any curated content
-					const trails = collection.curated.concat(
-						collection.backfill,
-					);
+					const trails = collection.curated.concat(collection.backfill);
 					const [trail] = trails;
 
 					// There are some containers that have zero trails. We don't want to render these
@@ -272,8 +276,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 									index,
 									front.isNetworkFront,
 									front.pressedPage.collections.length,
-									front.pressedPage.frontProperties
-										.isPaidContent,
+									front.pressedPage.frontProperties.isPaidContent,
 									format.display,
 									mobileAdPositions,
 								)}
@@ -298,13 +301,9 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 									ophanComponentLink={ophanComponentLink}
 									ophanComponentName={ophanName}
 									containerName={collection.collectionType}
-									containerPalette={
-										collection.containerPalette
-									}
+									containerPalette={collection.containerPalette}
 									sectionId={ophanName}
-									showDateHeader={
-										collection.config.showDateHeader
-									}
+									showDateHeader={collection.config.showDateHeader}
 									editionId={front.editionId}
 									treats={collection.treats}
 									data-print-layout="hide"
@@ -323,8 +322,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 									index,
 									front.isNetworkFront,
 									front.pressedPage.collections.length,
-									front.pressedPage.frontProperties
-										.isPaidContent,
+									front.pressedPage.frontProperties.isPaidContent,
 									format.display,
 									mobileAdPositions,
 								)}
@@ -354,21 +352,15 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 									front.isNetworkFront,
 								)}
 								leftContent={
-									(front.config.pageId ===
-										'uk/commentisfree' ||
-										front.config.pageId ===
-											'au/commentisfree') &&
-									collection.displayName === 'Opinion' && (
-										<CPScottHeader />
-									)
+									(front.config.pageId === 'uk/commentisfree' ||
+										front.config.pageId === 'au/commentisfree') &&
+									collection.displayName === 'Opinion' && <CPScottHeader />
 								}
 								badge={showBadge(collection.displayName)}
 								sectionId={ophanName}
 								collectionId={collection.id}
 								pageId={front.pressedPage.id}
-								showDateHeader={
-									collection.config.showDateHeader
-								}
+								showDateHeader={collection.config.showDateHeader}
 								editionId={front.editionId}
 								treats={collection.treats}
 								canShowMore={collection.canShowMore}
@@ -379,12 +371,8 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 									index={index}
 									groupedTrails={collection.grouped}
 									containerType={collection.collectionType}
-									containerPalette={
-										collection.containerPalette
-									}
-									showAge={
-										collection.displayName === 'Headlines'
-									}
+									containerPalette={collection.containerPalette}
+									showAge={collection.displayName === 'Headlines'}
 									renderAds={renderAds}
 								/>
 							</FrontSection>
@@ -393,10 +381,11 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 									index,
 									front.isNetworkFront,
 									front.pressedPage.collections.length,
-									front.pressedPage.frontProperties
-										.isPaidContent,
+									front.pressedPage.frontProperties.isPaidContent,
 									format.display,
 									mobileAdPositions,
+									front.config.pageId === 'uk',
+									collection.displayName,
 								)}
 						</>
 					);


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
