### PR TITLE
Fix SpecialReportAlt card straight lines

### DIFF
--- a/dotcom-rendering/src/web/components/Card/components/CardFooter.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/CardFooter.tsx
@@ -3,6 +3,7 @@ import { ArticleDesign, ArticleSpecial } from '@guardian/libs';
 import { StraightLines } from '@guardian/source-react-components-development-kitchen';
 import type { DCRContainerPalette } from '../../../../types/front';
 import { decidePalette } from '../../../lib/decidePalette';
+import { decideContainerOverrides } from '../../../lib/decideContainerOverrides';
 
 type Props = {
 	format: ArticleFormat;
@@ -41,6 +42,9 @@ export const CardFooter = ({
 }: Props) => {
 	const palette = decidePalette(format, containerPalette);
 
+	const overrides =
+		containerPalette && decideContainerOverrides(containerPalette);
+
 	if (format.theme === ArticleSpecial.Labs && cardBranding) {
 		return <footer css={margins}>{cardBranding}</footer>;
 	}
@@ -62,7 +66,9 @@ export const CardFooter = ({
 								flex: 1;
 								align-self: flex-end;
 							`}
-							color={palette.border.lines}
+							color={
+								overrides?.border?.lines ?? palette.border.lines
+							}
 							count={4}
 						/>
 					)}

--- a/dotcom-rendering/src/web/lib/decideContainerOverrides.ts
+++ b/dotcom-rendering/src/web/lib/decideContainerOverrides.ts
@@ -331,7 +331,30 @@ const borderContainer = (
 	}
 };
 
-const borderLines = textCardHeadline;
+const borderLines = (
+	containerPalette: Exclude<DCRContainerPalette, 'Branded'>,
+): string => {
+	switch (containerPalette) {
+		case 'LongRunningPalette':
+			return neutral[100];
+		case 'LongRunningAltPalette':
+			return neutral[7];
+		case 'SombrePalette':
+			return neutral[100];
+		case 'SombreAltPalette':
+			return neutral[100];
+		case 'InvestigationPalette':
+			return neutral[100];
+		case 'BreakingPalette':
+			return neutral[100];
+		case 'EventPalette':
+			return brand[300];
+		case 'EventAltPalette':
+			return brand[300];
+		case 'SpecialReportAltPalette':
+			return transparentColour(neutral[46], 0.3);
+	}
+};
 
 const backgroundContainer = (containerPalette: DCRContainerPalette): string => {
 	switch (containerPalette) {


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Fixes `StraightLines` colour in the `CardFooter`.

## Why?
For parity with frontend

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/4203d681-88c4-40fa-ad33-ba32a5332d9a) | ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/94297421-cc65-4f7c-add6-256c542bca41) |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
