### PR TITLE
Use the Labs header on paid fronts

### DIFF
--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -1,9 +1,16 @@
 import { css } from '@emotion/react';
-import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
 import {
+	ArticleDesign,
+	ArticleDisplay,
+	ArticlePillar,
+	ArticleSpecial,
+} from '@guardian/libs';
+import {
+	border,
 	brandBackground,
 	brandBorder,
 	brandLine,
+	labs,
 	neutral,
 } from '@guardian/source-foundations';
 import { Hide } from '@guardian/source-react-components';
@@ -17,6 +24,7 @@ import { FrontSection } from '../components/FrontSection';
 import { Header } from '../components/Header';
 import { HeaderAdSlot } from '../components/HeaderAdSlot';
 import { Island } from '../components/Island';
+import { LabsHeader } from '../components/LabsHeader';
 import { LabsSection } from '../components/LabsSection';
 import { Nav } from '../components/Nav/Nav';
 import { Section } from '../components/Section';
@@ -153,30 +161,36 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 						</Stuck>
 					)}
 
-					<Section
-						fullWidth={true}
-						shouldCenter={false}
-						showTopBorder={false}
-						showSideBorders={false}
-						padSides={false}
-						backgroundColour={brandBackground.primary}
-						element="header"
-					>
-						<Header
-							editionId={front.editionId}
-							idUrl={front.config.idUrl}
-							mmaUrl={front.config.mmaUrl}
-							discussionApiUrl={front.config.discussionApiUrl}
-							urls={front.nav.readerRevenueLinks.header}
-							remoteHeader={!!front.config.switches.remoteHeader}
-							contributionsServiceUrl="https://contributions.guardianapis.com" // TODO: Pass this in
-							idApiUrl="https://idapi.theguardian.com/" // TODO: read this from somewhere as in other layouts
-							isInEuropeTest={isInEuropeTest}
-							headerTopBarSearchCapiSwitch={
-								!!front.config.switches.headerTopBarSearchCapi
-							}
-						/>
-					</Section>
+					{!isPaidContent && (
+						<Section
+							fullWidth={true}
+							shouldCenter={false}
+							showTopBorder={false}
+							showSideBorders={false}
+							padSides={false}
+							backgroundColour={brandBackground.primary}
+							element="header"
+						>
+							<Header
+								editionId={front.editionId}
+								idUrl={front.config.idUrl}
+								mmaUrl={front.config.mmaUrl}
+								discussionApiUrl={front.config.discussionApiUrl}
+								urls={front.nav.readerRevenueLinks.header}
+								remoteHeader={
+									!!front.config.switches.remoteHeader
+								}
+								contributionsServiceUrl="https://contributions.guardianapis.com" // TODO: Pass this in
+								idApiUrl="https://idapi.theguardian.com/" // TODO: read this from somewhere as in other layouts
+								isInEuropeTest={isInEuropeTest}
+								headerTopBarSearchCapiSwitch={
+									!!front.config.switches
+										.headerTopBarSearchCapi
+								}
+							/>
+						</Section>
+					)}
+
 					<Section
 						fullWidth={true}
 						borderColour={brandLine.primary}
@@ -229,6 +243,18 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 								/>
 							</Section>
 						</>
+					)}
+
+					{isPaidContent && (
+						<Section
+							fullWidth={true}
+							showTopBorder={false}
+							backgroundColour={labs[400]}
+							borderColour={border.primary}
+							sectionId="labs-header"
+						>
+							<LabsHeader />
+						</Section>
 					)}
 				</>
 			</div>

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -103,16 +103,17 @@ const decideAdSlot = (
 
 export const FrontLayout = ({ front, NAV }: Props) => {
 	const {
-		config: { isPaidContent },
+		config: { isPaidContent, abTests },
 	} = front;
 
-	const isInEuropeTest =
-		front.config.abTests.europeNetworkFrontVariant === 'variant';
+	const isInEuropeTest = abTests.europeNetworkFrontVariant === 'variant';
+
+	const theme = isPaidContent ? ArticleSpecial.Labs : ArticlePillar.News;
 
 	const format = {
 		display: ArticleDisplay.Standard,
 		design: ArticleDesign.Standard,
-		theme: ArticlePillar.News,
+		theme,
 	};
 
 	const palette = decidePalette(format);

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -116,12 +116,10 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 
 	const isInEuropeTest = abTests.europeNetworkFrontVariant === 'variant';
 
-	const theme = isPaidContent ? ArticleSpecial.Labs : ArticlePillar.News;
-
 	const format = {
 		display: ArticleDisplay.Standard,
 		design: ArticleDesign.Standard,
-		theme,
+		theme: isPaidContent ? ArticleSpecial.Labs : ArticlePillar.News,
 	};
 
 	const palette = decidePalette(format);


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Use the `<LabsHeader />` component on _paid  fronts_. We decide whether a front is paid based on whether the `isPaidContent` property is true.

## Why?

One step towards https://github.com/guardian/dotcom-rendering/issues/5945.

## Screenshots

I believe some design changes are to be expected from the DCR version and the current Frontend.

| DCR Before      | DCR After      | Frontend current |
| ----------- | ---------- | ---------- |
| ![before][] | ![after][] | ![frontend] |

[before]: https://github.com/guardian/dotcom-rendering/assets/8000415/42423fcc-f75a-48e5-a636-dfae9e02e3ab
[after]: https://github.com/guardian/dotcom-rendering/assets/8000415/6cde55b4-ba18-4c25-a049-08561e6ab203
[frontend]: https://github.com/guardian/dotcom-rendering/assets/8000415/5ddbc516-a1bf-449d-8ad4-d8013cb71ab5
