### PR TITLE
build(cypress): Fix Cypress test failures with `cypress-io/gitub-action@v5`

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -26,7 +26,7 @@ jobs:
         working-directory: dotcom-rendering
 
       - name: Cypress run
-        uses: cypress-io/github-action@v4
+        uses: cypress-io/github-action@v5
         with:
           start: make start-ci
           working-directory: dotcom-rendering


### PR DESCRIPTION
Co-authored-by: Alina Boghiu <alina.boghiu@gmail.com>

## What does this change?

- Bumps `cypress-io/github-action` to `v5`. The [Release Notes](https://github.com/cypress-io/github-action/releases/tag/v5.0.0) for v5 indicate the breaking change is dropping Node 12 support

## Why?

- We have been seeing intermittent cypress test failures ([example](https://github.com/guardian/dotcom-rendering/actions/runs/5047460568/jobs/9054359972?pr=7765)), which should be fixed by using `v5` of the github action. See https://github.com/cypress-io/github-action/issues/203 for more details

Resolves #7768 