### PR TITLE
Use a labelled badge on paid for fronts

### DIFF
--- a/dotcom-rendering/src/components/Badge.tsx
+++ b/dotcom-rendering/src/components/Badge.tsx
@@ -8,11 +8,6 @@ const badgeSizingStyles = css`
 	}
 `;
 
-const badgeWrapper = css`
-	float: left;
-	${badgeSizingStyles}
-`;
-
 const imageStyles = css`
 	display: block;
 	width: auto;
@@ -30,7 +25,7 @@ type Props = {
 
 export const Badge = ({ imageSrc, href }: Props) => {
 	return (
-		<div css={badgeWrapper}>
+		<div css={badgeSizingStyles}>
 			<a href={href} css={badgeLink} role="button">
 				<img css={imageStyles} src={imageSrc} alt="" />
 			</a>

--- a/dotcom-rendering/src/components/Badge.tsx
+++ b/dotcom-rendering/src/components/Badge.tsx
@@ -11,6 +11,8 @@ const badgeSizingStyles = css`
 const imageStyles = css`
 	display: block;
 	width: auto;
+	max-width: 100%;
+	object-fit: contain;
 	${badgeSizingStyles}
 `;
 

--- a/dotcom-rendering/src/components/FrontSection.stories.tsx
+++ b/dotcom-rendering/src/components/FrontSection.stories.tsx
@@ -201,3 +201,38 @@ export const TreatsStory = () => {
 	);
 };
 TreatsStory.storyName = 'with treats and date header';
+
+/**
+ * Note only the first container should show a badge
+ */
+export const MultipleOnAPaidFront = () => {
+	return (
+		<>
+			<FrontSection
+				title="Section one"
+				isOnPaidContentFront={true}
+				index={0}
+				badge={{
+					imageSrc:
+						'https://static.theguardian.com/commercial/sponsor/28/Oct/2020/daa941da-14fd-46cc-85cb-731ce59050ee-Grounded_badging-280x180.png',
+					href: '/',
+				}}
+			>
+				<Placeholder />
+			</FrontSection>
+			<FrontSection
+				title="Section two"
+				isOnPaidContentFront={true}
+				index={1}
+				badge={{
+					imageSrc:
+						'https://static.theguardian.com/commercial/sponsor/28/Oct/2020/daa941da-14fd-46cc-85cb-731ce59050ee-Grounded_badging-280x180.png',
+					href: '/',
+				}}
+			>
+				<Placeholder />
+			</FrontSection>
+		</>
+	);
+};
+MultipleOnAPaidFront.storyName = 'two sections on a paid front';

--- a/dotcom-rendering/src/components/FrontSection.tsx
+++ b/dotcom-rendering/src/components/FrontSection.tsx
@@ -66,7 +66,7 @@ type Props = {
 	ajaxUrl?: string;
 	/** Does this front section reside on a "paid for" content front */
 	isOnPaidContentFront?: boolean;
-	/** INDEX TODO */
+	/** Denotes the position of this section on the front */
 	index?: number;
 };
 
@@ -450,6 +450,7 @@ export const FrontSection = ({
 					),
 				]}
 			>
+				{/* Only show the badge with a "Paid for by" label on the FIRST card of a paid front */}
 				{isOnPaidContentFront && index === 0 ? (
 					<div css={titleStyle}>
 						<ContainerTitle
@@ -457,7 +458,7 @@ export const FrontSection = ({
 							fontColour={overrides?.text?.container}
 							description={description}
 							// On paid fronts the title is not treated as a link
-							// So explicitly mark it as undefined here
+							// Be explicit and pass in undefined
 							url={undefined}
 							containerPalette={containerPalette}
 							showDateHeader={showDateHeader}

--- a/dotcom-rendering/src/components/FrontSection.tsx
+++ b/dotcom-rendering/src/components/FrontSection.tsx
@@ -57,6 +57,8 @@ type Props = {
 	/** Enable the "Show More" button on this container to allow readers to load more cards */
 	canShowMore?: boolean;
 	ajaxUrl?: string;
+	/** Does this front section reside on a "paid for" content front */
+	isOnPaidContentFront?: boolean;
 };
 
 const width = (columns: number, columnWidth: number, columnGap: number) =>
@@ -391,6 +393,7 @@ export const FrontSection = ({
 	badge,
 	canShowMore,
 	ajaxUrl,
+	isOnPaidContentFront,
 }: Props) => {
 	const overrides =
 		containerPalette && decideContainerOverrides(containerPalette);

--- a/dotcom-rendering/src/components/FrontSection.tsx
+++ b/dotcom-rendering/src/components/FrontSection.tsx
@@ -1,5 +1,12 @@
 import { css } from '@emotion/react';
-import { from, neutral, space, until } from '@guardian/source-foundations';
+import {
+	from,
+	neutral,
+	palette,
+	space,
+	textSans,
+	until,
+} from '@guardian/source-foundations';
 import { Hide } from '@guardian/source-react-components';
 import { decideContainerOverrides } from '../lib/decideContainerOverrides';
 import type { EditionId } from '../lib/edition';
@@ -59,6 +66,8 @@ type Props = {
 	ajaxUrl?: string;
 	/** Does this front section reside on a "paid for" content front */
 	isOnPaidContentFront?: boolean;
+	/** INDEX TODO */
+	index?: number;
 };
 
 const width = (columns: number, columnWidth: number, columnGap: number) =>
@@ -394,6 +403,7 @@ export const FrontSection = ({
 	canShowMore,
 	ajaxUrl,
 	isOnPaidContentFront,
+	index,
 }: Props) => {
 	const overrides =
 		containerPalette && decideContainerOverrides(containerPalette);
@@ -440,30 +450,77 @@ export const FrontSection = ({
 					),
 				]}
 			>
-				<Hide until="leftCol">
-					{badge && (
-						<Badge imageSrc={badge.imageSrc} href={badge.href} />
-					)}
-				</Hide>
-				<div css={titleStyle}>
-					<Hide from="leftCol">
+				{isOnPaidContentFront && index === 0 ? (
+					<div css={titleStyle}>
+						<ContainerTitle
+							title={title}
+							fontColour={overrides?.text?.container}
+							description={description}
+							// On paid fronts the title is not treated as a link
+							// So explicitly mark it as undefined here
+							url={undefined}
+							containerPalette={containerPalette}
+							showDateHeader={showDateHeader}
+							editionId={editionId}
+						/>
 						{badge && (
-							<Badge
-								imageSrc={badge.imageSrc}
-								href={badge.href}
-							/>
+							<div
+								css={css`
+									display: inline-block;
+									border-top: 1px dotted
+										${palette.neutral[86]};
+									${textSans.xxsmall()}
+									color: ${palette.neutral[46]};
+									font-weight: bold;
+
+									${from.leftCol} {
+										width: 100%;
+									}
+								`}
+							>
+								Paid for by
+								<Badge
+									imageSrc={badge.imageSrc}
+									href={badge.href}
+								/>
+							</div>
 						)}
-					</Hide>
-					<ContainerTitle
-						title={title}
-						fontColour={overrides?.text?.container}
-						description={description}
-						url={url}
-						containerPalette={containerPalette}
-						showDateHeader={showDateHeader}
-						editionId={editionId}
-					/>
-				</div>
+					</div>
+				) : (
+					<>
+						{!isOnPaidContentFront && (
+							<Hide until="leftCol">
+								{badge && (
+									<Badge
+										imageSrc={badge.imageSrc}
+										href={badge.href}
+									/>
+								)}
+							</Hide>
+						)}
+						<div css={titleStyle}>
+							{!isOnPaidContentFront && (
+								<Hide from="leftCol">
+									{badge && (
+										<Badge
+											imageSrc={badge.imageSrc}
+											href={badge.href}
+										/>
+									)}
+								</Hide>
+							)}
+							<ContainerTitle
+								title={title}
+								fontColour={overrides?.text?.container}
+								description={description}
+								url={url}
+								containerPalette={containerPalette}
+								showDateHeader={showDateHeader}
+								editionId={editionId}
+							/>
+						</div>
+					</>
+				)}
 				{leftContent}
 			</div>
 

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -459,6 +459,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 								canShowMore={collection.canShowMore}
 								ajaxUrl={front.config.ajaxUrl}
 								isOnPaidContentFront={isPaidContent}
+								index={index}
 							>
 								<DecideContainer
 									trails={trails}

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -458,6 +458,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 								treats={collection.treats}
 								canShowMore={collection.canShowMore}
 								ajaxUrl={front.config.ajaxUrl}
+								isOnPaidContentFront={isPaidContent}
 							>
 								<DecideContainer
 									trails={trails}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

This PR makes some changes to the way we display the badges associated with sections on paid fronts:

- For a front section on a paid for front, if there is a badge present then display it **below** the title, along with a "Paid for by" label. Note that the front section doesn't actually require any special denotation as being _paid for_ this property is determined across the entire page.
- Only display the badge on the first container of a paid front, and hide the badge on subsequent containers. This appears to be the behaviour used by Frontend, although most of these fronts only have one container anyway.
- A small change to the CSS of badges to prevent wide ones from breaking out of their containers at certain breakpoints.

This PR also adds a story showing how two of these sections would appear on a paid front. This feels like the easiest way to catch any visual regressions against these kind of sections in the future.

## Why?

In order to [support paid fronts](https://github.com/guardian/dotcom-rendering/issues/5945).

## Screenshots

| DCR Before      | DCR After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/8000415/98264ed2-83b9-4d46-a224-8555f1519ebc
[after]: https://github.com/guardian/dotcom-rendering/assets/8000415/0119d040-26fd-4d5e-95cd-d044199f246d

**DCR Before:**

https://github.com/guardian/dotcom-rendering/assets/8000415/8e778b63-e525-44bc-8b54-3ab9951ffcbd

**DCR After:**

https://github.com/guardian/dotcom-rendering/assets/8000415/e02037b9-faf1-4077-a7e0-012f0976b91a

**Frontend Reference:**

https://github.com/guardian/dotcom-rendering/assets/8000415/236c66a4-3b78-465b-9de0-497f5bfb764d


