### PR TITLE
Fix Data validation errors with WitnessBlockElement

### DIFF
--- a/dotcom-rendering/src/components/WitnessBlockComponent.tsx
+++ b/dotcom-rendering/src/components/WitnessBlockComponent.tsx
@@ -148,7 +148,7 @@ export const WitnessImageBlockComponent = ({
 	// asset in the list
 	const bestImgSource =
 		assets.find(
-			(asset) => asset.typeData.name === 'mediumoriginalaspectdouble',
+			(asset) => asset.typeData?.name === 'mediumoriginalaspectdouble',
 		) ?? assets[0];
 	return (
 		<WitnessWrapper
@@ -161,7 +161,6 @@ export const WitnessImageBlockComponent = ({
 					css={css`
 						width: 100%;
 					`}
-					// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- it could be undefined, until we have noUncheckedIndexedAccess
 					src={bestImgSource?.file}
 					alt={alt}
 					itemProp="contentURL"

--- a/dotcom-rendering/src/model/article-schema.json
+++ b/dotcom-rendering/src/model/article-schema.json
@@ -3428,10 +3428,7 @@
                     ]
                 },
                 "mimeType": {
-                    "type": "string",
-                    "enum": [
-                        "image/jpeg"
-                    ]
+                    "type": "string"
                 },
                 "file": {
                     "type": "string"
@@ -3442,17 +3439,11 @@
                         "name": {
                             "type": "string"
                         }
-                    },
-                    "required": [
-                        "name"
-                    ]
+                    }
                 }
             },
             "required": [
-                "file",
-                "mimeType",
-                "type",
-                "typeData"
+                "type"
             ]
         },
         "WitnessTypeDataImage": {

--- a/dotcom-rendering/src/model/block-schema.json
+++ b/dotcom-rendering/src/model/block-schema.json
@@ -3017,10 +3017,7 @@
                     ]
                 },
                 "mimeType": {
-                    "type": "string",
-                    "enum": [
-                        "image/jpeg"
-                    ]
+                    "type": "string"
                 },
                 "file": {
                     "type": "string"
@@ -3031,17 +3028,11 @@
                         "name": {
                             "type": "string"
                         }
-                    },
-                    "required": [
-                        "name"
-                    ]
+                    }
                 }
             },
             "required": [
-                "file",
-                "mimeType",
-                "type",
-                "typeData"
+                "type"
             ]
         },
         "WitnessTypeDataImage": {

--- a/dotcom-rendering/src/types/content.ts
+++ b/dotcom-rendering/src/types/content.ts
@@ -578,10 +578,10 @@ interface WitnessTypeDataText extends WitnessTypeDataBase {
 
 export interface WitnessAssetType {
 	type: 'Image';
-	mimeType: 'image/jpeg';
-	file: string;
-	typeData: {
-		name: string;
+	mimeType?: string;
+	file?: string;
+	typeData?: {
+		name?: string;
 	};
 }
 interface WitnessTypeBlockElement extends ThirdPartyEmbeddedContent {


### PR DESCRIPTION
## What does this change?

Makes most of the properties of WitnessAssetType optional as per https://github.com/guardian/frontend/blob/77fe48ed548240d0f6f260aa9937f2995bf9eec2/common/app/model/dotcomrendering/pageElements/PageElement.scala#L645

## Why?

Theres a bug in Frontend where old liveblogs such as https://www.theguardian.com/music/musicblog/2013/jun/28/glastonbury-2013-day-one-liveblog are rendered by DCR AMP despite the fact that the normal web version isn't supported in DCR.

We could just restrict these liveblogs from rendering in AMP but I figured its best to fix forward.

FYI these old liveblogs to actually look quite good in DCR now, I wonder if its possible to remove https://github.com/guardian/frontend/blob/main/article/app/services/dotcomrendering/ArticlePicker.scala#L31

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/21217225/1afba794-aa4b-4727-b454-8323f47e1eaf
[after]: https://github.com/guardian/dotcom-rendering/assets/21217225/e8810a6d-33c4-4d15-b3d2-e8ba1ccf2536


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
