### PR TITLE
Inline 'Now' block of Weather widget on Desktop displays

### DIFF
--- a/dotcom-rendering/src/components/WeatherSlot.tsx
+++ b/dotcom-rendering/src/components/WeatherSlot.tsx
@@ -100,6 +100,16 @@ const iconCSS = (size: number) => css`
 	}
 `;
 
+const flexRow = css`
+	display: flex;
+	flex-direction: row;
+`;
+
+const flexColumn = css`
+	display: flex;
+	flex-direction: column;
+`;
+
 const LoadingIcon = () => (
 	<span
 		css={css`
@@ -148,23 +158,13 @@ export const WeatherSlot = ({
 				{isNow ? 'The current weather' : 'The forecast for'}
 			</span>
 			{isNow ? (
-				<div
-					css={css`
-						display: flex;
-						flex-direction: row;
-					`}
-				>
+				<div css={flexRow}>
 					<div>
 						<Suspense fallback={<LoadingIcon />}>
 							<Icon size={50} />
 						</Suspense>
 					</div>
-					<div
-						css={css`
-							display: flex;
-							flex-direction: column;
-						`}
-					>
+					<div css={flexColumn}>
 						<span css={nowCSS} aria-hidden={true}>
 							Now
 						</span>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Inlines the 'Now' block of Weather widget on Desktop displays
## Why?
Fixes https://github.com/guardian/dotcom-rendering/issues/8179
## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/110032454/705369de-2f7c-4fed-b312-692185fee572
[after]: https://github.com/guardian/dotcom-rendering/assets/110032454/6f663ce0-665f-4b03-8046-4a9c7ed51e7b

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
