### PR TITLE
Don't show the weather widget when there's a page skin

### DIFF
--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -114,6 +114,7 @@ export const decideAdSlot = (
 const decideLeftContent = (
 	front: DCRFrontType,
 	collection: DCRCollectionType,
+	hasPageSkin: boolean,
 ) => {
 	// show CPScott?
 	if (
@@ -130,7 +131,8 @@ const decideLeftContent = (
 			front.config.pageId,
 		) &&
 		// based on https://github.com/guardian/frontend/blob/473aafd168fec7f2a578a52c8e84982e3ec10fea/common/app/views/support/GetClasses.scala#L107
-		collection.displayName.toLowerCase() === 'headlines'
+		collection.displayName.toLowerCase() === 'headlines' &&
+		!hasPageSkin
 	) {
 		return (
 			<Island clientOnly={true} deferUntil={'idle'}>
@@ -571,6 +573,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 								leftContent={decideLeftContent(
 									front,
 									collection,
+									hasPageSkin,
 								)}
 								badge={collection.badge}
 								sectionId={ophanName}


### PR DESCRIPTION
## What does this change?

Don't show the weather widget when there's a page skin.

This is a temporary measure ™️ until we fix the layout for the weather widget when a page skin is active.

