### PR TITLE
Fix `make fix` Command

### DIFF
--- a/dotcom-rendering/.eslintignore
+++ b/dotcom-rendering/.eslintignore
@@ -1,2 +1,3 @@
 node_modules
 .eslintrc.js
+storybook-static/

--- a/dotcom-rendering/makefile
+++ b/dotcom-rendering/makefile
@@ -125,7 +125,7 @@ tsc: clean-dist install
 
 fix: clear clean-dist install
 	$(call log, "attempting to fix lint errors")
-	@yarn lint --fix
+	@yarn lint:fix
 	@yarn prettier:fix
 
 snapshot: clear clean-dist install

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -6,8 +6,10 @@
 	"tocList": "README.md docs/contributing/**",
 	"private": true,
 	"scripts": {
-		"lint": "eslint . --ext .ts,.tsx --quiet && yarn lint-cypress",
-		"lint-cypress": "eslint ./cypress",
+		"lint": "yarn lint:src && yarn lint:cypress",
+		"lint:fix": "yarn lint:src --fix && yarn lint:cypress --fix",
+		"lint:src": "eslint . --ext .ts,.tsx --quiet",
+		"lint:cypress": "eslint ./cypress",
 		"lint-staged": "lint-staged",
 		"prettier:check": "prettier . --check --cache",
 		"prettier:fix": "prettier . --write --cache",


### PR DESCRIPTION
## Why?

It wasn't working as expected. The way `--fix` was being passed meant that it didn't reach the first ESLint command.

## Changes

- This splits up the lint commands to avoid repetition, and passes `--fix` to all.
- Also ignored `storybook-static`, as it's a generated directory and was causing configuration errors.
