### PR TITLE
Use `@guardian/libs` new `startPerformanceMeasure` for unified duration measurements

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -72,7 +72,7 @@
 		"@guardian/eslint-config-typescript": "6.0.1",
 		"@guardian/eslint-plugin-source-react-components": "17.0.0",
 		"@guardian/identity-auth": "0.2.0",
-		"@guardian/libs": "15.3.0",
+		"@guardian/libs": "15.4.0",
 		"@guardian/prettier": "4.0.0",
 		"@guardian/shimport": "1.0.2",
 		"@guardian/source-foundations": "12.0.0",

--- a/dotcom-rendering/src/client/startup.ts
+++ b/dotcom-rendering/src/client/startup.ts
@@ -1,18 +1,15 @@
-import { log } from '@guardian/libs';
-import { measureDuration } from './measureDuration';
+import { log, startPerformanceMeasure } from '@guardian/libs';
 
 const measure = (name: string, task: () => Promise<void>): void => {
-	const { start, end } = measureDuration(name);
-
-	start();
+	const { endPerformanceMeasure } = startPerformanceMeasure('dotcom', name);
 
 	task()
 		.then(() => {
-			const duration = end();
+			const duration = endPerformanceMeasure();
 			log('dotcom', `🥾 Booted ${name} in ${duration}ms`);
 		})
 		.catch(() => {
-			const duration = end();
+			const duration = endPerformanceMeasure();
 			log('dotcom', `🤒 Failed to boot ${name} in ${duration}ms`);
 		});
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3195,10 +3195,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/identity-auth/-/identity-auth-0.2.0.tgz#aaad1667095c5ba4bc7610e1a119ec007c249307"
   integrity sha512-4bKanidGEH+VKaYQNNcS2y8ubmxfzMicr+wiIDsdosxicn3mLA1Hw0kHiaZm1vroo3JKp4442qVba3Z8Ot5vPA==
 
-"@guardian/libs@15.3.0":
-  version "15.3.0"
-  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-15.3.0.tgz#fbb133b33a9704bb5699ea2be5a9fcd556e7a5bb"
-  integrity sha512-qWQy6L6HsXgZEJwVREWLmsJRZ6jwkQM5d6kSXV+arlQipkrRMy3n2eacNTqC/bn7WTBcVBPkbLWFslTsig9Vyg==
+"@guardian/libs@15.4.0":
+  version "15.4.0"
+  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-15.4.0.tgz#725191fab57a036f7180f7e3a127214d0c20736c"
+  integrity sha512-UnLLRnVNHhuBE8uRSx3b0rjpjovFK7lSbnfCZ5jZqabEutkZimkNdW4DX95y3QWDHJT/faHo3kV7heiXKbiO3g==
 
 "@guardian/libs@^10.0.0":
   version "10.1.1"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Replace usage of `measureDuration` relevant to the WebX/`dotcom` team with the [new `startPerformanceMeasure` api from @guardian/libs](https://github.com/guardian/csnx/releases/tag/%40guardian%2Flibs%4015.4.0)

## Why?

The new `startPerformanceMeasure` helper creates a simpler API that’s impossible to misuse.

We plan on recording these measurements to our data warehouse soon, and a consistent naming will help.

## Screenshots

| Before (Marks) | After (Measure) |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/76776/25340b94-e8f6-408c-8015-3ede345d10df
[after]: https://github.com/guardian/dotcom-rendering/assets/76776/077a7769-e8d1-4d1f-8ed2-39970c11f758