### PR TITLE
chore: remove redundant nodemon.json file

### DIFF
--- a/dotcom-rendering/nodemon.json
+++ b/dotcom-rendering/nodemon.json
@@ -1,6 +1,0 @@
-{
-    "watch": [
-      "server/",
-      "scripts/frontend/"
-    ]
-}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Removes `nodemon.json` file.

## Why?

Hasn't been used in a while and definitely not used since the [removal of nodemon](https://github.com/guardian/dotcom-rendering/pull/8464) from package.json
