### PR TITLE
refactor: put discussion stories into discussion sub folder on Storybook

### DIFF
--- a/dotcom-rendering/src/discussion-rendering/App.stories.tsx
+++ b/dotcom-rendering/src/discussion-rendering/App.stories.tsx
@@ -3,7 +3,7 @@ import { ArticlePillar } from '@guardian/libs';
 import { App } from './App';
 import type { UserProfile } from './discussionTypes';
 
-export default { component: App, title: 'App' };
+export default { component: App, title: 'Discussion/App' };
 
 const aUser: UserProfile = {
 	userId: 'abc123',

--- a/dotcom-rendering/src/discussion-rendering/components/AbuseReportForm/AbuseReportForm.stories.tsx
+++ b/dotcom-rendering/src/discussion-rendering/components/AbuseReportForm/AbuseReportForm.stories.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/react';
 import { ArticlePillar } from '@guardian/libs';
 import { AbuseReportForm } from './AbuseReportForm';
 
-export default { title: 'Abuse Report Form' };
+export default { title: 'Discussion/Abuse Report Form' };
 
 const wrapperStyles = css`
 	padding: 20px;

--- a/dotcom-rendering/src/discussion-rendering/components/Avatar/Avatar.stories.tsx
+++ b/dotcom-rendering/src/discussion-rendering/components/Avatar/Avatar.stories.tsx
@@ -1,6 +1,6 @@
 import { Avatar } from './Avatar';
 
-export default { component: Avatar, title: 'Avatar' };
+export default { component: Avatar, title: 'Discussion/Avatar' };
 
 export const Sizes = () => {
 	return (

--- a/dotcom-rendering/src/discussion-rendering/components/Comment/Comment.stories.tsx
+++ b/dotcom-rendering/src/discussion-rendering/components/Comment/Comment.stories.tsx
@@ -1,8 +1,8 @@
 import { ArticlePillar } from '@guardian/libs';
-import { CommentType, UserProfile } from '../../discussionTypes';
+import type { CommentType, UserProfile } from '../../discussionTypes';
 import { Comment } from './Comment';
 
-export default { title: 'Comment' };
+export default { title: 'Discussion/Comment' };
 
 const commentData: CommentType = {
 	id: 25487686,

--- a/dotcom-rendering/src/discussion-rendering/components/CommentContainer/CommentContainer.stories.tsx
+++ b/dotcom-rendering/src/discussion-rendering/components/CommentContainer/CommentContainer.stories.tsx
@@ -1,8 +1,8 @@
 import { ArticlePillar } from '@guardian/libs';
-import { CommentType } from '../../discussionTypes';
+import type { CommentType } from '../../discussionTypes';
 import { CommentContainer } from './CommentContainer';
 
-export default { title: 'CommentContainer' };
+export default { title: 'Discussion/CommentContainer' };
 
 const commentData: CommentType = {
 	id: 25487686,

--- a/dotcom-rendering/src/discussion-rendering/components/CommentForm/CommentForm.stories.tsx
+++ b/dotcom-rendering/src/discussion-rendering/components/CommentForm/CommentForm.stories.tsx
@@ -1,8 +1,8 @@
 import { ArticlePillar } from '@guardian/libs';
-import { CommentType } from '../../discussionTypes';
+import type { CommentType } from '../../discussionTypes';
 import { CommentForm } from './CommentForm';
 
-export default { component: CommentForm, title: 'CommentForm' };
+export default { component: CommentForm, title: 'Discussion/CommentForm' };
 
 const shortUrl = '/p/39f5z';
 

--- a/dotcom-rendering/src/discussion-rendering/components/CommentReplyPreview/CommentReplyPreview.stories.tsx
+++ b/dotcom-rendering/src/discussion-rendering/components/CommentReplyPreview/CommentReplyPreview.stories.tsx
@@ -1,9 +1,9 @@
 import { css } from '@emotion/react';
 import { ArticlePillar } from '@guardian/libs';
-import { CommentType } from '../../discussionTypes';
+import type { CommentType } from '../../discussionTypes';
 import { CommentReplyPreview, Preview } from './CommentReplyPreview';
 
-export default { title: 'CommentReplyPreview' };
+export default { title: 'Discussion/CommentReplyPreview' };
 
 const singleLineParagraph =
 	'<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>';

--- a/dotcom-rendering/src/discussion-rendering/components/Dropdown/Dropdown.stories.tsx
+++ b/dotcom-rendering/src/discussion-rendering/components/Dropdown/Dropdown.stories.tsx
@@ -79,7 +79,7 @@ const optionsWithNoneActive = [
 /* tslint:disable */
 export default {
 	component: Dropdown,
-	title: 'Dropdown',
+	title: 'Discussion/Dropdown',
 };
 /* tslint:enable */
 

--- a/dotcom-rendering/src/discussion-rendering/components/Filters/Filters.stories.tsx
+++ b/dotcom-rendering/src/discussion-rendering/components/Filters/Filters.stories.tsx
@@ -1,9 +1,9 @@
 import { ArticlePillar } from '@guardian/libs';
 import { useState } from 'react';
-import { FilterOptions } from '../../discussionTypes';
+import type { FilterOptions } from '../../discussionTypes';
 import { Filters } from './Filters';
 
-export default { title: 'Filters' };
+export default { title: 'Discussion/Filters' };
 
 export const Default = () => {
 	const [filters, setFilters] = useState<FilterOptions>({

--- a/dotcom-rendering/src/discussion-rendering/components/FirstCommentWelcome/FirstCommentWelcome.stories.tsx
+++ b/dotcom-rendering/src/discussion-rendering/components/FirstCommentWelcome/FirstCommentWelcome.stories.tsx
@@ -1,7 +1,7 @@
 import { ArticlePillar } from '@guardian/libs';
 import { FirstCommentWelcome } from './FirstCommentWelcome';
 
-export default { title: 'FirstCommentWelcome' };
+export default { title: 'Discussion/FirstCommentWelcome' };
 
 export const defaultStory = () => (
 	<FirstCommentWelcome

--- a/dotcom-rendering/src/discussion-rendering/components/LoadingComments/LoadingComments.stories.tsx
+++ b/dotcom-rendering/src/discussion-rendering/components/LoadingComments/LoadingComments.stories.tsx
@@ -1,6 +1,9 @@
 import { LoadingComments } from './LoadingComments';
 
-export default { component: LoadingComments, title: 'LoadingComments' };
+export default {
+	component: LoadingComments,
+	title: 'Discussion/LoadingComments',
+};
 
 export const Default = () => <LoadingComments />;
 Default.storyName = 'default';

--- a/dotcom-rendering/src/discussion-rendering/components/LoadingPicks/LoadingPicks.stories.tsx
+++ b/dotcom-rendering/src/discussion-rendering/components/LoadingPicks/LoadingPicks.stories.tsx
@@ -1,6 +1,6 @@
 import { LoadingPicks } from './LoadingPicks';
 
-export default { component: LoadingPicks, title: 'LoadingPicks' };
+export default { component: LoadingPicks, title: 'Discussion/LoadingPicks' };
 
 export const Default = () => <LoadingPicks />;
 Default.storyName = 'default';

--- a/dotcom-rendering/src/discussion-rendering/components/Pagination/Pagination.stories.tsx
+++ b/dotcom-rendering/src/discussion-rendering/components/Pagination/Pagination.stories.tsx
@@ -1,8 +1,8 @@
 import { useState } from 'react';
-import { FilterOptions } from '../../discussionTypes';
+import type { FilterOptions } from '../../discussionTypes';
 import { Pagination } from './Pagination';
 
-export default { component: Pagination, title: 'Pagination' };
+export default { component: Pagination, title: 'Discussion/Pagination' };
 
 const DEFAULT_FILTERS: FilterOptions = {
 	orderBy: 'newest',

--- a/dotcom-rendering/src/discussion-rendering/components/PillarButton/PillarButton.stories.tsx
+++ b/dotcom-rendering/src/discussion-rendering/components/PillarButton/PillarButton.stories.tsx
@@ -13,7 +13,7 @@ const Space = ({ amount }: { amount: 1 | 2 | 3 | 4 | 5 | 6 | 9 | 12 | 24 }) => (
 	/>
 );
 
-export default { component: PillarButton, title: 'PillarButton' };
+export default { component: PillarButton, title: 'Discussion/PillarButton' };
 
 export const EachPillar = () => (
 	<Row>

--- a/dotcom-rendering/src/discussion-rendering/components/Preview/Preview.stories.tsx
+++ b/dotcom-rendering/src/discussion-rendering/components/Preview/Preview.stories.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import { Preview } from './Preview';
 
-export default { component: Preview, title: 'Preview' };
+export default { component: Preview, title: 'Discussion/Preview' };
 
 export const PreviewStory = () => (
 	<div

--- a/dotcom-rendering/src/discussion-rendering/components/RecommendationCount/RecommendationCount.stories.tsx
+++ b/dotcom-rendering/src/discussion-rendering/components/RecommendationCount/RecommendationCount.stories.tsx
@@ -1,6 +1,6 @@
 import { RecommendationCount } from './RecommendationCount';
 
-export default { title: 'RecommendationCount' };
+export default { title: 'Discussion/RecommendationCount' };
 
 export const NeverRecomended = () => (
 	<RecommendationCount

--- a/dotcom-rendering/src/discussion-rendering/components/Timestamp/Timestamp.stories.tsx
+++ b/dotcom-rendering/src/discussion-rendering/components/Timestamp/Timestamp.stories.tsx
@@ -1,6 +1,6 @@
 import { Timestamp } from './Timestamp';
 
-export default { component: Timestamp, title: 'Timestamp' };
+export default { component: Timestamp, title: 'Discussion/Timestamp' };
 
 // Date is mocked to "Fri March 27 2020 12:00:00 GMT+0000 (Greenwich Mean Time)" in config
 

--- a/dotcom-rendering/src/discussion-rendering/components/TopPick/TopPick.stories.tsx
+++ b/dotcom-rendering/src/discussion-rendering/components/TopPick/TopPick.stories.tsx
@@ -1,9 +1,9 @@
 import { css } from '@emotion/react';
 import { ArticlePillar } from '@guardian/libs';
-import { CommentType } from '../../discussionTypes';
+import type { CommentType } from '../../discussionTypes';
 import { TopPick } from './TopPick';
 
-export default { component: TopPick, title: 'TopPick' };
+export default { component: TopPick, title: 'Discussion/TopPick' };
 
 const comment: CommentType = {
 	id: 25488498,

--- a/dotcom-rendering/src/discussion-rendering/components/TopPicks/TopPicks.stories.tsx
+++ b/dotcom-rendering/src/discussion-rendering/components/TopPicks/TopPicks.stories.tsx
@@ -1,8 +1,8 @@
 import { ArticlePillar } from '@guardian/libs';
-import { CommentType } from '../../discussionTypes';
+import type { CommentType } from '../../discussionTypes';
 import { TopPicks } from './TopPicks';
 
-export default { component: TopPicks, title: 'TopPicks' };
+export default { component: TopPicks, title: 'Discussion/TopPicks' };
 
 const comment: CommentType = {
 	id: 25488498,


### PR DESCRIPTION
## What does this change?

Renames stories to set all discussion stories to be within `Discussion` folder on Storybook/Chromatic

_n.b. my prettier has autofixed a couple of things too_

## Why?

Easier to see which stories relate to which platform and there was no visible indication on Storybook for which were part of DCR and which are purely related to discussion rendering.

I know we are merging the two codebases so it might be more sensible to put this within "Components/Discussion", but this feels like an easy way to identify components before any further work is done on the discussion rendering project in general. Let me know if there's a more sensible way!

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/43961396/0307ae89-00a1-4bab-8d90-319e93148eef
[after]: https://github.com/guardian/dotcom-rendering/assets/43961396/178e3756-614d-41c8-b466-377f84eb923d

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
