### PR TITLE
Add `decideAdSlot` to fronts `fixed/video` container

### DIFF
--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -454,9 +454,8 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 						const containerOverrides =
 							decideContainerOverrides(containerPalette);
 						return (
-							<>
+							<Fragment key={ophanName}>
 								<Section
-									key={ophanName}
 									title={collection.displayName}
 									sectionId={`container-${ophanName}`}
 									ophanComponentName={ophanName}
@@ -508,7 +507,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 									mobileAdPositions,
 									hasPageSkin,
 								)}
-							</>
+							</Fragment>
 						);
 					}
 

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -454,47 +454,61 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 						const containerOverrides =
 							decideContainerOverrides(containerPalette);
 						return (
-							<Section
-								key={ophanName}
-								title={collection.displayName}
-								sectionId={`container-${ophanName}`}
-								ophanComponentName={ophanName}
-								ophanComponentLink={ophanComponentLink}
-								containerName={collection.collectionType}
-								fullWidth={true}
-								padBottom={true}
-								showSideBorders={
-									collection.collectionType !== 'fixed/video'
-								}
-								showTopBorder={index > 0}
-								padContent={false}
-								url={collection.href}
-								containerPalette={containerPalette}
-								showDateHeader={
-									collection.config.showDateHeader
-								}
-								editionId={front.editionId}
-								backgroundColour={
-									containerOverrides.background.containerOuter
-								}
-								innerBackgroundColour={
-									containerOverrides.background.container
-								}
-								hasPageSkin={hasPageSkin}
-							>
-								<Island deferUntil={'visible'}>
-									<Carousel
-										heading={collection.displayName}
-										trails={trails}
-										onwardsSource={'unknown-source'}
-										palette={containerPalette}
-										leftColSize={'compact'}
-										collectionType={
-											collection.collectionType
-										}
-									/>
-								</Island>
-							</Section>
+							<>
+								<Section
+									key={ophanName}
+									title={collection.displayName}
+									sectionId={`container-${ophanName}`}
+									ophanComponentName={ophanName}
+									ophanComponentLink={ophanComponentLink}
+									containerName={collection.collectionType}
+									fullWidth={true}
+									padBottom={true}
+									showSideBorders={
+										collection.collectionType !==
+										'fixed/video'
+									}
+									showTopBorder={index > 0}
+									padContent={false}
+									url={collection.href}
+									containerPalette={containerPalette}
+									showDateHeader={
+										collection.config.showDateHeader
+									}
+									editionId={front.editionId}
+									backgroundColour={
+										containerOverrides.background
+											.containerOuter
+									}
+									innerBackgroundColour={
+										containerOverrides.background.container
+									}
+									hasPageSkin={hasPageSkin}
+								>
+									<Island deferUntil={'visible'}>
+										<Carousel
+											heading={collection.displayName}
+											trails={trails}
+											onwardsSource={'unknown-source'}
+											palette={containerPalette}
+											leftColSize={'compact'}
+											collectionType={
+												collection.collectionType
+											}
+										/>
+									</Island>
+								</Section>
+								{decideAdSlot(
+									renderAds,
+									index,
+									front.isNetworkFront,
+									front.pressedPage.collections.length,
+									front.pressedPage.frontProperties
+										.isPaidContent,
+									mobileAdPositions,
+									hasPageSkin,
+								)}
+							</>
 						);
 					}
 

--- a/dotcom-rendering/src/lib/getAdPositions.test.ts
+++ b/dotcom-rendering/src/lib/getAdPositions.test.ts
@@ -116,6 +116,40 @@ describe('Mobile Ads', () => {
 		expect(mobileAdPositions).toEqual([0, 2, 6, 9, 12, 16, 18, 20, 22]);
 	});
 
+	// We used https://www.theguardian.com/international as a blueprint
+	it('International Network Front, with more than 4 collections, with thrashers at various places', () => {
+		const merchHighPosition = 3;
+		const testCollections: Pick<DCRCollectionType, 'collectionType'>[] = [
+			{ collectionType: 'dynamic/fast' }, // 0 headlines (top-above-nav)
+			{ collectionType: 'fixed/small/slow-IV' }, // 1 ukraine
+			{ collectionType: 'dynamic/slow' }, // 2 spotlight (m1)
+			{ collectionType: 'dynamic/slow-mpu' }, // 3 opinion (merch-high)
+			{ collectionType: 'dynamic/slow' }, // 4 sport
+			{ collectionType: 'fixed/thrasher' }, // 5 wordiply
+			{ collectionType: 'fixed/small/slow-IV' }, // 6 europe (mobile-2)
+			{ collectionType: 'dynamic/fast' }, // 7 world
+			{ collectionType: 'fixed/small/slow-IV' }, // 8 climate
+			{ collectionType: 'fixed/thrasher' }, // 9 tip us off (mobile-3)
+			{ collectionType: 'dynamic/slow-mpu' }, // 10 culture
+			{ collectionType: 'fixed/thrasher' }, // 11 cotton capital
+			{ collectionType: 'dynamic/slow-mpu' }, // 12 lifestyle
+			{ collectionType: 'fixed/thrasher' }, // 13 documentaries (mobile-4)
+			{ collectionType: 'dynamic/slow-mpu' }, // 14 explore
+			{ collectionType: 'fixed/small/slow-IV' }, // 15 take part (mobile-5)
+			{ collectionType: 'fixed/small/slow-IV' }, // 16 podcasts
+			{ collectionType: 'fixed/video' }, // 17 videos (mobile-6)
+			{ collectionType: 'fixed/medium/slow-VI' }, // 18 in pictures
+			{ collectionType: 'news/most-popular' }, // 19 most popular
+		];
+
+		const mobileAdPositions = getMobileAdPositions(
+			testCollections,
+			merchHighPosition,
+		);
+
+		expect(mobileAdPositions).toEqual([0, 2, 6, 9, 13, 15, 17]);
+	});
+
 	// We used https://www.theguardian.com/us as a blueprint
 	it('US Network Front, with more than 4 collections, with thrashers at various places', () => {
 		const merchHighPosition = 3;


### PR DESCRIPTION
## What does this change?

@ioannakok  noticed that we weren't rendering the mobile ad slot `inline6-mobile` on the international front. This was due to the `fixed/video` container not including a `decideAdSlot` call immediately after itself.

