### PR TITLE
build: add permissions for the compressed size action

### DIFF
--- a/.github/workflows/compress.yml
+++ b/.github/workflows/compress.yml
@@ -1,4 +1,9 @@
 name: DCR Compressed Size
+
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   pull_request:
     paths-ignore:


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

- set permissions for the compressed size workflow. It's been [failing silently](https://github.com/guardian/dotcom-rendering/actions/runs/5078851266/jobs/9123875111#step:4:475) 😢 

