### PR TITLE
Fix HTML boolean attribute `clientOnly`

### DIFF
--- a/dotcom-rendering/src/client/islands/doHydration.tsx
+++ b/dotcom-rendering/src/client/islands/doHydration.tsx
@@ -39,9 +39,7 @@ export const doHydration = async (
 		.then((module) => {
 			/** The duration of importing the module for this island */
 			const importDuration = importEnd();
-			const clientOnly =
-				element.hasAttribute('clientonly') &&
-				element.getAttribute('clientonly') !== 'false';
+			const clientOnly = element.hasAttribute('clientonly');
 
 			const { start: islandStart, end: islandEnd } = initPerf(
 				`island-${name}`,

--- a/dotcom-rendering/src/components/Island.tsx
+++ b/dotcom-rendering/src/components/Island.tsx
@@ -151,6 +151,6 @@ export const Island = ({
  */
 export const islandNoscriptStyles = `
 <style>
-	gu-island[clientOnly=true] { display: none; }
+	gu-island[clientOnly] { display: none; }
 </style>
 `;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Adjusts [boolean HTML attribute](https://developer.mozilla.org/en-US/docs/Glossary/Boolean/HTML) `clientOnly` to rely on presence to determine value.

Correclty hides client-only islands if there is no JavaScript running.

## Why?

Follow-up on #7657 & #6233

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/76776/1f99a1f2-b9d9-474d-8b6c-c3b7179173bc
[after]: https://github.com/guardian/dotcom-rendering/assets/76776/e9219655-877e-413d-8562-c61d4f828d89