### PR TITLE
Set Cypress config `numTestsKeptInMemory`

### DIFF
--- a/dotcom-rendering/cypress.config.js
+++ b/dotcom-rendering/cypress.config.js
@@ -8,6 +8,7 @@ module.exports = defineConfig({
 	viewportHeight: 860,
 	video: false,
 	chromeWebSecurity: false,
+	numTestsKeptInMemory: 5,
 	blockHosts: [
 		'*ophan.theguardian.com',
 		'pixel.adsafeprotected.com',


### PR DESCRIPTION
## What does this change?

We're seeing out of memory errors when running Cypress tests on TeamCity.

This PR attempts to limit memory usage by setting `numTestsKeptInMemory` to a value much less than the default of 50.

https://docs.cypress.io/guides/references/configuration#Global

