### PR TITLE
Add missing `data-component` values

### DIFF
--- a/dotcom-rendering/src/components/Header.tsx
+++ b/dotcom-rendering/src/components/Header.tsx
@@ -38,7 +38,7 @@ export const Header = ({
 	headerTopBarSearchCapiSwitch,
 	isInEuropeTest,
 }: Props) => (
-	<div css={headerStyles}>
+	<div css={headerStyles} data-component="nav3">
 		<Island>
 			<HeaderTopBar
 				editionId={editionId}

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -464,7 +464,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 			<Section
 				fullWidth={true}
 				showTopBorder={false}
-				data-component="trending-topics"
+				ophanComponentName="trending-topics"
 			>
 				<TrendingTopics trendingTopics={front.trendingTopics} />
 			</Section>


### PR DESCRIPTION
Addresses some of the issues in #4698

<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Adds missing `data-component` values

## Why?
For parity with frontend and because Ophan consumes those.

## Screenshots

| Frontend      | DCR after      |
| ----------- | ---------- |
| <img width="856" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/19683595/b57da447-47c1-40e6-8978-6af51a5d3d13"> | ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/852d1be0-072f-434d-83f3-24b9b535b07d) |
| <img width="1241" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/19683595/82ebb0b4-5b63-48a9-a19b-4c83b172c945">| ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/881af18e-e427-494a-aab9-c2b0734384c3) |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
