### PR TITLE
Add key to BylineLink <span> element

### DIFF
--- a/dotcom-rendering/src/components/BylineLink.tsx
+++ b/dotcom-rendering/src/components/BylineLink.tsx
@@ -114,7 +114,9 @@ export const BylineLink = ({ byline, tags, format }: Props) => {
 				format.design === ArticleDesign.Analysis && hasSingleContributor
 					? removeComma(bylineComponent)
 					: bylineComponent;
-			return displayString ? <span>{displayString}</span> : null;
+			return displayString ? (
+				<span key={bylineComponent}>{displayString}</span>
+			) : null;
 		}
 		return (
 			<ContributorLink


### PR DESCRIPTION
## What does this change?

Add key to `BylineLink`’s `<span>` element.

## Why?

this error is not caught by ESLint’s [react/jsx-key](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-key.md)