### PR TITLE
Remove underline from `nav/list` and `nav/media-list`

### DIFF
--- a/dotcom-rendering/src/components/MiniCard.tsx
+++ b/dotcom-rendering/src/components/MiniCard.tsx
@@ -1,10 +1,10 @@
 import { css } from '@emotion/react';
 import { body, breakpoints } from '@guardian/source-foundations';
 import { Link } from '@guardian/source-react-components';
+import { decideContainerOverrides } from '../lib/decideContainerOverrides';
 import type { DCRContainerPalette } from '../types/front';
 import type { ContainerOverrides } from '../types/palette';
 import type { TrailType } from '../types/trails';
-import { decideContainerOverrides } from '../lib/decideContainerOverrides';
 import { generateSources } from './Picture';
 
 const imageStyles = css`
@@ -17,6 +17,7 @@ const linkStyles = css`
 	font-weight: bold;
 	display: flex;
 	align-items: flex-start;
+	text-decoration: none;
 `;
 
 const linkOverrideStyles = (containerOverrides?: ContainerOverrides) => css`
@@ -73,7 +74,6 @@ export const MiniCard = ({ trail, showImage, containerPalette }: Props) => {
 		<Link
 			href={trail.url}
 			priority="secondary"
-			subdued={true}
 			cssOverrides={[linkStyles, linkOverrideStyles(containerOverrides)]}
 		>
 			{showImage && !!trail.image && (


### PR DESCRIPTION
## What does this change?

Remove underlines on links in `nav/list` and `nav/media-list`

## Why?

Frontend doesn't have these underlines. Design is happy with them either way but DigiEds would prefer them gone.

This was introduced when a upgrade in Source caused the `subdued` prop to no longer do anything.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/21217225/a0be0ac8-b0d5-42d1-aff8-7501beb1b6ef
[after]: https://github.com/guardian/dotcom-rendering/assets/21217225/748da247-714d-4e4a-94a6-5b9cd4b67cc7

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
