### PR TITLE
feat: implement filterSeenArticles in DCR

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -99,6 +99,11 @@ export type Props = {
 	showLivePlayable?: boolean;
 	onwardsSource?: string;
 	pauseOffscreenVideo?: boolean;
+	/**
+	 * Represents if the card content has been read or "seen" by the user already.
+	 * Only relevant for apps-rendered content.
+	 */
+	hasBeenSeen?: boolean;
 };
 
 const StarRatingComponent = ({
@@ -286,6 +291,7 @@ export const Card = ({
 	showLivePlayable = false,
 	onwardsSource,
 	pauseOffscreenVideo = false,
+	hasBeenSeen = false,
 }: Props) => {
 	const palette = decidePalette(format, containerPalette);
 
@@ -392,6 +398,7 @@ export const Card = ({
 			format={format}
 			containerPalette={containerPalette}
 			isDynamo={isDynamo}
+			hasBeenSeen={hasBeenSeen}
 		>
 			<CardLink
 				linkTo={linkTo}

--- a/dotcom-rendering/src/components/Card/components/CardWrapper.tsx
+++ b/dotcom-rendering/src/components/Card/components/CardWrapper.tsx
@@ -12,6 +12,11 @@ type Props = {
 	containerPalette?: DCRContainerPalette;
 	/** The first card in a dynamic package is ”Dynamo” and gets special styling */
 	isDynamo?: true;
+	/**
+	 * Represents if the card content has been read or "seen" by the user already.
+	 * Only relevant for apps-rendered content.
+	 */
+	hasBeenSeen?: boolean;
 };
 
 const cardStyles = (
@@ -172,11 +177,16 @@ const topBarStyles = ({
 	`;
 };
 
+const fadedStyles = css`
+	opacity: 0.7;
+`;
+
 export const CardWrapper = ({
 	children,
 	format,
 	containerPalette,
 	isDynamo,
+	hasBeenSeen = false,
 }: Props) => {
 	const palette = decidePalette(format, containerPalette);
 	return (
@@ -184,6 +194,7 @@ export const CardWrapper = ({
 			css={[
 				cardStyles(format, palette, isDynamo, containerPalette),
 				topBarStyles({ isDynamo, palette }),
+				hasBeenSeen && fadedStyles,
 			]}
 		>
 			{children}

--- a/dotcom-rendering/src/components/Carousel.importable.tsx
+++ b/dotcom-rendering/src/components/Carousel.importable.tsx
@@ -11,6 +11,7 @@ import {
 } from '@guardian/source-foundations';
 import libDebounce from 'lodash.debounce';
 import { useEffect, useRef, useState } from 'react';
+// import { getUserClient } from '../lib/bridgetApi';
 import { decideContainerOverrides } from '../lib/decideContainerOverrides';
 import { decidePalette } from '../lib/decidePalette';
 import { formatAttrString } from '../lib/formatAttrString';
@@ -20,6 +21,7 @@ import type { Branding } from '../types/branding';
 import type { DCRContainerPalette, DCRContainerType } from '../types/front';
 import type { MainMedia } from '../types/mainMedia';
 import type { OnwardsSource } from '../types/onwards';
+import type { RenderingTarget } from '../types/renderingTarget';
 import type { TrailType } from '../types/trails';
 import { Card } from './Card/Card';
 import { LI } from './Card/components/LI';
@@ -35,6 +37,7 @@ type Props = {
 	onwardsSource: OnwardsSource;
 	leftColSize: LeftColSize;
 	discussionApiUrl: string;
+	renderingTarget: RenderingTarget;
 };
 
 type ArticleProps = Props & {
@@ -479,6 +482,11 @@ type CarouselCardProps = {
 	verticalDividerColour?: string;
 	onwardsSource?: string;
 	containerType?: DCRContainerType;
+	/**
+	 * Represents if the card content has been read or "seen" by the user already.
+	 * Only relevant for apps-rendered content.
+	 */
+	hasBeenSeen?: boolean;
 };
 
 const CarouselCard = ({
@@ -498,6 +506,7 @@ const CarouselCard = ({
 	containerType,
 	imageLoading,
 	discussionApiUrl,
+	hasBeenSeen,
 }: CarouselCardProps) => {
 	const isVideoContainer = containerType === 'fixed/video';
 	return (
@@ -533,6 +542,7 @@ const CarouselCard = ({
 				containerType={containerType}
 				imageLoading={imageLoading}
 				discussionApiUrl={discussionApiUrl}
+				hasBeenSeen={hasBeenSeen}
 			/>
 		</LI>
 	);
@@ -860,6 +870,7 @@ export const Carousel = ({
 	onwardsSource,
 	leftColSize,
 	discussionApiUrl,
+	renderingTarget,
 	...props
 }: ArticleProps | FrontProps) => {
 	const carouselColours = decideCarouselColours(props);
@@ -975,6 +986,14 @@ export const Carousel = ({
 	// using old data to determine the max index. Instead we say update maxIndex
 	// when index changes and compare it against the prior maxIndex only.
 	useEffect(() => setMaxIndex((m) => Math.max(index, m)), [index]);
+
+	// const identifySeenCards = async (trails: TrailType[]): Promise<TrailType & { isSeen?: boolean }[]> => {
+	// 	const seenCardUrls = await getUserClient().filterSeenArticles(trails.map(x => x.url))
+	// 	return trails.map(t => ({...t, isSeen: seenCardUrls.find(value => value === t.url)}))
+	// }
+	// useEffect(() => {
+	// 	renderingTarget === "Apps" && getUserClient().filterSeenArticles(trails.map(_ => _.))
+	// }, []);
 
 	return (
 		<div

--- a/dotcom-rendering/src/components/Carousel.stories.tsx
+++ b/dotcom-rendering/src/components/Carousel.stories.tsx
@@ -208,6 +208,7 @@ export const Headlines = () => (
 				}}
 				leftColSize={'compact'}
 				discussionApiUrl={discussionApiUrl}
+				renderingTarget="Web"
 			/>
 		</Section>
 		<Section fullWidth={true}>
@@ -222,6 +223,7 @@ export const Headlines = () => (
 				}}
 				leftColSize={'compact'}
 				discussionApiUrl={discussionApiUrl}
+				renderingTarget="Web"
 			/>
 		</Section>
 	</>
@@ -243,6 +245,7 @@ export const SingleItemCarousel = () => (
 				}}
 				leftColSize={'compact'}
 				discussionApiUrl={discussionApiUrl}
+				renderingTarget="Web"
 			/>
 		</Section>
 	</>
@@ -264,6 +267,7 @@ export const Immersive = () => (
 				}}
 				leftColSize={'compact'}
 				discussionApiUrl={discussionApiUrl}
+				renderingTarget="Web"
 			/>
 		</Section>
 		<Section fullWidth={true}>
@@ -278,6 +282,7 @@ export const Immersive = () => (
 				}}
 				leftColSize={'compact'}
 				discussionApiUrl={discussionApiUrl}
+				renderingTarget="Web"
 			/>
 		</Section>
 	</>
@@ -309,6 +314,7 @@ export const SpecialReportAlt = () => {
 					}}
 					leftColSize={'compact'}
 					discussionApiUrl={discussionApiUrl}
+					renderingTarget="Web"
 				/>
 			</Section>
 		</>

--- a/dotcom-rendering/src/components/FetchOnwardsData.importable.tsx
+++ b/dotcom-rendering/src/components/FetchOnwardsData.importable.tsx
@@ -6,6 +6,7 @@ import { revealStyles } from '../lib/revealStyles';
 import { useApi } from '../lib/useApi';
 import { addDiscussionIds } from '../lib/useCommentCount';
 import type { OnwardsSource } from '../types/onwards';
+import type { RenderingTarget } from '../types/renderingTarget';
 import type { FETrailType, TrailType } from '../types/trails';
 import { Carousel } from './Carousel.importable';
 import { Placeholder } from './Placeholder';
@@ -16,6 +17,7 @@ type Props = {
 	onwardsSource: OnwardsSource;
 	format: ArticleFormat;
 	discussionApiUrl: string;
+	renderingTarget: RenderingTarget;
 };
 
 type OnwardsResponse = {
@@ -35,6 +37,7 @@ export const FetchOnwardsData = ({
 	onwardsSource,
 	format,
 	discussionApiUrl,
+	renderingTarget,
 }: Props) => {
 	const { data, loading, error } = useApi<OnwardsResponse>(url);
 
@@ -96,6 +99,7 @@ export const FetchOnwardsData = ({
 								: 'compact'
 						}
 						discussionApiUrl={discussionApiUrl}
+						renderingTarget={renderingTarget}
 					/>
 				</div>
 			</div>

--- a/dotcom-rendering/src/components/OnwardsUpper.importable.tsx
+++ b/dotcom-rendering/src/components/OnwardsUpper.importable.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/react';
 import { joinUrl, Pillar } from '@guardian/libs';
 import type { EditionId } from '../lib/edition';
 import type { OnwardsSource } from '../types/onwards';
+import type { RenderingTarget } from '../types/renderingTarget';
 import type { TagType } from '../types/tag';
 import { FetchOnwardsData } from './FetchOnwardsData.importable';
 import { Section } from './Section';
@@ -170,6 +171,7 @@ type Props = {
 	pillar: ArticleTheme;
 	shortUrlId: string;
 	discussionApiUrl: string;
+	renderingTarget: RenderingTarget;
 };
 
 /**
@@ -203,6 +205,7 @@ export const OnwardsUpper = ({
 	editionId,
 	shortUrlId,
 	discussionApiUrl,
+	renderingTarget,
 }: Props) => {
 	// Related content can be a collection of articles based on
 	// two things, 1: A popular tag, or 2: A generic text match
@@ -290,6 +293,7 @@ export const OnwardsUpper = ({
 						onwardsSource={onwardsSource}
 						format={format}
 						discussionApiUrl={discussionApiUrl}
+						renderingTarget={renderingTarget}
 					/>
 				</Section>
 			)}
@@ -301,6 +305,7 @@ export const OnwardsUpper = ({
 						onwardsSource="curated-content"
 						format={format}
 						discussionApiUrl={discussionApiUrl}
+						renderingTarget={renderingTarget}
 					/>
 				</Section>
 			)}

--- a/dotcom-rendering/src/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/layouts/CommentLayout.tsx
@@ -729,6 +729,7 @@ export const CommentLayout = ({
 								discussionApiUrl={
 									article.config.discussionApiUrl
 								}
+								renderingTarget={renderingTarget}
 							/>
 						</Island>
 					</Section>
@@ -755,6 +756,7 @@ export const CommentLayout = ({
 						editionId={article.editionId}
 						shortUrlId={article.config.shortUrlId}
 						discussionApiUrl={article.config.discussionApiUrl}
+						renderingTarget={renderingTarget}
 					/>
 				</Island>
 

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -673,6 +673,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 											discussionApiUrl={
 												front.config.discussionApiUrl
 											}
+											renderingTarget="Web"
 										/>
 									</Island>
 								</Section>

--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -775,6 +775,7 @@ export const ImmersiveLayout = ({
 								discussionApiUrl={
 									article.config.discussionApiUrl
 								}
+								renderingTarget={renderingTarget}
 							/>
 						</Island>
 					</Section>
@@ -801,6 +802,7 @@ export const ImmersiveLayout = ({
 						editionId={article.editionId}
 						shortUrlId={article.config.shortUrlId}
 						discussionApiUrl={article.config.discussionApiUrl}
+						renderingTarget={renderingTarget}
 					/>
 				</Island>
 

--- a/dotcom-rendering/src/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/InteractiveLayout.tsx
@@ -642,6 +642,7 @@ export const InteractiveLayout = ({
 								discussionApiUrl={
 									article.config.discussionApiUrl
 								}
+								renderingTarget={renderingTarget}
 							/>
 						</Island>
 					</Section>
@@ -668,6 +669,7 @@ export const InteractiveLayout = ({
 						editionId={article.editionId}
 						shortUrlId={article.config.shortUrlId}
 						discussionApiUrl={article.config.discussionApiUrl}
+						renderingTarget={renderingTarget}
 					/>
 				</Island>
 

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -1176,6 +1176,7 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 									discussionApiUrl={
 										article.config.discussionApiUrl
 									}
+									renderingTarget={renderingTarget}
 								/>
 							</Island>
 						</Section>
@@ -1204,6 +1205,7 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 							editionId={article.editionId}
 							shortUrlId={article.config.shortUrlId}
 							discussionApiUrl={article.config.discussionApiUrl}
+							renderingTarget={renderingTarget}
 						/>
 					</Island>
 

--- a/dotcom-rendering/src/layouts/NewsletterSignupLayout.tsx
+++ b/dotcom-rendering/src/layouts/NewsletterSignupLayout.tsx
@@ -526,6 +526,7 @@ export const NewsletterSignupLayout = ({
 								discussionApiUrl={
 									article.config.discussionApiUrl
 								}
+								renderingTarget={renderingTarget}
 							/>
 						</Island>
 					</Section>
@@ -552,6 +553,7 @@ export const NewsletterSignupLayout = ({
 						editionId={article.editionId}
 						shortUrlId={article.config.shortUrlId}
 						discussionApiUrl={article.config.discussionApiUrl}
+						renderingTarget={renderingTarget}
 					/>
 				</Island>
 			</main>

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -88,7 +88,7 @@ const ShowcaseGrid = ({
 					Vertical grey border
 					Main content
 					Right Column
-					
+
 				*/
 				${from.wide} {
 					${isPictureContent
@@ -781,6 +781,7 @@ export const ShowcaseLayout = ({
 								discussionApiUrl={
 									article.config.discussionApiUrl
 								}
+								renderingTarget={renderingTarget}
 							/>
 						</Island>
 					</Section>
@@ -807,6 +808,7 @@ export const ShowcaseLayout = ({
 						editionId={article.editionId}
 						shortUrlId={article.config.shortUrlId}
 						discussionApiUrl={article.config.discussionApiUrl}
+						renderingTarget={renderingTarget}
 					/>
 				</Island>
 

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -804,6 +804,7 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 								discussionApiUrl={
 									article.config.discussionApiUrl
 								}
+								renderingTarget={renderingTarget}
 							/>
 						</Island>
 					</Section>
@@ -836,6 +837,7 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 								discussionApiUrl={
 									article.config.discussionApiUrl
 								}
+								renderingTarget={renderingTarget}
 							/>
 						</Island>
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Introduces a new prop `hasBeenSeen` for `<Card />` components to allow them to be dimmed for app users who have already visited the article represented by the card.

_⚠️ Note that this is very directed towards cards in `<Carousel />` components as these are the ones used at the bottom of articles. Any specific fronts-related cards have been left as is since there is no requirement to support fronts for apps._

Prop-drills `renderingTarget` into a number of components to allow `hasBeenSeen` to only be truthy for `renderingTarget === "Apps"`

## Why?

As part of the migration of the Bridget user service to DCR, this migrates the use of `filterSeenArticles` across, since it was being used to dim cards that had already been read by the mobile user.


### Potential improvements

The `filterSeenArticles` method is used in a very convoluted way. In this PR, we aren't interested in changing the underlying Bridget methods so this is being shoehorned in. 
It would be worth addressing what the "ideal" method would be here based on what the native layer needs and what makes most sense in this context.
