### PR TITLE
Only prefetch non-legacy scripts

### DIFF
--- a/dotcom-rendering/src/server/index.allEditorialNewslettersPage.web.ts
+++ b/dotcom-rendering/src/server/index.allEditorialNewslettersPage.web.ts
@@ -12,8 +12,8 @@ export const handleAllEditorialNewslettersPage: RequestHandler = (
 	recordTypeAndPlatform('newsletters');
 	const feNewslettersData = validateAsAllEditorialNewslettersPageType(body);
 	const newslettersPage = enhanceNewslettersPage(feNewslettersData);
-	const { html, clientScripts } = renderEditorialNewslettersPage({
+	const { html, prefetchScripts } = renderEditorialNewslettersPage({
 		newslettersPage,
 	});
-	res.status(200).set('Link', makePrefetchHeader(clientScripts)).send(html);
+	res.status(200).set('Link', makePrefetchHeader(prefetchScripts)).send(html);
 };

--- a/dotcom-rendering/src/server/index.article.apps.ts
+++ b/dotcom-rendering/src/server/index.article.apps.ts
@@ -7,8 +7,8 @@ import { renderArticle } from './render.article.apps';
 export const handleAppsArticle: RequestHandler = ({ body }, res) => {
 	recordTypeAndPlatform('article', 'apps');
 	const article = enhanceArticleType(body);
-	const { html, clientScripts } = renderArticle(article);
+	const { html, prefetchScripts } = renderArticle(article);
 
 	// The Android app will cache these assets to enable offline reading
-	res.set('Link', makePrefetchHeader(clientScripts)).send(html);
+	res.set('Link', makePrefetchHeader(prefetchScripts)).send(html);
 };

--- a/dotcom-rendering/src/server/index.article.web.ts
+++ b/dotcom-rendering/src/server/index.article.web.ts
@@ -76,11 +76,11 @@ export const enhanceArticleType = (body: unknown): FEArticleType => {
 export const handleArticle: RequestHandler = ({ body }, res) => {
 	recordTypeAndPlatform('article', 'web');
 	const article = enhanceArticleType(body);
-	const { html, clientScripts } = renderHtml({
+	const { html, prefetchScripts } = renderHtml({
 		article,
 	});
 
-	res.status(200).set('Link', makePrefetchHeader(clientScripts)).send(html);
+	res.status(200).set('Link', makePrefetchHeader(prefetchScripts)).send(html);
 };
 
 export const handleArticleJson: RequestHandler = ({ body }, res) => {
@@ -105,11 +105,11 @@ export const handleArticlePerfTest: RequestHandler = (req, res, next) => {
 export const handleInteractive: RequestHandler = ({ body }, res) => {
 	recordTypeAndPlatform('interactive', 'web');
 	const article = enhanceArticleType(body);
-	const { html, clientScripts } = renderHtml({
+	const { html, prefetchScripts } = renderHtml({
 		article,
 	});
 
-	res.status(200).set('Link', makePrefetchHeader(clientScripts)).send(html);
+	res.status(200).set('Link', makePrefetchHeader(prefetchScripts)).send(html);
 };
 
 export const handleBlocks: RequestHandler = ({ body }, res) => {

--- a/dotcom-rendering/src/server/index.front.web.ts
+++ b/dotcom-rendering/src/server/index.front.web.ts
@@ -92,10 +92,10 @@ const enhanceTagFront = (body: unknown): DCRTagFrontType => {
 export const handleFront: RequestHandler = ({ body }, res) => {
 	recordTypeAndPlatform('front');
 	const front = enhanceFront(body);
-	const { html, clientScripts } = renderFront({
+	const { html, prefetchScripts } = renderFront({
 		front,
 	});
-	res.status(200).set('Link', makePrefetchHeader(clientScripts)).send(html);
+	res.status(200).set('Link', makePrefetchHeader(prefetchScripts)).send(html);
 };
 
 export const handleFrontJson: RequestHandler = ({ body }, res) => {
@@ -105,10 +105,10 @@ export const handleFrontJson: RequestHandler = ({ body }, res) => {
 export const handleTagFront: RequestHandler = ({ body }, res) => {
 	recordTypeAndPlatform('tagFront');
 	const tagFront = enhanceTagFront(body);
-	const { html, clientScripts } = renderTagFront({
+	const { html, prefetchScripts } = renderTagFront({
 		tagFront,
 	});
-	res.status(200).set('Link', makePrefetchHeader(clientScripts)).send(html);
+	res.status(200).set('Link', makePrefetchHeader(prefetchScripts)).send(html);
 };
 
 export const handleTagFrontJson: RequestHandler = ({ body }, res) => {

--- a/dotcom-rendering/src/server/render.allEditorialNewslettersPage.web.tsx
+++ b/dotcom-rendering/src/server/render.allEditorialNewslettersPage.web.tsx
@@ -18,7 +18,7 @@ interface Props {
 
 export const renderEditorialNewslettersPage = ({
 	newslettersPage,
-}: Props): { html: string; clientScripts: string[] } => {
+}: Props): { html: string; prefetchScripts: string[] } => {
 	const title = newslettersPage.webTitle;
 	const NAV = extractNAV(newslettersPage.nav);
 
@@ -45,16 +45,23 @@ export const renderEditorialNewslettersPage = ({
 	 * Please talk to the dotcom platform team before adding more.
 	 * Scripts will be executed in the order they appear in this array
 	 */
-	const clientScripts = [
+	const prefetchScripts = [
 		polyfillIO,
 		getPathFromManifest(build, 'frameworks.js'),
 		getPathFromManifest(build, 'index.js'),
-		getPathFromManifest('web.legacy', 'frameworks.js'),
-		getPathFromManifest('web.legacy', 'index.js'),
 		process.env.COMMERCIAL_BUNDLE_URL ??
 			newslettersPage.config.commercialBundleUrl,
 	].map((script) => (offerHttp3 ? getHttp3Url(script) : script));
-	const scriptTags = generateScriptTags(clientScripts);
+
+	const legacyScripts = [
+		getPathFromManifest('web.legacy', 'frameworks.js'),
+		getPathFromManifest('web.legacy', 'index.js'),
+	].map((script) => (offerHttp3 ? getHttp3Url(script) : script));
+
+	const scriptTags = generateScriptTags([
+		...prefetchScripts,
+		...legacyScripts,
+	]);
 
 	const guardian = createGuardian({
 		editionId: newslettersPage.editionId,
@@ -88,6 +95,6 @@ export const renderEditorialNewslettersPage = ({
 	});
 	return {
 		html: pageHtml,
-		clientScripts,
+		prefetchScripts,
 	};
 };

--- a/dotcom-rendering/src/server/render.article.apps.tsx
+++ b/dotcom-rendering/src/server/render.article.apps.tsx
@@ -10,7 +10,7 @@ import { htmlPageTemplate } from './htmlPageTemplate';
 export const renderArticle = (
 	article: FEArticleType,
 ): {
-	clientScripts: string[];
+	prefetchScripts: string[];
 	html: string;
 } => {
 	const format: ArticleFormat = decideFormat(article.format);
@@ -58,7 +58,7 @@ export const renderArticle = (
 	});
 
 	return {
-		clientScripts,
+		prefetchScripts: clientScripts,
 		html: renderedPage,
 	};
 };

--- a/dotcom-rendering/src/server/render.front.web.tsx
+++ b/dotcom-rendering/src/server/render.front.web.tsx
@@ -71,7 +71,7 @@ const extractFrontNav = (front: DCRFrontType): NavType => {
 
 export const renderFront = ({
 	front,
-}: Props): { html: string; clientScripts: string[] } => {
+}: Props): { html: string; prefetchScripts: string[] } => {
 	const title = front.webTitle;
 	const NAV = extractFrontNav(front);
 
@@ -95,17 +95,23 @@ export const renderFront = ({
 	 * Please talk to the dotcom platform team before adding more.
 	 * Scripts will be executed in the order they appear in this array
 	 */
-	const clientScripts = [
+	const prefetchScripts = [
 		polyfillIO,
 		getPathFromManifest(build, 'frameworks.js'),
 		getPathFromManifest(build, 'index.js'),
-		getPathFromManifest('web.legacy', 'frameworks.js'),
-		getPathFromManifest('web.legacy', 'index.js'),
 		process.env.COMMERCIAL_BUNDLE_URL ?? front.config.commercialBundleUrl,
 	]
 		.filter(isString)
 		.map((script) => (offerHttp3 ? getHttp3Url(script) : script));
-	const scriptTags = generateScriptTags(clientScripts);
+
+	const legacyScripts = [
+		getPathFromManifest('web.legacy', 'frameworks.js'),
+		getPathFromManifest('web.legacy', 'index.js'),
+	].map((script) => (offerHttp3 ? getHttp3Url(script) : script));
+	const scriptTags = generateScriptTags([
+		...prefetchScripts,
+		...legacyScripts,
+	]);
 
 	const guardian = createGuardian({
 		editionId: front.editionId,
@@ -146,7 +152,7 @@ export const renderFront = ({
 
 	return {
 		html: pageHtml,
-		clientScripts,
+		prefetchScripts,
 	};
 };
 
@@ -154,7 +160,7 @@ export const renderTagFront = ({
 	tagFront,
 }: {
 	tagFront: DCRTagFrontType;
-}): { html: string; clientScripts: string[] } => {
+}): { html: string; prefetchScripts: string[] } => {
 	const title = tagFront.webTitle;
 	const NAV = extractNAV(tagFront.nav);
 
@@ -178,18 +184,24 @@ export const renderTagFront = ({
 	 * Please talk to the dotcom platform team before adding more.
 	 * Scripts will be executed in the order they appear in this array
 	 */
-	const clientScripts = [
+	const prefetchScripts = [
 		polyfillIO,
 		getPathFromManifest(build, 'frameworks.js'),
 		getPathFromManifest(build, 'index.js'),
-		getPathFromManifest('web.legacy', 'frameworks.js'),
-		getPathFromManifest('web.legacy', 'index.js'),
 		process.env.COMMERCIAL_BUNDLE_URL ??
 			tagFront.config.commercialBundleUrl,
 	]
 		.filter(isString)
 		.map((script) => (offerHttp3 ? getHttp3Url(script) : script));
-	const scriptTags = generateScriptTags(clientScripts);
+
+	const legacyScripts = [
+		getPathFromManifest('web.legacy', 'frameworks.js'),
+		getPathFromManifest('web.legacy', 'index.js'),
+	].map((script) => (offerHttp3 ? getHttp3Url(script) : script));
+	const scriptTags = generateScriptTags([
+		...prefetchScripts,
+		...legacyScripts,
+	]);
 
 	const guardian = createGuardian({
 		editionId: tagFront.editionId,
@@ -228,6 +240,6 @@ export const renderTagFront = ({
 	});
 	return {
 		html: pageHtml,
-		clientScripts,
+		prefetchScripts,
 	};
 };


### PR DESCRIPTION
PR #8657 introduced script prefetching, but it instructs browsers to prefetch legacy bundles. This is unnecessary and has introduced 80kb to article JS size.

This change stops prefetching legacy bundles.