### PR TITLE
Hide Share and syndication buttons for apps articles

### DIFF
--- a/dotcom-rendering/src/components/ArticleMeta.tsx
+++ b/dotcom-rendering/src/components/ArticleMeta.tsx
@@ -402,31 +402,34 @@ export const ArticleMeta = ({
 						</div>
 					</>
 				</RowBelowLeftCol>
+
 				<div data-print-layout="hide" css={metaFlex}>
-					<div
-						className={
-							isInteractive
-								? interactiveLegacyClasses.shareIcons
-								: ''
-						}
-						css={[
-							metaExtras(palette, isPictureContent),
-							format.design === ArticleDesign.LiveBlog &&
-								css(
-									borderColourWhenBackgroundDark,
-									metaExtrasLiveBlog,
-								),
-						]}
-					>
-						<ShareIcons
-							pageId={pageId}
-							webTitle={webTitle}
-							format={format}
-							displayIcons={['facebook', 'twitter', 'email']}
-							size="medium"
-							context="ArticleMeta"
-						/>
-					</div>
+					{renderingTarget === 'Web' && (
+						<div
+							className={
+								isInteractive
+									? interactiveLegacyClasses.shareIcons
+									: ''
+							}
+							css={[
+								metaExtras(palette, isPictureContent),
+								format.design === ArticleDesign.LiveBlog &&
+									css(
+										borderColourWhenBackgroundDark,
+										metaExtrasLiveBlog,
+									),
+							]}
+						>
+							<ShareIcons
+								pageId={pageId}
+								webTitle={webTitle}
+								format={format}
+								displayIcons={['facebook', 'twitter', 'email']}
+								size="medium"
+								context="ArticleMeta"
+							/>
+						</div>
+					)}
 					<div
 						className={
 							isInteractive
@@ -445,15 +448,19 @@ export const ArticleMeta = ({
 						<Counts format={format}>
 							{/* The meta-number css is needed by Counts.tsx */}
 							<div className="meta-number">
-								{showShareCount && (
-									<Island clientOnly={true} deferUntil="idle">
-										<ShareCount
-											ajaxUrl={ajaxUrl}
-											pageId={pageId}
-											format={format}
-										/>
-									</Island>
-								)}
+								{showShareCount &&
+									renderingTarget === 'Web' && (
+										<Island
+											clientOnly={true}
+											deferUntil="idle"
+										>
+											<ShareCount
+												ajaxUrl={ajaxUrl}
+												pageId={pageId}
+												format={format}
+											/>
+										</Island>
+									)}
 							</div>
 							<div className="meta-number">
 								{isCommentable && (

--- a/dotcom-rendering/src/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/layouts/CommentLayout.tsx
@@ -658,7 +658,8 @@ export const CommentLayout = ({
 										webUrl={article.webURL}
 										webTitle={article.webTitle}
 										showBottomSocialButtons={
-											article.showBottomSocialButtons
+											article.showBottomSocialButtons &&
+											renderingTarget === 'Web'
 										}
 										badge={article.badge?.enhanced}
 									/>

--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -696,7 +696,8 @@ export const ImmersiveLayout = ({
 									webUrl={article.webURL}
 									webTitle={article.webTitle}
 									showBottomSocialButtons={
-										article.showBottomSocialButtons
+										article.showBottomSocialButtons &&
+										renderingTarget === 'Web'
 									}
 									badge={article.badge?.enhanced}
 								/>

--- a/dotcom-rendering/src/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/InteractiveLayout.tsx
@@ -605,7 +605,8 @@ export const InteractiveLayout = ({
 						webUrl={article.webURL}
 						webTitle={article.webTitle}
 						showBottomSocialButtons={
-							article.showBottomSocialButtons
+							article.showBottomSocialButtons &&
+							renderingTarget === 'Web'
 						}
 						badge={article.badge?.enhanced}
 					/>

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -946,7 +946,9 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 													webUrl={article.webURL}
 													webTitle={article.webTitle}
 													showBottomSocialButtons={
-														article.showBottomSocialButtons
+														article.showBottomSocialButtons &&
+														renderingTarget ===
+															'Web'
 													}
 													badge={
 														article.badge?.enhanced
@@ -1100,7 +1102,9 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 													webUrl={article.webURL}
 													webTitle={article.webTitle}
 													showBottomSocialButtons={
-														article.showBottomSocialButtons
+														article.showBottomSocialButtons &&
+														renderingTarget ===
+															'Web'
 													}
 													badge={
 														article.badge?.enhanced

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -711,7 +711,8 @@ export const ShowcaseLayout = ({
 									webUrl={article.webURL}
 									webTitle={article.webTitle}
 									showBottomSocialButtons={
-										article.showBottomSocialButtons
+										article.showBottomSocialButtons &&
+										renderingTarget === 'Web'
 									}
 									badge={article.badge?.enhanced}
 								/>

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -732,7 +732,8 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 									webUrl={article.webURL}
 									webTitle={article.webTitle}
 									showBottomSocialButtons={
-										article.showBottomSocialButtons
+										article.showBottomSocialButtons &&
+										renderingTarget === 'Web'
 									}
 									badge={article.badge?.enhanced}
 								/>


### PR DESCRIPTION
We only want to show share buttons and syndication links on web.

We also show share buttons on blog blocks, but we don't have a decision yet on how to handle these in apps articles.

We still want to show comment counts on apps, but not share counts. The share counts switch has been turned off for some time, see https://github.com/guardian/frontend/issues/26568.

Closes #7706

## Screenshots

### Article Meta

| Before | After | With Comment Count |
|--------|--------|--|
| ![Screen Shot 2023-08-30 at 15 06 05](https://github.com/guardian/dotcom-rendering/assets/705427/895ca9c1-01ea-4468-b3d4-4a4599b3ddfe) | ![Screen Shot 2023-08-30 at 15 05 19](https://github.com/guardian/dotcom-rendering/assets/705427/83c61fde-2759-4893-8b70-2aad9cfa0d93) | ![Screen Shot 2023-08-30 at 16 47 13](https://github.com/guardian/dotcom-rendering/assets/705427/b46bb598-a630-4fe7-be20-fc81b37fd560) |

### Sub Meta

| Before | After |
|--------|--------|
| ![Screen Shot 2023-08-30 at 15 22 38](https://github.com/guardian/dotcom-rendering/assets/705427/2f13ce97-b3a2-471a-8449-866b606346d2) | ![Screen Shot 2023-08-30 at 15 21 54](https://github.com/guardian/dotcom-rendering/assets/705427/b9a78978-03a8-4d5b-b6e4-42dbd69bb38f) | 


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
