### PR TITLE
Memoize asset manifest retrieval

### DIFF
--- a/dotcom-rendering/src/lib/assets.test.ts
+++ b/dotcom-rendering/src/lib/assets.test.ts
@@ -1,13 +1,18 @@
+import { readFileSync } from 'node:fs';
 import { BUILD_VARIANT } from '../../scripts/webpack/bundles';
 import {
 	APPS_SCRIPT,
 	decideAssetOrigin,
 	getModulesBuild,
+	getPathFromManifest,
 	WEB,
 	WEB_LEGACY_SCRIPT,
 	WEB_SCHEDULED_SCRIPT,
 	WEB_VARIANT_SCRIPT,
 } from './assets';
+
+jest.mock('node:fs');
+jest.mock('node:path');
 
 describe('decideAssetOrigin for stage', () => {
 	it('PROD', () => {
@@ -78,6 +83,38 @@ describe('regular expression to match files', () => {
 		expect(
 			'https://assets.guim.co.uk/assets/ophan.web.eb74205c979f58659ed7.js?http3=true',
 		).toMatch(WEB);
+	});
+});
+
+describe('getPathFromManifest', () => {
+	beforeEach(() => {
+		const assetHash = `{
+			"7305.web.js": "7305.web.8cdc05567d98ebd9f67e.js",
+			"356.web.js": "356.web.0a1bbdf8c7a5e5826b7c.js"
+		}`;
+		(readFileSync as jest.Mock).mockReturnValue(assetHash);
+	});
+
+	afterEach(() => {
+		jest.resetAllMocks();
+	});
+
+	it('returns correct hashed asset (1)', () => {
+		expect(getPathFromManifest('web', '7305.web.js')).toBe(
+			'/assets/7305.web.8cdc05567d98ebd9f67e.js',
+		);
+	});
+
+	it('returns correct hashed asset (2)', () => {
+		expect(getPathFromManifest('web', '356.web.js')).toBe(
+			'/assets/356.web.0a1bbdf8c7a5e5826b7c.js',
+		);
+	});
+
+	it('throws an error when the hashed asset cant be found', () => {
+		expect(() => getPathFromManifest('web', 'foo.bar.js')).toThrow(
+			'Missing manifest for foo.bar.js',
+		);
 	});
 });
 

--- a/dotcom-rendering/src/lib/assets.ts
+++ b/dotcom-rendering/src/lib/assets.ts
@@ -8,6 +8,7 @@ import {
 	ophanEsm,
 } from '../../scripts/webpack/bundles';
 import type { ServerSideTests, Switches } from '../types/config';
+import { memoize } from './memoize';
 
 interface AssetHash {
 	[key: string]: string;
@@ -50,13 +51,14 @@ const isAssetHash = (manifest: unknown): manifest is AssetHash =>
 		([key, value]) => isString(key) && isString(value),
 	);
 
-const getManifest = (path: string): AssetHash => {
+const getManifest = memoize((path: string): AssetHash => {
 	try {
 		const assetHash: unknown = JSON.parse(
 			readFileSync(resolve(__dirname, path), { encoding: 'utf-8' }),
 		);
-		if (!isAssetHash(assetHash))
+		if (!isAssetHash(assetHash)) {
 			throw new Error('Not a valid AssetHash type');
+		}
 
 		return assetHash;
 	} catch (e) {
@@ -64,7 +66,7 @@ const getManifest = (path: string): AssetHash => {
 		console.error('Some filename lookups will fail');
 		return {};
 	}
-};
+});
 
 export type Build =
 	| 'apps'

--- a/dotcom-rendering/src/lib/memoize.test.ts
+++ b/dotcom-rendering/src/lib/memoize.test.ts
@@ -1,0 +1,29 @@
+import { memoize } from './memoize';
+
+describe('memoize', () => {
+	it('memoized function is only called once for each unique key', () => {
+		const f = jest.fn().mockImplementation(<T>(x: T) => ({
+			data: x,
+		}));
+
+		const memoizedF = memoize(f);
+
+		memoizedF('foo');
+		memoizedF('foo');
+		memoizedF('bar');
+		memoizedF('foo');
+		memoizedF('bar');
+		memoizedF('baz');
+		memoizedF('baz');
+
+		expect(f).toHaveBeenCalledTimes(3);
+
+		expect(f).toHaveBeenNthCalledWith(1, 'foo');
+		expect(f).toHaveBeenNthCalledWith(2, 'bar');
+		expect(f).toHaveBeenNthCalledWith(3, 'baz');
+
+		expect(f).toHaveNthReturnedWith(1, { data: 'foo' });
+		expect(f).toHaveNthReturnedWith(2, { data: 'bar' });
+		expect(f).toHaveNthReturnedWith(3, { data: 'baz' });
+	});
+});

--- a/dotcom-rendering/src/lib/memoize.ts
+++ b/dotcom-rendering/src/lib/memoize.ts
@@ -1,0 +1,17 @@
+/**
+ * Cache the results of calling a function with string keys
+ */
+export const memoize = <T>(f: (key: string) => T): ((key: string) => T) => {
+	const cache: {
+		[key: string]: T;
+	} = {};
+	return (key: string): T => {
+		const memoized = cache[key];
+		if (memoized !== undefined) {
+			return memoized;
+		}
+		const v = f(key);
+		cache[key] = v;
+		return v;
+	};
+};

--- a/dotcom-rendering/src/lib/memoize.ts
+++ b/dotcom-rendering/src/lib/memoize.ts
@@ -1,17 +1,15 @@
 /**
- * Cache the results of calling a function with string keys
+ * Cache the results of calling an expensive function
  */
-export const memoize = <T>(f: (key: string) => T): ((key: string) => T) => {
-	const cache: {
-		[key: string]: T;
-	} = {};
-	return (key: string): T => {
-		const memoized = cache[key];
+export const memoize = <K, V>(f: (key: K) => V): ((key: K) => V) => {
+	const cache: Map<K, V> = new Map();
+	return (key: K): V => {
+		const memoized = cache.get(key);
 		if (memoized !== undefined) {
 			return memoized;
 		}
-		const v = f(key);
-		cache[key] = v;
-		return v;
+		const value = f(key);
+		cache.set(key, value);
+		return value;
 	};
 };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

This PR adds a simple memoization function to DCR, in order to cache the result of expensive operations (keyed with strings here for simplicity).

We then use this `memoize` function to cache the results of reading `manifest.*.json` files from disk.

## Why?

It should result in a small performance improvement. On the server, we're currently reading and parsing a couple of JSON files on every render (look out for the readFileSync calls):

![Screenshot 2023-09-12 at 14 33 59](https://github.com/guardian/dotcom-rendering/assets/8000415/053ad08d-9923-425b-9ba7-97bcfed9c224)

This PR caches the retrieval of these files, so we only ever read any given manifest once. This should avoid performing unnecessary IO during each render.

## Screenshots

In order to work out a rough speedup on my local machine, I borrowed the method from #8789 (thanks @arelra), using K6 to POST a snapshot of the UK front JSON data with 10 virtual users making requests for 20 seconds.

The numbers should be taken with a pinch of salt - I only ran them on my local machine, and didn't average over a number of sessions.

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/8000415/37f021aa-9c4a-4dbf-87b5-2e954b0fc829
[after]: https://github.com/guardian/dotcom-rendering/assets/8000415/fc311d5d-1b0a-45ed-841d-b37652389198
