### PR TITLE
Scheduler: always on for the adaptive site test

### DIFF
--- a/dotcom-rendering/scripts/webpack/bundles.js
+++ b/dotcom-rendering/scripts/webpack/bundles.js
@@ -21,9 +21,13 @@ const BUILD_VARIANT = true;
  *
  * @type {(variant: 'Variant' | 'Control') => import("../../src/types/config").ServerSideTestNames}
  */
-const dcrJavascriptBundle = (variant) => `adaptiveSite${variant}`;
+const dcrJavascriptBundle = (variant) => `dcrJavascriptBundle${variant}`;
+
+/** @type {(variant: 'Variant' | 'Control') => import("../../src/types/config").ServerSideTestNames} */
+const adaptive = (variant) => `adaptiveSite${variant}`;
 
 module.exports = {
 	BUILD_VARIANT,
 	dcrJavascriptBundle,
+	adaptive,
 };

--- a/dotcom-rendering/src/client/sentryLoader/sentry.ts
+++ b/dotcom-rendering/src/client/sentryLoader/sentry.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/browser';
 import type { BrowserOptions } from '@sentry/browser';
 import { CaptureConsole } from '@sentry/integrations';
 import {
+	adaptive,
 	BUILD_VARIANT,
 	dcrJavascriptBundle,
 } from '../../../scripts/webpack/bundles';
@@ -56,6 +57,10 @@ if (
 	window.guardian.config.tests[dcrJavascriptBundle('Variant')] === 'variant'
 ) {
 	Sentry.setTag('dcr.bundle', dcrJavascriptBundle('Variant'));
+}
+
+if (window.guardian.config.tests[adaptive('Variant')] === 'variant') {
+	Sentry.setTag('dcr.bundle', 'adaptive');
 }
 
 export const reportError = (error: Error, feature?: string): void => {

--- a/dotcom-rendering/src/lib/assets.test.ts
+++ b/dotcom-rendering/src/lib/assets.test.ts
@@ -1,6 +1,8 @@
+import { BUILD_VARIANT } from '../../scripts/webpack/bundles';
 import {
 	APPS_SCRIPT,
 	decideAssetOrigin,
+	getModulesBuild,
 	WEB,
 	WEB_LEGACY_SCRIPT,
 	WEB_SCHEDULED_SCRIPT,
@@ -76,5 +78,37 @@ describe('regular expression to match files', () => {
 		expect(
 			'https://assets.guim.co.uk/assets/ophan.web.eb74205c979f58659ed7.js?http3=true',
 		).toMatch(WEB);
+	});
+});
+
+describe('getModulesBuild', () => {
+	it('should default to web', () => {
+		const build = getModulesBuild({ tests: {}, switches: {} });
+		expect(build).toBe('web');
+	});
+
+	it('should support variant build when in test, if enabled', () => {
+		const build = getModulesBuild({
+			tests: { dcrJavascriptBundleVariant: 'variant' },
+			switches: {},
+		});
+		const expected = BUILD_VARIANT ? 'web.variant' : 'web';
+		expect(build).toBe(expected);
+	});
+
+	it('should serve the scheduled build when in adaptive test', () => {
+		const build = getModulesBuild({
+			tests: { adaptiveSiteVariant: 'variant' },
+			switches: {},
+		});
+		expect(build).toBe('web.scheduled');
+	});
+
+	it('should serve the scheduled build when switched on', () => {
+		const build = getModulesBuild({
+			tests: {},
+			switches: { scheduler: true },
+		});
+		expect(build).toBe('web.scheduled');
 	});
 });

--- a/dotcom-rendering/src/lib/assets.ts
+++ b/dotcom-rendering/src/lib/assets.ts
@@ -2,6 +2,7 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { isObject, isString } from '@guardian/libs';
 import {
+	adaptive,
 	BUILD_VARIANT,
 	dcrJavascriptBundle,
 } from '../../scripts/webpack/bundles';
@@ -145,7 +146,7 @@ export const getModulesBuild = ({
 	if (BUILD_VARIANT && tests[dcrJavascriptBundle('Variant')] === 'variant') {
 		return 'web.variant';
 	}
-	if (switches.scheduler) {
+	if (switches.scheduler || tests[adaptive('Variant')] === 'variant') {
 		return 'web.scheduled';
 	}
 	return 'web';


### PR DESCRIPTION
## What does this change?

- use `index.scheduled.ts` in the adaptive site test variant
- add some test to capture the various possible scenarios

## Why?

We always want the adaptive site to be using the scheduler, irregardless of the switch.

Follow-up on #8648 

## Screenshots

N/A