### PR TITLE
Change when AR CI runs

### DIFF
--- a/.github/workflows/ar-ci.yml
+++ b/.github/workflows/ar-ci.yml
@@ -2,9 +2,6 @@ name: AR CI
 
 on:
   push:
-    paths-ignore:
-      - "dotcom-rendering/**"
-
   workflow_dispatch:
 
 # Allow queued workflows to interrupt previous runs
@@ -12,15 +9,42 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
   cancel-in-progress: true
 
-# Allow GitHub to request an OIDC JWT ID token, to use with aws-actions/configure-aws-credentials
-permissions:
-  id-token: write
-  contents: read
-
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      ar: ${{ steps.filter.outputs.ar }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          # the ar filter should be true if any file outside dotcom-rendering/ has changed
+          filters: |
+            ar:
+              - './!(dotcom-rendering)/**'
+
+  skip_build:
+    runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.ar == 'false' }}
+    steps:
+      - name: exit
+        run: |
+          echo "Exiting early, there are no changes to Apps Rendering"
+          exit 0
+
   build:
     name: AR CI
+    needs: changes
+    if: ${{ needs.changes.outputs.ar == 'true' }}
     runs-on: ubuntu-latest
+    # Allow GitHub to request an OIDC JWT ID token, to use with aws-actions/configure-aws-credentials
+    permissions:
+      id-token: write
+      contents: read
 
     # Checkout the repository
     steps:
@@ -71,4 +95,3 @@ jobs:
               - apps-rendering/dist/server/mobile-apps-rendering.zip
             mobile-assets:
               - apps-rendering/dist/assets/
-


### PR DESCRIPTION
It should run when:

* Files in the root of the repository change
* Files in the apps-rendering/ directory change

It should not run when:

* Only files in the dotcom-rendering/ directory change
