### PR TITLE
DCAR: Apps footer on `StandardLayout`

### DIFF
--- a/dotcom-rendering/src/components/AppsFooter.importable.tsx
+++ b/dotcom-rendering/src/components/AppsFooter.importable.tsx
@@ -1,0 +1,106 @@
+import { css } from '@emotion/react';
+import { neutral, remSpace, textSans } from '@guardian/source-foundations';
+import { ButtonLink } from '@guardian/source-react-components';
+import { useEffect, useState } from 'react';
+import { getNavigationClient, getUserClient } from '../lib/bridgetApi';
+
+const year = new Date().getFullYear();
+
+const footerStyles = css`
+	${textSans.small({ lineHeight: 'regular' })}
+	padding: ${remSpace[4]} ${remSpace[3]};
+`;
+
+const linkStyles = css`
+	${textSans.small({ lineHeight: 'regular' })};
+	color: ${neutral[7]};
+`;
+
+type PrivacySettingsProps = {
+	isCcpa: boolean;
+	privacyPolicyClickHandler: (e: React.MouseEvent<HTMLButtonElement>) => void;
+	privacySettingsClickHandler: (
+		e: React.MouseEvent<HTMLButtonElement>,
+	) => void;
+};
+const PrivacySettings = ({
+	isCcpa,
+	privacyPolicyClickHandler,
+	privacySettingsClickHandler,
+}: PrivacySettingsProps) => {
+	if (isCcpa) {
+		return (
+			<>
+				<ButtonLink
+					priority="secondary"
+					onClick={privacyPolicyClickHandler}
+					css={linkStyles}
+				>
+					California Residents - Do Not Sell
+				</ButtonLink>
+				&nbsp;&#183;&nbsp;
+			</>
+		);
+	} else {
+		return (
+			<>
+				<ButtonLink
+					priority="secondary"
+					onClick={privacySettingsClickHandler}
+					css={linkStyles}
+				>
+					Privacy Settings
+				</ButtonLink>
+				&nbsp;&#183;&nbsp;
+			</>
+		);
+	}
+};
+
+export const AppsFooter = () => {
+	const [isCcpa, setIsCcpa] = useState<boolean>(false);
+
+	useEffect(() => {
+		void getUserClient()
+			.doesCcpaApply()
+			.then(setIsCcpa)
+			.catch(() => undefined);
+	}, []);
+
+	const privacyPolicyClickHandler = (
+		e: React.MouseEvent<HTMLButtonElement>,
+	) => {
+		e.preventDefault();
+		void getNavigationClient()
+			.openPrivacyPolicy()
+			.catch(() => undefined);
+	};
+	const privacySettingsClickHandler = (
+		e: React.MouseEvent<HTMLButtonElement>,
+	) => {
+		e.preventDefault();
+		void getNavigationClient()
+			.openPrivacySettings()
+			.catch(() => undefined);
+	};
+
+	return (
+		<div css={footerStyles}>
+			&#169; {year} Guardian News and Media Limited or its affiliated
+			companies. All rights reserved. (modern)
+			<br />
+			<PrivacySettings
+				isCcpa={isCcpa}
+				privacyPolicyClickHandler={privacyPolicyClickHandler}
+				privacySettingsClickHandler={privacySettingsClickHandler}
+			/>
+			<ButtonLink
+				priority="secondary"
+				onClick={privacyPolicyClickHandler}
+				css={linkStyles}
+			>
+				Privacy Policy
+			</ButtonLink>
+		</div>
+	);
+};

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -988,6 +988,7 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 					<Section
 						fullWidth={true}
 						data-print-layout="hide"
+						backgroundColour={neutral[97]}
 						padSides={false}
 						showSideBorders={false}
 						element="footer"

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -15,6 +15,7 @@ import {
 } from '@guardian/source-foundations';
 import { StraightLines } from '@guardian/source-react-components-development-kitchen';
 import { AdSlot, MobileStickyContainer } from '../components/AdSlot';
+import { AppsFooter } from '../components/AppsFooter.importable';
 import { ArticleBody } from '../components/ArticleBody';
 import { ArticleContainer } from '../components/ArticleContainer';
 import { ArticleHeadline } from '../components/ArticleHeadline';
@@ -979,6 +980,22 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 						</Island>
 					</BannerWrapper>
 					<MobileStickyContainer data-print-layout="hide" />
+				</>
+			)}
+
+			{!isWeb && (
+				<>
+					<Section
+						fullWidth={true}
+						data-print-layout="hide"
+						padSides={false}
+						showSideBorders={false}
+						element="footer"
+					>
+						<Island>
+							<AppsFooter />
+						</Island>
+					</Section>
 				</>
 			)}
 		</>

--- a/dotcom-rendering/src/server/htmlPageTemplate.ts
+++ b/dotcom-rendering/src/server/htmlPageTemplate.ts
@@ -207,7 +207,11 @@ https://workforus.theguardian.com/careers/product-engineering/
                 <meta charset="utf-8">
 
                 <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
-                <meta name="theme-color" content="${brandBackground.primary}" />
+                ${
+					renderingTarget === 'Web'
+						? `<meta name="theme-color" content="${brandBackground.primary}" />`
+						: ``
+				}
                 <link rel="icon" href="https://static.guim.co.uk/images/${favicon}">
 
                 ${preconnectTags.join('\n')}


### PR DESCRIPTION
The apps footer shows some copyright information as well as buttons to privacy settings and the privacy policy. If the user is affected by CCPA (California Consumer Privacy Act), we adjust the wording for the Privacy Policy button.

When the buttons are clicked, we call Bridget to show the relevant information in the native UI.

Additionally I've removed the `theme-color` meta element, because I don't think it's relevant for apps articles.

Although this PR mentions `StandardLayout` specifically, this component would be used across most other layouts.

## Other things to consider

- The `AppsFooter.importable` component breaks the `[name].[target].tsx` (e.g `Footer.apps.tsx`) pattern introduced in https://github.com/guardian/dotcom-rendering/pull/7860, because Island/Importable components must be named `[name].importable.tsx`. This might be something we want to refactor, if we end up having enough apps island components
- I've implemented the privacy policy/settings links as `LinkButton` components, but maybe an actual `<a>` is better here

## How it looks

https://github.com/guardian/dotcom-rendering/assets/705427/c8da0f1e-9a8d-4fa3-bbe7-3076f1cd8776

Closes [#8589](https://github.com/guardian/dotcom-rendering/issues/8589)
