### PR TITLE
Share AdTargeting between Islands

### DIFF
--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -278,27 +278,6 @@ interface FENavType {
 type StageType = 'DEV' | 'CODE' | 'PROD';
 
 /**
- * BlocksRequest is the expected body format for POST requests made to /Blocks
- */
-interface FEBlocksRequest {
-	blocks: Block[];
-	format: FEFormat;
-	host?: string;
-	pageId: string;
-	webTitle: string;
-	ajaxUrl: string;
-	isAdFreeUser: boolean;
-	isSensitive: boolean;
-	edition: string;
-	section: string;
-	sharedAdTargeting: Record<string, unknown>;
-	adUnit: string;
-	videoDuration?: number;
-	switches: { [key: string]: boolean };
-	keywordIds: string;
-}
-
-/**
  * KeyEventsRequest is the expected body format for POST requests made to /KeyEvents
  */
 interface FEKeyEventsRequest {

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -62,7 +62,7 @@
 		"@emotion/react": "11.10.5",
 		"@emotion/server": "11.10.0",
 		"@guardian/ab-core": "4.0.0",
-		"@guardian/atoms-rendering": "31.0.0",
+		"@guardian/atoms-rendering": "32.2.0",
 		"@guardian/braze-components": "13.3.0",
 		"@guardian/bridget": "2.3.0",
 		"@guardian/browserslist-config": "5.0.0",

--- a/dotcom-rendering/src/components/ArticleBody.tsx
+++ b/dotcom-rendering/src/components/ArticleBody.tsx
@@ -20,7 +20,6 @@ type Props = {
 	format: ArticleFormat;
 	blocks: Block[];
 	pinnedPost?: Block;
-	adTargeting: AdTargeting;
 	host?: string;
 	pageId: string;
 	webTitle: string;
@@ -123,7 +122,6 @@ export const ArticleBody = ({
 	format,
 	blocks,
 	pinnedPost,
-	adTargeting,
 	host,
 	pageId,
 	webTitle,
@@ -183,7 +181,6 @@ export const ArticleBody = ({
 					format={format}
 					blocks={blocks}
 					pinnedPost={pinnedPost}
-					adTargeting={adTargeting}
 					host={host}
 					pageId={pageId}
 					webTitle={webTitle}
@@ -239,7 +236,6 @@ export const ArticleBody = ({
 				<ArticleRenderer
 					format={format}
 					elements={blocks[0] ? blocks[0].elements : []}
-					adTargeting={adTargeting}
 					host={host}
 					pageId={pageId}
 					webTitle={webTitle}

--- a/dotcom-rendering/src/components/ArticlePage.tsx
+++ b/dotcom-rendering/src/components/ArticlePage.tsx
@@ -3,6 +3,7 @@ import { ArticleDesign } from '@guardian/libs';
 import { brandAlt, focusHalo, neutral } from '@guardian/source-foundations';
 import { StrictMode } from 'react';
 import { DecideLayout } from '../layouts/DecideLayout';
+import { buildAdTargeting } from '../lib/ad-targeting';
 import { filterABTestSwitches } from '../model/enhance-switches';
 import type { NavType } from '../model/extract-nav';
 import type { FEArticleType } from '../types/frontend';
@@ -16,6 +17,7 @@ import { Island } from './Island';
 import { Metrics } from './Metrics.importable';
 import { ReaderRevenueDev } from './ReaderRevenueDev.importable';
 import { SetABTests } from './SetABTests.importable';
+import { SetAdTargeting } from './SetAdTargeting.importable';
 import { SkipTo } from './SkipTo';
 
 interface BaseProps {
@@ -39,6 +41,16 @@ interface AppProps extends BaseProps {
  * */
 export const ArticlePage = (props: WebProps | AppProps) => {
 	const { article, format, renderingTarget } = props;
+
+	const adTargeting = buildAdTargeting({
+		isAdFreeUser: article.isAdFreeUser,
+		isSensitive: article.config.isSensitive,
+		edition: article.config.edition,
+		section: article.config.section,
+		sharedAdTargeting: article.config.sharedAdTargeting,
+		adUnit: article.config.adUnit,
+	});
+
 	return (
 		<StrictMode>
 			<Global
@@ -101,6 +113,9 @@ export const ArticlePage = (props: WebProps | AppProps) => {
 							pageIsSensitive={article.config.isSensitive}
 							isDev={!!article.config.isDev}
 						/>
+					</Island>
+					<Island clientOnly={true}>
+						<SetAdTargeting adTargeting={adTargeting} />
 					</Island>
 				</>
 			)}

--- a/dotcom-rendering/src/components/EnhancePinnedPost.importable.tsx
+++ b/dotcom-rendering/src/components/EnhancePinnedPost.importable.tsx
@@ -1,9 +1,8 @@
 import { useEffect, useRef, useState } from 'react';
 import { initPerf } from '../client/initPerf';
 import { submitComponentEvent } from '../client/ophan/ophan';
+import { isServer } from '../lib/isServer';
 import { useIsInView } from '../lib/useIsInView';
-
-const isServer = typeof window === 'undefined';
 
 const pinnedPost: HTMLElement | null = !isServer
 	? window.document.querySelector('[data-gu-marker=pinned-post]')

--- a/dotcom-rendering/src/components/FrontPage.tsx
+++ b/dotcom-rendering/src/components/FrontPage.tsx
@@ -2,6 +2,7 @@ import { css, Global } from '@emotion/react';
 import { brandAlt, focusHalo, neutral } from '@guardian/source-foundations';
 import { StrictMode } from 'react';
 import { FrontLayout } from '../layouts/FrontLayout';
+import { buildAdTargeting } from '../lib/ad-targeting';
 import { filterABTestSwitches } from '../model/enhance-switches';
 import type { NavType } from '../model/extract-nav';
 import type { DCRFrontType } from '../types/front';
@@ -12,6 +13,7 @@ import { FocusStyles } from './FocusStyles.importable';
 import { Island } from './Island';
 import { Metrics } from './Metrics.importable';
 import { SetABTests } from './SetABTests.importable';
+import { SetAdTargeting } from './SetAdTargeting.importable';
 import { ShowHideContainers } from './ShowHideContainers.importable';
 import { SkipTo } from './SkipTo';
 
@@ -29,6 +31,15 @@ type Props = {
  * @param {NAVType} props.NAV - The article JSON data
  * */
 export const FrontPage = ({ front, NAV }: Props) => {
+	const adTargeting = buildAdTargeting({
+		isAdFreeUser: front.isAdFreeUser,
+		isSensitive: front.config.isSensitive,
+		edition: front.config.edition,
+		section: front.config.section,
+		sharedAdTargeting: front.config.sharedAdTargeting,
+		adUnit: front.config.adUnit,
+	});
+
 	return (
 		<StrictMode>
 			<Global
@@ -74,6 +85,9 @@ export const FrontPage = ({ front, NAV }: Props) => {
 					pageIsSensitive={front.config.isSensitive}
 					isDev={!!front.config.isDev}
 				/>
+			</Island>
+			<Island clientOnly={true}>
+				<SetAdTargeting adTargeting={adTargeting} />
 			</Island>
 			<FrontLayout front={front} NAV={NAV} />
 		</StrictMode>

--- a/dotcom-rendering/src/components/LiveBlock.stories.tsx
+++ b/dotcom-rendering/src/components/LiveBlock.stories.tsx
@@ -64,10 +64,6 @@ export const VideoAsSecond = () => {
 	return (
 		<Wrapper>
 			<LiveBlock
-				adTargeting={{
-					customParams: { sens: 'f', urlkw: [] },
-					adUnit: '',
-				}}
 				format={{
 					theme: ArticlePillar.News,
 					design: ArticleDesign.LiveBlog,
@@ -113,10 +109,6 @@ export const Title = () => {
 	return (
 		<Wrapper>
 			<LiveBlock
-				adTargeting={{
-					customParams: { sens: 'f', urlkw: [] },
-					adUnit: '',
-				}}
 				format={{
 					theme: ArticlePillar.News,
 					design: ArticleDesign.LiveBlog,
@@ -183,10 +175,6 @@ export const Video = () => {
 	return (
 		<Wrapper>
 			<LiveBlock
-				adTargeting={{
-					customParams: { sens: 'f', urlkw: [] },
-					adUnit: '',
-				}}
 				format={{
 					theme: ArticlePillar.News,
 					design: ArticleDesign.LiveBlog,
@@ -228,10 +216,6 @@ export const RichLink = () => {
 	return (
 		<Wrapper>
 			<LiveBlock
-				adTargeting={{
-					customParams: { sens: 'f', urlkw: [] },
-					adUnit: '',
-				}}
 				format={{
 					theme: ArticlePillar.News,
 					design: ArticleDesign.LiveBlog,
@@ -264,10 +248,6 @@ export const FirstImage = () => {
 	return (
 		<Wrapper>
 			<LiveBlock
-				adTargeting={{
-					customParams: { sens: 'f', urlkw: [] },
-					adUnit: '',
-				}}
 				format={{
 					theme: ArticlePillar.News,
 					design: ArticleDesign.LiveBlog,
@@ -326,10 +306,6 @@ export const ImageRoles = () => {
 	return (
 		<Wrapper>
 			<LiveBlock
-				adTargeting={{
-					customParams: { sens: 'f', urlkw: [] },
-					adUnit: '',
-				}}
 				format={{
 					theme: ArticlePillar.News,
 					design: ArticleDesign.LiveBlog,
@@ -377,10 +353,6 @@ export const Thumbnail = () => {
 	return (
 		<Wrapper>
 			<LiveBlock
-				adTargeting={{
-					customParams: { sens: 'f', urlkw: [] },
-					adUnit: '',
-				}}
 				format={{
 					theme: ArticlePillar.News,
 					design: ArticleDesign.LiveBlog,
@@ -414,10 +386,6 @@ export const ImageAndTitle = () => {
 	return (
 		<Wrapper>
 			<LiveBlock
-				adTargeting={{
-					customParams: { sens: 'f', urlkw: [] },
-					adUnit: '',
-				}}
 				format={{
 					theme: ArticlePillar.News,
 					design: ArticleDesign.LiveBlog,
@@ -447,10 +415,6 @@ export const Updated = () => {
 	return (
 		<Wrapper>
 			<LiveBlock
-				adTargeting={{
-					customParams: { sens: 'f', urlkw: [] },
-					adUnit: '',
-				}}
 				format={{
 					theme: ArticlePillar.News,
 					design: ArticleDesign.LiveBlog,
@@ -484,10 +448,6 @@ export const Contributor = () => {
 	return (
 		<Wrapper>
 			<LiveBlock
-				adTargeting={{
-					customParams: { sens: 'f', urlkw: [] },
-					adUnit: '',
-				}}
 				format={{
 					theme: ArticlePillar.News,
 					design: ArticleDesign.LiveBlog,
@@ -519,10 +479,6 @@ export const NoAvatar = () => {
 	return (
 		<Wrapper>
 			<LiveBlock
-				adTargeting={{
-					customParams: { sens: 'f', urlkw: [] },
-					adUnit: '',
-				}}
 				format={{
 					theme: ArticlePillar.Opinion,
 					design: ArticleDesign.LiveBlog,
@@ -557,10 +513,6 @@ export const TitleAndContributor = () => {
 	return (
 		<Wrapper>
 			<LiveBlock
-				adTargeting={{
-					customParams: { sens: 'f', urlkw: [] },
-					adUnit: '',
-				}}
 				format={{
 					theme: ArticlePillar.Sport,
 					design: ArticleDesign.LiveBlog,

--- a/dotcom-rendering/src/components/LiveBlock.tsx
+++ b/dotcom-rendering/src/components/LiveBlock.tsx
@@ -10,7 +10,6 @@ type Props = {
 	block: Block;
 	pageId: string;
 	webTitle: string;
-	adTargeting: AdTargeting;
 	host?: string;
 	ajaxUrl: string;
 	isAdFreeUser: boolean;
@@ -26,7 +25,6 @@ export const LiveBlock = ({
 	block,
 	pageId,
 	webTitle,
-	adTargeting,
 	host = 'https://www.theguardian.com',
 	ajaxUrl,
 	isAdFreeUser,
@@ -68,7 +66,6 @@ export const LiveBlock = ({
 					key={index}
 					format={format}
 					element={element}
-					adTargeting={adTargeting}
 					ajaxUrl={ajaxUrl}
 					host={host}
 					index={index}

--- a/dotcom-rendering/src/components/LiveBlogBlocksAndAdverts.tsx
+++ b/dotcom-rendering/src/components/LiveBlogBlocksAndAdverts.tsx
@@ -9,7 +9,6 @@ import { LiveBlock } from './LiveBlock';
 type Props = {
 	format: ArticleFormat;
 	blocks: Block[];
-	adTargeting: AdTargeting;
 	pinnedPost?: Block;
 	host?: string;
 	pageId: string;
@@ -26,7 +25,6 @@ export const LiveBlogBlocksAndAdverts = ({
 	format,
 	blocks,
 	pinnedPost,
-	adTargeting,
 	host,
 	pageId,
 	webTitle,
@@ -47,7 +45,6 @@ export const LiveBlogBlocksAndAdverts = ({
 						block={block}
 						pageId={pageId}
 						webTitle={webTitle}
-						adTargeting={adTargeting}
 						host={host}
 						ajaxUrl={ajaxUrl}
 						isLiveUpdate={isLiveUpdate}
@@ -93,7 +90,6 @@ export const LiveBlogBlocksAndAdverts = ({
 							block={block}
 							pageId={pageId}
 							webTitle={webTitle}
-							adTargeting={adTargeting}
 							host={host}
 							ajaxUrl={ajaxUrl}
 							isLiveUpdate={isLiveUpdate}

--- a/dotcom-rendering/src/components/Liveness.importable.tsx
+++ b/dotcom-rendering/src/components/Liveness.importable.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from 'react';
 import ReactDOM from 'react-dom';
 import { initHydration } from '../client/islands/initHydration';
 import { updateTimeElement } from '../client/relativeTime/updateTimeElements';
+import { isServer } from '../lib/isServer';
 import { useApi } from '../lib/useApi';
 import { Toast } from './Toast';
 
@@ -18,8 +19,6 @@ type Props = {
 	hasPinnedPost: boolean;
 	selectedTopics?: Topic[];
 };
-
-const isServer = typeof window === 'undefined';
 
 const topOfBlog: Element | null = !isServer
 	? window.document.getElementById('top-of-blog')

--- a/dotcom-rendering/src/components/MainMedia.tsx
+++ b/dotcom-rendering/src/components/MainMedia.tsx
@@ -65,7 +65,6 @@ type Props = {
 	format: ArticleFormat;
 	elements: FEElement[];
 	hideCaption?: boolean;
-	adTargeting?: AdTargeting;
 	starRating?: number;
 	host?: string;
 	pageId: string;
@@ -80,7 +79,6 @@ export const MainMedia = ({
 	elements,
 	format,
 	hideCaption,
-	adTargeting,
 	starRating,
 	host,
 	pageId,
@@ -98,7 +96,6 @@ export const MainMedia = ({
 					key={index}
 					format={format}
 					element={element}
-					adTargeting={adTargeting}
 					ajaxUrl={ajaxUrl}
 					host={host}
 					index={index}

--- a/dotcom-rendering/src/components/PinnedPost.stories.tsx
+++ b/dotcom-rendering/src/components/PinnedPost.stories.tsx
@@ -74,10 +74,6 @@ export const Sport = () => {
 		<Wrapper>
 			<PinnedPost pinnedPost={block} format={format}>
 				<LiveBlock
-					adTargeting={{
-						customParams: { sens: 'f', urlkw: [] },
-						adUnit: '',
-					}}
 					format={format}
 					block={block}
 					pageId=""
@@ -123,10 +119,6 @@ export const News = () => {
 		<Wrapper>
 			<PinnedPost pinnedPost={block} format={format}>
 				<LiveBlock
-					adTargeting={{
-						customParams: { sens: 'f', urlkw: [] },
-						adUnit: '',
-					}}
 					format={format}
 					block={block}
 					pageId=""
@@ -172,10 +164,6 @@ export const Culture = () => {
 		<Wrapper>
 			<PinnedPost pinnedPost={block} format={format}>
 				<LiveBlock
-					adTargeting={{
-						customParams: { sens: 'f', urlkw: [] },
-						adUnit: '',
-					}}
 					format={format}
 					block={block}
 					pageId=""
@@ -221,10 +209,6 @@ export const Lifestyle = () => {
 		<Wrapper>
 			<PinnedPost pinnedPost={block} format={format}>
 				<LiveBlock
-					adTargeting={{
-						customParams: { sens: 'f', urlkw: [] },
-						adUnit: '',
-					}}
 					format={format}
 					block={block}
 					pageId=""
@@ -270,10 +254,6 @@ export const Opinion = () => {
 		<Wrapper>
 			<PinnedPost pinnedPost={block} format={format}>
 				<LiveBlock
-					adTargeting={{
-						customParams: { sens: 'f', urlkw: [] },
-						adUnit: '',
-					}}
 					format={format}
 					block={block}
 					pageId=""
@@ -319,10 +299,6 @@ export const SpecialReport = () => {
 		<Wrapper>
 			<PinnedPost pinnedPost={block} format={format}>
 				<LiveBlock
-					adTargeting={{
-						customParams: { sens: 'f', urlkw: [] },
-						adUnit: '',
-					}}
 					format={format}
 					block={block}
 					pageId=""
@@ -368,10 +344,6 @@ export const Labs = () => {
 		<Wrapper>
 			<PinnedPost pinnedPost={block} format={format}>
 				<LiveBlock
-					adTargeting={{
-						customParams: { sens: 'f', urlkw: [] },
-						adUnit: '',
-					}}
 					format={format}
 					block={block}
 					pageId=""

--- a/dotcom-rendering/src/components/RecipeMultiplier.importable.tsx
+++ b/dotcom-rendering/src/components/RecipeMultiplier.importable.tsx
@@ -4,6 +4,7 @@ import { lifestyle, space, textSans } from '@guardian/source-foundations';
 import { Button, SvgMinus, SvgPlus } from '@guardian/source-react-components';
 import type { ChangeEventHandler } from 'react';
 import { useEffect, useState } from 'react';
+import { isServer } from '../lib/isServer';
 import { useOnce } from '../lib/useOnce';
 
 const colours = `
@@ -33,8 +34,6 @@ const units = ['g', 'l'] as const;
 const isUnit = (unit: string): unit is (typeof units)[number] =>
 	//@ts-expect-error -- custom type guard
 	units.includes(unit);
-
-const isServer = typeof document === 'undefined';
 
 /** These values should not update based on servings  */
 const constants = [
@@ -156,7 +155,7 @@ export const RecipeMultiplier = () => {
 				if (!(node instanceof Text)) continue;
 
 				const match =
-					node.nodeValue?.match(RECIPE_ELEMENTS) ?? undefined;
+					node.nodeValue.match(RECIPE_ELEMENTS) ?? undefined;
 
 				if (!match) continue;
 

--- a/dotcom-rendering/src/components/SecureSignupIframe.importable.tsx
+++ b/dotcom-rendering/src/components/SecureSignupIframe.importable.tsx
@@ -16,8 +16,7 @@ import {
 	getOphanRecordFunction,
 	submitComponentEvent,
 } from '../client/ophan/ophan';
-
-const isServer = typeof window === 'undefined';
+import { isServer } from '../lib/isServer';
 
 // The Google documentation specifies that if the 'recaptcha-badge' is hidden,
 // their T+C's must be displayed instead. While this component hides the

--- a/dotcom-rendering/src/components/SetAdTargeting.importable.tsx
+++ b/dotcom-rendering/src/components/SetAdTargeting.importable.tsx
@@ -1,0 +1,18 @@
+import { log } from '@guardian/libs';
+import { isServer } from '../lib/isServer';
+import { setAdTargeting } from '../lib/useAdTargeting';
+
+type Props = {
+	adTargeting: AdTargeting;
+};
+
+export const SetAdTargeting = ({ adTargeting }: Props) => {
+	if (isServer) {
+		throw new Error('SetAdTargeting is client only');
+	}
+
+	setAdTargeting(adTargeting);
+	log('commercial', '🎯 Ad targeting', adTargeting);
+
+	return null;
+};

--- a/dotcom-rendering/src/components/SignInGate/componentEventTracking.tsx
+++ b/dotcom-rendering/src/components/SignInGate/componentEventTracking.tsx
@@ -1,7 +1,6 @@
 import type { OphanComponent, OphanComponentEvent } from '@guardian/libs';
+import { isServer } from '../../lib/isServer';
 import type { CurrentSignInGateABTest } from './types';
-
-const isServer = typeof window === 'undefined';
 
 export type ComponentEventParams = {
 	componentType: string;

--- a/dotcom-rendering/src/components/TagFrontPage.tsx
+++ b/dotcom-rendering/src/components/TagFrontPage.tsx
@@ -2,6 +2,7 @@ import { css, Global } from '@emotion/react';
 import { brandAlt, focusHalo, neutral } from '@guardian/source-foundations';
 import { StrictMode } from 'react';
 import { TagFrontLayout } from '../layouts/TagFrontLayout';
+import { buildAdTargeting } from '../lib/ad-targeting';
 import { filterABTestSwitches } from '../model/enhance-switches';
 import type { NavType } from '../model/extract-nav';
 import type { DCRTagFrontType } from '../types/tagFront';
@@ -12,6 +13,7 @@ import { FocusStyles } from './FocusStyles.importable';
 import { Island } from './Island';
 import { Metrics } from './Metrics.importable';
 import { SetABTests } from './SetABTests.importable';
+import { SetAdTargeting } from './SetAdTargeting.importable';
 import { SkipTo } from './SkipTo';
 
 type Props = {
@@ -28,6 +30,15 @@ type Props = {
  * @param {NAVType} props.NAV - The article JSON data
  * */
 export const TagFrontPage = ({ tagFront, NAV }: Props) => {
+	const adTargeting = buildAdTargeting({
+		isAdFreeUser: tagFront.isAdFreeUser,
+		isSensitive: tagFront.config.isSensitive,
+		edition: tagFront.config.edition,
+		section: tagFront.config.section,
+		sharedAdTargeting: tagFront.config.sharedAdTargeting,
+		adUnit: tagFront.config.adUnit,
+	});
+
 	return (
 		<StrictMode>
 			<Global
@@ -72,6 +83,9 @@ export const TagFrontPage = ({ tagFront, NAV }: Props) => {
 					pageIsSensitive={tagFront.config.isSensitive}
 					isDev={!!tagFront.config.isDev}
 				/>
+			</Island>
+			<Island clientOnly={true}>
+				<SetAdTargeting adTargeting={adTargeting} />
 			</Island>
 			<TagFrontLayout tagFront={tagFront} NAV={NAV} />
 		</StrictMode>

--- a/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
@@ -7,6 +7,7 @@ import { useEffect, useState } from 'react';
 import { trackVideoInteraction } from '../client/ga/ga';
 import { record } from '../client/ophan/ophan';
 import { useAB } from '../lib/useAB';
+import { useAdTargeting } from '../lib/useAdTargeting';
 import type { RoleType } from '../types/content';
 import { Caption } from './Caption';
 
@@ -25,7 +26,6 @@ type Props = {
 		url: string;
 		width: number;
 	}[];
-	adTargeting?: AdTargeting;
 	isMainMedia?: boolean;
 	height?: number;
 	width?: number;
@@ -83,7 +83,6 @@ export const YoutubeBlockComponent = ({
 	posterImage,
 	expired,
 	role,
-	adTargeting,
 	isMainMedia,
 	height = 259,
 	width = 460,
@@ -94,6 +93,8 @@ export const YoutubeBlockComponent = ({
 	const [consentState, setConsentState] = useState<ConsentState | undefined>(
 		undefined,
 	);
+
+	const adTargeting = useAdTargeting(duration);
 
 	const abTests = useAB();
 	const abTestsApi = abTests?.api;

--- a/dotcom-rendering/src/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/layouts/CommentLayout.tsx
@@ -39,7 +39,6 @@ import { Standfirst } from '../components/Standfirst';
 import { StickyBottomBanner } from '../components/StickyBottomBanner.importable';
 import { SubMeta } from '../components/SubMeta';
 import { SubNav } from '../components/SubNav.importable';
-import { buildAdTargeting } from '../lib/ad-targeting';
 import { getSoleContributor } from '../lib/byline';
 import { canRenderAds } from '../lib/canRenderAds';
 import { getContributionsServiceUrl } from '../lib/contributions';
@@ -279,16 +278,6 @@ export const CommentLayout = ({
 	const isInEuropeTest =
 		article.config.abTests.europeNetworkFrontVariant === 'variant';
 
-	const adTargeting: AdTargeting = buildAdTargeting({
-		isAdFreeUser: article.isAdFreeUser,
-		isSensitive: article.config.isSensitive,
-		videoDuration: article.config.videoDuration,
-		edition: article.config.edition,
-		section: article.config.section,
-		sharedAdTargeting: article.config.sharedAdTargeting,
-		adUnit: article.config.adUnit,
-	});
-
 	const showBodyEndSlot =
 		parse(article.slotMachineFlags ?? '').showBodyEnd ||
 		article.config.switches.slotBodyEnd;
@@ -449,7 +438,6 @@ export const CommentLayout = ({
 								<MainMedia
 									format={format}
 									elements={article.mainMediaElements}
-									adTargeting={adTargeting}
 									starRating={
 										format.design ===
 											ArticleDesign.Review &&
@@ -579,7 +567,6 @@ export const CommentLayout = ({
 									<ArticleBody
 										format={format}
 										blocks={article.blocks}
-										adTargeting={adTargeting}
 										host={host}
 										pageId={article.pageId}
 										webTitle={article.webTitle}

--- a/dotcom-rendering/src/layouts/FullPageInteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/FullPageInteractiveLayout.tsx
@@ -72,7 +72,6 @@ const Renderer = ({
 			format,
 
 			element,
-			adTargeting: undefined,
 			host,
 			index,
 			isMainMedia: false,

--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -43,7 +43,6 @@ import { Standfirst } from '../components/Standfirst';
 import { StickyBottomBanner } from '../components/StickyBottomBanner.importable';
 import { SubMeta } from '../components/SubMeta';
 import { SubNav } from '../components/SubNav.importable';
-import { buildAdTargeting } from '../lib/ad-targeting';
 import { canRenderAds } from '../lib/canRenderAds';
 import { getContributionsServiceUrl } from '../lib/contributions';
 import { decidePalette } from '../lib/decidePalette';
@@ -255,16 +254,6 @@ export const ImmersiveLayout = ({
 		config: { isPaidContent, host },
 	} = article;
 
-	const adTargeting: AdTargeting = buildAdTargeting({
-		isAdFreeUser: article.isAdFreeUser,
-		isSensitive: article.config.isSensitive,
-		videoDuration: article.config.videoDuration,
-		edition: article.config.edition,
-		section: article.config.section,
-		sharedAdTargeting: article.config.sharedAdTargeting,
-		adUnit: article.config.adUnit,
-	});
-
 	const showBodyEndSlot =
 		parse(article.slotMachineFlags ?? '').showBodyEnd ||
 		article.config.switches.slotBodyEnd;
@@ -408,7 +397,6 @@ export const ImmersiveLayout = ({
 					<MainMedia
 						format={format}
 						elements={article.mainMediaElements}
-						adTargeting={adTargeting}
 						starRating={
 							format.design === ArticleDesign.Review &&
 							article.starRating !== undefined
@@ -629,7 +617,6 @@ export const ImmersiveLayout = ({
 								<ArticleBody
 									format={format}
 									blocks={article.blocks}
-									adTargeting={adTargeting}
 									host={host}
 									pageId={article.pageId}
 									webTitle={article.webTitle}

--- a/dotcom-rendering/src/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/InteractiveLayout.tsx
@@ -42,7 +42,6 @@ import { StarRating } from '../components/StarRating/StarRating';
 import { StickyBottomBanner } from '../components/StickyBottomBanner.importable';
 import { SubMeta } from '../components/SubMeta';
 import { SubNav } from '../components/SubNav.importable';
-import { buildAdTargeting } from '../lib/ad-targeting';
 import { canRenderAds } from '../lib/canRenderAds';
 import { getContributionsServiceUrl } from '../lib/contributions';
 import { decidePalette } from '../lib/decidePalette';
@@ -221,16 +220,6 @@ export const InteractiveLayout = ({
 	const isInEuropeTest =
 		article.config.abTests.europeNetworkFrontVariant === 'variant';
 
-	const adTargeting: AdTargeting = buildAdTargeting({
-		isAdFreeUser: article.isAdFreeUser,
-		isSensitive: article.config.isSensitive,
-		videoDuration: article.config.videoDuration,
-		edition: article.config.edition,
-		section: article.config.section,
-		sharedAdTargeting: article.config.sharedAdTargeting,
-		adUnit: article.config.adUnit,
-	});
-
 	const showComments = article.isCommentable;
 
 	const { branding } = article.commercialProperties[article.editionId];
@@ -403,7 +392,6 @@ export const InteractiveLayout = ({
 									<MainMedia
 										format={format}
 										elements={article.mainMediaElements}
-										adTargeting={adTargeting}
 										host={host}
 										pageId={article.pageId}
 										webTitle={article.webTitle}
@@ -511,7 +499,6 @@ export const InteractiveLayout = ({
 									<ArticleBody
 										format={format}
 										blocks={article.blocks}
-										adTargeting={adTargeting}
 										host={host}
 										pageId={article.pageId}
 										webTitle={article.webTitle}

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -53,7 +53,6 @@ import {
 	hasRelevantTopics,
 	TopicFilterBank,
 } from '../components/TopicFilterBank';
-import { buildAdTargeting } from '../lib/ad-targeting';
 import { canRenderAds } from '../lib/canRenderAds';
 import { getContributionsServiceUrl } from '../lib/contributions';
 import { decidePalette } from '../lib/decidePalette';
@@ -261,16 +260,6 @@ export const LiveLayout = ({
 
 	const isInEuropeTest =
 		article.config.abTests.europeNetworkFrontVariant === 'variant';
-
-	const adTargeting: AdTargeting = buildAdTargeting({
-		isAdFreeUser: article.isAdFreeUser,
-		isSensitive: article.config.isSensitive,
-		videoDuration: article.config.videoDuration,
-		edition: article.config.edition,
-		section: article.config.section,
-		sharedAdTargeting: article.config.sharedAdTargeting,
-		adUnit: article.config.adUnit,
-	});
 
 	// TODO:
 	// 1) Read 'forceEpic' value from URL parameter and use it to force the slot to render
@@ -694,7 +683,6 @@ export const LiveLayout = ({
 									<MainMedia
 										format={format}
 										elements={article.mainMediaElements}
-										adTargeting={adTargeting}
 										host={host}
 										pageId={article.pageId}
 										webTitle={article.webTitle}
@@ -828,7 +816,6 @@ export const LiveLayout = ({
 													pinnedPost={
 														article.pinnedPost
 													}
-													adTargeting={adTargeting}
 													host={host}
 													pageId={article.pageId}
 													webTitle={article.webTitle}
@@ -983,7 +970,6 @@ export const LiveLayout = ({
 													pinnedPost={
 														article.pinnedPost
 													}
-													adTargeting={adTargeting}
 													host={host}
 													pageId={article.pageId}
 													webTitle={article.webTitle}

--- a/dotcom-rendering/src/layouts/NewsletterSignupLayout.tsx
+++ b/dotcom-rendering/src/layouts/NewsletterSignupLayout.tsx
@@ -1,6 +1,7 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
-import { ArticleDisplay, ArticleFormat, ArticleSpecial } from '@guardian/libs';
+import type { ArticleFormat } from '@guardian/libs';
+import { ArticleDisplay, ArticleSpecial } from '@guardian/libs';
 import {
 	brandAlt,
 	brandBackground,
@@ -40,7 +41,6 @@ import { SecureSignup } from '../components/SecureSignup';
 import { ShareIcons } from '../components/ShareIcons';
 import { Standfirst } from '../components/Standfirst';
 import { SubNav } from '../components/SubNav.importable';
-import { buildAdTargeting } from '../lib/ad-targeting';
 import { canRenderAds } from '../lib/canRenderAds';
 import { getContributionsServiceUrl } from '../lib/contributions';
 import { decidePalette } from '../lib/decidePalette';
@@ -198,15 +198,6 @@ export const NewsletterSignupLayout = ({ article, NAV, format }: Props) => {
 	const isInEuropeTest =
 		article.config.abTests.europeNetworkFrontVariant === 'variant';
 
-	const adTargeting: AdTargeting = buildAdTargeting({
-		isAdFreeUser: article.isAdFreeUser,
-		isSensitive: article.config.isSensitive,
-		videoDuration: article.config.videoDuration,
-		edition: article.config.edition,
-		section: article.config.section,
-		sharedAdTargeting: article.config.sharedAdTargeting,
-		adUnit: article.config.adUnit,
-	});
 	const contributionsServiceUrl = getContributionsServiceUrl(article);
 
 	const palette = decidePalette(format);
@@ -493,7 +484,6 @@ export const NewsletterSignupLayout = ({ article, NAV, format }: Props) => {
 								<MainMedia
 									format={format}
 									elements={article.mainMediaElements}
-									adTargeting={adTargeting}
 									host={host}
 									pageId={article.pageId}
 									webTitle={article.webTitle}

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -41,7 +41,6 @@ import { Standfirst } from '../components/Standfirst';
 import { StickyBottomBanner } from '../components/StickyBottomBanner.importable';
 import { SubMeta } from '../components/SubMeta';
 import { SubNav } from '../components/SubNav.importable';
-import { buildAdTargeting } from '../lib/ad-targeting';
 import { canRenderAds } from '../lib/canRenderAds';
 import { getContributionsServiceUrl } from '../lib/contributions';
 import { decidePalette } from '../lib/decidePalette';
@@ -222,16 +221,6 @@ export const ShowcaseLayout = ({
 
 	const isInEuropeTest =
 		article.config.abTests.europeNetworkFrontVariant === 'variant';
-
-	const adTargeting: AdTargeting = buildAdTargeting({
-		isAdFreeUser: article.isAdFreeUser,
-		isSensitive: article.config.isSensitive,
-		videoDuration: article.config.videoDuration,
-		edition: article.config.edition,
-		section: article.config.section,
-		sharedAdTargeting: article.config.sharedAdTargeting,
-		adUnit: article.config.adUnit,
-	});
 
 	const showBodyEndSlot =
 		parse(article.slotMachineFlags ?? '').showBodyEnd ||
@@ -455,7 +444,6 @@ export const ShowcaseLayout = ({
 								<MainMedia
 									format={format}
 									elements={article.mainMediaElements}
-									adTargeting={adTargeting}
 									starRating={
 										format.design ===
 											ArticleDesign.Review &&
@@ -548,7 +536,6 @@ export const ShowcaseLayout = ({
 								<ArticleBody
 									format={format}
 									blocks={article.blocks}
-									adTargeting={adTargeting}
 									host={host}
 									pageId={article.pageId}
 									webTitle={article.webTitle}

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -48,7 +48,6 @@ import { StarRating } from '../components/StarRating/StarRating';
 import { StickyBottomBanner } from '../components/StickyBottomBanner.importable';
 import { SubMeta } from '../components/SubMeta';
 import { SubNav } from '../components/SubNav.importable';
-import { buildAdTargeting } from '../lib/ad-targeting';
 import { canRenderAds } from '../lib/canRenderAds';
 import { getContributionsServiceUrl } from '../lib/contributions';
 import { decidePalette } from '../lib/decidePalette';
@@ -309,16 +308,6 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 	const isInEuropeTest =
 		article.config.abTests.europeNetworkFrontVariant === 'variant';
 
-	const adTargeting: AdTargeting = buildAdTargeting({
-		isAdFreeUser: article.isAdFreeUser,
-		isSensitive: article.config.isSensitive,
-		videoDuration: article.config.videoDuration,
-		edition: article.config.edition,
-		section: article.config.section,
-		sharedAdTargeting: article.config.sharedAdTargeting,
-		adUnit: article.config.adUnit,
-	});
-
 	const showBodyEndSlot =
 		parse(article.slotMachineFlags ?? '').showBodyEnd ||
 		article.config.switches.slotBodyEnd;
@@ -537,7 +526,6 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 								<MainMedia
 									format={format}
 									elements={article.mainMediaElements}
-									adTargeting={adTargeting}
 									host={host}
 									pageId={article.pageId}
 									webTitle={article.webTitle}
@@ -646,7 +634,6 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 									format={format}
 									blocks={article.blocks}
 									pinnedPost={article.pinnedPost}
-									adTargeting={adTargeting}
 									host={host}
 									pageId={article.pageId}
 									webTitle={article.webTitle}

--- a/dotcom-rendering/src/lib/ArticleRenderer.tsx
+++ b/dotcom-rendering/src/lib/ArticleRenderer.tsx
@@ -27,7 +27,6 @@ const adStylesDynamic = css`
 type Props = {
 	format: ArticleFormat;
 	elements: FEElement[];
-	adTargeting?: AdTargeting;
 	host?: string;
 	pageId: string;
 	webTitle: string;
@@ -49,7 +48,6 @@ type Props = {
 export const ArticleRenderer = ({
 	format,
 	elements,
-	adTargeting,
 	host,
 	pageId,
 	webTitle,
@@ -74,7 +72,6 @@ export const ArticleRenderer = ({
 				key={index}
 				format={format}
 				element={element}
-				adTargeting={adTargeting}
 				ajaxUrl={ajaxUrl}
 				host={host}
 				index={index}

--- a/dotcom-rendering/src/lib/LiveBlogRenderer.tsx
+++ b/dotcom-rendering/src/lib/LiveBlogRenderer.tsx
@@ -17,7 +17,6 @@ import type { TagType } from '../types/tag';
 type Props = {
 	format: ArticleFormat;
 	blocks: Block[];
-	adTargeting: AdTargeting;
 	pinnedPost?: Block;
 	host?: string;
 	pageId: string;
@@ -45,7 +44,6 @@ export const LiveBlogRenderer = ({
 	format,
 	blocks,
 	pinnedPost,
-	adTargeting,
 	host,
 	pageId,
 	webTitle,
@@ -83,7 +81,6 @@ export const LiveBlogRenderer = ({
 							block={pinnedPost}
 							pageId={pageId}
 							webTitle={webTitle}
-							adTargeting={adTargeting}
 							host={host}
 							ajaxUrl={ajaxUrl}
 							isLiveUpdate={isLiveUpdate}
@@ -137,7 +134,6 @@ export const LiveBlogRenderer = ({
 				format={format}
 				pageId={pageId}
 				webTitle={webTitle}
-				adTargeting={adTargeting}
 				host={host}
 				ajaxUrl={ajaxUrl}
 				isLiveUpdate={isLiveUpdate}

--- a/dotcom-rendering/src/lib/ad-targeting.ts
+++ b/dotcom-rendering/src/lib/ad-targeting.ts
@@ -1,5 +1,7 @@
 import { isString } from '@guardian/libs';
 
+export type SharedAdTargeting = Record<string, unknown>;
+
 // TODO: this function already exists in commercial-core, consider exporting it to avoid duplication
 const getUrlKeywords = (url: string): string[] => {
 	const lastSegment = url
@@ -23,7 +25,7 @@ export const buildAdTargeting = ({
 	isSensitive: boolean;
 	edition: string;
 	section: string;
-	sharedAdTargeting: Record<string, unknown>;
+	sharedAdTargeting: SharedAdTargeting;
 	adUnit: string;
 	videoDuration?: number;
 }): AdTargeting => {

--- a/dotcom-rendering/src/lib/isServer.ts
+++ b/dotcom-rendering/src/lib/isServer.ts
@@ -1,0 +1,1 @@
+export const isServer = typeof window === 'undefined';

--- a/dotcom-rendering/src/lib/renderElement.tsx
+++ b/dotcom-rendering/src/lib/renderElement.tsx
@@ -71,7 +71,6 @@ import { decidePalette } from './decidePalette';
 type Props = {
 	format: ArticleFormat;
 	element: FEElement;
-	adTargeting?: AdTargeting;
 	host?: string;
 	index: number;
 	isMainMedia: boolean;
@@ -126,7 +125,6 @@ const updateRole = (el: FEElement, format: ArticleFormat): FEElement => {
 export const renderElement = ({
 	format,
 	element,
-	adTargeting,
 	host,
 	index,
 	hideCaption,
@@ -736,7 +734,6 @@ export const renderElement = ({
 						key={index}
 						hideCaption={hideCaption}
 						role="inline"
-						adTargeting={adTargeting}
 						isMainMedia={isMainMedia}
 						id={element.id}
 						elementId={element.elementId}
@@ -784,7 +781,6 @@ const bareElements = new Set<FEElement['_type']>([
 export const RenderArticleElement = ({
 	format,
 	element,
-	adTargeting,
 	ajaxUrl,
 	host,
 	index,
@@ -804,7 +800,6 @@ export const RenderArticleElement = ({
 	const el = renderElement({
 		format,
 		element: withUpdatedRole,
-		adTargeting,
 		ajaxUrl,
 		host,
 		index,

--- a/dotcom-rendering/src/lib/useAdTargeting.ts
+++ b/dotcom-rendering/src/lib/useAdTargeting.ts
@@ -1,0 +1,33 @@
+import { log } from '@guardian/libs';
+import { mutate } from 'swr';
+import useSWRImmutable from 'swr/immutable';
+
+const key = 'ad-targeting';
+const apiPromise = new Promise<AdTargeting>(() => {
+	/* this never resolves */
+});
+
+/**
+ * A hook which returns the Ad Targeting for a given page.
+ *
+ * @param videoLength allows overriding video length, when there are multiple videos on a page
+ */
+export const useAdTargeting = (
+	videoLength?: number,
+): AdTargeting | undefined => {
+	const { data } = useSWRImmutable(key, () => apiPromise);
+
+	if (data && !data.disableAds && typeof videoLength === 'number') {
+		data.customParams['vl'] = videoLength;
+		log(
+			'commercial',
+			`🎯 Ad Targeting – video length (vl) overriden to ${videoLength}`,
+		);
+	}
+
+	return data;
+};
+
+export const setAdTargeting = (adTargeting: AdTargeting): void => {
+	void mutate(key, adTargeting, false);
+};

--- a/dotcom-rendering/src/model/article-schema.json
+++ b/dotcom-rendering/src/model/article-schema.json
@@ -4122,8 +4122,7 @@
                     "type": "string"
                 },
                 "sharedAdTargeting": {
-                    "type": "object",
-                    "additionalProperties": {}
+                    "$ref": "#/definitions/SharedAdTargeting"
                 },
                 "isPaidContent": {
                     "type": "boolean"
@@ -4259,6 +4258,9 @@
                 "PROD"
             ],
             "type": "string"
+        },
+        "SharedAdTargeting": {
+            "type": "object"
         },
         "FETrailType": {
             "type": "object",

--- a/dotcom-rendering/src/model/front-schema.json
+++ b/dotcom-rendering/src/model/front-schema.json
@@ -59,8 +59,7 @@
                     "type": "string"
                 },
                 "sharedAdTargeting": {
-                    "type": "object",
-                    "additionalProperties": {}
+                    "$ref": "#/definitions/SharedAdTargeting"
                 },
                 "buildNumber": {
                     "type": "string"
@@ -3203,6 +3202,9 @@
             "additionalProperties": {
                 "type": "boolean"
             }
+        },
+        "SharedAdTargeting": {
+            "type": "object"
         },
         "StageType": {
             "enum": [

--- a/dotcom-rendering/src/model/tag-front-schema.json
+++ b/dotcom-rendering/src/model/tag-front-schema.json
@@ -866,8 +866,7 @@
                     "type": "string"
                 },
                 "sharedAdTargeting": {
-                    "type": "object",
-                    "additionalProperties": {}
+                    "$ref": "#/definitions/SharedAdTargeting"
                 },
                 "buildNumber": {
                     "type": "string"
@@ -1549,6 +1548,9 @@
             "additionalProperties": {
                 "type": "boolean"
             }
+        },
+        "SharedAdTargeting": {
+            "type": "object"
         },
         "StageType": {
             "enum": [

--- a/dotcom-rendering/src/server/index.article.web.ts
+++ b/dotcom-rendering/src/server/index.article.web.ts
@@ -7,7 +7,7 @@ import { enhanceTableOfContents } from '../model/enhanceTableOfContents';
 import { validateAsArticleType } from '../model/validate';
 import { recordTypeAndPlatform } from '../server/lib/logging-store';
 import type { FEArticleBadgeType } from '../types/badge';
-import type { FEArticleType } from '../types/frontend';
+import type { FEArticleType, FEBlocksRequest } from '../types/frontend';
 import {
 	renderBlocks,
 	renderHtml,

--- a/dotcom-rendering/src/server/render.article.web.tsx
+++ b/dotcom-rendering/src/server/render.article.web.tsx
@@ -23,7 +23,7 @@ import { extractGA } from '../model/extract-ga';
 import { extractNAV } from '../model/extract-nav';
 import { makeWindowGuardian } from '../model/window-guardian';
 import type { FEElement } from '../types/content';
-import type { FEArticleType } from '../types/frontend';
+import type { FEArticleType, FEBlocksRequest } from '../types/frontend';
 import type { TagType } from '../types/tag';
 import { htmlPageTemplate } from './htmlPageTemplate';
 import { recipeSchema } from './temporaryRecipeStructuredData';

--- a/dotcom-rendering/src/server/render.article.web.tsx
+++ b/dotcom-rendering/src/server/render.article.web.tsx
@@ -6,7 +6,6 @@ import {
 import { ArticlePage } from '../components/ArticlePage';
 import { isAmpSupported } from '../components/Elements.amp';
 import { KeyEventsContainer } from '../components/KeyEventsContainer';
-import { buildAdTargeting } from '../lib/ad-targeting';
 import {
 	ASSET_ORIGIN,
 	generateScriptTags,
@@ -261,31 +260,16 @@ export const renderBlocks = ({
 	ajaxUrl,
 	isAdFreeUser,
 	isSensitive,
-	videoDuration,
-	edition,
 	section,
-	sharedAdTargeting,
-	adUnit,
 	switches,
 	keywordIds,
 }: FEBlocksRequest): string => {
 	const format: ArticleFormat = decideFormat(FEFormat);
 
-	const adTargeting: AdTargeting = buildAdTargeting({
-		isAdFreeUser,
-		isSensitive,
-		videoDuration,
-		edition,
-		section,
-		sharedAdTargeting,
-		adUnit,
-	});
-
 	const { html, extractedCss } = renderToStringWithEmotion(
 		<LiveBlogRenderer
 			blocks={blocks}
 			format={format}
-			adTargeting={adTargeting}
 			host={host}
 			pageId={pageId}
 			webTitle={webTitle}

--- a/dotcom-rendering/src/types/config.ts
+++ b/dotcom-rendering/src/types/config.ts
@@ -1,3 +1,4 @@
+import type { SharedAdTargeting } from '../lib/ad-targeting';
 import type { EditionId } from '../lib/edition';
 
 export interface CommercialConfigType {
@@ -61,7 +62,7 @@ export interface ConfigType extends CommercialConfigType {
 	edition: EditionId;
 	section: string;
 
-	sharedAdTargeting: { [key: string]: any };
+	sharedAdTargeting: SharedAdTargeting;
 	isPaidContent?: boolean;
 	keywordIds: string;
 	showRelatedContent: boolean;

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -1,4 +1,5 @@
 import type { ArticlePillar, ArticleSpecial } from '@guardian/libs';
+import type { SharedAdTargeting } from '../lib/ad-targeting';
 import type { EditionId } from '../lib/edition';
 import type { DCRBadgeType } from './badge';
 import type { Branding } from './branding';
@@ -399,7 +400,7 @@ export type FEFrontConfigType = {
 	section: string;
 	keywordIds: string;
 	locationapiurl: string;
-	sharedAdTargeting: { [key: string]: unknown };
+	sharedAdTargeting: SharedAdTargeting;
 	buildNumber: string;
 	abTests: ServerSideTests;
 	pbIndexSites: { [key: string]: unknown }[];

--- a/dotcom-rendering/src/types/frontend.ts
+++ b/dotcom-rendering/src/types/frontend.ts
@@ -1,3 +1,4 @@
+import type { SharedAdTargeting } from '../lib/ad-targeting';
 import type { EditionId } from '../lib/edition';
 import type { FEArticleBadgeType } from './badge';
 import type { CommercialProperties } from './commercial';
@@ -125,4 +126,25 @@ export interface TableOfContents {
 export interface TableOfContentsItem {
 	id: string;
 	title: string;
+}
+
+/**
+ * BlocksRequest is the expected body format for POST requests made to /Blocks
+ */
+export interface FEBlocksRequest {
+	blocks: Block[];
+	format: FEFormat;
+	host?: string;
+	pageId: string;
+	webTitle: string;
+	ajaxUrl: string;
+	isAdFreeUser: boolean;
+	isSensitive: boolean;
+	edition: string;
+	section: string;
+	sharedAdTargeting: SharedAdTargeting;
+	adUnit: string;
+	videoDuration?: number;
+	switches: { [key: string]: boolean };
+	keywordIds: string;
 }

--- a/dotcom-rendering/src/types/newslettersPage.ts
+++ b/dotcom-rendering/src/types/newslettersPage.ts
@@ -26,7 +26,7 @@ type FENewslettersConfigType = {
 	// videoDuration?: number;
 	edition: EditionId;
 	// section: string;
-	// sharedAdTargeting: { [key: string]: any };
+	// sharedAdTargeting: SharedAdTargeting;
 	idApiUrl: string;
 	discussionApiUrl: string;
 	// discussionD2Uid: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3489,10 +3489,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/ab-core/-/ab-core-5.0.0.tgz#cce32ff4cdfb6b24c013723bf352dcd61135d34d"
   integrity sha512-Td5gtK2sARl+fXj1Qe6RuFqf/zxuZjW1q2Jck09zXPIfMgU+sJoTi549zbNeC1cldCBhPWy/qPQ0r+8klfF7jg==
 
-"@guardian/atoms-rendering@31.0.0":
-  version "31.0.0"
-  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-31.0.0.tgz#31e0f727b574e3385ef6688767a507ea18c3a9b6"
-  integrity sha512-dWhTI/djARS0qhtvMmpa91Rcyz/O82KHFWNCXsQLOg74Na96p+ibl6mDUOW5M/xBiL5TbF5Ac/ZbWdspWsiwWA==
+"@guardian/atoms-rendering@32.2.0":
+  version "32.2.0"
+  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-32.2.0.tgz#00db2120252060e5e0c5b3b4b45897d18864cec4"
+  integrity sha512-14BFR+rb6iQ4qYcqX/aPt/C3iVYSfKrHZj5ps9EbDeOx8dKejohsLyPiPKaNkPj+M0CTH42r8kcOjatx4Yx1yw==
   dependencies:
     is-mobile "3.1.1"
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

This simplifies the logic of handling ad targetting across all Islands by setting it once via SWR like we did for AB Tests in #4200. 

An optional override for media duration (`videoLength`) is provided.

## Why?

Required to avoid having to drill the property deeply into Front Cards in #8075 

## Screenshots

![image](https://github.com/guardian/dotcom-rendering/assets/76776/e89534af-c045-4b1f-a4c7-8986fc9471b9)
