### PR TITLE
Add support for `ArticleDesign.Timeline` in Editions

### DIFF
--- a/apps-rendering/src/components/editions/layout/index.tsx
+++ b/apps-rendering/src/components/editions/layout/index.tsx
@@ -169,6 +169,7 @@ const getSectionStyles = (item: ArticleFormat): SerializedStyles[] => {
 
 const Layout: FC<Props> = ({ item }) => {
 	if (
+		item.design === ArticleDesign.Timeline ||
 		item.design === ArticleDesign.Profile ||
 		item.design === ArticleDesign.Explainer ||
 		item.design === ArticleDesign.Analysis ||


### PR DESCRIPTION
Allowed `ArticleDesign.Timeline` to be rendered by the main Editions layout

Fixes #8332 