### PR TITLE
fix: remove refreshInterval from useCommentCount

### DIFF
--- a/dotcom-rendering/src/lib/useCommentCount.ts
+++ b/dotcom-rendering/src/lib/useCommentCount.ts
@@ -46,10 +46,7 @@ export const useCommentCount = (
 	 */
 	const url = getUrl(discussionApiUrl, uniqueDiscussionIds);
 
-	const { data } = useApi<CommentCounts>(url, {
-		// Discussion reponses have a long cache (~300s)
-		refreshInterval: 27_000,
-	});
+	const { data } = useApi<CommentCounts>(url);
 
 	return data?.[shortUrl];
 };


### PR DESCRIPTION
## What does this change?
Removes the refresh interval. This isn't useful as the discussion API endpoint has a long cache, and the value to the reader not evident as it'll refetch values on refresh of a page.

It also might be the cause of some resource leaks we're seeing on the server that we would like to investigate.
