### PR TITLE
Disable AMP for articles that have a VideoYoutubeBlockElement containing Playlist

### DIFF
--- a/dotcom-rendering/src/components/Elements.amp.tsx
+++ b/dotcom-rendering/src/components/Elements.amp.tsx
@@ -95,6 +95,18 @@ export const isAmpSupported = ({
 		return false;
 	}
 
+	// <amp-youtube> does not support rendering Playlists, only normal videos.
+	if (
+		elements.find(
+			(element) =>
+				element._type ===
+					'model.dotcomrendering.pageElements.VideoYoutubeBlockElement' &&
+				(element.originalUrl || element.url).includes('/playlist'),
+		)
+	) {
+		return false;
+	}
+
 	return elements.every((element) => {
 		if ((element as { isMandatory?: boolean }).isMandatory) {
 			return AMP_SUPPORTED_ELEMENTS.includes(element._type);


### PR DESCRIPTION
## What does this change?

Disables suggesting a page can be rendered by AMP if said page has a VideoYoutubeBlockElement containing a Playlist.

## Why?

The `<amp-youtube>` component doesn't support Playlists by itself, only regular videos. AMP failing to render these VideoYoutubeBlockElements is by far the most common reason for DCR to error and return a 500.

At time of writing DCR has errored 69 times, 61 of those times were caused by VideoYoutubeBlockElement.