### PR TITLE
Exclude `storybook-static` From TS Program

### DIFF
--- a/dotcom-rendering/tsconfig.json
+++ b/dotcom-rendering/tsconfig.json
@@ -16,5 +16,5 @@
 		},
 		"preserveConstEnums": true
 	},
-	"exclude": ["cypress", "./cypress.config.js"]
+	"exclude": ["cypress", "./cypress.config.js", "storybook-static"]
 }


### PR DESCRIPTION
## Why?

This isn't part of our source code, and the VSCode TS integration says there are too many files with this included.

## Changes

- Add `storybook-static` to TS excludes
