### PR TITLE
Tidy up the ad slot and ad container styles

### DIFF
--- a/dotcom-rendering/src/components/AdSlot.tsx
+++ b/dotcom-rendering/src/components/AdSlot.tsx
@@ -264,8 +264,6 @@ const mobileStickyAdStyles = css`
 	}
 `;
 
-const adStyles = [labelStyles, fluidAdStyles, adContainerCollapseStyles];
-
 export const adContainerStyles = [adContainerCollapseStyles, labelStyles];
 
 export const AdSlot = ({
@@ -296,7 +294,6 @@ export const AdSlot = ({
 									'ad-slot--rendered',
 									'js-sticky-mpu',
 								].join(' ')}
-								css={adStyles}
 								data-link-name="ad slot right"
 								data-name="right"
 								aria-hidden="true"
@@ -308,7 +305,7 @@ export const AdSlot = ({
 					return (
 						<TopRightAdSlot
 							isPaidContent={isPaidContent}
-							adStyles={adStyles}
+							adStyles={[labelStyles]}
 						/>
 					);
 				}
@@ -328,7 +325,6 @@ export const AdSlot = ({
 							'ad-slot--rendered',
 							'js-sticky-mpu',
 						].join(' ')}
-						css={[adStyles]}
 						data-link-name="ad slot comments"
 						data-name="comments"
 						aria-hidden="true"
@@ -355,7 +351,11 @@ export const AdSlot = ({
 						'ad-slot--mpu-banner-ad',
 						'ad-slot--rendered',
 					].join(' ')}
-					css={[adStyles, fluidFullWidthAdStyles, adSlotAboveNav]}
+					css={[
+						fluidAdStyles,
+						fluidFullWidthAdStyles,
+						adSlotAboveNav,
+					]}
 					data-link-name="ad slot top-above-nav"
 					data-name="top-above-nav"
 					aria-hidden="true"
@@ -374,7 +374,7 @@ export const AdSlot = ({
 							'ad-slot--mpu-banner-ad',
 							'ad-slot--rendered',
 						].join(' ')}
-						css={[adStyles, mostPopAdStyles]}
+						css={[mostPopAdStyles]}
 						data-link-name="ad slot mostpop"
 						data-name="mostpop"
 						aria-hidden="true"
@@ -404,7 +404,7 @@ export const AdSlot = ({
 						].join(' ')}
 						css={[
 							merchandisingAdStyles,
-							adStyles,
+							fluidAdStyles,
 							fluidFullWidthAdStyles,
 						]}
 						data-link-name="ad slot merchandising-high"
@@ -435,7 +435,7 @@ export const AdSlot = ({
 						].join(' ')}
 						css={[
 							merchandisingAdStyles,
-							adStyles,
+							fluidAdStyles,
 							fluidFullWidthAdStyles,
 						]}
 						data-link-name="ad slot merchandising"
@@ -481,7 +481,6 @@ export const AdSlot = ({
 							css`
 								position: relative;
 							`,
-							adStyles,
 						]}
 						data-link-name={`ad slot ${advertId}`}
 						data-name={advertId}
@@ -507,8 +506,6 @@ export const AdSlot = ({
 							css`
 								position: relative;
 							`,
-							adStyles,
-							adSlotCollapseStyles,
 						]}
 						data-link-name={`ad slot ${advertId}`}
 						data-name={advertId}
@@ -540,7 +537,6 @@ export const AdSlot = ({
 								width: 300px;
 								margin: 12px auto;
 							`,
-							adStyles,
 							fluidFullWidthAdStyles,
 						]}
 						data-link-name={`ad slot ${advertId}`}

--- a/dotcom-rendering/src/components/AdSlot.tsx
+++ b/dotcom-rendering/src/components/AdSlot.tsx
@@ -266,6 +266,8 @@ const mobileStickyAdStyles = css`
 
 const adStyles = [labelStyles, fluidAdStyles, adContainerCollapseStyles];
 
+export const adContainerStyles = [adContainerCollapseStyles, labelStyles];
+
 export const AdSlot = ({
 	position,
 	display,
@@ -280,7 +282,10 @@ export const AdSlot = ({
 				case ArticleDisplay.Showcase:
 				case ArticleDisplay.NumberedList: {
 					return (
-						<div className="ad-slot-container" css={[adStyles]}>
+						<div
+							className="ad-slot-container"
+							css={[adContainerStyles]}
+						>
 							<div
 								id="dfp-ad--right"
 								className={[
@@ -312,7 +317,7 @@ export const AdSlot = ({
 			}
 		case 'comments': {
 			return (
-				<div className="ad-slot-container" css={[adStyles]}>
+				<div className="ad-slot-container" css={[adContainerStyles]}>
 					<div
 						id="dfp-ad--comments"
 						className={[
@@ -359,7 +364,7 @@ export const AdSlot = ({
 		}
 		case 'mostpop': {
 			return (
-				<div className="ad-slot-container" css={[adStyles]}>
+				<div className="ad-slot-container" css={[adContainerStyles]}>
 					<div
 						id="dfp-ad--mostpop"
 						className={[
@@ -387,7 +392,7 @@ export const AdSlot = ({
 							justify-content: center;
 						`,
 						hasPageskin && pageSkinContainer,
-						adStyles,
+						adContainerStyles,
 					]}
 				>
 					<div
@@ -418,7 +423,7 @@ export const AdSlot = ({
 							display: flex;
 							justify-content: center;
 						`,
-						adStyles,
+						adContainerStyles,
 					]}
 				>
 					<div
@@ -462,7 +467,7 @@ export const AdSlot = ({
 		case 'inline': {
 			const advertId = `inline${index + 1}`;
 			return (
-				<div className="ad-slot-container" css={[adStyles]}>
+				<div className="ad-slot-container" css={[adContainerStyles]}>
 					<div
 						id={`dfp-ad--${advertId}`}
 						className={[
@@ -488,7 +493,7 @@ export const AdSlot = ({
 		case 'liveblog-inline': {
 			const advertId = `inline${index}`;
 			return (
-				<div className="ad-slot-container">
+				<div className="ad-slot-container" css={[adContainerStyles]}>
 					<div
 						id={`dfp-ad--${advertId}`}
 						className={[
@@ -515,7 +520,7 @@ export const AdSlot = ({
 		case 'mobile-front': {
 			const advertId = index === 0 ? 'top-above-nav' : `inline${index}`;
 			return (
-				<div className="ad-slot-container" css={[adStyles]}>
+				<div className="ad-slot-container" css={[adContainerStyles]}>
 					<div
 						id={`dfp-ad--${advertId}--mobile`}
 						className={[
@@ -547,7 +552,7 @@ export const AdSlot = ({
 		}
 		case 'pageskin': {
 			return (
-				<div className="ad-slot-container" css={[adStyles]}>
+				<div className="ad-slot-container" css={[adContainerStyles]}>
 					<div
 						id="dfp-ad--pageskin-inread"
 						className={[

--- a/dotcom-rendering/src/components/AdSlot.tsx
+++ b/dotcom-rendering/src/components/AdSlot.tsx
@@ -46,7 +46,7 @@ type Props = InlineProps | NonInlineProps;
 
 export const labelHeight = 24;
 
-export const individualLabelCSS = css`
+const individualLabelCSS = css`
 	${textSans.xxsmall()};
 	height: ${labelHeight}px;
 	max-height: ${labelHeight}px;
@@ -120,15 +120,26 @@ export const labelStyles = css`
 		padding: 0;
 		border: 0;
 	}
+
+	.ad-slot--interscroller[data-label-show='true']::before {
+		content: 'Advertisement';
+		position: absolute;
+		top: 0px;
+		left: 0px;
+		right: 0px;
+		border: 0;
+		display: block;
+		${individualLabelCSS}
+	}
 `;
 
-export const adContainerCollapseStyles = css`
+const adContainerCollapseStyles = css`
 	& .ad-slot.ad-slot--collapse {
 		display: none;
 	}
 `;
 
-export const adSlotCollapseStyles = css`
+const adSlotCollapseStyles = css`
 	&.ad-slot.ad-slot--collapse {
 		display: none;
 	}

--- a/dotcom-rendering/src/components/ArticleContainer.tsx
+++ b/dotcom-rendering/src/components/ArticleContainer.tsx
@@ -2,12 +2,7 @@ import { css } from '@emotion/react';
 import { adSizes } from '@guardian/commercial';
 import { ArticleDesign } from '@guardian/libs';
 import { from, neutral, space, until } from '@guardian/source-foundations';
-import {
-	carrotAdStyles,
-	individualLabelCSS,
-	labelHeight,
-	labelStyles,
-} from './AdSlot';
+import { carrotAdStyles, labelHeight, labelStyles } from './AdSlot';
 
 type Props = {
 	format: ArticleFormat;
@@ -122,17 +117,6 @@ const adStyles = css`
 				/* must be behind as the actual ad is on top of the iframe */
 				z-index: -1;
 			}
-		}
-
-		.ad-slot--interscroller[data-label-show='true']::before {
-			content: 'Advertisement';
-			position: absolute;
-			top: 0px;
-			left: 0px;
-			right: 0px;
-			border: 0;
-			display: block;
-			${individualLabelCSS}
 		}
 
 		/* liveblogs ads have different background colours due the darker page background */

--- a/dotcom-rendering/src/components/HeaderAdSlot.tsx
+++ b/dotcom-rendering/src/components/HeaderAdSlot.tsx
@@ -26,7 +26,7 @@ const headerAdWrapper = css`
 	top: 0;
 `;
 
-const adSlotContainer = css`
+const topAboveNavContainer = css`
 	&[top-above-nav-ad-rendered] {
 		width: fit-content;
 		margin: auto;
@@ -51,7 +51,7 @@ export const HeaderAdSlot = () => (
 		<Hide when="below" breakpoint="tablet">
 			<div css={[headerAdWrapper]} className="top-banner-ad-container">
 				<div
-					css={[adSlotContainer, adContainerStyles]}
+					css={[adContainerStyles, topAboveNavContainer]}
 					className="ad-slot-container"
 				>
 					<AdSlot position="top-above-nav" />

--- a/dotcom-rendering/src/components/HeaderAdSlot.tsx
+++ b/dotcom-rendering/src/components/HeaderAdSlot.tsx
@@ -1,12 +1,7 @@
 import { css, Global } from '@emotion/react';
 import { TOP_ABOVE_NAV_HEIGHT } from '@guardian/commercial/dist/esm/core/constants';
 import { border, neutral, space } from '@guardian/source-foundations';
-import {
-	adContainerCollapseStyles,
-	AdSlot,
-	labelHeight,
-	labelStyles,
-} from './AdSlot';
+import { adContainerStyles, AdSlot, labelHeight } from './AdSlot';
 import { Hide } from './Hide';
 
 const headerWrapper = css`
@@ -54,12 +49,9 @@ export const HeaderAdSlot = () => (
 			`}
 		/>
 		<Hide when="below" breakpoint="tablet">
-			<div
-				css={[headerAdWrapper, labelStyles]}
-				className="top-banner-ad-container"
-			>
+			<div css={[headerAdWrapper]} className="top-banner-ad-container">
 				<div
-					css={[adSlotContainer, adContainerCollapseStyles]}
+					css={[adSlotContainer, adContainerStyles]}
 					className="ad-slot-container"
 				>
 					<AdSlot position="top-above-nav" />

--- a/dotcom-rendering/src/layouts/FullPageInteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/FullPageInteractiveLayout.tsx
@@ -11,11 +11,7 @@ import {
 	neutral,
 	until,
 } from '@guardian/source-foundations';
-import {
-	adContainerCollapseStyles,
-	labelStyles as adLabelStyles,
-	MobileStickyContainer,
-} from '../components/AdSlot';
+import { adContainerStyles, MobileStickyContainer } from '../components/AdSlot';
 import { Footer } from '../components/Footer';
 import { Header } from '../components/Header';
 import { HeaderAdSlot } from '../components/HeaderAdSlot';
@@ -112,8 +108,7 @@ const Renderer = ({
 	});
 
 	const adStyles = css`
-		${adLabelStyles}
-		${adContainerCollapseStyles}
+		${adContainerStyles}
 
 		${from.tablet} {
 			.mobile-only .ad-slot {

--- a/dotcom-rendering/src/lib/ArticleRenderer.tsx
+++ b/dotcom-rendering/src/lib/ArticleRenderer.tsx
@@ -1,10 +1,7 @@
 import { css } from '@emotion/react';
 import type { ArticleFormat } from '@guardian/libs';
 import { ArticleDesign } from '@guardian/libs';
-import {
-	adContainerCollapseStyles,
-	labelStyles as adLabelStyles,
-} from '../components/AdSlot';
+import { adContainerStyles } from '../components/AdSlot';
 import { interactiveLegacyClasses } from '../layouts/lib/interactiveLegacyStyling';
 import type { ServerSideTests, Switches } from '../types/config';
 import type { FEElement } from '../types/content';
@@ -24,8 +21,7 @@ const commercialPosition = css`
 // spacefinder is scoped to placing elements in spaces within the .article-body-commercial-selector
 // hence we scope the styles at the same level
 const adStylesDynamic = css`
-	${adLabelStyles}
-	${adContainerCollapseStyles}
+	${adContainerStyles}
 `;
 
 type Props = {


### PR DESCRIPTION
## What does this change?
This PR aims to tidy up the ad styles code and make the assignment of different styles clearer and easier to work with. Label styles are now applied at the container level using a new const to assign the ad container collapse styles and label styles to a container.

The adStyles const has been deleted as it contained more styles than most ads needed. Any extra styles required at slot level rather than container level are now applied more explicitly.

This PR also tidies up some of the style exports, reducing the total number of styles being exported from AdSlot.tsx.

## Why?
This work aims to create a clearer developer experience. The adStyles were being used at both slot and container level, and were often adding in blanket CSS to the ad slots that was not required in every case. The styles applied at container level are consistent, and any specificity is done at the slot level.
