### PR TITLE
Unify `allowFlashingElements` preferences

### DIFF
--- a/dotcom-rendering/scripts/jest/setup.ts
+++ b/dotcom-rendering/scripts/jest/setup.ts
@@ -14,8 +14,7 @@ const windowGuardianConfig = {
 		browserId: 'jest-browser-id',
 		pageViewId: 'jest-page-view-id',
 	},
-	tests: {
-	}
+	tests: {},
 } as WindowGuardianConfig;
 
 const windowGuardian = {
@@ -110,6 +109,17 @@ Object.defineProperty(window, 'localStorage', {
  */
 global.TextEncoder = TextEncoder;
 global.TextDecoder = TextDecoder as unknown as typeof global.TextDecoder;
+
+global.matchMedia = () => ({
+	matches: false,
+	media: 'jest',
+	onchange: () => void 0,
+	addListener: () => void 0,
+	removeListener: () => void 0,
+	addEventListener: () => void 0,
+	removeEventListener: () => void 0,
+	dispatchEvent: () => false,
+});
 
 // Mocks the version number used by CDK, we don't want our tests to fail every time we update our cdk dependency.
 jest.mock('@guardian/cdk/lib/constants/tracking-tag');

--- a/dotcom-rendering/src/components/AnimatePulsingDots.importable.tsx
+++ b/dotcom-rendering/src/components/AnimatePulsingDots.importable.tsx
@@ -1,5 +1,5 @@
-import { storage } from '@guardian/libs';
-import { useEffect } from 'react';
+import { allowFlashingElements } from '../lib/allowFlashingElements';
+import { useOnce } from '../lib/useOnce';
 
 const animatePulsingDots = () => {
 	// Get all the elements that aren't hydrated
@@ -22,19 +22,11 @@ const animatePulsingDots = () => {
  * - We use this for fronts, where we add pulsing dots to the page which aren't wrapped in islands
  */
 export const AnimatePulsingDots = () => {
-	useEffect(() => {
-		// Respect the accessibility flag set here
-		// https://www.theguardian.com/help/accessibility-help
-		const flashingPreference = storage.local.get(
-			'gu.prefs.accessibility.flashing-elements',
-		);
-
-		// If the user hasn't explicitly set their flashing preference to 'false'
-		// then we can animate the pulsing dots
-		if (flashingPreference !== false) {
+	useOnce(() => {
+		if (allowFlashingElements) {
 			animatePulsingDots();
 		}
-	});
+	}, []);
 
 	return null;
 };

--- a/dotcom-rendering/src/components/PulsingDot.tsx
+++ b/dotcom-rendering/src/components/PulsingDot.tsx
@@ -1,6 +1,6 @@
 import { css, keyframes } from '@emotion/react';
-import { storage } from '@guardian/libs';
 import { useEffect, useState } from 'react';
+import { allowFlashingElements } from '../lib/allowFlashingElements';
 
 const dotStyles = (colour?: string) => css`
 	color: ${colour && colour};
@@ -40,19 +40,8 @@ interface Props {
 
 export const PulsingDot = ({ colour }: Props) => {
 	const [hydrated, setHydrated] = useState(false);
-	const [shouldFlash, setShouldFlash] = useState(false);
 
 	useEffect(() => {
-		// Respect the accessibility flag set here
-		// https://www.theguardian.com/help/accessibility-help
-
-		const flashingPreference = storage.local.get(
-			'gu.prefs.accessibility.flashing-elements',
-		);
-
-		// flashingPreference is null if no preference exists and explicitly
-		// false when the reader has said they don't want flashing
-		setShouldFlash(flashingPreference !== false);
 		// We use this to track if the flashing dot is hydrated
 		// Uses of pulsing dot that aren't in islands can instead be animated by
 		// the 'AnimatePulsingDots.importable.tsx' component
@@ -81,7 +70,7 @@ export const PulsingDot = ({ colour }: Props) => {
 			 * before setting the 'animate' property. This method allows us to enable the animation through both methods
 			 * outlined above.
 			 */
-			data-animate={shouldFlash}
+			data-animate={allowFlashingElements}
 		/>
 	);
 };

--- a/dotcom-rendering/src/lib/allowFlashingElements.ts
+++ b/dotcom-rendering/src/lib/allowFlashingElements.ts
@@ -1,0 +1,33 @@
+import { isBoolean, storage } from '@guardian/libs';
+import { isServer } from './isServer';
+
+const shouldAllowFlashingElements = () => {
+	const key = 'gu.prefs.accessibility.flashing-elements';
+	const storedPreference = storage.local.get(key);
+	const prefersReducedMotion = matchMedia(
+		'(prefers-reduced-motion: reduce)',
+	).matches;
+
+	if (storedPreference === null) {
+		storage.local.set(key, !prefersReducedMotion);
+	}
+
+	return isBoolean(storedPreference)
+		? storedPreference
+		: !prefersReducedMotion;
+};
+
+/**
+ * The [user’s preference for flashing elements][accessibility-help].
+ *
+ * If they have not specified it or it cannot be retrieved,
+ * falls back to the [prefers-reduced-motion][] media query.
+ *
+ * **N.B.** this is always `true` on the server.
+ *
+ * [accessibility-help]: https://www.theguardian.com/help/accessibility-help
+ * [prefers-reduced-motion]: https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion
+ */
+export const allowFlashingElements = isServer
+	? true
+	: shouldAllowFlashingElements();


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Create a `allowFlashingElements` module

If no preference is set or storage is unavailable, use the `prefers-reduced-motion` media query  as a proxy. Unless users have disabled storage, they can control the setting in https://www.theguardian.com/help/accessibility-help

## Why?

Ensuring this value is always a boolean helps simplify logic across the codebase.

## Screenshots

N/A