### PR TITLE
Enable lazy-loading for most card’s pictures

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.stories.tsx
+++ b/dotcom-rendering/src/components/Card/Card.stories.tsx
@@ -33,6 +33,7 @@ const basicCardProps: CardProps = {
 	showAge: true,
 	isExternalLink: false,
 	isPlayableMediaCard: true,
+	imageLoading: 'eager',
 };
 
 const aBasicLink = {

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -17,7 +17,7 @@ import type { MainMedia } from '../../types/mainMedia';
 import type { Palette } from '../../types/palette';
 import { Avatar } from '../Avatar';
 import { CardHeadline } from '../CardHeadline';
-import { CardPicture } from '../CardPicture';
+import { CardPicture, Loading } from '../CardPicture';
 import { Hide } from '../Hide';
 import { Island } from '../Island';
 import { LatestLinks } from '../LatestLinks.importable';
@@ -62,6 +62,7 @@ export type Props = {
 	imagePositionOnMobile?: ImagePositionType;
 	/** Size is ignored when position = 'top' because in that case the image flows based on width */
 	imageSize?: ImageSizeType;
+	imageLoading: Loading;
 	isCrossword?: boolean;
 	trailText?: string;
 	avatarUrl?: string;
@@ -254,6 +255,7 @@ export const Card = ({
 	imagePosition = 'top',
 	imagePositionOnMobile = 'left',
 	imageSize = 'small',
+	imageLoading,
 	trailText,
 	avatarUrl,
 	showClock,
@@ -466,6 +468,7 @@ export const Card = ({
 									master={media.imageUrl}
 									imageSize={imageSize}
 									alt={media.imageAltText}
+									loading={imageLoading}
 								/>
 								{showPlayIcon && (
 									<MediaDuration

--- a/dotcom-rendering/src/components/CardPicture.tsx
+++ b/dotcom-rendering/src/components/CardPicture.tsx
@@ -1,13 +1,16 @@
 import { css } from '@emotion/react';
 import { breakpoints } from '@guardian/source-foundations';
-import React from 'react';
+import React, { ImgHTMLAttributes } from 'react';
 import type { ImageSizeType } from './Card/components/ImageWrapper';
 import type { ImageWidthType } from './Picture';
 import { generateSources, getFallbackSource } from './Picture';
 
+export type Loading = NonNullable<ImgHTMLAttributes<unknown>['loading']>;
+
 type Props = {
 	imageSize: ImageSizeType;
 	master: string;
+	loading: Loading;
 	alt?: string;
 };
 
@@ -90,7 +93,7 @@ const aspectRatio = css`
 	}
 `;
 
-export const CardPicture = ({ master, alt, imageSize }: Props) => {
+export const CardPicture = ({ master, alt, imageSize, loading }: Props) => {
 	const sources = generateSources(master, decideImageWidths(imageSize));
 
 	const fallbackSource = getFallbackSource(sources);
@@ -114,7 +117,12 @@ export const CardPicture = ({ master, alt, imageSize }: Props) => {
 				);
 			})}
 
-			<img alt={alt} src={fallbackSource.lowResUrl} css={block} />
+			<img
+				alt={alt}
+				src={fallbackSource.lowResUrl}
+				css={block}
+				loading={loading}
+			/>
 		</picture>
 	);
 };

--- a/dotcom-rendering/src/components/Carousel.importable.tsx
+++ b/dotcom-rendering/src/components/Carousel.importable.tsx
@@ -23,6 +23,7 @@ import type { OnwardsSource } from '../types/onwards';
 import type { TrailType } from '../types/trails';
 import { Card } from './Card/Card';
 import { LI } from './Card/components/LI';
+import type { Loading } from './CardPicture';
 import { FetchCommentCounts } from './FetchCommentCounts.importable';
 import { Hide } from './Hide';
 import { LeftColumn } from './LeftColumn';
@@ -466,6 +467,7 @@ type CarouselCardProps = {
 	linkTo: string;
 	headlineText: string;
 	webPublicationDate: string;
+	imageLoading: Loading;
 	kickerText?: string;
 	imageUrl?: string;
 	dataLinkName?: string;
@@ -493,6 +495,7 @@ const CarouselCard = ({
 	verticalDividerColour,
 	onwardsSource,
 	containerType,
+	imageLoading,
 }: CarouselCardProps) => {
 	const isVideoContainer = containerType === 'fixed/video';
 	return (
@@ -526,6 +529,7 @@ const CarouselCard = ({
 				isPlayableMediaCard={isVideoContainer}
 				onwardsSource={onwardsSource}
 				containerType={containerType}
+				imageLoading={imageLoading}
 			/>
 		</LI>
 	);
@@ -1057,6 +1061,8 @@ export const Carousel = ({
 
 						const imageUrl = image && getSourceImageUrl(image);
 
+						const imageLoading = i > 3 ? 'lazy' : 'eager';
+
 						return (
 							<CarouselCard
 								key={`${trail.url}${i}`}
@@ -1080,6 +1086,7 @@ export const Carousel = ({
 								}
 								onwardsSource={onwardsSource}
 								containerType={containerType}
+								imageLoading={imageLoading}
 							/>
 						);
 					})}

--- a/dotcom-rendering/src/components/DecideContainer.tsx
+++ b/dotcom-rendering/src/components/DecideContainer.tsx
@@ -1,3 +1,4 @@
+import { ImgHTMLAttributes } from 'react';
 import type {
 	DCRContainerPalette,
 	DCRContainerType,
@@ -27,6 +28,7 @@ type Props = {
 	trails: DCRFrontCard[];
 	adIndex: number;
 	groupedTrails: DCRGroupedTrails;
+	imageLoading: NonNullable<ImgHTMLAttributes<unknown>['loading']>;
 	containerType: DCRContainerType;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
@@ -41,6 +43,7 @@ export const DecideContainer = ({
 	containerPalette,
 	showAge,
 	renderAds,
+	imageLoading,
 }: Props) => {
 	// If you add a new container type which contains an MPU, you must also add it to
 	switch (containerType) {
@@ -50,6 +53,7 @@ export const DecideContainer = ({
 					groupedTrails={groupedTrails}
 					containerPalette={containerPalette}
 					showAge={showAge}
+					imageLoading={imageLoading}
 				/>
 			);
 		case 'dynamic/slow':
@@ -58,6 +62,7 @@ export const DecideContainer = ({
 					groupedTrails={groupedTrails}
 					containerPalette={containerPalette}
 					showAge={showAge}
+					imageLoading={imageLoading}
 				/>
 			);
 		case 'dynamic/slow-mpu':
@@ -68,6 +73,7 @@ export const DecideContainer = ({
 					showAge={showAge}
 					adIndex={adIndex}
 					renderAds={renderAds}
+					imageLoading={imageLoading}
 				/>
 			);
 		case 'dynamic/package':
@@ -76,6 +82,7 @@ export const DecideContainer = ({
 					groupedTrails={groupedTrails}
 					containerPalette={containerPalette}
 					showAge={showAge}
+					imageLoading={imageLoading}
 				/>
 			);
 		case 'fixed/large/slow-XIV':
@@ -84,6 +91,7 @@ export const DecideContainer = ({
 					trails={trails}
 					containerPalette={containerPalette}
 					showAge={showAge}
+					imageLoading={imageLoading}
 				/>
 			);
 		case 'fixed/small/slow-IV':
@@ -92,6 +100,7 @@ export const DecideContainer = ({
 					trails={trails}
 					containerPalette={containerPalette}
 					showAge={showAge}
+					imageLoading={imageLoading}
 				/>
 			);
 		case 'fixed/small/slow-V-mpu':
@@ -102,6 +111,7 @@ export const DecideContainer = ({
 					showAge={showAge}
 					adIndex={adIndex}
 					renderAds={renderAds}
+					imageLoading={imageLoading}
 				/>
 			);
 		case 'fixed/small/slow-III':
@@ -110,6 +120,7 @@ export const DecideContainer = ({
 					trails={trails}
 					containerPalette={containerPalette}
 					showAge={showAge}
+					imageLoading={imageLoading}
 				/>
 			);
 		case 'fixed/small/slow-I':
@@ -118,6 +129,7 @@ export const DecideContainer = ({
 					trails={trails}
 					containerPalette={containerPalette}
 					showAge={showAge}
+					imageLoading={imageLoading}
 				/>
 			);
 		case 'fixed/small/slow-V-third':
@@ -126,6 +138,7 @@ export const DecideContainer = ({
 					trails={trails}
 					containerPalette={containerPalette}
 					showAge={showAge}
+					imageLoading={imageLoading}
 				/>
 			);
 		case 'fixed/small/slow-V-half':
@@ -134,6 +147,7 @@ export const DecideContainer = ({
 					trails={trails}
 					containerPalette={containerPalette}
 					showAge={showAge}
+					imageLoading={imageLoading}
 				/>
 			);
 		case 'fixed/medium/slow-VI':
@@ -142,6 +156,7 @@ export const DecideContainer = ({
 					trails={trails}
 					containerPalette={containerPalette}
 					showAge={showAge}
+					imageLoading={imageLoading}
 				/>
 			);
 		case 'fixed/medium/slow-VII':
@@ -150,6 +165,7 @@ export const DecideContainer = ({
 					trails={trails}
 					containerPalette={containerPalette}
 					showAge={showAge}
+					imageLoading={imageLoading}
 				/>
 			);
 		case 'fixed/medium/slow-XII-mpu':
@@ -160,6 +176,7 @@ export const DecideContainer = ({
 					showAge={showAge}
 					renderAds={renderAds}
 					adIndex={adIndex}
+					imageLoading={imageLoading}
 				/>
 			);
 		case 'fixed/medium/fast-XII':
@@ -168,6 +185,7 @@ export const DecideContainer = ({
 					trails={trails}
 					containerPalette={containerPalette}
 					showAge={showAge}
+					imageLoading={imageLoading}
 				/>
 			);
 		case 'fixed/medium/fast-XI':
@@ -176,6 +194,7 @@ export const DecideContainer = ({
 					trails={trails}
 					containerPalette={containerPalette}
 					showAge={showAge}
+					imageLoading={imageLoading}
 				/>
 			);
 		case 'fixed/small/fast-VIII':
@@ -184,6 +203,7 @@ export const DecideContainer = ({
 					trails={trails}
 					containerPalette={containerPalette}
 					showAge={showAge}
+					imageLoading={imageLoading}
 				/>
 			);
 		case 'nav/list':

--- a/dotcom-rendering/src/components/DecideContainerByTrails.stories.tsx
+++ b/dotcom-rendering/src/components/DecideContainerByTrails.stories.tsx
@@ -20,7 +20,11 @@ export default {
 export const OneCardFast = () => {
 	return (
 		<FrontSection title="Fast - One card">
-			<DecideContainerByTrails trails={trails.slice(0, 1)} speed="fast" />
+			<DecideContainerByTrails
+				trails={trails.slice(0, 1)}
+				speed="fast"
+				imageLoading="eager"
+			/>
 		</FrontSection>
 	);
 };
@@ -29,7 +33,11 @@ OneCardFast.storyName = 'Fast - One card';
 export const TwoCardFast = () => {
 	return (
 		<FrontSection title="Fast - Two cards">
-			<DecideContainerByTrails trails={trails.slice(0, 2)} speed="fast" />
+			<DecideContainerByTrails
+				trails={trails.slice(0, 2)}
+				speed="fast"
+				imageLoading="eager"
+			/>
 		</FrontSection>
 	);
 };
@@ -38,7 +46,11 @@ TwoCardFast.storyName = 'Fast - Two cards';
 export const ThreeCardFast = () => {
 	return (
 		<FrontSection title="Fast - Three cards">
-			<DecideContainerByTrails trails={trails.slice(0, 3)} speed="fast" />
+			<DecideContainerByTrails
+				trails={trails.slice(0, 3)}
+				speed="fast"
+				imageLoading="eager"
+			/>
 		</FrontSection>
 	);
 };
@@ -47,7 +59,11 @@ ThreeCardFast.storyName = 'Fast - Three cards';
 export const FourCardFast = () => {
 	return (
 		<FrontSection title="Fast - Four cards">
-			<DecideContainerByTrails trails={trails.slice(0, 4)} speed="fast" />
+			<DecideContainerByTrails
+				trails={trails.slice(0, 4)}
+				speed="fast"
+				imageLoading="eager"
+			/>
 		</FrontSection>
 	);
 };
@@ -56,7 +72,11 @@ FourCardFast.storyName = 'Fast - Four cards';
 export const FiveCardFast = () => {
 	return (
 		<FrontSection title="Fast - Five cards">
-			<DecideContainerByTrails trails={trails.slice(0, 5)} speed="fast" />
+			<DecideContainerByTrails
+				trails={trails.slice(0, 5)}
+				speed="fast"
+				imageLoading="eager"
+			/>
 		</FrontSection>
 	);
 };
@@ -65,7 +85,11 @@ FiveCardFast.storyName = 'Fast - Five cards';
 export const SixCardFast = () => {
 	return (
 		<FrontSection title="Fast - Six cards">
-			<DecideContainerByTrails trails={trails.slice(0, 6)} speed="fast" />
+			<DecideContainerByTrails
+				trails={trails.slice(0, 6)}
+				speed="fast"
+				imageLoading="eager"
+			/>
 		</FrontSection>
 	);
 };
@@ -74,7 +98,11 @@ SixCardFast.storyName = 'Fast - Six cards';
 export const SevenCardFast = () => {
 	return (
 		<FrontSection title="Fast - Seven cards">
-			<DecideContainerByTrails trails={trails.slice(0, 7)} speed="fast" />
+			<DecideContainerByTrails
+				trails={trails.slice(0, 7)}
+				speed="fast"
+				imageLoading="eager"
+			/>
 		</FrontSection>
 	);
 };
@@ -83,7 +111,11 @@ SevenCardFast.storyName = 'Fast - Seven cards';
 export const EightCardFast = () => {
 	return (
 		<FrontSection title="Fast - Eight cards">
-			<DecideContainerByTrails trails={trails.slice(0, 8)} speed="fast" />
+			<DecideContainerByTrails
+				trails={trails.slice(0, 8)}
+				speed="fast"
+				imageLoading="eager"
+			/>
 		</FrontSection>
 	);
 };
@@ -96,6 +128,7 @@ export const TwelveCardFast = () => {
 			<DecideContainerByTrails
 				trails={trails.slice(0, 12)}
 				speed="fast"
+				imageLoading="eager"
 			/>
 		</FrontSection>
 	);
@@ -105,7 +138,11 @@ TwelveCardFast.storyName = 'Fast - Twelve cards';
 export const OneCardSlow = () => {
 	return (
 		<FrontSection title="Slow - One card">
-			<DecideContainerByTrails trails={trails.slice(0, 1)} speed="slow" />
+			<DecideContainerByTrails
+				trails={trails.slice(0, 1)}
+				speed="slow"
+				imageLoading="eager"
+			/>
 		</FrontSection>
 	);
 };
@@ -114,7 +151,11 @@ OneCardSlow.storyName = 'Slow - One card';
 export const TwoCardSlow = () => {
 	return (
 		<FrontSection title="Slow - Two cards">
-			<DecideContainerByTrails trails={trails.slice(0, 2)} speed="slow" />
+			<DecideContainerByTrails
+				trails={trails.slice(0, 2)}
+				speed="slow"
+				imageLoading="eager"
+			/>
 		</FrontSection>
 	);
 };
@@ -123,7 +164,11 @@ TwoCardSlow.storyName = 'Slow - Two cards';
 export const ThreeCardSlow = () => {
 	return (
 		<FrontSection title="Slow - Three cards">
-			<DecideContainerByTrails trails={trails.slice(0, 3)} speed="slow" />
+			<DecideContainerByTrails
+				trails={trails.slice(0, 3)}
+				speed="slow"
+				imageLoading="eager"
+			/>
 		</FrontSection>
 	);
 };
@@ -132,7 +177,11 @@ ThreeCardSlow.storyName = 'Slow - Three cards';
 export const FourCardSlow = () => {
 	return (
 		<FrontSection title="Slow - Four cards">
-			<DecideContainerByTrails trails={trails.slice(0, 4)} speed="slow" />
+			<DecideContainerByTrails
+				trails={trails.slice(0, 4)}
+				speed="slow"
+				imageLoading="eager"
+			/>
 		</FrontSection>
 	);
 };
@@ -141,7 +190,11 @@ FourCardSlow.storyName = 'Slow - Four cards';
 export const FiveCardSlow = () => {
 	return (
 		<FrontSection title="Slow - Five cards">
-			<DecideContainerByTrails trails={trails.slice(0, 5)} speed="slow" />
+			<DecideContainerByTrails
+				trails={trails.slice(0, 5)}
+				speed="slow"
+				imageLoading="eager"
+			/>
 		</FrontSection>
 	);
 };
@@ -150,7 +203,11 @@ FiveCardSlow.storyName = 'Slow - Five cards';
 export const SixCardSlow = () => {
 	return (
 		<FrontSection title="Slow - Six cards">
-			<DecideContainerByTrails trails={trails.slice(0, 6)} speed="slow" />
+			<DecideContainerByTrails
+				trails={trails.slice(0, 6)}
+				speed="slow"
+				imageLoading="eager"
+			/>
 		</FrontSection>
 	);
 };
@@ -159,7 +216,11 @@ SixCardSlow.storyName = 'Slow - Six cards';
 export const SevenCardSlow = () => {
 	return (
 		<FrontSection title="Slow - Seven cards">
-			<DecideContainerByTrails trails={trails.slice(0, 7)} speed="slow" />
+			<DecideContainerByTrails
+				trails={trails.slice(0, 7)}
+				speed="slow"
+				imageLoading="eager"
+			/>
 		</FrontSection>
 	);
 };
@@ -168,7 +229,11 @@ SevenCardSlow.storyName = 'Slow - Seven cards';
 export const EightCardSlow = () => {
 	return (
 		<FrontSection title="Slow - Eight cards">
-			<DecideContainerByTrails trails={trails.slice(0, 8)} speed="slow" />
+			<DecideContainerByTrails
+				trails={trails.slice(0, 8)}
+				speed="slow"
+				imageLoading="eager"
+			/>
 		</FrontSection>
 	);
 };
@@ -181,6 +246,7 @@ export const TwelveCardSlow = () => {
 			<DecideContainerByTrails
 				trails={trails.slice(0, 12)}
 				speed="slow"
+				imageLoading="eager"
 			/>
 		</FrontSection>
 	);

--- a/dotcom-rendering/src/components/DecideContainerByTrails.tsx
+++ b/dotcom-rendering/src/components/DecideContainerByTrails.tsx
@@ -11,75 +11,151 @@ import { takeFirst } from '../lib/tuple';
 import type { DCRFrontCard } from '../types/front';
 import { LI } from './Card/components/LI';
 import { UL } from './Card/components/UL';
+import { Loading } from './CardPicture';
 
 type Props = {
 	trails: DCRFrontCard[];
 	speed: 'fast' | 'slow';
+	imageLoading: Loading;
 };
 
-export const OneCardFast = ({ trail }: { trail: DCRFrontCard }) => {
+export const OneCardFast = ({
+	trail,
+	imageLoading,
+}: {
+	trail: DCRFrontCard;
+	imageLoading: Loading;
+}) => {
 	return (
 		<UL direction="row">
 			<LI percentage="100%" padSides={true}>
-				<Card100Media50 trail={trail} showAge={true} />
+				<Card100Media50
+					trail={trail}
+					showAge={true}
+					imageLoading={imageLoading}
+				/>
 			</LI>
 		</UL>
 	);
 };
 
-export const OneCardSlow = ({ trail }: { trail: DCRFrontCard }) => {
+export const OneCardSlow = ({
+	trail,
+	imageLoading,
+}: {
+	trail: DCRFrontCard;
+	imageLoading: Loading;
+}) => {
 	return (
 		<UL direction="row">
 			<LI percentage="100%" padSides={true}>
-				<Card100Media75 trail={trail} showAge={true} />
+				<Card100Media75
+					trail={trail}
+					showAge={true}
+					imageLoading={imageLoading}
+				/>
 			</LI>
 		</UL>
 	);
 };
 
-export const TwoCard = ({ trails }: { trails: Tuple<DCRFrontCard, 2> }) => {
+export const TwoCard = ({
+	trails,
+	imageLoading,
+}: {
+	trails: Tuple<DCRFrontCard, 2>;
+	imageLoading: Loading;
+}) => {
 	return (
 		<UL direction="row">
 			<LI percentage="50%" padSides={true}>
-				<Card50Media50 trail={trails[0]} showAge={true} />
+				<Card50Media50
+					trail={trails[0]}
+					showAge={true}
+					imageLoading={imageLoading}
+				/>
 			</LI>
 			<LI percentage="50%" padSides={true} showDivider={true}>
-				<Card50Media50 trail={trails[1]} showAge={true} />
+				<Card50Media50
+					trail={trails[1]}
+					showAge={true}
+					imageLoading={imageLoading}
+				/>
 			</LI>
 		</UL>
 	);
 };
 
-export const ThreeCard = ({ trails }: { trails: Tuple<DCRFrontCard, 3> }) => {
+export const ThreeCard = ({
+	trails,
+	imageLoading,
+}: {
+	trails: Tuple<DCRFrontCard, 3>;
+	imageLoading: Loading;
+}) => {
 	return (
 		<UL direction="row">
 			<LI percentage="33.333%" padSides={true}>
-				<Card33Media33 trail={trails[0]} showAge={true} />
+				<Card33Media33
+					trail={trails[0]}
+					showAge={true}
+					imageLoading={imageLoading}
+				/>
 			</LI>
 			<LI percentage="33.333%" padSides={true} showDivider={true}>
-				<Card33Media33 trail={trails[1]} showAge={true} />
+				<Card33Media33
+					trail={trails[1]}
+					showAge={true}
+					imageLoading={imageLoading}
+				/>
 			</LI>
 			<LI percentage="33.333%" padSides={true} showDivider={true}>
-				<Card33Media33 trail={trails[2]} showAge={true} />
+				<Card33Media33
+					trail={trails[2]}
+					showAge={true}
+					imageLoading={imageLoading}
+				/>
 			</LI>
 		</UL>
 	);
 };
 
-export const FourCard = ({ trails }: { trails: Tuple<DCRFrontCard, 4> }) => {
+export const FourCard = ({
+	trails,
+	imageLoading,
+}: {
+	trails: Tuple<DCRFrontCard, 4>;
+	imageLoading: Loading;
+}) => {
 	return (
 		<UL direction="row">
 			<LI percentage="25%" padSides={true}>
-				<Card25Media25 trail={trails[0]} showAge={true} />
+				<Card25Media25
+					trail={trails[0]}
+					showAge={true}
+					imageLoading={imageLoading}
+				/>
 			</LI>
 			<LI percentage="25%" padSides={true} showDivider={true}>
-				<Card25Media25 trail={trails[1]} showAge={true} />
+				<Card25Media25
+					trail={trails[1]}
+					showAge={true}
+					imageLoading={imageLoading}
+				/>
 			</LI>
 			<LI percentage="25%" padSides={true} showDivider={true}>
-				<Card25Media25 trail={trails[2]} showAge={true} />
+				<Card25Media25
+					trail={trails[2]}
+					showAge={true}
+					imageLoading={imageLoading}
+				/>
 			</LI>
 			<LI percentage="25%" padSides={true} showDivider={true}>
-				<Card25Media25 trail={trails[3]} showAge={true} />
+				<Card25Media25
+					trail={trails[3]}
+					showAge={true}
+					imageLoading={imageLoading}
+				/>
 			</LI>
 		</UL>
 	);
@@ -87,16 +163,26 @@ export const FourCard = ({ trails }: { trails: Tuple<DCRFrontCard, 4> }) => {
 
 export const FiveCardFast = ({
 	trails,
+	imageLoading,
 }: {
 	trails: Tuple<DCRFrontCard, 5>;
+	imageLoading: Loading;
 }) => {
 	return (
 		<UL direction="row">
 			<LI percentage="33.333%" padSides={true}>
-				<Card33Media33 trail={trails[0]} showAge={true} />
+				<Card33Media33
+					trail={trails[0]}
+					showAge={true}
+					imageLoading={imageLoading}
+				/>
 			</LI>
 			<LI percentage="33.333%" padSides={true} showDivider={true}>
-				<Card33Media33 trail={trails[1]} showAge={true} />
+				<Card33Media33
+					trail={trails[1]}
+					showAge={true}
+					imageLoading={imageLoading}
+				/>
 			</LI>
 			<LI percentage="33.333%">
 				<UL direction="column" showDivider={true}>
@@ -117,49 +203,93 @@ export const FiveCardFast = ({
 
 export const FiveCardSlow = ({
 	trails,
+	imageLoading,
 }: {
 	trails: Tuple<DCRFrontCard, 5>;
+	imageLoading: Loading;
 }) => {
 	return (
 		<>
 			<UL direction="row" padBottom={true}>
 				<LI percentage="50%" padSides={true}>
-					<Card33Media33 trail={trails[0]} showAge={true} />
+					<Card33Media33
+						trail={trails[0]}
+						showAge={true}
+						imageLoading={imageLoading}
+					/>
 				</LI>
 				<LI percentage="50%" padSides={true} showDivider={true}>
-					<Card33Media33 trail={trails[1]} showAge={true} />
+					<Card33Media33
+						trail={trails[1]}
+						showAge={true}
+						imageLoading={imageLoading}
+					/>
 				</LI>
 			</UL>
 			<UL direction="row">
 				<LI percentage="33.333%" padSides={true}>
-					<Card33Media33 trail={trails[2]} showAge={true} />
+					<Card33Media33
+						trail={trails[2]}
+						showAge={true}
+						imageLoading={imageLoading}
+					/>
 				</LI>
 				<LI percentage="33.333%" padSides={true} showDivider={true}>
-					<Card33Media33 trail={trails[3]} showAge={true} />
+					<Card33Media33
+						trail={trails[3]}
+						showAge={true}
+						imageLoading={imageLoading}
+					/>
 				</LI>
 				<LI percentage="33.333%" padSides={true} showDivider={true}>
-					<Card33Media33 trail={trails[4]} showAge={true} />
+					<Card33Media33
+						trail={trails[4]}
+						showAge={true}
+						imageLoading={imageLoading}
+					/>
 				</LI>
 			</UL>
 		</>
 	);
 };
 
-export const SixCardFast = ({ trails }: { trails: Tuple<DCRFrontCard, 6> }) => {
+export const SixCardFast = ({
+	trails,
+	imageLoading,
+}: {
+	trails: Tuple<DCRFrontCard, 6>;
+	imageLoading: Loading;
+}) => {
 	return (
 		<>
 			<UL direction="row" padBottom={true}>
 				<LI percentage="25%" padSides={true}>
-					<Card25Media25 trail={trails[0]} showAge={true} />
+					<Card25Media25
+						trail={trails[0]}
+						showAge={true}
+						imageLoading={imageLoading}
+					/>
 				</LI>
 				<LI percentage="25%" padSides={true} showDivider={true}>
-					<Card25Media25 trail={trails[1]} showAge={true} />
+					<Card25Media25
+						trail={trails[1]}
+						showAge={true}
+						imageLoading={imageLoading}
+					/>
 				</LI>
 				<LI percentage="25%" padSides={true} showDivider={true}>
-					<Card25Media25 trail={trails[2]} showAge={true} />
+					<Card25Media25
+						trail={trails[2]}
+						showAge={true}
+						imageLoading={imageLoading}
+					/>
 				</LI>
 				<LI percentage="25%" padSides={true} showDivider={true}>
-					<Card25Media25 trail={trails[3]} showAge={true} />
+					<Card25Media25
+						trail={trails[3]}
+						showAge={true}
+						imageLoading={imageLoading}
+					/>
 				</LI>
 			</UL>
 			<UL direction="row">
@@ -174,29 +304,59 @@ export const SixCardFast = ({ trails }: { trails: Tuple<DCRFrontCard, 6> }) => {
 	);
 };
 
-export const SixCardSlow = ({ trails }: { trails: Tuple<DCRFrontCard, 6> }) => {
+export const SixCardSlow = ({
+	trails,
+	imageLoading,
+}: {
+	trails: Tuple<DCRFrontCard, 6>;
+	imageLoading: Loading;
+}) => {
 	return (
 		<>
 			<UL direction="row" padBottom={true}>
 				<LI percentage="33.333%" padSides={true}>
-					<Card33Media33 trail={trails[0]} showAge={true} />
+					<Card33Media33
+						trail={trails[0]}
+						showAge={true}
+						imageLoading={imageLoading}
+					/>
 				</LI>
 				<LI percentage="33.333%" padSides={true} showDivider={true}>
-					<Card33Media33 trail={trails[1]} showAge={true} />
+					<Card33Media33
+						trail={trails[1]}
+						showAge={true}
+						imageLoading={imageLoading}
+					/>
 				</LI>
 				<LI percentage="33.333%" padSides={true} showDivider={true}>
-					<Card33Media33 trail={trails[2]} showAge={true} />
+					<Card33Media33
+						trail={trails[2]}
+						showAge={true}
+						imageLoading={imageLoading}
+					/>
 				</LI>
 			</UL>
 			<UL direction="row">
 				<LI percentage="33.333%" padSides={true}>
-					<Card33Media33 trail={trails[3]} showAge={true} />
+					<Card33Media33
+						trail={trails[3]}
+						showAge={true}
+						imageLoading={imageLoading}
+					/>
 				</LI>
 				<LI percentage="33.333%" padSides={true} showDivider={true}>
-					<Card33Media33 trail={trails[4]} showAge={true} />
+					<Card33Media33
+						trail={trails[4]}
+						showAge={true}
+						imageLoading={imageLoading}
+					/>
 				</LI>
 				<LI percentage="33.333%" padSides={true} showDivider={true}>
-					<Card33Media33 trail={trails[5]} showAge={true} />
+					<Card33Media33
+						trail={trails[5]}
+						showAge={true}
+						imageLoading={imageLoading}
+					/>
 				</LI>
 			</UL>
 		</>
@@ -205,23 +365,41 @@ export const SixCardSlow = ({ trails }: { trails: Tuple<DCRFrontCard, 6> }) => {
 
 export const SevenCardFast = ({
 	trails,
+	imageLoading,
 }: {
 	trails: Tuple<DCRFrontCard, 7>;
+	imageLoading: Loading;
 }) => {
 	return (
 		<>
 			<UL direction="row" padBottom={true}>
 				<LI percentage="25%" padSides={true}>
-					<Card25Media25 trail={trails[0]} showAge={true} />
+					<Card25Media25
+						trail={trails[0]}
+						showAge={true}
+						imageLoading={imageLoading}
+					/>
 				</LI>
 				<LI percentage="25%" padSides={true} showDivider={true}>
-					<Card25Media25 trail={trails[1]} showAge={true} />
+					<Card25Media25
+						trail={trails[1]}
+						showAge={true}
+						imageLoading={imageLoading}
+					/>
 				</LI>
 				<LI percentage="25%" padSides={true} showDivider={true}>
-					<Card25Media25 trail={trails[2]} showAge={true} />
+					<Card25Media25
+						trail={trails[2]}
+						showAge={true}
+						imageLoading={imageLoading}
+					/>
 				</LI>
 				<LI percentage="25%" padSides={true} showDivider={true}>
-					<Card25Media25 trail={trails[3]} showAge={true} />
+					<Card25Media25
+						trail={trails[3]}
+						showAge={true}
+						imageLoading={imageLoading}
+					/>
 				</LI>
 			</UL>
 			<UL direction="row">
@@ -241,34 +419,64 @@ export const SevenCardFast = ({
 
 export const SevenCardSlow = ({
 	trails,
+	imageLoading,
 }: {
 	trails: Tuple<DCRFrontCard, 7>;
+	imageLoading: Loading;
 }) => {
 	return (
 		<>
 			<UL direction="row" padBottom={true}>
 				<LI percentage="33.333%" padSides={true}>
-					<Card33Media33 trail={trails[0]} showAge={true} />
+					<Card33Media33
+						trail={trails[0]}
+						showAge={true}
+						imageLoading={imageLoading}
+					/>
 				</LI>
 				<LI percentage="33.333%" padSides={true} showDivider={true}>
-					<Card33Media33 trail={trails[1]} showAge={true} />
+					<Card33Media33
+						trail={trails[1]}
+						showAge={true}
+						imageLoading={imageLoading}
+					/>
 				</LI>
 				<LI percentage="33.333%" padSides={true} showDivider={true}>
-					<Card33Media33 trail={trails[2]} showAge={true} />
+					<Card33Media33
+						trail={trails[2]}
+						showAge={true}
+						imageLoading={imageLoading}
+					/>
 				</LI>
 			</UL>
 			<UL direction="row">
 				<LI percentage="25%" padSides={true}>
-					<Card25Media25 trail={trails[3]} showAge={true} />
+					<Card25Media25
+						trail={trails[3]}
+						showAge={true}
+						imageLoading={imageLoading}
+					/>
 				</LI>
 				<LI percentage="25%" padSides={true} showDivider={true}>
-					<Card25Media25 trail={trails[4]} showAge={true} />
+					<Card25Media25
+						trail={trails[4]}
+						showAge={true}
+						imageLoading={imageLoading}
+					/>
 				</LI>
 				<LI percentage="25%" padSides={true} showDivider={true}>
-					<Card25Media25 trail={trails[5]} showAge={true} />
+					<Card25Media25
+						trail={trails[5]}
+						showAge={true}
+						imageLoading={imageLoading}
+					/>
 				</LI>
 				<LI percentage="25%" padSides={true} showDivider={true}>
-					<Card25Media25 trail={trails[6]} showAge={true} />
+					<Card25Media25
+						trail={trails[6]}
+						showAge={true}
+						imageLoading={imageLoading}
+					/>
 				</LI>
 			</UL>
 		</>
@@ -277,8 +485,10 @@ export const SevenCardSlow = ({
 
 export const EightOrMoreFast = ({
 	trails,
+	imageLoading,
 }: {
 	trails: [...Tuple<DCRFrontCard, 8>, ...DCRFrontCard[]];
+	imageLoading: Loading;
 }) => {
 	const afterEight = trails.slice(8);
 
@@ -286,16 +496,32 @@ export const EightOrMoreFast = ({
 		<>
 			<UL direction="row" padBottom={true}>
 				<LI percentage="25%" padSides={true}>
-					<Card25Media25 trail={trails[0]} showAge={true} />
+					<Card25Media25
+						trail={trails[0]}
+						showAge={true}
+						imageLoading={imageLoading}
+					/>
 				</LI>
 				<LI percentage="25%" padSides={true} showDivider={true}>
-					<Card25Media25 trail={trails[1]} showAge={true} />
+					<Card25Media25
+						trail={trails[1]}
+						showAge={true}
+						imageLoading={imageLoading}
+					/>
 				</LI>
 				<LI percentage="25%" padSides={true} showDivider={true}>
-					<Card25Media25 trail={trails[2]} showAge={true} />
+					<Card25Media25
+						trail={trails[2]}
+						showAge={true}
+						imageLoading={imageLoading}
+					/>
 				</LI>
 				<LI percentage="25%" padSides={true} showDivider={true}>
-					<Card25Media25 trail={trails[3]} showAge={true} />
+					<Card25Media25
+						trail={trails[3]}
+						showAge={true}
+						imageLoading={imageLoading}
+					/>
 				</LI>
 			</UL>
 			<UL direction="row" padBottom={afterEight.length > 0}>
@@ -334,8 +560,10 @@ export const EightOrMoreFast = ({
 
 export const EightOrMoreSlow = ({
 	trails,
+	imageLoading,
 }: {
 	trails: [...Tuple<DCRFrontCard, 8>, ...DCRFrontCard[]];
+	imageLoading: Loading;
 }) => {
 	const afterEight = trails.slice(8);
 
@@ -343,30 +571,62 @@ export const EightOrMoreSlow = ({
 		<>
 			<UL direction="row" padBottom={true}>
 				<LI percentage="25%" padSides={true}>
-					<Card25Media25 trail={trails[0]} showAge={true} />
+					<Card25Media25
+						trail={trails[0]}
+						showAge={true}
+						imageLoading={imageLoading}
+					/>
 				</LI>
 				<LI percentage="25%" padSides={true} showDivider={true}>
-					<Card25Media25 trail={trails[1]} showAge={true} />
+					<Card25Media25
+						trail={trails[1]}
+						showAge={true}
+						imageLoading={imageLoading}
+					/>
 				</LI>
 				<LI percentage="25%" padSides={true} showDivider={true}>
-					<Card25Media25 trail={trails[2]} showAge={true} />
+					<Card25Media25
+						trail={trails[2]}
+						showAge={true}
+						imageLoading={imageLoading}
+					/>
 				</LI>
 				<LI percentage="25%" padSides={true} showDivider={true}>
-					<Card25Media25 trail={trails[3]} showAge={true} />
+					<Card25Media25
+						trail={trails[3]}
+						showAge={true}
+						imageLoading={imageLoading}
+					/>
 				</LI>
 			</UL>
 			<UL direction="row" padBottom={afterEight.length > 0}>
 				<LI percentage="25%" padSides={true}>
-					<Card25Media25 trail={trails[4]} showAge={true} />
+					<Card25Media25
+						trail={trails[4]}
+						showAge={true}
+						imageLoading={imageLoading}
+					/>
 				</LI>
 				<LI percentage="25%" padSides={true} showDivider={true}>
-					<Card25Media25 trail={trails[5]} showAge={true} />
+					<Card25Media25
+						trail={trails[5]}
+						showAge={true}
+						imageLoading={imageLoading}
+					/>
 				</LI>
 				<LI percentage="25%" padSides={true} showDivider={true}>
-					<Card25Media25 trail={trails[6]} showAge={true} />
+					<Card25Media25
+						trail={trails[6]}
+						showAge={true}
+						imageLoading={imageLoading}
+					/>
 				</LI>
 				<LI percentage="25%" padSides={true} showDivider={true}>
-					<Card25Media25 trail={trails[7]} showAge={true} />
+					<Card25Media25
+						trail={trails[7]}
+						showAge={true}
+						imageLoading={imageLoading}
+					/>
 				</LI>
 			</UL>
 			{afterEight.length > 0 ? (
@@ -378,7 +638,11 @@ export const EightOrMoreSlow = ({
 							padSides={true}
 							showDivider={index % 4 !== 0}
 						>
-							<Card25Media25 trail={trail} showAge={true} />
+							<Card25Media25
+								trail={trail}
+								showAge={true}
+								imageLoading={imageLoading}
+							/>
 						</LI>
 					))}
 				</UL>
@@ -389,7 +653,11 @@ export const EightOrMoreSlow = ({
 	);
 };
 
-export const DecideContainerByTrails = ({ trails, speed }: Props) => {
+export const DecideContainerByTrails = ({
+	trails,
+	speed,
+	imageLoading,
+}: Props) => {
 	const initialTrails = takeFirst(trails, 8);
 
 	if (speed === 'fast') {
@@ -397,23 +665,59 @@ export const DecideContainerByTrails = ({ trails, speed }: Props) => {
 			case 0:
 				return <></>;
 			case 1:
-				return <OneCardFast trail={initialTrails[0]} />;
+				return (
+					<OneCardFast
+						trail={initialTrails[0]}
+						imageLoading={imageLoading}
+					/>
+				);
 			case 2:
-				return <TwoCard trails={initialTrails} />;
+				return (
+					<TwoCard
+						trails={initialTrails}
+						imageLoading={imageLoading}
+					/>
+				);
 			case 3:
-				return <ThreeCard trails={initialTrails} />;
+				return (
+					<ThreeCard
+						trails={initialTrails}
+						imageLoading={imageLoading}
+					/>
+				);
 			case 4:
-				return <FourCard trails={initialTrails} />;
+				return (
+					<FourCard
+						trails={initialTrails}
+						imageLoading={imageLoading}
+					/>
+				);
 			case 5:
-				return <FiveCardFast trails={initialTrails} />;
+				return (
+					<FiveCardFast
+						trails={initialTrails}
+						imageLoading={imageLoading}
+					/>
+				);
 			case 6:
-				return <SixCardFast trails={initialTrails} />;
+				return (
+					<SixCardFast
+						trails={initialTrails}
+						imageLoading={imageLoading}
+					/>
+				);
 			case 7:
-				return <SevenCardFast trails={initialTrails} />;
+				return (
+					<SevenCardFast
+						trails={initialTrails}
+						imageLoading={imageLoading}
+					/>
+				);
 			case 8:
 				return (
 					<EightOrMoreFast
 						trails={[...initialTrails, ...trails.slice(8)]}
+						imageLoading={imageLoading}
 					/>
 				);
 		}
@@ -422,23 +726,59 @@ export const DecideContainerByTrails = ({ trails, speed }: Props) => {
 			case 0:
 				return <></>;
 			case 1:
-				return <OneCardSlow trail={initialTrails[0]} />;
+				return (
+					<OneCardSlow
+						trail={initialTrails[0]}
+						imageLoading={imageLoading}
+					/>
+				);
 			case 2:
-				return <TwoCard trails={initialTrails} />;
+				return (
+					<TwoCard
+						trails={initialTrails}
+						imageLoading={imageLoading}
+					/>
+				);
 			case 3:
-				return <ThreeCard trails={initialTrails} />;
+				return (
+					<ThreeCard
+						trails={initialTrails}
+						imageLoading={imageLoading}
+					/>
+				);
 			case 4:
-				return <FourCard trails={initialTrails} />;
+				return (
+					<FourCard
+						trails={initialTrails}
+						imageLoading={imageLoading}
+					/>
+				);
 			case 5:
-				return <FiveCardSlow trails={initialTrails} />;
+				return (
+					<FiveCardSlow
+						trails={initialTrails}
+						imageLoading={imageLoading}
+					/>
+				);
 			case 6:
-				return <SixCardSlow trails={initialTrails} />;
+				return (
+					<SixCardSlow
+						trails={initialTrails}
+						imageLoading={imageLoading}
+					/>
+				);
 			case 7:
-				return <SevenCardSlow trails={initialTrails} />;
+				return (
+					<SevenCardSlow
+						trails={initialTrails}
+						imageLoading={imageLoading}
+					/>
+				);
 			case 8:
 				return (
 					<EightOrMoreSlow
 						trails={[...initialTrails, ...trails.slice(8)]}
+						imageLoading={imageLoading}
 					/>
 				);
 		}

--- a/dotcom-rendering/src/components/DynamicFast.stories.tsx
+++ b/dotcom-rendering/src/components/DynamicFast.stories.tsx
@@ -41,6 +41,7 @@ export const OneHugeTwoBigsSixStandards = () => (
 				standard: trails.slice(3, 10),
 			}}
 			showAge={true}
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );
@@ -59,6 +60,7 @@ export const OneVeryBigTwoBigsSixStandards = () => (
 				standard: trails.slice(3, 10),
 			}}
 			showAge={true}
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );
@@ -78,6 +80,7 @@ export const TwoVeryBigsTwoBigsSixStandards = () => (
 				standard: trails.slice(4, 11),
 			}}
 			showAge={true}
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );
@@ -97,6 +100,7 @@ export const TwoVeryBigs1stBoostedTwoBigsSixStandards = () => (
 				standard: trails.slice(4, 11),
 			}}
 			showAge={true}
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );
@@ -116,6 +120,7 @@ export const TwoVeryBigs2ndBoostedTwoBigsSixStandards = () => (
 				standard: trails.slice(4, 11),
 			}}
 			showAge={true}
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );
@@ -136,6 +141,7 @@ export const TwoVeryBigsTwelveStandards = () => (
 				standard: trails.slice(2, 14),
 			}}
 			showAge={true}
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );
@@ -155,6 +161,7 @@ export const TwoVeryBigsOneBigEightStandards = () => (
 				standard: trails.slice(4, 12),
 			}}
 			showAge={true}
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );
@@ -175,6 +182,7 @@ export const TwoVeryBigsOneBigBoostedSixStandards = () => (
 				standard: trails.slice(4, 10),
 			}}
 			showAge={true}
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );
@@ -195,6 +203,7 @@ export const TwoVeryBigsTwoBigsFiveStandards = () => (
 				standard: trails.slice(5, 10),
 			}}
 			showAge={true}
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );
@@ -215,6 +224,7 @@ export const TwoVeryBigsTwoBigsFirstBoostedEightStandards = () => (
 				standard: trails.slice(5, 12),
 			}}
 			showAge={true}
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );
@@ -235,6 +245,7 @@ export const TwoVeryBigsThreeBigsThreeStandards = () => (
 				standard: trails.slice(6, 9),
 			}}
 			showAge={true}
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );
@@ -254,6 +265,7 @@ export const TwoVeryBigsFourBigs = () => (
 				big: [trails[3], trails[4], trails[5], trails[6]],
 			}}
 			showAge={true}
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );
@@ -277,6 +289,7 @@ export const OneHugeOneVeryBig7Standards = () => (
 				standard: trails.slice(2, 9),
 			}}
 			showAge={true}
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );
@@ -296,6 +309,7 @@ export const ThreeVeryBigsFourBigs = () => (
 				big: [trails[3], trails[4], trails[5], trails[6]],
 			}}
 			showAge={true}
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );
@@ -315,6 +329,7 @@ export const TwoBigsFourStandards = () => (
 				standard: trails.slice(2, 6),
 			}}
 			showAge={true}
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );
@@ -335,6 +350,7 @@ export const OneVeryBigTwoBigs = () => (
 				big: [trails[1], trails[2]],
 			}}
 			showAge={true}
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );
@@ -353,6 +369,7 @@ export const OneVeryBig = () => (
 				veryBig: [trails[0]],
 			}}
 			showAge={true}
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );
@@ -373,6 +390,7 @@ export const TwoVeryBigsFourBigsFirstBoostedThreeStandards = () => (
 				standard: trails.slice(5, 8),
 			}}
 			showAge={true}
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );

--- a/dotcom-rendering/src/components/DynamicFast.tsx
+++ b/dotcom-rendering/src/components/DynamicFast.tsx
@@ -20,6 +20,7 @@ import type {
 } from '../types/front';
 import { LI } from './Card/components/LI';
 import { UL } from './Card/components/UL';
+import { Loading } from './CardPicture';
 
 /**
  * Not sure where to start? This PR documents a lot of the key features
@@ -31,6 +32,7 @@ import { UL } from './Card/components/UL';
 
 type Props = {
 	groupedTrails: DCRGroupedTrails;
+	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
 };
@@ -46,8 +48,10 @@ const Card50_ColumnOfThreeCards25_ColumnOfFiveCards = ({
 	cards,
 	showAge,
 	containerPalette,
+	imageLoading,
 }: {
 	cards: DCRFrontCard[];
+	imageLoading: Loading;
 	showAge?: boolean;
 	containerPalette?: DCRContainerPalette;
 }) => {
@@ -64,6 +68,7 @@ const Card50_ColumnOfThreeCards25_ColumnOfFiveCards = ({
 					trail={big}
 					containerPalette={containerPalette}
 					showAge={showAge}
+					imageLoading={imageLoading}
 				/>
 			</LI>
 			<LI
@@ -85,6 +90,7 @@ const Card50_ColumnOfThreeCards25_ColumnOfFiveCards = ({
 										trail={card}
 										containerPalette={containerPalette}
 										showAge={showAge}
+										imageLoading={imageLoading}
 									/>
 								) : (
 									<CardDefault
@@ -129,8 +135,10 @@ const Card50_ColumnOfThreeCards25_ColumnOfThreeCards25 = ({
 	cards,
 	showAge,
 	containerPalette,
+	imageLoading,
 }: {
 	cards: DCRFrontCard[];
+	imageLoading: Loading;
 	showAge?: boolean;
 	containerPalette?: DCRContainerPalette;
 }) => {
@@ -145,6 +153,7 @@ const Card50_ColumnOfThreeCards25_ColumnOfThreeCards25 = ({
 					trail={big}
 					containerPalette={containerPalette}
 					showAge={showAge}
+					imageLoading={imageLoading}
 				/>
 			</LI>
 			<LI percentage="50%">
@@ -190,8 +199,10 @@ const ColumnOfThreeCards25_ColumnOfThreeCards25_ColumnOfThreeCards25_ColumnOfThr
 		cards,
 		showAge,
 		containerPalette,
+		imageLoading,
 	}: {
 		cards: DCRFrontCard[];
+		imageLoading: Loading;
 		showAge?: boolean;
 		containerPalette?: DCRContainerPalette;
 	}) => {
@@ -231,8 +242,10 @@ const Card25_ColumnOfCards25_ColumnOfThreeCards25_ColumnOfThreeCards25 = ({
 	cards,
 	showAge,
 	containerPalette,
+	imageLoading,
 }: {
 	cards: DCRFrontCard[];
+	imageLoading: Loading;
 	showAge?: boolean;
 	containerPalette?: DCRContainerPalette;
 }) => {
@@ -247,6 +260,7 @@ const Card25_ColumnOfCards25_ColumnOfThreeCards25_ColumnOfThreeCards25 = ({
 					trail={big}
 					containerPalette={containerPalette}
 					showAge={showAge}
+					imageLoading={imageLoading}
 				/>
 			</LI>
 			<LI percentage="75%">
@@ -291,8 +305,10 @@ const Card25_Card25_ColumnOfThreeCards25_ColumnOfThreeCards25 = ({
 	cards,
 	showAge,
 	containerPalette,
+	imageLoading,
 }: {
 	cards: DCRFrontCard[];
+	imageLoading: Loading;
 	showAge?: boolean;
 	containerPalette?: DCRContainerPalette;
 }) => {
@@ -316,6 +332,7 @@ const Card25_Card25_ColumnOfThreeCards25_ColumnOfThreeCards25 = ({
 							trail={card}
 							containerPalette={containerPalette}
 							showAge={showAge}
+							imageLoading={imageLoading}
 						/>
 					</LI>
 				);
@@ -363,8 +380,10 @@ const Card25_Card25_Card25_ColumnOfThreeCards25 = ({
 	cards,
 	showAge,
 	containerPalette,
+	imageLoading,
 }: {
 	cards: DCRFrontCard[];
+	imageLoading: Loading;
 	showAge?: boolean;
 	containerPalette?: DCRContainerPalette;
 }) => {
@@ -388,6 +407,7 @@ const Card25_Card25_Card25_ColumnOfThreeCards25 = ({
 							trail={card}
 							containerPalette={containerPalette}
 							showAge={showAge}
+							imageLoading={imageLoading}
 						/>
 					</LI>
 				);
@@ -427,6 +447,7 @@ export const DynamicFast = ({
 	groupedTrails,
 	containerPalette,
 	showAge,
+	imageLoading,
 }: Props) => {
 	let firstSliceLayout:
 		| undefined // If there are no very bigs or huges, there is no first slice
@@ -559,6 +580,7 @@ export const DynamicFast = ({
 						cards={firstSliceCards}
 						showAge={showAge}
 						containerPalette={containerPalette}
+						imageLoading={imageLoading}
 					/>
 				);
 			case 'oneVeryBig':
@@ -567,6 +589,7 @@ export const DynamicFast = ({
 						cards={firstSliceCards}
 						showAge={showAge}
 						containerPalette={containerPalette}
+						imageLoading={imageLoading}
 					/>
 				);
 			case 'TwoVeryBigsFirstBoosted':
@@ -575,6 +598,7 @@ export const DynamicFast = ({
 						cards={firstSliceCards}
 						showAge={showAge}
 						containerPalette={containerPalette}
+						imageLoading={imageLoading}
 					/>
 				);
 			case 'TwoVeryBigsSecondBoosted':
@@ -583,6 +607,7 @@ export const DynamicFast = ({
 						cards={firstSliceCards}
 						showAge={showAge}
 						containerPalette={containerPalette}
+						imageLoading={imageLoading}
 					/>
 				);
 			case 'twoVeryBigs':
@@ -591,6 +616,7 @@ export const DynamicFast = ({
 						cards={firstSliceCards}
 						showAge={showAge}
 						containerPalette={containerPalette}
+						imageLoading={imageLoading}
 					/>
 				);
 			default:
@@ -606,6 +632,7 @@ export const DynamicFast = ({
 						cards={secondSliceCards}
 						showAge={showAge}
 						containerPalette={containerPalette}
+						imageLoading={imageLoading}
 					/>
 				);
 			case 'twoOrMoreBigsFirstBoosted':
@@ -614,6 +641,7 @@ export const DynamicFast = ({
 						cards={secondSliceCards}
 						showAge={showAge}
 						containerPalette={containerPalette}
+						imageLoading={imageLoading}
 					/>
 				);
 			case 'noBigs':
@@ -622,6 +650,7 @@ export const DynamicFast = ({
 						cards={secondSliceCards}
 						showAge={showAge}
 						containerPalette={containerPalette}
+						imageLoading={imageLoading}
 					/>
 				);
 			case 'oneBig':
@@ -630,6 +659,7 @@ export const DynamicFast = ({
 						cards={secondSliceCards}
 						showAge={showAge}
 						containerPalette={containerPalette}
+						imageLoading={imageLoading}
 					/>
 				);
 			case 'twoBigs':
@@ -638,6 +668,7 @@ export const DynamicFast = ({
 						cards={secondSliceCards}
 						showAge={showAge}
 						containerPalette={containerPalette}
+						imageLoading={imageLoading}
 					/>
 				);
 			case 'threeBigs':
@@ -646,6 +677,7 @@ export const DynamicFast = ({
 						cards={secondSliceCards}
 						showAge={showAge}
 						containerPalette={containerPalette}
+						imageLoading={imageLoading}
 					/>
 				);
 			case 'fourBigs':
@@ -654,6 +686,7 @@ export const DynamicFast = ({
 						cards={secondSliceCards}
 						showAge={showAge}
 						containerPalette={containerPalette}
+						imageLoading={imageLoading}
 					/>
 				);
 			default:

--- a/dotcom-rendering/src/components/DynamicPackage.stories.tsx
+++ b/dotcom-rendering/src/components/DynamicPackage.stories.tsx
@@ -36,6 +36,7 @@ export const One = () => (
 				standard: trails.slice(0, 1),
 			}}
 			containerPalette="LongRunningPalette"
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );
@@ -50,6 +51,7 @@ export const Two = () => (
 				standard: trails.slice(0, 2),
 			}}
 			containerPalette="LongRunningPalette"
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );
@@ -64,6 +66,7 @@ export const Three = () => (
 				standard: trails.slice(0, 3),
 			}}
 			containerPalette="LongRunningPalette"
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );
@@ -78,6 +81,7 @@ export const Four = () => (
 				standard: trails.slice(0, 4),
 			}}
 			containerPalette="LongRunningPalette"
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );
@@ -92,6 +96,7 @@ export const Five = () => (
 				standard: trails.slice(0, 5),
 			}}
 			containerPalette="LongRunningPalette"
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );
@@ -106,6 +111,7 @@ export const Six = () => (
 				standard: trails.slice(0, 6),
 			}}
 			containerPalette="LongRunningPalette"
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );
@@ -120,6 +126,7 @@ export const Seven = () => (
 				standard: trails.slice(0, 7),
 			}}
 			containerPalette="LongRunningPalette"
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );
@@ -134,6 +141,7 @@ export const Eight = () => (
 				standard: trails.slice(0, 8),
 			}}
 			containerPalette="LongRunningPalette"
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );
@@ -148,6 +156,7 @@ export const Nine = () => (
 				standard: trails.slice(0, 9),
 			}}
 			containerPalette="LongRunningPalette"
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );
@@ -166,6 +175,7 @@ export const Boosted1 = () => {
 				}}
 				showAge={true}
 				containerPalette="LongRunningPalette"
+				imageLoading="eager"
 			/>
 		</FrontSection>
 	);
@@ -186,6 +196,7 @@ export const Boosted2 = () => {
 				}}
 				showAge={true}
 				containerPalette="LongRunningPalette"
+				imageLoading="eager"
 			/>
 		</FrontSection>
 	);
@@ -206,6 +217,7 @@ export const Boosted3 = () => {
 				}}
 				showAge={true}
 				containerPalette="LongRunningPalette"
+				imageLoading="eager"
 			/>
 		</FrontSection>
 	);
@@ -226,6 +238,7 @@ export const Boosted4 = () => {
 				}}
 				showAge={true}
 				containerPalette="LongRunningPalette"
+				imageLoading="eager"
 			/>
 		</FrontSection>
 	);
@@ -246,6 +259,7 @@ export const Boosted5 = () => {
 				}}
 				showAge={true}
 				containerPalette="LongRunningPalette"
+				imageLoading="eager"
 			/>
 		</FrontSection>
 	);
@@ -266,6 +280,7 @@ export const Boosted8 = () => {
 				}}
 				showAge={true}
 				containerPalette="LongRunningPalette"
+				imageLoading="eager"
 			/>
 		</FrontSection>
 	);
@@ -286,6 +301,7 @@ export const Boosted9 = () => {
 				}}
 				showAge={true}
 				containerPalette="LongRunningPalette"
+				imageLoading="eager"
 			/>
 		</FrontSection>
 	);
@@ -301,6 +317,7 @@ export const OneSnapThreeStandard = () => (
 				standard: trails.slice(1, 4),
 			}}
 			containerPalette="LongRunningPalette"
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );
@@ -315,6 +332,7 @@ export const ThreeSnapTwoStandard = () => (
 				standard: trails.slice(3, 5),
 			}}
 			containerPalette="LongRunningPalette"
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );
@@ -329,6 +347,7 @@ export const ThreeSnapTwoStandard2ndBoosted = () => (
 				standard: trails.slice(3, 5),
 			}}
 			containerPalette="LongRunningPalette"
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );
@@ -369,6 +388,7 @@ export const SpecialReportWithoutPalette = () => (
 					},
 				],
 			}}
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );

--- a/dotcom-rendering/src/components/DynamicPackage.tsx
+++ b/dotcom-rendering/src/components/DynamicPackage.tsx
@@ -6,10 +6,12 @@ import type {
 } from '../types/front';
 import { LI } from './Card/components/LI';
 import { UL } from './Card/components/UL';
+import { Loading } from './CardPicture';
 import { FrontCard } from './FrontCard';
 
 type Props = {
 	groupedTrails: DCRGroupedTrails;
+	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
 };
@@ -25,8 +27,10 @@ const Snap100 = ({
 	snaps,
 	containerPalette,
 	showAge,
+	imageLoading,
 }: {
 	snaps: DCRFrontCard[];
+	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
 }) => {
@@ -46,6 +50,7 @@ const Snap100 = ({
 					imageSize="medium"
 					trailText={snaps[0].trailText}
 					supportingContentAlignment="horizontal"
+					imageLoading={imageLoading}
 				/>
 			</LI>
 		</UL>
@@ -56,8 +61,10 @@ const Card100 = ({
 	cards,
 	containerPalette,
 	showAge,
+	imageLoading,
 }: {
 	cards: DCRFrontCard[];
+	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
 }) => {
@@ -77,6 +84,7 @@ const Card100 = ({
 					isDynamo={containerPalette && true}
 					supportingContent={cards[0].supportingContent}
 					supportingContentAlignment="horizontal"
+					imageLoading={imageLoading}
 				/>
 			</LI>
 		</UL>
@@ -87,8 +95,10 @@ const Card75_Card25 = ({
 	cards,
 	containerPalette,
 	showAge,
+	imageLoading,
 }: {
 	cards: DCRFrontCard[];
+	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
 }) => {
@@ -111,6 +121,7 @@ const Card75_Card25 = ({
 						imagePositionOnMobile="bottom"
 						imageSize="medium"
 						trailText={card.trailText}
+						imageLoading={imageLoading}
 					/>
 				</LI>
 			))}
@@ -127,6 +138,7 @@ const Card75_Card25 = ({
 						containerPalette={containerPalette}
 						containerType="dynamic/package"
 						showAge={showAge}
+						imageLoading={imageLoading}
 					/>
 				</LI>
 			))}
@@ -140,8 +152,10 @@ const Card25_Card25_Card25_Card25 = ({
 	showAge,
 	showImage = true,
 	padBottom,
+	imageLoading,
 }: {
 	cards: DCRFrontCard[];
+	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
 	showImage?: boolean;
@@ -164,6 +178,7 @@ const Card25_Card25_Card25_Card25 = ({
 							showAge={showAge}
 							supportingContent={card.supportingContent}
 							imageUrl={showImage ? card.image : undefined}
+							imageLoading={imageLoading}
 						/>
 					</LI>
 				);
@@ -176,8 +191,10 @@ const Card25_Card25_Card25_ColumnOfTwo25 = ({
 	cards,
 	containerPalette,
 	showAge,
+	imageLoading,
 }: {
 	cards: DCRFrontCard[];
+	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
 }) => {
@@ -201,6 +218,7 @@ const Card25_Card25_Card25_ColumnOfTwo25 = ({
 							containerType="dynamic/package"
 							showAge={showAge}
 							supportingContent={card.supportingContent}
+							imageLoading={imageLoading}
 						/>
 					</LI>
 				);
@@ -225,6 +243,7 @@ const Card25_Card25_Card25_ColumnOfTwo25 = ({
 									showAge={showAge}
 									supportingContent={card.supportingContent}
 									imageUrl={undefined}
+									imageLoading={imageLoading}
 								/>
 							</LI>
 						);
@@ -239,8 +258,10 @@ const Card25_Card25_ColumnOfTwo25_ColumnOfTwo25 = ({
 	cards,
 	containerPalette,
 	showAge,
+	imageLoading,
 }: {
 	cards: DCRFrontCard[];
+	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
 }) => {
@@ -264,6 +285,7 @@ const Card25_Card25_ColumnOfTwo25_ColumnOfTwo25 = ({
 							containerType="dynamic/package"
 							showAge={showAge}
 							supportingContent={card.supportingContent}
+							imageLoading={imageLoading}
 						/>
 					</LI>
 				);
@@ -295,6 +317,7 @@ const Card25_Card25_ColumnOfTwo25_ColumnOfTwo25 = ({
 									showAge={showAge}
 									supportingContent={card.supportingContent}
 									imageUrl={undefined}
+									imageLoading={imageLoading}
 								/>
 							</LI>
 						);
@@ -309,8 +332,10 @@ const Card25_ColumnOfTwo25_ColumnOfTwo25_ColumnOfTwo25 = ({
 	cards,
 	containerPalette,
 	showAge,
+	imageLoading,
 }: {
 	cards: DCRFrontCard[];
+	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
 }) => {
@@ -328,6 +353,7 @@ const Card25_ColumnOfTwo25_ColumnOfTwo25_ColumnOfTwo25 = ({
 							containerType="dynamic/package"
 							showAge={showAge}
 							supportingContent={card.supportingContent}
+							imageLoading={imageLoading}
 						/>
 					</LI>
 				);
@@ -359,6 +385,7 @@ const Card25_ColumnOfTwo25_ColumnOfTwo25_ColumnOfTwo25 = ({
 									showAge={showAge}
 									supportingContent={card.supportingContent}
 									imageUrl={undefined}
+									imageLoading={imageLoading}
 								/>
 							</LI>
 						);
@@ -373,8 +400,10 @@ const Card75_ColumnOfCards25 = ({
 	cards,
 	containerPalette,
 	showAge,
+	imageLoading,
 }: {
 	cards: DCRFrontCard[];
+	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
 }) => {
@@ -396,6 +425,7 @@ const Card75_ColumnOfCards25 = ({
 						imageSize="large"
 						supportingContent={card.supportingContent}
 						isDynamo={true}
+						imageLoading={imageLoading}
 					/>
 				</LI>
 			))}
@@ -428,6 +458,7 @@ const Card75_ColumnOfCards25 = ({
 											: 'small'
 									}
 									supportingContent={card.supportingContent}
+									imageLoading={imageLoading}
 								/>
 							</LI>
 						);
@@ -442,6 +473,7 @@ export const DynamicPackage = ({
 	groupedTrails,
 	containerPalette,
 	showAge,
+	imageLoading,
 }: Props) => {
 	let layout:
 		| 'oneStandard'
@@ -530,11 +562,13 @@ export const DynamicPackage = ({
 						snaps={firstSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						imageLoading={imageLoading}
 					/>
 					<Card100
 						cards={secondSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						imageLoading={imageLoading}
 					/>
 				</>
 			);
@@ -545,6 +579,7 @@ export const DynamicPackage = ({
 						snaps={firstSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						imageLoading={imageLoading}
 					/>
 					{/* Card75_Card25 does not support the first card being boosted - on Frontend the 75% card would
 						receive a ginourmous headline size - however this broke the layout visually, so we decided not
@@ -553,6 +588,7 @@ export const DynamicPackage = ({
 						cards={secondSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						imageLoading={imageLoading}
 					/>
 				</>
 			);
@@ -563,16 +599,19 @@ export const DynamicPackage = ({
 						snaps={firstSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						imageLoading={imageLoading}
 					/>
 					<Card100
 						cards={secondSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						imageLoading={imageLoading}
 					/>
 					<Card25_Card25_Card25_Card25
 						cards={thirdSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						imageLoading={imageLoading}
 					/>
 				</>
 			);
@@ -583,11 +622,13 @@ export const DynamicPackage = ({
 						snaps={firstSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						imageLoading={imageLoading}
 					/>
 					<Card75_ColumnOfCards25
 						cards={secondSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						imageLoading={imageLoading}
 					/>
 				</>
 			);
@@ -598,16 +639,19 @@ export const DynamicPackage = ({
 						snaps={firstSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						imageLoading={imageLoading}
 					/>
 					<Card100
 						cards={secondSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						imageLoading={imageLoading}
 					/>
 					<Card25_Card25_Card25_Card25
 						cards={thirdSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						imageLoading={imageLoading}
 					/>
 				</>
 			);
@@ -618,16 +662,19 @@ export const DynamicPackage = ({
 						snaps={firstSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						imageLoading={imageLoading}
 					/>
 					<Card100
 						cards={secondSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						imageLoading={imageLoading}
 					/>
 					<Card25_Card25_Card25_ColumnOfTwo25
 						cards={thirdSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						imageLoading={imageLoading}
 					/>
 				</>
 			);
@@ -638,16 +685,19 @@ export const DynamicPackage = ({
 						snaps={firstSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						imageLoading={imageLoading}
 					/>
 					<Card100
 						cards={secondSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						imageLoading={imageLoading}
 					/>
 					<Card25_Card25_ColumnOfTwo25_ColumnOfTwo25
 						cards={thirdSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						imageLoading={imageLoading}
 					/>
 				</>
 			);
@@ -658,16 +708,19 @@ export const DynamicPackage = ({
 						snaps={firstSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						imageLoading={imageLoading}
 					/>
 					<Card100
 						cards={secondSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						imageLoading={imageLoading}
 					/>
 					<Card25_ColumnOfTwo25_ColumnOfTwo25_ColumnOfTwo25
 						cards={thirdSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						imageLoading={imageLoading}
 					/>
 				</>
 			);
@@ -678,23 +731,27 @@ export const DynamicPackage = ({
 						snaps={firstSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						imageLoading={imageLoading}
 					/>
 					<Card100
 						cards={secondSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						imageLoading={imageLoading}
 					/>
 					<Card25_Card25_Card25_Card25
 						cards={thirdSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
 						padBottom={true}
+						imageLoading={imageLoading}
 					/>
 					<Card25_Card25_Card25_Card25
 						cards={fourthSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
 						showImage={false}
+						imageLoading={imageLoading}
 					/>
 				</>
 			);

--- a/dotcom-rendering/src/components/DynamicSlow.stories.tsx
+++ b/dotcom-rendering/src/components/DynamicSlow.stories.tsx
@@ -56,6 +56,7 @@ export const Avatar = () => {
 					standard: avatarTrails.slice(4, 8),
 				}}
 				showAge={true}
+				imageLoading="eager"
 			/>
 		</FrontSection>
 	);
@@ -76,6 +77,7 @@ export const OneHugeTwoBigsFourStandards = () => (
 				standard: trails.slice(3, 7),
 			}}
 			showAge={true}
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );
@@ -94,6 +96,7 @@ export const OneVeryBigTwoBigsFourStandards = () => (
 				standard: trails.slice(3, 7),
 			}}
 			showAge={true}
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );
@@ -113,6 +116,7 @@ export const TwoVeryBigsTwoBigsFourStandards = () => (
 				standard: trails.slice(4, 8),
 			}}
 			showAge={true}
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );
@@ -132,6 +136,7 @@ export const TwoVeryBigs1stBoostedTwoBigsFourStandards = () => (
 				standard: trails.slice(4, 8),
 			}}
 			showAge={true}
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );
@@ -151,6 +156,7 @@ export const TwoVeryBigs2ndBoostedTwoBigsFourStandards = () => (
 				standard: trails.slice(4, 8),
 			}}
 			showAge={true}
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );
@@ -170,6 +176,7 @@ export const TwoVeryBigs8Standards = () => (
 				standard: trails.slice(2, 10),
 			}}
 			showAge={true}
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );
@@ -188,6 +195,7 @@ export const TwoVeryBigsOneBig4Standards = () => (
 				standard: trails.slice(3, 7),
 			}}
 			showAge={true}
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );
@@ -207,6 +215,7 @@ export const TwoVeryBigsTwoBigs4Standards = () => (
 				standard: trails.slice(4, 8),
 			}}
 			showAge={true}
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );
@@ -228,6 +237,7 @@ export const TwoVeryBigsFiveStandards = () => (
 				standard: trails.slice(2, 7),
 			}}
 			showAge={true}
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );
@@ -246,6 +256,7 @@ export const ThreeVeryBigsFiveStandards = () => (
 				standard: trails.slice(3, 8),
 			}}
 			showAge={true}
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );
@@ -264,6 +275,7 @@ export const TwoVeryBigsOneBig = () => (
 				big: trails.slice(2, 3),
 			}}
 			showAge={true}
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );
@@ -282,6 +294,7 @@ export const TwoBigsThreeStandards = () => (
 				standard: trails.slice(2, 5),
 			}}
 			showAge={true}
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );
@@ -301,6 +314,7 @@ export const OneVeryBigTwoBigsOneStandard = () => (
 				standard: trails.slice(4, 5),
 			}}
 			showAge={true}
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );

--- a/dotcom-rendering/src/components/DynamicSlow.tsx
+++ b/dotcom-rendering/src/components/DynamicSlow.tsx
@@ -20,9 +20,11 @@ import type {
 } from '../types/front';
 import { LI } from './Card/components/LI';
 import { UL } from './Card/components/UL';
+import { Loading } from './CardPicture';
 
 type Props = {
 	groupedTrails: DCRGroupedTrails;
+	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
 };
@@ -31,8 +33,10 @@ const ColumnOfCards50_Card50 = ({
 	cards,
 	showAge,
 	containerPalette,
+	imageLoading,
 }: {
 	cards: DCRFrontCard[];
+	imageLoading: Loading;
 	showAge?: boolean;
 	containerPalette?: DCRContainerPalette;
 }) => {
@@ -53,6 +57,7 @@ const ColumnOfCards50_Card50 = ({
 						trail={card}
 						showAge={showAge}
 						containerPalette={containerPalette}
+						imageLoading={imageLoading}
 					/>
 				</LI>
 			))}
@@ -69,6 +74,7 @@ const ColumnOfCards50_Card50 = ({
 									trail={card}
 									containerPalette={containerPalette}
 									showAge={showAge}
+									imageLoading={imageLoading}
 								/>
 							</LI>
 						);
@@ -83,8 +89,10 @@ const ColumnOfCards50_ColumnOfCards50 = ({
 	cards,
 	showAge,
 	containerPalette,
+	imageLoading,
 }: {
 	cards: DCRFrontCard[];
+	imageLoading: Loading;
 	showAge?: boolean;
 	containerPalette?: DCRContainerPalette;
 }) => {
@@ -109,6 +117,7 @@ const ColumnOfCards50_ColumnOfCards50 = ({
 							trail={card}
 							containerPalette={containerPalette}
 							showAge={showAge}
+							imageLoading={imageLoading}
 						/>
 					</LI>
 				);
@@ -126,6 +135,7 @@ export const DynamicSlow = ({
 	groupedTrails,
 	containerPalette,
 	showAge,
+	imageLoading,
 }: Props) => {
 	let firstSliceLayout:
 		| undefined // If there are no very bigs or huges, there is no first slice
@@ -209,6 +219,7 @@ export const DynamicSlow = ({
 						cards={firstSliceCards}
 						showAge={showAge}
 						containerPalette={containerPalette}
+						imageLoading={imageLoading}
 					/>
 				);
 			case 'oneVeryBig':
@@ -217,6 +228,7 @@ export const DynamicSlow = ({
 						cards={firstSliceCards}
 						showAge={showAge}
 						containerPalette={containerPalette}
+						imageLoading={imageLoading}
 					/>
 				);
 			case 'TwoVeryBigsFirstBoosted':
@@ -225,6 +237,7 @@ export const DynamicSlow = ({
 						cards={firstSliceCards}
 						showAge={showAge}
 						containerPalette={containerPalette}
+						imageLoading={imageLoading}
 					/>
 				);
 			case 'TwoVeryBigsSecondBoosted':
@@ -233,6 +246,7 @@ export const DynamicSlow = ({
 						cards={firstSliceCards}
 						showAge={showAge}
 						containerPalette={containerPalette}
+						imageLoading={imageLoading}
 					/>
 				);
 			case 'twoVeryBigs':
@@ -241,6 +255,7 @@ export const DynamicSlow = ({
 						cards={firstSliceCards}
 						showAge={showAge}
 						containerPalette={containerPalette}
+						imageLoading={imageLoading}
 					/>
 				);
 			default:
@@ -256,6 +271,7 @@ export const DynamicSlow = ({
 						cards={secondSliceCards}
 						showAge={showAge}
 						containerPalette={containerPalette}
+						imageLoading={imageLoading}
 					/>
 				);
 			case 'oneBig':
@@ -264,6 +280,7 @@ export const DynamicSlow = ({
 						cards={secondSliceCards}
 						showAge={showAge}
 						containerPalette={containerPalette}
+						imageLoading={imageLoading}
 					/>
 				);
 			case 'twoBigs':
@@ -272,6 +289,7 @@ export const DynamicSlow = ({
 						cards={secondSliceCards}
 						showAge={showAge}
 						containerPalette={containerPalette}
+						imageLoading={imageLoading}
 					/>
 				);
 		}

--- a/dotcom-rendering/src/components/DynamicSlowMPU.stories.tsx
+++ b/dotcom-rendering/src/components/DynamicSlowMPU.stories.tsx
@@ -33,6 +33,7 @@ export const NoBigs = () => (
 			showAge={true}
 			adIndex={1}
 			renderAds={true}
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );
@@ -51,6 +52,7 @@ export const OneBig = () => (
 			showAge={true}
 			adIndex={1}
 			renderAds={true}
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );
@@ -69,6 +71,7 @@ export const TwoBigs = () => (
 			showAge={true}
 			adIndex={1}
 			renderAds={true}
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );
@@ -91,6 +94,7 @@ export const FirstBigBoosted = () => (
 			showAge={true}
 			adIndex={1}
 			renderAds={true}
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );
@@ -113,6 +117,7 @@ export const SecondBigBoosted = () => (
 			showAge={true}
 			adIndex={1}
 			renderAds={true}
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );
@@ -131,6 +136,7 @@ export const ThreeBigs = () => (
 			showAge={true}
 			adIndex={1}
 			renderAds={true}
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );
@@ -149,6 +155,7 @@ export const AllBigs = () => (
 			showAge={true}
 			adIndex={1}
 			renderAds={true}
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );
@@ -167,6 +174,7 @@ export const AllBigsNoMPU = () => (
 			showAge={true}
 			adIndex={1}
 			renderAds={false}
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );
@@ -185,6 +193,7 @@ export const TwoBigsThreeStandardsNoMPU = () => (
 			showAge={true}
 			adIndex={1}
 			renderAds={false}
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );
@@ -203,6 +212,7 @@ export const NoBigsTwoStandardsNoMPU = () => (
 			showAge={true}
 			adIndex={1}
 			renderAds={false}
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );
@@ -221,6 +231,7 @@ export const NoBigsFiveStandardsNoMPU = () => (
 			showAge={true}
 			adIndex={1}
 			renderAds={false}
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );

--- a/dotcom-rendering/src/components/DynamicSlowMPU.tsx
+++ b/dotcom-rendering/src/components/DynamicSlowMPU.tsx
@@ -21,6 +21,7 @@ import type {
 import { AdSlot } from './AdSlot';
 import { LI } from './Card/components/LI';
 import { UL } from './Card/components/UL';
+import { Loading } from './CardPicture';
 
 type Props = {
 	groupedTrails: DCRGroupedTrails;
@@ -28,6 +29,7 @@ type Props = {
 	showAge?: boolean;
 	adIndex: number;
 	renderAds: boolean;
+	imageLoading: Loading;
 };
 
 /* .___________.___________.___________.
@@ -40,8 +42,10 @@ const Card33_ColumnOfThree33_Ad33 = ({
 	containerPalette,
 	showAge,
 	adIndex,
+	imageLoading,
 }: {
 	cards: DCRFrontCard[];
+	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
 	adIndex: number;
@@ -57,6 +61,7 @@ const Card33_ColumnOfThree33_Ad33 = ({
 						trail={card}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						imageLoading={imageLoading}
 					/>
 				</LI>
 			))}
@@ -124,8 +129,10 @@ const ColumnOfThree50_Ad50 = ({
 	containerPalette,
 	showAge,
 	adIndex,
+	imageLoading,
 }: {
 	cards: DCRFrontCard[];
+	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
 	adIndex: number;
@@ -142,6 +149,7 @@ const ColumnOfThree50_Ad50 = ({
 								trail={card}
 								containerPalette={containerPalette}
 								showAge={showAge}
+								imageLoading={imageLoading}
 							/>
 						</LI>
 					))}
@@ -176,6 +184,7 @@ export const DynamicSlowMPU = ({
 	showAge,
 	adIndex,
 	renderAds,
+	imageLoading,
 }: Props) => {
 	let firstSliceLayout:
 		| undefined
@@ -262,6 +271,7 @@ export const DynamicSlowMPU = ({
 						cards={firstSliceCards}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						imageLoading={imageLoading}
 					/>
 				);
 			case 'twoBigsFirstBoosted':
@@ -270,6 +280,7 @@ export const DynamicSlowMPU = ({
 						cards={firstSliceCards}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						imageLoading={imageLoading}
 					/>
 				);
 			case 'twoBigsSecondBoosted':
@@ -278,6 +289,7 @@ export const DynamicSlowMPU = ({
 						cards={firstSliceCards}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						imageLoading={imageLoading}
 					/>
 				);
 			case 'threeBigs':
@@ -286,6 +298,7 @@ export const DynamicSlowMPU = ({
 						cards={firstSliceCards}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						imageLoading={imageLoading}
 					/>
 				);
 			default:
@@ -303,6 +316,7 @@ export const DynamicSlowMPU = ({
 						containerPalette={containerPalette}
 						showAge={showAge}
 						adIndex={adIndex}
+						imageLoading={imageLoading}
 					/>
 				);
 			case 'noFirstSlice':
@@ -312,6 +326,7 @@ export const DynamicSlowMPU = ({
 						containerPalette={containerPalette}
 						showAge={showAge}
 						adIndex={adIndex}
+						imageLoading={imageLoading}
 					/>
 				);
 			// Without MPU
@@ -330,6 +345,7 @@ export const DynamicSlowMPU = ({
 						cards={secondSliceCards}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						imageLoading={imageLoading}
 					/>
 				);
 
@@ -339,6 +355,7 @@ export const DynamicSlowMPU = ({
 						cards={secondSliceCards}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						imageLoading={imageLoading}
 					/>
 				);
 			case 'noFirstSliceNoMPUThreeOrMore':
@@ -347,6 +364,7 @@ export const DynamicSlowMPU = ({
 						cards={secondSliceCards}
 						showAge={showAge}
 						containerPalette={containerPalette}
+						imageLoading={imageLoading}
 					/>
 				);
 		}

--- a/dotcom-rendering/src/components/FixedLargeSlowXIV.stories.tsx
+++ b/dotcom-rendering/src/components/FixedLargeSlowXIV.stories.tsx
@@ -19,7 +19,11 @@ export default {
 
 export const Default = () => (
 	<FrontSection title="Fixed Large Slow XIV">
-		<FixedLargeSlowXIV trails={trails} showAge={true} />
+		<FixedLargeSlowXIV
+			trails={trails}
+			showAge={true}
+			imageLoading="eager"
+		/>
 	</FrontSection>
 );
 Default.storyName = 'FixedLargeSlowXIV';

--- a/dotcom-rendering/src/components/FixedLargeSlowXIV.tsx
+++ b/dotcom-rendering/src/components/FixedLargeSlowXIV.tsx
@@ -8,9 +8,11 @@ import { shouldPadWrappableRows } from '../lib/dynamicSlices';
 import type { DCRContainerPalette, DCRFrontCard } from '../types/front';
 import { LI } from './Card/components/LI';
 import { UL } from './Card/components/UL';
+import { Loading } from './CardPicture';
 
 type Props = {
 	trails: DCRFrontCard[];
+	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
 };
@@ -19,6 +21,7 @@ export const FixedLargeSlowXIV = ({
 	trails,
 	containerPalette,
 	showAge,
+	imageLoading,
 }: Props) => {
 	const firstSlice75 = trails.slice(0, 1);
 	const firstSlice25 = trails.slice(1, 2);
@@ -35,6 +38,7 @@ export const FixedLargeSlowXIV = ({
 								trail={card}
 								showAge={showAge}
 								containerPalette={containerPalette}
+								imageLoading={imageLoading}
 							/>
 						</LI>
 					);
@@ -52,6 +56,7 @@ export const FixedLargeSlowXIV = ({
 								trail={card}
 								showAge={showAge}
 								containerPalette={containerPalette}
+								imageLoading={imageLoading}
 							/>
 						</LI>
 					);
@@ -71,6 +76,7 @@ export const FixedLargeSlowXIV = ({
 								trail={card}
 								containerPalette={containerPalette}
 								showAge={showAge}
+								imageLoading={imageLoading}
 							/>
 						</LI>
 					);

--- a/dotcom-rendering/src/components/FixedMediumFastXI.stories.tsx
+++ b/dotcom-rendering/src/components/FixedMediumFastXI.stories.tsx
@@ -19,77 +19,77 @@ export default {
 
 export const OneTrail = () => (
 	<FrontSection title="Fixed Medium Fast XI">
-		<FixedMediumFastXI trails={trails.slice(0, 1)} />
+		<FixedMediumFastXI trails={trails.slice(0, 1)} imageLoading="eager" />
 	</FrontSection>
 );
 OneTrail.storyName = 'with one trail';
 
 export const TwoTrails = () => (
 	<FrontSection title="Fixed Medium Fast XI">
-		<FixedMediumFastXI trails={trails.slice(0, 2)} />
+		<FixedMediumFastXI trails={trails.slice(0, 2)} imageLoading="eager" />
 	</FrontSection>
 );
 TwoTrails.storyName = 'with two trails';
 
 export const ThreeTrails = () => (
 	<FrontSection title="Fixed Medium Fast XI">
-		<FixedMediumFastXI trails={trails.slice(0, 3)} />
+		<FixedMediumFastXI trails={trails.slice(0, 3)} imageLoading="eager" />
 	</FrontSection>
 );
 ThreeTrails.storyName = 'with three trails';
 
 export const FourTrails = () => (
 	<FrontSection title="Fixed Medium Fast XI">
-		<FixedMediumFastXI trails={trails.slice(0, 4)} />
+		<FixedMediumFastXI trails={trails.slice(0, 4)} imageLoading="eager" />
 	</FrontSection>
 );
 FourTrails.storyName = 'with four trails';
 
 export const FiveTrails = () => (
 	<FrontSection title="Fixed Medium Fast XI">
-		<FixedMediumFastXI trails={trails.slice(0, 5)} />
+		<FixedMediumFastXI trails={trails.slice(0, 5)} imageLoading="eager" />
 	</FrontSection>
 );
 FiveTrails.storyName = 'with five trails';
 
 export const SixTrails = () => (
 	<FrontSection title="Fixed Medium Fast XI">
-		<FixedMediumFastXI trails={trails.slice(0, 6)} />
+		<FixedMediumFastXI trails={trails.slice(0, 6)} imageLoading="eager" />
 	</FrontSection>
 );
 SixTrails.storyName = 'with six trails';
 
 export const SevenTrails = () => (
 	<FrontSection title="Fixed Medium Fast XI">
-		<FixedMediumFastXI trails={trails.slice(0, 7)} />
+		<FixedMediumFastXI trails={trails.slice(0, 7)} imageLoading="eager" />
 	</FrontSection>
 );
 SevenTrails.storyName = 'with seven trails';
 
 export const EightTrails = () => (
 	<FrontSection title="Fixed Medium Fast XI">
-		<FixedMediumFastXI trails={trails.slice(0, 8)} />
+		<FixedMediumFastXI trails={trails.slice(0, 8)} imageLoading="eager" />
 	</FrontSection>
 );
 EightTrails.storyName = 'with eight trails';
 
 export const NineTrails = () => (
 	<FrontSection title="Fixed Medium Fast XI">
-		<FixedMediumFastXI trails={trails.slice(0, 9)} />
+		<FixedMediumFastXI trails={trails.slice(0, 9)} imageLoading="eager" />
 	</FrontSection>
 );
 NineTrails.storyName = 'with nine trails';
 
 export const TenTrails = () => (
 	<FrontSection title="Fixed Medium Fast XI">
-		<FixedMediumFastXI trails={trails.slice(0, 10)} />
+		<FixedMediumFastXI trails={trails.slice(0, 10)} imageLoading="eager" />
 	</FrontSection>
 );
 TenTrails.storyName = 'with ten trails';
 
 export const ElevenTrails = () => (
 	<FrontSection title="Fixed Medium Fast XI">
-		<FixedMediumFastXI trails={trails.slice(0, 11)} />
+		<FixedMediumFastXI trails={trails.slice(0, 11)} imageLoading="eager" />
 	</FrontSection>
 );
 ElevenTrails.storyName = 'with eleven trails';

--- a/dotcom-rendering/src/components/FixedMediumFastXI.tsx
+++ b/dotcom-rendering/src/components/FixedMediumFastXI.tsx
@@ -3,9 +3,11 @@ import { Card50_Card25_Card25 } from '../lib/dynamicSlices';
 import type { DCRContainerPalette, DCRFrontCard } from '../types/front';
 import { LI } from './Card/components/LI';
 import { UL } from './Card/components/UL';
+import { Loading } from './CardPicture';
 
 type Props = {
 	trails: DCRFrontCard[];
+	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
 };
@@ -41,6 +43,7 @@ export const FixedMediumFastXI = ({
 	trails,
 	containerPalette,
 	showAge,
+	imageLoading,
 }: Props) => {
 	const firstSlice = trails.slice(0, 3);
 	const remaining = trails.slice(3, 11);
@@ -50,6 +53,7 @@ export const FixedMediumFastXI = ({
 				cards={firstSlice}
 				containerPalette={containerPalette}
 				showAge={showAge}
+				imageLoading={imageLoading}
 			/>
 			{/*
 			 * This pattern of using wrapCards on the UL + percentage=25 and stretch=true

--- a/dotcom-rendering/src/components/FixedMediumFastXII.stories.tsx
+++ b/dotcom-rendering/src/components/FixedMediumFastXII.stories.tsx
@@ -19,7 +19,11 @@ export default {
 
 export const Default = () => (
 	<FrontSection title="Fixed Medium Fast XII">
-		<FixedMediumFastXII trails={trails} showAge={true} />
+		<FixedMediumFastXII
+			trails={trails}
+			showAge={true}
+			imageLoading="eager"
+		/>
 	</FrontSection>
 );
 Default.storyName = 'FixedMediumFastXII';

--- a/dotcom-rendering/src/components/FixedMediumFastXII.tsx
+++ b/dotcom-rendering/src/components/FixedMediumFastXII.tsx
@@ -2,9 +2,11 @@ import { Card25Media25, CardDefault } from '../lib/cardWrappers';
 import type { DCRContainerPalette, DCRFrontCard } from '../types/front';
 import { LI } from './Card/components/LI';
 import { UL } from './Card/components/UL';
+import { Loading } from './CardPicture';
 
 type Props = {
 	trails: DCRFrontCard[];
+	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
 };
@@ -13,6 +15,7 @@ export const FixedMediumFastXII = ({
 	trails,
 	containerPalette,
 	showAge,
+	imageLoading,
 }: Props) => {
 	const firstSlice25 = trails.slice(0, 4);
 	const remaining = trails.slice(4, 12);
@@ -32,6 +35,7 @@ export const FixedMediumFastXII = ({
 								trail={trail}
 								containerPalette={containerPalette}
 								showAge={showAge}
+								imageLoading={imageLoading}
 							/>
 						</LI>
 					);

--- a/dotcom-rendering/src/components/FixedMediumSlowVI.stories.tsx
+++ b/dotcom-rendering/src/components/FixedMediumSlowVI.stories.tsx
@@ -19,7 +19,11 @@ export default {
 
 export const Default = () => (
 	<FrontSection title="Fixed Medium Slow VI">
-		<FixedMediumSlowVI trails={trails} showAge={true} />
+		<FixedMediumSlowVI
+			trails={trails}
+			showAge={true}
+			imageLoading="eager"
+		/>
 	</FrontSection>
 );
 Default.storyName = 'FixedMediumSlowVI';

--- a/dotcom-rendering/src/components/FixedMediumSlowVI.tsx
+++ b/dotcom-rendering/src/components/FixedMediumSlowVI.tsx
@@ -6,9 +6,11 @@ import {
 import type { DCRContainerPalette, DCRFrontCard } from '../types/front';
 import { LI } from './Card/components/LI';
 import { UL } from './Card/components/UL';
+import { Loading } from './CardPicture';
 
 type Props = {
 	trails: DCRFrontCard[];
+	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
 };
@@ -17,6 +19,7 @@ export const FixedMediumSlowVI = ({
 	trails,
 	containerPalette,
 	showAge,
+	imageLoading,
 }: Props) => {
 	const firstSlice75 = trails.slice(0, 1);
 	const firstSlice25 = trails.slice(1, 2);
@@ -31,6 +34,7 @@ export const FixedMediumSlowVI = ({
 							trail={trail}
 							containerPalette={containerPalette}
 							showAge={showAge}
+							imageLoading={imageLoading}
 						/>
 					</LI>
 				))}
@@ -46,6 +50,7 @@ export const FixedMediumSlowVI = ({
 							trail={trail}
 							containerPalette={containerPalette}
 							showAge={showAge}
+							imageLoading={imageLoading}
 						/>
 					</LI>
 				))}
@@ -62,6 +67,7 @@ export const FixedMediumSlowVI = ({
 							trail={trail}
 							containerPalette={containerPalette}
 							showAge={showAge}
+							imageLoading={imageLoading}
 						/>
 					</LI>
 				))}

--- a/dotcom-rendering/src/components/FixedMediumSlowVII.stories.tsx
+++ b/dotcom-rendering/src/components/FixedMediumSlowVII.stories.tsx
@@ -19,7 +19,11 @@ export default {
 
 export const Default = () => (
 	<FrontSection title="Fixed Medium Slow VII" showTopBorder={true}>
-		<FixedMediumSlowVII trails={trails} showAge={true} />
+		<FixedMediumSlowVII
+			trails={trails}
+			showAge={true}
+			imageLoading="eager"
+		/>
 	</FrontSection>
 );
 Default.storyName = 'FixedMediumSlowVII';

--- a/dotcom-rendering/src/components/FixedMediumSlowVII.tsx
+++ b/dotcom-rendering/src/components/FixedMediumSlowVII.tsx
@@ -6,9 +6,11 @@ import {
 import type { DCRContainerPalette, DCRFrontCard } from '../types/front';
 import { LI } from './Card/components/LI';
 import { UL } from './Card/components/UL';
+import { Loading } from './CardPicture';
 
 type Props = {
 	trails: DCRFrontCard[];
+	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
 };
@@ -17,6 +19,7 @@ export const FixedMediumSlowVII = ({
 	trails,
 	containerPalette,
 	showAge,
+	imageLoading,
 }: Props) => {
 	const firstSlice50 = trails.slice(0, 1);
 	const firstSlice25 = trails.slice(1, 3);
@@ -36,6 +39,7 @@ export const FixedMediumSlowVII = ({
 							trail={trail}
 							containerPalette={containerPalette}
 							showAge={showAge}
+							imageLoading={imageLoading}
 						/>
 					</LI>
 				))}
@@ -52,6 +56,7 @@ export const FixedMediumSlowVII = ({
 							trail={trail}
 							containerPalette={containerPalette}
 							showAge={showAge}
+							imageLoading={imageLoading}
 						/>
 					</LI>
 				))}
@@ -68,6 +73,7 @@ export const FixedMediumSlowVII = ({
 							trail={trail}
 							containerPalette={containerPalette}
 							showAge={showAge}
+							imageLoading={imageLoading}
 						/>
 					</LI>
 				))}

--- a/dotcom-rendering/src/components/FixedMediumSlowXIIMPU.stories.tsx
+++ b/dotcom-rendering/src/components/FixedMediumSlowXIIMPU.stories.tsx
@@ -24,6 +24,7 @@ export const OneTrail = () => (
 			showAge={true}
 			adIndex={1}
 			renderAds={true}
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );
@@ -36,6 +37,7 @@ export const TwoTrails = () => (
 			showAge={true}
 			adIndex={1}
 			renderAds={true}
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );
@@ -48,6 +50,7 @@ export const ThreeTrails = () => (
 			showAge={true}
 			adIndex={1}
 			renderAds={true}
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );
@@ -60,6 +63,7 @@ export const FourTrails = () => (
 			showAge={true}
 			adIndex={1}
 			renderAds={true}
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );
@@ -72,6 +76,7 @@ export const FiveTrails = () => (
 			showAge={true}
 			adIndex={1}
 			renderAds={true}
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );
@@ -84,6 +89,7 @@ export const SixTrails = () => (
 			showAge={true}
 			adIndex={1}
 			renderAds={true}
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );
@@ -96,6 +102,7 @@ export const SevenTrails = () => (
 			showAge={true}
 			adIndex={1}
 			renderAds={true}
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );
@@ -108,6 +115,7 @@ export const EightTrails = () => (
 			showAge={true}
 			adIndex={1}
 			renderAds={true}
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );
@@ -120,6 +128,7 @@ export const NineTrails = () => (
 			showAge={true}
 			adIndex={1}
 			renderAds={true}
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );
@@ -132,6 +141,7 @@ export const EightTrailsNoAds = () => (
 			showAge={true}
 			adIndex={1}
 			renderAds={false}
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );

--- a/dotcom-rendering/src/components/FixedMediumSlowXIIMPU.tsx
+++ b/dotcom-rendering/src/components/FixedMediumSlowXIIMPU.tsx
@@ -10,10 +10,12 @@ import type { DCRContainerPalette, DCRFrontCard } from '../types/front';
 import { AdSlot } from './AdSlot';
 import { LI } from './Card/components/LI';
 import { UL } from './Card/components/UL';
+import { Loading } from './CardPicture';
 
 type Props = {
 	trails: DCRFrontCard[];
 	containerPalette?: DCRContainerPalette;
+	imageLoading: Loading;
 	showAge?: boolean;
 	adIndex: number;
 	renderAds: boolean;
@@ -22,6 +24,7 @@ type Props = {
 
 type MPUSliceProps = {
 	trails: DCRFrontCard[];
+	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
 	adIndex: number;
@@ -37,8 +40,10 @@ const Card33_Card33_Card33 = ({
 	containerPalette,
 	showAge,
 	padBottom,
+	imageLoading,
 }: {
 	trails: DCRFrontCard[];
+	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
 	padBottom?: boolean;
@@ -54,6 +59,7 @@ const Card33_Card33_Card33 = ({
 						trail={trail}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						imageLoading={imageLoading}
 					/>
 				</LI>
 			))}
@@ -68,6 +74,7 @@ const Card33_Card33_Card33 = ({
 						trail={trail}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						imageLoading={imageLoading}
 					/>
 				</LI>
 			))}
@@ -85,8 +92,10 @@ const Card50_Card50 = ({
 	containerPalette,
 	showAge,
 	padBottom,
+	imageLoading,
 }: {
 	trails: DCRFrontCard[];
+	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
 	padBottom?: boolean;
@@ -101,6 +110,7 @@ const Card50_Card50 = ({
 						trail={trail}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						imageLoading={imageLoading}
 					/>
 				</LI>
 			))}
@@ -115,6 +125,7 @@ const Card50_Card50 = ({
 						trail={trail}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						imageLoading={imageLoading}
 					/>
 				</LI>
 			))}
@@ -138,6 +149,7 @@ const ThreeColumnSliceWithAdSlot = ({
 	containerPalette,
 	showAge,
 	adIndex,
+	imageLoading,
 }: MPUSliceProps) => {
 	return (
 		<UL direction="row">
@@ -198,6 +210,7 @@ export const FixedMediumSlowXIIMPU = ({
 	adIndex,
 	renderAds,
 	padBottom,
+	imageLoading,
 }: Props) => {
 	const firstSlice = trails.slice(0, 3);
 	const remaining = trails.slice(3, 9);
@@ -212,6 +225,7 @@ export const FixedMediumSlowXIIMPU = ({
 								containerPalette={containerPalette}
 								showAge={showAge}
 								key={trail.url}
+								imageLoading={imageLoading}
 							/>
 						))}
 					</LI>
@@ -221,6 +235,7 @@ export const FixedMediumSlowXIIMPU = ({
 					trails={trails}
 					containerPalette={containerPalette}
 					showAge={showAge}
+					imageLoading={imageLoading}
 				/>
 			) : (
 				<Card33_Card33_Card33
@@ -228,6 +243,7 @@ export const FixedMediumSlowXIIMPU = ({
 					containerPalette={containerPalette}
 					showAge={showAge}
 					padBottom={true}
+					imageLoading={imageLoading}
 				/>
 			)}
 			{renderAds && remaining.length > 0 ? (
@@ -236,6 +252,7 @@ export const FixedMediumSlowXIIMPU = ({
 					containerPalette={containerPalette}
 					showAge={showAge}
 					adIndex={adIndex}
+					imageLoading={imageLoading}
 				/>
 			) : (
 				/**

--- a/dotcom-rendering/src/components/FixedSmallFastVIII.stories.tsx
+++ b/dotcom-rendering/src/components/FixedSmallFastVIII.stories.tsx
@@ -19,7 +19,11 @@ export default {
 
 export const Default = () => (
 	<FrontSection title="Fixed Small Fast VIII" showTopBorder={true}>
-		<FixedSmallFastVIII trails={trails} showAge={true} />
+		<FixedSmallFastVIII
+			trails={trails}
+			showAge={true}
+			imageLoading="eager"
+		/>
 	</FrontSection>
 );
 Default.storyName = 'FixedSmallFastVIII';

--- a/dotcom-rendering/src/components/FixedSmallFastVIII.tsx
+++ b/dotcom-rendering/src/components/FixedSmallFastVIII.tsx
@@ -3,9 +3,11 @@ import { shouldPadWrappableRows } from '../lib/dynamicSlices';
 import type { DCRContainerPalette, DCRFrontCard } from '../types/front';
 import { LI } from './Card/components/LI';
 import { UL } from './Card/components/UL';
+import { Loading } from './CardPicture';
 
 type Props = {
 	trails: DCRFrontCard[];
+	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
 };
@@ -14,6 +16,7 @@ export const FixedSmallFastVIII = ({
 	trails,
 	containerPalette,
 	showAge,
+	imageLoading,
 }: Props) => {
 	if (!trails[0]) return null;
 	const firstSlice25 = trails.slice(0, 2);
@@ -33,6 +36,7 @@ export const FixedSmallFastVIII = ({
 							trail={card}
 							containerPalette={containerPalette}
 							showAge={showAge}
+							imageLoading={imageLoading}
 						/>
 					</LI>
 				);

--- a/dotcom-rendering/src/components/FixedSmallSlowI.stories.tsx
+++ b/dotcom-rendering/src/components/FixedSmallSlowI.stories.tsx
@@ -19,7 +19,7 @@ export default {
 
 export const Default = () => (
 	<FrontSection title="Fixed Small Slow I">
-		<FixedSmallSlowI trails={trails} showAge={true} />
+		<FixedSmallSlowI trails={trails} showAge={true} imageLoading="eager" />
 	</FrontSection>
 );
 Default.storyName = 'FixedSmallSlowI';

--- a/dotcom-rendering/src/components/FixedSmallSlowI.tsx
+++ b/dotcom-rendering/src/components/FixedSmallSlowI.tsx
@@ -2,9 +2,11 @@ import { Card100Media75 } from '../lib/cardWrappers';
 import type { DCRContainerPalette, DCRFrontCard } from '../types/front';
 import { LI } from './Card/components/LI';
 import { UL } from './Card/components/UL';
+import { Loading } from './CardPicture';
 
 type Props = {
 	trails: DCRFrontCard[];
+	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
 };
@@ -13,6 +15,7 @@ export const FixedSmallSlowI = ({
 	trails,
 	containerPalette,
 	showAge,
+	imageLoading,
 }: Props) => {
 	const firstSlice100 = trails.slice(0, 1);
 
@@ -24,6 +27,7 @@ export const FixedSmallSlowI = ({
 						trail={card}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						imageLoading={imageLoading}
 					/>
 				</LI>
 			))}

--- a/dotcom-rendering/src/components/FixedSmallSlowIII.stories.tsx
+++ b/dotcom-rendering/src/components/FixedSmallSlowIII.stories.tsx
@@ -19,7 +19,11 @@ export default {
 
 export const Default = () => (
 	<FrontSection title="Fixed Small Slow III">
-		<FixedSmallSlowIII trails={trails} showAge={true} />
+		<FixedSmallSlowIII
+			trails={trails}
+			showAge={true}
+			imageLoading="eager"
+		/>
 	</FrontSection>
 );
 Default.storyName = 'FixedSmallSlowIII';

--- a/dotcom-rendering/src/components/FixedSmallSlowIII.tsx
+++ b/dotcom-rendering/src/components/FixedSmallSlowIII.tsx
@@ -2,9 +2,11 @@ import { Card25Media25Tall, Card50Media50 } from '../lib/cardWrappers';
 import type { DCRContainerPalette, DCRFrontCard } from '../types/front';
 import { LI } from './Card/components/LI';
 import { UL } from './Card/components/UL';
+import { Loading } from './CardPicture';
 
 type Props = {
 	trails: DCRFrontCard[];
+	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
 };
@@ -13,6 +15,7 @@ export const FixedSmallSlowIII = ({
 	trails,
 	containerPalette,
 	showAge,
+	imageLoading,
 }: Props) => {
 	const firstSlice50 = trails.slice(0, 1);
 	const firstSlice25 = trails.slice(1, 3);
@@ -25,6 +28,7 @@ export const FixedSmallSlowIII = ({
 						trail={trail}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						imageLoading={imageLoading}
 					/>
 				</LI>
 			))}
@@ -40,6 +44,7 @@ export const FixedSmallSlowIII = ({
 						trail={trail}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						imageLoading={imageLoading}
 					/>
 				</LI>
 			))}

--- a/dotcom-rendering/src/components/FixedSmallSlowIV.stories.tsx
+++ b/dotcom-rendering/src/components/FixedSmallSlowIV.stories.tsx
@@ -19,7 +19,7 @@ export default {
 
 export const Default = () => (
 	<FrontSection title="Fixed Small Slow IV">
-		<FixedSmallSlowIV trails={trails} showAge={true} />
+		<FixedSmallSlowIV trails={trails} showAge={true} imageLoading="eager" />
 	</FrontSection>
 );
 Default.storyName = 'FixedSmallSlowIV';

--- a/dotcom-rendering/src/components/FixedSmallSlowIV.tsx
+++ b/dotcom-rendering/src/components/FixedSmallSlowIV.tsx
@@ -2,9 +2,11 @@ import { Card25Media25 } from '../lib/cardWrappers';
 import type { DCRContainerPalette, DCRFrontCard } from '../types/front';
 import { LI } from './Card/components/LI';
 import { UL } from './Card/components/UL';
+import { Loading } from './CardPicture';
 
 type Props = {
 	trails: DCRFrontCard[];
+	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
 };
@@ -13,6 +15,7 @@ export const FixedSmallSlowIV = ({
 	trails,
 	containerPalette,
 	showAge,
+	imageLoading,
 }: Props) => {
 	const firstSlice25 = trails.slice(0, 4);
 
@@ -30,6 +33,7 @@ export const FixedSmallSlowIV = ({
 							trail={trail}
 							containerPalette={containerPalette}
 							showAge={showAge}
+							imageLoading={imageLoading}
 						/>
 					</LI>
 				);

--- a/dotcom-rendering/src/components/FixedSmallSlowVHalf.stories.tsx
+++ b/dotcom-rendering/src/components/FixedSmallSlowVHalf.stories.tsx
@@ -19,7 +19,11 @@ export default {
 
 export const Default = () => (
 	<FrontSection title="Fixed Small Slow V Half">
-		<FixedSmallSlowVHalf trails={trails} showAge={true} />
+		<FixedSmallSlowVHalf
+			trails={trails}
+			showAge={true}
+			imageLoading="eager"
+		/>
 	</FrontSection>
 );
 Default.storyName = 'FixedSmallSlowVHalf';

--- a/dotcom-rendering/src/components/FixedSmallSlowVHalf.tsx
+++ b/dotcom-rendering/src/components/FixedSmallSlowVHalf.tsx
@@ -2,9 +2,11 @@ import { Card50Media50, CardDefaultMediaMobile } from '../lib/cardWrappers';
 import type { DCRContainerPalette, DCRFrontCard } from '../types/front';
 import { LI } from './Card/components/LI';
 import { UL } from './Card/components/UL';
+import { Loading } from './CardPicture';
 
 type Props = {
 	trails: DCRFrontCard[];
+	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
 };
@@ -13,6 +15,7 @@ export const FixedSmallSlowVHalf = ({
 	trails,
 	containerPalette,
 	showAge,
+	imageLoading,
 }: Props) => {
 	const firstSlice50 = trails.slice(0, 1);
 	const remaining = trails.slice(1, 5);
@@ -32,6 +35,7 @@ export const FixedSmallSlowVHalf = ({
 							trail={trail}
 							containerPalette={containerPalette}
 							showAge={showAge}
+							imageLoading={imageLoading}
 						/>
 					</LI>
 				);
@@ -45,6 +49,7 @@ export const FixedSmallSlowVHalf = ({
 									trail={trail}
 									containerPalette={containerPalette}
 									showAge={showAge}
+									imageLoading={imageLoading}
 								/>
 							</LI>
 						);

--- a/dotcom-rendering/src/components/FixedSmallSlowVMPU.stories.tsx
+++ b/dotcom-rendering/src/components/FixedSmallSlowVMPU.stories.tsx
@@ -24,6 +24,7 @@ export const FourCards = () => (
 			showAge={true}
 			adIndex={1}
 			renderAds={true}
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );
@@ -37,6 +38,7 @@ export const ThreeCards = () => (
 			showAge={true}
 			adIndex={1}
 			renderAds={true}
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );
@@ -50,6 +52,7 @@ export const TwoCards = () => (
 			showAge={true}
 			adIndex={1}
 			renderAds={true}
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );
@@ -63,6 +66,7 @@ export const OneCard = () => (
 			showAge={true}
 			adIndex={1}
 			renderAds={true}
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );
@@ -76,6 +80,7 @@ export const AdfreeFixedSmallSlowVMPU = () => (
 			showAge={true}
 			adIndex={1}
 			renderAds={false}
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );

--- a/dotcom-rendering/src/components/FixedSmallSlowVMPU.tsx
+++ b/dotcom-rendering/src/components/FixedSmallSlowVMPU.tsx
@@ -8,9 +8,11 @@ import type { DCRContainerPalette, DCRFrontCard } from '../types/front';
 import { AdSlot } from './AdSlot';
 import { LI } from './Card/components/LI';
 import { UL } from './Card/components/UL';
+import { Loading } from './CardPicture';
 
 type Props = {
 	trails: DCRFrontCard[];
+	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
 	adIndex: number;
@@ -23,6 +25,7 @@ export const FixedSmallSlowVMPU = ({
 	showAge,
 	adIndex,
 	renderAds,
+	imageLoading,
 }: Props) => {
 	const firstSlice33 = trails.slice(0, 1);
 	const remaining = trails.slice(1, 4);
@@ -35,6 +38,7 @@ export const FixedSmallSlowVMPU = ({
 							trail={trail}
 							containerPalette={containerPalette}
 							showAge={showAge}
+							imageLoading={imageLoading}
 						/>
 					</LI>
 				))}
@@ -82,6 +86,7 @@ export const FixedSmallSlowVMPU = ({
 								trail={card}
 								containerPalette={containerPalette}
 								showAge={showAge}
+								imageLoading={imageLoading}
 							/>
 						</LI>
 					);

--- a/dotcom-rendering/src/components/FixedSmallSlowVThird.stories.tsx
+++ b/dotcom-rendering/src/components/FixedSmallSlowVThird.stories.tsx
@@ -19,7 +19,11 @@ export default {
 
 export const Default = () => (
 	<FrontSection title="Fixed Small Slow V Third">
-		<FixedSmallSlowVThird trails={trails} showAge={true} />
+		<FixedSmallSlowVThird
+			trails={trails}
+			showAge={true}
+			imageLoading="eager"
+		/>
 	</FrontSection>
 );
 Default.storyName = 'FixedSmallSlowVThird';

--- a/dotcom-rendering/src/components/FixedSmallSlowVThird.tsx
+++ b/dotcom-rendering/src/components/FixedSmallSlowVThird.tsx
@@ -2,10 +2,12 @@ import { Card25Media25 } from '../lib/cardWrappers';
 import type { DCRContainerPalette, DCRFrontCard } from '../types/front';
 import { LI } from './Card/components/LI';
 import { UL } from './Card/components/UL';
+import { Loading } from './CardPicture';
 import { FrontCard } from './FrontCard';
 
 type Props = {
 	trails: DCRFrontCard[];
+	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
 };
@@ -14,6 +16,7 @@ export const FixedSmallSlowVThird = ({
 	trails,
 	containerPalette,
 	showAge,
+	imageLoading,
 }: Props) => {
 	const firstSlice25 = trails.slice(0, 2);
 	const remaining = trails.slice(2, 5);
@@ -33,6 +36,7 @@ export const FixedSmallSlowVThird = ({
 							trail={trail}
 							containerPalette={containerPalette}
 							showAge={showAge}
+							imageLoading={imageLoading}
 						/>
 					</LI>
 				);
@@ -54,6 +58,7 @@ export const FixedSmallSlowVThird = ({
 									imagePosition="left"
 									imagePositionOnMobile="none"
 									imageSize="small"
+									imageLoading={imageLoading}
 								/>
 							</LI>
 						);

--- a/dotcom-rendering/src/components/FrontCard.tsx
+++ b/dotcom-rendering/src/components/FrontCard.tsx
@@ -5,7 +5,8 @@ import { Card } from './Card/Card';
 
 type Props = {
 	trail: DCRFrontCard;
-} & Partial<CardProps>;
+} & Partial<CardProps> &
+	Pick<CardProps, 'imageLoading'>;
 
 /**
  * A wrapper around the normal Card component providing sensible defaults for Cards on front containers.
@@ -25,7 +26,7 @@ type Props = {
  */
 export const FrontCard = (props: Props) => {
 	const { trail, ...cardProps } = props;
-	const defaultProps: CardProps = {
+	const defaultProps: Omit<CardProps, 'imageLoading'> = {
 		linkTo: trail.url,
 		format: trail.format,
 		headlineText: trail.headline,

--- a/dotcom-rendering/src/components/NewsletterCard.tsx
+++ b/dotcom-rendering/src/components/NewsletterCard.tsx
@@ -207,6 +207,7 @@ export const NewsletterCard = ({
 						imageSize="carousel"
 						alt=""
 						master={newsletter.illustrationCard}
+						loading="lazy"
 					/>
 				</div>
 			) : (

--- a/dotcom-rendering/src/components/Palettes.stories.tsx
+++ b/dotcom-rendering/src/components/Palettes.stories.tsx
@@ -34,6 +34,7 @@ export const EventPalette = () => (
 			groupedTrails={groupedTrails}
 			containerPalette="EventPalette"
 			showAge={true}
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );
@@ -60,6 +61,7 @@ export const EventAltPalette = () => (
 			groupedTrails={groupedTrails}
 			containerPalette="EventAltPalette"
 			showAge={true}
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );
@@ -75,6 +77,7 @@ export const SombrePalette = () => (
 			groupedTrails={groupedTrails}
 			containerPalette="SombrePalette"
 			showAge={true}
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );
@@ -90,6 +93,7 @@ export const SombreAltPalette = () => (
 			groupedTrails={groupedTrails}
 			containerPalette="SombreAltPalette"
 			showAge={true}
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );
@@ -105,6 +109,7 @@ export const BreakingPalette = () => (
 			groupedTrails={groupedTrails}
 			containerPalette="BreakingPalette"
 			showAge={true}
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );
@@ -120,6 +125,7 @@ export const LongRunningPalette = () => (
 			groupedTrails={groupedTrails}
 			containerPalette="LongRunningPalette"
 			showAge={true}
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );
@@ -135,6 +141,7 @@ export const LongRunningAltPalette = () => (
 			groupedTrails={groupedTrails}
 			containerPalette="LongRunningAltPalette"
 			showAge={true}
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );
@@ -150,6 +157,7 @@ export const InvestigationPalette = () => (
 			groupedTrails={groupedTrails}
 			containerPalette="InvestigationPalette"
 			showAge={true}
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );
@@ -165,6 +173,7 @@ export const SpecialReportAltPalette = () => (
 			groupedTrails={groupedTrails}
 			containerPalette="SpecialReportAltPalette"
 			showAge={true}
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );
@@ -183,6 +192,7 @@ export const BrandedPalette = () => (
 			groupedTrails={groupedTrails}
 			containerPalette="Branded"
 			showAge={true}
+			imageLoading="eager"
 		/>
 	</LabsSection>
 );
@@ -198,6 +208,7 @@ export const MediaPalette = () => (
 			groupedTrails={groupedTrails}
 			containerPalette="MediaPalette"
 			showAge={true}
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );
@@ -216,6 +227,7 @@ export const PodcastPalette = () => (
 			groupedTrails={groupedTrails}
 			containerPalette="PodcastPalette"
 			showAge={true}
+			imageLoading="eager"
 		/>
 	</FrontSection>
 );

--- a/dotcom-rendering/src/components/ShowMore.importable.tsx
+++ b/dotcom-rendering/src/components/ShowMore.importable.tsx
@@ -170,6 +170,7 @@ export const ShowMore = ({
 											containerPalette={containerPalette}
 											showAge={showAge}
 											headlineSize="small"
+											imageLoading="eager"
 										/>
 									</LI>
 								);

--- a/dotcom-rendering/src/components/Slideshow.tsx
+++ b/dotcom-rendering/src/components/Slideshow.tsx
@@ -188,6 +188,7 @@ export const Slideshow = ({
 	return (
 		<>
 			{images.map((slideshowImage, index) => {
+				const loading = index === 0 ? 'eager' : 'lazy';
 				return (
 					<figure
 						key={slideshowImage.imageSrc}
@@ -208,6 +209,7 @@ export const Slideshow = ({
 							master={slideshowImage.imageSrc}
 							imageSize={imageSize}
 							alt={slideshowImage.imageCaption}
+							loading={loading}
 						/>
 						<figcaption
 							css={[

--- a/dotcom-rendering/src/components/SupportingContent.stories.tsx
+++ b/dotcom-rendering/src/components/SupportingContent.stories.tsx
@@ -33,6 +33,7 @@ const basicCardProps: CardProps = {
 	isExternalLink: false,
 	showLivePlayable: false,
 	isPlayableMediaCard: true,
+	imageLoading: 'eager',
 };
 
 const aBasicLink = {

--- a/dotcom-rendering/src/components/TagFrontFastMpu.stories.tsx
+++ b/dotcom-rendering/src/components/TagFrontFastMpu.stories.tsx
@@ -28,6 +28,7 @@ export const WithTwoCards = () => {
 				year={2023}
 				trails={[trails[0], trails[1]]}
 				adIndex={1}
+				imageLoading="eager"
 			/>
 		</FrontSection>
 	);
@@ -45,6 +46,7 @@ export const WithFourCards = () => {
 				year={2023}
 				trails={[trails[0], trails[1], trails[2], trails[3]]}
 				adIndex={1}
+				imageLoading="eager"
 			/>
 		</FrontSection>
 	);
@@ -69,6 +71,7 @@ export const WithSixCards = () => {
 					trails[5],
 				]}
 				adIndex={1}
+				imageLoading="eager"
 			/>
 		</FrontSection>
 	);
@@ -96,6 +99,7 @@ export const WithNineCards = () => {
 					trails[8],
 				]}
 				adIndex={1}
+				imageLoading="eager"
 			/>
 		</FrontSection>
 	);

--- a/dotcom-rendering/src/components/TagFrontFastMpu.tsx
+++ b/dotcom-rendering/src/components/TagFrontFastMpu.tsx
@@ -6,21 +6,32 @@ import type { GroupedTrailsFastMpu } from '../types/tagFront';
 import { AdSlot } from './AdSlot';
 import { LI } from './Card/components/LI';
 import { UL } from './Card/components/UL';
+import { Loading } from './CardPicture';
 
 const TwoCard = ({
 	trails,
 	adIndex,
+	imageLoading,
 }: {
 	trails: Tuple<DCRFrontCard, 2>;
 	adIndex: number;
+	imageLoading: Loading;
 }) => {
 	return (
 		<UL direction="row">
 			<LI percentage="33.333%" padSides={true}>
-				<Card33Media33 trail={trails[0]} showAge={true} />
+				<Card33Media33
+					trail={trails[0]}
+					showAge={true}
+					imageLoading={imageLoading}
+				/>
 			</LI>
 			<LI percentage="33.333%" padSides={true} showDivider={true}>
-				<Card33Media33 trail={trails[1]} showAge={true} />
+				<Card33Media33
+					trail={trails[1]}
+					showAge={true}
+					imageLoading={imageLoading}
+				/>
 			</LI>
 			<LI percentage="33.333%" padSides={true} showDivider={true}>
 				<Hide until="tablet">
@@ -34,14 +45,20 @@ const TwoCard = ({
 const FourCard = ({
 	trails,
 	adIndex,
+	imageLoading,
 }: {
 	trails: Tuple<DCRFrontCard, 4>;
 	adIndex: number;
+	imageLoading: Loading;
 }) => {
 	return (
 		<UL direction="row">
 			<LI percentage="33.333%" padSides={true}>
-				<Card33Media33 trail={trails[0]} showAge={true} />
+				<Card33Media33
+					trail={trails[0]}
+					showAge={true}
+					imageLoading={imageLoading}
+				/>
 			</LI>
 			<LI percentage="33.333%">
 				<UL direction="column" showDivider={true}>
@@ -112,21 +129,35 @@ const SixCard = ({
 const NineCard = ({
 	trails,
 	adIndex,
+	imageLoading,
 }: {
 	trails: Tuple<DCRFrontCard, 9>;
 	adIndex: number;
+	imageLoading: Loading;
 }) => {
 	return (
 		<>
 			<UL direction="row" padBottom={true}>
 				<LI percentage="33.333%" padSides={true}>
-					<Card33Media33 trail={trails[0]} showAge={true} />
+					<Card33Media33
+						trail={trails[0]}
+						showAge={true}
+						imageLoading={imageLoading}
+					/>
 				</LI>
 				<LI percentage="33.333%" padSides={true} showDivider={true}>
-					<Card33Media33 trail={trails[1]} showAge={true} />
+					<Card33Media33
+						trail={trails[1]}
+						showAge={true}
+						imageLoading={imageLoading}
+					/>
 				</LI>
 				<LI percentage="33.333%" padSides={true} showDivider={true}>
-					<Card33Media33 trail={trails[2]} showAge={true} />
+					<Card33Media33
+						trail={trails[2]}
+						showAge={true}
+						imageLoading={imageLoading}
+					/>
 				</LI>
 			</UL>
 			<UL direction="row">
@@ -168,17 +199,36 @@ const NineCard = ({
 
 type Props = GroupedTrailsFastMpu & {
 	adIndex: number;
+	imageLoading: Loading;
 };
 
-export const TagFrontFastMpu = ({ trails, adIndex }: Props) => {
+export const TagFrontFastMpu = ({ trails, adIndex, imageLoading }: Props) => {
 	switch (trails.length) {
 		case 2:
-			return <TwoCard trails={trails} adIndex={adIndex} />;
+			return (
+				<TwoCard
+					trails={trails}
+					adIndex={adIndex}
+					imageLoading={imageLoading}
+				/>
+			);
 		case 4:
-			return <FourCard trails={trails} adIndex={adIndex} />;
+			return (
+				<FourCard
+					trails={trails}
+					adIndex={adIndex}
+					imageLoading={imageLoading}
+				/>
+			);
 		case 6:
 			return <SixCard trails={trails} adIndex={adIndex} />;
 		case 9:
-			return <NineCard trails={trails} adIndex={adIndex} />;
+			return (
+				<NineCard
+					trails={trails}
+					adIndex={adIndex}
+					imageLoading={imageLoading}
+				/>
+			);
 	}
 };

--- a/dotcom-rendering/src/components/TagFrontSlowMpu.stories.tsx
+++ b/dotcom-rendering/src/components/TagFrontSlowMpu.stories.tsx
@@ -28,6 +28,7 @@ export const WithTwoCards = () => {
 				year={2023}
 				trails={[trails[0], trails[1]]}
 				adIndex={1}
+				imageLoading="eager"
 			/>
 		</FrontSection>
 	);
@@ -45,6 +46,7 @@ export const WithFourCards = () => {
 				year={2023}
 				trails={[trails[0], trails[1], trails[2], trails[3]]}
 				adIndex={1}
+				imageLoading="eager"
 			/>
 		</FrontSection>
 	);
@@ -62,6 +64,7 @@ export const WithFiveCards = () => {
 				year={2023}
 				trails={[trails[0], trails[1], trails[2], trails[3], trails[4]]}
 				adIndex={1}
+				imageLoading="eager"
 			/>
 		</FrontSection>
 	);
@@ -87,6 +90,7 @@ export const WithSevenCards = () => {
 					trails[6],
 				]}
 				adIndex={1}
+				imageLoading="eager"
 			/>
 		</FrontSection>
 	);

--- a/dotcom-rendering/src/components/TagFrontSlowMpu.tsx
+++ b/dotcom-rendering/src/components/TagFrontSlowMpu.tsx
@@ -6,21 +6,32 @@ import type { GroupedTrailsSlowMpu } from '../types/tagFront';
 import { AdSlot } from './AdSlot';
 import { LI } from './Card/components/LI';
 import { UL } from './Card/components/UL';
+import { Loading } from './CardPicture';
 
 const TwoCard = ({
 	trails,
 	adIndex,
+	imageLoading,
 }: {
 	trails: Tuple<DCRFrontCard, 2>;
 	adIndex: number;
+	imageLoading: Loading;
 }) => {
 	return (
 		<UL direction="row">
 			<LI percentage="33.333%" padSides={true}>
-				<Card33Media33 trail={trails[0]} showAge={true} />
+				<Card33Media33
+					trail={trails[0]}
+					showAge={true}
+					imageLoading={imageLoading}
+				/>
 			</LI>
 			<LI percentage="33.333%" padSides={true} showDivider={true}>
-				<Card33Media33 trail={trails[1]} showAge={true} />
+				<Card33Media33
+					trail={trails[1]}
+					showAge={true}
+					imageLoading={imageLoading}
+				/>
 			</LI>
 			<LI percentage="33.333%" padSides={true} showDivider={true}>
 				<Hide until="tablet">
@@ -34,14 +45,20 @@ const TwoCard = ({
 const FourCard = ({
 	trails,
 	adIndex,
+	imageLoading,
 }: {
 	trails: Tuple<DCRFrontCard, 4>;
 	adIndex: number;
+	imageLoading: Loading;
 }) => {
 	return (
 		<UL direction="row">
 			<LI percentage="33.333%" padSides={true}>
-				<Card33Media33 trail={trails[0]} showAge={true} />
+				<Card33Media33
+					trail={trails[0]}
+					showAge={true}
+					imageLoading={imageLoading}
+				/>
 			</LI>
 			<LI percentage="33.333%">
 				<UL direction="column" showDivider={true}>
@@ -68,29 +85,51 @@ const FourCard = ({
 const FiveCard = ({
 	trails,
 	adIndex,
+	imageLoading,
 }: {
 	trails: Tuple<DCRFrontCard, 5>;
 	adIndex: number;
+	imageLoading: Loading;
 }) => {
 	return (
 		<>
 			<UL direction="row" padBottom={true}>
 				<LI percentage="33.333%" padSides={true}>
-					<Card33Media33 trail={trails[0]} showAge={true} />
+					<Card33Media33
+						trail={trails[0]}
+						showAge={true}
+						imageLoading={imageLoading}
+					/>
 				</LI>
 				<LI percentage="33.333%" padSides={true} showDivider={true}>
-					<Card33Media33 trail={trails[1]} showAge={true} />
+					<Card33Media33
+						trail={trails[1]}
+						showAge={true}
+						imageLoading={imageLoading}
+					/>
 				</LI>
 				<LI percentage="33.333%" padSides={true} showDivider={true}>
-					<Card33Media33 trail={trails[2]} showAge={true} />
+					<Card33Media33
+						trail={trails[2]}
+						showAge={true}
+						imageLoading={imageLoading}
+					/>
 				</LI>
 			</UL>
 			<UL direction="row">
 				<LI percentage="33.333%" padSides={true}>
-					<Card33Media33 trail={trails[3]} showAge={true} />
+					<Card33Media33
+						trail={trails[3]}
+						showAge={true}
+						imageLoading={imageLoading}
+					/>
 				</LI>
 				<LI percentage="33.333%" padSides={true} showDivider={true}>
-					<Card33Media33 trail={trails[4]} showAge={true} />
+					<Card33Media33
+						trail={trails[4]}
+						showAge={true}
+						imageLoading={imageLoading}
+					/>
 				</LI>
 				<LI percentage="33.333%" padSides={true} showDivider={true}>
 					<Hide until="tablet">
@@ -105,37 +144,67 @@ const FiveCard = ({
 const SevenCards = ({
 	trails,
 	adIndex,
+	imageLoading,
 }: {
 	trails: Tuple<DCRFrontCard, 7>;
 	adIndex: number;
+	imageLoading: Loading;
 }) => {
 	return (
 		<>
 			<UL direction="row" padBottom={true}>
 				<LI percentage="50%" padSides={true}>
-					<Card50Media50 trail={trails[0]} showAge={true} />
+					<Card50Media50
+						trail={trails[0]}
+						showAge={true}
+						imageLoading={imageLoading}
+					/>
 				</LI>
 				<LI percentage="50%" padSides={true} showDivider={true}>
-					<Card50Media50 trail={trails[1]} showAge={true} />
+					<Card50Media50
+						trail={trails[1]}
+						showAge={true}
+						imageLoading={imageLoading}
+					/>
 				</LI>
 			</UL>
 			<UL direction="row" padBottom={true}>
 				<LI percentage="33.333%" padSides={true}>
-					<Card33Media33 trail={trails[2]} showAge={true} />
+					<Card33Media33
+						trail={trails[2]}
+						showAge={true}
+						imageLoading={imageLoading}
+					/>
 				</LI>
 				<LI percentage="33.333%" padSides={true} showDivider={true}>
-					<Card33Media33 trail={trails[3]} showAge={true} />
+					<Card33Media33
+						trail={trails[3]}
+						showAge={true}
+						imageLoading={imageLoading}
+					/>
 				</LI>
 				<LI percentage="33.333%" padSides={true} showDivider={true}>
-					<Card33Media33 trail={trails[4]} showAge={true} />
+					<Card33Media33
+						trail={trails[4]}
+						showAge={true}
+						imageLoading={imageLoading}
+					/>
 				</LI>
 			</UL>
 			<UL direction="row">
 				<LI percentage="33.333%" padSides={true}>
-					<Card33Media33 trail={trails[5]} showAge={true} />
+					<Card33Media33
+						trail={trails[5]}
+						showAge={true}
+						imageLoading={imageLoading}
+					/>
 				</LI>
 				<LI percentage="33.333%" padSides={true} showDivider={true}>
-					<Card33Media33 trail={trails[6]} showAge={true} />
+					<Card33Media33
+						trail={trails[6]}
+						showAge={true}
+						imageLoading={imageLoading}
+					/>
 				</LI>
 				<LI percentage="33.333%" padSides={true} showDivider={true}>
 					<Hide until="tablet">
@@ -149,17 +218,42 @@ const SevenCards = ({
 
 type Props = GroupedTrailsSlowMpu & {
 	adIndex: number;
+	imageLoading: Loading;
 };
 
-export const TagFrontSlowMpu = ({ trails, adIndex }: Props) => {
+export const TagFrontSlowMpu = ({ trails, adIndex, imageLoading }: Props) => {
 	switch (trails.length) {
 		case 2:
-			return <TwoCard trails={trails} adIndex={adIndex} />;
+			return (
+				<TwoCard
+					trails={trails}
+					adIndex={adIndex}
+					imageLoading={imageLoading}
+				/>
+			);
 		case 4:
-			return <FourCard trails={trails} adIndex={adIndex} />;
+			return (
+				<FourCard
+					trails={trails}
+					adIndex={adIndex}
+					imageLoading={imageLoading}
+				/>
+			);
 		case 5:
-			return <FiveCard trails={trails} adIndex={adIndex} />;
+			return (
+				<FiveCard
+					trails={trails}
+					adIndex={adIndex}
+					imageLoading={imageLoading}
+				/>
+			);
 		case 7:
-			return <SevenCards trails={trails} adIndex={adIndex} />;
+			return (
+				<SevenCards
+					trails={trails}
+					adIndex={adIndex}
+					imageLoading={imageLoading}
+				/>
+			);
 	}
 };

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -330,7 +330,11 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 					// There are some containers that have zero trails. We don't want to render these
 					if (!trail) return null;
 
-					const imageLoading = index > 0 ? 'lazy' : 'eager';
+					const imageLoading =
+						front.config.abTests.lazyLoadImagesVariant ===
+							'variant' && index > 0
+							? 'lazy'
+							: 'eager';
 
 					const ophanName = ophanComponentId(collection.displayName);
 					const ophanComponentLink = `container-${

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -330,6 +330,8 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 					// There are some containers that have zero trails. We don't want to render these
 					if (!trail) return null;
 
+					const imageLoading = index > 0 ? 'lazy' : 'eager';
+
 					const ophanName = ophanComponentId(collection.displayName);
 					const ophanComponentLink = `container-${
 						index + 1
@@ -493,6 +495,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 									containerPalette={
 										collection.containerPalette
 									}
+									imageLoading={imageLoading}
 									adIndex={desktopAdPositions.indexOf(index)}
 									renderAds={false}
 								/>
@@ -622,6 +625,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 											collection.displayName,
 										)
 									}
+									imageLoading={imageLoading}
 									adIndex={desktopAdPositions.indexOf(index)}
 									renderAds={renderAds}
 								/>

--- a/dotcom-rendering/src/layouts/TagFrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/TagFrontLayout.tsx
@@ -213,7 +213,11 @@ export const TagFrontLayout = ({ tagFront, NAV }: Props) => {
 						groupedTrails.day !== undefined,
 					);
 
-					const imageLoading = index > 0 ? 'lazy' : 'eager';
+					const imageLoading =
+						tagFront.config.abTests.lazyLoadImagesVariant ===
+							'variant' && index > 0
+							? 'lazy'
+							: 'eager';
 
 					const ContainerComponent = () => {
 						if (

--- a/dotcom-rendering/src/layouts/TagFrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/TagFrontLayout.tsx
@@ -213,6 +213,8 @@ export const TagFrontLayout = ({ tagFront, NAV }: Props) => {
 						groupedTrails.day !== undefined,
 					);
 
+					const imageLoading = index > 0 ? 'lazy' : 'eager';
+
 					const ContainerComponent = () => {
 						if (
 							'injected' in groupedTrails &&
@@ -223,6 +225,7 @@ export const TagFrontLayout = ({ tagFront, NAV }: Props) => {
 									<TagFrontFastMpu
 										{...groupedTrails}
 										adIndex={1} // There is only ever 1 inline ad in a tag front
+										imageLoading={imageLoading}
 									/>
 								);
 							} else {
@@ -230,6 +233,7 @@ export const TagFrontLayout = ({ tagFront, NAV }: Props) => {
 									<TagFrontSlowMpu
 										{...groupedTrails}
 										adIndex={1} // There is only ever 1 inline ad in a tag front
+										imageLoading={imageLoading}
 									/>
 								);
 							}
@@ -238,6 +242,7 @@ export const TagFrontLayout = ({ tagFront, NAV }: Props) => {
 							<DecideContainerByTrails
 								trails={groupedTrails.trails}
 								speed={tagFront.speed}
+								imageLoading={imageLoading}
 							/>
 						);
 					};

--- a/dotcom-rendering/src/lib/cardWrappers.tsx
+++ b/dotcom-rendering/src/lib/cardWrappers.tsx
@@ -1,8 +1,10 @@
+import { Loading } from '../components/CardPicture';
 import { FrontCard } from '../components/FrontCard';
 import type { DCRContainerPalette, DCRFrontCard } from '../types/front';
 
 type TrailProps = {
 	trail: DCRFrontCard;
+	imageLoading: Loading;
 	showAge?: boolean;
 	containerPalette?: DCRContainerPalette;
 };
@@ -43,9 +45,11 @@ export const Card100Media50 = ({
 	trail,
 	showAge,
 	containerPalette,
+	imageLoading,
 }: TrailProps) => {
 	return (
 		<FrontCard
+			imageLoading={imageLoading}
 			trail={trail}
 			containerPalette={containerPalette}
 			showAge={showAge}
@@ -90,6 +94,7 @@ export const Card100Media75 = ({
 	trail,
 	showAge,
 	containerPalette,
+	imageLoading,
 }: TrailProps) => {
 	return (
 		<FrontCard
@@ -102,6 +107,7 @@ export const Card100Media75 = ({
 			imageSize="jumbo"
 			imagePosition="right"
 			imagePositionOnMobile="top"
+			imageLoading={imageLoading}
 			trailText={
 				// Only show trail text if there is no supportContent
 				trail.supportingContent === undefined ||
@@ -138,6 +144,7 @@ export const Card100Media100 = ({
 	trail,
 	showAge,
 	containerPalette,
+	imageLoading,
 }: TrailProps) => {
 	return (
 		<FrontCard
@@ -149,6 +156,7 @@ export const Card100Media100 = ({
 			imageUrl={trail.image}
 			imagePosition="top"
 			imagePositionOnMobile="top"
+			imageLoading={imageLoading}
 			supportingContent={trail.supportingContent?.slice(0, 4)}
 			supportingContentAlignment="horizontal"
 		/>
@@ -175,6 +183,7 @@ export const Card100Media100Tall = ({
 	trail,
 	showAge,
 	containerPalette,
+	imageLoading,
 }: TrailProps) => {
 	return (
 		<FrontCard
@@ -186,6 +195,7 @@ export const Card100Media100Tall = ({
 			imageUrl={trail.image}
 			imagePosition="top"
 			imagePositionOnMobile="top"
+			imageLoading={imageLoading}
 			supportingContent={trail.supportingContent?.slice(0, 2)}
 			supportingContentAlignment="vertical"
 			trailText={trail.trailText}
@@ -211,6 +221,7 @@ export const Card75Media50Right = ({
 	trail,
 	showAge,
 	containerPalette,
+	imageLoading,
 }: TrailProps) => {
 	return (
 		<FrontCard
@@ -227,6 +238,7 @@ export const Card75Media50Right = ({
 			imagePosition="right"
 			imageSize="large"
 			imagePositionOnMobile="top"
+			imageLoading={imageLoading}
 			headlineSize="large"
 			headlineSizeOnMobile="large"
 		/>
@@ -251,6 +263,7 @@ export const Card75Media50Left = ({
 	trail,
 	showAge,
 	containerPalette,
+	imageLoading,
 }: TrailProps) => {
 	return (
 		<FrontCard
@@ -267,6 +280,7 @@ export const Card75Media50Left = ({
 			imagePosition="left"
 			imagePositionOnMobile="top"
 			imageSize="large"
+			imageLoading={imageLoading}
 			headlineSize="large"
 			headlineSizeOnMobile="large"
 		/>
@@ -291,6 +305,7 @@ export const Card25Media25 = ({
 	trail,
 	showAge,
 	containerPalette,
+	imageLoading,
 }: TrailProps) => {
 	return (
 		<FrontCard
@@ -302,6 +317,7 @@ export const Card25Media25 = ({
 			imagePosition="top"
 			imagePositionOnMobile="left"
 			imageSize="small"
+			imageLoading={imageLoading}
 			headlineSize="medium"
 			headlineSizeOnMobile="medium"
 			isPlayableMediaCard={false}
@@ -327,6 +343,7 @@ export const Card25Media25SmallHeadline = ({
 	trail,
 	showAge,
 	containerPalette,
+	imageLoading,
 }: TrailProps) => {
 	return (
 		<FrontCard
@@ -338,6 +355,7 @@ export const Card25Media25SmallHeadline = ({
 			imagePosition="top"
 			imagePositionOnMobile="left"
 			imageSize="small"
+			imageLoading={imageLoading}
 			headlineSize="small"
 			headlineSizeOnMobile="medium"
 			isPlayableMediaCard={false}
@@ -364,6 +382,7 @@ export const Card25Media25Tall = ({
 	trail,
 	showAge,
 	containerPalette,
+	imageLoading,
 }: TrailProps) => {
 	return (
 		<FrontCard
@@ -373,6 +392,7 @@ export const Card25Media25Tall = ({
 			imagePosition="top"
 			imagePositionOnMobile="left"
 			imageSize="small"
+			imageLoading={imageLoading}
 			headlineSize="medium"
 			headlineSizeOnMobile="medium"
 			trailText={
@@ -406,6 +426,7 @@ export const Card25Media25TallNoTrail = ({
 	trail,
 	showAge,
 	containerPalette,
+	imageLoading,
 }: TrailProps) => {
 	return (
 		<FrontCard
@@ -415,6 +436,7 @@ export const Card25Media25TallNoTrail = ({
 			imagePosition="top"
 			imagePositionOnMobile="left"
 			imageSize="small"
+			imageLoading={imageLoading}
 			headlineSize="medium"
 			headlineSizeOnMobile="medium"
 			supportingContent={trail.supportingContent?.slice(0, 2)}
@@ -441,6 +463,7 @@ export const Card25Media25TallSmallHeadline = ({
 	trail,
 	showAge,
 	containerPalette,
+	imageLoading,
 }: TrailProps) => {
 	return (
 		<FrontCard
@@ -450,6 +473,7 @@ export const Card25Media25TallSmallHeadline = ({
 			imagePosition="top"
 			imagePositionOnMobile="left"
 			imageSize="small"
+			imageLoading={imageLoading}
 			headlineSize="small"
 			headlineSizeOnMobile="medium"
 			supportingContent={trail.supportingContent?.slice(0, 2)}
@@ -476,6 +500,7 @@ export const Card50Media50 = ({
 	trail,
 	showAge,
 	containerPalette,
+	imageLoading,
 }: TrailProps) => {
 	return (
 		<FrontCard
@@ -486,6 +511,7 @@ export const Card50Media50 = ({
 			imageSize="medium"
 			imagePosition="top"
 			imagePositionOnMobile="top"
+			imageLoading={imageLoading}
 			showAge={showAge}
 			supportingContent={trail.supportingContent?.slice(0, 3)}
 			supportingContentAlignment="horizontal"
@@ -512,6 +538,7 @@ export const Card50Media50Tall = ({
 	trail,
 	showAge,
 	containerPalette,
+	imageLoading,
 }: TrailProps) => {
 	return (
 		<FrontCard
@@ -524,6 +551,7 @@ export const Card50Media50Tall = ({
 			imagePosition="top"
 			imagePositionOnMobile="top"
 			imageSize="medium"
+			imageLoading={imageLoading}
 			headlineSize="large"
 			headlineSizeOnMobile="large"
 		/>
@@ -548,6 +576,7 @@ export const Card66Media66 = ({
 	trail,
 	showAge,
 	containerPalette,
+	imageLoading,
 }: TrailProps) => {
 	return (
 		<FrontCard
@@ -560,6 +589,7 @@ export const Card66Media66 = ({
 			imagePosition="top"
 			imagePositionOnMobile="top"
 			imageSize="large"
+			imageLoading={imageLoading}
 		/>
 	);
 };
@@ -582,6 +612,7 @@ export const Card33Media33 = ({
 	trail,
 	showAge,
 	containerPalette,
+	imageLoading,
 }: TrailProps) => {
 	return (
 		<FrontCard
@@ -592,6 +623,7 @@ export const Card33Media33 = ({
 			imageSize="medium"
 			imagePosition="top"
 			imagePositionOnMobile="left"
+			imageLoading={imageLoading}
 			headlineSize="medium"
 			headlineSizeOnMobile="medium"
 		/>
@@ -615,6 +647,7 @@ export const Card33Media33Tall = ({
 	trail,
 	showAge,
 	containerPalette,
+	imageLoading,
 }: TrailProps) => {
 	return (
 		<FrontCard
@@ -624,6 +657,7 @@ export const Card33Media33Tall = ({
 			imageSize="medium"
 			imagePosition="top"
 			imagePositionOnMobile="left"
+			imageLoading={imageLoading}
 			headlineSize="medium"
 			headlineSizeOnMobile="medium"
 			supportingContent={trail.supportingContent?.slice(0, 2)}
@@ -650,6 +684,7 @@ export const Card33Media33MobileTopTall = ({
 	trail,
 	showAge,
 	containerPalette,
+	imageLoading,
 }: TrailProps) => {
 	return (
 		<FrontCard
@@ -660,6 +695,7 @@ export const Card33Media33MobileTopTall = ({
 			imageSize="medium"
 			imagePosition="top"
 			imagePositionOnMobile="top"
+			imageLoading={imageLoading}
 			headlineSize="medium"
 			headlineSizeOnMobile="large"
 			supportingContent={trail.supportingContent?.slice(0, 2)}
@@ -684,13 +720,14 @@ export const CardDefault = ({
 	trail,
 	showAge,
 	containerPalette,
-}: TrailProps) => {
+}: Omit<TrailProps, 'imageLoading'>) => {
 	return (
 		<FrontCard
 			trail={trail}
 			containerPalette={containerPalette}
 			showAge={showAge}
 			imageUrl={undefined}
+			imageLoading={'lazy'}
 			avatarUrl={undefined}
 			headlineSize="small"
 			headlineSizeOnMobile="small"
@@ -715,6 +752,7 @@ export const CardDefaultMedia = ({
 	trail,
 	showAge,
 	containerPalette,
+	imageLoading,
 }: TrailProps) => {
 	return (
 		<FrontCard
@@ -724,6 +762,7 @@ export const CardDefaultMedia = ({
 			imageSize="small"
 			imagePosition="left"
 			imagePositionOnMobile="none"
+			imageLoading={imageLoading}
 			headlineSize="small"
 			headlineSizeOnMobile="small"
 			isPlayableMediaCard={false}
@@ -747,6 +786,7 @@ export const CardDefaultMediaMobile = ({
 	trail,
 	showAge,
 	containerPalette,
+	imageLoading,
 }: TrailProps) => {
 	return (
 		<FrontCard
@@ -756,6 +796,7 @@ export const CardDefaultMediaMobile = ({
 			imageSize="small"
 			imagePosition="left"
 			imagePositionOnMobile="left"
+			imageLoading={imageLoading}
 			headlineSize="small"
 			headlineSizeOnMobile="small"
 			isPlayableMediaCard={false}

--- a/dotcom-rendering/src/lib/dynamicSlices.tsx
+++ b/dotcom-rendering/src/lib/dynamicSlices.tsx
@@ -1,5 +1,6 @@
 import { LI } from '../components/Card/components/LI';
 import { UL } from '../components/Card/components/UL';
+import { Loading } from '../components/CardPicture';
 import type {
 	DCRContainerPalette,
 	DCRFrontCard,
@@ -35,8 +36,10 @@ export const Card50_Card50 = ({
 	cards,
 	containerPalette,
 	showAge,
+	imageLoading,
 }: {
 	cards: DCRFrontCard[];
+	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
 }) => {
@@ -56,6 +59,7 @@ export const Card50_Card50 = ({
 						trail={trail}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						imageLoading={imageLoading}
 					/>
 				</LI>
 			))}
@@ -72,8 +76,10 @@ export const Card75_Card25 = ({
 	cards,
 	containerPalette,
 	showAge,
+	imageLoading,
 }: {
 	cards: DCRFrontCard[];
+	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
 }) => {
@@ -88,6 +94,7 @@ export const Card75_Card25 = ({
 						trail={trail}
 						showAge={showAge}
 						containerPalette={containerPalette}
+						imageLoading={imageLoading}
 					/>
 				</LI>
 			))}
@@ -103,6 +110,7 @@ export const Card75_Card25 = ({
 						trail={trail}
 						showAge={showAge}
 						containerPalette={containerPalette}
+						imageLoading={imageLoading}
 					/>
 				</LI>
 			))}
@@ -119,8 +127,10 @@ export const Card25_Card75 = ({
 	cards,
 	containerPalette,
 	showAge,
+	imageLoading,
 }: {
 	cards: DCRFrontCard[];
+	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
 }) => {
@@ -135,6 +145,7 @@ export const Card25_Card75 = ({
 						trail={trail}
 						showAge={showAge}
 						containerPalette={containerPalette}
+						imageLoading={imageLoading}
 					/>
 				</LI>
 			))}
@@ -150,6 +161,7 @@ export const Card25_Card75 = ({
 						trail={trail}
 						showAge={showAge}
 						containerPalette={containerPalette}
+						imageLoading={imageLoading}
 					/>
 				</LI>
 			))}
@@ -166,8 +178,10 @@ export const Card50_Card25_Card25 = ({
 	cards,
 	containerPalette,
 	showAge,
+	imageLoading,
 }: {
 	cards: DCRFrontCard[];
+	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
 }) => {
@@ -182,6 +196,7 @@ export const Card50_Card25_Card25 = ({
 						trail={trail}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						imageLoading={imageLoading}
 					/>
 				</LI>
 			))}
@@ -198,6 +213,7 @@ export const Card50_Card25_Card25 = ({
 						trail={trail}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						imageLoading={imageLoading}
 					/>
 				</LI>
 			))}
@@ -215,8 +231,10 @@ export const Card100PictureTop = ({
 	cards,
 	showAge,
 	containerPalette,
+	imageLoading,
 }: {
 	cards: DCRFrontCard[];
+	imageLoading: Loading;
 	showAge?: boolean;
 	containerPalette?: DCRContainerPalette;
 }) => {
@@ -230,6 +248,7 @@ export const Card100PictureTop = ({
 						trail={card}
 						showAge={showAge}
 						containerPalette={containerPalette}
+						imageLoading={imageLoading}
 					/>
 				</LI>
 			))}
@@ -241,8 +260,10 @@ export const Card25_Card25_Card25_Card25 = ({
 	cards,
 	showAge,
 	containerPalette,
+	imageLoading,
 }: {
 	cards: DCRFrontCard[];
+	imageLoading: Loading;
 	showAge?: boolean;
 	containerPalette?: DCRContainerPalette;
 }) => {
@@ -265,6 +286,7 @@ export const Card25_Card25_Card25_Card25 = ({
 							trail={card}
 							containerPalette={containerPalette}
 							showAge={showAge}
+							imageLoading={imageLoading}
 						/>
 					</LI>
 				);
@@ -277,8 +299,10 @@ export const ColumnOfCards50_Card25_Card25 = ({
 	cards,
 	showAge,
 	containerPalette,
+	imageLoading,
 }: {
 	cards: DCRFrontCard[];
+	imageLoading: Loading;
 	showAge?: boolean;
 	containerPalette?: DCRContainerPalette;
 }) => {
@@ -300,6 +324,7 @@ export const ColumnOfCards50_Card25_Card25 = ({
 							trail={big}
 							showAge={showAge}
 							containerPalette={containerPalette}
+							imageLoading={imageLoading}
 						/>
 					</LI>
 				);
@@ -317,6 +342,7 @@ export const ColumnOfCards50_Card25_Card25 = ({
 									trail={card}
 									containerPalette={containerPalette}
 									showAge={showAge}
+									imageLoading={imageLoading}
 								/>
 							</LI>
 						);
@@ -337,8 +363,10 @@ export const Card100PictureRight = ({
 	cards,
 	showAge,
 	containerPalette,
+	imageLoading,
 }: {
 	cards: DCRFrontCard[];
+	imageLoading: Loading;
 	showAge?: boolean;
 	containerPalette?: DCRContainerPalette;
 }) => {
@@ -352,6 +380,7 @@ export const Card100PictureRight = ({
 						trail={card}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						imageLoading={imageLoading}
 					/>
 				</LI>
 			))}


### PR DESCRIPTION
## What does this change?

Forces a decision about the image loading strategy for `CardPicture`.

## Why?

[Loading 'eager' or 'lazy'](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/loading), you must choose! This has a big impact on the initial number of request on Front pages.

We are currently scoring quite low on the `Lighthouse performance score`, and one of the top recommendations is to load images below the fold lazily. [Read more on this Google/Web.dev article](https://web.dev/browser-level-image-lazy-loading/). 

<img width="957" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/76776/ea00fce5-fc54-4951-9dd3-4a8a12cef838">


## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/76776/0d2e8174-8d09-4345-ab12-0de871398679
[after]: https://github.com/guardian/dotcom-rendering/assets/76776/b5091163-6da0-4a00-aa29-f0229b50935d