### PR TITLE
Kickers in pressed and tag fronts

### DIFF
--- a/dotcom-rendering/src/components/ShowMore.importable.tsx
+++ b/dotcom-rendering/src/components/ShowMore.importable.tsx
@@ -113,7 +113,7 @@ export const ShowMore = ({
 
 	const cards =
 		data &&
-		enhanceCards(data, { editionId }).filter(
+		enhanceCards(data, { editionId }, false).filter(
 			(card) => !existingCardLinks.includes(card.url),
 		);
 

--- a/dotcom-rendering/src/components/ShowMore.importable.tsx
+++ b/dotcom-rendering/src/components/ShowMore.importable.tsx
@@ -113,7 +113,7 @@ export const ShowMore = ({
 
 	const cards =
 		data &&
-		enhanceCards(data, { editionId }, false).filter(
+		enhanceCards(data, { cardInTagFront: false, editionId }).filter(
 			(card) => !existingCardLinks.includes(card.url),
 		);
 

--- a/dotcom-rendering/src/model/enhanceCards.ts
+++ b/dotcom-rendering/src/model/enhanceCards.ts
@@ -192,16 +192,18 @@ const enhanceTags = (tags: FETagType[]): TagType[] => {
 export const enhanceCards = (
 	collections: FEFrontCard[],
 	{
+		cardInTagFront,
 		offset = 0,
 		editionId,
 		containerPalette,
+		pageId,
 	}: {
+		cardInTagFront: boolean;
 		offset?: number;
 		editionId?: EditionId;
 		containerPalette?: DCRContainerPalette;
+		pageId?: string;
 	},
-	cardInTagFront: boolean,
-	pageId?: string,
 ): DCRFrontCard[] =>
 	collections.map((faciaCard, index) => {
 		// Snap cards may not have a format, default to a standard format if that's the case.

--- a/dotcom-rendering/src/model/enhanceCards.ts
+++ b/dotcom-rendering/src/model/enhanceCards.ts
@@ -136,15 +136,22 @@ const decideMediaType = (format: ArticleFormat): MediaType | undefined => {
 	}
 };
 
-const decideKicker = (trail: FEFrontCard) => {
+const decideKicker = (
+	trail: FEFrontCard,
+	cardInTagFront: boolean,
+	pageId?: string,
+) => {
 	if (trail.properties.isBreaking) {
 		return 'Breaking news';
 	}
 
-	return (
-		trail.header.kicker?.item?.properties.kickerText ??
-		trail.header.seriesOrBlogKicker?.name
-	);
+	if (cardInTagFront) {
+		return pageId && !pageId.includes('/series')
+			? trail.header.seriesOrBlogKicker?.name
+			: undefined;
+	}
+
+	return trail.header.kicker?.item?.properties.kickerText;
 };
 
 const decideSlideshowImages = (
@@ -193,6 +200,8 @@ export const enhanceCards = (
 		editionId?: EditionId;
 		containerPalette?: DCRContainerPalette;
 	},
+	cardInTagFront: boolean,
+	pageId?: string,
 ): DCRFrontCard[] =>
 	collections.map((faciaCard, index) => {
 		// Snap cards may not have a format, default to a standard format if that's the case.
@@ -247,7 +256,7 @@ export const enhanceCards = (
 					  ).toISOString()
 					: undefined,
 			image: decideImage(faciaCard),
-			kickerText: decideKicker(faciaCard),
+			kickerText: decideKicker(faciaCard, cardInTagFront, pageId),
 			supportingContent: faciaCard.supportingContent
 				? enhanceSupportingContent(
 						faciaCard.supportingContent,

--- a/dotcom-rendering/src/model/enhanceCollections.ts
+++ b/dotcom-rendering/src/model/enhanceCollections.ts
@@ -82,22 +82,16 @@ export const enhanceCollections = (
 				editionId,
 				containerPalette,
 			),
-			curated: enhanceCards(
-				collection.curated,
-				{
-					editionId,
-					containerPalette,
-				},
-				false,
-			),
-			backfill: enhanceCards(
-				collection.backfill,
-				{
-					editionId,
-					containerPalette,
-				},
-				false,
-			),
+			curated: enhanceCards(collection.curated, {
+				cardInTagFront: false,
+				editionId,
+				containerPalette,
+			}),
+			backfill: enhanceCards(collection.backfill, {
+				cardInTagFront: false,
+				editionId,
+				containerPalette,
+			}),
 			treats: enhanceTreats(
 				collection.treats,
 				displayName,

--- a/dotcom-rendering/src/model/enhanceCollections.ts
+++ b/dotcom-rendering/src/model/enhanceCollections.ts
@@ -82,14 +82,22 @@ export const enhanceCollections = (
 				editionId,
 				containerPalette,
 			),
-			curated: enhanceCards(collection.curated, {
-				editionId,
-				containerPalette,
-			}),
-			backfill: enhanceCards(collection.backfill, {
-				editionId,
-				containerPalette,
-			}),
+			curated: enhanceCards(
+				collection.curated,
+				{
+					editionId,
+					containerPalette,
+				},
+				false,
+			),
+			backfill: enhanceCards(
+				collection.backfill,
+				{
+					editionId,
+					containerPalette,
+				},
+				false,
+			),
 			treats: enhanceTreats(
 				collection.treats,
 				displayName,

--- a/dotcom-rendering/src/model/groupCards.ts
+++ b/dotcom-rendering/src/model/groupCards.ts
@@ -39,13 +39,14 @@ export const groupCards = (
 				snap: [],
 				huge: [],
 				veryBig: [],
-				big: enhanceCards(big, { editionId, containerPalette }),
+				big: enhanceCards(big, { editionId, containerPalette }, false),
 				standard: enhanceCards(
 					// Backfilled cards will always be treated as 'standard' cards
 					curated
 						.filter(({ card }) => card.group === '0')
 						.concat(backfill),
 					{ offset: big.length, editionId, containerPalette },
+					false,
 				),
 			};
 		}
@@ -57,17 +58,29 @@ export const groupCards = (
 			return {
 				// Snap is not supported on these container types
 				snap: [],
-				huge: enhanceCards(huge, { editionId, containerPalette }),
-				veryBig: enhanceCards(veryBig, {
-					offset: huge.length,
-					editionId,
-					containerPalette,
-				}),
-				big: enhanceCards(big, {
-					offset: huge.length + veryBig.length,
-					editionId,
-					containerPalette,
-				}),
+				huge: enhanceCards(
+					huge,
+					{ editionId, containerPalette },
+					false,
+				),
+				veryBig: enhanceCards(
+					veryBig,
+					{
+						offset: huge.length,
+						editionId,
+						containerPalette,
+					},
+					false,
+				),
+				big: enhanceCards(
+					big,
+					{
+						offset: huge.length + veryBig.length,
+						editionId,
+						containerPalette,
+					},
+					false,
+				),
 				standard: enhanceCards(
 					// Backfilled cards will always be treated as 'standard' cards
 					curated
@@ -78,6 +91,7 @@ export const groupCards = (
 						editionId,
 						containerPalette,
 					},
+					false,
 				),
 			};
 		}
@@ -88,13 +102,18 @@ export const groupCards = (
 				veryBig: [],
 				big: [],
 				// Only 'snap' and 'standard' are supported by dynamic/package
-				snap: enhanceCards(snap, { editionId, containerPalette }),
+				snap: enhanceCards(
+					snap,
+					{ editionId, containerPalette },
+					false,
+				),
 				standard: enhanceCards(
 					// Backfilled cards will always be treated as 'standard' cards
 					curated
 						.filter(({ card }) => card.group === '0')
 						.concat(backfill),
 					{ offset: snap.length, editionId, containerPalette },
+					false,
 				),
 			};
 		}

--- a/dotcom-rendering/src/model/groupCards.ts
+++ b/dotcom-rendering/src/model/groupCards.ts
@@ -39,14 +39,22 @@ export const groupCards = (
 				snap: [],
 				huge: [],
 				veryBig: [],
-				big: enhanceCards(big, { editionId, containerPalette }, false),
+				big: enhanceCards(big, {
+					cardInTagFront: false,
+					editionId,
+					containerPalette,
+				}),
 				standard: enhanceCards(
 					// Backfilled cards will always be treated as 'standard' cards
 					curated
 						.filter(({ card }) => card.group === '0')
 						.concat(backfill),
-					{ offset: big.length, editionId, containerPalette },
-					false,
+					{
+						cardInTagFront: false,
+						offset: big.length,
+						editionId,
+						containerPalette,
+					},
 				),
 			};
 		}
@@ -58,40 +66,34 @@ export const groupCards = (
 			return {
 				// Snap is not supported on these container types
 				snap: [],
-				huge: enhanceCards(
-					huge,
-					{ editionId, containerPalette },
-					false,
-				),
-				veryBig: enhanceCards(
-					veryBig,
-					{
-						offset: huge.length,
-						editionId,
-						containerPalette,
-					},
-					false,
-				),
-				big: enhanceCards(
-					big,
-					{
-						offset: huge.length + veryBig.length,
-						editionId,
-						containerPalette,
-					},
-					false,
-				),
+				huge: enhanceCards(huge, {
+					cardInTagFront: false,
+					editionId,
+					containerPalette,
+				}),
+				veryBig: enhanceCards(veryBig, {
+					cardInTagFront: false,
+					offset: huge.length,
+					editionId,
+					containerPalette,
+				}),
+				big: enhanceCards(big, {
+					cardInTagFront: false,
+					offset: huge.length + veryBig.length,
+					editionId,
+					containerPalette,
+				}),
 				standard: enhanceCards(
 					// Backfilled cards will always be treated as 'standard' cards
 					curated
 						.filter(({ card }) => card.group === '0')
 						.concat(backfill),
 					{
+						cardInTagFront: false,
 						offset: huge.length + veryBig.length + big.length,
 						editionId,
 						containerPalette,
 					},
-					false,
 				),
 			};
 		}
@@ -102,18 +104,22 @@ export const groupCards = (
 				veryBig: [],
 				big: [],
 				// Only 'snap' and 'standard' are supported by dynamic/package
-				snap: enhanceCards(
-					snap,
-					{ editionId, containerPalette },
-					false,
-				),
+				snap: enhanceCards(snap, {
+					cardInTagFront: false,
+					editionId,
+					containerPalette,
+				}),
 				standard: enhanceCards(
 					// Backfilled cards will always be treated as 'standard' cards
 					curated
 						.filter(({ card }) => card.group === '0')
 						.concat(backfill),
-					{ offset: snap.length, editionId, containerPalette },
-					false,
+					{
+						cardInTagFront: false,
+						offset: snap.length,
+						editionId,
+						containerPalette,
+					},
 				),
 			};
 		}

--- a/dotcom-rendering/src/server/index.front.web.ts
+++ b/dotcom-rendering/src/server/index.front.web.ts
@@ -47,7 +47,10 @@ const enhanceFront = (body: unknown): DCRFrontType => {
 const enhanceTagFront = (body: unknown): DCRTagFrontType => {
 	const data: FETagFrontType = validateAsTagFrontType(body);
 
-	const enhancedCards = enhanceCards(data.contents, {}, true, data.pageId);
+	const enhancedCards = enhanceCards(data.contents, {
+		cardInTagFront: true,
+		pageId: data.pageId,
+	});
 	const speed = getSpeedFromTrails(data.contents);
 
 	return {

--- a/dotcom-rendering/src/server/index.front.web.ts
+++ b/dotcom-rendering/src/server/index.front.web.ts
@@ -47,7 +47,7 @@ const enhanceFront = (body: unknown): DCRFrontType => {
 const enhanceTagFront = (body: unknown): DCRTagFrontType => {
 	const data: FETagFrontType = validateAsTagFrontType(body);
 
-	const enhancedCards = enhanceCards(data.contents, {});
+	const enhancedCards = enhanceCards(data.contents, {}, true, data.pageId);
 	const speed = getSpeedFromTrails(data.contents);
 
 	return {


### PR DESCRIPTION
Addresses one issue in: https://github.com/guardian/dotcom-rendering/issues/8050

<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Modifies the kicker logic to distinguish between pressed and tag fronts.

## Why?
To achieve parity with frontend.

## Screenshots

Fronts used for screenshots:
* pressed front: https://www.theguardian.com/uk/commentisfree
* non-series tag front: https://www.theguardian.com/business/energy-industry
* series tag front: https://www.theguardian.com/politics/series/politics-live-with-andrew-sparrow
* pressed front that looks like tag but is not: https://www.theguardian.com/culture/series/saved-for-later


|                      | Frontend | DCR Before | DCR After |
|----------------------|----------|------------|-----------|
| pressed front        | ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/ec697339-ddcd-442d-9c3a-71e41fb8dbd6) | ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/cf4df4f0-4088-4272-a0ee-f8c1d7321380) | ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/4c76706d-be2f-4e4e-924f-e4d1edc0db58) |
| non-series tag front     | ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/19a959d1-248a-4686-9221-f6174179ee80) | ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/f64fe059-3429-4f0b-ac73-2c57063d7cb8) | ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/c1b33505-12ea-4909-be06-37808d6bb095) |
| series tag front | ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/9372e2ac-e6a5-4eb1-a3e3-186ea9757509) |  ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/5e742d1a-e8c3-4251-8ce0-d2eb72b58b9d) | ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/970adfba-d15e-4f6d-a295-dcf3ee3966b1) |
| pressed front that looks like tag but is not | ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/6000771d-bc20-4f6a-abb1-a76c872eaf47) | ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/357f9d56-8307-48b0-814b-9c345bc97a58) | ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/396093b9-b40c-4342-b0ec-e2e838605520) |


## Next PR
In my next PR I will use the [`hideKickers`](https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/src/types/front.ts#L349) property in the [`CardHeadline`](https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/src/components/CardHeadline.tsx#L272) level to control whether the kickers should be hidden in pressed fronts.

This will implement the control that comes from Fronts Config:

<img width="542" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/19683595/0fbaf4c6-bebd-4537-ab5e-b313a2eee595">

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
