### PR TITLE
Scheduler: meaningful island boot times

### DIFF
--- a/dotcom-rendering/src/client/islands/index.ts
+++ b/dotcom-rendering/src/client/islands/index.ts
@@ -1,8 +1,11 @@
+import { getEmotionCache } from './emotion';
 import { initHydration } from './initHydration';
 
-export const islands = (): Promise<void> => {
-	const elements = document.querySelectorAll('gu-island');
-	initHydration(elements);
-
-	return Promise.resolve();
+export const islands = async (): Promise<void> => {
+	// Get the emotion cache which is shared between islands
+	const emotionCache = getEmotionCache();
+	const elements = document.querySelectorAll<HTMLElement>('gu-island');
+	await Promise.all(
+		[...elements].map((element) => initHydration(element, emotionCache)),
+	);
 };

--- a/dotcom-rendering/src/client/islands/initHydration.ts
+++ b/dotcom-rendering/src/client/islands/initHydration.ts
@@ -1,5 +1,5 @@
+import type { EmotionCache } from '@emotion/cache';
 import { doHydration } from './doHydration';
-import { getEmotionCache } from './emotion';
 import { getName } from './getName';
 import { getProps } from './getProps';
 import { onInteraction } from './onInteraction';
@@ -19,98 +19,75 @@ function hasLightboxHash(name: string) {
 	);
 }
 
-export const initHydration = (elements: NodeListOf<Element>): void => {
-	// Get the emotion cache which is shared between islands
-	const emotionCache = getEmotionCache();
+/**
+ * Partial Hydration / React Islands
+ *
+ * The code here looks for parts of the dom that have been marked using the `gu-island`
+ * marker, hydrating/rendering each one using the following properties:
+ *
+ * deferUntil - Used to optionally defer execution
+ * name - The name of the component. Used to dynamically import the code
+ * props - The data for the component that has been serialised in the dom
+ * element - The `gu-island` custom element which is wrapping the content
+ */
+export const initHydration = async (
+	element: HTMLElement,
+	emotionCache: EmotionCache,
+): Promise<void> => {
+	const name = getName(element);
+	const props = getProps(element);
 
-	/**
-	 * Partial Hydration / React Islands
-	 *
-	 * The code here looks for parts of the dom that have been marked using the `gu-island`
-	 * marker, hydrating/rendering each one using the following properties:
-	 *
-	 * deferUntil - Used to optionally defer execution
-	 * name - The name of the component. Used to dynamically import the code
-	 * props - The data for the component that has been serialised in the dom
-	 * element - The `gu-island` custom element which is wrapping the content
-	 */
-	for (const element of elements) {
-		if (element instanceof HTMLElement) {
-			const name = getName(element);
-			const props = getProps(element);
+	if (!name) return;
 
-			if (!name) continue;
-
-			const deferUntil = element.getAttribute('deferuntil');
-			switch (deferUntil) {
-				case 'idle': {
-					whenIdle(() => {
-						void doHydration(name, props, element, emotionCache);
-					});
-					break;
-				}
-				case 'visible': {
-					const rootMargin =
-						element.getAttribute('rootmargin') ?? undefined;
-					whenVisible(
-						element,
-						() => {
-							void doHydration(
-								name,
-								props,
-								element,
-								emotionCache,
-							);
-						},
-						{ rootMargin },
-					);
-					break;
-				}
-				case 'interaction': {
-					onInteraction(element, (targetElement) => {
-						void doHydration(
-							name,
-							props,
-							element,
-							emotionCache,
-						).then(() => {
-							targetElement.dispatchEvent(
-								new MouseEvent('click'),
-							);
-						});
-					});
-					break;
-				}
-				case 'hash': {
+	const deferUntil = element.getAttribute('deferuntil');
+	switch (deferUntil) {
+		case 'idle': {
+			whenIdle(() => {
+				void doHydration(name, props, element, emotionCache);
+			});
+			return;
+		}
+		case 'visible': {
+			const rootMargin = element.getAttribute('rootmargin') ?? undefined;
+			whenVisible(
+				element,
+				() => {
+					void doHydration(name, props, element, emotionCache);
+				},
+				{ rootMargin },
+			);
+			return;
+		}
+		case 'interaction': {
+			onInteraction(element, (targetElement) => {
+				void doHydration(name, props, element, emotionCache).then(
+					() => {
+						targetElement.dispatchEvent(new MouseEvent('click'));
+					},
+				);
+			});
+			return;
+		}
+		case 'hash': {
+			if (window.location.hash.includes(name) || hasLightboxHash(name)) {
+				void doHydration(name, props, element, emotionCache);
+			} else {
+				// If we didn't find a matching hash on page load, set a
+				// listener so that we check again each time the reader
+				// navigates within the page (changes the hash on the url)
+				onNavigation(() => {
 					if (
 						window.location.hash.includes(name) ||
 						hasLightboxHash(name)
 					) {
 						void doHydration(name, props, element, emotionCache);
-					} else {
-						// If we didn't find a matching hash on page load, set a
-						// listener so that we check again each time the reader
-						// navigates within the page (changes the hash on the url)
-						onNavigation(() => {
-							if (
-								window.location.hash.includes(name) ||
-								hasLightboxHash(name)
-							) {
-								void doHydration(
-									name,
-									props,
-									element,
-									emotionCache,
-								);
-							}
-						});
 					}
-					break;
-				}
-				default: {
-					void doHydration(name, props, element, emotionCache);
-				}
+				});
 			}
+			return;
+		}
+		default: {
+			return doHydration(name, props, element, emotionCache);
 		}
 	}
 };

--- a/dotcom-rendering/src/components/Liveness.importable.tsx
+++ b/dotcom-rendering/src/components/Liveness.importable.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import ReactDOM from 'react-dom';
+import { getEmotionCache } from '../client/islands/emotion';
 import { initHydration } from '../client/islands/initHydration';
 import { updateTimeElement } from '../client/relativeTime/updateTimeElements';
 import { isServer } from '../lib/isServer';
@@ -50,8 +51,10 @@ function insert(html: string, enhanceTweetsSwitch: boolean) {
 
 	// Hydrate
 	// -------
-	const islands = fragment.querySelectorAll('gu-island');
-	initHydration(islands);
+	const islands = fragment.querySelectorAll<HTMLElement>('gu-island');
+	void Promise.all(
+		[...islands].map((island) => initHydration(island, getEmotionCache())),
+	);
 
 	// Insert
 	// ------


### PR DESCRIPTION
## What does this change?

Include the time to load the non-deferred islands on the page as part of the startup/boot time.

## Why?

More meaningful durations for the `islands` boot script

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/76776/20d70dd0-8c91-4121-966c-c3ffcd64f01d
[after]: https://github.com/guardian/dotcom-rendering/assets/76776/27eb3f2d-a84a-496e-84ef-9acc1ead464d