### PR TITLE
Feat: update designs of topics in submeta links

### DIFF
--- a/dotcom-rendering/src/components/SubMeta.tsx
+++ b/dotcom-rendering/src/components/SubMeta.tsx
@@ -13,6 +13,7 @@ const labelStyles = (palette: Palette) => css`
 	${textSans.xxsmall()};
 	display: block;
 	color: ${palette.text.subMetaLabel};
+	margin-bottom: 8px;
 `;
 
 const badgeWrapper = css`
@@ -71,6 +72,7 @@ const listItemStyles = (palette: Palette) => css`
 	border-radius: 12px;
 	padding: 2px 9px;
 	margin-right: 7px;
+	margin-bottom: 8px;
 	a {
 		position: relative;
 		display: block;

--- a/dotcom-rendering/src/components/SubMeta.tsx
+++ b/dotcom-rendering/src/components/SubMeta.tsx
@@ -57,6 +57,27 @@ const listStyleNone = css`
 		height: 0;
 		width: 0;
 	}
+	display: flex;
+	flex-wrap: wrap;
+	gap: 1.5rem 0.25rem;
+	background-image: repeating-linear-gradient(
+			to bottom,
+			#fff 0px,
+			#fff 36px,
+			transparent 36px,
+			transparent 37px,
+			#fff 37px,
+			#fff 46px
+		),
+		repeating-linear-gradient(
+			to right,
+			#ccc 0px,
+			#ccc 3px,
+			transparent 3px,
+			transparent 5px
+		);
+	background-position: top;
+	background-repeat: no-repeat;
 `;
 
 const listWrapper = (palette: Palette) => css`
@@ -66,13 +87,10 @@ const listWrapper = (palette: Palette) => css`
 `;
 
 const listItemStyles = (palette: Palette) => css`
-	display: inline-block;
 	${textSans.xsmall()};
 	border: 1px solid ${palette.text.subMeta};
 	border-radius: 12px;
 	padding: 2px 9px;
-	margin-right: 7px;
-	margin-bottom: 8px;
 	a {
 		position: relative;
 		display: block;

--- a/dotcom-rendering/src/components/SubMeta.tsx
+++ b/dotcom-rendering/src/components/SubMeta.tsx
@@ -1,6 +1,12 @@
 import { css } from '@emotion/react';
 import { ArticleDesign } from '@guardian/libs';
-import { from, space, textSans, until } from '@guardian/source-foundations';
+import {
+	from,
+	neutral,
+	space,
+	textSans,
+	until,
+} from '@guardian/source-foundations';
 import { LinkButton } from '@guardian/source-react-components';
 import { decidePalette } from '../lib/decidePalette';
 import type { BaseLinkType } from '../model/extract-nav';
@@ -47,7 +53,7 @@ const setMetaWidth = (palette: Palette) => css`
 	}
 `;
 
-const listStyleNone = css`
+const listStyleNone = (palette: Palette) => css`
 	list-style: none;
 	/* https://developer.mozilla.org/en-US/docs/Web/CSS/list-style#accessibility_concerns */
 	/* Needs double escape char: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#es2018_revision_of_illegal_escape_sequences */
@@ -62,17 +68,17 @@ const listStyleNone = css`
 	gap: 1.5rem 0.25rem;
 	background-image: repeating-linear-gradient(
 			to bottom,
-			#fff 0px,
-			#fff 36px,
+			${palette.background.subMeta} 0px,
+			${palette.background.subMeta} 36px,
 			transparent 36px,
 			transparent 37px,
-			#fff 37px,
-			#fff 46px
+			${palette.background.subMeta} 37px,
+			${palette.background.subMeta} 46px
 		),
 		repeating-linear-gradient(
 			to right,
-			#ccc 0px,
-			#ccc 3px,
+			${neutral[86]} 0px,
+			${neutral[86]} 3px,
 			transparent 3px,
 			transparent 5px
 		);
@@ -170,7 +176,7 @@ export const SubMeta = ({
 						Explore more on these topics
 					</span>
 					<div css={listWrapper(palette)}>
-						<ul css={listStyleNone}>
+						<ul css={listStyleNone(palette)}>
 							{links.map((link) => (
 								<li
 									css={listItemStyles(palette)}

--- a/dotcom-rendering/src/components/SubMeta.tsx
+++ b/dotcom-rendering/src/components/SubMeta.tsx
@@ -127,7 +127,7 @@ export const SubMeta = ({
 		if (subMetaSectionLinks.length > 0) links.push(...subMetaSectionLinks);
 		if (subMetaKeywordLinks.length > 0) links.push(...subMetaKeywordLinks);
 		return {
-			links: links,
+			links,
 			hasLinks: links.length > 0,
 		};
 	};

--- a/dotcom-rendering/src/components/SubMeta.tsx
+++ b/dotcom-rendering/src/components/SubMeta.tsx
@@ -1,12 +1,6 @@
 import { css } from '@emotion/react';
-import { ArticleDesign, ArticleSpecial } from '@guardian/libs';
-import {
-	from,
-	headline,
-	space,
-	textSans,
-	until,
-} from '@guardian/source-foundations';
+import { ArticleDesign } from '@guardian/libs';
+import { from, space, textSans, until } from '@guardian/source-foundations';
 import { LinkButton } from '@guardian/source-react-components';
 import { decidePalette } from '../lib/decidePalette';
 import type { BaseLinkType } from '../model/extract-nav';
@@ -71,22 +65,18 @@ const listWrapper = (palette: Palette) => css`
 `;
 
 const listItemStyles = (palette: Palette) => css`
-	margin-right: 5px;
 	display: inline-block;
+	${textSans.xsmall()};
+	border: 1px solid ${palette.text.subMeta};
+	border-radius: 12px;
+	padding: 2px 9px;
+	margin-right: 7px;
 	a {
 		position: relative;
 		display: block;
-		padding-right: 5px;
 		text-decoration: none;
 	}
-	a::after {
-		content: '/';
-		position: absolute;
-		pointer-events: none;
-		top: 0;
-		right: -3px;
-		color: ${palette.text.subMetaLink};
-	}
+
 	a:hover {
 		text-decoration: underline;
 	}
@@ -98,28 +88,6 @@ const linkStyles = (palette: Palette) => css`
 		text-decoration: underline;
 	}
 	color: ${palette.text.subMeta};
-`;
-
-const sectionStyles = (format: ArticleFormat) => {
-	if (format.theme === ArticleSpecial.Labs) {
-		return css`
-			${textSans.medium()}
-			line-height: 19px;
-		`;
-	}
-	return css`
-		${headline.xxxsmall()};
-	`;
-};
-
-const keywordStyles = css`
-	${textSans.small()};
-`;
-
-const hideSlash = css`
-	a::after {
-		content: '';
-	}
 `;
 
 type Props = {
@@ -152,8 +120,16 @@ export const SubMeta = ({
 	badge,
 }: Props) => {
 	const palette = decidePalette(format);
-	const hasSectionLinks = subMetaSectionLinks.length > 0;
-	const hasKeywordLinks = subMetaKeywordLinks.length > 0;
+	const createLinks = () => {
+		const links: BaseLinkType[] = [];
+		if (subMetaSectionLinks.length > 0) links.push(...subMetaSectionLinks);
+		if (subMetaKeywordLinks.length > 0) links.push(...subMetaKeywordLinks);
+		return {
+			links: links,
+			hasLinks: links.length > 0,
+		};
+	};
+	const { links, hasLinks } = createLinks();
 	return (
 		<div
 			data-print-layout="hide"
@@ -168,56 +144,27 @@ export const SubMeta = ({
 					<Badge imageSrc={badge.imageSrc} href={badge.href} />
 				</div>
 			)}
-			{(hasSectionLinks || hasKeywordLinks) && (
+			{hasLinks && (
 				<>
-					<span css={labelStyles(palette)}>Topics</span>
+					<span css={labelStyles(palette)}>
+						Explore more on these topics
+					</span>
 					<div css={listWrapper(palette)}>
-						{hasSectionLinks && (
-							<ul css={listStyleNone}>
-								{subMetaSectionLinks.map((link, i) => (
-									<li
-										css={[
-											listItemStyles(palette),
-											sectionStyles(format),
-											i ===
-												subMetaSectionLinks.length -
-													1 && hideSlash,
-										]}
-										key={link.url}
+						<ul css={listStyleNone}>
+							{links.map((link) => (
+								<li
+									css={listItemStyles(palette)}
+									key={link.url}
+								>
+									<a
+										css={linkStyles(palette)}
+										href={link.url}
 									>
-										<a
-											css={linkStyles(palette)}
-											href={link.url}
-										>
-											{link.title}
-										</a>
-									</li>
-								))}
-							</ul>
-						)}
-						{hasKeywordLinks && (
-							<ul css={listStyleNone}>
-								{subMetaKeywordLinks.map((link, i) => (
-									<li
-										css={[
-											listItemStyles(palette),
-											keywordStyles,
-											i ===
-												subMetaKeywordLinks.length -
-													1 && hideSlash,
-										]}
-										key={link.url}
-									>
-										<a
-											css={linkStyles(palette)}
-											href={link.url}
-										>
-											{link.title}
-										</a>
-									</li>
-								))}
-							</ul>
-						)}
+										{link.title}
+									</a>
+								</li>
+							))}
+						</ul>
 					</div>
 				</>
 			)}

--- a/dotcom-rendering/src/lib/decidePalette.ts
+++ b/dotcom-rendering/src/lib/decidePalette.ts
@@ -2201,6 +2201,48 @@ const backgroundDiscussionPillarButton = (format: ArticleFormat) => {
 	}
 };
 
+const backgroundSubmeta = (format: ArticleFormat) => {
+	// specialreport blogs should have specialreport background
+	if (
+		(format.design === ArticleDesign.LiveBlog ||
+			format.design === ArticleDesign.DeadBlog) &&
+		format.theme !== ArticleSpecial.SpecialReport
+	)
+		return neutral[97];
+
+	// Order matters. We want comment special report pieces to have the opinion background
+	if (format.design === ArticleDesign.Letter) return opinion[800];
+
+	if (format.design === ArticleDesign.Comment) {
+		if (format.theme === ArticleSpecial.SpecialReportAlt)
+			return palette.specialReportAlt[800];
+
+		return opinion[800];
+	}
+	if (format.design === ArticleDesign.Editorial) return opinion[800];
+
+	if (format.design === ArticleDesign.Analysis) {
+		if (format.theme === ArticleSpecial.SpecialReportAlt)
+			return palette.specialReportAlt[800];
+		else return news[800];
+	}
+
+	if (format.theme === ArticleSpecial.SpecialReport)
+		return specialReport[800]; // Note, check theme rather than design here
+
+	if (format.theme === ArticleSpecial.SpecialReportAlt)
+		return palette.specialReportAlt[800];
+
+	if (
+		format.theme === ArticleSpecial.Labs &&
+		format.display !== ArticleDisplay.Immersive
+	)
+		return neutral[97];
+	if (format.design === ArticleDesign.Picture) return BLACK;
+
+	return neutral[100];
+};
+
 export const decidePalette = (
 	format: ArticleFormat,
 	containerPalette?: DCRContainerPalette,
@@ -2313,6 +2355,7 @@ export const decidePalette = (
 			pullQuote: backgroundPullQuote(format),
 			messageForm: backgroundMessageForm(format),
 			discussionPillarButton: backgroundDiscussionPillarButton(format),
+			subMeta: backgroundSubmeta(format),
 		},
 		fill: {
 			commentCount: fillCommentCount(format),

--- a/dotcom-rendering/src/types/palette.ts
+++ b/dotcom-rendering/src/types/palette.ts
@@ -102,6 +102,7 @@ export type Palette = {
 		lightboxDivider: Colour;
 		messageForm: Colour;
 		discussionPillarButton: Colour;
+		subMeta: Colour;
 	};
 	fill: {
 		commentCount: Colour;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Updates the designs of the tags / topics that live at the bottom of articles and fronts. On Articles, there is now no visual difference between section and keyword links now so these are combined together in the list, section first, then keywords.
## Why?
This is part of the wider body of work to create parity between DCR and Apps, ready for the DCAR migration.

## Article Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |
| ![before2][] | ![after2][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/20416599/2a38ce9d-45bc-43c7-b6cd-b9917f7ffc5f
[after]: https://github.com/guardian/dotcom-rendering/assets/20416599/720b00df-e1c2-4800-9c6a-08369d869245

[before2]: https://github.com/guardian/dotcom-rendering/assets/20416599/8355e884-d437-422a-abc5-c7db34640b2d
[after2]: https://github.com/guardian/dotcom-rendering/assets/20416599/b06c13d4-7d13-4e1a-b015-79d3720b8023

## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
