### PR TITLE
Enlarge clickable area for sublinks on fronts

### DIFF
--- a/dotcom-rendering/src/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/components/CardHeadline.tsx
@@ -155,6 +155,7 @@ const labTextStyles = (size: SmallHeadlineSize) => {
 };
 
 const sublinkStyles = css`
+	display: inline-block;
 	/* See: https://css-tricks.com/nested-links/ */
 	${getZIndex('card-nested-link')}
 	/* The following styles turn off those provided by Link */

--- a/dotcom-rendering/src/components/SupportingContent.tsx
+++ b/dotcom-rendering/src/components/SupportingContent.tsx
@@ -18,9 +18,9 @@ type Props = {
 const wrapperStyles = css`
 	position: relative;
 	display: flex;
-	margin-left: 5px;
-	margin-right: 5px;
-	margin-bottom: 5px;
+	padding-left: 5px;
+	padding-right: 5px;
+	padding-bottom: 5px;
 `;
 
 const directionStyles = (alignment: Alignment) => {


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Updates sublinks to expand their clickable area by making 2 changes:
- Replaces some margins with padding. Margins are outside of the box-model and so are not clickable, whereas padding is clickable
- Makes sublinks inline-blocks rather than defaulting to inline so we respect the padding

## Why?

## Screenshots

|| Before      | After      |
|-| ----------- | ---------- |
|Mobile (web)| ![mobile-before mov](https://github.com/guardian/dotcom-rendering/assets/26366706/fb5ac814-8656-4468-8571-1d60f1845acf) | ![mobile-after mov](https://github.com/guardian/dotcom-rendering/assets/26366706/97e20b9f-d951-4511-93f9-1c736ae02fb5) |
|Desktop| ![desktop-before mov](https://github.com/guardian/dotcom-rendering/assets/26366706/9b33df57-b57c-426d-948d-1ff9dfb29091) |  ![desktop-after mov](https://github.com/guardian/dotcom-rendering/assets/26366706/13152473-3eaf-497b-b18f-c0dc07b1d53a)|

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
