### PR TITLE
Update contribution epics test parameters

### DIFF
--- a/dotcom-rendering/src/web/components/Metrics.importable.tsx
+++ b/dotcom-rendering/src/web/components/Metrics.importable.tsx
@@ -10,6 +10,7 @@ import {
 import { getCookie } from '@guardian/libs';
 import { integrateIma } from '../experiments/tests/integrate-ima';
 import { limitInlineMerch } from '../experiments/tests/limit-inline-merch';
+import { removeBusinessLiveblogEpics } from '../experiments/tests/remove-business-liveblog-epics';
 import { useAB } from '../lib/useAB';
 import { useAdBlockInUse } from '../lib/useAdBlockInUse';
 import { useOnce } from '../lib/useOnce';
@@ -27,6 +28,7 @@ const clientSideTestsToForceMetrics: ABTest[] = [
 	/* keep array multi-line */
 	integrateIma,
 	limitInlineMerch,
+	removeBusinessLiveblogEpics,
 ];
 
 export const Metrics = ({ commercialMetricsEnabled }: Props) => {

--- a/dotcom-rendering/src/web/experiments/tests/remove-business-liveblog-epics.ts
+++ b/dotcom-rendering/src/web/experiments/tests/remove-business-liveblog-epics.ts
@@ -7,11 +7,11 @@ export const removeBusinessLiveblogEpics: ABTest = {
 	author: '@commercial-dev',
 	description:
 		'Test the commercial impact of removing contribution epics on business liveblogs',
-	audience: 0 / 100,
-	audienceOffset: 0 / 100,
-	audienceCriteria: 'Opt in',
+	audience: 20 / 100,
+	audienceOffset: 20 / 100,
+	audienceCriteria: 'Business liveblogs',
 	successMeasure: 'Ad revenue increases on business liveblogs',
-	canRun: () => true,
+	canRun: () => !!(window.guardian.config.page.contentType === 'LiveBlog'),
 	variants: [
 		{
 			id: 'control',


### PR DESCRIPTION
## What does this change?
Following the AB test scoping, the test details have been updated as follows:

- Add the test participation and audience offset percentages
- Add a canrun function so that the test will only run on liveblogs
- Record commercial metrics for the test

