### PR TITLE
Simplify `useCommentCount` server logic

### DIFF
--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -556,16 +556,5 @@ declare namespace JSX {
 		 * link is clicked.
 		 */
 		'data-link-name'?: string;
-
-		/**
-		 * **Build an initial set of discussions**
-		 *
-		 * Setting this attribute helps build an initial set of discussion IDs.
-		 * Without it, there is a risk that each new usage of `useCommentCount`
-		 * leads to a distinct request to the discussion API
-		 *
-		 * @see {@link ../src/lib/useCommentCount.ts}
-		 */
-		'data-discussion-id'?: string;
 	}
 }

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -5,6 +5,7 @@ import { Link } from '@guardian/source-react-components';
 import { StraightLines } from '@guardian/source-react-components-development-kitchen';
 import { decidePalette } from '../../lib/decidePalette';
 import { getZIndex } from '../../lib/getZIndex';
+import { DISCUSSION_ID_DATA_ATTRIBUTE } from '../../lib/useCommentCount';
 import type { Branding } from '../../types/branding';
 import type {
 	DCRContainerPalette,
@@ -326,7 +327,9 @@ export const Card = ({
 				commentCount={
 					discussionId !== undefined ? (
 						<Link
-							data-discussion-id={discussionId}
+							{...{
+								[DISCUSSION_ID_DATA_ATTRIBUTE]: discussionId,
+							}}
 							data-ignore="global-link-styling"
 							data-link-name="Comment count"
 							href={`${linkTo}#comments`}

--- a/dotcom-rendering/src/lib/useCommentCount.ts
+++ b/dotcom-rendering/src/lib/useCommentCount.ts
@@ -4,32 +4,35 @@ import { useApi } from './useApi';
 
 type CommentCounts = Record<string, number>;
 
-const getInitialSetFromDOMAttribute = (attribute: string) =>
-	[...document.querySelectorAll(`[${attribute}]`)]
-		.map((element) => element.getAttribute(attribute))
-		.filter(isNonNullable);
+const DATA_ATTRIBUTE = 'data-discussion-id';
 
-const uniqueDiscussionIds = new Set<string>(
-	isServer ? [] : getInitialSetFromDOMAttribute('data-discussion-id'),
-);
+const uniqueDiscussionIds = isServer
+	? undefined
+	: new Set<string>(
+			// create an initial set of IDs by reading what is in the DOM
+			[...document.querySelectorAll(`[${DATA_ATTRIBUTE}]`)]
+				.map((element) => element.getAttribute(DATA_ATTRIBUTE))
+				.filter(isNonNullable),
+	  );
+
+const getUrl = (base: string) =>
+	uniqueDiscussionIds
+		? `${base}/getCommentCounts?${new URLSearchParams({
+				'short-urls': [...uniqueDiscussionIds]
+					.sort() // ensures identical sets produce the same query parameter
+					.join(','),
+		  }).toString()}`
+		: undefined;
 
 export const useCommentCount = (
 	discussionApiUrl: string,
 	shortUrl: string,
 ): number | undefined => {
-	if (!isServer) {
-		uniqueDiscussionIds.add(shortUrl);
-	}
+	uniqueDiscussionIds?.add(shortUrl);
 
-	const searchParams = new URLSearchParams({
-		'short-urls': [...uniqueDiscussionIds]
-			.sort() // ensures identical sets produce the same query parameter
-			.join(','),
-	});
-	const url = `${discussionApiUrl}/getCommentCounts?${searchParams.toString()}`;
-	const { data } = useApi<CommentCounts>(url, {
+	const { data } = useApi<CommentCounts>(getUrl(discussionApiUrl), {
 		// Discussion reponses have a long cache (~300s)
-		refreshInterval: isServer ? 0 : 27_000,
+		refreshInterval: 27_000,
 	});
 
 	return data?.[shortUrl];

--- a/dotcom-rendering/src/lib/useCommentCount.ts
+++ b/dotcom-rendering/src/lib/useCommentCount.ts
@@ -4,14 +4,23 @@ import { useApi } from './useApi';
 
 type CommentCounts = Record<string, number>;
 
-const DATA_ATTRIBUTE = 'data-discussion-id';
+/**
+ * **Build an initial set of discussions**
+ *
+ * Setting this attribute helps build an initial set of discussion IDs.
+ * Without it, there is a risk that each new usage of `useCommentCount`
+ * leads to a distinct request to the discussion API
+ */
+export const DISCUSSION_ID_DATA_ATTRIBUTE = 'data-discussion-id';
 
 const uniqueDiscussionIds = isServer
 	? undefined
 	: new Set<string>(
 			// create an initial set of IDs by reading what is in the DOM
-			[...document.querySelectorAll(`[${DATA_ATTRIBUTE}]`)]
-				.map((element) => element.getAttribute(DATA_ATTRIBUTE))
+			[...document.querySelectorAll(`[${DISCUSSION_ID_DATA_ATTRIBUTE}]`)]
+				.map((element) =>
+					element.getAttribute(DISCUSSION_ID_DATA_ATTRIBUTE),
+				)
 				.filter(isNonNullable),
 	  );
 

--- a/dotcom-rendering/src/lib/useCommentCount.ts
+++ b/dotcom-rendering/src/lib/useCommentCount.ts
@@ -15,10 +15,10 @@ const uniqueDiscussionIds = isServer
 				.filter(isNonNullable),
 	  );
 
-const getUrl = (base: string) =>
-	uniqueDiscussionIds
+const getUrl = (base: string, ids: Set<string> | undefined) =>
+	ids
 		? `${base}/getCommentCounts?${new URLSearchParams({
-				'short-urls': [...uniqueDiscussionIds]
+				'short-urls': [...ids]
 					.sort() // ensures identical sets produce the same query parameter
 					.join(','),
 		  }).toString()}`
@@ -30,7 +30,14 @@ export const useCommentCount = (
 ): number | undefined => {
 	uniqueDiscussionIds?.add(shortUrl);
 
-	const { data } = useApi<CommentCounts>(getUrl(discussionApiUrl), {
+	/**
+	 * Generate an URL string or `undefined`,
+	 * to enable conditional fetching with SWR.
+	 * @see https://swr.vercel.app/docs/conditional-fetching#conditional
+	 */
+	const url = getUrl(discussionApiUrl, uniqueDiscussionIds);
+
+	const { data } = useApi<CommentCounts>(url, {
 		// Discussion reponses have a long cache (~300s)
 		refreshInterval: 27_000,
 	});


### PR DESCRIPTION
## What does this change?

Refactors `useCommentCount` to make a single decision about `isServer`

Remove the conditional call to `refreshInterval`, as it does not apply on the server.

## Why?

Couple decisions where they matter.

Improvement on #8623 

## Screenshots

N/A