### PR TITLE
Carousel layout for page skins

### DIFF
--- a/dotcom-rendering/src/components/Carousel.importable.tsx
+++ b/dotcom-rendering/src/components/Carousel.importable.tsx
@@ -541,7 +541,7 @@ type CarouselColours = {
 	arrowBackgroundHoverColour: string;
 };
 
-const HeaderChevrons = ({
+const HeaderAndChevrons = ({
 	heading,
 	trails,
 	carouselColours,
@@ -932,7 +932,7 @@ export const Carousel = ({
 				data-link={formatAttrString(heading)}
 			>
 				{hasPageSkin ? (
-					<HeaderChevrons
+					<HeaderAndChevrons
 						heading={heading}
 						trails={trails}
 						carouselColours={carouselColours}
@@ -946,7 +946,7 @@ export const Carousel = ({
 					/>
 				) : (
 					<Hide when="above" breakpoint="leftCol">
-						<HeaderChevrons
+						<HeaderAndChevrons
 							heading={heading}
 							trails={trails}
 							carouselColours={carouselColours}

--- a/dotcom-rendering/src/components/Carousel.importable.tsx
+++ b/dotcom-rendering/src/components/Carousel.importable.tsx
@@ -531,16 +531,6 @@ const HeaderAndNav = ({
 	</div>
 );
 
-type CarouselColours = {
-	titleColour: string;
-	titleHighlightColour: string;
-	borderColour: string;
-	activeDotColour: string;
-	arrowColour: string;
-	arrowBackgroundColour: string;
-	arrowBackgroundHoverColour: string;
-};
-
 const Header = ({
 	heading,
 	trails,
@@ -738,6 +728,16 @@ const InlineChevrons = ({
 		</div>
 	</>
 );
+
+type CarouselColours = {
+	titleColour: string;
+	titleHighlightColour: string;
+	borderColour: string;
+	activeDotColour: string;
+	arrowColour: string;
+	arrowBackgroundColour: string;
+	arrowBackgroundHoverColour: string;
+};
 
 const decideCarouselColours = (
 	props: { format: ArticleFormat } | { palette: DCRContainerPalette },

--- a/dotcom-rendering/src/components/Carousel.importable.tsx
+++ b/dotcom-rendering/src/components/Carousel.importable.tsx
@@ -541,7 +541,7 @@ type CarouselColours = {
 	arrowBackgroundHoverColour: string;
 };
 
-const HeaderAndChevrons = ({
+const Header = ({
 	heading,
 	trails,
 	carouselColours,
@@ -552,6 +552,7 @@ const HeaderAndChevrons = ({
 	arrowName,
 	isCuratedContent,
 	isVideoContainer,
+	hasPageSkin,
 }: {
 	heading: string;
 	trails: TrailType[];
@@ -563,73 +564,88 @@ const HeaderAndChevrons = ({
 	arrowName: string;
 	isCuratedContent: boolean;
 	isVideoContainer: boolean;
-}) => (
-	<div css={headerRowStyles}>
-		<HeaderAndNav
-			heading={heading}
-			trails={trails}
-			titleHighlightColour={carouselColours.titleHighlightColour}
-			titleColour={carouselColours.titleColour}
-			activeDotColour={carouselColours.activeDotColour}
-			index={index}
-			isCuratedContent={isCuratedContent}
-			goToIndex={goToIndex}
-		/>
-		<Hide when="below" breakpoint="desktop">
-			<button
-				type="button"
-				onClick={prev}
-				aria-label="Move carousel backwards"
-				css={[
-					buttonStyle(
-						carouselColours.arrowColour,
-						carouselColours.arrowBackgroundColour,
-						carouselColours.arrowBackgroundHoverColour,
-					),
-					prevButtonStyle(
-						index,
-						carouselColours.arrowColour,
-						carouselColours.arrowBackgroundColour,
-						carouselColours.arrowBackgroundHoverColour,
-					),
-				]}
-				data-link-name={getDataLinkNameCarouselButton(
-					'prev',
-					arrowName,
-					isVideoContainer,
-				)}
-			>
-				<SvgChevronLeftSingle />
-			</button>
-			<button
-				type="button"
-				onClick={next}
-				aria-label="Move carousel forwards"
-				css={[
-					buttonStyle(
-						carouselColours.arrowColour,
-						carouselColours.arrowBackgroundColour,
-						carouselColours.arrowBackgroundHoverColour,
-					),
-					nextButtonStyle(
-						index,
-						trails.length,
-						carouselColours.arrowColour,
-						carouselColours.arrowBackgroundColour,
-						carouselColours.arrowBackgroundHoverColour,
-					),
-				]}
-				data-link-name={getDataLinkNameCarouselButton(
-					'next',
-					arrowName,
-					isVideoContainer,
-				)}
-			>
-				<SvgChevronRightSingle />
-			</button>
+	hasPageSkin: boolean;
+}) => {
+	const header = (
+		<div css={headerRowStyles}>
+			<HeaderAndNav
+				heading={heading}
+				trails={trails}
+				titleHighlightColour={carouselColours.titleHighlightColour}
+				titleColour={carouselColours.titleColour}
+				activeDotColour={carouselColours.activeDotColour}
+				index={index}
+				isCuratedContent={isCuratedContent}
+				goToIndex={goToIndex}
+			/>
+			<Hide when="below" breakpoint="desktop">
+				<button
+					type="button"
+					onClick={prev}
+					aria-label="Move carousel backwards"
+					css={[
+						buttonStyle(
+							carouselColours.arrowColour,
+							carouselColours.arrowBackgroundColour,
+							carouselColours.arrowBackgroundHoverColour,
+						),
+						prevButtonStyle(
+							index,
+							carouselColours.arrowColour,
+							carouselColours.arrowBackgroundColour,
+							carouselColours.arrowBackgroundHoverColour,
+						),
+					]}
+					data-link-name={getDataLinkNameCarouselButton(
+						'prev',
+						arrowName,
+						isVideoContainer,
+					)}
+				>
+					<SvgChevronLeftSingle />
+				</button>
+				<button
+					type="button"
+					onClick={next}
+					aria-label="Move carousel forwards"
+					css={[
+						buttonStyle(
+							carouselColours.arrowColour,
+							carouselColours.arrowBackgroundColour,
+							carouselColours.arrowBackgroundHoverColour,
+						),
+						nextButtonStyle(
+							index,
+							trails.length,
+							carouselColours.arrowColour,
+							carouselColours.arrowBackgroundColour,
+							carouselColours.arrowBackgroundHoverColour,
+						),
+					]}
+					data-link-name={getDataLinkNameCarouselButton(
+						'next',
+						arrowName,
+						isVideoContainer,
+					)}
+				>
+					<SvgChevronRightSingle />
+				</button>
+			</Hide>
+		</div>
+	);
+	/**
+	 * When there is a page skin we constrain to a desktop layout
+	 * So don't hide the header past leftcol as normal
+	 */
+	if (hasPageSkin) {
+		return header;
+	}
+	return (
+		<Hide when="above" breakpoint="leftCol">
+			{header}
 		</Hide>
-	</div>
-);
+	);
+};
 
 const InlineChevrons = ({
 	trails,
@@ -686,7 +702,6 @@ const InlineChevrons = ({
 				<SvgChevronLeftSingle />
 			</button>
 		</div>
-
 		<div
 			css={[
 				buttonContainerStyle,
@@ -931,35 +946,19 @@ export const Carousel = ({
 				data-component={onwardsSource}
 				data-link={formatAttrString(heading)}
 			>
-				{hasPageSkin ? (
-					<HeaderAndChevrons
-						heading={heading}
-						trails={trails}
-						carouselColours={carouselColours}
-						index={index}
-						goToIndex={goToIndex}
-						prev={prev}
-						next={next}
-						arrowName={arrowName}
-						isCuratedContent={isCuratedContent}
-						isVideoContainer={isVideoContainer}
-					/>
-				) : (
-					<Hide when="above" breakpoint="leftCol">
-						<HeaderAndChevrons
-							heading={heading}
-							trails={trails}
-							carouselColours={carouselColours}
-							index={index}
-							goToIndex={goToIndex}
-							prev={prev}
-							next={next}
-							arrowName={arrowName}
-							isCuratedContent={isCuratedContent}
-							isVideoContainer={isVideoContainer}
-						/>
-					</Hide>
-				)}
+				<Header
+					heading={heading}
+					trails={trails}
+					carouselColours={carouselColours}
+					index={index}
+					goToIndex={goToIndex}
+					prev={prev}
+					next={next}
+					arrowName={arrowName}
+					isCuratedContent={isCuratedContent}
+					isVideoContainer={isVideoContainer}
+					hasPageSkin={hasPageSkin}
+				/>
 				<ul
 					css={carouselStyle}
 					ref={carouselRef}

--- a/dotcom-rendering/src/components/Carousel.importable.tsx
+++ b/dotcom-rendering/src/components/Carousel.importable.tsx
@@ -631,6 +631,99 @@ const HeaderChevrons = ({
 	</div>
 );
 
+const InlineChevrons = ({
+	trails,
+	carouselColours,
+	index,
+	prev,
+	next,
+	arrowName,
+	isVideoContainer,
+	leftColSize,
+	hasPageSkin,
+}: {
+	trails: TrailType[];
+	carouselColours: CarouselColours;
+	index: number;
+	prev: () => void;
+	next: () => void;
+	arrowName: string;
+	isVideoContainer: boolean;
+	leftColSize: LeftColSize;
+	hasPageSkin: boolean;
+}) => (
+	<>
+		<div
+			css={[
+				buttonContainerStyle,
+				hasPageSkin && buttonContainerStyleWithPageSkin,
+				!hasPageSkin && prevButtonContainerStyle(leftColSize),
+			]}
+		>
+			<button
+				type="button"
+				onClick={prev}
+				aria-label="Move carousel backwards"
+				css={[
+					buttonStyle(
+						carouselColours.arrowColour,
+						carouselColours.arrowBackgroundColour,
+						carouselColours.arrowBackgroundHoverColour,
+					),
+					prevButtonStyle(
+						index,
+						carouselColours.arrowColour,
+						carouselColours.arrowBackgroundColour,
+						carouselColours.arrowBackgroundHoverColour,
+					),
+				]}
+				data-link-name={getDataLinkNameCarouselButton(
+					'prev',
+					arrowName,
+					isVideoContainer,
+				)}
+			>
+				<SvgChevronLeftSingle />
+			</button>
+		</div>
+
+		<div
+			css={[
+				buttonContainerStyle,
+				hasPageSkin && buttonContainerStyleWithPageSkin,
+				nextButtonContainerStyle,
+			]}
+		>
+			<button
+				type="button"
+				onClick={next}
+				aria-label="Move carousel forwards"
+				css={[
+					buttonStyle(
+						carouselColours.arrowColour,
+						carouselColours.arrowBackgroundColour,
+						carouselColours.arrowBackgroundHoverColour,
+					),
+					nextButtonStyle(
+						index,
+						trails.length,
+						carouselColours.arrowColour,
+						carouselColours.arrowBackgroundColour,
+						carouselColours.arrowBackgroundHoverColour,
+					),
+				]}
+				data-link-name={getDataLinkNameCarouselButton(
+					'next',
+					arrowName,
+					isVideoContainer,
+				)}
+			>
+				<SvgChevronRightSingle />
+			</button>
+		</div>
+	</>
+);
+
 const decideCarouselColours = (
 	props: { format: ArticleFormat } | { palette: DCRContainerPalette },
 ): CarouselColours => {
@@ -695,7 +788,7 @@ export const Carousel = ({
 	const isVideoContainer =
 		'collectionType' in props && props.collectionType === 'fixed/video';
 
-	const hasPageSkin = 'hasPageSkin' in props && props.hasPageSkin;
+	const hasPageSkin = 'hasPageSkin' in props && (props.hasPageSkin ?? false);
 
 	const notPresentation = (el: HTMLElement): boolean =>
 		el.getAttribute('role') !== 'presentation';
@@ -818,74 +911,17 @@ export const Carousel = ({
 					goToIndex={goToIndex}
 				/>
 			</LeftColumn>
-			<div
-				css={[
-					buttonContainerStyle,
-					hasPageSkin && buttonContainerStyleWithPageSkin,
-					!hasPageSkin && prevButtonContainerStyle(leftColSize),
-				]}
-			>
-				<button
-					type="button"
-					onClick={prev}
-					aria-label="Move carousel backwards"
-					css={[
-						buttonStyle(
-							carouselColours.arrowColour,
-							carouselColours.arrowBackgroundColour,
-							carouselColours.arrowBackgroundHoverColour,
-						),
-						prevButtonStyle(
-							index,
-							carouselColours.arrowColour,
-							carouselColours.arrowBackgroundColour,
-							carouselColours.arrowBackgroundHoverColour,
-						),
-					]}
-					data-link-name={getDataLinkNameCarouselButton(
-						'prev',
-						arrowName,
-						isVideoContainer,
-					)}
-				>
-					<SvgChevronLeftSingle />
-				</button>
-			</div>
-
-			<div
-				css={[
-					buttonContainerStyle,
-					hasPageSkin && buttonContainerStyleWithPageSkin,
-					nextButtonContainerStyle,
-				]}
-			>
-				<button
-					type="button"
-					onClick={next}
-					aria-label="Move carousel forwards"
-					css={[
-						buttonStyle(
-							carouselColours.arrowColour,
-							carouselColours.arrowBackgroundColour,
-							carouselColours.arrowBackgroundHoverColour,
-						),
-						nextButtonStyle(
-							index,
-							trails.length,
-							carouselColours.arrowColour,
-							carouselColours.arrowBackgroundColour,
-							carouselColours.arrowBackgroundHoverColour,
-						),
-					]}
-					data-link-name={getDataLinkNameCarouselButton(
-						'next',
-						arrowName,
-						isVideoContainer,
-					)}
-				>
-					<SvgChevronRightSingle />
-				</button>
-			</div>
+			<InlineChevrons
+				trails={trails}
+				carouselColours={carouselColours}
+				index={index}
+				prev={prev}
+				next={next}
+				arrowName={arrowName}
+				isVideoContainer={isVideoContainer}
+				leftColSize={leftColSize}
+				hasPageSkin={hasPageSkin}
+			/>
 			<div
 				css={[
 					containerStyles,

--- a/dotcom-rendering/src/components/FrontSection.tsx
+++ b/dotcom-rendering/src/components/FrontSection.tsx
@@ -331,7 +331,6 @@ const decideBackgroundColour = (
 		return overrideBackgroundColour;
 	}
 	if (hasPageSkin) {
-		// TODO check this is the right background colour to use
 		return background.primary;
 	}
 	return undefined;

--- a/dotcom-rendering/src/components/Section.tsx
+++ b/dotcom-rendering/src/components/Section.tsx
@@ -251,7 +251,6 @@ const decideBackgroundColour = (
 		return overrideBackgroundColour;
 	}
 	if (hasPageSkin) {
-		// TODO check this is the right background colour to use
 		return background.primary;
 	}
 	return undefined;

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -533,6 +533,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 											collectionType={
 												collection.collectionType
 											}
+											hasPageSkin={hasPageSkin}
 										/>
 									</Island>
 								</Section>


### PR DESCRIPTION
## What does this change?

Fixes video and podcasts carousel layout when there is a page skin.

The carousel component has been updated as follows:
- constrain to a desktop layout (i.e. don't apply > `leftCol` styles) when a page skin is present
- header and navigation chevrons extracted to their own components to aid readability

An extension of #7871 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/7014230/fb119f7a-e879-4fd8-ae77-557bf25d3f7a
[after]: https://github.com/guardian/dotcom-rendering/assets/7014230/08da1293-397d-4614-9285-f36e4582b4d7




