### PR TITLE
Wrap Snaps in Cards with SnapCssSandbox

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -23,6 +23,7 @@ import { LatestLinks } from '../LatestLinks.importable';
 import { MediaMeta } from '../MediaMeta';
 import { Slideshow } from '../Slideshow';
 import { Snap } from '../Snap';
+import { SnapCssSandbox } from '../SnapCssSandbox';
 import { StarRating } from '../StarRating/StarRating';
 import type { Alignment } from '../SupportingContent';
 import { SupportingContent } from '../SupportingContent';
@@ -363,7 +364,11 @@ export const Card = ({
 	});
 
 	if (snapData?.embedHtml) {
-		return <Snap snapData={snapData} dataLinkName={dataLinkName} />;
+		return (
+			<SnapCssSandbox snapData={snapData}>
+				<Snap snapData={snapData} dataLinkName={dataLinkName} />
+			</SnapCssSandbox>
+		);
 	}
 
 	const image = getImage({


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Wraps Snaps used in Cards with our SnapCssSandbox

## Why?

There are certain embeds that go in a `fixed/small/slow-I` container instead of a `fixed/thrasher`

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/21217225/0c40cdac-9a71-44fd-9246-54cec57ff28e
[after]: https://github.com/guardian/dotcom-rendering/assets/21217225/9d234993-0e25-4293-b5ae-67e964ced15c

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
