### PR TITLE
`data-link-name` ignore list

### DIFF
--- a/dotcom-rendering/src/components/Nav/ExpandedMenu/CollapseColumnButton.tsx
+++ b/dotcom-rendering/src/components/Nav/ExpandedMenu/CollapseColumnButton.tsx
@@ -102,10 +102,7 @@ export const CollapseColumnButton = ({
 		// eslint-disable-next-line jsx-a11y/no-noninteractive-element-to-interactive-role -- we’re using this label for a CSS-only toggle
 		role="menuitem"
 		data-cy={`column-collapse-${title}`}
-		data-link-name={nestedOphanComponents(
-			'nav2',
-			`column-toggle-${title}: show`,
-		)}
+		data-link-name={nestedOphanComponents('nav2', `secondary`, title)}
 	>
 		{title}
 	</label>

--- a/scripts/deno/ophan-components.ts
+++ b/scripts/deno/ophan-components.ts
@@ -18,6 +18,27 @@ const html = await Promise.all(
 const known_errors = new Set([
 	// it only appears in DCR after hydration if signed in
 	'nav3 : topbar : my account',
+	'nav3 : topbar : account overview',
+	'nav3 : topbar : billing',
+	'nav3 : topbar : profile',
+	'nav3 : topbar : email prefs',
+	'nav3 : topbar : data privacy',
+	'nav3 : topbar : settings',
+	'nav3 : topbar : help',
+	'nav3 : topbar : comment activity',
+	'nav3 : topbar : sign out',
+
+	// Palette thrasher related
+	'container-0 | palette-styles-new-do-not-delete',
+	'palette-styles-new-do-not-delete',
+	'external | group-0 | card-@1',
+
+	// These elements don't exist anymore in the DOM after Deeply Read component was added
+	'6 | text',
+	'7 | text',
+	'8 | text',
+	'9 | text',
+	'10 | text'
 ]);
 
 const getOphanComponents = (


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## Why?
We know they will never match. We are adding them in the ignore list so that `ophan-components.ts` does not add them in https://github.com/guardian/dotcom-rendering/issues/4692 and https://github.com/guardian/dotcom-rendering/issues/4698 

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
