### PR TITLE
Fix `data-link-name` in various places 

### DIFF
--- a/dotcom-rendering/src/components/BackToTop.tsx
+++ b/dotcom-rendering/src/components/BackToTop.tsx
@@ -57,7 +57,7 @@ const textStyles = css`
 `;
 
 export const BackToTop = () => (
-	<a css={link} href="#top">
+	<a css={link} href="#top" data-link-name="back to top">
 		<span css={textStyles}>Back to top</span>
 		<span css={iconContainer} className="icon-container">
 			<i css={icon} />

--- a/dotcom-rendering/src/components/ContainerTitle.tsx
+++ b/dotcom-rendering/src/components/ContainerTitle.tsx
@@ -94,7 +94,11 @@ export const ContainerTitle = ({
 	return (
 		<div css={marginStyles}>
 			{url ? (
-				<a css={[linkStyles, bottomMargin]} href={url}>
+				<a
+					css={[linkStyles, bottomMargin]}
+					href={url}
+					data-link-name="section heading"
+				>
 					<h2 css={headerStyles(fontColour)}>
 						{localisedTitle(title, editionId)}
 					</h2>

--- a/dotcom-rendering/src/components/MostPopularFooterGrid.tsx
+++ b/dotcom-rendering/src/components/MostPopularFooterGrid.tsx
@@ -105,6 +105,7 @@ export const MostPopularFooterGrid = ({
 	return (
 		<div
 			data-component={ophanLinkName(sectionName)}
+			data-link-name={ophanLinkName(sectionName)}
 			css={gridContainerStyle}
 		>
 			<section data-link-name="most-viewed" css={displayContent}>

--- a/dotcom-rendering/src/components/MostViewedFooterGrid.tsx
+++ b/dotcom-rendering/src/components/MostViewedFooterGrid.tsx
@@ -164,7 +164,7 @@ export const MostViewedFooterGrid = ({
 								id={`tabs-popular-${i}-tab`}
 								data-cy={`tab-heading-${i}`}
 								key={`tabs-popular-${tab.heading}-tab`}
-								data-link-name={tab.heading}
+								data-link-name={`tab ${i + 1} ${tab.heading}`}
 								data-chromatic="ignore"
 							>
 								<a

--- a/dotcom-rendering/src/components/ReaderRevenueLinks.importable.tsx
+++ b/dotcom-rendering/src/components/ReaderRevenueLinks.importable.tsx
@@ -356,7 +356,7 @@ const ReaderRevenueLinksNative = ({
 		<a
 			css={linkStyles}
 			href={getUrl('contribute')}
-			data-link-name={`${dataLinkNamePrefix}subscribe-cta`}
+			data-link-name={`${dataLinkNamePrefix}contribute-cta`}
 		>
 			Support us <ArrowRightIcon />
 		</a>

--- a/dotcom-rendering/src/components/ShowMore.importable.tsx
+++ b/dotcom-rendering/src/components/ShowMore.importable.tsx
@@ -208,6 +208,7 @@ export const ShowMore = ({
 					aria-controls={showMoreContainerId}
 					aria-expanded={isOpen && !loading}
 					aria-describedby={`show-more-button-${collectionId}-description`}
+					data-link-name="more"
 				>
 					{decideButtonText({
 						isOpen,

--- a/dotcom-rendering/src/components/SupportingContent.tsx
+++ b/dotcom-rendering/src/components/SupportingContent.tsx
@@ -124,6 +124,7 @@ export const SupportingContent = ({
 							shouldPadLeft && leftMargin,
 							isLast && bottomMargin,
 						]}
+						data-link-name={`sublinks | ${index + 1}`}
 					>
 						<CardHeadline
 							format={subLink.format}

--- a/dotcom-rendering/src/components/Treats.tsx
+++ b/dotcom-rendering/src/components/Treats.tsx
@@ -18,11 +18,13 @@ import { SvgCrossword } from './SvgCrossword';
 const TextTreat = ({
 	text,
 	linkTo,
+	index,
 	borderColour,
 	fontColour,
 }: {
 	text: string;
 	linkTo: string;
+	index: number;
 	borderColour?: string;
 	fontColour?: string;
 }) => (
@@ -44,6 +46,7 @@ const TextTreat = ({
 				color: ${fontColour ?? sourcePalette.neutral[7]};
 			`}
 			href={linkTo}
+			data-link-name={`treat | ${index + 1} | ${text}`}
 		>
 			{text}
 		</Link>
@@ -180,7 +183,7 @@ export const Treats = ({
 				flex-direction: column;
 			`}
 		>
-			{treats.map((treat) => {
+			{treats.map((treat, index) => {
 				const [link] = treat.links;
 				if (link?.linkTo === '/crosswords' && link.text) {
 					// Treats that link to /crosswords are special. If any
@@ -198,6 +201,7 @@ export const Treats = ({
 									key={linkTo}
 									text={text}
 									linkTo={linkTo}
+									index={index}
 									borderColour={borderColour}
 									fontColour={fontColour}
 								/>
@@ -234,6 +238,7 @@ export const Treats = ({
 								key={linkTo}
 								text={text}
 								linkTo={linkTo}
+								index={index}
 								borderColour={borderColour}
 								fontColour={fontColour}
 							/>

--- a/dotcom-rendering/src/components/TrendingTopics.tsx
+++ b/dotcom-rendering/src/components/TrendingTopics.tsx
@@ -52,12 +52,7 @@ export const TrendingTopics = ({ trendingTopics }: Props) => {
 						key={tag.properties.webTitle}
 						href={tag.properties.webUrl}
 						css={linkStyle}
-						data-link-name={
-							'keyword: ' +
-							(tag.properties.url === undefined
-								? tag.properties.webTitle
-								: tag.properties.url)
-						}
+						data-link-name={`keyword: ${tag.properties.id}`}
 					>
 						{tag.properties.webTitle}
 					</a>

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -257,7 +257,11 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 				</>
 			</div>
 
-			<main data-layout="FrontLayout" id="maincontent">
+			<main
+				data-layout="FrontLayout"
+				data-link-name={`Front | /${front.pressedPage.id}`}
+				id="maincontent"
+			>
 				{front.pressedPage.collections.map((collection, index) => {
 					// Backfills should be added to the end of any curated content
 					const trails = collection.curated.concat(


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
Addresses some of the issues in #4692 

## What does this change?
Adds the following `data-link-name` attributes:
* back to top → <A/>
* section heading → <A/>
* tab 1 Most viewed → <A/>
* tab 2 Across the guardian → <A/>
* footer : contribute-cta → <A/>
* more → <BUTTON/>
* Front | /international → <DIV/>
* `data-link-name` for:
    * sublinks
    * treats
    * keywords

## Why?
Ophan consumes those.


<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
