### PR TITLE
Move `GuideAtom` and `ExpandableAtom` to DCR

### DIFF
--- a/dotcom-rendering/fixtures/manual/guideAtom.ts
+++ b/dotcom-rendering/fixtures/manual/guideAtom.ts
@@ -1,0 +1,118 @@
+import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
+
+export const defaultStoryExpanded = {
+	id: 'a76d998e-d4b0-4d00-8afb-773eddb4064c',
+	title: "Wednesday's Hong Kong tips",
+	html: '<p><b>Happy Valley&nbsp;</b></p><p><b>11.45</b> Happy Good Guys <b>12.15</b> Salto Olimpico <b>12.45</b> Seize The Spirit <b>1.15</b> Allied Agility <b>1.45 </b>Hero Time <b>2.15</b> Simply Fluke <b>2.45</b> Brave King <b>3.15</b> Golden Dash <b>3.50</b> This Is Class</p>',
+	pillar: ArticlePillar.Sport,
+	format: {
+		display: ArticleDisplay.Standard,
+		design: ArticleDesign.Standard,
+		theme: ArticlePillar.Sport,
+	},
+	expandForStorybook: true,
+	likeHandler: (): null => null,
+	dislikeHandler: (): null => null,
+	expandCallback: (): null => null,
+};
+
+// Non expanded version needed for Cypress
+export const defaultStory = {
+	id: 'a76d998e-d4b0-4d00-8afb-773eddb4064c',
+	title: "Wednesday's Hong Kong tips",
+	html: '<p><b>Happy Valley&nbsp;</b></p><p><b>11.45</b> Happy Good Guys <b>12.15</b> Salto Olimpico <b>12.45</b> Seize The Spirit <b>1.15</b> Allied Agility <b>1.45 </b>Hero Time <b>2.15</b> Simply Fluke <b>2.45</b> Brave King <b>3.15</b> Golden Dash <b>3.50</b> This Is Class</p>',
+	format: {
+		display: ArticleDisplay.Standard,
+		design: ArticleDesign.Standard,
+		theme: ArticlePillar.Sport,
+	},
+	expandForStorybook: false,
+	likeHandler: (): null => null,
+	dislikeHandler: (): null => null,
+	expandCallback: (): null => null,
+};
+
+export const listStoryExpanded = {
+	id: '0a09a661-0ee2-41ea-b0a0-9e1deefd9268',
+	label: 'Quick Guide',
+	title: 'What are coronavirus symptoms and should I go to a doctor?',
+	html: '<p>Covid-19 is caused by a member of the coronavirus family that has never been encountered before. Like other coronaviruses, it has come from animals. The World Health Organization (WHO) has declared it a pandemic.</p><p>According to the WHO, the most common symptoms of Covid-19 are fever, tiredness and a dry cough. Some patients may also have a runny nose, sore throat, nasal congestion and aches and pains or diarrhoea. Some people report losing their sense of taste and/or smell. About 80% of people who get Covid-19 experience a mild case – about as serious as a regular cold – and recover without needing any special treatment.</p><p>About one in six people, the WHO says, become seriously ill. The elderly and people with underlying medical problems like high blood pressure, heart problems or diabetes, or chronic respiratory conditions, are at a greater risk of serious illness from Covid-19.</p><p>In the UK, the National health Service (NHS) has identified the specific symptoms to look for as experiencing either:</p><ul><li>a high temperature - you feel hot to touch on your chest or back</li><li>a new continuous cough - this means you’ve started coughing repeatedly</li></ul><p>As this is viral pneumonia, antibiotics are of no use. The antiviral drugs we have against flu will not work, and there is currently no vaccine. Recovery depends on the strength of the immune system.</p><p>Medical advice varies around the world - with many countries imposing travel bans and lockdowns to try and prevent the spread of the virus. In many place people are being told to stay at home rather than visit a doctor of hospital in person. Check with your local authorities.</p><p>In the UK, NHS advice is that anyone with symptoms should<b> stay at home for at least 7 days</b>. If you live with other people, <b>they should stay at home for at least 14 days</b>, to avoid spreading the infection outside the home.</p>',
+	format: {
+		display: ArticleDisplay.Standard,
+		design: ArticleDesign.Standard,
+		theme: ArticlePillar.News,
+	},
+	expandForStorybook: true,
+	likeHandler: (): null => null,
+	dislikeHandler: (): null => null,
+	expandCallback: (): null => null,
+};
+
+export const orderedListStoryExpanded = {
+	id: 'b4c77875-8ba3-40d0-926b-0cd7956eed8a',
+
+	title: 'The locations in England with the highest annual average levels of NO2',
+	html: '<ol><li>Chideock Hill, West Dorset 97.7</li><li>Station Taxi Rank, Sheffield 91.7</li><li>North Street Clock Tower, Brighton 90.8</li><li>Neville Street Tunnel, Leeds 88</li><li>Strand, City of Westminster 88</li><li>Walbrook Wharf, City of London 87</li><li>Hickleton opp Fir Tree Close, Doncaster 86</li><li>Marylebone Road, City of Westminster 85</li><li>Euston Road, London Borough of Camden 82.3</li><li>Hickleton, John O’Gaunts, Doncaster 82</li></ol><p>&nbsp;Latest data is from 2018.&nbsp; The Annual Air Quality Objective is set at 40ug/m3. Source: Friends of the Earth&nbsp;<br></p>',
+	format: {
+		display: ArticleDisplay.Standard,
+		design: ArticleDesign.Standard,
+		theme: ArticlePillar.News,
+	},
+	expandForStorybook: true,
+	likeHandler: (): null => null,
+	dislikeHandler: (): null => null,
+	expandCallback: (): null => null,
+};
+
+export const imageStoryExpanded = {
+	id: '249abe8e-134a-45e3-afcf-b45a665c9a93',
+	label: 'Quick Guide',
+	title: 'Tory party leadership contest',
+	html: "<p>As she <a href='https://www.theguardian.com/politics/video/2019/may/24/prime-minister-theresa-mays-resignation-speech-in-full-video'>announced on 24 May</a>, Theresa May stepped down formally as Conservative leader on Friday 7 June, although she remains in place as prime minister until her successor is chosen.</p><p>In a Conservative leadership contest MPs hold a series of votes, in order to narrow down the initially crowded field to two leadership hopefuls, who go to a postal ballot of members.<br></p><p><b>How does the voting work?</b></p><p>MPs choose one candidate, in a secret ballot held in a committee room in the House of Commons. The votes are tallied and the results announced on the same day.</p><p>In the first round any candidate who won the support of less than 17 MPs was eliminated. In the second round anybody reaching less than 33 votes was eliminated. In subsequent rounds the bottom placed contender drops out until there are only two left. The party membership then chooses between them.</p><p><b>When will the results be announced?</b><br></p><p>The postal ballot of members has begun, and the Tory party says it will announce the new prime minister on 23 July..</p>",
+	credit: 'Photograph: Neil Hall/EPA',
+	image: 'https://i.guim.co.uk/img/media/d032f9d883807ea5003356289b7a1e9783cc67e5/0_37_4131_2480/4131.jpg?width=620&quality=85&auto=format&fit=max&s=53971cc47cb7c125202b7a647e82a44d',
+	format: {
+		display: ArticleDisplay.Standard,
+		design: ArticleDesign.Standard,
+		theme: ArticlePillar.Culture,
+	},
+	expandForStorybook: true,
+	likeHandler: (): null => null,
+	dislikeHandler: (): null => null,
+	expandCallback: (): null => null,
+};
+
+export const lifestylePillarStoryExpanded = {
+	id: 'acf5fd97-28ab-4971-96f2-2acaab08b5e9',
+
+	title: 'What is the energy price cap and how does it work?',
+	html: "<p>The cap, one of the biggest shake-ups of the energy market since privatisation,&nbsp;<a href='https://www.theguardian.com/business/2018/dec/31/millions-to-see-annual-energy-bills-drop-as-price-cap-takes-effect'>came into effect on 1 January 2019</a>&nbsp;for 11m households on default tariffs, known as standard variable tariffs (SVTs). The government told the energy regulator, Ofgem, to set the cap because ministers argued people on SVTs were being ripped off by big energy firms capitalising on consumer loyalty. The limit is not an absolute one but the maximum suppliers can charge per unit of energy and for a standing charge. There is a separate cap for 4m homes on prepayment meters.</p><p><b>Does that mean energy bills will never go up?</b></p><p>No. It is not <a href='https://www.theguardian.com/money/2017/apr/23/energy-prices-tory-cap-miliband-freeze'>a freeze</a>, it is a movable cap. The energy cap has fallen twice since it was put in place because the wholesale price of electricity and gas, the biggest variable influencing prices, have fallen. But if energy market prices climb higher, the cap would move higher, too. Homes may also face higher bills if they use more energy because the cap applies to the price of each unit of energy - not the whole bill.&nbsp;</p><p><b>Is there any way to avoid the increase?</b></p><p>Yes. Homes can save hundreds of pounds a year by spending a few minutes on one of the many comparison sites, or sign up to an <a href='https://www.theguardian.com/money/2019/feb/02/energy-bills-will-these-sites-save-you-a-flipping-fortune'>auto-switching service</a>, and move to a cheaper tariff, either with your existing supplier or a rival one. Fixed tariffs, which are not covered by the cap, are almost always much cheaper than SVTs, although <a href='https://www.theguardian.com/money/2018/oct/22/third-dual-fuel-tariffs-break-government-price-cap'>there are exceptions</a>, so watch out. Several smaller suppliers also offer good customer service and variable tariffs that are well below the cap.&nbsp;</p><p><b>Could bills fall again?</b></p><p>Maybe. Energy market experts believe gas and electricity wholesale prices will remain low through 2020 because energy demand is lower than normal because of the Covid-19 crisis. But wholesale costs are not the only factor in setting the level of the cap. Ofgem, the regulator, includes the cost of using energy networks and paying for government policies, too. These costs are expected to keep rising.&nbsp;</p>",
+	credit: '',
+	format: {
+		display: ArticleDisplay.Standard,
+		design: ArticleDesign.Standard,
+		theme: ArticlePillar.Lifestyle,
+	},
+	expandForStorybook: true,
+	likeHandler: (): null => null,
+	dislikeHandler: (): null => null,
+	expandCallback: (): null => null,
+};
+
+export const analysisStoryExpanded = {
+	id: 'a76d998e-d4b0-4d00-8afb-773eddb4064c',
+	title: 'Qatar: beyond the football',
+	html: '<p>It was a World Cup like no other. For the last 12 years the Guardian has been reporting on the issues surrounding Qatar 2022, from corruption and human rights abuses to the treatment of migrant workers and discriminatory laws. <br/> The best of our journalism is gathered on our dedicated <a href="https://www.theguardian.com/news/series/qatar-beyond-the-football">Qatar: Beyond the Football</a> home page for those who want to go deeper into the issues beyond the pitch. <br/> <br/> Guardian reporting goes far beyond what happens on the pitch. Support our investigative journalism today.</p>',
+	image: 'https://i.guim.co.uk/img/media/48be60e8b3371ffecc4f784e0411526ed9f3f3ba/1700_1199_1330_1331/1330.jpg?width=620&quality=85&auto=format&fit=max&s=8b3ad26c4ab238688c860e907b2cb116',
+	pillar: ArticlePillar.Sport,
+	design: ArticleDesign.Analysis,
+	format: {
+		display: ArticleDisplay.Standard,
+		design: ArticleDesign.Analysis,
+		theme: ArticlePillar.Sport,
+	},
+	expandForStorybook: true,
+	likeHandler: (): null => null,
+	dislikeHandler: (): null => null,
+	expandCallback: (): null => null,
+};

--- a/dotcom-rendering/src/components/ExpandableAtom/Body.tsx
+++ b/dotcom-rendering/src/components/ExpandableAtom/Body.tsx
@@ -1,0 +1,116 @@
+import { css } from '@emotion/react';
+import { body, neutral, textSans } from '@guardian/source-foundations';
+import { SvgInfo } from '@guardian/source-react-components';
+import { decidePalette } from '../../lib/decidePalette';
+
+const imageStyling = css`
+	float: left;
+	margin-right: 16px;
+	margin-bottom: 6px;
+	object-fit: cover;
+	border-radius: 50%;
+	display: block;
+	border: 0px;
+	width: 100px;
+	height: 100px;
+`;
+
+const creditStyling = css`
+	${textSans.xsmall()};
+	margin: 12px 0;
+	display: flex;
+	align-items: center;
+	svg {
+		width: 30px;
+		fill: ${neutral[60]};
+	}
+`;
+
+const bodyStyling = css`
+	${body.medium()}
+	p {
+		margin-bottom: 0.5rem;
+	}
+
+	ol {
+		list-style: decimal;
+		list-style-position: inside;
+		margin-bottom: 1rem;
+	}
+
+	ul {
+		list-style: none;
+		margin: 0 0 0.75rem;
+		padding: 0;
+		margin-bottom: 1rem;
+	}
+
+	ul li {
+		margin-bottom: 0.375rem;
+		padding-left: 1.25rem;
+	}
+
+	ul li:before {
+		display: inline-block;
+		content: '';
+		border-radius: 0.375rem;
+		height: 0.75rem;
+		width: 0.75rem;
+		margin-right: 0.5rem;
+		background-color: ${neutral[86]};
+		margin-left: -1.25rem;
+	}
+
+	/* Without this bold elements are overridden */
+	b {
+		font-weight: 700;
+	}
+
+	i {
+		font-style: italic;
+	}
+`;
+
+const linkStyling = (format: ArticleFormat) => css`
+	a {
+		color: ${decidePalette(format).text.expandableAtom};
+		text-decoration: none;
+		border-bottom: 0.0625rem solid ${neutral[86]};
+		transition: border-color 0.15s ease-out;
+	}
+
+	a:hover {
+		border-bottom: solid 0.0625rem
+			${decidePalette(format).background.expandableAtom};
+	}
+`;
+
+export const Body = ({
+	html,
+	image,
+	credit,
+	format,
+}: {
+	html: string;
+	image?: string;
+	credit?: string;
+	format: ArticleFormat;
+}): JSX.Element => {
+	return (
+		<div>
+			{image && <img css={imageStyling} src={image} alt="" />}
+			<div
+				css={[bodyStyling, linkStyling(format)]}
+				dangerouslySetInnerHTML={{
+					__html: html,
+				}}
+			/>
+			{credit && (
+				<div css={creditStyling}>
+					<SvgInfo />
+					{credit}
+				</div>
+			)}
+		</div>
+	);
+};

--- a/dotcom-rendering/src/components/ExpandableAtom/Body.tsx
+++ b/dotcom-rendering/src/components/ExpandableAtom/Body.tsx
@@ -81,7 +81,7 @@ const linkStyling = (format: ArticleFormat) => css`
 
 	a:hover {
 		border-bottom: solid 0.0625rem
-			${decidePalette(format).background.expandableAtom};
+			${decidePalette(format).text.expandableAtomHover};
 	}
 `;
 

--- a/dotcom-rendering/src/components/ExpandableAtom/Body.tsx
+++ b/dotcom-rendering/src/components/ExpandableAtom/Body.tsx
@@ -98,14 +98,14 @@ export const Body = ({
 }): JSX.Element => {
 	return (
 		<div>
-			{image && <img css={imageStyling} src={image} alt="" />}
+			{!!image && <img css={imageStyling} src={image} alt="" />}
 			<div
 				css={[bodyStyling, linkStyling(format)]}
 				dangerouslySetInnerHTML={{
 					__html: html,
 				}}
 			/>
-			{credit && (
+			{!!credit && (
 				<div css={creditStyling}>
 					<SvgInfo />
 					{credit}

--- a/dotcom-rendering/src/components/ExpandableAtom/Container.tsx
+++ b/dotcom-rendering/src/components/ExpandableAtom/Container.tsx
@@ -1,0 +1,83 @@
+import { css } from '@emotion/react';
+import type { SerializedStyles } from '@emotion/react';
+import { ArticleDesign } from '@guardian/libs';
+import { neutral, text } from '@guardian/source-foundations';
+import { Summary } from './Summary';
+
+const containerStyling = css`
+	display: block;
+	position: relative;
+`;
+
+export const detailStyling = (design?: ArticleDesign): SerializedStyles => {
+	// One off background colour for analysis articles
+	const background =
+		design === ArticleDesign.Analysis ? '#F2E8E6' : neutral[93];
+	return css`
+		margin: 16px 0 36px;
+		background: ${background};
+		color: ${text.primary};
+		padding: 0 5px 6px;
+		border-image: repeating-linear-gradient(
+				to bottom,
+				${neutral[86]},
+				${neutral[86]} 1px,
+				transparent 1px,
+				transparent 4px
+			)
+			13;
+		border-top: 13px solid black;
+		position: relative;
+		summary {
+			list-style: none;
+			margin: 0 0 16px;
+		}
+
+		/* https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details#Customizing_the_disclosure_widget */
+		summary::-webkit-details-marker {
+			display: none;
+		}
+
+		summary:focus {
+			outline: none;
+		}
+	`;
+};
+
+export const Container = ({
+	id,
+	title,
+	children,
+	format,
+	expandForStorybook,
+	atomType,
+	atomTypeTitle,
+	expandCallback,
+}: {
+	id: string;
+	title: string;
+	design?: ArticleDesign;
+	format: ArticleFormat;
+	expandForStorybook?: boolean;
+	atomType: string;
+	atomTypeTitle: string;
+	children: React.ReactNode;
+	expandCallback: () => void;
+}): JSX.Element => (
+	<div css={containerStyling} data-atom-id={id} data-atom-type={atomType}>
+		<details
+			css={detailStyling(format.design)}
+			data-atom-id={id}
+			data-snippet-type={atomType}
+			open={expandForStorybook}
+		>
+			<Summary
+				sectionTitle={atomTypeTitle}
+				format={format}
+				title={title}
+				expandCallback={expandCallback}
+			/>
+			{children}
+		</details>
+	</div>
+);

--- a/dotcom-rendering/src/components/ExpandableAtom/Footer.tsx
+++ b/dotcom-rendering/src/components/ExpandableAtom/Footer.tsx
@@ -53,7 +53,7 @@ export const Footer = ({
 		width: 28px;
 		height: 28px;
 		:hover {
-			background: ${decidePalette(format).background.expandableAtom};
+			background: ${decidePalette(format).text.expandableAtomHover};
 		}
 		:focus {
 			border: none;

--- a/dotcom-rendering/src/components/ExpandableAtom/Footer.tsx
+++ b/dotcom-rendering/src/components/ExpandableAtom/Footer.tsx
@@ -1,0 +1,118 @@
+import { css } from '@emotion/react';
+import { textSans } from '@guardian/source-foundations';
+import { useState } from 'react';
+import { decidePalette } from '../../lib/decidePalette';
+
+/// LIKE/DISLIKE FEEDBACK FOOTER
+const footerStyling = css`
+	font-size: 13px;
+	line-height: 16px;
+	display: flex;
+	justify-content: flex-end;
+`;
+
+// Currently no thumb icon in src-icons so a path is needed
+const ThumbImage = () => {
+	return (
+		<svg
+			css={css`
+				width: 16px;
+				height: 16px;
+			`}
+			viewBox="0 0 40 40"
+		>
+			<path
+				fill="#FFF"
+				d="M33.78 22.437l-4.228 13.98L27.93 37.5 5.062 34.14V15.503l7.8-1.517L24.354 2.5h1.624L28.9 5.426l-4.548 8.67h.107l10.477 1.31"
+			></path>
+		</svg>
+	);
+};
+
+export const Footer = ({
+	format,
+	likeHandler,
+	dislikeHandler,
+}: {
+	format: ArticleFormat;
+	likeHandler: () => void;
+	dislikeHandler: () => void;
+}): JSX.Element => {
+	// This is defined here because adding the hover styling using cx breaks the text styling
+	const buttonStyling = css`
+		display: inline-flex;
+		cursor: pointer;
+		align-items: center;
+		justify-content: center;
+		background: black;
+		color: white;
+		border-style: hidden;
+		border-radius: 100%;
+		margin: 0 0 0 5px;
+		padding: 0;
+		width: 28px;
+		height: 28px;
+		:hover {
+			background: ${decidePalette(format).background.expandableAtom};
+		}
+		:focus {
+			border: none;
+		}
+	`;
+	const [showThankYou, setShowThankYou] = useState(false);
+	return (
+		<footer css={footerStyling}>
+			<div hidden={showThankYou}>
+				<div
+					css={css`
+						display: flex;
+						align-items: center;
+						${textSans.xsmall()};
+					`}
+				>
+					<div>Was this helpful?</div>
+					<button
+						aria-label="yes, this was helpful"
+						data-testid="like"
+						css={buttonStyling}
+						onClick={() => {
+							likeHandler();
+							setShowThankYou(true);
+						}}
+					>
+						<ThumbImage />
+					</button>
+					<button
+						aria-label="no, this was not helpful"
+						css={[
+							buttonStyling,
+							css`
+								transform: rotate(180deg);
+								-webkit-transform: rotate(180deg);
+								-moz-transform: rotate(180deg);
+								-o-transform: rotate(180deg);
+							`,
+						]}
+						data-testid="dislike"
+						onClick={() => {
+							dislikeHandler();
+							setShowThankYou(true);
+						}}
+					>
+						<ThumbImage />
+					</button>
+				</div>
+			</div>
+			<div
+				css={css`
+					${textSans.xsmall()};
+					height: 28px;
+				`}
+				data-testid="feedback"
+				hidden={!showThankYou}
+			>
+				Thank you for your feedback.
+			</div>
+		</footer>
+	);
+};

--- a/dotcom-rendering/src/components/ExpandableAtom/Footer.tsx
+++ b/dotcom-rendering/src/components/ExpandableAtom/Footer.tsx
@@ -88,9 +88,6 @@ export const Footer = ({
 							buttonStyling,
 							css`
 								transform: rotate(180deg);
-								-webkit-transform: rotate(180deg);
-								-moz-transform: rotate(180deg);
-								-o-transform: rotate(180deg);
 							`,
 						]}
 						data-testid="dislike"

--- a/dotcom-rendering/src/components/ExpandableAtom/Summary.tsx
+++ b/dotcom-rendering/src/components/ExpandableAtom/Summary.tsx
@@ -1,0 +1,116 @@
+import { css } from '@emotion/react';
+import {
+	body,
+	headline,
+	neutral,
+	textSans,
+} from '@guardian/source-foundations';
+import { SvgMinus, SvgPlus } from '@guardian/source-react-components';
+import { useState } from 'react';
+import { decidePalette } from '../../lib/decidePalette';
+
+/// SUMMARY ELEMENT
+
+const titleStyling = css`
+	${headline.xxxsmall({
+		fontWeight: 'medium',
+	})};
+	margin: 0;
+	line-height: 22px;
+`;
+
+const plusStyling = css`
+	margin-right: 12px;
+	margin-bottom: 6px;
+	width: 33px;
+	fill: white;
+	height: 28px;
+`;
+
+const minusStyling = css`
+	margin-right: 14px;
+	margin-bottom: 6px;
+	width: 30px;
+	fill: white;
+	height: 25px;
+	padding-left: 4px;
+`;
+
+const iconSpacing = css`
+	display: inline-flex;
+	align-items: center;
+	${textSans.small()};
+`;
+
+export const Summary = ({
+	sectionTitle,
+	title,
+	format,
+	expandCallback,
+}: {
+	format: ArticleFormat;
+	sectionTitle: string;
+	title: string;
+	expandCallback: () => void;
+}): JSX.Element => {
+	const atomTitleStyling = css`
+		display: block;
+		${body.medium({
+			lineHeight: 'tight',
+			fontWeight: 'bold',
+		})};
+		color: ${decidePalette(format).text.expandableAtom};
+	`;
+
+	const showHideStyling = css`
+		background: ${neutral[7]};
+		color: ${neutral[100]};
+		height: 2rem;
+		position: absolute;
+		bottom: 0;
+		transform: translate(0, 50%);
+		padding: 0 15px 0 7px;
+		border-radius: 100em;
+		cursor: pointer;
+		display: inline-flex;
+		align-items: center;
+		border: 0;
+		margin: 0;
+		:hover {
+			background: ${decidePalette(format).text.expandableAtom};
+		}
+	`;
+	const [hasBeenExpanded, setHasBeenExpanded] = useState(false);
+	const [expandEventSent, setExpandEventFired] = useState(false);
+	return (
+		<summary
+			onClick={() => {
+				if (!expandEventSent) {
+					expandCallback();
+					setExpandEventFired(true);
+				}
+				setHasBeenExpanded(!hasBeenExpanded);
+			}}
+		>
+			<span css={atomTitleStyling}>{sectionTitle}</span>
+			<h4 css={titleStyling}>{title}</h4>
+			<span css={showHideStyling}>
+				{!hasBeenExpanded ? (
+					<span css={iconSpacing}>
+						<span css={plusStyling}>
+							<SvgPlus />
+						</span>
+						Show
+					</span>
+				) : (
+					<span css={iconSpacing}>
+						<span css={minusStyling}>
+							<SvgMinus />
+						</span>
+						Hide
+					</span>
+				)}
+			</span>
+		</summary>
+	);
+};

--- a/dotcom-rendering/src/components/ExpandableAtom/Summary.tsx
+++ b/dotcom-rendering/src/components/ExpandableAtom/Summary.tsx
@@ -61,7 +61,7 @@ export const Summary = ({
 			lineHeight: 'tight',
 			fontWeight: 'bold',
 		})};
-		color: ${decidePalette(format).text.expandableAtom};
+		color: ${decidePalette(format).background.expandableAtom};
 	`;
 
 	const showHideStyling = css`
@@ -79,7 +79,7 @@ export const Summary = ({
 		border: 0;
 		margin: 0;
 		:hover {
-			background: ${decidePalette(format).text.expandableAtom};
+			background: ${decidePalette(format).background.expandableAtom};
 		}
 	`;
 	const [hasBeenExpanded, setHasBeenExpanded] = useState(false);

--- a/dotcom-rendering/src/components/ExpandableAtom/Summary.tsx
+++ b/dotcom-rendering/src/components/ExpandableAtom/Summary.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable jsx-a11y/no-static-element-interactions -- TODO: Imported with minor changes from `@guardian/atoms-rendering` */
+/* eslint-disable jsx-a11y/click-events-have-key-events -- TODO: Imported with minor changes from `@guardian/atoms-rendering` */
 import { css } from '@emotion/react';
 import {
 	body,

--- a/dotcom-rendering/src/components/ExpandableAtom/Summary.tsx
+++ b/dotcom-rendering/src/components/ExpandableAtom/Summary.tsx
@@ -61,7 +61,7 @@ export const Summary = ({
 			lineHeight: 'tight',
 			fontWeight: 'bold',
 		})};
-		color: ${decidePalette(format).background.expandableAtom};
+		color: ${decidePalette(format).text.expandableAtomHover};
 	`;
 
 	const showHideStyling = css`
@@ -79,7 +79,7 @@ export const Summary = ({
 		border: 0;
 		margin: 0;
 		:hover {
-			background: ${decidePalette(format).background.expandableAtom};
+			background: ${decidePalette(format).text.expandableAtomHover};
 		}
 	`;
 	const [hasBeenExpanded, setHasBeenExpanded] = useState(false);

--- a/dotcom-rendering/src/components/GuideAtom/GuideAtom.stories.tsx
+++ b/dotcom-rendering/src/components/GuideAtom/GuideAtom.stories.tsx
@@ -10,7 +10,7 @@ import {
 import { GuideAtom } from './GuideAtom';
 
 export default {
-	title: 'GuideAtom',
+	title: 'Components/GuideAtom',
 	component: GuideAtom,
 };
 

--- a/dotcom-rendering/src/components/GuideAtom/GuideAtom.stories.tsx
+++ b/dotcom-rendering/src/components/GuideAtom/GuideAtom.stories.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import { palette } from '@guardian/source-foundations';
 import {
 	analysisStoryExpanded,
 	defaultStoryExpanded,
@@ -44,7 +45,7 @@ export const AnalysisStoryExpanded = (): JSX.Element => {
 	return (
 		<div
 			css={css`
-				background-color: #fff4f2;
+				background-color: ${palette.news[800]};
 			`}
 		>
 			Analysis Articles have a different color background, so quick guide

--- a/dotcom-rendering/src/components/GuideAtom/GuideAtom.stories.tsx
+++ b/dotcom-rendering/src/components/GuideAtom/GuideAtom.stories.tsx
@@ -1,13 +1,13 @@
+import { css } from '@emotion/react';
 import {
+	analysisStoryExpanded,
 	defaultStoryExpanded,
 	imageStoryExpanded,
 	lifestylePillarStoryExpanded,
 	listStoryExpanded,
 	orderedListStoryExpanded,
-	analysisStoryExpanded,
 } from '../../../fixtures/manual/guideAtom';
 import { GuideAtom } from './GuideAtom';
-import { css } from '@emotion/react';
 
 export default {
 	title: 'GuideAtom',

--- a/dotcom-rendering/src/components/GuideAtom/GuideAtom.stories.tsx
+++ b/dotcom-rendering/src/components/GuideAtom/GuideAtom.stories.tsx
@@ -1,0 +1,55 @@
+import {
+	defaultStoryExpanded,
+	imageStoryExpanded,
+	lifestylePillarStoryExpanded,
+	listStoryExpanded,
+	orderedListStoryExpanded,
+	analysisStoryExpanded,
+} from '../../../fixtures/manual/guideAtom';
+import { GuideAtom } from './GuideAtom';
+import { css } from '@emotion/react';
+
+export default {
+	title: 'GuideAtom',
+	component: GuideAtom,
+};
+
+export const DefaultStoryExpanded = (): JSX.Element => {
+	// Modelled after: https://www.theguardian.com/sport/2020/may/19/pinatubo-has-probably-trained-on-for-the-2000-guineas-says-charlie-appleby
+	return <GuideAtom {...defaultStoryExpanded} />;
+};
+
+export const ListStoryExpanded = (): JSX.Element => {
+	//Modelled after: https://www.theguardian.com/business/2020/jan/27/global-markets-slide-on-back-of-coronavirus-concerns-in-china-stocks
+	return <GuideAtom {...listStoryExpanded} />;
+};
+
+export const OrderedListStoryExpanded = (): JSX.Element => {
+	//Modelled after: https://www.theguardian.com/environment/2020/aug/01/plan-to-curb-englands-most-polluted-spot-divides-residents
+	return <GuideAtom {...orderedListStoryExpanded} />;
+};
+
+export const ImageStoryExpanded = (): JSX.Element => {
+	//Modelled after: https://www.theguardian.com/politics/2019/jul/06/tory-member-questions-boris-johnsons-ability-to-represent-minorities
+	return <GuideAtom {...imageStoryExpanded} />;
+};
+
+export const LifestylePillarStoryExpanded = (): JSX.Element => {
+	//Modelled after: https://www.theguardian.com/money/2020/aug/07/energy-bills-to-be-cut-by-84-pounds-for-11m-uk-households-ofgem
+	return <GuideAtom {...lifestylePillarStoryExpanded} />;
+};
+
+export const AnalysisStoryExpanded = (): JSX.Element => {
+	// Modelled after: https://www.theguardian.com/football/2022/dec/11/gareth-southgate-england-world-cup-qatar
+	return (
+		<div
+			css={css`
+				background-color: #fff4f2;
+			`}
+		>
+			Analysis Articles have a different color background, so quick guide
+			atoms should too.
+			<GuideAtom {...analysisStoryExpanded} />
+		</div>
+	);
+};

--- a/dotcom-rendering/src/components/GuideAtom/GuideAtom.test.tsx
+++ b/dotcom-rendering/src/components/GuideAtom/GuideAtom.test.tsx
@@ -1,0 +1,59 @@
+import { fireEvent, render } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import { defaultStory } from '../../../fixtures/manual/guideAtom';
+import { GuideAtom } from './GuideAtom';
+
+describe('GuideAtom', () => {
+	it('should render', () => {
+		const { getByText, queryByText } = render(
+			<GuideAtom {...defaultStory} />,
+		);
+
+		expect(getByText('Quick Guide')).toBeInTheDocument();
+
+		// Test that the 'Show' part of the expand switch is hidden on expand
+		expect(getByText('Show')).toBeInTheDocument();
+		fireEvent.click(getByText('Show'));
+		expect(queryByText('Show')).toBe(null);
+		// Test that 'Hide' is hidden after closing the Guide
+		expect(getByText('Hide')).toBeInTheDocument();
+		fireEvent.click(getByText('Hide'));
+		expect(queryByText('Hide')).toBe(null);
+	});
+
+	it('Show feedback on like', () => {
+		const { getByText, queryByText, queryByTestId } = render(
+			<GuideAtom {...defaultStory} />,
+		);
+
+		// Expand Guide
+		fireEvent.click(getByText('Show'));
+		// Like button should be visibile and feedback not visibile
+		expect(queryByTestId('like')).toBeVisible();
+		expect(queryByText('Thank you for your feedback.')).not.toBeVisible();
+
+		// Fire like event
+		fireEvent.click(queryByTestId('like') as HTMLElement);
+		// Feedback should be visible, like button should be hidden
+		expect(queryByText('Thank you for your feedback.')).toBeVisible();
+		expect(queryByTestId('like')).not.toBeVisible();
+	});
+
+	it('Show feedback on dislike', () => {
+		const { getByText, queryByText, queryByTestId } = render(
+			<GuideAtom {...defaultStory} />,
+		);
+
+		// Expand Guide
+		fireEvent.click(getByText('Show'));
+		// Like button should be visibile and feedback not visibile
+		expect(queryByTestId('dislike')).toBeVisible();
+		expect(queryByText('Thank you for your feedback.')).not.toBeVisible();
+
+		// Fire dislike event
+		fireEvent.click(queryByTestId('dislike') as HTMLElement);
+		// Feedback should be visible, like button should be hidden
+		expect(queryByText('Thank you for your feedback.')).toBeVisible();
+		expect(queryByTestId('dislike')).not.toBeVisible();
+	});
+});

--- a/dotcom-rendering/src/components/GuideAtom/GuideAtom.tsx
+++ b/dotcom-rendering/src/components/GuideAtom/GuideAtom.tsx
@@ -1,7 +1,7 @@
+import { submitComponentEvent } from '../../client/ophan/ophan';
 import { Body } from '../ExpandableAtom/Body';
 import { Container } from '../ExpandableAtom/Container';
 import { Footer } from '../ExpandableAtom/Footer';
-import { submitComponentEvent } from '../../client/ophan/ophan';
 
 type Props = {
 	id: string;

--- a/dotcom-rendering/src/components/GuideAtom/GuideAtom.tsx
+++ b/dotcom-rendering/src/components/GuideAtom/GuideAtom.tsx
@@ -3,7 +3,7 @@ import { Body } from '../ExpandableAtom/Body';
 import { Container } from '../ExpandableAtom/Container';
 import { Footer } from '../ExpandableAtom/Footer';
 
-type Props = {
+export type GuideAtomProps = {
 	id: string;
 	label?: string;
 	title: string;
@@ -28,7 +28,7 @@ export const GuideAtom = ({
 	likeHandler,
 	dislikeHandler,
 	expandCallback,
-}: Props): JSX.Element => {
+}: GuideAtomProps): JSX.Element => {
 	return (
 		<Container
 			id={id}

--- a/dotcom-rendering/src/components/GuideAtom/GuideAtom.tsx
+++ b/dotcom-rendering/src/components/GuideAtom/GuideAtom.tsx
@@ -1,0 +1,86 @@
+import { Body } from '../ExpandableAtom/Body';
+import { Container } from '../ExpandableAtom/Container';
+import { Footer } from '../ExpandableAtom/Footer';
+import { submitComponentEvent } from '../../client/ophan/ophan';
+
+type Props = {
+	id: string;
+	label?: string;
+	title: string;
+	image?: string;
+	html: string;
+	credit?: string;
+	format: ArticleFormat;
+	expandForStorybook?: boolean;
+	likeHandler?: () => void;
+	dislikeHandler?: () => void;
+	expandCallback?: () => void;
+};
+
+export const GuideAtom = ({
+	id,
+	title,
+	image,
+	html,
+	credit,
+	format,
+	expandForStorybook,
+	likeHandler,
+	dislikeHandler,
+	expandCallback,
+}: Props): JSX.Element => {
+	return (
+		<Container
+			id={id}
+			title={title}
+			format={format}
+			atomType="guide"
+			atomTypeTitle="Quick Guide"
+			expandForStorybook={expandForStorybook}
+			expandCallback={
+				expandCallback ??
+				(() =>
+					submitComponentEvent({
+						component: {
+							componentType: 'GUIDE_ATOM',
+							id,
+							products: [],
+							labels: [],
+						},
+						action: 'EXPAND',
+					}))
+			}
+		>
+			<Body html={html} image={image} credit={credit} format={format} />
+			<Footer
+				format={format}
+				dislikeHandler={
+					dislikeHandler ??
+					(() =>
+						submitComponentEvent({
+							component: {
+								componentType: 'GUIDE_ATOM',
+								id,
+								products: [],
+								labels: [],
+							},
+							action: 'DISLIKE',
+						}))
+				}
+				likeHandler={
+					likeHandler ??
+					(() =>
+						submitComponentEvent({
+							component: {
+								componentType: 'GUIDE_ATOM',
+								id,
+								products: [],
+								labels: [],
+							},
+							action: 'LIKE',
+						}))
+				}
+			></Footer>
+		</Container>
+	);
+};

--- a/dotcom-rendering/src/components/GuideAtomWrapper.importable.tsx
+++ b/dotcom-rendering/src/components/GuideAtomWrapper.importable.tsx
@@ -1,6 +1,6 @@
-import { GuideAtom } from '@guardian/atoms-rendering';
-import type { GuideAtomType } from '@guardian/atoms-rendering';
+import { GuideAtom } from './GuideAtom/GuideAtom';
+import type { GuideAtomProps } from './GuideAtom/GuideAtom';
 
-export const GuideAtomWrapper = (props: GuideAtomType) => {
+export const GuideAtomWrapper = (props: GuideAtomProps) => {
 	return <GuideAtom {...props} />;
 };

--- a/dotcom-rendering/src/lib/decidePalette.ts
+++ b/dotcom-rendering/src/lib/decidePalette.ts
@@ -2079,27 +2079,6 @@ const backgroundAudioAtom = (format: ArticleFormat) => {
 const textExpandableAtom = (format: ArticleFormat) => {
 	switch (format.theme) {
 		case ArticlePillar.News:
-			return news[400];
-		case ArticlePillar.Lifestyle:
-			return lifestyle[400];
-		case ArticlePillar.Sport:
-			return sport[400];
-		case ArticlePillar.Culture:
-			return culture[400];
-		case ArticlePillar.Opinion:
-			return opinion[400];
-		case ArticleSpecial.Labs:
-			return lifestyle[400];
-		case ArticleSpecial.SpecialReport:
-			return news[400];
-		case ArticleSpecial.SpecialReportAlt:
-			return news[400];
-	}
-};
-
-const backgroundExpandableAtom = (format: ArticleFormat) => {
-	switch (format.theme) {
-		case ArticlePillar.News:
 			return news[300];
 		case ArticlePillar.Lifestyle:
 			return lifestyle[300];
@@ -2115,6 +2094,27 @@ const backgroundExpandableAtom = (format: ArticleFormat) => {
 			return news[300];
 		case ArticleSpecial.SpecialReportAlt:
 			return news[300];
+	}
+};
+
+const backgroundExpandableAtom = (format: ArticleFormat) => {
+	switch (format.theme) {
+		case ArticlePillar.News:
+			return news[400];
+		case ArticlePillar.Lifestyle:
+			return lifestyle[400];
+		case ArticlePillar.Sport:
+			return sport[400];
+		case ArticlePillar.Culture:
+			return culture[400];
+		case ArticlePillar.Opinion:
+			return opinion[400];
+		case ArticleSpecial.Labs:
+			return lifestyle[400];
+		case ArticleSpecial.SpecialReport:
+			return news[400];
+		case ArticleSpecial.SpecialReportAlt:
+			return news[400];
 	}
 };
 

--- a/dotcom-rendering/src/lib/decidePalette.ts
+++ b/dotcom-rendering/src/lib/decidePalette.ts
@@ -2076,6 +2076,48 @@ const backgroundAudioAtom = (format: ArticleFormat) => {
 	}
 };
 
+const textExpandableAtom = (format: ArticleFormat) => {
+	switch (format.theme) {
+		case ArticlePillar.News:
+			return news[400];
+		case ArticlePillar.Lifestyle:
+			return lifestyle[400];
+		case ArticlePillar.Sport:
+			return sport[400];
+		case ArticlePillar.Culture:
+			return culture[400];
+		case ArticlePillar.Opinion:
+			return opinion[400];
+		case ArticleSpecial.Labs:
+			return lifestyle[400];
+		case ArticleSpecial.SpecialReport:
+			return news[400];
+		case ArticleSpecial.SpecialReportAlt:
+			return news[400];
+	}
+};
+
+const backgroundExpandableAtom = (format: ArticleFormat) => {
+	switch (format.theme) {
+		case ArticlePillar.News:
+			return news[300];
+		case ArticlePillar.Lifestyle:
+			return lifestyle[300];
+		case ArticlePillar.Sport:
+			return sport[300];
+		case ArticlePillar.Culture:
+			return culture[300];
+		case ArticlePillar.Opinion:
+			return opinion[300];
+		case ArticleSpecial.Labs:
+			return lifestyle[300];
+		case ArticleSpecial.SpecialReport:
+			return news[300];
+		case ArticleSpecial.SpecialReportAlt:
+			return news[300];
+	}
+};
+
 export const decidePalette = (
 	format: ArticleFormat,
 	containerPalette?: DCRContainerPalette,
@@ -2146,6 +2188,7 @@ export const decidePalette = (
 			designTag: textDesignTag(format),
 			dateLine: textDateLine(format),
 			tableOfContents: textTableOfContents(),
+			expandableAtom: textExpandableAtom(format),
 		},
 		background: {
 			article: backgroundArticle(format),
@@ -2184,6 +2227,7 @@ export const decidePalette = (
 			designTag: backgroundDesignTag(format),
 			pullQuote: backgroundPullQuote(format),
 			messageForm: backgroundMessageForm(format),
+			expandableAtom: backgroundExpandableAtom(format),
 		},
 		fill: {
 			commentCount: fillCommentCount(format),

--- a/dotcom-rendering/src/lib/decidePalette.ts
+++ b/dotcom-rendering/src/lib/decidePalette.ts
@@ -2097,7 +2097,7 @@ const textExpandableAtom = (format: ArticleFormat) => {
 	}
 };
 
-const backgroundExpandableAtom = (format: ArticleFormat) => {
+const textExpandableAtomHover = (format: ArticleFormat) => {
 	switch (format.theme) {
 		case ArticlePillar.News:
 			return news[400];
@@ -2189,6 +2189,7 @@ export const decidePalette = (
 			dateLine: textDateLine(format),
 			tableOfContents: textTableOfContents(),
 			expandableAtom: textExpandableAtom(format),
+			expandableAtomHover: textExpandableAtomHover(format),
 		},
 		background: {
 			article: backgroundArticle(format),
@@ -2227,7 +2228,6 @@ export const decidePalette = (
 			designTag: backgroundDesignTag(format),
 			pullQuote: backgroundPullQuote(format),
 			messageForm: backgroundMessageForm(format),
-			expandableAtom: backgroundExpandableAtom(format),
 		},
 		fill: {
 			commentCount: fillCommentCount(format),

--- a/dotcom-rendering/src/lib/renderElement.tsx
+++ b/dotcom-rendering/src/lib/renderElement.tsx
@@ -318,7 +318,7 @@ export const renderElement = ({
 						html={element.html}
 						image={element.img}
 						credit={element.credit}
-						pillar={format.theme}
+						format={format}
 					/>
 				</Island>
 			);

--- a/dotcom-rendering/src/types/palette.ts
+++ b/dotcom-rendering/src/types/palette.ts
@@ -61,6 +61,7 @@ export type Palette = {
 		dateLine: Colour;
 		tableOfContents: Colour;
 		expandableAtom: Colour;
+		expandableAtomHover: Colour;
 	};
 	background: {
 		article: Colour;
@@ -99,7 +100,6 @@ export type Palette = {
 		pullQuote: Colour;
 		lightboxDivider: Colour;
 		messageForm: Colour;
-		expandableAtom: Colour;
 	};
 	fill: {
 		commentCount: Colour;

--- a/dotcom-rendering/src/types/palette.ts
+++ b/dotcom-rendering/src/types/palette.ts
@@ -60,6 +60,7 @@ export type Palette = {
 		designTag: Colour;
 		dateLine: Colour;
 		tableOfContents: Colour;
+		expandableAtom: Colour;
 	};
 	background: {
 		article: Colour;
@@ -98,6 +99,7 @@ export type Palette = {
 		pullQuote: Colour;
 		lightboxDivider: Colour;
 		messageForm: Colour;
+		expandableAtom: Colour;
 	};
 	fill: {
 		commentCount: Colour;


### PR DESCRIPTION
## What does this change?

Moves `GuideAtom` component and `ExpandableAtom` sub-component from `@guardian/atoms-rendering` directly into the DCR repo. Like the previous migration of `AudioAtom` (#8229) this is largely a direct port with some minor linting fixes and changes the existing `pillar` prop to `format`.

## Why?

These components are not used anywhere else so there's no reason for them to live in a separate package.