### PR TITLE
Fronts banner ads AB test: don't insert ad above top container

### DIFF
--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -129,13 +129,15 @@ export const decideFrontsBannerAdSlot = (
 	pageId: string,
 	collectionName: string,
 	numBannerAdsInserted: React.MutableRefObject<number>,
+	isFirstContainer: boolean,
 ) => {
 	const targetedSections = frontsBannerAdSections[pageId];
 
 	if (
 		!renderAds ||
 		!isInFrontsBannerTest ||
-		!targetedSections?.includes(collectionName)
+		!targetedSections?.includes(collectionName) ||
+		isFirstContainer
 	) {
 		return null;
 	}
@@ -426,6 +428,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 										front.config.pageId,
 										collection.displayName,
 										numBannerAdsInserted,
+										index === 0,
 									)}
 									{!!trail.embedUri && (
 										<SnapCssSandbox
@@ -487,6 +490,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 									front.config.pageId,
 									collection.displayName,
 									numBannerAdsInserted,
+									index === 0,
 								)}
 								<FrontSection
 									toggleable={true}
@@ -615,6 +619,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 									front.config.pageId,
 									collection.displayName,
 									numBannerAdsInserted,
+									index === 0,
 								)}
 								<Section
 									title={collection.displayName}
@@ -684,6 +689,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 								front.config.pageId,
 								collection.displayName,
 								numBannerAdsInserted,
+								index === 0,
 							)}
 							<FrontSection
 								title={collection.displayName}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

- in the Fronts banner ads AB test, don't insert ad above top container

## Why?

- In the event that containers are moved around and a container we're targeting for this test is moved in to the top position on a front, we don't want to display an ad above it. This would mean an ad would appear below the header. An example would be the Women's World Cup container in Australia being moved to the top section
