### PR TITLE
Simplify extraction of images for Lightbox

### DIFF
--- a/dotcom-rendering/src/components/Picture.tsx
+++ b/dotcom-rendering/src/components/Picture.tsx
@@ -8,7 +8,7 @@ import type { RoleType } from '../types/content';
  * Working on this file? Checkout out 027-pictures.md & 029-signing-image-urls.md for background information & context
  **/
 
-type Orientation = 'portrait' | 'landscape';
+export type Orientation = 'portrait' | 'landscape';
 
 type Props = {
 	role: RoleType;

--- a/dotcom-rendering/src/model/buildLightboxImages.ts
+++ b/dotcom-rendering/src/model/buildLightboxImages.ts
@@ -1,13 +1,12 @@
 import { randomUUID } from 'node:crypto';
 import { getLargest, getMaster } from '../components/ImageComponent';
+import type { Orientation } from '../components/Picture';
 import type {
 	FEElement,
 	ImageBlockElement,
 	ImageForLightbox,
 } from '../types/content';
 import { isImage } from './enhance-images';
-
-type Orientation = 'horizontal' | 'portrait';
 
 /**
  * Only allow the lightbox to show images that have a source with a width greater
@@ -22,7 +21,7 @@ const isLightboxable = (
 	orientation: Orientation,
 ): boolean => {
 	switch (orientation) {
-		case 'horizontal':
+		case 'landscape':
 			// If any width is above 620 we allow this image in lightbox
 			return element.media.allImages.some(
 				(mediaImg) => parseInt(mediaImg.fields.width, 10) > 620,
@@ -75,7 +74,7 @@ const buildLightboxImage = (
 	const width = parseInt(masterImage.fields.width, 10);
 	const height = parseInt(masterImage.fields.height, 10);
 
-	const orientation = width >= height ? 'horizontal' : 'portrait';
+	const orientation = width >= height ? 'landscape' : 'portrait';
 	if (!isLightboxable(element, orientation)) return;
 
 	return {

--- a/dotcom-rendering/src/model/buildLightboxImages.ts
+++ b/dotcom-rendering/src/model/buildLightboxImages.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import { getLargest, getMaster } from '../components/ImageComponent';
 import type {
 	FEElement,
@@ -160,28 +161,12 @@ export const buildLightboxImages = (
 	});
 	// On gallery articles the main media is often repeated as an element in the article body so
 	// we deduplicate the array here
-	const alreadySeen: string[] = [];
-	let uniqueImages: ImageForLightbox[] = [];
-	lightboxImages.forEach((image) => {
-		const imageId = decideImageId(image);
-		if (!imageId) {
-			// It's unlikely that we would not have an imageId here but if we do we fail
-			// open, passing the image through
-			uniqueImages.push(image);
-			return;
-		}
-		if (alreadySeen.includes(imageId)) {
-			// Replace the element with the duplicated one. We do this because we want to favour
-			// the higher quality body images you get with galleries.
-			uniqueImages = uniqueImages.filter(
-				(thisImage) => decideImageId(thisImage) !== imageId,
-			);
-			uniqueImages.push(image);
-		} else {
-			// This image is not duplicated so we pass it through
-			uniqueImages.push(image);
-			alreadySeen.push(imageId);
-		}
-	});
-	return uniqueImages;
+	return [
+		...new Map(
+			lightboxImages.map<[string, ImageForLightbox]>((image) => [
+				decideImageId(image) ?? randomUUID(),
+				image,
+			]),
+		).values(),
+	];
 };

--- a/dotcom-rendering/src/model/enhance-images.ts
+++ b/dotcom-rendering/src/model/enhance-images.ts
@@ -120,25 +120,19 @@ const constructMultiImageElement = (
 	};
 };
 
-export const addLightboxData = (elements: FEElement[]): FEElement[] => {
-	const withLightboxData: FEElement[] = [];
-	elements.forEach((thisElement, i) => {
-		if (isImage(thisElement)) {
-			// Copy caption and credit
-			withLightboxData.push({
-				...thisElement,
-				lightbox: {
-					caption: thisElement.data.caption,
-					credit: thisElement.data.credit,
-				},
-			});
-		} else {
-			// Pass through
-			withLightboxData.push(thisElement);
-		}
-	});
-	return withLightboxData;
-};
+export const addLightboxData = (elements: FEElement[]): FEElement[] =>
+	elements.map<FEElement>((thisElement) =>
+		isImage(thisElement)
+			? {
+					...thisElement,
+					// Copy caption and credit
+					lightbox: {
+						caption: thisElement.data.caption,
+						credit: thisElement.data.credit,
+					},
+			  }
+			: thisElement,
+	);
 
 const addMultiImageElements = (elements: FEElement[]): FEElement[] => {
 	const withMultiImageElements: FEElement[] = [];

--- a/dotcom-rendering/src/model/enhance-images.ts
+++ b/dotcom-rendering/src/model/enhance-images.ts
@@ -32,7 +32,7 @@ const isMultiImage = (
 	);
 };
 
-const isImage = (element?: FEElement): element is ImageBlockElement => {
+export const isImage = (element?: FEElement): element is ImageBlockElement => {
 	if (!element) return false;
 	return (
 		element._type === 'model.dotcomrendering.pageElements.ImageBlockElement'


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Refactors lightbox images build methods:
- [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) have unique keys which makes them ideal for deduplicating values. Keys fall back to using `node:crypto` for UUIDv4
- Two near-identical code paths are unified by using `flatMap`s
- Reuse and unify `Orientation` types across the codebase

## Why?

Code reuse where applicable, consistency with our standards and usage of native Javascript features.

## Screenshots

N/A