### PR TITLE
fix recaptcha component import

### DIFF
--- a/dotcom-rendering/src/components/ManyNewsletterSignUp.importable.tsx
+++ b/dotcom-rendering/src/components/ManyNewsletterSignUp.importable.tsx
@@ -8,7 +8,10 @@ import {
 import { Button, SvgCross } from '@guardian/source-react-components';
 import type { ChangeEventHandler, ReactEventHandler } from 'react';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { ReCAPTCHA } from 'react-google-recaptcha';
+// Note - the package also exports a component as a named export "ReCAPTCHA",
+// that version will compile and render but is non-functional.
+// Use the default export instead.
+import ReactGoogleRecaptcha from 'react-google-recaptcha';
 import { isServer } from '../lib/isServer';
 import {
 	getCaptchaSiteKey,
@@ -318,10 +321,14 @@ export const ManyNewsletterSignUp = () => {
 								css={css`
 									.grecaptcha-badge {
 										visibility: hidden;
+										// The Google documentation specifies that if the 'recaptcha-badge' is hidden,
+										// their T+C's must be displayed instead. While this component hides the
+										// badge, the T+C's are inluded in the ManyNewslettersForm component.
+										// https://developers.google.com/recaptcha/docs/faq#id-like-to-hide-the-recaptcha-badge.-what-is-allowed
 									}
 								`}
 							>
-								<ReCAPTCHA
+								<ReactGoogleRecaptcha
 									sitekey={captchaSiteKey}
 									ref={reCaptchaRef}
 									onError={handleCaptchaError}

--- a/dotcom-rendering/src/components/ManyNewsletterSignUp.importable.tsx
+++ b/dotcom-rendering/src/components/ManyNewsletterSignUp.importable.tsx
@@ -318,13 +318,13 @@ export const ManyNewsletterSignUp = () => {
 
 						{useReCaptcha && !!captchaSiteKey && (
 							<div
+								// The Google documentation specifies that if the 'recaptcha-badge' is hidden,
+								// their T+C's must be displayed instead. While this component hides the
+								// badge, the T+C's are inluded in the ManyNewslettersForm component.
+								// https://developers.google.com/recaptcha/docs/faq#id-like-to-hide-the-recaptcha-badge.-what-is-allowed
 								css={css`
 									.grecaptcha-badge {
 										visibility: hidden;
-										// The Google documentation specifies that if the 'recaptcha-badge' is hidden,
-										// their T+C's must be displayed instead. While this component hides the
-										// badge, the T+C's are inluded in the ManyNewslettersForm component.
-										// https://developers.google.com/recaptcha/docs/faq#id-like-to-hide-the-recaptcha-badge.-what-is-allowed
 									}
 								`}
 							>

--- a/dotcom-rendering/src/components/ManyNewsletterSignUp.importable.tsx
+++ b/dotcom-rendering/src/components/ManyNewsletterSignUp.importable.tsx
@@ -117,7 +117,7 @@ export const ManyNewsletterSignUp = () => {
 	>([]);
 	const [status, setStatus] = useState<FormStatus>('NotSent');
 	const [email, setEmail] = useState('');
-	const reCaptchaRef = useRef<ReCAPTCHA>(null);
+	const reCaptchaRef = useRef<ReactGoogleRecaptcha>(null);
 	const useReCaptcha = isServer
 		? false
 		: !!window.guardian.config.switches['emailSignupRecaptcha'];

--- a/dotcom-rendering/src/components/SecureSignupIframe.importable.tsx
+++ b/dotcom-rendering/src/components/SecureSignupIframe.importable.tsx
@@ -11,7 +11,10 @@ import {
 } from '@guardian/source-react-components';
 import type { ReactEventHandler } from 'react';
 import { useRef, useState } from 'react';
-import ReCAPTCHA from 'react-google-recaptcha';
+// Note - the package also exports a component as a named export "ReCAPTCHA",
+// that version will compile and render but is non-functional.
+// Use the default export instead.
+import ReactGoogleRecaptcha from 'react-google-recaptcha';
 import {
 	getOphanRecordFunction,
 	submitComponentEvent,
@@ -196,7 +199,7 @@ export const SecureSignupIframe = ({
 	successDescription,
 }: Props) => {
 	const iframeRef = useRef<HTMLIFrameElement>(null);
-	const recaptchaRef = useRef<ReCAPTCHA>(null);
+	const recaptchaRef = useRef<ReactGoogleRecaptcha>(null);
 
 	const [iframeHeight, setIFrameHeight] = useState<number>(0);
 	const [isWaitingForResponse, setIsWaitingForResponse] =
@@ -421,7 +424,7 @@ export const SecureSignupIframe = ({
 						}
 					`}
 				>
-					<ReCAPTCHA
+					<ReactGoogleRecaptcha
 						sitekey={captchaSiteKey}
 						ref={recaptchaRef}
 						onChange={handleCaptchaComplete}

--- a/dotcom-rendering/src/model/window-guardian.ts
+++ b/dotcom-rendering/src/model/window-guardian.ts
@@ -88,7 +88,7 @@ export const makeWindowGuardian = ({
 	 * `googleRecaptchaSiteKey` key needs to be explicitly set on the
 	 * config object (even if undefined) rather than included in `unknownConfig`.
 	 *
-	 * Even thought the value will included in `unknownConfig` if the config from
+	 * Even though the value will included in `unknownConfig` if the config from
 	 * frontend is used, the value will be overwritten by the `Object.assign` below.
 	 *
 	 * @see https://github.com/guardian/dotcom-rendering/pull/8483

--- a/dotcom-rendering/src/model/window-guardian.ts
+++ b/dotcom-rendering/src/model/window-guardian.ts
@@ -83,10 +83,20 @@ export const makeWindowGuardian = ({
 	brazeApiKey?: string;
 	GAData?: GADataType;
 	hasInlineMerchandise?: boolean;
-	googleRecaptchaSiteKey?: string;
 	/**
-	 * In the case of articles we don't know the exact values that need to exist
-	 * on the window.guardian.config.page property so rather than filter them we
+	 * Using `string | undefined` rather than an optional `string` so the
+	 * `googleRecaptchaSiteKey` key needs to be explicitly set on the
+	 * config object (even if undefined) rather than included in `unknownConfig`.
+	 *
+	 * Even thought the value will included in `unknownConfig` if the config from
+	 * frontend is used, the value will be overwritten by the `Object.assign` below.
+	 *
+	 * @see https://github.com/guardian/dotcom-rendering/pull/8483
+	 */
+	googleRecaptchaSiteKey: string | undefined;
+	/**
+	 * In the case of articles and fronts we don't know the exact values that need to
+	 * exist on the window.guardian.config.page property so rather than filter them we
 	 * allow the entire object to be passed through here and we then extend it
 	 * using Object.assigns
 	 *

--- a/dotcom-rendering/src/model/window-guardian.ts
+++ b/dotcom-rendering/src/model/window-guardian.ts
@@ -88,7 +88,7 @@ export const makeWindowGuardian = ({
 	 * `googleRecaptchaSiteKey` key needs to be explicitly set on the
 	 * config object (even if undefined) rather than included in `unknownConfig`.
 	 *
-	 * Even though the value will included in `unknownConfig` if the config from
+	 * Even thought the value will included in `unknownConfig` if the config from
 	 * frontend is used, the value will be overwritten by the `Object.assign` below.
 	 *
 	 * @see https://github.com/guardian/dotcom-rendering/pull/8483

--- a/dotcom-rendering/src/model/window-guardian.ts
+++ b/dotcom-rendering/src/model/window-guardian.ts
@@ -83,20 +83,10 @@ export const makeWindowGuardian = ({
 	brazeApiKey?: string;
 	GAData?: GADataType;
 	hasInlineMerchandise?: boolean;
+	googleRecaptchaSiteKey?: string;
 	/**
-	 * Using `string | undefined` rather than an optional `string` so the
-	 * `googleRecaptchaSiteKey` key needs to be explicitly set on the
-	 * config object (even if undefined) rather than included in `unknownConfig`.
-	 *
-	 * Even thought the value will included in `unknownConfig` if the config from
-	 * frontend is used, the value will be overwritten by the `Object.assign` below.
-	 *
-	 * @see https://github.com/guardian/dotcom-rendering/pull/8483
-	 */
-	googleRecaptchaSiteKey: string | undefined;
-	/**
-	 * In the case of articles and fronts we don't know the exact values that need to
-	 * exist on the window.guardian.config.page property so rather than filter them we
+	 * In the case of articles we don't know the exact values that need to exist
+	 * on the window.guardian.config.page property so rather than filter them we
 	 * allow the entire object to be passed through here and we then extend it
 	 * using Object.assigns
 	 *


### PR DESCRIPTION
## What does this change?

 - changes the component imported from the 'react-google-recaptcha' package in "dotcom-rendering/src/components/ManyNewsletterSignUp.importable.tsx" to a functional version
 - adds comment to comment about the usage of the package to the components that use it

## Why?

Fixes the sign-up functionality in the WIP DCR all-newsletters page - see https://github.com/guardian/dotcom-rendering/issues/8423 for background. Currently, the `execute` method on the Recaptcha component is hanging as the page uses a non-functional version.


