### PR TITLE
Do not allow branded containers on paid fronts

### DIFF
--- a/dotcom-rendering/src/model/decideContainerPalette.ts
+++ b/dotcom-rendering/src/model/decideContainerPalette.ts
@@ -7,7 +7,7 @@ import type { DCRContainerPalette, FEContainerPalette } from '../types/front';
 
 export const decideContainerPalette = (
 	palettes?: FEContainerPalette[],
-	allCardsHaveBranding?: boolean,
+	canBeBranded?: boolean,
 ): DCRContainerPalette | undefined => {
 	if (palettes?.includes('EventPalette')) return 'EventPalette';
 	if (palettes?.includes('SombreAltPalette')) return 'SombreAltPalette';
@@ -21,6 +21,6 @@ export const decideContainerPalette = (
 	if (palettes?.includes('BreakingPalette')) return 'BreakingPalette';
 	if (palettes?.includes('SpecialReportAltPalette'))
 		return 'SpecialReportAltPalette';
-	if (palettes?.includes('Branded') && allCardsHaveBranding) return 'Branded';
+	if (palettes?.includes('Branded') && canBeBranded) return 'Branded';
 	return undefined;
 };

--- a/dotcom-rendering/src/model/enhanceCollections.ts
+++ b/dotcom-rendering/src/model/enhanceCollections.ts
@@ -42,6 +42,7 @@ export const enhanceCollections = (
 	editionId: EditionId,
 	pageId: string,
 	onPageDescription?: string,
+	isPaidContent?: boolean,
 ): DCRCollectionType[] => {
 	return collections.filter(isSupported).map((collection, index) => {
 		const { id, displayName, collectionType, hasMore, href, description } =
@@ -49,9 +50,16 @@ export const enhanceCollections = (
 		const allCards = [...collection.curated, ...collection.backfill];
 		const allBranding = getBrandingFromCards(allCards, editionId);
 		const allCardsHaveBranding = allCards.length === allBranding.length;
+
+		/**
+		 * We do this because Frontend had logic to ignore the "Branded" palette tag in the Fronts tool
+		 * when rendering a paid front or when non-paid content is curated inside a "Branded" container
+		 * */
+		const canBeBranded = !isPaidContent && allCardsHaveBranding;
+
 		const containerPalette = decideContainerPalette(
 			collection.config.metadata?.map((meta) => meta.type),
-			allCardsHaveBranding,
+			canBeBranded,
 		);
 		return {
 			id,

--- a/dotcom-rendering/src/server/index.front.web.ts
+++ b/dotcom-rendering/src/server/index.front.web.ts
@@ -22,6 +22,7 @@ const enhanceFront = (body: unknown): DCRFrontType => {
 				data.editionId,
 				data.pageId,
 				data.pressedPage.frontProperties.onPageDescription,
+				data.config.isPaidContent,
 			),
 		},
 		mostViewed: data.mostViewed.map((trail) => decideTrail(trail)),


### PR DESCRIPTION
## What does this change?

Does not allow branded containers on paid fronts as 
Fixes: https://github.com/guardian/dotcom-rendering/issues/5945

## Why?

We already have a labs header on paid fronts. 
This logic also exists in Frontend. 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/1229808/8db18edc-7182-477d-8637-991f27024da9
[after]: https://github.com/guardian/dotcom-rendering/assets/1229808/1267fc89-1059-4891-8575-e64cc5273813

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
