### PR TITLE
Handle true ratio of Immersive media on mobile

### DIFF
--- a/dotcom-rendering/src/components/Picture.tsx
+++ b/dotcom-rendering/src/components/Picture.tsx
@@ -288,7 +288,25 @@ export const Picture = ({
 		decideImageWidths({ role, format, isMainMedia }),
 	);
 
+	/** portrait if higher than 1 or landscape if lower than 1 */
 	const ratio = parseInt(height, 10) / parseInt(width, 10);
+
+	/**
+	 * Immersive MainMedia elements fill the height of the viewport, meaning on mobile
+	 * devices even though the viewport width is small, we'll need a larger image to
+	 * maintain quality. To solve this problem we're using the viewport height (vh) to
+	 * calculate width on portrait devices.
+
+	 * If either of these media queries match then the browser will choose an image from the
+	 * list of sources in srcset based on the viewport list. If the media query doesn't match
+	 * it continues checking using the standard sources underneath
+	 */
+	const sizes =
+		ratio >= 1
+			? // portrait or square
+			  '100vw'
+			: // landscape
+			  `${Math.round(100 / ratio)}vh`;
 
 	const fallbackSource = getFallbackSource(sources);
 
@@ -297,21 +315,10 @@ export const Picture = ({
 			{/* Immersive Main Media images get additional sources specifically for when in portrait orientation */}
 			{format.display === ArticleDisplay.Immersive && isMainMedia && (
 				<>
-					{/*
-						Immersive MainMedia elements fill the height of the viewport, meaning on mobile
-						devices even though the viewport width is small, we'll need a larger image to
-						maintain quality. To solve this problem we're using the viewport height (vh) to
-						calculate width. The value of 167vh relates to an assumed image ratio of 5:3
-						which is equal to 167 (viewport height) : 100 (viewport width)
-
-						If either of these media queries match then the browser will choose an image from the
-						list of sources in srcset based on the viewport list. If the media query doesn't match
-						it continues checking using the standard sources underneath
-					*/}
 					{/* High resolution (HDPI) portrait sources*/}
 					<source
 						media="(orientation: portrait) and (-webkit-min-device-pixel-ratio: 1.25), (orientation: portrait) and (min-resolution: 120dpi)"
-						sizes="167vh"
+						sizes={sizes}
 						srcSet={sources
 							.map(
 								(source) =>
@@ -322,7 +329,7 @@ export const Picture = ({
 					{/* Low resolution (MDPI) portrait sources*/}
 					<source
 						media="(orientation: portrait)"
-						sizes="167vh"
+						sizes={sizes}
 						srcSet={sources
 							.map(
 								(source) =>


### PR DESCRIPTION
## What does this change?

This fixes the requested size for portrait images so that they never request more than the viewport width.

## Why?

@paperboyo indicated that main media images can be of any ratio, including elongated portrait.

## Screenshots

No visual change (all immersive currently are 5:3)