### PR TITLE
feat(SubNav): show top border

### DIFF
--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -227,7 +227,6 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 						<>
 							<Section
 								fullWidth={true}
-								showTopBorder={false}
 								padSides={false}
 								element="aside"
 								hasPageSkin={hasPageSkin}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Add a top border to the SubNav on fronts

## Why?

This is how articles do it, and it prevents the content from jumping by 1px up and down when navigating between fronts and articles.

## Screenshots

Honestly, you have to squint…