### PR TITLE
Support latest links in Dynamic containers

### DIFF
--- a/dotcom-rendering/fixtures/manual/trails.ts
+++ b/dotcom-rendering/fixtures/manual/trails.ts
@@ -73,6 +73,7 @@ export const trails: [
 		],
 		showMainVideo: false,
 		isExternalLink: false,
+		showLivePlayable: false,
 	},
 	{
 		url: 'https://www.theguardian.com/environment/2019/dec/02/migration-v-climate-europes-new-political-divide',
@@ -92,6 +93,7 @@ export const trails: [
 		showQuotedHeadline: false,
 		showMainVideo: false,
 		isExternalLink: false,
+		showLivePlayable: false,
 	},
 	{
 		url: 'https://www.theguardian.com/world/2019/nov/28/eu-parliament-declares-climate-emergency',
@@ -110,6 +112,7 @@ export const trails: [
 		showQuotedHeadline: false,
 		showMainVideo: false,
 		isExternalLink: false,
+		showLivePlayable: false,
 	},
 	{
 		url: 'https://www.theguardian.com/environment/2019/nov/27/climate-emergency-world-may-have-crossed-tipping-points',
@@ -127,6 +130,7 @@ export const trails: [
 		showQuotedHeadline: true,
 		showMainVideo: false,
 		isExternalLink: false,
+		showLivePlayable: false,
 	},
 	{
 		url: 'https://www.theguardian.com/world/2019/nov/26/european-parliament-split-on-declaring-climate-emergency',
@@ -144,6 +148,7 @@ export const trails: [
 		showQuotedHeadline: false,
 		showMainVideo: false,
 		isExternalLink: false,
+		showLivePlayable: false,
 	},
 	{
 		url: 'https://www.theguardian.com/world/2019/nov/23/north-pole-explorers-on-thin-ice-as-climate-change-hits-expedition',
@@ -162,6 +167,7 @@ export const trails: [
 		showQuotedHeadline: false,
 		showMainVideo: false,
 		isExternalLink: false,
+		showLivePlayable: false,
 	},
 	{
 		url: 'https://www.theguardian.com/environment/2019/oct/25/scientists-glacial-rivers-absorb-carbon-faster-rainforests',
@@ -181,6 +187,7 @@ export const trails: [
 		showQuotedHeadline: false,
 		showMainVideo: false,
 		isExternalLink: false,
+		showLivePlayable: false,
 	},
 	{
 		url: 'https://www.theguardian.com/business/2019/oct/20/uk-urges-world-bank-to-channel-more-money-into-tackling-climate-crisis',
@@ -199,6 +206,7 @@ export const trails: [
 		showQuotedHeadline: false,
 		showMainVideo: false,
 		isExternalLink: false,
+		showLivePlayable: false,
 	},
 
 	{
@@ -219,6 +227,7 @@ export const trails: [
 		showQuotedHeadline: false,
 		showMainVideo: false,
 		isExternalLink: false,
+		showLivePlayable: false,
 	},
 	{
 		url: 'https://www.theguardian.com/world/2021/feb/17/uk-to-begin-worlds-first-covid-human-challenge-study-within-weeks',
@@ -238,6 +247,7 @@ export const trails: [
 		showQuotedHeadline: false,
 		showMainVideo: false,
 		isExternalLink: false,
+		showLivePlayable: false,
 	},
 	{
 		url: 'https://www.theguardian.com/world/2021/feb/17/scottish-government-inadequately-prepared-for-covid-audit-scotland-report',
@@ -257,6 +267,7 @@ export const trails: [
 		showQuotedHeadline: false,
 		showMainVideo: false,
 		isExternalLink: false,
+		showLivePlayable: false,
 	},
 	{
 		url: 'https://www.theguardian.com/society/2021/feb/16/encouraging-signs-covid-vaccine-over-80s-deaths-fall-england',
@@ -276,6 +287,7 @@ export const trails: [
 		showQuotedHeadline: false,
 		showMainVideo: false,
 		isExternalLink: false,
+		showLivePlayable: false,
 	},
 	{
 		url: 'https://www.theguardian.com/world/2021/feb/16/contact-tracing-alone-has-little-impact-on-curbing-covid-spread-report-finds',
@@ -295,6 +307,7 @@ export const trails: [
 		showQuotedHeadline: false,
 		showMainVideo: false,
 		isExternalLink: false,
+		showLivePlayable: false,
 	},
 	{
 		url: 'https://www.theguardian.com/world/2021/feb/16/covid-almost-2m-more-people-asked-shield-england',
@@ -314,6 +327,7 @@ export const trails: [
 		showQuotedHeadline: false,
 		showMainVideo: false,
 		isExternalLink: false,
+		showLivePlayable: false,
 	},
 	{
 		url: 'https://www.theguardian.com/politics/live/2021/feb/16/uk-covid-live-coronavirus-sturgeon-return-scottish-schools-latest-updates',
@@ -333,6 +347,7 @@ export const trails: [
 		showQuotedHeadline: false,
 		showMainVideo: false,
 		isExternalLink: false,
+		showLivePlayable: false,
 	},
 	{
 		url: 'https://www.theguardian.com/uk-news/2021/feb/16/qcovid-how-improved-algorithm-can-identify-more-higher-risk-adults',
@@ -352,6 +367,7 @@ export const trails: [
 		showQuotedHeadline: false,
 		showMainVideo: false,
 		isExternalLink: false,
+		showLivePlayable: false,
 	},
 	{
 		url: 'https://www.theguardian.com/world/2019/nov/28/eu-parliament-declares-climate-emergency',
@@ -369,6 +385,7 @@ export const trails: [
 		showQuotedHeadline: false,
 		showMainVideo: false,
 		isExternalLink: false,
+		showLivePlayable: false,
 	},
 	{
 		url: 'https://www.theguardian.com/society/2023/may/30/trans-activists-disrupt-kathleen-stock-speech-at-oxford-union',
@@ -387,6 +404,7 @@ export const trails: [
 		showQuotedHeadline: false,
 		showMainVideo: false,
 		isExternalLink: false,
+		showLivePlayable: false,
 	},
 	{
 		url: 'https://www.theguardian.com/commentisfree/2023/may/31/price-controls-rishi-sunak-thatcher-prime-minister',
@@ -405,6 +423,7 @@ export const trails: [
 		showQuotedHeadline: false,
 		showMainVideo: false,
 		isExternalLink: false,
+		showLivePlayable: false,
 	},
 	{
 		url: 'https://www.theguardian.com/tv-and-radio/2023/may/30/a-revelation-succession-matthew-macfadyen-has-been-a-consummate-shapeshifter',
@@ -423,5 +442,6 @@ export const trails: [
 		showQuotedHeadline: false,
 		showMainVideo: false,
 		isExternalLink: false,
+		showLivePlayable: false,
 	},
 ];

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -18,6 +18,8 @@ import { Avatar } from '../Avatar';
 import { CardHeadline } from '../CardHeadline';
 import { CardPicture } from '../CardPicture';
 import { Hide } from '../Hide';
+import { Island } from '../Island';
+import { LatestLinks } from '../LatestLinks.importable';
 import { MediaMeta } from '../MediaMeta';
 import { Slideshow } from '../Slideshow';
 import { Snap } from '../Snap';
@@ -77,6 +79,7 @@ export type Props = {
 	isDynamo?: true;
 	isExternalLink: boolean;
 	slideshowImages?: DCRSlideshowImage[];
+	showLivePlayable?: boolean;
 };
 
 const StarRatingComponent = ({
@@ -117,14 +120,17 @@ const StarRatingComponent = ({
  *
  */
 const decideIfAgeShouldShow = ({
+	showLivePlayable,
 	containerPalette,
 	format,
 	showAge,
 }: {
+	showLivePlayable: boolean;
 	containerPalette?: DCRContainerPalette;
 	format: ArticleFormat;
 	showAge: boolean;
 }): boolean => {
+	if (showLivePlayable) return false;
 	// Some containers force all cards to show age. E.g., The articles in the headlines
 	// container are typically very recent so we want to display age there
 	if (showAge) return true;
@@ -271,6 +277,7 @@ export const Card = ({
 	isCrossword,
 	isExternalLink,
 	slideshowImages,
+	showLivePlayable = false,
 }: Props) => {
 	const palette = decidePalette(format, containerPalette);
 
@@ -295,6 +302,7 @@ export const Card = ({
 		displayAge?: boolean;
 		displayLines?: boolean;
 	}) => {
+		if (showLivePlayable) return <></>;
 		return (
 			<CardFooter
 				format={format}
@@ -348,6 +356,7 @@ export const Card = ({
 	};
 
 	const displayAge = decideIfAgeShouldShow({
+		showLivePlayable,
 		containerPalette,
 		format,
 		showAge,
@@ -490,6 +499,17 @@ export const Card = ({
 									}}
 								/>
 							</TrailTextWrapper>
+						)}
+						{showLivePlayable && (
+							<Island>
+								<LatestLinks
+									id={linkTo}
+									format={format}
+									isDynamo={isDynamo}
+									direction={supportingContentAlignment}
+									containerPalette={containerPalette}
+								></LatestLinks>
+							</Island>
 						)}
 						<DecideFooter
 							isOpinion={isOpinion}

--- a/dotcom-rendering/src/components/Card/components/CardWrapper.tsx
+++ b/dotcom-rendering/src/components/Card/components/CardWrapper.tsx
@@ -2,12 +2,12 @@ import { css } from '@emotion/react';
 import type { ArticleFormat } from '@guardian/libs';
 import { ArticleDesign, ArticleSpecial } from '@guardian/libs';
 import { from, neutral } from '@guardian/source-foundations';
+import { decidePalette } from '../../../lib/decidePalette';
 import type {
 	DCRContainerPalette,
 	DCRContainerType,
 } from '../../../types/front';
 import type { Palette } from '../../../types/palette';
-import { decidePalette } from '../../../lib/decidePalette';
 
 type Props = {
 	children: React.ReactNode;

--- a/dotcom-rendering/src/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/components/CardHeadline.tsx
@@ -198,7 +198,8 @@ const dynamoStyles = css`
 	font-weight: ${fontWeights.medium};
 	padding: 5px;
 `;
-const WithLink = ({
+
+export const WithLink = ({
 	linkTo,
 	children,
 	isDynamo,

--- a/dotcom-rendering/src/components/DynamicPackage.tsx
+++ b/dotcom-rendering/src/components/DynamicPackage.tsx
@@ -46,6 +46,7 @@ const Snap100 = ({
 					imagePositionOnMobile="left"
 					imageSize="medium"
 					trailText={snaps[0].trailText}
+					supportingContentAlignment="horizontal"
 				/>
 			</LI>
 		</UL>
@@ -76,6 +77,7 @@ const Card100 = ({
 					imageSize="large"
 					isDynamo={true}
 					supportingContent={cards[0].supportingContent}
+					supportingContentAlignment="horizontal"
 				/>
 			</LI>
 		</UL>

--- a/dotcom-rendering/src/components/FrontCard.tsx
+++ b/dotcom-rendering/src/components/FrontCard.tsx
@@ -49,6 +49,7 @@ export const FrontCard = (props: Props) => {
 		isExternalLink: trail.isExternalLink,
 		branding: trail.branding,
 		slideshowImages: trail.slideshowImages,
+		showLivePlayable: trail.showLivePlayable,
 	};
 
 	return Card({ ...defaultProps, ...cardProps });

--- a/dotcom-rendering/src/components/LatestLinks.importable.tsx
+++ b/dotcom-rendering/src/components/LatestLinks.importable.tsx
@@ -1,0 +1,202 @@
+import type { SerializedStyles } from '@emotion/react';
+import { css } from '@emotion/react';
+import {
+	type ArticleFormat,
+	timeAgo as timeAgoHasAWeirdInterface,
+} from '@guardian/libs';
+import { palette, space, textSans } from '@guardian/source-foundations';
+import { decideContainerOverrides } from '../lib/decideContainerOverrides';
+import { decidePalette } from '../lib/decidePalette';
+import { revealStyles } from '../lib/revealStyles';
+import { useApi } from '../lib/useApi';
+import type { DCRContainerPalette } from '../types/front';
+import { WithLink } from './CardHeadline';
+
+type Props = {
+	id: string;
+	format: ArticleFormat;
+	direction: 'horizontal' | 'vertical';
+	isDynamo?: true;
+	containerPalette?: DCRContainerPalette;
+};
+
+const timeAgo = (epoch: number) => {
+	const value = timeAgoHasAWeirdInterface(epoch);
+
+	if (typeof value === 'string' && value !== '') return value;
+	else return undefined;
+};
+
+const style = css`
+	display: flex;
+	gap: 5px;
+	padding-bottom: ${space[2]}px;
+`;
+
+const horizontal = css`
+	flex-direction: row;
+`;
+const vertical = css`
+	flex-direction: column;
+	padding: 0 ${space[1]}px;
+`;
+
+const li = css`
+	${textSans.xsmall()}
+	overflow: hidden;
+	flex-grow: 1;
+	height: calc(4 * 1.35em + 2 * ${space[1]}px);
+`;
+
+const dividerStyles = css`
+	border-top: 1px solid currentColor;
+	border-left: 1px solid currentColor;
+`;
+
+const bold = css`
+	${textSans.xsmall({ fontWeight: 'bold' })};
+
+	:before {
+		content: '';
+		height: 0.75em;
+		width: 0.75em;
+		margin-right: ${space[1]}px;
+		display: inline-block;
+		background-color: currentColor;
+		border-radius: 100%;
+	}
+`;
+
+const transparent = css`
+	color: transparent;
+`;
+
+const Time = ({
+	epoch,
+	colour,
+}: {
+	epoch: number;
+	colour: SerializedStyles;
+}) => (
+	<>
+		<time
+			dateTime={new Date(epoch).toISOString()}
+			data-relativeformat="med"
+			css={[bold, colour]}
+		>
+			{timeAgo(epoch)}
+		</time>
+		<br />
+	</>
+);
+
+const THREE_LINES_AS_CHARACTERS = 75;
+
+/**
+ * We cannot rely on [`text-overflow: ellipsis`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-overflow)
+ * because that only applies to single lines of text without whitespace wrapping
+ */
+const extractAboutThreeLines = (text: string) =>
+	text.length <= THREE_LINES_AS_CHARACTERS
+		? text
+		: text
+				.slice(0, THREE_LINES_AS_CHARACTERS) // take a few characters
+				.split(' ') // split by words
+				.slice(0, -1) // drop the last word as it’s likely a partial one
+				.join(' ') + '…'; // join with spaces and add an ellipsis
+
+/**
+ * # Latest Links
+ *
+ * Display the last three blocks from a Liveblog when the fronts
+ * tool has enabled showing live updates.
+ *
+ * ## Why does this need to be an Island?
+ *
+ * We make an API call to retrieve the latest blocks,
+ * constantly updating when new data comes in.
+ *
+ * ---
+ *
+ * (No visual story exists)
+ */
+export const LatestLinks = ({
+	id,
+	format,
+	direction,
+	isDynamo,
+	containerPalette,
+}: Props) => {
+	const { data } = useApi<{
+		blocks: Array<{
+			id: string;
+			title: string;
+			publishedDateTime: number;
+			lastUpdatedDateTime: number;
+			body: string;
+		}>;
+	}>(`https://api.nextgen.guardianapps.co.uk${id}.json?rendered=false`, {
+		refreshInterval: 9_600,
+	});
+
+	const { text } = decidePalette(format, containerPalette);
+	const kickerColour = isDynamo ? text.dynamoKicker : text.cardKicker;
+
+	const colour = css`
+		color: ${kickerColour};
+	`;
+
+	const dividerColour = css`
+		color: ${containerPalette
+			? decideContainerOverrides(containerPalette).border?.container
+			: palette.neutral[86]};
+	`;
+
+	return (
+		<ul
+			css={[
+				style,
+				revealStyles,
+				isDynamo || direction === 'horizontal' ? horizontal : vertical,
+				css`
+					color: ${text.cardHeadline};
+				`,
+			]}
+		>
+			{data && data.blocks.length >= 3 ? (
+				data.blocks.slice(0, 3).map((block, index) => (
+					<>
+						{index > 0 && (
+							<li
+								key={block.id + ' : divider'}
+								css={[dividerStyles, dividerColour]}
+							></li>
+						)}
+						<li key={block.id} css={li} className={'reveal'}>
+							<WithLink
+								linkTo={`${id}?page=with:block-${block.id}#block-${block.id}`}
+								isDynamo={isDynamo}
+							>
+								<Time
+									epoch={block.publishedDateTime}
+									colour={colour}
+								/>
+								<span className="show-underline">
+									{extractAboutThreeLines(block.body)}
+								</span>
+							</WithLink>
+						</li>
+					</>
+				))
+			) : (
+				<>
+					<li css={li} />
+					<li css={[dividerStyles, transparent]} />
+					<li css={li} />
+					<li css={[dividerStyles, transparent]} />
+					<li css={li} />
+				</>
+			)}
+		</ul>
+	);
+};

--- a/dotcom-rendering/src/components/SupportingContent.stories.tsx
+++ b/dotcom-rendering/src/components/SupportingContent.stories.tsx
@@ -31,6 +31,7 @@ const basicCardProps: CardProps = {
 		'https://media.guim.co.uk/6537e163c9164d25ec6102641f6a04fa5ba76560/0_0_5472_3648/master/5472.jpg',
 	imagePosition: 'top',
 	isExternalLink: false,
+	showLivePlayable: false,
 };
 
 const aBasicLink = {

--- a/dotcom-rendering/src/model/enhanceCards.ts
+++ b/dotcom-rendering/src/model/enhanceCards.ts
@@ -256,6 +256,7 @@ export const enhanceCards = (
 			isBoosted: faciaCard.display.isBoosted,
 			isCrossword: faciaCard.properties.isCrossword,
 			showQuotedHeadline: faciaCard.display.showQuotedHeadline,
+			showLivePlayable: faciaCard.display.showLivePlayable,
 			avatarUrl:
 				faciaCard.properties.maybeContent?.tags.tags &&
 				faciaCard.properties.image?.type === 'Cutout'

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -276,6 +276,7 @@ export type DCRFrontCard = {
 	embedUri?: string;
 	branding?: Branding;
 	slideshowImages?: DCRSlideshowImage[];
+	showLivePlayable: boolean;
 };
 
 export type DCRSlideshowImage = {


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Adds support for latest links on dynamic containers.

Working alongside Alex B, we’ve made some small visual tweaks to these links, which is closer to the way they look on the Apps. Unlike in Frontend, they have a full dot, their published time matches the kicker colour and they have small dividers.

The blocks are fetched from an endpoint every 9.6s to make sure that these stay up-to-date. This value was picked as it’s similar but also slightly different to other polling intervals across the codebase.

## Why?

Closes #5196 

### Considerations

- [X] Reserve space as they are loaded client-side.
- [X] Refreshed these on a polling interval
- [X] We cannot use [css elipsis](https://css-tricks.com/snippets/css/truncate-string-with-ellipsis/) for truncation as it only handles single lines
- [X] The loading state is similar to Frontend, fading in once results are loaded
- [x] What if there are no results?
  - _We do not display any link, leaving a space for when 3 or more blocks are available_
- [X] Do we filter by key events or all?
  - _all events_
- [ ] Can we create an in-memory cache for the latest n posts on each live blog and read in from there so we can server render this content? We can then progressively enhance the container by adding javascript to keep these posts up to date.
  - _This could be a nice future improvement_

## Screenshots

| DCR Before  | Frontend    | DCR After  |
| ----------- | ----------- | ---------- |
| ![DCR before][] | ![Frontend][] | ![DCR after][] |
| ![DCR before horizontal][] | ![Frontend horizontal][] | ![DCR after horizontal][] |


[DCR before]: https://github.com/guardian/dotcom-rendering/assets/76776/a70cc804-5fec-404e-8489-3861e9d222fe
[Frontend]: https://github.com/guardian/dotcom-rendering/assets/76776/3aacc3a1-d36d-45bc-91d1-74ff2c236256
[DCR after]: https://github.com/guardian/dotcom-rendering/assets/76776/de0bb1d7-b426-41a1-8640-420efc85839b


[DCR before horizontal]: https://github.com/guardian/dotcom-rendering/assets/76776/779bdc1f-f1ec-4340-976f-1153ada83410
[Frontend horizontal]: https://github.com/guardian/dotcom-rendering/assets/76776/5c4699fa-3c28-4759-afc2-78a39327aa04
[DCR after horizontal]: https://github.com/guardian/dotcom-rendering/assets/76776/caf9dab5-33d5-4286-ab3f-8e95ca1d484f


## Known issues

I’m not sure how to go about creating a story or Cypress test for this, as it requires making a network call to get the data from the blocks endpoint.