### PR TITLE
Bump `tough-cookie` To 4.1.3

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -252,7 +252,7 @@
 		"swc-loader": "0.2.3",
 		"swr": "1.3.0",
 		"to-string-loader": "1.2.0",
-		"tough-cookie": "4.1.2",
+		"tough-cookie": "4.1.3",
 		"trusted-types": "2.0.0",
 		"ts-loader": "9.4.3",
 		"ts-unused-exports": "8.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16895,17 +16895,7 @@ touch@^3.1.0:
   dependencies:
     nopt "~1.0.10"
 
-tough-cookie@4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-4.1.2.tgz#e53e84b85f24e0b65dd526f46628db6c85f6b874"
-  integrity sha512-G9fqXWoYFZgTc2z8Q5zaHy/vJMjm+WV0AkAeHxVCQiEB1b+dGvWzFW6QV07cY5jQ5gRkeid2qIkzkxUnmoQZUQ==
-  dependencies:
-    psl "^1.1.33"
-    punycode "^2.1.1"
-    universalify "^0.2.0"
-    url-parse "^1.5.3"
-
-tough-cookie@^4.1.2:
+tough-cookie@4.1.3, tough-cookie@^4.1.2:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-4.1.3.tgz#97b9adb0728b42280aa3d814b6b999b2ff0318bf"
   integrity sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==


### PR DESCRIPTION
Keeping dependencies up-to-date.
