### PR TITLE
Fix use of isSignedIn in header

### DIFF
--- a/dotcom-rendering/src/components/SupportTheG.importable.tsx
+++ b/dotcom-rendering/src/components/SupportTheG.importable.tsx
@@ -242,7 +242,7 @@ const ReaderRevenueLinksRemote = ({
 					'rr-header-links',
 				);
 			});
-	}, [countryCode]);
+	}, [countryCode, isSignedIn]);
 
 	if (SupportHeader !== null && supportHeaderResponse) {
 		return (


### PR DESCRIPTION
The type of `isSignedIn` is `boolean | undefined` - because the signed in status may not be available yet. We should not make a request to SDC until it is defined.
Currently, because we send `isSignedIn: isSignedIn === true`, it may send `false` immediately.

I've been unable to test this in CODE because the issue doesn't occur there!