### PR TITLE
Fix margin for most viewed with pageskin layout

### DIFF
--- a/dotcom-rendering/src/components/MostViewedFooterLayout.tsx
+++ b/dotcom-rendering/src/components/MostViewedFooterLayout.tsx
@@ -47,11 +47,11 @@ const mostPopMarginWithPageSkin = css`
 	margin: 9px 0 0 10px;
 `;
 
-const frontStyles = css`
+const frontStyles = (hasPageSkin: boolean) => css`
 	${from.wide} {
 		margin-top: -${space[2]}px;
 	}
-	${between.leftCol.and.wide} {
+	${!hasPageSkin && between.leftCol.and.wide} {
 		margin-top: -${space[12] - 6}px;
 	}
 `;
@@ -83,7 +83,7 @@ export const MostViewedFooterLayout = ({
 			<div
 				css={[
 					hasPageSkin ? fixedWidthsPageSkin : fixedWidths,
-					isFront && frontStyles,
+					isFront && frontStyles(hasPageSkin),
 					!renderAds && !hasPageSkin && adFreeStyles,
 				]}
 			>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Checks if there is a pageskin before applying margin
## Why?
Fixes https://github.com/guardian/dotcom-rendering/issues/8224
## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/110032454/80ae98d3-7e6e-4cbf-a325-feb7bad960ee
[after]: https://github.com/guardian/dotcom-rendering/assets/110032454/10b29c80-de5c-4e42-84ec-5904dfc6b21c

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
