### PR TITLE
Fix Dynamo Sublink Backgrounds

### DIFF
--- a/dotcom-rendering/src/components/SupportingContent.tsx
+++ b/dotcom-rendering/src/components/SupportingContent.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { from, neutral, until } from '@guardian/source-foundations';
+import { from, until } from '@guardian/source-foundations';
 import { decidePalette } from '../lib/decidePalette';
 import { transparentColour } from '../lib/transparentColour';
 import type { DCRContainerPalette, DCRSupportingContent } from '../types/front';
@@ -74,8 +74,14 @@ const liStyles = css`
 	}
 `;
 
-const dynamoLiStyles = css`
-	background-color: ${transparentColour(neutral[97], 0.875)};
+const dynamoLiStyles = (
+	format: ArticleFormat,
+	containerPalette?: DCRContainerPalette,
+) => css`
+	background-color: ${transparentColour(
+		decidePalette(format, containerPalette).background.dynamoSublink,
+		0.875,
+	)};
 	/* Creates a containing block which allows Ophan heatmap to place bubbles correctly. */
 	position: relative;
 	border-top: 1px solid;
@@ -126,7 +132,10 @@ export const SupportingContent = ({
 						css={[
 							isDynamo
 								? [
-										dynamoLiStyles,
+										dynamoLiStyles(
+											parentFormat,
+											containerPalette,
+										),
 										css`
 											border-color: ${decidePalette(
 												parentFormat,

--- a/dotcom-rendering/src/lib/decideContainerOverrides.ts
+++ b/dotcom-rendering/src/lib/decideContainerOverrides.ts
@@ -499,6 +499,21 @@ const backgroundCard = (
 	}
 };
 
+const backgroundDynamoSublink = (
+	containerPalette: DCRContainerPalette,
+): string => {
+	switch (containerPalette) {
+		case 'SombrePalette':
+			return specialReport[300];
+		case 'SombreAltPalette':
+			return specialReport[100];
+		case 'InvestigationPalette':
+			return specialReport[300];
+		default:
+			return palette.neutral[97];
+	}
+};
+
 const topBarCard = textCardKicker;
 
 /**
@@ -535,6 +550,7 @@ export const decideContainerOverrides = (
 				carouselArrow: backgroundCarouselArrow(containerPalette),
 				carouselArrowHover:
 					backgroundCarouselArrowHover(containerPalette),
+				dynamoSublink: backgroundDynamoSublink(containerPalette),
 			},
 		};
 	}
@@ -559,6 +575,7 @@ export const decideContainerOverrides = (
 				carouselArrow: backgroundCarouselArrow(containerPalette),
 				carouselArrowHover:
 					backgroundCarouselArrowHover(containerPalette),
+				dynamoSublink: backgroundDynamoSublink(containerPalette),
 			},
 		};
 	}
@@ -591,6 +608,7 @@ export const decideContainerOverrides = (
 			carouselDot: backgroundCarouselDot(containerPalette),
 			carouselArrow: backgroundCarouselArrow(containerPalette),
 			carouselArrowHover: backgroundCarouselArrowHover(containerPalette),
+			dynamoSublink: backgroundDynamoSublink(containerPalette),
 		},
 		topBar: {
 			card: topBarCard(containerPalette),

--- a/dotcom-rendering/src/lib/decidePalette.ts
+++ b/dotcom-rendering/src/lib/decidePalette.ts
@@ -2243,6 +2243,9 @@ const backgroundSubmeta = (format: ArticleFormat) => {
 	return neutral[100];
 };
 
+const backgroundDynamoSublink = (_format: ArticleFormat): string =>
+	palette.neutral[97];
+
 export const decidePalette = (
 	format: ArticleFormat,
 	containerPalette?: DCRContainerPalette,
@@ -2356,6 +2359,9 @@ export const decidePalette = (
 			messageForm: backgroundMessageForm(format),
 			discussionPillarButton: backgroundDiscussionPillarButton(format),
 			subMeta: backgroundSubmeta(format),
+			dynamoSublink:
+				overrides?.background.dynamoSublink ??
+				backgroundDynamoSublink(format),
 		},
 		fill: {
 			commentCount: fillCommentCount(format),

--- a/dotcom-rendering/src/types/palette.ts
+++ b/dotcom-rendering/src/types/palette.ts
@@ -103,6 +103,7 @@ export type Palette = {
 		messageForm: Colour;
 		discussionPillarButton: Colour;
 		subMeta: Colour;
+		dynamoSublink: Colour;
 	};
 	fill: {
 		commentCount: Colour;
@@ -189,6 +190,7 @@ export type ContainerOverrides = {
 		carouselDot: Colour;
 		carouselArrow: Colour;
 		carouselArrowHover: Colour;
+		dynamoSublink: Colour;
 	};
 	topBar?: {
 		card?: Colour;


### PR DESCRIPTION
All dynamo sublinks were using the same background colour, which didn't look correct when combined with some of the text colours used when container palettes were applied. This varies the sublink background colour by container palette.

## Screenshots

| Before | After |
| - | - |
| ![sublink-before] | ![sublink-after] |

[sublink-after]: https://github.com/guardian/dotcom-rendering/assets/53781962/04c6ab40-838c-4522-ace1-a62b4864e095
[sublink-before]: https://github.com/guardian/dotcom-rendering/assets/53781962/7db14d6c-2e0e-4809-9e30-a2636f875d79
