### PR TITLE
various attempts to fix babel

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -154,7 +154,7 @@
 		"aws-cdk": "2.68.0",
 		"aws-cdk-lib": "2.68.0",
 		"babel-core": "7.0.0-bridge.0",
-		"babel-loader": "8.3.0",
+		"babel-loader": "9.1.2",
 		"babel-plugin-module-resolver": "5.0.0",
 		"babel-plugin-polyfill-corejs3": "0.6.0",
 		"babel-plugin-px-to-rem": "https://github.com/guardian/babel-plugin-px-to-rem#v0.1.0",

--- a/dotcom-rendering/scripts/webpack/webpack.config.client.js
+++ b/dotcom-rendering/scripts/webpack/webpack.config.client.js
@@ -36,24 +36,24 @@ const getLoaders = (bundle) => {
 	switch (bundle) {
 		case 'legacy':
 			return [
-				// {
-				// 	loader: 'babel-loader',
-				// 	options: {
-				// 		presets: [
-				// 			'@babel/preset-react',
-				// 			[
-				// 				'@babel/preset-env',
-				// 				{
-				// 					targets: {
-				// 						ie: '11',
-				// 					},
-				// 					modules: false,
-				// 				},
-				// 			],
-				// 		],
-				// 		compact: true,
-				// 	},
-				// },
+				{
+					loader: 'babel-loader',
+					options: {
+						presets: [
+							'@babel/preset-react',
+							[
+								'@babel/preset-env',
+								{
+									targets: {
+										ie: '11',
+									},
+									modules: false,
+								},
+							],
+						],
+						compact: true,
+					},
+				},
 				{
 					loader: 'ts-loader',
 					options: {


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
