### PR TITLE
Move US Today Treat

### DIFF
--- a/dotcom-rendering/src/model/enhanceTreats.ts
+++ b/dotcom-rendering/src/model/enhanceTreats.ts
@@ -45,7 +45,7 @@ const PLATFORM_TREATS: TreatType[] = [
 	{
 		...HEADLINES_US_TREAT,
 		pageId: 'us',
-		containerTitle: 'Spotlight',
+		containerTitle: 'Headlines',
 		editionId: 'US',
 	},
 	{


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Move the Guardian Today US treat from Spotlight to Headlines

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| <img width="1088" alt="Screenshot 2023-08-02 at 09 26 24" src="https://github.com/guardian/dotcom-rendering/assets/1229808/04baaa03-8739-49bd-adb5-d82e5dc2c46d"> | <img width="1149" alt="Screenshot 2023-08-02 at 09 26 10" src="https://github.com/guardian/dotcom-rendering/assets/1229808/3dbc0986-2f48-438c-8da3-2e584917e1cb"> |

