### PR TITLE
DCAR: Add basic (Live|Dead)Blog handling for apps

### DIFF
--- a/dotcom-rendering/src/layouts/DecideLayout.tsx
+++ b/dotcom-rendering/src/layouts/DecideLayout.tsx
@@ -34,20 +34,34 @@ const DecideLayoutApps = ({
 	article: FEArticleType;
 	format: ArticleFormat;
 }) => {
-	if (
-		format.display === ArticleDisplay.Standard &&
-		format.design === ArticleDesign.Standard
-	) {
-		return (
-			<StandardLayout
-				article={article}
-				format={format}
-				renderingTarget="Apps"
-			/>
-		);
+	const notSupported = <pre>Not supported</pre>;
+	switch (format.display) {
+		case ArticleDisplay.Standard: {
+			switch (format.design) {
+				case ArticleDesign.Standard:
+					return (
+						<StandardLayout
+							article={article}
+							format={format}
+							renderingTarget="Apps"
+						/>
+					);
+				case ArticleDesign.LiveBlog:
+				case ArticleDesign.DeadBlog:
+					return (
+						<LiveLayout
+							article={article}
+							format={format}
+							renderingTarget="Apps"
+						/>
+					);
+				default:
+					return notSupported;
+			}
+		}
+		default:
+			return notSupported;
 	}
-
-	return <pre>Not supported</pre>;
 };
 
 const DecideLayoutWeb = ({
@@ -147,7 +161,7 @@ const DecideLayoutWeb = ({
 							article={article}
 							NAV={NAV}
 							format={format}
-							renderingTarget={renderingTarget}
+							renderingTarget="Web"
 						/>
 					);
 				case ArticleDesign.Comment:

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -61,7 +61,6 @@ import { decideTrail } from '../lib/decideTrail';
 import { getZIndex } from '../lib/getZIndex';
 import type { NavType } from '../model/extract-nav';
 import type { FEArticleType } from '../types/frontend';
-import type { RenderingTarget } from '../types/renderingTarget';
 import { BannerWrapper, SendToBack, Stuck } from './lib/stickiness';
 
 const HeadlineGrid = ({ children }: { children: React.ReactNode }) => (
@@ -232,13 +231,6 @@ const starWrapper = css`
 	margin-left: -10px;
 `;
 
-interface Props {
-	article: FEArticleType;
-	NAV: NavType;
-	format: ArticleFormat;
-	renderingTarget: RenderingTarget;
-}
-
 const paddingBody = css`
 	padding: ${space[3]}px;
 	${from.mobileLandscape} {
@@ -249,12 +241,22 @@ const paddingBody = css`
 	}
 `;
 
-export const LiveLayout = ({
-	article,
-	NAV,
-	format,
-	renderingTarget,
-}: Props) => {
+interface BaseProps {
+	article: FEArticleType;
+	format: ArticleFormat;
+}
+
+interface AppsProps extends BaseProps {
+	renderingTarget: 'Apps';
+}
+
+interface WebProps extends BaseProps {
+	renderingTarget: 'Web';
+	NAV: NavType;
+}
+
+export const LiveLayout = (props: WebProps | AppsProps) => {
+	const { article, format, renderingTarget } = props;
 	const {
 		config: { isPaidContent, host },
 	} = article;
@@ -293,113 +295,126 @@ export const LiveLayout = ({
 	const hasKeyEvents = !!article.keyEvents.length;
 	const showKeyEventsToggle = !showTopicFilterBank && hasKeyEvents;
 
-	const renderAds = canRenderAds(article);
+	const renderAds = canRenderAds(article, renderingTarget);
+
+	const isWeb = renderingTarget === 'Web';
 
 	return (
 		<>
-			<div data-print-layout="hide">
-				{renderAds && (
-					<Stuck>
+			{isWeb && (
+				<div data-print-layout="hide">
+					{renderAds && (
+						<Stuck>
+							<Section
+								fullWidth={true}
+								showTopBorder={false}
+								showSideBorders={false}
+								padSides={false}
+								shouldCenter={false}
+								element="aside"
+							>
+								<HeaderAdSlot />
+							</Section>
+						</Stuck>
+					)}
+					<SendToBack>
 						<Section
 							fullWidth={true}
+							shouldCenter={false}
 							showTopBorder={false}
 							showSideBorders={false}
 							padSides={false}
-							shouldCenter={false}
-							element="aside"
+							backgroundColour={brandBackground.primary}
+							element="header"
 						>
-							<HeaderAdSlot />
+							<Header
+								editionId={article.editionId}
+								idUrl={article.config.idUrl}
+								mmaUrl={article.config.mmaUrl}
+								discussionApiUrl={
+									article.config.discussionApiUrl
+								}
+								urls={article.nav.readerRevenueLinks.header}
+								remoteHeader={
+									!!article.config.switches.remoteHeader
+								}
+								contributionsServiceUrl={
+									contributionsServiceUrl
+								}
+								idApiUrl={article.config.idApiUrl}
+								isInEuropeTest={isInEuropeTest}
+								headerTopBarSearchCapiSwitch={
+									!!article.config.switches
+										.headerTopBarSearchCapi
+								}
+							/>
 						</Section>
-					</Stuck>
-				)}
-				<SendToBack>
-					<Section
-						fullWidth={true}
-						shouldCenter={false}
-						showTopBorder={false}
-						showSideBorders={false}
-						padSides={false}
-						backgroundColour={brandBackground.primary}
-						element="header"
-					>
-						<Header
-							editionId={article.editionId}
-							idUrl={article.config.idUrl}
-							mmaUrl={article.config.mmaUrl}
-							discussionApiUrl={article.config.discussionApiUrl}
-							urls={article.nav.readerRevenueLinks.header}
-							remoteHeader={
-								!!article.config.switches.remoteHeader
-							}
-							contributionsServiceUrl={contributionsServiceUrl}
-							idApiUrl={article.config.idApiUrl}
-							isInEuropeTest={isInEuropeTest}
-							headerTopBarSearchCapiSwitch={
-								!!article.config.switches.headerTopBarSearchCapi
-							}
-						/>
-					</Section>
 
-					<Section
-						fullWidth={true}
-						borderColour={brandLine.primary}
-						showTopBorder={false}
-						padSides={false}
-						backgroundColour={brandBackground.primary}
-						element="nav"
-					>
-						<Nav
-							nav={NAV}
-							selectedPillar={NAV.selectedPillar}
-							subscribeUrl={
-								article.nav.readerRevenueLinks.header.subscribe
-							}
-							editionId={article.editionId}
-							headerTopBarSwitch={
-								!!article.config.switches.headerTopNav
-							}
-							isInEuropeTest={isInEuropeTest}
-						/>
-					</Section>
+						<Section
+							fullWidth={true}
+							borderColour={brandLine.primary}
+							showTopBorder={false}
+							padSides={false}
+							backgroundColour={brandBackground.primary}
+							element="nav"
+						>
+							<Nav
+								nav={props.NAV}
+								selectedPillar={props.NAV.selectedPillar}
+								subscribeUrl={
+									article.nav.readerRevenueLinks.header
+										.subscribe
+								}
+								editionId={article.editionId}
+								headerTopBarSwitch={
+									!!article.config.switches.headerTopNav
+								}
+								isInEuropeTest={isInEuropeTest}
+							/>
+						</Section>
 
-					{NAV.subNavSections && (
+						{props.NAV.subNavSections && (
+							<Section
+								fullWidth={true}
+								backgroundColour={palette.background.article}
+								padSides={false}
+								borderColour={palette.border.article}
+								element="aside"
+							>
+								<Island deferUntil="idle">
+									<SubNav
+										subNavSections={
+											props.NAV.subNavSections
+										}
+										currentNavLink={
+											props.NAV.currentNavLink
+										}
+										linkHoverColour={
+											palette.text.articleLinkHover
+										}
+										borderColour={palette.border.subNav}
+									/>
+								</Island>
+							</Section>
+						)}
+
 						<Section
 							fullWidth={true}
 							backgroundColour={palette.background.article}
 							padSides={false}
+							showTopBorder={false}
 							borderColour={palette.border.article}
-							element="aside"
 						>
-							<Island deferUntil="idle">
-								<SubNav
-									subNavSections={NAV.subNavSections}
-									currentNavLink={NAV.currentNavLink}
-									linkHoverColour={
-										palette.text.articleLinkHover
-									}
-									borderColour={palette.border.subNav}
-								/>
-							</Island>
+							<StraightLines
+								count={4}
+								cssOverrides={css`
+									display: block;
+								`}
+							/>
 						</Section>
-					)}
-
-					<Section
-						fullWidth={true}
-						backgroundColour={palette.background.article}
-						padSides={false}
-						showTopBorder={false}
-						borderColour={palette.border.article}
-					>
-						<StraightLines
-							count={4}
-							cssOverrides={css`
-								display: block;
-							`}
-						/>
-					</Section>
-				</SendToBack>
-			</div>
-
+					</SendToBack>
+				</div>
+			)}
 			<main data-layout="LiveLayout">
 				{footballMatchUrl ? (
 					<Section
@@ -1260,70 +1275,82 @@ export const LiveLayout = ({
 				</div>
 			</main>
 
-			{NAV.subNavSections && (
-				<Section
-					fullWidth={true}
-					data-print-layout="hide"
-					padSides={false}
-					element="aside"
-				>
-					<Island deferUntil="visible">
-						<SubNav
-							subNavSections={NAV.subNavSections}
-							currentNavLink={NAV.currentNavLink}
-							linkHoverColour={palette.text.articleLinkHover}
-							borderColour={palette.border.subNav}
+			{isWeb && (
+				<>
+					{props.NAV.subNavSections && (
+						<Section
+							fullWidth={true}
+							data-print-layout="hide"
+							padSides={false}
+							element="aside"
+						>
+							<Island deferUntil="visible">
+								<SubNav
+									subNavSections={props.NAV.subNavSections}
+									currentNavLink={props.NAV.currentNavLink}
+									linkHoverColour={
+										palette.text.articleLinkHover
+									}
+									borderColour={palette.border.subNav}
+								/>
+							</Island>
+						</Section>
+					)}
+
+					<Section
+						fullWidth={true}
+						data-print-layout="hide"
+						padSides={false}
+						backgroundColour={brandBackground.primary}
+						borderColour={brandBorder.primary}
+						showSideBorders={false}
+						element="footer"
+					>
+						<Footer
+							pageFooter={article.pageFooter}
+							selectedPillar={props.NAV.selectedPillar}
+							pillars={props.NAV.pillars}
+							urls={article.nav.readerRevenueLinks.header}
+							editionId={article.editionId}
+							contributionsServiceUrl={
+								article.contributionsServiceUrl
+							}
 						/>
-					</Island>
-				</Section>
+					</Section>
+
+					<BannerWrapper data-print-layout="hide">
+						<Island deferUntil="idle" clientOnly={true}>
+							<StickyBottomBanner
+								contentType={article.contentType}
+								contributionsServiceUrl={
+									contributionsServiceUrl
+								}
+								idApiUrl={article.config.idApiUrl}
+								isMinuteArticle={
+									article.pageType.isMinuteArticle
+								}
+								isPaidContent={article.pageType.isPaidContent}
+								isPreview={!!article.config.isPreview}
+								isSensitive={article.config.isSensitive}
+								keywordIds={article.config.keywordIds}
+								pageId={article.pageId}
+								sectionId={article.config.section}
+								shouldHideReaderRevenue={
+									article.shouldHideReaderRevenue
+								}
+								remoteBannerSwitch={
+									!!article.config.switches.remoteBanner
+								}
+								puzzleBannerSwitch={
+									!!article.config.switches.puzzlesBanner
+								}
+								tags={article.tags}
+							/>
+						</Island>
+					</BannerWrapper>
+					<MobileStickyContainer data-print-layout="hide" />
+				</>
 			)}
-
-			<Section
-				fullWidth={true}
-				data-print-layout="hide"
-				padSides={false}
-				backgroundColour={brandBackground.primary}
-				borderColour={brandBorder.primary}
-				showSideBorders={false}
-				element="footer"
-			>
-				<Footer
-					pageFooter={article.pageFooter}
-					selectedPillar={NAV.selectedPillar}
-					pillars={NAV.pillars}
-					urls={article.nav.readerRevenueLinks.header}
-					editionId={article.editionId}
-					contributionsServiceUrl={article.contributionsServiceUrl}
-				/>
-			</Section>
-
-			<BannerWrapper data-print-layout="hide">
-				<Island deferUntil="idle" clientOnly={true}>
-					<StickyBottomBanner
-						contentType={article.contentType}
-						contributionsServiceUrl={contributionsServiceUrl}
-						idApiUrl={article.config.idApiUrl}
-						isMinuteArticle={article.pageType.isMinuteArticle}
-						isPaidContent={article.pageType.isPaidContent}
-						isPreview={!!article.config.isPreview}
-						isSensitive={article.config.isSensitive}
-						keywordIds={article.config.keywordIds}
-						pageId={article.pageId}
-						sectionId={article.config.section}
-						shouldHideReaderRevenue={
-							article.shouldHideReaderRevenue
-						}
-						remoteBannerSwitch={
-							!!article.config.switches.remoteBanner
-						}
-						puzzleBannerSwitch={
-							!!article.config.switches.puzzlesBanner
-						}
-						tags={article.tags}
-					/>
-				</Island>
-			</BannerWrapper>
-			<MobileStickyContainer data-print-layout="hide" />
 		</>
 	);
 };

--- a/dotcom-rendering/src/lib/canRenderAds.ts
+++ b/dotcom-rendering/src/lib/canRenderAds.ts
@@ -1,5 +1,6 @@
 import type { DCRFrontType } from '../types/front';
 import type { FEArticleType } from '../types/frontend';
+import type { RenderingTarget } from '../types/renderingTarget';
 import type { DCRTagFrontType } from '../types/tagFront';
 
 /**
@@ -8,7 +9,11 @@ import type { DCRTagFrontType } from '../types/tagFront';
  */
 export const canRenderAds = (
 	pageData: FEArticleType | DCRFrontType | DCRTagFrontType,
+	renderingTarget?: RenderingTarget,
 ): boolean => {
+	if (renderingTarget === 'Apps') {
+		return false;
+	}
 	if (pageData.isAdFreeUser) {
 		return false;
 	}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

- Adds a basic live/dead blog layout for apps
- Omits ads for now (until https://github.com/guardian/dotcom-rendering/issues/8381 is decided)

## Screenshots
<img src="https://github.com/guardian/dotcom-rendering/assets/705427/6f7471b2-0c3a-423e-bb96-5dccb5ef433b" width="420" />
