### PR TITLE
debug-paid-for-logo-in-front

### DIFF
--- a/dotcom-rendering/src/components/LabsSection.tsx
+++ b/dotcom-rendering/src/components/LabsSection.tsx
@@ -14,7 +14,9 @@ import {
 import { decideContainerOverrides } from '../lib/decideContainerOverrides';
 import LabsLogo from '../static/logos/the-guardian-labs.svg';
 import type { DCRBadgeType } from '../types/badge';
+import type { Branding } from '../types/branding';
 import { Badge } from './Badge';
+import { CardBranding } from './Card/components/CardBranding';
 import { Details } from './Details';
 import { Island } from './Island';
 import { Section } from './Section';
@@ -55,6 +57,10 @@ type Props = {
 
 	/** A sponsor badge can be displayed under the content cards */
 	badge?: DCRBadgeType;
+
+	branding?: Branding;
+
+	format?: ArticleFormat;
 
 	/** Usually the content cards that will be displayed inside the container */
 	children?: React.ReactNode;
@@ -373,10 +379,13 @@ export const LabsSection = ({
 	canShowMore,
 	url,
 	badge,
+	branding,
+	format,
 	children,
 	hasPageSkin = false,
 }: Props) => {
 	const overrides = decideContainerOverrides('Branded');
+	console.log('badge', badge);
 
 	return (
 		<Section
@@ -460,8 +469,12 @@ export const LabsSection = ({
 							/>
 						</div>
 					)}
+					{branding && format && (
+						<CardBranding branding={branding} format={format} />
+					)}
 				</Content>
 			</Container>
+			END OF CVONTAINNERR????
 		</Section>
 	);
 };

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -322,6 +322,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 				css={hasPageSkin && pageSkinContainer}
 			>
 				{front.pressedPage.collections.map((collection, index) => {
+					console.log('Collection', collection.displayName);
 					// Backfills should be added to the end of any curated content
 					const trails = collection.curated.concat(
 						collection.backfill,
@@ -352,6 +353,10 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 								eB.edition.id === front.editionId &&
 								!!eB.branding,
 						);
+
+					// Populate a variable for badge; if collection has a badge, use it.
+					// If not, create an object of DCRBadgeType populated with data from the Branding object
+					// of the first item in backfill.
 
 					if (collection.collectionType === 'fixed/thrasher') {
 						return (
@@ -483,7 +488,9 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 								containerName={collection.collectionType}
 								canShowMore={collection.canShowMore}
 								url={collection.href}
-								badge={collection.badge}
+								badge={collection.badge} // this branding obj
+								branding={collection.backfill[0]?.branding}
+								format={collection.backfill[0]?.format}
 								data-print-layout="hide"
 								hasPageSkin={hasPageSkin}
 							>

--- a/dotcom-rendering/src/server/index.front.web.ts
+++ b/dotcom-rendering/src/server/index.front.web.ts
@@ -17,7 +17,10 @@ import { renderFront, renderTagFront } from './render.front.web';
 
 const enhanceFront = (body: unknown): DCRFrontType => {
 	const data: FEFrontType = validateAsFrontType(body);
-
+	console.log(
+		'>>>',
+		data.pressedPage.collections.map((name) => name.displayName),
+	);
 	return {
 		...data,
 		webTitle: `${


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
This is a DRAFT PR to get the ball rolling for possible solutions to Branding on Fronts.
Currently we have logos for Branding in the cards of a section in Fronts. We wold like the logos to be in the Section Layout rather than in cards.