### PR TITLE
Upgrade @guardian/braze-components to v13.3.0

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -63,7 +63,7 @@
 		"@emotion/server": "11.10.0",
 		"@guardian/ab-core": "4.0.0",
 		"@guardian/atoms-rendering": "31.0.0",
-		"@guardian/braze-components": "13.1.0",
+		"@guardian/braze-components": "13.3.0",
 		"@guardian/bridget": "2.3.0",
 		"@guardian/browserslist-config": "4.0.0",
 		"@guardian/cdk": "49.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3510,10 +3510,10 @@
   dependencies:
     is-mobile "3.1.1"
 
-"@guardian/braze-components@13.1.0":
-  version "13.1.0"
-  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-13.1.0.tgz#7af08f1586fdc9876c52aec27c6ca842b0ef9182"
-  integrity sha512-Gntd5xbf2dg9bKYtXPvSDD7hbedZgS19ONXcRNgBcFGyqEHp2i73/P4Les75Q2kW6jQPUVKmjaNMY6m/0kXj5g==
+"@guardian/braze-components@13.3.0":
+  version "13.3.0"
+  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-13.3.0.tgz#a3233d8a4f4e43fe32a5a98fbbc81703a8b6bfec"
+  integrity sha512-rmQG/sUGxTGlZw4qKciyhyS3CNgblzVisa6+aM8ZijG0lm7pWD/+w3KmPHPF/XZN3VS5iCGvPCTxiU+okc+MzQ==
 
 "@guardian/bridget@2.3.0":
   version "2.3.0"
@@ -3619,7 +3619,7 @@
   resolved "https://registry.yarnpkg.com/@guardian/identity-auth/-/identity-auth-0.1.2.tgz#ce357767c0228d7792158770e94173ad6723b7be"
   integrity sha512-vInqAay30pyRS3EHoQwFYW1Fr6t3lD2zvpnnbPOzqqg/5eAoxNFloVkdmnffdB6XguSd9JUmVYS1XLtpZZswTQ==
 
-"@guardian/libs@14.1.0":
+"@guardian/libs@14.1.0", "@guardian/libs@^14.0.0":
   version "14.1.0"
   resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-14.1.0.tgz#feac9cc5636639e45ab2a6e2fd4a3f29f7af9a70"
   integrity sha512-V/6ROWh0s8A6tJVFBMP9h9sb4L2SN98zSp84aLhBac4Ir1XJjG3kljAyB4uV1+341Amd+44QJGhB/D7roVsSfQ==


### PR DESCRIPTION
## What does this change?

Upgrade `@guardian/braze-components` to v13.3.0.

## Why?

This release contains minor changes to the library:

* Better validation of epic author image
* Built and published with Node 18 and upgraded np

## Screenshots

Deployed to CODE and saw Braze messaging:

<img width="1295" alt="Screenshot 2023-06-20 at 14 03 24" src="https://github.com/guardian/dotcom-rendering/assets/379839/84e69c69-47df-4626-a0f8-c340e6bc6d78">

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
