### PR TITLE
Separate index file for apps, and remove `bootCmp` from it

### DIFF
--- a/dotcom-rendering/scripts/webpack/webpack.config.client.js
+++ b/dotcom-rendering/scripts/webpack/webpack.config.client.js
@@ -33,6 +33,19 @@ const generateName = (build) => {
  * @param {Build} build
  * @returns {string}
  */
+const getEntryIndex = (build) => {
+	switch (build) {
+		case 'apps':
+			return './src/client/index.apps.ts';
+		default:
+			return './src/client/index.ts';
+	}
+};
+
+/**
+ * @param {Build} build
+ * @returns {string}
+ */
 const getLoaders = (build) => {
 	switch (build) {
 		case 'web.legacy':
@@ -78,7 +91,7 @@ const getLoaders = (build) => {
  */
 module.exports = ({ build, sessionId }) => ({
 	entry: {
-		index: './src/client/index.ts',
+		index: getEntryIndex(build),
 		debug: './src/client/debug/index.ts',
 	},
 	resolve: {

--- a/dotcom-rendering/src/client/index.apps.ts
+++ b/dotcom-rendering/src/client/index.apps.ts
@@ -1,0 +1,134 @@
+import './webpackPublicPath';
+import { startup } from './startup';
+
+/*************************************************************
+ *
+ * The following modules are bundled in the entry chunk,
+ * so they can be run immediately, but we still want to report
+ * on the duration of loading and evaluating them.
+ *
+ *************************************************************/
+
+void startup(
+	'recordInitialPageEvents',
+	() =>
+		import(
+			/* webpackMode: "eager" */ './ophan/recordInitialPageEvents'
+		).then(({ recordInitialPageEvents }) => recordInitialPageEvents()),
+	{
+		priority: 'critical',
+	},
+);
+
+void startup(
+	'ga',
+	() => import(/* webpackMode: "eager" */ './ga').then(({ ga }) => ga()),
+	{
+		priority: 'critical',
+	},
+);
+
+void startup(
+	'sentryLoader',
+	() =>
+		import(/* webpackMode: "eager" */ './sentryLoader').then(
+			({ sentryLoader }) => sentryLoader(),
+		),
+	{
+		priority: 'critical',
+	},
+);
+
+void startup(
+	'dynamicImport',
+	() =>
+		import(/* webpackMode: "eager" */ './dynamicImport').then(
+			({ dynamicImport }) => dynamicImport(),
+		),
+	{
+		priority: 'critical',
+	},
+);
+
+void startup(
+	'islands',
+	() =>
+		import(/* webpackMode: "eager" */ './islands').then(({ islands }) =>
+			islands(),
+		),
+	{
+		priority: 'critical',
+	},
+);
+
+void startup(
+	'performanceMonitoring',
+	() =>
+		import(/* webpackMode: "eager" */ './performanceMonitoring').then(
+			({ performanceMonitoring }) => performanceMonitoring(),
+		),
+	{
+		priority: 'critical',
+	},
+);
+
+/*************************************************************
+ *
+ * The following modules are lazy loaded,
+ * because they are lower priority and do not want to block
+ * the modules above on loading these.
+ *
+ * We are not assigning chunk name to allow Webpack
+ * to optimise chunking based on its algorithm.
+ *
+ *************************************************************/
+
+void startup(
+	'atomIframe',
+	() =>
+		import(
+			/* webpackMode: 'lazy' */
+			'./atomIframe'
+		).then(({ atomIframe }) => atomIframe()),
+	{ priority: 'feature' },
+);
+
+void startup(
+	'embedIframe',
+	() =>
+		import(
+			/* webpackMode: 'lazy' */
+			'./embedIframe'
+		).then(({ embedIframe }) => embedIframe()),
+	{ priority: 'feature' },
+);
+
+void startup(
+	'newsletterEmbedIframe',
+	() =>
+		import(
+			/* webpackMode: 'lazy' */
+			'./newsletterEmbedIframe'
+		).then(({ newsletterEmbedIframe }) => newsletterEmbedIframe()),
+	{ priority: 'feature' },
+);
+
+void startup(
+	'relativeTime',
+	() =>
+		import(
+			/* webpackMode: 'lazy' */
+			'./relativeTime'
+		).then(({ relativeTime }) => relativeTime()),
+	{ priority: 'feature' },
+);
+
+void startup(
+	'initDiscussion',
+	() =>
+		import(
+			/* webpackMode: 'lazy' */
+			'./discussion'
+		).then(({ discussion }) => discussion()),
+	{ priority: 'feature' },
+);


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
This PR creates an app specific entry file, which does not call `bootCmp`.
Closes https://github.com/guardian/dotcom-rendering/issues/8875

## Why?
This is because, for apps, we want to use consent given in the native layer, rather than display the web consent banner. Separating the index files by platform, allows us to decouple and gives us more flexibility in the future.

## Screenshots

| Before (banner)     | After (no banner)   |
| ----------- | ---------- |
| <img width="357" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/11a67c52-1d55-43e1-b501-4ccc6af378c0"> | <img width="357" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/eb5e266c-d0ed-4aa4-8c3f-13ba92c1f642"> |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
