### PR TITLE
Remove hiring message

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,3 @@
-## We're hiring!
-
-Ever thought about joining us?
-[https://workforus.theguardian.com/careers/product-engineering/](https://workforus.theguardian.com/careers/product-engineering/)
-
 # Dotcom/Apps Rendering
 
 This repository contains the rendering logic for articles on theguardian.com. It is a monorepo with 2 projects, `apps-rendering` and `dotcom-rendering`.

--- a/dotcom-rendering/src/server/htmlPageTemplate.ts
+++ b/dotcom-rendering/src/server/htmlPageTemplate.ts
@@ -28,6 +28,7 @@ type BaseProps = {
 	renderingTarget: RenderingTarget;
 	offerHttp3: boolean;
 	hasPageSkin?: boolean;
+	weAreHiring: boolean;
 };
 
 interface WebProps extends BaseProps {
@@ -75,6 +76,7 @@ export const htmlPageTemplate = (props: WebProps | AppProps): string => {
 		hasPageSkin = false,
 		borkFCP,
 		borkFID,
+		weAreHiring,
 	} = props;
 
 	const favicon =
@@ -191,7 +193,11 @@ https://workforus.theguardian.com/careers/product-engineering/
 	return `<!doctype html>
         <html lang="en">
             <head>
-			    ${weAreHiringMessage}
+			    ${
+					weAreHiring
+						? weAreHiringMessage
+						: '<!-- Hello there, HTML enthusiast! -->'
+				}
                 <title>${title}</title>
                 <meta name="description" content="${he.encode(description)}" />
 				${

--- a/dotcom-rendering/src/server/render.allEditorialNewslettersPage.web.tsx
+++ b/dotcom-rendering/src/server/render.allEditorialNewslettersPage.web.tsx
@@ -108,5 +108,6 @@ export const renderEditorialNewslettersPage = ({
 		renderingTarget: 'Web',
 		borkFCP: newslettersPage.config.abTests.borkFcpVariant === 'variant',
 		borkFID: newslettersPage.config.abTests.borkFidVariant === 'variant',
+		weAreHiring: !!newslettersPage.config.switches.weAreHiring,
 	});
 };

--- a/dotcom-rendering/src/server/render.article.apps.tsx
+++ b/dotcom-rendering/src/server/render.article.apps.tsx
@@ -67,6 +67,7 @@ export const renderArticle = (
 		offerHttp3: false,
 		borkFCP: false,
 		borkFID: false,
+		weAreHiring: !!article.config.switches.weAreHiring,
 	});
 
 	return {

--- a/dotcom-rendering/src/server/render.article.web.tsx
+++ b/dotcom-rendering/src/server/render.article.web.tsx
@@ -242,6 +242,7 @@ window.twttr = (function(d, s, id) {
 		renderingTarget: 'Web',
 		borkFCP: article.config.abTests.borkFcpVariant === 'variant',
 		borkFID: article.config.abTests.borkFidVariant === 'variant',
+		weAreHiring: !!article.config.switches.weAreHiring,
 	});
 };
 

--- a/dotcom-rendering/src/server/render.front.web.tsx
+++ b/dotcom-rendering/src/server/render.front.web.tsx
@@ -164,6 +164,7 @@ export const renderFront = ({ front }: Props): string => {
 		hasPageSkin: front.config.hasPageSkin,
 		borkFCP: front.config.abTests.borkFcpVariant === 'variant',
 		borkFID: front.config.abTests.borkFidVariant === 'variant',
+		weAreHiring: !!front.config.switches.weAreHiring,
 	});
 };
 
@@ -263,5 +264,6 @@ export const renderTagFront = ({
 		renderingTarget: 'Web',
 		borkFCP: tagFront.config.abTests.borkFcpVariant === 'variant',
 		borkFID: tagFront.config.abTests.borkFidVariant === 'variant',
+		weAreHiring: !!tagFront.config.switches.weAreHiring,
 	});
 };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Removing hiring message.

## Why?

I do not think we’re hiring at the moment…