### PR TITLE
fix: only try to fetch branded badge if container is paid content type

### DIFF
--- a/dotcom-rendering/src/model/enhanceCollections.ts
+++ b/dotcom-rendering/src/model/enhanceCollections.ts
@@ -72,7 +72,8 @@ export const enhanceCollections = (
 			href,
 			containerPalette,
 			badge: decideBadge(
-				allCardsHaveBranding ? allBranding : [],
+				// We only try to use branded badge for paid content containers
+				isPaidContent && allCardsHaveBranding ? allBranding : [],
 				collection.config.href,
 			),
 			grouped: groupCards(


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Stops badges from appearing randomly on non paid-content containers containing cards with branding e.g. the /uk/environment front.

## Why?

Addresses the leaky logic for deciding which badge to include in enhanced container data. Fixes #8130 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/43961396/c22ade10-fb21-4c7f-9b86-b9c0ddb07407
[after]: https://github.com/guardian/dotcom-rendering/assets/43961396/e3d0e055-f43f-4835-954e-fb4ce6891236

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->

## Still TODO:

This code is wacky and needs a refactor to make it understandable. Refactor coming in a PR shortly! But separating the fix from the refactor here