### PR TITLE
fix: remove mobile padding fully in template literal

### DIFF
--- a/dotcom-rendering/src/components/Card/components/LI.tsx
+++ b/dotcom-rendering/src/components/Card/components/LI.tsx
@@ -18,15 +18,13 @@ const liStyles = css`
 	row-gap: ${GAP_SIZE};
 `;
 
-const sidePaddingStylesMobile = (padSidesOnMobile: boolean) =>
+const sidePaddingStylesMobile = css`
 	/* Set spacing on the li element */
-	padSidesOnMobile &&
-	css`
-		${until.tablet} {
-			padding-left: 10px;
-			padding-right: 10px;
-		}
-	`;
+	${until.tablet} {
+		padding-left: 10px;
+		padding-right: 10px;
+	}
+`;
 
 const sidePaddingStyles = css`
 	${from.tablet} {
@@ -117,8 +115,8 @@ export const LI = ({
 						GAP_SIZE,
 						containerPalette,
 					),
-				sidePaddingStyles,
-				padSides && sidePaddingStylesMobile(padSidesOnMobile),
+				padSides && sidePaddingStyles,
+				padSidesOnMobile && sidePaddingStylesMobile,
 				snapAlignStart && snapAlignStartStyles,
 			]}
 		>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
There was a dangling CSS block in the `List` component styles due to a template literal having a logic issue for the condition of `padSidesOnMobile = false`.

It's pretty hard to spot this issue unless for some reason you're deep in the source HTML, since modern browsers fix a lot of minor bugs like this automatically! So the end result is that there should be no noticeable change...

## Why?
I spotted some dodgy CSS in the source when trying to make a new DCR harness for thrashers. Though, the browsers are smart enough for this not to be a problem anyway.



<!--
## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png
-->

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
