### PR TITLE
Memoize function improvements

### DIFF
--- a/dotcom-rendering/src/lib/assets.ts
+++ b/dotcom-rendering/src/lib/assets.ts
@@ -8,7 +8,7 @@ import {
 	ophanEsm,
 } from '../../scripts/webpack/bundles';
 import type { ServerSideTests, Switches } from '../types/config';
-import { memoize } from './memoize';
+import { makeMemoizedFunction } from './memoize';
 
 interface AssetHash {
 	[key: string]: string;
@@ -51,7 +51,7 @@ const isAssetHash = (manifest: unknown): manifest is AssetHash =>
 		([key, value]) => isString(key) && isString(value),
 	);
 
-const getManifest = memoize((path: string): AssetHash => {
+const getManifest = makeMemoizedFunction((path: string): AssetHash => {
 	try {
 		const assetHash: unknown = JSON.parse(
 			readFileSync(resolve(__dirname, path), { encoding: 'utf-8' }),

--- a/dotcom-rendering/src/lib/memoize.test.ts
+++ b/dotcom-rendering/src/lib/memoize.test.ts
@@ -1,4 +1,4 @@
-import { memoize } from './memoize';
+import { makeMemoizedFunction } from './memoize';
 
 describe('memoize', () => {
 	it('memoized function is only called once for each unique key', () => {
@@ -6,7 +6,7 @@ describe('memoize', () => {
 			data: x,
 		}));
 
-		const memoizedF = memoize(f);
+		const memoizedF = makeMemoizedFunction(f);
 
 		memoizedF('foo');
 		memoizedF('foo');
@@ -25,5 +25,24 @@ describe('memoize', () => {
 		expect(f).toHaveNthReturnedWith(1, { data: 'foo' });
 		expect(f).toHaveNthReturnedWith(2, { data: 'bar' });
 		expect(f).toHaveNthReturnedWith(3, { data: 'baz' });
+	});
+
+	it('has separate caches for each memoized function', () => {
+		const f = jest.fn().mockImplementation((key: string) => ({
+			f: key,
+		}));
+		const g = jest.fn().mockImplementation((key: string) => ({
+			g: key,
+		}));
+
+		const memoizedF = makeMemoizedFunction(f);
+		const memoizedG = makeMemoizedFunction(g);
+
+		// If these two functions shared a cache they'd return the same value
+		expect(memoizedF('input')).toStrictEqual({ f: 'input' });
+		expect(memoizedG('input')).toStrictEqual({ g: 'input' });
+
+		expect(f).toHaveBeenCalledTimes(1);
+		expect(g).toHaveBeenCalledTimes(1);
 	});
 });

--- a/dotcom-rendering/src/lib/memoize.ts
+++ b/dotcom-rendering/src/lib/memoize.ts
@@ -1,7 +1,9 @@
 /**
  * Cache the results of calling an expensive function
  */
-export const memoize = <K, V>(f: (key: K) => V): ((key: K) => V) => {
+export const makeMemoizedFunction = <K, V>(
+	f: (key: K) => V,
+): ((key: K) => V) => {
 	const cache: Map<K, V> = new Map();
 	return (key: K): V => {
 		const memoized = cache.get(key);


### PR DESCRIPTION
## What does this change?

Follow up to https://github.com/guardian/dotcom-rendering/pull/8819.

- Rename `memoize` to `makeMemoizedFunction`, to make it clearer that it initialises a new cache each time.
- Add a test that checks that two separate calls to the function initialise two distinct caches.

## Why?

Clarity around how this function works.