### PR TITLE
Reserve 10px height for comment count

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -342,6 +342,7 @@ export const Card = ({
 								font-size: inherit;
 								line-height: inherit;
 								text-decoration: none;
+								min-height: 10px;
 							`}
 						/>
 					) : undefined


### PR DESCRIPTION
## What does this change?

Add `min-height: 10px` to the Comment count link on cards.

## Why?

After this component is hydrated its height increases. By adding a min-height we ensure that after its hydrated its not taller than what it was originally. This should help reduce CLS.

Fixes #7980 