### PR TITLE
Scheduler for all

### DIFF
--- a/dotcom-rendering/scripts/test/build-check.js
+++ b/dotcom-rendering/scripts/test/build-check.js
@@ -28,12 +28,14 @@ const fileExists = async (glob) => {
 (async () => {
 	// Check that the manifest files exist
 	await fileExists('manifest.web.json');
+	await fileExists('manifest.web.scheduled.json');
 	await fileExists('manifest.web.legacy.json');
 	if (BUILD_VARIANT) await fileExists('manifest.web.variant.json');
 
 	// Check that the manifest files return values for all the chunks
 	const manifests = [
 		await loadJsonFile('./dist/manifest.web.json'),
+		await loadJsonFile('./dist/manifest.web.scheduled.json'),
 		await loadJsonFile('./dist/manifest.web.legacy.json'),
 	];
 	if (BUILD_VARIANT) {

--- a/dotcom-rendering/scripts/webpack/webpack.config.client.js
+++ b/dotcom-rendering/scripts/webpack/webpack.config.client.js
@@ -67,6 +67,7 @@ const getLoaders = (build) => {
 		case 'apps':
 			return swcLoader(['android >= 5', 'ios >= 12']);
 		case 'web.variant':
+		case 'web.scheduled':
 		case 'web':
 			return swcLoader(getBrowserTargets());
 	}
@@ -79,7 +80,7 @@ const getLoaders = (build) => {
 module.exports = ({ build, sessionId }) => ({
 	entry: {
 		index:
-			build === 'web.variant'
+			build === 'web.scheduled'
 				? './src/client/index.scheduled.ts'
 				: './src/client/index.ts',
 		debug: './src/client/debug/index.ts',

--- a/dotcom-rendering/scripts/webpack/webpack.config.js
+++ b/dotcom-rendering/scripts/webpack/webpack.config.js
@@ -138,6 +138,7 @@ const commonConfigs = ({ platform }) => ({
 /** @type {readonly Build[]} */
 const clientBuilds = [
 	'web',
+	'web.scheduled',
 	...((PROD && BUILD_VARIANT_SWITCH) || BUILD_VARIANT
 		? /** @type {const} */ (['web.variant'])
 		: []),

--- a/dotcom-rendering/src/lib/assets.test.ts
+++ b/dotcom-rendering/src/lib/assets.test.ts
@@ -3,6 +3,7 @@ import {
 	decideAssetOrigin,
 	WEB,
 	WEB_LEGACY_SCRIPT,
+	WEB_SCHEDULED_SCRIPT,
 	WEB_VARIANT_SCRIPT,
 } from './assets';
 
@@ -60,6 +61,9 @@ describe('regular expression to match files', () => {
 		expect(
 			'https://assets.guim.co.uk/assets/ophan.web.variant.abcdefghijklmnopqrst.js',
 		).toMatch(WEB_VARIANT_SCRIPT);
+		expect(
+			'https://assets.guim.co.uk/assets/ophan.web.scheduled.abcdefghijklmnopqrst.js',
+		).toMatch(WEB_SCHEDULED_SCRIPT);
 		expect(
 			'https://assets.guim.co.uk/assets/ophan.web.legacy.eb74205c979f58659ed7.js',
 		).toMatch(WEB_LEGACY_SCRIPT);

--- a/dotcom-rendering/src/lib/assets.ts
+++ b/dotcom-rendering/src/lib/assets.ts
@@ -64,7 +64,12 @@ const getManifest = (path: string): AssetHash => {
 	}
 };
 
-export type Build = 'apps' | 'web' | 'web.variant' | 'web.legacy';
+export type Build =
+	| 'apps'
+	| 'web'
+	| 'web.variant'
+	| 'web.scheduled'
+	| 'web.legacy';
 
 type ManifestPath = `./manifest.${Build}.json`;
 
@@ -108,6 +113,7 @@ const getScriptRegex = (build: Build) =>
 export const WEB = getScriptRegex('web');
 export const WEB_VARIANT_SCRIPT = getScriptRegex('web.variant');
 export const WEB_LEGACY_SCRIPT = getScriptRegex('web.legacy');
+export const WEB_SCHEDULED_SCRIPT = getScriptRegex('web.scheduled');
 export const APPS_SCRIPT = getScriptRegex('apps');
 
 export const generateScriptTags = (scripts: string[]): string[] =>
@@ -131,12 +137,16 @@ export const generateScriptTags = (scripts: string[]): string[] =>
 
 export const getModulesBuild = ({
 	tests,
+	switches,
 }: {
 	tests: ServerSideTests;
 	switches: Switches;
-}): Extract<Build, 'web' | 'web.variant'> => {
+}): Extract<Build, 'web' | 'web.variant' | 'web.scheduled'> => {
 	if (BUILD_VARIANT && tests[dcrJavascriptBundle('Variant')] === 'variant') {
 		return 'web.variant';
+	}
+	if (switches.scheduler) {
+		return 'web.scheduled';
 	}
 	return 'web';
 };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

- Unify the naming of various builds
- Serve the scheduler to all users, but keep it behind a switch in case we need to turn it off

## Why?

We have confirmed that the 1% test has had no negative impact on Core Web Vitals on key engagement metrics.

## Screenshots

Deployed on CODE

| On | Off |
|--------|--------|
| <img width="923" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/76776/0f8df261-1dcf-4fca-81f6-964f46a46b9a"> | <img width="925" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/76776/545ce32b-552b-49e2-9f36-d725155d6f86"> | 