### PR TITLE
Refactor Emotion usage in `ElementContainer`

### DIFF
--- a/dotcom-rendering/src/components/ElementContainer.tsx
+++ b/dotcom-rendering/src/components/ElementContainer.tsx
@@ -1,5 +1,5 @@
 import { css, jsx } from '@emotion/react';
-import { border, from, space } from '@guardian/source-foundations';
+import { from, palette, space } from '@guardian/source-foundations';
 import { center } from '../lib/center';
 
 const sidePadding = css`
@@ -69,7 +69,7 @@ export const ElementContainer = ({
 	showTopBorder = true,
 	padSides = true,
 	padBottom = false,
-	borderColour = border.secondary,
+	borderColour = palette.neutral[86],
 	backgroundColour,
 	innerBackgroundColour,
 	shouldCenter = true,

--- a/dotcom-rendering/src/components/ElementContainer.tsx
+++ b/dotcom-rendering/src/components/ElementContainer.tsx
@@ -58,6 +58,9 @@ type Props = {
 };
 
 /**
+ * Create a react element from the tagName passed in OR
+ * default to <div>
+ *
  * @deprecated please use Section fullWidth={true}  instead
  */
 export const ElementContainer = ({
@@ -76,37 +79,32 @@ export const ElementContainer = ({
 	ophanComponentName,
 	ophanComponentLink,
 	containerName,
-}: Props) => {
-	const child = (
-		<div
-			/**
-			 * id is being used to set the containerId in @see {ShowMore.importable.tsx}
-			 * this id pre-existed showMore so is probably also being used for something else.
-			 */
-			id={sectionId}
-			css={[
-				shouldCenter && center,
-				showSideBorders && sideBorderStyles(borderColour),
-				showTopBorder && topBorderStyles(borderColour),
-				innerBackgroundColour &&
-					setBackgroundColour(innerBackgroundColour),
-				padSides && sidePadding,
-				padBottom && bottomPadding,
-			]}
-		>
-			{children}
-		</div>
-	);
-
-	// Create a react element from the tagName passed in OR
-	// default to <div>
-	return jsx(element, {
+}: Props) =>
+	jsx(element, {
 		id: ophanComponentName,
 		'data-link-name': ophanComponentLink,
 		'data-component': ophanComponentName,
 		'data-container-name': containerName,
 		css: [backgroundColour && setBackgroundColour(backgroundColour)],
 		className,
-		children: child,
+		children: (
+			<div
+				/**
+				 * id is being used to set the containerId in @see {ShowMore.importable.tsx}
+				 * this id pre-existed showMore so is probably also being used for something else.
+				 */
+				id={sectionId}
+				css={[
+					shouldCenter && center,
+					showSideBorders && sideBorderStyles(borderColour),
+					showTopBorder && topBorderStyles(borderColour),
+					innerBackgroundColour &&
+						setBackgroundColour(innerBackgroundColour),
+					padSides && sidePadding,
+					padBottom && bottomPadding,
+				]}
+			>
+				{children}
+			</div>
+		),
 	});
-};

--- a/dotcom-rendering/src/components/ElementContainer.tsx
+++ b/dotcom-rendering/src/components/ElementContainer.tsx
@@ -1,10 +1,8 @@
-import { ClassNames, css as emoCss } from '@emotion/react';
+import { css, jsx } from '@emotion/react';
 import { border, from, space } from '@guardian/source-foundations';
-// @ts-expect-error
-import { jsx as _jsx } from 'react/jsx-runtime';
 import { center } from '../lib/center';
 
-const sidePadding = emoCss`
+const sidePadding = css`
 	padding-left: 10px;
 	padding-right: 10px;
 
@@ -14,22 +12,22 @@ const sidePadding = emoCss`
 	}
 `;
 
-const bottomPadding = emoCss`
+const bottomPadding = css`
 	padding-bottom: ${space[9]}px;
 `;
 
-const sideBorderStyles = (colour: string) => emoCss`
+const sideBorderStyles = (colour: string) => css`
 	${from.tablet} {
 		border-left: 1px solid ${colour};
 		border-right: 1px solid ${colour};
 	}
 `;
 
-const topBorderStyles = (colour: string) => emoCss`
+const topBorderStyles = (colour: string) => css`
 	border-top: 1px solid ${colour};
 `;
 
-const setBackgroundColour = (colour: string) => emoCss`
+const setBackgroundColour = (colour: string) => css`
 	background-color: ${colour};
 `;
 
@@ -78,42 +76,37 @@ export const ElementContainer = ({
 	ophanComponentName,
 	ophanComponentLink,
 	containerName,
-}: Props) => (
-	<ClassNames>
-		{({ css }) => {
-			const child = (
-				<div
-					/**
-					 * id is being used to set the containerId in @see {ShowMore.importable.tsx}
-					 * this id pre-existed showMore so is probably also being used for something else.
-					 */
-					id={sectionId}
-					css={[
-						shouldCenter && center,
-						showSideBorders && sideBorderStyles(borderColour),
-						showTopBorder && topBorderStyles(borderColour),
-						innerBackgroundColour &&
-							setBackgroundColour(innerBackgroundColour),
-						padSides && sidePadding,
-						padBottom && bottomPadding,
-					]}
-				>
-					{children}
-				</div>
-			);
-			const style = css`
-				${backgroundColour && setBackgroundColour(backgroundColour)};
-			`;
-			// Create a react element from the tagName passed in OR
-			// default to <div>
-			return _jsx(`${element}`, {
-				id: ophanComponentName,
-				'data-link-name': ophanComponentLink,
-				'data-component': ophanComponentName,
-				'data-container-name': containerName,
-				className: className ? `${style} ${className}` : style,
-				children: child,
-			});
-		}}
-	</ClassNames>
-);
+}: Props) => {
+	const child = (
+		<div
+			/**
+			 * id is being used to set the containerId in @see {ShowMore.importable.tsx}
+			 * this id pre-existed showMore so is probably also being used for something else.
+			 */
+			id={sectionId}
+			css={[
+				shouldCenter && center,
+				showSideBorders && sideBorderStyles(borderColour),
+				showTopBorder && topBorderStyles(borderColour),
+				innerBackgroundColour &&
+					setBackgroundColour(innerBackgroundColour),
+				padSides && sidePadding,
+				padBottom && bottomPadding,
+			]}
+		>
+			{children}
+		</div>
+	);
+
+	// Create a react element from the tagName passed in OR
+	// default to <div>
+	return jsx(element, {
+		id: ophanComponentName,
+		'data-link-name': ophanComponentLink,
+		'data-component': ophanComponentName,
+		'data-container-name': containerName,
+		css: [backgroundColour && setBackgroundColour(backgroundColour)],
+		className,
+		children: child,
+	});
+};


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Remove a TS error by using `@emotion/react` in the standard way.

## Why?

Improve consistency and reduce errors