### PR TITLE
Remove checks on europe feature switch

### DIFF
--- a/dotcom-rendering/src/components/Header.stories.tsx
+++ b/dotcom-rendering/src/components/Header.stories.tsx
@@ -28,7 +28,6 @@ export const defaultStory = () => {
 			contributionsServiceUrl="https://contributions.guardianapis.com"
 			idApiUrl="https://idapi.theguardian.com"
 			headerTopBarSearchCapiSwitch={false}
-			isInEuropeTest={false}
 		/>
 	);
 };

--- a/dotcom-rendering/src/components/Header.tsx
+++ b/dotcom-rendering/src/components/Header.tsx
@@ -38,7 +38,6 @@ type Props = {
 	remoteHeader: boolean;
 	contributionsServiceUrl: string;
 	idApiUrl: string;
-	isInEuropeTest: boolean;
 	headerTopBarSearchCapiSwitch: boolean;
 	hasPageSkin?: boolean;
 };
@@ -53,7 +52,6 @@ export const Header = ({
 	contributionsServiceUrl,
 	idApiUrl,
 	headerTopBarSearchCapiSwitch,
-	isInEuropeTest,
 	hasPageSkin = false,
 }: Props) => (
 	<div css={headerStyles} data-component="nav3">
@@ -70,7 +68,6 @@ export const Header = ({
 				discussionApiUrl={discussionApiUrl}
 				idApiUrl={idApiUrl}
 				headerTopBarSearchCapiSwitch={headerTopBarSearchCapiSwitch}
-				isInEuropeTest={isInEuropeTest}
 				hasPageSkin={hasPageSkin}
 			/>
 		</Island>

--- a/dotcom-rendering/src/components/HeaderTopBar.importable.tsx
+++ b/dotcom-rendering/src/components/HeaderTopBar.importable.tsx
@@ -20,7 +20,6 @@ interface HeaderTopBarProps {
 	discussionApiUrl: string;
 	idApiUrl: string;
 	headerTopBarSearchCapiSwitch: boolean;
-	isInEuropeTest: boolean;
 	hasPageSkin?: boolean;
 }
 
@@ -70,7 +69,6 @@ export const HeaderTopBar = ({
 	discussionApiUrl,
 	idApiUrl,
 	headerTopBarSearchCapiSwitch,
-	isInEuropeTest,
 	hasPageSkin = false,
 }: HeaderTopBarProps) => {
 	const authStatus = useAuthStatus();
@@ -109,7 +107,6 @@ export const HeaderTopBar = ({
 					<HeaderTopBarEditionDropdown
 						editionId={editionId}
 						dataLinkName={dataLinkName}
-						isInEuropeTest={isInEuropeTest}
 					/>
 				</Hide>
 			</div>

--- a/dotcom-rendering/src/components/HeaderTopBar.stories.tsx
+++ b/dotcom-rendering/src/components/HeaderTopBar.stories.tsx
@@ -15,7 +15,6 @@ export const defaultStory = () => {
 			discussionApiUrl="discussionApiUrl"
 			idApiUrl="idApiUrl"
 			headerTopBarSearchCapiSwitch={false}
-			isInEuropeTest={false}
 		/>
 	);
 };

--- a/dotcom-rendering/src/components/HeaderTopBarEditionDropdown.stories.tsx
+++ b/dotcom-rendering/src/components/HeaderTopBarEditionDropdown.stories.tsx
@@ -10,13 +10,7 @@ export default {
 };
 
 export const defaultStory = () => {
-	return (
-		<HeaderTopBarEditionDropdown
-			editionId="UK"
-			dataLinkName="test"
-			isInEuropeTest={false}
-		/>
-	);
+	return <HeaderTopBarEditionDropdown editionId="UK" dataLinkName="test" />;
 };
 
 defaultStory.storyName = 'default';

--- a/dotcom-rendering/src/components/HeaderTopBarEditionDropdown.tsx
+++ b/dotcom-rendering/src/components/HeaderTopBarEditionDropdown.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import { brand } from '@guardian/source-foundations';
 import type { EditionId } from '../lib/edition';
-import { getEditionFromId, getEditions } from '../lib/edition';
+import { editionList, getEditionFromId } from '../lib/edition';
 import { getZIndex } from '../lib/getZIndex';
 import { nestedOphanComponents } from '../lib/ophan-helpers';
 import type { EditionLinkType } from '../model/extract-nav';
@@ -12,7 +12,6 @@ import { dropDownOverrides } from './HeaderTopBarMyAccount';
 interface HeaderTopBarEditionDropdownProps {
 	editionId: EditionId;
 	dataLinkName: string;
-	isInEuropeTest: boolean;
 }
 
 const editionDropdownStyles = css`
@@ -29,7 +28,6 @@ const editionDropdownStyles = css`
 export const HeaderTopBarEditionDropdown = ({
 	editionId,
 	dataLinkName,
-	isInEuropeTest,
 }: HeaderTopBarEditionDropdownProps) => {
 	const editionToDropdownLink = (edition: EditionLinkType) => ({
 		id: edition.editionId,
@@ -47,7 +45,7 @@ export const HeaderTopBarEditionDropdown = ({
 		getEditionFromId(editionId),
 	);
 
-	const dropdownItems: DropdownLinkType[] = getEditions(isInEuropeTest).map(
+	const dropdownItems: DropdownLinkType[] = editionList.map(
 		editionToDropdownLink,
 	);
 

--- a/dotcom-rendering/src/components/Nav/ExpandedMenu/Columns.tsx
+++ b/dotcom-rendering/src/components/Nav/ExpandedMenu/Columns.tsx
@@ -210,7 +210,6 @@ type Props = {
 	isImmersive?: boolean;
 	nav: NavType;
 	headerTopBarSwitch: boolean;
-	isInEuropeTest: boolean;
 };
 
 export const Columns = ({
@@ -218,13 +217,9 @@ export const Columns = ({
 	nav,
 	editionId,
 	headerTopBarSwitch,
-	isInEuropeTest,
 }: Props) => {
 	const activeEdition = getEditionFromId(editionId);
-	const remainingEditions = getRemainingEditions(
-		activeEdition.editionId,
-		isInEuropeTest,
-	);
+	const remainingEditions = getRemainingEditions(activeEdition.editionId);
 	return (
 		<ul
 			css={columnsStyle(isImmersive)}

--- a/dotcom-rendering/src/components/Nav/ExpandedMenu/ExpandedMenu.tsx
+++ b/dotcom-rendering/src/components/Nav/ExpandedMenu/ExpandedMenu.tsx
@@ -108,7 +108,6 @@ type Props = {
 	isImmersive?: boolean;
 	nav: NavType;
 	headerTopBarSwitch: boolean;
-	isInEuropeTest: boolean;
 };
 
 export const ExpandedMenu = ({
@@ -116,7 +115,6 @@ export const ExpandedMenu = ({
 	nav,
 	editionId,
 	headerTopBarSwitch,
-	isInEuropeTest,
 }: Props) => {
 	return (
 		<div id="expanded-menu-root">
@@ -133,7 +131,6 @@ export const ExpandedMenu = ({
 						isImmersive={isImmersive}
 						nav={nav}
 						headerTopBarSwitch={headerTopBarSwitch}
-						isInEuropeTest={isInEuropeTest}
 					/>
 				</div>
 			</div>

--- a/dotcom-rendering/src/components/Nav/Nav.stories.tsx
+++ b/dotcom-rendering/src/components/Nav/Nav.stories.tsx
@@ -25,7 +25,6 @@ export const StandardStory = () => {
 				subscribeUrl=""
 				editionId="UK"
 				headerTopBarSwitch={false}
-				isInEuropeTest={true}
 			/>
 		</Section>
 	);
@@ -47,7 +46,6 @@ export const StandardStoryTopBarHeader = () => {
 				subscribeUrl=""
 				editionId="UK"
 				headerTopBarSwitch={true}
-				isInEuropeTest={true}
 			/>
 		</Section>
 	);
@@ -69,7 +67,6 @@ export const OpinionStory = () => {
 				subscribeUrl=""
 				editionId="UK"
 				headerTopBarSwitch={false}
-				isInEuropeTest={true}
 			/>
 		</Section>
 	);
@@ -94,7 +91,6 @@ export const ImmersiveStory = () => {
 				subscribeUrl=""
 				editionId="UK"
 				headerTopBarSwitch={false}
-				isInEuropeTest={true}
 			/>
 		</Section>
 	);
@@ -119,7 +115,6 @@ export const ExpandedMenuStory = () => {
 				subscribeUrl=""
 				editionId="UK"
 				headerTopBarSwitch={false}
-				isInEuropeTest={true}
 			/>
 		</Section>
 	);

--- a/dotcom-rendering/src/components/Nav/Nav.test.tsx
+++ b/dotcom-rendering/src/components/Nav/Nav.test.tsx
@@ -12,7 +12,6 @@ describe('Nav', () => {
 				subscribeUrl=""
 				editionId="UK"
 				headerTopBarSwitch={false}
-				isInEuropeTest={true}
 			/>,
 		);
 		const list = within(getByTestId('pillar-list'));
@@ -31,7 +30,6 @@ describe('Nav', () => {
 				subscribeUrl=""
 				editionId="UK"
 				headerTopBarSwitch={false}
-				isInEuropeTest={true}
 			/>,
 		);
 

--- a/dotcom-rendering/src/components/Nav/Nav.tsx
+++ b/dotcom-rendering/src/components/Nav/Nav.tsx
@@ -18,7 +18,6 @@ type Props = {
 	displayRoundel?: boolean;
 	isImmersive?: boolean;
 	selectedPillar?: Pillar;
-	isInEuropeTest: boolean;
 	headerTopBarSwitch: boolean;
 };
 
@@ -62,7 +61,6 @@ export const Nav = ({
 	isImmersive,
 	selectedPillar,
 	headerTopBarSwitch,
-	isInEuropeTest,
 }: Props) => {
 	return (
 		<div css={rowStyles}>
@@ -214,7 +212,6 @@ export const Nav = ({
 					nav={nav}
 					isImmersive={isImmersive}
 					headerTopBarSwitch={headerTopBarSwitch}
-					isInEuropeTest={isInEuropeTest}
 				/>
 			</div>
 			{displayRoundel && (

--- a/dotcom-rendering/src/layouts/AllEditorialNewslettersPageLayout.tsx
+++ b/dotcom-rendering/src/layouts/AllEditorialNewslettersPageLayout.tsx
@@ -40,8 +40,6 @@ export const AllEditorialNewslettersPageLayout = ({
 
 	const renderAds = !isAdFreeUser;
 
-	const isInEuropeTest = config.switches['europeNetworkFrontSwitch'] === true;
-
 	const contributionsServiceUrl =
 		process.env.SDC_URL ?? pageContributionsServiceUrl;
 
@@ -90,7 +88,6 @@ export const AllEditorialNewslettersPageLayout = ({
 							}
 							contributionsServiceUrl={contributionsServiceUrl}
 							idApiUrl={config.idApiUrl}
-							isInEuropeTest={isInEuropeTest}
 							headerTopBarSearchCapiSwitch={
 								!!newslettersPage.config.switches
 									.headerTopBarSearchCapi
@@ -110,7 +107,6 @@ export const AllEditorialNewslettersPageLayout = ({
 							nav={NAV}
 							subscribeUrl={subscribeUrl}
 							editionId={editionId}
-							isInEuropeTest={isInEuropeTest}
 						/>
 					</Section>
 					{NAV.subNavSections && (

--- a/dotcom-rendering/src/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/layouts/CommentLayout.tsx
@@ -269,9 +269,6 @@ export const CommentLayout = ({ article, NAV, format }: Props) => {
 		config: { isPaidContent, host },
 	} = article;
 
-	const isInEuropeTest =
-		article.config.switches['europeNetworkFrontSwitch'] === true;
-
 	const showBodyEndSlot =
 		parse(article.slotMachineFlags ?? '').showBodyEnd ||
 		article.config.switches.slotBodyEnd;
@@ -340,7 +337,6 @@ export const CommentLayout = ({ article, NAV, format }: Props) => {
 									contributionsServiceUrl
 								}
 								idApiUrl={article.config.idApiUrl}
-								isInEuropeTest={isInEuropeTest}
 								headerTopBarSearchCapiSwitch={
 									!!article.config.switches
 										.headerTopBarSearchCapi
@@ -374,7 +370,6 @@ export const CommentLayout = ({ article, NAV, format }: Props) => {
 							headerTopBarSwitch={
 								!!article.config.switches.headerTopNav
 							}
-							isInEuropeTest={isInEuropeTest}
 						/>
 					</Section>
 

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -215,8 +215,6 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 		},
 	} = front;
 
-	const isInEuropeTest = switches['europeNetworkFrontSwitch'] === true;
-
 	const renderAds = canRenderAds(front);
 
 	const hasPageSkin = hasPageSkinConfig && renderAds;
@@ -320,7 +318,6 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 									contributionsServiceUrl
 								}
 								idApiUrl={front.config.idApiUrl}
-								isInEuropeTest={isInEuropeTest}
 								headerTopBarSearchCapiSwitch={
 									!!front.config.switches
 										.headerTopBarSearchCapi
@@ -349,7 +346,6 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 							headerTopBarSwitch={
 								!!front.config.switches.headerTopNav
 							}
-							isInEuropeTest={isInEuropeTest}
 						/>
 					</Section>
 					{NAV.subNavSections && (
@@ -398,11 +394,9 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 					)}
 				</>
 			</div>
-			{isInEuropeTest && (
-				<Island clientOnly={true}>
-					<EuropeLandingModal edition={front.editionId} />
-				</Island>
-			)}
+			<Island clientOnly={true}>
+				<EuropeLandingModal edition={front.editionId} />
+			</Island>
 			<main
 				data-layout="FrontLayout"
 				data-link-name={`Front | /${front.pressedPage.id}`}

--- a/dotcom-rendering/src/layouts/FullPageInteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/FullPageInteractiveLayout.tsx
@@ -140,9 +140,6 @@ const NavHeader = ({ article, NAV, format }: Props) => {
 	 */
 	const renderAds = canRenderAds(article);
 
-	const isInEuropeTest =
-		article.config.switches['europeNetworkFrontSwitch'] === true;
-
 	if (isSlimNav) {
 		return (
 			<div
@@ -176,7 +173,6 @@ const NavHeader = ({ article, NAV, format }: Props) => {
 						headerTopBarSwitch={
 							!!article.config.switches.headerTopNav
 						}
-						isInEuropeTest={isInEuropeTest}
 					/>
 				</Section>
 			</div>
@@ -232,7 +228,6 @@ const NavHeader = ({ article, NAV, format }: Props) => {
 								article.contributionsServiceUrl
 							}
 							idApiUrl={article.config.idApiUrl}
-							isInEuropeTest={isInEuropeTest}
 							headerTopBarSearchCapiSwitch={
 								!!article.config.switches.headerTopBarSearchCapi
 							}
@@ -262,7 +257,6 @@ const NavHeader = ({ article, NAV, format }: Props) => {
 					}
 					editionId={article.editionId}
 					headerTopBarSwitch={!!article.config.switches.headerTopNav}
-					isInEuropeTest={isInEuropeTest}
 				/>
 			</Section>
 

--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -269,9 +269,6 @@ export const ImmersiveLayout = ({ article, NAV, format }: Props) => {
 
 	const isLabs = format.theme === ArticleSpecial.Labs;
 
-	const isInEuropeTest =
-		article.config.switches['europeNetworkFrontSwitch'] === true;
-
 	const { renderingTarget } = useConfig();
 
 	/**
@@ -354,7 +351,6 @@ export const ImmersiveLayout = ({ article, NAV, format }: Props) => {
 						headerTopBarSwitch={
 							!!article.config.switches.headerTopNav
 						}
-						isInEuropeTest={isInEuropeTest}
 					/>
 				</Section>
 			</div>

--- a/dotcom-rendering/src/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/InteractiveLayout.tsx
@@ -211,9 +211,6 @@ export const InteractiveLayout = ({ article, NAV, format }: Props) => {
 		config: { isPaidContent, host },
 	} = article;
 
-	const isInEuropeTest =
-		article.config.switches['europeNetworkFrontSwitch'] === true;
-
 	const showComments = article.isCommentable;
 
 	const { branding } = article.commercialProperties[article.editionId];
@@ -278,7 +275,6 @@ export const InteractiveLayout = ({ article, NAV, format }: Props) => {
 									contributionsServiceUrl
 								}
 								idApiUrl={article.config.idApiUrl}
-								isInEuropeTest={isInEuropeTest}
 								headerTopBarSearchCapiSwitch={
 									!!article.config.switches
 										.headerTopBarSearchCapi
@@ -313,7 +309,6 @@ export const InteractiveLayout = ({ article, NAV, format }: Props) => {
 						headerTopBarSwitch={
 							!!article.config.switches.headerTopNav
 						}
-						isInEuropeTest={isInEuropeTest}
 					/>
 				</Section>
 

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -262,9 +262,6 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 		config: { isPaidContent, host },
 	} = article;
 
-	const isInEuropeTest =
-		article.config.switches['europeNetworkFrontSwitch'] === true;
-
 	// TODO:
 	// 1) Read 'forceEpic' value from URL parameter and use it to force the slot to render
 	// 2) Otherwise, ensure slot only renders if `article.config.shouldHideReaderRevenue` equals false.
@@ -343,7 +340,6 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 									contributionsServiceUrl
 								}
 								idApiUrl={article.config.idApiUrl}
-								isInEuropeTest={isInEuropeTest}
 								headerTopBarSearchCapiSwitch={
 									!!article.config.switches
 										.headerTopBarSearchCapi
@@ -370,7 +366,6 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 								headerTopBarSwitch={
 									!!article.config.switches.headerTopNav
 								}
-								isInEuropeTest={isInEuropeTest}
 							/>
 						</Section>
 

--- a/dotcom-rendering/src/layouts/NewsletterSignupLayout.tsx
+++ b/dotcom-rendering/src/layouts/NewsletterSignupLayout.tsx
@@ -195,9 +195,6 @@ export const NewsletterSignupLayout = ({ article, NAV, format }: Props) => {
 		config: { host },
 	} = article;
 
-	const isInEuropeTest =
-		article.config.switches['europeNetworkFrontSwitch'] === true;
-
 	const contributionsServiceUrl = getContributionsServiceUrl(article);
 
 	const palette = decidePalette(format);
@@ -254,7 +251,6 @@ export const NewsletterSignupLayout = ({ article, NAV, format }: Props) => {
 						remoteHeader={!!article.config.switches.remoteHeader}
 						contributionsServiceUrl={contributionsServiceUrl}
 						idApiUrl={article.config.idApiUrl}
-						isInEuropeTest={isInEuropeTest}
 						headerTopBarSearchCapiSwitch={
 							!!article.config.switches.headerTopBarSearchCapi
 						}
@@ -286,7 +282,6 @@ export const NewsletterSignupLayout = ({ article, NAV, format }: Props) => {
 						headerTopBarSwitch={
 							!!article.config.switches.headerTopNav
 						}
-						isInEuropeTest={isInEuropeTest}
 					/>
 				</Section>
 

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -287,9 +287,6 @@ export const ShowcaseLayout = ({ article, NAV, format }: Props) => {
 		config: { isPaidContent, host },
 	} = article;
 
-	const isInEuropeTest =
-		article.config.switches['europeNetworkFrontSwitch'] === true;
-
 	const showBodyEndSlot =
 		parse(article.slotMachineFlags ?? '').showBodyEnd ||
 		article.config.switches.slotBodyEnd;
@@ -360,7 +357,6 @@ export const ShowcaseLayout = ({ article, NAV, format }: Props) => {
 										contributionsServiceUrl
 									}
 									idApiUrl={article.config.idApiUrl}
-									isInEuropeTest={isInEuropeTest}
 									headerTopBarSearchCapiSwitch={
 										!!article.config.switches
 											.headerTopBarSearchCapi
@@ -396,7 +392,6 @@ export const ShowcaseLayout = ({ article, NAV, format }: Props) => {
 									headerTopBarSwitch={
 										!!article.config.switches.headerTopNav
 									}
-									isInEuropeTest={isInEuropeTest}
 								/>
 							</Section>
 
@@ -490,7 +485,6 @@ export const ShowcaseLayout = ({ article, NAV, format }: Props) => {
 									headerTopBarSwitch={
 										!!article.config.switches.headerTopNav
 									}
-									isInEuropeTest={isInEuropeTest}
 								/>
 							</Section>
 						</Stuck>

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -307,9 +307,6 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 		config: { isPaidContent, host },
 	} = article;
 
-	const isInEuropeTest =
-		article.config.switches['europeNetworkFrontSwitch'] === true;
-
 	const showBodyEndSlot =
 		parse(article.slotMachineFlags ?? '').showBodyEnd ||
 		article.config.switches.slotBodyEnd;
@@ -383,7 +380,6 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 									contributionsServiceUrl
 								}
 								idApiUrl={article.config.idApiUrl}
-								isInEuropeTest={isInEuropeTest}
 								headerTopBarSearchCapiSwitch={
 									!!article.config.switches
 										.headerTopBarSearchCapi
@@ -416,7 +412,6 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 							headerTopBarSwitch={
 								!!article.config.switches.headerTopNav
 							}
-							isInEuropeTest={isInEuropeTest}
 						/>
 					</Section>
 					{props.NAV.subNavSections && !isLabs && (

--- a/dotcom-rendering/src/layouts/TagFrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/TagFrontLayout.tsx
@@ -63,9 +63,6 @@ const getContainerId = (date: Date, locale: string, hasDay: boolean) => {
 };
 
 export const TagFrontLayout = ({ tagFront, NAV }: Props) => {
-	const isInEuropeTest =
-		tagFront.config.switches['europeNetworkFrontSwitch'] === true;
-
 	const format = {
 		display: ArticleDisplay.Standard,
 		design: ArticleDesign.Standard,
@@ -128,7 +125,6 @@ export const TagFrontLayout = ({ tagFront, NAV }: Props) => {
 							}
 							contributionsServiceUrl="https://contributions.guardianapis.com" // TODO: Pass this in
 							idApiUrl="https://idapi.theguardian.com/" // TODO: read this from somewhere as in other layouts
-							isInEuropeTest={isInEuropeTest}
 							headerTopBarSearchCapiSwitch={
 								!!tagFront.config.switches
 									.headerTopBarSearchCapi
@@ -155,7 +151,6 @@ export const TagFrontLayout = ({ tagFront, NAV }: Props) => {
 							headerTopBarSwitch={
 								!!tagFront.config.switches.headerTopNav
 							}
-							isInEuropeTest={isInEuropeTest}
 						/>
 					</Section>
 					{NAV.subNavSections && (

--- a/dotcom-rendering/src/lib/edition.ts
+++ b/dotcom-rendering/src/lib/edition.ts
@@ -3,12 +3,6 @@ import { guard } from './guard';
 
 export type EditionId = (typeof editionList)[number]['editionId'];
 
-/**
- * Warning: This list included the behind a 0% test edition
- * 'Europe', please use `getEditions` unless you're certain
- * you won't be accidentally displaying Europe edition to
- * users.
- */
 export const editionList = [
 	{
 		url: '/preference/edition/uk',
@@ -52,20 +46,8 @@ export const editionList = [
 	},
 ] as const;
 
-/**
- * Gets all the editions, factoring in whether or not the user is in the europe test group or not.
- * Use over 'editionList' in any case where you're listing available editions to the user.
- *
- * @param isInEuropeTest Whether or not the user is in the europe edition test group
- * @returns All editions, optionally excluding Europe edition
- */
-export const getEditions = (isInEuropeTest: boolean): EditionLinkType[] =>
-	editionList.filter((e) => (e.editionId === 'EUR' ? isInEuropeTest : true));
-
 export const getEditionFromId = (editionId: EditionId): EditionLinkType => {
 	return (
-		// We can use just 'editionList' here as we can safely assume if the user
-		// is in the europe edition, they're also in the test group
 		editionList.find((edition) => edition.editionId === editionId) ??
 		editionList[0]
 	);
@@ -73,11 +55,8 @@ export const getEditionFromId = (editionId: EditionId): EditionLinkType => {
 
 export const getRemainingEditions = (
 	editionId: EditionId,
-	isInEuropeTest: boolean,
 ): EditionLinkType[] => {
-	return getEditions(isInEuropeTest).filter(
-		(edition) => edition.editionId !== editionId,
-	);
+	return editionList.filter((edition) => edition.editionId !== editionId);
 };
 
 /**


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

This removes all references to the Europe feature switch introduced in #8867 as a precursor to merging https://github.com/guardian/frontend/pull/26599

