### PR TITLE
Suppress `sanitize-html` warnings

### DIFF
--- a/dotcom-rendering/src/components/Standfirst.tsx
+++ b/dotcom-rendering/src/components/Standfirst.tsx
@@ -222,6 +222,9 @@ export const Standfirst = ({ format, standfirst }: Props) => {
 				}
 				dangerouslySetInnerHTML={{
 					__html: sanitise(standfirst, {
+						// We allow all tags, which includes script & style which are potentially vulnerable
+						// `allowVulnerableTags: true` suppresses this warning
+						allowVulnerableTags: true,
 						allowedTags: false, // Leave tags from CAPI alone
 						allowedAttributes: false, // Leave attributes from CAPI alone
 						transformTags: {

--- a/dotcom-rendering/src/components/TextBlockComponent.tsx
+++ b/dotcom-rendering/src/components/TextBlockComponent.tsx
@@ -116,6 +116,9 @@ const shouldShowDropCaps = (
  * https://www.npmjs.com/package/sanitize-html#default-options
  */
 const sanitiserOptions: IOptions = {
+	// We allow all tags, which includes script & style which are potentially vulnerable
+	// `allowVulnerableTags: true` suppresses this warning
+	allowVulnerableTags: true,
 	allowedTags: false, // Leave tags from CAPI alone
 	allowedAttributes: false, // Leave attributes from CAPI alone
 	transformTags: {


### PR DESCRIPTION
Following a version bump of dependency `sanitize-html` in https://github.com/guardian/dotcom-rendering/pull/8108, we now see warnings in the server console about `script` and `style` tags being potentially vulnerable to XSS. Since we do not use `sanitize-html` to filter tags, we can set the `allowVulnerableTags` option to `true` to disable this warning.

This is no more dangerous than what we had before. This change acknowledges that we permit some vulnerable tags.
