### PR TITLE
Weather widget - Apply margin to correct element 

### DIFF
--- a/dotcom-rendering/src/components/WeatherSlot.tsx
+++ b/dotcom-rendering/src/components/WeatherSlot.tsx
@@ -14,7 +14,6 @@ import type { WeatherData } from './WeatherData.importable';
 
 interface IconProps {
 	size?: number;
-	margin?: number;
 }
 
 const formatTemperature = (value: number, unit: string) =>
@@ -86,7 +85,7 @@ const tempCSS = (isNow: boolean) => [
 		`,
 ];
 
-const iconCSS = (size: number, margin: number) => css`
+const iconCSS = (size: number) => css`
 	position: absolute;
 	top: 50%;
 	left: 0px;
@@ -97,7 +96,7 @@ const iconCSS = (size: number, margin: number) => css`
 		margin-top: 0;
 		height: ${size}px;
 		width: ${size}px;
-		margin-right: ${margin}px;
+		margin-right: ${size === 50 ? 8 : 0}px;
 	}
 `;
 
@@ -141,9 +140,9 @@ export const WeatherSlot = ({
 		import(`../static/icons/weather/weather-${icon}.svg`).then(
 			({ default: Component }) => {
 				return {
-					default: ({ size = 32, margin = 0 }: IconProps) => (
+					default: ({ size = 32 }: IconProps) => (
 						<Component
-							css={iconCSS(size, margin)}
+							css={iconCSS(size)}
 							aria-hidden={true}
 							className="icon"
 						/>
@@ -162,7 +161,7 @@ export const WeatherSlot = ({
 				<div css={flexRow}>
 					<div>
 						<Suspense fallback={<LoadingIcon />}>
-							<Icon size={50} margin={8} />
+							<Icon size={50} />
 						</Suspense>
 					</div>
 					<div css={flexColumn}>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Changes the element the margin is applied to.
## Why?
Fix bug. 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/110032454/bb8014ea-8e74-4970-b83a-a42eb2bb7d9c
[after]: https://github.com/guardian/dotcom-rendering/assets/110032454/7480fc8b-9721-42fb-82ee-06e6fbcc0805

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
