### PR TITLE
Allow native templates to be served in fronts-banner ad slots

### DIFF
--- a/dotcom-rendering/src/components/AdSlot.tsx
+++ b/dotcom-rendering/src/components/AdSlot.tsx
@@ -241,15 +241,14 @@ const frontsBannerAdTopContainerStyles = css`
 `;
 
 const frontsBannerAdContainerStyles = css`
-	max-width: ${breakpoints['wide']}px;
-	/*
-		The following flex settings are to stop the visual effect where the
-		advert renders at the top of the ad slot, then is pushed down 24px to the
-		bottom of the slot when the label renders
-	*/
+	/* Native templates require a width (or min-width) to be explicitly set */
+	width: ${breakpoints['wide']}px;
 	display: flex;
-	flex-direction: column;
-	justify-content: flex-end;
+	justify-content: center;
+
+	/* This stops the visual effect where the advert renders at the
+	   top of the ad slot, then is pushed down 24px when the label renders */
+	align-items: flex-end;
 `;
 
 const frontsBannerCollapseStyles = css`
@@ -257,6 +256,7 @@ const frontsBannerCollapseStyles = css`
 `;
 
 const frontsBannerAdStyles = css`
+	position: relative;
 	max-width: ${breakpoints['wide']}px;
 	overflow: hidden;
 	padding-bottom: ${frontsBannerPaddingHeight}px;
@@ -565,6 +565,41 @@ export const AdSlot = ({
 				</div>
 			);
 		}
+		case 'fronts-banner': {
+			const advertId = `fronts-banner-${index}`;
+			return (
+				<div css={frontsBannerAdTopContainerStyles}>
+					<div
+						className="ad-slot-container"
+						css={[
+							adContainerStyles,
+							frontsBannerAdContainerStyles,
+							hasPageskin && frontsBannerCollapseStyles,
+						]}
+					>
+						<div
+							id={`dfp-ad--${advertId}`}
+							className={[
+								'js-ad-slot',
+								'ad-slot',
+								`ad-slot--${advertId}`,
+								'ad-slot--rendered',
+								hasPageskin && 'ad-slot--collapse',
+							].join(' ')}
+							css={[
+								fluidAdStyles,
+								fluidFullWidthAdStyles,
+								frontsBannerAdStyles,
+							]}
+							data-link-name={`ad slot ${advertId}`}
+							data-name={`${advertId}`}
+							data-refresh="false"
+							aria-hidden="true"
+						/>
+					</div>
+				</div>
+			);
+		}
 		case 'survey': {
 			return (
 				<div
@@ -623,41 +658,6 @@ export const AdSlot = ({
 						data-name={advertId}
 						aria-hidden="true"
 					/>
-				</div>
-			);
-		}
-		case 'fronts-banner': {
-			const advertId = `fronts-banner-${index}`;
-			return (
-				<div css={frontsBannerAdTopContainerStyles}>
-					<div
-						className="ad-slot-container"
-						css={[
-							adContainerStyles,
-							frontsBannerAdContainerStyles,
-							hasPageskin && frontsBannerCollapseStyles,
-						]}
-					>
-						<div
-							id={`dfp-ad--${advertId}`}
-							className={[
-								'js-ad-slot',
-								'ad-slot',
-								`ad-slot--${advertId}`,
-								'ad-slot--rendered',
-								hasPageskin && 'ad-slot--collapse',
-							].join(' ')}
-							css={[
-								fluidAdStyles,
-								fluidFullWidthAdStyles,
-								frontsBannerAdStyles,
-							]}
-							data-link-name={`ad slot ${advertId}`}
-							data-name={`${advertId}`}
-							data-refresh="false"
-							aria-hidden="true"
-						/>
-					</div>
 				</div>
 			);
 		}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Add a width to fronts-banner ad containers for native templates.

## Why?

The native templates look for the explicit width/min-width of the ad slot or ad container to decide how much space they can take up. If this is not set, then they will have a width of 0px.

## Screenshots

The Native Template took up a height of 1610px when it did not have a width (still not sure why!)

|      Ad type           | Before          | After          |
| ----------------  | ------------ | ---------- |
| Native Template  | ![before][]   | ![after][]   |
| Fluid/Billboard     | ![before2][] | ![after2][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/9574885/7a26e810-7a3e-45df-b19c-c9b14a544f7b
[before2]: https://github.com/guardian/dotcom-rendering/assets/9574885/bda13856-e8f4-41ab-95c0-000051236af0
[after]: https://github.com/guardian/dotcom-rendering/assets/9574885/1d881148-6d98-4f70-803a-015a81d2abba
[after2]: https://github.com/guardian/dotcom-rendering/assets/9574885/3b57f836-853c-485f-8adb-d31e08a88d12

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
