### PR TITLE
Braze handling on DCR fronts

### DIFF
--- a/dotcom-rendering/src/components/FrontPage.tsx
+++ b/dotcom-rendering/src/components/FrontPage.tsx
@@ -8,6 +8,7 @@ import type { NavType } from '../model/extract-nav';
 import type { DCRFrontType } from '../types/front';
 import { AlreadyVisited } from './AlreadyVisited.importable';
 import { AnimatePulsingDots } from './AnimatePulsingDots.importable';
+import { BrazeMessaging } from './BrazeMessaging.importable';
 import { FetchCommentCounts } from './FetchCommentCounts.importable';
 import { FocusStyles } from './FocusStyles.importable';
 import { Island } from './Island';
@@ -88,6 +89,9 @@ export const FrontPage = ({ front, NAV }: Props) => {
 			</Island>
 			<Island clientOnly={true}>
 				<SetAdTargeting adTargeting={adTargeting} />
+			</Island>
+			<Island clientOnly={true} deferUntil="idle">
+				<BrazeMessaging idApiUrl={front.config.idApiUrl} />
 			</Island>
 			<FrontLayout front={front} NAV={NAV} />
 		</StrictMode>

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -14,7 +14,6 @@ import { Hide } from '@guardian/source-react-components';
 import { StraightLines } from '@guardian/source-react-components-development-kitchen';
 import { Fragment } from 'react';
 import { AdSlot } from '../components/AdSlot';
-import { BrazeMessaging } from '../components/BrazeMessaging.importable';
 import { Carousel } from '../components/Carousel.importable';
 import { CPScottHeader } from '../components/CPScottHeader';
 import { DecideContainer } from '../components/DecideContainer';
@@ -686,10 +685,6 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 					contributionsServiceUrl="https://contributions.guardianapis.com" // TODO: Pass this in
 				/>
 			</Section>
-
-			<Island clientOnly={true} deferUntil="idle">
-				<BrazeMessaging idApiUrl={front.config.idApiUrl} />
-			</Island>
 		</>
 	);
 };

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -14,6 +14,7 @@ import { Hide } from '@guardian/source-react-components';
 import { StraightLines } from '@guardian/source-react-components-development-kitchen';
 import { Fragment } from 'react';
 import { AdSlot } from '../components/AdSlot';
+import { BrazeMessaging } from '../components/BrazeMessaging.importable';
 import { Carousel } from '../components/Carousel.importable';
 import { CPScottHeader } from '../components/CPScottHeader';
 import { DecideContainer } from '../components/DecideContainer';
@@ -225,7 +226,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 									!!front.config.switches.remoteHeader
 								}
 								contributionsServiceUrl="https://contributions.guardianapis.com" // TODO: Pass this in
-								idApiUrl="https://idapi.theguardian.com/" // TODO: read this from somewhere as in other layouts
+								idApiUrl={front.config.idApiUrl}
 								isInEuropeTest={isInEuropeTest}
 								headerTopBarSearchCapiSwitch={
 									!!front.config.switches
@@ -685,6 +686,10 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 					contributionsServiceUrl="https://contributions.guardianapis.com" // TODO: Pass this in
 				/>
 			</Section>
+
+			<Island clientOnly={true} deferUntil="idle">
+				<BrazeMessaging idApiUrl={front.config.idApiUrl} />
+			</Island>
 		</>
 	);
 };


### PR DESCRIPTION
## What does this change?

As we've migrated to DCR fronts, the Braze handling code which runs on articles isn't happening. This PR doesn't get Braze banners rendering, but it does get Braze logic running which means on DCR fronts we will now:

* fetch messages from Braze for eligible users (signed in and consented)
* clean up any local data when the user _was_ eligible but now isn't (e.g. signed-out or removed consent)

This matches the behaviour on articles.

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
