### PR TITLE
Improve reliability of Cypress liveblog tests

### DIFF
--- a/dotcom-rendering/cypress/e2e/parallel-5/liveblog.interactivity.cy.js
+++ b/dotcom-rendering/cypress/e2e/parallel-5/liveblog.interactivity.cy.js
@@ -56,17 +56,17 @@ describe('Liveblogs', function () {
 				html: '<p>New block</p>',
 				mostRecentBlockId: 'abc',
 			});
-			cy.get(`[data-cy="toast"]`).should('exist');
-			cy.contains('1 new update');
-			cy.window().then(function (win) {
-				win.mockLiveUpdate({
-					numNewBlocks: 1,
-					html: '<p>New block</p>',
-					mostRecentBlockId: 'abc',
-				});
-				cy.contains('2 new updates');
+		});
+		cy.get(`[data-cy="toast"]`).should('exist');
+		cy.contains('1 new update');
+		cy.window().then(function (win) {
+			win.mockLiveUpdate({
+				numNewBlocks: 1,
+				html: '<p>New block</p>',
+				mostRecentBlockId: 'abc',
 			});
 		});
+		cy.contains('2 new updates');
 	});
 
 	it('should insert the html from the update call', function () {
@@ -82,8 +82,8 @@ describe('Liveblogs', function () {
 				html: '<p>New block</p>',
 				mostRecentBlockId: 'abc',
 			});
-			cy.contains('New block');
 		});
+		cy.contains('New block');
 	});
 
 	it('should scroll the page to the top and reveal content when the toast is clicked', function () {
@@ -101,10 +101,10 @@ describe('Liveblogs', function () {
 				html: '<p>New block</p>',
 				mostRecentBlockId: 'abc',
 			});
-			cy.get(`[data-cy="toast"]`).should('exist');
-			cy.contains('1 new update').click({ force: true });
-			cy.get(`[data-cy="toast"]`).should('not.exist');
 		});
+		cy.get(`[data-cy="toast"]`).should('exist');
+		cy.contains('1 new update').click({ force: true });
+		cy.get(`[data-cy="toast"]`).should('not.exist');
 	});
 
 	it('should enhance tweets after they have been inserted', function () {
@@ -129,14 +129,14 @@ describe('Liveblogs', function () {
 				html: tweetBlock,
 				mostRecentBlockId: 'abc',
 			});
-			cy.scrollTo(0, 1200);
-			getTwitterIframe().contains(
-				'They will prepare the extraordinary European Council meeting tonight',
-				{
-					timeout: 15000,
-				},
-			);
 		});
+		cy.scrollTo(0, 1200);
+		getTwitterIframe().contains(
+			'They will prepare the extraordinary European Council meeting tonight',
+			{
+				timeout: 15000,
+			},
+		);
 	});
 
 	it('should use the right block id when polling from the second page', function () {
@@ -173,15 +173,15 @@ describe('Liveblogs', function () {
 				html: '<p>New block</p>',
 				mostRecentBlockId: 'abc',
 			});
-			cy.get(`[data-cy="toast"]`).should('exist');
-			cy.contains('1 new update').click({ force: true });
-			cy.location().should((loc) => {
-				expect(loc.hash).to.eq('#maincontent');
-				expect(loc.pathname).to.eq(
-					'/australia-news/live/2022/feb/22/australia-news-live-updates-scott-morrison-nsw-trains-coronavirus-covid-omicron-weather',
-				);
-				expect(loc.search).to.eq('');
-			});
+		});
+		cy.get(`[data-cy="toast"]`).should('exist');
+		cy.contains('1 new update').click({ force: true });
+		cy.location().should((loc) => {
+			expect(loc.hash).to.eq('#maincontent');
+			expect(loc.pathname).to.eq(
+				'/australia-news/live/2022/feb/22/australia-news-live-updates-scott-morrison-nsw-trains-coronavirus-covid-omicron-weather',
+			);
+			expect(loc.search).to.eq('');
 		});
 	});
 
@@ -199,20 +199,20 @@ describe('Liveblogs', function () {
 				html: tweetBlock,
 				mostRecentBlockId: 'abc',
 			});
-			cy.get('#46d194c9-ea50-4cd5-af8b-a51e8b15c65e').should(
-				'not.be.visible',
-			);
-
-			// Previously we were using #maincontent as top of blog.
-			// After repositioning the key events, the test scrolling
-			// was not enough and the tweetBlock was not added to
-			// the page. Using data-gu-name="media" for now to get
-			// around this scroll depth issue
-			cy.get('div[data-gu-name="media"]').scrollIntoView();
-			cy.get('#46d194c9-ea50-4cd5-af8b-a51e8b15c65e', {
-				timeout: 10000,
-			}).should('be.visible');
 		});
+		cy.get('#46d194c9-ea50-4cd5-af8b-a51e8b15c65e').should(
+			'not.be.visible',
+		);
+
+		// Previously we were using #maincontent as top of blog.
+		// After repositioning the key events, the test scrolling
+		// was not enough and the tweetBlock was not added to
+		// the page. Using data-gu-name="media" for now to get
+		// around this scroll depth issue
+		cy.get('div[data-gu-name="media"]').scrollIntoView();
+		cy.get('#46d194c9-ea50-4cd5-af8b-a51e8b15c65e', {
+			timeout: 10000,
+		}).should('be.visible');
 	});
 
 	// For some reason Sport deadblogs lose their scores after a certain duration. Not quite sure what causes this just yet


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

- Moved `cy.should(...)` outside of `cy.(...).then(...)`.

## Why?

When retrying, it appears that Cypress is retrying from the top of the `.then()`, which is causing the insertion of another tweet block, called by `mockLiveUpdate`. We don't want another tweet block to be inserting when retrying subsequent Cypress commands, so move subsequent Cypress commands out of `.then()`. There are some other test that use the same pattern

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/9574885/7d681362-1af0-44e3-a76a-a7b751106dcc
[after]: https://github.com/guardian/dotcom-rendering/assets/9574885/46ae0559-358a-41c3-831b-c21201c603e8



