### PR TITLE
Enable refreshing every 30s on AMP adverts

### DIFF
--- a/dotcom-rendering/src/components/Ad.amp.tsx
+++ b/dotcom-rendering/src/components/Ad.amp.tsx
@@ -112,6 +112,7 @@ export const Ad = ({
 			data-multi-size-validation="false"
 			data-npa-on-unknown-consent={true}
 			data-loading-strategy="prefer-viewability-over-views"
+			data-enable-refresh="30"
 			layout="fixed"
 			type="doubleclick"
 			json={stringify(


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Add's a data attribute to the `amp-ad` elements to enable refreshing.

## Why?
💰

