### PR TITLE
Fix "Supported By" container badge

### DIFF
--- a/dotcom-rendering/src/components/FrontSection.tsx
+++ b/dotcom-rendering/src/components/FrontSection.tsx
@@ -96,7 +96,7 @@ type Props = {
 	hasPageSkin?: boolean;
 	discussionApiUrl: string;
 
-	editionBranding?: DCRFrontType['pressedPage']['frontProperties']['commercial']['editionBrandings'][number];
+	frontEditionBranding?: DCRFrontType['pressedPage']['frontProperties']['commercial']['editionBrandings'][number];
 };
 
 const width = (columns: number, columnWidth: number, columnGap: number) =>
@@ -496,7 +496,7 @@ export const FrontSection = ({
 	index,
 	targetedTerritory,
 	hasPageSkin = false,
-	editionBranding,
+	frontEditionBranding,
 	discussionApiUrl,
 }: Props) => {
 	const overrides =
@@ -628,29 +628,29 @@ export const FrontSection = ({
 								editionId={editionId}
 							/>
 							{!isOnPaidContentFront &&
-								!!editionBranding &&
-								editionBranding.branding &&
+								!!frontEditionBranding &&
+								frontEditionBranding.branding &&
 								index === 0 && (
 									<>
 										<p css={labelStyles}>
 											{
-												editionBranding.branding.logo
-													.label
+												frontEditionBranding.branding
+													.logo.label
 											}
 										</p>
 										<Badge
 											imageSrc={
-												editionBranding.branding.logo
-													.src
+												frontEditionBranding.branding
+													.logo.src
 											}
 											href={
-												editionBranding.branding.logo
-													.link
+												frontEditionBranding.branding
+													.logo.link
 											}
 										/>
 										<a
 											href={
-												editionBranding.branding
+												frontEditionBranding.branding
 													.aboutThisLink
 											}
 											css={aboutThisLinkStyles}

--- a/dotcom-rendering/src/components/FrontSection.tsx
+++ b/dotcom-rendering/src/components/FrontSection.tsx
@@ -16,6 +16,7 @@ import { decideContainerOverrides } from '../lib/decideContainerOverrides';
 import type { EditionId } from '../lib/edition';
 import { hideAge } from '../lib/hideAge';
 import type { DCRBadgeType } from '../types/badge';
+import type { Branding } from '../types/branding';
 import type {
 	DCRContainerPalette,
 	DCRFrontType,
@@ -31,7 +32,6 @@ import { Island } from './Island';
 import { ShowHideButton } from './ShowHideButton';
 import { ShowMore } from './ShowMore.importable';
 import { Treats } from './Treats';
-import { Branding } from '../types/branding';
 
 type Props = {
 	/** This text will be used as the h2 shown in the left column for the section */
@@ -96,10 +96,8 @@ type Props = {
 	 */
 	hasPageSkin?: boolean;
 	discussionApiUrl: string;
-
 	frontEditionBranding?: DCRFrontType['pressedPage']['frontProperties']['commercial']['editionBrandings'][number];
-
-	containerEditionBranding?: Branding;
+	containerSponsorBranding?: Branding;
 };
 
 const width = (columns: number, columnWidth: number, columnGap: number) =>
@@ -501,7 +499,7 @@ export const FrontSection = ({
 	hasPageSkin = false,
 	frontEditionBranding,
 	discussionApiUrl,
-	containerEditionBranding,
+	containerSponsorBranding,
 }: Props) => {
 	const overrides =
 		containerPalette && decideContainerOverrides(containerPalette);
@@ -601,19 +599,9 @@ export const FrontSection = ({
 					</div>
 				) : (
 					<>
-						{!isOnPaidContentFront && (
-							<Hide until="leftCol">
-								{badge && (
-									<Badge
-										imageSrc={badge.imageSrc}
-										href={badge.href}
-									/>
-								)}
-							</Hide>
-						)}
-						<div css={titleStyle}>
-							{!isOnPaidContentFront && (
-								<Hide from="leftCol">
+						{!isOnPaidContentFront &&
+							containerSponsorBranding === undefined && (
+								<Hide until="leftCol">
 									{badge && (
 										<Badge
 											imageSrc={badge.imageSrc}
@@ -622,6 +610,18 @@ export const FrontSection = ({
 									)}
 								</Hide>
 							)}
+						<div css={titleStyle}>
+							{!isOnPaidContentFront &&
+								containerSponsorBranding === undefined && (
+									<Hide from="leftCol">
+										{badge && (
+											<Badge
+												imageSrc={badge.imageSrc}
+												href={badge.href}
+											/>
+										)}
+									</Hide>
+								)}
 							<ContainerTitle
 								title={title}
 								fontColour={overrides?.text.container}
@@ -663,6 +663,30 @@ export const FrontSection = ({
 										</a>
 									</>
 								)}
+
+							{containerSponsorBranding && (
+								<>
+									<p css={labelStyles}>
+										{containerSponsorBranding.logo.label}
+									</p>
+									<Badge
+										imageSrc={
+											containerSponsorBranding.logo.src
+										}
+										href={
+											containerSponsorBranding.logo.link
+										}
+									/>
+									<a
+										href={
+											containerSponsorBranding.aboutThisLink
+										}
+										css={aboutThisLinkStyles}
+									>
+										About this content
+									</a>
+								</>
+							)}
 						</div>
 					</>
 				)}

--- a/dotcom-rendering/src/components/FrontSection.tsx
+++ b/dotcom-rendering/src/components/FrontSection.tsx
@@ -31,6 +31,7 @@ import { Island } from './Island';
 import { ShowHideButton } from './ShowHideButton';
 import { ShowMore } from './ShowMore.importable';
 import { Treats } from './Treats';
+import { Branding } from '../types/branding';
 
 type Props = {
 	/** This text will be used as the h2 shown in the left column for the section */
@@ -97,6 +98,8 @@ type Props = {
 	discussionApiUrl: string;
 
 	frontEditionBranding?: DCRFrontType['pressedPage']['frontProperties']['commercial']['editionBrandings'][number];
+
+	containerEditionBranding?: Branding;
 };
 
 const width = (columns: number, columnWidth: number, columnGap: number) =>
@@ -498,6 +501,7 @@ export const FrontSection = ({
 	hasPageSkin = false,
 	frontEditionBranding,
 	discussionApiUrl,
+	containerEditionBranding,
 }: Props) => {
 	const overrides =
 		containerPalette && decideContainerOverrides(containerPalette);

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -444,7 +444,30 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 
 					const isFirstContainer = index === 0;
 
-					const containerEditionBranding = undefined;
+					const deduplicatedCards = [
+						...collection.curated,
+						...collection.backfill,
+					].filter(
+						(card, cardIndex, allCards) =>
+							cardIndex ===
+							allCards.findIndex((c) => c.url === card.url),
+					);
+
+					const cardsEditionBrandings = deduplicatedCards.map(
+						(card) => card.branding,
+					);
+
+					const containerSponsorBranding =
+						cardsEditionBrandings.every(
+							(branding) =>
+								branding !== undefined &&
+								branding.brandingType?.name === 'sponsored' &&
+								cardsEditionBrandings[0] &&
+								branding.sponsorName ===
+									cardsEditionBrandings[0]?.sponsorName,
+						)
+							? cardsEditionBrandings[0]
+							: undefined;
 
 					if (collection.collectionType === 'fixed/thrasher') {
 						return (
@@ -765,8 +788,8 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 								hasPageSkin={hasPageSkin}
 								frontEditionBranding={frontEditionBranding}
 								discussionApiUrl={front.config.discussionApiUrl}
-								containerEditionBranding={
-									containerEditionBranding
+								containerSponsorBranding={
+									containerSponsorBranding
 								}
 							>
 								<DecideContainer

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -444,6 +444,8 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 
 					const isFirstContainer = index === 0;
 
+					const containerEditionBranding = undefined;
+
 					if (collection.collectionType === 'fixed/thrasher') {
 						return (
 							<Fragment key={ophanName}>
@@ -763,6 +765,9 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 								hasPageSkin={hasPageSkin}
 								frontEditionBranding={frontEditionBranding}
 								discussionApiUrl={front.config.discussionApiUrl}
+								containerEditionBranding={
+									containerEditionBranding
+								}
 							>
 								<DecideContainer
 									trails={trailsWithoutBranding}

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -435,7 +435,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 						  })
 						: trails;
 
-					const editionBranding =
+					const frontEditionBranding =
 						front.pressedPage.frontProperties.commercial.editionBrandings.find(
 							(eB) =>
 								eB.edition.id === front.editionId &&
@@ -761,7 +761,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 								index={index}
 								targetedTerritory={collection.targetedTerritory}
 								hasPageSkin={hasPageSkin}
-								editionBranding={editionBranding}
+								frontEditionBranding={frontEditionBranding}
 								discussionApiUrl={front.config.discussionApiUrl}
 							>
 								<DecideContainer

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -444,31 +444,6 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 
 					const isFirstContainer = index === 0;
 
-					const deduplicatedCards = [
-						...collection.curated,
-						...collection.backfill,
-					].filter(
-						(card, cardIndex, allCards) =>
-							cardIndex ===
-							allCards.findIndex((c) => c.url === card.url),
-					);
-
-					const cardsEditionBrandings = deduplicatedCards.map(
-						(card) => card.branding,
-					);
-
-					const containerSponsorBranding =
-						cardsEditionBrandings.every(
-							(branding) =>
-								branding !== undefined &&
-								branding.brandingType?.name === 'sponsored' &&
-								cardsEditionBrandings[0] &&
-								branding.sponsorName ===
-									cardsEditionBrandings[0]?.sponsorName,
-						)
-							? cardsEditionBrandings[0]
-							: undefined;
-
 					if (collection.collectionType === 'fixed/thrasher') {
 						return (
 							<Fragment key={ophanName}>
@@ -789,7 +764,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 								frontEditionBranding={frontEditionBranding}
 								discussionApiUrl={front.config.discussionApiUrl}
 								containerSponsorBranding={
-									containerSponsorBranding
+									collection.collectionBranding
 								}
 							>
 								<DecideContainer

--- a/dotcom-rendering/src/model/enhanceCollections.ts
+++ b/dotcom-rendering/src/model/enhanceCollections.ts
@@ -96,9 +96,7 @@ export const enhanceCollections = ({
 			badge: decideBadge(
 				collection.config.href,
 				// We only try to use a branded badge for paid content
-				isCollectionPaidContent && allCardsHaveBranding
-					? allBranding
-					: undefined,
+				allCardsHaveBranding ? allBranding : undefined,
 			),
 			grouped: groupCards(
 				collectionType,

--- a/dotcom-rendering/src/model/enhanceCollections.ts
+++ b/dotcom-rendering/src/model/enhanceCollections.ts
@@ -75,7 +75,12 @@ export const enhanceCollections = ({
 			 * We do this because Frontend had logic to ignore the "Branded" palette tag in the Fronts tool
 			 * when rendering a paid front or when non-paid content is curated inside a "Branded" container
 			 */
-			{ canBeBranded: !isPaidContent && allCardsHaveBranding },
+			{
+				canBeBranded:
+					!isPaidContent &&
+					allCardsHaveBranding &&
+					isCollectionPaidContent,
+			},
 		);
 
 		return {

--- a/dotcom-rendering/src/model/enhanceCollections.ts
+++ b/dotcom-rendering/src/model/enhanceCollections.ts
@@ -96,7 +96,9 @@ export const enhanceCollections = ({
 			badge: decideBadge(
 				collection.config.href,
 				// We only try to use a branded badge for paid content
-				allCardsHaveBranding ? allBranding : undefined,
+				isCollectionPaidContent && allCardsHaveBranding
+					? allBranding
+					: undefined,
 			),
 			grouped: groupCards(
 				collectionType,

--- a/dotcom-rendering/src/model/enhanceCollections.ts
+++ b/dotcom-rendering/src/model/enhanceCollections.ts
@@ -69,6 +69,14 @@ export const enhanceCollections = ({
 			({ brandingType }) => brandingType?.name === 'paid-content',
 		);
 
+		const sponsorBranding = allBranding.every(
+			(branding) =>
+				branding.brandingType?.name === 'sponsored' &&
+				branding.sponsorName === allBranding[0]?.sponsorName,
+		)
+			? allBranding[0]
+			: undefined;
+
 		const containerPalette = decideContainerPalette(
 			collection.config.metadata?.map((meta) => meta.type),
 			/**
@@ -131,6 +139,7 @@ export const enhanceCollections = ({
 			},
 			canShowMore: hasMore && !collection.config.hideShowMore,
 			targetedTerritory: collection.targetedTerritory,
+			collectionBranding: sponsorBranding,
 		};
 	});
 };

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -402,6 +402,8 @@ export type DCRCollectionType = {
 	canShowMore?: boolean;
 	badge?: DCRBadgeType;
 	targetedTerritory?: Territory;
+
+	collectionBranding?: Branding;
 };
 
 export type DCRGroupedTrails = {


### PR DESCRIPTION
Fixes #8089 

<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## Background

Inspired by [this document](https://docs.google.com/document/d/1yPCmjz33SahtVrzT-7E8Iau6hoo46YFUgLDBJJSJwJw/edit) which explains the different types of badges we can see on the website, I have created this diagram only for the fronts badges. This PR is fixing an issue with sponsored badges which label [editorially independent content](https://www.theguardian.com/info/2016/jan/25/content-funding) but thought it's worth having a diagram as we might want to [refactor the badges](https://github.com/guardian/dotcom-rendering/milestone/153) code in the future. 

```mermaid
flowchart TD
    A(Fronts badges) --> |e.g. This is Europe. Front or container specific.| A1
    A(Fronts badges)--> |Badges coming from Edition Branding. Front or container specific.| A2
    A1(Content / Design Badges)
    A2(Commercial badges)

    A2-->B1
    A2-->B2
    B1(Fronts branding)
    B2(Container branding)

    B1 --> C1
    B2-->C1
    B2-->C2
    C1(Branding)
    C2(MultiPaidBranding)

    C1 --> D1
    C1 --> D2
    C1 --> D3
    D1(Paid Content)
    D2(Sponsored)
    D3(Foundation)

```

## What does this change?
* Renames `editionBranding` to `frontEditionBranding` in `FrontSection` props to be able to separate it from specific to the container branding. For now we're only passing container sponsor branding in order to fix the ticket bug but we could refactor in the future to cover the rest of `Branding` types.
* Introduces `collectionBranding` of type `Branding` in `DCRCollectionType`. This is a first step to [separate the badge from branding logic](https://github.com/guardian/dotcom-rendering/issues/8435) 
* Adds one more condition to show a Labs container: all cards should be of type "paid content" 

## Why?
We need to be able to label our [content with funding from outside parties](https://www.theguardian.com/info/2016/jan/25/content-funding) correctly  

## Future work
* This PR tries to make it easier to pick up [the badges related work](https://github.com/guardian/dotcom-rendering/milestone/153) that's left. 
* This PR also unblocks https://github.com/guardian/dotcom-rendering/issues/7989 but does not fix it yet. There are some tweaks left to do as part of that ticket.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/a917240e-a2bc-4033-9b61-1e3cb667f7de) | ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/138ab8c5-823c-4187-8443-03289daccf1b) |
| ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/a917240e-a2bc-4033-9b61-1e3cb667f7de) | ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/138ab8c5-823c-4187-8443-03289daccf1b) |

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
