### PR TITLE
fix(ImmersiveLayout): ensure minHeight parsed properly to avoid nulls in calc css

### DIFF
--- a/dotcom-rendering/src/components/Nav/Nav.tsx
+++ b/dotcom-rendering/src/components/Nav/Nav.tsx
@@ -1,5 +1,5 @@
 import { css, Global } from '@emotion/react';
-import { ArticlePillar } from '@guardian/libs';
+import type { ArticlePillar } from '@guardian/libs';
 import { until, visuallyHidden } from '@guardian/source-foundations';
 import type { EditionId } from '../../lib/edition';
 import { clearFix } from '../../lib/mixins';
@@ -32,8 +32,9 @@ const rowStyles = css`
 	justify-content: space-between;
 `;
 
+export const minNavHeightPx = 48;
 export const minNavHeight = css`
-	min-height: 48px;
+	min-height: ${minNavHeightPx}px;
 `;
 
 const PositionRoundel = ({ children }: { children: React.ReactNode }) => (

--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -1,5 +1,4 @@
 import { css } from '@emotion/react';
-import type { SerializedStyles } from '@emotion/react';
 import { ArticleDesign, ArticleDisplay, ArticleSpecial } from '@guardian/libs';
 import type { ArticleFormat } from '@guardian/libs';
 import {
@@ -34,7 +33,7 @@ import { LabsHeader } from '../components/LabsHeader';
 import { MainMedia } from '../components/MainMedia';
 import { MostViewedFooterData } from '../components/MostViewedFooterData.importable';
 import { MostViewedFooterLayout } from '../components/MostViewedFooterLayout';
-import { minNavHeight, Nav } from '../components/Nav/Nav';
+import { minNavHeightPx, Nav } from '../components/Nav/Nav';
 import { OnwardsUpper } from '../components/OnwardsUpper.importable';
 import { RightColumn } from '../components/RightColumn';
 import { Section } from '../components/Section';
@@ -285,13 +284,11 @@ export const ImmersiveLayout = ({
 	*/
 
 	const labsHeaderHeight = LABS_HEADER_HEIGHT;
-	const navHeightCSS: SerializedStyles = minNavHeight;
-	const navHeight = parseInt(navHeightCSS.styles.slice(11, -2));
-	const combinedHeight = (navHeight + labsHeaderHeight).toString();
+	const combinedHeight = (minNavHeightPx + labsHeaderHeight).toString();
 
 	const navAndLabsHeaderHeight = isLabs
 		? `${combinedHeight}px`
-		: `${navHeight}px`;
+		: `${minNavHeightPx}px`;
 
 	const hasMainMediaStyles = css`
 		height: calc(80vh - ${navAndLabsHeaderHeight});


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Exports min height as a number in Nav to use in other places, instead of trying to backwards parse the emotion CSS block in ImmersiveLayout

## Why?

Fixes a bug introduced in https://github.com/guardian/dotcom-rendering/pull/6762 where the nav height wasn't being parsed correctly, resulting in null values for the calculated css heights on non labs immersive articles.

## Screenshots

| Frontend | Before      | After      |
| ----------- | ----------- | ---------- |
| ![frontend][] | ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/43961396/61e83578-4407-44e0-8b41-9b9374a6247b
[after]: https://github.com/guardian/dotcom-rendering/assets/43961396/1a4345f4-9b6c-4442-a279-710b6a098d9d
[frontend]: https://github.com/guardian/dotcom-rendering/assets/43961396/56ab62ce-e961-4e3c-9d11-13bfa5882e03


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
