### PR TITLE
Add 0% test to remove epics from business liveblog

### DIFF
--- a/dotcom-rendering/src/web/components/LiveBlogEpic.importable.tsx
+++ b/dotcom-rendering/src/web/components/LiveBlogEpic.importable.tsx
@@ -17,6 +17,7 @@ import {
 } from '../lib/contributions';
 import { getLocaleCode } from '../lib/getCountryCode';
 import { setAutomat } from '../lib/setAutomat';
+import { useAB } from '../lib/useAB';
 import { useSDCLiveblogEpic } from '../lib/useSDC';
 
 type Props = {
@@ -241,6 +242,20 @@ export const LiveBlogEpic = ({
 }: Props) => {
 	log('dotcom', 'LiveBlogEpic started');
 
+	const [removeEpic, setRemoveEpic] = useState(false);
+
+	const ABTestAPI = useAB()?.api;
+	const userIsInRemoveLiveblogEpicTest = ABTestAPI?.isUserInVariant(
+		'RemoveBusinessLiveblogEpics',
+		'variant',
+	);
+
+	useEffect(() => {
+		setRemoveEpic(
+			!!userIsInRemoveLiveblogEpicTest && section == 'business',
+		);
+	}, [userIsInRemoveLiveblogEpicTest, section]);
+
 	// First construct the payload
 	const payload = usePayload({
 		shouldHideReaderRevenue,
@@ -251,6 +266,7 @@ export const LiveBlogEpic = ({
 		keywordIds,
 	});
 	if (!payload) return null;
+	if (removeEpic) return null;
 
 	/**
 	 * Here we decide where to insert the epic.

--- a/dotcom-rendering/src/web/components/LiveBlogEpic.importable.tsx
+++ b/dotcom-rendering/src/web/components/LiveBlogEpic.importable.tsx
@@ -249,7 +249,7 @@ export const LiveBlogEpic = ({
 	);
 
 	const removeEpic =
-		!!userIsInRemoveLiveblogEpicTest && section == 'business';
+		(userIsInRemoveLiveblogEpicTest ?? false) && section == 'business';
 
 	// First construct the payload
 	const payload = usePayload({

--- a/dotcom-rendering/src/web/components/LiveBlogEpic.importable.tsx
+++ b/dotcom-rendering/src/web/components/LiveBlogEpic.importable.tsx
@@ -242,19 +242,14 @@ export const LiveBlogEpic = ({
 }: Props) => {
 	log('dotcom', 'LiveBlogEpic started');
 
-	const [removeEpic, setRemoveEpic] = useState(false);
-
 	const ABTestAPI = useAB()?.api;
 	const userIsInRemoveLiveblogEpicTest = ABTestAPI?.isUserInVariant(
 		'RemoveBusinessLiveblogEpics',
 		'variant',
 	);
 
-	useEffect(() => {
-		setRemoveEpic(
-			!!userIsInRemoveLiveblogEpicTest && section == 'business',
-		);
-	}, [userIsInRemoveLiveblogEpicTest, section]);
+	const removeEpic =
+		!!userIsInRemoveLiveblogEpicTest && section == 'business';
 
 	// First construct the payload
 	const payload = usePayload({

--- a/dotcom-rendering/src/web/experiments/ab-tests.ts
+++ b/dotcom-rendering/src/web/experiments/ab-tests.ts
@@ -5,6 +5,7 @@ import { consentlessAds } from './tests/consentless-ads';
 import { elementsManager } from './tests/elements-manager';
 import { integrateIma } from './tests/integrate-ima';
 import { limitInlineMerch } from './tests/limit-inline-merch';
+import { removeBusinessLiveblogEpics } from './tests/remove-business-liveblog-epics';
 import { signInGateCopyTestJan2023 } from './tests/sign-in-gate-copy-test-variants';
 import { signInGateMainControl } from './tests/sign-in-gate-main-control';
 import { signInGateMainVariant } from './tests/sign-in-gate-main-variant';
@@ -21,4 +22,5 @@ export const tests: ABTest[] = [
 	billboardsInMerch,
 	elementsManager,
 	limitInlineMerch,
+	removeBusinessLiveblogEpics,
 ];

--- a/dotcom-rendering/src/web/experiments/tests/remove-business-liveblog-epics.ts
+++ b/dotcom-rendering/src/web/experiments/tests/remove-business-liveblog-epics.ts
@@ -1,0 +1,29 @@
+import type { ABTest } from '@guardian/ab-core';
+
+export const removeBusinessLiveblogEpics: ABTest = {
+	id: 'RemoveBusinessLiveblogEpics',
+	start: '2023-05-24',
+	expiry: '2023-07-10',
+	author: '@commercial-dev',
+	description:
+		'Test the commercial impact of removing contribution epics on business liveblogs',
+	audience: 0 / 100,
+	audienceOffset: 0 / 100,
+	audienceCriteria: 'Opt in',
+	successMeasure: 'Ad revenue increases on business liveblogs',
+	canRun: () => true,
+	variants: [
+		{
+			id: 'control',
+			test: (): void => {
+				/* no-op */
+			},
+		},
+		{
+			id: 'variant',
+			test: (): void => {
+				/* no-op */
+			},
+		},
+	],
+};


### PR DESCRIPTION
## What does this change?
Partner to this PR: https://github.com/guardian/frontend/pull/26172

Adds a 0% test to allow us to test the impact of removing business liveblog contribution epics on ad revenue and metrics.

