### PR TITLE
Refine `constructQuery`'s parameter type

### DIFF
--- a/dotcom-rendering/src/lib/querystring.test.ts
+++ b/dotcom-rendering/src/lib/querystring.test.ts
@@ -13,8 +13,9 @@ describe('constructQuery', () => {
 			url: '/sport/2017/sep/30/test-article',
 			su: ['0'],
 			pa: 'f',
+			a: undefined,
 		};
-		const expectedQuery = `sens=f&si=f&vl=333&cc=UK&s=sport&inskin=f&ct=article&url=%2Fsport%2F2017%2Fsep%2F30%2Ftest-article&su=0&pa=f`;
+		const expectedQuery = `sens=f&si=f&vl=333&cc=UK&s=sport&inskin=f&ct=article&url=%2Fsport%2F2017%2Fsep%2F30%2Ftest-article&su=0&pa=f&a=undefined`;
 		expect(constructQuery(testParams)).toBe(expectedQuery);
 	});
 });

--- a/dotcom-rendering/src/lib/querystring.ts
+++ b/dotcom-rendering/src/lib/querystring.ts
@@ -1,7 +1,16 @@
-const constructQuery = (query: { [key: string]: any }): string =>
+const constructQuery = (query: {
+	[key: string]:
+		| string
+		| string[]
+		| number
+		| number[]
+		| boolean
+		| boolean[]
+		| undefined;
+}): string =>
 	Object.keys(query)
 		.map((param: string) => {
-			const value = query[param];
+			const value = query[param] ?? 'undefined';
 			const queryValue = Array.isArray(value)
 				? value.map((v) => encodeURIComponent(v)).join(',')
 				: encodeURIComponent(value);


### PR DESCRIPTION
Replaces the `any` type with the specific types this function accepts.

If the value lookup from the input object is `undefined`, use string value `"undefined"` instead. This was silently already happening, as `encodeURIComponent(undefined) => undefined`.

