### PR TITLE
Reinstate `startup` task names as arguments

### DIFF
--- a/dotcom-rendering/src/client/index.ts
+++ b/dotcom-rendering/src/client/index.ts
@@ -9,26 +9,28 @@ import { ophan } from './ophan';
 import { sentryLoader } from './sentryLoader';
 import { startup } from './startup';
 
-startup(bootCmp);
-startup(ophan);
-startup(ga);
-startup(sentryLoader);
-startup(dynamicImport);
-startup(islands);
+startup('bootCmp', bootCmp);
+startup('ophan', ophan);
+startup('ga', ga);
+startup('sentryLoader', sentryLoader);
+startup('dynamicImport', dynamicImport);
+startup('islands', islands);
 
 // these modules are loaded as separate chunks, so that they can be lazy-loaded
 void import(/* webpackChunkName: 'atomIframe' */ './atomIframe').then(
-	({ atomIframe }) => startup(atomIframe),
+	({ atomIframe }) => startup('atomIframe', atomIframe),
 );
 void import(/* webpackChunkName: 'embedIframe' */ './embedIframe').then(
-	({ embedIframe }) => startup(embedIframe),
+	({ embedIframe }) => startup('embedIframe', embedIframe),
 );
 void import(
 	/* webpackChunkName: 'newsletterEmbedIframe' */ './newsletterEmbedIframe'
-).then(({ newsletterEmbedIframe }) => startup(newsletterEmbedIframe));
+).then(({ newsletterEmbedIframe }) =>
+	startup('newsletterEmbedIframe', newsletterEmbedIframe),
+);
 void import(/* webpackChunkName: 'relativeTime' */ './relativeTime').then(
-	({ relativeTime }) => startup(relativeTime),
+	({ relativeTime }) => startup('relativeTime', relativeTime),
 );
 void import(/* webpackChunkName: 'discussion' */ './discussion').then(
-	({ discussion }) => startup(discussion),
+	({ discussion }) => startup('initDiscussion', discussion),
 );

--- a/dotcom-rendering/src/client/startup.ts
+++ b/dotcom-rendering/src/client/startup.ts
@@ -23,7 +23,7 @@ const measure = (name: string, task: () => Promise<void>): void => {
 
 export const startup = (name: string, task: () => Promise<void>): void => {
 	const measureMe = () => {
-		measure(name, task.bind(null));
+		measure(name, task);
 	};
 	if (window.guardian.mustardCut || window.guardian.polyfilled) {
 		measureMe();

--- a/dotcom-rendering/src/client/startup.ts
+++ b/dotcom-rendering/src/client/startup.ts
@@ -1,8 +1,8 @@
 import { log } from '@guardian/libs';
 import { initPerf } from './initPerf';
 
-const measure = (task: () => Promise<void>): void => {
-	const { start, end } = initPerf(task.name);
+const measure = (name: string, task: () => Promise<void>): void => {
+	const { start, end } = initPerf(name);
 
 	start();
 
@@ -13,17 +13,17 @@ const measure = (task: () => Promise<void>): void => {
 		// See: https://github.com/cypress-io/cypress/issues/2651#issuecomment-432698837
 		.then(() => {
 			end();
-			log('dotcom', `🥾 Booted ${task.name} in ${end()}ms`);
+			log('dotcom', `🥾 Booted ${name} in ${end()}ms`);
 		})
 		.catch(() => {
 			end();
-			log('dotcom', `🤒 Failed to boot ${task.name} in ${end()}ms`);
+			log('dotcom', `🤒 Failed to boot ${name} in ${end()}ms`);
 		});
 };
 
-export const startup = (task: () => Promise<void>): void => {
+export const startup = (name: string, task: () => Promise<void>): void => {
 	const measureMe = () => {
-		measure(task);
+		measure(name, task.bind(null));
 	};
 	if (window.guardian.mustardCut || window.guardian.polyfilled) {
 		measureMe();


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

This reverts commit 4fe0cbc0b564967db0b37567024469e07abcfe83 in #7858 

## Why?

The function’s `name` is mangled in production by minification.

[I originally made this suggestion which ended up not being so clever](https://github.com/guardian/dotcom-rendering/pull/7858#issuecomment-1587074183).

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/76776/61a01534-0272-4b09-8814-75b0368f4e0d
[after]: https://github.com/guardian/dotcom-rendering/assets/76776/21ab3b57-fefc-4136-a55a-77f4a91777ad
