### PR TITLE
Container title description style changes

### DIFF
--- a/dotcom-rendering/src/components/ContainerTitle.tsx
+++ b/dotcom-rendering/src/components/ContainerTitle.tsx
@@ -43,7 +43,7 @@ const headerStylesWithUrl = css`
 `;
 
 const descriptionStyles = (fontColour?: string) => css`
-	${body.xsmall({ fontWeight: 'medium' })};
+	${body.medium({ fontWeight: 'medium', lineHeight: 'tight' })};
 	color: ${fontColour ?? neutral[46]};
 	p {
 		/* Handle paragraphs in the description */


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
This updates the fontSize and lineHeight. For an exact match we would need to use font-family: 'Guardian Egyptian Web' but this has been superseded by body from source.

## Why?
More closely match frontend styling

Fixes https://github.com/guardian/dotcom-rendering/issues/7926
## Screenshots

|frontend | Before      | After      |
| ----------- | ----------- | ---------- |
| ![frontend][] | ![before][] | ![after][] |

[frontend]: 
https://github.com/guardian/dotcom-rendering/assets/110032454/e98a5c40-7daa-4737-8539-8084e1f62ad7

[before]: https://github.com/guardian/dotcom-rendering/assets/110032454/2871746a-636f-46e1-a588-734d29375b47
[after]: https://github.com/guardian/dotcom-rendering/assets/110032454/200c96fa-899e-458d-b721-c48263a18e20

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
