### PR TITLE
use ab test switch for deeply read

### DIFF
--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -176,7 +176,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 		: [];
 
 	const showMostPopular =
-		front.config.switches.deeplyReadSwitch &&
+		front.config.switches.deeplyRead &&
 		front.isNetworkFront &&
 		front.deeplyRead &&
 		front.deeplyRead.length > 0;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Uses DeeplyRead AB test switch to decide if the deeply read footer section needs to be rendered 

This AB test is mainly used at the server side code to decide if the deeplyRead data should be retrieved for the page or not. Without the deeplyRead data, DCR won't render the deeplyRead (most popular) section. 

But the `deeplyRead` switch is used here just to check if the AB test switch is on or not. 

serverside PR: https://github.com/guardian/frontend/pull/26418
