### PR TITLE
Ensure node versions are aligned (bis)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,6 +13,9 @@ jobs:
           cache: 'yarn'
       - run: make install
         working-directory: dotcom-rendering
+      - name: Lint Project
+        run: make lint-project
+        working-directory: dotcom-rendering
       - name: Lint
         run: make lint
         working-directory: dotcom-rendering

--- a/apps-rendering/riff-raff.yaml
+++ b/apps-rendering/riff-raff.yaml
@@ -11,7 +11,8 @@ templates:
       amiParameter: AMIMobileappsrendering
       amiEncrypted: true
       amiTags:
-        Recipe: jammy-mobile-node18-ARM
+        # Keep the Node version in sync with `.nvmrc`
+        Recipe: jammy-mobile-node18.16.1-ARM
         AmigoStage: PROD
 deployments:
   mobile-apps-rendering-cfn:

--- a/dotcom-rendering/Containerfile
+++ b/dotcom-rendering/Containerfile
@@ -1,4 +1,5 @@
 # This container is used in our CICD pipelines for running E2E and regression tests.
+# Keep the Node version in sync with `.nvmrc`
 FROM node:18.16.1-alpine
 
 WORKDIR /opt/app/dotcom-rendering/dotcom-rendering

--- a/dotcom-rendering/makefile
+++ b/dotcom-rendering/makefile
@@ -136,6 +136,10 @@ lint: clean-dist install
 	$(call log, "checking for lint errors")
 	@yarn lint
 
+lint-project:
+	$(call log, "linting project")
+	@node ../scripts/check-node-versions.mjs
+
 stylelint: clean-dist install
 	$(call log, "checking for style lint errors")
 	@stylelint "src/**/*.ts{,x}"
@@ -149,10 +153,10 @@ test-ci: clear clean-dist install
 	$(call log, "running tests")
 	@yarn test:ci --verbose --collectCoverage --coverageReporters=lcov
 
-validate: clean-dist install tsc lint stylelint test validate-build
+validate: clean-dist install lint-project tsc lint stylelint test validate-build
 	$(call log, "everything seems 👌")
 
-validate-ci: install tsc lint stylelint test-ci
+validate-ci: install lint-project tsc lint stylelint test-ci
 	$(call log, "everything seems 👌")
 
 # helpers #########################################

--- a/dotcom-rendering/scripts/deploy/riff-raff.yaml
+++ b/dotcom-rendering/scripts/deploy/riff-raff.yaml
@@ -19,7 +19,8 @@ deployments:
           InstanceType: t4g.small
       amiParametersToTags:
         AMI:
-          Recipe: dotcom-rendering-ARM-jammy-node-18
+          # Keep the Node version in sync with `.nvmrc`
+          Recipe: dotcom-rendering-ARM-jammy-node-18.16.1
           BuiltBy: amigo
           AmigoStage: PROD
   rendering:

--- a/scripts/check-node-versions.mjs
+++ b/scripts/check-node-versions.mjs
@@ -1,0 +1,76 @@
+// @ts-check
+
+import { readFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { log, warn } from '../dotcom-rendering/scripts/env/log.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+process.chdir(resolve(__dirname, '..'));
+
+const nvmrc = (await readFile('.nvmrc', 'utf-8'))
+	// We don’t care about leading or trailing whitespace
+	.trim();
+
+/** Matches `x.y.z` pattern */
+const nodeVersionPattern = /^\d+\.\d+\.\d+$/;
+const nodeVersion = nvmrc.match(nodeVersionPattern)?.[0] ?? undefined;
+
+if (!nodeVersion) {
+	warn(
+		'Node version in .nvmrc has incorrect pattern:',
+		`\`${nvmrc}\` does not match \`x.y.z\``,
+	);
+	process.exit(1);
+} else {
+	log(`Found node version ${nodeVersion} in \`.nvmrc\``);
+}
+
+const requiredNodeVersionMatches =
+	/** @type {const} @satisfies {ReadonlyArray<{filepath: string, pattern: RegExp}>}*/ ([
+		{
+			filepath: 'dotcom-rendering/Containerfile',
+			pattern: /^FROM node:(.+)-alpine$/m,
+		},
+		{
+			filepath: 'dotcom-rendering/scripts/deploy/riff-raff.yaml',
+			pattern: /^ +Recipe: dotcom-rendering.*-node-(\d+\.\d+\.\d+)$/m,
+		},
+		{
+			filepath: 'apps-rendering/riff-raff.yaml',
+			pattern: /^ +Recipe: .+-mobile-node(\d+\.\d+\.\d+).*$/m,
+		},
+	]);
+
+const problems = (
+	await Promise.all(
+		requiredNodeVersionMatches.map(async ({ filepath, pattern }) => {
+			const fileContents = await readFile(
+				resolve(...filepath.split('/')),
+				'utf-8',
+			);
+			const foundNodeVersion =
+				fileContents.match(pattern)?.[1] ?? undefined;
+
+			return foundNodeVersion === nodeVersion
+				? undefined
+				: `Node version in ${filepath} (${foundNodeVersion}) does not match \`.nvmrc\` (${nodeVersion})`;
+		}),
+	)
+).filter(
+	/** @type {(problem?: string) => problem is string} */
+	(problem) => !!problem,
+);
+
+if (problems.length === 0) {
+	log(
+		`All ${requiredNodeVersionMatches.length} checked files use the correct Node version`,
+	);
+	process.exitCode = 0;
+} else {
+	for (const problem of problems) {
+		warn(problem);
+	}
+	process.exitCode = 1;
+}


### PR DESCRIPTION
## What does this change?

Add a check for Node versions in all known config using it:
- [`dotcom-rendering/scripts/deploy/riff-raff.yaml`](https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/scripts/deploy/riff-raff.yaml)
- [`dotcom-rendering/Containerfile`](https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/Containerfile)
- [`apps-rendering/riff-raff.yaml`](https://github.com/guardian/dotcom-rendering/blob/main/apps-rendering/riff-raff.yaml)

The `lint-project` target is run as part of `make validate` and in CI

AMIGo recipes have been updated to contain the exact node version: **major.minor.patch**.

## Why?

Alternative to #7959 – We are using a regular expression rather than a `SemVer` class and full parsing in order to reduce our dependencies.

Ensures that robots warn us when we do the next #7948 

## Screenshots

<img width="422" alt="successful CLI output" src="https://github.com/guardian/dotcom-rendering/assets/76776/053d6b0f-4086-4491-b3a1-d58b0c71cd96">