### PR TITLE
Delete references to simpleReach switch

### DIFF
--- a/dotcom-rendering/cypress/fixtures/manual/standard-article.js
+++ b/dotcom-rendering/cypress/fixtures/manual/standard-article.js
@@ -1426,7 +1426,6 @@ export const Standard = {
 			brazeTaylorReport: false,
 			abConsentlessAds: true,
 			externalVideoEmbeds: true,
-			simpleReach: true,
 			abIntegrateIma: true,
 			callouts: true,
 			sentinelLogger: true,

--- a/dotcom-rendering/fixtures/config.js
+++ b/dotcom-rendering/fixtures/config.js
@@ -43,7 +43,6 @@ module.exports = {
 			mobileStickyPrebid: true,
 			breakingNews: true,
 			externalVideoEmbeds: true,
-			simpleReach: true,
 			carrotTrafficDriver: true,
 			geoMostPopular: true,
 			weAreHiring: true,

--- a/dotcom-rendering/fixtures/generated/articles/Analysis.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Analysis.ts
@@ -2239,7 +2239,6 @@ export const Analysis: FEArticleType = {
 			mobileStickyPrebid: true,
 			breakingNews: true,
 			externalVideoEmbeds: true,
-			simpleReach: true,
 			carrotTrafficDriver: true,
 			geoMostPopular: true,
 			weAreHiring: true,

--- a/dotcom-rendering/fixtures/generated/articles/Audio.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Audio.ts
@@ -2057,7 +2057,6 @@ export const Audio: FEArticleType = {
 			mobileStickyPrebid: true,
 			breakingNews: true,
 			externalVideoEmbeds: true,
-			simpleReach: true,
 			carrotTrafficDriver: true,
 			geoMostPopular: true,
 			weAreHiring: true,

--- a/dotcom-rendering/fixtures/generated/articles/Comment.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Comment.ts
@@ -1963,7 +1963,6 @@ export const Comment: FEArticleType = {
 			mobileStickyPrebid: true,
 			breakingNews: true,
 			externalVideoEmbeds: true,
-			simpleReach: true,
 			carrotTrafficDriver: true,
 			geoMostPopular: true,
 			weAreHiring: true,

--- a/dotcom-rendering/fixtures/generated/articles/Dead.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Dead.ts
@@ -4510,7 +4510,6 @@ export const Dead: FEArticleType = {
 			mobileStickyPrebid: true,
 			breakingNews: true,
 			externalVideoEmbeds: true,
-			simpleReach: true,
 			carrotTrafficDriver: true,
 			geoMostPopular: true,
 			weAreHiring: true,

--- a/dotcom-rendering/fixtures/generated/articles/Editorial.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Editorial.ts
@@ -1867,7 +1867,6 @@ export const Editorial: FEArticleType = {
 			mobileStickyPrebid: true,
 			breakingNews: true,
 			externalVideoEmbeds: true,
-			simpleReach: true,
 			carrotTrafficDriver: true,
 			geoMostPopular: true,
 			weAreHiring: true,

--- a/dotcom-rendering/fixtures/generated/articles/Explainer.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Explainer.ts
@@ -2749,7 +2749,6 @@ export const Explainer: FEArticleType = {
 			mobileStickyPrebid: true,
 			breakingNews: true,
 			externalVideoEmbeds: true,
-			simpleReach: true,
 			carrotTrafficDriver: true,
 			geoMostPopular: true,
 			weAreHiring: true,

--- a/dotcom-rendering/fixtures/generated/articles/Feature.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Feature.ts
@@ -2365,7 +2365,6 @@ export const Feature: FEArticleType = {
 			mobileStickyPrebid: true,
 			breakingNews: true,
 			externalVideoEmbeds: true,
-			simpleReach: true,
 			carrotTrafficDriver: true,
 			geoMostPopular: true,
 			weAreHiring: true,

--- a/dotcom-rendering/fixtures/generated/articles/Gallery.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Gallery.ts
@@ -2057,7 +2057,6 @@ export const Gallery: FEArticleType = {
 			mobileStickyPrebid: true,
 			breakingNews: true,
 			externalVideoEmbeds: true,
-			simpleReach: true,
 			carrotTrafficDriver: true,
 			geoMostPopular: true,
 			weAreHiring: true,

--- a/dotcom-rendering/fixtures/generated/articles/Interview.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Interview.ts
@@ -3674,7 +3674,6 @@ export const Interview: FEArticleType = {
 			mobileStickyPrebid: true,
 			breakingNews: true,
 			externalVideoEmbeds: true,
-			simpleReach: true,
 			carrotTrafficDriver: true,
 			geoMostPopular: true,
 			weAreHiring: true,

--- a/dotcom-rendering/fixtures/generated/articles/Labs.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Labs.ts
@@ -2844,7 +2844,6 @@ export const Labs: FEArticleType = {
 			mobileStickyPrebid: true,
 			breakingNews: true,
 			externalVideoEmbeds: true,
-			simpleReach: true,
 			carrotTrafficDriver: true,
 			geoMostPopular: true,
 			weAreHiring: true,

--- a/dotcom-rendering/fixtures/generated/articles/Letter.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Letter.ts
@@ -1731,7 +1731,6 @@ export const Letter: FEArticleType = {
 			mobileStickyPrebid: true,
 			breakingNews: true,
 			externalVideoEmbeds: true,
-			simpleReach: true,
 			carrotTrafficDriver: true,
 			geoMostPopular: true,
 			weAreHiring: true,

--- a/dotcom-rendering/fixtures/generated/articles/Live.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Live.ts
@@ -4510,7 +4510,6 @@ export const Live: FEArticleType = {
 			mobileStickyPrebid: true,
 			breakingNews: true,
 			externalVideoEmbeds: true,
-			simpleReach: true,
 			carrotTrafficDriver: true,
 			geoMostPopular: true,
 			weAreHiring: true,

--- a/dotcom-rendering/fixtures/generated/articles/MatchReport.ts
+++ b/dotcom-rendering/fixtures/generated/articles/MatchReport.ts
@@ -1862,7 +1862,6 @@ export const MatchReport: FEArticleType = {
 			mobileStickyPrebid: true,
 			breakingNews: true,
 			externalVideoEmbeds: true,
-			simpleReach: true,
 			carrotTrafficDriver: true,
 			geoMostPopular: true,
 			weAreHiring: true,

--- a/dotcom-rendering/fixtures/generated/articles/NewsletterSignup.ts
+++ b/dotcom-rendering/fixtures/generated/articles/NewsletterSignup.ts
@@ -1809,7 +1809,6 @@ export const NewsletterSignup: FEArticleType = {
 			mobileStickyPrebid: true,
 			breakingNews: true,
 			externalVideoEmbeds: true,
-			simpleReach: true,
 			carrotTrafficDriver: true,
 			geoMostPopular: true,
 			weAreHiring: true,

--- a/dotcom-rendering/fixtures/generated/articles/NumberedList.ts
+++ b/dotcom-rendering/fixtures/generated/articles/NumberedList.ts
@@ -7508,7 +7508,6 @@ export const NumberedList: FEArticleType = {
 			mobileStickyPrebid: true,
 			breakingNews: true,
 			externalVideoEmbeds: true,
-			simpleReach: true,
 			carrotTrafficDriver: true,
 			geoMostPopular: true,
 			weAreHiring: true,

--- a/dotcom-rendering/fixtures/generated/articles/PhotoEssay.ts
+++ b/dotcom-rendering/fixtures/generated/articles/PhotoEssay.ts
@@ -8849,7 +8849,6 @@ export const PhotoEssay: FEArticleType = {
 			mobileStickyPrebid: true,
 			breakingNews: true,
 			externalVideoEmbeds: true,
-			simpleReach: true,
 			carrotTrafficDriver: true,
 			geoMostPopular: true,
 			weAreHiring: true,

--- a/dotcom-rendering/fixtures/generated/articles/Picture.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Picture.ts
@@ -1767,7 +1767,6 @@ export const Picture: FEArticleType = {
 			mobileStickyPrebid: true,
 			breakingNews: true,
 			externalVideoEmbeds: true,
-			simpleReach: true,
 			carrotTrafficDriver: true,
 			geoMostPopular: true,
 			weAreHiring: true,

--- a/dotcom-rendering/fixtures/generated/articles/PrintShop.ts
+++ b/dotcom-rendering/fixtures/generated/articles/PrintShop.ts
@@ -1841,7 +1841,6 @@ export const PrintShop: FEArticleType = {
 			mobileStickyPrebid: true,
 			breakingNews: true,
 			externalVideoEmbeds: true,
-			simpleReach: true,
 			carrotTrafficDriver: true,
 			geoMostPopular: true,
 			weAreHiring: true,

--- a/dotcom-rendering/fixtures/generated/articles/Quiz.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Quiz.ts
@@ -2383,7 +2383,6 @@ export const Quiz: FEArticleType = {
 			mobileStickyPrebid: true,
 			breakingNews: true,
 			externalVideoEmbeds: true,
-			simpleReach: true,
 			carrotTrafficDriver: true,
 			geoMostPopular: true,
 			weAreHiring: true,

--- a/dotcom-rendering/fixtures/generated/articles/Recipe.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Recipe.ts
@@ -1941,7 +1941,6 @@ export const Recipe: FEArticleType = {
 			mobileStickyPrebid: true,
 			breakingNews: true,
 			externalVideoEmbeds: true,
-			simpleReach: true,
 			carrotTrafficDriver: true,
 			geoMostPopular: true,
 			weAreHiring: true,

--- a/dotcom-rendering/fixtures/generated/articles/Review.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Review.ts
@@ -2214,7 +2214,6 @@ export const Review: FEArticleType = {
 			mobileStickyPrebid: true,
 			breakingNews: true,
 			externalVideoEmbeds: true,
-			simpleReach: true,
 			carrotTrafficDriver: true,
 			geoMostPopular: true,
 			weAreHiring: true,

--- a/dotcom-rendering/fixtures/generated/articles/SpecialReport.ts
+++ b/dotcom-rendering/fixtures/generated/articles/SpecialReport.ts
@@ -2266,7 +2266,6 @@ export const SpecialReport: FEArticleType = {
 			mobileStickyPrebid: true,
 			breakingNews: true,
 			externalVideoEmbeds: true,
-			simpleReach: true,
 			carrotTrafficDriver: true,
 			geoMostPopular: true,
 			weAreHiring: true,

--- a/dotcom-rendering/fixtures/generated/articles/Standard.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Standard.ts
@@ -2057,7 +2057,6 @@ export const Standard: FEArticleType = {
 			mobileStickyPrebid: true,
 			breakingNews: true,
 			externalVideoEmbeds: true,
-			simpleReach: true,
 			carrotTrafficDriver: true,
 			geoMostPopular: true,
 			weAreHiring: true,

--- a/dotcom-rendering/fixtures/generated/articles/Video.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Video.ts
@@ -2057,7 +2057,6 @@ export const Video: FEArticleType = {
 			mobileStickyPrebid: true,
 			breakingNews: true,
 			externalVideoEmbeds: true,
-			simpleReach: true,
 			carrotTrafficDriver: true,
 			geoMostPopular: true,
 			weAreHiring: true,


### PR DESCRIPTION
## What does this change?
Removes references to the simpleReach switch in articles in Cypress fixtures.

## Why?
We're deleting the simpleReach switch in frontend as it's no longer used, so we also need to remove references to it in the code.