### PR TITLE
Rename `frontend.server.js` to `server.js`

### DIFF
--- a/.github/workflows/pr-deployment.yml
+++ b/.github/workflows/pr-deployment.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Boot server and run ngrok
         run: |
           npm install -g ngrok
-          NODE_ENV=production DISABLE_LOGGING_AND_METRICS=true node dotcom-rendering/dist/frontend.server.js &
+          NODE_ENV=production DISABLE_LOGGING_AND_METRICS=true node dotcom-rendering/dist/server.js &
           timeout 5h ngrok http 9000 -log=stdout | \
             grep --line-buffered -o 'https://.*' | \
             xargs -L1 -I{} -t \

--- a/dotcom-rendering/Containerfile
+++ b/dotcom-rendering/Containerfile
@@ -11,4 +11,4 @@ EXPOSE 9000
 ENV DISABLE_LOGGING_AND_METRICS=true
 ENV NODE_ENV=production
 
-ENTRYPOINT ["node", "dist/frontend.server.js"]
+ENTRYPOINT ["node", "dist/server.js"]

--- a/dotcom-rendering/docs/development/run-prod-bundle-locally.md
+++ b/dotcom-rendering/docs/development/run-prod-bundle-locally.md
@@ -6,7 +6,7 @@ production build locally.
 To do this:
 
     $ make build
-    $ node dist/frontend-server.js
+    $ node dist/server.js
 
 *Note, you will need AWS `frontend` credentials to run the service.*
 

--- a/dotcom-rendering/lighthouserc.js
+++ b/dotcom-rendering/lighthouserc.js
@@ -3,7 +3,7 @@ module.exports = {
 		collect: {
 			url: [process.env.LHCI_URL],
 			startServerCommand:
-				'NODE_ENV=production DISABLE_LOGGING_AND_METRICS=true node dist/frontend.server.js',
+				'NODE_ENV=production DISABLE_LOGGING_AND_METRICS=true node dist/server.js',
 			numberOfRuns: '10',
 			puppeteerScript: './scripts/lighthouse/puppeteer-script.js',
 			settings: {

--- a/dotcom-rendering/makefile
+++ b/dotcom-rendering/makefile
@@ -112,7 +112,7 @@ cypress: clear clean-dist install build
 	@NODE_ENV=production DISABLE_LOGGING_AND_METRICS=true start-server-and-test 'node dist/server.js' 9000 'cypress run --spec "cypress/e2e/**/*"'
 
 cypress-open: clear clean-dist install build
-	$(call log, "starting frontend PROD server and opening Cypress")
+	$(call log, "starting PROD server and opening Cypress")
 	@NODE_ENV=production DISABLE_LOGGING_AND_METRICS=true start-server-and-test 'node dist/server.js' 9000 'cypress open --e2e --browser electron'
 
 ampValidation: clean-dist install

--- a/dotcom-rendering/makefile
+++ b/dotcom-rendering/makefile
@@ -46,12 +46,12 @@ build-ci: clean-dist install
 
 start-ci: install
 	$(call log, "starting PROD server...")
-	@NODE_ENV=production DISABLE_LOGGING_AND_METRICS=true node dist/frontend.server.js
+	@NODE_ENV=production DISABLE_LOGGING_AND_METRICS=true node dist/server.js
 
 start: install
 	$(call log, "starting PROD server...")
 	@echo '' # just a spacer
-	NODE_ENV=production pm2 start dist/frontend.server.js
+	NODE_ENV=production pm2 start dist/server.js
 	@echo '' # just a spacer
 	$(call log, "PROD server is running")
 	@NODE_ENV=production pm2 logs
@@ -62,7 +62,7 @@ start: install
 start-prod:
 	$(call log, "starting PROD server...")
 	@echo '' # just a spacer
-	NODE_ENV=production /usr/local/node/pm2 start --uid dotcom-rendering --gid frontend dist/frontend.server.js
+	NODE_ENV=production /usr/local/node/pm2 start --uid dotcom-rendering --gid frontend dist/server.js
 	@echo '' # just a spacer
 	$(call log, "PROD server is running")
 
@@ -109,11 +109,11 @@ storybook-dev: clear clean-dist install
 
 cypress: clear clean-dist install build
 	$(call log, "starting frontend PROD server for Cypress")
-	@NODE_ENV=production DISABLE_LOGGING_AND_METRICS=true start-server-and-test 'node dist/frontend.server.js' 9000 'cypress run --spec "cypress/e2e/**/*"'
+	@NODE_ENV=production DISABLE_LOGGING_AND_METRICS=true start-server-and-test 'node dist/server.js' 9000 'cypress run --spec "cypress/e2e/**/*"'
 
 cypress-open: clear clean-dist install build
 	$(call log, "starting frontend PROD server and opening Cypress")
-	@NODE_ENV=production DISABLE_LOGGING_AND_METRICS=true start-server-and-test 'node dist/frontend.server.js' 9000 'cypress open --e2e --browser electron'
+	@NODE_ENV=production DISABLE_LOGGING_AND_METRICS=true start-server-and-test 'node dist/server.js' 9000 'cypress open --e2e --browser electron'
 
 ampValidation: clean-dist install
 	$(call log, "starting AMP Validation test")

--- a/dotcom-rendering/makefile
+++ b/dotcom-rendering/makefile
@@ -108,7 +108,7 @@ storybook-dev: clear clean-dist install
 # tests #####################################
 
 cypress: clear clean-dist install build
-	$(call log, "starting frontend PROD server for Cypress")
+	$(call log, "starting PROD server for Cypress")
 	@NODE_ENV=production DISABLE_LOGGING_AND_METRICS=true start-server-and-test 'node dist/server.js' 9000 'cypress run --spec "cypress/e2e/**/*"'
 
 cypress-open: clear clean-dist install build

--- a/dotcom-rendering/scripts/webpack/webpack.config.dev-server.js
+++ b/dotcom-rendering/scripts/webpack/webpack.config.dev-server.js
@@ -79,7 +79,7 @@ module.exports = {
 				name: 'server',
 				// @ts-expect-error -- it’s a MultiCompiler
 				middleware: webpackHotServerMiddleware(devServer.compiler, {
-					chunkName: 'frontend.server',
+					chunkName: 'server',
 				}),
 			});
 

--- a/dotcom-rendering/scripts/webpack/webpack.config.server.js
+++ b/dotcom-rendering/scripts/webpack/webpack.config.server.js
@@ -24,7 +24,7 @@ const swcLoader = [
 /** @type {(options: { sessionId: string } ) => import('webpack').Configuration} */
 module.exports = ({ sessionId }) => ({
 	entry: {
-		'frontend.server': './src/server/index.ts',
+		server: './src/server/index.ts',
 	},
 	output: {
 		filename: `[name].js`,


### PR DESCRIPTION
## What does this change?

Rename the dist server output file from `frontend.server.js` to `server.js`

## Why?

'frontend' is a potentially confusing and unnecessary prefix for the server app.

I assume it's a hangover from ye olde Frontend.

