### PR TITLE
Doughnut holes

### DIFF
--- a/dotcom-rendering/src/web/components/Doughnut.stories.tsx
+++ b/dotcom-rendering/src/web/components/Doughnut.stories.tsx
@@ -61,12 +61,12 @@ const threeSections = [
 
 const identicalColours = [
 	{
-		value: 55,
+		value: 50,
 		label: 'Orange',
 		color: palette.opinion[400],
 	},
 	{
-		value: 35,
+		value: 40,
 		label: 'Tangerine',
 		color: palette.opinion[400],
 	},

--- a/dotcom-rendering/src/web/components/Doughnut.tsx
+++ b/dotcom-rendering/src/web/components/Doughnut.tsx
@@ -16,9 +16,11 @@ type SectionType = {
 
 /** set decimal places */
 const PRECISION = 2;
-
 /** gap between segments in pixels */
 const SEGMENT_GAP = 2;
+/** τ = 2π https://en.wikipedia.org/wiki/Turn_(angle)#Tau_proposals */
+const TAU = Math.PI * 2;
+const QUARTER_TURN = TAU / 4;
 
 const unitStyles = css`
 	${headline.medium({ fontWeight: 'bold' })}
@@ -64,10 +66,6 @@ export const Doughnut = ({
 		.map((section) => section.value)
 		.reduce((runningTotal, currentValue) => runningTotal + currentValue);
 
-	/** τ = 2π https://en.wikipedia.org/wiki/Turn_(angle)#Tau_proposals */
-	const tau = Math.PI * 2;
-	const quarterTurn = Math.PI / 2;
-
 	const halfSize = size / 2;
 
 	// Segments
@@ -79,22 +77,22 @@ export const Doughnut = ({
 		value: number;
 	}[] = [];
 
-	let angleStart = -quarterTurn;
+	let angleStart = -QUARTER_TURN;
 	for (const { color, label, value } of withoutZeroSections(sections)) {
-		const angleLength = (value / totalValue) * tau;
+		const angleLength = (value / totalValue) * TAU;
 
 		const angleEnd = angleStart + angleLength;
 		const angleMid = angleStart + angleLength / 2;
 
 		/** depends on segment being smaller or larger than one half */
-		const largeArcFlag = angleLength < tau / 2 ? 0 : 1;
+		const largeArcFlag = angleLength < TAU / 2 ? 0 : 1;
 
 		/**
 		 * Either a circle, for a single segment, or an arc for multiple segments.
 		 * @see https://developer.mozilla.org/en-US/docs/Web/SVG/Tutorial/Paths#arcs
 		 */
 		const element =
-			angleLength === tau ? (
+			angleLength === TAU ? (
 				<circle
 					r={radius}
 					fill="none"

--- a/dotcom-rendering/src/web/components/Doughnut.tsx
+++ b/dotcom-rendering/src/web/components/Doughnut.tsx
@@ -49,6 +49,16 @@ const polarToCartesian = (angle: number, radius: number) =>
 
 const halfGap = (radius: number) => Math.asin(SEGMENT_GAP / 2 / radius);
 
+/** @see https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/d#elliptical_arc_curve */
+const arc = (start: number, end: number, radius: number) =>
+	[
+		`A${radius},${radius}`,
+		0, // rotation
+		Math.abs(end - start) <= TAU / 2 ? 0 : 1, // 1 - large / 0 small arc
+		end < start ? 0 : 1, // sweep flag (clockwise / )
+		polarToCartesian(end, radius),
+	].join(' ');
+
 export const Doughnut = ({
 	sections,
 	percentCutout = 35,
@@ -84,12 +94,8 @@ export const Doughnut = ({
 		const angleEnd = angleStart + angleLength;
 		const angleMid = angleStart + angleLength / 2;
 
-		/** depends on segment being smaller or larger than one half */
-		const largeArcFlag = angleLength < TAU / 2 ? 0 : 1;
-
 		/**
 		 * Either a circle, for a single segment, or an arc for multiple segments.
-		 * @see https://developer.mozilla.org/en-US/docs/Web/SVG/Tutorial/Paths#arcs
 		 */
 		const element =
 			angleLength === TAU ? (
@@ -106,18 +112,20 @@ export const Doughnut = ({
 							angleStart + halfGap(outerRadius),
 							outerRadius,
 						)}`,
-						`A${outerRadius},${outerRadius} 0 ${largeArcFlag} 1 ${polarToCartesian(
+						arc(
+							angleStart + halfGap(outerRadius),
 							angleEnd - halfGap(outerRadius),
 							outerRadius,
-						)}`,
+						),
 						`L${polarToCartesian(
 							angleEnd - halfGap(innerRadius),
 							innerRadius,
 						)}`,
-						`A${innerRadius},${innerRadius} 0 ${largeArcFlag} 0 ${polarToCartesian(
+						arc(
+							angleEnd - halfGap(innerRadius),
 							angleStart + halfGap(innerRadius),
 							innerRadius,
-						)}`,
+						),
 						'Z',
 					].join(' ')}
 					fill={color}


### PR DESCRIPTION
## What does this change?

Use actual gap between segments, as a suggested follow-up on #7372.

Extract constants to the module scope.

**N.B.** not to be confused with [“trous de beigne”](https://fr.wikipedia.org/wiki/Trou_de_beigne)!

## Why?

This allows any arbitrary background to be seen through the segments. Especially useful [on match reports](https://www.theguardian.com/football/2023/mar/04/arsenal-bournemouth-premier-league-match-report).

## Screenshots

You have to squint a bit to notice that the separation goes from **off-white** to **light blue**.

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |
| ![line][]   | ![hole][] |


[before]: https://github.com/guardian/dotcom-rendering/assets/76776/1f5c6307-3ee1-4722-a81d-b0efd88ac45b
[after]: https://github.com/guardian/dotcom-rendering/assets/76776/bf08cea8-2af2-4feb-ad64-711b7bacca4b

[line]: https://github.com/guardian/dotcom-rendering/assets/76776/e87e17f1-c036-429a-a05f-8afda74c417c
[hole]: https://github.com/guardian/dotcom-rendering/assets/76776/2b7c3834-68f2-4dea-8cc5-5d3b839662ab


