### PR TITLE
Don't show EU modal if the user will see the CMP banner

### DIFF
--- a/dotcom-rendering/src/components/EuropeLandingModal.importable.tsx
+++ b/dotcom-rendering/src/components/EuropeLandingModal.importable.tsx
@@ -14,11 +14,10 @@ import {
 	RadioGroup,
 	SvgCross,
 } from '@guardian/source-react-components';
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import type { EditionId } from '../lib/edition';
 import { getEditionFromId } from '../lib/edition';
 import { guard } from '../lib/guard';
-import { useOnce } from '../lib/useOnce';
 import { SvgFlagsInCircle } from './SvgFlagsInCircle';
 
 const modalShownKey = 'gu.euModalShown';
@@ -211,7 +210,7 @@ export const EuropeLandingModal = ({ edition }: Props) => {
 		}
 	}, [editionCookie, modalType]);
 
-	useOnce(() => {
+	useEffect(() => {
 		void cmp.willShowPrivacyMessage().then((willShowCmp) => {
 			// Don't show the EU modal if its the users first time visiting the site and they haven't
 			// seen the CMP banner yet.
@@ -219,7 +218,7 @@ export const EuropeLandingModal = ({ edition }: Props) => {
 				initialize();
 			}
 		});
-	}, []);
+	}, [initialize]);
 
 	const confirmNewEdition = (editionId: EditionId) => {
 		setCookie({

--- a/dotcom-rendering/src/components/EuropeLandingModal.importable.tsx
+++ b/dotcom-rendering/src/components/EuropeLandingModal.importable.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import { cmp } from '@guardian/consent-management-platform';
 import { getCookie, setCookie } from '@guardian/libs';
 import {
 	body,
@@ -13,7 +14,7 @@ import {
 	RadioGroup,
 	SvgCross,
 } from '@guardian/source-react-components';
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import type { EditionId } from '../lib/edition';
 import { getEditionFromId } from '../lib/edition';
 import { guard } from '../lib/guard';
@@ -185,7 +186,7 @@ export const EuropeLandingModal = ({ edition }: Props) => {
 		isValidEdition(editionCookie) ? editionCookie : edition,
 	);
 
-	useOnce(() => {
+	const initialize = useCallback(() => {
 		const europeModal = document.getElementById('europe-modal-dialog');
 		const modalShown = localStorage.getItem(modalShownKey);
 		if (
@@ -208,6 +209,16 @@ export const EuropeLandingModal = ({ edition }: Props) => {
 				});
 			}
 		}
+	}, [editionCookie, modalType]);
+
+	useOnce(() => {
+		void cmp.willShowPrivacyMessage().then((willShowCmp) => {
+			// Don't show the EU modal if its the users first time visiting the site and they haven't
+			// seen the CMP banner yet.
+			if (!willShowCmp) {
+				initialize();
+			}
+		});
 	}, []);
 
 	const confirmNewEdition = (editionId: EditionId) => {


### PR DESCRIPTION
## What does this change?

Don't show the EU modal banner if the user is going to see the CMP banner. Wait till next time they visit the site to avoid bombarding the user with things to click on in order to view our content.

<del>This PR doesn't check if the user has provided consent for the `gu.euModalShown` local storage value. It's still unclear whether this localStorage value will be a "essential" or not, which I think will impact how we check for consent for it.</del> It is being considered an essential cookie, therefore not optional and doesn't require us to specifically check for consent.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/21217225/1b6bf032-d492-4070-9f79-021cf375d9e8
[after]: https://github.com/guardian/dotcom-rendering/assets/21217225/96077854-bef2-41e0-b59b-8e8517f8ab00
