### PR TITLE
Update video card design

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -463,8 +463,7 @@ export const Card = ({
 							/>
 						) : null}
 						{format.design === ArticleDesign.Gallery ||
-						format.design === ArticleDesign.Audio ||
-						format.design === ArticleDesign.Video ? (
+						format.design === ArticleDesign.Audio ? (
 							<MediaMeta
 								containerPalette={containerPalette}
 								format={format}

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -242,7 +242,7 @@ const decidePlayableMainMedia = (
 	showMainVideo: boolean | undefined,
 	design: ArticleDesign,
 ) => {
-	if (!!showMainVideo) return true;
+	if (showMainVideo) return true;
 	if (design === ArticleDesign.Video) return true;
 	return false;
 };

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -416,7 +416,10 @@ export const Card = ({
 						)}
 
 						{mediaDuration !== undefined && mediaDuration > 0 && (
-							<MediaDuration mediaDuration={mediaDuration} />
+							<MediaDuration
+								mediaDuration={mediaDuration}
+								imagePositionOnMobile={imagePositionOnMobile}
+							/>
 						)}
 					</ImageWrapper>
 				)}

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -42,6 +42,7 @@ import type {
 } from './components/ImageWrapper';
 import { ImageWrapper } from './components/ImageWrapper';
 import { TrailTextWrapper } from './components/TrailTextWrapper';
+import { MediaDuration } from '../MediaDuration';
 
 export type Props = {
 	linkTo: string;
@@ -412,6 +413,10 @@ export const Card = ({
 						)}
 						{image.type === 'crossword' && (
 							<img src={image.src} alt="" />
+						)}
+
+						{mediaDuration !== undefined && mediaDuration > 0 && (
+							<MediaDuration mediaDuration={mediaDuration} />
 						)}
 					</ImageWrapper>
 				)}

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -20,6 +20,7 @@ import { CardPicture } from '../CardPicture';
 import { Hide } from '../Hide';
 import { Island } from '../Island';
 import { LatestLinks } from '../LatestLinks.importable';
+import { MediaDuration } from '../MediaDuration';
 import { MediaMeta } from '../MediaMeta';
 import { Slideshow } from '../Slideshow';
 import { Snap } from '../Snap';
@@ -42,7 +43,6 @@ import type {
 } from './components/ImageWrapper';
 import { ImageWrapper } from './components/ImageWrapper';
 import { TrailTextWrapper } from './components/TrailTextWrapper';
-import { MediaDuration } from '../MediaDuration';
 
 export type Props = {
 	linkTo: string;

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -418,6 +418,7 @@ export const Card = ({
 						{mediaDuration !== undefined && mediaDuration > 0 && (
 							<MediaDuration
 								mediaDuration={mediaDuration}
+								imagePosition={imagePosition}
 								imagePositionOnMobile={imagePositionOnMobile}
 							/>
 						)}

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -233,6 +233,20 @@ const decideSublinkPosition = (
 	return alignment === 'vertical' ? 'inner' : 'outer';
 };
 
+/**
+ * This function contains the business logic that determines whether the article contains a
+ * playable main media. It is used to determine which iconography should be displayed on the card.
+ *
+ */
+const decidePlayableMainMedia = (
+	showMainVideo: boolean | undefined,
+	design: ArticleDesign,
+) => {
+	if (!!showMainVideo) return true;
+	if (design === ArticleDesign.Video) return true;
+	return false;
+};
+
 export const Card = ({
 	linkTo,
 	format,
@@ -350,13 +364,17 @@ export const Card = ({
 		);
 	}
 
+	const isPlayableMainMedia = decidePlayableMainMedia(
+		showMainVideo,
+		format.design,
+	);
+
 	const image = getImage({
 		imageUrl,
 		avatarUrl,
 		isCrossword,
 		slideshowImages,
 	});
-
 	return (
 		<CardWrapper
 			format={format}
@@ -382,11 +400,7 @@ export const Card = ({
 						imageType={image.type}
 						imagePosition={imagePosition}
 						imagePositionOnMobile={imagePositionOnMobile}
-						showPlayIcon={
-							(showMainVideo ||
-								format.design === ArticleDesign.Video) ??
-							false
-						}
+						showPlayIcon={isPlayableMainMedia}
 					>
 						{image.type === 'slideshow' &&
 							image.slideshowImages && (
@@ -419,13 +433,17 @@ export const Card = ({
 							<img src={image.src} alt="" />
 						)}
 
-						{mediaDuration !== undefined && mediaDuration > 0 && (
-							<MediaDuration
-								mediaDuration={mediaDuration}
-								imagePosition={imagePosition}
-								imagePositionOnMobile={imagePositionOnMobile}
-							/>
-						)}
+						{isPlayableMainMedia &&
+							mediaDuration !== undefined &&
+							mediaDuration > 0 && (
+								<MediaDuration
+									mediaDuration={mediaDuration}
+									imagePosition={imagePosition}
+									imagePositionOnMobile={
+										imagePositionOnMobile
+									}
+								/>
+							)}
 					</ImageWrapper>
 				)}
 				<ContentWrapper

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -382,7 +382,11 @@ export const Card = ({
 						imageType={image.type}
 						imagePosition={imagePosition}
 						imagePositionOnMobile={imagePositionOnMobile}
-						showPlayIcon={showMainVideo ?? false}
+						showPlayIcon={
+							(showMainVideo ||
+								format.design === ArticleDesign.Video) ??
+							false
+						}
 					>
 						{image.type === 'slideshow' &&
 							image.slideshowImages && (

--- a/dotcom-rendering/src/components/Card/components/PlayIcon.tsx
+++ b/dotcom-rendering/src/components/Card/components/PlayIcon.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { brandAlt, from } from '@guardian/source-foundations';
+import { from, palette } from '@guardian/source-foundations';
 import { SvgMediaControlsPlay } from '@guardian/source-react-components';
 import type { ImagePositionType, ImageSizeType } from './ImageWrapper';
 
@@ -23,7 +23,7 @@ const iconStyles = (
 	size: PlayButtonSize,
 	sizeOnMobile: Extract<PlayButtonSize, 'small' | 'large'>,
 ) => css`
-	background-color: ${brandAlt[400]};
+	background-color: rgba(18, 18, 18, 0.6);
 	border-radius: 50%;
 	width: ${sizes[sizeOnMobile].button}px;
 	height: ${sizes[sizeOnMobile].button}px;
@@ -38,6 +38,7 @@ const iconStyles = (
 
 	svg {
 		/* Visual centering */
+		fill: ${palette.neutral[100]};
 		transform: translateX(1px);
 		width: ${sizes[sizeOnMobile].icon}px;
 		height: ${sizes[sizeOnMobile].icon}px;

--- a/dotcom-rendering/src/components/Card/components/PlayIcon.tsx
+++ b/dotcom-rendering/src/components/Card/components/PlayIcon.tsx
@@ -6,10 +6,10 @@ import type { ImagePositionType, ImageSizeType } from './ImageWrapper';
 type PlayButtonSize = keyof typeof sizes;
 
 const sizes = {
-	small: { button: 28, icon: 26 },
-	medium: { button: 44, icon: 36 },
-	large: { button: 48, icon: 40 },
-	xlarge: { button: 60, icon: 54 },
+	small: { button: 40, icon: 32 },
+	medium: { button: 80, icon: 72 },
+	large: { button: 80, icon: 72 },
+	xlarge: { button: 80, icon: 72 },
 } as const satisfies Record<string, { button: number; icon: number }>;
 
 const iconWrapperStyles = css`

--- a/dotcom-rendering/src/components/Card/components/PlayIcon.tsx
+++ b/dotcom-rendering/src/components/Card/components/PlayIcon.tsx
@@ -15,8 +15,9 @@ const sizes = {
 const iconWrapperStyles = css`
 	display: flex; /* Fixes the div mis-sizing itself */
 	position: absolute;
-	bottom: 4px;
-	left: 4px;
+	top: 50%;
+	left: 50%;
+	transform: translate(-50%, -50%);
 `;
 
 const iconStyles = (

--- a/dotcom-rendering/src/components/MediaDuration.tsx
+++ b/dotcom-rendering/src/components/MediaDuration.tsx
@@ -38,11 +38,16 @@ export function secondsToDuration(secs?: number): string {
 
 export const MediaDuration = ({
 	mediaDuration,
+	imagePosition,
 	imagePositionOnMobile,
 }: {
 	mediaDuration: number;
+	imagePosition?: ImagePositionType;
 	imagePositionOnMobile?: ImagePositionType;
 }) => {
+	if (imagePosition === 'left') {
+		return null;
+	}
 	if (imagePositionOnMobile === 'left')
 		return (
 			<Hide until="tablet">

--- a/dotcom-rendering/src/components/MediaDuration.tsx
+++ b/dotcom-rendering/src/components/MediaDuration.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react';
 import { space, textSans } from '@guardian/source-foundations';
 import { Hide } from '@guardian/source-react-components';
+import { ImagePositionType } from './Card/components/ImageWrapper';
 
 const durationStyles = css`
 	position: absolute;

--- a/dotcom-rendering/src/components/MediaDuration.tsx
+++ b/dotcom-rendering/src/components/MediaDuration.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
-import { palette, space, textSans } from '@guardian/source-foundations';
+import { space, textSans } from '@guardian/source-foundations';
+import { Hide } from '@guardian/source-react-components';
 
 const durationStyles = css`
 	position: absolute;
@@ -9,7 +10,7 @@ const durationStyles = css`
 	width: fit-content;
 	padding: ${space[1]}px ${space[3]}px;
 	border-radius: ${space[3]}px;
-	color: ${palette.neutral[100]};
+	color: white;
 	${textSans.xxsmall({ fontWeight: `bold` })}
 `;
 
@@ -35,8 +36,25 @@ export function secondsToDuration(secs?: number): string {
 	return duration.join(':');
 }
 
-export const MediaDuration = ({ mediaDuration }: { mediaDuration: number }) => (
-	<div css={durationStyles}>
-		<p>{secondsToDuration(mediaDuration)}</p>
-	</div>
-);
+export const MediaDuration = ({
+	mediaDuration,
+	imagePositionOnMobile,
+}: {
+	mediaDuration: number;
+	imagePositionOnMobile?: ImagePositionType;
+}) => {
+	if (imagePositionOnMobile === 'left')
+		return (
+			<Hide until="tablet">
+				<div css={durationStyles}>
+					<p>{secondsToDuration(mediaDuration)}</p>
+				</div>
+			</Hide>
+		);
+
+	return (
+		<div css={durationStyles}>
+			<p>{secondsToDuration(mediaDuration)}</p>
+		</div>
+	);
+};

--- a/dotcom-rendering/src/components/MediaDuration.tsx
+++ b/dotcom-rendering/src/components/MediaDuration.tsx
@@ -1,15 +1,15 @@
 import { css } from '@emotion/react';
-import { textSans } from '@guardian/source-foundations';
+import { palette, space, textSans } from '@guardian/source-foundations';
 
 const durationStyles = css`
 	position: absolute;
-	top: 8px;
-	right: 8px;
+	top: ${space[2]}px;
+	right: ${space[2]}px;
 	background-color: rgba(0, 0, 0, 0.7);
 	width: fit-content;
-	padding: 6px 12px;
-	border-radius: 18px;
-	color: white;
+	padding: ${space[1]}px ${space[3]}px;
+	border-radius: ${space[3]}px;
+	color: ${palette.neutral[100]};
 	${textSans.xxsmall({ fontWeight: `bold` })}
 `;
 

--- a/dotcom-rendering/src/components/MediaDuration.tsx
+++ b/dotcom-rendering/src/components/MediaDuration.tsx
@@ -1,0 +1,42 @@
+import { css } from '@emotion/react';
+import { textSans } from '@guardian/source-foundations';
+
+const durationStyles = css`
+	position: absolute;
+	top: 8px;
+	right: 8px;
+	background-color: rgba(0, 0, 0, 0.7);
+	width: fit-content;
+	padding: 6px 12px;
+	border-radius: 18px;
+	color: white;
+	${textSans.xxsmall({ fontWeight: `bold` })}
+`;
+
+export function secondsToDuration(secs?: number): string {
+	if (typeof secs === `undefined` || secs === 0) {
+		return ``;
+	}
+	const seconds = Number(secs);
+	const h = Math.floor(seconds / 3600);
+	const m = Math.floor((seconds % 3600) / 60);
+	const s = Math.floor((seconds % 3600) % 60);
+
+	const duration = [];
+	if (h > 0) {
+		duration.push(h);
+	}
+	if (h > 0 && m < 10) duration.push(`0${m}`); // e.g 1:01:11
+	else duration.push(m); // supports 0:59
+	if (s > 0) {
+		if (s < 10) duration.push(`0${s}`);
+		else duration.push(s);
+	}
+	return duration.join(':');
+}
+
+export const MediaDuration = ({ mediaDuration }: { mediaDuration: number }) => (
+	<div css={durationStyles}>
+		<p>{secondsToDuration(mediaDuration)}</p>
+	</div>
+);

--- a/dotcom-rendering/src/components/MediaMeta.test.tsx
+++ b/dotcom-rendering/src/components/MediaMeta.test.tsx
@@ -1,4 +1,4 @@
-import { secondsToDuration } from './MediaMeta';
+import { secondsToDuration } from './MediaDuration';
 
 describe(`MediaText`, () => {
 	it(`converts from a number of seconds to a duration string`, () => {

--- a/dotcom-rendering/src/components/MediaMeta.tsx
+++ b/dotcom-rendering/src/components/MediaMeta.tsx
@@ -59,7 +59,6 @@ const MediaIcon = ({
 	palette: Palette;
 	hasKicker: boolean;
 }) => {
-	if (mediaType == 'Video') return null;
 	return (
 		<span css={iconWrapperStyles(palette, hasKicker)}>
 			<Icon mediaType={mediaType} />

--- a/dotcom-rendering/src/components/MediaMeta.tsx
+++ b/dotcom-rendering/src/components/MediaMeta.tsx
@@ -1,5 +1,4 @@
 import { css } from '@emotion/react';
-import { textSans } from '@guardian/source-foundations';
 import { SvgAudio, SvgCamera } from '@guardian/source-react-components';
 import { decidePalette } from '../lib/decidePalette';
 import type { DCRContainerPalette } from '../types/front';
@@ -34,38 +33,11 @@ const iconWrapperStyles = (palette: Palette, hasKicker: boolean) => css`
 	}
 `;
 
-const durationStyles = (palette: Palette, hasKicker: boolean) => css`
-	color: ${hasKicker ? palette.text.cardKicker : palette.text.cardFooter};
-	${textSans.xxsmall({ fontWeight: `bold` })}
-`;
-
 const wrapperStyles = css`
 	display: flex;
 	align-items: center;
 	margin-top: 4px;
 `;
-
-export function secondsToDuration(secs?: number): string {
-	if (typeof secs === `undefined` || secs === 0) {
-		return ``;
-	}
-	const seconds = Number(secs);
-	const h = Math.floor(seconds / 3600);
-	const m = Math.floor((seconds % 3600) / 60);
-	const s = Math.floor((seconds % 3600) % 60);
-
-	const duration = [];
-	if (h > 0) {
-		duration.push(h);
-	}
-	if (h > 0 && m < 10) duration.push(`0${m}`); // e.g 1:01:11
-	else duration.push(m); // supports 0:59
-	if (s > 0) {
-		if (s < 10) duration.push(`0${s}`);
-		else duration.push(s);
-	}
-	return duration.join(':');
-}
 
 const Icon = ({ mediaType }: { mediaType: MediaType }) => {
 	switch (mediaType) {
@@ -95,23 +67,8 @@ const MediaIcon = ({
 	);
 };
 
-const MediaDuration = ({
-	mediaDuration,
-	palette,
-	hasKicker,
-}: {
-	mediaDuration: number;
-	palette: Palette;
-	hasKicker: boolean;
-}) => (
-	<p css={durationStyles(palette, hasKicker)}>
-		{secondsToDuration(mediaDuration)}
-	</p>
-);
-
 export const MediaMeta = ({
 	mediaType,
-	mediaDuration,
 	format,
 	containerPalette,
 	hasKicker,
@@ -124,14 +81,6 @@ export const MediaMeta = ({
 				palette={palette}
 				hasKicker={hasKicker}
 			/>
-			&nbsp;
-			{mediaDuration !== undefined && mediaDuration > 0 && (
-				<MediaDuration
-					mediaDuration={mediaDuration}
-					palette={palette}
-					hasKicker={hasKicker}
-				/>
-			)}
 		</div>
 	);
 };

--- a/dotcom-rendering/src/components/MediaMeta.tsx
+++ b/dotcom-rendering/src/components/MediaMeta.tsx
@@ -1,10 +1,6 @@
 import { css } from '@emotion/react';
 import { textSans } from '@guardian/source-foundations';
-import {
-	SvgAudio,
-	SvgCamera,
-	SvgVideo,
-} from '@guardian/source-react-components';
+import { SvgAudio, SvgCamera } from '@guardian/source-react-components';
 import { decidePalette } from '../lib/decidePalette';
 import type { DCRContainerPalette } from '../types/front';
 import type { Palette } from '../types/palette';
@@ -76,7 +72,7 @@ const Icon = ({ mediaType }: { mediaType: MediaType }) => {
 		case 'Gallery':
 			return <SvgCamera />;
 		case 'Video':
-			return <SvgVideo />;
+			return null;
 		case 'Audio':
 			return <SvgAudio />;
 	}
@@ -90,11 +86,14 @@ const MediaIcon = ({
 	mediaType: MediaType;
 	palette: Palette;
 	hasKicker: boolean;
-}) => (
-	<span css={iconWrapperStyles(palette, hasKicker)}>
-		<Icon mediaType={mediaType} />
-	</span>
-);
+}) => {
+	if (mediaType == 'Video') return null;
+	return (
+		<span css={iconWrapperStyles(palette, hasKicker)}>
+			<Icon mediaType={mediaType} />
+		</span>
+	);
+};
 
 const MediaDuration = ({
 	mediaDuration,


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
This updates the video card design. This includes 

- removing the pillar colour from the duration and play button
- positioning the duration top right (this is hidden on mobile on left aligned images)
- center-positioning the play button
- increasing the size of the play button

## Why?
This is part of a larger body of work, with new designs for videos across the whole site aimed at reducing the noise of video cards.

## Screenshots
desktop
| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

| Before      | After      |
| ----------- | ---------- |
| ![before-d][] | ![after-d][] |

mobile
| Before      | After      |
| ----------- | ---------- |
| ![before-m][] | ![after-m][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/20416599/b39e50c4-0276-4d6c-a1cf-ccde1451268b
[after]: https://github.com/guardian/dotcom-rendering/assets/20416599/23c96c03-5aa0-4c89-912b-e933e2b40415

[before-d]: https://github.com/guardian/dotcom-rendering/assets/20416599/c04bd6ba-9612-4f0a-a13a-350d8a830a45
[after-d]: https://github.com/guardian/dotcom-rendering/assets/20416599/fe4af412-236d-42aa-82fe-5291b1ba4b74

[before-m]: https://github.com/guardian/dotcom-rendering/assets/20416599/a58628fc-db20-4746-b2c3-dbff90641c01
[after-m]: https://github.com/guardian/dotcom-rendering/assets/20416599/e01ed731-a24b-4944-8171-081901b553b7



<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
