### PR TITLE
bump commercial 10.6.0

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -65,7 +65,7 @@
 		"@guardian/bridget": "2.3.0",
 		"@guardian/browserslist-config": "5.0.0",
 		"@guardian/cdk": "49.5.0",
-		"@guardian/commercial": "10.1.1",
+		"@guardian/commercial": "10.6.0",
 		"@guardian/consent-management-platform": "13.5.0",
 		"@guardian/core-web-vitals": "5.0.0",
 		"@guardian/eslint-config": "4.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3129,10 +3129,10 @@
     read-pkg-up "7.0.1"
     yargs "^17.6.2"
 
-"@guardian/commercial@10.1.1":
-  version "10.1.1"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-10.1.1.tgz#0a6820613fd7ecfa91adf438daf33ee397b16d8d"
-  integrity sha512-vq8jPbAnZcc7mhQz0TDIAq0/Qy18SXQ0K5XOc7ZQxUaSDfIrOm9zNLaLggFDqJ4PppSz+AcgN53+2CimU+S55w==
+"@guardian/commercial@10.6.0":
+  version "10.6.0"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-10.6.0.tgz#315325ce9625540bb22574bad9eace2552543706"
+  integrity sha512-xs50dVkUrSwRtH3Y3e1ruDkQTpL+lT1nbZHyiml5JYYzs1VCOoVBWlFdTbuKeXRLoMrmWQB6A2/wkS+eGUccZg==
   dependencies:
     "@changesets/cli" "^2.26.1"
     "@guardian/ab-core" "^5.0.0"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
[Changelog](https://github.com/guardian/commercial/blob/main/CHANGELOG.md)
# @guardian/commercial

## 10.6.0

### Minor Changes

- 66b65f0: Remove fronts banner test. Remove code to create banner ads on frontend
- a51ae56: Refactor EventTimer incorporating new measurements (see PR)

## 10.5.0

### Minor Changes

- 940b294: Use the new `shouldLoadGoogletag` switch.

## 10.4.0

### Minor Changes

- e128f63: In dfp-env shouldLazyLoad should always returns true if on mobile/tablet breakpoints

### Patch Changes

- e556b32: Remove `hbImpl`.

## 10.3.0

### Minor Changes

- a3a35ac: Drop support for paid container more less button text
- a3297bb: Remove track-labs-containers
- 733d538: Log the commit SHA of the current build to the browser console

### Patch Changes

- 7c9ebc1: remove usage of mobileStickyLeaderboard and mobileStickyPrebid switches

## 10.2.0

### Minor Changes

- a421b30: Remove the non refreshable line item ids fallback
