### PR TITLE
fix(FrontLayout): add key prop to fragments

### DIFF
--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -15,6 +15,7 @@ import {
 } from '@guardian/source-foundations';
 import { Hide } from '@guardian/source-react-components';
 import { StraightLines } from '@guardian/source-react-components-development-kitchen';
+import { Fragment } from 'react';
 import { AdSlot } from '../components/AdSlot';
 import { CPScottHeader } from '../components/CPScottHeader';
 import { DecideContainer } from '../components/DecideContainer';
@@ -280,7 +281,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 
 					if (collection.collectionType === 'fixed/thrasher') {
 						return (
-							<>
+							<Fragment key={ophanName}>
 								{!!trail.embedUri && (
 									<SnapCssSandbox snapData={trail.snapData}>
 										<Section
@@ -310,7 +311,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 									format.display,
 									mobileAdPositions,
 								)}
-							</>
+							</Fragment>
 						);
 					}
 
@@ -423,9 +424,8 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 					}
 
 					return (
-						<>
+						<Fragment key={ophanName}>
 							<FrontSection
-								key={ophanName}
 								title={collection.displayName}
 								description={collection.description}
 								showTopBorder={index > 0}
@@ -489,7 +489,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 								format.display,
 								mobileAdPositions,
 							)}
-						</>
+						</Fragment>
 					);
 				})}
 			</main>


### PR DESCRIPTION
## What does this change?

Add `key` prop to `Fragment`s

## Why?

We get errors from the server. [React needs `key` properties for elements in an array](https://react.dev/learn/rendering-lists#why-does-react-need-keys).

## Screenshots

<img width="903" alt="JSX elements directly inside a map() call always need keys!" src="https://github.com/guardian/dotcom-rendering/assets/76776/f4ba4861-0ff5-4dfb-9cc9-0e16e8cbc25a">