### PR TITLE
Use British English Date Format (`en-GB`) On Fronts

### DIFF
--- a/dotcom-rendering/src/components/ContainerTitle.tsx
+++ b/dotcom-rendering/src/components/ContainerTitle.tsx
@@ -10,7 +10,6 @@ import {
 } from '@guardian/source-foundations';
 import { decideContainerOverrides } from '../lib/decideContainerOverrides';
 import type { EditionId } from '../lib/edition';
-import { getEditionFromId } from '../lib/edition';
 import type { DCRContainerPalette } from '../types/front';
 import type { Colour } from '../types/palette';
 import { localisedTitle } from './Localisation';
@@ -103,7 +102,6 @@ export const ContainerTitle = ({
 		containerPalette && decideContainerOverrides(containerPalette);
 
 	const now = new Date();
-	const locale = editionId && getEditionFromId(editionId).locale;
 	return (
 		<div css={marginStyles}>
 			{url ? (
@@ -134,7 +132,7 @@ export const ContainerTitle = ({
 							overrides?.text.containerDate ?? neutral[0],
 						)}
 					>
-						{now.toLocaleDateString(locale, { weekday: 'long' })}
+						{now.toLocaleDateString('en-GB', { weekday: 'long' })}
 					</span>
 					<span
 						css={[
@@ -147,7 +145,7 @@ export const ContainerTitle = ({
 							bottomMargin,
 						]}
 					>
-						{now.toLocaleDateString(locale, {
+						{now.toLocaleDateString('en-GB', {
 							day: 'numeric',
 							month: 'long',
 							year: 'numeric',

--- a/dotcom-rendering/src/layouts/TagFrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/TagFrontLayout.tsx
@@ -261,7 +261,7 @@ export const TagFrontLayout = ({ tagFront, NAV }: Props) => {
 					return (
 						<Fragment key={containedId}>
 							<FrontSection
-								title={date.toLocaleDateString(locale, {
+								title={date.toLocaleDateString('en-GB', {
 									day:
 										groupedTrails.day !== undefined
 											? 'numeric'


### PR DESCRIPTION
## Why?

They were using the US date format of the form "`month` `date`, `year`" when the user's edition was set to US. This is incorrect according to our style guide (see the "dates" entry): https://www.theguardian.com/guardian-observer-style-guide-d

This occurred in two places that I could find:

- The date in the headlines container on network fronts; for example: https://www.theguardian.com/uk
- The dates that form the container title on tag fronts; for example: https://www.theguardian.com/tone/features

To replicate the problem set your edition to US and make sure you're viewing the DCR version of the above pages.

Let me know if you're aware of other places to update!

## Changes

Set the `en-GB` locale for some usages of `toLocaleDateString`. The previous implementation used a locale derived from edition, which can be one of `en-gb`, `en-us` or `en-au`. We didn't notice this problem for the AU edition because Australian dates of this format are the same as British ones.

https://github.com/guardian/dotcom-rendering/blob/4b28ee6a180a108fceec6080e9cbc3f3032f6ae8/dotcom-rendering/src/lib/edition.ts#L12-L48

## Screenshots

| | Before | After |
| - | - | - |
| Network Front | ![network-front-before] | ![network-front-after] |
| Tag Front | ![tag-front-before] | ![tag-front-after] |

[tag-front-after]: https://github.com/guardian/dotcom-rendering/assets/53781962/69ff89ee-2296-41db-9b6f-fb8332d9a638
[tag-front-before]: https://github.com/guardian/dotcom-rendering/assets/53781962/0559b228-f835-455b-a887-d0b40c5d9fc6
[network-front-after]: https://github.com/guardian/dotcom-rendering/assets/53781962/5176ffba-67b4-4e15-881b-1e2da1061575
[network-front-before]: https://github.com/guardian/dotcom-rendering/assets/53781962/6508705b-8e18-40fc-b9b2-63556e5a879f
