### PR TITLE
refactor: Rely on `containerType` not `title`

### DIFF
--- a/dotcom-rendering/src/components/Carousel.importable.tsx
+++ b/dotcom-rendering/src/components/Carousel.importable.tsx
@@ -41,6 +41,7 @@ type ArticleProps = Props & {
 
 type FrontProps = Props & {
 	palette: DCRContainerPalette;
+	collectionType?: string;
 };
 
 // Carousel icons - need replicating from source for centring
@@ -360,12 +361,14 @@ const titleStyle = (
 `;
 
 const getDataLinkNameCarouselButton = (
-	heading: string,
 	direction: string,
 	arrowName: string,
+	collectionType?: string,
 ): string => {
 	return `${
-		heading.toLowerCase() === 'videos' ? 'video-container' : arrowName
+		collectionType && collectionType === 'fixed/video'
+			? 'video-container'
+			: arrowName
 	}-${direction}`;
 };
 
@@ -699,7 +702,8 @@ export const Carousel = ({
 			css={wrapperStyle(trails.length)}
 			data-link-name={formatAttrString(heading)}
 			data-component={
-				heading.toLowerCase() === 'videos'
+				'collectionType' in props &&
+				props.collectionType === 'fixed/video'
 					? 'video-playlist'
 					: undefined
 			}

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -483,6 +483,9 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 										onwardsSource={'unknown-source'}
 										palette={'MediaPalette'}
 										leftColSize={'compact'}
+										collectionType={
+											collection.collectionType
+										}
 									/>
 								</Island>
 							</Section>


### PR DESCRIPTION
## What does this change?
Decides whether the `Carousel.importable` is used for the video container based on the `containerType` instead of `title`.

## Why?
Suggestion by @alinaboghiu and @mxdvl  on https://github.com/guardian/dotcom-rendering/pull/8046. Title can be changed by tools and may therefore be quite brittle.


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
