### PR TITLE
Allow RiffRaff To Update DCR's AMI

### DIFF
--- a/dotcom-rendering/cdk/bin/cdk.ts
+++ b/dotcom-rendering/cdk/bin/cdk.ts
@@ -8,7 +8,6 @@ const sharedProps = {
 	app: 'rendering',
 	stack: 'frontend',
 	region: 'eu-west-1',
-	amiRecipe: 'dotcom-rendering-ARM-jammy-node-18.17.0',
 };
 
 new DotcomRendering(app, 'DotcomRendering-PROD', {

--- a/dotcom-rendering/cdk/lib/__snapshots__/dotcom-rendering.test.ts.snap
+++ b/dotcom-rendering/cdk/lib/__snapshots__/dotcom-rendering.test.ts.snap
@@ -43,9 +43,8 @@ exports[`The DotcomRendering stack matches the snapshot 1`] = `
   },
   "Parameters": {
     "AMIRendering": {
-      "Default": "/TEST/frontend/rendering/ami.imageId",
       "Description": "Amazon Machine Image ID for the app rendering. Use this in conjunction with AMIgo to keep AMIs up to date.",
-      "Type": "AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>",
+      "Type": "AWS::EC2::Image::Id",
     },
     "DistributionBucketName": {
       "Default": "/account/services/artifact.bucket",

--- a/dotcom-rendering/cdk/lib/dotcom-rendering.test.ts
+++ b/dotcom-rendering/cdk/lib/dotcom-rendering.test.ts
@@ -17,7 +17,6 @@ describe('The DotcomRendering stack', () => {
 			maxCapacity: 4,
 			instanceType: 't4g.micro',
 			region: 'eu-west-1',
-			amiRecipe: 'amiRecipe',
 		});
 		const template = Template.fromStack(stack);
 		expect(template.toJSON()).toMatchSnapshot();

--- a/dotcom-rendering/cdk/lib/dotcom-rendering.ts
+++ b/dotcom-rendering/cdk/lib/dotcom-rendering.ts
@@ -1,6 +1,5 @@
 import { GuAutoScalingGroup } from '@guardian/cdk/lib/constructs/autoscaling';
 import {
-	GuAmiParameter,
 	GuStack,
 	GuStringParameter,
 } from '@guardian/cdk/lib/constructs/core';
@@ -234,12 +233,6 @@ export class DotcomRendering extends GuStack {
 					default: `${ssmPrefix}/logging.stream.name`,
 				}).valueAsString,
 			}),
-			imageId: new GuAmiParameter(this, {
-				app,
-				fromSSM: true,
-				default: `${ssmPrefix}/ami.imageId`,
-			}),
-			imageRecipe: props.amiRecipe,
 			role: instanceRole,
 			additionalSecurityGroups: [instanceSecurityGroup],
 			vpcSubnets: { subnets: privateSubnets },

--- a/dotcom-rendering/cdk/lib/types.ts
+++ b/dotcom-rendering/cdk/lib/types.ts
@@ -22,10 +22,6 @@ export interface DCRProps extends GuStackProps {
 	 * The region in AWS where this app will run
 	 */
 	region: string;
-	/**
-	 * AMI Recipe to use
-	 */
-	amiRecipe: string;
 }
 
 export interface UserDataProps

--- a/dotcom-rendering/scripts/deploy/riff-raff.yaml
+++ b/dotcom-rendering/scripts/deploy/riff-raff.yaml
@@ -12,6 +12,12 @@ deployments:
         PROD: DotcomRendering-PROD.template.json
       cloudFormationStackByTags: false
       cloudFormationStackName: rendering
+      amiParameter: AMIRendering
+      amiEncrypted: true
+      amiTags:
+        # Keep the Node version in sync with `.nvmrc`
+        Recipe: dotcom-rendering-ARM-jammy-node-18.17.0
+        AmigoStage: PROD
   rendering:
     type: autoscaling
     parameters:

--- a/scripts/check-node-versions.mjs
+++ b/scripts/check-node-versions.mjs
@@ -34,9 +34,8 @@ const requiredNodeVersionMatches =
 			pattern: /^FROM node:(.+)-alpine$/m,
 		},
 		{
-			filepath: 'dotcom-rendering/cdk/bin/cdk.ts',
-			pattern:
-				/^.+amiRecipe: \'dotcom-rendering.*-node-(\d+\.\d+\.\d+)\'\,$/m,
+			filepath: 'dotcom-rendering/scripts/deploy/riff-raff.yaml',
+			pattern: /^ +Recipe: dotcom-rendering.*-node-(\d+\.\d+\.\d+)$/m,
 		},
 		{
 			filepath: 'apps-rendering/riff-raff.yaml',


### PR DESCRIPTION
## Why?

We'd like the application to always be on the latest AMI, which we can do by specifying a recipe and allowing RiffRaff to select the latest image. We believe this was the previous behaviour before this change: https://github.com/guardian/dotcom-rendering/pull/8507/files#diff-7423a3e6e89774c277c681ff67a381522c6a124dfe1ede87cb923054e1a8b9ed

Paired with @jacobwinch 

## Changes

- Set AMI recipe in RiffRaff config file
- Removed references to an AMI recipe and image from CDK
- Switched to an encrypted AMI at the same time
