### PR TITLE
MatchStats grid spacing

### DIFF
--- a/dotcom-rendering/src/components/MatchStats.tsx
+++ b/dotcom-rendering/src/components/MatchStats.tsx
@@ -46,7 +46,8 @@ const StatsGrid = ({
 							display: grid;
 
 							${until.desktop} {
-								grid-template-columns: 50% 50%;
+								grid-template-columns: 49% 49%;
+								column-gap: 2%;
 								grid-template-areas:
 									'title          .'
 									'possession     attempts'
@@ -58,6 +59,7 @@ const StatsGrid = ({
 
 							${from.desktop} {
 								grid-template-columns: 100%;
+								column-gap: 0%;
 								grid-template-areas:
 									'title'
 									'possession'
@@ -70,6 +72,7 @@ const StatsGrid = ({
 							}
 							${until.phablet} {
 								grid-template-columns: 50% 50%;
+								column-gap: 0%;
 								grid-template-areas:
 									'title			title'
 									'possession		possession'
@@ -99,7 +102,8 @@ const StatsGrid = ({
 							display: grid;
 
 							${from.wide} {
-								grid-template-columns: 50% 50%;
+								grid-template-columns: 49% 49%;
+								column-gap: 2%;
 								grid-template-areas:
 									'title          .'
 									'possession     attempts'
@@ -110,7 +114,8 @@ const StatsGrid = ({
 							}
 
 							${until.wide} {
-								grid-template-columns: 50% 50%;
+								grid-template-columns: 49% 49%;
+								column-gap: 2%;
 								grid-template-areas:
 									'title          .'
 									'possession     attempts'
@@ -122,6 +127,7 @@ const StatsGrid = ({
 
 							${until.phablet} {
 								grid-template-columns: 50% 50%;
+								column-gap: 0%;
 								grid-template-areas:
 									'title			title'
 									'possession		possession'


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Add a column-gap to the MatchStats grid, so that there is space between the graphics at large breakpoints

## Why?
The graphics were squashed on larger screens as reported in this issue https://github.com/guardian/dotcom-rendering/issues/8316

## Screenshots

| Screen size | Before      | After      |
| -- | ----------- | ---------- |
| Wide | <img width="987" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/8ff1efbe-e203-480f-9915-ede5b9874f62"> | <img width="987" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/4bb01df3-dfa9-4133-ae7a-7dc607755d55"> |
| Desktop | <img width="630" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/b3cb69b5-5b72-4481-bca6-54d0d77b9ce2"> | <img width="630" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/9c5bd22b-f50b-433e-a0a7-f1408ef67b66"> |
| Mobile (no change) | <img width="517" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/4813aaea-b26a-4991-91dc-fb44bfd1b94c"> | <img width="517" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/09e90914-defe-493d-b630-a85c62e17c18"> |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
