### PR TITLE
Use `Record` type in `abTestPayload`

### DIFF
--- a/dotcom-rendering/src/client/ophan/ophan.ts
+++ b/dotcom-rendering/src/client/ophan/ophan.ts
@@ -79,7 +79,7 @@ export const sendOphanComponentEvent = (
 };
 
 export const abTestPayload = (tests: ServerSideTests): OphanABPayload => {
-	const records: { [key: string]: OphanABEvent } = {};
+	const records: Record<`ab${string}`, OphanABEvent> = {};
 	Object.entries(tests).forEach(([testName, variantName]) => {
 		records[`ab${testName}`] = {
 			variantName,


### PR DESCRIPTION
Any time we have an object where the key is a subtype of `string`, I think it's a good opportunity to use a `Record` type. It's not possible to have the keys of a regular object type as anything other than `string | number | symbol`.
