### PR TITLE
Prevent redeclaring variables (including eponymous types)

### DIFF
--- a/dotcom-rendering/.eslintrc.js
+++ b/dotcom-rendering/.eslintrc.js
@@ -127,6 +127,7 @@ module.exports = {
 		'@typescript-eslint/no-shadow': ['error'],
 		'no-underscore-dangle': ['warn', { allow: ['_type'] }],
 		'no-useless-escape': 'error',
+		'no-redeclare': 'error',
 		'custom-elements/file-name-matches-element': 'error',
 
 		'object-shorthand': ['error', 'always'],
@@ -171,7 +172,7 @@ module.exports = {
 		...rulesToOverrideGuardianConfig,
 	},
 	settings: {
-		'import/resolver': 'typescript'
+		'import/resolver': 'typescript',
 	},
 	overrides: [
 		{

--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -482,12 +482,26 @@ declare module 'dynamic-import-polyfill' {
 	}) => void;
 }
 
-// ------------------------------------- //
-// AMP types                             //
-// ------------------------------------- //
+// SVG handling
+declare module '*.svg' {
+	const content: any;
+	// eslint-disable-next-line import/no-default-export -- This is how we import SVGs
+	export default content;
+}
+
+// Extend PerformanceEntry from lib.dom.ts with current 'In Draft' properties (to allow access as use in browsers that support)
+// lib.dom.ts: https://microsoft.github.io/PowerBI-JavaScript/interfaces/_node_modules_typedoc_node_modules_typescript_lib_lib_dom_d_.performanceentry.html
+// Draft: https://wicg.github.io/element-timing/#sec-performance-element-timing
+interface PerformanceEntry {
+	loadTime: number;
+	renderTime: number;
+}
 
 declare namespace JSX {
 	interface IntrinsicElements {
+		// ------------------------------------- //
+		// AMP types                             //
+		// ------------------------------------- //
 		'amp-accordion': any;
 		'amp-ad': any;
 		'amp-analytics': any;
@@ -513,26 +527,8 @@ declare namespace JSX {
 		'amp-video': any;
 		'amp-vimeo': any;
 		'amp-youtube': any;
-	}
-}
 
-// SVG handling
-declare module '*.svg' {
-	const content: any;
-	// eslint-disable-next-line import/no-default-export -- This is how we import SVGs
-	export default content;
-}
-
-// Extend PerformanceEntry from lib.dom.ts with current 'In Draft' properties (to allow access as use in browsers that support)
-// lib.dom.ts: https://microsoft.github.io/PowerBI-JavaScript/interfaces/_node_modules_typedoc_node_modules_typescript_lib_lib_dom_d_.performanceentry.html
-// Draft: https://wicg.github.io/element-timing/#sec-performance-element-timing
-interface PerformanceEntry {
-	loadTime: number;
-	renderTime: number;
-}
-
-declare namespace JSX {
-	interface IntrinsicElements {
+		/** Island {@link ./src/components/Island.tsx} */
 		'gu-island': {
 			name: string;
 			deferUntil?: 'idle' | 'visible' | 'interaction' | 'hash';

--- a/dotcom-rendering/src/components/Weather.tsx
+++ b/dotcom-rendering/src/components/Weather.tsx
@@ -29,8 +29,8 @@ import {
 } from '@guardian/source-react-components';
 import { useId } from 'react';
 import type { EditionId } from '../lib/edition';
-import type { WeatherData, WeatherForecast } from './WeatherData.importable';
 import { WeatherSlot } from './WeatherSlot';
+import type { WeatherData, WeatherForecast } from './WeatherWrapper.importable';
 
 const visuallyHiddenCSS = css`
 	${visuallyHidden}

--- a/dotcom-rendering/src/components/WeatherSlot.tsx
+++ b/dotcom-rendering/src/components/WeatherSlot.tsx
@@ -11,7 +11,7 @@ import {
 import { isNull } from 'lodash';
 import { lazy, Suspense } from 'react';
 import { type EditionId, getEditionFromId } from '../lib/edition';
-import type { WeatherData } from './WeatherData.importable';
+import type { WeatherData } from './WeatherWrapper.importable';
 
 interface IconProps {
 	size?: number;

--- a/dotcom-rendering/src/components/WeatherWrapper.importable.tsx
+++ b/dotcom-rendering/src/components/WeatherWrapper.importable.tsx
@@ -59,7 +59,7 @@ type Props = {
 	edition: EditionId;
 };
 
-export const WeatherData = ({ ajaxUrl, edition }: Props) => {
+export const WeatherWrapper = ({ ajaxUrl, edition }: Props) => {
 	const { data, error } = useApi<WeatherApiData>(`${ajaxUrl}/weather.json`);
 
 	if (error) {

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -32,7 +32,7 @@ import { SnapCssSandbox } from '../components/SnapCssSandbox';
 import { StickyBottomBanner } from '../components/StickyBottomBanner.importable';
 import { SubNav } from '../components/SubNav.importable';
 import { TrendingTopics } from '../components/TrendingTopics';
-import { WeatherData } from '../components/WeatherData.importable';
+import { WeatherWrapper } from '../components/WeatherWrapper.importable';
 import { canRenderAds } from '../lib/canRenderAds';
 import { getContributionsServiceUrl } from '../lib/contributions';
 import { decideContainerOverrides } from '../lib/decideContainerOverrides';
@@ -140,7 +140,7 @@ const decideLeftContent = (
 	) {
 		return (
 			<Island clientOnly={true} deferUntil={'idle'}>
-				<WeatherData
+				<WeatherWrapper
 					ajaxUrl={front.config.ajaxUrl}
 					edition={front.editionId}
 				/>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Prevents a variable having the same exact name as a type in the same module.

## Why?

It’s ambiguous for humans what the intent is. We cannot get the best out of [the consistent type imports rule](https://typescript-eslint.io/rules/consistent-type-imports/).