### PR TITLE
Temporarily disable cypress checks from `ci-dcr.sh`

### DIFF
--- a/scripts/ci-dcr.sh
+++ b/scripts/ci-dcr.sh
@@ -48,7 +48,7 @@ else
 		# Cypress Tests
 		# see https://docs.cypress.io/guides/guides/continuous-integration.html#Advanced-setup
 		# apt-get install xvfb libgtk-3-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2
-		make cypress
+#		make cypress
 	else
 		printf "Skipping code checks when not on main"
 	fi


### PR DESCRIPTION
TeamCity running cypress tests is hanging forever and blocks main builds in DCR. Cypress tests are running via GitHub Actions as well.

<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Temporarily comment out `make cypress` from `ci-drc.sh` so that it doesn't run on main builds. We will still be running the [Cypress GH Action](https://github.com/guardian/dotcom-rendering/blob/47561bb8a5471fc387718825626b6744802c36db/.github/workflows/cypress.yml).

## Why?

Cypress tests are causing TeamCity builds to [timeout](https://teamcity.gutools.co.uk/viewLog.html?buildId=868933&buildTypeId=dotcom_rendering)

![image](https://github.com/guardian/dotcom-rendering/assets/19683595/0070b673-bef2-4ce8-9c43-d01eb50c92bd)

![image](https://github.com/guardian/dotcom-rendering/assets/19683595/6277c6a4-a8ff-474a-b1ff-c818b82bb0c8)




<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
