### PR TITLE
Refactor `relativeTime` slightly

### DIFF
--- a/dotcom-rendering/src/client/relativeTime/index.ts
+++ b/dotcom-rendering/src/client/relativeTime/index.ts
@@ -2,9 +2,7 @@ import { updateTimeElements } from './updateTimeElements';
 
 export const relativeTime = (): Promise<void> => {
 	updateTimeElements();
-	window.setInterval(() => {
-		updateTimeElements();
-	}, 15000);
+	setInterval(updateTimeElements, 15000);
 
 	return Promise.resolve();
 };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Remove unnecessary brackets and anonymous function from `relativeTime`.

## Why?

Noticed as part of the #8529.

## Screenshots

N/A

## Known issues

The server time before the first invocation of relativeTime will **almost always be wrong**, as the page is served from cache. It would probably make more sense to always send absolute times from the server, and make them relative if we are confident the user has JavaScript enabled.