### PR TITLE
Migrate AR over to guardian/fonts

### DIFF
--- a/apps-rendering/config/rendered-items-assets-styles.ts
+++ b/apps-rendering/config/rendered-items-assets-styles.ts
@@ -1,8 +1,8 @@
-export const renederedItemsAssetsCss = `
+export const renderedItemsAssetsCss = `
 @font-face {
   font-family: Guardian Text Egyptian Web;
   font-weight: 400;
-  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Regular.ttf");
+  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Regular.ttf"), url("/assets/fonts/GuardianTextEgyptian-Reg.ttf");
 }
 .GuardianTextEgyptian-Reg {
   font-family: Guardian Text Egyptian Web;
@@ -12,7 +12,7 @@ export const renederedItemsAssetsCss = `
   font-family: Guardian Text Egyptian Web;
   font-style: italic;
   font-weight: 400;
-  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-RegularItalic.ttf");
+  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-RegularItalic.ttf"), url("/assets/fonts/GuardianTextEgyptian-RegItalic.ttf");
 }
 .GuardianTextEgyptian-RegItalic {
   font-family: Guardian Text Egyptian Web;
@@ -22,7 +22,7 @@ export const renederedItemsAssetsCss = `
 @font-face {
   font-family: Guardian Text Egyptian Web;
   font-weight: 700;
-  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Bold.ttf");
+  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Bold.ttf"), url("/assets/fonts/GuardianTextEgyptian-Bold.ttf");
 }
 .GuardianTextEgyptian-Bold {
   font-family: Guardian Text Egyptian Web;
@@ -32,7 +32,7 @@ export const renederedItemsAssetsCss = `
   font-family: Guardian Text Egyptian Web;
   font-style: italic;
   font-weight: 700;
-  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-BoldItalic.ttf");
+  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-BoldItalic.ttf"), url("/assets/fonts/GuardianTextEgyptian-BoldItalic.ttf");
 }
 .GuardianTextEgyptian-BoldItalic {
   font-family: Guardian Text Egyptian Web;
@@ -42,7 +42,7 @@ export const renederedItemsAssetsCss = `
 @font-face {
   font-family: Guardian Text Sans Web;
   font-weight: 400;
-  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Regular.ttf");
+  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Regular.ttf"), url("/assets/fonts/GuardianTextSans-Regular.ttf");
 }
 .GuardianTextSans-Regular {
   font-family: Guardian Text Sans Web;
@@ -52,7 +52,7 @@ export const renederedItemsAssetsCss = `
   font-family: Guardian Text Sans Web;
   font-style: italic;
   font-weight: 400;
-  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-RegularItalic.ttf");
+  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-RegularItalic.ttf"), url("/assets/fonts/GuardianTextSans-RegularItalic.ttf");
 }
 .GuardianTextSans-RegularItalic {
   font-family: Guardian Text Sans Web;
@@ -62,7 +62,7 @@ export const renederedItemsAssetsCss = `
 @font-face {
   font-family: Guardian Text Sans Web;
   font-weight: 700;
-  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Bold.ttf");
+  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Bold.ttf"), url("/assets/fonts/GuardianTextSans-Bold.ttf");
 }
 .GuardianTextSans-Bold {
   font-family: Guardian Text Sans Web;
@@ -72,7 +72,7 @@ export const renederedItemsAssetsCss = `
   font-family: Guardian Text Sans Web;
   font-style: italic;
   font-weight: 700;
-  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-BoldItalic.ttf");
+  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-BoldItalic.ttf"), url("/assets/fonts/GuardianTextSans-BoldItalic.ttf");
 }
 .GuardianTextSans-BoldItalic {
   font-family: Guardian Text Sans Web;
@@ -82,7 +82,7 @@ export const renederedItemsAssetsCss = `
 @font-face {
   font-family: GH Guardian Headline;
   font-weight: 300;
-  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Light.ttf");
+  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Light.ttf"), url("/assets/fonts/GHGuardianHeadline-Light.ttf");
 }
 .GHGuardianHeadline-Light {
   font-family: GH Guardian Headline;
@@ -92,7 +92,7 @@ export const renederedItemsAssetsCss = `
   font-family: GH Guardian Headline;
   font-style: italic;
   font-weight: 300;
-  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-LightItalic.ttf");
+  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-LightItalic.ttf"), url("/assets/fonts/GHGuardianHeadline-LightItalic.ttf");
 }
 .GHGuardianHeadline-LightItalic {
   font-family: GH Guardian Headline;
@@ -102,7 +102,7 @@ export const renederedItemsAssetsCss = `
 @font-face {
   font-family: GH Guardian Headline;
   font-weight: 400;
-  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Regular.ttf");
+  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Regular.ttf"), url("/assets/fonts/GHGuardianHeadline-Regular.ttf");
 }
 .GHGuardianHeadline-Regular {
   font-family: GH Guardian Headline;
@@ -112,7 +112,7 @@ export const renederedItemsAssetsCss = `
   font-family: GH Guardian Headline;
   font-style: italic;
   font-weight: 400;
-  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-RegularItalic.ttf");
+  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-RegularItalic.ttf"), url("/assets/fonts/GHGuardianHeadline-RegularItalic.ttf");
 }
 .GHGuardianHeadline-RegularItalic {
   font-family: GH Guardian Headline;
@@ -122,7 +122,7 @@ export const renederedItemsAssetsCss = `
 @font-face {
   font-family: GH Guardian Headline;
   font-weight: 500;
-  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Medium.ttf");
+  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Medium.ttf"), url("/assets/fonts/GHGuardianHeadline-Medium.ttf");
 }
 .GHGuardianHeadline-Medium {
   font-family: GH Guardian Headline;
@@ -132,7 +132,7 @@ export const renederedItemsAssetsCss = `
   font-family: GH Guardian Headline;
   font-style: italic;
   font-weight: 500;
-  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-MediumItalic.ttf");
+  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-MediumItalic.ttf"), url("/assets/fonts/GHGuardianHeadline-MediumItalic.ttf");
 }
 .GHGuardianHeadline-MediumItalic {
   font-family: GH Guardian Headline;
@@ -142,7 +142,7 @@ export const renederedItemsAssetsCss = `
 @font-face {
   font-family: GH Guardian Headline;
   font-weight: 600;
-  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Semibold.ttf");
+  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Semibold.ttf"), url("/assets/fonts/GHGuardianHeadline-Semibold.ttf");
 }
 .GHGuardianHeadline-Semibold {
   font-family: GH Guardian Headline;
@@ -152,7 +152,7 @@ export const renederedItemsAssetsCss = `
   font-family: GH Guardian Headline;
   font-style: italic;
   font-weight: 600;
-  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-SemiboldItalic.ttf");
+  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-SemiboldItalic.ttf"), url("/assets/fonts/GHGuardianHeadline-SemiboldItalic.ttf");
 }
 .GHGuardianHeadline-SemiboldItalic {
   font-family: GH Guardian Headline;
@@ -162,7 +162,7 @@ export const renederedItemsAssetsCss = `
 @font-face {
   font-family: GH Guardian Headline;
   font-weight: 700;
-  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Bold.ttf");
+  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Bold.ttf"), url("/assets/fonts/GHGuardianHeadline-Bold.ttf");
 }
 .GHGuardianHeadline-Bold {
   font-family: GH Guardian Headline;
@@ -172,7 +172,7 @@ export const renederedItemsAssetsCss = `
   font-family: GH Guardian Headline;
   font-style: italic;
   font-weight: 700;
-  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-BoldItalic.ttf");
+  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-BoldItalic.ttf"), url("/assets/fonts/GHGuardianHeadline-BoldItalic.ttf");
 }
 .GHGuardianHeadline-BoldItalic {
   font-family: GH Guardian Headline;

--- a/apps-rendering/config/rendered-items-assets-styles.ts
+++ b/apps-rendering/config/rendered-items-assets-styles.ts
@@ -2,7 +2,7 @@ export const renderedItemsAssetsCss = `
 @font-face {
   font-family: Guardian Text Egyptian Web;
   font-weight: 400;
-  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Regular.ttf"), url("/assets/fonts/GuardianTextEgyptian-Reg.ttf");
+  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Regular.ttf");
 }
 .GuardianTextEgyptian-Reg {
   font-family: Guardian Text Egyptian Web;
@@ -12,7 +12,7 @@ export const renderedItemsAssetsCss = `
   font-family: Guardian Text Egyptian Web;
   font-style: italic;
   font-weight: 400;
-  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-RegularItalic.ttf"), url("/assets/fonts/GuardianTextEgyptian-RegItalic.ttf");
+  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-RegularItalic.ttf");
 }
 .GuardianTextEgyptian-RegItalic {
   font-family: Guardian Text Egyptian Web;
@@ -22,7 +22,7 @@ export const renderedItemsAssetsCss = `
 @font-face {
   font-family: Guardian Text Egyptian Web;
   font-weight: 700;
-  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Bold.ttf"), url("/assets/fonts/GuardianTextEgyptian-Bold.ttf");
+  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Bold.ttf");
 }
 .GuardianTextEgyptian-Bold {
   font-family: Guardian Text Egyptian Web;
@@ -32,7 +32,7 @@ export const renderedItemsAssetsCss = `
   font-family: Guardian Text Egyptian Web;
   font-style: italic;
   font-weight: 700;
-  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-BoldItalic.ttf"), url("/assets/fonts/GuardianTextEgyptian-BoldItalic.ttf");
+  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-BoldItalic.ttf");
 }
 .GuardianTextEgyptian-BoldItalic {
   font-family: Guardian Text Egyptian Web;
@@ -42,7 +42,7 @@ export const renderedItemsAssetsCss = `
 @font-face {
   font-family: Guardian Text Sans Web;
   font-weight: 400;
-  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Regular.ttf"), url("/assets/fonts/GuardianTextSans-Regular.ttf");
+  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Regular.ttf");
 }
 .GuardianTextSans-Regular {
   font-family: Guardian Text Sans Web;
@@ -52,7 +52,7 @@ export const renderedItemsAssetsCss = `
   font-family: Guardian Text Sans Web;
   font-style: italic;
   font-weight: 400;
-  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-RegularItalic.ttf"), url("/assets/fonts/GuardianTextSans-RegularItalic.ttf");
+  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-RegularItalic.ttf");
 }
 .GuardianTextSans-RegularItalic {
   font-family: Guardian Text Sans Web;
@@ -62,7 +62,7 @@ export const renderedItemsAssetsCss = `
 @font-face {
   font-family: Guardian Text Sans Web;
   font-weight: 700;
-  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Bold.ttf"), url("/assets/fonts/GuardianTextSans-Bold.ttf");
+  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Bold.ttf");
 }
 .GuardianTextSans-Bold {
   font-family: Guardian Text Sans Web;
@@ -72,7 +72,7 @@ export const renderedItemsAssetsCss = `
   font-family: Guardian Text Sans Web;
   font-style: italic;
   font-weight: 700;
-  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-BoldItalic.ttf"), url("/assets/fonts/GuardianTextSans-BoldItalic.ttf");
+  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-BoldItalic.ttf");
 }
 .GuardianTextSans-BoldItalic {
   font-family: Guardian Text Sans Web;
@@ -82,7 +82,7 @@ export const renderedItemsAssetsCss = `
 @font-face {
   font-family: GH Guardian Headline;
   font-weight: 300;
-  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Light.ttf"), url("/assets/fonts/GHGuardianHeadline-Light.ttf");
+  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Light.ttf");
 }
 .GHGuardianHeadline-Light {
   font-family: GH Guardian Headline;
@@ -92,7 +92,7 @@ export const renderedItemsAssetsCss = `
   font-family: GH Guardian Headline;
   font-style: italic;
   font-weight: 300;
-  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-LightItalic.ttf"), url("/assets/fonts/GHGuardianHeadline-LightItalic.ttf");
+  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-LightItalic.ttf");
 }
 .GHGuardianHeadline-LightItalic {
   font-family: GH Guardian Headline;
@@ -102,7 +102,7 @@ export const renderedItemsAssetsCss = `
 @font-face {
   font-family: GH Guardian Headline;
   font-weight: 400;
-  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Regular.ttf"), url("/assets/fonts/GHGuardianHeadline-Regular.ttf");
+  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Regular.ttf");
 }
 .GHGuardianHeadline-Regular {
   font-family: GH Guardian Headline;
@@ -112,7 +112,7 @@ export const renderedItemsAssetsCss = `
   font-family: GH Guardian Headline;
   font-style: italic;
   font-weight: 400;
-  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-RegularItalic.ttf"), url("/assets/fonts/GHGuardianHeadline-RegularItalic.ttf");
+  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-RegularItalic.ttf");
 }
 .GHGuardianHeadline-RegularItalic {
   font-family: GH Guardian Headline;
@@ -122,7 +122,7 @@ export const renderedItemsAssetsCss = `
 @font-face {
   font-family: GH Guardian Headline;
   font-weight: 500;
-  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Medium.ttf"), url("/assets/fonts/GHGuardianHeadline-Medium.ttf");
+  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Medium.ttf");
 }
 .GHGuardianHeadline-Medium {
   font-family: GH Guardian Headline;
@@ -132,7 +132,7 @@ export const renderedItemsAssetsCss = `
   font-family: GH Guardian Headline;
   font-style: italic;
   font-weight: 500;
-  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-MediumItalic.ttf"), url("/assets/fonts/GHGuardianHeadline-MediumItalic.ttf");
+  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-MediumItalic.ttf");
 }
 .GHGuardianHeadline-MediumItalic {
   font-family: GH Guardian Headline;
@@ -142,7 +142,7 @@ export const renderedItemsAssetsCss = `
 @font-face {
   font-family: GH Guardian Headline;
   font-weight: 600;
-  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Semibold.ttf"), url("/assets/fonts/GHGuardianHeadline-Semibold.ttf");
+  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Semibold.ttf");
 }
 .GHGuardianHeadline-Semibold {
   font-family: GH Guardian Headline;
@@ -152,7 +152,7 @@ export const renderedItemsAssetsCss = `
   font-family: GH Guardian Headline;
   font-style: italic;
   font-weight: 600;
-  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-SemiboldItalic.ttf"), url("/assets/fonts/GHGuardianHeadline-SemiboldItalic.ttf");
+  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-SemiboldItalic.ttf");
 }
 .GHGuardianHeadline-SemiboldItalic {
   font-family: GH Guardian Headline;
@@ -162,7 +162,7 @@ export const renderedItemsAssetsCss = `
 @font-face {
   font-family: GH Guardian Headline;
   font-weight: 700;
-  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Bold.ttf"), url("/assets/fonts/GHGuardianHeadline-Bold.ttf");
+  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Bold.ttf");
 }
 .GHGuardianHeadline-Bold {
   font-family: GH Guardian Headline;
@@ -172,7 +172,7 @@ export const renderedItemsAssetsCss = `
   font-family: GH Guardian Headline;
   font-style: italic;
   font-weight: 700;
-  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-BoldItalic.ttf"), url("/assets/fonts/GHGuardianHeadline-BoldItalic.ttf");
+  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-BoldItalic.ttf");
 }
 .GHGuardianHeadline-BoldItalic {
   font-family: GH Guardian Headline;

--- a/apps-rendering/config/rendered-items-assets-styles.ts
+++ b/apps-rendering/config/rendered-items-assets-styles.ts
@@ -2,7 +2,7 @@ export const renederedItemsAssetsCss = `
 @font-face {
   font-family: Guardian Text Egyptian Web;
   font-weight: 400;
-  src: url("/assets/fonts/GuardianTextEgyptian-Reg.ttf");
+  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Regular.ttf");
 }
 .GuardianTextEgyptian-Reg {
   font-family: Guardian Text Egyptian Web;
@@ -12,7 +12,7 @@ export const renederedItemsAssetsCss = `
   font-family: Guardian Text Egyptian Web;
   font-style: italic;
   font-weight: 400;
-  src: url("/assets/fonts/GuardianTextEgyptian-RegItalic.ttf");
+  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-RegularItalic.ttf");
 }
 .GuardianTextEgyptian-RegItalic {
   font-family: Guardian Text Egyptian Web;
@@ -22,7 +22,7 @@ export const renederedItemsAssetsCss = `
 @font-face {
   font-family: Guardian Text Egyptian Web;
   font-weight: 700;
-  src: url("/assets/fonts/GuardianTextEgyptian-Bold.ttf");
+  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Bold.ttf");
 }
 .GuardianTextEgyptian-Bold {
   font-family: Guardian Text Egyptian Web;
@@ -32,7 +32,7 @@ export const renederedItemsAssetsCss = `
   font-family: Guardian Text Egyptian Web;
   font-style: italic;
   font-weight: 700;
-  src: url("/assets/fonts/GuardianTextEgyptian-BoldItalic.ttf");
+  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-BoldItalic.ttf");
 }
 .GuardianTextEgyptian-BoldItalic {
   font-family: Guardian Text Egyptian Web;
@@ -42,7 +42,7 @@ export const renederedItemsAssetsCss = `
 @font-face {
   font-family: Guardian Text Sans Web;
   font-weight: 400;
-  src: url("/assets/fonts/GuardianTextSans-Regular.ttf");
+  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Regular.ttf");
 }
 .GuardianTextSans-Regular {
   font-family: Guardian Text Sans Web;
@@ -52,7 +52,7 @@ export const renederedItemsAssetsCss = `
   font-family: Guardian Text Sans Web;
   font-style: italic;
   font-weight: 400;
-  src: url("/assets/fonts/GuardianTextSans-RegularItalic.ttf");
+  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-RegularItalic.ttf");
 }
 .GuardianTextSans-RegularItalic {
   font-family: Guardian Text Sans Web;
@@ -62,7 +62,7 @@ export const renederedItemsAssetsCss = `
 @font-face {
   font-family: Guardian Text Sans Web;
   font-weight: 700;
-  src: url("/assets/fonts/GuardianTextSans-Bold.ttf");
+  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Bold.ttf");
 }
 .GuardianTextSans-Bold {
   font-family: Guardian Text Sans Web;
@@ -72,7 +72,7 @@ export const renederedItemsAssetsCss = `
   font-family: Guardian Text Sans Web;
   font-style: italic;
   font-weight: 700;
-  src: url("/assets/fonts/GuardianTextSans-BoldItalic.ttf");
+  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-BoldItalic.ttf");
 }
 .GuardianTextSans-BoldItalic {
   font-family: Guardian Text Sans Web;
@@ -82,7 +82,7 @@ export const renederedItemsAssetsCss = `
 @font-face {
   font-family: GH Guardian Headline;
   font-weight: 300;
-  src: url("/assets/fonts/GHGuardianHeadline-Light.ttf");
+  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Light.ttf");
 }
 .GHGuardianHeadline-Light {
   font-family: GH Guardian Headline;
@@ -92,7 +92,7 @@ export const renederedItemsAssetsCss = `
   font-family: GH Guardian Headline;
   font-style: italic;
   font-weight: 300;
-  src: url("/assets/fonts/GHGuardianHeadline-LightItalic.ttf");
+  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-LightItalic.ttf");
 }
 .GHGuardianHeadline-LightItalic {
   font-family: GH Guardian Headline;
@@ -102,7 +102,7 @@ export const renederedItemsAssetsCss = `
 @font-face {
   font-family: GH Guardian Headline;
   font-weight: 400;
-  src: url("/assets/fonts/GHGuardianHeadline-Regular.ttf");
+  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Regular.ttf");
 }
 .GHGuardianHeadline-Regular {
   font-family: GH Guardian Headline;
@@ -112,7 +112,7 @@ export const renederedItemsAssetsCss = `
   font-family: GH Guardian Headline;
   font-style: italic;
   font-weight: 400;
-  src: url("/assets/fonts/GHGuardianHeadline-RegularItalic.ttf");
+  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-RegularItalic.ttf");
 }
 .GHGuardianHeadline-RegularItalic {
   font-family: GH Guardian Headline;
@@ -122,7 +122,7 @@ export const renederedItemsAssetsCss = `
 @font-face {
   font-family: GH Guardian Headline;
   font-weight: 500;
-  src: url("/assets/fonts/GHGuardianHeadline-Medium.ttf");
+  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Medium.ttf");
 }
 .GHGuardianHeadline-Medium {
   font-family: GH Guardian Headline;
@@ -132,7 +132,7 @@ export const renederedItemsAssetsCss = `
   font-family: GH Guardian Headline;
   font-style: italic;
   font-weight: 500;
-  src: url("/assets/fonts/GHGuardianHeadline-MediumItalic.ttf");
+  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-MediumItalic.ttf");
 }
 .GHGuardianHeadline-MediumItalic {
   font-family: GH Guardian Headline;
@@ -142,7 +142,7 @@ export const renederedItemsAssetsCss = `
 @font-face {
   font-family: GH Guardian Headline;
   font-weight: 600;
-  src: url("/assets/fonts/GHGuardianHeadline-Semibold.ttf");
+  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Semibold.ttf");
 }
 .GHGuardianHeadline-Semibold {
   font-family: GH Guardian Headline;
@@ -152,7 +152,7 @@ export const renederedItemsAssetsCss = `
   font-family: GH Guardian Headline;
   font-style: italic;
   font-weight: 600;
-  src: url("/assets/fonts/GHGuardianHeadline-SemiboldItalic.ttf");
+  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-SemiboldItalic.ttf");
 }
 .GHGuardianHeadline-SemiboldItalic {
   font-family: GH Guardian Headline;
@@ -162,7 +162,7 @@ export const renederedItemsAssetsCss = `
 @font-face {
   font-family: GH Guardian Headline;
   font-weight: 700;
-  src: url("/assets/fonts/GHGuardianHeadline-Bold.ttf");
+  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Bold.ttf");
 }
 .GHGuardianHeadline-Bold {
   font-family: GH Guardian Headline;
@@ -172,7 +172,7 @@ export const renederedItemsAssetsCss = `
   font-family: GH Guardian Headline;
   font-style: italic;
   font-weight: 700;
-  src: url("/assets/fonts/GHGuardianHeadline-BoldItalic.ttf");
+  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-BoldItalic.ttf");
 }
 .GHGuardianHeadline-BoldItalic {
   font-family: GH Guardian Headline;

--- a/apps-rendering/src/server/csp.ts
+++ b/apps-rendering/src/server/csp.ts
@@ -113,7 +113,7 @@ const buildCsp = (
 			? 'https://platform.twitter.com https://syndication.twitter.com https://twitter.com'
 			: ''
 	};
-    font-src 'self' https://interactive.guim.co.uk;
+    font-src 'self' https://assets.guim.co.uk https://interactive.guim.co.uk;
     connect-src 'self' https://callouts.code.dev-guardianapis.com/formstack-campaign/submit https://interactive.guim.co.uk https://sf-hs-sg.ibytedtos.com/ https://gdn-cdn.s3.amazonaws.com/;
     media-src 'self' https://audio.guim.co.uk/
 `.trim();
@@ -145,7 +145,7 @@ function buildCspEditions(
 			? 'https://platform.twitter.com https://syndication.twitter.com https://twitter.com'
 			: ''
 	};
-	font-src 'self' https://interactive.guim.co.uk https://editions-published-code.s3.eu-west-1.amazonaws.com https://editions-published-prod.s3.eu-west-1.amazonaws.com;
+	font-src 'self' https://assets.guim.co.uk https://interactive.guim.co.uk https://editions-published-code.s3.eu-west-1.amazonaws.com https://editions-published-prod.s3.eu-west-1.amazonaws.com;
 	connect-src 'self' https://callouts.code.dev-guardianapis.com/formstack-campaign/submit https://interactive.guim.co.uk https://sf-hs-sg.ibytedtos.com/ https://gdn-cdn.s3.amazonaws.com/;
 	media-src 'self' https://audio.guim.co.uk/
 	`;

--- a/apps-rendering/src/server/editionsPage.tsx
+++ b/apps-rendering/src/server/editionsPage.tsx
@@ -24,7 +24,7 @@ import { createElement as h } from 'react';
 import { renderToString } from 'react-dom/server';
 import { csp } from 'server/csp';
 import {
-	pageFonts as devFonts,
+	editionsDevFonts as devFonts,
 	editionsPreviewFonts as previewFonts,
 	editionsPageFonts as prodFonts,
 } from 'styles';

--- a/apps-rendering/src/styles.ts
+++ b/apps-rendering/src/styles.ts
@@ -148,129 +148,105 @@ export const fontFace = (
 `;
 
 export const pageFonts = `
-    ${fontFace(
-		'Guardian Text Egyptian Web',
-		some(400),
-		none,
-		'https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Regular.ttf',
-	)}
-    ${fontFace(
-		'Guardian Text Egyptian Web',
-		some(400),
-		some('italic'),
-		'https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-RegularItalic.ttf',
-	)}
-    ${fontFace(
-		'Guardian Text Egyptian Web',
-		some(700),
-		none,
-		'https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Bold.ttf',
-	)}
-    ${fontFace(
-		'Guardian Text Egyptian Web',
-		some(700),
-		some('italic'),
-		'https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-BoldItalic.ttf',
-	)}
-    ${fontFace(
-		'Guardian Text Egyptian Web',
-		some('bold'),
-		none,
-		'https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Bold.ttf',
-	)}
-    ${fontFace(
-		'Guardian Text Egyptian Web',
-		some('bold'),
-		some('italic'),
-		'https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-BoldItalic.ttf',
-	)}
-
-    ${fontFace(
-		'Guardian Text Sans Web',
-		some(400),
-		none,
-		'https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Regular.ttf',
-	)}
-    ${fontFace(
-		'Guardian Text Sans Web',
-		some(400),
-		some('italic'),
-		'https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-RegularItalic.ttf',
-	)}
-    ${fontFace(
-		'Guardian Text Sans Web',
-		some(700),
-		none,
-		'https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Bold.ttf',
-	)}
-    ${fontFace(
-		'Guardian Text Sans Web',
-		some(700),
-		some('italic'),
-		'https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-BoldItalic.ttf',
-	)}
-
-    ${fontFace(
-		'GH Guardian Headline',
-		some(300),
-		none,
-		'https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Light.ttf',
-	)}
-    ${fontFace(
-		'GH Guardian Headline',
-		some(300),
-		some('italic'),
-		'https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-LightItalic.ttf',
-	)}
-    ${fontFace(
-		'GH Guardian Headline',
-		some(400),
-		none,
-		'https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Regular.ttf',
-	)}
-    ${fontFace(
-		'GH Guardian Headline',
-		some(400),
-		some('italic'),
-		'https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-RegularItalic.ttf',
-	)}
-    ${fontFace(
-		'GH Guardian Headline',
-		some(500),
-		none,
-		'https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Medium.ttf',
-	)}
-    ${fontFace(
-		'GH Guardian Headline',
-		some(500),
-		some('italic'),
-		'https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-MediumItalic.ttf',
-	)}
-    ${fontFace(
-		'GH Guardian Headline',
-		some(600),
-		none,
-		'https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Semibold.ttf',
-	)}
-    ${fontFace(
-		'GH Guardian Headline',
-		some(600),
-		some('italic'),
-		'https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-SemiboldItalic.ttf',
-	)}
-    ${fontFace(
-		'GH Guardian Headline',
-		some(700),
-		none,
-		'https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Bold.ttf',
-	)}
-    ${fontFace(
-		'GH Guardian Headline',
-		some(700),
-		some('italic'),
-		'https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-BoldItalic.ttf',
-	)}
-
+@font-face {
+  font-family: Guardian Text Egyptian Web;
+  font-weight: 400;
+  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Regular.ttf"), url("/assets/fonts/GuardianTextEgyptian-Reg.ttf");
+}
+@font-face {
+  font-family: Guardian Text Egyptian Web;
+  font-style: italic;
+  font-weight: 400;
+  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-RegularItalic.ttf"), url("/assets/fonts/GuardianTextEgyptian-RegItalic.ttf");
+}
+@font-face {
+  font-family: Guardian Text Egyptian Web;
+  font-weight: 700;
+  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Bold.ttf"), url("/assets/fonts/GuardianTextEgyptian-Bold.ttf");
+}
+@font-face {
+  font-family: Guardian Text Egyptian Web;
+  font-style: italic;
+  font-weight: 700;
+  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-BoldItalic.ttf"), url("/assets/fonts/GuardianTextEgyptian-BoldItalic.ttf");
+}
+@font-face {
+  font-family: Guardian Text Sans Web;
+  font-weight: 400;
+  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Regular.ttf"), url("/assets/fonts/GuardianTextSans-Regular.ttf");
+}
+@font-face {
+  font-family: Guardian Text Sans Web;
+  font-style: italic;
+  font-weight: 400;
+  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-RegularItalic.ttf"), url("/assets/fonts/GuardianTextSans-RegularItalic.ttf");
+}
+@font-face {
+  font-family: Guardian Text Sans Web;
+  font-weight: 700;
+  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Bold.ttf"), url("/assets/fonts/GuardianTextSans-Bold.ttf");
+}
+@font-face {
+  font-family: Guardian Text Sans Web;
+  font-style: italic;
+  font-weight: 700;
+  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-BoldItalic.ttf"), url("/assets/fonts/GuardianTextSans-BoldItalic.ttf");
+}
+@font-face {
+  font-family: GH Guardian Headline;
+  font-weight: 300;
+  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Light.ttf"), url("/assets/fonts/GHGuardianHeadline-Light.ttf");
+}
+@font-face {
+  font-family: GH Guardian Headline;
+  font-style: italic;
+  font-weight: 300;
+  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-LightItalic.ttf"), url("/assets/fonts/GHGuardianHeadline-LightItalic.ttf");
+}
+@font-face {
+  font-family: GH Guardian Headline;
+  font-weight: 400;
+  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Regular.ttf"), url("/assets/fonts/GHGuardianHeadline-Regular.ttf");
+}
+@font-face {
+  font-family: GH Guardian Headline;
+  font-style: italic;
+  font-weight: 400;
+  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-RegularItalic.ttf"), url("/assets/fonts/GHGuardianHeadline-RegularItalic.ttf");
+}
+@font-face {
+  font-family: GH Guardian Headline;
+  font-weight: 500;
+  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Medium.ttf"), url("/assets/fonts/GHGuardianHeadline-Medium.ttf");
+}
+@font-face {
+  font-family: GH Guardian Headline;
+  font-style: italic;
+  font-weight: 500;
+  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-MediumItalic.ttf"), url("/assets/fonts/GHGuardianHeadline-MediumItalic.ttf");
+}
+@font-face {
+  font-family: GH Guardian Headline;
+  font-weight: 600;
+  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Semibold.ttf"), url("/assets/fonts/GHGuardianHeadline-Semibold.ttf");
+}
+@font-face {
+  font-family: GH Guardian Headline;
+  font-style: italic;
+  font-weight: 600;
+  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-SemiboldItalic.ttf"), url("/assets/fonts/GHGuardianHeadline-SemiboldItalic.ttf");
+}
+@font-face {
+  font-family: GH Guardian Headline;
+  font-weight: 700;
+  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Bold.ttf"), url("/assets/fonts/GHGuardianHeadline-Bold.ttf");
+}
+@font-face {
+  font-family: GH Guardian Headline;
+  font-style: italic;
+  font-weight: 700;
+  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-BoldItalic.ttf"), url("/assets/fonts/GHGuardianHeadline-BoldItalic.ttf");
+}
 `;
 
 export const editionsDevFonts = `

--- a/apps-rendering/src/styles.ts
+++ b/apps-rendering/src/styles.ts
@@ -273,6 +273,132 @@ export const pageFonts = `
 
 `;
 
+export const editionsDevFonts = `
+    ${fontFace(
+		'Guardian Text Egyptian Web',
+		some(400),
+		none,
+		'/assets/fonts/GuardianTextEgyptian-Reg.ttf',
+	)}
+    ${fontFace(
+		'Guardian Text Egyptian Web',
+		some(400),
+		some('italic'),
+		'/assets/fonts/GuardianTextEgyptian-RegItalic.ttf',
+	)}
+    ${fontFace(
+		'Guardian Text Egyptian Web',
+		some(700),
+		none,
+		'/assets/fonts/GuardianTextEgyptian-Bold.ttf',
+	)}
+    ${fontFace(
+		'Guardian Text Egyptian Web',
+		some(700),
+		some('italic'),
+		'/assets/fonts/GuardianTextEgyptian-BoldItalic.ttf',
+	)}
+    ${fontFace(
+		'Guardian Text Egyptian Web',
+		some('bold'),
+		none,
+		'/assets/fonts/GuardianTextEgyptian-Bold.ttf',
+	)}
+    ${fontFace(
+		'Guardian Text Egyptian Web',
+		some('bold'),
+		some('italic'),
+		'/assets/fonts/GuardianTextEgyptian-BoldItalic.ttf',
+	)}
+
+    ${fontFace(
+		'Guardian Text Sans Web',
+		some(400),
+		none,
+		'/assets/fonts/GuardianTextSans-Regular.ttf',
+	)}
+    ${fontFace(
+		'Guardian Text Sans Web',
+		some(400),
+		some('italic'),
+		'/assets/fonts/GuardianTextSans-RegularItalic.ttf',
+	)}
+    ${fontFace(
+		'Guardian Text Sans Web',
+		some(700),
+		none,
+		'/assets/fonts/GuardianTextSans-Bold.ttf',
+	)}
+    ${fontFace(
+		'Guardian Text Sans Web',
+		some(700),
+		some('italic'),
+		'/assets/fonts/GuardianTextSans-BoldItalic.ttf',
+	)}
+
+    ${fontFace(
+		'GH Guardian Headline',
+		some(300),
+		none,
+		'/assets/fonts/GHGuardianHeadline-Light.ttf',
+	)}
+    ${fontFace(
+		'GH Guardian Headline',
+		some(300),
+		some('italic'),
+		'/assets/fonts/GHGuardianHeadline-LightItalic.ttf',
+	)}
+    ${fontFace(
+		'GH Guardian Headline',
+		some(400),
+		none,
+		'/assets/fonts/GHGuardianHeadline-Regular.ttf',
+	)}
+    ${fontFace(
+		'GH Guardian Headline',
+		some(400),
+		some('italic'),
+		'/assets/fonts/GHGuardianHeadline-RegularItalic.ttf',
+	)}
+    ${fontFace(
+		'GH Guardian Headline',
+		some(500),
+		none,
+		'/assets/fonts/GHGuardianHeadline-Medium.ttf',
+	)}
+    ${fontFace(
+		'GH Guardian Headline',
+		some(500),
+		some('italic'),
+		'/assets/fonts/GHGuardianHeadline-MediumItalic.ttf',
+	)}
+    ${fontFace(
+		'GH Guardian Headline',
+		some(600),
+		none,
+		'/assets/fonts/GHGuardianHeadline-Semibold.ttf',
+	)}
+    ${fontFace(
+		'GH Guardian Headline',
+		some(600),
+		some('italic'),
+		'/assets/fonts/GHGuardianHeadline-SemiboldItalic.ttf',
+	)}
+    ${fontFace(
+		'GH Guardian Headline',
+		some(700),
+		none,
+		'/assets/fonts/GHGuardianHeadline-Bold.ttf',
+	)}
+    ${fontFace(
+		'GH Guardian Headline',
+		some(700),
+		some('italic'),
+		'/assets/fonts/GHGuardianHeadline-BoldItalic.ttf',
+	)}
+
+`;
+
 export const editionsPageFonts = `
     ${fontFace(
 		'Guardian Text Egyptian Web',

--- a/apps-rendering/src/styles.ts
+++ b/apps-rendering/src/styles.ts
@@ -152,123 +152,123 @@ export const pageFonts = `
 		'Guardian Text Egyptian Web',
 		some(400),
 		none,
-		'/assets/fonts/GuardianTextEgyptian-Reg.ttf',
+		'https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Regular.ttf',
 	)}
     ${fontFace(
 		'Guardian Text Egyptian Web',
 		some(400),
 		some('italic'),
-		'/assets/fonts/GuardianTextEgyptian-RegItalic.ttf',
+		'https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-RegularItalic.ttf',
 	)}
     ${fontFace(
 		'Guardian Text Egyptian Web',
 		some(700),
 		none,
-		'/assets/fonts/GuardianTextEgyptian-Bold.ttf',
+		'https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Bold.ttf',
 	)}
     ${fontFace(
 		'Guardian Text Egyptian Web',
 		some(700),
 		some('italic'),
-		'/assets/fonts/GuardianTextEgyptian-BoldItalic.ttf',
+		'https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-BoldItalic.ttf',
 	)}
     ${fontFace(
 		'Guardian Text Egyptian Web',
 		some('bold'),
 		none,
-		'/assets/fonts/GuardianTextEgyptian-Bold.ttf',
+		'https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Bold.ttf',
 	)}
     ${fontFace(
 		'Guardian Text Egyptian Web',
 		some('bold'),
 		some('italic'),
-		'/assets/fonts/GuardianTextEgyptian-BoldItalic.ttf',
+		'https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-BoldItalic.ttf',
 	)}
 
     ${fontFace(
 		'Guardian Text Sans Web',
 		some(400),
 		none,
-		'/assets/fonts/GuardianTextSans-Regular.ttf',
+		'https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Regular.ttf',
 	)}
     ${fontFace(
 		'Guardian Text Sans Web',
 		some(400),
 		some('italic'),
-		'/assets/fonts/GuardianTextSans-RegularItalic.ttf',
+		'https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-RegularItalic.ttf',
 	)}
     ${fontFace(
 		'Guardian Text Sans Web',
 		some(700),
 		none,
-		'/assets/fonts/GuardianTextSans-Bold.ttf',
+		'https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Bold.ttf',
 	)}
     ${fontFace(
 		'Guardian Text Sans Web',
 		some(700),
 		some('italic'),
-		'/assets/fonts/GuardianTextSans-BoldItalic.ttf',
+		'https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-BoldItalic.ttf',
 	)}
 
     ${fontFace(
 		'GH Guardian Headline',
 		some(300),
 		none,
-		'/assets/fonts/GHGuardianHeadline-Light.ttf',
+		'https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Light.ttf',
 	)}
     ${fontFace(
 		'GH Guardian Headline',
 		some(300),
 		some('italic'),
-		'/assets/fonts/GHGuardianHeadline-LightItalic.ttf',
+		'https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-LightItalic.ttf',
 	)}
     ${fontFace(
 		'GH Guardian Headline',
 		some(400),
 		none,
-		'/assets/fonts/GHGuardianHeadline-Regular.ttf',
+		'https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Regular.ttf',
 	)}
     ${fontFace(
 		'GH Guardian Headline',
 		some(400),
 		some('italic'),
-		'/assets/fonts/GHGuardianHeadline-RegularItalic.ttf',
+		'https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-RegularItalic.ttf',
 	)}
     ${fontFace(
 		'GH Guardian Headline',
 		some(500),
 		none,
-		'/assets/fonts/GHGuardianHeadline-Medium.ttf',
+		'https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Medium.ttf',
 	)}
     ${fontFace(
 		'GH Guardian Headline',
 		some(500),
 		some('italic'),
-		'/assets/fonts/GHGuardianHeadline-MediumItalic.ttf',
+		'https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-MediumItalic.ttf',
 	)}
     ${fontFace(
 		'GH Guardian Headline',
 		some(600),
 		none,
-		'/assets/fonts/GHGuardianHeadline-Semibold.ttf',
+		'https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Semibold.ttf',
 	)}
     ${fontFace(
 		'GH Guardian Headline',
 		some(600),
 		some('italic'),
-		'/assets/fonts/GHGuardianHeadline-SemiboldItalic.ttf',
+		'https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-SemiboldItalic.ttf',
 	)}
     ${fontFace(
 		'GH Guardian Headline',
 		some(700),
 		none,
-		'/assets/fonts/GHGuardianHeadline-Bold.ttf',
+		'https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Bold.ttf',
 	)}
     ${fontFace(
 		'GH Guardian Headline',
 		some(700),
 		some('italic'),
-		'/assets/fonts/GHGuardianHeadline-BoldItalic.ttf',
+		'https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-BoldItalic.ttf',
 	)}
 
 `;

--- a/apps-rendering/webpack.config.ts
+++ b/apps-rendering/webpack.config.ts
@@ -9,7 +9,7 @@ import HtmlWebpackPlugin from 'html-webpack-plugin';
 import type { Compiler, Configuration, ResolveOptions } from 'webpack';
 import webpack from 'webpack';
 import { WebpackManifestPlugin } from 'webpack-manifest-plugin';
-import { renederedItemsAssetsCss } from './config/rendered-items-assets-styles';
+import { renderedItemsAssetsCss } from './config/rendered-items-assets-styles';
 import { WebpackPluginInstance } from 'webpack';
 // Needed for TS to bring in the webpack-dev-server types, so it can merge
 // the 'devServer` field into the main webpack Configuration type
@@ -204,7 +204,7 @@ export const clientConfig: Configuration = {
 };
 
 const assetsTemplateCss = new CleanCSS()
-	.minify(renederedItemsAssetsCss)
+	.minify(renderedItemsAssetsCss)
 	.styles.trim();
 const assetHash = (asset: string): string =>
 	createHash('sha256').update(asset).digest('base64');


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Recreates [PR7796](https://github.com/guardian/dotcom-rendering/pull/7796) with some amendments.

Local fonts have been kept both for [fallback fonts ](https://www.w3.org/TR/css-fonts-3/#src-desc)for android devices that have not yet updated to the latest version and for Editions.  Editions dev fonts have been separated into their own object so that no changes have been made to the Editions pipeline. Whilst DCR might serve Editions at some point, it doesn't currently so we are leaving the Editions font mechanism as is.


## Test Plan

**iOS**
Before each test
- clear cache -> go offline -> check AR rendered article fonts are correct
- [x] Point asset prewarm to m.code rendered asset file with asset.guim font paths - fonts should succeed
 
**Android**
Before each test
clear cache -> check AR rendered article fonts are correct
Test Varitions
- [x] 1. Android main branch && MAPI fonts only on MAPI PROD - fonts should succeed
- [x] 2. Android main branch && asset.guim fonts only on MAPI code - fonts should fail
- [x] 2. Android header branch && asset.guim fonts only on MAPI code - fonts should succeed
- [x] 3. Android main branch && asset.guim fonts & backup fonts on MAPI code - fonts should succeed
- [x] 4. Android header branch && asset.guim fonts & backup fonts on MAPI code - fonts should succeed

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/20416599/636826d5-dbc7-4a9b-be0d-4d6744df5ec3
[after]: https://github.com/guardian/dotcom-rendering/assets/20416599/14c2dfcc-a53f-4e18-bc9a-f474840243b7

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
