### PR TITLE
Fix page skin click throughs

### DIFF
--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -270,6 +270,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 				data-layout="FrontLayout"
 				data-link-name={`Front | /${front.pressedPage.id}`}
 				id="maincontent"
+				css={hasPageSkin && pageSkinContainer}
 			>
 				{front.pressedPage.collections.map((collection, index) => {
 					// Backfills should be added to the end of any curated content


### PR DESCRIPTION
## What does this change?

Fix page skin click throughs by constraining `maincontent` width when there is a page skin.

Currently maincontent takes the full width and was stealing clicks from the page skin.

