### PR TITLE
fix sticky sign-up form on safari

### DIFF
--- a/dotcom-rendering/src/components/ManyNewsletterSignUp.importable.tsx
+++ b/dotcom-rendering/src/components/ManyNewsletterSignUp.importable.tsx
@@ -37,6 +37,7 @@ const contentWrapperStyle = css`
 const sectionWrapperStyle = (hide: boolean) => css`
 	display: ${hide ? 'none' : 'block'};
 	position: fixed;
+	/* stylelint-disable-next-line value-no-vendor-prefix -- required safari before v13 https://developer.mozilla.org/en-US/docs/Web/CSS/position */
 	position: -webkit-sticky;
 	position: sticky;
 	bottom: 0;

--- a/dotcom-rendering/src/components/ManyNewsletterSignUp.importable.tsx
+++ b/dotcom-rendering/src/components/ManyNewsletterSignUp.importable.tsx
@@ -35,8 +35,9 @@ const contentWrapperStyle = css`
 `;
 
 const sectionWrapperStyle = (hide: boolean) => css`
-	display: ${hide ? 'none' : 'unset'};
+	display: ${hide ? 'none' : 'block'};
 	position: fixed;
+	position: -webkit-sticky;
 	position: sticky;
 	bottom: 0;
 	left: 0;


### PR DESCRIPTION
## What does this change?

CSS for the newsletters signup form on /email-newsletters 
 - `display:block` instead of `display:unset`  
 - `position:-webkit-sticky` as well as `position: sticky`

## Why?
Address CSS quirks in safari 
- `display:unset`  on an element displayed a block by default will prevent `position: sticky` from working.
-  webkit prefix required for sticky positioning prior to 13 (Released 2019-09-19) https://developer.mozilla.org/en-US/docs/Web/CSS/position


