### PR TITLE
Improve naming in the AR build

### DIFF
--- a/.github/workflows/ar-ci.yml
+++ b/.github/workflows/ar-ci.yml
@@ -1,4 +1,4 @@
-name: "AR CI"
+name: AR CI
 
 on:
   push:
@@ -19,6 +19,7 @@ permissions:
 
 jobs:
   build:
+    name: AR CI
     runs-on: ubuntu-latest
 
     # Checkout the repository


### PR DESCRIPTION
 <!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Give "AR CI" name to the AR build job.

## Why?
Without a name it is currently called "build" in the required checks UI which is not very descriptive. Will become "AR CI".

| Before | After |
|--------|-------|
| ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/b573c77f-a506-4291-9733-ba994059cd65) | ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/c557b348-783b-400c-b29c-06b50e80ea5b)|




## Renaming steps

- [ ] Change the required job from "build" to "AR CI" in the settings
- [ ] Merge


[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
