### PR TITLE
Bump `@guardian/libs` to enable perf logging

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -74,7 +74,7 @@
 		"@guardian/eslint-plugin-source-react-components": "18.0.0",
 		"@guardian/identity-auth": "1.0.0",
 		"@guardian/identity-auth-frontend": "1.0.0",
-		"@guardian/libs": "15.6.4",
+		"@guardian/libs": "15.7.0",
 		"@guardian/prettier": "5.0.0",
 		"@guardian/shimport": "1.0.2",
 		"@guardian/source-foundations": "13.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3201,6 +3201,11 @@
   resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-15.6.4.tgz#13787065e5c58b884944c5c71d6e324c7f2e566a"
   integrity sha512-oN+xN7FBuVKLCbbjvAMdWjgWqOtvR38acnqwAKsjUDkFsBzRWU/pueDSEGTCTTVSFcRdCKOsWnop+Vwh59P47g==
 
+"@guardian/libs@15.7.0":
+  version "15.7.0"
+  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-15.7.0.tgz#56313b27c240064a13a76469985e6fba3df211b4"
+  integrity sha512-uE7GZf05Hea6R8SLPjtG/znVgCqXyq6jvvKpsp34L3u4iz/t5AbopGuILrQhTpo6NcjKYFxgg59wb4vUStxJ1g==
+
 "@guardian/libs@^10.0.0":
   version "10.1.1"
   resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-10.1.1.tgz#7048c365a68dda068f707d46c78979f430221963"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

now we can do `guardian.logger.subscribeTo('perf')` to log performance measures in the console

## Why?

perf is good

## Screenshots

<img width="381" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/867233/73e0a2dc-b6d3-4d0c-9b65-a0fe3ae28b4b">

