### PR TITLE
Migrate AR to Github Actions

### DIFF
--- a/.github/workflows/ar-ci.yml
+++ b/.github/workflows/ar-ci.yml
@@ -1,0 +1,73 @@
+name: "AR CI"
+
+on:
+  push:
+
+  workflow_dispatch:
+
+# Allow queued workflows to interrupt previous runs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
+  cancel-in-progress: true
+
+# Allow GitHub to request an OIDC JWT ID token, to use with aws-actions/configure-aws-credentials
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    # Checkout the repository
+    steps:
+      - uses: actions/checkout@v4
+
+      # Get the desired version of Node installed
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: .nvmrc
+
+      - name: Install dependencies
+        run: |
+          npm i -g yarn@1.x
+          yarn --silent --frozen-lockfile
+
+      # Execute some tasks from the `apps-rendering/package.json` file, using `yarn`
+      - name: Build and package
+        working-directory: apps-rendering
+        run: |
+          yarn test
+          yarn build:client:prod
+          yarn build:server:prod
+          yarn copy-manifest
+          yarn copy-fonts
+          yarn synth
+          zip -r dist/server/mobile-apps-rendering.zip dist/server
+
+      - name: AWS Auth
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+          aws-region: eu-west-1
+
+      - name: Upload to riff-raff
+        uses: guardian/actions-riff-raff@v2.2.2
+        with:
+          configPath: apps-rendering/riff-raff.yaml
+          projectName: Mobile::mobile-apps-rendering
+          buildNumberOffset: 22000 # This is the last build number from TeamCity
+          contentDirectories: |
+            mobile-apps-rendering-cfn:
+              - cdk/cdk.out/MobileAppsRendering-CODE.template.json
+              - cdk/cdk.out/MobileAppsRendering-PROD.template.json
+            mobile-apps-rendering-preview-cfn:
+              - cdk/cdk.out/MobileAppsRenderingPreview-CODE.template.json
+              - cdk/cdk.out/MobileAppsRenderingPreview-PROD.template.json
+            mobile-apps-rendering:
+              - dist/server/mobile-apps-rendering.zip
+            mobile-assets:
+              - dist/assets/manifest.json
+              - dist/assets/fonts
+              - dist/assets/
+

--- a/.github/workflows/ar-ci.yml
+++ b/.github/workflows/ar-ci.yml
@@ -2,6 +2,8 @@ name: "AR CI"
 
 on:
   push:
+    paths-ignore:
+      - "dotcom-rendering/**"
 
   workflow_dispatch:
 
@@ -56,7 +58,7 @@ jobs:
         with:
           configPath: apps-rendering/riff-raff.yaml
           projectName: Mobile::mobile-apps-rendering
-          buildNumberOffset: 22000 # This is the last build number from TeamCity
+          buildNumberOffset: 27000 # This is the last build number from TeamCity
           contentDirectories: |
             mobile-apps-rendering-cfn:
               - cdk/cdk.out/MobileAppsRendering-CODE.template.json

--- a/.github/workflows/ar-ci.yml
+++ b/.github/workflows/ar-ci.yml
@@ -28,11 +28,11 @@ jobs:
       # Get the desired version of Node installed
       - uses: actions/setup-node@v3
         with:
+          cache: yarn
           node-version-file: .nvmrc
 
       - name: Install dependencies
         run: |
-          npm i -g yarn@1.x
           yarn --silent --frozen-lockfile
 
       # Execute some tasks from the `apps-rendering/package.json` file, using `yarn`

--- a/.github/workflows/ar-ci.yml
+++ b/.github/workflows/ar-ci.yml
@@ -69,7 +69,5 @@ jobs:
             mobile-apps-rendering:
               - apps-rendering/dist/server/mobile-apps-rendering.zip
             mobile-assets:
-              - apps-rendering/dist/assets/manifest.json
-              - apps-rendering/dist/assets/fonts
               - apps-rendering/dist/assets/
 

--- a/.github/workflows/ar-ci.yml
+++ b/.github/workflows/ar-ci.yml
@@ -61,11 +61,11 @@ jobs:
           buildNumberOffset: 27000 # This is the last build number from TeamCity
           contentDirectories: |
             mobile-apps-rendering-cfn:
-              - apps-rendering/cdk/cdk.out/MobileAppsRendering-CODE.template.json
-              - apps-rendering/cdk/cdk.out/MobileAppsRendering-PROD.template.json
+              - apps-rendering/cdk.out/MobileAppsRendering-CODE.template.json
+              - apps-rendering/cdk.out/MobileAppsRendering-PROD.template.json
             mobile-apps-rendering-preview-cfn:
-              - apps-rendering/cdk/cdk.out/MobileAppsRenderingPreview-CODE.template.json
-              - apps-rendering/cdk/cdk.out/MobileAppsRenderingPreview-PROD.template.json
+              - apps-rendering/cdk.out/MobileAppsRenderingPreview-CODE.template.json
+              - apps-rendering/cdk.out/MobileAppsRenderingPreview-PROD.template.json
             mobile-apps-rendering:
               - apps-rendering/dist/server/mobile-apps-rendering.zip
             mobile-assets:

--- a/.github/workflows/ar-ci.yml
+++ b/.github/workflows/ar-ci.yml
@@ -45,7 +45,7 @@ jobs:
           yarn copy-manifest
           yarn copy-fonts
           yarn synth
-          zip -r dist/server/mobile-apps-rendering.zip dist/server
+          zip -j dist/server/mobile-apps-rendering.zip dist/server/*
 
       - name: AWS Auth
         uses: aws-actions/configure-aws-credentials@v2

--- a/.github/workflows/ar-ci.yml
+++ b/.github/workflows/ar-ci.yml
@@ -61,15 +61,15 @@ jobs:
           buildNumberOffset: 27000 # This is the last build number from TeamCity
           contentDirectories: |
             mobile-apps-rendering-cfn:
-              - cdk/cdk.out/MobileAppsRendering-CODE.template.json
-              - cdk/cdk.out/MobileAppsRendering-PROD.template.json
+              - apps-rendering/cdk/cdk.out/MobileAppsRendering-CODE.template.json
+              - apps-rendering/cdk/cdk.out/MobileAppsRendering-PROD.template.json
             mobile-apps-rendering-preview-cfn:
-              - cdk/cdk.out/MobileAppsRenderingPreview-CODE.template.json
-              - cdk/cdk.out/MobileAppsRenderingPreview-PROD.template.json
+              - apps-rendering/cdk/cdk.out/MobileAppsRenderingPreview-CODE.template.json
+              - apps-rendering/cdk/cdk.out/MobileAppsRenderingPreview-PROD.template.json
             mobile-apps-rendering:
-              - dist/server/mobile-apps-rendering.zip
+              - apps-rendering/dist/server/mobile-apps-rendering.zip
             mobile-assets:
-              - dist/assets/manifest.json
-              - dist/assets/fonts
-              - dist/assets/
+              - apps-rendering/dist/assets/manifest.json
+              - apps-rendering/dist/assets/fonts
+              - apps-rendering/dist/assets/
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

Closes #8676 

## What does this change?
* Adds an `ar-ci.yml` GitHub workflow
* Replaces [`node-riffraff-artifact`](https://github.com/guardian/node-riffraff-artifact) with [`actions-riff-raff`](https://github.com/guardian/actions-riff-raff) to upload the artifacts in Riff-Raff.

## Why?
We are moving away from TC

## Testing 

[Deployed to CODE](https://riffraff.gutools.co.uk/deployment/view/6125c011-625d-4ffe-90a9-2559a3a5b2c1) and checked various types of articles:

- [X] Standard
- [X] Liveblog
- [X] Deadblog
- [X] Gallery

### Build
* [TeamCity build is successful](https://teamcity.gutools.co.uk/viewLog.html?buildId=877224&buildTypeId=Mobile_Mapi_AppsRenderingMonoRepo)
* [GH Actions build is successful](https://github.com/guardian/dotcom-rendering/actions/runs/6264706584/job/17011985070?pr=8886)

### Deployments

[Build produced by GH Actions deployed successfully](https://riffraff.gutools.co.uk/deployment/view/6125c011-625d-4ffe-90a9-2559a3a5b2c1)

Build produced by [TeamCity](https://riffraff.gutools.co.uk/deployment/request/deployFiles?projectName=Mobile%3A%3Amobile-apps-rendering&id=20844) and [GH Actions](https://riffraff.gutools.co.uk/deployment/request/deployFiles?projectName=Mobile%3A%3Amobile-apps-rendering&id=27006) produce the same artefacts

| TeamCity      | GH Actions      |
| ----------- | ---------- |
| ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/24b028a5-b718-4e8a-9c2e-9a3ce91d9173) | ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/bd84a015-bbf8-46c8-8a16-f7a33c2a1792) |

Zip produced by TC and GH Actions has the same structure

| TeamCity      | GH Actions      |
| ----------- | ---------- |
| <img width="987" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/19683595/f7a8d0ad-9f93-4277-a5a6-264202a7e555"> | <img width="992" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/19683595/6a1070dd-94b9-43c1-9565-b47950c2c31b"> |


[before]: https://example.com/before.png
[after]: https://example.com/after.png

## Release plan

- [x] Add a Riff-Raff restriction to `Mobile::mobile-apps-rendering`
- [x] Pause TC build
- [x] Replace TC build with GH Actions built in the required checks of the repo
- [x] Remove restriction
- [ ] Merge this PR and make sure Continuous Deployment gets kicked off
- [ ] After making sure everything works fine raise PR to remove:
   - [`apps-rendering/artifact.json`](https://github.com/guardian/dotcom-rendering/blob/4f2a7a1b463be9a48431cbb72703ec983494157d/apps-rendering/artifact.json)
   - [`ci-ar.sh`](https://github.com/guardian/dotcom-rendering/blob/4f2a7a1b463be9a48431cbb72703ec983494157d/scripts/ci-ar.sh)
   - [Command to upload artefacts via `node-riffraff-artifact` from `package.json`](https://github.com/guardian/dotcom-rendering/blob/4f2a7a1b463be9a48431cbb72703ec983494157d/apps-rendering/package.json#L11)
   - [`node-riffraff-artifact` dependency](https://github.com/guardian/dotcom-rendering/blob/4f2a7a1b463be9a48431cbb72703ec983494157d/apps-rendering/package.json#L52)

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
