### PR TITLE
Adds missing newsletter treat and missing Qatar football treat

### DIFF
--- a/dotcom-rendering/src/model/enhanceCollections.ts
+++ b/dotcom-rendering/src/model/enhanceCollections.ts
@@ -7,9 +7,10 @@ import { groupCards } from './groupCards';
 
 const FORBIDDEN_CONTAINERS = [
 	'Palette styles new do not delete',
+	'Palette styles',
 	'culture-treat',
 	'newsletter treat',
-	'Palette styles',
+	'qatar treat',
 ];
 const isSupported = (collection: FECollectionType): boolean =>
 	!FORBIDDEN_CONTAINERS.includes(collection.displayName);

--- a/dotcom-rendering/src/model/enhanceTreats.ts
+++ b/dotcom-rendering/src/model/enhanceTreats.ts
@@ -32,6 +32,35 @@ const PLATFORM_TREATS: TreatType[] = [
 		altText: 'The White House',
 		pageId: 'us',
 	},
+	{
+		links: [
+			{
+				linkTo: '/info/2015/dec/08/daily-email-us?INTCMP=gdnwb_treat_election_today_us',
+				title: 'Guardian Today US: ',
+				text: 'Get the headlines & more in a daily email',
+			},
+		],
+		theme: ArticlePillar.News,
+		containerTitle: 'US headlines',
+		imageUrl:
+			'https://uploads.guim.co.uk/2020/10/22/newsletter-treat-img.png',
+		altText: 'The White House',
+		pageId: 'us-news',
+	},
+	{
+		links: [
+			{
+				linkTo: '/news/series/qatar-beyond-the-football',
+				text: 'Qatar: beyond the football',
+			},
+		],
+		theme: ArticlePillar.News,
+		containerTitle: 'Qatar: beyond the football',
+		imageUrl:
+			'https://uploads.guim.co.uk/2023/06/02/BALL-nugget-grass_5.png',
+		altText: 'Image of football covered in bank notes',
+		pageId: 'football/world-cup-2022',
+	},
 ];
 
 const getPlatformTreats = (


### PR DESCRIPTION
## What does this change?

- Adds the "Qatar: Beyond the football" treat to the "Qatar: beyond the football" section on the football/world-cup-2022 front
- Adds the "Guardian Today US" newsletter treat to the "US headlines" section on the us-news front

## Why?

a) They're currently missing on DCR
b) The thrashers used to do this on Frontend are JSON.HTML thrashers that we want to avoid.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |
| ![before2][] | ![after2][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/21217225/42b01126-36fd-443b-9c09-a66e7b0b719d

[after]: https://github.com/guardian/dotcom-rendering/assets/21217225/791cb268-6ebf-48d1-bd0a-1532e1e49c63
[before2]: https://github.com/guardian/dotcom-rendering/assets/21217225/7053b1e4-0deb-4803-bbf0-76583afde7c8
[after2]: https://github.com/guardian/dotcom-rendering/assets/21217225/0742f994-f5a5-4766-bdf6-a81c4a669f79


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.



You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
