### PR TITLE
Fix OL styling

### DIFF
--- a/dotcom-rendering/src/components/TextBlockComponent.tsx
+++ b/dotcom-rendering/src/components/TextBlockComponent.tsx
@@ -301,6 +301,13 @@ const buildElementTree =
 					key,
 					children,
 				});
+			case 'OL':
+				return jsx('ol', {
+					'data-ignore':
+						getAttrs(node)?.getNamedItem('data-ignore')?.value,
+					key,
+					children,
+				});
 			case 'FOOTER':
 			case 'SUB':
 			case 'SUP':
@@ -310,7 +317,6 @@ const buildElementTree =
 			case 'B':
 			case 'EM':
 			case 'UL':
-			case 'OL':
 			case 'LI':
 			case 'MARK':
 			case 'S':


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Passes the data-ignore attribute to correctly apply styling
## Why?
Was not applying the correct styles. Now looks the same as frontend.
Fixes https://github.com/guardian/dotcom-rendering/issues/8294
## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/110032454/a9848c3f-d8dc-409e-ac54-a7cae34ab1ff
[after]: https://github.com/guardian/dotcom-rendering/assets/110032454/fb05f06f-27e3-4e1a-87d7-627e372400d7

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
