### PR TITLE
`CardCommentCount` can run on the server

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -346,7 +346,7 @@ export const Card = ({
 								min-height: 10px;
 							`}
 						>
-							<Island clientOnly={true} deferUntil="visible">
+							<Island deferUntil="visible">
 								<CardCommentCount
 									format={format}
 									discussionApiUrl={discussionApiUrl}


### PR DESCRIPTION
## What?

Reverts guardian/dotcom-rendering#8730

## Why?

It wasn’t the problem! And this creates three different state:

| SSR | Hydration | Fetched Count |
|--------|--------|--------|
| ![ssr](https://github.com/guardian/dotcom-rendering/assets/76776/792cb56e-5a58-480d-981e-67e773b00db8) | ![hydrated](https://github.com/guardian/dotcom-rendering/assets/76776/1e0f28cb-85ef-445e-947a-83983d69edc0) | ![counted](https://github.com/guardian/dotcom-rendering/assets/76776/e5991de8-4615-4421-a425-66e5e3a420d0) | 

