### PR TITLE
fix: bump minCapacity from 15 => 30

### DIFF
--- a/dotcom-rendering/cdk/bin/cdk.ts
+++ b/dotcom-rendering/cdk/bin/cdk.ts
@@ -15,7 +15,7 @@ new DotcomRendering(app, 'DotcomRendering-PROD', {
 	...sharedProps,
 	stage: 'PROD',
 	minCapacity: 30,
-	maxCapacity: 60,
+	maxCapacity: 120,
 	instanceType: 't4g.small',
 });
 

--- a/dotcom-rendering/cdk/bin/cdk.ts
+++ b/dotcom-rendering/cdk/bin/cdk.ts
@@ -14,7 +14,7 @@ const sharedProps = {
 new DotcomRendering(app, 'DotcomRendering-PROD', {
 	...sharedProps,
 	stage: 'PROD',
-	minCapacity: 15,
+	minCapacity: 30,
 	maxCapacity: 60,
 	instanceType: 't4g.small',
 });


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Bumps the min capacity from 15-30 as it seems the minimum isn't holding up with all the new traffic we're sending it.

This is a hotfix until we split our stacks, and can start setting scaling policies and capacities for specifically for each of our stacks.