### PR TITLE
Fix video container when has page skin

### DIFF
--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -468,6 +468,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 									collection.config.showDateHeader
 								}
 								editionId={front.editionId}
+								hasPageSkin={hasPageSkin}
 							>
 								<Island deferUntil={'visible'}>
 									<Carousel


### PR DESCRIPTION
## What does this change?

Constrains the video container when there is a page skin

We still need to rejig the carousel to constrain to a desktop layout when there's a page skin but will do as a follow up.

## Screenshots

### Before

<img width="1608" alt="Screenshot 2023-06-23 at 16 32 26" src="https://github.com/guardian/dotcom-rendering/assets/7014230/c12ad9c6-9b24-4bfa-9d31-9a5c7a6b677f">

### After

<img width="1634" alt="Screenshot 2023-06-23 at 16 31 14" src="https://github.com/guardian/dotcom-rendering/assets/7014230/d1b88ccd-7ba2-4642-9a65-61eea3561076">

