### PR TITLE
Exclude more folders from TS compilation

### DIFF
--- a/dotcom-rendering/tsconfig.json
+++ b/dotcom-rendering/tsconfig.json
@@ -16,5 +16,12 @@
 		},
 		"preserveConstEnums": true
 	},
-	"exclude": ["cypress", "./cypress.config.js", "storybook-static", "target"]
+	"exclude": [
+		"cypress",
+		"./cypress.config.js",
+		"storybook-static",
+		"target",
+		"dist",
+		"node_modules"
+	]
 }


### PR DESCRIPTION
## What does this change?

Exclude the following folders from TypeScript compilation:
- `node_modules`
- `dist`

## Why?

We never want to run TS against those folders.