### PR TITLE
Clear `localStorage` on every Story

### DIFF
--- a/dotcom-rendering/.storybook/preview.js
+++ b/dotcom-rendering/.storybook/preview.js
@@ -1,4 +1,4 @@
-import { setCookie } from '@guardian/libs';
+import { setCookie, storage } from '@guardian/libs';
 import { AB } from '@guardian/ab-core';
 
 import isChromatic from 'chromatic/isChromatic';
@@ -134,6 +134,16 @@ const guardianViewports = {
 			height: '800px',
 		},
 	},
+};
+
+/** @type {import('@storybook/react').Preview} */
+export default {
+	decorators: [
+		(Story) => {
+			storage.local.clear();
+			return Story();
+		},
+	],
 };
 
 export const viewports = [320, 375, 480, 660, 740, 980, 1140, 1300];


### PR DESCRIPTION

<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Clear `localStorage` on every Story using [Storybook decorators](https://storybook.js.org/docs/react/writing-stories/decorators#global-decorators)

## Why?

this causes intermittent issues which are difficult to reproduce, that rely on the order in which stories are generated.

Mainly seen in in the discussion comments order, which keeps alternating between “Older” and “Newer”.

## Screenshots

(No more false positives in Chromatic)