### PR TITLE
Navigating between liveblog pages is anchored to the pagination’s location

### DIFF
--- a/dotcom-rendering/src/components/Pagination.stories.tsx
+++ b/dotcom-rendering/src/components/Pagination.stories.tsx
@@ -25,6 +25,10 @@ export const notFirstPage = () => (
 				currentPage={2}
 				totalPages={6}
 				format={format}
+				oldest="oldest"
+				older="older"
+				newer="newer"
+				newest="newest"
 			/>
 		))}
 	</>
@@ -40,9 +44,30 @@ export const firstPageStory = () => (
 				currentPage={1}
 				totalPages={4}
 				format={format}
+				oldest="oldest"
+				older="older"
+				newer="newer"
+				newest="newest"
 			/>
 		))}
 	</>
 );
 
 firstPageStory.storyName = 'First page';
+
+export const lastPage = () => (
+	<>
+		{formats.map((format) => (
+			<Pagination
+				key={JSON.stringify(format)}
+				currentPage={9}
+				totalPages={9}
+				format={format}
+				oldest="oldest"
+				older="older"
+				newer="newer"
+				newest="newest"
+			/>
+		))}
+	</>
+);

--- a/dotcom-rendering/src/components/Pagination.tsx
+++ b/dotcom-rendering/src/components/Pagination.tsx
@@ -85,7 +85,8 @@ export const Pagination = ({
 									icon={<SvgChevronLeftDouble />}
 									iconSide="left"
 									hideLabel={true}
-									href={newest}
+									// There’s no pagination at the top of the newest page
+									href={`${newest}#maincontent`}
 									cssOverrides={cssOverrides}
 								>
 									Newest
@@ -97,7 +98,8 @@ export const Pagination = ({
 									priority="tertiary"
 									icon={<SvgChevronLeftDouble />}
 									iconSide="left"
-									href={newest}
+									// There’s no pagination at the top of the newest page
+									href={`${newest}#maincontent`}
 									cssOverrides={cssOverrides}
 								>
 									Newest
@@ -111,7 +113,7 @@ export const Pagination = ({
 							priority="tertiary"
 							icon={<SvgChevronLeftSingle />}
 							hideLabel={true}
-							href={newer}
+							href={`${newer}#${id}`}
 							cssOverrides={cssOverrides}
 						>
 							Previous
@@ -142,7 +144,7 @@ export const Pagination = ({
 							priority="tertiary"
 							icon={<SvgChevronRightSingle />}
 							hideLabel={true}
-							href={older}
+							href={`${older}#${id}`}
 							cssOverrides={cssOverrides}
 						>
 							Next
@@ -156,7 +158,7 @@ export const Pagination = ({
 									priority="tertiary"
 									icon={<SvgChevronRightDouble />}
 									iconSide="right"
-									href={oldest}
+									href={`${oldest}#${id}`}
 									hideLabel={true}
 									cssOverrides={cssOverrides}
 								>
@@ -169,7 +171,7 @@ export const Pagination = ({
 									priority="tertiary"
 									icon={<SvgChevronRightDouble />}
 									iconSide="right"
-									href={oldest}
+									href={`${oldest}#${id}`}
 									cssOverrides={cssOverrides}
 								>
 									Oldest

--- a/dotcom-rendering/src/components/Pagination.tsx
+++ b/dotcom-rendering/src/components/Pagination.tsx
@@ -1,7 +1,7 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import type { ArticleFormat } from '@guardian/libs';
-import { space, textSans, until } from '@guardian/source-foundations';
+import { from, space, textSans } from '@guardian/source-foundations';
 import {
 	Hide,
 	LinkButton,
@@ -22,74 +22,33 @@ type Props = {
 	format: ArticleFormat;
 };
 
-const NavWrapper = ({ children }: { children: React.ReactNode }) => (
-	<nav
-		// Used to scroll the page to this point when using permalinks
-		id="liveblog-navigation"
-		css={css`
-			display: flex;
-			flex-direction: row;
-			justify-content: space-between;
-			padding-top: ${space[1]}px;
-			padding-bottom: ${space[4]}px;
-		`}
-	>
-		{children}
-	</nav>
-);
+/** Used to scroll the page to this point when using permalinks */
+const id = 'liveblog-navigation';
 
-const FlexSection = ({
-	hide = false,
-	children,
-}: {
-	hide?: boolean;
-	children: React.ReactNode;
-}) => (
-	<section
-		css={css`
-			display: flex;
-			align-items: center;
-			visibility: ${hide ? 'hidden' : 'visible'};
-		`}
-	>
-		{children}
-	</section>
-);
+const grid = css`
+	display: grid;
+	grid-template-areas: 'newer position older';
+	grid-template-columns: 1fr auto 1fr;
+	grid-gap: ${space[2]}px;
+	align-items: center;
 
-const Bold = ({ children }: { children: React.ReactNode }) => (
-	<div
-		css={css`
-			font-weight: bold;
-		`}
-	>
-		{children}
-	</div>
-);
+	padding-top: ${space[1]}px;
+	padding-bottom: ${space[4]}px;
+`;
 
-const Position = ({ children }: { children: React.ReactNode }) => (
-	<div
-		css={css`
-			display: flex;
-			flex-direction: row;
-			${textSans.small()}
-		`}
-	>
-		{children}
-	</div>
-);
+const flexSection = css`
+	display: flex;
+	align-items: center;
+	gap: ${space[2]}px;
 
-const Of = () => <span>&nbsp;of&nbsp;</span>;
+	${from.phablet} {
+		gap: ${space[4]}px;
+	}
+`;
 
-const Space = () => (
-	<div
-		css={css`
-			${until.phablet} {
-				width: ${space[2]}px;
-			}
-			width: ${space[4]}px;
-		`}
-	/>
-);
+const bold = css`
+	font-weight: bold;
+`;
 
 const decidePaginationCss = (format: ArticleFormat): SerializedStyles => css`
 	color: ${decidePalette(format).text.pagination};
@@ -111,90 +70,115 @@ export const Pagination = ({
 	const cssOverrides = decidePaginationCss(format);
 
 	return (
-		<NavWrapper>
-			<FlexSection hide={currentPage === 1}>
-				<Hide above="phablet">
-					<LinkButton
-						size="small"
-						priority="tertiary"
-						icon={<SvgChevronLeftDouble />}
-						iconSide="left"
-						hideLabel={true}
-						href={newest}
-						cssOverrides={cssOverrides}
-					>
-						Newest
-					</LinkButton>
-				</Hide>
-				<Hide below="phablet">
-					<LinkButton
-						size="small"
-						priority="tertiary"
-						icon={<SvgChevronLeftDouble />}
-						iconSide="left"
-						href={newest}
-						cssOverrides={cssOverrides}
-					>
-						Newest
-					</LinkButton>
-				</Hide>
-				<Space />
-				<LinkButton
-					size="small"
-					priority="tertiary"
-					icon={<SvgChevronLeftSingle />}
-					hideLabel={true}
-					href={newer}
-					cssOverrides={cssOverrides}
+		<nav id={id} css={grid}>
+			{currentPage !== 1 && (
+				<section
+					style={{ gridArea: 'newer', justifySelf: 'start' }}
+					css={flexSection}
 				>
-					Previous
-				</LinkButton>
-			</FlexSection>
-			<FlexSection>
-				<Position>
-					<Bold>{currentPage}</Bold>
-					<Of />
-					<Bold>{totalPages}</Bold>
-				</Position>
-			</FlexSection>
-			<FlexSection hide={currentPage === totalPages}>
-				<LinkButton
-					size="small"
-					priority="tertiary"
-					icon={<SvgChevronRightSingle />}
-					hideLabel={true}
-					href={older}
-					cssOverrides={cssOverrides}
+					{!!newest && (
+						<>
+							<Hide from="phablet">
+								<LinkButton
+									size="small"
+									priority="tertiary"
+									icon={<SvgChevronLeftDouble />}
+									iconSide="left"
+									hideLabel={true}
+									href={newest}
+									cssOverrides={cssOverrides}
+								>
+									Newest
+								</LinkButton>
+							</Hide>
+							<Hide until="phablet">
+								<LinkButton
+									size="small"
+									priority="tertiary"
+									icon={<SvgChevronLeftDouble />}
+									iconSide="left"
+									href={newest}
+									cssOverrides={cssOverrides}
+								>
+									Newest
+								</LinkButton>
+							</Hide>
+						</>
+					)}
+					{!!newer && (
+						<LinkButton
+							size="small"
+							priority="tertiary"
+							icon={<SvgChevronLeftSingle />}
+							hideLabel={true}
+							href={newer}
+							cssOverrides={cssOverrides}
+						>
+							Previous
+						</LinkButton>
+					)}
+				</section>
+			)}
+
+			<section
+				style={{ gridArea: 'position' }}
+				css={css`
+					${textSans.small()}
+				`}
+			>
+				<strong css={bold}>{currentPage}</strong>
+				&nbsp;of&nbsp;
+				<strong css={bold}>{totalPages}</strong>
+			</section>
+
+			{currentPage !== totalPages && (
+				<section
+					style={{ gridArea: 'older', justifySelf: 'end' }}
+					css={flexSection}
 				>
-					Next
-				</LinkButton>
-				<Space />
-				<Hide above="phablet">
-					<LinkButton
-						size="small"
-						priority="tertiary"
-						icon={<SvgChevronRightDouble />}
-						iconSide="right"
-						href={oldest}
-						hideLabel={true}
-						cssOverrides={cssOverrides}
-					>
-						Oldest
-					</LinkButton>
-				</Hide>
-				<Hide below="phablet">
-					<LinkButton
-						size="small"
-						priority="tertiary"
-						icon={<SvgChevronRightDouble />}
-						iconSide="right"
-						href={oldest}
-						cssOverrides={cssOverrides}
-					>
-						Oldest
-					</LinkButton>
-				</Hide>
-			</FlexSection>
-		</NavWrapper>
+					{!!older && (
+						<LinkButton
+							size="small"
+							priority="tertiary"
+							icon={<SvgChevronRightSingle />}
+							hideLabel={true}
+							href={older}
+							cssOverrides={cssOverrides}
+						>
+							Next
+						</LinkButton>
+					)}
+					{!!oldest && (
+						<>
+							<Hide from="phablet">
+								<LinkButton
+									size="small"
+									priority="tertiary"
+									icon={<SvgChevronRightDouble />}
+									iconSide="right"
+									href={oldest}
+									hideLabel={true}
+									cssOverrides={cssOverrides}
+								>
+									Oldest
+								</LinkButton>
+							</Hide>
+							<Hide until="phablet">
+								<LinkButton
+									size="small"
+									priority="tertiary"
+									icon={<SvgChevronRightDouble />}
+									iconSide="right"
+									href={oldest}
+									cssOverrides={cssOverrides}
+								>
+									Oldest
+								</LinkButton>
+							</Hide>
+						</>
+					)}
+				</section>
+			)}
+		</nav>
 	);
 };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

- Refactor the `Pagination` to use CSS grid and remove unnecessary abstrations
- Adds a hash to the older and newer URLs so browser anchor to `#liveblog-navigation`

## Why?

Closes #8352 

## Screenshots

No visual change

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/76776/99bd1463-de48-4319-b0b4-f1cdd293566b
[after]: https://github.com/guardian/dotcom-rendering/assets/76776/823ceb37-5620-41a1-8cc7-2ca499fe3b31