### PR TITLE
Revert "Parse HTML for Textblockcomponent "

### DIFF
--- a/dotcom-rendering/src/web/components/BlockquoteBlockComponent.tsx
+++ b/dotcom-rendering/src/web/components/BlockquoteBlockComponent.tsx
@@ -4,7 +4,7 @@ import type { ReactNode } from 'react';
 import { Fragment } from 'react';
 import { logger } from '../../server/lib/logging';
 import type { Palette } from '../../types/palette';
-import { getAttrs, isElement, parseHtml } from '../lib/domUtils';
+import { isElement, parseHtml } from '../lib/domUtils';
 import { QuoteIcon } from './QuoteIcon';
 
 type Props = {
@@ -34,6 +34,9 @@ const quotedBlockquoteStyles = (palette: Palette) => css`
 	${baseBlockquoteStyles}
 	color: ${palette.text.blockquote};
 `;
+
+const getAttrs = (node: Node): NamedNodeMap | undefined =>
+	isElement(node) ? node.attributes : undefined;
 
 /**
  * Searches through the siblings of an element to determine if it's the first
@@ -79,7 +82,7 @@ const textElement =
 						: simpleBlockquoteStyles,
 				});
 			case 'A':
-				return jsx('a', {
+				return jsx('A', {
 					href: getAttrs(node)?.getNamedItem('href')?.value,
 					key,
 					children,
@@ -95,7 +98,7 @@ const textElement =
 				return text;
 			case 'BR':
 				// BR cannot accept children as it's a void element
-				return jsx('br', {
+				return jsx('BR', {
 					key,
 				});
 			case 'H2':
@@ -109,7 +112,7 @@ const textElement =
 			case 'SUP':
 			case 'S':
 			case 'I':
-				return jsx(node.nodeName.toLowerCase(), {
+				return jsx(node.nodeName, {
 					key,
 					children,
 				});

--- a/dotcom-rendering/src/web/components/TextBlockComponent.tsx
+++ b/dotcom-rendering/src/web/components/TextBlockComponent.tsx
@@ -1,4 +1,4 @@
-import { css, jsx } from '@emotion/react';
+import { css } from '@emotion/react';
 import type { ArticleFormat } from '@guardian/libs';
 import { ArticleDesign, ArticleDisplay, ArticleSpecial } from '@guardian/libs';
 import {
@@ -8,14 +8,12 @@ import {
 	textSans,
 	until,
 } from '@guardian/source-foundations';
-import type { ReactNode } from 'react';
-import { Fragment } from 'react';
 import type { IOptions } from 'sanitize-html';
 import sanitise from 'sanitize-html';
-import { logger } from '../../server/lib/logging';
+import { unwrapHtml } from '../../model/unwrapHtml';
 import { decidePalette } from '../lib/decidePalette';
-import { getAttrs, isElement, parseHtml } from '../lib/domUtils';
 import { DropCap } from './DropCap';
+import { RewrappedComponent } from './RewrappedComponent';
 
 type Props = {
 	html: string;
@@ -112,6 +110,7 @@ const shouldShowDropCaps = (
 
 	return false;
 };
+
 /**
  * https://www.npmjs.com/package/sanitize-html#default-options
  */
@@ -210,124 +209,69 @@ const styles = (format: ArticleFormat) => css`
 	}
 `;
 
-const buildElementTree =
-	(html: string, format: ArticleFormat, showDropCaps: boolean) =>
-	(node: Node, key: number): ReactNode => {
-		const children = Array.from(node.childNodes).map(
-			buildElementTree(html, format, showDropCaps),
-		);
-
-		switch (node.nodeName) {
-			case 'P': {
-				return jsx('p', { css: styles(format), children });
-			}
-			case 'BLOCKQUOTE':
-				return jsx('blockquote', {
-					key,
-					children,
-				});
-			case 'A':
-				return jsx('a', {
-					href: getAttrs(node)?.getNamedItem('href')?.value,
-					target: getAttrs(node)?.getNamedItem('target')?.value,
-					key,
-					children,
-				});
-			case 'STRONG':
-				return jsx('strong', {
-					key,
-					children,
-				});
-			case '#text': {
-				if (node.textContent !== null) {
-					const dropCappedSentence = showDropCaps
-						? getDropCappedSentence(node.textContent)
-						: undefined;
-					if (
-						dropCappedSentence &&
-						node.textContent.startsWith(
-							stripHtmlFromString(html).slice(0, 10),
-						)
-					) {
-						const { dropCap, restOfSentence } = dropCappedSentence;
-						return (
-							<>
-								<DropCap letter={dropCap} format={format} />
-								{restOfSentence}
-							</>
-						);
-					}
-
-					return node.textContent;
-				}
-				return jsx('p', { css: styles(format), children });
-			}
-			case 'SPAN':
-				if (
-					getAttrs(node)?.getNamedItem('data-dcr-style')?.value ===
-					'bullet'
-				) {
-					return jsx('span', {
-						'data-dcr-style': 'bullet',
-						key,
-						children,
-					});
-				}
-				return jsx('p', { css: styles(format), children });
-			case 'BR':
-				return jsx('br', {
-					key,
-				});
-			case 'SUB':
-			case 'SUP':
-			case 'H2':
-			case 'H3':
-			case 'B':
-			case 'EM':
-			case 'UL':
-			case 'OL':
-			case 'LI':
-			case 'MARK':
-			case 'S':
-			case 'I':
-			case 'VAR':
-				return jsx(node.nodeName.toLowerCase(), {
-					css: styles(format),
-					key,
-					children,
-				});
-			default:
-				logger.warn('TextBlockComponent: Unknown element received', {
-					isDev: process.env.NODE_ENV !== 'production',
-					element: {
-						name: node.nodeName,
-						html: isElement(node) ? node.outerHTML : undefined,
-					},
-				});
-				return null;
-		}
-	};
-
 export const TextBlockComponent = ({
 	html,
 	format,
 	isFirstParagraph,
 	forceDropCap,
 }: Props) => {
+	const paraStyles = styles(format);
+	const {
+		willUnwrap: isUnwrapped,
+		unwrappedHtml,
+		unwrappedElement,
+	} = unwrapHtml({
+		fixes: [
+			{
+				unwrappedElement: 'p',
+				prefix: '<p>',
+				suffix: '</p>',
+			},
+			{
+				unwrappedElement: 'ul',
+				prefix: '<ul>',
+				suffix: '</ul>',
+			},
+			{
+				unwrappedElement: 'h3',
+				prefix: '<h3>',
+				suffix: '</h3>',
+			},
+		],
+		html,
+	});
+
 	const showDropCaps = shouldShowDropCaps(
 		html,
 		format,
 		isFirstParagraph,
 		forceDropCap,
 	);
-	const fragment = parseHtml(sanitise(html, sanitiserOptions));
-	return jsx(Fragment, {
-		children: Array.from(fragment.childNodes).map(
-			buildElementTree(
-				sanitise(html, sanitiserOptions),
-				format,
-				showDropCaps,
-			),
-		),
-	});
+	const dropCappedSentence = showDropCaps
+		? getDropCappedSentence(unwrappedHtml)
+		: undefined;
+
+	if (dropCappedSentence) {
+		const { dropCap, restOfSentence } = dropCappedSentence;
+		return (
+			<p css={paraStyles}>
+				<DropCap letter={dropCap} format={format} />
+				<RewrappedComponent
+					isUnwrapped={isUnwrapped}
+					html={sanitise(restOfSentence, sanitiserOptions)}
+					elCss={paraStyles}
+					tagName="span"
+				/>
+			</p>
+		);
+	}
+
+	return (
+		<RewrappedComponent
+			isUnwrapped={isUnwrapped}
+			html={sanitise(unwrappedHtml, sanitiserOptions)}
+			elCss={paraStyles}
+			tagName={unwrappedElement || 'p'}
+		/>
+	);
 };

--- a/dotcom-rendering/src/web/lib/domUtils.ts
+++ b/dotcom-rendering/src/web/lib/domUtils.ts
@@ -7,6 +7,3 @@ export const parseHtml = (html: string): DocumentFragment =>
 export function isElement(node: Node): node is Element {
 	return node.nodeType === 1;
 }
-
-export const getAttrs = (node: Node): NamedNodeMap | undefined =>
-	isElement(node) ? node.attributes : undefined;


### PR DESCRIPTION
Reverts guardian/dotcom-rendering#7684

Was not accounting for Footer elements. And i am struggling to get footer ```<strong>``` elements working right now so best to revert rather than submit a new pr.