### PR TITLE
Ash/europe front switch

### DIFF
--- a/dotcom-rendering/src/components/EuropeLandingModal.importable.tsx
+++ b/dotcom-rendering/src/components/EuropeLandingModal.importable.tsx
@@ -216,7 +216,7 @@ export const EuropeLandingModal = ({ edition }: Props) => {
 			europeModal.showModal();
 			europeModal.click();
 			europeModal.addEventListener('close', () => {
-				hideModal();
+				dismissModal();
 			});
 
 			document.documentElement.style.overflow = 'hidden';
@@ -247,17 +247,13 @@ export const EuropeLandingModal = ({ edition }: Props) => {
 			isCrossSubdomain: true,
 		});
 		if (editionId === edition) {
-			hideModal();
+			dismissModal();
 		} else {
 			window.location.replace(getEditionFromId(editionId).url);
 		}
 	};
 
 	const dismissModal = () => {
-		hideModal();
-	};
-
-	const hideModal = () => {
 		const europeModal = document.getElementById('europe-modal-dialog');
 		if (europeModal instanceof HTMLDialogElement) {
 			europeModal.close();

--- a/dotcom-rendering/src/components/EuropeLandingModal.importable.tsx
+++ b/dotcom-rendering/src/components/EuropeLandingModal.importable.tsx
@@ -188,6 +188,7 @@ export const getModalType = (): ModalType => {
 			return 'ModalDoYouWantToSwitch';
 		}
 	}
+
 	return 'NoModal';
 };
 
@@ -217,11 +218,15 @@ export const EuropeLandingModal = ({ edition }: Props) => {
 				value: 'true',
 				daysToLive: 90,
 			});
-			europeModal.showModal();
-			europeModal.click();
+			// Remove data-link-name from europeModal after first click so that no future clicks are recorded
+			europeModal.addEventListener('click', () => {
+				europeModal.attributes.removeNamedItem('data-link-name');
+			});
 			europeModal.addEventListener('close', () => {
 				dismissModal();
 			});
+			europeModal.showModal();
+			europeModal.click();
 
 			document.documentElement.style.overflow = 'hidden';
 			if (modalType === 'ModalSwitched') {

--- a/dotcom-rendering/src/components/EuropeLandingModal.importable.tsx
+++ b/dotcom-rendering/src/components/EuropeLandingModal.importable.tsx
@@ -218,15 +218,14 @@ export const EuropeLandingModal = ({ edition }: Props) => {
 				value: 'true',
 				daysToLive: 90,
 			});
-			// Remove data-link-name from europeModal after first click so that no future clicks are recorded
-			europeModal.addEventListener('click', () => {
-				europeModal.attributes.removeNamedItem('data-link-name');
-			});
 			europeModal.addEventListener('close', () => {
 				dismissModal();
 			});
 			europeModal.showModal();
-			europeModal.click();
+
+			// Dirty way of recording that the EU modal has been opened by creating
+			// a synthetic click which gets Ophan to record a "eu-modal : open" click event.
+			document.getElementById('eu-modal-synthetic-click')?.click();
 
 			document.documentElement.style.overflow = 'hidden';
 			if (modalType === 'ModalSwitched') {
@@ -271,9 +270,13 @@ export const EuropeLandingModal = ({ edition }: Props) => {
 		<dialog
 			css={dialogStyles}
 			id={'europe-modal-dialog'}
-			data-link-name={nestedOphanComponents('eu-modal', 'open')}
 			data-component={'eu-modal'}
 		>
+			<div
+				id="eu-modal-synthetic-click"
+				hidden={true}
+				data-link-name={nestedOphanComponents('eu-modal', 'open')}
+			/>
 			{!switchEdition ? (
 				<>
 					<div css={textStyles}>

--- a/dotcom-rendering/src/components/EuropeLandingModal.importable.tsx
+++ b/dotcom-rendering/src/components/EuropeLandingModal.importable.tsx
@@ -338,7 +338,7 @@ export const EuropeLandingModal = ({ edition }: Props) => {
 							</Button>
 						</div>
 					</div>
-					<div css={imageStyles}>
+					<div css={imageStyles} aria-hidden="true">
 						<SvgFlagsInCircle />
 					</div>
 				</>

--- a/dotcom-rendering/src/components/EuropeLandingModal.importable.tsx
+++ b/dotcom-rendering/src/components/EuropeLandingModal.importable.tsx
@@ -345,30 +345,35 @@ export const EuropeLandingModal = ({ edition }: Props) => {
 							label="Europe edition"
 							value="EUR"
 							onChange={() => setSelectedEdition('EUR')}
+							checked={selectedEdition === 'EUR'}
 						/>
 						<Radio
 							defaultChecked={selectedEdition === 'UK'}
 							label="UK edition"
 							value="UK"
 							onChange={() => setSelectedEdition('UK')}
+							checked={selectedEdition === 'UK'}
 						/>
 						<Radio
 							defaultChecked={selectedEdition === 'US'}
 							label="US edition"
 							value="US"
 							onChange={() => setSelectedEdition('US')}
+							checked={selectedEdition === 'US'}
 						/>
 						<Radio
 							defaultChecked={selectedEdition === 'AU'}
 							label="Australia edition"
 							value="AU"
 							onChange={() => setSelectedEdition('AU')}
+							checked={selectedEdition === 'AU'}
 						/>
 						<Radio
 							defaultChecked={selectedEdition === 'INT'}
 							label="International edition"
 							value="INT"
 							onChange={() => setSelectedEdition('INT')}
+							checked={selectedEdition === 'INT'}
 						/>
 					</RadioGroup>
 					<Button

--- a/dotcom-rendering/src/components/EuropeLandingModal.importable.tsx
+++ b/dotcom-rendering/src/components/EuropeLandingModal.importable.tsx
@@ -160,6 +160,7 @@ export const getModalType = (): ModalType => {
 	if (!geoCountryCookie) {
 		return 'NoModal';
 	}
+
 	if (
 		!editionCookie &&
 		!coe.includes(geoCountryCookie) &&
@@ -167,10 +168,12 @@ export const getModalType = (): ModalType => {
 	) {
 		return 'ModalDoYouWantToSwitch';
 	}
+
 	// If selected INT and not in COE show do u want to switch
 	if (editionCookie === 'INT' && !coe.includes(geoCountryCookie)) {
 		return 'ModalDoYouWantToSwitch';
 	}
+
 	// If in COE
 	if (coe.includes(geoCountryCookie)) {
 		if (
@@ -202,6 +205,7 @@ export const EuropeLandingModal = ({ edition }: Props) => {
 	const initialize = useCallback(() => {
 		const europeModal = document.getElementById('europe-modal-dialog');
 		const modalShown = getCookie({ name: modalShownCookie });
+
 		if (
 			europeModal instanceof HTMLDialogElement &&
 			modalType !== 'NoModal' &&
@@ -241,12 +245,9 @@ export const EuropeLandingModal = ({ edition }: Props) => {
 	}, [initialize]);
 
 	const confirmNewEdition = (editionId: EditionId) => {
-		setCookie({
-			name: 'GU_EDITION',
-			value: editionId,
-			isCrossSubdomain: true,
-		});
-		if (editionId === edition) {
+		// Always send EUR users to the Edition preference endpoint.
+		// We want them to be redirected to the /europe front.
+		if (editionId === edition && editionId !== 'EUR') {
 			dismissModal();
 		} else {
 			window.location.replace(getEditionFromId(editionId).url);
@@ -293,8 +294,7 @@ export const EuropeLandingModal = ({ edition }: Props) => {
 									)}
 									size={'small'}
 									onClick={() => {
-										dismissModal();
-										window.location.reload();
+										confirmNewEdition('EUR');
 									}}
 									cssOverrides={OKButtonStyles}
 								>


### PR DESCRIPTION
## What does this change?

 - When a reader presses "Ok, Thanks" they get sent to the switch edition endpoint instead of just setting a cookie using JS and reloading the page. We want them to eventually get redirected to the /europe front so we mayaswell use the existing infrastructure to change their Edition cookie too.
 - On the "Switch Edition" page, check the radio button of the users current edition.
 - Instead of applying `data-link-name` to the dialog element apply it to a hidden div instead. This avoids race conditions and accidentally recording multiple modal open events if the user clicks on parts of the dialog.
 - Apply `aria-hidden` to the europe logo image. This image is purely decorative and we don't want screen readers to try to understand it.