### PR TITLE
Dblatcher newsletters page header

### DIFF
--- a/dotcom-rendering/src/components/NewsletterPageHeading.tsx
+++ b/dotcom-rendering/src/components/NewsletterPageHeading.tsx
@@ -1,25 +1,31 @@
 import { css } from '@emotion/react';
-import { headline } from '@guardian/source-foundations';
-import { LinkButton } from '@guardian/source-react-components';
-import type { EditionId } from '../lib/edition';
-import { getEditionFromId } from '../lib/edition';
+import { from, headline, palette, space } from '@guardian/source-foundations';
+import {
+	LinkButton,
+	SvgChevronRightSingle,
+} from '@guardian/source-react-components';
+import { Flex } from './Flex';
 import { Section } from './Section';
 
 export interface NewslettersListProps {
 	headingText: string;
 	mmaUrl?: string;
-	editionId: EditionId;
+	newsletterCount: number;
 }
 
 export const NewslettersPageHeading = ({
 	headingText,
 	mmaUrl,
-	editionId,
+	newsletterCount,
 }: NewslettersListProps) => {
-	const edition = getEditionFromId(editionId);
-
 	return (
-		<Section fullWidth={true} element="header" padBottom={true}>
+		<Section
+			element="header"
+			fullWidth={false}
+			padBottom={false}
+			padSides={false}
+			stretchRight={true}
+		>
 			<h1
 				css={css`
 					${headline.medium()}
@@ -32,13 +38,34 @@ export const NewslettersPageHeading = ({
 					${headline.xxsmall()}
 				`}
 			>
-				{edition.longTitle}
+				Choose from {newsletterCount} available newsletters
 			</div>
 
 			{!!mmaUrl && (
-				<LinkButton href={`${mmaUrl}/email-prefs`} size={'small'}>
-					Manage my newsletters
-				</LinkButton>
+				<div
+					css={css`
+						display: flex;
+						justify-content: flex-start;
+
+						${from.leftCol} {
+							justify-content: flex-end;
+						}
+					`}
+				>
+					<LinkButton
+						href={`${mmaUrl}/email-prefs`}
+						size={'xsmall'}
+						priority="subdued"
+						icon={<SvgChevronRightSingle size="small" />}
+						iconSide="right"
+						cssOverrides={css`
+							margin-bottom: ${space[2]}px;
+							color: ${palette.brand[500]};
+						`}
+					>
+						Manage my newsletters
+					</LinkButton>
+				</div>
 			)}
 		</Section>
 	);

--- a/dotcom-rendering/src/components/NewsletterPageHeading.tsx
+++ b/dotcom-rendering/src/components/NewsletterPageHeading.tsx
@@ -22,6 +22,7 @@ export const NewslettersPageHeading = ({
 			padBottom={false}
 			padSides={false}
 			stretchRight={true}
+			verticalMargins={false}
 		>
 			<div>
 				<div
@@ -33,6 +34,7 @@ export const NewslettersPageHeading = ({
 						padding: 1px ${space[1]}px;
 						border: 1px dashed ${palette.neutral[7]};
 						margin-bottom: ${space[2]}px;
+						margin-top: ${space[2]}px;
 					`}
 				>
 					<h1
@@ -57,8 +59,10 @@ export const NewslettersPageHeading = ({
 					css={css`
 						display: flex;
 						justify-content: flex-start;
+						margin-top: ${space[1]}px;
 
 						${from.leftCol} {
+							margin-top: 0;
 							justify-content: flex-end;
 						}
 					`}

--- a/dotcom-rendering/src/components/NewsletterPageHeading.tsx
+++ b/dotcom-rendering/src/components/NewsletterPageHeading.tsx
@@ -4,17 +4,14 @@ import {
 	LinkButton,
 	SvgChevronRightSingle,
 } from '@guardian/source-react-components';
-import { Flex } from './Flex';
 import { Section } from './Section';
 
 export interface NewslettersListProps {
-	headingText: string;
 	mmaUrl?: string;
 	newsletterCount: number;
 }
 
 export const NewslettersPageHeading = ({
-	headingText,
 	mmaUrl,
 	newsletterCount,
 }: NewslettersListProps) => {
@@ -26,13 +23,27 @@ export const NewslettersPageHeading = ({
 			padSides={false}
 			stretchRight={true}
 		>
-			<h1
-				css={css`
-					${headline.medium()}
-				`}
-			>
-				{headingText}
-			</h1>
+			<div>
+				<div
+					css={css`
+						display: inline-flex;
+						flex-direction: row;
+						justify-content: flex-start;
+						align-items: center;
+						padding: 1px ${space[1]}px;
+						border: 1px dashed ${palette.neutral[7]};
+						margin-bottom: ${space[2]}px;
+					`}
+				>
+					<h1
+						css={css`
+							${headline.medium()}
+						`}
+					>
+						Newsletters
+					</h1>
+				</div>
+			</div>
 			<div
 				css={css`
 					${headline.xxsmall()}

--- a/dotcom-rendering/src/components/NewsletterPageHeading.tsx
+++ b/dotcom-rendering/src/components/NewsletterPageHeading.tsx
@@ -11,6 +11,38 @@ export interface NewslettersListProps {
 	newsletterCount: number;
 }
 
+const headlineStyle = css`
+	display: inline-flex;
+	flex-direction: row;
+	justify-content: flex-start;
+	align-items: center;
+	padding: 1px ${space[1]}px;
+	border: 1px dashed ${palette.neutral[7]};
+	margin-bottom: ${space[2]}px;
+	margin-top: ${space[2]}px;
+	${headline.medium()}
+`;
+
+const subtitleStyle = css`
+	${headline.xxsmall()}
+`;
+
+const manageLinkContainer = css`
+	display: flex;
+	justify-content: flex-start;
+	margin-top: ${space[2]}px;
+	margin-bottom: ${space[2]}px;
+
+	${from.leftCol} {
+		margin-top: 0;
+		justify-content: flex-end;
+	}
+`;
+
+const linkStyle = css`
+	color: ${palette.brand[500]};
+`;
+
 export const NewslettersPageHeading = ({
 	mmaUrl,
 	newsletterCount,
@@ -25,58 +57,23 @@ export const NewslettersPageHeading = ({
 			verticalMargins={false}
 		>
 			<div>
-				<div
-					css={css`
-						display: inline-flex;
-						flex-direction: row;
-						justify-content: flex-start;
-						align-items: center;
-						padding: 1px ${space[1]}px;
-						border: 1px dashed ${palette.neutral[7]};
-						margin-bottom: ${space[2]}px;
-						margin-top: ${space[2]}px;
-					`}
-				>
-					<h1
-						css={css`
-							${headline.medium()}
-						`}
-					>
-						Newsletters
-					</h1>
-				</div>
+				<h1 css={headlineStyle}>
+					<span>Newsletters</span>
+				</h1>
 			</div>
-			<div
-				css={css`
-					${headline.xxsmall()}
-				`}
-			>
+			<p css={subtitleStyle}>
 				Choose from {newsletterCount} available newsletters
-			</div>
+			</p>
 
 			{!!mmaUrl && (
-				<div
-					css={css`
-						display: flex;
-						justify-content: flex-start;
-						margin-top: ${space[1]}px;
-
-						${from.leftCol} {
-							margin-top: 0;
-							justify-content: flex-end;
-						}
-					`}
-				>
+				<div css={manageLinkContainer}>
 					<LinkButton
 						href={`${mmaUrl}/email-prefs`}
 						size={'xsmall'}
 						priority="subdued"
 						icon={<SvgChevronRightSingle size="small" />}
 						iconSide="right"
-						cssOverrides={css`
-							margin-bottom: ${space[2]}px;
-							color: ${palette.brand[500]};
-						`}
+						cssOverrides={linkStyle}
 					>
 						Manage my newsletters
 					</LinkButton>

--- a/dotcom-rendering/src/components/NewsletterPageHeading.tsx
+++ b/dotcom-rendering/src/components/NewsletterPageHeading.tsx
@@ -50,8 +50,6 @@ export const NewslettersPageHeading = ({
 	return (
 		<Section
 			element="header"
-			fullWidth={false}
-			padBottom={false}
 			padSides={false}
 			stretchRight={true}
 			verticalMargins={false}

--- a/dotcom-rendering/src/layouts/AllEditorialNewslettersPageLayout.tsx
+++ b/dotcom-rendering/src/layouts/AllEditorialNewslettersPageLayout.tsx
@@ -157,7 +157,6 @@ export const AllEditorialNewslettersPageLayout = ({
 			<main data-layout="NewsletterPageLayout" id="maincontent">
 				<NewslettersPageHeading
 					mmaUrl={newslettersPage.config.mmaUrl}
-					headingText={newslettersPage.webTitle}
 					newsletterCount={displayedNewslettersCount}
 				/>
 				<GroupedNewslettersList

--- a/dotcom-rendering/src/layouts/AllEditorialNewslettersPageLayout.tsx
+++ b/dotcom-rendering/src/layouts/AllEditorialNewslettersPageLayout.tsx
@@ -50,6 +50,12 @@ export const AllEditorialNewslettersPageLayout = ({
 	const contributionsServiceUrl =
 		process.env.SDC_URL ?? pageContributionsServiceUrl;
 
+	const displayedNewslettersCount =
+		newslettersPage.groupedNewsletters.groups.reduce<number>(
+			(count, group) => count + group.newsletters.length,
+			0,
+		);
+
 	return (
 		<>
 			<div data-print-layout="hide" id="bannerandheader">
@@ -151,8 +157,8 @@ export const AllEditorialNewslettersPageLayout = ({
 			<main data-layout="NewsletterPageLayout" id="maincontent">
 				<NewslettersPageHeading
 					mmaUrl={newslettersPage.config.mmaUrl}
-					editionId={newslettersPage.editionId}
 					headingText={newslettersPage.webTitle}
+					newsletterCount={displayedNewslettersCount}
 				/>
 				<GroupedNewslettersList
 					groupedNewsletters={newslettersPage.groupedNewsletters}


### PR DESCRIPTION
## What does this change?
Visual changes to unreleased DCR newsletters page -  new styling and layout for the page header.

## Why?
Applying the design for this part of the page.

## Screenshots

### before 
<img width="906" alt="Screenshot 2023-06-21 at 17 01 54" src="https://github.com/guardian/dotcom-rendering/assets/30567854/67f23fb8-2ead-4065-97de-3e282d9ac922">


### After
<img width="906" alt="Screenshot 2023-06-21 at 17 01 27" src="https://github.com/guardian/dotcom-rendering/assets/30567854/a14e08cb-088d-4345-90ad-86762fdbdffe">

