### PR TITLE
Remove dependency `qs`

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -223,7 +223,6 @@
 		"preact-render-to-string": "6.0.2",
 		"pretty-bytes": "6.1.0",
 		"prop-types": "15.8.1",
-		"qs": "6.11.0",
 		"react": "18.2.0",
 		"react-dom": "18.2.0",
 		"react-google-recaptcha": "2.1.0",


### PR DESCRIPTION
It does not get imported anywhere, so it doesn't seem to be used

