### PR TITLE
Clean up team codes in the matchStats doughnut

### DIFF
--- a/dotcom-rendering/src/components/MatchStats.tsx
+++ b/dotcom-rendering/src/components/MatchStats.tsx
@@ -273,6 +273,18 @@ const H4 = ({ children }: { children: React.ReactNode }) => (
 	</h4>
 );
 
+const cleanTeamCode = (code: string) => {
+	switch (code) {
+		case 'JAP':
+			return 'JPN';
+		case 'HOL':
+		case 'NET':
+			return 'NED';
+		default:
+			return code;
+	}
+};
+
 const DecideDoughnut = ({
 	home,
 	away,
@@ -285,12 +297,12 @@ const DecideDoughnut = ({
 	const sections = [
 		{
 			value: home.possession,
-			label: home.codename,
+			label: cleanTeamCode(home.codename),
 			color: home.colours,
 		},
 		{
 			value: away.possession,
-			label: away.codename,
+			label: cleanTeamCode(away.codename),
 			color: away.colours,
 		},
 	].reverse();


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Adds a helper to transform Japan's team code to match the functionality of frontend
https://github.com/guardian/frontend/blob/6378e2bef1297f0240ff74118ce26a9d42b28c91/sport/app/football/model/model.scala#L185.

I've also updated the Netherlands code, as previously we were getting NET from pa, but according to the [FIFA country codes ](https://en.wikipedia.org/wiki/List_of_FIFA_country_codes#:~:text=%C2%A0Netherlands-,NED,-New%20Caledonia) we should be using NED

## Why?
A user pointed out that the previous abbreviation for Japan  is an offensive term

## Screenshots

| | Before      | After      |
| -| ----------- | ---------- |
Japan | <img width="914" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/d610b1ae-f27f-4bc2-af6c-33e837e7050b"> | <img width="936" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/83873a40-a6ac-4456-b785-91738ef381d8"> |
The Netherlands | <img width="986" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/026c2669-94f1-4d3a-80af-5f2a852ec26c"> | <img width="986" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/e22b3dd7-d55c-4c25-826c-7a393d8b89f4"> |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
