### PR TITLE
Switch load balancer type

### DIFF
--- a/dotcom-rendering/cdk/lib/__snapshots__/dotcom-rendering.test.ts.snap
+++ b/dotcom-rendering/cdk/lib/__snapshots__/dotcom-rendering.test.ts.snap
@@ -344,6 +344,11 @@ exports[`The DotcomRendering stack matches the snapshot 1`] = `
             ],
           },
         },
+        "LoadBalancerNames": [
+          {
+            "Ref": "InternalLoadBalancer",
+          },
+        ],
         "MaxSize": "4",
         "MinSize": "1",
         "Tags": [

--- a/dotcom-rendering/cdk/lib/dotcom-rendering.ts
+++ b/dotcom-rendering/cdk/lib/dotcom-rendering.ts
@@ -214,6 +214,8 @@ export class DotcomRendering extends GuStack {
 			reason: 'Retaining a stateful resource previously defined in YAML',
 		});
 
+		asg.attachToClassicLB(loadBalancer);
+
 		const yamlTemplateFilePath = join(
 			__dirname,
 			'../..',


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Replaces `CfnLoadBalancer` with `GuClassicLoadBalancer` for the load balancer migration.


## Why?

For the ASG (autoscaling group) migration, we want to be able to attach the ASG to our classic load balancer. This doesn't seem to be possible with the `CfnLoadBalancer` class as there's a type mismatch.

Turns out we can override some of the resulting cloudformation template with the `propertiesToOverride` field, which seems to do what we want it to. The only issue is that we have an extra orphaned security group which was created as part of the `GuClassicLoadBalancer` construct. We're planning on migrating from the classic LB to an application LB soon so this shouldn't make too much of a difference, especially as we don't actually _use_ this additional security group anywhere.

This is possibly a slightly better solution anyway as we're using Gu CDK for all resources rather than partially using the `Cfn` AWS lib ones.

