### PR TITLE
Narrower server-side test type

### DIFF
--- a/dotcom-rendering/src/model/article-schema.json
+++ b/dotcom-rendering/src/model/article-schema.json
@@ -4088,15 +4088,8 @@
                     "$ref": "#/definitions/Switches"
                 },
                 "abTests": {
-                    "description": "This type is not support by JSON-schema, it evaluates as `object`",
-                    "type": "object",
-                    "additionalProperties": {
-                        "enum": [
-                            "control",
-                            "variant"
-                        ],
-                        "type": "string"
-                    }
+                    "description": "Narrowest representation of the server-side tests\nobject shape, which is [defined in `frontend`](https://github.com/guardian/frontend/blob/23743723030a041e4f4f59fa265ee2be0bb51825/common/app/experiments/ExperimentsDefinition.scala#L24-L26).\n\n**Note:** This type is not support by JSON-schema, it evaluates as `object`",
+                    "type": "object"
                 },
                 "dfpAccountId": {
                     "type": "string"

--- a/dotcom-rendering/src/model/front-schema.json
+++ b/dotcom-rendering/src/model/front-schema.json
@@ -66,15 +66,8 @@
                     "type": "string"
                 },
                 "abTests": {
-                    "description": "This type is not support by JSON-schema, it evaluates as `object`",
-                    "type": "object",
-                    "additionalProperties": {
-                        "enum": [
-                            "control",
-                            "variant"
-                        ],
-                        "type": "string"
-                    }
+                    "description": "Narrowest representation of the server-side tests\nobject shape, which is [defined in `frontend`](https://github.com/guardian/frontend/blob/23743723030a041e4f4f59fa265ee2be0bb51825/common/app/experiments/ExperimentsDefinition.scala#L24-L26).\n\n**Note:** This type is not support by JSON-schema, it evaluates as `object`",
+                    "type": "object"
                 },
                 "pbIndexSites": {
                     "type": "array",

--- a/dotcom-rendering/src/model/newsletter-page-schema.json
+++ b/dotcom-rendering/src/model/newsletter-page-schema.json
@@ -86,15 +86,8 @@
                     "$ref": "#/definitions/Switches"
                 },
                 "abTests": {
-                    "description": "This type is not support by JSON-schema, it evaluates as `object`",
-                    "type": "object",
-                    "additionalProperties": {
-                        "enum": [
-                            "control",
-                            "variant"
-                        ],
-                        "type": "string"
-                    }
+                    "description": "Narrowest representation of the server-side tests\nobject shape, which is [defined in `frontend`](https://github.com/guardian/frontend/blob/23743723030a041e4f4f59fa265ee2be0bb51825/common/app/experiments/ExperimentsDefinition.scala#L24-L26).\n\n**Note:** This type is not support by JSON-schema, it evaluates as `object`",
+                    "type": "object"
                 },
                 "dfpAccountId": {
                     "type": "string"

--- a/dotcom-rendering/src/types/config.ts
+++ b/dotcom-rendering/src/types/config.ts
@@ -15,12 +15,18 @@ export interface CommercialConfigType {
 	ampIframeUrl: string;
 }
 
-/** This type is not support by JSON-schema, it evaluates as `object` */
+/**
+ * Narrowest representation of the server-side tests
+ * object shape, which is [defined in `frontend`](https://github.com/guardian/frontend/blob/23743723030a041e4f4f59fa265ee2be0bb51825/common/app/experiments/ExperimentsDefinition.scala#L24-L26).
+ *
+ * **Note:** This type is not support by JSON-schema, it evaluates as `object`
+ */
 export type ServerSideTests = {
-	[k: string]: 'variant' | 'control';
+	[key: `${string}Variant`]: 'variant';
+	[key: `${string}Control`]: 'control';
 };
 
-export type ServerSideTestNames = `${string}Control` | `${string}Variant`;
+export type ServerSideTestNames = keyof ServerSideTests;
 
 export interface Switches {
 	[key: string]: boolean | undefined;

--- a/dotcom-rendering/src/web/browser/ophan/ophan.test.ts
+++ b/dotcom-rendering/src/web/browser/ophan/ophan.test.ts
@@ -4,13 +4,13 @@ import { abTestPayload } from './ophan';
 describe('abTestPayload', () => {
 	test('constructs payload correctly from config test data', () => {
 		const tests: ServerSideTests = {
-			MyTest: 'variant',
+			MyTestVariant: 'variant',
 		};
 
 		const actual = abTestPayload(tests);
 		const expected = {
 			abTestRegister: {
-				abMyTest: { variantName: 'variant', complete: false },
+				abMyTestVariant: { variantName: 'variant', complete: false },
 			},
 		};
 

--- a/dotcom-rendering/src/web/server/allEditorialNewslettersPageToHtml.tsx
+++ b/dotcom-rendering/src/web/server/allEditorialNewslettersPageToHtml.tsx
@@ -106,7 +106,7 @@ export const allEditorialNewslettersPageToHtml = ({
 		keywords: '',
 		offerHttp3,
 		renderingTarget: 'Web',
-		borkFCP: !!newslettersPage.config.abTests.borkFcp,
-		borkFID: !!newslettersPage.config.abTests.borkFid,
+		borkFCP: newslettersPage.config.abTests.borkFcpVariant === 'variant',
+		borkFID: newslettersPage.config.abTests.borkFidVariant === 'variant',
 	});
 };

--- a/dotcom-rendering/src/web/server/articleToHtml.tsx
+++ b/dotcom-rendering/src/web/server/articleToHtml.tsx
@@ -232,7 +232,7 @@ window.twttr = (function(d, s, id) {
 		offerHttp3,
 		canonicalUrl,
 		renderingTarget: 'Web',
-		borkFCP: !!article.config.abTests.borkFcp,
-		borkFID: !!article.config.abTests.borkFid,
+		borkFCP: article.config.abTests.borkFcpVariant === 'variant',
+		borkFID: article.config.abTests.borkFidVariant === 'variant',
 	});
 };

--- a/dotcom-rendering/src/web/server/frontToHtml.tsx
+++ b/dotcom-rendering/src/web/server/frontToHtml.tsx
@@ -107,7 +107,7 @@ export const frontToHtml = ({ front }: Props): string => {
 		keywords,
 		offerHttp3,
 		renderingTarget: 'Web',
-		borkFCP: !!front.config.abTests.borkFcp,
-		borkFID: !!front.config.abTests.borkFid,
+		borkFCP: front.config.abTests.borkFcpVariant === 'variant',
+		borkFID: front.config.abTests.borkFidVariant === 'variant',
 	});
 };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Narrow the shape of `ServerSiteTests`.

## Why?

Helps reduce incorrect usage as in #7711 & #7741.

Also addresses an known issue with our AB Test framework:

> […] Ensure the name of the client side test definition matches some transformation of the name of the Experiment in Scala (I can’t even remember what it is off the top of my head, something to do with kebab-case vs CamelCase). The test will silently fail if this isn’t correct.

## Screenshots

Any misspelling or incorrect variant name throws a TypeScript error:

<img width="293" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/76776/350e3ab3-9d49-446b-85aa-a9ed8f60485f">
