### PR TITLE
Dynamo only if there’s a container palette

### DIFF
--- a/dotcom-rendering/src/components/DynamicPackage.stories.tsx
+++ b/dotcom-rendering/src/components/DynamicPackage.stories.tsx
@@ -1,3 +1,4 @@
+import { ArticleDesign, ArticleDisplay, ArticleSpecial } from '@guardian/libs';
 import { breakpoints } from '@guardian/source-foundations';
 import { trails } from '../../fixtures/manual/trails';
 import type { DCRGroupedTrails } from '../types/front';
@@ -333,3 +334,42 @@ export const ThreeSnapTwoStandard2ndBoosted = () => (
 );
 ThreeSnapTwoStandard2ndBoosted.storyName =
 	'With three snaps (2nd boosted) - two standard cards';
+
+export const SpecialReportWithoutPalette = () => (
+	<FrontSection title="Dynamic Package" showTopBorder={true}>
+		<DynamicPackage
+			groupedTrails={{
+				...defaultGroupedTrails,
+				snap: trails.slice(0, 1),
+				standard: [
+					{
+						format: {
+							display: ArticleDisplay.Immersive,
+							theme: ArticleSpecial.SpecialReport,
+							design: ArticleDesign.Standard,
+						},
+						url: '/news/2016/apr/08/mossack-fonseca-law-firm-hide-money-panama-papers',
+						kickerText: 'Mossack Fonseca',
+						headline:
+							'inside the firm that helps the super-rich hide their money',
+						showQuotedHeadline: false,
+						dataLinkName: 'news | group-0 | card-@1',
+						showMainVideo: false,
+						showLivePlayable: false,
+						isExternalLink: false,
+						webPublicationDate: '2016-04-08T12:15:09.000Z',
+						image: 'https://media.guim.co.uk/bc9acaefba82b18506aa4e60801d0a6af7176a44/0_106_3000_1800/3000.jpg',
+						isBoosted: false,
+						trailText:
+							'As Panama Papers shine light on offshore world, Luke Harding takes a closer look at company exploiting tropical tax havens',
+						supportingContent: [],
+						byline: 'Luke Harding',
+						snapData: {},
+						isCrossword: false,
+					},
+				],
+			}}
+		/>
+	</FrontSection>
+);
+One.storyName = 'With one standard card';

--- a/dotcom-rendering/src/components/DynamicPackage.tsx
+++ b/dotcom-rendering/src/components/DynamicPackage.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention -- because underscores work here*/
 import { shouldPadWrappableRows } from '../lib/dynamicSlices';
 import type {
 	DCRContainerPalette,
@@ -75,7 +74,7 @@ const Card100 = ({
 					imagePosition="bottom"
 					imagePositionOnMobile="bottom"
 					imageSize="large"
-					isDynamo={true}
+					isDynamo={containerPalette && true}
 					supportingContent={cards[0].supportingContent}
 					supportingContentAlignment="horizontal"
 				/>


### PR DESCRIPTION
## What does this change?

Only allow dynamic container’s first standard card to be `dynamo` if the container has a palette

## Why?

Otherwise it looks naff…

Closes #7951 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/76776/f0b23e42-cbce-4b01-88dc-8334611e9796
[after]: https://github.com/guardian/dotcom-rendering/assets/76776/f8eeb5ce-9eac-4bdf-8431-d75cc79b4d70
