### PR TITLE
Load privacy settings link when page load interactive or complete

### DIFF
--- a/dotcom-rendering/src/client/bootCmp.ts
+++ b/dotcom-rendering/src/client/bootCmp.ts
@@ -3,7 +3,7 @@ import type { ConsentState } from '@guardian/consent-management-platform/dist/ty
 import type { OphanAction, OphanComponentType } from '@guardian/libs';
 import { getCookie, log } from '@guardian/libs';
 import { getLocaleCode } from '../lib/getCountryCode';
-import { injectPrivacySettingsLink } from '../lib/injectPrivacySettingsLink';
+import { injectPrivacySettingsLinkWhenReady } from '../lib/injectPrivacySettingsLink';
 import { submitComponentEvent } from './ophan/ophan';
 
 export const bootCmp = async (): Promise<void> => {
@@ -85,15 +85,8 @@ export const bootCmp = async (): Promise<void> => {
 		submitComponentEvent(event);
 	});
 
-	document.onreadystatechange = () => {
-		if (
-			document.readyState === 'interactive' ||
-			document.readyState === 'complete'
-		) {
-			// Manually updates the footer DOM because it's not hydrated
-			injectPrivacySettingsLink();
-		}
-	};
+	// Manually updates the footer DOM because it's not hydrated
+	void injectPrivacySettingsLinkWhenReady();
 
 	cmp.init({
 		pubData: {

--- a/dotcom-rendering/src/lib/injectPrivacySettingsLink.ts
+++ b/dotcom-rendering/src/lib/injectPrivacySettingsLink.ts
@@ -49,3 +49,18 @@ export const injectPrivacySettingsLink = (): void => {
 		}
 	}
 };
+
+// Inject privacy link when document has finished loading
+export const injectPrivacySettingsLinkWhenReady = (): void => {
+	if (document.readyState === 'loading') {
+		document.addEventListener(
+			'readystatechange',
+			() => {
+				injectPrivacySettingsLink();
+			},
+			{ once: true },
+		);
+	} else {
+		injectPrivacySettingsLink();
+	}
+};


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

The privacy settings link will now be loaded as soon as the document readyState is `interactive` or `complete`.

Before, the privacy settings link was loaded when the document state changed AND the new state was `interactive` or `complete`. This meant that when this piece of code was run and the document ready state was already `interactive`, the privacy settings link would only run when the ready state changed to `complete`.

## Why?

We can load the privacy settings link when the document ready state is `interactive` or `complete`. It looks that the code assumed that the document ready state would be `loading` when this code is run, however, this may not be true.

Also, this will prevent the possibility that this code path could be run multiple times.

## Screenshots

#### Note that the link "Privacy settings" is displayed after this change when the ready state is interactive.

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/9574885/db3cd0e2-4ba4-4fc9-a406-e33d128a7f76
[after]: https://github.com/guardian/dotcom-rendering/assets/9574885/24c31cb2-2415-43ae-b6ef-1a654c15f751

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
