### PR TITLE
chore(enhanceBlocks): remove unused import

### DIFF
--- a/dotcom-rendering/src/model/enhanceBlocks.ts
+++ b/dotcom-rendering/src/model/enhanceBlocks.ts
@@ -8,10 +8,6 @@ import { enhanceH3s } from './enhance-H3s';
 import { enhanceImages } from './enhance-images';
 import { enhanceInteractiveContentsElements } from './enhance-interactive-contents-elements';
 import { enhanceNumberedLists } from './enhance-numbered-lists';
-/**
- * Removing this enhancer temporarily because it's causing a bug in production
- */
-// import { enhanceRecipes } from './enhance-recipes';
 import { enhanceTweets } from './enhance-tweets';
 import { insertPromotedNewsletter } from './insertPromotedNewsletter';
 import { validateAsBlock } from './validate';


### PR DESCRIPTION
## What does this change?

Remove reference to the recipe enhancer.

## Why?

The recipe enhancer is no longer a thing. It’s been gone since https://github.com/guardian/dotcom-rendering/pull/6620/files#diff-ad99233aaf26e9b35f0c3991063a89bb447f4f9b90380e669e63f6b5bc8f40bd

Follow-up on #6614 