### PR TITLE
Mark DocumentBlockElement props as optional

### DIFF
--- a/dotcom-rendering/src/components/DocumentBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/components/DocumentBlockComponent.importable.tsx
@@ -25,14 +25,14 @@ export const getDocumentCloudAssetUrl = (
 
 type Props = {
 	embedUrl?: string;
-	height: number;
+	height?: number;
 	isMainMedia: boolean;
 	isTracking: boolean;
 	role?: RoleType;
 	source?: string;
 	sourceDomain?: string;
 	title?: string;
-	width: number;
+	width?: number;
 };
 
 export const DocumentBlockComponent = ({

--- a/dotcom-rendering/src/model/article-schema.json
+++ b/dotcom-rendering/src/model/article-schema.json
@@ -1666,10 +1666,7 @@
             "required": [
                 "_type",
                 "elementId",
-                "embedUrl",
-                "height",
-                "isThirdPartyTracking",
-                "width"
+                "isThirdPartyTracking"
             ]
         },
         "EmbedBlockElement": {

--- a/dotcom-rendering/src/model/block-schema.json
+++ b/dotcom-rendering/src/model/block-schema.json
@@ -1197,10 +1197,7 @@
             "required": [
                 "_type",
                 "elementId",
-                "embedUrl",
-                "height",
-                "isThirdPartyTracking",
-                "width"
+                "isThirdPartyTracking"
             ]
         },
         "EmbedBlockElement": {

--- a/dotcom-rendering/src/types/content.ts
+++ b/dotcom-rendering/src/types/content.ts
@@ -158,9 +158,9 @@ export interface DividerBlockElement {
 export interface DocumentBlockElement extends ThirdPartyEmbeddedContent {
 	_type: 'model.dotcomrendering.pageElements.DocumentBlockElement';
 	elementId: string;
-	embedUrl: string;
-	height: number;
-	width: number;
+	embedUrl?: string;
+	height?: number;
+	width?: number;
 	title?: string;
 	role?: RoleType;
 }


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Makes the props of DocumentBlockElement optional

## Why?

[Frontend considers these props to be optional](https://github.com/guardian/frontend/blob/bc5065244a3d9d54c0a816996105e0f4eb2b7074/common/app/model/dotcomrendering/pageElements/PageElement.scala#L205) and therefore DCR should too. This should fix the issue with https://theguardian.com/football/2014/mar/27/retro-mbm-england-v-west-germany-sort-of-live

<img width="2037" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/21217225/3cc3e1cb-0d78-48f9-8dc3-d9b3dfd40876">
