### PR TITLE
Add missing elements to textblockcomponent

### DIFF
--- a/dotcom-rendering/src/components/TextBlockComponent.tsx
+++ b/dotcom-rendering/src/components/TextBlockComponent.tsx
@@ -290,6 +290,12 @@ const buildElementTree =
 				return jsx('br', {
 					key,
 				});
+			case 'STRIKE':
+				return jsx('s', {
+					css: styles(format),
+					key,
+					children,
+				});
 			case 'FOOTER':
 			case 'SUB':
 			case 'SUP':
@@ -305,7 +311,6 @@ const buildElementTree =
 			case 'S':
 			case 'I':
 			case 'VAR':
-			case 'STRIKE':
 			case 'U':
 			case 'DEL':
 				return jsx(node.nodeName.toLowerCase(), {


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Spotted these were missing.
## Why?
Should show these elements on articles.
## Screenshots

STRIKE
| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |
U
| Before      | After      |
| ----------- | ---------- |
| ![before1][] | ![after1][] |
DEL
| Before      | After      |
| ----------- | ---------- |
| ![before2][] | ![after2][] |
H4
| Before      | After      |
| ----------- | ---------- |
| ![before3][] | ![after3][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/110032454/a0d17744-b51c-4e17-b30c-829fb947caf9
[after]: https://github.com/guardian/dotcom-rendering/assets/110032454/bb7142da-5f79-4cf3-a272-03a3cdbbb388
[before1]: https://github.com/guardian/dotcom-rendering/assets/110032454/642280e2-f612-4af5-943e-168d1e474dc1
[after1]: https://github.com/guardian/dotcom-rendering/assets/110032454/943e2486-c81c-4e06-84df-3dff4cfa7af0
[before2]: https://github.com/guardian/dotcom-rendering/assets/110032454/9cd10749-552c-4c0e-bd1e-e8a9656a5f34
[after2]: https://github.com/guardian/dotcom-rendering/assets/110032454/70e0f25d-c56b-47a1-b4d0-36e872ff642a
[before3]: https://github.com/guardian/dotcom-rendering/assets/110032454/6d1dc24c-224a-4450-b5f9-1f49a56e8c41
[after3]: https://github.com/guardian/dotcom-rendering/assets/110032454/edd2e8e6-49cc-4523-8256-5012fd8ce795

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
