### PR TITLE
Hide fronts banner slots when a pageskin is running

### DIFF
--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -218,15 +218,20 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 		abTests.europeNetworkFrontVariant === 'variant' ||
 		switches['europeNetworkFrontSwitch'] === true;
 
+	const renderAds = canRenderAds(front);
+
+	const hasPageSkin = hasPageSkinConfig && renderAds;
+
 	const isInNetworkFrontsBannerTest =
 		!!switches.frontsBannerAdsDcr &&
+		!hasPageSkin &&
 		abTests.frontsBannerAdsDcrVariant === 'variant' &&
 		Object.keys(networkFrontsBannerAdCollections).includes(
 			front.config.pageId,
 		);
-
 	const isInSectionFrontsBannerTest =
 		!!switches.sectionFrontsBannerAds &&
+		!hasPageSkin &&
 		abTests.sectionFrontsBannerAdsVariant === 'variant' &&
 		Object.keys(sectionFrontsBannerAdCollections).includes(
 			front.config.pageId,
@@ -242,10 +247,6 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 	const merchHighPosition = getMerchHighPosition(
 		front.pressedPage.collections.length,
 	);
-
-	const renderAds = canRenderAds(front);
-
-	const hasPageSkin = hasPageSkinConfig && renderAds;
 
 	const mobileAdPositions = renderAds
 		? getMobileAdPositions(front.pressedPage.collections, merchHighPosition)

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -99,7 +99,10 @@ export const decideAdSlot = (
 		collectionCount > minContainers &&
 		index === getMerchHighPosition(collectionCount)
 	) {
-		if (isInNetworkFrontsBannerTest || isInSectionFrontsBannerTest) {
+		if (
+			(isInNetworkFrontsBannerTest || isInSectionFrontsBannerTest) &&
+			!hasPageSkin
+		) {
 			return (
 				<Hide from="desktop">
 					<AdSlot
@@ -147,6 +150,7 @@ export const decideFrontsBannerAdSlot = (
 ) => {
 	if (
 		!renderAds ||
+		hasPageSkin ||
 		!targetedCollections?.includes(collectionName) ||
 		isFirstContainer
 	) {
@@ -224,14 +228,12 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 
 	const isInNetworkFrontsBannerTest =
 		!!switches.frontsBannerAdsDcr &&
-		!hasPageSkin &&
 		abTests.frontsBannerAdsDcrVariant === 'variant' &&
 		Object.keys(networkFrontsBannerAdCollections).includes(
 			front.config.pageId,
 		);
 	const isInSectionFrontsBannerTest =
 		!!switches.sectionFrontsBannerAds &&
-		!hasPageSkin &&
 		abTests.sectionFrontsBannerAdsVariant === 'variant' &&
 		Object.keys(sectionFrontsBannerAdCollections).includes(
 			front.config.pageId,

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -99,10 +99,7 @@ export const decideAdSlot = (
 		collectionCount > minContainers &&
 		index === getMerchHighPosition(collectionCount)
 	) {
-		if (
-			(isInNetworkFrontsBannerTest || isInSectionFrontsBannerTest) &&
-			!hasPageSkin
-		) {
+		if (isInNetworkFrontsBannerTest || isInSectionFrontsBannerTest) {
 			return (
 				<Hide from="desktop">
 					<AdSlot


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Hide fronts banner slots when a pageskin is running

## Why?
Due to the pageskin, the slots display blank spaces, we can remove the slots when a pageskin is running server side.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/1731150/879d0dce-8564-470c-85d3-f1efa5d46b83
[after]: https://github.com/guardian/dotcom-rendering/assets/1731150/e6610c78-65cd-433d-bade-bbcdb0ebc536

