### PR TITLE
Weather Time Format By Edition

### DIFF
--- a/dotcom-rendering/src/components/Weather.tsx
+++ b/dotcom-rendering/src/components/Weather.tsx
@@ -28,9 +28,9 @@ import {
 	SvgExternal,
 } from '@guardian/source-react-components';
 import { useId } from 'react';
+import type { EditionId } from '../lib/edition';
 import type { WeatherData, WeatherForecast } from './WeatherData.importable';
 import { WeatherSlot } from './WeatherSlot';
-import type { EditionId } from '../lib/edition';
 
 const visuallyHiddenCSS = css`
 	${visuallyHidden}

--- a/dotcom-rendering/src/components/Weather.tsx
+++ b/dotcom-rendering/src/components/Weather.tsx
@@ -28,9 +28,9 @@ import {
 	SvgExternal,
 } from '@guardian/source-react-components';
 import { useId } from 'react';
-import type { FEFrontConfigType } from '../types/front';
 import type { WeatherData, WeatherForecast } from './WeatherData.importable';
 import { WeatherSlot } from './WeatherSlot';
+import type { EditionId } from '../lib/edition';
 
 const visuallyHiddenCSS = css`
 	${visuallyHidden}
@@ -193,7 +193,7 @@ export interface WeatherProps {
 	};
 	now: WeatherData;
 	forecast: WeatherForecast;
-	edition: FEFrontConfigType['edition'];
+	edition: EditionId;
 }
 
 const collapsibleStyles = css`
@@ -235,7 +235,6 @@ const collapsibleStyles = css`
 export const Weather = ({ location, now, forecast, edition }: WeatherProps) => {
 	const checkboxId = useId();
 
-	const isUS = edition === 'US';
 	return (
 		<aside css={[collapsibleStyles, weatherCSS]}>
 			<input id={checkboxId} className="checkbox" type="checkbox" />
@@ -247,7 +246,7 @@ export const Weather = ({ location, now, forecast, edition }: WeatherProps) => {
 			<p css={visuallyHiddenCSS}>Today’s weather for {location.city}:</p>
 
 			<div css={[nowCSS, slotCSS]} className="now">
-				<WeatherSlot {...now} isUS={isUS} />
+				<WeatherSlot {...now} edition={edition} />
 				<label htmlFor={checkboxId} className="checkbox-label">
 					<SvgChevronDownSingle size="xsmall"></SvgChevronDownSingle>
 					<SvgChevronUpSingle size="xsmall"></SvgChevronUpSingle>
@@ -255,16 +254,16 @@ export const Weather = ({ location, now, forecast, edition }: WeatherProps) => {
 			</div>
 
 			<div css={slotCSS} className="forecast-1 collapsible">
-				<WeatherSlot isUS={isUS} {...forecast[3]} />
+				<WeatherSlot edition={edition} {...forecast[3]} />
 			</div>
 			<div css={slotCSS} className="forecast-2 collapsible">
-				<WeatherSlot isUS={isUS} {...forecast[6]} />
+				<WeatherSlot edition={edition} {...forecast[6]} />
 			</div>
 			<div css={slotCSS} className="forecast-3 collapsible">
-				<WeatherSlot isUS={isUS} {...forecast[9]} />
+				<WeatherSlot edition={edition} {...forecast[9]} />
 			</div>
 			<div css={slotCSS} className="forecast-4 collapsible">
-				<WeatherSlot isUS={isUS} {...forecast[12]} />
+				<WeatherSlot edition={edition} {...forecast[12]} />
 			</div>
 
 			<div css={linkCSS} className="collapsible">

--- a/dotcom-rendering/src/components/WeatherData.importable.tsx
+++ b/dotcom-rendering/src/components/WeatherData.importable.tsx
@@ -1,5 +1,5 @@
+import type { EditionId } from '../lib/edition';
 import { useApi } from '../lib/useApi';
-import type { FEFrontConfigType } from '../types/front';
 import { Weather } from './Weather';
 
 /**
@@ -56,7 +56,7 @@ export type WeatherApiData = {
 
 type Props = {
 	ajaxUrl: string;
-	edition: FEFrontConfigType['edition'];
+	edition: EditionId;
 };
 
 export const WeatherData = ({ ajaxUrl, edition }: Props) => {

--- a/dotcom-rendering/src/components/WeatherSlot.tsx
+++ b/dotcom-rendering/src/components/WeatherSlot.tsx
@@ -10,8 +10,8 @@ import {
 } from '@guardian/source-foundations';
 import { isNull } from 'lodash';
 import { lazy, Suspense } from 'react';
-import type { WeatherData } from './WeatherData.importable';
 import { type EditionId, getEditionFromId } from '../lib/edition';
+import type { WeatherData } from './WeatherData.importable';
 
 interface IconProps {
 	size?: number;

--- a/dotcom-rendering/src/components/WeatherSlot.tsx
+++ b/dotcom-rendering/src/components/WeatherSlot.tsx
@@ -11,6 +11,7 @@ import {
 import { isNull } from 'lodash';
 import { lazy, Suspense } from 'react';
 import type { WeatherData } from './WeatherData.importable';
+import { type EditionId, getEditionFromId } from '../lib/edition';
 
 interface IconProps {
 	size?: number;
@@ -19,15 +20,11 @@ interface IconProps {
 const formatTemperature = (value: number, unit: string) =>
 	`${value}°${unit.toLocaleUpperCase()}`;
 
-const formatTime = (dateTime: string, isUS: boolean) =>
-	isUS
-		? new Date(dateTime).toLocaleTimeString('en-US', {
-				hour: 'numeric',
-		  })
-		: new Date(dateTime).toLocaleTimeString(undefined, {
-				hour: '2-digit',
-				minute: '2-digit',
-		  });
+const formatTime = (dateTime: string, edition: EditionId) =>
+	new Date(dateTime).toLocaleTimeString(getEditionFromId(edition).locale, {
+		hour: 'numeric',
+		minute: 'numeric',
+	});
 
 const visuallyHiddenCSS = css`
 	${visuallyHidden}
@@ -133,7 +130,7 @@ const LoadingIcon = () => (
 );
 
 export type WeatherSlotProps = WeatherData & {
-	isUS: boolean;
+	edition: EditionId;
 	css?: SerializedStyles;
 	dateTime?: string;
 };
@@ -143,7 +140,7 @@ export const WeatherSlot = ({
 	temperature,
 	dateTime,
 	description,
-	isUS,
+	edition,
 	...props
 }: WeatherSlotProps) => {
 	const isNow = isUndefined(dateTime) || isNull(dateTime);
@@ -183,10 +180,10 @@ export const WeatherSlot = ({
 						<span css={visuallyHiddenCSS}>is</span>
 						<span css={tempCSS(isNow)} className="temp">
 							{formatTemperature(
-								isUS
+								edition === 'US'
 									? temperature.imperial
 									: temperature.metric,
-								isUS ? 'F' : 'C',
+								edition === 'US' ? 'F' : 'C',
 							)}
 						</span>
 						<span css={visuallyHiddenCSS}>
@@ -198,15 +195,15 @@ export const WeatherSlot = ({
 				<div css={flexRowBelowLeftCol}>
 					<div css={flexColumnBelowLeftCol}>
 						<time css={timeCSS} dateTime={dateTime}>
-							{formatTime(dateTime, isUS)}
+							{formatTime(dateTime, edition)}
 						</time>
 						<span css={visuallyHiddenCSS}>is</span>
 						<span css={tempCSS(isNow)} className="temp">
 							{formatTemperature(
-								isUS
+								edition === 'US'
 									? temperature.imperial
 									: temperature.metric,
-								isUS ? 'F' : 'C',
+								edition === 'US' ? 'F' : 'C',
 							)}
 						</span>
 						<span css={visuallyHiddenCSS}>

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -142,7 +142,7 @@ const decideLeftContent = (
 			<Island clientOnly={true} deferUntil={'idle'}>
 				<WeatherData
 					ajaxUrl={front.config.ajaxUrl}
-					edition={front.config.edition}
+					edition={front.editionId}
 				/>
 			</Island>
 		);


### PR DESCRIPTION
## Why?

Previously this relied on the user's runtime locale in all cases except the US edition, which was causing formatting problems.

## Changes

- Use the locale derived from the edition to format weather timestamps
- Use the built-in `hour: 'numeric'` and `minute: 'numeric'` formatters to provide locale-appropriate time formatting
- Pass edition down to the weather widget

## Screenshots

| Edition | Locale | Widget |
| - | - | - |
| UK | en-GB | ![weather-gb] |
| US | en-US | ![weather-us] |
| AU | en-AU | ![weather-au] |
| International | en-GB | ![weather-gb] |
| Europe | en-GB | ![weather-gb] |

[weather-gb]: https://github.com/guardian/dotcom-rendering/assets/53781962/69d2aac6-a0b1-472e-978f-ca27574c1acd
[weather-au]: https://github.com/guardian/dotcom-rendering/assets/53781962/7ff4fefb-c32d-4d5c-bed2-cd9cfd8be79d
[weather-us]: https://github.com/guardian/dotcom-rendering/assets/53781962/bec9a142-bc40-485d-b703-33477ccca70e
