### PR TITLE
Lower TTFB threshold for poor page performance

### DIFF
--- a/dotcom-rendering/src/client/performanceMonitoring.ts
+++ b/dotcom-rendering/src/client/performanceMonitoring.ts
@@ -49,8 +49,8 @@ export const performanceMonitoring = (): Promise<void> => {
 			};
 			logPerformanceInfo('navigation', info);
 			const ttfb = nav.responseStart - nav.startTime;
-			if (ttfb > 2400) {
-				recordPoorDeviceConnectivity('TTFB over 2.4s');
+			if (ttfb > 1200) {
+				recordPoorDeviceConnectivity('TTFB over 1.2s');
 			}
 		}
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Lower the threshold for time to first byte (TTFB) down to 1.2s from 2.4s in #7847 

## Why?

We want to improve sensitivity with minimal cost to specificity.

That means correctly identify more pages that will actually be slow,
while keeping the number of pages that are fast and incorrectly
identified as slow minimal.

For the last two weeks of page views, here’s how that breaks down:
- TTFB 1200+ : Sensitivity 7.43%, Specificity  99.23%
- TTFB 2400+ : Sensitivity 3.33%, Specificity 100.00%

## Screenshots

<img width="737" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/76776/a80e061e-7081-4ef3-b5f2-8d80f3d738ec">

Even though we still only have ~50% of TTFB 1.2 leading to “good” core web vitals rating, we still achieve a specificity of over 99%, as the vast majority of pageviews have a TTFB well below 1.2s.

<img width="874" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/76776/78333054-f0c9-40a0-92a5-c16415c44a1b">

This is easier when the stack are not stacked to 100% but have the correct relative heights:

<img width="869" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/76776/ea369473-1295-40fc-a765-e2d644c2459f">

