### PR TITLE
Fix safari flex-direction column issues

### DIFF
--- a/dotcom-rendering/src/components/Card/components/CardWrapper.tsx
+++ b/dotcom-rendering/src/components/Card/components/CardWrapper.tsx
@@ -33,6 +33,15 @@ const cardStyles = (
 		so this is required here */
 		position: relative;
 
+		/* Media query for Safari 10.1 and Safari 10.3 */
+		@media screen and (-webkit-min-device-pixel-ratio: 0) {
+			@media not all and (min-resolution: 0.001dpcm) {
+				@media {
+					display: -webkit-box;
+				}
+			}
+		}
+
 		:hover .image-overlay {
 			position: absolute;
 			top: 0;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Adds a media query for relevant safari versions and uses -webkit-box for legacy flex support
## Why?
Fixes https://github.com/guardian/dotcom-rendering/issues/7584
## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/110032454/d5143236-4159-4283-b432-3e6407987eba
[after]: https://github.com/guardian/dotcom-rendering/assets/110032454/b541d4e4-b1c4-48b9-a07d-f5b8ba625969
<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
