### PR TITLE
Poor web page performance monitoring

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -74,7 +74,7 @@
 		"@guardian/eslint-config": "3.0.0",
 		"@guardian/eslint-config-typescript": "5.0.0",
 		"@guardian/eslint-plugin-source-react-components": "14.0.0",
-		"@guardian/libs": "14.0.0",
+		"@guardian/libs": "14.1.0",
 		"@guardian/prettier": "3.0.0",
 		"@guardian/shimport": "1.0.2",
 		"@guardian/source-foundations": "10.0.1",

--- a/dotcom-rendering/src/client/index.ts
+++ b/dotcom-rendering/src/client/index.ts
@@ -6,6 +6,7 @@ import { dynamicImport } from './dynamicImport';
 import { ga } from './ga';
 import { islands } from './islands';
 import { ophan } from './ophan';
+import { performanceMonitoring } from './performanceMonitoring';
 import { sentryLoader } from './sentryLoader';
 import { startup } from './startup';
 
@@ -15,6 +16,7 @@ startup('ga', ga);
 startup('sentryLoader', sentryLoader);
 startup('dynamicImport', dynamicImport);
 startup('islands', islands);
+startup('performanceMonitoring', performanceMonitoring);
 
 // these modules are loaded as separate chunks, so that they can be lazy-loaded
 void import(/* webpackChunkName: 'atomIframe' */ './atomIframe').then(

--- a/dotcom-rendering/src/client/ophan/ophan.ts
+++ b/dotcom-rendering/src/client/ophan/ophan.ts
@@ -9,7 +9,7 @@ import { log } from '@guardian/libs';
 import type { ServerSideTests } from '../../types/config';
 
 export type OphanRecordFunction = (
-	event: { [key: string]: any },
+	event: { [key: string]: unknown },
 	callback?: () => void,
 ) => void;
 
@@ -18,8 +18,11 @@ export const getOphanRecordFunction = (): OphanRecordFunction => {
 
 	if (record) return record;
 
+	// eslint-disable-next-line no-console -- worth informing all users
 	console.warn('window.guardian.ophan.record is not available');
-	return () => {};
+	return () => {
+		/* do nothing */
+	};
 };
 
 export const record: OphanRecordFunction = (event) => {

--- a/dotcom-rendering/src/client/performanceMonitoring.ts
+++ b/dotcom-rendering/src/client/performanceMonitoring.ts
@@ -1,0 +1,98 @@
+import { log } from '@guardian/libs';
+import { record } from './ophan/ophan';
+
+const logPerformanceInfo = (name: string, data?: unknown) =>
+	log('openJournalism', '⏱', name, data);
+
+const reasons = new Set<string>();
+const recordPoorDeviceConnectivity = (reason: string) => {
+	reasons.add(reason);
+	log('openJournalism', '🐌', reasons);
+	if (reasons.size >= 2) {
+		/** Not sure here if we should duplicate “dotcom-rendering” */
+		const experiences = ['dotcom-rendering', 'poor-page-performance'].join(
+			',',
+		);
+		record({ experiences });
+	}
+};
+
+export const performanceMonitoring = (): Promise<void> => {
+	try {
+		// First contentful paint is the best single indicator
+		// of core web vitals label
+		new PerformanceObserver((entries, observer) => {
+			for (const { name, duration, startTime } of entries.getEntries()) {
+				switch (name) {
+					case 'first-contentful-paint': {
+						logPerformanceInfo(name, { startTime, duration });
+						if (startTime > 2400) {
+							recordPoorDeviceConnectivity('FCP over 2.4s');
+							observer.disconnect();
+						}
+					}
+				}
+			}
+		}).observe({
+			type: 'paint',
+			buffered: true,
+		});
+
+		// Time to first byte is a widely supported performance marker
+		// which is the second-best indicator of core web vitals label
+		const [nav] = window.performance.getEntriesByType('navigation');
+		if (nav) {
+			const info = {
+				domContentLoadedEventEnd: nav.domContentLoadedEventEnd,
+				type: nav.type,
+				responseEnd: nav.responseEnd,
+			};
+			logPerformanceInfo('navigation', info);
+			const ttfb = nav.responseStart - nav.startTime;
+			if (ttfb > 2400) {
+				recordPoorDeviceConnectivity('TTFB over 2.4s');
+			}
+		}
+
+		// If Ophan takes a long time to load, we take it as an indicator
+		// of very slow connection or very little processing power
+		new PerformanceObserver((entries, observer) => {
+			for (const { name, duration, startTime } of entries.getEntries()) {
+				switch (name) {
+					case 'ophan': {
+						logPerformanceInfo(name, { startTime, duration });
+						if (startTime > 5000 || duration > 20) {
+							recordPoorDeviceConnectivity(
+								'Ophan took over 5s to boot or 20ms to execute',
+							);
+							observer.disconnect();
+						}
+					}
+				}
+			}
+		}).observe({
+			type: 'measure',
+			buffered: true,
+		});
+
+		// Long tasks are only supported in Chromium, but can be a good indicator
+		// of poor performance
+		let longTasks = 0;
+		new PerformanceObserver((entries, observer) => {
+			for (const { name, duration, startTime } of entries.getEntries()) {
+				longTasks += duration;
+				logPerformanceInfo('longtask:' + name, { startTime, duration });
+				if (longTasks >= 120) {
+					recordPoorDeviceConnectivity(
+						'Long tasks total duration above 120ms',
+					);
+					observer.disconnect();
+				}
+			}
+		}).observe({ type: 'longtask', buffered: true });
+	} catch (error) {
+		// do nothing if the performance API is not available
+	}
+
+	return Promise.resolve();
+};

--- a/dotcom-rendering/src/client/startup.ts
+++ b/dotcom-rendering/src/client/startup.ts
@@ -7,17 +7,13 @@ const measure = (name: string, task: () => Promise<void>): void => {
 	start();
 
 	task()
-		// You could use 'finally' here to prevent this duplication but finally isn't supported
-		// in Chrome 59 which is used by Cypress in headless mode so if you do it will
-		// break the Cypress tests on CI
-		// See: https://github.com/cypress-io/cypress/issues/2651#issuecomment-432698837
 		.then(() => {
-			end();
-			log('dotcom', `🥾 Booted ${name} in ${end()}ms`);
+			const duration = end();
+			log('dotcom', `🥾 Booted ${name} in ${duration}ms`);
 		})
 		.catch(() => {
-			end();
-			log('dotcom', `🤒 Failed to boot ${name} in ${end()}ms`);
+			const duration = end();
+			log('dotcom', `🤒 Failed to boot ${name} in ${duration}ms`);
 		});
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2749,10 +2749,10 @@
     "@typescript-eslint/eslint-plugin" "5.46.1"
     "@typescript-eslint/parser" "5.46.1"
 
-"@guardian/libs@14.0.0":
-  version "14.0.0"
-  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-14.0.0.tgz#07022b652430a1c5d6b16f8aa105ae3d73da4e7c"
-  integrity sha512-rB4h4FlD3EcoCY66f3xjO7alnXiimPOynL9znvX/xP2nAVpG4UyedJnIpupw4KPqJuB0lZMih6EeXq0a1XnI3w==
+"@guardian/libs@14.1.0":
+  version "14.1.0"
+  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-14.1.0.tgz#feac9cc5636639e45ab2a6e2fd4a3f29f7af9a70"
+  integrity sha512-V/6ROWh0s8A6tJVFBMP9h9sb4L2SN98zSp84aLhBac4Ir1XJjG3kljAyB4uV1+341Amd+44QJGhB/D7roVsSfQ==
 
 "@guardian/prettier@3.0.0":
   version "3.0.0"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

We want to test our ability to identify poor web page performance as it happens. We have added the following conditions as indicators, and will report to Ophan when two or more are met:

- First contentful paint (FCP) is over 2.4 seconds
  - For the first half of June 2023, this has 10.91% sensitivity and 99.92% specificity
  
- Time to first byte (TTFB) is over 2.4 seconds
  - For the first half of June 2023, this has 3.33% sensitivity and 100.00% specificity
  
- Ophan took more than 5s to boot or 20ms to execute
  - This is just a guess at approximating performance, as we do not currently record any performance marks.

- The total duration of long tasks is above 120ms
  - We hope this can be a good indicator of FID. Only supported in Chromium browsers

## Why?

We believe that the best approache to page performance is to adaptively respond to user conditions. We need to establish a baseline of how good our predictions of poor web page performance are.

We have opted for extremely high specificity as a starting point, but a different tradeoff may be needed in the future.

## Screenshots

![FCP as CWV indicator](https://github.com/guardian/dotcom-rendering/assets/76776/624e6640-f984-455c-8f0b-7f8a667668f3)

![TTFB as CWV indicator](https://github.com/guardian/dotcom-rendering/assets/76776/c56cbbbe-7795-4524-b1d6-bc1f850bf600)
