### PR TITLE
Fix Dialog element always being visible on Safari 10

### DIFF
--- a/dotcom-rendering/src/components/EuropeLandingModal.importable.tsx
+++ b/dotcom-rendering/src/components/EuropeLandingModal.importable.tsx
@@ -32,6 +32,7 @@ const dialogStyles = css`
 	&[open] {
 		display: flex;
 	}
+	display: none;
 	max-width: calc(100vw - 20px);
 	padding: 0;
 	width: 620px;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Add `display: none;' to the Dialog CSS. This is meant to be added by the dialog element itself, but it seems like support for `<dialog>` is pretty poor in a lot of older browsers, including ones that we're meant to be supporting.

https://caniuse.com/dialog

I've gone through browserstack and tested the EU modal against all our recommended browsers https://www.theguardian.com/help/recommended-browsers . For the most part they're all functional and behaving correctly. The only 2 issues are:

- On Safari 10 the Dialog is always visible (addressed by this PR)
- On Firefox 78 it doesn't show at all.

This change essentially causes any browsers that dont have `showModal()` to not render the modal

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
