### PR TITLE
Run lint in DCR CICD

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -12,6 +12,9 @@ jobs:
       packages: write
     uses: ./.github/workflows/container.yml
 
+  lint:
+    uses: ./.github/workflows/lint.yml
+
   cypress:
     needs: [container]
     uses: ./.github/workflows/cypress.yml

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,12 +1,9 @@
-name: DCR lint 🔎
 on:
-  push:
-    paths-ignore:
-      - 'apps-rendering/**'
+  workflow_call:
+
 
 jobs:
-  lint:
-    name: DCR Lint
+  check:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Changes our lint workflow to be ran by our CICD workflow.

## Why?

The ultimate goal is to add a "RiffRaff deploy" action to the end of the CICD workflow which depends on the `lint` workflow to complete successfully.

## Screenshots

<img width="1647" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/21217225/5d3a84e0-2fa6-46f4-8220-5d774b884aa8">

