### PR TITLE
Add container to merchandising high on fronts

### DIFF
--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -93,11 +93,20 @@ export const decideAdSlot = (
 		index === getMerchHighPosition(collectionCount, isNetworkFront)
 	) {
 		return (
-			<AdSlot
-				data-print-layout="hide"
-				position="merchandising-high"
-				hasPageskin={hasPageSkin}
-			/>
+			<Section
+				fullWidth={true}
+				padSides={false}
+				showTopBorder={false}
+				showSideBorders={false}
+				backgroundColour={neutral[93]}
+				element="aside"
+			>
+				<AdSlot
+					data-print-layout="hide"
+					position="merchandising-high"
+					hasPageskin={hasPageSkin}
+				/>
+			</Section>
 		);
 	} else if (mobileAdPositions.includes(index)) {
 		return (


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Wrap the merchandising-high slot on fronts in a section container that applies a light grey background.

## Why?

This is to match the styling on articles pages. It shouldn't be noticeable when a native template fills the slot,
but will be when we serve billboards (which we'll be testing shortly).

## Screenshots

| Before      | After      | Article (for comparison)
| ----------- | ---------- | ---------- |
| ![before][] | ![after][] | ![article][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/8000415/d557bea0-aaa0-476d-ad49-8d2084e6c156
[after]: https://github.com/guardian/dotcom-rendering/assets/8000415/7d035154-56fa-4074-90e6-3d9700b40a1a
[article]: https://github.com/guardian/dotcom-rendering/assets/8000415/c8410995-7c54-42fd-8d6b-36ec821c12d6



<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
