### PR TITLE
Don't run pm2 as root

### DIFF
--- a/dotcom-rendering/cdk/lib/__snapshots__/dotcom-rendering.test.ts.snap
+++ b/dotcom-rendering/cdk/lib/__snapshots__/dotcom-rendering.test.ts.snap
@@ -879,7 +879,7 @@ export GU_STAGE=\${Stage}
 mkdir /var/log/dotcom-rendering
 chown -R dotcom-rendering:frontend /var/log/dotcom-rendering
 
-make start-prod
+sudo -u dotcom-rendering -g frontend make start-prod
 
 /opt/aws-kinesis-agent/configure-aws-kinesis-agent \${AWS::Region} \${ELKStream} /var/log/dotcom-rendering/dotcom-rendering.log
 ",

--- a/dotcom-rendering/cdk/lib/__snapshots__/dotcom-rendering.test.ts.snap
+++ b/dotcom-rendering/cdk/lib/__snapshots__/dotcom-rendering.test.ts.snap
@@ -879,7 +879,7 @@ export GU_STAGE=\${Stage}
 mkdir /var/log/dotcom-rendering
 chown -R dotcom-rendering:frontend /var/log/dotcom-rendering
 
-sudo -u dotcom-rendering -g frontend make start-prod
+sudo NODE_ENV=$NODE_ENV GU_STAGE=$GU_STAGE -u dotcom-rendering -g frontend make start-prod
 
 /opt/aws-kinesis-agent/configure-aws-kinesis-agent \${AWS::Region} \${ELKStream} /var/log/dotcom-rendering/dotcom-rendering.log
 ",

--- a/dotcom-rendering/cloudformation.yml
+++ b/dotcom-rendering/cloudformation.yml
@@ -121,7 +121,7 @@ Resources:
           mkdir /var/log/dotcom-rendering
           chown -R dotcom-rendering:frontend /var/log/dotcom-rendering
 
-          sudo -u dotcom-rendering -g frontend make start-prod
+          sudo NODE_ENV=$NODE_ENV GU_STAGE=$GU_STAGE -u dotcom-rendering -g frontend make start-prod
 
           /opt/aws-kinesis-agent/configure-aws-kinesis-agent ${AWS::Region} ${ELKStream} /var/log/dotcom-rendering/dotcom-rendering.log
 

--- a/dotcom-rendering/cloudformation.yml
+++ b/dotcom-rendering/cloudformation.yml
@@ -121,7 +121,7 @@ Resources:
           mkdir /var/log/dotcom-rendering
           chown -R dotcom-rendering:frontend /var/log/dotcom-rendering
 
-          make start-prod
+          sudo -u dotcom-rendering -g frontend make start-prod
 
           /opt/aws-kinesis-agent/configure-aws-kinesis-agent ${AWS::Region} ${ELKStream} /var/log/dotcom-rendering/dotcom-rendering.log
 

--- a/dotcom-rendering/makefile
+++ b/dotcom-rendering/makefile
@@ -62,7 +62,7 @@ start: install
 start-prod:
 	$(call log, "starting PROD server...")
 	@echo '' # just a spacer
-	NODE_ENV=production /usr/local/node/pm2 start --uid dotcom-rendering --gid frontend dist/server.js
+	NODE_ENV=production /usr/local/node/pm2 start dist/server.js
 	@echo '' # just a spacer
 	$(call log, "PROD server is running")
 


### PR DESCRIPTION
## What does this change?

We use [pm2](https://pm2.keymetrics.io/) as a process manager for production instances of DCR. 

pm2 runs as a daemon process which in turn creates the main application process for the application.

As part of looking into enabling cluster mode it became apparent that we currently run pm2 in the following configuration:

| process     | user      | group      |
| ----------- | ---------- | -- |
| pm2 daemon | root |  |
| pm2 application | dotcom-rendering | frontend |

This configuration has two issues:
1. security - the pm2 daemon is running as root which leaves us open to pm2 vulnerabilities having root access which goes against the [principle of least privilege](https://en.wikipedia.org/wiki/Principle_of_least_privilege)
2. cluster mode -  this configuration works in single process mode but when enabling cluster mode pm2 will not start as each application process requires access to runtime files in pm2's home location. These files are owned by root and not the `dotcom-rendering` user so pm2 refuses to start.

I don't see any reason for pm2 to run as root and everything works as expected on CODE with this change.

But would appreciate some extra eyes on this particularly:

- is there any reason that pm2 should run as root?
- do we ship the pm2 logs anywhere?

## Why?

- Give the least privilege required to pm2
- Enable cluster mode

## Screenshots

### Before

pm2 daemon process runs as root:

```
root        1446  0.0  4.4 641052 42108 ?        Ssl  10:52   0:03 PM2 v5.3.0: God Daemon (/etc/.pm2)
dotcom-+    1465  0.4 19.8 1018568 186596 ?      Ssl  10:52   0:42 node /home/dotcom-rendering/rendering/dist/server.js
```

.pm2 directory is in `/etc/.pm2` and owned by root

### After

pm2 daemon process runs as dotcom-rendering:

```
dotcom-+    1359  0.1  3.7 639136 34976 ?        Ssl  11:11   0:00 PM2 v5.3.0: God Daemon (/home/dotcom-rendering/.pm2)
dotcom-+    1374  1.9 17.7 1005868 166748 ?      Ssl  11:11   0:05 node /home/dotcom-rendering/rendering/dist/server.js
```

.pm2 directory is in `/home/dotcom-rendering/.pm2` and owned by dotcom-rendering