### PR TITLE
Migrate DCR user data and API calls to use Okta/OAuth tokens

### DIFF
--- a/dotcom-rendering/src/components/DiscussionMeta.importable.tsx
+++ b/dotcom-rendering/src/components/DiscussionMeta.importable.tsx
@@ -2,6 +2,10 @@ import { joinUrl } from '@guardian/libs';
 import { decidePalette } from '../lib/decidePalette';
 import { useApi } from '../lib/useApi';
 import { useDiscussion } from '../lib/useDiscussion';
+import {
+	getOptionsHeadersWithOkta,
+	useSignedInAuthState,
+} from '../lib/useSignedInAuthState';
 import { SignedInAs } from './SignedInAs';
 
 type Props = {
@@ -17,17 +21,23 @@ export const DiscussionMeta = ({
 	shortUrlId,
 	enableDiscussionSwitch,
 }: Props) => {
+	const [status, authState] = useSignedInAuthState();
+
 	const { commentCount, isClosedForComments } = useDiscussion(
 		joinUrl(discussionApiUrl, 'discussion', shortUrlId),
 	);
 
-	// TODO Okta: getting user, migrate to access tokens
+	const options = getOptionsHeadersWithOkta(status, authState);
+
 	const { data } = useApi<{ userProfile: UserProfile }>(
-		joinUrl(discussionApiUrl, 'profile/me?strict_sanctions_check=false'),
+		status !== 'Pending'
+			? joinUrl(
+					discussionApiUrl,
+					'profile/me?strict_sanctions_check=false',
+			  )
+			: undefined,
 		{},
-		{
-			credentials: 'include',
-		},
+		options,
 	);
 
 	const palette = decidePalette(format);

--- a/dotcom-rendering/src/components/DiscussionMeta.importable.tsx
+++ b/dotcom-rendering/src/components/DiscussionMeta.importable.tsx
@@ -21,6 +21,7 @@ export const DiscussionMeta = ({
 		joinUrl(discussionApiUrl, 'discussion', shortUrlId),
 	);
 
+	// TODO Okta: getting user, migrate to access tokens
 	const { data } = useApi<{ userProfile: UserProfile }>(
 		joinUrl(discussionApiUrl, 'profile/me?strict_sanctions_check=false'),
 		{},

--- a/dotcom-rendering/src/components/DiscussionMeta.importable.tsx
+++ b/dotcom-rendering/src/components/DiscussionMeta.importable.tsx
@@ -21,16 +21,16 @@ export const DiscussionMeta = ({
 	shortUrlId,
 	enableDiscussionSwitch,
 }: Props) => {
-	const [status, authState] = useSignedInAuthState();
+	const authStatus = useSignedInAuthState();
 
 	const { commentCount, isClosedForComments } = useDiscussion(
 		joinUrl(discussionApiUrl, 'discussion', shortUrlId),
 	);
 
-	const options = getOptionsHeadersWithOkta(status, authState);
+	const options = getOptionsHeadersWithOkta(authStatus);
 
 	const { data } = useApi<{ userProfile: UserProfile }>(
-		status !== 'Pending'
+		authStatus.kind !== 'Pending'
 			? joinUrl(
 					discussionApiUrl,
 					'profile/me?strict_sanctions_check=false',

--- a/dotcom-rendering/src/components/DiscussionWhenSignedIn.tsx
+++ b/dotcom-rendering/src/components/DiscussionWhenSignedIn.tsx
@@ -5,6 +5,8 @@ import { Discussion } from './Discussion';
 
 export const DiscussionWhenSignedIn = (props: DiscussionProps) => {
 	const { discussionApiUrl } = props;
+
+	// TODO OKTA: Discussion API call to migrate to use access token
 	const { data } = useApi<{ userProfile: UserProfile }>(
 		joinUrl(discussionApiUrl, 'profile/me?strict_sanctions_check=false'),
 		{},

--- a/dotcom-rendering/src/components/DiscussionWhenSignedIn.tsx
+++ b/dotcom-rendering/src/components/DiscussionWhenSignedIn.tsx
@@ -8,13 +8,13 @@ import type { Props as DiscussionProps } from './Discussion';
 import { Discussion } from './Discussion';
 
 export const DiscussionWhenSignedIn = (props: DiscussionProps) => {
-	const [status, authState] = useSignedInAuthState();
+	const authStatus = useSignedInAuthState();
 	const { discussionApiUrl } = props;
 
-	const options = getOptionsHeadersWithOkta(status, authState);
+	const options = getOptionsHeadersWithOkta(authStatus);
 
 	const { data } = useApi<{ userProfile: UserProfile }>(
-		status !== 'Pending'
+		authStatus.kind !== 'Pending'
 			? joinUrl(
 					discussionApiUrl,
 					'profile/me?strict_sanctions_check=false',

--- a/dotcom-rendering/src/components/DiscussionWhenSignedIn.tsx
+++ b/dotcom-rendering/src/components/DiscussionWhenSignedIn.tsx
@@ -1,18 +1,27 @@
 import { joinUrl } from '@guardian/libs';
 import { useApi } from '../lib/useApi';
+import {
+	getOptionsHeadersWithOkta,
+	useSignedInAuthState,
+} from '../lib/useSignedInAuthState';
 import type { Props as DiscussionProps } from './Discussion';
 import { Discussion } from './Discussion';
 
 export const DiscussionWhenSignedIn = (props: DiscussionProps) => {
+	const [status, authState] = useSignedInAuthState();
 	const { discussionApiUrl } = props;
 
-	// TODO OKTA: Discussion API call to migrate to use access token
+	const options = getOptionsHeadersWithOkta(status, authState);
+
 	const { data } = useApi<{ userProfile: UserProfile }>(
-		joinUrl(discussionApiUrl, 'profile/me?strict_sanctions_check=false'),
+		status !== 'Pending'
+			? joinUrl(
+					discussionApiUrl,
+					'profile/me?strict_sanctions_check=false',
+			  )
+			: undefined,
 		{},
-		{
-			credentials: 'include',
-		},
+		options,
 	);
 	if (!data) return null;
 

--- a/dotcom-rendering/src/components/HeaderTopBarMyAccount.tsx
+++ b/dotcom-rendering/src/components/HeaderTopBarMyAccount.tsx
@@ -190,13 +190,13 @@ const SignedInWithNotifications = ({
 	discussionApiUrl,
 	notifications,
 }: SignedInWithNotificationsProps) => {
-	const [status, authState] = useSignedInAuthState();
+	const authStatus = useSignedInAuthState();
 
 	let userId: string | undefined;
 
 	// TODO Okta: Remove the useApi and status === 'NotInTest' when at 100% in Okta oktaVariant
 	const { data, error } = useApi<{ userProfile: UserProfile }>(
-		status === 'NotInTest'
+		authStatus.kind === 'NotInTest'
 			? joinUrl(
 					discussionApiUrl,
 					'profile/me?strict_sanctions_check=false',
@@ -208,12 +208,12 @@ const SignedInWithNotifications = ({
 			credentials: 'include',
 		},
 	);
-	if (status === 'NotInTest' && data) {
+	if (authStatus.kind === 'NotInTest' && data) {
 		userId = data.userProfile.userId;
 	}
 
-	if (status === 'Ready') {
-		userId = authState.idToken?.claims.legacy_identity_id;
+	if (authStatus.kind === 'Ready') {
+		userId = authStatus.authState.idToken?.claims.legacy_identity_id;
 	}
 
 	if (!userId || error) return <SignIn idUrl={idUrl} />;

--- a/dotcom-rendering/src/components/HeaderTopBarMyAccount.tsx
+++ b/dotcom-rendering/src/components/HeaderTopBarMyAccount.tsx
@@ -189,6 +189,7 @@ const SignedInWithNotifications = ({
 	discussionApiUrl,
 	notifications,
 }: SignedInWithNotificationsProps) => {
+	// TODO OKTA: get user id from id token
 	const { data, error } = useApi<{ userProfile: UserProfile }>(
 		joinUrl(discussionApiUrl, 'profile/me?strict_sanctions_check=false'),
 		{},

--- a/dotcom-rendering/src/components/HeaderTopBarMyAccount.tsx
+++ b/dotcom-rendering/src/components/HeaderTopBarMyAccount.tsx
@@ -195,6 +195,8 @@ const SignedInWithNotifications = ({
 	let userId: string | undefined;
 
 	// TODO Okta: Remove the useApi and status === 'NotInTest' when at 100% in Okta oktaVariant
+	// If we encounter an error or don't have user data display sign in to the user.
+	// SWR will retry in the background if the request failed
 	const { data, error } = useApi<{ userProfile: UserProfile }>(
 		authStatus.kind === 'NotInTest'
 			? joinUrl(

--- a/dotcom-rendering/src/components/HeaderTopBarMyAccount.tsx
+++ b/dotcom-rendering/src/components/HeaderTopBarMyAccount.tsx
@@ -194,7 +194,7 @@ const SignedInWithNotifications = ({
 
 	let userId: string | undefined;
 
-	// TODO Okta: Remove this when at 100% in Okta oktaVariant
+	// TODO Okta: Remove the useApi and status === 'NotInTest' when at 100% in Okta oktaVariant
 	const { data, error } = useApi<{ userProfile: UserProfile }>(
 		status === 'NotInTest'
 			? joinUrl(

--- a/dotcom-rendering/src/components/SlotBodyEnd/BrazeEpic.tsx
+++ b/dotcom-rendering/src/components/SlotBodyEnd/BrazeEpic.tsx
@@ -140,6 +140,7 @@ const BrazeEpicWithSatisfiedDependencies = ({
 					componentName={componentName}
 					brazeMessageProps={meta.dataFromBraze}
 					subscribeToNewsletter={async (newsletterId) => {
+						// TODO Okta: migrate to use access tokens
 						await fetch(`${idApiUrl}/users/me/newsletters`, {
 							method: 'PATCH',
 							body: JSON.stringify({

--- a/dotcom-rendering/src/components/SlotBodyEnd/BrazeEpic.tsx
+++ b/dotcom-rendering/src/components/SlotBodyEnd/BrazeEpic.tsx
@@ -101,7 +101,7 @@ const BrazeEpicWithSatisfiedDependencies = ({
 	countryCode,
 	idApiUrl,
 }: InnerProps) => {
-	const [authStatus, authState] = useSignedInAuthState();
+	const authStatus = useSignedInAuthState();
 	const [hasBeenSeen, setNode] = useIsInView({
 		rootMargin: '-18px',
 		threshold: 0,
@@ -139,8 +139,8 @@ const BrazeEpicWithSatisfiedDependencies = ({
 	if (!componentName) return null;
 
 	const subscribeToNewsletter = async (newsletterId: string) => {
-		if (authStatus !== 'Pending') {
-			const options = getOptionsHeadersWithOkta(authStatus, authState);
+		if (authStatus.kind !== 'Pending') {
+			const options = getOptionsHeadersWithOkta(authStatus);
 
 			await fetch(`${idApiUrl}/users/me/newsletters`, {
 				method: 'PATCH',

--- a/dotcom-rendering/src/components/SlotBodyEnd/BrazeEpic.tsx
+++ b/dotcom-rendering/src/components/SlotBodyEnd/BrazeEpic.tsx
@@ -11,6 +11,10 @@ import { suppressForTaylorReport } from '../../lib/braze/taylorReport';
 import type { CanShowResult } from '../../lib/messagePicker';
 import { useIsInView } from '../../lib/useIsInView';
 import { useOnce } from '../../lib/useOnce';
+import {
+	getOptionsHeadersWithOkta,
+	useSignedInAuthState,
+} from '../../lib/useSignedInAuthState';
 import type { TagType } from '../../types/tag';
 
 const wrapperMargins = css`
@@ -97,6 +101,7 @@ const BrazeEpicWithSatisfiedDependencies = ({
 	countryCode,
 	idApiUrl,
 }: InnerProps) => {
+	const [authStatus, authState] = useSignedInAuthState();
 	const [hasBeenSeen, setNode] = useIsInView({
 		rootMargin: '-18px',
 		threshold: 0,
@@ -133,23 +138,28 @@ const BrazeEpicWithSatisfiedDependencies = ({
 	const componentName = meta.dataFromBraze.componentName;
 	if (!componentName) return null;
 
+	const subscribeToNewsletter = async (newsletterId: string) => {
+		if (authStatus !== 'Pending') {
+			const options = getOptionsHeadersWithOkta(authStatus, authState);
+
+			await fetch(`${idApiUrl}/users/me/newsletters`, {
+				method: 'PATCH',
+				body: JSON.stringify({
+					id: newsletterId,
+					subscribed: true,
+				}),
+				...options,
+			});
+		}
+	};
+
 	return (
 		<div ref={setNode} css={wrapperMargins}>
 			<div ref={epicRef}>
 				<BrazeComponent
 					componentName={componentName}
 					brazeMessageProps={meta.dataFromBraze}
-					subscribeToNewsletter={async (newsletterId) => {
-						// TODO Okta: migrate to use access tokens
-						await fetch(`${idApiUrl}/users/me/newsletters`, {
-							method: 'PATCH',
-							body: JSON.stringify({
-								id: newsletterId,
-								subscribed: true,
-							}),
-							credentials: 'include',
-						});
-					}}
+					subscribeToNewsletter={subscribeToNewsletter}
 					countryCode={countryCode}
 					logButtonClickWithBraze={meta.logButtonClickWithBraze}
 					submitComponentEvent={submitComponentEvent}

--- a/dotcom-rendering/src/components/StickyBottomBanner/BrazeBanner.tsx
+++ b/dotcom-rendering/src/components/StickyBottomBanner/BrazeBanner.tsx
@@ -108,7 +108,7 @@ const BrazeBannerWithSatisfiedDependencies = ({
 	meta,
 	idApiUrl,
 }: InnerProps) => {
-	const [authStatus, authState] = useSignedInAuthState();
+	const authStatus = useSignedInAuthState();
 
 	useEffect(() => {
 		// Log the impression with Braze
@@ -131,8 +131,8 @@ const BrazeBannerWithSatisfiedDependencies = ({
 	if (!componentName) return null;
 
 	const subscribeToNewsletter = async (newsletterId: string) => {
-		if (authStatus !== 'Pending') {
-			const options = getOptionsHeadersWithOkta(authStatus, authState);
+		if (authStatus.kind !== 'Pending') {
+			const options = getOptionsHeadersWithOkta(authStatus);
 
 			await fetch(`${idApiUrl}/users/me/newsletters`, {
 				method: 'PATCH',

--- a/dotcom-rendering/src/components/StickyBottomBanner/BrazeBanner.tsx
+++ b/dotcom-rendering/src/components/StickyBottomBanner/BrazeBanner.tsx
@@ -131,6 +131,7 @@ const BrazeBannerWithSatisfiedDependencies = ({
 				submitComponentEvent={submitComponentEvent}
 				componentName={componentName}
 				brazeMessageProps={meta.dataFromBraze}
+				// TODO Okta: Migrate to use access tokens
 				subscribeToNewsletter={async (newsletterId: string) => {
 					await fetch(`${idApiUrl}/users/me/newsletters`, {
 						method: 'PATCH',

--- a/dotcom-rendering/src/lib/contributions.ts
+++ b/dotcom-rendering/src/lib/contributions.ts
@@ -236,6 +236,7 @@ export const setLocalNoBannerCachePeriod = (): void =>
 	window.localStorage.setItem(NO_RR_BANNER_TIMESTAMP_KEY, `${Date.now()}`);
 
 const getEmail = (ajaxUrl: string): Promise<string | undefined> => {
+	// TODO Okta: This is just getting the email, use ID token instead
 	return getIdApiUserData(ajaxUrl)
 		.then((data: IdApiUserData) => data.user?.primaryEmailAddress)
 		.catch((error) => {

--- a/dotcom-rendering/src/lib/contributions.ts
+++ b/dotcom-rendering/src/lib/contributions.ts
@@ -237,7 +237,7 @@ export const setLocalNoBannerCachePeriod = (): void =>
 	window.localStorage.setItem(NO_RR_BANNER_TIMESTAMP_KEY, `${Date.now()}`);
 
 const getEmail = async (ajaxUrl: string): Promise<string | undefined> =>
-	// TODO Okta: Remove either when at 100& in oktaVariant test
+	// TODO Okta: Remove either when at 100% in oktaVariant test, and just use idToken
 	eitherSignedInWithOktaOrElse(
 		(authState) => authState.idToken?.claims.email,
 		() =>

--- a/dotcom-rendering/src/lib/getBrazeUuid.ts
+++ b/dotcom-rendering/src/lib/getBrazeUuid.ts
@@ -2,6 +2,7 @@ import type { IdApiUserIdentifiers } from './getIdapiUserData';
 import { getIdapiUserIdentifiers } from './getIdapiUserData';
 
 export const getBrazeUuid = async (ajaxUrl: string): Promise<string | void> => {
+	// TODO: We need the brazeUUID, add this to the ID token
 	return getIdapiUserIdentifiers(ajaxUrl)
 		.then((data: IdApiUserIdentifiers) => data.brazeUuid)
 		.catch((error) => {

--- a/dotcom-rendering/src/lib/getBrazeUuid.ts
+++ b/dotcom-rendering/src/lib/getBrazeUuid.ts
@@ -3,7 +3,7 @@ import { getIdapiUserIdentifiers } from './getIdapiUserData';
 import { eitherSignedInWithOktaOrElse } from './useSignedInAuthState';
 
 export const getBrazeUuid = async (ajaxUrl: string): Promise<string | void> =>
-	// TODO Okta: Remove either when at 100& in oktaVariant test
+	// TODO Okta: Remove either when at 100% in oktaVariant test, and just use idToken
 	eitherSignedInWithOktaOrElse(
 		(authState) => authState.idToken?.claims.braze_uuid,
 		() =>

--- a/dotcom-rendering/src/lib/getBrazeUuid.ts
+++ b/dotcom-rendering/src/lib/getBrazeUuid.ts
@@ -2,7 +2,7 @@ import type { IdApiUserIdentifiers } from './getIdapiUserData';
 import { getIdapiUserIdentifiers } from './getIdapiUserData';
 
 export const getBrazeUuid = async (ajaxUrl: string): Promise<string | void> => {
-	// TODO: We need the brazeUUID, add this to the ID token
+	// TODO Okta: We need the brazeUUID, add this to the ID token
 	return getIdapiUserIdentifiers(ajaxUrl)
 		.then((data: IdApiUserIdentifiers) => data.brazeUuid)
 		.catch((error) => {

--- a/dotcom-rendering/src/lib/getBrazeUuid.ts
+++ b/dotcom-rendering/src/lib/getBrazeUuid.ts
@@ -1,11 +1,18 @@
 import type { IdApiUserIdentifiers } from './getIdapiUserData';
 import { getIdapiUserIdentifiers } from './getIdapiUserData';
+import { eitherSignedInWithOktaOrElse } from './useSignedInAuthState';
 
-export const getBrazeUuid = async (ajaxUrl: string): Promise<string | void> => {
-	// TODO Okta: We need the brazeUUID, add this to the ID token
-	return getIdapiUserIdentifiers(ajaxUrl)
-		.then((data: IdApiUserIdentifiers) => data.brazeUuid)
-		.catch((error) => {
-			window.guardian.modules.sentry.reportError(error, 'getBrazeUuid');
-		});
-};
+export const getBrazeUuid = async (ajaxUrl: string): Promise<string | void> =>
+	// TODO Okta: Remove either when at 100& in oktaVariant test
+	eitherSignedInWithOktaOrElse(
+		(authState) => authState.idToken?.claims.braze_uuid,
+		() =>
+			getIdapiUserIdentifiers(ajaxUrl)
+				.then((data: IdApiUserIdentifiers) => data.brazeUuid)
+				.catch((error) => {
+					window.guardian.modules.sentry.reportError(
+						error,
+						'getBrazeUuid',
+					);
+				}),
+	);

--- a/dotcom-rendering/src/lib/identity.ts
+++ b/dotcom-rendering/src/lib/identity.ts
@@ -1,7 +1,9 @@
-import type { CustomClaims } from '@guardian/identity-auth';
+import type { CustomClaims, IdentityAuthState } from '@guardian/identity-auth';
 import { IdentityAuth } from '@guardian/identity-auth';
 
-type CustomIdTokenClaims = CustomClaims & {
+// the `id_token.profile.theguardian` scope is used to get custom claims
+export type CustomIdTokenClaims = CustomClaims & {
+	email: string;
 	braze_uuid: string;
 };
 
@@ -58,6 +60,8 @@ function getIdentityAuth() {
 	return identityAuth;
 }
 
-export async function isSignedInWithOkta(): Promise<boolean> {
-	return getIdentityAuth().isSignedIn();
+export async function isSignInWithOktaAuthState(): Promise<
+	IdentityAuthState<never, CustomIdTokenClaims>
+> {
+	return getIdentityAuth().isSignedInWithAuthState();
 }

--- a/dotcom-rendering/src/lib/identity.ts
+++ b/dotcom-rendering/src/lib/identity.ts
@@ -1,4 +1,9 @@
+import type { CustomClaims } from '@guardian/identity-auth';
 import { IdentityAuth } from '@guardian/identity-auth';
+
+type CustomIdTokenClaims = CustomClaims & {
+	braze_uuid: string;
+};
 
 function getStage() {
 	if (!window.guardian.config.isDev) {
@@ -26,13 +31,14 @@ const getRedirectUri = (stage: StageType) => {
 	}
 };
 
-let identityAuth: IdentityAuth | undefined = undefined;
+let identityAuth: IdentityAuth<never, CustomIdTokenClaims> | undefined =
+	undefined;
 
 function getIdentityAuth() {
 	if (identityAuth === undefined) {
 		const stage = getStage();
 
-		identityAuth = new IdentityAuth({
+		identityAuth = new IdentityAuth<never, CustomIdTokenClaims>({
 			issuer: getIssuer(stage),
 			clientId: getClientId(stage),
 			redirectUri: getRedirectUri(stage),

--- a/dotcom-rendering/src/lib/identity.ts
+++ b/dotcom-rendering/src/lib/identity.ts
@@ -36,7 +36,17 @@ function getIdentityAuth() {
 			issuer: getIssuer(stage),
 			clientId: getClientId(stage),
 			redirectUri: getRedirectUri(stage),
-			scopes: ['openid', 'profile', 'email'], // and any other scopes you need
+			scopes: [
+				'openid', // required for open id connect, returns an id token
+				'profile', // populates the id token with basic profile information
+				'email', // populates the id token with the user's email address
+				'guardian.discussion-api.private-profile.read.self', // allows the access token to be used to make requests to the discussion api to read the user's profile
+				'guardian.discussion-api.update.secure', // allows the access token to be used to make requests to the discussion api to post comments, upvote etc
+				'guardian.identity-api.newsletters.read.self', // allows the access token to be used to make requests to the identity api to read the user's newsletter subscriptions
+				'guardian.identity-api.newsletters.update.self', // allows the access token to be used to make requests to the identity api to update the user's newsletter subscriptions
+				'guardian.members-data-api.read.self', // allows the access token to be used to make requests to the members data api to read the user's membership status
+				'id_token.profile.theguardian', // populates the id token with application specific profile information
+			],
 		});
 	}
 	return identityAuth;

--- a/dotcom-rendering/src/lib/identity.ts
+++ b/dotcom-rendering/src/lib/identity.ts
@@ -60,7 +60,7 @@ function getIdentityAuth() {
 	return identityAuth;
 }
 
-export async function isSignInWithOktaAuthState(): Promise<
+export async function isSignedInWithOktaAuthState(): Promise<
 	IdentityAuthState<never, CustomIdTokenClaims>
 > {
 	return getIdentityAuth().isSignedInWithAuthState();

--- a/dotcom-rendering/src/lib/useSignedInAuthState.ts
+++ b/dotcom-rendering/src/lib/useSignedInAuthState.ts
@@ -4,6 +4,27 @@ import type { CustomIdTokenClaims } from './identity';
 
 export type AuthStateStatus = 'Pending' | 'NotInTest' | 'Ready';
 
+export const getOptionsHeadersWithOkta = (
+	status: AuthStateStatus,
+	state: IdentityAuthState,
+): RequestInit => {
+	if (status === 'NotInTest') {
+		return {
+			credentials: 'include',
+		};
+	}
+
+	if (status === 'Ready' && state.accessToken?.accessToken) {
+		return {
+			headers: {
+				Authorization: `Bearer ${state.accessToken.accessToken}`,
+			},
+		};
+	}
+
+	return {};
+};
+
 export async function getAuthState(): Promise<
 	IdentityAuthState<never, CustomIdTokenClaims>
 > {

--- a/dotcom-rendering/src/lib/useSignedInAuthState.ts
+++ b/dotcom-rendering/src/lib/useSignedInAuthState.ts
@@ -26,6 +26,7 @@ export const getOptionsHeadersWithOkta = (
 		return {
 			headers: {
 				Authorization: `Bearer ${authStatus.authState.accessToken.accessToken}`,
+				'X-GU-IS-OAUTH': 'true',
 			},
 		};
 	}

--- a/dotcom-rendering/src/lib/useSignedInAuthState.ts
+++ b/dotcom-rendering/src/lib/useSignedInAuthState.ts
@@ -1,0 +1,40 @@
+import type { IdentityAuthState } from '@guardian/identity-auth';
+import { useEffect, useState } from 'react';
+
+export type AuthStateStatus = 'Pending' | 'NotInTest' | 'Ready';
+
+async function getAuthState(): Promise<IdentityAuthState> {
+	const { isSignInWithOktaAuthState } = await import('./identity');
+	const authState = await isSignInWithOktaAuthState();
+	return authState;
+}
+
+export const useSignedInAuthState = (): [
+	AuthStateStatus,
+	IdentityAuthState,
+] => {
+	const [status, setStatus] = useState<AuthStateStatus>('Pending');
+	const [authState, setAuthState] = useState<IdentityAuthState>({
+		isAuthenticated: false,
+	});
+
+	useEffect(() => {
+		const isInOktaExperiment =
+			window.guardian.config.tests.oktaVariant === 'variant';
+
+		if (isInOktaExperiment) {
+			getAuthState()
+				.then((result) => {
+					setAuthState(result);
+					setStatus('Ready');
+				})
+				.catch((error) => {
+					console.error(error);
+				});
+		} else {
+			setStatus('NotInTest');
+		}
+	}, []);
+
+	return [status, authState];
+};

--- a/dotcom-rendering/src/lib/useSignedInAuthState.ts
+++ b/dotcom-rendering/src/lib/useSignedInAuthState.ts
@@ -28,8 +28,8 @@ export const getOptionsHeadersWithOkta = (
 export async function getAuthState(): Promise<
 	IdentityAuthState<never, CustomIdTokenClaims>
 > {
-	const { isSignInWithOktaAuthState } = await import('./identity');
-	const authState = await isSignInWithOktaAuthState();
+	const { isSignedInWithOktaAuthState } = await import('./identity');
+	const authState = await isSignedInWithOktaAuthState();
 	return authState;
 }
 
@@ -54,7 +54,8 @@ export const useSignedInAuthState = (): [
 	AuthStateStatus,
 	IdentityAuthState<never, CustomIdTokenClaims>,
 ] => {
-	const [status, setStatus] = useState<AuthStateStatus>('Pending');
+	const [authStateStatus, setAuthStateStatus] =
+		useState<AuthStateStatus>('Pending');
 	const [authState, setAuthState] = useState<
 		IdentityAuthState<never, CustomIdTokenClaims>
 	>({
@@ -65,13 +66,13 @@ export const useSignedInAuthState = (): [
 		eitherSignedInWithOktaOrElse(
 			(state) => {
 				setAuthState(state);
-				setStatus('Ready');
+				setAuthStateStatus('Ready');
 			},
-			() => setStatus('NotInTest'),
+			() => setAuthStateStatus('NotInTest'),
 		).catch((error) => {
 			console.error(error);
 		});
 	}, []);
 
-	return [status, authState];
+	return [authStateStatus, authState];
 };

--- a/dotcom-rendering/src/lib/useSignedInStatus.ts
+++ b/dotcom-rendering/src/lib/useSignedInStatus.ts
@@ -14,19 +14,21 @@ function getSignedInStatusWithCookie(): 'NotSignedIn' | 'SignedIn' {
 export const useSignedInStatus = (): SignedInStatus => {
 	const [signedInStatus, setSignedInStatus] =
 		useState<SignedInStatus>('Pending');
-	const [authStateStatus, authState] = useSignedInAuthState();
+	const authStateStatus = useSignedInAuthState();
 
 	useEffect(() => {
-		if (authStateStatus === 'Ready') {
+		if (authStateStatus.kind === 'Ready') {
 			setSignedInStatus(
-				authState.isAuthenticated ? 'SignedIn' : 'NotSignedIn',
+				authStateStatus.authState.isAuthenticated
+					? 'SignedIn'
+					: 'NotSignedIn',
 			);
 		}
 
-		if (authStateStatus === 'NotInTest') {
+		if (authStateStatus.kind === 'NotInTest') {
 			setSignedInStatus(getSignedInStatusWithCookie());
 		}
-	}, [authState.isAuthenticated, authStateStatus]);
+	}, [authStateStatus]);
 
 	return signedInStatus;
 };


### PR DESCRIPTION
Co-authored by: Georges Lebreton georges.lebreton@guardian.co.uk
Co-authored by: Jamie Byers james.byers@guardian.co.uk

## What does this change?

Following on from https://github.com/guardian/dotcom-rendering/pull/7643 we identified places in DCR when we need to either use the OAuth ID Token to read data about the user, or use the OAuth Access token to make requests to Guardian APIs on behalf of the user.

We first identified the places where this was being used in: https://github.com/guardian/dotcom-rendering/pull/7982/commits/2305fab32de1f8db8f6c904a4865af40401d4a94

- [x] `dotcom-rendering/src/components/DiscussionMeta.importable.tsx` - Migrate to use Access Token to make call to Discussion API `/profile/me` endpoint
- [x] `dotcom-rendering/src/components/DiscussionWhenSignedIn.tsx` - Migrate to use Access Token to make call to Discussion API `/profile/me` endpoint
- [x] `dotcom-rendering/src/components/HeaderTopBarMyAccount.tsx` - Update to read `userId` from the ID token claims (`legacy_identity_id`)
- [x] `dotcom-rendering/src/components/SlotBodyEnd/BrazeEpic.tsx` - Migrate to use Access Token to update users newsletters
- [x] `dotcom-rendering/src/components/StickyBottomBanner/BrazeBanner.tsx` - Migrate to use Access Token to update users newsletters
- [x] `dotcom-rendering/src/lib/contributions.ts` - Update to read `email` from the ID token claims
- [x] `dotcom-rendering/src/lib/getBrazeUuid.ts` - Update to read `brazeUuid` from the ID token claims (`braze_uuid`)

The `IdentityAuth` library initialisation was updated to add in the new scopes required for migrating the above items, and commented to explain what each scope does:

```ts
...
scopes: [
	'openid', // required for open id connect, returns an id token
	'profile', // populates the id token with basic profile information
	'email', // populates the id token with the user's email address
	'guardian.discussion-api.private-profile.read.self', // allows the access token to be used to make requests to the discussion api to read the user's profile
	'guardian.discussion-api.update.secure', // allows the access token to be used to make requests to the discussion api to post comments, upvote etc
	'guardian.identity-api.newsletters.read.self', // allows the access token to be used to make requests to the identity api to read the user's newsletter subscriptions
	'guardian.identity-api.newsletters.update.self', // allows the access token to be used to make requests to the identity api to update the user's newsletter subscriptions
	'guardian.members-data-api.read.self', // allows the access token to be used to make requests to the members data api to read the user's membership status
	'id_token.profile.theguardian', // populates the id token with application specific profile information
],
...
```

We make sure to add a `CustomIdTokenClaims` to make typescript aware that we're expecting the `email` and `braze_uuid` in the ID token claims too.

To facilitate getting the `IdentityAuthState` which contains the Access Token, ID Token, and authenticated `boolean`, we first update the `isSignedInWithOkta` method to be called `isSignInWithOktaAuthState` which returns the `IdentityAuthState` instead of a boolean.

We made a new React hook called `useSignedInAuthState`, which used the `isSignInWithOktaAuthState` method, the hook returns the current status (`'Pending' | 'NotInTest' | 'Ready'`), and the `IdentityAuthState`.

Depending on if the user is in the `oktaVariant` test or not we need to do different things. The `eitherSignedInWithOktaOrElse` is used to do this. This method checks if the user is in the `oktaVariant` test or not and does one of two things. If in the test, the method calls the `inOktaTestFunction` parameter, which is a callback function that handles what should happen in the case the user is in the test. If the user is not in the test, the `eitherSignedInWithOktaOrElse` method calls the `notInOktaTestFunction` callback function, which as describes handles the case when the user isn't in the test.

Once the status is determined, we either set the `Ready` flag, or `NotInTest` flag.

Now that we have the `useSignedInAuthState` and the `eitherSignedInWithOktaOrElse` method we can update the places we need. In the case of a React component/function we use the `useSignedInAuthState` hook to perform Okta related activites, in the case where it's not in the context of React we use the `eitherSignedInWithOktaOrElse` method.

## How to test

View or display relevant pages which have Identity related features, e.g. articles with commenting.

Opt into the Okta test by setting the relevant cookie value.

## Follow up

[`discussion-rendering`](https://github.com/guardian/discussion-rendering/) needs to be migrated to use Okta Access tokens too to make API calls in a discussion related context.