### PR TITLE
Bug Fix:  add googleRecaptchaSiteKey to config

### DIFF
--- a/dotcom-rendering/src/model/article-schema.json
+++ b/dotcom-rendering/src/model/article-schema.json
@@ -3970,6 +3970,9 @@
                 "isPreview": {
                     "type": "boolean"
                 },
+                "googleRecaptchaSiteKey": {
+                    "type": "string"
+                },
                 "pageId": {
                     "type": "string"
                 },

--- a/dotcom-rendering/src/server/render.article.apps.tsx
+++ b/dotcom-rendering/src/server/render.article.apps.tsx
@@ -49,6 +49,7 @@ export const renderArticle = (
 				abTests: article.config.abTests,
 				isPaidContent: article.pageType.isPaidContent,
 				contentType: article.contentType,
+				googleRecaptchaSiteKey: article.config.googleRecaptchaSiteKey,
 				unknownConfig: article.config,
 			}),
 		),

--- a/dotcom-rendering/src/server/render.article.web.tsx
+++ b/dotcom-rendering/src/server/render.article.web.tsx
@@ -137,6 +137,7 @@ export const renderHtml = ({ article }: Props): string => {
 				isPaidContent: article.pageType.isPaidContent,
 				contentType: article.contentType,
 				shouldHideReaderRevenue: article.shouldHideReaderRevenue,
+				googleRecaptchaSiteKey: article.config.googleRecaptchaSiteKey,
 				GAData: extractGA({
 					webTitle: article.webTitle,
 					format: article.format,

--- a/dotcom-rendering/src/server/render.front.web.tsx
+++ b/dotcom-rendering/src/server/render.front.web.tsx
@@ -131,6 +131,7 @@ export const renderFront = ({ front }: Props): string => {
 				switches: front.config.switches,
 				abTests: front.config.abTests,
 				brazeApiKey: front.config.brazeApiKey,
+				googleRecaptchaSiteKey: front.config.googleRecaptchaSiteKey,
 				// Until we understand exactly what config we need to make available client-side,
 				// add everything we haven't explicitly typed as unknown config
 				unknownConfig: front.config,
@@ -220,6 +221,7 @@ export const renderTagFront = ({
 				switches: tagFront.config.switches,
 				abTests: tagFront.config.abTests,
 				brazeApiKey: tagFront.config.brazeApiKey,
+				googleRecaptchaSiteKey: tagFront.config.googleRecaptchaSiteKey,
 				// Until we understand exactly what config we need to make available client-side,
 				// add everything we haven't explicitly typed as unknown config
 				unknownConfig: tagFront.config,

--- a/dotcom-rendering/src/types/config.ts
+++ b/dotcom-rendering/src/types/config.ts
@@ -81,4 +81,5 @@ export interface ConfigType extends CommercialConfigType {
 	isLiveBlog?: boolean;
 	isLive?: boolean;
 	isPreview?: boolean;
+	googleRecaptchaSiteKey?: string;
 }


### PR DESCRIPTION
## What does this change?

Adds `googleRecaptchaSiteKey` to the `ConfigType` interface. Include it in calls to `makeWindowGuardian`

## Why?
Bug (my fault) introduced https://github.com/guardian/dotcom-rendering/pull/7955 - previously this value was being included fro articles under 'unknown config' but adding to to the model for newsletters pages meant it was being excluded.