### PR TITLE
Extend the team codename cleaner

### DIFF
--- a/dotcom-rendering/src/components/GetMatchNav.importable.tsx
+++ b/dotcom-rendering/src/components/GetMatchNav.importable.tsx
@@ -5,6 +5,7 @@ import type { SWRConfiguration } from 'swr';
 import { useApi } from '../lib/useApi';
 import type { TagType } from '../types/tag';
 import { ArticleHeadline } from './ArticleHeadline';
+import { cleanTeamData } from './GetMatchStats.importable';
 import { MatchNav } from './MatchNav';
 import { Placeholder } from './Placeholder';
 
@@ -87,8 +88,8 @@ export const GetMatchNav = ({
 	if (data) {
 		return (
 			<MatchNav
-				homeTeam={data.homeTeam}
-				awayTeam={data.awayTeam}
+				homeTeam={cleanTeamData(data.homeTeam)}
+				awayTeam={cleanTeamData(data.awayTeam)}
 				comments={data.comments}
 			/>
 		);

--- a/dotcom-rendering/src/components/GetMatchStats.importable.tsx
+++ b/dotcom-rendering/src/components/GetMatchStats.importable.tsx
@@ -11,6 +11,43 @@ type Props = {
 
 const Loading = () => <Placeholder height={800} />;
 
+const cleanTeamCodes = (team: TeamType): string => {
+	// Need to check the team name as South Korea and South Africa both have SOU as their code
+	switch (team.name) {
+		case 'China PR':
+			return 'CHN';
+		case 'Costa Rica':
+			return 'CRC';
+		case 'Japan':
+			return 'JPN';
+		case 'Morocco':
+			return 'MAR';
+		case 'Netherlands':
+			return 'NED';
+		case 'New Zealand':
+			return 'NZL';
+		case 'Nigeria':
+			return 'NGA';
+		case 'Rep of Ireland':
+			return 'IRL';
+		case 'South Africa':
+			return 'RSA';
+		case 'South Korea':
+			return 'KOR';
+		case 'Spain':
+			return 'ESP';
+		case 'Switzerland':
+			return 'SUI';
+		default:
+			return team.codename;
+	}
+};
+
+export const cleanTeamData = (team: TeamType): TeamType => ({
+	...team,
+	codename: cleanTeamCodes(team),
+});
+
 /**
  * # Get Match Stats
  *
@@ -46,8 +83,8 @@ export const GetMatchStats = ({ matchUrl, format }: Props) => {
 	if (data) {
 		return (
 			<MatchStats
-				home={data.homeTeam}
-				away={data.awayTeam}
+				home={cleanTeamData(data.homeTeam)}
+				away={cleanTeamData(data.awayTeam)}
 				format={format}
 			/>
 		);

--- a/dotcom-rendering/src/components/MatchStats.tsx
+++ b/dotcom-rendering/src/components/MatchStats.tsx
@@ -273,18 +273,6 @@ const H4 = ({ children }: { children: React.ReactNode }) => (
 	</h4>
 );
 
-const cleanTeamCode = (code: string) => {
-	switch (code) {
-		case 'JAP':
-			return 'JPN';
-		case 'HOL':
-		case 'NET':
-			return 'NED';
-		default:
-			return code;
-	}
-};
-
 const DecideDoughnut = ({
 	home,
 	away,
@@ -297,12 +285,12 @@ const DecideDoughnut = ({
 	const sections = [
 		{
 			value: home.possession,
-			label: cleanTeamCode(home.codename),
+			label: home.codename,
 			color: home.colours,
 		},
 		{
 			value: away.possession,
-			label: cleanTeamCode(away.codename),
+			label: away.codename,
 			color: away.colours,
 		},
 	].reverse();


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
This extends the team codename cleaner to fix the abbreviations for more teams

## Why?
The abbreviations provided by PA don't line up with the list of [FIFA country codes](https://en.wikipedia.org/wiki/List_of_FIFA_country_codes)

Resolves https://github.com/guardian/dotcom-rendering/issues/8364

## Screenshots

|Country | Before      | After      |
| --| ----------- | ---------- |
|New Zealand – NZL |<img width="859" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/be4609d3-0f90-48f8-85cb-876880a5234f"> |<img width="859" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/6e99991b-665b-4bd1-92cf-9446ff7ff369"> |
|Switzerland – SUI|<img width="859" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/6627cc94-6624-4aeb-b241-ae06f5f5f686"> |<img width="859" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/dfdf5d3b-5f2b-45b1-b2a2-c6084ccca96e"> |
|Republic of Ireland – IRL|<img width="859" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/8ba349a4-63ed-4400-9d11-8f68a04a8545"> |<img width="859" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/3695225d-b27d-4ea1-a4e8-e86c197082d2"> |
|Nigeria – NGA|<img width="859" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/6a00e0cd-7eaa-416c-a8e0-d375d9f934fe"> |<img width="859" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/eada065d-b8ed-420b-be55-6b45904fbc4b"> |
|Spain – ESP|<img width="859" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/de6b5754-6590-48fd-a767-02f1a3e0aa2c"> |<img width="859" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/a4d08f58-f96b-4f52-a8a8-eeaf4f0f9b8d"> |
|Costa Rica – CRC|<img width="859" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/11f0ef57-35e4-4a29-ac76-0202c6016688"> |<img width="859" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/13b5c3fa-3d74-415e-a30c-413c0c351197"> |
|China – CHN|<img width="859" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/a14fb742-2f9a-4111-8db3-8ad9fa74a971"> |<img width="859" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/2d08d041-ed47-43f8-a3c3-31787683aac1"> |
|Netherlands – NED|<img width="859" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/2b346811-2116-48c1-ac11-7c0b48faef74"> |<img width="859" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/b2e8a2ae-6437-4af2-9ba3-b097dc503261"> |
|South Africa – RSA|<img width="859" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/05dfeaba-5a91-46c7-842a-570f62af1e64"> |<img width="859" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/b022967d-16ad-4bb0-9da0-e6fba5385578"> |
|Morocco – MAR|<img width="859" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/cb67f1f8-2c2a-4c13-bc5b-4ce25744280a"> |<img width="859" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/8666a83d-3ea9-4f09-87b3-502e17bc9eee"> |
|South Korea – KOR|<img width="859" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/5e5520cf-b0df-486d-88ef-18f59a3ed8ab"> |<img width="859" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/ec578200-f690-4bd1-aaff-979362c334b3"> |

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
