### PR TITLE
bump braze-components dependency to v14.1.1

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -61,7 +61,7 @@
 		"@emotion/server": "11.11.0",
 		"@guardian/ab-core": "5.0.0",
 		"@guardian/atoms-rendering": "32.2.0",
-		"@guardian/braze-components": "14.1.0",
+		"@guardian/braze-components": "14.1.1",
 		"@guardian/bridget": "2.3.0",
 		"@guardian/browserslist-config": "5.0.0",
 		"@guardian/cdk": "49.5.0",

--- a/dotcom-rendering/src/components/StickyBottomBanner/BrazeBanner.stories.tsx
+++ b/dotcom-rendering/src/components/StickyBottomBanner/BrazeBanner.stories.tsx
@@ -254,6 +254,7 @@ export const BrazeStyleableBannerComponent = (
 			styleHighlightBackground: args.styleHighlightBackground,
 			buttonText: args.buttonText,
 			buttonUrl: args.buttonUrl,
+			showPaymentIcons: args.showPaymentIcons,
 			styleButton: args.styleButton,
 			styleButtonBackground: args.styleButtonBackground,
 			styleButtonHover: args.styleButtonHover,
@@ -302,6 +303,7 @@ BrazeStyleableBannerComponent.args = {
 	buttonText: 'Take a look back',
 	buttonUrl:
 		'https://www.theguardian.com/info/ng-interactive/2020/dec/21/the-guardian-in-2020?INTCMP=gdnwb_mrtn_banner_edtrl_MK_SU_WorkingReport2020Canvas',
+	showPaymentIcons: 'false',
 	styleButton: '#ffffff',
 	styleButtonBackground: '#052962',
 	styleButtonHover: '#234b8a',

--- a/yarn.lock
+++ b/yarn.lock
@@ -3095,10 +3095,10 @@
   dependencies:
     is-mobile "3.1.1"
 
-"@guardian/braze-components@14.1.0":
-  version "14.1.0"
-  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-14.1.0.tgz#3b362f66cc4c37920ed452187a7cc33dec9314a0"
-  integrity sha512-SsTrqdYfNq9k63VhicCrnF0WhWCwhxZKyERVzTt5NMt4mG4iWqrrpa+G7SdVQockf3OYEizv4WJtPRt/N1F9pg==
+"@guardian/braze-components@14.1.1":
+  version "14.1.1"
+  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-14.1.1.tgz#12672e3992ad3eab3bade848861ca01631a0edf5"
+  integrity sha512-wHuJwdOC2hsTBie+zWJYFyasP4fOJXOPcKXpN2Cp+GlljPah3YtS2Fbgn8pcxxt8d5JKO9ra7sHKvX8FNxkAyg==
 
 "@guardian/bridget@2.3.0":
   version "2.3.0"


### PR DESCRIPTION
## What does this change?
This PR updates the braze-components dependency to latest version.

The changes in braze-components are minor and do not affect the layout of other DCR components
