### PR TITLE
Fix trending topics overflow

### DIFF
--- a/dotcom-rendering/src/components/TrendingTopics.tsx
+++ b/dotcom-rendering/src/components/TrendingTopics.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { neutral, textSans } from '@guardian/source-foundations';
+import { palette, textSans } from '@guardian/source-foundations';
 import { StraightLines } from '@guardian/source-react-components-development-kitchen';
 import type { FETagType } from '../types/tag';
 
@@ -12,11 +12,11 @@ const linkStyle = css`
 	${textSans.xsmall({ lineHeight: 'loose' })}
 	text-decoration: none;
 	top: 0;
-	color: ${neutral[7]};
+	color: ${palette.neutral[7]};
 
 	/** All but first items */
 	&:nth-of-type(n + 2):before {
-		color: ${neutral[86]};
+		color: ${palette.neutral[86]};
 		pointer-events: none;
 		margin: 2.56px;
 		content: '/';
@@ -25,7 +25,7 @@ const linkStyle = css`
 
 const topicLabel = css`
 	${textSans.xxsmall({ lineHeight: 'regular' })}
-	color: ${neutral[60]};
+	color: ${palette.neutral[60]};
 `;
 
 const trendingTopicContainer = css`

--- a/dotcom-rendering/src/components/TrendingTopics.tsx
+++ b/dotcom-rendering/src/components/TrendingTopics.tsx
@@ -8,6 +8,7 @@ type Props = {
 };
 
 const linkStyle = css`
+	display: inline-block;
 	${textSans.xsmall({ lineHeight: 'loose' })}
 	text-decoration: none;
 	top: 0;

--- a/dotcom-rendering/src/components/TrendingTopics.tsx
+++ b/dotcom-rendering/src/components/TrendingTopics.tsx
@@ -13,16 +13,13 @@ const linkStyle = css`
 	text-decoration: none;
 	top: 0;
 	color: ${neutral[7]};
-	&:after {
+
+	/** All but first items */
+	&:nth-of-type(n + 2):before {
 		color: ${neutral[86]};
 		pointer-events: none;
 		margin: 2.56px;
 		content: '/';
-	}
-	&:last-of-type {
-		&:after {
-			content: '';
-		}
 	}
 `;
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Fix:
- wrap long lines

Refactor: 
- simplify `n`th selector
- use Source’s palette

## Why?

Currently, the UK Front has horizontal scroll on small viewports, as raised by @ioannakok 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/76776/2ef00b5f-c091-4623-84a1-d6f2dedb4f51
[after]: https://github.com/guardian/dotcom-rendering/assets/76776/8d6a2f31-7d06-4044-bfac-2be0b204449b
