### PR TITLE
Set `z-index: 1` in `VeggieBurgerMenu`

### DIFF
--- a/dotcom-rendering/src/web/components/Nav/ExpandedMenu/VeggieBurgerMenu.tsx
+++ b/dotcom-rendering/src/web/components/Nav/ExpandedMenu/VeggieBurgerMenu.tsx
@@ -77,6 +77,7 @@ const veggieBurgerStyles = (display: ArticleDisplay) => css`
 	position: absolute;
 	border: 0;
 	border-radius: 50%;
+	z-index: 1;
 
 	right: 5px;
 	bottom: 58px;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Sets `z-index: 1` in `VeggieBurgerMenu`

## Why?

This change is to make sure part of the burger menu does not get hidden. It addresses the following edge case: 
a. The first container is a thrasher. 
b. The front path starts with `news/series` or any other combination that does not open any submenu, e.g https://www.theguardian.com/news/series/pandora-papers. (As opposed to this, a path that opens the News submenu would be `uk-news/series`.) 

| Before | After |
|--------|-------|
| ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/40406678-1218-42ef-9dc3-8069b26231ab) | ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/8bad87de-5eaa-42f0-9289-49b4afb97a99) |

This problem does not occur when only condition _a_ is true, e.g. in https://www.theguardian.com/uk-news/series/cost-of-the-crown

![image](https://github.com/guardian/dotcom-rendering/assets/19683595/926e6c8a-70cb-4da9-92bc-87de0b683506)

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
