### PR TITLE
Reduce network calls for comments count

### DIFF
--- a/dotcom-rendering/src/components/FetchOnwardsData.importable.tsx
+++ b/dotcom-rendering/src/components/FetchOnwardsData.importable.tsx
@@ -1,9 +1,10 @@
 import { css } from '@emotion/react';
-import { ArticleDesign } from '@guardian/libs';
+import { ArticleDesign, isNonNullable } from '@guardian/libs';
 import { useEffect } from 'react';
 import { decideTrail } from '../lib/decideTrail';
 import { revealStyles } from '../lib/revealStyles';
 import { useApi } from '../lib/useApi';
+import { addDiscussionIds } from '../lib/useCommentCount';
 import type { OnwardsSource } from '../types/onwards';
 import type { FETrailType, TrailType } from '../types/trails';
 import { Carousel } from './Carousel.importable';
@@ -74,6 +75,11 @@ export const FetchOnwardsData = ({
 	}
 
 	if (data?.trails) {
+		addDiscussionIds(
+			data.trails
+				.map((trail) => trail.discussion?.discussionId)
+				.filter(isNonNullable),
+		);
 		return (
 			<div css={[minHeight, revealStyles]} className="onwards">
 				<div className="pending">

--- a/dotcom-rendering/src/lib/useCommentCount.ts
+++ b/dotcom-rendering/src/lib/useCommentCount.ts
@@ -50,3 +50,11 @@ export const useCommentCount = (
 
 	return data?.[shortUrl];
 };
+
+/** Ensure that we reduce the number of requests to get comment counts */
+export const addDiscussionIds = (ids: string[]): void => {
+	if (!uniqueDiscussionIds) return;
+	for (const id of ids) {
+		uniqueDiscussionIds.add(id);
+	}
+};


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Reduce the number of network calls to fetch comments count.

This is achieved by eagerly setting the set of discussion IDs as soon as they are know, before SWR is called.

~Non-`https` request URLs are also automatically upgraded, to reduce duplication even more.~ #8619 

## Why?

Improvement on #8307

## Screenshots

| Before      | Now    | After    |
| ----------- | ---------- |----------|
| ![before][] | ![now][] |![after][]|

[before]: https://github.com/guardian/dotcom-rendering/assets/76776/94d42a9a-0382-4eba-9ae6-e2d955294ff7
[now]: https://github.com/guardian/dotcom-rendering/assets/76776/50f24d40-1c25-4964-b0f0-c10465e804c2
[after]: https://github.com/guardian/dotcom-rendering/assets/76776/44909731-c558-46b8-860f-33ddaf2d41b7