### PR TITLE
Fix ad slot indexing on DCR Fronts

### DIFF
--- a/dotcom-rendering/src/components/AdSlot.tsx
+++ b/dotcom-rendering/src/components/AdSlot.tsx
@@ -452,7 +452,7 @@ export const AdSlot = ({
 			);
 		}
 		case 'inline': {
-			const advertId = `inline${index}`;
+			const advertId = `inline${index + 1}`;
 			return (
 				<div className="ad-slot-container" css={[adStyles]}>
 					<div

--- a/dotcom-rendering/src/components/DecideContainer.tsx
+++ b/dotcom-rendering/src/components/DecideContainer.tsx
@@ -25,7 +25,7 @@ import { NavList } from './NavList';
 
 type Props = {
 	trails: DCRFrontCard[];
-	index: number;
+	adIndex: number;
 	groupedTrails: DCRGroupedTrails;
 	containerType: DCRContainerType;
 	containerPalette?: DCRContainerPalette;
@@ -35,13 +35,14 @@ type Props = {
 
 export const DecideContainer = ({
 	trails,
-	index,
+	adIndex,
 	groupedTrails,
 	containerType,
 	containerPalette,
 	showAge,
 	renderAds,
 }: Props) => {
+	// If you add a new container type which contains an MPU, you must also add it to
 	switch (containerType) {
 		case 'dynamic/fast':
 			return (
@@ -65,7 +66,7 @@ export const DecideContainer = ({
 					groupedTrails={groupedTrails}
 					containerPalette={containerPalette}
 					showAge={showAge}
-					index={index}
+					adIndex={adIndex}
 					renderAds={renderAds}
 					trails={trails}
 				/>
@@ -100,7 +101,7 @@ export const DecideContainer = ({
 					trails={trails}
 					containerPalette={containerPalette}
 					showAge={showAge}
-					index={index}
+					adIndex={adIndex}
 					renderAds={renderAds}
 				/>
 			);
@@ -159,7 +160,7 @@ export const DecideContainer = ({
 					containerPalette={containerPalette}
 					showAge={showAge}
 					renderAds={renderAds}
-					index={index}
+					adIndex={adIndex}
 				/>
 			);
 		case 'fixed/medium/fast-XII':

--- a/dotcom-rendering/src/components/DynamicSlowMPU.stories.tsx
+++ b/dotcom-rendering/src/components/DynamicSlowMPU.stories.tsx
@@ -31,7 +31,7 @@ export const NoBigs = () => (
 				standard: standards,
 			}}
 			showAge={true}
-			index={1}
+			adIndex={1}
 			renderAds={true}
 			trails={trails}
 		/>
@@ -50,7 +50,7 @@ export const OneBig = () => (
 				standard: standards,
 			}}
 			showAge={true}
-			index={1}
+			adIndex={1}
 			renderAds={true}
 			trails={trails}
 		/>
@@ -69,7 +69,7 @@ export const TwoBigs = () => (
 				standard: standards,
 			}}
 			showAge={true}
-			index={1}
+			adIndex={1}
 			renderAds={true}
 			trails={trails}
 		/>
@@ -92,7 +92,7 @@ export const FirstBigBoosted = () => (
 				standard: standards,
 			}}
 			showAge={true}
-			index={1}
+			adIndex={1}
 			renderAds={true}
 			trails={trails}
 		/>
@@ -115,7 +115,7 @@ export const SecondBigBoosted = () => (
 				standard: standards,
 			}}
 			showAge={true}
-			index={1}
+			adIndex={1}
 			renderAds={true}
 			trails={trails}
 		/>
@@ -134,7 +134,7 @@ export const ThreeBigs = () => (
 				standard: standards,
 			}}
 			showAge={true}
-			index={1}
+			adIndex={1}
 			renderAds={true}
 			trails={trails}
 		/>
@@ -153,7 +153,7 @@ export const AllBigs = () => (
 				standard: [],
 			}}
 			showAge={true}
-			index={1}
+			adIndex={1}
 			renderAds={true}
 			trails={trails}
 		/>
@@ -172,7 +172,7 @@ export const AdfreeDynamicSlowMPU = () => (
 				standard: [],
 			}}
 			showAge={true}
-			index={1}
+			adIndex={1}
 			renderAds={false}
 			trails={trails}
 		/>

--- a/dotcom-rendering/src/components/DynamicSlowMPU.tsx
+++ b/dotcom-rendering/src/components/DynamicSlowMPU.tsx
@@ -24,7 +24,7 @@ type Props = {
 	groupedTrails: DCRGroupedTrails;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
-	index: number;
+	adIndex: number;
 	renderAds: boolean;
 	trails: DCRFrontCard[];
 };
@@ -38,12 +38,12 @@ const Card33_ColumnOfThree33_Ad33 = ({
 	cards,
 	containerPalette,
 	showAge,
-	index,
+	adIndex,
 }: {
 	cards: DCRFrontCard[];
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
-	index: number;
+	adIndex: number;
 }) => {
 	const card33 = cards.slice(0, 1);
 	const cards33 = cards.slice(1, 4);
@@ -79,7 +79,7 @@ const Card33_ColumnOfThree33_Ad33 = ({
 			</LI>
 			<LI percentage="33.333%" padSides={true} showDivider={true}>
 				<Hide until="tablet">
-					<AdSlot position="inline" index={index} />
+					<AdSlot position="inline" index={adIndex} />
 				</Hide>
 			</LI>
 		</UL>
@@ -95,12 +95,12 @@ const ColumnOfThree50_Ad50 = ({
 	cards,
 	containerPalette,
 	showAge,
-	index,
+	adIndex,
 }: {
 	cards: DCRFrontCard[];
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
-	index: number;
+	adIndex: number;
 }) => {
 	const cards50 = cards.slice(0, 3);
 
@@ -121,7 +121,7 @@ const ColumnOfThree50_Ad50 = ({
 			</LI>
 			<LI percentage="50%" padSides={true} showDivider={true}>
 				<Hide until="tablet">
-					<AdSlot position="inline" index={index} />
+					<AdSlot position="inline" index={adIndex} />
 				</Hide>
 			</LI>
 		</UL>
@@ -132,14 +132,14 @@ type MPUProps = {
 	groupedTrails: DCRGroupedTrails;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
-	index: number;
+	adIndex: number;
 };
 
 const MPUSlice = ({
 	groupedTrails,
 	containerPalette,
 	showAge,
-	index,
+	adIndex,
 }: MPUProps) => {
 	let layout:
 		| 'noBigs'
@@ -199,7 +199,7 @@ const MPUSlice = ({
 					cards={standardCards}
 					containerPalette={containerPalette}
 					showAge={showAge}
-					index={index}
+					adIndex={adIndex}
 				/>
 			);
 		}
@@ -215,7 +215,7 @@ const MPUSlice = ({
 						cards={standardCards}
 						containerPalette={containerPalette}
 						showAge={showAge}
-						index={index}
+						adIndex={adIndex}
 					/>
 				</>
 			);
@@ -232,7 +232,7 @@ const MPUSlice = ({
 						cards={standardCards}
 						containerPalette={containerPalette}
 						showAge={showAge}
-						index={index}
+						adIndex={adIndex}
 					/>
 				</>
 			);
@@ -249,7 +249,7 @@ const MPUSlice = ({
 						cards={standardCards}
 						containerPalette={containerPalette}
 						showAge={showAge}
-						index={index}
+						adIndex={adIndex}
 					/>
 				</>
 			);
@@ -266,7 +266,7 @@ const MPUSlice = ({
 						cards={standardCards}
 						containerPalette={containerPalette}
 						showAge={showAge}
-						index={index}
+						adIndex={adIndex}
 					/>
 				</>
 			);
@@ -322,7 +322,7 @@ export const DynamicSlowMPU = ({
 	groupedTrails,
 	containerPalette,
 	showAge,
-	index,
+	adIndex,
 	renderAds,
 	trails,
 }: Props) => {
@@ -331,7 +331,7 @@ export const DynamicSlowMPU = ({
 			groupedTrails={groupedTrails}
 			containerPalette={containerPalette}
 			showAge={showAge}
-			index={index}
+			adIndex={adIndex}
 		/>
 	) : (
 		<NonMPUSlice

--- a/dotcom-rendering/src/components/FixedMediumSlowXIIMPU.stories.tsx
+++ b/dotcom-rendering/src/components/FixedMediumSlowXIIMPU.stories.tsx
@@ -22,7 +22,7 @@ export const OneTrail = () => (
 		<FixedMediumSlowXIIMPU
 			trails={trails.slice(0, 1)}
 			showAge={true}
-			index={1}
+			adIndex={1}
 			renderAds={true}
 		/>
 	</FrontSection>
@@ -34,7 +34,7 @@ export const TwoTrails = () => (
 		<FixedMediumSlowXIIMPU
 			trails={trails.slice(0, 2)}
 			showAge={true}
-			index={1}
+			adIndex={1}
 			renderAds={true}
 		/>
 	</FrontSection>
@@ -46,7 +46,7 @@ export const ThreeTrails = () => (
 		<FixedMediumSlowXIIMPU
 			trails={trails.slice(0, 3)}
 			showAge={true}
-			index={1}
+			adIndex={1}
 			renderAds={true}
 		/>
 	</FrontSection>
@@ -58,7 +58,7 @@ export const FourTrails = () => (
 		<FixedMediumSlowXIIMPU
 			trails={trails.slice(0, 4)}
 			showAge={true}
-			index={1}
+			adIndex={1}
 			renderAds={true}
 		/>
 	</FrontSection>
@@ -70,7 +70,7 @@ export const FiveTrails = () => (
 		<FixedMediumSlowXIIMPU
 			trails={trails.slice(0, 5)}
 			showAge={true}
-			index={1}
+			adIndex={1}
 			renderAds={true}
 		/>
 	</FrontSection>
@@ -82,7 +82,7 @@ export const SixTrails = () => (
 		<FixedMediumSlowXIIMPU
 			trails={trails.slice(0, 6)}
 			showAge={true}
-			index={1}
+			adIndex={1}
 			renderAds={true}
 		/>
 	</FrontSection>
@@ -94,7 +94,7 @@ export const SevenTrails = () => (
 		<FixedMediumSlowXIIMPU
 			trails={trails.slice(0, 7)}
 			showAge={true}
-			index={1}
+			adIndex={1}
 			renderAds={true}
 		/>
 	</FrontSection>
@@ -106,7 +106,7 @@ export const EightTrails = () => (
 		<FixedMediumSlowXIIMPU
 			trails={trails.slice(0, 8)}
 			showAge={true}
-			index={1}
+			adIndex={1}
 			renderAds={true}
 		/>
 	</FrontSection>
@@ -118,7 +118,7 @@ export const NineTrails = () => (
 		<FixedMediumSlowXIIMPU
 			trails={trails.slice(0, 9)}
 			showAge={true}
-			index={1}
+			adIndex={1}
 			renderAds={true}
 		/>
 	</FrontSection>
@@ -130,7 +130,7 @@ export const EightTrailsNoAds = () => (
 		<FixedMediumSlowXIIMPU
 			trails={trails.slice(0, 8)}
 			showAge={true}
-			index={1}
+			adIndex={1}
 			renderAds={false}
 		/>
 	</FrontSection>

--- a/dotcom-rendering/src/components/FixedMediumSlowXIIMPU.tsx
+++ b/dotcom-rendering/src/components/FixedMediumSlowXIIMPU.tsx
@@ -14,7 +14,7 @@ type Props = {
 	trails: DCRFrontCard[];
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
-	index: number;
+	adIndex: number;
 	renderAds: boolean;
 };
 
@@ -22,7 +22,7 @@ type MPUSliceProps = {
 	trails: DCRFrontCard[];
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
-	index: number;
+	adIndex: number;
 };
 
 /* .___________.___________.___________.
@@ -88,7 +88,7 @@ const ThreeColumnSliceWithAdSlot = ({
 	trails,
 	containerPalette,
 	showAge,
-	index,
+	adIndex,
 }: MPUSliceProps) => {
 	return (
 		<UL direction="row">
@@ -106,15 +106,15 @@ const ThreeColumnSliceWithAdSlot = ({
 				 * |_______________________|
 				 */}
 				<UL direction="row" wrapCards={true}>
-					{trails.map((trail, trailIndex, { length }) => (
+					{trails.map((trail, trailadIndex, { length }) => (
 						<LI
 							padSides={true}
 							offsetBottomPaddingOnDivider={shouldPadWrappableRows(
-								trailIndex,
+								trailadIndex,
 								length - (length % 2),
 								2,
 							)}
-							showDivider={trailIndex % 2 !== 0}
+							showDivider={trailadIndex % 2 !== 0}
 							containerPalette={containerPalette}
 							percentage="50%"
 							stretch={true}
@@ -131,7 +131,7 @@ const ThreeColumnSliceWithAdSlot = ({
 			</LI>
 			<LI percentage="33.333%" padSides={true} showDivider={true}>
 				<Hide until="tablet">
-					<AdSlot position="inline" index={index} />
+					<AdSlot position="inline" index={adIndex} />
 				</Hide>
 			</LI>
 		</UL>
@@ -146,7 +146,7 @@ export const FixedMediumSlowXIIMPU = ({
 	trails,
 	containerPalette,
 	showAge,
-	index,
+	adIndex,
 	renderAds,
 }: Props) => {
 	const firstSlice = trails.slice(0, 3);
@@ -164,7 +164,7 @@ export const FixedMediumSlowXIIMPU = ({
 					trails={remaining}
 					containerPalette={containerPalette}
 					showAge={showAge}
-					index={index}
+					adIndex={adIndex}
 				/>
 			) : (
 				/**
@@ -172,15 +172,15 @@ export const FixedMediumSlowXIIMPU = ({
 				 * wrapping three-column layout instead.
 				 */
 				<UL direction="row" wrapCards={true}>
-					{remaining.map((trail, trailIndex) => (
+					{remaining.map((trail, trailadIndex) => (
 						<LI
 							padSides={true}
 							offsetBottomPaddingOnDivider={shouldPadWrappableRows(
-								trailIndex,
+								trailadIndex,
 								remaining.length - (remaining.length % 3),
 								3,
 							)}
-							showDivider={trailIndex % 3 !== 0}
+							showDivider={trailadIndex % 3 !== 0}
 							containerPalette={containerPalette}
 							percentage="33.333%"
 							stretch={true}

--- a/dotcom-rendering/src/components/FixedSmallSlowVMPU.stories.tsx
+++ b/dotcom-rendering/src/components/FixedSmallSlowVMPU.stories.tsx
@@ -22,7 +22,7 @@ export const FourCards = () => (
 		<FixedSmallSlowVMPU
 			trails={trails.slice(0, 4)}
 			showAge={true}
-			index={1}
+			adIndex={1}
 			renderAds={true}
 		/>
 	</FrontSection>
@@ -35,7 +35,7 @@ export const ThreeCards = () => (
 		<FixedSmallSlowVMPU
 			trails={trails.slice(0, 3)}
 			showAge={true}
-			index={1}
+			adIndex={1}
 			renderAds={true}
 		/>
 	</FrontSection>
@@ -48,7 +48,7 @@ export const TwoCards = () => (
 		<FixedSmallSlowVMPU
 			trails={trails.slice(0, 2)}
 			showAge={true}
-			index={1}
+			adIndex={1}
 			renderAds={true}
 		/>
 	</FrontSection>
@@ -61,7 +61,7 @@ export const OneCard = () => (
 		<FixedSmallSlowVMPU
 			trails={trails.slice(0, 1)}
 			showAge={true}
-			index={1}
+			adIndex={1}
 			renderAds={true}
 		/>
 	</FrontSection>
@@ -74,7 +74,7 @@ export const AdfreeFixedSmallSlowVMPU = () => (
 		<FixedSmallSlowVMPU
 			trails={trails.slice(0, 4)}
 			showAge={true}
-			index={1}
+			adIndex={1}
 			renderAds={false}
 		/>
 	</FrontSection>

--- a/dotcom-rendering/src/components/FixedSmallSlowVMPU.tsx
+++ b/dotcom-rendering/src/components/FixedSmallSlowVMPU.tsx
@@ -13,7 +13,7 @@ type Props = {
 	trails: DCRFrontCard[];
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
-	index: number;
+	adIndex: number;
 	renderAds: boolean;
 };
 
@@ -21,7 +21,7 @@ export const FixedSmallSlowVMPU = ({
 	trails,
 	containerPalette,
 	showAge,
-	index,
+	adIndex,
 	renderAds,
 }: Props) => {
 	const firstSlice33 = trails.slice(0, 1);
@@ -63,7 +63,7 @@ export const FixedSmallSlowVMPU = ({
 					containerPalette={containerPalette}
 				>
 					<Hide until="tablet">
-						<AdSlot position="inline" index={index} />
+						<AdSlot position="inline" index={adIndex} />
 					</Hide>
 				</LI>
 			</UL>

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -36,6 +36,7 @@ import { TrendingTopics } from '../components/TrendingTopics';
 import { canRenderAds } from '../lib/canRenderAds';
 import { decidePalette } from '../lib/decidePalette';
 import {
+	getDesktopAdPositions,
 	getMerchHighPosition,
 	getMobileAdPositions,
 } from '../lib/getAdPositions';
@@ -99,7 +100,7 @@ const decideAdSlot = (
 		return (
 			<Hide from="tablet">
 				<AdSlot
-					index={index}
+					index={mobileAdPositions.indexOf(index)}
 					data-print-layout="hide"
 					position="mobile-front"
 					display={format}
@@ -134,6 +135,10 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 
 	const mobileAdPositions = renderAds
 		? getMobileAdPositions(front.pressedPage.collections, merchHighPosition)
+		: [];
+
+	const desktopAdPositions = renderAds
+		? getDesktopAdPositions(front.pressedPage.collections)
 		: [];
 
 	const showMostPopular =
@@ -411,12 +416,12 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 							>
 								<DecideContainer
 									trails={trailsWithoutBranding}
-									index={index}
 									groupedTrails={collection.grouped}
 									containerType={collection.collectionType}
 									containerPalette={
 										collection.containerPalette
 									}
+									adIndex={desktopAdPositions.indexOf(index)}
 									renderAds={false}
 								/>
 							</LabsSection>
@@ -468,7 +473,6 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 							>
 								<DecideContainer
 									trails={trails}
-									index={index}
 									groupedTrails={collection.grouped}
 									containerType={collection.collectionType}
 									containerPalette={
@@ -477,6 +481,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 									showAge={
 										collection.displayName === 'Headlines'
 									}
+									adIndex={desktopAdPositions.indexOf(index)}
 									renderAds={renderAds}
 								/>
 							</FrontSection>

--- a/dotcom-rendering/src/lib/getAdPositions.test.ts
+++ b/dotcom-rendering/src/lib/getAdPositions.test.ts
@@ -1,5 +1,5 @@
 import type { DCRCollectionType } from '../types/front';
-import { getMobileAdPositions } from './getAdPositions';
+import { getDesktopAdPositions, getMobileAdPositions } from './getAdPositions';
 
 const defaultTestCollections: Pick<DCRCollectionType, 'collectionType'>[] = [
 	...Array<number>(12),
@@ -209,5 +209,30 @@ describe('Mobile Ads', () => {
 		);
 
 		expect(mobileAdPositions).toEqual([1, 4, 6, 8, 10, 12]);
+	});
+});
+
+describe('Desktop Ads', () => {
+	it('should return a list of the MPU ads/containers in correct positions', () => {
+		const testCollections: Pick<DCRCollectionType, 'collectionType'>[] = [
+			{ collectionType: 'fixed/small/slow-IV' },
+			{ collectionType: 'fixed/medium/slow-VI' },
+			{ collectionType: 'fixed/small/slow-V-third' },
+			{ collectionType: 'fixed/medium/slow-XII-mpu' },
+			{ collectionType: 'fixed/medium/fast-XII' },
+			{ collectionType: 'fixed/small/slow-V-third' },
+			{ collectionType: 'dynamic/slow-mpu' },
+			{ collectionType: 'fixed/medium/fast-XI' },
+			{ collectionType: 'fixed/small/slow-III' },
+			{ collectionType: 'fixed/small/slow-V-mpu' },
+			{ collectionType: 'fixed/small/slow-V-half' },
+			{ collectionType: 'fixed/medium/slow-XII-mpu' },
+			{ collectionType: 'fixed/small/fast-VIII' },
+			{ collectionType: 'news/most-popular' },
+		];
+
+		const desktopAdPositions = getDesktopAdPositions(testCollections);
+
+		expect(desktopAdPositions).toEqual([3, 6, 9, 11]);
 	});
 });

--- a/dotcom-rendering/src/lib/getAdPositions.ts
+++ b/dotcom-rendering/src/lib/getAdPositions.ts
@@ -73,3 +73,18 @@ export const getMobileAdPositions = (
 		.map((collection: AdCandidate) => collections.indexOf(collection))
 		// Should insert no more than 10 ads
 		.slice(0, 10);
+
+const hasDesktopAd = (collection: DCRCollectionType) => {
+	return (
+		collection.collectionType == 'dynamic/slow-mpu' ||
+		collection.collectionType == 'fixed/small/slow-V-mpu' ||
+		collection.collectionType == 'fixed/medium/slow-XII-mpu'
+	);
+};
+
+export const getDesktopAdPositions = (
+	collections: DCRCollectionType[],
+): number[] =>
+	collections
+		.filter(hasDesktopAd)
+		.map((collection) => collections.indexOf(collection));

--- a/dotcom-rendering/src/lib/getAdPositions.ts
+++ b/dotcom-rendering/src/lib/getAdPositions.ts
@@ -74,7 +74,7 @@ export const getMobileAdPositions = (
 		// Should insert no more than 10 ads
 		.slice(0, 10);
 
-const hasDesktopAd = (collection: DCRCollectionType) => {
+const hasDesktopAd = (collection: AdCandidate) => {
 	return (
 		collection.collectionType == 'dynamic/slow-mpu' ||
 		collection.collectionType == 'fixed/small/slow-V-mpu' ||
@@ -82,9 +82,7 @@ const hasDesktopAd = (collection: DCRCollectionType) => {
 	);
 };
 
-export const getDesktopAdPositions = (
-	collections: DCRCollectionType[],
-): number[] =>
+export const getDesktopAdPositions = (collections: AdCandidate[]): number[] =>
 	collections
 		.filter(hasDesktopAd)
 		.map((collection) => collections.indexOf(collection));


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
There's a bug in the indexing of ad slots, they are taking the index of the section that they are in/adjacent to rather than the index of the ads on the page.

This PR alter the ad slot indexing so that the id, class etc. are correct.

## Why?
Gain parity with frontend, the inconsistent indexing also makes targeting hard for some campaigns.
