### PR TITLE
Add Australia state switcher

### DIFF
--- a/dotcom-rendering/src/components/AustralianTerritorySwitcher.importable.stories.tsx
+++ b/dotcom-rendering/src/components/AustralianTerritorySwitcher.importable.stories.tsx
@@ -1,0 +1,25 @@
+import { userEvent, within } from '@storybook/testing-library';
+import { AustralianTerritorySwitcher } from './AustralianTerritorySwitcher.importable';
+
+export default {
+	component: AustralianTerritorySwitcher,
+	title: 'Components/AustralianTerritorySwitcher',
+};
+
+export const Victoria = () => (
+	<AustralianTerritorySwitcher targetedTerritory="AU-VIC" />
+);
+
+export const Queensland = () => (
+	<AustralianTerritorySwitcher targetedTerritory="AU-QLD" />
+);
+
+/**
+ * Clicks the “Not in Queensland” button so that Chromatic can capture
+ * it the component in its `expanded` state.
+ */
+Queensland.play = ({ canvasElement }: { canvasElement: HTMLElement }) => {
+	const canvas = within(canvasElement);
+	userEvent.click(canvas.getByRole('button'));
+};
+Queensland.storyName = 'Queensland (expanded)';

--- a/dotcom-rendering/src/components/AustralianTerritorySwitcher.importable.tsx
+++ b/dotcom-rendering/src/components/AustralianTerritorySwitcher.importable.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import { removeCookie, setCookie } from '@guardian/libs';
-import { space } from '@guardian/source-foundations';
+import { space, textSans } from '@guardian/source-foundations';
 import {
 	Button,
 	ChoiceCard,
@@ -23,6 +23,19 @@ const territories = {
 } as const satisfies Record<AustralianTerritory, string>;
 
 const controls = 'change-territory';
+const controlsStyles = css`
+	max-width: 700px;
+`;
+
+const labelStyles = css`
+	${textSans.medium()}
+	padding-bottom: ${space[3]}px;
+	display: block;
+
+	strong {
+		${textSans.medium({ fontWeight: 'bold' })}
+	}
+`;
 
 type Props = {
 	targetedTerritory: AustralianTerritory;
@@ -48,36 +61,46 @@ export const AustralianTerritorySwitcher = ({ targetedTerritory }: Props) => {
 			</Button>
 
 			{expanded && (
-				<ChoiceCardGroup
-					id={controls}
-					name="territory"
-					label="The articles above have been curated for you based on the state you are in."
-					supporting="If we have your location wrong or you want to see coverage of a different state, please select from the links below. We hope to expand this service to other states in the future."
-					onChange={({ target }) => {
-						if ('value' in target && isString(target.value)) {
-							const value = target.value;
+				<div id={controls} css={controlsStyles}>
+					<label htmlFor="territory" css={labelStyles}>
+						<strong>
+							The articles above have been curated for you based
+							on the state you are in.
+						</strong>{' '}
+						If we have your location wrong or you want to see
+						coverage of a different state, please select from the
+						links below. We hope to expand this service to other
+						states in the future.
+					</label>
 
-							removeCookie({ name: 'GU_territory' });
-							setCookie({
-								name: 'GU_territory',
-								value,
-							});
-							window.location.reload();
-						}
-					}}
-				>
-					<>
-						{Object.entries(territories).map(([id, label]) => (
-							<ChoiceCard
-								key={id}
-								id={id}
-								value={id}
-								label={label}
-								checked={id === targetedTerritory}
-							/>
-						))}
-					</>
-				</ChoiceCardGroup>
+					<ChoiceCardGroup
+						name="territory"
+						onChange={({ target }) => {
+							if ('value' in target && isString(target.value)) {
+								const value = target.value;
+
+								removeCookie({ name: 'GU_territory' });
+								setCookie({
+									name: 'GU_territory',
+									value,
+								});
+								window.location.reload();
+							}
+						}}
+					>
+						<>
+							{Object.entries(territories).map(([id, label]) => (
+								<ChoiceCard
+									key={id}
+									id={id}
+									value={id}
+									label={label}
+									checked={id === targetedTerritory}
+								/>
+							))}
+						</>
+					</ChoiceCardGroup>
+				</div>
 			)}
 		</div>
 	);

--- a/dotcom-rendering/src/components/AustralianTerritorySwitcher.importable.tsx
+++ b/dotcom-rendering/src/components/AustralianTerritorySwitcher.importable.tsx
@@ -1,0 +1,84 @@
+import { css } from '@emotion/react';
+import { removeCookie, setCookie } from '@guardian/libs';
+import { space } from '@guardian/source-foundations';
+import {
+	Button,
+	ChoiceCard,
+	ChoiceCardGroup,
+	SvgChevronDownSingle,
+	SvgChevronUpSingle,
+} from '@guardian/source-react-components';
+import { isString } from 'lodash';
+import { useState } from 'react';
+import type { AustralianTerritory } from '../types/territory';
+
+const styles = css`
+	padding: ${space[2]}px;
+`;
+
+const territories = {
+	'AU-NSW': 'New South Wales',
+	'AU-QLD': 'Queensland',
+	'AU-VIC': 'Victoria',
+} as const satisfies Record<AustralianTerritory, string>;
+
+const controls = 'change-territory';
+
+type Props = {
+	targetedTerritory: AustralianTerritory;
+};
+export const AustralianTerritorySwitcher = ({ targetedTerritory }: Props) => {
+	const [expanded, setExpanded] = useState(false);
+
+	return (
+		<div css={styles}>
+			<Button
+				priority="subdued"
+				onClick={() => {
+					setExpanded(!expanded);
+				}}
+				icon={
+					expanded ? <SvgChevronUpSingle /> : <SvgChevronDownSingle />
+				}
+				iconSide="right"
+				aria-expanded={expanded}
+				aria-controls={controls}
+			>
+				Not in {territories[targetedTerritory]}? Change region
+			</Button>
+
+			{expanded && (
+				<ChoiceCardGroup
+					id={controls}
+					name="territory"
+					label="The articles above have been curated for you based on the state you are in."
+					supporting="If we have your location wrong or you want to see coverage of a different state, please select from the links below. We hope to expand this service to other states in the future."
+					onChange={({ target }) => {
+						if ('value' in target && isString(target.value)) {
+							const value = target.value;
+
+							removeCookie({ name: 'GU_territory' });
+							setCookie({
+								name: 'GU_territory',
+								value,
+							});
+							window.location.reload();
+						}
+					}}
+				>
+					<>
+						{Object.entries(territories).map(([id, label]) => (
+							<ChoiceCard
+								key={id}
+								id={id}
+								value={id}
+								label={label}
+								checked={id === targetedTerritory}
+							/>
+						))}
+					</>
+				</ChoiceCardGroup>
+			)}
+		</div>
+	);
+};

--- a/dotcom-rendering/src/components/FrontSection.tsx
+++ b/dotcom-rendering/src/components/FrontSection.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import { isString } from '@guardian/libs';
 import {
 	from,
 	neutral,
@@ -12,6 +13,8 @@ import { decideContainerOverrides } from '../lib/decideContainerOverrides';
 import type { EditionId } from '../lib/edition';
 import type { DCRBadgeType } from '../types/badge';
 import type { DCRContainerPalette, TreatType } from '../types/front';
+import { isAustralianTerritory, type Territory } from '../types/territory';
+import { AustralianTerritorySwitcher } from './AustralianTerritorySwitcher.importable';
 import { Badge } from './Badge';
 import { ContainerTitle } from './ContainerTitle';
 import { Island } from './Island';
@@ -68,6 +71,8 @@ type Props = {
 	isOnPaidContentFront?: boolean;
 	/** Denotes the position of this section on the front */
 	index?: number;
+	/** Indicates if the container is targetted to a specific territory */
+	targetedTerritory?: Territory;
 };
 
 const width = (columns: number, columnWidth: number, columnGap: number) =>
@@ -404,6 +409,7 @@ export const FrontSection = ({
 	ajaxUrl,
 	isOnPaidContentFront,
 	index,
+	targetedTerritory,
 }: Props) => {
 	const overrides =
 		containerPalette && decideContainerOverrides(containerPalette);
@@ -549,7 +555,14 @@ export const FrontSection = ({
 			</div>
 
 			<div css={[sectionContentPadded, sectionShowMore, bottomPadding]}>
-				{showMore && (
+				{isString(targetedTerritory) &&
+				isAustralianTerritory(targetedTerritory) ? (
+					<Island deferUntil="interaction">
+						<AustralianTerritorySwitcher
+							targetedTerritory={targetedTerritory}
+						/>
+					</Island>
+				) : showMore ? (
 					<Island deferUntil="interaction">
 						<ShowMore
 							title={title}
@@ -562,7 +575,7 @@ export const FrontSection = ({
 							showAge={title === 'Headlines'}
 						/>
 					</Island>
-				)}
+				) : null}
 			</div>
 
 			{treats && (

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -475,6 +475,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 								ajaxUrl={front.config.ajaxUrl}
 								isOnPaidContentFront={isPaidContent}
 								index={index}
+								targetedTerritory={collection.targetedTerritory}
 							>
 								<DecideContainer
 									trails={trails}

--- a/dotcom-rendering/src/lib/guard.ts
+++ b/dotcom-rendering/src/lib/guard.ts
@@ -1,0 +1,7 @@
+/** A method to create type-guard for string unions */
+export const guard =
+	<T extends readonly string[]>(array: T) =>
+	(value: string): value is (typeof array)[number] =>
+		array.includes(value);
+
+export type Guard<T> = T extends readonly string[] ? T[number] : never;

--- a/dotcom-rendering/src/model/enhanceCollections.ts
+++ b/dotcom-rendering/src/model/enhanceCollections.ts
@@ -92,6 +92,7 @@ export const enhanceCollections = (
 				showDateHeader: collection.config.showDateHeader,
 			},
 			canShowMore: hasMore && !collection.config.hideShowMore,
+			targetedTerritory: collection.targetedTerritory,
 		};
 	});
 };

--- a/dotcom-rendering/src/model/front-schema.json
+++ b/dotcom-rendering/src/model/front-schema.json
@@ -2694,6 +2694,9 @@
                             },
                             "hasMore": {
                                 "type": "boolean"
+                            },
+                            "targetedTerritory": {
+                                "$ref": "#/definitions/Territory"
                             }
                         },
                         "required": [
@@ -2955,6 +2958,20 @@
                 "SombrePalette",
                 "Special",
                 "SpecialReportAltPalette"
+            ],
+            "type": "string"
+        },
+        "Territory": {
+            "description": "List of territories that can be targetted against.",
+            "enum": [
+                "AU-NSW",
+                "AU-QLD",
+                "AU-VIC",
+                "EU-27",
+                "NZ",
+                "US-East-Coast",
+                "US-West-Coast",
+                "XX"
             ],
             "type": "string"
         },

--- a/dotcom-rendering/src/server/lib/get-content-from-url.js
+++ b/dotcom-rendering/src/server/lib/get-content-from-url.js
@@ -24,7 +24,11 @@ async function getContentFromURL(url, _headers) {
 	/** @type {HeadersInit} */
 	const headers = Object.fromEntries(
 		Object.entries(_headers)
-			.filter(([key]) => key.toLowerCase().startsWith('x-gu-'))
+			.filter(
+				([key]) =>
+					key.toLowerCase() === 'cookie' ||
+					key.toLowerCase().startsWith('x-gu-'),
+			)
 			.filter(isStringTuple),
 	);
 

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -5,6 +5,7 @@ import type { Branding } from './branding';
 import type { ServerSideTests, Switches } from './config';
 import type { FooterType } from './footer';
 import type { FETagType } from './tag';
+import type { Territory } from './territory';
 import type { FETrailType, TrailType } from './trails';
 
 export interface FEFrontType {
@@ -348,6 +349,7 @@ export type FECollectionType = {
 	showLatestUpdate: boolean;
 	config: FECollectionConfigType;
 	hasMore: boolean;
+	targetedTerritory?: Territory;
 };
 
 export type DCRCollectionType = {
@@ -372,6 +374,7 @@ export type DCRCollectionType = {
 	 **/
 	canShowMore?: boolean;
 	badge?: DCRBadgeType;
+	targetedTerritory?: Territory;
 };
 
 export type DCRGroupedTrails = {

--- a/dotcom-rendering/src/types/territory.ts
+++ b/dotcom-rendering/src/types/territory.ts
@@ -1,0 +1,26 @@
+import type { Guard } from '../lib/guard';
+import { guard } from '../lib/guard';
+
+type AmericanTerritories = 'US-East-Coast' | 'US-West-Coast';
+
+type EuropeanTerritories = 'EU-27';
+
+const australianTerritories = ['AU-VIC', 'AU-QLD', 'AU-NSW'] as const;
+export const isAustralianTerritory = guard(australianTerritories);
+export type AustralianTerritory = Guard<typeof australianTerritories>;
+
+type NewZealandTerritories = 'NZ';
+
+type UnknownTerritories = 'XX';
+
+/**
+ * List of territories that can be targetted against.
+ *
+ * @see https://github.com/guardian/facia-scala-client/blob/52562dec5e8518b79ba1c8b95a0cbe9502b9e2e5/facia-json/src/main/scala/com/gu/facia/client/models/Config.scala#L123-L187
+ */
+export type Territory =
+	| AmericanTerritories
+	| EuropeanTerritories
+	| AustralianTerritory
+	| NewZealandTerritories
+	| UnknownTerritories;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Add the australian state switcher on DCR fronts, which is required to display localised news on the `AU` front.

Once this is done, we can [update Frontend’s `FaciaPicker` to allow displaying fronts with Australian territories targetted containers](https://github.com/guardian/frontend/blob/0ab174b0b3982a68c60338130c6b68ed58b2e75c/facia/app/services/dotcomrendering/FaciaPicker.scala#L127-L138).

Pass local cookies to the content request, which enables local testing of the targetted territories feature.

## Why?

Closes #6177 
Closes #6234

## Screenshots

We can see slight differences between the two rendering tiers, but I deemed them acceptable as the DCR version is using native **Source** components rathen than an exact visual replica.

| Frontend      | DCR      |
| ------------- | ---------- |
| ![Frontend][] | ![DCR][] |
| ![Frontend mobile][] | ![DCR mobile][] |

[Frontend]: https://github.com/guardian/dotcom-rendering/assets/76776/7d371249-0584-4f3f-96d3-06dcd4d52d07
[DCR]: https://github.com/guardian/dotcom-rendering/assets/76776/b5991372-f4d5-4453-9d25-9235f767c596

[Frontend mobile]: https://github.com/guardian/dotcom-rendering/assets/76776/e29fef95-d1c0-45d8-bb25-62870777c776
[DCR mobile]: https://github.com/guardian/dotcom-rendering/assets/76776/e516f4e8-25d3-4fad-aaca-d9a0980a5d2d


**Note:** Compared to Frontend, we removed “Hide local news”, as hiding the container is sufficient for this use-case, and when people click this button they cannot get the local news container ever again–bar modifying their cookies manually. Discussed with @rhiannareechaye 

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.



You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->