### PR TITLE
Create a `decideUrl` function in `enhanceCards`

### DIFF
--- a/dotcom-rendering/src/model/enhanceCards.ts
+++ b/dotcom-rendering/src/model/enhanceCards.ts
@@ -112,17 +112,15 @@ const decideAvatarUrl = (
 /**
  * This function decides the best URL to link to on a Card or Supporting Content. It will pick the first non-undefined property of the following:
  *
- * `trail.properties.webUrl` - Where CAPI expects the content to be. Fully qualified but turned into a relative URL by DCR if possible.
- *                             Ignored if the trail is type LinkSnap.
+ * `trail.properties.webUrl` - Where CAPI expects the content to be. Fully qualified but turned into a relative URL by DCR if possible. Ignored if the trail is type LinkSnap.
  * `trail.properties.href` - Location that a LinkSnap references.
- * `trail.header.url` - Where Frontend/FAPI expects the content to be. Usually identical to a relative-ized webUrl.
+ * `trail.header.url` - Where Frontend/FAPI expects the content to be. Usually identical to a relative-ized webUrl. In theory this should never get picked but it's the only URL where we're guaranteed it not be undefined which makes TypeScript happy.
  */
 const decideUrl = (trail: FESupportingContent | FEFrontCard) => {
 	/**
 	 * Frontend gives us fully qualified webUrls (https://www.theguardian.com/a/thing) which we want as relative URLs instead
 	 *
-	 * Don't try to provide a relative URL for LinkSnap, these will link to domains other than www.theguardian.com
-	 * and therefore wont have a relative path.
+	 * Don't try to provide a relative URL for LinkSnap, these will link to domains other than www.theguardian.com and therefore wont have a relative path.
 	 */
 	if (
 		trail.properties.webUrl !== undefined &&
@@ -135,7 +133,7 @@ const decideUrl = (trail: FESupportingContent | FEFrontCard) => {
 			 * In theory CAPI/FAPI/Frontend should never give us an webURL but
 			 * lets just fallback to a non relative URL just in case.
 			 *
-			 * Unfortunately we can't access `logger` from here as this code also needs to be ran on the client by ShowMore.
+			 * Ideally we'd like to know when this happens, but unfortunately we can't access `logger` from here as this code also needs to be ran on the client by ShowMore.
 			 */
 		}
 	}

--- a/dotcom-rendering/src/model/front-schema.json
+++ b/dotcom-rendering/src/model/front-schema.json
@@ -1196,6 +1196,9 @@
                                                         "properties": {
                                                             "href": {
                                                                 "type": "string"
+                                                            },
+                                                            "webUrl": {
+                                                                "type": "string"
                                                             }
                                                         }
                                                     },
@@ -1259,6 +1262,7 @@
                                                     }
                                                 },
                                                 "required": [
+                                                    "header",
                                                     "properties"
                                                 ]
                                             }
@@ -1918,6 +1922,9 @@
                                                         "properties": {
                                                             "href": {
                                                                 "type": "string"
+                                                            },
+                                                            "webUrl": {
+                                                                "type": "string"
                                                             }
                                                         }
                                                     },
@@ -1981,6 +1988,7 @@
                                                     }
                                                 },
                                                 "required": [
+                                                    "header",
                                                     "properties"
                                                 ]
                                             }
@@ -2640,6 +2648,9 @@
                                                         "properties": {
                                                             "href": {
                                                                 "type": "string"
+                                                            },
+                                                            "webUrl": {
+                                                                "type": "string"
                                                             }
                                                         }
                                                     },
@@ -2703,6 +2714,7 @@
                                                     }
                                                 },
                                                 "required": [
+                                                    "header",
                                                     "properties"
                                                 ]
                                             }

--- a/dotcom-rendering/src/model/tag-front-schema.json
+++ b/dotcom-rendering/src/model/tag-front-schema.json
@@ -631,6 +631,9 @@
                                     "properties": {
                                         "href": {
                                             "type": "string"
+                                        },
+                                        "webUrl": {
+                                            "type": "string"
                                         }
                                     }
                                 },
@@ -694,6 +697,7 @@
                                 }
                             },
                             "required": [
+                                "header",
                                 "properties"
                             ]
                         }

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -535,8 +535,9 @@ type FEFrontPropertiesType = {
 export type FESupportingContent = {
 	properties: {
 		href?: string;
+		webUrl?: string;
 	};
-	header?: {
+	header: {
 		kicker?: {
 			item?: {
 				properties: {


### PR DESCRIPTION
## What does this change?

Creates a new `decideUrl` function in `enhanceCards` which prioritizes the `trail.properties.webUrl` property over `trail.properties.href` and `trail.header.url`

`webUrl` is a fully qualified URL so this function also takes care of turning it into a relative URL.

## Why?

 - DCR currently uses `trail.header.url` for the URL of a card. This is the URL that FAPI thinks is where the content lives. However, if an article is moved this URL will not update until someone manually updates the card in FAPI, instead webUrl is where CAPI thinks the article lives. By using webUrl we avoid creating unecessary redirects for users.
   - The Ophan heatmap also expect the latest URL for an article and will not work on cards that use old URLs. Part of #8575
 - We convert webUrl to a relative URL because A) thats what we've always done in Frontend and B) allows DCR dev-server to still redirect these URLs to localhost.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/21217225/641c31cd-5326-4382-98a8-e6ff8374372a
[after]: https://github.com/guardian/dotcom-rendering/assets/21217225/50409ec4-2eff-4003-aae4-731d781e658c

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
