### PR TITLE
Delegate handling errors to Expresse's ErrorRequestHandler

### DIFF
--- a/dotcom-rendering/src/web/server/index.allEditorialNewslettersPage.web.ts
+++ b/dotcom-rendering/src/web/server/index.allEditorialNewslettersPage.web.ts
@@ -1,10 +1,8 @@
 import type { RequestHandler } from 'express';
 import { validateAsAllEditorialNewslettersPageType } from '../../model/validate';
+import { recordTypeAndPlatform } from '../../server/lib/logging-store';
 import type { DCRNewslettersPageType } from '../../types/newslettersPage';
 import { renderEditorialNewslettersPage } from './render.allEditorialNewslettersPage.web';
-
-const getStack = (e: unknown): string =>
-	e instanceof Error ? e.stack ?? 'No error stack' : 'Unknown error';
 
 const enhanceAllEditorialNewslettersPage = (
 	body: unknown,
@@ -19,11 +17,8 @@ export const handleAllEditorialNewslettersPage: RequestHandler = (
 	{ body },
 	res,
 ) => {
-	try {
-		const newslettersPage = enhanceAllEditorialNewslettersPage(body);
-		const html = renderEditorialNewslettersPage({ newslettersPage });
-		res.status(200).send(html);
-	} catch (e) {
-		res.status(500).send(`<pre>${getStack(e)}</pre>`);
-	}
+	recordTypeAndPlatform('newsletters');
+	const newslettersPage = enhanceAllEditorialNewslettersPage(body);
+	const html = renderEditorialNewslettersPage({ newslettersPage });
+	res.status(200).send(html);
 };

--- a/dotcom-rendering/src/web/server/index.article.apps.ts
+++ b/dotcom-rendering/src/web/server/index.article.apps.ts
@@ -1,10 +1,7 @@
 import type { RequestHandler } from 'express';
-import { renderArticle } from './render.article.apps';
 import { recordTypeAndPlatform } from '../../server/lib/logging-store';
 import { enhanceArticleType } from './index.article.web';
-
-const getStack = (e: unknown): string =>
-	e instanceof Error ? e.stack ?? 'No error stack' : 'Unknown error';
+import { renderArticle } from './render.article.apps';
 
 /**
  * Formats script paths as a Link header
@@ -18,14 +15,10 @@ const makePrefetchHeader = (scriptPaths: string[]): string =>
 	);
 
 export const handleAppsArticle: RequestHandler = ({ body }, res) => {
-	try {
-		recordTypeAndPlatform('article', 'apps');
-		const article = enhanceArticleType(body);
-		const { html, clientScripts } = renderArticle(article);
+	recordTypeAndPlatform('article', 'apps');
+	const article = enhanceArticleType(body);
+	const { html, clientScripts } = renderArticle(article);
 
-		// The Android app will cache these assets to enable offline reading
-		res.set('Link', makePrefetchHeader(clientScripts)).send(html);
-	} catch (e) {
-		res.status(500).send(`<pre>${getStack(e)}`);
-	}
+	// The Android app will cache these assets to enable offline reading
+	res.set('Link', makePrefetchHeader(clientScripts)).send(html);
 };

--- a/dotcom-rendering/src/web/server/index.article.web.ts
+++ b/dotcom-rendering/src/web/server/index.article.web.ts
@@ -14,9 +14,6 @@ import {
 	renderKeyEvents,
 } from './render.article.web';
 
-const getStack = (e: unknown): string =>
-	e instanceof Error ? e.stack ?? 'No error stack' : 'Unknown error';
-
 const enhancePinnedPost = (format: FEFormat, block?: Block) => {
 	return block ? enhanceBlocks([block], format)[0] : block;
 };
@@ -54,35 +51,27 @@ export const enhanceArticleType = (body: unknown): FEArticleType => {
 };
 
 export const handleArticle: RequestHandler = ({ body }, res) => {
-	try {
-		recordTypeAndPlatform('article', 'web');
-		const article = enhanceArticleType(body);
-		const resp = renderHtml({
-			article,
-		});
+	recordTypeAndPlatform('article', 'web');
+	const article = enhanceArticleType(body);
+	const resp = renderHtml({
+		article,
+	});
 
-		res.status(200).send(resp);
-	} catch (e) {
-		res.status(500).send(`<pre>${getStack(e)}</pre>`);
-	}
+	res.status(200).send(resp);
 };
 
 export const handleArticleJson: RequestHandler = ({ body }, res) => {
-	try {
-		recordTypeAndPlatform('article', 'json');
-		const article = enhanceArticleType(body);
-		const resp = {
-			data: {
-				// TODO: We should rename this to 'article' or 'FEArticle', but first we need to investigate
-				// where/if this is used.
-				CAPIArticle: article,
-			},
-		};
+	recordTypeAndPlatform('article', 'json');
+	const article = enhanceArticleType(body);
+	const resp = {
+		data: {
+			// TODO: We should rename this to 'article' or 'FEArticle', but first we need to investigate
+			// where/if this is used.
+			CAPIArticle: article,
+		},
+	};
 
-		res.status(200).send(resp);
-	} catch (e) {
-		res.status(500).send(`<pre>${getStack(e)}</pre>`);
-	}
+	res.status(200).send(resp);
 };
 
 export const handleArticlePerfTest: RequestHandler = (req, res, next) => {
@@ -91,84 +80,72 @@ export const handleArticlePerfTest: RequestHandler = (req, res, next) => {
 };
 
 export const handleInteractive: RequestHandler = ({ body }, res) => {
-	try {
-		recordTypeAndPlatform('interactive', 'web');
-		const article = enhanceArticleType(body);
-		const resp = renderHtml({
-			article,
-		});
+	recordTypeAndPlatform('interactive', 'web');
+	const article = enhanceArticleType(body);
+	const resp = renderHtml({
+		article,
+	});
 
-		res.status(200).send(resp);
-	} catch (e) {
-		res.status(500).send(`<pre>${getStack(e)}</pre>`);
-	}
+	res.status(200).send(resp);
 };
 
 export const handleBlocks: RequestHandler = ({ body }, res) => {
 	recordTypeAndPlatform('blocks');
-	try {
-		const {
-			blocks,
-			format,
-			host,
-			pageId,
-			webTitle,
-			ajaxUrl,
-			isAdFreeUser,
-			isSensitive,
-			videoDuration,
-			edition,
-			section,
-			sharedAdTargeting,
-			adUnit,
-			switches,
-			keywordIds,
-		} =
-			// The content if body is not checked
-			body as FEBlocksRequest;
+	const {
+		blocks,
+		format,
+		host,
+		pageId,
+		webTitle,
+		ajaxUrl,
+		isAdFreeUser,
+		isSensitive,
+		videoDuration,
+		edition,
+		section,
+		sharedAdTargeting,
+		adUnit,
+		switches,
+		keywordIds,
+	} =
+		// The content if body is not checked
+		body as FEBlocksRequest;
 
-		const enhancedBlocks = enhanceBlocks(blocks, format);
-		const html = renderBlocks({
-			blocks: enhancedBlocks,
-			format,
-			host,
-			pageId,
-			webTitle,
-			ajaxUrl,
-			isAdFreeUser,
-			isSensitive,
-			videoDuration,
-			edition,
-			section,
-			sharedAdTargeting,
-			adUnit,
-			switches,
-			keywordIds,
-		});
+	const enhancedBlocks = enhanceBlocks(blocks, format);
+	const html = renderBlocks({
+		blocks: enhancedBlocks,
+		format,
+		host,
+		pageId,
+		webTitle,
+		ajaxUrl,
+		isAdFreeUser,
+		isSensitive,
+		videoDuration,
+		edition,
+		section,
+		sharedAdTargeting,
+		adUnit,
+		switches,
+		keywordIds,
+	});
 
-		res.status(200).send(html);
-	} catch (e) {
-		res.status(500).send(`<pre>${getStack(e)}</pre>`);
-	}
+	res.status(200).send(html);
 };
 
 export const handleKeyEvents: RequestHandler = ({ body }, res) => {
 	// TODO: This endpoint is unused - we should consider removing it, talk to Olly 24/05/2023
 
 	recordTypeAndPlatform('keyEvents');
-	try {
-		const { keyEvents, format, filterKeyEvents } =
-			// The content if body is not checked
-			body as FEKeyEventsRequest;
+	const { keyEvents, format, filterKeyEvents } =
+		// The content if body is not checked
+		body as FEKeyEventsRequest;
 
-		const html = renderKeyEvents({
-			keyEvents,
-			format,
-			filterKeyEvents,
-		});
+	const html = renderKeyEvents({
+		keyEvents,
+		format,
+		filterKeyEvents,
+	});
 
-		res.status(200).send(html);
-	} catch (e) {
-		res.status(500).send(`<pre>${getStack(e)}</pre>`);
-	}
+	res.status(200).send(html);
 };

--- a/dotcom-rendering/src/web/server/index.front.web.ts
+++ b/dotcom-rendering/src/web/server/index.front.web.ts
@@ -7,9 +7,6 @@ import type { DCRFrontType, FEFrontType } from '../../types/front';
 import { decideTrail } from '../lib/decideTrail';
 import { renderFront } from './render.front.web';
 
-const getStack = (e: unknown): string =>
-	e instanceof Error ? e.stack ?? 'No error stack' : 'Unknown error';
-
 const enhanceFront = (body: unknown): DCRFrontType => {
 	const data: FEFrontType = validateAsFrontType(body);
 
@@ -38,15 +35,11 @@ const enhanceFront = (body: unknown): DCRFrontType => {
 
 export const handleFront: RequestHandler = ({ body }, res) => {
 	recordTypeAndPlatform('front');
-	try {
-		const front = enhanceFront(body);
-		const html = renderFront({
-			front,
-		});
-		res.status(200).send(html);
-	} catch (e) {
-		res.status(500).send(`<pre>${getStack(e)}</pre>`);
-	}
+	const front = enhanceFront(body);
+	const html = renderFront({
+		front,
+	});
+	res.status(200).send(html);
 };
 
 export const handleFrontJson: RequestHandler = ({ body }, res) => {


### PR DESCRIPTION
## What does this change?

Use Express's ErrorRequestHandler instead of trying to handle errors in every single controller.

(also adds platform logging to the Newsletter endpoint)

## Why?

With the Fronts slideshow issue happening yesterday evening I noticed that I couldn't find any of the errors for it in DCRs logs. This is because we only record the error in our logs when it reaches Express's ErrorRequestHandler.

## Before

<img width="1433" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/21217225/34222d34-4459-46cb-8fca-dd6c9fd0aa49">


## After

<img width="1437" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/21217225/76f87cf6-7cc3-471a-9c2a-5408944491d1">

