### PR TITLE
Bump CMP 13.3.1

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -68,7 +68,7 @@
 		"@guardian/browserslist-config": "4.0.0",
 		"@guardian/cdk": "49.5.0",
 		"@guardian/commercial": "9.1.0",
-		"@guardian/consent-management-platform": "13.2.0",
+		"@guardian/consent-management-platform": "13.3.1",
 		"@guardian/core-web-vitals": "4.0.0",
 		"@guardian/discussion-rendering": "14.0.0",
 		"@guardian/eslint-config": "3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3566,7 +3566,12 @@
     web-vitals "^2.1.2"
     wolfy87-eventemitter "^5.2.9"
 
-"@guardian/consent-management-platform@13.2.0", "@guardian/consent-management-platform@^13.2.0":
+"@guardian/consent-management-platform@13.3.1":
+  version "13.3.1"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-13.3.1.tgz#66c5366f8d5210e50ca6fb63599f924cda4c3143"
+  integrity sha512-hQZgpax8s5xNhq46bsAbIYXoiv4T+52RM0FgphSRWiyj3jrsm2DxEu0R2x4Epg8EGFHmNQDj7GfXvJ5j89ihkQ==
+
+"@guardian/consent-management-platform@^13.2.0":
   version "13.2.0"
   resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-13.2.0.tgz#089dcd6b3b7883e281d8764ac7557d1a3a627ae5"
   integrity sha512-1ggVotJaJad2k7w1QAKffnxSRigEiU1ztWNxu0SncNvnsF90BJ8wMCTECsyp/xMhJFIm1DSVJyIucBzzc7VYRg==
@@ -3609,7 +3614,7 @@
     "@typescript-eslint/eslint-plugin" "5.46.1"
     "@typescript-eslint/parser" "5.46.1"
 
-"@guardian/libs@14.1.0":
+"@guardian/libs@14.1.0", "@guardian/libs@^14.0.0":
   version "14.1.0"
   resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-14.1.0.tgz#feac9cc5636639e45ab2a6e2fd4a3f29f7af9a70"
   integrity sha512-V/6ROWh0s8A6tJVFBMP9h9sb4L2SN98zSp84aLhBac4Ir1XJjG3kljAyB4uV1+341Amd+44QJGhB/D7roVsSfQ==
@@ -3618,11 +3623,6 @@
   version "10.1.1"
   resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-10.1.1.tgz#7048c365a68dda068f707d46c78979f430221963"
   integrity sha512-OdWReBHRWhdbErVmS15hihVzlkdU8DkKrjDsUIN0P8QZiF4twuzcU3qsPwto2UfibAwPkWqKkNwH1k8b6xNclA==
-
-"@guardian/libs@^14.0.0":
-  version "14.1.0"
-  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-14.1.0.tgz#feac9cc5636639e45ab2a6e2fd4a3f29f7af9a70"
-  integrity sha512-V/6ROWh0s8A6tJVFBMP9h9sb4L2SN98zSp84aLhBac4Ir1XJjG3kljAyB4uV1+341Amd+44QJGhB/D7roVsSfQ==
 
 "@guardian/prettier@3.0.0":
   version "3.0.0"


### PR DESCRIPTION
## What does this change?
Bump consent-management-platform 13.3.1

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
