### PR TITLE
Change slideshow caption position only when `isDynamo`

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -409,6 +409,7 @@ export const Card = ({
 							<Slideshow
 								images={media.slideshowImages}
 								imageSize={imageSize}
+								isDynamo={isDynamo}
 							/>
 						)}
 						{media.type === 'avatar' && (

--- a/dotcom-rendering/src/components/Slideshow.tsx
+++ b/dotcom-rendering/src/components/Slideshow.tsx
@@ -138,7 +138,9 @@ const captionStyles = css`
 	);
 	color: ${neutral[100]};
 	padding: 60px 8px 8px;
+`;
 
+const additionalDynamoCaptionStyles = css`
 	${from.tablet} {
 		top: 0;
 		bottom: initial;
@@ -177,9 +179,11 @@ const captionStyles = css`
 export const Slideshow = ({
 	images,
 	imageSize,
+	isDynamo,
 }: {
 	images: DCRSlideshowImage[];
 	imageSize: ImageSizeType;
+	isDynamo?: boolean;
 }) => {
 	return (
 		<>
@@ -208,6 +212,9 @@ export const Slideshow = ({
 						<figcaption
 							css={[
 								captionStyles,
+								isDynamo
+									? additionalDynamoCaptionStyles
+									: undefined,
 								// Don't show captions on mobile for small images
 								imageSize === 'small' && hideOnMobile,
 							]}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Applies [this bug fix](https://github.com/guardian/dotcom-rendering/pull/8340) only when `isDynamo`

## Why?
Frontend parity

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/7a90d349-529c-4cb1-aee4-ddc2cd8091a4) | ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/b2bd2723-82cc-4ef5-927e-d194a65fafa4) |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
