### PR TITLE
Respect `rel` attribute on Links in articles

### DIFF
--- a/dotcom-rendering/src/components/TextBlockComponent.tsx
+++ b/dotcom-rendering/src/components/TextBlockComponent.tsx
@@ -242,6 +242,7 @@ const buildElementTree =
 						getAttrs(node)?.getNamedItem('data-link-name')?.value,
 					'data-component':
 						getAttrs(node)?.getNamedItem('data-component')?.value,
+					rel: getAttrs(node)?.getNamedItem('rel')?.value,
 					key,
 					children,
 				});


### PR DESCRIPTION
## What does this change?

Respect `rel` attribute in links in the Article body.

## Why?

Composer adds `rel="nofollow"` to any links in Branded content.

Fixes #8586

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/21217225/64ced9d3-953e-4070-949b-17789c6c9c5a

[after]: https://github.com/guardian/dotcom-rendering/assets/21217225/94576ca1-7bab-4b54-84ec-e6023f430526

