### PR TITLE
Add `width: 100%` to UL used in Fronts

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.stories.tsx
+++ b/dotcom-rendering/src/components/Card/Card.stories.tsx
@@ -973,52 +973,55 @@ export const WhenVideoWithPlayButton = () => {
 						showMainVideo={true}
 					/>
 				</LI>
-				<UL direction="column" showDivider={true}>
-					<LI padSides={true}>
-						<Card
-							{...basicCardProps}
-							format={{
-								display: ArticleDisplay.Standard,
-								design: ArticleDesign.Video,
-								theme: ArticlePillar.News,
-							}}
-							imagePosition="left"
-							mediaDuration={200}
-							mediaType="Video"
-							showMainVideo={true}
-						/>
-					</LI>
-					<LI padSides={true}>
-						<Card
-							{...basicCardProps}
-							format={{
-								display: ArticleDisplay.Standard,
-								design: ArticleDesign.Video,
-								theme: ArticlePillar.News,
-							}}
-							imagePosition="right"
-							mediaDuration={200}
-							mediaType="Video"
-							showMainVideo={true}
-						/>
-					</LI>
+				<LI percentage="50%">
+					<UL direction="column" showDivider={true}>
+						<LI padSides={true}>
+							<Card
+								{...basicCardProps}
+								format={{
+									display: ArticleDisplay.Standard,
+									design: ArticleDesign.Video,
+									theme: ArticlePillar.News,
+								}}
+								imagePosition="left"
+								mediaDuration={200}
+								mediaType="Video"
+								showMainVideo={true}
+							/>
+						</LI>
+						<LI padSides={true}>
+							<Card
+								{...basicCardProps}
+								format={{
+									display: ArticleDisplay.Standard,
+									design: ArticleDesign.Video,
+									theme: ArticlePillar.News,
+								}}
+								imagePosition="right"
+								mediaDuration={200}
+								mediaType="Video"
+								showMainVideo={true}
+							/>
+						</LI>
 
-					<LI padSides={true}>
-						<Card
-							{...basicCardProps}
-							format={{
-								display: ArticleDisplay.Standard,
-								design: ArticleDesign.Video,
-								theme: ArticlePillar.News,
-							}}
-							imagePosition="right"
-							mediaDuration={200}
-							mediaType="Video"
-							showMainVideo={true}
-						/>
-					</LI>
-				</UL>
+						<LI padSides={true}>
+							<Card
+								{...basicCardProps}
+								format={{
+									display: ArticleDisplay.Standard,
+									design: ArticleDesign.Video,
+									theme: ArticlePillar.News,
+								}}
+								imagePosition="right"
+								mediaDuration={200}
+								mediaType="Video"
+								showMainVideo={true}
+							/>
+						</LI>
+					</UL>
+				</LI>
 			</UL>
+
 			<UL direction="row" padBottom={true}>
 				<LI percentage={'66.666%'} padSides={true}>
 					<Card

--- a/dotcom-rendering/src/components/Card/components/UL.tsx
+++ b/dotcom-rendering/src/components/Card/components/UL.tsx
@@ -6,6 +6,7 @@ import type { DCRContainerPalette } from '../../../types/front';
 type Direction = 'row' | 'column' | 'row-reverse';
 
 const ulStyles = (direction: Direction) => css`
+	width: 100%;
 	position: relative;
 	display: flex;
 	flex-direction: ${direction};


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Adds `width: 100%` to the ULs used by Fronts containers.

## Why?

This ensures that cards in said container are stretched to fit the entire area that they're in.

Fixes #7932 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/21217225/de2bbe3c-bcf5-4726-a5c1-ef47fe16684b
[after]: https://github.com/guardian/dotcom-rendering/assets/21217225/5c79a596-7a12-438a-bf5d-ab3140584feb

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
