### PR TITLE
fix logic for displaying sponsored branding

### DIFF
--- a/dotcom-rendering/src/components/FrontSection.tsx
+++ b/dotcom-rendering/src/components/FrontSection.tsx
@@ -389,6 +389,25 @@ const aboutThisLinkStyles = css`
 	text-decoration: none;
 `;
 
+const SponsoredBranding = ({
+	branding,
+}: {
+	branding: Branding | undefined;
+}) => {
+	if (!branding) {
+		return null;
+	}
+	const { logo, aboutThisLink } = branding;
+	return (
+		<>
+			<p css={labelStyles}>{logo.label}</p>
+			<Badge imageSrc={logo.src} href={logo.link} />
+			<a href={aboutThisLink} css={aboutThisLinkStyles}>
+				About this content
+			</a>
+		</>
+	);
+};
 /**
  * # Front Container
  *
@@ -522,6 +541,12 @@ export const FrontSection = ({
 	const isTheFirstContainerOnASponsoredFront =
 		!isOnPaidContentFront && index === 0 && !!frontBranding;
 
+	const showSponsoredBranding =
+		(isTheFirstContainerOnASponsoredFront && frontBranding.branding) ||
+		containerBranding;
+
+	const sponsoredBranding = frontBranding?.branding ?? containerBranding;
+
 	/**
 	 * id is being used to set the containerId in @see {ShowMore.importable.tsx}
 	 * this id pre-existed showMore so is probably also being used for something else.
@@ -582,7 +607,7 @@ export const FrontSection = ({
 							showDateHeader={showDateHeader}
 							editionId={editionId}
 						/>
-						{!!frontBranding?.branding?.logo.src && (
+						{!!frontBranding.branding?.logo.src && (
 							<div
 								css={css`
 									display: inline-block;
@@ -599,8 +624,8 @@ export const FrontSection = ({
 							>
 								Paid for by
 								<Badge
-									imageSrc={frontBranding?.branding?.logo.src}
-									href={frontBranding?.branding?.logo.link}
+									imageSrc={frontBranding.branding.logo.src}
+									href={frontBranding.branding.logo.link}
 								/>
 							</div>
 						)}
@@ -633,48 +658,10 @@ export const FrontSection = ({
 								showDateHeader={showDateHeader}
 								editionId={editionId}
 							/>
-							{isTheFirstContainerOnASponsoredFront &&
-								frontBranding?.branding && (
-									<>
-										<p css={labelStyles}>
-											{frontBranding.branding.logo.label}
-										</p>
-										<Badge
-											imageSrc={
-												frontBranding.branding.logo.src
-											}
-											href={
-												frontBranding.branding.logo.link
-											}
-										/>
-										<a
-											href={
-												frontBranding.branding
-													.aboutThisLink
-											}
-											css={aboutThisLinkStyles}
-										>
-											About this content
-										</a>
-									</>
-								)}
-
-							{containerBranding && (
-								<>
-									<p css={labelStyles}>
-										{containerBranding.logo.label}
-									</p>
-									<Badge
-										imageSrc={containerBranding.logo.src}
-										href={containerBranding.logo.link}
-									/>
-									<a
-										href={containerBranding.aboutThisLink}
-										css={aboutThisLinkStyles}
-									>
-										About this content
-									</a>
-								</>
+							{showSponsoredBranding && (
+								<SponsoredBranding
+									branding={sponsoredBranding}
+								/>
 							)}
 						</div>
 					</>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Pulls out the sponsored branding into a sub-component and deduplicates the badges so that we don't count a front badge and container badge twice, since they should be in the same position.

Currently the front branding takes precedence over the container branding, but we need to decide and document rules for when to show which badges in which scenarios.

## Why?

Resolves #8894

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/43961396/072a44bc-d809-4c5d-aee1-1f85eb6900aa
[after]: https://github.com/guardian/dotcom-rendering/assets/43961396/bc289fd5-4aea-47fe-b53e-b79661d19aae

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
