### PR TITLE
test: CDK Backend5xxAlarm alarm

### DIFF
--- a/dotcom-rendering/src/server/prod-server.ts
+++ b/dotcom-rendering/src/server/prod-server.ts
@@ -132,6 +132,20 @@ export const prodServer = (): void => {
 		handleAppsArticle,
 	);
 
+	// To test CDK 5xx alarm
+	app.get('/trigger-5xx', (req: Request, res: Response) => {
+		if (
+			req.headers['x-trigger-alarm'] === 'true' ||
+			req.cookies['trigger-alarm'] === 'true'
+		) {
+			throw new Error('Intentionally triggered 5xx for alarm testing.');
+		} else {
+			res.status(200).send(
+				'Endpoint for testing Backend5xxAlarm. Use the correct header or cookie to trigger a 5xx error.',
+			);
+		}
+	});
+
 	app.use('/ArticlePerfTest/*', handleArticlePerfTest);
 	app.use('/AMPArticlePerfTest/*', handleAMPArticlePerfTest);
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

As part of our migration to CDK (#7614), we are migrating the Backend5xxAlarm alarm (#7637). This PR tests the Backend5xxAlarm alarm to test if it would be triggered correctly and that the SNS topic notifications would work (and therefore PagerDuty notifications).

## Why?

We need to ensure that the Backend5xxAlarm alarm would work in a production environment, as it currently does in its un-CDK-ed state.

Rather than testing completely from end to end, @akash1810 suggested creating a dedicated endpoint in our server that, when accessed with a specific header or cookie, will intentionally induce 5xxs in our application to trigger the Backend5xxAlarm alarm and test it would work in a production environment. As well as testing the alarm's behaviour, it would also allow us to test its associated actions i.e. SNS topic notifications.

Checklist:
- [x] Set up SNS topic e.g. `Frontend-CODE-CriticalAlerts`
- [x] Link Cloudwatch Alarm to SNS topic
- [x] Ensure dedicated endpoint with specific header/cookie added to server
- [x] Use curl/Postman to send GET request to dedicated endpoint with specific header/cookie
- [x] Check Cloudwatch alarm is in alarm state
- [x] Check SNS notifications

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
