### PR TITLE
add vertical video to fronts container type

### DIFF
--- a/dotcom-rendering/src/model/front-schema.json
+++ b/dotcom-rendering/src/model/front-schema.json
@@ -1,3403 +1,3403 @@
 {
-	"type": "object",
-	"properties": {
-		"pressedPage": {
-			"$ref": "#/definitions/FEPressedPageType"
-		},
-		"nav": {
-			"$ref": "#/definitions/FENavType"
-		},
-		"editionId": {
-			"$ref": "#/definitions/EditionId"
-		},
-		"editionLongForm": {
-			"type": "string"
-		},
-		"guardianBaseURL": {
-			"type": "string"
-		},
-		"pageId": {
-			"type": "string"
-		},
-		"webTitle": {
-			"type": "string"
-		},
-		"webURL": {
-			"type": "string"
-		},
-		"config": {
-			"type": "object",
-			"properties": {
-				"avatarApiUrl": {
-					"type": "string"
-				},
-				"externalEmbedHost": {
-					"type": "string"
-				},
-				"ajaxUrl": {
-					"type": "string"
-				},
-				"keywords": {
-					"type": "string"
-				},
-				"revisionNumber": {
-					"type": "string"
-				},
-				"isProd": {
-					"type": "boolean"
-				},
-				"switches": {
-					"$ref": "#/definitions/Switches"
-				},
-				"section": {
-					"type": "string"
-				},
-				"keywordIds": {
-					"type": "string"
-				},
-				"locationapiurl": {
-					"type": "string"
-				},
-				"sharedAdTargeting": {
-					"type": "object",
-					"additionalProperties": {}
-				},
-				"buildNumber": {
-					"type": "string"
-				},
-				"abTests": {
-					"description": "Narrowest representation of the server-side tests\nobject shape, which is [defined in `frontend`](https://github.com/guardian/frontend/blob/23743723030a041e4f4f59fa265ee2be0bb51825/common/app/experiments/ExperimentsDefinition.scala#L24-L26).\n\n**Note:** This type is not support by JSON-schema, it evaluates as `object`",
-					"type": "object"
-				},
-				"pbIndexSites": {
-					"type": "array",
-					"items": {
-						"type": "object",
-						"additionalProperties": {}
-					}
-				},
-				"ampIframeUrl": {
-					"type": "string"
-				},
-				"beaconUrl": {
-					"type": "string"
-				},
-				"userAttributesApiUrl": {
-					"type": "string"
-				},
-				"host": {
-					"type": "string"
-				},
-				"brazeApiKey": {
-					"type": "string"
-				},
-				"calloutsUrl": {
-					"type": "string"
-				},
-				"requiresMembershipAccess": {
-					"type": "boolean"
-				},
-				"onwardWebSocket": {
-					"type": "string"
-				},
-				"a9PublisherId": {
-					"type": "string"
-				},
-				"contentType": {
-					"type": "string"
-				},
-				"facebookIaAdUnitRoot": {
-					"type": "string"
-				},
-				"ophanEmbedJsUrl": {
-					"type": "string"
-				},
-				"idUrl": {
-					"type": "string"
-				},
-				"dcrSentryDsn": {
-					"type": "string"
-				},
-				"isFront": {
-					"type": "boolean",
-					"enum": [
-						true
-					]
-				},
-				"idWebAppUrl": {
-					"type": "string"
-				},
-				"discussionApiUrl": {
-					"type": "string"
-				},
-				"sentryPublicApiKey": {
-					"type": "string"
-				},
-				"omnitureAccount": {
-					"type": "string"
-				},
-				"dfpAccountId": {
-					"type": "string"
-				},
-				"pageId": {
-					"type": "string"
-				},
-				"forecastsapiurl": {
-					"type": "string"
-				},
-				"assetsPath": {
-					"type": "string"
-				},
-				"pillar": {
-					"type": "string"
-				},
-				"commercialBundleUrl": {
-					"type": "string"
-				},
-				"discussionApiClientHeader": {
-					"type": "string"
-				},
-				"membershipUrl": {
-					"type": "string"
-				},
-				"dfpHost": {
-					"type": "string"
-				},
-				"cardStyle": {
-					"type": "string"
-				},
-				"googletagUrl": {
-					"type": "string"
-				},
-				"sentryHost": {
-					"type": "string"
-				},
-				"shouldHideAdverts": {
-					"type": "boolean"
-				},
-				"mmaUrl": {
-					"type": "string"
-				},
-				"membershipAccess": {
-					"type": "string"
-				},
-				"isPreview": {
-					"type": "boolean"
-				},
-				"googletagJsUrl": {
-					"type": "string"
-				},
-				"supportUrl": {
-					"type": "string"
-				},
-				"edition": {
-					"type": "string"
-				},
-				"discussionFrontendUrl": {
-					"type": "string"
-				},
-				"ipsosTag": {
-					"type": "string"
-				},
-				"ophanJsUrl": {
-					"type": "string"
-				},
-				"isPaidContent": {
-					"type": "boolean"
-				},
-				"mobileAppsAdUnitRoot": {
-					"type": "string"
-				},
-				"plistaPublicApiKey": {
-					"type": "string"
-				},
-				"frontendAssetsFullURL": {
-					"type": "string"
-				},
-				"googleSearchId": {
-					"type": "string"
-				},
-				"allowUserGeneratedContent": {
-					"type": "boolean"
-				},
-				"dfpAdUnitRoot": {
-					"type": "string"
-				},
-				"idApiUrl": {
-					"type": "string"
-				},
-				"omnitureAmpAccount": {
-					"type": "string"
-				},
-				"adUnit": {
-					"type": "string"
-				},
-				"hasPageSkin": {
-					"type": "boolean"
-				},
-				"webTitle": {
-					"type": "string"
-				},
-				"stripePublicToken": {
-					"type": "string"
-				},
-				"googleRecaptchaSiteKey": {
-					"type": "string"
-				},
-				"discussionD2Uid": {
-					"type": "string"
-				},
-				"weatherapiurl": {
-					"type": "string"
-				},
-				"googleSearchUrl": {
-					"type": "string"
-				},
-				"optimizeEpicUrl": {
-					"type": "string"
-				},
-				"stage": {
-					"$ref": "#/definitions/StageType"
-				},
-				"idOAuthUrl": {
-					"type": "string"
-				},
-				"isSensitive": {
-					"type": "boolean"
-				},
-				"isDev": {
-					"type": "boolean"
-				},
-				"thirdPartyAppsAccount": {
-					"type": "string"
-				},
-				"avatarImagesUrl": {
-					"type": "string"
-				},
-				"fbAppId": {
-					"type": "string"
-				}
-			},
-			"required": [
-				"a9PublisherId",
-				"abTests",
-				"adUnit",
-				"ajaxUrl",
-				"allowUserGeneratedContent",
-				"ampIframeUrl",
-				"assetsPath",
-				"avatarApiUrl",
-				"avatarImagesUrl",
-				"beaconUrl",
-				"buildNumber",
-				"calloutsUrl",
-				"commercialBundleUrl",
-				"contentType",
-				"dcrSentryDsn",
-				"dfpAccountId",
-				"dfpAdUnitRoot",
-				"dfpHost",
-				"discussionApiClientHeader",
-				"discussionApiUrl",
-				"discussionD2Uid",
-				"discussionFrontendUrl",
-				"edition",
-				"externalEmbedHost",
-				"facebookIaAdUnitRoot",
-				"fbAppId",
-				"forecastsapiurl",
-				"frontendAssetsFullURL",
-				"googleRecaptchaSiteKey",
-				"googleSearchId",
-				"googleSearchUrl",
-				"googletagJsUrl",
-				"googletagUrl",
-				"hasPageSkin",
-				"host",
-				"idApiUrl",
-				"idOAuthUrl",
-				"idUrl",
-				"idWebAppUrl",
-				"ipsosTag",
-				"isDev",
-				"isFront",
-				"isPreview",
-				"isProd",
-				"isSensitive",
-				"keywordIds",
-				"keywords",
-				"locationapiurl",
-				"membershipAccess",
-				"membershipUrl",
-				"mmaUrl",
-				"mobileAppsAdUnitRoot",
-				"omnitureAccount",
-				"omnitureAmpAccount",
-				"onwardWebSocket",
-				"ophanEmbedJsUrl",
-				"ophanJsUrl",
-				"optimizeEpicUrl",
-				"pageId",
-				"pbIndexSites",
-				"pillar",
-				"plistaPublicApiKey",
-				"requiresMembershipAccess",
-				"revisionNumber",
-				"section",
-				"sentryHost",
-				"sentryPublicApiKey",
-				"sharedAdTargeting",
-				"shouldHideAdverts",
-				"stage",
-				"stripePublicToken",
-				"supportUrl",
-				"switches",
-				"userAttributesApiUrl",
-				"weatherapiurl",
-				"webTitle"
-			]
-		},
-		"commercialProperties": {
-			"$ref": "#/definitions/Record<string,unknown>"
-		},
-		"pageFooter": {
-			"$ref": "#/definitions/FooterType"
-		},
-		"isAdFreeUser": {
-			"type": "boolean"
-		},
-		"isNetworkFront": {
-			"type": "boolean"
-		},
-		"mostViewed": {
-			"type": "array",
-			"items": {
-				"$ref": "#/definitions/FETrailType"
-			}
-		},
-		"mostCommented": {
-			"$ref": "#/definitions/FETrailType"
-		},
-		"mostShared": {
-			"$ref": "#/definitions/FETrailType"
-		},
-		"deeplyRead": {
-			"type": "array",
-			"items": {
-				"$ref": "#/definitions/FETrailType"
-			}
-		}
-	},
-	"required": [
-		"commercialProperties",
-		"config",
-		"editionId",
-		"editionLongForm",
-		"guardianBaseURL",
-		"isAdFreeUser",
-		"isNetworkFront",
-		"mostViewed",
-		"nav",
-		"pageFooter",
-		"pageId",
-		"pressedPage",
-		"webTitle",
-		"webURL"
-	],
-	"definitions": {
-		"FEPressedPageType": {
-			"type": "object",
-			"properties": {
-				"id": {
-					"type": "string"
-				},
-				"seoData": {
-					"type": "object",
-					"properties": {
-						"id": {
-							"type": "string"
-						},
-						"navSection": {
-							"type": "string"
-						},
-						"webTitle": {
-							"type": "string"
-						},
-						"title": {
-							"type": "string"
-						},
-						"description": {
-							"type": "string"
-						}
-					},
-					"required": [
-						"description",
-						"id",
-						"navSection",
-						"webTitle"
-					]
-				},
-				"frontProperties": {
-					"type": "object",
-					"properties": {
-						"isImageDisplayed": {
-							"type": "boolean"
-						},
-						"commercial": {
-							"$ref": "#/definitions/Record<string,unknown>"
-						},
-						"isPaidContent": {
-							"type": "boolean"
-						},
-						"onPageDescription": {
-							"type": "string"
-						}
-					},
-					"required": [
-						"commercial",
-						"isImageDisplayed"
-					]
-				},
-				"collections": {
-					"type": "array",
-					"items": {
-						"type": "object",
-						"properties": {
-							"id": {
-								"type": "string"
-							},
-							"displayName": {
-								"type": "string"
-							},
-							"description": {
-								"type": "string"
-							},
-							"curated": {
-								"type": "array",
-								"items": {
-									"type": "object",
-									"properties": {
-										"properties": {
-											"type": "object",
-											"properties": {
-												"isBreaking": {
-													"type": "boolean"
-												},
-												"showMainVideo": {
-													"type": "boolean"
-												},
-												"showKickerTag": {
-													"type": "boolean"
-												},
-												"showByline": {
-													"type": "boolean"
-												},
-												"imageSlideshowReplace": {
-													"type": "boolean"
-												},
-												"maybeContent": {
-													"type": "object",
-													"properties": {
-														"trail": {
-															"type": "object",
-															"properties": {
-																"trailPicture": {
-																	"type": "object",
-																	"properties": {
-																		"allImages": {
-																			"type": "array",
-																			"items": {
-																				"type": "object",
-																				"properties": {
-																					"index": {
-																						"type": "number"
-																					},
-																					"fields": {
-																						"type": "object",
-																						"properties": {
-																							"displayCredit": {
-																								"type": "string"
-																							},
-																							"source": {
-																								"type": "string"
-																							},
-																							"photographer": {
-																								"type": "string"
-																							},
-																							"isMaster": {
-																								"type": "string"
-																							},
-																							"altText": {
-																								"type": "string"
-																							},
-																							"height": {
-																								"type": "string"
-																							},
-																							"credit": {
-																								"type": "string"
-																							},
-																							"mediaId": {
-																								"type": "string"
-																							},
-																							"width": {
-																								"type": "string"
-																							}
-																						},
-																						"required": [
-																							"height",
-																							"width"
-																						]
-																					},
-																					"mediaType": {
-																						"type": "string"
-																					},
-																					"url": {
-																						"type": "string"
-																					}
-																				},
-																				"required": [
-																					"fields",
-																					"index",
-																					"mediaType",
-																					"url"
-																				]
-																			}
-																		}
-																	},
-																	"required": [
-																		"allImages"
-																	]
-																},
-																"byline": {
-																	"type": "string"
-																},
-																"thumbnailPath": {
-																	"type": "string"
-																},
-																"webPublicationDate": {
-																	"type": "number"
-																}
-															},
-															"required": [
-																"webPublicationDate"
-															]
-														},
-														"metadata": {
-															"type": "object",
-															"properties": {
-																"id": {
-																	"type": "string"
-																},
-																"webTitle": {
-																	"type": "string"
-																},
-																"webUrl": {
-																	"type": "string"
-																},
-																"type": {
-																	"type": "string"
-																},
-																"sectionId": {
-																	"type": "object",
-																	"properties": {
-																		"value": {
-																			"type": "string"
-																		}
-																	},
-																	"required": [
-																		"value"
-																	]
-																},
-																"format": {
-																	"type": "object",
-																	"properties": {
-																		"design": {
-																			"$ref": "#/definitions/FEDesign"
-																		},
-																		"theme": {
-																			"$ref": "#/definitions/FETheme"
-																		},
-																		"display": {
-																			"$ref": "#/definitions/FEDisplay"
-																		}
-																	},
-																	"required": [
-																		"design",
-																		"display",
-																		"theme"
-																	]
-																}
-															},
-															"required": [
-																"format",
-																"id",
-																"type",
-																"webTitle",
-																"webUrl"
-															]
-														},
-														"fields": {
-															"type": "object",
-															"properties": {
-																"main": {
-																	"type": "string"
-																},
-																"body": {
-																	"type": "string"
-																},
-																"standfirst": {
-																	"type": "string"
-																}
-															},
-															"required": [
-																"body",
-																"main"
-															]
-														},
-														"elements": {
-															"type": "object",
-															"properties": {
-																"mainVideo": {},
-																"mediaAtoms": {
-																	"type": "array",
-																	"items": {
-																		"$ref": "#/definitions/FEMediaAtoms"
-																	}
-																}
-															},
-															"required": [
-																"mediaAtoms"
-															]
-														},
-														"tags": {
-															"type": "object",
-															"properties": {
-																"tags": {
-																	"type": "array",
-																	"items": {
-																		"description": "This type comes from `frontend`, hence the FE prefix.",
-																		"type": "object",
-																		"properties": {
-																			"properties": {
-																				"type": "object",
-																				"properties": {
-																					"id": {
-																						"type": "string"
-																					},
-																					"tagType": {
-																						"type": "string"
-																					},
-																					"webTitle": {
-																						"type": "string"
-																					},
-																					"bio": {
-																						"type": "string"
-																					},
-																					"bylineImageUrl": {
-																						"type": "string"
-																					},
-																					"bylineLargeImageUrl": {
-																						"type": "string"
-																					},
-																					"contributorLargeImagePath": {
-																						"type": "string"
-																					},
-																					"paidContentType": {
-																						"type": "string"
-																					},
-																					"sectionId": {
-																						"type": "string"
-																					},
-																					"sectionName": {
-																						"type": "string"
-																					},
-																					"twitterHandle": {
-																						"type": "string"
-																					},
-																					"url": {
-																						"type": "string"
-																					},
-																					"webUrl": {
-																						"type": "string"
-																					}
-																				},
-																				"required": [
-																					"id",
-																					"tagType",
-																					"webTitle"
-																				]
-																			},
-																			"pagination": {
-																				"type": "object",
-																				"properties": {
-																					"currentPage": {
-																						"type": "number"
-																					},
-																					"lastPage": {
-																						"type": "number"
-																					},
-																					"totalContent": {
-																						"type": "number"
-																					}
-																				},
-																				"required": [
-																					"currentPage",
-																					"lastPage",
-																					"totalContent"
-																				]
-																			}
-																		},
-																		"required": [
-																			"properties"
-																		]
-																	}
-																}
-															},
-															"required": [
-																"tags"
-															]
-														}
-													},
-													"required": [
-														"elements",
-														"fields",
-														"metadata",
-														"tags",
-														"trail"
-													]
-												},
-												"maybeContentId": {
-													"type": "string"
-												},
-												"isLiveBlog": {
-													"type": "boolean"
-												},
-												"isCrossword": {
-													"type": "boolean"
-												},
-												"byline": {
-													"type": "string"
-												},
-												"image": {
-													"type": "object",
-													"properties": {
-														"type": {
-															"type": "string"
-														},
-														"item": {
-															"type": "object",
-															"properties": {
-																"imageSrc": {
-																	"type": "string"
-																},
-																"assets": {
-																	"type": "array",
-																	"items": {
-																		"type": "object",
-																		"properties": {
-																			"imageSrc": {
-																				"type": "string"
-																			},
-																			"imageCaption": {
-																				"type": "string"
-																			}
-																		},
-																		"required": [
-																			"imageSrc"
-																		]
-																	}
-																}
-															}
-														}
-													},
-													"required": [
-														"item",
-														"type"
-													]
-												},
-												"webTitle": {
-													"type": "string"
-												},
-												"linkText": {
-													"type": "string"
-												},
-												"webUrl": {
-													"type": "string"
-												},
-												"editionBrandings": {
-													"type": "array",
-													"items": {
-														"type": "object",
-														"properties": {
-															"edition": {
-																"type": "object",
-																"properties": {
-																	"id": {
-																		"$ref": "#/definitions/EditionId"
-																	}
-																},
-																"required": [
-																	"id"
-																]
-															},
-															"branding": {
-																"$ref": "#/definitions/Branding"
-															}
-														},
-														"required": [
-															"edition"
-														]
-													}
-												},
-												"href": {
-													"type": "string"
-												},
-												"embedUri": {
-													"type": "string"
-												}
-											},
-											"required": [
-												"editionBrandings",
-												"imageSlideshowReplace",
-												"isBreaking",
-												"isCrossword",
-												"isLiveBlog",
-												"showByline",
-												"showKickerTag",
-												"showMainVideo",
-												"webTitle"
-											]
-										},
-										"header": {
-											"type": "object",
-											"properties": {
-												"isVideo": {
-													"type": "boolean"
-												},
-												"isComment": {
-													"type": "boolean"
-												},
-												"isGallery": {
-													"type": "boolean"
-												},
-												"isAudio": {
-													"type": "boolean"
-												},
-												"kicker": {
-													"type": "object",
-													"properties": {
-														"type": {
-															"type": "string"
-														},
-														"item": {
-															"type": "object",
-															"properties": {
-																"properties": {
-																	"type": "object",
-																	"properties": {
-																		"kickerText": {
-																			"type": "string"
-																		}
-																	},
-																	"required": [
-																		"kickerText"
-																	]
-																}
-															},
-															"required": [
-																"properties"
-															]
-														}
-													},
-													"required": [
-														"type"
-													]
-												},
-												"seriesOrBlogKicker": {
-													"type": "object",
-													"properties": {
-														"properties": {
-															"type": "object",
-															"properties": {
-																"kickerText": {
-																	"type": "string"
-																}
-															},
-															"required": [
-																"kickerText"
-															]
-														},
-														"name": {
-															"type": "string"
-														},
-														"url": {
-															"type": "string"
-														},
-														"id": {
-															"type": "string"
-														}
-													},
-													"required": [
-														"id",
-														"name",
-														"properties",
-														"url"
-													]
-												},
-												"headline": {
-													"type": "string"
-												},
-												"url": {
-													"type": "string"
-												},
-												"hasMainVideoElement": {
-													"type": "boolean"
-												}
-											},
-											"required": [
-												"hasMainVideoElement",
-												"headline",
-												"isAudio",
-												"isComment",
-												"isGallery",
-												"isVideo",
-												"url"
-											]
-										},
-										"card": {
-											"type": "object",
-											"properties": {
-												"id": {
-													"type": "string"
-												},
-												"cardStyle": {
-													"type": "object",
-													"properties": {
-														"type": {
-															"$ref": "#/definitions/FEFrontCardStyle"
-														}
-													},
-													"required": [
-														"type"
-													]
-												},
-												"webPublicationDateOption": {
-													"type": "number"
-												},
-												"lastModifiedOption": {
-													"type": "number"
-												},
-												"trailText": {
-													"type": "string"
-												},
-												"starRating": {
-													"type": "number"
-												},
-												"shortUrlPath": {
-													"type": "string"
-												},
-												"shortUrl": {
-													"type": "string"
-												},
-												"group": {
-													"type": "string"
-												},
-												"isLive": {
-													"type": "boolean"
-												}
-											},
-											"required": [
-												"cardStyle",
-												"group",
-												"id",
-												"isLive",
-												"shortUrl"
-											]
-										},
-										"discussion": {
-											"type": "object",
-											"properties": {
-												"isCommentable": {
-													"type": "boolean"
-												},
-												"isClosedForComments": {
-													"type": "boolean"
-												},
-												"discussionId": {
-													"type": "string"
-												}
-											},
-											"required": [
-												"isClosedForComments",
-												"isCommentable"
-											]
-										},
-										"display": {
-											"type": "object",
-											"properties": {
-												"isBoosted": {
-													"type": "boolean"
-												},
-												"showBoostedHeadline": {
-													"type": "boolean"
-												},
-												"showQuotedHeadline": {
-													"type": "boolean"
-												},
-												"imageHide": {
-													"type": "boolean"
-												},
-												"showLivePlayable": {
-													"type": "boolean"
-												}
-											},
-											"required": [
-												"imageHide",
-												"isBoosted",
-												"showBoostedHeadline",
-												"showLivePlayable",
-												"showQuotedHeadline"
-											]
-										},
-										"format": {
-											"type": "object",
-											"properties": {
-												"design": {
-													"$ref": "#/definitions/FEDesign"
-												},
-												"theme": {
-													"$ref": "#/definitions/FETheme"
-												},
-												"display": {
-													"$ref": "#/definitions/FEDisplay"
-												}
-											},
-											"required": [
-												"design",
-												"display",
-												"theme"
-											]
-										},
-										"enriched": {
-											"type": "object",
-											"properties": {
-												"embedHtml": {
-													"type": "string"
-												},
-												"embedCss": {
-													"type": "string"
-												},
-												"embedJs": {
-													"type": "string"
-												}
-											}
-										},
-										"supportingContent": {
-											"type": "array",
-											"items": {
-												"type": "object",
-												"properties": {
-													"properties": {
-														"type": "object",
-														"properties": {
-															"href": {
-																"type": "string"
-															}
-														}
-													},
-													"header": {
-														"type": "object",
-														"properties": {
-															"kicker": {
-																"type": "object",
-																"properties": {
-																	"item": {
-																		"type": "object",
-																		"properties": {
-																			"properties": {
-																				"type": "object",
-																				"properties": {
-																					"kickerText": {
-																						"type": "string"
-																					}
-																				},
-																				"required": [
-																					"kickerText"
-																				]
-																			}
-																		},
-																		"required": [
-																			"properties"
-																		]
-																	}
-																}
-															},
-															"headline": {
-																"type": "string"
-															},
-															"url": {
-																"type": "string"
-															}
-														},
-														"required": [
-															"headline",
-															"url"
-														]
-													},
-													"format": {
-														"type": "object",
-														"properties": {
-															"design": {
-																"$ref": "#/definitions/FEDesign"
-															},
-															"theme": {
-																"$ref": "#/definitions/FETheme"
-															},
-															"display": {
-																"$ref": "#/definitions/FEDisplay"
-															}
-														},
-														"required": [
-															"design",
-															"display",
-															"theme"
-														]
-													}
-												},
-												"required": [
-													"properties"
-												]
-											}
-										},
-										"cardStyle": {
-											"type": "object",
-											"properties": {
-												"type": {
-													"$ref": "#/definitions/FEFrontCardStyle"
-												}
-											},
-											"required": [
-												"type"
-											]
-										},
-										"type": {
-											"type": "string"
-										}
-									},
-									"required": [
-										"card",
-										"discussion",
-										"display",
-										"header",
-										"properties",
-										"type"
-									]
-								}
-							},
-							"backfill": {
-								"type": "array",
-								"items": {
-									"type": "object",
-									"properties": {
-										"properties": {
-											"type": "object",
-											"properties": {
-												"isBreaking": {
-													"type": "boolean"
-												},
-												"showMainVideo": {
-													"type": "boolean"
-												},
-												"showKickerTag": {
-													"type": "boolean"
-												},
-												"showByline": {
-													"type": "boolean"
-												},
-												"imageSlideshowReplace": {
-													"type": "boolean"
-												},
-												"maybeContent": {
-													"type": "object",
-													"properties": {
-														"trail": {
-															"type": "object",
-															"properties": {
-																"trailPicture": {
-																	"type": "object",
-																	"properties": {
-																		"allImages": {
-																			"type": "array",
-																			"items": {
-																				"type": "object",
-																				"properties": {
-																					"index": {
-																						"type": "number"
-																					},
-																					"fields": {
-																						"type": "object",
-																						"properties": {
-																							"displayCredit": {
-																								"type": "string"
-																							},
-																							"source": {
-																								"type": "string"
-																							},
-																							"photographer": {
-																								"type": "string"
-																							},
-																							"isMaster": {
-																								"type": "string"
-																							},
-																							"altText": {
-																								"type": "string"
-																							},
-																							"height": {
-																								"type": "string"
-																							},
-																							"credit": {
-																								"type": "string"
-																							},
-																							"mediaId": {
-																								"type": "string"
-																							},
-																							"width": {
-																								"type": "string"
-																							}
-																						},
-																						"required": [
-																							"height",
-																							"width"
-																						]
-																					},
-																					"mediaType": {
-																						"type": "string"
-																					},
-																					"url": {
-																						"type": "string"
-																					}
-																				},
-																				"required": [
-																					"fields",
-																					"index",
-																					"mediaType",
-																					"url"
-																				]
-																			}
-																		}
-																	},
-																	"required": [
-																		"allImages"
-																	]
-																},
-																"byline": {
-																	"type": "string"
-																},
-																"thumbnailPath": {
-																	"type": "string"
-																},
-																"webPublicationDate": {
-																	"type": "number"
-																}
-															},
-															"required": [
-																"webPublicationDate"
-															]
-														},
-														"metadata": {
-															"type": "object",
-															"properties": {
-																"id": {
-																	"type": "string"
-																},
-																"webTitle": {
-																	"type": "string"
-																},
-																"webUrl": {
-																	"type": "string"
-																},
-																"type": {
-																	"type": "string"
-																},
-																"sectionId": {
-																	"type": "object",
-																	"properties": {
-																		"value": {
-																			"type": "string"
-																		}
-																	},
-																	"required": [
-																		"value"
-																	]
-																},
-																"format": {
-																	"type": "object",
-																	"properties": {
-																		"design": {
-																			"$ref": "#/definitions/FEDesign"
-																		},
-																		"theme": {
-																			"$ref": "#/definitions/FETheme"
-																		},
-																		"display": {
-																			"$ref": "#/definitions/FEDisplay"
-																		}
-																	},
-																	"required": [
-																		"design",
-																		"display",
-																		"theme"
-																	]
-																}
-															},
-															"required": [
-																"format",
-																"id",
-																"type",
-																"webTitle",
-																"webUrl"
-															]
-														},
-														"fields": {
-															"type": "object",
-															"properties": {
-																"main": {
-																	"type": "string"
-																},
-																"body": {
-																	"type": "string"
-																},
-																"standfirst": {
-																	"type": "string"
-																}
-															},
-															"required": [
-																"body",
-																"main"
-															]
-														},
-														"elements": {
-															"type": "object",
-															"properties": {
-																"mainVideo": {},
-																"mediaAtoms": {
-																	"type": "array",
-																	"items": {
-																		"$ref": "#/definitions/FEMediaAtoms"
-																	}
-																}
-															},
-															"required": [
-																"mediaAtoms"
-															]
-														},
-														"tags": {
-															"type": "object",
-															"properties": {
-																"tags": {
-																	"type": "array",
-																	"items": {
-																		"description": "This type comes from `frontend`, hence the FE prefix.",
-																		"type": "object",
-																		"properties": {
-																			"properties": {
-																				"type": "object",
-																				"properties": {
-																					"id": {
-																						"type": "string"
-																					},
-																					"tagType": {
-																						"type": "string"
-																					},
-																					"webTitle": {
-																						"type": "string"
-																					},
-																					"bio": {
-																						"type": "string"
-																					},
-																					"bylineImageUrl": {
-																						"type": "string"
-																					},
-																					"bylineLargeImageUrl": {
-																						"type": "string"
-																					},
-																					"contributorLargeImagePath": {
-																						"type": "string"
-																					},
-																					"paidContentType": {
-																						"type": "string"
-																					},
-																					"sectionId": {
-																						"type": "string"
-																					},
-																					"sectionName": {
-																						"type": "string"
-																					},
-																					"twitterHandle": {
-																						"type": "string"
-																					},
-																					"url": {
-																						"type": "string"
-																					},
-																					"webUrl": {
-																						"type": "string"
-																					}
-																				},
-																				"required": [
-																					"id",
-																					"tagType",
-																					"webTitle"
-																				]
-																			},
-																			"pagination": {
-																				"type": "object",
-																				"properties": {
-																					"currentPage": {
-																						"type": "number"
-																					},
-																					"lastPage": {
-																						"type": "number"
-																					},
-																					"totalContent": {
-																						"type": "number"
-																					}
-																				},
-																				"required": [
-																					"currentPage",
-																					"lastPage",
-																					"totalContent"
-																				]
-																			}
-																		},
-																		"required": [
-																			"properties"
-																		]
-																	}
-																}
-															},
-															"required": [
-																"tags"
-															]
-														}
-													},
-													"required": [
-														"elements",
-														"fields",
-														"metadata",
-														"tags",
-														"trail"
-													]
-												},
-												"maybeContentId": {
-													"type": "string"
-												},
-												"isLiveBlog": {
-													"type": "boolean"
-												},
-												"isCrossword": {
-													"type": "boolean"
-												},
-												"byline": {
-													"type": "string"
-												},
-												"image": {
-													"type": "object",
-													"properties": {
-														"type": {
-															"type": "string"
-														},
-														"item": {
-															"type": "object",
-															"properties": {
-																"imageSrc": {
-																	"type": "string"
-																},
-																"assets": {
-																	"type": "array",
-																	"items": {
-																		"type": "object",
-																		"properties": {
-																			"imageSrc": {
-																				"type": "string"
-																			},
-																			"imageCaption": {
-																				"type": "string"
-																			}
-																		},
-																		"required": [
-																			"imageSrc"
-																		]
-																	}
-																}
-															}
-														}
-													},
-													"required": [
-														"item",
-														"type"
-													]
-												},
-												"webTitle": {
-													"type": "string"
-												},
-												"linkText": {
-													"type": "string"
-												},
-												"webUrl": {
-													"type": "string"
-												},
-												"editionBrandings": {
-													"type": "array",
-													"items": {
-														"type": "object",
-														"properties": {
-															"edition": {
-																"type": "object",
-																"properties": {
-																	"id": {
-																		"$ref": "#/definitions/EditionId"
-																	}
-																},
-																"required": [
-																	"id"
-																]
-															},
-															"branding": {
-																"$ref": "#/definitions/Branding"
-															}
-														},
-														"required": [
-															"edition"
-														]
-													}
-												},
-												"href": {
-													"type": "string"
-												},
-												"embedUri": {
-													"type": "string"
-												}
-											},
-											"required": [
-												"editionBrandings",
-												"imageSlideshowReplace",
-												"isBreaking",
-												"isCrossword",
-												"isLiveBlog",
-												"showByline",
-												"showKickerTag",
-												"showMainVideo",
-												"webTitle"
-											]
-										},
-										"header": {
-											"type": "object",
-											"properties": {
-												"isVideo": {
-													"type": "boolean"
-												},
-												"isComment": {
-													"type": "boolean"
-												},
-												"isGallery": {
-													"type": "boolean"
-												},
-												"isAudio": {
-													"type": "boolean"
-												},
-												"kicker": {
-													"type": "object",
-													"properties": {
-														"type": {
-															"type": "string"
-														},
-														"item": {
-															"type": "object",
-															"properties": {
-																"properties": {
-																	"type": "object",
-																	"properties": {
-																		"kickerText": {
-																			"type": "string"
-																		}
-																	},
-																	"required": [
-																		"kickerText"
-																	]
-																}
-															},
-															"required": [
-																"properties"
-															]
-														}
-													},
-													"required": [
-														"type"
-													]
-												},
-												"seriesOrBlogKicker": {
-													"type": "object",
-													"properties": {
-														"properties": {
-															"type": "object",
-															"properties": {
-																"kickerText": {
-																	"type": "string"
-																}
-															},
-															"required": [
-																"kickerText"
-															]
-														},
-														"name": {
-															"type": "string"
-														},
-														"url": {
-															"type": "string"
-														},
-														"id": {
-															"type": "string"
-														}
-													},
-													"required": [
-														"id",
-														"name",
-														"properties",
-														"url"
-													]
-												},
-												"headline": {
-													"type": "string"
-												},
-												"url": {
-													"type": "string"
-												},
-												"hasMainVideoElement": {
-													"type": "boolean"
-												}
-											},
-											"required": [
-												"hasMainVideoElement",
-												"headline",
-												"isAudio",
-												"isComment",
-												"isGallery",
-												"isVideo",
-												"url"
-											]
-										},
-										"card": {
-											"type": "object",
-											"properties": {
-												"id": {
-													"type": "string"
-												},
-												"cardStyle": {
-													"type": "object",
-													"properties": {
-														"type": {
-															"$ref": "#/definitions/FEFrontCardStyle"
-														}
-													},
-													"required": [
-														"type"
-													]
-												},
-												"webPublicationDateOption": {
-													"type": "number"
-												},
-												"lastModifiedOption": {
-													"type": "number"
-												},
-												"trailText": {
-													"type": "string"
-												},
-												"starRating": {
-													"type": "number"
-												},
-												"shortUrlPath": {
-													"type": "string"
-												},
-												"shortUrl": {
-													"type": "string"
-												},
-												"group": {
-													"type": "string"
-												},
-												"isLive": {
-													"type": "boolean"
-												}
-											},
-											"required": [
-												"cardStyle",
-												"group",
-												"id",
-												"isLive",
-												"shortUrl"
-											]
-										},
-										"discussion": {
-											"type": "object",
-											"properties": {
-												"isCommentable": {
-													"type": "boolean"
-												},
-												"isClosedForComments": {
-													"type": "boolean"
-												},
-												"discussionId": {
-													"type": "string"
-												}
-											},
-											"required": [
-												"isClosedForComments",
-												"isCommentable"
-											]
-										},
-										"display": {
-											"type": "object",
-											"properties": {
-												"isBoosted": {
-													"type": "boolean"
-												},
-												"showBoostedHeadline": {
-													"type": "boolean"
-												},
-												"showQuotedHeadline": {
-													"type": "boolean"
-												},
-												"imageHide": {
-													"type": "boolean"
-												},
-												"showLivePlayable": {
-													"type": "boolean"
-												}
-											},
-											"required": [
-												"imageHide",
-												"isBoosted",
-												"showBoostedHeadline",
-												"showLivePlayable",
-												"showQuotedHeadline"
-											]
-										},
-										"format": {
-											"type": "object",
-											"properties": {
-												"design": {
-													"$ref": "#/definitions/FEDesign"
-												},
-												"theme": {
-													"$ref": "#/definitions/FETheme"
-												},
-												"display": {
-													"$ref": "#/definitions/FEDisplay"
-												}
-											},
-											"required": [
-												"design",
-												"display",
-												"theme"
-											]
-										},
-										"enriched": {
-											"type": "object",
-											"properties": {
-												"embedHtml": {
-													"type": "string"
-												},
-												"embedCss": {
-													"type": "string"
-												},
-												"embedJs": {
-													"type": "string"
-												}
-											}
-										},
-										"supportingContent": {
-											"type": "array",
-											"items": {
-												"type": "object",
-												"properties": {
-													"properties": {
-														"type": "object",
-														"properties": {
-															"href": {
-																"type": "string"
-															}
-														}
-													},
-													"header": {
-														"type": "object",
-														"properties": {
-															"kicker": {
-																"type": "object",
-																"properties": {
-																	"item": {
-																		"type": "object",
-																		"properties": {
-																			"properties": {
-																				"type": "object",
-																				"properties": {
-																					"kickerText": {
-																						"type": "string"
-																					}
-																				},
-																				"required": [
-																					"kickerText"
-																				]
-																			}
-																		},
-																		"required": [
-																			"properties"
-																		]
-																	}
-																}
-															},
-															"headline": {
-																"type": "string"
-															},
-															"url": {
-																"type": "string"
-															}
-														},
-														"required": [
-															"headline",
-															"url"
-														]
-													},
-													"format": {
-														"type": "object",
-														"properties": {
-															"design": {
-																"$ref": "#/definitions/FEDesign"
-															},
-															"theme": {
-																"$ref": "#/definitions/FETheme"
-															},
-															"display": {
-																"$ref": "#/definitions/FEDisplay"
-															}
-														},
-														"required": [
-															"design",
-															"display",
-															"theme"
-														]
-													}
-												},
-												"required": [
-													"properties"
-												]
-											}
-										},
-										"cardStyle": {
-											"type": "object",
-											"properties": {
-												"type": {
-													"$ref": "#/definitions/FEFrontCardStyle"
-												}
-											},
-											"required": [
-												"type"
-											]
-										},
-										"type": {
-											"type": "string"
-										}
-									},
-									"required": [
-										"card",
-										"discussion",
-										"display",
-										"header",
-										"properties",
-										"type"
-									]
-								}
-							},
-							"treats": {
-								"type": "array",
-								"items": {
-									"type": "object",
-									"properties": {
-										"properties": {
-											"type": "object",
-											"properties": {
-												"isBreaking": {
-													"type": "boolean"
-												},
-												"showMainVideo": {
-													"type": "boolean"
-												},
-												"showKickerTag": {
-													"type": "boolean"
-												},
-												"showByline": {
-													"type": "boolean"
-												},
-												"imageSlideshowReplace": {
-													"type": "boolean"
-												},
-												"maybeContent": {
-													"type": "object",
-													"properties": {
-														"trail": {
-															"type": "object",
-															"properties": {
-																"trailPicture": {
-																	"type": "object",
-																	"properties": {
-																		"allImages": {
-																			"type": "array",
-																			"items": {
-																				"type": "object",
-																				"properties": {
-																					"index": {
-																						"type": "number"
-																					},
-																					"fields": {
-																						"type": "object",
-																						"properties": {
-																							"displayCredit": {
-																								"type": "string"
-																							},
-																							"source": {
-																								"type": "string"
-																							},
-																							"photographer": {
-																								"type": "string"
-																							},
-																							"isMaster": {
-																								"type": "string"
-																							},
-																							"altText": {
-																								"type": "string"
-																							},
-																							"height": {
-																								"type": "string"
-																							},
-																							"credit": {
-																								"type": "string"
-																							},
-																							"mediaId": {
-																								"type": "string"
-																							},
-																							"width": {
-																								"type": "string"
-																							}
-																						},
-																						"required": [
-																							"height",
-																							"width"
-																						]
-																					},
-																					"mediaType": {
-																						"type": "string"
-																					},
-																					"url": {
-																						"type": "string"
-																					}
-																				},
-																				"required": [
-																					"fields",
-																					"index",
-																					"mediaType",
-																					"url"
-																				]
-																			}
-																		}
-																	},
-																	"required": [
-																		"allImages"
-																	]
-																},
-																"byline": {
-																	"type": "string"
-																},
-																"thumbnailPath": {
-																	"type": "string"
-																},
-																"webPublicationDate": {
-																	"type": "number"
-																}
-															},
-															"required": [
-																"webPublicationDate"
-															]
-														},
-														"metadata": {
-															"type": "object",
-															"properties": {
-																"id": {
-																	"type": "string"
-																},
-																"webTitle": {
-																	"type": "string"
-																},
-																"webUrl": {
-																	"type": "string"
-																},
-																"type": {
-																	"type": "string"
-																},
-																"sectionId": {
-																	"type": "object",
-																	"properties": {
-																		"value": {
-																			"type": "string"
-																		}
-																	},
-																	"required": [
-																		"value"
-																	]
-																},
-																"format": {
-																	"type": "object",
-																	"properties": {
-																		"design": {
-																			"$ref": "#/definitions/FEDesign"
-																		},
-																		"theme": {
-																			"$ref": "#/definitions/FETheme"
-																		},
-																		"display": {
-																			"$ref": "#/definitions/FEDisplay"
-																		}
-																	},
-																	"required": [
-																		"design",
-																		"display",
-																		"theme"
-																	]
-																}
-															},
-															"required": [
-																"format",
-																"id",
-																"type",
-																"webTitle",
-																"webUrl"
-															]
-														},
-														"fields": {
-															"type": "object",
-															"properties": {
-																"main": {
-																	"type": "string"
-																},
-																"body": {
-																	"type": "string"
-																},
-																"standfirst": {
-																	"type": "string"
-																}
-															},
-															"required": [
-																"body",
-																"main"
-															]
-														},
-														"elements": {
-															"type": "object",
-															"properties": {
-																"mainVideo": {},
-																"mediaAtoms": {
-																	"type": "array",
-																	"items": {
-																		"$ref": "#/definitions/FEMediaAtoms"
-																	}
-																}
-															},
-															"required": [
-																"mediaAtoms"
-															]
-														},
-														"tags": {
-															"type": "object",
-															"properties": {
-																"tags": {
-																	"type": "array",
-																	"items": {
-																		"description": "This type comes from `frontend`, hence the FE prefix.",
-																		"type": "object",
-																		"properties": {
-																			"properties": {
-																				"type": "object",
-																				"properties": {
-																					"id": {
-																						"type": "string"
-																					},
-																					"tagType": {
-																						"type": "string"
-																					},
-																					"webTitle": {
-																						"type": "string"
-																					},
-																					"bio": {
-																						"type": "string"
-																					},
-																					"bylineImageUrl": {
-																						"type": "string"
-																					},
-																					"bylineLargeImageUrl": {
-																						"type": "string"
-																					},
-																					"contributorLargeImagePath": {
-																						"type": "string"
-																					},
-																					"paidContentType": {
-																						"type": "string"
-																					},
-																					"sectionId": {
-																						"type": "string"
-																					},
-																					"sectionName": {
-																						"type": "string"
-																					},
-																					"twitterHandle": {
-																						"type": "string"
-																					},
-																					"url": {
-																						"type": "string"
-																					},
-																					"webUrl": {
-																						"type": "string"
-																					}
-																				},
-																				"required": [
-																					"id",
-																					"tagType",
-																					"webTitle"
-																				]
-																			},
-																			"pagination": {
-																				"type": "object",
-																				"properties": {
-																					"currentPage": {
-																						"type": "number"
-																					},
-																					"lastPage": {
-																						"type": "number"
-																					},
-																					"totalContent": {
-																						"type": "number"
-																					}
-																				},
-																				"required": [
-																					"currentPage",
-																					"lastPage",
-																					"totalContent"
-																				]
-																			}
-																		},
-																		"required": [
-																			"properties"
-																		]
-																	}
-																}
-															},
-															"required": [
-																"tags"
-															]
-														}
-													},
-													"required": [
-														"elements",
-														"fields",
-														"metadata",
-														"tags",
-														"trail"
-													]
-												},
-												"maybeContentId": {
-													"type": "string"
-												},
-												"isLiveBlog": {
-													"type": "boolean"
-												},
-												"isCrossword": {
-													"type": "boolean"
-												},
-												"byline": {
-													"type": "string"
-												},
-												"image": {
-													"type": "object",
-													"properties": {
-														"type": {
-															"type": "string"
-														},
-														"item": {
-															"type": "object",
-															"properties": {
-																"imageSrc": {
-																	"type": "string"
-																},
-																"assets": {
-																	"type": "array",
-																	"items": {
-																		"type": "object",
-																		"properties": {
-																			"imageSrc": {
-																				"type": "string"
-																			},
-																			"imageCaption": {
-																				"type": "string"
-																			}
-																		},
-																		"required": [
-																			"imageSrc"
-																		]
-																	}
-																}
-															}
-														}
-													},
-													"required": [
-														"item",
-														"type"
-													]
-												},
-												"webTitle": {
-													"type": "string"
-												},
-												"linkText": {
-													"type": "string"
-												},
-												"webUrl": {
-													"type": "string"
-												},
-												"editionBrandings": {
-													"type": "array",
-													"items": {
-														"type": "object",
-														"properties": {
-															"edition": {
-																"type": "object",
-																"properties": {
-																	"id": {
-																		"$ref": "#/definitions/EditionId"
-																	}
-																},
-																"required": [
-																	"id"
-																]
-															},
-															"branding": {
-																"$ref": "#/definitions/Branding"
-															}
-														},
-														"required": [
-															"edition"
-														]
-													}
-												},
-												"href": {
-													"type": "string"
-												},
-												"embedUri": {
-													"type": "string"
-												}
-											},
-											"required": [
-												"editionBrandings",
-												"imageSlideshowReplace",
-												"isBreaking",
-												"isCrossword",
-												"isLiveBlog",
-												"showByline",
-												"showKickerTag",
-												"showMainVideo",
-												"webTitle"
-											]
-										},
-										"header": {
-											"type": "object",
-											"properties": {
-												"isVideo": {
-													"type": "boolean"
-												},
-												"isComment": {
-													"type": "boolean"
-												},
-												"isGallery": {
-													"type": "boolean"
-												},
-												"isAudio": {
-													"type": "boolean"
-												},
-												"kicker": {
-													"type": "object",
-													"properties": {
-														"type": {
-															"type": "string"
-														},
-														"item": {
-															"type": "object",
-															"properties": {
-																"properties": {
-																	"type": "object",
-																	"properties": {
-																		"kickerText": {
-																			"type": "string"
-																		}
-																	},
-																	"required": [
-																		"kickerText"
-																	]
-																}
-															},
-															"required": [
-																"properties"
-															]
-														}
-													},
-													"required": [
-														"type"
-													]
-												},
-												"seriesOrBlogKicker": {
-													"type": "object",
-													"properties": {
-														"properties": {
-															"type": "object",
-															"properties": {
-																"kickerText": {
-																	"type": "string"
-																}
-															},
-															"required": [
-																"kickerText"
-															]
-														},
-														"name": {
-															"type": "string"
-														},
-														"url": {
-															"type": "string"
-														},
-														"id": {
-															"type": "string"
-														}
-													},
-													"required": [
-														"id",
-														"name",
-														"properties",
-														"url"
-													]
-												},
-												"headline": {
-													"type": "string"
-												},
-												"url": {
-													"type": "string"
-												},
-												"hasMainVideoElement": {
-													"type": "boolean"
-												}
-											},
-											"required": [
-												"hasMainVideoElement",
-												"headline",
-												"isAudio",
-												"isComment",
-												"isGallery",
-												"isVideo",
-												"url"
-											]
-										},
-										"card": {
-											"type": "object",
-											"properties": {
-												"id": {
-													"type": "string"
-												},
-												"cardStyle": {
-													"type": "object",
-													"properties": {
-														"type": {
-															"$ref": "#/definitions/FEFrontCardStyle"
-														}
-													},
-													"required": [
-														"type"
-													]
-												},
-												"webPublicationDateOption": {
-													"type": "number"
-												},
-												"lastModifiedOption": {
-													"type": "number"
-												},
-												"trailText": {
-													"type": "string"
-												},
-												"starRating": {
-													"type": "number"
-												},
-												"shortUrlPath": {
-													"type": "string"
-												},
-												"shortUrl": {
-													"type": "string"
-												},
-												"group": {
-													"type": "string"
-												},
-												"isLive": {
-													"type": "boolean"
-												}
-											},
-											"required": [
-												"cardStyle",
-												"group",
-												"id",
-												"isLive",
-												"shortUrl"
-											]
-										},
-										"discussion": {
-											"type": "object",
-											"properties": {
-												"isCommentable": {
-													"type": "boolean"
-												},
-												"isClosedForComments": {
-													"type": "boolean"
-												},
-												"discussionId": {
-													"type": "string"
-												}
-											},
-											"required": [
-												"isClosedForComments",
-												"isCommentable"
-											]
-										},
-										"display": {
-											"type": "object",
-											"properties": {
-												"isBoosted": {
-													"type": "boolean"
-												},
-												"showBoostedHeadline": {
-													"type": "boolean"
-												},
-												"showQuotedHeadline": {
-													"type": "boolean"
-												},
-												"imageHide": {
-													"type": "boolean"
-												},
-												"showLivePlayable": {
-													"type": "boolean"
-												}
-											},
-											"required": [
-												"imageHide",
-												"isBoosted",
-												"showBoostedHeadline",
-												"showLivePlayable",
-												"showQuotedHeadline"
-											]
-										},
-										"format": {
-											"type": "object",
-											"properties": {
-												"design": {
-													"$ref": "#/definitions/FEDesign"
-												},
-												"theme": {
-													"$ref": "#/definitions/FETheme"
-												},
-												"display": {
-													"$ref": "#/definitions/FEDisplay"
-												}
-											},
-											"required": [
-												"design",
-												"display",
-												"theme"
-											]
-										},
-										"enriched": {
-											"type": "object",
-											"properties": {
-												"embedHtml": {
-													"type": "string"
-												},
-												"embedCss": {
-													"type": "string"
-												},
-												"embedJs": {
-													"type": "string"
-												}
-											}
-										},
-										"supportingContent": {
-											"type": "array",
-											"items": {
-												"type": "object",
-												"properties": {
-													"properties": {
-														"type": "object",
-														"properties": {
-															"href": {
-																"type": "string"
-															}
-														}
-													},
-													"header": {
-														"type": "object",
-														"properties": {
-															"kicker": {
-																"type": "object",
-																"properties": {
-																	"item": {
-																		"type": "object",
-																		"properties": {
-																			"properties": {
-																				"type": "object",
-																				"properties": {
-																					"kickerText": {
-																						"type": "string"
-																					}
-																				},
-																				"required": [
-																					"kickerText"
-																				]
-																			}
-																		},
-																		"required": [
-																			"properties"
-																		]
-																	}
-																}
-															},
-															"headline": {
-																"type": "string"
-															},
-															"url": {
-																"type": "string"
-															}
-														},
-														"required": [
-															"headline",
-															"url"
-														]
-													},
-													"format": {
-														"type": "object",
-														"properties": {
-															"design": {
-																"$ref": "#/definitions/FEDesign"
-															},
-															"theme": {
-																"$ref": "#/definitions/FETheme"
-															},
-															"display": {
-																"$ref": "#/definitions/FEDisplay"
-															}
-														},
-														"required": [
-															"design",
-															"display",
-															"theme"
-														]
-													}
-												},
-												"required": [
-													"properties"
-												]
-											}
-										},
-										"cardStyle": {
-											"type": "object",
-											"properties": {
-												"type": {
-													"$ref": "#/definitions/FEFrontCardStyle"
-												}
-											},
-											"required": [
-												"type"
-											]
-										},
-										"type": {
-											"type": "string"
-										}
-									},
-									"required": [
-										"card",
-										"discussion",
-										"display",
-										"header",
-										"properties",
-										"type"
-									]
-								}
-							},
-							"lastUpdate": {
-								"type": "number"
-							},
-							"href": {
-								"type": "string"
-							},
-							"groups": {
-								"type": "array",
-								"items": {
-									"type": "string"
-								}
-							},
-							"collectionType": {
-								"$ref": "#/definitions/FEContainerType"
-							},
-							"uneditable": {
-								"type": "boolean"
-							},
-							"showTags": {
-								"type": "boolean"
-							},
-							"showSections": {
-								"type": "boolean"
-							},
-							"hideKickers": {
-								"type": "boolean"
-							},
-							"showDateHeader": {
-								"type": "boolean"
-							},
-							"showLatestUpdate": {
-								"type": "boolean"
-							},
-							"config": {
-								"type": "object",
-								"properties": {
-									"displayName": {
-										"type": "string"
-									},
-									"metadata": {
-										"type": "array",
-										"items": {
-											"type": "object",
-											"properties": {
-												"type": {
-													"$ref": "#/definitions/FEContainerPalette"
-												}
-											},
-											"required": [
-												"type"
-											]
-										}
-									},
-									"collectionType": {
-										"$ref": "#/definitions/FEContainerType"
-									},
-									"href": {
-										"type": "string"
-									},
-									"groups": {
-										"type": "array",
-										"items": {
-											"type": "string"
-										}
-									},
-									"uneditable": {
-										"type": "boolean"
-									},
-									"showTags": {
-										"type": "boolean"
-									},
-									"showSections": {
-										"type": "boolean"
-									},
-									"hideKickers": {
-										"type": "boolean"
-									},
-									"showDateHeader": {
-										"type": "boolean"
-									},
-									"showLatestUpdate": {
-										"type": "boolean"
-									},
-									"excludeFromRss": {
-										"type": "boolean"
-									},
-									"showTimestamps": {
-										"type": "boolean"
-									},
-									"hideShowMore": {
-										"type": "boolean"
-									},
-									"platform": {
-										"type": "string"
-									}
-								},
-								"required": [
-									"collectionType",
-									"displayName",
-									"excludeFromRss",
-									"hideKickers",
-									"hideShowMore",
-									"platform",
-									"showDateHeader",
-									"showLatestUpdate",
-									"showSections",
-									"showTags",
-									"showTimestamps",
-									"uneditable"
-								]
-							},
-							"hasMore": {
-								"type": "boolean"
-							},
-							"targetedTerritory": {
-								"$ref": "#/definitions/Territory"
-							}
-						},
-						"required": [
-							"backfill",
-							"collectionType",
-							"config",
-							"curated",
-							"displayName",
-							"hasMore",
-							"hideKickers",
-							"id",
-							"showDateHeader",
-							"showLatestUpdate",
-							"showSections",
-							"showTags",
-							"treats",
-							"uneditable"
-						]
-					}
-				}
-			},
-			"required": [
-				"collections",
-				"frontProperties",
-				"id",
-				"seoData"
-			]
-		},
-		"Record<string,unknown>": {
-			"type": "object"
-		},
-		"FEDesign": {
-			"enum": [
-				"AnalysisDesign",
-				"ArticleDesign",
-				"AudioDesign",
-				"CommentDesign",
-				"DeadBlogDesign",
-				"EditorialDesign",
-				"ExplainerDesign",
-				"FeatureDesign",
-				"FullPageInteractiveDesign",
-				"GalleryDesign",
-				"InteractiveDesign",
-				"InterviewDesign",
-				"LetterDesign",
-				"LiveBlogDesign",
-				"MatchReportDesign",
-				"NewsletterSignupDesign",
-				"ObituaryDesign",
-				"PhotoEssayDesign",
-				"PrintShopDesign",
-				"ProfileDesign",
-				"QuizDesign",
-				"RecipeDesign",
-				"ReviewDesign",
-				"TimelineDesign",
-				"VideoDesign"
-			],
-			"type": "string"
-		},
-		"FETheme": {
-			"enum": [
-				"CulturePillar",
-				"Labs",
-				"LifestylePillar",
-				"NewsPillar",
-				"OpinionPillar",
-				"SpecialReportAltTheme",
-				"SpecialReportTheme",
-				"SportPillar"
-			],
-			"type": "string"
-		},
-		"FEDisplay": {
-			"enum": [
-				"ImmersiveDisplay",
-				"NumberedListDisplay",
-				"ShowcaseDisplay",
-				"StandardDisplay"
-			],
-			"type": "string"
-		},
-		"FEMediaAtoms": {
-			"type": "object",
-			"properties": {
-				"duration": {
-					"type": "number"
-				}
-			}
-		},
-		"EditionId": {
-			"enum": [
-				"AU",
-				"EUR",
-				"INT",
-				"UK",
-				"US"
-			],
-			"type": "string"
-		},
-		"Branding": {
-			"type": "object",
-			"properties": {
-				"brandingType": {
-					"type": "object",
-					"properties": {
-						"name": {
-							"type": "string"
-						}
-					},
-					"required": [
-						"name"
-					]
-				},
-				"sponsorName": {
-					"type": "string"
-				},
-				"logo": {
-					"type": "object",
-					"properties": {
-						"src": {
-							"type": "string"
-						},
-						"link": {
-							"type": "string"
-						},
-						"label": {
-							"type": "string"
-						},
-						"dimensions": {
-							"type": "object",
-							"properties": {
-								"width": {
-									"type": "number"
-								},
-								"height": {
-									"type": "number"
-								}
-							},
-							"required": [
-								"height",
-								"width"
-							]
-						}
-					},
-					"required": [
-						"dimensions",
-						"label",
-						"link",
-						"src"
-					]
-				},
-				"aboutThisLink": {
-					"type": "string"
-				},
-				"logoForDarkBackground": {
-					"type": "object",
-					"properties": {
-						"src": {
-							"type": "string"
-						},
-						"link": {
-							"type": "string"
-						},
-						"label": {
-							"type": "string"
-						},
-						"dimensions": {
-							"type": "object",
-							"properties": {
-								"width": {
-									"type": "number"
-								},
-								"height": {
-									"type": "number"
-								}
-							},
-							"required": [
-								"height",
-								"width"
-							]
-						}
-					},
-					"required": [
-						"dimensions",
-						"label",
-						"link",
-						"src"
-					]
-				}
-			},
-			"required": [
-				"aboutThisLink",
-				"logo",
-				"sponsorName"
-			]
-		},
-		"FEFrontCardStyle": {
-			"enum": [
-				"Analysis",
-				"Comment",
-				"DeadBlog",
-				"DefaultCardstyle",
-				"Editorial",
-				"ExternalLink",
-				"Feature",
-				"Letters",
-				"LiveBlog",
-				"Media",
-				"Review",
-				"SpecialReport",
-				"SpecialReportAlt"
-			],
-			"type": "string"
-		},
-		"FEContainerType": {
-			"enum": [
-				"dynamic/fast",
-				"dynamic/package",
-				"dynamic/slow",
-				"dynamic/slow-mpu",
-				"fixed/large/slow-XIV",
-				"fixed/medium/fast-XI",
-				"fixed/medium/fast-XII",
-				"fixed/medium/slow-VI",
-				"fixed/medium/slow-VII",
-				"fixed/medium/slow-XII-mpu",
-				"fixed/small/fast-VIII",
-				"fixed/small/slow-I",
-				"fixed/small/slow-III",
-				"fixed/small/slow-IV",
-				"fixed/small/slow-V-half",
-				"fixed/small/slow-V-mpu",
-				"fixed/small/slow-V-third",
-				"fixed/thrasher",
-				"fixed/video",
-				"fixed/video/vertical",
-				"nav/list",
-				"nav/media-list",
-				"news/most-popular"
-			],
-			"type": "string"
-		},
-		"FEContainerPalette": {
-			"enum": [
-				"Branded",
-				"Breaking",
-				"BreakingPalette",
-				"Canonical",
-				"Dynamo",
-				"DynamoLike",
-				"EventAltPalette",
-				"EventPalette",
-				"InvestigationPalette",
-				"LongRunningAltPalette",
-				"LongRunningPalette",
-				"Podcast",
-				"SombreAltPalette",
-				"SombrePalette",
-				"Special",
-				"SpecialReportAltPalette"
-			],
-			"type": "string"
-		},
-		"Territory": {
-			"description": "List of territories that can be targetted against.",
-			"enum": [
-				"AU-NSW",
-				"AU-QLD",
-				"AU-VIC",
-				"EU-27",
-				"NZ",
-				"US-East-Coast",
-				"US-West-Coast",
-				"XX"
-			],
-			"type": "string"
-		},
-		"FENavType": {
-			"type": "object",
-			"properties": {
-				"currentUrl": {
-					"type": "string"
-				},
-				"pillars": {
-					"type": "array",
-					"items": {
-						"$ref": "#/definitions/FELinkType"
-					}
-				},
-				"otherLinks": {
-					"type": "array",
-					"items": {
-						"$ref": "#/definitions/FELinkType"
-					}
-				},
-				"brandExtensions": {
-					"type": "array",
-					"items": {
-						"$ref": "#/definitions/FELinkType"
-					}
-				},
-				"currentNavLink": {
-					"$ref": "#/definitions/FELinkType"
-				},
-				"currentNavLinkTitle": {
-					"type": "string"
-				},
-				"currentPillarTitle": {
-					"type": "string"
-				},
-				"subNavSections": {
-					"type": "object",
-					"properties": {
-						"parent": {
-							"$ref": "#/definitions/FELinkType"
-						},
-						"links": {
-							"type": "array",
-							"items": {
-								"$ref": "#/definitions/FELinkType"
-							}
-						}
-					},
-					"required": [
-						"links"
-					]
-				},
-				"readerRevenueLinks": {
-					"$ref": "#/definitions/ReaderRevenuePositions"
-				}
-			},
-			"required": [
-				"brandExtensions",
-				"currentUrl",
-				"otherLinks",
-				"pillars",
-				"readerRevenueLinks"
-			]
-		},
-		"FELinkType": {
-			"type": "object",
-			"properties": {
-				"url": {
-					"type": "string"
-				},
-				"title": {
-					"type": "string"
-				},
-				"longTitle": {
-					"type": "string"
-				},
-				"iconName": {
-					"type": "string"
-				},
-				"children": {
-					"type": "array",
-					"items": {
-						"$ref": "#/definitions/FELinkType"
-					}
-				},
-				"pillar": {
-					"$ref": "#/definitions/LegacyPillar"
-				},
-				"more": {
-					"type": "boolean"
-				},
-				"classList": {
-					"type": "array",
-					"items": {
-						"type": "string"
-					}
-				}
-			},
-			"required": [
-				"title",
-				"url"
-			]
-		},
-		"LegacyPillar": {
-			"enum": [
-				"culture",
-				"labs",
-				"lifestyle",
-				"news",
-				"opinion",
-				"sport"
-			],
-			"type": "string"
-		},
-		"ReaderRevenuePositions": {
-			"type": "object",
-			"properties": {
-				"header": {
-					"$ref": "#/definitions/ReaderRevenueCategories"
-				},
-				"footer": {
-					"$ref": "#/definitions/ReaderRevenueCategories"
-				},
-				"sideMenu": {
-					"$ref": "#/definitions/ReaderRevenueCategories"
-				},
-				"ampHeader": {
-					"$ref": "#/definitions/ReaderRevenueCategories"
-				},
-				"ampFooter": {
-					"$ref": "#/definitions/ReaderRevenueCategories"
-				}
-			},
-			"required": [
-				"ampFooter",
-				"ampHeader",
-				"footer",
-				"header",
-				"sideMenu"
-			]
-		},
-		"ReaderRevenueCategories": {
-			"type": "object",
-			"properties": {
-				"contribute": {
-					"type": "string"
-				},
-				"subscribe": {
-					"type": "string"
-				},
-				"support": {
-					"type": "string"
-				},
-				"supporter": {
-					"type": "string"
-				},
-				"gifting": {
-					"type": "string"
-				}
-			},
-			"required": [
-				"contribute",
-				"subscribe",
-				"support",
-				"supporter"
-			]
-		},
-		"Switches": {
-			"type": "object",
-			"additionalProperties": {
-				"type": "boolean"
-			}
-		},
-		"StageType": {
-			"enum": [
-				"CODE",
-				"DEV",
-				"PROD"
-			],
-			"type": "string"
-		},
-		"FooterType": {
-			"type": "object",
-			"properties": {
-				"footerLinks": {
-					"type": "array",
-					"items": {
-						"type": "array",
-						"items": {
-							"$ref": "#/definitions/FooterLink"
-						}
-					}
-				}
-			},
-			"required": [
-				"footerLinks"
-			]
-		},
-		"FooterLink": {
-			"type": "object",
-			"properties": {
-				"text": {
-					"type": "string"
-				},
-				"url": {
-					"type": "string"
-				},
-				"dataLinkName": {
-					"type": "string"
-				},
-				"extraClasses": {
-					"type": "string"
-				}
-			},
-			"required": [
-				"dataLinkName",
-				"text",
-				"url"
-			]
-		},
-		"FETrailType": {
-			"type": "object",
-			"properties": {
-				"format": {
-					"type": "object",
-					"properties": {
-						"design": {
-							"$ref": "#/definitions/FEDesign"
-						},
-						"theme": {
-							"$ref": "#/definitions/FETheme"
-						},
-						"display": {
-							"$ref": "#/definitions/FEDisplay"
-						}
-					},
-					"required": [
-						"design",
-						"display",
-						"theme"
-					]
-				},
-				"designType": {
-					"type": "string"
-				},
-				"pillar": {
-					"type": "string"
-				},
-				"carouselImages": {
-					"type": "object",
-					"additionalProperties": {
-						"type": "string"
-					}
-				},
-				"isLiveBlog": {
-					"type": "boolean"
-				},
-				"masterImage": {
-					"type": "string"
-				},
-				"url": {
-					"type": "string"
-				},
-				"headline": {
-					"type": "string"
-				},
-				"webPublicationDate": {
-					"type": "string"
-				},
-				"image": {
-					"type": "string"
-				},
-				"avatarUrl": {
-					"type": "string"
-				},
-				"mediaType": {
-					"$ref": "#/definitions/MediaType"
-				},
-				"mediaDuration": {
-					"type": "number"
-				},
-				"ageWarning": {
-					"type": "string"
-				},
-				"byline": {
-					"type": "string"
-				},
-				"showByline": {
-					"type": "boolean"
-				},
-				"kickerText": {
-					"type": "string"
-				},
-				"shortUrl": {
-					"type": "string"
-				},
-				"commentCount": {
-					"type": "number"
-				},
-				"starRating": {
-					"type": "number"
-				},
-				"linkText": {
-					"type": "string"
-				},
-				"branding": {
-					"$ref": "#/definitions/Branding"
-				},
-				"isSnap": {
-					"type": "boolean"
-				},
-				"isCrossword": {
-					"type": "boolean"
-				},
-				"snapData": {
-					"type": "object",
-					"properties": {
-						"embedHtml": {
-							"type": "string"
-						},
-						"embedCss": {
-							"type": "string"
-						},
-						"embedJs": {
-							"type": "string"
-						}
-					}
-				},
-				"showQuotedHeadline": {
-					"type": "boolean"
-				},
-				"discussion": {
-					"type": "object",
-					"properties": {
-						"isCommentable": {
-							"type": "boolean"
-						},
-						"isClosedForComments": {
-							"type": "boolean"
-						},
-						"discussionId": {
-							"type": "string"
-						}
-					},
-					"required": [
-						"isClosedForComments",
-						"isCommentable"
-					]
-				},
-				"showMainVideo": {
-					"type": "boolean"
-				}
-			},
-			"required": [
-				"format",
-				"headline",
-				"url"
-			]
-		},
-		"MediaType": {
-			"enum": [
-				"Audio",
-				"Gallery",
-				"Video"
-			],
-			"type": "string"
-		}
-	},
-	"$schema": "http://json-schema.org/draft-07/schema#"
+    "type": "object",
+    "properties": {
+        "pressedPage": {
+            "$ref": "#/definitions/FEPressedPageType"
+        },
+        "nav": {
+            "$ref": "#/definitions/FENavType"
+        },
+        "editionId": {
+            "$ref": "#/definitions/EditionId"
+        },
+        "editionLongForm": {
+            "type": "string"
+        },
+        "guardianBaseURL": {
+            "type": "string"
+        },
+        "pageId": {
+            "type": "string"
+        },
+        "webTitle": {
+            "type": "string"
+        },
+        "webURL": {
+            "type": "string"
+        },
+        "config": {
+            "type": "object",
+            "properties": {
+                "avatarApiUrl": {
+                    "type": "string"
+                },
+                "externalEmbedHost": {
+                    "type": "string"
+                },
+                "ajaxUrl": {
+                    "type": "string"
+                },
+                "keywords": {
+                    "type": "string"
+                },
+                "revisionNumber": {
+                    "type": "string"
+                },
+                "isProd": {
+                    "type": "boolean"
+                },
+                "switches": {
+                    "$ref": "#/definitions/Switches"
+                },
+                "section": {
+                    "type": "string"
+                },
+                "keywordIds": {
+                    "type": "string"
+                },
+                "locationapiurl": {
+                    "type": "string"
+                },
+                "sharedAdTargeting": {
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "buildNumber": {
+                    "type": "string"
+                },
+                "abTests": {
+                    "description": "Narrowest representation of the server-side tests\nobject shape, which is [defined in `frontend`](https://github.com/guardian/frontend/blob/23743723030a041e4f4f59fa265ee2be0bb51825/common/app/experiments/ExperimentsDefinition.scala#L24-L26).\n\n**Note:** This type is not support by JSON-schema, it evaluates as `object`",
+                    "type": "object"
+                },
+                "pbIndexSites": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": {}
+                    }
+                },
+                "ampIframeUrl": {
+                    "type": "string"
+                },
+                "beaconUrl": {
+                    "type": "string"
+                },
+                "userAttributesApiUrl": {
+                    "type": "string"
+                },
+                "host": {
+                    "type": "string"
+                },
+                "brazeApiKey": {
+                    "type": "string"
+                },
+                "calloutsUrl": {
+                    "type": "string"
+                },
+                "requiresMembershipAccess": {
+                    "type": "boolean"
+                },
+                "onwardWebSocket": {
+                    "type": "string"
+                },
+                "a9PublisherId": {
+                    "type": "string"
+                },
+                "contentType": {
+                    "type": "string"
+                },
+                "facebookIaAdUnitRoot": {
+                    "type": "string"
+                },
+                "ophanEmbedJsUrl": {
+                    "type": "string"
+                },
+                "idUrl": {
+                    "type": "string"
+                },
+                "dcrSentryDsn": {
+                    "type": "string"
+                },
+                "isFront": {
+                    "type": "boolean",
+                    "enum": [
+                        true
+                    ]
+                },
+                "idWebAppUrl": {
+                    "type": "string"
+                },
+                "discussionApiUrl": {
+                    "type": "string"
+                },
+                "sentryPublicApiKey": {
+                    "type": "string"
+                },
+                "omnitureAccount": {
+                    "type": "string"
+                },
+                "dfpAccountId": {
+                    "type": "string"
+                },
+                "pageId": {
+                    "type": "string"
+                },
+                "forecastsapiurl": {
+                    "type": "string"
+                },
+                "assetsPath": {
+                    "type": "string"
+                },
+                "pillar": {
+                    "type": "string"
+                },
+                "commercialBundleUrl": {
+                    "type": "string"
+                },
+                "discussionApiClientHeader": {
+                    "type": "string"
+                },
+                "membershipUrl": {
+                    "type": "string"
+                },
+                "dfpHost": {
+                    "type": "string"
+                },
+                "cardStyle": {
+                    "type": "string"
+                },
+                "googletagUrl": {
+                    "type": "string"
+                },
+                "sentryHost": {
+                    "type": "string"
+                },
+                "shouldHideAdverts": {
+                    "type": "boolean"
+                },
+                "mmaUrl": {
+                    "type": "string"
+                },
+                "membershipAccess": {
+                    "type": "string"
+                },
+                "isPreview": {
+                    "type": "boolean"
+                },
+                "googletagJsUrl": {
+                    "type": "string"
+                },
+                "supportUrl": {
+                    "type": "string"
+                },
+                "edition": {
+                    "type": "string"
+                },
+                "discussionFrontendUrl": {
+                    "type": "string"
+                },
+                "ipsosTag": {
+                    "type": "string"
+                },
+                "ophanJsUrl": {
+                    "type": "string"
+                },
+                "isPaidContent": {
+                    "type": "boolean"
+                },
+                "mobileAppsAdUnitRoot": {
+                    "type": "string"
+                },
+                "plistaPublicApiKey": {
+                    "type": "string"
+                },
+                "frontendAssetsFullURL": {
+                    "type": "string"
+                },
+                "googleSearchId": {
+                    "type": "string"
+                },
+                "allowUserGeneratedContent": {
+                    "type": "boolean"
+                },
+                "dfpAdUnitRoot": {
+                    "type": "string"
+                },
+                "idApiUrl": {
+                    "type": "string"
+                },
+                "omnitureAmpAccount": {
+                    "type": "string"
+                },
+                "adUnit": {
+                    "type": "string"
+                },
+                "hasPageSkin": {
+                    "type": "boolean"
+                },
+                "webTitle": {
+                    "type": "string"
+                },
+                "stripePublicToken": {
+                    "type": "string"
+                },
+                "googleRecaptchaSiteKey": {
+                    "type": "string"
+                },
+                "discussionD2Uid": {
+                    "type": "string"
+                },
+                "weatherapiurl": {
+                    "type": "string"
+                },
+                "googleSearchUrl": {
+                    "type": "string"
+                },
+                "optimizeEpicUrl": {
+                    "type": "string"
+                },
+                "stage": {
+                    "$ref": "#/definitions/StageType"
+                },
+                "idOAuthUrl": {
+                    "type": "string"
+                },
+                "isSensitive": {
+                    "type": "boolean"
+                },
+                "isDev": {
+                    "type": "boolean"
+                },
+                "thirdPartyAppsAccount": {
+                    "type": "string"
+                },
+                "avatarImagesUrl": {
+                    "type": "string"
+                },
+                "fbAppId": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "a9PublisherId",
+                "abTests",
+                "adUnit",
+                "ajaxUrl",
+                "allowUserGeneratedContent",
+                "ampIframeUrl",
+                "assetsPath",
+                "avatarApiUrl",
+                "avatarImagesUrl",
+                "beaconUrl",
+                "buildNumber",
+                "calloutsUrl",
+                "commercialBundleUrl",
+                "contentType",
+                "dcrSentryDsn",
+                "dfpAccountId",
+                "dfpAdUnitRoot",
+                "dfpHost",
+                "discussionApiClientHeader",
+                "discussionApiUrl",
+                "discussionD2Uid",
+                "discussionFrontendUrl",
+                "edition",
+                "externalEmbedHost",
+                "facebookIaAdUnitRoot",
+                "fbAppId",
+                "forecastsapiurl",
+                "frontendAssetsFullURL",
+                "googleRecaptchaSiteKey",
+                "googleSearchId",
+                "googleSearchUrl",
+                "googletagJsUrl",
+                "googletagUrl",
+                "hasPageSkin",
+                "host",
+                "idApiUrl",
+                "idOAuthUrl",
+                "idUrl",
+                "idWebAppUrl",
+                "ipsosTag",
+                "isDev",
+                "isFront",
+                "isPreview",
+                "isProd",
+                "isSensitive",
+                "keywordIds",
+                "keywords",
+                "locationapiurl",
+                "membershipAccess",
+                "membershipUrl",
+                "mmaUrl",
+                "mobileAppsAdUnitRoot",
+                "omnitureAccount",
+                "omnitureAmpAccount",
+                "onwardWebSocket",
+                "ophanEmbedJsUrl",
+                "ophanJsUrl",
+                "optimizeEpicUrl",
+                "pageId",
+                "pbIndexSites",
+                "pillar",
+                "plistaPublicApiKey",
+                "requiresMembershipAccess",
+                "revisionNumber",
+                "section",
+                "sentryHost",
+                "sentryPublicApiKey",
+                "sharedAdTargeting",
+                "shouldHideAdverts",
+                "stage",
+                "stripePublicToken",
+                "supportUrl",
+                "switches",
+                "userAttributesApiUrl",
+                "weatherapiurl",
+                "webTitle"
+            ]
+        },
+        "commercialProperties": {
+            "$ref": "#/definitions/Record<string,unknown>"
+        },
+        "pageFooter": {
+            "$ref": "#/definitions/FooterType"
+        },
+        "isAdFreeUser": {
+            "type": "boolean"
+        },
+        "isNetworkFront": {
+            "type": "boolean"
+        },
+        "mostViewed": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/FETrailType"
+            }
+        },
+        "mostCommented": {
+            "$ref": "#/definitions/FETrailType"
+        },
+        "mostShared": {
+            "$ref": "#/definitions/FETrailType"
+        },
+        "deeplyRead": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/FETrailType"
+            }
+        }
+    },
+    "required": [
+        "commercialProperties",
+        "config",
+        "editionId",
+        "editionLongForm",
+        "guardianBaseURL",
+        "isAdFreeUser",
+        "isNetworkFront",
+        "mostViewed",
+        "nav",
+        "pageFooter",
+        "pageId",
+        "pressedPage",
+        "webTitle",
+        "webURL"
+    ],
+    "definitions": {
+        "FEPressedPageType": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "seoData": {
+                    "type": "object",
+                    "properties": {
+                        "id": {
+                            "type": "string"
+                        },
+                        "navSection": {
+                            "type": "string"
+                        },
+                        "webTitle": {
+                            "type": "string"
+                        },
+                        "title": {
+                            "type": "string"
+                        },
+                        "description": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "description",
+                        "id",
+                        "navSection",
+                        "webTitle"
+                    ]
+                },
+                "frontProperties": {
+                    "type": "object",
+                    "properties": {
+                        "isImageDisplayed": {
+                            "type": "boolean"
+                        },
+                        "commercial": {
+                            "$ref": "#/definitions/Record<string,unknown>"
+                        },
+                        "isPaidContent": {
+                            "type": "boolean"
+                        },
+                        "onPageDescription": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "commercial",
+                        "isImageDisplayed"
+                    ]
+                },
+                "collections": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "id": {
+                                "type": "string"
+                            },
+                            "displayName": {
+                                "type": "string"
+                            },
+                            "description": {
+                                "type": "string"
+                            },
+                            "curated": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "properties": {
+                                            "type": "object",
+                                            "properties": {
+                                                "isBreaking": {
+                                                    "type": "boolean"
+                                                },
+                                                "showMainVideo": {
+                                                    "type": "boolean"
+                                                },
+                                                "showKickerTag": {
+                                                    "type": "boolean"
+                                                },
+                                                "showByline": {
+                                                    "type": "boolean"
+                                                },
+                                                "imageSlideshowReplace": {
+                                                    "type": "boolean"
+                                                },
+                                                "maybeContent": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "trail": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "trailPicture": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "allImages": {
+                                                                            "type": "array",
+                                                                            "items": {
+                                                                                "type": "object",
+                                                                                "properties": {
+                                                                                    "index": {
+                                                                                        "type": "number"
+                                                                                    },
+                                                                                    "fields": {
+                                                                                        "type": "object",
+                                                                                        "properties": {
+                                                                                            "displayCredit": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "source": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "photographer": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "isMaster": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "altText": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "height": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "credit": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "mediaId": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "width": {
+                                                                                                "type": "string"
+                                                                                            }
+                                                                                        },
+                                                                                        "required": [
+                                                                                            "height",
+                                                                                            "width"
+                                                                                        ]
+                                                                                    },
+                                                                                    "mediaType": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "url": {
+                                                                                        "type": "string"
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "fields",
+                                                                                    "index",
+                                                                                    "mediaType",
+                                                                                    "url"
+                                                                                ]
+                                                                            }
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "allImages"
+                                                                    ]
+                                                                },
+                                                                "byline": {
+                                                                    "type": "string"
+                                                                },
+                                                                "thumbnailPath": {
+                                                                    "type": "string"
+                                                                },
+                                                                "webPublicationDate": {
+                                                                    "type": "number"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "webPublicationDate"
+                                                            ]
+                                                        },
+                                                        "metadata": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "id": {
+                                                                    "type": "string"
+                                                                },
+                                                                "webTitle": {
+                                                                    "type": "string"
+                                                                },
+                                                                "webUrl": {
+                                                                    "type": "string"
+                                                                },
+                                                                "type": {
+                                                                    "type": "string"
+                                                                },
+                                                                "sectionId": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "value": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "value"
+                                                                    ]
+                                                                },
+                                                                "format": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "design": {
+                                                                            "$ref": "#/definitions/FEDesign"
+                                                                        },
+                                                                        "theme": {
+                                                                            "$ref": "#/definitions/FETheme"
+                                                                        },
+                                                                        "display": {
+                                                                            "$ref": "#/definitions/FEDisplay"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "design",
+                                                                        "display",
+                                                                        "theme"
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "format",
+                                                                "id",
+                                                                "type",
+                                                                "webTitle",
+                                                                "webUrl"
+                                                            ]
+                                                        },
+                                                        "fields": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "main": {
+                                                                    "type": "string"
+                                                                },
+                                                                "body": {
+                                                                    "type": "string"
+                                                                },
+                                                                "standfirst": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "body",
+                                                                "main"
+                                                            ]
+                                                        },
+                                                        "elements": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "mainVideo": {},
+                                                                "mediaAtoms": {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                        "$ref": "#/definitions/FEMediaAtoms"
+                                                                    }
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "mediaAtoms"
+                                                            ]
+                                                        },
+                                                        "tags": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "tags": {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                        "description": "This type comes from `frontend`, hence the FE prefix.",
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "properties": {
+                                                                                "type": "object",
+                                                                                "properties": {
+                                                                                    "id": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "tagType": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "webTitle": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "bio": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "bylineImageUrl": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "bylineLargeImageUrl": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "contributorLargeImagePath": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "paidContentType": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "sectionId": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "sectionName": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "twitterHandle": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "url": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "webUrl": {
+                                                                                        "type": "string"
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "id",
+                                                                                    "tagType",
+                                                                                    "webTitle"
+                                                                                ]
+                                                                            },
+                                                                            "pagination": {
+                                                                                "type": "object",
+                                                                                "properties": {
+                                                                                    "currentPage": {
+                                                                                        "type": "number"
+                                                                                    },
+                                                                                    "lastPage": {
+                                                                                        "type": "number"
+                                                                                    },
+                                                                                    "totalContent": {
+                                                                                        "type": "number"
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "currentPage",
+                                                                                    "lastPage",
+                                                                                    "totalContent"
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "properties"
+                                                                        ]
+                                                                    }
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "tags"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "elements",
+                                                        "fields",
+                                                        "metadata",
+                                                        "tags",
+                                                        "trail"
+                                                    ]
+                                                },
+                                                "maybeContentId": {
+                                                    "type": "string"
+                                                },
+                                                "isLiveBlog": {
+                                                    "type": "boolean"
+                                                },
+                                                "isCrossword": {
+                                                    "type": "boolean"
+                                                },
+                                                "byline": {
+                                                    "type": "string"
+                                                },
+                                                "image": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string"
+                                                        },
+                                                        "item": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "imageSrc": {
+                                                                    "type": "string"
+                                                                },
+                                                                "assets": {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "imageSrc": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "imageCaption": {
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "imageSrc"
+                                                                        ]
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "item",
+                                                        "type"
+                                                    ]
+                                                },
+                                                "webTitle": {
+                                                    "type": "string"
+                                                },
+                                                "linkText": {
+                                                    "type": "string"
+                                                },
+                                                "webUrl": {
+                                                    "type": "string"
+                                                },
+                                                "editionBrandings": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "edition": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "id": {
+                                                                        "$ref": "#/definitions/EditionId"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "id"
+                                                                ]
+                                                            },
+                                                            "branding": {
+                                                                "$ref": "#/definitions/Branding"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "edition"
+                                                        ]
+                                                    }
+                                                },
+                                                "href": {
+                                                    "type": "string"
+                                                },
+                                                "embedUri": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "editionBrandings",
+                                                "imageSlideshowReplace",
+                                                "isBreaking",
+                                                "isCrossword",
+                                                "isLiveBlog",
+                                                "showByline",
+                                                "showKickerTag",
+                                                "showMainVideo",
+                                                "webTitle"
+                                            ]
+                                        },
+                                        "header": {
+                                            "type": "object",
+                                            "properties": {
+                                                "isVideo": {
+                                                    "type": "boolean"
+                                                },
+                                                "isComment": {
+                                                    "type": "boolean"
+                                                },
+                                                "isGallery": {
+                                                    "type": "boolean"
+                                                },
+                                                "isAudio": {
+                                                    "type": "boolean"
+                                                },
+                                                "kicker": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string"
+                                                        },
+                                                        "item": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "properties": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "kickerText": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "kickerText"
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "properties"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type"
+                                                    ]
+                                                },
+                                                "seriesOrBlogKicker": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "properties": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "kickerText": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "kickerText"
+                                                            ]
+                                                        },
+                                                        "name": {
+                                                            "type": "string"
+                                                        },
+                                                        "url": {
+                                                            "type": "string"
+                                                        },
+                                                        "id": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "id",
+                                                        "name",
+                                                        "properties",
+                                                        "url"
+                                                    ]
+                                                },
+                                                "headline": {
+                                                    "type": "string"
+                                                },
+                                                "url": {
+                                                    "type": "string"
+                                                },
+                                                "hasMainVideoElement": {
+                                                    "type": "boolean"
+                                                }
+                                            },
+                                            "required": [
+                                                "hasMainVideoElement",
+                                                "headline",
+                                                "isAudio",
+                                                "isComment",
+                                                "isGallery",
+                                                "isVideo",
+                                                "url"
+                                            ]
+                                        },
+                                        "card": {
+                                            "type": "object",
+                                            "properties": {
+                                                "id": {
+                                                    "type": "string"
+                                                },
+                                                "cardStyle": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "$ref": "#/definitions/FEFrontCardStyle"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type"
+                                                    ]
+                                                },
+                                                "webPublicationDateOption": {
+                                                    "type": "number"
+                                                },
+                                                "lastModifiedOption": {
+                                                    "type": "number"
+                                                },
+                                                "trailText": {
+                                                    "type": "string"
+                                                },
+                                                "starRating": {
+                                                    "type": "number"
+                                                },
+                                                "shortUrlPath": {
+                                                    "type": "string"
+                                                },
+                                                "shortUrl": {
+                                                    "type": "string"
+                                                },
+                                                "group": {
+                                                    "type": "string"
+                                                },
+                                                "isLive": {
+                                                    "type": "boolean"
+                                                }
+                                            },
+                                            "required": [
+                                                "cardStyle",
+                                                "group",
+                                                "id",
+                                                "isLive",
+                                                "shortUrl"
+                                            ]
+                                        },
+                                        "discussion": {
+                                            "type": "object",
+                                            "properties": {
+                                                "isCommentable": {
+                                                    "type": "boolean"
+                                                },
+                                                "isClosedForComments": {
+                                                    "type": "boolean"
+                                                },
+                                                "discussionId": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "isClosedForComments",
+                                                "isCommentable"
+                                            ]
+                                        },
+                                        "display": {
+                                            "type": "object",
+                                            "properties": {
+                                                "isBoosted": {
+                                                    "type": "boolean"
+                                                },
+                                                "showBoostedHeadline": {
+                                                    "type": "boolean"
+                                                },
+                                                "showQuotedHeadline": {
+                                                    "type": "boolean"
+                                                },
+                                                "imageHide": {
+                                                    "type": "boolean"
+                                                },
+                                                "showLivePlayable": {
+                                                    "type": "boolean"
+                                                }
+                                            },
+                                            "required": [
+                                                "imageHide",
+                                                "isBoosted",
+                                                "showBoostedHeadline",
+                                                "showLivePlayable",
+                                                "showQuotedHeadline"
+                                            ]
+                                        },
+                                        "format": {
+                                            "type": "object",
+                                            "properties": {
+                                                "design": {
+                                                    "$ref": "#/definitions/FEDesign"
+                                                },
+                                                "theme": {
+                                                    "$ref": "#/definitions/FETheme"
+                                                },
+                                                "display": {
+                                                    "$ref": "#/definitions/FEDisplay"
+                                                }
+                                            },
+                                            "required": [
+                                                "design",
+                                                "display",
+                                                "theme"
+                                            ]
+                                        },
+                                        "enriched": {
+                                            "type": "object",
+                                            "properties": {
+                                                "embedHtml": {
+                                                    "type": "string"
+                                                },
+                                                "embedCss": {
+                                                    "type": "string"
+                                                },
+                                                "embedJs": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        },
+                                        "supportingContent": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "properties": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "href": {
+                                                                "type": "string"
+                                                            }
+                                                        }
+                                                    },
+                                                    "header": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "kicker": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "item": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "properties": {
+                                                                                "type": "object",
+                                                                                "properties": {
+                                                                                    "kickerText": {
+                                                                                        "type": "string"
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "kickerText"
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "properties"
+                                                                        ]
+                                                                    }
+                                                                }
+                                                            },
+                                                            "headline": {
+                                                                "type": "string"
+                                                            },
+                                                            "url": {
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "headline",
+                                                            "url"
+                                                        ]
+                                                    },
+                                                    "format": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "design": {
+                                                                "$ref": "#/definitions/FEDesign"
+                                                            },
+                                                            "theme": {
+                                                                "$ref": "#/definitions/FETheme"
+                                                            },
+                                                            "display": {
+                                                                "$ref": "#/definitions/FEDisplay"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "design",
+                                                            "display",
+                                                            "theme"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "properties"
+                                                ]
+                                            }
+                                        },
+                                        "cardStyle": {
+                                            "type": "object",
+                                            "properties": {
+                                                "type": {
+                                                    "$ref": "#/definitions/FEFrontCardStyle"
+                                                }
+                                            },
+                                            "required": [
+                                                "type"
+                                            ]
+                                        },
+                                        "type": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "card",
+                                        "discussion",
+                                        "display",
+                                        "header",
+                                        "properties",
+                                        "type"
+                                    ]
+                                }
+                            },
+                            "backfill": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "properties": {
+                                            "type": "object",
+                                            "properties": {
+                                                "isBreaking": {
+                                                    "type": "boolean"
+                                                },
+                                                "showMainVideo": {
+                                                    "type": "boolean"
+                                                },
+                                                "showKickerTag": {
+                                                    "type": "boolean"
+                                                },
+                                                "showByline": {
+                                                    "type": "boolean"
+                                                },
+                                                "imageSlideshowReplace": {
+                                                    "type": "boolean"
+                                                },
+                                                "maybeContent": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "trail": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "trailPicture": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "allImages": {
+                                                                            "type": "array",
+                                                                            "items": {
+                                                                                "type": "object",
+                                                                                "properties": {
+                                                                                    "index": {
+                                                                                        "type": "number"
+                                                                                    },
+                                                                                    "fields": {
+                                                                                        "type": "object",
+                                                                                        "properties": {
+                                                                                            "displayCredit": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "source": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "photographer": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "isMaster": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "altText": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "height": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "credit": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "mediaId": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "width": {
+                                                                                                "type": "string"
+                                                                                            }
+                                                                                        },
+                                                                                        "required": [
+                                                                                            "height",
+                                                                                            "width"
+                                                                                        ]
+                                                                                    },
+                                                                                    "mediaType": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "url": {
+                                                                                        "type": "string"
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "fields",
+                                                                                    "index",
+                                                                                    "mediaType",
+                                                                                    "url"
+                                                                                ]
+                                                                            }
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "allImages"
+                                                                    ]
+                                                                },
+                                                                "byline": {
+                                                                    "type": "string"
+                                                                },
+                                                                "thumbnailPath": {
+                                                                    "type": "string"
+                                                                },
+                                                                "webPublicationDate": {
+                                                                    "type": "number"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "webPublicationDate"
+                                                            ]
+                                                        },
+                                                        "metadata": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "id": {
+                                                                    "type": "string"
+                                                                },
+                                                                "webTitle": {
+                                                                    "type": "string"
+                                                                },
+                                                                "webUrl": {
+                                                                    "type": "string"
+                                                                },
+                                                                "type": {
+                                                                    "type": "string"
+                                                                },
+                                                                "sectionId": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "value": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "value"
+                                                                    ]
+                                                                },
+                                                                "format": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "design": {
+                                                                            "$ref": "#/definitions/FEDesign"
+                                                                        },
+                                                                        "theme": {
+                                                                            "$ref": "#/definitions/FETheme"
+                                                                        },
+                                                                        "display": {
+                                                                            "$ref": "#/definitions/FEDisplay"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "design",
+                                                                        "display",
+                                                                        "theme"
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "format",
+                                                                "id",
+                                                                "type",
+                                                                "webTitle",
+                                                                "webUrl"
+                                                            ]
+                                                        },
+                                                        "fields": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "main": {
+                                                                    "type": "string"
+                                                                },
+                                                                "body": {
+                                                                    "type": "string"
+                                                                },
+                                                                "standfirst": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "body",
+                                                                "main"
+                                                            ]
+                                                        },
+                                                        "elements": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "mainVideo": {},
+                                                                "mediaAtoms": {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                        "$ref": "#/definitions/FEMediaAtoms"
+                                                                    }
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "mediaAtoms"
+                                                            ]
+                                                        },
+                                                        "tags": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "tags": {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                        "description": "This type comes from `frontend`, hence the FE prefix.",
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "properties": {
+                                                                                "type": "object",
+                                                                                "properties": {
+                                                                                    "id": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "tagType": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "webTitle": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "bio": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "bylineImageUrl": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "bylineLargeImageUrl": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "contributorLargeImagePath": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "paidContentType": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "sectionId": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "sectionName": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "twitterHandle": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "url": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "webUrl": {
+                                                                                        "type": "string"
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "id",
+                                                                                    "tagType",
+                                                                                    "webTitle"
+                                                                                ]
+                                                                            },
+                                                                            "pagination": {
+                                                                                "type": "object",
+                                                                                "properties": {
+                                                                                    "currentPage": {
+                                                                                        "type": "number"
+                                                                                    },
+                                                                                    "lastPage": {
+                                                                                        "type": "number"
+                                                                                    },
+                                                                                    "totalContent": {
+                                                                                        "type": "number"
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "currentPage",
+                                                                                    "lastPage",
+                                                                                    "totalContent"
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "properties"
+                                                                        ]
+                                                                    }
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "tags"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "elements",
+                                                        "fields",
+                                                        "metadata",
+                                                        "tags",
+                                                        "trail"
+                                                    ]
+                                                },
+                                                "maybeContentId": {
+                                                    "type": "string"
+                                                },
+                                                "isLiveBlog": {
+                                                    "type": "boolean"
+                                                },
+                                                "isCrossword": {
+                                                    "type": "boolean"
+                                                },
+                                                "byline": {
+                                                    "type": "string"
+                                                },
+                                                "image": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string"
+                                                        },
+                                                        "item": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "imageSrc": {
+                                                                    "type": "string"
+                                                                },
+                                                                "assets": {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "imageSrc": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "imageCaption": {
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "imageSrc"
+                                                                        ]
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "item",
+                                                        "type"
+                                                    ]
+                                                },
+                                                "webTitle": {
+                                                    "type": "string"
+                                                },
+                                                "linkText": {
+                                                    "type": "string"
+                                                },
+                                                "webUrl": {
+                                                    "type": "string"
+                                                },
+                                                "editionBrandings": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "edition": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "id": {
+                                                                        "$ref": "#/definitions/EditionId"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "id"
+                                                                ]
+                                                            },
+                                                            "branding": {
+                                                                "$ref": "#/definitions/Branding"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "edition"
+                                                        ]
+                                                    }
+                                                },
+                                                "href": {
+                                                    "type": "string"
+                                                },
+                                                "embedUri": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "editionBrandings",
+                                                "imageSlideshowReplace",
+                                                "isBreaking",
+                                                "isCrossword",
+                                                "isLiveBlog",
+                                                "showByline",
+                                                "showKickerTag",
+                                                "showMainVideo",
+                                                "webTitle"
+                                            ]
+                                        },
+                                        "header": {
+                                            "type": "object",
+                                            "properties": {
+                                                "isVideo": {
+                                                    "type": "boolean"
+                                                },
+                                                "isComment": {
+                                                    "type": "boolean"
+                                                },
+                                                "isGallery": {
+                                                    "type": "boolean"
+                                                },
+                                                "isAudio": {
+                                                    "type": "boolean"
+                                                },
+                                                "kicker": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string"
+                                                        },
+                                                        "item": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "properties": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "kickerText": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "kickerText"
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "properties"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type"
+                                                    ]
+                                                },
+                                                "seriesOrBlogKicker": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "properties": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "kickerText": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "kickerText"
+                                                            ]
+                                                        },
+                                                        "name": {
+                                                            "type": "string"
+                                                        },
+                                                        "url": {
+                                                            "type": "string"
+                                                        },
+                                                        "id": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "id",
+                                                        "name",
+                                                        "properties",
+                                                        "url"
+                                                    ]
+                                                },
+                                                "headline": {
+                                                    "type": "string"
+                                                },
+                                                "url": {
+                                                    "type": "string"
+                                                },
+                                                "hasMainVideoElement": {
+                                                    "type": "boolean"
+                                                }
+                                            },
+                                            "required": [
+                                                "hasMainVideoElement",
+                                                "headline",
+                                                "isAudio",
+                                                "isComment",
+                                                "isGallery",
+                                                "isVideo",
+                                                "url"
+                                            ]
+                                        },
+                                        "card": {
+                                            "type": "object",
+                                            "properties": {
+                                                "id": {
+                                                    "type": "string"
+                                                },
+                                                "cardStyle": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "$ref": "#/definitions/FEFrontCardStyle"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type"
+                                                    ]
+                                                },
+                                                "webPublicationDateOption": {
+                                                    "type": "number"
+                                                },
+                                                "lastModifiedOption": {
+                                                    "type": "number"
+                                                },
+                                                "trailText": {
+                                                    "type": "string"
+                                                },
+                                                "starRating": {
+                                                    "type": "number"
+                                                },
+                                                "shortUrlPath": {
+                                                    "type": "string"
+                                                },
+                                                "shortUrl": {
+                                                    "type": "string"
+                                                },
+                                                "group": {
+                                                    "type": "string"
+                                                },
+                                                "isLive": {
+                                                    "type": "boolean"
+                                                }
+                                            },
+                                            "required": [
+                                                "cardStyle",
+                                                "group",
+                                                "id",
+                                                "isLive",
+                                                "shortUrl"
+                                            ]
+                                        },
+                                        "discussion": {
+                                            "type": "object",
+                                            "properties": {
+                                                "isCommentable": {
+                                                    "type": "boolean"
+                                                },
+                                                "isClosedForComments": {
+                                                    "type": "boolean"
+                                                },
+                                                "discussionId": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "isClosedForComments",
+                                                "isCommentable"
+                                            ]
+                                        },
+                                        "display": {
+                                            "type": "object",
+                                            "properties": {
+                                                "isBoosted": {
+                                                    "type": "boolean"
+                                                },
+                                                "showBoostedHeadline": {
+                                                    "type": "boolean"
+                                                },
+                                                "showQuotedHeadline": {
+                                                    "type": "boolean"
+                                                },
+                                                "imageHide": {
+                                                    "type": "boolean"
+                                                },
+                                                "showLivePlayable": {
+                                                    "type": "boolean"
+                                                }
+                                            },
+                                            "required": [
+                                                "imageHide",
+                                                "isBoosted",
+                                                "showBoostedHeadline",
+                                                "showLivePlayable",
+                                                "showQuotedHeadline"
+                                            ]
+                                        },
+                                        "format": {
+                                            "type": "object",
+                                            "properties": {
+                                                "design": {
+                                                    "$ref": "#/definitions/FEDesign"
+                                                },
+                                                "theme": {
+                                                    "$ref": "#/definitions/FETheme"
+                                                },
+                                                "display": {
+                                                    "$ref": "#/definitions/FEDisplay"
+                                                }
+                                            },
+                                            "required": [
+                                                "design",
+                                                "display",
+                                                "theme"
+                                            ]
+                                        },
+                                        "enriched": {
+                                            "type": "object",
+                                            "properties": {
+                                                "embedHtml": {
+                                                    "type": "string"
+                                                },
+                                                "embedCss": {
+                                                    "type": "string"
+                                                },
+                                                "embedJs": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        },
+                                        "supportingContent": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "properties": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "href": {
+                                                                "type": "string"
+                                                            }
+                                                        }
+                                                    },
+                                                    "header": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "kicker": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "item": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "properties": {
+                                                                                "type": "object",
+                                                                                "properties": {
+                                                                                    "kickerText": {
+                                                                                        "type": "string"
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "kickerText"
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "properties"
+                                                                        ]
+                                                                    }
+                                                                }
+                                                            },
+                                                            "headline": {
+                                                                "type": "string"
+                                                            },
+                                                            "url": {
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "headline",
+                                                            "url"
+                                                        ]
+                                                    },
+                                                    "format": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "design": {
+                                                                "$ref": "#/definitions/FEDesign"
+                                                            },
+                                                            "theme": {
+                                                                "$ref": "#/definitions/FETheme"
+                                                            },
+                                                            "display": {
+                                                                "$ref": "#/definitions/FEDisplay"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "design",
+                                                            "display",
+                                                            "theme"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "properties"
+                                                ]
+                                            }
+                                        },
+                                        "cardStyle": {
+                                            "type": "object",
+                                            "properties": {
+                                                "type": {
+                                                    "$ref": "#/definitions/FEFrontCardStyle"
+                                                }
+                                            },
+                                            "required": [
+                                                "type"
+                                            ]
+                                        },
+                                        "type": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "card",
+                                        "discussion",
+                                        "display",
+                                        "header",
+                                        "properties",
+                                        "type"
+                                    ]
+                                }
+                            },
+                            "treats": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "properties": {
+                                            "type": "object",
+                                            "properties": {
+                                                "isBreaking": {
+                                                    "type": "boolean"
+                                                },
+                                                "showMainVideo": {
+                                                    "type": "boolean"
+                                                },
+                                                "showKickerTag": {
+                                                    "type": "boolean"
+                                                },
+                                                "showByline": {
+                                                    "type": "boolean"
+                                                },
+                                                "imageSlideshowReplace": {
+                                                    "type": "boolean"
+                                                },
+                                                "maybeContent": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "trail": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "trailPicture": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "allImages": {
+                                                                            "type": "array",
+                                                                            "items": {
+                                                                                "type": "object",
+                                                                                "properties": {
+                                                                                    "index": {
+                                                                                        "type": "number"
+                                                                                    },
+                                                                                    "fields": {
+                                                                                        "type": "object",
+                                                                                        "properties": {
+                                                                                            "displayCredit": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "source": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "photographer": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "isMaster": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "altText": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "height": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "credit": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "mediaId": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "width": {
+                                                                                                "type": "string"
+                                                                                            }
+                                                                                        },
+                                                                                        "required": [
+                                                                                            "height",
+                                                                                            "width"
+                                                                                        ]
+                                                                                    },
+                                                                                    "mediaType": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "url": {
+                                                                                        "type": "string"
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "fields",
+                                                                                    "index",
+                                                                                    "mediaType",
+                                                                                    "url"
+                                                                                ]
+                                                                            }
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "allImages"
+                                                                    ]
+                                                                },
+                                                                "byline": {
+                                                                    "type": "string"
+                                                                },
+                                                                "thumbnailPath": {
+                                                                    "type": "string"
+                                                                },
+                                                                "webPublicationDate": {
+                                                                    "type": "number"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "webPublicationDate"
+                                                            ]
+                                                        },
+                                                        "metadata": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "id": {
+                                                                    "type": "string"
+                                                                },
+                                                                "webTitle": {
+                                                                    "type": "string"
+                                                                },
+                                                                "webUrl": {
+                                                                    "type": "string"
+                                                                },
+                                                                "type": {
+                                                                    "type": "string"
+                                                                },
+                                                                "sectionId": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "value": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "value"
+                                                                    ]
+                                                                },
+                                                                "format": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "design": {
+                                                                            "$ref": "#/definitions/FEDesign"
+                                                                        },
+                                                                        "theme": {
+                                                                            "$ref": "#/definitions/FETheme"
+                                                                        },
+                                                                        "display": {
+                                                                            "$ref": "#/definitions/FEDisplay"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "design",
+                                                                        "display",
+                                                                        "theme"
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "format",
+                                                                "id",
+                                                                "type",
+                                                                "webTitle",
+                                                                "webUrl"
+                                                            ]
+                                                        },
+                                                        "fields": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "main": {
+                                                                    "type": "string"
+                                                                },
+                                                                "body": {
+                                                                    "type": "string"
+                                                                },
+                                                                "standfirst": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "body",
+                                                                "main"
+                                                            ]
+                                                        },
+                                                        "elements": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "mainVideo": {},
+                                                                "mediaAtoms": {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                        "$ref": "#/definitions/FEMediaAtoms"
+                                                                    }
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "mediaAtoms"
+                                                            ]
+                                                        },
+                                                        "tags": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "tags": {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                        "description": "This type comes from `frontend`, hence the FE prefix.",
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "properties": {
+                                                                                "type": "object",
+                                                                                "properties": {
+                                                                                    "id": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "tagType": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "webTitle": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "bio": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "bylineImageUrl": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "bylineLargeImageUrl": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "contributorLargeImagePath": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "paidContentType": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "sectionId": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "sectionName": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "twitterHandle": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "url": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "webUrl": {
+                                                                                        "type": "string"
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "id",
+                                                                                    "tagType",
+                                                                                    "webTitle"
+                                                                                ]
+                                                                            },
+                                                                            "pagination": {
+                                                                                "type": "object",
+                                                                                "properties": {
+                                                                                    "currentPage": {
+                                                                                        "type": "number"
+                                                                                    },
+                                                                                    "lastPage": {
+                                                                                        "type": "number"
+                                                                                    },
+                                                                                    "totalContent": {
+                                                                                        "type": "number"
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "currentPage",
+                                                                                    "lastPage",
+                                                                                    "totalContent"
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "properties"
+                                                                        ]
+                                                                    }
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "tags"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "elements",
+                                                        "fields",
+                                                        "metadata",
+                                                        "tags",
+                                                        "trail"
+                                                    ]
+                                                },
+                                                "maybeContentId": {
+                                                    "type": "string"
+                                                },
+                                                "isLiveBlog": {
+                                                    "type": "boolean"
+                                                },
+                                                "isCrossword": {
+                                                    "type": "boolean"
+                                                },
+                                                "byline": {
+                                                    "type": "string"
+                                                },
+                                                "image": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string"
+                                                        },
+                                                        "item": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "imageSrc": {
+                                                                    "type": "string"
+                                                                },
+                                                                "assets": {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "imageSrc": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "imageCaption": {
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "imageSrc"
+                                                                        ]
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "item",
+                                                        "type"
+                                                    ]
+                                                },
+                                                "webTitle": {
+                                                    "type": "string"
+                                                },
+                                                "linkText": {
+                                                    "type": "string"
+                                                },
+                                                "webUrl": {
+                                                    "type": "string"
+                                                },
+                                                "editionBrandings": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "edition": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "id": {
+                                                                        "$ref": "#/definitions/EditionId"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "id"
+                                                                ]
+                                                            },
+                                                            "branding": {
+                                                                "$ref": "#/definitions/Branding"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "edition"
+                                                        ]
+                                                    }
+                                                },
+                                                "href": {
+                                                    "type": "string"
+                                                },
+                                                "embedUri": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "editionBrandings",
+                                                "imageSlideshowReplace",
+                                                "isBreaking",
+                                                "isCrossword",
+                                                "isLiveBlog",
+                                                "showByline",
+                                                "showKickerTag",
+                                                "showMainVideo",
+                                                "webTitle"
+                                            ]
+                                        },
+                                        "header": {
+                                            "type": "object",
+                                            "properties": {
+                                                "isVideo": {
+                                                    "type": "boolean"
+                                                },
+                                                "isComment": {
+                                                    "type": "boolean"
+                                                },
+                                                "isGallery": {
+                                                    "type": "boolean"
+                                                },
+                                                "isAudio": {
+                                                    "type": "boolean"
+                                                },
+                                                "kicker": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string"
+                                                        },
+                                                        "item": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "properties": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "kickerText": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "kickerText"
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "properties"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type"
+                                                    ]
+                                                },
+                                                "seriesOrBlogKicker": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "properties": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "kickerText": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "kickerText"
+                                                            ]
+                                                        },
+                                                        "name": {
+                                                            "type": "string"
+                                                        },
+                                                        "url": {
+                                                            "type": "string"
+                                                        },
+                                                        "id": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "id",
+                                                        "name",
+                                                        "properties",
+                                                        "url"
+                                                    ]
+                                                },
+                                                "headline": {
+                                                    "type": "string"
+                                                },
+                                                "url": {
+                                                    "type": "string"
+                                                },
+                                                "hasMainVideoElement": {
+                                                    "type": "boolean"
+                                                }
+                                            },
+                                            "required": [
+                                                "hasMainVideoElement",
+                                                "headline",
+                                                "isAudio",
+                                                "isComment",
+                                                "isGallery",
+                                                "isVideo",
+                                                "url"
+                                            ]
+                                        },
+                                        "card": {
+                                            "type": "object",
+                                            "properties": {
+                                                "id": {
+                                                    "type": "string"
+                                                },
+                                                "cardStyle": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "$ref": "#/definitions/FEFrontCardStyle"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type"
+                                                    ]
+                                                },
+                                                "webPublicationDateOption": {
+                                                    "type": "number"
+                                                },
+                                                "lastModifiedOption": {
+                                                    "type": "number"
+                                                },
+                                                "trailText": {
+                                                    "type": "string"
+                                                },
+                                                "starRating": {
+                                                    "type": "number"
+                                                },
+                                                "shortUrlPath": {
+                                                    "type": "string"
+                                                },
+                                                "shortUrl": {
+                                                    "type": "string"
+                                                },
+                                                "group": {
+                                                    "type": "string"
+                                                },
+                                                "isLive": {
+                                                    "type": "boolean"
+                                                }
+                                            },
+                                            "required": [
+                                                "cardStyle",
+                                                "group",
+                                                "id",
+                                                "isLive",
+                                                "shortUrl"
+                                            ]
+                                        },
+                                        "discussion": {
+                                            "type": "object",
+                                            "properties": {
+                                                "isCommentable": {
+                                                    "type": "boolean"
+                                                },
+                                                "isClosedForComments": {
+                                                    "type": "boolean"
+                                                },
+                                                "discussionId": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "isClosedForComments",
+                                                "isCommentable"
+                                            ]
+                                        },
+                                        "display": {
+                                            "type": "object",
+                                            "properties": {
+                                                "isBoosted": {
+                                                    "type": "boolean"
+                                                },
+                                                "showBoostedHeadline": {
+                                                    "type": "boolean"
+                                                },
+                                                "showQuotedHeadline": {
+                                                    "type": "boolean"
+                                                },
+                                                "imageHide": {
+                                                    "type": "boolean"
+                                                },
+                                                "showLivePlayable": {
+                                                    "type": "boolean"
+                                                }
+                                            },
+                                            "required": [
+                                                "imageHide",
+                                                "isBoosted",
+                                                "showBoostedHeadline",
+                                                "showLivePlayable",
+                                                "showQuotedHeadline"
+                                            ]
+                                        },
+                                        "format": {
+                                            "type": "object",
+                                            "properties": {
+                                                "design": {
+                                                    "$ref": "#/definitions/FEDesign"
+                                                },
+                                                "theme": {
+                                                    "$ref": "#/definitions/FETheme"
+                                                },
+                                                "display": {
+                                                    "$ref": "#/definitions/FEDisplay"
+                                                }
+                                            },
+                                            "required": [
+                                                "design",
+                                                "display",
+                                                "theme"
+                                            ]
+                                        },
+                                        "enriched": {
+                                            "type": "object",
+                                            "properties": {
+                                                "embedHtml": {
+                                                    "type": "string"
+                                                },
+                                                "embedCss": {
+                                                    "type": "string"
+                                                },
+                                                "embedJs": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        },
+                                        "supportingContent": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "properties": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "href": {
+                                                                "type": "string"
+                                                            }
+                                                        }
+                                                    },
+                                                    "header": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "kicker": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "item": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "properties": {
+                                                                                "type": "object",
+                                                                                "properties": {
+                                                                                    "kickerText": {
+                                                                                        "type": "string"
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "kickerText"
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "properties"
+                                                                        ]
+                                                                    }
+                                                                }
+                                                            },
+                                                            "headline": {
+                                                                "type": "string"
+                                                            },
+                                                            "url": {
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "headline",
+                                                            "url"
+                                                        ]
+                                                    },
+                                                    "format": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "design": {
+                                                                "$ref": "#/definitions/FEDesign"
+                                                            },
+                                                            "theme": {
+                                                                "$ref": "#/definitions/FETheme"
+                                                            },
+                                                            "display": {
+                                                                "$ref": "#/definitions/FEDisplay"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "design",
+                                                            "display",
+                                                            "theme"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "properties"
+                                                ]
+                                            }
+                                        },
+                                        "cardStyle": {
+                                            "type": "object",
+                                            "properties": {
+                                                "type": {
+                                                    "$ref": "#/definitions/FEFrontCardStyle"
+                                                }
+                                            },
+                                            "required": [
+                                                "type"
+                                            ]
+                                        },
+                                        "type": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "card",
+                                        "discussion",
+                                        "display",
+                                        "header",
+                                        "properties",
+                                        "type"
+                                    ]
+                                }
+                            },
+                            "lastUpdate": {
+                                "type": "number"
+                            },
+                            "href": {
+                                "type": "string"
+                            },
+                            "groups": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "collectionType": {
+                                "$ref": "#/definitions/FEContainerType"
+                            },
+                            "uneditable": {
+                                "type": "boolean"
+                            },
+                            "showTags": {
+                                "type": "boolean"
+                            },
+                            "showSections": {
+                                "type": "boolean"
+                            },
+                            "hideKickers": {
+                                "type": "boolean"
+                            },
+                            "showDateHeader": {
+                                "type": "boolean"
+                            },
+                            "showLatestUpdate": {
+                                "type": "boolean"
+                            },
+                            "config": {
+                                "type": "object",
+                                "properties": {
+                                    "displayName": {
+                                        "type": "string"
+                                    },
+                                    "metadata": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "type": {
+                                                    "$ref": "#/definitions/FEContainerPalette"
+                                                }
+                                            },
+                                            "required": [
+                                                "type"
+                                            ]
+                                        }
+                                    },
+                                    "collectionType": {
+                                        "$ref": "#/definitions/FEContainerType"
+                                    },
+                                    "href": {
+                                        "type": "string"
+                                    },
+                                    "groups": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "uneditable": {
+                                        "type": "boolean"
+                                    },
+                                    "showTags": {
+                                        "type": "boolean"
+                                    },
+                                    "showSections": {
+                                        "type": "boolean"
+                                    },
+                                    "hideKickers": {
+                                        "type": "boolean"
+                                    },
+                                    "showDateHeader": {
+                                        "type": "boolean"
+                                    },
+                                    "showLatestUpdate": {
+                                        "type": "boolean"
+                                    },
+                                    "excludeFromRss": {
+                                        "type": "boolean"
+                                    },
+                                    "showTimestamps": {
+                                        "type": "boolean"
+                                    },
+                                    "hideShowMore": {
+                                        "type": "boolean"
+                                    },
+                                    "platform": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "collectionType",
+                                    "displayName",
+                                    "excludeFromRss",
+                                    "hideKickers",
+                                    "hideShowMore",
+                                    "platform",
+                                    "showDateHeader",
+                                    "showLatestUpdate",
+                                    "showSections",
+                                    "showTags",
+                                    "showTimestamps",
+                                    "uneditable"
+                                ]
+                            },
+                            "hasMore": {
+                                "type": "boolean"
+                            },
+                            "targetedTerritory": {
+                                "$ref": "#/definitions/Territory"
+                            }
+                        },
+                        "required": [
+                            "backfill",
+                            "collectionType",
+                            "config",
+                            "curated",
+                            "displayName",
+                            "hasMore",
+                            "hideKickers",
+                            "id",
+                            "showDateHeader",
+                            "showLatestUpdate",
+                            "showSections",
+                            "showTags",
+                            "treats",
+                            "uneditable"
+                        ]
+                    }
+                }
+            },
+            "required": [
+                "collections",
+                "frontProperties",
+                "id",
+                "seoData"
+            ]
+        },
+        "Record<string,unknown>": {
+            "type": "object"
+        },
+        "FEDesign": {
+            "enum": [
+                "AnalysisDesign",
+                "ArticleDesign",
+                "AudioDesign",
+                "CommentDesign",
+                "DeadBlogDesign",
+                "EditorialDesign",
+                "ExplainerDesign",
+                "FeatureDesign",
+                "FullPageInteractiveDesign",
+                "GalleryDesign",
+                "InteractiveDesign",
+                "InterviewDesign",
+                "LetterDesign",
+                "LiveBlogDesign",
+                "MatchReportDesign",
+                "NewsletterSignupDesign",
+                "ObituaryDesign",
+                "PhotoEssayDesign",
+                "PrintShopDesign",
+                "ProfileDesign",
+                "QuizDesign",
+                "RecipeDesign",
+                "ReviewDesign",
+                "TimelineDesign",
+                "VideoDesign"
+            ],
+            "type": "string"
+        },
+        "FETheme": {
+            "enum": [
+                "CulturePillar",
+                "Labs",
+                "LifestylePillar",
+                "NewsPillar",
+                "OpinionPillar",
+                "SpecialReportAltTheme",
+                "SpecialReportTheme",
+                "SportPillar"
+            ],
+            "type": "string"
+        },
+        "FEDisplay": {
+            "enum": [
+                "ImmersiveDisplay",
+                "NumberedListDisplay",
+                "ShowcaseDisplay",
+                "StandardDisplay"
+            ],
+            "type": "string"
+        },
+        "FEMediaAtoms": {
+            "type": "object",
+            "properties": {
+                "duration": {
+                    "type": "number"
+                }
+            }
+        },
+        "EditionId": {
+            "enum": [
+                "AU",
+                "EUR",
+                "INT",
+                "UK",
+                "US"
+            ],
+            "type": "string"
+        },
+        "Branding": {
+            "type": "object",
+            "properties": {
+                "brandingType": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "name"
+                    ]
+                },
+                "sponsorName": {
+                    "type": "string"
+                },
+                "logo": {
+                    "type": "object",
+                    "properties": {
+                        "src": {
+                            "type": "string"
+                        },
+                        "link": {
+                            "type": "string"
+                        },
+                        "label": {
+                            "type": "string"
+                        },
+                        "dimensions": {
+                            "type": "object",
+                            "properties": {
+                                "width": {
+                                    "type": "number"
+                                },
+                                "height": {
+                                    "type": "number"
+                                }
+                            },
+                            "required": [
+                                "height",
+                                "width"
+                            ]
+                        }
+                    },
+                    "required": [
+                        "dimensions",
+                        "label",
+                        "link",
+                        "src"
+                    ]
+                },
+                "aboutThisLink": {
+                    "type": "string"
+                },
+                "logoForDarkBackground": {
+                    "type": "object",
+                    "properties": {
+                        "src": {
+                            "type": "string"
+                        },
+                        "link": {
+                            "type": "string"
+                        },
+                        "label": {
+                            "type": "string"
+                        },
+                        "dimensions": {
+                            "type": "object",
+                            "properties": {
+                                "width": {
+                                    "type": "number"
+                                },
+                                "height": {
+                                    "type": "number"
+                                }
+                            },
+                            "required": [
+                                "height",
+                                "width"
+                            ]
+                        }
+                    },
+                    "required": [
+                        "dimensions",
+                        "label",
+                        "link",
+                        "src"
+                    ]
+                }
+            },
+            "required": [
+                "aboutThisLink",
+                "logo",
+                "sponsorName"
+            ]
+        },
+        "FEFrontCardStyle": {
+            "enum": [
+                "Analysis",
+                "Comment",
+                "DeadBlog",
+                "DefaultCardstyle",
+                "Editorial",
+                "ExternalLink",
+                "Feature",
+                "Letters",
+                "LiveBlog",
+                "Media",
+                "Review",
+                "SpecialReport",
+                "SpecialReportAlt"
+            ],
+            "type": "string"
+        },
+        "FEContainerType": {
+            "enum": [
+                "dynamic/fast",
+                "dynamic/package",
+                "dynamic/slow",
+                "dynamic/slow-mpu",
+                "fixed/large/slow-XIV",
+                "fixed/medium/fast-XI",
+                "fixed/medium/fast-XII",
+                "fixed/medium/slow-VI",
+                "fixed/medium/slow-VII",
+                "fixed/medium/slow-XII-mpu",
+                "fixed/small/fast-VIII",
+                "fixed/small/slow-I",
+                "fixed/small/slow-III",
+                "fixed/small/slow-IV",
+                "fixed/small/slow-V-half",
+                "fixed/small/slow-V-mpu",
+                "fixed/small/slow-V-third",
+                "fixed/thrasher",
+                "fixed/video",
+                "fixed/video/vertical",
+                "nav/list",
+                "nav/media-list",
+                "news/most-popular"
+            ],
+            "type": "string"
+        },
+        "FEContainerPalette": {
+            "enum": [
+                "Branded",
+                "Breaking",
+                "BreakingPalette",
+                "Canonical",
+                "Dynamo",
+                "DynamoLike",
+                "EventAltPalette",
+                "EventPalette",
+                "InvestigationPalette",
+                "LongRunningAltPalette",
+                "LongRunningPalette",
+                "Podcast",
+                "SombreAltPalette",
+                "SombrePalette",
+                "Special",
+                "SpecialReportAltPalette"
+            ],
+            "type": "string"
+        },
+        "Territory": {
+            "description": "List of territories that can be targetted against.",
+            "enum": [
+                "AU-NSW",
+                "AU-QLD",
+                "AU-VIC",
+                "EU-27",
+                "NZ",
+                "US-East-Coast",
+                "US-West-Coast",
+                "XX"
+            ],
+            "type": "string"
+        },
+        "FENavType": {
+            "type": "object",
+            "properties": {
+                "currentUrl": {
+                    "type": "string"
+                },
+                "pillars": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/FELinkType"
+                    }
+                },
+                "otherLinks": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/FELinkType"
+                    }
+                },
+                "brandExtensions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/FELinkType"
+                    }
+                },
+                "currentNavLink": {
+                    "$ref": "#/definitions/FELinkType"
+                },
+                "currentNavLinkTitle": {
+                    "type": "string"
+                },
+                "currentPillarTitle": {
+                    "type": "string"
+                },
+                "subNavSections": {
+                    "type": "object",
+                    "properties": {
+                        "parent": {
+                            "$ref": "#/definitions/FELinkType"
+                        },
+                        "links": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/FELinkType"
+                            }
+                        }
+                    },
+                    "required": [
+                        "links"
+                    ]
+                },
+                "readerRevenueLinks": {
+                    "$ref": "#/definitions/ReaderRevenuePositions"
+                }
+            },
+            "required": [
+                "brandExtensions",
+                "currentUrl",
+                "otherLinks",
+                "pillars",
+                "readerRevenueLinks"
+            ]
+        },
+        "FELinkType": {
+            "type": "object",
+            "properties": {
+                "url": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "longTitle": {
+                    "type": "string"
+                },
+                "iconName": {
+                    "type": "string"
+                },
+                "children": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/FELinkType"
+                    }
+                },
+                "pillar": {
+                    "$ref": "#/definitions/LegacyPillar"
+                },
+                "more": {
+                    "type": "boolean"
+                },
+                "classList": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "title",
+                "url"
+            ]
+        },
+        "LegacyPillar": {
+            "enum": [
+                "culture",
+                "labs",
+                "lifestyle",
+                "news",
+                "opinion",
+                "sport"
+            ],
+            "type": "string"
+        },
+        "ReaderRevenuePositions": {
+            "type": "object",
+            "properties": {
+                "header": {
+                    "$ref": "#/definitions/ReaderRevenueCategories"
+                },
+                "footer": {
+                    "$ref": "#/definitions/ReaderRevenueCategories"
+                },
+                "sideMenu": {
+                    "$ref": "#/definitions/ReaderRevenueCategories"
+                },
+                "ampHeader": {
+                    "$ref": "#/definitions/ReaderRevenueCategories"
+                },
+                "ampFooter": {
+                    "$ref": "#/definitions/ReaderRevenueCategories"
+                }
+            },
+            "required": [
+                "ampFooter",
+                "ampHeader",
+                "footer",
+                "header",
+                "sideMenu"
+            ]
+        },
+        "ReaderRevenueCategories": {
+            "type": "object",
+            "properties": {
+                "contribute": {
+                    "type": "string"
+                },
+                "subscribe": {
+                    "type": "string"
+                },
+                "support": {
+                    "type": "string"
+                },
+                "supporter": {
+                    "type": "string"
+                },
+                "gifting": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "contribute",
+                "subscribe",
+                "support",
+                "supporter"
+            ]
+        },
+        "Switches": {
+            "type": "object",
+            "additionalProperties": {
+                "type": "boolean"
+            }
+        },
+        "StageType": {
+            "enum": [
+                "CODE",
+                "DEV",
+                "PROD"
+            ],
+            "type": "string"
+        },
+        "FooterType": {
+            "type": "object",
+            "properties": {
+                "footerLinks": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/definitions/FooterLink"
+                        }
+                    }
+                }
+            },
+            "required": [
+                "footerLinks"
+            ]
+        },
+        "FooterLink": {
+            "type": "object",
+            "properties": {
+                "text": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                },
+                "dataLinkName": {
+                    "type": "string"
+                },
+                "extraClasses": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "dataLinkName",
+                "text",
+                "url"
+            ]
+        },
+        "FETrailType": {
+            "type": "object",
+            "properties": {
+                "format": {
+                    "type": "object",
+                    "properties": {
+                        "design": {
+                            "$ref": "#/definitions/FEDesign"
+                        },
+                        "theme": {
+                            "$ref": "#/definitions/FETheme"
+                        },
+                        "display": {
+                            "$ref": "#/definitions/FEDisplay"
+                        }
+                    },
+                    "required": [
+                        "design",
+                        "display",
+                        "theme"
+                    ]
+                },
+                "designType": {
+                    "type": "string"
+                },
+                "pillar": {
+                    "type": "string"
+                },
+                "carouselImages": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "isLiveBlog": {
+                    "type": "boolean"
+                },
+                "masterImage": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                },
+                "headline": {
+                    "type": "string"
+                },
+                "webPublicationDate": {
+                    "type": "string"
+                },
+                "image": {
+                    "type": "string"
+                },
+                "avatarUrl": {
+                    "type": "string"
+                },
+                "mediaType": {
+                    "$ref": "#/definitions/MediaType"
+                },
+                "mediaDuration": {
+                    "type": "number"
+                },
+                "ageWarning": {
+                    "type": "string"
+                },
+                "byline": {
+                    "type": "string"
+                },
+                "showByline": {
+                    "type": "boolean"
+                },
+                "kickerText": {
+                    "type": "string"
+                },
+                "shortUrl": {
+                    "type": "string"
+                },
+                "commentCount": {
+                    "type": "number"
+                },
+                "starRating": {
+                    "type": "number"
+                },
+                "linkText": {
+                    "type": "string"
+                },
+                "branding": {
+                    "$ref": "#/definitions/Branding"
+                },
+                "isSnap": {
+                    "type": "boolean"
+                },
+                "isCrossword": {
+                    "type": "boolean"
+                },
+                "snapData": {
+                    "type": "object",
+                    "properties": {
+                        "embedHtml": {
+                            "type": "string"
+                        },
+                        "embedCss": {
+                            "type": "string"
+                        },
+                        "embedJs": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "showQuotedHeadline": {
+                    "type": "boolean"
+                },
+                "discussion": {
+                    "type": "object",
+                    "properties": {
+                        "isCommentable": {
+                            "type": "boolean"
+                        },
+                        "isClosedForComments": {
+                            "type": "boolean"
+                        },
+                        "discussionId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "isClosedForComments",
+                        "isCommentable"
+                    ]
+                },
+                "showMainVideo": {
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "format",
+                "headline",
+                "url"
+            ]
+        },
+        "MediaType": {
+            "enum": [
+                "Audio",
+                "Gallery",
+                "Video"
+            ],
+            "type": "string"
+        }
+    },
+    "$schema": "http://json-schema.org/draft-07/schema#"
 }

--- a/dotcom-rendering/src/model/front-schema.json
+++ b/dotcom-rendering/src/model/front-schema.json
@@ -1,3402 +1,3403 @@
 {
-    "type": "object",
-    "properties": {
-        "pressedPage": {
-            "$ref": "#/definitions/FEPressedPageType"
-        },
-        "nav": {
-            "$ref": "#/definitions/FENavType"
-        },
-        "editionId": {
-            "$ref": "#/definitions/EditionId"
-        },
-        "editionLongForm": {
-            "type": "string"
-        },
-        "guardianBaseURL": {
-            "type": "string"
-        },
-        "pageId": {
-            "type": "string"
-        },
-        "webTitle": {
-            "type": "string"
-        },
-        "webURL": {
-            "type": "string"
-        },
-        "config": {
-            "type": "object",
-            "properties": {
-                "avatarApiUrl": {
-                    "type": "string"
-                },
-                "externalEmbedHost": {
-                    "type": "string"
-                },
-                "ajaxUrl": {
-                    "type": "string"
-                },
-                "keywords": {
-                    "type": "string"
-                },
-                "revisionNumber": {
-                    "type": "string"
-                },
-                "isProd": {
-                    "type": "boolean"
-                },
-                "switches": {
-                    "$ref": "#/definitions/Switches"
-                },
-                "section": {
-                    "type": "string"
-                },
-                "keywordIds": {
-                    "type": "string"
-                },
-                "locationapiurl": {
-                    "type": "string"
-                },
-                "sharedAdTargeting": {
-                    "type": "object",
-                    "additionalProperties": {}
-                },
-                "buildNumber": {
-                    "type": "string"
-                },
-                "abTests": {
-                    "description": "Narrowest representation of the server-side tests\nobject shape, which is [defined in `frontend`](https://github.com/guardian/frontend/blob/23743723030a041e4f4f59fa265ee2be0bb51825/common/app/experiments/ExperimentsDefinition.scala#L24-L26).\n\n**Note:** This type is not support by JSON-schema, it evaluates as `object`",
-                    "type": "object"
-                },
-                "pbIndexSites": {
-                    "type": "array",
-                    "items": {
-                        "type": "object",
-                        "additionalProperties": {}
-                    }
-                },
-                "ampIframeUrl": {
-                    "type": "string"
-                },
-                "beaconUrl": {
-                    "type": "string"
-                },
-                "userAttributesApiUrl": {
-                    "type": "string"
-                },
-                "host": {
-                    "type": "string"
-                },
-                "brazeApiKey": {
-                    "type": "string"
-                },
-                "calloutsUrl": {
-                    "type": "string"
-                },
-                "requiresMembershipAccess": {
-                    "type": "boolean"
-                },
-                "onwardWebSocket": {
-                    "type": "string"
-                },
-                "a9PublisherId": {
-                    "type": "string"
-                },
-                "contentType": {
-                    "type": "string"
-                },
-                "facebookIaAdUnitRoot": {
-                    "type": "string"
-                },
-                "ophanEmbedJsUrl": {
-                    "type": "string"
-                },
-                "idUrl": {
-                    "type": "string"
-                },
-                "dcrSentryDsn": {
-                    "type": "string"
-                },
-                "isFront": {
-                    "type": "boolean",
-                    "enum": [
-                        true
-                    ]
-                },
-                "idWebAppUrl": {
-                    "type": "string"
-                },
-                "discussionApiUrl": {
-                    "type": "string"
-                },
-                "sentryPublicApiKey": {
-                    "type": "string"
-                },
-                "omnitureAccount": {
-                    "type": "string"
-                },
-                "dfpAccountId": {
-                    "type": "string"
-                },
-                "pageId": {
-                    "type": "string"
-                },
-                "forecastsapiurl": {
-                    "type": "string"
-                },
-                "assetsPath": {
-                    "type": "string"
-                },
-                "pillar": {
-                    "type": "string"
-                },
-                "commercialBundleUrl": {
-                    "type": "string"
-                },
-                "discussionApiClientHeader": {
-                    "type": "string"
-                },
-                "membershipUrl": {
-                    "type": "string"
-                },
-                "dfpHost": {
-                    "type": "string"
-                },
-                "cardStyle": {
-                    "type": "string"
-                },
-                "googletagUrl": {
-                    "type": "string"
-                },
-                "sentryHost": {
-                    "type": "string"
-                },
-                "shouldHideAdverts": {
-                    "type": "boolean"
-                },
-                "mmaUrl": {
-                    "type": "string"
-                },
-                "membershipAccess": {
-                    "type": "string"
-                },
-                "isPreview": {
-                    "type": "boolean"
-                },
-                "googletagJsUrl": {
-                    "type": "string"
-                },
-                "supportUrl": {
-                    "type": "string"
-                },
-                "edition": {
-                    "type": "string"
-                },
-                "discussionFrontendUrl": {
-                    "type": "string"
-                },
-                "ipsosTag": {
-                    "type": "string"
-                },
-                "ophanJsUrl": {
-                    "type": "string"
-                },
-                "isPaidContent": {
-                    "type": "boolean"
-                },
-                "mobileAppsAdUnitRoot": {
-                    "type": "string"
-                },
-                "plistaPublicApiKey": {
-                    "type": "string"
-                },
-                "frontendAssetsFullURL": {
-                    "type": "string"
-                },
-                "googleSearchId": {
-                    "type": "string"
-                },
-                "allowUserGeneratedContent": {
-                    "type": "boolean"
-                },
-                "dfpAdUnitRoot": {
-                    "type": "string"
-                },
-                "idApiUrl": {
-                    "type": "string"
-                },
-                "omnitureAmpAccount": {
-                    "type": "string"
-                },
-                "adUnit": {
-                    "type": "string"
-                },
-                "hasPageSkin": {
-                    "type": "boolean"
-                },
-                "webTitle": {
-                    "type": "string"
-                },
-                "stripePublicToken": {
-                    "type": "string"
-                },
-                "googleRecaptchaSiteKey": {
-                    "type": "string"
-                },
-                "discussionD2Uid": {
-                    "type": "string"
-                },
-                "weatherapiurl": {
-                    "type": "string"
-                },
-                "googleSearchUrl": {
-                    "type": "string"
-                },
-                "optimizeEpicUrl": {
-                    "type": "string"
-                },
-                "stage": {
-                    "$ref": "#/definitions/StageType"
-                },
-                "idOAuthUrl": {
-                    "type": "string"
-                },
-                "isSensitive": {
-                    "type": "boolean"
-                },
-                "isDev": {
-                    "type": "boolean"
-                },
-                "thirdPartyAppsAccount": {
-                    "type": "string"
-                },
-                "avatarImagesUrl": {
-                    "type": "string"
-                },
-                "fbAppId": {
-                    "type": "string"
-                }
-            },
-            "required": [
-                "a9PublisherId",
-                "abTests",
-                "adUnit",
-                "ajaxUrl",
-                "allowUserGeneratedContent",
-                "ampIframeUrl",
-                "assetsPath",
-                "avatarApiUrl",
-                "avatarImagesUrl",
-                "beaconUrl",
-                "buildNumber",
-                "calloutsUrl",
-                "commercialBundleUrl",
-                "contentType",
-                "dcrSentryDsn",
-                "dfpAccountId",
-                "dfpAdUnitRoot",
-                "dfpHost",
-                "discussionApiClientHeader",
-                "discussionApiUrl",
-                "discussionD2Uid",
-                "discussionFrontendUrl",
-                "edition",
-                "externalEmbedHost",
-                "facebookIaAdUnitRoot",
-                "fbAppId",
-                "forecastsapiurl",
-                "frontendAssetsFullURL",
-                "googleRecaptchaSiteKey",
-                "googleSearchId",
-                "googleSearchUrl",
-                "googletagJsUrl",
-                "googletagUrl",
-                "hasPageSkin",
-                "host",
-                "idApiUrl",
-                "idOAuthUrl",
-                "idUrl",
-                "idWebAppUrl",
-                "ipsosTag",
-                "isDev",
-                "isFront",
-                "isPreview",
-                "isProd",
-                "isSensitive",
-                "keywordIds",
-                "keywords",
-                "locationapiurl",
-                "membershipAccess",
-                "membershipUrl",
-                "mmaUrl",
-                "mobileAppsAdUnitRoot",
-                "omnitureAccount",
-                "omnitureAmpAccount",
-                "onwardWebSocket",
-                "ophanEmbedJsUrl",
-                "ophanJsUrl",
-                "optimizeEpicUrl",
-                "pageId",
-                "pbIndexSites",
-                "pillar",
-                "plistaPublicApiKey",
-                "requiresMembershipAccess",
-                "revisionNumber",
-                "section",
-                "sentryHost",
-                "sentryPublicApiKey",
-                "sharedAdTargeting",
-                "shouldHideAdverts",
-                "stage",
-                "stripePublicToken",
-                "supportUrl",
-                "switches",
-                "userAttributesApiUrl",
-                "weatherapiurl",
-                "webTitle"
-            ]
-        },
-        "commercialProperties": {
-            "$ref": "#/definitions/Record<string,unknown>"
-        },
-        "pageFooter": {
-            "$ref": "#/definitions/FooterType"
-        },
-        "isAdFreeUser": {
-            "type": "boolean"
-        },
-        "isNetworkFront": {
-            "type": "boolean"
-        },
-        "mostViewed": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/FETrailType"
-            }
-        },
-        "mostCommented": {
-            "$ref": "#/definitions/FETrailType"
-        },
-        "mostShared": {
-            "$ref": "#/definitions/FETrailType"
-        },
-        "deeplyRead": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/FETrailType"
-            }
-        }
-    },
-    "required": [
-        "commercialProperties",
-        "config",
-        "editionId",
-        "editionLongForm",
-        "guardianBaseURL",
-        "isAdFreeUser",
-        "isNetworkFront",
-        "mostViewed",
-        "nav",
-        "pageFooter",
-        "pageId",
-        "pressedPage",
-        "webTitle",
-        "webURL"
-    ],
-    "definitions": {
-        "FEPressedPageType": {
-            "type": "object",
-            "properties": {
-                "id": {
-                    "type": "string"
-                },
-                "seoData": {
-                    "type": "object",
-                    "properties": {
-                        "id": {
-                            "type": "string"
-                        },
-                        "navSection": {
-                            "type": "string"
-                        },
-                        "webTitle": {
-                            "type": "string"
-                        },
-                        "title": {
-                            "type": "string"
-                        },
-                        "description": {
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "description",
-                        "id",
-                        "navSection",
-                        "webTitle"
-                    ]
-                },
-                "frontProperties": {
-                    "type": "object",
-                    "properties": {
-                        "isImageDisplayed": {
-                            "type": "boolean"
-                        },
-                        "commercial": {
-                            "$ref": "#/definitions/Record<string,unknown>"
-                        },
-                        "isPaidContent": {
-                            "type": "boolean"
-                        },
-                        "onPageDescription": {
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "commercial",
-                        "isImageDisplayed"
-                    ]
-                },
-                "collections": {
-                    "type": "array",
-                    "items": {
-                        "type": "object",
-                        "properties": {
-                            "id": {
-                                "type": "string"
-                            },
-                            "displayName": {
-                                "type": "string"
-                            },
-                            "description": {
-                                "type": "string"
-                            },
-                            "curated": {
-                                "type": "array",
-                                "items": {
-                                    "type": "object",
-                                    "properties": {
-                                        "properties": {
-                                            "type": "object",
-                                            "properties": {
-                                                "isBreaking": {
-                                                    "type": "boolean"
-                                                },
-                                                "showMainVideo": {
-                                                    "type": "boolean"
-                                                },
-                                                "showKickerTag": {
-                                                    "type": "boolean"
-                                                },
-                                                "showByline": {
-                                                    "type": "boolean"
-                                                },
-                                                "imageSlideshowReplace": {
-                                                    "type": "boolean"
-                                                },
-                                                "maybeContent": {
-                                                    "type": "object",
-                                                    "properties": {
-                                                        "trail": {
-                                                            "type": "object",
-                                                            "properties": {
-                                                                "trailPicture": {
-                                                                    "type": "object",
-                                                                    "properties": {
-                                                                        "allImages": {
-                                                                            "type": "array",
-                                                                            "items": {
-                                                                                "type": "object",
-                                                                                "properties": {
-                                                                                    "index": {
-                                                                                        "type": "number"
-                                                                                    },
-                                                                                    "fields": {
-                                                                                        "type": "object",
-                                                                                        "properties": {
-                                                                                            "displayCredit": {
-                                                                                                "type": "string"
-                                                                                            },
-                                                                                            "source": {
-                                                                                                "type": "string"
-                                                                                            },
-                                                                                            "photographer": {
-                                                                                                "type": "string"
-                                                                                            },
-                                                                                            "isMaster": {
-                                                                                                "type": "string"
-                                                                                            },
-                                                                                            "altText": {
-                                                                                                "type": "string"
-                                                                                            },
-                                                                                            "height": {
-                                                                                                "type": "string"
-                                                                                            },
-                                                                                            "credit": {
-                                                                                                "type": "string"
-                                                                                            },
-                                                                                            "mediaId": {
-                                                                                                "type": "string"
-                                                                                            },
-                                                                                            "width": {
-                                                                                                "type": "string"
-                                                                                            }
-                                                                                        },
-                                                                                        "required": [
-                                                                                            "height",
-                                                                                            "width"
-                                                                                        ]
-                                                                                    },
-                                                                                    "mediaType": {
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "url": {
-                                                                                        "type": "string"
-                                                                                    }
-                                                                                },
-                                                                                "required": [
-                                                                                    "fields",
-                                                                                    "index",
-                                                                                    "mediaType",
-                                                                                    "url"
-                                                                                ]
-                                                                            }
-                                                                        }
-                                                                    },
-                                                                    "required": [
-                                                                        "allImages"
-                                                                    ]
-                                                                },
-                                                                "byline": {
-                                                                    "type": "string"
-                                                                },
-                                                                "thumbnailPath": {
-                                                                    "type": "string"
-                                                                },
-                                                                "webPublicationDate": {
-                                                                    "type": "number"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "webPublicationDate"
-                                                            ]
-                                                        },
-                                                        "metadata": {
-                                                            "type": "object",
-                                                            "properties": {
-                                                                "id": {
-                                                                    "type": "string"
-                                                                },
-                                                                "webTitle": {
-                                                                    "type": "string"
-                                                                },
-                                                                "webUrl": {
-                                                                    "type": "string"
-                                                                },
-                                                                "type": {
-                                                                    "type": "string"
-                                                                },
-                                                                "sectionId": {
-                                                                    "type": "object",
-                                                                    "properties": {
-                                                                        "value": {
-                                                                            "type": "string"
-                                                                        }
-                                                                    },
-                                                                    "required": [
-                                                                        "value"
-                                                                    ]
-                                                                },
-                                                                "format": {
-                                                                    "type": "object",
-                                                                    "properties": {
-                                                                        "design": {
-                                                                            "$ref": "#/definitions/FEDesign"
-                                                                        },
-                                                                        "theme": {
-                                                                            "$ref": "#/definitions/FETheme"
-                                                                        },
-                                                                        "display": {
-                                                                            "$ref": "#/definitions/FEDisplay"
-                                                                        }
-                                                                    },
-                                                                    "required": [
-                                                                        "design",
-                                                                        "display",
-                                                                        "theme"
-                                                                    ]
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "format",
-                                                                "id",
-                                                                "type",
-                                                                "webTitle",
-                                                                "webUrl"
-                                                            ]
-                                                        },
-                                                        "fields": {
-                                                            "type": "object",
-                                                            "properties": {
-                                                                "main": {
-                                                                    "type": "string"
-                                                                },
-                                                                "body": {
-                                                                    "type": "string"
-                                                                },
-                                                                "standfirst": {
-                                                                    "type": "string"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "body",
-                                                                "main"
-                                                            ]
-                                                        },
-                                                        "elements": {
-                                                            "type": "object",
-                                                            "properties": {
-                                                                "mainVideo": {},
-                                                                "mediaAtoms": {
-                                                                    "type": "array",
-                                                                    "items": {
-                                                                        "$ref": "#/definitions/FEMediaAtoms"
-                                                                    }
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "mediaAtoms"
-                                                            ]
-                                                        },
-                                                        "tags": {
-                                                            "type": "object",
-                                                            "properties": {
-                                                                "tags": {
-                                                                    "type": "array",
-                                                                    "items": {
-                                                                        "description": "This type comes from `frontend`, hence the FE prefix.",
-                                                                        "type": "object",
-                                                                        "properties": {
-                                                                            "properties": {
-                                                                                "type": "object",
-                                                                                "properties": {
-                                                                                    "id": {
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "tagType": {
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "webTitle": {
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "bio": {
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "bylineImageUrl": {
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "bylineLargeImageUrl": {
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "contributorLargeImagePath": {
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "paidContentType": {
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "sectionId": {
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "sectionName": {
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "twitterHandle": {
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "url": {
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "webUrl": {
-                                                                                        "type": "string"
-                                                                                    }
-                                                                                },
-                                                                                "required": [
-                                                                                    "id",
-                                                                                    "tagType",
-                                                                                    "webTitle"
-                                                                                ]
-                                                                            },
-                                                                            "pagination": {
-                                                                                "type": "object",
-                                                                                "properties": {
-                                                                                    "currentPage": {
-                                                                                        "type": "number"
-                                                                                    },
-                                                                                    "lastPage": {
-                                                                                        "type": "number"
-                                                                                    },
-                                                                                    "totalContent": {
-                                                                                        "type": "number"
-                                                                                    }
-                                                                                },
-                                                                                "required": [
-                                                                                    "currentPage",
-                                                                                    "lastPage",
-                                                                                    "totalContent"
-                                                                                ]
-                                                                            }
-                                                                        },
-                                                                        "required": [
-                                                                            "properties"
-                                                                        ]
-                                                                    }
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "tags"
-                                                            ]
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "elements",
-                                                        "fields",
-                                                        "metadata",
-                                                        "tags",
-                                                        "trail"
-                                                    ]
-                                                },
-                                                "maybeContentId": {
-                                                    "type": "string"
-                                                },
-                                                "isLiveBlog": {
-                                                    "type": "boolean"
-                                                },
-                                                "isCrossword": {
-                                                    "type": "boolean"
-                                                },
-                                                "byline": {
-                                                    "type": "string"
-                                                },
-                                                "image": {
-                                                    "type": "object",
-                                                    "properties": {
-                                                        "type": {
-                                                            "type": "string"
-                                                        },
-                                                        "item": {
-                                                            "type": "object",
-                                                            "properties": {
-                                                                "imageSrc": {
-                                                                    "type": "string"
-                                                                },
-                                                                "assets": {
-                                                                    "type": "array",
-                                                                    "items": {
-                                                                        "type": "object",
-                                                                        "properties": {
-                                                                            "imageSrc": {
-                                                                                "type": "string"
-                                                                            },
-                                                                            "imageCaption": {
-                                                                                "type": "string"
-                                                                            }
-                                                                        },
-                                                                        "required": [
-                                                                            "imageSrc"
-                                                                        ]
-                                                                    }
-                                                                }
-                                                            }
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "item",
-                                                        "type"
-                                                    ]
-                                                },
-                                                "webTitle": {
-                                                    "type": "string"
-                                                },
-                                                "linkText": {
-                                                    "type": "string"
-                                                },
-                                                "webUrl": {
-                                                    "type": "string"
-                                                },
-                                                "editionBrandings": {
-                                                    "type": "array",
-                                                    "items": {
-                                                        "type": "object",
-                                                        "properties": {
-                                                            "edition": {
-                                                                "type": "object",
-                                                                "properties": {
-                                                                    "id": {
-                                                                        "$ref": "#/definitions/EditionId"
-                                                                    }
-                                                                },
-                                                                "required": [
-                                                                    "id"
-                                                                ]
-                                                            },
-                                                            "branding": {
-                                                                "$ref": "#/definitions/Branding"
-                                                            }
-                                                        },
-                                                        "required": [
-                                                            "edition"
-                                                        ]
-                                                    }
-                                                },
-                                                "href": {
-                                                    "type": "string"
-                                                },
-                                                "embedUri": {
-                                                    "type": "string"
-                                                }
-                                            },
-                                            "required": [
-                                                "editionBrandings",
-                                                "imageSlideshowReplace",
-                                                "isBreaking",
-                                                "isCrossword",
-                                                "isLiveBlog",
-                                                "showByline",
-                                                "showKickerTag",
-                                                "showMainVideo",
-                                                "webTitle"
-                                            ]
-                                        },
-                                        "header": {
-                                            "type": "object",
-                                            "properties": {
-                                                "isVideo": {
-                                                    "type": "boolean"
-                                                },
-                                                "isComment": {
-                                                    "type": "boolean"
-                                                },
-                                                "isGallery": {
-                                                    "type": "boolean"
-                                                },
-                                                "isAudio": {
-                                                    "type": "boolean"
-                                                },
-                                                "kicker": {
-                                                    "type": "object",
-                                                    "properties": {
-                                                        "type": {
-                                                            "type": "string"
-                                                        },
-                                                        "item": {
-                                                            "type": "object",
-                                                            "properties": {
-                                                                "properties": {
-                                                                    "type": "object",
-                                                                    "properties": {
-                                                                        "kickerText": {
-                                                                            "type": "string"
-                                                                        }
-                                                                    },
-                                                                    "required": [
-                                                                        "kickerText"
-                                                                    ]
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "properties"
-                                                            ]
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "type"
-                                                    ]
-                                                },
-                                                "seriesOrBlogKicker": {
-                                                    "type": "object",
-                                                    "properties": {
-                                                        "properties": {
-                                                            "type": "object",
-                                                            "properties": {
-                                                                "kickerText": {
-                                                                    "type": "string"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "kickerText"
-                                                            ]
-                                                        },
-                                                        "name": {
-                                                            "type": "string"
-                                                        },
-                                                        "url": {
-                                                            "type": "string"
-                                                        },
-                                                        "id": {
-                                                            "type": "string"
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "id",
-                                                        "name",
-                                                        "properties",
-                                                        "url"
-                                                    ]
-                                                },
-                                                "headline": {
-                                                    "type": "string"
-                                                },
-                                                "url": {
-                                                    "type": "string"
-                                                },
-                                                "hasMainVideoElement": {
-                                                    "type": "boolean"
-                                                }
-                                            },
-                                            "required": [
-                                                "hasMainVideoElement",
-                                                "headline",
-                                                "isAudio",
-                                                "isComment",
-                                                "isGallery",
-                                                "isVideo",
-                                                "url"
-                                            ]
-                                        },
-                                        "card": {
-                                            "type": "object",
-                                            "properties": {
-                                                "id": {
-                                                    "type": "string"
-                                                },
-                                                "cardStyle": {
-                                                    "type": "object",
-                                                    "properties": {
-                                                        "type": {
-                                                            "$ref": "#/definitions/FEFrontCardStyle"
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "type"
-                                                    ]
-                                                },
-                                                "webPublicationDateOption": {
-                                                    "type": "number"
-                                                },
-                                                "lastModifiedOption": {
-                                                    "type": "number"
-                                                },
-                                                "trailText": {
-                                                    "type": "string"
-                                                },
-                                                "starRating": {
-                                                    "type": "number"
-                                                },
-                                                "shortUrlPath": {
-                                                    "type": "string"
-                                                },
-                                                "shortUrl": {
-                                                    "type": "string"
-                                                },
-                                                "group": {
-                                                    "type": "string"
-                                                },
-                                                "isLive": {
-                                                    "type": "boolean"
-                                                }
-                                            },
-                                            "required": [
-                                                "cardStyle",
-                                                "group",
-                                                "id",
-                                                "isLive",
-                                                "shortUrl"
-                                            ]
-                                        },
-                                        "discussion": {
-                                            "type": "object",
-                                            "properties": {
-                                                "isCommentable": {
-                                                    "type": "boolean"
-                                                },
-                                                "isClosedForComments": {
-                                                    "type": "boolean"
-                                                },
-                                                "discussionId": {
-                                                    "type": "string"
-                                                }
-                                            },
-                                            "required": [
-                                                "isClosedForComments",
-                                                "isCommentable"
-                                            ]
-                                        },
-                                        "display": {
-                                            "type": "object",
-                                            "properties": {
-                                                "isBoosted": {
-                                                    "type": "boolean"
-                                                },
-                                                "showBoostedHeadline": {
-                                                    "type": "boolean"
-                                                },
-                                                "showQuotedHeadline": {
-                                                    "type": "boolean"
-                                                },
-                                                "imageHide": {
-                                                    "type": "boolean"
-                                                },
-                                                "showLivePlayable": {
-                                                    "type": "boolean"
-                                                }
-                                            },
-                                            "required": [
-                                                "imageHide",
-                                                "isBoosted",
-                                                "showBoostedHeadline",
-                                                "showLivePlayable",
-                                                "showQuotedHeadline"
-                                            ]
-                                        },
-                                        "format": {
-                                            "type": "object",
-                                            "properties": {
-                                                "design": {
-                                                    "$ref": "#/definitions/FEDesign"
-                                                },
-                                                "theme": {
-                                                    "$ref": "#/definitions/FETheme"
-                                                },
-                                                "display": {
-                                                    "$ref": "#/definitions/FEDisplay"
-                                                }
-                                            },
-                                            "required": [
-                                                "design",
-                                                "display",
-                                                "theme"
-                                            ]
-                                        },
-                                        "enriched": {
-                                            "type": "object",
-                                            "properties": {
-                                                "embedHtml": {
-                                                    "type": "string"
-                                                },
-                                                "embedCss": {
-                                                    "type": "string"
-                                                },
-                                                "embedJs": {
-                                                    "type": "string"
-                                                }
-                                            }
-                                        },
-                                        "supportingContent": {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "properties": {
-                                                        "type": "object",
-                                                        "properties": {
-                                                            "href": {
-                                                                "type": "string"
-                                                            }
-                                                        }
-                                                    },
-                                                    "header": {
-                                                        "type": "object",
-                                                        "properties": {
-                                                            "kicker": {
-                                                                "type": "object",
-                                                                "properties": {
-                                                                    "item": {
-                                                                        "type": "object",
-                                                                        "properties": {
-                                                                            "properties": {
-                                                                                "type": "object",
-                                                                                "properties": {
-                                                                                    "kickerText": {
-                                                                                        "type": "string"
-                                                                                    }
-                                                                                },
-                                                                                "required": [
-                                                                                    "kickerText"
-                                                                                ]
-                                                                            }
-                                                                        },
-                                                                        "required": [
-                                                                            "properties"
-                                                                        ]
-                                                                    }
-                                                                }
-                                                            },
-                                                            "headline": {
-                                                                "type": "string"
-                                                            },
-                                                            "url": {
-                                                                "type": "string"
-                                                            }
-                                                        },
-                                                        "required": [
-                                                            "headline",
-                                                            "url"
-                                                        ]
-                                                    },
-                                                    "format": {
-                                                        "type": "object",
-                                                        "properties": {
-                                                            "design": {
-                                                                "$ref": "#/definitions/FEDesign"
-                                                            },
-                                                            "theme": {
-                                                                "$ref": "#/definitions/FETheme"
-                                                            },
-                                                            "display": {
-                                                                "$ref": "#/definitions/FEDisplay"
-                                                            }
-                                                        },
-                                                        "required": [
-                                                            "design",
-                                                            "display",
-                                                            "theme"
-                                                        ]
-                                                    }
-                                                },
-                                                "required": [
-                                                    "properties"
-                                                ]
-                                            }
-                                        },
-                                        "cardStyle": {
-                                            "type": "object",
-                                            "properties": {
-                                                "type": {
-                                                    "$ref": "#/definitions/FEFrontCardStyle"
-                                                }
-                                            },
-                                            "required": [
-                                                "type"
-                                            ]
-                                        },
-                                        "type": {
-                                            "type": "string"
-                                        }
-                                    },
-                                    "required": [
-                                        "card",
-                                        "discussion",
-                                        "display",
-                                        "header",
-                                        "properties",
-                                        "type"
-                                    ]
-                                }
-                            },
-                            "backfill": {
-                                "type": "array",
-                                "items": {
-                                    "type": "object",
-                                    "properties": {
-                                        "properties": {
-                                            "type": "object",
-                                            "properties": {
-                                                "isBreaking": {
-                                                    "type": "boolean"
-                                                },
-                                                "showMainVideo": {
-                                                    "type": "boolean"
-                                                },
-                                                "showKickerTag": {
-                                                    "type": "boolean"
-                                                },
-                                                "showByline": {
-                                                    "type": "boolean"
-                                                },
-                                                "imageSlideshowReplace": {
-                                                    "type": "boolean"
-                                                },
-                                                "maybeContent": {
-                                                    "type": "object",
-                                                    "properties": {
-                                                        "trail": {
-                                                            "type": "object",
-                                                            "properties": {
-                                                                "trailPicture": {
-                                                                    "type": "object",
-                                                                    "properties": {
-                                                                        "allImages": {
-                                                                            "type": "array",
-                                                                            "items": {
-                                                                                "type": "object",
-                                                                                "properties": {
-                                                                                    "index": {
-                                                                                        "type": "number"
-                                                                                    },
-                                                                                    "fields": {
-                                                                                        "type": "object",
-                                                                                        "properties": {
-                                                                                            "displayCredit": {
-                                                                                                "type": "string"
-                                                                                            },
-                                                                                            "source": {
-                                                                                                "type": "string"
-                                                                                            },
-                                                                                            "photographer": {
-                                                                                                "type": "string"
-                                                                                            },
-                                                                                            "isMaster": {
-                                                                                                "type": "string"
-                                                                                            },
-                                                                                            "altText": {
-                                                                                                "type": "string"
-                                                                                            },
-                                                                                            "height": {
-                                                                                                "type": "string"
-                                                                                            },
-                                                                                            "credit": {
-                                                                                                "type": "string"
-                                                                                            },
-                                                                                            "mediaId": {
-                                                                                                "type": "string"
-                                                                                            },
-                                                                                            "width": {
-                                                                                                "type": "string"
-                                                                                            }
-                                                                                        },
-                                                                                        "required": [
-                                                                                            "height",
-                                                                                            "width"
-                                                                                        ]
-                                                                                    },
-                                                                                    "mediaType": {
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "url": {
-                                                                                        "type": "string"
-                                                                                    }
-                                                                                },
-                                                                                "required": [
-                                                                                    "fields",
-                                                                                    "index",
-                                                                                    "mediaType",
-                                                                                    "url"
-                                                                                ]
-                                                                            }
-                                                                        }
-                                                                    },
-                                                                    "required": [
-                                                                        "allImages"
-                                                                    ]
-                                                                },
-                                                                "byline": {
-                                                                    "type": "string"
-                                                                },
-                                                                "thumbnailPath": {
-                                                                    "type": "string"
-                                                                },
-                                                                "webPublicationDate": {
-                                                                    "type": "number"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "webPublicationDate"
-                                                            ]
-                                                        },
-                                                        "metadata": {
-                                                            "type": "object",
-                                                            "properties": {
-                                                                "id": {
-                                                                    "type": "string"
-                                                                },
-                                                                "webTitle": {
-                                                                    "type": "string"
-                                                                },
-                                                                "webUrl": {
-                                                                    "type": "string"
-                                                                },
-                                                                "type": {
-                                                                    "type": "string"
-                                                                },
-                                                                "sectionId": {
-                                                                    "type": "object",
-                                                                    "properties": {
-                                                                        "value": {
-                                                                            "type": "string"
-                                                                        }
-                                                                    },
-                                                                    "required": [
-                                                                        "value"
-                                                                    ]
-                                                                },
-                                                                "format": {
-                                                                    "type": "object",
-                                                                    "properties": {
-                                                                        "design": {
-                                                                            "$ref": "#/definitions/FEDesign"
-                                                                        },
-                                                                        "theme": {
-                                                                            "$ref": "#/definitions/FETheme"
-                                                                        },
-                                                                        "display": {
-                                                                            "$ref": "#/definitions/FEDisplay"
-                                                                        }
-                                                                    },
-                                                                    "required": [
-                                                                        "design",
-                                                                        "display",
-                                                                        "theme"
-                                                                    ]
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "format",
-                                                                "id",
-                                                                "type",
-                                                                "webTitle",
-                                                                "webUrl"
-                                                            ]
-                                                        },
-                                                        "fields": {
-                                                            "type": "object",
-                                                            "properties": {
-                                                                "main": {
-                                                                    "type": "string"
-                                                                },
-                                                                "body": {
-                                                                    "type": "string"
-                                                                },
-                                                                "standfirst": {
-                                                                    "type": "string"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "body",
-                                                                "main"
-                                                            ]
-                                                        },
-                                                        "elements": {
-                                                            "type": "object",
-                                                            "properties": {
-                                                                "mainVideo": {},
-                                                                "mediaAtoms": {
-                                                                    "type": "array",
-                                                                    "items": {
-                                                                        "$ref": "#/definitions/FEMediaAtoms"
-                                                                    }
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "mediaAtoms"
-                                                            ]
-                                                        },
-                                                        "tags": {
-                                                            "type": "object",
-                                                            "properties": {
-                                                                "tags": {
-                                                                    "type": "array",
-                                                                    "items": {
-                                                                        "description": "This type comes from `frontend`, hence the FE prefix.",
-                                                                        "type": "object",
-                                                                        "properties": {
-                                                                            "properties": {
-                                                                                "type": "object",
-                                                                                "properties": {
-                                                                                    "id": {
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "tagType": {
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "webTitle": {
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "bio": {
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "bylineImageUrl": {
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "bylineLargeImageUrl": {
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "contributorLargeImagePath": {
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "paidContentType": {
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "sectionId": {
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "sectionName": {
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "twitterHandle": {
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "url": {
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "webUrl": {
-                                                                                        "type": "string"
-                                                                                    }
-                                                                                },
-                                                                                "required": [
-                                                                                    "id",
-                                                                                    "tagType",
-                                                                                    "webTitle"
-                                                                                ]
-                                                                            },
-                                                                            "pagination": {
-                                                                                "type": "object",
-                                                                                "properties": {
-                                                                                    "currentPage": {
-                                                                                        "type": "number"
-                                                                                    },
-                                                                                    "lastPage": {
-                                                                                        "type": "number"
-                                                                                    },
-                                                                                    "totalContent": {
-                                                                                        "type": "number"
-                                                                                    }
-                                                                                },
-                                                                                "required": [
-                                                                                    "currentPage",
-                                                                                    "lastPage",
-                                                                                    "totalContent"
-                                                                                ]
-                                                                            }
-                                                                        },
-                                                                        "required": [
-                                                                            "properties"
-                                                                        ]
-                                                                    }
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "tags"
-                                                            ]
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "elements",
-                                                        "fields",
-                                                        "metadata",
-                                                        "tags",
-                                                        "trail"
-                                                    ]
-                                                },
-                                                "maybeContentId": {
-                                                    "type": "string"
-                                                },
-                                                "isLiveBlog": {
-                                                    "type": "boolean"
-                                                },
-                                                "isCrossword": {
-                                                    "type": "boolean"
-                                                },
-                                                "byline": {
-                                                    "type": "string"
-                                                },
-                                                "image": {
-                                                    "type": "object",
-                                                    "properties": {
-                                                        "type": {
-                                                            "type": "string"
-                                                        },
-                                                        "item": {
-                                                            "type": "object",
-                                                            "properties": {
-                                                                "imageSrc": {
-                                                                    "type": "string"
-                                                                },
-                                                                "assets": {
-                                                                    "type": "array",
-                                                                    "items": {
-                                                                        "type": "object",
-                                                                        "properties": {
-                                                                            "imageSrc": {
-                                                                                "type": "string"
-                                                                            },
-                                                                            "imageCaption": {
-                                                                                "type": "string"
-                                                                            }
-                                                                        },
-                                                                        "required": [
-                                                                            "imageSrc"
-                                                                        ]
-                                                                    }
-                                                                }
-                                                            }
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "item",
-                                                        "type"
-                                                    ]
-                                                },
-                                                "webTitle": {
-                                                    "type": "string"
-                                                },
-                                                "linkText": {
-                                                    "type": "string"
-                                                },
-                                                "webUrl": {
-                                                    "type": "string"
-                                                },
-                                                "editionBrandings": {
-                                                    "type": "array",
-                                                    "items": {
-                                                        "type": "object",
-                                                        "properties": {
-                                                            "edition": {
-                                                                "type": "object",
-                                                                "properties": {
-                                                                    "id": {
-                                                                        "$ref": "#/definitions/EditionId"
-                                                                    }
-                                                                },
-                                                                "required": [
-                                                                    "id"
-                                                                ]
-                                                            },
-                                                            "branding": {
-                                                                "$ref": "#/definitions/Branding"
-                                                            }
-                                                        },
-                                                        "required": [
-                                                            "edition"
-                                                        ]
-                                                    }
-                                                },
-                                                "href": {
-                                                    "type": "string"
-                                                },
-                                                "embedUri": {
-                                                    "type": "string"
-                                                }
-                                            },
-                                            "required": [
-                                                "editionBrandings",
-                                                "imageSlideshowReplace",
-                                                "isBreaking",
-                                                "isCrossword",
-                                                "isLiveBlog",
-                                                "showByline",
-                                                "showKickerTag",
-                                                "showMainVideo",
-                                                "webTitle"
-                                            ]
-                                        },
-                                        "header": {
-                                            "type": "object",
-                                            "properties": {
-                                                "isVideo": {
-                                                    "type": "boolean"
-                                                },
-                                                "isComment": {
-                                                    "type": "boolean"
-                                                },
-                                                "isGallery": {
-                                                    "type": "boolean"
-                                                },
-                                                "isAudio": {
-                                                    "type": "boolean"
-                                                },
-                                                "kicker": {
-                                                    "type": "object",
-                                                    "properties": {
-                                                        "type": {
-                                                            "type": "string"
-                                                        },
-                                                        "item": {
-                                                            "type": "object",
-                                                            "properties": {
-                                                                "properties": {
-                                                                    "type": "object",
-                                                                    "properties": {
-                                                                        "kickerText": {
-                                                                            "type": "string"
-                                                                        }
-                                                                    },
-                                                                    "required": [
-                                                                        "kickerText"
-                                                                    ]
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "properties"
-                                                            ]
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "type"
-                                                    ]
-                                                },
-                                                "seriesOrBlogKicker": {
-                                                    "type": "object",
-                                                    "properties": {
-                                                        "properties": {
-                                                            "type": "object",
-                                                            "properties": {
-                                                                "kickerText": {
-                                                                    "type": "string"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "kickerText"
-                                                            ]
-                                                        },
-                                                        "name": {
-                                                            "type": "string"
-                                                        },
-                                                        "url": {
-                                                            "type": "string"
-                                                        },
-                                                        "id": {
-                                                            "type": "string"
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "id",
-                                                        "name",
-                                                        "properties",
-                                                        "url"
-                                                    ]
-                                                },
-                                                "headline": {
-                                                    "type": "string"
-                                                },
-                                                "url": {
-                                                    "type": "string"
-                                                },
-                                                "hasMainVideoElement": {
-                                                    "type": "boolean"
-                                                }
-                                            },
-                                            "required": [
-                                                "hasMainVideoElement",
-                                                "headline",
-                                                "isAudio",
-                                                "isComment",
-                                                "isGallery",
-                                                "isVideo",
-                                                "url"
-                                            ]
-                                        },
-                                        "card": {
-                                            "type": "object",
-                                            "properties": {
-                                                "id": {
-                                                    "type": "string"
-                                                },
-                                                "cardStyle": {
-                                                    "type": "object",
-                                                    "properties": {
-                                                        "type": {
-                                                            "$ref": "#/definitions/FEFrontCardStyle"
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "type"
-                                                    ]
-                                                },
-                                                "webPublicationDateOption": {
-                                                    "type": "number"
-                                                },
-                                                "lastModifiedOption": {
-                                                    "type": "number"
-                                                },
-                                                "trailText": {
-                                                    "type": "string"
-                                                },
-                                                "starRating": {
-                                                    "type": "number"
-                                                },
-                                                "shortUrlPath": {
-                                                    "type": "string"
-                                                },
-                                                "shortUrl": {
-                                                    "type": "string"
-                                                },
-                                                "group": {
-                                                    "type": "string"
-                                                },
-                                                "isLive": {
-                                                    "type": "boolean"
-                                                }
-                                            },
-                                            "required": [
-                                                "cardStyle",
-                                                "group",
-                                                "id",
-                                                "isLive",
-                                                "shortUrl"
-                                            ]
-                                        },
-                                        "discussion": {
-                                            "type": "object",
-                                            "properties": {
-                                                "isCommentable": {
-                                                    "type": "boolean"
-                                                },
-                                                "isClosedForComments": {
-                                                    "type": "boolean"
-                                                },
-                                                "discussionId": {
-                                                    "type": "string"
-                                                }
-                                            },
-                                            "required": [
-                                                "isClosedForComments",
-                                                "isCommentable"
-                                            ]
-                                        },
-                                        "display": {
-                                            "type": "object",
-                                            "properties": {
-                                                "isBoosted": {
-                                                    "type": "boolean"
-                                                },
-                                                "showBoostedHeadline": {
-                                                    "type": "boolean"
-                                                },
-                                                "showQuotedHeadline": {
-                                                    "type": "boolean"
-                                                },
-                                                "imageHide": {
-                                                    "type": "boolean"
-                                                },
-                                                "showLivePlayable": {
-                                                    "type": "boolean"
-                                                }
-                                            },
-                                            "required": [
-                                                "imageHide",
-                                                "isBoosted",
-                                                "showBoostedHeadline",
-                                                "showLivePlayable",
-                                                "showQuotedHeadline"
-                                            ]
-                                        },
-                                        "format": {
-                                            "type": "object",
-                                            "properties": {
-                                                "design": {
-                                                    "$ref": "#/definitions/FEDesign"
-                                                },
-                                                "theme": {
-                                                    "$ref": "#/definitions/FETheme"
-                                                },
-                                                "display": {
-                                                    "$ref": "#/definitions/FEDisplay"
-                                                }
-                                            },
-                                            "required": [
-                                                "design",
-                                                "display",
-                                                "theme"
-                                            ]
-                                        },
-                                        "enriched": {
-                                            "type": "object",
-                                            "properties": {
-                                                "embedHtml": {
-                                                    "type": "string"
-                                                },
-                                                "embedCss": {
-                                                    "type": "string"
-                                                },
-                                                "embedJs": {
-                                                    "type": "string"
-                                                }
-                                            }
-                                        },
-                                        "supportingContent": {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "properties": {
-                                                        "type": "object",
-                                                        "properties": {
-                                                            "href": {
-                                                                "type": "string"
-                                                            }
-                                                        }
-                                                    },
-                                                    "header": {
-                                                        "type": "object",
-                                                        "properties": {
-                                                            "kicker": {
-                                                                "type": "object",
-                                                                "properties": {
-                                                                    "item": {
-                                                                        "type": "object",
-                                                                        "properties": {
-                                                                            "properties": {
-                                                                                "type": "object",
-                                                                                "properties": {
-                                                                                    "kickerText": {
-                                                                                        "type": "string"
-                                                                                    }
-                                                                                },
-                                                                                "required": [
-                                                                                    "kickerText"
-                                                                                ]
-                                                                            }
-                                                                        },
-                                                                        "required": [
-                                                                            "properties"
-                                                                        ]
-                                                                    }
-                                                                }
-                                                            },
-                                                            "headline": {
-                                                                "type": "string"
-                                                            },
-                                                            "url": {
-                                                                "type": "string"
-                                                            }
-                                                        },
-                                                        "required": [
-                                                            "headline",
-                                                            "url"
-                                                        ]
-                                                    },
-                                                    "format": {
-                                                        "type": "object",
-                                                        "properties": {
-                                                            "design": {
-                                                                "$ref": "#/definitions/FEDesign"
-                                                            },
-                                                            "theme": {
-                                                                "$ref": "#/definitions/FETheme"
-                                                            },
-                                                            "display": {
-                                                                "$ref": "#/definitions/FEDisplay"
-                                                            }
-                                                        },
-                                                        "required": [
-                                                            "design",
-                                                            "display",
-                                                            "theme"
-                                                        ]
-                                                    }
-                                                },
-                                                "required": [
-                                                    "properties"
-                                                ]
-                                            }
-                                        },
-                                        "cardStyle": {
-                                            "type": "object",
-                                            "properties": {
-                                                "type": {
-                                                    "$ref": "#/definitions/FEFrontCardStyle"
-                                                }
-                                            },
-                                            "required": [
-                                                "type"
-                                            ]
-                                        },
-                                        "type": {
-                                            "type": "string"
-                                        }
-                                    },
-                                    "required": [
-                                        "card",
-                                        "discussion",
-                                        "display",
-                                        "header",
-                                        "properties",
-                                        "type"
-                                    ]
-                                }
-                            },
-                            "treats": {
-                                "type": "array",
-                                "items": {
-                                    "type": "object",
-                                    "properties": {
-                                        "properties": {
-                                            "type": "object",
-                                            "properties": {
-                                                "isBreaking": {
-                                                    "type": "boolean"
-                                                },
-                                                "showMainVideo": {
-                                                    "type": "boolean"
-                                                },
-                                                "showKickerTag": {
-                                                    "type": "boolean"
-                                                },
-                                                "showByline": {
-                                                    "type": "boolean"
-                                                },
-                                                "imageSlideshowReplace": {
-                                                    "type": "boolean"
-                                                },
-                                                "maybeContent": {
-                                                    "type": "object",
-                                                    "properties": {
-                                                        "trail": {
-                                                            "type": "object",
-                                                            "properties": {
-                                                                "trailPicture": {
-                                                                    "type": "object",
-                                                                    "properties": {
-                                                                        "allImages": {
-                                                                            "type": "array",
-                                                                            "items": {
-                                                                                "type": "object",
-                                                                                "properties": {
-                                                                                    "index": {
-                                                                                        "type": "number"
-                                                                                    },
-                                                                                    "fields": {
-                                                                                        "type": "object",
-                                                                                        "properties": {
-                                                                                            "displayCredit": {
-                                                                                                "type": "string"
-                                                                                            },
-                                                                                            "source": {
-                                                                                                "type": "string"
-                                                                                            },
-                                                                                            "photographer": {
-                                                                                                "type": "string"
-                                                                                            },
-                                                                                            "isMaster": {
-                                                                                                "type": "string"
-                                                                                            },
-                                                                                            "altText": {
-                                                                                                "type": "string"
-                                                                                            },
-                                                                                            "height": {
-                                                                                                "type": "string"
-                                                                                            },
-                                                                                            "credit": {
-                                                                                                "type": "string"
-                                                                                            },
-                                                                                            "mediaId": {
-                                                                                                "type": "string"
-                                                                                            },
-                                                                                            "width": {
-                                                                                                "type": "string"
-                                                                                            }
-                                                                                        },
-                                                                                        "required": [
-                                                                                            "height",
-                                                                                            "width"
-                                                                                        ]
-                                                                                    },
-                                                                                    "mediaType": {
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "url": {
-                                                                                        "type": "string"
-                                                                                    }
-                                                                                },
-                                                                                "required": [
-                                                                                    "fields",
-                                                                                    "index",
-                                                                                    "mediaType",
-                                                                                    "url"
-                                                                                ]
-                                                                            }
-                                                                        }
-                                                                    },
-                                                                    "required": [
-                                                                        "allImages"
-                                                                    ]
-                                                                },
-                                                                "byline": {
-                                                                    "type": "string"
-                                                                },
-                                                                "thumbnailPath": {
-                                                                    "type": "string"
-                                                                },
-                                                                "webPublicationDate": {
-                                                                    "type": "number"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "webPublicationDate"
-                                                            ]
-                                                        },
-                                                        "metadata": {
-                                                            "type": "object",
-                                                            "properties": {
-                                                                "id": {
-                                                                    "type": "string"
-                                                                },
-                                                                "webTitle": {
-                                                                    "type": "string"
-                                                                },
-                                                                "webUrl": {
-                                                                    "type": "string"
-                                                                },
-                                                                "type": {
-                                                                    "type": "string"
-                                                                },
-                                                                "sectionId": {
-                                                                    "type": "object",
-                                                                    "properties": {
-                                                                        "value": {
-                                                                            "type": "string"
-                                                                        }
-                                                                    },
-                                                                    "required": [
-                                                                        "value"
-                                                                    ]
-                                                                },
-                                                                "format": {
-                                                                    "type": "object",
-                                                                    "properties": {
-                                                                        "design": {
-                                                                            "$ref": "#/definitions/FEDesign"
-                                                                        },
-                                                                        "theme": {
-                                                                            "$ref": "#/definitions/FETheme"
-                                                                        },
-                                                                        "display": {
-                                                                            "$ref": "#/definitions/FEDisplay"
-                                                                        }
-                                                                    },
-                                                                    "required": [
-                                                                        "design",
-                                                                        "display",
-                                                                        "theme"
-                                                                    ]
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "format",
-                                                                "id",
-                                                                "type",
-                                                                "webTitle",
-                                                                "webUrl"
-                                                            ]
-                                                        },
-                                                        "fields": {
-                                                            "type": "object",
-                                                            "properties": {
-                                                                "main": {
-                                                                    "type": "string"
-                                                                },
-                                                                "body": {
-                                                                    "type": "string"
-                                                                },
-                                                                "standfirst": {
-                                                                    "type": "string"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "body",
-                                                                "main"
-                                                            ]
-                                                        },
-                                                        "elements": {
-                                                            "type": "object",
-                                                            "properties": {
-                                                                "mainVideo": {},
-                                                                "mediaAtoms": {
-                                                                    "type": "array",
-                                                                    "items": {
-                                                                        "$ref": "#/definitions/FEMediaAtoms"
-                                                                    }
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "mediaAtoms"
-                                                            ]
-                                                        },
-                                                        "tags": {
-                                                            "type": "object",
-                                                            "properties": {
-                                                                "tags": {
-                                                                    "type": "array",
-                                                                    "items": {
-                                                                        "description": "This type comes from `frontend`, hence the FE prefix.",
-                                                                        "type": "object",
-                                                                        "properties": {
-                                                                            "properties": {
-                                                                                "type": "object",
-                                                                                "properties": {
-                                                                                    "id": {
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "tagType": {
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "webTitle": {
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "bio": {
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "bylineImageUrl": {
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "bylineLargeImageUrl": {
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "contributorLargeImagePath": {
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "paidContentType": {
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "sectionId": {
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "sectionName": {
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "twitterHandle": {
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "url": {
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "webUrl": {
-                                                                                        "type": "string"
-                                                                                    }
-                                                                                },
-                                                                                "required": [
-                                                                                    "id",
-                                                                                    "tagType",
-                                                                                    "webTitle"
-                                                                                ]
-                                                                            },
-                                                                            "pagination": {
-                                                                                "type": "object",
-                                                                                "properties": {
-                                                                                    "currentPage": {
-                                                                                        "type": "number"
-                                                                                    },
-                                                                                    "lastPage": {
-                                                                                        "type": "number"
-                                                                                    },
-                                                                                    "totalContent": {
-                                                                                        "type": "number"
-                                                                                    }
-                                                                                },
-                                                                                "required": [
-                                                                                    "currentPage",
-                                                                                    "lastPage",
-                                                                                    "totalContent"
-                                                                                ]
-                                                                            }
-                                                                        },
-                                                                        "required": [
-                                                                            "properties"
-                                                                        ]
-                                                                    }
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "tags"
-                                                            ]
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "elements",
-                                                        "fields",
-                                                        "metadata",
-                                                        "tags",
-                                                        "trail"
-                                                    ]
-                                                },
-                                                "maybeContentId": {
-                                                    "type": "string"
-                                                },
-                                                "isLiveBlog": {
-                                                    "type": "boolean"
-                                                },
-                                                "isCrossword": {
-                                                    "type": "boolean"
-                                                },
-                                                "byline": {
-                                                    "type": "string"
-                                                },
-                                                "image": {
-                                                    "type": "object",
-                                                    "properties": {
-                                                        "type": {
-                                                            "type": "string"
-                                                        },
-                                                        "item": {
-                                                            "type": "object",
-                                                            "properties": {
-                                                                "imageSrc": {
-                                                                    "type": "string"
-                                                                },
-                                                                "assets": {
-                                                                    "type": "array",
-                                                                    "items": {
-                                                                        "type": "object",
-                                                                        "properties": {
-                                                                            "imageSrc": {
-                                                                                "type": "string"
-                                                                            },
-                                                                            "imageCaption": {
-                                                                                "type": "string"
-                                                                            }
-                                                                        },
-                                                                        "required": [
-                                                                            "imageSrc"
-                                                                        ]
-                                                                    }
-                                                                }
-                                                            }
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "item",
-                                                        "type"
-                                                    ]
-                                                },
-                                                "webTitle": {
-                                                    "type": "string"
-                                                },
-                                                "linkText": {
-                                                    "type": "string"
-                                                },
-                                                "webUrl": {
-                                                    "type": "string"
-                                                },
-                                                "editionBrandings": {
-                                                    "type": "array",
-                                                    "items": {
-                                                        "type": "object",
-                                                        "properties": {
-                                                            "edition": {
-                                                                "type": "object",
-                                                                "properties": {
-                                                                    "id": {
-                                                                        "$ref": "#/definitions/EditionId"
-                                                                    }
-                                                                },
-                                                                "required": [
-                                                                    "id"
-                                                                ]
-                                                            },
-                                                            "branding": {
-                                                                "$ref": "#/definitions/Branding"
-                                                            }
-                                                        },
-                                                        "required": [
-                                                            "edition"
-                                                        ]
-                                                    }
-                                                },
-                                                "href": {
-                                                    "type": "string"
-                                                },
-                                                "embedUri": {
-                                                    "type": "string"
-                                                }
-                                            },
-                                            "required": [
-                                                "editionBrandings",
-                                                "imageSlideshowReplace",
-                                                "isBreaking",
-                                                "isCrossword",
-                                                "isLiveBlog",
-                                                "showByline",
-                                                "showKickerTag",
-                                                "showMainVideo",
-                                                "webTitle"
-                                            ]
-                                        },
-                                        "header": {
-                                            "type": "object",
-                                            "properties": {
-                                                "isVideo": {
-                                                    "type": "boolean"
-                                                },
-                                                "isComment": {
-                                                    "type": "boolean"
-                                                },
-                                                "isGallery": {
-                                                    "type": "boolean"
-                                                },
-                                                "isAudio": {
-                                                    "type": "boolean"
-                                                },
-                                                "kicker": {
-                                                    "type": "object",
-                                                    "properties": {
-                                                        "type": {
-                                                            "type": "string"
-                                                        },
-                                                        "item": {
-                                                            "type": "object",
-                                                            "properties": {
-                                                                "properties": {
-                                                                    "type": "object",
-                                                                    "properties": {
-                                                                        "kickerText": {
-                                                                            "type": "string"
-                                                                        }
-                                                                    },
-                                                                    "required": [
-                                                                        "kickerText"
-                                                                    ]
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "properties"
-                                                            ]
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "type"
-                                                    ]
-                                                },
-                                                "seriesOrBlogKicker": {
-                                                    "type": "object",
-                                                    "properties": {
-                                                        "properties": {
-                                                            "type": "object",
-                                                            "properties": {
-                                                                "kickerText": {
-                                                                    "type": "string"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "kickerText"
-                                                            ]
-                                                        },
-                                                        "name": {
-                                                            "type": "string"
-                                                        },
-                                                        "url": {
-                                                            "type": "string"
-                                                        },
-                                                        "id": {
-                                                            "type": "string"
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "id",
-                                                        "name",
-                                                        "properties",
-                                                        "url"
-                                                    ]
-                                                },
-                                                "headline": {
-                                                    "type": "string"
-                                                },
-                                                "url": {
-                                                    "type": "string"
-                                                },
-                                                "hasMainVideoElement": {
-                                                    "type": "boolean"
-                                                }
-                                            },
-                                            "required": [
-                                                "hasMainVideoElement",
-                                                "headline",
-                                                "isAudio",
-                                                "isComment",
-                                                "isGallery",
-                                                "isVideo",
-                                                "url"
-                                            ]
-                                        },
-                                        "card": {
-                                            "type": "object",
-                                            "properties": {
-                                                "id": {
-                                                    "type": "string"
-                                                },
-                                                "cardStyle": {
-                                                    "type": "object",
-                                                    "properties": {
-                                                        "type": {
-                                                            "$ref": "#/definitions/FEFrontCardStyle"
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "type"
-                                                    ]
-                                                },
-                                                "webPublicationDateOption": {
-                                                    "type": "number"
-                                                },
-                                                "lastModifiedOption": {
-                                                    "type": "number"
-                                                },
-                                                "trailText": {
-                                                    "type": "string"
-                                                },
-                                                "starRating": {
-                                                    "type": "number"
-                                                },
-                                                "shortUrlPath": {
-                                                    "type": "string"
-                                                },
-                                                "shortUrl": {
-                                                    "type": "string"
-                                                },
-                                                "group": {
-                                                    "type": "string"
-                                                },
-                                                "isLive": {
-                                                    "type": "boolean"
-                                                }
-                                            },
-                                            "required": [
-                                                "cardStyle",
-                                                "group",
-                                                "id",
-                                                "isLive",
-                                                "shortUrl"
-                                            ]
-                                        },
-                                        "discussion": {
-                                            "type": "object",
-                                            "properties": {
-                                                "isCommentable": {
-                                                    "type": "boolean"
-                                                },
-                                                "isClosedForComments": {
-                                                    "type": "boolean"
-                                                },
-                                                "discussionId": {
-                                                    "type": "string"
-                                                }
-                                            },
-                                            "required": [
-                                                "isClosedForComments",
-                                                "isCommentable"
-                                            ]
-                                        },
-                                        "display": {
-                                            "type": "object",
-                                            "properties": {
-                                                "isBoosted": {
-                                                    "type": "boolean"
-                                                },
-                                                "showBoostedHeadline": {
-                                                    "type": "boolean"
-                                                },
-                                                "showQuotedHeadline": {
-                                                    "type": "boolean"
-                                                },
-                                                "imageHide": {
-                                                    "type": "boolean"
-                                                },
-                                                "showLivePlayable": {
-                                                    "type": "boolean"
-                                                }
-                                            },
-                                            "required": [
-                                                "imageHide",
-                                                "isBoosted",
-                                                "showBoostedHeadline",
-                                                "showLivePlayable",
-                                                "showQuotedHeadline"
-                                            ]
-                                        },
-                                        "format": {
-                                            "type": "object",
-                                            "properties": {
-                                                "design": {
-                                                    "$ref": "#/definitions/FEDesign"
-                                                },
-                                                "theme": {
-                                                    "$ref": "#/definitions/FETheme"
-                                                },
-                                                "display": {
-                                                    "$ref": "#/definitions/FEDisplay"
-                                                }
-                                            },
-                                            "required": [
-                                                "design",
-                                                "display",
-                                                "theme"
-                                            ]
-                                        },
-                                        "enriched": {
-                                            "type": "object",
-                                            "properties": {
-                                                "embedHtml": {
-                                                    "type": "string"
-                                                },
-                                                "embedCss": {
-                                                    "type": "string"
-                                                },
-                                                "embedJs": {
-                                                    "type": "string"
-                                                }
-                                            }
-                                        },
-                                        "supportingContent": {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "properties": {
-                                                        "type": "object",
-                                                        "properties": {
-                                                            "href": {
-                                                                "type": "string"
-                                                            }
-                                                        }
-                                                    },
-                                                    "header": {
-                                                        "type": "object",
-                                                        "properties": {
-                                                            "kicker": {
-                                                                "type": "object",
-                                                                "properties": {
-                                                                    "item": {
-                                                                        "type": "object",
-                                                                        "properties": {
-                                                                            "properties": {
-                                                                                "type": "object",
-                                                                                "properties": {
-                                                                                    "kickerText": {
-                                                                                        "type": "string"
-                                                                                    }
-                                                                                },
-                                                                                "required": [
-                                                                                    "kickerText"
-                                                                                ]
-                                                                            }
-                                                                        },
-                                                                        "required": [
-                                                                            "properties"
-                                                                        ]
-                                                                    }
-                                                                }
-                                                            },
-                                                            "headline": {
-                                                                "type": "string"
-                                                            },
-                                                            "url": {
-                                                                "type": "string"
-                                                            }
-                                                        },
-                                                        "required": [
-                                                            "headline",
-                                                            "url"
-                                                        ]
-                                                    },
-                                                    "format": {
-                                                        "type": "object",
-                                                        "properties": {
-                                                            "design": {
-                                                                "$ref": "#/definitions/FEDesign"
-                                                            },
-                                                            "theme": {
-                                                                "$ref": "#/definitions/FETheme"
-                                                            },
-                                                            "display": {
-                                                                "$ref": "#/definitions/FEDisplay"
-                                                            }
-                                                        },
-                                                        "required": [
-                                                            "design",
-                                                            "display",
-                                                            "theme"
-                                                        ]
-                                                    }
-                                                },
-                                                "required": [
-                                                    "properties"
-                                                ]
-                                            }
-                                        },
-                                        "cardStyle": {
-                                            "type": "object",
-                                            "properties": {
-                                                "type": {
-                                                    "$ref": "#/definitions/FEFrontCardStyle"
-                                                }
-                                            },
-                                            "required": [
-                                                "type"
-                                            ]
-                                        },
-                                        "type": {
-                                            "type": "string"
-                                        }
-                                    },
-                                    "required": [
-                                        "card",
-                                        "discussion",
-                                        "display",
-                                        "header",
-                                        "properties",
-                                        "type"
-                                    ]
-                                }
-                            },
-                            "lastUpdate": {
-                                "type": "number"
-                            },
-                            "href": {
-                                "type": "string"
-                            },
-                            "groups": {
-                                "type": "array",
-                                "items": {
-                                    "type": "string"
-                                }
-                            },
-                            "collectionType": {
-                                "$ref": "#/definitions/FEContainerType"
-                            },
-                            "uneditable": {
-                                "type": "boolean"
-                            },
-                            "showTags": {
-                                "type": "boolean"
-                            },
-                            "showSections": {
-                                "type": "boolean"
-                            },
-                            "hideKickers": {
-                                "type": "boolean"
-                            },
-                            "showDateHeader": {
-                                "type": "boolean"
-                            },
-                            "showLatestUpdate": {
-                                "type": "boolean"
-                            },
-                            "config": {
-                                "type": "object",
-                                "properties": {
-                                    "displayName": {
-                                        "type": "string"
-                                    },
-                                    "metadata": {
-                                        "type": "array",
-                                        "items": {
-                                            "type": "object",
-                                            "properties": {
-                                                "type": {
-                                                    "$ref": "#/definitions/FEContainerPalette"
-                                                }
-                                            },
-                                            "required": [
-                                                "type"
-                                            ]
-                                        }
-                                    },
-                                    "collectionType": {
-                                        "$ref": "#/definitions/FEContainerType"
-                                    },
-                                    "href": {
-                                        "type": "string"
-                                    },
-                                    "groups": {
-                                        "type": "array",
-                                        "items": {
-                                            "type": "string"
-                                        }
-                                    },
-                                    "uneditable": {
-                                        "type": "boolean"
-                                    },
-                                    "showTags": {
-                                        "type": "boolean"
-                                    },
-                                    "showSections": {
-                                        "type": "boolean"
-                                    },
-                                    "hideKickers": {
-                                        "type": "boolean"
-                                    },
-                                    "showDateHeader": {
-                                        "type": "boolean"
-                                    },
-                                    "showLatestUpdate": {
-                                        "type": "boolean"
-                                    },
-                                    "excludeFromRss": {
-                                        "type": "boolean"
-                                    },
-                                    "showTimestamps": {
-                                        "type": "boolean"
-                                    },
-                                    "hideShowMore": {
-                                        "type": "boolean"
-                                    },
-                                    "platform": {
-                                        "type": "string"
-                                    }
-                                },
-                                "required": [
-                                    "collectionType",
-                                    "displayName",
-                                    "excludeFromRss",
-                                    "hideKickers",
-                                    "hideShowMore",
-                                    "platform",
-                                    "showDateHeader",
-                                    "showLatestUpdate",
-                                    "showSections",
-                                    "showTags",
-                                    "showTimestamps",
-                                    "uneditable"
-                                ]
-                            },
-                            "hasMore": {
-                                "type": "boolean"
-                            },
-                            "targetedTerritory": {
-                                "$ref": "#/definitions/Territory"
-                            }
-                        },
-                        "required": [
-                            "backfill",
-                            "collectionType",
-                            "config",
-                            "curated",
-                            "displayName",
-                            "hasMore",
-                            "hideKickers",
-                            "id",
-                            "showDateHeader",
-                            "showLatestUpdate",
-                            "showSections",
-                            "showTags",
-                            "treats",
-                            "uneditable"
-                        ]
-                    }
-                }
-            },
-            "required": [
-                "collections",
-                "frontProperties",
-                "id",
-                "seoData"
-            ]
-        },
-        "Record<string,unknown>": {
-            "type": "object"
-        },
-        "FEDesign": {
-            "enum": [
-                "AnalysisDesign",
-                "ArticleDesign",
-                "AudioDesign",
-                "CommentDesign",
-                "DeadBlogDesign",
-                "EditorialDesign",
-                "ExplainerDesign",
-                "FeatureDesign",
-                "FullPageInteractiveDesign",
-                "GalleryDesign",
-                "InteractiveDesign",
-                "InterviewDesign",
-                "LetterDesign",
-                "LiveBlogDesign",
-                "MatchReportDesign",
-                "NewsletterSignupDesign",
-                "ObituaryDesign",
-                "PhotoEssayDesign",
-                "PrintShopDesign",
-                "ProfileDesign",
-                "QuizDesign",
-                "RecipeDesign",
-                "ReviewDesign",
-                "TimelineDesign",
-                "VideoDesign"
-            ],
-            "type": "string"
-        },
-        "FETheme": {
-            "enum": [
-                "CulturePillar",
-                "Labs",
-                "LifestylePillar",
-                "NewsPillar",
-                "OpinionPillar",
-                "SpecialReportAltTheme",
-                "SpecialReportTheme",
-                "SportPillar"
-            ],
-            "type": "string"
-        },
-        "FEDisplay": {
-            "enum": [
-                "ImmersiveDisplay",
-                "NumberedListDisplay",
-                "ShowcaseDisplay",
-                "StandardDisplay"
-            ],
-            "type": "string"
-        },
-        "FEMediaAtoms": {
-            "type": "object",
-            "properties": {
-                "duration": {
-                    "type": "number"
-                }
-            }
-        },
-        "EditionId": {
-            "enum": [
-                "AU",
-                "EUR",
-                "INT",
-                "UK",
-                "US"
-            ],
-            "type": "string"
-        },
-        "Branding": {
-            "type": "object",
-            "properties": {
-                "brandingType": {
-                    "type": "object",
-                    "properties": {
-                        "name": {
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "name"
-                    ]
-                },
-                "sponsorName": {
-                    "type": "string"
-                },
-                "logo": {
-                    "type": "object",
-                    "properties": {
-                        "src": {
-                            "type": "string"
-                        },
-                        "link": {
-                            "type": "string"
-                        },
-                        "label": {
-                            "type": "string"
-                        },
-                        "dimensions": {
-                            "type": "object",
-                            "properties": {
-                                "width": {
-                                    "type": "number"
-                                },
-                                "height": {
-                                    "type": "number"
-                                }
-                            },
-                            "required": [
-                                "height",
-                                "width"
-                            ]
-                        }
-                    },
-                    "required": [
-                        "dimensions",
-                        "label",
-                        "link",
-                        "src"
-                    ]
-                },
-                "aboutThisLink": {
-                    "type": "string"
-                },
-                "logoForDarkBackground": {
-                    "type": "object",
-                    "properties": {
-                        "src": {
-                            "type": "string"
-                        },
-                        "link": {
-                            "type": "string"
-                        },
-                        "label": {
-                            "type": "string"
-                        },
-                        "dimensions": {
-                            "type": "object",
-                            "properties": {
-                                "width": {
-                                    "type": "number"
-                                },
-                                "height": {
-                                    "type": "number"
-                                }
-                            },
-                            "required": [
-                                "height",
-                                "width"
-                            ]
-                        }
-                    },
-                    "required": [
-                        "dimensions",
-                        "label",
-                        "link",
-                        "src"
-                    ]
-                }
-            },
-            "required": [
-                "aboutThisLink",
-                "logo",
-                "sponsorName"
-            ]
-        },
-        "FEFrontCardStyle": {
-            "enum": [
-                "Analysis",
-                "Comment",
-                "DeadBlog",
-                "DefaultCardstyle",
-                "Editorial",
-                "ExternalLink",
-                "Feature",
-                "Letters",
-                "LiveBlog",
-                "Media",
-                "Review",
-                "SpecialReport",
-                "SpecialReportAlt"
-            ],
-            "type": "string"
-        },
-        "FEContainerType": {
-            "enum": [
-                "dynamic/fast",
-                "dynamic/package",
-                "dynamic/slow",
-                "dynamic/slow-mpu",
-                "fixed/large/slow-XIV",
-                "fixed/medium/fast-XI",
-                "fixed/medium/fast-XII",
-                "fixed/medium/slow-VI",
-                "fixed/medium/slow-VII",
-                "fixed/medium/slow-XII-mpu",
-                "fixed/small/fast-VIII",
-                "fixed/small/slow-I",
-                "fixed/small/slow-III",
-                "fixed/small/slow-IV",
-                "fixed/small/slow-V-half",
-                "fixed/small/slow-V-mpu",
-                "fixed/small/slow-V-third",
-                "fixed/thrasher",
-                "fixed/video",
-                "nav/list",
-                "nav/media-list",
-                "news/most-popular"
-            ],
-            "type": "string"
-        },
-        "FEContainerPalette": {
-            "enum": [
-                "Branded",
-                "Breaking",
-                "BreakingPalette",
-                "Canonical",
-                "Dynamo",
-                "DynamoLike",
-                "EventAltPalette",
-                "EventPalette",
-                "InvestigationPalette",
-                "LongRunningAltPalette",
-                "LongRunningPalette",
-                "Podcast",
-                "SombreAltPalette",
-                "SombrePalette",
-                "Special",
-                "SpecialReportAltPalette"
-            ],
-            "type": "string"
-        },
-        "Territory": {
-            "description": "List of territories that can be targetted against.",
-            "enum": [
-                "AU-NSW",
-                "AU-QLD",
-                "AU-VIC",
-                "EU-27",
-                "NZ",
-                "US-East-Coast",
-                "US-West-Coast",
-                "XX"
-            ],
-            "type": "string"
-        },
-        "FENavType": {
-            "type": "object",
-            "properties": {
-                "currentUrl": {
-                    "type": "string"
-                },
-                "pillars": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/FELinkType"
-                    }
-                },
-                "otherLinks": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/FELinkType"
-                    }
-                },
-                "brandExtensions": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/FELinkType"
-                    }
-                },
-                "currentNavLink": {
-                    "$ref": "#/definitions/FELinkType"
-                },
-                "currentNavLinkTitle": {
-                    "type": "string"
-                },
-                "currentPillarTitle": {
-                    "type": "string"
-                },
-                "subNavSections": {
-                    "type": "object",
-                    "properties": {
-                        "parent": {
-                            "$ref": "#/definitions/FELinkType"
-                        },
-                        "links": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/FELinkType"
-                            }
-                        }
-                    },
-                    "required": [
-                        "links"
-                    ]
-                },
-                "readerRevenueLinks": {
-                    "$ref": "#/definitions/ReaderRevenuePositions"
-                }
-            },
-            "required": [
-                "brandExtensions",
-                "currentUrl",
-                "otherLinks",
-                "pillars",
-                "readerRevenueLinks"
-            ]
-        },
-        "FELinkType": {
-            "type": "object",
-            "properties": {
-                "url": {
-                    "type": "string"
-                },
-                "title": {
-                    "type": "string"
-                },
-                "longTitle": {
-                    "type": "string"
-                },
-                "iconName": {
-                    "type": "string"
-                },
-                "children": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/FELinkType"
-                    }
-                },
-                "pillar": {
-                    "$ref": "#/definitions/LegacyPillar"
-                },
-                "more": {
-                    "type": "boolean"
-                },
-                "classList": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                }
-            },
-            "required": [
-                "title",
-                "url"
-            ]
-        },
-        "LegacyPillar": {
-            "enum": [
-                "culture",
-                "labs",
-                "lifestyle",
-                "news",
-                "opinion",
-                "sport"
-            ],
-            "type": "string"
-        },
-        "ReaderRevenuePositions": {
-            "type": "object",
-            "properties": {
-                "header": {
-                    "$ref": "#/definitions/ReaderRevenueCategories"
-                },
-                "footer": {
-                    "$ref": "#/definitions/ReaderRevenueCategories"
-                },
-                "sideMenu": {
-                    "$ref": "#/definitions/ReaderRevenueCategories"
-                },
-                "ampHeader": {
-                    "$ref": "#/definitions/ReaderRevenueCategories"
-                },
-                "ampFooter": {
-                    "$ref": "#/definitions/ReaderRevenueCategories"
-                }
-            },
-            "required": [
-                "ampFooter",
-                "ampHeader",
-                "footer",
-                "header",
-                "sideMenu"
-            ]
-        },
-        "ReaderRevenueCategories": {
-            "type": "object",
-            "properties": {
-                "contribute": {
-                    "type": "string"
-                },
-                "subscribe": {
-                    "type": "string"
-                },
-                "support": {
-                    "type": "string"
-                },
-                "supporter": {
-                    "type": "string"
-                },
-                "gifting": {
-                    "type": "string"
-                }
-            },
-            "required": [
-                "contribute",
-                "subscribe",
-                "support",
-                "supporter"
-            ]
-        },
-        "Switches": {
-            "type": "object",
-            "additionalProperties": {
-                "type": "boolean"
-            }
-        },
-        "StageType": {
-            "enum": [
-                "CODE",
-                "DEV",
-                "PROD"
-            ],
-            "type": "string"
-        },
-        "FooterType": {
-            "type": "object",
-            "properties": {
-                "footerLinks": {
-                    "type": "array",
-                    "items": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/definitions/FooterLink"
-                        }
-                    }
-                }
-            },
-            "required": [
-                "footerLinks"
-            ]
-        },
-        "FooterLink": {
-            "type": "object",
-            "properties": {
-                "text": {
-                    "type": "string"
-                },
-                "url": {
-                    "type": "string"
-                },
-                "dataLinkName": {
-                    "type": "string"
-                },
-                "extraClasses": {
-                    "type": "string"
-                }
-            },
-            "required": [
-                "dataLinkName",
-                "text",
-                "url"
-            ]
-        },
-        "FETrailType": {
-            "type": "object",
-            "properties": {
-                "format": {
-                    "type": "object",
-                    "properties": {
-                        "design": {
-                            "$ref": "#/definitions/FEDesign"
-                        },
-                        "theme": {
-                            "$ref": "#/definitions/FETheme"
-                        },
-                        "display": {
-                            "$ref": "#/definitions/FEDisplay"
-                        }
-                    },
-                    "required": [
-                        "design",
-                        "display",
-                        "theme"
-                    ]
-                },
-                "designType": {
-                    "type": "string"
-                },
-                "pillar": {
-                    "type": "string"
-                },
-                "carouselImages": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "isLiveBlog": {
-                    "type": "boolean"
-                },
-                "masterImage": {
-                    "type": "string"
-                },
-                "url": {
-                    "type": "string"
-                },
-                "headline": {
-                    "type": "string"
-                },
-                "webPublicationDate": {
-                    "type": "string"
-                },
-                "image": {
-                    "type": "string"
-                },
-                "avatarUrl": {
-                    "type": "string"
-                },
-                "mediaType": {
-                    "$ref": "#/definitions/MediaType"
-                },
-                "mediaDuration": {
-                    "type": "number"
-                },
-                "ageWarning": {
-                    "type": "string"
-                },
-                "byline": {
-                    "type": "string"
-                },
-                "showByline": {
-                    "type": "boolean"
-                },
-                "kickerText": {
-                    "type": "string"
-                },
-                "shortUrl": {
-                    "type": "string"
-                },
-                "commentCount": {
-                    "type": "number"
-                },
-                "starRating": {
-                    "type": "number"
-                },
-                "linkText": {
-                    "type": "string"
-                },
-                "branding": {
-                    "$ref": "#/definitions/Branding"
-                },
-                "isSnap": {
-                    "type": "boolean"
-                },
-                "isCrossword": {
-                    "type": "boolean"
-                },
-                "snapData": {
-                    "type": "object",
-                    "properties": {
-                        "embedHtml": {
-                            "type": "string"
-                        },
-                        "embedCss": {
-                            "type": "string"
-                        },
-                        "embedJs": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "showQuotedHeadline": {
-                    "type": "boolean"
-                },
-                "discussion": {
-                    "type": "object",
-                    "properties": {
-                        "isCommentable": {
-                            "type": "boolean"
-                        },
-                        "isClosedForComments": {
-                            "type": "boolean"
-                        },
-                        "discussionId": {
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "isClosedForComments",
-                        "isCommentable"
-                    ]
-                },
-                "showMainVideo": {
-                    "type": "boolean"
-                }
-            },
-            "required": [
-                "format",
-                "headline",
-                "url"
-            ]
-        },
-        "MediaType": {
-            "enum": [
-                "Audio",
-                "Gallery",
-                "Video"
-            ],
-            "type": "string"
-        }
-    },
-    "$schema": "http://json-schema.org/draft-07/schema#"
+	"type": "object",
+	"properties": {
+		"pressedPage": {
+			"$ref": "#/definitions/FEPressedPageType"
+		},
+		"nav": {
+			"$ref": "#/definitions/FENavType"
+		},
+		"editionId": {
+			"$ref": "#/definitions/EditionId"
+		},
+		"editionLongForm": {
+			"type": "string"
+		},
+		"guardianBaseURL": {
+			"type": "string"
+		},
+		"pageId": {
+			"type": "string"
+		},
+		"webTitle": {
+			"type": "string"
+		},
+		"webURL": {
+			"type": "string"
+		},
+		"config": {
+			"type": "object",
+			"properties": {
+				"avatarApiUrl": {
+					"type": "string"
+				},
+				"externalEmbedHost": {
+					"type": "string"
+				},
+				"ajaxUrl": {
+					"type": "string"
+				},
+				"keywords": {
+					"type": "string"
+				},
+				"revisionNumber": {
+					"type": "string"
+				},
+				"isProd": {
+					"type": "boolean"
+				},
+				"switches": {
+					"$ref": "#/definitions/Switches"
+				},
+				"section": {
+					"type": "string"
+				},
+				"keywordIds": {
+					"type": "string"
+				},
+				"locationapiurl": {
+					"type": "string"
+				},
+				"sharedAdTargeting": {
+					"type": "object",
+					"additionalProperties": {}
+				},
+				"buildNumber": {
+					"type": "string"
+				},
+				"abTests": {
+					"description": "Narrowest representation of the server-side tests\nobject shape, which is [defined in `frontend`](https://github.com/guardian/frontend/blob/23743723030a041e4f4f59fa265ee2be0bb51825/common/app/experiments/ExperimentsDefinition.scala#L24-L26).\n\n**Note:** This type is not support by JSON-schema, it evaluates as `object`",
+					"type": "object"
+				},
+				"pbIndexSites": {
+					"type": "array",
+					"items": {
+						"type": "object",
+						"additionalProperties": {}
+					}
+				},
+				"ampIframeUrl": {
+					"type": "string"
+				},
+				"beaconUrl": {
+					"type": "string"
+				},
+				"userAttributesApiUrl": {
+					"type": "string"
+				},
+				"host": {
+					"type": "string"
+				},
+				"brazeApiKey": {
+					"type": "string"
+				},
+				"calloutsUrl": {
+					"type": "string"
+				},
+				"requiresMembershipAccess": {
+					"type": "boolean"
+				},
+				"onwardWebSocket": {
+					"type": "string"
+				},
+				"a9PublisherId": {
+					"type": "string"
+				},
+				"contentType": {
+					"type": "string"
+				},
+				"facebookIaAdUnitRoot": {
+					"type": "string"
+				},
+				"ophanEmbedJsUrl": {
+					"type": "string"
+				},
+				"idUrl": {
+					"type": "string"
+				},
+				"dcrSentryDsn": {
+					"type": "string"
+				},
+				"isFront": {
+					"type": "boolean",
+					"enum": [
+						true
+					]
+				},
+				"idWebAppUrl": {
+					"type": "string"
+				},
+				"discussionApiUrl": {
+					"type": "string"
+				},
+				"sentryPublicApiKey": {
+					"type": "string"
+				},
+				"omnitureAccount": {
+					"type": "string"
+				},
+				"dfpAccountId": {
+					"type": "string"
+				},
+				"pageId": {
+					"type": "string"
+				},
+				"forecastsapiurl": {
+					"type": "string"
+				},
+				"assetsPath": {
+					"type": "string"
+				},
+				"pillar": {
+					"type": "string"
+				},
+				"commercialBundleUrl": {
+					"type": "string"
+				},
+				"discussionApiClientHeader": {
+					"type": "string"
+				},
+				"membershipUrl": {
+					"type": "string"
+				},
+				"dfpHost": {
+					"type": "string"
+				},
+				"cardStyle": {
+					"type": "string"
+				},
+				"googletagUrl": {
+					"type": "string"
+				},
+				"sentryHost": {
+					"type": "string"
+				},
+				"shouldHideAdverts": {
+					"type": "boolean"
+				},
+				"mmaUrl": {
+					"type": "string"
+				},
+				"membershipAccess": {
+					"type": "string"
+				},
+				"isPreview": {
+					"type": "boolean"
+				},
+				"googletagJsUrl": {
+					"type": "string"
+				},
+				"supportUrl": {
+					"type": "string"
+				},
+				"edition": {
+					"type": "string"
+				},
+				"discussionFrontendUrl": {
+					"type": "string"
+				},
+				"ipsosTag": {
+					"type": "string"
+				},
+				"ophanJsUrl": {
+					"type": "string"
+				},
+				"isPaidContent": {
+					"type": "boolean"
+				},
+				"mobileAppsAdUnitRoot": {
+					"type": "string"
+				},
+				"plistaPublicApiKey": {
+					"type": "string"
+				},
+				"frontendAssetsFullURL": {
+					"type": "string"
+				},
+				"googleSearchId": {
+					"type": "string"
+				},
+				"allowUserGeneratedContent": {
+					"type": "boolean"
+				},
+				"dfpAdUnitRoot": {
+					"type": "string"
+				},
+				"idApiUrl": {
+					"type": "string"
+				},
+				"omnitureAmpAccount": {
+					"type": "string"
+				},
+				"adUnit": {
+					"type": "string"
+				},
+				"hasPageSkin": {
+					"type": "boolean"
+				},
+				"webTitle": {
+					"type": "string"
+				},
+				"stripePublicToken": {
+					"type": "string"
+				},
+				"googleRecaptchaSiteKey": {
+					"type": "string"
+				},
+				"discussionD2Uid": {
+					"type": "string"
+				},
+				"weatherapiurl": {
+					"type": "string"
+				},
+				"googleSearchUrl": {
+					"type": "string"
+				},
+				"optimizeEpicUrl": {
+					"type": "string"
+				},
+				"stage": {
+					"$ref": "#/definitions/StageType"
+				},
+				"idOAuthUrl": {
+					"type": "string"
+				},
+				"isSensitive": {
+					"type": "boolean"
+				},
+				"isDev": {
+					"type": "boolean"
+				},
+				"thirdPartyAppsAccount": {
+					"type": "string"
+				},
+				"avatarImagesUrl": {
+					"type": "string"
+				},
+				"fbAppId": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"a9PublisherId",
+				"abTests",
+				"adUnit",
+				"ajaxUrl",
+				"allowUserGeneratedContent",
+				"ampIframeUrl",
+				"assetsPath",
+				"avatarApiUrl",
+				"avatarImagesUrl",
+				"beaconUrl",
+				"buildNumber",
+				"calloutsUrl",
+				"commercialBundleUrl",
+				"contentType",
+				"dcrSentryDsn",
+				"dfpAccountId",
+				"dfpAdUnitRoot",
+				"dfpHost",
+				"discussionApiClientHeader",
+				"discussionApiUrl",
+				"discussionD2Uid",
+				"discussionFrontendUrl",
+				"edition",
+				"externalEmbedHost",
+				"facebookIaAdUnitRoot",
+				"fbAppId",
+				"forecastsapiurl",
+				"frontendAssetsFullURL",
+				"googleRecaptchaSiteKey",
+				"googleSearchId",
+				"googleSearchUrl",
+				"googletagJsUrl",
+				"googletagUrl",
+				"hasPageSkin",
+				"host",
+				"idApiUrl",
+				"idOAuthUrl",
+				"idUrl",
+				"idWebAppUrl",
+				"ipsosTag",
+				"isDev",
+				"isFront",
+				"isPreview",
+				"isProd",
+				"isSensitive",
+				"keywordIds",
+				"keywords",
+				"locationapiurl",
+				"membershipAccess",
+				"membershipUrl",
+				"mmaUrl",
+				"mobileAppsAdUnitRoot",
+				"omnitureAccount",
+				"omnitureAmpAccount",
+				"onwardWebSocket",
+				"ophanEmbedJsUrl",
+				"ophanJsUrl",
+				"optimizeEpicUrl",
+				"pageId",
+				"pbIndexSites",
+				"pillar",
+				"plistaPublicApiKey",
+				"requiresMembershipAccess",
+				"revisionNumber",
+				"section",
+				"sentryHost",
+				"sentryPublicApiKey",
+				"sharedAdTargeting",
+				"shouldHideAdverts",
+				"stage",
+				"stripePublicToken",
+				"supportUrl",
+				"switches",
+				"userAttributesApiUrl",
+				"weatherapiurl",
+				"webTitle"
+			]
+		},
+		"commercialProperties": {
+			"$ref": "#/definitions/Record<string,unknown>"
+		},
+		"pageFooter": {
+			"$ref": "#/definitions/FooterType"
+		},
+		"isAdFreeUser": {
+			"type": "boolean"
+		},
+		"isNetworkFront": {
+			"type": "boolean"
+		},
+		"mostViewed": {
+			"type": "array",
+			"items": {
+				"$ref": "#/definitions/FETrailType"
+			}
+		},
+		"mostCommented": {
+			"$ref": "#/definitions/FETrailType"
+		},
+		"mostShared": {
+			"$ref": "#/definitions/FETrailType"
+		},
+		"deeplyRead": {
+			"type": "array",
+			"items": {
+				"$ref": "#/definitions/FETrailType"
+			}
+		}
+	},
+	"required": [
+		"commercialProperties",
+		"config",
+		"editionId",
+		"editionLongForm",
+		"guardianBaseURL",
+		"isAdFreeUser",
+		"isNetworkFront",
+		"mostViewed",
+		"nav",
+		"pageFooter",
+		"pageId",
+		"pressedPage",
+		"webTitle",
+		"webURL"
+	],
+	"definitions": {
+		"FEPressedPageType": {
+			"type": "object",
+			"properties": {
+				"id": {
+					"type": "string"
+				},
+				"seoData": {
+					"type": "object",
+					"properties": {
+						"id": {
+							"type": "string"
+						},
+						"navSection": {
+							"type": "string"
+						},
+						"webTitle": {
+							"type": "string"
+						},
+						"title": {
+							"type": "string"
+						},
+						"description": {
+							"type": "string"
+						}
+					},
+					"required": [
+						"description",
+						"id",
+						"navSection",
+						"webTitle"
+					]
+				},
+				"frontProperties": {
+					"type": "object",
+					"properties": {
+						"isImageDisplayed": {
+							"type": "boolean"
+						},
+						"commercial": {
+							"$ref": "#/definitions/Record<string,unknown>"
+						},
+						"isPaidContent": {
+							"type": "boolean"
+						},
+						"onPageDescription": {
+							"type": "string"
+						}
+					},
+					"required": [
+						"commercial",
+						"isImageDisplayed"
+					]
+				},
+				"collections": {
+					"type": "array",
+					"items": {
+						"type": "object",
+						"properties": {
+							"id": {
+								"type": "string"
+							},
+							"displayName": {
+								"type": "string"
+							},
+							"description": {
+								"type": "string"
+							},
+							"curated": {
+								"type": "array",
+								"items": {
+									"type": "object",
+									"properties": {
+										"properties": {
+											"type": "object",
+											"properties": {
+												"isBreaking": {
+													"type": "boolean"
+												},
+												"showMainVideo": {
+													"type": "boolean"
+												},
+												"showKickerTag": {
+													"type": "boolean"
+												},
+												"showByline": {
+													"type": "boolean"
+												},
+												"imageSlideshowReplace": {
+													"type": "boolean"
+												},
+												"maybeContent": {
+													"type": "object",
+													"properties": {
+														"trail": {
+															"type": "object",
+															"properties": {
+																"trailPicture": {
+																	"type": "object",
+																	"properties": {
+																		"allImages": {
+																			"type": "array",
+																			"items": {
+																				"type": "object",
+																				"properties": {
+																					"index": {
+																						"type": "number"
+																					},
+																					"fields": {
+																						"type": "object",
+																						"properties": {
+																							"displayCredit": {
+																								"type": "string"
+																							},
+																							"source": {
+																								"type": "string"
+																							},
+																							"photographer": {
+																								"type": "string"
+																							},
+																							"isMaster": {
+																								"type": "string"
+																							},
+																							"altText": {
+																								"type": "string"
+																							},
+																							"height": {
+																								"type": "string"
+																							},
+																							"credit": {
+																								"type": "string"
+																							},
+																							"mediaId": {
+																								"type": "string"
+																							},
+																							"width": {
+																								"type": "string"
+																							}
+																						},
+																						"required": [
+																							"height",
+																							"width"
+																						]
+																					},
+																					"mediaType": {
+																						"type": "string"
+																					},
+																					"url": {
+																						"type": "string"
+																					}
+																				},
+																				"required": [
+																					"fields",
+																					"index",
+																					"mediaType",
+																					"url"
+																				]
+																			}
+																		}
+																	},
+																	"required": [
+																		"allImages"
+																	]
+																},
+																"byline": {
+																	"type": "string"
+																},
+																"thumbnailPath": {
+																	"type": "string"
+																},
+																"webPublicationDate": {
+																	"type": "number"
+																}
+															},
+															"required": [
+																"webPublicationDate"
+															]
+														},
+														"metadata": {
+															"type": "object",
+															"properties": {
+																"id": {
+																	"type": "string"
+																},
+																"webTitle": {
+																	"type": "string"
+																},
+																"webUrl": {
+																	"type": "string"
+																},
+																"type": {
+																	"type": "string"
+																},
+																"sectionId": {
+																	"type": "object",
+																	"properties": {
+																		"value": {
+																			"type": "string"
+																		}
+																	},
+																	"required": [
+																		"value"
+																	]
+																},
+																"format": {
+																	"type": "object",
+																	"properties": {
+																		"design": {
+																			"$ref": "#/definitions/FEDesign"
+																		},
+																		"theme": {
+																			"$ref": "#/definitions/FETheme"
+																		},
+																		"display": {
+																			"$ref": "#/definitions/FEDisplay"
+																		}
+																	},
+																	"required": [
+																		"design",
+																		"display",
+																		"theme"
+																	]
+																}
+															},
+															"required": [
+																"format",
+																"id",
+																"type",
+																"webTitle",
+																"webUrl"
+															]
+														},
+														"fields": {
+															"type": "object",
+															"properties": {
+																"main": {
+																	"type": "string"
+																},
+																"body": {
+																	"type": "string"
+																},
+																"standfirst": {
+																	"type": "string"
+																}
+															},
+															"required": [
+																"body",
+																"main"
+															]
+														},
+														"elements": {
+															"type": "object",
+															"properties": {
+																"mainVideo": {},
+																"mediaAtoms": {
+																	"type": "array",
+																	"items": {
+																		"$ref": "#/definitions/FEMediaAtoms"
+																	}
+																}
+															},
+															"required": [
+																"mediaAtoms"
+															]
+														},
+														"tags": {
+															"type": "object",
+															"properties": {
+																"tags": {
+																	"type": "array",
+																	"items": {
+																		"description": "This type comes from `frontend`, hence the FE prefix.",
+																		"type": "object",
+																		"properties": {
+																			"properties": {
+																				"type": "object",
+																				"properties": {
+																					"id": {
+																						"type": "string"
+																					},
+																					"tagType": {
+																						"type": "string"
+																					},
+																					"webTitle": {
+																						"type": "string"
+																					},
+																					"bio": {
+																						"type": "string"
+																					},
+																					"bylineImageUrl": {
+																						"type": "string"
+																					},
+																					"bylineLargeImageUrl": {
+																						"type": "string"
+																					},
+																					"contributorLargeImagePath": {
+																						"type": "string"
+																					},
+																					"paidContentType": {
+																						"type": "string"
+																					},
+																					"sectionId": {
+																						"type": "string"
+																					},
+																					"sectionName": {
+																						"type": "string"
+																					},
+																					"twitterHandle": {
+																						"type": "string"
+																					},
+																					"url": {
+																						"type": "string"
+																					},
+																					"webUrl": {
+																						"type": "string"
+																					}
+																				},
+																				"required": [
+																					"id",
+																					"tagType",
+																					"webTitle"
+																				]
+																			},
+																			"pagination": {
+																				"type": "object",
+																				"properties": {
+																					"currentPage": {
+																						"type": "number"
+																					},
+																					"lastPage": {
+																						"type": "number"
+																					},
+																					"totalContent": {
+																						"type": "number"
+																					}
+																				},
+																				"required": [
+																					"currentPage",
+																					"lastPage",
+																					"totalContent"
+																				]
+																			}
+																		},
+																		"required": [
+																			"properties"
+																		]
+																	}
+																}
+															},
+															"required": [
+																"tags"
+															]
+														}
+													},
+													"required": [
+														"elements",
+														"fields",
+														"metadata",
+														"tags",
+														"trail"
+													]
+												},
+												"maybeContentId": {
+													"type": "string"
+												},
+												"isLiveBlog": {
+													"type": "boolean"
+												},
+												"isCrossword": {
+													"type": "boolean"
+												},
+												"byline": {
+													"type": "string"
+												},
+												"image": {
+													"type": "object",
+													"properties": {
+														"type": {
+															"type": "string"
+														},
+														"item": {
+															"type": "object",
+															"properties": {
+																"imageSrc": {
+																	"type": "string"
+																},
+																"assets": {
+																	"type": "array",
+																	"items": {
+																		"type": "object",
+																		"properties": {
+																			"imageSrc": {
+																				"type": "string"
+																			},
+																			"imageCaption": {
+																				"type": "string"
+																			}
+																		},
+																		"required": [
+																			"imageSrc"
+																		]
+																	}
+																}
+															}
+														}
+													},
+													"required": [
+														"item",
+														"type"
+													]
+												},
+												"webTitle": {
+													"type": "string"
+												},
+												"linkText": {
+													"type": "string"
+												},
+												"webUrl": {
+													"type": "string"
+												},
+												"editionBrandings": {
+													"type": "array",
+													"items": {
+														"type": "object",
+														"properties": {
+															"edition": {
+																"type": "object",
+																"properties": {
+																	"id": {
+																		"$ref": "#/definitions/EditionId"
+																	}
+																},
+																"required": [
+																	"id"
+																]
+															},
+															"branding": {
+																"$ref": "#/definitions/Branding"
+															}
+														},
+														"required": [
+															"edition"
+														]
+													}
+												},
+												"href": {
+													"type": "string"
+												},
+												"embedUri": {
+													"type": "string"
+												}
+											},
+											"required": [
+												"editionBrandings",
+												"imageSlideshowReplace",
+												"isBreaking",
+												"isCrossword",
+												"isLiveBlog",
+												"showByline",
+												"showKickerTag",
+												"showMainVideo",
+												"webTitle"
+											]
+										},
+										"header": {
+											"type": "object",
+											"properties": {
+												"isVideo": {
+													"type": "boolean"
+												},
+												"isComment": {
+													"type": "boolean"
+												},
+												"isGallery": {
+													"type": "boolean"
+												},
+												"isAudio": {
+													"type": "boolean"
+												},
+												"kicker": {
+													"type": "object",
+													"properties": {
+														"type": {
+															"type": "string"
+														},
+														"item": {
+															"type": "object",
+															"properties": {
+																"properties": {
+																	"type": "object",
+																	"properties": {
+																		"kickerText": {
+																			"type": "string"
+																		}
+																	},
+																	"required": [
+																		"kickerText"
+																	]
+																}
+															},
+															"required": [
+																"properties"
+															]
+														}
+													},
+													"required": [
+														"type"
+													]
+												},
+												"seriesOrBlogKicker": {
+													"type": "object",
+													"properties": {
+														"properties": {
+															"type": "object",
+															"properties": {
+																"kickerText": {
+																	"type": "string"
+																}
+															},
+															"required": [
+																"kickerText"
+															]
+														},
+														"name": {
+															"type": "string"
+														},
+														"url": {
+															"type": "string"
+														},
+														"id": {
+															"type": "string"
+														}
+													},
+													"required": [
+														"id",
+														"name",
+														"properties",
+														"url"
+													]
+												},
+												"headline": {
+													"type": "string"
+												},
+												"url": {
+													"type": "string"
+												},
+												"hasMainVideoElement": {
+													"type": "boolean"
+												}
+											},
+											"required": [
+												"hasMainVideoElement",
+												"headline",
+												"isAudio",
+												"isComment",
+												"isGallery",
+												"isVideo",
+												"url"
+											]
+										},
+										"card": {
+											"type": "object",
+											"properties": {
+												"id": {
+													"type": "string"
+												},
+												"cardStyle": {
+													"type": "object",
+													"properties": {
+														"type": {
+															"$ref": "#/definitions/FEFrontCardStyle"
+														}
+													},
+													"required": [
+														"type"
+													]
+												},
+												"webPublicationDateOption": {
+													"type": "number"
+												},
+												"lastModifiedOption": {
+													"type": "number"
+												},
+												"trailText": {
+													"type": "string"
+												},
+												"starRating": {
+													"type": "number"
+												},
+												"shortUrlPath": {
+													"type": "string"
+												},
+												"shortUrl": {
+													"type": "string"
+												},
+												"group": {
+													"type": "string"
+												},
+												"isLive": {
+													"type": "boolean"
+												}
+											},
+											"required": [
+												"cardStyle",
+												"group",
+												"id",
+												"isLive",
+												"shortUrl"
+											]
+										},
+										"discussion": {
+											"type": "object",
+											"properties": {
+												"isCommentable": {
+													"type": "boolean"
+												},
+												"isClosedForComments": {
+													"type": "boolean"
+												},
+												"discussionId": {
+													"type": "string"
+												}
+											},
+											"required": [
+												"isClosedForComments",
+												"isCommentable"
+											]
+										},
+										"display": {
+											"type": "object",
+											"properties": {
+												"isBoosted": {
+													"type": "boolean"
+												},
+												"showBoostedHeadline": {
+													"type": "boolean"
+												},
+												"showQuotedHeadline": {
+													"type": "boolean"
+												},
+												"imageHide": {
+													"type": "boolean"
+												},
+												"showLivePlayable": {
+													"type": "boolean"
+												}
+											},
+											"required": [
+												"imageHide",
+												"isBoosted",
+												"showBoostedHeadline",
+												"showLivePlayable",
+												"showQuotedHeadline"
+											]
+										},
+										"format": {
+											"type": "object",
+											"properties": {
+												"design": {
+													"$ref": "#/definitions/FEDesign"
+												},
+												"theme": {
+													"$ref": "#/definitions/FETheme"
+												},
+												"display": {
+													"$ref": "#/definitions/FEDisplay"
+												}
+											},
+											"required": [
+												"design",
+												"display",
+												"theme"
+											]
+										},
+										"enriched": {
+											"type": "object",
+											"properties": {
+												"embedHtml": {
+													"type": "string"
+												},
+												"embedCss": {
+													"type": "string"
+												},
+												"embedJs": {
+													"type": "string"
+												}
+											}
+										},
+										"supportingContent": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"properties": {
+														"type": "object",
+														"properties": {
+															"href": {
+																"type": "string"
+															}
+														}
+													},
+													"header": {
+														"type": "object",
+														"properties": {
+															"kicker": {
+																"type": "object",
+																"properties": {
+																	"item": {
+																		"type": "object",
+																		"properties": {
+																			"properties": {
+																				"type": "object",
+																				"properties": {
+																					"kickerText": {
+																						"type": "string"
+																					}
+																				},
+																				"required": [
+																					"kickerText"
+																				]
+																			}
+																		},
+																		"required": [
+																			"properties"
+																		]
+																	}
+																}
+															},
+															"headline": {
+																"type": "string"
+															},
+															"url": {
+																"type": "string"
+															}
+														},
+														"required": [
+															"headline",
+															"url"
+														]
+													},
+													"format": {
+														"type": "object",
+														"properties": {
+															"design": {
+																"$ref": "#/definitions/FEDesign"
+															},
+															"theme": {
+																"$ref": "#/definitions/FETheme"
+															},
+															"display": {
+																"$ref": "#/definitions/FEDisplay"
+															}
+														},
+														"required": [
+															"design",
+															"display",
+															"theme"
+														]
+													}
+												},
+												"required": [
+													"properties"
+												]
+											}
+										},
+										"cardStyle": {
+											"type": "object",
+											"properties": {
+												"type": {
+													"$ref": "#/definitions/FEFrontCardStyle"
+												}
+											},
+											"required": [
+												"type"
+											]
+										},
+										"type": {
+											"type": "string"
+										}
+									},
+									"required": [
+										"card",
+										"discussion",
+										"display",
+										"header",
+										"properties",
+										"type"
+									]
+								}
+							},
+							"backfill": {
+								"type": "array",
+								"items": {
+									"type": "object",
+									"properties": {
+										"properties": {
+											"type": "object",
+											"properties": {
+												"isBreaking": {
+													"type": "boolean"
+												},
+												"showMainVideo": {
+													"type": "boolean"
+												},
+												"showKickerTag": {
+													"type": "boolean"
+												},
+												"showByline": {
+													"type": "boolean"
+												},
+												"imageSlideshowReplace": {
+													"type": "boolean"
+												},
+												"maybeContent": {
+													"type": "object",
+													"properties": {
+														"trail": {
+															"type": "object",
+															"properties": {
+																"trailPicture": {
+																	"type": "object",
+																	"properties": {
+																		"allImages": {
+																			"type": "array",
+																			"items": {
+																				"type": "object",
+																				"properties": {
+																					"index": {
+																						"type": "number"
+																					},
+																					"fields": {
+																						"type": "object",
+																						"properties": {
+																							"displayCredit": {
+																								"type": "string"
+																							},
+																							"source": {
+																								"type": "string"
+																							},
+																							"photographer": {
+																								"type": "string"
+																							},
+																							"isMaster": {
+																								"type": "string"
+																							},
+																							"altText": {
+																								"type": "string"
+																							},
+																							"height": {
+																								"type": "string"
+																							},
+																							"credit": {
+																								"type": "string"
+																							},
+																							"mediaId": {
+																								"type": "string"
+																							},
+																							"width": {
+																								"type": "string"
+																							}
+																						},
+																						"required": [
+																							"height",
+																							"width"
+																						]
+																					},
+																					"mediaType": {
+																						"type": "string"
+																					},
+																					"url": {
+																						"type": "string"
+																					}
+																				},
+																				"required": [
+																					"fields",
+																					"index",
+																					"mediaType",
+																					"url"
+																				]
+																			}
+																		}
+																	},
+																	"required": [
+																		"allImages"
+																	]
+																},
+																"byline": {
+																	"type": "string"
+																},
+																"thumbnailPath": {
+																	"type": "string"
+																},
+																"webPublicationDate": {
+																	"type": "number"
+																}
+															},
+															"required": [
+																"webPublicationDate"
+															]
+														},
+														"metadata": {
+															"type": "object",
+															"properties": {
+																"id": {
+																	"type": "string"
+																},
+																"webTitle": {
+																	"type": "string"
+																},
+																"webUrl": {
+																	"type": "string"
+																},
+																"type": {
+																	"type": "string"
+																},
+																"sectionId": {
+																	"type": "object",
+																	"properties": {
+																		"value": {
+																			"type": "string"
+																		}
+																	},
+																	"required": [
+																		"value"
+																	]
+																},
+																"format": {
+																	"type": "object",
+																	"properties": {
+																		"design": {
+																			"$ref": "#/definitions/FEDesign"
+																		},
+																		"theme": {
+																			"$ref": "#/definitions/FETheme"
+																		},
+																		"display": {
+																			"$ref": "#/definitions/FEDisplay"
+																		}
+																	},
+																	"required": [
+																		"design",
+																		"display",
+																		"theme"
+																	]
+																}
+															},
+															"required": [
+																"format",
+																"id",
+																"type",
+																"webTitle",
+																"webUrl"
+															]
+														},
+														"fields": {
+															"type": "object",
+															"properties": {
+																"main": {
+																	"type": "string"
+																},
+																"body": {
+																	"type": "string"
+																},
+																"standfirst": {
+																	"type": "string"
+																}
+															},
+															"required": [
+																"body",
+																"main"
+															]
+														},
+														"elements": {
+															"type": "object",
+															"properties": {
+																"mainVideo": {},
+																"mediaAtoms": {
+																	"type": "array",
+																	"items": {
+																		"$ref": "#/definitions/FEMediaAtoms"
+																	}
+																}
+															},
+															"required": [
+																"mediaAtoms"
+															]
+														},
+														"tags": {
+															"type": "object",
+															"properties": {
+																"tags": {
+																	"type": "array",
+																	"items": {
+																		"description": "This type comes from `frontend`, hence the FE prefix.",
+																		"type": "object",
+																		"properties": {
+																			"properties": {
+																				"type": "object",
+																				"properties": {
+																					"id": {
+																						"type": "string"
+																					},
+																					"tagType": {
+																						"type": "string"
+																					},
+																					"webTitle": {
+																						"type": "string"
+																					},
+																					"bio": {
+																						"type": "string"
+																					},
+																					"bylineImageUrl": {
+																						"type": "string"
+																					},
+																					"bylineLargeImageUrl": {
+																						"type": "string"
+																					},
+																					"contributorLargeImagePath": {
+																						"type": "string"
+																					},
+																					"paidContentType": {
+																						"type": "string"
+																					},
+																					"sectionId": {
+																						"type": "string"
+																					},
+																					"sectionName": {
+																						"type": "string"
+																					},
+																					"twitterHandle": {
+																						"type": "string"
+																					},
+																					"url": {
+																						"type": "string"
+																					},
+																					"webUrl": {
+																						"type": "string"
+																					}
+																				},
+																				"required": [
+																					"id",
+																					"tagType",
+																					"webTitle"
+																				]
+																			},
+																			"pagination": {
+																				"type": "object",
+																				"properties": {
+																					"currentPage": {
+																						"type": "number"
+																					},
+																					"lastPage": {
+																						"type": "number"
+																					},
+																					"totalContent": {
+																						"type": "number"
+																					}
+																				},
+																				"required": [
+																					"currentPage",
+																					"lastPage",
+																					"totalContent"
+																				]
+																			}
+																		},
+																		"required": [
+																			"properties"
+																		]
+																	}
+																}
+															},
+															"required": [
+																"tags"
+															]
+														}
+													},
+													"required": [
+														"elements",
+														"fields",
+														"metadata",
+														"tags",
+														"trail"
+													]
+												},
+												"maybeContentId": {
+													"type": "string"
+												},
+												"isLiveBlog": {
+													"type": "boolean"
+												},
+												"isCrossword": {
+													"type": "boolean"
+												},
+												"byline": {
+													"type": "string"
+												},
+												"image": {
+													"type": "object",
+													"properties": {
+														"type": {
+															"type": "string"
+														},
+														"item": {
+															"type": "object",
+															"properties": {
+																"imageSrc": {
+																	"type": "string"
+																},
+																"assets": {
+																	"type": "array",
+																	"items": {
+																		"type": "object",
+																		"properties": {
+																			"imageSrc": {
+																				"type": "string"
+																			},
+																			"imageCaption": {
+																				"type": "string"
+																			}
+																		},
+																		"required": [
+																			"imageSrc"
+																		]
+																	}
+																}
+															}
+														}
+													},
+													"required": [
+														"item",
+														"type"
+													]
+												},
+												"webTitle": {
+													"type": "string"
+												},
+												"linkText": {
+													"type": "string"
+												},
+												"webUrl": {
+													"type": "string"
+												},
+												"editionBrandings": {
+													"type": "array",
+													"items": {
+														"type": "object",
+														"properties": {
+															"edition": {
+																"type": "object",
+																"properties": {
+																	"id": {
+																		"$ref": "#/definitions/EditionId"
+																	}
+																},
+																"required": [
+																	"id"
+																]
+															},
+															"branding": {
+																"$ref": "#/definitions/Branding"
+															}
+														},
+														"required": [
+															"edition"
+														]
+													}
+												},
+												"href": {
+													"type": "string"
+												},
+												"embedUri": {
+													"type": "string"
+												}
+											},
+											"required": [
+												"editionBrandings",
+												"imageSlideshowReplace",
+												"isBreaking",
+												"isCrossword",
+												"isLiveBlog",
+												"showByline",
+												"showKickerTag",
+												"showMainVideo",
+												"webTitle"
+											]
+										},
+										"header": {
+											"type": "object",
+											"properties": {
+												"isVideo": {
+													"type": "boolean"
+												},
+												"isComment": {
+													"type": "boolean"
+												},
+												"isGallery": {
+													"type": "boolean"
+												},
+												"isAudio": {
+													"type": "boolean"
+												},
+												"kicker": {
+													"type": "object",
+													"properties": {
+														"type": {
+															"type": "string"
+														},
+														"item": {
+															"type": "object",
+															"properties": {
+																"properties": {
+																	"type": "object",
+																	"properties": {
+																		"kickerText": {
+																			"type": "string"
+																		}
+																	},
+																	"required": [
+																		"kickerText"
+																	]
+																}
+															},
+															"required": [
+																"properties"
+															]
+														}
+													},
+													"required": [
+														"type"
+													]
+												},
+												"seriesOrBlogKicker": {
+													"type": "object",
+													"properties": {
+														"properties": {
+															"type": "object",
+															"properties": {
+																"kickerText": {
+																	"type": "string"
+																}
+															},
+															"required": [
+																"kickerText"
+															]
+														},
+														"name": {
+															"type": "string"
+														},
+														"url": {
+															"type": "string"
+														},
+														"id": {
+															"type": "string"
+														}
+													},
+													"required": [
+														"id",
+														"name",
+														"properties",
+														"url"
+													]
+												},
+												"headline": {
+													"type": "string"
+												},
+												"url": {
+													"type": "string"
+												},
+												"hasMainVideoElement": {
+													"type": "boolean"
+												}
+											},
+											"required": [
+												"hasMainVideoElement",
+												"headline",
+												"isAudio",
+												"isComment",
+												"isGallery",
+												"isVideo",
+												"url"
+											]
+										},
+										"card": {
+											"type": "object",
+											"properties": {
+												"id": {
+													"type": "string"
+												},
+												"cardStyle": {
+													"type": "object",
+													"properties": {
+														"type": {
+															"$ref": "#/definitions/FEFrontCardStyle"
+														}
+													},
+													"required": [
+														"type"
+													]
+												},
+												"webPublicationDateOption": {
+													"type": "number"
+												},
+												"lastModifiedOption": {
+													"type": "number"
+												},
+												"trailText": {
+													"type": "string"
+												},
+												"starRating": {
+													"type": "number"
+												},
+												"shortUrlPath": {
+													"type": "string"
+												},
+												"shortUrl": {
+													"type": "string"
+												},
+												"group": {
+													"type": "string"
+												},
+												"isLive": {
+													"type": "boolean"
+												}
+											},
+											"required": [
+												"cardStyle",
+												"group",
+												"id",
+												"isLive",
+												"shortUrl"
+											]
+										},
+										"discussion": {
+											"type": "object",
+											"properties": {
+												"isCommentable": {
+													"type": "boolean"
+												},
+												"isClosedForComments": {
+													"type": "boolean"
+												},
+												"discussionId": {
+													"type": "string"
+												}
+											},
+											"required": [
+												"isClosedForComments",
+												"isCommentable"
+											]
+										},
+										"display": {
+											"type": "object",
+											"properties": {
+												"isBoosted": {
+													"type": "boolean"
+												},
+												"showBoostedHeadline": {
+													"type": "boolean"
+												},
+												"showQuotedHeadline": {
+													"type": "boolean"
+												},
+												"imageHide": {
+													"type": "boolean"
+												},
+												"showLivePlayable": {
+													"type": "boolean"
+												}
+											},
+											"required": [
+												"imageHide",
+												"isBoosted",
+												"showBoostedHeadline",
+												"showLivePlayable",
+												"showQuotedHeadline"
+											]
+										},
+										"format": {
+											"type": "object",
+											"properties": {
+												"design": {
+													"$ref": "#/definitions/FEDesign"
+												},
+												"theme": {
+													"$ref": "#/definitions/FETheme"
+												},
+												"display": {
+													"$ref": "#/definitions/FEDisplay"
+												}
+											},
+											"required": [
+												"design",
+												"display",
+												"theme"
+											]
+										},
+										"enriched": {
+											"type": "object",
+											"properties": {
+												"embedHtml": {
+													"type": "string"
+												},
+												"embedCss": {
+													"type": "string"
+												},
+												"embedJs": {
+													"type": "string"
+												}
+											}
+										},
+										"supportingContent": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"properties": {
+														"type": "object",
+														"properties": {
+															"href": {
+																"type": "string"
+															}
+														}
+													},
+													"header": {
+														"type": "object",
+														"properties": {
+															"kicker": {
+																"type": "object",
+																"properties": {
+																	"item": {
+																		"type": "object",
+																		"properties": {
+																			"properties": {
+																				"type": "object",
+																				"properties": {
+																					"kickerText": {
+																						"type": "string"
+																					}
+																				},
+																				"required": [
+																					"kickerText"
+																				]
+																			}
+																		},
+																		"required": [
+																			"properties"
+																		]
+																	}
+																}
+															},
+															"headline": {
+																"type": "string"
+															},
+															"url": {
+																"type": "string"
+															}
+														},
+														"required": [
+															"headline",
+															"url"
+														]
+													},
+													"format": {
+														"type": "object",
+														"properties": {
+															"design": {
+																"$ref": "#/definitions/FEDesign"
+															},
+															"theme": {
+																"$ref": "#/definitions/FETheme"
+															},
+															"display": {
+																"$ref": "#/definitions/FEDisplay"
+															}
+														},
+														"required": [
+															"design",
+															"display",
+															"theme"
+														]
+													}
+												},
+												"required": [
+													"properties"
+												]
+											}
+										},
+										"cardStyle": {
+											"type": "object",
+											"properties": {
+												"type": {
+													"$ref": "#/definitions/FEFrontCardStyle"
+												}
+											},
+											"required": [
+												"type"
+											]
+										},
+										"type": {
+											"type": "string"
+										}
+									},
+									"required": [
+										"card",
+										"discussion",
+										"display",
+										"header",
+										"properties",
+										"type"
+									]
+								}
+							},
+							"treats": {
+								"type": "array",
+								"items": {
+									"type": "object",
+									"properties": {
+										"properties": {
+											"type": "object",
+											"properties": {
+												"isBreaking": {
+													"type": "boolean"
+												},
+												"showMainVideo": {
+													"type": "boolean"
+												},
+												"showKickerTag": {
+													"type": "boolean"
+												},
+												"showByline": {
+													"type": "boolean"
+												},
+												"imageSlideshowReplace": {
+													"type": "boolean"
+												},
+												"maybeContent": {
+													"type": "object",
+													"properties": {
+														"trail": {
+															"type": "object",
+															"properties": {
+																"trailPicture": {
+																	"type": "object",
+																	"properties": {
+																		"allImages": {
+																			"type": "array",
+																			"items": {
+																				"type": "object",
+																				"properties": {
+																					"index": {
+																						"type": "number"
+																					},
+																					"fields": {
+																						"type": "object",
+																						"properties": {
+																							"displayCredit": {
+																								"type": "string"
+																							},
+																							"source": {
+																								"type": "string"
+																							},
+																							"photographer": {
+																								"type": "string"
+																							},
+																							"isMaster": {
+																								"type": "string"
+																							},
+																							"altText": {
+																								"type": "string"
+																							},
+																							"height": {
+																								"type": "string"
+																							},
+																							"credit": {
+																								"type": "string"
+																							},
+																							"mediaId": {
+																								"type": "string"
+																							},
+																							"width": {
+																								"type": "string"
+																							}
+																						},
+																						"required": [
+																							"height",
+																							"width"
+																						]
+																					},
+																					"mediaType": {
+																						"type": "string"
+																					},
+																					"url": {
+																						"type": "string"
+																					}
+																				},
+																				"required": [
+																					"fields",
+																					"index",
+																					"mediaType",
+																					"url"
+																				]
+																			}
+																		}
+																	},
+																	"required": [
+																		"allImages"
+																	]
+																},
+																"byline": {
+																	"type": "string"
+																},
+																"thumbnailPath": {
+																	"type": "string"
+																},
+																"webPublicationDate": {
+																	"type": "number"
+																}
+															},
+															"required": [
+																"webPublicationDate"
+															]
+														},
+														"metadata": {
+															"type": "object",
+															"properties": {
+																"id": {
+																	"type": "string"
+																},
+																"webTitle": {
+																	"type": "string"
+																},
+																"webUrl": {
+																	"type": "string"
+																},
+																"type": {
+																	"type": "string"
+																},
+																"sectionId": {
+																	"type": "object",
+																	"properties": {
+																		"value": {
+																			"type": "string"
+																		}
+																	},
+																	"required": [
+																		"value"
+																	]
+																},
+																"format": {
+																	"type": "object",
+																	"properties": {
+																		"design": {
+																			"$ref": "#/definitions/FEDesign"
+																		},
+																		"theme": {
+																			"$ref": "#/definitions/FETheme"
+																		},
+																		"display": {
+																			"$ref": "#/definitions/FEDisplay"
+																		}
+																	},
+																	"required": [
+																		"design",
+																		"display",
+																		"theme"
+																	]
+																}
+															},
+															"required": [
+																"format",
+																"id",
+																"type",
+																"webTitle",
+																"webUrl"
+															]
+														},
+														"fields": {
+															"type": "object",
+															"properties": {
+																"main": {
+																	"type": "string"
+																},
+																"body": {
+																	"type": "string"
+																},
+																"standfirst": {
+																	"type": "string"
+																}
+															},
+															"required": [
+																"body",
+																"main"
+															]
+														},
+														"elements": {
+															"type": "object",
+															"properties": {
+																"mainVideo": {},
+																"mediaAtoms": {
+																	"type": "array",
+																	"items": {
+																		"$ref": "#/definitions/FEMediaAtoms"
+																	}
+																}
+															},
+															"required": [
+																"mediaAtoms"
+															]
+														},
+														"tags": {
+															"type": "object",
+															"properties": {
+																"tags": {
+																	"type": "array",
+																	"items": {
+																		"description": "This type comes from `frontend`, hence the FE prefix.",
+																		"type": "object",
+																		"properties": {
+																			"properties": {
+																				"type": "object",
+																				"properties": {
+																					"id": {
+																						"type": "string"
+																					},
+																					"tagType": {
+																						"type": "string"
+																					},
+																					"webTitle": {
+																						"type": "string"
+																					},
+																					"bio": {
+																						"type": "string"
+																					},
+																					"bylineImageUrl": {
+																						"type": "string"
+																					},
+																					"bylineLargeImageUrl": {
+																						"type": "string"
+																					},
+																					"contributorLargeImagePath": {
+																						"type": "string"
+																					},
+																					"paidContentType": {
+																						"type": "string"
+																					},
+																					"sectionId": {
+																						"type": "string"
+																					},
+																					"sectionName": {
+																						"type": "string"
+																					},
+																					"twitterHandle": {
+																						"type": "string"
+																					},
+																					"url": {
+																						"type": "string"
+																					},
+																					"webUrl": {
+																						"type": "string"
+																					}
+																				},
+																				"required": [
+																					"id",
+																					"tagType",
+																					"webTitle"
+																				]
+																			},
+																			"pagination": {
+																				"type": "object",
+																				"properties": {
+																					"currentPage": {
+																						"type": "number"
+																					},
+																					"lastPage": {
+																						"type": "number"
+																					},
+																					"totalContent": {
+																						"type": "number"
+																					}
+																				},
+																				"required": [
+																					"currentPage",
+																					"lastPage",
+																					"totalContent"
+																				]
+																			}
+																		},
+																		"required": [
+																			"properties"
+																		]
+																	}
+																}
+															},
+															"required": [
+																"tags"
+															]
+														}
+													},
+													"required": [
+														"elements",
+														"fields",
+														"metadata",
+														"tags",
+														"trail"
+													]
+												},
+												"maybeContentId": {
+													"type": "string"
+												},
+												"isLiveBlog": {
+													"type": "boolean"
+												},
+												"isCrossword": {
+													"type": "boolean"
+												},
+												"byline": {
+													"type": "string"
+												},
+												"image": {
+													"type": "object",
+													"properties": {
+														"type": {
+															"type": "string"
+														},
+														"item": {
+															"type": "object",
+															"properties": {
+																"imageSrc": {
+																	"type": "string"
+																},
+																"assets": {
+																	"type": "array",
+																	"items": {
+																		"type": "object",
+																		"properties": {
+																			"imageSrc": {
+																				"type": "string"
+																			},
+																			"imageCaption": {
+																				"type": "string"
+																			}
+																		},
+																		"required": [
+																			"imageSrc"
+																		]
+																	}
+																}
+															}
+														}
+													},
+													"required": [
+														"item",
+														"type"
+													]
+												},
+												"webTitle": {
+													"type": "string"
+												},
+												"linkText": {
+													"type": "string"
+												},
+												"webUrl": {
+													"type": "string"
+												},
+												"editionBrandings": {
+													"type": "array",
+													"items": {
+														"type": "object",
+														"properties": {
+															"edition": {
+																"type": "object",
+																"properties": {
+																	"id": {
+																		"$ref": "#/definitions/EditionId"
+																	}
+																},
+																"required": [
+																	"id"
+																]
+															},
+															"branding": {
+																"$ref": "#/definitions/Branding"
+															}
+														},
+														"required": [
+															"edition"
+														]
+													}
+												},
+												"href": {
+													"type": "string"
+												},
+												"embedUri": {
+													"type": "string"
+												}
+											},
+											"required": [
+												"editionBrandings",
+												"imageSlideshowReplace",
+												"isBreaking",
+												"isCrossword",
+												"isLiveBlog",
+												"showByline",
+												"showKickerTag",
+												"showMainVideo",
+												"webTitle"
+											]
+										},
+										"header": {
+											"type": "object",
+											"properties": {
+												"isVideo": {
+													"type": "boolean"
+												},
+												"isComment": {
+													"type": "boolean"
+												},
+												"isGallery": {
+													"type": "boolean"
+												},
+												"isAudio": {
+													"type": "boolean"
+												},
+												"kicker": {
+													"type": "object",
+													"properties": {
+														"type": {
+															"type": "string"
+														},
+														"item": {
+															"type": "object",
+															"properties": {
+																"properties": {
+																	"type": "object",
+																	"properties": {
+																		"kickerText": {
+																			"type": "string"
+																		}
+																	},
+																	"required": [
+																		"kickerText"
+																	]
+																}
+															},
+															"required": [
+																"properties"
+															]
+														}
+													},
+													"required": [
+														"type"
+													]
+												},
+												"seriesOrBlogKicker": {
+													"type": "object",
+													"properties": {
+														"properties": {
+															"type": "object",
+															"properties": {
+																"kickerText": {
+																	"type": "string"
+																}
+															},
+															"required": [
+																"kickerText"
+															]
+														},
+														"name": {
+															"type": "string"
+														},
+														"url": {
+															"type": "string"
+														},
+														"id": {
+															"type": "string"
+														}
+													},
+													"required": [
+														"id",
+														"name",
+														"properties",
+														"url"
+													]
+												},
+												"headline": {
+													"type": "string"
+												},
+												"url": {
+													"type": "string"
+												},
+												"hasMainVideoElement": {
+													"type": "boolean"
+												}
+											},
+											"required": [
+												"hasMainVideoElement",
+												"headline",
+												"isAudio",
+												"isComment",
+												"isGallery",
+												"isVideo",
+												"url"
+											]
+										},
+										"card": {
+											"type": "object",
+											"properties": {
+												"id": {
+													"type": "string"
+												},
+												"cardStyle": {
+													"type": "object",
+													"properties": {
+														"type": {
+															"$ref": "#/definitions/FEFrontCardStyle"
+														}
+													},
+													"required": [
+														"type"
+													]
+												},
+												"webPublicationDateOption": {
+													"type": "number"
+												},
+												"lastModifiedOption": {
+													"type": "number"
+												},
+												"trailText": {
+													"type": "string"
+												},
+												"starRating": {
+													"type": "number"
+												},
+												"shortUrlPath": {
+													"type": "string"
+												},
+												"shortUrl": {
+													"type": "string"
+												},
+												"group": {
+													"type": "string"
+												},
+												"isLive": {
+													"type": "boolean"
+												}
+											},
+											"required": [
+												"cardStyle",
+												"group",
+												"id",
+												"isLive",
+												"shortUrl"
+											]
+										},
+										"discussion": {
+											"type": "object",
+											"properties": {
+												"isCommentable": {
+													"type": "boolean"
+												},
+												"isClosedForComments": {
+													"type": "boolean"
+												},
+												"discussionId": {
+													"type": "string"
+												}
+											},
+											"required": [
+												"isClosedForComments",
+												"isCommentable"
+											]
+										},
+										"display": {
+											"type": "object",
+											"properties": {
+												"isBoosted": {
+													"type": "boolean"
+												},
+												"showBoostedHeadline": {
+													"type": "boolean"
+												},
+												"showQuotedHeadline": {
+													"type": "boolean"
+												},
+												"imageHide": {
+													"type": "boolean"
+												},
+												"showLivePlayable": {
+													"type": "boolean"
+												}
+											},
+											"required": [
+												"imageHide",
+												"isBoosted",
+												"showBoostedHeadline",
+												"showLivePlayable",
+												"showQuotedHeadline"
+											]
+										},
+										"format": {
+											"type": "object",
+											"properties": {
+												"design": {
+													"$ref": "#/definitions/FEDesign"
+												},
+												"theme": {
+													"$ref": "#/definitions/FETheme"
+												},
+												"display": {
+													"$ref": "#/definitions/FEDisplay"
+												}
+											},
+											"required": [
+												"design",
+												"display",
+												"theme"
+											]
+										},
+										"enriched": {
+											"type": "object",
+											"properties": {
+												"embedHtml": {
+													"type": "string"
+												},
+												"embedCss": {
+													"type": "string"
+												},
+												"embedJs": {
+													"type": "string"
+												}
+											}
+										},
+										"supportingContent": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"properties": {
+														"type": "object",
+														"properties": {
+															"href": {
+																"type": "string"
+															}
+														}
+													},
+													"header": {
+														"type": "object",
+														"properties": {
+															"kicker": {
+																"type": "object",
+																"properties": {
+																	"item": {
+																		"type": "object",
+																		"properties": {
+																			"properties": {
+																				"type": "object",
+																				"properties": {
+																					"kickerText": {
+																						"type": "string"
+																					}
+																				},
+																				"required": [
+																					"kickerText"
+																				]
+																			}
+																		},
+																		"required": [
+																			"properties"
+																		]
+																	}
+																}
+															},
+															"headline": {
+																"type": "string"
+															},
+															"url": {
+																"type": "string"
+															}
+														},
+														"required": [
+															"headline",
+															"url"
+														]
+													},
+													"format": {
+														"type": "object",
+														"properties": {
+															"design": {
+																"$ref": "#/definitions/FEDesign"
+															},
+															"theme": {
+																"$ref": "#/definitions/FETheme"
+															},
+															"display": {
+																"$ref": "#/definitions/FEDisplay"
+															}
+														},
+														"required": [
+															"design",
+															"display",
+															"theme"
+														]
+													}
+												},
+												"required": [
+													"properties"
+												]
+											}
+										},
+										"cardStyle": {
+											"type": "object",
+											"properties": {
+												"type": {
+													"$ref": "#/definitions/FEFrontCardStyle"
+												}
+											},
+											"required": [
+												"type"
+											]
+										},
+										"type": {
+											"type": "string"
+										}
+									},
+									"required": [
+										"card",
+										"discussion",
+										"display",
+										"header",
+										"properties",
+										"type"
+									]
+								}
+							},
+							"lastUpdate": {
+								"type": "number"
+							},
+							"href": {
+								"type": "string"
+							},
+							"groups": {
+								"type": "array",
+								"items": {
+									"type": "string"
+								}
+							},
+							"collectionType": {
+								"$ref": "#/definitions/FEContainerType"
+							},
+							"uneditable": {
+								"type": "boolean"
+							},
+							"showTags": {
+								"type": "boolean"
+							},
+							"showSections": {
+								"type": "boolean"
+							},
+							"hideKickers": {
+								"type": "boolean"
+							},
+							"showDateHeader": {
+								"type": "boolean"
+							},
+							"showLatestUpdate": {
+								"type": "boolean"
+							},
+							"config": {
+								"type": "object",
+								"properties": {
+									"displayName": {
+										"type": "string"
+									},
+									"metadata": {
+										"type": "array",
+										"items": {
+											"type": "object",
+											"properties": {
+												"type": {
+													"$ref": "#/definitions/FEContainerPalette"
+												}
+											},
+											"required": [
+												"type"
+											]
+										}
+									},
+									"collectionType": {
+										"$ref": "#/definitions/FEContainerType"
+									},
+									"href": {
+										"type": "string"
+									},
+									"groups": {
+										"type": "array",
+										"items": {
+											"type": "string"
+										}
+									},
+									"uneditable": {
+										"type": "boolean"
+									},
+									"showTags": {
+										"type": "boolean"
+									},
+									"showSections": {
+										"type": "boolean"
+									},
+									"hideKickers": {
+										"type": "boolean"
+									},
+									"showDateHeader": {
+										"type": "boolean"
+									},
+									"showLatestUpdate": {
+										"type": "boolean"
+									},
+									"excludeFromRss": {
+										"type": "boolean"
+									},
+									"showTimestamps": {
+										"type": "boolean"
+									},
+									"hideShowMore": {
+										"type": "boolean"
+									},
+									"platform": {
+										"type": "string"
+									}
+								},
+								"required": [
+									"collectionType",
+									"displayName",
+									"excludeFromRss",
+									"hideKickers",
+									"hideShowMore",
+									"platform",
+									"showDateHeader",
+									"showLatestUpdate",
+									"showSections",
+									"showTags",
+									"showTimestamps",
+									"uneditable"
+								]
+							},
+							"hasMore": {
+								"type": "boolean"
+							},
+							"targetedTerritory": {
+								"$ref": "#/definitions/Territory"
+							}
+						},
+						"required": [
+							"backfill",
+							"collectionType",
+							"config",
+							"curated",
+							"displayName",
+							"hasMore",
+							"hideKickers",
+							"id",
+							"showDateHeader",
+							"showLatestUpdate",
+							"showSections",
+							"showTags",
+							"treats",
+							"uneditable"
+						]
+					}
+				}
+			},
+			"required": [
+				"collections",
+				"frontProperties",
+				"id",
+				"seoData"
+			]
+		},
+		"Record<string,unknown>": {
+			"type": "object"
+		},
+		"FEDesign": {
+			"enum": [
+				"AnalysisDesign",
+				"ArticleDesign",
+				"AudioDesign",
+				"CommentDesign",
+				"DeadBlogDesign",
+				"EditorialDesign",
+				"ExplainerDesign",
+				"FeatureDesign",
+				"FullPageInteractiveDesign",
+				"GalleryDesign",
+				"InteractiveDesign",
+				"InterviewDesign",
+				"LetterDesign",
+				"LiveBlogDesign",
+				"MatchReportDesign",
+				"NewsletterSignupDesign",
+				"ObituaryDesign",
+				"PhotoEssayDesign",
+				"PrintShopDesign",
+				"ProfileDesign",
+				"QuizDesign",
+				"RecipeDesign",
+				"ReviewDesign",
+				"TimelineDesign",
+				"VideoDesign"
+			],
+			"type": "string"
+		},
+		"FETheme": {
+			"enum": [
+				"CulturePillar",
+				"Labs",
+				"LifestylePillar",
+				"NewsPillar",
+				"OpinionPillar",
+				"SpecialReportAltTheme",
+				"SpecialReportTheme",
+				"SportPillar"
+			],
+			"type": "string"
+		},
+		"FEDisplay": {
+			"enum": [
+				"ImmersiveDisplay",
+				"NumberedListDisplay",
+				"ShowcaseDisplay",
+				"StandardDisplay"
+			],
+			"type": "string"
+		},
+		"FEMediaAtoms": {
+			"type": "object",
+			"properties": {
+				"duration": {
+					"type": "number"
+				}
+			}
+		},
+		"EditionId": {
+			"enum": [
+				"AU",
+				"EUR",
+				"INT",
+				"UK",
+				"US"
+			],
+			"type": "string"
+		},
+		"Branding": {
+			"type": "object",
+			"properties": {
+				"brandingType": {
+					"type": "object",
+					"properties": {
+						"name": {
+							"type": "string"
+						}
+					},
+					"required": [
+						"name"
+					]
+				},
+				"sponsorName": {
+					"type": "string"
+				},
+				"logo": {
+					"type": "object",
+					"properties": {
+						"src": {
+							"type": "string"
+						},
+						"link": {
+							"type": "string"
+						},
+						"label": {
+							"type": "string"
+						},
+						"dimensions": {
+							"type": "object",
+							"properties": {
+								"width": {
+									"type": "number"
+								},
+								"height": {
+									"type": "number"
+								}
+							},
+							"required": [
+								"height",
+								"width"
+							]
+						}
+					},
+					"required": [
+						"dimensions",
+						"label",
+						"link",
+						"src"
+					]
+				},
+				"aboutThisLink": {
+					"type": "string"
+				},
+				"logoForDarkBackground": {
+					"type": "object",
+					"properties": {
+						"src": {
+							"type": "string"
+						},
+						"link": {
+							"type": "string"
+						},
+						"label": {
+							"type": "string"
+						},
+						"dimensions": {
+							"type": "object",
+							"properties": {
+								"width": {
+									"type": "number"
+								},
+								"height": {
+									"type": "number"
+								}
+							},
+							"required": [
+								"height",
+								"width"
+							]
+						}
+					},
+					"required": [
+						"dimensions",
+						"label",
+						"link",
+						"src"
+					]
+				}
+			},
+			"required": [
+				"aboutThisLink",
+				"logo",
+				"sponsorName"
+			]
+		},
+		"FEFrontCardStyle": {
+			"enum": [
+				"Analysis",
+				"Comment",
+				"DeadBlog",
+				"DefaultCardstyle",
+				"Editorial",
+				"ExternalLink",
+				"Feature",
+				"Letters",
+				"LiveBlog",
+				"Media",
+				"Review",
+				"SpecialReport",
+				"SpecialReportAlt"
+			],
+			"type": "string"
+		},
+		"FEContainerType": {
+			"enum": [
+				"dynamic/fast",
+				"dynamic/package",
+				"dynamic/slow",
+				"dynamic/slow-mpu",
+				"fixed/large/slow-XIV",
+				"fixed/medium/fast-XI",
+				"fixed/medium/fast-XII",
+				"fixed/medium/slow-VI",
+				"fixed/medium/slow-VII",
+				"fixed/medium/slow-XII-mpu",
+				"fixed/small/fast-VIII",
+				"fixed/small/slow-I",
+				"fixed/small/slow-III",
+				"fixed/small/slow-IV",
+				"fixed/small/slow-V-half",
+				"fixed/small/slow-V-mpu",
+				"fixed/small/slow-V-third",
+				"fixed/thrasher",
+				"fixed/video",
+				"fixed/video/vertical",
+				"nav/list",
+				"nav/media-list",
+				"news/most-popular"
+			],
+			"type": "string"
+		},
+		"FEContainerPalette": {
+			"enum": [
+				"Branded",
+				"Breaking",
+				"BreakingPalette",
+				"Canonical",
+				"Dynamo",
+				"DynamoLike",
+				"EventAltPalette",
+				"EventPalette",
+				"InvestigationPalette",
+				"LongRunningAltPalette",
+				"LongRunningPalette",
+				"Podcast",
+				"SombreAltPalette",
+				"SombrePalette",
+				"Special",
+				"SpecialReportAltPalette"
+			],
+			"type": "string"
+		},
+		"Territory": {
+			"description": "List of territories that can be targetted against.",
+			"enum": [
+				"AU-NSW",
+				"AU-QLD",
+				"AU-VIC",
+				"EU-27",
+				"NZ",
+				"US-East-Coast",
+				"US-West-Coast",
+				"XX"
+			],
+			"type": "string"
+		},
+		"FENavType": {
+			"type": "object",
+			"properties": {
+				"currentUrl": {
+					"type": "string"
+				},
+				"pillars": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/FELinkType"
+					}
+				},
+				"otherLinks": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/FELinkType"
+					}
+				},
+				"brandExtensions": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/FELinkType"
+					}
+				},
+				"currentNavLink": {
+					"$ref": "#/definitions/FELinkType"
+				},
+				"currentNavLinkTitle": {
+					"type": "string"
+				},
+				"currentPillarTitle": {
+					"type": "string"
+				},
+				"subNavSections": {
+					"type": "object",
+					"properties": {
+						"parent": {
+							"$ref": "#/definitions/FELinkType"
+						},
+						"links": {
+							"type": "array",
+							"items": {
+								"$ref": "#/definitions/FELinkType"
+							}
+						}
+					},
+					"required": [
+						"links"
+					]
+				},
+				"readerRevenueLinks": {
+					"$ref": "#/definitions/ReaderRevenuePositions"
+				}
+			},
+			"required": [
+				"brandExtensions",
+				"currentUrl",
+				"otherLinks",
+				"pillars",
+				"readerRevenueLinks"
+			]
+		},
+		"FELinkType": {
+			"type": "object",
+			"properties": {
+				"url": {
+					"type": "string"
+				},
+				"title": {
+					"type": "string"
+				},
+				"longTitle": {
+					"type": "string"
+				},
+				"iconName": {
+					"type": "string"
+				},
+				"children": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/FELinkType"
+					}
+				},
+				"pillar": {
+					"$ref": "#/definitions/LegacyPillar"
+				},
+				"more": {
+					"type": "boolean"
+				},
+				"classList": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				}
+			},
+			"required": [
+				"title",
+				"url"
+			]
+		},
+		"LegacyPillar": {
+			"enum": [
+				"culture",
+				"labs",
+				"lifestyle",
+				"news",
+				"opinion",
+				"sport"
+			],
+			"type": "string"
+		},
+		"ReaderRevenuePositions": {
+			"type": "object",
+			"properties": {
+				"header": {
+					"$ref": "#/definitions/ReaderRevenueCategories"
+				},
+				"footer": {
+					"$ref": "#/definitions/ReaderRevenueCategories"
+				},
+				"sideMenu": {
+					"$ref": "#/definitions/ReaderRevenueCategories"
+				},
+				"ampHeader": {
+					"$ref": "#/definitions/ReaderRevenueCategories"
+				},
+				"ampFooter": {
+					"$ref": "#/definitions/ReaderRevenueCategories"
+				}
+			},
+			"required": [
+				"ampFooter",
+				"ampHeader",
+				"footer",
+				"header",
+				"sideMenu"
+			]
+		},
+		"ReaderRevenueCategories": {
+			"type": "object",
+			"properties": {
+				"contribute": {
+					"type": "string"
+				},
+				"subscribe": {
+					"type": "string"
+				},
+				"support": {
+					"type": "string"
+				},
+				"supporter": {
+					"type": "string"
+				},
+				"gifting": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"contribute",
+				"subscribe",
+				"support",
+				"supporter"
+			]
+		},
+		"Switches": {
+			"type": "object",
+			"additionalProperties": {
+				"type": "boolean"
+			}
+		},
+		"StageType": {
+			"enum": [
+				"CODE",
+				"DEV",
+				"PROD"
+			],
+			"type": "string"
+		},
+		"FooterType": {
+			"type": "object",
+			"properties": {
+				"footerLinks": {
+					"type": "array",
+					"items": {
+						"type": "array",
+						"items": {
+							"$ref": "#/definitions/FooterLink"
+						}
+					}
+				}
+			},
+			"required": [
+				"footerLinks"
+			]
+		},
+		"FooterLink": {
+			"type": "object",
+			"properties": {
+				"text": {
+					"type": "string"
+				},
+				"url": {
+					"type": "string"
+				},
+				"dataLinkName": {
+					"type": "string"
+				},
+				"extraClasses": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"dataLinkName",
+				"text",
+				"url"
+			]
+		},
+		"FETrailType": {
+			"type": "object",
+			"properties": {
+				"format": {
+					"type": "object",
+					"properties": {
+						"design": {
+							"$ref": "#/definitions/FEDesign"
+						},
+						"theme": {
+							"$ref": "#/definitions/FETheme"
+						},
+						"display": {
+							"$ref": "#/definitions/FEDisplay"
+						}
+					},
+					"required": [
+						"design",
+						"display",
+						"theme"
+					]
+				},
+				"designType": {
+					"type": "string"
+				},
+				"pillar": {
+					"type": "string"
+				},
+				"carouselImages": {
+					"type": "object",
+					"additionalProperties": {
+						"type": "string"
+					}
+				},
+				"isLiveBlog": {
+					"type": "boolean"
+				},
+				"masterImage": {
+					"type": "string"
+				},
+				"url": {
+					"type": "string"
+				},
+				"headline": {
+					"type": "string"
+				},
+				"webPublicationDate": {
+					"type": "string"
+				},
+				"image": {
+					"type": "string"
+				},
+				"avatarUrl": {
+					"type": "string"
+				},
+				"mediaType": {
+					"$ref": "#/definitions/MediaType"
+				},
+				"mediaDuration": {
+					"type": "number"
+				},
+				"ageWarning": {
+					"type": "string"
+				},
+				"byline": {
+					"type": "string"
+				},
+				"showByline": {
+					"type": "boolean"
+				},
+				"kickerText": {
+					"type": "string"
+				},
+				"shortUrl": {
+					"type": "string"
+				},
+				"commentCount": {
+					"type": "number"
+				},
+				"starRating": {
+					"type": "number"
+				},
+				"linkText": {
+					"type": "string"
+				},
+				"branding": {
+					"$ref": "#/definitions/Branding"
+				},
+				"isSnap": {
+					"type": "boolean"
+				},
+				"isCrossword": {
+					"type": "boolean"
+				},
+				"snapData": {
+					"type": "object",
+					"properties": {
+						"embedHtml": {
+							"type": "string"
+						},
+						"embedCss": {
+							"type": "string"
+						},
+						"embedJs": {
+							"type": "string"
+						}
+					}
+				},
+				"showQuotedHeadline": {
+					"type": "boolean"
+				},
+				"discussion": {
+					"type": "object",
+					"properties": {
+						"isCommentable": {
+							"type": "boolean"
+						},
+						"isClosedForComments": {
+							"type": "boolean"
+						},
+						"discussionId": {
+							"type": "string"
+						}
+					},
+					"required": [
+						"isClosedForComments",
+						"isCommentable"
+					]
+				},
+				"showMainVideo": {
+					"type": "boolean"
+				}
+			},
+			"required": [
+				"format",
+				"headline",
+				"url"
+			]
+		},
+		"MediaType": {
+			"enum": [
+				"Audio",
+				"Gallery",
+				"Video"
+			],
+			"type": "string"
+		}
+	},
+	"$schema": "http://json-schema.org/draft-07/schema#"
 }

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -78,6 +78,7 @@ type FEContainerType =
 	| 'fixed/small/slow-V-third'
 	| 'fixed/thrasher'
 	| 'fixed/video'
+	| 'fixed/video/vertical'
 	| 'nav/list'
 	| 'nav/media-list'
 	| 'news/most-popular';


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Adds  `fixed/video/vertical` to fronts container types.
## Why?
This is a new layout. Without this change, DCR crashes if the layout is added to the front. This layout has not been implemented and is not yet supported. 


## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |


[before]: https://github.com/guardian/dotcom-rendering/assets/20416599/6d68e78c-3a69-4f6a-950d-84254b1c7a77
[after]: https://github.com/guardian/dotcom-rendering/assets/20416599/02a84dd2-a823-471c-b4b4-a6b87a74b6a0


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
