### PR TITLE
Representative startup task durations

### DIFF
--- a/dotcom-rendering/src/client/bootCmp.ts
+++ b/dotcom-rendering/src/client/bootCmp.ts
@@ -85,19 +85,21 @@ export const bootCmp = async (): Promise<void> => {
 		submitComponentEvent(event);
 	});
 
-	// Manually updates the footer DOM because it's not hydrated
-	void injectPrivacySettingsLinkWhenReady();
-
-	cmp.init({
-		pubData: {
-			platform: 'next-gen',
-			// If `undefined`, the resulting consent signal cannot be joined to a page view.
-			browserId: browserId ?? undefined,
-			pageViewId,
-		},
-		country: (await getLocaleCode()) ?? undefined,
-	});
-	log('dotcom', 'CMP initialised');
-
-	return Promise.resolve();
+	await Promise.all([
+		// Manually updates the footer DOM because it's not hydrated
+		injectPrivacySettingsLinkWhenReady(),
+		getLocaleCode().then((code) => {
+			const country = code ?? undefined;
+			cmp.init({
+				pubData: {
+					platform: 'next-gen',
+					// If `undefined`, the resulting consent signal cannot be joined to a page view.
+					browserId: browserId ?? undefined,
+					pageViewId,
+				},
+				country,
+			});
+			log('dotcom', 'CMP initialised');
+		}),
+	]);
 };

--- a/dotcom-rendering/src/client/discussion.ts
+++ b/dotcom-rendering/src/client/discussion.ts
@@ -2,15 +2,14 @@ import { doHydration } from './islands/doHydration';
 import { getEmotionCache } from './islands/emotion';
 import { getProps } from './islands/getProps';
 
-function forceHydration() {
+const forceHydration = async () => {
 	try {
 		const name = 'DiscussionContainer';
 
 		// Select the Discussion island element
-		const guElement = document.querySelector<HTMLElement>(
-			`gu-island[name=${name}]`,
-		);
-		if (!guElement) return;
+		const guElement = document.querySelector(`gu-island[name=${name}]`);
+
+		if (!(guElement instanceof HTMLElement)) return;
 
 		// Read the props from where they have been serialised in the dom using an Island
 		const props = getProps(guElement);
@@ -19,21 +18,18 @@ function forceHydration() {
 		props.expanded = true;
 
 		// Force hydration
-		void doHydration(name, props, guElement, getEmotionCache());
+		return doHydration(name, props, guElement, getEmotionCache());
 	} catch (err) {
 		// Do nothing
 	}
-}
-
-export const discussion = (): Promise<void> => {
-	/**
-	 * If we have either a #comment-123456 permalink or the #comments link in the url
-	 * then we want to hydrate and expand the discussion without waiting for the
-	 * reader to scroll down to it
-	 *
-	 */
-	const hashLink = window.location.hash;
-	if (hashLink.includes('comment')) forceHydration();
-
-	return Promise.resolve();
 };
+
+/**
+ * If we have either a #comment-123456 permalink or the #comments link in the url
+ * then we want to hydrate and expand the discussion without waiting for the
+ * reader to scroll down to it
+ */
+export const discussion = (): Promise<void> =>
+	window.location.hash.includes('comment')
+		? forceHydration()
+		: Promise.resolve();

--- a/dotcom-rendering/src/client/ga/index.ts
+++ b/dotcom-rendering/src/client/ga/index.ts
@@ -6,39 +6,41 @@ import type { ConsentState } from '@guardian/consent-management-platform/dist/ty
 import { loadScript, log } from '@guardian/libs';
 import { init, sendPageView } from './ga';
 
-export const ga = (): Promise<void> => {
-	// Check if we have consent for GA so that if the reader removes consent for tracking we
-	// remove ga from the page
-	onConsentChange((consentState: ConsentState) => {
-		const consentGivenForGA = getConsentFor(
-			'google-analytics',
-			consentState,
-		);
-		if (consentGivenForGA) {
-			loadScript('https://www.google-analytics.com/analytics.js')
-				.then(() => {
-					log('dotcom', 'GA script loaded');
+export const ga = (): Promise<void> =>
+	new Promise((resolve) => {
+		// Check if we have consent for GA so that if the reader removes consent for tracking we
+		// remove ga from the page
 
-					init();
-					sendPageView();
-				})
-				.catch((e) => {
-					// We don't need to log script loading errors (these will mostly be adblock, etc),
-					if (!String(e).includes('Error loading script')) {
-						// This is primarily for logging errors with our GA code.
-						window.guardian.modules.sentry.reportError(
-							e instanceof Error ? e : new Error(e),
-							'ga',
-						);
-					}
-				});
-		} else {
-			// Disable Google Analytics
-			// @ts-expect-error -- We should never be able to directly set things to the global window object
-			// but in this case we want to stub things for testing, so it's ok to ignore this rule
-			window.ga = null;
-		}
+		onConsentChange((consentState: ConsentState) => {
+			const consentGivenForGA = getConsentFor(
+				'google-analytics',
+				consentState,
+			);
+			if (consentGivenForGA) {
+				loadScript('https://www.google-analytics.com/analytics.js')
+					.then(() => {
+						log('dotcom', 'GA script loaded');
+
+						init();
+						sendPageView();
+					})
+					.catch((e) => {
+						// We don't need to log script loading errors (these will mostly be adblock, etc),
+						if (!String(e).includes('Error loading script')) {
+							// This is primarily for logging errors with our GA code.
+							window.guardian.modules.sentry.reportError(
+								e instanceof Error ? e : new Error(e),
+								'ga',
+							);
+						}
+					})
+					.finally(() => resolve());
+			} else {
+				// Disable Google Analytics
+				// @ts-expect-error -- We should never be able to directly set things to the global window object
+				// but in this case we want to stub things for testing, so it's ok to ignore this rule
+				window.ga = null;
+				resolve();
+			}
+		});
 	});
-
-	return Promise.resolve();
-};

--- a/dotcom-rendering/src/client/ophan/index.ts
+++ b/dotcom-rendering/src/client/ophan/index.ts
@@ -1,9 +1,9 @@
 import { abTestPayload, record, recordPerformance } from './ophan';
 
-// side effect only
-import 'ophan-tracker-js';
+export const ophan = async (): Promise<void> => {
+	// @ts-expect-error -- no definitions, side effect only
+	await import('ophan-tracker-js');
 
-export const ophan = (): Promise<void> => {
 	record({ experiences: 'dotcom-rendering' });
 	record({ edition: window.guardian.config.page.edition });
 
@@ -15,6 +15,4 @@ export const ophan = (): Promise<void> => {
 		recordPerformance();
 		window.removeEventListener('load', load, false);
 	});
-
-	return Promise.resolve();
 };

--- a/dotcom-rendering/src/layouts/Layout.stories.tsx
+++ b/dotcom-rendering/src/layouts/Layout.stories.tsx
@@ -77,7 +77,7 @@ const HydratedLayout = ({
 			console.error(`HydratedLayout embedIframe - error: ${String(e)}`),
 		);
 		// Manually updates the footer DOM because it's not hydrated
-		injectPrivacySettingsLink();
+		void injectPrivacySettingsLink();
 		doStorybookHydration();
 	}, [serverArticle]);
 

--- a/dotcom-rendering/src/lib/injectPrivacySettingsLink.ts
+++ b/dotcom-rendering/src/lib/injectPrivacySettingsLink.ts
@@ -3,7 +3,7 @@ import { getPrivacyFramework } from './getPrivacyFramework';
 
 const newPrivacyLinkName = 'privacy-settings';
 
-export const injectPrivacySettingsLink = (): void => {
+export const injectPrivacySettingsLink = async (): Promise<void> => {
 	const privacyLink = document.querySelector('a[data-link-name=privacy]');
 
 	if (
@@ -13,54 +13,54 @@ export const injectPrivacySettingsLink = (): void => {
 		const privacyLinkListItem = privacyLink.parentElement;
 
 		if (privacyLinkListItem) {
-			getPrivacyFramework()
-				.then((framework) => {
-					const newPrivacyLink = privacyLink.cloneNode(
-						false,
-					) as Element;
+			try {
+				const framework = await getPrivacyFramework();
+				const newPrivacyLink = privacyLink.cloneNode(false) as Element;
 
-					newPrivacyLink.setAttribute(
-						'data-link-name',
-						newPrivacyLinkName,
-					);
-					newPrivacyLink.setAttribute('href', '#');
-					newPrivacyLink.innerHTML = framework.ccpa
-						? 'California resident – Do Not Sell'
-						: 'Privacy settings';
-
-					const newPrivacyLinkListItem =
-						privacyLinkListItem.cloneNode(false) as Element;
-
-					newPrivacyLinkListItem.appendChild(newPrivacyLink);
-
-					privacyLinkListItem.insertAdjacentElement(
-						'beforebegin',
-						newPrivacyLinkListItem,
-					);
-
-					newPrivacyLink.addEventListener('click', (event) => {
-						event.preventDefault();
-						cmp.showPrivacyManager();
-					});
-				})
-				.catch((e) =>
-					console.error(`privacy settings - error: ${String(e)}`),
+				newPrivacyLink.setAttribute(
+					'data-link-name',
+					newPrivacyLinkName,
 				);
+				newPrivacyLink.setAttribute('href', '#');
+				newPrivacyLink.innerHTML = framework.ccpa
+					? 'California resident – Do Not Sell'
+					: 'Privacy settings';
+
+				const newPrivacyLinkListItem = privacyLinkListItem.cloneNode(
+					false,
+				) as Element;
+
+				newPrivacyLinkListItem.appendChild(newPrivacyLink);
+
+				privacyLinkListItem.insertAdjacentElement(
+					'beforebegin',
+					newPrivacyLinkListItem,
+				);
+
+				newPrivacyLink.addEventListener('click', (event) => {
+					event.preventDefault();
+					cmp.showPrivacyManager();
+				});
+			} catch (e) {
+				return console.error(`privacy settings - error: ${String(e)}`);
+			}
 		}
 	}
 };
 
 // Inject privacy link when document has finished loading
-export const injectPrivacySettingsLinkWhenReady = (): void => {
+export const injectPrivacySettingsLinkWhenReady = (): Promise<void> => {
 	if (document.readyState === 'loading') {
-		document.addEventListener(
-			'readystatechange',
-			() => {
-				injectPrivacySettingsLink();
-			},
-			{ once: true },
-		);
+		return new Promise((resolve) => {
+			document.addEventListener(
+				'readystatechange',
+				() => {
+					void injectPrivacySettingsLink().then(resolve);
+				},
+				{ once: true },
+			);
+		});
 	} else {
-		injectPrivacySettingsLink();
+		return injectPrivacySettingsLink();
 	}
 };

--- a/dotcom-rendering/src/lib/polyfill.io.ts
+++ b/dotcom-rendering/src/lib/polyfill.io.ts
@@ -19,6 +19,7 @@ export const polyfillIO = new URL(
 				'navigator.sendBeacon',
 				'performance.now',
 				'Promise.allSettled',
+				'Promise.prototype.finally',
 			].join(','),
 			flags: 'gated',
 			callback: 'guardianPolyfilled',

--- a/dotcom-rendering/src/lib/polyfill.io.ts
+++ b/dotcom-rendering/src/lib/polyfill.io.ts
@@ -1,0 +1,28 @@
+/** Polyfill.io script URL configuration */
+export const polyfillIO = new URL(
+	'https://assets.guim.co.uk/polyfill.io/v3/polyfill.min.js?' +
+		new URLSearchParams({
+			rum: String(0),
+			features: [
+				'es6',
+				'es7',
+				'es2017',
+				'es2018',
+				'es2019',
+				'default-3.6',
+				'HTMLPictureElement',
+				'IntersectionObserver',
+				'IntersectionObserverEntry',
+				'URLSearchParams',
+				'fetch',
+				'NodeList.prototype.forEach',
+				'navigator.sendBeacon',
+				'performance.now',
+				'Promise.allSettled',
+			].join(','),
+			flags: 'gated',
+			callback: 'guardianPolyfilled',
+			unknown: 'polyfill',
+			cacheClear: String(1),
+		}).toString(),
+).toString();

--- a/dotcom-rendering/src/server/render.allEditorialNewslettersPage.web.tsx
+++ b/dotcom-rendering/src/server/render.allEditorialNewslettersPage.web.tsx
@@ -7,6 +7,7 @@ import { generateScriptTags, getPathFromManifest } from '../lib/assets';
 import { renderToStringWithEmotion } from '../lib/emotion';
 import { escapeData } from '../lib/escapeData';
 import { getHttp3Url } from '../lib/getHttp3Url';
+import { polyfillIO } from '../lib/polyfill.io';
 import { extractNAV } from '../model/extract-nav';
 import { makeWindowGuardian } from '../model/window-guardian';
 import type { DCRNewslettersPageType } from '../types/newslettersPage';
@@ -32,9 +33,6 @@ export const renderEditorialNewslettersPage = ({
 	// Evaluating the performance of HTTP3 over HTTP2
 	// See: https://github.com/guardian/dotcom-rendering/pull/5394
 	const { offerHttp3 = false } = newslettersPage.config.switches;
-
-	const polyfillIO =
-		'https://assets.guim.co.uk/polyfill.io/v3/polyfill.min.js?rum=0&features=es6,es7,es2017,es2018,es2019,default-3.6,HTMLPictureElement,IntersectionObserver,IntersectionObserverEntry,URLSearchParams,fetch,NodeList.prototype.forEach,navigator.sendBeacon,performance.now,Promise.allSettled&flags=gated&callback=guardianPolyfilled&unknown=polyfill&cacheClear=1';
 
 	const shouldServeVariantBundle: boolean = [
 		BUILD_VARIANT,

--- a/dotcom-rendering/src/server/render.article.web.tsx
+++ b/dotcom-rendering/src/server/render.article.web.tsx
@@ -18,6 +18,7 @@ import { escapeData } from '../lib/escapeData';
 import { getHttp3Url } from '../lib/getHttp3Url';
 import { getCurrentPillar } from '../lib/layoutHelpers';
 import { LiveBlogRenderer } from '../lib/LiveBlogRenderer';
+import { polyfillIO } from '../lib/polyfill.io';
 import { extractGA } from '../model/extract-ga';
 import { extractNAV } from '../model/extract-nav';
 import { makeWindowGuardian } from '../model/window-guardian';
@@ -67,9 +68,6 @@ export const renderHtml = ({ article }: Props): string => {
 	// Evaluating the performance of HTTP3 over HTTP2
 	// See: https://github.com/guardian/dotcom-rendering/pull/5394
 	const { offerHttp3 = false } = article.config.switches;
-
-	const polyfillIO =
-		'https://assets.guim.co.uk/polyfill.io/v3/polyfill.min.js?rum=0&features=es6,es7,es2017,es2018,es2019,default-3.6,HTMLPictureElement,IntersectionObserver,IntersectionObserverEntry,URLSearchParams,fetch,NodeList.prototype.forEach,navigator.sendBeacon,performance.now,Promise.allSettled&flags=gated&callback=guardianPolyfilled&unknown=polyfill&cacheClear=1';
 
 	const pageHasNonBootInteractiveElements = elements.some(
 		(element) =>

--- a/dotcom-rendering/src/server/render.front.web.tsx
+++ b/dotcom-rendering/src/server/render.front.web.tsx
@@ -9,6 +9,7 @@ import { generateScriptTags, getPathFromManifest } from '../lib/assets';
 import { renderToStringWithEmotion } from '../lib/emotion';
 import { escapeData } from '../lib/escapeData';
 import { getHttp3Url } from '../lib/getHttp3Url';
+import { polyfillIO } from '../lib/polyfill.io';
 import { themeToPillar } from '../lib/themeToPillar';
 import type { NavType } from '../model/extract-nav';
 import { extractNAV } from '../model/extract-nav';
@@ -80,9 +81,6 @@ export const renderFront = ({ front }: Props): string => {
 	// Evaluating the performance of HTTP3 over HTTP2
 	// See: https://github.com/guardian/dotcom-rendering/pull/5394
 	const { offerHttp3 = false } = front.config.switches;
-
-	const polyfillIO =
-		'https://assets.guim.co.uk/polyfill.io/v3/polyfill.min.js?rum=0&features=es6,es7,es2017,es2018,es2019,default-3.6,HTMLPictureElement,IntersectionObserver,IntersectionObserverEntry,URLSearchParams,fetch,NodeList.prototype.forEach,navigator.sendBeacon,performance.now,Promise.allSettled&flags=gated&callback=guardianPolyfilled&unknown=polyfill&cacheClear=1';
 
 	const shouldServeVariantBundle: boolean = [
 		BUILD_VARIANT,
@@ -172,9 +170,6 @@ export const renderTagFront = ({
 	// Evaluating the performance of HTTP3 over HTTP2
 	// See: https://github.com/guardian/dotcom-rendering/pull/5394
 	const { offerHttp3 = false } = tagFront.config.switches;
-
-	const polyfillIO =
-		'https://assets.guim.co.uk/polyfill.io/v3/polyfill.min.js?rum=0&features=es6,es7,es2017,es2018,es2019,default-3.6,HTMLPictureElement,IntersectionObserver,IntersectionObserverEntry,URLSearchParams,fetch,NodeList.prototype.forEach,navigator.sendBeacon,performance.now,Promise.allSettled&flags=gated&callback=guardianPolyfilled&unknown=polyfill&cacheClear=1';
 
 	const shouldServeVariantBundle: boolean = [
 		BUILD_VARIANT,


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Make the durations of startup tasks more representative.

## Why?

Allows for more informative results from our `PerformanceMeasure` entries.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png