### PR TITLE
Update Chromatic untraced glob

### DIFF
--- a/.github/workflows/ar-chromatic.yml
+++ b/.github/workflows/ar-chromatic.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN__APPS_RENDERING }}
           token: ${{ secrets.GITHUB_TOKEN }}
-          untraced: '**/(package**.json|yarn.lock)'
+          untraced: '**/(package*.json|yarn.lock|preview.js)'
           exitOnceUploaded: true
           onlyChanged: '!(main)' # only turbosnap on non-main branches
           workingDir: apps-rendering

--- a/.github/workflows/dcr-chromatic.yml
+++ b/.github/workflows/dcr-chromatic.yml
@@ -44,5 +44,5 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           autoAcceptChanges: main
           onlyChanged: true
-          untraced: '**/(package**.json|yarn.lock|preview.js)'
+          untraced: '**/(package*.json|yarn.lock|preview.js)'
           workingDir: dotcom-rendering


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Fixes the `untraced` glob in our Chromatic workflows so we only create snapshots when necessary. https://www.chromatic.com/docs/turbosnap

## Why?

Follows conversation with Reuben at Chromatic who flagged these are setup incorrectly.

