### PR TITLE
Modify ophan components script

### DIFF
--- a/scripts/deno/deno.lock
+++ b/scripts/deno/deno.lock
@@ -119,9 +119,7 @@
       },
       "@octokit/auth-token@3.0.3": {
         "integrity": "sha512-/aFM2M4HVDBT/jjDBa84sJniv1t9Gm/rLkalaz9htOm+L+8JMj1k9w0CkUdcxNyNxZPlTxKPVko+m1VlM58ZVA==",
-        "dependencies": {
-          "@octokit/types": "@octokit/types@9.0.0"
-        }
+        "dependencies": { "@octokit/types": "@octokit/types@9.0.0" }
       },
       "@octokit/auth-unauthenticated@3.0.4": {
         "integrity": "sha512-AT74XGBylcLr4lmUp1s6mjSUgphGdlse21Qjtv5DzpX1YOl5FXKwvNcZWESdhyBbpDT8VkVyLFqa/7a7eqpPNw==",
@@ -273,9 +271,7 @@
       },
       "@types/jsonwebtoken@9.0.1": {
         "integrity": "sha512-c5ltxazpWabia/4UzhIoaDcIza4KViOQhdbjRlfcIGVnsE3c3brkz9Z+F/EeJIECOQP7W7US2hNE930cWWkPiw==",
-        "dependencies": {
-          "@types/node": "@types/node@18.11.9"
-        }
+        "dependencies": { "@types/node": "@types/node@18.11.9" }
       },
       "@types/lru-cache@5.1.1": {
         "integrity": "sha512-ssE3Vlrys7sdIzs5LOxCzTVMsU7i9oa/IaW92wF32JFb3CVczqOkru2xspuKczHEbG3nvmPY7IFqVmGGHdNbYw==",
@@ -318,9 +314,7 @@
       },
       "ecdsa-sig-formatter@1.0.11": {
         "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
-        "dependencies": {
-          "safe-buffer": "safe-buffer@5.2.1"
-        }
+        "dependencies": { "safe-buffer": "safe-buffer@5.2.1" }
       },
       "fromentries@1.3.2": {
         "integrity": "sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==",
@@ -364,9 +358,7 @@
       },
       "lru-cache@6.0.0": {
         "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-        "dependencies": {
-          "yallist": "yallist@4.0.0"
-        }
+        "dependencies": { "yallist": "yallist@4.0.0" }
       },
       "ms@2.1.3": {
         "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
@@ -374,9 +366,7 @@
       },
       "node-fetch@2.6.9": {
         "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
-        "dependencies": {
-          "whatwg-url": "whatwg-url@5.0.0"
-        }
+        "dependencies": { "whatwg-url": "whatwg-url@5.0.0" }
       },
       "octokit@2.0.14_@octokit+core@4.2.0": {
         "integrity": "sha512-z6cgZBFxirpFEQ1La8Lg83GCs5hOV2EPpkYYdjsGNbfQMv8qUGjq294MiRBCbZqLufviakGsPUxaNKe3JrPmsA==",
@@ -393,9 +383,7 @@
       },
       "once@1.4.0": {
         "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-        "dependencies": {
-          "wrappy": "wrappy@1.0.2"
-        }
+        "dependencies": { "wrappy": "wrappy@1.0.2" }
       },
       "pretty-bytes@6.1.0": {
         "integrity": "sha512-Rk753HI8f4uivXi4ZCIYdhmG1V+WKzvRMg/X+M42a6t7D07RcmopXJMDNk6N++7Bl75URRGsb40ruvg7Hcp2wQ==",
@@ -407,9 +395,7 @@
       },
       "semver@7.3.8": {
         "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-        "dependencies": {
-          "lru-cache": "lru-cache@6.0.0"
-        }
+        "dependencies": { "lru-cache": "lru-cache@6.0.0" }
       },
       "tr46@0.0.3": {
         "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",

--- a/scripts/deno/ophan-components.ts
+++ b/scripts/deno/ophan-components.ts
@@ -56,7 +56,7 @@ const getOphanComponents = (
 	const doc = new DOMParser().parseFromString(html, 'text/html');
 	if (!doc) throw new Error('Unable to parse DOM');
 
-	return [...doc.querySelectorAll(`[${attribute}]`)].filter(
+	return [...doc.querySelectorAll(`[${attribute}]:not(.is-hidden,.is-hidden *)`)].filter(
 		(node): node is Element => node instanceof Element,
 	);
 };

--- a/scripts/deno/ophan-components.ts
+++ b/scripts/deno/ophan-components.ts
@@ -38,7 +38,15 @@ const known_errors = new Set([
 	'7 | text',
 	'8 | text',
 	'9 | text',
-	'10 | text'
+	'10 | text',
+	'most-viewed',
+	'tab 1 Most viewed',
+	'tab 2 Across the guardian',
+	'Most viewed',
+	'Across the guardian',
+
+	// Not visible when JS is disabled
+	'nav2 : overlay',
 ]);
 
 const getOphanComponents = (


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
* Adds some more known errors to the `ophan-component.ts`. These are specific to the changes made by the EdEx team for introducing the Deeply Read component in the network fronts. See relevant PRs:
   - https://github.com/guardian/dotcom-rendering/pull/7829
   - https://github.com/guardian/frontend/pull/26189 
* Ignores components that are hidden when JS is disabled. We are not interested in achieving parity for those as they are not clickable by the user.

## Why?
To reduce the noise when tracking differences in Ophan components in https://github.com/guardian/dotcom-rendering/issues/4692 and https://github.com/guardian/dotcom-rendering/issues/4698

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
