### PR TITLE
Hf/fix sublink accessibility

### DIFF
--- a/dotcom-rendering/src/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/components/CardHeadline.tsx
@@ -155,7 +155,7 @@ const labTextStyles = (size: SmallHeadlineSize) => {
 };
 
 const sublinkStyles = css`
-	display: inline-block;
+	display: block;
 	/* See: https://css-tricks.com/nested-links/ */
 	${getZIndex('card-nested-link')}
 	/* The following styles turn off those provided by Link */
@@ -166,6 +166,9 @@ const sublinkStyles = css`
 	font-size: inherit;
 	font-weight: ${fontWeights.medium};
 	line-height: inherit;
+	${until.desktop} {
+		min-height: 48px;
+	}
 	/* This css is used to remove any underline from the kicker but still
 	 * have it applied to the headline when the kicker is hovered */
 	:hover {

--- a/dotcom-rendering/src/components/SupportingContent.tsx
+++ b/dotcom-rendering/src/components/SupportingContent.tsx
@@ -59,8 +59,11 @@ const liStyles = css`
 	flex: 1;
 	padding-top: 2px;
 	position: relative;
-	margin-top: 8px;
+	&:first-child {
+		margin-top: 8px;
+	}
 	${from.tablet} {
+		margin-top: 8px;
 		margin-bottom: 4px;
 	}
 `;
@@ -76,12 +79,6 @@ const dynamoLiStyles = css`
 const leftMargin = css`
 	${from.tablet} {
 		margin-left: 10px;
-	}
-`;
-
-const bottomMargin = css`
-	${until.tablet} {
-		margin-bottom: 8px;
 	}
 `;
 
@@ -122,7 +119,6 @@ export const SupportingContent = ({
 								  ]
 								: liStyles,
 							shouldPadLeft && leftMargin,
-							isLast && bottomMargin,
 						]}
 						data-link-name={`sublinks | ${index + 1}`}
 					>

--- a/dotcom-rendering/src/components/SupportingContent.tsx
+++ b/dotcom-rendering/src/components/SupportingContent.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { from, neutral, until } from '@guardian/source-foundations';
+import { from, neutral } from '@guardian/source-foundations';
 import { decidePalette } from '../lib/decidePalette';
 import { transparentColour } from '../lib/transparentColour';
 import type { DCRContainerPalette, DCRSupportingContent } from '../types/front';
@@ -102,7 +102,6 @@ export const SupportingContent = ({
 				if (!subLink.headline) return null;
 				const shouldPadLeft =
 					!isDynamo && index > 0 && alignment === 'horizontal';
-				const isLast = index === length - 1;
 				return (
 					<li
 						key={subLink.url}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Fixes this 
https://github.com/guardian/dotcom-rendering/issues/8425

## Why?
Sublinks were hard to tap on mobile
