### PR TITLE
Always run the AR build

### DIFF
--- a/.github/workflows/ar-ci.yml
+++ b/.github/workflows/ar-ci.yml
@@ -2,9 +2,6 @@ name: AR CI
 
 on:
   push:
-    paths-ignore:
-      - "dotcom-rendering/**"
-
   workflow_dispatch:
 
 # Allow queued workflows to interrupt previous runs
@@ -71,4 +68,3 @@ jobs:
               - apps-rendering/dist/server/mobile-apps-rendering.zip
             mobile-assets:
               - apps-rendering/dist/assets/
-


### PR DESCRIPTION
We migrated to GHA in https://github.com/guardian/dotcom-rendering/pull/8886.

The repository has a status check on the AR build workflow, but the workflow doesn't always run because of the `paths-ignore`. This change removes the filter, so the action will always run and the status check will pass if the build is successful.

https://github.com/guardian/dotcom-rendering/blob/d50e5d486136e116bfd9e8da66961bb1dc0a7745/.github/workflows/ar-ci.yml#L5

