### PR TITLE
fix: Pass href to a tags for subheading block component

### DIFF
--- a/dotcom-rendering/src/web/components/SubheadingBlockComponent.tsx
+++ b/dotcom-rendering/src/web/components/SubheadingBlockComponent.tsx
@@ -8,10 +8,24 @@ type Props = { html: string };
 
 const buildElementTree = (node: Node): ReactNode => {
 	if (isElement(node)) {
-		return jsx(node.tagName.toLowerCase(), {
-			id: node.attributes.getNamedItem('id')?.value,
-			children: Array.from(node.childNodes).map(buildElementTree),
-		});
+		switch (node.nodeName) {
+			case 'A':
+				return jsx('a', {
+					href: node.attributes.getNamedItem('href')?.value,
+					target: node.attributes.getNamedItem('target')?.value,
+					children: Array.from(node.childNodes).map(buildElementTree),
+				});
+
+			case 'H2':
+				return jsx('h2', {
+					id: node.attributes.getNamedItem('id')?.value,
+					children: Array.from(node.childNodes).map(buildElementTree),
+				});
+			default:
+				return jsx(node.tagName.toLowerCase(), {
+					children: Array.from(node.childNodes).map(buildElementTree),
+				});
+		}
 	} else if (node.nodeType === node.TEXT_NODE) {
 		return node.textContent;
 	} else {


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Fixes an issue where <a> tags in subheadings (h2s) were not receiving href attributes

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/9575458/921b16ca-ca1c-4535-9ce4-73d638c3082a
[after]: https://github.com/guardian/dotcom-rendering/assets/9575458/b3c40bda-9435-46a8-a392-e56a44d877d3
