### PR TITLE
Restyle mostpop ad slots and containers

### DIFF
--- a/dotcom-rendering/src/components/AdSlot.tsx
+++ b/dotcom-rendering/src/components/AdSlot.tsx
@@ -274,8 +274,8 @@ const articleEndAdStyles = css`
 const mostPopAdStyles = css`
 	position: relative;
 	min-height: ${adSizes.mpu.height + labelHeight}px;
-	min-width: 300px;
-	max-width: 300px;
+	min-width: ${adSizes.mpu.width};
+	max-width: ${adSizes.mpu.width};
 	margin: 12px auto;
 	text-align: center;
 	${from.tablet} {
@@ -283,7 +283,7 @@ const mostPopAdStyles = css`
 	}
 	${from.desktop} {
 		width: auto;
-		max-width: 300px;
+		max-width: ${adSizes.mpu.width};
 	}
 	${from.wide} {
 		margin-top: 25px;
@@ -292,15 +292,15 @@ const mostPopAdStyles = css`
 
 const mostPopContainerStyles = css`
 	min-height: ${adSizes.mpu.height + labelHeight}px;
-	min-width: 300px;
+	min-width: ${adSizes.mpu.width};
 	width: fit-content;
-	max-width: 300px;
+	max-width: ${adSizes.mpu.width};
 	margin: 0 auto;
 	${from.tablet} {
 		max-width: 700px;
 	}
 	${from.desktop} {
-		max-width: 300px;
+		max-width: ${adSizes.mpu.width};
 	}
 `;
 

--- a/dotcom-rendering/src/components/AdSlot.tsx
+++ b/dotcom-rendering/src/components/AdSlot.tsx
@@ -274,8 +274,8 @@ const articleEndAdStyles = css`
 const mostPopAdStyles = css`
 	position: relative;
 	min-height: ${adSizes.mpu.height + labelHeight}px;
-	min-width: ${adSizes.mpu.width};
-	max-width: ${adSizes.mpu.width};
+	min-width: ${adSizes.mpu.width}px;
+	max-width: ${adSizes.mpu.width}px;
 	margin: 12px auto;
 	text-align: center;
 	${from.tablet} {
@@ -283,7 +283,7 @@ const mostPopAdStyles = css`
 	}
 	${from.desktop} {
 		width: auto;
-		max-width: ${adSizes.mpu.width};
+		max-width: ${adSizes.mpu.width}px;
 	}
 	${from.wide} {
 		margin-top: 25px;
@@ -292,15 +292,15 @@ const mostPopAdStyles = css`
 
 const mostPopContainerStyles = css`
 	min-height: ${adSizes.mpu.height + labelHeight}px;
-	min-width: ${adSizes.mpu.width};
+	min-width: ${adSizes.mpu.width}px;
 	width: fit-content;
-	max-width: ${adSizes.mpu.width};
+	max-width: ${adSizes.mpu.width}px;
 	margin: 0 auto;
 	${from.tablet} {
 		max-width: 700px;
 	}
 	${from.desktop} {
-		max-width: ${adSizes.mpu.width};
+		max-width: ${adSizes.mpu.width}px;
 	}
 `;
 

--- a/dotcom-rendering/src/components/AdSlot.tsx
+++ b/dotcom-rendering/src/components/AdSlot.tsx
@@ -366,6 +366,11 @@ const mobileStickyAdStyles = css`
 	}
 `;
 
+const nonExpandingContainerStyles = css`
+	width: max-content;
+	margin: auto;
+`;
+
 export const adContainerStyles = [adContainerCollapseStyles, labelStyles];
 
 export const AdSlot = ({
@@ -492,7 +497,10 @@ export const AdSlot = ({
 		}
 		case 'mostpop': {
 			return (
-				<div className="ad-slot-container" css={[adContainerStyles]}>
+				<div
+					className="ad-slot-container"
+					css={[adContainerStyles, nonExpandingContainerStyles]}
+				>
 					<div
 						id="dfp-ad--mostpop"
 						className={[
@@ -622,7 +630,10 @@ export const AdSlot = ({
 		case 'inline': {
 			const advertId = `inline${index + 1}`;
 			return (
-				<div className="ad-slot-container" css={[adContainerStyles]}>
+				<div
+					className="ad-slot-container"
+					css={[adContainerStyles, nonExpandingContainerStyles]}
+				>
 					<div
 						id={`dfp-ad--${advertId}`}
 						className={[
@@ -664,7 +675,10 @@ export const AdSlot = ({
 		case 'mobile-front': {
 			const advertId = index === 0 ? 'top-above-nav' : `inline${index}`;
 			return (
-				<div className="ad-slot-container" css={[adContainerStyles]}>
+				<div
+					className="ad-slot-container"
+					css={[adContainerStyles, nonExpandingContainerStyles]}
+				>
 					<div
 						id={`dfp-ad--${advertId}--mobile`}
 						className={[

--- a/dotcom-rendering/src/components/AdSlot.tsx
+++ b/dotcom-rendering/src/components/AdSlot.tsx
@@ -279,7 +279,6 @@ const mostPopAdStyles = css`
 	margin: 12px auto;
 	text-align: center;
 	${from.tablet} {
-		margin: 0;
 		max-width: 699px;
 	}
 	${from.desktop} {

--- a/dotcom-rendering/src/components/AdSlot.tsx
+++ b/dotcom-rendering/src/components/AdSlot.tsx
@@ -295,7 +295,7 @@ const mostPopContainerStyles = css`
 	min-width: 300px;
 	width: fit-content;
 	max-width: 300px;
-	margin: 0px auto;
+	margin: 0 auto;
 	${from.tablet} {
 		max-width: 700px;
 	}

--- a/dotcom-rendering/src/components/AdSlot.tsx
+++ b/dotcom-rendering/src/components/AdSlot.tsx
@@ -367,7 +367,7 @@ const mobileStickyAdStyles = css`
 `;
 
 const nonExpandingContainerStyles = css`
-	width: max-content;
+	width: 300px;
 	margin: auto;
 `;
 

--- a/dotcom-rendering/src/components/AdSlot.tsx
+++ b/dotcom-rendering/src/components/AdSlot.tsx
@@ -366,9 +366,18 @@ const mobileStickyAdStyles = css`
 	}
 `;
 
-const nonExpandingContainerStyles = css`
+const mostPopContainerStyles = css`
+	min-height: ${adSizes.mpu.height + labelHeight}px;
+	min-width: 300px;
 	width: 300px;
-	margin: auto;
+	margin: 0px auto;
+	${from.desktop} {
+		margin: 0;
+		width: auto;
+	}
+	${from.wide} {
+		margin-top: 25px;
+	}
 `;
 
 export const adContainerStyles = [adContainerCollapseStyles, labelStyles];
@@ -499,7 +508,7 @@ export const AdSlot = ({
 			return (
 				<div
 					className="ad-slot-container"
-					css={[adContainerStyles, nonExpandingContainerStyles]}
+					css={[adContainerStyles, mostPopContainerStyles]}
 				>
 					<div
 						id="dfp-ad--mostpop"
@@ -630,10 +639,7 @@ export const AdSlot = ({
 		case 'inline': {
 			const advertId = `inline${index + 1}`;
 			return (
-				<div
-					className="ad-slot-container"
-					css={[adContainerStyles, nonExpandingContainerStyles]}
-				>
+				<div className="ad-slot-container" css={[adContainerStyles]}>
 					<div
 						id={`dfp-ad--${advertId}`}
 						className={[
@@ -675,10 +681,7 @@ export const AdSlot = ({
 		case 'mobile-front': {
 			const advertId = index === 0 ? 'top-above-nav' : `inline${index}`;
 			return (
-				<div
-					className="ad-slot-container"
-					css={[adContainerStyles, nonExpandingContainerStyles]}
-				>
+				<div className="ad-slot-container" css={[adContainerStyles]}>
 					<div
 						id={`dfp-ad--${advertId}--mobile`}
 						className={[

--- a/dotcom-rendering/src/components/AdSlot.tsx
+++ b/dotcom-rendering/src/components/AdSlot.tsx
@@ -275,12 +275,16 @@ const mostPopAdStyles = css`
 	position: relative;
 	min-height: ${adSizes.mpu.height + labelHeight}px;
 	min-width: 300px;
-	width: 300px;
+	max-width: 300px;
 	margin: 12px auto;
 	text-align: center;
-	${from.desktop} {
+	${from.tablet} {
 		margin: 0;
+		max-width: 699px;
+	}
+	${from.desktop} {
 		width: auto;
+		max-width: 300px;
 	}
 	${from.wide} {
 		margin-top: 25px;
@@ -291,7 +295,14 @@ const mostPopContainerStyles = css`
 	min-height: ${adSizes.mpu.height + labelHeight}px;
 	min-width: 300px;
 	width: fit-content;
+	max-width: 300px;
 	margin: 0px auto;
+	${from.tablet} {
+		max-width: 699px;
+	}
+	${from.desktop} {
+		max-width: 300px;
+	}
 `;
 
 /**

--- a/dotcom-rendering/src/components/AdSlot.tsx
+++ b/dotcom-rendering/src/components/AdSlot.tsx
@@ -279,7 +279,7 @@ const mostPopAdStyles = css`
 	margin: 12px auto;
 	text-align: center;
 	${from.tablet} {
-		max-width: 699px;
+		max-width: 700px;
 	}
 	${from.desktop} {
 		width: auto;
@@ -297,7 +297,7 @@ const mostPopContainerStyles = css`
 	max-width: 300px;
 	margin: 0px auto;
 	${from.tablet} {
-		max-width: 699px;
+		max-width: 700px;
 	}
 	${from.desktop} {
 		max-width: 300px;

--- a/dotcom-rendering/src/components/AdSlot.tsx
+++ b/dotcom-rendering/src/components/AdSlot.tsx
@@ -275,12 +275,12 @@ const mostPopAdStyles = css`
 	position: relative;
 	min-height: ${adSizes.mpu.height + labelHeight}px;
 	min-width: 300px;
-	width: min-content;
+	width: 300px;
 	margin: 12px auto;
 	text-align: center;
 	${from.desktop} {
 		margin: 0;
-		width: 300px;
+		width: auto;
 	}
 	${from.wide} {
 		margin-top: 25px;
@@ -288,15 +288,10 @@ const mostPopAdStyles = css`
 `;
 
 const mostPopContainerStyles = css`
-	position: relative;
 	min-height: ${adSizes.mpu.height + labelHeight}px;
 	min-width: 300px;
-	width: min-content;
+	width: fit-content;
 	margin: 0px auto;
-	${from.desktop} {
-		margin: 0;
-		width: 300px;
-	}
 `;
 
 /**
@@ -517,7 +512,11 @@ export const AdSlot = ({
 							'ad-slot--mpu-banner-ad',
 							'ad-slot--rendered',
 						].join(' ')}
-						css={[mostPopAdStyles]}
+						css={[
+							fluidAdStyles,
+							fluidFullWidthAdStyles,
+							mostPopAdStyles,
+						]}
 						data-link-name="ad slot mostpop"
 						data-name="mostpop"
 						aria-hidden="true"

--- a/dotcom-rendering/src/components/AdSlot.tsx
+++ b/dotcom-rendering/src/components/AdSlot.tsx
@@ -275,15 +275,27 @@ const mostPopAdStyles = css`
 	position: relative;
 	min-height: ${adSizes.mpu.height + labelHeight}px;
 	min-width: 300px;
-	width: 300px;
+	width: min-content;
 	margin: 12px auto;
 	text-align: center;
 	${from.desktop} {
 		margin: 0;
-		width: auto;
+		width: 300px;
 	}
 	${from.wide} {
 		margin-top: 25px;
+	}
+`;
+
+const mostPopContainerStyles = css`
+	position: relative;
+	min-height: ${adSizes.mpu.height + labelHeight}px;
+	min-width: 300px;
+	width: min-content;
+	margin: 0px auto;
+	${from.desktop} {
+		margin: 0;
+		width: 300px;
 	}
 `;
 
@@ -363,20 +375,6 @@ const mobileStickyAdStyles = css`
 		display: block;
 		position: relative;
 		${individualLabelCSS}
-	}
-`;
-
-const mostPopContainerStyles = css`
-	min-height: ${adSizes.mpu.height + labelHeight}px;
-	min-width: 300px;
-	width: 300px;
-	margin: 0px auto;
-	${from.desktop} {
-		margin: 0;
-		width: auto;
-	}
-	${from.wide} {
-		margin-top: 25px;
 	}
 `;
 

--- a/dotcom-rendering/src/components/MostViewedFooterLayout.tsx
+++ b/dotcom-rendering/src/components/MostViewedFooterLayout.tsx
@@ -37,7 +37,10 @@ const fixedWidthsPageSkin = css`
 `;
 
 const mostPopMargin = css`
-	margin: 9px 0 0 10px;
+	margin: 0 0 0 10px;
+	${from.desktop} {
+		margin: 9px 0 0 10px;
+	}
 	${from.leftCol} {
 		margin: 6px 0 0 10px;
 	}

--- a/dotcom-rendering/src/components/MostViewedFooterLayout.tsx
+++ b/dotcom-rendering/src/components/MostViewedFooterLayout.tsx
@@ -37,7 +37,7 @@ const fixedWidthsPageSkin = css`
 `;
 
 const mostPopMargin = css`
-	margin: 0 0 0 10px;
+	margin-top: 9px;
 	${from.desktop} {
 		margin: 9px 0 0 10px;
 	}


### PR DESCRIPTION
## What does this change?
- Adds fluid styles to the mostpop ad slot
- Adds container styles for the mostpop ad slot so that max-widths are specified
- Adds a larger width for mostpop ads on tablet view, as they have more room than on mobile or desktop views and won't always be 300px
- Removes the left margin for mostpop ads on tablet, as this pushes the ad slightly off centre

## Why?
Mostpop ads were not displaying well on tablet view. We allow ads bigger than 300px to come into the mostpop ad slot but constrain the width to 300px, which led to ads overflowing their containers. We retain this width of 300px for desktop and mobile mostpop ads, while allowing more flexibility in size for tablet ads. This will improve the appearance of these ads by allowing the ad slot to expand and centre them properly.

We also set a max-width on the container to safeguard against ads coming in that are too big for the slot, because they think they can expand into the parent container.

## Screenshots


| Before      | After      |
| ----------- | ---------- |
| <img width="360" src="https://github.com/guardian/dotcom-rendering/assets/108270776/eb77f3f9-63b0-4633-a9f4-5641eed49fd3"> | <img width="360" src="https://github.com/guardian/dotcom-rendering/assets/108270776/456513bb-5d98-43d4-8762-d2b91b2e76fb"> |
| <img width="360" src="https://github.com/guardian/dotcom-rendering/assets/108270776/76149686-102e-4a5d-af5d-ef452e621efe"> | <img width="360" src="https://github.com/guardian/dotcom-rendering/assets/108270776/7f99e871-c169-4c47-b49d-345b355507d3"> |


