### PR TITLE
Remove getProfile()

### DIFF
--- a/dotcom-rendering/src/discussion-rendering/lib/api.tsx
+++ b/dotcom-rendering/src/discussion-rendering/lib/api.tsx
@@ -130,20 +130,6 @@ export const preview = (body: string): Promise<string> => {
 	);
 };
 
-export const getProfile = (): Promise<UserProfile> => {
-	const url =
-		joinUrl(options.baseUrl, 'profile/me') + objAsParams(defaultParams);
-
-	return fetch(url, {
-		credentials: 'include',
-		headers: {
-			...options.headers,
-		},
-	})
-		.then((resp) => resp.json())
-		.catch((error) => console.error(`Error fetching ${url}`, error));
-};
-
 export const comment = (
 	shortUrl: string,
 	body: string,

--- a/dotcom-rendering/src/discussion-rendering/lib/api.tsx
+++ b/dotcom-rendering/src/discussion-rendering/lib/api.tsx
@@ -8,7 +8,6 @@ import type {
 	OrderByType,
 	ThreadsType,
 	UserNameResponse,
-	UserProfile,
 } from '../discussionTypes';
 
 const options = {


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

This isn't getting used anywhere in the codebase: 
![image](https://github.com/guardian/dotcom-rendering/assets/102960844/7755abb3-b088-4345-9132-31f7ab74bab8)