### PR TITLE
fix: avoid nodes embedded in non-root nodes dropping caps

### DIFF
--- a/dotcom-rendering/src/components/TextBlockComponent.tsx
+++ b/dotcom-rendering/src/components/TextBlockComponent.tsx
@@ -260,7 +260,11 @@ const buildElementTree =
 						dropCappedSentence &&
 						node.textContent.startsWith(
 							stripHtmlFromString(html).slice(0, 10),
-						)
+						) &&
+						// The node is at the root of the document avoiding nodes like <a>
+						// tags embedded in <p> tags dropping their cap
+						node.parentNode?.parentNode?.nodeName ===
+							'#document-fragment'
 					) {
 						const { dropCap, restOfSentence } = dropCappedSentence;
 						return (


### PR DESCRIPTION
## What does this change?
Avoids dropping a cap on nodes that aren't first children of the `#document-fragment`. e.g. <p>Some text <a>THIS SHOULND'T DROP</a></p>


## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/31692/847ab153-4afa-47bf-a025-50f838e5040a
[after]: https://github.com/guardian/dotcom-rendering/assets/31692/9a721072-1b85-4347-b020-24119105c7a4

This might not, and probably isn't, _the_ fix, but is a hotfix.