### PR TITLE
Updates to TrendingTopics tag selection

### DIFF
--- a/dotcom-rendering/src/components/TrendingTopics.tsx
+++ b/dotcom-rendering/src/components/TrendingTopics.tsx
@@ -44,7 +44,15 @@ export const TrendingTopics = ({ trendingTopics }: Props) => {
 			/>
 			<div css={topicLabel}>Topics</div>
 			{/* TODO: Add allpath link */}
-			{trendingTopics?.map((tag) => {
+			{trendingTopics?.slice(0, 5).map((tag) => {
+				const section = trendingTopics
+					.filter((existingTag) => existingTag !== tag)
+					.find(
+						(existingTag) =>
+							existingTag.properties.webTitle ===
+							tag.properties.webTitle,
+					)?.properties.sectionName;
+
 				return (
 					<a
 						key={tag.properties.webTitle}
@@ -53,6 +61,7 @@ export const TrendingTopics = ({ trendingTopics }: Props) => {
 						data-link-name={`keyword: ${tag.properties.id}`}
 					>
 						{tag.properties.webTitle}
+						{!!section && ` (${section})`}
 					</a>
 				);
 			})}

--- a/dotcom-rendering/src/model/extractTrendingTopics.test.ts
+++ b/dotcom-rendering/src/model/extractTrendingTopics.test.ts
@@ -1,0 +1,159 @@
+import type { FETagType } from '../types/tag';
+import type {
+	NarrowedFECollectionType,
+	NarrowedFEFrontCard,
+} from './extractTrendingTopics';
+import { extractTrendingTopicsFomFront } from './extractTrendingTopics';
+
+const tag = (
+	id: string,
+	tagType = 'Keyword',
+	paidContentType?: string,
+): FETagType => {
+	return {
+		properties: {
+			id,
+			tagType,
+			webTitle: id,
+			paidContentType,
+		},
+	};
+};
+
+const card = (id: string, tags: FETagType[]): NarrowedFEFrontCard => {
+	return {
+		card: {
+			id,
+		},
+		properties: {
+			maybeContentId: id,
+			maybeContent: {
+				tags: {
+					tags,
+				},
+			},
+		},
+	};
+};
+
+const tagA = tag('a');
+const tagB = tag('b');
+const tagC = tag('c');
+const tagD = tag('d');
+const tagE = tag('e');
+const tagF = tag('f');
+
+describe('extractTrendingTopics', () => {
+	it('returns tags in correct order with normal input', () => {
+		const collection: NarrowedFECollectionType = {
+			curated: [
+				card('a', [tagA]),
+				card('b', [tagA, tagB]),
+				card('c', [tagA, tagB, tagC]),
+			],
+			backfill: [
+				card('d', [tagA, tagB, tagC, tagD]),
+				card('e', [tagA, tagB, tagC, tagD, tagE]),
+				card('f', [tagA, tagB, tagC, tagD, tagE, tagF]),
+			],
+		};
+
+		expect(
+			extractTrendingTopicsFomFront([collection], 'au/environment'),
+		).toEqual([tagA, tagB, tagC, tagD, tagE, tagF]);
+	});
+
+	it('deduplicates cards', () => {
+		const collection: NarrowedFECollectionType = {
+			curated: [
+				card('a', [tagA]),
+				card('b', [tagA, tagB]),
+				card('c', [tagA, tagB, tagC]),
+				card('g', [tagF]),
+			],
+			backfill: [
+				card('d', [tagA, tagB, tagC, tagD]),
+				card('e', [tagA, tagB, tagC, tagD, tagE]),
+				card('f', [tagA, tagB, tagC, tagD, tagE]),
+				card('g', [tagF]),
+			],
+		};
+		const secondCollection: NarrowedFECollectionType = {
+			curated: [card('g', [tagF])],
+			backfill: [card('g', [tagF])],
+		};
+		expect(
+			extractTrendingTopicsFomFront(
+				[collection, secondCollection],
+				'au/environment',
+			),
+		).toEqual([tagA, tagB, tagC, tagD, tagE, tagF]);
+	});
+
+	it('removes cards with id matching pageId', () => {
+		const tagWithPageId = tag('au/environment');
+		const collection: NarrowedFECollectionType = {
+			curated: [
+				card('a', [tagWithPageId, tagA]),
+				card('b', [tagWithPageId, tagA, tagB]),
+				card('c', [tagWithPageId, tagA, tagB, tagC]),
+			],
+			backfill: [
+				card('d', [tagWithPageId, tagA, tagB, tagC, tagD]),
+				card('e', [tagWithPageId, tagA, tagB, tagC, tagD, tagE]),
+				card('f', [tagWithPageId, tagA, tagB, tagC, tagD, tagE, tagF]),
+			],
+		};
+		expect(
+			extractTrendingTopicsFomFront([collection], 'au/environment'),
+		).toEqual([tagA, tagB, tagC, tagD, tagE, tagF]);
+	});
+
+	it('removes cards without paidContentType or tagType being Keyword or Topics', () => {
+		const tagWithTopicsPaidContentType = tag(
+			'tagWithTopicsPaidContentType',
+			'',
+			'Topics',
+		);
+		const tagWithKeywordPaidContentType = tag(
+			'tagWithKeywordPaidContentType',
+			'',
+			'Keyword',
+		);
+		const tagWithKeywordTagType = tag('tagWithKeywordTagType');
+		const tagWithNoneOfTheAbove = tag(
+			'tagWithNoneOfTheAbove',
+			'Series',
+			'Series',
+		);
+		const collection: NarrowedFECollectionType = {
+			curated: [
+				card('a', [tagWithNoneOfTheAbove]),
+				card('b', [
+					tagWithNoneOfTheAbove,
+					tagWithTopicsPaidContentType,
+				]),
+			],
+			backfill: [
+				card('c', [
+					tagWithNoneOfTheAbove,
+					tagWithTopicsPaidContentType,
+					tagWithKeywordPaidContentType,
+				]),
+				card('d', [
+					tagWithNoneOfTheAbove,
+					tagWithTopicsPaidContentType,
+					tagWithKeywordPaidContentType,
+					tagWithKeywordTagType,
+				]),
+			],
+		};
+		expect(
+			extractTrendingTopicsFomFront([collection], 'au/environment'),
+		).toEqual([
+			tagWithTopicsPaidContentType,
+			tagWithKeywordPaidContentType,
+			tagWithKeywordTagType,
+		]);
+	});
+});

--- a/dotcom-rendering/src/model/extractTrendingTopics.ts
+++ b/dotcom-rendering/src/model/extractTrendingTopics.ts
@@ -32,12 +32,31 @@ const isNotSectionTag = (tag: FETagType): boolean => {
 	);
 };
 
+export type NarrowedFEFrontCard = {
+	card: {
+		id: string;
+	};
+	properties: {
+		maybeContent?: {
+			tags: {
+				tags: FETagType[];
+			};
+		};
+		maybeContentId?: string;
+	};
+};
+
+export type NarrowedFECollectionType = {
+	curated: NarrowedFEFrontCard[];
+	backfill: NarrowedFEFrontCard[];
+};
+
 /**
  * Gets all relevant tags filtered by properties
  * @param tags - The deduplicated trails
  * @returns An array of relevant tags
  */
-const getTags = (trails: FEFrontCard[], pageId: string): FETagType[] =>
+const getTags = (trails: NarrowedFEFrontCard[], pageId: string): FETagType[] =>
 	trails
 		.flatMap((trail) => trail.properties.maybeContent?.tags.tags)
 		.filter(isNonNullable)
@@ -73,14 +92,12 @@ const sortTags = (tag: FETagType[]): FETagType[] => {
 	return sortedTags.map((x) => x[1][0]);
 };
 
-
 export const extractTrendingTopicsFomFront = (
-	collections: FECollectionType[],
+	collections: NarrowedFECollectionType[],
 	pageId: string,
 ): FETagType[] => {
 	// Get a single array of all trails in the collections
-	const trails = new Map<string, FEFrontCard>();
-
+	const trails = new Map<string, NarrowedFEFrontCard>();
 	collections
 		.flatMap((collection) => [
 			...collection.curated,
@@ -93,7 +110,7 @@ export const extractTrendingTopicsFomFront = (
 	return extractTrendingTopics([...trails.values()], pageId);
 };
 
-export const extractTrendingTopics = (trails: FEFrontCard[], pageId: string): FETagType[] => {
+export const extractTrendingTopics = (trails: NarrowedFEFrontCard[], pageId: string): FETagType[] => {
 	const allTags = getTags(trails, pageId);
 	const tags = sortTags(allTags).slice(0, 20);
 

--- a/dotcom-rendering/src/model/extractTrendingTopics.ts
+++ b/dotcom-rendering/src/model/extractTrendingTopics.ts
@@ -45,8 +45,8 @@ const getTags = (trails: FEFrontCard[], pageId: string): FETagType[] =>
 		.filter((tag) => tag.properties.id !== pageId)
 		.filter((tag) => {
 			return (
-				tag.properties.paidContentType?.includes('Keyword') ??
-				tag.properties.paidContentType?.includes('Topic') ??
+				!!tag.properties.paidContentType?.includes('Keyword') ||
+				!!tag.properties.paidContentType?.includes('Topic') ||
 				tag.properties.tagType === 'Keyword'
 			);
 		});

--- a/dotcom-rendering/src/model/extractTrendingTopics.ts
+++ b/dotcom-rendering/src/model/extractTrendingTopics.ts
@@ -108,7 +108,10 @@ export const extractTrendingTopicsFomFront = (
 	return extractTrendingTopics([...trails.values()], pageId);
 };
 
-export const extractTrendingTopics = (trails: NarrowedFEFrontCard[], pageId: string): FETagType[] => {
+export const extractTrendingTopics = (
+	trails: NarrowedFEFrontCard[],
+	pageId: string,
+): FETagType[] => {
 	const allTags = getTags(trails, pageId);
 	const tags = sortTags(allTags).slice(0, 20);
 

--- a/dotcom-rendering/src/model/extractTrendingTopics.ts
+++ b/dotcom-rendering/src/model/extractTrendingTopics.ts
@@ -1,5 +1,4 @@
 import { isNonNullable } from '@guardian/libs';
-import type { FECollectionType, FEFrontCard } from '../types/front';
 import type { FETagType } from '../types/tag';
 
 /**
@@ -75,21 +74,20 @@ const getTags = (trails: NarrowedFEFrontCard[], pageId: string): FETagType[] =>
  * @param tags - Tags which you want to have filtered
  * @returns An array of tags which has been sorted by frequency
  */
-const sortTags = (tag: FETagType[]): FETagType[] => {
-	const counter: { [key: string]: [FETagType, number] } = {};
+const sortTags = (tags: readonly FETagType[]): FETagType[] => {
+	const map = new Map<string, { count: number; tag: FETagType }>();
 
-	tag.forEach((x) => {
-		const id = x.properties.id;
-		const count = counter[id]?.[1] ?? 0;
+	for (const tag of tags) {
+		const {
+			properties: { id },
+		} = tag;
 
-		counter[id] = [x, count + 1];
-	});
+		map.set(id, { count: (map.get(id)?.count ?? 0) + 1, tag });
+	}
 
-	const sortedTags = Object.entries(counter).sort(
-		(a, b) => b[1][1] - a[1][1],
-	);
-
-	return sortedTags.map((x) => x[1][0]);
+	return [...map.values()]
+		.sort(({ count: a }, { count: b }) => b - a)
+		.map(({ tag }) => tag);
 };
 
 export const extractTrendingTopicsFomFront = (

--- a/dotcom-rendering/src/server/index.front.web.ts
+++ b/dotcom-rendering/src/server/index.front.web.ts
@@ -39,6 +39,7 @@ const enhanceFront = (body: unknown): DCRFrontType => {
 		mostShared: data.mostShared ? decideTrail(data.mostShared) : undefined,
 		trendingTopics: extractTrendingTopicsFomFront(
 			data.pressedPage.collections,
+			data.pageId,
 		),
 		deeplyRead: data.deeplyRead?.map((trail) => decideTrail(trail)),
 	};
@@ -68,7 +69,7 @@ const enhanceTagFront = (body: unknown): DCRTagFrontType => {
 						pageId: data.pageId,
 				  }
 				: undefined,
-		trendingTopics: extractTrendingTopics(data.contents),
+		trendingTopics: extractTrendingTopics(data.contents, data.pageId),
 		header: {
 			title: data.webTitle,
 			description: data.tags.tags[0]?.properties.bio,


### PR DESCRIPTION
## What does this change?

- Show sectionId by tags in trending topics
- Updates `extractTrendingTopics` to more closely resemble Frontends version. Its still not exactly the same due to 2 reasons:
   - Frontend does a deep comparison of tags and cards when deduping which is not super straightforward to do in JS, especially as we don't have all the fields Frontend has.
   - When multiple tags have the same frequency frontend doesn't specify how to order them, I had difficulties trying to replicate this order in DCR.

I think this is probably close enough, any differences comes down to how tags are ordered and deduped in DCR which I don't think were even intentional in the first place in Frontend.

## Why?

Fixes #7947
Fixes #7983 

## Screenshots

| Frontend      | Before     | After      |
| ------------- | ---------- | ---------- |
| ![frontend][] |![before][] | ![after][] |
| ![frontend2][] |![before2][] | ![after2][] |


[frontend]: https://github.com/guardian/dotcom-rendering/assets/21217225/35a5e589-8a51-4f23-ab60-11db6a4ae84c
[before]: https://github.com/guardian/dotcom-rendering/assets/21217225/59fd72aa-2779-45b6-ba70-cdfe3505a94c
[after]: https://github.com/guardian/dotcom-rendering/assets/21217225/9b9e7833-c66f-45bc-921a-edb339d3511f
[frontend2]: https://github.com/guardian/dotcom-rendering/assets/21217225/8ad579d3-5bd6-46f4-92b2-db6b448ad84a
[before2]: https://github.com/guardian/dotcom-rendering/assets/21217225/dbca1eff-97b6-476b-be78-80ebcc4fe466
[after2]: https://github.com/guardian/dotcom-rendering/assets/21217225/20e2d84b-9d06-47a4-8a53-7840aabec7b1



<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
