### PR TITLE
Revert "Merge pull request #8508 from guardian/mob/log-all-okta"

### DIFF
--- a/dotcom-rendering/src/client/sentryLoader/index.test.ts
+++ b/dotcom-rendering/src/client/sentryLoader/index.test.ts
@@ -10,7 +10,6 @@ describe('Enable Sentry when it passes loading conditions', () => {
 				isDev: false,
 				enableSentryReporting: false,
 				isInBrowserVariantTest: true,
-				isInOktaVariantTest: false,
 				random: 99 / 100,
 			}),
 		).toEqual(false);
@@ -21,7 +20,6 @@ describe('Enable Sentry when it passes loading conditions', () => {
 				isDev: true,
 				enableSentryReporting: true,
 				isInBrowserVariantTest: true,
-				isInOktaVariantTest: true,
 				random: 1 / 100,
 			}),
 		).toEqual(false);
@@ -32,18 +30,6 @@ describe('Enable Sentry when it passes loading conditions', () => {
 				isDev: false,
 				enableSentryReporting: true,
 				isInBrowserVariantTest: true,
-				isInOktaVariantTest: false,
-				random: 1 / 100,
-			}),
-		).toEqual(true);
-	});
-	it('does enable Sentry when the user is in the Okta variant test', () => {
-		expect(
-			isSentryEnabled({
-				isDev: false,
-				enableSentryReporting: true,
-				isInBrowserVariantTest: false,
-				isInOktaVariantTest: true,
 				random: 1 / 100,
 			}),
 		).toEqual(true);
@@ -54,7 +40,6 @@ describe('Enable Sentry when it passes loading conditions', () => {
 				isDev: false,
 				enableSentryReporting: true,
 				isInBrowserVariantTest: false,
-				isInOktaVariantTest: false,
 				random: 1 / 100,
 			}),
 		).toEqual(false);
@@ -63,7 +48,6 @@ describe('Enable Sentry when it passes loading conditions', () => {
 				isDev: false,
 				enableSentryReporting: true,
 				isInBrowserVariantTest: false,
-				isInOktaVariantTest: false,
 				random: 99 / 100,
 			}),
 		).toEqual(false);
@@ -72,7 +56,6 @@ describe('Enable Sentry when it passes loading conditions', () => {
 				isDev: false,
 				enableSentryReporting: true,
 				isInBrowserVariantTest: false,
-				isInOktaVariantTest: false,
 				random: 99.0001 / 100,
 			}),
 		).toEqual(true);
@@ -81,7 +64,6 @@ describe('Enable Sentry when it passes loading conditions', () => {
 				isDev: false,
 				enableSentryReporting: true,
 				isInBrowserVariantTest: false,
-				isInOktaVariantTest: false,
 				random: 100 / 100,
 			}),
 		).toEqual(true);

--- a/dotcom-rendering/src/client/sentryLoader/index.ts
+++ b/dotcom-rendering/src/client/sentryLoader/index.ts
@@ -8,7 +8,6 @@ type IsSentryEnabled = {
 	enableSentryReporting: boolean;
 	isDev: boolean;
 	isInBrowserVariantTest: boolean;
-	isInOktaVariantTest: boolean;
 	random: number;
 };
 
@@ -16,7 +15,6 @@ const isSentryEnabled = ({
 	enableSentryReporting,
 	isDev,
 	isInBrowserVariantTest,
-	isInOktaVariantTest,
 	random,
 }: IsSentryEnabled): boolean => {
 	// We don't send errors on the dev server, or if the enableSentryReporting switch is off
@@ -27,8 +25,6 @@ const isSentryEnabled = ({
 	// the variant and control so they each represent 1% of the overall traffic.
 	// This will allow a like for like comparison in Sentry.
 	if (isInBrowserVariantTest) return true;
-	// We want to log all errors for users in the Okta variant test.
-	if (isInOktaVariantTest) return true;
 	// Sentry lets you configure sampleRate to reduce the volume of events sent
 	// but this filter only happens _after_ the library is loaded. The Guardian
 	// measures page views in the billions so we only want to log 1% of errors that
@@ -45,14 +41,10 @@ export const sentryLoader = (): Promise<void> => {
 	const isInBrowserVariantTest =
 		BUILD_VARIANT && tests[dcrJavascriptBundle('Variant')] === 'variant';
 
-	const isInOktaVariantTest =
-		!!switches.okta && tests.oktaVariant === 'variant';
-
 	const canLoadSentry = isSentryEnabled({
 		enableSentryReporting,
 		isDev,
 		isInBrowserVariantTest,
-		isInOktaVariantTest,
 		random: Math.random(),
 	});
 	canLoadSentry ? loadSentryOnError() : stubSentry();


### PR DESCRIPTION
## What does this change?

- Reverts #8508 in preparation for moving to a 5% test in https://github.com/guardian/frontend/pull/26526. We do not want to continue logging all errors because we could quickly use up our Sentry allowance