### PR TITLE
docs: update LICENSE with owner

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright {yyyy} {name of copyright owner}
+   Copyright 2023 Guardian News & Media Limited or its affiliated companies
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
## What does this change?

Taken from `www.theguardian.com`’s footer: “© 2023 Guardian News & Media Limited or its affiliated companies”

## Why?

It was incomplete as noticed alongside @JamieB-gu 