### PR TITLE
fix: move most viewed section inside island

### DIFF
--- a/dotcom-rendering/src/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/layouts/CommentLayout.tsx
@@ -775,26 +775,26 @@ export const CommentLayout = ({
 				)}
 
 				{!isPaidContent && (
-					<Section
-						title="Most viewed"
-						padContent={false}
-						verticalMargins={false}
-						element="aside"
-						data-print-layout="hide"
-						data-link-name="most-popular"
-						data-component="most-popular"
-					>
-						<MostViewedFooterLayout renderAds={renderAds}>
-							<Island clientOnly={true} deferUntil="visible">
+					<Island clientOnly={true} deferUntil="visible">
+						<Section
+							title="Most viewed"
+							padContent={false}
+							verticalMargins={false}
+							element="aside"
+							data-print-layout="hide"
+							data-link-name="most-popular"
+							data-component="most-popular"
+						>
+							<MostViewedFooterLayout renderAds={renderAds}>
 								<MostViewedFooterData
 									sectionId={article.config.section}
 									format={format}
 									ajaxUrl={article.config.ajaxUrl}
 									edition={article.editionId}
 								/>
-							</Island>
-						</MostViewedFooterLayout>
-					</Section>
+							</MostViewedFooterLayout>
+						</Section>
+					</Island>
 				)}
 
 				{renderAds && (

--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -821,26 +821,26 @@ export const ImmersiveLayout = ({
 					</Section>
 				)}
 				{!isPaidContent && (
-					<Section
-						title="Most viewed"
-						padContent={false}
-						verticalMargins={false}
-						element="aside"
-						data-print-layout="hide"
-						data-link-name="most-popular"
-						data-component="most-popular"
-					>
-						<MostViewedFooterLayout renderAds={renderAds}>
-							<Island clientOnly={true} deferUntil="visible">
+					<Island clientOnly={true} deferUntil="visible">
+						<Section
+							title="Most viewed"
+							padContent={false}
+							verticalMargins={false}
+							element="aside"
+							data-print-layout="hide"
+							data-link-name="most-popular"
+							data-component="most-popular"
+						>
+							<MostViewedFooterLayout renderAds={renderAds}>
 								<MostViewedFooterData
 									sectionId={article.config.section}
 									format={format}
 									ajaxUrl={article.config.ajaxUrl}
 									edition={article.editionId}
 								/>
-							</Island>
-						</MostViewedFooterLayout>
-					</Section>
+							</MostViewedFooterLayout>
+						</Section>
+					</Island>
 				)}
 				{!isLabs && renderAds && (
 					<Section

--- a/dotcom-rendering/src/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/InteractiveLayout.tsx
@@ -689,26 +689,26 @@ export const InteractiveLayout = ({
 				)}
 
 				{!isPaidContent && (
-					<Section
-						title="Most viewed"
-						padContent={false}
-						verticalMargins={false}
-						element="aside"
-						data-print-layout="hide"
-						data-link-name="most-popular"
-						data-component="most-popular"
-					>
-						<MostViewedFooterLayout renderAds={renderAds}>
-							<Island clientOnly={true} deferUntil="visible">
+					<Island clientOnly={true} deferUntil="visible">
+						<Section
+							title="Most viewed"
+							padContent={false}
+							verticalMargins={false}
+							element="aside"
+							data-print-layout="hide"
+							data-link-name="most-popular"
+							data-component="most-popular"
+						>
+							<MostViewedFooterLayout renderAds={renderAds}>
 								<MostViewedFooterData
 									sectionId={article.config.section}
 									format={format}
 									ajaxUrl={article.config.ajaxUrl}
 									edition={article.editionId}
 								/>
-							</Island>
-						</MostViewedFooterLayout>
-					</Section>
+							</MostViewedFooterLayout>
+						</Section>
+					</Island>
 				)}
 
 				{renderAds && (

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -1220,27 +1220,27 @@ export const LiveLayout = ({
 					)}
 
 					{!isPaidContent && (
-						<Section
-							title="Most viewed"
-							padContent={false}
-							verticalMargins={false}
-							element="aside"
-							data-print-layout="hide"
-							data-link-name="most-popular"
-							data-component="most-popular"
-							leftColSize="wide"
-						>
-							<MostViewedFooterLayout renderAds={renderAds}>
-								<Island clientOnly={true} deferUntil="visible">
+						<Island clientOnly={true} deferUntil="visible">
+							<Section
+								title="Most viewed"
+								padContent={false}
+								verticalMargins={false}
+								element="aside"
+								data-print-layout="hide"
+								data-link-name="most-popular"
+								data-component="most-popular"
+								leftColSize="wide"
+							>
+								<MostViewedFooterLayout renderAds={renderAds}>
 									<MostViewedFooterData
 										sectionId={article.config.section}
 										format={format}
 										ajaxUrl={article.config.ajaxUrl}
 										edition={article.editionId}
 									/>
-								</Island>
-							</MostViewedFooterLayout>
-						</Section>
+								</MostViewedFooterLayout>
+							</Section>
+						</Island>
 					)}
 
 					{renderAds && (

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -732,26 +732,26 @@ export const ShowcaseLayout = ({
 				)}
 
 				{!isPaidContent && (
-					<Section
-						title="Most viewed"
-						padContent={false}
-						verticalMargins={false}
-						element="aside"
-						data-print-layout="hide"
-						data-link-name="most-popular"
-						data-component="most-popular"
-					>
-						<MostViewedFooterLayout renderAds={renderAds}>
-							<Island clientOnly={true} deferUntil="visible">
+					<Island clientOnly={true} deferUntil="visible">
+						<Section
+							title="Most viewed"
+							padContent={false}
+							verticalMargins={false}
+							element="aside"
+							data-print-layout="hide"
+							data-link-name="most-popular"
+							data-component="most-popular"
+						>
+							<MostViewedFooterLayout renderAds={renderAds}>
 								<MostViewedFooterData
 									sectionId={article.config.section}
 									format={format}
 									ajaxUrl={article.config.ajaxUrl}
 									edition={article.editionId}
 								/>
-							</Island>
-						</MostViewedFooterLayout>
-					</Section>
+							</MostViewedFooterLayout>
+						</Section>
+					</Island>
 				)}
 
 				{renderAds && !isLabs && (

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -858,19 +858,18 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 						)}
 
 						{!isPaidContent && (
-							<Section
-								title="Most viewed"
-								padContent={false}
-								verticalMargins={false}
-								element="aside"
-								data-print-layout="hide"
-								data-link-name="most-popular"
-								data-component="most-popular"
-							>
-								<MostViewedFooterLayout renderAds={renderAds}>
-									<Island
-										clientOnly={true}
-										deferUntil="visible"
+							<Island clientOnly={true} deferUntil="visible">
+								<Section
+									title="Most viewed"
+									padContent={false}
+									verticalMargins={false}
+									element="aside"
+									data-print-layout="hide"
+									data-link-name="most-popular"
+									data-component="most-popular"
+								>
+									<MostViewedFooterLayout
+										renderAds={renderAds}
 									>
 										<MostViewedFooterData
 											sectionId={article.config.section}
@@ -878,9 +877,9 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 											ajaxUrl={article.config.ajaxUrl}
 											edition={article.editionId}
 										/>
-									</Island>
-								</MostViewedFooterLayout>
-							</Section>
+									</MostViewedFooterLayout>
+								</Section>
+							</Island>
 						)}
 
 						{renderAds && !isLabs && (


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Puts the whole of the "Most Viewed" section inside an `<Island>` component. 
Previously, only the inner components of this `<Section>` component were an island but this results in the title of the Section being visible even without onward content. 

## Why?

Partially solves #8313 

## Still problematic
The print view still has a huge amount of whitespace at the end of articles...

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/43961396/43006c5c-ebbd-42d9-85b5-7669bbd697bd
[after]: https://github.com/guardian/dotcom-rendering/assets/43961396/68f69da1-608b-4711-9672-71fbc0c89c24

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
