### PR TITLE
Bump `@guardian/commercial` to version 10.15

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -66,7 +66,7 @@
 		"@guardian/bridget": "2.3.0",
 		"@guardian/browserslist-config": "5.0.0",
 		"@guardian/cdk": "50.10.6",
-		"@guardian/commercial": "10.14.0",
+		"@guardian/commercial": "10.15.0",
 		"@guardian/consent-management-platform": "13.6.1",
 		"@guardian/core-web-vitals": "5.1.0",
 		"@guardian/eslint-config": "4.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3120,16 +3120,16 @@
     read-pkg-up "7.0.1"
     yargs "^17.6.2"
 
-"@guardian/commercial@10.14.0":
-  version "10.14.0"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-10.14.0.tgz#98f8540d09b86f03606c8eaf70d8e7bdb7c7231b"
-  integrity sha512-9fZhNXw/WsEMG7xVCst8VjJ1xQ25Ony9BAZLQDPGv5tOjZSglDGNOqalFCuU4chiU8/cKPgXoBYa37LPWpFVpQ==
+"@guardian/commercial@10.15.0":
+  version "10.15.0"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-10.15.0.tgz#35357141e918e50f0f2c015f41c23c4987b70faa"
+  integrity sha512-EJn6P4f962oJG+o90ngHXaTlV/oPVwdv5dlaK0biwvOpm7YkHK1X3JTNxi0HYax38mpKlUGMoKiubboum5/DAQ==
   dependencies:
     "@changesets/cli" "^2.26.1"
     "@guardian/ab-core" "^5.0.0"
-    "@guardian/consent-management-platform" "^13.5.0"
+    "@guardian/consent-management-platform" "^13.6.1"
     "@guardian/core-web-vitals" "^5.0.0"
-    "@guardian/libs" "^15.0.0"
+    "@guardian/libs" "15.6.3"
     "@guardian/source-foundations" "^12.0.0"
     "@guardian/support-dotcom-components" "^1.0.7"
     "@octokit/core" "^4.0.5"
@@ -3143,15 +3143,10 @@
     web-vitals "^3.3.2"
     wolfy87-eventemitter "^5.2.9"
 
-"@guardian/consent-management-platform@13.6.1":
+"@guardian/consent-management-platform@13.6.1", "@guardian/consent-management-platform@^13.6.1":
   version "13.6.1"
   resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-13.6.1.tgz#528ed9193b1bd96e9f84964a5a1a080de43e29c1"
   integrity sha512-5KQ4dZrqIBKuJCSJ/TTWXZ4F0WXY9ecpMnfOfvNIU9tXF1LAeT+LNv7hfV8eC5qMJskj2yvZZUi7hlwWD+Nq/A==
-
-"@guardian/consent-management-platform@^13.5.0":
-  version "13.5.0"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-13.5.0.tgz#61a97c823f6b18f62a6517a3374f6e7bdfca121d"
-  integrity sha512-9iz04lyonWAbUeZ7B+fNp0KbgAervsWDO3A4CE/3e+d876AQj0I3TwU7W4jpWxI4tthcA6UVk7Y6faaS8l+lFw==
 
 "@guardian/core-web-vitals@5.1.0", "@guardian/core-web-vitals@^5.0.0":
   version "5.1.0"
@@ -3196,15 +3191,15 @@
   resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-15.6.1.tgz#ee6ad1fc33631c4c9c23892114c90c8d915ba41c"
   integrity sha512-uicGZF7HRzodAa2zhhD5Qm4NK0iBSLwRPOGG7j8H2Y5VUgoMHz4hPYTGUg8FfFi3QApuxfxqN5QjCh2dJrsIvw==
 
+"@guardian/libs@15.6.3":
+  version "15.6.3"
+  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-15.6.3.tgz#3c748640bfe706ef8ecbd44c101567bf2b769f4a"
+  integrity sha512-WRHnZGXMn7TD2p/gXWdK+u2ZnS+CAvQ1pdBEjT3x61Ab1YhxOYEIkF5gT+l2kACuJZ7a8pWwuO6CA89JcfZfrw==
+
 "@guardian/libs@^10.0.0":
   version "10.1.1"
   resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-10.1.1.tgz#7048c365a68dda068f707d46c78979f430221963"
   integrity sha512-OdWReBHRWhdbErVmS15hihVzlkdU8DkKrjDsUIN0P8QZiF4twuzcU3qsPwto2UfibAwPkWqKkNwH1k8b6xNclA==
-
-"@guardian/libs@^15.0.0":
-  version "15.1.0"
-  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-15.1.0.tgz#a919fd08cb298cba0b7363d128f0da38e598ec98"
-  integrity sha512-1USL3EuhwhyUANjWeVBZx2mRVCydE0QAzUIOV2ukojp92ZAWyt2RqxV8luTEPgUxbDAtma9MuO6lgTshTk5nYw==
 
 "@guardian/prettier@5.0.0":
   version "5.0.0"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Bump [`@guardian/commercial` to version 10.15.0](https://github.com/guardian/commercial/releases/tag/v10.15.0)

## Why?

This version will start recording performance events from 'dotcom' to our data warehouse