### PR TITLE
Remove unnecessary badges

### DIFF
--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -270,9 +270,19 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 			>
 				{front.pressedPage.collections.map((collection, index) => {
 					// Backfills should be added to the end of any curated content
-					const trails = collection.curated.concat(
+					const curatedAndBackfill = collection.curated.concat(
 						collection.backfill,
 					);
+
+					const trails = collection.badge
+						? curatedAndBackfill.map((labTrail) => {
+								return {
+									...labTrail,
+									branding: undefined,
+								};
+						  })
+						: curatedAndBackfill;
+
 					const [trail] = trails;
 
 					// There are some containers that have zero trails. We don't want to render these
@@ -394,15 +404,6 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 						collection.containerPalette === 'Branded' &&
 						renderAds
 					) {
-						const trailsWithoutBranding = collection.badge
-							? trails.map((labTrail) => {
-									return {
-										...labTrail,
-										branding: undefined,
-									};
-							  })
-							: trails;
-
 						return (
 							<LabsSection
 								key={ophanName}
@@ -420,7 +421,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 								data-print-layout="hide"
 							>
 								<DecideContainer
-									trails={trailsWithoutBranding}
+									trails={trails}
 									groupedTrails={collection.grouped}
 									containerType={collection.collectionType}
 									containerPalette={


### PR DESCRIPTION
Fixes: https://github.com/guardian/dotcom-rendering/issues/5945

## What does this change?

Removes badges from cards when a badge is passed to the container

## Why?

Too many badges. This is in line with Frontend behaviour.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| <img width="1315" alt="Screenshot 2023-06-21 at 19 04 01" src="https://github.com/guardian/dotcom-rendering/assets/1229808/25da8b28-4bdc-4939-b3da-dce68630e1da"> | <img width="1315" alt="Screenshot 2023-06-21 at 19 02 32" src="https://github.com/guardian/dotcom-rendering/assets/1229808/7dce6d56-96df-4d75-ae6c-b1655b5d3bfc"> |
