### PR TITLE
Style: updates fronts tags

### DIFF
--- a/dotcom-rendering/src/components/TrendingTopics.tsx
+++ b/dotcom-rendering/src/components/TrendingTopics.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { palette, textSans } from '@guardian/source-foundations';
+import { neutral, palette, textSans } from '@guardian/source-foundations';
 import { StraightLines } from '@guardian/source-react-components-development-kitchen';
 import type { FETagType } from '../types/tag';
 
@@ -8,29 +8,58 @@ type Props = {
 };
 
 const linkStyle = css`
+	${textSans.xsmall()};
+	border: 1px solid ${palette.neutral[20]};
+	border-radius: 12px;
+	padding: 2px 9px;
 	display: inline-block;
 	${textSans.xsmall({ lineHeight: 'loose' })}
 	text-decoration: none;
 	top: 0;
-	color: ${palette.neutral[7]};
-
-	/** All but first items */
-	&:nth-of-type(n + 2):before {
-		color: ${palette.neutral[86]};
-		pointer-events: none;
-		margin: 2.56px;
-		content: '/';
-	}
+	color: ${palette.neutral[20]};
 `;
 
 const topicLabel = css`
 	${textSans.xxsmall({ lineHeight: 'regular' })}
-	color: ${palette.neutral[60]};
+	color: ${palette.neutral[20]};
 `;
 
 const trendingTopicContainer = css`
 	padding-top: 30px;
 	padding-bottom: 20px;
+`;
+const listStyleNone = css`
+	list-style: none;
+	/* https://developer.mozilla.org/en-US/docs/Web/CSS/list-style#accessibility_concerns */
+	/* Needs double escape char: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#es2018_revision_of_illegal_escape_sequences */
+	li::before {
+		content: '\\200B'; /* Zero width space */
+		display: block;
+		height: 0;
+		width: 0;
+	}
+	display: flex;
+	flex-wrap: wrap;
+	gap: 1.5rem 0.25rem;
+	background-image: repeating-linear-gradient(
+			to bottom,
+			${neutral[100]} 0px,
+			${neutral[100]} 36px,
+			transparent 36px,
+			transparent 37px,
+			${neutral[100]} 37px,
+			${neutral[100]} 46px
+		),
+		repeating-linear-gradient(
+			to right,
+			${neutral[86]} 0px,
+			${neutral[86]} 3px,
+			transparent 3px,
+			transparent 5px
+		);
+	background-position: top;
+	background-repeat: no-repeat;
+	margin-top: 8px;
 `;
 
 export const TrendingTopics = ({ trendingTopics }: Props) => {
@@ -42,29 +71,34 @@ export const TrendingTopics = ({ trendingTopics }: Props) => {
 				`}
 				count={4}
 			/>
-			<div css={topicLabel}>Topics</div>
+			<div css={topicLabel}>Explore more on these topics</div>
 			{/* TODO: Add allpath link */}
-			{trendingTopics?.slice(0, 5).map((tag) => {
-				const section = trendingTopics
-					.filter((existingTag) => existingTag !== tag)
-					.find(
-						(existingTag) =>
-							existingTag.properties.webTitle ===
-							tag.properties.webTitle,
-					)?.properties.sectionName;
 
-				return (
-					<a
-						key={tag.properties.webTitle}
-						href={tag.properties.webUrl}
-						css={linkStyle}
-						data-link-name={`keyword: ${tag.properties.id}`}
-					>
-						{tag.properties.webTitle}
-						{!!section && ` (${section})`}
-					</a>
-				);
-			})}
+			<ul css={listStyleNone}>
+				{trendingTopics?.slice(0, 5).map((tag) => {
+					const section = trendingTopics
+						.filter((existingTag) => existingTag !== tag)
+						.find(
+							(existingTag) =>
+								existingTag.properties.webTitle ===
+								tag.properties.webTitle,
+						)?.properties.sectionName;
+
+					return (
+						<li key={tag.properties.id}>
+							<a
+								key={tag.properties.webTitle}
+								href={tag.properties.webUrl}
+								css={linkStyle}
+								data-link-name={`keyword: ${tag.properties.id}`}
+							>
+								{tag.properties.webTitle}
+								{!!section && ` (${section})`}
+							</a>
+						</li>
+					);
+				})}
+			</ul>
 		</div>
 	);
 };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Updates the styling of fronts tags to the new designs. 

## Why?
This is part of a wider body of parity work to align designs between apps and web.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |
| ![before2][] | ![after2][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/20416599/41c682f8-6ec2-41a2-9242-89e0f75da844
[after]: https://github.com/guardian/dotcom-rendering/assets/20416599/5ee5b4c6-a14c-4fe0-b037-dbf77bdd1577


[before2]: https://github.com/guardian/dotcom-rendering/assets/20416599/281f79c3-c762-4198-86d0-88a986084735
[after2]: https://github.com/guardian/dotcom-rendering/assets/20416599/1c414692-48a9-4940-a0ec-727520819e20

