### PR TITLE
Align CP Scott avatar (to prevent cut off)

### DIFF
--- a/dotcom-rendering/src/components/CPScottHeader.tsx
+++ b/dotcom-rendering/src/components/CPScottHeader.tsx
@@ -16,6 +16,9 @@ const scottAvatarStyles = css`
 	overflow: hidden;
 	background-color: ${opinion[800]};
 	flex-shrink: 0;
+	display: inline-flex;
+	/* Align at end to prevent cut off (see https://github.com/guardian/dotcom-rendering/issues/8510) */
+	align-items: flex-end;
 	${until.mobileLandscape} {
 		margin-top: -30px;
 	}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
The CP Scott avatar looks like its been cut off. This is actually because its centred perfectly in the circle, which results in the circle background colour being shown beneath the icon. Unfortunately because the circle background is almost the same colour as the page background this isn't super obvious and it just looks cut off.

Aligning the avatar at the bottom of the circle prevents this.

Fixes https://github.com/guardian/dotcom-rendering/issues/8510

<img width="287" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/c89b3923-74f8-4351-9fe4-cc30725d965d">

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| <img width="389" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/063661cd-cc4b-4235-93a7-9bda6ef5b9b4"> | <img width="389" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/8fa932fb-656f-4d74-9ef6-50302fcf8904"> |

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
