### PR TITLE
An improved and configurable Slideshow

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -377,6 +377,7 @@ export const Card = ({
 		mainMedia,
 		isPlayableMediaCard,
 	});
+
 	return (
 		<CardWrapper
 			format={format}

--- a/dotcom-rendering/src/components/Slideshow.stories.tsx
+++ b/dotcom-rendering/src/components/Slideshow.stories.tsx
@@ -1,3 +1,6 @@
+import { css } from '@emotion/react';
+import { space } from '@guardian/source-foundations';
+import type { PropsWithChildren } from 'react';
 import type { DCRSlideshowImage } from '../types/front';
 import { Slideshow } from './Slideshow';
 
@@ -19,20 +22,42 @@ const images = [
 	{
 		imageSrc:
 			'https://media.guim.co.uk/fe310d0ab79125e2f55680b02b9347e45832e1f0/0_0_4800_3536/master/4800.jpg',
-		imageCaption: 'Cat Royale',
+		imageCaption: 'Dog Splash',
 	},
 	{
 		imageSrc:
 			'https://media.guim.co.uk/4199670a084d3179778332af3ee6297486332e91/0_0_4000_3000/master/4000.jpg',
 	},
+	{
+		imageSrc:
+			'https://media.guim.co.uk/fe27aabf35683caa6b89f2781ee5d0ad9042e209/0_0_4800_3197/master/4800.jpg',
+	},
 ] as const satisfies readonly DCRSlideshowImage[];
 
+const wrapper = css`
+	margin: ${space[3]}px;
+	max-width: 640px;
+	aspect-ratio: 5 / 3;
+	contain: layout;
+`;
+
+const Wrapper = ({ children }: PropsWithChildren) => (
+	<div css={wrapper}>{children}</div>
+);
+
+/** this one makes no sense, but it’s technically possible so let’s capture it */
 export const WithOneImage = () => (
-	<Slideshow images={images.slice(0, 1)} imageSize="large"></Slideshow>
+	<Wrapper>
+		<Slideshow images={[images[3]]} imageSize="large" />
+	</Wrapper>
 );
 export const WithTwoImages = () => (
-	<Slideshow images={images.slice(0, 2)} imageSize="large"></Slideshow>
+	<Wrapper>
+		<Slideshow images={images.slice(0, 2)} imageSize="large" />
+	</Wrapper>
 );
 export const WithFiveImages = () => (
-	<Slideshow images={images.slice(0, 10)} imageSize="large"></Slideshow>
+	<Wrapper>
+		<Slideshow images={images} imageSize="large" />
+	</Wrapper>
 );

--- a/dotcom-rendering/src/components/Slideshow.stories.tsx
+++ b/dotcom-rendering/src/components/Slideshow.stories.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { space } from '@guardian/source-foundations';
+import { breakpoints, space } from '@guardian/source-foundations';
 import type { PropsWithChildren } from 'react';
 import type { DCRSlideshowImage } from '../types/front';
 import { Slideshow } from './Slideshow';
@@ -7,13 +7,25 @@ import { Slideshow } from './Slideshow';
 export default {
 	component: Slideshow,
 	title: 'Components/Slideshow',
+	parameters: {
+		chromatic: {
+			viewports: [
+				breakpoints.mobile,
+				breakpoints.tablet,
+				breakpoints.leftCol,
+			],
+		},
+	},
 };
 
-const images = [
+const one = [
 	{
 		imageSrc:
 			'https://media.guim.co.uk/d9ede9177cd8a01c7a7e87da54fb15e0615adf20/0_1597_6000_3599/master/6000.jpg',
 	},
+] as const satisfies readonly DCRSlideshowImage[];
+
+const two = [
 	{
 		imageSrc:
 			'https://media.guim.co.uk/69a5b094811888463d7887484571cbfcea3143fc/0_97_5827_3902/master/5827.jpg',
@@ -24,6 +36,9 @@ const images = [
 			'https://media.guim.co.uk/fe310d0ab79125e2f55680b02b9347e45832e1f0/0_0_4800_3536/master/4800.jpg',
 		imageCaption: 'Dog Splash',
 	},
+] as const satisfies readonly DCRSlideshowImage[];
+
+const six = [
 	{
 		imageSrc:
 			'https://media.guim.co.uk/4199670a084d3179778332af3ee6297486332e91/0_0_4000_3000/master/4000.jpg',
@@ -32,32 +47,80 @@ const images = [
 		imageSrc:
 			'https://media.guim.co.uk/fe27aabf35683caa6b89f2781ee5d0ad9042e209/0_0_4800_3197/master/4800.jpg',
 	},
+	{
+		imageSrc:
+			'https://media.guim.co.uk/326773ef9d4e78e14be0cb6f6123bfec773ddf03/0_229_5500_3300/5500.jpg',
+	},
+	{
+		imageSrc:
+			'https://media.guim.co.uk/2b14981ddc59bce686c07fe356eb09cae48fde87/0_76_5832_3499/5832.jpg',
+	},
+	{
+		imageSrc:
+			'https://media.guim.co.uk/cc9dc53d0eff3b047c6d045fa49cb48846a860b3/0_36_2048_1500/2048.jpg',
+	},
+	{
+		imageSrc:
+			'https://media.guim.co.uk/ed66e9dc6a84de6bc0afe1965833f0fa4047c22d/0_324_3500_2100/3500.jpg',
+	},
 ] as const satisfies readonly DCRSlideshowImage[];
 
 const wrapper = css`
 	margin: ${space[3]}px;
-	max-width: 640px;
 	aspect-ratio: 5 / 3;
 	contain: layout;
 `;
 
-const Wrapper = ({ children }: PropsWithChildren) => (
-	<div css={wrapper}>{children}</div>
+const Wrapper = ({
+	children,
+	maxWidth,
+}: PropsWithChildren<{ maxWidth: number }>) => (
+	<div
+		css={[
+			wrapper,
+			css`
+				max-width: ${maxWidth}px;
+			`,
+		]}
+	>
+		{children}
+	</div>
+);
+
+/** this one makes no sense, but it’s technically possible so let’s capture it */
+export const WithoutAnyImage = () => (
+	<Wrapper maxWidth={480}>
+		<Slideshow images={[]} imageSize="medium" />
+	</Wrapper>
 );
 
 /** this one makes no sense, but it’s technically possible so let’s capture it */
 export const WithOneImage = () => (
-	<Wrapper>
-		<Slideshow images={[images[3]]} imageSize="large" />
+	<Wrapper maxWidth={640}>
+		<Slideshow images={one} imageSize="large" />
 	</Wrapper>
 );
+
+export const WithTwoDynamo = () => (
+	<Wrapper maxWidth={640}>
+		<Slideshow images={two} imageSize="jumbo" isDynamo={true} />
+	</Wrapper>
+);
+
 export const WithTwoImages = () => (
-	<Wrapper>
-		<Slideshow images={images.slice(0, 2)} imageSize="large" />
+	<Wrapper maxWidth={320}>
+		<Slideshow images={two} imageSize="small" />
 	</Wrapper>
 );
+
 export const WithFiveImages = () => (
-	<Wrapper>
-		<Slideshow images={images} imageSize="large" />
+	<Wrapper maxWidth={480}>
+		<Slideshow images={six} imageSize="medium" />
+	</Wrapper>
+);
+
+export const Fast = () => (
+	<Wrapper maxWidth={480}>
+		<Slideshow images={six} imageSize="jumbo" fade={0.25} display={1} />
 	</Wrapper>
 );

--- a/dotcom-rendering/src/components/Slideshow.stories.tsx
+++ b/dotcom-rendering/src/components/Slideshow.stories.tsx
@@ -1,0 +1,38 @@
+import type { DCRSlideshowImage } from '../types/front';
+import { Slideshow } from './Slideshow';
+
+export default {
+	component: Slideshow,
+	title: 'Components/Slideshow',
+};
+
+const images = [
+	{
+		imageSrc:
+			'https://media.guim.co.uk/d9ede9177cd8a01c7a7e87da54fb15e0615adf20/0_1597_6000_3599/master/6000.jpg',
+	},
+	{
+		imageSrc:
+			'https://media.guim.co.uk/69a5b094811888463d7887484571cbfcea3143fc/0_97_5827_3902/master/5827.jpg',
+		imageCaption: 'Cat Royale',
+	},
+	{
+		imageSrc:
+			'https://media.guim.co.uk/fe310d0ab79125e2f55680b02b9347e45832e1f0/0_0_4800_3536/master/4800.jpg',
+		imageCaption: 'Cat Royale',
+	},
+	{
+		imageSrc:
+			'https://media.guim.co.uk/4199670a084d3179778332af3ee6297486332e91/0_0_4000_3000/master/4000.jpg',
+	},
+] as const satisfies readonly DCRSlideshowImage[];
+
+export const WithOneImage = () => (
+	<Slideshow images={images.slice(0, 1)} imageSize="large"></Slideshow>
+);
+export const WithTwoImages = () => (
+	<Slideshow images={images.slice(0, 2)} imageSize="large"></Slideshow>
+);
+export const WithFiveImages = () => (
+	<Slideshow images={images.slice(0, 10)} imageSize="large"></Slideshow>
+);

--- a/dotcom-rendering/src/components/Slideshow.tsx
+++ b/dotcom-rendering/src/components/Slideshow.tsx
@@ -1,5 +1,6 @@
 import { css, keyframes } from '@emotion/react';
 import { from, neutral, textSans, until } from '@guardian/source-foundations';
+import { takeFirst } from '../lib/tuple';
 import type { DCRSlideshowImage } from '../types/front';
 import type { ImageSizeType } from './Card/components/ImageWrapper';
 import { CardPicture } from './CardPicture';
@@ -41,7 +42,6 @@ function decideDuration({ slideshowLength }: { slideshowLength: number }) {
 }
 
 /**
- *
  * Decide how long each image should wait to start their animation sequence based
  * on how many images there are and how long we show each image for.
  */
@@ -52,10 +52,8 @@ function decideDelay({
 	imageIndex: number;
 	slideshowLength: number;
 }) {
-	if (imageIndex === 0) return 0;
 	const totalLoopTime = slideshowLength * (HANG_TIME + FADE_TIME);
-	const delay = (totalLoopTime / slideshowLength) * imageIndex;
-	return delay;
+	return (totalLoopTime / slideshowLength) * imageIndex - FADE_TIME;
 }
 
 const hideOnMobile = css`
@@ -187,22 +185,21 @@ export const Slideshow = ({
 }) => {
 	return (
 		<>
-			{images.map((slideshowImage, index) => {
-				const loading = index === 0 ? 'eager' : 'lazy';
+			{takeFirst(images, 5).map((slideshowImage, index) => {
+				const isNotFirst = index > 0;
+				const loading = isNotFirst ? 'lazy' : 'eager';
 				return (
 					<figure
 						key={slideshowImage.imageSrc}
 						css={[
-							index !== 0 && overlayImage,
+							isNotFirst && overlayImage,
 							animationStyles({
 								imageIndex: index,
 								slideshowLength: images.length,
 								imageSize,
 							}),
 							// When small and on mobile, hide all images except the first one
-							index !== 0 &&
-								imageSize === 'small' &&
-								hideOnMobile,
+							isNotFirst && imageSize === 'small' && hideOnMobile,
 						]}
 					>
 						<CardPicture

--- a/dotcom-rendering/src/components/Slideshow.tsx
+++ b/dotcom-rendering/src/components/Slideshow.tsx
@@ -1,59 +1,59 @@
 import { css, keyframes } from '@emotion/react';
-import { from, neutral, textSans, until } from '@guardian/source-foundations';
+import {
+	from,
+	palette,
+	space,
+	textSans,
+	until,
+} from '@guardian/source-foundations';
 import { takeFirst } from '../lib/tuple';
 import type { DCRSlideshowImage } from '../types/front';
 import type { ImageSizeType } from './Card/components/ImageWrapper';
 import { CardPicture } from './CardPicture';
 
-/**
- * It might look like you can change these and expect the animation to adapt accordingly
- * but it probably won't 😞
- */
-const HANG_TIME = 5;
-const FADE_TIME = 1;
+/** in seconds */
+const DISPLAY_DURATION = 5;
+const FADING_DURATION = DISPLAY_DURATION / 5;
 
 /**
  * We pass the result of the Emotion `keyframes` utility (decided here) to the animation-name
  * css property
  */
-function decideAnimationName({ slideshowLength }: { slideshowLength: number }) {
-	const totalLoopTime = slideshowLength * (HANG_TIME + FADE_TIME);
+function decideAnimationName(slideshowLength: number) {
+	if (slideshowLength === 1) {
+		return keyframes`from {opacity: 1} to {opacity:1}`;
+	}
+
+	const totalLoopTime = decideDuration(slideshowLength) / 100;
 	// Calculate the percentages for how long each animation stage lasts
-	const stageOne = `0%`;
-	const stageTwo = `${(100 / totalLoopTime) * FADE_TIME}%`;
-	const stageThree = `${(100 / totalLoopTime) * (FADE_TIME + HANG_TIME)}%`;
-	const stageFour = `${
-		(100 / totalLoopTime) * (FADE_TIME + HANG_TIME + FADE_TIME)
-	}%`;
+	const stages = [
+		0,
+		FADING_DURATION,
+		FADING_DURATION + DISPLAY_DURATION + FADING_DURATION,
+		FADING_DURATION + DISPLAY_DURATION + FADING_DURATION + FADING_DURATION,
+	] as const;
 	// Generate and return a keyframes name for this animation
 	return keyframes`
-		${stageOne} {opacity: 0;}
-		${stageTwo} {opacity: 1;}
-		${stageThree} {opacity: 1;}
-		${stageFour} {opacity: 0;}
+		${`${stages[0] / totalLoopTime}%`} {opacity: 0;}
+		${`${stages[1] / totalLoopTime}%`} {opacity: 1;}
+		${`${stages[2] / totalLoopTime}%`} {opacity: 1;}
+		${`${stages[3] / totalLoopTime}%`} {opacity: 0;}
 	`;
 }
 
 /**
  * How long the whole animation loop will last for before it starts again
  */
-function decideDuration({ slideshowLength }: { slideshowLength: number }) {
-	return slideshowLength * (HANG_TIME + FADE_TIME);
+function decideDuration(slideshowLength: number) {
+	return slideshowLength * (DISPLAY_DURATION + FADING_DURATION);
 }
 
 /**
  * Decide how long each image should wait to start their animation sequence based
  * on how many images there are and how long we show each image for.
  */
-function decideDelay({
-	imageIndex,
-	slideshowLength,
-}: {
-	imageIndex: number;
-	slideshowLength: number;
-}) {
-	const totalLoopTime = slideshowLength * (HANG_TIME + FADE_TIME);
-	return (totalLoopTime / slideshowLength) * imageIndex - FADE_TIME;
+function decideDelay(imageIndex: number) {
+	return (DISPLAY_DURATION + FADING_DURATION) * imageIndex - FADING_DURATION;
 }
 
 const hideOnMobile = css`
@@ -82,18 +82,11 @@ const animationStyles = ({
 	slideshowLength: number;
 	imageSize: ImageSizeType;
 }) => {
-	const delay = decideDelay({
-		imageIndex,
-		slideshowLength,
-	});
+	const delay = decideDelay(imageIndex);
 
-	const duration = decideDuration({
-		slideshowLength,
-	});
+	const duration = decideDuration(slideshowLength);
 
-	const animationName = decideAnimationName({
-		slideshowLength,
-	});
+	const animationName = decideAnimationName(slideshowLength);
 
 	const animationCss = css`
 		animation-delay: ${delay}s;
@@ -134,15 +127,15 @@ const captionStyles = css`
 		rgba(0, 0, 0, 0) 0%,
 		rgba(0, 0, 0, 0.8) 100%
 	);
-	color: ${neutral[100]};
-	padding: 60px 8px 8px;
+	color: ${palette.neutral[100]};
+	padding: 60px ${space[2]}px ${space[2]}px;
 `;
 
 const additionalDynamoCaptionStyles = css`
 	${from.tablet} {
 		top: 0;
 		bottom: initial;
-		padding-top: 8px;
+		padding-top: ${space[2]}px;
 		background: linear-gradient(
 			to bottom,
 			rgba(0, 0, 0, 0.8) 0%,
@@ -152,7 +145,8 @@ const additionalDynamoCaptionStyles = css`
 `;
 
 /**
- * **Slildeshow**
+ * Slideshow
+ * =========
  *
  * Uses the perpetual canon effect to create a slideshow of images using only css. It:
  *
@@ -162,11 +156,13 @@ const additionalDynamoCaptionStyles = css`
  * - uses animation-delay to stagger the start for each image's animation, thus
  *   causing the slideshow effect
  *
+ *  ```
  *                 time ->
  *   image-1 > ####|----|----|----
  *   image-2 > ----|####|----|----
  *   image-3 > ----|----|####|----
  *   image-4 > ----|----|----|####
+ *  ```
  *
  * What's a perpetual canon?
  * -------------------------
@@ -179,35 +175,35 @@ export const Slideshow = ({
 	imageSize,
 	isDynamo,
 }: {
-	images: DCRSlideshowImage[];
+	images: readonly DCRSlideshowImage[];
 	imageSize: ImageSizeType;
 	isDynamo?: boolean;
-}) => {
-	return (
-		<>
-			{takeFirst(images, 5).map((slideshowImage, index) => {
-				const isNotFirst = index > 0;
-				const loading = isNotFirst ? 'lazy' : 'eager';
-				return (
-					<figure
-						key={slideshowImage.imageSrc}
-						css={[
-							isNotFirst && overlayImage,
-							animationStyles({
-								imageIndex: index,
-								slideshowLength: images.length,
-								imageSize,
-							}),
-							// When small and on mobile, hide all images except the first one
-							isNotFirst && imageSize === 'small' && hideOnMobile,
-						]}
-					>
-						<CardPicture
-							master={slideshowImage.imageSrc}
-							imageSize={imageSize}
-							alt={slideshowImage.imageCaption}
-							loading={loading}
-						/>
+}) => (
+	<>
+		{takeFirst(images, 5).map((slideshowImage, index) => {
+			const isNotFirst = index > 0;
+			const loading = isNotFirst ? 'lazy' : 'eager';
+			return (
+				<figure
+					key={slideshowImage.imageSrc}
+					css={[
+						isNotFirst && overlayImage,
+						animationStyles({
+							imageIndex: index,
+							slideshowLength: images.length,
+							imageSize,
+						}),
+						// When small and on mobile, hide all images except the first one
+						isNotFirst && imageSize === 'small' && hideOnMobile,
+					]}
+				>
+					<CardPicture
+						master={slideshowImage.imageSrc}
+						imageSize={imageSize}
+						alt={slideshowImage.imageCaption}
+						loading={loading}
+					/>
+					{!!slideshowImage.imageCaption && (
 						<figcaption
 							css={[
 								captionStyles,
@@ -220,9 +216,9 @@ export const Slideshow = ({
 						>
 							{slideshowImage.imageCaption}
 						</figcaption>
-					</figure>
-				);
-			})}
-		</>
-	);
-};
+					)}
+				</figure>
+			);
+		})}
+	</>
+);


### PR DESCRIPTION
## What does this change?

- Add a negative delay for the first image
- Remove the figure caption gradient if there is no caption
- Refactor the component so the configuration makes sense
- Handle the case of a single image being passed down
- Add some stories for the `Slideshow` component

## Why?

Currently, the slideshow fades in, which looks odd. When images cross-fade, it’s possible to see the background through as they both have some transparency.

Help empower the current maintainers to feel empowered to make relevant changes to this component. Make it more visually pleasing. Improve [on Frontend’s version](https://github.com/guardian/frontend/pull/10325).

Crossfade is [hard](https://stackoverflow.com/a/73874280/1577447). I [made a visualisation to explain this further](https://www.mxdvl.com/tools/slideshow).

![screenshot of slideshow visualisation](https://github.com/guardian/dotcom-rendering/assets/76776/3d8c2606-8388-4398-b9b8-2e087fc55225)

## Screenshots

**Before** (notice initial white background)

https://github.com/guardian/dotcom-rendering/assets/76776/62781b4f-4bf8-4e48-a6a3-047d98fdb669

**After** (smooth as)

https://github.com/guardian/dotcom-rendering/assets/76776/7255c1d5-b5d4-492e-9590-50b0026f3ea4
