### PR TITLE
Explicit Header height

### DIFF
--- a/dotcom-rendering/src/components/Header.tsx
+++ b/dotcom-rendering/src/components/Header.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { brand } from '@guardian/source-foundations';
+import { brand, from } from '@guardian/source-foundations';
 import { pageSkinContainer } from '../layouts/lib/pageSkin';
 import { center } from '../lib/center';
 import type { EditionId } from '../lib/edition';
@@ -9,6 +9,21 @@ import { Island } from './Island';
 import { Logo } from './Logo';
 import { Snow } from './Snow.importable';
 import { SupportTheG } from './SupportTheG.importable';
+
+/** Ensures we do not cause CLS from lazy loaded component height */
+const explicitHeight = css`
+	overflow: hidden;
+	height: 80px;
+	${from.mobileMedium} {
+		height: 100px;
+	}
+	${from.tablet} {
+		height: 120px;
+	}
+	${from.desktop} {
+		height: 150px;
+	}
+`;
 
 const headerStyles = css`
 	background-color: ${brand[400]};
@@ -60,14 +75,7 @@ export const Header = ({
 			/>
 		</Island>
 
-		<div
-			css={[
-				hasPageSkin ? pageSkinContainer : center,
-				css`
-					overflow: hidden;
-				`,
-			]}
-		>
+		<div css={[hasPageSkin ? pageSkinContainer : center, explicitHeight]}>
 			<Island deferUntil="hash" clientOnly={true}>
 				<Snow />
 			</Island>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Set an explicit CSS height on the `Header` component at three breakpoints:

- mobile: 80px
- mobileMedium: 100px
- tablet: 120px
- desktop: 150px

These values are based on the current sizes, after loading the supporter component.

N.B. **Overflow will be hidden!**

## Why?

The header has several lazy loaded components, which may cause layout shift which is jarring to users and negatively impacts our search engine rankings.

It may also help with our page skins, cc. @guardian/commercial-dev 

## Screenshots

| Size | Before           | After      |
| ---- | ---------------- | ---------- |
| 320  | ![before-320][]  | ![after-320][] |
| 420  | ![before-420][]  | ![after-420][] |
| 800  | ![before-800][]  | ![after-800][] |
| 1200 | ![before-1200][] | ![after-1200][] |


[after-320]: https://github.com/guardian/dotcom-rendering/assets/76776/9a4a5ca4-6928-4be0-8d63-1fde621b14e0
[after-420]: https://github.com/guardian/dotcom-rendering/assets/76776/6d4f3848-98c7-43ef-9d8f-ff789a5262f8
[after-800]: https://github.com/guardian/dotcom-rendering/assets/76776/4dd643e3-6826-43db-b120-eb3cdd1f3323
[after-1200]: https://github.com/guardian/dotcom-rendering/assets/76776/cb906432-e50f-4494-ba84-52ff904399c5

[before-320]: https://github.com/guardian/dotcom-rendering/assets/76776/dd78a3e0-00ed-46e9-a432-12795b1e22e4
[before-420]: https://github.com/guardian/dotcom-rendering/assets/76776/a3dbf70e-cf4a-41bc-9f82-ae490e49e43d
[before-800]: https://github.com/guardian/dotcom-rendering/assets/76776/ca6343ba-a428-4da7-a42c-7502c54f57a1
[before-1200]: https://github.com/guardian/dotcom-rendering/assets/76776/1e05b712-8a46-4ffe-9af1-d34fdda44457