### PR TITLE
Bump `@types/yarnpkg__lockfile` to v1.1.6

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -139,7 +139,7 @@
 		"@types/webpack-bundle-analyzer": "4.6.0",
 		"@types/webpack-env": "1.18.0",
 		"@types/webpack-node-externals": "3.0.0",
-		"@types/yarnpkg__lockfile": "1.1.5",
+		"@types/yarnpkg__lockfile": "1.1.6",
 		"@types/youtube": "0.0.46",
 		"@typescript-eslint/eslint-plugin": "5.52.0",
 		"@typescript-eslint/eslint-plugin-tslint": "5.52.0",

--- a/dotcom-rendering/scripts/env/check-deps.js
+++ b/dotcom-rendering/scripts/env/check-deps.js
@@ -9,7 +9,6 @@ if (pkg.devDependencies) {
 	process.exit(1);
 }
 
-/** @type {{ object: import('@types/yarnpkg__lockfile').LockFileObject }}*/
 const { object: json } = lockfile.parse(
 	fs.readFileSync('../yarn.lock', 'utf8'),
 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -5794,10 +5794,10 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@types/yarnpkg__lockfile@1.1.5":
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/@types/yarnpkg__lockfile/-/yarnpkg__lockfile-1.1.5.tgz#9639020e1fb65120a2f4387db8f1e8b63efdf229"
-  integrity sha512-8NYnGOctzsI4W0ApsP/BIHD/LnxpJ6XaGf2AZmz4EyDYJMxtprN4279dLNI1CPZcwC9H18qYcaFv4bXi0wmokg==
+"@types/yarnpkg__lockfile@1.1.6":
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/@types/yarnpkg__lockfile/-/yarnpkg__lockfile-1.1.6.tgz#60a35ede6197d8cbedd5bb8393f3921e8d56d44b"
+  integrity sha512-kbdQa3J+hVCkqmGQm31fthEwGxszZtepw84p9QGCiJB7TmiPqPAf3/g9eZUnkCeanmiFOaG4pVhiPDyqJxaoaw==
 
 "@types/yauzl@^2.9.1":
   version "2.10.0"


### PR DESCRIPTION
## What does this change?

Bump the version of `@types/yarnpkg__lockfile`

## Why?

Return type is no longer `any`, reducing the amount of extra work needed, thanks to [the magic of open-source](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/65374)