### PR TITLE
Update GH action check for dependabot

### DIFF
--- a/.github/workflows/ar-chromatic.yml
+++ b/.github/workflows/ar-chromatic.yml
@@ -42,7 +42,7 @@ jobs:
         if: |
           (github.event.label.name == 'run_chromatic' ||  github.ref == 'refs/heads/main') &&
           (!contains(github.event.pull_request.labels.*.name, 'dependencies') &&
-          github.event.pull_request.user.login != 'dependabot')
+          github.event.pull_request.user.login != 'dependabot[bot]')
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN__APPS_RENDERING }}
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -53,7 +53,7 @@ jobs:
 
       - name: Chromatic - Apps Rendering Dependency PR
         uses: chromaui/action@v1
-        if: ${{ github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'dependencies') || github.event.pull_request.user.login == 'dependabot') }}
+        if: ${{ github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'dependencies') || github.event.pull_request.user.login == 'dependabot[bot]') }}
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN__APPS_RENDERING }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dcr-chromatic.yml
+++ b/.github/workflows/dcr-chromatic.yml
@@ -42,7 +42,7 @@ jobs:
         if: |
           (contains(github.event.pull_request.labels.*.name, 'run_chromatic')  ||  github.ref == 'refs/heads/main') &&
           (!contains(github.event.pull_request.labels.*.name, 'dependencies') &&
-          github.event.pull_request.user.login != 'dependabot')
+          github.event.pull_request.user.login != 'dependabot[bot]')
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN__DOTCOM_RENDERING }}
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -53,7 +53,7 @@ jobs:
 
       - name: Chromatic - DCR Dependency PR
         uses: chromaui/action@v1
-        if: ${{ github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'dependencies') || github.event.pull_request.user.login == 'dependabot') }}
+        if: ${{ github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'dependencies') || github.event.pull_request.user.login == 'dependabot[bot]') }}
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN__DOTCOM_RENDERING }}
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Updates the Chromatic GH action to use what we hope it the correct Dependabot username.

## Why?

We've seen a massive spike of Chromatic snapshots from Dependabot PRs, we think this is most likely caused by the username being incorrect.

<img width="614" alt="Screenshot 2023-05-31 at 11 33 49" src="https://github.com/guardian/dotcom-rendering/assets/77005274/8cdbe8e0-5c26-48ab-9fec-7b470d4794c8">


