### PR TITLE
Fix bork test config usage

### DIFF
--- a/dotcom-rendering/src/web/server/allEditorialNewslettersPageToHtml.tsx
+++ b/dotcom-rendering/src/web/server/allEditorialNewslettersPageToHtml.tsx
@@ -106,7 +106,7 @@ export const allEditorialNewslettersPageToHtml = ({
 		keywords: '',
 		offerHttp3,
 		renderingTarget: 'Web',
-		borkFCP: !!newslettersPage.config.abTests.borkFcp,
-		borkFID: !!newslettersPage.config.abTests.borkFid,
+		borkFCP: newslettersPage.config.abTests.borkFcpVariant === 'variant',
+		borkFID: newslettersPage.config.abTests.borkFidVariant === 'variant',
 	});
 };

--- a/dotcom-rendering/src/web/server/articleToHtml.tsx
+++ b/dotcom-rendering/src/web/server/articleToHtml.tsx
@@ -232,7 +232,7 @@ window.twttr = (function(d, s, id) {
 		offerHttp3,
 		canonicalUrl,
 		renderingTarget: 'Web',
-		borkFCP: !!article.config.abTests.borkFcp,
-		borkFID: !!article.config.abTests.borkFid,
+		borkFCP: article.config.abTests.borkFcpVariant === 'variant',
+		borkFID: article.config.abTests.borkFidVariant === 'variant',
 	});
 };

--- a/dotcom-rendering/src/web/server/frontToHtml.tsx
+++ b/dotcom-rendering/src/web/server/frontToHtml.tsx
@@ -107,7 +107,7 @@ export const frontToHtml = ({ front }: Props): string => {
 		keywords,
 		offerHttp3,
 		renderingTarget: 'Web',
-		borkFCP: !!front.config.abTests.borkFcp,
-		borkFID: !!front.config.abTests.borkFid,
+		borkFCP: front.config.abTests.borkFcpVariant === 'variant',
+		borkFID: front.config.abTests.borkFidVariant === 'variant',
 	});
 };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Check the actual bork test config, not the name of the bork test

## Why?

should make it work!

