### PR TITLE
Prefetch script assets on HTML page responses

### DIFF
--- a/dotcom-rendering/src/server/index.allEditorialNewslettersPage.web.ts
+++ b/dotcom-rendering/src/server/index.allEditorialNewslettersPage.web.ts
@@ -1,6 +1,7 @@
 import type { RequestHandler } from 'express';
 import { enhanceNewslettersPage } from '../model/enhance-newsletters-page';
 import { validateAsAllEditorialNewslettersPageType } from '../model/validate';
+import { makePrefetchHeader } from './lib/header';
 import { recordTypeAndPlatform } from './lib/logging-store';
 import { renderEditorialNewslettersPage } from './render.allEditorialNewslettersPage.web';
 
@@ -11,6 +12,8 @@ export const handleAllEditorialNewslettersPage: RequestHandler = (
 	recordTypeAndPlatform('newsletters');
 	const feNewslettersData = validateAsAllEditorialNewslettersPageType(body);
 	const newslettersPage = enhanceNewslettersPage(feNewslettersData);
-	const html = renderEditorialNewslettersPage({ newslettersPage });
-	res.status(200).send(html);
+	const { html, clientScripts } = renderEditorialNewslettersPage({
+		newslettersPage,
+	});
+	res.status(200).set('Link', makePrefetchHeader(clientScripts)).send(html);
 };

--- a/dotcom-rendering/src/server/index.article.apps.ts
+++ b/dotcom-rendering/src/server/index.article.apps.ts
@@ -1,18 +1,8 @@
 import type { RequestHandler } from 'express';
 import { recordTypeAndPlatform } from '../server/lib/logging-store';
 import { enhanceArticleType } from './index.article.web';
+import { makePrefetchHeader } from './lib/header';
 import { renderArticle } from './render.article.apps';
-
-/**
- * Formats script paths as a Link header
- * @see https://datatracker.ietf.org/doc/html/rfc5988#section-5.5
- * @param scriptPaths - the script paths to include in the Link header
- */
-const makePrefetchHeader = (scriptPaths: string[]): string =>
-	scriptPaths.reduce(
-		(acc, scriptPath) => acc + `<${scriptPath}>; rel=prefetch,`,
-		'',
-	);
 
 export const handleAppsArticle: RequestHandler = ({ body }, res) => {
 	recordTypeAndPlatform('article', 'apps');

--- a/dotcom-rendering/src/server/index.article.web.ts
+++ b/dotcom-rendering/src/server/index.article.web.ts
@@ -11,6 +11,7 @@ import { validateAsArticleType } from '../model/validate';
 import { recordTypeAndPlatform } from '../server/lib/logging-store';
 import type { FEArticleBadgeType } from '../types/badge';
 import type { FEArticleType, FEBlocksRequest } from '../types/frontend';
+import { makePrefetchHeader } from './lib/header';
 import {
 	renderBlocks,
 	renderHtml,
@@ -75,11 +76,11 @@ export const enhanceArticleType = (body: unknown): FEArticleType => {
 export const handleArticle: RequestHandler = ({ body }, res) => {
 	recordTypeAndPlatform('article', 'web');
 	const article = enhanceArticleType(body);
-	const resp = renderHtml({
+	const { html, clientScripts } = renderHtml({
 		article,
 	});
 
-	res.status(200).send(resp);
+	res.status(200).set('Link', makePrefetchHeader(clientScripts)).send(html);
 };
 
 export const handleArticleJson: RequestHandler = ({ body }, res) => {
@@ -104,11 +105,11 @@ export const handleArticlePerfTest: RequestHandler = (req, res, next) => {
 export const handleInteractive: RequestHandler = ({ body }, res) => {
 	recordTypeAndPlatform('interactive', 'web');
 	const article = enhanceArticleType(body);
-	const resp = renderHtml({
+	const { html, clientScripts } = renderHtml({
 		article,
 	});
 
-	res.status(200).send(resp);
+	res.status(200).set('Link', makePrefetchHeader(clientScripts)).send(html);
 };
 
 export const handleBlocks: RequestHandler = ({ body }, res) => {

--- a/dotcom-rendering/src/server/index.front.web.ts
+++ b/dotcom-rendering/src/server/index.front.web.ts
@@ -13,6 +13,7 @@ import { validateAsFrontType, validateAsTagFrontType } from '../model/validate';
 import { recordTypeAndPlatform } from '../server/lib/logging-store';
 import type { DCRFrontType, FEFrontType } from '../types/front';
 import type { DCRTagFrontType, FETagFrontType } from '../types/tagFront';
+import { makePrefetchHeader } from './lib/header';
 import { renderFront, renderTagFront } from './render.front.web';
 
 const enhanceFront = (body: unknown): DCRFrontType => {
@@ -91,10 +92,10 @@ const enhanceTagFront = (body: unknown): DCRTagFrontType => {
 export const handleFront: RequestHandler = ({ body }, res) => {
 	recordTypeAndPlatform('front');
 	const front = enhanceFront(body);
-	const html = renderFront({
+	const { html, clientScripts } = renderFront({
 		front,
 	});
-	res.status(200).send(html);
+	res.status(200).set('Link', makePrefetchHeader(clientScripts)).send(html);
 };
 
 export const handleFrontJson: RequestHandler = ({ body }, res) => {
@@ -104,10 +105,10 @@ export const handleFrontJson: RequestHandler = ({ body }, res) => {
 export const handleTagFront: RequestHandler = ({ body }, res) => {
 	recordTypeAndPlatform('tagFront');
 	const tagFront = enhanceTagFront(body);
-	const html = renderTagFront({
+	const { html, clientScripts } = renderTagFront({
 		tagFront,
 	});
-	res.status(200).send(html);
+	res.status(200).set('Link', makePrefetchHeader(clientScripts)).send(html);
 };
 
 export const handleTagFrontJson: RequestHandler = ({ body }, res) => {

--- a/dotcom-rendering/src/server/lib/header.ts
+++ b/dotcom-rendering/src/server/lib/header.ts
@@ -1,0 +1,10 @@
+/**
+ * Formats script paths as a Link header
+ * @see https://datatracker.ietf.org/doc/html/rfc5988#section-5.5
+ * @param scriptPaths - the script paths to include in the Link header
+ */
+export const makePrefetchHeader = (scriptPaths: string[]): string =>
+	scriptPaths.reduce(
+		(acc, scriptPath) => acc + `<${scriptPath}>; rel=prefetch,`,
+		'',
+	);

--- a/dotcom-rendering/src/server/render.allEditorialNewslettersPage.web.tsx
+++ b/dotcom-rendering/src/server/render.allEditorialNewslettersPage.web.tsx
@@ -18,7 +18,7 @@ interface Props {
 
 export const renderEditorialNewslettersPage = ({
 	newslettersPage,
-}: Props): string => {
+}: Props): { html: string; clientScripts: string[] } => {
 	const title = newslettersPage.webTitle;
 	const NAV = extractNAV(newslettersPage.nav);
 
@@ -45,17 +45,16 @@ export const renderEditorialNewslettersPage = ({
 	 * Please talk to the dotcom platform team before adding more.
 	 * Scripts will be executed in the order they appear in this array
 	 */
-	const scriptTags = generateScriptTags(
-		[
-			polyfillIO,
-			getPathFromManifest(build, 'frameworks.js'),
-			getPathFromManifest(build, 'index.js'),
-			getPathFromManifest('web.legacy', 'frameworks.js'),
-			getPathFromManifest('web.legacy', 'index.js'),
-			process.env.COMMERCIAL_BUNDLE_URL ??
-				newslettersPage.config.commercialBundleUrl,
-		].map((script) => (offerHttp3 ? getHttp3Url(script) : script)),
-	);
+	const clientScripts = [
+		polyfillIO,
+		getPathFromManifest(build, 'frameworks.js'),
+		getPathFromManifest(build, 'index.js'),
+		getPathFromManifest('web.legacy', 'frameworks.js'),
+		getPathFromManifest('web.legacy', 'index.js'),
+		process.env.COMMERCIAL_BUNDLE_URL ??
+			newslettersPage.config.commercialBundleUrl,
+	].map((script) => (offerHttp3 ? getHttp3Url(script) : script));
+	const scriptTags = generateScriptTags(clientScripts);
 
 	const guardian = createGuardian({
 		editionId: newslettersPage.editionId,
@@ -75,7 +74,7 @@ export const renderEditorialNewslettersPage = ({
 		googleRecaptchaSiteKey: newslettersPage.config.googleRecaptchaSiteKey,
 	});
 
-	return htmlPageTemplate({
+	const pageHtml = htmlPageTemplate({
 		scriptTags,
 		css: extractedCss,
 		html,
@@ -87,4 +86,8 @@ export const renderEditorialNewslettersPage = ({
 		renderingTarget: 'Web',
 		weAreHiring: !!newslettersPage.config.switches.weAreHiring,
 	});
+	return {
+		html: pageHtml,
+		clientScripts,
+	};
 };

--- a/dotcom-rendering/src/server/render.article.web.tsx
+++ b/dotcom-rendering/src/server/render.article.web.tsx
@@ -34,7 +34,9 @@ const decideTitle = (article: FEArticleType): string => {
 	return `${article.headline} | ${article.sectionLabel} | The Guardian`;
 };
 
-export const renderHtml = ({ article }: Props): string => {
+export const renderHtml = ({
+	article,
+}: Props): { html: string; clientScripts: string[] } => {
 	const NAV = {
 		...extractNAV(article.nav),
 		selectedPillar: getCurrentPillar(article),
@@ -90,21 +92,19 @@ export const renderHtml = ({ article }: Props): string => {
 	 * Please talk to the dotcom platform team before adding more.
 	 * Scripts will be executed in the order they appear in this array
 	 */
-	const scriptTags = generateScriptTags(
-		[
-			polyfillIO,
-			getPathFromManifest(build, 'frameworks.js'),
-			getPathFromManifest(build, 'index.js'),
-			getPathFromManifest('web.legacy', 'frameworks.js'),
-			getPathFromManifest('web.legacy', 'index.js'),
-			process.env.COMMERCIAL_BUNDLE_URL ??
-				article.config.commercialBundleUrl,
-			pageHasNonBootInteractiveElements &&
-				`${ASSET_ORIGIN}static/frontend/js/curl-with-js-and-domReady.js`,
-		]
-			.filter(isString)
-			.map((script) => (offerHttp3 ? getHttp3Url(script) : script)),
-	);
+	const clientScripts = [
+		polyfillIO,
+		getPathFromManifest(build, 'frameworks.js'),
+		getPathFromManifest(build, 'index.js'),
+		getPathFromManifest('web.legacy', 'frameworks.js'),
+		getPathFromManifest('web.legacy', 'index.js'),
+		process.env.COMMERCIAL_BUNDLE_URL ?? article.config.commercialBundleUrl,
+		pageHasNonBootInteractiveElements &&
+			`${ASSET_ORIGIN}static/frontend/js/curl-with-js-and-domReady.js`,
+	]
+		.filter(isString)
+		.map((script) => (offerHttp3 ? getHttp3Url(script) : script));
+	const scriptTags = generateScriptTags(clientScripts);
 
 	/**
 	 * We escape windowGuardian here to prevent errors when the data
@@ -195,7 +195,7 @@ window.twttr = (function(d, s, id) {
 
 	const { canonicalUrl } = article;
 
-	return htmlPageTemplate({
+	const pageHtml = htmlPageTemplate({
 		linkedData,
 		scriptTags,
 		css: extractedCss,
@@ -216,6 +216,8 @@ window.twttr = (function(d, s, id) {
 		renderingTarget: 'Web',
 		weAreHiring: !!article.config.switches.weAreHiring,
 	});
+
+	return { html: pageHtml, clientScripts };
 };
 
 /**

--- a/dotcom-rendering/src/server/render.front.web.tsx
+++ b/dotcom-rendering/src/server/render.front.web.tsx
@@ -69,7 +69,9 @@ const extractFrontNav = (front: DCRFrontType): NavType => {
 	};
 };
 
-export const renderFront = ({ front }: Props): string => {
+export const renderFront = ({
+	front,
+}: Props): { html: string; clientScripts: string[] } => {
 	const title = front.webTitle;
 	const NAV = extractFrontNav(front);
 
@@ -93,19 +95,17 @@ export const renderFront = ({ front }: Props): string => {
 	 * Please talk to the dotcom platform team before adding more.
 	 * Scripts will be executed in the order they appear in this array
 	 */
-	const scriptTags = generateScriptTags(
-		[
-			polyfillIO,
-			getPathFromManifest(build, 'frameworks.js'),
-			getPathFromManifest(build, 'index.js'),
-			getPathFromManifest('web.legacy', 'frameworks.js'),
-			getPathFromManifest('web.legacy', 'index.js'),
-			process.env.COMMERCIAL_BUNDLE_URL ??
-				front.config.commercialBundleUrl,
-		]
-			.filter(isString)
-			.map((script) => (offerHttp3 ? getHttp3Url(script) : script)),
-	);
+	const clientScripts = [
+		polyfillIO,
+		getPathFromManifest(build, 'frameworks.js'),
+		getPathFromManifest(build, 'index.js'),
+		getPathFromManifest('web.legacy', 'frameworks.js'),
+		getPathFromManifest('web.legacy', 'index.js'),
+		process.env.COMMERCIAL_BUNDLE_URL ?? front.config.commercialBundleUrl,
+	]
+		.filter(isString)
+		.map((script) => (offerHttp3 ? getHttp3Url(script) : script));
+	const scriptTags = generateScriptTags(clientScripts);
 
 	const guardian = createGuardian({
 		editionId: front.editionId,
@@ -130,7 +130,7 @@ export const renderFront = ({ front }: Props): string => {
 
 	const keywords = front.config.keywords;
 
-	return htmlPageTemplate({
+	const pageHtml = htmlPageTemplate({
 		scriptTags,
 		css: extractedCss,
 		html,
@@ -143,13 +143,18 @@ export const renderFront = ({ front }: Props): string => {
 		hasPageSkin: front.config.hasPageSkin,
 		weAreHiring: !!front.config.switches.weAreHiring,
 	});
+
+	return {
+		html: pageHtml,
+		clientScripts,
+	};
 };
 
 export const renderTagFront = ({
 	tagFront,
 }: {
 	tagFront: DCRTagFrontType;
-}): string => {
+}): { html: string; clientScripts: string[] } => {
 	const title = tagFront.webTitle;
 	const NAV = extractNAV(tagFront.nav);
 
@@ -173,19 +178,18 @@ export const renderTagFront = ({
 	 * Please talk to the dotcom platform team before adding more.
 	 * Scripts will be executed in the order they appear in this array
 	 */
-	const scriptTags = generateScriptTags(
-		[
-			polyfillIO,
-			getPathFromManifest(build, 'frameworks.js'),
-			getPathFromManifest(build, 'index.js'),
-			getPathFromManifest('web.legacy', 'frameworks.js'),
-			getPathFromManifest('web.legacy', 'index.js'),
-			process.env.COMMERCIAL_BUNDLE_URL ??
-				tagFront.config.commercialBundleUrl,
-		]
-			.filter(isString)
-			.map((script) => (offerHttp3 ? getHttp3Url(script) : script)),
-	);
+	const clientScripts = [
+		polyfillIO,
+		getPathFromManifest(build, 'frameworks.js'),
+		getPathFromManifest(build, 'index.js'),
+		getPathFromManifest('web.legacy', 'frameworks.js'),
+		getPathFromManifest('web.legacy', 'index.js'),
+		process.env.COMMERCIAL_BUNDLE_URL ??
+			tagFront.config.commercialBundleUrl,
+	]
+		.filter(isString)
+		.map((script) => (offerHttp3 ? getHttp3Url(script) : script));
+	const scriptTags = generateScriptTags(clientScripts);
 
 	const guardian = createGuardian({
 		editionId: tagFront.editionId,
@@ -210,7 +214,7 @@ export const renderTagFront = ({
 
 	const keywords = tagFront.config.keywords;
 
-	return htmlPageTemplate({
+	const pageHtml = htmlPageTemplate({
 		scriptTags,
 		css: extractedCss,
 		html,
@@ -222,4 +226,8 @@ export const renderTagFront = ({
 		renderingTarget: 'Web',
 		weAreHiring: !!tagFront.config.switches.weAreHiring,
 	});
+	return {
+		html: pageHtml,
+		clientScripts,
+	};
 };


### PR DESCRIPTION
DCR rendered pages link to some high priority static script assets. We can improve the loading of these by using the `Link` header, which instructs the browser to prefetch them. Frontend transparently passes the `Link` header from DCR's response to the client [^1].

See [^2] for more information about `Link`.

Part of https://github.com/guardian/dotcom-rendering/issues/8550.

[^1]: https://github.com/guardian/frontend/blob/main/common/app/renderers/DotcomRenderingService.scala
[^2]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Link