### PR TITLE
Make Braze messaging respect `shouldHideReaderRevenue` flag

### DIFF
--- a/dotcom-rendering/src/web/components/SlotBodyEnd.importable.tsx
+++ b/dotcom-rendering/src/web/components/SlotBodyEnd.importable.tsx
@@ -63,6 +63,7 @@ const buildBrazeEpicConfig = (
 	contentType: string,
 	brazeArticleContext: BrazeArticleContext,
 	tags: TagType[],
+	shouldHideReaderRevenue: boolean,
 ): CandidateConfig<any> => {
 	return {
 		candidate: {
@@ -73,6 +74,7 @@ const buildBrazeEpicConfig = (
 					brazeArticleContext,
 					contentType,
 					tags,
+					shouldHideReaderRevenue,
 				),
 			show: (meta: any) => () =>
 				(
@@ -161,6 +163,7 @@ export const SlotBodyEnd = ({
 			contentType,
 			brazeArticleContext,
 			tags,
+			shouldHideReaderRevenue,
 		);
 		const epicConfig: SlotConfig = {
 			candidates: [brazeEpic, readerRevenueEpic],

--- a/dotcom-rendering/src/web/components/SlotBodyEnd/BrazeEpic.tsx
+++ b/dotcom-rendering/src/web/components/SlotBodyEnd/BrazeEpic.tsx
@@ -5,13 +5,13 @@ import type {
 	BrazeMessagesInterface,
 } from '@guardian/braze-components/logic';
 import { useEffect, useRef, useState } from 'react';
+import type { TagType } from '../../../types/tag';
 import { submitComponentEvent } from '../../browser/ophan/ophan';
 import { getBrazeMetaFromUrlFragment } from '../../lib/braze/forceBrazeMessage';
+import { suppressForTaylorReport } from '../../lib/braze/taylorReport';
 import type { CanShowResult } from '../../lib/messagePicker';
 import { useIsInView } from '../../lib/useIsInView';
 import { useOnce } from '../../lib/useOnce';
-import { suppressForTaylorReport } from '../../lib/braze/taylorReport';
-import { TagType } from '../../../types/tag';
 
 const wrapperMargins = css`
 	margin: 18px 0;
@@ -36,6 +36,7 @@ export const canShowBrazeEpic = async (
 	brazeArticleContext: BrazeArticleContext,
 	contentType: string,
 	tags: TagType[],
+	shouldHideReaderRevenue: boolean,
 ): Promise<CanShowResult<Meta>> => {
 	if (contentType.toLowerCase() === 'interactive') {
 		return { show: false };
@@ -47,6 +48,10 @@ export const canShowBrazeEpic = async (
 			show: true,
 			meta: forcedBrazeMeta,
 		};
+	}
+
+	if (shouldHideReaderRevenue) {
+		return { show: false };
 	}
 
 	if (suppressForTaylorReport(tags)) {

--- a/dotcom-rendering/src/web/components/StickyBottomBanner.importable.tsx
+++ b/dotcom-rendering/src/web/components/StickyBottomBanner.importable.tsx
@@ -194,11 +194,17 @@ const buildBrazeBanner = (
 	brazeArticleContext: BrazeArticleContext,
 	idApiUrl: string,
 	tags: TagType[],
+	shouldHideReaderRevenue: boolean,
 ): CandidateConfig<any> => ({
 	candidate: {
 		id: 'braze-banner',
 		canShow: () =>
-			canShowBrazeBanner(brazeMessages, brazeArticleContext, tags),
+			canShowBrazeBanner(
+				brazeMessages,
+				brazeArticleContext,
+				tags,
+				shouldHideReaderRevenue,
+			),
 		show: (meta: any) => () =>
 			<BrazeBanner meta={meta} idApiUrl={idApiUrl} />,
 	},
@@ -293,6 +299,7 @@ export const StickyBottomBanner = ({
 			brazeArticleContext,
 			idApiUrl,
 			tags,
+			shouldHideReaderRevenue,
 		);
 		const bannerConfig: SlotConfig = {
 			candidates: [CMP, puzzlesBanner, readerRevenue, brazeBanner],

--- a/dotcom-rendering/src/web/components/StickyBottomBanner/BrazeBanner.tsx
+++ b/dotcom-rendering/src/web/components/StickyBottomBanner/BrazeBanner.tsx
@@ -5,12 +5,12 @@ import type {
 	BrazeMessagesInterface,
 } from '@guardian/braze-components/logic';
 import { useEffect, useState } from 'react';
+import type { TagType } from '../../../types/tag';
 import { submitComponentEvent } from '../../browser/ophan/ophan';
 import { getBrazeMetaFromUrlFragment } from '../../lib/braze/forceBrazeMessage';
+import { suppressForTaylorReport } from '../../lib/braze/taylorReport';
 import { getZIndex } from '../../lib/getZIndex';
 import type { CanShowResult } from '../../lib/messagePicker';
-import { suppressForTaylorReport } from '../../lib/braze/taylorReport';
-import { TagType } from '../../../types/tag';
 
 type Meta = {
 	dataFromBraze: { [key: string]: string };
@@ -45,6 +45,7 @@ export const canShowBrazeBanner = async (
 	brazeMessages: BrazeMessagesInterface,
 	brazeArticleContext: BrazeArticleContext,
 	tags: TagType[],
+	shouldHideReaderRevenue: boolean,
 ): Promise<CanShowResult<Meta>> => {
 	const forcedBrazeMeta = getBrazeMetaFromUrlFragment();
 	if (forcedBrazeMeta) {
@@ -52,6 +53,10 @@ export const canShowBrazeBanner = async (
 			show: true,
 			meta: forcedBrazeMeta,
 		};
+	}
+
+	if (shouldHideReaderRevenue) {
+		return { show: false };
 	}
 
 	if (suppressForTaylorReport(tags)) {


### PR DESCRIPTION
## What does this change?

Make Braze messaging consistent with messaging from RRCP/SDC and don't show anything (banners or epics) on articles which have `shouldHideReaderRevenue` flag set to true.

## Why?

So that editorial can set the flag and be confident no messaging will be shown.

## Testing

I've tested on CODE and checked:

- [x] Banners show on articles without the flag set
- [x] Epics show on articles without the flag set
- [x] Banners do not show on articles with the flag set
- [x] Epics show on articles with the flag set

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
