### PR TITLE
Fix article badge schema

### DIFF
--- a/dotcom-rendering/fixtures/generated/articles/SpecialReport.ts
+++ b/dotcom-rendering/fixtures/generated/articles/SpecialReport.ts
@@ -1585,8 +1585,8 @@ export const SpecialReport: FEArticleType = {
 		},
 	],
 	badge: {
-		href: '/environment/series/the-polluters',
-		imageSrc:
+		seriesTag: 'environment/series/the-polluters',
+		imageUrl:
 			'https://assets.guim.co.uk/images/badges/b36f98674bc4fdb9631360f7d66b2531/the-polluters.svg',
 	},
 	pillar: 'news',

--- a/dotcom-rendering/src/model/article-schema.json
+++ b/dotcom-rendering/src/model/article-schema.json
@@ -442,7 +442,7 @@
             "type": "string"
         },
         "badge": {
-            "$ref": "#/definitions/BadgeType"
+            "$ref": "#/definitions/FEArticleBadgeType"
         },
         "nav": {
             "$ref": "#/definitions/FENavType"
@@ -4595,7 +4595,25 @@
                 "value"
             ]
         },
-        "BadgeType": {
+        "FEArticleBadgeType": {
+            "type": "object",
+            "properties": {
+                "seriesTag": {
+                    "type": "string"
+                },
+                "imageUrl": {
+                    "type": "string"
+                },
+                "enhanced": {
+                    "$ref": "#/definitions/DCRBadgeType"
+                }
+            },
+            "required": [
+                "imageUrl",
+                "seriesTag"
+            ]
+        },
+        "DCRBadgeType": {
             "type": "object",
             "properties": {
                 "imageSrc": {

--- a/dotcom-rendering/src/model/decideBadge.ts
+++ b/dotcom-rendering/src/model/decideBadge.ts
@@ -1,5 +1,5 @@
-import { BadgeType } from '../types/badge';
-import { Branding } from '../types/branding';
+import type { DCRBadgeType } from '../types/badge';
+import type { Branding } from '../types/branding';
 
 /**
  * Construct a badge based on the collection displayName or card branding
@@ -7,7 +7,7 @@ import { Branding } from '../types/branding';
 export const decideBadge = (
 	displayName: string,
 	allBranding: Branding[],
-): BadgeType | undefined => {
+): DCRBadgeType | undefined => {
 	if (displayName === 'This is Europe') {
 		return {
 			imageSrc:

--- a/dotcom-rendering/src/types/badge.ts
+++ b/dotcom-rendering/src/types/badge.ts
@@ -1,4 +1,10 @@
-export interface BadgeType {
+export interface DCRBadgeType {
 	imageSrc: string;
 	href: string;
+}
+
+export interface FEArticleBadgeType {
+	seriesTag: string;
+	imageUrl: string;
+	enhanced?: DCRBadgeType;
 }

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -1,11 +1,11 @@
 import type { ArticlePillar, ArticleSpecial } from '@guardian/libs';
 import type { EditionId } from '../web/lib/edition';
+import type { DCRBadgeType } from './badge';
+import type { Branding } from './branding';
 import type { ServerSideTests, Switches } from './config';
 import type { FooterType } from './footer';
 import type { FETagType } from './tag';
 import type { FETrailType, TrailType } from './trails';
-import { Branding } from './branding';
-import { BadgeType } from './badge';
 
 export interface FEFrontType {
 	pressedPage: FEPressedPageType;
@@ -350,7 +350,7 @@ export type DCRCollectionType = {
 	 *
 	 * */
 	isLabs?: boolean;
-	badge?: BadgeType;
+	badge?: DCRBadgeType;
 };
 
 export type DCRGroupedTrails = {

--- a/dotcom-rendering/src/types/frontend.ts
+++ b/dotcom-rendering/src/types/frontend.ts
@@ -1,5 +1,5 @@
 import type { EditionId } from '../web/lib/edition';
-import type { BadgeType } from './badge';
+import type { FEArticleBadgeType } from './badge';
 import type { CommercialProperties } from './commercial';
 import type { ConfigType } from './config';
 import type { FEElement, Newsletter } from './content';
@@ -83,7 +83,7 @@ export interface FEArticleType {
 	commercialProperties: CommercialProperties;
 	starRating?: number;
 	trailText: string;
-	badge?: BadgeType;
+	badge?: FEArticleBadgeType;
 
 	nav: FENavType; // TODO move this out as most code uses a different internal NAV model.
 

--- a/dotcom-rendering/src/web/components/ArticleTitle.tsx
+++ b/dotcom-rendering/src/web/components/ArticleTitle.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import { ArticleDesign, ArticleDisplay } from '@guardian/libs';
 import { from, until } from '@guardian/source-foundations';
-import type { BadgeType } from '../../types/badge';
+import type { DCRBadgeType } from '../../types/badge';
 import type { TagType } from '../../types/tag';
 import { Badge } from './Badge';
 import { SeriesSectionLink } from './SeriesSectionLink';
@@ -12,7 +12,7 @@ type Props = {
 	sectionLabel: string;
 	sectionUrl: string;
 	guardianBaseURL: string;
-	badge?: BadgeType;
+	badge?: DCRBadgeType;
 	isMatch?: boolean;
 };
 

--- a/dotcom-rendering/src/web/components/FrontSection.tsx
+++ b/dotcom-rendering/src/web/components/FrontSection.tsx
@@ -1,16 +1,16 @@
 import { css } from '@emotion/react';
 import { from, neutral, space, until } from '@guardian/source-foundations';
 import { Hide } from '@guardian/source-react-components';
+import type { DCRBadgeType } from '../../types/badge';
 import type { DCRContainerPalette, TreatType } from '../../types/front';
 import { decideContainerOverrides } from '../lib/decideContainerOverrides';
 import type { EditionId } from '../lib/edition';
+import { Badge } from './Badge';
 import { ContainerTitle } from './ContainerTitle';
 import { Island } from './Island';
 import { ShowHideButton } from './ShowHideButton';
 import { ShowMore } from './ShowMore.importable';
 import { Treats } from './Treats';
-import { BadgeType } from '../../types/badge';
-import { Badge } from './Badge';
 
 type Props = {
 	/** This text will be used as the h2 shown in the left column for the section */
@@ -53,7 +53,7 @@ type Props = {
 	editionId?: EditionId;
 	/** A list of related links that appear in the bottom of the left column on fronts */
 	treats?: TreatType[];
-	badge?: BadgeType;
+	badge?: DCRBadgeType;
 	/** Enable the "Show More" button on this container to allow readers to load more cards */
 	canShowMore?: boolean;
 	ajaxUrl?: string;
@@ -419,7 +419,7 @@ export const FrontSection = ({
 				fallbackStyles,
 				containerStyles,
 				css`
-					background-color: ${overrides?.background?.container};
+					background-color: ${overrides?.background.container};
 				`,
 			]}
 		>
@@ -428,15 +428,15 @@ export const FrontSection = ({
 			<div css={[sectionHeadline]}>
 				<Hide until="leftCol">
 					{badge && (
-						<Badge imageSrc={badge?.imageSrc} href={badge?.href} />
+						<Badge imageSrc={badge.imageSrc} href={badge.href} />
 					)}
 				</Hide>
 				<div css={titleStyle}>
 					<Hide from="leftCol">
 						{badge && (
 							<Badge
-								imageSrc={badge?.imageSrc}
-								href={badge?.href}
+								imageSrc={badge.imageSrc}
+								href={badge.href}
 							/>
 						)}
 					</Hide>

--- a/dotcom-rendering/src/web/components/SeriesSectionLink.tsx
+++ b/dotcom-rendering/src/web/components/SeriesSectionLink.tsx
@@ -7,7 +7,7 @@ import {
 	textSans,
 	until,
 } from '@guardian/source-foundations';
-import type { BadgeType } from '../../types/badge';
+import type { DCRBadgeType } from '../../types/badge';
 import type { Palette } from '../../types/palette';
 import type { TagType } from '../../types/tag';
 import { interactiveLegacyClasses } from '../layouts/lib/interactiveLegacyStyling';
@@ -22,7 +22,7 @@ type Props = {
 	sectionLabel: string;
 	sectionUrl: string;
 	guardianBaseURL: string;
-	badge?: BadgeType;
+	badge?: DCRBadgeType;
 	isMatch?: boolean;
 };
 

--- a/dotcom-rendering/src/web/components/SubMeta.tsx
+++ b/dotcom-rendering/src/web/components/SubMeta.tsx
@@ -9,7 +9,7 @@ import {
 } from '@guardian/source-foundations';
 import { LinkButton } from '@guardian/source-react-components';
 import type { BaseLinkType } from '../../model/extract-nav';
-import type { BadgeType } from '../../types/badge';
+import type { DCRBadgeType } from '../../types/badge';
 import type { Palette } from '../../types/palette';
 import { decidePalette } from '../lib/decidePalette';
 import { Badge } from './Badge';
@@ -130,7 +130,7 @@ type Props = {
 	webUrl: string;
 	webTitle: string;
 	showBottomSocialButtons: boolean;
-	badge?: BadgeType;
+	badge?: DCRBadgeType;
 };
 
 const syndicationButtonOverrides = (palette: Palette) => css`

--- a/dotcom-rendering/src/web/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/CommentLayout.tsx
@@ -468,7 +468,7 @@ export const CommentLayout = ({
 								sectionLabel={article.sectionLabel}
 								sectionUrl={article.sectionUrl}
 								guardianBaseURL={article.guardianBaseURL}
-								badge={article.badge}
+								badge={article.badge?.enhanced}
 							/>
 						</GridItem>
 						<GridItem area="border">
@@ -667,7 +667,7 @@ export const CommentLayout = ({
 										showBottomSocialButtons={
 											article.showBottomSocialButtons
 										}
-										badge={article.badge}
+										badge={article.badge?.enhanced}
 									/>
 								</div>
 							</ArticleContainer>

--- a/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
@@ -450,7 +450,7 @@ export const ImmersiveLayout = ({
 									sectionLabel={article.sectionLabel}
 									sectionUrl={article.sectionUrl}
 									guardianBaseURL={article.guardianBaseURL}
-									badge={article.badge}
+									badge={article.badge?.enhanced}
 								/>
 							</Section>
 							<Box palette={palette}>
@@ -528,7 +528,7 @@ export const ImmersiveLayout = ({
 											guardianBaseURL={
 												article.guardianBaseURL
 											}
-											badge={article.badge}
+											badge={article.badge?.enhanced}
 										/>
 									</div>
 								)}
@@ -707,7 +707,7 @@ export const ImmersiveLayout = ({
 									showBottomSocialButtons={
 										article.showBottomSocialButtons
 									}
-									badge={article.badge}
+									badge={article.badge?.enhanced}
 								/>
 							</ArticleContainer>
 						</GridItem>

--- a/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
@@ -422,7 +422,7 @@ export const InteractiveLayout = ({
 										guardianBaseURL={
 											article.guardianBaseURL
 										}
-										badge={article.badge}
+										badge={article.badge?.enhanced}
 									/>
 								</div>
 							</GridItem>
@@ -614,7 +614,7 @@ export const InteractiveLayout = ({
 						showBottomSocialButtons={
 							article.showBottomSocialButtons
 						}
-						badge={article.badge}
+						badge={article.badge?.enhanced}
 					/>
 				</Section>
 				{renderAds && (

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -424,7 +424,7 @@ export const LiveLayout = ({
 								sectionLabel={article.sectionLabel}
 								sectionUrl={article.sectionUrl}
 								guardianBaseURL={article.guardianBaseURL}
-								badge={article.badge}
+								badge={article.badge?.enhanced}
 								isMatch={true}
 							/>
 						}
@@ -439,7 +439,7 @@ export const LiveLayout = ({
 								sectionLabel={article.sectionLabel}
 								sectionUrl={article.sectionUrl}
 								guardianBaseURL={article.guardianBaseURL}
-								badge={article.badge}
+								badge={article.badge?.enhanced}
 								isMatch={true}
 							/>
 						</Hide>
@@ -475,7 +475,7 @@ export const LiveLayout = ({
 									sectionLabel={article.sectionLabel}
 									sectionUrl={article.sectionUrl}
 									guardianBaseURL={article.guardianBaseURL}
-									badge={article.badge}
+									badge={article.badge?.enhanced}
 								/>
 							</GridItem>
 							<GridItem area="headline">
@@ -946,7 +946,9 @@ export const LiveLayout = ({
 													showBottomSocialButtons={
 														article.showBottomSocialButtons
 													}
-													badge={article.badge}
+													badge={
+														article.badge?.enhanced
+													}
 												/>
 											</ArticleContainer>
 										</div>
@@ -1103,7 +1105,9 @@ export const LiveLayout = ({
 													showBottomSocialButtons={
 														article.showBottomSocialButtons
 													}
-													badge={article.badge}
+													badge={
+														article.badge?.enhanced
+													}
 												/>
 											</ArticleContainer>
 										</Accordion>

--- a/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
@@ -466,7 +466,7 @@ export const ShowcaseLayout = ({
 								sectionLabel={article.sectionLabel}
 								sectionUrl={article.sectionUrl}
 								guardianBaseURL={article.guardianBaseURL}
-								badge={article.badge}
+								badge={article.badge?.enhanced}
 							/>
 						</GridItem>
 						<GridItem area="border">
@@ -615,7 +615,7 @@ export const ShowcaseLayout = ({
 									showBottomSocialButtons={
 										article.showBottomSocialButtons
 									}
-									badge={article.badge}
+									badge={article.badge?.enhanced}
 								/>
 							</ArticleContainer>
 						</GridItem>

--- a/dotcom-rendering/src/web/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/StandardLayout.tsx
@@ -554,7 +554,7 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 								sectionLabel={article.sectionLabel}
 								sectionUrl={article.sectionUrl}
 								guardianBaseURL={article.guardianBaseURL}
-								badge={article.badge}
+								badge={article.badge?.enhanced}
 								isMatch={!!footballMatchUrl}
 							/>
 						</GridItem>
@@ -742,7 +742,7 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 									showBottomSocialButtons={
 										article.showBottomSocialButtons
 									}
-									badge={article.badge}
+									badge={article.badge?.enhanced}
 								/>
 							</ArticleContainer>
 						</GridItem>

--- a/dotcom-rendering/src/web/server/index.article.web.ts
+++ b/dotcom-rendering/src/web/server/index.article.web.ts
@@ -6,6 +6,7 @@ import { enhanceStandfirst } from '../../model/enhanceStandfirst';
 import { enhanceTableOfContents } from '../../model/enhanceTableOfContents';
 import { validateAsArticleType } from '../../model/validate';
 import { recordTypeAndPlatform } from '../../server/lib/logging-store';
+import type { FEArticleBadgeType } from '../../types/badge';
 import type { FEArticleType } from '../../types/frontend';
 import {
 	renderBlocks,
@@ -19,6 +20,17 @@ const getStack = (e: unknown): string =>
 const enhancePinnedPost = (format: FEFormat, block?: Block) => {
 	return block ? enhanceBlocks([block], format)[0] : block;
 };
+
+const enhanceBadge = (badge?: FEArticleBadgeType) =>
+	badge
+		? {
+				...badge,
+				enhanced: {
+					href: `/${badge.seriesTag}`,
+					imageSrc: badge.imageUrl,
+				},
+		  }
+		: undefined;
 
 export const enhanceArticleType = (body: unknown): FEArticleType => {
 	const data = validateAsArticleType(body);
@@ -37,6 +49,7 @@ export const enhanceArticleType = (body: unknown): FEArticleType => {
 		tableOfContents: data.showTableOfContents
 			? enhanceTableOfContents(data.format, enhancedBlocks)
 			: undefined,
+		badge: enhanceBadge(data.badge),
 	};
 };
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Fixes a problem introduced in https://github.com/guardian/dotcom-rendering/pull/7764 where the article schema for badges is not correctly defined.

This PR changes the article schema to use the original properties, which is then enhanced into the new badge type

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/9575458/ba8fcd57-3ef9-43a5-83d3-9cc4ba0e2710
[after]: https://github.com/guardian/dotcom-rendering/assets/9575458/f5cc4066-222c-483c-8460-adec5954e0c4

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
