### PR TITLE
Remove viewport grid line

### DIFF
--- a/dotcom-rendering/src/web/components/FrontSection.tsx
+++ b/dotcom-rendering/src/web/components/FrontSection.tsx
@@ -135,7 +135,7 @@ const containerStyles = css`
 			[hide-start]
 			60px
 			[decoration-end content-end title-end hide-end]
-			minmax(0, 1fr) [viewport-end];
+			minmax(0, 1fr);
 	}
 
 	${from.leftCol} {
@@ -155,7 +155,7 @@ const containerStyles = css`
 			[hide-start]
 			60px
 			[decoration-end hide-end content-end]
-			minmax(0, 1fr) [viewport-end];
+			minmax(0, 1fr);
 	}
 
 	${from.wide} {


### PR DESCRIPTION
## What does this change?

Minor fix to remove any grid lines with the name 'viewport' following #7839 

