### PR TITLE
Render a video card on fronts if showMainVideo is enabled

### DIFF
--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -318,7 +318,6 @@ export type DCRFrontCard = {
 	branding?: Branding;
 	slideshowImages?: DCRSlideshowImage[];
 	showLivePlayable: boolean;
-	showMainVideo?: boolean;
 };
 
 export type DCRSlideshowImage = {


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
This makes use of the `showMainVideo` boolean so that when it is true, a mainMedia is passed to the card, so that a video card renders.

Note: this updates the card image, which is expected as we are now displaying the image as selected by editorial in the video tool

## Why?
Parity with frontend, editorial expect a video card to be rendered  when the showVideo toggle is on in the fronts tool

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| <img width="1278" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/a7ff9c08-9115-4b96-9fb2-5556ac3cee80"> | <img width="1278" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/f416409c-efda-4eff-b067-3f31215b569e"> |


<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
