### PR TITLE
Identity auth in discussion rendering

### DIFF
--- a/dotcom-rendering/src/components/Discussion.tsx
+++ b/dotcom-rendering/src/components/Discussion.tsx
@@ -5,6 +5,7 @@ import { SvgPlus } from '@guardian/source-react-components';
 import { EditorialButton } from '@guardian/source-react-components-development-kitchen';
 import { useEffect, useState } from 'react';
 import { App as Comments } from '../discussion-rendering/App';
+import type { SignedInUser } from '../discussion-rendering/discussionTypes';
 import { decidePalette } from '../lib/decidePalette';
 import { getCommentContext } from '../lib/getCommentContext';
 import { revealStyles } from '../lib/revealStyles';
@@ -19,7 +20,7 @@ export type Props = {
 	discussionD2Uid: string;
 	discussionApiClientHeader: string;
 	enableDiscussionSwitch: boolean;
-	user?: UserProfile;
+	user?: SignedInUser;
 	idApiUrl: string;
 };
 
@@ -162,7 +163,7 @@ export const Discussion = ({
 							<SignedInAs
 								palette={palette}
 								enableDiscussionSwitch={enableDiscussionSwitch}
-								user={user}
+								user={user?.profile}
 								commentCount={commentCount}
 								isClosedForComments={isClosedForComments}
 							/>

--- a/dotcom-rendering/src/components/DiscussionWhenSignedIn.tsx
+++ b/dotcom-rendering/src/components/DiscussionWhenSignedIn.tsx
@@ -24,5 +24,7 @@ export const DiscussionWhenSignedIn = ({ authStatus, ...props }: Props) => {
 	);
 	if (!data) return null;
 
-	return <Discussion user={data.userProfile} {...props} />;
+	const user = { profile: data.userProfile, authStatus };
+
+	return <Discussion user={user} {...props} />;
 };

--- a/dotcom-rendering/src/discussion-rendering/App.stories.tsx
+++ b/dotcom-rendering/src/discussion-rendering/App.stories.tsx
@@ -1,23 +1,26 @@
 import { css } from '@emotion/react';
 import { ArticlePillar } from '@guardian/libs';
 import { App } from './App';
-import type { UserProfile } from './discussionTypes';
+import type { SignedInUser } from './discussionTypes';
 
 export default { component: App, title: 'Discussion/App' };
 
-const aUser: UserProfile = {
-	userId: 'abc123',
-	displayName: 'Jane Smith',
-	webUrl: '',
-	apiUrl: '',
-	avatar: '',
-	secureAvatarUrl: '',
-	badge: [],
-	privateFields: {
-		canPostComment: true,
-		isPremoderated: false,
-		hasCommented: true,
+const aUser: SignedInUser = {
+	profile: {
+		userId: 'abc123',
+		displayName: 'Jane Smith',
+		webUrl: '',
+		apiUrl: '',
+		avatar: '',
+		secureAvatarUrl: '',
+		badge: [],
+		privateFields: {
+			canPostComment: true,
+			isPremoderated: false,
+			hasCommented: true,
+		},
 	},
+	authStatus: { kind: 'SignedInWithCookies' },
 };
 
 export const LoggedOutHiddenPicks = () => (

--- a/dotcom-rendering/src/discussion-rendering/App.tsx
+++ b/dotcom-rendering/src/discussion-rendering/App.tsx
@@ -213,6 +213,7 @@ const writeMutes = (mutes: string[]) => {
 	}
 };
 
+//todo: should probably rename this to Comments?
 export const App = ({
 	baseUrl,
 	shortUrl,

--- a/dotcom-rendering/src/discussion-rendering/App.tsx
+++ b/dotcom-rendering/src/discussion-rendering/App.tsx
@@ -15,8 +15,8 @@ import type {
 	FilterOptions,
 	OrderByType,
 	PageSizeType,
+	SignedInUser,
 	ThreadsType,
-	UserProfile,
 } from './discussionTypes';
 import { getDiscussion, getPicks, initialiseApi } from './lib/api';
 
@@ -29,7 +29,7 @@ type Props = {
 	initialPage?: number;
 	pageSizeOverride?: PageSizeType;
 	orderByOverride?: OrderByType;
-	user?: UserProfile;
+	user?: SignedInUser;
 	additionalHeaders: AdditionalHeadersType;
 	expanded: boolean;
 	onPermalinkClick: (commentId: number) => void;
@@ -427,7 +427,7 @@ export const App = ({
 							<TopPicks
 								pillar={pillar}
 								comments={picks.slice(0, 2)}
-								isSignedIn={!!user}
+								authStatus={user?.authStatus}
 								onPermalinkClick={onPermalinkClick}
 								onRecommend={onRecommend}
 							/>
@@ -511,7 +511,7 @@ export const App = ({
 					<TopPicks
 						pillar={pillar}
 						comments={picks}
-						isSignedIn={!!user}
+						authStatus={user?.authStatus}
 						onPermalinkClick={onPermalinkClick}
 						onRecommend={onRecommend}
 					/>

--- a/dotcom-rendering/src/discussion-rendering/components/AbuseReportForm/AbuseReportForm.stories.tsx
+++ b/dotcom-rendering/src/discussion-rendering/components/AbuseReportForm/AbuseReportForm.stories.tsx
@@ -18,6 +18,7 @@ export const Dialog = () => (
 			toggleSetShowForm={() => {}}
 			pillar={ArticlePillar.Sport}
 			commentId={123}
+			authStatus={undefined}
 		/>
 	</div>
 );

--- a/dotcom-rendering/src/discussion-rendering/components/AbuseReportForm/AbuseReportForm.test.tsx
+++ b/dotcom-rendering/src/discussion-rendering/components/AbuseReportForm/AbuseReportForm.test.tsx
@@ -14,6 +14,7 @@ describe('Dropdown', () => {
 				toggleSetShowForm={() => undefined}
 				pillar={ArticlePillar.Sport}
 				commentId={123}
+				authStatus={undefined}
 			/>,
 		);
 
@@ -28,6 +29,7 @@ describe('Dropdown', () => {
 				toggleSetShowForm={() => undefined}
 				pillar={ArticlePillar.Sport}
 				commentId={123}
+				authStatus={undefined}
 			/>,
 		);
 
@@ -44,6 +46,7 @@ describe('Dropdown', () => {
 				toggleSetShowForm={() => undefined}
 				pillar={ArticlePillar.Sport}
 				commentId={123}
+				authStatus={undefined}
 			/>,
 		);
 

--- a/dotcom-rendering/src/discussion-rendering/components/AbuseReportForm/AbuseReportForm.tsx
+++ b/dotcom-rendering/src/discussion-rendering/components/AbuseReportForm/AbuseReportForm.tsx
@@ -4,13 +4,13 @@ import { log } from '@guardian/libs';
 import { neutral, space, textSans } from '@guardian/source-foundations';
 import { Button, SvgCross } from '@guardian/source-react-components';
 import { useEffect, useRef, useState } from 'react';
-import { reportAbuse } from '../../lib/api';
-import { palette } from '../../lib/palette';
-import { pillarToString } from '../../lib/pillarToString';
 import {
 	SignedInWithCookies,
 	SignedInWithOkta,
 } from '../../../lib/useAuthStatus';
+import { reportAbuse } from '../../lib/api';
+import { palette } from '../../lib/palette';
+import { pillarToString } from '../../lib/pillarToString';
 
 type FormData = {
 	categoryId: number;

--- a/dotcom-rendering/src/discussion-rendering/components/AbuseReportForm/AbuseReportForm.tsx
+++ b/dotcom-rendering/src/discussion-rendering/components/AbuseReportForm/AbuseReportForm.tsx
@@ -7,6 +7,10 @@ import { useEffect, useRef, useState } from 'react';
 import { reportAbuse } from '../../lib/api';
 import { palette } from '../../lib/palette';
 import { pillarToString } from '../../lib/pillarToString';
+import {
+	SignedInWithCookies,
+	SignedInWithOkta,
+} from '../../../lib/useAuthStatus';
 
 type FormData = {
 	categoryId: number;
@@ -59,12 +63,14 @@ type Props = {
 	commentId: number;
 	toggleSetShowForm: () => void;
 	pillar: ArticleTheme;
+	authStatus: SignedInWithCookies | SignedInWithOkta | undefined;
 };
 
 export const AbuseReportForm = ({
 	commentId,
 	toggleSetShowForm,
 	pillar,
+	authStatus,
 }: Props) => {
 	const modalRef = useRef<HTMLDivElement>(null);
 	// TODO: use ref once forwardRef is implemented @guardian/src-button
@@ -163,6 +169,7 @@ export const AbuseReportForm = ({
 			reason,
 			email,
 			commentId,
+			authStatus,
 		})
 			.then((response) => {
 				if (response.status !== 'ok') {

--- a/dotcom-rendering/src/discussion-rendering/components/AbuseReportForm/AbuseReportForm.tsx
+++ b/dotcom-rendering/src/discussion-rendering/components/AbuseReportForm/AbuseReportForm.tsx
@@ -63,7 +63,7 @@ type Props = {
 	commentId: number;
 	toggleSetShowForm: () => void;
 	pillar: ArticleTheme;
-	authStatus: SignedInWithCookies | SignedInWithOkta | undefined;
+	authStatus?: SignedInWithCookies | SignedInWithOkta;
 };
 
 export const AbuseReportForm = ({

--- a/dotcom-rendering/src/discussion-rendering/components/AbuseReportForm/AbuseReportForm.tsx
+++ b/dotcom-rendering/src/discussion-rendering/components/AbuseReportForm/AbuseReportForm.tsx
@@ -4,7 +4,7 @@ import { log } from '@guardian/libs';
 import { neutral, space, textSans } from '@guardian/source-foundations';
 import { Button, SvgCross } from '@guardian/source-react-components';
 import { useEffect, useRef, useState } from 'react';
-import {
+import type {
 	SignedInWithCookies,
 	SignedInWithOkta,
 } from '../../../lib/useAuthStatus';

--- a/dotcom-rendering/src/discussion-rendering/components/Comment/Comment.stories.tsx
+++ b/dotcom-rendering/src/discussion-rendering/components/Comment/Comment.stories.tsx
@@ -1,5 +1,5 @@
 import { ArticlePillar } from '@guardian/libs';
-import type { CommentType, UserProfile } from '../../discussionTypes';
+import type { CommentType, SignedInUser } from '../../discussionTypes';
 import { Comment } from './Comment';
 
 export default { title: 'Discussion/Comment' };
@@ -103,34 +103,40 @@ const longBothReplyCommentData: CommentType = {
 	},
 };
 
-const user: UserProfile = {
-	userId: 'abc123',
-	displayName: 'Jane Smith',
-	webUrl: '',
-	apiUrl: '',
-	avatar: '',
-	secureAvatarUrl: '',
-	badge: [],
-	privateFields: {
-		canPostComment: true,
-		isPremoderated: false,
-		hasCommented: true,
+const user: SignedInUser = {
+	profile: {
+		userId: 'abc123',
+		displayName: 'Jane Smith',
+		webUrl: '',
+		apiUrl: '',
+		avatar: '',
+		secureAvatarUrl: '',
+		badge: [],
+		privateFields: {
+			canPostComment: true,
+			isPremoderated: false,
+			hasCommented: true,
+		},
 	},
+	authStatus: { kind: 'SignedInWithCookies' },
 };
 
-const staffUser: UserProfile = {
-	userId: 'abc123',
-	displayName: 'Jane Smith',
-	webUrl: '',
-	apiUrl: '',
-	avatar: '',
-	secureAvatarUrl: '',
-	badge: [{ name: 'Staff' }],
-	privateFields: {
-		canPostComment: true,
-		isPremoderated: false,
-		hasCommented: true,
+const staffUser: SignedInUser = {
+	profile: {
+		userId: 'abc123',
+		displayName: 'Jane Smith',
+		webUrl: '',
+		apiUrl: '',
+		avatar: '',
+		secureAvatarUrl: '',
+		badge: [{ name: 'Staff' }],
+		privateFields: {
+			canPostComment: true,
+			isPremoderated: false,
+			hasCommented: true,
+		},
 	},
+	authStatus: { kind: 'SignedInWithCookies' },
 };
 
 export const Root = () => (

--- a/dotcom-rendering/src/discussion-rendering/components/Comment/Comment.tsx
+++ b/dotcom-rendering/src/discussion-rendering/components/Comment/Comment.tsx
@@ -12,7 +12,7 @@ import {
 } from '@guardian/source-foundations';
 import { Button, Link, SvgIndent } from '@guardian/source-react-components';
 import { useState } from 'react';
-import type { CommentType, UserProfile } from '../../discussionTypes';
+import type { CommentType, SignedInUser } from '../../discussionTypes';
 import { pickComment, unPickComment } from '../../lib/api';
 import { createAuthenticationEventParams } from '../../lib/identity-component-event';
 import { palette } from '../../lib/palette';
@@ -30,7 +30,7 @@ import { Row } from '../Row/Row';
 import { Timestamp } from '../Timestamp/Timestamp';
 
 type Props = {
-	user?: UserProfile;
+	user?: SignedInUser;
 	comment: CommentType;
 	pillar: ArticleTheme;
 	isClosedForComments: boolean;
@@ -535,11 +535,12 @@ export const Comment = ({
 								commentId={comment.id}
 								initialCount={comment.numRecommends}
 								alreadyRecommended={false}
-								isSignedIn={!!user}
+								authStatus={user?.authStatus}
 								onRecommend={onRecommend}
 								userMadeComment={
 									!!user &&
-									user.userId === comment.userProfile.userId
+									user.profile.userId ===
+										comment.userProfile.userId
 								}
 							/>
 						)}
@@ -696,10 +697,10 @@ export const Comment = ({
 									)}
 									<Space amount={4} />
 									{/* Only staff can pick, and they cannot pick thier own comment */}
-									{user?.badge.some(
+									{user?.profile.badge.some(
 										(e) => e.name === 'Staff',
 									) &&
-										user.userId !==
+										user.profile.userId !==
 											comment.userProfile.userId && (
 											<div
 												css={[
@@ -740,7 +741,7 @@ export const Comment = ({
 									{/* You can't mute unless logged in and you can't mute yourself */}
 									{user &&
 									comment.userProfile.userId !==
-										user.userId ? (
+										user.profile.userId ? (
 										<div
 											css={[
 												buttonLinkBaseStyles,

--- a/dotcom-rendering/src/discussion-rendering/components/Comment/Comment.tsx
+++ b/dotcom-rendering/src/discussion-rendering/components/Comment/Comment.tsx
@@ -320,9 +320,10 @@ export const Comment = ({
 	const [showAbuseReportForm, setAbuseReportForm] = useState(false);
 	const toggleSetShowForm = () => setAbuseReportForm(!showAbuseReportForm);
 
-	const pick = async () => {
+	const pick = async (staffUser: SignedInUser) => {
 		setError('');
-		const response = await pickComment(comment.id);
+
+		const response = await pickComment(staffUser.authStatus, comment.id);
 		if (response.status === 'error') {
 			setError(response.message);
 		} else {
@@ -330,9 +331,9 @@ export const Comment = ({
 		}
 	};
 
-	const unPick = async () => {
+	const unPick = async (staffUser: SignedInUser) => {
 		setError('');
-		const response = await unPickComment(comment.id);
+		const response = await unPickComment(staffUser.authStatus, comment.id);
 		if (response.status === 'error') {
 			setError(response.message);
 		} else {
@@ -721,8 +722,8 @@ export const Comment = ({
 													priority="subdued"
 													onClick={
 														isHighlighted
-															? unPick
-															: pick
+															? () => unPick(user)
+															: () => pick(user)
 													}
 													data-link-name={
 														isHighlighted

--- a/dotcom-rendering/src/discussion-rendering/components/Comment/Comment.tsx
+++ b/dotcom-rendering/src/discussion-rendering/components/Comment/Comment.tsx
@@ -802,6 +802,7 @@ export const Comment = ({
 												}
 												pillar={pillar}
 												commentId={comment.id}
+												authStatus={user?.authStatus}
 											/>
 										</div>
 									)}

--- a/dotcom-rendering/src/discussion-rendering/components/CommentContainer/CommentContainer.stories.tsx
+++ b/dotcom-rendering/src/discussion-rendering/components/CommentContainer/CommentContainer.stories.tsx
@@ -1,5 +1,5 @@
 import { ArticlePillar } from '@guardian/libs';
-import type { CommentType } from '../../discussionTypes';
+import type { CommentType, SignedInUser } from '../../discussionTypes';
 import { CommentContainer } from './CommentContainer';
 
 export default { title: 'Discussion/CommentContainer' };
@@ -132,19 +132,22 @@ const commentDataWithLongThread: CommentType = {
 	},
 };
 
-const aUser = {
-	userId: 'abc123',
-	displayName: 'Jane Smith',
-	webUrl: '',
-	apiUrl: '',
-	avatar: '',
-	secureAvatarUrl: '',
-	badge: [],
-	privateFields: {
-		canPostComment: true,
-		isPremoderated: false,
-		hasCommented: true,
+const aUser: SignedInUser = {
+	profile: {
+		userId: 'abc123',
+		displayName: 'Jane Smith',
+		webUrl: '',
+		apiUrl: '',
+		avatar: '',
+		secureAvatarUrl: '',
+		badge: [],
+		privateFields: {
+			canPostComment: true,
+			isPremoderated: false,
+			hasCommented: true,
+		},
 	},
+	authStatus: { kind: 'SignedInWithCookies' },
 };
 
 const commentDataThreaded: CommentType = {

--- a/dotcom-rendering/src/discussion-rendering/components/CommentContainer/CommentContainer.test.tsx
+++ b/dotcom-rendering/src/discussion-rendering/components/CommentContainer/CommentContainer.test.tsx
@@ -3,7 +3,7 @@ import { ArticlePillar } from '@guardian/libs';
 import { fireEvent, render, waitFor } from '@testing-library/react';
 import { comment } from '../../../../fixtures/manual/comment';
 import { mockedMessageID, mockRESTCalls } from '../../../lib/mockRESTCalls';
-import type { CommentType } from '../../discussionTypes';
+import type { CommentType, SignedInUser } from '../../discussionTypes';
 import { CommentContainer } from './CommentContainer';
 
 mockRESTCalls();
@@ -21,19 +21,22 @@ const commentWithoutReply: CommentType = {
 	responses: [],
 };
 
-const aUser = {
-	userId: 'abc123',
-	displayName: 'Jane Smith',
-	webUrl: '',
-	apiUrl: '',
-	avatar: '',
-	secureAvatarUrl: '',
-	badge: [],
-	privateFields: {
-		canPostComment: true,
-		isPremoderated: false,
-		hasCommented: true,
+const aUser: SignedInUser = {
+	profile: {
+		userId: 'abc123',
+		displayName: 'Jane Smith',
+		webUrl: '',
+		apiUrl: '',
+		avatar: '',
+		secureAvatarUrl: '',
+		badge: [],
+		privateFields: {
+			canPostComment: true,
+			isPremoderated: false,
+			hasCommented: true,
+		},
 	},
+	authStatus: { kind: 'SignedInWithCookies' },
 };
 
 describe('CommentContainer', () => {

--- a/dotcom-rendering/src/discussion-rendering/components/CommentContainer/CommentContainer.tsx
+++ b/dotcom-rendering/src/discussion-rendering/components/CommentContainer/CommentContainer.tsx
@@ -6,8 +6,8 @@ import { useEffect, useState } from 'react';
 import type {
 	CommentResponse,
 	CommentType,
+	SignedInUser,
 	ThreadsType,
-	UserProfile,
 } from '../../discussionTypes';
 import { getMoreResponses } from '../../lib/api';
 import { Comment } from '../Comment/Comment';
@@ -20,7 +20,7 @@ type Props = {
 	pillar: ArticleTheme;
 	isClosedForComments: boolean;
 	shortUrl: string;
-	user?: UserProfile;
+	user?: SignedInUser;
 	threads: ThreadsType;
 	commentBeingRepliedTo?: CommentType;
 	setCommentBeingRepliedTo: (commentBeingRepliedTo?: CommentType) => void;

--- a/dotcom-rendering/src/discussion-rendering/components/CommentForm/CommentForm.stories.tsx
+++ b/dotcom-rendering/src/discussion-rendering/components/CommentForm/CommentForm.stories.tsx
@@ -1,24 +1,27 @@
 import { ArticlePillar } from '@guardian/libs';
-import type { CommentType } from '../../discussionTypes';
+import type { CommentType, SignedInUser } from '../../discussionTypes';
 import { CommentForm } from './CommentForm';
 
 export default { component: CommentForm, title: 'Discussion/CommentForm' };
 
 const shortUrl = '/p/39f5z';
 
-const aUser = {
-	userId: 'abc123',
-	displayName: 'Jane Smith',
-	webUrl: '',
-	apiUrl: '',
-	avatar: '',
-	secureAvatarUrl: '',
-	badge: [],
-	privateFields: {
-		canPostComment: true,
-		isPremoderated: false,
-		hasCommented: true,
+const aUser: SignedInUser = {
+	profile: {
+		userId: 'abc123',
+		displayName: 'Jane Smith',
+		webUrl: '',
+		apiUrl: '',
+		avatar: '',
+		secureAvatarUrl: '',
+		badge: [],
+		privateFields: {
+			canPostComment: true,
+			isPremoderated: false,
+			hasCommented: true,
+		},
 	},
+	authStatus: { kind: 'SignedInWithCookies' },
 };
 
 const aComment: CommentType = {
@@ -88,9 +91,13 @@ export const Premoderated = () => (
 		pillar={ArticlePillar.Opinion}
 		user={{
 			...aUser,
-			privateFields: {
-				...aUser.privateFields,
-				isPremoderated: true,
+			profile: {
+				...aUser.profile,
+				privateFields: {
+					canPostComment: true,
+					isPremoderated: true,
+					hasCommented: true,
+				},
 			},
 		}}
 		onAddComment={(comment) => {}}

--- a/dotcom-rendering/src/discussion-rendering/components/CommentForm/CommentForm.tsx
+++ b/dotcom-rendering/src/discussion-rendering/components/CommentForm/CommentForm.tsx
@@ -354,7 +354,7 @@ export const CommentForm = ({
 			return;
 		}
 
-		const response = await addUserName(userName);
+		const response = await addUserName(user.authStatus, userName);
 		if (response.status === 'ok') {
 			// If we are able to submit userName we should continue with submitting comment
 			void submitForm();

--- a/dotcom-rendering/src/discussion-rendering/components/CommentForm/CommentForm.tsx
+++ b/dotcom-rendering/src/discussion-rendering/components/CommentForm/CommentForm.tsx
@@ -5,7 +5,7 @@ import { useEffect, useRef, useState } from 'react';
 import type {
 	CommentResponse,
 	CommentType,
-	UserProfile,
+	SignedInUser,
 } from '../../discussionTypes';
 import {
 	addUserName,
@@ -22,7 +22,7 @@ import { Row } from '../Row/Row';
 type Props = {
 	shortUrl: string;
 	pillar: ArticleTheme;
-	user: UserProfile;
+	user: SignedInUser;
 	onAddComment: (response: CommentType) => void;
 	setCommentBeingRepliedTo?: () => void;
 	commentBeingRepliedTo?: CommentType;
@@ -259,8 +259,8 @@ export const CommentForm = ({
 		setInfo('');
 
 		if (body) {
-			const comment = onComment ?? defaultComment;
-			const reply = onReply ?? defaultReply;
+			const comment = onComment ?? defaultComment(user.authStatus);
+			const reply = onReply ?? defaultReply(user.authStatus);
 			const response: CommentResponse = commentBeingRepliedTo
 				? await reply(shortUrl, body, commentBeingRepliedTo.id)
 				: await comment(shortUrl, body);
@@ -336,7 +336,7 @@ export const CommentForm = ({
 						// it is returned as a string, so we need to cast to an number to be compatable
 						parseInt(response.message),
 						body,
-						user,
+						user.profile,
 						commentBeingRepliedTo,
 					),
 				);
@@ -410,7 +410,7 @@ export const CommentForm = ({
 							.
 						</p>
 
-						{user.privateFields?.isPremoderated && (
+						{user.profile.privateFields?.isPremoderated && (
 							<p css={[errorTextStyles, linkStyles]}>
 								Your comments are currently being pre-moderated
 								(

--- a/dotcom-rendering/src/discussion-rendering/components/RecommendationCount/RecommendationCount.stories.tsx
+++ b/dotcom-rendering/src/discussion-rendering/components/RecommendationCount/RecommendationCount.stories.tsx
@@ -1,13 +1,16 @@
+import type { SignedInWithCookies } from '../../../lib/useAuthStatus';
 import { RecommendationCount } from './RecommendationCount';
 
 export default { title: 'Discussion/RecommendationCount' };
+
+const signedInStatus: SignedInWithCookies = { kind: 'SignedInWithCookies' };
 
 export const NeverRecomended = () => (
 	<RecommendationCount
 		commentId={123}
 		initialCount={383}
 		alreadyRecommended={false}
-		isSignedIn={true}
+		authStatus={signedInStatus}
 		userMadeComment={false}
 	/>
 );
@@ -17,7 +20,7 @@ export const AlreadyRecomended = () => (
 		commentId={123}
 		initialCount={83}
 		alreadyRecommended={true}
-		isSignedIn={true}
+		authStatus={signedInStatus}
 		userMadeComment={false}
 	/>
 );
@@ -27,7 +30,6 @@ export const NotSignedIn = () => (
 		commentId={123}
 		initialCount={83}
 		alreadyRecommended={false}
-		isSignedIn={false}
 		userMadeComment={false}
 	/>
 );
@@ -37,7 +39,7 @@ export const OwnPost = () => (
 		commentId={123}
 		initialCount={83}
 		alreadyRecommended={false}
-		isSignedIn={false}
+		authStatus={signedInStatus}
 		userMadeComment={true}
 	/>
 );

--- a/dotcom-rendering/src/discussion-rendering/components/TopPick/TopPick.stories.tsx
+++ b/dotcom-rendering/src/discussion-rendering/components/TopPick/TopPick.stories.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import { ArticlePillar } from '@guardian/libs';
+import type { SignedInWithCookies } from '../../../lib/useAuthStatus';
 import type { CommentType } from '../../discussionTypes';
 import { TopPick } from './TopPick';
 
@@ -70,6 +71,8 @@ const contributorCommentWithShortBody: CommentType = {
 	body: "<p>It's still there FrankDeFord - and thanks, I will pass that on</p>",
 };
 
+const signedInStatus: SignedInWithCookies = { kind: 'SignedInWithCookies' };
+
 export const LongPick = () => (
 	<div
 		css={css`
@@ -80,7 +83,6 @@ export const LongPick = () => (
 		<TopPick
 			pillar={ArticlePillar.News}
 			comment={comment}
-			isSignedIn={false}
 			userMadeComment={false}
 			onPermalinkClick={() => {}}
 		/>
@@ -98,7 +100,7 @@ export const ShortPick = () => (
 		<TopPick
 			pillar={ArticlePillar.Opinion}
 			comment={commentWithShortBody}
-			isSignedIn={true}
+			authStatus={signedInStatus}
 			userMadeComment={false}
 			onPermalinkClick={() => {}}
 		/>
@@ -116,7 +118,6 @@ export const LongPickContributor = () => (
 		<TopPick
 			pillar={ArticlePillar.News}
 			comment={commentContributor}
-			isSignedIn={false}
 			userMadeComment={false}
 			onPermalinkClick={() => {}}
 		/>
@@ -134,7 +135,7 @@ export const ShortPickContributor = () => (
 		<TopPick
 			pillar={ArticlePillar.Opinion}
 			comment={contributorCommentWithShortBody}
-			isSignedIn={true}
+			authStatus={signedInStatus}
 			userMadeComment={false}
 			onPermalinkClick={() => {}}
 		/>

--- a/dotcom-rendering/src/discussion-rendering/components/TopPick/TopPick.tsx
+++ b/dotcom-rendering/src/discussion-rendering/components/TopPick/TopPick.tsx
@@ -8,6 +8,10 @@ import {
 	textSans,
 } from '@guardian/source-foundations';
 import { Link } from '@guardian/source-react-components';
+import type {
+	SignedInWithCookies,
+	SignedInWithOkta,
+} from '../../../lib/useAuthStatus';
 import type { CommentType } from '../../discussionTypes';
 import { palette } from '../../lib/palette';
 import { pillarToString } from '../../lib/pillarToString';
@@ -21,7 +25,7 @@ import { Timestamp } from '../Timestamp/Timestamp';
 type Props = {
 	pillar: ArticleTheme;
 	comment: CommentType;
-	isSignedIn: boolean;
+	authStatus?: SignedInWithCookies | SignedInWithOkta;
 	userMadeComment: boolean;
 	onPermalinkClick: (commentId: number) => void;
 	onRecommend?: (commentId: number) => Promise<boolean>;
@@ -163,7 +167,7 @@ const truncateText = (input: string, limit: number) => {
 export const TopPick = ({
 	pillar,
 	comment,
-	isSignedIn,
+	authStatus,
 	userMadeComment,
 	onPermalinkClick,
 	onRecommend,
@@ -241,7 +245,7 @@ export const TopPick = ({
 					commentId={comment.id}
 					initialCount={comment.numRecommends}
 					alreadyRecommended={false}
-					isSignedIn={isSignedIn}
+					authStatus={authStatus}
 					userMadeComment={userMadeComment}
 					onRecommend={onRecommend}
 				/>

--- a/dotcom-rendering/src/discussion-rendering/components/TopPicks/TopPicks.stories.tsx
+++ b/dotcom-rendering/src/discussion-rendering/components/TopPicks/TopPicks.stories.tsx
@@ -1,4 +1,5 @@
 import { ArticlePillar } from '@guardian/libs';
+import type { SignedInWithCookies } from '../../../lib/useAuthStatus';
 import type { CommentType } from '../../discussionTypes';
 import { TopPicks } from './TopPicks';
 
@@ -48,12 +49,13 @@ const commentWithShortBody: CommentType = {
 	...comment,
 	body: "<p>It's still there FrankDeFord - and thanks, I will pass that on</p>",
 };
+const signedInStatus: SignedInWithCookies = { kind: 'SignedInWithCookies' };
 
 export const SingleComment = () => (
 	<TopPicks
 		pillar={ArticlePillar.News}
 		comments={[commentWithShortBody]}
-		isSignedIn={true}
+		authStatus={signedInStatus}
 		onPermalinkClick={() => {}}
 	/>
 );
@@ -68,7 +70,7 @@ export const MulitColumn = () => (
 			commentWithShortBody,
 			commentWithShortBody,
 		]}
-		isSignedIn={true}
+		authStatus={signedInStatus}
 		onPermalinkClick={() => {}}
 	/>
 );
@@ -83,7 +85,7 @@ export const SingleColumn = () => (
 			commentWithShortBody,
 			commentWithShortBody,
 		]}
-		isSignedIn={true}
+		authStatus={signedInStatus}
 		onPermalinkClick={() => {}}
 	/>
 );

--- a/dotcom-rendering/src/discussion-rendering/components/TopPicks/TopPicks.tsx
+++ b/dotcom-rendering/src/discussion-rendering/components/TopPicks/TopPicks.tsx
@@ -1,14 +1,18 @@
 import { css } from '@emotion/react';
-import { ArticleTheme } from '@guardian/libs';
+import type { ArticleTheme } from '@guardian/libs';
 import { from, until } from '@guardian/source-foundations';
-import { CommentType, UserProfile } from '../../discussionTypes';
+import type {
+	SignedInWithCookies,
+	SignedInWithOkta,
+} from '../../../lib/useAuthStatus';
+import type { CommentType, UserProfile } from '../../discussionTypes';
 import { TopPick } from '../TopPick/TopPick';
 
 type Props = {
 	pillar: ArticleTheme;
 	user?: UserProfile;
 	comments: CommentType[];
-	isSignedIn: boolean;
+	authStatus?: SignedInWithCookies | SignedInWithOkta;
 	onPermalinkClick: (commentId: number) => void;
 	onRecommend?: (commentId: number) => Promise<boolean>;
 };
@@ -50,7 +54,7 @@ export const TopPicks = ({
 	pillar,
 	user,
 	comments,
-	isSignedIn,
+	authStatus,
 	onPermalinkClick,
 	onRecommend,
 }: Props) => {
@@ -70,7 +74,7 @@ export const TopPicks = ({
 							key={comment.id}
 							pillar={pillar}
 							comment={comment}
-							isSignedIn={isSignedIn}
+							authStatus={authStatus}
 							userMadeComment={
 								!!user &&
 								user.userId === comment.userProfile.userId
@@ -86,7 +90,7 @@ export const TopPicks = ({
 							key={comment.id}
 							pillar={pillar}
 							comment={comment}
-							isSignedIn={isSignedIn}
+							authStatus={authStatus}
 							userMadeComment={
 								!!user &&
 								user.userId === comment.userProfile.userId
@@ -103,7 +107,7 @@ export const TopPicks = ({
 						key={comment.id}
 						pillar={pillar}
 						comment={comment}
-						isSignedIn={isSignedIn}
+						authStatus={authStatus}
 						userMadeComment={
 							!!user && user.userId === comment.userProfile.userId
 						}

--- a/dotcom-rendering/src/discussion-rendering/discussionTypes.ts
+++ b/dotcom-rendering/src/discussion-rendering/discussionTypes.ts
@@ -1,3 +1,8 @@
+import type {
+	SignedInWithCookies,
+	SignedInWithOkta,
+} from '../lib/useAuthStatus';
+
 export type CAPIPillar =
 	| 'news'
 	| 'sport'
@@ -117,6 +122,11 @@ export interface FilterOptions {
 	pageSize: PageSizeType;
 	threads: ThreadsType;
 }
+
+export type SignedInUser = {
+	profile: UserProfile;
+	authStatus: SignedInWithCookies | SignedInWithOkta;
+};
 
 export interface UserProfile {
 	userId: string;

--- a/dotcom-rendering/src/discussion-rendering/lib/api.tsx
+++ b/dotcom-rendering/src/discussion-rendering/lib/api.tsx
@@ -276,12 +276,18 @@ export const recommend =
 	};
 
 //todo: adjust this when the endpoint is ready
-export const addUserName = (userName: string): Promise<UserNameResponse> => {
-	const url = options.idApiUrl + `/user/me` + objAsParams(defaultParams);
+//is it just adding /username to the /user/me path? https://github.com/guardian/identity/pull/2418
+export const addUserName = (
+	authStatus: SignedInWithCookies | SignedInWithOkta,
+	userName: string,
+): Promise<UserNameResponse> => {
+	// const url = options.idApiUrl + `/user/me` + objAsParams(defaultParams);
+	const url =
+		options.idApiUrl + `/user/me/username` + objAsParams(defaultParams);
+	const requestOptions = getOptionsHeadersWithOkta(authStatus);
 
 	return fetch(url, {
 		method: 'POST',
-		credentials: 'include',
 		body: JSON.stringify({
 			publicFields: {
 				username: userName,
@@ -290,30 +296,44 @@ export const addUserName = (userName: string): Promise<UserNameResponse> => {
 		}),
 		headers: {
 			'Content-Type': 'application/json',
+			...(requestOptions.headers !== undefined
+				? requestOptions.headers
+				: {}),
 		},
+		credentials: requestOptions.credentials,
 	})
 		.then((resp) => resp.json())
 		.catch((error) => console.error(`Error fetching ${url}`, error));
 };
 
-export const pickComment = (commentId: number): Promise<CommentResponse> => {
+export const pickComment = (
+	authStatus: SignedInWithCookies | SignedInWithOkta,
+	commentId: number,
+): Promise<CommentResponse> => {
 	const url =
 		joinUrl(options.baseUrl, 'comment', commentId.toString(), 'highlight') +
 		objAsParams(defaultParams);
 
+	const requestOptions = getOptionsHeadersWithOkta(authStatus);
 	return fetch(url, {
 		method: 'POST',
 		headers: {
 			'Content-Type': 'application/x-www-form-urlencoded',
 			...options.headers,
+			...(requestOptions.headers !== undefined
+				? requestOptions.headers
+				: {}),
 		},
-		credentials: 'include',
+		credentials: requestOptions.credentials,
 	})
 		.then((resp) => resp.json())
 		.catch((error) => console.error(`Error fetching ${url}`, error));
 };
 
-export const unPickComment = (commentId: number): Promise<CommentResponse> => {
+export const unPickComment = (
+	authStatus: SignedInWithCookies | SignedInWithOkta,
+	commentId: number,
+): Promise<CommentResponse> => {
 	const url =
 		joinUrl(
 			options.baseUrl,
@@ -321,14 +341,18 @@ export const unPickComment = (commentId: number): Promise<CommentResponse> => {
 			commentId.toString(),
 			'unhighlight',
 		) + objAsParams(defaultParams);
+	const requestOptions = getOptionsHeadersWithOkta(authStatus);
 
 	return fetch(url, {
 		method: 'POST',
 		headers: {
 			'Content-Type': 'application/x-www-form-urlencoded',
 			...options.headers,
+			...(requestOptions.headers !== undefined
+				? requestOptions.headers
+				: {}),
 		},
-		credentials: 'include',
+		credentials: requestOptions.credentials,
 	})
 		.then((resp) => resp.json())
 		.catch((error) => console.error(`Error fetching ${url}`, error));

--- a/dotcom-rendering/src/discussion-rendering/lib/api.tsx
+++ b/dotcom-rendering/src/discussion-rendering/lib/api.tsx
@@ -281,15 +281,12 @@ export const recommend =
 		}).then((resp) => resp.ok);
 	};
 
-//todo: adjust this when the endpoint is ready
-//is it just adding /username to the /user/me path? https://github.com/guardian/identity/pull/2418
 export const addUserName = (
 	authStatus: SignedInWithCookies | SignedInWithOkta,
 	userName: string,
 ): Promise<UserNameResponse> => {
-	// const url = options.idApiUrl + `/user/me` + objAsParams(defaultParams);
 	const url =
-		options.idApiUrl + `/user/me/username` + objAsParams(defaultParams);
+		options.idApiUrl + `/user/me/username`
 	const authOptions = getOptionsHeadersWithOkta(authStatus);
 
 	return fetch(url, {

--- a/dotcom-rendering/src/discussion-rendering/lib/api.tsx
+++ b/dotcom-rendering/src/discussion-rendering/lib/api.tsx
@@ -143,7 +143,7 @@ export const comment =
 		const data = new URLSearchParams();
 		data.append('body', body);
 
-		const requestOptions = getOptionsHeadersWithOkta(authStatus);
+		const authOptions = getOptionsHeadersWithOkta(authStatus);
 
 		return fetch(url, {
 			method: 'POST',
@@ -151,11 +151,11 @@ export const comment =
 			headers: {
 				'Content-Type': 'application/x-www-form-urlencoded',
 				...options.headers,
-				...(requestOptions.headers !== undefined
-					? requestOptions.headers
+				...(authOptions.headers !== undefined
+					? authOptions.headers
 					: {}),
 			},
-			credentials: requestOptions.credentials,
+			credentials: authOptions.credentials,
 		}).then((resp) => resp.json());
 	};
 
@@ -177,7 +177,7 @@ export const reply =
 			) + objAsParams(defaultParams);
 		const data = new URLSearchParams();
 		data.append('body', body);
-		const requestOptions = getOptionsHeadersWithOkta(authStatus);
+		const authOptions = getOptionsHeadersWithOkta(authStatus);
 
 		return fetch(url, {
 			method: 'POST',
@@ -185,11 +185,11 @@ export const reply =
 			headers: {
 				'Content-Type': 'application/x-www-form-urlencoded',
 				...options.headers,
-				...(requestOptions.headers !== undefined
-					? requestOptions.headers
+				...(authOptions.headers !== undefined
+					? authOptions.headers
 					: {}),
 			},
-			credentials: requestOptions.credentials,
+			credentials: authOptions.credentials,
 		}).then((resp) => resp.json());
 	};
 
@@ -214,17 +214,18 @@ export const getPicks = (
 	);
 };
 
-//todo - at some point in the future: would be nice to have a signed in with user, signed in anonymous and signed out options
 export const reportAbuse = ({
 	commentId,
 	categoryId,
 	email,
 	reason,
+	authStatus,
 }: {
 	commentId: number;
 	categoryId: number;
 	reason?: string;
 	email?: string;
+	authStatus?: SignedInWithCookies | SignedInWithOkta;
 }): Promise<CommentResponse> => {
 	const url =
 		joinUrl(
@@ -239,14 +240,19 @@ export const reportAbuse = ({
 	email && data.append('email', email.toString());
 	reason && data.append('reason', reason);
 
+	const authOptions = authStatus
+		? getOptionsHeadersWithOkta(authStatus)
+		: undefined;
+
 	return fetch(url, {
 		method: 'POST',
 		body: data.toString(),
-		credentials: 'include',
 		headers: {
 			'Content-Type': 'application/x-www-form-urlencoded',
 			...options.headers,
+			...(authOptions?.headers !== undefined ? authOptions.headers : {}),
 		},
+		credentials: authOptions?.credentials,
 	}).then((resp) => resp.json());
 };
 
@@ -261,17 +267,17 @@ export const recommend =
 				'recommend',
 			) + objAsParams(defaultParams);
 
-		const requestOptions = getOptionsHeadersWithOkta(authStatus);
+		const authOptions = getOptionsHeadersWithOkta(authStatus);
 
 		return fetch(url, {
 			method: 'POST',
 			headers: {
 				...options.headers,
-				...(requestOptions.headers !== undefined
-					? requestOptions.headers
+				...(authOptions.headers !== undefined
+					? authOptions.headers
 					: {}),
 			},
-			credentials: requestOptions.credentials,
+			credentials: authOptions.credentials,
 		}).then((resp) => resp.ok);
 	};
 
@@ -284,7 +290,7 @@ export const addUserName = (
 	// const url = options.idApiUrl + `/user/me` + objAsParams(defaultParams);
 	const url =
 		options.idApiUrl + `/user/me/username` + objAsParams(defaultParams);
-	const requestOptions = getOptionsHeadersWithOkta(authStatus);
+	const authOptions = getOptionsHeadersWithOkta(authStatus);
 
 	return fetch(url, {
 		method: 'POST',
@@ -296,11 +302,9 @@ export const addUserName = (
 		}),
 		headers: {
 			'Content-Type': 'application/json',
-			...(requestOptions.headers !== undefined
-				? requestOptions.headers
-				: {}),
+			...(authOptions.headers !== undefined ? authOptions.headers : {}),
 		},
-		credentials: requestOptions.credentials,
+		credentials: authOptions.credentials,
 	})
 		.then((resp) => resp.json())
 		.catch((error) => console.error(`Error fetching ${url}`, error));
@@ -314,17 +318,15 @@ export const pickComment = (
 		joinUrl(options.baseUrl, 'comment', commentId.toString(), 'highlight') +
 		objAsParams(defaultParams);
 
-	const requestOptions = getOptionsHeadersWithOkta(authStatus);
+	const authOptions = getOptionsHeadersWithOkta(authStatus);
 	return fetch(url, {
 		method: 'POST',
 		headers: {
 			'Content-Type': 'application/x-www-form-urlencoded',
 			...options.headers,
-			...(requestOptions.headers !== undefined
-				? requestOptions.headers
-				: {}),
+			...(authOptions.headers !== undefined ? authOptions.headers : {}),
 		},
-		credentials: requestOptions.credentials,
+		credentials: authOptions.credentials,
 	})
 		.then((resp) => resp.json())
 		.catch((error) => console.error(`Error fetching ${url}`, error));
@@ -341,18 +343,16 @@ export const unPickComment = (
 			commentId.toString(),
 			'unhighlight',
 		) + objAsParams(defaultParams);
-	const requestOptions = getOptionsHeadersWithOkta(authStatus);
+	const authOptions = getOptionsHeadersWithOkta(authStatus);
 
 	return fetch(url, {
 		method: 'POST',
 		headers: {
 			'Content-Type': 'application/x-www-form-urlencoded',
 			...options.headers,
-			...(requestOptions.headers !== undefined
-				? requestOptions.headers
-				: {}),
+			...(authOptions.headers !== undefined ? authOptions.headers : {}),
 		},
-		credentials: requestOptions.credentials,
+		credentials: authOptions.credentials,
 	})
 		.then((resp) => resp.json())
 		.catch((error) => console.error(`Error fetching ${url}`, error));

--- a/dotcom-rendering/src/discussion-rendering/lib/api.tsx
+++ b/dotcom-rendering/src/discussion-rendering/lib/api.tsx
@@ -285,8 +285,7 @@ export const addUserName = (
 	authStatus: SignedInWithCookies | SignedInWithOkta,
 	userName: string,
 ): Promise<UserNameResponse> => {
-	const url =
-		options.idApiUrl + `/user/me/username`
+	const url = options.idApiUrl + `/user/me/username`;
 	const authOptions = getOptionsHeadersWithOkta(authStatus);
 
 	return fetch(url, {


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

Co-authored-by: @JamieB-gu 

## What does this change?

Following on from previous Okta/Identity-auth PRs, specifically the [latest refactor ](https://github.com/guardian/dotcom-rendering/pull/8119) and the [discussion-rendering into DCR move](https://github.com/guardian/dotcom-rendering/pull/8057), this enables various API calls in discussion-rendering to use Okta access/ID tokens where necessary when in the Okta experiment, as an alternative to the current method of the request being made with the `credentials: include` property. 

The API calls now take into account an `authStatus` parameter. This is a property of the `SignedInUser` type, which expands on the UserProfile type that exists in discussionTypes.ts. `SignedInUser` is now the type of the [`user` prop](https://github.com/guardian/dotcom-rendering/pull/8211/files#diff-0521f1dc80ca434dfbd843bbe156ffe6e0ba17272a9e9d27dc1b89281aedfb64R23) that gets passed down to discussion-rendering from the Discussion.tsx component in DCR. From there, the `authStatus` gets passed down to relevant components, e.g. [CommentForm.tsx,](https://github.com/guardian/dotcom-rendering/pull/8211/files#diff-e30f7d20b95c377cd00201c31c3f26e48c427a728325d0b187276292e6d18ec6R262) which then trigger the functions defined in [api.tsx](https://github.com/guardian/dotcom-rendering/pull/8211/files#diff-ae460a81df60e9adb882cddbba675359ef3ef98f869a762f3598024fd1fa55a4R137)

The functions which have been updated are:

- comment
- reply
- recommend
- pick and unpick
- reportAbuse
- addUserName

## Why?

This is the last piece for the Okta/DCR development work - next step is to migrate frontend. 