### PR TITLE
Handle Safari 13 performance measure errors

### DIFF
--- a/dotcom-rendering/src/client/islands/doHydration.tsx
+++ b/dotcom-rendering/src/client/islands/doHydration.tsx
@@ -1,9 +1,10 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access -- necessary for calling our async loaded modules */
 import type { EmotionCache } from '@emotion/react';
 import { CacheProvider } from '@emotion/react';
-import { log, startPerformanceMeasure } from '@guardian/libs';
+import { log } from '@guardian/libs';
 import { createElement } from 'react';
 import { createRoot, hydrateRoot } from 'react-dom/client';
+import { startPerformanceMeasure } from '../../lib/startPerformanceMeasure';
 
 declare global {
 	interface DOMStringMap {

--- a/dotcom-rendering/src/client/startup.ts
+++ b/dotcom-rendering/src/client/startup.ts
@@ -1,17 +1,25 @@
-import { log, startPerformanceMeasure } from '@guardian/libs';
+import { log } from '@guardian/libs';
+import { startPerformanceMeasure } from '../lib/startPerformanceMeasure';
 
 const measure = (name: string, task: () => Promise<void>): void => {
-	const { endPerformanceMeasure } = startPerformanceMeasure('dotcom', name);
+	try {
+		const { endPerformanceMeasure } = startPerformanceMeasure(
+			'dotcom',
+			name,
+		);
 
-	task()
-		.then(() => {
-			const duration = endPerformanceMeasure();
-			log('dotcom', `🥾 Booted ${name} in ${duration}ms`);
-		})
-		.catch(() => {
-			const duration = endPerformanceMeasure();
-			log('dotcom', `🤒 Failed to boot ${name} in ${duration}ms`);
-		});
+		task()
+			.then(() => {
+				const duration = endPerformanceMeasure();
+				log('dotcom', `🥾 Booted ${name} in ${duration}ms`);
+			})
+			.catch(() => {
+				const duration = endPerformanceMeasure();
+				log('dotcom', `🤒 Failed to boot ${name} in ${duration}ms`);
+			});
+	} catch (error) {
+		// performance APIs are unsupported or broken…
+	}
 };
 
 export const startup = (name: string, task: () => Promise<void>): void => {

--- a/dotcom-rendering/src/components/EnhancePinnedPost.importable.tsx
+++ b/dotcom-rendering/src/components/EnhancePinnedPost.importable.tsx
@@ -1,7 +1,7 @@
-import { startPerformanceMeasure } from '@guardian/libs';
 import { useEffect, useRef, useState } from 'react';
 import { submitComponentEvent } from '../client/ophan/ophan';
 import { isServer } from '../lib/isServer';
+import { startPerformanceMeasure } from '../lib/startPerformanceMeasure';
 import { useIsInView } from '../lib/useIsInView';
 
 const pinnedPost: HTMLElement | null = !isServer

--- a/dotcom-rendering/src/components/SignInGate/gates/fake-social-variant.tsx
+++ b/dotcom-rendering/src/components/SignInGate/gates/fake-social-variant.tsx
@@ -1,5 +1,5 @@
-import { startPerformanceMeasure } from '@guardian/libs';
 import React, { Suspense } from 'react';
+import { startPerformanceMeasure } from '../../../lib/startPerformanceMeasure';
 import { Lazy } from '../../Lazy';
 import { canShowSignInGate } from '../displayRule';
 import type { SignInGateComponent } from '../types';

--- a/dotcom-rendering/src/components/SignInGate/gates/main-mandatory-variant.tsx
+++ b/dotcom-rendering/src/components/SignInGate/gates/main-mandatory-variant.tsx
@@ -1,5 +1,5 @@
-import { startPerformanceMeasure } from '@guardian/libs';
 import React, { Suspense } from 'react';
+import { startPerformanceMeasure } from '../../../lib/startPerformanceMeasure';
 import { Lazy } from '../../Lazy';
 import { canShowSignInGateMandatory } from '../displayRule';
 import type { SignInGateComponent } from '../types';

--- a/dotcom-rendering/src/components/SignInGate/gates/main-variant.tsx
+++ b/dotcom-rendering/src/components/SignInGate/gates/main-variant.tsx
@@ -1,5 +1,5 @@
-import { startPerformanceMeasure } from '@guardian/libs';
 import React, { Suspense } from 'react';
+import { startPerformanceMeasure } from '../../../lib/startPerformanceMeasure';
 import { Lazy } from '../../Lazy';
 import { canShowSignInGate } from '../displayRule';
 import type { SignInGateComponent } from '../types';

--- a/dotcom-rendering/src/components/SignInGate/gates/sign-in-gate-copy-test-jan2023.tsx
+++ b/dotcom-rendering/src/components/SignInGate/gates/sign-in-gate-copy-test-jan2023.tsx
@@ -1,5 +1,5 @@
-import { startPerformanceMeasure } from '@guardian/libs';
 import React, { Suspense } from 'react';
+import { startPerformanceMeasure } from '../../../lib/startPerformanceMeasure';
 import { Lazy } from '../../Lazy';
 import { canShowSignInGate } from '../displayRule';
 import type { SignInGateComponent } from '../types';

--- a/dotcom-rendering/src/lib/braze/buildBrazeMessaging.ts
+++ b/dotcom-rendering/src/lib/braze/buildBrazeMessaging.ts
@@ -9,13 +9,14 @@ import {
 	NullBrazeCards,
 	NullBrazeMessages,
 } from '@guardian/braze-components/logic';
-import { log, startPerformanceMeasure, storage } from '@guardian/libs';
+import { log, storage } from '@guardian/libs';
 import { record } from '../../client/ophan/ophan';
 import {
 	clearHasCurrentBrazeUser,
 	hasCurrentBrazeUser,
 	setHasCurrentBrazeUser,
 } from '../hasCurrentBrazeUser';
+import { startPerformanceMeasure } from '../startPerformanceMeasure';
 import { checkBrazeDependencies } from './checkBrazeDependencies';
 import { getInitialisedAppboy } from './initialiseAppboy';
 

--- a/dotcom-rendering/src/lib/messagePicker.ts
+++ b/dotcom-rendering/src/lib/messagePicker.ts
@@ -1,5 +1,5 @@
-import { startPerformanceMeasure } from '@guardian/libs';
 import { record } from '../client/ophan/ophan';
+import { startPerformanceMeasure } from './startPerformanceMeasure';
 
 export type MaybeFC = React.FC | null;
 type ShowMessage<T> = (meta: T) => MaybeFC;

--- a/dotcom-rendering/src/lib/scheduler.ts
+++ b/dotcom-rendering/src/lib/scheduler.ts
@@ -1,4 +1,5 @@
-import { log as libsLog, startPerformanceMeasure } from '@guardian/libs';
+import { log as libsLog } from '@guardian/libs';
+import { startPerformanceMeasure } from './startPerformanceMeasure';
 
 const START = performance.now();
 

--- a/dotcom-rendering/src/lib/startPerformanceMeasure.ts
+++ b/dotcom-rendering/src/lib/startPerformanceMeasure.ts
@@ -1,0 +1,18 @@
+import type { TeamName } from '@guardian/libs';
+import { startPerformanceMeasure as startPerformanceMeasureLibs } from '@guardian/libs';
+
+const fallback = { endPerformanceMeasure: () => -1 };
+
+export const startPerformanceMeasure = (
+	team: TeamName,
+	name: string,
+	action?: string,
+): ReturnType<typeof startPerformanceMeasureLibs> => {
+	if (!('measure' in window.performance)) return fallback;
+	try {
+		window.performance.measure('fake-measure', { start: 0 }); // MeasureOptions is only supported in Safari 14.1+
+		return startPerformanceMeasureLibs(team, name, action);
+	} catch (error) {
+		return fallback;
+	}
+};


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Add a hotfix for Safari 13 where we introduce fallback for `startPerformanceMeasure`

In unsupported browsers, we create no `PerformanceMeasure` and the duration will be `-1`.

## Why?

Currently, all our JavaScript is broken on Safari 13 and below.

Sentry error ID: `DOTCOM-RENDERING-27FS`

Reported by @coldlink, paired with @abeddow91 & @jamesgorrie 

## Screenshots

<img width="1830" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/76776/c4852bc4-6005-4a5f-b171-69b3dee81a03">
