### PR TITLE
Bump `@guardian/identity-auth@0.5.0`

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -72,7 +72,7 @@
 		"@guardian/eslint-config": "4.1.0",
 		"@guardian/eslint-config-typescript": "6.0.1",
 		"@guardian/eslint-plugin-source-react-components": "18.0.0",
-		"@guardian/identity-auth": "0.4.0",
+		"@guardian/identity-auth": "0.5.0",
 		"@guardian/libs": "15.6.4",
 		"@guardian/prettier": "5.0.0",
 		"@guardian/shimport": "1.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3181,10 +3181,10 @@
     "@typescript-eslint/eslint-plugin" "5.46.1"
     "@typescript-eslint/parser" "5.59.9"
 
-"@guardian/identity-auth@0.4.0":
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/@guardian/identity-auth/-/identity-auth-0.4.0.tgz#11fc3b9daec7b4186cf0822b18d6379dbdac8ce5"
-  integrity sha512-+lXmoMhrACvibKYBIwKQ15zyWGiGKC+mOg8831R8ilwF3vwXuXnzCLy1EpLTlSfDf72IOAuGyX4gDOqdQP8R/w==
+"@guardian/identity-auth@0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@guardian/identity-auth/-/identity-auth-0.5.0.tgz#5bfd869ea23959cffdcb25820a7e85e8b28b8a5f"
+  integrity sha512-0nfVZp9X8cNSoWOj7sS7DmyCKCEOhnZiUzMZ2FpgjED/Kawd4bC8FhuLN65Cvd0ryW2N4zD3azVBKUK8OBogLg==
 
 "@guardian/libs@15.6.4":
   version "15.6.4"


### PR DESCRIPTION
Fixes an issue with calculating the clock skew, and will unblock us from continuing with the Okta rollout.