### PR TITLE
Change card kicker teal to labs.200 from labs.400

### DIFF
--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -683,6 +683,13 @@ const textCardKicker = (format: ArticleFormat): string => {
 	if (format.theme === ArticleSpecial.SpecialReportAlt) return neutral[7];
 
 	if (format.theme === ArticleSpecial.SpecialReport) return brandAlt[400];
+
+	if (
+		format.theme === ArticleSpecial.Labs &&
+		format.design === ArticleDesign.Standard
+	)
+		return labs[200];
+
 	switch (format.design) {
 		case ArticleDesign.LiveBlog:
 			switch (format.theme) {


### PR DESCRIPTION
## What does this change?

Changes the colour of paid content cards from labs.400 to labs.300

## Why?

This is an accessibility improvement (better contrast) documented in this figma file: https://www.figma.com/file/5CfbWOeZPRi15lXBD5u1rW/Card-layout-system?type=design&node-id=161-4258&t=pW3pACoFVHznYUgr-0 and signed off by Alex and Harry and the Labs team

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| <img width="230" alt="Screenshot 2023-05-18 at 10 49 52" src="https://github.com/guardian/dotcom-rendering/assets/1229808/2476fda3-8c7c-4287-b71f-ae0a4db6ef99"> | <img width="229" alt="Screenshot 2023-05-18 at 10 50 14" src="https://github.com/guardian/dotcom-rendering/assets/1229808/45f6cf47-21e8-476a-b975-a58d689821f5"> |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
