### PR TITLE
fix: remove refreshInterval and uniqueCommentCount increment on server for useCommentCount

### DIFF
--- a/dotcom-rendering/src/lib/useCommentCount.ts
+++ b/dotcom-rendering/src/lib/useCommentCount.ts
@@ -20,7 +20,10 @@ export const useCommentCount = (
 	discussionApiUrl: string,
 	shortUrl: string,
 ): number | undefined => {
-	uniqueDiscussionIds.add(shortUrl);
+	if (!isServer) {
+		uniqueDiscussionIds.add(shortUrl);
+	}
+
 	const searchParams = new URLSearchParams({
 		'short-urls': [...uniqueDiscussionIds]
 			.sort() // ensures identical sets produce the same query parameter
@@ -31,7 +34,7 @@ export const useCommentCount = (
 	)}/getCommentCounts?${searchParams.toString()}`;
 	const { data } = useApi<CommentCounts>(url, {
 		// Discussion reponses have a long cache (~300s)
-		refreshInterval: 27_000,
+		refreshInterval: isServer ? 0 : 27_000,
 	});
 
 	return data?.[shortUrl];

--- a/dotcom-rendering/src/server/prod-server.ts
+++ b/dotcom-rendering/src/server/prod-server.ts
@@ -36,6 +36,9 @@ const logRenderTime = responseTime(
 		logger.info('Page render time', {
 			renderTime,
 		});
+		console.info('Page render time', {
+			renderTime,
+		});
 	},
 );
 


### PR DESCRIPTION
We have identified that [this PR](https://github.com/guardian/dotcom-rendering/pull/8307) might have been a cause for a spike in server side renderTime, in a spiky fashion, which feels like a memory leak or similar.

This indicates we probably have some garbage laying around, this PR tries to stop that.

![Screenshot 2023-08-18 at 12 28 00](https://github.com/guardian/dotcom-rendering/assets/31692/2b8c005a-6dff-42ea-9661-f56e3474152a)



We've validated that `useSWR` doesn't actually `fetch` on server, it does run. The docs [say something similar with it's usage with Next.js](https://swr.vercel.app/docs/with-nextjs).

This PR is more a test to see if that's the case (we've rolled back and it indicated it might be). I would have reverted the original PR, but we've had a few fixes beyond that, so this felt closer to fixing forward.

Co-Authored-By: Max Duval <max.duval@theguardian.com>