### PR TITLE
Target us and au versions of selected section fronts

### DIFF
--- a/dotcom-rendering/src/lib/frontsBannerAbTestAdPositions.ts
+++ b/dotcom-rendering/src/lib/frontsBannerAbTestAdPositions.ts
@@ -58,6 +58,15 @@ export const sectionFrontsBannerAdCollections: FrontsBannerAdCollections = {
 		'Video',
 		'Other sports',
 	],
+	'us/sport': [
+		// multiline array
+		'Around the world',
+		'Video',
+	],
+	'au/sport': [
+		'Woman’s World Cup 2023', // Apostrophe is intentionally U+2019 "’" instead of the more common ASCII character U+0060 "`",
+		'Pictures & video',
+	],
 	football: [
 		// multiline array
 		'In depth',
@@ -69,11 +78,35 @@ export const sectionFrontsBannerAdCollections: FrontsBannerAdCollections = {
 		'News',
 		'You may have missed',
 	],
+	'us/culture': [
+		// multiline array
+		'Talking points',
+		'The big picture',
+		'Pictures & video',
+	],
+	'au/culture': [
+		// multiline array
+		'Australia this month',
+		'Reviews',
+		'News',
+	],
 	'uk/lifeandstyle': [
 		// multiline array
 		'Fashion',
 		'Health & wellbeing',
 		'Money',
+		'The big picture',
+	],
+	'us/lifeandstyle': [
+		'Fashion',
+		'Food & drink',
+		'Regulars',
+		'The big picture',
+	],
+	'au/lifeandstyle': [
+		// multiline array
+		'Relationships',
+		'Health & fitness',
 		'The big picture',
 	],
 	'uk/commentisfree': [
@@ -83,6 +116,15 @@ export const sectionFrontsBannerAdCollections: FrontsBannerAdCollections = {
 		'You may have missed',
 		'Cartoons',
 		'Letters',
+	],
+	'us/commentisfree': [
+		// multiline array
+		'The Guardian view',
+	],
+	'au/commentisfree': [
+		// multiline array
+		'Columnists',
+		'Indigenous Australia',
 	],
 	'uk-news': [
 		// multiline array
@@ -108,6 +150,17 @@ export const sectionFrontsBannerAdCollections: FrontsBannerAdCollections = {
 		'Opinion & analysis',
 		'Multimedia',
 	],
+	'us/business': [
+		// multiline array
+		'In depth',
+		'Featured Topics',
+	],
+	'au/business': [
+		// multiline array
+		'Greg Jericho',
+		'World news',
+	],
+
 	'australia-news': [
 		// multiline array
 		'Australian politics',


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Target us and au versions of selected section fronts

## Why?
We want to get data from all regions not just uk/international


<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
