### PR TITLE
Apply width: 100% to thrashers first element

### DIFF
--- a/dotcom-rendering/src/components/Snap.tsx
+++ b/dotcom-rendering/src/components/Snap.tsx
@@ -5,6 +5,11 @@ const snapStyles = css`
 	overflow: hidden;
 	position: relative;
 	display: flex;
+
+	// Some thrashers don't have "width: 100%" applied to their first element which causes them to not correctly take up their space
+	> * {
+		width: 100%;
+	}
 `;
 
 type Props = {

--- a/dotcom-rendering/src/components/Snap.tsx
+++ b/dotcom-rendering/src/components/Snap.tsx
@@ -1,12 +1,12 @@
 import { css } from '@emotion/react';
 import type { DCRSnapType } from '../types/front';
 
+// Some thrashers don't have "width: 100%" applied to their first element which causes them to not correctly take up their space
 const snapStyles = css`
 	overflow: hidden;
 	position: relative;
 	display: flex;
 
-	// Some thrashers don't have "width: 100%" applied to their first element which causes them to not correctly take up their space
 	> * {
 		width: 100%;
 	}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Apply `width: 100%;` to the immediate children of a thrasher.

## Why?

Some thrashers are having problems being sized correctly in a `display: flex;` wrapper, frontend used to wrap thrashers in a `display: block` wrapper instead. We didn't really pick `display: flex` for any particular reason in DCR, but it was done early on in the migration and we didn't realize this would affect some thrashers.

I don't think its a good idea to revert to `display: block` now due to the fact that we've checked all thrashers and fixed most of them with `display: flex`. Adding `width: 100%` seems to fix the ones that are broken by flex.

Fixes #8069

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/21217225/c0798b62-f877-4017-b4fb-a4e411992bb4
[after]: https://github.com/guardian/dotcom-rendering/assets/21217225/26e05be2-9a6d-4feb-918b-ae551f126cc2

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
