### PR TITLE
Hide section from "less <section>" button on fronts for non-screen-reader users

### DIFF
--- a/dotcom-rendering/src/web/components/ShowMore.importable.tsx
+++ b/dotcom-rendering/src/web/components/ShowMore.importable.tsx
@@ -21,7 +21,7 @@ import { LI } from './Card/components/LI';
 import { UL } from './Card/components/UL';
 import { FrontCard } from './FrontCard';
 
-function decideButtonText({
+const decideButtonText = ({
 	isOpen,
 	loading,
 	title,
@@ -29,11 +29,24 @@ function decideButtonText({
 	isOpen: boolean;
 	loading: boolean;
 	title: string;
-}) {
-	if (isOpen && loading) return 'Loading';
-	if (isOpen) return `Less ${title}`;
-	return `More ${title}`;
-}
+}) => {
+	if (isOpen && loading) return <>Loading</>;
+	if (isOpen)
+		return (
+			<>
+				Less{' '}
+				<span
+					css={css`
+						${visuallyHidden}
+					`}
+				>
+					{/* The context of what we're hiding is likely more useful for screen-reader users */}
+					{title}
+				</span>
+			</>
+		);
+	return <>More {title}</>;
+};
 
 type Props = {
 	title: string;


### PR DESCRIPTION

<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Closes #7739

An editorial request has come in to change the show less button from saying "Less \<section\>" to just "Less". This is in-line with how frontend already works.

However, I'm concerned this would remove valuable context for screen-reader users, as just having "Less" read out (in some cases like apple voice over this is all you get), so I've left the text there but set it to be "visually hidden"

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |



[before]: https://github.com/guardian/dotcom-rendering/assets/9575458/39466784-5044-47ef-9848-2be9763f0686
[after]: https://github.com/guardian/dotcom-rendering/assets/9575458/ffec1a64-ffe8-47c4-aee6-ef5a10d9f9fa


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
