### PR TITLE
Bridget environment hook

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -160,6 +160,7 @@
 		"browserslist": "4.21.9",
 		"buffer": "6.0.3",
 		"chalk": "4.1.2",
+		"compare-versions": "6.1.0",
 		"compression": "1.7.4",
 		"constructs": "10.2.69",
 		"cpy": "10.1.0",

--- a/dotcom-rendering/src/lib/getBridgetVersion.ts
+++ b/dotcom-rendering/src/lib/getBridgetVersion.ts
@@ -1,0 +1,33 @@
+import { useEffect, useState } from 'react';
+import { getEnvironmentClient } from './bridgetApi';
+
+const isCorrectBridgetVersion = (
+	version: string,
+	requiredVersion: number,
+): boolean => {
+	const majorVersion = parseInt(version);
+	return majorVersion >= requiredVersion;
+};
+
+export const useIsBridgetCompatible = (
+	requiredVersion = 2,
+): boolean | undefined => {
+	const [isCompatible, setIsCompatible] = useState<boolean | undefined>(
+		undefined,
+	);
+
+	useEffect(() => {
+		void getEnvironmentClient()
+			.nativeThriftPackageVersion()
+			.then((bridgetVersion) => {
+				setIsCompatible(
+					isCorrectBridgetVersion(bridgetVersion, requiredVersion),
+				);
+			})
+			.catch((error) => {
+				setIsCompatible(false);
+				console.log('nativeThriftPackageVersion', { error });
+			});
+	}, [requiredVersion]);
+	return isCompatible;
+};

--- a/dotcom-rendering/src/lib/getBridgetVersion.ts
+++ b/dotcom-rendering/src/lib/getBridgetVersion.ts
@@ -1,16 +1,9 @@
 import { useEffect, useState } from 'react';
 import { getEnvironmentClient } from './bridgetApi';
-
-const isCorrectBridgetVersion = (
-	version: string,
-	requiredVersion: number,
-): boolean => {
-	const majorVersion = parseInt(version);
-	return majorVersion >= requiredVersion;
-};
+import { compare } from 'compare-versions';
 
 export const useIsBridgetCompatible = (
-	requiredVersion = 2,
+	requiredVersion = '2.0.0',
 ): boolean | undefined => {
 	const [isCompatible, setIsCompatible] = useState<boolean | undefined>(
 		undefined,
@@ -20,9 +13,7 @@ export const useIsBridgetCompatible = (
 		void getEnvironmentClient()
 			.nativeThriftPackageVersion()
 			.then((bridgetVersion) => {
-				setIsCompatible(
-					isCorrectBridgetVersion(bridgetVersion, requiredVersion),
-				);
+				setIsCompatible(compare(bridgetVersion, requiredVersion, '>='));
 			})
 			.catch((error) => {
 				setIsCompatible(false);

--- a/dotcom-rendering/src/lib/useIsBridgetCompatible.test.ts
+++ b/dotcom-rendering/src/lib/useIsBridgetCompatible.test.ts
@@ -1,0 +1,32 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { useIsBridgetCompatible } from './useIsBridgetCompatible';
+
+const mockRequiredVersion = '2.1.1';
+
+jest.mock('./bridgetApi', () => ({
+	getEnvironmentClient: () => ({
+		nativeThriftPackageVersion: async () => {
+			return mockRequiredVersion;
+		},
+	}),
+}));
+
+describe('useIsBridgetCompatible', () => {
+	test.each([
+		['1.9.0', true],
+		['2.0.0', true],
+		['2.0.1', true],
+		['2.1.0', true],
+		['3.0.0', false],
+	])(
+		`For version %s, returns %s when required version is ${mockRequiredVersion}`,
+		async (minVersion, expected) => {
+			const { result } = renderHook(() =>
+				useIsBridgetCompatible(minVersion),
+			);
+			await waitFor(() => {
+				expect(result.current).toBe(expected);
+			});
+		},
+	);
+});

--- a/dotcom-rendering/src/lib/useIsBridgetCompatible.ts
+++ b/dotcom-rendering/src/lib/useIsBridgetCompatible.ts
@@ -1,6 +1,6 @@
+import { compare } from 'compare-versions';
 import { useEffect, useState } from 'react';
 import { getEnvironmentClient } from './bridgetApi';
-import { compare } from 'compare-versions';
 
 export const useIsBridgetCompatible = (
 	requiredVersion = '2.0.0',

--- a/yarn.lock
+++ b/yarn.lock
@@ -8267,6 +8267,11 @@ commondir@^1.0.1:
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
   integrity sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==
 
+compare-versions@6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-6.1.0.tgz#3f2131e3ae93577df111dba133e6db876ffe127a"
+  integrity sha512-LNZQXhqUvqUTotpZ00qLSaify3b4VFD588aRr8MKFw4CMUr98ytzCW5wDH5qx/DEY5kCDXcbcRuCqL0szEf2tg==
+
 compressible@~2.0.16:
   version "2.0.18"
   resolved "https://registry.yarnpkg.com/compressible/-/compressible-2.0.18.tgz#af53cca6b070d4c3c0750fbd77286a6d7cc46fba"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Adds a new custom hook that checks if the client has a compatible version of Bridget. 
## Why?
This is required for rendering apps articles through DCR. It will be used initially for implementing newsletter signups. This implementation will follow in a separate PR. 
