### PR TITLE
Don't install dependencies when running Cypress step

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -27,6 +27,8 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'yarn'
 
+      - run: yarn install --frozen-lockfile
+
       - name: Cypress run
         uses: cypress-io/github-action@v5
         with:
@@ -35,3 +37,4 @@ jobs:
           wait-on-timeout: 30
           browser: chrome
           spec: cypress/e2e/parallel-${{ matrix.group }}/*.js
+          install: false


### PR DESCRIPTION
## What does this change?

Stops Cypress from running `yarn i` in the Cypress action. This causes cypress to re-download our 1.2GB dependency cache which we already have from `actions/setup-node`.


## Why?

A slight amount of time saved by not having to download our 1.2GB dependency cache twice.
