### PR TITLE
Use correct layouts when ad-free for `dynamic/slow-mpu`

### DIFF
--- a/dotcom-rendering/src/components/DecideContainer.tsx
+++ b/dotcom-rendering/src/components/DecideContainer.tsx
@@ -68,7 +68,6 @@ export const DecideContainer = ({
 					showAge={showAge}
 					adIndex={adIndex}
 					renderAds={renderAds}
-					trails={trails}
 				/>
 			);
 		case 'dynamic/package':

--- a/dotcom-rendering/src/components/DynamicFast.tsx
+++ b/dotcom-rendering/src/components/DynamicFast.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention -- because underscores work here*/
 import {
 	Card25Media25,
 	Card50Media50Tall,
@@ -7,6 +6,7 @@ import {
 import {
 	Card100PictureRight,
 	Card100PictureTop,
+	Card25_Card25_Card25_Card25,
 	Card25_Card75,
 	Card50_Card50,
 	Card75_Card25,
@@ -419,42 +419,6 @@ const Card25_Card25_Card25_ColumnOfThreeCards25 = ({
 					})}
 				</UL>
 			</LI>
-		</UL>
-	);
-};
-
-const Card25_Card25_Card25_Card25 = ({
-	cards,
-	showAge,
-	containerPalette,
-}: {
-	cards: DCRFrontCard[];
-	showAge?: boolean;
-	containerPalette?: DCRContainerPalette;
-}) => {
-	if (cards.length < 4) return null;
-
-	const bigs = cards.slice(0, 4);
-
-	return (
-		<UL direction="row" wrapCards={true}>
-			{bigs.map((card, cardIndex) => {
-				return (
-					<LI
-						key={card.url}
-						percentage={`25%`}
-						padSides={true}
-						showDivider={cardIndex !== 0}
-						containerPalette={containerPalette}
-					>
-						<Card25Media25
-							trail={card}
-							containerPalette={containerPalette}
-							showAge={showAge}
-						/>
-					</LI>
-				);
-			})}
 		</UL>
 	);
 };

--- a/dotcom-rendering/src/components/DynamicSlow.tsx
+++ b/dotcom-rendering/src/components/DynamicSlow.tsx
@@ -1,5 +1,4 @@
 import {
-	Card25Media25Tall,
 	Card50Media50,
 	CardDefaultMedia,
 	CardDefaultMediaMobile,
@@ -10,6 +9,7 @@ import {
 	Card25_Card75,
 	Card50_Card50,
 	Card75_Card25,
+	ColumnOfCards50_Card25_Card25,
 	filterGroupedTrails,
 	shouldPadWrappableRows,
 } from '../lib/dynamicSlices';
@@ -66,60 +66,6 @@ const ColumnOfCards50_Card50 = ({
 								padSides={true}
 							>
 								<CardDefaultMediaMobile
-									trail={card}
-									containerPalette={containerPalette}
-									showAge={showAge}
-								/>
-							</LI>
-						);
-					})}
-				</UL>
-			</LI>
-		</UL>
-	);
-};
-
-const ColumnOfCards50_Card25_Card25 = ({
-	cards,
-	showAge,
-	containerPalette,
-}: {
-	cards: DCRFrontCard[];
-	showAge?: boolean;
-	containerPalette?: DCRContainerPalette;
-}) => {
-	const bigs = cards.slice(0, 2).reverse();
-	const remaining = cards.slice(2);
-
-	return (
-		<UL direction="row-reverse">
-			{bigs.map((big) => {
-				return (
-					<LI
-						percentage="25%"
-						padSides={true}
-						showDivider={true}
-						containerPalette={containerPalette}
-						key={big.url}
-					>
-						<Card25Media25Tall
-							trail={big}
-							showAge={showAge}
-							containerPalette={containerPalette}
-						/>
-					</LI>
-				);
-			})}
-			<LI percentage="50%">
-				<UL direction="row" wrapCards={true}>
-					{remaining.map((card) => {
-						return (
-							<LI
-								percentage="100%"
-								key={card.url}
-								padSides={true}
-							>
-								<CardDefaultMedia
 									trail={card}
 									containerPalette={containerPalette}
 									showAge={showAge}

--- a/dotcom-rendering/src/components/DynamicSlowMPU.stories.tsx
+++ b/dotcom-rendering/src/components/DynamicSlowMPU.stories.tsx
@@ -33,7 +33,6 @@ export const NoBigs = () => (
 			showAge={true}
 			adIndex={1}
 			renderAds={true}
-			trails={trails}
 		/>
 	</FrontSection>
 );
@@ -52,7 +51,6 @@ export const OneBig = () => (
 			showAge={true}
 			adIndex={1}
 			renderAds={true}
-			trails={trails}
 		/>
 	</FrontSection>
 );
@@ -71,7 +69,6 @@ export const TwoBigs = () => (
 			showAge={true}
 			adIndex={1}
 			renderAds={true}
-			trails={trails}
 		/>
 	</FrontSection>
 );
@@ -94,7 +91,6 @@ export const FirstBigBoosted = () => (
 			showAge={true}
 			adIndex={1}
 			renderAds={true}
-			trails={trails}
 		/>
 	</FrontSection>
 );
@@ -117,7 +113,6 @@ export const SecondBigBoosted = () => (
 			showAge={true}
 			adIndex={1}
 			renderAds={true}
-			trails={trails}
 		/>
 	</FrontSection>
 );
@@ -136,7 +131,6 @@ export const ThreeBigs = () => (
 			showAge={true}
 			adIndex={1}
 			renderAds={true}
-			trails={trails}
 		/>
 	</FrontSection>
 );
@@ -155,13 +149,12 @@ export const AllBigs = () => (
 			showAge={true}
 			adIndex={1}
 			renderAds={true}
-			trails={trails}
 		/>
 	</FrontSection>
 );
 AllBigs.storyName = 'with lots of bigs and no standards';
 
-export const AdfreeDynamicSlowMPU = () => (
+export const AllBigsNoMPU = () => (
 	<FrontSection title="DynamicSlowMPU">
 		<DynamicSlowMPU
 			groupedTrails={{
@@ -174,8 +167,61 @@ export const AdfreeDynamicSlowMPU = () => (
 			showAge={true}
 			adIndex={1}
 			renderAds={false}
-			trails={trails}
 		/>
 	</FrontSection>
 );
-AdfreeDynamicSlowMPU.storyName = 'Ad-free dynamic slow MPU';
+AllBigsNoMPU.storyName = 'Ad-free with lots of bigs';
+
+export const TwoBigsThreeStandardsNoMPU = () => (
+	<FrontSection title="DynamicSlowMPU">
+		<DynamicSlowMPU
+			groupedTrails={{
+				snap: [],
+				huge: [],
+				veryBig: [],
+				big: bigs.slice(0, 2),
+				standard: standards.slice(0, 3),
+			}}
+			showAge={true}
+			adIndex={1}
+			renderAds={false}
+		/>
+	</FrontSection>
+);
+TwoBigsThreeStandardsNoMPU.storyName = 'Ad-free with 2 bigs & 3 standards';
+
+export const NoBigsTwoStandardsNoMPU = () => (
+	<FrontSection title="DynamicSlowMPU">
+		<DynamicSlowMPU
+			groupedTrails={{
+				snap: [],
+				huge: [],
+				veryBig: [],
+				big: [],
+				standard: standards.slice(0, 2),
+			}}
+			showAge={true}
+			adIndex={1}
+			renderAds={false}
+		/>
+	</FrontSection>
+);
+NoBigsTwoStandardsNoMPU.storyName = 'Ad-free with 0 bigs & 2 standards';
+
+export const NoBigsFiveStandardsNoMPU = () => (
+	<FrontSection title="DynamicSlowMPU">
+		<DynamicSlowMPU
+			groupedTrails={{
+				snap: [],
+				huge: [],
+				veryBig: [],
+				big: [],
+				standard: standards.slice(0, 5),
+			}}
+			showAge={true}
+			adIndex={1}
+			renderAds={false}
+		/>
+	</FrontSection>
+);
+NoBigsFiveStandardsNoMPU.storyName = 'Ad-free with 0 bigs & 5 standards';

--- a/dotcom-rendering/src/components/DynamicSlowMPU.tsx
+++ b/dotcom-rendering/src/components/DynamicSlowMPU.tsx
@@ -161,7 +161,7 @@ const ColumnOfThree50_Ad50 = ({
  *
  * This container only allows big and standard cards (from groupedTrails)
  *
- * Layout is dynamic deopending on the number of big cards. You're only
+ * Layout is dynamic depending on the number of big cards. You're only
  * allowed to have 2 or 3 big cards. If you pass 1 a standard card will
  * get promoted to make two bigs. If you pass more than 3 bigs then the
  * extras will get demoted to standard.

--- a/dotcom-rendering/src/components/DynamicSlowMPU.tsx
+++ b/dotcom-rendering/src/components/DynamicSlowMPU.tsx
@@ -1,15 +1,17 @@
 import { Hide } from '@guardian/source-react-components';
 import {
-	Card25Media25SmallHeadline,
 	Card33Media33,
 	CardDefault,
 	CardDefaultMediaMobile,
 } from '../lib/cardWrappers';
 import {
+	Card25_Card25_Card25_Card25,
 	Card25_Card75,
 	Card50_Card25_Card25,
 	Card50_Card50,
 	Card75_Card25,
+	ColumnOfCards50_Card25_Card25,
+	filterGroupedTrails,
 } from '../lib/dynamicSlices';
 import type {
 	DCRContainerPalette,
@@ -26,7 +28,6 @@ type Props = {
 	showAge?: boolean;
 	adIndex: number;
 	renderAds: boolean;
-	trails: DCRFrontCard[];
 };
 
 /* .___________.___________.___________.
@@ -86,6 +87,33 @@ const Card33_ColumnOfThree33_Ad33 = ({
 	);
 };
 
+/* .___________.___________.___________.
+ * |___________|___________|___________|
+ */
+const Card33_Card33_Card33 = ({
+	cards,
+	containerPalette,
+	showAge,
+}: {
+	cards: DCRFrontCard[];
+	containerPalette?: DCRContainerPalette;
+	showAge?: boolean;
+}) => {
+	return (
+		<UL direction="row">
+			{cards.slice(0, 3).map((card) => (
+				<LI padSides={true} key={card.url} percentage="33.333%">
+					<CardDefault
+						trail={card}
+						containerPalette={containerPalette}
+						showAge={showAge}
+					/>
+				</LI>
+			))}
+		</UL>
+	);
+};
+
 /* ._________________._________________.
  * |_###_____________|                 |
  * |_###_____________|       MPU       |
@@ -128,182 +156,6 @@ const ColumnOfThree50_Ad50 = ({
 	);
 };
 
-type MPUProps = {
-	groupedTrails: DCRGroupedTrails;
-	containerPalette?: DCRContainerPalette;
-	showAge?: boolean;
-	adIndex: number;
-};
-
-const MPUSlice = ({
-	groupedTrails,
-	containerPalette,
-	showAge,
-	adIndex,
-}: MPUProps) => {
-	let layout:
-		| 'noBigs'
-		| 'twoBigs'
-		| 'twoBigsFirstBoosted'
-		| 'twoBigsSecondBoosted'
-		| 'threeBigs';
-	let bigCards: DCRFrontCard[] = [];
-	let standardCards: DCRFrontCard[] = [];
-	switch (groupedTrails.big.length) {
-		case 0: {
-			standardCards = groupedTrails.standard;
-			layout = 'noBigs';
-			break;
-		}
-		case 1: {
-			// If there is only one big item a standard item is promoted such that
-			// there is always at least two
-			const promoted = groupedTrails.standard.slice(0, 1);
-			bigCards = [...groupedTrails.big, ...promoted];
-			standardCards = groupedTrails.standard.slice(1);
-			layout = 'twoBigs';
-			break;
-		}
-		case 2: {
-			bigCards = groupedTrails.big;
-			standardCards = groupedTrails.standard;
-			if (groupedTrails.big[0]?.isBoosted) {
-				layout = 'twoBigsFirstBoosted';
-			} else if (groupedTrails.big[1]?.isBoosted) {
-				layout = 'twoBigsSecondBoosted';
-			} else {
-				layout = 'twoBigs';
-			}
-			break;
-		}
-		case 3: {
-			bigCards = groupedTrails.big;
-			standardCards = groupedTrails.standard;
-			layout = 'threeBigs';
-			break;
-		}
-		default: {
-			// If there are more than three big cards, these extra bigs are demoted to
-			// standard.
-			const demoted = groupedTrails.big.slice(3);
-			standardCards = [...demoted, ...groupedTrails.standard];
-			bigCards = groupedTrails.big.slice(0, 3);
-			layout = 'threeBigs';
-		}
-	}
-
-	switch (layout) {
-		case 'noBigs': {
-			return (
-				<Card33_ColumnOfThree33_Ad33
-					cards={standardCards}
-					containerPalette={containerPalette}
-					showAge={showAge}
-					adIndex={adIndex}
-				/>
-			);
-		}
-		case 'twoBigs': {
-			return (
-				<>
-					<Card50_Card50
-						cards={bigCards}
-						containerPalette={containerPalette}
-						showAge={showAge}
-					/>
-					<ColumnOfThree50_Ad50
-						cards={standardCards}
-						containerPalette={containerPalette}
-						showAge={showAge}
-						adIndex={adIndex}
-					/>
-				</>
-			);
-		}
-		case 'twoBigsFirstBoosted': {
-			return (
-				<>
-					<Card75_Card25
-						cards={bigCards}
-						containerPalette={containerPalette}
-						showAge={showAge}
-					/>
-					<ColumnOfThree50_Ad50
-						cards={standardCards}
-						containerPalette={containerPalette}
-						showAge={showAge}
-						adIndex={adIndex}
-					/>
-				</>
-			);
-		}
-		case 'twoBigsSecondBoosted': {
-			return (
-				<>
-					<Card25_Card75
-						cards={bigCards}
-						containerPalette={containerPalette}
-						showAge={showAge}
-					/>
-					<ColumnOfThree50_Ad50
-						cards={standardCards}
-						containerPalette={containerPalette}
-						showAge={showAge}
-						adIndex={adIndex}
-					/>
-				</>
-			);
-		}
-		case 'threeBigs': {
-			return (
-				<>
-					<Card50_Card25_Card25
-						cards={bigCards}
-						containerPalette={containerPalette}
-						showAge={showAge}
-					/>
-					<ColumnOfThree50_Ad50
-						cards={standardCards}
-						containerPalette={containerPalette}
-						showAge={showAge}
-						adIndex={adIndex}
-					/>
-				</>
-			);
-		}
-	}
-};
-
-type NonMPUProps = {
-	containerPalette?: DCRContainerPalette;
-	showAge?: boolean;
-	trails: DCRFrontCard[];
-};
-
-const NonMPUSlice = ({ trails, containerPalette, showAge }: NonMPUProps) => {
-	return (
-		<UL direction="row" padBottom={true}>
-			{trails.slice(0, 4).map((card, cardIndex) => {
-				return (
-					<LI
-						padSides={true}
-						percentage="25%"
-						showDivider={cardIndex > 0}
-						containerPalette={containerPalette}
-						key={card.url}
-					>
-						<Card25Media25SmallHeadline
-							trail={card}
-							containerPalette={containerPalette}
-							showAge={showAge}
-						/>
-					</LI>
-				);
-			})}
-		</UL>
-	);
-};
-
 /**
  * DynamicSlowMPU
  *
@@ -324,20 +176,186 @@ export const DynamicSlowMPU = ({
 	showAge,
 	adIndex,
 	renderAds,
-	trails,
 }: Props) => {
-	return renderAds ? (
-		<MPUSlice
-			groupedTrails={groupedTrails}
-			containerPalette={containerPalette}
-			showAge={showAge}
-			adIndex={adIndex}
-		/>
-	) : (
-		<NonMPUSlice
-			trails={trails}
-			containerPalette={containerPalette}
-			showAge={showAge}
-		/>
+	let firstSliceLayout:
+		| undefined
+		| 'twoBigs'
+		| 'twoBigsFirstBoosted'
+		| 'twoBigsSecondBoosted'
+		| 'threeBigs';
+	let firstSliceCards: DCRFrontCard[] = [];
+	if (groupedTrails.big.length === 1) {
+		// If there is only one big item a standard item is promoted such that
+		// there is always at least two
+		const promoted = groupedTrails.standard.slice(0, 1);
+		firstSliceCards = [...groupedTrails.big, ...promoted];
+		firstSliceLayout = 'twoBigs';
+	} else if (groupedTrails.big.length === 2) {
+		firstSliceCards = groupedTrails.big.slice(0, 2);
+		if (groupedTrails.big[0]?.isBoosted) {
+			firstSliceLayout = 'twoBigsFirstBoosted';
+		} else if (groupedTrails.big[1]?.isBoosted) {
+			firstSliceLayout = 'twoBigsSecondBoosted';
+		} else {
+			firstSliceLayout = 'twoBigs';
+		}
+	} else if (groupedTrails.big.length > 2) {
+		firstSliceCards = groupedTrails.big.slice(0, 3);
+		firstSliceLayout = 'threeBigs';
+	}
+
+	// Create our object of grouped trails that doesn't include any
+	// cards used by the first slice
+	const secondSliceGroupedTrails = filterGroupedTrails({
+		groupedTrails,
+		filter: firstSliceCards,
+	});
+
+	let secondSliceLayout:
+		| 'noFirstSlice'
+		| 'standard'
+		| 'noFirstSliceNoMPU'
+		| 'noFirstSliceNoMPUThreeOrMore'
+		| 'standardNoMPU'
+		| 'standardNoMPUFourOrMore';
+
+	let secondSliceCards: DCRFrontCard[] = [];
+	const standards = [
+		// Demote any left over 'big' grouped cards
+		...secondSliceGroupedTrails.big,
+		...secondSliceGroupedTrails.standard,
+	];
+
+	if (firstSliceCards.length === 0) {
+		if (renderAds) {
+			secondSliceCards = standards;
+			secondSliceLayout = 'noFirstSlice';
+		} else {
+			if (standards.length > 2) {
+				secondSliceCards = standards.slice(0, 4);
+				secondSliceLayout = 'noFirstSliceNoMPUThreeOrMore';
+			} else {
+				secondSliceCards = standards.slice(0, 2);
+				secondSliceLayout = 'noFirstSliceNoMPU';
+			}
+		}
+	} else {
+		if (renderAds) {
+			secondSliceCards = standards;
+			secondSliceLayout = 'standard';
+		} else {
+			if (standards.length > 3) {
+				secondSliceCards = standards.slice(0, 5);
+				secondSliceLayout = 'standardNoMPUFourOrMore';
+			} else {
+				secondSliceCards = standards.slice(0, 3);
+				secondSliceLayout = 'standardNoMPU';
+			}
+		}
+	}
+
+	const FirstSlice = () => {
+		switch (firstSliceLayout) {
+			case 'twoBigs':
+				return (
+					<Card50_Card50
+						cards={firstSliceCards}
+						containerPalette={containerPalette}
+						showAge={showAge}
+					/>
+				);
+			case 'twoBigsFirstBoosted':
+				return (
+					<Card75_Card25
+						cards={firstSliceCards}
+						containerPalette={containerPalette}
+						showAge={showAge}
+					/>
+				);
+			case 'twoBigsSecondBoosted':
+				return (
+					<Card25_Card75
+						cards={firstSliceCards}
+						containerPalette={containerPalette}
+						showAge={showAge}
+					/>
+				);
+			case 'threeBigs':
+				return (
+					<Card50_Card25_Card25
+						cards={firstSliceCards}
+						containerPalette={containerPalette}
+						showAge={showAge}
+					/>
+				);
+			default:
+				return <></>;
+		}
+	};
+
+	const SecondSlice = () => {
+		switch (secondSliceLayout) {
+			// With MPU
+			case 'standard':
+				return (
+					<ColumnOfThree50_Ad50
+						cards={secondSliceCards}
+						containerPalette={containerPalette}
+						showAge={showAge}
+						adIndex={adIndex}
+					/>
+				);
+			case 'noFirstSlice':
+				return (
+					<Card33_ColumnOfThree33_Ad33
+						cards={secondSliceCards}
+						containerPalette={containerPalette}
+						showAge={showAge}
+						adIndex={adIndex}
+					/>
+				);
+			// Without MPU
+			case 'standardNoMPU':
+				return (
+					<Card33_Card33_Card33
+						cards={secondSliceCards}
+						containerPalette={containerPalette}
+						showAge={showAge}
+					/>
+				);
+
+			case 'standardNoMPUFourOrMore':
+				return (
+					<ColumnOfCards50_Card25_Card25
+						cards={secondSliceCards}
+						containerPalette={containerPalette}
+						showAge={showAge}
+					/>
+				);
+
+			case 'noFirstSliceNoMPU':
+				return (
+					<Card50_Card50
+						cards={secondSliceCards}
+						containerPalette={containerPalette}
+						showAge={showAge}
+					/>
+				);
+			case 'noFirstSliceNoMPUThreeOrMore':
+				return (
+					<Card25_Card25_Card25_Card25
+						cards={secondSliceCards}
+						showAge={showAge}
+						containerPalette={containerPalette}
+					/>
+				);
+		}
+	};
+
+	return (
+		<>
+			<FirstSlice />
+			<SecondSlice />
+		</>
 	);
 };

--- a/dotcom-rendering/src/lib/dynamicSlices.tsx
+++ b/dotcom-rendering/src/lib/dynamicSlices.tsx
@@ -15,6 +15,7 @@ import {
 	Card50Media50Tall,
 	Card75Media50Left,
 	Card75Media50Right,
+	CardDefaultMedia,
 } from './cardWrappers';
 
 /**
@@ -232,6 +233,96 @@ export const Card100PictureTop = ({
 					/>
 				</LI>
 			))}
+		</UL>
+	);
+};
+
+export const Card25_Card25_Card25_Card25 = ({
+	cards,
+	showAge,
+	containerPalette,
+}: {
+	cards: DCRFrontCard[];
+	showAge?: boolean;
+	containerPalette?: DCRContainerPalette;
+}) => {
+	if (cards.length < 4) return null;
+
+	const bigs = cards.slice(0, 4);
+
+	return (
+		<UL direction="row" wrapCards={true}>
+			{bigs.map((card, cardIndex) => {
+				return (
+					<LI
+						key={card.url}
+						percentage={`25%`}
+						padSides={true}
+						showDivider={cardIndex !== 0}
+						containerPalette={containerPalette}
+					>
+						<Card25Media25
+							trail={card}
+							containerPalette={containerPalette}
+							showAge={showAge}
+						/>
+					</LI>
+				);
+			})}
+		</UL>
+	);
+};
+
+export const ColumnOfCards50_Card25_Card25 = ({
+	cards,
+	showAge,
+	containerPalette,
+}: {
+	cards: DCRFrontCard[];
+	showAge?: boolean;
+	containerPalette?: DCRContainerPalette;
+}) => {
+	const bigs = cards.slice(0, 2).reverse();
+	const remaining = cards.slice(2);
+
+	return (
+		<UL direction="row-reverse">
+			{bigs.map((big) => {
+				return (
+					<LI
+						percentage="25%"
+						padSides={true}
+						showDivider={true}
+						containerPalette={containerPalette}
+						key={big.url}
+					>
+						<Card25Media25Tall
+							trail={big}
+							showAge={showAge}
+							containerPalette={containerPalette}
+						/>
+					</LI>
+				);
+			})}
+			<LI percentage="50%">
+				<UL direction="row" wrapCards={true}>
+					{remaining.map((card) => {
+						return (
+							<LI
+								percentage="100%"
+								key={card.url}
+								padSides={true}
+							>
+								<CardDefaultMedia
+									trail={card}
+									containerPalette={containerPalette}
+									showAge={showAge}
+								/>
+							</LI>
+						);
+					})}
+				</UL>
+			</LI>
 		</UL>
 	);
 };


### PR DESCRIPTION
Closes https://github.com/guardian/dotcom-rendering/issues/8053

Fixes an issue where DCR was incorrectly rendering layouts for dynamic/slow-mpu when the user was ad free.

This ends up being quite a big refactor, but by using the 'two slice' layout like we do in DynamicSlow & DynamicFast components - we're able to more easily support the ad-free layouts, which only affect the second slice.

The logic for these different layouts in Frontend can be found [here](https://github.com/guardian/frontend/blob/main/common/app/layout/slices/DynamicSlowMpu.scala#L25)

I've added some stories which cover the different variations of the 'ad-free' layouts depending on whether there's a first slice & the number of cards. There could be a few edge cases though that aren't covered, since Frontend's CSS does a lot of stretching & changing when the number of cards aren't what is expected. From a quick look around the fronts I don't see any of these crop up though.

## Screenshots

| Before      | After      | Frontend      |
| ----------- | ---------- | ---------- |
| ![before][] | ![after][] | ![frontend][]  |

[before]: https://github.com/guardian/dotcom-rendering/assets/9575458/4707151c-d623-45a3-a52f-50c444bc8d36
[after]: https://github.com/guardian/dotcom-rendering/assets/9575458/79294af5-342e-4327-beff-fd117314d2f6
[frontend]: https://github.com/guardian/dotcom-rendering/assets/9575458/54c37bff-6957-4df5-bd6f-daf9b97e300b


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
