### PR TITLE
Add strong styling for trailtextwrapper

### DIFF
--- a/dotcom-rendering/src/components/Card/components/TrailTextWrapper.tsx
+++ b/dotcom-rendering/src/components/Card/components/TrailTextWrapper.tsx
@@ -51,13 +51,14 @@ export const TrailTextWrapper = ({
 					display: flex;
 					flex-direction: column;
 					color: ${palette.text.cardStandfirst};
-
 					${body.small({ lineHeight: 'regular' })};
 					font-size: 14px;
-
 					padding-left: 5px;
 					padding-right: 5px;
 					padding-bottom: 8px;
+					strong {
+						font-weight: bold;
+					}
 				`,
 				showTrailText(imagePosition, imageSize, imageType),
 			]}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
This adds bold styling for strong tags
## Why?
Fixes https://github.com/guardian/dotcom-rendering/issues/8192
## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/110032454/4b5f4e5e-01ab-4d13-b99c-36adf8cc2ec2
[after]: https://github.com/guardian/dotcom-rendering/assets/110032454/0dea16c8-a9e1-4817-ae6b-469f86f3e25a

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
