### PR TITLE
Fix Editions Avatar Background Colour In Dark Mode

### DIFF
--- a/apps-rendering/src/components/editions/avatar/index.tsx
+++ b/apps-rendering/src/components/editions/avatar/index.tsx
@@ -8,6 +8,7 @@ import type { Item } from 'item';
 import { getFormat } from 'item';
 import { pipe } from 'lib';
 import type { FC, ReactElement } from 'react';
+import { darkModeCss } from 'styles';
 
 // ----- Component ----- //
 
@@ -18,6 +19,10 @@ interface Props {
 const imgStyles = css`
 	background: none;
 	width: 125px;
+
+	${darkModeCss`
+		background: none;
+	`}
 `;
 
 const sizes: Sizes = {


### PR DESCRIPTION
## Why?

The Editions app doesn't support dark mode, so everything should look the same whether the user is in light or dark mode. There's a bug where the contributor avatar that appears on Comment pieces was switching to a different background when in dark mode. This happened because the underlying `Img` component Editions uses is shared, and comes with a dark mode background. The fix is to add some dark mode styles specifically for Editions that override this dark mode background, setting it to `none` instead.

## Screenshots

| Before | After |
| - | - |
| ![editions-before] | ![editions-after] |

[editions-before]: https://github.com/guardian/dotcom-rendering/assets/53781962/b91cffe6-c210-4335-b410-a2d45acb9ed3
[editions-after]: https://github.com/guardian/dotcom-rendering/assets/53781962/151287a4-b78b-4795-9eb7-ea0b28fe9384
