### PR TITLE
Add tell us button for fronts action cards

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.stories.tsx
+++ b/dotcom-rendering/src/components/Card/Card.stories.tsx
@@ -903,6 +903,22 @@ export const WhenOpinionWithImageAtBottom = () => {
 	);
 };
 
+export const ActionCard = () => {
+	return (
+		<CardGroup>
+			<CardWrapper>
+				<Card
+					{...basicCardProps}
+					kickerText="Kicker"
+					headlineSize="small"
+					headlineText="Heading small"
+					isActionCard={true}
+				/>
+			</CardWrapper>
+		</CardGroup>
+	);
+};
+
 export const WhenVideoWithPlayButton = () => {
 	return (
 		<Section title="Play icons" padContent={false} centralBorder="partial">

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -81,6 +81,7 @@ export type Props = {
 	isExternalLink: boolean;
 	slideshowImages?: DCRSlideshowImage[];
 	showLivePlayable?: boolean;
+	isActionCard?: boolean;
 };
 
 const StarRatingComponent = ({
@@ -279,6 +280,7 @@ export const Card = ({
 	isExternalLink,
 	slideshowImages,
 	showLivePlayable = false,
+	isActionCard,
 }: Props) => {
 	const palette = decidePalette(format, containerPalette);
 
@@ -469,6 +471,7 @@ export const Card = ({
 							showByline={showByline}
 							isDynamo={isDynamo}
 							isExternalLink={isExternalLink}
+							isActionCard={isActionCard}
 						/>
 						{starRating !== undefined ? (
 							<StarRatingComponent

--- a/dotcom-rendering/src/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/components/CardHeadline.tsx
@@ -7,10 +7,16 @@ import {
 	from,
 	headline,
 	space,
+	palette as srcPallet,
 	textSans,
 	until,
 } from '@guardian/source-foundations';
-import { Link, SvgExternal } from '@guardian/source-react-components';
+import {
+	Button,
+	Link,
+	SvgArrowRightStraight,
+	SvgExternal,
+} from '@guardian/source-react-components';
 import React from 'react';
 import { decidePalette } from '../lib/decidePalette';
 import { getZIndex } from '../lib/getZIndex';
@@ -36,6 +42,7 @@ type Props = {
 	linkTo?: string; // If provided, the headline is wrapped in a link
 	isDynamo?: true;
 	isExternalLink?: boolean;
+	isActionCard?: boolean;
 };
 
 const fontStyles = ({
@@ -199,6 +206,16 @@ const dynamoStyles = css`
 	padding: 5px;
 `;
 
+const tellUsButtonStyles = css`
+	margin: 8px 0px;
+	display: flex;
+	color: ${srcPallet.neutral[7]};
+	border-color: ${srcPallet.neutral[0]};
+	svg {
+		color: ${srcPallet.neutral[0]};
+	}
+`;
+
 export const WithLink = ({
 	linkTo,
 	children,
@@ -242,6 +259,7 @@ export const CardHeadline = ({
 	linkTo,
 	isDynamo,
 	isExternalLink,
+	isActionCard,
 }: Props) => {
 	const palette = decidePalette(format, containerPalette);
 	const kickerColour = isDynamo
@@ -309,6 +327,19 @@ export const CardHeadline = ({
 					size={size}
 					isCard={true}
 				/>
+			)}
+			{isActionCard ? (
+				<Button
+					priority="tertiary"
+					size="xsmall"
+					icon={<SvgArrowRightStraight />}
+					iconSide="right"
+					cssOverrides={tellUsButtonStyles}
+				>
+					Tell us
+				</Button>
+			) : (
+				<></>
 			)}
 		</>
 	);

--- a/dotcom-rendering/src/components/FrontCard.tsx
+++ b/dotcom-rendering/src/components/FrontCard.tsx
@@ -50,6 +50,7 @@ export const FrontCard = (props: Props) => {
 		branding: trail.branding,
 		slideshowImages: trail.slideshowImages,
 		showLivePlayable: trail.showLivePlayable,
+		isActionCard: trail.isActionCard,
 	};
 
 	return Card({ ...defaultProps, ...cardProps });

--- a/dotcom-rendering/src/model/enhanceCards.ts
+++ b/dotcom-rendering/src/model/enhanceCards.ts
@@ -233,6 +233,11 @@ export const enhanceCards = (
 			(editionBranding) => editionBranding.edition.id === editionId,
 		)?.branding;
 
+		// Action card is a new card type that invites users to take action as opposed to merely
+		// read, view, watch or listen
+		const isActionCard =
+			tags.filter((tag) => tag.id === 'tone/callout').length > 0;
+
 		return {
 			format,
 			dataLinkName,
@@ -282,5 +287,6 @@ export const enhanceCards = (
 			embedUri: faciaCard.properties.embedUri ?? undefined,
 			branding,
 			slideshowImages: decideSlideshowImages(faciaCard),
+			isActionCard,
 		};
 	});

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -293,6 +293,7 @@ export type DCRFrontCard = {
 	branding?: Branding;
 	slideshowImages?: DCRSlideshowImage[];
 	showLivePlayable: boolean;
+	isActionCard?: boolean;
 };
 
 export type DCRSlideshowImage = {


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
This PR adds a `Tell us` button for actionable card where user can take an action by opening the article, e.g. filling in a callout form.

## Why?
Currently, there is not a very clear way of visually setting apart what is a "callout" article on fronts. Because of this, some of our users currently think callout articles are actual articles. This ambiguity could be having a negative impact on our users' experience. Additionally, we think that if we can make it clearer to our users that an article is a callout, we could drive user engagement in our callout campaigns.

![image](https://github.com/guardian/dotcom-rendering/assets/15894063/74168228-307c-4596-9603-6272328f1c15)


This change was first implemented in frontend and AB tested. 