### PR TITLE
Ab/video container spike

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -478,105 +478,108 @@ export const Card = ({
 						)}
 					</ImageWrapper>
 				)}
-				<ContentWrapper
-					imageType={media?.type}
-					imageSize={imageSize}
-					imagePosition={imagePosition}
-				>
-					<HeadlineWrapper
-						imagePositionOnMobile={imagePositionOnMobile}
+
+				{containerType != 'fixed/video' && (
+					<ContentWrapper
+						imageType={media?.type}
+						imageSize={imageSize}
 						imagePosition={imagePosition}
-						imageUrl={imageUrl}
-						hasStarRating={starRating !== undefined}
 					>
-						<CardHeadline
-							headlineText={headlineText}
-							format={format}
-							containerPalette={containerPalette}
-							size={headlineSize}
-							sizeOnMobile={headlineSizeOnMobile}
-							showQuotes={showQuotes}
-							kickerText={
-								format.design === ArticleDesign.LiveBlog &&
-								!kickerText
-									? 'Live'
-									: kickerText
-							}
-							showPulsingDot={
-								format.design === ArticleDesign.LiveBlog ||
-								showPulsingDot
-							}
-							byline={byline}
-							showByline={showByline}
-							isDynamo={isDynamo}
-							isExternalLink={isExternalLink}
-						/>
-						{starRating !== undefined ? (
-							<StarRatingComponent
-								rating={starRating}
-								cardHasImage={imageUrl !== undefined}
-							/>
-						) : null}
-						{!!mainMedia && mainMedia.type !== 'Video' && (
-							<MediaMeta
-								containerPalette={containerPalette}
+						<HeadlineWrapper
+							imagePositionOnMobile={imagePositionOnMobile}
+							imagePosition={imagePosition}
+							imageUrl={imageUrl}
+							hasStarRating={starRating !== undefined}
+						>
+							<CardHeadline
+								headlineText={headlineText}
 								format={format}
-								mediaType={mainMedia.type}
-								mediaDuration={
-									mainMedia.type === 'Audio'
-										? mainMedia.duration
-										: undefined
+								containerPalette={containerPalette}
+								size={headlineSize}
+								sizeOnMobile={headlineSizeOnMobile}
+								showQuotes={showQuotes}
+								kickerText={
+									format.design === ArticleDesign.LiveBlog &&
+									!kickerText
+										? 'Live'
+										: kickerText
 								}
-								hasKicker={!!kickerText}
-							/>
-						)}
-					</HeadlineWrapper>
-					{/* This div is needed to push this content to the bottom of the card */}
-					<div>
-						{!!trailText && (
-							<TrailTextWrapper
-								containerPalette={containerPalette}
-								format={format}
-								imagePosition={imagePosition}
-								imageSize={imageSize}
-								imageType={media?.type}
-							>
-								<div
-									dangerouslySetInnerHTML={{
-										__html: trailText,
-									}}
-								/>
-							</TrailTextWrapper>
-						)}
-						{showLivePlayable && (
-							<Island>
-								<LatestLinks
-									id={linkTo}
-									format={format}
-									isDynamo={isDynamo}
-									direction={supportingContentAlignment}
-									containerPalette={containerPalette}
-								></LatestLinks>
-							</Island>
-						)}
-						<DecideFooter
-							isOpinion={isOpinion}
-							hasSublinks={hasSublinks}
-							renderFooter={renderFooter}
-						/>
-						{hasSublinks && sublinkPosition === 'inner' ? (
-							<SupportingContent
-								supportingContent={supportingContent}
-								alignment="vertical"
-								containerPalette={containerPalette}
+								showPulsingDot={
+									format.design === ArticleDesign.LiveBlog ||
+									showPulsingDot
+								}
+								byline={byline}
+								showByline={showByline}
 								isDynamo={isDynamo}
-								parentFormat={format}
+								isExternalLink={isExternalLink}
 							/>
-						) : (
-							<></>
-						)}
-					</div>
-				</ContentWrapper>
+							{starRating !== undefined ? (
+								<StarRatingComponent
+									rating={starRating}
+									cardHasImage={imageUrl !== undefined}
+								/>
+							) : null}
+							{!!mainMedia && mainMedia.type !== 'Video' && (
+								<MediaMeta
+									containerPalette={containerPalette}
+									format={format}
+									mediaType={mainMedia.type}
+									mediaDuration={
+										mainMedia.type === 'Audio'
+											? mainMedia.duration
+											: undefined
+									}
+									hasKicker={!!kickerText}
+								/>
+							)}
+						</HeadlineWrapper>
+						{/* This div is needed to push this content to the bottom of the card */}
+						<div>
+							{!!trailText && (
+								<TrailTextWrapper
+									containerPalette={containerPalette}
+									format={format}
+									imagePosition={imagePosition}
+									imageSize={imageSize}
+									imageType={media?.type}
+								>
+									<div
+										dangerouslySetInnerHTML={{
+											__html: trailText,
+										}}
+									/>
+								</TrailTextWrapper>
+							)}
+							{showLivePlayable && (
+								<Island>
+									<LatestLinks
+										id={linkTo}
+										format={format}
+										isDynamo={isDynamo}
+										direction={supportingContentAlignment}
+										containerPalette={containerPalette}
+									></LatestLinks>
+								</Island>
+							)}
+							<DecideFooter
+								isOpinion={isOpinion}
+								hasSublinks={hasSublinks}
+								renderFooter={renderFooter}
+							/>
+							{hasSublinks && sublinkPosition === 'inner' ? (
+								<SupportingContent
+									supportingContent={supportingContent}
+									alignment="vertical"
+									containerPalette={containerPalette}
+									isDynamo={isDynamo}
+									parentFormat={format}
+								/>
+							) : (
+								<></>
+							)}
+						</div>
+					</ContentWrapper>
+				)}
 			</CardLayout>
 
 			{hasSublinks && sublinkPosition === 'outer' ? (

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -454,6 +454,7 @@ export const Card = ({
 										hideCaption={true}
 										role="inline"
 										stickyVideos={false}
+										kicker={'Breaking News'}
 									/>
 								</Island>
 							</div>

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -94,6 +94,7 @@ export type Props = {
 	slideshowImages?: DCRSlideshowImage[];
 	showLivePlayable?: boolean;
 	onwardsSource?: string;
+	minWidthInPixelsOnMobile?: number;
 };
 
 const StarRatingComponent = ({
@@ -282,6 +283,7 @@ export const Card = ({
 	slideshowImages,
 	showLivePlayable = false,
 	onwardsSource,
+	minWidthInPixelsOnMobile,
 }: Props) => {
 	const palette = decidePalette(format, containerPalette);
 
@@ -395,6 +397,7 @@ export const Card = ({
 				imagePosition={imagePosition}
 				imagePositionOnMobile={imagePositionOnMobile}
 				minWidthInPixels={minWidthInPixels}
+				minWidthInPixelsOnMobile={minWidthInPixelsOnMobile}
 				imageType={media?.type}
 			>
 				{media && (

--- a/dotcom-rendering/src/components/Card/components/CardLayout.tsx
+++ b/dotcom-rendering/src/components/Card/components/CardLayout.tsx
@@ -8,6 +8,7 @@ type Props = {
 	imagePosition: ImagePositionType;
 	imagePositionOnMobile: ImagePositionType;
 	minWidthInPixels?: number;
+	minWidthInPixelsOnMobile?: number;
 };
 
 const decideDirection = (imagePosition: ImagePositionType) => {
@@ -26,7 +27,24 @@ const decideDirection = (imagePosition: ImagePositionType) => {
 	}
 };
 
-const decideWidth = (minWidthInPixels?: number) => {
+const decideWidth = (
+	minWidthInPixels?: number,
+	minWidthInPixelsOnMobile?: number,
+) => {
+	if (
+		minWidthInPixels !== undefined &&
+		minWidthInPixels > 0 &&
+		minWidthInPixelsOnMobile !== undefined &&
+		minWidthInPixelsOnMobile > 0
+	) {
+		return css`
+			min-width: ${minWidthInPixels}px;
+			${until.tablet} {
+				min-width: ${minWidthInPixelsOnMobile}px;
+			}
+		`;
+	}
+
 	if (minWidthInPixels !== undefined && minWidthInPixels > 0) {
 		return css`
 			min-width: ${minWidthInPixels}px;
@@ -77,6 +95,7 @@ export const CardLayout = ({
 	imagePositionOnMobile,
 	minWidthInPixels,
 	imageType,
+	minWidthInPixelsOnMobile,
 }: Props) => (
 	<div
 		css={[
@@ -84,7 +103,7 @@ export const CardLayout = ({
 				display: flex;
 				flex-basis: 100%;
 			`,
-			decideWidth(minWidthInPixels),
+			decideWidth(minWidthInPixels, minWidthInPixelsOnMobile),
 			decidePosition(imagePosition, imagePositionOnMobile, imageType),
 		]}
 	>

--- a/dotcom-rendering/src/components/Carousel.importable.tsx
+++ b/dotcom-rendering/src/components/Carousel.importable.tsx
@@ -474,7 +474,7 @@ const CarouselCard = ({
 			showClock={true}
 			showAge={true}
 			imagePositionOnMobile="top"
-			minWidthInPixels={isVideoContainer ? 480 : 220}
+			minWidthInPixels={isVideoContainer ? 600 : 220}
 			showQuotedHeadline={format.design === ArticleDesign.Comment}
 			dataLinkName={dataLinkName}
 			discussionId={discussionId}

--- a/dotcom-rendering/src/components/Carousel.importable.tsx
+++ b/dotcom-rendering/src/components/Carousel.importable.tsx
@@ -436,6 +436,7 @@ type CarouselCardProps = {
 	mainMedia?: MainMedia;
 	verticalDividerColour?: string;
 	onwardsSource?: string;
+	isVideoContainer?: boolean;
 };
 
 const CarouselCard = ({
@@ -452,6 +453,7 @@ const CarouselCard = ({
 	mainMedia,
 	verticalDividerColour,
 	onwardsSource,
+	isVideoContainer,
 }: CarouselCardProps) => (
 	<LI
 		percentage="25%"
@@ -481,6 +483,7 @@ const CarouselCard = ({
 			mainMedia={mainMedia}
 			videoSize="too small to play: 479px or less"
 			onwardsSource={onwardsSource}
+			containerType={isVideoContainer ? 'fixed/video' : undefined}
 		/>
 	</LI>
 );
@@ -1008,6 +1011,7 @@ export const Carousel = ({
 									carouselColours.borderColour
 								}
 								onwardsSource={onwardsSource}
+								isVideoContainer={isVideoContainer}
 							/>
 						);
 					})}

--- a/dotcom-rendering/src/components/Carousel.importable.tsx
+++ b/dotcom-rendering/src/components/Carousel.importable.tsx
@@ -474,7 +474,7 @@ const CarouselCard = ({
 			showClock={true}
 			showAge={true}
 			imagePositionOnMobile="top"
-			minWidthInPixels={220}
+			minWidthInPixels={isVideoContainer ? 480 : 220}
 			showQuotedHeadline={format.design === ArticleDesign.Comment}
 			dataLinkName={dataLinkName}
 			discussionId={discussionId}
@@ -487,6 +487,7 @@ const CarouselCard = ({
 					: 'too small to play: 479px or less'
 			}
 			onwardsSource={onwardsSource}
+			minWidthInPixelsOnMobile={isVideoContainer ? 380 : undefined}
 			containerType={isVideoContainer ? 'fixed/video' : undefined}
 		/>
 	</LI>

--- a/dotcom-rendering/src/components/Carousel.importable.tsx
+++ b/dotcom-rendering/src/components/Carousel.importable.tsx
@@ -481,7 +481,11 @@ const CarouselCard = ({
 			branding={branding}
 			isExternalLink={false}
 			mainMedia={mainMedia}
-			videoSize="too small to play: 479px or less"
+			videoSize={
+				isVideoContainer
+					? 'large enough to play: at least 480px'
+					: 'too small to play: 479px or less'
+			}
 			onwardsSource={onwardsSource}
 			containerType={isVideoContainer ? 'fixed/video' : undefined}
 		/>

--- a/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
@@ -32,6 +32,7 @@ type Props = {
 	duration?: number; // in seconds
 	origin?: string;
 	stickyVideos: boolean;
+	kicker?: string;
 };
 
 const expiredOverlayStyles = (overrideImage?: string) =>
@@ -89,6 +90,7 @@ export const YoutubeBlockComponent = ({
 	duration,
 	origin,
 	stickyVideos,
+	kicker,
 }: Props) => {
 	const [consentState, setConsentState] = useState<ConsentState | undefined>(
 		undefined,
@@ -228,6 +230,7 @@ export const YoutubeBlockComponent = ({
 				isMainMedia={isMainMedia}
 				imaEnabled={imaEnabled}
 				abTestParticipations={abTestParticipations}
+				kicker={kicker}
 			/>
 			{!hideCaption && (
 				<Caption


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
