### PR TITLE
RFC: Apps Dark Mode Support

### DIFF
--- a/dotcom-rendering/src/types/palette.ts
+++ b/dotcom-rendering/src/types/palette.ts
@@ -1,6 +1,6 @@
 export type Colour = string;
 
-export type Palette = {
+type LightPaletteColours = {
 	text: {
 		headline: Colour;
 		headlineWhenMatch: Colour;
@@ -149,6 +149,16 @@ export type Palette = {
 		pagination: Colour;
 	};
 };
+
+type DarkPaletteColours = {
+	text: {
+		headline: Colour;
+	};
+};
+
+export interface Palette extends LightPaletteColours {
+	dark: DarkPaletteColours;
+}
 
 export type ContainerOverrides = {
 	text: {

--- a/dotcom-rendering/src/types/palette.ts
+++ b/dotcom-rendering/src/types/palette.ts
@@ -150,7 +150,7 @@ type LightPaletteColours = {
 	};
 };
 
-type DarkPaletteColours = {
+export type DarkPaletteColours = {
 	text: {
 		headline: Colour;
 	};

--- a/dotcom-rendering/src/web/components/ArticleHeadline.tsx
+++ b/dotcom-rendering/src/web/components/ArticleHeadline.tsx
@@ -1,3 +1,4 @@
+import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import type { ArticleFormat } from '@guardian/libs';
 import { ArticleDesign, ArticleDisplay, ArticleSpecial } from '@guardian/libs';
@@ -18,6 +19,27 @@ import { AgeWarning } from './AgeWarning';
 import { DesignTag } from './DesignTag';
 import { HeadlineByline } from './HeadlineByline';
 
+const darkModeCss =
+	(supportsDarkMode: boolean) =>
+	(styles: TemplateStringsArray, ...placeholders: string[]) => {
+		if (supportsDarkMode) {
+			const darkStyles = styles
+				// eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+				.map(
+					(style, i) =>
+						`${style}${placeholders[i] ? placeholders[i] : ''}`,
+				)
+				.join('');
+			return css`
+				@media (prefers-color-scheme: dark) {
+					${darkStyles}
+				}
+			`;
+		} else {
+			return '';
+		}
+	};
+
 type Props = {
 	headlineString: string;
 	format: ArticleFormat;
@@ -27,6 +49,7 @@ type Props = {
 	hasStarRating?: boolean;
 	hasAvatar?: boolean;
 	isMatch?: boolean;
+	supportsDarkMode: boolean;
 };
 
 const curly = (x: any) => x;
@@ -342,6 +365,7 @@ export const ArticleHeadline = ({
 	hasStarRating,
 	hasAvatar,
 	isMatch,
+	supportsDarkMode = false,
 }: Props) => {
 	const palette = decidePalette(format);
 	switch (format.display) {
@@ -439,6 +463,9 @@ export const ArticleHeadline = ({
 									darkBackground(palette),
 									css`
 										color: ${palette.text.headline};
+										@media (prefers-color-scheme: dark) {@media (prefers-color-scheme: dark) {
+											color: ${palette.dark.text.headline};
+										}
 									`,
 								]}
 							>
@@ -808,6 +835,10 @@ export const ArticleHeadline = ({
 										topPadding,
 										css`
 											color: ${palette.text.headline};
+
+											${darkModeCss(supportsDarkMode)`
+												color: ${palette.dark.text.headline};
+											`}
 										`,
 									]}
 								>

--- a/dotcom-rendering/src/web/components/ArticleHeadline.tsx
+++ b/dotcom-rendering/src/web/components/ArticleHeadline.tsx
@@ -24,9 +24,9 @@ const darkModeCss =
 	(styles: TemplateStringsArray, ...placeholders: string[]) => {
 		if (supportsDarkMode) {
 			const darkStyles = styles
-				// eslint-disable-next-line @typescript-eslint/restrict-template-expressions
 				.map(
 					(style, i) =>
+						// eslint-disable-next-line @typescript-eslint/restrict-template-expressions
 						`${style}${placeholders[i] ? placeholders[i] : ''}`,
 				)
 				.join('');
@@ -463,9 +463,6 @@ export const ArticleHeadline = ({
 									darkBackground(palette),
 									css`
 										color: ${palette.text.headline};
-										@media (prefers-color-scheme: dark) {@media (prefers-color-scheme: dark) {
-											color: ${palette.dark.text.headline};
-										}
 									`,
 								]}
 							>

--- a/dotcom-rendering/src/web/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/StandardLayout.tsx
@@ -580,6 +580,9 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 									hasStarRating={
 										typeof article.starRating === 'number'
 									}
+									supportsDarkMode={
+										renderingTarget === 'Apps'
+									}
 								/>
 							</div>
 						</GridItem>

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -23,7 +23,7 @@ import {
 // Here is the one place where we use `pillarPalette`
 import { pillarPalette_DO_NOT_USE as pillarPalette } from '../../lib/pillars';
 import type { DCRContainerPalette } from '../../types/front';
-import type { Palette } from '../../types/palette';
+import type { DarkPaletteColours, Palette } from '../../types/palette';
 import { decideContainerOverrides } from './decideContainerOverrides';
 import { transparentColour } from './transparentColour';
 
@@ -2053,6 +2053,14 @@ const hoverPagination = (format: ArticleFormat) => {
 	}
 };
 
+const decidePaletteDark = (format: ArticleFormat): DarkPaletteColours => {
+	return {
+		text: {
+			headline: textHeadlineDark(format),
+		},
+	};
+};
+
 export const decidePalette = (
 	format: ArticleFormat,
 	containerPalette?: DCRContainerPalette,
@@ -2060,11 +2068,7 @@ export const decidePalette = (
 	const overrides =
 		containerPalette && decideContainerOverrides(containerPalette);
 	return {
-		dark: {
-			text: {
-				headline: textHeadlineDark(format),
-			},
-		},
+		dark: decidePaletteDark(format),
 		text: {
 			headline: textHeadline(format),
 			headlineWhenMatch: textHeadlineWhenMatch(format),

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -51,6 +51,10 @@ const blogsGrayBackgroundPalette = (format: ArticleFormat): string => {
 	}
 };
 
+const textHeadlineDark = (_format: ArticleFormat): string => {
+	return 'orangered';
+};
+
 const textHeadline = (format: ArticleFormat): string => {
 	switch (format.display) {
 		case ArticleDisplay.Immersive:
@@ -2056,6 +2060,11 @@ export const decidePalette = (
 	const overrides =
 		containerPalette && decideContainerOverrides(containerPalette);
 	return {
+		dark: {
+			text: {
+				headline: textHeadlineDark(format),
+			},
+		},
 		text: {
 			headline: textHeadline(format),
 			headlineWhenMatch: textHeadlineWhenMatch(format),


### PR DESCRIPTION
Co-authored-by: Georges Lebreton <georges.lebreton@guardian.co.uk>

## What does this change?

This RFC demonstrates dark mode support for apps articles by extending the existing `decidePalette`. There is some excellent prior art about the topic of dark mode in DCR, particularly around CSS Variables in https://github.com/guardian/dotcom-rendering/pull/5454 and https://github.com/guardian/dotcom-rendering/issues/4241.

This proposal is an alternative option for consideration. It addresses some of the concerns around determining colour values using CSS variables, but possibly at the cost of increased verbosity in components.

## Why?

Dark mode support is an existing feature in our apps, and it's something we want to keep as we implement apps articles in DCR.

Would close #7071 

## Screenshots

### Apps article

In this example, the article headline component turns orange when dark mode is enabled.

| Light mode      | Dark mode      |
| ----------- | ---------- |
| <img width="883" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/705427/41fb0036-5f49-4d67-8cb5-d9767b163ef9"> | <img width="877" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/705427/08938402-134b-4eeb-a029-437934f2166f"> |

Web articles remain unchanged.