### PR TITLE
Revert "Don't add merchandising slots for DCR network fronts in the fronts banner test"

### DIFF
--- a/dotcom-rendering/src/web/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FrontLayout.tsx
@@ -70,22 +70,19 @@ const decideAdSlot = (
 	isPaidContent: boolean | undefined,
 	format: ArticleDisplay,
 	mobileAdPositions: (number | undefined)[],
-	isInFrontsBannerTest: boolean,
 ) => {
 	const minContainers = isPaidContent ? 1 : 2;
 	if (
 		collectionCount > minContainers &&
 		index === getMerchHighPosition(collectionCount, isNetworkFront)
 	) {
-		if (!(isInFrontsBannerTest && isNetworkFront)) {
-			return (
-				<AdSlot
-					data-print-layout="hide"
-					position="merchandising-high"
-					display={format}
-				/>
-			);
-		}
+		return (
+			<AdSlot
+				data-print-layout="hide"
+				position="merchandising-high"
+				display={format}
+			/>
+		);
 	} else if (mobileAdPositions.includes(index)) {
 		return (
 			<Hide from="tablet">
@@ -121,9 +118,6 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 
 	const isInEuropeTest =
 		front.config.abTests.europeNetworkFrontVariant === 'variant';
-
-	const isInFrontsBannerTest =
-		front.config.abTests.frontsBannerAdsVariant === 'variant';
 
 	const format = {
 		display: ArticleDisplay.Standard,
@@ -282,7 +276,6 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 										.isPaidContent,
 									format.display,
 									mobileAdPositions,
-									isInFrontsBannerTest,
 								)}
 							</>
 						);
@@ -334,7 +327,6 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 										.isPaidContent,
 									format.display,
 									mobileAdPositions,
-									isInFrontsBannerTest,
 								)}
 							</>
 						);
@@ -405,7 +397,6 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 										.isPaidContent,
 									format.display,
 									mobileAdPositions,
-									isInFrontsBannerTest,
 								)}
 						</>
 					);
@@ -418,19 +409,17 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 			>
 				<TrendingTopics trendingTopics={front.trendingTopics} />
 			</Section>
-			{!(isInFrontsBannerTest && front.isNetworkFront) && (
-				<Section
-					fullWidth={true}
-					data-print-layout="hide"
-					padSides={false}
-					showTopBorder={false}
-					showSideBorders={false}
-					backgroundColour={neutral[93]}
-					element="aside"
-				>
-					<AdSlot position="merchandising" display={format.display} />
-				</Section>
-			)}
+			<Section
+				fullWidth={true}
+				data-print-layout="hide"
+				padSides={false}
+				showTopBorder={false}
+				showSideBorders={false}
+				backgroundColour={neutral[93]}
+				element="aside"
+			>
+				<AdSlot position="merchandising" display={format.display} />
+			</Section>
 
 			{NAV.subNavSections && (
 				<Section


### PR DESCRIPTION
Reverts guardian/dotcom-rendering#7710

We're now going to run this test in Frontend instead of dotcom-rendering, so we're reverting this test case.