### PR TITLE
refactor(types): FEMediaAtom is singular

### DIFF
--- a/dotcom-rendering/src/model/enhanceCards.ts
+++ b/dotcom-rendering/src/model/enhanceCards.ts
@@ -10,7 +10,7 @@ import type {
 	DCRSlideshowImage,
 	DCRSupportingContent,
 	FEFrontCard,
-	FEMediaAtoms,
+	FEMediaAtom,
 	FESupportingContent,
 } from '../types/front';
 import type { MainMedia } from '../types/mainMedia';
@@ -185,9 +185,7 @@ const enhanceTags = (tags: FETagType[]): TagType[] => {
  * @see https://github.com/guardian/frontend/pull/26247 for inspiration
  */
 
-const getActiveMediaAtom = (
-	mediaAtom?: FEMediaAtoms,
-): MainMedia | undefined => {
+const getActiveMediaAtom = (mediaAtom?: FEMediaAtom): MainMedia | undefined => {
 	if (mediaAtom) {
 		const asset = mediaAtom.assets.find(
 			({ version }) => version === mediaAtom.activeVersion,
@@ -220,7 +218,7 @@ const getActiveMediaAtom = (
 const decideMedia = (
 	format: ArticleFormat,
 	showMainVideo?: boolean,
-	mediaAtom?: FEMediaAtoms,
+	mediaAtom?: FEMediaAtom,
 ): MainMedia | undefined => {
 	// If the showVideo toggle is enabled in the fronts tool,
 	// we should return the active mediaAtom regardless of the design

--- a/dotcom-rendering/src/model/front-schema.json
+++ b/dotcom-rendering/src/model/front-schema.json
@@ -755,7 +755,7 @@
                                                                 "mediaAtoms": {
                                                                     "type": "array",
                                                                     "items": {
-                                                                        "$ref": "#/definitions/FEMediaAtoms"
+                                                                        "$ref": "#/definitions/FEMediaAtom"
                                                                     }
                                                                 }
                                                             },
@@ -1477,7 +1477,7 @@
                                                                 "mediaAtoms": {
                                                                     "type": "array",
                                                                     "items": {
-                                                                        "$ref": "#/definitions/FEMediaAtoms"
+                                                                        "$ref": "#/definitions/FEMediaAtom"
                                                                     }
                                                                 }
                                                             },
@@ -2199,7 +2199,7 @@
                                                                 "mediaAtoms": {
                                                                     "type": "array",
                                                                     "items": {
-                                                                        "$ref": "#/definitions/FEMediaAtoms"
+                                                                        "$ref": "#/definitions/FEMediaAtom"
                                                                     }
                                                                 }
                                                             },
@@ -2928,7 +2928,7 @@
             ],
             "type": "string"
         },
-        "FEMediaAtoms": {
+        "FEMediaAtom": {
             "type": "object",
             "properties": {
                 "id": {

--- a/dotcom-rendering/src/model/tag-front-schema.json
+++ b/dotcom-rendering/src/model/tag-front-schema.json
@@ -190,7 +190,7 @@
                                             "mediaAtoms": {
                                                 "type": "array",
                                                 "items": {
-                                                    "$ref": "#/definitions/FEMediaAtoms"
+                                                    "$ref": "#/definitions/FEMediaAtom"
                                                 }
                                             }
                                         },
@@ -1243,7 +1243,7 @@
             ],
             "type": "string"
         },
-        "FEMediaAtoms": {
+        "FEMediaAtom": {
             "type": "object",
             "properties": {
                 "id": {

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -147,7 +147,7 @@ interface MediaAsset {
 }
 
 /** @see https://github.com/guardian/frontend/blob/0bf69f55a/common/app/model/content/Atom.scala#L158-L169 */
-export interface FEMediaAtoms {
+export interface FEMediaAtom {
 	id: string;
 	// defaultHtml: string; // currently unused
 	assets: MediaAsset[];
@@ -206,7 +206,7 @@ export type FEFrontCard = {
 			};
 			elements: {
 				mainVideo?: unknown;
-				mediaAtoms: FEMediaAtoms[];
+				mediaAtoms: FEMediaAtom[];
 			};
 			tags: { tags: FETagType[] };
 		};


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Rename `FEMediaAtom` to the singular, as a plural generally indicates an array.

## Why?

More consistency!

Discovered in #8075 

## Screenshots

N/A