### PR TITLE
Remove CLS from Weather entirely

### DIFF
--- a/dotcom-rendering/src/components/Weather.tsx
+++ b/dotcom-rendering/src/components/Weather.tsx
@@ -48,6 +48,7 @@ const weatherCSS = css`
 
 	${between.tablet.and.leftCol} {
 		padding-top: 6px;
+		height: 52px;
 	}
 `;
 
@@ -231,6 +232,10 @@ const collapsibleStyles = css`
 		}
 	}
 `;
+
+export const WeatherPlaceholder = () => (
+	<aside css={[collapsibleStyles, weatherCSS]}></aside>
+);
 
 export const Weather = ({ location, now, forecast, edition }: WeatherProps) => {
 	const checkboxId = useId();

--- a/dotcom-rendering/src/components/WeatherWrapper.importable.tsx
+++ b/dotcom-rendering/src/components/WeatherWrapper.importable.tsx
@@ -1,6 +1,6 @@
 import type { EditionId } from '../lib/edition';
 import { useApi } from '../lib/useApi';
-import { Weather } from './Weather';
+import { Weather, WeatherPlaceholder } from './Weather';
 
 /**
  * Our weather API returns 24 forecast.
@@ -66,7 +66,9 @@ export const WeatherWrapper = ({ ajaxUrl, edition }: Props) => {
 		window.guardian.modules.sentry.reportError(error, 'weather');
 	}
 
-	return !data ? null : (
+	return !data ? (
+		<WeatherPlaceholder />
+	) : (
 		<Weather
 			location={data.location}
 			now={data.weather}

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -139,7 +139,7 @@ const decideLeftContent = (
 		!hasPageSkin
 	) {
 		return (
-			<Island clientOnly={true} deferUntil={'idle'}>
+			<Island deferUntil={'idle'}>
 				<WeatherWrapper
 					ajaxUrl={front.config.ajaxUrl}
 					edition={front.editionId}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Adds a server-side rendered placeholder.

## Why?

Ensures that between `tablet` and `leftCol` we do not caus CLS.

## Screenshots

https://github.com/guardian/dotcom-rendering/assets/76776/e79d26c9-ab8f-46de-bbfd-753208966608

https://github.com/guardian/dotcom-rendering/assets/76776/43984ed5-4414-4078-9543-7fc8f3b21757






