### PR TITLE
Skip Cypress tests in TeamCity if `SKIP_CYPRESS` is set

### DIFF
--- a/scripts/ci-dcr.sh
+++ b/scripts/ci-dcr.sh
@@ -46,6 +46,10 @@ else
 		# If $SKIP_CYPRESS is not set, run the Cypress tests
 		if [ -z $SKIP_CYPRESS ]; then
 			make cypress
+			cypressExitCode=$?
+			if [ $cypressExitCode -ne 0 ]; then
+				echo "Cypress failed. If you're trying to release something urgently, set \$SKIP_CYPRESS to any non-empty value\n\n"
+			fi
 		fi
 	else
 		printf "Skipping code checks when not on main"

--- a/scripts/ci-dcr.sh
+++ b/scripts/ci-dcr.sh
@@ -43,7 +43,10 @@ else
 	if [ $currentBranch == "main" ]
 	then
 		make validate-ci
-		make cypress
+		# If $SKIP_CYPRESS is not set, run the Cypress tests
+		if [ -z $SKIP_CYPRESS ]; then
+			make cypress
+		fi
 	else
 		printf "Skipping code checks when not on main"
 	fi


### PR DESCRIPTION
We've seen a lot of failures of our Cypress tests in our TeamCity builds recently. Cypress tests are required to pass for the build to succeed.

When we have changes that need to be released quickly and the cypress tests are failing, this can become a blocker.

Typically, we either retry or disable cypress tests in TeamCity temporarily (as in #8447). Although this works, it can be a slow process to raise the PR and wait for the builds.

Until we have a robust solution to fix the Cypress tests, we can disable the tests by setting this environment variable to any value.
Resolves #8450