### PR TITLE
Perfectly crisp contributor avatars

### DIFF
--- a/dotcom-rendering/src/components/ContributorAvatar.tsx
+++ b/dotcom-rendering/src/components/ContributorAvatar.tsx
@@ -1,12 +1,29 @@
 import { css } from '@emotion/react';
-import { from } from '@guardian/source-foundations';
+import { breakpoints, from } from '@guardian/source-foundations';
+import { getSourceImageUrl } from '../lib/getSourceImageUrl_temp_fix';
+import { generateSources, getFallbackSource, Sources } from './Picture';
+
+const widths = [
+	{ breakpoint: breakpoints.mobile, width: 180 },
+	{ breakpoint: breakpoints.mobileLandscape, width: 216 },
+] as const satisfies ReadonlyArray<{ breakpoint: number; width: number }>;
 
 const imageStyles = css`
-	height: 9.375rem;
+	width: ${widths[0].width}px;
 
 	${from.mobileLandscape} {
-		height: 11.25rem;
+		width: ${widths[1].width}px;
 	}
+`;
+
+/**
+ * Used on `picture` and `img` to prevent having a line-height,
+ * as these elements are `inline` by default.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#styling_with_css
+ */
+const block = css`
+	display: block;
 `;
 
 type Props = {
@@ -15,5 +32,16 @@ type Props = {
 };
 
 export const ContributorAvatar = ({ imageSrc, imageAlt }: Props) => {
-	return <img src={imageSrc} alt={imageAlt} css={imageStyles} />;
+	const sources = generateSources(getSourceImageUrl(imageSrc), widths);
+
+	return (
+		<picture css={block}>
+			<Sources sources={sources} />
+			<img
+				alt={imageAlt}
+				src={getFallbackSource(sources).lowResUrl}
+				css={[block, imageStyles]}
+			/>
+		</picture>
+	);
 };

--- a/dotcom-rendering/src/components/Picture.tsx
+++ b/dotcom-rendering/src/components/Picture.tsx
@@ -272,7 +272,7 @@ type ImageSource = {
  */
 export const generateSources = (
 	master: string,
-	imageWidths: [ImageWidthType, ...ImageWidthType[]],
+	imageWidths: readonly [ImageWidthType, ...ImageWidthType[]],
 ): ImageSource[] =>
 	imageWidths
 		.slice()


### PR DESCRIPTION
## What does this change?

Align the sources’ width with the CSS dimensions.

## Why?

The crisper images the better.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/76776/f42c9bf1-f6e2-45de-818b-8668c6fd5425
[after]: https://github.com/guardian/dotcom-rendering/assets/76776/aecb03c2-4f60-4d22-aa56-c4569dded4fa