### PR TITLE
Guardian Labs: Tracking

### DIFF
--- a/dotcom-rendering/src/components/LabsSection.tsx
+++ b/dotcom-rendering/src/components/LabsSection.tsx
@@ -388,6 +388,10 @@ export const LabsSection = ({
 			ophanComponentLink={ophanComponentLink}
 			ophanComponentName={ophanComponentName}
 			hasPageSkin={hasPageSkin}
+			/**
+			 * This is the secret word that will fool the ad blockers but allow commercial code to track Labs Containers
+			 */
+			className={'dumathoin'}
 		>
 			<Container hasPageSkin={hasPageSkin}>
 				<LeftColumn

--- a/dotcom-rendering/src/components/LabsSection.tsx
+++ b/dotcom-rendering/src/components/LabsSection.tsx
@@ -389,7 +389,9 @@ export const LabsSection = ({
 			ophanComponentName={ophanComponentName}
 			hasPageSkin={hasPageSkin}
 			/**
-			 * This is the secret word that will fool the ad blockers but allow commercial code to track Labs Containers
+			 * dumathoin?
+			 * https://github.com/guardian/frontend/pull/17625
+			 * https://forgottenrealms.fandom.com/wiki/Dumathoin
 			 */
 			className={'dumathoin'}
 		>


### PR DESCRIPTION
## What does this change?

Fixes: https://github.com/guardian/dotcom-rendering/issues/7957

@arelra here:

Commercial code is relying on specific classnames to perform tracking on labs containers. However after discussing with @Amouzle we will pause this collection and reassess whether to continue with this special tracking.

The existing Ophan tracking via `data-component` and `data-link-name` attributes has been reviewed and is deemed sufficient for now.

I've kept dumathoin as an offering to the old gods.