### PR TITLE
Report all errors to Sentry if in the Okta experiment

### DIFF
--- a/dotcom-rendering/src/client/sentryLoader/index.test.ts
+++ b/dotcom-rendering/src/client/sentryLoader/index.test.ts
@@ -10,6 +10,7 @@ describe('Enable Sentry when it passes loading conditions', () => {
 				isDev: false,
 				enableSentryReporting: false,
 				isInBrowserVariantTest: true,
+				isInOktaVariantTest: false,
 				randomCentile: 99,
 			}),
 		).toEqual(false);
@@ -20,6 +21,7 @@ describe('Enable Sentry when it passes loading conditions', () => {
 				isDev: true,
 				enableSentryReporting: true,
 				isInBrowserVariantTest: true,
+				isInOktaVariantTest: true,
 				randomCentile: 1,
 			}),
 		).toEqual(false);
@@ -30,6 +32,18 @@ describe('Enable Sentry when it passes loading conditions', () => {
 				isDev: false,
 				enableSentryReporting: true,
 				isInBrowserVariantTest: true,
+				isInOktaVariantTest: false,
+				randomCentile: 1,
+			}),
+		).toEqual(true);
+	});
+	it('does enable Sentry when the user is in the Okta variant test', () => {
+		expect(
+			isSentryEnabled({
+				isDev: false,
+				enableSentryReporting: true,
+				isInBrowserVariantTest: false,
+				isInOktaVariantTest: true,
 				randomCentile: 1,
 			}),
 		).toEqual(true);
@@ -40,6 +54,7 @@ describe('Enable Sentry when it passes loading conditions', () => {
 				isDev: false,
 				enableSentryReporting: true,
 				isInBrowserVariantTest: false,
+				isInOktaVariantTest: false,
 				randomCentile: 1,
 			}),
 		).toEqual(false);
@@ -48,6 +63,7 @@ describe('Enable Sentry when it passes loading conditions', () => {
 				isDev: false,
 				enableSentryReporting: true,
 				isInBrowserVariantTest: false,
+				isInOktaVariantTest: false,
 				randomCentile: 99,
 			}),
 		).toEqual(false);
@@ -56,6 +72,7 @@ describe('Enable Sentry when it passes loading conditions', () => {
 				isDev: false,
 				enableSentryReporting: true,
 				isInBrowserVariantTest: false,
+				isInOktaVariantTest: false,
 				randomCentile: 100,
 			}),
 		).toEqual(true);

--- a/dotcom-rendering/src/client/sentryLoader/index.ts
+++ b/dotcom-rendering/src/client/sentryLoader/index.ts
@@ -8,6 +8,7 @@ type IsSentryEnabled = {
 	enableSentryReporting: boolean;
 	isDev: boolean;
 	isInBrowserVariantTest: boolean;
+	isInOktaVariantTest: boolean;
 	randomCentile: number;
 };
 
@@ -15,6 +16,7 @@ const isSentryEnabled = ({
 	enableSentryReporting,
 	isDev,
 	isInBrowserVariantTest,
+	isInOktaVariantTest,
 	randomCentile,
 }: IsSentryEnabled): boolean => {
 	// We don't send errors on the dev server, or if the enableSentryReporting switch is off
@@ -25,6 +27,8 @@ const isSentryEnabled = ({
 	// the variant and control so they each represent 1% of the overall traffic.
 	// This will allow a like for like comparison in Sentry.
 	if (isInBrowserVariantTest) return true;
+	// We want to log all errors for users in the Okta variant test.
+	if (isInOktaVariantTest) return true;
 	// Sentry lets you configure sampleRate to reduce the volume of events sent
 	// but this filter only happens _after_ the library is loaded. The Guardian
 	// measures page views in the billions so we only want to log 1% of errors that
@@ -46,12 +50,17 @@ export const sentryLoader = (): Promise<void> => {
 	const enableSentryReporting = !!switches.enableSentryReporting;
 	const isInBrowserVariantTest =
 		BUILD_VARIANT && tests[dcrJavascriptBundle('Variant')] === 'variant';
+
+	const isInOktaVariantTest =
+		!!switches.okta && tests.oktaVariant === 'variant';
+
 	// Generate a number between 1 - 100
 	const randomCentile = Math.floor(Math.random() * 100) + 1;
 	const canLoadSentry = isSentryEnabled({
 		enableSentryReporting,
 		isDev,
 		isInBrowserVariantTest,
+		isInOktaVariantTest,
 		randomCentile,
 	});
 	canLoadSentry ? loadSentry() : stubSentry();


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

If the `okta` switch is on and you are enrolled in the `okta` experiment, log all errors to Sentry. This will help us understand any issues with the migration to Okta.

This PR should be reverted before the Okta experiment moves beyond a 1% test.