### PR TITLE
fix: default to grey line if no match for cardSupporting colour

### DIFF
--- a/dotcom-rendering/src/lib/decidePalette.ts
+++ b/dotcom-rendering/src/lib/decidePalette.ts
@@ -1446,7 +1446,7 @@ const borderCardSupporting = (format: ArticleFormat): string => {
 				case ArticleSpecial.SpecialReport:
 					return opinion[550];
 				default:
-					return neutral[46];
+					return neutral[86];
 			}
 		case ArticleDesign.LiveBlog:
 			switch (format.theme) {
@@ -1464,7 +1464,7 @@ const borderCardSupporting = (format: ArticleFormat): string => {
 					return brandAlt[400];
 				case ArticleSpecial.Labs:
 				default:
-					return BLACK;
+					return neutral[86];
 			}
 		case ArticleDesign.Gallery:
 		case ArticleDesign.Audio:
@@ -1486,6 +1486,8 @@ const borderCardSupporting = (format: ArticleFormat): string => {
 					return culture[500];
 				case ArticleSpecial.Labs:
 					return labs[400];
+				default:
+					return neutral[86];
 			}
 		default:
 			switch (format.theme) {


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Defaults to `neutral[86]` if no matches found in the switch statement.

## Why?

The "hairline" or line above the headline for supporting content was defaulting to black, or dark grey for some cases
Fixes #8390.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/43961396/bd5fd23c-7d8b-474f-8f63-aeb17cb25152
[after]: https://github.com/guardian/dotcom-rendering/assets/43961396/d9b90cb4-4391-4f46-a61c-bab40891b3ad

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
