### PR TITLE
Header wait for isSignedIn

### DIFF
--- a/dotcom-rendering/src/components/ReaderRevenueLinks.importable.tsx
+++ b/dotcom-rendering/src/components/ReaderRevenueLinks.importable.tsx
@@ -233,7 +233,7 @@ const ReaderRevenueLinksRemote = ({
 					'rr-header-links',
 				);
 			});
-	}, [countryCode]);
+	}, [countryCode, isSignedIn]);
 
 	if (SupportHeader !== null && supportHeaderResponse) {
 		return (

--- a/dotcom-rendering/src/components/SupportTheG.importable.tsx
+++ b/dotcom-rendering/src/components/SupportTheG.importable.tsx
@@ -242,7 +242,7 @@ const ReaderRevenueLinksRemote = ({
 					'rr-header-links',
 				);
 			});
-	}, [countryCode]);
+	}, [countryCode, isSignedIn]);
 
 	if (SupportHeader !== null && supportHeaderResponse) {
 		return (


### PR DESCRIPTION
Closing as fixed in #8188. 
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

**Observed Bug:** on Article pages, after signing in, the sign in prompt header did not disappear. This was because the call to the support-dotcom-components was being sent before the sign in state had resolved. 

**Fix:** Ensure the `isSignedIn` variable is present in the `useOnce`  waitFor array. 

This bug arrose when fetching the sign in state was moved into a hook and so moved out of the useOnce function. 

I have made the change in both `ReaderRevenueLinks` and `SupportTheG` even though I belive only the latter is beign used in production. 


Checked in Code

- [x] Correct sign in prompt header is seen for non-signed in user (Correct signin state sent in targeting payload to SDC)
- [x] thank you header seen after sign in for a signed in user (Correct signin state sent in targeting payload to SDC)
## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
