### PR TITLE
Liveblog right hand ad test

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -65,7 +65,7 @@
 		"@guardian/bridget": "2.3.0",
 		"@guardian/browserslist-config": "5.0.0",
 		"@guardian/cdk": "49.5.0",
-		"@guardian/commercial": "10.6.0",
+		"@guardian/commercial": "10.8.0",
 		"@guardian/consent-management-platform": "13.5.0",
 		"@guardian/core-web-vitals": "5.0.0",
 		"@guardian/eslint-config": "4.1.0",

--- a/dotcom-rendering/src/components/AdSlot.tsx
+++ b/dotcom-rendering/src/components/AdSlot.tsx
@@ -14,29 +14,31 @@ import {
 import { Island } from '../components/Island';
 import { pageSkinContainer } from '../layouts/lib/pageSkin';
 import { getZIndex } from '../lib/getZIndex';
+import { AD_CONTAINER_HEIGHT } from '../lib/liveblog-right-ad-constants';
 import { TopRightAdSlot } from './TopRightAdSlot.importable';
 
-type InlinePosition = 'inline' | 'liveblog-inline' | 'mobile-front';
+type InlinePosition =
+	| 'inline'
+	| 'liveblog-inline'
+	| 'liveblog-right'
+	| 'mobile-front';
 
-type InlineProps = {
+type DefaultProps = {
 	display?: ArticleDisplay;
-	position: InlinePosition;
-	index: number;
-	shouldHideReaderRevenue?: boolean;
 	isPaidContent?: boolean;
 	hasPageskin?: boolean;
 };
 
-// TODO move to commercial
 type SlotNamesWithPageSkin = SlotName | 'pageskin';
 
+type InlineProps = {
+	position: InlinePosition;
+	index: number;
+};
+
 type NonInlineProps = {
-	display?: ArticleDisplay;
 	position: Exclude<SlotNamesWithPageSkin, InlinePosition>;
 	index?: never;
-	shouldHideReaderRevenue?: boolean;
-	isPaidContent?: boolean;
-	hasPageskin?: boolean;
 };
 
 /**
@@ -44,7 +46,7 @@ type NonInlineProps = {
  * based on position. If `position` is 'inline' or 'mobile-front' then we expect the index
  * value. If not, then we explicitly refuse this property
  */
-type Props = InlineProps | NonInlineProps;
+type Props = DefaultProps & (InlineProps | NonInlineProps);
 
 export const labelHeight = 24;
 
@@ -126,9 +128,9 @@ export const labelStyles = css`
 	.ad-slot--interscroller[data-label-show='true']::before {
 		content: 'Advertisement';
 		position: absolute;
-		top: 0px;
-		left: 0px;
-		right: 0px;
+		top: 0;
+		left: 0;
+		right: 0;
 		border: 0;
 		display: block;
 		${individualLabelCSS}
@@ -327,6 +329,40 @@ export const AdSlot = ({
 				default:
 					return null;
 			}
+		case 'liveblog-right': {
+			const advertId = `liveblog-right-${index}`;
+			return (
+				<div
+					className="ad-slot-container"
+					css={[
+						labelStyles,
+						css`
+							height: ${AD_CONTAINER_HEIGHT}px;
+						`,
+					]}
+				>
+					<div
+						id={`dfp-ad--${advertId}`}
+						className={[
+							'js-ad-slot',
+							'ad-slot',
+							`ad-slot--${advertId}`,
+							'ad-slot--liveblog-right',
+							'ad-slot--rendered',
+						].join(' ')}
+						css={[
+							css`
+								position: sticky;
+								top: 0;
+							`,
+						]}
+						data-link-name={`ad slot ${advertId}`}
+						data-name={advertId}
+						aria-hidden="true"
+					/>
+				</div>
+			);
+		}
 		case 'comments': {
 			return (
 				<div className="ad-slot-container" css={[adContainerStyles]}>

--- a/dotcom-rendering/src/components/AdSlot.tsx
+++ b/dotcom-rendering/src/components/AdSlot.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { adSizes } from '@guardian/commercial';
+import { adSizes, constants } from '@guardian/commercial';
 import type { SlotName } from '@guardian/commercial';
 import { ArticleDisplay } from '@guardian/libs';
 import {
@@ -30,6 +30,7 @@ type DefaultProps = {
 	isLiveblog?: boolean;
 };
 
+// TODO move to commercial
 type SlotNamesWithPageSkin = SlotName | 'pageskin';
 
 type InlineProps = {
@@ -43,13 +44,13 @@ type NonInlineProps = {
 };
 
 /**
- * This union type allows us to conditionally require the index property
- * based on position. If `position` is 'inline' or 'mobile-front' then we expect the index
- * value. If not, then we explicitly refuse this property
+ * This allows us to conditionally require the index property based
+ * on position. If `position` is an inline type then we expect the
+ * index value. If not, then we explicitly refuse this property
  */
 type Props = DefaultProps & (InlineProps | NonInlineProps);
 
-export const labelHeight = 24;
+export const labelHeight = constants.AD_LABEL_HEIGHT.toString();
 
 const individualLabelCSS = css`
 	${textSans.xxsmall()};
@@ -320,7 +321,8 @@ export const AdSlot = ({
 				}
 				case ArticleDisplay.Standard: {
 					return isLiveblog ? (
-						// We've already created an Island for liveblogs
+						// We've already created an Island for liveblogs. This can be
+						// simplified when we remove the liveblogRightColumnAds ab test
 						<TopRightAdSlot
 							isPaidContent={isPaidContent}
 							adStyles={[labelStyles]}

--- a/dotcom-rendering/src/components/AdSlot.tsx
+++ b/dotcom-rendering/src/components/AdSlot.tsx
@@ -14,8 +14,7 @@ import {
 import { pageSkinContainer } from '../layouts/lib/pageSkin';
 import { getZIndex } from '../lib/getZIndex';
 import { AD_CONTAINER_HEIGHT } from '../lib/liveblog-right-ad-constants';
-import { Island } from './Island';
-import { TopRightAdSlot } from './TopRightAdSlot.importable';
+import { TopRightAdSlot } from './TopRightAdSlot';
 
 type InlinePosition =
 	| 'inline'
@@ -27,7 +26,6 @@ type DefaultProps = {
 	display?: ArticleDisplay;
 	isPaidContent?: boolean;
 	hasPageskin?: boolean;
-	isLiveblog?: boolean;
 };
 
 // TODO move to commercial
@@ -292,7 +290,6 @@ export const AdSlot = ({
 	isPaidContent = false,
 	index,
 	hasPageskin = false,
-	isLiveblog = false,
 }: Props) => {
 	switch (position) {
 		case 'right':
@@ -323,20 +320,11 @@ export const AdSlot = ({
 					);
 				}
 				case ArticleDisplay.Standard: {
-					return isLiveblog ? (
-						// We've already created an Island for liveblogs. This can be
-						// simplified when we remove the liveblogRightColumnAds ab test
+					return (
 						<TopRightAdSlot
 							isPaidContent={isPaidContent}
 							adStyles={[labelStyles]}
 						/>
-					) : (
-						<Island clientOnly={true}>
-							<TopRightAdSlot
-								isPaidContent={isPaidContent}
-								adStyles={[labelStyles]}
-							/>
-						</Island>
 					);
 				}
 				default:

--- a/dotcom-rendering/src/components/AdSlot.tsx
+++ b/dotcom-rendering/src/components/AdSlot.tsx
@@ -301,7 +301,10 @@ export const AdSlot = ({
 				case ArticleDisplay.Showcase:
 				case ArticleDisplay.NumberedList: {
 					return (
-						<div className="ad-slot-container" css={[adContainerStyles]}>
+						<div
+							className="ad-slot-container"
+							css={[adContainerStyles]}
+						>
 							<div
 								id="dfp-ad--right"
 								className={[
@@ -412,7 +415,11 @@ export const AdSlot = ({
 						'ad-slot--mpu-banner-ad',
 						'ad-slot--rendered',
 					].join(' ')}
-					css={[fluidAdStyles, fluidFullWidthAdStyles, adSlotAboveNav]}
+					css={[
+						fluidAdStyles,
+						fluidFullWidthAdStyles,
+						adSlotAboveNav,
+					]}
 					data-link-name="ad slot top-above-nav"
 					data-name="top-above-nav"
 					aria-hidden="true"
@@ -459,7 +466,11 @@ export const AdSlot = ({
 							'ad-slot',
 							'ad-slot--merchandising-high',
 						].join(' ')}
-						css={[merchandisingAdStyles, fluidAdStyles, fluidFullWidthAdStyles]}
+						css={[
+							merchandisingAdStyles,
+							fluidAdStyles,
+							fluidFullWidthAdStyles,
+						]}
 						data-link-name="ad slot merchandising-high"
 						data-name="merchandising-high"
 						data-refresh="false"
@@ -482,10 +493,16 @@ export const AdSlot = ({
 				>
 					<div
 						id="dfp-ad--merchandising"
-						className={['js-ad-slot', 'ad-slot', 'ad-slot--merchandising'].join(
-							' ',
-						)}
-						css={[merchandisingAdStyles, fluidAdStyles, fluidFullWidthAdStyles]}
+						className={[
+							'js-ad-slot',
+							'ad-slot',
+							'ad-slot--merchandising',
+						].join(' ')}
+						css={[
+							merchandisingAdStyles,
+							fluidAdStyles,
+							fluidFullWidthAdStyles,
+						]}
 						data-link-name="ad slot merchandising"
 						data-name="merchandising"
 						aria-hidden="true"
@@ -497,7 +514,11 @@ export const AdSlot = ({
 			return (
 				<div
 					id="dfp-ad--survey"
-					className={['js-ad-slot', 'ad-slot', 'ad-slot--survey'].join(' ')}
+					className={[
+						'js-ad-slot',
+						'ad-slot',
+						'ad-slot--survey',
+					].join(' ')}
 					css={[outOfPageStyles, adSlotCollapseStyles]}
 					data-link-name="ad slot survey"
 					data-name="survey"
@@ -639,5 +660,7 @@ export const AdSlot = ({
 };
 
 export const MobileStickyContainer = () => {
-	return <div className="mobilesticky-container" css={mobileStickyAdStyles} />;
+	return (
+		<div className="mobilesticky-container" css={mobileStickyAdStyles} />
+	);
 };

--- a/dotcom-rendering/src/components/AdSlot.tsx
+++ b/dotcom-rendering/src/components/AdSlot.tsx
@@ -11,10 +11,10 @@ import {
 	textSans,
 	until,
 } from '@guardian/source-foundations';
-import { Island } from '../components/Island';
 import { pageSkinContainer } from '../layouts/lib/pageSkin';
 import { getZIndex } from '../lib/getZIndex';
 import { AD_CONTAINER_HEIGHT } from '../lib/liveblog-right-ad-constants';
+import { Island } from './Island';
 import { TopRightAdSlot } from './TopRightAdSlot.importable';
 
 type InlinePosition =
@@ -27,6 +27,7 @@ type DefaultProps = {
 	display?: ArticleDisplay;
 	isPaidContent?: boolean;
 	hasPageskin?: boolean;
+	isLiveblog?: boolean;
 };
 
 type SlotNamesWithPageSkin = SlotName | 'pageskin';
@@ -290,6 +291,7 @@ export const AdSlot = ({
 	isPaidContent = false,
 	index,
 	hasPageskin = false,
+	isLiveblog = false,
 }: Props) => {
 	switch (position) {
 		case 'right':
@@ -317,7 +319,13 @@ export const AdSlot = ({
 					);
 				}
 				case ArticleDisplay.Standard: {
-					return (
+					return isLiveblog ? (
+						// We've already created an Island for liveblogs
+						<TopRightAdSlot
+							isPaidContent={isPaidContent}
+							adStyles={[labelStyles]}
+						/>
+					) : (
 						<Island clientOnly={true}>
 							<TopRightAdSlot
 								isPaidContent={isPaidContent}

--- a/dotcom-rendering/src/components/AdSlot.tsx
+++ b/dotcom-rendering/src/components/AdSlot.tsx
@@ -11,6 +11,7 @@ import {
 	textSans,
 	until,
 } from '@guardian/source-foundations';
+import { Island } from '../components/Island';
 import { pageSkinContainer } from '../layouts/lib/pageSkin';
 import { getZIndex } from '../lib/getZIndex';
 import { TopRightAdSlot } from './TopRightAdSlot.importable';
@@ -295,10 +296,7 @@ export const AdSlot = ({
 				case ArticleDisplay.Showcase:
 				case ArticleDisplay.NumberedList: {
 					return (
-						<div
-							className="ad-slot-container"
-							css={[adContainerStyles]}
-						>
+						<div className="ad-slot-container" css={[adContainerStyles]}>
 							<div
 								id="dfp-ad--right"
 								className={[
@@ -318,10 +316,12 @@ export const AdSlot = ({
 				}
 				case ArticleDisplay.Standard: {
 					return (
-						<TopRightAdSlot
-							isPaidContent={isPaidContent}
-							adStyles={[labelStyles]}
-						/>
+						<Island clientOnly={true}>
+							<TopRightAdSlot
+								isPaidContent={isPaidContent}
+								adStyles={[labelStyles]}
+							/>
+						</Island>
 					);
 				}
 				default:
@@ -366,11 +366,7 @@ export const AdSlot = ({
 						'ad-slot--mpu-banner-ad',
 						'ad-slot--rendered',
 					].join(' ')}
-					css={[
-						fluidAdStyles,
-						fluidFullWidthAdStyles,
-						adSlotAboveNav,
-					]}
+					css={[fluidAdStyles, fluidFullWidthAdStyles, adSlotAboveNav]}
 					data-link-name="ad slot top-above-nav"
 					data-name="top-above-nav"
 					aria-hidden="true"
@@ -417,11 +413,7 @@ export const AdSlot = ({
 							'ad-slot',
 							'ad-slot--merchandising-high',
 						].join(' ')}
-						css={[
-							merchandisingAdStyles,
-							fluidAdStyles,
-							fluidFullWidthAdStyles,
-						]}
+						css={[merchandisingAdStyles, fluidAdStyles, fluidFullWidthAdStyles]}
 						data-link-name="ad slot merchandising-high"
 						data-name="merchandising-high"
 						data-refresh="false"
@@ -444,16 +436,10 @@ export const AdSlot = ({
 				>
 					<div
 						id="dfp-ad--merchandising"
-						className={[
-							'js-ad-slot',
-							'ad-slot',
-							'ad-slot--merchandising',
-						].join(' ')}
-						css={[
-							merchandisingAdStyles,
-							fluidAdStyles,
-							fluidFullWidthAdStyles,
-						]}
+						className={['js-ad-slot', 'ad-slot', 'ad-slot--merchandising'].join(
+							' ',
+						)}
+						css={[merchandisingAdStyles, fluidAdStyles, fluidFullWidthAdStyles]}
 						data-link-name="ad slot merchandising"
 						data-name="merchandising"
 						aria-hidden="true"
@@ -465,11 +451,7 @@ export const AdSlot = ({
 			return (
 				<div
 					id="dfp-ad--survey"
-					className={[
-						'js-ad-slot',
-						'ad-slot',
-						'ad-slot--survey',
-					].join(' ')}
+					className={['js-ad-slot', 'ad-slot', 'ad-slot--survey'].join(' ')}
 					css={[outOfPageStyles, adSlotCollapseStyles]}
 					data-link-name="ad slot survey"
 					data-name="survey"
@@ -611,7 +593,5 @@ export const AdSlot = ({
 };
 
 export const MobileStickyContainer = () => {
-	return (
-		<div className="mobilesticky-container" css={mobileStickyAdStyles} />
-	);
+	return <div className="mobilesticky-container" css={mobileStickyAdStyles} />;
 };

--- a/dotcom-rendering/src/components/ArticleContainer.tsx
+++ b/dotcom-rendering/src/components/ArticleContainer.tsx
@@ -1,8 +1,8 @@
 import { css } from '@emotion/react';
-import { adSizes } from '@guardian/commercial';
+import { adSizes, constants } from '@guardian/commercial';
 import { ArticleDesign } from '@guardian/libs';
 import { from, neutral, space, until } from '@guardian/source-foundations';
-import { carrotAdStyles, labelHeight, labelStyles } from './AdSlot';
+import { carrotAdStyles, labelStyles } from './AdSlot';
 
 type Props = {
 	format: ArticleFormat;
@@ -123,9 +123,10 @@ const adStyles = css`
 		.ad-slot--liveblog-inline {
 			/* outstreamMobile is the ad with the smallest height that we serve for mobile
 			   liveblog-inline slots. For desktop, this is an mpu */
-			min-height: ${adSizes.outstreamMobile.height + labelHeight}px;
+			min-height: ${adSizes.outstreamMobile.height +
+			constants.AD_LABEL_HEIGHT}px;
 			${from.desktop} {
-				min-height: ${adSizes.mpu.height + labelHeight}px;
+				min-height: ${adSizes.mpu.height + constants.AD_LABEL_HEIGHT}px;
 			}
 
 			background-color: ${neutral[93]};

--- a/dotcom-rendering/src/components/HeaderAdSlot.tsx
+++ b/dotcom-rendering/src/components/HeaderAdSlot.tsx
@@ -43,7 +43,9 @@ export const HeaderAdSlot = () => (
 				* Hides the top-above-nav ad-slot container when a
 				* Bonzai TrueSkin (Australian 3rd Party page skin) is shown
 				*/
-				.bz-custom-container ~ #bannerandheader .top-banner-ad-container {
+				.bz-custom-container
+					~ #bannerandheader
+					.top-banner-ad-container {
 					display: none;
 				}
 			`}

--- a/dotcom-rendering/src/components/HeaderAdSlot.tsx
+++ b/dotcom-rendering/src/components/HeaderAdSlot.tsx
@@ -1,12 +1,14 @@
 import { css, Global } from '@emotion/react';
 import { constants } from '@guardian/commercial';
 import { border, neutral, space } from '@guardian/source-foundations';
-import { adContainerStyles, AdSlot, labelHeight } from './AdSlot';
+import { adContainerStyles, AdSlot } from './AdSlot';
 import { Hide } from './Hide';
 
 const headerWrapper = css`
 	position: static;
 `;
+
+const { TOP_ABOVE_NAV_HEIGHT, AD_LABEL_HEIGHT } = constants;
 
 const padding = space[4] + 2; // 18px - currently being reviewed
 
@@ -14,7 +16,7 @@ const headerAdWrapper = css`
 	z-index: 1080;
 	width: 100%;
 	background-color: ${neutral[97]};
-	min-height: ${constants.TOP_ABOVE_NAV_HEIGHT + padding + labelHeight}px;
+	min-height: ${TOP_ABOVE_NAV_HEIGHT + padding + AD_LABEL_HEIGHT}px;
 	border-bottom: 1px solid ${border.secondary};
 	padding-bottom: ${padding}px;
 

--- a/dotcom-rendering/src/components/HeaderAdSlot.tsx
+++ b/dotcom-rendering/src/components/HeaderAdSlot.tsx
@@ -1,5 +1,5 @@
 import { css, Global } from '@emotion/react';
-import { TOP_ABOVE_NAV_HEIGHT } from '@guardian/commercial/dist/esm/core/constants';
+import { constants } from '@guardian/commercial';
 import { border, neutral, space } from '@guardian/source-foundations';
 import { adContainerStyles, AdSlot, labelHeight } from './AdSlot';
 import { Hide } from './Hide';
@@ -14,7 +14,7 @@ const headerAdWrapper = css`
 	z-index: 1080;
 	width: 100%;
 	background-color: ${neutral[97]};
-	min-height: ${TOP_ABOVE_NAV_HEIGHT + padding + labelHeight}px;
+	min-height: ${constants.TOP_ABOVE_NAV_HEIGHT + padding + labelHeight}px;
 	border-bottom: 1px solid ${border.secondary};
 	padding-bottom: ${padding}px;
 
@@ -41,9 +41,7 @@ export const HeaderAdSlot = () => (
 				* Hides the top-above-nav ad-slot container when a
 				* Bonzai TrueSkin (Australian 3rd Party page skin) is shown
 				*/
-				.bz-custom-container
-					~ #bannerandheader
-					.top-banner-ad-container {
+				.bz-custom-container ~ #bannerandheader .top-banner-ad-container {
 					display: none;
 				}
 			`}

--- a/dotcom-rendering/src/components/LiveblogRightAdSlots.importable.tsx
+++ b/dotcom-rendering/src/components/LiveblogRightAdSlots.importable.tsx
@@ -1,0 +1,33 @@
+import { useAB } from '../lib/useAB';
+import { AdSlot } from './AdSlot';
+import { LiveblogRightMultipleAdSlots } from './LiveblogRightMultipleAdSlots';
+
+type Props = {
+	display?: ArticleDisplay;
+	isPaidContent?: boolean;
+};
+
+export const LiveblogRightAdSlots = ({ display, isPaidContent }: Props) => {
+	const ABTestAPI = useAB()?.api;
+	const shouldInsertMultipleAdverts =
+		ABTestAPI?.isUserInVariant('LiveblogRightColumnAds', 'multiple-adverts') ??
+		false;
+
+	if (shouldInsertMultipleAdverts) {
+		return (
+			<LiveblogRightMultipleAdSlots
+				display={display}
+				isPaidContent={isPaidContent}
+			/>
+		);
+	}
+
+	return (
+		<AdSlot
+			data-right-ad="1"
+			position="right"
+			display={display}
+			isPaidContent={isPaidContent}
+		/>
+	);
+};

--- a/dotcom-rendering/src/components/LiveblogRightAdSlots.importable.tsx
+++ b/dotcom-rendering/src/components/LiveblogRightAdSlots.importable.tsx
@@ -1,6 +1,7 @@
 import { useAB } from '../lib/useAB';
-import { AdSlot } from './AdSlot';
+import { labelStyles } from './AdSlot';
 import { LiveblogRightMultipleAdSlots } from './LiveblogRightMultipleAdSlots';
+import { TopRightAdSlot } from './TopRightAdSlot';
 
 type Props = {
 	display?: ArticleDisplay;
@@ -24,13 +25,17 @@ export const LiveblogRightAdSlots = ({ display, isPaidContent }: Props) => {
 		);
 	}
 
+	const restrictStickyHeight =
+		ABTestAPI?.isUserInVariant(
+			'LiveblogRightColumnAds',
+			'minimum-stickiness',
+		) ?? false;
+
 	return (
-		<AdSlot
-			data-right-ad="1"
-			position="right"
-			display={display}
+		<TopRightAdSlot
 			isPaidContent={isPaidContent}
-			isLiveblog={true}
+			adStyles={[labelStyles]}
+			restrictStickyHeight={restrictStickyHeight}
 		/>
 	);
 };

--- a/dotcom-rendering/src/components/LiveblogRightAdSlots.importable.tsx
+++ b/dotcom-rendering/src/components/LiveblogRightAdSlots.importable.tsx
@@ -28,6 +28,7 @@ export const LiveblogRightAdSlots = ({ display, isPaidContent }: Props) => {
 			position="right"
 			display={display}
 			isPaidContent={isPaidContent}
+			isLiveblog={true}
 		/>
 	);
 };

--- a/dotcom-rendering/src/components/LiveblogRightAdSlots.importable.tsx
+++ b/dotcom-rendering/src/components/LiveblogRightAdSlots.importable.tsx
@@ -10,8 +10,10 @@ type Props = {
 export const LiveblogRightAdSlots = ({ display, isPaidContent }: Props) => {
 	const ABTestAPI = useAB()?.api;
 	const shouldInsertMultipleAdverts =
-		ABTestAPI?.isUserInVariant('LiveblogRightColumnAds', 'multiple-adverts') ??
-		false;
+		ABTestAPI?.isUserInVariant(
+			'LiveblogRightColumnAds',
+			'multiple-adverts',
+		) ?? false;
 
 	if (shouldInsertMultipleAdverts) {
 		return (

--- a/dotcom-rendering/src/components/LiveblogRightMultipleAdSlots.tsx
+++ b/dotcom-rendering/src/components/LiveblogRightMultipleAdSlots.tsx
@@ -44,7 +44,8 @@ export const LiveblogRightMultipleAdSlots = ({
 }: Props) => {
 	const [rightColHeight, setRightColHeight] = useState<number | null>(null);
 	const [numberAdvertsThatFit, setNumberAdvertsThatFit] = useState<number>(0);
-	const [numberAdvertsInserted, setNumberAdvertsInserted] = useState<number>(0);
+	const [numberAdvertsInserted, setNumberAdvertsInserted] =
+		useState<number>(0);
 
 	useEffect(() => {
 		if (rightColHeight === null) return;
@@ -73,7 +74,9 @@ export const LiveblogRightMultipleAdSlots = ({
 		const resizeObserver = new ResizeObserver(
 			(entries: ResizeObserverEntry[]) => {
 				for (const entry of entries) {
-					const newRightColHeight = Math.round(entry.contentRect.height);
+					const newRightColHeight = Math.round(
+						entry.contentRect.height,
+					);
 					setRightColHeight(newRightColHeight);
 				}
 			},

--- a/dotcom-rendering/src/components/LiveblogRightMultipleAdSlots.tsx
+++ b/dotcom-rendering/src/components/LiveblogRightMultipleAdSlots.tsx
@@ -56,7 +56,7 @@ export const LiveblogRightMultipleAdSlots = ({
 	useEffect(() => {
 		if (numberAdvertsThatFit === numberAdvertsInserted) return;
 
-		// Dispatch event so commercial will display ad in new slot
+		// Dispatch event to instruct commercial to display an ad in new slot(s).
 		const event = new CustomEvent('liveblog-right-ads-inserted', {
 			detail: {
 				numAdsToInsert: numberAdvertsThatFit - numberAdvertsInserted,

--- a/dotcom-rendering/src/components/LiveblogRightMultipleAdSlots.tsx
+++ b/dotcom-rendering/src/components/LiveblogRightMultipleAdSlots.tsx
@@ -1,16 +1,11 @@
 import { css } from '@emotion/react';
 import { useEffect, useState } from 'react';
-import { isServer } from '../lib/isServer';
 import {
 	AD_CONTAINER_HEIGHT,
 	PADDING_BOTTOM,
 	SPACE_BETWEEN_ADS,
 } from '../lib/liveblog-right-ad-constants';
 import { AdSlot } from './AdSlot';
-
-const rightColumn: HTMLElement | null = !isServer
-	? window.document.querySelector('[data-gu-name="right-column"]')
-	: null;
 
 const calculateNumAdsThatFit = (rightColHeight: number) => {
 	if (rightColHeight < AD_CONTAINER_HEIGHT) return 0;
@@ -54,6 +49,8 @@ export const LiveblogRightMultipleAdSlots = ({
 		setNumberAdvertsThatFit(numAdsThatFit);
 	}, [rightColHeight]);
 
+	// If a new ad slot has been created, send an event
+	// to commercial to fill the slot with an advert.
 	useEffect(() => {
 		if (numberAdvertsThatFit === numberAdvertsInserted) return;
 
@@ -82,6 +79,9 @@ export const LiveblogRightMultipleAdSlots = ({
 			},
 		);
 
+		const rightColumn: HTMLElement | null = window.document.querySelector(
+			'[data-gu-name="right-column"]',
+		);
 		if (rightColumn !== null) {
 			setRightColHeight(rightColumn.offsetHeight);
 			resizeObserver.observe(rightColumn);

--- a/dotcom-rendering/src/components/LiveblogRightMultipleAdSlots.tsx
+++ b/dotcom-rendering/src/components/LiveblogRightMultipleAdSlots.tsx
@@ -1,0 +1,109 @@
+import { css } from '@emotion/react';
+import { useEffect, useState } from 'react';
+import { isServer } from '../lib/isServer';
+import {
+	AD_CONTAINER_HEIGHT,
+	PADDING_BOTTOM,
+	SPACE_BETWEEN_ADS,
+} from '../lib/liveblog-right-ad-constants';
+import { AdSlot } from './AdSlot';
+
+const rightColumn: HTMLElement | null = !isServer
+	? window.document.querySelector('[data-gu-name="right-column"]')
+	: null;
+
+const calculateNumAdsThatFit = (rightColHeight: number) => {
+	if (rightColHeight < AD_CONTAINER_HEIGHT) return 0;
+
+	return (
+		Math.floor(
+			(rightColHeight - PADDING_BOTTOM + SPACE_BETWEEN_ADS) /
+				(AD_CONTAINER_HEIGHT + SPACE_BETWEEN_ADS),
+		) || 1
+	);
+};
+
+const rightAdContainerStyles = css`
+	height: 100%;
+	max-height: 100%;
+	width: 300px;
+	display: flex;
+	flex-direction: column;
+	gap: ${SPACE_BETWEEN_ADS}px;
+	padding-bottom: ${PADDING_BOTTOM}px;
+`;
+
+type Props = {
+	display?: ArticleDisplay;
+	isPaidContent?: boolean;
+};
+
+export const LiveblogRightMultipleAdSlots = ({
+	display,
+	isPaidContent,
+}: Props) => {
+	const [rightColHeight, setRightColHeight] = useState<number | null>(null);
+	const [numberAdvertsThatFit, setNumberAdvertsThatFit] = useState<number>(0);
+	const [numberAdvertsInserted, setNumberAdvertsInserted] = useState<number>(0);
+
+	useEffect(() => {
+		if (rightColHeight === null) return;
+
+		const numAdsThatFit = calculateNumAdsThatFit(rightColHeight);
+		setNumberAdvertsThatFit(numAdsThatFit);
+	}, [rightColHeight]);
+
+	useEffect(() => {
+		if (numberAdvertsThatFit === numberAdvertsInserted) return;
+
+		// Dispatch event so commercial will display ad in new slot
+		const event = new CustomEvent('liveblog-right-ads-inserted', {
+			detail: {
+				numAdsToInsert: numberAdvertsThatFit - numberAdvertsInserted,
+				fromIndex: numberAdvertsInserted + 1,
+			},
+		});
+
+		document.dispatchEvent(event);
+
+		setNumberAdvertsInserted(numberAdvertsThatFit);
+	}, [numberAdvertsThatFit, numberAdvertsInserted]);
+
+	useEffect(() => {
+		const resizeObserver = new ResizeObserver(
+			(entries: ResizeObserverEntry[]) => {
+				for (const entry of entries) {
+					const newRightColHeight = Math.round(entry.contentRect.height);
+					setRightColHeight(newRightColHeight);
+				}
+			},
+		);
+
+		if (rightColumn !== null) {
+			setRightColHeight(rightColumn.offsetHeight);
+			resizeObserver.observe(rightColumn);
+		}
+
+		return () => {
+			resizeObserver.disconnect();
+		};
+	}, []);
+
+	if (numberAdvertsThatFit === 0) return null;
+
+	return (
+		<div id="right-ad-container" css={[rightAdContainerStyles]}>
+			{[...new Array<undefined>(numberAdvertsThatFit)].map((_, i) => {
+				return (
+					<AdSlot
+						key={i}
+						position="liveblog-right"
+						index={i + 1}
+						display={display}
+						isPaidContent={isPaidContent}
+					/>
+				);
+			})}
+		</div>
+	);
+};

--- a/dotcom-rendering/src/components/Metrics.importable.tsx
+++ b/dotcom-rendering/src/components/Metrics.importable.tsx
@@ -103,7 +103,9 @@ export const Metrics = ({ commercialMetricsEnabled }: Props) => {
 					}
 				})
 				.catch((e) =>
-					console.error(`Error initialising commercial metrics: ${String(e)}`),
+					console.error(
+						`Error initialising commercial metrics: ${String(e)}`,
+					),
 				);
 		},
 		[abTestApi, adBlockerInUse, commercialMetricsEnabled],

--- a/dotcom-rendering/src/components/Metrics.importable.tsx
+++ b/dotcom-rendering/src/components/Metrics.importable.tsx
@@ -11,6 +11,7 @@ import { getCookie } from '@guardian/libs';
 import { billboardsInMerchHigh } from '../experiments/tests/billboards-in-merch-high';
 import { integrateIma } from '../experiments/tests/integrate-ima';
 import { limitInlineMerch } from '../experiments/tests/limit-inline-merch';
+import { liveblogRightColumnAds } from '../experiments/tests/liveblog-right-column-ads';
 import { useAB } from '../lib/useAB';
 import { useAdBlockInUse } from '../lib/useAdBlockInUse';
 import { useOnce } from '../lib/useOnce';
@@ -29,6 +30,7 @@ const clientSideTestsToForceMetrics: ABTest[] = [
 	integrateIma,
 	limitInlineMerch,
 	billboardsInMerchHigh,
+	liveblogRightColumnAds,
 ];
 
 export const Metrics = ({ commercialMetricsEnabled }: Props) => {
@@ -101,9 +103,7 @@ export const Metrics = ({ commercialMetricsEnabled }: Props) => {
 					}
 				})
 				.catch((e) =>
-					console.error(
-						`Error initialising commercial metrics: ${String(e)}`,
-					),
+					console.error(`Error initialising commercial metrics: ${String(e)}`),
 				);
 		},
 		[abTestApi, adBlockerInUse, commercialMetricsEnabled],

--- a/dotcom-rendering/src/components/MostViewedRightWithAd.tsx
+++ b/dotcom-rendering/src/components/MostViewedRightWithAd.tsx
@@ -20,7 +20,6 @@ export const MostViewedRightWithAd = ({
 	display,
 	isPaidContent,
 	renderAds,
-	shouldHideReaderRevenue,
 }: Props) => {
 	const componentDataAttribute = 'most-viewed-right-container';
 	return (
@@ -40,7 +39,6 @@ export const MostViewedRightWithAd = ({
 				<AdSlot
 					position="right"
 					display={display}
-					shouldHideReaderRevenue={shouldHideReaderRevenue}
 					isPaidContent={isPaidContent}
 				/>
 			) : null}

--- a/dotcom-rendering/src/components/TopRightAdSlot.importable.tsx
+++ b/dotcom-rendering/src/components/TopRightAdSlot.importable.tsx
@@ -1,6 +1,7 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import { LABS_HEADER_HEIGHT } from '../lib/labs-constants';
+import { useAB } from '../lib/useAB';
 
 /**
  * # Top Right Ad Slot
@@ -27,6 +28,13 @@ export const TopRightAdSlot = ({
 	adStyles: SerializedStyles[];
 	isPaidContent: boolean;
 }) => {
+	const ABTestAPI = useAB()?.api;
+	const shouldRestrictRightAdStickyHeight =
+		ABTestAPI?.isUserInVariant(
+			'LiveblogRightColumnAds',
+			'minimum-stickiness',
+		) ?? false;
+
 	return (
 		<div
 			id="top-right-ad-slot"
@@ -35,6 +43,7 @@ export const TopRightAdSlot = ({
 				css`
 					position: static;
 					height: 100%;
+					max-height: ${shouldRestrictRightAdStickyHeight ? '1059px' : '100%'};
 				`,
 				adStyles,
 			]}

--- a/dotcom-rendering/src/components/TopRightAdSlot.importable.tsx
+++ b/dotcom-rendering/src/components/TopRightAdSlot.importable.tsx
@@ -13,9 +13,8 @@ import { useAB } from '../lib/useAB';
  *
  * ## Why does this need to be an Island?
  *
- * It relies on running `useAdBlockInUse` on the client.
- *
- * **Currently**, it does not need to be.
+ *  - It relies on running `useAdBlockInUse` on the client.
+ *  - It is required for the LiveblogRightColumnAds AB test.
  *
  * ---
  *
@@ -29,7 +28,7 @@ export const TopRightAdSlot = ({
 	isPaidContent: boolean;
 }) => {
 	const ABTestAPI = useAB()?.api;
-	const shouldRestrictRightAdStickyHeight =
+	const restrictStickyHeight =
 		ABTestAPI?.isUserInVariant(
 			'LiveblogRightColumnAds',
 			'minimum-stickiness',
@@ -43,7 +42,7 @@ export const TopRightAdSlot = ({
 				css`
 					position: static;
 					height: 100%;
-					max-height: ${shouldRestrictRightAdStickyHeight ? '1059px' : '100%'};
+					max-height: ${restrictStickyHeight ? '1059px' : '100%'};
 				`,
 				adStyles,
 			]}

--- a/dotcom-rendering/src/components/TopRightAdSlot.tsx
+++ b/dotcom-rendering/src/components/TopRightAdSlot.tsx
@@ -1,7 +1,6 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import { LABS_HEADER_HEIGHT } from '../lib/labs-constants';
-import { useAB } from '../lib/useAB';
 
 /**
  * # Top Right Ad Slot
@@ -11,29 +10,17 @@ import { useAB } from '../lib/useAB';
  * **Currently**, `ShadyPie` is  disabled, pending the rollout
  * of the new supporter plus product.
  *
- * ## Why does this need to be an Island?
- *
- *  - It relies on running `useAdBlockInUse` on the client.
- *  - It is required for the LiveblogRightColumnAds AB test.
- *
- * ---
- *
  * (No visual story exists)
  */
 export const TopRightAdSlot = ({
 	adStyles,
-	isPaidContent,
+	isPaidContent = false,
+	restrictStickyHeight = false,
 }: {
 	adStyles: SerializedStyles[];
-	isPaidContent: boolean;
+	isPaidContent?: boolean;
+	restrictStickyHeight?: boolean;
 }) => {
-	const ABTestAPI = useAB()?.api;
-	const restrictStickyHeight =
-		ABTestAPI?.isUserInVariant(
-			'LiveblogRightColumnAds',
-			'minimum-stickiness',
-		) ?? false;
-
 	return (
 		<div
 			id="top-right-ad-slot"

--- a/dotcom-rendering/src/experiments/ab-tests.ts
+++ b/dotcom-rendering/src/experiments/ab-tests.ts
@@ -5,6 +5,7 @@ import { consentlessAds } from './tests/consentless-ads';
 import { elementsManager } from './tests/elements-manager';
 import { integrateIma } from './tests/integrate-ima';
 import { limitInlineMerch } from './tests/limit-inline-merch';
+import { liveblogRightColumnAds } from './tests/liveblog-right-column-ads';
 import { signInGateCopyTestJan2023 } from './tests/sign-in-gate-copy-test-variants';
 import { signInGateMainControl } from './tests/sign-in-gate-main-control';
 import { signInGateMainVariant } from './tests/sign-in-gate-main-variant';
@@ -21,4 +22,5 @@ export const tests: ABTest[] = [
 	billboardsInMerchHigh,
 	elementsManager,
 	limitInlineMerch,
+	liveblogRightColumnAds,
 ];

--- a/dotcom-rendering/src/experiments/tests/liveblog-right-column-ads.ts
+++ b/dotcom-rendering/src/experiments/tests/liveblog-right-column-ads.ts
@@ -32,5 +32,5 @@ export const liveblogRightColumnAds: ABTest = {
 			},
 		},
 	],
-	canRun: () => true,
+	canRun: () => window.guardian.config.page.contentType === 'LiveBlog',
 };

--- a/dotcom-rendering/src/experiments/tests/liveblog-right-column-ads.ts
+++ b/dotcom-rendering/src/experiments/tests/liveblog-right-column-ads.ts
@@ -1,0 +1,36 @@
+import type { ABTest } from '@guardian/ab-core';
+
+export const liveblogRightColumnAds: ABTest = {
+	id: 'LiveblogRightColumnAds',
+	author: '@commercial-dev',
+	start: '2023-07-15',
+	expiry: '2023-09-20',
+	audience: 0 / 100,
+	audienceOffset: 0 / 100,
+	audienceCriteria: 'Desktop users with wide (1300px+) screens only',
+	successMeasure:
+		'Displaying an advert in the right-hand column on liveblog pages below the top 1000px of the content will have a significant revenue increase.',
+	description:
+		'Test the commercial impact of different advert display strategies in the right column on liveblog pages',
+	variants: [
+		{
+			id: 'control',
+			test: (): void => {
+				/* no-op */
+			},
+		},
+		{
+			id: 'minimum-stickiness',
+			test: (): void => {
+				/* no-op */
+			},
+		},
+		{
+			id: 'multiple-adverts',
+			test: (): void => {
+				/* no-op */
+			},
+		},
+	],
+	canRun: () => true,
+};

--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -191,8 +191,7 @@ const decideCaption = (mainMedia: FEElement | undefined): string => {
 	const caption = [];
 
 	if (
-		mainMedia?._type ===
-		'model.dotcomrendering.pageElements.ImageBlockElement'
+		mainMedia?._type === 'model.dotcomrendering.pageElements.ImageBlockElement'
 	) {
 		if (mainMedia.data.caption) {
 			caption.push(mainMedia.data.caption);
@@ -342,22 +341,16 @@ export const ImmersiveLayout = ({
 					element="nav"
 				>
 					<Nav
-						isImmersive={
-							format.display === ArticleDisplay.Immersive
-						}
+						isImmersive={format.display === ArticleDisplay.Immersive}
 						displayRoundel={
 							format.display === ArticleDisplay.Immersive ||
 							format.theme === ArticleSpecial.Labs
 						}
 						selectedPillar={NAV.selectedPillar}
 						nav={NAV}
-						subscribeUrl={
-							article.nav.readerRevenueLinks.header.contribute
-						}
+						subscribeUrl={article.nav.readerRevenueLinks.header.contribute}
 						editionId={article.editionId}
-						headerTopBarSwitch={
-							!!article.config.switches.headerTopNav
-						}
+						headerTopBarSwitch={!!article.config.switches.headerTopNav}
 						isInEuropeTest={isInEuropeTest}
 					/>
 				</Section>
@@ -457,9 +450,7 @@ export const ImmersiveLayout = ({
 										webPublicationDateDeprecated={
 											article.webPublicationDateDeprecated
 										}
-										hasStarRating={
-											article.starRating !== undefined
-										}
+										hasStarRating={article.starRating !== undefined}
 									/>
 								</Section>
 							</Box>
@@ -513,9 +504,7 @@ export const ImmersiveLayout = ({
 											tags={article.tags}
 											sectionLabel={article.sectionLabel}
 											sectionUrl={article.sectionUrl}
-											guardianBaseURL={
-												article.guardianBaseURL
-											}
+											guardianBaseURL={article.guardianBaseURL}
 											badge={article.badge?.enhanced}
 										/>
 									</div>
@@ -534,20 +523,14 @@ export const ImmersiveLayout = ({
 											webPublicationDateDeprecated={
 												article.webPublicationDateDeprecated
 											}
-											hasStarRating={
-												typeof article.starRating ===
-												'number'
-											}
+											hasStarRating={typeof article.starRating === 'number'}
 										/>
 									</div>
 								)}
 							</>
 						</GridItem>
 						<GridItem area="standfirst">
-							<Standfirst
-								format={format}
-								standfirst={article.standfirst}
-							/>
+							<Standfirst format={format} standfirst={article.standfirst} />
 						</GridItem>
 						<GridItem area="byline">
 							{!!article.byline && (
@@ -559,22 +542,17 @@ export const ImmersiveLayout = ({
 							)}
 						</GridItem>
 						<GridItem area="lines">
-							{format.design === ArticleDesign.PhotoEssay &&
-							!isLabs ? (
+							{format.design === ArticleDesign.PhotoEssay && !isLabs ? (
 								<></>
 							) : (
 								<div css={maxWidth}>
 									<div css={stretchLines}>
-										{format.theme ===
-										ArticleSpecial.Labs ? (
+										{format.theme === ArticleSpecial.Labs ? (
 											<GuardianLabsLines />
 										) : (
 											<DecideLines
 												format={format}
-												color={
-													decidePalette(format).border
-														.article
-												}
+												color={decidePalette(format).border.article}
 											/>
 										)}
 									</div>
@@ -590,22 +568,13 @@ export const ImmersiveLayout = ({
 									webTitle={article.webTitle}
 									byline={article.byline}
 									tags={article.tags}
-									primaryDateline={
-										article.webPublicationDateDisplay
-									}
-									secondaryDateline={
-										article.webPublicationSecondaryDateDisplay
-									}
+									primaryDateline={article.webPublicationDateDisplay}
+									secondaryDateline={article.webPublicationSecondaryDateDisplay}
 									isCommentable={article.isCommentable}
-									discussionApiUrl={
-										article.config.discussionApiUrl
-									}
+									discussionApiUrl={article.config.discussionApiUrl}
 									shortUrlId={article.config.shortUrlId}
 									ajaxUrl={article.config.ajaxUrl}
-									showShareCount={
-										!!article.config.switches
-											.serverShareCounts
-									}
+									showShareCount={!!article.config.switches.serverShareCounts}
 								/>
 							</div>
 						</GridItem>
@@ -622,17 +591,11 @@ export const ImmersiveLayout = ({
 									isSensitive={article.config.isSensitive}
 									isAdFreeUser={article.isAdFreeUser}
 									sectionId={article.config.section}
-									shouldHideReaderRevenue={
-										article.shouldHideReaderRevenue
-									}
+									shouldHideReaderRevenue={article.shouldHideReaderRevenue}
 									tags={article.tags}
-									isPaidContent={
-										!!article.config.isPaidContent
-									}
+									isPaidContent={!!article.config.isPaidContent}
 									keywordIds={article.config.keywordIds}
-									contributionsServiceUrl={
-										contributionsServiceUrl
-									}
+									contributionsServiceUrl={contributionsServiceUrl}
 									contentType={article.contentType}
 									isPreview={article.config.isPreview}
 									idUrl={article.config.idUrl ?? ''}
@@ -640,33 +603,21 @@ export const ImmersiveLayout = ({
 									abTests={article.config.abTests}
 									tableOfContents={article.tableOfContents}
 									lang={article.lang}
-									isRightToLeftLang={
-										article.isRightToLeftLang
-									}
+									isRightToLeftLang={article.isRightToLeftLang}
 									renderingTarget={renderingTarget}
 								/>
 								{showBodyEndSlot && (
 									<Island clientOnly={true}>
 										<SlotBodyEnd
 											contentType={article.contentType}
-											contributionsServiceUrl={
-												contributionsServiceUrl
-											}
+											contributionsServiceUrl={contributionsServiceUrl}
 											idApiUrl={article.config.idApiUrl}
-											isMinuteArticle={
-												article.pageType.isMinuteArticle
-											}
-											isPaidContent={
-												article.pageType.isPaidContent
-											}
-											keywordIds={
-												article.config.keywordIds
-											}
+											isMinuteArticle={article.pageType.isMinuteArticle}
+											isPaidContent={article.pageType.isPaidContent}
+											keywordIds={article.config.keywordIds}
 											pageId={article.pageId}
 											sectionId={article.config.section}
-											shouldHideReaderRevenue={
-												article.shouldHideReaderRevenue
-											}
+											shouldHideReaderRevenue={article.shouldHideReaderRevenue}
 											stage={article.config.stage}
 											tags={article.tags}
 										/>
@@ -674,24 +625,16 @@ export const ImmersiveLayout = ({
 								)}
 								<StraightLines
 									count={4}
-									color={
-										decidePalette(format).border.secondary
-									}
+									color={decidePalette(format).border.secondary}
 								/>
 								<SubMeta
 									format={format}
-									subMetaKeywordLinks={
-										article.subMetaKeywordLinks
-									}
-									subMetaSectionLinks={
-										article.subMetaSectionLinks
-									}
+									subMetaKeywordLinks={article.subMetaKeywordLinks}
+									subMetaSectionLinks={article.subMetaSectionLinks}
 									pageId={article.pageId}
 									webUrl={article.webURL}
 									webTitle={article.webTitle}
-									showBottomSocialButtons={
-										article.showBottomSocialButtons
-									}
+									showBottomSocialButtons={article.showBottomSocialButtons}
 									badge={article.badge?.enhanced}
 								/>
 							</ArticleContainer>
@@ -725,13 +668,7 @@ export const ImmersiveLayout = ({
 													<AdSlot
 														position="right"
 														display={format.display}
-														shouldHideReaderRevenue={
-															article.shouldHideReaderRevenue
-														}
-														isPaidContent={
-															article.pageType
-																.isPaidContent
-														}
+														isPaidContent={article.pageType.isPaidContent}
 													/>
 												}
 											</div>
@@ -751,10 +688,7 @@ export const ImmersiveLayout = ({
 						backgroundColour={neutral[93]}
 						element="aside"
 					>
-						<AdSlot
-							position="merchandising-high"
-							display={format.display}
-						/>
+						<AdSlot position="merchandising-high" display={format.display} />
 					</Section>
 				)}
 
@@ -763,9 +697,7 @@ export const ImmersiveLayout = ({
 						<Island deferUntil="visible">
 							<Carousel
 								heading={article.storyPackage.heading}
-								trails={article.storyPackage.trails.map(
-									decideTrail,
-								)}
+								trails={article.storyPackage.trails.map(decideTrail)}
 								onwardsSource="more-on-this-story"
 								format={format}
 								leftColSize={'compact'}
@@ -774,11 +706,7 @@ export const ImmersiveLayout = ({
 					</Section>
 				)}
 
-				<Island
-					clientOnly={true}
-					deferUntil="visible"
-					placeholderHeight={600}
-				>
+				<Island clientOnly={true} deferUntil="visible" placeholderHeight={600}>
 					<OnwardsUpper
 						ajaxUrl={article.config.ajaxUrl}
 						hasRelated={article.hasRelated}
@@ -798,11 +726,7 @@ export const ImmersiveLayout = ({
 				</Island>
 
 				{!isPaidContent && showComments && (
-					<Section
-						fullWidth={true}
-						sectionId="comments"
-						element="aside"
-					>
+					<Section fullWidth={true} sectionId="comments" element="aside">
 						<DiscussionLayout
 							discussionApiUrl={article.config.discussionApiUrl}
 							shortUrlId={article.config.shortUrlId}
@@ -851,10 +775,7 @@ export const ImmersiveLayout = ({
 						backgroundColour={neutral[93]}
 						element="aside"
 					>
-						<AdSlot
-							position="merchandising"
-							display={format.display}
-						/>
+						<AdSlot position="merchandising" display={format.display} />
 					</Section>
 				)}
 			</main>
@@ -903,15 +824,9 @@ export const ImmersiveLayout = ({
 						keywordIds={article.config.keywordIds}
 						pageId={article.pageId}
 						sectionId={article.config.section}
-						shouldHideReaderRevenue={
-							article.shouldHideReaderRevenue
-						}
-						remoteBannerSwitch={
-							!!article.config.switches.remoteBanner
-						}
-						puzzleBannerSwitch={
-							!!article.config.switches.puzzlesBanner
-						}
+						shouldHideReaderRevenue={article.shouldHideReaderRevenue}
+						remoteBannerSwitch={!!article.config.switches.remoteBanner}
+						puzzleBannerSwitch={!!article.config.switches.puzzlesBanner}
 						tags={article.tags}
 					/>
 				</Island>

--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -191,7 +191,8 @@ const decideCaption = (mainMedia: FEElement | undefined): string => {
 	const caption = [];
 
 	if (
-		mainMedia?._type === 'model.dotcomrendering.pageElements.ImageBlockElement'
+		mainMedia?._type ===
+		'model.dotcomrendering.pageElements.ImageBlockElement'
 	) {
 		if (mainMedia.data.caption) {
 			caption.push(mainMedia.data.caption);
@@ -341,16 +342,22 @@ export const ImmersiveLayout = ({
 					element="nav"
 				>
 					<Nav
-						isImmersive={format.display === ArticleDisplay.Immersive}
+						isImmersive={
+							format.display === ArticleDisplay.Immersive
+						}
 						displayRoundel={
 							format.display === ArticleDisplay.Immersive ||
 							format.theme === ArticleSpecial.Labs
 						}
 						selectedPillar={NAV.selectedPillar}
 						nav={NAV}
-						subscribeUrl={article.nav.readerRevenueLinks.header.contribute}
+						subscribeUrl={
+							article.nav.readerRevenueLinks.header.contribute
+						}
 						editionId={article.editionId}
-						headerTopBarSwitch={!!article.config.switches.headerTopNav}
+						headerTopBarSwitch={
+							!!article.config.switches.headerTopNav
+						}
 						isInEuropeTest={isInEuropeTest}
 					/>
 				</Section>
@@ -450,7 +457,9 @@ export const ImmersiveLayout = ({
 										webPublicationDateDeprecated={
 											article.webPublicationDateDeprecated
 										}
-										hasStarRating={article.starRating !== undefined}
+										hasStarRating={
+											article.starRating !== undefined
+										}
 									/>
 								</Section>
 							</Box>
@@ -504,7 +513,9 @@ export const ImmersiveLayout = ({
 											tags={article.tags}
 											sectionLabel={article.sectionLabel}
 											sectionUrl={article.sectionUrl}
-											guardianBaseURL={article.guardianBaseURL}
+											guardianBaseURL={
+												article.guardianBaseURL
+											}
 											badge={article.badge?.enhanced}
 										/>
 									</div>
@@ -523,14 +534,20 @@ export const ImmersiveLayout = ({
 											webPublicationDateDeprecated={
 												article.webPublicationDateDeprecated
 											}
-											hasStarRating={typeof article.starRating === 'number'}
+											hasStarRating={
+												typeof article.starRating ===
+												'number'
+											}
 										/>
 									</div>
 								)}
 							</>
 						</GridItem>
 						<GridItem area="standfirst">
-							<Standfirst format={format} standfirst={article.standfirst} />
+							<Standfirst
+								format={format}
+								standfirst={article.standfirst}
+							/>
 						</GridItem>
 						<GridItem area="byline">
 							{!!article.byline && (
@@ -542,17 +559,22 @@ export const ImmersiveLayout = ({
 							)}
 						</GridItem>
 						<GridItem area="lines">
-							{format.design === ArticleDesign.PhotoEssay && !isLabs ? (
+							{format.design === ArticleDesign.PhotoEssay &&
+							!isLabs ? (
 								<></>
 							) : (
 								<div css={maxWidth}>
 									<div css={stretchLines}>
-										{format.theme === ArticleSpecial.Labs ? (
+										{format.theme ===
+										ArticleSpecial.Labs ? (
 											<GuardianLabsLines />
 										) : (
 											<DecideLines
 												format={format}
-												color={decidePalette(format).border.article}
+												color={
+													decidePalette(format).border
+														.article
+												}
 											/>
 										)}
 									</div>
@@ -568,13 +590,22 @@ export const ImmersiveLayout = ({
 									webTitle={article.webTitle}
 									byline={article.byline}
 									tags={article.tags}
-									primaryDateline={article.webPublicationDateDisplay}
-									secondaryDateline={article.webPublicationSecondaryDateDisplay}
+									primaryDateline={
+										article.webPublicationDateDisplay
+									}
+									secondaryDateline={
+										article.webPublicationSecondaryDateDisplay
+									}
 									isCommentable={article.isCommentable}
-									discussionApiUrl={article.config.discussionApiUrl}
+									discussionApiUrl={
+										article.config.discussionApiUrl
+									}
 									shortUrlId={article.config.shortUrlId}
 									ajaxUrl={article.config.ajaxUrl}
-									showShareCount={!!article.config.switches.serverShareCounts}
+									showShareCount={
+										!!article.config.switches
+											.serverShareCounts
+									}
 								/>
 							</div>
 						</GridItem>
@@ -591,11 +622,17 @@ export const ImmersiveLayout = ({
 									isSensitive={article.config.isSensitive}
 									isAdFreeUser={article.isAdFreeUser}
 									sectionId={article.config.section}
-									shouldHideReaderRevenue={article.shouldHideReaderRevenue}
+									shouldHideReaderRevenue={
+										article.shouldHideReaderRevenue
+									}
 									tags={article.tags}
-									isPaidContent={!!article.config.isPaidContent}
+									isPaidContent={
+										!!article.config.isPaidContent
+									}
 									keywordIds={article.config.keywordIds}
-									contributionsServiceUrl={contributionsServiceUrl}
+									contributionsServiceUrl={
+										contributionsServiceUrl
+									}
 									contentType={article.contentType}
 									isPreview={article.config.isPreview}
 									idUrl={article.config.idUrl ?? ''}
@@ -603,21 +640,33 @@ export const ImmersiveLayout = ({
 									abTests={article.config.abTests}
 									tableOfContents={article.tableOfContents}
 									lang={article.lang}
-									isRightToLeftLang={article.isRightToLeftLang}
+									isRightToLeftLang={
+										article.isRightToLeftLang
+									}
 									renderingTarget={renderingTarget}
 								/>
 								{showBodyEndSlot && (
 									<Island clientOnly={true}>
 										<SlotBodyEnd
 											contentType={article.contentType}
-											contributionsServiceUrl={contributionsServiceUrl}
+											contributionsServiceUrl={
+												contributionsServiceUrl
+											}
 											idApiUrl={article.config.idApiUrl}
-											isMinuteArticle={article.pageType.isMinuteArticle}
-											isPaidContent={article.pageType.isPaidContent}
-											keywordIds={article.config.keywordIds}
+											isMinuteArticle={
+												article.pageType.isMinuteArticle
+											}
+											isPaidContent={
+												article.pageType.isPaidContent
+											}
+											keywordIds={
+												article.config.keywordIds
+											}
 											pageId={article.pageId}
 											sectionId={article.config.section}
-											shouldHideReaderRevenue={article.shouldHideReaderRevenue}
+											shouldHideReaderRevenue={
+												article.shouldHideReaderRevenue
+											}
 											stage={article.config.stage}
 											tags={article.tags}
 										/>
@@ -625,16 +674,24 @@ export const ImmersiveLayout = ({
 								)}
 								<StraightLines
 									count={4}
-									color={decidePalette(format).border.secondary}
+									color={
+										decidePalette(format).border.secondary
+									}
 								/>
 								<SubMeta
 									format={format}
-									subMetaKeywordLinks={article.subMetaKeywordLinks}
-									subMetaSectionLinks={article.subMetaSectionLinks}
+									subMetaKeywordLinks={
+										article.subMetaKeywordLinks
+									}
+									subMetaSectionLinks={
+										article.subMetaSectionLinks
+									}
 									pageId={article.pageId}
 									webUrl={article.webURL}
 									webTitle={article.webTitle}
-									showBottomSocialButtons={article.showBottomSocialButtons}
+									showBottomSocialButtons={
+										article.showBottomSocialButtons
+									}
 									badge={article.badge?.enhanced}
 								/>
 							</ArticleContainer>
@@ -668,7 +725,10 @@ export const ImmersiveLayout = ({
 													<AdSlot
 														position="right"
 														display={format.display}
-														isPaidContent={article.pageType.isPaidContent}
+														isPaidContent={
+															article.pageType
+																.isPaidContent
+														}
 													/>
 												}
 											</div>
@@ -688,7 +748,10 @@ export const ImmersiveLayout = ({
 						backgroundColour={neutral[93]}
 						element="aside"
 					>
-						<AdSlot position="merchandising-high" display={format.display} />
+						<AdSlot
+							position="merchandising-high"
+							display={format.display}
+						/>
 					</Section>
 				)}
 
@@ -697,7 +760,9 @@ export const ImmersiveLayout = ({
 						<Island deferUntil="visible">
 							<Carousel
 								heading={article.storyPackage.heading}
-								trails={article.storyPackage.trails.map(decideTrail)}
+								trails={article.storyPackage.trails.map(
+									decideTrail,
+								)}
 								onwardsSource="more-on-this-story"
 								format={format}
 								leftColSize={'compact'}
@@ -706,7 +771,11 @@ export const ImmersiveLayout = ({
 					</Section>
 				)}
 
-				<Island clientOnly={true} deferUntil="visible" placeholderHeight={600}>
+				<Island
+					clientOnly={true}
+					deferUntil="visible"
+					placeholderHeight={600}
+				>
 					<OnwardsUpper
 						ajaxUrl={article.config.ajaxUrl}
 						hasRelated={article.hasRelated}
@@ -726,7 +795,11 @@ export const ImmersiveLayout = ({
 				</Island>
 
 				{!isPaidContent && showComments && (
-					<Section fullWidth={true} sectionId="comments" element="aside">
+					<Section
+						fullWidth={true}
+						sectionId="comments"
+						element="aside"
+					>
 						<DiscussionLayout
 							discussionApiUrl={article.config.discussionApiUrl}
 							shortUrlId={article.config.shortUrlId}
@@ -775,7 +848,10 @@ export const ImmersiveLayout = ({
 						backgroundColour={neutral[93]}
 						element="aside"
 					>
-						<AdSlot position="merchandising" display={format.display} />
+						<AdSlot
+							position="merchandising"
+							display={format.display}
+						/>
 					</Section>
 				)}
 			</main>
@@ -824,9 +900,15 @@ export const ImmersiveLayout = ({
 						keywordIds={article.config.keywordIds}
 						pageId={article.pageId}
 						sectionId={article.config.section}
-						shouldHideReaderRevenue={article.shouldHideReaderRevenue}
-						remoteBannerSwitch={!!article.config.switches.remoteBanner}
-						puzzleBannerSwitch={!!article.config.switches.puzzlesBanner}
+						shouldHideReaderRevenue={
+							article.shouldHideReaderRevenue
+						}
+						remoteBannerSwitch={
+							!!article.config.switches.remoteBanner
+						}
+						puzzleBannerSwitch={
+							!!article.config.switches.puzzlesBanner
+						}
 						tags={article.tags}
 					/>
 				</Island>

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -917,7 +917,10 @@ export const LiveLayout = ({
 											format.design === ArticleDesign.LiveBlog ||
 											format.design === ArticleDesign.DeadBlog ? (
 												<Island clientOnly={true} deferUntil="visible">
-													<LiveblogRightAdSlots isPaidContent={isPaidContent} />
+													<LiveblogRightAdSlots
+														display={format.display}
+														isPaidContent={isPaidContent}
+													/>
 												</Island>
 											) : (
 												<AdSlot

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -279,7 +279,9 @@ export const LiveLayout = ({
 	const palette = decidePalette(format);
 
 	const footballMatchUrl =
-		article.matchType === 'FootballMatchType' ? article.matchUrl : undefined;
+		article.matchType === 'FootballMatchType'
+			? article.matchUrl
+			: undefined;
 
 	const cricketMatchUrl =
 		article.matchType === 'CricketMatchType' ? article.matchUrl : undefined;
@@ -326,7 +328,9 @@ export const LiveLayout = ({
 							mmaUrl={article.config.mmaUrl}
 							discussionApiUrl={article.config.discussionApiUrl}
 							urls={article.nav.readerRevenueLinks.header}
-							remoteHeader={!!article.config.switches.remoteHeader}
+							remoteHeader={
+								!!article.config.switches.remoteHeader
+							}
 							contributionsServiceUrl={contributionsServiceUrl}
 							idApiUrl={article.config.idApiUrl}
 							isInEuropeTest={isInEuropeTest}
@@ -347,9 +351,13 @@ export const LiveLayout = ({
 						<Nav
 							nav={NAV}
 							selectedPillar={NAV.selectedPillar}
-							subscribeUrl={article.nav.readerRevenueLinks.header.subscribe}
+							subscribeUrl={
+								article.nav.readerRevenueLinks.header.subscribe
+							}
 							editionId={article.editionId}
-							headerTopBarSwitch={!!article.config.switches.headerTopNav}
+							headerTopBarSwitch={
+								!!article.config.switches.headerTopNav
+							}
 							isInEuropeTest={isInEuropeTest}
 						/>
 					</Section>
@@ -366,7 +374,9 @@ export const LiveLayout = ({
 								<SubNav
 									subNavSections={NAV.subNavSections}
 									currentNavLink={NAV.currentNavLink}
-									linkHoverColour={palette.text.articleLinkHover}
+									linkHoverColour={
+										palette.text.articleLinkHover
+									}
 									borderColour={palette.border.subNav}
 								/>
 							</Island>
@@ -468,13 +478,19 @@ export const LiveLayout = ({
 											webPublicationDateDeprecated={
 												article.webPublicationDateDeprecated
 											}
-											hasStarRating={typeof article.starRating === 'number'}
+											hasStarRating={
+												typeof article.starRating ===
+												'number'
+											}
 										/>
 									)}
 								</div>
 								{article.starRating !== undefined ? (
 									<div css={starWrapper}>
-										<StarRating rating={article.starRating} size="large" />
+										<StarRating
+											rating={article.starRating}
+											size="large"
+										/>
 									</div>
 								) : (
 									<></>
@@ -492,14 +508,20 @@ export const LiveLayout = ({
 				>
 					<StandFirstGrid>
 						<GridItem area="standfirst">
-							<Standfirst format={format} standfirst={article.standfirst} />
+							<Standfirst
+								format={format}
+								standfirst={article.standfirst}
+							/>
 						</GridItem>
 						<GridItem area="lastupdated">
 							<Hide until="desktop">
-								{article.blocks[0]?.blockLastUpdated !== undefined && (
+								{article.blocks[0]?.blockLastUpdated !==
+									undefined && (
 									<ArticleLastUpdated
 										format={format}
-										lastUpdated={article.blocks[0].blockLastUpdated}
+										lastUpdated={
+											article.blocks[0].blockLastUpdated
+										}
 									/>
 								)}
 							</Hide>
@@ -510,7 +532,8 @@ export const LiveLayout = ({
 									<DecideLines
 										format={format}
 										color={
-											format.design === ArticleDesign.LiveBlog
+											format.design ===
+											ArticleDesign.LiveBlog
 												? 'rgba(255, 255, 255, 0.4)'
 												: undefined
 										}
@@ -528,15 +551,22 @@ export const LiveLayout = ({
 										webTitle={article.webTitle}
 										byline={article.byline}
 										tags={article.tags}
-										primaryDateline={article.webPublicationDateDisplay}
+										primaryDateline={
+											article.webPublicationDateDisplay
+										}
 										secondaryDateline={
 											article.webPublicationSecondaryDateDisplay
 										}
 										isCommentable={article.isCommentable}
-										discussionApiUrl={article.config.discussionApiUrl}
+										discussionApiUrl={
+											article.config.discussionApiUrl
+										}
 										shortUrlId={article.config.shortUrlId}
 										ajaxUrl={article.config.ajaxUrl}
-										showShareCount={!!article.config.switches.serverShareCounts}
+										showShareCount={
+											!!article.config.switches
+												.serverShareCounts
+										}
 										messageUs={article.messageUs}
 									/>
 								</div>
@@ -548,7 +578,9 @@ export const LiveLayout = ({
 					<Section
 						fullWidth={true}
 						showTopBorder={false}
-						backgroundColour={palette.background.keyEventFromDesktop}
+						backgroundColour={
+							palette.background.keyEventFromDesktop
+						}
 						borderColour={palette.border.article}
 					>
 						<Hide until={'desktop'}>
@@ -600,12 +632,16 @@ export const LiveLayout = ({
 									ajaxUrl={article.config.ajaxUrl}
 									filterKeyEvents={article.filterKeyEvents}
 									format={format}
-									enhanceTweetsSwitch={!!article.config.switches.enhanceTweets}
+									enhanceTweetsSwitch={
+										!!article.config.switches.enhanceTweets
+									}
 									onFirstPage={pagination.currentPage === 1}
 									webURL={article.webURL}
 									// We default to string here because the property is optional but we
 									// know it will exist for all blogs
-									mostRecentBlockId={article.mostRecentBlockId ?? ''}
+									mostRecentBlockId={
+										article.mostRecentBlockId ?? ''
+									}
 									hasPinnedPost={!!article.pinnedPost}
 									selectedTopics={article.selectedTopics}
 								/>
@@ -624,7 +660,10 @@ export const LiveLayout = ({
 							<GridItem area="media">
 								<div css={maxWidth}>
 									{!!footballMatchUrl && (
-										<Island clientOnly={true} placeholderHeight={40}>
+										<Island
+											clientOnly={true}
+											placeholderHeight={40}
+										>
 											<GetMatchTabs
 												matchUrl={footballMatchUrl}
 												format={format}
@@ -632,7 +671,10 @@ export const LiveLayout = ({
 										</Island>
 									)}
 									{!!cricketMatchUrl && (
-										<Island clientOnly={true} placeholderHeight={172}>
+										<Island
+											clientOnly={true}
+											placeholderHeight={172}
+										>
 											<GetCricketScoreboard
 												matchUrl={cricketMatchUrl}
 												format={format}
@@ -669,16 +711,25 @@ export const LiveLayout = ({
 											webTitle={article.webTitle}
 											byline={article.byline}
 											tags={article.tags}
-											primaryDateline={article.webPublicationDateDisplay}
+											primaryDateline={
+												article.webPublicationDateDisplay
+											}
 											secondaryDateline={
 												article.webPublicationSecondaryDateDisplay
 											}
-											isCommentable={article.isCommentable}
-											discussionApiUrl={article.config.discussionApiUrl}
-											shortUrlId={article.config.shortUrlId}
+											isCommentable={
+												article.isCommentable
+											}
+											discussionApiUrl={
+												article.config.discussionApiUrl
+											}
+											shortUrlId={
+												article.config.shortUrlId
+											}
 											ajaxUrl={article.config.ajaxUrl}
 											showShareCount={
-												!!article.config.switches.serverShareCounts
+												!!article.config.switches
+													.serverShareCounts
 											}
 											messageUs={article.messageUs}
 										/>
@@ -689,12 +740,20 @@ export const LiveLayout = ({
 									<Hide until="desktop">
 										<div css={sidePaddingDesktop}>
 											<TopicFilterBank
-												availableTopics={article.availableTopics}
-												selectedTopics={article.selectedTopics}
+												availableTopics={
+													article.availableTopics
+												}
+												selectedTopics={
+													article.selectedTopics
+												}
 												format={format}
 												keyEvents={article.keyEvents}
-												filterKeyEvents={article.filterKeyEvents}
-												id={'key-events-carousel-desktop'}
+												filterKeyEvents={
+													article.filterKeyEvents
+												}
+												id={
+													'key-events-carousel-desktop'
+												}
 											/>
 										</div>
 									</Hide>
@@ -719,7 +778,9 @@ export const LiveLayout = ({
 										<Hide below="desktop">
 											<Island deferUntil="visible">
 												<FilterKeyEventsToggle
-													filterKeyEvents={article.filterKeyEvents}
+													filterKeyEvents={
+														article.filterKeyEvents
+													}
 													id="filter-toggle-desktop"
 												/>
 											</Island>
@@ -730,12 +791,21 @@ export const LiveLayout = ({
 									{showTopicFilterBank ? (
 										<div css={paddingBody}>
 											<ArticleContainer format={format}>
-												{pagination.currentPage !== 1 && (
+												{pagination.currentPage !==
+													1 && (
 													<Pagination
-														currentPage={pagination.currentPage}
-														totalPages={pagination.totalPages}
-														newest={pagination.newest}
-														oldest={pagination.oldest}
+														currentPage={
+															pagination.currentPage
+														}
+														totalPages={
+															pagination.totalPages
+														}
+														newest={
+															pagination.newest
+														}
+														oldest={
+															pagination.oldest
+														}
 														newer={pagination.newer}
 														older={pagination.older}
 														format={format}
@@ -744,43 +814,95 @@ export const LiveLayout = ({
 												<ArticleBody
 													format={format}
 													blocks={article.blocks}
-													pinnedPost={article.pinnedPost}
+													pinnedPost={
+														article.pinnedPost
+													}
 													host={host}
 													pageId={article.pageId}
 													webTitle={article.webTitle}
-													ajaxUrl={article.config.ajaxUrl}
-													sectionId={article.config.section}
-													switches={article.config.switches}
-													isSensitive={article.config.isSensitive}
-													isAdFreeUser={article.isAdFreeUser}
+													ajaxUrl={
+														article.config.ajaxUrl
+													}
+													sectionId={
+														article.config.section
+													}
+													switches={
+														article.config.switches
+													}
+													isSensitive={
+														article.config
+															.isSensitive
+													}
+													isAdFreeUser={
+														article.isAdFreeUser
+													}
 													shouldHideReaderRevenue={
 														article.shouldHideReaderRevenue
 													}
 													tags={article.tags}
-													isPaidContent={!!article.config.isPaidContent}
-													contributionsServiceUrl={contributionsServiceUrl}
-													contentType={article.contentType}
-													isPreview={article.config.isPreview}
-													idUrl={article.config.idUrl ?? ''}
-													isDev={!!article.config.isDev}
-													onFirstPage={pagination.currentPage === 1}
-													keyEvents={article.keyEvents}
-													filterKeyEvents={article.filterKeyEvents}
-													availableTopics={article.availableTopics}
-													selectedTopics={article.selectedTopics}
-													keywordIds={article.config.keywordIds}
+													isPaidContent={
+														!!article.config
+															.isPaidContent
+													}
+													contributionsServiceUrl={
+														contributionsServiceUrl
+													}
+													contentType={
+														article.contentType
+													}
+													isPreview={
+														article.config.isPreview
+													}
+													idUrl={
+														article.config.idUrl ??
+														''
+													}
+													isDev={
+														!!article.config.isDev
+													}
+													onFirstPage={
+														pagination.currentPage ===
+														1
+													}
+													keyEvents={
+														article.keyEvents
+													}
+													filterKeyEvents={
+														article.filterKeyEvents
+													}
+													availableTopics={
+														article.availableTopics
+													}
+													selectedTopics={
+														article.selectedTopics
+													}
+													keywordIds={
+														article.config
+															.keywordIds
+													}
 													isInLiveblogAdSlotTest={
 														article.config.abTests
-															.serverSideLiveblogInlineAdsVariant === 'variant'
+															.serverSideLiveblogInlineAdsVariant ===
+														'variant'
 													}
-													renderingTarget={renderingTarget}
+													renderingTarget={
+														renderingTarget
+													}
 												/>
 												{pagination.totalPages > 1 && (
 													<Pagination
-														currentPage={pagination.currentPage}
-														totalPages={pagination.totalPages}
-														newest={pagination.newest}
-														oldest={pagination.oldest}
+														currentPage={
+															pagination.currentPage
+														}
+														totalPages={
+															pagination.totalPages
+														}
+														newest={
+															pagination.newest
+														}
+														oldest={
+															pagination.oldest
+														}
 														newer={pagination.newer}
 														older={pagination.older}
 														format={format}
@@ -795,27 +917,45 @@ export const LiveLayout = ({
 												/>
 												<SubMeta
 													format={format}
-													subMetaKeywordLinks={article.subMetaKeywordLinks}
-													subMetaSectionLinks={article.subMetaSectionLinks}
+													subMetaKeywordLinks={
+														article.subMetaKeywordLinks
+													}
+													subMetaSectionLinks={
+														article.subMetaSectionLinks
+													}
 													pageId={article.pageId}
 													webUrl={article.webURL}
 													webTitle={article.webTitle}
 													showBottomSocialButtons={
 														article.showBottomSocialButtons
 													}
-													badge={article.badge?.enhanced}
+													badge={
+														article.badge?.enhanced
+													}
 												/>
 											</ArticleContainer>
 										</div>
 									) : (
-										<Accordion accordionTitle="Live feed" context="liveFeed">
+										<Accordion
+											accordionTitle="Live feed"
+											context="liveFeed"
+										>
 											<ArticleContainer format={format}>
-												{pagination.currentPage !== 1 && (
+												{pagination.currentPage !==
+													1 && (
 													<Pagination
-														currentPage={pagination.currentPage}
-														totalPages={pagination.totalPages}
-														newest={pagination.newest}
-														oldest={pagination.oldest}
+														currentPage={
+															pagination.currentPage
+														}
+														totalPages={
+															pagination.totalPages
+														}
+														newest={
+															pagination.newest
+														}
+														oldest={
+															pagination.oldest
+														}
 														newer={pagination.newer}
 														older={pagination.older}
 														format={format}
@@ -824,45 +964,99 @@ export const LiveLayout = ({
 												<ArticleBody
 													format={format}
 													blocks={article.blocks}
-													pinnedPost={article.pinnedPost}
+													pinnedPost={
+														article.pinnedPost
+													}
 													host={host}
 													pageId={article.pageId}
 													webTitle={article.webTitle}
-													ajaxUrl={article.config.ajaxUrl}
-													sectionId={article.config.section}
-													switches={article.config.switches}
-													isSensitive={article.config.isSensitive}
-													isAdFreeUser={article.isAdFreeUser}
+													ajaxUrl={
+														article.config.ajaxUrl
+													}
+													sectionId={
+														article.config.section
+													}
+													switches={
+														article.config.switches
+													}
+													isSensitive={
+														article.config
+															.isSensitive
+													}
+													isAdFreeUser={
+														article.isAdFreeUser
+													}
 													shouldHideReaderRevenue={
 														article.shouldHideReaderRevenue
 													}
 													tags={article.tags}
-													isPaidContent={!!article.config.isPaidContent}
-													contributionsServiceUrl={contributionsServiceUrl}
-													contentType={article.contentType}
-													isPreview={article.config.isPreview}
-													idUrl={article.config.idUrl ?? ''}
-													isDev={!!article.config.isDev}
-													onFirstPage={pagination.currentPage === 1}
-													keyEvents={article.keyEvents}
-													filterKeyEvents={article.filterKeyEvents}
-													availableTopics={article.availableTopics}
-													selectedTopics={article.selectedTopics}
-													keywordIds={article.config.keywordIds}
+													isPaidContent={
+														!!article.config
+															.isPaidContent
+													}
+													contributionsServiceUrl={
+														contributionsServiceUrl
+													}
+													contentType={
+														article.contentType
+													}
+													isPreview={
+														article.config.isPreview
+													}
+													idUrl={
+														article.config.idUrl ??
+														''
+													}
+													isDev={
+														!!article.config.isDev
+													}
+													onFirstPage={
+														pagination.currentPage ===
+														1
+													}
+													keyEvents={
+														article.keyEvents
+													}
+													filterKeyEvents={
+														article.filterKeyEvents
+													}
+													availableTopics={
+														article.availableTopics
+													}
+													selectedTopics={
+														article.selectedTopics
+													}
+													keywordIds={
+														article.config
+															.keywordIds
+													}
 													isInLiveblogAdSlotTest={
 														article.config.abTests
-															.serverSideLiveblogInlineAdsVariant === 'variant'
+															.serverSideLiveblogInlineAdsVariant ===
+														'variant'
 													}
 													lang={article.lang}
-													isRightToLeftLang={article.isRightToLeftLang}
-													renderingTarget={renderingTarget}
+													isRightToLeftLang={
+														article.isRightToLeftLang
+													}
+													renderingTarget={
+														renderingTarget
+													}
 												/>
 												{pagination.totalPages > 1 && (
 													<Pagination
-														currentPage={pagination.currentPage}
-														totalPages={pagination.totalPages}
-														newest={pagination.newest}
-														oldest={pagination.oldest}
+														currentPage={
+															pagination.currentPage
+														}
+														totalPages={
+															pagination.totalPages
+														}
+														newest={
+															pagination.newest
+														}
+														oldest={
+															pagination.oldest
+														}
 														newer={pagination.newer}
 														older={pagination.older}
 														format={format}
@@ -877,15 +1071,21 @@ export const LiveLayout = ({
 												/>
 												<SubMeta
 													format={format}
-													subMetaKeywordLinks={article.subMetaKeywordLinks}
-													subMetaSectionLinks={article.subMetaSectionLinks}
+													subMetaKeywordLinks={
+														article.subMetaKeywordLinks
+													}
+													subMetaSectionLinks={
+														article.subMetaSectionLinks
+													}
 													pageId={article.pageId}
 													webUrl={article.webURL}
 													webTitle={article.webTitle}
 													showBottomSocialButtons={
 														article.showBottomSocialButtons
 													}
-													badge={article.badge?.enhanced}
+													badge={
+														article.badge?.enhanced
+													}
 												/>
 											</ArticleContainer>
 										</Accordion>
@@ -914,19 +1114,28 @@ export const LiveLayout = ({
 								>
 									<RightColumn>
 										{renderAds ? (
-											format.design === ArticleDesign.LiveBlog ||
-											format.design === ArticleDesign.DeadBlog ? (
-												<Island clientOnly={true} deferUntil="visible">
+											format.design ===
+												ArticleDesign.LiveBlog ||
+											format.design ===
+												ArticleDesign.DeadBlog ? (
+												<Island
+													clientOnly={true}
+													deferUntil="visible"
+												>
 													<LiveblogRightAdSlots
 														display={format.display}
-														isPaidContent={isPaidContent}
+														isPaidContent={
+															isPaidContent
+														}
 													/>
 												</Island>
 											) : (
 												<AdSlot
 													data-right-ad="1"
 													position="right"
-													isPaidContent={isPaidContent}
+													isPaidContent={
+														isPaidContent
+													}
 												/>
 											)
 										) : null}
@@ -959,7 +1168,9 @@ export const LiveLayout = ({
 							<Island deferUntil="visible">
 								<Carousel
 									heading={article.storyPackage.heading}
-									trails={article.storyPackage.trails.map(decideTrail)}
+									trails={article.storyPackage.trails.map(
+										decideTrail,
+									)}
 									onwardsSource="more-on-this-story"
 									format={format}
 									leftColSize={'wide'}
@@ -980,7 +1191,9 @@ export const LiveLayout = ({
 							isAdFreeUser={article.isAdFreeUser}
 							pageId={article.pageId}
 							isPaidContent={!!article.config.isPaidContent}
-							showRelatedContent={article.config.showRelatedContent}
+							showRelatedContent={
+								article.config.showRelatedContent
+							}
 							keywordIds={article.config.keywordIds}
 							contentType={article.contentType}
 							tags={article.tags}
@@ -1000,7 +1213,9 @@ export const LiveLayout = ({
 							element="section"
 						>
 							<DiscussionLayout
-								discussionApiUrl={article.config.discussionApiUrl}
+								discussionApiUrl={
+									article.config.discussionApiUrl
+								}
 								shortUrlId={article.config.shortUrlId}
 								format={format}
 								discussionD2Uid={article.config.discussionD2Uid}
@@ -1008,7 +1223,8 @@ export const LiveLayout = ({
 									article.config.discussionApiClientHeader
 								}
 								enableDiscussionSwitch={
-									!!article.config.switches.enableDiscussionSwitch
+									!!article.config.switches
+										.enableDiscussionSwitch
 								}
 								isAdFreeUser={article.isAdFreeUser}
 								shouldHideAds={article.shouldHideAds}
@@ -1051,7 +1267,10 @@ export const LiveLayout = ({
 							backgroundColour={neutral[93]}
 							element="aside"
 						>
-							<AdSlot position="merchandising" display={format.display} />
+							<AdSlot
+								position="merchandising"
+								display={format.display}
+							/>
 						</Section>
 					)}
 				</div>
@@ -1107,9 +1326,15 @@ export const LiveLayout = ({
 						keywordIds={article.config.keywordIds}
 						pageId={article.pageId}
 						sectionId={article.config.section}
-						shouldHideReaderRevenue={article.shouldHideReaderRevenue}
-						remoteBannerSwitch={!!article.config.switches.remoteBanner}
-						puzzleBannerSwitch={!!article.config.switches.puzzlesBanner}
+						shouldHideReaderRevenue={
+							article.shouldHideReaderRevenue
+						}
+						remoteBannerSwitch={
+							!!article.config.switches.remoteBanner
+						}
+						puzzleBannerSwitch={
+							!!article.config.switches.puzzlesBanner
+						}
 						tags={article.tags}
 					/>
 				</Island>

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -1113,32 +1113,19 @@ export const LiveLayout = ({
 									`}
 								>
 									<RightColumn>
-										{renderAds ? (
-											format.design ===
-												ArticleDesign.LiveBlog ||
-											format.design ===
-												ArticleDesign.DeadBlog ? (
-												<Island
-													clientOnly={true}
-													deferUntil="visible"
-												>
-													<LiveblogRightAdSlots
-														display={format.display}
-														isPaidContent={
-															isPaidContent
-														}
-													/>
-												</Island>
-											) : (
-												<AdSlot
-													data-right-ad="1"
-													position="right"
+										{renderAds && (
+											<Island
+												clientOnly={true}
+												deferUntil="visible"
+											>
+												<LiveblogRightAdSlots
+													display={format.display}
 													isPaidContent={
 														isPaidContent
 													}
 												/>
-											)
-										) : null}
+											</Island>
+										)}
 									</RightColumn>
 								</div>
 							</GridItem>

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -35,6 +35,7 @@ import { Header } from '../components/Header';
 import { HeaderAdSlot } from '../components/HeaderAdSlot';
 import { Island } from '../components/Island';
 import { KeyEventsCarousel } from '../components/KeyEventsCarousel.importable';
+import { LiveblogRightAdSlots } from '../components/LiveblogRightAdSlots.importable';
 import { Liveness } from '../components/Liveness.importable';
 import { MainMedia } from '../components/MainMedia';
 import { MostViewedFooterData } from '../components/MostViewedFooterData.importable';
@@ -175,7 +176,7 @@ const LiveGrid = ({ children }: { children: React.ReactNode }) => (
 				/* from wide define fixed body width */
 				${from.wide} {
 					grid-column-gap: 20px;
-					grid-template-columns: 240px 700px 1fr;
+					grid-template-columns: 240px 700px 300px;
 					grid-template-areas:
 						'info		media		right-column'
 						'info		body		right-column';
@@ -278,9 +279,7 @@ export const LiveLayout = ({
 	const palette = decidePalette(format);
 
 	const footballMatchUrl =
-		article.matchType === 'FootballMatchType'
-			? article.matchUrl
-			: undefined;
+		article.matchType === 'FootballMatchType' ? article.matchUrl : undefined;
 
 	const cricketMatchUrl =
 		article.matchType === 'CricketMatchType' ? article.matchUrl : undefined;
@@ -327,9 +326,7 @@ export const LiveLayout = ({
 							mmaUrl={article.config.mmaUrl}
 							discussionApiUrl={article.config.discussionApiUrl}
 							urls={article.nav.readerRevenueLinks.header}
-							remoteHeader={
-								!!article.config.switches.remoteHeader
-							}
+							remoteHeader={!!article.config.switches.remoteHeader}
 							contributionsServiceUrl={contributionsServiceUrl}
 							idApiUrl={article.config.idApiUrl}
 							isInEuropeTest={isInEuropeTest}
@@ -350,13 +347,9 @@ export const LiveLayout = ({
 						<Nav
 							nav={NAV}
 							selectedPillar={NAV.selectedPillar}
-							subscribeUrl={
-								article.nav.readerRevenueLinks.header.subscribe
-							}
+							subscribeUrl={article.nav.readerRevenueLinks.header.subscribe}
 							editionId={article.editionId}
-							headerTopBarSwitch={
-								!!article.config.switches.headerTopNav
-							}
+							headerTopBarSwitch={!!article.config.switches.headerTopNav}
 							isInEuropeTest={isInEuropeTest}
 						/>
 					</Section>
@@ -373,9 +366,7 @@ export const LiveLayout = ({
 								<SubNav
 									subNavSections={NAV.subNavSections}
 									currentNavLink={NAV.currentNavLink}
-									linkHoverColour={
-										palette.text.articleLinkHover
-									}
+									linkHoverColour={palette.text.articleLinkHover}
 									borderColour={palette.border.subNav}
 								/>
 							</Island>
@@ -477,19 +468,13 @@ export const LiveLayout = ({
 											webPublicationDateDeprecated={
 												article.webPublicationDateDeprecated
 											}
-											hasStarRating={
-												typeof article.starRating ===
-												'number'
-											}
+											hasStarRating={typeof article.starRating === 'number'}
 										/>
 									)}
 								</div>
 								{article.starRating !== undefined ? (
 									<div css={starWrapper}>
-										<StarRating
-											rating={article.starRating}
-											size="large"
-										/>
+										<StarRating rating={article.starRating} size="large" />
 									</div>
 								) : (
 									<></>
@@ -507,20 +492,14 @@ export const LiveLayout = ({
 				>
 					<StandFirstGrid>
 						<GridItem area="standfirst">
-							<Standfirst
-								format={format}
-								standfirst={article.standfirst}
-							/>
+							<Standfirst format={format} standfirst={article.standfirst} />
 						</GridItem>
 						<GridItem area="lastupdated">
 							<Hide until="desktop">
-								{article.blocks[0]?.blockLastUpdated !==
-									undefined && (
+								{article.blocks[0]?.blockLastUpdated !== undefined && (
 									<ArticleLastUpdated
 										format={format}
-										lastUpdated={
-											article.blocks[0].blockLastUpdated
-										}
+										lastUpdated={article.blocks[0].blockLastUpdated}
 									/>
 								)}
 							</Hide>
@@ -531,8 +510,7 @@ export const LiveLayout = ({
 									<DecideLines
 										format={format}
 										color={
-											format.design ===
-											ArticleDesign.LiveBlog
+											format.design === ArticleDesign.LiveBlog
 												? 'rgba(255, 255, 255, 0.4)'
 												: undefined
 										}
@@ -550,22 +528,15 @@ export const LiveLayout = ({
 										webTitle={article.webTitle}
 										byline={article.byline}
 										tags={article.tags}
-										primaryDateline={
-											article.webPublicationDateDisplay
-										}
+										primaryDateline={article.webPublicationDateDisplay}
 										secondaryDateline={
 											article.webPublicationSecondaryDateDisplay
 										}
 										isCommentable={article.isCommentable}
-										discussionApiUrl={
-											article.config.discussionApiUrl
-										}
+										discussionApiUrl={article.config.discussionApiUrl}
 										shortUrlId={article.config.shortUrlId}
 										ajaxUrl={article.config.ajaxUrl}
-										showShareCount={
-											!!article.config.switches
-												.serverShareCounts
-										}
+										showShareCount={!!article.config.switches.serverShareCounts}
 										messageUs={article.messageUs}
 									/>
 								</div>
@@ -577,9 +548,7 @@ export const LiveLayout = ({
 					<Section
 						fullWidth={true}
 						showTopBorder={false}
-						backgroundColour={
-							palette.background.keyEventFromDesktop
-						}
+						backgroundColour={palette.background.keyEventFromDesktop}
 						borderColour={palette.border.article}
 					>
 						<Hide until={'desktop'}>
@@ -631,16 +600,12 @@ export const LiveLayout = ({
 									ajaxUrl={article.config.ajaxUrl}
 									filterKeyEvents={article.filterKeyEvents}
 									format={format}
-									enhanceTweetsSwitch={
-										!!article.config.switches.enhanceTweets
-									}
+									enhanceTweetsSwitch={!!article.config.switches.enhanceTweets}
 									onFirstPage={pagination.currentPage === 1}
 									webURL={article.webURL}
 									// We default to string here because the property is optional but we
 									// know it will exist for all blogs
-									mostRecentBlockId={
-										article.mostRecentBlockId ?? ''
-									}
+									mostRecentBlockId={article.mostRecentBlockId ?? ''}
 									hasPinnedPost={!!article.pinnedPost}
 									selectedTopics={article.selectedTopics}
 								/>
@@ -659,10 +624,7 @@ export const LiveLayout = ({
 							<GridItem area="media">
 								<div css={maxWidth}>
 									{!!footballMatchUrl && (
-										<Island
-											clientOnly={true}
-											placeholderHeight={40}
-										>
+										<Island clientOnly={true} placeholderHeight={40}>
 											<GetMatchTabs
 												matchUrl={footballMatchUrl}
 												format={format}
@@ -670,10 +632,7 @@ export const LiveLayout = ({
 										</Island>
 									)}
 									{!!cricketMatchUrl && (
-										<Island
-											clientOnly={true}
-											placeholderHeight={172}
-										>
+										<Island clientOnly={true} placeholderHeight={172}>
 											<GetCricketScoreboard
 												matchUrl={cricketMatchUrl}
 												format={format}
@@ -710,25 +669,16 @@ export const LiveLayout = ({
 											webTitle={article.webTitle}
 											byline={article.byline}
 											tags={article.tags}
-											primaryDateline={
-												article.webPublicationDateDisplay
-											}
+											primaryDateline={article.webPublicationDateDisplay}
 											secondaryDateline={
 												article.webPublicationSecondaryDateDisplay
 											}
-											isCommentable={
-												article.isCommentable
-											}
-											discussionApiUrl={
-												article.config.discussionApiUrl
-											}
-											shortUrlId={
-												article.config.shortUrlId
-											}
+											isCommentable={article.isCommentable}
+											discussionApiUrl={article.config.discussionApiUrl}
+											shortUrlId={article.config.shortUrlId}
 											ajaxUrl={article.config.ajaxUrl}
 											showShareCount={
-												!!article.config.switches
-													.serverShareCounts
+												!!article.config.switches.serverShareCounts
 											}
 											messageUs={article.messageUs}
 										/>
@@ -739,20 +689,12 @@ export const LiveLayout = ({
 									<Hide until="desktop">
 										<div css={sidePaddingDesktop}>
 											<TopicFilterBank
-												availableTopics={
-													article.availableTopics
-												}
-												selectedTopics={
-													article.selectedTopics
-												}
+												availableTopics={article.availableTopics}
+												selectedTopics={article.selectedTopics}
 												format={format}
 												keyEvents={article.keyEvents}
-												filterKeyEvents={
-													article.filterKeyEvents
-												}
-												id={
-													'key-events-carousel-desktop'
-												}
+												filterKeyEvents={article.filterKeyEvents}
+												id={'key-events-carousel-desktop'}
 											/>
 										</div>
 									</Hide>
@@ -777,9 +719,7 @@ export const LiveLayout = ({
 										<Hide below="desktop">
 											<Island deferUntil="visible">
 												<FilterKeyEventsToggle
-													filterKeyEvents={
-														article.filterKeyEvents
-													}
+													filterKeyEvents={article.filterKeyEvents}
 													id="filter-toggle-desktop"
 												/>
 											</Island>
@@ -790,21 +730,12 @@ export const LiveLayout = ({
 									{showTopicFilterBank ? (
 										<div css={paddingBody}>
 											<ArticleContainer format={format}>
-												{pagination.currentPage !==
-													1 && (
+												{pagination.currentPage !== 1 && (
 													<Pagination
-														currentPage={
-															pagination.currentPage
-														}
-														totalPages={
-															pagination.totalPages
-														}
-														newest={
-															pagination.newest
-														}
-														oldest={
-															pagination.oldest
-														}
+														currentPage={pagination.currentPage}
+														totalPages={pagination.totalPages}
+														newest={pagination.newest}
+														oldest={pagination.oldest}
 														newer={pagination.newer}
 														older={pagination.older}
 														format={format}
@@ -813,95 +744,43 @@ export const LiveLayout = ({
 												<ArticleBody
 													format={format}
 													blocks={article.blocks}
-													pinnedPost={
-														article.pinnedPost
-													}
+													pinnedPost={article.pinnedPost}
 													host={host}
 													pageId={article.pageId}
 													webTitle={article.webTitle}
-													ajaxUrl={
-														article.config.ajaxUrl
-													}
-													sectionId={
-														article.config.section
-													}
-													switches={
-														article.config.switches
-													}
-													isSensitive={
-														article.config
-															.isSensitive
-													}
-													isAdFreeUser={
-														article.isAdFreeUser
-													}
+													ajaxUrl={article.config.ajaxUrl}
+													sectionId={article.config.section}
+													switches={article.config.switches}
+													isSensitive={article.config.isSensitive}
+													isAdFreeUser={article.isAdFreeUser}
 													shouldHideReaderRevenue={
 														article.shouldHideReaderRevenue
 													}
 													tags={article.tags}
-													isPaidContent={
-														!!article.config
-															.isPaidContent
-													}
-													contributionsServiceUrl={
-														contributionsServiceUrl
-													}
-													contentType={
-														article.contentType
-													}
-													isPreview={
-														article.config.isPreview
-													}
-													idUrl={
-														article.config.idUrl ??
-														''
-													}
-													isDev={
-														!!article.config.isDev
-													}
-													onFirstPage={
-														pagination.currentPage ===
-														1
-													}
-													keyEvents={
-														article.keyEvents
-													}
-													filterKeyEvents={
-														article.filterKeyEvents
-													}
-													availableTopics={
-														article.availableTopics
-													}
-													selectedTopics={
-														article.selectedTopics
-													}
-													keywordIds={
-														article.config
-															.keywordIds
-													}
+													isPaidContent={!!article.config.isPaidContent}
+													contributionsServiceUrl={contributionsServiceUrl}
+													contentType={article.contentType}
+													isPreview={article.config.isPreview}
+													idUrl={article.config.idUrl ?? ''}
+													isDev={!!article.config.isDev}
+													onFirstPage={pagination.currentPage === 1}
+													keyEvents={article.keyEvents}
+													filterKeyEvents={article.filterKeyEvents}
+													availableTopics={article.availableTopics}
+													selectedTopics={article.selectedTopics}
+													keywordIds={article.config.keywordIds}
 													isInLiveblogAdSlotTest={
 														article.config.abTests
-															.serverSideLiveblogInlineAdsVariant ===
-														'variant'
+															.serverSideLiveblogInlineAdsVariant === 'variant'
 													}
-													renderingTarget={
-														renderingTarget
-													}
+													renderingTarget={renderingTarget}
 												/>
 												{pagination.totalPages > 1 && (
 													<Pagination
-														currentPage={
-															pagination.currentPage
-														}
-														totalPages={
-															pagination.totalPages
-														}
-														newest={
-															pagination.newest
-														}
-														oldest={
-															pagination.oldest
-														}
+														currentPage={pagination.currentPage}
+														totalPages={pagination.totalPages}
+														newest={pagination.newest}
+														oldest={pagination.oldest}
 														newer={pagination.newer}
 														older={pagination.older}
 														format={format}
@@ -916,45 +795,27 @@ export const LiveLayout = ({
 												/>
 												<SubMeta
 													format={format}
-													subMetaKeywordLinks={
-														article.subMetaKeywordLinks
-													}
-													subMetaSectionLinks={
-														article.subMetaSectionLinks
-													}
+													subMetaKeywordLinks={article.subMetaKeywordLinks}
+													subMetaSectionLinks={article.subMetaSectionLinks}
 													pageId={article.pageId}
 													webUrl={article.webURL}
 													webTitle={article.webTitle}
 													showBottomSocialButtons={
 														article.showBottomSocialButtons
 													}
-													badge={
-														article.badge?.enhanced
-													}
+													badge={article.badge?.enhanced}
 												/>
 											</ArticleContainer>
 										</div>
 									) : (
-										<Accordion
-											accordionTitle="Live feed"
-											context="liveFeed"
-										>
+										<Accordion accordionTitle="Live feed" context="liveFeed">
 											<ArticleContainer format={format}>
-												{pagination.currentPage !==
-													1 && (
+												{pagination.currentPage !== 1 && (
 													<Pagination
-														currentPage={
-															pagination.currentPage
-														}
-														totalPages={
-															pagination.totalPages
-														}
-														newest={
-															pagination.newest
-														}
-														oldest={
-															pagination.oldest
-														}
+														currentPage={pagination.currentPage}
+														totalPages={pagination.totalPages}
+														newest={pagination.newest}
+														oldest={pagination.oldest}
 														newer={pagination.newer}
 														older={pagination.older}
 														format={format}
@@ -963,99 +824,45 @@ export const LiveLayout = ({
 												<ArticleBody
 													format={format}
 													blocks={article.blocks}
-													pinnedPost={
-														article.pinnedPost
-													}
+													pinnedPost={article.pinnedPost}
 													host={host}
 													pageId={article.pageId}
 													webTitle={article.webTitle}
-													ajaxUrl={
-														article.config.ajaxUrl
-													}
-													sectionId={
-														article.config.section
-													}
-													switches={
-														article.config.switches
-													}
-													isSensitive={
-														article.config
-															.isSensitive
-													}
-													isAdFreeUser={
-														article.isAdFreeUser
-													}
+													ajaxUrl={article.config.ajaxUrl}
+													sectionId={article.config.section}
+													switches={article.config.switches}
+													isSensitive={article.config.isSensitive}
+													isAdFreeUser={article.isAdFreeUser}
 													shouldHideReaderRevenue={
 														article.shouldHideReaderRevenue
 													}
 													tags={article.tags}
-													isPaidContent={
-														!!article.config
-															.isPaidContent
-													}
-													contributionsServiceUrl={
-														contributionsServiceUrl
-													}
-													contentType={
-														article.contentType
-													}
-													isPreview={
-														article.config.isPreview
-													}
-													idUrl={
-														article.config.idUrl ??
-														''
-													}
-													isDev={
-														!!article.config.isDev
-													}
-													onFirstPage={
-														pagination.currentPage ===
-														1
-													}
-													keyEvents={
-														article.keyEvents
-													}
-													filterKeyEvents={
-														article.filterKeyEvents
-													}
-													availableTopics={
-														article.availableTopics
-													}
-													selectedTopics={
-														article.selectedTopics
-													}
-													keywordIds={
-														article.config
-															.keywordIds
-													}
+													isPaidContent={!!article.config.isPaidContent}
+													contributionsServiceUrl={contributionsServiceUrl}
+													contentType={article.contentType}
+													isPreview={article.config.isPreview}
+													idUrl={article.config.idUrl ?? ''}
+													isDev={!!article.config.isDev}
+													onFirstPage={pagination.currentPage === 1}
+													keyEvents={article.keyEvents}
+													filterKeyEvents={article.filterKeyEvents}
+													availableTopics={article.availableTopics}
+													selectedTopics={article.selectedTopics}
+													keywordIds={article.config.keywordIds}
 													isInLiveblogAdSlotTest={
 														article.config.abTests
-															.serverSideLiveblogInlineAdsVariant ===
-														'variant'
+															.serverSideLiveblogInlineAdsVariant === 'variant'
 													}
 													lang={article.lang}
-													isRightToLeftLang={
-														article.isRightToLeftLang
-													}
-													renderingTarget={
-														renderingTarget
-													}
+													isRightToLeftLang={article.isRightToLeftLang}
+													renderingTarget={renderingTarget}
 												/>
 												{pagination.totalPages > 1 && (
 													<Pagination
-														currentPage={
-															pagination.currentPage
-														}
-														totalPages={
-															pagination.totalPages
-														}
-														newest={
-															pagination.newest
-														}
-														oldest={
-															pagination.oldest
-														}
+														currentPage={pagination.currentPage}
+														totalPages={pagination.totalPages}
+														newest={pagination.newest}
+														oldest={pagination.oldest}
 														newer={pagination.newer}
 														older={pagination.older}
 														format={format}
@@ -1070,21 +877,15 @@ export const LiveLayout = ({
 												/>
 												<SubMeta
 													format={format}
-													subMetaKeywordLinks={
-														article.subMetaKeywordLinks
-													}
-													subMetaSectionLinks={
-														article.subMetaSectionLinks
-													}
+													subMetaKeywordLinks={article.subMetaKeywordLinks}
+													subMetaSectionLinks={article.subMetaSectionLinks}
 													pageId={article.pageId}
 													webUrl={article.webURL}
 													webTitle={article.webTitle}
 													showBottomSocialButtons={
 														article.showBottomSocialButtons
 													}
-													badge={
-														article.badge?.enhanced
-													}
+													badge={article.badge?.enhanced}
 												/>
 											</ArticleContainer>
 										</Accordion>
@@ -1112,19 +913,20 @@ export const LiveLayout = ({
 									`}
 								>
 									<RightColumn>
-										{renderAds && (
-											<AdSlot
-												position="right"
-												display={format.display}
-												shouldHideReaderRevenue={
-													article.shouldHideReaderRevenue
-												}
-												isPaidContent={
-													article.pageType
-														.isPaidContent
-												}
-											/>
-										)}
+										{renderAds ? (
+											format.design === ArticleDesign.LiveBlog ||
+											format.design === ArticleDesign.DeadBlog ? (
+												<Island clientOnly={true} deferUntil="visible">
+													<LiveblogRightAdSlots isPaidContent={isPaidContent} />
+												</Island>
+											) : (
+												<AdSlot
+													data-right-ad="1"
+													position="right"
+													isPaidContent={isPaidContent}
+												/>
+											)
+										) : null}
 									</RightColumn>
 								</div>
 							</GridItem>
@@ -1154,9 +956,7 @@ export const LiveLayout = ({
 							<Island deferUntil="visible">
 								<Carousel
 									heading={article.storyPackage.heading}
-									trails={article.storyPackage.trails.map(
-										decideTrail,
-									)}
+									trails={article.storyPackage.trails.map(decideTrail)}
 									onwardsSource="more-on-this-story"
 									format={format}
 									leftColSize={'wide'}
@@ -1177,9 +977,7 @@ export const LiveLayout = ({
 							isAdFreeUser={article.isAdFreeUser}
 							pageId={article.pageId}
 							isPaidContent={!!article.config.isPaidContent}
-							showRelatedContent={
-								article.config.showRelatedContent
-							}
+							showRelatedContent={article.config.showRelatedContent}
 							keywordIds={article.config.keywordIds}
 							contentType={article.contentType}
 							tags={article.tags}
@@ -1199,9 +997,7 @@ export const LiveLayout = ({
 							element="section"
 						>
 							<DiscussionLayout
-								discussionApiUrl={
-									article.config.discussionApiUrl
-								}
+								discussionApiUrl={article.config.discussionApiUrl}
 								shortUrlId={article.config.shortUrlId}
 								format={format}
 								discussionD2Uid={article.config.discussionD2Uid}
@@ -1209,8 +1005,7 @@ export const LiveLayout = ({
 									article.config.discussionApiClientHeader
 								}
 								enableDiscussionSwitch={
-									!!article.config.switches
-										.enableDiscussionSwitch
+									!!article.config.switches.enableDiscussionSwitch
 								}
 								isAdFreeUser={article.isAdFreeUser}
 								shouldHideAds={article.shouldHideAds}
@@ -1253,10 +1048,7 @@ export const LiveLayout = ({
 							backgroundColour={neutral[93]}
 							element="aside"
 						>
-							<AdSlot
-								position="merchandising"
-								display={format.display}
-							/>
+							<AdSlot position="merchandising" display={format.display} />
 						</Section>
 					)}
 				</div>
@@ -1312,15 +1104,9 @@ export const LiveLayout = ({
 						keywordIds={article.config.keywordIds}
 						pageId={article.pageId}
 						sectionId={article.config.section}
-						shouldHideReaderRevenue={
-							article.shouldHideReaderRevenue
-						}
-						remoteBannerSwitch={
-							!!article.config.switches.remoteBanner
-						}
-						puzzleBannerSwitch={
-							!!article.config.switches.puzzlesBanner
-						}
+						shouldHideReaderRevenue={article.shouldHideReaderRevenue}
+						remoteBannerSwitch={!!article.config.switches.remoteBanner}
+						puzzleBannerSwitch={!!article.config.switches.puzzlesBanner}
 						tags={article.tags}
 					/>
 				</Island>

--- a/dotcom-rendering/src/lib/liveblog-right-ad-constants.ts
+++ b/dotcom-rendering/src/lib/liveblog-right-ad-constants.ts
@@ -1,0 +1,19 @@
+// These settings are used to configure ad placement in the right-column on liveblog pages
+
+/**
+ * The height of the container in which the ad will be placed.
+ * Unit: pixels
+ */
+export const AD_CONTAINER_HEIGHT = 1400;
+
+/**
+ * The height of the gap between the ad containers
+ * Unit: pixels
+ */
+export const SPACE_BETWEEN_ADS = 900;
+
+/**
+ * The height to leave as empty space between the final as container and the bottom of the right space
+ * Unit: pixels
+ */
+export const PADDING_BOTTOM = 36;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3129,10 +3129,10 @@
     read-pkg-up "7.0.1"
     yargs "^17.6.2"
 
-"@guardian/commercial@10.6.0":
-  version "10.6.0"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-10.6.0.tgz#315325ce9625540bb22574bad9eace2552543706"
-  integrity sha512-xs50dVkUrSwRtH3Y3e1ruDkQTpL+lT1nbZHyiml5JYYzs1VCOoVBWlFdTbuKeXRLoMrmWQB6A2/wkS+eGUccZg==
+"@guardian/commercial@10.8.0":
+  version "10.8.0"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-10.8.0.tgz#2033142e874dffba725319e5d23ce3dd0a044c66"
+  integrity sha512-tHrzUyKBBoFS0JUha4kiv5aPD5Q3ej0pjVFiseu6NtPGijaK5JmAnlF4UitbRUP46dlOnoDA3RVAVZ02hcBTbw==
   dependencies:
     "@changesets/cli" "^2.26.1"
     "@guardian/ab-core" "^5.0.0"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Creates an AB test for placing adverts in the right-hand column. 

|   |   |
| :---                               | :---     |
| control                         | One advert that is sticky for the whole length of the column |
| minimum-stickiness   | One advert that is sticky for a maximum of 1059px|
| multiple-adverts         | Multiple adverts that are sticky for a specific height, with a gap between advert containers      |

## Why?

We want to test the effects of different strategies of utilising the right-hand column on liveblog pages

## Other PR's

- [Frontend](https://github.com/guardian/frontend/pull/26332)
- [Commercial](https://github.com/guardian/commercial/pull/947)

## Screenshots

https://github.com/guardian/dotcom-rendering/assets/9574885/a56a8fb8-4938-4bef-82ad-fed7150980c9

https://github.com/guardian/dotcom-rendering/assets/9574885/22d256fb-9c03-4089-b7b4-9c2ef5fc2ac4

https://github.com/guardian/dotcom-rendering/assets/9574885/2682c12f-78c7-482c-bba8-0bf4decb8e68

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
