### PR TITLE
Scheduler: more meaningful measurements for `sentryLoader`

### DIFF
--- a/dotcom-rendering/src/client/sentryLoader/index.test.ts
+++ b/dotcom-rendering/src/client/sentryLoader/index.test.ts
@@ -11,7 +11,7 @@ describe('Enable Sentry when it passes loading conditions', () => {
 				enableSentryReporting: false,
 				isInBrowserVariantTest: true,
 				isInOktaVariantTest: false,
-				randomCentile: 99,
+				random: 99 / 100,
 			}),
 		).toEqual(false);
 	});
@@ -22,7 +22,7 @@ describe('Enable Sentry when it passes loading conditions', () => {
 				enableSentryReporting: true,
 				isInBrowserVariantTest: true,
 				isInOktaVariantTest: true,
-				randomCentile: 1,
+				random: 1 / 100,
 			}),
 		).toEqual(false);
 	});
@@ -33,7 +33,7 @@ describe('Enable Sentry when it passes loading conditions', () => {
 				enableSentryReporting: true,
 				isInBrowserVariantTest: true,
 				isInOktaVariantTest: false,
-				randomCentile: 1,
+				random: 1 / 100,
 			}),
 		).toEqual(true);
 	});
@@ -44,7 +44,7 @@ describe('Enable Sentry when it passes loading conditions', () => {
 				enableSentryReporting: true,
 				isInBrowserVariantTest: false,
 				isInOktaVariantTest: true,
-				randomCentile: 1,
+				random: 1 / 100,
 			}),
 		).toEqual(true);
 	});
@@ -55,7 +55,7 @@ describe('Enable Sentry when it passes loading conditions', () => {
 				enableSentryReporting: true,
 				isInBrowserVariantTest: false,
 				isInOktaVariantTest: false,
-				randomCentile: 1,
+				random: 1 / 100,
 			}),
 		).toEqual(false);
 		expect(
@@ -64,7 +64,7 @@ describe('Enable Sentry when it passes loading conditions', () => {
 				enableSentryReporting: true,
 				isInBrowserVariantTest: false,
 				isInOktaVariantTest: false,
-				randomCentile: 99,
+				random: 99 / 100,
 			}),
 		).toEqual(false);
 		expect(
@@ -73,7 +73,16 @@ describe('Enable Sentry when it passes loading conditions', () => {
 				enableSentryReporting: true,
 				isInBrowserVariantTest: false,
 				isInOktaVariantTest: false,
-				randomCentile: 100,
+				random: 99.0001 / 100,
+			}),
+		).toEqual(true);
+		expect(
+			isSentryEnabled({
+				isDev: false,
+				enableSentryReporting: true,
+				isInBrowserVariantTest: false,
+				isInOktaVariantTest: false,
+				random: 100 / 100,
 			}),
 		).toEqual(true);
 	});


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Add one more measurement to `sentryLoader`: the actualy time it takes to inject Sentry when an error occurs. This will not be recorded on every page view, only those with errors.

Refactor imports so their intent is clearer

## Why?

Better understanding of the performance cost of Sentry.

Part of #8529 

## Screenshots

N/A 

You can trigger and error with the following code:

```js
window.guardian.modules.sentry.reportError(new Error("trigger Sentry injection"))
```