### PR TITLE
fix(cypress): wait on IPV4 loopback address

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -33,7 +33,7 @@ jobs:
         uses: cypress-io/github-action@v5
         with:
           working-directory: dotcom-rendering
-          wait-on: "http://localhost:9000"
+          wait-on: "http://127.0.0.1:9000"
           wait-on-timeout: 30
           browser: chrome
           spec: cypress/e2e/parallel-${{ matrix.group }}/*.js


### PR DESCRIPTION

<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Uses the loopback IPV4 address `127.0.0.1` instead of `localhost`.

## Why?

A [known issue in Node 18 which can be fixed by setting `127.0.0.1` instead of `localhost`](https://github.com/cypress-io/github-action#wait-on-with-nodejs-18).

Cypress test should no longer hang for five hours. cc @vlbee 