### PR TITLE
Consider only FCP & TTFB for page performance

### DIFF
--- a/dotcom-rendering/src/client/performanceMonitoring.ts
+++ b/dotcom-rendering/src/client/performanceMonitoring.ts
@@ -53,43 +53,6 @@ export const performanceMonitoring = (): Promise<void> => {
 				recordPoorDeviceConnectivity('TTFB over 1.2s');
 			}
 		}
-
-		// If Ophan takes a long time to load, we take it as an indicator
-		// of very slow connection or very little processing power
-		new PerformanceObserver((entries, observer) => {
-			for (const { name, duration, startTime } of entries.getEntries()) {
-				switch (name) {
-					case 'ophan': {
-						logPerformanceInfo(name, { startTime, duration });
-						if (startTime > 5000 || duration > 20) {
-							recordPoorDeviceConnectivity(
-								'Ophan took over 5s to boot or 20ms to execute',
-							);
-							observer.disconnect();
-						}
-					}
-				}
-			}
-		}).observe({
-			type: 'measure',
-			buffered: true,
-		});
-
-		// Long tasks are only supported in Chromium, but can be a good indicator
-		// of poor performance
-		let longTasks = 0;
-		new PerformanceObserver((entries, observer) => {
-			for (const { name, duration, startTime } of entries.getEntries()) {
-				longTasks += duration;
-				logPerformanceInfo('longtask:' + name, { startTime, duration });
-				if (longTasks >= 120) {
-					recordPoorDeviceConnectivity(
-						'Long tasks total duration above 120ms',
-					);
-					observer.disconnect();
-				}
-			}
-		}).observe({ type: 'longtask', buffered: true });
 	} catch (error) {
 		// do nothing if the performance API is not available
 	}


### PR DESCRIPTION
## What does this change?

Reduce indicators to “First contentful paint” and “Time to first byte” for `poor-page-performance` experiences

## Why?

Looking at Ophan boot time and long task identifies too many pages as having poor performance, just over 20% of them for June 13th. That meant that ~15% of fast pages where incorrectly identified as slow, when comparing with core web vitals labels.

Follow-up on #7847 and #7899 

## Screenshots

Data for yesterday from the BigQuery page view table:

![23.3% of page views identified as “poor-page-performance”](https://github.com/guardian/dotcom-rendering/assets/76776/2f19ccbe-c9d2-4e32-801b-48d94296d0f1)

And when joined with the actual Core web vitals label:

![image](https://github.com/guardian/dotcom-rendering/assets/76776/3da3746a-4599-413f-828a-73ff444d37db)