### PR TITLE
ESLint: lint JS scripts

### DIFF
--- a/dotcom-rendering/.eslintrc.js
+++ b/dotcom-rendering/.eslintrc.js
@@ -181,6 +181,7 @@ module.exports = {
 		{
 			files: ['**/**.js'],
 			rules: {
+				'global-require': 'off',
 				'@typescript-eslint/no-var-requires': 'off',
 				'@typescript-eslint/no-unsafe-member-access': 'off',
 				'@typescript-eslint/no-misused-promises': 'off',

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -9,6 +9,7 @@
 		"lint": "yarn lint:src && yarn lint:cypress",
 		"lint:fix": "yarn lint:src --fix && yarn lint:cypress --fix",
 		"lint:src": "eslint . --ext .ts,.tsx --quiet",
+		"lint:scripts": "eslint scripts --quiet",
 		"lint:cypress": "eslint ./cypress",
 		"lint-staged": "lint-staged",
 		"prettier:check": "prettier . --check --cache",

--- a/dotcom-rendering/scripts/env/check-node.js
+++ b/dotcom-rendering/scripts/env/check-node.js
@@ -1,7 +1,7 @@
+// eslint-disable-next-line @typescript-eslint/unbound-method
 const { join } = require('node:path');
 const { promisify } = require('node:util');
 const readFile = promisify(require('node:fs').readFile);
-
 const ensure = require('./ensure');
 
 // eslint-disable-next-line @typescript-eslint/no-floating-promises
@@ -18,7 +18,7 @@ const ensure = require('./ensure');
 			const { warn, prompt, log } = require('./log');
 			warn(
 				`dotcom-rendering requires Node v${nvmrcVersion}`,
-				`You are using v${nodeVersion}`,
+				`You are using v${nodeVersion ?? '(unknown)'}`,
 			);
 			if (process.env.NVM_DIR) {
 				prompt('Run `nvm install` from the repo root and try again.');

--- a/dotcom-rendering/scripts/env/check-yarn.js
+++ b/dotcom-rendering/scripts/env/check-yarn.js
@@ -1,6 +1,5 @@
 const { promisify } = require('node:util');
 const exec = promisify(require('node:child_process').execFile);
-
 const ensure = require('./ensure');
 
 // Yarn v1.x support .yarnrc, so we can use a local (check-in) copy of yarn

--- a/dotcom-rendering/scripts/perf/perf-test.js
+++ b/dotcom-rendering/scripts/perf/perf-test.js
@@ -19,4 +19,4 @@ const run = async () => {
 	}
 };
 
-run();
+void run();

--- a/dotcom-rendering/scripts/test-data/gen-fixtures.js
+++ b/dotcom-rendering/scripts/test-data/gen-fixtures.js
@@ -1,7 +1,5 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 
-/* eslint-disable @typescript-eslint/no-floating-promises */
-
 const fs = require('node:fs/promises');
 const { resolve } = require('node:path');
 const execa = require('execa');
@@ -303,7 +301,7 @@ Promise.allSettled(requests)
 		if (successful.length > 0) {
 			console.log(
 				`\n✅ Successfully created ${successful.length} / ${requests.length} fixtures:\n`,
-				...successful.map(({ value }) => `${value}\n`),
+				...successful.map(({ value }) => `${String(value)}\n`),
 			);
 		}
 

--- a/dotcom-rendering/scripts/webpack/plugins/gu-stats-report-plugin.js
+++ b/dotcom-rendering/scripts/webpack/plugins/gu-stats-report-plugin.js
@@ -1,8 +1,8 @@
 // @ts-check
-const fetch = require('node-fetch');
 const { exec } = require('node:child_process');
 const os = require('node:os');
 const chalk = require('chalk');
+const fetch = require('node-fetch');
 
 const PLUGIN_NAME = 'GuStatsReportPlugin';
 
@@ -14,10 +14,10 @@ const PLUGIN_NAME = 'GuStatsReportPlugin';
 class GuStatsReportPlugin {
 	/** @param {Config} config */
 	constructor(config) {
-		this.buildName = config?.buildName;
-		this.project = config?.project;
-		this.team = config?.team;
-		this.sessionId = config?.sessionId;
+		this.buildName = config.buildName;
+		this.project = config.project;
+		this.team = config.team;
+		this.sessionId = config.sessionId;
 		this.buildCount = 0;
 		/** @type {Record<'log' | 'warn' | 'error', (...args: unknown[]) => void>} */
 		this.logger = console;
@@ -30,7 +30,7 @@ class GuStatsReportPlugin {
 		this.fetchGitBranch();
 		this.fetchGitHash();
 
-		if (config?.displayDisclaimer)
+		if (config.displayDisclaimer)
 			console.log(
 				chalk.yellow.dim(
 					'This project reports compilation and machine stats to improve the development experience.',
@@ -66,13 +66,13 @@ class GuStatsReportPlugin {
 			// Increment the buildCount
 			this.buildCount += 1;
 
-			if (!this.isValidConfig)
+			if (!this.isValidConfig())
 				return this.logger.error(
 					'Unable to report stats - invalid config',
 				);
 
 			const URL = 'https://logs.guardianapis.com/log';
-			// @ts-ignore -- the type declaration isn’t playing nice
+			// @ts-expect-error -- the type declaration isn’t playing nice
 			fetch(URL, {
 				method: 'POST',
 				body: JSON.stringify({
@@ -97,11 +97,11 @@ class GuStatsReportPlugin {
 						},
 						{
 							name: 'gitHash',
-							value: this.gitHash || 'unknown',
+							value: this.gitHash ?? 'unknown',
 						},
 						{
 							name: 'gitBranch',
-							value: this.gitBranch || 'unknown',
+							value: this.gitBranch ?? 'unknown',
 						},
 						{
 							name: 'sessionId',
@@ -154,10 +154,8 @@ class GuStatsReportPlugin {
 				);
 		};
 
-		if (compiler.hooks) {
-			const plugin = { name: PLUGIN_NAME };
-			compiler.hooks.done.tap(plugin, onDone);
-		}
+		const plugin = { name: PLUGIN_NAME };
+		compiler.hooks.done.tap(plugin, onDone);
 	}
 }
 

--- a/dotcom-rendering/scripts/webpack/webpack.config.js
+++ b/dotcom-rendering/scripts/webpack/webpack.config.js
@@ -88,16 +88,19 @@ const commonConfigs = ({ platform }) => ({
 						logger: (message) => {
 							// distinguish between initial and subsequent (re)builds in console output
 							if (builds < module.exports.length * 2) {
-								message = message
-									.replace('Building', 'Building initial')
-									.replace('Completed', 'Completed initial');
+								console.log(
+									message
+										.replace('Building', 'Building initial')
+										.replace(
+											'Completed',
+											'Completed initial',
+										),
+								);
 							} else {
-								message = message.replace(
-									'Building',
-									'Rebuilding',
+								console.log(
+									message.replace('Building', 'Rebuilding'),
 								);
 							}
-							console.log(message);
 							builds += 1;
 						},
 					}),


### PR DESCRIPTION

<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Apply ESLint rules to the `dotcom-rendering/scripts` folder.

## Why?

There’s no reason these should not be linted, as they are being formatted with Prettier