### PR TITLE
AB Test: Fronts banners on network fronts

### DIFF
--- a/dotcom-rendering/src/components/AdSlot.tsx
+++ b/dotcom-rendering/src/components/AdSlot.tsx
@@ -139,6 +139,12 @@ export const labelStyles = css`
 	}
 `;
 
+const adContainerCollapseStyles = css`
+	& .ad-slot.ad-slot--collapse {
+		display: none;
+	}
+`;
+
 const adSlotCollapseStyles = css`
 	&.ad-slot.ad-slot--collapse {
 		display: none;
@@ -349,7 +355,7 @@ const mobileStickyAdStyles = css`
 	}
 `;
 
-export const adContainerStyles = [adSlotCollapseStyles, labelStyles];
+export const adContainerStyles = [adContainerCollapseStyles, labelStyles];
 
 export const AdSlot = ({
 	position,

--- a/dotcom-rendering/src/components/AdSlot.tsx
+++ b/dotcom-rendering/src/components/AdSlot.tsx
@@ -238,6 +238,10 @@ const frontsBannerAdContainerStyles = css`
 	}
 `;
 
+const frontsBannerCollapseStyles = css`
+	display: none;
+`;
+
 const frontsBannerAdStyles = css`
 	max-width: ${breakpoints['wide']}px;
 	overflow: hidden;
@@ -616,14 +620,14 @@ export const AdSlot = ({
 			);
 		}
 		case 'fronts-banner': {
-			const advertId = `fronts-banner-${index + 1}`;
+			const advertId = `fronts-banner-${index}`;
 			return (
 				<div
 					className="ad-slot-container"
 					css={[
-						hasPageskin && pageSkinContainer,
 						adContainerStyles,
 						frontsBannerAdContainerStyles,
+						hasPageskin && frontsBannerCollapseStyles,
 					]}
 				>
 					<div
@@ -633,6 +637,7 @@ export const AdSlot = ({
 							'ad-slot',
 							`ad-slot--${advertId}`,
 							'ad-slot--rendered',
+							hasPageskin && 'ad-slot--collapse',
 						].join(' ')}
 						css={[
 							fluidAdStyles,

--- a/dotcom-rendering/src/components/AdSlot.tsx
+++ b/dotcom-rendering/src/components/AdSlot.tsx
@@ -4,6 +4,7 @@ import type { SlotName } from '@guardian/commercial';
 import { ArticleDisplay } from '@guardian/libs';
 import {
 	border,
+	breakpoints,
 	from,
 	neutral,
 	space,
@@ -17,6 +18,7 @@ import { AD_CONTAINER_HEIGHT } from '../lib/liveblog-right-ad-constants';
 import { TopRightAdSlot } from './TopRightAdSlot';
 
 type InlinePosition =
+	| 'fronts-banner'
 	| 'inline'
 	| 'liveblog-inline'
 	| 'liveblog-right'
@@ -137,21 +139,119 @@ export const labelStyles = css`
 	}
 `;
 
-const adContainerCollapseStyles = css`
-	& .ad-slot.ad-slot--collapse {
-		display: none;
-	}
-`;
-
 const adSlotCollapseStyles = css`
 	&.ad-slot.ad-slot--collapse {
 		display: none;
 	}
 `;
 
+/**
+ * For CSS in Frontend, see mark: 9473ae05-a901-4a8d-a51d-1b9c894d6e1f
+ */
+const fluidAdStyles = css`
+	&.ad-slot--fluid {
+		min-height: 250px;
+		line-height: 10px;
+		padding: 0;
+		margin: 0;
+		overflow: visible;
+	}
+`;
+
+/**
+ * Usage according to DAP (Digital Ad Production)
+ *
+ * #### Desktop
+ * - `fabric` &rarr; `top-above-nav`,`merchandising-high`,`merchandising`
+ * - `fabric-custom` &rarr; `top-above-nav`,`merchandising-high`,`merchandising`
+ * - `fabric-expandable` &rarr; `merchandising-high`
+ * - `fabric-third-party` &rarr; `top-above-nav`,`merchandising-high`,`merchandising`
+ * - `fabric-video` &rarr; `top-above-nav`,`merchandising-high`
+ * - `fabric-video-expandable` &rarr; `merchandising-high`
+ *
+ * #### Mobile
+ * - `interscroller` &rarr; `top-above-nav`
+ * - `mobile-revealer` &rarr; `top-above-nav`
+ */
+const fluidFullWidthAdStyles = css`
+	&.ad-slot--fluid {
+		width: 100%;
+	}
+`;
+
+const topAboveNavStyles = css`
+	position: relative;
+	margin: 0 auto;
+	min-height: ${adSizes.leaderboard.height}px;
+	min-width: ${adSizes.leaderboard.width}px;
+	text-align: left;
+	display: block;
+`;
+
+const merchandisingAdContainerStyles = css`
+	display: flex;
+	justify-content: center;
+`;
+
 const merchandisingAdStyles = css`
 	position: relative;
 	min-height: 250px;
+`;
+
+const inlineAdStyles = css`
+	position: relative;
+	${until.tablet} {
+		display: none;
+	}
+`;
+
+const liveblogInlineAdStyles = css`
+	position: relative;
+`;
+
+const mobileFrontAdStyles = css`
+	position: relative;
+	min-height: ${250 + labelHeight}px;
+	min-width: 300px;
+	width: 300px;
+	margin: 12px auto;
+
+	${from.tablet} {
+		display: none;
+	}
+`;
+
+const frontsBannerAdContainerStyles = css`
+	display: flex;
+	justify-content: center;
+	background-color: ${neutral[97]};
+	min-height: ${250 + labelHeight}px;
+
+	${until.desktop} {
+		display: none;
+	}
+`;
+
+const frontsBannerAdStyles = css`
+	max-width: ${breakpoints['wide']}px;
+	overflow: hidden;
+	/*
+		The following flex settings are to stop the visual effect where the
+		advert renders at the top of the ad slot, then is pushed down 24px to the
+		bottom of the slot when the label renders
+	*/
+	display: flex;
+	flex-direction: column;
+	justify-content: flex-end;
+`;
+
+const articleEndAdStyles = css`
+	position: relative;
+	min-height: 450px;
+
+	&.ad-slot--fluid {
+		min-height: 450px;
+	}
 `;
 
 const mostPopAdStyles = css`
@@ -190,39 +290,6 @@ export const carrotAdStyles = css`
 			margin-left: -240px;
 			width: 220px;
 		}
-	}
-`;
-
-/**
- * For CSS in Frontend, see mark: 9473ae05-a901-4a8d-a51d-1b9c894d6e1f
- */
-const fluidAdStyles = css`
-	&.ad-slot--fluid {
-		min-height: 250px;
-		line-height: 10px;
-		padding: 0;
-		margin: 0;
-	}
-`;
-
-/**
- * Usage according to DAP (Digital Ad Production)
- *
- * #### Desktop
- * - `fabric` &rarr; `top-above-nav`,`merchandising-high`,`merchandising`
- * - `fabric-custom` &rarr; `top-above-nav`,`merchandising-high`,`merchandising`
- * - `fabric-expandable` &rarr; `merchandising-high`
- * - `fabric-third-party` &rarr; `top-above-nav`,`merchandising-high`,`merchandising`
- * - `fabric-video` &rarr; `top-above-nav`,`merchandising-high`
- * - `fabric-video-expandable` &rarr; `merchandising-high`
- *
- * #### Mobile
- * - `interscroller` &rarr; `top-above-nav`
- * - `mobile-revealer` &rarr; `top-above-nav`
- */
-const fluidFullWidthAdStyles = css`
-	&.ad-slot--fluid {
-		width: 100%;
 	}
 `;
 
@@ -282,7 +349,7 @@ const mobileStickyAdStyles = css`
 	}
 `;
 
-export const adContainerStyles = [adContainerCollapseStyles, labelStyles];
+export const adContainerStyles = [adSlotCollapseStyles, labelStyles];
 
 export const AdSlot = ({
 	position,
@@ -336,7 +403,7 @@ export const AdSlot = ({
 				<div
 					className="ad-slot-container"
 					css={[
-						labelStyles,
+						adContainerStyles,
 						css`
 							height: ${AD_CONTAINER_HEIGHT}px;
 						`,
@@ -385,14 +452,6 @@ export const AdSlot = ({
 			);
 		}
 		case 'top-above-nav': {
-			const adSlotAboveNav = css`
-				position: relative;
-				margin: 0 auto;
-				min-height: ${adSizes.leaderboard.height}px;
-				text-align: left;
-				display: block;
-				min-width: 728px;
-			`;
 			return (
 				<div
 					id="dfp-ad--top-above-nav"
@@ -406,7 +465,7 @@ export const AdSlot = ({
 					css={[
 						fluidAdStyles,
 						fluidFullWidthAdStyles,
-						adSlotAboveNav,
+						topAboveNavStyles,
 					]}
 					data-link-name="ad slot top-above-nav"
 					data-name="top-above-nav"
@@ -439,10 +498,7 @@ export const AdSlot = ({
 				<div
 					className="ad-slot-container"
 					css={[
-						css`
-							display: flex;
-							justify-content: center;
-						`,
+						merchandisingAdContainerStyles,
 						hasPageskin && pageSkinContainer,
 						adContainerStyles,
 					]}
@@ -471,13 +527,7 @@ export const AdSlot = ({
 			return (
 				<div
 					className="ad-slot-container"
-					css={[
-						css`
-							display: flex;
-							justify-content: center;
-						`,
-						adContainerStyles,
-					]}
+					css={[merchandisingAdContainerStyles, adContainerStyles]}
 				>
 					<div
 						id="dfp-ad--merchandising"
@@ -530,20 +580,7 @@ export const AdSlot = ({
 							'ad-slot--container-inline',
 							'ad-slot--rendered',
 						].join(' ')}
-						css={[
-							/**
-							 * commercial code will look for slots that are display: none
-							 * and remove them from the dom
-							 *
-							 * on desktop we hide mobile inline slots
-							 */
-							css`
-								position: relative;
-								${until.tablet} {
-									display: none;
-								}
-							`,
-						]}
+						css={[inlineAdStyles]}
 						data-link-name={`ad slot ${advertId}`}
 						data-name={advertId}
 						aria-hidden="true"
@@ -564,13 +601,41 @@ export const AdSlot = ({
 							'ad-slot--liveblog-inline',
 							'ad-slot--rendered',
 						].join(' ')}
-						css={[
-							css`
-								position: relative;
-							`,
-						]}
+						css={[liveblogInlineAdStyles]}
 						data-link-name={`ad slot ${advertId}`}
 						data-name={advertId}
+						aria-hidden="true"
+					/>
+				</div>
+			);
+		}
+		case 'fronts-banner': {
+			const advertId = `fronts-banner-${index + 1}`;
+			return (
+				<div
+					className="ad-slot-container"
+					css={[
+						hasPageskin && pageSkinContainer,
+						adContainerStyles,
+						frontsBannerAdContainerStyles,
+					]}
+				>
+					<div
+						id={`dfp-ad--${advertId}`}
+						className={[
+							'js-ad-slot',
+							'ad-slot',
+							`ad-slot--${advertId}`,
+							'ad-slot--rendered',
+						].join(' ')}
+						css={[
+							fluidAdStyles,
+							fluidFullWidthAdStyles,
+							frontsBannerAdStyles,
+						]}
+						data-link-name={`ad slot ${advertId}`}
+						data-name={`${advertId}`}
+						data-refresh="false"
 						aria-hidden="true"
 					/>
 				</div>
@@ -591,27 +656,7 @@ export const AdSlot = ({
 							'mobile-only',
 							'ad-slot--rendered',
 						].join(' ')}
-						css={[
-							css`
-								position: relative;
-								min-height: 274px;
-								min-width: 300px;
-								width: 300px;
-								margin: 12px auto;
-							`,
-							/**
-							 * commercial code will look for slots that are display: none
-							 * and remove them from the dom
-							 *
-							 * on mobile we hide desktop inline slots
-							 */
-							css`
-								${from.tablet} {
-									display: none;
-								}
-							`,
-							fluidFullWidthAdStyles,
-						]}
+						css={[mobileFrontAdStyles, fluidFullWidthAdStyles]}
 						data-link-name={`ad slot ${advertId}`}
 						data-name={advertId}
 						aria-hidden="true"
@@ -656,14 +701,7 @@ export const AdSlot = ({
 						css={[
 							fluidAdStyles,
 							fluidFullWidthAdStyles,
-							css`
-								position: relative;
-								min-height: 450px;
-
-								&.ad-slot--fluid {
-									min-height: 450px;
-								}
-							`,
+							articleEndAdStyles,
 						]}
 						data-link-name="ad slot article-end"
 						data-name="article-end"

--- a/dotcom-rendering/src/components/FixedMediumSlowXIIMPU.tsx
+++ b/dotcom-rendering/src/components/FixedMediumSlowXIIMPU.tsx
@@ -10,7 +10,7 @@ import type { DCRContainerPalette, DCRFrontCard } from '../types/front';
 import { AdSlot } from './AdSlot';
 import { LI } from './Card/components/LI';
 import { UL } from './Card/components/UL';
-import { Loading } from './CardPicture';
+import type { Loading } from './CardPicture';
 
 type Props = {
 	trails: DCRFrontCard[];
@@ -199,17 +199,12 @@ const ThreeColumnSliceWithAdSlot = ({
 	);
 };
 
-/**
- * FixedMediumSlowXIIMPU
- *
- */
 export const FixedMediumSlowXIIMPU = ({
 	trails,
 	containerPalette,
 	showAge,
 	adIndex,
 	renderAds,
-	padBottom,
 	imageLoading,
 }: Props) => {
 	const firstSlice = trails.slice(0, 3);

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -197,11 +197,17 @@ const decideLeftContent = (
 
 export const FrontLayout = ({ front, NAV }: Props) => {
 	const {
-		config: { abTests, isPaidContent, hasPageSkin: hasPageSkinConfig },
+		config: {
+			switches,
+			abTests,
+			isPaidContent,
+			hasPageSkin: hasPageSkinConfig,
+		},
 	} = front;
 
 	const isInEuropeTest = abTests.europeNetworkFrontVariant === 'variant';
 	const isInFrontsBannerTest =
+		!!switches.frontsBannerAdsDcr &&
 		abTests.frontsBannerAdsDcrVariant === 'variant';
 
 	const merchHighPosition = getMerchHighPosition(

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -12,7 +12,7 @@ import {
 } from '@guardian/source-foundations';
 import { Hide } from '@guardian/source-react-components';
 import { StraightLines } from '@guardian/source-react-components-development-kitchen';
-import { Fragment } from 'react';
+import { Fragment, useRef } from 'react';
 import { AdSlot } from '../components/AdSlot';
 import { Carousel } from '../components/Carousel.importable';
 import { CPScottHeader } from '../components/CPScottHeader';
@@ -128,6 +128,7 @@ export const decideFrontsBannerAdSlot = (
 	isInFrontsBannerTest: boolean,
 	pageId: string,
 	collectionName: string,
+	numBannerAdsInserted: React.MutableRefObject<number>,
 ) => {
 	// We're not using contentType === "Network Front", just
 	// in case Europe goes live before the testing concludes.
@@ -144,13 +145,13 @@ export const decideFrontsBannerAdSlot = (
 		return null;
 	}
 
-	const adIndex = targetedSections.findIndex((ad) => ad === collectionName);
+	numBannerAdsInserted.current = numBannerAdsInserted.current + 1;
 
 	return (
 		<AdSlot
 			data-print-layout="hide"
 			position="fronts-banner"
-			index={adIndex}
+			index={numBannerAdsInserted.current}
 			hasPageskin={hasPageSkin}
 		/>
 	);
@@ -225,6 +226,8 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 	const desktopAdPositions = renderAds
 		? getDesktopAdPositions(front.pressedPage.collections)
 		: [];
+
+	const numBannerAdsInserted = useRef(0);
 
 	const renderMpuAds = !isInFrontsBannerTest && renderAds;
 
@@ -421,6 +424,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 										isInFrontsBannerTest,
 										front.config.pageId,
 										collection.displayName,
+										numBannerAdsInserted,
 									)}
 									{!!trail.embedUri && (
 										<SnapCssSandbox
@@ -481,6 +485,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 									isInFrontsBannerTest,
 									front.config.pageId,
 									collection.displayName,
+									numBannerAdsInserted,
 								)}
 								<FrontSection
 									toggleable={true}
@@ -592,6 +597,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 									isInFrontsBannerTest,
 									front.config.pageId,
 									collection.displayName,
+									numBannerAdsInserted,
 								)}
 								<Section
 									title={collection.displayName}
@@ -660,6 +666,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 								isInFrontsBannerTest,
 								front.config.pageId,
 								collection.displayName,
+								numBannerAdsInserted,
 							)}
 							<FrontSection
 								title={collection.displayName}

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -130,16 +130,11 @@ export const decideFrontsBannerAdSlot = (
 	collectionName: string,
 	numBannerAdsInserted: React.MutableRefObject<number>,
 ) => {
-	// We're not using contentType === "Network Front", just
-	// in case Europe goes live before the testing concludes.
-	// We don't want Europe in this test.
-	const networkFrontPageIds = ['uk', 'us', 'au', 'international'];
 	const targetedSections = frontsBannerAdSections[pageId];
 
 	if (
 		!renderAds ||
 		!isInFrontsBannerTest ||
-		!networkFrontPageIds.includes(pageId) ||
 		!targetedSections?.includes(collectionName)
 	) {
 		return null;
@@ -207,9 +202,15 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 	} = front;
 
 	const isInEuropeTest = abTests.europeNetworkFrontVariant === 'variant';
+
+	// For the FrontsBannerAds test, we're not using contentType === "Network Front",
+	// just in case Europe goes live before the testing concludes.
+	// We don't want Europe in this test.
+	const networkFrontPageIds = ['uk', 'us', 'au', 'international'];
 	const isInFrontsBannerTest =
 		!!switches.frontsBannerAdsDcr &&
-		abTests.frontsBannerAdsDcrVariant === 'variant';
+		abTests.frontsBannerAdsDcrVariant === 'variant' &&
+		networkFrontPageIds.includes(front.config.pageId);
 
 	const merchHighPosition = getMerchHighPosition(
 		front.pressedPage.collections.length,
@@ -229,7 +230,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 
 	const numBannerAdsInserted = useRef(0);
 
-	const renderMpuAds = !isInFrontsBannerTest && renderAds;
+	const renderMpuAds = renderAds && !isInFrontsBannerTest;
 
 	const showMostPopular =
 		front.config.switches.deeplyRead &&

--- a/dotcom-rendering/src/lib/frontsBannerAbTestAdPositions.ts
+++ b/dotcom-rendering/src/lib/frontsBannerAbTestAdPositions.ts
@@ -1,0 +1,52 @@
+/**
+ * This file is temporary.
+ *
+ * For the Fronts banner AB test, we will target
+ * specific sections on the page to insert ads above.
+ *
+ * When we go live with fronts-banner ads, there will be a setting in
+ * the fronts config tool which will decide whether a section has an ad
+ * inserted above it. At the time of this AB test, the setting does not yet exist.
+ */
+
+type FrontsBannerAdSections = {
+	[key: string]: string[];
+};
+
+export const frontsBannerAdSections: FrontsBannerAdSections = {
+	uk: [
+		'Spotlight',
+		'Opinion',
+		"Women's World Cup 2023",
+		'Sport',
+		'Around the world',
+		'Take part',
+		'Explore',
+		'In pictures',
+	],
+	us: [
+		'Spotlight',
+		'Opinion',
+		'Sports',
+		'Around the world',
+		'Culture',
+		'Take part',
+		'In pictures',
+	],
+	au: [
+		'Women’s World Cup 2023', // Apostrophe is intentionally U+2019 "’" instead of the more common ASCII character U+0060 "`",
+		'Spotlight',
+		'Opinion',
+		'Culture',
+		'Around the world',
+		'The big picture',
+	],
+	international: [
+		'Spotlight',
+		'Opinion',
+		'Sport',
+		'Culture',
+		'Around the world',
+		'Take part',
+	],
+};


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

- When in the AB test, `fronts-banner` ads will be displayed above certain sections
- in-section MPUs, `merchandising` and `merchandising-high` ad slots will NOT be displayed

## Why?

- We are running an AB test into `fronts-banner` ads and their effect on revenue, page performance and user experience metrics

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/9574885/62f7df18-6b03-44fb-9a8c-86424894a8dc
[after]: https://github.com/guardian/dotcom-rendering/assets/9574885/6ab333b9-2caf-469a-8b74-414a84a45f8e

Ad slot collapses when a pageskin is displayed
<img width="1614" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/9574885/02ccbed6-1177-426e-a3e4-2af3c87a9e83">


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
