### PR TITLE
feat(ophan): test ESM beta version

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -214,6 +214,7 @@
 		"node-fetch": "2.6.7",
 		"npm-run-all": "4.1.5",
 		"ophan-tracker-js": "1.4.0",
+		"ophan-tracker-js-esm": "npm:ophan-tracker-js@2.0.0-beta-5",
 		"parse5": "7.1.2",
 		"pm2": "5.3.0",
 		"preact": "10.15.1",

--- a/dotcom-rendering/scripts/env/check-deps.js
+++ b/dotcom-rendering/scripts/env/check-deps.js
@@ -15,6 +15,7 @@ const { object: json } = lockfile.parse(
 
 const knownNonSemver = /** @type {const} */ ([
 	'https://github.com/guardian/babel-plugin-px-to-rem#v0.1.0',
+	'npm:ophan-tracker-js@2.0.0-beta-5',
 ]);
 
 const mismatches = Object.entries(pkg.dependencies)

--- a/dotcom-rendering/scripts/test/build-check.js
+++ b/dotcom-rendering/scripts/test/build-check.js
@@ -29,6 +29,7 @@ const fileExists = async (glob) => {
 	// Check that the manifest files exist
 	await fileExists('manifest.web.json');
 	await fileExists('manifest.web.scheduled.json');
+	await fileExists('manifest.web.ophan-esm.json');
 	await fileExists('manifest.web.legacy.json');
 	if (BUILD_VARIANT) await fileExists('manifest.web.variant.json');
 
@@ -36,6 +37,7 @@ const fileExists = async (glob) => {
 	const manifests = [
 		await loadJsonFile('./dist/manifest.web.json'),
 		await loadJsonFile('./dist/manifest.web.scheduled.json'),
+		await loadJsonFile('./dist/manifest.web.ophan-esm.json'),
 		await loadJsonFile('./dist/manifest.web.legacy.json'),
 	];
 	if (BUILD_VARIANT) {

--- a/dotcom-rendering/scripts/webpack/bundles.js
+++ b/dotcom-rendering/scripts/webpack/bundles.js
@@ -26,8 +26,12 @@ const dcrJavascriptBundle = (variant) => `dcrJavascriptBundle${variant}`;
 /** @type {(variant: 'Variant' | 'Control') => import("../../src/types/config").ServerSideTestNames} */
 const adaptive = (variant) => `adaptiveSite${variant}`;
 
+/** @type {(variant: 'Variant' | 'Control') => import("../../src/types/config").ServerSideTestNames} */
+const ophanEsm = (variant) => `ophanEsm${variant}`;
+
 module.exports = {
 	BUILD_VARIANT,
 	dcrJavascriptBundle,
 	adaptive,
+	ophanEsm,
 };

--- a/dotcom-rendering/scripts/webpack/webpack.config.client.js
+++ b/dotcom-rendering/scripts/webpack/webpack.config.client.js
@@ -67,6 +67,7 @@ const getLoaders = (build) => {
 			return swcLoader(['android >= 5', 'ios >= 12']);
 		case 'web.variant':
 		case 'web.scheduled':
+		case 'web.ophan-esm':
 		case 'web':
 			return swcLoader(getBrowserTargets());
 	}
@@ -83,6 +84,14 @@ module.exports = ({ build, sessionId }) => ({
 				? './src/client/index.scheduled.ts'
 				: './src/client/index.ts',
 		debug: './src/client/debug/index.ts',
+	},
+	resolve: {
+		alias: {
+			'ophan-tracker-js':
+				build === 'web.ophan-esm'
+					? 'ophan-tracker-js-esm'
+					: 'ophan-tracker-js',
+		},
 	},
 	optimization:
 		// We don't need chunk optimization for apps as we use the 'LimitChunkCountPlugin' to produce just 1 chunk

--- a/dotcom-rendering/scripts/webpack/webpack.config.js
+++ b/dotcom-rendering/scripts/webpack/webpack.config.js
@@ -118,6 +118,7 @@ const commonConfigs = ({ platform }) => ({
 const clientBuilds = [
 	'web',
 	'web.scheduled',
+	'web.ophan-esm',
 	...((PROD && BUILD_VARIANT_SWITCH) || BUILD_VARIANT
 		? /** @type {const} */ (['web.variant'])
 		: []),

--- a/dotcom-rendering/src/client/sentryLoader/sentry.ts
+++ b/dotcom-rendering/src/client/sentryLoader/sentry.ts
@@ -5,6 +5,7 @@ import {
 	adaptive,
 	BUILD_VARIANT,
 	dcrJavascriptBundle,
+	ophanEsm,
 } from '../../../scripts/webpack/bundles';
 
 const allowUrls: BrowserOptions['allowUrls'] = [
@@ -61,6 +62,10 @@ if (
 
 if (window.guardian.config.tests[adaptive('Variant')] === 'variant') {
 	Sentry.setTag('dcr.bundle', 'adaptive');
+}
+
+if (window.guardian.config.tests[ophanEsm('Variant')] === 'variant') {
+	Sentry.setTag('dcr.bundle', 'ophanEsm');
 }
 
 export const reportError = (error: Error, feature?: string): void => {

--- a/dotcom-rendering/src/lib/assets.test.ts
+++ b/dotcom-rendering/src/lib/assets.test.ts
@@ -96,6 +96,14 @@ describe('getModulesBuild', () => {
 		expect(build).toBe(expected);
 	});
 
+	it('should support Ophan ESM build when in test', () => {
+		const build = getModulesBuild({
+			tests: { ophanEsmVariant: 'variant' },
+			switches: {},
+		});
+		expect(build).toBe('web.ophan-esm');
+	});
+
 	it('should serve the scheduled build when in adaptive test', () => {
 		const build = getModulesBuild({
 			tests: { adaptiveSiteVariant: 'variant' },

--- a/dotcom-rendering/src/lib/assets.ts
+++ b/dotcom-rendering/src/lib/assets.ts
@@ -5,6 +5,7 @@ import {
 	adaptive,
 	BUILD_VARIANT,
 	dcrJavascriptBundle,
+	ophanEsm,
 } from '../../scripts/webpack/bundles';
 import type { ServerSideTests, Switches } from '../types/config';
 
@@ -69,6 +70,7 @@ export type Build =
 	| 'apps'
 	| 'web'
 	| 'web.variant'
+	| 'web.ophan-esm'
 	| 'web.scheduled'
 	| 'web.legacy';
 
@@ -142,9 +144,12 @@ export const getModulesBuild = ({
 }: {
 	tests: ServerSideTests;
 	switches: Switches;
-}): Extract<Build, 'web' | 'web.variant' | 'web.scheduled'> => {
+}): Exclude<Extract<Build, `web${string}`>, 'web.legacy'> => {
 	if (BUILD_VARIANT && tests[dcrJavascriptBundle('Variant')] === 'variant') {
 		return 'web.variant';
+	}
+	if (tests[ophanEsm('Variant')] === 'variant') {
+		return 'web.ophan-esm';
 	}
 	if (switches.scheduler || tests[adaptive('Variant')] === 'variant') {
 		return 'web.scheduled';

--- a/yarn.lock
+++ b/yarn.lock
@@ -14344,6 +14344,11 @@ opener@^1.5.2:
   resolved "https://registry.yarnpkg.com/opener/-/opener-1.5.2.tgz#5d37e1f35077b9dcac4301372271afdeb2a13598"
   integrity sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==
 
+"ophan-tracker-js-esm@npm:ophan-tracker-js@2.0.0-beta-5":
+  version "2.0.0-beta-5"
+  resolved "https://registry.yarnpkg.com/ophan-tracker-js/-/ophan-tracker-js-2.0.0-beta-5.tgz#548720300b64bfaf224d8b42241c697dc522063d"
+  integrity sha512-4Kw3EnSJr9/P179AbS+93v7XI3MU+hQv5MtLgByG6sQbkE9MOAlDuGR+bQKH2GPKJjcqVdBiHx6mohoFb3BHHw==
+
 ophan-tracker-js@1.4.0, ophan-tracker-js@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/ophan-tracker-js/-/ophan-tracker-js-1.4.0.tgz#6c0e8f56157f2bd1473beaa6b79b54b99f5a7b1d"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Serve the ESM version of `ophan-tracker-js` ([@2.0.0-beta-5](https://www.npmjs.com/package/ophan-tracker-js/v/2.0.0-beta-5)) to users in the `variant` bundle.

## Why?

before we release [ophan-tracker-js@2.0.0](https://github.com/guardian/ophan/pull/5117), we want to ensure that it does not cause issues in production.

Looping @guardian/ophan for visibility.

## Screenshots

The same events are being sent

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |


[before]: https://github.com/guardian/dotcom-rendering/assets/76776/c2dc32b6-6926-441c-bb88-ddf35f59d38a
[after]: https://github.com/guardian/dotcom-rendering/assets/76776/9ddc27fb-adcb-45ff-9bab-9bb979e8aa00
