### PR TITLE
fix: remove stray console.info from prod-server

### DIFF
--- a/dotcom-rendering/src/server/prod-server.ts
+++ b/dotcom-rendering/src/server/prod-server.ts
@@ -36,9 +36,6 @@ const logRenderTime = responseTime(
 		logger.info('Page render time', {
 			renderTime,
 		});
-		console.info('Page render time', {
-			renderTime,
-		});
 	},
 );
 


### PR DESCRIPTION
## What does this change?
Removes a stray `console.info` introduced [here](https://github.com/guardian/dotcom-rendering/commit/4477ae6e6799bec478c62a5cc1f661491b3ee802#diff-13cffd924db463a64b4901c657b556b42dca8b39220d505889071fea9dbdd34bR39-R41).

Thanks @arelra [for surfacing it](https://github.com/guardian/dotcom-rendering/pull/8653#pullrequestreview-1591220647)!
