### PR TITLE
Favour `Array.prototype.map` over mutation with `Array.prototype.forEach`

### DIFF
--- a/dotcom-rendering/src/model/enhance-H2s.ts
+++ b/dotcom-rendering/src/model/enhance-H2s.ts
@@ -63,9 +63,8 @@ const generateId = (element: SubheadingBlockElement, existingIds: string[]) => {
  */
 const enhance = (elements: FEElement[]): FEElement[] => {
 	const slugifiedIds: string[] = [];
-	const enhanced: FEElement[] = [];
 	const shouldUseElementId = shouldUseLegacyIDs(elements);
-	elements.forEach((element) => {
+	return elements.map<FEElement>((element) => {
 		if (
 			element._type ===
 			'model.dotcomrendering.pageElements.SubheadingBlockElement'
@@ -79,16 +78,15 @@ const enhance = (elements: FEElement[]): FEElement[] => {
 				// add ID to H2 element
 				`<h2 id='${id}'>`,
 			);
-			enhanced.push({
+			return {
 				...element,
 				html: withId,
-			});
+			};
 		} else {
 			// Otherwise, do nothing
-			enhanced.push(element);
+			return element;
 		}
 	});
-	return enhanced;
 };
 
 export const enhanceH2s = (blocks: Block[]): Block[] => {

--- a/dotcom-rendering/src/model/enhance-blockquotes.ts
+++ b/dotcom-rendering/src/model/enhance-blockquotes.ts
@@ -7,40 +7,37 @@ const isQuoted = (element: BlockquoteBlockElement): boolean => {
 	return !!frag.querySelector('.quoted');
 };
 
-const enhance = (elements: FEElement[], isPhotoEssay: boolean): FEElement[] => {
+const enhance = (elements: FEElement[], isPhotoEssay: boolean): FEElement[] =>
 	// Loops the array of article elements looking for BlockquoteBlockElements to enhance
-	const enhanced: FEElement[] = [];
-	elements.forEach((element) => {
+	elements.map<FEElement>((element) => {
 		switch (element._type) {
 			case 'model.dotcomrendering.pageElements.BlockquoteBlockElement':
 				if (isQuoted(element)) {
 					// When blockquotes have the `quoted` class we represent this using
 					// the quoted prop
-					enhanced.push({
+					return {
 						_type: 'model.dotcomrendering.pageElements.BlockquoteBlockElement',
 						elementId: element.elementId,
 						html: element.html,
 						quoted: true,
-					});
+					};
 				} else if (isPhotoEssay) {
 					// If a blockquote is not queoted it is a Simple Blockquote and for
 					// photo essays we transform these into HighlightBlockElements
-					enhanced.push({
+					return {
 						_type: 'model.dotcomrendering.pageElements.HighlightBlockElement',
 						elementId: element.elementId,
 						html: element.html,
-					});
+					};
 				} else {
 					// Otherwise we don't transform anything and pass the element through
-					enhanced.push(element);
+					return element;
 				}
 				break;
 			default:
-				enhanced.push(element);
+				return element;
 		}
 	});
-	return enhanced;
-};
 
 export const enhanceBlockquotes = (
 	blocks: Block[],

--- a/dotcom-rendering/src/model/enhance-dividers.ts
+++ b/dotcom-rendering/src/model/enhance-dividers.ts
@@ -21,23 +21,22 @@ const isDinkus = (element: FEElement): boolean => {
 	);
 };
 
-const checkForDividers = (elements: FEElement[]): FEElement[] => {
+const checkForDividers = (elements: FEElement[]): FEElement[] =>
 	// checkForDividers loops the array of article elements looking for star flags and
 	// enhancing the data accordingly. In short, if a h2 tag is equal to * * * then we
 	// insert a divider and any the text element immediately afterwards should have dropCap
 	// set to true
-	const enhanced: FEElement[] = [];
-	elements.forEach((element, i) => {
+	elements.map<FEElement>((element, i) => {
 		const previous = elements[i - 1];
 
 		if (i === 0) {
 			// Always pass first element through
-			enhanced.push(element);
+			return element;
 		} else if (isDinkus(element)) {
 			// If this element is a dinkus, replace it with a divider
-			enhanced.push({
+			return {
 				_type: 'model.dotcomrendering.pageElements.DividerBlockElement',
-			});
+			};
 		} else if (
 			previous &&
 			// If the previous element was a dinkus and this one is a text block, set it's dropCap flag
@@ -45,17 +44,15 @@ const checkForDividers = (elements: FEElement[]): FEElement[] => {
 			element._type ===
 				'model.dotcomrendering.pageElements.TextBlockElement'
 		) {
-			enhanced.push({
+			return {
 				...element,
 				dropCap: true,
-			});
+			};
 		} else {
 			// Otherwise, do nothing
-			enhanced.push(element);
+			return element;
 		}
 	});
-	return enhanced;
-};
 
 export const enhanceDividers = (blocks: Block[]): Block[] =>
 	blocks.map((block: Block) => {

--- a/dotcom-rendering/src/model/enhance-dots.ts
+++ b/dotcom-rendering/src/model/enhance-dots.ts
@@ -1,32 +1,29 @@
 import type { FEElement } from '../types/content';
 import { transformDots } from './transformDots';
 
-const checkForDots = (elements: FEElement[]): FEElement[] => {
+const checkForDots = (elements: FEElement[]): FEElement[] =>
 	// Loop over elements and check if a dot is in the TextBlockElement
-	const enhanced: FEElement[] = [];
-	elements.forEach((element, i) => {
+	elements.map<FEElement>((element, i) => {
 		if (
 			element._type ===
 				'model.dotcomrendering.pageElements.TextBlockElement' &&
 			element.html.includes('•')
 		) {
 			if (elements.length - 1 === i) {
-				enhanced.push({
+				return {
 					...element,
 					html: `<footer>${transformDots(element.html)}</footer>`,
-				});
+				};
 			} else {
-				enhanced.push({
+				return {
 					...element,
 					html: transformDots(element.html),
-				});
+				};
 			}
 		} else {
-			enhanced.push(element);
+			return element;
 		}
 	});
-	return enhanced;
-};
 
 export const enhanceDots = (blocks: Block[]): Block[] =>
 	blocks.map((block: Block) => {

--- a/dotcom-rendering/src/model/enhance-embeds.ts
+++ b/dotcom-rendering/src/model/enhance-embeds.ts
@@ -1,9 +1,8 @@
 import { JSDOM } from 'jsdom';
 import type { FEElement } from '../types/content';
 
-const addTitleToIframe = (elements: FEElement[]): FEElement[] => {
-	const enhanced: FEElement[] = [];
-	elements.forEach((element) => {
+const addTitleToIframe = (elements: FEElement[]): FEElement[] =>
+	elements.map<FEElement>((element) => {
 		switch (element._type) {
 			case 'model.dotcomrendering.pageElements.EmbedBlockElement':
 				// Parse the embed block element, find the iframe and add
@@ -13,22 +12,20 @@ const addTitleToIframe = (elements: FEElement[]): FEElement[] => {
 				const iframe = dom.querySelector('iframe');
 				if (iframe && element.alt) {
 					iframe.setAttribute('title', element.alt);
-					enhanced.push({
+					return {
 						...element,
 						...{
 							html: iframe.outerHTML,
 						},
-					});
+					};
 				} else {
-					enhanced.push(element);
+					return element;
 				}
 				break;
 			default:
-				enhanced.push(element);
+				return element;
 		}
 	});
-	return enhanced;
-};
 
 export const enhanceEmbeds = (blocks: Block[]): Block[] =>
 	blocks.map((block: Block) => {

--- a/dotcom-rendering/src/model/enhance-images.ts
+++ b/dotcom-rendering/src/model/enhance-images.ts
@@ -242,53 +242,47 @@ const addCaptionsToMultis = (elements: FEElement[]): FEElement[] => {
 	return withSpecialCaptions;
 };
 
-const stripCaptions = (elements: FEElement[]): FEElement[] => {
+const stripCaptions = (elements: FEElement[]): FEElement[] =>
 	// Remove all captions from all images
-	const withoutCaptions: FEElement[] = [];
-	elements.forEach((thisElement) => {
+	elements.map<FEElement>((thisElement) => {
 		if (
 			thisElement._type ===
 			'model.dotcomrendering.pageElements.ImageBlockElement'
 		) {
 			// Remove the caption from this image
-			withoutCaptions.push({
+			return {
 				...thisElement,
 				data: {
 					...thisElement.data,
 					caption: '',
 				},
-			});
+			};
 		} else {
 			// Pass through
-			withoutCaptions.push(thisElement);
+			return thisElement;
 		}
 	});
-	return withoutCaptions;
-};
 
-const removeCredit = (elements: FEElement[]): FEElement[] => {
+const removeCredit = (elements: FEElement[]): FEElement[] =>
 	// Remove credit from all images
-	const withoutCredit: FEElement[] = [];
-	elements.forEach((thisElement) => {
+	elements.map<FEElement>((thisElement) => {
 		if (
 			thisElement._type ===
 			'model.dotcomrendering.pageElements.ImageBlockElement'
 		) {
 			// Remove the credit from this image
-			withoutCredit.push({
+			return {
 				...thisElement,
 				data: {
 					...thisElement.data,
 					credit: '',
 				},
-			});
+			};
 		} else {
 			// Pass through
-			withoutCredit.push(thisElement);
+			return thisElement;
 		}
 	});
-	return withoutCredit;
-};
 
 class Enhancer {
 	elements: FEElement[];

--- a/dotcom-rendering/src/model/enhance-numbered-lists.ts
+++ b/dotcom-rendering/src/model/enhance-numbered-lists.ts
@@ -1,9 +1,5 @@
 import { JSDOM } from 'jsdom';
-import type {
-	FEElement,
-	ImageBlockElement,
-	TextBlockElement,
-} from '../types/content';
+import type { FEElement, TextBlockElement } from '../types/content';
 
 const isFalseH3 = (element: FEElement): boolean => {
 	// Checks if this element is a 'false h3' based on the convention: <p><strong><H3 text</strong></p>
@@ -134,9 +130,8 @@ const starifyImages = (elements: FEElement[]): FEElement[] => {
 	return starified;
 };
 
-const inlineStarRatings = (elements: FEElement[]): FEElement[] => {
-	const withStars: FEElement[] = [];
-	elements.forEach((thisElement) => {
+const inlineStarRatings = (elements: FEElement[]): FEElement[] =>
+	elements.map<FEElement>((thisElement) => {
 		if (
 			thisElement._type ===
 				'model.dotcomrendering.pageElements.TextBlockElement' &&
@@ -144,40 +139,35 @@ const inlineStarRatings = (elements: FEElement[]): FEElement[] => {
 		) {
 			const rating = extractStarCount(thisElement);
 			// Inline this image
-			withStars.push({
+			return {
 				_type: 'model.dotcomrendering.pageElements.StarRatingBlockElement',
 				elementId: thisElement.elementId,
 				rating,
 				size: 'large',
-			});
+			};
 		} else {
 			// Pass through
-			withStars.push(thisElement);
+			return thisElement;
 		}
 	});
-	return withStars;
-};
 
-const makeThumbnailsRound = (elements: FEElement[]): FEElement[] => {
-	const inlined: FEElement[] = [];
-	elements.forEach((thisElement) => {
+const makeThumbnailsRound = (elements: FEElement[]): FEElement[] =>
+	elements.map<FEElement>((thisElement) => {
 		if (
 			thisElement._type ===
 				'model.dotcomrendering.pageElements.ImageBlockElement' &&
 			thisElement.role === 'thumbnail'
 		) {
 			// Make this image round
-			inlined.push({
+			return {
 				...thisElement,
 				isAvatar: true,
-			} as ImageBlockElement);
+			};
 		} else {
 			// Pass through
-			inlined.push(thisElement);
+			return thisElement;
 		}
 	});
-	return inlined;
-};
 
 const isItemLink = (element: FEElement): boolean => {
 	// Checks if this element is a 'item link' based on the convention: <ul> <li>...</li> </ul>
@@ -197,7 +187,7 @@ const isItemLink = (element: FEElement): boolean => {
 	return hasULWrapper && hasOnlyOneChild && hasLINestedWrapper;
 };
 
-const removeGlobalH2Styles = (elements: FEElement[]): FEElement[] => {
+const removeGlobalH2Styles = (elements: FEElement[]): FEElement[] =>
 	/**
 	 * Article pages come with some global style rules, one of which affects h2
 	 * tags. But for numbered lists we don't want these styles because we use
@@ -205,29 +195,26 @@ const removeGlobalH2Styles = (elements: FEElement[]): FEElement[] => {
 	 * css war, this enhancer uses the `data-ignore` attribute which is a contract
 	 * established to allow global styles to be ignored.
 	 *
-	 * All h2 tags inside an article of Design: NumberedList have this attirbute
+	 * All h2 tags inside an article of Design: NumberedList have this attribute
 	 * set.
 	 */
-	const withH2StylesIgnored: FEElement[] = [];
-	elements.forEach((thisElement) => {
+	elements.map<FEElement>((thisElement) => {
 		if (
 			thisElement._type ===
 			'model.dotcomrendering.pageElements.SubheadingBlockElement'
 		) {
-			withH2StylesIgnored.push({
+			return {
 				...thisElement,
 				html: thisElement.html.replace(
 					'<h2>',
 					'<h2 data-ignore="global-h2-styling">',
 				),
-			});
+			};
 		} else {
 			// Pass through
-			withH2StylesIgnored.push(thisElement);
+			return thisElement;
 		}
 	});
-	return withH2StylesIgnored;
-};
 
 const addH3s = (elements: FEElement[]): FEElement[] => {
 	/**

--- a/dotcom-rendering/src/model/enhance-tweets.ts
+++ b/dotcom-rendering/src/model/enhance-tweets.ts
@@ -1,10 +1,9 @@
 import type { FEElement } from '../types/content';
 
-const removeTweetClass = (elements: FEElement[]): FEElement[] => {
-	const enhanced: FEElement[] = [];
-	elements.forEach((element) => {
+const removeTweetClass = (elements: FEElement[]): FEElement[] =>
+	elements.map<FEElement>((element) => {
 		switch (element._type) {
-			case 'model.dotcomrendering.pageElements.TweetBlockElement':
+			case 'model.dotcomrendering.pageElements.TweetBlockElement': {
 				// Parse the embed block element, find the iframe and add
 				// the alt text as a title attribute if it exists
 				// https://dequeuniversity.com/tips/provide-iframe-titles
@@ -12,17 +11,16 @@ const removeTweetClass = (elements: FEElement[]): FEElement[] => {
 					'twitter-tweet',
 					'nojs-tweet',
 				);
-				enhanced.push({
+				return {
 					...element,
 					html: withoutTweetClass,
-				});
-				break;
+				};
+			}
+
 			default:
-				enhanced.push(element);
+				return element;
 		}
 	});
-	return enhanced;
-};
 
 export const enhanceTweets = (blocks: Block[]): Block[] =>
 	blocks.map((block: Block) => {


### PR DESCRIPTION
## What does this change?

Replaces usage of [`Array.prototype.forEach`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach) in our enhancers with [`Array.prototype.map`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map).

## Why?

We generally favour declarative programming over imperative programming. This improves readability by:
- having all the logic self-contained
- lending itself to composition and functional programming
- being more explicit in the number of items returned

This PR is hoping to open the discussion.

## Known issues

Imperative for loops can be slightly faster in JavaScript. My micro-benchmarks and flame graph analysis of DCR request does not suggest that this is a critical performance issue.

I have heard several times that this style of programming is **less readable**. I would love to understand better why that is the case.

I have looked for a rule to enforce this with ESLint, but could not find one. There’s a suggestion it could come here: https://github.com/sindresorhus/eslint-plugin-unicorn/issues/1712