### PR TITLE
fix: add altText to fronts cards

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -62,6 +62,7 @@ export type Props = {
 	showByline?: boolean;
 	webPublicationDate?: string;
 	imageUrl?: string;
+	imageAltText?: string;
 	imagePosition?: ImagePositionType;
 	imagePositionOnMobile?: ImagePositionType;
 	/** Size is ignored when position = 'top' because in that case the image flows based on width */
@@ -189,6 +190,7 @@ const CommentFooter = ({
 
 const getMedia = ({
 	imageUrl,
+	imageAltText,
 	avatarUrl,
 	isCrossword,
 	slideshowImages,
@@ -196,6 +198,7 @@ const getMedia = ({
 	videoSize,
 }: {
 	imageUrl?: string;
+	imageAltText?: string;
 	avatarUrl?: string;
 	isCrossword?: boolean;
 	slideshowImages?: DCRSlideshowImage[];
@@ -213,7 +216,7 @@ const getMedia = ({
 	if (avatarUrl) return { type: 'avatar', avatarUrl } as const;
 	if (imageUrl) {
 		const type = isCrossword ? 'crossword' : 'picture';
-		return { type, imageUrl } as const;
+		return { type, imageUrl, imageAltText } as const;
 	}
 	return undefined;
 };
@@ -251,6 +254,7 @@ export const Card = ({
 	showByline,
 	webPublicationDate,
 	imageUrl,
+	imageAltText,
 	imagePosition = 'top',
 	imagePositionOnMobile = 'left',
 	imageSize = 'small',
@@ -367,6 +371,7 @@ export const Card = ({
 
 	const media = getMedia({
 		imageUrl,
+		imageAltText,
 		avatarUrl,
 		isCrossword,
 		slideshowImages,
@@ -455,7 +460,7 @@ export const Card = ({
 								<CardPicture
 									master={media.imageUrl}
 									imageSize={imageSize}
-									alt=""
+									alt={media.imageAltText}
 								/>
 								{showPlayIcon && (
 									<MediaDuration

--- a/dotcom-rendering/src/components/FrontCard.tsx
+++ b/dotcom-rendering/src/components/FrontCard.tsx
@@ -37,6 +37,7 @@ export const FrontCard = (props: Props) => {
 		showPulsingDot: trail.format.design === ArticleDesign.LiveBlog,
 		showClock: false,
 		imageUrl: trail.image,
+		imageAltText: trail.imageAltText,
 		isCrossword: trail.isCrossword,
 		videoSize: 'large enough to play: at least 480px',
 		starRating: trail.starRating,

--- a/dotcom-rendering/src/model/enhanceCards.ts
+++ b/dotcom-rendering/src/model/enhanceCards.ts
@@ -302,6 +302,11 @@ export const enhanceCards = (
 					  ).toISOString()
 					: undefined,
 			image: decideImage(faciaCard),
+			/** This property is coupled to the `image` property above.
+			 * There's room to create a codified coupling, but that has more far reaching changes */
+			imageAltText:
+				faciaCard.properties.maybeContent?.trail.trailPicture
+					?.allImages[0]?.fields.altText,
 			kickerText: decideKicker(faciaCard, cardInTagFront, pageId),
 			supportingContent: faciaCard.supportingContent
 				? enhanceSupportingContent(

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -298,6 +298,7 @@ export type DCRFrontCard = {
 	starRating?: number;
 	webPublicationDate?: string;
 	image?: string;
+	imageAltText?: string;
 	kickerText?: string;
 	supportingContent?: DCRSupportingContent[];
 	snapData?: DCRSnapType;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Fixes #8144 

This changes propagates the data from Composer => Frontend => DCR via the enhancers, and renders the altText on fronts images.

The scope of this PR is to fix fronts to ++➕ our accessibility, which suffers poorly due to this omission, and could also have further reaching negative impact e.g. SEO. There are some questions on potential better solutions 👇 .

There's a comment that alludes to another we might do this, and I think we should, but maybe as a follow up, and a pairing session. 

e.g.
```TS
type Image = { alt: string, src: string; }
```

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/31692/a9249dbc-8158-431a-86f8-a867d7d4e2b4
[after]: https://github.com/guardian/dotcom-rendering/assets/31692/4a2e8e94-b19d-447d-95aa-68711ffba8be






