### PR TITLE
feat: include credentials on reportAbuse method in discussion

### DIFF
--- a/dotcom-rendering/src/discussion-rendering/lib/api.tsx
+++ b/dotcom-rendering/src/discussion-rendering/lib/api.tsx
@@ -241,6 +241,7 @@ export const reportAbuse = ({
 	return fetch(url, {
 		method: 'POST',
 		body: data.toString(),
+		credentials: 'include',
 		headers: {
 			'Content-Type': 'application/x-www-form-urlencoded',
 			...options.headers,


### PR DESCRIPTION
Includes credentials when reporting abuse on comments. This is a feature the mod team has been been requesting for a little while. I _think_ because it help prioritise reports.

This will also mean this functionality is carried over when the Okta migration is done.

This has been E2E tested on code and confirmed by @coldlink as working.