### PR TITLE
Respect curated kicker in sublinks liveblogs

### DIFF
--- a/dotcom-rendering/src/model/enhanceCards.ts
+++ b/dotcom-rendering/src/model/enhanceCards.ts
@@ -87,13 +87,14 @@ const enhanceSupportingContent = (
 		const supportingContentIsLive =
 			subLink.format?.design === 'LiveBlogDesign';
 
+		const kickerText = subLink.header?.kicker?.item?.properties.kickerText;
+
 		return {
 			format: presentationFormat,
 			headline: subLink.header?.headline ?? '',
 			url: subLink.properties.href ?? subLink.header?.url,
-			kickerText: supportingContentIsLive
-				? 'Live'
-				: subLink.header?.kicker?.item?.properties.kickerText,
+			kickerText:
+				supportingContentIsLive && !kickerText ? 'Live' : kickerText,
 		};
 	});
 };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## Why?

Same as this https://github.com/guardian/dotcom-rendering/pull/8142 for sublinks live kickers.

## Screenshots

|               | Tool | Before | After |
|---------------|------|--------|-------|
| no kicker     | ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/67a80721-7ff3-45f9-917c-4dfb329d9065) | ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/15331fdc-627b-4c97-a7cc-a7256043e3f7) | ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/10246d8f-69dc-4651-9ac0-4d109cacdccc) |
| custom kicker | ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/d131bd76-6967-4e12-b09b-a5ee0fab1040) | ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/a38ebbe3-c935-4dfe-aff3-ac363ad182a6) | ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/0593b978-ff40-4845-b75e-29f0314b488e) |

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
