### PR TITLE
Rename sectionName to sectionId

### DIFF
--- a/dotcom-rendering/src/components/ArticleBody.tsx
+++ b/dotcom-rendering/src/components/ArticleBody.tsx
@@ -26,13 +26,12 @@ type Props = {
 	ajaxUrl: string;
 	isAdFreeUser: boolean;
 	switches: Switches;
-	section: string;
+	sectionId: string;
 	shouldHideReaderRevenue: boolean;
 	tags: TagType[];
 	isPaidContent: boolean;
 	contributionsServiceUrl: string;
 	contentType: string;
-	sectionName: string;
 	keywordIds: string;
 	isPreview?: boolean;
 	idUrl: string;
@@ -128,13 +127,12 @@ export const ArticleBody = ({
 	ajaxUrl,
 	switches,
 	isAdFreeUser,
-	section,
+	sectionId,
 	shouldHideReaderRevenue,
 	tags,
 	isPaidContent,
 	contributionsServiceUrl,
 	contentType,
-	sectionName,
 	isPreview,
 	idUrl,
 	isSensitive,
@@ -189,7 +187,7 @@ export const ArticleBody = ({
 					isAdFreeUser={isAdFreeUser}
 					isSensitive={isSensitive}
 					isLiveUpdate={false}
-					section={section}
+					sectionId={sectionId}
 					shouldHideReaderRevenue={shouldHideReaderRevenue}
 					tags={tags}
 					isPaidContent={isPaidContent}
@@ -241,7 +239,7 @@ export const ArticleBody = ({
 					webTitle={webTitle}
 					ajaxUrl={ajaxUrl}
 					contentType={contentType}
-					sectionName={sectionName}
+					sectionId={sectionId}
 					tags={tags}
 					isPaidContent={isPaidContent}
 					isPreview={isPreview}

--- a/dotcom-rendering/src/components/FrontMostViewed.tsx
+++ b/dotcom-rendering/src/components/FrontMostViewed.tsx
@@ -75,7 +75,7 @@ export const FrontMostViewed = ({
 				<Island deferUntil="visible">
 					<MostViewedFooter
 						tabs={tabs}
-						sectionName="Most viewed"
+						sectionId="Most viewed"
 						mostCommented={mostCommented}
 						mostShared={mostShared}
 						hasPageSkin={hasPageSkin}
@@ -91,7 +91,7 @@ export const FrontMostViewed = ({
 			) : (
 				<MostViewedFooter
 					tabs={tabs}
-					sectionName="Most viewed"
+					sectionId="Most viewed"
 					mostCommented={mostCommented}
 					mostShared={mostShared}
 					hasPageSkin={hasPageSkin}

--- a/dotcom-rendering/src/components/LiveBlogEpic.importable.tsx
+++ b/dotcom-rendering/src/components/LiveBlogEpic.importable.tsx
@@ -21,7 +21,7 @@ import { useSignedInStatus } from '../lib/useSignedInStatus';
 import type { TagType } from '../types/tag';
 
 type Props = {
-	section: string;
+	sectionId: string;
 	shouldHideReaderRevenue: boolean;
 	isPaidContent: boolean;
 	tags: TagType[];
@@ -87,14 +87,14 @@ const useEpic = ({ url, name }: { url: string; name: string }) => {
  */
 const usePayload = ({
 	shouldHideReaderRevenue,
-	section,
+	sectionId,
 	isPaidContent,
 	tags,
 	pageId,
 	keywordIds,
 }: {
 	shouldHideReaderRevenue: boolean;
-	section: string;
+	sectionId: string;
 	isPaidContent: boolean;
 	tags: TagType[];
 	pageId: string;
@@ -122,7 +122,7 @@ const usePayload = ({
 		},
 		targeting: {
 			contentType: 'LiveBlog',
-			sectionId: section,
+			sectionId,
 			shouldHideReaderRevenue,
 			isMinuteArticle: true,
 			isPaidContent,
@@ -232,7 +232,7 @@ function insertAfter(referenceNode: HTMLElement, newNode: Element) {
  *    and render the Epic component using it
  */
 export const LiveBlogEpic = ({
-	section,
+	sectionId,
 	shouldHideReaderRevenue,
 	isPaidContent,
 	tags,
@@ -245,7 +245,7 @@ export const LiveBlogEpic = ({
 	// First construct the payload
 	const payload = usePayload({
 		shouldHideReaderRevenue,
-		section,
+		sectionId,
 		isPaidContent,
 		tags,
 		pageId,

--- a/dotcom-rendering/src/components/MostViewedFooter.importable.tsx
+++ b/dotcom-rendering/src/components/MostViewedFooter.importable.tsx
@@ -12,7 +12,7 @@ type Props = {
 	mostShared?: TrailType;
 	abTestCypressDataAttr?: string;
 	variantFromRunnable?: string;
-	sectionName?: string;
+	sectionId?: string;
 	hasPageSkin?: boolean;
 };
 
@@ -47,7 +47,7 @@ export const MostViewedFooter = ({
 	mostShared,
 	abTestCypressDataAttr,
 	variantFromRunnable,
-	sectionName,
+	sectionId,
 	selectedColour,
 	hasPageSkin = false,
 }: Props) => {
@@ -63,7 +63,7 @@ export const MostViewedFooter = ({
 		>
 			<MostViewedFooterGrid
 				data={tabs}
-				sectionName={sectionName}
+				sectionId={sectionId}
 				selectedColour={selectedColour}
 				hasPageSkin={hasPageSkin}
 			/>

--- a/dotcom-rendering/src/components/MostViewedFooter.test.tsx
+++ b/dotcom-rendering/src/components/MostViewedFooter.test.tsx
@@ -23,7 +23,7 @@ describe('MostViewedFooterData', () => {
 
 		const { getByText, getAllByText, getByTestId } = render(
 			<MostViewedFooterData
-				sectionName="Section Name"
+				sectionId="Section Name"
 				format={{
 					theme: ArticlePillar.News,
 					design: ArticleDesign.Standard,
@@ -60,7 +60,7 @@ describe('MostViewedFooterData', () => {
 
 		const { getByTestId, getByText } = render(
 			<MostViewedFooterData
-				sectionName="Section Name"
+				sectionId="Section Name"
 				format={{
 					display: ArticleDisplay.Standard,
 					design: ArticleDesign.Standard,
@@ -117,7 +117,7 @@ describe('MostViewedFooterData', () => {
 
 		const { getByText } = render(
 			<MostViewedFooterData
-				sectionName="Section Name"
+				sectionId="Section Name"
 				format={{
 					display: ArticleDisplay.Standard,
 					design: ArticleDesign.Standard,
@@ -159,7 +159,7 @@ describe('MostViewedFooterData', () => {
 
 		const { queryByText } = render(
 			<MostViewedFooterData
-				sectionName="Section Name"
+				sectionId="Section Name"
 				format={{
 					display: ArticleDisplay.Standard,
 					design: ArticleDesign.Standard,
@@ -178,7 +178,7 @@ describe('MostViewedFooterData', () => {
 
 		const { asFragment } = render(
 			<MostViewedFooterData
-				sectionName="Section Name"
+				sectionId="Section Name"
 				format={{
 					display: ArticleDisplay.Standard,
 					design: ArticleDesign.Standard,

--- a/dotcom-rendering/src/components/MostViewedFooterData.importable.tsx
+++ b/dotcom-rendering/src/components/MostViewedFooterData.importable.tsx
@@ -13,7 +13,7 @@ import type {
 import { MostViewedFooter } from './MostViewedFooter.importable';
 
 interface Props {
-	sectionName?: string;
+	sectionId?: string;
 	format: ArticleFormat;
 	ajaxUrl: string;
 	edition: EditionId;
@@ -22,14 +22,13 @@ interface Props {
 function buildSectionUrl(
 	ajaxUrl: string,
 	edition: EditionId,
-	sectionName?: string,
+	sectionId?: string,
 ) {
 	const sectionsWithoutPopular = ['info', 'global'];
 	const hasSection =
-		sectionName !== undefined &&
-		!sectionsWithoutPopular.includes(sectionName);
+		sectionId !== undefined && !sectionsWithoutPopular.includes(sectionId);
 	const endpoint = `/most-read${
-		hasSection ? `/${sectionName}` : ''
+		hasSection ? `/${sectionId}` : ''
 	}.json?_edition=${edition}`;
 	return joinUrl(ajaxUrl, `${endpoint}&dcr=true`);
 }
@@ -48,7 +47,7 @@ interface MostViewedFooterPayloadType {
 }
 
 export const MostViewedFooterData = ({
-	sectionName,
+	sectionId,
 	format,
 	ajaxUrl,
 	edition,
@@ -67,7 +66,7 @@ export const MostViewedFooterData = ({
 	const runnableTest = ABTestAPI?.runnableTest(abTestTest);
 	const variantFromRunnable = runnableTest?.variantToRun.id ?? 'not-runnable';
 
-	const url = buildSectionUrl(ajaxUrl, edition, sectionName);
+	const url = buildSectionUrl(ajaxUrl, edition, sectionId);
 	const { data, error } = useApi<
 		MostViewedFooterPayloadType | FETrailTabType[]
 	>(url);
@@ -94,7 +93,7 @@ export const MostViewedFooterData = ({
 				}
 				abTestCypressDataAttr={abTestCypressDataAttr}
 				variantFromRunnable={variantFromRunnable}
-				sectionName={sectionName}
+				sectionId={sectionId}
 				selectedColour={palette.background.mostViewedTab}
 			/>
 		);

--- a/dotcom-rendering/src/components/MostViewedFooterGrid.tsx
+++ b/dotcom-rendering/src/components/MostViewedFooterGrid.tsx
@@ -104,7 +104,7 @@ const gridContainer = css`
 
 type Props = {
 	data: TrailTabType[];
-	sectionName?: string;
+	sectionId?: string;
 	selectedColour?: string;
 	hasPageSkin?: boolean;
 };
@@ -131,7 +131,7 @@ const TabHeading = ({ heading }: { heading: string }) => {
 
 export const MostViewedFooterGrid = ({
 	data,
-	sectionName = '',
+	sectionId = '',
 	selectedColour = neutral[0],
 	hasPageSkin = false,
 }: Props) => {
@@ -230,7 +230,7 @@ export const MostViewedFooterGrid = ({
 						css={gridContainer}
 						data-cy={`tab-body-${i}`}
 						data-link-name={tab.heading}
-						data-link-context={`most-read/${sectionName}`}
+						data-link-context={`most-read/${sectionId}`}
 					>
 						{tab.trails.map((trail: TrailType, j: number) => (
 							<MostViewedFooterItem

--- a/dotcom-rendering/src/components/SignInGate/displayRule.ts
+++ b/dotcom-rendering/src/components/SignInGate/displayRule.ts
@@ -40,7 +40,7 @@ export const isValidContentType = (contentType: string): boolean => {
 };
 
 // hide the sign in gate on certain sections of the site, e.g info, about, help etc.
-export const isValidSection = (sectionName?: string): boolean => {
+export const isValidSection = (sectionId?: string): boolean => {
 	const invalidSections = [
 		'about',
 		'info',
@@ -53,7 +53,7 @@ export const isValidSection = (sectionName?: string): boolean => {
 	// we check for invalid section by reducing the above array, and then NOT the result so we know
 	// its a valid section
 	return !invalidSections.some(
-		(section: string): boolean => sectionName === section,
+		(section: string): boolean => sectionId === section,
 	);
 };
 
@@ -76,7 +76,7 @@ export const canShowSignInGate = ({
 	isSignedIn,
 	currentTest,
 	contentType,
-	sectionName,
+	sectionId,
 	tags,
 	isPaidContent,
 	isPreview,
@@ -90,7 +90,7 @@ export const canShowSignInGate = ({
 			) &&
 			isNPageOrHigherPageView(3) &&
 			isValidContentType(contentType) &&
-			isValidSection(sectionName) &&
+			isValidSection(sectionId) &&
 			isValidTag(tags) &&
 			// hide the sign in gate on isPaidContent
 			!isPaidContent &&
@@ -103,7 +103,7 @@ export const canShowSignInGateMandatory: ({
 	isSignedIn,
 	currentTest,
 	contentType,
-	sectionName,
+	sectionId,
 	tags,
 	isPaidContent,
 	isPreview,
@@ -111,7 +111,7 @@ export const canShowSignInGateMandatory: ({
 	isSignedIn,
 	currentTest,
 	contentType,
-	sectionName,
+	sectionId,
 	tags,
 	isPaidContent,
 	isPreview,
@@ -122,7 +122,7 @@ export const canShowSignInGateMandatory: ({
 			isSignedIn,
 			currentTest,
 			contentType,
-			sectionName,
+			sectionId,
 			tags,
 			isPaidContent,
 			isPreview,

--- a/dotcom-rendering/src/components/SignInGate/gates/main-control.ts
+++ b/dotcom-rendering/src/components/SignInGate/gates/main-control.ts
@@ -12,7 +12,7 @@ const canShow = ({
 	isSignedIn,
 	currentTest,
 	contentType,
-	sectionName,
+	sectionId,
 	tags,
 	isPaidContent,
 	isPreview,
@@ -22,7 +22,7 @@ const canShow = ({
 			!hasUserDismissedGate(currentTest.variant, currentTest.name) &&
 			isNPageOrHigherPageView(3) &&
 			isValidContentType(contentType) &&
-			isValidSection(sectionName) &&
+			isValidSection(sectionId) &&
 			isValidTag(tags) &&
 			// hide the sign in gate on isPaidContent
 			!isPaidContent &&

--- a/dotcom-rendering/src/components/SignInGate/types.ts
+++ b/dotcom-rendering/src/components/SignInGate/types.ts
@@ -7,7 +7,7 @@ export type CanShowGateProps = {
 	isSignedIn: boolean;
 	currentTest: CurrentSignInGateABTest;
 	contentType: string;
-	sectionName?: string;
+	sectionId?: string;
 	tags: TagType[];
 	isPaidContent: boolean;
 	isPreview?: boolean;

--- a/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
+++ b/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
@@ -25,7 +25,7 @@ import type {
 type Props = {
 	format: ArticleFormat;
 	contentType: string;
-	sectionName?: string;
+	sectionId?: string;
 	tags: TagType[];
 	isPaidContent: boolean;
 	isPreview: boolean;
@@ -142,7 +142,7 @@ const ShowSignInGate = ({
 export const SignInGateSelector = ({
 	format,
 	contentType,
-	sectionName = '',
+	sectionId = '',
 	tags,
 	isPaidContent,
 	isPreview,
@@ -228,7 +228,7 @@ export const SignInGateSelector = ({
 					isSignedIn: !!isSignedIn,
 					currentTest,
 					contentType,
-					sectionName,
+					sectionId,
 					tags,
 					isPaidContent,
 					isPreview,
@@ -240,7 +240,7 @@ export const SignInGateSelector = ({
 		gateVariant,
 		isSignedIn,
 		contentType,
-		sectionName,
+		sectionId,
 		tags,
 		isPaidContent,
 		isPreview,

--- a/dotcom-rendering/src/components/SlotBodyEnd.importable.tsx
+++ b/dotcom-rendering/src/components/SlotBodyEnd.importable.tsx
@@ -30,7 +30,6 @@ import type {
 
 type Props = {
 	contentType: string;
-	sectionName?: string;
 	sectionId: string;
 	shouldHideReaderRevenue: boolean;
 	isMinuteArticle: boolean;
@@ -104,7 +103,6 @@ function getIsSignedIn(signedInStatus: SignedInStatus): boolean | undefined {
 
 export const SlotBodyEnd = ({
 	contentType,
-	sectionName,
 	sectionId,
 	shouldHideReaderRevenue,
 	isMinuteArticle,
@@ -166,7 +164,7 @@ export const SlotBodyEnd = ({
 			browserId: browserId ?? undefined,
 		});
 		const brazeArticleContext: BrazeArticleContext = {
-			section: sectionName,
+			section: sectionId,
 		};
 		const brazeEpic = buildBrazeEpicConfig(
 			brazeMessages as BrazeMessagesInterface,

--- a/dotcom-rendering/src/components/StickyBottomBanner.importable.tsx
+++ b/dotcom-rendering/src/components/StickyBottomBanner.importable.tsx
@@ -36,8 +36,7 @@ import type {
 
 type Props = {
 	contentType: string;
-	sectionName?: string;
-	section: string;
+	sectionId: string;
 	tags: TagType[];
 	isPaidContent: boolean;
 	isPreview: boolean;
@@ -101,7 +100,7 @@ const buildRRBannerConfigWith = ({
 		asyncArticleCounts,
 		signInGateWillShow = false,
 		contentType,
-		section,
+		sectionId,
 		shouldHideReaderRevenue,
 		isMinuteArticle,
 		isPaidContent,
@@ -116,7 +115,7 @@ const buildRRBannerConfigWith = ({
 		asyncArticleCounts: Promise<ArticleCounts | undefined>;
 		signInGateWillShow?: boolean;
 		contentType: string;
-		section: string;
+		sectionId: string;
 		shouldHideReaderRevenue: boolean;
 		isMinuteArticle: boolean;
 		isPaidContent: boolean;
@@ -134,7 +133,7 @@ const buildRRBannerConfigWith = ({
 						isSignedIn,
 						asyncCountryCode,
 						contentType,
-						sectionId: section,
+						sectionId,
 						shouldHideReaderRevenue,
 						isMinuteArticle,
 						isPaidContent,
@@ -151,7 +150,6 @@ const buildRRBannerConfigWith = ({
 						signInBannerLastClosedAt: getBannerLastClosedAt(
 							'signInBannerLastClosedAt',
 						),
-						section,
 						isPreview,
 						idApiUrl,
 						signInGateWillShow,
@@ -213,8 +211,7 @@ const buildBrazeBanner = (
 
 export const StickyBottomBanner = ({
 	contentType,
-	sectionName,
-	section,
+	sectionId,
 	tags,
 	isPaidContent,
 	isPreview,
@@ -242,7 +239,7 @@ export const StickyBottomBanner = ({
 	const signInGateWillShow = useSignInGateWillShow({
 		isSignedIn,
 		contentType,
-		sectionName,
+		sectionId,
 		tags,
 		isPaidContent,
 		isPreview,
@@ -262,7 +259,7 @@ export const StickyBottomBanner = ({
 				ArticleCounts | undefined
 			>,
 			contentType,
-			section,
+			sectionId,
 			shouldHideReaderRevenue,
 			isMinuteArticle,
 			isPaidContent,
@@ -282,7 +279,7 @@ export const StickyBottomBanner = ({
 			>,
 			signInGateWillShow,
 			contentType,
-			section,
+			sectionId,
 			shouldHideReaderRevenue,
 			isMinuteArticle,
 			isPaidContent,
@@ -292,7 +289,7 @@ export const StickyBottomBanner = ({
 			idApiUrl,
 		});
 		const brazeArticleContext: BrazeArticleContext = {
-			section: sectionName,
+			section: sectionId,
 		};
 		const brazeBanner = buildBrazeBanner(
 			brazeMessages as BrazeMessagesInterface,

--- a/dotcom-rendering/src/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/dotcom-rendering/src/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -57,7 +57,6 @@ type BuildPayloadProps = BaseProps & {
 type CanShowProps = BaseProps & {
 	asyncCountryCode: Promise<string>;
 	remoteBannerConfig: boolean;
-	section: string;
 	isPreview: boolean;
 	idApiUrl: string;
 	signInGateWillShow: boolean;
@@ -248,11 +247,10 @@ export const canShowPuzzlesBanner: CanShowFunctionType<BannerProps> = async ({
 	alreadyVisitedCount,
 	engagementBannerLastClosedAt,
 	subscriptionBannerLastClosedAt,
-	section,
 	asyncArticleCounts,
 }) => {
 	const isPuzzlesPage =
-		section === 'crosswords' ||
+		sectionId === 'crosswords' ||
 		tags.some((tag) => tag.type === 'Series' && tag.title === 'Sudoku');
 
 	if (shouldHideReaderRevenue) {

--- a/dotcom-rendering/src/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/layouts/CommentLayout.tsx
@@ -574,7 +574,7 @@ export const CommentLayout = ({
 										switches={article.config.switches}
 										isSensitive={article.config.isSensitive}
 										isAdFreeUser={article.isAdFreeUser}
-										section={article.config.section}
+										sectionId={article.config.section}
 										shouldHideReaderRevenue={
 											article.shouldHideReaderRevenue
 										}
@@ -586,7 +586,6 @@ export const CommentLayout = ({
 											contributionsServiceUrl
 										}
 										contentType={article.contentType}
-										sectionName={article.sectionName ?? ''}
 										isPreview={article.config.isPreview}
 										idUrl={article.config.idUrl ?? ''}
 										isDev={!!article.config.isDev}
@@ -627,9 +626,6 @@ export const CommentLayout = ({
 												pageId={article.pageId}
 												sectionId={
 													article.config.section
-												}
-												sectionName={
-													article.sectionName
 												}
 												shouldHideReaderRevenue={
 													article.shouldHideReaderRevenue
@@ -861,8 +857,7 @@ export const CommentLayout = ({
 						isSensitive={article.config.isSensitive}
 						keywordIds={article.config.keywordIds}
 						pageId={article.pageId}
-						section={article.config.section}
-						sectionName={article.sectionName}
+						sectionId={article.config.section}
 						shouldHideReaderRevenue={
 							article.shouldHideReaderRevenue
 						}

--- a/dotcom-rendering/src/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/layouts/CommentLayout.tsx
@@ -787,7 +787,7 @@ export const CommentLayout = ({
 						<MostViewedFooterLayout renderAds={renderAds}>
 							<Island clientOnly={true} deferUntil="visible">
 								<MostViewedFooterData
-									sectionName={article.sectionName}
+									sectionId={article.config.section}
 									format={format}
 									ajaxUrl={article.config.ajaxUrl}
 									edition={article.editionId}

--- a/dotcom-rendering/src/layouts/FullPageInteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/FullPageInteractiveLayout.tsx
@@ -399,8 +399,7 @@ export const FullPageInteractiveLayout = ({ article, NAV, format }: Props) => {
 						isSensitive={article.config.isSensitive}
 						keywordIds={article.config.keywordIds}
 						pageId={article.pageId}
-						section={article.config.section}
-						sectionName={article.sectionName}
+						sectionId={article.config.section}
 						shouldHideReaderRevenue={
 							article.shouldHideReaderRevenue
 						}

--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -621,7 +621,7 @@ export const ImmersiveLayout = ({
 									switches={article.config.switches}
 									isSensitive={article.config.isSensitive}
 									isAdFreeUser={article.isAdFreeUser}
-									section={article.config.section}
+									sectionId={article.config.section}
 									shouldHideReaderRevenue={
 										article.shouldHideReaderRevenue
 									}
@@ -634,7 +634,6 @@ export const ImmersiveLayout = ({
 										contributionsServiceUrl
 									}
 									contentType={article.contentType}
-									sectionName={article.sectionName ?? ''}
 									isPreview={article.config.isPreview}
 									idUrl={article.config.idUrl ?? ''}
 									isDev={!!article.config.isDev}
@@ -665,7 +664,6 @@ export const ImmersiveLayout = ({
 											}
 											pageId={article.pageId}
 											sectionId={article.config.section}
-											sectionName={article.sectionName}
 											shouldHideReaderRevenue={
 												article.shouldHideReaderRevenue
 											}
@@ -904,8 +902,7 @@ export const ImmersiveLayout = ({
 						isSensitive={article.config.isSensitive}
 						keywordIds={article.config.keywordIds}
 						pageId={article.pageId}
-						section={article.config.section}
-						sectionName={article.sectionName}
+						sectionId={article.config.section}
 						shouldHideReaderRevenue={
 							article.shouldHideReaderRevenue
 						}

--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -833,7 +833,7 @@ export const ImmersiveLayout = ({
 						<MostViewedFooterLayout renderAds={renderAds}>
 							<Island clientOnly={true} deferUntil="visible">
 								<MostViewedFooterData
-									sectionName={article.sectionName}
+									sectionId={article.config.section}
 									format={format}
 									ajaxUrl={article.config.ajaxUrl}
 									edition={article.editionId}

--- a/dotcom-rendering/src/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/InteractiveLayout.tsx
@@ -506,7 +506,7 @@ export const InteractiveLayout = ({
 										switches={article.config.switches}
 										isSensitive={article.config.isSensitive}
 										isAdFreeUser={article.isAdFreeUser}
-										section={article.config.section}
+										sectionId={article.config.section}
 										shouldHideReaderRevenue={
 											article.shouldHideReaderRevenue
 										}
@@ -518,7 +518,6 @@ export const InteractiveLayout = ({
 											contributionsServiceUrl
 										}
 										contentType={article.contentType}
-										sectionName={article.sectionName ?? ''}
 										isPreview={article.config.isPreview}
 										idUrl={article.config.idUrl ?? ''}
 										isDev={!!article.config.isDev}
@@ -564,7 +563,6 @@ export const InteractiveLayout = ({
 								keywordIds={article.config.keywordIds}
 								pageId={article.pageId}
 								sectionId={article.config.section}
-								sectionName={article.sectionName}
 								shouldHideReaderRevenue={
 									article.shouldHideReaderRevenue
 								}
@@ -780,8 +778,7 @@ export const InteractiveLayout = ({
 						isSensitive={article.config.isSensitive}
 						keywordIds={article.config.keywordIds}
 						pageId={article.pageId}
-						section={article.config.section}
-						sectionName={article.sectionName}
+						sectionId={article.config.section}
 						shouldHideReaderRevenue={
 							article.shouldHideReaderRevenue
 						}

--- a/dotcom-rendering/src/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/InteractiveLayout.tsx
@@ -701,7 +701,7 @@ export const InteractiveLayout = ({
 						<MostViewedFooterLayout renderAds={renderAds}>
 							<Island clientOnly={true} deferUntil="visible">
 								<MostViewedFooterData
-									sectionName={article.sectionName}
+									sectionId={article.config.section}
 									format={format}
 									ajaxUrl={article.config.ajaxUrl}
 									edition={article.editionId}

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -822,7 +822,7 @@ export const LiveLayout = ({
 													ajaxUrl={
 														article.config.ajaxUrl
 													}
-													section={
+													sectionId={
 														article.config.section
 													}
 													switches={
@@ -848,10 +848,6 @@ export const LiveLayout = ({
 													}
 													contentType={
 														article.contentType
-													}
-													sectionName={
-														article.sectionName ??
-														''
 													}
 													isPreview={
 														article.config.isPreview
@@ -976,7 +972,7 @@ export const LiveLayout = ({
 													ajaxUrl={
 														article.config.ajaxUrl
 													}
-													section={
+													sectionId={
 														article.config.section
 													}
 													switches={
@@ -1002,10 +998,6 @@ export const LiveLayout = ({
 													}
 													contentType={
 														article.contentType
-													}
-													sectionName={
-														article.sectionName ??
-														''
 													}
 													isPreview={
 														article.config.isPreview
@@ -1319,8 +1311,7 @@ export const LiveLayout = ({
 						isSensitive={article.config.isSensitive}
 						keywordIds={article.config.keywordIds}
 						pageId={article.pageId}
-						section={article.config.section}
-						sectionName={article.sectionName}
+						sectionId={article.config.section}
 						shouldHideReaderRevenue={
 							article.shouldHideReaderRevenue
 						}

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -1233,7 +1233,7 @@ export const LiveLayout = ({
 							<MostViewedFooterLayout renderAds={renderAds}>
 								<Island clientOnly={true} deferUntil="visible">
 									<MostViewedFooterData
-										sectionName={article.sectionName}
+										sectionId={article.config.section}
 										format={format}
 										ajaxUrl={article.config.ajaxUrl}
 										edition={article.editionId}

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -744,7 +744,7 @@ export const ShowcaseLayout = ({
 						<MostViewedFooterLayout renderAds={renderAds}>
 							<Island clientOnly={true} deferUntil="visible">
 								<MostViewedFooterData
-									sectionName={article.sectionName}
+									sectionId={article.config.section}
 									format={format}
 									ajaxUrl={article.config.ajaxUrl}
 									edition={article.editionId}

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -543,7 +543,7 @@ export const ShowcaseLayout = ({
 									switches={article.config.switches}
 									isSensitive={article.config.isSensitive}
 									isAdFreeUser={article.isAdFreeUser}
-									section={article.config.section}
+									sectionId={article.config.section}
 									shouldHideReaderRevenue={
 										article.shouldHideReaderRevenue
 									}
@@ -555,7 +555,6 @@ export const ShowcaseLayout = ({
 										contributionsServiceUrl
 									}
 									contentType={article.contentType}
-									sectionName={article.sectionName ?? ''}
 									isPreview={article.config.isPreview}
 									idUrl={article.config.idUrl ?? ''}
 									isDev={!!article.config.isDev}
@@ -587,7 +586,6 @@ export const ShowcaseLayout = ({
 											}
 											pageId={article.pageId}
 											sectionId={article.config.section}
-											sectionName={article.sectionName}
 											shouldHideReaderRevenue={
 												article.shouldHideReaderRevenue
 											}
@@ -816,8 +814,7 @@ export const ShowcaseLayout = ({
 						isSensitive={article.config.isSensitive}
 						keywordIds={article.config.keywordIds}
 						pageId={article.pageId}
-						section={article.config.section}
-						sectionName={article.sectionName}
+						sectionId={article.config.section}
 						shouldHideReaderRevenue={
 							article.shouldHideReaderRevenue
 						}

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -873,7 +873,7 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 										deferUntil="visible"
 									>
 										<MostViewedFooterData
-											sectionName={article.sectionName}
+											sectionId={article.config.section}
 											format={format}
 											ajaxUrl={article.config.ajaxUrl}
 											edition={article.editionId}

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -641,7 +641,7 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 									switches={article.config.switches}
 									isSensitive={article.config.isSensitive}
 									isAdFreeUser={article.isAdFreeUser}
-									section={article.config.section}
+									sectionId={article.config.section}
 									shouldHideReaderRevenue={
 										article.shouldHideReaderRevenue
 									}
@@ -653,7 +653,6 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 										contributionsServiceUrl
 									}
 									contentType={article.contentType}
-									sectionName={article.sectionName ?? ''}
 									isPreview={article.config.isPreview}
 									idUrl={article.config.idUrl ?? ''}
 									isDev={!!article.config.isDev}
@@ -699,7 +698,6 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 											}
 											pageId={article.pageId}
 											sectionId={article.config.section}
-											sectionName={article.sectionName}
 											shouldHideReaderRevenue={
 												article.shouldHideReaderRevenue
 											}
@@ -961,8 +959,7 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 								isSensitive={article.config.isSensitive}
 								keywordIds={article.config.keywordIds}
 								pageId={article.pageId}
-								section={article.config.section}
-								sectionName={article.sectionName}
+								sectionId={article.config.section}
 								shouldHideReaderRevenue={
 									article.shouldHideReaderRevenue
 								}

--- a/dotcom-rendering/src/lib/ArticleRenderer.tsx
+++ b/dotcom-rendering/src/lib/ArticleRenderer.tsx
@@ -32,7 +32,7 @@ type Props = {
 	webTitle: string;
 	ajaxUrl: string;
 	contentType: string;
-	sectionName: string;
+	sectionId: string;
 	tags: TagType[];
 	isPaidContent: boolean;
 	isPreview?: boolean;
@@ -53,7 +53,7 @@ export const ArticleRenderer = ({
 	webTitle,
 	ajaxUrl,
 	contentType,
-	sectionName,
+	sectionId,
 	tags,
 	isPaidContent,
 	isPreview,
@@ -112,7 +112,7 @@ export const ArticleRenderer = ({
 						renderedElements,
 						format,
 						contentType,
-						sectionName,
+						sectionId,
 						tags,
 						isPaidContent,
 						isPreview,

--- a/dotcom-rendering/src/lib/LiveBlogRenderer.tsx
+++ b/dotcom-rendering/src/lib/LiveBlogRenderer.tsx
@@ -26,7 +26,7 @@ type Props = {
 	isSensitive: boolean;
 	switches: Switches;
 	isLiveUpdate?: boolean;
-	section: string;
+	sectionId: string;
 	shouldHideReaderRevenue: boolean;
 	tags: TagType[];
 	isPaidContent: boolean;
@@ -52,7 +52,7 @@ export const LiveBlogRenderer = ({
 	isAdFreeUser,
 	isSensitive,
 	isLiveUpdate,
-	section,
+	sectionId,
 	shouldHideReaderRevenue,
 	tags,
 	isPaidContent,
@@ -146,7 +146,7 @@ export const LiveBlogRenderer = ({
 			{blocks.length > 4 && (
 				<Island clientOnly={true}>
 					<LiveBlogEpic
-						section={section}
+						sectionId={sectionId}
 						shouldHideReaderRevenue={shouldHideReaderRevenue}
 						tags={tags}
 						isPaidContent={isPaidContent}

--- a/dotcom-rendering/src/lib/useSignInGateWillShow.ts
+++ b/dotcom-rendering/src/lib/useSignInGateWillShow.ts
@@ -10,7 +10,7 @@ import { useSignInGateSelector } from './useSignInGateSelector';
 type Props = {
 	isSignedIn?: boolean;
 	contentType: string;
-	sectionName?: string;
+	sectionId?: string;
 	tags: TagType[];
 	isPaidContent: boolean;
 	isPreview: boolean;
@@ -23,7 +23,7 @@ type Props = {
 export const useSignInGateWillShow = ({
 	isSignedIn,
 	contentType,
-	sectionName,
+	sectionId,
 	tags,
 	isPaidContent,
 	isPreview,
@@ -54,7 +54,7 @@ export const useSignInGateWillShow = ({
 					isSignedIn: !!isSignedIn,
 					currentTest,
 					contentType,
-					sectionName,
+					sectionId,
 					tags,
 					isPaidContent,
 					isPreview,
@@ -66,7 +66,7 @@ export const useSignInGateWillShow = ({
 		gateVariant,
 		isSignedIn,
 		contentType,
-		sectionName,
+		sectionId,
 		tags,
 		isPaidContent,
 		isPreview,

--- a/dotcom-rendering/src/lib/withSignInGateSlot.tsx
+++ b/dotcom-rendering/src/lib/withSignInGateSlot.tsx
@@ -11,7 +11,7 @@ type Props = {
 	renderedElements: (JSX.Element | null | undefined)[];
 	format: ArticleFormat;
 	contentType: string;
-	sectionName: string;
+	sectionId: string;
 	tags: TagType[];
 	isPaidContent: boolean;
 	isPreview?: boolean;
@@ -27,7 +27,7 @@ export const withSignInGateSlot = ({
 	renderedElements,
 	format,
 	contentType,
-	sectionName,
+	sectionId,
 	tags,
 	isPaidContent,
 	isPreview,
@@ -46,7 +46,7 @@ export const withSignInGateSlot = ({
 							<SignInGateSelector
 								format={format}
 								contentType={contentType}
-								sectionName={sectionName}
+								sectionId={sectionId}
 								tags={tags}
 								isPaidContent={isPaidContent}
 								isPreview={!!isPreview}

--- a/dotcom-rendering/src/server/render.article.web.tsx
+++ b/dotcom-rendering/src/server/render.article.web.tsx
@@ -279,7 +279,7 @@ export const renderBlocks = ({
 			isAdFreeUser={isAdFreeUser}
 			switches={switches}
 			isLiveUpdate={true}
-			section={section}
+			sectionId={section}
 			// The props below are never used because isLiveUpdate is true but, typescript...
 			shouldHideReaderRevenue={false}
 			tags={[]}


### PR DESCRIPTION
In DCR we get two section fields from Frontend for articles:
- `article.config.section`
- `article.sectionName`

Despite the difference in name, they are always the same, and they are in fact the section _ID_. E.g. `australia-news`.
This contradicts the CAPI content model, e.g:
![Screenshot 2023-07-11 at 09 33 13](https://github.com/guardian/dotcom-rendering/assets/1513454/a05f175c-b661-4d08-beb1-74f9189a0d87)

Where we are currently using `sectionName`, we're actually using it as an ID.


Currently both fields are used in different places. This PR: 
- changes usages of `article.sectionName` to `article.config.section`, for consistency
- renames any props/variables called `section` or `sectionName` to `sectionId`, for clarity