### PR TITLE
CDK - migrate scaling policies from cloudformation

### DIFF
--- a/dotcom-rendering/cdk/lib/__snapshots__/dotcom-rendering.test.ts.snap
+++ b/dotcom-rendering/cdk/lib/__snapshots__/dotcom-rendering.test.ts.snap
@@ -850,7 +850,9 @@ exports[`The DotcomRendering stack matches the snapshot 1`] = `
       "Condition": "HasLatencyScalingAlarm",
       "Properties": {
         "AlarmActions": [
-          "ScaleUpPolicy",
+          {
+            "Ref": "ScaleUpPolicy",
+          },
         ],
         "AlarmDescription": {
           "Fn::Sub": "Scale-Up if latency is greater than 0.2 seconds over 1 period(s) of 60 seconds
@@ -869,7 +871,9 @@ exports[`The DotcomRendering stack matches the snapshot 1`] = `
         "MetricName": "Latency",
         "Namespace": "AWS/ELB",
         "OKActions": [
-          "ScaleDownPolicy",
+          {
+            "Ref": "ScaleDownPolicy",
+          },
         ],
         "Period": 60,
         "Statistic": "Average",

--- a/dotcom-rendering/cdk/lib/dotcom-rendering.ts
+++ b/dotcom-rendering/cdk/lib/dotcom-rendering.ts
@@ -252,8 +252,8 @@ export class DotcomRendering extends GuStack {
 				AutoscalingGroup: asg.autoScalingGroupName,
 				InternalLoadBalancer: loadBalancer.loadBalancerName,
 				InstanceRole: instanceRole.roleName,
-				ScaleUpPolicy: scaleUpPolicy.logicalId,
-				ScaleDownPolicy: scaleDownPolicy.logicalId,
+				ScaleUpPolicy: scaleUpPolicy.ref,
+				ScaleDownPolicy: scaleDownPolicy.ref,
 			},
 		});
 

--- a/dotcom-rendering/cloudformation.yml
+++ b/dotcom-rendering/cloudformation.yml
@@ -52,11 +52,11 @@ Parameters:
     Description: Name of instance role
     Type: String
   ScaleDownPolicy:
-    Description: Id of scale down policy
-    Type: String
+    Description: Ref of scale down policy
+    Type: AWS::AutoScaling::ScalingPolicy
   ScaleUpPolicy:
-    Description: Id of scale up policy
-    Type: String
+    Description: Ref of scale up policy
+    Type: AWS::AutoScaling::ScalingPolicy
   # ! These params are not used but should be kept until the migration is finished
   ELKStream:
     Description: name of the kinesis stream to use to send logs to the central ELK stack


### PR DESCRIPTION
## What does this change?
Migrates `ScaleUpPolicy` and `ScaleDownPolicy` from Cloudformation to CDK

Resolves #7635, resolves #7634

This PR supersedes and cherry-picks commits from #8514 and #8631 


## Why?
Part of our migration to [CDK](https://github.com/guardian/dotcom-rendering/issues/7614)
