### PR TITLE
Stop page jumping to top on "Privacy settings" link click

### DIFF
--- a/dotcom-rendering/src/lib/injectPrivacySettingsLink.ts
+++ b/dotcom-rendering/src/lib/injectPrivacySettingsLink.ts
@@ -38,10 +38,10 @@ export const injectPrivacySettingsLink = (): void => {
 						newPrivacyLinkListItem,
 					);
 
-					newPrivacyLink.addEventListener(
-						'click',
-						cmp.showPrivacyManager,
-					);
+					newPrivacyLink.addEventListener('click', (event) => {
+						event.preventDefault();
+						cmp.showPrivacyManager();
+					});
 				})
 				.catch((e) =>
 					console.error(`privacy settings - error: ${String(e)}`),


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Prevents the default behaviour of the browser to go to the top of the page when the "Privacy Settings" link is clicked. This stops the flash of content from the top of the page when the link is clicked.

## Why?

To provide a better experience for users.

## Screenshots

https://github.com/guardian/dotcom-rendering/assets/9574885/67397086-6e83-4452-ae29-d4e3f0f58768

https://github.com/guardian/dotcom-rendering/assets/9574885/8f43a8e0-8dd4-4848-a9e3-f67047ad1add

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
