### PR TITLE
AB test: Insert two sets of inline ad slots server-side on liveblogs

### DIFF
--- a/dotcom-rendering/src/components/AdSlot.tsx
+++ b/dotcom-rendering/src/components/AdSlot.tsx
@@ -19,6 +19,7 @@ type InlinePosition =
 	| 'fronts-banner'
 	| 'inline'
 	| 'liveblog-inline'
+	| 'liveblog-inline-mobile'
 	| 'liveblog-right'
 	| 'mobile-front';
 
@@ -204,6 +205,7 @@ const merchandisingAdStyles = css`
 
 const inlineAdStyles = css`
 	position: relative;
+
 	${until.tablet} {
 		display: none;
 	}
@@ -211,6 +213,22 @@ const inlineAdStyles = css`
 
 const liveblogInlineAdStyles = css`
 	position: relative;
+	min-height: ${adSizes.mpu.height + constants.AD_LABEL_HEIGHT}px;
+	background-color: ${palette.neutral[93]};
+
+	${until.tablet} {
+		display: none;
+	}
+`;
+
+const liveblogInlineMobileAdStyles = css`
+	position: relative;
+	min-height: ${adSizes.outstreamMobile.height + constants.AD_LABEL_HEIGHT}px;
+	background-color: ${palette.neutral[93]};
+
+	${from.tablet} {
+		display: none;
+	}
 `;
 
 const mobileFrontAdStyles = css`
@@ -678,6 +696,27 @@ export const AdSlot = ({
 							'ad-slot--rendered',
 						].join(' ')}
 						css={[liveblogInlineAdStyles]}
+						data-link-name={`ad slot ${advertId}`}
+						data-name={advertId}
+						aria-hidden="true"
+					/>
+				</div>
+			);
+		}
+		case 'liveblog-inline-mobile': {
+			const advertId = `inline${index}`;
+			return (
+				<div className="ad-slot-container" css={[adContainerStyles]}>
+					<div
+						id={`dfp-ad--${advertId}--mobile`}
+						className={[
+							'js-ad-slot',
+							'ad-slot',
+							`ad-slot--${advertId}`,
+							`ad-slot--liveblog-inline--mobile`,
+							'ad-slot--rendered',
+						].join(' ')}
+						css={[liveblogInlineMobileAdStyles]}
 						data-link-name={`ad slot ${advertId}`}
 						data-name={advertId}
 						aria-hidden="true"

--- a/dotcom-rendering/src/components/ArticleContainer.tsx
+++ b/dotcom-rendering/src/components/ArticleContainer.tsx
@@ -1,5 +1,4 @@
 import { css } from '@emotion/react';
-import { adSizes, constants } from '@guardian/commercial';
 import { ArticleDesign } from '@guardian/libs';
 import { from, neutral, space, until } from '@guardian/source-foundations';
 import { carrotAdStyles, labelStyles } from './AdSlot';
@@ -120,19 +119,6 @@ const adStyles = css`
 				/* must be behind as the actual ad is on top of the iframe */
 				z-index: -1;
 			}
-		}
-
-		/* liveblogs ads have different background colours due the darker page background */
-		.ad-slot--liveblog-inline {
-			/* outstreamMobile is the ad with the smallest height that we serve for mobile
-			   liveblog-inline slots. For desktop, this is an mpu */
-			min-height: ${adSizes.outstreamMobile.height +
-			constants.AD_LABEL_HEIGHT}px;
-			${from.desktop} {
-				min-height: ${adSizes.mpu.height + constants.AD_LABEL_HEIGHT}px;
-			}
-
-			background-color: ${neutral[93]};
 		}
 	}
 

--- a/dotcom-rendering/src/components/LiveBlogBlocksAndAdverts.tsx
+++ b/dotcom-rendering/src/components/LiveBlogBlocksAndAdverts.tsx
@@ -59,49 +59,49 @@ export const LiveBlogBlocksAndAdverts = ({
 		);
 	}
 
-	let pixelsSinceAdMobile = 0;
+	let pxSinceAdMobile = 0;
 	let mobileAdCounter = 0;
 
-	let pixelsSinceAdLargeScreen = 0;
-	let largeScreenAdCounter = 0;
+	let pxSinceAdDesktop = 0;
+	let desktopAdCounter = 0;
 
 	return (
 		<>
 			{blocks.map((block, i) => {
-				pixelsSinceAdMobile += calculateApproximateBlockHeight(
+				pxSinceAdMobile += calculateApproximateBlockHeight(
 					block.elements,
 					true,
 				);
-				const willinsertAdOnSmallScreens =
+				const willinsertAdMobile =
 					!isAdFreeUser &&
 					shouldDisplayAd(
 						i + 1,
 						blocks.length,
 						mobileAdCounter,
-						pixelsSinceAdMobile,
+						pxSinceAdMobile,
 						true,
 					);
-				if (willinsertAdOnSmallScreens) {
+				if (willinsertAdMobile) {
 					mobileAdCounter++;
-					pixelsSinceAdMobile = 0;
+					pxSinceAdMobile = 0;
 				}
 
-				pixelsSinceAdLargeScreen += calculateApproximateBlockHeight(
+				pxSinceAdDesktop += calculateApproximateBlockHeight(
 					block.elements,
 					false,
 				);
-				const willinsertAdOnLargeScreens =
+				const willinsertAdDesktop =
 					!isAdFreeUser &&
 					shouldDisplayAd(
 						i + 1,
 						blocks.length,
-						largeScreenAdCounter,
-						pixelsSinceAdLargeScreen,
+						desktopAdCounter,
+						pxSinceAdDesktop,
 						false,
 					);
-				if (willinsertAdOnLargeScreens) {
-					largeScreenAdCounter++;
-					pixelsSinceAdLargeScreen = 0;
+				if (willinsertAdDesktop) {
+					desktopAdCounter++;
+					pxSinceAdDesktop = 0;
 				}
 
 				return (
@@ -121,16 +121,16 @@ export const LiveBlogBlocksAndAdverts = ({
 							isPinnedPost={false}
 							pinnedPostId={pinnedPost?.id}
 						/>
-						{willinsertAdOnSmallScreens && (
+						{willinsertAdMobile && (
 							<AdSlot
 								position="liveblog-inline-mobile"
 								index={mobileAdCounter}
 							/>
 						)}
-						{willinsertAdOnLargeScreens && (
+						{willinsertAdDesktop && (
 							<AdSlot
 								position="liveblog-inline"
-								index={largeScreenAdCounter}
+								index={desktopAdCounter}
 							/>
 						)}
 					</>

--- a/dotcom-rendering/src/components/LiveBlogBlocksAndAdverts.tsx
+++ b/dotcom-rendering/src/components/LiveBlogBlocksAndAdverts.tsx
@@ -59,27 +59,49 @@ export const LiveBlogBlocksAndAdverts = ({
 		);
 	}
 
-	let numPixelsOfContentWithoutAdvert = 0;
-	let numAdvertsInserted = 0;
+	let pixelsSinceAdMobile = 0;
+	let mobileAdCounter = 0;
+
+	let pixelsSinceAdLargeScreen = 0;
+	let largeScreenAdCounter = 0;
 
 	return (
 		<>
 			{blocks.map((block, i) => {
-				numPixelsOfContentWithoutAdvert +=
-					calculateApproximateBlockHeight(block.elements);
-
-				const willDisplayAdAfterBlock =
+				pixelsSinceAdMobile += calculateApproximateBlockHeight(
+					block.elements,
+					true,
+				);
+				const willinsertAdOnSmallScreens =
 					!isAdFreeUser &&
 					shouldDisplayAd(
 						i + 1,
 						blocks.length,
-						numAdvertsInserted,
-						numPixelsOfContentWithoutAdvert,
+						mobileAdCounter,
+						pixelsSinceAdMobile,
+						true,
 					);
+				if (willinsertAdOnSmallScreens) {
+					mobileAdCounter++;
+					pixelsSinceAdMobile = 0;
+				}
 
-				if (willDisplayAdAfterBlock) {
-					numAdvertsInserted++;
-					numPixelsOfContentWithoutAdvert = 0;
+				pixelsSinceAdLargeScreen += calculateApproximateBlockHeight(
+					block.elements,
+					false,
+				);
+				const willinsertAdOnLargeScreens =
+					!isAdFreeUser &&
+					shouldDisplayAd(
+						i + 1,
+						blocks.length,
+						largeScreenAdCounter,
+						pixelsSinceAdLargeScreen,
+						false,
+					);
+				if (willinsertAdOnLargeScreens) {
+					largeScreenAdCounter++;
+					pixelsSinceAdLargeScreen = 0;
 				}
 
 				return (
@@ -99,10 +121,16 @@ export const LiveBlogBlocksAndAdverts = ({
 							isPinnedPost={false}
 							pinnedPostId={pinnedPost?.id}
 						/>
-						{willDisplayAdAfterBlock && (
+						{willinsertAdOnSmallScreens && (
+							<AdSlot
+								position="liveblog-inline-mobile"
+								index={mobileAdCounter}
+							/>
+						)}
+						{willinsertAdOnLargeScreens && (
 							<AdSlot
 								position="liveblog-inline"
-								index={numAdvertsInserted}
+								index={largeScreenAdCounter}
 							/>
 						)}
 					</>

--- a/dotcom-rendering/src/components/LiveBlogBlocksAndAdverts.tsx
+++ b/dotcom-rendering/src/components/LiveBlogBlocksAndAdverts.tsx
@@ -72,7 +72,7 @@ export const LiveBlogBlocksAndAdverts = ({
 					block.elements,
 					true,
 				);
-				const willinsertAdMobile =
+				const willInsertAdMobile =
 					!isAdFreeUser &&
 					shouldDisplayAd(
 						i + 1,
@@ -81,7 +81,7 @@ export const LiveBlogBlocksAndAdverts = ({
 						pxSinceAdMobile,
 						true,
 					);
-				if (willinsertAdMobile) {
+				if (willInsertAdMobile) {
 					mobileAdCounter++;
 					pxSinceAdMobile = 0;
 				}
@@ -90,7 +90,7 @@ export const LiveBlogBlocksAndAdverts = ({
 					block.elements,
 					false,
 				);
-				const willinsertAdDesktop =
+				const willInsertAdDesktop =
 					!isAdFreeUser &&
 					shouldDisplayAd(
 						i + 1,
@@ -99,7 +99,7 @@ export const LiveBlogBlocksAndAdverts = ({
 						pxSinceAdDesktop,
 						false,
 					);
-				if (willinsertAdDesktop) {
+				if (willInsertAdDesktop) {
 					desktopAdCounter++;
 					pxSinceAdDesktop = 0;
 				}
@@ -121,13 +121,13 @@ export const LiveBlogBlocksAndAdverts = ({
 							isPinnedPost={false}
 							pinnedPostId={pinnedPost?.id}
 						/>
-						{willinsertAdMobile && (
+						{willInsertAdMobile && (
 							<AdSlot
 								position="liveblog-inline-mobile"
 								index={mobileAdCounter}
 							/>
 						)}
-						{willinsertAdDesktop && (
+						{willInsertAdDesktop && (
 							<AdSlot
 								position="liveblog-inline"
 								index={desktopAdCounter}

--- a/dotcom-rendering/src/lib/liveblogAdSlots.test.ts
+++ b/dotcom-rendering/src/lib/liveblogAdSlots.test.ts
@@ -5,7 +5,23 @@ import {
 } from './liveblogAdSlots';
 
 describe('calculateApproximateBlockHeight', () => {
-	const textElementOneLine: FEElement[] = [
+	const textElementOneLineDesktop: FEElement[] = [
+		{
+			elementId: '1',
+			_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+			html: `<p>${'a'.repeat(72)}</p>`,
+		},
+	];
+
+	const textElementTwoLinesDestkop: FEElement[] = [
+		{
+			elementId: '1',
+			_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+			html: `<p>${'a'.repeat(73)}</p>`,
+		},
+	];
+
+	const textElementOneLineMobile: FEElement[] = [
 		{
 			elementId: '1',
 			_type: 'model.dotcomrendering.pageElements.TextBlockElement',
@@ -13,7 +29,7 @@ describe('calculateApproximateBlockHeight', () => {
 		},
 	];
 
-	const textElementTwoLines: FEElement[] = [
+	const textElementTwoLinesMobile: FEElement[] = [
 		{
 			elementId: '1',
 			_type: 'model.dotcomrendering.pageElements.TextBlockElement',
@@ -25,12 +41,12 @@ describe('calculateApproximateBlockHeight', () => {
 		{
 			elementId: '1',
 			_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-			html: `<p>${'a'.repeat(70)}</p>`,
+			html: `<p>${'a'.repeat(38)}</p>`,
 		},
 		{
 			elementId: '2',
 			_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-			html: `<p>${'a'.repeat(70)}</p>`,
+			html: `<p>${'a'.repeat(38)}</p>`,
 		},
 	];
 
@@ -46,44 +62,101 @@ describe('calculateApproximateBlockHeight', () => {
 	];
 
 	const defaultBlockSpacing = 75;
-	const defaultElementSpacing = 12;
 
 	describe('zero elements', () => {
-		it('should return zero when there are zero elements', () => {
-			expect(calculateApproximateBlockHeight([], false)).toEqual(0);
+		describe('desktop', () => {
+			it('should return zero when there are zero elements', () => {
+				expect(calculateApproximateBlockHeight([], false)).toEqual(0);
+			});
+		});
+		describe('mobile', () => {
+			it('should return zero when there are zero elements', () => {
+				expect(calculateApproximateBlockHeight([], true)).toEqual(0);
+			});
 		});
 	});
 
 	describe('text block elements', () => {
-		const textLineHeight = 25.5;
+		describe('desktop', () => {
+			const textLineHeight = 23.8;
+			const margin = 14;
 
-		it('should return the correct height for varying line length', () => {
-			expect(
-				calculateApproximateBlockHeight(textElementOneLine, false),
-			).toEqual(
-				textLineHeight + defaultBlockSpacing + defaultElementSpacing,
-			);
-			expect(
-				calculateApproximateBlockHeight(textElementTwoLines, false),
-			).toEqual(
-				2 * textLineHeight +
-					defaultBlockSpacing +
-					defaultElementSpacing,
-			);
+			it('should return the correct height for varying line length', () => {
+				expect(
+					calculateApproximateBlockHeight(
+						textElementOneLineDesktop,
+						false,
+					),
+				).toEqual(textLineHeight + margin + defaultBlockSpacing);
+				expect(
+					calculateApproximateBlockHeight(
+						textElementTwoLinesDestkop,
+						false,
+					),
+				).toEqual(2 * textLineHeight + margin + defaultBlockSpacing);
+			});
+
+			it('should return the correct height when there are multiple elements', () => {
+				expect(
+					calculateApproximateBlockHeight(
+						multipleTextElements,
+						false,
+					),
+				).toEqual(
+					2 * textLineHeight + 2 * margin + defaultBlockSpacing,
+				);
+			});
 		});
 
-		it('should return the correct height when there are multiple elements', () => {
-			expect(
-				calculateApproximateBlockHeight(multipleTextElements, false),
-			).toEqual(201);
+		describe('mobile', () => {
+			const textLineHeight = 23.8;
+			const margin = 14;
+
+			it('should return the correct height for varying line length', () => {
+				expect(
+					calculateApproximateBlockHeight(
+						textElementOneLineMobile,
+						true,
+					),
+				).toEqual(textLineHeight + margin + defaultBlockSpacing);
+				expect(
+					calculateApproximateBlockHeight(
+						textElementTwoLinesMobile,
+						true,
+					),
+				).toEqual(2 * textLineHeight + margin + defaultBlockSpacing);
+			});
+
+			it('should return the correct height when there are multiple elements', () => {
+				expect(
+					calculateApproximateBlockHeight(multipleTextElements, true),
+				).toEqual(
+					2 * textLineHeight + 2 * margin + defaultBlockSpacing,
+				);
+			});
 		});
 	});
 
 	describe('youtube block elements', () => {
-		it('should return the correct height', () => {
-			expect(
-				calculateApproximateBlockHeight(youtubeElement, false),
-			).toEqual(239 + defaultBlockSpacing + defaultElementSpacing);
+		describe('desktop', () => {
+			it('should return the correct height', () => {
+				const heightExcludingText = 350;
+				const margin = 12;
+
+				expect(
+					calculateApproximateBlockHeight(youtubeElement, false),
+				).toEqual(heightExcludingText + margin + defaultBlockSpacing);
+			});
+		});
+		describe('mobile', () => {
+			it('should return the correct height', () => {
+				const heightExcludingText = 195;
+				const margin = 12;
+
+				expect(
+					calculateApproximateBlockHeight(youtubeElement, true),
+				).toEqual(heightExcludingText + margin + defaultBlockSpacing);
+			});
 		});
 	});
 });
@@ -112,15 +185,23 @@ describe('shouldDisplayAd', () => {
 		const numAdsInserted = 8;
 		const numPixelsWithoutAdvert = 5000;
 
-		const result = shouldDisplayAd(
+		const resultDesktop = shouldDisplayAd(
 			block,
 			totalBlocks,
 			numAdsInserted,
 			numPixelsWithoutAdvert,
 			false,
 		);
+		const resultMobile = shouldDisplayAd(
+			block,
+			totalBlocks,
+			numAdsInserted,
+			numPixelsWithoutAdvert,
+			true,
+		);
 
-		expect(result).toBeFalsy();
+		expect(resultDesktop).toBeFalsy();
+		expect(resultMobile).toBeFalsy();
 	});
 
 	describe('inserting the first ad slot', () => {
@@ -130,7 +211,14 @@ describe('shouldDisplayAd', () => {
 			const numAdsInserted = 0;
 			const numPixelsWithoutAdvert = 550;
 
-			const result = shouldDisplayAd(
+			const resultDesktop = shouldDisplayAd(
+				block,
+				totalBlocks,
+				numAdsInserted,
+				numPixelsWithoutAdvert,
+				false,
+			);
+			const resultMobile = shouldDisplayAd(
 				block,
 				totalBlocks,
 				numAdsInserted,
@@ -138,43 +226,81 @@ describe('shouldDisplayAd', () => {
 				false,
 			);
 
-			expect(result).toBeTruthy();
+			expect(resultDesktop).toBeTruthy();
+			expect(resultMobile).toBeTruthy();
 		});
 	});
 
 	describe('inserting further ad slots', () => {
-		it('should display ad if number of pixels without an ad is more than 1500', () => {
-			const block = 5;
-			const totalBlocks = 10;
-			const numAdsInserted = 1;
-			const numPixelsWithoutAdvert = 1550;
+		describe('desktop', () => {
+			it('should display ad if number of pixels without an ad is more than 1500', () => {
+				const block = 5;
+				const totalBlocks = 10;
+				const numAdsInserted = 1;
+				const numPixelsWithoutAdvert = 1550;
 
-			const result = shouldDisplayAd(
-				block,
-				totalBlocks,
-				numAdsInserted,
-				numPixelsWithoutAdvert,
-				false,
-			);
+				const result = shouldDisplayAd(
+					block,
+					totalBlocks,
+					numAdsInserted,
+					numPixelsWithoutAdvert,
+					false,
+				);
 
-			expect(result).toBeTruthy();
+				expect(result).toBeTruthy();
+			});
+
+			it('should NOT display ad if number of pixels without an ad is less than 1500', () => {
+				const block = 5;
+				const totalBlocks = 10;
+				const numAdsInserted = 1;
+				const numPixelsWithoutAdvert = 1450;
+
+				const result = shouldDisplayAd(
+					block,
+					totalBlocks,
+					numAdsInserted,
+					numPixelsWithoutAdvert,
+					false,
+				);
+
+				expect(result).toBeFalsy();
+			});
 		});
+		describe('mobile', () => {
+			it('should display ad if number of pixels without an ad is more than 1200', () => {
+				const block = 5;
+				const totalBlocks = 10;
+				const numAdsInserted = 1;
+				const numPixelsWithoutAdvert = 1250;
 
-		it('should NOT display ad if number of pixels without an ad is less than 1500', () => {
-			const block = 5;
-			const totalBlocks = 10;
-			const numAdsInserted = 1;
-			const numPixelsWithoutAdvert = 1450;
+				const result = shouldDisplayAd(
+					block,
+					totalBlocks,
+					numAdsInserted,
+					numPixelsWithoutAdvert,
+					true,
+				);
 
-			const result = shouldDisplayAd(
-				block,
-				totalBlocks,
-				numAdsInserted,
-				numPixelsWithoutAdvert,
-				false,
-			);
+				expect(result).toBeTruthy();
+			});
 
-			expect(result).toBeFalsy();
+			it('should NOT display ad if number of pixels without an ad is less than 1200', () => {
+				const block = 5;
+				const totalBlocks = 10;
+				const numAdsInserted = 1;
+				const numPixelsWithoutAdvert = 1150;
+
+				const result = shouldDisplayAd(
+					block,
+					totalBlocks,
+					numAdsInserted,
+					numPixelsWithoutAdvert,
+					true,
+				);
+
+				expect(result).toBeFalsy();
+			});
 		});
 	});
 });

--- a/dotcom-rendering/src/lib/liveblogAdSlots.test.ts
+++ b/dotcom-rendering/src/lib/liveblogAdSlots.test.ts
@@ -64,243 +64,197 @@ describe('calculateApproximateBlockHeight', () => {
 	const defaultBlockSpacing = 75;
 
 	describe('zero elements', () => {
-		describe('desktop', () => {
-			it('should return zero when there are zero elements', () => {
-				expect(calculateApproximateBlockHeight([], false)).toEqual(0);
-			});
-		});
-		describe('mobile', () => {
-			it('should return zero when there are zero elements', () => {
-				expect(calculateApproximateBlockHeight([], true)).toEqual(0);
-			});
-		});
+		it.each(['mobile', 'desktop'])(
+			'should return zero when there are zero elements on %s',
+			(screenSize) => {
+				const isMobile = screenSize === 'mobile';
+				expect(calculateApproximateBlockHeight([], isMobile)).toEqual(
+					0,
+				);
+			},
+		);
 	});
 
 	describe('text block elements', () => {
-		describe('desktop', () => {
-			const textLineHeight = 23.8;
-			const margin = 14;
+		const textLineHeight = 23.8;
+		const margin = 14;
 
-			it('should return the correct height for varying line length', () => {
+		it.each([
+			['mobile', textElementOneLineMobile, textElementTwoLinesMobile],
+			['desktop', textElementOneLineDesktop, textElementTwoLinesDestkop],
+		])(
+			'should return the correct height for varying line length on %s',
+			(screenSize, textElementOneLine, textElementTwoLines) => {
+				const isMobile = screenSize === 'mobile';
+
 				expect(
 					calculateApproximateBlockHeight(
-						textElementOneLineDesktop,
-						false,
+						textElementOneLine,
+						isMobile,
 					),
 				).toEqual(textLineHeight + margin + defaultBlockSpacing);
 				expect(
 					calculateApproximateBlockHeight(
-						textElementTwoLinesDestkop,
-						false,
+						textElementTwoLines,
+						isMobile,
 					),
 				).toEqual(2 * textLineHeight + margin + defaultBlockSpacing);
-			});
+			},
+		);
 
-			it('should return the correct height when there are multiple elements', () => {
+		it.each(['mobile', 'desktop'])(
+			'should return the correct height when there are multiple elements on %s',
+			(screenSize) => {
+				const isMobile = screenSize === 'mobile';
+
 				expect(
 					calculateApproximateBlockHeight(
 						multipleTextElements,
-						false,
+						isMobile,
 					),
 				).toEqual(
 					2 * textLineHeight + 2 * margin + defaultBlockSpacing,
 				);
-			});
-		});
-
-		describe('mobile', () => {
-			const textLineHeight = 23.8;
-			const margin = 14;
-
-			it('should return the correct height for varying line length', () => {
-				expect(
-					calculateApproximateBlockHeight(
-						textElementOneLineMobile,
-						true,
-					),
-				).toEqual(textLineHeight + margin + defaultBlockSpacing);
-				expect(
-					calculateApproximateBlockHeight(
-						textElementTwoLinesMobile,
-						true,
-					),
-				).toEqual(2 * textLineHeight + margin + defaultBlockSpacing);
-			});
-
-			it('should return the correct height when there are multiple elements', () => {
-				expect(
-					calculateApproximateBlockHeight(multipleTextElements, true),
-				).toEqual(
-					2 * textLineHeight + 2 * margin + defaultBlockSpacing,
-				);
-			});
-		});
+			},
+		);
 	});
 
 	describe('youtube block elements', () => {
-		describe('desktop', () => {
-			it('should return the correct height', () => {
-				const heightExcludingText = 350;
+		it.each([
+			['mobile', 195],
+			['desktop', 350],
+		])(
+			'should return the correct height on %s',
+			(screenSize, heightExcludingText) => {
+				const isMobile = screenSize === 'mobile';
 				const margin = 12;
 
 				expect(
-					calculateApproximateBlockHeight(youtubeElement, false),
+					calculateApproximateBlockHeight(youtubeElement, isMobile),
 				).toEqual(heightExcludingText + margin + defaultBlockSpacing);
-			});
-		});
-		describe('mobile', () => {
-			it('should return the correct height', () => {
-				const heightExcludingText = 195;
-				const margin = 12;
-
-				expect(
-					calculateApproximateBlockHeight(youtubeElement, true),
-				).toEqual(heightExcludingText + margin + defaultBlockSpacing);
-			});
-		});
+			},
+		);
 	});
 });
 
 describe('shouldDisplayAd', () => {
-	it('should NOT display an ad if this is the final block', () => {
-		const block = 5;
-		const totalBlocks = 5;
-		const numAdsInserted = 1;
-		const numPixelsWithoutAdvert = 5000;
+	describe('The final block of content', () => {
+		it.each(['mobile', 'desktop'])(
+			'should NOT display an ad if this is the final block on %s',
+			(screenSize) => {
+				const isMobile = screenSize === 'mobile';
 
-		const result = shouldDisplayAd(
-			block,
-			totalBlocks,
-			numAdsInserted,
-			numPixelsWithoutAdvert,
-			false,
+				const block = 5;
+				const totalBlocks = 5;
+				const numAdsInserted = 1;
+				const numPixelsWithoutAdvert = 5000;
+
+				const result = shouldDisplayAd(
+					block,
+					totalBlocks,
+					numAdsInserted,
+					numPixelsWithoutAdvert,
+					isMobile,
+				);
+
+				expect(result).toBeFalsy();
+			},
 		);
-
-		expect(result).toBeFalsy();
 	});
 
-	it('should NOT insert another ad slot if we have reached the limit.', () => {
-		const block = 5;
-		const totalBlocks = 10;
-		const numAdsInserted = 8;
-		const numPixelsWithoutAdvert = 5000;
+	describe('Reaching the ad limit', () => {
+		it.each(['mobile', 'desktop'])(
+			'should NOT insert another ad slot if we have reached the limit on %s.',
+			(screenSize) => {
+				const isMobile = screenSize === 'mobile';
+				const block = 5;
+				const totalBlocks = 10;
+				const numAdsInserted = 8;
+				const numPixelsWithoutAdvert = 5000;
 
-		const resultDesktop = shouldDisplayAd(
-			block,
-			totalBlocks,
-			numAdsInserted,
-			numPixelsWithoutAdvert,
-			false,
-		);
-		const resultMobile = shouldDisplayAd(
-			block,
-			totalBlocks,
-			numAdsInserted,
-			numPixelsWithoutAdvert,
-			true,
-		);
+				const result = shouldDisplayAd(
+					block,
+					totalBlocks,
+					numAdsInserted,
+					numPixelsWithoutAdvert,
+					isMobile,
+				);
 
-		expect(resultDesktop).toBeFalsy();
-		expect(resultMobile).toBeFalsy();
+				expect(result).toBeFalsy();
+			},
+		);
 	});
 
 	describe('inserting the first ad slot', () => {
-		it('should display ad if this is the first block', () => {
-			const block = 1;
-			const totalBlocks = 10;
-			const numAdsInserted = 0;
-			const numPixelsWithoutAdvert = 550;
+		it.each(['mobile', 'desktop'])(
+			'should display ad if this is the first block on %s.',
+			(screenSize) => {
+				const isMobile = screenSize === 'mobile';
+				const block = 1;
+				const totalBlocks = 10;
+				const numAdsInserted = 0;
+				const numPixelsWithoutAdvert = 550;
 
-			const resultDesktop = shouldDisplayAd(
-				block,
-				totalBlocks,
-				numAdsInserted,
-				numPixelsWithoutAdvert,
-				false,
-			);
-			const resultMobile = shouldDisplayAd(
-				block,
-				totalBlocks,
-				numAdsInserted,
-				numPixelsWithoutAdvert,
-				false,
-			);
+				const result = shouldDisplayAd(
+					block,
+					totalBlocks,
+					numAdsInserted,
+					numPixelsWithoutAdvert,
+					isMobile,
+				);
 
-			expect(resultDesktop).toBeTruthy();
-			expect(resultMobile).toBeTruthy();
-		});
+				expect(result).toBeTruthy();
+			},
+		);
 	});
 
 	describe('inserting further ad slots', () => {
-		describe('desktop', () => {
-			it('should display ad if number of pixels without an ad is more than 1500', () => {
+		it.each([
+			[1200, 'mobile'],
+			[1500, 'desktop'],
+		])(
+			'should display ad if number of pixels without an ad is more than %s on %s',
+			(pixels, screenSize) => {
+				const isMobile = screenSize === 'mobile';
 				const block = 5;
 				const totalBlocks = 10;
 				const numAdsInserted = 1;
-				const numPixelsWithoutAdvert = 1550;
+				const numPixelsWithoutAdvert = pixels + 50;
 
 				const result = shouldDisplayAd(
 					block,
 					totalBlocks,
 					numAdsInserted,
 					numPixelsWithoutAdvert,
-					false,
+					isMobile,
 				);
 
 				expect(result).toBeTruthy();
-			});
+			},
+		);
 
-			it('should NOT display ad if number of pixels without an ad is less than 1500', () => {
+		it.each([
+			[1200, 'mobile'],
+			[1500, 'desktop'],
+		])(
+			'should NOT display ad if number of pixels without an ad is less than %s on %s',
+			(pixels, screenSize) => {
+				const isMobile = screenSize === 'mobile';
 				const block = 5;
 				const totalBlocks = 10;
 				const numAdsInserted = 1;
-				const numPixelsWithoutAdvert = 1450;
+				const numPixelsWithoutAdvert = pixels - 50;
 
 				const result = shouldDisplayAd(
 					block,
 					totalBlocks,
 					numAdsInserted,
 					numPixelsWithoutAdvert,
-					false,
+					isMobile,
 				);
 
 				expect(result).toBeFalsy();
-			});
-		});
-		describe('mobile', () => {
-			it('should display ad if number of pixels without an ad is more than 1200', () => {
-				const block = 5;
-				const totalBlocks = 10;
-				const numAdsInserted = 1;
-				const numPixelsWithoutAdvert = 1250;
-
-				const result = shouldDisplayAd(
-					block,
-					totalBlocks,
-					numAdsInserted,
-					numPixelsWithoutAdvert,
-					true,
-				);
-
-				expect(result).toBeTruthy();
-			});
-
-			it('should NOT display ad if number of pixels without an ad is less than 1200', () => {
-				const block = 5;
-				const totalBlocks = 10;
-				const numAdsInserted = 1;
-				const numPixelsWithoutAdvert = 1150;
-
-				const result = shouldDisplayAd(
-					block,
-					totalBlocks,
-					numAdsInserted,
-					numPixelsWithoutAdvert,
-					true,
-				);
-
-				expect(result).toBeFalsy();
-			});
-		});
+			},
+		);
 	});
 });

--- a/dotcom-rendering/src/lib/liveblogAdSlots.test.ts
+++ b/dotcom-rendering/src/lib/liveblogAdSlots.test.ts
@@ -50,7 +50,7 @@ describe('calculateApproximateBlockHeight', () => {
 
 	describe('zero elements', () => {
 		it('should return zero when there are zero elements', () => {
-			expect(calculateApproximateBlockHeight([])).toEqual(0);
+			expect(calculateApproximateBlockHeight([], false)).toEqual(0);
 		});
 	});
 
@@ -58,11 +58,13 @@ describe('calculateApproximateBlockHeight', () => {
 		const textLineHeight = 25.5;
 
 		it('should return the correct height for varying line length', () => {
-			expect(calculateApproximateBlockHeight(textElementOneLine)).toEqual(
+			expect(
+				calculateApproximateBlockHeight(textElementOneLine, false),
+			).toEqual(
 				textLineHeight + defaultBlockSpacing + defaultElementSpacing,
 			);
 			expect(
-				calculateApproximateBlockHeight(textElementTwoLines),
+				calculateApproximateBlockHeight(textElementTwoLines, false),
 			).toEqual(
 				2 * textLineHeight +
 					defaultBlockSpacing +
@@ -72,16 +74,16 @@ describe('calculateApproximateBlockHeight', () => {
 
 		it('should return the correct height when there are multiple elements', () => {
 			expect(
-				calculateApproximateBlockHeight(multipleTextElements),
+				calculateApproximateBlockHeight(multipleTextElements, false),
 			).toEqual(201);
 		});
 	});
 
 	describe('youtube block elements', () => {
 		it('should return the correct height', () => {
-			expect(calculateApproximateBlockHeight(youtubeElement)).toEqual(
-				239 + defaultBlockSpacing + defaultElementSpacing,
-			);
+			expect(
+				calculateApproximateBlockHeight(youtubeElement, false),
+			).toEqual(239 + defaultBlockSpacing + defaultElementSpacing);
 		});
 	});
 });
@@ -98,6 +100,7 @@ describe('shouldDisplayAd', () => {
 			totalBlocks,
 			numAdsInserted,
 			numPixelsWithoutAdvert,
+			false,
 		);
 
 		expect(result).toBeFalsy();
@@ -114,6 +117,7 @@ describe('shouldDisplayAd', () => {
 			totalBlocks,
 			numAdsInserted,
 			numPixelsWithoutAdvert,
+			false,
 		);
 
 		expect(result).toBeFalsy();
@@ -131,6 +135,7 @@ describe('shouldDisplayAd', () => {
 				totalBlocks,
 				numAdsInserted,
 				numPixelsWithoutAdvert,
+				false,
 			);
 
 			expect(result).toBeTruthy();
@@ -149,6 +154,7 @@ describe('shouldDisplayAd', () => {
 				totalBlocks,
 				numAdsInserted,
 				numPixelsWithoutAdvert,
+				false,
 			);
 
 			expect(result).toBeTruthy();
@@ -165,6 +171,7 @@ describe('shouldDisplayAd', () => {
 				totalBlocks,
 				numAdsInserted,
 				numPixelsWithoutAdvert,
+				false,
 			);
 
 			expect(result).toBeFalsy();

--- a/dotcom-rendering/src/lib/liveblogAdSlots.ts
+++ b/dotcom-rendering/src/lib/liveblogAdSlots.ts
@@ -5,8 +5,10 @@ import type {
 	ImageBlockElement,
 	RichLinkBlockElement,
 	SubheadingBlockElement,
+	TableBlockElement,
 	TextBlockElement,
 	TweetBlockElement,
+	YoutubeBlockElement,
 } from '../types/content';
 
 /**
@@ -24,12 +26,6 @@ const MIN_SPACE_BETWEEN_ADS = 1_500;
  */
 const MIN_SPACE_BETWEEN_ADS_MOBILE = 1_200;
 
-/**
- * Estimated margin associated with an element.
- * This can sometimes be slightly more or less.
- */
-export const ELEMENT_MARGIN = 12;
-
 // Extra height found in every block.
 const BLOCK_HEADER = 20; // Date and time
 const BLOCK_FOOTER = 25; // Sharing links (Facebook, Twitter)
@@ -43,6 +39,7 @@ type BlockElementTextData = {
 type BlockElementHeightData = {
 	heightExcludingText: number;
 	heightExcludingTextMobile: number;
+	margin: number;
 } & (
 	| {
 			textHeight: BlockElementTextData;
@@ -78,7 +75,7 @@ type KnownBlockElementType =
 
 /**
  * Approximations of the height of each type of block element in pixels.
- * "Mobile" indicates the value is used for devices up to the tablet breakpoint."
+ * "...Mobile" indicates the value is used for devices up to the tablet breakpoint."
  */
 const elementHeightDataMap: {
 	[key in KnownBlockElementType]: BlockElementHeightData;
@@ -86,79 +83,87 @@ const elementHeightDataMap: {
 	'model.dotcomrendering.pageElements.BlockquoteBlockElement': {
 		heightExcludingText: 0,
 		heightExcludingTextMobile: 0,
+		margin: 16,
 		textHeight: {
-			lineHeight: 25.5,
-			lineLength: 40,
+			lineHeight: 23.8,
+			lineLength: 69,
 		},
 		textHeightMobile: {
-			lineHeight: 25.5,
+			lineHeight: 23.8,
 			lineLength: 40,
 		},
 		text: (element) =>
 			(element as BlockquoteBlockElement).html.replace(/<[^>]+>/g, ''),
 	},
 	'model.dotcomrendering.pageElements.CommentBlockElement': {
-		heightExcludingText: 74,
-		heightExcludingTextMobile: 74,
+		heightExcludingText: 68,
+		heightExcludingTextMobile: 84,
+		margin: 48,
 		textHeight: {
-			lineHeight: 18,
-			lineLength: 28,
+			lineHeight: 22,
+			lineLength: 70,
 		},
 		textHeightMobile: {
-			lineHeight: 18,
-			lineLength: 28,
+			lineHeight: 22,
+			lineLength: 40,
 		},
 		text: (element) =>
 			(element as CommentBlockElement).body.replace(/<[^>]+>/g, ''),
 	},
 	'model.dotcomrendering.pageElements.EmbedBlockElement': {
-		heightExcludingText: 251,
+		heightExcludingText: 178,
 		heightExcludingTextMobile: 251,
+		margin: 12,
 	},
 	'model.dotcomrendering.pageElements.GuideAtomBlockElement': {
-		heightExcludingText: 77,
+		heightExcludingText: 90,
 		heightExcludingTextMobile: 77,
+		margin: 12,
 	},
 	'model.dotcomrendering.pageElements.ImageBlockElement': {
-		heightExcludingText: 230,
-		heightExcludingTextMobile: 230,
+		heightExcludingText: 392,
+		heightExcludingTextMobile: 220,
+		margin: 12,
 		textHeight: {
-			lineHeight: 20,
-			lineLength: 52,
+			lineHeight: 19,
+			lineLength: 85,
 		},
 		textHeightMobile: {
-			lineHeight: 20,
-			lineLength: 52,
+			lineHeight: 19,
+			lineLength: 45,
 		},
 		text: (element) => (element as ImageBlockElement).data.caption ?? '',
 	},
 	'model.dotcomrendering.pageElements.InteractiveBlockElement': {
-		heightExcludingText: 600,
-		heightExcludingTextMobile: 600,
+		heightExcludingText: 537,
+		heightExcludingTextMobile: 449,
+		margin: 0,
 	},
 	'model.dotcomrendering.pageElements.RichLinkBlockElement': {
-		heightExcludingText: 65,
-		heightExcludingTextMobile: 65,
+		heightExcludingText: 45,
+		heightExcludingTextMobile: 52,
+		margin: 12,
 		textHeight: {
-			lineHeight: 16,
-			lineLength: 52,
+			lineHeight: 23,
+			lineLength: 75,
 		},
 		textHeightMobile: {
-			lineHeight: 16,
-			lineLength: 52,
+			lineHeight: 19.5,
+			lineLength: 39,
 		},
 		text: (element) => (element as RichLinkBlockElement).text,
 	},
 	'model.dotcomrendering.pageElements.SubheadingBlockElement': {
 		heightExcludingText: 0,
 		heightExcludingTextMobile: 0,
+		margin: 0,
 		textHeight: {
 			lineHeight: 23,
-			lineLength: 40,
+			lineLength: 65,
 		},
 		textHeightMobile: {
 			lineHeight: 23,
-			lineLength: 40,
+			lineLength: 31,
 		},
 		text: (element) =>
 			(element as SubheadingBlockElement).html.replace(/<[^>]+>/g, ''),
@@ -166,41 +171,64 @@ const elementHeightDataMap: {
 	'model.dotcomrendering.pageElements.TableBlockElement': {
 		heightExcludingText: 32,
 		heightExcludingTextMobile: 32,
+		margin: 12,
+		textHeight: {
+			lineHeight: 32,
+			lineLength: 100,
+		},
+		textHeightMobile: {
+			lineHeight: 32,
+			lineLength: 100,
+		},
+		text: (element) => (element as TableBlockElement).html,
 	},
 	'model.dotcomrendering.pageElements.TextBlockElement': {
 		heightExcludingText: 0,
 		heightExcludingTextMobile: 0,
+		margin: 14,
 		textHeight: {
-			lineHeight: 25.5,
-			lineLength: 39,
+			lineHeight: 23.8,
+			lineLength: 72,
 		},
 		textHeightMobile: {
-			lineHeight: 25.5,
+			lineHeight: 23.8,
 			lineLength: 39,
 		},
 		text: (element) =>
 			(element as TextBlockElement).html.replace(/<[^>]+>/g, ''),
 	},
 	'model.dotcomrendering.pageElements.TweetBlockElement': {
-		heightExcludingText: 190,
+		heightExcludingText: 320,
 		heightExcludingTextMobile: 190,
+		margin: 12,
 		textHeight: {
-			lineHeight: 19,
-			lineLength: 40,
+			lineHeight: 24,
+			lineLength: 70,
 		},
 		textHeightMobile: {
 			lineHeight: 19,
-			lineLength: 40,
+			lineLength: 42,
 		},
-		text: (element) => (element as TweetBlockElement).html,
+		text: (element) => (element as TweetBlockElement).html, // Includes all the markup for the tweet, not just the text
 	},
 	'model.dotcomrendering.pageElements.VideoYoutubeBlockElement': {
-		heightExcludingText: 215,
-		heightExcludingTextMobile: 215,
+		heightExcludingText: 381,
+		heightExcludingTextMobile: 213,
+		margin: 0,
 	},
 	'model.dotcomrendering.pageElements.YoutubeBlockElement': {
-		heightExcludingText: 239,
-		heightExcludingTextMobile: 239,
+		heightExcludingText: 350,
+		heightExcludingTextMobile: 195,
+		margin: 12,
+		textHeight: {
+			lineHeight: 19,
+			lineLength: 95,
+		},
+		textHeightMobile: {
+			lineHeight: 18,
+			lineLength: 45,
+		},
+		text: (element) => (element as YoutubeBlockElement).mediaTitle,
 	},
 };
 
@@ -222,24 +250,26 @@ export const calculateApproximateElementHeight = (
 	const heightData = elementHeightDataMap[elementType];
 
 	const heightExcludingText = isMobile
-		? heightData.heightExcludingText
-		: heightData.heightExcludingTextMobile;
+		? heightData.heightExcludingTextMobile
+		: heightData.heightExcludingText;
 
-	let estimatedHeight = heightExcludingText + ELEMENT_MARGIN;
-	const textHeight = isMobile
-		? heightData.textHeight
-		: heightData.textHeightMobile;
+	const estimatedHeightWithoutText = heightExcludingText + heightData.margin;
+
+	if (!heightData.text) {
+		return estimatedHeightWithoutText;
+	}
 
 	// If the element has text that contributes to the height of the element, estimate
 	// the height of the text and increment the height
-	if (textHeight && heightData.text) {
-		const { lineHeight, lineLength } = textHeight;
-		const characterCount = heightData.text(element).length;
+	const { lineHeight, lineLength } = isMobile
+		? heightData.textHeightMobile
+		: heightData.textHeight;
 
-		estimatedHeight += lineHeight * Math.ceil(characterCount / lineLength);
-	}
-
-	return estimatedHeight;
+	const characterCount = heightData.text(element).length;
+	return (
+		estimatedHeightWithoutText +
+		lineHeight * Math.ceil(characterCount / lineLength)
+	);
 };
 
 /**

--- a/dotcom-rendering/src/lib/liveblogAdSlots.ts
+++ b/dotcom-rendering/src/lib/liveblogAdSlots.ts
@@ -312,8 +312,8 @@ const shouldDisplayAd = (
 	}
 
 	const minSpaceBetweenAds = isMobile
-		? MIN_SPACE_BETWEEN_ADS
-		: MIN_SPACE_BETWEEN_ADS_MOBILE;
+		? MIN_SPACE_BETWEEN_ADS_MOBILE
+		: MIN_SPACE_BETWEEN_ADS;
 
 	return numPixelsWithoutAdvert > minSpaceBetweenAds;
 };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

- Creates an AB test.
- On liveblog pages, insert two sets of inline ad slots server-side. Fill the relevant slots (mobile or desktop) with ads

## Why?

- We can move from inserting ad slots client side to inserting them server-side. One set of ad slots inserted server-side was not flexible enough to offer a suitable ad frequency on both desktop and mobile. Since viewport height tends to be smaller when the screen width is smaller, number of ads per viewport height is smaller on mobile when inserting ads above the same blocks on all screen sizes.

## Screenshots

Two sets of ad slot containers are created on the page.

| Desktop      | Mobile      |
| ----------- | ---------- |
| The inline ad slots for large screens are filled with ads. The mobile inline ad slots remain unfilled | The ad slots for mobile screens are filled with inline ads. The desktop inline ad slots remain unfilled |
| ![desktop][] | ![mobile][] |

[desktop]: https://github.com/guardian/dotcom-rendering/assets/9574885/1324f279-7780-4b6b-a5fe-425b97deb4bf
[mobile]: https://github.com/guardian/dotcom-rendering/assets/9574885/78353a8a-2533-4be1-b252-0fcf7787a590

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
