### PR TITLE
Lightbox refactors

### DIFF
--- a/dotcom-rendering/src/components/Caption.tsx
+++ b/dotcom-rendering/src/components/Caption.tsx
@@ -35,7 +35,7 @@ const captionStyle = (palette: Palette) => css`
 	${textSans.xsmall()};
 	line-height: 135%;
 	padding-top: 6px;
-	word-wrap: break-all;
+	overflow-wrap: break-all;
 	color: ${palette.text.caption};
 `;
 

--- a/dotcom-rendering/src/components/ImageComponent.tsx
+++ b/dotcom-rendering/src/components/ImageComponent.tsx
@@ -9,6 +9,7 @@ import {
 	until,
 } from '@guardian/source-foundations';
 import { decidePalette } from '../lib/decidePalette';
+import { isWideEnough } from '../lib/lightbox';
 import type { Switches } from '../types/config';
 import type { Image, ImageBlockElement, RoleType } from '../types/content';
 import type { Palette } from '../types/palette';
@@ -272,7 +273,6 @@ export const ImageComponent = ({
 	/**
 	 * We use height and width for two things.
 	 *
-	 * 1) To decide if an image is large enough to be used in lightbox (>620) and
 	 * 2) To get a true ratio value to apply to the image in the page, so the browser's pre-parser can reserve the space
 	 *
 	 * On the second point, see this PR for more detail
@@ -335,7 +335,7 @@ export const ImageComponent = ({
 					<ImageTitle title={title} role={role} palette={palette} />
 				)}
 				{switches?.lightbox === true &&
-					imageWidth > 620 &&
+					isWideEnough(master) &&
 					element.position !== undefined && (
 						<LightboxLink
 							role={role}
@@ -385,7 +385,7 @@ export const ImageComponent = ({
 					<ImageTitle title={title} role={role} palette={palette} />
 				)}
 				{switches?.lightbox === true &&
-					imageWidth > 620 &&
+					isWideEnough(master) &&
 					element.position !== undefined && (
 						<LightboxLink
 							role={role}
@@ -474,7 +474,7 @@ export const ImageComponent = ({
 				)}
 
 				{switches?.lightbox === true &&
-					imageWidth > 620 &&
+					isWideEnough(master) &&
 					element.position !== undefined && (
 						<LightboxLink
 							role={role}

--- a/dotcom-rendering/src/components/ImageComponent.tsx
+++ b/dotcom-rendering/src/components/ImageComponent.tsx
@@ -279,8 +279,8 @@ export const ImageComponent = ({
 	 * https://github.com/guardian/dotcom-rendering/pull/1879
 	 *
 	 */
-	const imageWidth = master.fields.width;
-	const imageHeight = master.fields.width;
+	const imageWidth = parseInt(master.fields.width, 10);
+	const imageHeight = parseInt(master.fields.height, 10);
 
 	const palette = decidePalette(format);
 
@@ -335,7 +335,7 @@ export const ImageComponent = ({
 					<ImageTitle title={title} role={role} palette={palette} />
 				)}
 				{switches?.lightbox === true &&
-					parseInt(imageWidth, 10) > 620 &&
+					imageWidth > 620 &&
 					element.position !== undefined && (
 						<LightboxLink
 							role={role}
@@ -385,7 +385,7 @@ export const ImageComponent = ({
 					<ImageTitle title={title} role={role} palette={palette} />
 				)}
 				{switches?.lightbox === true &&
-					parseInt(imageWidth, 10) > 620 &&
+					imageWidth > 620 &&
 					element.position !== undefined && (
 						<LightboxLink
 							role={role}
@@ -474,7 +474,7 @@ export const ImageComponent = ({
 				)}
 
 				{switches?.lightbox === true &&
-					parseInt(imageWidth, 10) > 620 &&
+					imageWidth > 620 &&
 					element.position !== undefined && (
 						<LightboxLink
 							role={role}

--- a/dotcom-rendering/src/components/ImageComponent.tsx
+++ b/dotcom-rendering/src/components/ImageComponent.tsx
@@ -260,12 +260,12 @@ export const ImageComponent = ({
 		format.design !== ArticleDesign.Comment &&
 		format.design !== ArticleDesign.Editorial;
 
-	// Legacy images do not have a master so we fallback to the largest available
-	const master =
+	/** Legacy images do not have a master so we fallback to the largest available */
+	const image =
 		getMaster(element.media.allImages) ??
 		getLargest(element.media.allImages);
 
-	if (!master?.url || !isSupported(master.url)) {
+	if (!image?.url || !isSupported(image.url)) {
 		// We should only try to render images that are supported by Fastly
 		return null;
 	}
@@ -279,8 +279,8 @@ export const ImageComponent = ({
 	 * https://github.com/guardian/dotcom-rendering/pull/1879
 	 *
 	 */
-	const imageWidth = parseInt(master.fields.width, 10);
-	const imageHeight = parseInt(master.fields.height, 10);
+	const imageWidth = parseInt(image.fields.width, 10);
+	const imageHeight = parseInt(image.fields.height, 10);
 
 	const palette = decidePalette(format);
 
@@ -324,7 +324,7 @@ export const ImageComponent = ({
 				<Picture
 					role={role}
 					format={format}
-					master={master.url}
+					master={image.url}
 					alt={element.data.alt ?? ''}
 					width={imageWidth}
 					height={imageHeight}
@@ -335,7 +335,7 @@ export const ImageComponent = ({
 					<ImageTitle title={title} role={role} palette={palette} />
 				)}
 				{switches?.lightbox === true &&
-					isWideEnough(master) &&
+					isWideEnough(image) &&
 					element.position !== undefined && (
 						<LightboxLink
 							role={role}
@@ -371,7 +371,7 @@ export const ImageComponent = ({
 				<Picture
 					role={role}
 					format={format}
-					master={master.url}
+					master={image.url}
 					alt={element.data.alt ?? ''}
 					width={imageWidth}
 					height={imageHeight}
@@ -385,7 +385,7 @@ export const ImageComponent = ({
 					<ImageTitle title={title} role={role} palette={palette} />
 				)}
 				{switches?.lightbox === true &&
-					isWideEnough(master) &&
+					isWideEnough(image) &&
 					element.position !== undefined && (
 						<LightboxLink
 							role={role}
@@ -421,7 +421,7 @@ export const ImageComponent = ({
 				<Picture
 					role={role}
 					format={format}
-					master={master.url}
+					master={image.url}
 					alt={element.data.alt ?? ''}
 					width={imageWidth}
 					height={imageHeight}
@@ -474,7 +474,7 @@ export const ImageComponent = ({
 				)}
 
 				{switches?.lightbox === true &&
-					isWideEnough(master) &&
+					isWideEnough(image) &&
 					element.position !== undefined && (
 						<LightboxLink
 							role={role}

--- a/dotcom-rendering/src/components/ImageComponent.tsx
+++ b/dotcom-rendering/src/components/ImageComponent.tsx
@@ -216,14 +216,23 @@ const CaptionToggle = () => (
 	</>
 );
 
+const descendingByWidthComparator = (a: Image, b: Image) => {
+	return parseInt(b.fields.width, 10) - parseInt(a.fields.width, 10);
+};
+
+const isSupported = (imageUrl: string): boolean => {
+	const supportedImages = ['jpg', 'jpeg', 'png'];
+	return supportedImages.some((extension) =>
+		imageUrl.endsWith(`.${extension}`),
+	);
+};
+
 export const getMaster = (images: Image[]) => {
 	return images.find((image) => image.fields.isMaster);
 };
+
 export const getLargest = (images: Image[]) => {
-	const descendingByWidth = (a: Image, b: Image) => {
-		return parseInt(b.fields.width) - parseInt(a.fields.width);
-	};
-	return images.slice().sort(descendingByWidth)[0];
+	return images.slice().sort(descendingByWidthComparator)[0];
 };
 
 export const ImageComponent = ({
@@ -254,13 +263,6 @@ export const ImageComponent = ({
 	const master =
 		getMaster(element.media.allImages) ??
 		getLargest(element.media.allImages);
-
-	const isSupported = (imageUrl: string): boolean => {
-		const supportedImages = ['jpg', 'jpeg', 'png'];
-		return supportedImages.some((extension) =>
-			imageUrl.endsWith(`.${extension}`),
-		);
-	};
 
 	if (!master?.url || !isSupported(master.url)) {
 		// We should only try to render images that are supported by Fastly

--- a/dotcom-rendering/src/components/LightboxCaption.tsx
+++ b/dotcom-rendering/src/components/LightboxCaption.tsx
@@ -22,7 +22,7 @@ export const LightboxCaption = ({
 			css={css`
 				${textSans.xsmall()};
 				line-height: 135%;
-				word-wrap: break4all;
+				overflow-wrap: break-all;
 				padding-top: ${space[2]}px;
 				padding-bottom: ${space[2]}px;
 				border-top: 3px solid ${palette.background.lightboxDivider};

--- a/dotcom-rendering/src/components/LightboxHash.importable.tsx
+++ b/dotcom-rendering/src/components/LightboxHash.importable.tsx
@@ -1,5 +1,5 @@
 import { log } from '@guardian/libs';
-import { useEffect } from 'react';
+import { useOnce } from '../lib/useOnce';
 
 /**
  * This small snippet of javascript is executed at page load. It checks to
@@ -15,7 +15,7 @@ import { useEffect } from 'react';
  * url into the browser and unable to access the article under the lightbox.
  */
 export const LightboxHash = () => {
-	useEffect(() => {
+	useOnce(() => {
 		const hash = window.location.hash;
 		if (hash.startsWith('#img-')) {
 			log(

--- a/dotcom-rendering/src/components/LightboxImages.tsx
+++ b/dotcom-rendering/src/components/LightboxImages.tsx
@@ -206,8 +206,8 @@ export const LightboxImages = ({ format, images }: Props) => {
 								// Height and width are only used here so the browser has a ratio to work with
 								// when laying out the page. The actual size of the image is based on the
 								// viewport
-								height={image.height.toString()}
-								width={image.width.toString()}
+								height={image.height}
+								width={image.width}
 								master={image.masterUrl}
 								format={format}
 								isLightbox={true}

--- a/dotcom-rendering/src/components/LightboxImages.tsx
+++ b/dotcom-rendering/src/components/LightboxImages.tsx
@@ -1,10 +1,9 @@
 import { css } from '@emotion/react';
 import { timeAgo } from '@guardian/libs';
 import {
-	brandAltBackground,
 	from,
 	headline,
-	neutral,
+	palette,
 	space,
 	textSans,
 	until,
@@ -98,12 +97,12 @@ const asideStyles = css`
 		max-width: 300px;
 	}
 	${until.tablet} {
-		border-top: 1px solid ${neutral[20]};
+		border-top: 1px solid ${palette.neutral[20]};
 	}
 	${from.tablet} {
-		border-left: 1px solid ${neutral[20]};
+		border-left: 1px solid ${palette.neutral[20]};
 	}
-	background-color: ${neutral[7]};
+	background-color: ${palette.neutral[7]};
 
 	padding: ${space[3]}px;
 
@@ -145,7 +144,7 @@ const Selection = ({
 					margin-bottom: ${space[1]}px;
 				}
 				${textSans.xsmall()};
-				color: ${neutral[86]};
+				color: ${palette.neutral[86]};
 				${until.tablet} {
 					margin-bottom: ${space[2]}px;
 				}
@@ -164,7 +163,7 @@ const Selection = ({
 			</span>
 			<span
 				css={css`
-					color: ${neutral[97]};
+					color: ${palette.neutral[97]};
 				`}
 			>
 				{countOfImages}
@@ -218,7 +217,7 @@ export const LightboxImages = ({ format, images }: Props) => {
 											${headline.xsmall({
 												fontWeight: 'light',
 											})}
-											color: ${neutral[100]};
+											color: ${palette.neutral[100]};
 											margin-bottom: ${space[1]}px;
 											${from.tablet} {
 												margin-bottom: ${space[2]}px;
@@ -232,7 +231,8 @@ export const LightboxImages = ({ format, images }: Props) => {
 									<div
 										css={css`
 											display: inline-block;
-											background-color: ${brandAltBackground.primary};
+											background-color: ${palette
+												.brandAlt[400]};
 											margin-bottom: ${space[2]}px;
 											${from.tablet} {
 												margin-bottom: ${space[3]}px;
@@ -267,9 +267,10 @@ export const LightboxImages = ({ format, images }: Props) => {
 											priority="secondary"
 											cssOverrides={css`
 												${textSans.xsmall()};
-												color: ${neutral[60]};
+												color: ${palette.neutral[60]};
 												:hover {
-													color: ${neutral[86]};
+													color: ${palette
+														.neutral[86]};
 												}
 											`}
 										>

--- a/dotcom-rendering/src/components/LightboxImages.tsx
+++ b/dotcom-rendering/src/components/LightboxImages.tsx
@@ -105,10 +105,7 @@ const asideStyles = css`
 	}
 	background-color: ${neutral[7]};
 
-	padding-left: ${space[3]}px;
-	padding-right: ${space[3]}px;
-	padding-top: ${space[3]}px;
-	padding-bottom: ${space[3]}px;
+	padding: ${space[3]}px;
 
 	${from.tablet} {
 		padding-left: ${space[5]}px;

--- a/dotcom-rendering/src/components/Picture.tsx
+++ b/dotcom-rendering/src/components/Picture.tsx
@@ -15,8 +15,8 @@ type Props = {
 	format: ArticleFormat;
 	master: string;
 	alt: string;
-	height: string;
-	width: string;
+	height: number;
+	width: number;
 	isMainMedia?: boolean;
 	isLazy?: boolean;
 	isLightbox?: boolean;
@@ -355,7 +355,7 @@ export const Picture = ({
 	);
 
 	/** portrait if higher than 1 or landscape if lower than 1 */
-	const ratio = parseInt(height, 10) / parseInt(width, 10);
+	const ratio = height / width;
 
 	/**
 	 * Immersive MainMedia elements fill the height of the viewport, meaning on mobile

--- a/dotcom-rendering/src/lib/lightbox.ts
+++ b/dotcom-rendering/src/lib/lightbox.ts
@@ -1,0 +1,12 @@
+import type { Image } from '../types/content';
+
+/** Used to determine if a lightbox can be created */
+const THRESHOLD = 620;
+
+/** has a width above the threshold */
+export const isWideEnough = ({ fields: { width } }: Image): boolean =>
+	parseInt(width, 10) > THRESHOLD;
+
+/** Has a height above the threshold */
+export const isHighEnough = ({ fields: { height } }: Image): boolean =>
+	parseInt(height, 10) > THRESHOLD;

--- a/dotcom-rendering/src/model/buildLightboxImages.ts
+++ b/dotcom-rendering/src/model/buildLightboxImages.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import { getLargest, getMaster } from '../components/ImageComponent';
 import type { Orientation } from '../components/Picture';
+import { isHighEnough, isWideEnough } from '../lib/lightbox';
 import type {
 	FEElement,
 	ImageBlockElement,
@@ -10,7 +11,7 @@ import { isImage } from './enhance-images';
 
 /**
  * Only allow the lightbox to show images that have a source with a width greater
- * than 620 pixels.
+ * than a threshold.
  *
  * Frontend has similar logic here:
  * https://github.com/guardian/frontend/blob/126dfcbc1aa961650b7f7ff41ee50a12782bb62e/common/app/model/content.scala#L549
@@ -22,15 +23,9 @@ const isLightboxable = (
 ): boolean => {
 	switch (orientation) {
 		case 'landscape':
-			// If any width is above 620 we allow this image in lightbox
-			return element.media.allImages.some(
-				(mediaImg) => parseInt(mediaImg.fields.width, 10) > 620,
-			);
+			return element.media.allImages.some(isWideEnough);
 		case 'portrait':
-			// If any height is above 620 we allow this image in lightbox
-			return element.media.allImages.some(
-				(mediaImg) => parseInt(mediaImg.fields.height, 10) > 620,
-			);
+			return element.media.allImages.some(isHighEnough);
 	}
 };
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

- extract methods/functions to the top level of the module, preventing them from being generated at each execution
- parse pictures dimensions once, as these are inherently numerical
- unify decision on “lightboxability” which is when a dimension is above a threshold (width > 620)
- use CSS shorthand notation
- use Source’s `palette` instead of deprecated accessors
- `useOnce` hook for when it should only run once, as it is more semantic
- `text-wrap` is now [`overflow-wrap`](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-wrap)
- rename `image` back to what it was, because it may not always be a master

## Why?

These are deviations from our coding standards that were not addressed in the original PR.

## Screenshots

N/A