### PR TITLE
Always apply `flex-grow`  to Card content

### DIFF
--- a/dotcom-rendering/src/components/Card/components/ContentWrapper.tsx
+++ b/dotcom-rendering/src/components/Card/components/ContentWrapper.tsx
@@ -5,6 +5,7 @@ import { between, from } from '@guardian/source-foundations';
 const sizingStyles = css`
 	display: flex;
 	flex-direction: column;
+	flex-grow: 1;
 	justify-content: space-between;
 `;
 
@@ -72,18 +73,11 @@ export const ContentWrapper = ({
 	imagePosition,
 }: Props) => {
 	const isHorizontal = imagePosition === 'left' || imagePosition === 'right';
-	const isVertical = imagePosition === 'top' || imagePosition === 'bottom';
 	return (
 		<div
 			css={[
 				sizingStyles,
 				isHorizontal && flexBasisStyles({ imageSize, imageType }),
-				/* If the image is top or bottom positioned then it takes 100% of the width and
-				   we want the content to grow into the remaining vertical space */
-				isVertical &&
-					css`
-						flex-grow: 1;
-					`,
 			]}
 		>
 			{children}


### PR DESCRIPTION
## What does this change?

Always apply `flex-grow` to Card content. 

## Why?

This makes sure that if a card is missing an image that the content can grow to fill that empty gap. This is especially noticeable when a card in `fixed/small/slow-I` has no image, such as the "How to listen to Podcasts" container on the podcasts front.

Fixes #7689

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/21217225/2753147b-c7ed-494a-916e-05e0352611ae
[after]: https://github.com/guardian/dotcom-rendering/assets/21217225/5561ac0e-ecab-47f8-8215-7bda3641cea7

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
