### PR TITLE
Rectify prod redirectUri variable

### DIFF
--- a/dotcom-rendering/src/lib/identity.ts
+++ b/dotcom-rendering/src/lib/identity.ts
@@ -17,7 +17,7 @@ const getClientId = (stage: StageType) =>
 const getRedirectUri = (stage: StageType) => {
 	switch (stage) {
 		case 'PROD':
-			return 'https://www.theguardian.com/ ';
+			return 'https://www.theguardian.com/';
 		case 'CODE':
 			return 'https://m.code.dev-theguardian.com/';
 		case 'DEV':


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Removes a space that snuck into the switch statement. 

## Why?

It's not the correct variable otherwise. 