### PR TITLE
Guardian Labs: sponsor badge

### DIFF
--- a/dotcom-rendering/fixtures/generated/articles/SpecialReport.ts
+++ b/dotcom-rendering/fixtures/generated/articles/SpecialReport.ts
@@ -1585,8 +1585,8 @@ export const SpecialReport: FEArticleType = {
 		},
 	],
 	badge: {
-		seriesTag: 'environment/series/the-polluters',
-		imageUrl:
+		href: '/environment/series/the-polluters',
+		imageSrc:
 			'https://assets.guim.co.uk/images/badges/b36f98674bc4fdb9631360f7d66b2531/the-polluters.svg',
 	},
 	pillar: 'news',

--- a/dotcom-rendering/src/model/article-schema.json
+++ b/dotcom-rendering/src/model/article-schema.json
@@ -4595,16 +4595,16 @@
         "BadgeType": {
             "type": "object",
             "properties": {
-                "seriesTag": {
+                "imageSrc": {
                     "type": "string"
                 },
-                "imageUrl": {
+                "href": {
                     "type": "string"
                 }
             },
             "required": [
-                "imageUrl",
-                "seriesTag"
+                "href",
+                "imageSrc"
             ]
         },
         "FENavType": {

--- a/dotcom-rendering/src/model/decideBadge.ts
+++ b/dotcom-rendering/src/model/decideBadge.ts
@@ -28,7 +28,7 @@ export const decideBadge = (
 		return {
 			imageSrc:
 				'https://assets.guim.co.uk/images/badges/768d8d7999510d6d05aa2d865640803c/this-is-europe.svg',
-			href: 'world/series/this-is-europe',
+			href: '/world/series/this-is-europe',
 		};
 	}
 

--- a/dotcom-rendering/src/model/decideBadge.ts
+++ b/dotcom-rendering/src/model/decideBadge.ts
@@ -1,28 +1,12 @@
-import type { FEFrontCard } from '../types/front';
 import { BadgeType } from '../types/badge';
-import { EditionId } from '../web/lib/edition';
-
-function getBrandingFromCards(
-	allCards: FEFrontCard[],
-	editionId: 'UK' | 'US' | 'AU' | 'INT' | 'EUR',
-) {
-	return allCards.map(
-		(card) =>
-			card.properties.editionBrandings.find(
-				(editionBranding) => editionBranding.edition.id === editionId,
-			)?.branding,
-	);
-}
+import { Branding } from '../types/branding';
 
 /**
  * Construct a badge based on the collection displayName or card branding
  */
 export const decideBadge = (
 	displayName: string,
-	curated: FEFrontCard[],
-	backfill: FEFrontCard[],
-	isLabs: boolean,
-	editionId: EditionId,
+	allBranding: Branding[],
 ): BadgeType | undefined => {
 	if (displayName === 'This is Europe') {
 		return {
@@ -32,22 +16,19 @@ export const decideBadge = (
 		};
 	}
 
-	const allCards = [...curated, ...backfill];
-	const allBranding = getBrandingFromCards(allCards, editionId);
-	const allSponsorNames = allBranding.map((brand) => brand?.sponsorName);
-	const theFirstBrand = allBranding[0];
-	const theFirstName = theFirstBrand?.sponsorName;
+	if (allBranding[0] !== undefined) {
+		const theFirstBrand = allBranding[0];
+		const theFirstName = theFirstBrand.sponsorName;
+		const allSponsorNames = allBranding.map((brand) => brand.sponsorName);
+		const allCardsHaveTheSameSponsor = allSponsorNames.every(
+			(sponsorName) => sponsorName === theFirstName,
+		);
+		const imageSrc = theFirstBrand.logo.src;
+		const href = theFirstBrand.logo.link;
 
-	const allCardsHaveTheSameSponsor = allSponsorNames.every(
-		(sponsorName) =>
-			sponsorName !== undefined && sponsorName === theFirstName,
-	);
-
-	const imageSrc = theFirstBrand?.logo.src;
-	const href = theFirstBrand?.logo.link;
-
-	if (isLabs && allCardsHaveTheSameSponsor && imageSrc && href) {
-		return { imageSrc, href };
+		if (allCardsHaveTheSameSponsor) {
+			return { imageSrc, href };
+		}
 	}
 
 	return undefined;

--- a/dotcom-rendering/src/model/decideBadge.ts
+++ b/dotcom-rendering/src/model/decideBadge.ts
@@ -1,0 +1,54 @@
+import type { FEFrontCard } from '../types/front';
+import { BadgeType } from '../types/badge';
+import { EditionId } from '../web/lib/edition';
+
+function getBrandingFromCards(
+	allCards: FEFrontCard[],
+	editionId: 'UK' | 'US' | 'AU' | 'INT' | 'EUR',
+) {
+	return allCards.map(
+		(card) =>
+			card.properties.editionBrandings.find(
+				(editionBranding) => editionBranding.edition.id === editionId,
+			)?.branding,
+	);
+}
+
+/**
+ * Construct a badge based on the collection displayName or card branding
+ */
+export const decideBadge = (
+	displayName: string,
+	curated: FEFrontCard[],
+	backfill: FEFrontCard[],
+	isLabs: boolean,
+	editionId: EditionId,
+): BadgeType | undefined => {
+	if (displayName === 'This is Europe') {
+		return {
+			imageSrc:
+				'https://assets.guim.co.uk/images/badges/768d8d7999510d6d05aa2d865640803c/this-is-europe.svg',
+			href: 'world/series/this-is-europe',
+		};
+	}
+
+	const allCards = [...curated, ...backfill];
+	const allBranding = getBrandingFromCards(allCards, editionId);
+	const allSponsorNames = allBranding.map((brand) => brand?.sponsorName);
+	const theFirstBrand = allBranding[0];
+	const theFirstName = theFirstBrand?.sponsorName;
+
+	const allCardsHaveTheSameSponsor = allSponsorNames.every(
+		(sponsorName) =>
+			sponsorName !== undefined && sponsorName === theFirstName,
+	);
+
+	const imageSrc = theFirstBrand?.logo.src;
+	const href = theFirstBrand?.logo.link;
+
+	if (isLabs && allCardsHaveTheSameSponsor && imageSrc && href) {
+		return { imageSrc, href };
+	}
+
+	return undefined;
+};

--- a/dotcom-rendering/src/model/decideContainerPalette.ts
+++ b/dotcom-rendering/src/model/decideContainerPalette.ts
@@ -20,5 +20,6 @@ export const decideContainerPalette = (
 	if (palettes?.includes('BreakingPalette')) return 'BreakingPalette';
 	if (palettes?.includes('SpecialReportAltPalette'))
 		return 'SpecialReportAltPalette';
+	if (palettes?.includes('Branded')) return 'Branded';
 	return undefined;
 };

--- a/dotcom-rendering/src/model/enhanceCollections.ts
+++ b/dotcom-rendering/src/model/enhanceCollections.ts
@@ -36,13 +36,6 @@ function getBrandingFromCards(
 		.filter(isNonNullable);
 }
 
-function allCardsHaveSponsors(
-	allCards: FEFrontCard[],
-	allBranding: Branding[],
-): boolean {
-	return allCards.length === allBranding.length;
-}
-
 export const enhanceCollections = (
 	collections: FECollectionType[],
 	editionId: EditionId,
@@ -57,10 +50,7 @@ export const enhanceCollections = (
 		);
 		const allCards = [...collection.curated, ...collection.curated];
 		const allBranding = getBrandingFromCards(allCards, editionId);
-		const allCardsHaveBranding = allCardsHaveSponsors(
-			allCards,
-			allBranding,
-		);
+		const allCardsHaveBranding = allCards.length === allBranding.length;
 		const isLabs = containerPalette === 'Branded' && allCardsHaveBranding;
 		return {
 			id,

--- a/dotcom-rendering/src/model/enhanceCollections.ts
+++ b/dotcom-rendering/src/model/enhanceCollections.ts
@@ -22,7 +22,7 @@ const isSupported = (collection: FECollectionType): boolean =>
 
 function getBrandingFromCards(
 	allCards: FEFrontCard[],
-	editionId: 'UK' | 'US' | 'AU' | 'INT' | 'EUR',
+	editionId: EditionId,
 ): (Branding | undefined)[] {
 	return allCards.map(
 		(card) =>

--- a/dotcom-rendering/src/model/enhanceCollections.ts
+++ b/dotcom-rendering/src/model/enhanceCollections.ts
@@ -68,7 +68,7 @@ export const enhanceCollections = (
 			badge: decideBadge(
 				displayName,
 				// allCardsHaveBranding is ensuring the correct type here
-				// @ts-ignore
+				// @ts-expect-error
 				allCardsHaveBranding ? allBranding : [],
 			),
 			grouped: groupCards(

--- a/dotcom-rendering/src/model/enhanceCollections.ts
+++ b/dotcom-rendering/src/model/enhanceCollections.ts
@@ -4,6 +4,7 @@ import { decideContainerPalette } from './decideContainerPalette';
 import { enhanceCards } from './enhanceCards';
 import { enhanceTreats } from './enhanceTreats';
 import { groupCards } from './groupCards';
+import { decideBadge } from './decideBadge';
 
 const FORBIDDEN_CONTAINERS = [
 	'Palette styles new do not delete',
@@ -26,6 +27,7 @@ export const enhanceCollections = (
 		const containerPalette = decideContainerPalette(
 			collection.config.metadata?.map((meta) => meta.type),
 		);
+		const isLabs = false; // TODO contains branded tag in metadata
 		return {
 			id,
 			displayName,
@@ -36,6 +38,14 @@ export const enhanceCollections = (
 			collectionType,
 			href,
 			containerPalette,
+			isLabs,
+			badge: decideBadge(
+				displayName,
+				collection.curated,
+				collection.backfill,
+				isLabs,
+				editionId,
+			),
 			grouped: groupCards(
 				collectionType,
 				collection.curated,

--- a/dotcom-rendering/src/types/badge.ts
+++ b/dotcom-rendering/src/types/badge.ts
@@ -1,4 +1,4 @@
 export interface BadgeType {
-	seriesTag: string;
-	imageUrl: string;
+	imageSrc: string;
+	href: string;
 }

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -5,6 +5,7 @@ import type { FooterType } from './footer';
 import type { FETagType } from './tag';
 import type { FETrailType, TrailType } from './trails';
 import { Branding } from './branding';
+import { BadgeType } from './badge';
 
 export interface FEFrontType {
 	pressedPage: FEPressedPageType;
@@ -105,7 +106,8 @@ export type DCRContainerPalette =
 	| 'LongRunningPalette'
 	| 'SombrePalette'
 	| 'BreakingPalette'
-	| 'SpecialReportAltPalette';
+	| 'SpecialReportAltPalette'
+	| 'Branded';
 
 // TODO: These may need to be declared differently than the front types in the future
 export type DCRContainerType = FEContainerType;
@@ -341,6 +343,14 @@ export type DCRCollectionType = {
 	 * will always be `false`.
 	 **/
 	canShowMore?: boolean;
+	/** Indicates whether we should render a Guardian Labs collection.
+	 *
+	 *  This overrides collectionType because we must take into account all the cards in a collection
+	 *  before deciding if we can render a Guardian Labs container.
+	 *
+	 * */
+	isLabs?: boolean;
+	badge?: BadgeType;
 };
 
 export type DCRGroupedTrails = {

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -106,7 +106,8 @@ export type DCRContainerPalette =
 	| 'LongRunningPalette'
 	| 'SombrePalette'
 	| 'BreakingPalette'
-	| 'SpecialReportAltPalette';
+	| 'SpecialReportAltPalette'
+	| 'Branded';
 
 // TODO: These may need to be declared differently than the front types in the future
 export type DCRContainerType = FEContainerType;

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -106,8 +106,7 @@ export type DCRContainerPalette =
 	| 'LongRunningPalette'
 	| 'SombrePalette'
 	| 'BreakingPalette'
-	| 'SpecialReportAltPalette'
-	| 'Branded';
+	| 'SpecialReportAltPalette';
 
 // TODO: These may need to be declared differently than the front types in the future
 export type DCRContainerType = FEContainerType;

--- a/dotcom-rendering/src/types/palette.ts
+++ b/dotcom-rendering/src/types/palette.ts
@@ -151,7 +151,7 @@ export type Palette = {
 };
 
 export type ContainerOverrides = {
-	text: {
+	text?: {
 		cardHeadline: Colour;
 		cardStandfirst: Colour;
 		cardKicker: Colour;
@@ -166,15 +166,15 @@ export type ContainerOverrides = {
 		containerToggle: Colour;
 		containerDate: Colour;
 	};
-	border: {
+	border?: {
 		container: Colour;
 		lines: Colour;
 	};
 	background: {
 		container: Colour;
-		card: Colour;
+		card?: Colour;
 	};
-	topBar: {
+	topBar?: {
 		card: Colour;
 	};
 };

--- a/dotcom-rendering/src/web/components/ArticleTitle.stories.tsx
+++ b/dotcom-rendering/src/web/components/ArticleTitle.stories.tsx
@@ -32,8 +32,8 @@ const FEBrexit = {
 		sectionLabel: 'Brexit',
 		sectionUrl: '/brexit',
 		badge: {
-			seriesTag: 'politics/series/brexit-how-it-came-to-this',
-			imageUrl:
+			href: '/politics/series/brexit-how-it-came-to-this',
+			imageSrc:
 				'https://assets.guim.co.uk/images/badges/05c6ace4e60dd0209a3f80eb03e16524/EUReferendumBadge.svg',
 		},
 	},
@@ -45,8 +45,8 @@ const FEBeyondTheBlade = {
 		sectionLabel: 'Beyond the blade',
 		sectionUrl: '/beyond-the-blade',
 		badge: {
-			seriesTag: 'membership/series/beyond-the-blade',
-			imageUrl:
+			href: '/membership/series/beyond-the-blade',
+			imageSrc:
 				'https://assets.guim.co.uk/images/badges/bfc00bc58eb966845ccf1200fd8c54e0/beyondthebladebadge.svg',
 		},
 	},

--- a/dotcom-rendering/src/web/components/ArticleTitle.tsx
+++ b/dotcom-rendering/src/web/components/ArticleTitle.tsx
@@ -70,7 +70,7 @@ export const ArticleTitle = ({
 	<div css={[sectionStyles, badge && badgeContainer]}>
 		{badge && format.display !== ArticleDisplay.Immersive && (
 			<div css={titleBadgeWrapper}>
-				<Badge imageUrl={badge.imageUrl} seriesTag={badge.seriesTag} />
+				<Badge imageSrc={badge.imageSrc} href={badge.href} />
 			</div>
 		)}
 		<div

--- a/dotcom-rendering/src/web/components/Badge.tsx
+++ b/dotcom-rendering/src/web/components/Badge.tsx
@@ -24,16 +24,15 @@ const badgeLink = css`
 `;
 
 type Props = {
-	imageUrl: string;
-	seriesTag: string;
+	imageSrc: string;
+	href: string;
 };
 
-export const Badge = ({ imageUrl, seriesTag }: Props) => {
-	const urlPath = `/${seriesTag}`;
+export const Badge = ({ imageSrc, href }: Props) => {
 	return (
 		<div css={badgeWrapper}>
-			<a href={urlPath} css={badgeLink} role="button">
-				<img css={imageStyles} src={imageUrl} alt="" />
+			<a href={href} css={badgeLink} role="button">
+				<img css={imageStyles} src={imageSrc} alt="" />
 			</a>
 		</div>
 	);

--- a/dotcom-rendering/src/web/components/ContainerTitle.tsx
+++ b/dotcom-rendering/src/web/components/ContainerTitle.tsx
@@ -110,7 +110,7 @@ export const ContainerTitle = ({
 				<>
 					<span
 						css={dateTextStyles(
-							overrides?.text.containerDate ?? neutral[0],
+							overrides?.text?.containerDate ?? neutral[0],
 						)}
 					>
 						{now.toLocaleDateString(locale, { weekday: 'long' })}
@@ -121,7 +121,7 @@ export const ContainerTitle = ({
 								display: block;
 							`,
 							dateTextStyles(
-								overrides?.text.containerDate ?? news[400],
+								overrides?.text?.containerDate ?? news[400],
 							),
 							bottomMargin,
 						]}

--- a/dotcom-rendering/src/web/components/FrontSection.tsx
+++ b/dotcom-rendering/src/web/components/FrontSection.tsx
@@ -1,5 +1,4 @@
 import { css } from '@emotion/react';
-import type { EmotionJSX } from '@emotion/react/types/jsx-namespace';
 import { from, neutral, space, until } from '@guardian/source-foundations';
 import { Hide } from '@guardian/source-react-components';
 import type { DCRContainerPalette, TreatType } from '../../types/front';
@@ -10,6 +9,8 @@ import { Island } from './Island';
 import { ShowHideButton } from './ShowHideButton';
 import { ShowMore } from './ShowMore.importable';
 import { Treats } from './Treats';
+import { BadgeType } from '../../types/badge';
+import { Badge } from './Badge';
 
 type Props = {
 	/** This text will be used as the h2 shown in the left column for the section */
@@ -52,7 +53,7 @@ type Props = {
 	editionId?: EditionId;
 	/** A list of related links that appear in the bottom of the left column on fronts */
 	treats?: TreatType[];
-	badge?: EmotionJSX.Element;
+	badge?: BadgeType;
 	/** Enable the "Show More" button on this container to allow readers to load more cards */
 	canShowMore?: boolean;
 	ajaxUrl?: string;
@@ -418,19 +419,30 @@ export const FrontSection = ({
 				fallbackStyles,
 				containerStyles,
 				css`
-					background-color: ${overrides?.background.container};
+					background-color: ${overrides?.background?.container};
 				`,
 			]}
 		>
 			<div css={[decoration, sideBorders, showTopBorder && topBorder]} />
 
 			<div css={[sectionHeadline]}>
-				<Hide until="leftCol">{badge}</Hide>
+				<Hide until="leftCol">
+					{badge && (
+						<Badge imageSrc={badge?.imageSrc} href={badge?.href} />
+					)}
+				</Hide>
 				<div css={titleStyle}>
-					<Hide from="leftCol">{badge}</Hide>
+					<Hide from="leftCol">
+						{badge && (
+							<Badge
+								imageSrc={badge?.imageSrc}
+								href={badge?.href}
+							/>
+						)}
+					</Hide>
 					<ContainerTitle
 						title={title}
-						fontColour={overrides?.text.container}
+						fontColour={overrides?.text?.container}
 						description={description}
 						url={url}
 						containerPalette={containerPalette}
@@ -446,7 +458,7 @@ export const FrontSection = ({
 					<ShowHideButton
 						sectionId={sectionId}
 						overrideContainerToggleColour={
-							overrides?.text.containerToggle
+							overrides?.text?.containerToggle
 						}
 					/>
 				</div>
@@ -485,7 +497,7 @@ export const FrontSection = ({
 				<div css={[sectionTreats, paddings]}>
 					<Treats
 						treats={treats}
-						borderColour={overrides?.border.container}
+						borderColour={overrides?.border?.container}
 					/>
 				</div>
 			)}

--- a/dotcom-rendering/src/web/components/MiniCard.tsx
+++ b/dotcom-rendering/src/web/components/MiniCard.tsx
@@ -20,7 +20,7 @@ const linkStyles = css`
 `;
 
 const linkOverrideStyles = (containerOverrides?: ContainerOverrides) => css`
-	${containerOverrides && `color: ${containerOverrides.text.cardHeadline}`}
+	${containerOverrides && `color: ${containerOverrides.text?.cardHeadline}`}
 `;
 
 type Props = {

--- a/dotcom-rendering/src/web/components/MiniCard.tsx
+++ b/dotcom-rendering/src/web/components/MiniCard.tsx
@@ -20,7 +20,9 @@ const linkStyles = css`
 `;
 
 const linkOverrideStyles = (containerOverrides?: ContainerOverrides) => css`
-	${containerOverrides && `color: ${containerOverrides.text?.cardHeadline}`}
+	${containerOverrides &&
+	containerOverrides.text &&
+	`color: ${containerOverrides.text.cardHeadline}`}
 `;
 
 type Props = {

--- a/dotcom-rendering/src/web/components/MiniCard.tsx
+++ b/dotcom-rendering/src/web/components/MiniCard.tsx
@@ -20,8 +20,7 @@ const linkStyles = css`
 `;
 
 const linkOverrideStyles = (containerOverrides?: ContainerOverrides) => css`
-	${containerOverrides &&
-	containerOverrides.text &&
+	${containerOverrides?.text &&
 	`color: ${containerOverrides.text.cardHeadline}`}
 `;
 

--- a/dotcom-rendering/src/web/components/NavList.tsx
+++ b/dotcom-rendering/src/web/components/NavList.tsx
@@ -14,12 +14,12 @@ type Props = {
 
 const columnRuleColour = (containerOverrides?: ContainerOverrides) => css`
 	column-rule: 1px solid
-		${containerOverrides?.border.container ?? border.secondary};
+		${containerOverrides?.border?.container ?? border.secondary};
 `;
 
 const topBorderColour = (containerOverrides?: ContainerOverrides) => css`
 	border-top: 1px solid
-		${containerOverrides?.topBar.card ?? palette.neutral[93]};
+		${containerOverrides?.topBar?.card ?? palette.neutral[93]};
 `;
 
 const ulStyles = css`

--- a/dotcom-rendering/src/web/components/Section.tsx
+++ b/dotcom-rendering/src/web/components/Section.tsx
@@ -237,9 +237,9 @@ export const Section = ({
 				showTopBorder={showTopBorder}
 				padSides={padSides}
 				padBottom={padBottom}
-				borderColour={borderColour ?? overrides?.border.container}
+				borderColour={borderColour ?? overrides?.border?.container}
 				backgroundColour={
-					backgroundColour ?? overrides?.background.container
+					backgroundColour ?? overrides?.background?.container
 				}
 				ophanComponentLink={ophanComponentLink}
 				ophanComponentName={ophanComponentName}
@@ -260,9 +260,9 @@ export const Section = ({
 			showSideBorders={showSideBorders}
 			showTopBorder={showTopBorder}
 			padSides={padSides}
-			borderColour={borderColour ?? overrides?.border.container}
+			borderColour={borderColour ?? overrides?.border?.container}
 			backgroundColour={
-				backgroundColour ?? overrides?.background.container
+				backgroundColour ?? overrides?.background?.container
 			}
 			element="section"
 			ophanComponentLink={ophanComponentLink}
@@ -273,7 +273,7 @@ export const Section = ({
 			<Flex>
 				<LeftColumn
 					borderType={centralBorder}
-					borderColour={borderColour ?? overrides?.border.container}
+					borderColour={borderColour ?? overrides?.border?.container}
 					size={leftColSize}
 					verticalMargins={verticalMargins}
 				>
@@ -289,7 +289,7 @@ export const Section = ({
 							<ContainerTitle
 								title={title}
 								fontColour={
-									fontColour ?? overrides?.text.container
+									fontColour ?? overrides?.text?.container
 								}
 								description={description}
 								url={url}
@@ -303,7 +303,7 @@ export const Section = ({
 							<Treats
 								treats={treats}
 								borderColour={
-									borderColour ?? overrides?.border.container
+									borderColour ?? overrides?.border?.container
 								}
 							/>
 						)}
@@ -320,7 +320,7 @@ export const Section = ({
 							<ContainerTitle
 								title={title}
 								fontColour={
-									fontColour ?? overrides?.text.container
+									fontColour ?? overrides?.text?.container
 								}
 								description={description}
 								url={url}
@@ -333,7 +333,7 @@ export const Section = ({
 							<ShowHideButton
 								sectionId={sectionId}
 								overrideContainerToggleColour={
-									overrides?.text.containerToggle
+									overrides?.text?.containerToggle
 								}
 							/>
 						)}

--- a/dotcom-rendering/src/web/components/SeriesSectionLink.tsx
+++ b/dotcom-rendering/src/web/components/SeriesSectionLink.tsx
@@ -323,8 +323,8 @@ export const SeriesSectionLink = ({
 										]}
 									>
 										<Badge
-											imageUrl={badge.imageUrl}
-											seriesTag={badge.seriesTag}
+											imageSrc={badge.imageSrc}
+											href={badge.href}
 										/>
 									</div>
 								)}

--- a/dotcom-rendering/src/web/components/SubMeta.tsx
+++ b/dotcom-rendering/src/web/components/SubMeta.tsx
@@ -165,10 +165,7 @@ export const SubMeta = ({
 		>
 			{badge && (
 				<div css={badgeWrapper}>
-					<Badge
-						imageUrl={badge.imageUrl}
-						seriesTag={badge.seriesTag}
-					/>
+					<Badge imageSrc={badge.imageSrc} href={badge.href} />
 				</div>
 			)}
 			{(hasSectionLinks || hasKeywordLinks) && (

--- a/dotcom-rendering/src/web/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FrontLayout.tsx
@@ -11,7 +11,6 @@ import { StraightLines } from '@guardian/source-react-components-development-kit
 import type { NavType } from '../../model/extract-nav';
 import type { DCRCollectionType, DCRFrontType } from '../../types/front';
 import { AdSlot } from '../components/AdSlot';
-import { Badge } from '../components/Badge';
 import { CPScottHeader } from '../components/CPScottHeader';
 import { Footer } from '../components/Footer';
 import { FrontMostViewed } from '../components/FrontMostViewed';
@@ -97,19 +96,6 @@ const decideAdSlot = (
 		);
 	}
 	return null;
-};
-
-const showBadge = (displayName: string) => {
-	if (displayName === 'This is Europe')
-		return (
-			<Badge
-				imageUrl={
-					'https://assets.guim.co.uk/images/badges/768d8d7999510d6d05aa2d865640803c/this-is-europe.svg'
-				}
-				seriesTag={'world/series/this-is-europe'}
-			/>
-		);
-	return undefined;
 };
 
 export const FrontLayout = ({ front, NAV }: Props) => {
@@ -389,7 +375,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 										<CPScottHeader />
 									)
 								}
-								badge={showBadge(collection.displayName)}
+								badge={collection.badge}
 								sectionId={ophanName}
 								collectionId={collection.id}
 								pageId={front.pressedPage.id}

--- a/dotcom-rendering/src/web/lib/decideContainerOverrides.ts
+++ b/dotcom-rendering/src/web/lib/decideContainerOverrides.ts
@@ -14,7 +14,9 @@ const {
 	sport,
 } = palette;
 
-const textCardHeadline = (containerPalette: DCRContainerPalette): string => {
+const textCardHeadline = (
+	containerPalette: Exclude<DCRContainerPalette, 'Branded'>,
+): string => {
 	switch (containerPalette) {
 		case 'LongRunningPalette':
 			return neutral[100];
@@ -40,7 +42,9 @@ const textCardHeadline = (containerPalette: DCRContainerPalette): string => {
 const textCardStandfirst = textCardHeadline;
 const textCardFooter = textCardHeadline;
 
-const textCardKicker = (containerPalette: DCRContainerPalette): string => {
+const textCardKicker = (
+	containerPalette: Exclude<DCRContainerPalette, 'Branded'>,
+): string => {
 	switch (containerPalette) {
 		case 'LongRunningPalette':
 			return news[550];
@@ -65,7 +69,9 @@ const textCardKicker = (containerPalette: DCRContainerPalette): string => {
 
 const textCardByline = textCardKicker;
 
-const textContainerDate = (containerPalette: DCRContainerPalette): string => {
+const textContainerDate = (
+	containerPalette: Exclude<DCRContainerPalette, 'Branded'>,
+): string => {
 	switch (containerPalette) {
 		case 'LongRunningPalette':
 			return news[400];
@@ -89,7 +95,7 @@ const textContainerDate = (containerPalette: DCRContainerPalette): string => {
 };
 
 const textCardCommentCount = (
-	containerPalette: DCRContainerPalette,
+	containerPalette: Exclude<DCRContainerPalette, 'Branded'>,
 ): string => {
 	switch (containerPalette) {
 		case 'LongRunningPalette':
@@ -113,7 +119,9 @@ const textCardCommentCount = (
 	}
 };
 
-const textDynamoHeadline = (containerPalette: DCRContainerPalette): string => {
+const textDynamoHeadline = (
+	containerPalette: Exclude<DCRContainerPalette, 'Branded'>,
+): string => {
 	switch (containerPalette) {
 		case 'LongRunningPalette':
 			return brand[400];
@@ -136,7 +144,9 @@ const textDynamoHeadline = (containerPalette: DCRContainerPalette): string => {
 	}
 };
 
-const textDynamoKicker = (containerPalette: DCRContainerPalette): string => {
+const textDynamoKicker = (
+	containerPalette: Exclude<DCRContainerPalette, 'Branded'>,
+): string => {
 	switch (containerPalette) {
 		case 'LongRunningPalette':
 			return news[400];
@@ -181,10 +191,14 @@ const textDynamoSublinkKicker = (
 			return news[400];
 		case 'SpecialReportAltPalette':
 			return neutral[7];
+		case 'Branded':
+			return neutral[7];
 	}
 };
 
-const textDynamoMeta = (containerPalette: DCRContainerPalette): string => {
+const textDynamoMeta = (
+	containerPalette: Exclude<DCRContainerPalette, 'Branded'>,
+): string => {
 	switch (containerPalette) {
 		case 'LongRunningPalette':
 			return brand[400];
@@ -207,7 +221,9 @@ const textDynamoMeta = (containerPalette: DCRContainerPalette): string => {
 	}
 };
 
-const textContainer = (containerPalette: DCRContainerPalette): string => {
+const textContainer = (
+	containerPalette: Exclude<DCRContainerPalette, 'Branded'>,
+): string => {
 	switch (containerPalette) {
 		case 'LongRunningPalette':
 			return brand[400];
@@ -230,7 +246,9 @@ const textContainer = (containerPalette: DCRContainerPalette): string => {
 	}
 };
 
-const textContainerToggle = (containerPalette: DCRContainerPalette): string => {
+const textContainerToggle = (
+	containerPalette: Exclude<DCRContainerPalette, 'Branded'>,
+): string => {
 	switch (containerPalette) {
 		case 'LongRunningPalette':
 			return neutral[20];
@@ -253,7 +271,9 @@ const textContainerToggle = (containerPalette: DCRContainerPalette): string => {
 	}
 };
 
-const borderContainer = (containerPalette: DCRContainerPalette): string => {
+const borderContainer = (
+	containerPalette: Exclude<DCRContainerPalette, 'Branded'>,
+): string => {
 	switch (containerPalette) {
 		case 'LongRunningPalette':
 			return transparentColour(neutral[60], 0.4);
@@ -298,10 +318,14 @@ const backgroundContainer = (containerPalette: DCRContainerPalette): string => {
 			return culture[800];
 		case 'SpecialReportAltPalette':
 			return specialReportAlt[800];
+		case 'Branded':
+			return neutral[93];
 	}
 };
 
-const backgroundCard = (containerPalette: DCRContainerPalette): string => {
+const backgroundCard = (
+	containerPalette: Exclude<DCRContainerPalette, 'Branded'>,
+): string => {
 	switch (containerPalette) {
 		case 'LongRunningPalette':
 			return brand[400];
@@ -337,6 +361,13 @@ const topBarCard = textCardKicker;
 export const decideContainerOverrides = (
 	containerPalette: DCRContainerPalette,
 ): ContainerOverrides => {
+	if (containerPalette === 'Branded') {
+		return {
+			background: {
+				container: backgroundContainer(containerPalette),
+			},
+		};
+	}
 	return {
 		text: {
 			cardHeadline: textCardHeadline(containerPalette),

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -2081,18 +2081,18 @@ export const decidePalette = (
 			articleLink: textArticleLink(format),
 			articleLinkHover: textArticleLinkHover(format),
 			cardHeadline:
-				overrides?.text.cardHeadline ?? textCardHeadline(format),
+				overrides?.text?.cardHeadline ?? textCardHeadline(format),
 			dynamoHeadline:
-				overrides?.text.dynamoHeadline ?? textCardHeadline(format),
-			cardByline: overrides?.text.cardByline ?? textCardByline(format),
-			cardKicker: overrides?.text.cardKicker ?? textCardKicker(format),
+				overrides?.text?.dynamoHeadline ?? textCardHeadline(format),
+			cardByline: overrides?.text?.cardByline ?? textCardByline(format),
+			cardKicker: overrides?.text?.cardKicker ?? textCardKicker(format),
 			dynamoKicker:
-				overrides?.text.dynamoKicker ?? textCardKicker(format),
+				overrides?.text?.dynamoKicker ?? textCardKicker(format),
 			linkKicker: textLinkKicker(format),
 			cardStandfirst:
-				overrides?.text.cardStandfirst ?? textCardStandfirst(format),
-			cardFooter: overrides?.text.cardFooter ?? textCardFooter(format),
-			dynamoMeta: overrides?.text.dynamoMeta ?? textCardFooter(format),
+				overrides?.text?.cardStandfirst ?? textCardStandfirst(format),
+			cardFooter: overrides?.text?.cardFooter ?? textCardFooter(format),
+			dynamoMeta: overrides?.text?.dynamoMeta ?? textCardFooter(format),
 			headlineByline: textHeadlineByline(format),
 			standfirst: textStandfirst(format),
 			standfirstLink: textStandfirstLink(format),
@@ -2134,7 +2134,7 @@ export const decidePalette = (
 			seriesTitle: backgroundSeriesTitle(format),
 			sectionTitle: backgroundSectionTitle(format),
 			avatar: backgroundAvatar(format),
-			card: overrides?.background.card ?? backgroundCard(format),
+			card: overrides?.background?.card ?? backgroundCard(format),
 			headline: backgroundHeadline(format),
 			headlineByline: backgroundHeadlineByline(format),
 			bullet: backgroundBullet(format),
@@ -2192,7 +2192,7 @@ export const decidePalette = (
 			richLink: borderRichLink(format),
 			navPillar: borderNavPillar(format),
 			article: borderArticle(format),
-			lines: overrides?.border.lines ?? borderLines(format),
+			lines: overrides?.border?.lines ?? borderLines(format),
 			cricketScoreboardTop: borderCricketScoreboardTop(),
 			cricketScoreboardDivider: borderCricketScoreboardDivider(),
 			matchTab: matchTab(),
@@ -2204,7 +2204,7 @@ export const decidePalette = (
 			pagination: borderPagination(),
 		},
 		topBar: {
-			card: overrides?.topBar.card ?? topBarCard(format),
+			card: overrides?.topBar?.card ?? topBarCard(format),
 		},
 		hover: {
 			headlineByline: hoverHeadlineByline(format),

--- a/dotcom-rendering/src/web/lib/verticalDivider.ts
+++ b/dotcom-rendering/src/web/lib/verticalDivider.ts
@@ -23,7 +23,7 @@ export const verticalDivider = (
 				height: 100%;
 				border-left: 1px solid
 					${containerOverrides
-						? containerOverrides.border.container
+						? containerOverrides.border?.container
 						: border.secondary};
 			}
 		}

--- a/dotcom-rendering/src/web/lib/verticalDividerWithBottomOffset.ts
+++ b/dotcom-rendering/src/web/lib/verticalDividerWithBottomOffset.ts
@@ -26,7 +26,7 @@ export function verticalDividerWithBottomOffset(
 				height: calc(100% + ${bottomPaddingSize});
 				border-left: 1px solid
 					${containerOverrides
-						? containerOverrides.border.container
+						? containerOverrides.border?.container
 						: border.secondary};
 			}
 		}


### PR DESCRIPTION
## What does this change?

This change introduces a sponsor's badge into the existing badge field of the DCRCollectionType.

The sponsor badge will be provided when: 
* all the cards in a container have the same sponsor and 
* the container palette is "branded", which means a "branded" tag was added to it in the fronts config tool 

Since the DCRContainerPalette needs to now be aware of the Branded type, I have updated decideContainerOverrides.ts to allow for the fact that in the case of a Branded container (or Labs container) the only override is the background colour.

## Why?

Guardian Labs containers will display this sponsor badge more prominently when it is provided. 

## Screenshots

Note: the badge is not yet displayed in the correct location, and it also needs to be removed from the individual cards. But one step at a time.. 

| Before      | After      |
| ----------- | ---------- |
| <img width="1297" alt="Screenshot 2023-05-22 at 15 32 10" src="https://github.com/guardian/dotcom-rendering/assets/1229808/fbde92b0-8fe8-4de9-b26e-2b76df1465aa"> | <img width="1297" alt="Screenshot 2023-05-22 at 15 31 29" src="https://github.com/guardian/dotcom-rendering/assets/1229808/e1eab483-d927-4e6e-b9da-aa3e9a8e14f2"> |



<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
