### PR TITLE
`Picture` Takes Precedence Over `Comment`

### DIFF
--- a/apps-rendering/src/item.ts
+++ b/apps-rendering/src/item.ts
@@ -524,6 +524,12 @@ const fromCapi =
 				body,
 				...itemFields,
 			};
+		} else if (isPicture(tags)) {
+			return {
+				design: ArticleDesign.Picture,
+				body,
+				...itemFields,
+			};
 		} else if (isReview(tags)) {
 			return {
 				design: ArticleDesign.Review,
@@ -626,12 +632,6 @@ const fromCapi =
 		} else if (isProfile(tags)) {
 			return {
 				design: ArticleDesign.Profile,
-				body,
-				...itemFields,
-			};
-		} else if (isPicture(tags)) {
-			return {
-				design: ArticleDesign.Picture,
 				body,
 				...itemFields,
 			};


### PR DESCRIPTION
## Why?

It's common for picture content to have both `type/picture` and `tone/comment` tags. Many of the pieces here are tagged this way: https://www.theguardian.com/pictures

We use these tags to define `ArticleDesign.Picture` and `ArticleDesign.Comment` respectively. If content has both then picture should take precedence and the piece should be defined as `ArticleDesign.Picture`.

This incorrect precedence was introduced in #8416, where we added a parsing condition for picture articles and placed it at the bottom of the precedence order. Previously we were (incorrectly, but intentionally) parsing picture articles as galleries as a temporary measure to make sure they were understood by Editions. Galleries were (and still are) above comment pieces in the precedence order.

It's possible this is responsible for #8530, although it doesn't explain the production/preview discrepancy.

## Changes

Changed the order in which content is parsed to move the check for `ArticleDesign.Picture` above the check for `ArticleDesign.Comment`.
