### PR TITLE
Check versions of `@types/node` match `.nvmrc`

### DIFF
--- a/scripts/check-node-versions.mjs
+++ b/scripts/check-node-versions.mjs
@@ -41,6 +41,14 @@ const requiredNodeVersionMatches =
 			filepath: 'apps-rendering/riff-raff.yaml',
 			pattern: /^ +Recipe: .+-mobile-node(\d+\.\d+\.\d+).*$/m,
 		},
+		{
+			filepath: 'dotcom-rendering/package.json',
+			pattern: /^\s*"@types\/node": "(\d+\.\d+\.\d+)",?$/m,
+		},
+		{
+			filepath: 'apps-rendering/package.json',
+			pattern: /^\s*"@types\/node": "(\d+\.\d+\.\d+)",?$/m,
+		},
 	]);
 
 const problems = (


### PR DESCRIPTION
The `@types/*` package should match the version of the library. See https://github.com/DefinitelyTyped/DefinitelyTyped#how-do-definitely-typed-package-versions-relate-to-versions-of-the-corresponding-library

