### PR TITLE
fix width issue for lozenges tag

### DIFF
--- a/dotcom-rendering/src/web/components/ArticleTitle.tsx
+++ b/dotcom-rendering/src/web/components/ArticleTitle.tsx
@@ -46,7 +46,7 @@ const marginTop = css`
 
 const immersiveMargins = css`
 	max-width: 400px;
-	min-width: 100px;
+	min-width: 200px;
 	margin-bottom: 4px;
 	/*
         Make sure we vertically align the title font with the body font

--- a/dotcom-rendering/src/web/components/ArticleTitle.tsx
+++ b/dotcom-rendering/src/web/components/ArticleTitle.tsx
@@ -46,6 +46,7 @@ const marginTop = css`
 
 const immersiveMargins = css`
 	max-width: 400px;
+	min-width: 100px;
 	margin-bottom: 4px;
 	/*
         Make sure we vertically align the title font with the body font


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
This PR fixes a strange width issue for the lozenges series tag on immersive display articles. 

This is a very strange issue that I couldn't get convinced why it's happening, but I found that the mixture of having `box-decoration-break: clone;` & `word-break: break-word;` & `padding-right: ${space[1]}px;` on the anchor tag for the series link and the flex on it's parent are affecting this. Even when the word is just 2 letters such as `Ra` it would still appear in multiline. 

If we remove the padding-right, or change the break-word to break-all or use flex-direction column, this issue is fixed but I think the safest fix that won't break anything else, would be to give a min-width to the div container that's an item of the flex. 

I don't know what would be the best min-width. It really depends on how long the word would be. With 200px that I used we can have one word as long as `RankedRankedRank` but any more letter after that would cause a multiline.

## Why?


## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![image](https://github.com/guardian/dotcom-rendering/assets/15894063/1e4d5a8c-0d37-4665-b0ab-916925f273c6) | ![image](https://github.com/guardian/dotcom-rendering/assets/15894063/1d898fae-6245-42b2-a4a2-5405b1741ed4) |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
