### PR TITLE
AR `ImmersiveLayout`: Add darkmode text styles

### DIFF
--- a/apps-rendering/src/components/ArticleBody/index.tsx
+++ b/apps-rendering/src/components/ArticleBody/index.tsx
@@ -1,7 +1,7 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import type { ArticleFormat } from '@guardian/libs';
-import { neutral, remSpace } from '@guardian/source-foundations';
+import { palette, remSpace } from '@guardian/source-foundations';
 import type { BodyElement } from 'bodyElement';
 import { background } from 'palette';
 import type { FC } from 'react';
@@ -34,7 +34,7 @@ const styles = (format: ArticleFormat): SerializedStyles => css`
 
 	${darkModeCss`
 		background: ${background.articleContentDark(format)};
-		color: ${neutral[86]};
+		color: ${palette.neutral[86]};
 
 		p:last-child {
 			margin-bottom: 0;

--- a/apps-rendering/src/components/Layout/ImmersiveLayout.tsx
+++ b/apps-rendering/src/components/Layout/ImmersiveLayout.tsx
@@ -3,7 +3,7 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import type { ArticleFormat } from '@guardian/libs';
-import { between, from, remSpace } from '@guardian/source-foundations';
+import { between, from, palette, remSpace } from '@guardian/source-foundations';
 import { StraightLines } from '@guardian/source-react-components-development-kitchen';
 import Footer from 'components/Footer';
 import Headline from 'components/Headline';
@@ -55,6 +55,10 @@ const bodyStyles = css`
 	${from.leftCol} {
 		grid-row: 1 / 6;
 	}
+
+	${darkModeCss`
+		color: ${palette.neutral[86]};
+	`}
 `;
 
 const linesStyles = (format: ArticleFormat): SerializedStyles => css`


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

- Adds darkmode text styles for `ImmersiveLayout`

## Why?

Resolves #7714 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![image](https://github.com/guardian/dotcom-rendering/assets/705427/e251fd98-febb-402a-9ba9-e436bdd8425b) | ![image](https://github.com/guardian/dotcom-rendering/assets/705427/f098808d-22c9-4613-85dc-3983329355fd) |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
