### PR TITLE
Pass `idCookieSessionRefresh` option to `IdentityAuth` constructor

### DIFF
--- a/dotcom-rendering/src/lib/identity.ts
+++ b/dotcom-rendering/src/lib/identity.ts
@@ -44,6 +44,8 @@ function getIdentityAuth() {
 			issuer: getIssuer(stage),
 			clientId: getClientId(stage),
 			redirectUri: getRedirectUri(stage),
+			idCookieSessionRefresh:
+				window.guardian.config.switches.idCookieRefresh ?? false,
 			scopes: [
 				'openid', // required for open id connect, returns an id token
 				'profile', // populates the id token with basic profile information


### PR DESCRIPTION
The `IdentityAuth` library should handle cookie refreshes if the `idCookieRefresh` switch is true. Option defaults to false if the switch is unavailable.