### PR TITLE
Change merchandising high position for improved parity with frontend

### DIFF
--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -90,7 +90,7 @@ export const decideAdSlot = (
 	const minContainers = isPaidContent ? 1 : 2;
 	if (
 		collectionCount > minContainers &&
-		index === getMerchHighPosition(collectionCount, isNetworkFront)
+		index === getMerchHighPosition(collectionCount)
 	) {
 		return (
 			<AdSlot
@@ -161,7 +161,6 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 
 	const merchHighPosition = getMerchHighPosition(
 		front.pressedPage.collections.length,
-		front.isNetworkFront,
 	);
 
 	const renderAds = canRenderAds(front);

--- a/dotcom-rendering/src/layouts/TagFrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/TagFrontLayout.tsx
@@ -76,7 +76,6 @@ export const TagFrontLayout = ({ tagFront, NAV }: Props) => {
 
 	const merchHighPosition = getMerchHighPosition(
 		tagFront.groupedTrails.length,
-		false,
 	);
 
 	/**

--- a/dotcom-rendering/src/lib/getAdPositions.test.ts
+++ b/dotcom-rendering/src/lib/getAdPositions.test.ts
@@ -222,7 +222,7 @@ describe('Mobile Ads', () => {
 			merchHighPosition,
 		);
 
-		expect(mobileAdPositions).toEqual([0, 3, 6, 9, 12, 14]);
+		expect(mobileAdPositions).toEqual([0, 4, 8, 10, 13]);
 	});
 
 	// We used https://www.theguardian.com/tone/recipes as a blueprint
@@ -251,7 +251,7 @@ describe('Mobile Ads', () => {
 			merchHighPosition,
 		);
 
-		expect(mobileAdPositions).toEqual([2, 4, 6, 8, 10, 12]);
+		expect(mobileAdPositions).toEqual([1, 4, 6, 8, 10, 12]);
 	});
 });
 

--- a/dotcom-rendering/src/lib/getAdPositions.test.ts
+++ b/dotcom-rendering/src/lib/getAdPositions.test.ts
@@ -43,7 +43,6 @@ describe('Mobile Ads', () => {
 	it('Should not insert ad after a thrasher container', () => {
 		const merchHighPosition = getMerchHighPosition(
 			defaultTestCollections.length,
-			false,
 		);
 		const testCollections = [...defaultTestCollections];
 		testCollections.splice(6, 0, { collectionType: 'fixed/thrasher' });
@@ -76,10 +75,7 @@ describe('Mobile Ads', () => {
 			{ collectionType: 'news/most-popular' },
 		];
 
-		const merchHighPosition = getMerchHighPosition(
-			testCollections.length,
-			false,
-		);
+		const merchHighPosition = getMerchHighPosition(testCollections.length);
 
 		const mobileAdPositions = getMobileAdPositions(
 			testCollections,
@@ -118,10 +114,7 @@ describe('Mobile Ads', () => {
 			{ collectionType: 'news/most-popular' },
 		];
 
-		const merchHighPosition = getMerchHighPosition(
-			testCollections.length,
-			true,
-		);
+		const merchHighPosition = getMerchHighPosition(testCollections.length);
 
 		const mobileAdPositions = getMobileAdPositions(
 			testCollections,
@@ -191,10 +184,7 @@ describe('Mobile Ads', () => {
 			{ collectionType: 'news/most-popular' },
 		];
 
-		const merchHighPosition = getMerchHighPosition(
-			testCollections.length,
-			true,
-		);
+		const merchHighPosition = getMerchHighPosition(testCollections.length);
 
 		const mobileAdPositions = getMobileAdPositions(
 			testCollections,
@@ -225,10 +215,7 @@ describe('Mobile Ads', () => {
 			{ collectionType: 'news/most-popular' },
 		];
 
-		const merchHighPosition = getMerchHighPosition(
-			testCollections.length,
-			false,
-		);
+		const merchHighPosition = getMerchHighPosition(testCollections.length);
 
 		const mobileAdPositions = getMobileAdPositions(
 			testCollections,
@@ -257,10 +244,7 @@ describe('Mobile Ads', () => {
 			{ collectionType: 'news/most-popular' },
 		];
 
-		const merchHighPosition = getMerchHighPosition(
-			testCollections.length,
-			false,
-		);
+		const merchHighPosition = getMerchHighPosition(testCollections.length);
 
 		const mobileAdPositions = getMobileAdPositions(
 			testCollections,

--- a/dotcom-rendering/src/lib/getAdPositions.ts
+++ b/dotcom-rendering/src/lib/getAdPositions.ts
@@ -3,16 +3,9 @@ import type { GroupedTrailsBase } from '../types/tagFront';
 
 type AdCandidate = Pick<DCRCollectionType, 'collectionType'>;
 
-export const getMerchHighPosition = (
-	collectionCount: number,
-	isNetworkFront: boolean | undefined,
-): number => {
+export const getMerchHighPosition = (collectionCount: number): number => {
 	if (collectionCount >= 4) {
-		if (isNetworkFront === true) {
-			return 2;
-		} else {
-			return 1;
-		}
+		return 2;
 	} else {
 		return 0;
 	}


### PR DESCRIPTION
## What does this change?
Changes the merchandising high position for non network fronts.

## Why?

On frontend, the code returns the merchandising high position as 2 for non network fronts. The difficulty in reaching parity with frontend is partly due to palette styles being present on **some** frontend fronts and not others, which actually raises the position of the merch high slot. On the science front, when rendered by frontend, the merch high slot looks like it is at index 1, because the palette styles container is marked as being index 0 even though it isn't visible. On the environment front however, the merch high slot appears at index 2, **because there are no palette styles disrupting the container numbering**.

Given that we filter out the palette styles in DCR where frontend doesn't, the fronts **won't look exactly the same as in frontend**, due to the container numbering being consistent in DCR. This PR changes the merch high position for non network fronts to be index 2, **for parity with those fronts in frontend that do not contain the palette styles container**.

This means the merch high position should actually be the same for both network and non network fronts, so we can remove this parameter from the function.

This will also help resolve an issue that we currently have on the Culture front. Fronts that have a thrasher in the first or second container can't render their top-above-nav mobile slot after the first container. Due to the merch high being inserted after the second container, the top-above-nav gets pushed down to appearing after the third container. This means that between frontend and DCR, the mobile top-above-nav and merch high slots have effectively swapped places. This is disrupting some slot targeting for takeover ad campaigns. This numbering change should return the mobile slots to their correct positions.

## Screenshots

The palette styles container in frontend being numbered as the first container:
<img width="250" alt="Screenshot 2023-07-31 at 15 20 49" src="https://github.com/guardian/dotcom-rendering/assets/108270776/f49e2c10-c3c8-49bf-b002-c943c1c8cdcd">
