### PR TITLE
Restrict width in fronts-banner ads

### DIFF
--- a/dotcom-rendering/src/components/AdSlot.tsx
+++ b/dotcom-rendering/src/components/AdSlot.tsx
@@ -225,10 +225,12 @@ const mobileFrontAdStyles = css`
 	}
 `;
 
+const frontsBannerPaddingHeight = 20;
+
 const frontsBannerAdTopContainerStyles = css`
 	display: flex;
 	justify-content: center;
-	min-height: ${250 + labelHeight}px;
+	min-height: ${250 + labelHeight + frontsBannerPaddingHeight}px;
 	background-color: ${palette.neutral[97]};
 
 	${until.desktop} {
@@ -238,6 +240,14 @@ const frontsBannerAdTopContainerStyles = css`
 
 const frontsBannerAdContainerStyles = css`
 	max-width: ${breakpoints['wide']}px;
+	/*
+		The following flex settings are to stop the visual effect where the
+		advert renders at the top of the ad slot, then is pushed down 24px to the
+		bottom of the slot when the label renders
+	*/
+	display: flex;
+	flex-direction: column;
+	justify-content: flex-end;
 `;
 
 const frontsBannerCollapseStyles = css`
@@ -247,14 +257,7 @@ const frontsBannerCollapseStyles = css`
 const frontsBannerAdStyles = css`
 	max-width: ${breakpoints['wide']}px;
 	overflow: hidden;
-	/*
-		The following flex settings are to stop the visual effect where the
-		advert renders at the top of the ad slot, then is pushed down 24px to the
-		bottom of the slot when the label renders
-	*/
-	display: flex;
-	flex-direction: column;
-	justify-content: flex-end;
+	padding-bottom: ${frontsBannerPaddingHeight}px;
 `;
 
 const articleEndAdStyles = css`

--- a/dotcom-rendering/src/components/AdSlot.tsx
+++ b/dotcom-rendering/src/components/AdSlot.tsx
@@ -3,12 +3,10 @@ import { adSizes, constants } from '@guardian/commercial';
 import type { SlotName } from '@guardian/commercial';
 import { ArticleDisplay } from '@guardian/libs';
 import {
-	border,
 	breakpoints,
 	from,
-	neutral,
+	palette,
 	space,
-	text,
 	textSans,
 	until,
 } from '@guardian/source-foundations';
@@ -56,10 +54,10 @@ const individualLabelCSS = css`
 	${textSans.xxsmall()};
 	height: ${labelHeight}px;
 	max-height: ${labelHeight}px;
-	background-color: ${neutral[97]};
+	background-color: ${palette.neutral[97]};
 	padding: 0 8px;
-	border-top: 1px solid ${border.secondary};
-	color: ${text.supporting};
+	border-top: 1px solid ${palette.neutral[86]};
+	color: ${palette.neutral[46]};
 	text-align: left;
 	box-sizing: border-box;
 `;
@@ -227,15 +225,19 @@ const mobileFrontAdStyles = css`
 	}
 `;
 
-const frontsBannerAdContainerStyles = css`
+const frontsBannerAdTopContainerStyles = css`
 	display: flex;
 	justify-content: center;
-	background-color: ${neutral[97]};
 	min-height: ${250 + labelHeight}px;
+	background-color: ${palette.neutral[97]};
 
 	${until.desktop} {
 		display: none;
 	}
+`;
+
+const frontsBannerAdContainerStyles = css`
+	max-width: ${breakpoints['wide']}px;
 `;
 
 const frontsBannerCollapseStyles = css`
@@ -328,8 +330,8 @@ const mobileStickyAdStyles = css`
 	.ad-slot__close-button svg {
 		height: 0.75rem;
 		width: 0.75rem;
-		stroke: ${neutral[7]};
-		fill: ${neutral[7]};
+		stroke: ${palette.neutral[7]};
+		fill: ${palette.neutral[7]};
 		stroke-linecap: round;
 		stroke-width: 0;
 		text-align: center;
@@ -338,7 +340,7 @@ const mobileStickyAdStyles = css`
 		display: block;
 	}
 	.ad-slot__close-button__x {
-		stroke: ${neutral[7]};
+		stroke: ${palette.neutral[7]};
 		fill: transparent;
 		stroke-linecap: round;
 		stroke-width: 2;
@@ -622,33 +624,35 @@ export const AdSlot = ({
 		case 'fronts-banner': {
 			const advertId = `fronts-banner-${index}`;
 			return (
-				<div
-					className="ad-slot-container"
-					css={[
-						adContainerStyles,
-						frontsBannerAdContainerStyles,
-						hasPageskin && frontsBannerCollapseStyles,
-					]}
-				>
+				<div css={frontsBannerAdTopContainerStyles}>
 					<div
-						id={`dfp-ad--${advertId}`}
-						className={[
-							'js-ad-slot',
-							'ad-slot',
-							`ad-slot--${advertId}`,
-							'ad-slot--rendered',
-							hasPageskin && 'ad-slot--collapse',
-						].join(' ')}
+						className="ad-slot-container"
 						css={[
-							fluidAdStyles,
-							fluidFullWidthAdStyles,
-							frontsBannerAdStyles,
+							adContainerStyles,
+							frontsBannerAdContainerStyles,
+							hasPageskin && frontsBannerCollapseStyles,
 						]}
-						data-link-name={`ad slot ${advertId}`}
-						data-name={`${advertId}`}
-						data-refresh="false"
-						aria-hidden="true"
-					/>
+					>
+						<div
+							id={`dfp-ad--${advertId}`}
+							className={[
+								'js-ad-slot',
+								'ad-slot',
+								`ad-slot--${advertId}`,
+								'ad-slot--rendered',
+								hasPageskin && 'ad-slot--collapse',
+							].join(' ')}
+							css={[
+								fluidAdStyles,
+								fluidFullWidthAdStyles,
+								frontsBannerAdStyles,
+							]}
+							data-link-name={`ad slot ${advertId}`}
+							data-name={`${advertId}`}
+							data-refresh="false"
+							aria-hidden="true"
+						/>
+					</div>
 				</div>
 			);
 		}

--- a/dotcom-rendering/src/components/AdSlot.tsx
+++ b/dotcom-rendering/src/components/AdSlot.tsx
@@ -48,7 +48,7 @@ type NonInlineProps = {
  */
 type Props = DefaultProps & (InlineProps | NonInlineProps);
 
-export const labelHeight = constants.AD_LABEL_HEIGHT;
+const labelHeight = constants.AD_LABEL_HEIGHT;
 
 const individualLabelCSS = css`
 	${textSans.xxsmall()};
@@ -199,7 +199,7 @@ const merchandisingAdContainerStyles = css`
 
 const merchandisingAdStyles = css`
 	position: relative;
-	min-height: 250px;
+	min-height: ${adSizes.billboard.height}px;
 `;
 
 const inlineAdStyles = css`
@@ -215,7 +215,7 @@ const liveblogInlineAdStyles = css`
 
 const mobileFrontAdStyles = css`
 	position: relative;
-	min-height: ${250 + labelHeight}px;
+	min-height: ${adSizes.mpu.height + labelHeight}px;
 	min-width: 300px;
 	width: 300px;
 	margin: 12px auto;
@@ -226,11 +226,13 @@ const mobileFrontAdStyles = css`
 `;
 
 const frontsBannerPaddingHeight = 20;
+const frontsBannerMinHeight =
+	adSizes.billboard.height + labelHeight + frontsBannerPaddingHeight;
 
 const frontsBannerAdTopContainerStyles = css`
 	display: flex;
 	justify-content: center;
-	min-height: ${250 + labelHeight + frontsBannerPaddingHeight}px;
+	min-height: ${frontsBannerMinHeight}px;
 	background-color: ${palette.neutral[97]};
 
 	${until.desktop} {
@@ -271,7 +273,7 @@ const articleEndAdStyles = css`
 
 const mostPopAdStyles = css`
 	position: relative;
-	min-height: ${250 + labelHeight}px;
+	min-height: ${adSizes.mpu.height + labelHeight}px;
 	min-width: 300px;
 	width: 300px;
 	margin: 12px auto;

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -417,6 +417,8 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 								!!eB.branding,
 						);
 
+					const isFirstContainer = index === 0;
+
 					if (collection.collectionType === 'fixed/thrasher') {
 						return (
 							<Fragment key={ophanName}>
@@ -428,7 +430,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 										front.config.pageId,
 										collection.displayName,
 										numBannerAdsInserted,
-										index === 0,
+										isFirstContainer,
 									)}
 									{!!trail.embedUri && (
 										<SnapCssSandbox
@@ -490,7 +492,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 									front.config.pageId,
 									collection.displayName,
 									numBannerAdsInserted,
-									index === 0,
+									isFirstContainer,
 								)}
 								<FrontSection
 									toggleable={true}
@@ -619,7 +621,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 									front.config.pageId,
 									collection.displayName,
 									numBannerAdsInserted,
-									index === 0,
+									isFirstContainer,
 								)}
 								<Section
 									title={collection.displayName}
@@ -689,7 +691,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 								front.config.pageId,
 								collection.displayName,
 								numBannerAdsInserted,
-								index === 0,
+								isFirstContainer,
 							)}
 							<FrontSection
 								title={collection.displayName}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

- The max-width of the `fronts-banner` ad slot container is now set to 1300px. 
- There is a new container around the original container

## Why?

- DFP fluid ads look at the width of the ad slot container and the width of the page to know whether they can display. We restrict the width of the ad slot to 1300px, but the ad does not know about this. By setting `max-width:1300px` on the ad slot container, these slots will no longer be filled by ads that are wider than 1300px.
- We can retain the grey background to the left and right of the ad

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/9574885/9916497f-13b8-48de-8c47-01d896e1785f
[after]: https://github.com/guardian/dotcom-rendering/assets/9574885/c72aced0-c3e0-4e0e-92fa-6ac4a38c247c

The full ad for reference
<img width="1692" alt="Screenshot 2023-08-17 at 17 06 02" src="https://github.com/guardian/dotcom-rendering/assets/9574885/e44ed804-47bc-4d7c-9547-82b533a23704">

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
