### PR TITLE
Use type guard for string unions

### DIFF
--- a/dotcom-rendering/src/components/ContentABTest.amp.tsx
+++ b/dotcom-rendering/src/components/ContentABTest.amp.tsx
@@ -1,5 +1,6 @@
 import sha256 from 'crypto-js/sha256';
 import React from 'react';
+import { guard } from '../lib/guard';
 import type { Switches } from '../types/config';
 
 const AB_TEST_GROUPS = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11] as const;
@@ -8,8 +9,7 @@ const NUM_GROUPS = AB_TEST_GROUPS.length;
 
 type ContentABTestGroup = (typeof AB_TEST_GROUPS)[number];
 
-const isContentABTestGroup = (n: number): n is ContentABTestGroup =>
-	AB_TEST_GROUPS.includes(n as ContentABTestGroup);
+const isContentABTestGroup = guard(AB_TEST_GROUPS);
 
 interface ContentABTestContext {
 	group?: ContentABTestGroup;

--- a/dotcom-rendering/src/components/SignInGate/types.ts
+++ b/dotcom-rendering/src/components/SignInGate/types.ts
@@ -1,4 +1,6 @@
-import { isObject } from '@guardian/libs';
+import { isObject, isString } from '@guardian/libs';
+import type { Guard } from '../../lib/guard';
+import { guard } from '../../lib/guard';
 import type { TagType } from '../../types/tag';
 
 export type CanShowGateProps = {
@@ -20,11 +22,9 @@ export type SignInGateComponent = {
 };
 
 export const ALL_USER_TYPES = ['new', 'guest', 'current'] as const;
-type UserTypeTuple = typeof ALL_USER_TYPES;
-export type UserType = UserTypeTuple[number];
+export type UserType = Guard<typeof ALL_USER_TYPES>;
 
-export const isUserType = (value: unknown): value is UserType =>
-	ALL_USER_TYPES.includes(value as UserType);
+export const isUserType = guard(ALL_USER_TYPES);
 
 export const ALL_PRODUCTS = [
 	'Contribution',
@@ -32,11 +32,9 @@ export const ALL_PRODUCTS = [
 	'Paper',
 	'GuardianWeekly',
 ] as const;
-type ProductTuple = typeof ALL_PRODUCTS;
-export type Product = ProductTuple[number];
+export type Product = Guard<typeof ALL_PRODUCTS>;
 
-export const isProduct = (value: unknown): value is Product =>
-	ALL_PRODUCTS.includes(value as Product);
+export const isProduct = guard(ALL_PRODUCTS);
 export interface CheckoutCompleteCookieData {
 	userType: UserType;
 	product: Product;
@@ -45,7 +43,13 @@ export interface CheckoutCompleteCookieData {
 export function isCheckoutCompleteCookieData(
 	obj: unknown,
 ): obj is CheckoutCompleteCookieData {
-	return isObject(obj) && isUserType(obj.userType) && isProduct(obj.product);
+	return (
+		isObject(obj) &&
+		isString(obj.userType) &&
+		isUserType(obj.userType) &&
+		isString(obj.product) &&
+		isProduct(obj.product)
+	);
 }
 export type SignInGateProps = {
 	signInUrl: string;

--- a/dotcom-rendering/src/lib/edition.ts
+++ b/dotcom-rendering/src/lib/edition.ts
@@ -1,4 +1,5 @@
 import type { EditionLinkType } from '../model/extract-nav';
+import { guard } from './guard';
 
 export type EditionId = (typeof editionList)[number]['editionId'];
 
@@ -79,5 +80,4 @@ export const getRemainingEditions = (
  *
  * @param s The string to test
  */
-export const isEditionId = (s: string): s is EditionId =>
-	editionList.map(({ editionId }) => String(editionId)).includes(s);
+export const isEditionId = guard(editionList.map(({ editionId }) => editionId));

--- a/dotcom-rendering/src/lib/guard.ts
+++ b/dotcom-rendering/src/lib/guard.ts
@@ -1,7 +1,7 @@
 /** A method to create type-guard for string unions */
 export const guard =
-	<T extends readonly string[]>(array: T) =>
-	(value: string): value is (typeof array)[number] =>
+	<T extends readonly unknown[]>(array: T) =>
+	(value: unknown): value is (typeof array)[number] =>
 		array.includes(value);
 
-export type Guard<T> = T extends readonly string[] ? T[number] : never;
+export type Guard<T> = T extends readonly unknown[] ? T[number] : never;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Use type-guard library method introduced in #7984

## Why?

It’s a pattern used three times already, so it seems worth abstracting away.

## Screenshots

N/A