### PR TITLE
Filter out palette styles to fix container numbering on DCR fronts

### DIFF
--- a/dotcom-rendering/src/model/enhanceCollections.ts
+++ b/dotcom-rendering/src/model/enhanceCollections.ts
@@ -13,7 +13,6 @@ import { enhanceTreats } from './enhanceTreats';
 import { groupCards } from './groupCards';
 
 const FORBIDDEN_CONTAINERS = [
-	'Palette styles new do not delete',
 	'Palette styles',
 	'culture-treat',
 	'newsletter treat',

--- a/dotcom-rendering/src/model/enhanceCollections.ts
+++ b/dotcom-rendering/src/model/enhanceCollections.ts
@@ -17,13 +17,15 @@ const FORBIDDEN_CONTAINERS = [
 	'newsletter treat',
 	'qatar treat',
 ];
+
+const PALETTE_STYLES_URI =
+	'https://content.guardianapis.com/atom/interactive/interactives/2022/03/29/fronts-container-colours/default';
+
 const isSupported = (collection: FECollectionType): boolean =>
 	!(
 		FORBIDDEN_CONTAINERS.includes(collection.displayName) ||
 		collection.curated.some(
-			(card) =>
-				card.properties.embedUri ===
-				'https://content.guardianapis.com/atom/interactive/interactives/2022/03/29/fronts-container-colours/default',
+			(card) => card.properties.embedUri === PALETTE_STYLES_URI,
 		)
 	);
 

--- a/dotcom-rendering/src/model/enhanceCollections.ts
+++ b/dotcom-rendering/src/model/enhanceCollections.ts
@@ -20,7 +20,7 @@ const FORBIDDEN_CONTAINERS = [
 	'qatar treat',
 ];
 const isSupported = (collection: FECollectionType): boolean =>
-	!FORBIDDEN_CONTAINERS.includes(collection.displayName);
+	!FORBIDDEN_CONTAINERS.some((name) => collection.displayName.includes(name));
 
 function getBrandingFromCards(
 	allCards: FEFrontCard[],

--- a/dotcom-rendering/src/model/enhanceCollections.ts
+++ b/dotcom-rendering/src/model/enhanceCollections.ts
@@ -13,13 +13,19 @@ import { enhanceTreats } from './enhanceTreats';
 import { groupCards } from './groupCards';
 
 const FORBIDDEN_CONTAINERS = [
-	'Palette styles',
 	'culture-treat',
 	'newsletter treat',
 	'qatar treat',
 ];
 const isSupported = (collection: FECollectionType): boolean =>
-	!FORBIDDEN_CONTAINERS.some((name) => collection.displayName.includes(name));
+	!(
+		FORBIDDEN_CONTAINERS.includes(collection.displayName) ||
+		collection.curated.some(
+			(card) =>
+				card.properties.embedUri ===
+				'https://content.guardianapis.com/atom/interactive/interactives/2022/03/29/fronts-container-colours/default',
+		)
+	);
 
 function getBrandingFromCards(
 	allCards: FEFrontCard[],


### PR DESCRIPTION
## What does this change?
Changes the isSupported value to check if a container display name contains a forbidden container name as a substring, instead of matching it exactly.

## Why?
For some DCR fronts (https://www.theguardian.com/uk/business, https://www.theguardian.com/football) the palette styles are not being filtered out and are being labelled as 'container-1' in the DOM. 

<img width="333" alt="Screenshot 2023-07-27 at 14 43 34" src="https://github.com/guardian/dotcom-rendering/assets/108270776/a4986db6-1667-4113-80ce-a6a0a82fbf25">

This is happening for these edge cases because the display names of the palette styles container in the collection contains a mistake or typo. In the case of the business front, the palette container display name contains a space, so it doesn't exactly match the forbidden container string and will not be filtered out.

<img width="478" alt="Screenshot 2023-07-27 at 14 45 21" src="https://github.com/guardian/dotcom-rendering/assets/108270776/994de8d2-59f1-412b-bba7-2d71dad43209">

This is causing the top-above-nav ad to be rendered further down on mobile view on these fronts, as it can't be added to the first container, because it's the palette styles container. For the business front, the first top-above-nav appears about a third of the way down the front.

<img width="353" alt="Screenshot 2023-07-27 at 14 49 07" src="https://github.com/guardian/dotcom-rendering/assets/108270776/55ba7741-512a-44b6-a51f-cdfab03b09f8">


This PR should hopefully resolve this issue, helping the top-above-nav to render after the first container on mobile, boosting ad revenue for these fronts. The code change now means that any container containing the substring 'Palette styles' will now be filtered out, catching these edge cases.

