### PR TITLE
Drill Discussion API URL prop down

### DIFF
--- a/dotcom-rendering/fixtures/manual/discussionApiUrl.ts
+++ b/dotcom-rendering/fixtures/manual/discussionApiUrl.ts
@@ -1,0 +1,2 @@
+export const discussionApiUrl =
+	'https://discussion.theguardian.com/discussion-api';

--- a/dotcom-rendering/fixtures/manual/trails.ts
+++ b/dotcom-rendering/fixtures/manual/trails.ts
@@ -1,5 +1,6 @@
 import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
 import type { DCRFrontCard } from '../../src/types/front';
+import { discussionApiUrl } from './discussionApiUrl';
 
 export const trails: [
 	DCRFrontCard,
@@ -74,6 +75,7 @@ export const trails: [
 		mainMedia: undefined,
 		isExternalLink: false,
 		showLivePlayable: false,
+		discussionApiUrl,
 	},
 	{
 		url: 'https://www.theguardian.com/environment/2019/dec/02/migration-v-climate-europes-new-political-divide',
@@ -108,6 +110,7 @@ export const trails: [
 		},
 		isExternalLink: false,
 		showLivePlayable: false,
+		discussionApiUrl,
 	},
 	{
 		url: 'https://www.theguardian.com/world/2019/nov/28/eu-parliament-declares-climate-emergency',
@@ -127,6 +130,7 @@ export const trails: [
 		mainMedia: undefined,
 		isExternalLink: false,
 		showLivePlayable: false,
+		discussionApiUrl,
 	},
 	{
 		url: 'https://www.theguardian.com/environment/2019/nov/27/climate-emergency-world-may-have-crossed-tipping-points',
@@ -145,6 +149,7 @@ export const trails: [
 		mainMedia: undefined,
 		isExternalLink: false,
 		showLivePlayable: false,
+		discussionApiUrl,
 	},
 	{
 		url: 'https://www.theguardian.com/world/2019/nov/26/european-parliament-split-on-declaring-climate-emergency',
@@ -163,6 +168,7 @@ export const trails: [
 		mainMedia: undefined,
 		isExternalLink: false,
 		showLivePlayable: false,
+		discussionApiUrl,
 	},
 	{
 		url: 'https://www.theguardian.com/world/2019/nov/23/north-pole-explorers-on-thin-ice-as-climate-change-hits-expedition',
@@ -182,6 +188,7 @@ export const trails: [
 		mainMedia: undefined,
 		isExternalLink: false,
 		showLivePlayable: false,
+		discussionApiUrl,
 	},
 	{
 		url: 'https://www.theguardian.com/environment/2019/oct/25/scientists-glacial-rivers-absorb-carbon-faster-rainforests',
@@ -202,6 +209,7 @@ export const trails: [
 		mainMedia: undefined,
 		isExternalLink: false,
 		showLivePlayable: false,
+		discussionApiUrl,
 	},
 	{
 		url: 'https://www.theguardian.com/business/2019/oct/20/uk-urges-world-bank-to-channel-more-money-into-tackling-climate-crisis',
@@ -221,6 +229,7 @@ export const trails: [
 		mainMedia: undefined,
 		isExternalLink: false,
 		showLivePlayable: false,
+		discussionApiUrl,
 	},
 
 	{
@@ -242,6 +251,7 @@ export const trails: [
 		mainMedia: undefined,
 		isExternalLink: false,
 		showLivePlayable: false,
+		discussionApiUrl,
 	},
 	{
 		url: 'https://www.theguardian.com/world/2021/feb/17/uk-to-begin-worlds-first-covid-human-challenge-study-within-weeks',
@@ -262,6 +272,7 @@ export const trails: [
 		mainMedia: undefined,
 		isExternalLink: false,
 		showLivePlayable: false,
+		discussionApiUrl,
 	},
 	{
 		url: 'https://www.theguardian.com/world/2021/feb/17/scottish-government-inadequately-prepared-for-covid-audit-scotland-report',
@@ -282,6 +293,7 @@ export const trails: [
 		mainMedia: undefined,
 		isExternalLink: false,
 		showLivePlayable: false,
+		discussionApiUrl,
 	},
 	{
 		url: 'https://www.theguardian.com/society/2021/feb/16/encouraging-signs-covid-vaccine-over-80s-deaths-fall-england',
@@ -302,6 +314,7 @@ export const trails: [
 		mainMedia: undefined,
 		isExternalLink: false,
 		showLivePlayable: false,
+		discussionApiUrl,
 	},
 	{
 		url: 'https://www.theguardian.com/world/2021/feb/16/contact-tracing-alone-has-little-impact-on-curbing-covid-spread-report-finds',
@@ -322,6 +335,7 @@ export const trails: [
 		mainMedia: undefined,
 		isExternalLink: false,
 		showLivePlayable: false,
+		discussionApiUrl,
 	},
 	{
 		url: 'https://www.theguardian.com/world/2021/feb/16/covid-almost-2m-more-people-asked-shield-england',
@@ -342,6 +356,7 @@ export const trails: [
 		mainMedia: undefined,
 		isExternalLink: false,
 		showLivePlayable: false,
+		discussionApiUrl,
 	},
 	{
 		url: 'https://www.theguardian.com/politics/live/2021/feb/16/uk-covid-live-coronavirus-sturgeon-return-scottish-schools-latest-updates',
@@ -362,6 +377,7 @@ export const trails: [
 		mainMedia: undefined,
 		isExternalLink: false,
 		showLivePlayable: false,
+		discussionApiUrl,
 	},
 	{
 		url: 'https://www.theguardian.com/uk-news/2021/feb/16/qcovid-how-improved-algorithm-can-identify-more-higher-risk-adults',
@@ -382,6 +398,7 @@ export const trails: [
 		mainMedia: undefined,
 		isExternalLink: false,
 		showLivePlayable: false,
+		discussionApiUrl,
 	},
 	{
 		url: 'https://www.theguardian.com/world/2019/nov/28/eu-parliament-declares-climate-emergency',
@@ -400,6 +417,7 @@ export const trails: [
 		mainMedia: undefined,
 		isExternalLink: false,
 		showLivePlayable: false,
+		discussionApiUrl,
 	},
 	{
 		url: 'https://www.theguardian.com/society/2023/may/30/trans-activists-disrupt-kathleen-stock-speech-at-oxford-union',
@@ -419,6 +437,7 @@ export const trails: [
 		mainMedia: undefined,
 		isExternalLink: false,
 		showLivePlayable: false,
+		discussionApiUrl,
 	},
 	{
 		url: 'https://www.theguardian.com/commentisfree/2023/may/31/price-controls-rishi-sunak-thatcher-prime-minister',
@@ -438,6 +457,7 @@ export const trails: [
 		mainMedia: undefined,
 		isExternalLink: false,
 		showLivePlayable: false,
+		discussionApiUrl,
 	},
 	{
 		url: 'https://www.theguardian.com/tv-and-radio/2023/may/30/a-revelation-succession-matthew-macfadyen-has-been-a-consummate-shapeshifter',
@@ -457,5 +477,6 @@ export const trails: [
 		mainMedia: undefined,
 		isExternalLink: false,
 		showLivePlayable: false,
+		discussionApiUrl,
 	},
 ];

--- a/dotcom-rendering/src/components/Card/Card.stories.tsx
+++ b/dotcom-rendering/src/components/Card/Card.stories.tsx
@@ -34,6 +34,7 @@ const basicCardProps: CardProps = {
 	isExternalLink: false,
 	isPlayableMediaCard: true,
 	imageLoading: 'eager',
+	discussionApiUrl: 'https://discussion.theguardian.com/discussion-api/',
 };
 
 const aBasicLink = {

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -89,7 +89,7 @@ export type Props = {
 	containerPalette?: DCRContainerPalette;
 	containerType?: DCRContainerType;
 	showAge?: boolean;
-	discussionApiUrl?: string;
+	discussionApiUrl: string;
 	discussionId?: string;
 	/** The first card in a dynamic package is ”Dynamo” and gets special styling */
 	isDynamo?: true;
@@ -276,7 +276,7 @@ export const Card = ({
 	containerPalette,
 	containerType,
 	showAge = true,
-	discussionApiUrl = 'http://discussion.theguardian.com/discussion-api', // should require a value
+	discussionApiUrl,
 	discussionId,
 	isDynamo,
 	isCrossword,

--- a/dotcom-rendering/src/components/Carousel.importable.tsx
+++ b/dotcom-rendering/src/components/Carousel.importable.tsx
@@ -34,6 +34,7 @@ type Props = {
 	url?: string;
 	onwardsSource: OnwardsSource;
 	leftColSize: LeftColSize;
+	discussionApiUrl: string;
 };
 
 type ArticleProps = Props & {
@@ -470,6 +471,7 @@ type CarouselCardProps = {
 	kickerText?: string;
 	imageUrl?: string;
 	dataLinkName?: string;
+	discussionApiUrl: string;
 	discussionId?: string;
 	/** Only used on Labs cards */
 	branding?: Branding;
@@ -495,6 +497,7 @@ const CarouselCard = ({
 	onwardsSource,
 	containerType,
 	imageLoading,
+	discussionApiUrl,
 }: CarouselCardProps) => {
 	const isVideoContainer = containerType === 'fixed/video';
 	return (
@@ -529,6 +532,7 @@ const CarouselCard = ({
 				onwardsSource={onwardsSource}
 				containerType={containerType}
 				imageLoading={imageLoading}
+				discussionApiUrl={discussionApiUrl}
 			/>
 		</LI>
 	);
@@ -857,6 +861,7 @@ export const Carousel = ({
 	trails,
 	onwardsSource,
 	leftColSize,
+	discussionApiUrl,
 	...props
 }: ArticleProps | FrontProps) => {
 	const carouselColours = decideCarouselColours(props);
@@ -1085,6 +1090,7 @@ export const Carousel = ({
 								onwardsSource={onwardsSource}
 								containerType={containerType}
 								imageLoading={imageLoading}
+								discussionApiUrl={discussionApiUrl}
 							/>
 						);
 					})}

--- a/dotcom-rendering/src/components/Carousel.stories.tsx
+++ b/dotcom-rendering/src/components/Carousel.stories.tsx
@@ -5,6 +5,7 @@ import {
 	Pillar,
 } from '@guardian/libs';
 import { breakpoints } from '@guardian/source-foundations';
+import { discussionApiUrl } from '../../fixtures/manual/discussionApiUrl';
 import type { TrailType } from '../types/trails';
 import { Carousel } from './Carousel.importable';
 import { Section } from './Section';
@@ -206,6 +207,7 @@ export const Headlines = () => (
 					display: ArticleDisplay.Standard,
 				}}
 				leftColSize={'compact'}
+				discussionApiUrl={discussionApiUrl}
 			/>
 		</Section>
 		<Section fullWidth={true}>
@@ -219,6 +221,7 @@ export const Headlines = () => (
 					display: ArticleDisplay.Standard,
 				}}
 				leftColSize={'compact'}
+				discussionApiUrl={discussionApiUrl}
 			/>
 		</Section>
 	</>
@@ -239,6 +242,7 @@ export const SingleItemCarousel = () => (
 					display: ArticleDisplay.Standard,
 				}}
 				leftColSize={'compact'}
+				discussionApiUrl={discussionApiUrl}
 			/>
 		</Section>
 	</>
@@ -259,6 +263,7 @@ export const Immersive = () => (
 					display: ArticleDisplay.Immersive,
 				}}
 				leftColSize={'compact'}
+				discussionApiUrl={discussionApiUrl}
 			/>
 		</Section>
 		<Section fullWidth={true}>
@@ -272,6 +277,7 @@ export const Immersive = () => (
 					display: ArticleDisplay.Immersive,
 				}}
 				leftColSize={'compact'}
+				discussionApiUrl={discussionApiUrl}
 			/>
 		</Section>
 	</>
@@ -302,6 +308,7 @@ export const SpecialReportAlt = () => {
 						display: ArticleDisplay.Standard,
 					}}
 					leftColSize={'compact'}
+					discussionApiUrl={discussionApiUrl}
 				/>
 			</Section>
 		</>

--- a/dotcom-rendering/src/components/DecideContainerByTrails.stories.tsx
+++ b/dotcom-rendering/src/components/DecideContainerByTrails.stories.tsx
@@ -1,4 +1,5 @@
 import { breakpoints } from '@guardian/source-foundations';
+import { discussionApiUrl } from '../../fixtures/manual/discussionApiUrl';
 import { trails } from '../../fixtures/manual/trails';
 import { DecideContainerByTrails } from './DecideContainerByTrails';
 import { FrontSection } from './FrontSection';
@@ -19,7 +20,10 @@ export default {
 
 export const OneCardFast = () => {
 	return (
-		<FrontSection title="Fast - One card">
+		<FrontSection
+			title="Fast - One card"
+			discussionApiUrl={discussionApiUrl}
+		>
 			<DecideContainerByTrails
 				trails={trails.slice(0, 1)}
 				speed="fast"
@@ -32,7 +36,10 @@ OneCardFast.storyName = 'Fast - One card';
 
 export const TwoCardFast = () => {
 	return (
-		<FrontSection title="Fast - Two cards">
+		<FrontSection
+			title="Fast - Two cards"
+			discussionApiUrl={discussionApiUrl}
+		>
 			<DecideContainerByTrails
 				trails={trails.slice(0, 2)}
 				speed="fast"
@@ -45,7 +52,10 @@ TwoCardFast.storyName = 'Fast - Two cards';
 
 export const ThreeCardFast = () => {
 	return (
-		<FrontSection title="Fast - Three cards">
+		<FrontSection
+			title="Fast - Three cards"
+			discussionApiUrl={discussionApiUrl}
+		>
 			<DecideContainerByTrails
 				trails={trails.slice(0, 3)}
 				speed="fast"
@@ -58,7 +68,10 @@ ThreeCardFast.storyName = 'Fast - Three cards';
 
 export const FourCardFast = () => {
 	return (
-		<FrontSection title="Fast - Four cards">
+		<FrontSection
+			title="Fast - Four cards"
+			discussionApiUrl={discussionApiUrl}
+		>
 			<DecideContainerByTrails
 				trails={trails.slice(0, 4)}
 				speed="fast"
@@ -71,7 +84,10 @@ FourCardFast.storyName = 'Fast - Four cards';
 
 export const FiveCardFast = () => {
 	return (
-		<FrontSection title="Fast - Five cards">
+		<FrontSection
+			title="Fast - Five cards"
+			discussionApiUrl={discussionApiUrl}
+		>
 			<DecideContainerByTrails
 				trails={trails.slice(0, 5)}
 				speed="fast"
@@ -84,7 +100,10 @@ FiveCardFast.storyName = 'Fast - Five cards';
 
 export const SixCardFast = () => {
 	return (
-		<FrontSection title="Fast - Six cards">
+		<FrontSection
+			title="Fast - Six cards"
+			discussionApiUrl={discussionApiUrl}
+		>
 			<DecideContainerByTrails
 				trails={trails.slice(0, 6)}
 				speed="fast"
@@ -97,7 +116,10 @@ SixCardFast.storyName = 'Fast - Six cards';
 
 export const SevenCardFast = () => {
 	return (
-		<FrontSection title="Fast - Seven cards">
+		<FrontSection
+			title="Fast - Seven cards"
+			discussionApiUrl={discussionApiUrl}
+		>
 			<DecideContainerByTrails
 				trails={trails.slice(0, 7)}
 				speed="fast"
@@ -110,7 +132,10 @@ SevenCardFast.storyName = 'Fast - Seven cards';
 
 export const EightCardFast = () => {
 	return (
-		<FrontSection title="Fast - Eight cards">
+		<FrontSection
+			title="Fast - Eight cards"
+			discussionApiUrl={discussionApiUrl}
+		>
 			<DecideContainerByTrails
 				trails={trails.slice(0, 8)}
 				speed="fast"
@@ -124,7 +149,10 @@ EightCardFast.storyName = 'Fast - Eight cards';
 
 export const TwelveCardFast = () => {
 	return (
-		<FrontSection title="Fast - Twelve cards">
+		<FrontSection
+			title="Fast - Twelve cards"
+			discussionApiUrl={discussionApiUrl}
+		>
 			<DecideContainerByTrails
 				trails={trails.slice(0, 12)}
 				speed="fast"
@@ -137,7 +165,10 @@ TwelveCardFast.storyName = 'Fast - Twelve cards';
 
 export const OneCardSlow = () => {
 	return (
-		<FrontSection title="Slow - One card">
+		<FrontSection
+			title="Slow - One card"
+			discussionApiUrl={discussionApiUrl}
+		>
 			<DecideContainerByTrails
 				trails={trails.slice(0, 1)}
 				speed="slow"
@@ -150,7 +181,10 @@ OneCardSlow.storyName = 'Slow - One card';
 
 export const TwoCardSlow = () => {
 	return (
-		<FrontSection title="Slow - Two cards">
+		<FrontSection
+			title="Slow - Two cards"
+			discussionApiUrl={discussionApiUrl}
+		>
 			<DecideContainerByTrails
 				trails={trails.slice(0, 2)}
 				speed="slow"
@@ -163,7 +197,10 @@ TwoCardSlow.storyName = 'Slow - Two cards';
 
 export const ThreeCardSlow = () => {
 	return (
-		<FrontSection title="Slow - Three cards">
+		<FrontSection
+			title="Slow - Three cards"
+			discussionApiUrl={discussionApiUrl}
+		>
 			<DecideContainerByTrails
 				trails={trails.slice(0, 3)}
 				speed="slow"
@@ -176,7 +213,10 @@ ThreeCardSlow.storyName = 'Slow - Three cards';
 
 export const FourCardSlow = () => {
 	return (
-		<FrontSection title="Slow - Four cards">
+		<FrontSection
+			title="Slow - Four cards"
+			discussionApiUrl={discussionApiUrl}
+		>
 			<DecideContainerByTrails
 				trails={trails.slice(0, 4)}
 				speed="slow"
@@ -189,7 +229,10 @@ FourCardSlow.storyName = 'Slow - Four cards';
 
 export const FiveCardSlow = () => {
 	return (
-		<FrontSection title="Slow - Five cards">
+		<FrontSection
+			title="Slow - Five cards"
+			discussionApiUrl={discussionApiUrl}
+		>
 			<DecideContainerByTrails
 				trails={trails.slice(0, 5)}
 				speed="slow"
@@ -202,7 +245,10 @@ FiveCardSlow.storyName = 'Slow - Five cards';
 
 export const SixCardSlow = () => {
 	return (
-		<FrontSection title="Slow - Six cards">
+		<FrontSection
+			title="Slow - Six cards"
+			discussionApiUrl={discussionApiUrl}
+		>
 			<DecideContainerByTrails
 				trails={trails.slice(0, 6)}
 				speed="slow"
@@ -215,7 +261,10 @@ SixCardSlow.storyName = 'Slow - Six cards';
 
 export const SevenCardSlow = () => {
 	return (
-		<FrontSection title="Slow - Seven cards">
+		<FrontSection
+			title="Slow - Seven cards"
+			discussionApiUrl={discussionApiUrl}
+		>
 			<DecideContainerByTrails
 				trails={trails.slice(0, 7)}
 				speed="slow"
@@ -228,7 +277,10 @@ SevenCardSlow.storyName = 'Slow - Seven cards';
 
 export const EightCardSlow = () => {
 	return (
-		<FrontSection title="Slow - Eight cards">
+		<FrontSection
+			title="Slow - Eight cards"
+			discussionApiUrl={discussionApiUrl}
+		>
 			<DecideContainerByTrails
 				trails={trails.slice(0, 8)}
 				speed="slow"
@@ -242,7 +294,10 @@ EightCardSlow.storyName = 'Slow - Eight cards';
 
 export const TwelveCardSlow = () => {
 	return (
-		<FrontSection title="Slow - Twelve cards">
+		<FrontSection
+			title="Slow - Twelve cards"
+			discussionApiUrl={discussionApiUrl}
+		>
 			<DecideContainerByTrails
 				trails={trails.slice(0, 12)}
 				speed="slow"

--- a/dotcom-rendering/src/components/DynamicFast.stories.tsx
+++ b/dotcom-rendering/src/components/DynamicFast.stories.tsx
@@ -1,4 +1,5 @@
 import { breakpoints } from '@guardian/source-foundations';
+import { discussionApiUrl } from '../../fixtures/manual/discussionApiUrl';
 import { trails } from '../../fixtures/manual/trails';
 import type { DCRGroupedTrails } from '../types/front';
 import { DynamicFast } from './DynamicFast';
@@ -32,6 +33,7 @@ export const OneHugeTwoBigsSixStandards = () => (
 	<FrontSection
 		title="Dynamic Fast"
 		description={`first slice: oneHuge</br>second slice: twoBigs`}
+		discussionApiUrl={discussionApiUrl}
 	>
 		<DynamicFast
 			groupedTrails={{
@@ -51,6 +53,7 @@ export const OneVeryBigTwoBigsSixStandards = () => (
 	<FrontSection
 		title="Dynamic Fast"
 		description={`first slice: oneVeryBig</br>second slice: twoBigs`}
+		discussionApiUrl={discussionApiUrl}
 	>
 		<DynamicFast
 			groupedTrails={{
@@ -71,6 +74,7 @@ export const TwoVeryBigsTwoBigsSixStandards = () => (
 	<FrontSection
 		title="Dynamic Fast"
 		description={`first slice: twoVeryBigs</br>second slice: twoBigs`}
+		discussionApiUrl={discussionApiUrl}
 	>
 		<DynamicFast
 			groupedTrails={{
@@ -91,6 +95,7 @@ export const TwoVeryBigs1stBoostedTwoBigsSixStandards = () => (
 	<FrontSection
 		title="Dynamic Fast"
 		description={`first slice: twoVeryBigsFirstBoosted</br>second slice: twoBigs`}
+		discussionApiUrl={discussionApiUrl}
 	>
 		<DynamicFast
 			groupedTrails={{
@@ -111,6 +116,7 @@ export const TwoVeryBigs2ndBoostedTwoBigsSixStandards = () => (
 	<FrontSection
 		title="Dynamic Fast"
 		description={`first slice: twoVeryBigsSecondBoosted</br>second slice: twoBigs`}
+		discussionApiUrl={discussionApiUrl}
 	>
 		<DynamicFast
 			groupedTrails={{
@@ -133,6 +139,7 @@ export const TwoVeryBigsTwelveStandards = () => (
 	<FrontSection
 		title="Dynamic Fast"
 		description={`first slice: twoVeryBigs</br>second slice: noBigs`}
+		discussionApiUrl={discussionApiUrl}
 	>
 		<DynamicFast
 			groupedTrails={{
@@ -152,6 +159,7 @@ export const TwoVeryBigsOneBigEightStandards = () => (
 	<FrontSection
 		title="Dynamic Fast"
 		description={`first slice: twoVeryBigs</br>second slice: oneBig`}
+		discussionApiUrl={discussionApiUrl}
 	>
 		<DynamicFast
 			groupedTrails={{
@@ -173,6 +181,7 @@ export const TwoVeryBigsOneBigBoostedSixStandards = () => (
 	<FrontSection
 		title="Dynamic Fast"
 		description={`first slice: twoVeryBigs</br>second slice: oneBigBoosted`}
+		discussionApiUrl={discussionApiUrl}
 	>
 		<DynamicFast
 			groupedTrails={{
@@ -194,6 +203,7 @@ export const TwoVeryBigsTwoBigsFiveStandards = () => (
 	<FrontSection
 		title="Dynamic Fast"
 		description={`first slice: twoVeryBigs</br>second slice: twoBigs`}
+		discussionApiUrl={discussionApiUrl}
 	>
 		<DynamicFast
 			groupedTrails={{
@@ -215,6 +225,7 @@ export const TwoVeryBigsTwoBigsFirstBoostedEightStandards = () => (
 	<FrontSection
 		title="Dynamic Fast"
 		description={`first slice: twoVeryBigs</br>second slice: twoOrMoreBigsFirstBoosted`}
+		discussionApiUrl={discussionApiUrl}
 	>
 		<DynamicFast
 			groupedTrails={{
@@ -236,6 +247,7 @@ export const TwoVeryBigsThreeBigsThreeStandards = () => (
 	<FrontSection
 		title="Dynamic Fast"
 		description={`first slice: twoVeryBigs</br>second slice: threeBigs`}
+		discussionApiUrl={discussionApiUrl}
 	>
 		<DynamicFast
 			groupedTrails={{
@@ -257,6 +269,7 @@ export const TwoVeryBigsFourBigs = () => (
 	<FrontSection
 		title="Dynamic Fast"
 		description={`first slice: twoVeryBigs</br>second slice: fourBigs`}
+		discussionApiUrl={discussionApiUrl}
 	>
 		<DynamicFast
 			groupedTrails={{
@@ -280,6 +293,7 @@ export const OneHugeOneVeryBig7Standards = () => (
 	<FrontSection
 		title="Dynamic Fast"
 		description={`first slice: oneHuge</br>second slice: oneBig`}
+		discussionApiUrl={discussionApiUrl}
 	>
 		<DynamicFast
 			groupedTrails={{
@@ -301,6 +315,7 @@ export const ThreeVeryBigsFourBigs = () => (
 	<FrontSection
 		title="Dynamic Fast"
 		description={`first slice: twoVeryBigs</br>second slice: fourBigs`}
+		discussionApiUrl={discussionApiUrl}
 	>
 		<DynamicFast
 			groupedTrails={{
@@ -321,6 +336,7 @@ export const TwoBigsFourStandards = () => (
 	<FrontSection
 		title="Dynamic Fast"
 		description={`first slice: undefined</br>second slice: twoBigs`}
+		discussionApiUrl={discussionApiUrl}
 	>
 		<DynamicFast
 			groupedTrails={{
@@ -342,6 +358,7 @@ export const OneVeryBigTwoBigs = () => (
 	<FrontSection
 		title="Dynamic Fast"
 		description={`first slice: oneVeryBig</br>second slice: twoBigs`}
+		discussionApiUrl={discussionApiUrl}
 	>
 		<DynamicFast
 			groupedTrails={{
@@ -362,6 +379,7 @@ export const OneVeryBig = () => (
 	<FrontSection
 		title="Dynamic Fast"
 		description={`first slice: oneVeryBig</br>second slice: noBigs`}
+		discussionApiUrl={discussionApiUrl}
 	>
 		<DynamicFast
 			groupedTrails={{
@@ -381,6 +399,7 @@ export const TwoVeryBigsFourBigsFirstBoostedThreeStandards = () => (
 	<FrontSection
 		title="Dynamic Fast"
 		description={`first slice: twoVeryBigs</br>second slice: twoOrMoreBigsFirstBoosted`}
+		discussionApiUrl={discussionApiUrl}
 	>
 		<DynamicFast
 			groupedTrails={{

--- a/dotcom-rendering/src/components/DynamicPackage.stories.tsx
+++ b/dotcom-rendering/src/components/DynamicPackage.stories.tsx
@@ -1,5 +1,6 @@
 import { ArticleDesign, ArticleDisplay, ArticleSpecial } from '@guardian/libs';
 import { breakpoints } from '@guardian/source-foundations';
+import { discussionApiUrl } from '../../fixtures/manual/discussionApiUrl';
 import { trails } from '../../fixtures/manual/trails';
 import type { DCRGroupedTrails } from '../types/front';
 import { DynamicPackage } from './DynamicPackage';
@@ -28,7 +29,11 @@ export default {
 };
 
 export const One = () => (
-	<FrontSection title="Dynamic Package" showTopBorder={true}>
+	<FrontSection
+		title="Dynamic Package"
+		showTopBorder={true}
+		discussionApiUrl={discussionApiUrl}
+	>
 		<DynamicPackage
 			groupedTrails={{
 				...defaultGroupedTrails,
@@ -43,7 +48,11 @@ export const One = () => (
 One.storyName = 'With one standard card';
 
 export const Two = () => (
-	<FrontSection title="Dynamic Package" showTopBorder={true}>
+	<FrontSection
+		title="Dynamic Package"
+		showTopBorder={true}
+		discussionApiUrl={discussionApiUrl}
+	>
 		<DynamicPackage
 			groupedTrails={{
 				...defaultGroupedTrails,
@@ -58,7 +67,7 @@ export const Two = () => (
 Two.storyName = 'With two standard cards';
 
 export const Three = () => (
-	<FrontSection title="Dynamic Package">
+	<FrontSection title="Dynamic Package" discussionApiUrl={discussionApiUrl}>
 		<DynamicPackage
 			groupedTrails={{
 				...defaultGroupedTrails,
@@ -73,7 +82,7 @@ export const Three = () => (
 Three.storyName = 'With three standard cards';
 
 export const Four = () => (
-	<FrontSection title="Dynamic Package">
+	<FrontSection title="Dynamic Package" discussionApiUrl={discussionApiUrl}>
 		<DynamicPackage
 			groupedTrails={{
 				...defaultGroupedTrails,
@@ -88,7 +97,7 @@ export const Four = () => (
 Four.storyName = 'With four standard cards';
 
 export const Five = () => (
-	<FrontSection title="Dynamic Package">
+	<FrontSection title="Dynamic Package" discussionApiUrl={discussionApiUrl}>
 		<DynamicPackage
 			groupedTrails={{
 				...defaultGroupedTrails,
@@ -103,7 +112,11 @@ export const Five = () => (
 Five.storyName = 'With five standard cards';
 
 export const Six = () => (
-	<FrontSection title="Dynamic Package" showTopBorder={true}>
+	<FrontSection
+		title="Dynamic Package"
+		showTopBorder={true}
+		discussionApiUrl={discussionApiUrl}
+	>
 		<DynamicPackage
 			groupedTrails={{
 				...defaultGroupedTrails,
@@ -118,7 +131,11 @@ export const Six = () => (
 Six.storyName = 'With six standard cards';
 
 export const Seven = () => (
-	<FrontSection title="Dynamic Package" showTopBorder={true}>
+	<FrontSection
+		title="Dynamic Package"
+		showTopBorder={true}
+		discussionApiUrl={discussionApiUrl}
+	>
 		<DynamicPackage
 			groupedTrails={{
 				...defaultGroupedTrails,
@@ -133,7 +150,11 @@ export const Seven = () => (
 Seven.storyName = 'With seven standard cards';
 
 export const Eight = () => (
-	<FrontSection title="Dynamic Package" showTopBorder={true}>
+	<FrontSection
+		title="Dynamic Package"
+		showTopBorder={true}
+		discussionApiUrl={discussionApiUrl}
+	>
 		<DynamicPackage
 			groupedTrails={{
 				...defaultGroupedTrails,
@@ -148,7 +169,11 @@ export const Eight = () => (
 Eight.storyName = 'With eight standard cards';
 
 export const Nine = () => (
-	<FrontSection title="Dynamic Package" showTopBorder={true}>
+	<FrontSection
+		title="Dynamic Package"
+		showTopBorder={true}
+		discussionApiUrl={discussionApiUrl}
+	>
 		<DynamicPackage
 			groupedTrails={{
 				...defaultGroupedTrails,
@@ -166,7 +191,11 @@ export const Boosted1 = () => {
 	const primary = trails[0];
 
 	return (
-		<FrontSection title="Dynamic Package" showTopBorder={true}>
+		<FrontSection
+			title="Dynamic Package"
+			showTopBorder={true}
+			discussionApiUrl={discussionApiUrl}
+		>
 			<DynamicPackage
 				groupedTrails={{
 					...defaultGroupedTrails,
@@ -187,7 +216,11 @@ export const Boosted2 = () => {
 	const remaining = trails.slice(1, 2);
 
 	return (
-		<FrontSection title="Dynamic Package" showTopBorder={true}>
+		<FrontSection
+			title="Dynamic Package"
+			showTopBorder={true}
+			discussionApiUrl={discussionApiUrl}
+		>
 			<DynamicPackage
 				groupedTrails={{
 					...defaultGroupedTrails,
@@ -208,7 +241,10 @@ export const Boosted3 = () => {
 	const remaining = trails.slice(1, 3);
 
 	return (
-		<FrontSection title="Dynamic Package">
+		<FrontSection
+			title="Dynamic Package"
+			discussionApiUrl={discussionApiUrl}
+		>
 			<DynamicPackage
 				groupedTrails={{
 					...defaultGroupedTrails,
@@ -229,7 +265,10 @@ export const Boosted4 = () => {
 	const remaining = trails.slice(1, 4);
 
 	return (
-		<FrontSection title="Dynamic Package">
+		<FrontSection
+			title="Dynamic Package"
+			discussionApiUrl={discussionApiUrl}
+		>
 			<DynamicPackage
 				groupedTrails={{
 					...defaultGroupedTrails,
@@ -250,7 +289,10 @@ export const Boosted5 = () => {
 	const remaining = trails.slice(1, 5);
 
 	return (
-		<FrontSection title="Dynamic Package">
+		<FrontSection
+			title="Dynamic Package"
+			discussionApiUrl={discussionApiUrl}
+		>
 			<DynamicPackage
 				groupedTrails={{
 					...defaultGroupedTrails,
@@ -271,7 +313,11 @@ export const Boosted8 = () => {
 	const remaining = trails.slice(1, 8);
 
 	return (
-		<FrontSection title="Dynamic Package" showTopBorder={true}>
+		<FrontSection
+			title="Dynamic Package"
+			showTopBorder={true}
+			discussionApiUrl={discussionApiUrl}
+		>
 			<DynamicPackage
 				groupedTrails={{
 					...defaultGroupedTrails,
@@ -292,7 +338,11 @@ export const Boosted9 = () => {
 	const remaining = trails.slice(1, 9);
 
 	return (
-		<FrontSection title="Dynamic Package" showTopBorder={true}>
+		<FrontSection
+			title="Dynamic Package"
+			showTopBorder={true}
+			discussionApiUrl={discussionApiUrl}
+		>
 			<DynamicPackage
 				groupedTrails={{
 					...defaultGroupedTrails,
@@ -309,7 +359,7 @@ export const Boosted9 = () => {
 Boosted9.storyName = 'With nine standard cards - boosted';
 
 export const OneSnapThreeStandard = () => (
-	<FrontSection title="Dynamic Package">
+	<FrontSection title="Dynamic Package" discussionApiUrl={discussionApiUrl}>
 		<DynamicPackage
 			groupedTrails={{
 				...defaultGroupedTrails,
@@ -324,7 +374,7 @@ export const OneSnapThreeStandard = () => (
 OneSnapThreeStandard.storyName = 'With one snap - three standard cards';
 
 export const ThreeSnapTwoStandard = () => (
-	<FrontSection title="Dynamic Package">
+	<FrontSection title="Dynamic Package" discussionApiUrl={discussionApiUrl}>
 		<DynamicPackage
 			groupedTrails={{
 				...defaultGroupedTrails,
@@ -339,7 +389,7 @@ export const ThreeSnapTwoStandard = () => (
 ThreeSnapTwoStandard.storyName = 'With three snaps - two standard cards';
 
 export const ThreeSnapTwoStandard2ndBoosted = () => (
-	<FrontSection title="Dynamic Package">
+	<FrontSection title="Dynamic Package" discussionApiUrl={discussionApiUrl}>
 		<DynamicPackage
 			groupedTrails={{
 				...defaultGroupedTrails,
@@ -355,7 +405,11 @@ ThreeSnapTwoStandard2ndBoosted.storyName =
 	'With three snaps (2nd boosted) - two standard cards';
 
 export const SpecialReportWithoutPalette = () => (
-	<FrontSection title="Dynamic Package" showTopBorder={true}>
+	<FrontSection
+		title="Dynamic Package"
+		showTopBorder={true}
+		discussionApiUrl={discussionApiUrl}
+	>
 		<DynamicPackage
 			groupedTrails={{
 				...defaultGroupedTrails,
@@ -385,6 +439,7 @@ export const SpecialReportWithoutPalette = () => (
 						byline: 'Luke Harding',
 						snapData: {},
 						isCrossword: false,
+						discussionApiUrl,
 					},
 				],
 			}}

--- a/dotcom-rendering/src/components/DynamicSlow.stories.tsx
+++ b/dotcom-rendering/src/components/DynamicSlow.stories.tsx
@@ -1,5 +1,6 @@
 import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
 import { breakpoints } from '@guardian/source-foundations';
+import { discussionApiUrl } from '../../fixtures/manual/discussionApiUrl';
 import { trails } from '../../fixtures/manual/trails';
 import type { DCRGroupedTrails } from '../types/front';
 import { DynamicSlow } from './DynamicSlow';
@@ -43,7 +44,7 @@ export const Avatar = () => {
 		};
 	});
 	return (
-		<FrontSection title="Dynamic Slow">
+		<FrontSection title="Dynamic Slow" discussionApiUrl={discussionApiUrl}>
 			<DynamicSlow
 				groupedTrails={{
 					...defaultGroupedTrails,
@@ -68,6 +69,7 @@ export const OneHugeTwoBigsFourStandards = () => (
 	<FrontSection
 		title="Dynamic Slow"
 		description={`first slice: oneHuge</br>second slice: twoBigs`}
+		discussionApiUrl={discussionApiUrl}
 	>
 		<DynamicSlow
 			groupedTrails={{
@@ -87,6 +89,7 @@ export const OneVeryBigTwoBigsFourStandards = () => (
 	<FrontSection
 		title="Dynamic Slow"
 		description={`first slice: oneVeryBig</br>second slice: twoBigs`}
+		discussionApiUrl={discussionApiUrl}
 	>
 		<DynamicSlow
 			groupedTrails={{
@@ -107,6 +110,7 @@ export const TwoVeryBigsTwoBigsFourStandards = () => (
 	<FrontSection
 		title="Dynamic Slow"
 		description={`first slice: twoVeryBigs</br>second slice: twoBigs`}
+		discussionApiUrl={discussionApiUrl}
 	>
 		<DynamicSlow
 			groupedTrails={{
@@ -127,6 +131,7 @@ export const TwoVeryBigs1stBoostedTwoBigsFourStandards = () => (
 	<FrontSection
 		title="Dynamic Slow"
 		description={`first slice: twoVeryBigsFirstBoosted</br>second slice: twoBigs`}
+		discussionApiUrl={discussionApiUrl}
 	>
 		<DynamicSlow
 			groupedTrails={{
@@ -147,6 +152,7 @@ export const TwoVeryBigs2ndBoostedTwoBigsFourStandards = () => (
 	<FrontSection
 		title="Dynamic Slow"
 		description={`first slice: twoVeryBigsSecondBoosted</br>second slice: twoBigs`}
+		discussionApiUrl={discussionApiUrl}
 	>
 		<DynamicSlow
 			groupedTrails={{
@@ -168,6 +174,7 @@ export const TwoVeryBigs8Standards = () => (
 	<FrontSection
 		title="Dynamic Slow"
 		description={`first slice: twoVeryBigs</br>second slice: noBigs`}
+		discussionApiUrl={discussionApiUrl}
 	>
 		<DynamicSlow
 			groupedTrails={{
@@ -186,6 +193,7 @@ export const TwoVeryBigsOneBig4Standards = () => (
 	<FrontSection
 		title="Dynamic Slow"
 		description={`first slice: twoVeryBigs</br>second slice: oneBig`}
+		discussionApiUrl={discussionApiUrl}
 	>
 		<DynamicSlow
 			groupedTrails={{
@@ -206,6 +214,7 @@ export const TwoVeryBigsTwoBigs4Standards = () => (
 	<FrontSection
 		title="Dynamic Slow"
 		description={`first slice: twoVeryBigs</br>second slice: twoBigs`}
+		discussionApiUrl={discussionApiUrl}
 	>
 		<DynamicSlow
 			groupedTrails={{
@@ -229,6 +238,7 @@ export const TwoVeryBigsFiveStandards = () => (
 	<FrontSection
 		title="Dynamic Slow"
 		description={`first slice: twoVeryBigs</br>second slice: noBigs`}
+		discussionApiUrl={discussionApiUrl}
 	>
 		<DynamicSlow
 			groupedTrails={{
@@ -248,6 +258,7 @@ export const ThreeVeryBigsFiveStandards = () => (
 	<FrontSection
 		title="Dynamic Slow"
 		description={`first slice: twoVeryBigs</br>second slice: oneBig`}
+		discussionApiUrl={discussionApiUrl}
 	>
 		<DynamicSlow
 			groupedTrails={{
@@ -267,6 +278,7 @@ export const TwoVeryBigsOneBig = () => (
 	<FrontSection
 		title="Dynamic Slow"
 		description={`first slice: twoVeryBigs</br>second slice: oneBig`}
+		discussionApiUrl={discussionApiUrl}
 	>
 		<DynamicSlow
 			groupedTrails={{
@@ -286,6 +298,7 @@ export const TwoBigsThreeStandards = () => (
 	<FrontSection
 		title="Dynamic Slow"
 		description={`first slice: undefined</br>second slice: twoBigs`}
+		discussionApiUrl={discussionApiUrl}
 	>
 		<DynamicSlow
 			groupedTrails={{
@@ -305,6 +318,7 @@ export const OneVeryBigTwoBigsOneStandard = () => (
 	<FrontSection
 		title="Dynamic Slow"
 		description={`first slice: twoVeryBigs</br>second slice: twoBigs`}
+		discussionApiUrl={discussionApiUrl}
 	>
 		<DynamicSlow
 			groupedTrails={{

--- a/dotcom-rendering/src/components/DynamicSlowMPU.stories.tsx
+++ b/dotcom-rendering/src/components/DynamicSlowMPU.stories.tsx
@@ -1,4 +1,5 @@
 import { breakpoints } from '@guardian/source-foundations';
+import { discussionApiUrl } from '../../fixtures/manual/discussionApiUrl';
 import { trails } from '../../fixtures/manual/trails';
 import { DynamicSlowMPU } from './DynamicSlowMPU';
 import { FrontSection } from './FrontSection';
@@ -21,7 +22,7 @@ const bigs = trails.slice(0, 3);
 const standards = trails.slice(3);
 
 export const NoBigs = () => (
-	<FrontSection title="Dynamic Slow MPU">
+	<FrontSection title="Dynamic Slow MPU" discussionApiUrl={discussionApiUrl}>
 		<DynamicSlowMPU
 			groupedTrails={{
 				snap: [],
@@ -40,7 +41,7 @@ export const NoBigs = () => (
 NoBigs.storyName = 'with no big cards, only standard';
 
 export const OneBig = () => (
-	<FrontSection title="Dynamic Slow MPU">
+	<FrontSection title="Dynamic Slow MPU" discussionApiUrl={discussionApiUrl}>
 		<DynamicSlowMPU
 			groupedTrails={{
 				snap: [],
@@ -59,7 +60,7 @@ export const OneBig = () => (
 OneBig.storyName = 'with just one big';
 
 export const TwoBigs = () => (
-	<FrontSection title="Dynamic Slow MPU">
+	<FrontSection title="Dynamic Slow MPU" discussionApiUrl={discussionApiUrl}>
 		<DynamicSlowMPU
 			groupedTrails={{
 				snap: [],
@@ -78,7 +79,7 @@ export const TwoBigs = () => (
 TwoBigs.storyName = 'with two bigs';
 
 export const FirstBigBoosted = () => (
-	<FrontSection title="Dynamic Slow MPU">
+	<FrontSection title="Dynamic Slow MPU" discussionApiUrl={discussionApiUrl}>
 		<DynamicSlowMPU
 			groupedTrails={{
 				snap: [],
@@ -101,7 +102,7 @@ export const FirstBigBoosted = () => (
 FirstBigBoosted.storyName = 'with the first of two bigs boosted';
 
 export const SecondBigBoosted = () => (
-	<FrontSection title="Dynamic Slow MPU">
+	<FrontSection title="Dynamic Slow MPU" discussionApiUrl={discussionApiUrl}>
 		<DynamicSlowMPU
 			groupedTrails={{
 				snap: [],
@@ -124,7 +125,7 @@ export const SecondBigBoosted = () => (
 SecondBigBoosted.storyName = 'with the second of two bigs boosted';
 
 export const ThreeBigs = () => (
-	<FrontSection title="Dynamic Slow MPU">
+	<FrontSection title="Dynamic Slow MPU" discussionApiUrl={discussionApiUrl}>
 		<DynamicSlowMPU
 			groupedTrails={{
 				snap: [],
@@ -143,7 +144,7 @@ export const ThreeBigs = () => (
 ThreeBigs.storyName = 'with three bigs';
 
 export const AllBigs = () => (
-	<FrontSection title="Dynamic Slow MPU">
+	<FrontSection title="Dynamic Slow MPU" discussionApiUrl={discussionApiUrl}>
 		<DynamicSlowMPU
 			groupedTrails={{
 				snap: [],
@@ -162,7 +163,7 @@ export const AllBigs = () => (
 AllBigs.storyName = 'with lots of bigs and no standards';
 
 export const AllBigsNoMPU = () => (
-	<FrontSection title="DynamicSlowMPU">
+	<FrontSection title="DynamicSlowMPU" discussionApiUrl={discussionApiUrl}>
 		<DynamicSlowMPU
 			groupedTrails={{
 				snap: [],
@@ -181,7 +182,7 @@ export const AllBigsNoMPU = () => (
 AllBigsNoMPU.storyName = 'Ad-free with lots of bigs';
 
 export const TwoBigsThreeStandardsNoMPU = () => (
-	<FrontSection title="DynamicSlowMPU">
+	<FrontSection title="DynamicSlowMPU" discussionApiUrl={discussionApiUrl}>
 		<DynamicSlowMPU
 			groupedTrails={{
 				snap: [],
@@ -200,7 +201,7 @@ export const TwoBigsThreeStandardsNoMPU = () => (
 TwoBigsThreeStandardsNoMPU.storyName = 'Ad-free with 2 bigs & 3 standards';
 
 export const NoBigsTwoStandardsNoMPU = () => (
-	<FrontSection title="DynamicSlowMPU">
+	<FrontSection title="DynamicSlowMPU" discussionApiUrl={discussionApiUrl}>
 		<DynamicSlowMPU
 			groupedTrails={{
 				snap: [],
@@ -219,7 +220,7 @@ export const NoBigsTwoStandardsNoMPU = () => (
 NoBigsTwoStandardsNoMPU.storyName = 'Ad-free with 0 bigs & 2 standards';
 
 export const NoBigsFiveStandardsNoMPU = () => (
-	<FrontSection title="DynamicSlowMPU">
+	<FrontSection title="DynamicSlowMPU" discussionApiUrl={discussionApiUrl}>
 		<DynamicSlowMPU
 			groupedTrails={{
 				snap: [],

--- a/dotcom-rendering/src/components/FetchOnwardsData.importable.tsx
+++ b/dotcom-rendering/src/components/FetchOnwardsData.importable.tsx
@@ -14,6 +14,7 @@ type Props = {
 	limit: number; // Limit the number of items shown (the api often returns more)
 	onwardsSource: OnwardsSource;
 	format: ArticleFormat;
+	discussionApiUrl: string;
 };
 
 type OnwardsResponse = {
@@ -32,6 +33,7 @@ export const FetchOnwardsData = ({
 	limit,
 	onwardsSource,
 	format,
+	discussionApiUrl,
 }: Props) => {
 	const { data, loading, error } = useApi<OnwardsResponse>(url);
 
@@ -87,6 +89,7 @@ export const FetchOnwardsData = ({
 								? 'wide'
 								: 'compact'
 						}
+						discussionApiUrl={discussionApiUrl}
 					/>
 				</div>
 			</div>

--- a/dotcom-rendering/src/components/FixedLargeSlowXIV.stories.tsx
+++ b/dotcom-rendering/src/components/FixedLargeSlowXIV.stories.tsx
@@ -1,4 +1,5 @@
 import { breakpoints } from '@guardian/source-foundations';
+import { discussionApiUrl } from '../../fixtures/manual/discussionApiUrl';
 import { trails } from '../../fixtures/manual/trails';
 import { FixedLargeSlowXIV } from './FixedLargeSlowXIV';
 import { FrontSection } from './FrontSection';
@@ -18,7 +19,10 @@ export default {
 };
 
 export const Default = () => (
-	<FrontSection title="Fixed Large Slow XIV">
+	<FrontSection
+		title="Fixed Large Slow XIV"
+		discussionApiUrl={discussionApiUrl}
+	>
 		<FixedLargeSlowXIV
 			trails={trails}
 			showAge={true}

--- a/dotcom-rendering/src/components/FixedMediumFastXI.stories.tsx
+++ b/dotcom-rendering/src/components/FixedMediumFastXI.stories.tsx
@@ -1,4 +1,5 @@
 import { breakpoints } from '@guardian/source-foundations';
+import { discussionApiUrl } from '../../fixtures/manual/discussionApiUrl';
 import { trails } from '../../fixtures/manual/trails';
 import { FixedMediumFastXI } from './FixedMediumFastXI';
 import { FrontSection } from './FrontSection';
@@ -18,77 +19,110 @@ export default {
 };
 
 export const OneTrail = () => (
-	<FrontSection title="Fixed Medium Fast XI">
+	<FrontSection
+		title="Fixed Medium Fast XI"
+		discussionApiUrl={discussionApiUrl}
+	>
 		<FixedMediumFastXI trails={trails.slice(0, 1)} imageLoading="eager" />
 	</FrontSection>
 );
 OneTrail.storyName = 'with one trail';
 
 export const TwoTrails = () => (
-	<FrontSection title="Fixed Medium Fast XI">
+	<FrontSection
+		title="Fixed Medium Fast XI"
+		discussionApiUrl={discussionApiUrl}
+	>
 		<FixedMediumFastXI trails={trails.slice(0, 2)} imageLoading="eager" />
 	</FrontSection>
 );
 TwoTrails.storyName = 'with two trails';
 
 export const ThreeTrails = () => (
-	<FrontSection title="Fixed Medium Fast XI">
+	<FrontSection
+		title="Fixed Medium Fast XI"
+		discussionApiUrl={discussionApiUrl}
+	>
 		<FixedMediumFastXI trails={trails.slice(0, 3)} imageLoading="eager" />
 	</FrontSection>
 );
 ThreeTrails.storyName = 'with three trails';
 
 export const FourTrails = () => (
-	<FrontSection title="Fixed Medium Fast XI">
+	<FrontSection
+		title="Fixed Medium Fast XI"
+		discussionApiUrl={discussionApiUrl}
+	>
 		<FixedMediumFastXI trails={trails.slice(0, 4)} imageLoading="eager" />
 	</FrontSection>
 );
 FourTrails.storyName = 'with four trails';
 
 export const FiveTrails = () => (
-	<FrontSection title="Fixed Medium Fast XI">
+	<FrontSection
+		title="Fixed Medium Fast XI"
+		discussionApiUrl={discussionApiUrl}
+	>
 		<FixedMediumFastXI trails={trails.slice(0, 5)} imageLoading="eager" />
 	</FrontSection>
 );
 FiveTrails.storyName = 'with five trails';
 
 export const SixTrails = () => (
-	<FrontSection title="Fixed Medium Fast XI">
+	<FrontSection
+		title="Fixed Medium Fast XI"
+		discussionApiUrl={discussionApiUrl}
+	>
 		<FixedMediumFastXI trails={trails.slice(0, 6)} imageLoading="eager" />
 	</FrontSection>
 );
 SixTrails.storyName = 'with six trails';
 
 export const SevenTrails = () => (
-	<FrontSection title="Fixed Medium Fast XI">
+	<FrontSection
+		title="Fixed Medium Fast XI"
+		discussionApiUrl={discussionApiUrl}
+	>
 		<FixedMediumFastXI trails={trails.slice(0, 7)} imageLoading="eager" />
 	</FrontSection>
 );
 SevenTrails.storyName = 'with seven trails';
 
 export const EightTrails = () => (
-	<FrontSection title="Fixed Medium Fast XI">
+	<FrontSection
+		title="Fixed Medium Fast XI"
+		discussionApiUrl={discussionApiUrl}
+	>
 		<FixedMediumFastXI trails={trails.slice(0, 8)} imageLoading="eager" />
 	</FrontSection>
 );
 EightTrails.storyName = 'with eight trails';
 
 export const NineTrails = () => (
-	<FrontSection title="Fixed Medium Fast XI">
+	<FrontSection
+		title="Fixed Medium Fast XI"
+		discussionApiUrl={discussionApiUrl}
+	>
 		<FixedMediumFastXI trails={trails.slice(0, 9)} imageLoading="eager" />
 	</FrontSection>
 );
 NineTrails.storyName = 'with nine trails';
 
 export const TenTrails = () => (
-	<FrontSection title="Fixed Medium Fast XI">
+	<FrontSection
+		title="Fixed Medium Fast XI"
+		discussionApiUrl={discussionApiUrl}
+	>
 		<FixedMediumFastXI trails={trails.slice(0, 10)} imageLoading="eager" />
 	</FrontSection>
 );
 TenTrails.storyName = 'with ten trails';
 
 export const ElevenTrails = () => (
-	<FrontSection title="Fixed Medium Fast XI">
+	<FrontSection
+		title="Fixed Medium Fast XI"
+		discussionApiUrl={discussionApiUrl}
+	>
 		<FixedMediumFastXI trails={trails.slice(0, 11)} imageLoading="eager" />
 	</FrontSection>
 );

--- a/dotcom-rendering/src/components/FixedMediumFastXII.stories.tsx
+++ b/dotcom-rendering/src/components/FixedMediumFastXII.stories.tsx
@@ -1,4 +1,5 @@
 import { breakpoints } from '@guardian/source-foundations';
+import { discussionApiUrl } from '../../fixtures/manual/discussionApiUrl';
 import { trails } from '../../fixtures/manual/trails';
 import { FixedMediumFastXII } from './FixedMediumFastXII';
 import { FrontSection } from './FrontSection';
@@ -18,7 +19,10 @@ export default {
 };
 
 export const Default = () => (
-	<FrontSection title="Fixed Medium Fast XII">
+	<FrontSection
+		title="Fixed Medium Fast XII"
+		discussionApiUrl={discussionApiUrl}
+	>
 		<FixedMediumFastXII
 			trails={trails}
 			showAge={true}

--- a/dotcom-rendering/src/components/FixedMediumSlowVI.stories.tsx
+++ b/dotcom-rendering/src/components/FixedMediumSlowVI.stories.tsx
@@ -1,4 +1,5 @@
 import { breakpoints } from '@guardian/source-foundations';
+import { discussionApiUrl } from '../../fixtures/manual/discussionApiUrl';
 import { trails } from '../../fixtures/manual/trails';
 import { FixedMediumSlowVI } from './FixedMediumSlowVI';
 import { FrontSection } from './FrontSection';
@@ -18,7 +19,10 @@ export default {
 };
 
 export const Default = () => (
-	<FrontSection title="Fixed Medium Slow VI">
+	<FrontSection
+		title="Fixed Medium Slow VI"
+		discussionApiUrl={discussionApiUrl}
+	>
 		<FixedMediumSlowVI
 			trails={trails}
 			showAge={true}

--- a/dotcom-rendering/src/components/FixedMediumSlowVII.stories.tsx
+++ b/dotcom-rendering/src/components/FixedMediumSlowVII.stories.tsx
@@ -1,4 +1,5 @@
 import { breakpoints } from '@guardian/source-foundations';
+import { discussionApiUrl } from '../../fixtures/manual/discussionApiUrl';
 import { trails } from '../../fixtures/manual/trails';
 import { FixedMediumSlowVII } from './FixedMediumSlowVII';
 import { FrontSection } from './FrontSection';
@@ -18,7 +19,11 @@ export default {
 };
 
 export const Default = () => (
-	<FrontSection title="Fixed Medium Slow VII" showTopBorder={true}>
+	<FrontSection
+		title="Fixed Medium Slow VII"
+		showTopBorder={true}
+		discussionApiUrl={discussionApiUrl}
+	>
 		<FixedMediumSlowVII
 			trails={trails}
 			showAge={true}

--- a/dotcom-rendering/src/components/FixedMediumSlowXIIMPU.stories.tsx
+++ b/dotcom-rendering/src/components/FixedMediumSlowXIIMPU.stories.tsx
@@ -1,4 +1,5 @@
 import { breakpoints } from '@guardian/source-foundations';
+import { discussionApiUrl } from '../../fixtures/manual/discussionApiUrl';
 import { trails } from '../../fixtures/manual/trails';
 import { FixedMediumSlowXIIMPU } from './FixedMediumSlowXIIMPU';
 import { FrontSection } from './FrontSection';
@@ -18,7 +19,10 @@ export default {
 };
 
 export const OneTrail = () => (
-	<FrontSection title="Fixed Medium Slow XII MPU">
+	<FrontSection
+		title="Fixed Medium Slow XII MPU"
+		discussionApiUrl={discussionApiUrl}
+	>
 		<FixedMediumSlowXIIMPU
 			trails={trails.slice(0, 1)}
 			showAge={true}
@@ -31,7 +35,10 @@ export const OneTrail = () => (
 OneTrail.storyName = 'with one trail';
 
 export const TwoTrails = () => (
-	<FrontSection title="Fixed Medium Slow XII MPU">
+	<FrontSection
+		title="Fixed Medium Slow XII MPU"
+		discussionApiUrl={discussionApiUrl}
+	>
 		<FixedMediumSlowXIIMPU
 			trails={trails.slice(0, 2)}
 			showAge={true}
@@ -44,7 +51,10 @@ export const TwoTrails = () => (
 TwoTrails.storyName = 'with two trails';
 
 export const ThreeTrails = () => (
-	<FrontSection title="Fixed Medium Slow XII MPU">
+	<FrontSection
+		title="Fixed Medium Slow XII MPU"
+		discussionApiUrl={discussionApiUrl}
+	>
 		<FixedMediumSlowXIIMPU
 			trails={trails.slice(0, 3)}
 			showAge={true}
@@ -57,7 +67,10 @@ export const ThreeTrails = () => (
 ThreeTrails.storyName = 'with three trails';
 
 export const FourTrails = () => (
-	<FrontSection title="Fixed Medium Slow XII MPU">
+	<FrontSection
+		title="Fixed Medium Slow XII MPU"
+		discussionApiUrl={discussionApiUrl}
+	>
 		<FixedMediumSlowXIIMPU
 			trails={trails.slice(0, 4)}
 			showAge={true}
@@ -70,7 +83,10 @@ export const FourTrails = () => (
 FourTrails.storyName = 'with four trails';
 
 export const FiveTrails = () => (
-	<FrontSection title="Fixed Medium Slow XII MPU">
+	<FrontSection
+		title="Fixed Medium Slow XII MPU"
+		discussionApiUrl={discussionApiUrl}
+	>
 		<FixedMediumSlowXIIMPU
 			trails={trails.slice(0, 5)}
 			showAge={true}
@@ -83,7 +99,10 @@ export const FiveTrails = () => (
 FiveTrails.storyName = 'with five trails';
 
 export const SixTrails = () => (
-	<FrontSection title="Fixed Medium Slow XII MPU">
+	<FrontSection
+		title="Fixed Medium Slow XII MPU"
+		discussionApiUrl={discussionApiUrl}
+	>
 		<FixedMediumSlowXIIMPU
 			trails={trails.slice(0, 6)}
 			showAge={true}
@@ -96,7 +115,10 @@ export const SixTrails = () => (
 SixTrails.storyName = 'with six trails';
 
 export const SevenTrails = () => (
-	<FrontSection title="Fixed Medium Slow XII MPU">
+	<FrontSection
+		title="Fixed Medium Slow XII MPU"
+		discussionApiUrl={discussionApiUrl}
+	>
 		<FixedMediumSlowXIIMPU
 			trails={trails.slice(0, 7)}
 			showAge={true}
@@ -109,7 +131,10 @@ export const SevenTrails = () => (
 SevenTrails.storyName = 'with seven trails';
 
 export const EightTrails = () => (
-	<FrontSection title="Fixed Medium Slow XII MPU">
+	<FrontSection
+		title="Fixed Medium Slow XII MPU"
+		discussionApiUrl={discussionApiUrl}
+	>
 		<FixedMediumSlowXIIMPU
 			trails={trails.slice(0, 8)}
 			showAge={true}
@@ -122,7 +147,10 @@ export const EightTrails = () => (
 EightTrails.storyName = 'with eight trails';
 
 export const NineTrails = () => (
-	<FrontSection title="Fixed Medium Slow XII MPU">
+	<FrontSection
+		title="Fixed Medium Slow XII MPU"
+		discussionApiUrl={discussionApiUrl}
+	>
 		<FixedMediumSlowXIIMPU
 			trails={trails.slice(0, 9)}
 			showAge={true}
@@ -135,7 +163,10 @@ export const NineTrails = () => (
 NineTrails.storyName = 'with nine trails';
 
 export const EightTrailsNoAds = () => (
-	<FrontSection title="Fixed Medium Slow XII MPU">
+	<FrontSection
+		title="Fixed Medium Slow XII MPU"
+		discussionApiUrl={discussionApiUrl}
+	>
 		<FixedMediumSlowXIIMPU
 			trails={trails.slice(0, 8)}
 			showAge={true}

--- a/dotcom-rendering/src/components/FixedSmallFastVIII.stories.tsx
+++ b/dotcom-rendering/src/components/FixedSmallFastVIII.stories.tsx
@@ -1,4 +1,5 @@
 import { breakpoints } from '@guardian/source-foundations';
+import { discussionApiUrl } from '../../fixtures/manual/discussionApiUrl';
 import { trails } from '../../fixtures/manual/trails';
 import { FixedSmallFastVIII } from './FixedSmallFastVIII';
 import { FrontSection } from './FrontSection';
@@ -18,7 +19,11 @@ export default {
 };
 
 export const Default = () => (
-	<FrontSection title="Fixed Small Fast VIII" showTopBorder={true}>
+	<FrontSection
+		title="Fixed Small Fast VIII"
+		showTopBorder={true}
+		discussionApiUrl={discussionApiUrl}
+	>
 		<FixedSmallFastVIII
 			trails={trails}
 			showAge={true}

--- a/dotcom-rendering/src/components/FixedSmallSlowI.stories.tsx
+++ b/dotcom-rendering/src/components/FixedSmallSlowI.stories.tsx
@@ -1,4 +1,5 @@
 import { breakpoints } from '@guardian/source-foundations';
+import { discussionApiUrl } from '../../fixtures/manual/discussionApiUrl';
 import { trails } from '../../fixtures/manual/trails';
 import { FixedSmallSlowI } from './FixedSmallSlowI';
 import { FrontSection } from './FrontSection';
@@ -18,7 +19,10 @@ export default {
 };
 
 export const Default = () => (
-	<FrontSection title="Fixed Small Slow I">
+	<FrontSection
+		title="Fixed Small Slow I"
+		discussionApiUrl={discussionApiUrl}
+	>
 		<FixedSmallSlowI trails={trails} showAge={true} imageLoading="eager" />
 	</FrontSection>
 );

--- a/dotcom-rendering/src/components/FixedSmallSlowIII.stories.tsx
+++ b/dotcom-rendering/src/components/FixedSmallSlowIII.stories.tsx
@@ -1,4 +1,5 @@
 import { breakpoints } from '@guardian/source-foundations';
+import { discussionApiUrl } from '../../fixtures/manual/discussionApiUrl';
 import { trails } from '../../fixtures/manual/trails';
 import { FixedSmallSlowIII } from './FixedSmallSlowIII';
 import { FrontSection } from './FrontSection';
@@ -18,7 +19,10 @@ export default {
 };
 
 export const Default = () => (
-	<FrontSection title="Fixed Small Slow III">
+	<FrontSection
+		title="Fixed Small Slow III"
+		discussionApiUrl={discussionApiUrl}
+	>
 		<FixedSmallSlowIII
 			trails={trails}
 			showAge={true}

--- a/dotcom-rendering/src/components/FixedSmallSlowIV.stories.tsx
+++ b/dotcom-rendering/src/components/FixedSmallSlowIV.stories.tsx
@@ -1,4 +1,5 @@
 import { breakpoints } from '@guardian/source-foundations';
+import { discussionApiUrl } from '../../fixtures/manual/discussionApiUrl';
 import { trails } from '../../fixtures/manual/trails';
 import { FixedSmallSlowIV } from './FixedSmallSlowIV';
 import { FrontSection } from './FrontSection';
@@ -18,7 +19,10 @@ export default {
 };
 
 export const Default = () => (
-	<FrontSection title="Fixed Small Slow IV">
+	<FrontSection
+		title="Fixed Small Slow IV"
+		discussionApiUrl={discussionApiUrl}
+	>
 		<FixedSmallSlowIV trails={trails} showAge={true} imageLoading="eager" />
 	</FrontSection>
 );

--- a/dotcom-rendering/src/components/FixedSmallSlowVHalf.stories.tsx
+++ b/dotcom-rendering/src/components/FixedSmallSlowVHalf.stories.tsx
@@ -1,4 +1,5 @@
 import { breakpoints } from '@guardian/source-foundations';
+import { discussionApiUrl } from '../../fixtures/manual/discussionApiUrl';
 import { trails } from '../../fixtures/manual/trails';
 import { FixedSmallSlowVHalf } from './FixedSmallSlowVHalf';
 import { FrontSection } from './FrontSection';
@@ -18,7 +19,10 @@ export default {
 };
 
 export const Default = () => (
-	<FrontSection title="Fixed Small Slow V Half">
+	<FrontSection
+		title="Fixed Small Slow V Half"
+		discussionApiUrl={discussionApiUrl}
+	>
 		<FixedSmallSlowVHalf
 			trails={trails}
 			showAge={true}

--- a/dotcom-rendering/src/components/FixedSmallSlowVMPU.stories.tsx
+++ b/dotcom-rendering/src/components/FixedSmallSlowVMPU.stories.tsx
@@ -1,4 +1,5 @@
 import { breakpoints } from '@guardian/source-foundations';
+import { discussionApiUrl } from '../../fixtures/manual/discussionApiUrl';
 import { trails } from '../../fixtures/manual/trails';
 import { FixedSmallSlowVMPU } from './FixedSmallSlowVMPU';
 import { FrontSection } from './FrontSection';
@@ -18,7 +19,10 @@ export default {
 };
 
 export const FourCards = () => (
-	<FrontSection title="Fixed Small Slow V MPU">
+	<FrontSection
+		title="Fixed Small Slow V MPU"
+		discussionApiUrl={discussionApiUrl}
+	>
 		<FixedSmallSlowVMPU
 			trails={trails.slice(0, 4)}
 			showAge={true}
@@ -32,7 +36,10 @@ export const FourCards = () => (
 FourCards.storyName = 'With 4 cards';
 
 export const ThreeCards = () => (
-	<FrontSection title="Fixed Small Slow V MPU">
+	<FrontSection
+		title="Fixed Small Slow V MPU"
+		discussionApiUrl={discussionApiUrl}
+	>
 		<FixedSmallSlowVMPU
 			trails={trails.slice(0, 3)}
 			showAge={true}
@@ -46,7 +53,10 @@ export const ThreeCards = () => (
 ThreeCards.storyName = 'With 3 cards';
 
 export const TwoCards = () => (
-	<FrontSection title="Fixed Small Slow V MPU">
+	<FrontSection
+		title="Fixed Small Slow V MPU"
+		discussionApiUrl={discussionApiUrl}
+	>
 		<FixedSmallSlowVMPU
 			trails={trails.slice(0, 2)}
 			showAge={true}
@@ -60,7 +70,10 @@ export const TwoCards = () => (
 TwoCards.storyName = 'With 2 cards';
 
 export const OneCard = () => (
-	<FrontSection title="Fixed Small Slow V MPU">
+	<FrontSection
+		title="Fixed Small Slow V MPU"
+		discussionApiUrl={discussionApiUrl}
+	>
 		<FixedSmallSlowVMPU
 			trails={trails.slice(0, 1)}
 			showAge={true}
@@ -74,7 +87,10 @@ export const OneCard = () => (
 OneCard.storyName = 'With 1 card';
 
 export const AdfreeFixedSmallSlowVMPU = () => (
-	<FrontSection title="Fixed Small Slow V MPU">
+	<FrontSection
+		title="Fixed Small Slow V MPU"
+		discussionApiUrl={discussionApiUrl}
+	>
 		<FixedSmallSlowVMPU
 			trails={trails.slice(0, 4)}
 			showAge={true}

--- a/dotcom-rendering/src/components/FixedSmallSlowVThird.stories.tsx
+++ b/dotcom-rendering/src/components/FixedSmallSlowVThird.stories.tsx
@@ -1,4 +1,5 @@
 import { breakpoints } from '@guardian/source-foundations';
+import { discussionApiUrl } from '../../fixtures/manual/discussionApiUrl';
 import { trails } from '../../fixtures/manual/trails';
 import { FixedSmallSlowVThird } from './FixedSmallSlowVThird';
 import { FrontSection } from './FrontSection';
@@ -18,7 +19,10 @@ export default {
 };
 
 export const Default = () => (
-	<FrontSection title="Fixed Small Slow V Third">
+	<FrontSection
+		title="Fixed Small Slow V Third"
+		discussionApiUrl={discussionApiUrl}
+	>
 		<FixedSmallSlowVThird
 			trails={trails}
 			showAge={true}

--- a/dotcom-rendering/src/components/FrontCard.tsx
+++ b/dotcom-rendering/src/components/FrontCard.tsx
@@ -44,6 +44,7 @@ export const FrontCard = (props: Props) => {
 		starRating: trail.starRating,
 		dataLinkName: trail.dataLinkName,
 		snapData: trail.snapData,
+		discussionApiUrl: trail.discussionApiUrl,
 		discussionId: trail.discussionId,
 		avatarUrl: trail.avatarUrl,
 		mainMedia: trail.mainMedia,

--- a/dotcom-rendering/src/components/FrontSection.stories.tsx
+++ b/dotcom-rendering/src/components/FrontSection.stories.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import { breakpoints } from '@guardian/source-foundations';
+import { discussionApiUrl } from '../../fixtures/manual/discussionApiUrl';
 import { LI } from './Card/components/LI';
 import { FrontSection } from './FrontSection';
 
@@ -73,7 +74,11 @@ const LeftColPlaceholder = ({
 
 export const ContainerStory = () => {
 	return (
-		<FrontSection title="Default Container" showTopBorder={false}>
+		<FrontSection
+			title="Default Container"
+			showTopBorder={false}
+			discussionApiUrl={discussionApiUrl}
+		>
 			<Placeholder />
 		</FrontSection>
 	);
@@ -82,7 +87,7 @@ ContainerStory.storyName = 'default container';
 
 export const NoTitleStory = () => {
 	return (
-		<FrontSection showTopBorder={false}>
+		<FrontSection showTopBorder={false} discussionApiUrl={discussionApiUrl}>
 			<Placeholder />
 		</FrontSection>
 	);
@@ -91,7 +96,7 @@ NoTitleStory.storyName = 'with no title';
 
 export const TopBorderStory = () => {
 	return (
-		<FrontSection title="Borders">
+		<FrontSection title="Borders" discussionApiUrl={discussionApiUrl}>
 			<Placeholder />
 		</FrontSection>
 	);
@@ -105,6 +110,7 @@ export const LeftContentStory = () => {
 			leftContent={
 				<LeftColPlaceholder text="LeftCol" heightInPixels={100} />
 			}
+			discussionApiUrl={discussionApiUrl}
 		>
 			<Placeholder />
 		</FrontSection>
@@ -119,6 +125,7 @@ export const LeftContentOpinionStory = () => {
 			leftContent={
 				<LeftColPlaceholder text="LeftCol" heightInPixels={100} />
 			}
+			discussionApiUrl={discussionApiUrl}
 		>
 			<Placeholder />
 		</FrontSection>
@@ -134,6 +141,7 @@ export const ToggleableStory = () => {
 			toggleable={true}
 			sectionId="section-id"
 			showTopBorder={false}
+			discussionApiUrl={discussionApiUrl}
 		>
 			<Placeholder />
 		</FrontSection>
@@ -144,26 +152,42 @@ ToggleableStory.storyName = 'toggleable container';
 export const MultipleStory = () => {
 	return (
 		<>
-			<FrontSection title="Page Title" showTopBorder={false} />
-			<FrontSection title="Headlines">
+			<FrontSection
+				title="Page Title"
+				showTopBorder={false}
+				discussionApiUrl={discussionApiUrl}
+			/>
+			<FrontSection title="Headlines" discussionApiUrl={discussionApiUrl}>
 				<Placeholder />
 			</FrontSection>
-			<FrontSection title="Useful links" />
+			<FrontSection
+				title="Useful links"
+				discussionApiUrl={discussionApiUrl}
+			/>
 			<FrontSection
 				title="Around the World - I'm a link"
 				url="https://www.theguardian.com/world"
+				discussionApiUrl={discussionApiUrl}
 			>
 				<Placeholder />
 			</FrontSection>
-			<FrontSection showTopBorder={false}>
+			<FrontSection
+				showTopBorder={false}
+				discussionApiUrl={discussionApiUrl}
+			>
 				<h2>Insert call to action here</h2>
 			</FrontSection>
-			<FrontSection title="Videos" showTopBorder={false}>
+			<FrontSection
+				title="Videos"
+				showTopBorder={false}
+				discussionApiUrl={discussionApiUrl}
+			>
 				<Placeholder />
 			</FrontSection>
 			<FrontSection
 				title="Coronavirus"
 				description="A collection of stories about Coronavirus"
+				discussionApiUrl={discussionApiUrl}
 			>
 				<Placeholder />
 			</FrontSection>
@@ -210,6 +234,7 @@ export const TreatsStory = () => {
 			showTopBorder={false}
 			showDateHeader={true}
 			editionId="UK"
+			discussionApiUrl={discussionApiUrl}
 		>
 			<Placeholder />
 		</FrontSection>
@@ -232,6 +257,7 @@ export const MultipleOnAPaidFront = () => {
 						'https://static.theguardian.com/commercial/sponsor/28/Oct/2020/daa941da-14fd-46cc-85cb-731ce59050ee-Grounded_badging-280x180.png',
 					href: '/',
 				}}
+				discussionApiUrl={discussionApiUrl}
 			>
 				<Placeholder />
 			</FrontSection>
@@ -244,6 +270,7 @@ export const MultipleOnAPaidFront = () => {
 						'https://static.theguardian.com/commercial/sponsor/28/Oct/2020/daa941da-14fd-46cc-85cb-731ce59050ee-Grounded_badging-280x180.png',
 					href: '/',
 				}}
+				discussionApiUrl={discussionApiUrl}
 			>
 				<Placeholder />
 			</FrontSection>
@@ -254,7 +281,11 @@ MultipleOnAPaidFront.storyName = 'two sections on a paid front';
 
 export const PageSkinStory = () => {
 	return (
-		<FrontSection title="Page Skin" hasPageSkin={true}>
+		<FrontSection
+			title="Page Skin"
+			hasPageSkin={true}
+			discussionApiUrl={discussionApiUrl}
+		>
 			<Placeholder text="Page skins constrain my layout to desktop" />
 		</FrontSection>
 	);

--- a/dotcom-rendering/src/components/FrontSection.tsx
+++ b/dotcom-rendering/src/components/FrontSection.tsx
@@ -94,6 +94,7 @@ type Props = {
 	 *   the page skin background showing through the containers
 	 */
 	hasPageSkin?: boolean;
+	discussionApiUrl: string;
 
 	editionBranding?: DCRFrontType['pressedPage']['frontProperties']['commercial']['editionBrandings'][number];
 };
@@ -496,6 +497,7 @@ export const FrontSection = ({
 	targetedTerritory,
 	hasPageSkin = false,
 	editionBranding,
+	discussionApiUrl,
 }: Props) => {
 	const overrides =
 		containerPalette && decideContainerOverrides(containerPalette);
@@ -711,6 +713,7 @@ export const FrontSection = ({
 							editionId={editionId}
 							containerPalette={containerPalette}
 							showAge={!hideAge.includes(title)}
+							discussionApiUrl={discussionApiUrl}
 						/>
 					</Island>
 				) : null}

--- a/dotcom-rendering/src/components/LabsSection.stories.tsx
+++ b/dotcom-rendering/src/components/LabsSection.stories.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import { breakpoints } from '@guardian/source-foundations';
+import { discussionApiUrl } from '../../fixtures/manual/discussionApiUrl';
 import { LI } from './Card/components/LI';
 import { FrontSection } from './FrontSection';
 import { LabsSection } from './LabsSection';
@@ -59,6 +60,7 @@ export const WithoutBadgeStory = () => {
 			pageId={''}
 			ophanComponentName={''}
 			ophanComponentLink={''}
+			discussionApiUrl={discussionApiUrl}
 		>
 			<Placeholder />
 		</LabsSection>
@@ -81,6 +83,7 @@ export const WithBadgeStory = () => {
 					'https://static.theguardian.com/commercial/sponsor/17/Apr/2023/6c577c8c-b60f-4041-baa3-f4852219d3ff-OS_logo_strapline_colour_rgb_280.png',
 				href: 'https://www.theguardian.com/guardian-labs',
 			}}
+			discussionApiUrl={discussionApiUrl}
 		>
 			<Placeholder />
 		</LabsSection>
@@ -91,7 +94,11 @@ WithBadgeStory.storyName = 'with badge';
 export const InContext = () => {
 	return (
 		<>
-			<FrontSection title="Default Container" showTopBorder={false}>
+			<FrontSection
+				title="Default Container"
+				showTopBorder={false}
+				discussionApiUrl={discussionApiUrl}
+			>
 				<Placeholder />
 			</FrontSection>
 			<LabsSection
@@ -107,10 +114,15 @@ export const InContext = () => {
 						'https://static.theguardian.com/commercial/sponsor/17/Apr/2023/6c577c8c-b60f-4041-baa3-f4852219d3ff-OS_logo_strapline_colour_rgb_280.png',
 					href: 'https://www.theguardian.com/guardian-labs',
 				}}
+				discussionApiUrl={discussionApiUrl}
 			>
 				<Placeholder />
 			</LabsSection>
-			<FrontSection title="Default Container" showTopBorder={true}>
+			<FrontSection
+				title="Default Container"
+				showTopBorder={true}
+				discussionApiUrl={discussionApiUrl}
+			>
 				<Placeholder />
 			</FrontSection>
 		</>

--- a/dotcom-rendering/src/components/LabsSection.tsx
+++ b/dotcom-rendering/src/components/LabsSection.tsx
@@ -60,6 +60,8 @@ type Props = {
 	children?: React.ReactNode;
 
 	hasPageSkin?: boolean;
+
+	discussionApiUrl: string;
 };
 
 const leftColumnBackground = (backgroundColour?: string) => css`
@@ -375,6 +377,7 @@ export const LabsSection = ({
 	badge,
 	children,
 	hasPageSkin = false,
+	discussionApiUrl,
 }: Props) => {
 	const overrides = decideContainerOverrides('Branded');
 
@@ -442,6 +445,7 @@ export const LabsSection = ({
 								ajaxUrl={ajaxUrl}
 								containerPalette={'Branded'}
 								showAge={true}
+								discussionApiUrl={discussionApiUrl}
 							/>
 						</Island>
 					)}

--- a/dotcom-rendering/src/components/NavList.stories.tsx
+++ b/dotcom-rendering/src/components/NavList.stories.tsx
@@ -1,4 +1,5 @@
 import { breakpoints } from '@guardian/source-foundations';
+import { discussionApiUrl } from '../../fixtures/manual/discussionApiUrl';
 import { trails } from '../../fixtures/manual/trails-nav';
 import { FrontSection } from './FrontSection';
 import { NavList } from './NavList';
@@ -18,14 +19,14 @@ export default {
 };
 
 export const Default = () => (
-	<FrontSection title="NavList">
+	<FrontSection title="NavList" discussionApiUrl={discussionApiUrl}>
 		<NavList trails={trails} showImage={false} />
 	</FrontSection>
 );
 Default.storyName = 'NavList';
 
 export const DefaultWithImages = () => (
-	<FrontSection title="Nav Media List">
+	<FrontSection title="Nav Media List" discussionApiUrl={discussionApiUrl}>
 		<NavList trails={trails} showImage={true} />
 	</FrontSection>
 );

--- a/dotcom-rendering/src/components/OnwardsUpper.importable.tsx
+++ b/dotcom-rendering/src/components/OnwardsUpper.importable.tsx
@@ -169,6 +169,7 @@ type Props = {
 	editionId: EditionId;
 	pillar: ArticleTheme;
 	shortUrlId: string;
+	discussionApiUrl: string;
 };
 
 /**
@@ -203,6 +204,7 @@ export const OnwardsUpper = ({
 	pillar,
 	editionId,
 	shortUrlId,
+	discussionApiUrl,
 }: Props) => {
 	// Related content can be a collection of articles based on
 	// two things, 1: A popular tag, or 2: A generic text match
@@ -289,6 +291,7 @@ export const OnwardsUpper = ({
 						limit={8}
 						onwardsSource={onwardsSource}
 						format={format}
+						discussionApiUrl={discussionApiUrl}
 					/>
 				</Section>
 			)}
@@ -299,6 +302,7 @@ export const OnwardsUpper = ({
 						limit={20}
 						onwardsSource="curated-content"
 						format={format}
+						discussionApiUrl={discussionApiUrl}
 					/>
 				</Section>
 			)}

--- a/dotcom-rendering/src/components/Palettes.stories.tsx
+++ b/dotcom-rendering/src/components/Palettes.stories.tsx
@@ -1,4 +1,5 @@
 import { breakpoints } from '@guardian/source-foundations';
+import { discussionApiUrl } from '../../fixtures/manual/discussionApiUrl';
 import { trails } from '../../fixtures/manual/trails';
 import { DynamicFast } from './DynamicFast';
 import { FrontSection } from './FrontSection';
@@ -29,6 +30,7 @@ export const EventPalette = () => (
 		containerPalette="EventPalette"
 		showDateHeader={true}
 		editionId={'UK'}
+		discussionApiUrl={discussionApiUrl}
 	>
 		<DynamicFast
 			groupedTrails={groupedTrails}
@@ -56,6 +58,7 @@ export const EventAltPalette = () => (
 		containerPalette="EventAltPalette"
 		showDateHeader={true}
 		editionId={'UK'}
+		discussionApiUrl={discussionApiUrl}
 	>
 		<DynamicFast
 			groupedTrails={groupedTrails}
@@ -72,6 +75,7 @@ export const SombrePalette = () => (
 		containerPalette="SombrePalette"
 		showDateHeader={true}
 		editionId={'UK'}
+		discussionApiUrl={discussionApiUrl}
 	>
 		<DynamicFast
 			groupedTrails={groupedTrails}
@@ -88,6 +92,7 @@ export const SombreAltPalette = () => (
 		containerPalette="SombreAltPalette"
 		showDateHeader={true}
 		editionId={'UK'}
+		discussionApiUrl={discussionApiUrl}
 	>
 		<DynamicFast
 			groupedTrails={groupedTrails}
@@ -104,6 +109,7 @@ export const BreakingPalette = () => (
 		containerPalette="BreakingPalette"
 		showDateHeader={true}
 		editionId={'UK'}
+		discussionApiUrl={discussionApiUrl}
 	>
 		<DynamicFast
 			groupedTrails={groupedTrails}
@@ -120,6 +126,7 @@ export const LongRunningPalette = () => (
 		containerPalette="LongRunningPalette"
 		showDateHeader={true}
 		editionId={'UK'}
+		discussionApiUrl={discussionApiUrl}
 	>
 		<DynamicFast
 			groupedTrails={groupedTrails}
@@ -136,6 +143,7 @@ export const LongRunningAltPalette = () => (
 		containerPalette="LongRunningAltPalette"
 		showDateHeader={true}
 		editionId={'UK'}
+		discussionApiUrl={discussionApiUrl}
 	>
 		<DynamicFast
 			groupedTrails={groupedTrails}
@@ -152,6 +160,7 @@ export const InvestigationPalette = () => (
 		containerPalette="InvestigationPalette"
 		showDateHeader={true}
 		editionId={'UK'}
+		discussionApiUrl={discussionApiUrl}
 	>
 		<DynamicFast
 			groupedTrails={groupedTrails}
@@ -168,6 +177,7 @@ export const SpecialReportAltPalette = () => (
 		containerPalette="SpecialReportAltPalette"
 		showDateHeader={true}
 		editionId={'UK'}
+		discussionApiUrl={discussionApiUrl}
 	>
 		<DynamicFast
 			groupedTrails={groupedTrails}
@@ -187,6 +197,7 @@ export const BrandedPalette = () => (
 		sectionId={'branded-palette'}
 		ophanComponentName={'branded-palette'}
 		ophanComponentLink={'branded-palette'}
+		discussionApiUrl={discussionApiUrl}
 	>
 		<DynamicFast
 			groupedTrails={groupedTrails}
@@ -203,6 +214,7 @@ export const MediaPalette = () => (
 		containerPalette="MediaPalette"
 		showDateHeader={true}
 		editionId={'UK'}
+		discussionApiUrl={discussionApiUrl}
 	>
 		<DynamicFast
 			groupedTrails={groupedTrails}
@@ -222,6 +234,7 @@ export const PodcastPalette = () => (
 		sectionId={'podcast-palette'}
 		ophanComponentName={'podcast-palette'}
 		ophanComponentLink={'podcast-palette'}
+		discussionApiUrl={discussionApiUrl}
 	>
 		<DynamicFast
 			groupedTrails={groupedTrails}

--- a/dotcom-rendering/src/components/ShowMore.importable.tsx
+++ b/dotcom-rendering/src/components/ShowMore.importable.tsx
@@ -71,6 +71,7 @@ type Props = {
 	ajaxUrl: string;
 	editionId?: EditionId;
 	containerPalette?: DCRContainerPalette;
+	discussionApiUrl: string;
 };
 
 export const ShowMore = ({
@@ -82,6 +83,7 @@ export const ShowMore = ({
 	ajaxUrl,
 	editionId,
 	containerPalette,
+	discussionApiUrl,
 }: Props) => {
 	const [existingCardLinks, setExistingCardLinks] = useState<string[]>([]);
 	const [isOpen, setIsOpen] = useState(false);
@@ -113,9 +115,11 @@ export const ShowMore = ({
 
 	const cards =
 		data &&
-		enhanceCards(data, { cardInTagFront: false, editionId }).filter(
-			(card) => !existingCardLinks.includes(card.url),
-		);
+		enhanceCards(data, {
+			cardInTagFront: false,
+			editionId,
+			discussionApiUrl,
+		}).filter((card) => !existingCardLinks.includes(card.url));
 
 	const showMoreContainerId = `show-more-${collectionId}`;
 

--- a/dotcom-rendering/src/components/ShowMore.stories.tsx
+++ b/dotcom-rendering/src/components/ShowMore.stories.tsx
@@ -1,5 +1,6 @@
 import { userEvent, within } from '@storybook/testing-library';
 import fetchMock from 'fetch-mock';
+import { discussionApiUrl } from '../../fixtures/manual/discussionApiUrl';
 import { trails } from '../../fixtures/manual/show-more-trails';
 import { ShowMore } from './ShowMore.importable';
 
@@ -25,7 +26,8 @@ const defaultProps = {
 	collectionId,
 	sectionId,
 	showAge: false,
-};
+	discussionApiUrl,
+} satisfies Parameters<typeof ShowMore>[0];
 
 export default {
 	component: ShowMore,

--- a/dotcom-rendering/src/components/SupportingContent.stories.tsx
+++ b/dotcom-rendering/src/components/SupportingContent.stories.tsx
@@ -34,6 +34,7 @@ const basicCardProps: CardProps = {
 	showLivePlayable: false,
 	isPlayableMediaCard: true,
 	imageLoading: 'eager',
+	discussionApiUrl: 'https://discussion.theguardian.com/discussion-api',
 };
 
 const aBasicLink = {

--- a/dotcom-rendering/src/components/TagFrontFastMpu.stories.tsx
+++ b/dotcom-rendering/src/components/TagFrontFastMpu.stories.tsx
@@ -1,4 +1,5 @@
 import { breakpoints } from '@guardian/source-foundations';
+import { discussionApiUrl } from '../../fixtures/manual/discussionApiUrl';
 import { trails } from '../../fixtures/manual/trails';
 import { FrontSection } from './FrontSection';
 import { TagFrontFastMpu } from './TagFrontFastMpu';
@@ -19,7 +20,11 @@ export default {
 
 export const WithTwoCards = () => {
 	return (
-		<FrontSection title="Fast MPU" description="With two cards">
+		<FrontSection
+			title="Fast MPU"
+			description="With two cards"
+			discussionApiUrl={discussionApiUrl}
+		>
 			<TagFrontFastMpu
 				speed="fast"
 				injected={true}
@@ -37,7 +42,11 @@ WithTwoCards.storyName = 'With two cards';
 
 export const WithFourCards = () => {
 	return (
-		<FrontSection title="Fast MPU" description="With four cards">
+		<FrontSection
+			title="Fast MPU"
+			description="With four cards"
+			discussionApiUrl={discussionApiUrl}
+		>
 			<TagFrontFastMpu
 				speed="fast"
 				injected={true}
@@ -55,7 +64,11 @@ WithFourCards.storyName = 'With four cards';
 
 export const WithSixCards = () => {
 	return (
-		<FrontSection title="Fast MPU" description="With six cards">
+		<FrontSection
+			title="Fast MPU"
+			description="With six cards"
+			discussionApiUrl={discussionApiUrl}
+		>
 			<TagFrontFastMpu
 				speed="fast"
 				injected={true}
@@ -80,7 +93,11 @@ WithSixCards.storyName = 'With six cards';
 
 export const WithNineCards = () => {
 	return (
-		<FrontSection title="Fast MPU" description="With nine cards">
+		<FrontSection
+			title="Fast MPU"
+			description="With nine cards"
+			discussionApiUrl={discussionApiUrl}
+		>
 			<TagFrontFastMpu
 				speed="fast"
 				injected={true}

--- a/dotcom-rendering/src/components/TagFrontSlowMpu.stories.tsx
+++ b/dotcom-rendering/src/components/TagFrontSlowMpu.stories.tsx
@@ -1,4 +1,5 @@
 import { breakpoints } from '@guardian/source-foundations';
+import { discussionApiUrl } from '../../fixtures/manual/discussionApiUrl';
 import { trails } from '../../fixtures/manual/trails';
 import { FrontSection } from './FrontSection';
 import { TagFrontSlowMpu } from './TagFrontSlowMpu';
@@ -19,7 +20,11 @@ export default {
 
 export const WithTwoCards = () => {
 	return (
-		<FrontSection title="Slow MPU" description="With two cards">
+		<FrontSection
+			title="Slow MPU"
+			description="With two cards"
+			discussionApiUrl={discussionApiUrl}
+		>
 			<TagFrontSlowMpu
 				speed="slow"
 				injected={true}
@@ -37,7 +42,11 @@ WithTwoCards.storyName = 'With two cards';
 
 export const WithFourCards = () => {
 	return (
-		<FrontSection title="Slow MPU" description="With four cards">
+		<FrontSection
+			title="Slow MPU"
+			description="With four cards"
+			discussionApiUrl={discussionApiUrl}
+		>
 			<TagFrontSlowMpu
 				speed="slow"
 				injected={true}
@@ -55,7 +64,11 @@ WithFourCards.storyName = 'With four cards';
 
 export const WithFiveCards = () => {
 	return (
-		<FrontSection title="Slow MPU" description="With five cards">
+		<FrontSection
+			title="Slow MPU"
+			description="With five cards"
+			discussionApiUrl={discussionApiUrl}
+		>
 			<TagFrontSlowMpu
 				speed="slow"
 				injected={true}
@@ -73,7 +86,11 @@ WithFiveCards.storyName = 'With five cards';
 
 export const WithSevenCards = () => {
 	return (
-		<FrontSection title="Slow MPU" description="With seven cards">
+		<FrontSection
+			title="Slow MPU"
+			description="With seven cards"
+			discussionApiUrl={discussionApiUrl}
+		>
 			<TagFrontSlowMpu
 				speed="slow"
 				injected={true}

--- a/dotcom-rendering/src/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/layouts/CommentLayout.tsx
@@ -726,6 +726,9 @@ export const CommentLayout = ({
 								onwardsSource="more-on-this-story"
 								format={format}
 								leftColSize={'compact'}
+								discussionApiUrl={
+									article.config.discussionApiUrl
+								}
 							/>
 						</Island>
 					</Section>
@@ -751,6 +754,7 @@ export const CommentLayout = ({
 						pillar={format.theme}
 						editionId={article.editionId}
 						shortUrlId={article.config.shortUrlId}
+						discussionApiUrl={article.config.discussionApiUrl}
 					/>
 				</Island>
 

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -520,6 +520,9 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 									treats={collection.treats}
 									data-print-layout="hide"
 									hasPageSkin={hasPageSkin}
+									discussionApiUrl={
+										front.config.discussionApiUrl
+									}
 								>
 									<FrontMostViewed
 										displayName={collection.displayName}
@@ -570,6 +573,9 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 									badge={collection.badge}
 									data-print-layout="hide"
 									hasPageSkin={hasPageSkin}
+									discussionApiUrl={
+										front.config.discussionApiUrl
+									}
 								>
 									<DecideContainer
 										trails={trailsWithoutBranding}
@@ -662,6 +668,9 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 											}
 											hasPageSkin={hasPageSkin}
 											url={collection.href}
+											discussionApiUrl={
+												front.config.discussionApiUrl
+											}
 										/>
 									</Island>
 								</Section>
@@ -730,6 +739,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 								targetedTerritory={collection.targetedTerritory}
 								hasPageSkin={hasPageSkin}
 								editionBranding={editionBranding}
+								discussionApiUrl={front.config.discussionApiUrl}
 							>
 								<DecideContainer
 									trails={trailsWithoutBranding}

--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -772,6 +772,9 @@ export const ImmersiveLayout = ({
 								onwardsSource="more-on-this-story"
 								format={format}
 								leftColSize={'compact'}
+								discussionApiUrl={
+									article.config.discussionApiUrl
+								}
 							/>
 						</Island>
 					</Section>
@@ -797,6 +800,7 @@ export const ImmersiveLayout = ({
 						pillar={format.theme}
 						editionId={article.editionId}
 						shortUrlId={article.config.shortUrlId}
+						discussionApiUrl={article.config.discussionApiUrl}
 					/>
 				</Island>
 

--- a/dotcom-rendering/src/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/InteractiveLayout.tsx
@@ -639,6 +639,9 @@ export const InteractiveLayout = ({
 								onwardsSource="more-on-this-story"
 								format={format}
 								leftColSize={'compact'}
+								discussionApiUrl={
+									article.config.discussionApiUrl
+								}
 							/>
 						</Island>
 					</Section>
@@ -664,6 +667,7 @@ export const InteractiveLayout = ({
 						pillar={format.theme}
 						editionId={article.editionId}
 						shortUrlId={article.config.shortUrlId}
+						discussionApiUrl={article.config.discussionApiUrl}
 					/>
 				</Island>
 

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -1158,6 +1158,9 @@ export const LiveLayout = ({
 									onwardsSource="more-on-this-story"
 									format={format}
 									leftColSize={'wide'}
+									discussionApiUrl={
+										article.config.discussionApiUrl
+									}
 								/>
 							</Island>
 						</Section>
@@ -1185,6 +1188,7 @@ export const LiveLayout = ({
 							pillar={format.theme}
 							editionId={article.editionId}
 							shortUrlId={article.config.shortUrlId}
+							discussionApiUrl={article.config.discussionApiUrl}
 						/>
 					</Island>
 

--- a/dotcom-rendering/src/layouts/NewsletterSignupLayout.tsx
+++ b/dotcom-rendering/src/layouts/NewsletterSignupLayout.tsx
@@ -523,6 +523,9 @@ export const NewsletterSignupLayout = ({
 								onwardsSource="more-on-this-story"
 								format={format}
 								leftColSize={'compact'}
+								discussionApiUrl={
+									article.config.discussionApiUrl
+								}
 							/>
 						</Island>
 					</Section>
@@ -548,6 +551,7 @@ export const NewsletterSignupLayout = ({
 						pillar={format.theme}
 						editionId={article.editionId}
 						shortUrlId={article.config.shortUrlId}
+						discussionApiUrl={article.config.discussionApiUrl}
 					/>
 				</Island>
 			</main>

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -699,6 +699,9 @@ export const ShowcaseLayout = ({
 								onwardsSource="more-on-this-story"
 								format={format}
 								leftColSize={'compact'}
+								discussionApiUrl={
+									article.config.discussionApiUrl
+								}
 							/>
 						</Island>
 					</Section>
@@ -724,6 +727,7 @@ export const ShowcaseLayout = ({
 						pillar={format.theme}
 						editionId={article.editionId}
 						shortUrlId={article.config.shortUrlId}
+						discussionApiUrl={article.config.discussionApiUrl}
 					/>
 				</Island>
 

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -800,6 +800,9 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 								onwardsSource="more-on-this-story"
 								format={format}
 								leftColSize={'compact'}
+								discussionApiUrl={
+									article.config.discussionApiUrl
+								}
 							/>
 						</Island>
 					</Section>
@@ -829,6 +832,9 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 								pillar={format.theme}
 								editionId={article.editionId}
 								shortUrlId={article.config.shortUrlId}
+								discussionApiUrl={
+									article.config.discussionApiUrl
+								}
 							/>
 						</Island>
 

--- a/dotcom-rendering/src/layouts/TagFrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/TagFrontLayout.tsx
@@ -292,6 +292,9 @@ export const TagFrontLayout = ({ tagFront, NAV }: Props) => {
 										? tagFront.pagination
 										: undefined
 								}
+								discussionApiUrl={
+									tagFront.config.discussionApiUrl
+								}
 							>
 								<ContainerComponent />
 							</FrontSection>

--- a/dotcom-rendering/src/lib/useCommentCount.ts
+++ b/dotcom-rendering/src/lib/useCommentCount.ts
@@ -2,9 +2,6 @@ import { isNonNullable } from '@guardian/libs';
 import { isServer } from './isServer';
 import { useApi } from './useApi';
 
-const REPLACEMENT = [/^http:\/\//, 'https://'] as const;
-const upgradeToHttps = (url: string) => url.replace(...REPLACEMENT);
-
 type CommentCounts = Record<string, number>;
 
 const getInitialSetFromDOMAttribute = (attribute: string) =>
@@ -26,9 +23,7 @@ export const useCommentCount = (
 			.sort() // ensures identical sets produce the same query parameter
 			.join(','),
 	});
-	const url = `${upgradeToHttps(
-		discussionApiUrl,
-	)}/getCommentCounts?${searchParams.toString()}`;
+	const url = `${discussionApiUrl}/getCommentCounts?${searchParams.toString()}`;
 	const { data } = useApi<CommentCounts>(url, {
 		// Discussion reponses have a long cache (~300s)
 		refreshInterval: 27_000,

--- a/dotcom-rendering/src/model/enhanceCards.ts
+++ b/dotcom-rendering/src/model/enhanceCards.ts
@@ -285,12 +285,14 @@ export const enhanceCards = (
 		editionId,
 		containerPalette,
 		pageId,
+		discussionApiUrl,
 	}: {
 		cardInTagFront: boolean;
 		offset?: number;
 		editionId?: EditionId;
 		containerPalette?: DCRContainerPalette;
 		pageId?: string;
+		discussionApiUrl: string;
 	},
 ): DCRFrontCard[] =>
 	collections.map((faciaCard, index) => {
@@ -348,6 +350,7 @@ export const enhanceCards = (
 						containerPalette,
 				  )
 				: undefined,
+			discussionApiUrl,
 			discussionId: faciaCard.discussion.isCommentable
 				? faciaCard.discussion.discussionId
 				: undefined,

--- a/dotcom-rendering/src/model/enhanceCollections.ts
+++ b/dotcom-rendering/src/model/enhanceCollections.ts
@@ -44,13 +44,21 @@ function getBrandingFromCards(
 		.filter(isNonNullable);
 }
 
-export const enhanceCollections = (
-	collections: FECollectionType[],
-	editionId: EditionId,
-	pageId: string,
-	onPageDescription?: string,
-	isPaidContent?: boolean,
-): DCRCollectionType[] => {
+export const enhanceCollections = ({
+	collections,
+	editionId,
+	pageId,
+	discussionApiUrl,
+	onPageDescription,
+	isPaidContent,
+}: {
+	collections: FECollectionType[];
+	editionId: EditionId;
+	pageId: string;
+	discussionApiUrl: string;
+	onPageDescription?: string;
+	isPaidContent?: boolean;
+}): DCRCollectionType[] => {
 	return collections.filter(isSupported).map((collection, index) => {
 		const { id, displayName, collectionType, hasMore, href, description } =
 			collection;
@@ -92,17 +100,20 @@ export const enhanceCollections = (
 				collection.curated,
 				collection.backfill,
 				editionId,
+				discussionApiUrl,
 				containerPalette,
 			),
 			curated: enhanceCards(collection.curated, {
 				cardInTagFront: false,
 				editionId,
 				containerPalette,
+				discussionApiUrl,
 			}),
 			backfill: enhanceCards(collection.backfill, {
 				cardInTagFront: false,
 				editionId,
 				containerPalette,
+				discussionApiUrl,
 			}),
 			treats: enhanceTreats(
 				collection.treats,

--- a/dotcom-rendering/src/model/groupCards.ts
+++ b/dotcom-rendering/src/model/groupCards.ts
@@ -29,6 +29,7 @@ export const groupCards = (
 	curated: FEFrontCard[],
 	backfill: FEFrontCard[],
 	editionId: EditionId,
+	discussionApiUrl: string,
 	containerPalette?: DCRContainerPalette,
 ): DCRGroupedTrails => {
 	switch (container) {
@@ -43,6 +44,7 @@ export const groupCards = (
 					cardInTagFront: false,
 					editionId,
 					containerPalette,
+					discussionApiUrl,
 				}),
 				standard: enhanceCards(
 					// Backfilled cards will always be treated as 'standard' cards
@@ -54,6 +56,7 @@ export const groupCards = (
 						offset: big.length,
 						editionId,
 						containerPalette,
+						discussionApiUrl,
 					},
 				),
 			};
@@ -70,18 +73,21 @@ export const groupCards = (
 					cardInTagFront: false,
 					editionId,
 					containerPalette,
+					discussionApiUrl,
 				}),
 				veryBig: enhanceCards(veryBig, {
 					cardInTagFront: false,
 					offset: huge.length,
 					editionId,
 					containerPalette,
+					discussionApiUrl,
 				}),
 				big: enhanceCards(big, {
 					cardInTagFront: false,
 					offset: huge.length + veryBig.length,
 					editionId,
 					containerPalette,
+					discussionApiUrl,
 				}),
 				standard: enhanceCards(
 					// Backfilled cards will always be treated as 'standard' cards
@@ -93,6 +99,7 @@ export const groupCards = (
 						offset: huge.length + veryBig.length + big.length,
 						editionId,
 						containerPalette,
+						discussionApiUrl,
 					},
 				),
 			};
@@ -108,6 +115,7 @@ export const groupCards = (
 					cardInTagFront: false,
 					editionId,
 					containerPalette,
+					discussionApiUrl,
 				}),
 				standard: enhanceCards(
 					// Backfilled cards will always be treated as 'standard' cards
@@ -119,6 +127,7 @@ export const groupCards = (
 						offset: snap.length,
 						editionId,
 						containerPalette,
+						discussionApiUrl,
 					},
 				),
 			};

--- a/dotcom-rendering/src/server/index.front.web.ts
+++ b/dotcom-rendering/src/server/index.front.web.ts
@@ -24,13 +24,15 @@ const enhanceFront = (body: unknown): DCRFrontType => {
 		} | The Guardian`,
 		pressedPage: {
 			...data.pressedPage,
-			collections: enhanceCollections(
-				data.pressedPage.collections,
-				data.editionId,
-				data.pageId,
-				data.pressedPage.frontProperties.onPageDescription,
-				data.config.isPaidContent,
-			),
+			collections: enhanceCollections({
+				collections: data.pressedPage.collections,
+				editionId: data.editionId,
+				pageId: data.pageId,
+				onPageDescription:
+					data.pressedPage.frontProperties.onPageDescription,
+				isPaidContent: data.config.isPaidContent,
+				discussionApiUrl: data.config.discussionApiUrl,
+			}),
 		},
 		mostViewed: data.mostViewed.map((trail) => decideTrail(trail)),
 		mostCommented: data.mostCommented
@@ -51,6 +53,7 @@ const enhanceTagFront = (body: unknown): DCRTagFrontType => {
 	const enhancedCards = enhanceCards(data.contents, {
 		cardInTagFront: true,
 		pageId: data.pageId,
+		discussionApiUrl: data.config.discussionApiUrl,
 	});
 	const speed = getSpeedFromTrails(data.contents);
 

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -308,6 +308,7 @@ export type DCRFrontCard = {
 	isCrossword?: boolean;
 	/** @see JSX.IntrinsicAttributes["data-link-name"] */
 	dataLinkName: string;
+	discussionApiUrl: string;
 	discussionId?: string;
 	byline?: string;
 	showByline?: boolean;


### PR DESCRIPTION
## What does this change?

- drill `discussionApiUrl` prop down
- Revert "discussion API always HTTPS (#8619)"

## Why?

This is the correct way to get the API from `frontend`.
Left to do in #8307 

## Screenshots

N/A – see Chromatic