### PR TITLE
Use Fronts click through URL on carousel titles

### DIFF
--- a/dotcom-rendering/src/components/Carousel.importable.tsx
+++ b/dotcom-rendering/src/components/Carousel.importable.tsx
@@ -413,17 +413,23 @@ const Title = ({
 	titleColour,
 	titleHighlightColour,
 	isCuratedContent,
+	url,
 }: {
 	title: string;
 	titleColour: string;
 	titleHighlightColour: string;
 	isCuratedContent?: boolean;
+	url?: string;
 }) =>
-	title === 'Videos' ? (
+	url ? (
 		<a
 			css={[linkStyles]}
-			href="https://www.theguardian.com/video"
-			data-link-name="video-container-title Videos"
+			href={url}
+			data-link-name={
+				title === 'Videos'
+					? 'video-container-title Videos'
+					: 'section heading'
+			}
 		>
 			<h2 css={headerStyles}>
 				<span
@@ -454,7 +460,6 @@ const Title = ({
 			</span>
 		</h2>
 	);
-
 type CarouselCardProps = {
 	isFirst: boolean;
 	format: ArticleFormat;
@@ -536,6 +541,7 @@ type HeaderAndNavProps = {
 	goToIndex: (newIndex: number) => void;
 	isCuratedContent?: boolean;
 	containerType?: DCRContainerType;
+	url?: string;
 };
 
 const HeaderAndNav = ({
@@ -548,6 +554,7 @@ const HeaderAndNav = ({
 	goToIndex,
 	isCuratedContent,
 	containerType,
+	url,
 }: HeaderAndNavProps) => {
 	return (
 		<div>
@@ -556,6 +563,7 @@ const HeaderAndNav = ({
 				titleColour={titleColour}
 				titleHighlightColour={titleHighlightColour}
 				isCuratedContent={isCuratedContent}
+				url={url}
 			/>
 			<div css={dotsStyle}>
 				{trails.map((_, i) => (
@@ -595,6 +603,7 @@ const Header = ({
 	isCuratedContent,
 	containerType,
 	hasPageSkin,
+	url,
 }: {
 	heading: string;
 	trails: TrailType[];
@@ -607,6 +616,7 @@ const Header = ({
 	isCuratedContent: boolean;
 	containerType?: DCRContainerType;
 	hasPageSkin: boolean;
+	url?: string;
 }) => {
 	const isVideoContainer = containerType === 'fixed/video';
 	const header = (
@@ -621,6 +631,7 @@ const Header = ({
 				isCuratedContent={isCuratedContent}
 				goToIndex={goToIndex}
 				containerType={containerType}
+				url={url}
 			/>
 			<Hide when="below" breakpoint="desktop">
 				<button
@@ -981,6 +992,7 @@ export const Carousel = ({
 					index={index}
 					isCuratedContent={isCuratedContent}
 					goToIndex={goToIndex}
+					url={props.url}
 				/>
 			</LeftColumn>
 			<InlineChevrons
@@ -1016,6 +1028,7 @@ export const Carousel = ({
 					isCuratedContent={isCuratedContent}
 					containerType={containerType}
 					hasPageSkin={hasPageSkin}
+					url={props.url}
 				/>
 				<ul
 					css={[

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -551,6 +551,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 												collection.collectionType
 											}
 											hasPageSkin={hasPageSkin}
+											url={collection.href}
 										/>
 									</Island>
 								</Section>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Passes through the collection URL to the carousel title so that users can click through to the relevant page. The url is set in Fronts tool. This replaces the previously hardcoded `videos` link and ensures Fronts is the source of truth for this config.

## Why?
This is expected behaviour and replicates the behaviour of Frontend. 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
