### PR TITLE
Container type refactor

### DIFF
--- a/dotcom-rendering/src/components/Carousel.importable.tsx
+++ b/dotcom-rendering/src/components/Carousel.importable.tsx
@@ -42,7 +42,7 @@ type ArticleProps = Props & {
 
 type FrontProps = Props & {
 	palette: DCRContainerPalette;
-	collectionType?: string;
+	containerType?: DCRContainerType;
 	hasPageSkin?: boolean;
 };
 
@@ -852,7 +852,7 @@ export const Carousel = ({
 
 	const isCuratedContent = onwardsSource === 'curated-content';
 	const containerType =
-		'collectionType' in props ? props.collectionType : undefined;
+		'containerType' in props ? props.containerType : undefined;
 
 	const isVideoContainer = containerType === 'fixed/video';
 

--- a/dotcom-rendering/src/components/Carousel.importable.tsx
+++ b/dotcom-rendering/src/components/Carousel.importable.tsx
@@ -470,7 +470,7 @@ type CarouselCardProps = {
 	mainMedia?: MainMedia;
 	verticalDividerColour?: string;
 	onwardsSource?: string;
-	isVideoContainer?: boolean;
+	containerType?: DCRContainerType;
 };
 
 const CarouselCard = ({
@@ -487,41 +487,44 @@ const CarouselCard = ({
 	mainMedia,
 	verticalDividerColour,
 	onwardsSource,
-	isVideoContainer,
-}: CarouselCardProps) => (
-	<LI
-		percentage="25%"
-		showDivider={!isFirst && !isVideoContainer}
-		padSides={true}
-		padSidesOnMobile={true}
-		snapAlignStart={true}
-		verticalDividerColour={verticalDividerColour}
-	>
-		<Card
-			linkTo={linkTo}
-			format={format}
-			headlineText={headlineText}
-			webPublicationDate={webPublicationDate}
-			kickerText={kickerText}
-			imageUrl={imageUrl}
-			imageSize={'small'}
-			showClock={true}
-			showAge={true}
-			imagePositionOnMobile="top"
-			pauseOffscreenVideo={isVideoContainer}
-			showQuotedHeadline={format.design === ArticleDesign.Comment}
-			dataLinkName={dataLinkName}
-			discussionId={discussionId}
-			branding={branding}
-			isExternalLink={false}
-			mainMedia={mainMedia}
-			minWidthInPixels={220}
-			isPlayableMediaCard={isVideoContainer}
-			onwardsSource={onwardsSource}
-			containerType={isVideoContainer ? 'fixed/video' : undefined}
-		/>
-	</LI>
-);
+	containerType,
+}: CarouselCardProps) => {
+	const isVideoContainer = containerType === 'fixed/video';
+	return (
+		<LI
+			percentage="25%"
+			showDivider={!isFirst && !isVideoContainer}
+			padSides={true}
+			padSidesOnMobile={true}
+			snapAlignStart={true}
+			verticalDividerColour={verticalDividerColour}
+		>
+			<Card
+				linkTo={linkTo}
+				format={format}
+				headlineText={headlineText}
+				webPublicationDate={webPublicationDate}
+				kickerText={kickerText}
+				imageUrl={imageUrl}
+				imageSize={'small'}
+				showClock={true}
+				showAge={true}
+				imagePositionOnMobile="top"
+				pauseOffscreenVideo={isVideoContainer}
+				showQuotedHeadline={format.design === ArticleDesign.Comment}
+				dataLinkName={dataLinkName}
+				discussionId={discussionId}
+				branding={branding}
+				isExternalLink={false}
+				mainMedia={mainMedia}
+				minWidthInPixels={220}
+				isPlayableMediaCard={isVideoContainer}
+				onwardsSource={onwardsSource}
+				containerType={containerType}
+			/>
+		</LI>
+	);
+};
 
 type HeaderAndNavProps = {
 	heading: string;
@@ -1062,7 +1065,7 @@ export const Carousel = ({
 									carouselColours.borderColour
 								}
 								onwardsSource={onwardsSource}
-								isVideoContainer={isVideoContainer}
+								containerType={containerType}
 							/>
 						);
 					})}

--- a/dotcom-rendering/src/components/Carousel.importable.tsx
+++ b/dotcom-rendering/src/components/Carousel.importable.tsx
@@ -851,9 +851,10 @@ export const Carousel = ({
 	const arrowName = 'carousel-small-arrow';
 
 	const isCuratedContent = onwardsSource === 'curated-content';
+	const containerType =
+		'collectionType' in props ? props.collectionType : undefined;
 
-	const isVideoContainer =
-		'collectionType' in props && props.collectionType === 'fixed/video';
+	const isVideoContainer = containerType === 'fixed/video';
 
 	const hasPageSkin = 'hasPageSkin' in props && (props.hasPageSkin ?? false);
 

--- a/dotcom-rendering/src/components/Carousel.importable.tsx
+++ b/dotcom-rendering/src/components/Carousel.importable.tsx
@@ -593,7 +593,7 @@ const Header = ({
 	next,
 	arrowName,
 	isCuratedContent,
-	isVideoContainer,
+	containerType,
 	hasPageSkin,
 }: {
 	heading: string;
@@ -605,9 +605,10 @@ const Header = ({
 	next: () => void;
 	arrowName: string;
 	isCuratedContent: boolean;
-	isVideoContainer: boolean;
+	containerType?: DCRContainerType;
 	hasPageSkin: boolean;
 }) => {
+	const isVideoContainer = containerType === 'fixed/video';
 	const header = (
 		<div css={headerRowStyles}>
 			<HeaderAndNav
@@ -619,7 +620,7 @@ const Header = ({
 				index={index}
 				isCuratedContent={isCuratedContent}
 				goToIndex={goToIndex}
-				containerType={isVideoContainer ? 'fixed/video' : undefined}
+				containerType={containerType}
 			/>
 			<Hide when="below" breakpoint="desktop">
 				<button
@@ -1013,7 +1014,7 @@ export const Carousel = ({
 					next={next}
 					arrowName={arrowName}
 					isCuratedContent={isCuratedContent}
-					isVideoContainer={isVideoContainer}
+					containerType={containerType}
 					hasPageSkin={hasPageSkin}
 				/>
 				<ul

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -547,7 +547,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 											onwardsSource={'unknown-source'}
 											palette={containerPalette}
 											leftColSize={'compact'}
-											collectionType={
+											containerType={
 												collection.collectionType
 											}
 											hasPageSkin={hasPageSkin}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Refactors the use of the isVideoContainer prop in favour of a more generic containerType prop to reduce the layers of transformation as suggested by @jamesgorrie [here](https://github.com/guardian/dotcom-rendering/pull/8392#discussion_r1276418229). It also refactors the containerType prop name to be more consistent across the code base and favours a stricter type of DCRContainerType over string.