### PR TITLE
Enforce between 1 and 5 slides in Slideshow

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -9,7 +9,7 @@ import type { Branding } from '../../types/branding';
 import type {
 	DCRContainerPalette,
 	DCRContainerType,
-	DCRSlideshowImage,
+	DCRSlideshow,
 	DCRSnapType,
 	DCRSupportingContent,
 } from '../../types/front';
@@ -17,7 +17,8 @@ import type { MainMedia } from '../../types/mainMedia';
 import type { Palette } from '../../types/palette';
 import { Avatar } from '../Avatar';
 import { CardHeadline } from '../CardHeadline';
-import { CardPicture, Loading } from '../CardPicture';
+import type { Loading } from '../CardPicture';
+import { CardPicture } from '../CardPicture';
 import { Hide } from '../Hide';
 import { Island } from '../Island';
 import { LatestLinks } from '../LatestLinks.importable';
@@ -91,7 +92,7 @@ export type Props = {
 	/** The first card in a dynamic package is ”Dynamo” and gets special styling */
 	isDynamo?: true;
 	isExternalLink: boolean;
-	slideshowImages?: DCRSlideshowImage[];
+	slideshowImages?: DCRSlideshow;
 	showLivePlayable?: boolean;
 	onwardsSource?: string;
 	pauseOffscreenVideo?: boolean;
@@ -202,7 +203,7 @@ const getMedia = ({
 	imageAltText?: string;
 	avatarUrl?: string;
 	isCrossword?: boolean;
-	slideshowImages?: DCRSlideshowImage[];
+	slideshowImages?: DCRSlideshow;
 	mainMedia?: MainMedia;
 	isPlayableMediaCard?: boolean;
 }) => {

--- a/dotcom-rendering/src/components/Slideshow.stories.tsx
+++ b/dotcom-rendering/src/components/Slideshow.stories.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import { breakpoints, space } from '@guardian/source-foundations';
 import type { PropsWithChildren } from 'react';
-import type { DCRSlideshowImage } from '../types/front';
+import type { DCRSlideshow } from '../types/front';
 import { Slideshow } from './Slideshow';
 
 export default {
@@ -23,7 +23,7 @@ const one = [
 		imageSrc:
 			'https://media.guim.co.uk/d9ede9177cd8a01c7a7e87da54fb15e0615adf20/0_1597_6000_3599/master/6000.jpg',
 	},
-] as const satisfies readonly DCRSlideshowImage[];
+] as const satisfies DCRSlideshow;
 
 const two = [
 	{
@@ -36,7 +36,7 @@ const two = [
 			'https://media.guim.co.uk/fe310d0ab79125e2f55680b02b9347e45832e1f0/0_0_4800_3536/master/4800.jpg',
 		imageCaption: 'Dog Splash',
 	},
-] as const satisfies readonly DCRSlideshowImage[];
+] as const satisfies DCRSlideshow;
 
 const six = [
 	{
@@ -59,11 +59,7 @@ const six = [
 		imageSrc:
 			'https://media.guim.co.uk/cc9dc53d0eff3b047c6d045fa49cb48846a860b3/0_36_2048_1500/2048.jpg',
 	},
-	{
-		imageSrc:
-			'https://media.guim.co.uk/ed66e9dc6a84de6bc0afe1965833f0fa4047c22d/0_324_3500_2100/3500.jpg',
-	},
-] as const satisfies readonly DCRSlideshowImage[];
+] as const satisfies DCRSlideshow;
 
 const wrapper = css`
 	margin: ${space[3]}px;
@@ -85,13 +81,6 @@ const Wrapper = ({
 	>
 		{children}
 	</div>
-);
-
-/** this one makes no sense, but it’s technically possible so let’s capture it */
-export const WithoutAnyImage = () => (
-	<Wrapper maxWidth={480}>
-		<Slideshow images={[]} imageSize="medium" />
-	</Wrapper>
 );
 
 /** this one makes no sense, but it’s technically possible so let’s capture it */

--- a/dotcom-rendering/src/components/Slideshow.tsx
+++ b/dotcom-rendering/src/components/Slideshow.tsx
@@ -7,8 +7,7 @@ import {
 	textSans,
 	until,
 } from '@guardian/source-foundations';
-import { takeFirst } from '../lib/tuple';
-import type { DCRSlideshowImage } from '../types/front';
+import type { DCRSlideshow } from '../types/front';
 import type { ImageSizeType } from './Card/components/ImageWrapper';
 import { CardPicture } from './CardPicture';
 
@@ -143,14 +142,14 @@ export const Slideshow = ({
 	fade = 1,
 	display = 5,
 }: {
-	images: readonly DCRSlideshowImage[];
+	images: DCRSlideshow;
 	imageSize: ImageSizeType;
 	fade?: number;
 	display?: number;
 	isDynamo?: boolean;
 }) => (
 	<>
-		{takeFirst(images, 5).map((slideshowImage, index, { length }) => {
+		{images.map((slideshowImage, index, { length }) => {
 			const isNotFirst = index > 0;
 			const loading = isNotFirst ? 'lazy' : 'eager';
 

--- a/dotcom-rendering/src/lib/tuple.ts
+++ b/dotcom-rendering/src/lib/tuple.ts
@@ -1,30 +1,30 @@
 /** A tuple of up to 12 items. Larger tuples will not be narrowed */
 export type Tuple<T, N extends number> = N extends 12
-	? [T, T, T, T, T, T, T, T, T, T, T, T]
+	? readonly [T, T, T, T, T, T, T, T, T, T, T, T]
 	: N extends 11
-	? [T, T, T, T, T, T, T, T, T, T, T]
+	? readonly [T, T, T, T, T, T, T, T, T, T, T]
 	: N extends 10
-	? [T, T, T, T, T, T, T, T, T, T]
+	? readonly [T, T, T, T, T, T, T, T, T, T]
 	: N extends 9
-	? [T, T, T, T, T, T, T, T, T]
+	? readonly [T, T, T, T, T, T, T, T, T]
 	: N extends 8
-	? [T, T, T, T, T, T, T, T]
+	? readonly [T, T, T, T, T, T, T, T]
 	: N extends 7
-	? [T, T, T, T, T, T, T]
+	? readonly [T, T, T, T, T, T, T]
 	: N extends 6
-	? [T, T, T, T, T, T]
+	? readonly [T, T, T, T, T, T]
 	: N extends 5
-	? [T, T, T, T, T]
+	? readonly [T, T, T, T, T]
 	: N extends 4
-	? [T, T, T, T]
+	? readonly [T, T, T, T]
 	: N extends 3
-	? [T, T, T]
+	? readonly [T, T, T]
 	: N extends 2
-	? [T, T]
+	? readonly [T, T]
 	: N extends 1
-	? [T]
+	? readonly [T]
 	: N extends 0
-	? []
+	? readonly []
 	: T[];
 
 /**

--- a/dotcom-rendering/src/model/enhanceCards.ts
+++ b/dotcom-rendering/src/model/enhanceCards.ts
@@ -4,10 +4,11 @@ import { decideFormat } from '../lib/decideFormat';
 import type { EditionId } from '../lib/edition';
 import type { Group } from '../lib/getDataLinkName';
 import { getDataLinkNameCard } from '../lib/getDataLinkName';
+import { takeFirst } from '../lib/tuple';
 import type {
 	DCRContainerPalette,
 	DCRFrontCard,
-	DCRSlideshowImage,
+	DCRSlideshow,
 	DCRSupportingContent,
 	FEFrontCard,
 	FEMediaAtom,
@@ -146,15 +147,12 @@ const decideKicker = (
 
 const decideSlideshowImages = (
 	trail: FEFrontCard,
-): DCRSlideshowImage[] | undefined => {
-	const assets = trail.properties.image?.item.assets;
+): DCRSlideshow | undefined => {
+	const assets = takeFirst(trail.properties.image?.item.assets ?? [], 5);
 	const shouldShowSlideshow =
 		trail.properties.image?.type === 'ImageSlideshow' &&
 		trail.properties.imageSlideshowReplace;
-	if (shouldShowSlideshow && assets && assets.length > 0) {
-		return assets;
-	}
-	return undefined;
+	return shouldShowSlideshow && assets.length != 0 ? assets : undefined;
 };
 
 const enhanceTags = (tags: FETagType[]): TagType[] => {

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -1,6 +1,7 @@
 import type { ArticleSpecial, Pillar } from '@guardian/libs';
 import type { SharedAdTargeting } from '../lib/ad-targeting';
 import type { EditionId } from '../lib/edition';
+import type { Tuple } from '../lib/tuple';
 import type { DCRBadgeType } from './badge';
 import type { Branding } from './branding';
 import type { ServerSideTests, Switches } from './config';
@@ -316,11 +317,13 @@ export type DCRFrontCard = {
 	isExternalLink: boolean;
 	embedUri?: string;
 	branding?: Branding;
-	slideshowImages?: DCRSlideshowImage[];
+	slideshowImages?: DCRSlideshow;
 	showLivePlayable: boolean;
 };
 
-export type DCRSlideshowImage = {
+export type DCRSlideshow = Tuple<DCRSlideshowImage, 1 | 2 | 3 | 4 | 5>;
+
+type DCRSlideshowImage = {
 	imageSrc: string;
 	imageCaption?: string;
 };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Capture a tuple of length, 1, 2, 3, 4 or 5 for the `Slideshow` component.

## Why?

The `takeFirst` tuple helpers ensure that we only get a specific number of slides, preventing empty or overly long slideshow at the type-level.

Follow-up on #8544 

## Screenshots

N/A – but we got rid of the stories with 0 and 6+ slides.