### PR TITLE
Delete old DCR container images

### DIFF
--- a/.github/workflows/delete-old-packages.yml
+++ b/.github/workflows/delete-old-packages.yml
@@ -1,0 +1,27 @@
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - ".github/workflows/delete-old-packages.yaml"
+  schedule:
+    # Runs "At 7:00am on every day of the week from Monday through Friday"
+    - cron: "0 7 * * 1-5"
+
+name: Delete Old Packages
+
+env:
+  NUM_OF_VERSIONS_TO_KEEP: 5
+
+jobs:
+  delete-old-packages:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Delete packages
+        uses: actions/delete-package-versions@v4
+        with:
+          package-name: "dotcom-rendering"
+          package-type: "container"
+          min-versions-to-keep: ${{ env.NUM_OF_VERSIONS_TO_KEEP }}

--- a/.github/workflows/delete-old-packages.yml
+++ b/.github/workflows/delete-old-packages.yml
@@ -10,7 +10,7 @@ on:
 name: Delete Old Packages
 
 env:
-  NUM_OF_VERSIONS_TO_KEEP: 5
+  NUM_OF_VERSIONS_TO_KEEP: 25
 
 jobs:
   delete-old-packages:


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Inspired by https://github.com/guardian/coverdrop/pull/471

## Why?

Packages are free for public repositories, but its good for the environment for us tidy up our packages as there is a lot of them and they're quite big.