### PR TITLE
Add `DCRArticle` type to model an enhanced article

### DIFF
--- a/dotcom-rendering/src/components/ArticlePage.tsx
+++ b/dotcom-rendering/src/components/ArticlePage.tsx
@@ -6,7 +6,7 @@ import { DecideLayout } from '../layouts/DecideLayout';
 import { buildAdTargeting } from '../lib/ad-targeting';
 import { filterABTestSwitches } from '../model/enhance-switches';
 import type { NavType } from '../model/extract-nav';
-import type { FEArticleType } from '../types/frontend';
+import type { DCRArticle } from '../types/frontend';
 import type { RenderingTarget } from '../types/renderingTarget';
 import { AlreadyVisited } from './AlreadyVisited.importable';
 import { BrazeMessaging } from './BrazeMessaging.importable';
@@ -23,7 +23,7 @@ import { SetAdTargeting } from './SetAdTargeting.importable';
 import { SkipTo } from './SkipTo';
 
 interface BaseProps {
-	article: FEArticleType;
+	article: DCRArticle;
 	format: ArticleFormat;
 	renderingTarget: RenderingTarget;
 }

--- a/dotcom-rendering/src/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/layouts/CommentLayout.tsx
@@ -47,7 +47,7 @@ import { decidePalette } from '../lib/decidePalette';
 import { decideTrail } from '../lib/decideTrail';
 import { parse } from '../lib/slot-machine-flags';
 import type { NavType } from '../model/extract-nav';
-import type { FEArticleType } from '../types/frontend';
+import type { DCRArticle } from '../types/frontend';
 import { BannerWrapper, SendToBack, Stuck } from './lib/stickiness';
 
 const StandardGrid = ({
@@ -259,7 +259,7 @@ const mainMediaWrapper = css`
 `;
 
 interface Props {
-	article: FEArticleType;
+	article: DCRArticle;
 	NAV: NavType;
 	format: ArticleFormat;
 }

--- a/dotcom-rendering/src/layouts/DecideLayout.tsx
+++ b/dotcom-rendering/src/layouts/DecideLayout.tsx
@@ -1,7 +1,7 @@
 import { ArticleDesign, ArticleDisplay } from '@guardian/libs';
 import type { ArticleFormat } from '@guardian/libs';
 import type { NavType } from '../model/extract-nav';
-import type { FEArticleType } from '../types/frontend';
+import type { DCRArticle } from '../types/frontend';
 import type { RenderingTarget } from '../types/renderingTarget';
 import { CommentLayout } from './CommentLayout';
 import { FullPageInteractiveLayout } from './FullPageInteractiveLayout';
@@ -13,7 +13,7 @@ import { ShowcaseLayout } from './ShowcaseLayout';
 import { StandardLayout } from './StandardLayout';
 
 interface BaseProps {
-	article: FEArticleType;
+	article: DCRArticle;
 	format: ArticleFormat;
 	renderingTarget: RenderingTarget;
 }

--- a/dotcom-rendering/src/layouts/FullPageInteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/FullPageInteractiveLayout.tsx
@@ -32,12 +32,12 @@ import { renderElement } from '../lib/renderElement';
 import type { NavType } from '../model/extract-nav';
 import type { Switches } from '../types/config';
 import type { FEElement } from '../types/content';
-import type { FEArticleType } from '../types/frontend';
+import type { DCRArticle } from '../types/frontend';
 import { interactiveGlobalStyles } from './lib/interactiveLegacyStyling';
 import { BannerWrapper, Stuck } from './lib/stickiness';
 
 interface Props {
-	article: FEArticleType;
+	article: DCRArticle;
 	NAV: NavType;
 	format: ArticleFormat;
 }

--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -52,7 +52,7 @@ import { LABS_HEADER_HEIGHT } from '../lib/labs-constants';
 import { parse } from '../lib/slot-machine-flags';
 import type { NavType } from '../model/extract-nav';
 import type { FEElement } from '../types/content';
-import type { FEArticleType } from '../types/frontend';
+import type { DCRArticle } from '../types/frontend';
 import type { Palette } from '../types/palette';
 import { BannerWrapper, Stuck } from './lib/stickiness';
 
@@ -181,7 +181,7 @@ const stretchLines = css`
 `;
 
 interface Props {
-	article: FEArticleType;
+	article: DCRArticle;
 	NAV: NavType;
 	format: ArticleFormat;
 }

--- a/dotcom-rendering/src/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/InteractiveLayout.tsx
@@ -48,7 +48,7 @@ import { getContributionsServiceUrl } from '../lib/contributions';
 import { decidePalette } from '../lib/decidePalette';
 import { decideTrail } from '../lib/decideTrail';
 import type { NavType } from '../model/extract-nav';
-import type { FEArticleType } from '../types/frontend';
+import type { DCRArticle } from '../types/frontend';
 import {
 	interactiveGlobalStyles,
 	interactiveLegacyClasses,
@@ -201,7 +201,7 @@ const starWrapper = css`
 `;
 
 interface Props {
-	article: FEArticleType;
+	article: DCRArticle;
 	NAV: NavType;
 	format: ArticleFormat;
 }

--- a/dotcom-rendering/src/layouts/Layout.stories.tsx
+++ b/dotcom-rendering/src/layouts/Layout.stories.tsx
@@ -28,7 +28,7 @@ import { decideFormat } from '../lib/decideFormat';
 import { getCurrentPillar } from '../lib/layoutHelpers';
 import { mockRESTCalls } from '../lib/mockRESTCalls';
 import { extractNAV } from '../model/extract-nav';
-import type { FEArticleType } from '../types/frontend';
+import type { DCRArticle, FEArticleType } from '../types/frontend';
 import type { RenderingTarget } from '../types/renderingTarget';
 import { DecideLayout } from './DecideLayout';
 
@@ -65,7 +65,7 @@ const HydratedLayout = ({
 	serverArticle,
 	renderingTarget,
 }: {
-	serverArticle: FEArticleType;
+	serverArticle: DCRArticle;
 	renderingTarget: RenderingTarget;
 }) => {
 	const NAV = {

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -59,7 +59,7 @@ import { decidePalette } from '../lib/decidePalette';
 import { decideTrail } from '../lib/decideTrail';
 import { getZIndex } from '../lib/getZIndex';
 import type { NavType } from '../model/extract-nav';
-import type { FEArticleType } from '../types/frontend';
+import type { DCRArticle } from '../types/frontend';
 import type { RenderingTarget } from '../types/renderingTarget';
 import { BannerWrapper, SendToBack, Stuck } from './lib/stickiness';
 
@@ -242,7 +242,7 @@ const paddingBody = css`
 `;
 
 interface BaseProps {
-	article: FEArticleType;
+	article: DCRArticle;
 	format: ArticleFormat;
 	renderingTarget: RenderingTarget;
 }

--- a/dotcom-rendering/src/layouts/NewsletterSignupLayout.tsx
+++ b/dotcom-rendering/src/layouts/NewsletterSignupLayout.tsx
@@ -47,11 +47,11 @@ import { decidePalette } from '../lib/decidePalette';
 import { decideTrail } from '../lib/decideTrail';
 import { isValidUrl } from '../lib/isValidUrl';
 import type { NavType } from '../model/extract-nav';
-import type { FEArticleType } from '../types/frontend';
+import type { DCRArticle } from '../types/frontend';
 import { BannerWrapper, Stuck } from './lib/stickiness';
 
 type Props = {
-	article: FEArticleType;
+	article: DCRArticle;
 	NAV: NavType;
 	format: ArticleFormat;
 };
@@ -182,7 +182,7 @@ const regionalFocusDivStyle = css`
 	margin-bottom: ${space[2]}px;
 `;
 
-const getMainMediaCaptions = (article: FEArticleType): (string | undefined)[] =>
+const getMainMediaCaptions = (article: DCRArticle): (string | undefined)[] =>
 	article.mainMediaElements.map((el) =>
 		el._type === 'model.dotcomrendering.pageElements.ImageBlockElement'
 			? el.data.caption

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -49,7 +49,7 @@ import { decideTrail } from '../lib/decideTrail';
 import { decideLanguage, decideLanguageDirection } from '../lib/lang';
 import { parse } from '../lib/slot-machine-flags';
 import type { NavType } from '../model/extract-nav';
-import type { FEArticleType } from '../types/frontend';
+import type { DCRArticle } from '../types/frontend';
 import { BannerWrapper, SendToBack, Stuck } from './lib/stickiness';
 
 const ShowcaseGrid = ({
@@ -277,7 +277,7 @@ const PositionHeadline = ({
 };
 
 interface Props {
-	article: FEArticleType;
+	article: DCRArticle;
 	NAV: NavType;
 	format: ArticleFormat;
 }

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -56,7 +56,7 @@ import { decidePalette } from '../lib/decidePalette';
 import { decideTrail } from '../lib/decideTrail';
 import { parse } from '../lib/slot-machine-flags';
 import type { NavType } from '../model/extract-nav';
-import type { FEArticleType } from '../types/frontend';
+import type { DCRArticle } from '../types/frontend';
 import type { RenderingTarget } from '../types/renderingTarget';
 import { BannerWrapper, Stuck } from './lib/stickiness';
 
@@ -287,7 +287,7 @@ const starWrapper = css`
 `;
 
 interface Props {
-	article: FEArticleType;
+	article: DCRArticle;
 	format: ArticleFormat;
 	renderingTarget: RenderingTarget;
 }

--- a/dotcom-rendering/src/lib/canRenderAds.ts
+++ b/dotcom-rendering/src/lib/canRenderAds.ts
@@ -1,5 +1,5 @@
 import type { DCRFrontType } from '../types/front';
-import type { FEArticleType } from '../types/frontend';
+import type { DCRArticle } from '../types/frontend';
 import type { RenderingTarget } from '../types/renderingTarget';
 import type { DCRTagFrontType } from '../types/tagFront';
 
@@ -8,7 +8,7 @@ import type { DCRTagFrontType } from '../types/tagFront';
  * prevent ads from being displayed.
  */
 export const canRenderAds = (
-	pageData: FEArticleType | DCRFrontType | DCRTagFrontType,
+	pageData: DCRArticle | DCRFrontType | DCRTagFrontType,
 	renderingTarget?: RenderingTarget,
 ): boolean => {
 	if (renderingTarget === 'Apps') {

--- a/dotcom-rendering/src/lib/contributions.ts
+++ b/dotcom-rendering/src/lib/contributions.ts
@@ -3,7 +3,7 @@ import { getCookie } from '@guardian/libs';
 import type { HeaderPayload } from '@guardian/support-dotcom-components/dist/dotcom/src/types';
 import { useState } from 'react';
 import type { DCRFrontType } from '../types/front';
-import type { FEArticleType } from '../types/frontend';
+import type { DCRArticle } from '../types/frontend';
 import type { IdApiUserData } from './getIdapiUserData';
 import { getIdApiUserData } from './getIdapiUserData';
 import { eitherInOktaTestOrElse } from './useAuthStatus';
@@ -270,7 +270,7 @@ export const lazyFetchEmailWithTimeout =
 	};
 
 export const getContributionsServiceUrl = (
-	config: FEArticleType | DCRFrontType,
+	config: DCRArticle | DCRFrontType,
 ): string => process.env.SDC_URL ?? config.contributionsServiceUrl;
 
 type PurchaseInfo = HeaderPayload['targeting']['purchaseInfo'];

--- a/dotcom-rendering/src/lib/layoutHelpers.ts
+++ b/dotcom-rendering/src/lib/layoutHelpers.ts
@@ -1,10 +1,8 @@
 import type { Pillar } from '@guardian/libs';
-import type { FEArticleType } from '../types/frontend';
+import type { DCRArticle } from '../types/frontend';
 import { decideNavPillar } from './decideNavPillar';
 
-export const getCurrentPillar = (
-	article: FEArticleType,
-): Pillar | undefined => {
+export const getCurrentPillar = (article: DCRArticle): Pillar | undefined => {
 	const currentPillar =
 		(article.nav.currentPillarTitle &&
 			(article.nav.currentPillarTitle.toLowerCase() as LegacyPillar)) ||

--- a/dotcom-rendering/src/model/addImageIDs.ts
+++ b/dotcom-rendering/src/model/addImageIDs.ts
@@ -1,5 +1,5 @@
 import type { FEElement } from '../types/content';
-import type { FEArticleType } from '../types/frontend';
+import type { DCRArticle } from '../types/frontend';
 
 /**
  * This function adds the position property to each image
@@ -13,7 +13,7 @@ import type { FEArticleType } from '../types/frontend';
  *
  */
 export const addImageIDs = (
-	data: FEArticleType,
+	data: DCRArticle,
 ): { mainMediaElements: FEElement[]; blocks: Block[] } => {
 	// position needs to be defined outside the addPosition function otherwise
 	// it will get reset to 1 each time

--- a/dotcom-rendering/src/model/article-schema.json
+++ b/dotcom-rendering/src/model/article-schema.json
@@ -418,69 +418,8 @@
                 "theme"
             ]
         },
-        "tableOfContents": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/TableOfContentsItem"
-            }
-        },
         "canonicalUrl": {
             "type": "string"
-        },
-        "imagesForLightbox": {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "properties": {
-                    "masterUrl": {
-                        "type": "string"
-                    },
-                    "elementId": {
-                        "type": "string"
-                    },
-                    "width": {
-                        "type": "number"
-                    },
-                    "height": {
-                        "type": "number"
-                    },
-                    "position": {
-                        "type": "number"
-                    },
-                    "alt": {
-                        "type": "string"
-                    },
-                    "credit": {
-                        "type": "string"
-                    },
-                    "caption": {
-                        "type": "string"
-                    },
-                    "displayCredit": {
-                        "type": "boolean"
-                    },
-                    "title": {
-                        "type": "string"
-                    },
-                    "starRating": {
-                        "type": "number"
-                    },
-                    "blockId": {
-                        "description": "Used for liveblog images to generate a link back to the\noriginal post where the image was used",
-                        "type": "string"
-                    },
-                    "firstPublished": {
-                        "description": "Used to show when a liveblog image was posted",
-                        "type": "number"
-                    }
-                },
-                "required": [
-                    "elementId",
-                    "height",
-                    "masterUrl",
-                    "width"
-                ]
-            }
         },
         "showTableOfContents": {
             "type": "boolean"
@@ -4856,21 +4795,6 @@
                 {
                     "$ref": "#/definitions/CampaignFieldTextArea"
                 }
-            ]
-        },
-        "TableOfContentsItem": {
-            "type": "object",
-            "properties": {
-                "id": {
-                    "type": "string"
-                },
-                "title": {
-                    "type": "string"
-                }
-            },
-            "required": [
-                "id",
-                "title"
             ]
         }
     },

--- a/dotcom-rendering/src/model/extract-ga.ts
+++ b/dotcom-rendering/src/model/extract-ga.ts
@@ -1,11 +1,11 @@
 // All GA fields should  fall back to default values -
 
 import type { EditionId } from '../lib/edition';
-import type { FEArticleType } from '../types/frontend';
+import type { DCRArticle } from '../types/frontend';
 import type { TagType } from '../types/tag';
 
 const filterTags = (
-	tags: FEArticleType['tags'],
+	tags: DCRArticle['tags'],
 	tagType: 'Contributor' | 'Keyword' | 'Tone' | 'Series', // Let’s make a decision to keep this tag getter small and well defined, we don't really want to use tags
 ): TagType['id'] | '' => {
 	const tagArr = tags.filter((tag) => tag.type === tagType);
@@ -21,7 +21,7 @@ const filterTags = (
 
 // Annoyingly we ping GA with commissioningdesk as the title of the tag, not the id so handle that separately
 const getCommissioningDesk = (
-	tags: FEArticleType['tags'],
+	tags: DCRArticle['tags'],
 ): TagType['title'] | '' => {
 	const tag = tags.find((thisTag) =>
 		thisTag.id.includes('tracking/commissioningdesk'),

--- a/dotcom-rendering/src/server/index.article.web.ts
+++ b/dotcom-rendering/src/server/index.article.web.ts
@@ -10,7 +10,7 @@ import { enhanceTableOfContents } from '../model/enhanceTableOfContents';
 import { validateAsArticleType } from '../model/validate';
 import { recordTypeAndPlatform } from '../server/lib/logging-store';
 import type { FEArticleBadgeType } from '../types/badge';
-import type { FEArticleType, FEBlocksRequest } from '../types/frontend';
+import type { DCRArticle, FEBlocksRequest } from '../types/frontend';
 import type { RenderingTarget } from '../types/renderingTarget';
 import { makePrefetchHeader } from './lib/header';
 import {
@@ -41,7 +41,7 @@ const enhanceBadge = (badge?: FEArticleBadgeType) =>
 export const enhanceArticleType = (
 	body: unknown,
 	renderingTarget: RenderingTarget,
-): FEArticleType => {
+): DCRArticle => {
 	const validated = validateAsArticleType(body);
 	// addImageIDs needs to take account of both main media elements
 	// and block elements, so it needs to be executed here

--- a/dotcom-rendering/src/server/render.article.apps.tsx
+++ b/dotcom-rendering/src/server/render.article.apps.tsx
@@ -6,11 +6,11 @@ import { decideFormat } from '../lib/decideFormat';
 import { renderToStringWithEmotion } from '../lib/emotion';
 import { createGuardian } from '../model/guardian';
 import type { Config } from '../types/configContext';
-import type { FEArticleType } from '../types/frontend';
+import type { DCRArticle } from '../types/frontend';
 import { htmlPageTemplate } from './htmlPageTemplate';
 
 export const renderArticle = (
-	article: FEArticleType,
+	article: DCRArticle,
 ): {
 	prefetchScripts: string[];
 	html: string;

--- a/dotcom-rendering/src/server/render.article.web.tsx
+++ b/dotcom-rendering/src/server/render.article.web.tsx
@@ -21,15 +21,15 @@ import { extractNAV } from '../model/extract-nav';
 import { createGuardian as createWindowGuardian } from '../model/guardian';
 import type { Config } from '../types/configContext';
 import type { FEElement } from '../types/content';
-import type { FEArticleType, FEBlocksRequest } from '../types/frontend';
+import type { DCRArticle, FEBlocksRequest } from '../types/frontend';
 import type { TagType } from '../types/tag';
 import { htmlPageTemplate } from './htmlPageTemplate';
 
 interface Props {
-	article: FEArticleType;
+	article: DCRArticle;
 }
 
-const decideTitle = (article: FEArticleType): string => {
+const decideTitle = (article: DCRArticle): string => {
 	if (decideTheme(article.format) === Pillar.Opinion && article.byline) {
 		return `${article.headline} | ${article.byline} | The Guardian`;
 	}

--- a/dotcom-rendering/src/types/frontend.ts
+++ b/dotcom-rendering/src/types/frontend.ts
@@ -112,13 +112,20 @@ export interface FEArticleType {
 	messageUs?: MessageUs;
 
 	promotedNewsletter?: Newsletter;
-	tableOfContents?: TableOfContentsItem[];
 	canonicalUrl: string;
-	imagesForLightbox?: ImageForLightbox[];
 	showTableOfContents: boolean;
 	lang?: string;
 	isRightToLeftLang?: boolean;
 }
+
+/**
+ * The `DCRArticle` type models the `FEArticleType` in addition to any enhancements DCR makes after
+ * receiving the data from Frontend.
+ */
+export type DCRArticle = FEArticleType & {
+	imagesForLightbox?: ImageForLightbox[];
+	tableOfContents?: TableOfContentsItem[];
+};
 
 export interface TableOfContents {
 	items: TableOfContentsItem[];


### PR DESCRIPTION
We use `FEArticleType` to model data generated by Frontend and passed to DCR. However, we also add fields to this type which _don't_ exist in the data sent by Frontend, like `tableOfContents` and `imagesForLightbox`. This is confusing!

This change adds a `DCRArticle` type which is intended to model an article type for DCR to use after we enhance the incoming data from Frontend. We can add fields to this type that do not exist in Frontend.

<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

