### PR TITLE
Add label styles for merchandising slots

### DIFF
--- a/dotcom-rendering/src/web/components/AdSlot.tsx
+++ b/dotcom-rendering/src/web/components/AdSlot.tsx
@@ -85,10 +85,22 @@ export const labelStyles = css`
 		visibility: hidden;
 	}
 
-	.ad-slot[data-label-show='true']:not(.ad-slot--interscroller)::before {
+	.ad-slot[data-label-show='true']:not(.ad-slot--interscroller):not(
+			.ad-slot--merchandising
+		):not(.ad-slot--merchandising-high)::before {
 		content: attr(ad-label-text);
 		display: block;
 		position: relative;
+		${individualLabelCSS}
+	}
+
+	.ad-slot--merchandising[data-label-show='true']::before,
+	.ad-slot--merchandising-high[data-label-show='true']::before {
+		content: attr(ad-label-text);
+		display: block;
+		position: relative;
+		max-width: 970px;
+		margin: auto;
 		${individualLabelCSS}
 	}
 


### PR DESCRIPTION
## What does this change?
Adds label styles for merchandising slots which render consentless advertising.

## Why?
Consentless ads in the merchandising slots currently don't have any labels applied. These styles add ad labels for ads in merchandising slots rendered by DCR.

## Screenshots

Before
<img width="1247" alt="Screenshot 2023-05-16 at 17 50 31" src="https://github.com/guardian/dotcom-rendering/assets/108270776/b525431d-afe5-4472-90a7-eec31cbe71ae">
After
<img width="1206" alt="Screenshot 2023-05-16 at 17 42 54" src="https://github.com/guardian/dotcom-rendering/assets/108270776/e8d136de-08bc-4912-b5ac-f877fe3818ae">
