### PR TITLE
Run prettier in DCR CICD

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -12,6 +12,9 @@ jobs:
       packages: write
     uses: ./.github/workflows/container.yml
 
+  prettier:
+    uses: ./.github/workflows/prettier.yml
+
   cypress:
     needs: [container]
     uses: ./.github/workflows/cypress.yml

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -1,12 +1,8 @@
-name: DCR prettier 💅
 on:
-  push:
-    paths-ignore:
-      - 'apps-rendering/**'
+  workflow_call:
 
 jobs:
-  lint:
-    name: DCR Prettier
+  check:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Changes our prettier workflow to be ran by our CICD workflow.

## Why?

The ultimate goal is to add a "RiffRaff deploy" action to the end of the CICD workflow which depends on the `prettier` workflow to complete successfully.

## Screenshots

<img width="1645" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/21217225/03b14300-de2b-4d82-bf80-dc2ec67a8d12">

