### PR TITLE
Show timestamps on onwards content

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -92,6 +92,7 @@ export type Props = {
 	isExternalLink: boolean;
 	slideshowImages?: DCRSlideshowImage[];
 	showLivePlayable?: boolean;
+	onwardsSource?: string;
 };
 
 const StarRatingComponent = ({
@@ -276,6 +277,7 @@ export const Card = ({
 	isExternalLink,
 	slideshowImages,
 	showLivePlayable = false,
+	onwardsSource,
 }: Props) => {
 	const palette = decidePalette(format, containerPalette);
 
@@ -301,9 +303,10 @@ export const Card = ({
 				containerPalette={containerPalette}
 				displayLines={displayLines}
 				age={
-					showAge &&
-					webPublicationDate &&
-					isWithinTwelveHours(webPublicationDate) ? (
+					(!!onwardsSource && webPublicationDate) ||
+					(showAge &&
+						webPublicationDate &&
+						isWithinTwelveHours(webPublicationDate)) ? (
 						<CardAge
 							format={format}
 							containerPalette={containerPalette}

--- a/dotcom-rendering/src/components/Carousel.importable.tsx
+++ b/dotcom-rendering/src/components/Carousel.importable.tsx
@@ -435,6 +435,7 @@ type CarouselCardProps = {
 	branding?: Branding;
 	mainMedia?: MainMedia;
 	verticalDividerColour?: string;
+	onwardsSource?: string;
 };
 
 const CarouselCard = ({
@@ -450,6 +451,7 @@ const CarouselCard = ({
 	branding,
 	mainMedia,
 	verticalDividerColour,
+	onwardsSource,
 }: CarouselCardProps) => (
 	<LI
 		percentage="25%"
@@ -478,6 +480,7 @@ const CarouselCard = ({
 			isExternalLink={false}
 			mainMedia={mainMedia}
 			videoSize="too small to play: 479px or less"
+			onwardsSource={onwardsSource}
 		/>
 	</LI>
 );
@@ -1004,6 +1007,7 @@ export const Carousel = ({
 								verticalDividerColour={
 									carouselColours.borderColour
 								}
+								onwardsSource={onwardsSource}
 							/>
 						);
 					})}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Pass onwardsSource prop to enable showing age on onwards section
## Why?
This is the desired behaviour
## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/110032454/f8f9a029-d258-4833-a7e1-e36141cee0b2
[after]: https://github.com/guardian/dotcom-rendering/assets/110032454/ef24abbc-50d8-455f-a8bc-bdb6fcae9e31

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://github.com/guardian/dotcom-rendering/assets/110032454/f8f9a029-d258-4833-a7e1-e36141cee0b2
[after2]: https://github.com/guardian/dotcom-rendering/assets/110032454/ef24abbc-50d8-455f-a8bc-bdb6fcae9e31
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
