### PR TITLE
Performance measurements: `ga` resolves after fully initialised

### DIFF
--- a/dotcom-rendering/src/client/ga/index.ts
+++ b/dotcom-rendering/src/client/ga/index.ts
@@ -1,44 +1,62 @@
 import {
 	getConsentFor,
+	onConsent,
 	onConsentChange,
 } from '@guardian/consent-management-platform';
 import type { ConsentState } from '@guardian/consent-management-platform/dist/types';
 import { loadScript, log } from '@guardian/libs';
 import { init, sendPageView } from './ga';
 
-export const ga = (): Promise<void> => {
+/** Memoize loading to prevent loading twice */
+let loadedGoogleAnalytics = false;
+
+/** Enable Google Analytics */
+const loadGoogleAnalytics = async () => {
+	if (loadedGoogleAnalytics) return;
+
+	try {
+		await loadScript('https://www.google-analytics.com/analytics.js');
+		loadedGoogleAnalytics = true;
+
+		log('dotcom', 'GA script loaded');
+
+		init();
+		sendPageView();
+	} catch (error) {
+		loadedGoogleAnalytics = false;
+		// We don't need to log script loading errors (these will mostly be adblock, etc),
+		if (!String(error).includes('Error loading script')) {
+			// This is primarily for logging errors with our GA code.
+			window.guardian.modules.sentry.reportError(
+				error instanceof Error ? error : new Error(String(error)),
+				'ga',
+			);
+		}
+	}
+};
+
+/** Disable Google Analytics */
+const unloadGoogleAnalytics = () => {
+	// @ts-expect-error -- We should never be able to directly set things to the global window object
+	// but in this case we want to stub things for testing, so it's ok to ignore this rule
+	window.ga = null;
+	loadedGoogleAnalytics = false;
+};
+
+const handleGoogleAnalytics = async (state: ConsentState) => {
+	if (getConsentFor('google-analytics', state)) {
+		await loadGoogleAnalytics();
+	} else {
+		unloadGoogleAnalytics();
+	}
+};
+
+export const ga = async (): Promise<void> => {
+	await onConsent().then(handleGoogleAnalytics);
+
 	// Check if we have consent for GA so that if the reader removes consent for tracking we
 	// remove ga from the page
-	onConsentChange((consentState: ConsentState) => {
-		const consentGivenForGA = getConsentFor(
-			'google-analytics',
-			consentState,
-		);
-		if (consentGivenForGA) {
-			loadScript('https://www.google-analytics.com/analytics.js')
-				.then(() => {
-					log('dotcom', 'GA script loaded');
-
-					init();
-					sendPageView();
-				})
-				.catch((e) => {
-					// We don't need to log script loading errors (these will mostly be adblock, etc),
-					if (!String(e).includes('Error loading script')) {
-						// This is primarily for logging errors with our GA code.
-						window.guardian.modules.sentry.reportError(
-							e instanceof Error ? e : new Error(e),
-							'ga',
-						);
-					}
-				});
-		} else {
-			// Disable Google Analytics
-			// @ts-expect-error -- We should never be able to directly set things to the global window object
-			// but in this case we want to stub things for testing, so it's ok to ignore this rule
-			window.ga = null;
-		}
+	onConsentChange((consentState) => {
+		void handleGoogleAnalytics(consentState);
 	});
-
-	return Promise.resolve();
 };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Refactor `ga` to only resolve once all the Google Analytics (GA) work is complete:

- got consent
- loaded scripts
- registered consent state listener

## Why?

Part of @guardian/open-journalism’s work to get meaningful timings from startup scripts: #8529

## Screenshots

TBC

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/76776/2b73288c-f1df-49b5-b033-ced6f3f1b19d
[after]: https://github.com/guardian/dotcom-rendering/assets/76776/4b95445f-20ea-484c-ac38-6dbec834bc6a