### PR TITLE
Use latest source-foundations in DCR

### DIFF
--- a/.github/workflows/dcr-chromatic.yml
+++ b/.github/workflows/dcr-chromatic.yml
@@ -43,6 +43,6 @@ jobs:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN__DOTCOM_RENDERING }}
           token: ${{ secrets.GITHUB_TOKEN }}
           autoAcceptChanges: main
-          # onlyChanged: true
-          # untraced: '**/(package*.json|yarn.lock|preview.js)'
+          onlyChanged: true
+          untraced: '**/(package*.json|yarn.lock|preview.js)'
           workingDir: dotcom-rendering

--- a/.github/workflows/dcr-chromatic.yml
+++ b/.github/workflows/dcr-chromatic.yml
@@ -44,5 +44,5 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           autoAcceptChanges: main
           onlyChanged: true
-          untraced: '**/(package*.json|yarn.lock|preview.js)'
+          # untraced: '**/(package*.json|yarn.lock|preview.js)'
           workingDir: dotcom-rendering

--- a/.github/workflows/dcr-chromatic.yml
+++ b/.github/workflows/dcr-chromatic.yml
@@ -43,6 +43,6 @@ jobs:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN__DOTCOM_RENDERING }}
           token: ${{ secrets.GITHUB_TOKEN }}
           autoAcceptChanges: main
-          onlyChanged: true
+          # onlyChanged: true
           # untraced: '**/(package*.json|yarn.lock|preview.js)'
           workingDir: dotcom-rendering

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -75,7 +75,7 @@
 		"@guardian/libs": "15.4.0",
 		"@guardian/prettier": "4.0.0",
 		"@guardian/shimport": "1.0.2",
-		"@guardian/source-foundations": "12.0.0",
+		"@guardian/source-foundations": "13.0.0",
 		"@guardian/source-react-components": "15.0.1",
 		"@guardian/source-react-components-development-kitchen": "13.0.1",
 		"@guardian/support-dotcom-components": "1.0.7",

--- a/dotcom-rendering/src/components/TextBlockComponent.tsx
+++ b/dotcom-rendering/src/components/TextBlockComponent.tsx
@@ -146,7 +146,7 @@ const styles = (format: ArticleFormat) => css`
 	margin-bottom: 14px;
 	word-break: break-word;
 	${format.theme === ArticleSpecial.Labs ? textSans.medium() : body.medium()};
-	line-height: 1.4;
+
 	strong em,
 	strong u {
 		font-weight: bold;

--- a/dotcom-rendering/src/components/TextBlockComponent.tsx
+++ b/dotcom-rendering/src/components/TextBlockComponent.tsx
@@ -143,7 +143,7 @@ const sanitiserOptions: IOptions = {
 };
 
 const styles = (format: ArticleFormat) => css`
-	margin-bottom: 16px;
+	margin-bottom: 14px;
 	word-break: break-word;
 	${format.theme === ArticleSpecial.Labs ? textSans.medium() : body.medium()};
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3222,7 +3222,14 @@
   dependencies:
     tslib "^2.0.0"
 
-"@guardian/source-foundations@12.0.0", "@guardian/source-foundations@^12.0.0":
+"@guardian/source-foundations@13.0.0":
+  version "13.0.0"
+  resolved "https://registry.yarnpkg.com/@guardian/source-foundations/-/source-foundations-13.0.0.tgz#3e8f4e67dcd5fe706001fd04df582f69210b132f"
+  integrity sha512-1+z20ySfwm0K2GiQXh2JlWIjOKBwHxISRdAgAKivOdT1QUCh5VdU+2xCVE07juMI4lBBfIzXe/qZXAI7II6tQQ==
+  dependencies:
+    mini-svg-data-uri "1.4.4"
+
+"@guardian/source-foundations@^12.0.0":
   version "12.0.0"
   resolved "https://registry.yarnpkg.com/@guardian/source-foundations/-/source-foundations-12.0.0.tgz#3f75d5dd26dae0d3fe13fd93aabe1e837cf0ddbb"
   integrity sha512-sq+htAsvPlaZBjfSZ8ISZZdAnFQwuZ7xeCrI/C369HA+MDl3pQ1dFWz3YmqCP/vkXS8Wr3qVlxXNqWGwKKrYrw==


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Test to see what chaos this brings.

Ref: https://github.com/guardian/dotcom-rendering/pull/8385#discussion_r1275238346

Fixes the DCR side of #8386.
