### PR TITLE
fix: ensure allCards references both curated and backfill

### DIFF
--- a/dotcom-rendering/src/model/enhanceCollections.ts
+++ b/dotcom-rendering/src/model/enhanceCollections.ts
@@ -46,7 +46,7 @@ export const enhanceCollections = (
 	return collections.filter(isSupported).map((collection, index) => {
 		const { id, displayName, collectionType, hasMore, href, description } =
 			collection;
-		const allCards = [...collection.curated, ...collection.curated];
+		const allCards = [...collection.curated, ...collection.backfill];
 		const allBranding = getBrandingFromCards(allCards, editionId);
 		const allCardsHaveBranding = allCards.length === allBranding.length;
 		const containerPalette = decideContainerPalette(


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Dedupes the `allCards` array of double `curated` in favour of both `curated` and `backfill` cards

## Why?

Fixing a mini typo / bug