### PR TITLE
Split editorial and commercial badge logic

### DIFF
--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -764,7 +764,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 								frontEditionBranding={frontEditionBranding}
 								discussionApiUrl={front.config.discussionApiUrl}
 								containerSponsorBranding={
-									collection.collectionBranding
+									collection.sponsoredContentBranding
 								}
 							>
 								<DecideContainer

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -426,7 +426,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 					} | ${ophanName}`;
 					const mostPopularTitle = 'Most popular';
 
-					const trailsWithoutBranding = collection.badge
+					const trailsWithoutBranding = collection.editorialBadge
 						? trails.map((labTrail) => {
 								return {
 									...labTrail,
@@ -595,7 +595,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 									containerName={collection.collectionType}
 									canShowMore={collection.canShowMore}
 									url={collection.href}
-									badge={collection.badge}
+									badge={collection.editorialBadge}
 									data-print-layout="hide"
 									hasPageSkin={hasPageSkin}
 									discussionApiUrl={
@@ -746,7 +746,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 									collection,
 									hasPageSkin,
 								)}
-								badge={collection.badge}
+								badge={collection.editorialBadge}
 								sectionId={ophanName}
 								collectionId={collection.id}
 								pageId={front.pressedPage.id}

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -426,7 +426,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 					} | ${ophanName}`;
 					const mostPopularTitle = 'Most popular';
 
-					const trailsWithoutBranding = collection.editorialBadge
+					const trailsWithoutBranding = collection.paidContentBadge
 						? trails.map((labTrail) => {
 								return {
 									...labTrail,
@@ -595,7 +595,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 									containerName={collection.collectionType}
 									canShowMore={collection.canShowMore}
 									url={collection.href}
-									badge={collection.editorialBadge}
+									badge={collection.paidContentBadge}
 									data-print-layout="hide"
 									hasPageSkin={hasPageSkin}
 									discussionApiUrl={

--- a/dotcom-rendering/src/model/decideBadge.test.ts
+++ b/dotcom-rendering/src/model/decideBadge.test.ts
@@ -1,8 +1,4 @@
-import {
-	decideBadge,
-	decidePaidContentBadge,
-	decideEditorialBadge,
-} from './decideBadge';
+import { decideEditorialBadge, decidePaidContentBadge } from './decideBadge';
 
 jest.mock('./badges');
 
@@ -116,36 +112,6 @@ describe('Decide badge', () => {
 
 			const result2 = decidePaidContentBadge([]);
 			expect(result2).toEqual(expectedResult);
-		});
-	});
-
-	describe('decideBadge function', () => {
-		it('return series tag match if both seriesTag and branding provided', () => {
-			const branding = [brandingAmazon, brandingAmazon];
-			const tagId = 'uk-news/series/the-brexit-gamble';
-			const expectedResult = {
-				href: `/${tagId}`,
-				imageSrc: `/static/frontend/badges/EUReferendumBadge.svg`,
-			};
-			const result = decideBadge(tagId, branding);
-			expect(result).toMatchObject(expectedResult);
-		});
-
-		it('returns branding sponsor if branding but no series tag match', () => {
-			const branding = [brandingAmazon, brandingAmazon];
-
-			const expectedResult = {
-				imageSrc: brandingAmazon.logo.src,
-				href: brandingAmazon.logo.link,
-			};
-			const result = decideBadge('seriesTag', branding);
-			expect(result).toEqual(expectedResult);
-		});
-
-		it('returns undefined if no match by seriesTag or branding', () => {
-			const expectedResult = undefined;
-			const result = decideBadge('seriesTag', []);
-			expect(result).toEqual(expectedResult);
 		});
 	});
 });

--- a/dotcom-rendering/src/model/decideBadge.test.ts
+++ b/dotcom-rendering/src/model/decideBadge.test.ts
@@ -1,7 +1,7 @@
 import {
 	decideBadge,
-	getBadgeFromBranding,
-	getEditorialBadge,
+	decidePaidContentBadge,
+	decideEditorialBadge,
 } from './decideBadge';
 
 jest.mock('./badges');
@@ -59,7 +59,7 @@ describe('Decide badge', () => {
 				href: `/${tagId}`,
 				imageSrc: `/static/frontend/badges/EUReferendumBadge.svg`,
 			};
-			const result = getEditorialBadge(tagId);
+			const result = decideEditorialBadge(tagId);
 			expect(result).toMatchObject(expectedResult);
 		});
 
@@ -69,21 +69,21 @@ describe('Decide badge', () => {
 				href: `/${tagId}`,
 				imageSrc: `/static/frontend/badges/newsletter-badge.svg`,
 			};
-			const result = getEditorialBadge(tagId);
+			const result = decideEditorialBadge(tagId);
 			expect(result).toMatchObject(expectedResult);
 		});
 
 		it('returns undefined if no standard or special badge match found for series tag', () => {
 			const tagId = 'lifeandstyle/home-and-garden';
 			const expectedResult = undefined;
-			const result = getEditorialBadge(tagId);
+			const result = decideEditorialBadge(tagId);
 			expect(result).toEqual(expectedResult);
 		});
 
 		it('returns undefined for undefined series tag', () => {
 			const tagId = undefined;
 			const expectedResult = undefined;
-			const result = getEditorialBadge(tagId);
+			const result = decideEditorialBadge(tagId);
 			expect(result).toEqual(expectedResult);
 		});
 	});
@@ -96,7 +96,7 @@ describe('Decide badge', () => {
 				imageSrc: brandingAmazon.logo.src,
 				href: brandingAmazon.logo.link,
 			};
-			const result = getBadgeFromBranding(branding);
+			const result = decidePaidContentBadge(branding);
 			expect(result).toEqual(expectedResult);
 		});
 
@@ -104,17 +104,17 @@ describe('Decide badge', () => {
 			const branding = [brandingAmazon, brandingGuardianOrg];
 
 			const expectedResult = undefined;
-			const result = getBadgeFromBranding(branding);
+			const result = decidePaidContentBadge(branding);
 			expect(result).toEqual(expectedResult);
 		});
 
 		it('returns undefined if no branding supplied', () => {
 			const expectedResult = undefined;
 
-			const result = getBadgeFromBranding(undefined);
+			const result = decidePaidContentBadge(undefined);
 			expect(result).toEqual(expectedResult);
 
-			const result2 = getBadgeFromBranding([]);
+			const result2 = decidePaidContentBadge([]);
 			expect(result2).toEqual(expectedResult);
 		});
 	});

--- a/dotcom-rendering/src/model/decideBadge.test.ts
+++ b/dotcom-rendering/src/model/decideBadge.test.ts
@@ -1,7 +1,7 @@
 import {
 	decideBadge,
 	getBadgeFromBranding,
-	getBadgeFromSeriesTag,
+	getEditorialBadge,
 } from './decideBadge';
 
 jest.mock('./badges');
@@ -59,7 +59,7 @@ describe('Decide badge', () => {
 				href: `/${tagId}`,
 				imageSrc: `/static/frontend/badges/EUReferendumBadge.svg`,
 			};
-			const result = getBadgeFromSeriesTag(tagId);
+			const result = getEditorialBadge(tagId);
 			expect(result).toMatchObject(expectedResult);
 		});
 
@@ -69,21 +69,21 @@ describe('Decide badge', () => {
 				href: `/${tagId}`,
 				imageSrc: `/static/frontend/badges/newsletter-badge.svg`,
 			};
-			const result = getBadgeFromSeriesTag(tagId);
+			const result = getEditorialBadge(tagId);
 			expect(result).toMatchObject(expectedResult);
 		});
 
 		it('returns undefined if no standard or special badge match found for series tag', () => {
 			const tagId = 'lifeandstyle/home-and-garden';
 			const expectedResult = undefined;
-			const result = getBadgeFromSeriesTag(tagId);
+			const result = getEditorialBadge(tagId);
 			expect(result).toEqual(expectedResult);
 		});
 
 		it('returns undefined for undefined series tag', () => {
 			const tagId = undefined;
 			const expectedResult = undefined;
-			const result = getBadgeFromSeriesTag(tagId);
+			const result = getEditorialBadge(tagId);
 			expect(result).toEqual(expectedResult);
 		});
 	});

--- a/dotcom-rendering/src/model/decideBadge.ts
+++ b/dotcom-rendering/src/model/decideBadge.ts
@@ -33,7 +33,7 @@ export const getBadgeFromBranding = (
 /**
  * Fetches the corresponding badge using the series tag, if there's a match in the lookup.
  */
-export const getBadgeFromSeriesTag = (
+export const getEditorialBadge = (
 	seriesTag?: string,
 ): DCRBadgeType | undefined => {
 	if (!seriesTag) return undefined;
@@ -73,7 +73,5 @@ export const decideBadge = (
 	seriesTag?: string,
 	allBranding?: Branding[],
 ): DCRBadgeType | undefined => {
-	return (
-		getBadgeFromSeriesTag(seriesTag) ?? getBadgeFromBranding(allBranding)
-	);
+	return getEditorialBadge(seriesTag) ?? getBadgeFromBranding(allBranding);
 };

--- a/dotcom-rendering/src/model/decideBadge.ts
+++ b/dotcom-rendering/src/model/decideBadge.ts
@@ -7,7 +7,7 @@ import { BADGES, SPECIAL_BADGES } from './badges';
 /**
  * Fetches the badge properties only if ALL branding has the same sponsor.
  */
-export const getBadgeFromBranding = (
+export const decidePaidContentBadge = (
 	branding?: Branding[],
 ): DCRBadgeType | undefined => {
 	// Early return if there are no branding elements
@@ -33,7 +33,7 @@ export const getBadgeFromBranding = (
 /**
  * Fetches the corresponding badge using the series tag, if there's a match in the lookup.
  */
-export const getEditorialBadge = (
+export const decideEditorialBadge = (
 	seriesTag?: string,
 ): DCRBadgeType | undefined => {
 	if (!seriesTag) return undefined;
@@ -73,5 +73,7 @@ export const decideBadge = (
 	seriesTag?: string,
 	allBranding?: Branding[],
 ): DCRBadgeType | undefined => {
-	return getEditorialBadge(seriesTag) ?? getBadgeFromBranding(allBranding);
+	return (
+		decideEditorialBadge(seriesTag) ?? decidePaidContentBadge(allBranding)
+	);
 };

--- a/dotcom-rendering/src/model/decideBadge.ts
+++ b/dotcom-rendering/src/model/decideBadge.ts
@@ -61,19 +61,3 @@ export const decideEditorialBadge = (
 			: undefined; // No badge or special badge found
 	}
 };
-
-/**
- * Return a badge based on the series tag or container branding
- *
- * Try to fetch badge using series tag first
- * Otherwise try to fetch badge using branding elements
- * Returns undefined as default / if no matches found
- */
-export const decideBadge = (
-	seriesTag?: string,
-	allBranding?: Branding[],
-): DCRBadgeType | undefined => {
-	return (
-		decideEditorialBadge(seriesTag) ?? decidePaidContentBadge(allBranding)
-	);
-};

--- a/dotcom-rendering/src/model/decideCollectionBranding.ts
+++ b/dotcom-rendering/src/model/decideCollectionBranding.ts
@@ -1,42 +1,24 @@
-import { isNonNullable } from '@guardian/libs';
-import type { EditionId } from '../lib/edition';
 import type { Branding } from '../types/branding';
-import type { FEFrontCard } from '../types/front';
-
-const getBrandingFromCards = (
-	allCards: FEFrontCard[],
-	editionId: EditionId,
-): Branding[] => {
-	return allCards
-		.map(
-			(card) =>
-				card.properties.editionBrandings.find(
-					(editionBranding) =>
-						editionBranding.edition.id === editionId,
-				)?.branding,
-		)
-		.filter(isNonNullable);
-};
 
 export const decideCollectionBranding = (
-	allCards: FEFrontCard[],
-	editionId: EditionId,
+	collectionsLength: number,
+	allCardsBranding: Branding[],
 ): Branding | undefined => {
-	const allBranding = getBrandingFromCards(allCards, editionId);
-	const allCardsHaveBranding = allCards.length === allBranding.length;
+	const allCardsHaveBranding = collectionsLength === allCardsBranding.length;
 
 	const allCardsHaveSponsoredBranding =
 		allCardsHaveBranding &&
-		allBranding.every(
+		allCardsBranding.every(
 			(branding) => branding.brandingType?.name === 'sponsored',
 		);
 	const allCardsHaveTheSameSponsor =
 		allCardsHaveBranding &&
-		allBranding.every(
-			(branding) => branding.sponsorName === allBranding[0]?.sponsorName,
+		allCardsBranding.every(
+			(branding) =>
+				branding.sponsorName === allCardsBranding[0]?.sponsorName,
 		);
 	const shouldHaveSponsorBranding =
 		allCardsHaveSponsoredBranding && allCardsHaveTheSameSponsor;
 
-	return shouldHaveSponsorBranding ? allBranding[0] : undefined;
+	return shouldHaveSponsorBranding ? allCardsBranding[0] : undefined;
 };

--- a/dotcom-rendering/src/model/enhanceCollections.ts
+++ b/dotcom-rendering/src/model/enhanceCollections.ts
@@ -94,7 +94,7 @@ export const enhanceCollections = ({
 			collectionType,
 			href,
 			containerPalette,
-			badge: decideBadge(
+			editorialBadge: decideBadge(
 				collection.config.href,
 				// We only try to use a branded badge for paid content
 				isCollectionPaidContent && allCardsHaveBranding

--- a/dotcom-rendering/src/model/enhanceCollections.ts
+++ b/dotcom-rendering/src/model/enhanceCollections.ts
@@ -132,7 +132,10 @@ export const enhanceCollections = ({
 			},
 			canShowMore: hasMore && !collection.config.hideShowMore,
 			targetedTerritory: collection.targetedTerritory,
-			collectionBranding: decideCollectionBranding(allCards, editionId),
+			collectionBranding: decideCollectionBranding(
+				allCards.length,
+				allBranding,
+			),
 		};
 	});
 };

--- a/dotcom-rendering/src/model/enhanceCollections.ts
+++ b/dotcom-rendering/src/model/enhanceCollections.ts
@@ -132,7 +132,7 @@ export const enhanceCollections = ({
 			},
 			canShowMore: hasMore && !collection.config.hideShowMore,
 			targetedTerritory: collection.targetedTerritory,
-			collectionBranding: decideCollectionBranding(
+			sponsoredContentBranding: decideCollectionBranding(
 				allCards.length,
 				allBranding,
 			),

--- a/dotcom-rendering/src/model/enhanceCollections.ts
+++ b/dotcom-rendering/src/model/enhanceCollections.ts
@@ -6,7 +6,7 @@ import type {
 	FECollectionType,
 	FEFrontCard,
 } from '../types/front';
-import { decideBadge } from './decideBadge';
+import { decidePaidContentBadge, decideEditorialBadge } from './decideBadge';
 import { decideCollectionBranding } from './decideCollectionBranding';
 import { decideContainerPalette } from './decideContainerPalette';
 import { enhanceCards } from './enhanceCards';
@@ -94,8 +94,8 @@ export const enhanceCollections = ({
 			collectionType,
 			href,
 			containerPalette,
-			editorialBadge: decideBadge(
-				collection.config.href,
+			editorialBadge: decideEditorialBadge(collection.config.href),
+			paidContentBadge: decidePaidContentBadge(
 				// We only try to use a branded badge for paid content
 				isCollectionPaidContent && allCardsHaveBranding
 					? allBranding

--- a/dotcom-rendering/src/model/enhanceCollections.ts
+++ b/dotcom-rendering/src/model/enhanceCollections.ts
@@ -6,7 +6,7 @@ import type {
 	FECollectionType,
 	FEFrontCard,
 } from '../types/front';
-import { decidePaidContentBadge, decideEditorialBadge } from './decideBadge';
+import { decideEditorialBadge, decidePaidContentBadge } from './decideBadge';
 import { decideCollectionBranding } from './decideCollectionBranding';
 import { decideContainerPalette } from './decideContainerPalette';
 import { enhanceCards } from './enhanceCards';

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -400,7 +400,7 @@ export type DCRCollectionType = {
 	 * will always be `false`.
 	 **/
 	canShowMore?: boolean;
-	badge?: DCRBadgeType;
+	editorialBadge?: DCRBadgeType;
 	targetedTerritory?: Territory;
 
 	collectionBranding?: Branding;

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -401,9 +401,8 @@ export type DCRCollectionType = {
 	 **/
 	canShowMore?: boolean;
 	editorialBadge?: DCRBadgeType;
+	sponsoredContentBranding?: Branding;
 	targetedTerritory?: Territory;
-
-	collectionBranding?: Branding;
 };
 
 export type DCRGroupedTrails = {

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -401,6 +401,7 @@ export type DCRCollectionType = {
 	 **/
 	canShowMore?: boolean;
 	editorialBadge?: DCRBadgeType;
+	paidContentBadge?: DCRBadgeType;
 	sponsoredContentBranding?: Branding;
 	targetedTerritory?: Territory;
 };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

Closes https://github.com/guardian/dotcom-rendering/issues/8435

## What does this change?
Splits editorial and paid content badge logic

## Why?
We're trying to make it easier to work with badges in the codebase. At the moment the logic is quite complicated.  Splitting the logic for editorial and commercial badges is s first step.

See more info [here](https://docs.google.com/document/d/1yPCmjz33SahtVrzT-7E8Iau6hoo46YFUgLDBJJSJwJw/edit#heading=h.xqnvzljtmuar)

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/023ac778-815f-4715-81f7-1f2604921c0c) | ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/1800ee73-55b8-4937-a6fb-a472eac497eb) |
| ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/a4a2204f-5359-45f6-a000-7620917d6507) | ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/bf42ef53-2359-4eba-a494-a2df773c459b) |
| ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/686a0db4-111b-42e3-a644-695d61ca8277) | ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/ff60990d-2e6a-4c78-903b-fc345fcc708e) |
| ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/42f43df1-87c0-4aa0-91f2-143c811734ba) | ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/42f43df1-87c0-4aa0-91f2-143c811734ba) |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
