### PR TITLE
Not render pinned post if is same as last block

### DIFF
--- a/dotcom-rendering/src/components/LiveBlogBlocksAndAdverts.tsx
+++ b/dotcom-rendering/src/components/LiveBlogBlocksAndAdverts.tsx
@@ -38,23 +38,30 @@ export const LiveBlogBlocksAndAdverts = ({
 	if (!isInLiveblogAdSlotTest) {
 		return (
 			<>
-				{blocks.map((block) => (
-					<LiveBlock
-						key={block.id}
-						format={format}
-						block={block}
-						pageId={pageId}
-						webTitle={webTitle}
-						host={host}
-						ajaxUrl={ajaxUrl}
-						isLiveUpdate={isLiveUpdate}
-						switches={switches}
-						isAdFreeUser={isAdFreeUser}
-						isSensitive={isSensitive}
-						isPinnedPost={false}
-						pinnedPostId={pinnedPost?.id}
-					/>
-				))}
+				{blocks.map((block, i) => {
+					const lastBlockIsPinned =
+						i === 0 && pinnedPost?.id === block.id;
+
+					return (
+						<LiveBlock
+							key={block.id}
+							format={format}
+							block={block}
+							pageId={pageId}
+							webTitle={webTitle}
+							host={host}
+							ajaxUrl={ajaxUrl}
+							isLiveUpdate={isLiveUpdate}
+							switches={switches}
+							isAdFreeUser={isAdFreeUser}
+							isSensitive={isSensitive}
+							isPinnedPost={false}
+							pinnedPostId={
+								lastBlockIsPinned ? undefined : pinnedPost?.id
+							}
+						/>
+					);
+				})}
 			</>
 		);
 	}
@@ -82,6 +89,9 @@ export const LiveBlogBlocksAndAdverts = ({
 					numPixelsOfContentWithoutAdvert = 0;
 				}
 
+				const lastBlockIsPinned =
+					i === 0 && pinnedPost?.id === block.id;
+
 				return (
 					<>
 						<LiveBlock
@@ -97,7 +107,9 @@ export const LiveBlogBlocksAndAdverts = ({
 							isAdFreeUser={isAdFreeUser}
 							isSensitive={isSensitive}
 							isPinnedPost={false}
-							pinnedPostId={pinnedPost?.id}
+							pinnedPostId={
+								lastBlockIsPinned ? undefined : pinnedPost?.id
+							}
 						/>
 						{willDisplayAdAfterBlock && (
 							<AdSlot

--- a/dotcom-rendering/src/lib/LiveBlogRenderer.tsx
+++ b/dotcom-rendering/src/lib/LiveBlogRenderer.tsx
@@ -68,30 +68,36 @@ export const LiveBlogRenderer = ({
 	const filtered =
 		(selectedTopics && selectedTopics.length > 0) || filterKeyEvents;
 
+	const lastBlockIsPinnedPost = pinnedPost?.id === blocks[0]?.id;
+
 	return (
 		<>
-			{pinnedPost && onFirstPage && !filtered && (
-				<>
-					<Island clientOnly={true} deferUntil="idle">
-						<EnhancePinnedPost />
-					</Island>
-					<PinnedPost pinnedPost={pinnedPost} format={format}>
-						<LiveBlock
-							format={format}
-							block={pinnedPost}
-							pageId={pageId}
-							webTitle={webTitle}
-							host={host}
-							ajaxUrl={ajaxUrl}
-							isLiveUpdate={isLiveUpdate}
-							switches={switches}
-							isAdFreeUser={isAdFreeUser}
-							isSensitive={isSensitive}
-							isPinnedPost={true}
-						/>
-					</PinnedPost>
-				</>
-			)}
+			{pinnedPost &&
+				onFirstPage &&
+				!lastBlockIsPinnedPost &&
+				!filtered && (
+					<>
+						<Island clientOnly={true} deferUntil="idle">
+							<EnhancePinnedPost />
+						</Island>
+						<PinnedPost pinnedPost={pinnedPost} format={format}>
+							<LiveBlock
+								format={format}
+								block={pinnedPost}
+								pageId={pageId}
+								webTitle={webTitle}
+								adTargeting={adTargeting}
+								host={host}
+								ajaxUrl={ajaxUrl}
+								isLiveUpdate={isLiveUpdate}
+								switches={switches}
+								isAdFreeUser={isAdFreeUser}
+								isSensitive={isSensitive}
+								isPinnedPost={true}
+							/>
+						</PinnedPost>
+					</>
+				)}
 			{keyEvents !== undefined && keyEvents.length > 0 ? (
 				<Hide from="desktop">
 					<Island deferUntil="visible">

--- a/dotcom-rendering/src/lib/LiveBlogRenderer.tsx
+++ b/dotcom-rendering/src/lib/LiveBlogRenderer.tsx
@@ -86,7 +86,6 @@ export const LiveBlogRenderer = ({
 								block={pinnedPost}
 								pageId={pageId}
 								webTitle={webTitle}
-								adTargeting={adTargeting}
 								host={host}
 								ajaxUrl={ajaxUrl}
 								isLiveUpdate={isLiveUpdate}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
In this change, the pinned post won't be rendered if the last block is also the pinned post. Also the pinned icon is removed from the block.


Currently in prod this would never happen, because the pinned block is filtered out in frontend. After this is released, we would need to merge the frontend PR which is removing the filtering. https://github.com/guardian/frontend/pull/26261
## Why?




## Screenshots

| Before      | After      |
|-------------|------------|
| ![before](https://github.com/guardian/frontend/assets/15894063/2ca3d607-ea6b-4bce-80ce-26534bbab3fe) | ![image](https://github.com/guardian/dotcom-rendering/assets/15894063/d6e06e33-eb57-4657-a375-6fa2596fce27) |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
