### PR TITLE
Parse HTML for Textblockcomponent

### DIFF
--- a/dotcom-rendering/src/components/BlockquoteBlockComponent.tsx
+++ b/dotcom-rendering/src/components/BlockquoteBlockComponent.tsx
@@ -2,7 +2,7 @@ import { css, jsx } from '@emotion/react';
 import { body } from '@guardian/source-foundations';
 import type { ReactNode } from 'react';
 import { Fragment } from 'react';
-import { isElement, parseHtml } from '../lib/domUtils';
+import { getAttrs, isElement, parseHtml } from '../lib/domUtils';
 import { logger } from '../server/lib/logging';
 import type { Palette } from '../types/palette';
 import { QuoteIcon } from './QuoteIcon';
@@ -34,9 +34,6 @@ const quotedBlockquoteStyles = (palette: Palette) => css`
 	${baseBlockquoteStyles}
 	color: ${palette.text.blockquote};
 `;
-
-const getAttrs = (node: Node): NamedNodeMap | undefined =>
-	isElement(node) ? node.attributes : undefined;
 
 /**
  * Searches through the siblings of an element to determine if it's the first
@@ -82,7 +79,7 @@ const textElement =
 						: simpleBlockquoteStyles,
 				});
 			case 'A':
-				return jsx('A', {
+				return jsx('a', {
 					href: getAttrs(node)?.getNamedItem('href')?.value,
 					key,
 					children,
@@ -98,7 +95,7 @@ const textElement =
 				return text;
 			case 'BR':
 				// BR cannot accept children as it's a void element
-				return jsx('BR', {
+				return jsx('br', {
 					key,
 				});
 			case 'H2':
@@ -112,7 +109,7 @@ const textElement =
 			case 'SUP':
 			case 'S':
 			case 'I':
-				return jsx(node.nodeName, {
+				return jsx(node.nodeName.toLowerCase(), {
 					key,
 					children,
 				});

--- a/dotcom-rendering/src/lib/domUtils.ts
+++ b/dotcom-rendering/src/lib/domUtils.ts
@@ -7,3 +7,6 @@ export const parseHtml = (html: string): DocumentFragment =>
 export function isElement(node: Node): node is Element {
 	return node.nodeType === 1;
 }
+
+export const getAttrs = (node: Node): NamedNodeMap | undefined =>
+	isElement(node) ? node.attributes : undefined;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
This resolves 20% of the warnings on DCR. 
see [logs](https://logs.gutools.co.uk/s/dotcom/goto/a13dc1a0-7c8f-11ed-a4c5-21512d9bf308) 
```"RewrappedComponent called with isUnwrapped === false"``` this was due to no matching of the  ```<footer>``` and ```<ol>``` tags in the ```UnwrapHtml``` function.

See these prs for context: https://github.com/guardian/dotcom-rendering/pull/7672 and https://github.com/guardian/dotcom-rendering/pull/7650. 

This PR is a copy of https://github.com/guardian/dotcom-rendering/pull/7684 as was reverted due to missing the ```<footer>``` case. This is now accounted for with styling added for specificity.

## Why?

This resolves https://github.com/guardian/dotcom-rendering/issues/6798

This also fixes issues of the old code producing some unexpected and strange html e.g empty tags
![image](https://github.com/guardian/dotcom-rendering/assets/110032454/1af6b77e-2382-4659-aab9-5b9d754b51a9)


## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/110032454/236486925-49d615f5-5a37-480b-ad15-864aaa7f077f.png
[after]: https://user-images.githubusercontent.com/110032454/236486829-a3fe5311-37f3-4bf3-880d-47320f7da92e.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
