### PR TITLE
Ophan components ID parity for video container

### DIFF
--- a/dotcom-rendering/src/components/Carousel.importable.tsx
+++ b/dotcom-rendering/src/components/Carousel.importable.tsx
@@ -253,6 +253,16 @@ const buttonStyle = css`
 	}
 `;
 
+const linkStyles = css`
+	text-decoration: none;
+`;
+
+const headerStylesWithUrl = css`
+	:hover {
+		text-decoration: underline;
+	}
+`;
+
 const prevButtonStyle = (index: number) => css`
 	background-color: ${index !== 0 ? neutral[0] : neutral[60]};
 	cursor: ${index !== 0 ? 'pointer' : 'default'};
@@ -320,6 +330,16 @@ const titleStyle = (
 	}
 `;
 
+const getDataLinkNameCarouselButton = (
+	heading: string,
+	direction: string,
+	arrowName: string,
+): string => {
+	return `${
+		heading.toLowerCase() === 'videos' ? 'video-container' : arrowName
+	}-${direction}`;
+};
+
 const Title = ({
 	title,
 	titleHighlightColour,
@@ -328,14 +348,32 @@ const Title = ({
 	title: string;
 	titleHighlightColour: string;
 	isCuratedContent?: boolean;
-}) => (
-	<h2 css={headerStyles}>
-		{isCuratedContent ? 'More from ' : ''}
-		<span css={titleStyle(titleHighlightColour, isCuratedContent)}>
-			{title}
-		</span>
-	</h2>
-);
+}) =>
+	title === 'Videos' ? (
+		<a
+			css={[linkStyles]}
+			href="https://www.theguardian.com/video"
+			data-link-name="video-container-title Videos"
+		>
+			<h2 css={headerStyles}>
+				<span
+					css={[
+						headerStylesWithUrl,
+						titleStyle(titleHighlightColour, isCuratedContent),
+					]}
+				>
+					{title}
+				</span>
+			</h2>
+		</a>
+	) : (
+		<h2 css={headerStyles}>
+			{isCuratedContent ? 'More from ' : ''}
+			<span css={titleStyle(titleHighlightColour, isCuratedContent)}>
+				{title}
+			</span>
+		</h2>
+	);
 
 type CarouselCardProps = {
 	isFirst: boolean;
@@ -569,6 +607,11 @@ export const Carousel = ({
 		<div
 			css={wrapperStyle(trails.length)}
 			data-link-name={formatAttrString(heading)}
+			data-component={
+				heading.toLowerCase() === 'videos'
+					? 'video-playlist'
+					: undefined
+			}
 		>
 			<FetchCommentCounts />
 			<LeftColumn borderType="partial" size={leftColSize}>
@@ -593,7 +636,11 @@ export const Carousel = ({
 					onClick={prev}
 					aria-label="Move carousel backwards"
 					css={[buttonStyle, prevButtonStyle(index)]}
-					data-link-name={`${arrowName}-prev`}
+					data-link-name={getDataLinkNameCarouselButton(
+						heading,
+						'prev',
+						arrowName,
+					)}
 				>
 					<SvgChevronLeftSingle />
 				</button>
@@ -605,7 +652,11 @@ export const Carousel = ({
 					onClick={next}
 					aria-label="Move carousel forwards"
 					css={[buttonStyle, nextButtonStyle(index, trails.length)]}
-					data-link-name={`${arrowName}-next`}
+					data-link-name={getDataLinkNameCarouselButton(
+						heading,
+						'next',
+						arrowName,
+					)}
 				>
 					<SvgChevronRightSingle />
 				</button>
@@ -632,7 +683,11 @@ export const Carousel = ({
 								onClick={prev}
 								aria-label="Move carousel backwards"
 								css={[buttonStyle, prevButtonStyle(index)]}
-								data-link-name={`${arrowName}-prev`}
+								data-link-name={getDataLinkNameCarouselButton(
+									heading,
+									'prev',
+									arrowName,
+								)}
 							>
 								<SvgChevronLeftSingle />
 							</button>
@@ -644,7 +699,11 @@ export const Carousel = ({
 									buttonStyle,
 									nextButtonStyle(index, trails.length),
 								]}
-								data-link-name={`${arrowName}-next`}
+								data-link-name={getDataLinkNameCarouselButton(
+									heading,
+									'next',
+									arrowName,
+								)}
 							>
 								<SvgChevronRightSingle />
 							</button>

--- a/scripts/deno/ophan-components.ts
+++ b/scripts/deno/ophan-components.ts
@@ -47,6 +47,14 @@ const known_errors = new Set([
 
 	// Not visible when JS is disabled
 	'nav2 : overlay',
+	'nav3 : edition picker',
+
+	// In frontend there is <input> and <label>. In DCR it's a <button>
+	'nav3 : topbar : edition-picker: toggle',
+
+	// It's an island with deferUntil="visible"
+	'footer : contribute-cta'
+
 ]);
 
 const getOphanComponents = (


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

Addresses issues in:
* https://github.com/guardian/dotcom-rendering/issues/4698
* https://github.com/guardian/dotcom-rendering/issues/4692

## What does this change?
* Adds values for `data-link-name` and `data-component` attributes in the video container. These are consumed by Ophan and analysed by our data analysts.
* Adds a few more differences in the known errors in `ophan-components.ts`

## Why?
For parity with frontend in what data we send to Ophan.


<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
