### PR TITLE
Use `getOphan` in DCR Ophan methods

### DIFF
--- a/dotcom-rendering/src/client/bootCmp.ts
+++ b/dotcom-rendering/src/client/bootCmp.ts
@@ -8,7 +8,7 @@ import type {
 import { getCookie, log } from '@guardian/libs';
 import { getLocaleCode } from '../lib/getCountryCode';
 import { injectPrivacySettingsLink } from '../lib/injectPrivacySettingsLink';
-import { submitComponentEvent } from './ophan/ophan';
+import { __OLD__submitComponentEvent } from './ophan/ophan';
 
 const submitConsentEventsToOphan = () =>
 	onConsent().then((consentState: ConsentState) => {
@@ -78,7 +78,7 @@ const submitConsentEventsToOphan = () =>
 			action,
 		} satisfies OphanComponentEvent;
 
-		submitComponentEvent(event);
+		__OLD__submitComponentEvent(event);
 	});
 
 const initialiseCmp = () =>

--- a/dotcom-rendering/src/client/bootCmp.ts
+++ b/dotcom-rendering/src/client/bootCmp.ts
@@ -8,7 +8,7 @@ import type {
 import { getCookie, log } from '@guardian/libs';
 import { getLocaleCode } from '../lib/getCountryCode';
 import { injectPrivacySettingsLink } from '../lib/injectPrivacySettingsLink';
-import { __OLD__submitComponentEvent } from './ophan/ophan';
+import { deprecatedSubmitComponentEvent } from './ophan/ophan';
 
 const submitConsentEventsToOphan = () =>
 	onConsent().then((consentState: ConsentState) => {
@@ -78,7 +78,7 @@ const submitConsentEventsToOphan = () =>
 			action,
 		} satisfies OphanComponentEvent;
 
-		__OLD__submitComponentEvent(event);
+		deprecatedSubmitComponentEvent(event);
 	});
 
 const initialiseCmp = () =>

--- a/dotcom-rendering/src/client/ophan/ophan.ts
+++ b/dotcom-rendering/src/client/ophan/ophan.ts
@@ -93,8 +93,8 @@ export const __OLD__submitComponentEvent = (
 export const submitComponentEvent = async (
 	componentEvent: OphanComponentEvent,
 ): Promise<void> => {
-	const { record } = await getOphan();
-	__OLD__submitComponentEvent(componentEvent, record);
+	const ophan = await getOphan();
+	__OLD__submitComponentEvent(componentEvent, ophan.record);
 };
 
 interface SdcTestMeta extends OphanABTestMeta {
@@ -141,8 +141,8 @@ export const sendOphanComponentEvent = async (
 	action: OphanAction,
 	testMeta: SdcTestMeta,
 ): Promise<void> => {
-	const { record } = await getOphan();
-	__OLD__sendOphanComponentEvent(action, testMeta, record);
+	const ophan = await getOphan();
+	__OLD__sendOphanComponentEvent(action, testMeta, ophan.record);
 };
 
 export const abTestPayload = (tests: ServerSideTests): OphanABPayload => {

--- a/dotcom-rendering/src/client/ophan/ophan.ts
+++ b/dotcom-rendering/src/client/ophan/ophan.ts
@@ -101,7 +101,10 @@ interface SdcTestMeta extends OphanABTestMeta {
 	labels?: string[];
 }
 
-export const sendOphanComponentEvent = (
+/**
+ * @deprecated use `sendOphanComponentEvent` instead
+ */
+export const __OLD__sendOphanComponentEvent = (
 	action: OphanAction,
 	testMeta: SdcTestMeta,
 	ophanRecord: OphanRecordFunction = record, // TODO - migrate uses and make this mandatory
@@ -131,6 +134,15 @@ export const sendOphanComponentEvent = (
 	};
 
 	__OLD__submitComponentEvent(componentEvent, ophanRecord);
+};
+
+// temporarily wrap __OLD__sendOphanComponentEvent while using `getOphan`
+export const sendOphanComponentEvent = async (
+	action: OphanAction,
+	testMeta: SdcTestMeta,
+): Promise<void> => {
+	const { record } = await getOphan();
+	__OLD__sendOphanComponentEvent(action, testMeta, record);
 };
 
 export const abTestPayload = (tests: ServerSideTests): OphanABPayload => {

--- a/dotcom-rendering/src/client/ophan/ophan.ts
+++ b/dotcom-rendering/src/client/ophan/ophan.ts
@@ -157,7 +157,7 @@ export const abTestPayload = (tests: ServerSideTests): OphanABPayload => {
 	return { abTestRegister: records };
 };
 
-export const recordPerformance = (): void => {
+export const recordPerformance = async (): Promise<void> => {
 	const { performance: performanceAPI } = window;
 	const supportsPerformanceProperties =
 		// eslint-disable-next-line @typescript-eslint/strict-boolean-expressions, @typescript-eslint/no-unnecessary-condition -- Safety on browsers
@@ -183,7 +183,8 @@ export const recordPerformance = (): void => {
 		redirectCount: performanceAPI.navigation.redirectCount,
 	};
 
-	record({
+	const ophan = await getOphan();
+	ophan.record({
 		performance,
 	});
 };

--- a/dotcom-rendering/src/client/ophan/ophan.ts
+++ b/dotcom-rendering/src/client/ophan/ophan.ts
@@ -79,11 +79,22 @@ export const record: OphanRecordFunction = (event) => {
 	}
 };
 
-export const submitComponentEvent = (
+/**
+ * @deprecated use `submitComponentEvent` instead
+ */
+export const __OLD__submitComponentEvent = (
 	componentEvent: OphanComponentEvent,
 	ophanRecord: OphanRecordFunction = record, // TODO - migrate uses and make this mandatory
 ): void => {
 	ophanRecord({ componentEvent });
+};
+
+// temporarily wrap __OLD__submitComponentEvent while using `getOphan`
+export const submitComponentEvent = async (
+	componentEvent: OphanComponentEvent,
+): Promise<void> => {
+	const { record } = await getOphan();
+	__OLD__submitComponentEvent(componentEvent, record);
 };
 
 interface SdcTestMeta extends OphanABTestMeta {
@@ -119,7 +130,7 @@ export const sendOphanComponentEvent = (
 		action,
 	};
 
-	submitComponentEvent(componentEvent, ophanRecord);
+	__OLD__submitComponentEvent(componentEvent, ophanRecord);
 };
 
 export const abTestPayload = (tests: ServerSideTests): OphanABPayload => {

--- a/dotcom-rendering/src/client/ophan/ophan.ts
+++ b/dotcom-rendering/src/client/ophan/ophan.ts
@@ -82,19 +82,19 @@ export const record: OphanRecordFunction = (event) => {
 /**
  * @deprecated use `submitComponentEvent` instead
  */
-export const __OLD__submitComponentEvent = (
+export const deprecatedSubmitComponentEvent = (
 	componentEvent: OphanComponentEvent,
 	ophanRecord: OphanRecordFunction = record, // TODO - migrate uses and make this mandatory
 ): void => {
 	ophanRecord({ componentEvent });
 };
 
-// temporarily wrap __OLD__submitComponentEvent while using `getOphan`
+// temporarily wrap deprecatedSubmitComponentEvent while using `getOphan`
 export const submitComponentEvent = async (
 	componentEvent: OphanComponentEvent,
 ): Promise<void> => {
 	const ophan = await getOphan();
-	__OLD__submitComponentEvent(componentEvent, ophan.record);
+	deprecatedSubmitComponentEvent(componentEvent, ophan.record);
 };
 
 interface SdcTestMeta extends OphanABTestMeta {
@@ -104,7 +104,7 @@ interface SdcTestMeta extends OphanABTestMeta {
 /**
  * @deprecated use `sendOphanComponentEvent` instead
  */
-export const __OLD__sendOphanComponentEvent = (
+export const deprecatedSendOphanComponentEvent = (
 	action: OphanAction,
 	testMeta: SdcTestMeta,
 	ophanRecord: OphanRecordFunction = record, // TODO - migrate uses and make this mandatory
@@ -133,16 +133,16 @@ export const __OLD__sendOphanComponentEvent = (
 		action,
 	};
 
-	__OLD__submitComponentEvent(componentEvent, ophanRecord);
+	deprecatedSubmitComponentEvent(componentEvent, ophanRecord);
 };
 
-// temporarily wrap __OLD__sendOphanComponentEvent while using `getOphan`
+// temporarily wrap deprecatedSendOphanComponentEvent while using `getOphan`
 export const sendOphanComponentEvent = async (
 	action: OphanAction,
 	testMeta: SdcTestMeta,
 ): Promise<void> => {
 	const ophan = await getOphan();
-	__OLD__sendOphanComponentEvent(action, testMeta, ophan.record);
+	deprecatedSendOphanComponentEvent(action, testMeta, ophan.record);
 };
 
 export const abTestPayload = (tests: ServerSideTests): OphanABPayload => {

--- a/dotcom-rendering/src/client/ophan/recordInitialPageEvents.ts
+++ b/dotcom-rendering/src/client/ophan/recordInitialPageEvents.ts
@@ -11,7 +11,7 @@ export const recordInitialPageEvents = async (): Promise<void> => {
 
 	// We wait for the load event so that we can be sure our assetPerformance is reported as expected.
 	window.addEventListener('load', function load() {
-		recordPerformance();
 		window.removeEventListener('load', load, false);
+		void recordPerformance();
 	});
 };

--- a/dotcom-rendering/src/components/Dropdown.tsx
+++ b/dotcom-rendering/src/components/Dropdown.tsx
@@ -15,7 +15,7 @@ import {
 	visuallyHidden,
 } from '@guardian/source-foundations';
 import { useEffect, useMemo, useState } from 'react';
-import { __OLD__submitComponentEvent } from '../client/ophan/ophan';
+import { deprecatedSubmitComponentEvent } from '../client/ophan/ophan';
 import { getZIndex } from '../lib/getZIndex';
 import { linkNotificationCount } from '../lib/linkNotificationCount';
 import type { Notification } from '../lib/notification';
@@ -306,7 +306,7 @@ const DropdownLink = ({ link, index }: DropdownLinkProps) => {
 				notification.logImpression?.();
 			}
 
-			__OLD__submitComponentEvent({
+			deprecatedSubmitComponentEvent({
 				component: ophanComponent,
 				action: 'VIEW',
 			});
@@ -321,7 +321,7 @@ const DropdownLink = ({ link, index }: DropdownLinkProps) => {
 
 	useOnce(() => {
 		if (ophanComponent) {
-			__OLD__submitComponentEvent({
+			deprecatedSubmitComponentEvent({
 				component: ophanComponent,
 				action: 'INSERT',
 			});
@@ -347,7 +347,7 @@ const DropdownLink = ({ link, index }: DropdownLinkProps) => {
 				data-link-name={link.dataLinkName}
 				onClick={() => {
 					if (ophanComponent) {
-						__OLD__submitComponentEvent({
+						deprecatedSubmitComponentEvent({
 							component: ophanComponent,
 							action: 'CLICK',
 						});

--- a/dotcom-rendering/src/components/Dropdown.tsx
+++ b/dotcom-rendering/src/components/Dropdown.tsx
@@ -15,7 +15,7 @@ import {
 	visuallyHidden,
 } from '@guardian/source-foundations';
 import { useEffect, useMemo, useState } from 'react';
-import { submitComponentEvent } from '../client/ophan/ophan';
+import { __OLD__submitComponentEvent } from '../client/ophan/ophan';
 import { getZIndex } from '../lib/getZIndex';
 import { linkNotificationCount } from '../lib/linkNotificationCount';
 import type { Notification } from '../lib/notification';
@@ -306,7 +306,7 @@ const DropdownLink = ({ link, index }: DropdownLinkProps) => {
 				notification.logImpression?.();
 			}
 
-			submitComponentEvent({
+			__OLD__submitComponentEvent({
 				component: ophanComponent,
 				action: 'VIEW',
 			});
@@ -321,7 +321,7 @@ const DropdownLink = ({ link, index }: DropdownLinkProps) => {
 
 	useOnce(() => {
 		if (ophanComponent) {
-			submitComponentEvent({
+			__OLD__submitComponentEvent({
 				component: ophanComponent,
 				action: 'INSERT',
 			});
@@ -347,7 +347,7 @@ const DropdownLink = ({ link, index }: DropdownLinkProps) => {
 				data-link-name={link.dataLinkName}
 				onClick={() => {
 					if (ophanComponent) {
-						submitComponentEvent({
+						__OLD__submitComponentEvent({
 							component: ophanComponent,
 							action: 'CLICK',
 						});

--- a/dotcom-rendering/src/components/EnhancePinnedPost.importable.tsx
+++ b/dotcom-rendering/src/components/EnhancePinnedPost.importable.tsx
@@ -1,6 +1,6 @@
 import { startPerformanceMeasure } from '@guardian/libs';
 import { useEffect, useRef, useState } from 'react';
-import { __OLD__submitComponentEvent } from '../client/ophan/ophan';
+import { deprecatedSubmitComponentEvent } from '../client/ophan/ophan';
 import { isServer } from '../lib/isServer';
 import { useIsInView } from '../lib/useIsInView';
 
@@ -59,7 +59,7 @@ function scrollOnCollapse() {
 const handleClickTracking = () => {
 	if (pinnedPostCheckBox instanceof HTMLInputElement) {
 		if (pinnedPostCheckBox.checked) {
-			__OLD__submitComponentEvent({
+			deprecatedSubmitComponentEvent({
 				component: {
 					componentType: 'LIVE_BLOG_PINNED_POST',
 					id: pinnedPost?.id,
@@ -68,7 +68,7 @@ const handleClickTracking = () => {
 				value: 'show-more',
 			});
 		} else {
-			__OLD__submitComponentEvent({
+			deprecatedSubmitComponentEvent({
 				component: {
 					componentType: 'LIVE_BLOG_PINNED_POST',
 					id: pinnedPost?.id,
@@ -147,7 +147,7 @@ export const EnhancePinnedPost = () => {
 			const timeTaken = pinnedPostTiming.current?.endPerformanceMeasure();
 			if (timeTaken !== undefined) {
 				const timeTakenInSeconds = timeTaken / 1000;
-				__OLD__submitComponentEvent({
+				deprecatedSubmitComponentEvent({
 					component: {
 						componentType: 'LIVE_BLOG_PINNED_POST',
 						id: pinnedPost.id,

--- a/dotcom-rendering/src/components/EnhancePinnedPost.importable.tsx
+++ b/dotcom-rendering/src/components/EnhancePinnedPost.importable.tsx
@@ -1,6 +1,6 @@
 import { startPerformanceMeasure } from '@guardian/libs';
 import { useEffect, useRef, useState } from 'react';
-import { submitComponentEvent } from '../client/ophan/ophan';
+import { __OLD__submitComponentEvent } from '../client/ophan/ophan';
 import { isServer } from '../lib/isServer';
 import { useIsInView } from '../lib/useIsInView';
 
@@ -59,7 +59,7 @@ function scrollOnCollapse() {
 const handleClickTracking = () => {
 	if (pinnedPostCheckBox instanceof HTMLInputElement) {
 		if (pinnedPostCheckBox.checked) {
-			submitComponentEvent({
+			__OLD__submitComponentEvent({
 				component: {
 					componentType: 'LIVE_BLOG_PINNED_POST',
 					id: pinnedPost?.id,
@@ -68,7 +68,7 @@ const handleClickTracking = () => {
 				value: 'show-more',
 			});
 		} else {
-			submitComponentEvent({
+			__OLD__submitComponentEvent({
 				component: {
 					componentType: 'LIVE_BLOG_PINNED_POST',
 					id: pinnedPost?.id,
@@ -147,7 +147,7 @@ export const EnhancePinnedPost = () => {
 			const timeTaken = pinnedPostTiming.current?.endPerformanceMeasure();
 			if (timeTaken !== undefined) {
 				const timeTakenInSeconds = timeTaken / 1000;
-				submitComponentEvent({
+				__OLD__submitComponentEvent({
 					component: {
 						componentType: 'LIVE_BLOG_PINNED_POST',
 						id: pinnedPost.id,

--- a/dotcom-rendering/src/components/GuideAtom/GuideAtom.tsx
+++ b/dotcom-rendering/src/components/GuideAtom/GuideAtom.tsx
@@ -1,4 +1,4 @@
-import { submitComponentEvent } from '../../client/ophan/ophan';
+import { __OLD__submitComponentEvent } from '../../client/ophan/ophan';
 import { Body } from '../ExpandableAtom/Body';
 import { Container } from '../ExpandableAtom/Container';
 import { Footer } from '../ExpandableAtom/Footer';
@@ -40,7 +40,7 @@ export const GuideAtom = ({
 			expandCallback={
 				expandCallback ??
 				(() =>
-					submitComponentEvent({
+					__OLD__submitComponentEvent({
 						component: {
 							componentType: 'GUIDE_ATOM',
 							id,
@@ -57,7 +57,7 @@ export const GuideAtom = ({
 				dislikeHandler={
 					dislikeHandler ??
 					(() =>
-						submitComponentEvent({
+						__OLD__submitComponentEvent({
 							component: {
 								componentType: 'GUIDE_ATOM',
 								id,
@@ -70,7 +70,7 @@ export const GuideAtom = ({
 				likeHandler={
 					likeHandler ??
 					(() =>
-						submitComponentEvent({
+						__OLD__submitComponentEvent({
 							component: {
 								componentType: 'GUIDE_ATOM',
 								id,

--- a/dotcom-rendering/src/components/GuideAtom/GuideAtom.tsx
+++ b/dotcom-rendering/src/components/GuideAtom/GuideAtom.tsx
@@ -1,4 +1,4 @@
-import { __OLD__submitComponentEvent } from '../../client/ophan/ophan';
+import { deprecatedSubmitComponentEvent } from '../../client/ophan/ophan';
 import { Body } from '../ExpandableAtom/Body';
 import { Container } from '../ExpandableAtom/Container';
 import { Footer } from '../ExpandableAtom/Footer';
@@ -40,7 +40,7 @@ export const GuideAtom = ({
 			expandCallback={
 				expandCallback ??
 				(() =>
-					__OLD__submitComponentEvent({
+					deprecatedSubmitComponentEvent({
 						component: {
 							componentType: 'GUIDE_ATOM',
 							id,
@@ -57,7 +57,7 @@ export const GuideAtom = ({
 				dislikeHandler={
 					dislikeHandler ??
 					(() =>
-						__OLD__submitComponentEvent({
+						deprecatedSubmitComponentEvent({
 							component: {
 								componentType: 'GUIDE_ATOM',
 								id,
@@ -70,7 +70,7 @@ export const GuideAtom = ({
 				likeHandler={
 					likeHandler ??
 					(() =>
-						__OLD__submitComponentEvent({
+						deprecatedSubmitComponentEvent({
 							component: {
 								componentType: 'GUIDE_ATOM',
 								id,

--- a/dotcom-rendering/src/components/LiveBlogEpic.importable.tsx
+++ b/dotcom-rendering/src/components/LiveBlogEpic.importable.tsx
@@ -6,7 +6,7 @@ import { getEpicViewLog } from '@guardian/support-dotcom-components';
 import type { EpicPayload } from '@guardian/support-dotcom-components/dist/dotcom/src/types';
 import React, { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
-import { submitComponentEvent } from '../client/ophan/ophan';
+import { __OLD__submitComponentEvent } from '../client/ophan/ophan';
 import { useArticleCounts } from '../lib/articleCount';
 import {
 	getLastOneOffContributionTimestamp,
@@ -207,7 +207,7 @@ const Fetch = ({
 	// Add submitComponentEvent function to props to enable Ophan tracking in the component
 	const props = {
 		...response.data.module.props,
-		submitComponentEvent,
+		submitComponentEvent: __OLD__submitComponentEvent,
 	};
 
 	// Take any returned module and render it

--- a/dotcom-rendering/src/components/LiveBlogEpic.importable.tsx
+++ b/dotcom-rendering/src/components/LiveBlogEpic.importable.tsx
@@ -6,7 +6,7 @@ import { getEpicViewLog } from '@guardian/support-dotcom-components';
 import type { EpicPayload } from '@guardian/support-dotcom-components/dist/dotcom/src/types';
 import React, { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
-import { __OLD__submitComponentEvent } from '../client/ophan/ophan';
+import { deprecatedSubmitComponentEvent } from '../client/ophan/ophan';
 import { useArticleCounts } from '../lib/articleCount';
 import {
 	getLastOneOffContributionTimestamp,
@@ -207,7 +207,7 @@ const Fetch = ({
 	// Add submitComponentEvent function to props to enable Ophan tracking in the component
 	const props = {
 		...response.data.module.props,
-		submitComponentEvent: __OLD__submitComponentEvent,
+		submitComponentEvent: deprecatedSubmitComponentEvent,
 	};
 
 	// Take any returned module and render it

--- a/dotcom-rendering/src/components/NewsletterCard.tsx
+++ b/dotcom-rendering/src/components/NewsletterCard.tsx
@@ -13,7 +13,7 @@ import {
 import { useCallback, useEffect, useState } from 'react';
 import {
 	getOphanRecordFunction,
-	submitComponentEvent,
+	__OLD__submitComponentEvent,
 } from '../client/ophan/ophan';
 import { useIsInView } from '../lib/useIsInView';
 import type { Newsletter } from '../types/content';
@@ -169,7 +169,7 @@ export const NewsletterCard = ({
 			timestamp: Date.now(),
 		};
 
-		submitComponentEvent(
+		__OLD__submitComponentEvent(
 			{
 				component: {
 					componentType: 'CARD',

--- a/dotcom-rendering/src/components/NewsletterCard.tsx
+++ b/dotcom-rendering/src/components/NewsletterCard.tsx
@@ -12,8 +12,8 @@ import {
 } from '@guardian/source-react-components';
 import { useCallback, useEffect, useState } from 'react';
 import {
-	getOphanRecordFunction,
 	__OLD__submitComponentEvent,
+	getOphanRecordFunction,
 } from '../client/ophan/ophan';
 import { useIsInView } from '../lib/useIsInView';
 import type { Newsletter } from '../types/content';

--- a/dotcom-rendering/src/components/NewsletterCard.tsx
+++ b/dotcom-rendering/src/components/NewsletterCard.tsx
@@ -12,7 +12,7 @@ import {
 } from '@guardian/source-react-components';
 import { useCallback, useEffect, useState } from 'react';
 import {
-	__OLD__submitComponentEvent,
+	deprecatedSubmitComponentEvent,
 	getOphanRecordFunction,
 } from '../client/ophan/ophan';
 import { useIsInView } from '../lib/useIsInView';
@@ -169,7 +169,7 @@ export const NewsletterCard = ({
 			timestamp: Date.now(),
 		};
 
-		__OLD__submitComponentEvent(
+		deprecatedSubmitComponentEvent(
 			{
 				component: {
 					componentType: 'CARD',

--- a/dotcom-rendering/src/components/ReaderRevenueLinks.importable.tsx
+++ b/dotcom-rendering/src/components/ReaderRevenueLinks.importable.tsx
@@ -20,9 +20,9 @@ import type {
 import { useEffect, useState } from 'react';
 import type { OphanRecordFunction } from '../client/ophan/ophan';
 import {
-	getOphanRecordFunction,
 	__OLD__sendOphanComponentEvent,
 	__OLD__submitComponentEvent,
+	getOphanRecordFunction,
 } from '../client/ophan/ophan';
 import { addTrackingCodesToUrl } from '../lib/acquisitions';
 import {

--- a/dotcom-rendering/src/components/ReaderRevenueLinks.importable.tsx
+++ b/dotcom-rendering/src/components/ReaderRevenueLinks.importable.tsx
@@ -22,7 +22,7 @@ import type { OphanRecordFunction } from '../client/ophan/ophan';
 import {
 	getOphanRecordFunction,
 	sendOphanComponentEvent,
-	submitComponentEvent,
+	__OLD__submitComponentEvent,
 } from '../client/ophan/ophan';
 import { addTrackingCodesToUrl } from '../lib/acquisitions';
 import {
@@ -245,7 +245,9 @@ const ReaderRevenueLinksRemote = ({
 				<SupportHeader
 					submitComponentEvent={(
 						componentEvent: OphanComponentEvent,
-					) => submitComponentEvent(componentEvent, ophanRecord)}
+					) =>
+						__OLD__submitComponentEvent(componentEvent, ophanRecord)
+					}
 					{...supportHeaderResponse.props}
 				/>
 			</div>

--- a/dotcom-rendering/src/components/ReaderRevenueLinks.importable.tsx
+++ b/dotcom-rendering/src/components/ReaderRevenueLinks.importable.tsx
@@ -21,7 +21,7 @@ import { useEffect, useState } from 'react';
 import type { OphanRecordFunction } from '../client/ophan/ophan';
 import {
 	getOphanRecordFunction,
-	sendOphanComponentEvent,
+	__OLD__sendOphanComponentEvent,
 	__OLD__submitComponentEvent,
 } from '../client/ophan/ophan';
 import { addTrackingCodesToUrl } from '../lib/acquisitions';
@@ -297,14 +297,14 @@ const ReaderRevenueLinksNative = ({
 
 	useEffect(() => {
 		if (!hideSupportMessaging && inHeader) {
-			sendOphanComponentEvent('INSERT', tracking, ophanRecord);
+			__OLD__sendOphanComponentEvent('INSERT', tracking, ophanRecord);
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 
 	useEffect(() => {
 		if (hasBeenSeen && inHeader) {
-			sendOphanComponentEvent('VIEW', tracking, ophanRecord);
+			__OLD__sendOphanComponentEvent('VIEW', tracking, ophanRecord);
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [hasBeenSeen]);

--- a/dotcom-rendering/src/components/ReaderRevenueLinks.importable.tsx
+++ b/dotcom-rendering/src/components/ReaderRevenueLinks.importable.tsx
@@ -20,8 +20,8 @@ import type {
 import { useEffect, useState } from 'react';
 import type { OphanRecordFunction } from '../client/ophan/ophan';
 import {
-	__OLD__sendOphanComponentEvent,
-	__OLD__submitComponentEvent,
+	deprecatedSendOphanComponentEvent,
+	deprecatedSubmitComponentEvent,
 	getOphanRecordFunction,
 } from '../client/ophan/ophan';
 import { addTrackingCodesToUrl } from '../lib/acquisitions';
@@ -246,7 +246,10 @@ const ReaderRevenueLinksRemote = ({
 					submitComponentEvent={(
 						componentEvent: OphanComponentEvent,
 					) =>
-						__OLD__submitComponentEvent(componentEvent, ophanRecord)
+						deprecatedSubmitComponentEvent(
+							componentEvent,
+							ophanRecord,
+						)
 					}
 					{...supportHeaderResponse.props}
 				/>
@@ -297,14 +300,14 @@ const ReaderRevenueLinksNative = ({
 
 	useEffect(() => {
 		if (!hideSupportMessaging && inHeader) {
-			__OLD__sendOphanComponentEvent('INSERT', tracking, ophanRecord);
+			deprecatedSendOphanComponentEvent('INSERT', tracking, ophanRecord);
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 
 	useEffect(() => {
 		if (hasBeenSeen && inHeader) {
-			__OLD__sendOphanComponentEvent('VIEW', tracking, ophanRecord);
+			deprecatedSendOphanComponentEvent('VIEW', tracking, ophanRecord);
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [hasBeenSeen]);

--- a/dotcom-rendering/src/components/SecureSignupIframe.importable.tsx
+++ b/dotcom-rendering/src/components/SecureSignupIframe.importable.tsx
@@ -17,7 +17,7 @@ import { useRef, useState } from 'react';
 import ReactGoogleRecaptcha from 'react-google-recaptcha';
 import {
 	getOphanRecordFunction,
-	submitComponentEvent,
+	__OLD__submitComponentEvent,
 } from '../client/ophan/ophan';
 import { isServer } from '../lib/isServer';
 
@@ -164,7 +164,7 @@ const sendTracking = (
 		timestamp: Date.now(),
 	});
 
-	submitComponentEvent(
+	__OLD__submitComponentEvent(
 		{
 			action,
 			value,

--- a/dotcom-rendering/src/components/SecureSignupIframe.importable.tsx
+++ b/dotcom-rendering/src/components/SecureSignupIframe.importable.tsx
@@ -16,7 +16,7 @@ import { useRef, useState } from 'react';
 // Use the default export instead.
 import ReactGoogleRecaptcha from 'react-google-recaptcha';
 import {
-	__OLD__submitComponentEvent,
+	deprecatedSubmitComponentEvent,
 	getOphanRecordFunction,
 } from '../client/ophan/ophan';
 import { isServer } from '../lib/isServer';
@@ -164,7 +164,7 @@ const sendTracking = (
 		timestamp: Date.now(),
 	});
 
-	__OLD__submitComponentEvent(
+	deprecatedSubmitComponentEvent(
 		{
 			action,
 			value,

--- a/dotcom-rendering/src/components/SecureSignupIframe.importable.tsx
+++ b/dotcom-rendering/src/components/SecureSignupIframe.importable.tsx
@@ -16,8 +16,8 @@ import { useRef, useState } from 'react';
 // Use the default export instead.
 import ReactGoogleRecaptcha from 'react-google-recaptcha';
 import {
-	getOphanRecordFunction,
 	__OLD__submitComponentEvent,
+	getOphanRecordFunction,
 } from '../client/ophan/ophan';
 import { isServer } from '../lib/isServer';
 

--- a/dotcom-rendering/src/components/SlotBodyEnd/BrazeEpic.tsx
+++ b/dotcom-rendering/src/components/SlotBodyEnd/BrazeEpic.tsx
@@ -5,7 +5,7 @@ import type {
 	BrazeMessagesInterface,
 } from '@guardian/braze-components/logic';
 import { useEffect, useRef, useState } from 'react';
-import { submitComponentEvent } from '../../client/ophan/ophan';
+import { __OLD__submitComponentEvent } from '../../client/ophan/ophan';
 import { getBrazeMetaFromUrlFragment } from '../../lib/braze/forceBrazeMessage';
 import { suppressForTaylorReport } from '../../lib/braze/taylorReport';
 import type { CanShowResult } from '../../lib/messagePicker';
@@ -111,7 +111,7 @@ const BrazeEpicWithSatisfiedDependencies = ({
 	const epicRef = useRef(null);
 
 	useOnce(() => {
-		submitComponentEvent({
+		__OLD__submitComponentEvent({
 			component: {
 				componentType: COMPONENT_TYPE,
 				id: meta.dataFromBraze.ophanComponentId,
@@ -125,7 +125,7 @@ const BrazeEpicWithSatisfiedDependencies = ({
 			meta.logImpressionWithBraze();
 
 			// Log VIEW event with Ophan
-			submitComponentEvent({
+			__OLD__submitComponentEvent({
 				component: {
 					componentType: COMPONENT_TYPE,
 					id: meta.dataFromBraze.ophanComponentId,
@@ -165,7 +165,7 @@ const BrazeEpicWithSatisfiedDependencies = ({
 					subscribeToNewsletter={subscribeToNewsletter}
 					countryCode={countryCode}
 					logButtonClickWithBraze={meta.logButtonClickWithBraze}
-					submitComponentEvent={submitComponentEvent}
+					submitComponentEvent={__OLD__submitComponentEvent}
 				/>
 			</div>
 		</div>

--- a/dotcom-rendering/src/components/SlotBodyEnd/BrazeEpic.tsx
+++ b/dotcom-rendering/src/components/SlotBodyEnd/BrazeEpic.tsx
@@ -5,7 +5,7 @@ import type {
 	BrazeMessagesInterface,
 } from '@guardian/braze-components/logic';
 import { useEffect, useRef, useState } from 'react';
-import { __OLD__submitComponentEvent } from '../../client/ophan/ophan';
+import { deprecatedSubmitComponentEvent } from '../../client/ophan/ophan';
 import { getBrazeMetaFromUrlFragment } from '../../lib/braze/forceBrazeMessage';
 import { suppressForTaylorReport } from '../../lib/braze/taylorReport';
 import type { CanShowResult } from '../../lib/messagePicker';
@@ -111,7 +111,7 @@ const BrazeEpicWithSatisfiedDependencies = ({
 	const epicRef = useRef(null);
 
 	useOnce(() => {
-		__OLD__submitComponentEvent({
+		deprecatedSubmitComponentEvent({
 			component: {
 				componentType: COMPONENT_TYPE,
 				id: meta.dataFromBraze.ophanComponentId,
@@ -125,7 +125,7 @@ const BrazeEpicWithSatisfiedDependencies = ({
 			meta.logImpressionWithBraze();
 
 			// Log VIEW event with Ophan
-			__OLD__submitComponentEvent({
+			deprecatedSubmitComponentEvent({
 				component: {
 					componentType: COMPONENT_TYPE,
 					id: meta.dataFromBraze.ophanComponentId,
@@ -165,7 +165,7 @@ const BrazeEpicWithSatisfiedDependencies = ({
 					subscribeToNewsletter={subscribeToNewsletter}
 					countryCode={countryCode}
 					logButtonClickWithBraze={meta.logButtonClickWithBraze}
-					submitComponentEvent={__OLD__submitComponentEvent}
+					submitComponentEvent={deprecatedSubmitComponentEvent}
 				/>
 			</div>
 		</div>

--- a/dotcom-rendering/src/components/SlotBodyEnd/ReaderRevenueEpic.tsx
+++ b/dotcom-rendering/src/components/SlotBodyEnd/ReaderRevenueEpic.tsx
@@ -10,7 +10,7 @@ import type {
 	WeeklyArticleHistory,
 } from '@guardian/support-dotcom-components/dist/dotcom/src/types';
 import { useEffect, useState } from 'react';
-import { __OLD__submitComponentEvent } from '../../client/ophan/ophan';
+import { deprecatedSubmitComponentEvent } from '../../client/ophan/ophan';
 import {
 	getLastOneOffContributionTimestamp,
 	hasCmpConsentForArticleCount,
@@ -199,7 +199,7 @@ export const ReaderRevenueEpic = ({
 				<Epic
 					{...module.props}
 					fetchEmail={fetchEmail}
-					submitComponentEvent={__OLD__submitComponentEvent}
+					submitComponentEvent={deprecatedSubmitComponentEvent}
 					openCmp={openCmp}
 					hasConsentForArticleCount={hasConsentForArticleCount}
 					stage={stage}

--- a/dotcom-rendering/src/components/SlotBodyEnd/ReaderRevenueEpic.tsx
+++ b/dotcom-rendering/src/components/SlotBodyEnd/ReaderRevenueEpic.tsx
@@ -10,7 +10,7 @@ import type {
 	WeeklyArticleHistory,
 } from '@guardian/support-dotcom-components/dist/dotcom/src/types';
 import { useEffect, useState } from 'react';
-import { submitComponentEvent } from '../../client/ophan/ophan';
+import { __OLD__submitComponentEvent } from '../../client/ophan/ophan';
 import {
 	getLastOneOffContributionTimestamp,
 	hasCmpConsentForArticleCount,
@@ -199,7 +199,7 @@ export const ReaderRevenueEpic = ({
 				<Epic
 					{...module.props}
 					fetchEmail={fetchEmail}
-					submitComponentEvent={submitComponentEvent}
+					submitComponentEvent={__OLD__submitComponentEvent}
 					openCmp={openCmp}
 					hasConsentForArticleCount={hasConsentForArticleCount}
 					stage={stage}

--- a/dotcom-rendering/src/components/StickyBottomBanner/BrazeBanner.tsx
+++ b/dotcom-rendering/src/components/StickyBottomBanner/BrazeBanner.tsx
@@ -5,7 +5,7 @@ import type {
 	BrazeMessagesInterface,
 } from '@guardian/braze-components/logic';
 import { useEffect, useState } from 'react';
-import { __OLD__submitComponentEvent } from '../../client/ophan/ophan';
+import { deprecatedSubmitComponentEvent } from '../../client/ophan/ophan';
 import { getBrazeMetaFromUrlFragment } from '../../lib/braze/forceBrazeMessage';
 import { suppressForTaylorReport } from '../../lib/braze/taylorReport';
 import { getZIndex } from '../../lib/getZIndex';
@@ -115,7 +115,7 @@ const BrazeBannerWithSatisfiedDependencies = ({
 		meta.logImpressionWithBraze();
 
 		// Log VIEW event with Ophan
-		__OLD__submitComponentEvent({
+		deprecatedSubmitComponentEvent({
 			component: {
 				componentType: 'RETENTION_ENGAGEMENT_BANNER',
 				id:
@@ -152,7 +152,7 @@ const BrazeBannerWithSatisfiedDependencies = ({
 		<div css={containerStyles}>
 			<BrazeComponent
 				logButtonClickWithBraze={meta.logButtonClickWithBraze}
-				submitComponentEvent={__OLD__submitComponentEvent}
+				submitComponentEvent={deprecatedSubmitComponentEvent}
 				componentName={componentName}
 				brazeMessageProps={meta.dataFromBraze}
 				subscribeToNewsletter={subscribeToNewsletter}

--- a/dotcom-rendering/src/components/StickyBottomBanner/BrazeBanner.tsx
+++ b/dotcom-rendering/src/components/StickyBottomBanner/BrazeBanner.tsx
@@ -5,7 +5,7 @@ import type {
 	BrazeMessagesInterface,
 } from '@guardian/braze-components/logic';
 import { useEffect, useState } from 'react';
-import { submitComponentEvent } from '../../client/ophan/ophan';
+import { __OLD__submitComponentEvent } from '../../client/ophan/ophan';
 import { getBrazeMetaFromUrlFragment } from '../../lib/braze/forceBrazeMessage';
 import { suppressForTaylorReport } from '../../lib/braze/taylorReport';
 import { getZIndex } from '../../lib/getZIndex';
@@ -115,7 +115,7 @@ const BrazeBannerWithSatisfiedDependencies = ({
 		meta.logImpressionWithBraze();
 
 		// Log VIEW event with Ophan
-		submitComponentEvent({
+		__OLD__submitComponentEvent({
 			component: {
 				componentType: 'RETENTION_ENGAGEMENT_BANNER',
 				id:
@@ -152,7 +152,7 @@ const BrazeBannerWithSatisfiedDependencies = ({
 		<div css={containerStyles}>
 			<BrazeComponent
 				logButtonClickWithBraze={meta.logButtonClickWithBraze}
-				submitComponentEvent={submitComponentEvent}
+				submitComponentEvent={__OLD__submitComponentEvent}
 				componentName={componentName}
 				brazeMessageProps={meta.dataFromBraze}
 				subscribeToNewsletter={subscribeToNewsletter}

--- a/dotcom-rendering/src/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/dotcom-rendering/src/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -11,7 +11,7 @@ import type {
 } from '@guardian/support-dotcom-components/dist/dotcom/src/types';
 import { useState } from 'react';
 import { trackNonClickInteraction } from '../../client/ga/ga';
-import { submitComponentEvent } from '../../client/ophan/ophan';
+import { __OLD__submitComponentEvent } from '../../client/ophan/ophan';
 import type { ArticleCounts } from '../../lib/articleCount';
 import {
 	getLastOneOffContributionDate,
@@ -363,7 +363,7 @@ const RemoteBanner = ({
 				{}
 				<Banner
 					{...module.props}
-					submitComponentEvent={submitComponentEvent}
+					submitComponentEvent={__OLD__submitComponentEvent}
 					fetchEmail={fetchEmail}
 				/>
 			</div>

--- a/dotcom-rendering/src/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/dotcom-rendering/src/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -11,7 +11,7 @@ import type {
 } from '@guardian/support-dotcom-components/dist/dotcom/src/types';
 import { useState } from 'react';
 import { trackNonClickInteraction } from '../../client/ga/ga';
-import { __OLD__submitComponentEvent } from '../../client/ophan/ophan';
+import { deprecatedSubmitComponentEvent } from '../../client/ophan/ophan';
 import type { ArticleCounts } from '../../lib/articleCount';
 import {
 	getLastOneOffContributionDate,
@@ -363,7 +363,7 @@ const RemoteBanner = ({
 				{}
 				<Banner
 					{...module.props}
-					submitComponentEvent={__OLD__submitComponentEvent}
+					submitComponentEvent={deprecatedSubmitComponentEvent}
 					fetchEmail={fetchEmail}
 				/>
 			</div>

--- a/dotcom-rendering/src/components/SupportTheG.importable.tsx
+++ b/dotcom-rendering/src/components/SupportTheG.importable.tsx
@@ -22,7 +22,7 @@ import type { OphanRecordFunction } from '../client/ophan/ophan';
 import {
 	getOphanRecordFunction,
 	sendOphanComponentEvent,
-	submitComponentEvent,
+	__OLD__submitComponentEvent,
 } from '../client/ophan/ophan';
 import { addTrackingCodesToUrl } from '../lib/acquisitions';
 import {
@@ -253,7 +253,9 @@ const ReaderRevenueLinksRemote = ({
 				<SupportHeader
 					submitComponentEvent={(
 						componentEvent: OphanComponentEvent,
-					) => submitComponentEvent(componentEvent, ophanRecord)}
+					) =>
+						__OLD__submitComponentEvent(componentEvent, ophanRecord)
+					}
 					{...supportHeaderResponse.props}
 				/>
 			</div>

--- a/dotcom-rendering/src/components/SupportTheG.importable.tsx
+++ b/dotcom-rendering/src/components/SupportTheG.importable.tsx
@@ -20,9 +20,9 @@ import type {
 import { useEffect, useState } from 'react';
 import type { OphanRecordFunction } from '../client/ophan/ophan';
 import {
-	getOphanRecordFunction,
 	__OLD__sendOphanComponentEvent,
 	__OLD__submitComponentEvent,
+	getOphanRecordFunction,
 } from '../client/ophan/ophan';
 import { addTrackingCodesToUrl } from '../lib/acquisitions';
 import {

--- a/dotcom-rendering/src/components/SupportTheG.importable.tsx
+++ b/dotcom-rendering/src/components/SupportTheG.importable.tsx
@@ -21,7 +21,7 @@ import { useEffect, useState } from 'react';
 import type { OphanRecordFunction } from '../client/ophan/ophan';
 import {
 	getOphanRecordFunction,
-	sendOphanComponentEvent,
+	__OLD__sendOphanComponentEvent,
 	__OLD__submitComponentEvent,
 } from '../client/ophan/ophan';
 import { addTrackingCodesToUrl } from '../lib/acquisitions';
@@ -307,14 +307,14 @@ const ReaderRevenueLinksNative = ({
 
 	useEffect(() => {
 		if (!hideSupportMessaging && inHeader) {
-			sendOphanComponentEvent('INSERT', tracking, ophanRecord);
+			__OLD__sendOphanComponentEvent('INSERT', tracking, ophanRecord);
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 
 	useEffect(() => {
 		if (hasBeenSeen && inHeader) {
-			sendOphanComponentEvent('VIEW', tracking, ophanRecord);
+			__OLD__sendOphanComponentEvent('VIEW', tracking, ophanRecord);
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [hasBeenSeen]);

--- a/dotcom-rendering/src/components/SupportTheG.importable.tsx
+++ b/dotcom-rendering/src/components/SupportTheG.importable.tsx
@@ -20,8 +20,8 @@ import type {
 import { useEffect, useState } from 'react';
 import type { OphanRecordFunction } from '../client/ophan/ophan';
 import {
-	__OLD__sendOphanComponentEvent,
-	__OLD__submitComponentEvent,
+	deprecatedSendOphanComponentEvent,
+	deprecatedSubmitComponentEvent,
 	getOphanRecordFunction,
 } from '../client/ophan/ophan';
 import { addTrackingCodesToUrl } from '../lib/acquisitions';
@@ -254,7 +254,10 @@ const ReaderRevenueLinksRemote = ({
 					submitComponentEvent={(
 						componentEvent: OphanComponentEvent,
 					) =>
-						__OLD__submitComponentEvent(componentEvent, ophanRecord)
+						deprecatedSubmitComponentEvent(
+							componentEvent,
+							ophanRecord,
+						)
 					}
 					{...supportHeaderResponse.props}
 				/>
@@ -307,14 +310,14 @@ const ReaderRevenueLinksNative = ({
 
 	useEffect(() => {
 		if (!hideSupportMessaging && inHeader) {
-			__OLD__sendOphanComponentEvent('INSERT', tracking, ophanRecord);
+			deprecatedSendOphanComponentEvent('INSERT', tracking, ophanRecord);
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 
 	useEffect(() => {
 		if (hasBeenSeen && inHeader) {
-			__OLD__sendOphanComponentEvent('VIEW', tracking, ophanRecord);
+			deprecatedSendOphanComponentEvent('VIEW', tracking, ophanRecord);
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [hasBeenSeen]);

--- a/dotcom-rendering/src/lib/newsletter-sign-up-requests.ts
+++ b/dotcom-rendering/src/lib/newsletter-sign-up-requests.ts
@@ -1,6 +1,6 @@
 import type { OphanAction } from '@guardian/libs';
 import {
-	__OLD__submitComponentEvent,
+	deprecatedSubmitComponentEvent,
 	getOphanRecordFunction,
 } from '../client/ophan/ophan';
 
@@ -142,7 +142,7 @@ export const reportTrackingEvent = (
 		timestamp: Date.now(),
 	};
 
-	__OLD__submitComponentEvent(
+	deprecatedSubmitComponentEvent(
 		{
 			component: {
 				componentType: 'NEWSLETTER_SUBSCRIPTION',

--- a/dotcom-rendering/src/lib/newsletter-sign-up-requests.ts
+++ b/dotcom-rendering/src/lib/newsletter-sign-up-requests.ts
@@ -1,7 +1,7 @@
 import type { OphanAction } from '@guardian/libs';
 import {
 	getOphanRecordFunction,
-	submitComponentEvent,
+	__OLD__submitComponentEvent,
 } from '../client/ophan/ophan';
 
 const isServer = typeof window === 'undefined';
@@ -142,7 +142,7 @@ export const reportTrackingEvent = (
 		timestamp: Date.now(),
 	};
 
-	submitComponentEvent(
+	__OLD__submitComponentEvent(
 		{
 			component: {
 				componentType: 'NEWSLETTER_SUBSCRIPTION',

--- a/dotcom-rendering/src/lib/newsletter-sign-up-requests.ts
+++ b/dotcom-rendering/src/lib/newsletter-sign-up-requests.ts
@@ -1,7 +1,7 @@
 import type { OphanAction } from '@guardian/libs';
 import {
-	getOphanRecordFunction,
 	__OLD__submitComponentEvent,
+	getOphanRecordFunction,
 } from '../client/ophan/ophan';
 
 const isServer = typeof window === 'undefined';


### PR DESCRIPTION
## What does this change?

- uses the new `getOphan` method in internal DCR ophan methods
- creates duplicates of the old, sync, methods and marks them ready for subsequent removal

## Why?

we need to do this, but this is an attempt to keep PRs small and focussed. more incoming that remove usage of these old methods.

refs #8520
