### PR TITLE
CI Fixes

### DIFF
--- a/.github/workflows/permissions-advisor.yml
+++ b/.github/workflows/permissions-advisor.yml
@@ -1,0 +1,26 @@
+name: Permissions Advisor
+
+permissions:
+  actions: read
+
+on:
+  workflow_dispatch:
+    inputs:
+      name:
+        description: 'The name of the workflow file to analyze'
+        required: true
+        type: string
+      count:
+        description: 'How many last runs to analyze'
+        required: false
+        type: number
+        default: 5
+
+jobs:
+  advisor:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: GitHubSecurityLab/actions-permissions/advisor@v1
+      with:
+        name: ${{ inputs.name }}
+        count: ${{ inputs.count }}

--- a/dotcom-rendering/cypress/e2e/parallel-2/braze.cy.js
+++ b/dotcom-rendering/cypress/e2e/parallel-2/braze.cy.js
@@ -3,11 +3,20 @@ import { setLocalBaseUrl } from '../../lib/setLocalBaseUrl.js';
 
 const idapiIdentifiersResponse = `{ "id": "000000000", "brazeUuid": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "puzzleUuid": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "googleTagId": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" }`;
 
-const handleGuCookieError = () => {
+const handleCommercialErrors = () => {
 	cy.on('uncaught:exception', (err, runnable) => {
 		// When we set the `GU_U` cookie this is causing the commercial bundle to try and do
 		// something with the url which is failing in Cypress with a malformed URI error
 		if (err.message.includes('URI malformed')) {
+			// This error is unrelated to the test in question so return  false to prevent
+			// this commercial error from failing this test
+			return false;
+		}
+		if (
+			err.message.includes(
+				"Cannot read properties of undefined (reading 'map')",
+			)
+		) {
 			// This error is unrelated to the test in question so return  false to prevent
 			// this commercial error from failing this test
 			return false;
@@ -26,7 +35,7 @@ const cmpIframe = () => {
 describe('Braze messaging', function () {
 	beforeEach(function () {
 		cy.clearLocalStorage();
-		handleGuCookieError();
+		handleCommercialErrors();
 		setLocalBaseUrl();
 	});
 

--- a/dotcom-rendering/cypress/e2e/parallel-4/atom.interactivity.cy.js
+++ b/dotcom-rendering/cypress/e2e/parallel-4/atom.interactivity.cy.js
@@ -122,9 +122,9 @@ describe('Why do wombats do square poos?', function () {
 		// We got the question wrong!
 		// Our choice is shown as wrong (red) and the actual correct answer is shown in green
 		cy.get('[data-answer-type=incorrect-answer]').should('exist');
-		cy.get('[data-answer-type=non-selected-correct-answer]').should(
-			'exist',
-		);
+		cy.get('[data-answer-type=non-selected-correct-answer]', {
+			timeout: 30000,
+		}).should('exist');
 	});
 
 	it('when I get the answer right, it should commend my skills when I click Reveal', function () {
@@ -143,6 +143,8 @@ describe('Why do wombats do square poos?', function () {
 		// Click Reveal to show the results
 		cy.get('[data-atom-type=knowledgequiz]').contains('Reveal').click();
 		// We were right!
-		cy.get('[data-answer-type=correct-selected-answer]').should('exist');
+		cy.get('[data-answer-type=correct-selected-answer]', {
+			timeout: 30000,
+		}).should('exist');
 	});
 });

--- a/dotcom-rendering/cypress/e2e/parallel-6/paid.content.cy.js
+++ b/dotcom-rendering/cypress/e2e/parallel-6/paid.content.cy.js
@@ -4,6 +4,27 @@ import { cmpIframe } from '../../lib/cmpIframe';
 import { privacySettingsIframe } from '../../lib/privacySettingsIframe';
 import { storage } from '@guardian/libs';
 
+const handleCommercialErrors = () => {
+	cy.on('uncaught:exception', (err, runnable) => {
+		// When we set the `GU_U` cookie this is causing the commercial bundle to try and do
+		// something with the url which is failing in Cypress with a malformed URI error
+		if (err.message.includes('URI malformed')) {
+			// This error is unrelated to the test in question so return  false to prevent
+			// this commercial error from failing this test
+			return false;
+		}
+		if (
+			err.message.includes(
+				"Cannot read properties of undefined (reading 'map')",
+			)
+		) {
+			// This error is unrelated to the test in question so return  false to prevent
+			// this commercial error from failing this test
+			return false;
+		}
+	});
+};
+
 const paidContentPage =
 	'https://www.theguardian.com/the-future-of-sustainable-entrepreneurship/2023/jun/01/take-your-sustainable-business-to-the-next-level-win-your-own-retail-space-at-one-of-londons-westfield-centres';
 
@@ -16,6 +37,7 @@ const paidContentPage =
  */
 describe('Paid content tests', function () {
 	beforeEach(function () {
+		handleCommercialErrors();
 		setLocalBaseUrl();
 		storage.local.set('gu.geo.override', 'GB');
 	});


### PR DESCRIPTION
## What does this change?

1.

Update Cypress tests to ignore an uncaught exception from the commercial runtime.

This will allow DCR PRs to be merged while a fixed is worked on.

#### Error

```
Cannot read properties of undefined (reading 'map')
```

This is coming from the commercial runtime following a recent release:

https://github.com/guardian/commercial/blob/cb6492e6fab4adf4bf5256f2918dbae79c85e010/src/core/send-commercial-metrics.ts#L99

2.

Add an actions permissions advisor workflow that will help us diagnose the permissions required by actions.

https://github.com/GitHubSecurityLab/actions-permissions/tree/main/advisor

3.

Increase timeouts for `atom.interactivity' quick checks

