### PR TITLE
feat: allow Badge component to use branded props

### DIFF
--- a/dotcom-rendering/.storybook/main.js
+++ b/dotcom-rendering/.storybook/main.js
@@ -43,6 +43,11 @@ module.exports = {
 			},
 		},
 	],
+	// This just adds the storybook favicon to make the browser tab more easily identifiable
+	managerHead: (head) => `
+    	${head}
+		<link rel="shortcut icon" href="https://storybook.js.org/favicon.svg">
+	`,
 	webpackFinal: async (config) => {
 		// Get project specific webpack options
 		config = webpackConfig(config);

--- a/dotcom-rendering/src/components/Badge.stories.tsx
+++ b/dotcom-rendering/src/components/Badge.stories.tsx
@@ -1,0 +1,63 @@
+import { Badge } from './Badge';
+
+export default {
+	component: Badge,
+	title: 'Components/Badge',
+};
+
+const BADGES = {
+	hardcoded: {
+		imageSrc:
+			'https://assets.guim.co.uk/static/frontend/badges/this-is-europe.svg',
+		href: '/world/series/this-is-europe',
+	},
+	foundation: {
+		imageSrc:
+			'https://static.theguardian.com/commercial/sponsor/19/Dec/2022/57ba1d00-b2bd-4f6d-ba35-15a82b8d9507-0094b90a-bdb8-4e97-b866-dcf49179b29d-theguardian.org.png',
+		href: 'https://theguardian.org/',
+		label: 'Supported by',
+		aboutThisLinkHref:
+			'https://www.theguardian.com/environment/2023/jan/06/about-animals-farmed-investigating-modern-farming-around-the-world',
+		width: 280,
+		height: 180,
+	},
+	sponsored: {
+		imageSrc:
+			'https://static.theguardian.com/commercial/sponsor/30/Jun/2023/de73b4b2-0a99-4f41-9ad2-aaeb21a95eb0-Google_Pixel_Logo_Grey.png',
+		href: 'https://store.google.com/product/pixel_7a',
+		label: 'Supported by',
+		aboutThisLinkHref:
+			'https://www.theguardian.com/info/2016/jan/25/content-funding',
+		width: 124,
+		height: 45,
+	},
+	paid: {
+		imageSrc:
+			'https://static.theguardian.com/commercial/sponsor/08/Jun/2023/25aa36aa-6f9a-4d41-9f42-1630abe4b6a1-NU_Logo_Black_pos280.png',
+		href: 'https://www.northumbria.ac.uk/study-at-northumbria/ucas-clearing-confirmation-adjustment-and-extra',
+		label: 'Paid for by',
+		aboutThisLinkHref: '',
+		width: 280,
+		height: 180,
+	},
+};
+
+export const Hardcoded = () => {
+	return <Badge {...BADGES.hardcoded} />;
+};
+Hardcoded.storyName = 'Hardcoded';
+
+export const FoundationFunded = () => {
+	return <Badge {...BADGES.foundation} />;
+};
+FoundationFunded.storyName = 'Sponsored Badge - foundation funded';
+
+export const Sponsored = () => {
+	return <Badge {...BADGES.sponsored} />;
+};
+Sponsored.storyName = 'Sponsored Badge - sponsored';
+
+export const Paid = () => {
+	return <Badge {...BADGES.paid} />;
+};
+Paid.storyName = 'Sponsored Badge - paid';

--- a/dotcom-rendering/src/components/Badge.tsx
+++ b/dotcom-rendering/src/components/Badge.tsx
@@ -6,6 +6,7 @@ const badgeSizingStyles = (width?: number, height?: number) => {
 	// where the size of the badge is unknown
 	if (width === undefined || height === undefined) {
 		return css`
+			width: auto;
 			height: 42px;
 			${from.leftCol} {
 				height: 54px;

--- a/dotcom-rendering/src/components/Badge.tsx
+++ b/dotcom-rendering/src/components/Badge.tsx
@@ -1,36 +1,95 @@
 import { css } from '@emotion/react';
-import { from } from '@guardian/source-foundations';
+import { from, palette, textSans } from '@guardian/source-foundations';
 
-const badgeSizingStyles = css`
-	height: 42px;
-	${from.leftCol} {
-		height: 54px;
+const badgeSizingStyles = (width?: number, height?: number) => {
+	// This default applies to non-sponsored badges
+	// where the size of the badge is unknown
+	if (width === undefined || height === undefined) {
+		return css`
+			height: 42px;
+			${from.leftCol} {
+				height: 54px;
+			}
+		`;
+	} else {
+		// The sizing here uses the width and height from the branding
+		// The badge is at half size unless at wide viewpoints
+		return css`
+			width: ${width / 2}px;
+			height: ${height / 2}px;
+			${from.wide} {
+				width: ${width}px;
+				height: ${height}px;
+			}
+		`;
 	}
-`;
+};
 
 const imageStyles = css`
 	display: block;
-	width: auto;
 	max-width: 100%;
 	object-fit: contain;
-	${badgeSizingStyles}
 `;
 
 const badgeLink = css`
 	text-decoration: none;
 `;
 
+const labelStyles = css`
+	${textSans.xxsmall()};
+	line-height: 1rem;
+	color: ${palette.neutral[46]};
+	font-weight: bold;
+	margin-top: 0.375rem;
+	padding-right: 0.625rem;
+	padding-bottom: 0.625rem;
+	text-align: left;
+`;
+
+const aboutThisLinkStyles = css`
+	${textSans.xxsmall()};
+	line-height: 11px;
+	color: ${palette.neutral[46]};
+	font-weight: normal;
+	text-decoration: none;
+`;
+
 type Props = {
 	imageSrc: string;
 	href: string;
+	label?: string;
+	aboutThisLinkHref?: string;
+	sponsorName?: string;
+	width?: number;
+	height?: number;
 };
 
-export const Badge = ({ imageSrc, href }: Props) => {
+export const Badge = ({
+	imageSrc,
+	href,
+	label,
+	aboutThisLinkHref,
+	sponsorName,
+	width,
+	height,
+}: Props) => {
 	return (
-		<div css={badgeSizingStyles}>
+		<>
+			{!!label && <p css={labelStyles}>{label}</p>}
+
 			<a href={href} css={badgeLink} role="button">
-				<img css={imageStyles} src={imageSrc} alt="" />
+				<img
+					css={[imageStyles, badgeSizingStyles(width, height)]}
+					src={imageSrc}
+					alt={`${sponsorName ?? 'brand'} logo`}
+				/>
 			</a>
-		</div>
+
+			{!!aboutThisLinkHref && (
+				<a css={aboutThisLinkStyles} href={aboutThisLinkHref}>
+					About this content
+				</a>
+			)}
+		</>
 	);
 };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Allows the `Badge.tsx` component to accept props relating to branded badges. Adds Storybook stories to show how this badge component will look with various types of badges.
These new props are not being used yet so this shouldn't massively affect styling of badges (yet), as providing the props in the relevant places will come in following PRs.

**Mini extra**
I added a favicon to Storybook as I find it helpful to identify which window/tab I'm working on when I've got lots of tabs open on my browser.

## Why?

Since `<Badge>` is being used for both the hardcoded type of badge and the branded, sponsored content type of badge, we may as well use the same component. 

Whether we _should_ combine `Branding` and `Badge` components is a totally different discussion. This PR will remain WIP until we've decided which way we're going.

See [Badges doc](https://docs.google.com/document/d/1yPCmjz33SahtVrzT-7E8Iau6hoo46YFUgLDBJJSJwJw/edit?usp=sharing) for more context.

## Screenshots
These are to demonstrate that no visual difference should arise from this change:

| Before      | After      |
| ----------- | ---------- |
| ![before1][] | ![after1][] |
| ![before2][] | ![after2][] |
| ![before3][] | ![after3][] |
| ![before4][] | ![after4][] |

[before1]: https://github.com/guardian/dotcom-rendering/assets/43961396/4220e733-1fe6-400d-9886-7e896600edfb
[after1]: https://github.com/guardian/dotcom-rendering/assets/43961396/18ae29d9-a706-4cbe-92ea-906a10fa430b
[before2]: https://github.com/guardian/dotcom-rendering/assets/43961396/0ea3e7d8-54d8-47ae-a592-daa7c0789da2
[after2]: https://github.com/guardian/dotcom-rendering/assets/43961396/e0901acc-1bc3-445e-8766-577406275d55
[before3]: https://github.com/guardian/dotcom-rendering/assets/43961396/e7a5e5e3-7992-4f73-96ee-37a73a89913a
[after3]: https://github.com/guardian/dotcom-rendering/assets/43961396/5587b100-e693-453e-88ba-5b0514cc2ad8
[before4]: https://github.com/guardian/dotcom-rendering/assets/43961396/2d80e084-b291-496d-b4e8-63204ca28a45
[after4]: https://github.com/guardian/dotcom-rendering/assets/43961396/1c5c2c77-ea6b-4e81-a92f-9a54c36d08bb


