### PR TITLE
Do not show sponsor if not in front branding

### DIFF
--- a/dotcom-rendering/src/components/FrontSection.stories.tsx
+++ b/dotcom-rendering/src/components/FrontSection.stories.tsx
@@ -246,17 +246,36 @@ TreatsStory.storyName = 'with treats and date header';
  * Note only the first container should show a badge
  */
 export const MultipleOnAPaidFront = () => {
+	const frontBranding = {
+		edition: {
+			id: 'UK',
+		},
+		branding: {
+			brandingType: {
+				name: 'paid-content',
+			},
+			sponsorName: 'Grounded',
+			logo: {
+				src: 'https://static.theguardian.com/commercial/sponsor/28/Oct/2020/daa941da-14fd-46cc-85cb-731ce59050ee-Grounded_badging-280x180.png',
+				dimensions: {
+					width: 140,
+					height: 90,
+				},
+				link: '/',
+				label: 'Paid for by',
+			},
+			aboutThisLink:
+				'https://www.theguardian.com/info/2016/jan/25/content-funding',
+		},
+	};
+
 	return (
 		<>
 			<FrontSection
 				title="Section one"
 				isOnPaidContentFront={true}
 				index={0}
-				badge={{
-					imageSrc:
-						'https://static.theguardian.com/commercial/sponsor/28/Oct/2020/daa941da-14fd-46cc-85cb-731ce59050ee-Grounded_badging-280x180.png',
-					href: '/',
-				}}
+				frontBranding={frontBranding}
 				discussionApiUrl={discussionApiUrl}
 			>
 				<Placeholder />
@@ -265,11 +284,7 @@ export const MultipleOnAPaidFront = () => {
 				title="Section two"
 				isOnPaidContentFront={true}
 				index={1}
-				badge={{
-					imageSrc:
-						'https://static.theguardian.com/commercial/sponsor/28/Oct/2020/daa941da-14fd-46cc-85cb-731ce59050ee-Grounded_badging-280x180.png',
-					href: '/',
-				}}
+				frontBranding={frontBranding}
 				discussionApiUrl={discussionApiUrl}
 			>
 				<Placeholder />

--- a/dotcom-rendering/src/components/FrontSection.tsx
+++ b/dotcom-rendering/src/components/FrontSection.tsx
@@ -513,14 +513,14 @@ export const FrontSection = ({
 		!!pageId &&
 		!!ajaxUrl;
 
-	const frontHasEditorialOrDesignBadge =
-		!isOnPaidContentFront && containerBranding === undefined;
+	const frontHasEditorialOrDesignBadge = !!badge;
 
 	// Only show the badge with a "Paid for by" label on the FIRST card of a paid front, aka as Labs front.
-	const isTheFirstContainerOnAPaidFront = isOnPaidContentFront && index === 0;
+	const isTheFirstContainerOnAPaidFront =
+		isOnPaidContentFront && index === 0 && !!frontBranding;
 
-	const hasFrontBranding =
-		!isOnPaidContentFront && !!frontBranding && index === 0;
+	const isTheFirstContainerOnASponsoredFront =
+		!isOnPaidContentFront && index === 0 && !!frontBranding;
 
 	/**
 	 * id is being used to set the containerId in @see {ShowMore.importable.tsx}
@@ -582,7 +582,7 @@ export const FrontSection = ({
 							showDateHeader={showDateHeader}
 							editionId={editionId}
 						/>
-						{badge && (
+						{!!frontBranding?.branding?.logo.src && (
 							<div
 								css={css`
 									display: inline-block;
@@ -599,8 +599,8 @@ export const FrontSection = ({
 							>
 								Paid for by
 								<Badge
-									imageSrc={badge.imageSrc}
-									href={badge.href}
+									imageSrc={frontBranding?.branding?.logo.src}
+									href={frontBranding?.branding?.logo.link}
 								/>
 							</div>
 						)}
@@ -609,23 +609,19 @@ export const FrontSection = ({
 					<>
 						{frontHasEditorialOrDesignBadge && (
 							<Hide until="leftCol">
-								{badge && (
-									<Badge
-										imageSrc={badge.imageSrc}
-										href={badge.href}
-									/>
-								)}
+								<Badge
+									imageSrc={badge.imageSrc}
+									href={badge.href}
+								/>
 							</Hide>
 						)}
 						<div css={titleStyle}>
 							{frontHasEditorialOrDesignBadge && (
 								<Hide from="leftCol">
-									{badge && (
-										<Badge
-											imageSrc={badge.imageSrc}
-											href={badge.href}
-										/>
-									)}
+									<Badge
+										imageSrc={badge.imageSrc}
+										href={badge.href}
+									/>
 								</Hide>
 							)}
 							<ContainerTitle
@@ -637,27 +633,31 @@ export const FrontSection = ({
 								showDateHeader={showDateHeader}
 								editionId={editionId}
 							/>
-							{hasFrontBranding && frontBranding?.branding && (
-								<>
-									<p css={labelStyles}>
-										{frontBranding.branding.logo.label}
-									</p>
-									<Badge
-										imageSrc={
-											frontBranding.branding.logo.src
-										}
-										href={frontBranding.branding.logo.link}
-									/>
-									<a
-										href={
-											frontBranding.branding.aboutThisLink
-										}
-										css={aboutThisLinkStyles}
-									>
-										About this content
-									</a>
-								</>
-							)}
+							{isTheFirstContainerOnASponsoredFront &&
+								frontBranding?.branding && (
+									<>
+										<p css={labelStyles}>
+											{frontBranding.branding.logo.label}
+										</p>
+										<Badge
+											imageSrc={
+												frontBranding.branding.logo.src
+											}
+											href={
+												frontBranding.branding.logo.link
+											}
+										/>
+										<a
+											href={
+												frontBranding.branding
+													.aboutThisLink
+											}
+											css={aboutThisLinkStyles}
+										>
+											About this content
+										</a>
+									</>
+								)}
 
 							{containerBranding && (
 								<>

--- a/dotcom-rendering/src/components/FrontSection.tsx
+++ b/dotcom-rendering/src/components/FrontSection.tsx
@@ -96,8 +96,8 @@ type Props = {
 	 */
 	hasPageSkin?: boolean;
 	discussionApiUrl: string;
-	frontEditionBranding?: DCRFrontType['pressedPage']['frontProperties']['commercial']['editionBrandings'][number];
-	containerSponsorBranding?: Branding;
+	frontBranding?: DCRFrontType['pressedPage']['frontProperties']['commercial']['editionBrandings'][number];
+	containerBranding?: Branding;
 };
 
 const width = (columns: number, columnWidth: number, columnGap: number) =>
@@ -497,9 +497,9 @@ export const FrontSection = ({
 	index,
 	targetedTerritory,
 	hasPageSkin = false,
-	frontEditionBranding,
+	frontBranding,
 	discussionApiUrl,
-	containerSponsorBranding,
+	containerBranding,
 }: Props) => {
 	const overrides =
 		containerPalette && decideContainerOverrides(containerPalette);
@@ -512,6 +512,15 @@ export const FrontSection = ({
 		!!collectionId &&
 		!!pageId &&
 		!!ajaxUrl;
+
+	const frontHasEditorialOrDesignBadge =
+		!isOnPaidContentFront && containerBranding === undefined;
+
+	// Only show the badge with a "Paid for by" label on the FIRST card of a paid front, aka as Labs front.
+	const isTheFirstContainerOnAPaidFront = isOnPaidContentFront && index === 0;
+
+	const hasFrontBranding =
+		!isOnPaidContentFront && !!frontBranding && index === 0;
 
 	/**
 	 * id is being used to set the containerId in @see {ShowMore.importable.tsx}
@@ -560,8 +569,7 @@ export const FrontSection = ({
 						sectionHeadlineHeight,
 				]}
 			>
-				{/* Only show the badge with a "Paid for by" label on the FIRST card of a paid front */}
-				{isOnPaidContentFront && index === 0 ? (
+				{isTheFirstContainerOnAPaidFront ? (
 					<div css={titleStyle}>
 						<ContainerTitle
 							title={title}
@@ -599,9 +607,19 @@ export const FrontSection = ({
 					</div>
 				) : (
 					<>
-						{!isOnPaidContentFront &&
-							containerSponsorBranding === undefined && (
-								<Hide until="leftCol">
+						{frontHasEditorialOrDesignBadge && (
+							<Hide until="leftCol">
+								{badge && (
+									<Badge
+										imageSrc={badge.imageSrc}
+										href={badge.href}
+									/>
+								)}
+							</Hide>
+						)}
+						<div css={titleStyle}>
+							{frontHasEditorialOrDesignBadge && (
+								<Hide from="leftCol">
 									{badge && (
 										<Badge
 											imageSrc={badge.imageSrc}
@@ -610,18 +628,6 @@ export const FrontSection = ({
 									)}
 								</Hide>
 							)}
-						<div css={titleStyle}>
-							{!isOnPaidContentFront &&
-								containerSponsorBranding === undefined && (
-									<Hide from="leftCol">
-										{badge && (
-											<Badge
-												imageSrc={badge.imageSrc}
-												href={badge.href}
-											/>
-										)}
-									</Hide>
-								)}
 							<ContainerTitle
 								title={title}
 								fontColour={overrides?.text.container}
@@ -631,56 +637,39 @@ export const FrontSection = ({
 								showDateHeader={showDateHeader}
 								editionId={editionId}
 							/>
-							{!isOnPaidContentFront &&
-								!!frontEditionBranding &&
-								frontEditionBranding.branding &&
-								index === 0 && (
-									<>
-										<p css={labelStyles}>
-											{
-												frontEditionBranding.branding
-													.logo.label
-											}
-										</p>
-										<Badge
-											imageSrc={
-												frontEditionBranding.branding
-													.logo.src
-											}
-											href={
-												frontEditionBranding.branding
-													.logo.link
-											}
-										/>
-										<a
-											href={
-												frontEditionBranding.branding
-													.aboutThisLink
-											}
-											css={aboutThisLinkStyles}
-										>
-											About this content
-										</a>
-									</>
-								)}
-
-							{containerSponsorBranding && (
+							{hasFrontBranding && frontBranding?.branding && (
 								<>
 									<p css={labelStyles}>
-										{containerSponsorBranding.logo.label}
+										{frontBranding.branding.logo.label}
 									</p>
 									<Badge
 										imageSrc={
-											containerSponsorBranding.logo.src
+											frontBranding.branding.logo.src
 										}
-										href={
-											containerSponsorBranding.logo.link
-										}
+										href={frontBranding.branding.logo.link}
 									/>
 									<a
 										href={
-											containerSponsorBranding.aboutThisLink
+											frontBranding.branding.aboutThisLink
 										}
+										css={aboutThisLinkStyles}
+									>
+										About this content
+									</a>
+								</>
+							)}
+
+							{containerBranding && (
+								<>
+									<p css={labelStyles}>
+										{containerBranding.logo.label}
+									</p>
+									<Badge
+										imageSrc={containerBranding.logo.src}
+										href={containerBranding.logo.link}
+									/>
+									<a
+										href={containerBranding.aboutThisLink}
 										css={aboutThisLinkStyles}
 									>
 										About this content

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -763,9 +763,9 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 								index={index}
 								targetedTerritory={collection.targetedTerritory}
 								hasPageSkin={hasPageSkin}
-								frontEditionBranding={frontEditionBranding}
+								frontBranding={frontEditionBranding}
 								discussionApiUrl={front.config.discussionApiUrl}
-								containerSponsorBranding={
+								containerBranding={
 									collection.sponsoredContentBranding
 								}
 							>

--- a/dotcom-rendering/src/model/decideCollectionBranding.ts
+++ b/dotcom-rendering/src/model/decideCollectionBranding.ts
@@ -17,6 +17,7 @@ export const decideCollectionBranding = (
 			(branding) =>
 				branding.sponsorName === allCardsBranding[0]?.sponsorName,
 		);
+
 	const shouldHaveSponsorBranding =
 		allCardsHaveSponsoredBranding && allCardsHaveTheSameSponsor;
 

--- a/dotcom-rendering/src/model/decideSponsoredContentBranding.test.ts
+++ b/dotcom-rendering/src/model/decideSponsoredContentBranding.test.ts
@@ -1,0 +1,120 @@
+import type { Branding } from '../types/branding';
+import { decideSponsoredContentBranding } from './decideSponsoredContentBranding';
+
+const editionBrandingWithSponsor: Branding = {
+	brandingType: {
+		name: 'sponsored',
+	},
+	sponsorName: 'guardian.org',
+	logo: {
+		src: 'https://static.theguardian.com/commercial/sponsor/16/Mar/2022/1e17c6f8-8114-44e9-8e10-02b8e5c6b929-theguardianorg badge.png',
+		dimensions: {
+			width: 280,
+			height: 180,
+		},
+		link: 'https://www.theguardian.com/global-development/2021/feb/21/about-the-rights-and-freedom-series',
+		label: 'Supported by',
+	},
+	logoForDarkBackground: {
+		src: 'https://static.theguardian.com/commercial/sponsor/16/Mar/2022/2cb64c63-e09c-4877-90ee-b5fe4eac7fc6-44d00539-51bd-4749-a16a-7dde8ff8e19b-a060074a-c6d4-4e6e-b33a-8f4930d5617c-g.org_hc.png',
+		dimensions: {
+			width: 280,
+			height: 180,
+		},
+		link: 'https://www.theguardian.com/global-development/2021/feb/21/about-the-rights-and-freedom-series',
+		label: 'Supported by',
+	},
+	aboutThisLink:
+		'https://www.theguardian.com/global-development/2021/feb/21/about-the-rights-and-freedom-series',
+};
+
+describe('decideSponsoredContentBranding', () => {
+	it('returns sponsored branding if all cards in a collection have sponsored branding, they have the same sponsor and front has the same branding', () => {
+		expect(
+			decideSponsoredContentBranding(
+				4,
+				[
+					editionBrandingWithSponsor,
+					editionBrandingWithSponsor,
+					editionBrandingWithSponsor,
+					editionBrandingWithSponsor,
+				],
+				true,
+				'fixed/small/slow-IV',
+			),
+		).toEqual(editionBrandingWithSponsor);
+	});
+
+	it('returns undefined if at least one card in the collection does not have sponsored branding', () => {
+		expect(
+			decideSponsoredContentBranding(
+				4,
+				Array(3).fill(editionBrandingWithSponsor),
+				false,
+				'fixed/small/slow-IV',
+			),
+		).toEqual(undefined);
+	});
+
+	it('returns undefined if at least one card in the collection has different sponsor from the rest', () => {
+		const editionBrandingWithDifferentSponsor: Branding = {
+			brandingType: {
+				name: 'sponsored',
+			},
+			sponsorName: 'Bertha Foundation',
+			logo: {
+				src: 'https://static.theguardian.com/commercial/sponsor/28/Mar/2017/d1105d96-b067-4091-81ce-02f7c7c24173-Logo.png',
+				dimensions: {
+					width: 108,
+					height: 45,
+				},
+				link: 'http://www.berthafoundation.org/',
+				label: 'Supported by',
+			},
+			logoForDarkBackground: {
+				src: 'https://static.theguardian.com/commercial/sponsor/28/Mar/2017/8aabe16e-fd35-4f3c-a39b-3ec149877f56-Logo.png',
+				dimensions: {
+					width: 108,
+					height: 45,
+				},
+				link: 'http://www.berthafoundation.org/',
+				label: 'Supported by',
+			},
+			aboutThisLink:
+				'https://www.theguardian.com/info/2016/aug/31/about-guardian-bertha-documentary-partnership',
+		};
+
+		expect(
+			decideSponsoredContentBranding(
+				4,
+				Array(3)
+					.fill(editionBrandingWithSponsor)
+					.fill(editionBrandingWithDifferentSponsor),
+				false,
+				'fixed/small/slow-IV',
+			),
+		).toEqual(undefined);
+	});
+
+	it('returns undefined if front does not have the same branding as the cards', () => {
+		expect(
+			decideSponsoredContentBranding(
+				4,
+				Array(4).fill(editionBrandingWithSponsor),
+				false,
+				'fixed/small/slow-IV',
+			),
+		).toEqual(undefined);
+	});
+
+	it('returns undefined if the container is a thrasher', () => {
+		expect(
+			decideSponsoredContentBranding(
+				4,
+				Array(4).fill(editionBrandingWithSponsor),
+				true,
+				'fixed/thrasher',
+			),
+		).toEqual(undefined);
+	});
+});

--- a/dotcom-rendering/src/model/decideSponsoredContentBranding.ts
+++ b/dotcom-rendering/src/model/decideSponsoredContentBranding.ts
@@ -1,9 +1,11 @@
 import type { Branding } from '../types/branding';
+import type { DCRContainerType } from '../types/front';
 
 export const decideSponsoredContentBranding = (
 	collectionsLength: number,
 	allCardsBranding: Branding[],
 	editionHasBranding: boolean,
+	collectionType: DCRContainerType,
 ): Branding | undefined => {
 	const allCardsHaveBranding = collectionsLength === allCardsBranding.length;
 
@@ -19,7 +21,10 @@ export const decideSponsoredContentBranding = (
 				branding.sponsorName === allCardsBranding[0]?.sponsorName,
 		);
 
+	const isNotAThrasher = collectionType !== 'fixed/thrasher';
+
 	const shouldHaveSponsorBranding =
+		isNotAThrasher &&
 		editionHasBranding &&
 		allCardsHaveSponsoredBranding &&
 		allCardsHaveTheSameSponsor;

--- a/dotcom-rendering/src/model/decideSponsoredContentBranding.ts
+++ b/dotcom-rendering/src/model/decideSponsoredContentBranding.ts
@@ -1,8 +1,9 @@
 import type { Branding } from '../types/branding';
 
-export const decideCollectionBranding = (
+export const decideSponsoredContentBranding = (
 	collectionsLength: number,
 	allCardsBranding: Branding[],
+	editionHasBranding: boolean,
 ): Branding | undefined => {
 	const allCardsHaveBranding = collectionsLength === allCardsBranding.length;
 
@@ -19,7 +20,9 @@ export const decideCollectionBranding = (
 		);
 
 	const shouldHaveSponsorBranding =
-		allCardsHaveSponsoredBranding && allCardsHaveTheSameSponsor;
+		editionHasBranding &&
+		allCardsHaveSponsoredBranding &&
+		allCardsHaveTheSameSponsor;
 
 	return shouldHaveSponsorBranding ? allCardsBranding[0] : undefined;
 };

--- a/dotcom-rendering/src/model/enhanceCollections.ts
+++ b/dotcom-rendering/src/model/enhanceCollections.ts
@@ -7,8 +7,8 @@ import type {
 	FEFrontCard,
 } from '../types/front';
 import { decideEditorialBadge, decidePaidContentBadge } from './decideBadge';
-import { decideCollectionBranding } from './decideCollectionBranding';
 import { decideContainerPalette } from './decideContainerPalette';
+import { decideSponsoredContentBranding } from './decideSponsoredContentBranding';
 import { enhanceCards } from './enhanceCards';
 import { enhanceTreats } from './enhanceTreats';
 import { groupCards } from './groupCards';
@@ -50,17 +50,17 @@ export const enhanceCollections = ({
 	editionId,
 	pageId,
 	discussionApiUrl,
+	editionHasBranding,
 	onPageDescription,
 	isPaidContent,
-	isEditionBranded,
 }: {
 	collections: FECollectionType[];
 	editionId: EditionId;
 	pageId: string;
 	discussionApiUrl: string;
+	editionHasBranding: boolean;
 	onPageDescription?: string;
 	isPaidContent?: boolean;
-	isEditionBranded?: boolean;
 }): DCRCollectionType[] => {
 	return collections.filter(isSupported).map((collection, index) => {
 		const { id, displayName, collectionType, hasMore, href, description } =
@@ -103,6 +103,11 @@ export const enhanceCollections = ({
 					? allBranding
 					: undefined,
 			),
+			sponsoredContentBranding: decideSponsoredContentBranding(
+				allCards.length,
+				allBranding,
+				editionHasBranding,
+			),
 			grouped: groupCards(
 				collectionType,
 				collection.curated,
@@ -134,9 +139,6 @@ export const enhanceCollections = ({
 			},
 			canShowMore: hasMore && !collection.config.hideShowMore,
 			targetedTerritory: collection.targetedTerritory,
-			sponsoredContentBranding: isEditionBranded
-				? decideCollectionBranding(allCards.length, allBranding)
-				: undefined,
 		};
 	});
 };

--- a/dotcom-rendering/src/model/enhanceCollections.ts
+++ b/dotcom-rendering/src/model/enhanceCollections.ts
@@ -107,6 +107,7 @@ export const enhanceCollections = ({
 				allCards.length,
 				allBranding,
 				editionHasBranding,
+				collectionType,
 			),
 			grouped: groupCards(
 				collectionType,

--- a/dotcom-rendering/src/model/enhanceCollections.ts
+++ b/dotcom-rendering/src/model/enhanceCollections.ts
@@ -52,6 +52,7 @@ export const enhanceCollections = ({
 	discussionApiUrl,
 	onPageDescription,
 	isPaidContent,
+	isEditionBranded,
 }: {
 	collections: FECollectionType[];
 	editionId: EditionId;
@@ -59,6 +60,7 @@ export const enhanceCollections = ({
 	discussionApiUrl: string;
 	onPageDescription?: string;
 	isPaidContent?: boolean;
+	isEditionBranded?: boolean;
 }): DCRCollectionType[] => {
 	return collections.filter(isSupported).map((collection, index) => {
 		const { id, displayName, collectionType, hasMore, href, description } =
@@ -132,10 +134,9 @@ export const enhanceCollections = ({
 			},
 			canShowMore: hasMore && !collection.config.hideShowMore,
 			targetedTerritory: collection.targetedTerritory,
-			sponsoredContentBranding: decideCollectionBranding(
-				allCards.length,
-				allBranding,
-			),
+			sponsoredContentBranding: isEditionBranded
+				? decideCollectionBranding(allCards.length, allBranding)
+				: undefined,
 		};
 	});
 };

--- a/dotcom-rendering/src/server/index.front.web.ts
+++ b/dotcom-rendering/src/server/index.front.web.ts
@@ -18,6 +18,13 @@ import { renderFront, renderTagFront } from './render.front.web';
 
 const enhanceFront = (body: unknown): DCRFrontType => {
 	const data: FEFrontType = validateAsFrontType(body);
+	const isEditionBranded =
+		!!data.pressedPage.frontProperties.commercial.editionBrandings.find(
+			(editionBranding) =>
+				editionBranding.edition.id === data.editionId &&
+				!!editionBranding.branding,
+		);
+
 	return {
 		...data,
 		webTitle: `${
@@ -33,6 +40,7 @@ const enhanceFront = (body: unknown): DCRFrontType => {
 					data.pressedPage.frontProperties.onPageDescription,
 				isPaidContent: data.config.isPaidContent,
 				discussionApiUrl: data.config.discussionApiUrl,
+				isEditionBranded,
 			}),
 		},
 		mostViewed: data.mostViewed.map((trail) => decideTrail(trail)),

--- a/dotcom-rendering/src/server/index.front.web.ts
+++ b/dotcom-rendering/src/server/index.front.web.ts
@@ -18,7 +18,7 @@ import { renderFront, renderTagFront } from './render.front.web';
 
 const enhanceFront = (body: unknown): DCRFrontType => {
 	const data: FEFrontType = validateAsFrontType(body);
-	const isEditionBranded =
+	const editionHasBranding = () =>
 		!!data.pressedPage.frontProperties.commercial.editionBrandings.find(
 			(editionBranding) =>
 				editionBranding.edition.id === data.editionId &&
@@ -40,7 +40,7 @@ const enhanceFront = (body: unknown): DCRFrontType => {
 					data.pressedPage.frontProperties.onPageDescription,
 				isPaidContent: data.config.isPaidContent,
 				discussionApiUrl: data.config.discussionApiUrl,
-				isEditionBranded,
+				editionHasBranding: editionHasBranding(),
 			}),
 		},
 		mostViewed: data.mostViewed.map((trail) => decideTrail(trail)),


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

Closes https://github.com/guardian/dotcom-rendering/issues/8805
## Background

`editionBranding` exists on 2 levels of the JSON DCR receives:

* The whole front (`pressedPage.frontProperties.commercial.editionBrandings`)
<img width="757" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/19683595/790ac317-c5a0-4f58-906a-30514db6d014"> 


* Each card (`card.properties.editionBrandings`)
<img width="1679" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/19683595/f10a8cea-0a5b-461f-8fdf-5a19d3d4114d">


https://github.com/guardian/dotcom-rendering/pull/8764 and https://github.com/guardian/dotcom-rendering/pull/8801 introduced "Sponsored by" badges on the container level if all the cards in the collection have:

1. branding of sponsored type
2. the same sponsor

## What does this change?
* This PR adds a 3rd condition: `editionBranding` on the front level must be the same  as `editionBranding` in the cards level. If it doesn't exist, as it's the case for `/au` front, we don't show the badge on the container.
* Refactors a bit the logic in `FrontSection` to improve readability
* Fix: Re-introduces badge in a paid front (Labs front) (disappeared in #8813)

## Why?
We need to be able to label our [content with funding from outside parties](https://www.theguardian.com/info/2016/jan/25/content-funding) correctly.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/f4544408-e13f-4104-852b-d71e35a38db5) | ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/0d743f5c-b1cd-475f-8128-607586fa7909) |
| ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/f6a558a9-e103-4ec9-b7f6-b670fa655e62) | ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/b74b9de7-199c-4d56-91dd-497f59c6d53e) |

We still show "Sponsored by" when front has the same `editionBranding` as the cards of a container, e.g. `/world/series/guardian-bertha-documentaries`

* Front `editionBranding`
<img width="1711" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/19683595/868510e2-1deb-4722-8673-711d4bffd15f">

* Cards `editionBranding`
<img width="1641" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/19683595/d3849c10-31c1-41d5-80b2-0eaf892e7cc4">

| Before      | After      |
| ----------- | ---------- |
| ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/48ca5cb0-2452-443e-bd09-19304da90710) | ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/48ca5cb0-2452-443e-bd09-19304da90710) |


Also, things still look good in the other types of badges:

* Front badge in sponsored front
![image](https://github.com/guardian/dotcom-rendering/assets/19683595/e6b6bfbe-3d02-46e8-8921-3eead9d902f4)
 
* Container badge in sponsored container
![image](https://github.com/guardian/dotcom-rendering/assets/19683595/eda566e5-8cef-44fc-abe3-55d13929399b)

* Design / Editorial badges
![image](https://github.com/guardian/dotcom-rendering/assets/19683595/68fe020e-e345-475f-9115-a8cdfe39d70a)



[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
