### PR TITLE
fix(palette): remove immersive styling from headlines

### DIFF
--- a/dotcom-rendering/src/lib/decidePalette.ts
+++ b/dotcom-rendering/src/lib/decidePalette.ts
@@ -659,7 +659,16 @@ const textCardHeadline = (format: ArticleFormat): string => {
 	if (format.theme === ArticleSpecial.SpecialReportAlt)
 		return palette.specialReportAlt[100];
 
-	if (format.display === ArticleDisplay.Immersive) return BLACK;
+	if (
+		// Galleries are now considered Immersive, which would give them a dark background, so mustn't have `BLACK` text.
+		// There color is decided below in the `format.design` `switch`.
+		// see: https://github.com/guardian/content-api-scala-client/pull/387/files#diff-9384ebc9ebed8b6773587afc23b56246ec6ad014752a9b3718fd68339b705f1fR209
+		format.design !== ArticleDesign.Gallery &&
+		format.display === ArticleDisplay.Immersive
+	) {
+		return BLACK;
+	}
+
 	switch (format.design) {
 		case ArticleDesign.Gallery:
 		case ArticleDesign.Audio:


### PR DESCRIPTION
## What does this change?
As per [this change](https://github.com/guardian/content-api-scala-client/pull/387/files#diff-9384ebc9ebed8b6773587afc23b56246ec6ad014752a9b3718fd68339b705f1fL201) - galleries are now immersive. 

But... they are also on a dark background, so we should stop them having `BLACK` text. 

Raises the issue of "How do we test the data stuff that affects design" - I would suggest colocation of code, which might become easier with the App/DCR initiative.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/31692/ff609f76-c480-40da-aafe-2b4faf74419d

[after]: https://github.com/guardian/dotcom-rendering/assets/31692/ad2fbab8-236f-4519-a75e-fcb740a43f24


