### PR TITLE
Discussion’s `Comment` refactors and bugfixes

### DIFF
--- a/dotcom-rendering/src/components/Discussion.tsx
+++ b/dotcom-rendering/src/components/Discussion.tsx
@@ -4,7 +4,7 @@ import { neutral, space } from '@guardian/source-foundations';
 import { SvgPlus } from '@guardian/source-react-components';
 import { EditorialButton } from '@guardian/source-react-components-development-kitchen';
 import { useEffect, useState } from 'react';
-import { App as Comments } from '../discussion-rendering/App';
+import { Comments } from '../discussion-rendering/Comments';
 import type { SignedInUser } from '../discussion-rendering/discussionTypes';
 import { decidePalette } from '../lib/decidePalette';
 import { getCommentContext } from '../lib/getCommentContext';

--- a/dotcom-rendering/src/components/DiscussionWhenSignedIn.tsx
+++ b/dotcom-rendering/src/components/DiscussionWhenSignedIn.tsx
@@ -22,9 +22,8 @@ export const DiscussionWhenSignedIn = ({ authStatus, ...props }: Props) => {
 		{},
 		options,
 	);
-	if (!data) return null;
 
-	const user = { profile: data.userProfile, authStatus };
+	const user = data ? { profile: data.userProfile, authStatus } : undefined;
 
 	return <Discussion user={user} {...props} />;
 };

--- a/dotcom-rendering/src/discussion-rendering/Comments.stories.tsx
+++ b/dotcom-rendering/src/discussion-rendering/Comments.stories.tsx
@@ -1,9 +1,9 @@
 import { css } from '@emotion/react';
 import { Pillar } from '@guardian/libs';
-import { App } from './App';
+import { Comments } from './Comments';
 import type { SignedInUser } from './discussionTypes';
 
-export default { component: App, title: 'Discussion/App' };
+export default { component: Comments, title: 'Discussion/App' };
 
 const aUser: SignedInUser = {
 	profile: {
@@ -30,7 +30,7 @@ export const LoggedOutHiddenPicks = () => (
 			max-width: 620px;
 		`}
 	>
-		<App
+		<Comments
 			shortUrl="p/39f5z"
 			baseUrl="https://discussion.theguardian.com/discussion-api"
 			pillar={Pillar.Culture}
@@ -55,7 +55,7 @@ export const InitialPage = () => (
 			max-width: 620px;
 		`}
 	>
-		<App
+		<Comments
 			shortUrl="p/39f5z"
 			initialPage={3}
 			baseUrl="https://discussion.theguardian.com/discussion-api"
@@ -81,7 +81,7 @@ export const Overrides = () => (
 			max-width: 620px;
 		`}
 	>
-		<App
+		<Comments
 			shortUrl="p/39f5z"
 			initialPage={3}
 			pageSizeOverride={50}
@@ -109,7 +109,7 @@ export const LoggedInHiddenNoPicks = () => (
 			max-width: 620px;
 		`}
 	>
-		<App
+		<Comments
 			shortUrl="p/abc123"
 			pillar={Pillar.News}
 			isClosedForComments={false}
@@ -136,7 +136,7 @@ export const LoggedIn = () => (
 			max-width: 620px;
 		`}
 	>
-		<App
+		<Comments
 			shortUrl="p/abc123"
 			pillar={Pillar.News}
 			isClosedForComments={false}
@@ -162,7 +162,7 @@ export const LoggedInShortDiscussion = () => (
 			max-width: 620px;
 		`}
 	>
-		<App
+		<Comments
 			shortUrl="p/39f5a" // Two comments"
 			pillar={Pillar.News}
 			isClosedForComments={false}
@@ -188,7 +188,7 @@ export const LoggedOutHiddenNoPicks = () => (
 			max-width: 620px;
 		`}
 	>
-		<App
+		<Comments
 			shortUrl="p/abc123"
 			pillar={Pillar.Sport}
 			isClosedForComments={false}
@@ -214,7 +214,7 @@ export const Closed = () => (
 			max-width: 620px;
 		`}
 	>
-		<App
+		<Comments
 			shortUrl="p/39f5z"
 			baseUrl="https://discussion.theguardian.com/discussion-api"
 			pillar={Pillar.Lifestyle}
@@ -240,7 +240,7 @@ export const NoComments = () => (
 			max-width: 620px;
 		`}
 	>
-		<App
+		<Comments
 			shortUrl="p/39f5x" // A discussion with zero comments
 			baseUrl="https://discussion.theguardian.com/discussion-api"
 			pillar={Pillar.Culture}
@@ -265,7 +265,7 @@ export const LegacyDiscussion = () => (
 			max-width: 620px;
 		`}
 	>
-		<App
+		<Comments
 			shortUrl="p/32255" // A 'legacy' discussion that doesn't allow threading
 			baseUrl="https://discussion.theguardian.com/discussion-api"
 			pillar={Pillar.Culture}

--- a/dotcom-rendering/src/discussion-rendering/Comments.test.tsx
+++ b/dotcom-rendering/src/discussion-rendering/Comments.test.tsx
@@ -6,14 +6,14 @@ import {
 	waitForElementToBeRemoved,
 } from '@testing-library/react';
 import { mockRESTCalls } from '../lib/mockRESTCalls';
-import { App } from './App';
+import { Comments } from './Comments';
 
 mockRESTCalls();
 
 describe('App', () => {
 	it('should not render the comment form if user is logged out', async () => {
 		render(
-			<App
+			<Comments
 				shortUrl="p/39f5z"
 				baseUrl="https://discussion.theguardian.com/discussion-api"
 				pillar={Pillar.Culture}

--- a/dotcom-rendering/src/discussion-rendering/Comments.tsx
+++ b/dotcom-rendering/src/discussion-rendering/Comments.tsx
@@ -213,8 +213,7 @@ const writeMutes = (mutes: string[]) => {
 	}
 };
 
-//todo: should probably rename this to Comments?
-export const App = ({
+export const Comments = ({
 	baseUrl,
 	shortUrl,
 	pillar,

--- a/dotcom-rendering/src/discussion-rendering/Comments.tsx
+++ b/dotcom-rendering/src/discussion-rendering/Comments.tsx
@@ -248,7 +248,6 @@ export const Comments = ({
 		expanded || window.location.hash === '#comments',
 	);
 	const [loading, setLoading] = useState<boolean>(true);
-	const [loadingMore, setLoadingMore] = useState<boolean>(false);
 	const [totalPages, setTotalPages] = useState<number>(0);
 	const [page, setPage] = useState<number>(initialPage ?? 1);
 	const [picks, setPicks] = useState<CommentType[]>([]);
@@ -260,6 +259,8 @@ export const Comments = ({
 	const [commentCount, setCommentCount] = useState<number>(0);
 	const [mutes, setMutes] = useState<string[]>(readMutes());
 
+	const loadingMore = !loading && comments.length !== numberOfCommentsToShow;
+
 	useEffect(() => {
 		if (isExpanded) {
 			// We want react to complete the current work and render, without trying to batch this update
@@ -269,7 +270,6 @@ export const Comments = ({
 			// the remaining comments.
 			const timer = setTimeout(() => {
 				setNumberOfCommentsToShow(comments.length);
-				setLoadingMore(false);
 			}, 0);
 			return () => clearTimeout(timer);
 		} else return;
@@ -286,7 +286,6 @@ export const Comments = ({
 		//todo: come back and handle the error case
 		void getDiscussion(shortUrl, { ...filters, page }).then((json) => {
 			setLoading(false);
-			setLoadingMore(true);
 			if (json && json.status !== 'error') {
 				setComments(
 					// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- we'll come back and fix this by properly parsing the json
@@ -394,9 +393,9 @@ export const Comments = ({
 	};
 
 	const onAddComment = (comment: CommentType) => {
-		comments.pop(); // Remove last item from our local array
+		// Remove last item from our local array
 		// Replace it with this new comment at the start
-		setComments([comment, ...comments]);
+		setComments([comment, ...comments.slice(0, -1)]);
 
 		if (!isExpanded) {
 			// It's possible to post a comment without the view being expanded

--- a/dotcom-rendering/src/discussion-rendering/Comments.tsx
+++ b/dotcom-rendering/src/discussion-rendering/Comments.tsx
@@ -420,110 +420,150 @@ export const Comments = ({
 
 	if (!isExpanded) {
 		return (
-			<>
-				<div css={commentContainerStyles} data-component="discussion">
-					{picks.length !== 0 ? (
-						<div css={picksWrapper}>
-							<TopPicks
-								pillar={pillar}
-								comments={picks.slice(0, 2)}
-								authStatus={user?.authStatus}
-								onPermalinkClick={onPermalinkClick}
-								onRecommend={onRecommend}
-							/>
-						</div>
-					) : (
-						<>
-							<Filters
-								pillar={pillar}
-								filters={filters}
-								onFilterChange={onFilterChange}
+			<div data-component="discussion" css={commentContainerStyles}>
+				{picks.length !== 0 ? (
+					<div css={picksWrapper}>
+						<TopPicks
+							pillar={pillar}
+							comments={picks.slice(0, 2)}
+							authStatus={user?.authStatus}
+							onPermalinkClick={onPermalinkClick}
+							onRecommend={onRecommend}
+						/>
+					</div>
+				) : (
+					<>
+						<Filters
+							pillar={pillar}
+							filters={filters}
+							onFilterChange={onFilterChange}
+							totalPages={totalPages}
+							commentCount={commentCount}
+						/>
+						{showPagination && (
+							<Pagination
 								totalPages={totalPages}
+								currentPage={page}
+								setCurrentPage={(newPage: number) => {
+									onPageChange(newPage);
+								}}
 								commentCount={commentCount}
+								filters={filters}
 							/>
-							{showPagination && (
-								<Pagination
-									totalPages={totalPages}
-									currentPage={page}
-									setCurrentPage={(newPage: number) => {
-										onPageChange(newPage);
-									}}
-									commentCount={commentCount}
-									filters={filters}
-								/>
-							)}
-							{!comments.length ? (
-								<NoComments />
-							) : (
-								<ul css={commentContainerStyles}>
-									{comments.slice(0, 2).map((comment) => (
-										<li key={comment.id}>
-											<CommentContainer
-												comment={comment}
-												pillar={pillar}
-												isClosedForComments={
-													isClosedForComments
-												}
-												shortUrl={shortUrl}
-												user={user}
-												threads={filters.threads}
-												commentBeingRepliedTo={
-													commentBeingRepliedTo
-												}
-												setCommentBeingRepliedTo={
-													setCommentBeingRepliedTo
-												}
-												mutes={mutes}
-												toggleMuteStatus={
-													toggleMuteStatus
-												}
-												onPermalinkClick={
-													onPermalinkClick
-												}
-												onRecommend={onRecommend}
-											/>
-										</li>
-									))}
-								</ul>
-							)}
-						</>
-					)}
-				</div>
-			</>
+						)}
+						{!comments.length ? (
+							<NoComments />
+						) : (
+							<ul css={commentContainerStyles}>
+								{comments.slice(0, 2).map((comment) => (
+									<li key={comment.id}>
+										<CommentContainer
+											comment={comment}
+											pillar={pillar}
+											isClosedForComments={
+												isClosedForComments
+											}
+											shortUrl={shortUrl}
+											user={user}
+											threads={filters.threads}
+											commentBeingRepliedTo={
+												commentBeingRepliedTo
+											}
+											setCommentBeingRepliedTo={
+												setCommentBeingRepliedTo
+											}
+											mutes={mutes}
+											toggleMuteStatus={toggleMuteStatus}
+											onPermalinkClick={onPermalinkClick}
+											onRecommend={onRecommend}
+										/>
+									</li>
+								))}
+							</ul>
+						)}
+					</>
+				)}
+			</div>
 		);
 	}
 
 	return (
-		<>
-			<div data-component="discussion" css={commentColumnWrapperStyles}>
-				{user && !isClosedForComments && (
-					<CommentForm
-						pillar={pillar}
-						shortUrl={shortUrl}
-						onAddComment={onAddComment}
-						user={user}
-						onComment={onComment}
-						onReply={onReply}
-						onPreview={onPreview}
-					/>
-				)}
-				{!!picks.length && (
-					<TopPicks
-						pillar={pillar}
-						comments={picks}
-						authStatus={user?.authStatus}
-						onPermalinkClick={onPermalinkClick}
-						onRecommend={onRecommend}
-					/>
-				)}
-				<Filters
+		<div data-component="discussion" css={commentColumnWrapperStyles}>
+			{user && !isClosedForComments && (
+				<CommentForm
 					pillar={pillar}
-					filters={filters}
-					onFilterChange={onFilterChange}
-					totalPages={totalPages}
-					commentCount={commentCount}
+					shortUrl={shortUrl}
+					onAddComment={onAddComment}
+					user={user}
+					onComment={onComment}
+					onReply={onReply}
+					onPreview={onPreview}
 				/>
-				{showPagination && (
+			)}
+			{!!picks.length && (
+				<TopPicks
+					pillar={pillar}
+					comments={picks}
+					authStatus={user?.authStatus}
+					onPermalinkClick={onPermalinkClick}
+					onRecommend={onRecommend}
+				/>
+			)}
+			<Filters
+				pillar={pillar}
+				filters={filters}
+				onFilterChange={onFilterChange}
+				totalPages={totalPages}
+				commentCount={commentCount}
+			/>
+			{showPagination && (
+				<Pagination
+					totalPages={totalPages}
+					currentPage={page}
+					setCurrentPage={(newPage: number) => {
+						onPageChange(newPage);
+					}}
+					commentCount={commentCount}
+					filters={filters}
+				/>
+			)}
+			{loading ? (
+				<LoadingComments />
+			) : !comments.length ? (
+				<NoComments />
+			) : (
+				<ul css={commentContainerStyles}>
+					{comments
+						.slice(0, numberOfCommentsToShow)
+						.map((comment) => (
+							<li key={comment.id}>
+								<CommentContainer
+									comment={comment}
+									pillar={pillar}
+									isClosedForComments={isClosedForComments}
+									shortUrl={shortUrl}
+									user={user}
+									threads={filters.threads}
+									commentBeingRepliedTo={
+										commentBeingRepliedTo
+									}
+									setCommentBeingRepliedTo={
+										setCommentBeingRepliedTo
+									}
+									commentToScrollTo={commentToScrollTo}
+									mutes={mutes}
+									toggleMuteStatus={toggleMuteStatus}
+									onPermalinkClick={onPermalinkClick}
+									onRecommend={onRecommend}
+									onReply={onReply}
+								/>
+							</li>
+						))}
+				</ul>
+			)}
+			{loadingMore && <LoadingComments />}
+			{showPagination && (
+				<footer css={footerStyles}>
 					<Pagination
 						totalPages={totalPages}
 						currentPage={page}
@@ -533,69 +573,19 @@ export const Comments = ({
 						commentCount={commentCount}
 						filters={filters}
 					/>
-				)}
-				{loading ? (
-					<LoadingComments />
-				) : !comments.length ? (
-					<NoComments />
-				) : (
-					<ul css={commentContainerStyles}>
-						{comments
-							.slice(0, numberOfCommentsToShow)
-							.map((comment) => (
-								<li key={comment.id}>
-									<CommentContainer
-										comment={comment}
-										pillar={pillar}
-										isClosedForComments={
-											isClosedForComments
-										}
-										shortUrl={shortUrl}
-										user={user}
-										threads={filters.threads}
-										commentBeingRepliedTo={
-											commentBeingRepliedTo
-										}
-										setCommentBeingRepliedTo={
-											setCommentBeingRepliedTo
-										}
-										commentToScrollTo={commentToScrollTo}
-										mutes={mutes}
-										toggleMuteStatus={toggleMuteStatus}
-										onPermalinkClick={onPermalinkClick}
-										onRecommend={onRecommend}
-										onReply={onReply}
-									/>
-								</li>
-							))}
-					</ul>
-				)}
-				{loadingMore && <LoadingComments />}
-				{showPagination && (
-					<footer css={footerStyles}>
-						<Pagination
-							totalPages={totalPages}
-							currentPage={page}
-							setCurrentPage={(newPage: number) => {
-								onPageChange(newPage);
-							}}
-							commentCount={commentCount}
-							filters={filters}
-						/>
-					</footer>
-				)}
-				{user && !isClosedForComments && comments.length > 10 && (
-					<CommentForm
-						pillar={pillar}
-						shortUrl={shortUrl}
-						onAddComment={onAddComment}
-						user={user}
-						onComment={onComment}
-						onReply={onReply}
-						onPreview={onPreview}
-					/>
-				)}
-			</div>
-		</>
+				</footer>
+			)}
+			{user && !isClosedForComments && comments.length > 10 && (
+				<CommentForm
+					pillar={pillar}
+					shortUrl={shortUrl}
+					onAddComment={onAddComment}
+					user={user}
+					onComment={onComment}
+					onReply={onReply}
+					onPreview={onPreview}
+				/>
+			)}
+		</div>
 	);
 };

--- a/dotcom-rendering/src/discussion-rendering/discussionTypes.ts
+++ b/dotcom-rendering/src/discussion-rendering/discussionTypes.ts
@@ -1,3 +1,5 @@
+import type { Guard } from '../lib/guard';
+import { guard } from '../lib/guard';
 import type {
 	SignedInWithCookies,
 	SignedInWithOkta,
@@ -114,9 +116,17 @@ export type UserNameResponse = {
 	errors?: UserNameError[];
 };
 
-export type OrderByType = 'newest' | 'oldest' | 'recommendations';
-export type ThreadsType = 'collapsed' | 'expanded' | 'unthreaded';
-export type PageSizeType = 25 | 50 | 100;
+const orderBy = ['newest', 'oldest', 'recommendations'] as const;
+export const isOrderBy = guard(orderBy);
+export type OrderByType = Guard<typeof orderBy>;
+
+const threads = ['collapsed', 'expanded', 'unthreaded'] as const;
+export const isThreads = guard(threads);
+export type ThreadsType = Guard<typeof threads>;
+
+const pageSize = [25, 50, 100] as const;
+export const isPageSize = guard(pageSize);
+export type PageSizeType = Guard<typeof pageSize>;
 export interface FilterOptions {
 	orderBy: OrderByType;
 	pageSize: PageSizeType;

--- a/dotcom-rendering/src/discussion-rendering/test-page.tsx
+++ b/dotcom-rendering/src/discussion-rendering/test-page.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { createRoot } from 'react-dom/client';
-import { App } from './App';
+import { Comments } from './Comments';
 import type { CAPIPillar } from './discussionTypes';
 import { pillarToEnum } from './lib/pillarToEnum';
 
@@ -99,7 +99,7 @@ const IndexPageWrapper = () => {
 
 			<hr />
 			<main>
-				<App
+				<Comments
 					baseUrl="https://discussion.theguardian.com/discussion-api"
 					pillar={pillarToEnum(pillar)}
 					isClosedForComments={closed}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Refactors the `Comment` component:
- Rename from `App` to `Comment`
- Unnest the unnecessary top-level `div`
- Extract functional methods from inside the component’s function body
- Make `loadingMore` a derived value
- Use `@guardian/libs`’s storage interface and the `guard` helper

## Why?

- Fix the infinite loading bug – #6292 
  - `loadingMore` was originally introducing for [excellent performance reasons](https://github.com/guardian/discussion-rendering/pull/477)!
- I’m a nice person and I like consistency

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/76776/448cf71b-ff63-43c0-b3d3-0b4f04a68225
[after]: https://github.com/guardian/dotcom-rendering/assets/76776/960b30a5-67c1-40ab-866f-15f78999282c