### PR TITLE
Fixed Dropcaps For New Line Heights

### DIFF
--- a/apps-rendering/src/components/Paragraph/Paragraph.stories.tsx
+++ b/apps-rendering/src/components/Paragraph/Paragraph.stories.tsx
@@ -31,6 +31,18 @@ const Default: FC = () => (
 	</Paragraph>
 );
 
+const Dropcap: FC = () => (
+	<Paragraph format={standard} showDropCap={true} isEditions={false}>
+		Ever since Mexico City was founded on an island in the lake of Texcoco
+		its inhabitants have dreamed of water: containing it, draining it and
+		now retaining it. Ever since Mexico City was founded on an island in the lake of Texcoco
+		its inhabitants have dreamed of water: containing it, draining it and
+		now retaining it. Ever since Mexico City was founded on an island in the lake of Texcoco
+		its inhabitants have dreamed of water: containing it, draining it and
+		now retaining it.
+	</Paragraph>
+);
+
 const Labs: FC = () => (
 	<Paragraph format={labs} showDropCap={false} isEditions={false}>
 		Ever since Mexico City was founded on an island in the lake of Texcoco
@@ -46,4 +58,4 @@ export default {
 	title: 'AR/Paragraph',
 };
 
-export { Default, Labs };
+export { Default, Dropcap, Labs };

--- a/apps-rendering/src/components/Paragraph/index.tsx
+++ b/apps-rendering/src/components/Paragraph/index.tsx
@@ -54,8 +54,8 @@ const styles = (
 					${dropCapWeight(format)}
 					color: ${text.dropCap(format)};
 					float: left;
-					font-size: 7.375rem;
-					line-height: 6.188rem;
+					font-size: 6.75rem;
+					line-height: 5.7rem;
 					vertical-align: text-top;
 					pointer-events: none;
 					margin-right: ${remSpace[1]};

--- a/dotcom-rendering/src/components/DropCap.tsx
+++ b/dotcom-rendering/src/components/DropCap.tsx
@@ -23,8 +23,8 @@ const outerStyles = (palette: Palette) => css`
 const innerStyles = (format: ArticleFormat) => {
 	const baseStyles = css`
 		${headline.large({ fontWeight: 'bold' })}
-		font-size: 118px;
-		line-height: 99px;
+		font-size: 111px;
+		line-height: 93px;
 		vertical-align: text-top;
 		pointer-events: none;
 		margin-right: ${space[1]}px;


### PR DESCRIPTION
## Why?

Recent changes to body text line height (#8383, #8426, #8385) meant dropcaps were misaligned.

Spotted by @HarryFischer 

## Changes

- Updated dropcap font sizes and line heights on AR and DCR
- Added story for dropcaps to AR

## Screenshots

| | Before | After |
| - | - | - |
| Dotcom | ![dropcap-dotcom-before] | ![dropcap-dotcom-after] |
| Apps | ![dropcap-apps-before] | ![dropcap-apps-after] |

[dropcap-dotcom-before]: https://github.com/guardian/dotcom-rendering/assets/53781962/922f94ec-4e0c-40a6-9930-50aa30d8863b
[dropcap-dotcom-after]: https://github.com/guardian/dotcom-rendering/assets/53781962/feff8f15-cb87-4cd2-8daf-14c1b9497576
[dropcap-apps-before]: https://github.com/guardian/dotcom-rendering/assets/53781962/6b1ba4ea-f783-461d-b328-c2656710b0a8
[dropcap-apps-after]: https://github.com/guardian/dotcom-rendering/assets/53781962/0b3dc87d-5e28-4d3b-ac77-419b52bbb537
