### PR TITLE
Add fronts-banners to section fronts when in `sectionFrontsBannerAds` test

### DIFF
--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -84,12 +84,12 @@ const isToggleable = (
 export const decideAdSlot = (
 	renderAds: boolean,
 	index: number,
-	isNetworkFront: boolean | undefined,
 	collectionCount: number,
 	isPaidContent: boolean | undefined,
 	mobileAdPositions: (number | undefined)[],
 	hasPageSkin: boolean,
-	isInFrontsBannerTest?: boolean,
+	isInNetworkFrontsBannerTest?: boolean,
+	isInSectionFrontsBannerTest?: boolean,
 ) => {
 	if (!renderAds) return null;
 
@@ -97,7 +97,8 @@ export const decideAdSlot = (
 	if (
 		collectionCount > minContainers &&
 		index === getMerchHighPosition(collectionCount) &&
-		!(isInFrontsBannerTest && isNetworkFront)
+		!isInNetworkFrontsBannerTest &&
+		!isInSectionFrontsBannerTest
 	) {
 		return (
 			<AdSlot
@@ -474,13 +475,13 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 									{decideAdSlot(
 										renderAds,
 										index,
-										front.isNetworkFront,
 										front.pressedPage.collections.length,
 										front.pressedPage.frontProperties
 											.isPaidContent,
 										mobileAdPositions,
 										hasPageSkin,
 										isInNetworkFrontsBannerTest,
+										isInSectionFrontsBannerTest,
 									)}
 								</div>
 							</Fragment>
@@ -554,13 +555,13 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 								{decideAdSlot(
 									renderAds,
 									index,
-									front.isNetworkFront,
 									front.pressedPage.collections.length,
 									front.pressedPage.frontProperties
 										.isPaidContent,
 									mobileAdPositions,
 									hasPageSkin,
 									isInNetworkFrontsBannerTest,
+									isInSectionFrontsBannerTest,
 								)}
 							</>
 						);
@@ -609,13 +610,13 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 								{decideAdSlot(
 									renderAds,
 									index,
-									front.isNetworkFront,
 									front.pressedPage.collections.length,
 									front.pressedPage.frontProperties
 										.isPaidContent,
 									mobileAdPositions,
 									hasPageSkin,
 									isInNetworkFrontsBannerTest,
+									isInSectionFrontsBannerTest,
 								)}
 							</Fragment>
 						);
@@ -689,13 +690,13 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 								{decideAdSlot(
 									renderAds,
 									index,
-									front.isNetworkFront,
 									front.pressedPage.collections.length,
 									front.pressedPage.frontProperties
 										.isPaidContent,
 									mobileAdPositions,
 									hasPageSkin,
 									isInNetworkFrontsBannerTest,
+									isInSectionFrontsBannerTest,
 								)}
 							</Fragment>
 						);
@@ -772,12 +773,12 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 							{decideAdSlot(
 								renderAds,
 								index,
-								front.isNetworkFront,
 								front.pressedPage.collections.length,
 								front.pressedPage.frontProperties.isPaidContent,
 								mobileAdPositions,
 								hasPageSkin,
 								isInNetworkFrontsBannerTest,
+								isInSectionFrontsBannerTest,
 							)}
 						</Fragment>
 					);

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -212,7 +212,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 		);
 
 	const isInSectionFrontsBannerTest =
-		!!switches.frontsBannerAdsDcr &&
+		!!switches.sectionFrontsBannerAds &&
 		abTests.sectionFrontsBannerAdsVariant === 'variant' &&
 		Object.keys(sectionFrontsBannerAdCollections).includes(
 			front.config.pageId,

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -36,7 +36,10 @@ import { WeatherWrapper } from '../components/WeatherWrapper.importable';
 import { canRenderAds } from '../lib/canRenderAds';
 import { getContributionsServiceUrl } from '../lib/contributions';
 import { decideContainerOverrides } from '../lib/decideContainerOverrides';
-import { frontsBannerAdSections } from '../lib/frontsBannerAbTestAdPositions';
+import {
+	networkFrontsBannerAdSections,
+	sectionFrontsBannerAdSections,
+} from '../lib/frontsBannerAbTestAdPositions';
 import {
 	getDesktopAdPositions,
 	getMerchHighPosition,
@@ -125,18 +128,14 @@ export const decideAdSlot = (
 export const decideFrontsBannerAdSlot = (
 	renderAds: boolean,
 	hasPageSkin: boolean,
-	isInFrontsBannerTest: boolean,
-	pageId: string,
+	targetedFrontSections: string[] | undefined,
 	collectionName: string,
 	numBannerAdsInserted: React.MutableRefObject<number>,
 	isFirstContainer: boolean,
 ) => {
-	const targetedSections = frontsBannerAdSections[pageId];
-
 	if (
 		!renderAds ||
-		!isInFrontsBannerTest ||
-		!targetedSections?.includes(collectionName) ||
+		!targetedFrontSections?.includes(collectionName) ||
 		isFirstContainer
 	) {
 		return null;
@@ -205,14 +204,26 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 
 	const isInEuropeTest = abTests.europeNetworkFrontVariant === 'variant';
 
-	// For the FrontsBannerAds test, we're not using contentType === "Network Front",
-	// just in case Europe goes live before the testing concludes.
-	// We don't want Europe in this test.
-	const networkFrontPageIds = ['uk', 'us', 'au', 'international'];
-	const isInFrontsBannerTest =
+	const isInNetworkFrontsBannerTest =
 		!!switches.frontsBannerAdsDcr &&
 		abTests.frontsBannerAdsDcrVariant === 'variant' &&
-		networkFrontPageIds.includes(front.config.pageId);
+		Object.keys(networkFrontsBannerAdSections).includes(
+			front.config.pageId,
+		);
+
+	const isInSectionFrontsBannerTest =
+		!!switches.frontsBannerAdsDcr &&
+		true &&
+		// abTests.sectionBannerAdsVariant === 'variant' &&
+		Object.keys(sectionFrontsBannerAdSections).includes(
+			front.config.pageId,
+		);
+
+	const frontsBannerTargetedSections = isInNetworkFrontsBannerTest
+		? networkFrontsBannerAdSections[front.config.pageId]
+		: isInSectionFrontsBannerTest
+		? sectionFrontsBannerAdSections[front.config.pageId]
+		: [];
 
 	const merchHighPosition = getMerchHighPosition(
 		front.pressedPage.collections.length,
@@ -232,7 +243,10 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 
 	const numBannerAdsInserted = useRef(0);
 
-	const renderMpuAds = renderAds && !isInFrontsBannerTest;
+	const renderMpuAds =
+		renderAds &&
+		!isInNetworkFrontsBannerTest &&
+		!isInSectionFrontsBannerTest;
 
 	const showMostPopular =
 		front.config.switches.deeplyRead &&
@@ -426,8 +440,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 									{decideFrontsBannerAdSlot(
 										renderAds,
 										hasPageSkin,
-										isInFrontsBannerTest,
-										front.config.pageId,
+										frontsBannerTargetedSections,
 										collection.displayName,
 										numBannerAdsInserted,
 										isFirstContainer,
@@ -468,7 +481,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 											.isPaidContent,
 										mobileAdPositions,
 										hasPageSkin,
-										isInFrontsBannerTest,
+										isInNetworkFrontsBannerTest,
 									)}
 								</div>
 							</Fragment>
@@ -488,8 +501,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 								{decideFrontsBannerAdSlot(
 									renderAds,
 									hasPageSkin,
-									isInFrontsBannerTest,
-									front.config.pageId,
+									frontsBannerTargetedSections,
 									collection.displayName,
 									numBannerAdsInserted,
 									isFirstContainer,
@@ -549,7 +561,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 										.isPaidContent,
 									mobileAdPositions,
 									hasPageSkin,
-									isInFrontsBannerTest,
+									isInNetworkFrontsBannerTest,
 								)}
 							</>
 						);
@@ -604,7 +616,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 										.isPaidContent,
 									mobileAdPositions,
 									hasPageSkin,
-									isInFrontsBannerTest,
+									isInNetworkFrontsBannerTest,
 								)}
 							</Fragment>
 						);
@@ -623,8 +635,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 								{decideFrontsBannerAdSlot(
 									renderAds,
 									hasPageSkin,
-									isInFrontsBannerTest,
-									front.config.pageId,
+									frontsBannerTargetedSections,
 									collection.displayName,
 									numBannerAdsInserted,
 									isFirstContainer,
@@ -685,7 +696,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 										.isPaidContent,
 									mobileAdPositions,
 									hasPageSkin,
-									isInFrontsBannerTest,
+									isInNetworkFrontsBannerTest,
 								)}
 							</Fragment>
 						);
@@ -696,8 +707,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 							{decideFrontsBannerAdSlot(
 								renderAds,
 								hasPageSkin,
-								isInFrontsBannerTest,
-								front.config.pageId,
+								frontsBannerTargetedSections,
 								collection.displayName,
 								numBannerAdsInserted,
 								isFirstContainer,
@@ -768,7 +778,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 								front.pressedPage.frontProperties.isPaidContent,
 								mobileAdPositions,
 								hasPageSkin,
-								isInFrontsBannerTest,
+								isInNetworkFrontsBannerTest,
 							)}
 						</Fragment>
 					);

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -219,6 +219,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 			front.config.pageId,
 		);
 
+	// This will be the targeted collections, if the current page is in the fronts banner AB test.
 	const frontsBannerTargetedCollections = isInNetworkFrontsBannerTest
 		? networkFrontsBannerAdCollections[front.config.pageId]
 		: isInSectionFrontsBannerTest

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -213,8 +213,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 
 	const isInSectionFrontsBannerTest =
 		!!switches.frontsBannerAdsDcr &&
-		true &&
-		// abTests.sectionBannerAdsVariant === 'variant' &&
+		abTests.sectionBannerAdsVariant === 'variant' &&
 		Object.keys(sectionFrontsBannerAdCollections).includes(
 			front.config.pageId,
 		);

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -37,8 +37,8 @@ import { canRenderAds } from '../lib/canRenderAds';
 import { getContributionsServiceUrl } from '../lib/contributions';
 import { decideContainerOverrides } from '../lib/decideContainerOverrides';
 import {
-	networkFrontsBannerAdSections,
-	sectionFrontsBannerAdSections,
+	networkFrontsBannerAdCollections,
+	sectionFrontsBannerAdCollections,
 } from '../lib/frontsBannerAbTestAdPositions';
 import {
 	getDesktopAdPositions,
@@ -128,14 +128,14 @@ export const decideAdSlot = (
 export const decideFrontsBannerAdSlot = (
 	renderAds: boolean,
 	hasPageSkin: boolean,
-	targetedFrontSections: string[] | undefined,
+	targetedCollections: string[] | undefined,
 	collectionName: string,
 	numBannerAdsInserted: React.MutableRefObject<number>,
 	isFirstContainer: boolean,
 ) => {
 	if (
 		!renderAds ||
-		!targetedFrontSections?.includes(collectionName) ||
+		!targetedCollections?.includes(collectionName) ||
 		isFirstContainer
 	) {
 		return null;
@@ -207,7 +207,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 	const isInNetworkFrontsBannerTest =
 		!!switches.frontsBannerAdsDcr &&
 		abTests.frontsBannerAdsDcrVariant === 'variant' &&
-		Object.keys(networkFrontsBannerAdSections).includes(
+		Object.keys(networkFrontsBannerAdCollections).includes(
 			front.config.pageId,
 		);
 
@@ -215,14 +215,14 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 		!!switches.frontsBannerAdsDcr &&
 		true &&
 		// abTests.sectionBannerAdsVariant === 'variant' &&
-		Object.keys(sectionFrontsBannerAdSections).includes(
+		Object.keys(sectionFrontsBannerAdCollections).includes(
 			front.config.pageId,
 		);
 
-	const frontsBannerTargetedSections = isInNetworkFrontsBannerTest
-		? networkFrontsBannerAdSections[front.config.pageId]
+	const frontsBannerTargetedCollections = isInNetworkFrontsBannerTest
+		? networkFrontsBannerAdCollections[front.config.pageId]
 		: isInSectionFrontsBannerTest
-		? sectionFrontsBannerAdSections[front.config.pageId]
+		? sectionFrontsBannerAdCollections[front.config.pageId]
 		: [];
 
 	const merchHighPosition = getMerchHighPosition(
@@ -440,7 +440,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 									{decideFrontsBannerAdSlot(
 										renderAds,
 										hasPageSkin,
-										frontsBannerTargetedSections,
+										frontsBannerTargetedCollections,
 										collection.displayName,
 										numBannerAdsInserted,
 										isFirstContainer,
@@ -501,7 +501,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 								{decideFrontsBannerAdSlot(
 									renderAds,
 									hasPageSkin,
-									frontsBannerTargetedSections,
+									frontsBannerTargetedCollections,
 									collection.displayName,
 									numBannerAdsInserted,
 									isFirstContainer,
@@ -635,7 +635,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 								{decideFrontsBannerAdSlot(
 									renderAds,
 									hasPageSkin,
-									frontsBannerTargetedSections,
+									frontsBannerTargetedCollections,
 									collection.displayName,
 									numBannerAdsInserted,
 									isFirstContainer,
@@ -707,7 +707,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 							{decideFrontsBannerAdSlot(
 								renderAds,
 								hasPageSkin,
-								frontsBannerTargetedSections,
+								frontsBannerTargetedCollections,
 								collection.displayName,
 								numBannerAdsInserted,
 								isFirstContainer,

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -213,7 +213,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 
 	const isInSectionFrontsBannerTest =
 		!!switches.frontsBannerAdsDcr &&
-		abTests.sectionBannerAdsVariant === 'variant' &&
+		abTests.sectionFrontsBannerAdsVariant === 'variant' &&
 		Object.keys(sectionFrontsBannerAdCollections).includes(
 			front.config.pageId,
 		);

--- a/dotcom-rendering/src/layouts/TagFrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/TagFrontLayout.tsx
@@ -301,7 +301,6 @@ export const TagFrontLayout = ({ tagFront, NAV }: Props) => {
 							{decideAdSlot(
 								renderAds,
 								index,
-								false,
 								tagFront.groupedTrails.length,
 								tagFront.config.isPaidContent,
 								mobileAdPositions,

--- a/dotcom-rendering/src/lib/frontsBannerAbTestAdPositions.ts
+++ b/dotcom-rendering/src/lib/frontsBannerAbTestAdPositions.ts
@@ -2,7 +2,7 @@
  * This file is temporary.
  *
  * For the Fronts banner AB test, we will target
- * specific sections on the page to insert ads above.
+ * specific collections on the page to insert ads above.
  *
  * When we go live with fronts-banner ads, there will be a setting in
  * the fronts config tool which will decide whether a section has an ad

--- a/dotcom-rendering/src/lib/frontsBannerAbTestAdPositions.ts
+++ b/dotcom-rendering/src/lib/frontsBannerAbTestAdPositions.ts
@@ -57,38 +57,38 @@ export const sectionFrontsBannerAdCollections: FrontsBannerAdCollections = {
 		// 'football', has football weekly thrasher above atm
 		'Video',
 		'Other sports',
-		'The big picture',
 	],
 	football: [
 		// multiline array
-		'News and features',
+		'In depth',
 		'Regulars',
 		'Next generation',
 	],
 	'uk/culture': [
 		// multiline array
-		'Best culture for kids',
-		'Reviews',
+		'News',
 		'You may have missed',
 	],
 	'uk/lifeandstyle': [
 		// multiline array
 		'Fashion',
+		'Health & wellbeing',
 		'Money',
 		'The big picture',
 	],
 	'uk/commentisfree': [
 		'The Heat or Eat Diaries',
-		"Starmer's path to power",
-		'Spotlight',
-		'This is Europe',
-		'Columnists',
+		'Why I quit',
+		'The Guardian view',
+		'You may have missed',
+		'Cartoons',
+		'Letters',
 	],
 	'uk-news': [
 		// multiline array
 		'UK politics',
-		'Education',
-		'Multimedia',
+		'Culture',
+		'Society',
 	],
 	world: [
 		// multiline array
@@ -100,6 +100,7 @@ export const sectionFrontsBannerAdCollections: FrontsBannerAdCollections = {
 	'us-news': [
 		// multiline array
 		'Opinion',
+		'US politics',
 		'Video',
 	],
 	'uk/business': [

--- a/dotcom-rendering/src/lib/frontsBannerAbTestAdPositions.ts
+++ b/dotcom-rendering/src/lib/frontsBannerAbTestAdPositions.ts
@@ -13,7 +13,7 @@ type FrontsBannerAdSections = {
 	[key: string]: string[];
 };
 
-export const frontsBannerAdSections: FrontsBannerAdSections = {
+export const networkFrontsBannerAdSections: FrontsBannerAdSections = {
 	uk: [
 		'Spotlight',
 		'Opinion',
@@ -48,5 +48,68 @@ export const frontsBannerAdSections: FrontsBannerAdSections = {
 		'Culture',
 		'Around the world',
 		'Take part',
+	],
+};
+
+export const sectionFrontsBannerAdSections: FrontsBannerAdSections = {
+	'uk/sport': [
+		'News and features',
+		// 'football', has football weekly thrasher above atm
+		'Video',
+		'Other sports',
+		'The big picture',
+	],
+	football: [
+		// multiline array
+		'News and features',
+		'Regulars',
+		'Next generation',
+	],
+	'uk/culture': [
+		// multiline array
+		'Best culture for kids',
+		'Reviews',
+		'You may have missed',
+	],
+	'uk/lifeandstyle': [
+		// multiline array
+		'Fashion',
+		'Money',
+		'The big picture',
+	],
+	'uk/commentisfree': [
+		'The Heat or Eat Diaries',
+		"Starmer's path to power",
+		'Spotlight',
+		'This is Europe',
+		'Columnists',
+	],
+	'uk-news': [
+		// multiline array
+		'UK politics',
+		'Education',
+		'Multimedia',
+	],
+	world: [
+		// multiline array
+		'Americas',
+		'Australia',
+		'Middle East',
+		'UK',
+	],
+	'us-news': [
+		// multiline array
+		'Opinion',
+		'Video',
+	],
+	'uk/business': [
+		// multiline array
+		'Opinion & analysis',
+		'Multimedia',
+	],
+	'australia-news': [
+		// multiline array
+		'Australian politics',
+		'Video',
 	],
 };

--- a/dotcom-rendering/src/lib/frontsBannerAbTestAdPositions.ts
+++ b/dotcom-rendering/src/lib/frontsBannerAbTestAdPositions.ts
@@ -9,11 +9,11 @@
  * inserted above it. At the time of this AB test, the setting does not yet exist.
  */
 
-type FrontsBannerAdSections = {
+type FrontsBannerAdCollections = {
 	[key: string]: string[];
 };
 
-export const networkFrontsBannerAdSections: FrontsBannerAdSections = {
+export const networkFrontsBannerAdCollections: FrontsBannerAdCollections = {
 	uk: [
 		'Spotlight',
 		'Opinion',
@@ -51,7 +51,7 @@ export const networkFrontsBannerAdSections: FrontsBannerAdSections = {
 	],
 };
 
-export const sectionFrontsBannerAdSections: FrontsBannerAdSections = {
+export const sectionFrontsBannerAdCollections: FrontsBannerAdCollections = {
 	'uk/sport': [
 		'News and features',
 		// 'football', has football weekly thrasher above atm


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Add banner slots to section fronts on desktop when in the `sectionFrontsBannerAds` test.

There are a few tweaks to the network front test code to accommodate the section front test.

Including renaming the current `frontsBanner` variables to `networkFrontsBanner` to better distinguish the tests.

And use the alternative name for sections which is collections to reduce confusion with section fronts and the sections/collections on the fronts.


## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/1731150/683d8257-44d7-4bfa-93ff-68e4eee9e1b5
[after]: https://github.com/guardian/dotcom-rendering/assets/1731150/65e8a3b0-4928-4aba-b623-217e2d484a5a

### Examples of spacing I've gone for

| /uk/sport    | /uk/commentisfree      |
| ----------- | ---------- |
| ![sport][] | ![comment][] |

[sport]: https://github.com/guardian/dotcom-rendering/assets/1731150/bcff2ee5-9626-4ff6-a921-1b8306a219d9

[comment]: https://github.com/guardian/dotcom-rendering/assets/1731150/f8d81fea-38ad-49f1-8942-677fa6c06ad2

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
