### PR TITLE
Consider container border when calculating default height

### DIFF
--- a/dotcom-rendering/src/components/HeaderAdSlot.tsx
+++ b/dotcom-rendering/src/components/HeaderAdSlot.tsx
@@ -11,13 +11,16 @@ const headerWrapper = css`
 const { TOP_ABOVE_NAV_HEIGHT, AD_LABEL_HEIGHT } = constants;
 
 const padding = space[4] + 2; // 18px - currently being reviewed
+const borderBottomHeight = 1;
+const headerMinHeight =
+	TOP_ABOVE_NAV_HEIGHT + padding + AD_LABEL_HEIGHT + borderBottomHeight;
 
 const headerAdWrapper = css`
 	z-index: 1080;
 	width: 100%;
 	background-color: ${neutral[97]};
-	min-height: ${TOP_ABOVE_NAV_HEIGHT + padding + AD_LABEL_HEIGHT}px;
-	border-bottom: 1px solid ${border.secondary};
+	min-height: ${headerMinHeight}px;
+	border-bottom: ${borderBottomHeight}px solid ${border.secondary};
 	padding-bottom: ${padding}px;
 
 	display: flex;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

- Bumps the minimum height of the top banner ad container up by 1px. 

## Why?

- The top banner ad container has a border of 1px that we don't consider when calculating the minimum height. This means that when an advert with 90px loads, the page gets pushed down by 1px. Larger ads are also affected in the same way

## Screenshots (keen eye needed!)

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/9574885/62a30e4b-93d8-4c59-b0c1-7a04f2194f20
[after]: https://github.com/guardian/dotcom-rendering/assets/9574885/328a3d39-9a14-4dfb-8708-1a6c7c2561d8

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
