### PR TITLE
Fix some Ophan component IDs

### DIFF
--- a/dotcom-rendering/src/components/Carousel.importable.tsx
+++ b/dotcom-rendering/src/components/Carousel.importable.tsx
@@ -363,13 +363,9 @@ const titleStyle = (
 const getDataLinkNameCarouselButton = (
 	direction: string,
 	arrowName: string,
-	collectionType?: string,
+	isVideoContainer: boolean,
 ): string => {
-	return `${
-		collectionType && collectionType === 'fixed/video'
-			? 'video-container'
-			: arrowName
-	}-${direction}`;
+	return `${isVideoContainer ? 'video-container' : arrowName}-${direction}`;
 };
 
 const Title = ({
@@ -600,6 +596,9 @@ export const Carousel = ({
 
 	const isCuratedContent = onwardsSource === 'curated-content';
 
+	const isVideoContainer =
+		'collectionType' in props && props.collectionType === 'fixed/video';
+
 	const notPresentation = (el: HTMLElement): boolean =>
 		el.getAttribute('role') !== 'presentation';
 
@@ -701,12 +700,7 @@ export const Carousel = ({
 		<div
 			css={wrapperStyle(trails.length)}
 			data-link-name={formatAttrString(heading)}
-			data-component={
-				'collectionType' in props &&
-				props.collectionType === 'fixed/video'
-					? 'video-playlist'
-					: undefined
-			}
+			data-component={isVideoContainer ? 'video-playlist' : undefined}
 		>
 			<FetchCommentCounts />
 			<LeftColumn
@@ -749,9 +743,9 @@ export const Carousel = ({
 						),
 					]}
 					data-link-name={getDataLinkNameCarouselButton(
-						heading,
 						'prev',
 						arrowName,
+						isVideoContainer,
 					)}
 				>
 					<SvgChevronLeftSingle />
@@ -778,9 +772,9 @@ export const Carousel = ({
 						),
 					]}
 					data-link-name={getDataLinkNameCarouselButton(
-						heading,
 						'next',
 						arrowName,
+						isVideoContainer,
 					)}
 				>
 					<SvgChevronRightSingle />
@@ -824,9 +818,9 @@ export const Carousel = ({
 									),
 								]}
 								data-link-name={getDataLinkNameCarouselButton(
-									heading,
 									'prev',
 									arrowName,
+									isVideoContainer,
 								)}
 							>
 								<SvgChevronLeftSingle />
@@ -850,9 +844,9 @@ export const Carousel = ({
 									),
 								]}
 								data-link-name={getDataLinkNameCarouselButton(
-									heading,
 									'next',
 									arrowName,
+									isVideoContainer,
 								)}
 							>
 								<SvgChevronRightSingle />

--- a/dotcom-rendering/src/components/MostViewedFooter.importable.tsx
+++ b/dotcom-rendering/src/components/MostViewedFooter.importable.tsx
@@ -59,6 +59,7 @@ export const MostViewedFooter = ({
 			data-cy="mostviewed-footer"
 			data-cy-ab-user-in-variant={abTestCypressDataAttr}
 			data-cy-ab-runnable-test={variantFromRunnable}
+			data-link-name="most popular"
 		>
 			<MostViewedFooterGrid
 				data={tabs}

--- a/dotcom-rendering/src/lib/getDataLinkName.ts
+++ b/dotcom-rendering/src/lib/getDataLinkName.ts
@@ -9,6 +9,7 @@ const getLinkType = (
 	cardStyle?: FEFrontCardStyle,
 ): RichLinkCardType => {
 	if (cardStyle === 'ExternalLink') return 'external';
+	if (cardStyle === 'Feature') return 'feature';
 
 	switch (theme) {
 		case ArticleSpecial.SpecialReport:


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Fixes `data-link-name` for:
* Adds `most-popular` 
* Cards with `CardStyle` `Feature` (when the article has /tone/feature: https://github.com/guardian/content-api-scala-client/blob/d923dc5/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala#L81). This can differ from the format.
* The video container's next and prev buttons. I broke them here: https://github.com/guardian/dotcom-rendering/pull/8061

## Why?
For parity with frontend


<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
