### PR TITLE
FixedMediumSlowXIIMPU fix styling for fewer cards

### DIFF
--- a/dotcom-rendering/src/components/FixedMediumSlowXIIMPU.tsx
+++ b/dotcom-rendering/src/components/FixedMediumSlowXIIMPU.tsx
@@ -3,7 +3,6 @@ import {
 	Card100Media100Tall,
 	Card33Media33MobileTopTall,
 	Card33Media33Tall,
-	Card50Media50TallMPU,
 	CardDefault,
 } from '../lib/cardWrappers';
 import { shouldPadWrappableRows } from '../lib/dynamicSlices';
@@ -18,6 +17,7 @@ type Props = {
 	showAge?: boolean;
 	adIndex: number;
 	renderAds: boolean;
+	padBottom?: boolean;
 };
 
 type MPUSliceProps = {
@@ -91,16 +91,27 @@ const Card50_Card50 = ({
 	showAge?: boolean;
 	padBottom?: boolean;
 }) => {
+	const card50 = trails.slice(0, 1);
+	const cards50 = trails.slice(1);
 	return (
 		<UL direction="row" padBottom={padBottom}>
-			{trails.map((trail, index) => (
+			{card50.map((trail) => (
+				<LI percentage="50%" padSides={true} key={trail.url}>
+					<Card33Media33MobileTopTall
+						trail={trail}
+						containerPalette={containerPalette}
+						showAge={showAge}
+					/>
+				</LI>
+			))}
+			{cards50.map((trail) => (
 				<LI
 					percentage="50%"
 					padSides={true}
+					showDivider={true}
 					key={trail.url}
-					showDivider={index > 0}
 				>
-					<Card50Media50TallMPU
+					<Card33Media33Tall
 						trail={trail}
 						containerPalette={containerPalette}
 						showAge={showAge}
@@ -186,20 +197,25 @@ export const FixedMediumSlowXIIMPU = ({
 	showAge,
 	adIndex,
 	renderAds,
+	padBottom,
 }: Props) => {
 	const firstSlice = trails.slice(0, 3);
 	const remaining = trails.slice(3, 9);
 	return (
 		<>
 			{trails.length === 1 ? (
-				trails.map((trail) => (
-					<Card100Media100Tall
-						trail={trail}
-						containerPalette={containerPalette}
-						showAge={showAge}
-						key={trail.url}
-					/>
-				))
+				<UL>
+					<LI padSides={true} percentage="100%">
+						{trails.map((trail) => (
+							<Card100Media100Tall
+								trail={trail}
+								containerPalette={containerPalette}
+								showAge={showAge}
+								key={trail.url}
+							/>
+						))}
+					</LI>
+				</UL>
 			) : trails.length === 2 ? (
 				<Card50_Card50
 					trails={trails}

--- a/dotcom-rendering/src/lib/cardWrappers.tsx
+++ b/dotcom-rendering/src/lib/cardWrappers.tsx
@@ -526,43 +526,6 @@ export const Card50Media50Tall = ({
 };
 
 /**
- * ┏━━━━━━━━━━━━━━━━━━┱┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┐
- * ┃▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒┃                  ┊
- * ┃▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒┃        50%       ┊
- * ┃                  ┃     Remaining    ┊
- * ┃                  ┃                  ┊
- * ┗━━━━━━━━━━━━━━━━━━┹┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┘
- * Card designed to take up 50% of the container, with media that takes up 50%
- *
- * Options:
- *  - Medium headline (large on mobile)
- *  - Medium image on the top (top on mobile)
- *  - If avatar show trail text
- *  - Up to 3 supporting content items, always aligned horizontal
- */
-export const Card50Media50TallMPU = ({
-	trail,
-	showAge,
-	containerPalette,
-}: TrailProps) => {
-	return (
-		<FrontCard
-			trail={trail}
-			containerPalette={containerPalette}
-			showAge={showAge}
-			trailText={trail.avatarUrl ? trail.trailText : undefined}
-			supportingContent={trail.supportingContent?.slice(0, 3)}
-			supportingContentAlignment="horizontal"
-			imagePosition="top"
-			imagePositionOnMobile="top"
-			imageSize="medium"
-			headlineSize="medium"
-			headlineSizeOnMobile="large"
-		/>
-	);
-};
-
-/**
  * ┏━━━━━━━━━━━━━━━━━━━━━━━━┱┈┈┈┈┈┈┈┈┈┈┈┈┐
  * ┃▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒┃     33%    ┊
  * ┃▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒┃  Remaining ┊


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
This brings the FixedMediumSlowXIIMPU with 2 or fewer cards in line with frontend
## Why?
Fixes https://github.com/guardian/dotcom-rendering/issues/7937
## Screenshots

| Before      | After      | Frontend      |
| ----------- | ---------- | ---------- |
| ![before][] | ![after][] | ![frontend][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/110032454/ae5582cf-d8e2-474d-9455-7aed6dffe549
[after]: https://github.com/guardian/dotcom-rendering/assets/110032454/2019d687-da1e-4fd5-8f5f-b33cca8865f0
[frontend]: https://github.com/guardian/dotcom-rendering/assets/110032454/9db26873-c168-49a8-b5a7-fe950eff00db
<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
