### PR TITLE
fix: loosen rules for badges

### DIFF
--- a/dotcom-rendering/src/model/decideBadge.test.ts
+++ b/dotcom-rendering/src/model/decideBadge.test.ts
@@ -28,7 +28,7 @@ const brandingGuardianOrg = {
 	brandingType: {
 		name: 'sponsored',
 	},
-	sponsorName: 'guardian.org',
+	sponsorName: 'theguardian.org',
 	logo: {
 		src: 'https://static.theguardian.com/commercial/sponsor/16/Mar/2022/1e17c6f8-8114-44e9-8e10-02b8e5c6b929-theguardianorg badge.png',
 		dimensions: {
@@ -116,6 +116,13 @@ describe('Decide badge', () => {
 
 			const result2 = getBadgeFromBranding([]);
 			expect(result2).toEqual(expectedResult);
+		});
+
+		it('returns undefined if Guardian org brand supplied', () => {
+			const expectedResult = undefined;
+
+			const result = getBadgeFromBranding([brandingGuardianOrg]);
+			expect(result).toEqual(expectedResult);
 		});
 	});
 

--- a/dotcom-rendering/src/model/decideBadge.ts
+++ b/dotcom-rendering/src/model/decideBadge.ts
@@ -22,7 +22,12 @@ export const getBadgeFromBranding = (
 		({ sponsorName }) => sponsorName === firstBrand.sponsorName,
 	);
 
-	return allBrandingHasSameSponsor
+	// TODO FIXME - temporary hack to stop guardian.org badges appearing
+	const isFoundationFunded =
+		firstBrand.brandingType?.name === 'foundation' ||
+		firstBrand.sponsorName === 'theguardian.org';
+
+	return !isFoundationFunded && allBrandingHasSameSponsor
 		? {
 				imageSrc: firstBrand.logo.src,
 				href: firstBrand.logo.link,

--- a/dotcom-rendering/src/model/enhanceCollections.ts
+++ b/dotcom-rendering/src/model/enhanceCollections.ts
@@ -70,11 +70,7 @@ export const enhanceCollections = (
 			collectionType,
 			href,
 			containerPalette,
-			badge: decideBadge(
-				collection.config.href,
-				// We only try to use a branded badge for paid content
-				isPaidContent && allCardsHaveBranding ? allBranding : undefined,
-			),
+			badge: decideBadge(collection.config.href, allBranding),
 			grouped: groupCards(
 				collectionType,
 				collection.curated,


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Previously the `decideBadge` logic was such that:

- if there's a hardcoded badge associated with the container href, use that
- if not, use the branding elements on the cards in the container **only if**:
  - the front is a `paidContent` front  
  - _all_ cards have associated branding
  - _all_ cards have the same branding/sponsor. 
If so, take the first branding element as the overall branding.


NOW the logic is:

- if there's a hardcoded badge associated with the container href, use that
- if not, use the branding elements on the cards in the container. If all branding elements have the same branding/sponsor, but not necessarily all cards _having_ branding (i.e. some cards in the container are now allowed to have no associated branding at all)
  - use the first branding element as the overall branding IF it is neither `type: "foundation"` nor `sponsor: "theguardian.org"` to briefly ignore the foundation-funded badges while we work on a better fix


## Why?

The Women's World Cup has a sponsor of Google Pixel but was not showing on the relevant container. Resolves #8230 

NOTE: The styling of the badges still hasn't been fully addressed (see #7973)


## Screenshots

| Frontend | Before      | After      |
| -------- | ----------- | ---------- |
| ![frontend][] | ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/43961396/6fd6ffb0-2f12-460b-af15-0adc64cff707
[after]: https://github.com/guardian/dotcom-rendering/assets/43961396/c3ffad0a-f800-4e39-8260-c357b7495049
[frontend]: https://github.com/guardian/dotcom-rendering/assets/43961396/11923c27-db83-42a9-8ece-26dd17b8d107

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
