### PR TITLE
Run jest in DCR CICD

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -12,6 +12,9 @@ jobs:
       packages: write
     uses: ./.github/workflows/container.yml
 
+  jest:
+    uses: ./.github/workflows/jest.yml
+
   cypress:
     needs: [container]
     uses: ./.github/workflows/cypress.yml

--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -1,13 +1,8 @@
-name: DCR jest 🤔
 on:
-  push:
-    paths-ignore:
-      - 'apps-rendering/**'
-      - 'dotcom-rendering/docs/**'
+  workflow_call:
 
 jobs:
   jest:
-    name: DCR Jest
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Changes our jest workflow to be ran by our CICD workflow.

## Why?

The ultimate goal is to add a "RiffRaff deploy" action to the end of the CICD workflow which depends on the `jest` workflow to complete successfully.

## Screenshots

<img width="1649" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/21217225/1fd40df4-fe05-448d-b857-0b7ff19c7c3f">

