### PR TITLE
Add a new startup script which adds `isSignedInAuthState` to `window.…

### DIFF
--- a/dotcom-rendering/src/client/index.scheduled.ts
+++ b/dotcom-rendering/src/client/index.scheduled.ts
@@ -9,6 +9,7 @@ import './webpackPublicPath';
 
 import type { ScheduleOptions } from '../lib/scheduler';
 import { schedule, setSchedulerConcurrency } from '../lib/scheduler';
+import { identity } from '../lib/useAuthStatus';
 import { bootCmp } from './bootCmp';
 import { dynamicImport } from './dynamicImport';
 import { ga } from './ga';
@@ -45,6 +46,7 @@ boot('sentryLoader', sentryLoader);
 boot('dynamicImport', dynamicImport);
 boot('islands', islands);
 boot('performanceMonitoring', performanceMonitoring);
+boot('identity', identity);
 
 // these modules are loaded as separate chunks, so that they can be lazy-loaded
 void import(/* webpackChunkName: 'atomIframe' */ './atomIframe').then(

--- a/dotcom-rendering/src/client/index.ts
+++ b/dotcom-rendering/src/client/index.ts
@@ -1,6 +1,7 @@
 import './webpackPublicPath';
 
 // these modules are bundled in the initial (i.e. this) chunk, so that they run ASAP
+import { identity } from '../lib/useAuthStatus';
 import { bootCmp } from './bootCmp';
 import { dynamicImport } from './dynamicImport';
 import { ga } from './ga';
@@ -17,6 +18,7 @@ startup('sentryLoader', sentryLoader);
 startup('dynamicImport', dynamicImport);
 startup('islands', islands);
 startup('performanceMonitoring', performanceMonitoring);
+startup('identity', identity);
 
 // these modules are loaded as separate chunks, so that they can be lazy-loaded
 void import(/* webpackChunkName: 'atomIframe' */ './atomIframe').then(

--- a/dotcom-rendering/src/lib/useAuthStatus.ts
+++ b/dotcom-rendering/src/lib/useAuthStatus.ts
@@ -105,8 +105,8 @@ export const useAuthStatus = (): AuthStatus => {
 };
 
 export const identity = async (): Promise<void> => {
-	window.guardian.isSignedInAuthState = async () => {
+	window.guardian.isSignedInAuthStateResolve(async () => {
 		const { isSignedInWithOktaAuthState } = await import('./identity');
 		return isSignedInWithOktaAuthState();
-	};
+	});
 };

--- a/dotcom-rendering/src/lib/useAuthStatus.ts
+++ b/dotcom-rendering/src/lib/useAuthStatus.ts
@@ -7,7 +7,7 @@ import { getCookie } from '@guardian/libs';
 import { useEffect, useState } from 'react';
 import type { CustomIdTokenClaims } from './identity';
 
-type OktaAuthState = IdentityAuthState<never, CustomIdTokenClaims>;
+export type OktaAuthState = IdentityAuthState<never, CustomIdTokenClaims>;
 
 type SignedOutWithCookies = { kind: 'SignedOutWithCookies' };
 export type SignedInWithCookies = { kind: 'SignedInWithCookies' };
@@ -44,8 +44,7 @@ export const getOptionsHeadersWithOkta = (
 
 export async function getAuthState(): Promise<OktaAuthState> {
 	const { isSignedInWithOktaAuthState } = await import('./identity');
-	const authState = await isSignedInWithOktaAuthState();
-	return authState;
+	return isSignedInWithOktaAuthState();
 }
 
 export async function eitherInOktaTestOrElse<A, B>(
@@ -103,4 +102,11 @@ export const useAuthStatus = (): AuthStatus => {
 	}, []);
 
 	return authStatus;
+};
+
+export const identity = async (): Promise<void> => {
+	window.guardian.isSignedInAuthState = async () => {
+		const { isSignedInWithOktaAuthState } = await import('./identity');
+		return isSignedInWithOktaAuthState();
+	};
 };

--- a/dotcom-rendering/src/server/htmlPageTemplate.ts
+++ b/dotcom-rendering/src/server/htmlPageTemplate.ts
@@ -322,6 +322,10 @@ https://workforus.theguardian.com/careers/product-engineering/
 					window.curl = window.curlConfig;
 				</script>
 
+				<script>
+					window.guardian.isSignedInAuthState = new Promise(r => window.guardian.isSignedInAuthStateResolve = r)
+				</script>
+
 				${initTwitter ?? ''}
 
 				${

--- a/dotcom-rendering/window.guardian.d.ts
+++ b/dotcom-rendering/window.guardian.d.ts
@@ -53,7 +53,8 @@ declare global {
 			weeklyArticleCount: WeeklyArticleHistory | undefined;
 			dailyArticleCount: DailyArticleHistory | undefined;
 			GAData: GADataType;
-			isSignedInAuthState?: () => Promise<OktaAuthState>
+			isSignedInAuthStateResolve: (value: () => Promise<OktaAuthState>) => void;
+			isSignedInAuthState: Promise<() => Promise<OktaAuthState>>;
 		};
 		GoogleAnalyticsObject: string;
 		ga: UniversalAnalytics.ga | null;

--- a/dotcom-rendering/window.guardian.d.ts
+++ b/dotcom-rendering/window.guardian.d.ts
@@ -9,6 +9,7 @@ import type { WeeklyArticleHistory } from '@guardian/support-dotcom-components/d
 import type { OphanRecordFunction } from './src/client/ophan/ophan';
 import type { DailyArticleHistory } from './src/lib/dailyArticleCount';
 import type { ReaderRevenueDevUtils } from './src/lib/readerRevenueDevUtils';
+import type { OktaAuthState } from "./src/lib/useAuthStatus"
 import type { WindowGuardianConfig } from './src/model/window-guardian';
 
 declare global {
@@ -52,6 +53,7 @@ declare global {
 			weeklyArticleCount: WeeklyArticleHistory | undefined;
 			dailyArticleCount: DailyArticleHistory | undefined;
 			GAData: GADataType;
+			isSignedInAuthState?: () => Promise<OktaAuthState>
 		};
 		GoogleAnalyticsObject: string;
 		ga: UniversalAnalytics.ga | null;


### PR DESCRIPTION
## What does this change?

Adds a promise for `isSignedInAuthState` to `window.guardian`. This promise is later resolved by a startup script once DCR gets going.

The reason we need to add a promise of a function to the window is to prevent a race condition where Commercial tries to access the function before DCR has added it to the window.

## Alternative

An alternative to this would be to put `IdentityAuth` itself on the window and then whatever application needs it first (Commercial or DCR) can take care of initializing it.

This has the benefit of not blocking Commercial behind DCR initialization, but with the downside that we need to make sure that the Commercial IdentityAuth constructor always remains identical to the DCR one.
