### PR TITLE
fix: Do not show Sponsored by when we shouldn't

### DIFF
--- a/dotcom-rendering/src/model/decideCollectionBranding.ts
+++ b/dotcom-rendering/src/model/decideCollectionBranding.ts
@@ -1,0 +1,42 @@
+import { isNonNullable } from '@guardian/libs';
+import type { EditionId } from '../lib/edition';
+import type { Branding } from '../types/branding';
+import type { FEFrontCard } from '../types/front';
+
+const getBrandingFromCards = (
+	allCards: FEFrontCard[],
+	editionId: EditionId,
+): Branding[] => {
+	return allCards
+		.map(
+			(card) =>
+				card.properties.editionBrandings.find(
+					(editionBranding) =>
+						editionBranding.edition.id === editionId,
+				)?.branding,
+		)
+		.filter(isNonNullable);
+};
+
+export const decideCollectionBranding = (
+	allCards: FEFrontCard[],
+	editionId: EditionId,
+): Branding | undefined => {
+	const allBranding = getBrandingFromCards(allCards, editionId);
+	const allCardsHaveBranding = allCards.length === allBranding.length;
+
+	const allCardsHaveSponsoredBranding =
+		allCardsHaveBranding &&
+		allBranding.every(
+			(branding) => branding.brandingType?.name === 'sponsored',
+		);
+	const allCardsHaveTheSameSponsor =
+		allCardsHaveBranding &&
+		allBranding.every(
+			(branding) => branding.sponsorName === allBranding[0]?.sponsorName,
+		);
+	const shouldHaveSponsorBranding =
+		allCardsHaveSponsoredBranding && allCardsHaveTheSameSponsor;
+
+	return shouldHaveSponsorBranding ? allBranding[0] : undefined;
+};

--- a/dotcom-rendering/src/model/enhanceCollections.ts
+++ b/dotcom-rendering/src/model/enhanceCollections.ts
@@ -7,6 +7,7 @@ import type {
 	FEFrontCard,
 } from '../types/front';
 import { decideBadge } from './decideBadge';
+import { decideCollectionBranding } from './decideCollectionBranding';
 import { decideContainerPalette } from './decideContainerPalette';
 import { enhanceCards } from './enhanceCards';
 import { enhanceTreats } from './enhanceTreats';
@@ -68,14 +69,6 @@ export const enhanceCollections = ({
 		const isCollectionPaidContent = allBranding.every(
 			({ brandingType }) => brandingType?.name === 'paid-content',
 		);
-
-		const sponsorBranding = allBranding.every(
-			(branding) =>
-				branding.brandingType?.name === 'sponsored' &&
-				branding.sponsorName === allBranding[0]?.sponsorName,
-		)
-			? allBranding[0]
-			: undefined;
 
 		const containerPalette = decideContainerPalette(
 			collection.config.metadata?.map((meta) => meta.type),
@@ -139,7 +132,7 @@ export const enhanceCollections = ({
 			},
 			canShowMore: hasMore && !collection.config.hideShowMore,
 			targetedTerritory: collection.targetedTerritory,
-			collectionBranding: sponsorBranding,
+			collectionBranding: decideCollectionBranding(allCards, editionId),
 		};
 	});
 };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Fixes a bug introduced in https://github.com/guardian/dotcom-rendering/pull/8764. We should show "Sponsored by" only if all the cards in the collection have:
1. branding of `sponsored` type
2. the same sponsor

## Why?
We need to be able to label our [content with funding from outside parties](https://www.theguardian.com/info/2016/jan/25/content-funding) correctly

## Screenshots

Bug currently in [`/world-cup-2022`](https://www.theguardian.com/football/world-cup-2022) front

![image](https://github.com/guardian/dotcom-rendering/assets/19683595/d7d27b15-9a07-42bb-8f64-ab9e3f6a6c69)


| Before      | After      |
| ----------- | ---------- |
| ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/e28dcb2b-53b4-484a-bbcb-b6efe2b08ad3) | ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/7cb954dd-ad0b-489b-bb40-2af4da49eea4) |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
