### PR TITLE
Fix sign in gate CTA button register link

### DIFF
--- a/dotcom-rendering/cypress/e2e/parallel-1/sign-in-gate.cy.js
+++ b/dotcom-rendering/cypress/e2e/parallel-1/sign-in-gate.cy.js
@@ -186,24 +186,24 @@ describe('Sign In Gate Tests', function () {
 			cy.get('[data-cy=sign-in-gate-main]').should('not.exist');
 		});
 
-		it('register button should contain profile.theguardian.com href', function () {
+		it('register CTA button should contain correct profile.theguardian.com href', function () {
 			visitArticleAndScrollToGateForLazyLoad();
 
 			cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
 
 			cy.get('[data-cy=sign-in-gate-main_register]')
 				.invoke('attr', 'href')
-				.should('contains', 'profile.theguardian.com');
+				.should('contains', 'profile.theguardian.com/register');
 		});
 
-		it('sign in link should contain profile.theguardian.com href', function () {
+		it('sign in link should contain correct profile.theguardian.com href', function () {
 			visitArticleAndScrollToGateForLazyLoad();
 
 			cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
 
 			cy.get('[data-cy=sign-in-gate-main_signin]')
 				.invoke('attr', 'href')
-				.should('contains', 'profile.theguardian.com');
+				.should('contains', 'profile.theguardian.com/signin');
 		});
 
 		it('should show cmp ui when privacy settings link is clicked', function () {

--- a/dotcom-rendering/cypress/e2e/parallel-1/sign-in-gate.cy.js
+++ b/dotcom-rendering/cypress/e2e/parallel-1/sign-in-gate.cy.js
@@ -254,7 +254,7 @@ describe('Sign In Gate Tests', function () {
 				);
 				cy.get('[data-cy=sign-in-gate-main_register]')
 					.should('have.attr', 'href')
-					.and('contains', '/signin?returnUrl=')
+					.and('contains', '/register?returnUrl=')
 					.and('match', /componentId%3Dmain_variant_\d/)
 					.and('not.contains', 'personalised_new_SupporterPlus');
 			});
@@ -489,7 +489,7 @@ describe('Sign In Gate Tests', function () {
 					);
 					cy.get('[data-cy=sign-in-gate-main_register]')
 						.should('have.attr', 'href')
-						.and('contains', '/signin?returnUrl=')
+						.and('contains', '/register?returnUrl=')
 						.and(
 							'not.match',
 							/componentId%3Dmain_variant_\d_personalised/,

--- a/dotcom-rendering/src/components/SignInGate/SignInGate.stories.tsx
+++ b/dotcom-rendering/src/components/SignInGate/SignInGate.stories.tsx
@@ -20,7 +20,8 @@ export const mainStandalone = () => {
 		<Section fullWidth={true}>
 			<SignInGateMain
 				guUrl="https://theguardian.com"
-				signInUrl="https://profile.theguardian.com/"
+				signInUrl="https://profile.theguardian.com/signin"
+				registerUrl="https://profile.theguardian.com/register"
 				dismissGate={() => {}}
 				ophanComponentId="test"
 			/>
@@ -34,7 +35,8 @@ export const mainStandaloneMandatory = () => {
 		<Section fullWidth={true}>
 			<SignInGateMain
 				guUrl="https://theguardian.com"
-				signInUrl="https://profile.theguardian.com/"
+				signInUrl="https://profile.theguardian.com/signin"
+				registerUrl="https://profile.theguardian.com/register"
 				dismissGate={() => {}}
 				ophanComponentId="test"
 				isMandatory={true}
@@ -49,7 +51,8 @@ export const fakeSocialStandalone = () => {
 		<Section fullWidth={true}>
 			<SignInGateFakeSocial
 				guUrl="https://theguardian.com"
-				signInUrl="https://profile.theguardian.com/"
+				signInUrl="https://profile.theguardian.com/signin"
+				registerUrl="https://profile.theguardian.com/register"
 				dismissGate={() => {}}
 				ophanComponentId="test"
 			/>
@@ -63,7 +66,8 @@ export const fakeSocialStandaloneVertical = () => {
 		<Section fullWidth={true}>
 			<SignInGateFakeSocial
 				guUrl="https://theguardian.com"
-				signInUrl="https://profile.theguardian.com/"
+				signInUrl="https://profile.theguardian.com/signin"
+				registerUrl="https://profile.theguardian.com/register"
 				dismissGate={() => {}}
 				ophanComponentId="test"
 				abTest={{
@@ -82,7 +86,8 @@ export const signInGateCopyTest = () => {
 		<Section fullWidth={true}>
 			<SignInGateCopyTestJan2023
 				guUrl="https://theguardian.com"
-				signInUrl="https://profile.theguardian.com/"
+				signInUrl="https://profile.theguardian.com/signin"
+				registerUrl="https://profile.theguardian.com/register"
 				dismissGate={() => {}}
 				ophanComponentId="test"
 				abTest={{
@@ -103,7 +108,8 @@ export const signInGateMainCheckoutCompletePersonalisedCopy = (
 		<Section fullWidth={true}>
 			<SignInGateMainCheckoutComplete
 				guUrl="https://theguardian.com"
-				signInUrl="https://profile.theguardian.com/signin?" // this is personalised
+				signInUrl="https://profile.theguardian.com/signin"
+				registerUrl="https://profile.theguardian.com/register"
 				dismissGate={() => {}}
 				ophanComponentId="test"
 				checkoutCompleteCookieData={args}

--- a/dotcom-rendering/src/components/SignInGate/gateDesigns/SignInGateCopyTestJan2023.tsx
+++ b/dotcom-rendering/src/components/SignInGate/gateDesigns/SignInGateCopyTestJan2023.tsx
@@ -21,6 +21,7 @@ import {
 
 export const SignInGateCopyTestJan2023 = ({
 	signInUrl,
+	registerUrl,
 	guUrl,
 	dismissGate,
 	abTest,
@@ -77,7 +78,7 @@ export const SignInGateCopyTestJan2023 = ({
 					css={registerButton}
 					priority="primary"
 					size="small"
-					href={signInUrl}
+					href={registerUrl}
 					onClick={() => {
 						trackLink(ophanComponentId, 'register-link', abTest);
 					}}

--- a/dotcom-rendering/src/components/SignInGate/gateDesigns/SignInGateFakeSocial.tsx
+++ b/dotcom-rendering/src/components/SignInGate/gateDesigns/SignInGateFakeSocial.tsx
@@ -283,6 +283,7 @@ const appleIcon = (
 
 export const SignInGateFakeSocial = ({
 	signInUrl,
+	registerUrl,
 	guUrl,
 	dismissGate,
 	abTest,
@@ -328,7 +329,7 @@ export const SignInGateFakeSocial = ({
 					css={registerButton}
 					priority="primary"
 					size="small"
-					href={signInUrl}
+					href={registerUrl}
 					onClick={() => {
 						trackLink(ophanComponentId, 'register-link', abTest);
 					}}

--- a/dotcom-rendering/src/components/SignInGate/gateDesigns/SignInGateMain.tsx
+++ b/dotcom-rendering/src/components/SignInGate/gateDesigns/SignInGateMain.tsx
@@ -21,6 +21,7 @@ import {
 
 export const SignInGateMain = ({
 	signInUrl,
+	registerUrl,
 	guUrl,
 	dismissGate,
 	abTest,
@@ -60,7 +61,7 @@ export const SignInGateMain = ({
 					css={registerButton}
 					priority="primary"
 					size="small"
-					href={signInUrl}
+					href={registerUrl}
 					onClick={() => {
 						trackLink(ophanComponentId, 'register-link', abTest);
 					}}

--- a/dotcom-rendering/src/components/SignInGate/gateDesigns/SignInGateMainCheckoutComplete.tsx
+++ b/dotcom-rendering/src/components/SignInGate/gateDesigns/SignInGateMainCheckoutComplete.tsx
@@ -166,6 +166,7 @@ const getBodyText: (product: Product) => string[] = (product) => {
 
 export const SignInGateMainCheckoutComplete = ({
 	signInUrl,
+	registerUrl,
 	guUrl,
 	dismissGate,
 	abTest,
@@ -182,6 +183,7 @@ export const SignInGateMainCheckoutComplete = ({
 		return (
 			<SignInGateMain
 				signInUrl={signInUrl}
+				registerUrl={registerUrl}
 				guUrl={guUrl}
 				dismissGate={dismissGate}
 				abTest={abTest}

--- a/dotcom-rendering/src/components/SignInGate/gates/fake-social-variant.tsx
+++ b/dotcom-rendering/src/components/SignInGate/gates/fake-social-variant.tsx
@@ -19,7 +19,14 @@ const SignInGateFakeSocial = React.lazy(() => {
 });
 
 export const signInGateComponent: SignInGateComponent = {
-	gate: ({ ophanComponentId, dismissGate, guUrl, signInUrl, abTest }) => (
+	gate: ({
+		ophanComponentId,
+		dismissGate,
+		guUrl,
+		signInUrl,
+		registerUrl,
+		abTest,
+	}) => (
 		<Lazy margin={300}>
 			<Suspense fallback={<></>}>
 				<SignInGateFakeSocial
@@ -27,6 +34,7 @@ export const signInGateComponent: SignInGateComponent = {
 					dismissGate={dismissGate}
 					guUrl={guUrl}
 					signInUrl={signInUrl}
+					registerUrl={registerUrl}
 					abTest={abTest}
 				/>
 			</Suspense>

--- a/dotcom-rendering/src/components/SignInGate/gates/main-mandatory-variant.tsx
+++ b/dotcom-rendering/src/components/SignInGate/gates/main-mandatory-variant.tsx
@@ -18,7 +18,14 @@ const SignInGateMain = React.lazy(() => {
 });
 
 export const signInGateMandatoryComponent: SignInGateComponent = {
-	gate: ({ ophanComponentId, dismissGate, guUrl, signInUrl, abTest }) => (
+	gate: ({
+		ophanComponentId,
+		dismissGate,
+		guUrl,
+		signInUrl,
+		registerUrl,
+		abTest,
+	}) => (
 		<Lazy margin={300}>
 			<Suspense fallback={<></>}>
 				<SignInGateMain
@@ -26,6 +33,7 @@ export const signInGateMandatoryComponent: SignInGateComponent = {
 					dismissGate={dismissGate}
 					guUrl={guUrl}
 					signInUrl={signInUrl}
+					registerUrl={registerUrl}
 					abTest={abTest}
 					isMandatory={true}
 				/>

--- a/dotcom-rendering/src/components/SignInGate/gates/main-variant.tsx
+++ b/dotcom-rendering/src/components/SignInGate/gates/main-variant.tsx
@@ -48,6 +48,7 @@ export const signInGateComponent: SignInGateComponent = {
 		dismissGate,
 		guUrl,
 		signInUrl,
+		registerUrl,
 		abTest,
 		checkoutCompleteCookieData,
 		personaliseSignInGateAfterCheckoutSwitch,
@@ -62,6 +63,7 @@ export const signInGateComponent: SignInGateComponent = {
 							dismissGate={dismissGate}
 							guUrl={guUrl}
 							signInUrl={signInUrl}
+							registerUrl={registerUrl}
 							abTest={abTest}
 							checkoutCompleteCookieData={
 								checkoutCompleteCookieData
@@ -73,6 +75,7 @@ export const signInGateComponent: SignInGateComponent = {
 							dismissGate={dismissGate}
 							guUrl={guUrl}
 							signInUrl={signInUrl}
+							registerUrl={registerUrl}
 							abTest={abTest}
 						/>
 					)}

--- a/dotcom-rendering/src/components/SignInGate/gates/sign-in-gate-copy-test-jan2023.tsx
+++ b/dotcom-rendering/src/components/SignInGate/gates/sign-in-gate-copy-test-jan2023.tsx
@@ -18,7 +18,14 @@ const SignInGateCopyTestJan2023 = React.lazy(() => {
 });
 
 export const signInGateCopyTestJan2023Component: SignInGateComponent = {
-	gate: ({ ophanComponentId, dismissGate, guUrl, signInUrl, abTest }) => (
+	gate: ({
+		ophanComponentId,
+		dismissGate,
+		guUrl,
+		signInUrl,
+		registerUrl,
+		abTest,
+	}) => (
 		<Lazy margin={300}>
 			<Suspense fallback={<></>}>
 				<SignInGateCopyTestJan2023
@@ -26,6 +33,7 @@ export const signInGateCopyTestJan2023Component: SignInGateComponent = {
 					dismissGate={dismissGate}
 					guUrl={guUrl}
 					signInUrl={signInUrl}
+					registerUrl={registerUrl}
 					abTest={abTest}
 				/>
 			</Suspense>

--- a/dotcom-rendering/src/components/SignInGate/types.ts
+++ b/dotcom-rendering/src/components/SignInGate/types.ts
@@ -53,6 +53,7 @@ export function isCheckoutCompleteCookieData(
 }
 export type SignInGateProps = {
 	signInUrl: string;
+	registerUrl: string;
 	guUrl: string;
 	dismissGate: () => void;
 	ophanComponentId: string;

--- a/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
+++ b/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
@@ -43,6 +43,7 @@ interface ShowSignInGateProps {
 	componentId: string;
 	format: ArticleFormat;
 	signInUrl: string;
+	registerUrl: string;
 	gateVariant: SignInGateComponent;
 	host: string;
 	checkoutCompleteCookieData?: CheckoutCompleteCookieData;
@@ -63,21 +64,24 @@ const dismissGate = (
 
 // function to generate the profile.theguardian.com url with tracking params
 // and the return url (link to current article page)
-const generateSignInUrl = ({
-	pageId,
-	pageViewId,
-	idUrl,
-	host,
-	currentTest,
-	componentId,
-}: {
-	pageId: string;
-	pageViewId: string;
-	idUrl: string;
-	host: string;
-	currentTest: CurrentSignInGateABTest;
-	componentId?: string;
-}) => {
+const generateGatewayUrl = (
+	tab: 'register' | 'signin',
+	{
+		pageId,
+		pageViewId,
+		idUrl,
+		host,
+		currentTest,
+		componentId,
+	}: {
+		pageId: string;
+		pageViewId: string;
+		idUrl: string;
+		host: string;
+		currentTest: CurrentSignInGateABTest;
+		componentId?: string;
+	},
+) => {
 	// url of the article, return user here after sign in/registration
 	const returnUrl = `${host}/${pageId}`;
 
@@ -92,7 +96,7 @@ const generateSignInUrl = ({
 		viewId: pageViewId,
 	};
 
-	return `${idUrl}/signin?returnUrl=${returnUrl}&componentEventParams=${encodeURIComponent(
+	return `${idUrl}/${tab}?returnUrl=${returnUrl}&componentEventParams=${encodeURIComponent(
 		constructQuery(queryParams),
 	)}`;
 };
@@ -105,6 +109,7 @@ const ShowSignInGate = ({
 	componentId,
 	setShowGate,
 	signInUrl,
+	registerUrl,
 	gateVariant,
 	host,
 	checkoutCompleteCookieData,
@@ -126,6 +131,7 @@ const ShowSignInGate = ({
 		return gateVariant.gate({
 			guUrl: host,
 			signInUrl,
+			registerUrl,
 			dismissGate: () => {
 				dismissGate(setShowGate, abTest);
 			},
@@ -257,14 +263,14 @@ export const SignInGateSelector = ({
 		? personaliseComponentId(signInGateComponentId)
 		: signInGateComponentId;
 
-	const signInUrl = generateSignInUrl({
+	const ctaUrlParams = {
 		pageId,
 		host,
 		pageViewId,
 		idUrl,
 		currentTest,
 		componentId,
-	});
+	};
 
 	return (
 		<>
@@ -276,7 +282,8 @@ export const SignInGateSelector = ({
 					componentId={componentId}
 					// eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Odd react types, should review
 					setShowGate={(show) => setIsGateDismissed(!show)}
-					signInUrl={signInUrl}
+					signInUrl={generateGatewayUrl('signin', ctaUrlParams)}
+					registerUrl={generateGatewayUrl('register', ctaUrlParams)}
 					gateVariant={gateVariant}
 					host={host}
 					checkoutCompleteCookieData={checkoutCompleteCookieData}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

The sign in gate has a main CTA button that says "Register for free" - this button was linked to profile.theguardian.com/signin but has now been fixed to link to profile.theguardian.com/register

Believe this was a legacy link to the previous profile UX/UI which did not have separate tabs. 



## Screenshots for reference (no UI changes) 

![image](https://github.com/guardian/dotcom-rendering/assets/32312712/36a1808f-3951-4171-80d0-9b0403bef096)


Profile tabs: 
![image](https://github.com/guardian/dotcom-rendering/assets/32312712/d7020815-7cf1-4f61-8171-224ebbb60900)



[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
