### PR TITLE
Snaps `data-link-name`

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -363,7 +363,7 @@ export const Card = ({
 	});
 
 	if (snapData?.embedHtml) {
-		return <Snap snapData={snapData} />;
+		return <Snap snapData={snapData} dataLinkName={dataLinkName} />;
 	}
 
 	const image = getImage({

--- a/dotcom-rendering/src/components/Snap.tsx
+++ b/dotcom-rendering/src/components/Snap.tsx
@@ -9,9 +9,10 @@ const snapStyles = css`
 
 type Props = {
 	snapData?: DCRSnapType;
+	dataLinkName?: string;
 };
 
-export const Snap = ({ snapData }: Props) => {
+export const Snap = ({ snapData, dataLinkName }: Props) => {
 	if (snapData?.embedHtml === undefined) {
 		return <></>;
 	}
@@ -21,6 +22,7 @@ export const Snap = ({ snapData }: Props) => {
 			<div
 				css={[snapStyles]}
 				dangerouslySetInnerHTML={{ __html: snapData.embedHtml }}
+				data-link-name={dataLinkName}
 			/>
 			{snapData.embedJs ? (
 				<div>

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -297,7 +297,12 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 												collection.collectionType
 											}
 										>
-											<Snap snapData={trail.snapData} />
+											<Snap
+												snapData={trail.snapData}
+												dataLinkName={
+													trail.dataLinkName
+												}
+											/>
 										</Section>
 									</SnapCssSandbox>
 								)}

--- a/dotcom-rendering/src/lib/getDataLinkName.ts
+++ b/dotcom-rendering/src/lib/getDataLinkName.ts
@@ -1,16 +1,14 @@
 import { ArticleDesign, ArticleSpecial } from '@guardian/libs';
-import type { FEFrontCardStyle, FEFrontCardType } from '../types/front';
+import type { FEFrontCardStyle } from '../types/front';
 
 /**
  * TODO: missing "podcast"
  */
 const getLinkType = (
 	{ theme, design }: ArticleFormat,
-	cardType?: FEFrontCardType,
 	cardStyle?: FEFrontCardStyle,
 ): RichLinkCardType => {
-	if (cardType === 'LinkSnap' && cardStyle === 'ExternalLink')
-		return 'external';
+	if (cardStyle === 'ExternalLink') return 'external';
 
 	switch (theme) {
 		case ArticleSpecial.SpecialReport:
@@ -58,11 +56,10 @@ export const getDataLinkNameCard = (
 	format: ArticleFormat,
 	group: Group,
 	index: number,
-	cardType?: FEFrontCardType,
 	cardStyle?: FEFrontCardStyle,
 ): string =>
 	[
-		getLinkType(format, cardType, cardStyle),
+		getLinkType(format, cardStyle),
 		`group-${group}`,
 		`card-@${Math.max(index + 1, 1)}`,
 	].join(' | ');

--- a/dotcom-rendering/src/lib/getDataLinkName.ts
+++ b/dotcom-rendering/src/lib/getDataLinkName.ts
@@ -1,9 +1,17 @@
 import { ArticleDesign, ArticleSpecial } from '@guardian/libs';
+import type { FEFrontCardStyle, FEFrontCardType } from '../types/front';
 
 /**
- * TODO: missing "podcast" and "external"
+ * TODO: missing "podcast"
  */
-const getLinkType = ({ theme, design }: ArticleFormat): RichLinkCardType => {
+const getLinkType = (
+	{ theme, design }: ArticleFormat,
+	cardType?: FEFrontCardType,
+	cardStyle?: FEFrontCardStyle,
+): RichLinkCardType => {
+	if (cardType === 'LinkSnap' && cardStyle === 'ExternalLink')
+		return 'external';
+
 	switch (theme) {
 		case ArticleSpecial.SpecialReport:
 			return 'special-report';
@@ -50,9 +58,11 @@ export const getDataLinkNameCard = (
 	format: ArticleFormat,
 	group: Group,
 	index: number,
+	cardType?: FEFrontCardType,
+	cardStyle?: FEFrontCardStyle,
 ): string =>
 	[
-		getLinkType(format),
+		getLinkType(format, cardType, cardStyle),
 		`group-${group}`,
 		`card-@${Math.max(index + 1, 1)}`,
 	].join(' | ');

--- a/dotcom-rendering/src/model/enhanceCards.ts
+++ b/dotcom-rendering/src/model/enhanceCards.ts
@@ -206,7 +206,6 @@ export const enhanceCards = (
 			format,
 			group,
 			offset + index,
-			faciaCard.type,
 			faciaCard.card.cardStyle.type,
 		);
 

--- a/dotcom-rendering/src/model/enhanceCards.ts
+++ b/dotcom-rendering/src/model/enhanceCards.ts
@@ -201,7 +201,14 @@ export const enhanceCards = (
 		const group: Group = `${Number(faciaCard.card.group)}${
 			faciaCard.display.isBoosted ? '+' : ''
 		}`;
-		const dataLinkName = getDataLinkNameCard(format, group, offset + index);
+
+		const dataLinkName = getDataLinkNameCard(
+			format,
+			group,
+			offset + index,
+			faciaCard.type,
+			faciaCard.card.cardStyle.type,
+		);
 
 		const tags = faciaCard.properties.maybeContent?.tags.tags
 			? enhanceTags(faciaCard.properties.maybeContent.tags.tags)

--- a/dotcom-rendering/src/model/front-schema.json
+++ b/dotcom-rendering/src/model/front-schema.json
@@ -955,7 +955,7 @@
                                                     "type": "object",
                                                     "properties": {
                                                         "type": {
-                                                            "type": "string"
+                                                            "$ref": "#/definitions/FEFrontCardStyle"
                                                         }
                                                     },
                                                     "required": [
@@ -1154,7 +1154,7 @@
                                             "type": "object",
                                             "properties": {
                                                 "type": {
-                                                    "type": "string"
+                                                    "$ref": "#/definitions/FEFrontCardStyle"
                                                 }
                                             },
                                             "required": [
@@ -1162,7 +1162,7 @@
                                             ]
                                         },
                                         "type": {
-                                            "type": "string"
+                                            "$ref": "#/definitions/FEFrontCardType"
                                         }
                                     },
                                     "required": [
@@ -1658,7 +1658,7 @@
                                                     "type": "object",
                                                     "properties": {
                                                         "type": {
-                                                            "type": "string"
+                                                            "$ref": "#/definitions/FEFrontCardStyle"
                                                         }
                                                     },
                                                     "required": [
@@ -1857,7 +1857,7 @@
                                             "type": "object",
                                             "properties": {
                                                 "type": {
-                                                    "type": "string"
+                                                    "$ref": "#/definitions/FEFrontCardStyle"
                                                 }
                                             },
                                             "required": [
@@ -1865,7 +1865,7 @@
                                             ]
                                         },
                                         "type": {
-                                            "type": "string"
+                                            "$ref": "#/definitions/FEFrontCardType"
                                         }
                                     },
                                     "required": [
@@ -2361,7 +2361,7 @@
                                                     "type": "object",
                                                     "properties": {
                                                         "type": {
-                                                            "type": "string"
+                                                            "$ref": "#/definitions/FEFrontCardStyle"
                                                         }
                                                     },
                                                     "required": [
@@ -2560,7 +2560,7 @@
                                             "type": "object",
                                             "properties": {
                                                 "type": {
-                                                    "type": "string"
+                                                    "$ref": "#/definitions/FEFrontCardStyle"
                                                 }
                                             },
                                             "required": [
@@ -2568,7 +2568,7 @@
                                             ]
                                         },
                                         "type": {
-                                            "type": "string"
+                                            "$ref": "#/definitions/FEFrontCardType"
                                         }
                                     },
                                     "required": [
@@ -2891,6 +2891,33 @@
                 "logo",
                 "sponsorName"
             ]
+        },
+        "FEFrontCardStyle": {
+            "enum": [
+                "Analysis",
+                "Comment",
+                "DeadBlog",
+                "DefaultCardstyle",
+                "Editorial",
+                "ExternalLink",
+                "Feature",
+                "Letters",
+                "LiveBlog",
+                "Media",
+                "Review",
+                "SpecialReport",
+                "SpecialReportAlt"
+            ],
+            "type": "string"
+        },
+        "FEFrontCardType": {
+            "enum": [
+                "CuratedContent",
+                "LatestSnap",
+                "LinkSnap",
+                "SupportingCuratedContent"
+            ],
+            "type": "string"
         },
         "FEContainerType": {
             "enum": [

--- a/dotcom-rendering/src/model/front-schema.json
+++ b/dotcom-rendering/src/model/front-schema.json
@@ -1162,7 +1162,7 @@
                                             ]
                                         },
                                         "type": {
-                                            "$ref": "#/definitions/FEFrontCardType"
+                                            "type": "string"
                                         }
                                     },
                                     "required": [
@@ -1865,7 +1865,7 @@
                                             ]
                                         },
                                         "type": {
-                                            "$ref": "#/definitions/FEFrontCardType"
+                                            "type": "string"
                                         }
                                     },
                                     "required": [
@@ -2568,7 +2568,7 @@
                                             ]
                                         },
                                         "type": {
-                                            "$ref": "#/definitions/FEFrontCardType"
+                                            "type": "string"
                                         }
                                     },
                                     "required": [
@@ -2907,15 +2907,6 @@
                 "Review",
                 "SpecialReport",
                 "SpecialReportAlt"
-            ],
-            "type": "string"
-        },
-        "FEFrontCardType": {
-            "enum": [
-                "CuratedContent",
-                "LatestSnap",
-                "LinkSnap",
-                "SupportingCuratedContent"
             ],
             "type": "string"
         },

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -99,6 +99,27 @@ export type FEContainerPalette =
 	| 'BreakingPalette'
 	| 'SpecialReportAltPalette';
 
+export type FEFrontCardType =
+	| 'LinkSnap'
+	| 'LatestSnap'
+	| 'CuratedContent'
+	| 'SupportingCuratedContent';
+
+export type FEFrontCardStyle =
+	| 'SpecialReport'
+	| 'SpecialReportAlt'
+	| 'LiveBlog'
+	| 'DeadBlog'
+	| 'Feature'
+	| 'Editorial'
+	| 'Comment'
+	| 'Media'
+	| 'Analysis'
+	| 'Review'
+	| 'Letters'
+	| 'ExternalLink'
+	| 'DefaultCardstyle';
+
 export type DCRContainerPalette =
 	| 'EventPalette'
 	| 'SombreAltPalette'
@@ -217,7 +238,7 @@ export type FEFrontCard = {
 	card: {
 		id: string;
 		cardStyle: {
-			type: string;
+			type: FEFrontCardStyle;
 		};
 		webPublicationDateOption?: number;
 		lastModifiedOption?: number;
@@ -244,9 +265,9 @@ export type FEFrontCard = {
 	enriched?: FESnapType;
 	supportingContent?: FESupportingContent[];
 	cardStyle?: {
-		type: string;
+		type: FEFrontCardStyle;
 	};
-	type: string;
+	type: FEFrontCardType;
 };
 
 export type DCRFrontCard = {

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -99,12 +99,6 @@ export type FEContainerPalette =
 	| 'BreakingPalette'
 	| 'SpecialReportAltPalette';
 
-export type FEFrontCardType =
-	| 'LinkSnap'
-	| 'LatestSnap'
-	| 'CuratedContent'
-	| 'SupportingCuratedContent';
-
 export type FEFrontCardStyle =
 	| 'SpecialReport'
 	| 'SpecialReportAlt'
@@ -267,7 +261,7 @@ export type FEFrontCard = {
 	cardStyle?: {
 		type: FEFrontCardStyle;
 	};
-	type: FEFrontCardType;
+	type: string;
 };
 
 export type DCRFrontCard = {


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Fixes `data-link-name` for snaps.

## Why?
Ophan consumes it.

## Screenshots

| frontend      | DCR after      |
| ----------- | ---------- |
| <img width="888" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/19683595/0e5f2e37-ec5f-4c0b-a5f8-63355ef86c7c"> | ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/f500e51a-4ad3-4b97-96da-145067405acc) |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
