### PR TITLE
Allow deselecting topic filters

### DIFF
--- a/dotcom-rendering/src/web/components/TopicFilterBank.tsx
+++ b/dotcom-rendering/src/web/components/TopicFilterBank.tsx
@@ -42,7 +42,7 @@ const topicStyles = css`
 `;
 
 const getTopicLink = (isActive: boolean, topics: string, id: Props['id']) => {
-	// If active, remove the search params
+	// If active, remove the search params. Otherwise use them.
 	const urlParams = new URLSearchParams(isActive ? {} : { topics });
 	return `?${urlParams.toString()}#${id}`;
 };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Uses the URLSearchParams to remove filter params as well as add them.

## Why?
There was a bug where clicking on an already selected topic filter (other than key Events) was not working. This change uses the URLSearchParams to remove the filter param as well as remove them

## Video demos

| Before      | After      |
| ----------- | ---------- |
| Could not deselect a filter ![bug](https://github.com/guardian/dotcom-rendering/assets/26366706/6b74bdf5-3568-4b55-9f86-36dcfba4b6cb) | Could deselect a filter ![fix](https://github.com/guardian/dotcom-rendering/assets/26366706/c4c2ff8c-efd9-445e-8765-e2dcfd0a3fde) |

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
