### PR TITLE
Reintroduce Fallback `line-height`

### DIFF
--- a/apps-rendering/src/server/page.tsx
+++ b/apps-rendering/src/server/page.tsx
@@ -68,6 +68,7 @@ const styles = (format: ArticleFormat): string => `
         margin: 0;
         font-family: 'Guardian Text Egyptian Web';
         overflow-x: hidden;
+        line-height: 1.4;
     }
 
     @media (prefers-color-scheme: dark) {


### PR DESCRIPTION
This was removed when we made the change from 1.5 to 1.4 in #8385, but is still needed as the styles here are not making use of the Source typography API.
