### PR TITLE
Picture quality is optional

### DIFF
--- a/dotcom-rendering/src/components/Picture.tsx
+++ b/dotcom-rendering/src/components/Picture.tsx
@@ -191,13 +191,7 @@ const generateImageURL = ({
 
 	const params = new URLSearchParams({
 		width: imageWidth.toString(),
-		// Why 45 and 85?
-		// This numbers have been picked in 2018 as the right
-		// balance between image fidelity and file size
-		// https://github.com/guardian/fastly-image-service/pull/35
-		...(resolution === 'high'
-			? { quality: '45', dpr: '2' }
-			: { quality: '85', dpr: '1' }),
+		dpr: String(resolution === 'high' ? 2 : 1),
 		s: 'none',
 	});
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Drops the quality parameters for images.

## Why?

This is now optional since https://github.com/guardian/fastly-image-service/pull/71, and removes a coupling between the VCL/edge logic and generating the DOM.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=620&quality=45&dpr=2&s=none
[after]: https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=620&dpr=2&s=none