### PR TITLE
fix: use flex-grow to allow snaps to take up all the available space

### DIFF
--- a/dotcom-rendering/src/components/SnapCssSandbox.tsx
+++ b/dotcom-rendering/src/components/SnapCssSandbox.tsx
@@ -16,6 +16,10 @@ export const SnapCssSandbox = ({ snapData, children }: Props) => {
 			<div
 				css={[
 					css`
+						// LIs that contain cards are set to flex,
+						// setting this allows the contents to take up
+						// all the available space in the LI
+						flex-grow: 1;
 						${snapData.embedCss};
 					`,
 				]}

--- a/dotcom-rendering/src/components/SnapCssSandbox.tsx
+++ b/dotcom-rendering/src/components/SnapCssSandbox.tsx
@@ -16,9 +16,9 @@ export const SnapCssSandbox = ({ snapData, children }: Props) => {
 			<div
 				css={[
 					css`
-						// LIs that contain cards are set to flex,
-						// setting this allows the contents to take up
-						// all the available space in the LI
+						/* LIs that contain cards are set to flex,
+						   setting this allows the contents to take up
+						   all the available space in the LI */
 						flex-grow: 1;
 						${snapData.embedCss};
 					`,


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Adds flex grow to the first child of the LI a snap card is wrapped in

## Why?

After consulting @mxdvl it seems this is required for the child elements to expand beyond 'content'

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/9575458/e35fbe4b-3fa6-4045-a362-68fe2fcfcada
[after]: https://github.com/guardian/dotcom-rendering/assets/9575458/520cae99-50a4-445d-bf48-24fa63ff5ffb
