### PR TITLE
Remove mocks from `hasRequiredConsents` tests

### DIFF
--- a/dotcom-rendering/src/lib/braze/checkBrazeDependencies.ts
+++ b/dotcom-rendering/src/lib/braze/checkBrazeDependencies.ts
@@ -1,3 +1,4 @@
+import { onConsent } from '@guardian/consent-management-platform';
 import { getBrazeUuid } from '../getBrazeUuid';
 import { hasRequiredConsents } from './hasRequiredConsents';
 
@@ -51,7 +52,7 @@ const buildDependencies = (
 		},
 		{
 			name: 'consent',
-			value: hasRequiredConsents(),
+			value: onConsent().then(hasRequiredConsents),
 		},
 		{
 			name: 'isNotPaidContent',

--- a/dotcom-rendering/src/lib/braze/hasRequiredConsents.test.ts
+++ b/dotcom-rendering/src/lib/braze/hasRequiredConsents.test.ts
@@ -1,94 +1,82 @@
+import type { ConsentState } from '@guardian/consent-management-platform/dist/types';
 import { hasRequiredConsents } from './hasRequiredConsents';
 
 const brazeVendorId = '5ed8c49c4b8ce4571c7ad801';
 
-let mockOnConsentChangeResult: any;
-jest.mock('@guardian/consent-management-platform', () => ({
-	onConsentChange: (callback: any) => {
-		callback(mockOnConsentChangeResult);
-	},
-	// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-	getConsentFor: jest.requireActual('@guardian/consent-management-platform')
-		.getConsentFor,
-}));
-
-afterEach(() => {
-	mockOnConsentChangeResult = undefined;
-});
-
 describe('hasRequiredConsents', () => {
 	describe('when the user is covered by tcfv2 and consent is given', () => {
-		it('returns a promise which resolves with true', async () => {
-			mockOnConsentChangeResult = {
+		it('returns a promise which resolves with true', () => {
+			const mockState = {
 				tcfv2: {
 					vendorConsents: {
 						[brazeVendorId]: true,
 					},
 				},
-			};
-			await expect(hasRequiredConsents()).resolves.toBe(true);
+			} as unknown as ConsentState;
+
+			expect(hasRequiredConsents(mockState)).toBe(true);
 		});
 	});
 
 	describe('when the user is covered by tcfv2 and consent is not given', () => {
-		it('returns a promise which resolves with false', async () => {
-			mockOnConsentChangeResult = {
+		it('returns a promise which resolves with false', () => {
+			const mockState = {
 				tcfv2: {
 					vendorConsents: {
 						[brazeVendorId]: false,
 					},
 				},
-			};
+			} as unknown as ConsentState;
 
-			await expect(hasRequiredConsents()).resolves.toBe(false);
+			expect(hasRequiredConsents(mockState)).toBe(false);
 		});
 	});
 
 	describe('when the user is covered by ccpa and consent is given', () => {
-		it('returns a promise which resolves with true', async () => {
-			mockOnConsentChangeResult = {
+		it('returns a promise which resolves with true', () => {
+			const mockState = {
 				ccpa: {
 					doNotSell: false,
 				},
-			};
+			} as unknown as ConsentState;
 
-			await expect(hasRequiredConsents()).resolves.toBe(true);
+			expect(hasRequiredConsents(mockState)).toBe(true);
 		});
 	});
 
 	describe('when the user is covered by ccpa and consent is not given', () => {
-		it('returns a promise which resolves with false', async () => {
-			mockOnConsentChangeResult = {
+		it('returns a promise which resolves with false', () => {
+			const mockState = {
 				ccpa: {
 					doNotSell: true,
 				},
-			};
+			} as unknown as ConsentState;
 
-			await expect(hasRequiredConsents()).resolves.toBe(false);
+			expect(hasRequiredConsents(mockState)).toBe(false);
 		});
 	});
 
 	describe('when the user is covered by aus and consent is given', () => {
-		it('returns a promise which resolves with true', async () => {
-			mockOnConsentChangeResult = {
+		it('returns a promise which resolves with true', () => {
+			const mockState = {
 				aus: {
 					personalisedAdvertising: true,
 				},
-			};
+			} as unknown as ConsentState;
 
-			await expect(hasRequiredConsents()).resolves.toBe(true);
+			expect(hasRequiredConsents(mockState)).toBe(true);
 		});
 	});
 
 	describe('when the user is covered by aus and consent is not given', () => {
-		it('returns a promise which resolves with false', async () => {
-			mockOnConsentChangeResult = {
+		it('returns a promise which resolves with false', () => {
+			const mockState = {
 				aus: {
 					personalisedAdvertising: false,
 				},
-			};
+			} as unknown as ConsentState;
 
-			await expect(hasRequiredConsents()).resolves.toBe(false);
+			expect(hasRequiredConsents(mockState)).toBe(false);
 		});
 	});
 });

--- a/dotcom-rendering/src/lib/braze/hasRequiredConsents.ts
+++ b/dotcom-rendering/src/lib/braze/hasRequiredConsents.ts
@@ -1,17 +1,7 @@
-import {
-	getConsentFor,
-	onConsentChange,
-} from '@guardian/consent-management-platform';
+import { getConsentFor } from '@guardian/consent-management-platform';
+import type { ConsentState } from '@guardian/consent-management-platform/dist/types';
 
-const hasRequiredConsents = (): Promise<boolean> =>
-	new Promise((resolve, reject) => {
-		onConsentChange((state) => {
-			try {
-				resolve(getConsentFor('braze', state));
-			} catch (e) {
-				reject(e);
-			}
-		});
-	});
+const hasRequiredConsents = (state: ConsentState): boolean =>
+	getConsentFor('braze', state);
 
 export { hasRequiredConsents };


### PR DESCRIPTION

<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Leverage the CMP’s `onConsent()` method to make `hasRequiredConsent` a pure function. This removes the need for mocks in the test.

## Why?

Mocks should be avoided whenever possible, as they make testing ambiguous.

Enables an easier path forward for #8482 