### PR TITLE
Consume `isNonNullable` from @guardian/libs

### DIFF
--- a/dotcom-rendering/src/amp/components/Elements.tsx
+++ b/dotcom-rendering/src/amp/components/Elements.tsx
@@ -1,3 +1,4 @@
+import { isNonNullable } from '@guardian/libs';
 import { NotRenderableInDCR } from '../../lib/errors/not-renderable-in-dcr';
 import type { Switches } from '../../types/config';
 import type { FEElement } from '../../types/content';
@@ -349,7 +350,5 @@ export const Elements = (
 		}
 	});
 
-	return output.filter(
-		(el: JSX.Element | null): el is JSX.Element => el !== null,
-	);
+	return output.filter(isNonNullable);
 };

--- a/dotcom-rendering/src/amp/lib/scripts.ts
+++ b/dotcom-rendering/src/amp/lib/scripts.ts
@@ -1,6 +1,6 @@
+import { isNonNullable } from '@guardian/libs';
 import type { FEElement } from '../../types/content';
 
-const notEmpty = (value: string | null): value is string => value !== null;
 const unique = (value: string | null, index: number, self: (string | null)[]) =>
 	value && self.indexOf(value) === index;
 
@@ -31,7 +31,7 @@ export const extractScripts: (
 					return null;
 			}
 		})
-		.filter((scriptEl) => notEmpty(scriptEl))
+		.filter(isNonNullable)
 		.filter((scriptEl, index, self) =>
 			unique(scriptEl, index, self),
 		) as string[];

--- a/dotcom-rendering/src/amp/lib/srcset-utils.ts
+++ b/dotcom-rendering/src/amp/lib/srcset-utils.ts
@@ -1,4 +1,4 @@
-import { isUndefined } from '@guardian/libs';
+import { isNonNullable } from '@guardian/libs';
 import type { ImageSource, SrcSetItem } from '../../types/content';
 import { bestFitImage } from './image-fit';
 
@@ -31,16 +31,12 @@ const removeDuplicateWidth = (items: SrcSetItem[]): SrcSetItem[] => {
 	return packet.items;
 };
 
-const isSrcSet = (
-	item: SrcSetItem | undefined,
-): item is NonNullable<SrcSetItem> => !isUndefined(item);
-
 export const scrsetStringFromImagesSources = (
 	imageSources: ImageSource[],
 ): string => {
 	const srcSetItems1 = containerWidths
 		.map((width) => bestFitImage(imageSources, width))
-		.filter(isSrcSet);
+		.filter(isNonNullable);
 	// We now need to make sure that we do not have multiple images with the same width
 	const srcSetItems2 = removeDuplicateWidth(srcSetItems1);
 	return srcSetItems2.map((item) => `${item.src} ${item.width}w`).join(', ');

--- a/dotcom-rendering/src/model/extractTrendingTopics.ts
+++ b/dotcom-rendering/src/model/extractTrendingTopics.ts
@@ -1,9 +1,7 @@
+import { isNonNullable } from '@guardian/libs';
 import type { FECollectionType, FEFrontCard } from '../types/front';
 import type { FETagType } from '../types/tag';
 
-//type guard function that checks if a value is defined
-const notUndefined = (value: FETagType | undefined): value is FETagType =>
-	value !== undefined;
 /**
  * Gets all relevant tags filtered by properties
  * @param tags - The deduplicated trails
@@ -12,7 +10,7 @@ const notUndefined = (value: FETagType | undefined): value is FETagType =>
 const getTags = (trails: FEFrontCard[]): FETagType[] =>
 	trails
 		.flatMap((trail) => trail.properties.maybeContent?.tags.tags)
-		.filter(notUndefined)
+		.filter(isNonNullable)
 		.filter((tag) => {
 			return (
 				tag.properties.paidContentType?.includes('Keyword') ??
@@ -49,7 +47,7 @@ const filterTopFive = (tag: FETagType[]): FETagType[] => {
 const dedupeTags = (tag: FETagType[]): FETagType[] =>
 	[...new Set(tag.map((item) => item.properties.id))]
 		.map((id) => tag.find((item) => item.properties.id === id))
-		.filter(notUndefined);
+		.filter(isNonNullable);
 
 export const extractTrendingTopics = (
 	collections: FECollectionType[],

--- a/dotcom-rendering/src/web/components/ShowMore.importable.tsx
+++ b/dotcom-rendering/src/web/components/ShowMore.importable.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import { isNonNullable } from '@guardian/libs';
 import {
 	from,
 	neutral,
@@ -96,8 +97,7 @@ export const ShowMore = ({
 			container?.querySelectorAll('a') ?? [],
 		)
 			.map((element) => element.attributes.getNamedItem('href')?.value)
-			// Remove values that are not strings and coerce the type to a string[]
-			.filter((item): item is string => !!item);
+			.filter(isNonNullable);
 
 		setExistingCardLinks(containerLinks);
 	}, []);


### PR DESCRIPTION
## What does this change?

Small health refactor to use [`@guardian/libs`’s `isNonNullable`](https://github.com/guardian/csnx/pull/313)

## Why?

More consistency. We’re currently doing a very similar thing in 5 different ways.