### PR TITLE
Fix slideshow caption bug

### DIFF
--- a/dotcom-rendering/src/components/Slideshow.tsx
+++ b/dotcom-rendering/src/components/Slideshow.tsx
@@ -138,6 +138,17 @@ const captionStyles = css`
 	);
 	color: ${neutral[100]};
 	padding: 60px 8px 8px;
+
+	${from.tablet} {
+		top: 0;
+		bottom: initial;
+		padding-top: 8px;
+		background: linear-gradient(
+			to bottom,
+			rgba(0, 0, 0, 0.8) 0%,
+			rgba(0, 0, 0, 0) 100%
+		);
+	}
 `;
 
 /**


### PR DESCRIPTION
Co-authored-by: James Gorrie <james.gorrie@guardian.co.uk>

<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Fixes a bug that hides the caption of a slideshow behind sublinks. This fix changes the position of the caption above a certain breakpoint regardless of whether there are sublinks. We decided to do this for logic simplicity but if needed this can be changed in a follow up PR.

## Why?
We want to display the captions + frontend parity.


## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/30f3d048-8962-4685-9cd6-435afefc41b6) | ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/1f8a6611-173c-4eb9-93a6-8d177c2acc83) |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
