### PR TITLE
Dblatcher soccer treat

### DIFF
--- a/dotcom-rendering/src/model/enhanceTreats.ts
+++ b/dotcom-rendering/src/model/enhanceTreats.ts
@@ -15,6 +15,19 @@ const SOCCER_TREAT: TreatType = {
 	altText: 'Soccer ball',
 };
 
+const HEADLINES_US_TREAT: TreatType = {
+	links: [
+		{
+			linkTo: '/info/2015/dec/08/daily-email-us?INTCMP=gdnwb_treat_election_today_us',
+			title: 'Guardian Today US: ',
+			text: 'Get the headlines & more in a daily email',
+		},
+	],
+	theme: Pillar.News,
+	imageUrl: 'https://uploads.guim.co.uk/2020/10/22/newsletter-treat-img.png',
+	altText: 'The White House',
+};
+
 /**
  * PLATFORM_TREATS
  *
@@ -30,35 +43,15 @@ const SOCCER_TREAT: TreatType = {
  */
 const PLATFORM_TREATS: TreatType[] = [
 	{
-		links: [
-			{
-				linkTo: '/info/2015/dec/08/daily-email-us?INTCMP=gdnwb_treat_election_today_us',
-				title: 'Guardian Today US: ',
-				text: 'Get the headlines & more in a daily email',
-			},
-		],
-		theme: Pillar.News,
+		...HEADLINES_US_TREAT,
+		pageId: 'us',
 		containerTitle: 'Spotlight',
 		editionId: 'US',
-		imageUrl:
-			'https://uploads.guim.co.uk/2020/10/22/newsletter-treat-img.png',
-		altText: 'The White House',
-		pageId: 'us',
 	},
 	{
-		links: [
-			{
-				linkTo: '/info/2015/dec/08/daily-email-us?INTCMP=gdnwb_treat_election_today_us',
-				title: 'Guardian Today US: ',
-				text: 'Get the headlines & more in a daily email',
-			},
-		],
-		theme: Pillar.News,
-		containerTitle: 'US headlines',
-		imageUrl:
-			'https://uploads.guim.co.uk/2020/10/22/newsletter-treat-img.png',
-		altText: 'The White House',
+		...HEADLINES_US_TREAT,
 		pageId: 'us-news',
+		containerTitle: 'US headlines',
 	},
 	{
 		links: [
@@ -68,15 +61,15 @@ const PLATFORM_TREATS: TreatType[] = [
 			},
 		],
 		theme: Pillar.News,
-		containerTitle: 'Qatar: beyond the football',
 		imageUrl:
 			'https://uploads.guim.co.uk/2023/06/02/BALL-nugget-grass_5.png',
 		altText: 'Image of football covered in bank notes',
 		pageId: 'football/world-cup-2022',
+		containerTitle: 'Qatar: beyond the football',
 	},
 	{
 		...SOCCER_TREAT,
-		pageId:'us',
+		pageId: 'us',
 		containerTitle: 'Sports',
 	},
 ];

--- a/dotcom-rendering/src/model/enhanceTreats.ts
+++ b/dotcom-rendering/src/model/enhanceTreats.ts
@@ -2,6 +2,19 @@ import { Pillar } from '@guardian/libs';
 import type { EditionId } from '../lib/edition';
 import type { FEFrontCard, TreatType } from '../types/front';
 
+const SOCCER_TREAT: TreatType = {
+	links: [
+		{
+			linkTo: '/football/2023/jul/20/sign-up-for-soccer-with-jonathan-wilson-his-free-weekly-newsletter-on-european-soccer',
+			title: 'Soccer with Jonathan Wilson: ',
+			text: 'The latest on the global game',
+		},
+	],
+	theme: Pillar.Sport,
+	imageUrl: 'https://uploads.guim.co.uk/2023/07/26/soccer-treat-v1.png',
+	altText: 'Soccer ball',
+};
+
 /**
  * PLATFORM_TREATS
  *
@@ -60,6 +73,11 @@ const PLATFORM_TREATS: TreatType[] = [
 			'https://uploads.guim.co.uk/2023/06/02/BALL-nugget-grass_5.png',
 		altText: 'Image of football covered in bank notes',
 		pageId: 'football/world-cup-2022',
+	},
+	{
+		...SOCCER_TREAT,
+		pageId:'us',
+		containerTitle: 'Sports',
 	},
 ];
 


### PR DESCRIPTION
## What does this change?

Adds an illustrated platform Treat promoting the "Soccer with Jonathan Wilson" newsletter to the "Sports" container of the '/us' front

## Why?

Editorial request from the US newsletters team. 

Adding illustrated Treats to DCR using the frontend data model is not currently support - adding them manually in the `enhanceTreats`  module is the current solution.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| <img width="1534" alt="Screenshot 2023-07-28 at 12 56 17" src="https://github.com/guardian/dotcom-rendering/assets/30567854/ab279e24-9d71-4159-8be7-b452e75958a5">|<img width="1534" alt="Screenshot 2023-07-28 at 12 55 54" src="https://github.com/guardian/dotcom-rendering/assets/30567854/aaac19e3-5ae7-4b5e-8efc-fda7bbaac56a">|



