### PR TITLE
Upgrade Discussion API URL to HTTPS

### DIFF
--- a/dotcom-rendering/src/lib/useCommentCount.ts
+++ b/dotcom-rendering/src/lib/useCommentCount.ts
@@ -2,6 +2,9 @@ import { isNonNullable } from '@guardian/libs';
 import { isServer } from './isServer';
 import { useApi } from './useApi';
 
+const REPLACEMENT = [/^http:\/\//, 'https://'] as const;
+const upgradeToHttps = (url: string) => url.replace(...REPLACEMENT);
+
 type CommentCounts = Record<string, number>;
 
 const getInitialSetFromDOMAttribute = (attribute: string) =>
@@ -23,7 +26,9 @@ export const useCommentCount = (
 			.sort() // ensures identical sets produce the same query parameter
 			.join(','),
 	});
-	const url = `${discussionApiUrl}/getCommentCounts?${searchParams.toString()}`;
+	const url = `${upgradeToHttps(
+		discussionApiUrl,
+	)}/getCommentCounts?${searchParams.toString()}`;
 	const { data } = useApi<CommentCounts>(url, {
 		// Discussion reponses have a long cache (~300s)
 		refreshInterval: 27_000,


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Force upgrade to HTTPS for the discussion API

## Why?

it currently [comes in as an HTTP url from Frontend](https://github.com/guardian/frontend/blob/237dfa4498b5f9972bf93ee5528ddf9e5ce79635/common/app/common/configuration.scala#L93)

## Screenshots

![CSP error](https://github.com/guardian/dotcom-rendering/assets/76776/c2237ef5-3b5d-4f42-af06-3123ce1c66a4)