### PR TITLE
Run Cypress In TeamCity With More Memory

### DIFF
--- a/dotcom-rendering/makefile
+++ b/dotcom-rendering/makefile
@@ -109,7 +109,7 @@ storybook-dev: clear clean-dist install
 
 cypress: clear clean-dist install build
 	$(call log, "starting PROD server for Cypress")
-	@NODE_ENV=production DISABLE_LOGGING_AND_METRICS=true start-server-and-test 'node dist/server.js' 9000 'cypress run --spec "cypress/e2e/**/*"'
+	@NODE_ENV=production DISABLE_LOGGING_AND_METRICS=true start-server-and-test 'node dist/server.js' 9000 'node --max-old-space-size=4096 $$(yarn bin)/cypress run --spec "cypress/e2e/**/*"'
 
 cypress-open: clear clean-dist install build
 	$(call log, "starting PROD server and opening Cypress")

--- a/dotcom-rendering/makefile
+++ b/dotcom-rendering/makefile
@@ -109,7 +109,7 @@ storybook-dev: clear clean-dist install
 
 cypress: clear clean-dist install build
 	$(call log, "starting PROD server for Cypress")
-	@NODE_ENV=production DISABLE_LOGGING_AND_METRICS=true start-server-and-test 'node dist/server.js' 9000 'node --max-old-space-size=8192 $$(yarn bin)/cypress run --spec "cypress/e2e/**/*"'
+	@NODE_ENV=production NODE_OPTIONS="--max-old-space-size=8192" DISABLE_LOGGING_AND_METRICS=true start-server-and-test 'node dist/server.js' 9000 'cypress run --spec "cypress/e2e/**/*"'
 
 cypress-open: clear clean-dist install build
 	$(call log, "starting PROD server and opening Cypress")

--- a/dotcom-rendering/makefile
+++ b/dotcom-rendering/makefile
@@ -109,7 +109,7 @@ storybook-dev: clear clean-dist install
 
 cypress: clear clean-dist install build
 	$(call log, "starting PROD server for Cypress")
-	@NODE_ENV=production DISABLE_LOGGING_AND_METRICS=true start-server-and-test 'node dist/server.js' 9000 'node --max-old-space-size=4096 $$(yarn bin)/cypress run --spec "cypress/e2e/**/*"'
+	@NODE_ENV=production DISABLE_LOGGING_AND_METRICS=true start-server-and-test 'node dist/server.js' 9000 'node --max-old-space-size=8192 $$(yarn bin)/cypress run --spec "cypress/e2e/**/*"'
 
 cypress-open: clear clean-dist install build
 	$(call log, "starting PROD server and opening Cypress")

--- a/scripts/ci-dcr.sh
+++ b/scripts/ci-dcr.sh
@@ -45,6 +45,8 @@ else
 		make validate-ci
 		make cypress
 	else
+        # Temporarily running cypress on the branch to test if this works
+		make cypress
 		printf "Skipping code checks when not on main"
 	fi
 

--- a/scripts/ci-dcr.sh
+++ b/scripts/ci-dcr.sh
@@ -45,8 +45,6 @@ else
 		make validate-ci
 		make cypress
 	else
-        # Temporarily running cypress on the branch to test if this works
-		make cypress
 		printf "Skipping code checks when not on main"
 	fi
 


### PR DESCRIPTION
## Why?

We've been seeing out of memory errors when running Cypress in TeamCity (TC).

## Changes

Uses the Node `max-old-space-size` option[^1] to increase memory available to Cypress. We do something similar to build storybook:

https://github.com/guardian/dotcom-rendering/blob/8257b916b3667a44a69f2b8cd16fdddac4711f40/dotcom-rendering/package.json#L29

[^1]: https://nodejs.org/api/cli.html#--max-old-space-sizesize-in-megabytes

## Testing

There are several commits on this branch. The second-to-last one includes a temporary change to the TC build script to allow Cypress to run on all branches (normally we only run it on `main`). This means that the TC build check that ran against that commit includes a Cypress run, and it passed without running out of memory.

Credit to @ioannakok for suggesting the `NODE_OPTIONS` environment variable. Other ways of setting the space size weren't being applied correctly, as seen in some of the other commits on this PR.
