### PR TITLE
Add badge when branding exists in edition

### DIFF
--- a/dotcom-rendering/src/components/FrontSection.tsx
+++ b/dotcom-rendering/src/components/FrontSection.tsx
@@ -15,7 +15,11 @@ import { decideContainerOverrides } from '../lib/decideContainerOverrides';
 import type { EditionId } from '../lib/edition';
 import { hideAge } from '../lib/hideAge';
 import type { DCRBadgeType } from '../types/badge';
-import type { DCRContainerPalette, TreatType } from '../types/front';
+import type {
+	DCRContainerPalette,
+	DCRFrontType,
+	TreatType,
+} from '../types/front';
 import type { DCRFrontPagination } from '../types/tagFront';
 import { isAustralianTerritory, type Territory } from '../types/territory';
 import { AustralianTerritorySwitcher } from './AustralianTerritorySwitcher.importable';
@@ -89,6 +93,8 @@ type Props = {
 	 *   the page skin background showing through the containers
 	 */
 	hasPageSkin?: boolean;
+
+	editionBranding?: DCRFrontType['pressedPage']['frontProperties']['commercial']['editionBrandings'][number];
 };
 
 const width = (columns: number, columnWidth: number, columnGap: number) =>
@@ -336,6 +342,25 @@ const decideBackgroundColour = (
 	return undefined;
 };
 
+const labelStyles = css`
+	${textSans.xxsmall()};
+	line-height: 1rem;
+	color: ${palette.neutral[46]};
+	font-weight: bold;
+	margin-top: 0.375rem;
+	padding-right: 0.625rem;
+	padding-bottom: 0.625rem;
+	text-align: left;
+`;
+
+const aboutThisLinkStyles = css`
+	${textSans.xxsmall()};
+	line-height: 11px;
+	color: ${palette.neutral[46]};
+	font-weight: normal;
+	text-decoration: none;
+`;
+
 /**
  * # Front Container
  *
@@ -444,6 +469,7 @@ export const FrontSection = ({
 	index,
 	targetedTerritory,
 	hasPageSkin = false,
+	editionBranding,
 }: Props) => {
 	const overrides =
 		containerPalette && decideContainerOverrides(containerPalette);
@@ -566,6 +592,38 @@ export const FrontSection = ({
 								showDateHeader={showDateHeader}
 								editionId={editionId}
 							/>
+							{!isOnPaidContentFront &&
+								!!editionBranding &&
+								editionBranding?.branding &&
+								index === 0 && (
+									<>
+										<p css={labelStyles}>
+											{
+												editionBranding.branding.logo
+													.label
+											}
+										</p>
+										<Badge
+											imageSrc={
+												editionBranding.branding.logo
+													.src
+											}
+											href={
+												editionBranding.branding.logo
+													.link
+											}
+										/>
+										<a
+											href={
+												editionBranding.branding
+													.aboutThisLink
+											}
+											css={aboutThisLinkStyles}
+										>
+											About this content
+										</a>
+									</>
+								)}
 						</div>
 					</>
 				)}

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -344,6 +344,13 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 						  })
 						: trails;
 
+					const editionBranding =
+						front.pressedPage.frontProperties.commercial.editionBrandings.find(
+							(eB) =>
+								eB.edition.id === front.editionId &&
+								!!eB.branding,
+						);
+
 					if (collection.collectionType === 'fixed/thrasher') {
 						return (
 							<Fragment key={ophanName}>
@@ -599,6 +606,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 								index={index}
 								targetedTerritory={collection.targetedTerritory}
 								hasPageSkin={hasPageSkin}
+								editionBranding={editionBranding}
 							>
 								<DecideContainer
 									trails={trailsWithoutBranding}

--- a/dotcom-rendering/src/model/front-schema.json
+++ b/dotcom-rendering/src/model/front-schema.json
@@ -445,7 +445,100 @@
                             "type": "boolean"
                         },
                         "commercial": {
-                            "$ref": "#/definitions/Record<string,unknown>"
+                            "type": "object",
+                            "properties": {
+                                "editionBrandings": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "edition": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "id": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "id"
+                                                ]
+                                            },
+                                            "branding": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "brandingType": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "name": {
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "name"
+                                                        ]
+                                                    },
+                                                    "sponsorName": {
+                                                        "type": "string"
+                                                    },
+                                                    "logo": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "src": {
+                                                                "type": "string"
+                                                            },
+                                                            "dimensions": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "width": {
+                                                                        "type": "number"
+                                                                    },
+                                                                    "height": {
+                                                                        "type": "number"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "height",
+                                                                    "width"
+                                                                ]
+                                                            },
+                                                            "link": {
+                                                                "type": "string"
+                                                            },
+                                                            "label": {
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "dimensions",
+                                                            "label",
+                                                            "link",
+                                                            "src"
+                                                        ]
+                                                    },
+                                                    "aboutThisLink": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "aboutThisLink",
+                                                    "brandingType",
+                                                    "logo",
+                                                    "sponsorName"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "edition"
+                                        ]
+                                    }
+                                },
+                                "editionAdTargetings": {},
+                                "prebidIndexSites": {}
+                            },
+                            "required": [
+                                "editionAdTargetings",
+                                "editionBrandings"
+                            ]
                         },
                         "isPaidContent": {
                             "type": "boolean"
@@ -2783,9 +2876,6 @@
                 "seoData"
             ]
         },
-        "Record<string,unknown>": {
-            "type": "object"
-        },
         "FEDesign": {
             "enum": [
                 "AnalysisDesign",
@@ -3325,6 +3415,9 @@
                 "PROD"
             ],
             "type": "string"
+        },
+        "Record<string,unknown>": {
+            "type": "object"
         },
         "FooterType": {
             "type": "object",

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -503,7 +503,31 @@ type FESeoDataType = {
 
 type FEFrontPropertiesType = {
 	isImageDisplayed: boolean;
-	commercial: Record<string, unknown>;
+	commercial: {
+		editionBrandings: Array<{
+			edition: {
+				id: string;
+			};
+			branding?: {
+				brandingType: {
+					name: string;
+				};
+				sponsorName: string;
+				logo: {
+					src: string;
+					dimensions: {
+						width: number;
+						height: number;
+					};
+					link: string;
+					label: string;
+				};
+				aboutThisLink: string;
+			};
+		}>;
+		editionAdTargetings: unknown;
+		prebidIndexSites?: unknown;
+	};
 	isPaidContent?: boolean;
 	onPageDescription?: string;
 };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

Co-authored-by: James Gorrie <james.gorrie@guardian.co.uk>

## What does this change?
Adds badge when branding exists in edition

## Why?
Some content is paid by sponsors

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| <img width="1508" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/19683595/435832d9-75a9-44c2-85e1-6733181c70f1"> | ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/867cd8ce-b58e-449c-ba54-0769dd70a897) |


TODO in following PRs:
* Image needs to be smaller
* Write better PR description

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
