### PR TITLE
Fix mpu inline ad slots `data-link-name`

### DIFF
--- a/dotcom-rendering/src/components/AdSlot.tsx
+++ b/dotcom-rendering/src/components/AdSlot.tsx
@@ -21,6 +21,7 @@ type InlineProps = {
 	index: number;
 	shouldHideReaderRevenue?: boolean;
 	isPaidContent?: boolean;
+	MPUIndex?: number;
 };
 
 type NonInlineProps = {
@@ -29,6 +30,7 @@ type NonInlineProps = {
 	index?: never;
 	shouldHideReaderRevenue?: boolean;
 	isPaidContent?: boolean;
+	MPUIndex?: number;
 };
 
 /**
@@ -265,6 +267,7 @@ export const AdSlot = ({
 	display,
 	isPaidContent = false,
 	index,
+	MPUIndex,
 }: Props) => {
 	switch (position) {
 		case 'right':
@@ -452,7 +455,9 @@ export const AdSlot = ({
 			);
 		}
 		case 'inline': {
-			const advertId = `inline${index}`;
+			const advertId = `inline${
+				MPUIndex != undefined ? MPUIndex : index
+			}`;
 			return (
 				<div className="ad-slot-container" css={[adStyles]}>
 					<div

--- a/dotcom-rendering/src/components/DecideContainer.tsx
+++ b/dotcom-rendering/src/components/DecideContainer.tsx
@@ -30,6 +30,7 @@ type Props = {
 	containerType: DCRContainerType;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
+	MPUIndex?: number;
 	renderAds: boolean;
 };
 
@@ -41,6 +42,7 @@ export const DecideContainer = ({
 	containerPalette,
 	showAge,
 	renderAds,
+	MPUIndex,
 }: Props) => {
 	switch (containerType) {
 		case 'dynamic/fast':
@@ -68,6 +70,7 @@ export const DecideContainer = ({
 					index={index}
 					renderAds={renderAds}
 					trails={trails}
+					MPUIndex={MPUIndex}
 				/>
 			);
 		case 'dynamic/package':
@@ -102,6 +105,7 @@ export const DecideContainer = ({
 					showAge={showAge}
 					index={index}
 					renderAds={renderAds}
+					MPUIndex={MPUIndex}
 				/>
 			);
 		case 'fixed/small/slow-III':
@@ -160,6 +164,7 @@ export const DecideContainer = ({
 					showAge={showAge}
 					renderAds={renderAds}
 					index={index}
+					MPUIndex={MPUIndex}
 				/>
 			);
 		case 'fixed/medium/fast-XII':

--- a/dotcom-rendering/src/components/DynamicSlowMPU.tsx
+++ b/dotcom-rendering/src/components/DynamicSlowMPU.tsx
@@ -24,6 +24,7 @@ type Props = {
 	groupedTrails: DCRGroupedTrails;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
+	MPUIndex?: number;
 	index: number;
 	renderAds: boolean;
 	trails: DCRFrontCard[];
@@ -38,11 +39,13 @@ const Card33_ColumnOfThree33_Ad33 = ({
 	cards,
 	containerPalette,
 	showAge,
+	MPUIndex,
 	index,
 }: {
 	cards: DCRFrontCard[];
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
+	MPUIndex?: number;
 	index: number;
 }) => {
 	const card33 = cards.slice(0, 1);
@@ -79,7 +82,11 @@ const Card33_ColumnOfThree33_Ad33 = ({
 			</LI>
 			<LI percentage="33.333%" padSides={true} showDivider={true}>
 				<Hide until="tablet">
-					<AdSlot position="inline" index={index} />
+					<AdSlot
+						position="inline"
+						index={index}
+						MPUIndex={MPUIndex}
+					/>
 				</Hide>
 			</LI>
 		</UL>
@@ -95,11 +102,13 @@ const ColumnOfThree50_Ad50 = ({
 	cards,
 	containerPalette,
 	showAge,
+	MPUIndex,
 	index,
 }: {
 	cards: DCRFrontCard[];
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
+	MPUIndex?: number;
 	index: number;
 }) => {
 	const cards50 = cards.slice(0, 3);
@@ -121,7 +130,11 @@ const ColumnOfThree50_Ad50 = ({
 			</LI>
 			<LI percentage="50%" padSides={true} showDivider={true}>
 				<Hide until="tablet">
-					<AdSlot position="inline" index={index} />
+					<AdSlot
+						position="inline"
+						index={index}
+						MPUIndex={MPUIndex}
+					/>
 				</Hide>
 			</LI>
 		</UL>
@@ -132,6 +145,7 @@ type MPUProps = {
 	groupedTrails: DCRGroupedTrails;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
+	MPUIndex?: number;
 	index: number;
 };
 
@@ -140,6 +154,7 @@ const MPUSlice = ({
 	containerPalette,
 	showAge,
 	index,
+	MPUIndex,
 }: MPUProps) => {
 	let layout:
 		| 'noBigs'
@@ -200,6 +215,7 @@ const MPUSlice = ({
 					containerPalette={containerPalette}
 					showAge={showAge}
 					index={index}
+					MPUIndex={MPUIndex}
 				/>
 			);
 		}
@@ -216,6 +232,7 @@ const MPUSlice = ({
 						containerPalette={containerPalette}
 						showAge={showAge}
 						index={index}
+						MPUIndex={MPUIndex}
 					/>
 				</>
 			);
@@ -233,6 +250,7 @@ const MPUSlice = ({
 						containerPalette={containerPalette}
 						showAge={showAge}
 						index={index}
+						MPUIndex={MPUIndex}
 					/>
 				</>
 			);
@@ -250,6 +268,7 @@ const MPUSlice = ({
 						containerPalette={containerPalette}
 						showAge={showAge}
 						index={index}
+						MPUIndex={MPUIndex}
 					/>
 				</>
 			);
@@ -267,6 +286,7 @@ const MPUSlice = ({
 						containerPalette={containerPalette}
 						showAge={showAge}
 						index={index}
+						MPUIndex={MPUIndex}
 					/>
 				</>
 			);
@@ -325,6 +345,7 @@ export const DynamicSlowMPU = ({
 	index,
 	renderAds,
 	trails,
+	MPUIndex,
 }: Props) => {
 	return renderAds ? (
 		<MPUSlice
@@ -332,6 +353,7 @@ export const DynamicSlowMPU = ({
 			containerPalette={containerPalette}
 			showAge={showAge}
 			index={index}
+			MPUIndex={MPUIndex}
 		/>
 	) : (
 		<NonMPUSlice

--- a/dotcom-rendering/src/components/FixedMediumSlowXIIMPU.tsx
+++ b/dotcom-rendering/src/components/FixedMediumSlowXIIMPU.tsx
@@ -14,6 +14,7 @@ type Props = {
 	trails: DCRFrontCard[];
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
+	MPUIndex?: number;
 	index: number;
 	renderAds: boolean;
 };
@@ -22,6 +23,7 @@ type MPUSliceProps = {
 	trails: DCRFrontCard[];
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
+	MPUIndex?: number;
 	index: number;
 };
 
@@ -88,6 +90,7 @@ const ThreeColumnSliceWithAdSlot = ({
 	trails,
 	containerPalette,
 	showAge,
+	MPUIndex,
 	index,
 }: MPUSliceProps) => {
 	return (
@@ -131,7 +134,11 @@ const ThreeColumnSliceWithAdSlot = ({
 			</LI>
 			<LI percentage="33.333%" padSides={true} showDivider={true}>
 				<Hide until="tablet">
-					<AdSlot position="inline" index={index} />
+					<AdSlot
+						position="inline"
+						index={index}
+						MPUIndex={MPUIndex}
+					/>
 				</Hide>
 			</LI>
 		</UL>
@@ -146,6 +153,7 @@ export const FixedMediumSlowXIIMPU = ({
 	trails,
 	containerPalette,
 	showAge,
+	MPUIndex,
 	index,
 	renderAds,
 }: Props) => {
@@ -165,6 +173,7 @@ export const FixedMediumSlowXIIMPU = ({
 					containerPalette={containerPalette}
 					showAge={showAge}
 					index={index}
+					MPUIndex={MPUIndex}
 				/>
 			) : (
 				/**

--- a/dotcom-rendering/src/components/FixedSmallSlowVMPU.tsx
+++ b/dotcom-rendering/src/components/FixedSmallSlowVMPU.tsx
@@ -13,6 +13,7 @@ type Props = {
 	trails: DCRFrontCard[];
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
+	MPUIndex?: number;
 	index: number;
 	renderAds: boolean;
 };
@@ -21,6 +22,7 @@ export const FixedSmallSlowVMPU = ({
 	trails,
 	containerPalette,
 	showAge,
+	MPUIndex,
 	index,
 	renderAds,
 }: Props) => {
@@ -63,7 +65,11 @@ export const FixedSmallSlowVMPU = ({
 					containerPalette={containerPalette}
 				>
 					<Hide until="tablet">
-						<AdSlot position="inline" index={index} />
+						<AdSlot
+							position="inline"
+							index={index}
+							MPUIndex={MPUIndex}
+						/>
 					</Hide>
 				</LI>
 			</UL>

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -37,6 +37,7 @@ import { decidePalette } from '../lib/decidePalette';
 import {
 	getMerchHighPosition,
 	getMobileAdPositions,
+	getMPUAdsPositions,
 } from '../lib/getAdPositions';
 import type { NavType } from '../model/extract-nav';
 import type { DCRCollectionType, DCRFrontType } from '../types/front';
@@ -422,6 +423,10 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 						);
 					}
 
+					const MPUAdsPositions = getMPUAdsPositions(
+						front.pressedPage.collections,
+					);
+
 					return (
 						<>
 							<FrontSection
@@ -478,6 +483,9 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 										collection.displayName === 'Headlines'
 									}
 									renderAds={renderAds}
+									MPUIndex={
+										MPUAdsPositions.indexOf(index) + 1
+									}
 								/>
 							</FrontSection>
 							{decideAdSlot(

--- a/dotcom-rendering/src/lib/getAdPositions.test.ts
+++ b/dotcom-rendering/src/lib/getAdPositions.test.ts
@@ -1,5 +1,5 @@
 import type { DCRCollectionType } from '../types/front';
-import { getMobileAdPositions } from './getAdPositions';
+import { getMobileAdPositions, getMPUAdsPositions } from './getAdPositions';
 
 const defaultTestCollections: Pick<DCRCollectionType, 'collectionType'>[] = [
 	...Array<number>(12),
@@ -209,5 +209,30 @@ describe('Mobile Ads', () => {
 		);
 
 		expect(mobileAdPositions).toEqual([1, 4, 6, 8, 10, 12]);
+	});
+});
+
+describe('MPU Ads', () => {
+	it('should return a list of the MPU ads/containers positions', () => {
+		const testCollections: Pick<DCRCollectionType, 'collectionType'>[] = [
+			{ collectionType: 'fixed/small/slow-IV' },
+			{ collectionType: 'fixed/medium/slow-VI' },
+			{ collectionType: 'fixed/small/slow-V-third' },
+			{ collectionType: 'fixed/medium/slow-XII-mpu' },
+			{ collectionType: 'fixed/medium/fast-XII' },
+			{ collectionType: 'fixed/small/slow-V-third' },
+			{ collectionType: 'dynamic/slow-mpu' },
+			{ collectionType: 'fixed/medium/fast-XI' },
+			{ collectionType: 'fixed/small/slow-III' },
+			{ collectionType: 'fixed/small/slow-V-mpu' },
+			{ collectionType: 'fixed/small/slow-V-half' },
+			{ collectionType: 'fixed/medium/slow-XII-mpu' },
+			{ collectionType: 'fixed/small/fast-VIII' },
+			{ collectionType: 'news/most-popular' },
+		];
+
+		const MPUAdsPositions = getMPUAdsPositions(testCollections);
+
+		expect(MPUAdsPositions).toEqual([3, 6, 9, 11]);
 	});
 });

--- a/dotcom-rendering/src/lib/getAdPositions.ts
+++ b/dotcom-rendering/src/lib/getAdPositions.ts
@@ -73,3 +73,13 @@ export const getMobileAdPositions = (
 		.map((collection: AdCandidate) => collections.indexOf(collection))
 		// Should insert no more than 10 ads
 		.slice(0, 10);
+
+export const getMPUAdsPositions = (
+	collections: Pick<DCRCollectionType, 'collectionType'>[],
+): number[] => {
+	return collections
+		.map((collection, index) =>
+			collection.collectionType.includes('mpu') ? index : 0,
+		)
+		.filter((index) => index != 0);
+};


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Fixes `data-link-name` for MPU ad slots.

## Why?
Ophan consumes this info.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/b802cf6f-9907-4ad1-bb70-00e38ea02b0e) | ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/4e2d771b-3259-40f6-bb94-8753718e51d7) |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
