### PR TITLE
Use GU_EU_MODAL_SHOWN cookie to track if the EU modal has been shown

### DIFF
--- a/dotcom-rendering/src/components/EuropeLandingModal.importable.tsx
+++ b/dotcom-rendering/src/components/EuropeLandingModal.importable.tsx
@@ -20,7 +20,7 @@ import { guard } from '../lib/guard';
 import { useOnce } from '../lib/useOnce';
 import { SvgFlagsInCircle } from './SvgFlagsInCircle';
 
-const modalShownKey = 'gu.euModalShown';
+const modalShownCookie = 'GU_EU_MODAL_SHOWN';
 
 // Have not used margin as it will change the backdrop
 const dialogStyles = css`
@@ -187,14 +187,18 @@ export const EuropeLandingModal = ({ edition }: Props) => {
 
 	useOnce(() => {
 		const europeModal = document.getElementById('europe-modal-dialog');
-		const modalShown = localStorage.getItem(modalShownKey);
+		const modalShown = getCookie({ name: modalShownCookie });
 		if (
 			europeModal instanceof HTMLDialogElement &&
 			modalType !== 'NoModal' &&
 			!modalShown &&
 			editionCookie !== 'EUR'
 		) {
-			localStorage.setItem(modalShownKey, 'true');
+			setCookie({
+				name: modalShownCookie,
+				value: 'true',
+				daysToLive: 90,
+			});
 			europeModal.showModal();
 			europeModal.addEventListener('close', () => {
 				hideModal();


### PR DESCRIPTION
## What does this change?

Switch from using a localStorage value to a cookie for keeping track of whether a user has seen the EU friction screen / modal.

## Why?

We can set an expiry date using native on cookies which we were not able to do with localStorage. There is also approval to use this cookie in CMP

![image](https://github.com/guardian/dotcom-rendering/assets/21217225/7cee5ac9-6ed6-41dc-a4d4-1bd3fa6b9919)
