### PR TITLE
Dblatcher newsletters page fail states

### DIFF
--- a/dotcom-rendering/src/components/ManyNewsletterSignUp.importable.tsx
+++ b/dotcom-rendering/src/components/ManyNewsletterSignUp.importable.tsx
@@ -20,9 +20,6 @@ import { ManyNewslettersForm } from './ManyNewslettersForm';
 import { BUTTON_ROLE, BUTTON_SELECTED_CLASS } from './NewsletterCard';
 import { Section } from './Section';
 
-// TO DO - remove before merging
-const IN_DEV_MODE = true as boolean;
-
 const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 type FormStatus = 'NotSent' | 'Loading' | 'Success' | 'Failed' | 'InvalidEmail';
 
@@ -118,10 +115,9 @@ export const ManyNewsletterSignUp = () => {
 	const [status, setStatus] = useState<FormStatus>('NotSent');
 	const [email, setEmail] = useState('');
 	const reCaptchaRef = useRef<ReCAPTCHA>(null);
-	const useReCaptcha =
-		isServer || IN_DEV_MODE
-			? false
-			: !!window.guardian.config.switches['emailSignupRecaptcha'];
+	const useReCaptcha = isServer
+		? false
+		: !!window.guardian.config.switches['emailSignupRecaptcha'];
 	const captchaSiteKey = useReCaptcha ? getCaptchaSiteKey() : undefined;
 
 	const userCanInteract = status !== 'Success' && status !== 'Loading';
@@ -199,28 +195,11 @@ export const ManyNewsletterSignUp = () => {
 			newsletterIds: newslettersToSignUpFor,
 		});
 
-		const response = IN_DEV_MODE
-			? await new Promise<Response>((resolve) => {
-					setTimeout(() => {
-						resolve({
-							ok: false,
-							text() {
-								return new Promise<string>((resolveText) => {
-									resolveText(
-										`fake response text ${Math.random().toPrecision(
-											5,
-										)}`,
-									);
-								});
-							},
-						} as Response);
-					}, 2000);
-			  })
-			: await requestMultipleSignUps(
-					email,
-					newslettersToSignUpFor,
-					reCaptchaToken,
-			  );
+		const response = await requestMultipleSignUps(
+			email,
+			newslettersToSignUpFor,
+			reCaptchaToken,
+		);
 
 		if (!response.ok) {
 			const responseText = await response.text();

--- a/dotcom-rendering/src/components/ManyNewsletterSignUp.importable.tsx
+++ b/dotcom-rendering/src/components/ManyNewsletterSignUp.importable.tsx
@@ -124,9 +124,7 @@ export const ManyNewsletterSignUp = () => {
 			: !!window.guardian.config.switches['emailSignupRecaptcha'];
 	const captchaSiteKey = useReCaptcha ? getCaptchaSiteKey() : undefined;
 
-	const userCanInteract = ['NotSent', 'Failed', 'InvalidEmail'].includes(
-		status,
-	);
+	const userCanInteract = status !== 'Success' && status !== 'Loading';
 
 	const toggleNewsletter = useCallback(
 		(event: Event) => {

--- a/dotcom-rendering/src/components/ManyNewsletterSignUp.importable.tsx
+++ b/dotcom-rendering/src/components/ManyNewsletterSignUp.importable.tsx
@@ -236,7 +236,7 @@ export const ManyNewsletterSignUp = () => {
 	};
 
 	const handleSubmitButton = async () => {
-		if (status !== 'NotSent') {
+		if (status !== 'NotSent' && status !== 'Failed') {
 			return;
 		}
 

--- a/dotcom-rendering/src/components/ManyNewsletterSignUp.importable.tsx
+++ b/dotcom-rendering/src/components/ManyNewsletterSignUp.importable.tsx
@@ -199,10 +199,14 @@ export const ManyNewsletterSignUp = () => {
 			email,
 			newslettersToSignUpFor,
 			reCaptchaToken,
-		);
+		).catch(() => {
+			return undefined;
+		});
 
-		if (!response.ok) {
-			const responseText = await response.text();
+		if (!response?.ok) {
+			const responseText = response
+				? await response.text()
+				: '[fetch failure - no response]';
 			reportTrackingEvent('ManyNewsletterSignUp', 'failure-response', {
 				newsletterIds: newslettersToSignUpFor,
 				responseText,

--- a/dotcom-rendering/src/components/ManyNewslettersForm.tsx
+++ b/dotcom-rendering/src/components/ManyNewslettersForm.tsx
@@ -5,11 +5,7 @@ import {
 	palette,
 	space,
 } from '@guardian/source-foundations';
-import {
-	Button,
-	InlineError,
-	TextInput,
-} from '@guardian/source-react-components';
+import { Button, TextInput } from '@guardian/source-react-components';
 import type { ChangeEventHandler } from 'react';
 import { InlineSkipToWrapper } from './InlineSkipToWrapper';
 import { NewsletterPrivacyMessage } from './NewsletterPrivacyMessage';
@@ -39,7 +35,7 @@ export const formFrameStyle = css`
 		flex-basis: ${4 * CARD_CONTAINER_WIDTH - CARD_CONTAINER_PADDING}px;
 
 		flex-direction: row-reverse;
-		align-items: center;
+		align-items: flex-start;
 		justify-content: space-between;
 	}
 `;
@@ -130,13 +126,20 @@ export const ManyNewslettersForm = ({
 				</InlineSkipToWrapper>
 			</aside>
 
-			{(status === 'NotSent' || status === 'Loading') && (
+			{(status === 'NotSent' ||
+				status === 'Loading' ||
+				status === 'Failed') && (
 				<div css={formFieldsStyle}>
 					<span css={inputWrapperStyle}>
 						<TextInput
 							label="Enter your email"
 							value={email}
 							onChange={handleTextInput}
+							error={
+								status === 'Failed'
+									? 'Sign up failed. Please try again.'
+									: undefined
+							}
 						/>
 					</span>
 					<Button
@@ -152,8 +155,6 @@ export const ManyNewslettersForm = ({
 					</Button>
 				</div>
 			)}
-
-			{status === 'Failed' && <InlineError>Sign up failed.</InlineError>}
 
 			{status === 'Success' && (
 				<p css={successMessageStyle}>

--- a/dotcom-rendering/src/components/ManyNewslettersForm.tsx
+++ b/dotcom-rendering/src/components/ManyNewslettersForm.tsx
@@ -11,7 +11,7 @@ import { InlineSkipToWrapper } from './InlineSkipToWrapper';
 import { NewsletterPrivacyMessage } from './NewsletterPrivacyMessage';
 
 interface FormProps {
-	status: 'NotSent' | 'Loading' | 'Success' | 'Failed';
+	status: 'NotSent' | 'Loading' | 'Success' | 'Failed' | 'InvalidEmail';
 	email: string;
 	handleTextInput: ChangeEventHandler<HTMLInputElement>;
 	handleSubmitButton: { (): Promise<void> | void };
@@ -108,6 +108,13 @@ export const ManyNewslettersForm = ({
 			? 'Sign up for the newsletter you selected'
 			: `Sign up for the ${newsletterCount} newsletters you selected`;
 
+	const errorMessage =
+		status === 'Failed'
+			? 'Sign up failed. Please try again'
+			: status === 'InvalidEmail'
+			? 'Please enter a valid email address'
+			: undefined;
+
 	return (
 		<form
 			aria-label="sign-up confirmation form"
@@ -126,20 +133,15 @@ export const ManyNewslettersForm = ({
 				</InlineSkipToWrapper>
 			</aside>
 
-			{(status === 'NotSent' ||
-				status === 'Loading' ||
-				status === 'Failed') && (
+			{status !== 'Success' ? (
 				<div css={formFieldsStyle}>
 					<span css={inputWrapperStyle}>
 						<TextInput
 							label="Enter your email"
 							value={email}
 							onChange={handleTextInput}
-							error={
-								status === 'Failed'
-									? 'Sign up failed. Please try again.'
-									: undefined
-							}
+							error={errorMessage}
+							disabled={status === 'Loading'}
 						/>
 					</span>
 					<Button
@@ -154,9 +156,7 @@ export const ManyNewslettersForm = ({
 						Sign up
 					</Button>
 				</div>
-			)}
-
-			{status === 'Success' && (
+			) : (
 				<p css={successMessageStyle}>
 					You are now a subscriber! Thank you for signing up
 				</p>

--- a/dotcom-rendering/src/components/ManyNewslettersForm.tsx
+++ b/dotcom-rendering/src/components/ManyNewslettersForm.tsx
@@ -91,7 +91,12 @@ export const successMessageStyle = css`
 		fontWeight: 'bold',
 	})}
 
+	padding-bottom: ${space[12]}px;
+	max-width: 340px;
+
 	${from.desktop} {
+		padding-bottom: 0;
+		max-width: unset;
 		flex-basis: 340px;
 	}
 `;
@@ -133,34 +138,36 @@ export const ManyNewslettersForm = ({
 				</InlineSkipToWrapper>
 			</aside>
 
-			{status !== 'Success' ? (
-				<div css={formFieldsStyle}>
-					<span css={inputWrapperStyle}>
-						<TextInput
-							label="Enter your email"
-							value={email}
-							onChange={handleTextInput}
-							error={errorMessage}
-							disabled={status === 'Loading'}
-						/>
-					</span>
-					<Button
-						aria-label={ariaLabel}
-						isLoading={status === 'Loading'}
-						iconSide="right"
-						onClick={() => {
-							void handleSubmitButton();
-						}}
-						cssOverrides={signUpButtonStyle}
-					>
-						Sign up
-					</Button>
-				</div>
-			) : (
-				<p css={successMessageStyle}>
-					You are now a subscriber! Thank you for signing up
-				</p>
-			)}
+			<div css={formFieldsStyle}>
+				{status !== 'Success' ? (
+					<>
+						<span css={inputWrapperStyle}>
+							<TextInput
+								label="Enter your email"
+								value={email}
+								onChange={handleTextInput}
+								error={errorMessage}
+								disabled={status === 'Loading'}
+							/>
+						</span>
+						<Button
+							aria-label={ariaLabel}
+							isLoading={status === 'Loading'}
+							iconSide="right"
+							onClick={() => {
+								void handleSubmitButton();
+							}}
+							cssOverrides={signUpButtonStyle}
+						>
+							Sign up
+						</Button>
+					</>
+				) : (
+					<p css={successMessageStyle}>
+						You are now a subscriber! Thank you for signing up
+					</p>
+				)}
+			</div>
 		</form>
 	);
 };

--- a/dotcom-rendering/src/components/ManyNewslettersForm.tsx
+++ b/dotcom-rendering/src/components/ManyNewslettersForm.tsx
@@ -59,7 +59,7 @@ export const inputWrapperStyle = css`
 	${from.desktop} {
 		margin-bottom: 0;
 		margin-right: ${space[2]}px;
-		flex-basis: 280px;
+		flex-basis: 296px;
 	}
 `;
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Updates to the WIP DCR newsletters page - see https://github.com/guardian/dotcom-rendering/issues/8423 for background

 - validates the email address format client side before submitting the sign-up request
 - displays error messages for 'invalid email' or 'signup failed' under the text input
 - allows the user to resubmit from the error states


## Why?
Better user experience - allows users to try again without reloading the page. 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| <img width="982" alt="Screenshot 2023-08-03 at 14 24 17" src="https://github.com/guardian/dotcom-rendering/assets/30567854/9d5c9069-ca1b-4d3e-bcad-446b86b431f5">| <img width="982" alt="Screenshot 2023-08-03 at 14 22 33" src="https://github.com/guardian/dotcom-rendering/assets/30567854/31dd3926-fac9-405f-a549-28b540370d37">|

[before]: https://example.com/before.png
[after]: https://example.com/after.png


