### PR TITLE
AB test to limit inline merchandising slots

### DIFF
--- a/dotcom-rendering/src/model/article-schema.json
+++ b/dotcom-rendering/src/model/article-schema.json
@@ -4220,6 +4220,9 @@
                 },
                 "ampIframeUrl": {
                     "type": "string"
+                },
+                "hasInlineMerchandise": {
+                    "type": "boolean"
                 }
             },
             "required": [

--- a/dotcom-rendering/src/model/window-guardian.ts
+++ b/dotcom-rendering/src/model/window-guardian.ts
@@ -60,6 +60,7 @@ export const makeWindowGuardian = ({
 	contentType,
 	brazeApiKey,
 	GAData,
+	hasInlineMerchandise,
 	unknownConfig = {},
 }: {
 	stage: StageType;
@@ -80,6 +81,7 @@ export const makeWindowGuardian = ({
 	contentType?: string;
 	brazeApiKey?: string;
 	GAData?: GADataType;
+	hasInlineMerchandise?: boolean;
 	/**
 	 * In the case of articles we don't know the exact values that need to exist
 	 * on the window.guardian.config.page property so rather than filter them we
@@ -130,6 +132,7 @@ export const makeWindowGuardian = ({
 				shouldHideReaderRevenue: !!shouldHideReaderRevenue,
 				isPaidContent: !!isPaidContent,
 				brazeApiKey,
+				hasInlineMerchandise,
 			}),
 			libs: {
 				googletag: googletagUrl,

--- a/dotcom-rendering/src/model/window-guardian.ts
+++ b/dotcom-rendering/src/model/window-guardian.ts
@@ -24,6 +24,7 @@ export interface WindowGuardianConfig {
 		brazeApiKey?: string;
 		isPaidContent?: boolean;
 		isDev?: boolean;
+		hasInlineMerchandise?: boolean;
 	};
 	libs: {
 		googletag: string;

--- a/dotcom-rendering/src/types/config.ts
+++ b/dotcom-rendering/src/types/config.ts
@@ -13,6 +13,7 @@ export interface CommercialConfigType {
 	toneIds?: string;
 	contentType: string;
 	ampIframeUrl: string;
+	hasInlineMerchandise?: boolean;
 }
 
 /**

--- a/dotcom-rendering/src/web/components/Metrics.importable.tsx
+++ b/dotcom-rendering/src/web/components/Metrics.importable.tsx
@@ -9,6 +9,7 @@ import {
 } from '@guardian/core-web-vitals';
 import { getCookie } from '@guardian/libs';
 import { integrateIma } from '../experiments/tests/integrate-ima';
+import { limitInlineMerch } from '../experiments/tests/limit-inline-merch';
 import { useAB } from '../lib/useAB';
 import { useAdBlockInUse } from '../lib/useAdBlockInUse';
 import { useOnce } from '../lib/useOnce';
@@ -25,6 +26,7 @@ const willRecordCoreWebVitals = Math.random() < sampling;
 const clientSideTestsToForceMetrics: ABTest[] = [
 	/* keep array multi-line */
 	integrateIma,
+	limitInlineMerch,
 ];
 
 export const Metrics = ({ commercialMetricsEnabled }: Props) => {

--- a/dotcom-rendering/src/web/experiments/ab-tests.ts
+++ b/dotcom-rendering/src/web/experiments/ab-tests.ts
@@ -4,6 +4,7 @@ import { billboardsInMerch } from './tests/billboards-in-merch';
 import { consentlessAds } from './tests/consentless-ads';
 import { elementsManager } from './tests/elements-manager';
 import { integrateIma } from './tests/integrate-ima';
+import { limitInlineMerch } from './tests/limit-inline-merch';
 import { signInGateCopyTestJan2023 } from './tests/sign-in-gate-copy-test-variants';
 import { signInGateMainControl } from './tests/sign-in-gate-main-control';
 import { signInGateMainVariant } from './tests/sign-in-gate-main-variant';
@@ -19,4 +20,5 @@ export const tests: ABTest[] = [
 	integrateIma,
 	billboardsInMerch,
 	elementsManager,
+	limitInlineMerch,
 ];

--- a/dotcom-rendering/src/web/experiments/tests/limit-inline-merch.ts
+++ b/dotcom-rendering/src/web/experiments/tests/limit-inline-merch.ts
@@ -1,0 +1,31 @@
+import type { ABTest } from '@guardian/ab-core';
+
+export const limitInlineMerch: ABTest = {
+	id: 'LimitInlineMerch',
+	start: '2023-06-23',
+	expiry: '2023-09-01',
+	author: '@chrislomaxjones',
+	description:
+		'Test the impact of limiting the eligibility of inline merchandising ad slots',
+	audience: 0 / 100,
+	audienceOffset: 0 / 100,
+	audienceCriteria:
+		'Article pages eligible for rendering an inline merchandising ad slot',
+	successMeasure:
+		'Limiting the presence of inline merchandising ad slots increases ad-ratio on eligible article pages',
+	canRun: () => !!window.guardian.config.page.hasInlineMerchandise,
+	variants: [
+		{
+			id: 'control',
+			test: (): void => {
+				/* no-op */
+			},
+		},
+		{
+			id: 'variant',
+			test: (): void => {
+				/* no-op */
+			},
+		},
+	],
+};

--- a/dotcom-rendering/src/web/server/render.article.tsx
+++ b/dotcom-rendering/src/web/server/render.article.tsx
@@ -155,6 +155,7 @@ export const renderHtml = ({ article }: Props): string => {
 					editionId: article.editionId,
 					beaconURL: article.beaconURL,
 				}),
+				hasInlineMerchandise: article.config.hasInlineMerchandise,
 				// Until we understand exactly what config we need to make available client-side,
 				// add everything we haven't explicitly typed as unknown config
 				unknownConfig: article.config,


### PR DESCRIPTION
## What does this change?

Add a client side AB test for limiting the number of pageviews eligible for rendering an _inline merchandise_ slot. This AB test only needs to be present on DCR, as it won't run on Frontend rendered content  (inline merchandising slots only appear in articles).

The main implementation of the test can be found in [@guardian/commercial #884](https://github.com/guardian/commercial/pull/884).

As well as defining the test and ensuring we collect metrics, we also do some extra plumbing to ensure TypeScript is aware of the `hasInlineMerchandise` flag that is available on the page. This is so we can constrain the AB test to only run on pages already eligible for rendering an inline merchandising slot.

## Why?

This test should allow us to assess the relative impact to revenue of running a merchandising campaign using the inline merchandising slot.
