### PR TITLE
Add local container titles

### DIFF
--- a/dotcom-rendering/src/components/ContainerTitle.tsx
+++ b/dotcom-rendering/src/components/ContainerTitle.tsx
@@ -12,6 +12,7 @@ import type { Colour } from '../types/palette';
 import { decideContainerOverrides } from '../lib/decideContainerOverrides';
 import type { EditionId } from '../lib/edition';
 import { getEditionFromId } from '../lib/edition';
+import { localisedTitle } from './Localisation';
 
 type Props = {
 	title?: string;
@@ -21,12 +22,6 @@ type Props = {
 	containerPalette?: DCRContainerPalette;
 	showDateHeader?: boolean;
 	editionId?: EditionId;
-};
-
-type LocalisedTitles = {
-	[edition in EditionId]?: {
-		[title: string]: string;
-	};
 };
 
 const linkStyles = css`
@@ -90,20 +85,6 @@ export const ContainerTitle = ({
 	editionId,
 }: Props) => {
 	if (!title) return null;
-
-	const localisedTitles: LocalisedTitles = {
-		US: {
-			Film: 'Movies',
-			Football: 'Soccer',
-		},
-	};
-
-	const localisedTitle = (inputTitle: string, editionID?: EditionId) => {
-		if (editionID === undefined) {
-			return inputTitle;
-		}
-		return localisedTitles[editionID]?.[inputTitle] ?? inputTitle;
-	};
 
 	const overrides =
 		containerPalette && decideContainerOverrides(containerPalette);

--- a/dotcom-rendering/src/components/Localisation.ts
+++ b/dotcom-rendering/src/components/Localisation.ts
@@ -1,0 +1,27 @@
+import type { EditionId } from '../lib/edition';
+
+type LocalisedTitles = {
+	[edition in EditionId]?: {
+		[title: string]: string;
+	};
+};
+
+export const localisedTitles: LocalisedTitles = {
+	US: {
+		Film: 'Movies',
+		Football: 'Soccer',
+	},
+};
+
+// This ought to be fixed upstream in the tools, so that everyone is able to make use of the data.
+// For now, we'll just do it here.
+
+export const localisedTitle = (
+	inputTitle: string,
+	editionID?: EditionId,
+): string => {
+	if (editionID === undefined) {
+		return inputTitle;
+	}
+	return localisedTitles[editionID]?.[inputTitle] ?? inputTitle;
+};


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
This adds localised container titles to DCR. 


See frontend logic here: https://github.com/guardian/frontend/blob/5a05571ca414d6e61d147264a0699b7962f792e8/common/app/common/Localisation.scala#LL32C3-L35C4

## Why?
This resolves https://github.com/guardian/dotcom-rendering/issues/7691

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |
| Before      | After      |
| ----------- | ---------- |
| ![before1][] | ![after1][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/110032454/b7f0f3de-0bc7-4d1b-8a69-0926e188e9d3
[after]: https://github.com/guardian/dotcom-rendering/assets/110032454/d437a45b-762d-4e3e-b3cc-91f943c188fd
[before1]: https://github.com/guardian/dotcom-rendering/assets/110032454/0547f817-d5d8-411e-805a-2957f4f371f9
[after1]: https://github.com/guardian/dotcom-rendering/assets/110032454/0dadd93b-d00f-4f00-acc9-27d83b1d48c1

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
