### PR TITLE
Perf improvements to `scheduler`

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -74,7 +74,7 @@
 		"@guardian/eslint-plugin-source-react-components": "18.0.0",
 		"@guardian/identity-auth": "1.1.0",
 		"@guardian/identity-auth-frontend": "1.0.0",
-		"@guardian/libs": "15.7.0",
+		"@guardian/libs": "15.7.1",
 		"@guardian/prettier": "5.0.0",
 		"@guardian/shimport": "1.0.2",
 		"@guardian/source-foundations": "13.0.0",

--- a/dotcom-rendering/src/lib/scheduler.test.ts
+++ b/dotcom-rendering/src/lib/scheduler.test.ts
@@ -136,13 +136,13 @@ describe('scheduler', () => {
 
 		jest.runAllTimers();
 
-		expect(await featureTask1Result).toBe('feature task 1 result');
+		await expect(featureTask1Result).resolves.toBe('feature task 1 result');
 		expect(featureTask2).not.toHaveBeenCalled();
 		expect(criticalTask).toHaveBeenCalled();
 
 		jest.runAllTimers();
 
-		expect(await criticalTaskResult).toBe('critical task result');
+		await expect(criticalTaskResult).resolves.toBe('critical task result');
 		expect(featureTask2).toHaveBeenCalled();
 
 		jest.runAllTimers();

--- a/dotcom-rendering/src/lib/scheduler.ts
+++ b/dotcom-rendering/src/lib/scheduler.ts
@@ -1,4 +1,4 @@
-import { isUndefined, startPerformanceMeasure } from '@guardian/libs';
+import { startPerformanceMeasure } from '@guardian/libs';
 
 const START = Date.now();
 
@@ -84,11 +84,13 @@ function getNextTask() {
 
 	for (const priority of PRIORITIES) {
 		const { lastStartTime, tasks } = queue[priority];
-		if (runningTime < lastStartTime) {
-			const nextTask = tasks.shift();
-			if (nextTask?.canRun({ runningTime })) {
-				return nextTask;
-			}
+		const nextTask = tasks.shift();
+		if (
+			nextTask &&
+			runningTime < lastStartTime &&
+			nextTask.canRun({ runningTime })
+		) {
+			return nextTask;
 		}
 	}
 
@@ -107,7 +109,7 @@ function getNextTask() {
  */
 function run() {
 	const nextTask = getNextTask();
-	if (isUndefined(nextTask)) return;
+	if (!nextTask) return;
 
 	RUNNING_TASK_COUNT++;
 

--- a/dotcom-rendering/src/lib/scheduler.ts
+++ b/dotcom-rendering/src/lib/scheduler.ts
@@ -1,6 +1,6 @@
-import { log as libsLog, startPerformanceMeasure } from '@guardian/libs';
+import { startPerformanceMeasure } from '@guardian/libs';
 
-const START = performance.now();
+const START = Date.now();
 
 /**
  * Keeps a count of how many tasks are currently running, so we can manage concurrency.
@@ -12,12 +12,6 @@ let RUNNING_TASK_COUNT = 0;
  * @default Infinity
  */
 let CONCURRENCY_COUNT = Infinity;
-
-/**
- * Whether or not to log debug messages.
- * @default process.env.NODE_ENV !== 'production'
- */
-let DEBUG = process.env.NODE_ENV !== 'production';
 
 /**
  * Possible task priorities.
@@ -73,43 +67,32 @@ const queue: Record<
 };
 
 /**
- * Standardised console logging.
+ * Checks whether its ok to start running another task.
  */
-const log = (message: string) =>
-	libsLog('openJournalism', `🧑‍💻 Scheduler ${message}`);
+function canRunAnotherTask() {
+	return RUNNING_TASK_COUNT < CONCURRENCY_COUNT;
+}
 
 /**
  * Gets the next task to run, according to priority and the order they were
  * scheduled.
  */
 function getNextTask() {
-	if (DEBUG) {
-		log(
-			`has ${
-				Object.values(queue).flatMap((_) => _.tasks).length
-			} task(s) waiting`,
-		);
-	}
+	if (canRunAnotherTask()) {
+		const runningTime = Date.now() - START;
 
-	for (const priority of PRIORITIES) {
-		const { lastStartTime, tasks } = queue[priority];
-
-		if (tasks.length) {
-			if (performance.now() - START < lastStartTime) {
-				if (DEBUG) {
-					log(`found ${tasks.length} ${priority} task(s) waiting`);
-				}
-				return tasks.shift();
-			} else {
-				if (DEBUG) {
-					log(
-						`found ${tasks.length} ${priority} task(s) waiting but it's too late to run them 😢`,
-					);
-				}
+		for (const priority of PRIORITIES) {
+			const { lastStartTime, tasks } = queue[priority];
+			const nextTask = tasks.shift();
+			if (
+				nextTask &&
+				runningTime < lastStartTime &&
+				nextTask.canRun({ runningTime })
+			) {
+				return nextTask;
 			}
 		}
 	}
-
 	return undefined;
 }
 
@@ -122,69 +105,26 @@ function getNextTask() {
  * If there are no tasks to run, or the maximum number of tasks are already
  * running, then it does nothing.
  */
-async function run() {
-	if (DEBUG) {
-		log(`is looking to run more tasks`);
+function run() {
+	const nextTask = getNextTask();
+	if (!nextTask) return;
 
-		const availableSlotCount =
-			CONCURRENCY_COUNT === Infinity
-				? 'infinite'
-				: `${
-						CONCURRENCY_COUNT - RUNNING_TASK_COUNT
-				  }/${CONCURRENCY_COUNT}`;
+	RUNNING_TASK_COUNT++;
 
-		log(`has ${availableSlotCount} slots available 🏃‍♂️`);
-	}
-
-	if (RUNNING_TASK_COUNT === CONCURRENCY_COUNT) {
-		if (DEBUG) {
-			log(`is already maxed out 😮‍💨`);
-		}
-	} else {
-		const nextTask = getNextTask();
-
-		// If there was an eligible task waiting in the queue, run it.
-		if (nextTask) {
-			RUNNING_TASK_COUNT += 1;
-
-			if (nextTask.canRun({ runningTime: performance.now() - START })) {
-				if (DEBUG) {
-					log(`is running ${nextTask.name} 🏋️‍♂️`);
-				}
-
-				const { name, task, resolver } = nextTask;
-
-				const { endPerformanceMeasure } = startPerformanceMeasure(
-					'dotcom',
-					'scheduler',
-					name,
-				);
-
-				const result = await (window.scheduler
-					? window.scheduler.postTask(task)
-					: task());
-
-				resolver(result);
-
-				const duration = endPerformanceMeasure();
-				log(
-					`ran "${name}" in ${duration}ms (after ${
-						performance.now() - START
-					}ms) 🥳`,
-				);
-			} else {
-				if (DEBUG) {
-					log(
-						`was going to run ${nextTask.name} but it said not to 🤷‍♂️`,
-					);
-				}
-			}
-
-			RUNNING_TASK_COUNT -= 1;
-
-			void run();
-		}
-	}
+	const { name, task, resolver } = nextTask;
+	const { endPerformanceMeasure } = startPerformanceMeasure(
+		'dotcom',
+		'scheduler',
+		name,
+	);
+	task()
+		.then(resolver)
+		.catch(console.error)
+		.finally(() => {
+			endPerformanceMeasure();
+			RUNNING_TASK_COUNT--;
+			run();
+		});
 }
 
 export type ScheduleOptions = {
@@ -218,31 +158,20 @@ export async function schedule<T>(
 	// we know this is safe because we know function in the new Promise above
 	// is synchronous (even if TS doesn't)
 	queue[priority].tasks.push(queueableTask as QueueableTask);
-
-	log(`scheduled "${name}" (${priority})`);
-
-	void run();
-
+	run();
 	return scheduledTask;
 }
 
 export function setSchedulerConcurrency(
 	concurrency: typeof CONCURRENCY_COUNT,
 ): void {
-	log(`set concurrency to ${concurrency}`);
 	CONCURRENCY_COUNT = concurrency;
-}
-
-export function setSchedulerDebugMode(debug: typeof DEBUG): void {
-	DEBUG = debug;
-	log(`switched debug mode ${DEBUG ? 'on' : 'off'}`);
 }
 
 export function setSchedulerPriorityLastStartTime(
 	priority: TaskPriority,
 	lastStartTime: number,
 ): void {
-	log(`setting ${priority} priority last start time to ${lastStartTime}ms`);
 	queue[priority].lastStartTime = lastStartTime;
-	void run();
+	run();
 }

--- a/dotcom-rendering/src/lib/scheduler.ts
+++ b/dotcom-rendering/src/lib/scheduler.ts
@@ -85,11 +85,7 @@ function getNextTask() {
 	for (const priority of PRIORITIES) {
 		const { lastStartTime, tasks } = queue[priority];
 		const nextTask = tasks.shift();
-		if (
-			nextTask &&
-			runningTime < lastStartTime &&
-			nextTask.canRun({ runningTime })
-		) {
+		if (runningTime <= lastStartTime && nextTask?.canRun({ runningTime })) {
 			return nextTask;
 		}
 	}

--- a/dotcom-rendering/src/lib/scheduler.ts
+++ b/dotcom-rendering/src/lib/scheduler.ts
@@ -1,4 +1,4 @@
-import { startPerformanceMeasure } from '@guardian/libs';
+import { isUndefined, startPerformanceMeasure } from '@guardian/libs';
 
 const START = Date.now();
 
@@ -84,13 +84,11 @@ function getNextTask() {
 
 	for (const priority of PRIORITIES) {
 		const { lastStartTime, tasks } = queue[priority];
-		const nextTask = tasks.shift();
-		if (
-			nextTask &&
-			runningTime < lastStartTime &&
-			nextTask.canRun({ runningTime })
-		) {
-			return nextTask;
+		if (runningTime < lastStartTime) {
+			const nextTask = tasks.shift();
+			if (nextTask?.canRun({ runningTime })) {
+				return nextTask;
+			}
 		}
 	}
 
@@ -109,7 +107,7 @@ function getNextTask() {
  */
 function run() {
 	const nextTask = getNextTask();
-	if (!nextTask) return;
+	if (isUndefined(nextTask)) return;
 
 	RUNNING_TASK_COUNT++;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3201,10 +3201,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-15.6.4.tgz#13787065e5c58b884944c5c71d6e324c7f2e566a"
   integrity sha512-oN+xN7FBuVKLCbbjvAMdWjgWqOtvR38acnqwAKsjUDkFsBzRWU/pueDSEGTCTTVSFcRdCKOsWnop+Vwh59P47g==
 
-"@guardian/libs@15.7.0":
-  version "15.7.0"
-  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-15.7.0.tgz#56313b27c240064a13a76469985e6fba3df211b4"
-  integrity sha512-uE7GZf05Hea6R8SLPjtG/znVgCqXyq6jvvKpsp34L3u4iz/t5AbopGuILrQhTpo6NcjKYFxgg59wb4vUStxJ1g==
+"@guardian/libs@15.7.1":
+  version "15.7.1"
+  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-15.7.1.tgz#48f37dafbea1119a3e0aa7063b51d6ff0cd07053"
+  integrity sha512-7Q4iuojbETOxa/VQHj78G7iQyP5cWEGE5Rc12BL6lAo32sX11Qzb3ZpYK/jP3g4OCLlf8jgnL5e4yeeVNw09mg==
 
 "@guardian/libs@^10.0.0":
   version "10.1.1"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

- bumps libs to take advantage of [more efficient logging](https://github.com/guardian/csnx/pull/809)
- refactors `scheduler` to make it faster

## Why?

Preliminary numbers showed the scheduler seemed to slow things down too much, even though it was effectively working in passthru mode.

We need to get it closer to negligible effect before we can start scheduling things.

## Difference

Using [tachometer](https://www.npmjs.com/package/tachometer), running 1000 tasks that simply return `Promise.resolve()` on my work M1 Max mbp, I get these results:

| Unscheduled (baseline) | Previously | Now | 
| ----------- | ---------- | ---------- |
| ~0.25ms | ~20.14ms | ~4.6ms |

it drops to ~1.75ms if we don't measure the duration of tasks, but that slightly defeats the purpose...

## Failed attempts
I tried using https://www.npmjs.com/package/flatqueue instead of the naive one this scheduler uses, but it had no effect until running 10k tasks, and then only slightly.