### PR TITLE
Use arcs for Doughnout segments

### DIFF
--- a/dotcom-rendering/src/web/components/Doughnut.tsx
+++ b/dotcom-rendering/src/web/components/Doughnut.tsx
@@ -47,6 +47,11 @@ const lineStyles = css`
 const withoutZeroSections = (sections: SectionType[]) =>
 	sections.filter((section) => section.value !== 0);
 
+const polarToCartesian = (angle: number, radius: number) =>
+	[Math.cos(angle) * radius, Math.sin(angle) * radius]
+		.map((n) => n.toFixed(PRECISION))
+		.join(',');
+
 export const Doughnut = ({
 	sections,
 	percentCutout = 35,
@@ -107,15 +112,11 @@ export const Doughnut = ({
 			) : (
 				<path
 					d={[
-						'M',
-						(Math.cos(angleStart) * radius).toFixed(PRECISION),
-						(Math.sin(angleStart) * radius).toFixed(PRECISION),
+						`M${polarToCartesian(angleStart, radius)}`,
 						`A${radius},${radius} 0 ${
 							// large-arc-flag, depends on segment being smaller or larger than one half
 							angleLength < tau / 2 ? 0 : 1
-						} 1`,
-						(Math.cos(angleEnd) * radius).toFixed(PRECISION),
-						(Math.sin(angleEnd) * radius).toFixed(PRECISION),
+						} 1 ${polarToCartesian(angleEnd, radius)}`,
 					].join(' ')}
 					fill="none"
 					stroke={color}
@@ -126,26 +127,15 @@ export const Doughnut = ({
 			element,
 			label,
 			value,
-			transform: [
-				'translate(',
-				(Math.cos(angleMid) * radius).toFixed(PRECISION),
-				', ',
-				(Math.sin(angleMid) * radius).toFixed(PRECISION),
-				')',
-			].join(''),
+			transform: `translate(${polarToCartesian(angleMid, radius)})`,
 			color,
 		});
-
-		const x = Math.cos(angleEnd);
-		const y = Math.sin(angleEnd);
 
 		separatingLines.push({
 			label,
 			d: [
-				`M${x * innerRadius},${y * innerRadius}`, // start the line from inner radius
-				`l${x * (outerRadius - innerRadius)},${
-					y * (outerRadius - innerRadius)
-				}`, // stop it at the outer radius
+				`M${polarToCartesian(angleEnd, innerRadius)}`,
+				`L${polarToCartesian(angleEnd, outerRadius)}`,
 			].join(' '),
 		});
 


### PR DESCRIPTION
## What does this change?

This refactor introduces actual SVG arcs to represent segments using `path`s.

A `circle` is still used for a single segment as arcs cannot have the same point for start and end.

the SVG `viewBox` is now centred to 0,0 making some calculations simpler, as points now lay perfectly on the trigonometric circle. The precision has also been reduced to two decimals as it did not have any visually measurable impact.

## Why?

Using dash arrays on `circle`s leads to visual rendering bugs in Chromium. Firefox and Safari are fine.

Raised by @Fweddi 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/76776/402f5403-6349-455b-b52a-7b4792040b72
[after]: https://github.com/guardian/dotcom-rendering/assets/76776/537fe441-5fe6-4abe-8308-7fc9beee699e

