### PR TITLE
fix: pick colour from pillar palette for immersive card bylines

### DIFF
--- a/dotcom-rendering/src/lib/decidePalette.ts
+++ b/dotcom-rendering/src/lib/decidePalette.ts
@@ -673,10 +673,12 @@ const textCardHeadline = (format: ArticleFormat): string => {
 
 const textCardStandfirst = textCardHeadline;
 
-/** same as textByline except for SpecialReport */
 const textCardByline = (format: ArticleFormat): string => {
 	if (format.theme === ArticleSpecial.SpecialReport)
 		return specialReport[700];
+
+	if (format.display === ArticleDisplay.Immersive)
+		return pillarPalette[format.theme].main;
 
 	return textByline(format);
 };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Override byline colour by picking main pillar colour for Immersive Articles. 

## Why?

Addresses problem with immersive article cards which had unreadable bylines.
Fixes #8290 

## Screenshots

| Frontend | Before      | After      |
| ----------- | ----------- | ---------- |
| ![frontend][] | ![before][] | ![after][] |

[frontend]:https://github.com/guardian/dotcom-rendering/assets/43961396/31f5aa09-57d8-417b-9107-e96fc72fbb47
[before]: https://github.com/guardian/dotcom-rendering/assets/43961396/76bf28fb-cb4a-4d4c-8ff9-7302f2c54727
[after]: https://github.com/guardian/dotcom-rendering/assets/43961396/e3716cf7-0af4-4ba8-9b2d-c3490a8b2c23

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
