### PR TITLE
feat: cmp upgrade node 18, remove linkedin

### DIFF
--- a/dotcom-rendering/src/components/AustralianTerritorySwitcher.importable.stories.tsx
+++ b/dotcom-rendering/src/components/AustralianTerritorySwitcher.importable.stories.tsx
@@ -1,0 +1,25 @@
+import { userEvent, within } from '@storybook/testing-library';
+import { AustralianTerritorySwitcher } from './AustralianTerritorySwitcher.importable';
+
+export default {
+	component: AustralianTerritorySwitcher,
+	title: 'Components/AustralianTerritorySwitcher',
+};
+
+export const Victoria = () => (
+	<AustralianTerritorySwitcher targetedTerritory="AU-VIC" />
+);
+
+export const Queensland = () => (
+	<AustralianTerritorySwitcher targetedTerritory="AU-QLD" />
+);
+
+/**
+ * Clicks the “Not in Queensland” button so that Chromatic can capture
+ * it the component in its `expanded` state.
+ */
+Queensland.play = ({ canvasElement }: { canvasElement: HTMLElement }) => {
+	const canvas = within(canvasElement);
+	userEvent.click(canvas.getByRole('button'));
+};
+Queensland.storyName = 'Queensland (expanded)';

--- a/dotcom-rendering/src/components/AustralianTerritorySwitcher.importable.tsx
+++ b/dotcom-rendering/src/components/AustralianTerritorySwitcher.importable.tsx
@@ -1,0 +1,107 @@
+import { css } from '@emotion/react';
+import { removeCookie, setCookie } from '@guardian/libs';
+import { space, textSans } from '@guardian/source-foundations';
+import {
+	Button,
+	ChoiceCard,
+	ChoiceCardGroup,
+	SvgChevronDownSingle,
+	SvgChevronUpSingle,
+} from '@guardian/source-react-components';
+import { isString } from 'lodash';
+import { useState } from 'react';
+import type { AustralianTerritory } from '../types/territory';
+
+const styles = css`
+	padding: ${space[2]}px;
+`;
+
+const territories = {
+	'AU-NSW': 'New South Wales',
+	'AU-QLD': 'Queensland',
+	'AU-VIC': 'Victoria',
+} as const satisfies Record<AustralianTerritory, string>;
+
+const controls = 'change-territory';
+const controlsStyles = css`
+	max-width: 700px;
+`;
+
+const labelStyles = css`
+	${textSans.medium()}
+	padding-bottom: ${space[3]}px;
+	display: block;
+
+	strong {
+		${textSans.medium({ fontWeight: 'bold' })}
+	}
+`;
+
+type Props = {
+	targetedTerritory: AustralianTerritory;
+};
+export const AustralianTerritorySwitcher = ({ targetedTerritory }: Props) => {
+	const [expanded, setExpanded] = useState(false);
+
+	return (
+		<div css={styles}>
+			<Button
+				priority="subdued"
+				onClick={() => {
+					setExpanded(!expanded);
+				}}
+				icon={
+					expanded ? <SvgChevronUpSingle /> : <SvgChevronDownSingle />
+				}
+				iconSide="right"
+				aria-expanded={expanded}
+				aria-controls={controls}
+			>
+				Not in {territories[targetedTerritory]}? Change region
+			</Button>
+
+			{expanded && (
+				<div id={controls} css={controlsStyles}>
+					<label htmlFor="territory" css={labelStyles}>
+						<strong>
+							The articles above have been curated for you based
+							on the state you are in.
+						</strong>{' '}
+						If we have your location wrong or you want to see
+						coverage of a different state, please select from the
+						links below. We hope to expand this service to other
+						states in the future.
+					</label>
+
+					<ChoiceCardGroup
+						name="territory"
+						onChange={({ target }) => {
+							if ('value' in target && isString(target.value)) {
+								const value = target.value;
+
+								removeCookie({ name: 'GU_territory' });
+								setCookie({
+									name: 'GU_territory',
+									value,
+								});
+								window.location.reload();
+							}
+						}}
+					>
+						<>
+							{Object.entries(territories).map(([id, label]) => (
+								<ChoiceCard
+									key={id}
+									id={id}
+									value={id}
+									label={label}
+									checked={id === targetedTerritory}
+								/>
+							))}
+						</>
+					</ChoiceCardGroup>
+				</div>
+			)}
+		</div>
+	);
+};

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -342,6 +342,7 @@ export const Card = ({
 								font-size: inherit;
 								line-height: inherit;
 								text-decoration: none;
+								min-height: 10px;
 							`}
 						/>
 					) : undefined

--- a/dotcom-rendering/src/components/Card/components/ContentWrapper.tsx
+++ b/dotcom-rendering/src/components/Card/components/ContentWrapper.tsx
@@ -5,6 +5,7 @@ import { between, from } from '@guardian/source-foundations';
 const sizingStyles = css`
 	display: flex;
 	flex-direction: column;
+	flex-grow: 1;
 	justify-content: space-between;
 `;
 
@@ -72,18 +73,11 @@ export const ContentWrapper = ({
 	imagePosition,
 }: Props) => {
 	const isHorizontal = imagePosition === 'left' || imagePosition === 'right';
-	const isVertical = imagePosition === 'top' || imagePosition === 'bottom';
 	return (
 		<div
 			css={[
 				sizingStyles,
 				isHorizontal && flexBasisStyles({ imageSize, imageType }),
-				/* If the image is top or bottom positioned then it takes 100% of the width and
-				   we want the content to grow into the remaining vertical space */
-				isVertical &&
-					css`
-						flex-grow: 1;
-					`,
 			]}
 		>
 			{children}

--- a/dotcom-rendering/src/components/ContainerTitle.tsx
+++ b/dotcom-rendering/src/components/ContainerTitle.tsx
@@ -34,7 +34,9 @@ const headerStyles = (fontColour?: string) => css`
 	padding-bottom: ${space[1]}px;
 	padding-top: 6px;
 	overflow-wrap: break-word; /*if a single word is too long, this will break the word up rather than have the display be affected*/
+`;
 
+const headerStylesWithUrl = css`
 	:hover {
 		text-decoration: underline;
 	}
@@ -99,7 +101,7 @@ export const ContainerTitle = ({
 					href={url}
 					data-link-name="section heading"
 				>
-					<h2 css={headerStyles(fontColour)}>
+					<h2 css={[headerStylesWithUrl, headerStyles(fontColour)]}>
 						{localisedTitle(title, editionId)}
 					</h2>
 				</a>

--- a/dotcom-rendering/src/components/FrontSection.tsx
+++ b/dotcom-rendering/src/components/FrontSection.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import { isString } from '@guardian/libs';
 import {
 	from,
 	neutral,
@@ -12,6 +13,8 @@ import { decideContainerOverrides } from '../lib/decideContainerOverrides';
 import type { EditionId } from '../lib/edition';
 import type { DCRBadgeType } from '../types/badge';
 import type { DCRContainerPalette, TreatType } from '../types/front';
+import { isAustralianTerritory, type Territory } from '../types/territory';
+import { AustralianTerritorySwitcher } from './AustralianTerritorySwitcher.importable';
 import { Badge } from './Badge';
 import { ContainerTitle } from './ContainerTitle';
 import { Island } from './Island';
@@ -68,6 +71,8 @@ type Props = {
 	isOnPaidContentFront?: boolean;
 	/** Denotes the position of this section on the front */
 	index?: number;
+	/** Indicates if the container is targetted to a specific territory */
+	targetedTerritory?: Territory;
 };
 
 const width = (columns: number, columnWidth: number, columnGap: number) =>
@@ -404,6 +409,7 @@ export const FrontSection = ({
 	ajaxUrl,
 	isOnPaidContentFront,
 	index,
+	targetedTerritory,
 }: Props) => {
 	const overrides =
 		containerPalette && decideContainerOverrides(containerPalette);
@@ -549,7 +555,14 @@ export const FrontSection = ({
 			</div>
 
 			<div css={[sectionContentPadded, sectionShowMore, bottomPadding]}>
-				{showMore && (
+				{isString(targetedTerritory) &&
+				isAustralianTerritory(targetedTerritory) ? (
+					<Island deferUntil="interaction">
+						<AustralianTerritorySwitcher
+							targetedTerritory={targetedTerritory}
+						/>
+					</Island>
+				) : showMore ? (
 					<Island deferUntil="interaction">
 						<ShowMore
 							title={title}
@@ -562,7 +575,7 @@ export const FrontSection = ({
 							showAge={title === 'Headlines'}
 						/>
 					</Island>
-				)}
+				) : null}
 			</div>
 
 			{treats && (

--- a/dotcom-rendering/src/components/Nav/ExpandedMenu/CollapseColumnButton.tsx
+++ b/dotcom-rendering/src/components/Nav/ExpandedMenu/CollapseColumnButton.tsx
@@ -102,10 +102,7 @@ export const CollapseColumnButton = ({
 		// eslint-disable-next-line jsx-a11y/no-noninteractive-element-to-interactive-role -- we’re using this label for a CSS-only toggle
 		role="menuitem"
 		data-cy={`column-collapse-${title}`}
-		data-link-name={nestedOphanComponents(
-			'nav2',
-			`column-toggle-${title}: show`,
-		)}
+		data-link-name={nestedOphanComponents('nav2', `secondary`, title)}
 	>
 		{title}
 	</label>

--- a/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
+++ b/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 import { parseCheckoutCompleteCookieData } from '../lib/parser/parseCheckoutOutCookieData';
 import { constructQuery } from '../lib/querystring';
 import { useOnce } from '../lib/useOnce';
+import { useSignedInStatus } from '../lib/useSignedInStatus';
 import { useSignInGateSelector } from '../lib/useSignInGateSelector';
 import type { TagType } from '../types/tag';
 import type { ComponentEventParams } from './SignInGate/componentEventTracking';
@@ -150,7 +151,7 @@ export const SignInGateSelector = ({
 	pageId,
 	idUrl = 'https://profile.theguardian.com',
 }: Props) => {
-	const isSignedIn = !!getCookie({ name: 'GU_U', shouldMemoize: true });
+	const isSignedIn = useSignedInStatus() === 'SignedIn';
 	const [isGateDismissed, setIsGateDismissed] = useState<boolean | undefined>(
 		undefined,
 	);

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -475,6 +475,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 								ajaxUrl={front.config.ajaxUrl}
 								isOnPaidContentFront={isPaidContent}
 								index={index}
+								targetedTerritory={collection.targetedTerritory}
 							>
 								<DecideContainer
 									trails={trails}

--- a/dotcom-rendering/src/lib/guard.ts
+++ b/dotcom-rendering/src/lib/guard.ts
@@ -1,0 +1,7 @@
+/** A method to create type-guard for string unions */
+export const guard =
+	<T extends readonly string[]>(array: T) =>
+	(value: string): value is (typeof array)[number] =>
+		array.includes(value);
+
+export type Guard<T> = T extends readonly string[] ? T[number] : never;

--- a/dotcom-rendering/src/model/enhanceCards.ts
+++ b/dotcom-rendering/src/model/enhanceCards.ts
@@ -253,10 +253,7 @@ export const enhanceCards = (
 			discussionId: faciaCard.discussion.isCommentable
 				? faciaCard.discussion.discussionId
 				: undefined,
-			// nb. there is a distinct 'byline' property on FEFrontCard, at
-			// card.properties.byline
-			byline:
-				faciaCard.properties.maybeContent?.trail.byline ?? undefined,
+			byline: faciaCard.properties.byline ?? undefined,
 			showByline: faciaCard.properties.showByline,
 			snapData: enhanceSnaps(faciaCard.enriched),
 			isBoosted: faciaCard.display.isBoosted,

--- a/dotcom-rendering/src/model/enhanceCollections.ts
+++ b/dotcom-rendering/src/model/enhanceCollections.ts
@@ -92,6 +92,7 @@ export const enhanceCollections = (
 				showDateHeader: collection.config.showDateHeader,
 			},
 			canShowMore: hasMore && !collection.config.hideShowMore,
+			targetedTerritory: collection.targetedTerritory,
 		};
 	});
 };

--- a/dotcom-rendering/src/model/front-schema.json
+++ b/dotcom-rendering/src/model/front-schema.json
@@ -2694,6 +2694,9 @@
                             },
                             "hasMore": {
                                 "type": "boolean"
+                            },
+                            "targetedTerritory": {
+                                "$ref": "#/definitions/Territory"
                             }
                         },
                         "required": [
@@ -2955,6 +2958,20 @@
                 "SombrePalette",
                 "Special",
                 "SpecialReportAltPalette"
+            ],
+            "type": "string"
+        },
+        "Territory": {
+            "description": "List of territories that can be targetted against.",
+            "enum": [
+                "AU-NSW",
+                "AU-QLD",
+                "AU-VIC",
+                "EU-27",
+                "NZ",
+                "US-East-Coast",
+                "US-West-Coast",
+                "XX"
             ],
             "type": "string"
         },

--- a/dotcom-rendering/src/server/lib/get-content-from-url.js
+++ b/dotcom-rendering/src/server/lib/get-content-from-url.js
@@ -24,7 +24,11 @@ async function getContentFromURL(url, _headers) {
 	/** @type {HeadersInit} */
 	const headers = Object.fromEntries(
 		Object.entries(_headers)
-			.filter(([key]) => key.toLowerCase().startsWith('x-gu-'))
+			.filter(
+				([key]) =>
+					key.toLowerCase() === 'cookie' ||
+					key.toLowerCase().startsWith('x-gu-'),
+			)
 			.filter(isStringTuple),
 	);
 

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -5,6 +5,7 @@ import type { Branding } from './branding';
 import type { ServerSideTests, Switches } from './config';
 import type { FooterType } from './footer';
 import type { FETagType } from './tag';
+import type { Territory } from './territory';
 import type { FETrailType, TrailType } from './trails';
 
 export interface FEFrontType {
@@ -348,6 +349,7 @@ export type FECollectionType = {
 	showLatestUpdate: boolean;
 	config: FECollectionConfigType;
 	hasMore: boolean;
+	targetedTerritory?: Territory;
 };
 
 export type DCRCollectionType = {
@@ -372,6 +374,7 @@ export type DCRCollectionType = {
 	 **/
 	canShowMore?: boolean;
 	badge?: DCRBadgeType;
+	targetedTerritory?: Territory;
 };
 
 export type DCRGroupedTrails = {

--- a/dotcom-rendering/src/types/territory.ts
+++ b/dotcom-rendering/src/types/territory.ts
@@ -1,0 +1,26 @@
+import type { Guard } from '../lib/guard';
+import { guard } from '../lib/guard';
+
+type AmericanTerritories = 'US-East-Coast' | 'US-West-Coast';
+
+type EuropeanTerritories = 'EU-27';
+
+const australianTerritories = ['AU-VIC', 'AU-QLD', 'AU-NSW'] as const;
+export const isAustralianTerritory = guard(australianTerritories);
+export type AustralianTerritory = Guard<typeof australianTerritories>;
+
+type NewZealandTerritories = 'NZ';
+
+type UnknownTerritories = 'XX';
+
+/**
+ * List of territories that can be targetted against.
+ *
+ * @see https://github.com/guardian/facia-scala-client/blob/52562dec5e8518b79ba1c8b95a0cbe9502b9e2e5/facia-json/src/main/scala/com/gu/facia/client/models/Config.scala#L123-L187
+ */
+export type Territory =
+	| AmericanTerritories
+	| EuropeanTerritories
+	| AustralianTerritory
+	| NewZealandTerritories
+	| UnknownTerritories;

--- a/scripts/deno/ophan-components.ts
+++ b/scripts/deno/ophan-components.ts
@@ -18,6 +18,27 @@ const html = await Promise.all(
 const known_errors = new Set([
 	// it only appears in DCR after hydration if signed in
 	'nav3 : topbar : my account',
+	'nav3 : topbar : account overview',
+	'nav3 : topbar : billing',
+	'nav3 : topbar : profile',
+	'nav3 : topbar : email prefs',
+	'nav3 : topbar : data privacy',
+	'nav3 : topbar : settings',
+	'nav3 : topbar : help',
+	'nav3 : topbar : comment activity',
+	'nav3 : topbar : sign out',
+
+	// Palette thrasher related
+	'container-0 | palette-styles-new-do-not-delete',
+	'palette-styles-new-do-not-delete',
+	'external | group-0 | card-@1',
+
+	// These elements don't exist anymore in the DOM after Deeply Read component was added
+	'6 | text',
+	'7 | text',
+	'8 | text',
+	'9 | text',
+	'10 | text'
 ]);
 
 const getOphanComponents = (


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
