### PR TITLE
`Details` component for use in anything that may need it without JS

### DIFF
--- a/dotcom-rendering/src/web/components/Details.tsx
+++ b/dotcom-rendering/src/web/components/Details.tsx
@@ -1,0 +1,120 @@
+import { css } from '@emotion/react';
+import { textSans } from '@guardian/source-foundations';
+import {
+	SvgChevronDownSingle,
+	SvgChevronUpSingle,
+} from '@guardian/source-react-components';
+import { getZIndex } from '../lib/getZIndex';
+
+const colourStyles = (colour: string) => css`
+	color: ${colour};
+	svg {
+		fill: ${colour};
+	}
+`;
+
+const Position = ({
+	children,
+	top,
+	left,
+	right,
+	bottom,
+}: {
+	children: React.ReactNode;
+	top?: number;
+	left?: number;
+	right?: number;
+	bottom?: number;
+}) => {
+	return (
+		<div
+			css={css`
+				/* Decide where the content revealed by details appears */
+				position: absolute;
+				top: ${top != null && `${top}px`};
+				left: ${left != null && `${left}px`};
+				right: ${right != null && `${right}px`};
+				bottom: ${bottom != null && `${bottom}px`};
+				${getZIndex('summaryDetails')}
+			`}
+		>
+			{children}
+		</div>
+	);
+};
+
+/**
+ * **Details**
+ *
+ * A styled abstraction over the html summary/details elements. Renders a disclosure widget in which
+ * information is only shown when the widget is toggled into an "open" state
+ *
+ * See: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details
+ */
+export const Details = ({
+	label,
+	children,
+	colour,
+	top,
+	right,
+	bottom,
+	left,
+}: {
+	label: string;
+	children: React.ReactNode;
+	colour?: string;
+	top?: number;
+	right?: number;
+	bottom?: number;
+	left?: number;
+}) => (
+	<details
+		css={css`
+			/* Hide up icon when the disclosure is closed */
+			[data-icon='chevronDown'] {
+				display: inline;
+			}
+			[data-icon='chevronUp'] {
+				display: none;
+			}
+			:is([open]) {
+				/* Hide down icon when the disclosure is open */
+				[data-icon='chevronDown'] {
+					display: none;
+				}
+				[data-icon='chevronUp'] {
+					display: inline;
+				}
+			}
+			${textSans.small()}
+			position: relative;
+		`}
+	>
+		<summary
+			css={[
+				css`
+					/* Don't show the default summary triangle */
+					list-style: none;
+					::-webkit-details-marker {
+						display: none;
+					}
+					cursor: pointer;
+					display: flex;
+				`,
+				colour && colourStyles(colour),
+			]}
+		>
+			{label}
+			{/* We use these spans to show/hide the icons based on open state */}
+			<span data-icon="chevronDown">
+				<SvgChevronDownSingle size="xsmall" />
+			</span>
+			<span data-icon="chevronUp">
+				<SvgChevronUpSingle size="xsmall" />
+			</span>
+		</summary>
+		<Position top={top} left={left} bottom={bottom} right={right}>
+			{children}
+		</Position>
+	</details>
+);

--- a/dotcom-rendering/src/web/components/LabsHeader.stories.tsx
+++ b/dotcom-rendering/src/web/components/LabsHeader.stories.tsx
@@ -1,5 +1,5 @@
 import { border, labs } from '@guardian/source-foundations';
-import { LabsHeader } from './LabsHeader.importable';
+import { LabsHeader } from './LabsHeader';
 import { Section } from './Section';
 
 export default {

--- a/dotcom-rendering/src/web/components/LabsHeader.tsx
+++ b/dotcom-rendering/src/web/components/LabsHeader.tsx
@@ -3,7 +3,6 @@ import {
 	border,
 	from,
 	labs,
-	neutral,
 	space,
 	textSans,
 } from '@guardian/source-foundations';
@@ -14,7 +13,7 @@ import {
 } from '@guardian/source-react-components';
 import LabsLogo from '../../static/logos/the-guardian-labs.svg';
 import { LABS_HEADER_HEIGHT } from '../lib/labs-constants';
-import { Dropdown } from './Dropdown';
+import { Details } from './Details';
 
 const FlexWrapper = ({ children }: { children: React.ReactNode }) => (
 	<div
@@ -87,30 +86,10 @@ const Title = () => (
 	</div>
 );
 
-const AboutDropdown = ({ children }: { children: React.ReactNode }) => (
-	<div
-		css={css`
-			color: black;
-			> button {
-				${textSans.small()};
-				color: black;
-				:hover {
-					color: black;
-				}
-			}
-		`}
-	>
-		{children}
-	</div>
-);
-
 const About = () => (
 	<div
 		css={css`
 			${textSans.small()};
-			position: absolute;
-			top: 55px;
-			left: 0;
 			background-color: ${labs[400]};
 			border-top: 1px solid ${border.primary};
 
@@ -163,19 +142,9 @@ export const LabsHeader = () => (
 				<Title />
 			</HeaderSection>
 			<HeaderSection>
-				<AboutDropdown>
-					<Dropdown
-						label="About"
-						links={[]}
-						id="paidfor"
-						cssOverrides={css`
-							color: ${neutral[0]};
-						`}
-						dataLinkName=""
-					>
-						<About />
-					</Dropdown>
-				</AboutDropdown>
+				<Details label={'About'} top={40} left={-128}>
+					<About />
+				</Details>
 			</HeaderSection>
 		</Left>
 		<Right>

--- a/dotcom-rendering/src/web/layouts/FullPageInteractiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FullPageInteractiveLayout.tsx
@@ -24,7 +24,7 @@ import { Footer } from '../components/Footer';
 import { Header } from '../components/Header';
 import { HeaderAdSlot } from '../components/HeaderAdSlot';
 import { Island } from '../components/Island';
-import { LabsHeader } from '../components/LabsHeader.importable';
+import { LabsHeader } from '../components/LabsHeader';
 import { Nav } from '../components/Nav/Nav';
 import { Section } from '../components/Section';
 import { StickyBottomBanner } from '../components/StickyBottomBanner.importable';
@@ -313,9 +313,7 @@ export const FullPageInteractiveLayout = ({ article, NAV, format }: Props) => {
 							borderColour={border.primary}
 							sectionId="labs-header"
 						>
-							<Island deferUntil="idle">
-								<LabsHeader />
-							</Island>
+							<LabsHeader />
 						</Section>
 					</Stuck>
 				)}

--- a/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
@@ -37,7 +37,7 @@ import { GuardianLabsLines } from '../components/GuardianLabsLines';
 import { HeadlineByline } from '../components/HeadlineByline';
 import { Hide } from '../components/Hide';
 import { Island } from '../components/Island';
-import { LabsHeader } from '../components/LabsHeader.importable';
+import { LabsHeader } from '../components/LabsHeader';
 import { MainMedia } from '../components/MainMedia';
 import { MostViewedFooterData } from '../components/MostViewedFooterData.importable';
 import { MostViewedFooterLayout } from '../components/MostViewedFooterLayout';
@@ -383,9 +383,7 @@ export const ImmersiveLayout = ({
 						borderColour={border.primary}
 						sectionId="labs-header"
 					>
-						<Island deferUntil="idle">
-							<LabsHeader />
-						</Island>
+						<LabsHeader />
 					</Section>
 				</Stuck>
 			)}

--- a/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
@@ -33,7 +33,7 @@ import { GridItem } from '../components/GridItem';
 import { Header } from '../components/Header';
 import { HeaderAdSlot } from '../components/HeaderAdSlot';
 import { Island } from '../components/Island';
-import { LabsHeader } from '../components/LabsHeader.importable';
+import { LabsHeader } from '../components/LabsHeader';
 import { MainMedia } from '../components/MainMedia';
 import { MostViewedFooterData } from '../components/MostViewedFooterData.importable';
 import { MostViewedFooterLayout } from '../components/MostViewedFooterLayout';
@@ -372,9 +372,7 @@ export const InteractiveLayout = ({
 						borderColour={border.primary}
 						sectionId="labs-header"
 					>
-						<Island deferUntil="idle">
-							<LabsHeader />
-						</Island>
+						<LabsHeader />
 					</Section>
 				</Stuck>
 			)}

--- a/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
@@ -32,7 +32,7 @@ import { GridItem } from '../components/GridItem';
 import { Header } from '../components/Header';
 import { HeaderAdSlot } from '../components/HeaderAdSlot';
 import { Island } from '../components/Island';
-import { LabsHeader } from '../components/LabsHeader.importable';
+import { LabsHeader } from '../components/LabsHeader';
 import { MainMedia } from '../components/MainMedia';
 import { MostViewedFooterData } from '../components/MostViewedFooterData.importable';
 import { MostViewedFooterLayout } from '../components/MostViewedFooterLayout';
@@ -417,9 +417,7 @@ export const ShowcaseLayout = ({
 							borderColour={border.primary}
 							sectionId="labs-header"
 						>
-							<Island deferUntil="idle">
-								<LabsHeader />
-							</Island>
+							<LabsHeader />
 						</Section>
 					</Stuck>
 				</>

--- a/dotcom-rendering/src/web/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/StandardLayout.tsx
@@ -38,7 +38,7 @@ import { GuardianLabsLines } from '../components/GuardianLabsLines';
 import { Header } from '../components/Header';
 import { HeaderAdSlot } from '../components/HeaderAdSlot';
 import { Island } from '../components/Island';
-import { LabsHeader } from '../components/LabsHeader.importable';
+import { LabsHeader } from '../components/LabsHeader';
 import { MainMedia } from '../components/MainMedia';
 import { MostViewedFooterData } from '../components/MostViewedFooterData.importable';
 import { MostViewedFooterLayout } from '../components/MostViewedFooterLayout';
@@ -476,9 +476,7 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 						sectionId="labs-header"
 						element="aside"
 					>
-						<Island deferUntil="idle">
-							<LabsHeader />
-						</Island>
+						<LabsHeader />
 					</Section>
 				</Stuck>
 			)}

--- a/dotcom-rendering/src/web/lib/getZIndex.tsx
+++ b/dotcom-rendering/src/web/lib/getZIndex.tsx
@@ -44,6 +44,9 @@ const indices = [
 	// Edition selector in nav - needs to be below stickyAdWrapper
 	'editionDropdown',
 
+	// The content displayed by the Details component
+	'summaryDetails',
+
 	// Liveblog toast
 	'toast',
 


### PR DESCRIPTION
## What does this change?

Introduces a styled abstraction over the html summary/details elements. It will render a disclosure widget with information which is only shown when the widget is toggled into an "open" state

See: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details

## Why?

When creating the Guardian Labs fronts container in DCR I didn't want to introduce JS just for toggling the About details on/off. Instead, this uses the native summary and details elements to achieve the same behaviour. Once this is merged, it can also be used in the Labs fronts container. 

## Screenshots

The smallest available chevron icon in DCR is xsmall, if we want something smaller we should discuss with designers. 

| Before      | After      |
| ----------- | ---------- |
| <img width="356" alt="Screenshot 2023-05-29 at 18 14 49" src="https://github.com/guardian/dotcom-rendering/assets/1229808/d0a87ef8-31bd-414a-ae34-d6fd92717b33"> | <img width="357" alt="Screenshot 2023-05-29 at 18 14 36" src="https://github.com/guardian/dotcom-rendering/assets/1229808/73833e2f-bd6d-4595-b2f2-011a2827f5f6">|


