### PR TITLE
Use new Command constructor

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Format
         run: deno fmt scripts/deno
 
-      - name: Format
+      - name: Lint
         run: deno lint scripts/deno
 
       - name: Type-check

--- a/scripts/deno/deno.jsonc
+++ b/scripts/deno/deno.jsonc
@@ -5,12 +5,10 @@
 		"strict": true
 	},
 	"fmt": {
-		"options": {
-			"useTabs": true,
-			"lineWidth": 80,
-			"indentWidth": 4,
-			"singleQuote": true,
-			"proseWrap": "preserve"
-		}
+		"useTabs": true,
+		"lineWidth": 80,
+		"indentWidth": 4,
+		"singleQuote": true,
+		"proseWrap": "preserve"
 	}
 }

--- a/scripts/deno/eslint.ts
+++ b/scripts/deno/eslint.ts
@@ -3,18 +3,19 @@ const path = '.eslint/dotcom-rendering-report.json';
 const shouldLint = Deno.args.includes('--lint');
 
 const lint = () => {
-	const process = Deno.run({
-		cwd: './dotcom-rendering/',
-		cmd: [
-			'../node_modules/.bin/eslint',
-			'.',
-			...['--ext', '.ts,.tsx'],
-			...['--format', 'json'],
-			...['--output-file', '../' + path],
-		],
-	});
+	const command = new Deno.Command(
+		new URL(import.meta.resolve('../../node_modules/.bin/eslint')),
+		{
+			args: [
+				'.',
+				...['--ext', '.ts,.tsx'],
+				...['--format', 'json'],
+				...['--output-file', '../' + path],
+			],
+		},
+	);
 
-	return process.status();
+	return command.output();
 };
 
 if (shouldLint) await lint();

--- a/scripts/deno/github.ts
+++ b/scripts/deno/github.ts
@@ -1,4 +1,4 @@
-import { Octokit } from 'npm:octokit@2';
+import { Octokit } from 'npm:octokit@2.0.14';
 
 /** Github token for Authentication */
 const token = Deno.env.get('GITHUB_TOKEN');

--- a/scripts/deno/peer-dependencies.ts
+++ b/scripts/deno/peer-dependencies.ts
@@ -1,22 +1,19 @@
 import { octokit } from './github.ts';
 
 const peers = async (cwd: string) => {
-	const process = Deno.run({
+	const process = new Deno.Command('yarn', {
 		cwd,
-		cmd: ['yarn', '--force'],
+		args: ['--force'],
 		stdout: 'null',
 		stderr: 'piped',
 	});
 
-	const [{ code }, rawOutput] = await Promise.all([
-		process.status(),
-		process.stderrOutput(),
-	]);
+	const { code, stderr } = await process.output();
 
 	if (code !== 0) Deno.exit(code);
 
 	const deps = new TextDecoder()
-		.decode(rawOutput)
+		.decode(stderr)
 		.split('\n')
 		// keep only incorrect peer dependencies warnings
 		.filter((line) => line.includes('has incorrect peer dependency'))


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?


Use the `new Deno.Command()` constructor for running processes

## Why?

[`Deno.run` will be deprecated in Deno 2.0](https://deno.land/api@v1.34.2?s=Deno.run)

This allows our Deno health CI checks to pass