### PR TITLE
fix: change deferUntil to visible for AustralianTerritorySwitcher

### DIFF
--- a/dotcom-rendering/src/components/FrontSection.tsx
+++ b/dotcom-rendering/src/components/FrontSection.tsx
@@ -695,7 +695,7 @@ export const FrontSection = ({
 			>
 				{isString(targetedTerritory) &&
 				isAustralianTerritory(targetedTerritory) ? (
-					<Island deferUntil="interaction">
+					<Island deferUntil="visible">
 						<AustralianTerritorySwitcher
 							targetedTerritory={targetedTerritory}
 						/>


### PR DESCRIPTION
There seems to be a bug with the `deferUntil="interaction"` as seem on the live site. This has been reproduced, but is intermittent and I can't figure out what the conditions are.

While this seems like the right `deferUntil` - I suggest we change it to `visible` while we try to work out the bug.

It hasn't been reported on any other Islands with the same `deferUntil`.
