### PR TITLE
Add a no-op publish workflow

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -32,3 +32,9 @@ jobs:
     uses: ./.github/workflows/amp.yml
     with:
       container-image: ${{ needs.container.outputs.container-image }}
+
+  publish:
+    needs: [container, prettier, jest, lint, cypress, amp]
+    uses: ./.github/workflows/publish.yml
+    with:
+      container-image: ${{ needs.container.outputs.container-image }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,17 @@
+on:
+  workflow_call:
+    inputs:
+      container-image:
+        description: 'Image used by DCR service'
+        required: true
+        type: string
+
+jobs:
+  riffraff:
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ inputs.container-image }}
+
+    steps:
+      - run: ls /opt/app/dotcom-rendering/dotcom-rendering
+      - run: pwd


### PR DESCRIPTION
## What does this change?

Adds a final workflow to our CICD workflow to publish riffraff artifacts (although right now it is just an empty workflow that lists our build files)

## Why?

Makes the PR to use RiffRaff a slightly smaller less scary PR if we're changing an existing action.