### PR TITLE
Refactor Guardian global object type for safety

### DIFF
--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -399,22 +399,6 @@ interface MessageUs {
 	formFields: import('./src/types/content').MessageUsFieldType[];
 }
 
-interface GADataType {
-	pillar: LegacyPillar;
-	webTitle: string;
-	section: string;
-	contentType: string;
-	commissioningDesks: string;
-	contentId: string;
-	authorIds: string;
-	keywordIds: string;
-	toneIds: string;
-	seriesId: string;
-	isHosted: string;
-	edition: string;
-	beaconUrl: string;
-}
-
 // ----------------- //
 // General DataTypes //
 // ----------------- //

--- a/dotcom-rendering/scripts/jest/setup.ts
+++ b/dotcom-rendering/scripts/jest/setup.ts
@@ -1,7 +1,7 @@
 // add some helpful assertions
 import '@testing-library/jest-dom/extend-expect';
 import { TextDecoder, TextEncoder } from 'node:util';
-import type { WindowGuardianConfig } from '../../src/model/window-guardian';
+import type { Guardian } from '../../src/model/guardian';
 
 const windowGuardianConfig = {
 	page: {
@@ -14,9 +14,8 @@ const windowGuardianConfig = {
 		browserId: 'jest-browser-id',
 		pageViewId: 'jest-page-view-id',
 	},
-	tests: {
-	}
-} as WindowGuardianConfig;
+	tests: {},
+} as Guardian['config'];
 
 const windowGuardian = {
 	app: {

--- a/dotcom-rendering/src/client/ga/ga.ts
+++ b/dotcom-rendering/src/client/ga/ga.ts
@@ -88,7 +88,7 @@ export const sendPageView = (): void => {
 	}
 
 	ga(set, 'forceSSL', true);
-	ga(set, 'title', GAData.webTitle);
+	ga(set, 'title', GAData?.webTitle);
 	ga(set, 'anonymizeIp', true);
 	/** *************************************************************************************
 	 * Custom dimensions common to all platforms across the whole Guardian estate          *
@@ -98,22 +98,22 @@ export const sendPageView = (): void => {
 	 * Custom dimensions for 'editorial' platforms (this site, the mobile apps, etc.)      *
 	 * Some of these will be undefined for non-content pages, but that's fine.             *
 	 ************************************************************************************** */
-	ga(set, 'dimension4', GAData.section);
-	ga(set, 'dimension5', GAData.contentType);
-	ga(set, 'dimension6', GAData.commissioningDesks);
-	ga(set, 'dimension7', GAData.contentId);
-	ga(set, 'dimension8', GAData.authorIds);
-	ga(set, 'dimension9', GAData.keywordIds);
-	ga(set, 'dimension10', GAData.toneIds);
-	ga(set, 'dimension11', GAData.seriesId);
+	ga(set, 'dimension4', GAData?.section);
+	ga(set, 'dimension5', GAData?.contentType);
+	ga(set, 'dimension6', GAData?.commissioningDesks);
+	ga(set, 'dimension7', GAData?.contentId);
+	ga(set, 'dimension8', GAData?.authorIds);
+	ga(set, 'dimension9', GAData?.keywordIds);
+	ga(set, 'dimension10', GAData?.toneIds);
+	ga(set, 'dimension11', GAData?.seriesId);
 	ga(set, 'dimension16', (userCookie && 'true') || 'false');
 	ga(set, 'dimension21', getQueryParam('INTCMP', window.location.search)); // internal campaign code
 	ga(set, 'dimension22', getQueryParam('CMP_BUNIT', window.location.search)); // campaign business unit
 	ga(set, 'dimension23', getQueryParam('CMP_TU', window.location.search)); // campaign team
-	ga(set, 'dimension26', GAData.isHosted);
+	ga(set, 'dimension26', GAData?.isHosted);
 	ga(set, 'dimension27', navigator.userAgent); // I bet you a pint
 	ga(set, 'dimension29', window.location.href); // That both of these are already tracked.
-	ga(set, 'dimension30', GAData.edition);
+	ga(set, 'dimension30', GAData?.edition);
 
 	// TODO: sponsor logos
 	// ga(set, 'dimension31', GAData.sponsorLogos);
@@ -122,7 +122,7 @@ export const sendPageView = (): void => {
 	// ga(set, 'dimension42', 'GAData.brandingType');
 
 	ga(set, 'dimension43', 'dotcom-rendering');
-	ga(set, 'dimension50', GAData.pillar);
+	ga(set, 'dimension50', GAData?.pillar);
 
 	if (window.location.hash === '#fbLogin') {
 		ga(set, 'referrer', null);

--- a/dotcom-rendering/src/model/extract-ga.ts
+++ b/dotcom-rendering/src/model/extract-ga.ts
@@ -49,6 +49,22 @@ const convertToLegacyPillar = (theme: FETheme): LegacyPillar => {
 const formatStringForGa = (string: string): string =>
 	string.toLowerCase().split(' ').join('');
 
+export interface GADataType {
+	pillar: LegacyPillar;
+	webTitle: string;
+	section: string;
+	contentType: string;
+	commissioningDesks: string;
+	contentId: string;
+	authorIds: string;
+	keywordIds: string;
+	toneIds: string;
+	seriesId: string;
+	isHosted: string;
+	edition: string;
+	beaconUrl: string;
+}
+
 export const extractGA = ({
 	webTitle,
 	format,

--- a/dotcom-rendering/src/model/guardian.ts
+++ b/dotcom-rendering/src/model/guardian.ts
@@ -1,47 +1,66 @@
 import type { EditionId } from '../lib/edition';
 import type { ConfigType, ServerSideTests, Switches } from '../types/config';
+import type { GADataType } from './extract-ga';
 
-export interface WindowGuardianConfig {
-	isDotcomRendering: boolean;
-	isDev: boolean;
-	stage: StageType;
-	frontendAssetsFullURL: string;
-	page: {
-		dcrCouldRender: boolean;
-		contentType: string;
-		edition: EditionId;
-		revisionNumber: string;
-		dcrSentryDsn: string;
-		sentryHost: string;
-		sentryPublicApiKey: string;
-		keywordIds: string;
-		dfpAccountId: string;
-		adUnit: string;
-		showRelatedContent: boolean;
-		ajaxUrl: string;
-		shouldHideReaderRevenue: boolean;
-		googleRecaptchaSiteKey?: string;
-		brazeApiKey?: string;
-		isPaidContent?: boolean;
-		isDev?: boolean;
-		hasInlineMerchandise?: boolean;
+export interface Guardian {
+	polyfilled: boolean;
+	/**
+	 * The 'config' attribute is derived from CAPIArticle and contains
+	 * all the data that, for legacy reasons, for instance compatibility
+	 * with the frontend commercial stack, or other scripts, we want to find
+	 * at window.guardian.config
+	 */
+	config: {
+		isDotcomRendering: boolean;
+		isDev: boolean;
+		stage: StageType;
+		frontendAssetsFullURL: string;
+		page: {
+			dcrCouldRender: boolean;
+			contentType: string;
+			edition: EditionId;
+			revisionNumber: string;
+			dcrSentryDsn: string;
+			sentryHost: string;
+			sentryPublicApiKey: string;
+			keywordIds: string;
+			dfpAccountId: string;
+			adUnit: string;
+			showRelatedContent: boolean;
+			ajaxUrl: string;
+			shouldHideReaderRevenue: boolean;
+			googleRecaptchaSiteKey?: string;
+			brazeApiKey?: string;
+			isPaidContent?: boolean;
+			isDev?: boolean;
+			hasInlineMerchandise?: boolean;
+		};
+		libs: {
+			googletag: string;
+		};
+		switches: Switches;
+		tests: ServerSideTests;
+		ophan: {
+			pageViewId: string;
+			browserId: string;
+		};
 	};
-	libs: {
-		googletag: string;
+	modules: {
+		sentry: {
+			reportError: (error: Error, feature: string) => void;
+		};
 	};
-	switches: Switches;
-	tests: ServerSideTests;
-	ophan: {
-		pageViewId: string;
-		browserId: string;
-	};
+	GAData?: GADataType;
+	adBlockers: unknown;
 }
 
 /**
- * This function constructs the data object that gets written to the global
- * window.guardian property
+ * This function constructs the `Guardian` data object
+ *
+ * In `htmlPageTemplate.ts`, it is written to
+ * the global `window.guardian` property
  */
-export const makeWindowGuardian = ({
+export const createGuardian = ({
 	stage,
 	frontendAssetsFullURL,
 	revisionNumber,
@@ -94,21 +113,7 @@ export const makeWindowGuardian = ({
 	 * commercial code failing because it depended on a property we removed
 	 */
 	unknownConfig?: ConfigType | object;
-}): {
-	// The 'config' attribute is derived from CAPIArticle and contains
-	// all the data that, for legacy reasons, for instance compatibility
-	// with the frontend commercial stack, or other scripts, we want to find
-	// at window.guardian.config
-	config: WindowGuardianConfig;
-	polyfilled: boolean;
-	adBlockers: any;
-	modules: {
-		sentry: {
-			reportError: (error: Error, feature: string) => void;
-		};
-	};
-	GAData?: GADataType;
-} => {
+}): Guardian => {
 	return {
 		config: {
 			// This indicates to the client side code that we are running a dotcom-rendering rendered page.

--- a/dotcom-rendering/src/server/htmlPageTemplate.ts
+++ b/dotcom-rendering/src/server/htmlPageTemplate.ts
@@ -2,14 +2,16 @@ import { brandBackground, resets } from '@guardian/source-foundations';
 import he from 'he';
 import { islandNoscriptStyles } from '../components/Island';
 import { ASSET_ORIGIN } from '../lib/assets';
+import { escapeData } from '../lib/escapeData';
 import { getFontsCss } from '../lib/fonts-css';
 import { getHttp3Url } from '../lib/getHttp3Url';
+import type { Guardian } from '../model/guardian';
 import type { RenderingTarget } from '../types/renderingTarget';
 
 type BaseProps = {
 	css: string;
 	html: string;
-	windowGuardian: string;
+	guardian: Guardian;
 	scriptTags: string[];
 	title?: string;
 	description?: string;
@@ -54,7 +56,7 @@ export const htmlPageTemplate = (props: WebProps | AppProps): string => {
 	const {
 		css,
 		html,
-		windowGuardian,
+		guardian,
 		scriptTags,
 		title = 'The Guardian',
 		description = 'Latest news, sport, business, comment, analysis and reviews from the Guardian, the world&#x27;s leading liberal voice',
@@ -69,6 +71,12 @@ export const htmlPageTemplate = (props: WebProps | AppProps): string => {
 		hasPageSkin = false,
 		weAreHiring,
 	} = props;
+
+	/**
+	 * We escape windowGuardian here to prevent errors when the data
+	 * is placed in a script tag on the page
+	 */
+	const windowGuardian = escapeData(JSON.stringify(guardian));
 
 	const favicon =
 		process.env.NODE_ENV === 'production'

--- a/dotcom-rendering/src/server/render.allEditorialNewslettersPage.web.tsx
+++ b/dotcom-rendering/src/server/render.allEditorialNewslettersPage.web.tsx
@@ -5,11 +5,10 @@ import {
 import { AllEditorialNewslettersPage } from '../components/AllEditorialNewslettersPage';
 import { generateScriptTags, getPathFromManifest } from '../lib/assets';
 import { renderToStringWithEmotion } from '../lib/emotion';
-import { escapeData } from '../lib/escapeData';
 import { getHttp3Url } from '../lib/getHttp3Url';
 import { polyfillIO } from '../lib/polyfill.io';
 import { extractNAV } from '../model/extract-nav';
-import { makeWindowGuardian } from '../model/window-guardian';
+import { createGuardian } from '../model/guardian';
 import type { DCRNewslettersPageType } from '../types/newslettersPage';
 import { htmlPageTemplate } from './htmlPageTemplate';
 
@@ -61,33 +60,23 @@ export const renderEditorialNewslettersPage = ({
 		].map((script) => (offerHttp3 ? getHttp3Url(script) : script)),
 	);
 
-	/**
-	 * We escape windowGuardian here to prevent errors when the data
-	 * is placed in a script tag on the page
-	 */
-	const windowGuardian = escapeData(
-		JSON.stringify(
-			makeWindowGuardian({
-				editionId: newslettersPage.editionId,
-				stage: newslettersPage.config.stage,
-				frontendAssetsFullURL:
-					newslettersPage.config.frontendAssetsFullURL,
-				revisionNumber: newslettersPage.config.revisionNumber,
-				sentryPublicApiKey: newslettersPage.config.sentryPublicApiKey,
-				sentryHost: newslettersPage.config.sentryHost,
-				keywordIds: '',
-				dfpAccountId: newslettersPage.config.dfpAccountId,
-				adUnit: newslettersPage.config.adUnit,
-				ajaxUrl: newslettersPage.config.ajaxUrl,
-				googletagUrl: newslettersPage.config.googletagUrl,
-				switches: newslettersPage.config.switches,
-				abTests: newslettersPage.config.abTests,
-				brazeApiKey: newslettersPage.config.brazeApiKey,
-				googleRecaptchaSiteKey:
-					newslettersPage.config.googleRecaptchaSiteKey,
-			}),
-		),
-	);
+	const guardian = createGuardian({
+		editionId: newslettersPage.editionId,
+		stage: newslettersPage.config.stage,
+		frontendAssetsFullURL: newslettersPage.config.frontendAssetsFullURL,
+		revisionNumber: newslettersPage.config.revisionNumber,
+		sentryPublicApiKey: newslettersPage.config.sentryPublicApiKey,
+		sentryHost: newslettersPage.config.sentryHost,
+		keywordIds: '',
+		dfpAccountId: newslettersPage.config.dfpAccountId,
+		adUnit: newslettersPage.config.adUnit,
+		ajaxUrl: newslettersPage.config.ajaxUrl,
+		googletagUrl: newslettersPage.config.googletagUrl,
+		switches: newslettersPage.config.switches,
+		abTests: newslettersPage.config.abTests,
+		brazeApiKey: newslettersPage.config.brazeApiKey,
+		googleRecaptchaSiteKey: newslettersPage.config.googleRecaptchaSiteKey,
+	});
 
 	return htmlPageTemplate({
 		scriptTags,
@@ -95,7 +84,7 @@ export const renderEditorialNewslettersPage = ({
 		html,
 		title,
 		description: newslettersPage.description,
-		windowGuardian,
+		guardian,
 		keywords: '',
 		offerHttp3,
 		renderingTarget: 'Web',

--- a/dotcom-rendering/src/server/render.article.apps.tsx
+++ b/dotcom-rendering/src/server/render.article.apps.tsx
@@ -3,8 +3,7 @@ import { ArticlePage } from '../components/ArticlePage';
 import { generateScriptTags, getPathFromManifest } from '../lib/assets';
 import { decideFormat } from '../lib/decideFormat';
 import { renderToStringWithEmotion } from '../lib/emotion';
-import { escapeData } from '../lib/escapeData';
-import { makeWindowGuardian } from '../model/window-guardian';
+import { createGuardian } from '../model/guardian';
 import type { FEArticleType } from '../types/frontend';
 import { htmlPageTemplate } from './htmlPageTemplate';
 
@@ -27,39 +26,32 @@ export const renderArticle = (
 	const clientScripts = [getPathFromManifest('apps', 'index.js')];
 	const scriptTags = generateScriptTags([...clientScripts].filter(isString));
 
-	/**
-	 * We escape windowGuardian here to prevent errors when the data
-	 * is placed in a script tag on the page
-	 */
-	const windowGuardian = escapeData(
-		JSON.stringify(
-			makeWindowGuardian({
-				editionId: article.editionId,
-				stage: article.config.stage,
-				frontendAssetsFullURL: article.config.frontendAssetsFullURL,
-				revisionNumber: article.config.revisionNumber,
-				sentryPublicApiKey: article.config.sentryPublicApiKey,
-				sentryHost: article.config.sentryHost,
-				keywordIds: article.config.keywordIds,
-				dfpAccountId: article.config.dfpAccountId,
-				adUnit: article.config.adUnit,
-				ajaxUrl: article.config.ajaxUrl,
-				googletagUrl: article.config.googletagUrl,
-				switches: article.config.switches,
-				abTests: article.config.abTests,
-				isPaidContent: article.pageType.isPaidContent,
-				contentType: article.contentType,
-				googleRecaptchaSiteKey: article.config.googleRecaptchaSiteKey,
-				unknownConfig: article.config,
-			}),
-		),
-	);
+	const guardian = createGuardian({
+		editionId: article.editionId,
+		stage: article.config.stage,
+		frontendAssetsFullURL: article.config.frontendAssetsFullURL,
+		revisionNumber: article.config.revisionNumber,
+		sentryPublicApiKey: article.config.sentryPublicApiKey,
+		sentryHost: article.config.sentryHost,
+		keywordIds: article.config.keywordIds,
+		dfpAccountId: article.config.dfpAccountId,
+		adUnit: article.config.adUnit,
+		ajaxUrl: article.config.ajaxUrl,
+		googletagUrl: article.config.googletagUrl,
+		switches: article.config.switches,
+		abTests: article.config.abTests,
+		isPaidContent: article.pageType.isPaidContent,
+		contentType: article.contentType,
+		googleRecaptchaSiteKey: article.config.googleRecaptchaSiteKey,
+		unknownConfig: article.config,
+	});
+
 	const renderedPage = htmlPageTemplate({
 		css: extractedCss,
 		html,
 		title: article.webTitle,
 		scriptTags,
-		windowGuardian,
+		guardian,
 		renderingTarget: 'Apps',
 		offerHttp3: false,
 		weAreHiring: !!article.config.switches.weAreHiring,

--- a/dotcom-rendering/src/server/render.article.web.tsx
+++ b/dotcom-rendering/src/server/render.article.web.tsx
@@ -14,14 +14,13 @@ import {
 import { decideFormat } from '../lib/decideFormat';
 import { decideTheme } from '../lib/decideTheme';
 import { renderToStringWithEmotion } from '../lib/emotion';
-import { escapeData } from '../lib/escapeData';
 import { getHttp3Url } from '../lib/getHttp3Url';
 import { getCurrentPillar } from '../lib/layoutHelpers';
 import { LiveBlogRenderer } from '../lib/LiveBlogRenderer';
 import { polyfillIO } from '../lib/polyfill.io';
 import { extractGA } from '../model/extract-ga';
 import { extractNAV } from '../model/extract-nav';
-import { makeWindowGuardian } from '../model/window-guardian';
+import { createGuardian as createWindowGuardian } from '../model/guardian';
 import type { FEElement } from '../types/content';
 import type { FEArticleType, FEBlocksRequest } from '../types/frontend';
 import type { TagType } from '../types/tag';
@@ -116,44 +115,40 @@ export const renderHtml = ({ article }: Props): string => {
 	 * We escape windowGuardian here to prevent errors when the data
 	 * is placed in a script tag on the page
 	 */
-	const windowGuardian = escapeData(
-		JSON.stringify(
-			makeWindowGuardian({
-				editionId: article.editionId,
-				stage: article.config.stage,
-				frontendAssetsFullURL: article.config.frontendAssetsFullURL,
-				revisionNumber: article.config.revisionNumber,
-				sentryPublicApiKey: article.config.sentryPublicApiKey,
-				sentryHost: article.config.sentryHost,
-				keywordIds: article.config.keywordIds,
-				dfpAccountId: article.config.dfpAccountId,
-				adUnit: article.config.adUnit,
-				ajaxUrl: article.config.ajaxUrl,
-				googletagUrl: article.config.googletagUrl,
-				switches: article.config.switches,
-				abTests: article.config.abTests,
-				brazeApiKey: article.config.brazeApiKey,
-				isPaidContent: article.pageType.isPaidContent,
-				contentType: article.contentType,
-				shouldHideReaderRevenue: article.shouldHideReaderRevenue,
-				googleRecaptchaSiteKey: article.config.googleRecaptchaSiteKey,
-				GAData: extractGA({
-					webTitle: article.webTitle,
-					format: article.format,
-					sectionName: article.sectionName,
-					contentType: article.contentType,
-					tags: article.tags,
-					pageId: article.pageId,
-					editionId: article.editionId,
-					beaconURL: article.beaconURL,
-				}),
-				hasInlineMerchandise: article.config.hasInlineMerchandise,
-				// Until we understand exactly what config we need to make available client-side,
-				// add everything we haven't explicitly typed as unknown config
-				unknownConfig: article.config,
-			}),
-		),
-	);
+	const guardian = createWindowGuardian({
+		editionId: article.editionId,
+		stage: article.config.stage,
+		frontendAssetsFullURL: article.config.frontendAssetsFullURL,
+		revisionNumber: article.config.revisionNumber,
+		sentryPublicApiKey: article.config.sentryPublicApiKey,
+		sentryHost: article.config.sentryHost,
+		keywordIds: article.config.keywordIds,
+		dfpAccountId: article.config.dfpAccountId,
+		adUnit: article.config.adUnit,
+		ajaxUrl: article.config.ajaxUrl,
+		googletagUrl: article.config.googletagUrl,
+		switches: article.config.switches,
+		abTests: article.config.abTests,
+		brazeApiKey: article.config.brazeApiKey,
+		isPaidContent: article.pageType.isPaidContent,
+		contentType: article.contentType,
+		shouldHideReaderRevenue: article.shouldHideReaderRevenue,
+		googleRecaptchaSiteKey: article.config.googleRecaptchaSiteKey,
+		GAData: extractGA({
+			webTitle: article.webTitle,
+			format: article.format,
+			sectionName: article.sectionName,
+			contentType: article.contentType,
+			tags: article.tags,
+			pageId: article.pageId,
+			editionId: article.editionId,
+			beaconURL: article.beaconURL,
+		}),
+		hasInlineMerchandise: article.config.hasInlineMerchandise,
+		// Until we understand exactly what config we need to make available client-side,
+		// add everything we haven't explicitly typed as unknown config
+		unknownConfig: article.config,
+	});
 
 	const getAmpLink = (tags: TagType[]) => {
 		if (
@@ -212,7 +207,7 @@ window.twttr = (function(d, s, id) {
 		html,
 		title,
 		description: article.trailText,
-		windowGuardian,
+		guardian,
 		ampLink,
 		openGraphData,
 		twitterData,

--- a/dotcom-rendering/src/server/render.front.web.tsx
+++ b/dotcom-rendering/src/server/render.front.web.tsx
@@ -7,13 +7,12 @@ import { FrontPage } from '../components/FrontPage';
 import { TagFrontPage } from '../components/TagFrontPage';
 import { generateScriptTags, getPathFromManifest } from '../lib/assets';
 import { renderToStringWithEmotion } from '../lib/emotion';
-import { escapeData } from '../lib/escapeData';
 import { getHttp3Url } from '../lib/getHttp3Url';
 import { polyfillIO } from '../lib/polyfill.io';
 import { themeToPillar } from '../lib/themeToPillar';
 import type { NavType } from '../model/extract-nav';
 import { extractNAV } from '../model/extract-nav';
-import { makeWindowGuardian } from '../model/window-guardian';
+import { createGuardian } from '../model/guardian';
 import type { DCRFrontType } from '../types/front';
 import type { DCRTagFrontType } from '../types/tagFront';
 import { htmlPageTemplate } from './htmlPageTemplate';
@@ -110,34 +109,26 @@ export const renderFront = ({ front }: Props): string => {
 			.map((script) => (offerHttp3 ? getHttp3Url(script) : script)),
 	);
 
-	/**
-	 * We escape windowGuardian here to prevent errors when the data
-	 * is placed in a script tag on the page
-	 */
-	const windowGuardian = escapeData(
-		JSON.stringify(
-			makeWindowGuardian({
-				editionId: front.editionId,
-				stage: front.config.stage,
-				frontendAssetsFullURL: front.config.frontendAssetsFullURL,
-				revisionNumber: front.config.revisionNumber,
-				sentryPublicApiKey: front.config.sentryPublicApiKey,
-				sentryHost: front.config.sentryHost,
-				keywordIds: front.config.keywordIds,
-				dfpAccountId: front.config.dfpAccountId,
-				adUnit: front.config.adUnit,
-				ajaxUrl: front.config.ajaxUrl,
-				googletagUrl: front.config.googletagUrl,
-				switches: front.config.switches,
-				abTests: front.config.abTests,
-				brazeApiKey: front.config.brazeApiKey,
-				googleRecaptchaSiteKey: front.config.googleRecaptchaSiteKey,
-				// Until we understand exactly what config we need to make available client-side,
-				// add everything we haven't explicitly typed as unknown config
-				unknownConfig: front.config,
-			}),
-		),
-	);
+	const guardian = createGuardian({
+		editionId: front.editionId,
+		stage: front.config.stage,
+		frontendAssetsFullURL: front.config.frontendAssetsFullURL,
+		revisionNumber: front.config.revisionNumber,
+		sentryPublicApiKey: front.config.sentryPublicApiKey,
+		sentryHost: front.config.sentryHost,
+		keywordIds: front.config.keywordIds,
+		dfpAccountId: front.config.dfpAccountId,
+		adUnit: front.config.adUnit,
+		ajaxUrl: front.config.ajaxUrl,
+		googletagUrl: front.config.googletagUrl,
+		switches: front.config.switches,
+		abTests: front.config.abTests,
+		brazeApiKey: front.config.brazeApiKey,
+		googleRecaptchaSiteKey: front.config.googleRecaptchaSiteKey,
+		// Until we understand exactly what config we need to make available client-side,
+		// add everything we haven't explicitly typed as unknown config
+		unknownConfig: front.config,
+	});
 
 	const keywords = front.config.keywords;
 
@@ -147,7 +138,7 @@ export const renderFront = ({ front }: Props): string => {
 		html,
 		title,
 		description: front.pressedPage.seoData.description,
-		windowGuardian,
+		guardian,
 		keywords,
 		offerHttp3,
 		renderingTarget: 'Web',
@@ -200,34 +191,26 @@ export const renderTagFront = ({
 			.map((script) => (offerHttp3 ? getHttp3Url(script) : script)),
 	);
 
-	/**
-	 * We escape windowGuardian here to prevent errors when the data
-	 * is placed in a script tag on the page
-	 */
-	const windowGuardian = escapeData(
-		JSON.stringify(
-			makeWindowGuardian({
-				editionId: tagFront.editionId,
-				stage: tagFront.config.stage,
-				frontendAssetsFullURL: tagFront.config.frontendAssetsFullURL,
-				revisionNumber: tagFront.config.revisionNumber,
-				sentryPublicApiKey: tagFront.config.sentryPublicApiKey,
-				sentryHost: tagFront.config.sentryHost,
-				keywordIds: tagFront.config.keywordIds,
-				dfpAccountId: tagFront.config.dfpAccountId,
-				adUnit: tagFront.config.adUnit,
-				ajaxUrl: tagFront.config.ajaxUrl,
-				googletagUrl: tagFront.config.googletagUrl,
-				switches: tagFront.config.switches,
-				abTests: tagFront.config.abTests,
-				brazeApiKey: tagFront.config.brazeApiKey,
-				googleRecaptchaSiteKey: tagFront.config.googleRecaptchaSiteKey,
-				// Until we understand exactly what config we need to make available client-side,
-				// add everything we haven't explicitly typed as unknown config
-				unknownConfig: tagFront.config,
-			}),
-		),
-	);
+	const guardian = createGuardian({
+		editionId: tagFront.editionId,
+		stage: tagFront.config.stage,
+		frontendAssetsFullURL: tagFront.config.frontendAssetsFullURL,
+		revisionNumber: tagFront.config.revisionNumber,
+		sentryPublicApiKey: tagFront.config.sentryPublicApiKey,
+		sentryHost: tagFront.config.sentryHost,
+		keywordIds: tagFront.config.keywordIds,
+		dfpAccountId: tagFront.config.dfpAccountId,
+		adUnit: tagFront.config.adUnit,
+		ajaxUrl: tagFront.config.ajaxUrl,
+		googletagUrl: tagFront.config.googletagUrl,
+		switches: tagFront.config.switches,
+		abTests: tagFront.config.abTests,
+		brazeApiKey: tagFront.config.brazeApiKey,
+		googleRecaptchaSiteKey: tagFront.config.googleRecaptchaSiteKey,
+		// Until we understand exactly what config we need to make available client-side,
+		// add everything we haven't explicitly typed as unknown config
+		unknownConfig: tagFront.config,
+	});
 
 	const keywords = tagFront.config.keywords;
 
@@ -237,7 +220,7 @@ export const renderTagFront = ({
 		html,
 		title,
 		description: tagFront.header.description,
-		windowGuardian,
+		guardian,
 		keywords,
 		offerHttp3,
 		renderingTarget: 'Web',

--- a/dotcom-rendering/window.guardian.ts
+++ b/dotcom-rendering/window.guardian.ts
@@ -1,4 +1,4 @@
-import type { EmotionCache } from '@emotion/react';
+import type { EmotionCache } from '@emotion/cache';
 import type {
 	Callback,
 	CMP,
@@ -9,23 +9,21 @@ import type { WeeklyArticleHistory } from '@guardian/support-dotcom-components/d
 import type { OphanRecordFunction } from './src/client/ophan/ophan';
 import type { DailyArticleHistory } from './src/lib/dailyArticleCount';
 import type { ReaderRevenueDevUtils } from './src/lib/readerRevenueDevUtils';
-import type { WindowGuardianConfig } from './src/model/window-guardian';
+import type { Guardian } from './src/model/guardian';
 
 declare global {
 	/* ~ Here, declare things that go in the global namespace, or augment
 	 *~ existing declarations in the global namespace
 	 */
 	interface Window {
-		guardian: {
+		guardian: Guardian & {
 			mustardCut: boolean;
-			polyfilled: boolean;
 			onPolyfilled: () => void;
 			queue: Array<() => void>;
 			// Olly N 10/01/2022:
 			// The 'emotionCache' property would better live as a singleton package/chunk, but we're currently limited
 			// by having multiple entrypoints in webpack, meaning we can't guarantee singleton behavior
 			emotionCache?: EmotionCache;
-			config: WindowGuardianConfig;
 			ophan?: {
 				setEventEmitter: () => void; // We don't currently have a custom eventEmitter on DCR - like 'mediator' in Frontend.
 				trackComponentAttention: (
@@ -37,11 +35,6 @@ declare global {
 				viewId: string;
 				pageViewId: string;
 			};
-			modules: {
-				sentry: {
-					reportError: (error: Error, feature: string) => void;
-				};
-			};
 			// TODO expose as type from Automat client lib
 			automat: {
 				react: any;
@@ -51,7 +44,6 @@ declare global {
 			readerRevenue: ReaderRevenueDevUtils;
 			weeklyArticleCount: WeeklyArticleHistory | undefined;
 			dailyArticleCount: DailyArticleHistory | undefined;
-			GAData: GADataType;
 		};
 		GoogleAnalyticsObject: string;
 		ga: UniversalAnalytics.ga | null;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Unify the creation of the `Guardian` global object and share types throughout:

- rename `makeWindowGuardian` to `createGuardian`
- rename `WindowGuardian` to `Guardian`
- handle missing `GAData` to prevent errors from [accessing it’s `webTitle` attribute it `ga.ts`](https://github.com/guardian/dotcom-rendering/blob/ea1fee8ddef5216b7f1e8e011802fc65aba92424/dotcom-rendering/src/client/ga/ga.ts#L91)
- reduce the number of declaration files, as it can simply be `window.guardian.ts`

## Why?

The `Guardian` object type and the fact that it happens to be written to the window object are distinct concerns, and the code now reflects that.

Ensures a single source of truth of what this object should contain and lean into the TS compiler to surface errors.

## ~Screenshots~ Sentry reports

https://the-guardian.sentry.io/issues/?groupStatsPeriod=auto&project=1377847&query=error.value%3A%22Cannot+read+properties+of+undefined+%28reading+%27webTitle%27%29%22&referrer=issue-list&statsPeriod=14d