### PR TITLE
Run Lighthouse Check When Workflows Are Edited

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -14,6 +14,7 @@ on:
     types: [opened, synchronize]
     paths:
       - 'dotcom-rendering/**'
+      - '.github/workflows/**'
 
 jobs:
   lhci:


### PR DESCRIPTION
## Why?

We still want to run this check if workflows are changed, not just source code. For example, if we make changes to the lighthouse workflow we would want to run the check to make sure it still passes.
