### PR TITLE
ESLint: Prefer `node:` protocol

### DIFF
--- a/dotcom-rendering/.eslintrc.js
+++ b/dotcom-rendering/.eslintrc.js
@@ -89,6 +89,7 @@ module.exports = {
 		'jsx-a11y',
 		'jsx-expressions',
 		'custom-elements',
+		'unicorn',
 	],
 	rules: {
 		// React, Hooks & JSX
@@ -166,6 +167,8 @@ module.exports = {
 				allowAny: true,
 			},
 		],
+
+		'unicorn/prefer-node-protocol': 'error',
 
 		...rulesToReview,
 		...rulesToEnforce,

--- a/dotcom-rendering/cdk/lib/dotcom-rendering.ts
+++ b/dotcom-rendering/cdk/lib/dotcom-rendering.ts
@@ -1,4 +1,4 @@
-import { join } from 'path';
+import { join } from 'node:path';
 import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
 import { GuStack } from '@guardian/cdk/lib/constructs/core';
 import { GuSecurityGroup, GuVpc } from '@guardian/cdk/lib/constructs/ec2';

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -186,6 +186,7 @@
 		"eslint-plugin-mocha": "10.1.0",
 		"eslint-plugin-react": "7.32.2",
 		"eslint-plugin-react-hooks": "4.6.0",
+		"eslint-plugin-unicorn": "48.0.1",
 		"eslint-stats": "1.0.1",
 		"execa": "5.1.1",
 		"express": "4.18.2",

--- a/dotcom-rendering/scripts/env/check-deps.js
+++ b/dotcom-rendering/scripts/env/check-deps.js
@@ -1,4 +1,4 @@
-const fs = require('fs');
+const fs = require('node:fs');
 const lockfile = require('@yarnpkg/lockfile');
 const pkg = require('../../package.json');
 const { warn, log } = require('./log');

--- a/dotcom-rendering/scripts/env/check-node.js
+++ b/dotcom-rendering/scripts/env/check-node.js
@@ -1,6 +1,6 @@
-const { promisify } = require('util');
-const { join } = require('path');
-const readFile = promisify(require('fs').readFile);
+const { join } = require('node:path');
+const { promisify } = require('node:util');
+const readFile = promisify(require('node:fs').readFile);
 
 const ensure = require('./ensure');
 

--- a/dotcom-rendering/scripts/env/check-yarn.js
+++ b/dotcom-rendering/scripts/env/check-yarn.js
@@ -1,5 +1,5 @@
-const { promisify } = require('util');
-const exec = promisify(require('child_process').execFile);
+const { promisify } = require('node:util');
+const exec = promisify(require('node:child_process').execFile);
 
 const ensure = require('./ensure');
 

--- a/dotcom-rendering/scripts/env/ensure.js
+++ b/dotcom-rendering/scripts/env/ensure.js
@@ -10,7 +10,7 @@ module.exports = (...packages) =>
 			resolve(packages.map(require));
 		} catch (e) {
 			log(`Pre-installing dependency (${packages.join(', ')})...`);
-			const npmInstallProcess = require('child_process')
+			const npmInstallProcess = require('node:child_process')
 				.spawn('npm', [
 					'i',
 					...packages,

--- a/dotcom-rendering/scripts/gen-stories/get-stories.js
+++ b/dotcom-rendering/scripts/gen-stories/get-stories.js
@@ -12,8 +12,8 @@ It should be run whenever any of the Display, Design, or Theme `format` properti
 
 */
 
-const { writeFileSync, readFileSync, mkdirSync } = require('fs');
-const path = require('path');
+const { writeFileSync, readFileSync, mkdirSync } = require('node:fs');
+const path = require('node:path');
 const { log, success, warn } = require('../env/log');
 
 const STORIES_PATH = path.resolve(

--- a/dotcom-rendering/scripts/jest/setup.ts
+++ b/dotcom-rendering/scripts/jest/setup.ts
@@ -1,6 +1,6 @@
 // add some helpful assertions
 import '@testing-library/jest-dom/extend-expect';
-import { TextDecoder, TextEncoder } from 'util';
+import { TextDecoder, TextEncoder } from 'node:util';
 import type { WindowGuardianConfig } from '../../src/model/window-guardian';
 
 const windowGuardianConfig = {

--- a/dotcom-rendering/scripts/json-schema/check-schema.js
+++ b/dotcom-rendering/scripts/json-schema/check-schema.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-console -- logs are useful in scripts */
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 const {
 	getArticleSchema,
 	getFrontSchema,

--- a/dotcom-rendering/scripts/json-schema/gen-schema.js
+++ b/dotcom-rendering/scripts/json-schema/gen-schema.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-console -- Logs are useful for scripts */
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 const {
 	getArticleSchema,
 	getFrontSchema,

--- a/dotcom-rendering/scripts/json-schema/get-schema.js
+++ b/dotcom-rendering/scripts/json-schema/get-schema.js
@@ -1,4 +1,4 @@
-const path = require('path');
+const path = require('node:path');
 const TJS = require('typescript-json-schema');
 
 const root = path.resolve(__dirname, '..', '..');

--- a/dotcom-rendering/scripts/test-data/gen-fixtures.js
+++ b/dotcom-rendering/scripts/test-data/gen-fixtures.js
@@ -2,8 +2,8 @@
 
 /* eslint-disable @typescript-eslint/no-floating-promises */
 
-const fs = require('fs/promises');
-const { resolve } = require('path');
+const fs = require('node:fs/promises');
+const { resolve } = require('node:path');
 const execa = require('execa');
 const fetch = require('node-fetch');
 const { config } = require('../../fixtures/config');

--- a/dotcom-rendering/scripts/webpack/plugins/gu-stats-report-plugin.js
+++ b/dotcom-rendering/scripts/webpack/plugins/gu-stats-report-plugin.js
@@ -1,7 +1,7 @@
 // @ts-check
 const fetch = require('node-fetch');
-const os = require('os');
-const { exec } = require('child_process');
+const { exec } = require('node:child_process');
+const os = require('node:os');
 const chalk = require('chalk');
 
 const PLUGIN_NAME = 'GuStatsReportPlugin';

--- a/dotcom-rendering/scripts/webpack/webpack.config.dev-server.js
+++ b/dotcom-rendering/scripts/webpack/webpack.config.dev-server.js
@@ -1,5 +1,5 @@
 // @ts-check
-const path = require('path');
+const path = require('node:path');
 const bodyParser = require('body-parser');
 const chalk = require('chalk');
 const webpackHotServerMiddleware = require('webpack-hot-server-middleware');

--- a/dotcom-rendering/scripts/webpack/webpack.config.js
+++ b/dotcom-rendering/scripts/webpack/webpack.config.js
@@ -1,6 +1,6 @@
 /* eslint-disable global-require -- we merge configs in the export */
 // @ts-check
-const path = require('path');
+const path = require('node:path');
 const { v4: uuidv4 } = require('uuid');
 const webpack = require('webpack');
 const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');

--- a/dotcom-rendering/src/lib/assets.ts
+++ b/dotcom-rendering/src/lib/assets.ts
@@ -1,5 +1,5 @@
-import { readFileSync } from 'fs';
-import { resolve } from 'path';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { isObject, isString } from '@guardian/libs';
 
 interface AssetHash {

--- a/dotcom-rendering/src/lib/braze/checkBrazeDependencies.test.ts
+++ b/dotcom-rendering/src/lib/braze/checkBrazeDependencies.test.ts
@@ -1,4 +1,4 @@
-import { setImmediate } from 'timers';
+import { setImmediate } from 'node:timers';
 import { checkBrazeDependencies } from './checkBrazeDependencies';
 
 let mockBrazeUuid: string | null;

--- a/dotcom-rendering/src/lib/get-video-id.amp.ts
+++ b/dotcom-rendering/src/lib/get-video-id.amp.ts
@@ -1,4 +1,4 @@
-import { parse, URLSearchParams } from 'url';
+import { parse, URLSearchParams } from 'node:url';
 import { isString } from '@guardian/libs';
 
 export const getIdFromUrl = (

--- a/dotcom-rendering/src/lib/messagePicker.test.tsx
+++ b/dotcom-rendering/src/lib/messagePicker.test.tsx
@@ -1,4 +1,4 @@
-import { setImmediate } from 'timers';
+import { setImmediate } from 'node:timers';
 import { record } from '../client/ophan/ophan';
 import type { CanShowResult, SlotConfig } from './messagePicker';
 import { pickMessage } from './messagePicker';

--- a/dotcom-rendering/src/model/decideBadge.ts
+++ b/dotcom-rendering/src/model/decideBadge.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'crypto';
+import { createHash } from 'node:crypto';
 import { ASSET_ORIGIN } from '../lib/assets';
 import type { DCRBadgeType } from '../types/badge';
 import type { Branding } from '../types/branding';

--- a/dotcom-rendering/src/server/lib/aws/metrics-baseline.ts
+++ b/dotcom-rendering/src/server/lib/aws/metrics-baseline.ts
@@ -1,4 +1,4 @@
-import os from 'os';
+import os from 'node:os';
 import { BytesMetric, collectAndSendAWSMetrics } from './aws-metrics';
 
 const stage =

--- a/dotcom-rendering/src/server/lib/logging-store.ts
+++ b/dotcom-rendering/src/server/lib/logging-store.ts
@@ -9,7 +9,7 @@
  * For simplicity we're using Node 16's AsyncLocalStorage to handle state instead of any 3rd party dependency like Redux or React Context.
  */
 
-import { AsyncLocalStorage } from 'async_hooks';
+import { AsyncLocalStorage } from 'node:async_hooks';
 
 type DCRLoggingStore = {
 	request: {

--- a/dotcom-rendering/src/server/lib/logging.ts
+++ b/dotcom-rendering/src/server/lib/logging.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 import type { LoggingEvent } from 'log4js';
 import { addLayout, configure, getLogger, shutdown } from 'log4js';
 import { loggingStore } from './logging-store';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3015,7 +3015,7 @@
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.18.17.tgz#bcb2e042631b3c15792058e189ed879a22b2968b"
   integrity sha512-fGEb8f2BSA3CW7riJVurug65ACLuQAzKq0SSqkY2b2yHHH0MzDfbLyKIGzHwOI/gkHcxM/leuSW6D5w/LMNitA==
 
-"@eslint-community/eslint-utils@^4.2.0":
+"@eslint-community/eslint-utils@^4.2.0", "@eslint-community/eslint-utils@^4.4.0":
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz#a23514e8fb9af1269d5f7788aa556798d61c6b59"
   integrity sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==
@@ -7752,6 +7752,11 @@ buffer@^5.5.0, buffer@^5.6.0:
     base64-js "^1.3.1"
     ieee754 "^1.1.13"
 
+builtin-modules@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-3.3.0.tgz#cae62812b89801e9656336e46223e030386be7b6"
+  integrity sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==
+
 bundle-name@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/bundle-name/-/bundle-name-3.0.0.tgz#ba59bcc9ac785fb67ccdbf104a2bf60c099f0e1a"
@@ -8003,7 +8008,7 @@ chrome-trace-event@^1.0.2:
   resolved "https://registry.yarnpkg.com/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz#1015eced4741e15d06664a957dbbf50d041e26ac"
   integrity sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==
 
-ci-info@^3.1.0, ci-info@^3.2.0:
+ci-info@^3.1.0, ci-info@^3.2.0, ci-info@^3.8.0:
   version "3.8.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.8.0.tgz#81408265a5380c929f0bc665d62256628ce9ef91"
   integrity sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw==
@@ -8026,6 +8031,13 @@ clean-css@^5.2.2:
   integrity sha512-JVJbM+f3d3Q704rF4bqQ5UUyTtuJ0JRKNbTKVEeujCCBoMdkEi+V+e8oktO9qGQNSvHrFTM6JZRXrUvGR1czww==
   dependencies:
     source-map "~0.6.0"
+
+clean-regexp@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/clean-regexp/-/clean-regexp-1.0.0.tgz#8df7c7aae51fd36874e8f8d05b9180bc11a3fed7"
+  integrity sha512-GfisEZEJvzKrmGWkvfhgzcz/BllN1USeqD2V6tg14OAOgaCD2Z/PUEuxnAZ/nPvmaHRG7a8y77p1T/IRQ4D1Hw==
+  dependencies:
+    escape-string-regexp "^1.0.5"
 
 clean-stack@^2.0.0:
   version "2.2.0"
@@ -9763,6 +9775,27 @@ eslint-plugin-react@7.32.2:
     semver "^6.3.0"
     string.prototype.matchall "^4.0.8"
 
+eslint-plugin-unicorn@48.0.1:
+  version "48.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-unicorn/-/eslint-plugin-unicorn-48.0.1.tgz#a6573bc1687ae8db7121fdd8f92394b6549a6959"
+  integrity sha512-FW+4r20myG/DqFcCSzoumaddKBicIPeFnTrifon2mWIzlfyvzwyqZjqVP7m4Cqr/ZYisS2aiLghkUWaPg6vtCw==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.22.5"
+    "@eslint-community/eslint-utils" "^4.4.0"
+    ci-info "^3.8.0"
+    clean-regexp "^1.0.0"
+    esquery "^1.5.0"
+    indent-string "^4.0.0"
+    is-builtin-module "^3.2.1"
+    jsesc "^3.0.2"
+    lodash "^4.17.21"
+    pluralize "^8.0.0"
+    read-pkg-up "^7.0.1"
+    regexp-tree "^0.1.27"
+    regjsparser "^0.10.0"
+    semver "^7.5.4"
+    strip-indent "^3.0.0"
+
 eslint-scope@5.1.1, eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
@@ -9863,7 +9896,7 @@ esprima@^4.0.0, esprima@^4.0.1, esprima@~4.0.0:
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
 
-esquery@^1.4.0:
+esquery@^1.4.0, esquery@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.5.0.tgz#6ce17738de8577694edd7361c57182ac8cb0db0b"
   integrity sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==
@@ -11669,6 +11702,13 @@ is-buffer@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.5.tgz#ebc252e400d22ff8d77fa09888821a24a658c191"
   integrity sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==
 
+is-builtin-module@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/is-builtin-module/-/is-builtin-module-3.2.1.tgz#f03271717d8654cfcaf07ab0463faa3571581169"
+  integrity sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==
+  dependencies:
+    builtin-modules "^3.3.0"
+
 is-callable@^1.1.3, is-callable@^1.1.4, is-callable@^1.2.7:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.7.tgz#3bc2a85ea742d9e36205dcacdd72ca1fdc51b055"
@@ -12680,6 +12720,11 @@ jsesc@^2.5.1:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
   integrity sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==
+
+jsesc@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-3.0.2.tgz#bb8b09a6597ba426425f2e4a07245c3d00b9343e"
+  integrity sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==
 
 jsesc@~0.5.0:
   version "0.5.0"
@@ -14819,6 +14864,11 @@ platform@1.3.3:
   resolved "https://registry.yarnpkg.com/platform/-/platform-1.3.3.tgz#646c77011899870b6a0903e75e997e8e51da7461"
   integrity sha512-VJK1SRmXBpjwsB4YOHYSturx48rLKMzHgCqDH2ZDa6ZbMS/N5huoNqyQdK5Fj/xayu3fqbXckn5SeCS1EbMDZg==
 
+pluralize@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-8.0.0.tgz#1a6fa16a38d12a1901e0320fa017051c539ce3b1"
+  integrity sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==
+
 pm2-axon-rpc@~0.7.0, pm2-axon-rpc@~0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/pm2-axon-rpc/-/pm2-axon-rpc-0.7.1.tgz#2daec5383a63135b3f18babb70266dacdcbc429a"
@@ -15659,6 +15709,11 @@ regenerator-transform@^0.15.1:
   dependencies:
     "@babel/runtime" "^7.8.4"
 
+regexp-tree@^0.1.27:
+  version "0.1.27"
+  resolved "https://registry.yarnpkg.com/regexp-tree/-/regexp-tree-0.1.27.tgz#2198f0ef54518ffa743fe74d983b56ffd631b6cd"
+  integrity sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==
+
 regexp.prototype.flags@^1.4.3:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz#87cab30f80f66660181a3bb7bf5981a872b367ac"
@@ -15693,6 +15748,13 @@ regexpu-core@^5.2.1, regexpu-core@^5.3.1:
     regjsparser "^0.9.1"
     unicode-match-property-ecmascript "^2.0.0"
     unicode-match-property-value-ecmascript "^2.1.0"
+
+regjsparser@^0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/regjsparser/-/regjsparser-0.10.0.tgz#b1ed26051736b436f22fdec1c8f72635f9f44892"
+  integrity sha512-qx+xQGZVsy55CH0a1hiVwHmqjLryfh7wQyF5HO07XJ9f7dQMY/gPQHhlyDkIzJKC+x2fUCpCcUODUUUFrm7SHA==
+  dependencies:
+    jsesc "~0.5.0"
 
 regjsparser@^0.9.1:
   version "0.9.1"
@@ -16175,7 +16237,7 @@ semver@^7.2, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7, semver@^7.3.8, semver@
   dependencies:
     lru-cache "^6.0.0"
 
-semver@^7.5.1:
+semver@^7.5.1, semver@^7.5.4:
   version "7.5.4"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e"
   integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Prefer [`node:` protocol](https://nodejs.org/docs/latest-v18.x/api/esm.html#node-imports) in imports.

## Why?

It makes it perfectly clear that the package is a built-in one. See [ESLint rule documentation](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-node-protocol.md).