### PR TITLE
Use the scheduler to boot the app in 1% test

### DIFF
--- a/dotcom-rendering/scripts/webpack/bundles.js
+++ b/dotcom-rendering/scripts/webpack/bundles.js
@@ -2,26 +2,26 @@
  * Controls whether we should build the variant bundle.
  *
  * Set this to `true` if you want to serve a server-side experiment against
- * the `dcrJavascriptBundle` A/B test.
+ * the a variant bundle A/B test.
  *
  * Ensure Sentry sampling in sentry/index.ts is adjusted for the sample
  * size of the test
  *
  * @type {boolean} prevent TS from narrowing this to its current value
  */
-const BUILD_VARIANT = false;
+const BUILD_VARIANT = true;
 
 /**
- * Server-side test names for `dcr-javascript-bundle`.
+ * Server-side test names for running variant test.
  *
  * The name is transformed from kebab-case to camelCase,
- * so we have the `dcrJavascriptBundle` prefix.
+ * so we have the relevant prefix captured here.
  *
- * @see https://github.com/guardian/frontend/blob/a602273a/common/app/experiments/Experiments.scala#L20-L27
+ * @see https://github.com/guardian/frontend/blob/main/common/app/experiments/Experiments.scala
  *
  * @type {(variant: 'Variant' | 'Control') => import("../../src/types/config").ServerSideTestNames}
  */
-const dcrJavascriptBundle = (variant) => `dcrJavascriptBundle${variant}`;
+const dcrJavascriptBundle = (variant) => `adaptiveSite${variant}`;
 
 module.exports = {
 	BUILD_VARIANT,

--- a/dotcom-rendering/scripts/webpack/webpack.config.client.js
+++ b/dotcom-rendering/scripts/webpack/webpack.config.client.js
@@ -76,7 +76,10 @@ const getLoaders = (bundle) => {
  */
 module.exports = ({ bundle, sessionId }) => ({
 	entry: {
-		index: './src/client/index.ts',
+		index:
+			bundle === 'variant'
+				? './src/client/index.scheduled.ts'
+				: './src/client/index.ts',
 		debug: './src/client/debug/index.ts',
 	},
 	optimization:

--- a/dotcom-rendering/src/client/index.scheduled.ts
+++ b/dotcom-rendering/src/client/index.scheduled.ts
@@ -1,0 +1,70 @@
+// This is duplicate of ./index.ts that uses the scheduler to load modules.
+// The idea right now is to recreate the exact behaviour of a standard page,
+// to confirm that the scheduler itself does not introduce any regressions.
+// A bundle that uses this file as the entry point will be served in a 1% test.
+
+import './webpackPublicPath';
+
+// these modules are bundled in the initial (i.e. this) chunk, so that they run ASAP
+
+import type { ScheduleOptions } from '../lib/scheduler';
+import { schedule, setSchedulerConcurrency } from '../lib/scheduler';
+import { bootCmp } from './bootCmp';
+import { dynamicImport } from './dynamicImport';
+import { ga } from './ga';
+import { islands } from './islands';
+import { ophan } from './ophan';
+import { performanceMonitoring } from './performanceMonitoring';
+import { sentryLoader } from './sentryLoader';
+
+if (window.location.hash.includes('concurrency=')) {
+	const match = window.location.hash.match(/concurrency=(\d+)/);
+	if (match) {
+		setSchedulerConcurrency(Number(match[1]));
+	}
+}
+
+const boot = (
+	name: string,
+	task: () => Promise<unknown>,
+	options: ScheduleOptions = {
+		priority: 'critical',
+	},
+) => {
+	if (window.guardian.mustardCut || window.guardian.polyfilled) {
+		void schedule(name, task, options);
+	} else {
+		window.guardian.queue.push(() => void schedule(name, task, options));
+	}
+};
+
+boot('bootCmp', bootCmp);
+boot('ophan', ophan);
+boot('ga', ga);
+boot('sentryLoader', sentryLoader);
+boot('dynamicImport', dynamicImport);
+boot('islands', islands);
+boot('performanceMonitoring', performanceMonitoring);
+
+// these modules are loaded as separate chunks, so that they can be lazy-loaded
+void import(/* webpackChunkName: 'atomIframe' */ './atomIframe').then(
+	({ atomIframe }) => boot('atomIframe', atomIframe),
+);
+
+void import(/* webpackChunkName: 'embedIframe' */ './embedIframe').then(
+	({ embedIframe }) => boot('embedIframe', embedIframe),
+);
+
+void import(
+	/* webpackChunkName: 'newsletterEmbedIframe' */ './newsletterEmbedIframe'
+).then(({ newsletterEmbedIframe }) =>
+	boot('newsletterEmbedIframe', newsletterEmbedIframe),
+);
+
+void import(/* webpackChunkName: 'relativeTime' */ './relativeTime').then(
+	({ relativeTime }) => boot('relativeTime', relativeTime),
+);
+
+void import(/* webpackChunkName: 'discussion' */ './discussion').then(
+	({ discussion }) => boot('initDiscussion', discussion),
+);

--- a/dotcom-rendering/src/lib/scheduler.ts
+++ b/dotcom-rendering/src/lib/scheduler.ts
@@ -75,7 +75,8 @@ const queue: Record<
 /**
  * Standardised console logging.
  */
-const log = (message: string) => libsLog('dotcom', `🧑‍💻 Scheduler ${message}`);
+const log = (message: string) =>
+	libsLog('openJournalism', `🧑‍💻 Scheduler ${message}`);
 
 /**
  * Gets the next task to run, according to priority and the order they were


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

uses the scheduler added in #8334 to kick off the app for people in @guardian/open-journalism's `adaptive-site` experiment (1%).

although it's in use, it's not using any of the features (setting priority or limiting concurrency). 

## Why?

we want to confirm that by default, the scheduler behaves the same as the unregulated entry in `main`.