### PR TITLE
Fix scheduled jobs permissions

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -7,6 +7,10 @@ on:
   # Allows you to run this workflow manually from the Actions tab.
   workflow_dispatch:
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   scheduled:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
## What does this change?

Fixes the schedule job permissions.

## Why?

Without this, writing to PR & issues is impossible.

## How to test

See for yourself that [this branches’s run passes](https://github.com/guardian/dotcom-rendering/actions/runs/4956747781/jobs/8867570844), unlike [the previous 2](https://github.com/guardian/dotcom-rendering/actions/workflows/scheduled.yml).