### PR TITLE
Do not show side borders in thrashers

### DIFF
--- a/dotcom-rendering/src/web/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FrontLayout.tsx
@@ -282,7 +282,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 											fullWidth={true}
 											padSides={false}
 											showTopBorder={false}
-											showSideBorders={true}
+											showSideBorders={false}
 											ophanComponentLink={
 												ophanComponentLink
 											}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## Why?

This achieves parity with frontend and removes and extra gray line we now see in thrashers rendered by DCR. Thrashers have their own CSS for borders and they don't need this. This will allow us to remove [the Pandora Papers thrasher](https://github.com/guardian/frontend/blob/main/facia/app/services/dotcomrendering/FaciaPicker.scala#L81) from the unsupported list and render https://www.theguardian.com/news/series/pandora-papers front from DCR.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/010a4612-30d0-422f-890b-bfa55dd655cc) | ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/0db80736-ec91-49f1-bf6e-22d1dbe2cc21) |
| ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/43bd64c2-1b61-4c20-9b0a-18f822dcc609) | ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/63d439f0-3c99-4b70-84f4-96c9998393db) |


[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
