### PR TITLE
Only render ads on fronts if `renderAds` is true

### DIFF
--- a/dotcom-rendering/src/web/components/HeaderAdSlot.tsx
+++ b/dotcom-rendering/src/web/components/HeaderAdSlot.tsx
@@ -45,7 +45,6 @@ export const HeaderAdSlot = ({ display }: Props) => (
 				/**
 				* Hides the top-above-nav ad-slot container when a
 				* Bonzai TrueSkin (Australian 3rd Party page skin) is shown
-				* Temporary fix - introduced 06-Sep-2021
 				*/
 				.bz-custom-container
 					~ #bannerandheader

--- a/dotcom-rendering/src/web/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FrontLayout.tsx
@@ -135,9 +135,6 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 		front.isNetworkFront,
 	);
 
-	/**
-	 * This property currently only applies to the header and merchandising slots
-	 */
 	const renderAds = canRenderAds(front);
 
 	const mobileAdPositions = renderAds

--- a/dotcom-rendering/src/web/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FrontLayout.tsx
@@ -65,6 +65,7 @@ const isToggleable = (
 };
 
 const decideAdSlot = (
+	renderAds: boolean,
 	index: number,
 	isNetworkFront: boolean | undefined,
 	collectionCount: number,
@@ -72,6 +73,7 @@ const decideAdSlot = (
 	format: ArticleDisplay,
 	mobileAdPositions: (number | undefined)[],
 ) => {
+	if (!renderAds) return null;
 	const minContainers = isPaidContent ? 1 : 2;
 	if (
 		collectionCount > minContainers &&
@@ -296,6 +298,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 									</SnapCssSandbox>
 								)}
 								{decideAdSlot(
+									renderAds,
 									index,
 									front.isNetworkFront,
 									front.pressedPage.collections.length,
@@ -347,6 +350,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 									/>
 								</Section>
 								{decideAdSlot(
+									renderAds,
 									index,
 									front.isNetworkFront,
 									front.pressedPage.collections.length,
@@ -415,16 +419,15 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 									renderAds={renderAds}
 								/>
 							</FrontSection>
-							{renderAds &&
-								decideAdSlot(
-									index,
-									front.isNetworkFront,
-									front.pressedPage.collections.length,
-									front.pressedPage.frontProperties
-										.isPaidContent,
-									format.display,
-									mobileAdPositions,
-								)}
+							{decideAdSlot(
+								renderAds,
+								index,
+								front.isNetworkFront,
+								front.pressedPage.collections.length,
+								front.pressedPage.frontProperties.isPaidContent,
+								format.display,
+								mobileAdPositions,
+							)}
 						</>
 					);
 				})}

--- a/dotcom-rendering/src/web/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FrontLayout.tsx
@@ -439,17 +439,19 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 			>
 				<TrendingTopics trendingTopics={front.trendingTopics} />
 			</Section>
-			<Section
-				fullWidth={true}
-				data-print-layout="hide"
-				padSides={false}
-				showTopBorder={false}
-				showSideBorders={false}
-				backgroundColour={neutral[93]}
-				element="aside"
-			>
-				<AdSlot position="merchandising" display={format.display} />
-			</Section>
+			{renderAds && (
+				<Section
+					fullWidth={true}
+					data-print-layout="hide"
+					padSides={false}
+					showTopBorder={false}
+					showSideBorders={false}
+					backgroundColour={neutral[93]}
+					element="aside"
+				>
+					<AdSlot position="merchandising" display={format.display} />
+				</Section>
+			)}
 
 			{NAV.subNavSections && (
 				<Section

--- a/dotcom-rendering/src/web/lib/getAdPositions.ts
+++ b/dotcom-rendering/src/web/lib/getAdPositions.ts
@@ -57,7 +57,7 @@ const isEvenIndex = (_collection: unknown, index: number) => index % 2 === 0;
 /**
  * We do not insert mobile ads:
  * a. after the first container if it is a thrasher
- * b. after a commercial container (e.g. merchandise high)
+ * b. after a commercial container (e.g. merchandising-high)
  * c. between a regular container and a thrasher
  * d. after the Most Viewed container.
  * After we've filtered out the containers next to which we can insert an ad,


### PR DESCRIPTION
## What does this change?

Only render ads on fronts if `renderAds` is true

Mainly:
- a re-implementation of https://github.com/guardian/dotcom-rendering/pull/7449 thanks @bryophyta
- a little refactor to move the decision of `renderAds` into `decideAdSlots`. We were missing the check of `renderAds` before calling `decideAdSlots` in a few places so centralising makes this contract more explicit.



