### PR TITLE
Add empty string for alt tag as fallback if alt prop is undefined

### DIFF
--- a/dotcom-rendering/src/components/CardPicture.tsx
+++ b/dotcom-rendering/src/components/CardPicture.tsx
@@ -119,7 +119,7 @@ export const CardPicture = ({ master, alt, imageSize, loading }: Props) => {
 			})}
 
 			<img
-				alt={alt}
+				alt={alt ?? ''}
 				src={fallbackSource.lowResUrl}
 				css={block}
 				loading={loading}


### PR DESCRIPTION
## What does this change?

Uses nullish coalescing to set the `alt` attribute of the `<img>` tag in `CardPicture` to an empty string, if the `alt` prop passed to the component is `undefined`.

## Why?

[All images should have an alt attribute set](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/alt#decorative_images) even if the value is an empty string:

> Images with no semantic meaning—such as those which are solely decorative—or of limited informational value, should have their alt attributes set to the empty string ("").

In an ideal world (imo) the `alt` prop passed to `CardPicture` would always be a string, and never `undefined`, because ideally we'd be making an active decision as to whether the image is of solely decorative value or not, further up in the content production pipeline. However, given that we can't guarantee that a value will have been set upstream, I think that falling back to an empty string represents an improvement.

**nb.** Do we know whether the card images in the Podcasts container (screenshotted below) _should_ have more informative alt text set for them? I would have expected them to, so it might be worth checking if the alt prop is going missing at some point in the rendering process, or whether it's missing upstream in the content production pipeline as well?

## Screenshots

<img width="1052" alt="before and after screenshots of the 'podcasts' container on UK front, alongside a devtools window, showing that the alt attribute is now present" src="https://github.com/guardian/dotcom-rendering/assets/37048459/72f5abe1-8f0b-410d-803e-e7a3c8171780">

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
