### PR TITLE
Add missing merchandising-high slot under labs containers on fronts

### DIFF
--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -87,7 +87,6 @@ export const decideAdSlot = (
 	mobileAdPositions: (number | undefined)[],
 	hasPageSkin: boolean,
 	isInFrontsBannerTest?: boolean,
-	isBrandedSection?: boolean,
 ) => {
 	if (!renderAds) return null;
 
@@ -104,7 +103,7 @@ export const decideAdSlot = (
 				hasPageskin={hasPageSkin}
 			/>
 		);
-	} else if (!isBrandedSection && mobileAdPositions.includes(index)) {
+	} else if (mobileAdPositions.includes(index)) {
 		return (
 			<Hide from="tablet">
 				<AdSlot
@@ -594,7 +593,6 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 									mobileAdPositions,
 									hasPageSkin,
 									isInFrontsBannerTest,
-									true,
 								)}
 							</Fragment>
 						);

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -87,6 +87,7 @@ export const decideAdSlot = (
 	mobileAdPositions: (number | undefined)[],
 	hasPageSkin: boolean,
 	isInFrontsBannerTest?: boolean,
+	isBrandedSection?: boolean,
 ) => {
 	if (!renderAds) return null;
 
@@ -103,7 +104,7 @@ export const decideAdSlot = (
 				hasPageskin={hasPageSkin}
 			/>
 		);
-	} else if (mobileAdPositions.includes(index)) {
+	} else if (!isBrandedSection && mobileAdPositions.includes(index)) {
 		return (
 			<Hide from="tablet">
 				<AdSlot
@@ -551,34 +552,51 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 						renderAds
 					) {
 						return (
-							<LabsSection
-								key={ophanName}
-								title={collection.displayName}
-								collectionId={collection.id}
-								pageId={front.pressedPage.id}
-								ajaxUrl={front.config.ajaxUrl}
-								sectionId={`container-${ophanName}`}
-								ophanComponentName={ophanName}
-								ophanComponentLink={ophanComponentLink}
-								containerName={collection.collectionType}
-								canShowMore={collection.canShowMore}
-								url={collection.href}
-								badge={collection.badge}
-								data-print-layout="hide"
-								hasPageSkin={hasPageSkin}
-							>
-								<DecideContainer
-									trails={trailsWithoutBranding}
-									groupedTrails={collection.grouped}
-									containerType={collection.collectionType}
-									containerPalette={
-										collection.containerPalette
-									}
-									imageLoading={imageLoading}
-									adIndex={desktopAdPositions.indexOf(index)}
-									renderAds={renderMpuAds}
-								/>
-							</LabsSection>
+							<Fragment key={ophanName}>
+								<LabsSection
+									title={collection.displayName}
+									collectionId={collection.id}
+									pageId={front.pressedPage.id}
+									ajaxUrl={front.config.ajaxUrl}
+									sectionId={`container-${ophanName}`}
+									ophanComponentName={ophanName}
+									ophanComponentLink={ophanComponentLink}
+									containerName={collection.collectionType}
+									canShowMore={collection.canShowMore}
+									url={collection.href}
+									badge={collection.badge}
+									data-print-layout="hide"
+									hasPageSkin={hasPageSkin}
+								>
+									<DecideContainer
+										trails={trailsWithoutBranding}
+										groupedTrails={collection.grouped}
+										containerType={
+											collection.collectionType
+										}
+										containerPalette={
+											collection.containerPalette
+										}
+										imageLoading={imageLoading}
+										adIndex={desktopAdPositions.indexOf(
+											index,
+										)}
+										renderAds={renderMpuAds}
+									/>
+								</LabsSection>
+								{decideAdSlot(
+									renderAds,
+									index,
+									front.isNetworkFront,
+									front.pressedPage.collections.length,
+									front.pressedPage.frontProperties
+										.isPaidContent,
+									mobileAdPositions,
+									hasPageSkin,
+									isInFrontsBannerTest,
+									true,
+								)}
+							</Fragment>
 						);
 					}
 


### PR DESCRIPTION
## What does this change?
Add missing merchandising-high slot under labs containers

## Why?
At the moment there is a chance that merchansing-high won't appear at all on some fronts like the travel front at time of writing, Ad Opts relies on it being there for takeover campaigns that have been sold to advertisers.

Frontend already behaves this way so this must have been missed in the migration.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |
| ![before2][] | ![after2][] |


[before]: https://github.com/guardian/dotcom-rendering/assets/1731150/ac0d3a6c-85ef-4108-9fde-83adae61736f
[after]: https://github.com/guardian/dotcom-rendering/assets/1731150/d3118c49-119f-4ca4-95f9-fa35e764d069
[before2]: https://github.com/guardian/dotcom-rendering/assets/1731150/1a8128f8-e499-4ebb-a6a6-f70dc402999b
[after2]: https://github.com/guardian/dotcom-rendering/assets/1731150/82448509-cf2b-4379-ad9b-b73299347761



<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
