### PR TITLE
Includes SignInGateSelector component in identityAuth test

### DIFF
--- a/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
+++ b/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 import { parseCheckoutCompleteCookieData } from '../lib/parser/parseCheckoutOutCookieData';
 import { constructQuery } from '../lib/querystring';
 import { useOnce } from '../lib/useOnce';
+import { useSignedInStatus } from '../lib/useSignedInStatus';
 import { useSignInGateSelector } from '../lib/useSignInGateSelector';
 import type { TagType } from '../types/tag';
 import type { ComponentEventParams } from './SignInGate/componentEventTracking';
@@ -150,7 +151,7 @@ export const SignInGateSelector = ({
 	pageId,
 	idUrl = 'https://profile.theguardian.com',
 }: Props) => {
-	const isSignedIn = !!getCookie({ name: 'GU_U', shouldMemoize: true });
+	const isSignedIn = useSignedInStatus() === 'SignedIn';
 	const [isGateDismissed, setIsGateDismissed] = useState<boolean | undefined>(
 		undefined,
 	);


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Refactors the SignInGateSelector.importable component to use the useIsSignedIn like the other components who check the `isSignedIn` boolean.

## Why?

This got missed in [the initial PR](https://github.com/guardian/dotcom-rendering/pull/7643/). 
