### PR TITLE
Tweak showcase layout for picture content type

### DIFF
--- a/dotcom-rendering/src/components/ArticleContainer.tsx
+++ b/dotcom-rendering/src/components/ArticleContainer.tsx
@@ -12,8 +12,10 @@ type Props = {
 const articleWidth = (format: ArticleFormat) => {
 	switch (format.design) {
 		case ArticleDesign.Picture:
+			//This enables the straight lines and submeta in picture content to correctly "stretch" in the container.
+			return null;
 		case ArticleDesign.Interactive: {
-			/* These articles use a special template which manages it's own width */
+			/* These articles use a special template which manages its own width */
 			return null;
 		}
 		case ArticleDesign.LiveBlog:

--- a/dotcom-rendering/src/components/ArticleContainer.tsx
+++ b/dotcom-rendering/src/components/ArticleContainer.tsx
@@ -11,6 +11,7 @@ type Props = {
 
 const articleWidth = (format: ArticleFormat) => {
 	switch (format.design) {
+		case ArticleDesign.Picture:
 		case ArticleDesign.Interactive: {
 			/* These articles use a special template which manages it's own width */
 			return null;

--- a/dotcom-rendering/src/components/ArticleMeta.tsx
+++ b/dotcom-rendering/src/components/ArticleMeta.tsx
@@ -107,19 +107,19 @@ const borderColourWhenBackgroundDark = css`
 	}
 `;
 
-const metaExtras = (palette: Palette) => css`
+const metaExtras = (palette: Palette, isPictureContent: boolean) => css`
 	border-top: 1px solid ${palette.border.article};
 	flex-grow: 1;
 	padding-top: 6px;
 
-	${until.phablet} {
+	${!isPictureContent && until.phablet} {
 		margin-left: -20px;
 		margin-right: -20px;
 		padding-left: 20px;
 		padding-right: 20px;
 	}
 
-	${until.mobileLandscape} {
+	${!isPictureContent && until.phablet} {
 		margin-left: -10px;
 		margin-right: -10px;
 		padding-left: 10px;
@@ -131,7 +131,7 @@ const metaExtras = (palette: Palette) => css`
 	}
 `;
 
-const metaNumbers = (palette: Palette) => css`
+const metaNumbers = (palette: Palette, isPictureContent: boolean) => css`
 	border-top: 1px solid ${palette.border.article};
 	display: flex;
 	flex-grow: 1;
@@ -141,14 +141,14 @@ const metaNumbers = (palette: Palette) => css`
 		justify-content: flex-start;
 	}
 
-	${until.phablet} {
+	${!isPictureContent && until.phablet} {
 		margin-left: -20px;
 		margin-right: -20px;
 		padding-left: 20px;
 		padding-right: 20px;
 	}
 
-	${until.mobileLandscape} {
+	${!isPictureContent && until.phablet} {
 		margin-left: -10px;
 		margin-right: -10px;
 		padding-left: 10px;
@@ -324,6 +324,8 @@ export const ArticleMeta = ({
 
 	const palette = decidePalette(format);
 
+	const isPictureContent = format.design === ArticleDesign.Picture;
+
 	return (
 		<div
 			className={
@@ -404,7 +406,7 @@ export const ArticleMeta = ({
 								: ''
 						}
 						css={[
-							metaExtras(palette),
+							metaExtras(palette, isPictureContent),
 							format.design === ArticleDesign.LiveBlog &&
 								css(
 									borderColourWhenBackgroundDark,
@@ -428,7 +430,7 @@ export const ArticleMeta = ({
 								: ''
 						}
 						css={[
-							metaNumbers(palette),
+							metaNumbers(palette, isPictureContent),
 							format.design === ArticleDesign.LiveBlog &&
 								css(
 									borderColourWhenBackgroundDark,

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -92,24 +92,49 @@ const ShowcaseGrid = ({
 				*/
 				${from.wide} {
 					grid-template-columns: 219px 1px 1fr 300px;
-					grid-template-areas:
-						'title  border  headline    headline'
-						'lines  border  media       media'
-						'meta   border  media       media'
-						'meta   border  standfirst  right-column'
-						'.      border  body        right-column'
-						'.      border  .           right-column';
+					${isPictureContent
+						? css`
+								grid-template-areas:
+									'title  border  headline    headline'
+									'lines  border  standfirst       standfirst'
+									'meta   border  media       media'
+									'meta   border  media       media'
+									'.      border  body        right-column'
+									'.      border  .           right-column';
+						  `
+						: css`
+								grid-template-areas:
+									'title  border  headline    headline'
+									'lines  border  media       media'
+									'meta   border  media       media'
+									'meta   border  standfirst  right-column'
+									'.      border  body        right-column'
+									'.      border  .           right-column';
+						  `}
 				}
 
 				${until.wide} {
 					grid-template-columns: 140px 1px 1fr 300px;
-					grid-template-areas:
-						'title  border  headline    headline'
-						'lines  border  media       media'
-						'meta   border  media       media'
-						'meta   border  standfirst  right-column'
-						'.      border  body        right-column'
-						'.      border  .           right-column';
+
+					${isPictureContent
+						? css`
+								grid-template-areas:
+									'title  border  headline    headline'
+									'lines  border  standfirst       standfirst'
+									'meta   border  media       media'
+									'meta   border  media       media'
+									'.      border  body        right-column'
+									'.      border  .           right-column';
+						  `
+						: css`
+								grid-template-areas:
+									'title  border  headline    headline'
+									'lines  border  media       media'
+									'meta   border  media       media'
+									'meta   border  standfirst  right-column'
+									'.      border  body        right-column'
+									'.      border  .           right-column';
+						  `}
 				}
 
 				/*
@@ -147,14 +172,27 @@ const ShowcaseGrid = ({
 				${until.tablet} {
 					grid-column-gap: 0px;
 					grid-template-columns: 1fr; /* Main content */
-					grid-template-areas:
-						'media'
-						'title'
-						'headline'
-						'standfirst'
-						'lines'
-						'meta'
-						'body';
+					${isPictureContent
+						? css`
+								grid-template-areas:
+									'title'
+									'headline'
+									'standfirst'
+									'lines'
+									'media'
+									'meta'
+									'body';
+						  `
+						: css`
+								grid-template-areas:
+									'media'
+									'title'
+									'headline'
+									'standfirst'
+									'lines'
+									'meta'
+									'body';
+						  `}
 				}
 			}
 		`}

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -195,8 +195,8 @@ const ShowcaseGrid = ({
 									'title'
 									'headline'
 									'standfirst'
-									'lines'
 									'media'
+									'lines'
 									'meta'
 									'body';
 						  `
@@ -224,19 +224,26 @@ const maxWidth = css`
 	}
 `;
 
-const stretchLines = css`
-	${until.phablet} {
-		margin-left: -20px;
-		margin-right: -20px;
+const stretchLines = (isPictureContent: boolean) => css`
+	${!isPictureContent && until.phablet} {
+		margin-left: -30px;
+		margin-right: -30px;
 	}
-	${until.mobileLandscape} {
+	${!isPictureContent && until.mobileLandscape} {
 		margin-left: -10px;
 		margin-right: -10px;
 	}
 `;
-
-const mainMediaWrapper = css`
+const mainMediaWrapper = (isPictureContent: boolean) => css`
 	position: relative;
+	${isPictureContent && until.phablet} {
+		margin-left: 20px;
+		margin-right: 20px;
+	}
+	${isPictureContent && until.mobileLandscape} {
+		margin-left: 10px;
+		margin-right: 10px;
+	}
 `;
 
 const PositionHeadline = ({
@@ -516,7 +523,7 @@ export const ShowcaseLayout = ({
 				>
 					<ShowcaseGrid isPictureContent={isPictureContent}>
 						<GridItem area="media">
-							<div css={mainMediaWrapper}>
+							<div css={mainMediaWrapper(isPictureContent)}>
 								<MainMedia
 									format={format}
 									elements={article.mainMediaElements}
@@ -574,7 +581,7 @@ export const ShowcaseLayout = ({
 						</GridItem>
 						<GridItem area="lines">
 							<div css={maxWidth}>
-								<div css={stretchLines}>
+								<div css={stretchLines(isPictureContent)}>
 									<DecideLines
 										format={format}
 										color={palette.border.secondary}

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -52,7 +52,14 @@ import type { FEArticleType } from '../types/frontend';
 import type { RenderingTarget } from '../types/renderingTarget';
 import { BannerWrapper, SendToBack, Stuck } from './lib/stickiness';
 
-const ShowcaseGrid = ({ children }: { children: React.ReactNode }) => (
+const ShowcaseGrid = ({
+	children,
+	isPictureContent,
+}: {
+	children: React.ReactNode;
+	isPictureContent: boolean;
+}) => (
+	//add isPic content as decider
 	<div
 		css={css`
 			/* IE Fallback */
@@ -244,6 +251,8 @@ export const ShowcaseLayout = ({
 
 	const showSubNavTopBorder =
 		format.design !== ArticleDesign.Picture ? true : false;
+
+	const isPictureContent = format.design === ArticleDesign.Picture;
 
 	return (
 		<>
@@ -450,7 +459,7 @@ export const ShowcaseLayout = ({
 					element="article"
 					borderColour={palette.border.secondary}
 				>
-					<ShowcaseGrid>
+					<ShowcaseGrid isPictureContent={isPictureContent}>
 						<GridItem area="media">
 							<div css={mainMediaWrapper}>
 								<MainMedia

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -221,7 +221,7 @@ const ShowcaseGrid = ({
 	</div>
 );
 
-const maxWidth = (isPictureContent?: boolean) => css`
+const maxWidth = (isPictureContent: boolean) => css`
 	${!isPictureContent && from.desktop} {
 		max-width: 620px;
 	}
@@ -251,14 +251,14 @@ const mainMediaWrapper = (isPictureContent: boolean) => css`
 
 const PositionHeadline = ({
 	design,
+	isPictureContent,
 	children,
 }: {
 	design: ArticleDesign;
+	isPictureContent: boolean;
 	children: React.ReactNode;
 }) => {
 	switch (design) {
-		case ArticleDesign.Picture:
-			return <div>{children}</div>;
 		case ArticleDesign.Interview:
 			return (
 				<div
@@ -268,11 +268,11 @@ const PositionHeadline = ({
 						}
 					`}
 				>
-					<div css={maxWidth()}>{children}</div>
+					<div css={maxWidth(isPictureContent)}>{children}</div>
 				</div>
 			);
 		default:
-			return <div css={maxWidth()}>{children}</div>;
+			return <div css={maxWidth(isPictureContent)}>{children}</div>;
 	}
 };
 
@@ -563,7 +563,10 @@ export const ShowcaseLayout = ({
 							<Border format={format} />
 						</GridItem>
 						<GridItem area="headline">
-							<PositionHeadline design={format.design}>
+							<PositionHeadline
+								design={format.design}
+								isPictureContent={isPictureContent}
+							>
 								<ArticleHeadline
 									format={format}
 									headlineString={article.headline}

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -59,7 +59,6 @@ const ShowcaseGrid = ({
 	children: React.ReactNode;
 	isPictureContent: boolean;
 }) => (
-	//add isPic content as decider
 	<div
 		css={css`
 			/* IE Fallback */
@@ -89,20 +88,24 @@ const ShowcaseGrid = ({
 					Vertical grey border
 					Main content
 					Right Column
+					
 				*/
 				${from.wide} {
-					grid-template-columns: 219px 1px 1fr 300px;
 					${isPictureContent
 						? css`
+								grid-template-columns: 219px 1px 1fr;
+
 								grid-template-areas:
-									'title  border  headline    headline'
-									'lines  border  standfirst       standfirst'
-									'meta   border  media       media'
-									'meta   border  media       media'
-									'.      border  body        right-column'
-									'.      border  .           right-column';
+									'title  border  headline'
+									'lines  border  standfirst'
+									'meta   border  media'
+									'meta   border  media'
+									'.      border  body'
+									'.      border  .';
 						  `
 						: css`
+								grid-template-columns: 219px 1px 1fr 300px;
+
 								grid-template-areas:
 									'title  border  headline    headline'
 									'lines  border  media       media'
@@ -120,11 +123,11 @@ const ShowcaseGrid = ({
 						? css`
 								grid-template-areas:
 									'title  border  headline    headline'
-									'lines  border  standfirst       standfirst'
+									'lines  border  standfirst  standfirst'
 									'meta   border  media       media'
 									'meta   border  media       media'
-									'.      border  body        right-column'
-									'.      border  .           right-column';
+									'.      border  body        body'
+									'.      border  .           . ';
 						  `
 						: css`
 								grid-template-areas:
@@ -218,16 +221,16 @@ const ShowcaseGrid = ({
 	</div>
 );
 
-const maxWidth = css`
-	${from.desktop} {
+const maxWidth = (isPictureContent?: boolean) => css`
+	${!isPictureContent && from.desktop} {
 		max-width: 620px;
 	}
 `;
 
 const stretchLines = (isPictureContent: boolean) => css`
 	${!isPictureContent && until.phablet} {
-		margin-left: -30px;
-		margin-right: -30px;
+		margin-left: -20px;
+		margin-right: -20px;
 	}
 	${!isPictureContent && until.mobileLandscape} {
 		margin-left: -10px;
@@ -254,6 +257,8 @@ const PositionHeadline = ({
 	children: React.ReactNode;
 }) => {
 	switch (design) {
+		case ArticleDesign.Picture:
+			return <div>{children}</div>;
 		case ArticleDesign.Interview:
 			return (
 				<div
@@ -263,11 +268,11 @@ const PositionHeadline = ({
 						}
 					`}
 				>
-					<div css={maxWidth}>{children}</div>
+					<div css={maxWidth()}>{children}</div>
 				</div>
 			);
 		default:
-			return <div css={maxWidth}>{children}</div>;
+			return <div css={maxWidth()}>{children}</div>;
 	}
 };
 
@@ -580,7 +585,7 @@ export const ShowcaseLayout = ({
 							/>
 						</GridItem>
 						<GridItem area="lines">
-							<div css={maxWidth}>
+							<div css={maxWidth(isPictureContent)}>
 								<div css={stretchLines(isPictureContent)}>
 									<DecideLines
 										format={format}
@@ -590,7 +595,7 @@ export const ShowcaseLayout = ({
 							</div>
 						</GridItem>
 						<GridItem area="meta" element="aside">
-							<div css={maxWidth}>
+							<div css={maxWidth(isPictureContent)}>
 								<ArticleMeta
 									branding={branding}
 									format={format}

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -144,16 +144,33 @@ const ShowcaseGrid = ({
 					Right Column
 				*/
 				${until.leftCol} {
-					grid-template-columns: 1fr 300px;
-					grid-template-areas:
-						'title      right-column'
-						'headline   right-column'
-						'standfirst right-column'
-						'media      right-column'
-						'lines      right-column'
-						'meta       right-column'
-						'body       right-column'
-						'.          right-column';
+					${isPictureContent
+						? css`
+								grid-template-columns: 1fr; /* Main content */
+
+								grid-template-areas:
+									'title     '
+									'headline  '
+									'standfirst'
+									'media     '
+									'lines     '
+									'meta      '
+									'body      '
+									'.         ';
+						  `
+						: css`
+								grid-template-columns: 1fr 300px;
+
+								grid-template-areas:
+									'title      right-column'
+									'headline   right-column'
+									'standfirst right-column'
+									'media      right-column'
+									'lines      right-column'
+									'meta       right-column'
+									'body       right-column'
+									'.          right-column';
+						  `}
 				}
 
 				${until.desktop} {


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Tweaks showcase layout for picture content type.

Generally speaking this looks to use a isPictureContent boolean to make the relevant CSS decisions in the `showcaseLayout` - notably using a slightly different grid-template for most breakpoints. 

## Why?

Looks better this way! [The original PR](https://github.com/guardian/dotcom-rendering/pull/8562) didn't look great or completely correct (as in equal or on par with frontend) at certain breakpoints. E.g. on mobile, the ordering of the elements such as title and media is currently incorrect, and the image is missing a margin on the sides:
 
<img width="450" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/102960844/f9f13d56-303b-4aa2-ad5e-a014fce9433a">


## Screenshots

At each breakpoint, comparing the original frontend design to how DCR would look like with these tweaks:

| Frontend wide    | DCR wide      |
| ----------- | ---------- |
| ![fwide][] | ![dwide][] |

[fwide]:https://github.com/guardian/dotcom-rendering/assets/102960844/ff6ea3ee-5096-47ad-b9f4-fb41e5f5e792

[dwide]:https://github.com/guardian/dotcom-rendering/assets/102960844/19aa4186-5d53-4c7e-8cee-f59dff072327


| Frontend leftCol    | DCR leftCol      |
| ----------- | ---------- |
| ![fleftCol][] | ![dleftCol][] |

[fleftCol]:https://github.com/guardian/dotcom-rendering/assets/102960844/bd9c639a-6120-4064-84dc-e6779923417f
[dleftCol]:https://github.com/guardian/dotcom-rendering/assets/102960844/7006b3e2-a871-4193-b45e-293ffb2d0a48

| Frontend desktop    | DCR desktop      |
| ----------- | ---------- |
| ![fdesktop][] | ![ddesktop][] |

[fdesktop]:https://github.com/guardian/dotcom-rendering/assets/102960844/4274ab3a-6b47-47cf-860f-becac2f3a2c9
[ddesktop]:https://github.com/guardian/dotcom-rendering/assets/102960844/ffdfffca-9591-4498-b60f-22331743cca0

| Frontend tablet    | DCR tablet      |
| ----------- | ---------- |
| ![ftablet][] | ![dtablet][] |

[ftablet]:https://github.com/guardian/dotcom-rendering/assets/102960844/be4670ec-2b50-4efc-8c75-5aba3f9c0443
[dtablet]:https://github.com/guardian/dotcom-rendering/assets/102960844/8000ec2a-8c6c-4411-a0af-8db632c1a9de

| Frontend phablet    | DCR phablet      |
| ----------- | ---------- |
| ![fphablet][] | ![dphablet][] |

[fphablet]:https://github.com/guardian/dotcom-rendering/assets/102960844/6afe4882-2179-4d90-917e-e06781567e00
[dphablet]:https://github.com/guardian/dotcom-rendering/assets/102960844/3c028739-5f0e-4d07-aa2f-cfd75ffc957d

| Frontend mobile    | DCR mobile      |
| ----------- | ---------- |
| ![fmobile][] | ![dmobile][] |

[fmobile]:https://github.com/guardian/dotcom-rendering/assets/102960844/de127615-5939-4ab5-a882-213528a7a5fc
[dmobile]:https://github.com/guardian/dotcom-rendering/assets/102960844/2e467b57-f0e8-4ce2-b9f4-c6622e8ccd15




<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
