### PR TITLE
Adds `getOphan` and uses it to load Ophan

### DIFF
--- a/dotcom-rendering/src/client/index.scheduled.ts
+++ b/dotcom-rendering/src/client/index.scheduled.ts
@@ -42,8 +42,10 @@ boot('bootCmp', () =>
 		bootCmp(),
 	),
 );
-boot('ophan', () =>
-	import(/* webpackMode: "eager" */ './ophan').then(({ ophan }) => ophan()),
+boot('recordInitialPageEvents', () =>
+	import(/* webpackMode: "eager" */ './ophan/recordInitialPageEvents').then(
+		({ recordInitialPageEvents }) => recordInitialPageEvents(),
+	),
 );
 boot('ga', () =>
 	import(/* webpackMode: "eager" */ './ga').then(({ ga }) => ga()),

--- a/dotcom-rendering/src/client/index.ts
+++ b/dotcom-rendering/src/client/index.ts
@@ -5,13 +5,13 @@ import { bootCmp } from './bootCmp';
 import { dynamicImport } from './dynamicImport';
 import { ga } from './ga';
 import { islands } from './islands';
-import { ophan } from './ophan';
+import { recordInitialPageEvents } from './ophan/recordInitialPageEvents';
 import { performanceMonitoring } from './performanceMonitoring';
 import { sentryLoader } from './sentryLoader';
 import { startup } from './startup';
 
 startup('bootCmp', bootCmp);
-startup('ophan', ophan);
+startup('recordInitialPageEvents', recordInitialPageEvents);
 startup('ga', ga);
 startup('sentryLoader', sentryLoader);
 startup('dynamicImport', dynamicImport);

--- a/dotcom-rendering/src/client/ophan/ophan.ts
+++ b/dotcom-rendering/src/client/ophan/ophan.ts
@@ -13,6 +13,47 @@ export type OphanRecordFunction = (
 	callback?: () => void,
 ) => void;
 
+/**
+ * Loads Ophan (if it hasn't already been loaded) and returns a promise of Ophan's methods.
+ */
+export const getOphan = async (): Promise<
+	NonNullable<typeof window.guardian.ophan>
+> => {
+	// @ts-expect-error -- side effect only
+	await import(/* webpackMode: "eager" */ 'ophan-tracker-js');
+
+	const { ophan } = window.guardian;
+
+	if (!ophan) {
+		throw new Error('window.guardian.ophan is not available');
+	}
+
+	const record: OphanRecordFunction = (event, callback) => {
+		ophan.record(event, callback);
+		log('dotcom', '🧿 Ophan event recorded:', event);
+	};
+
+	const trackComponentAttention: typeof ophan.trackComponentAttention = (
+		name,
+		el,
+		visibilityThreshold,
+	) => {
+		ophan.trackComponentAttention(name, el, visibilityThreshold);
+		log('dotcom', '🧿 Ophan tracking component attention:', name, {
+			el,
+			visibilityThreshold,
+		});
+	};
+
+	// this is the future of `getOphan`'s API, but we need to move to a
+	// dynamic import of the Ophan library to get there, so just returning a
+	// meaningless promise for now, for future-proofing
+	return Promise.resolve({ ...ophan, record, trackComponentAttention });
+};
+
+/**
+ * @deprecated use `getOphan` instead
+ */
 export const getOphanRecordFunction = (): OphanRecordFunction => {
 	const record = window.guardian.ophan?.record;
 
@@ -25,6 +66,9 @@ export const getOphanRecordFunction = (): OphanRecordFunction => {
 	};
 };
 
+/**
+ * @deprecated use `getOphan` instead
+ */
 export const record: OphanRecordFunction = (event) => {
 	if (window.guardian.ophan?.record) {
 		window.guardian.ophan.record(event, () =>

--- a/dotcom-rendering/src/client/ophan/recordInitialPageEvents.ts
+++ b/dotcom-rendering/src/client/ophan/recordInitialPageEvents.ts
@@ -1,9 +1,8 @@
-import { abTestPayload, record, recordPerformance } from './ophan';
+import { abTestPayload, getOphan, recordPerformance } from './ophan';
 
-// side effect only
-import 'ophan-tracker-js';
+export const recordInitialPageEvents = async (): Promise<void> => {
+	const { record } = await getOphan();
 
-export const ophan = (): Promise<void> => {
 	record({ experiences: 'dotcom-rendering' });
 	record({ edition: window.guardian.config.page.edition });
 
@@ -15,6 +14,4 @@ export const ophan = (): Promise<void> => {
 		recordPerformance();
 		window.removeEventListener('load', load, false);
 	});
-
-	return Promise.resolve();
 };

--- a/dotcom-rendering/src/lib/useOphan.ts
+++ b/dotcom-rendering/src/lib/useOphan.ts
@@ -1,0 +1,14 @@
+import { useEffect, useState } from 'react';
+import { getOphan } from '../client/ophan/ophan';
+
+type Ophan = Awaited<ReturnType<typeof getOphan>>;
+
+export const useOphan = (): Ophan | undefined => {
+	const [ophan, setOphan] = useState<Ophan>();
+
+	useEffect(() => {
+		void getOphan().then(setOphan);
+	}, []);
+
+	return ophan;
+};


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

- adds a `getOphan` method that will load `ophan-tracker-js` if necessary and return Ophan's methods directly
- adds a `useOphan` hook that wraps `getOphan`

> [!note]
> Subsequent PRs will replace existing Ophan usage with these new APIs. This is just a PR to add them.

## Why?

- provides a single interface to using Ophan 
- provides a way for consumers to guarantee their measurements will be sent as soon as Ophan is available (if not already), rather than just failing if it's not ready yet
- will enable us to start measuring Ophan initialisation time

refs: #8520
