### PR TITLE
Ignore The `target` Directory For TS

### DIFF
--- a/dotcom-rendering/tsconfig.json
+++ b/dotcom-rendering/tsconfig.json
@@ -16,5 +16,5 @@
 		},
 		"preserveConstEnums": true
 	},
-	"exclude": ["cypress", "./cypress.config.js", "storybook-static"]
+	"exclude": ["cypress", "./cypress.config.js", "storybook-static", "target"]
 }


### PR DESCRIPTION
## Why?

It's generated code, created by the `build-riffraff-bundle` script. VSCode's TS integration can't handle the number of files in here when it's included. Ignoring it shouldn't have any effect on the build because it's not source code. See also #7746.
