### PR TITLE
Show logo in front cards when the content is paid

### DIFF
--- a/dotcom-rendering/src/model/enhanceCards.ts
+++ b/dotcom-rendering/src/model/enhanceCards.ts
@@ -194,6 +194,10 @@ export const enhanceCards = (
 				? faciaCard.properties.href
 				: faciaCard.header.url;
 
+		const branding = faciaCard.properties.editionBrandings.find(
+			(edBranding) => edBranding.edition.id === 'UK',
+		)?.branding;
+
 		return {
 			format,
 			dataLinkName,
@@ -243,5 +247,6 @@ export const enhanceCards = (
 			showMainVideo: faciaCard.properties.showMainVideo,
 			isExternalLink: faciaCard.card.cardStyle.type === 'ExternalLink',
 			embedUri: faciaCard.properties.embedUri ?? undefined,
+			branding,
 		};
 	});

--- a/dotcom-rendering/src/model/enhanceCards.ts
+++ b/dotcom-rendering/src/model/enhanceCards.ts
@@ -11,6 +11,7 @@ import type { FETagType, TagType } from '../types/tag';
 import { decideFormat } from '../web/lib/decideFormat';
 import { getDataLinkNameCard } from '../web/lib/getDataLinkName';
 import { enhanceSnaps } from './enhanceSnaps';
+import { EditionId } from '../web/lib/edition';
 
 /**
  *
@@ -163,6 +164,7 @@ const enhanceTags = (tags: FETagType[]): TagType[] => {
 
 export const enhanceCards = (
 	collections: FEFrontCard[],
+	editionId?: EditionId,
 	containerPalette?: DCRContainerPalette,
 ): DCRFrontCard[] =>
 	collections.map((faciaCard, index) => {
@@ -195,7 +197,7 @@ export const enhanceCards = (
 				: faciaCard.header.url;
 
 		const branding = faciaCard.properties.editionBrandings.find(
-			(edBranding) => edBranding.edition.id === 'UK',
+			(editionBranding) => editionBranding.edition.id === editionId,
 		)?.branding;
 
 		return {

--- a/dotcom-rendering/src/model/enhanceCollections.ts
+++ b/dotcom-rendering/src/model/enhanceCollections.ts
@@ -40,10 +40,19 @@ export const enhanceCollections = (
 				collectionType,
 				collection.curated,
 				collection.backfill,
+				editionId,
 				containerPalette,
 			),
-			curated: enhanceCards(collection.curated, containerPalette),
-			backfill: enhanceCards(collection.backfill, containerPalette),
+			curated: enhanceCards(
+				collection.curated,
+				editionId,
+				containerPalette,
+			),
+			backfill: enhanceCards(
+				collection.backfill,
+				editionId,
+				containerPalette,
+			),
 			treats: enhanceTreats(
 				collection.treats,
 				displayName,

--- a/dotcom-rendering/src/model/front-schema.json
+++ b/dotcom-rendering/src/model/front-schema.json
@@ -797,6 +797,9 @@
                                                                 "required": [
                                                                     "id"
                                                                 ]
+                                                            },
+                                                            "branding": {
+                                                                "$ref": "#/definitions/Branding"
                                                             }
                                                         },
                                                         "required": [
@@ -1480,6 +1483,9 @@
                                                                 "required": [
                                                                     "id"
                                                                 ]
+                                                            },
+                                                            "branding": {
+                                                                "$ref": "#/definitions/Branding"
                                                             }
                                                         },
                                                         "required": [
@@ -2163,6 +2169,9 @@
                                                                 "required": [
                                                                     "id"
                                                                 ]
+                                                            },
+                                                            "branding": {
+                                                                "$ref": "#/definitions/Branding"
                                                             }
                                                         },
                                                         "required": [
@@ -2729,6 +2738,103 @@
             ],
             "type": "string"
         },
+        "Branding": {
+            "type": "object",
+            "properties": {
+                "brandingType": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "name"
+                    ]
+                },
+                "sponsorName": {
+                    "type": "string"
+                },
+                "logo": {
+                    "type": "object",
+                    "properties": {
+                        "src": {
+                            "type": "string"
+                        },
+                        "link": {
+                            "type": "string"
+                        },
+                        "label": {
+                            "type": "string"
+                        },
+                        "dimensions": {
+                            "type": "object",
+                            "properties": {
+                                "width": {
+                                    "type": "number"
+                                },
+                                "height": {
+                                    "type": "number"
+                                }
+                            },
+                            "required": [
+                                "height",
+                                "width"
+                            ]
+                        }
+                    },
+                    "required": [
+                        "dimensions",
+                        "label",
+                        "link",
+                        "src"
+                    ]
+                },
+                "aboutThisLink": {
+                    "type": "string"
+                },
+                "logoForDarkBackground": {
+                    "type": "object",
+                    "properties": {
+                        "src": {
+                            "type": "string"
+                        },
+                        "link": {
+                            "type": "string"
+                        },
+                        "label": {
+                            "type": "string"
+                        },
+                        "dimensions": {
+                            "type": "object",
+                            "properties": {
+                                "width": {
+                                    "type": "number"
+                                },
+                                "height": {
+                                    "type": "number"
+                                }
+                            },
+                            "required": [
+                                "height",
+                                "width"
+                            ]
+                        }
+                    },
+                    "required": [
+                        "dimensions",
+                        "label",
+                        "link",
+                        "src"
+                    ]
+                }
+            },
+            "required": [
+                "aboutThisLink",
+                "logo",
+                "sponsorName"
+            ]
+        },
         "FEContainerType": {
             "enum": [
                 "dynamic/fast",
@@ -3141,103 +3247,6 @@
                 "Video"
             ],
             "type": "string"
-        },
-        "Branding": {
-            "type": "object",
-            "properties": {
-                "brandingType": {
-                    "type": "object",
-                    "properties": {
-                        "name": {
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "name"
-                    ]
-                },
-                "sponsorName": {
-                    "type": "string"
-                },
-                "logo": {
-                    "type": "object",
-                    "properties": {
-                        "src": {
-                            "type": "string"
-                        },
-                        "link": {
-                            "type": "string"
-                        },
-                        "label": {
-                            "type": "string"
-                        },
-                        "dimensions": {
-                            "type": "object",
-                            "properties": {
-                                "width": {
-                                    "type": "number"
-                                },
-                                "height": {
-                                    "type": "number"
-                                }
-                            },
-                            "required": [
-                                "height",
-                                "width"
-                            ]
-                        }
-                    },
-                    "required": [
-                        "dimensions",
-                        "label",
-                        "link",
-                        "src"
-                    ]
-                },
-                "aboutThisLink": {
-                    "type": "string"
-                },
-                "logoForDarkBackground": {
-                    "type": "object",
-                    "properties": {
-                        "src": {
-                            "type": "string"
-                        },
-                        "link": {
-                            "type": "string"
-                        },
-                        "label": {
-                            "type": "string"
-                        },
-                        "dimensions": {
-                            "type": "object",
-                            "properties": {
-                                "width": {
-                                    "type": "number"
-                                },
-                                "height": {
-                                    "type": "number"
-                                }
-                            },
-                            "required": [
-                                "height",
-                                "width"
-                            ]
-                        }
-                    },
-                    "required": [
-                        "dimensions",
-                        "label",
-                        "link",
-                        "src"
-                    ]
-                }
-            },
-            "required": [
-                "aboutThisLink",
-                "logo",
-                "sponsorName"
-            ]
         }
     },
     "$schema": "http://json-schema.org/draft-07/schema#"

--- a/dotcom-rendering/src/model/groupCards.ts
+++ b/dotcom-rendering/src/model/groupCards.ts
@@ -5,6 +5,7 @@ import type {
 	FEFrontCard,
 } from '../types/front';
 import { enhanceCards } from './enhanceCards';
+import { EditionId } from '../web/lib/edition';
 
 /**
  * Groups cards based on their group specified in fronts tool
@@ -27,6 +28,7 @@ export const groupCards = (
 	container: DCRContainerType,
 	curated: FEFrontCard[],
 	backfill: FEFrontCard[],
+	editionId: EditionId,
 	containerPalette?: DCRContainerPalette,
 ): DCRGroupedTrails => {
 	switch (container) {
@@ -38,6 +40,7 @@ export const groupCards = (
 				veryBig: [],
 				big: enhanceCards(
 					curated.filter(({ card }) => card.group === '1'),
+					editionId,
 					containerPalette,
 				),
 				standard: enhanceCards(
@@ -45,6 +48,7 @@ export const groupCards = (
 					curated
 						.filter(({ card }) => card.group === '0')
 						.concat(backfill),
+					editionId,
 					containerPalette,
 				),
 			};
@@ -55,14 +59,17 @@ export const groupCards = (
 				snap: [],
 				huge: enhanceCards(
 					curated.filter(({ card }) => card.group === '3'),
+					editionId,
 					containerPalette,
 				),
 				veryBig: enhanceCards(
 					curated.filter(({ card }) => card.group === '2'),
+					editionId,
 					containerPalette,
 				),
 				big: enhanceCards(
 					curated.filter(({ card }) => card.group === '1'),
+					editionId,
 					containerPalette,
 				),
 				standard: enhanceCards(
@@ -70,6 +77,7 @@ export const groupCards = (
 					curated
 						.filter(({ card }) => card.group === '0')
 						.concat(backfill),
+					editionId,
 					containerPalette,
 				),
 			};
@@ -81,6 +89,7 @@ export const groupCards = (
 				// Only 'snap' and 'standard' are supported by dynamic/package
 				snap: enhanceCards(
 					curated.filter(({ card }) => card.group === '1'),
+					editionId,
 					containerPalette,
 				),
 				standard: enhanceCards(
@@ -88,6 +97,7 @@ export const groupCards = (
 					curated
 						.filter(({ card }) => card.group === '0')
 						.concat(backfill),
+					editionId,
 					containerPalette,
 				),
 			};

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -4,6 +4,7 @@ import type { ServerSideTests, Switches } from './config';
 import type { FooterType } from './footer';
 import type { FETagType } from './tag';
 import type { FETrailType, TrailType } from './trails';
+import { Branding } from './branding';
 
 export interface FEFrontType {
 	pressedPage: FEPressedPageType;
@@ -176,7 +177,7 @@ export type FEFrontCard = {
 		webTitle: string;
 		linkText?: string;
 		webUrl?: string;
-		editionBrandings: { edition: { id: EditionId } }[];
+		editionBrandings: { edition: { id: EditionId }; branding?: Branding }[];
 		href?: string;
 		embedUri?: string;
 	};
@@ -265,6 +266,7 @@ export type DCRFrontCard = {
 	showMainVideo: boolean;
 	isExternalLink: boolean;
 	embedUri?: string;
+	branding?: Branding;
 };
 
 export type FESnapType = {

--- a/dotcom-rendering/src/web/components/FrontCard.tsx
+++ b/dotcom-rendering/src/web/components/FrontCard.tsx
@@ -47,6 +47,7 @@ export const FrontCard = (props: Props) => {
 		avatarUrl: trail.avatarUrl,
 		showMainVideo: trail.showMainVideo,
 		isExternalLink: trail.isExternalLink,
+		branding: trail.branding,
 	};
 
 	return Card({ ...defaultProps, ...cardProps });

--- a/dotcom-rendering/src/web/components/FrontSection.tsx
+++ b/dotcom-rendering/src/web/components/FrontSection.tsx
@@ -473,6 +473,7 @@ export const FrontSection = ({
 							collectionId={collectionId}
 							pageId={pageId}
 							ajaxUrl={ajaxUrl}
+							editionId={editionId}
 							containerPalette={containerPalette}
 							showAge={title === 'Headlines'}
 						/>

--- a/dotcom-rendering/src/web/components/ShowMore.importable.tsx
+++ b/dotcom-rendering/src/web/components/ShowMore.importable.tsx
@@ -20,6 +20,7 @@ import { useOnce } from '../lib/useOnce';
 import { LI } from './Card/components/LI';
 import { UL } from './Card/components/UL';
 import { FrontCard } from './FrontCard';
+import { EditionId } from '../lib/edition';
 
 const decideButtonText = ({
 	isOpen,
@@ -67,6 +68,7 @@ type Props = {
 	sectionId: string;
 	showAge: boolean;
 	ajaxUrl: string;
+	editionId?: EditionId;
 	containerPalette?: DCRContainerPalette;
 };
 
@@ -77,6 +79,7 @@ export const ShowMore = ({
 	collectionId,
 	showAge,
 	ajaxUrl,
+	editionId,
 	containerPalette,
 }: Props) => {
 	const [existingCardLinks, setExistingCardLinks] = useState<string[]>([]);
@@ -110,7 +113,7 @@ export const ShowMore = ({
 
 	const cards =
 		data &&
-		enhanceCards(data).filter(
+		enhanceCards(data, editionId).filter(
 			(card) => !existingCardLinks.includes(card.url),
 		);
 

--- a/dotcom-rendering/src/web/server/index.ts
+++ b/dotcom-rendering/src/web/server/index.ts
@@ -51,6 +51,7 @@ const getStack = (e: unknown): string =>
 
 const enhanceFront = (body: unknown): DCRFrontType => {
 	const data: FEFrontType = validateAsFrontType(body);
+
 	return {
 		...data,
 		webTitle: `${


### PR DESCRIPTION
Closes https://github.com/guardian/dotcom-rendering/issues/7749

<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

DCR already has a [`Branding`](https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/src/types/branding.ts) type which contains a `BrandingLogo`. This is displayed in `Carousel` cards in articles by being passed through [`Carousel.importable` > `CarouselCard` > `Card`](https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/src/web/components/Carousel.importable.tsx#L347C7-L382).

![image](https://github.com/guardian/dotcom-rendering/assets/19683595/8d55fe5f-9c89-4043-b885-211b8309d788)


## What does this change?
We are using existing data to pass `Branding` to the `DCRFrontCard` and `FrontCard`, so that we can display the logo in front cards when the content is paid. For fronts the DOM structure is: `CardWrapper` (e.g. `Card25Media25`) > `FrontCard` > `Card`. `Card` already knows how to handle `Branding` so adding this property is enough.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/fdbbba63-05ac-467b-9162-c641001a060e) | ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/23b132ef-39d9-4cd8-8936-abd86351c099) |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
