### PR TITLE
fix(cypress): update article URL for paid content test

### DIFF
--- a/dotcom-rendering/cypress/e2e/parallel-6/paid.content.cy.js
+++ b/dotcom-rendering/cypress/e2e/parallel-6/paid.content.cy.js
@@ -7,6 +7,11 @@ import { storage } from '@guardian/libs';
 const paidContentPage =
 	'https://www.theguardian.com/the-future-of-sustainable-entrepreneurship/2023/jun/01/take-your-sustainable-business-to-the-next-level-win-your-own-retail-space-at-one-of-londons-westfield-centres';
 
+/**
+ * This test relies on labs campaigns, where the content is often taken down one the campaign is complete.
+ * If this happens you'll need to find a new labs article with a brand badge, you can often find these here:
+ * https://www.theguardian.com/tone/advertisement-features"
+ */
 describe('Paid content tests', function () {
 	beforeEach(function () {
 		setLocalBaseUrl();

--- a/dotcom-rendering/cypress/e2e/parallel-6/paid.content.cy.js
+++ b/dotcom-rendering/cypress/e2e/parallel-6/paid.content.cy.js
@@ -5,7 +5,7 @@ import { privacySettingsIframe } from '../../lib/privacySettingsIframe';
 import { storage } from '@guardian/libs';
 
 const paidContentPage =
-	'https://www.theguardian.com/social-work-looking-to-the-future/2023/mar/13/social-work-in-2023-the-needs-the-challenges-and-reasons-to-be-optimistic';
+	'https://www.theguardian.com/the-future-of-sustainable-entrepreneurship/2023/jun/01/take-your-sustainable-business-to-the-next-level-win-your-own-retail-space-at-one-of-londons-westfield-centres';
 
 describe('Paid content tests', function () {
 	beforeEach(function () {

--- a/dotcom-rendering/cypress/e2e/parallel-6/paid.content.cy.js
+++ b/dotcom-rendering/cypress/e2e/parallel-6/paid.content.cy.js
@@ -10,7 +10,7 @@ const paidContentPage =
 /**
  * This test relies on labs campaigns, where the content is often taken down one the campaign is complete.
  * If this happens you'll need to find a new labs article with a brand badge, you can often find these here:
- * https://www.theguardian.com/tone/advertisement-features"
+ * https://www.theguardian.com/tone/advertisement-features
  */
 describe('Paid content tests', function () {
 	beforeEach(function () {

--- a/dotcom-rendering/cypress/e2e/parallel-6/paid.content.cy.js
+++ b/dotcom-rendering/cypress/e2e/parallel-6/paid.content.cy.js
@@ -11,6 +11,8 @@ const paidContentPage =
  * This test relies on labs campaigns, where the content is often taken down one the campaign is complete.
  * If this happens you'll need to find a new labs article with a brand badge, you can often find these here:
  * https://www.theguardian.com/tone/advertisement-features
+ * You need to edit the link as well as the expected requestURL to include the new brand in the code below, where it states `expect(requestURL).to.include('el=<logo goes here>');`.
+ * You can grab the required info in the dev tools network tab on the page itself.
  */
 describe('Paid content tests', function () {
 	beforeEach(function () {

--- a/dotcom-rendering/cypress/e2e/parallel-6/paid.content.cy.js
+++ b/dotcom-rendering/cypress/e2e/parallel-6/paid.content.cy.js
@@ -55,7 +55,7 @@ describe('Paid content tests', function () {
 			let requestURL = interception.request.url;
 			expect(requestURL).to.include('ec=click');
 			expect(requestURL).to.include('ea=sponsor%20logo');
-			expect(requestURL).to.include('el=guardian%20jobs');
+			expect(requestURL).to.include('el=westfield');
 		});
 	});
 
@@ -96,7 +96,7 @@ describe('Paid content tests', function () {
 			let requestURL = interception.request.url;
 			expect(requestURL).to.include('ec=click');
 			expect(requestURL).to.include('ea=sponsor%20logo');
-			expect(requestURL).to.include('el=guardian%20jobs');
+			expect(requestURL).to.include('el=westfield');
 		});
 	});
 });


### PR DESCRIPTION
- Fixes the Cypress paid content tests. They were failing because the article being tested no longer exists
- Added a comment explaining why the tests might fail and where to get another test article

Thanks @DanielCliftonGuardian and @OllysCoding for your help!