### PR TITLE
Temporarily Disable Cypress In TC

### DIFF
--- a/scripts/ci-dcr.sh
+++ b/scripts/ci-dcr.sh
@@ -43,7 +43,6 @@ else
 	if [ $currentBranch == "main" ]
 	then
 		make validate-ci
-		make cypress
 	else
 		printf "Skipping code checks when not on main"
 	fi


### PR DESCRIPTION
## Why?

We're seeing out of memory errors, and it's blocking builds. The idea is that this is temporary to allow builds to pass again, and we'll look into a fix in the meantime. We still have Cypress checks running in GHA on branches and on `main`.
