### PR TITLE
Fix indexing of ad slots on AMP

### DIFF
--- a/dotcom-rendering/cypress/e2e/parallel-1/article.e2e.cy.js
+++ b/dotcom-rendering/cypress/e2e/parallel-1/article.e2e.cy.js
@@ -136,6 +136,13 @@ describe('E2E Page rendering', function () {
 				`/AMPArticle/https://amp.theguardian.com/commentisfree/2019/oct/16/impostor-syndrome-class-unfairness`,
 			);
 			cy.contains('Opinion');
+
+			// In this AMP Article we'd expect three advert slots to be inserted
+			// (note each of these slots will itself contain a regional slot, that will only appear in certain geos)
+			// And each to have the follow IDs
+			cy.get('#ad-1').should('exist');
+			cy.get('#ad-2').should('exist');
+			cy.get('#ad-3').should('exist');
 		});
 	});
 });

--- a/dotcom-rendering/src/components/Blocks.amp.tsx
+++ b/dotcom-rendering/src/components/Blocks.amp.tsx
@@ -122,7 +122,7 @@ export const Blocks = ({
 		return <>{liveBlogBlocks}</>;
 	}
 
-	const slotIndexes = findBlockAdSlots(liveBlogBlocks);
+	const insertSlotsAfter = findBlockAdSlots(liveBlogBlocks);
 	const adInfo = {
 		section,
 		editionId,
@@ -146,9 +146,9 @@ export const Blocks = ({
 	};
 	return (
 		<>
-			{liveBlogBlocks.map((item, i) => {
-				if (slotIndexes.includes(i)) {
-					const slotIndex = slotIndexes.indexOf(i);
+			{liveBlogBlocks.map((item, blockIndex) => {
+				if (insertSlotsAfter.includes(blockIndex)) {
+					const slotIndex = insertSlotsAfter.indexOf(blockIndex);
 					const adSlotId = `ad-${slotIndex + 1}` as const;
 					return (
 						<>

--- a/dotcom-rendering/src/components/Blocks.amp.tsx
+++ b/dotcom-rendering/src/components/Blocks.amp.tsx
@@ -148,6 +148,9 @@ export const Blocks = ({
 		<>
 			{liveBlogBlocks.map((item, blockIndex) => {
 				if (insertSlotsAfter.includes(blockIndex)) {
+					// Ad slot ids take the form: `ad-1`, `ad-2`, `ad-3`, ...
+					// Looking up the block index in the array of ad insertion points
+					// gives us the slot indexes
 					const slotIndex = insertSlotsAfter.indexOf(blockIndex);
 					const adSlotId = `ad-${slotIndex + 1}` as const;
 					return (

--- a/dotcom-rendering/src/components/Blocks.amp.tsx
+++ b/dotcom-rendering/src/components/Blocks.amp.tsx
@@ -148,7 +148,8 @@ export const Blocks = ({
 		<>
 			{liveBlogBlocks.map((item, i) => {
 				if (slotIndexes.includes(i)) {
-					const adSlotId = `ad-${i + 1}` as const;
+					const slotIndex = slotIndexes.indexOf(i);
+					const adSlotId = `ad-${slotIndex + 1}` as const;
 					return (
 						<>
 							{item}

--- a/dotcom-rendering/src/components/BodyArticle.amp.tsx
+++ b/dotcom-rendering/src/components/BodyArticle.amp.tsx
@@ -125,7 +125,7 @@ export const Body = ({ data, config }: Props) => {
 		data.isImmersive,
 		adTargeting,
 	);
-	const slotIndexes = findAdSlots(bodyElements);
+	const insertSlotsAfter = findAdSlots(bodyElements);
 	const adInfo = {
 		adUnit: config.adUnit,
 		section: data.sectionName,
@@ -152,9 +152,9 @@ export const Body = ({ data, config }: Props) => {
 		<>{elementsWithoutAds}</>
 	) : (
 		<>
-			{elementsWithoutAds.map((item, i) => {
-				if (slotIndexes.includes(i)) {
-					const slotIndex = slotIndexes.indexOf(i);
+			{elementsWithoutAds.map((item, elementIndex) => {
+				if (insertSlotsAfter.includes(elementIndex)) {
+					const slotIndex = insertSlotsAfter.indexOf(elementIndex);
 					const adSlotId = `ad-${slotIndex + 1}` as const;
 					return (
 						<React.Fragment key={item.key}>

--- a/dotcom-rendering/src/components/BodyArticle.amp.tsx
+++ b/dotcom-rendering/src/components/BodyArticle.amp.tsx
@@ -154,6 +154,9 @@ export const Body = ({ data, config }: Props) => {
 		<>
 			{elementsWithoutAds.map((item, elementIndex) => {
 				if (insertSlotsAfter.includes(elementIndex)) {
+					// Ad slot ids take the form: `ad-1`, `ad-2`, `ad-3`, ...
+					// Looking up the element index in the array of ad insertion points
+					// gives us the slot indexes
 					const slotIndex = insertSlotsAfter.indexOf(elementIndex);
 					const adSlotId = `ad-${slotIndex + 1}` as const;
 					return (

--- a/dotcom-rendering/src/components/BodyArticle.amp.tsx
+++ b/dotcom-rendering/src/components/BodyArticle.amp.tsx
@@ -154,7 +154,8 @@ export const Body = ({ data, config }: Props) => {
 		<>
 			{elementsWithoutAds.map((item, i) => {
 				if (slotIndexes.includes(i)) {
-					const adSlotId = `ad-${i + 1}` as const;
+					const slotIndex = slotIndexes.indexOf(i);
+					const adSlotId = `ad-${slotIndex + 1}` as const;
 					return (
 						<React.Fragment key={item.key}>
 							{item}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Following on from #8713, this change fixes the slot indexing on AMP to ensure that, regardless of the article/liveblog structure, ad slots ids count up in the pattern `ad-1`, `ad-2`, `ad-3`, etc.

Previously, an ad slot used the element/block after which it was inserted to derive its id. For example, an ad inserted after the fifth element in an article would have id `ad-5`. This change instead looks up the element index in the array of indexes after which we insert ads, and uses the resulting index to insert adverts.

For example:
```
[ 2,    4,    5 ]  Insert ads after elements
  │     │     │
  ▼     ▼     ▼
  0     1     2    Slot indexes
  │     │     │
  ▼     ▼     ▼
ad-1  ad-2  ad-3   Slot ids
```

## Why?

It's important that ads have consistent indexing so that Ad Ops can target line items to only fill certain slots.
