### PR TITLE
Fix underline showing on non link titles

### DIFF
--- a/dotcom-rendering/src/components/ContainerTitle.tsx
+++ b/dotcom-rendering/src/components/ContainerTitle.tsx
@@ -34,7 +34,9 @@ const headerStyles = (fontColour?: string) => css`
 	padding-bottom: ${space[1]}px;
 	padding-top: 6px;
 	overflow-wrap: break-word; /*if a single word is too long, this will break the word up rather than have the display be affected*/
+`;
 
+const headerStylesWithUrl = css`
 	:hover {
 		text-decoration: underline;
 	}
@@ -99,7 +101,7 @@ export const ContainerTitle = ({
 					href={url}
 					data-link-name="section heading"
 				>
-					<h2 css={headerStyles(fontColour)}>
+					<h2 css={[headerStylesWithUrl, headerStyles(fontColour)]}>
 						{localisedTitle(title, editionId)}
 					</h2>
 				</a>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
This adds a new css class for container titles with URL to display an underline on hover.
## Why?
This was previously active on non links. Fixes https://github.com/guardian/dotcom-rendering/issues/7949
## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/110032454/f483bac6-2dde-43c4-9c52-747c12dfecfd
[after]: https://github.com/guardian/dotcom-rendering/assets/110032454/5e2d52e1-8507-4da1-9a0a-83d1f4cd99fd

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
