### PR TITLE
fix(Discussion): provide default value for commentOrderBy state hook

### DIFF
--- a/dotcom-rendering/src/components/Discussion.tsx
+++ b/dotcom-rendering/src/components/Discussion.tsx
@@ -75,7 +75,7 @@ export const Discussion = ({
 	const [commentPageSize, setCommentPageSize] = useState<25 | 50 | 100>();
 	const [commentOrderBy, setCommentOrderBy] = useState<
 		'newest' | 'oldest' | 'recommendations'
-	>('recommendations');
+	>('newest');
 	const [isExpanded, setIsExpanded] = useState<boolean>(false);
 	const [hashCommentId, setHashCommentId] = useState<number | undefined>(
 		commentIdFromUrl(),


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Adds a default value to the `useState` hook for comment ordering in `Discussion` component of `"newest"`. 


This seems the most logical choice as "recommendations" are "Guardian picks" which often appear on top of the general comment section anyway, so this would be repetition. "oldest" seems illogical as most comment sections on sites on the internet use newest first.

## Why?

The diff keeps flip-flopping in Chromatic, causing unexpected diffs for completely unrelated PRs.
Hoping that by setting it explicitly on render, this won't happen

It is also worth noting that this flip-flopping seems to also outside of Storybook/chromatic, so would be considered a bug fix.

## Screenshots

The following diff should not keep occurring after this PR
<img width="758" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/43961396/5685cbb8-af1e-4edd-bd98-f9eba020304d">
