### PR TITLE
Pass attribute object to each node

### DIFF
--- a/dotcom-rendering/src/components/TextBlockComponent.tsx
+++ b/dotcom-rendering/src/components/TextBlockComponent.tsx
@@ -227,9 +227,8 @@ const getAttributes = (node: Node): Attributes => {
 	if (!namedNodeMap) {
 		return {};
 	}
-	const attrs = Array.prototype.slice.call(namedNodeMap) as Attr[];
 	const attributes = Object.fromEntries(
-		attrs.map((attr) => [attr.name, attr.value]),
+		Array.from(namedNodeMap, (attr) => [attr.name, attr.value]),
 	);
 	return attributes;
 };
@@ -325,13 +324,12 @@ const buildElementTree =
 					key,
 					children,
 				});
-			case 'OL': {
+			case 'OL':
 				return jsx('ol', {
 					...attributes,
 					key,
 					children,
 				});
-			}
 			case 'FOOTER':
 			case 'SUB':
 			case 'SUP':


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Passes the attributes object to each node.
## Why?
Some were being missed e.g https://github.com/guardian/dotcom-rendering/pull/8714 . Think this is a better way to handle this so that we don't miss any.

<!--
## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png


You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
