### PR TITLE
fix: add timezone to edition and use in container title

### DIFF
--- a/dotcom-rendering/src/components/ContainerTitle.tsx
+++ b/dotcom-rendering/src/components/ContainerTitle.tsx
@@ -9,7 +9,7 @@ import {
 	until,
 } from '@guardian/source-foundations';
 import { decideContainerOverrides } from '../lib/decideContainerOverrides';
-import type { EditionId } from '../lib/edition';
+import { type EditionId, getEditionFromId } from '../lib/edition';
 import type { DCRContainerPalette } from '../types/front';
 import type { Colour } from '../types/palette';
 import { localisedTitle } from './Localisation';
@@ -102,6 +102,9 @@ export const ContainerTitle = ({
 		containerPalette && decideContainerOverrides(containerPalette);
 
 	const now = new Date();
+
+	const { timeZone } = getEditionFromId(editionId ?? 'UK');
+
 	return (
 		<div css={marginStyles}>
 			{url ? (
@@ -132,7 +135,10 @@ export const ContainerTitle = ({
 							overrides?.text.containerDate ?? neutral[0],
 						)}
 					>
-						{now.toLocaleDateString('en-GB', { weekday: 'long' })}
+						{now.toLocaleString('en-GB', {
+							weekday: 'long',
+							timeZone,
+						})}
 					</span>
 					<span
 						css={[
@@ -145,10 +151,11 @@ export const ContainerTitle = ({
 							bottomMargin,
 						]}
 					>
-						{now.toLocaleDateString('en-GB', {
+						{now.toLocaleString('en-GB', {
 							day: 'numeric',
 							month: 'long',
 							year: 'numeric',
+							timeZone,
 						})}
 					</span>
 				</div>

--- a/dotcom-rendering/src/lib/edition.ts
+++ b/dotcom-rendering/src/lib/edition.ts
@@ -16,6 +16,7 @@ export const editionList = [
 		longTitle: 'UK edition',
 		title: 'UK edition',
 		locale: 'en-gb',
+		timeZone: 'Europe/London',
 	},
 	{
 		url: '/preference/edition/us',
@@ -23,6 +24,7 @@ export const editionList = [
 		longTitle: 'US edition',
 		title: 'US edition',
 		locale: 'en-us',
+		timeZone: 'America/New_York',
 	},
 	{
 		url: '/preference/edition/au',
@@ -30,6 +32,7 @@ export const editionList = [
 		longTitle: 'Australia edition',
 		title: 'AU edition',
 		locale: 'en-au',
+		timeZone: 'Australia/Sydney',
 	},
 	{
 		url: '/preference/edition/int',
@@ -37,6 +40,7 @@ export const editionList = [
 		longTitle: 'International edition',
 		title: 'International edition',
 		locale: 'en-gb',
+		timeZone: 'Europe/London',
 	},
 	{
 		url: '/preference/edition/eur',
@@ -44,6 +48,7 @@ export const editionList = [
 		longTitle: 'Europe edition',
 		title: 'Europe edition',
 		locale: 'en-gb',
+		timeZone: 'Europe/Paris',
 	},
 ] as const;
 

--- a/dotcom-rendering/src/model/extract-nav.ts
+++ b/dotcom-rendering/src/model/extract-nav.ts
@@ -16,6 +16,7 @@ export interface LinkType extends BaseLinkType {
 export interface EditionLinkType extends LinkType {
 	editionId: EditionId;
 	locale: string;
+	timeZone: string;
 }
 
 export interface PillarLinkType extends LinkType {


### PR DESCRIPTION
`Co-authored-by: Jamie B <53781962+JamieB-gu@users.noreply.github.com>`

<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Add `timeZone` information to editions and use the edition to format the date in the `ContainerTitle`.

## Why?

Incorrect date was showing on network front for Australia.
Fixes #8371 

