### PR TITLE
change soccer treat image

### DIFF
--- a/dotcom-rendering/src/model/enhanceTreats.ts
+++ b/dotcom-rendering/src/model/enhanceTreats.ts
@@ -11,7 +11,7 @@ const SOCCER_TREAT: TreatType = {
 		},
 	],
 	theme: Pillar.Sport,
-	imageUrl: 'https://uploads.guim.co.uk/2023/07/26/soccer-treat-v1.png',
+	imageUrl: 'https://uploads.guim.co.uk/2023/08/03/Soccer-v7_TREAT.png',
 	altText: 'Soccer ball',
 };
 


### PR DESCRIPTION
## What does this change?
Image url for the soccer treat image on the /us front

## Why?
Request from the US design team.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| <img width="677" alt="Screenshot 2023-08-03 at 15 03 44" src="https://github.com/guardian/dotcom-rendering/assets/30567854/e50cd390-0e0d-40d1-8549-07f4eb9edec6"> | <img width="677" alt="Screenshot 2023-08-03 at 15 06 53" src="https://github.com/guardian/dotcom-rendering/assets/30567854/11614f5a-6a83-44c0-a01f-d492bf809622">|

