### PR TITLE
fix: switch card types on container layouts to match frontend

### DIFF
--- a/dotcom-rendering/src/components/FixedSmallSlowIII.tsx
+++ b/dotcom-rendering/src/components/FixedSmallSlowIII.tsx
@@ -1,5 +1,5 @@
+import { Card25Media25Tall, Card50Media50 } from '../lib/cardWrappers';
 import type { DCRContainerPalette, DCRFrontCard } from '../types/front';
-import { Card25Media25, Card50Media50 } from '../lib/cardWrappers';
 import { LI } from './Card/components/LI';
 import { UL } from './Card/components/UL';
 
@@ -36,7 +36,7 @@ export const FixedSmallSlowIII = ({
 					percentage={'25%'}
 					key={trail.url}
 				>
-					<Card25Media25
+					<Card25Media25Tall
 						trail={trail}
 						containerPalette={containerPalette}
 						showAge={showAge}

--- a/dotcom-rendering/src/components/FixedSmallSlowVThird.tsx
+++ b/dotcom-rendering/src/components/FixedSmallSlowVThird.tsx
@@ -1,5 +1,5 @@
+import { Card25Media25 } from '../lib/cardWrappers';
 import type { DCRContainerPalette, DCRFrontCard } from '../types/front';
-import { Card25Media25Tall } from '../lib/cardWrappers';
 import { LI } from './Card/components/LI';
 import { UL } from './Card/components/UL';
 import { FrontCard } from './FrontCard';
@@ -29,7 +29,7 @@ export const FixedSmallSlowVThird = ({
 						containerPalette={containerPalette}
 						percentage="25%"
 					>
-						<Card25Media25Tall
+						<Card25Media25
 							trail={trail}
 							containerPalette={containerPalette}
 							showAge={showAge}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

Resolves [#7612](https://github.com/guardian/dotcom-rendering/issues/7612)

## What does this change?

- Swaps `Card25Media25Tall` for `Card25Media25` in `FixedSmallSlowVThird` component
- Swaps `Card25Media25` for `Card25Media25Tall` in `FixedSmallSlowIII` component

## Why?

Changes cards used in containers to match DCR with frontend

## Screenshots

`FixedSmallSlowVThird`
| DCR Before      | DCR After      | Frontend |
| ----------- | ---------- | -------- |
| ![before1][] | ![after1][] | ![frontend1][] |

[before1]: https://github.com/guardian/dotcom-rendering/assets/43961396/1470a4ba-72ea-4fc1-9bed-55eb25ac8c7d
[after1]: https://github.com/guardian/dotcom-rendering/assets/43961396/b2cb575e-a6ee-4203-8b6b-769a3ea6fe29
[frontend1]: https://github.com/guardian/dotcom-rendering/assets/43961396/86af23c3-747f-42f0-b29e-04a599e0fb35

`FixedSmallSlowIII`
| DCR Before      | DCR After      | Frontend |
| ----------- | ---------- | -------- |
| ![before2][] | ![after2][] | ![frontend2][] |

[before2]: https://github.com/guardian/dotcom-rendering/assets/43961396/195ee002-51fa-4456-b51e-9a15663eeb94
[after2]: https://github.com/guardian/dotcom-rendering/assets/43961396/1763191d-a614-43e9-a944-bee6eb39b619
[frontend2]: https://github.com/guardian/dotcom-rendering/assets/43961396/f2d59f16-f8a9-4037-97d9-67116f73fe6e



Examples can all be found on the `/books` front at the time of writing.

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
