### PR TITLE
Create and adjust picture layout from feedback

### DIFF
--- a/dotcom-rendering/src/components/ShareIcons.tsx
+++ b/dotcom-rendering/src/components/ShareIcons.tsx
@@ -88,6 +88,15 @@ const decideIconColorOnHover = (format: ArticleFormat, context: Context) => {
 			}
 		`;
 	}
+	if (format.design === ArticleDesign.Picture) {
+		return css`
+			:hover {
+				background-color: ${palette.fill.shareIcon};
+				border-color: ${palette.fill.shareIcon};
+				fill: black;
+			}
+		`;
+	}
 	return css`
 		:hover {
 			background-color: ${palette.fill.shareIcon};

--- a/dotcom-rendering/src/layouts/DecideLayout.tsx
+++ b/dotcom-rendering/src/layouts/DecideLayout.tsx
@@ -121,7 +121,6 @@ const DecideLayoutWeb = ({
 							article={article}
 							NAV={NAV}
 							format={format}
-							renderingTarget={renderingTarget}
 						/>
 					);
 				default:

--- a/dotcom-rendering/src/layouts/DecideLayout.tsx
+++ b/dotcom-rendering/src/layouts/DecideLayout.tsx
@@ -11,6 +11,7 @@ import { LiveLayout } from './LiveLayout';
 import { NewsletterSignupLayout } from './NewsletterSignupLayout';
 import { ShowcaseLayout } from './ShowcaseLayout';
 import { StandardLayout } from './StandardLayout';
+import { PictureLayout } from './PictureLayout';
 
 interface BaseProps {
 	article: DCRArticle;
@@ -112,6 +113,15 @@ const DecideLayoutWeb = ({
 							article={article}
 							NAV={NAV}
 							format={format}
+						/>
+					);
+				case ArticleDesign.Picture:
+					return (
+						<PictureLayout
+							article={article}
+							NAV={NAV}
+							format={format}
+							renderingTarget={renderingTarget}
 						/>
 					);
 				default:

--- a/dotcom-rendering/src/layouts/DecideLayout.tsx
+++ b/dotcom-rendering/src/layouts/DecideLayout.tsx
@@ -9,9 +9,9 @@ import { ImmersiveLayout } from './ImmersiveLayout';
 import { InteractiveLayout } from './InteractiveLayout';
 import { LiveLayout } from './LiveLayout';
 import { NewsletterSignupLayout } from './NewsletterSignupLayout';
+import { PictureLayout } from './PictureLayout';
 import { ShowcaseLayout } from './ShowcaseLayout';
 import { StandardLayout } from './StandardLayout';
-import { PictureLayout } from './PictureLayout';
 
 interface BaseProps {
 	article: DCRArticle;

--- a/dotcom-rendering/src/layouts/PictureLayout.tsx
+++ b/dotcom-rendering/src/layouts/PictureLayout.tsx
@@ -239,9 +239,6 @@ export const PictureLayout = ({ article, NAV, format }: Props) => {
 		config: { isPaidContent, host },
 	} = article;
 
-	const isInEuropeTest =
-		article.config.abTests.europeNetworkFrontVariant === 'variant';
-
 	// TODO:
 	// 1) Read 'forceEpic' value from URL parameter and use it to force the slot to render
 	// 2) Otherwise, ensure slot only renders if `article.config.shouldHideReaderRevenue` equals false.
@@ -302,7 +299,6 @@ export const PictureLayout = ({ article, NAV, format }: Props) => {
 							}
 							contributionsServiceUrl={contributionsServiceUrl}
 							idApiUrl={article.config.idApiUrl}
-							isInEuropeTest={isInEuropeTest}
 							headerTopBarSearchCapiSwitch={
 								!!article.config.switches.headerTopBarSearchCapi
 							}
@@ -334,7 +330,6 @@ export const PictureLayout = ({ article, NAV, format }: Props) => {
 							headerTopBarSwitch={
 								!!article.config.switches.headerTopNav
 							}
-							isInEuropeTest={isInEuropeTest}
 						/>
 					</Section>
 

--- a/dotcom-rendering/src/layouts/PictureLayout.tsx
+++ b/dotcom-rendering/src/layouts/PictureLayout.tsx
@@ -110,10 +110,10 @@ const PictureGrid = ({ children }: { children: React.ReactNode }) => (
 					grid-template-areas:
 						'title     '
 						'headline  '
-						'media     '
-						'standfirst'
 						'lines     '
 						'meta      '
+						'media     '
+						'standfirst'
 						'submeta   '
 						'.         ';
 				}

--- a/dotcom-rendering/src/layouts/PictureLayout.tsx
+++ b/dotcom-rendering/src/layouts/PictureLayout.tsx
@@ -2,18 +2,15 @@ import { css } from '@emotion/react';
 import { ArticleDesign, ArticleDisplay, ArticleSpecial } from '@guardian/libs';
 import type { ArticleFormat } from '@guardian/libs';
 import {
-	border,
 	brandBackground,
 	brandBorder,
 	brandLine,
 	from,
-	labs,
 	neutral,
 	until,
 } from '@guardian/source-foundations';
 import { StraightLines } from '@guardian/source-react-components-development-kitchen';
 import { AdSlot, MobileStickyContainer } from '../components/AdSlot';
-import { ArticleBody } from '../components/ArticleBody';
 import { ArticleContainer } from '../components/ArticleContainer';
 import { ArticleHeadline } from '../components/ArticleHeadline';
 import { ArticleMeta } from '../components/ArticleMeta';
@@ -27,16 +24,12 @@ import { GridItem } from '../components/GridItem';
 import { Header } from '../components/Header';
 import { HeaderAdSlot } from '../components/HeaderAdSlot';
 import { Island } from '../components/Island';
-import { LabsHeader } from '../components/LabsHeader';
 import { MainMedia } from '../components/MainMedia';
 import { MostViewedFooterData } from '../components/MostViewedFooterData.importable';
 import { MostViewedFooterLayout } from '../components/MostViewedFooterLayout';
-import { MostViewedRightWithAd } from '../components/MostViewedRightWithAd';
 import { Nav } from '../components/Nav/Nav';
 import { OnwardsUpper } from '../components/OnwardsUpper.importable';
-import { RightColumn } from '../components/RightColumn';
 import { Section } from '../components/Section';
-import { SlotBodyEnd } from '../components/SlotBodyEnd.importable';
 import { Standfirst } from '../components/Standfirst';
 import { StickyBottomBanner } from '../components/StickyBottomBanner.importable';
 import { SubMeta } from '../components/SubMeta';
@@ -104,9 +97,9 @@ const PictureGrid = ({ children }: { children: React.ReactNode }) => (
 					
 								grid-template-areas:
 									'title  border  headline    headline'
+									'meta   border  media       media'
+									'meta   border  media       media'
 									'lines  border  standfirst  standfirst'
-									'meta   border  media       media'
-									'meta   border  media       media'
 									'.      border  submeta     submeta'
 									'.      border  .           . ';
 						
@@ -118,18 +111,19 @@ const PictureGrid = ({ children }: { children: React.ReactNode }) => (
 					Main content
 					Right Column
 				*/
-				${until.leftCol} {
+				${until.leftCol} {					grid-column-gap: 0px;
+
 					
 								grid-template-columns: 1fr; /* Main content */
 
 								grid-template-areas:
 									'title     '
 									'headline  '
-									'standfirst'
 									'media     '
+									'standfirst'
 									'lines     '
 									'meta      '
-									'submeta      '
+									'submeta   '
 									'.         ';
 						
 							
@@ -142,10 +136,10 @@ const PictureGrid = ({ children }: { children: React.ReactNode }) => (
 					grid-template-areas:
 						'title'
 						'headline'
-						'standfirst'
-						'media'
 						'lines'
 						'meta'
+						'media'
+						'standfirst'
 						'submeta';
 				}
 
@@ -156,10 +150,10 @@ const PictureGrid = ({ children }: { children: React.ReactNode }) => (
 								grid-template-areas:
 									'title'
 									'headline'
-									'standfirst'
-									'media'
 									'lines'
 									'meta'
+									'media'
+									'standfirst'
 									'submeta';
 				}						  
 			

--- a/dotcom-rendering/src/layouts/PictureLayout.tsx
+++ b/dotcom-rendering/src/layouts/PictureLayout.tsx
@@ -90,9 +90,9 @@ const PictureGrid = ({ children }: { children: React.ReactNode }) => (
 					grid-template-columns: 140px 1px 1fr 300px;
 					grid-template-areas:
 						'title  border  headline    headline'
+						'lines  border  media       media'
 						'meta   border  media       media'
-						'meta   border  media       media'
-						'lines  border  standfirst  standfirst'
+						'meta   border  standfirst  standfirst'
 						'.      border  submeta     submeta'
 						'.      border  .           . ';
 				}
@@ -155,16 +155,6 @@ const maxWidth = css`
 	}
 `;
 
-// const stretchLines = (isPictureContent: boolean) => css`
-// 	${!isPictureContent && until.phablet} {
-// 		margin-left: -20px;
-// 		margin-right: -20px;
-// 	}
-// 	${!isPictureContent && until.mobileLandscape} {
-// 		margin-left: -10px;
-// 		margin-right: -10px;
-// 	}
-// `;
 const mainMediaWrapper = css`
 	position: relative;
 	${until.phablet} {
@@ -176,11 +166,6 @@ const mainMediaWrapper = css`
 		margin-right: 10px;
 	}
 `;
-
-const PositionHeadline = ({ children }: { children: React.ReactNode }) => {
-	return <div css={maxWidth}>{children}</div>;
-};
-
 interface Props {
 	article: FEArticleType;
 	NAV: NavType;
@@ -364,7 +349,7 @@ export const PictureLayout = ({ article, NAV, format }: Props) => {
 							<Border format={format} />
 						</GridItem>
 						<GridItem area="headline">
-							<PositionHeadline>
+							<div css={maxWidth}>
 								<ArticleHeadline
 									format={format}
 									headlineString={article.headline}
@@ -377,7 +362,7 @@ export const PictureLayout = ({ article, NAV, format }: Props) => {
 										article.starRating !== undefined
 									}
 								/>
-							</PositionHeadline>
+							</div>
 						</GridItem>
 						<GridItem area="media">
 							<div css={mainMediaWrapper}>

--- a/dotcom-rendering/src/layouts/PictureLayout.tsx
+++ b/dotcom-rendering/src/layouts/PictureLayout.tsx
@@ -267,128 +267,117 @@ export const PictureLayout = ({ article, NAV, format }: Props) => {
 
 	return (
 		<>
-			<>
-				<div>
-					{renderAds && (
-						<Stuck>
-							<Section
-								fullWidth={true}
-								showTopBorder={false}
-								showSideBorders={false}
-								padSides={false}
-								shouldCenter={false}
-							>
-								<HeaderAdSlot />
-							</Section>
-						</Stuck>
-					)}
-					<SendToBack>
+			<div>
+				{renderAds && (
+					<Stuck>
 						<Section
 							fullWidth={true}
-							shouldCenter={false}
 							showTopBorder={false}
 							showSideBorders={false}
 							padSides={false}
-							backgroundColour={brandBackground.primary}
-							element="header"
+							shouldCenter={false}
 						>
-							<Header
-								editionId={article.editionId}
-								idUrl={article.config.idUrl}
-								mmaUrl={article.config.mmaUrl}
-								discussionApiUrl={
-									article.config.discussionApiUrl
-								}
-								urls={article.nav.readerRevenueLinks.header}
-								remoteHeader={
-									!!article.config.switches.remoteHeader
-								}
-								contributionsServiceUrl={
-									contributionsServiceUrl
-								}
-								idApiUrl={article.config.idApiUrl}
-								isInEuropeTest={isInEuropeTest}
-								headerTopBarSearchCapiSwitch={
-									!!article.config.switches
-										.headerTopBarSearchCapi
-								}
-							/>
+							<HeaderAdSlot />
 						</Section>
-						<Section
-							fullWidth={true}
-							borderColour={brandLine.primary}
-							showTopBorder={false}
-							padSides={false}
-							backgroundColour={brandBackground.primary}
-							element="nav"
-							format={format}
-						>
-							<Nav
-								nav={NAV}
-								isImmersive={
-									format.display === ArticleDisplay.Immersive
-								}
-								displayRoundel={
-									format.display ===
-										ArticleDisplay.Immersive ||
-									format.theme === ArticleSpecial.Labs
-								}
-								selectedPillar={NAV.selectedPillar}
-								subscribeUrl={
-									article.nav.readerRevenueLinks.header
-										.subscribe
-								}
-								editionId={article.editionId}
-								headerTopBarSwitch={
-									!!article.config.switches.headerTopNav
-								}
-								isInEuropeTest={isInEuropeTest}
-							/>
-						</Section>
+					</Stuck>
+				)}
+				<SendToBack>
+					<Section
+						fullWidth={true}
+						shouldCenter={false}
+						showTopBorder={false}
+						showSideBorders={false}
+						padSides={false}
+						backgroundColour={brandBackground.primary}
+						element="header"
+					>
+						<Header
+							editionId={article.editionId}
+							idUrl={article.config.idUrl}
+							mmaUrl={article.config.mmaUrl}
+							discussionApiUrl={article.config.discussionApiUrl}
+							urls={article.nav.readerRevenueLinks.header}
+							remoteHeader={
+								!!article.config.switches.remoteHeader
+							}
+							contributionsServiceUrl={contributionsServiceUrl}
+							idApiUrl={article.config.idApiUrl}
+							isInEuropeTest={isInEuropeTest}
+							headerTopBarSearchCapiSwitch={
+								!!article.config.switches.headerTopBarSearchCapi
+							}
+						/>
+					</Section>
+					<Section
+						fullWidth={true}
+						borderColour={brandLine.primary}
+						showTopBorder={false}
+						padSides={false}
+						backgroundColour={brandBackground.primary}
+						element="nav"
+						format={format}
+					>
+						<Nav
+							nav={NAV}
+							isImmersive={
+								format.display === ArticleDisplay.Immersive
+							}
+							displayRoundel={
+								format.display === ArticleDisplay.Immersive ||
+								format.theme === ArticleSpecial.Labs
+							}
+							selectedPillar={NAV.selectedPillar}
+							subscribeUrl={
+								article.nav.readerRevenueLinks.header.subscribe
+							}
+							editionId={article.editionId}
+							headerTopBarSwitch={
+								!!article.config.switches.headerTopNav
+							}
+							isInEuropeTest={isInEuropeTest}
+						/>
+					</Section>
 
-						{NAV.subNavSections && (
-							<Section
-								fullWidth={true}
-								backgroundColour={palette.background.article}
-								padSides={false}
-								element="aside"
-								format={format}
-								showTopBorder={showSubNavTopBorder}
-							>
-								<Island deferUntil="idle">
-									<SubNav
-										subNavSections={NAV.subNavSections}
-										currentNavLink={NAV.currentNavLink}
-										linkHoverColour={
-											palette.text.articleLinkHover
-										}
-										borderColour={palette.border.subNav}
-										subNavLinkColour={
-											palette.text.subNavLink
-										}
-									/>
-								</Island>
-							</Section>
-						)}
-
+					{NAV.subNavSections && (
 						<Section
 							fullWidth={true}
 							backgroundColour={palette.background.article}
 							padSides={false}
-							showTopBorder={false}
-							borderColour={palette.border.secondary}
+							element="aside"
+							format={format}
+							showTopBorder={showSubNavTopBorder}
 						>
-							<StraightLines
-								count={4}
-								color={palette.border.secondary}
-								cssOverrides={css`
-									display: block;
-								`}
-							/>
+							<Island deferUntil="idle">
+								<SubNav
+									subNavSections={NAV.subNavSections}
+									currentNavLink={NAV.currentNavLink}
+									linkHoverColour={
+										palette.text.articleLinkHover
+									}
+									borderColour={palette.border.subNav}
+									subNavLinkColour={palette.text.subNavLink}
+								/>
+							</Island>
 						</Section>
-					</SendToBack>
-				</div>
-			</>
+					)}
+
+					<Section
+						fullWidth={true}
+						backgroundColour={palette.background.article}
+						padSides={false}
+						showTopBorder={false}
+						borderColour={palette.border.secondary}
+					>
+						<StraightLines
+							count={4}
+							color={palette.border.secondary}
+							cssOverrides={css`
+								display: block;
+							`}
+						/>
+					</Section>
+				</SendToBack>
+			</div>
 
 			<main
 				data-layout="PictureLayout"

--- a/dotcom-rendering/src/layouts/PictureLayout.tsx
+++ b/dotcom-rendering/src/layouts/PictureLayout.tsx
@@ -180,6 +180,7 @@ const avatarHeadlineWrapper = css`
 	justify-content: space-between;
 `;
 
+// This styling taken from the similar approach in CommentLayout.tsx
 // If in mobile increase the margin top and margin right deficit
 const avatarPositionStyles = css`
 	display: flex;

--- a/dotcom-rendering/src/layouts/PictureLayout.tsx
+++ b/dotcom-rendering/src/layouts/PictureLayout.tsx
@@ -1,0 +1,691 @@
+import { css } from '@emotion/react';
+import { ArticleDesign, ArticleDisplay, ArticleSpecial } from '@guardian/libs';
+import type { ArticleFormat } from '@guardian/libs';
+import {
+	border,
+	brandBackground,
+	brandBorder,
+	brandLine,
+	from,
+	labs,
+	neutral,
+	until,
+} from '@guardian/source-foundations';
+import { StraightLines } from '@guardian/source-react-components-development-kitchen';
+import { AdSlot, MobileStickyContainer } from '../components/AdSlot';
+import { ArticleBody } from '../components/ArticleBody';
+import { ArticleContainer } from '../components/ArticleContainer';
+import { ArticleHeadline } from '../components/ArticleHeadline';
+import { ArticleMeta } from '../components/ArticleMeta';
+import { ArticleTitle } from '../components/ArticleTitle';
+import { Border } from '../components/Border';
+import { Carousel } from '../components/Carousel.importable';
+import { DecideLines } from '../components/DecideLines';
+import { DiscussionLayout } from '../components/DiscussionLayout';
+import { Footer } from '../components/Footer';
+import { GridItem } from '../components/GridItem';
+import { Header } from '../components/Header';
+import { HeaderAdSlot } from '../components/HeaderAdSlot';
+import { Island } from '../components/Island';
+import { LabsHeader } from '../components/LabsHeader';
+import { MainMedia } from '../components/MainMedia';
+import { MostViewedFooterData } from '../components/MostViewedFooterData.importable';
+import { MostViewedFooterLayout } from '../components/MostViewedFooterLayout';
+import { MostViewedRightWithAd } from '../components/MostViewedRightWithAd';
+import { Nav } from '../components/Nav/Nav';
+import { OnwardsUpper } from '../components/OnwardsUpper.importable';
+import { RightColumn } from '../components/RightColumn';
+import { Section } from '../components/Section';
+import { SlotBodyEnd } from '../components/SlotBodyEnd.importable';
+import { Standfirst } from '../components/Standfirst';
+import { StickyBottomBanner } from '../components/StickyBottomBanner.importable';
+import { SubMeta } from '../components/SubMeta';
+import { SubNav } from '../components/SubNav.importable';
+import { canRenderAds } from '../lib/canRenderAds';
+import { getContributionsServiceUrl } from '../lib/contributions';
+import { decidePalette } from '../lib/decidePalette';
+import { decideTrail } from '../lib/decideTrail';
+import { decideLanguage, decideLanguageDirection } from '../lib/lang';
+import type { NavType } from '../model/extract-nav';
+import type { FEArticleType } from '../types/frontend';
+import type { RenderingTarget } from '../types/renderingTarget';
+import { BannerWrapper, SendToBack, Stuck } from './lib/stickiness';
+
+const PictureGrid = ({ children }: { children: React.ReactNode }) => (
+	<div
+		css={css`
+			/* IE Fallback */
+			display: flex;
+			flex-direction: column;
+			${until.leftCol} {
+				margin-left: 0px;
+			}
+			${from.leftCol} {
+				margin-left: 151px;
+			}
+			${from.wide} {
+				margin-left: 230px;
+			}
+
+			@supports (display: grid) {
+				display: grid;
+				width: 100%;
+				margin-left: 0;
+
+				grid-column-gap: 10px;
+
+				/*
+					Explanation of each unit of grid-template-columns
+
+					Left Column (220 - 1px border)
+					Vertical grey border
+					Main content
+					Right Column
+					
+				*/
+				${from.wide} {
+				
+								grid-template-columns: 219px 1px 1fr;
+
+								grid-template-areas:
+									'title  border  headline'
+									'lines  border  media'
+									'meta   border  media'
+									'meta   border  standfirst'
+									'.      border  submeta'
+									'.      border  .';
+						  
+				
+				}
+
+				${until.wide} {
+					grid-template-columns: 140px 1px 1fr 300px;
+
+					
+								grid-template-areas:
+									'title  border  headline    headline'
+									'lines  border  standfirst  standfirst'
+									'meta   border  media       media'
+									'meta   border  media       media'
+									'.      border  submeta     submeta'
+									'.      border  .           . ';
+						
+				}
+
+				/*
+					Explanation of each unit of grid-template-columns
+
+					Main content
+					Right Column
+				*/
+				${until.leftCol} {
+					
+								grid-template-columns: 1fr; /* Main content */
+
+								grid-template-areas:
+									'title     '
+									'headline  '
+									'standfirst'
+									'media     '
+									'lines     '
+									'meta      '
+									'submeta      '
+									'.         ';
+						
+							
+						}
+				}
+
+				${until.desktop} {
+					grid-column-gap: 0px;
+					grid-template-columns: 1fr; /* Main content */
+					grid-template-areas:
+						'title'
+						'headline'
+						'standfirst'
+						'media'
+						'lines'
+						'meta'
+						'submeta';
+				}
+
+				${until.tablet} {
+					grid-column-gap: 0px;
+					grid-template-columns: 1fr; /* Main content */
+				
+								grid-template-areas:
+									'title'
+									'headline'
+									'standfirst'
+									'media'
+									'lines'
+									'meta'
+									'submeta';
+				}						  
+			
+				
+			}
+		`}
+	>
+		{children}
+	</div>
+);
+
+const maxWidth = css`
+	${from.desktop} {
+		max-width: 620px;
+	}
+`;
+
+// const stretchLines = (isPictureContent: boolean) => css`
+// 	${!isPictureContent && until.phablet} {
+// 		margin-left: -20px;
+// 		margin-right: -20px;
+// 	}
+// 	${!isPictureContent && until.mobileLandscape} {
+// 		margin-left: -10px;
+// 		margin-right: -10px;
+// 	}
+// `;
+const mainMediaWrapper = css`
+	position: relative;
+	${until.phablet} {
+		margin-left: 20px;
+		margin-right: 20px;
+	}
+	${until.mobileLandscape} {
+		margin-left: 10px;
+		margin-right: 10px;
+	}
+`;
+
+const PositionHeadline = ({ children }: { children: React.ReactNode }) => {
+	return <div css={maxWidth}>{children}</div>;
+};
+
+interface Props {
+	article: FEArticleType;
+	NAV: NavType;
+	format: ArticleFormat;
+	renderingTarget: RenderingTarget;
+}
+
+export const PictureLayout = ({
+	article,
+	NAV,
+	format,
+	renderingTarget,
+}: Props) => {
+	const {
+		config: { isPaidContent, host },
+	} = article;
+
+	const isInEuropeTest =
+		article.config.abTests.europeNetworkFrontVariant === 'variant';
+
+	// TODO:
+	// 1) Read 'forceEpic' value from URL parameter and use it to force the slot to render
+	// 2) Otherwise, ensure slot only renders if `article.config.shouldHideReaderRevenue` equals false.
+
+	const showComments = article.isCommentable;
+
+	const { branding } = article.commercialProperties[article.editionId];
+
+	const palette = decidePalette(format);
+
+	const contributionsServiceUrl = getContributionsServiceUrl(article);
+
+	const renderAds = canRenderAds(article);
+
+	const showSubNavTopBorder = false;
+
+	return (
+		<>
+			<>
+				<div>
+					{renderAds && (
+						<Stuck>
+							<Section
+								fullWidth={true}
+								showTopBorder={false}
+								showSideBorders={false}
+								padSides={false}
+								shouldCenter={false}
+							>
+								<HeaderAdSlot />
+							</Section>
+						</Stuck>
+					)}
+					<SendToBack>
+						<Section
+							fullWidth={true}
+							shouldCenter={false}
+							showTopBorder={false}
+							showSideBorders={false}
+							padSides={false}
+							backgroundColour={brandBackground.primary}
+							element="header"
+						>
+							<Header
+								editionId={article.editionId}
+								idUrl={article.config.idUrl}
+								mmaUrl={article.config.mmaUrl}
+								discussionApiUrl={
+									article.config.discussionApiUrl
+								}
+								urls={article.nav.readerRevenueLinks.header}
+								remoteHeader={
+									!!article.config.switches.remoteHeader
+								}
+								contributionsServiceUrl={
+									contributionsServiceUrl
+								}
+								idApiUrl={article.config.idApiUrl}
+								isInEuropeTest={isInEuropeTest}
+								headerTopBarSearchCapiSwitch={
+									!!article.config.switches
+										.headerTopBarSearchCapi
+								}
+							/>
+						</Section>
+						<Section
+							fullWidth={true}
+							borderColour={brandLine.primary}
+							showTopBorder={false}
+							padSides={false}
+							backgroundColour={brandBackground.primary}
+							element="nav"
+							format={format}
+						>
+							<Nav
+								nav={NAV}
+								isImmersive={
+									format.display === ArticleDisplay.Immersive
+								}
+								displayRoundel={
+									format.display ===
+										ArticleDisplay.Immersive ||
+									format.theme === ArticleSpecial.Labs
+								}
+								selectedPillar={NAV.selectedPillar}
+								subscribeUrl={
+									article.nav.readerRevenueLinks.header
+										.subscribe
+								}
+								editionId={article.editionId}
+								headerTopBarSwitch={
+									!!article.config.switches.headerTopNav
+								}
+								isInEuropeTest={isInEuropeTest}
+							/>
+						</Section>
+
+						{NAV.subNavSections && (
+							<Section
+								fullWidth={true}
+								backgroundColour={palette.background.article}
+								padSides={false}
+								element="aside"
+								format={format}
+								showTopBorder={showSubNavTopBorder}
+							>
+								<Island deferUntil="idle">
+									<SubNav
+										subNavSections={NAV.subNavSections}
+										currentNavLink={NAV.currentNavLink}
+										linkHoverColour={
+											palette.text.articleLinkHover
+										}
+										borderColour={palette.border.subNav}
+										subNavLinkColour={
+											palette.text.subNavLink
+										}
+									/>
+								</Island>
+							</Section>
+						)}
+
+						<Section
+							fullWidth={true}
+							backgroundColour={palette.background.article}
+							padSides={false}
+							showTopBorder={false}
+							borderColour={palette.border.secondary}
+						>
+							<StraightLines
+								count={4}
+								color={palette.border.secondary}
+								cssOverrides={css`
+									display: block;
+								`}
+							/>
+						</Section>
+					</SendToBack>
+				</div>
+			</>
+
+			<main
+				data-layout="PictureLayout"
+				id="maincontent"
+				lang={decideLanguage(article.lang)}
+				dir={decideLanguageDirection(article.isRightToLeftLang)}
+			>
+				<Section
+					fullWidth={true}
+					showTopBorder={false}
+					backgroundColour={palette.background.article}
+					element="article"
+					borderColour={palette.border.secondary}
+				>
+					<PictureGrid>
+						<GridItem area="title" element="aside">
+							<ArticleTitle
+								format={format}
+								tags={article.tags}
+								sectionLabel={article.sectionLabel}
+								sectionUrl={article.sectionUrl}
+								guardianBaseURL={article.guardianBaseURL}
+								badge={article.badge?.enhanced}
+							/>
+						</GridItem>
+						<GridItem area="border">
+							<Border format={format} />
+						</GridItem>
+						<GridItem area="headline">
+							<PositionHeadline>
+								<ArticleHeadline
+									format={format}
+									headlineString={article.headline}
+									tags={article.tags}
+									byline={article.byline}
+									webPublicationDateDeprecated={
+										article.webPublicationDateDeprecated
+									}
+									hasStarRating={
+										article.starRating !== undefined
+									}
+									renderingTarget={renderingTarget}
+								/>
+							</PositionHeadline>
+						</GridItem>
+						<GridItem area="media">
+							<div css={mainMediaWrapper}>
+								<MainMedia
+									format={format}
+									elements={article.mainMediaElements}
+									starRating={
+										format.design ===
+											ArticleDesign.Review &&
+										article.starRating !== undefined
+											? article.starRating
+											: undefined
+									}
+									host={host}
+									pageId={article.pageId}
+									webTitle={article.webTitle}
+									ajaxUrl={article.config.ajaxUrl}
+									switches={article.config.switches}
+									isAdFreeUser={article.isAdFreeUser}
+									isSensitive={article.config.isSensitive}
+								/>
+							</div>
+						</GridItem>
+						<GridItem area="standfirst">
+							<Standfirst
+								format={format}
+								standfirst={article.standfirst}
+							/>
+						</GridItem>
+						<GridItem area="lines">
+							<div>
+								<div>
+									<DecideLines
+										format={format}
+										color={palette.border.secondary}
+									/>
+								</div>
+							</div>
+						</GridItem>
+						<GridItem area="meta" element="aside">
+							<div>
+								<ArticleMeta
+									branding={branding}
+									format={format}
+									pageId={article.pageId}
+									webTitle={article.webTitle}
+									byline={article.byline}
+									tags={article.tags}
+									primaryDateline={
+										article.webPublicationDateDisplay
+									}
+									secondaryDateline={
+										article.webPublicationSecondaryDateDisplay
+									}
+									isCommentable={article.isCommentable}
+									discussionApiUrl={
+										article.config.discussionApiUrl
+									}
+									shortUrlId={article.config.shortUrlId}
+									ajaxUrl={article.config.ajaxUrl}
+									showShareCount={
+										!!article.config.switches
+											.serverShareCounts
+									}
+									renderingTarget={renderingTarget}
+								/>
+							</div>
+						</GridItem>
+						<GridItem area="submeta">
+							<ArticleContainer format={format}>
+								<StraightLines
+									count={4}
+									color={palette.border.secondary}
+									cssOverrides={css`
+										display: block;
+									`}
+								/>
+								<SubMeta
+									format={format}
+									subMetaKeywordLinks={
+										article.subMetaKeywordLinks
+									}
+									subMetaSectionLinks={
+										article.subMetaSectionLinks
+									}
+									pageId={article.pageId}
+									webUrl={article.webURL}
+									webTitle={article.webTitle}
+									showBottomSocialButtons={
+										article.showBottomSocialButtons
+									}
+									badge={article.badge?.enhanced}
+								/>
+							</ArticleContainer>
+						</GridItem>
+					</PictureGrid>
+				</Section>
+
+				{renderAds && (
+					<Section
+						fullWidth={true}
+						padSides={false}
+						showTopBorder={false}
+						showSideBorders={false}
+						backgroundColour={neutral[93]}
+						element="aside"
+					>
+						<AdSlot
+							position="merchandising-high"
+							display={format.display}
+						/>
+					</Section>
+				)}
+
+				{article.storyPackage && (
+					<Section fullWidth={true}>
+						<Island deferUntil="visible">
+							<Carousel
+								heading={article.storyPackage.heading}
+								trails={article.storyPackage.trails.map(
+									decideTrail,
+								)}
+								onwardsSource="more-on-this-story"
+								format={format}
+								leftColSize={'compact'}
+								discussionApiUrl={
+									article.config.discussionApiUrl
+								}
+							/>
+						</Island>
+					</Section>
+				)}
+
+				<Island
+					clientOnly={true}
+					deferUntil="visible"
+					placeholderHeight={600}
+				>
+					<OnwardsUpper
+						ajaxUrl={article.config.ajaxUrl}
+						hasRelated={article.hasRelated}
+						hasStoryPackage={article.hasStoryPackage}
+						isAdFreeUser={article.isAdFreeUser}
+						pageId={article.pageId}
+						isPaidContent={!!article.config.isPaidContent}
+						showRelatedContent={article.config.showRelatedContent}
+						keywordIds={article.config.keywordIds}
+						contentType={article.contentType}
+						tags={article.tags}
+						format={format}
+						pillar={format.theme}
+						editionId={article.editionId}
+						shortUrlId={article.config.shortUrlId}
+						discussionApiUrl={article.config.discussionApiUrl}
+					/>
+				</Island>
+
+				{!isPaidContent && showComments && (
+					<Section
+						fullWidth={true}
+						sectionId="comments"
+						element="section"
+					>
+						<DiscussionLayout
+							discussionApiUrl={article.config.discussionApiUrl}
+							shortUrlId={article.config.shortUrlId}
+							format={format}
+							discussionD2Uid={article.config.discussionD2Uid}
+							discussionApiClientHeader={
+								article.config.discussionApiClientHeader
+							}
+							enableDiscussionSwitch={
+								!!article.config.switches.enableDiscussionSwitch
+							}
+							isAdFreeUser={article.isAdFreeUser}
+							shouldHideAds={article.shouldHideAds}
+							idApiUrl={article.config.idApiUrl}
+						/>
+					</Section>
+				)}
+
+				{!isPaidContent && (
+					<Section
+						title="Most viewed"
+						padContent={false}
+						verticalMargins={false}
+						element="aside"
+						data-print-layout="hide"
+						data-link-name="most-popular"
+						data-component="most-popular"
+					>
+						<MostViewedFooterLayout renderAds={renderAds}>
+							<Island clientOnly={true} deferUntil="visible">
+								<MostViewedFooterData
+									sectionId={article.config.section}
+									format={format}
+									ajaxUrl={article.config.ajaxUrl}
+									edition={article.editionId}
+								/>
+							</Island>
+						</MostViewedFooterLayout>
+					</Section>
+				)}
+
+				{renderAds && (
+					<Section
+						fullWidth={true}
+						padSides={false}
+						showTopBorder={false}
+						showSideBorders={false}
+						backgroundColour={neutral[93]}
+						element="aside"
+					>
+						<AdSlot
+							position="merchandising"
+							display={format.display}
+						/>
+					</Section>
+				)}
+			</main>
+
+			{NAV.subNavSections && (
+				<Section fullWidth={true} padSides={false} element="aside">
+					<Island deferUntil="visible">
+						<SubNav
+							subNavSections={NAV.subNavSections}
+							currentNavLink={NAV.currentNavLink}
+							linkHoverColour={palette.text.articleLinkHover}
+							borderColour={palette.border.subNav}
+						/>
+					</Island>
+				</Section>
+			)}
+
+			<Section
+				fullWidth={true}
+				padSides={false}
+				backgroundColour={brandBackground.primary}
+				borderColour={brandBorder.primary}
+				showSideBorders={false}
+				element="footer"
+			>
+				<Footer
+					pageFooter={article.pageFooter}
+					selectedPillar={NAV.selectedPillar}
+					pillars={NAV.pillars}
+					urls={article.nav.readerRevenueLinks.header}
+					editionId={article.editionId}
+					contributionsServiceUrl={article.contributionsServiceUrl}
+				/>
+			</Section>
+
+			<BannerWrapper>
+				<Island deferUntil="idle" clientOnly={true}>
+					<StickyBottomBanner
+						contentType={article.contentType}
+						contributionsServiceUrl={contributionsServiceUrl}
+						idApiUrl={article.config.idApiUrl}
+						isMinuteArticle={article.pageType.isMinuteArticle}
+						isPaidContent={article.pageType.isPaidContent}
+						isPreview={!!article.config.isPreview}
+						isSensitive={article.config.isSensitive}
+						keywordIds={article.config.keywordIds}
+						pageId={article.pageId}
+						sectionId={article.config.section}
+						shouldHideReaderRevenue={
+							article.shouldHideReaderRevenue
+						}
+						remoteBannerSwitch={
+							!!article.config.switches.remoteBanner
+						}
+						puzzleBannerSwitch={
+							!!article.config.switches.puzzlesBanner
+						}
+						tags={article.tags}
+					/>
+				</Island>
+			</BannerWrapper>
+			<MobileStickyContainer />
+		</>
+	);
+};

--- a/dotcom-rendering/src/layouts/PictureLayout.tsx
+++ b/dotcom-rendering/src/layouts/PictureLayout.tsx
@@ -77,32 +77,25 @@ const PictureGrid = ({ children }: { children: React.ReactNode }) => (
 					
 				*/
 				${from.wide} {
-				
-								grid-template-columns: 219px 1px 1fr;
-
-								grid-template-areas:
-									'title  border  headline'
-									'lines  border  media'
-									'meta   border  media'
-									'meta   border  standfirst'
-									'.      border  submeta'
-									'.      border  .';
-						  
-				
+					grid-template-columns: 219px 1px 1fr;
+					grid-template-areas:
+						'title  border  headline'
+						'lines  border  media'
+						'meta   border  media'
+						'meta   border  standfirst'
+						'.      border  submeta'
+						'.      border  .';
 				}
 
 				${until.wide} {
 					grid-template-columns: 140px 1px 1fr 300px;
-
-					
-								grid-template-areas:
-									'title  border  headline    headline'
-									'meta   border  media       media'
-									'meta   border  media       media'
-									'lines  border  standfirst  standfirst'
-									'.      border  submeta     submeta'
-									'.      border  .           . ';
-						
+					grid-template-areas:
+						'title  border  headline    headline'
+						'meta   border  media       media'
+						'meta   border  media       media'
+						'lines  border  standfirst  standfirst'
+						'.      border  submeta     submeta'
+						'.      border  .           . ';
 				}
 
 				/*
@@ -111,23 +104,18 @@ const PictureGrid = ({ children }: { children: React.ReactNode }) => (
 					Main content
 					Right Column
 				*/
-				${until.leftCol} {					grid-column-gap: 0px;
-
-					
-								grid-template-columns: 1fr; /* Main content */
-
-								grid-template-areas:
-									'title     '
-									'headline  '
-									'media     '
-									'standfirst'
-									'lines     '
-									'meta      '
-									'submeta   '
-									'.         ';
-						
-							
-						}
+				${until.leftCol} {
+					grid-column-gap: 0px;
+					grid-template-columns: 1fr; /* Main content */
+					grid-template-areas:
+						'title     '
+						'headline  '
+						'media     '
+						'standfirst'
+						'lines     '
+						'meta      '
+						'submeta   '
+						'.         ';
 				}
 
 				${until.desktop} {
@@ -146,18 +134,15 @@ const PictureGrid = ({ children }: { children: React.ReactNode }) => (
 				${until.tablet} {
 					grid-column-gap: 0px;
 					grid-template-columns: 1fr; /* Main content */
-				
-								grid-template-areas:
-									'title'
-									'headline'
-									'lines'
-									'meta'
-									'media'
-									'standfirst'
-									'submeta';
-				}						  
-			
-				
+					grid-template-areas:
+						'title'
+						'headline'
+						'lines'
+						'meta'
+						'media'
+						'standfirst'
+						'submeta';
+				}
 			}
 		`}
 	>

--- a/dotcom-rendering/src/layouts/PictureLayout.tsx
+++ b/dotcom-rendering/src/layouts/PictureLayout.tsx
@@ -10,7 +10,7 @@ import {
 	until,
 } from '@guardian/source-foundations';
 import { StraightLines } from '@guardian/source-react-components-development-kitchen';
-import { AdSlot, MobileStickyContainer } from '../components/AdSlot';
+import { AdSlot, MobileStickyContainer } from '../components/AdSlot.web';
 import { ArticleContainer } from '../components/ArticleContainer';
 import { ArticleHeadline } from '../components/ArticleHeadline';
 import { ArticleMeta } from '../components/ArticleMeta';
@@ -41,7 +41,6 @@ import { decideTrail } from '../lib/decideTrail';
 import { decideLanguage, decideLanguageDirection } from '../lib/lang';
 import type { NavType } from '../model/extract-nav';
 import type { FEArticleType } from '../types/frontend';
-import type { RenderingTarget } from '../types/renderingTarget';
 import { BannerWrapper, SendToBack, Stuck } from './lib/stickiness';
 
 const PictureGrid = ({ children }: { children: React.ReactNode }) => (
@@ -186,15 +185,9 @@ interface Props {
 	article: FEArticleType;
 	NAV: NavType;
 	format: ArticleFormat;
-	renderingTarget: RenderingTarget;
 }
 
-export const PictureLayout = ({
-	article,
-	NAV,
-	format,
-	renderingTarget,
-}: Props) => {
+export const PictureLayout = ({ article, NAV, format }: Props) => {
 	const {
 		config: { isPaidContent, host },
 	} = article;
@@ -383,7 +376,6 @@ export const PictureLayout = ({
 									hasStarRating={
 										article.starRating !== undefined
 									}
-									renderingTarget={renderingTarget}
 								/>
 							</PositionHeadline>
 						</GridItem>
@@ -450,7 +442,6 @@ export const PictureLayout = ({
 										!!article.config.switches
 											.serverShareCounts
 									}
-									renderingTarget={renderingTarget}
 								/>
 							</div>
 						</GridItem>

--- a/dotcom-rendering/src/layouts/PictureLayout.tsx
+++ b/dotcom-rendering/src/layouts/PictureLayout.tsx
@@ -220,10 +220,10 @@ const avatarPositionStyles = css`
 `;
 
 const LeftColLines = (displayAvatarUrl: boolean) => css`
+	margin-bottom: 4px;
 	${displayAvatarUrl
 		? css`
 				margin-top: -29px;
-				margin-bottom: 8px;
 		  `
 		: ''}
 `;

--- a/dotcom-rendering/src/layouts/PictureLayout.tsx
+++ b/dotcom-rendering/src/layouts/PictureLayout.tsx
@@ -435,7 +435,6 @@ export const PictureLayout = ({ article, NAV, format }: Props) => {
 												'number'
 											}
 											hasAvatar={displayAvatarUrl}
-											renderingTarget={renderingTarget}
 										/>
 									</div>
 
@@ -474,7 +473,6 @@ export const PictureLayout = ({ article, NAV, format }: Props) => {
 										hasStarRating={
 											article.starRating !== undefined
 										}
-										renderingTarget={renderingTarget}
 									/>
 								</div>
 							</GridItem>

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -52,13 +52,7 @@ import type { NavType } from '../model/extract-nav';
 import type { DCRArticle } from '../types/frontend';
 import { BannerWrapper, SendToBack, Stuck } from './lib/stickiness';
 
-const ShowcaseGrid = ({
-	children,
-	isPictureContent,
-}: {
-	children: React.ReactNode;
-	isPictureContent: boolean;
-}) => (
+const ShowcaseGrid = ({ children }: { children: React.ReactNode }) => (
 	<div
 		css={css`
 			/* IE Fallback */
@@ -91,53 +85,25 @@ const ShowcaseGrid = ({
 
 				*/
 				${from.wide} {
-					${isPictureContent
-						? css`
-								grid-template-columns: 219px 1px 1fr;
-
-								grid-template-areas:
-									'title  border  headline'
-									'lines  border  standfirst'
-									'meta   border  media'
-									'meta   border  media'
-									'.      border  body'
-									'.      border  .';
-						  `
-						: css`
-								grid-template-columns: 219px 1px 1fr 300px;
-
-								grid-template-areas:
-									'title  border  headline    headline'
-									'lines  border  media       media'
-									'meta   border  media       media'
-									'meta   border  standfirst  right-column'
-									'.      border  body        right-column'
-									'.      border  .           right-column';
-						  `}
+					grid-template-columns: 219px 1px 1fr 300px;
+					grid-template-areas:
+						'title  border  headline    headline'
+						'lines  border  media       media'
+						'meta   border  media       media'
+						'meta   border  standfirst  right-column'
+						'.      border  body        right-column'
+						'.      border  .           right-column';
 				}
 
 				${until.wide} {
 					grid-template-columns: 140px 1px 1fr 300px;
-
-					${isPictureContent
-						? css`
-								grid-template-areas:
-									'title  border  headline    headline'
-									'lines  border  standfirst  standfirst'
-									'meta   border  media       media'
-									'meta   border  media       media'
-									'.      border  body        body'
-									'.      border  .           . ';
-						  `
-						: css`
-								grid-template-areas:
-									'title  border  headline    headline'
-									'lines  border  media       media'
-									'meta   border  media       media'
-									'meta   border  standfirst  right-column'
-									'.      border  body        right-column'
-									'.      border  .           right-column';
-						  `}
+					grid-template-areas:
+						'title  border  headline    headline'
+						'lines  border  media       media'
+						'meta   border  media       media'
+						'meta   border  standfirst  right-column'
+						'.      border  body        right-column'
+						'.      border  .           right-column';
 				}
 
 				/*
@@ -147,33 +113,16 @@ const ShowcaseGrid = ({
 					Right Column
 				*/
 				${until.leftCol} {
-					${isPictureContent
-						? css`
-								grid-template-columns: 1fr; /* Main content */
-
-								grid-template-areas:
-									'title     '
-									'headline  '
-									'standfirst'
-									'media     '
-									'lines     '
-									'meta      '
-									'body      '
-									'.         ';
-						  `
-						: css`
-								grid-template-columns: 1fr 300px;
-
-								grid-template-areas:
-									'title      right-column'
-									'headline   right-column'
-									'standfirst right-column'
-									'media      right-column'
-									'lines      right-column'
-									'meta       right-column'
-									'body       right-column'
-									'.          right-column';
-						  `}
+					grid-template-columns: 1fr 300px;
+					grid-template-areas:
+						'title      right-column'
+						'headline   right-column'
+						'standfirst right-column'
+						'media      right-column'
+						'lines      right-column'
+						'meta       right-column'
+						'body       right-column'
+						'.          right-column';
 				}
 
 				${until.desktop} {
@@ -192,27 +141,14 @@ const ShowcaseGrid = ({
 				${until.tablet} {
 					grid-column-gap: 0px;
 					grid-template-columns: 1fr; /* Main content */
-					${isPictureContent
-						? css`
-								grid-template-areas:
-									'title'
-									'headline'
-									'standfirst'
-									'media'
-									'lines'
-									'meta'
-									'body';
-						  `
-						: css`
-								grid-template-areas:
-									'media'
-									'title'
-									'headline'
-									'standfirst'
-									'lines'
-									'meta'
-									'body';
-						  `}
+					grid-template-areas:
+						'media'
+						'title'
+						'headline'
+						'standfirst'
+						'lines'
+						'meta'
+						'body';
 				}
 			}
 		`}
@@ -221,41 +157,31 @@ const ShowcaseGrid = ({
 	</div>
 );
 
-const maxWidth = (isPictureContent: boolean) => css`
-	${!isPictureContent && from.desktop} {
+const maxWidth = css`
+	${from.desktop} {
 		max-width: 620px;
 	}
 `;
 
-const stretchLines = (isPictureContent: boolean) => css`
-	${!isPictureContent && until.phablet} {
+const stretchLines = css`
+	${until.phablet} {
 		margin-left: -20px;
 		margin-right: -20px;
 	}
-	${!isPictureContent && until.mobileLandscape} {
+	${until.mobileLandscape} {
 		margin-left: -10px;
 		margin-right: -10px;
 	}
 `;
-const mainMediaWrapper = (isPictureContent: boolean) => css`
+const mainMediaWrapper = css`
 	position: relative;
-	${isPictureContent && until.phablet} {
-		margin-left: 20px;
-		margin-right: 20px;
-	}
-	${isPictureContent && until.mobileLandscape} {
-		margin-left: 10px;
-		margin-right: 10px;
-	}
 `;
 
 const PositionHeadline = ({
 	design,
-	isPictureContent,
 	children,
 }: {
 	design: ArticleDesign;
-	isPictureContent: boolean;
 	children: React.ReactNode;
 }) => {
 	switch (design) {
@@ -268,11 +194,11 @@ const PositionHeadline = ({
 						}
 					`}
 				>
-					<div css={maxWidth(isPictureContent)}>{children}</div>
+					<div css={maxWidth}>{children}</div>
 				</div>
 			);
 		default:
-			return <div css={maxWidth(isPictureContent)}>{children}</div>;
+			return <div css={maxWidth}>{children}</div>;
 	}
 };
 
@@ -306,11 +232,6 @@ export const ShowcaseLayout = ({ article, NAV, format }: Props) => {
 	const renderAds = canRenderAds(article);
 
 	const isLabs = format.theme === ArticleSpecial.Labs;
-
-	const showSubNavTopBorder =
-		format.design !== ArticleDesign.Picture ? true : false;
-
-	const isPictureContent = format.design === ArticleDesign.Picture;
 
 	const { renderingTarget } = useConfig();
 
@@ -404,7 +325,6 @@ export const ShowcaseLayout = ({ article, NAV, format }: Props) => {
 									padSides={false}
 									element="aside"
 									format={format}
-									showTopBorder={showSubNavTopBorder}
 								>
 									<Island deferUntil="idle">
 										<SubNav
@@ -516,9 +436,9 @@ export const ShowcaseLayout = ({ article, NAV, format }: Props) => {
 					element="article"
 					borderColour={palette.border.secondary}
 				>
-					<ShowcaseGrid isPictureContent={isPictureContent}>
+					<ShowcaseGrid>
 						<GridItem area="media">
-							<div css={mainMediaWrapper(isPictureContent)}>
+							<div css={mainMediaWrapper}>
 								<MainMedia
 									format={format}
 									elements={article.mainMediaElements}
@@ -553,10 +473,7 @@ export const ShowcaseLayout = ({ article, NAV, format }: Props) => {
 							<Border format={format} />
 						</GridItem>
 						<GridItem area="headline">
-							<PositionHeadline
-								design={format.design}
-								isPictureContent={isPictureContent}
-							>
+							<PositionHeadline design={format.design}>
 								<ArticleHeadline
 									format={format}
 									headlineString={article.headline}
@@ -578,8 +495,8 @@ export const ShowcaseLayout = ({ article, NAV, format }: Props) => {
 							/>
 						</GridItem>
 						<GridItem area="lines">
-							<div css={maxWidth(isPictureContent)}>
-								<div css={stretchLines(isPictureContent)}>
+							<div css={maxWidth}>
+								<div css={stretchLines}>
 									<DecideLines
 										format={format}
 										color={palette.border.secondary}
@@ -588,7 +505,7 @@ export const ShowcaseLayout = ({ article, NAV, format }: Props) => {
 							</div>
 						</GridItem>
 						<GridItem area="meta" element="aside">
-							<div css={maxWidth(isPictureContent)}>
+							<div css={maxWidth}>
 								<ArticleMeta
 									branding={branding}
 									format={format}

--- a/dotcom-rendering/src/lib/decidePalette.ts
+++ b/dotcom-rendering/src/lib/decidePalette.ts
@@ -566,11 +566,8 @@ const textStandfirstLink = (format: ArticleFormat): string => {
 		}
 	}
 
-	if (
-		format.design === ArticleDesign.Picture &&
-		format.theme === Pillar.Opinion
-	)
-		return palette.opinion[500];
+	if (format.design === ArticleDesign.Picture)
+		return pillarPalette[format.theme].bright;
 
 	if (format.theme === ArticleSpecial.SpecialReport)
 		return specialReport[400];

--- a/dotcom-rendering/src/lib/decidePalette.ts
+++ b/dotcom-rendering/src/lib/decidePalette.ts
@@ -565,6 +565,13 @@ const textStandfirstLink = (format: ArticleFormat): string => {
 				return pillarPalette[format.theme].dark;
 		}
 	}
+
+	if (
+		format.design === ArticleDesign.Picture &&
+		format.theme === Pillar.Opinion
+	)
+		return palette.opinion[500];
+
 	if (format.theme === ArticleSpecial.SpecialReport)
 		return specialReport[400];
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change and why?

This PR does a couple of things as a follow-up to previous PRs, [notably this one to support the content type](https://github.com/guardian/dotcom-rendering/pull/8562) and feedback from the design team on the back of it. In short, it creates a new `PictureLayout.tsx` which gets used to render picture content with the design feedback incorporated, and it restores the original showcase layout file to a state where it doesn't consider `isPictureContent` in its css decisions (i.e. to the point prior to #8562).

The original PR made use of the `ShowcaseLayout.tsx` as that seemed like an appropriate foundation and abstraction to use for the way this content should be displayed. However, iterating on it further, this doesn't feel like that is the case anymore: while branching logic does get used in some other places for layout decisions (e.g. `isMatchReport` impacting the grid-template-areas in `StandardLayout.tsx`), the concern is that the code for `ShowcaseLayout` is becoming excessively cluttered with variants that result in pages which look quite different from each other. 

In practice, this has meant:
1.  using `ShowcaseLayout.tsx` as a base to create `PictureLayout.tsx`, then stripping away some of the logic that isn't applicable to the new layout (e.g. cartoon pages don't have that column on the right hand side with an ad slot). There's also some logic to support showing an avatar (such as on the [first dog on the moon cartoons](https://www.theguardian.com/commentisfree/2023/aug/28/i-only-read-about-climate-change-now-because-i-have-to)), which was taken from the `CommentLayout.tsx`
2. Making further adjustments based on design feedback, specifically: 
- Moving the standfirst underneath the cartoon at all breakpoints, and moving the meta to above the picture at smaller breakpoints (when it all becomes a single column)
- Adjusting the link colours to be .500 ("bright") instead of .400 
- Ensuring the image at the desktop breakpoint has the correct margin on the right
- Styling the fill of the share icons to black on hover
3. Updating `decideLayout` to make use of the new `PictureLayout`
4. Undoing the changes made to `ShowcaseLayout.tsx` in both #8562 and #8638 



## Screenshots

From the last PR that used `ShowcaseLayout`, to this one with `PictureLayout`, at all breakpoints:

| Showcase wide    | Picture wide      |
| ----------- | ---------- |
| ![swide][] | ![pwide][] |

[swide]:https://github.com/guardian/dotcom-rendering/assets/102960844/7bc9ab73-e900-4278-ae2a-438b010847b2
[pwide]:https://github.com/guardian/dotcom-rendering/assets/102960844/3ae5a265-a777-4327-aa4d-30b37ef1e090


| Showcase leftCol    | Picture leftCol      |
| ----------- | ---------- |
| ![sleftCol][] | ![pleftCol][] |

[sleftCol]:https://github.com/guardian/dotcom-rendering/assets/102960844/1de0c9d3-1975-4ef0-a12a-3f4237c94c59
[pleftCol]:https://github.com/guardian/dotcom-rendering/assets/102960844/00709be7-392f-4246-8286-2b66e78474c4

| Showcase desktop    | Picture desktop      |
| ----------- | ---------- |
| ![sdesktop][] | ![pdesktop][] |

[sdesktop]:https://github.com/guardian/dotcom-rendering/assets/102960844/663667cb-950a-4854-9fb0-afab2f91bdf7
[pdesktop]:https://github.com/guardian/dotcom-rendering/assets/102960844/ec9c0d8c-79d6-4a24-811e-389577fe5815



| Showcase tablet    | Picture tablet      |
| ----------- | ---------- |
| ![stablet][] | ![ptablet][] |

[stablet]:https://github.com/guardian/dotcom-rendering/assets/102960844/88a73122-a710-4951-9df9-6d57df812a57
[ptablet]:https://github.com/guardian/dotcom-rendering/assets/102960844/39aa799f-1c1f-4e8e-9996-1761d4f485b8


| Showcase phablet    | Picture phablet      |
| ----------- | ---------- |
| ![sphablet][] | ![pphablet][] |

[sphablet]:https://github.com/guardian/dotcom-rendering/assets/102960844/16f1f52a-328a-480a-ab24-671046acd2df
[pphablet]:https://github.com/guardian/dotcom-rendering/assets/102960844/6763357f-7caa-4eca-bdde-c82dd8800b15



| Showcase mobile    | Picture mobile      |
| ----------- | ---------- |
| ![smobile][] | ![pmobile][] |

[smobile]:https://github.com/guardian/dotcom-rendering/assets/102960844/5fd7de4d-3bc4-469a-87e1-d3c50f6c524b
[pmobile]:https://github.com/guardian/dotcom-rendering/assets/102960844/b49bd5ed-fa03-4b6c-a2c6-071fcc690a74


<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
