### PR TITLE
New Palette Proposal

### DIFF
--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -6,40 +6,40 @@ import { palette as sourcePalette } from '@guardian/source-foundations';
 // ----- Palette Functions ----- //
 
 const headlineColourLight = ({ design }: ArticleFormat): string => {
-    switch (design) {
-        case ArticleDesign.Feature:
-            return sourcePalette.news[300];    
-        default:
-            return sourcePalette.neutral[10];
-    }
-}
+	switch (design) {
+		case ArticleDesign.Feature:
+			return sourcePalette.news[300];
+		default:
+			return sourcePalette.neutral[10];
+	}
+};
 
 const headlineColourDark = ({ design }: ArticleFormat): string => {
-    switch (design) {
-        case ArticleDesign.Feature:
-            return sourcePalette.news[600];    
-        default:
-            return sourcePalette.neutral[97];
-    }
-}
+	switch (design) {
+		case ArticleDesign.Feature:
+			return sourcePalette.news[600];
+		default:
+			return sourcePalette.neutral[97];
+	}
+};
 
 const headlineBackgroundColourLight = ({ design }: ArticleFormat): string => {
-    switch (design) {
-        case ArticleDesign.LiveBlog:
-            return sourcePalette.news[400];
-        default:
-            return sourcePalette.neutral[100];
-    }
-}
+	switch (design) {
+		case ArticleDesign.LiveBlog:
+			return sourcePalette.news[400];
+		default:
+			return sourcePalette.neutral[100];
+	}
+};
 
 const headlineBackgroundColourDark = ({ design }: ArticleFormat): string => {
-    switch (design) {
-        case ArticleDesign.LiveBlog:
-            return sourcePalette.news[200];
-        default:
-            return sourcePalette.neutral[7];
-    }
-}
+	switch (design) {
+		case ArticleDesign.LiveBlog:
+			return sourcePalette.news[200];
+		default:
+			return sourcePalette.neutral[7];
+	}
+};
 
 // ----- Palette ----- //
 
@@ -57,28 +57,31 @@ type PaletteFunction = (f: ArticleFormat) => string;
  * Used to validate that the palette object always has the correct shape,
  * without changing its type.
  */
-type PaletteColours = Record<CSSCustomProperty, {
-    light: PaletteFunction,
-    dark: PaletteFunction,
-}>;
+type PaletteColours = Record<
+	CSSCustomProperty,
+	{
+		light: PaletteFunction;
+		dark: PaletteFunction;
+	}
+>;
 
 /**
  * Maps palette colour names (which are also CSS custom property names) to
  * a pair of palette functions, which can be used to derive both light and dark
  * mode colours from an {@linkcode ArticleFormat}.
- * 
+ *
  * This is not accessed directly in components; the {@linkcode palette} function
  * is used instead.
  */
 const paletteColours = {
-    '--headline-colour': {
-        light: headlineColourLight,
-        dark: headlineColourDark,
-    },
-    '--headline-background-colour': {
-        light: headlineBackgroundColourLight,
-        dark: headlineBackgroundColourDark,
-    },
+	'--headline-colour': {
+		light: headlineColourLight,
+		dark: headlineColourDark,
+	},
+	'--headline-background-colour': {
+		light: headlineBackgroundColourLight,
+		dark: headlineBackgroundColourDark,
+	},
 } satisfies PaletteColours;
 
 /**
@@ -91,7 +94,7 @@ type ColourName = keyof typeof paletteColours;
  * Looks up a palette colour by name. Retrieves a CSS value for the specified
  * colour, for use in CSS declarations. See the examples for how this is
  * commonly used with our Emotion-based styles.
- * 
+ *
  * @param a The name of a palette colour; for example `--headline-colour`.
  * @returns A CSS `var` function call; for example `var(--headline-colour)`.
  * @example
@@ -107,7 +110,7 @@ const palette = (colour: ColourName): string => `var(${colour})`;
  * can be used to set up the palette on any element, and then retrieved to apply
  * styles via the {@linkcode palette} function. See the examples for ways the
  * palette could be set up.
- * 
+ *
  * @param format The `ArticleFormat` of the current article.
  * @param colourScheme Get declarations for either `light` or `dark` mode.
  * @returns A set of CSS custom property declarations for palette colours,
@@ -121,7 +124,7 @@ const palette = (colour: ColourName): string => `var(${colour})`;
  *   :root {
  *     ${paletteDeclarations(format, 'light').join('\n')}
  *   }
- * 
+ *
  *   (@)media (prefers-color-scheme: dark) {
  *     :root {
  *       ${paletteDeclarations(format, 'dark').join('\n')}
@@ -142,7 +145,7 @@ const palette = (colour: ColourName): string => `var(${colour})`;
  *     ${paletteDeclarations(format, 'dark').join('\n')}
  *   }
  * `;
- * 
+ *
  * const stylesheets = (
  *   <>
  *     <link
@@ -158,14 +161,15 @@ const palette = (colour: ColourName): string => `var(${colour})`;
  *   </>
  * );
  */
-const paletteDeclarations = (format: ArticleFormat, colourScheme: 'light' | 'dark'): string[] =>
-    Object.entries(paletteColours).map(([colourName, colour]) =>
-        `${colourName}: ${colour[colourScheme](format)};`,
-    );
+const paletteDeclarations = (
+	format: ArticleFormat,
+	colourScheme: 'light' | 'dark',
+): string[] =>
+	Object.entries(paletteColours).map(
+		([colourName, colour]) =>
+			`${colourName}: ${colour[colourScheme](format)};`,
+	);
 
 // ----- Exports ----- //
 
-export {
-    palette,
-    paletteDeclarations,
-}
+export { palette, paletteDeclarations };

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -1,0 +1,171 @@
+// ----- Imports ----- //
+
+import { ArticleDesign, type ArticleFormat } from '@guardian/libs';
+import { palette as sourcePalette } from '@guardian/source-foundations';
+
+// ----- Palette Functions ----- //
+
+const headlineColourLight = ({ design }: ArticleFormat): string => {
+    switch (design) {
+        case ArticleDesign.Feature:
+            return sourcePalette.news[300];    
+        default:
+            return sourcePalette.neutral[10];
+    }
+}
+
+const headlineColourDark = ({ design }: ArticleFormat): string => {
+    switch (design) {
+        case ArticleDesign.Feature:
+            return sourcePalette.news[600];    
+        default:
+            return sourcePalette.neutral[97];
+    }
+}
+
+const headlineBackgroundColourLight = ({ design }: ArticleFormat): string => {
+    switch (design) {
+        case ArticleDesign.LiveBlog:
+            return sourcePalette.news[400];
+        default:
+            return sourcePalette.neutral[100];
+    }
+}
+
+const headlineBackgroundColourDark = ({ design }: ArticleFormat): string => {
+    switch (design) {
+        case ArticleDesign.LiveBlog:
+            return sourcePalette.news[200];
+        default:
+            return sourcePalette.neutral[7];
+    }
+}
+
+// ----- Palette ----- //
+
+/**
+ * A template literal type used to make sure the keys of the palette use the
+ * correct CSS custom property syntax.
+ */
+type CSSCustomProperty = `--${string}`;
+/**
+ * Ensures that all palette functions provide the same API, deriving a palette
+ * colour from an {@linkcode ArticleFormat}.
+ */
+type PaletteFunction = (f: ArticleFormat) => string;
+/**
+ * Used to validate that the palette object always has the correct shape,
+ * without changing its type.
+ */
+type PaletteColours = Record<CSSCustomProperty, {
+    light: PaletteFunction,
+    dark: PaletteFunction,
+}>;
+
+/**
+ * Maps palette colour names (which are also CSS custom property names) to
+ * a pair of palette functions, which can be used to derive both light and dark
+ * mode colours from an {@linkcode ArticleFormat}.
+ * 
+ * This is not accessed directly in components; the {@linkcode palette} function
+ * is used instead.
+ */
+const paletteColours = {
+    '--headline-colour': {
+        light: headlineColourLight,
+        dark: headlineColourDark,
+    },
+    '--headline-background-colour': {
+        light: headlineBackgroundColourLight,
+        dark: headlineBackgroundColourDark,
+    },
+} satisfies PaletteColours;
+
+/**
+ * A union of all the keys of the palette object. In other words, all the
+ * possible colours that can be chosen.
+ */
+type ColourName = keyof typeof paletteColours;
+
+/**
+ * Looks up a palette colour by name. Retrieves a CSS value for the specified
+ * colour, for use in CSS declarations. See the examples for how this is
+ * commonly used with our Emotion-based styles.
+ * 
+ * @param a The name of a palette colour; for example `--headline-colour`.
+ * @returns A CSS `var` function call; for example `var(--headline-colour)`.
+ * @example
+ * const styles = css`
+ *   color: ${palette('--headline-colour')};
+ *   background-color: ${palette('--headline-background-colour')};
+ * `;
+ */
+const palette = (colour: ColourName): string => `var(${colour})`;
+
+/**
+ * Builds a list of CSS custom property declarations representing colours. These
+ * can be used to set up the palette on any element, and then retrieved to apply
+ * styles via the {@linkcode palette} function. See the examples for ways the
+ * palette could be set up.
+ * 
+ * @param format The `ArticleFormat` of the current article.
+ * @param colourScheme Get declarations for either `light` or `dark` mode.
+ * @returns A set of CSS custom property declarations for palette colours,
+ * in string format. For example:
+ * ```
+ * [ '--headline-colour: #1a1a1a;', '--headline-background-colour: #ffffff;' ]
+ * ```
+ * @example
+ * <caption>Create a single stylesheet to handle both colour schemes.</caption>
+ * const paletteStyles = css`
+ *   :root {
+ *     ${paletteDeclarations(format, 'light').join('\n')}
+ *   }
+ * 
+ *   (@)media (prefers-color-scheme: dark) {
+ *     :root {
+ *       ${paletteDeclarations(format, 'dark').join('\n')}
+ *     }
+ *   }
+ * `;
+ * @example
+ * <caption>Load separate stylesheets based on user preference.</caption>
+ * // Use to build a file called 'light.css'.
+ * const lightPalette = css`
+ *   :root {
+ *     ${paletteDeclarations(format, 'light').join('\n')}
+ *   }
+ * `;
+ * // Use to build a file called 'dark.css'.
+ * const darkPalette = css`
+ *   :root {
+ *     ${paletteDeclarations(format, 'dark').join('\n')}
+ *   }
+ * `;
+ * 
+ * const stylesheets = (
+ *   <>
+ *     <link
+ *       media="(prefers-color-scheme: light)"
+ *       rel="stylesheet"
+ *       href="light.css"
+ *     />
+ *     <link
+ *       media="(prefers-color-scheme: dark)"
+ *       rel="stylesheet"
+ *       href="dark.css"
+ *     />
+ *   </>
+ * );
+ */
+const paletteDeclarations = (format: ArticleFormat, colourScheme: 'light' | 'dark'): string[] =>
+    Object.entries(paletteColours).map(([colourName, colour]) =>
+        `${colourName}: ${colour[colourScheme](format)};`,
+    );
+
+// ----- Exports ----- //
+
+export {
+    palette,
+    paletteDeclarations,
+}

--- a/dotcom-rendering/src/web/components/HeadlineExample.stories.tsx
+++ b/dotcom-rendering/src/web/components/HeadlineExample.stories.tsx
@@ -1,0 +1,56 @@
+// ----- Imports ----- //
+
+import { css } from '@emotion/react';
+import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
+import type { Meta, StoryObj, Decorator } from '@storybook/react';
+import { HeadlineExample } from './HeadlineExample';
+import { paletteDeclarations } from '../../../src/palette';
+
+// ----- Meta ----- //
+
+const meta: Meta<typeof HeadlineExample> = {
+    title: 'components/HeadlineExample',
+    component: HeadlineExample,
+}
+
+export default meta;
+
+// ----- Decorators ----- //
+
+/**
+ * Creates storybook decorator used to wrap components in an element
+ * containing the light or dark mode palette colours.
+ * 
+ * @param colourScheme Choose whether to use the light or dark palette.
+ * @returns A decorator that wraps the component in a `div` containing the
+ * palette colours as CSS custom properties.
+ */
+const colourSchemeDecorator = (
+    colourScheme: 'light' | 'dark',
+): Decorator => (Story) => (
+    <div css={css(paletteDeclarations(format, colourScheme))}>
+        <Story />
+    </div>
+)
+
+// ----- Stories ----- //
+
+type Story = StoryObj<typeof HeadlineExample>;
+
+const format: ArticleFormat = {
+    design: ArticleDesign.Standard,
+    display: ArticleDisplay.Standard,
+    theme: ArticlePillar.News,
+};
+
+export const LightHeadline: Story = {
+    args: {
+        text: 'A short example headline',
+    },
+    decorators: [ colourSchemeDecorator('light') ]
+}
+
+export const DarkHeadline: Story = {
+    args: LightHeadline.args,
+    decorators: [ colourSchemeDecorator('dark') ]
+}

--- a/dotcom-rendering/src/web/components/HeadlineExample.stories.tsx
+++ b/dotcom-rendering/src/web/components/HeadlineExample.stories.tsx
@@ -9,9 +9,9 @@ import { paletteDeclarations } from '../../../src/palette';
 // ----- Meta ----- //
 
 const meta: Meta<typeof HeadlineExample> = {
-    title: 'components/HeadlineExample',
-    component: HeadlineExample,
-}
+	title: 'components/HeadlineExample',
+	component: HeadlineExample,
+};
 
 export default meta;
 
@@ -20,37 +20,38 @@ export default meta;
 /**
  * Creates storybook decorator used to wrap components in an element
  * containing the light or dark mode palette colours.
- * 
+ *
  * @param colourScheme Choose whether to use the light or dark palette.
  * @returns A decorator that wraps the component in a `div` containing the
  * palette colours as CSS custom properties.
  */
-const colourSchemeDecorator = (
-    colourScheme: 'light' | 'dark',
-): Decorator => (Story) => (
-    <div css={css(paletteDeclarations(format, colourScheme))}>
-        <Story />
-    </div>
-)
+const colourSchemeDecorator =
+	(colourScheme: 'light' | 'dark'): Decorator =>
+	(Story) =>
+		(
+			<div css={css(paletteDeclarations(format, colourScheme))}>
+				<Story />
+			</div>
+		);
 
 // ----- Stories ----- //
 
 type Story = StoryObj<typeof HeadlineExample>;
 
 const format: ArticleFormat = {
-    design: ArticleDesign.Standard,
-    display: ArticleDisplay.Standard,
-    theme: ArticlePillar.News,
+	design: ArticleDesign.Standard,
+	display: ArticleDisplay.Standard,
+	theme: ArticlePillar.News,
 };
 
 export const LightHeadline: Story = {
-    args: {
-        text: 'A short example headline',
-    },
-    decorators: [ colourSchemeDecorator('light') ]
-}
+	args: {
+		text: 'A short example headline',
+	},
+	decorators: [colourSchemeDecorator('light')],
+};
 
 export const DarkHeadline: Story = {
-    args: LightHeadline.args,
-    decorators: [ colourSchemeDecorator('dark') ]
-}
+	args: LightHeadline.args,
+	decorators: [colourSchemeDecorator('dark')],
+};

--- a/dotcom-rendering/src/web/components/HeadlineExample.stories.tsx
+++ b/dotcom-rendering/src/web/components/HeadlineExample.stories.tsx
@@ -26,7 +26,8 @@ export default meta;
  * palette colours as CSS custom properties.
  */
 const colourSchemeDecorator =
-	(colourScheme: 'light' | 'dark'): Decorator =>
+	(colourScheme: 'light' | 'dark') =>
+	(format: ArticleFormat): Decorator =>
 	(Story) =>
 		(
 			<div css={css(paletteDeclarations(format, colourScheme))}>
@@ -34,11 +35,14 @@ const colourSchemeDecorator =
 			</div>
 		);
 
+const lightMode = colourSchemeDecorator('light');
+const darkMode = colourSchemeDecorator('dark');
+
 // ----- Stories ----- //
 
 type Story = StoryObj<typeof HeadlineExample>;
 
-const format: ArticleFormat = {
+const articleFormat: ArticleFormat = {
 	design: ArticleDesign.Standard,
 	display: ArticleDisplay.Standard,
 	theme: ArticlePillar.News,
@@ -48,10 +52,10 @@ export const LightHeadline: Story = {
 	args: {
 		text: 'A short example headline',
 	},
-	decorators: [colourSchemeDecorator('light')],
+	decorators: [lightMode(articleFormat)],
 };
 
 export const DarkHeadline: Story = {
 	args: LightHeadline.args,
-	decorators: [colourSchemeDecorator('dark')],
+	decorators: [darkMode(articleFormat)],
 };

--- a/dotcom-rendering/src/web/components/HeadlineExample.tsx
+++ b/dotcom-rendering/src/web/components/HeadlineExample.tsx
@@ -7,10 +7,10 @@ import { headline } from '@guardian/source-foundations';
 // ----- Component ----- //
 
 export const HeadlineExample = ({ text }: { text: string }) => {
-    const styles = css`
-        color: ${palette('--headline-colour')};
-        background-color: ${palette('--headline-background-colour')};
-        ${headline.large()}
-    `
-    return <h1 css={styles}>{text}</h1>;
-}
+	const styles = css`
+		color: ${palette('--headline-colour')};
+		background-color: ${palette('--headline-background-colour')};
+		${headline.large()}
+	`;
+	return <h1 css={styles}>{text}</h1>;
+};

--- a/dotcom-rendering/src/web/components/HeadlineExample.tsx
+++ b/dotcom-rendering/src/web/components/HeadlineExample.tsx
@@ -1,0 +1,16 @@
+// ----- Imports ----- //
+
+import { css } from '@emotion/react';
+import { palette } from '../../../src/palette';
+import { headline } from '@guardian/source-foundations';
+
+// ----- Component ----- //
+
+export const HeadlineExample = ({ text }: { text: string }) => {
+    const styles = css`
+        color: ${palette('--headline-colour')};
+        background-color: ${palette('--headline-background-colour')};
+        ${headline.large()}
+    `
+    return <h1 css={styles}>{text}</h1>;
+}


### PR DESCRIPTION
## Why?

The DCAR project means bringing support for apps articles to DCR. As part of this we need to come up with a mechanism for handling dark mode. This draft PR is a proposal for one possible mechanism, and some examples of how it might be used. It includes:

- A new example `palette` module; an iteration on the current `decidePalette` module.
- An example of how a component might use this module, in `HeadlineExample`.
- Some example stories for this component, with dark mode support.

It builds on the: ideas in #4241; some of the existing code in apps-rendering; discussions with, and prior work undertaken by, @georgeblahblah and @Georges-GNM .

Most types and values in this PR have JSDoc comments, with some examples, explaining what they do.

**Note:** The stories are written using Component Story Format 3, which is the default for Storybook 7[^1].

## Architecture Overview

The idea is based on CSS custom properties (also known as CSS variables)[^2], which allow you to define a set of custom properties[^3] that can be accessed in other CSS declarations via the `var` function[^4]. In this case, we can set up our palette colours as CSS custom properties (automated in practice; this shows an example output):

```ts
const lightPalette = css`
  --headline-colour: #1a1a1a;
  --headline-background-colour: #ffffff;
`;

const darkPalette = css`
  --headline-colour: #f6f6f6;
  --headline-background-colour: #121212;
`;
```

and access them throughout our components to set `color`, `background-color` and so on:

```ts
const styles = css`
  color: palette('--headline-colour');
  background-color: palette('--headline-background-colour');
`;

const Headline = () => <h1 css={styles}>A short headline</h1>;
```

We then swap the values of these custom properties between their light and dark variants, based on user preference. Here is one approach:

```ts
const styles = css`
  :root {
    ${lightPalette}
  }

  @media (prefers-color-scheme: dark) {
    :root {
      ${darkPalette}
    }
  }
`;
```

## Features

### Dark Mode Support

The primary reason for introducing this approach is dark mode support. However, we also have to account for the fact that the apps currently support dark mode, but dotcom does not. Therefore we need a way to use the same components for dotcom and apps but only display them in dark mode on the apps. We also need to make sure we don't ship unused dark mode CSS to dotcom for performance reasons. On the other hand, we still want to allow for the possibility that we may add dark mode to dotcom at some point in the future, and in a way that doesn't impact performance by downloading unused dark mode colours in light mode and vice versa.

The idea here is to provide parallel palettes containing identical colour names: one for light mode and one for dark mode. For the apps we can include both and swap between them in pure CSS using the `prefers-color-scheme` media query[^5]:

```ts
const styles = css`
  :root {
    ${lightPalette}
  }

  @media (prefers-color-scheme: dark) {
    :root {
      ${darkPalette}
    }
  }
`
```

For dotcom we just include the light palette, so there's no dark mode and no dark mode colours get shipped to users. If in future we do want to add the dark mode colours to dotcom, we may opt to use `<link>` tags with `prefers-color-scheme` set in the `media` attribute[^6], which allows us to conditionally load one or other of the palettes based on user preference:

```html
<link
  rel="stylesheet"
  href="light.css"
  media="(prefers-color-scheme: light)"
/>

<link
  rel="stylesheet"
  href="dark.css"
  media="(prefers-color-scheme: dark)"
/>
```

These palettes could also be loaded and applied dynamically in client-side JavaScript if required.

### Less CSS

Compared to the current dark mode solution used in apps-rendering (AR), this option results in less CSS being written and shipped to users. At the moment, we add dark mode styles to a component in AR like this:

```ts
const styles = (format: ArticleFormat): SerializedStyles => css`
  color: ${text.headline(format)};
  background-color: ${background.headline(format)};

  ${darkModeCss`
    color: ${text.headlineDark(format)};
    background-color: ${background.headlineDark(format)};
  `}
`;
```

The proposal in this PR would mean avoiding having to write this extra dark mode block for many components, as you only need to set colour properties to the CSS variable once and have them swap between light and dark mode automatically:

```ts
const styles = css`
  color: ${palette('--headline-colour')};
  background-color: ${palette('--headline-background-colour')};
`;
```

The reason it also means less CSS shipped is that each of those `darkModeCss` blocks generates an additional `prefers-color-scheme` media query block, which contains the dark mode declarations to override the light mode ones. Those blocks would not be needed with the proposed approach, as you can set the entire dark mode palette with a single media query (demonstrated in the "Dark Mode Support" section above).

### Text Search For Colour Names

This proposal suggests using the CSS variable name in the source code in two places:

1. In the palette object as keys for the palette decision functions.
2. In a component's CSS declarations to look up the palette colour.

This should make it easy to connect what you can see within a browser with the corresponding code that's applying the CSS rules. The CSS variable names will be visible in the inspector, and can be copied and searched for in the codebase to find both the component where they're applied and the palette function used to derive the colour. This should be an improvement on the current situation.

### Dark Mode Stories

The current apps-rendering (AR) solution for dark mode does not provide an easy way to write dark mode stories. There's no way to control the `prefers-color-scheme` browser preference programmatically in JavaScript, so it's difficult to force components into their dark mode variants for snapshotting in storybook and chromatic.

As seen in the example stories in this proposal, this becomes much easier with custom properties. For any given story you can wrap the component in an element that has those properties applied, and have them propagate down to apply light or dark mode:

```tsx
const story = (
  <div css={darkModePalette}>
    <Component />
  </div>
);
```

### Naming Conventions

The naming conventions used in this proposal differ from the current pattern. They aren't strictly tied to the technical implementation, and therefore we could choose to adopt this new architecture without also switching to these new conventions.

The approach taken in this proposal is for colour names to match the CSS properties they're intended to be used with. For example, `--headline-colour` for the `color` property, `--headline-background-colour` for the `background-color` property, `--headline-border-colour` for the `border-color` property and so on. The intention is to make it very clear what each colour is for. Also, by putting the component name first, it may be easier to scan through the list of colours more quickly (there are far fewer that start with the word "headline" in this new pattern, for example, than would start with the word "text" in the existing pattern). Thanks to @georgeblahblah for a suggestion on this.

### CSS-only

Finally, and briefly, this is a CSS-only solution, so it doesn't require client-side JavaScript to be available and initialised to swap between light and dark mode colour schemes.

[^1]: https://storybook.js.org/blog/storybook-7-0/#csf3-with-improved-type-safety
[^2]: https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties
[^3]: https://developer.mozilla.org/en-US/docs/Web/CSS/--*
[^4]: https://developer.mozilla.org/en-US/docs/Web/CSS/var
[^5]: https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme
[^6]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#media
