### PR TITLE
refactor: rename schema type for ad placeholder element

### DIFF
--- a/dotcom-rendering/src/lib/renderElement.tsx
+++ b/dotcom-rendering/src/lib/renderElement.tsx
@@ -464,7 +464,7 @@ export const renderElement = ({
 			};
 
 			return <EmailSignUpSwitcher {...emailSignUpProps} />;
-		case 'model.dotcomrendering.pageElements.AdPlaceholderSlot':
+		case 'model.dotcomrendering.pageElements.AdPlaceholderBlockElement':
 			// TODO - include ad placeholder slot component
 			// @see https://github.com/guardian/dotcom-rendering/pull/8808
 			return <></>;

--- a/dotcom-rendering/src/model/article-schema.json
+++ b/dotcom-rendering/src/model/article-schema.json
@@ -638,7 +638,7 @@
                     "$ref": "#/definitions/NewsletterSignupBlockElement"
                 },
                 {
-                    "$ref": "#/definitions/AdPlaceholderSlot"
+                    "$ref": "#/definitions/AdPlaceholderBlockElement"
                 },
                 {
                     "$ref": "#/definitions/NumberedTitleBlockElement"
@@ -2510,12 +2510,12 @@
                 "newsletter"
             ]
         },
-        "AdPlaceholderSlot": {
+        "AdPlaceholderBlockElement": {
             "type": "object",
             "properties": {
                 "_type": {
                     "type": "string",
-                    "const": "model.dotcomrendering.pageElements.AdPlaceholderSlot"
+                    "const": "model.dotcomrendering.pageElements.AdPlaceholderBlockElement"
                 },
                 "isSquare": {
                     "type": "boolean"

--- a/dotcom-rendering/src/model/block-schema.json
+++ b/dotcom-rendering/src/model/block-schema.json
@@ -169,7 +169,7 @@
                     "$ref": "#/definitions/NewsletterSignupBlockElement"
                 },
                 {
-                    "$ref": "#/definitions/AdPlaceholderSlot"
+                    "$ref": "#/definitions/AdPlaceholderBlockElement"
                 },
                 {
                     "$ref": "#/definitions/NumberedTitleBlockElement"
@@ -2041,12 +2041,12 @@
                 "newsletter"
             ]
         },
-        "AdPlaceholderSlot": {
+        "AdPlaceholderBlockElement": {
             "type": "object",
             "properties": {
                 "_type": {
                     "type": "string",
-                    "const": "model.dotcomrendering.pageElements.AdPlaceholderSlot"
+                    "const": "model.dotcomrendering.pageElements.AdPlaceholderBlockElement"
                 },
                 "isSquare": {
                     "type": "boolean"

--- a/dotcom-rendering/src/model/enhance-ad-placeholders.test.ts
+++ b/dotcom-rendering/src/model/enhance-ad-placeholders.test.ts
@@ -1,5 +1,5 @@
 import { blockMetaData } from '../../fixtures/manual/block-meta-data';
-import type { AdPlaceholderSlot, FEElement } from '../types/content';
+import type { AdPlaceholderBlockElement, FEElement } from '../types/content';
 import { enhanceAdPlaceholders } from './enhance-ad-placeholders';
 
 // Test helper functions
@@ -10,11 +10,12 @@ const getTestElements = (length: number): FEElement[] => {
 		elementId: 'mockId',
 		html: '<p>I am a paragraph</p>',
 	};
-	return Array(length).fill(textElement) as FEElement[];
+	return Array(length).fill(textElement);
 };
 
 const elementIsAdPlaceholder = (element: FEElement): boolean =>
-	element._type === 'model.dotcomrendering.pageElements.AdPlaceholderSlot';
+	element._type ===
+	'model.dotcomrendering.pageElements.AdPlaceholderBlockElement';
 
 const getElementsFromBlocks = (blocks: Block[]): FEElement[] =>
 	blocks.map((o) => o.elements).flat();
@@ -46,7 +47,7 @@ describe('Enhancing ad placeholders', () => {
 			const outputElements = getElementsFromBlocks(output);
 			const outputPlaceholders = outputElements.filter(
 				elementIsAdPlaceholder,
-			) as AdPlaceholderSlot[];
+			) as AdPlaceholderBlockElement[];
 
 			it(`should insert ${expectedPlaceholders} ad placeholder(s)`, () => {
 				expect(outputPlaceholders.length).toEqual(expectedPlaceholders);

--- a/dotcom-rendering/src/model/enhance-ad-placeholders.ts
+++ b/dotcom-rendering/src/model/enhance-ad-placeholders.ts
@@ -1,4 +1,4 @@
-import type { AdPlaceholderSlot, FEElement } from '../types/content';
+import type { AdPlaceholderBlockElement, FEElement } from '../types/content';
 
 /**
  * Positioning rules:
@@ -40,8 +40,8 @@ const insertPlaceholder = (
 	elements: FEElement[],
 	numberOfAdsInserted: number,
 ): FEElement[] => {
-	const placeholder: AdPlaceholderSlot = {
-		_type: 'model.dotcomrendering.pageElements.AdPlaceholderSlot',
+	const placeholder: AdPlaceholderBlockElement = {
+		_type: 'model.dotcomrendering.pageElements.AdPlaceholderBlockElement',
 		// We only insert square ads for the first ad in the article
 		isSquare: numberOfAdsInserted === 0,
 	};

--- a/dotcom-rendering/src/types/content.ts
+++ b/dotcom-rendering/src/types/content.ts
@@ -361,8 +361,8 @@ export interface NewsletterSignupBlockElement {
 	elementId?: string;
 }
 
-export interface AdPlaceholderSlot {
-	_type: 'model.dotcomrendering.pageElements.AdPlaceholderSlot';
+export interface AdPlaceholderBlockElement {
+	_type: 'model.dotcomrendering.pageElements.AdPlaceholderBlockElement';
 	isSquare: boolean;
 }
 
@@ -636,7 +636,7 @@ interface WitnessTypeBlockElement extends ThirdPartyEmbeddedContent {
 		| WitnessTypeDataText;
 }
 export type FEElement =
-	| AdPlaceholderSlot
+	| AdPlaceholderBlockElement
 	| AudioAtomBlockElement
 	| AudioBlockElement
 	| BlockquoteBlockElement


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Renames `AdPlaceholderSlot` to `AdPlaceholderBlockElement`.

## Why?

To follow style of other types defined in `content.ts`
Part of #8592 

