### PR TITLE
Revert "use ab test switch for deeply read"

### DIFF
--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -260,7 +260,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 		!isInSectionFrontsBannerTest;
 
 	const showMostPopular =
-		front.config.switches.deeplyRead &&
+		front.config.switches.deeplyReadSwitch &&
 		front.isNetworkFront &&
 		front.deeplyRead &&
 		front.deeplyRead.length > 0;


### PR DESCRIPTION
Reverts guardian/dotcom-rendering#8439

D&I would like us to turn off the Deeply read test, so Anthony can run the analysis tomorrow.