### PR TITLE
fix: add data-link-name to image treats

### DIFF
--- a/dotcom-rendering/src/components/Treats.tsx
+++ b/dotcom-rendering/src/components/Treats.tsx
@@ -112,6 +112,7 @@ const ImageTreat = ({
 						key={link.linkTo}
 						href={link.linkTo}
 						data-ignore="global-link-styling"
+						data-link-name={`treat | ${index + 1} | ${link.text}`}
 						css={css`
 							text-decoration: none;
 						`}


### PR DESCRIPTION
## What does this change?
Adds the data-link-name to image treats

## Why?
So we can get some data on how they're performing

Note:
* we should probably add this to the crossword treat too.
* we could make this more explicit via an ID or similar given these are explicity defined "treats" but we're deciding what to do with them, so I'd rather not extend them as this will give us the data we need.
