### PR TITLE
feat(bork): consistent degradation by browser

### DIFF
--- a/dotcom-rendering/src/web/bork/fcp.ts
+++ b/dotcom-rendering/src/web/bork/fcp.ts
@@ -1,12 +1,6 @@
 /** synthetically bork FCP https://web.dev/fcp/ */
-export const fcp = (): void => {
+export const fcp = (delay: number): void => {
 	try {
-		/**
-		 * A value in the 0ms - 4000ms range.
-		 * The upper bound of 4s matches our current 99th percentile for FCP.
-		 */
-		const delay = Math.floor(Math.random() * 4000);
-
 		if (CSS.supports('animation-duration', 'var(--fake-var)')) {
 			window.guardian.borkWebVitals.fcp = String(delay);
 			// eslint-disable-next-line no-console -- we want to apologise, in the name of science!

--- a/dotcom-rendering/src/web/bork/fid.ts
+++ b/dotcom-rendering/src/web/bork/fid.ts
@@ -1,5 +1,5 @@
 /** synthetically bork FID https://web.dev/fid/ */
-export const fid = (): void => {
+export const fid = (delay: number): void => {
 	try {
 		/** @see https://github.com/GoogleChrome/web-vitals/blob/v3.1.1/src/lib/polyfills/firstInputPolyfill.ts#L172 */
 		const eventTypes = [
@@ -8,12 +8,6 @@ export const fid = (): void => {
 			'touchstart',
 			'pointerdown',
 		];
-
-		/**
-		 * A value in the 0ms - 1000ms range.
-		 * The upper bound of 1s matches our current 99th percentile for FID.
-		 */
-		const delay = Math.floor(Math.random() * 1000);
 
 		if (
 			typeof window.performance === 'object' &&

--- a/dotcom-rendering/src/web/bork/remap.test.ts
+++ b/dotcom-rendering/src/web/bork/remap.test.ts
@@ -1,0 +1,37 @@
+import { remap } from './remap';
+
+describe('bork', () => {
+	test.each([
+		['50000', 0, 0],
+		['50001', 1, 1],
+		['50002', 2, 1],
+
+		['50003', 3, 2],
+		['50004', 4, 2],
+		['50005', 5, 2],
+
+		['50006', 6, 3],
+		['50007', 7, 3],
+
+		['50008', 8, 4],
+		['50009', 9, 4],
+		['50010', 10, 4],
+
+		['50011', 11, 5],
+		['50012', 12, 5],
+
+		['50013', 13, 6],
+
+		['50026', 26, 11],
+
+		['59997', 9997, 3999],
+		['59998', 9998, 4000],
+		['59999', 9999, 4000],
+	])(
+		'for %s get %s, %s',
+		(rawMvtIdString, expectedRemainder, expectedDelay) => {
+			expect(Number(rawMvtIdString) % 10_000).toEqual(expectedRemainder);
+			expect(remap(rawMvtIdString, 10_000, 4000)).toEqual(expectedDelay);
+		},
+	);
+});

--- a/dotcom-rendering/src/web/bork/remap.ts
+++ b/dotcom-rendering/src/web/bork/remap.ts
@@ -1,0 +1,3 @@
+/** Remap a value from one range to another */
+export const remap = (mvtId: string, modulo: number, max: number): number =>
+	Math.ceil(((Number(mvtId) % modulo) / modulo) * max);

--- a/dotcom-rendering/src/web/server/htmlPageTemplate.ts
+++ b/dotcom-rendering/src/web/server/htmlPageTemplate.ts
@@ -5,6 +5,7 @@ import { getFontsCss } from '../../lib/fonts-css';
 import type { RenderingTarget } from '../../types/renderingTarget';
 import { fcp } from '../bork/fcp';
 import { fid } from '../bork/fid';
+import { remap } from '../bork/remap';
 import { islandNoscriptStyles } from '../components/Island';
 import { getHttp3Url } from '../lib/getHttp3Url';
 
@@ -326,12 +327,41 @@ https://workforus.theguardian.com/careers/product-engineering/
 					borkFID || borkFCP
 						? `
 				<script>
-				// sorry
-				${borkFID ? `(${fid.toString()})();` : ''}
-				${borkFCP ? `(${fcp.toString()})();` : ''}
+				try {
+					function getCookieValue(name) {
+						var nameEq = name + "=",
+							cookies = document.cookie.split(';'),
+							value = null;
+						cookies.forEach(function (cookie) {
+							while (cookie.charAt(0) === ' ') {
+								cookie = cookie.substring(1, cookie.length);
+							}
+							if (cookie.indexOf(nameEq) === 0) {
+								value = cookie.substring(nameEq.length, cookie.length);
+							}
+						});
+						return value;
+					}
+
+					// sorry
+					${
+						borkFID
+							? `var fidDelay = (${remap.toString()})(getCookieValue('GU_mvt_id'), 10000, 1000);
+							(${fid.toString()})(fidDelay);`
+							: ''
+					}
+					${
+						borkFCP
+							? `var fcpDelay = (${remap.toString()})(getCookieValue('GU_mvt_id'), 10000, 4000);
+							(${fcp.toString()})(fcpDelay);`
+							: ''
+					}
+				} catch (e) {
+					// do nothing (not sorry)
+				}
 				</script>
 				`
-						: ''
+						: '<!-- no borking -->'
 				}
 
 


### PR DESCRIPTION
## What does this change?

Ensure consistent delays by deriving it from the MVT ID, which is consistent accross browsing sessions.

## Why?

We want to measure the impact of a consistently degraded performance on engagement.

Follow-up on #7711 

## How do we know this works?

Through manual testing: 

<img width="787" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/76776/12e266a4-7fb8-4fcb-8829-2bb9bcc38531">
