### PR TITLE
Simplify performance measurements

### DIFF
--- a/dotcom-rendering/src/client/startup.ts
+++ b/dotcom-rendering/src/client/startup.ts
@@ -1,18 +1,16 @@
 import { log } from '@guardian/libs';
-import { measureDuration } from './measureDuration';
+import { createTimer } from './timer';
 
 const measure = (name: string, task: () => Promise<void>): void => {
-	const { start, end } = measureDuration(name);
-
-	start();
+	const timer = createTimer('dotcom', name)('start');
 
 	task()
 		.then(() => {
-			const duration = end();
+			const duration = timer('end');
 			log('dotcom', `🥾 Booted ${name} in ${duration}ms`);
 		})
 		.catch(() => {
-			const duration = end();
+			const duration = timer('end');
 			log('dotcom', `🤒 Failed to boot ${name} in ${duration}ms`);
 		});
 };

--- a/dotcom-rendering/src/client/timer.ts
+++ b/dotcom-rendering/src/client/timer.ts
@@ -1,0 +1,47 @@
+import { isNonNullable, type TeamName } from '@guardian/libs';
+
+/** For browser which do not fully support the performance API */
+const fallback = () => () => {
+	return -1;
+};
+
+/**
+ * Helper to measure the duration between two events.
+ *
+ * This uses curried function to ensure sequential usage,
+ * as times only flows one way.
+ *
+ * Rounded up to the nearest millisecond.
+ *
+ * @example
+ * const timer = createTimer('dotcom', 'fetch');
+ * const timerEnd = timer('start');
+ * await fetch('https://www.theguardian.com/uk.json');
+ * const duration = timerEnd('end');
+ */
+export const createTimer = (
+	team: TeamName,
+	name: string,
+	action?: string,
+): ((actions: 'start') => (action: 'end') => number) => {
+	const measureName = [team, name, action].filter(isNonNullable).join(' | ');
+
+	if (!('getEntriesByName' in window.performance)) {
+		return fallback;
+	}
+
+	return () => {
+		const options: PerformanceMeasureOptions = { start: performance.now() };
+		return () => {
+			const { duration = -1 } =
+				// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Firefox returned `undefined` before v101 https://developer.mozilla.org/en-US/docs/Web/API/Performance/mark#browser_compatibility
+				window.performance.measure(measureName, options) ??
+				window.performance
+					.getEntriesByName(measureName, 'measure')
+					.at(-1) ??
+				{};
+
+			return Math.ceil(duration);
+		};
+	};
+};


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Ensure that measurements are always sequential, and only create a single `PerformanceMeasure` for a given task, which contains start time and duration as a native feature.

## Why?

The existing API can be misused, tasks could be started or ended several times in the wrong order, whereas time is unidirectional (last I checked).

## Screenshots

<img width="1046" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/76776/a4de6345-ea56-4701-99cc-5e574e6e5505">

