### PR TITLE
Change card headline colour for immersive articles

### DIFF
--- a/dotcom-rendering/src/lib/decidePalette.ts
+++ b/dotcom-rendering/src/lib/decidePalette.ts
@@ -648,7 +648,7 @@ const textCardHeadline = (format: ArticleFormat): string => {
 	if (format.theme === ArticleSpecial.SpecialReportAlt)
 		return palette.specialReportAlt[100];
 
-	if (format.display === ArticleDisplay.Immersive) return BLACK;
+	if (format.display === ArticleDisplay.Immersive) return news[300];
 	switch (format.design) {
 		case ArticleDesign.Gallery:
 		case ArticleDesign.Audio:
@@ -2076,18 +2076,18 @@ export const decidePalette = (
 			articleLink: textArticleLink(format),
 			articleLinkHover: textArticleLinkHover(format),
 			cardHeadline:
-				overrides?.text?.cardHeadline ?? textCardHeadline(format),
+				overrides?.text.cardHeadline ?? textCardHeadline(format),
 			dynamoHeadline:
-				overrides?.text?.dynamoHeadline ?? textCardHeadline(format),
-			cardByline: overrides?.text?.cardByline ?? textCardByline(format),
-			cardKicker: overrides?.text?.cardKicker ?? textCardKicker(format),
+				overrides?.text.dynamoHeadline ?? textCardHeadline(format),
+			cardByline: overrides?.text.cardByline ?? textCardByline(format),
+			cardKicker: overrides?.text.cardKicker ?? textCardKicker(format),
 			dynamoKicker:
-				overrides?.text?.dynamoKicker ?? textCardKicker(format),
+				overrides?.text.dynamoKicker ?? textCardKicker(format),
 			linkKicker: textLinkKicker(format),
 			cardStandfirst:
-				overrides?.text?.cardStandfirst ?? textCardStandfirst(format),
-			cardFooter: overrides?.text?.cardFooter ?? textCardFooter(format),
-			dynamoMeta: overrides?.text?.dynamoMeta ?? textCardFooter(format),
+				overrides?.text.cardStandfirst ?? textCardStandfirst(format),
+			cardFooter: overrides?.text.cardFooter ?? textCardFooter(format),
+			dynamoMeta: overrides?.text.dynamoMeta ?? textCardFooter(format),
 			headlineByline: textHeadlineByline(format),
 			standfirst: textStandfirst(format),
 			standfirstLink: textStandfirstLink(format),
@@ -2129,7 +2129,7 @@ export const decidePalette = (
 			seriesTitle: backgroundSeriesTitle(format),
 			sectionTitle: backgroundSectionTitle(format),
 			avatar: backgroundAvatar(format),
-			card: overrides?.background?.card ?? backgroundCard(format),
+			card: overrides?.background.card ?? backgroundCard(format),
 			headline: backgroundHeadline(format),
 			headlineByline: backgroundHeadlineByline(format),
 			bullet: backgroundBullet(format),
@@ -2186,7 +2186,7 @@ export const decidePalette = (
 			richLink: borderRichLink(format),
 			navPillar: borderNavPillar(format),
 			article: borderArticle(format),
-			lines: overrides?.border?.lines ?? borderLines(format),
+			lines: overrides?.border.lines ?? borderLines(format),
 			cricketScoreboardTop: borderCricketScoreboardTop(),
 			cricketScoreboardDivider: borderCricketScoreboardDivider(),
 			matchTab: matchTab(),


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Updates the card headline colour for immersive articles
## Why?

Fixes https://github.com/guardian/dotcom-rendering/issues/7843

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |
| Before      | After      |
| ----------- | ---------- |
| ![before2][] | ![after2][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/110032454/78307cd1-2c9f-4f8a-9c50-b8da9346729a
[before2]: https://github.com/guardian/dotcom-rendering/assets/110032454/0cd04132-9cd4-4e3f-a8ad-fc464fe28a10

[after]: https://github.com/guardian/dotcom-rendering/assets/110032454/91498042-d780-4f59-b74e-dd4a1fea0a94
[after2]: https://github.com/guardian/dotcom-rendering/assets/110032454/2b317a65-e83e-4483-a45b-ae5a615edf2e

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
