### PR TITLE
Target safari and display cards as grid rather than flex

### DIFF
--- a/dotcom-rendering/src/components/Card/components/CardWrapper.tsx
+++ b/dotcom-rendering/src/components/Card/components/CardWrapper.tsx
@@ -33,6 +33,17 @@ const cardStyles = (
 		so this is required here */
 		position: relative;
 
+		/* Target Safari 10.1 */
+		/* https://www.browserstack.com/guide/create-browser-specific-css */
+		@media not all and (min-resolution: 0.001dpcm) {
+			@supports (-webkit-appearance: none) and
+				(not (stroke-color: transparent)) {
+				display: grid;
+				grid-auto-rows: min-content;
+				align-content: start;
+			}
+		}
+
 		:hover .image-overlay {
 			position: absolute;
 			top: 0;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

Fixes https://github.com/guardian/dotcom-rendering/issues/7584

## What does this change?
Targets safari 10 in order to use `display: grid` on the `CardBase`

## Why?
From the screenshots below you can see that the flex direction on the cardbase was causing all sorts of chaos on safari 10.1 and 10.3, this fixes it and while it isn't identical to more recent browsers (including more recent safari), its readable now.

## Screenshots


| Browser | Before      | After      |
| ----- | ----------- | ---------- |
| Safari 10.1 (tested using browserstack) | <img width="854" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/6726716c-29b6-4316-80c7-d5983b01eb94"> | <img width="854" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/fc07b327-f6b7-44ce-9fd3-9569794b84c0"> |
| Safari 10.3 (tested using browserstack) | <img width="617" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/3a9d44d5-02d6-42b4-b793-86c2859378b2"> | <img width="490" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/86430ef4-297b-4518-a66a-c07d994461c3">  |
| Firefox 10.1 (no change) | <img width="1328" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/4ef8bb1b-7863-4d02-96d3-79eebab50a53"> | <img width="1328" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/35eabed7-4fb6-4c0c-afd6-3289161816a6"> |
| Safari 16.5.2 (no change) | <img width="1309" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/c02dca6e-bd00-4ce8-a67b-9e8e0e345971"> | <img width="1309" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/56a0236e-7ca3-40f0-a9c6-fa9ba0a58c33"> |
| Chrome 114.0.5735.198 (no change) | <img width="1309" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/a42c399c-d87b-4b6c-a5c4-ff2248f41564"> | <img width="1309" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/a6e64639-e724-4d12-9d2d-77b6c3121404">| 

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
