### PR TITLE
Make some cartoon element fields optional

### DIFF
--- a/dotcom-rendering/src/components/CartoonComponent.mocks.ts
+++ b/dotcom-rendering/src/components/CartoonComponent.mocks.ts
@@ -1,4 +1,47 @@
-import type { CartoonBlockElement } from '../types/content';
+import type { CartoonBlockElement, CartoonVariant } from '../types/content';
+
+const variants: CartoonVariant[] = [
+	{
+		viewportSize: 'small',
+		images: [
+			{
+				index: 0,
+				mimeType: 'image/jpeg',
+				url: 'https://media.guim.co.uk/964dc2a933f5ec64b8298e763735fe3628deb3fc/3319_0_810_628/810.jpg',
+				fields: {
+					height: '833',
+					width: '622',
+				},
+				mediaType: 'Image',
+			},
+			{
+				index: 1,
+				mimeType: 'image/jpeg',
+				url: 'https://media.guim.co.uk/964dc2a933f5ec64b8298e763735fe3628deb3fc/2487_0_833_622/833.jpg',
+				fields: {
+					height: '810',
+					width: '628',
+				},
+				mediaType: 'Image',
+			},
+		],
+	},
+	{
+		viewportSize: 'large',
+		images: [
+			{
+				index: 0,
+				mimeType: 'image/jpeg',
+				url: 'https://media.guim.co.uk/964dc2a933f5ec64b8298e763735fe3628deb3fc/0_0_4129_1254/4129.jpg',
+				fields: {
+					height: '1254',
+					width: '4129',
+				},
+				mediaType: 'Image',
+			},
+		],
+	},
+];
 
 export const cartoon: CartoonBlockElement = {
 	_type: 'model.dotcomrendering.pageElements.CartoonBlockElement',
@@ -7,46 +50,11 @@ export const cartoon: CartoonBlockElement = {
 	credit: 'Comic by: Simone Lia / The Observer',
 	displayCredit: true,
 	alt: 'The Mary Poppins Method',
-	variants: [
-		{
-			viewportSize: 'small',
-			images: [
-				{
-					index: 0,
-					mimeType: 'image/jpeg',
-					url: 'https://media.guim.co.uk/964dc2a933f5ec64b8298e763735fe3628deb3fc/3319_0_810_628/810.jpg',
-					fields: {
-						height: '833',
-						width: '622',
-					},
-					mediaType: 'Image',
-				},
-				{
-					index: 1,
-					mimeType: 'image/jpeg',
-					url: 'https://media.guim.co.uk/964dc2a933f5ec64b8298e763735fe3628deb3fc/2487_0_833_622/833.jpg',
-					fields: {
-						height: '810',
-						width: '628',
-					},
-					mediaType: 'Image',
-				},
-			],
-		},
-		{
-			viewportSize: 'large',
-			images: [
-				{
-					index: 0,
-					mimeType: 'image/jpeg',
-					url: 'https://media.guim.co.uk/964dc2a933f5ec64b8298e763735fe3628deb3fc/0_0_4129_1254/4129.jpg',
-					fields: {
-						height: '1254',
-						width: '4129',
-					},
-					mediaType: 'Image',
-				},
-			],
-		},
-	],
+	variants,
+};
+
+export const cartoonWithoutCreditOrCaption: CartoonBlockElement = {
+	_type: 'model.dotcomrendering.pageElements.CartoonBlockElement',
+	role: 'inline',
+	variants,
 };

--- a/dotcom-rendering/src/components/CartoonComponent.stories.tsx
+++ b/dotcom-rendering/src/components/CartoonComponent.stories.tsx
@@ -1,7 +1,10 @@
 import { css } from '@emotion/react';
 import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
 import { CartoonComponent } from './CartoonComponent';
-import { cartoon } from './CartoonComponent.mocks';
+import {
+	cartoon,
+	cartoonWithoutCreditOrCaption,
+} from './CartoonComponent.mocks';
 import { Figure } from './Figure';
 import { Flex } from './Flex';
 import { LeftColumn } from './LeftColumn';
@@ -52,4 +55,23 @@ export const Cartoon = () => {
 		</Wrapper>
 	);
 };
-Cartoon.storyName = 'Cartoon';
+Cartoon.storyName = 'with credit and caption';
+
+export const CartoonWithoutCredit = () => {
+	return (
+		<Wrapper>
+			<Figure
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: Pillar.News,
+				}}
+				isMainMedia={false}
+				role="inline"
+			>
+				<CartoonComponent element={cartoonWithoutCreditOrCaption} />
+			</Figure>
+		</Wrapper>
+	);
+};
+CartoonWithoutCredit.storyName = 'with no credit or caption';

--- a/dotcom-rendering/src/components/CartoonComponent.tsx
+++ b/dotcom-rendering/src/components/CartoonComponent.tsx
@@ -39,7 +39,9 @@ export const CartoonComponent = ({ element }: Props) => {
 								design: ArticleDesign.Standard,
 								theme: Pillar.News,
 							}}
-							alt={`${element.alt}, panel ${image.index + 1}`}
+							alt={`${
+								element.alt ? `${element.alt}, ` : ''
+							}panel ${image.index + 1}`}
 							height={parseInt(image.fields.height, 10)}
 							width={parseInt(image.fields.width, 10)}
 							key={image.index}
@@ -58,7 +60,9 @@ export const CartoonComponent = ({ element }: Props) => {
 								design: ArticleDesign.Standard,
 								theme: Pillar.News,
 							}}
-							alt={`${element.alt}, panel ${image.index + 1}`}
+							alt={`${
+								element.alt ? `${element.alt}, ` : ''
+							}panel ${image.index + 1}`}
 							height={parseInt(image.fields.height, 10)}
 							width={parseInt(image.fields.width, 10)}
 							key={image.index}

--- a/dotcom-rendering/src/model/article-schema.json
+++ b/dotcom-rendering/src/model/article-schema.json
@@ -1326,18 +1326,6 @@
                 "role": {
                     "$ref": "#/definitions/RoleType"
                 },
-                "caption": {
-                    "type": "string"
-                },
-                "credit": {
-                    "type": "string"
-                },
-                "displayCredit": {
-                    "type": "boolean"
-                },
-                "alt": {
-                    "type": "string"
-                },
                 "variants": {
                     "type": "array",
                     "items": {
@@ -1362,14 +1350,22 @@
                             "viewportSize"
                         ]
                     }
+                },
+                "caption": {
+                    "type": "string"
+                },
+                "credit": {
+                    "type": "string"
+                },
+                "displayCredit": {
+                    "type": "boolean"
+                },
+                "alt": {
+                    "type": "string"
                 }
             },
             "required": [
                 "_type",
-                "alt",
-                "caption",
-                "credit",
-                "displayCredit",
                 "role",
                 "variants"
             ]

--- a/dotcom-rendering/src/model/block-schema.json
+++ b/dotcom-rendering/src/model/block-schema.json
@@ -857,18 +857,6 @@
                 "role": {
                     "$ref": "#/definitions/RoleType"
                 },
-                "caption": {
-                    "type": "string"
-                },
-                "credit": {
-                    "type": "string"
-                },
-                "displayCredit": {
-                    "type": "boolean"
-                },
-                "alt": {
-                    "type": "string"
-                },
                 "variants": {
                     "type": "array",
                     "items": {
@@ -893,14 +881,22 @@
                             "viewportSize"
                         ]
                     }
+                },
+                "caption": {
+                    "type": "string"
+                },
+                "credit": {
+                    "type": "string"
+                },
+                "displayCredit": {
+                    "type": "boolean"
+                },
+                "alt": {
+                    "type": "string"
                 }
             },
             "required": [
                 "_type",
-                "alt",
-                "caption",
-                "credit",
-                "displayCredit",
                 "role",
                 "variants"
             ]

--- a/dotcom-rendering/src/types/content.ts
+++ b/dotcom-rendering/src/types/content.ts
@@ -92,14 +92,14 @@ export interface CalloutBlockElementV2 {
 export interface CartoonBlockElement {
 	_type: 'model.dotcomrendering.pageElements.CartoonBlockElement';
 	role: RoleType;
-	caption: string;
-	credit: string;
-	displayCredit: boolean;
-	alt: string;
-	variants: Variant[];
+	variants: CartoonVariant[];
+	caption?: string;
+	credit?: string;
+	displayCredit?: boolean;
+	alt?: string;
 }
 
-type Variant = {
+export type CartoonVariant = {
 	viewportSize: 'small' | 'large';
 	images: Image[];
 };


### PR DESCRIPTION
## What does this change?
This makes some fields (namely caption, credit, displayCredit and alt) optional in the cartoon block element.

## Why?
This is to avoid rendering errors as it may be possible for these elements to come through with some or all of these fields missing.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| <img width="400" alt="Screenshot 2023-08-14 at 12 32 53" src="https://github.com/guardian/dotcom-rendering/assets/33927854/464f5f9c-f8b6-4797-95cf-b73a8cdf9f7c"> | <img width="400" alt="Screenshot 2023-08-14 at 12 33 02" src="https://github.com/guardian/dotcom-rendering/assets/33927854/8c6a43d2-dfd1-481b-ac24-1bc8dee8b309"> |

The Caption component already allows for these fields to be empty, so there should be no further changes required.
