### PR TITLE
Refactor and simplify manifest lookup logic

### DIFF
--- a/dotcom-rendering/src/lib/assets.ts
+++ b/dotcom-rendering/src/lib/assets.ts
@@ -61,9 +61,9 @@ const getManifest = (path: string): AssetHash => {
 
 type ManifestPath = `./manifest.${string}.json`;
 
-const getManifestPath = (
-	build: 'apps' | 'modern' | 'variant' | 'legacy',
-): ManifestPath => {
+type Build = 'apps' | 'modern' | 'variant' | 'legacy';
+
+const getManifestPath = (build: Build): ManifestPath => {
 	switch (build) {
 		case 'apps':
 			return './manifest.apps.json';
@@ -77,7 +77,7 @@ const getManifestPath = (
 };
 
 export const getPathFromManifest = (
-	build: 'apps' | 'modern' | 'variant' | 'legacy',
+	build: Build,
 	filename: `${string}.js`,
 ): string => {
 	if (!filename.endsWith('.js'))
@@ -107,8 +107,8 @@ export const getPathFromManifest = (
  * with an optional hash for local development
  * and stripped query parameters.
  */
-const getScriptRegex = (bundle: 'modern' | 'legacy' | 'variant' | 'apps') =>
-	new RegExp(`assets\\/\\w+\\.${bundle}\\.(\\w{20}\\.)?js(\\?.*)?$`);
+const getScriptRegex = (build: Build) =>
+	new RegExp(`assets\\/\\w+\\.${build}\\.(\\w{20}\\.)?js(\\?.*)?$`);
 
 export const LEGACY_SCRIPT = getScriptRegex('legacy');
 export const MODERN_SCRIPT = getScriptRegex('modern');

--- a/dotcom-rendering/src/lib/assets.ts
+++ b/dotcom-rendering/src/lib/assets.ts
@@ -59,9 +59,9 @@ const getManifest = (path: string): AssetHash => {
 	}
 };
 
-type ManifestPath = `./manifest.${string}.json`;
-
 type Build = 'apps' | 'modern' | 'variant' | 'legacy';
+
+type ManifestPath = `./manifest.${Build}.json`;
 
 const getManifestPath = (build: Build): ManifestPath => {
 	switch (build) {

--- a/dotcom-rendering/src/lib/assets.ts
+++ b/dotcom-rendering/src/lib/assets.ts
@@ -59,77 +59,50 @@ const getManifest = (path: string): AssetHash => {
 	}
 };
 
-const getManifestPaths = (
-	manifests: 'control' | 'variant' | 'apps',
-): [ManifestPath, ManifestPath] | [ManifestPath] => {
-	switch (manifests) {
+type ManifestPath = `./manifest.${string}.json`;
+
+const getManifestPath = (
+	build: 'apps' | 'modern' | 'variant' | 'legacy',
+): ManifestPath => {
+	switch (build) {
 		case 'apps':
-			return ['./manifest.apps.json'];
+			return './manifest.apps.json';
+		case 'modern':
+			return './manifest.modern.json';
 		case 'variant':
-			return ['./manifest.variant.json', './manifest.legacy.json'];
-		case 'control':
-			return ['./manifest.modern.json', './manifest.legacy.json'];
+			return './manifest.variant.json';
+		case 'legacy':
+			return './manifest.legacy.json';
 	}
 };
 
-type ManifestPath = `./manifest.${string}.json`;
-
-const getScripts = (
-	manifestPaths: Array<ManifestPath>,
-	file: `${string}.js`,
-): string[] => {
-	if (!file.endsWith('.js'))
+export const getPathFromManifest = (
+	build: 'apps' | 'modern' | 'variant' | 'legacy',
+	filename: `${string}.js`,
+): string => {
+	if (!filename.endsWith('.js'))
 		throw new Error('Invalid filename: extension must be .js');
 
 	if (isDev) {
-		if (manifestPaths.every((path) => path.includes('.apps.'))) {
-			return [`${ASSET_ORIGIN}assets/${file.replace('.js', '.apps.js')}`];
-		}
-		return [
-			`${ASSET_ORIGIN}assets/${file.replace('.js', '.modern.js')}`,
-			`${ASSET_ORIGIN}assets/${file.replace('.js', '.legacy.js')}`,
-		];
+		return `${ASSET_ORIGIN}assets/${filename.replace(
+			'.js',
+			`.${build}.js`,
+		)}`;
 	}
 
-	return manifestPaths.map((manifestPath) => {
-		const manifest = getManifest(manifestPath);
-		const filename = manifest[file];
+	const manifest = getManifest(getManifestPath(build));
+	const filenameFromManifest = manifest[filename];
 
-		if (!filename) {
-			throw new Error(`Missing manifest for ${file}`);
-		}
+	if (!filenameFromManifest) {
+		throw new Error(`Missing manifest for ${filename}`);
+	}
 
-		return `${ASSET_ORIGIN}assets/${filename}`;
-	});
+	return `${ASSET_ORIGIN}assets/${filenameFromManifest}`;
 };
 
 /**
- * A curried function that takes an array of manifests.
- *
- * The returned function takes a script name and returns
- * an array of scripts found in the manifests.
- */
-export const getScriptsFromManifest =
-	(
-		opts:
-			| { platform: 'apps' }
-			| { platform: 'web'; shouldServeVariantBundle: boolean },
-	) =>
-	(file: `${string}.js`): ReturnType<typeof getScripts> => {
-		if (opts.platform === 'apps') {
-			return getScripts(getManifestPaths('apps'), file);
-		} else {
-			return getScripts(
-				getManifestPaths(
-					opts.shouldServeVariantBundle ? 'variant' : 'control',
-				),
-				file,
-			);
-		}
-	};
-
-/** To ensure this only applies to guardian scripts,
- * we check that it is served from a asset/ directory
+ * To ensure this only applies to guardian scripts,
+ * we check that it is served from an asset/ directory
  * and that it ends with the bundle type and extension,
  * with an optional hash for local development
  * and stripped query parameters.

--- a/dotcom-rendering/src/server/render.allEditorialNewslettersPage.web.tsx
+++ b/dotcom-rendering/src/server/render.allEditorialNewslettersPage.web.tsx
@@ -3,7 +3,7 @@ import {
 	dcrJavascriptBundle,
 } from '../../scripts/webpack/bundles';
 import { AllEditorialNewslettersPage } from '../components/AllEditorialNewslettersPage';
-import { generateScriptTags, getScriptsFromManifest } from '../lib/assets';
+import { generateScriptTags, getPathFromManifest } from '../lib/assets';
 import { renderToStringWithEmotion } from '../lib/emotion';
 import { escapeData } from '../lib/escapeData';
 import { getHttp3Url } from '../lib/getHttp3Url';
@@ -42,16 +42,7 @@ export const renderEditorialNewslettersPage = ({
 			'variant',
 	].every(Boolean);
 
-	/**
-	 * This function returns an array of files found in the manifests
-	 * defined by `manifestPaths`.
-	 *
-	 * @see getScriptsFromManifest
-	 */
-	const getScriptArrayFromFile = getScriptsFromManifest({
-		platform: 'web',
-		shouldServeVariantBundle,
-	});
+	const build = shouldServeVariantBundle ? 'variant' : 'modern';
 
 	/**
 	 * The highest priority scripts.
@@ -63,8 +54,10 @@ export const renderEditorialNewslettersPage = ({
 	const scriptTags = generateScriptTags(
 		[
 			polyfillIO,
-			...getScriptArrayFromFile('frameworks.js'),
-			...getScriptArrayFromFile('index.js'),
+			getPathFromManifest(build, 'frameworks.js'),
+			getPathFromManifest(build, 'index.js'),
+			getPathFromManifest('legacy', 'frameworks.js'),
+			getPathFromManifest('legacy', 'index.js'),
 			process.env.COMMERCIAL_BUNDLE_URL ??
 				newslettersPage.config.commercialBundleUrl,
 		].map((script) => (offerHttp3 ? getHttp3Url(script) : script)),

--- a/dotcom-rendering/src/server/render.article.apps.tsx
+++ b/dotcom-rendering/src/server/render.article.apps.tsx
@@ -1,6 +1,6 @@
 import { isString } from '@guardian/libs';
 import { ArticlePage } from '../components/ArticlePage';
-import { generateScriptTags, getScriptsFromManifest } from '../lib/assets';
+import { generateScriptTags, getPathFromManifest } from '../lib/assets';
 import { decideFormat } from '../lib/decideFormat';
 import { renderToStringWithEmotion } from '../lib/emotion';
 import { escapeData } from '../lib/escapeData';
@@ -24,11 +24,7 @@ export const renderArticle = (
 		/>,
 	);
 
-	const getScriptArrayFromFile = getScriptsFromManifest({
-		platform: 'apps',
-	});
-
-	const clientScripts = getScriptArrayFromFile('index.js');
+	const clientScripts = [getPathFromManifest('apps', 'index.js')];
 	const scriptTags = generateScriptTags([...clientScripts].filter(isString));
 
 	/**

--- a/dotcom-rendering/src/server/render.article.web.tsx
+++ b/dotcom-rendering/src/server/render.article.web.tsx
@@ -9,7 +9,7 @@ import { KeyEventsContainer } from '../components/KeyEventsContainer';
 import {
 	ASSET_ORIGIN,
 	generateScriptTags,
-	getScriptsFromManifest,
+	getPathFromManifest,
 } from '../lib/assets';
 import { decideFormat } from '../lib/decideFormat';
 import { decideTheme } from '../lib/decideTheme';
@@ -88,21 +88,12 @@ export const renderHtml = ({ article }: Props): string => {
 			'model.dotcomrendering.pageElements.TweetBlockElement',
 	);
 
-	const shouldServeVariantBundle: boolean = [
+	const serveVariantBundle: boolean = [
 		BUILD_VARIANT,
 		article.config.abTests[dcrJavascriptBundle('Variant')] === 'variant',
 	].every(Boolean);
 
-	/**
-	 * This function returns an array of files found in the manifests
-	 * defined by `manifestPaths`.
-	 *
-	 * @see getScriptsFromManifest
-	 */
-	const getScriptArrayFromFile = getScriptsFromManifest({
-		platform: 'web',
-		shouldServeVariantBundle,
-	});
+	const build = serveVariantBundle ? 'variant' : 'modern';
 
 	/**
 	 * The highest priority scripts.
@@ -114,8 +105,10 @@ export const renderHtml = ({ article }: Props): string => {
 	const scriptTags = generateScriptTags(
 		[
 			polyfillIO,
-			...getScriptArrayFromFile('frameworks.js'),
-			...getScriptArrayFromFile('index.js'),
+			getPathFromManifest(build, 'frameworks.js'),
+			getPathFromManifest(build, 'index.js'),
+			getPathFromManifest('legacy', 'frameworks.js'),
+			getPathFromManifest('legacy', 'index.js'),
 			process.env.COMMERCIAL_BUNDLE_URL ??
 				article.config.commercialBundleUrl,
 			pageHasNonBootInteractiveElements &&

--- a/dotcom-rendering/src/server/render.front.web.tsx
+++ b/dotcom-rendering/src/server/render.front.web.tsx
@@ -5,12 +5,13 @@ import {
 } from '../../scripts/webpack/bundles';
 import { FrontPage } from '../components/FrontPage';
 import { TagFrontPage } from '../components/TagFrontPage';
-import { generateScriptTags, getScriptsFromManifest } from '../lib/assets';
+import { generateScriptTags, getPathFromManifest } from '../lib/assets';
 import { renderToStringWithEmotion } from '../lib/emotion';
 import { escapeData } from '../lib/escapeData';
 import { getHttp3Url } from '../lib/getHttp3Url';
 import { themeToPillar } from '../lib/themeToPillar';
-import { extractNAV, NavType } from '../model/extract-nav';
+import type { NavType } from '../model/extract-nav';
+import { extractNAV } from '../model/extract-nav';
 import { makeWindowGuardian } from '../model/window-guardian';
 import type { DCRFrontType } from '../types/front';
 import type { DCRTagFrontType } from '../types/tagFront';
@@ -91,16 +92,7 @@ export const renderFront = ({ front }: Props): string => {
 		front.config.abTests[dcrJavascriptBundle('Variant')] === 'variant',
 	].every(Boolean);
 
-	/**
-	 * This function returns an array of files found in the manifests
-	 * defined by `manifestPaths`.
-	 *
-	 * @see getScriptsFromManifest
-	 */
-	const getScriptArrayFromFile = getScriptsFromManifest({
-		platform: 'web',
-		shouldServeVariantBundle,
-	});
+	const build = shouldServeVariantBundle ? 'variant' : 'modern';
 
 	/**
 	 * The highest priority scripts.
@@ -112,8 +104,10 @@ export const renderFront = ({ front }: Props): string => {
 	const scriptTags = generateScriptTags(
 		[
 			polyfillIO,
-			...getScriptArrayFromFile('frameworks.js'),
-			...getScriptArrayFromFile('index.js'),
+			getPathFromManifest(build, 'frameworks.js'),
+			getPathFromManifest(build, 'index.js'),
+			getPathFromManifest('legacy', 'frameworks.js'),
+			getPathFromManifest('legacy', 'index.js'),
 			process.env.COMMERCIAL_BUNDLE_URL ??
 				front.config.commercialBundleUrl,
 		]
@@ -192,16 +186,7 @@ export const renderTagFront = ({
 		tagFront.config.abTests[dcrJavascriptBundle('Variant')] === 'variant',
 	].every(Boolean);
 
-	/**
-	 * This function returns an array of files found in the manifests
-	 * defined by `manifestPaths`.
-	 *
-	 * @see getScriptsFromManifest
-	 */
-	const getScriptArrayFromFile = getScriptsFromManifest({
-		platform: 'web',
-		shouldServeVariantBundle,
-	});
+	const build = shouldServeVariantBundle ? 'variant' : 'modern';
 
 	/**
 	 * The highest priority scripts.
@@ -213,8 +198,8 @@ export const renderTagFront = ({
 	const scriptTags = generateScriptTags(
 		[
 			polyfillIO,
-			...getScriptArrayFromFile('frameworks.js'),
-			...getScriptArrayFromFile('index.js'),
+			getPathFromManifest(build, 'frameworks.js'),
+			getPathFromManifest(build, 'index.js'),
 			process.env.COMMERCIAL_BUNDLE_URL ??
 				tagFront.config.commercialBundleUrl,
 		]

--- a/dotcom-rendering/src/server/render.front.web.tsx
+++ b/dotcom-rendering/src/server/render.front.web.tsx
@@ -200,6 +200,8 @@ export const renderTagFront = ({
 			polyfillIO,
 			getPathFromManifest(build, 'frameworks.js'),
 			getPathFromManifest(build, 'index.js'),
+			getPathFromManifest('legacy', 'frameworks.js'),
+			getPathFromManifest('legacy', 'index.js'),
 			process.env.COMMERCIAL_BUNDLE_URL ??
 				tagFront.config.commercialBundleUrl,
 		]


### PR DESCRIPTION
## What does this change?

When Webpack builds DCR it produces a manifest file for each type of build: `web.modern`, `web.variant` (if switched on), `web.legacy` and `apps`.

The manifest file contains a map from the generic name (e.g. index.js) to the actual hashed file name that is output by webpack (e.g. index.modern.34924.js).

When we add scripts to the html head for each of the different targets we lookup the actual file name and path from the manifest.

I think the current manifest logic (that I contributed to!) is quite complex, difficult to read and could be simplified.

This PR refactors the lookup logic as follows:

- one-to-one mapping between a lookup request and a path from the manifest being returned 
- explicitly require a legacy lookup rather than being implicitly returned by the 'web' build
- remove confusing curried functions (my [bad](https://github.com/guardian/dotcom-rendering/pull/5612/commits/315d63bd1319fe5d6a6c065b0cd38f5303586ca2))
- use the build names of 'modern', 'variant', 'legacy' and 'apps' as flow control

