### PR TITLE
Run AMP Validation in DCR CICD

### DIFF
--- a/.github/workflows/amp.yml
+++ b/.github/workflows/amp.yml
@@ -1,14 +1,19 @@
-name: DCR AMP Validation
 on:
-    push:
-        paths-ignore:
-            - "apps-rendering/**"
-            - "dotcom-rendering/docs/**"
+  workflow_call:
+    inputs:
+      container-image:
+        description: 'Image used by DCR service'
+        required: true
+        type: string
 
 jobs:
-    amp_validation:
-        name: DCR AMP Validation
+    validate:
         runs-on: ubuntu-latest
+        services:
+          DCR:
+            image: ${{ inputs.container-image }}
+            ports:
+              - 9000:9000
         steps:
             - name: Checkout code
               uses: actions/checkout@v3

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -17,3 +17,9 @@ jobs:
     uses: ./.github/workflows/cypress.yml
     with:
       container-image: ${{ needs.container.outputs.container-image }}
+
+  amp:
+    needs: [container]
+    uses: ./.github/workflows/amp.yml
+    with:
+      container-image: ${{ needs.container.outputs.container-image }}

--- a/dotcom-rendering/makefile
+++ b/dotcom-rendering/makefile
@@ -109,9 +109,9 @@ cypress-open: clear clean-dist install build
 	$(call log, "starting frontend PROD server and opening Cypress")
 	@NODE_ENV=production DISABLE_LOGGING_AND_METRICS=true start-server-and-test 'node dist/frontend.server.js' 9000 'cypress open --e2e --browser electron'
 
-ampValidation: clean-dist install build
-	$(call log, "starting frontend PROD server for AMP Validation")
-	@NODE_ENV=production DISABLE_LOGGING_AND_METRICS=true start-server-and-test 'node dist/frontend.server.js' 9000 'node scripts/test/amp-validation.js'
+ampValidation: clean-dist install
+	$(call log, "starting AMP Validation test")
+	@node scripts/test/amp-validation.js
 
 buildCheck:
 	$(call log, "checking build files")


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

- Changes our amp validation workflow to be ran by our CICD workflow.
- Updates our AMP Validation workflow to use the pre-built container image instead of creating its own DCR prod build.

## Why?

The ultimate goal is to add a "RiffRaff deploy" action to the end of the CICD workflow which depends on the amp validation workflow to complete successfully.

## Screenshots

<img width="1643" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/21217225/2cbade4e-1e61-461b-a105-fb22dc404117">
