### PR TITLE
Bump atoms rendering

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -60,7 +60,7 @@
 		"@emotion/react": "11.11.1",
 		"@emotion/server": "11.11.0",
 		"@guardian/ab-core": "5.0.0",
-		"@guardian/atoms-rendering": "32.2.0",
+		"@guardian/atoms-rendering": "32.2.3",
 		"@guardian/braze-components": "14.1.1",
 		"@guardian/bridget": "2.3.0",
 		"@guardian/browserslist-config": "5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3088,10 +3088,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/ab-core/-/ab-core-5.0.0.tgz#cce32ff4cdfb6b24c013723bf352dcd61135d34d"
   integrity sha512-Td5gtK2sARl+fXj1Qe6RuFqf/zxuZjW1q2Jck09zXPIfMgU+sJoTi549zbNeC1cldCBhPWy/qPQ0r+8klfF7jg==
 
-"@guardian/atoms-rendering@32.2.0":
-  version "32.2.0"
-  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-32.2.0.tgz#00db2120252060e5e0c5b3b4b45897d18864cec4"
-  integrity sha512-14BFR+rb6iQ4qYcqX/aPt/C3iVYSfKrHZj5ps9EbDeOx8dKejohsLyPiPKaNkPj+M0CTH42r8kcOjatx4Yx1yw==
+"@guardian/atoms-rendering@32.2.3":
+  version "32.2.3"
+  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-32.2.3.tgz#2abea32bf948844988c4a9fe4b4edd1c8c5d4e12"
+  integrity sha512-mwxDvJys+lbe7GyzyK7zi7dcjddYotGtKh7kOsYXZwDy4E5ptJ1m2BJwT7dXnzZ40B+Idys7rK3pyLynIIiqZg==
   dependencies:
     is-mobile "3.1.1"
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Bumps the version of atoms rendering

## Why?
Pulls in a fix to the youtube atom that prevents the play icon from shifting on hover. 

## Screenshots
| | Before | After |
| --|--------|--------|
| No shifting of icon (fullscreen is easier to see)  |<video src="https://github.com/guardian/csnx/assets/26366706/51641d8d-5895-493c-805b-edeb444ee9b1"> | <video src="https://github.com/guardian/csnx/assets/26366706/b35847b3-901e-46a1-aaff-04af659fd007"> |
| Positioning of icon |<img width="748" alt="image" src="https://github.com/guardian/csnx/assets/26366706/19e1c61d-914b-4142-92c0-73efbf852a70"> | <img width="746" alt="image" src="https://github.com/guardian/csnx/assets/26366706/9352949c-d033-4de7-8609-be86f97c7103"> |
<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
