### PR TITLE
Lint against `Array.prototype.forEach`

### DIFF
--- a/dotcom-rendering/.eslintrc.js
+++ b/dotcom-rendering/.eslintrc.js
@@ -133,6 +133,9 @@ module.exports = {
 
 		'object-shorthand': ['error', 'always'],
 
+		/** @see https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-array-for-each.md */
+		'unicorn/no-array-for-each': 'error',
+
 		'import/no-extraneous-dependencies': [
 			'error',
 			// https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-extraneous-dependencies.md#options

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -174,7 +174,7 @@
 		"doctoc": "2.2.1",
 		"dompurify": "3.0.3",
 		"dynamic-import-polyfill": "0.1.1",
-		"eslint": "8.34.0",
+		"eslint": "8.44.0",
 		"eslint-config-airbnb-base": "15.0.0",
 		"eslint-config-airbnb-typescript": "17.0.0",
 		"eslint-config-prettier": "8.6.0",

--- a/dotcom-rendering/src/client/islands/initHydration.ts
+++ b/dotcom-rendering/src/client/islands/initHydration.ts
@@ -34,12 +34,12 @@ export const initHydration = (elements: NodeListOf<Element>): void => {
 	 * props - The data for the component that has been serialised in the dom
 	 * element - The `gu-island` custom element which is wrapping the content
 	 */
-	elements.forEach((element) => {
+	for (const element of elements) {
 		if (element instanceof HTMLElement) {
 			const name = getName(element);
 			const props = getProps(element);
 
-			if (!name) return;
+			if (!name) continue;
 
 			const deferUntil = element.getAttribute('deferuntil');
 			switch (deferUntil) {
@@ -112,5 +112,5 @@ export const initHydration = (elements: NodeListOf<Element>): void => {
 				}
 			}
 		}
-	});
+	}
 };

--- a/dotcom-rendering/src/client/newsletterEmbedIframe.ts
+++ b/dotcom-rendering/src/client/newsletterEmbedIframe.ts
@@ -10,12 +10,12 @@ export const newsletterEmbedIframe = (): Promise<void> => {
 	// Tell the iframes to resize once this script is loaded
 	// Otherwise, earlier resize events might be missed
 	// So we don't have to load this script as a priority on each load
-	allIframes.forEach((iframe) => {
+	for (const iframe of allIframes) {
 		iframe.contentWindow?.postMessage(
 			'resize',
 			'https://www.theguardian.com',
 		);
-	});
+	}
 
 	window.addEventListener('message', (event) => {
 		if (!allowedOrigins.includes(event.origin)) return;
@@ -38,7 +38,7 @@ export const newsletterEmbedIframe = (): Promise<void> => {
 
 				switch (message.type) {
 					case 'set-height':
-						iframes.forEach((iframe) => {
+						for (const iframe of iframes) {
 							if (typeof message.value === 'number') {
 								iframe.height = `${message.value}`;
 							} else if (typeof message.value === 'string') {
@@ -47,7 +47,7 @@ export const newsletterEmbedIframe = (): Promise<void> => {
 									iframe.height = `${value}`;
 								}
 							}
-						});
+						}
 						break;
 					default:
 				}

--- a/dotcom-rendering/src/client/ophan/ophan.ts
+++ b/dotcom-rendering/src/client/ophan/ophan.ts
@@ -80,12 +80,12 @@ export const sendOphanComponentEvent = (
 
 export const abTestPayload = (tests: ServerSideTests): OphanABPayload => {
 	const records: { [key: string]: OphanABEvent } = {};
-	Object.entries(tests).forEach(([testName, variantName]) => {
+	for (const [testName, variantName] of Object.entries(tests)) {
 		records[`ab${testName}`] = {
 			variantName,
 			complete: false,
 		};
-	});
+	}
 
 	return { abTestRegister: records };
 };

--- a/dotcom-rendering/src/client/relativeTime/updateTimeElements.ts
+++ b/dotcom-rendering/src/client/relativeTime/updateTimeElements.ts
@@ -28,7 +28,8 @@ export const updateTimeElement = (element: Element): void => {
 };
 
 export const updateTimeElements = (): void => {
-	document
-		.querySelectorAll('time[data-relativeformat]')
-		.forEach(updateTimeElement);
+	const elements = document.querySelectorAll('time[data-relativeformat]');
+	for (const element of elements) {
+		updateTimeElement(element);
+	}
 };

--- a/dotcom-rendering/src/client/updateIframeHeight.tsx
+++ b/dotcom-rendering/src/client/updateIframeHeight.tsx
@@ -30,12 +30,12 @@ export const updateIframeHeight = (queryString: string): Promise<void> => {
 		}
 	});
 
-	iframes.forEach((iframe) => {
+	for (const iframe of iframes) {
 		const src = (iframe.getAttribute('srcdoc') ?? '')
 			.replace(/<gu-script>/g, '<script>')
 
 			.replace(/<\/gu-script>/g, '<' + '/script>');
 		iframe.setAttribute('srcdoc', src);
-	});
+	}
 	return Promise.resolve();
 };

--- a/dotcom-rendering/src/components/AnimatePulsingDots.importable.tsx
+++ b/dotcom-rendering/src/components/AnimatePulsingDots.importable.tsx
@@ -7,12 +7,12 @@ const animatePulsingDots = () => {
 		`[data-flashing-dot-hydrated="false"]`,
 	);
 
-	elements.forEach((element) => {
+	for (const element of elements) {
 		element.setAttribute('data-flashing-dot-hydrated', 'true');
 		// In PulsingDot.tsx, we set the animation only to run
 		// if this data attribute is set
 		element.setAttribute('data-animate', 'true');
-	});
+	}
 };
 
 /**

--- a/dotcom-rendering/src/components/Callout/Form.tsx
+++ b/dotcom-rendering/src/components/Callout/Form.tsx
@@ -97,11 +97,9 @@ export const Form = ({
 
 	const validateForm = (): boolean => {
 		const errors: { [key in string]: string } = {};
-		let isValid = true;
-		formFields.forEach((field: CampaignFieldType) => {
+		for (const field of formFields) {
 			if (field.required && !formData[field.id]) {
 				errors[field.id] = 'This field is required';
-				isValid = false;
 			}
 			if (field.type === 'select' && field.required) {
 				if (formData[field.id] === 'Please choose an option') {
@@ -113,7 +111,6 @@ export const Form = ({
 				const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 				if (!emailRegex.test(formData[field.id] as string)) {
 					errors[field.id] = 'Please enter a valid email address';
-					isValid = false;
 				}
 			}
 			if (
@@ -123,16 +120,13 @@ export const Form = ({
 				const numberRegex = /^[\d ()+-]+$/;
 				if (!numberRegex.test(formData[field.id] as string)) {
 					errors[field.id] = 'Please enter a valid number';
-					isValid = false;
 				}
 				const noWhiteSpace = formData[field.id] as string;
 				if (noWhiteSpace.length < 10) {
 					errors[field.id] = 'Please include your dialling/area code';
-					isValid = false;
 				}
 			}
-			return isValid;
-		});
+		}
 		setValidationErrors(errors);
 		return Object.keys(errors).length === 0;
 	};

--- a/dotcom-rendering/src/components/Callout/MessageUs.tsx
+++ b/dotcom-rendering/src/components/Callout/MessageUs.tsx
@@ -50,10 +50,10 @@ export const formatContactNumbers = (
 	const contactNumbers = new Map<string, string[]>();
 
 	// Group each contact by its value, so we can display multiple names for the same number.
-	contacts.forEach(({ name, value }) => {
+	for (const { name, value } of contacts) {
 		if (!contactNumbers.has(value)) contactNumbers.set(value, []);
 		contactNumbers.get(value)?.push(name);
-	});
+	}
 
 	// Join the names for each number together,
 	// and then join all the numbers together into a readable string.

--- a/dotcom-rendering/src/components/Carousel.stories.tsx
+++ b/dotcom-rendering/src/components/Carousel.stories.tsx
@@ -282,14 +282,12 @@ Immersive.storyName = 'Immersive carousel';
 export const SpecialReportAlt = () => {
 	const specialReportTrails = [...trails];
 
-	specialReportTrails.forEach(
-		(trail) =>
-			(trail.format = {
-				theme: ArticleSpecial.SpecialReportAlt,
-				design: ArticleDesign.Standard,
-				display: ArticleDisplay.Standard,
-			}),
-	);
+	for (const trail of specialReportTrails)
+		trail.format = {
+			theme: ArticleSpecial.SpecialReportAlt,
+			design: ArticleDesign.Standard,
+			display: ArticleDisplay.Standard,
+		};
 
 	return (
 		<>

--- a/dotcom-rendering/src/components/Discussion.tsx
+++ b/dotcom-rendering/src/components/Discussion.tsx
@@ -133,10 +133,10 @@ export const Discussion = ({
 		const pendingElements = document.querySelectorAll<HTMLElement>(
 			'.discussion > .pending',
 		);
-		pendingElements.forEach((element) => {
+		for (const element of pendingElements) {
 			element.classList.add('reveal');
 			element.classList.remove('pending');
-		});
+		}
 	}, []);
 
 	useEffect(() => {

--- a/dotcom-rendering/src/components/Discussion/TopPicks.tsx
+++ b/dotcom-rendering/src/components/Discussion/TopPicks.tsx
@@ -60,11 +60,10 @@ export const TopPicks = ({
 }: Props) => {
 	const leftColComments: CommentType[] = [];
 	const rightColComments: CommentType[] = [];
-	comments.forEach((comment, index) =>
+	for (const [index, comment] of comments.entries())
 		index % 2 === 0
 			? leftColComments.push(comment)
-			: rightColComments.push(comment),
-	);
+			: rightColComments.push(comment);
 	return (
 		<div css={picksWrapper}>
 			<div css={twoColCommentsStyles}>

--- a/dotcom-rendering/src/components/Dropdown.tsx
+++ b/dotcom-rendering/src/components/Dropdown.tsx
@@ -302,9 +302,9 @@ const DropdownLink = ({ link, index }: DropdownLinkProps) => {
 
 			// For each notification for this link, log the impression back to
 			// Braze separately
-			link.notifications.forEach((notification) => {
+			for (const notification of link.notifications) {
 				notification.logImpression?.();
-			});
+			}
 
 			submitComponentEvent({
 				component: ophanComponent,

--- a/dotcom-rendering/src/components/FetchCommentCounts.importable.tsx
+++ b/dotcom-rendering/src/components/FetchCommentCounts.importable.tsx
@@ -37,30 +37,28 @@ type EnhancedCountType = {
  * Reads the dom looking for markers that contain the information needed to render the
  * count
  */
-function extractMarkers() {
-	const markers: MarkerType[] = [];
-	document
-		.querySelectorAll('[data-discussion-id]')
-		.forEach((element: Element) => {
+const extractMarkers = () =>
+	Array.from(document.querySelectorAll('[data-discussion-id]'))
+		.map<MarkerType | undefined>((element: Element) => {
 			if (element instanceof HTMLElement) {
 				try {
 					const { discussionId, format, isDynamo, containerPalette } =
 						element.dataset;
 					if (discussionId && format) {
-						markers.push({
+						return {
 							discussionId,
 							format: JSON.parse(format),
 							isDynamo: isDynamo ? true : undefined,
 							containerPalette,
-						});
+						};
 					}
 				} catch (e) {
 					// Do nothing
 				}
 			}
-		});
-	return markers;
-}
+			return undefined;
+		})
+		.filter(isNonNullable);
 
 /**
  * @description

--- a/dotcom-rendering/src/components/FetchCommentCounts.importable.tsx
+++ b/dotcom-rendering/src/components/FetchCommentCounts.importable.tsx
@@ -1,4 +1,5 @@
 import { CacheProvider } from '@emotion/react';
+import { isNonNullable } from '@guardian/libs';
 import { useEffect, useState } from 'react';
 import { createRoot } from 'react-dom/client';
 import { getEmotionCache } from '../client/islands/emotion';
@@ -109,7 +110,7 @@ function enhanceCounts(
  * Takes the long and short version of each count and renders onto the page with react
  */
 function renderCounts(counts: EnhancedCountType[]) {
-	counts.forEach((count) => {
+	for (const count of counts) {
 		const container = document.querySelector(
 			`[data-discussion-id="${count.id}"]`,
 		);
@@ -130,7 +131,7 @@ function renderCounts(counts: EnhancedCountType[]) {
 
 			container.setAttribute('aria-label', `${count.short} Comments`);
 		}
-	});
+	}
 }
 
 /**

--- a/dotcom-rendering/src/components/FetchOnwardsData.importable.tsx
+++ b/dotcom-rendering/src/components/FetchOnwardsData.importable.tsx
@@ -47,10 +47,10 @@ export const FetchOnwardsData = ({
 			const pendingElements = document.querySelectorAll<HTMLElement>(
 				'.onwards > .pending',
 			);
-			pendingElements.forEach((element) => {
+			for (const element of pendingElements) {
 				element.classList.add('reveal');
 				element.classList.remove('pending');
-			});
+			}
 		}
 	});
 

--- a/dotcom-rendering/src/components/InteractiveContentsBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/components/InteractiveContentsBlockComponent.importable.tsx
@@ -240,9 +240,8 @@ export const InteractiveContentsBlockComponent = ({
 				rootMargin: `0px 0px -100% 0px`,
 			});
 
-			enhancedSubheadings.forEach(
-				(item) => item.ref && observer.observe(item.ref),
-			);
+			for (const item of enhancedSubheadings)
+				item.ref && observer.observe(item.ref);
 
 			if (endDocumentElementId) {
 				const endDocumentRef =

--- a/dotcom-rendering/src/components/LightboxJavascript.importable.tsx
+++ b/dotcom-rendering/src/components/LightboxJavascript.importable.tsx
@@ -361,7 +361,7 @@ function initialiseLightbox(lightbox: HTMLElement) {
 	// --------------------------------------------------------------------------------
 	// EVENT LISTENERS
 	// --------------------------------------------------------------------------------
-	pictures.forEach((picture) => {
+	for (const picture of pictures) {
 		// Clicking on the image toggles the caption
 		picture.addEventListener('mousedown', (event) => {
 			toggleInfo();
@@ -371,7 +371,7 @@ function initialiseLightbox(lightbox: HTMLElement) {
 		});
 		// Remove the loader once the image has been downloaded
 		const index = picture.closest('li')?.dataset.index;
-		if (index === undefined) return;
+		if (index === undefined) continue;
 		const position = parseInt(index, 10);
 		const image = picture.querySelector('img');
 		if (image?.complete) {
@@ -379,7 +379,7 @@ function initialiseLightbox(lightbox: HTMLElement) {
 		} else {
 			image?.addEventListener('load', () => removeLoader(position));
 		}
-	});
+	}
 
 	imageList?.addEventListener(
 		'scroll',
@@ -403,7 +403,7 @@ function initialiseLightbox(lightbox: HTMLElement) {
 	nextButton?.addEventListener('click', goForward);
 	infoButton?.addEventListener('click', toggleInfo);
 
-	captionLinks.forEach((link) => {
+	for (const link of captionLinks) {
 		link.addEventListener('click', (event) => {
 			// This prevents the event listener from this element's LI parent
 			// from firing. That LI event listener would have tried to hide the
@@ -412,7 +412,7 @@ function initialiseLightbox(lightbox: HTMLElement) {
 			// cause a weird flash
 			event.stopPropagation();
 		});
-	});
+	}
 
 	/**
 	 * We listen for the fullscreenchange event here so that we can fire our

--- a/dotcom-rendering/src/components/Liveness.importable.tsx
+++ b/dotcom-rendering/src/components/Liveness.importable.tsx
@@ -84,10 +84,11 @@ function revealPendingBlocks() {
 	const blogBody = document.querySelector<HTMLElement>('#liveblog-body');
 	const pendingBlocks =
 		blogBody?.querySelectorAll<HTMLElement>('.pending.block');
-	pendingBlocks?.forEach((block) => {
-		block.classList.add('reveal-slowly');
-		block.classList.remove('pending');
-	});
+	if (pendingBlocks)
+		for (const block of pendingBlocks) {
+			block.classList.add('reveal-slowly');
+			block.classList.remove('pending');
+		}
 
 	if (pendingBlocks !== undefined && pendingBlocks.length > 0)
 		// Notify commercial that new blocks are available and they can re-run spacefinder

--- a/dotcom-rendering/src/components/ManyNewsletterSignUp.importable.tsx
+++ b/dotcom-rendering/src/components/ManyNewsletterSignUp.importable.tsx
@@ -168,13 +168,13 @@ export const ManyNewsletterSignUp = () => {
 		const signUpButtons = [
 			...document.querySelectorAll(`[data-role=${BUTTON_ROLE}]`),
 		];
-		signUpButtons.forEach((button) => {
+		for (const button of signUpButtons) {
 			button.classList.remove(BUTTON_SELECTED_CLASS);
 			const ariaLabelText =
 				button.getAttribute('data-aria-label-when-unchecked') ??
 				'add to list';
 			button.setAttribute('aria-label', ariaLabelText);
-		});
+		}
 
 		setNewslettersToSignUpFor([]);
 	}, [userCanInteract]);
@@ -183,13 +183,13 @@ export const ManyNewsletterSignUp = () => {
 		const signUpButtons = [
 			...document.querySelectorAll(`[data-role=${BUTTON_ROLE}]`),
 		];
-		signUpButtons.forEach((button) => {
+		for (const button of signUpButtons) {
 			button.addEventListener('click', toggleNewsletter);
-		});
+		}
 		return () => {
-			signUpButtons.forEach((button) => {
+			for (const button of signUpButtons) {
 				button.removeEventListener('click', toggleNewsletter);
-			});
+			}
 		};
 	}, [toggleNewsletter, newslettersToSignUpFor]);
 

--- a/dotcom-rendering/src/components/MediaMeta.test.tsx
+++ b/dotcom-rendering/src/components/MediaMeta.test.tsx
@@ -12,9 +12,9 @@ describe(`MediaText`, () => {
 			`9:59:59`,
 			`1:00:01`,
 		];
-		secss.forEach((secs, i) => {
+		for (const [i, secs] of secss.entries()) {
 			const result = secondsToDuration(secs);
 			expect(result).toBe(expected[i]);
-		});
+		}
 	});
 });

--- a/dotcom-rendering/src/components/RecipeMultiplier.importable.tsx
+++ b/dotcom-rendering/src/components/RecipeMultiplier.importable.tsx
@@ -177,8 +177,8 @@ export const RecipeMultiplier = () => {
 
 						if (isConstant(groups?.unit)) continue;
 
-						Object.entries(groups ?? {})
-							.map(([key, value]) => {
+						const attributes = Object.entries(groups ?? {}).map(
+							([key, value]) => {
 								const [numerator, denominator] = value
 									.split('/')
 									.map(parseFloat);
@@ -197,13 +197,12 @@ export const RecipeMultiplier = () => {
 									key,
 									fractions.get(value)?.toString() ?? value,
 								] as const;
-							})
-							.forEach(([key, value]) => {
-								recipeElement.setAttribute(
-									`data-${key}`,
-									value,
-								);
-							});
+							},
+						);
+
+						for (const [key, value] of attributes) {
+							recipeElement.setAttribute(`data-${key}`, value);
+						}
 
 						node.parentNode?.insertBefore(recipeElement, node);
 

--- a/dotcom-rendering/src/components/RecipeMultiplier.importable.tsx
+++ b/dotcom-rendering/src/components/RecipeMultiplier.importable.tsx
@@ -228,24 +228,24 @@ export const RecipeMultiplier = () => {
 	}, [servings]);
 
 	useEffect(() => {
-		document
-			.querySelectorAll<HTMLElement>('gu-recipe')
-			.forEach((element) => {
-				const { value, separator, unit } = element.dataset;
+		for (const element of document.querySelectorAll<HTMLElement>(
+			'gu-recipe',
+		)) {
+			const { value, separator, unit } = element.dataset;
 
-				if (isUndefined(value) || isUndefined(separator)) return;
+			if (isUndefined(value) || isUndefined(separator)) continue;
 
-				if (isUndefined(unit)) return;
+			if (isUndefined(unit)) continue;
 
-				element.innerText = transform({
-					value: value
-						.split('-')
-						.map(parseFloat)
-						.map((v) => v * multiplier),
-					separator,
-					unit,
-				});
+			element.innerText = transform({
+				value: value
+					.split('-')
+					.map(parseFloat)
+					.map((v) => v * multiplier),
+				separator,
+				unit,
 			});
+		}
 	}, [multiplier]);
 
 	const handleChange: ChangeEventHandler<HTMLInputElement> = ({

--- a/dotcom-rendering/src/components/SecureSignupIframe.importable.tsx
+++ b/dotcom-rendering/src/components/SecureSignupIframe.importable.tsx
@@ -94,13 +94,13 @@ const postFormData = async (
 ): Promise<Response> => {
 	const requestBodyStrings: string[] = [];
 
-	formData.forEach((value, key) => {
+	for (const [key, value] of formData.entries()) {
 		requestBodyStrings.push(
 			`${encodeURIComponent(key)}=${encodeURIComponent(
 				value.toString(),
 			)}`,
 		);
-	});
+	}
 
 	return fetch(endpoint, {
 		method: 'POST',
@@ -323,21 +323,21 @@ export const SecureSignupIframe = ({
 
 		// get all the fontFaces on the parent matching the list of font names
 		const requiredFonts: FontFace[] = [];
-		document.fonts.forEach((fontFace) => {
+		for (const fontFace of document.fonts) {
 			if (requiredFontNames.includes(fontFace.family)) {
 				requiredFonts.push(fontFace);
 			}
-		});
+		}
 
 		// add the fonts to the iframe
-		requiredFonts.forEach((font) => {
+		for (const font of requiredFonts) {
 			try {
 				iframeFontFaceSet.add(font);
 			} catch (error) {
 				// Safari throws an InvalidModificationError
 				// https://developer.mozilla.org/en-US/docs/Web/API/FontFaceSet/add#exceptions
 			}
-		});
+		}
 	};
 
 	const onIFrameLoad = (): void => {

--- a/dotcom-rendering/src/components/SendAMessage.importable.tsx
+++ b/dotcom-rendering/src/components/SendAMessage.importable.tsx
@@ -167,17 +167,14 @@ const Form = ({
 
 	const validateForm = (): boolean => {
 		const errors: { [key in string]: string } = {};
-		let isValid = true;
-		formFields.forEach((field: MessageUsFieldType) => {
+		for (const field of formFields) {
 			if (field.required && !formData[field.id]) {
 				errors[field.id] = 'This field is required';
-				isValid = false;
 			}
 			if (field.type === 'email' && formData[field.id]) {
 				const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 				if (!emailRegex.test(formData[field.id] as string)) {
 					errors[field.id] = 'Please enter a valid email address';
-					isValid = false;
 				}
 			}
 			if (
@@ -187,17 +184,14 @@ const Form = ({
 				const numberRegex = /^[\d ()+-]+$/;
 				if (!numberRegex.test(formData[field.id] as string)) {
 					errors[field.id] = 'Please enter a valid number';
-					isValid = false;
 				}
 				const noWhiteSpace = formData[field.id] as string;
 				if (noWhiteSpace.length < 10) {
 					errors[field.id] = 'Please include your dialling/area code';
-					isValid = false;
 				}
 				// We should have checks here for min length and max length - this work is ticketed here https://trello.com/c/7sYM6Zzd/822-add-validation-for-max-min-length-on-the-message-us-work
 			}
-			return isValid;
-		});
+		}
 		setValidationErrors(errors);
 		return Object.keys(errors).length === 0;
 	};

--- a/dotcom-rendering/src/components/ShowHideContainers.importable.tsx
+++ b/dotcom-rendering/src/components/ShowHideContainers.importable.tsx
@@ -45,18 +45,18 @@ export const ShowHideContainers = () => {
 			storage.local.set(`gu.prefs.container-states`, containerStates);
 		};
 
-		window.document
-			.querySelectorAll<HTMLElement>('[data-show-hide-button]')
-			.forEach((e) => {
-				const sectionId = e.getAttribute('data-show-hide-button');
-				if (!sectionId) return;
+		for (const e of window.document.querySelectorAll<HTMLElement>(
+			'[data-show-hide-button]',
+		)) {
+			const sectionId = e.getAttribute('data-show-hide-button');
+			if (!sectionId) continue;
 
-				e.onclick = () => toggleContainer(sectionId, e);
+			e.onclick = () => toggleContainer(sectionId, e);
 
-				if (containerStates[sectionId] === 'closed') {
-					toggleContainer(sectionId, e);
-				}
-			});
+			if (containerStates[sectionId] === 'closed') {
+				toggleContainer(sectionId, e);
+			}
+		}
 	}, []);
 
 	return <></>;

--- a/dotcom-rendering/src/components/Snow.importable.tsx
+++ b/dotcom-rendering/src/components/Snow.importable.tsx
@@ -123,16 +123,16 @@ export const Snow = () => {
 					previousFlakes[flakeName] = updatedFlake;
 				}
 
-				document
-					.querySelectorAll<HTMLElement>('.snowflake')
-					.forEach((flake) => {
-						const previousFlake = flake.dataset.name
-							? previousFlakes[flake.dataset.name]
-							: undefined;
-						if (previousFlake !== undefined) {
-							flake.style.transform = `translate3d(${previousFlake.x}vw, ${previousFlake.y}px, 0.0)`;
-						}
-					});
+				for (const flake of document.querySelectorAll<HTMLElement>(
+					'.snowflake',
+				)) {
+					const previousFlake = flake.dataset.name
+						? previousFlakes[flake.dataset.name]
+						: undefined;
+					if (previousFlake !== undefined) {
+						flake.style.transform = `translate3d(${previousFlake.x}vw, ${previousFlake.y}px, 0.0)`;
+					}
+				}
 
 				return previousFlakes;
 			});

--- a/dotcom-rendering/src/lib/get-video-id.amp.test.ts
+++ b/dotcom-rendering/src/lib/get-video-id.amp.test.ts
@@ -31,10 +31,10 @@ describe('getIdFromUrl', () => {
 			},
 		];
 
-		formats.forEach((_) => {
+		for (const _ of formats) {
 			// Search for both in path & query param
 			expect(getIdFromUrl(_.url, youtubeRegEx, true, 'v')).toBe(_.id);
-		});
+		}
 	});
 
 	it('Returns matching ID for Vimeo formats', () => {
@@ -55,9 +55,9 @@ describe('getIdFromUrl', () => {
 			},
 		];
 
-		formats.forEach((_) => {
+		for (const _ of formats) {
 			expect(getIdFromUrl(_.url, vimeoRegEx, true)).toBe(_.id);
-		});
+		}
 	});
 
 	it('Finds ID if both options are allowed', () => {
@@ -67,9 +67,9 @@ describe('getIdFromUrl', () => {
 			'https://theguardian.com/test?a=test',
 		];
 
-		formats.forEach((_) => {
+		for (const _ of formats) {
 			expect(getIdFromUrl(_, 'test', true, 'a')).toBe('test');
-		});
+		}
 	});
 
 	it('Throws an error if it cannot find an ID', () => {

--- a/dotcom-rendering/src/lib/newsletter-sign-up-requests.ts
+++ b/dotcom-rendering/src/lib/newsletter-sign-up-requests.ts
@@ -22,9 +22,9 @@ const buildNewsletterSignUpFormData = (
 	formData.append('csrfToken', ''); // TO DO - PR on form handlers in frontend/identity to see how/if this is needed
 
 	if (Array.isArray(newsletterIdOrList)) {
-		newsletterIdOrList.forEach((newsletterId, index) => {
+		for (const [index, newsletterId] of newsletterIdOrList.entries()) {
 			formData.append(`listNames[${index}]`, newsletterId);
-		});
+		}
 	} else {
 		formData.append('listName', newsletterIdOrList);
 	}
@@ -45,13 +45,13 @@ const postFormData = async (
 ): Promise<Response> => {
 	const requestBodyStrings: string[] = [];
 
-	formData.forEach((value, key) => {
+	for (const [key, value] of formData.entries()) {
 		requestBodyStrings.push(
 			`${encodeURIComponent(key)}=${encodeURIComponent(
 				value.toString(),
 			)}`,
 		);
-	});
+	}
 
 	return fetch(endpoint, {
 		method: 'POST',

--- a/dotcom-rendering/src/lib/readerRevenueDevUtils.ts
+++ b/dotcom-rendering/src/lib/readerRevenueDevUtils.ts
@@ -77,7 +77,7 @@ const clearCommonReaderRevenueStateAndReload = (
 		return;
 	}
 
-	readerRevenueCookies.forEach((cookie) => removeCookie({ name: cookie }));
+	for (const cookie of readerRevenueCookies) removeCookie({ name: cookie });
 	clearEpicViewLog();
 
 	if (asExistingSupporter) {

--- a/dotcom-rendering/src/lib/thrift/nativeConnection.ts
+++ b/dotcom-rendering/src/lib/thrift/nativeConnection.ts
@@ -81,14 +81,14 @@ export class NativeConnection<Context = void> extends ThriftConnection {
 		if (oldConnectionId === this.connectionId && window.nativeConnections) {
 			console.warn('Reseting connection ' + oldConnectionId);
 			delete window.nativeConnections[this.connectionId];
-			this.promises.forEach((promise) => {
+			for (const promise of this.promises) {
 				promise.reject(
 					new TApplicationException(
 						TApplicationExceptionType.UNKNOWN,
 						'Timeout error',
 					),
 				);
-			});
+			}
 			this.promises = [];
 			this.connectionId = uuid.v4();
 			window.nativeConnections[this.connectionId] = this;

--- a/dotcom-rendering/src/model/addImageIDs.ts
+++ b/dotcom-rendering/src/model/addImageIDs.ts
@@ -17,25 +17,22 @@ export const addImageIDs = (
 ): { mainMediaElements: FEElement[]; blocks: Block[] } => {
 	// position needs to be defined outside the addPosition function otherwise
 	// it will get reset to 1 each time
-	let position = 1;
-	const addPosition = (elements: FEElement[]): FEElement[] => {
-		const withPosition: FEElement[] = [];
-		elements.forEach((thisElement) => {
+	let position = 0;
+	const addPosition = (elements: FEElement[]): FEElement[] =>
+		elements.map<FEElement>((thisElement) => {
 			if (
 				thisElement._type ===
 				'model.dotcomrendering.pageElements.ImageBlockElement'
 			) {
-				withPosition.push({
+				position += 1;
+				return {
 					...thisElement,
 					position,
-				});
-				position += 1;
+				};
 			} else {
-				withPosition.push(thisElement);
+				return thisElement;
 			}
 		});
-		return withPosition;
-	};
 
 	return {
 		mainMediaElements: addPosition(data.mainMediaElements),

--- a/dotcom-rendering/src/model/article-sections.test.ts
+++ b/dotcom-rendering/src/model/article-sections.test.ts
@@ -90,10 +90,10 @@ describe('returns section for each subsection', () => {
 	] as const;
 
 	it('returns correct Section for each test case', () => {
-		testCases.forEach(([subsections, section]) => {
+		for (const [subsections, section] of testCases) {
 			for (const subsection of subsections) {
 				expect(findBySubsection(subsection).name).toEqual(section);
 			}
-		});
+		}
 	});
 });

--- a/dotcom-rendering/src/model/enhance-images.ts
+++ b/dotcom-rendering/src/model/enhance-images.ts
@@ -136,7 +136,7 @@ export const addLightboxData = (elements: FEElement[]): FEElement[] =>
 
 const addMultiImageElements = (elements: FEElement[]): FEElement[] => {
 	const withMultiImageElements: FEElement[] = [];
-	elements.forEach((thisElement, i) => {
+	for (const [i, thisElement] of elements.entries()) {
 		const nextElement = elements[i + 1];
 		if (isHalfWidthImage(thisElement) && isHalfWidthImage(nextElement)) {
 			// Pair found. Add a multi element and remove the next entry
@@ -149,13 +149,13 @@ const addMultiImageElements = (elements: FEElement[]): FEElement[] => {
 			// Pass through
 			withMultiImageElements.push(thisElement);
 		}
-	});
+	}
 	return withMultiImageElements;
 };
 
 const addTitles = (elements: FEElement[]): FEElement[] => {
 	const withTitles: FEElement[] = [];
-	elements.forEach((thisElement, i) => {
+	for (const [i, thisElement] of elements.entries()) {
 		const nextElement = elements[i + 1];
 		const subsequentElement = elements[i + 2];
 		if (isImage(thisElement) && isTitle(nextElement)) {
@@ -182,13 +182,13 @@ const addTitles = (elements: FEElement[]): FEElement[] => {
 			// Pass through
 			withTitles.push(thisElement);
 		}
-	});
+	}
 	return withTitles;
 };
 
 const addCaptionsToImages = (elements: FEElement[]): FEElement[] => {
 	const withSpecialCaptions: FEElement[] = [];
-	elements.forEach((thisElement, i) => {
+	for (const [i, thisElement] of elements.entries()) {
 		const nextElement = elements[i + 1];
 		const subsequentElement = elements[i + 2];
 		if (isImage(thisElement) && isCaption(nextElement)) {
@@ -221,13 +221,13 @@ const addCaptionsToImages = (elements: FEElement[]): FEElement[] => {
 			// Pass through
 			withSpecialCaptions.push(thisElement);
 		}
-	});
+	}
 	return withSpecialCaptions;
 };
 
 const addCaptionsToMultis = (elements: FEElement[]): FEElement[] => {
 	const withSpecialCaptions: FEElement[] = [];
-	elements.forEach((thisElement, i) => {
+	for (const [i, thisElement] of elements.entries()) {
 		const nextElement = elements[i + 1];
 		const subsequentElement = elements[i + 2];
 		if (isMultiImage(thisElement) && isCaption(nextElement)) {
@@ -252,7 +252,7 @@ const addCaptionsToMultis = (elements: FEElement[]): FEElement[] => {
 			// Pass through
 			withSpecialCaptions.push(thisElement);
 		}
-	});
+	}
 	return withSpecialCaptions;
 };
 

--- a/dotcom-rendering/src/model/enhance-interactive-contents-elements.ts
+++ b/dotcom-rendering/src/model/enhance-interactive-contents-elements.ts
@@ -27,7 +27,7 @@ const enhance = (elements: FEElement[]): FEElement[] => {
 			.find((element) => 'elementId' in element);
 
 		// replace interactive content block
-		elements.forEach((element) => {
+		for (const element of elements) {
 			if (isLegacyTableOfContents(element)) {
 				updatedElements.push({
 					_type: 'model.dotcomrendering.pageElements.DividerBlockElement',
@@ -52,7 +52,7 @@ const enhance = (elements: FEElement[]): FEElement[] => {
 			} else {
 				updatedElements.push(element);
 			}
-		});
+		}
 
 		return updatedElements;
 	}

--- a/dotcom-rendering/src/model/enhance-newsletters-page.ts
+++ b/dotcom-rendering/src/model/enhance-newsletters-page.ts
@@ -42,7 +42,7 @@ const reduceToDefaultGrouping = (
 		groups: [],
 	};
 
-	newsletters.forEach((newsletter) => {
+	for (const newsletter of newsletters) {
 		const { group: groupName } = newsletter;
 		const exstingGroup = grouping.groups.find(
 			(group) => group.title === groupName,
@@ -55,7 +55,7 @@ const reduceToDefaultGrouping = (
 				newsletters: [newsletter],
 			});
 		}
-	});
+	}
 
 	return grouping;
 };

--- a/dotcom-rendering/src/model/enhance-numbered-lists.ts
+++ b/dotcom-rendering/src/model/enhance-numbered-lists.ts
@@ -92,7 +92,7 @@ const isStarableImage = (element: FEElement | undefined): boolean => {
 const starifyImages = (elements: FEElement[]): FEElement[] => {
 	const starified: FEElement[] = [];
 	let previousRating: number | undefined;
-	elements.forEach((thisElement, index) => {
+	for (const [index, thisElement] of elements.entries()) {
 		switch (thisElement._type) {
 			case 'model.dotcomrendering.pageElements.TextBlockElement':
 				if (
@@ -126,7 +126,7 @@ const starifyImages = (elements: FEElement[]): FEElement[] => {
 				// Pass through
 				starified.push(thisElement);
 		}
-	});
+	}
 	return starified;
 };
 
@@ -229,7 +229,7 @@ const addH3s = (elements: FEElement[]): FEElement[] => {
 	 */
 	const withH3s: FEElement[] = [];
 	let previousItem: FEElement | undefined;
-	elements.forEach((thisElement) => {
+	for (const thisElement of elements) {
 		if (
 			thisElement._type ===
 				'model.dotcomrendering.pageElements.TextBlockElement' &&
@@ -260,13 +260,13 @@ const addH3s = (elements: FEElement[]): FEElement[] => {
 			withH3s.push(thisElement);
 		}
 		previousItem = thisElement;
-	});
+	}
 	return withH3s;
 };
 
 const addItemLinks = (elements: FEElement[]): FEElement[] => {
 	const withItemLink: FEElement[] = [];
-	elements.forEach((thisElement) => {
+	for (const thisElement of elements) {
 		if (
 			thisElement._type ===
 				'model.dotcomrendering.pageElements.TextBlockElement' &&
@@ -287,7 +287,7 @@ const addItemLinks = (elements: FEElement[]): FEElement[] => {
 			// Pass through
 			withItemLink.push(thisElement);
 		}
-	});
+	}
 	return withItemLink;
 };
 
@@ -304,7 +304,7 @@ const addTitles = (elements: FEElement[], format: FEFormat): FEElement[] => {
 	 */
 	const withTitles: FEElement[] = [];
 	let position = 1;
-	elements.forEach((thisElement) => {
+	for (const thisElement of elements) {
 		if (
 			thisElement._type ===
 			'model.dotcomrendering.pageElements.SubheadingBlockElement'
@@ -329,7 +329,7 @@ const addTitles = (elements: FEElement[], format: FEFormat): FEElement[] => {
 			// Pass through
 			withTitles.push(thisElement);
 		}
-	});
+	}
 	return withTitles;
 };
 

--- a/dotcom-rendering/src/model/enhanceBlocks.ts
+++ b/dotcom-rendering/src/model/enhanceBlocks.ts
@@ -101,7 +101,7 @@ export const enhanceBlocks = (
 ): Block[] => {
 	const { promotedNewsletter } = options ?? {};
 
-	blocks.forEach((block) => validateAsBlock(block));
+	for (const block of blocks) validateAsBlock(block);
 	return new BlockEnhancer(blocks, format, { promotedNewsletter })
 		.enhanceDividers()
 		.enhanceH3s()

--- a/dotcom-rendering/src/model/enhanceTableOfContents.ts
+++ b/dotcom-rendering/src/model/enhanceTableOfContents.ts
@@ -43,16 +43,16 @@ export const enhanceTableOfContents = (
 
 	const tocItems: TableOfContentsItem[] = [];
 
-	blocks.forEach((block) => {
-		block.elements.forEach((element) => {
+	for (const block of blocks) {
+		for (const element of block.elements) {
 			if (isH2(element)) {
 				tocItems.push({
 					id: extractID(element),
 					title: extractText(element),
 				});
 			}
-		});
-	});
+		}
+	}
 
 	return tocItems.length >= 3 ? tocItems : undefined;
 };

--- a/dotcom-rendering/src/model/extractTrendingTopics.ts
+++ b/dotcom-rendering/src/model/extractTrendingTopics.ts
@@ -96,14 +96,11 @@ export const extractTrendingTopicsFomFront = (
 ): FETagType[] => {
 	// Get a single array of all trails in the collections
 	const trails = new Map<string, NarrowedFEFrontCard>();
-	collections
-		.flatMap((collection) => [
-			...collection.curated,
-			...collection.backfill,
-		])
-		.forEach((card) =>
-			trails.set(card.properties.maybeContentId ?? card.card.id, card),
-		);
+	for (const card of collections.flatMap((collection) => [
+		...collection.curated,
+		...collection.backfill,
+	]))
+		trails.set(card.properties.maybeContentId ?? card.card.id, card);
 
 	return extractTrendingTopics([...trails.values()], pageId);
 };

--- a/dotcom-rendering/src/model/groupTrailsByDates.ts
+++ b/dotcom-rendering/src/model/groupTrailsByDates.ts
@@ -34,7 +34,7 @@ const getMeanDayFrequency = (
 const groupByYear = (trails: TrailAndDate[]) => {
 	const trailsByYear: Array<{ year: number; trails: TrailAndDate[] }> = [];
 
-	trails.forEach(({ trail, date }) => {
+	for (const { trail, date } of trails) {
 		const existingYear = trailsByYear.find(
 			({ year }) => year === date.getUTCFullYear(),
 		);
@@ -46,7 +46,7 @@ const groupByYear = (trails: TrailAndDate[]) => {
 				trails: [{ trail, date }],
 			});
 		}
-	});
+	}
 
 	return trailsByYear;
 };
@@ -61,7 +61,7 @@ const groupTrailsByMonth = (trails: TrailAndDate[], year: number) => {
 		trails: TrailAndDate[];
 	}> = [];
 
-	trails.forEach(({ trail, date }) => {
+	for (const { trail, date } of trails) {
 		const existingMonth = trailsByMonth.find(
 			({ month }) => month === date.getUTCMonth(),
 		);
@@ -74,7 +74,7 @@ const groupTrailsByMonth = (trails: TrailAndDate[], year: number) => {
 				trails: [{ trail, date }],
 			});
 		}
-	});
+	}
 
 	return trailsByMonth;
 };
@@ -94,7 +94,7 @@ const groupTrailsByDay = (
 		trails: TrailAndDate[];
 	}> = [];
 
-	trails.forEach(({ trail, date }) => {
+	for (const { trail, date } of trails) {
 		const existingMonth = trailsByDay.find(
 			({ day }) => day === date.getUTCDate(),
 		);
@@ -108,7 +108,7 @@ const groupTrailsByDay = (
 				trails: [{ trail, date }],
 			});
 		}
-	});
+	}
 
 	return trailsByDay;
 };
@@ -148,10 +148,10 @@ export const groupTrailsByDates = (
 	// year, month & potentially day.
 	const groupedTrails: GroupedTrails[] = [];
 
-	trailsByYear.forEach(({ year, trails: trailsForYear }) => {
+	for (const { year, trails: trailsForYear } of trailsByYear) {
 		const trailsByMonth = groupTrailsByMonth(trailsForYear, year);
 
-		trailsByMonth.forEach(({ month, trails: trailsForMonth }) => {
+		for (const { month, trails: trailsForMonth } of trailsByMonth) {
 			const trailsByDay = groupTrailsByDay(trailsForMonth, year, month);
 
 			// Once we have trails grouped by year, month & day, we calculate the day frequency
@@ -191,8 +191,8 @@ export const groupTrailsByDates = (
 					),
 				});
 			}
-		});
-	});
+		}
+	}
 
 	return groupedTrails;
 };

--- a/dotcom-rendering/src/model/injectMpuIntoGroupedTrails.ts
+++ b/dotcom-rendering/src/model/injectMpuIntoGroupedTrails.ts
@@ -21,10 +21,10 @@ export const injectMpuIntoGroupedTrails = (
 		GroupedTrails | GroupedTrailsFastMpu | GroupedTrailsSlowMpu
 	> = [];
 
-	groupedTrails.forEach((grouped) => {
+	for (const grouped of groupedTrails) {
 		if (injected) {
 			result.push(grouped);
-			return;
+			continue;
 		}
 
 		if (speed === 'fast') {
@@ -75,7 +75,7 @@ export const injectMpuIntoGroupedTrails = (
 					break;
 			}
 		}
-	});
+	}
 
 	return result;
 };

--- a/dotcom-rendering/src/model/slowOrFastByTrails.ts
+++ b/dotcom-rendering/src/model/slowOrFastByTrails.ts
@@ -31,15 +31,15 @@ export const getSpeedFromTrails = (trails: FEFrontCard[]): 'slow' | 'fast' => {
 	// <tag id, number of occurrences>
 	const tagMap = new Map<string, number>();
 
-	trails.forEach((trail) => {
+	for (const trail of trails) {
 		const tags = trail.properties.maybeContent?.tags.tags;
 		if (tags) {
-			tags.forEach((tag) => {
+			for (const tag of tags) {
 				const count = tagMap.get(tag.properties.id) ?? 0;
 				tagMap.set(tag.properties.id, count + 1);
-			});
+			}
 		}
-	});
+	}
 
 	const matchingSlowTag = slowTags.find(
 		(tagId) =>

--- a/dotcom-rendering/src/model/validate.test.ts
+++ b/dotcom-rendering/src/model/validate.test.ts
@@ -17,7 +17,7 @@ describe('validate', () => {
 		expect(() => validateAsArticleType(data)).toThrowError(TypeError);
 	});
 
-	urlsToTest.forEach((url) => {
+	for (const url of urlsToTest) {
 		it('confirm valid data', () => {
 			return fetch(`${url}&purge=${Date.now()}`)
 				.then((response) => response.json())
@@ -25,5 +25,5 @@ describe('validate', () => {
 					expect(validateAsArticleType(myJson)).toBe(myJson);
 				});
 		});
-	});
+	}
 });

--- a/dotcom-rendering/src/server/lib/aws/aws-metrics.ts
+++ b/dotcom-rendering/src/server/lib/aws/aws-metrics.ts
@@ -41,7 +41,7 @@ const sendMetric = (m: any[]) => {
 
 const collectAndSendAWSMetrics = (...metrics: Metric[]): void => {
 	setInterval(() => {
-		metrics.forEach((m) => m.send());
+		for (const m of metrics) m.send();
 	}, METRICS_TIME_RESOLUTION);
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3027,20 +3027,25 @@
   resolved "https://registry.yarnpkg.com/@eslint-community/regexpp/-/regexpp-4.5.1.tgz#cdd35dce4fa1a89a4fd42b1599eb35b3af408884"
   integrity sha512-Z5ba73P98O1KUYCCJTUeVpja9RcGoMdncZ6T49FCUl2lN38JtCJ+3WgIDBv0AuY4WChU5PmtJmOCTlN6FZTFKQ==
 
-"@eslint/eslintrc@^1.4.1":
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.4.1.tgz#af58772019a2d271b7e2d4c23ff4ddcba3ccfb3e"
-  integrity sha512-XXrH9Uarn0stsyldqDYq8r++mROmWRI1xKMXa640Bb//SY1+ECYX6VzT6Lcx5frD0V30XieqJ0oX9I2Xj5aoMA==
+"@eslint/eslintrc@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-2.1.0.tgz#82256f164cc9e0b59669efc19d57f8092706841d"
+  integrity sha512-Lj7DECXqIVCqnqjjHMPna4vn6GJcMgul/wuS0je9OZ9gsL0zzDpKPVtcG1HaDVc+9y+qgXneTeUMbCqXJNpH1A==
   dependencies:
     ajv "^6.12.4"
     debug "^4.3.2"
-    espree "^9.4.0"
+    espree "^9.6.0"
     globals "^13.19.0"
     ignore "^5.2.0"
     import-fresh "^3.2.1"
     js-yaml "^4.1.0"
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
+
+"@eslint/js@8.44.0":
+  version "8.44.0"
+  resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.44.0.tgz#961a5903c74139390478bdc808bcde3fc45ab7af"
+  integrity sha512-Ag+9YM4ocKQx9AarydN0KY2j0ErMHNIocPDrVo8zAE44xLTjEtz81OdR68/cydGtk6m6jDb5Za3r2useMzYmSw==
 
 "@fal-works/esbuild-plugin-global-externals@^2.1.2":
   version "2.1.2"
@@ -3259,7 +3264,7 @@
   dependencies:
     "@hapi/hoek" "^9.0.0"
 
-"@humanwhocodes/config-array@^0.11.8":
+"@humanwhocodes/config-array@^0.11.10":
   version "0.11.10"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.11.10.tgz#5a3ffe32cc9306365fb3fd572596cd602d5e12d2"
   integrity sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==
@@ -6776,7 +6781,7 @@ acorn@^7.4.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
 
-acorn@^8.0.4, acorn@^8.1.0, acorn@^8.4.1, acorn@^8.7.1, acorn@^8.8.0, acorn@^8.8.1, acorn@^8.8.2:
+acorn@^8.0.4, acorn@^8.1.0, acorn@^8.4.1, acorn@^8.7.1, acorn@^8.8.1, acorn@^8.8.2:
   version "8.9.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.9.0.tgz#78a16e3b2bcc198c10822786fa6679e245db5b59"
   integrity sha512-jaVNAFBHNLXspO543WnNNPZFRtavh3skAkITqD0/2aeMkKZTN+254PyhwxFYrk3vQ1xfY+2wbesJMs/JC8/PwQ==
@@ -9807,10 +9812,10 @@ eslint-scope@5.1.1, eslint-scope@^5.1.1:
     esrecurse "^4.3.0"
     estraverse "^4.1.1"
 
-eslint-scope@^7.1.1:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-7.1.1.tgz#fff34894c2f65e5226d3041ac480b4513a163642"
-  integrity sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==
+eslint-scope@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-7.2.0.tgz#f21ebdafda02352f103634b96dd47d9f81ca117b"
+  integrity sha512-DYj5deGlHBfMt15J7rdtyKNq/Nqlv5KfU4iodrQ019XESsRnwXH9KAE0y3cwtUHDo2ob7CypAnCqefh6vioWRw==
   dependencies:
     esrecurse "^4.3.0"
     estraverse "^5.2.0"
@@ -9840,13 +9845,21 @@ eslint-visitor-keys@^3.3.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz#f6480fa6b1f30efe2d1968aa8ac745b862469826"
   integrity sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==
 
-eslint@8.34.0:
-  version "8.34.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.34.0.tgz#fe0ab0ef478104c1f9ebc5537e303d25a8fb22d6"
-  integrity sha512-1Z8iFsucw+7kSqXNZVslXS8Ioa4u2KM7GPwuKtkTFAqZ/cHMcEaR+1+Br0wLlot49cNxIiZk5wp8EAbPcYZxTg==
+eslint-visitor-keys@^3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz#c22c48f48942d08ca824cc526211ae400478a994"
+  integrity sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==
+
+eslint@8.44.0:
+  version "8.44.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.44.0.tgz#51246e3889b259bbcd1d7d736a0c10add4f0e500"
+  integrity sha512-0wpHoUbDUHgNCyvFB5aXLiQVfK9B0at6gUvzy83k4kAsQ/u769TQDX6iKC+aO4upIHO9WSaA3QoXYQDHbNwf1A==
   dependencies:
-    "@eslint/eslintrc" "^1.4.1"
-    "@humanwhocodes/config-array" "^0.11.8"
+    "@eslint-community/eslint-utils" "^4.2.0"
+    "@eslint-community/regexpp" "^4.4.0"
+    "@eslint/eslintrc" "^2.1.0"
+    "@eslint/js" "8.44.0"
+    "@humanwhocodes/config-array" "^0.11.10"
     "@humanwhocodes/module-importer" "^1.0.1"
     "@nodelib/fs.walk" "^1.2.8"
     ajv "^6.10.0"
@@ -9855,51 +9868,48 @@ eslint@8.34.0:
     debug "^4.3.2"
     doctrine "^3.0.0"
     escape-string-regexp "^4.0.0"
-    eslint-scope "^7.1.1"
-    eslint-utils "^3.0.0"
-    eslint-visitor-keys "^3.3.0"
-    espree "^9.4.0"
-    esquery "^1.4.0"
+    eslint-scope "^7.2.0"
+    eslint-visitor-keys "^3.4.1"
+    espree "^9.6.0"
+    esquery "^1.4.2"
     esutils "^2.0.2"
     fast-deep-equal "^3.1.3"
     file-entry-cache "^6.0.1"
     find-up "^5.0.0"
     glob-parent "^6.0.2"
     globals "^13.19.0"
-    grapheme-splitter "^1.0.4"
+    graphemer "^1.4.0"
     ignore "^5.2.0"
     import-fresh "^3.0.0"
     imurmurhash "^0.1.4"
     is-glob "^4.0.0"
     is-path-inside "^3.0.3"
-    js-sdsl "^4.1.4"
     js-yaml "^4.1.0"
     json-stable-stringify-without-jsonify "^1.0.1"
     levn "^0.4.1"
     lodash.merge "^4.6.2"
     minimatch "^3.1.2"
     natural-compare "^1.4.0"
-    optionator "^0.9.1"
-    regexpp "^3.2.0"
+    optionator "^0.9.3"
     strip-ansi "^6.0.1"
     strip-json-comments "^3.1.0"
     text-table "^0.2.0"
 
-espree@^9.4.0:
-  version "9.4.1"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-9.4.1.tgz#51d6092615567a2c2cff7833445e37c28c0065bd"
-  integrity sha512-XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==
+espree@^9.6.0:
+  version "9.6.0"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-9.6.0.tgz#80869754b1c6560f32e3b6929194a3fe07c5b82f"
+  integrity sha512-1FH/IiruXZ84tpUlm0aCUEwMl2Ho5ilqVh0VvQXw+byAz/4SAciyHLlfmL5WYqsvD38oymdUwBss0LtK8m4s/A==
   dependencies:
-    acorn "^8.8.0"
+    acorn "^8.9.0"
     acorn-jsx "^5.3.2"
-    eslint-visitor-keys "^3.3.0"
+    eslint-visitor-keys "^3.4.1"
 
 esprima@^4.0.0, esprima@^4.0.1, esprima@~4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
 
-esquery@^1.4.0, esquery@^1.5.0:
+esquery@^1.4.2, esquery@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.5.0.tgz#6ce17738de8577694edd7361c57182ac8cb0db0b"
   integrity sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==
@@ -10961,6 +10971,11 @@ grapheme-splitter@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz#9cf3a665c6247479896834af35cf1dbb4400767e"
   integrity sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==
+
+graphemer@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/graphemer/-/graphemer-1.4.0.tgz#fb2f1d55e0e3a1849aeffc90c4fa0dd53a0e66c6"
+  integrity sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==
 
 gunzip-maybe@^1.4.2:
   version "1.4.2"
@@ -12587,11 +12602,6 @@ js-git@^0.7.8:
     culvert "^0.1.2"
     git-sha1 "^0.1.2"
     pako "^0.2.5"
-
-js-sdsl@^4.1.4:
-  version "4.4.1"
-  resolved "https://registry.yarnpkg.com/js-sdsl/-/js-sdsl-4.4.1.tgz#9e3c7b566d8d9a7e1fe8fc26d00b5ab0f8918ab3"
-  integrity sha512-6Gsx8R0RucyePbWqPssR8DyfuXmLBooYN5cZFZKjHGnQuaf7pEzhtpceagJxVu4LqhYY5EYA7nko3FmeHZ1KbA==
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
@@ -14373,7 +14383,7 @@ optionator@^0.8.1:
     type-check "~0.3.2"
     word-wrap "~1.2.3"
 
-optionator@^0.9.1:
+optionator@^0.9.3:
   version "0.9.3"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.9.3.tgz#007397d44ed1872fdc6ed31360190f81814e2c64"
   integrity sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Prevents usage of [`Array.prototype.forEach`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach) in our codebase.

Most of the implementations are automatically fixed, except for the first four commits  which are manual: [51d0321..599ebd05f](https://github.com/guardian/dotcom-rendering/compare/51d0321..599ebd05f)

## Why?

The imperative nature of the code is more readily apparent.

This should help make a decision on whether this rule should be in out `@guardian/eslint` config.