### PR TITLE
S3: mark only hashed assets as immutable in frontend-static

### DIFF
--- a/dotcom-rendering/scripts/deploy/riff-raff.yaml
+++ b/dotcom-rendering/scripts/deploy/riff-raff.yaml
@@ -25,9 +25,9 @@ deployments:
       bucketSsmKey: /account/services/dotcom-static.bucket
       cacheControl:
         # assets hashed by Webpack
-        - pattern: "\\.[0-9a-f]{20}\\.js"
-          value: "public, max-age=315360000, immutable" # one year in seconds
-        - pattern: ".*"
-          value: "max-age=3600" # one hour in seconds
+        - pattern: \.[0-9a-f]{20}\.js
+          value: public, max-age=315360000, immutable # one year in seconds
+        - pattern: .*
+          value: max-age=3600 # one hour in seconds
       prefixStack: false
       publicReadAcl: false

--- a/dotcom-rendering/scripts/deploy/riff-raff.yaml
+++ b/dotcom-rendering/scripts/deploy/riff-raff.yaml
@@ -25,9 +25,9 @@ deployments:
       bucketSsmKey: /account/services/dotcom-static.bucket
       cacheControl:
         # assets hashed by Webpack
-        - pattern: "\.[0-9a-f]{20}\.js"
+        - pattern: \.[0-9a-f]{20}\.js
           value: public, max-age=315360000, immutable
-        - pattern: ".*"
+        - pattern: .*
           value: max-age=3600
       prefixStack: false
       publicReadAcl: false

--- a/dotcom-rendering/scripts/deploy/riff-raff.yaml
+++ b/dotcom-rendering/scripts/deploy/riff-raff.yaml
@@ -26,8 +26,8 @@ deployments:
       cacheControl:
         # assets hashed by Webpack
         - pattern: "\\.[0-9a-f]{20}\\.js"
-          value: "public, max-age=315360000, immutable"
+          value: "public, max-age=315360000, immutable" # one year in seconds
         - pattern: ".*"
-          value: "max-age=3600"
+          value: "max-age=3600" # one hour in seconds
       prefixStack: false
       publicReadAcl: false

--- a/dotcom-rendering/scripts/deploy/riff-raff.yaml
+++ b/dotcom-rendering/scripts/deploy/riff-raff.yaml
@@ -25,9 +25,9 @@ deployments:
       bucketSsmKey: /account/services/dotcom-static.bucket
       cacheControl:
         # assets hashed by Webpack
-        - pattern: \.[0-9a-f]{20}\.js
-          value: public, max-age=315360000, immutable
-        - pattern: .*
-          value: max-age=3600
+        - pattern: "\\.[0-9a-f]{20}\\.js"
+          value: "public, max-age=315360000, immutable"
+        - pattern: ".*"
+          value: "max-age=3600"
       prefixStack: false
       publicReadAcl: false

--- a/dotcom-rendering/scripts/deploy/riff-raff.yaml
+++ b/dotcom-rendering/scripts/deploy/riff-raff.yaml
@@ -23,6 +23,11 @@ deployments:
     type: aws-s3
     parameters:
       bucketSsmKey: /account/services/dotcom-static.bucket
-      cacheControl: public, max-age=315360000, immutable
+      cacheControl:
+        # assets hashed by Webpack
+        - pattern: "\.[0-9a-f]{20}\.js"
+          value: public, max-age=315360000, immutable
+        - pattern: ".*"
+          value: max-age=3600
       prefixStack: false
       publicReadAcl: false

--- a/dotcom-rendering/scripts/deploy/riff-raff.yaml
+++ b/dotcom-rendering/scripts/deploy/riff-raff.yaml
@@ -24,10 +24,11 @@ deployments:
     parameters:
       bucketSsmKey: /account/services/dotcom-static.bucket
       cacheControl:
-        # assets hashed by Webpack
-        - pattern: \.[0-9a-f]{20}\.js
-          value: public, max-age=315360000, immutable # one year in seconds
-        - pattern: .*
+        - pattern: \/stats\/ # stats file can change on each deploy
           value: max-age=3600 # one hour in seconds
+          # assume all other assets are hashed and never change,
+          # even though this is not the case–e.g. icons
+        - pattern: .*
+          value: public, max-age=315360000, immutable # one year in seconds
       prefixStack: false
       publicReadAcl: false


### PR DESCRIPTION
## What does this change?

Be selective about setting long immutable cache on assets uploaded to S3: only assets hashed by Webpack are immutable.

## Why?

Not all assets are hashed and immutable, for example: https://assets.guim.co.uk/assets/stats/islands.html, and our CDN and browser need to know about it.

Follow-up on #7158

[Tested in CODE and it works](https://riffraff.gutools.co.uk/deployment/view/71c03ec6-d1cc-4135-840a-ed06aba2bd78).