### PR TITLE
Scheduler: measure module loading time

### DIFF
--- a/dotcom-rendering/src/client/index.scheduled.ts
+++ b/dotcom-rendering/src/client/index.scheduled.ts
@@ -5,17 +5,8 @@
 
 import './webpackPublicPath';
 
-// these modules are bundled in the initial (i.e. this) chunk, so that they run ASAP
-
 import type { ScheduleOptions } from '../lib/scheduler';
 import { schedule, setSchedulerConcurrency } from '../lib/scheduler';
-import { bootCmp } from './bootCmp';
-import { dynamicImport } from './dynamicImport';
-import { ga } from './ga';
-import { islands } from './islands';
-import { ophan } from './ophan';
-import { performanceMonitoring } from './performanceMonitoring';
-import { sentryLoader } from './sentryLoader';
 
 if (window.location.hash.includes('concurrency=')) {
 	const match = window.location.hash.match(/concurrency=(\d+)/);
@@ -38,33 +29,90 @@ const boot = (
 	}
 };
 
-boot('bootCmp', bootCmp);
-boot('ophan', ophan);
-boot('ga', ga);
-boot('sentryLoader', sentryLoader);
-boot('dynamicImport', dynamicImport);
-boot('islands', islands);
-boot('performanceMonitoring', performanceMonitoring);
+/*************************************************************
+ *
+ * The following modules are bundled in the entry chunk,
+ * so they can be run immediately, but we still want to report
+ * on the duration of loading and evaluating them.
+ *
+ *************************************************************/
 
-// these modules are loaded as separate chunks, so that they can be lazy-loaded
-void import(/* webpackChunkName: 'atomIframe' */ './atomIframe').then(
-	({ atomIframe }) => boot('atomIframe', atomIframe),
+boot('bootCmp', () =>
+	import(/* webpackMode: "eager" */ './bootCmp').then(({ bootCmp }) =>
+		bootCmp(),
+	),
+);
+boot('ophan', () =>
+	import(/* webpackMode: "eager" */ './ophan').then(({ ophan }) => ophan()),
+);
+boot('ga', () =>
+	import(/* webpackMode: "eager" */ './ga').then(({ ga }) => ga()),
+);
+boot('sentryLoader', () =>
+	import(/* webpackMode: "eager" */ './sentryLoader').then(
+		({ sentryLoader }) => sentryLoader(),
+	),
+);
+boot('dynamicImport', () =>
+	import(/* webpackMode: "eager" */ './dynamicImport').then(
+		({ dynamicImport }) => dynamicImport(),
+	),
+);
+boot('islands', () =>
+	import(/* webpackMode: "eager" */ './islands').then(({ islands }) =>
+		islands(),
+	),
+);
+boot('performanceMonitoring', () =>
+	import(/* webpackMode: "eager" */ './performanceMonitoring').then(
+		({ performanceMonitoring }) => performanceMonitoring(),
+	),
 );
 
-void import(/* webpackChunkName: 'embedIframe' */ './embedIframe').then(
-	({ embedIframe }) => boot('embedIframe', embedIframe),
+/*************************************************************
+ *
+ * The following modules are lazy loaded as separate chunks,
+ * because they are lower priority and do not want to block
+ * the modules above on loading these.
+ *
+ *************************************************************/
+
+boot('atomIframe', () =>
+	import(
+		/* webpackMode: 'lazy' */
+		/* webpackChunkName: 'atomIframe' */
+		'./atomIframe'
+	).then(({ atomIframe }) => atomIframe()),
 );
 
-void import(
-	/* webpackChunkName: 'newsletterEmbedIframe' */ './newsletterEmbedIframe'
-).then(({ newsletterEmbedIframe }) =>
-	boot('newsletterEmbedIframe', newsletterEmbedIframe),
+boot('embedIframe', () =>
+	import(
+		/* webpackMode: 'lazy' */
+		/* webpackChunkName: 'embedIframe' */
+		'./embedIframe'
+	).then(({ embedIframe }) => embedIframe()),
 );
 
-void import(/* webpackChunkName: 'relativeTime' */ './relativeTime').then(
-	({ relativeTime }) => boot('relativeTime', relativeTime),
+boot('newsletterEmbedIframe', () =>
+	import(
+		/* webpackMode: 'lazy' */
+		/* webpackChunkName: 'newsletterEmbedIframe' */
+		'./newsletterEmbedIframe'
+	).then(({ newsletterEmbedIframe }) => newsletterEmbedIframe()),
 );
 
-void import(/* webpackChunkName: 'discussion' */ './discussion').then(
-	({ discussion }) => boot('initDiscussion', discussion),
+boot('relativeTime', () =>
+	import(
+		/* webpackMode: 'lazy' */
+		/* webpackChunkName: 'relativeTime' */
+		'./relativeTime'
+	).then(({ relativeTime }) => relativeTime()),
+);
+
+boot('initDiscussion', () =>
+	import(
+		/* webpackMode: 'lazy' */
+		/* webpackChunkName: 'discussion' */
+		'./discussion'
+	).then(({ discussion }) => discussion()),
 );


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Include module loading time in the scheduler test.

## Why?

Get more meaningful reports on the duration of boot scripts in the scheduled entry test

## Screenshots

| Before      | After (dev)|
| ----------- | ---------- |
| ![before][] | ![after][] |


[before]: https://github.com/guardian/dotcom-rendering/assets/76776/39d8c756-20b5-4955-a855-508482d8a145
[after]: https://github.com/guardian/dotcom-rendering/assets/76776/ce881470-e43a-4d11-baff-82581a477be7