### PR TITLE
Video container on DCR

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -60,7 +60,7 @@
 		"@emotion/react": "11.11.1",
 		"@emotion/server": "11.11.0",
 		"@guardian/ab-core": "5.0.0",
-		"@guardian/atoms-rendering": "32.2.3",
+		"@guardian/atoms-rendering": "32.3.0",
 		"@guardian/braze-components": "14.1.1",
 		"@guardian/bridget": "2.3.0",
 		"@guardian/browserslist-config": "5.0.0",

--- a/dotcom-rendering/src/components/Card/Card.stories.tsx
+++ b/dotcom-rendering/src/components/Card/Card.stories.tsx
@@ -32,7 +32,7 @@ const basicCardProps: CardProps = {
 	imagePosition: 'top',
 	showAge: true,
 	isExternalLink: false,
-	videoSize: 'large enough to play: at least 480px',
+	isPlayableMediaCard: true,
 };
 
 const aBasicLink = {
@@ -969,7 +969,7 @@ export const WhenVideoWithPlayButton = () => {
 						}}
 						imagePosition="top"
 						mainMedia={mainVideo}
-						videoSize="too small to play: 479px or less"
+						isPlayableMediaCard={false}
 					/>
 				</LI>
 			</UL>
@@ -1000,7 +1000,7 @@ export const WhenVideoWithPlayButton = () => {
 								}}
 								imagePosition="left"
 								mainMedia={mainVideo}
-								videoSize="too small to play: 479px or less"
+								isPlayableMediaCard={false}
 							/>
 						</LI>
 						<LI padSides={true}>
@@ -1013,7 +1013,7 @@ export const WhenVideoWithPlayButton = () => {
 								}}
 								imagePosition="right"
 								mainMedia={mainVideo}
-								videoSize="too small to play: 479px or less"
+								isPlayableMediaCard={false}
 							/>
 						</LI>
 
@@ -1027,7 +1027,7 @@ export const WhenVideoWithPlayButton = () => {
 								}}
 								imagePosition="right"
 								mainMedia={mainVideo}
-								videoSize="too small to play: 479px or less"
+								isPlayableMediaCard={false}
 							/>
 						</LI>
 					</UL>

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -478,105 +478,108 @@ export const Card = ({
 						)}
 					</ImageWrapper>
 				)}
-				<ContentWrapper
-					imageType={media?.type}
-					imageSize={imageSize}
-					imagePosition={imagePosition}
-				>
-					<HeadlineWrapper
-						imagePositionOnMobile={imagePositionOnMobile}
+
+				{containerType != 'fixed/video' && (
+					<ContentWrapper
+						imageType={media?.type}
+						imageSize={imageSize}
 						imagePosition={imagePosition}
-						imageUrl={imageUrl}
-						hasStarRating={starRating !== undefined}
 					>
-						<CardHeadline
-							headlineText={headlineText}
-							format={format}
-							containerPalette={containerPalette}
-							size={headlineSize}
-							sizeOnMobile={headlineSizeOnMobile}
-							showQuotes={showQuotes}
-							kickerText={
-								format.design === ArticleDesign.LiveBlog &&
-								!kickerText
-									? 'Live'
-									: kickerText
-							}
-							showPulsingDot={
-								format.design === ArticleDesign.LiveBlog ||
-								showPulsingDot
-							}
-							byline={byline}
-							showByline={showByline}
-							isDynamo={isDynamo}
-							isExternalLink={isExternalLink}
-						/>
-						{starRating !== undefined ? (
-							<StarRatingComponent
-								rating={starRating}
-								cardHasImage={imageUrl !== undefined}
-							/>
-						) : null}
-						{!!mainMedia && mainMedia.type !== 'Video' && (
-							<MediaMeta
-								containerPalette={containerPalette}
+						<HeadlineWrapper
+							imagePositionOnMobile={imagePositionOnMobile}
+							imagePosition={imagePosition}
+							imageUrl={imageUrl}
+							hasStarRating={starRating !== undefined}
+						>
+							<CardHeadline
+								headlineText={headlineText}
 								format={format}
-								mediaType={mainMedia.type}
-								mediaDuration={
-									mainMedia.type === 'Audio'
-										? mainMedia.duration
-										: undefined
+								containerPalette={containerPalette}
+								size={headlineSize}
+								sizeOnMobile={headlineSizeOnMobile}
+								showQuotes={showQuotes}
+								kickerText={
+									format.design === ArticleDesign.LiveBlog &&
+									!kickerText
+										? 'Live'
+										: kickerText
 								}
-								hasKicker={!!kickerText}
-							/>
-						)}
-					</HeadlineWrapper>
-					{/* This div is needed to push this content to the bottom of the card */}
-					<div>
-						{!!trailText && (
-							<TrailTextWrapper
-								containerPalette={containerPalette}
-								format={format}
-								imagePosition={imagePosition}
-								imageSize={imageSize}
-								imageType={media?.type}
-							>
-								<div
-									dangerouslySetInnerHTML={{
-										__html: trailText,
-									}}
-								/>
-							</TrailTextWrapper>
-						)}
-						{showLivePlayable && (
-							<Island>
-								<LatestLinks
-									id={linkTo}
-									format={format}
-									isDynamo={isDynamo}
-									direction={supportingContentAlignment}
-									containerPalette={containerPalette}
-								></LatestLinks>
-							</Island>
-						)}
-						<DecideFooter
-							isOpinion={isOpinion}
-							hasSublinks={hasSublinks}
-							renderFooter={renderFooter}
-						/>
-						{hasSublinks && sublinkPosition === 'inner' ? (
-							<SupportingContent
-								supportingContent={supportingContent}
-								alignment="vertical"
-								containerPalette={containerPalette}
+								showPulsingDot={
+									format.design === ArticleDesign.LiveBlog ||
+									showPulsingDot
+								}
+								byline={byline}
+								showByline={showByline}
 								isDynamo={isDynamo}
-								parentFormat={format}
+								isExternalLink={isExternalLink}
 							/>
-						) : (
-							<></>
-						)}
-					</div>
-				</ContentWrapper>
+							{starRating !== undefined ? (
+								<StarRatingComponent
+									rating={starRating}
+									cardHasImage={imageUrl !== undefined}
+								/>
+							) : null}
+							{!!mainMedia && mainMedia.type !== 'Video' && (
+								<MediaMeta
+									containerPalette={containerPalette}
+									format={format}
+									mediaType={mainMedia.type}
+									mediaDuration={
+										mainMedia.type === 'Audio'
+											? mainMedia.duration
+											: undefined
+									}
+									hasKicker={!!kickerText}
+								/>
+							)}
+						</HeadlineWrapper>
+						{/* This div is needed to push this content to the bottom of the card */}
+						<div>
+							{!!trailText && (
+								<TrailTextWrapper
+									containerPalette={containerPalette}
+									format={format}
+									imagePosition={imagePosition}
+									imageSize={imageSize}
+									imageType={media?.type}
+								>
+									<div
+										dangerouslySetInnerHTML={{
+											__html: trailText,
+										}}
+									/>
+								</TrailTextWrapper>
+							)}
+							{showLivePlayable && (
+								<Island>
+									<LatestLinks
+										id={linkTo}
+										format={format}
+										isDynamo={isDynamo}
+										direction={supportingContentAlignment}
+										containerPalette={containerPalette}
+									></LatestLinks>
+								</Island>
+							)}
+							<DecideFooter
+								isOpinion={isOpinion}
+								hasSublinks={hasSublinks}
+								renderFooter={renderFooter}
+							/>
+							{hasSublinks && sublinkPosition === 'inner' ? (
+								<SupportingContent
+									supportingContent={supportingContent}
+									alignment="vertical"
+									containerPalette={containerPalette}
+									isDynamo={isDynamo}
+									parentFormat={format}
+								/>
+							) : (
+								<></>
+							)}
+						</div>
+					</ContentWrapper>
+				)}
 			</CardLayout>
 
 			{hasSublinks && sublinkPosition === 'outer' ? (

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -446,9 +446,12 @@ export const Card = ({
 										hideCaption={true}
 										role="inline"
 										stickyVideos={false}
-										kicker={'Breaking News'}
+										kickerText={kickerText}
 										pauseOffscreenVideo={
 											pauseOffscreenVideo
+										}
+										showTextOverlay={
+											containerType === 'fixed/video'
 										}
 									/>
 								</Island>

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -454,6 +454,7 @@ export const Card = ({
 										hideCaption={true}
 										role="inline"
 										stickyVideos={false}
+										kicker={'Breaking News'}
 									/>
 								</Island>
 							</div>

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -94,6 +94,7 @@ export type Props = {
 	slideshowImages?: DCRSlideshowImage[];
 	showLivePlayable?: boolean;
 	onwardsSource?: string;
+	minWidthInPixelsOnMobile?: number;
 };
 
 const StarRatingComponent = ({
@@ -282,6 +283,7 @@ export const Card = ({
 	slideshowImages,
 	showLivePlayable = false,
 	onwardsSource,
+	minWidthInPixelsOnMobile,
 }: Props) => {
 	const palette = decidePalette(format, containerPalette);
 
@@ -394,6 +396,7 @@ export const Card = ({
 				imagePosition={imagePosition}
 				imagePositionOnMobile={imagePositionOnMobile}
 				minWidthInPixels={minWidthInPixels}
+				minWidthInPixelsOnMobile={minWidthInPixelsOnMobile}
 				imageType={media?.type}
 			>
 				{media && (

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -67,7 +67,10 @@ export type Props = {
 	avatarUrl?: string;
 	showClock?: boolean;
 	mainMedia?: MainMedia;
-	/** Note YouTube recommends a minimum width of 480px @see https://developers.google.com/youtube/terms/required-minimum-functionality#embedded-youtube-player-size */
+	/** Note YouTube recommends a minimum width of 480px @see https://developers.google.com/youtube/terms/required-minimum-functionality#embedded-youtube-player-size
+	 * At 300px or below, the player will begin to lose functionality e.g. volume controls being omitted.
+	 * Youtube requires a minimum width 200px.
+	 */
 	isPlayableMediaCard?: boolean;
 	kickerText?: string;
 	showPulsingDot?: boolean;

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -90,7 +90,6 @@ export type Props = {
 	slideshowImages?: DCRSlideshowImage[];
 	showLivePlayable?: boolean;
 	onwardsSource?: string;
-	minWidthInPixelsOnMobile?: number;
 	pauseOffscreenVideo?: boolean;
 };
 
@@ -276,7 +275,6 @@ export const Card = ({
 	slideshowImages,
 	showLivePlayable = false,
 	onwardsSource,
-	minWidthInPixelsOnMobile,
 	pauseOffscreenVideo = false,
 }: Props) => {
 	const palette = decidePalette(format, containerPalette);
@@ -390,8 +388,8 @@ export const Card = ({
 				imagePosition={imagePosition}
 				imagePositionOnMobile={imagePositionOnMobile}
 				minWidthInPixels={minWidthInPixels}
-				minWidthInPixelsOnMobile={minWidthInPixelsOnMobile}
 				imageType={media?.type}
+				containerType={containerType}
 			>
 				{media && (
 					<ImageWrapper

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -46,11 +46,6 @@ import type {
 import { ImageWrapper } from './components/ImageWrapper';
 import { TrailTextWrapper } from './components/TrailTextWrapper';
 
-/** Note YouTube recommends a minimum width of 480px @see https://developers.google.com/youtube/terms/required-minimum-functionality#embedded-youtube-player-size */
-export type VideoSize =
-	| 'large enough to play: at least 480px'
-	| 'too small to play: 479px or less';
-
 export type Props = {
 	linkTo: string;
 	format: ArticleFormat;
@@ -72,7 +67,8 @@ export type Props = {
 	avatarUrl?: string;
 	showClock?: boolean;
 	mainMedia?: MainMedia;
-	videoSize: VideoSize;
+	/** Note YouTube recommends a minimum width of 480px @see https://developers.google.com/youtube/terms/required-minimum-functionality#embedded-youtube-player-size */
+	isPlayableMediaCard?: boolean;
 	kickerText?: string;
 	showPulsingDot?: boolean;
 	starRating?: number;
@@ -197,7 +193,7 @@ const getMedia = ({
 	isCrossword,
 	slideshowImages,
 	mainMedia,
-	videoSize,
+	isPlayableMediaCard,
 }: {
 	imageUrl?: string;
 	imageAltText?: string;
@@ -205,13 +201,9 @@ const getMedia = ({
 	isCrossword?: boolean;
 	slideshowImages?: DCRSlideshowImage[];
 	mainMedia?: MainMedia;
-	videoSize: VideoSize;
+	isPlayableMediaCard?: boolean;
 }) => {
-	if (
-		mainMedia &&
-		mainMedia.type === 'Video' &&
-		videoSize === 'large enough to play: at least 480px'
-	) {
+	if (mainMedia && mainMedia.type === 'Video' && !!isPlayableMediaCard) {
 		return { type: 'video', mainMedia } as const;
 	}
 	if (slideshowImages) return { type: 'slideshow', slideshowImages } as const;
@@ -264,7 +256,7 @@ export const Card = ({
 	avatarUrl,
 	showClock,
 	mainMedia,
-	videoSize,
+	isPlayableMediaCard,
 	kickerText,
 	showPulsingDot,
 	starRating,
@@ -369,9 +361,9 @@ export const Card = ({
 		);
 	}
 
-	const showPlayIcon =
-		mainMedia?.type === 'Video' &&
-		videoSize === 'too small to play: 479px or less';
+	// If the card isn't playable, we need to show a play icon.
+	// Otherwise, this is handled by the YoutubeAtom
+	const showPlayIcon = mainMedia?.type === 'Video' && !isPlayableMediaCard;
 
 	const media = getMedia({
 		imageUrl,
@@ -380,7 +372,7 @@ export const Card = ({
 		isCrossword,
 		slideshowImages,
 		mainMedia,
-		videoSize,
+		isPlayableMediaCard,
 	});
 	return (
 		<CardWrapper

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -95,6 +95,7 @@ export type Props = {
 	showLivePlayable?: boolean;
 	onwardsSource?: string;
 	minWidthInPixelsOnMobile?: number;
+	pauseOffscreenVideo?: boolean;
 };
 
 const StarRatingComponent = ({
@@ -284,6 +285,7 @@ export const Card = ({
 	showLivePlayable = false,
 	onwardsSource,
 	minWidthInPixelsOnMobile,
+	pauseOffscreenVideo = false,
 }: Props) => {
 	const palette = decidePalette(format, containerPalette);
 
@@ -455,6 +457,9 @@ export const Card = ({
 										role="inline"
 										stickyVideos={false}
 										kicker={'Breaking News'}
+										pauseOffscreenVideo={
+											pauseOffscreenVideo
+										}
 									/>
 								</Island>
 							</div>

--- a/dotcom-rendering/src/components/Card/components/CardLayout.tsx
+++ b/dotcom-rendering/src/components/Card/components/CardLayout.tsx
@@ -8,6 +8,7 @@ type Props = {
 	imagePosition: ImagePositionType;
 	imagePositionOnMobile: ImagePositionType;
 	minWidthInPixels?: number;
+	minWidthInPixelsOnMobile?: number;
 };
 
 const decideDirection = (imagePosition: ImagePositionType) => {
@@ -26,7 +27,24 @@ const decideDirection = (imagePosition: ImagePositionType) => {
 	}
 };
 
-const decideWidth = (minWidthInPixels?: number) => {
+const decideWidth = (
+	minWidthInPixels?: number,
+	minWidthInPixelsOnMobile?: number,
+) => {
+	if (
+		minWidthInPixels !== undefined &&
+		minWidthInPixels > 0 &&
+		minWidthInPixelsOnMobile !== undefined &&
+		minWidthInPixelsOnMobile > 0
+	) {
+		return css`
+			min-width: ${minWidthInPixels}px;
+			${until.tablet} {
+				min-width: ${minWidthInPixelsOnMobile}px;
+			}
+		`;
+	}
+
 	if (minWidthInPixels !== undefined && minWidthInPixels > 0) {
 		return css`
 			min-width: ${minWidthInPixels}px;
@@ -77,6 +95,7 @@ export const CardLayout = ({
 	imagePositionOnMobile,
 	minWidthInPixels,
 	imageType,
+	minWidthInPixelsOnMobile,
 }: Props) => (
 	<div
 		css={[
@@ -84,7 +103,7 @@ export const CardLayout = ({
 				display: flex;
 				flex-basis: 100%;
 			`,
-			decideWidth(minWidthInPixels),
+			decideWidth(minWidthInPixels, minWidthInPixelsOnMobile),
 			decidePosition(imagePosition, imagePositionOnMobile, imageType),
 		]}
 	>

--- a/dotcom-rendering/src/components/Card/components/CardLayout.tsx
+++ b/dotcom-rendering/src/components/Card/components/CardLayout.tsx
@@ -32,16 +32,19 @@ const decideWidth = (
 	minWidthInPixels?: number,
 	containerType?: DCRContainerType,
 ) => {
+	const padding = 20;
 	switch (containerType) {
 		case 'fixed/video':
 			return css`
 				min-width: 300px;
 				max-width: 600px;
-				width: calc((100vw - 40px) / 1.5); // Show 1.5 cards
+				width: calc((100vw - ${padding}px) / 1.5); // Show 1.5 cards
 				overflow: hidden;
 
 				${until.mobileLandscape} {
-					width: calc((100vw - 40px)); // Show 1 card on small screens
+					width: calc(
+						100vw - ${padding}px
+					); // Show 1 card on small screens
 				}
 			`;
 

--- a/dotcom-rendering/src/components/Card/components/CardLayout.tsx
+++ b/dotcom-rendering/src/components/Card/components/CardLayout.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react';
 import { until } from '@guardian/source-foundations';
 import type { ImagePositionType } from './ImageWrapper';
+import { DCRContainerType } from 'src/types/front';
 
 type Props = {
 	children: React.ReactNode;
@@ -8,7 +9,7 @@ type Props = {
 	imagePosition: ImagePositionType;
 	imagePositionOnMobile: ImagePositionType;
 	minWidthInPixels?: number;
-	minWidthInPixelsOnMobile?: number;
+	containerType?: DCRContainerType;
 };
 
 const decideDirection = (imagePosition: ImagePositionType) => {
@@ -29,30 +30,31 @@ const decideDirection = (imagePosition: ImagePositionType) => {
 
 const decideWidth = (
 	minWidthInPixels?: number,
-	minWidthInPixelsOnMobile?: number,
+	containerType?: DCRContainerType,
 ) => {
-	if (
-		minWidthInPixels !== undefined &&
-		minWidthInPixels > 0 &&
-		minWidthInPixelsOnMobile !== undefined &&
-		minWidthInPixelsOnMobile > 0
-	) {
-		return css`
-			min-width: ${minWidthInPixels}px;
-			${until.tablet} {
-				min-width: ${minWidthInPixelsOnMobile}px;
-			}
-		`;
-	}
+	switch (containerType) {
+		case 'fixed/video':
+			return css`
+				min-width: 300px;
+				max-width: 600px;
+				width: calc((100vw - 40px) / 1.5); // Show 1.5 cards
+				overflow: hidden;
 
-	if (minWidthInPixels !== undefined && minWidthInPixels > 0) {
-		return css`
-			min-width: ${minWidthInPixels}px;
-		`;
+				${until.mobileLandscape} {
+					width: calc((100vw - 40px)); // Show 1 card on small screens
+				}
+			`;
+
+		default:
+			if (minWidthInPixels !== undefined && minWidthInPixels > 0) {
+				return css`
+					min-width: ${minWidthInPixels}px;
+				`;
+			}
+			return css`
+				width: 100%;
+			`;
 	}
-	return css`
-		width: 100%;
-	`;
 };
 
 const decidePosition = (
@@ -95,7 +97,7 @@ export const CardLayout = ({
 	imagePositionOnMobile,
 	minWidthInPixels,
 	imageType,
-	minWidthInPixelsOnMobile,
+	containerType,
 }: Props) => (
 	<div
 		css={[
@@ -103,7 +105,7 @@ export const CardLayout = ({
 				display: flex;
 				flex-basis: 100%;
 			`,
-			decideWidth(minWidthInPixels, minWidthInPixelsOnMobile),
+			decideWidth(minWidthInPixels, containerType),
 			decidePosition(imagePosition, imagePositionOnMobile, imageType),
 		]}
 	>

--- a/dotcom-rendering/src/components/Card/components/CardLayout.tsx
+++ b/dotcom-rendering/src/components/Card/components/CardLayout.tsx
@@ -30,15 +30,15 @@ const decideDirection = (imagePosition: ImagePositionType) => {
 	}
 };
 
+// Until mobile landscape, show 1 card on small screens
+// Above mobile landscape, show 1 full card and min 20vw of second card
 const videoWidth = css`
 	min-width: 300px;
 	max-width: 600px;
-	// Show 1 full card and min 20vw of second card
 	width: calc(80vw - ${padding}px);
 	overflow: hidden;
 
 	${until.mobileLandscape} {
-		// Show 1 card on small screens
 		width: calc(100vw - ${padding}px);
 	}
 `;

--- a/dotcom-rendering/src/components/Card/components/CardLayout.tsx
+++ b/dotcom-rendering/src/components/Card/components/CardLayout.tsx
@@ -38,7 +38,9 @@ const decideWidth = (
 			return css`
 				min-width: 300px;
 				max-width: 600px;
-				width: calc((100vw - ${padding}px) / 1.5); // Show 1.5 cards
+				width: calc(
+					80vw - ${padding}px
+				); // Show 1 full card and min 20vw of second card
 				overflow: hidden;
 
 				${until.mobileLandscape} {

--- a/dotcom-rendering/src/components/Card/components/CardLayout.tsx
+++ b/dotcom-rendering/src/components/Card/components/CardLayout.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/react';
 import { until } from '@guardian/source-foundations';
 import { DCRContainerType } from '../../../types/front';
 import type { ImagePositionType } from './ImageWrapper';
+
 const padding = 20;
 
 type Props = {

--- a/dotcom-rendering/src/components/Card/components/CardLayout.tsx
+++ b/dotcom-rendering/src/components/Card/components/CardLayout.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/react';
 import { until } from '@guardian/source-foundations';
 import { DCRContainerType } from '../../../types/front';
 import type { ImagePositionType } from './ImageWrapper';
+const padding = 20;
 
 type Props = {
 	children: React.ReactNode;
@@ -28,38 +29,28 @@ const decideDirection = (imagePosition: ImagePositionType) => {
 	}
 };
 
-const decideWidth = (
-	minWidthInPixels?: number,
-	containerType?: DCRContainerType,
-) => {
-	const padding = 20;
-	switch (containerType) {
-		case 'fixed/video':
-			return css`
-				min-width: 300px;
-				max-width: 600px;
-				width: calc(
-					80vw - ${padding}px
-				); // Show 1 full card and min 20vw of second card
-				overflow: hidden;
+const videoWidth = css`
+	min-width: 300px;
+	max-width: 600px;
+	// Show 1 full card and min 20vw of second card
+	width: calc(80vw - ${padding}px);
+	overflow: hidden;
 
-				${until.mobileLandscape} {
-					width: calc(
-						100vw - ${padding}px
-					); // Show 1 card on small screens
-				}
-			`;
-
-		default:
-			if (minWidthInPixels !== undefined && minWidthInPixels > 0) {
-				return css`
-					min-width: ${minWidthInPixels}px;
-				`;
-			}
-			return css`
-				width: 100%;
-			`;
+	${until.mobileLandscape} {
+		// Show 1 card on small screens
+		width: calc(100vw - ${padding}px);
 	}
+`;
+
+const minWidth = (minWidthInPixels?: number) => {
+	if (minWidthInPixels !== undefined && minWidthInPixels > 0) {
+		return css`
+			min-width: ${minWidthInPixels}px;
+		`;
+	}
+	return css`
+		width: 100%;
+	`;
 };
 
 const decidePosition = (
@@ -110,7 +101,9 @@ export const CardLayout = ({
 				display: flex;
 				flex-basis: 100%;
 			`,
-			decideWidth(minWidthInPixels, containerType),
+			containerType === 'fixed/video'
+				? videoWidth
+				: minWidth(minWidthInPixels),
 			decidePosition(imagePosition, imagePositionOnMobile, imageType),
 		]}
 	>

--- a/dotcom-rendering/src/components/Card/components/CardLayout.tsx
+++ b/dotcom-rendering/src/components/Card/components/CardLayout.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import { until } from '@guardian/source-foundations';
+import { DCRContainerType } from '../../../types/front';
 import type { ImagePositionType } from './ImageWrapper';
-import { DCRContainerType } from 'src/types/front';
 
 type Props = {
 	children: React.ReactNode;

--- a/dotcom-rendering/src/components/Carousel.importable.tsx
+++ b/dotcom-rendering/src/components/Carousel.importable.tsx
@@ -438,16 +438,6 @@ type CarouselCardProps = {
 	isVideoContainer?: boolean;
 };
 
-const CarouselCardStyles = css`
-	min-width: 320px;
-	width: calc((100vw - 40px) / 1.5); // Show 1.5 cards
-	overflow: hidden;
-
-	${until.phablet} {
-		width: calc((100vw - 40px)); // Show 1 card on small screens
-	}
-`;
-
 const CarouselCard = ({
 	format,
 	linkTo,
@@ -472,30 +462,29 @@ const CarouselCard = ({
 		snapAlignStart={true}
 		verticalDividerColour={verticalDividerColour}
 	>
-		<div css={CarouselCardStyles}>
-			<Card
-				linkTo={linkTo}
-				format={format}
-				headlineText={headlineText}
-				webPublicationDate={webPublicationDate}
-				kickerText={kickerText}
-				imageUrl={imageUrl}
-				imageSize={'small'}
-				showClock={true}
-				showAge={true}
-				imagePositionOnMobile="top"
-				pauseOffscreenVideo={isVideoContainer}
-				showQuotedHeadline={format.design === ArticleDesign.Comment}
-				dataLinkName={dataLinkName}
-				discussionId={discussionId}
-				branding={branding}
-				isExternalLink={false}
-				mainMedia={mainMedia}
-				isPlayableMediaCard={isVideoContainer}
-				onwardsSource={onwardsSource}
-				containerType={isVideoContainer ? 'fixed/video' : undefined}
-			/>
-		</div>
+		<Card
+			linkTo={linkTo}
+			format={format}
+			headlineText={headlineText}
+			webPublicationDate={webPublicationDate}
+			kickerText={kickerText}
+			imageUrl={imageUrl}
+			imageSize={'small'}
+			showClock={true}
+			showAge={true}
+			imagePositionOnMobile="top"
+			pauseOffscreenVideo={isVideoContainer}
+			showQuotedHeadline={format.design === ArticleDesign.Comment}
+			dataLinkName={dataLinkName}
+			discussionId={discussionId}
+			branding={branding}
+			isExternalLink={false}
+			mainMedia={mainMedia}
+			minWidthInPixels={220}
+			isPlayableMediaCard={isVideoContainer}
+			onwardsSource={onwardsSource}
+			containerType={isVideoContainer ? 'fixed/video' : undefined}
+		/>
 	</LI>
 );
 

--- a/dotcom-rendering/src/components/Carousel.importable.tsx
+++ b/dotcom-rendering/src/components/Carousel.importable.tsx
@@ -474,7 +474,7 @@ const CarouselCard = ({
 			showClock={true}
 			showAge={true}
 			imagePositionOnMobile="top"
-			minWidthInPixels={isVideoContainer ? 480 : 220}
+			minWidthInPixels={isVideoContainer ? 600 : 220}
 			showQuotedHeadline={format.design === ArticleDesign.Comment}
 			dataLinkName={dataLinkName}
 			discussionId={discussionId}

--- a/dotcom-rendering/src/components/Carousel.importable.tsx
+++ b/dotcom-rendering/src/components/Carousel.importable.tsx
@@ -98,6 +98,7 @@ const isLastCardShowing = (index: number, totalStories: number) =>
 
 const containerMargins = css`
 	margin-top: 6px;
+	margin-bottom: 24px;
 
 	margin-left: 0px;
 	margin-right: 0px;
@@ -108,6 +109,11 @@ const containerMargins = css`
 		margin-left: -10px;
 		margin-right: -10px;
 	}
+`;
+
+const videoContainerMargins = css`
+	margin-bottom: 0;
+	min-height: 0;
 `;
 
 const containerMarginsFromLeftCol = css`
@@ -123,6 +129,10 @@ const containerStyles = css`
 	flex-direction: column;
 	position: relative;
 	overflow: hidden; /* Needed for scrolling to work */
+`;
+
+const videoContainerHeight = css`
+	min-height: 0;
 `;
 
 const carouselStyle = css`
@@ -948,6 +958,7 @@ export const Carousel = ({
 					containerStyles,
 					containerMargins,
 					!hasPageSkin && containerMarginsFromLeftCol,
+					isVideoContainer && videoContainerMargins,
 				]}
 				data-component={onwardsSource}
 				data-link={formatAttrString(heading)}
@@ -966,7 +977,10 @@ export const Carousel = ({
 					hasPageSkin={hasPageSkin}
 				/>
 				<ul
-					css={carouselStyle}
+					css={[
+						carouselStyle,
+						isVideoContainer && videoContainerHeight,
+					]}
 					ref={carouselRef}
 					data-component={`carousel-small | maxIndex-${maxIndex}`}
 				>

--- a/dotcom-rendering/src/components/Carousel.importable.tsx
+++ b/dotcom-rendering/src/components/Carousel.importable.tsx
@@ -491,11 +491,7 @@ const CarouselCard = ({
 				branding={branding}
 				isExternalLink={false}
 				mainMedia={mainMedia}
-				videoSize={
-					isVideoContainer
-						? 'large enough to play: at least 480px'
-						: 'too small to play: 479px or less'
-				}
+				isPlayableMediaCard={isVideoContainer}
 				onwardsSource={onwardsSource}
 				containerType={isVideoContainer ? 'fixed/video' : undefined}
 			/>

--- a/dotcom-rendering/src/components/Carousel.importable.tsx
+++ b/dotcom-rendering/src/components/Carousel.importable.tsx
@@ -436,6 +436,7 @@ type CarouselCardProps = {
 	mainMedia?: MainMedia;
 	verticalDividerColour?: string;
 	onwardsSource?: string;
+	isVideoContainer?: boolean;
 };
 
 const CarouselCard = ({
@@ -452,6 +453,7 @@ const CarouselCard = ({
 	mainMedia,
 	verticalDividerColour,
 	onwardsSource,
+	isVideoContainer,
 }: CarouselCardProps) => (
 	<LI
 		percentage="25%"
@@ -481,6 +483,7 @@ const CarouselCard = ({
 			mainMedia={mainMedia}
 			videoSize="too small to play: 479px or less"
 			onwardsSource={onwardsSource}
+			containerType={isVideoContainer ? 'fixed/video' : undefined}
 		/>
 	</LI>
 );
@@ -1008,6 +1011,7 @@ export const Carousel = ({
 									carouselColours.borderColour
 								}
 								onwardsSource={onwardsSource}
+								isVideoContainer={isVideoContainer}
 							/>
 						);
 					})}

--- a/dotcom-rendering/src/components/Carousel.importable.tsx
+++ b/dotcom-rendering/src/components/Carousel.importable.tsx
@@ -474,7 +474,7 @@ const CarouselCard = ({
 			showClock={true}
 			showAge={true}
 			imagePositionOnMobile="top"
-			minWidthInPixels={220}
+			minWidthInPixels={isVideoContainer ? 480 : 220}
 			showQuotedHeadline={format.design === ArticleDesign.Comment}
 			dataLinkName={dataLinkName}
 			discussionId={discussionId}
@@ -487,6 +487,7 @@ const CarouselCard = ({
 					: 'too small to play: 479px or less'
 			}
 			onwardsSource={onwardsSource}
+			minWidthInPixelsOnMobile={isVideoContainer ? 380 : undefined}
 			containerType={isVideoContainer ? 'fixed/video' : undefined}
 		/>
 	</LI>

--- a/dotcom-rendering/src/components/Carousel.importable.tsx
+++ b/dotcom-rendering/src/components/Carousel.importable.tsx
@@ -475,6 +475,7 @@ const CarouselCard = ({
 			showAge={true}
 			imagePositionOnMobile="top"
 			minWidthInPixels={isVideoContainer ? 600 : 220}
+			pauseOffscreenVideo={isVideoContainer}
 			showQuotedHeadline={format.design === ArticleDesign.Comment}
 			dataLinkName={dataLinkName}
 			discussionId={discussionId}

--- a/dotcom-rendering/src/components/Carousel.importable.tsx
+++ b/dotcom-rendering/src/components/Carousel.importable.tsx
@@ -466,7 +466,7 @@ const CarouselCard = ({
 }: CarouselCardProps) => (
 	<LI
 		percentage="25%"
-		showDivider={!isFirst}
+		showDivider={!isFirst && !isVideoContainer}
 		padSides={true}
 		padSidesOnMobile={true}
 		snapAlignStart={true}

--- a/dotcom-rendering/src/components/Carousel.importable.tsx
+++ b/dotcom-rendering/src/components/Carousel.importable.tsx
@@ -98,7 +98,6 @@ const isLastCardShowing = (index: number, totalStories: number) =>
 
 const containerMargins = css`
 	margin-top: 6px;
-	margin-bottom: 24px;
 
 	margin-left: 0px;
 	margin-right: 0px;
@@ -439,6 +438,16 @@ type CarouselCardProps = {
 	isVideoContainer?: boolean;
 };
 
+const CarouselCardStyles = css`
+	min-width: 320px;
+	width: calc((100vw - 40px) / 1.5); // Show 1.5 cards
+	overflow: hidden;
+
+	${until.phablet} {
+		width: calc((100vw - 40px)); // Show 1 card on small screens
+	}
+`;
+
 const CarouselCard = ({
 	format,
 	linkTo,
@@ -463,34 +472,34 @@ const CarouselCard = ({
 		snapAlignStart={true}
 		verticalDividerColour={verticalDividerColour}
 	>
-		<Card
-			linkTo={linkTo}
-			format={format}
-			headlineText={headlineText}
-			webPublicationDate={webPublicationDate}
-			kickerText={kickerText}
-			imageUrl={imageUrl}
-			imageSize={'small'}
-			showClock={true}
-			showAge={true}
-			imagePositionOnMobile="top"
-			minWidthInPixels={isVideoContainer ? 600 : 220}
-			pauseOffscreenVideo={isVideoContainer}
-			showQuotedHeadline={format.design === ArticleDesign.Comment}
-			dataLinkName={dataLinkName}
-			discussionId={discussionId}
-			branding={branding}
-			isExternalLink={false}
-			mainMedia={mainMedia}
-			videoSize={
-				isVideoContainer
-					? 'large enough to play: at least 480px'
-					: 'too small to play: 479px or less'
-			}
-			onwardsSource={onwardsSource}
-			minWidthInPixelsOnMobile={isVideoContainer ? 380 : undefined}
-			containerType={isVideoContainer ? 'fixed/video' : undefined}
-		/>
+		<div css={CarouselCardStyles}>
+			<Card
+				linkTo={linkTo}
+				format={format}
+				headlineText={headlineText}
+				webPublicationDate={webPublicationDate}
+				kickerText={kickerText}
+				imageUrl={imageUrl}
+				imageSize={'small'}
+				showClock={true}
+				showAge={true}
+				imagePositionOnMobile="top"
+				pauseOffscreenVideo={isVideoContainer}
+				showQuotedHeadline={format.design === ArticleDesign.Comment}
+				dataLinkName={dataLinkName}
+				discussionId={discussionId}
+				branding={branding}
+				isExternalLink={false}
+				mainMedia={mainMedia}
+				videoSize={
+					isVideoContainer
+						? 'large enough to play: at least 480px'
+						: 'too small to play: 479px or less'
+				}
+				onwardsSource={onwardsSource}
+				containerType={isVideoContainer ? 'fixed/video' : undefined}
+			/>
+		</div>
 	</LI>
 );
 

--- a/dotcom-rendering/src/components/Carousel.importable.tsx
+++ b/dotcom-rendering/src/components/Carousel.importable.tsx
@@ -481,7 +481,11 @@ const CarouselCard = ({
 			branding={branding}
 			isExternalLink={false}
 			mainMedia={mainMedia}
-			videoSize="too small to play: 479px or less"
+			videoSize={
+				isVideoContainer
+					? 'large enough to play: at least 480px'
+					: 'too small to play: 479px or less'
+			}
 			onwardsSource={onwardsSource}
 			containerType={isVideoContainer ? 'fixed/video' : undefined}
 		/>

--- a/dotcom-rendering/src/components/Carousel.importable.tsx
+++ b/dotcom-rendering/src/components/Carousel.importable.tsx
@@ -42,7 +42,7 @@ type ArticleProps = Props & {
 
 type FrontProps = Props & {
 	palette: DCRContainerPalette;
-	collectionType?: string;
+	containerType?: DCRContainerType;
 	hasPageSkin?: boolean;
 };
 
@@ -470,7 +470,7 @@ type CarouselCardProps = {
 	mainMedia?: MainMedia;
 	verticalDividerColour?: string;
 	onwardsSource?: string;
-	isVideoContainer?: boolean;
+	containerType?: DCRContainerType;
 };
 
 const CarouselCard = ({
@@ -487,41 +487,44 @@ const CarouselCard = ({
 	mainMedia,
 	verticalDividerColour,
 	onwardsSource,
-	isVideoContainer,
-}: CarouselCardProps) => (
-	<LI
-		percentage="25%"
-		showDivider={!isFirst && !isVideoContainer}
-		padSides={true}
-		padSidesOnMobile={true}
-		snapAlignStart={true}
-		verticalDividerColour={verticalDividerColour}
-	>
-		<Card
-			linkTo={linkTo}
-			format={format}
-			headlineText={headlineText}
-			webPublicationDate={webPublicationDate}
-			kickerText={kickerText}
-			imageUrl={imageUrl}
-			imageSize={'small'}
-			showClock={true}
-			showAge={true}
-			imagePositionOnMobile="top"
-			pauseOffscreenVideo={isVideoContainer}
-			showQuotedHeadline={format.design === ArticleDesign.Comment}
-			dataLinkName={dataLinkName}
-			discussionId={discussionId}
-			branding={branding}
-			isExternalLink={false}
-			mainMedia={mainMedia}
-			minWidthInPixels={220}
-			isPlayableMediaCard={isVideoContainer}
-			onwardsSource={onwardsSource}
-			containerType={isVideoContainer ? 'fixed/video' : undefined}
-		/>
-	</LI>
-);
+	containerType,
+}: CarouselCardProps) => {
+	const isVideoContainer = containerType === 'fixed/video';
+	return (
+		<LI
+			percentage="25%"
+			showDivider={!isFirst && !isVideoContainer}
+			padSides={true}
+			padSidesOnMobile={true}
+			snapAlignStart={true}
+			verticalDividerColour={verticalDividerColour}
+		>
+			<Card
+				linkTo={linkTo}
+				format={format}
+				headlineText={headlineText}
+				webPublicationDate={webPublicationDate}
+				kickerText={kickerText}
+				imageUrl={imageUrl}
+				imageSize={'small'}
+				showClock={true}
+				showAge={true}
+				imagePositionOnMobile="top"
+				pauseOffscreenVideo={isVideoContainer}
+				showQuotedHeadline={format.design === ArticleDesign.Comment}
+				dataLinkName={dataLinkName}
+				discussionId={discussionId}
+				branding={branding}
+				isExternalLink={false}
+				mainMedia={mainMedia}
+				minWidthInPixels={220}
+				isPlayableMediaCard={isVideoContainer}
+				onwardsSource={onwardsSource}
+				containerType={containerType}
+			/>
+		</LI>
+	);
+};
 
 type HeaderAndNavProps = {
 	heading: string;
@@ -590,7 +593,7 @@ const Header = ({
 	next,
 	arrowName,
 	isCuratedContent,
-	isVideoContainer,
+	containerType,
 	hasPageSkin,
 }: {
 	heading: string;
@@ -602,9 +605,10 @@ const Header = ({
 	next: () => void;
 	arrowName: string;
 	isCuratedContent: boolean;
-	isVideoContainer: boolean;
+	containerType?: DCRContainerType;
 	hasPageSkin: boolean;
 }) => {
+	const isVideoContainer = containerType === 'fixed/video';
 	const header = (
 		<div css={headerRowStyles}>
 			<HeaderAndNav
@@ -616,7 +620,7 @@ const Header = ({
 				index={index}
 				isCuratedContent={isCuratedContent}
 				goToIndex={goToIndex}
-				containerType={isVideoContainer ? 'fixed/video' : undefined}
+				containerType={containerType}
 			/>
 			<Hide when="below" breakpoint="desktop">
 				<button
@@ -851,9 +855,10 @@ export const Carousel = ({
 	const arrowName = 'carousel-small-arrow';
 
 	const isCuratedContent = onwardsSource === 'curated-content';
+	const containerType =
+		'containerType' in props ? props.containerType : undefined;
 
-	const isVideoContainer =
-		'collectionType' in props && props.collectionType === 'fixed/video';
+	const isVideoContainer = containerType === 'fixed/video';
 
 	const hasPageSkin = 'hasPageSkin' in props && (props.hasPageSkin ?? false);
 
@@ -1009,7 +1014,7 @@ export const Carousel = ({
 					next={next}
 					arrowName={arrowName}
 					isCuratedContent={isCuratedContent}
-					isVideoContainer={isVideoContainer}
+					containerType={containerType}
 					hasPageSkin={hasPageSkin}
 				/>
 				<ul
@@ -1061,7 +1066,7 @@ export const Carousel = ({
 									carouselColours.borderColour
 								}
 								onwardsSource={onwardsSource}
-								isVideoContainer={isVideoContainer}
+								containerType={containerType}
 							/>
 						);
 					})}

--- a/dotcom-rendering/src/components/FrontCard.tsx
+++ b/dotcom-rendering/src/components/FrontCard.tsx
@@ -39,7 +39,7 @@ export const FrontCard = (props: Props) => {
 		imageUrl: trail.image,
 		imageAltText: trail.imageAltText,
 		isCrossword: trail.isCrossword,
-		videoSize: 'large enough to play: at least 480px',
+		isPlayableMediaCard: true,
 		starRating: trail.starRating,
 		dataLinkName: trail.dataLinkName,
 		snapData: trail.snapData,

--- a/dotcom-rendering/src/components/SupportingContent.stories.tsx
+++ b/dotcom-rendering/src/components/SupportingContent.stories.tsx
@@ -32,7 +32,7 @@ const basicCardProps: CardProps = {
 	imagePosition: 'top',
 	isExternalLink: false,
 	showLivePlayable: false,
-	videoSize: 'large enough to play: at least 480px',
+	isPlayableMediaCard: true,
 };
 
 const aBasicLink = {

--- a/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
@@ -233,8 +233,8 @@ export const YoutubeBlockComponent = ({
 				imaEnabled={imaEnabled}
 				abTestParticipations={abTestParticipations}
 				// Temp commenting as couldn't get prepush commit to work with locally linked atoms rendering
-				// kicker={kicker}
-				// shouldPauseOutOfView={pauseOffscreenVideo}
+				kicker={kicker}
+				shouldPauseOutOfView={pauseOffscreenVideo}
 			/>
 			{!hideCaption && (
 				<Caption

--- a/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
@@ -32,8 +32,9 @@ type Props = {
 	duration?: number; // in seconds
 	origin?: string;
 	stickyVideos: boolean;
-	kicker?: string;
+	kickerText?: string;
 	pauseOffscreenVideo?: boolean;
+	showTextOverlay?: boolean;
 };
 
 const expiredOverlayStyles = (overrideImage?: string) =>
@@ -91,8 +92,9 @@ export const YoutubeBlockComponent = ({
 	duration,
 	origin,
 	stickyVideos,
-	kicker,
+	kickerText,
 	pauseOffscreenVideo = false,
+	showTextOverlay,
 }: Props) => {
 	const [consentState, setConsentState] = useState<ConsentState | undefined>(
 		undefined,
@@ -232,9 +234,9 @@ export const YoutubeBlockComponent = ({
 				isMainMedia={isMainMedia}
 				imaEnabled={imaEnabled}
 				abTestParticipations={abTestParticipations}
-				// Temp commenting as couldn't get prepush commit to work with locally linked atoms rendering
-				// kicker={kicker}
-				// shouldPauseOutOfView={pauseOffscreenVideo}
+				kicker={kickerText}
+				shouldPauseOutOfView={pauseOffscreenVideo}
+				showTextOverlay={showTextOverlay}
 			/>
 			{!hideCaption && (
 				<Caption

--- a/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
@@ -233,8 +233,8 @@ export const YoutubeBlockComponent = ({
 				imaEnabled={imaEnabled}
 				abTestParticipations={abTestParticipations}
 				// Temp commenting as couldn't get prepush commit to work with locally linked atoms rendering
-				kicker={kicker}
-				shouldPauseOutOfView={pauseOffscreenVideo}
+				// kicker={kicker}
+				// shouldPauseOutOfView={pauseOffscreenVideo}
 			/>
 			{!hideCaption && (
 				<Caption

--- a/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
@@ -33,6 +33,7 @@ type Props = {
 	origin?: string;
 	stickyVideos: boolean;
 	kicker?: string;
+	pauseOffscreenVideo?: boolean;
 };
 
 const expiredOverlayStyles = (overrideImage?: string) =>
@@ -91,6 +92,7 @@ export const YoutubeBlockComponent = ({
 	origin,
 	stickyVideos,
 	kicker,
+	pauseOffscreenVideo = false,
 }: Props) => {
 	const [consentState, setConsentState] = useState<ConsentState | undefined>(
 		undefined,
@@ -230,7 +232,8 @@ export const YoutubeBlockComponent = ({
 				isMainMedia={isMainMedia}
 				imaEnabled={imaEnabled}
 				abTestParticipations={abTestParticipations}
-				kicker={kicker}
+				// kicker={kicker}
+				shouldPauseOutOfView={pauseOffscreenVideo}
 			/>
 			{!hideCaption && (
 				<Caption

--- a/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
@@ -232,8 +232,9 @@ export const YoutubeBlockComponent = ({
 				isMainMedia={isMainMedia}
 				imaEnabled={imaEnabled}
 				abTestParticipations={abTestParticipations}
+				// Temp commenting as couldn't get prepush commit to work with locally linked atoms rendering
 				// kicker={kicker}
-				shouldPauseOutOfView={pauseOffscreenVideo}
+				// shouldPauseOutOfView={pauseOffscreenVideo}
 			/>
 			{!hideCaption && (
 				<Caption

--- a/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
@@ -32,6 +32,7 @@ type Props = {
 	duration?: number; // in seconds
 	origin?: string;
 	stickyVideos: boolean;
+	kicker?: string;
 };
 
 const expiredOverlayStyles = (overrideImage?: string) =>
@@ -89,6 +90,7 @@ export const YoutubeBlockComponent = ({
 	duration,
 	origin,
 	stickyVideos,
+	kicker,
 }: Props) => {
 	const [consentState, setConsentState] = useState<ConsentState | undefined>(
 		undefined,
@@ -228,6 +230,7 @@ export const YoutubeBlockComponent = ({
 				isMainMedia={isMainMedia}
 				imaEnabled={imaEnabled}
 				abTestParticipations={abTestParticipations}
+				kicker={kicker}
 			/>
 			{!hideCaption && (
 				<Caption

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -547,7 +547,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 											onwardsSource={'unknown-source'}
 											palette={containerPalette}
 											leftColSize={'compact'}
-											collectionType={
+											containerType={
 												collection.collectionType
 											}
 											hasPageSkin={hasPageSkin}

--- a/dotcom-rendering/src/lib/cardWrappers.tsx
+++ b/dotcom-rendering/src/lib/cardWrappers.tsx
@@ -304,7 +304,7 @@ export const Card25Media25 = ({
 			imageSize="small"
 			headlineSize="medium"
 			headlineSizeOnMobile="medium"
-			videoSize="too small to play: 479px or less"
+			isPlayableMediaCard={false}
 		/>
 	);
 };
@@ -340,7 +340,7 @@ export const Card25Media25SmallHeadline = ({
 			imageSize="small"
 			headlineSize="small"
 			headlineSizeOnMobile="medium"
-			videoSize="too small to play: 479px or less"
+			isPlayableMediaCard={false}
 		/>
 	);
 };
@@ -383,7 +383,7 @@ export const Card25Media25Tall = ({
 					: undefined
 			}
 			supportingContent={trail.supportingContent?.slice(0, 2)}
-			videoSize="too small to play: 479px or less"
+			isPlayableMediaCard={false}
 		/>
 	);
 };
@@ -418,7 +418,7 @@ export const Card25Media25TallNoTrail = ({
 			headlineSize="medium"
 			headlineSizeOnMobile="medium"
 			supportingContent={trail.supportingContent?.slice(0, 2)}
-			videoSize="too small to play: 479px or less"
+			isPlayableMediaCard={false}
 		/>
 	);
 };
@@ -453,7 +453,7 @@ export const Card25Media25TallSmallHeadline = ({
 			headlineSize="small"
 			headlineSizeOnMobile="medium"
 			supportingContent={trail.supportingContent?.slice(0, 2)}
-			videoSize="too small to play: 479px or less"
+			isPlayableMediaCard={false}
 		/>
 	);
 };
@@ -694,7 +694,7 @@ export const CardDefault = ({
 			avatarUrl={undefined}
 			headlineSize="small"
 			headlineSizeOnMobile="small"
-			videoSize="too small to play: 479px or less"
+			isPlayableMediaCard={false}
 		/>
 	);
 };
@@ -726,7 +726,7 @@ export const CardDefaultMedia = ({
 			imagePositionOnMobile="none"
 			headlineSize="small"
 			headlineSizeOnMobile="small"
-			videoSize="too small to play: 479px or less"
+			isPlayableMediaCard={false}
 		/>
 	);
 };
@@ -758,7 +758,7 @@ export const CardDefaultMediaMobile = ({
 			imagePositionOnMobile="left"
 			headlineSize="small"
 			headlineSizeOnMobile="small"
-			videoSize="too small to play: 479px or less"
+			isPlayableMediaCard={false}
 		/>
 	);
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3088,10 +3088,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/ab-core/-/ab-core-5.0.0.tgz#cce32ff4cdfb6b24c013723bf352dcd61135d34d"
   integrity sha512-Td5gtK2sARl+fXj1Qe6RuFqf/zxuZjW1q2Jck09zXPIfMgU+sJoTi549zbNeC1cldCBhPWy/qPQ0r+8klfF7jg==
 
-"@guardian/atoms-rendering@32.2.3":
-  version "32.2.3"
-  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-32.2.3.tgz#2abea32bf948844988c4a9fe4b4edd1c8c5d4e12"
-  integrity sha512-mwxDvJys+lbe7GyzyK7zi7dcjddYotGtKh7kOsYXZwDy4E5ptJ1m2BJwT7dXnzZ40B+Idys7rK3pyLynIIiqZg==
+"@guardian/atoms-rendering@32.3.0":
+  version "32.3.0"
+  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-32.3.0.tgz#464e839822dc3e600085f024c5555e22cf74ffe5"
+  integrity sha512-x8EI257zhuJtf+1iXcqMnNTFhOSsAFn+Zwfw1yCebxD2VB9hAUUZh55+LezpPa18O68W+w6+cOM50C7XkN0YTQ==
   dependencies:
     is-mobile "3.1.1"
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Extends the current carousel and card components to build a video carousel container. 

Videos within the video container are playing on all breakpoints, not just cards greater than 480px. Because of this, the `videoSize` prop has been renamed `isPlayableMediaCard` to better reflect what this prop controls.

This PR also bumps Atoms Rendering to @32.3.3. This adds the ability to auto-pause videos on scroll and conditionally renders the text overlay (kicker and title)

## Why?
Previously, videos containers were the standard carousel container and did not play on fronts. This was not in parity with Frontend but the concession was made to allow a full roll out of dcr fronts across all editions. 

This PR builds back to parity with Frontend rendered fronts and also builds on this to allow videos in a video container to be playable across all all breakpoints.

## Screenshots

https://github.com/guardian/dotcom-rendering/assets/20416599/aacaa696-a9dd-418d-9055-45adef4ba908

# Desktop
| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |
| ![before2][] | ![after2][] |
| ![before3][] | ![after3][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/20416599/d860d3e6-7986-4201-9ba0-5509965f67b2
[after]: https://github.com/guardian/dotcom-rendering/assets/20416599/d6c01efa-514c-4c99-ae97-d314f027f539

[before2]: https://github.com/guardian/dotcom-rendering/assets/20416599/332209b7-959e-473a-95b7-512ec7056e80
[after2]: https://github.com/guardian/dotcom-rendering/assets/20416599/b7ae1764-33f6-4acb-a23a-09ac2d096a9b

[before3]: https://github.com/guardian/dotcom-rendering/assets/20416599/69542fd9-6742-43f9-8e9d-dee5961fb5cc
[after3]: https://github.com/guardian/dotcom-rendering/assets/20416599/ddf11b42-ef1e-42c4-a1a2-24f87132d0af
<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
