### PR TITLE
Temporarily Make Lighthouse Workflow Manual Only

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,19 +1,6 @@
 name: DCR Run Lighthouse CI
 on:
-  push:
-    branches:
-      - main
-    paths-ignore:
-      - 'apps-rendering/**'
-      - 'dotcom-rendering/docs/**'
-
-  # We need to run on "pull_request" to get the PR number in the event.
-  # When running on "push", we cannot add a comment to a specific PR.
-  pull_request:
-    #  If/when we compare results to `main`, we should also run on 'reopened'
-    types: [opened, synchronize]
-    paths:
-      - 'dotcom-rendering/**'
+  workflow_dispatch:
 
 jobs:
   lhci:


### PR DESCRIPTION
## Why?

To test some changes to this workflow on a specific branch without enabling it for everyone. Will open a revert PR to bring back the previous behaviour when done.
