### PR TITLE
Scheduler: meaningful `initDiscussion` duration

### DIFF
--- a/dotcom-rendering/src/client/discussion.ts
+++ b/dotcom-rendering/src/client/discussion.ts
@@ -2,7 +2,7 @@ import { doHydration } from './islands/doHydration';
 import { getEmotionCache } from './islands/emotion';
 import { getProps } from './islands/getProps';
 
-function forceHydration() {
+const forceHydration = async (): Promise<void> => {
 	try {
 		const name = 'DiscussionContainer';
 
@@ -19,21 +19,18 @@ function forceHydration() {
 		props.expanded = true;
 
 		// Force hydration
-		void doHydration(name, props, guElement, getEmotionCache());
+		await doHydration(name, props, guElement, getEmotionCache());
 	} catch (err) {
 		// Do nothing
 	}
-}
+};
 
-export const discussion = (): Promise<void> => {
-	/**
-	 * If we have either a #comment-123456 permalink or the #comments link in the url
-	 * then we want to hydrate and expand the discussion without waiting for the
-	 * reader to scroll down to it
-	 *
-	 */
-	const hashLink = window.location.hash;
-	if (hashLink.includes('comment')) forceHydration();
-
-	return Promise.resolve();
+/**
+ * If we have either a #comment-123456 permalink or the #comments link in the url
+ * then we want to hydrate and expand the discussion without waiting for the
+ * reader to scroll down to it
+ *
+ */
+export const discussion = async (): Promise<void> => {
+	if (window.location.hash.startsWith('#comment')) await forceHydration();
 };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Await hydration step in its entirety before reporting the boot/startup of `initDiscussion` as completed.

## Why?

Part of #8529 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/76776/1b361994-6ece-472d-b05e-b8c438bbe309
[after]: https://github.com/guardian/dotcom-rendering/assets/76776/15d4bd58-5ca0-4858-88f7-f6be2e967acc
