### PR TITLE
Prettify `index.d.ts`

### DIFF
--- a/dotcom-rendering/.prettierignore
+++ b/dotcom-rendering/.prettierignore
@@ -25,6 +25,7 @@ node_modules/
 !/cypress/**/*.ts
 !/scripts/**/*.js
 !/.storybook/**/*.js
+!/index.d.ts
 !package.json
 
 # Ignore specific files

--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -286,12 +286,7 @@ interface FEKeyEventsRequest {
 	filterKeyEvents: boolean;
 }
 
-type CardImageType =
-	| 'picture'
-	| 'avatar'
-	| 'crossword'
-	| 'slideshow'
-	| 'video';
+type CardImageType = 'picture' | 'avatar' | 'crossword' | 'slideshow' | 'video';
 
 type SmallHeadlineSize =
 	| 'tiny'


### PR DESCRIPTION
## What does this change?

Include [index.d.ts](https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/index.d.ts) for `prettier`

## Why?

It’s a file that we use, and it’s nearly enough prettified already!
