### PR TITLE
Revert "refactor(startup): remove generic type and helpers parameter from `startup`"

### DIFF
--- a/dotcom-rendering/src/client/index.ts
+++ b/dotcom-rendering/src/client/index.ts
@@ -9,26 +9,28 @@ import { ophan } from './ophan';
 import { sentryLoader } from './sentryLoader';
 import { startup } from './startup';
 
-startup(bootCmp);
-startup(ophan);
-startup(ga);
-startup(sentryLoader);
-startup(dynamicImport);
-startup(islands);
+startup('bootCmp', null, bootCmp);
+startup('ophan', null, ophan);
+startup('ga', null, ga);
+startup('sentryLoader', null, sentryLoader);
+startup('dynamicImport', null, dynamicImport);
+startup('islands', null, islands);
 
 // these modules are loaded as separate chunks, so that they can be lazy-loaded
 void import(/* webpackChunkName: 'atomIframe' */ './atomIframe').then(
-	({ atomIframe }) => startup(atomIframe),
+	({ atomIframe }) => startup('atomIframe', null, atomIframe),
 );
 void import(/* webpackChunkName: 'embedIframe' */ './embedIframe').then(
-	({ embedIframe }) => startup(embedIframe),
+	({ embedIframe }) => startup('embedIframe', null, embedIframe),
 );
 void import(
 	/* webpackChunkName: 'newsletterEmbedIframe' */ './newsletterEmbedIframe'
-).then(({ newsletterEmbedIframe }) => startup(newsletterEmbedIframe));
+).then(({ newsletterEmbedIframe }) =>
+	startup('newsletterEmbedIframe', null, newsletterEmbedIframe),
+);
 void import(/* webpackChunkName: 'relativeTime' */ './relativeTime').then(
-	({ relativeTime }) => startup(relativeTime),
+	({ relativeTime }) => startup('relativeTime', null, relativeTime),
 );
 void import(/* webpackChunkName: 'discussion' */ './discussion').then(
-	({ discussion }) => startup(discussion),
+	({ discussion }) => startup('initDiscussion', null, discussion),
 );

--- a/dotcom-rendering/src/client/startup.ts
+++ b/dotcom-rendering/src/client/startup.ts
@@ -1,8 +1,8 @@
 import { log } from '@guardian/libs';
 import { initPerf } from './initPerf';
 
-const measure = (task: () => Promise<void>): void => {
-	const { start, end } = initPerf(task.name);
+const measure = (name: string, task: () => Promise<void>): void => {
+	const { start, end } = initPerf(name);
 
 	start();
 
@@ -13,17 +13,21 @@ const measure = (task: () => Promise<void>): void => {
 		// See: https://github.com/cypress-io/cypress/issues/2651#issuecomment-432698837
 		.then(() => {
 			end();
-			log('dotcom', `🥾 Booted ${task.name} in ${end()}ms`);
+			log('dotcom', `🥾 Booted ${name} in ${end()}ms`);
 		})
 		.catch(() => {
 			end();
-			log('dotcom', `🤒 Failed to boot ${task.name} in ${end()}ms`);
+			log('dotcom', `🤒 Failed to boot ${name} in ${end()}ms`);
 		});
 };
 
-export const startup = (task: () => Promise<void>): void => {
+export const startup = <A>(
+	name: string,
+	helpers: A,
+	task: (helpers: A) => Promise<void>,
+): void => {
 	const measureMe = () => {
-		measure(task);
+		measure(name, task.bind(null, helpers));
 	};
 	if (window.guardian.mustardCut || window.guardian.polyfilled) {
 		measureMe();


### PR DESCRIPTION
Reverts guardian/dotcom-rendering#7858

The minified method names don't make any sense! We should continue to pass the function name as a string