### PR TITLE
Switch off liveblog right column ads AB test

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -66,7 +66,7 @@
 		"@guardian/bridget": "2.3.0",
 		"@guardian/browserslist-config": "5.0.0",
 		"@guardian/cdk": "50.10.6",
-		"@guardian/commercial": "10.15.0",
+		"@guardian/commercial": "10.17.0",
 		"@guardian/consent-management-platform": "13.6.1",
 		"@guardian/core-web-vitals": "5.1.0",
 		"@guardian/eslint-config": "4.1.0",

--- a/dotcom-rendering/src/experiments/tests/liveblog-right-column-ads.ts
+++ b/dotcom-rendering/src/experiments/tests/liveblog-right-column-ads.ts
@@ -5,7 +5,7 @@ export const liveblogRightColumnAds: ABTest = {
 	author: '@commercial-dev',
 	start: '2023-08-01',
 	expiry: '2023-09-20',
-	audience: 15 / 100,
+	audience: 0 / 100,
 	audienceOffset: 0 / 100,
 	audienceCriteria: 'Desktop users with wide (1300px+) screens only',
 	successMeasure:

--- a/yarn.lock
+++ b/yarn.lock
@@ -3120,10 +3120,10 @@
     read-pkg-up "7.0.1"
     yargs "^17.6.2"
 
-"@guardian/commercial@10.15.0":
-  version "10.15.0"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-10.15.0.tgz#35357141e918e50f0f2c015f41c23c4987b70faa"
-  integrity sha512-EJn6P4f962oJG+o90ngHXaTlV/oPVwdv5dlaK0biwvOpm7YkHK1X3JTNxi0HYax38mpKlUGMoKiubboum5/DAQ==
+"@guardian/commercial@10.17.0":
+  version "10.17.0"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-10.17.0.tgz#09304997478490ed36690475b89884ea6bf40763"
+  integrity sha512-AZTIyKqD39waxhi4hr6iyiUbVI0EvQKszPbbDLJaB8uYItVDteSeQ7kgXZxC4Nn+suXwnFcyY2eUv5v5hoke9Q==
   dependencies:
     "@changesets/cli" "^2.26.1"
     "@guardian/ab-core" "^5.0.0"


### PR DESCRIPTION
## What does this change?

Turns off the liveblog-right-column-ads AB test.

## Why?

We have reached the required number of impressions to obtain a result for the test.