### PR TITLE
Apps Ad Slot Storybook Actions

### DIFF
--- a/dotcom-rendering/src/components/AdSlot.apps.stories.tsx
+++ b/dotcom-rendering/src/components/AdSlot.apps.stories.tsx
@@ -13,6 +13,9 @@ export default {
 			defaultViewport: 'mobile',
 		},
 	},
+	argTypes: {
+		onClickSupportButton: { action: 'clicked' },
+	},
 };
 
 type Args = Omit<Props, 'ref'>;
@@ -24,7 +27,6 @@ export const AdSlotSquare = (args: Args) => {
 AdSlotSquare.storyName = 'with isFirstAdSlot = true';
 AdSlotSquare.args = {
 	isFirstAdSlot: true,
-	onClickSupportButton: { action: 'clicked' },
 };
 
 export const AdSlotNotSquare = (args: Args) => {
@@ -34,5 +36,4 @@ export const AdSlotNotSquare = (args: Args) => {
 AdSlotNotSquare.storyName = 'with isFirstAdSlot = false';
 AdSlotNotSquare.args = {
 	isFirstAdSlot: false,
-	onClickSupportButton: { action: 'clicked' },
 };


### PR DESCRIPTION
## Why?

Minor change to #8880 to fix a bug in the way storybook actions were configured. The docs suggest they should be set up using an `argTypes` property[^1].

## How to test?

Clicking on the button in these components should produce output in the "Actions" tab in storybook. Previously, clicking on them resulted in an error.

[^1]: https://storybook.js.org/docs/react/essentials/actions
