### PR TITLE
Skip Cypress in TeamCity

### DIFF
--- a/dotcom-rendering/cypress/e2e/parallel-5/liveblog.interactivity.cy.js
+++ b/dotcom-rendering/cypress/e2e/parallel-5/liveblog.interactivity.cy.js
@@ -107,6 +107,12 @@ describe('Liveblogs', function () {
 		cy.get(`[data-cy="toast"]`).should('not.exist');
 	});
 
+	/**
+	 * Note: This test periodically failed when running in TeamCity
+	 * It passes locally _almost_ every time.
+	 *
+	 * Cypress tests have now been disabled in TeamCity
+	 */
 	it('should enhance tweets after they have been inserted', function () {
 		const getTwitterIframe = () => {
 			return cy
@@ -130,6 +136,7 @@ describe('Liveblogs', function () {
 				mostRecentBlockId: 'abc',
 			});
 		});
+		// Should we use cy.get('#liveblog-body').scrollIntoView(); instead here?
 		cy.scrollTo(0, 1200);
 		getTwitterIframe().contains(
 			'They will prepare the extraordinary European Council meeting tonight',

--- a/scripts/ci-dcr.sh
+++ b/scripts/ci-dcr.sh
@@ -22,6 +22,16 @@ echo "filteredFiles: $filteredFiles"
 # Github actions sets this by default but we also want this variable set in TeamCity
 export CI=true
 
+# TeamCity is going away soon, and having a completely different
+# build step for main that takes over twice as long prevents getting
+# any meaningful estimates from TeamCity.
+# Cypress is also run by our GitHub Actions, where their flakiness
+# is not as problematic, because they can be re-run independently.
+#
+# At the time of writing this, Aug 16 2023, 75% of main runs in TC
+# failed over a 24h period.
+export SKIP_CYPRESS=true
+
 # run the ci steps if either of the followings is true
 # - filteredFiles is empty (all changes were in apps-rendering)
 # - we are in the main branch


### PR DESCRIPTION
## What does this change?

Stop running Cypress tests in TeamCity

## Why?

We are planning on moving away from TeamCity, and having a completely different build step for main that takes over twice as long prevents getting any meaningful estimates from TeamCity.
Cypress is also run by our GitHub Actions, where their flakiness is not as problematic, because they can be re-run independently.

## Screenshots

At the time of writing this, Aug 16 2023, 80% of main runs in TC
failed over a 24h period:

<img width="264" alt="screenshot of teamcity builds" src="https://github.com/guardian/dotcom-rendering/assets/76776/35accdf5-5e3c-4845-b16d-4e375335f14c">
