### PR TITLE
Use `.map` In Place Of `.either`

### DIFF
--- a/apps-rendering/src/newsletter.ts
+++ b/apps-rendering/src/newsletter.ts
@@ -166,12 +166,7 @@ function findInsertIndex(body: Body): Result<string, number> {
 		possibleElementsToPlaceBefore.length - 1,
 	);
 
-	return insertPosition.either(
-		(err) => Result.err(err),
-		(categoryAndIndex) => {
-			return Result.ok(categoryAndIndex.index);
-		},
-	);
+	return insertPosition.map((categoryAndIndex) => categoryAndIndex.index);
 }
 
 // ----- Procedures ----- //


### PR DESCRIPTION
The use of `.either` here is equivalent to `.map`, and `.map` is probably simpler and easier to reason about in this case. Functionality should be the same.
