### PR TITLE
Expose `IdentityAuth` on `window` object

### DIFF
--- a/dotcom-rendering/src/lib/identity.ts
+++ b/dotcom-rendering/src/lib/identity.ts
@@ -34,14 +34,14 @@ const getRedirectUri = (stage: StageType) => {
 	}
 };
 
-let identityAuth: IdentityAuth<never, CustomIdTokenClaims> | undefined =
-	undefined;
-
 function getIdentityAuth() {
-	if (identityAuth === undefined) {
+	if (window.guardian.identityAuth === undefined) {
 		const stage = getStage();
 
-		identityAuth = new IdentityAuth<never, CustomIdTokenClaims>({
+		window.guardian.identityAuth = new IdentityAuth<
+			never,
+			CustomIdTokenClaims
+		>({
 			issuer: getIssuer(stage),
 			clientId: getClientId(stage),
 			redirectUri: getRedirectUri(stage),
@@ -61,7 +61,8 @@ function getIdentityAuth() {
 			],
 		});
 	}
-	return identityAuth;
+
+	return window.guardian.identityAuth;
 }
 
 export async function isSignedInWithOktaAuthState(): Promise<

--- a/dotcom-rendering/window.guardian.d.ts
+++ b/dotcom-rendering/window.guardian.d.ts
@@ -5,9 +5,11 @@ import type {
 	ConsentState,
 	VendorName,
 } from '@guardian/consent-management-platform/dist/types';
+import type { IdentityAuth } from '@guardian/identity-auth';
 import type { WeeklyArticleHistory } from '@guardian/support-dotcom-components/dist/dotcom/src/types';
 import type { OphanRecordFunction } from './src/client/ophan/ophan';
 import type { DailyArticleHistory } from './src/lib/dailyArticleCount';
+import type { CustomIdTokenClaims } from './src/lib/identity';
 import type { ReaderRevenueDevUtils } from './src/lib/readerRevenueDevUtils';
 import type { WindowGuardianConfig } from './src/model/window-guardian';
 
@@ -52,6 +54,7 @@ declare global {
 			weeklyArticleCount: WeeklyArticleHistory | undefined;
 			dailyArticleCount: DailyArticleHistory | undefined;
 			GAData: GADataType;
+			identityAuth?: IdentityAuth<never, CustomIdTokenClaims>;
 		};
 		GoogleAnalyticsObject: string;
 		ga: UniversalAnalytics.ga | null;


### PR DESCRIPTION
## What does this change?

DCRs version of https://github.com/guardian/frontend/pull/26469

## In future

Eventually we'd like to move all of this into a library so that it can make sure that our 3 setups (Frontend, DCR, and Commercial) all keep their settings in sync and edit window in the same way.