### PR TITLE
Unify Polyfill.io URL across renders

### DIFF
--- a/dotcom-rendering/src/lib/polyfill.io.ts
+++ b/dotcom-rendering/src/lib/polyfill.io.ts
@@ -1,0 +1,28 @@
+/** Polyfill.io script URL configuration */
+export const polyfillIO = new URL(
+	'https://assets.guim.co.uk/polyfill.io/v3/polyfill.min.js?' +
+		new URLSearchParams({
+			rum: String(0),
+			features: [
+				'es6',
+				'es7',
+				'es2017',
+				'es2018',
+				'es2019',
+				'default-3.6',
+				'HTMLPictureElement',
+				'IntersectionObserver',
+				'IntersectionObserverEntry',
+				'URLSearchParams',
+				'fetch',
+				'NodeList.prototype.forEach',
+				'navigator.sendBeacon',
+				'performance.now',
+				'Promise.allSettled',
+			].join(','),
+			flags: 'gated',
+			callback: 'guardianPolyfilled',
+			unknown: 'polyfill',
+			cacheClear: String(1),
+		}).toString(),
+).toString();

--- a/dotcom-rendering/src/server/render.allEditorialNewslettersPage.web.tsx
+++ b/dotcom-rendering/src/server/render.allEditorialNewslettersPage.web.tsx
@@ -7,6 +7,7 @@ import { generateScriptTags, getPathFromManifest } from '../lib/assets';
 import { renderToStringWithEmotion } from '../lib/emotion';
 import { escapeData } from '../lib/escapeData';
 import { getHttp3Url } from '../lib/getHttp3Url';
+import { polyfillIO } from '../lib/polyfill.io';
 import { extractNAV } from '../model/extract-nav';
 import { makeWindowGuardian } from '../model/window-guardian';
 import type { DCRNewslettersPageType } from '../types/newslettersPage';
@@ -32,9 +33,6 @@ export const renderEditorialNewslettersPage = ({
 	// Evaluating the performance of HTTP3 over HTTP2
 	// See: https://github.com/guardian/dotcom-rendering/pull/5394
 	const { offerHttp3 = false } = newslettersPage.config.switches;
-
-	const polyfillIO =
-		'https://assets.guim.co.uk/polyfill.io/v3/polyfill.min.js?rum=0&features=es6,es7,es2017,es2018,es2019,default-3.6,HTMLPictureElement,IntersectionObserver,IntersectionObserverEntry,URLSearchParams,fetch,NodeList.prototype.forEach,navigator.sendBeacon,performance.now,Promise.allSettled&flags=gated&callback=guardianPolyfilled&unknown=polyfill&cacheClear=1';
 
 	const shouldServeVariantBundle: boolean = [
 		BUILD_VARIANT,

--- a/dotcom-rendering/src/server/render.article.web.tsx
+++ b/dotcom-rendering/src/server/render.article.web.tsx
@@ -18,6 +18,7 @@ import { escapeData } from '../lib/escapeData';
 import { getHttp3Url } from '../lib/getHttp3Url';
 import { getCurrentPillar } from '../lib/layoutHelpers';
 import { LiveBlogRenderer } from '../lib/LiveBlogRenderer';
+import { polyfillIO } from '../lib/polyfill.io';
 import { extractGA } from '../model/extract-ga';
 import { extractNAV } from '../model/extract-nav';
 import { makeWindowGuardian } from '../model/window-guardian';
@@ -67,9 +68,6 @@ export const renderHtml = ({ article }: Props): string => {
 	// Evaluating the performance of HTTP3 over HTTP2
 	// See: https://github.com/guardian/dotcom-rendering/pull/5394
 	const { offerHttp3 = false } = article.config.switches;
-
-	const polyfillIO =
-		'https://assets.guim.co.uk/polyfill.io/v3/polyfill.min.js?rum=0&features=es6,es7,es2017,es2018,es2019,default-3.6,HTMLPictureElement,IntersectionObserver,IntersectionObserverEntry,URLSearchParams,fetch,NodeList.prototype.forEach,navigator.sendBeacon,performance.now,Promise.allSettled&flags=gated&callback=guardianPolyfilled&unknown=polyfill&cacheClear=1';
 
 	const pageHasNonBootInteractiveElements = elements.some(
 		(element) =>

--- a/dotcom-rendering/src/server/render.front.web.tsx
+++ b/dotcom-rendering/src/server/render.front.web.tsx
@@ -9,6 +9,7 @@ import { generateScriptTags, getPathFromManifest } from '../lib/assets';
 import { renderToStringWithEmotion } from '../lib/emotion';
 import { escapeData } from '../lib/escapeData';
 import { getHttp3Url } from '../lib/getHttp3Url';
+import { polyfillIO } from '../lib/polyfill.io';
 import { themeToPillar } from '../lib/themeToPillar';
 import type { NavType } from '../model/extract-nav';
 import { extractNAV } from '../model/extract-nav';
@@ -80,9 +81,6 @@ export const renderFront = ({ front }: Props): string => {
 	// Evaluating the performance of HTTP3 over HTTP2
 	// See: https://github.com/guardian/dotcom-rendering/pull/5394
 	const { offerHttp3 = false } = front.config.switches;
-
-	const polyfillIO =
-		'https://assets.guim.co.uk/polyfill.io/v3/polyfill.min.js?rum=0&features=es6,es7,es2017,es2018,es2019,default-3.6,HTMLPictureElement,IntersectionObserver,IntersectionObserverEntry,URLSearchParams,fetch,NodeList.prototype.forEach,navigator.sendBeacon,performance.now,Promise.allSettled&flags=gated&callback=guardianPolyfilled&unknown=polyfill&cacheClear=1';
 
 	const shouldServeVariantBundle: boolean = [
 		BUILD_VARIANT,
@@ -172,9 +170,6 @@ export const renderTagFront = ({
 	// Evaluating the performance of HTTP3 over HTTP2
 	// See: https://github.com/guardian/dotcom-rendering/pull/5394
 	const { offerHttp3 = false } = tagFront.config.switches;
-
-	const polyfillIO =
-		'https://assets.guim.co.uk/polyfill.io/v3/polyfill.min.js?rum=0&features=es6,es7,es2017,es2018,es2019,default-3.6,HTMLPictureElement,IntersectionObserver,IntersectionObserverEntry,URLSearchParams,fetch,NodeList.prototype.forEach,navigator.sendBeacon,performance.now,Promise.allSettled&flags=gated&callback=guardianPolyfilled&unknown=polyfill&cacheClear=1';
 
 	const shouldServeVariantBundle: boolean = [
 		BUILD_VARIANT,


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

- refactor(polyfillIO): extract URL for reuse
- feat(polyfillIO): add `Promise.prototype.finally`

## Why?

Currently the URL is saved as a raw string, making it hard to parse which features are enabled. Commit diff are equally hard to parse. Changes to one type of page should be shared with others. Examples of previous commits:

- ca605d1b6360ecc2b48699a7574ecc7b3cfc503b
- b62b5850f7d7effea0954ad578afdfb752b66f9b
- cd76e03844fd344418f45beccda77b1bd7fb1ba1
- 2290286a7ca266eac786df0704c5b6f6cc0a19a0
- 6d5ab3f2699c4240694a1dee6826e674920ba59a
- b18f47bb64ff79a2b06a7a5500efb8339269e69c
- ef0c08417bee26083bfe2808fd23ad4b5cfb3cd1
- 6a7fc3c2f0783050b4b2fefc328517d6ed94f228
- 2cc46046e9711255a86ec6bf5fb628fc1cfdd265
- 01289c218d3d417101c9889da88c2f2ee7138440
- 7ba088b9b234668fc6fe2f048dd58fc77e8ae05f
