### PR TITLE
Less work when loading `iframe`s

### DIFF
--- a/dotcom-rendering/src/client/atomIframe.ts
+++ b/dotcom-rendering/src/client/atomIframe.ts
@@ -1,4 +1,4 @@
 import { updateIframeHeight } from './updateIframeHeight';
 
 export const atomIframe = (): Promise<void> =>
-	updateIframeHeight('.atom__iframe');
+	updateIframeHeight('iframe.atom__iframe');

--- a/dotcom-rendering/src/client/embedIframe.ts
+++ b/dotcom-rendering/src/client/embedIframe.ts
@@ -1,4 +1,4 @@
 import { updateIframeHeight } from './updateIframeHeight';
 
 export const embedIframe = (): Promise<void> =>
-	updateIframeHeight('.js-embed__iframe');
+	updateIframeHeight('iframe.js-embed__iframe');

--- a/dotcom-rendering/src/client/updateIframeHeight.tsx
+++ b/dotcom-rendering/src/client/updateIframeHeight.tsx
@@ -1,12 +1,21 @@
 type HeightEventType = { source: { name: string } };
 
-export const updateIframeHeight = (queryString: string): Promise<void> => {
-	const iframes: HTMLIFrameElement[] = [].slice.call(
-		document.querySelectorAll(queryString),
-	);
+type Message = {
+	type: string;
+	value: string;
+};
+
+export const updateIframeHeight = (
+	queryString: `iframe${string}`,
+): Promise<void> => {
+	const iframes = [
+		...document.querySelectorAll<HTMLIFrameElement>(queryString),
+	];
+
+	if (iframes.length === 0) return Promise.resolve();
 
 	window.addEventListener('message', (event) => {
-		const iframe: HTMLIFrameElement | undefined = iframes.find((i) => {
+		const iframe = iframes.find((i) => {
 			try {
 				return i.name === (event as HeightEventType).source.name;
 			} catch (e) {
@@ -15,27 +24,26 @@ export const updateIframeHeight = (queryString: string): Promise<void> => {
 		});
 		if (iframe) {
 			try {
-				const message = JSON.parse(event.data) as {
-					type: string;
-					value: string;
-				};
+				// eslint-disable-next-line @typescript-eslint/no-unsafe-argument -- we’re in a try-catch
+				const message = JSON.parse(event.data) as Message;
 				switch (message.type) {
 					case 'set-height':
 						iframe.height = message.value;
 						break;
 					default:
 				}
-				// eslint-disable-next-line no-empty
-			} catch (e) {}
+			} catch (e) {
+				// do nothing
+			}
 		}
 	});
 
 	for (const iframe of iframes) {
 		const src = (iframe.getAttribute('srcdoc') ?? '')
 			.replace(/<gu-script>/g, '<script>')
-
 			.replace(/<\/gu-script>/g, '<' + '/script>');
 		iframe.setAttribute('srcdoc', src);
 	}
+
 	return Promise.resolve();
 };


### PR DESCRIPTION
## What does this change?

Refactor `updateIframeHeight` to return early if no matching iframes are found.

Enforce the selector to starts with `iframe`, so we know that selected elements are instances of `HTMLIFrameElement`.

## Why?

We can reduce the amount of work necessary when there are no matching iframes on the page.

Discovered as part of #8529

## Screenshots

N/A