### PR TITLE
Fronts: Use `mainMediaAtom` field if it exists

### DIFF
--- a/dotcom-rendering/src/model/enhanceCards.ts
+++ b/dotcom-rendering/src/model/enhanceCards.ts
@@ -372,7 +372,8 @@ export const enhanceCards = (
 			mainMedia: decideMedia(
 				format,
 				faciaCard.properties.showMainVideo,
-				faciaCard.properties.maybeContent?.elements.mediaAtoms[0],
+				faciaCard.properties.maybeContent?.elements.mainMediaAtom ??
+					faciaCard.properties.maybeContent?.elements.mediaAtoms[0],
 			),
 			isExternalLink: faciaCard.card.cardStyle.type === 'ExternalLink',
 			embedUri: faciaCard.properties.embedUri ?? undefined,

--- a/dotcom-rendering/src/model/front-schema.json
+++ b/dotcom-rendering/src/model/front-schema.json
@@ -757,6 +757,9 @@
                                                                     "items": {
                                                                         "$ref": "#/definitions/FEMediaAtom"
                                                                     }
+                                                                },
+                                                                "mainMediaAtom": {
+                                                                    "$ref": "#/definitions/FEMediaAtom"
                                                                 }
                                                             },
                                                             "required": [
@@ -1483,6 +1486,9 @@
                                                                     "items": {
                                                                         "$ref": "#/definitions/FEMediaAtom"
                                                                     }
+                                                                },
+                                                                "mainMediaAtom": {
+                                                                    "$ref": "#/definitions/FEMediaAtom"
                                                                 }
                                                             },
                                                             "required": [
@@ -2209,6 +2215,9 @@
                                                                     "items": {
                                                                         "$ref": "#/definitions/FEMediaAtom"
                                                                     }
+                                                                },
+                                                                "mainMediaAtom": {
+                                                                    "$ref": "#/definitions/FEMediaAtom"
                                                                 }
                                                             },
                                                             "required": [

--- a/dotcom-rendering/src/model/tag-front-schema.json
+++ b/dotcom-rendering/src/model/tag-front-schema.json
@@ -192,6 +192,9 @@
                                                 "items": {
                                                     "$ref": "#/definitions/FEMediaAtom"
                                                 }
+                                            },
+                                            "mainMediaAtom": {
+                                                "$ref": "#/definitions/FEMediaAtom"
                                             }
                                         },
                                         "required": [

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -207,6 +207,7 @@ export type FEFrontCard = {
 			elements: {
 				mainVideo?: unknown;
 				mediaAtoms: FEMediaAtom[];
+				mainMediaAtom?: FEMediaAtom;
 			};
 			tags: { tags: FETagType[] };
 		};


### PR DESCRIPTION
The `mainMediaAtom` field was introduced to the model in https://github.com/guardian/frontend/pull/26534. If it's set, we should use it to determine the main media to use, otherwise falling back to the element at index 0.

Part of https://github.com/guardian/dotcom-rendering/issues/8679.
