### PR TITLE
Dont amplify if article has quiz atoms

### DIFF
--- a/dotcom-rendering/src/components/Elements.amp.tsx
+++ b/dotcom-rendering/src/components/Elements.amp.tsx
@@ -83,7 +83,14 @@ export const isAmpSupported = ({
 	if (tags.some((tag) => tag.id === 'type/article')) {
 		const isSwitchedOn = switches.ampArticleSwitch;
 		const hasQuizTag = tags.some((tag) => tag.id === 'tone/quizzes');
-		if (!isSwitchedOn || hasQuizTag || elements.length == 0) return false;
+		// Some Labs pages have quiz atoms but are not tagged as quizzes
+		const hasQuizAtoms = elements.find(
+			(element) =>
+				element._type ===
+				'model.dotcomrendering.pageElements.QuizAtomBlockElement',
+		);
+		if (!isSwitchedOn || hasQuizTag || hasQuizAtoms || elements.length == 0)
+			return false;
 	}
 
 	if (format.design === 'LiveBlogDesign') {


### PR DESCRIPTION
## What does this change?

Adds a check for quiz atoms elements in `Elements.amp.tsx`. If quiz atoms are included in the CAPI response, DCR should not render the AMP version of this article.

## Why?

Quizzes are not supported on AMP and are caught by the check for `tone/quizzes` in `Elements.amp.tsx`. However this check depends on the article having the `quizzes` tag. Labs quizzes don't receive this tag as they shouldn't appear in the `/tone/quizzes` front.

Checking for the presence of quiz atom elements catches this omission.

This issue was identified when a member of the Labs team noticed that a quiz they had shared was not appearing when the article was rendered in the LinkedIn app. This is because the LinkedIn app renders AMP pages for shared articles.

See also guardian/frontend#26209