### PR TITLE
use `StorybookConfig` type from `@storybook/react-webpack5`

### DIFF
--- a/dotcom-rendering/.storybook/main.js
+++ b/dotcom-rendering/.storybook/main.js
@@ -8,7 +8,7 @@ const {
 // Generate dynamic Card and Layout stories
 require('../scripts/gen-stories/gen-stories');
 
-/** @type {import("@storybook/react/types").StorybookConfig} */
+/** @type {import("@storybook/react-webpack5").StorybookConfig} */
 module.exports = {
 	features: {
 		// used in composition


### PR DESCRIPTION
The type for the storybook config object should be imported from the package given in the framework name.

Previously, the config object had type `any`.

| Before | After |
|--------|--------|
| <img width="377" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/705427/a0054b98-8a9f-45de-9764-7e43e036dc5f"> | <img width="1029" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/705427/eaae6f99-b672-4a86-bfbc-d6ab393c712c"> |