### PR TITLE
fix: stop text jumping around on pin hover

### DIFF
--- a/dotcom-rendering/src/components/FirstPublished.tsx
+++ b/dotcom-rendering/src/components/FirstPublished.tsx
@@ -88,10 +88,9 @@ const FirstPublished = ({
 						text-decoration: none;
 						display: flex;
 
-						:hover {
+						&:hover {
 							span {
-								height: 16px;
-								width: 16px;
+								transform: scale(1.2);
 							}
 						}
 					`}


### PR DESCRIPTION
## What does this change?

Fixes issue reported where if a user hovered over a pinned post on a live blog, the text in the event would shift around

## Why?

Make the website a fun experience rather than a jarring one.

Also, it's Friday afternoon and this is a fun time for small bug fixes 🤠 

## Screenshots

https://github.com/guardian/dotcom-rendering/assets/43961396/b6ad8e61-c554-4854-9837-2c5018271e8b

https://github.com/guardian/dotcom-rendering/assets/43961396/9459436d-261d-4f50-8c40-4f92a10c5c71
