### PR TITLE
Respect container palette colours 

### DIFF
--- a/dotcom-rendering/src/components/ContainerTitle.tsx
+++ b/dotcom-rendering/src/components/ContainerTitle.tsx
@@ -23,13 +23,8 @@ type Props = {
 	editionId?: EditionId;
 };
 
-const linkStyles = (fontColour?: string) => css`
+const linkStyles = css`
 	text-decoration: none;
-	color: ${fontColour ?? neutral[7]};
-
-	:hover {
-		text-decoration: underline;
-	}
 `;
 
 const headerStyles = (fontColour?: string) => css`
@@ -38,6 +33,10 @@ const headerStyles = (fontColour?: string) => css`
 	padding-bottom: ${space[1]}px;
 	padding-top: 6px;
 	overflow-wrap: break-word; /*if a single word is too long, this will break the word up rather than have the display be affected*/
+
+	:hover {
+		text-decoration: underline;
+	}
 `;
 
 const descriptionStyles = (fontColour?: string) => css`
@@ -94,7 +93,7 @@ export const ContainerTitle = ({
 	return (
 		<div css={marginStyles}>
 			{url ? (
-				<a css={[linkStyles(fontColour), bottomMargin]} href={url}>
+				<a css={[linkStyles, bottomMargin]} href={url}>
 					<h2 css={headerStyles(fontColour)}>{title}</h2>
 				</a>
 			) : (

--- a/dotcom-rendering/src/components/ContainerTitle.tsx
+++ b/dotcom-rendering/src/components/ContainerTitle.tsx
@@ -23,9 +23,9 @@ type Props = {
 	editionId?: EditionId;
 };
 
-const linkStyles = css`
+const linkStyles = (fontColour?: string) => css`
 	text-decoration: none;
-	color: ${neutral[7]};
+	color: ${fontColour ?? neutral[7]};
 
 	:hover {
 		text-decoration: underline;
@@ -94,7 +94,7 @@ export const ContainerTitle = ({
 	return (
 		<div css={marginStyles}>
 			{url ? (
-				<a css={[linkStyles, bottomMargin]} href={url}>
+				<a css={[linkStyles(fontColour), bottomMargin]} href={url}>
 					<h2 css={headerStyles(fontColour)}>{title}</h2>
 				</a>
 			) : (

--- a/dotcom-rendering/src/components/FrontSection.tsx
+++ b/dotcom-rendering/src/components/FrontSection.tsx
@@ -179,27 +179,29 @@ const containerStyles = css`
 	}
 `;
 
-const sectionHeadline = css`
-	grid-row: headline;
-	grid-column: title;
+const sectionHeadline = (borderColour: string) => {
+	return css`
+		grid-row: headline;
+		grid-column: title;
 
-	display: flex;
-	flex-direction: column;
+		display: flex;
+		flex-direction: column;
 
-	${from.leftCol} {
-		position: relative;
-		::after {
-			content: '';
-			display: block;
-			width: 1px;
-			top: 0;
-			height: 1.875rem;
-			right: -10px;
-			position: absolute;
-			background-color: ${neutral[86]};
+		${from.leftCol} {
+			position: relative;
+			::after {
+				content: '';
+				display: block;
+				width: 1px;
+				top: 0;
+				height: 1.875rem;
+				right: -10px;
+				position: absolute;
+				background-color: ${borderColour};
+			}
 		}
-	}
-`;
+	`;
+};
 
 const paddings = css`
 	padding-top: ${space[2]}px;
@@ -253,15 +255,17 @@ const sectionTreats = css`
 	}
 `;
 
-/** element which contains border and inner background colour, if set */
-const decoration = css`
-	grid-row: 1 / -1;
-	grid-column: decoration;
+const decoration = (borderColour: string) => {
+	/** element which contains border and inner background colour, if set */
+	return css`
+		grid-row: 1 / -1;
+		grid-column: decoration;
 
-	border-width: 1px;
-	border-color: ${neutral[86]};
-	border-style: none;
-`;
+		border-width: 1px;
+		border-color: ${borderColour};
+		border-style: none;
+	`;
+};
 
 /** only visible once content stops sticking to left and right edges */
 const sideBorders = css`
@@ -420,9 +424,21 @@ export const FrontSection = ({
 				`,
 			]}
 		>
-			<div css={[decoration, sideBorders, showTopBorder && topBorder]} />
+			<div
+				css={[
+					decoration(overrides?.border?.container ?? neutral[86]),
+					sideBorders,
+					showTopBorder && topBorder,
+				]}
+			/>
 
-			<div css={[sectionHeadline]}>
+			<div
+				css={[
+					sectionHeadline(
+						overrides?.border?.container ?? neutral[86],
+					),
+				]}
+			>
 				<Hide until="leftCol">
 					{badge && (
 						<Badge imageSrc={badge.imageSrc} href={badge.href} />

--- a/dotcom-rendering/src/components/FrontSection.tsx
+++ b/dotcom-rendering/src/components/FrontSection.tsx
@@ -509,7 +509,7 @@ export const FrontSection = ({
 					<Treats
 						treats={treats}
 						borderColour={overrides?.border?.container}
-						textColour={overrides?.text?.container ?? neutral[7]}
+						fontColour={overrides?.text?.container ?? neutral[7]}
 					/>
 				</div>
 			)}

--- a/dotcom-rendering/src/components/FrontSection.tsx
+++ b/dotcom-rendering/src/components/FrontSection.tsx
@@ -179,29 +179,27 @@ const containerStyles = css`
 	}
 `;
 
-const sectionHeadline = (borderColour: string) => {
-	return css`
-		grid-row: headline;
-		grid-column: title;
+const sectionHeadline = (borderColour: string) => css`
+	grid-row: headline;
+	grid-column: title;
 
-		display: flex;
-		flex-direction: column;
+	display: flex;
+	flex-direction: column;
 
-		${from.leftCol} {
-			position: relative;
-			::after {
-				content: '';
-				display: block;
-				width: 1px;
-				top: 0;
-				height: 1.875rem;
-				right: -10px;
-				position: absolute;
-				background-color: ${borderColour};
-			}
+	${from.leftCol} {
+		position: relative;
+		::after {
+			content: '';
+			display: block;
+			width: 1px;
+			top: 0;
+			height: 1.875rem;
+			right: -10px;
+			position: absolute;
+			background-color: ${borderColour};
 		}
-	`;
-};
+	}
+`;
 
 const paddings = css`
 	padding-top: ${space[2]}px;

--- a/dotcom-rendering/src/components/FrontSection.tsx
+++ b/dotcom-rendering/src/components/FrontSection.tsx
@@ -511,6 +511,7 @@ export const FrontSection = ({
 					<Treats
 						treats={treats}
 						borderColour={overrides?.border?.container}
+						textColour={overrides?.text?.container ?? neutral[7]}
 					/>
 				</div>
 			)}

--- a/dotcom-rendering/src/components/Section.tsx
+++ b/dotcom-rendering/src/components/Section.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import type { ArticleFormat } from '@guardian/libs';
 import { ArticleDesign } from '@guardian/libs';
-import { from, neutral, space, until } from '@guardian/source-foundations';
+import { from, space, until } from '@guardian/source-foundations';
 import { decideContainerOverrides } from '../lib/decideContainerOverrides';
 import type { EditionId } from '../lib/edition';
 import { hiddenStyles } from '../lib/hiddenStyles';
@@ -305,8 +305,8 @@ export const Section = ({
 								borderColour={
 									borderColour ?? overrides?.border?.container
 								}
-								textColour={
-									overrides?.text?.container ?? neutral[7]
+								fontColour={
+									fontColour ?? overrides?.text?.container
 								}
 							/>
 						)}

--- a/dotcom-rendering/src/components/Section.tsx
+++ b/dotcom-rendering/src/components/Section.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import type { ArticleFormat } from '@guardian/libs';
 import { ArticleDesign } from '@guardian/libs';
-import { from, space, until } from '@guardian/source-foundations';
+import { from, neutral, space, until } from '@guardian/source-foundations';
 import { decideContainerOverrides } from '../lib/decideContainerOverrides';
 import type { EditionId } from '../lib/edition';
 import { hiddenStyles } from '../lib/hiddenStyles';
@@ -304,6 +304,9 @@ export const Section = ({
 								treats={treats}
 								borderColour={
 									borderColour ?? overrides?.border?.container
+								}
+								textColour={
+									overrides?.text?.container ?? neutral[7]
 								}
 							/>
 						)}

--- a/dotcom-rendering/src/components/Treats.tsx
+++ b/dotcom-rendering/src/components/Treats.tsx
@@ -4,13 +4,14 @@ import {
 	from,
 	headline,
 	neutral,
+	palette as sourcePalette,
 	space,
 	textSans,
 } from '@guardian/source-foundations';
 import { Link } from '@guardian/source-react-components';
 import { Fragment } from 'react';
-import type { TreatType } from '../types/front';
 import { decidePalette } from '../lib/decidePalette';
+import type { TreatType } from '../types/front';
 import { generateSources, getFallbackSource } from './Picture';
 import { SvgCrossword } from './SvgCrossword';
 
@@ -18,12 +19,12 @@ const TextTreat = ({
 	text,
 	linkTo,
 	borderColour,
-	textColour,
+	fontColour,
 }: {
 	text: string;
 	linkTo: string;
 	borderColour?: string;
-	textColour?: string;
+	fontColour?: string;
 }) => (
 	<li
 		css={css`
@@ -40,7 +41,7 @@ const TextTreat = ({
 			cssOverrides={css`
 				${textSans.xxsmall()}
 				text-decoration: none;
-				color: ${textColour};
+				color: ${fontColour ?? sourcePalette.neutral[7]};
 			`}
 			href={linkTo}
 		>
@@ -165,11 +166,11 @@ const ImageTreat = ({
 export const Treats = ({
 	treats,
 	borderColour,
-	textColour,
+	fontColour,
 }: {
 	treats: TreatType[];
 	borderColour?: string;
-	textColour?: string;
+	fontColour?: string;
 }) => {
 	if (treats.length === 0) return null;
 	return (
@@ -198,7 +199,7 @@ export const Treats = ({
 									text={text}
 									linkTo={linkTo}
 									borderColour={borderColour}
-									textColour={textColour}
+									fontColour={fontColour}
 								/>
 							))}
 						</Fragment>
@@ -234,7 +235,7 @@ export const Treats = ({
 								text={text}
 								linkTo={linkTo}
 								borderColour={borderColour}
-								textColour={textColour}
+								fontColour={fontColour}
 							/>
 						))}
 					</>

--- a/dotcom-rendering/src/components/Treats.tsx
+++ b/dotcom-rendering/src/components/Treats.tsx
@@ -18,10 +18,12 @@ const TextTreat = ({
 	text,
 	linkTo,
 	borderColour,
+	textColour,
 }: {
 	text: string;
 	linkTo: string;
 	borderColour?: string;
+	textColour?: string;
 }) => (
 	<li
 		css={css`
@@ -38,6 +40,7 @@ const TextTreat = ({
 			cssOverrides={css`
 				${textSans.xxsmall()}
 				text-decoration: none;
+				color: ${textColour};
 			`}
 			href={linkTo}
 		>
@@ -162,9 +165,11 @@ const ImageTreat = ({
 export const Treats = ({
 	treats,
 	borderColour,
+	textColour,
 }: {
 	treats: TreatType[];
 	borderColour?: string;
+	textColour?: string;
 }) => {
 	if (treats.length === 0) return null;
 	return (
@@ -193,6 +198,7 @@ export const Treats = ({
 									text={text}
 									linkTo={linkTo}
 									borderColour={borderColour}
+									textColour={textColour}
 								/>
 							))}
 						</Fragment>
@@ -228,6 +234,7 @@ export const Treats = ({
 								text={text}
 								linkTo={linkTo}
 								borderColour={borderColour}
+								textColour={textColour}
 							/>
 						))}
 					</>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

Closes #7686 

## What does this change?
Respects container palette colours for:
* Borders
* Treat text
* Container title hovering state

## Why?
Parity with frontend / Improvements requested by Design

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/3fda13de-2dba-4f9f-8c51-2d61074bfebf) | ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/d4851b10-cd9f-452e-949c-65e467c550c2) |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
