### PR TITLE
Organise Webpack bundles in distinct folders in `dist`

### DIFF
--- a/dotcom-rendering/makefile
+++ b/dotcom-rendering/makefile
@@ -46,12 +46,12 @@ build-ci: clean-dist install
 
 start-ci: install
 	$(call log, "starting PROD server...")
-	@NODE_ENV=production DISABLE_LOGGING_AND_METRICS=true node dist/server.js
+	@NODE_ENV=production DISABLE_LOGGING_AND_METRICS=true node dist/server/server.js
 
 start: install
 	$(call log, "starting PROD server...")
 	@echo '' # just a spacer
-	NODE_ENV=production pm2 start dist/server.js
+	NODE_ENV=production pm2 start dist/server/server.js
 	@echo '' # just a spacer
 	$(call log, "PROD server is running")
 	@NODE_ENV=production pm2 logs
@@ -62,7 +62,7 @@ start: install
 start-prod:
 	$(call log, "starting PROD server...")
 	@echo '' # just a spacer
-	NODE_ENV=production /usr/local/node/pm2 start dist/server.js
+	NODE_ENV=production /usr/local/node/pm2 start dist/server/server.js
 	@echo '' # just a spacer
 	$(call log, "PROD server is running")
 
@@ -109,11 +109,11 @@ storybook-dev: clear clean-dist install
 
 cypress: clear clean-dist install build
 	$(call log, "starting PROD server for Cypress")
-	@NODE_ENV=production NODE_OPTIONS="--max-old-space-size=8192" DISABLE_LOGGING_AND_METRICS=true start-server-and-test 'node dist/server.js' 9000 'cypress run --spec "cypress/e2e/**/*"'
+	@NODE_ENV=production NODE_OPTIONS="--max-old-space-size=8192" DISABLE_LOGGING_AND_METRICS=true start-server-and-test 'node dist/server/server.js' 9000 'cypress run --spec "cypress/e2e/**/*"'
 
 cypress-open: clear clean-dist install build
 	$(call log, "starting PROD server and opening Cypress")
-	@NODE_ENV=production DISABLE_LOGGING_AND_METRICS=true start-server-and-test 'node dist/server.js' 9000 'cypress open --e2e --browser electron'
+	@NODE_ENV=production DISABLE_LOGGING_AND_METRICS=true start-server-and-test 'node dist/server/server.js' 9000 'cypress open --e2e --browser electron'
 
 ampValidation: clean-dist install
 	$(call log, "starting AMP Validation test")

--- a/dotcom-rendering/scripts/test/build-check.js
+++ b/dotcom-rendering/scripts/test/build-check.js
@@ -27,19 +27,21 @@ const fileExists = async (glob) => {
 
 (async () => {
 	// Check that the manifest files exist
-	await fileExists('manifest.web.json');
-	await fileExists('manifest.web.scheduled.json');
-	await fileExists('manifest.web.legacy.json');
-	if (BUILD_VARIANT) await fileExists('manifest.web.variant.json');
+	await fileExists('client.web/manifest.json');
+	await fileExists('client.web.scheduled/manifest.json');
+	await fileExists('client.web.legacy/manifest.json');
+	if (BUILD_VARIANT) await fileExists('client.web.variant/manifest.json');
 
 	// Check that the manifest files return values for all the chunks
 	const manifests = [
-		await loadJsonFile('./dist/manifest.web.json'),
-		await loadJsonFile('./dist/manifest.web.scheduled.json'),
-		await loadJsonFile('./dist/manifest.web.legacy.json'),
+		await loadJsonFile('./dist/client.web/manifest.json'),
+		await loadJsonFile('./dist/client.web.scheduled/manifest.json'),
+		await loadJsonFile('./dist/client.web.legacy/manifest.json'),
 	];
 	if (BUILD_VARIANT) {
-		manifests.push(await loadJsonFile('./dist/manifest.web.variant.json'));
+		manifests.push(
+			await loadJsonFile('./dist/client.web.variant/manifest.json'),
+		);
 	}
 
 	for (const name of [

--- a/dotcom-rendering/scripts/webpack/webpack.config.client.js
+++ b/dotcom-rendering/scripts/webpack/webpack.config.client.js
@@ -24,15 +24,6 @@ const swcLoader = (targets) => [
  * @param {Build} build
  * @returns {string}
  */
-const generateName = (build) => {
-	const chunkhashString = DEV ? '' : '.[chunkhash]';
-	return `[name].${build}${chunkhashString}.js`;
-};
-
-/**
- * @param {Build} build
- * @returns {string}
- */
 const getLoaders = (build) => {
 	switch (build) {
 		case 'web.legacy':
@@ -117,16 +108,15 @@ module.exports = ({ build, sessionId }) => ({
 	output: {
 		filename: (data) => {
 			// We don't want to hash the debug script so it can be used in bookmarklets
-			if (data.chunk.name === 'debug') return `[name].js`;
-			return generateName(build);
+			return data.chunk.name === 'debug' || DEV
+				? `[name].js`
+				: `[name].[chunkhash].js`;
 		},
-		chunkFilename: generateName(build),
+		chunkFilename: DEV ? `[name].js` : `[name].[chunkhash].js`,
 		publicPath: '',
 	},
 	plugins: [
-		new WebpackManifestPlugin({
-			fileName: `manifest.${build}.json`,
-		}),
+		new WebpackManifestPlugin(),
 		...(build === 'apps'
 			? [
 					new webpack.optimize.LimitChunkCountPlugin({

--- a/dotcom-rendering/scripts/webpack/webpack.config.dev-server.js
+++ b/dotcom-rendering/scripts/webpack/webpack.config.dev-server.js
@@ -26,10 +26,16 @@ module.exports = {
 			overlay: true,
 		},
 		port,
-		static: {
-			directory: path.join(__dirname, '..', '..', 'src', 'static'),
-			publicPath: '/static/frontend',
-		},
+		static: [
+			{
+				directory: path.join(__dirname, '..', '..', 'dist'),
+				publicPath: '/assets',
+			},
+			{
+				directory: path.join(__dirname, '..', '..', 'src', 'static'),
+				publicPath: '/static/frontend',
+			},
+		],
 		allowedHosts: ['r.thegulocal.com'],
 		devMiddleware: {
 			publicPath: '/assets/',
@@ -45,6 +51,7 @@ module.exports = {
 						req.headers.origin,
 					);
 			},
+			writeToDisk: true,
 		},
 		setupMiddlewares: (middlewares, devServer) => {
 			if (!devServer.app) {

--- a/dotcom-rendering/scripts/webpack/webpack.config.js
+++ b/dotcom-rendering/scripts/webpack/webpack.config.js
@@ -27,7 +27,7 @@ const commonConfigs = ({ platform }) => ({
 	name: platform,
 	mode: DEV ? 'development' : 'production',
 	output: {
-		path: dist,
+		path: path.resolve(dist, platform),
 	},
 	stats: DEV ? 'errors-only' : 'normal',
 	devtool:

--- a/dotcom-rendering/scripts/webpack/webpack.config.server.js
+++ b/dotcom-rendering/scripts/webpack/webpack.config.server.js
@@ -69,12 +69,6 @@ module.exports = ({ sessionId }) => ({
 				? callback(undefined, `commonjs ${request}`)
 				: callback();
 		},
-		// @ts-expect-error - webpack-node-externals types are incorrect
-		({ request }, callback) => {
-			return request?.endsWith('manifest.legacy.json')
-				? callback(undefined, `commonjs ${request}`)
-				: callback();
-		},
 	],
 	module: {
 		rules: [

--- a/dotcom-rendering/src/lib/assets.test.ts
+++ b/dotcom-rendering/src/lib/assets.test.ts
@@ -49,34 +49,34 @@ describe('decideAssetOrigin for stage', () => {
 
 describe('regular expression to match files', () => {
 	it('should handle CI environment', () => {
-		expect('/assets/ophan.web.eb74205c979f58659ed7.js').toMatch(WEB);
+		expect('/assets/web/ophan.eb74205c979f58659ed7.js').toMatch(WEB);
 	});
 
 	it('should handle DEV environment', () => {
-		expect('/assets/ophan.web.variant.js').toMatch(WEB_VARIANT_SCRIPT);
+		expect('/assets/web.variant/ophan.js').toMatch(WEB_VARIANT_SCRIPT);
 	});
 
 	it('should handle PROD environment', () => {
 		expect(
-			'https://assets.guim.co.uk/assets/ophan.web.abcdefghijklmnopqrst.js',
+			'https://assets.guim.co.uk/assets/web/ophan.abcdefghijklmnopqrst.js',
 		).toMatch(WEB);
 		expect(
-			'https://assets.guim.co.uk/assets/ophan.web.variant.abcdefghijklmnopqrst.js',
+			'https://assets.guim.co.uk/assets/web.variant/ophan.abcdefghijklmnopqrst.js',
 		).toMatch(WEB_VARIANT_SCRIPT);
 		expect(
-			'https://assets.guim.co.uk/assets/ophan.web.scheduled.abcdefghijklmnopqrst.js',
+			'https://assets.guim.co.uk/assets/web.scheduled/ophan.abcdefghijklmnopqrst.js',
 		).toMatch(WEB_SCHEDULED_SCRIPT);
 		expect(
-			'https://assets.guim.co.uk/assets/ophan.web.legacy.eb74205c979f58659ed7.js',
+			'https://assets.guim.co.uk/assets/web.legacy/ophan.eb74205c979f58659ed7.js',
 		).toMatch(WEB_LEGACY_SCRIPT);
 		expect(
-			'https://assets.guim.co.uk/assets/ophan.apps.eb74205c979f58659ed7.js',
+			'https://assets.guim.co.uk/assets/apps/ophan.eb74205c979f58659ed7.js',
 		).toMatch(APPS_SCRIPT);
 	});
 
 	it('should handle http3 query param', () => {
 		expect(
-			'https://assets.guim.co.uk/assets/ophan.web.eb74205c979f58659ed7.js?http3=true',
+			'https://assets.guim.co.uk/assets/web/ophan.eb74205c979f58659ed7.js?http3=true',
 		).toMatch(WEB);
 	});
 });

--- a/dotcom-rendering/src/lib/assets.ts
+++ b/dotcom-rendering/src/lib/assets.ts
@@ -72,10 +72,10 @@ export type Build =
 	| 'web.scheduled'
 	| 'web.legacy';
 
-type ManifestPath = `./manifest.${Build}.json`;
+type ManifestPath = `./${Build}/manifest.json`;
 
 const getManifestPath = (build: Build): ManifestPath =>
-	`./manifest.${build}.json`;
+	`./${build}/manifest.json`;
 
 export const getPathFromManifest = (
 	build: Build,
@@ -109,7 +109,7 @@ export const getPathFromManifest = (
  * and stripped query parameters.
  */
 const getScriptRegex = (build: Build) =>
-	new RegExp(`assets\\/\\w+\\.${build}\\.(\\w{20}\\.)?js(\\?.*)?$`);
+	new RegExp(`assets\\/${build}\\/\\w+\\.(\\w{20}\\.)?js(\\?.*)?$`);
 
 export const WEB = getScriptRegex('web');
 export const WEB_VARIANT_SCRIPT = getScriptRegex('web.variant');

--- a/dotcom-rendering/src/server/buildLegacy.ts
+++ b/dotcom-rendering/src/server/buildLegacy.ts
@@ -1,0 +1,3 @@
+export const BUILD_LEGACY =
+	process.env.NODE_ENV === 'production' ||
+	process.env.BUILD_LEGACY === 'true';

--- a/dotcom-rendering/src/server/dev-server.ts
+++ b/dotcom-rendering/src/server/dev-server.ts
@@ -22,8 +22,8 @@ const ARTICLE_URL = /\/\d{4}\/[a-z]{3}\/\d{2}\//;
 const FRONT_URL = /^\/[a-z-/]+/;
 /** This is imperfect, but covers *some* cases of tag fronts, consider expanding in the future */
 const TAG_FRONT_URL = /^\/(tone|series|profile)\/[a-z-]+/;
-/** assets are paths like /assets/index.xxx.js */
-const ASSETS_URL = /^assets\/.+\.js/;
+/** assets are paths like /assets/client.web/index.xxx.js */
+const ASSETS_URL = /^\/assets\/client\./;
 
 // see https://www.npmjs.com/package/webpack-hot-server-middleware
 // for more info

--- a/dotcom-rendering/src/server/render.allEditorialNewslettersPage.web.tsx
+++ b/dotcom-rendering/src/server/render.allEditorialNewslettersPage.web.tsx
@@ -1,3 +1,4 @@
+import { isString } from '@guardian/libs';
 import { AllEditorialNewslettersPage } from '../components/AllEditorialNewslettersPage';
 import {
 	generateScriptTags,
@@ -10,6 +11,7 @@ import { polyfillIO } from '../lib/polyfill.io';
 import { extractNAV } from '../model/extract-nav';
 import { createGuardian } from '../model/guardian';
 import type { DCRNewslettersPageType } from '../types/newslettersPage';
+import { BUILD_LEGACY } from './buildLegacy';
 import { htmlPageTemplate } from './htmlPageTemplate';
 
 interface Props {
@@ -49,11 +51,13 @@ export const renderEditorialNewslettersPage = ({
 		polyfillIO,
 		getPathFromManifest(build, 'frameworks.js'),
 		getPathFromManifest(build, 'index.js'),
-		getPathFromManifest('web.legacy', 'frameworks.js'),
-		getPathFromManifest('web.legacy', 'index.js'),
+		BUILD_LEGACY && getPathFromManifest('web.legacy', 'frameworks.js'),
+		BUILD_LEGACY && getPathFromManifest('web.legacy', 'index.js'),
 		process.env.COMMERCIAL_BUNDLE_URL ??
 			newslettersPage.config.commercialBundleUrl,
-	].map((script) => (offerHttp3 ? getHttp3Url(script) : script));
+	]
+		.filter(isString)
+		.map((script) => (offerHttp3 ? getHttp3Url(script) : script));
 	const scriptTags = generateScriptTags(clientScripts);
 
 	const guardian = createGuardian({

--- a/dotcom-rendering/src/server/render.article.web.tsx
+++ b/dotcom-rendering/src/server/render.article.web.tsx
@@ -21,6 +21,7 @@ import { createGuardian as createWindowGuardian } from '../model/guardian';
 import type { FEElement } from '../types/content';
 import type { FEArticleType, FEBlocksRequest } from '../types/frontend';
 import type { TagType } from '../types/tag';
+import { BUILD_LEGACY } from './buildLegacy';
 import { htmlPageTemplate } from './htmlPageTemplate';
 
 interface Props {
@@ -96,8 +97,8 @@ export const renderHtml = ({
 		polyfillIO,
 		getPathFromManifest(build, 'frameworks.js'),
 		getPathFromManifest(build, 'index.js'),
-		getPathFromManifest('web.legacy', 'frameworks.js'),
-		getPathFromManifest('web.legacy', 'index.js'),
+		BUILD_LEGACY && getPathFromManifest('web.legacy', 'frameworks.js'),
+		BUILD_LEGACY && getPathFromManifest('web.legacy', 'index.js'),
 		process.env.COMMERCIAL_BUNDLE_URL ?? article.config.commercialBundleUrl,
 		pageHasNonBootInteractiveElements &&
 			`${ASSET_ORIGIN}static/frontend/js/curl-with-js-and-domReady.js`,

--- a/dotcom-rendering/src/server/render.front.web.tsx
+++ b/dotcom-rendering/src/server/render.front.web.tsx
@@ -17,6 +17,10 @@ import type { DCRFrontType } from '../types/front';
 import type { DCRTagFrontType } from '../types/tagFront';
 import { htmlPageTemplate } from './htmlPageTemplate';
 
+const BUILD_LEGACY =
+	process.env.NODE_ENV === 'production' ||
+	process.env.BUILD_LEGACY === 'true';
+
 interface Props {
 	front: DCRFrontType;
 }
@@ -99,8 +103,8 @@ export const renderFront = ({
 		polyfillIO,
 		getPathFromManifest(build, 'frameworks.js'),
 		getPathFromManifest(build, 'index.js'),
-		getPathFromManifest('web.legacy', 'frameworks.js'),
-		getPathFromManifest('web.legacy', 'index.js'),
+		BUILD_LEGACY && getPathFromManifest('web.legacy', 'frameworks.js'),
+		BUILD_LEGACY && getPathFromManifest('web.legacy', 'index.js'),
 		process.env.COMMERCIAL_BUNDLE_URL ?? front.config.commercialBundleUrl,
 	]
 		.filter(isString)
@@ -182,8 +186,8 @@ export const renderTagFront = ({
 		polyfillIO,
 		getPathFromManifest(build, 'frameworks.js'),
 		getPathFromManifest(build, 'index.js'),
-		getPathFromManifest('web.legacy', 'frameworks.js'),
-		getPathFromManifest('web.legacy', 'index.js'),
+		BUILD_LEGACY && getPathFromManifest('web.legacy', 'frameworks.js'),
+		BUILD_LEGACY && getPathFromManifest('web.legacy', 'index.js'),
 		process.env.COMMERCIAL_BUNDLE_URL ??
 			tagFront.config.commercialBundleUrl,
 	]


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Organises `dist` folder with one folder per bundle. It now follows this pattern: `dist/client.*/index.*.js`

## Why?

Suggested by @arelra
Part of our work to simplify Webpack configuration