### PR TITLE
Increase Inline Merch test participation to `10%`

### DIFF
--- a/dotcom-rendering/src/web/experiments/tests/limit-inline-merch.ts
+++ b/dotcom-rendering/src/web/experiments/tests/limit-inline-merch.ts
@@ -7,8 +7,8 @@ export const limitInlineMerch: ABTest = {
 	author: '@chrislomaxjones',
 	description:
 		'Test the impact of limiting the eligibility of inline merchandising ad slots',
-	audience: 0 / 100,
-	audienceOffset: 0 / 100,
+	audience: 10 / 100,
+	audienceOffset: 40 / 100,
 	audienceCriteria:
 		'Article pages eligible for rendering an inline merchandising ad slot',
 	successMeasure:


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Increase the audience participation of the Inline Merch AB test to 10%.

Additionally, set its offset to 40%, so that it doesn't overlap with any other test groups.

Corresponding Commercial PR: https://github.com/guardian/commercial/pull/894
The original test setup: https://github.com/guardian/dotcom-rendering/pull/7780

## Why?

The sample sizes have been calculated and we're ready to launch the test.
