### PR TITLE
Honour heading value - don't hide for standalone callouts (unless set in composer)

### DIFF
--- a/apps-rendering/src/components/Callout/calloutBlock.tsx
+++ b/apps-rendering/src/components/Callout/calloutBlock.tsx
@@ -49,7 +49,7 @@ const CalloutBlock: FC<CalloutBlockProps> = ({
 	const id = getCalloutId(heading === "" ? formId.toString() : heading);
 	const [selectedTab, setSelectedTab] = useState('form');
 	const shouldShowContacts = contacts && contacts.length > 0;
-	const shouldShowHeading = !!heading && !isNonCollapsible;
+	const shouldShowHeading = !!heading;
 	const tabsContent = [
 		{
 			id: 'form',

--- a/dotcom-rendering/src/web/components/Callout/Callout.tsx
+++ b/dotcom-rendering/src/web/components/Callout/Callout.tsx
@@ -69,7 +69,7 @@ export const CalloutBlock = ({
 }: CalloutBlockProps) => {
 	const [selectedTab, setSelectedTab] = useState('form');
 	const shouldShowContacts = contacts && contacts.length > 0;
-	const shouldShowHeading = !!heading && !isNonCollapsible;
+	const shouldShowHeading = !!heading;
 	const tabsContent = [
 		{
 			id: 'form',


### PR DESCRIPTION

<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
This removes the condition that hides the callout heading for all standalone callouts. We've completed the work to add an overrideHeading to composer, so this can now be controlled from there.

## Why?
Currently editorial can add or change a heading to standalone callouts in composer, which is ignored on the front end. This isn't consistent behaviour so we're removing the condition to hide all standalone callout headings to fix that.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
