### PR TITLE
Ensure liveblog right island is rendered on the server

### DIFF
--- a/dotcom-rendering/docs/architecture/027-better-partial-hydration.md
+++ b/dotcom-rendering/docs/architecture/027-better-partial-hydration.md
@@ -12,7 +12,7 @@ See: https://addyosmani.com/blog/rehydration/
 
 ### Before
 
-We used App.tsx which was a global react app that let us have shared state between isands. For lazy loading we employed React Loadable Components. From there, we used a component called `HydrateOnce` which was designed to only execute once even though the global react was triggering re-renders as state changed.
+We used App.tsx which was a global react app that let us have shared state between islands. For lazy loading we employed React Loadable Components. From there, we used a component called `HydrateOnce` which was designed to only execute once even though the global react was triggering re-renders as state changed.
 
 This was problematic because sometimes you had dependencies on global state so to get around this we added the `waitFor` prop.
 
@@ -27,7 +27,7 @@ To create a new island you had to:
 
 ### After
 
-PRs #3629 & #3784 simplify the process of partial hydration by moving the logic out of a React app and into a simple script tag. This removes the need to manage re-renders, can use standard dynamic imports and reduces the effort needed to use.
+PRs #[3629](https://github.com/guardian/dotcom-rendering/pull/3629) & [#3784](https://github.com/guardian/dotcom-rendering/pull/3784) simplify the process of partial hydration by moving the logic out of a React app and into a simple script tag. This removes the need to manage re-renders, can use standard dynamic imports and reduces the effort needed to use.
 
 To create a new island you now:
 

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -1114,7 +1114,7 @@ export const LiveLayout = ({
 								>
 									<RightColumn>
 										{renderAds && (
-											<Island>
+											<Island deferUntil="visible">
 												<LiveblogRightAdSlots
 													display={format.display}
 													isPaidContent={

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -1114,10 +1114,7 @@ export const LiveLayout = ({
 								>
 									<RightColumn>
 										{renderAds && (
-											<Island
-												clientOnly={true}
-												deferUntil="visible"
-											>
+											<Island clientOnly={true}>
 												<LiveblogRightAdSlots
 													display={format.display}
 													isPaidContent={

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -1114,7 +1114,7 @@ export const LiveLayout = ({
 								>
 									<RightColumn>
 										{renderAds && (
-											<Island clientOnly={true}>
+											<Island>
 												<LiveblogRightAdSlots
 													display={format.display}
 													isPaidContent={


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

The liveblog right island is no longer only rendered on the client.

## Why?

The right ad slot is a fixed slot, so in order for an ad to be inserted in to this slot, it needs to be rendered on the server.
