### PR TITLE
Add fluid full width styles to the mobile-front ad slot

### DIFF
--- a/dotcom-rendering/src/components/AdSlot.tsx
+++ b/dotcom-rendering/src/components/AdSlot.tsx
@@ -536,6 +536,7 @@ export const AdSlot = ({
 								margin: 12px auto;
 							`,
 							adStyles,
+							fluidFullWidthAdStyles,
 						]}
 						data-link-name={`ad slot ${advertId}`}
 						data-name={advertId}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Add's the full width fluid styles to the `mobile-front` slot, these are only visible on mobile so don't need a media query.

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/1731150/71e880ac-223e-41aa-be2c-ea2e8d938820
[after]: https://github.com/guardian/dotcom-rendering/assets/1731150/02bcd168-7c39-4fe3-910b-5bbb75a46bdc


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
