### PR TITLE
Increase RR header slot width on tablet

### DIFF
--- a/dotcom-rendering/src/components/SupportTheG.importable.tsx
+++ b/dotcom-rendering/src/components/SupportTheG.importable.tsx
@@ -72,7 +72,7 @@ const headerStyles = css`
 		padding-top: ${space[1]}px;
 		padding-bottom: ${space[3]}px;
 		padding-left: ${space[5]}px;
-		max-width: 340px;
+		max-width: 400px;
 	}
 
 	${from.desktop} {


### PR DESCRIPTION
The max-width is more strict than it needs to be, and Marketing want to use copy that currently wraps on tablet.

### Before:
![Screenshot 2023-07-19 at 09 27 02](https://github.com/guardian/dotcom-rendering/assets/1513454/76c07a8a-3bd1-407a-9abd-336ced5286cd)


### After:

Article:
![Screenshot 2023-07-19 at 09 38 46](https://github.com/guardian/dotcom-rendering/assets/1513454/b2c7376f-14a1-4b28-88a8-a908349d97e4)



Front:
![Screenshot 2023-07-19 at 09 39 24](https://github.com/guardian/dotcom-rendering/assets/1513454/27afd331-62bd-4267-9e96-49bbc4f0734d)


