### PR TITLE
feat(datawrapper-embed): add `https://datawrapper.dwcdn.net` to CSP

### DIFF
--- a/apps-rendering/src/server/csp.ts
+++ b/apps-rendering/src/server/csp.ts
@@ -102,7 +102,7 @@ const buildCsp = (
 			? 'https://platform.twitter.com https://cdn.syndication.twimg.com'
 			: ''
 	};
-    frame-src https://www.theguardian.com https://www.scribd.com https://www.google.com https://webstories.theguardian.com https://www.linkedin.com ${
+    frame-src https://www.theguardian.com https://www.scribd.com https://www.google.com https://webstories.theguardian.com https://www.linkedin.com https://datawrapper.dwcdn.net ${
 		thirdPartyEmbed.instagram ? 'https://www.instagram.com' : ''
 	} https://www.facebook.com https://www.tiktok.com https://interactive.guim.co.uk ${
 		thirdPartyEmbed.spotify ? 'https://open.spotify.com' : ''


### PR DESCRIPTION
## What does this change?

- add `https://datawrapper.dwcdn.net` to Apps Rendering's `frame-src` CSP.
  - this change means embeds from this domain will load correctly

[Example article using this embed](https://mobile.guardianapis.com/uk/rendered-items/australia-news/2023/may/09/six-budget-2023-graphs-explain-surplus-australia-federal-may-labor-predictions-tax-revenue-cost-of-living-inflation-wages-unemployment-jobseeker-welfare)

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![image](https://github.com/guardian/dotcom-rendering/assets/705427/355a5733-9f97-4a35-bbdf-a48d2edfea9c) | ![image](https://github.com/guardian/dotcom-rendering/assets/705427/72f5c66f-1909-4c28-a050-3746d658ff4d) |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
