### PR TITLE
Fix type errors from `GuideAtom` migration

### DIFF
--- a/dotcom-rendering/src/lib/decidePalette.ts
+++ b/dotcom-rendering/src/lib/decidePalette.ts
@@ -2078,15 +2078,15 @@ const backgroundAudioAtom = (format: ArticleFormat) => {
 
 const textExpandableAtom = (format: ArticleFormat) => {
 	switch (format.theme) {
-		case ArticlePillar.News:
+		case Pillar.News:
 			return news[300];
-		case ArticlePillar.Lifestyle:
+		case Pillar.Lifestyle:
 			return lifestyle[300];
-		case ArticlePillar.Sport:
+		case Pillar.Sport:
 			return sport[300];
-		case ArticlePillar.Culture:
+		case Pillar.Culture:
 			return culture[300];
-		case ArticlePillar.Opinion:
+		case Pillar.Opinion:
 			return opinion[300];
 		case ArticleSpecial.Labs:
 			return lifestyle[300];
@@ -2099,15 +2099,15 @@ const textExpandableAtom = (format: ArticleFormat) => {
 
 const textExpandableAtomHover = (format: ArticleFormat) => {
 	switch (format.theme) {
-		case ArticlePillar.News:
+		case Pillar.News:
 			return news[400];
-		case ArticlePillar.Lifestyle:
+		case Pillar.Lifestyle:
 			return lifestyle[400];
-		case ArticlePillar.Sport:
+		case Pillar.Sport:
 			return sport[400];
-		case ArticlePillar.Culture:
+		case Pillar.Culture:
 			return culture[400];
-		case ArticlePillar.Opinion:
+		case Pillar.Opinion:
 			return opinion[400];
 		case ArticleSpecial.Labs:
 			return lifestyle[400];


### PR DESCRIPTION
## What does this change?

Replaces `ArticlePillar` with `Pillar` in `ExpandableAtom` colour palette.

## Why?

In between rebasing the `GuideAtom` migration (#8297) `@guardian/libs` was updated which renamed `ArticlePillar` to `Pillar`. As this PR lacked this change it broken the build with type errors on merge.