### PR TITLE
Refactor webpack to use ESM (ECMAScript Modules)

### DIFF
--- a/dotcom-rendering/makefile
+++ b/dotcom-rendering/makefile
@@ -28,14 +28,14 @@ riffraff-bundle: clean-dist build cdk-synth
 
 build: clean-dist install
 	$(call log, "building production bundles")
-	@NODE_ENV=production webpack --config ./scripts/webpack/webpack.config.js --progress
+	@NODE_ENV=production webpack --config ./scripts/webpack/webpack.config.mjs --progress
 	$(call log, "generating Islands report card")
 	@node ./scripts/islands/island-descriptions.mjs
 
 
 build-ci: clean-dist install
 	$(call log, "building production bundles")
-	@NODE_ENV=production webpack --config ./scripts/webpack/webpack.config.js
+	@NODE_ENV=production webpack --config ./scripts/webpack/webpack.config.mjs
 
 start-ci: install
 	$(call log, "starting PROD server...")
@@ -76,20 +76,20 @@ run-ci: stop build-ci start-ci
 
 dev: clear clean-dist install
 	$(call log, "starting DEV server")
-	@NODE_ENV=development webpack serve --config ./scripts/webpack/webpack.config.js
+	@NODE_ENV=development webpack serve --config ./scripts/webpack/webpack.config.mjs
 
 dev-variant: clear clean-dist install
 	$(call log, "starting DEV server")
-	@NODE_ENV=development BUILD_VARIANT=true webpack serve --config ./scripts/webpack/webpack.config.js
+	@NODE_ENV=development BUILD_VARIANT=true webpack serve --config ./scripts/webpack/webpack.config.mjs
 
 dev-legacy: clear clean-dist install
 	$(call log, "starting DEV server")
-	@NODE_ENV=development BUILD_LEGACY=true webpack serve --config ./scripts/webpack/webpack.config.js
+	@NODE_ENV=development BUILD_LEGACY=true webpack serve --config ./scripts/webpack/webpack.config.mjs
 
 dev-debug: clear clean-dist install
 	$(call log, "starting DEV server and debugger")
 	$(call log, "Open chrome://inspect in Chrome to attach to the debugger")
-	@NODE_ENV=development NODE_OPTIONS="--inspect" webpack serve --config ./scripts/webpack/webpack.config.js
+	@NODE_ENV=development NODE_OPTIONS="--inspect" webpack serve --config ./scripts/webpack/webpack.config.mjs
 
 # storybook #########################################
 
@@ -177,7 +177,7 @@ reinstall: clear clean-deps install
 validate-build: # private
 	$(call log, "checking bundling")
 	@rm -rf dist
-	@NODE_ENV=production webpack --config ./scripts/webpack/webpack.config.js
+	@NODE_ENV=production webpack --config ./scripts/webpack/webpack.config.mjs
 
 check-env: # private
 	$(call log, "checking environment")

--- a/dotcom-rendering/scripts/test/build-check.js
+++ b/dotcom-rendering/scripts/test/build-check.js
@@ -7,7 +7,7 @@
 
 const find = require('find');
 const loadJsonFile = require('load-json-file');
-const { BUILD_VARIANT } = require('../webpack/bundles');
+const { BUILD_VARIANT } = require('../webpack/bundles.mjs');
 
 const errorAndThrow = (error) => {
 	console.error(error);

--- a/dotcom-rendering/scripts/webpack/bundles.mjs
+++ b/dotcom-rendering/scripts/webpack/bundles.mjs
@@ -26,8 +26,4 @@ const dcrJavascriptBundle = (variant) => `dcrJavascriptBundle${variant}`;
 /** @type {(variant: 'Variant' | 'Control') => import("../../src/types/config").ServerSideTestNames} */
 const ophanEsm = (variant) => `ophanEsm${variant}`;
 
-module.exports = {
-	BUILD_VARIANT,
-	dcrJavascriptBundle,
-	ophanEsm,
-};
+export { BUILD_VARIANT, dcrJavascriptBundle, ophanEsm };

--- a/dotcom-rendering/scripts/webpack/webpack.config.client.mjs
+++ b/dotcom-rendering/scripts/webpack/webpack.config.client.mjs
@@ -1,10 +1,12 @@
-const webpack = require('webpack');
-const { WebpackManifestPlugin } = require('webpack-manifest-plugin');
-const swcConfig = require('./.swcrc.json');
-const { getBrowserTargets } = require('./browser-targets');
+// @ts-check
+import webpack from 'webpack';
+import { WebpackManifestPlugin } from 'webpack-manifest-plugin';
+import swcConfig from './.swcrc.json' assert { type: 'json' };
+import browserTargets from './browser-targets.js';
 
 const DEV = process.env.NODE_ENV === 'development';
 
+/** @param {Record<string, string> | string[]} targets */
 const swcLoader = (targets) => [
 	{
 		loader: 'swc-loader',
@@ -44,7 +46,7 @@ const getEntryIndex = (build) => {
 
 /**
  * @param {Build} build
- * @returns {string}
+ * @returns {webpack.RuleSetUse}
  */
 const getLoaders = (build) => {
 	switch (build) {
@@ -81,7 +83,7 @@ const getLoaders = (build) => {
 		case 'web.variant':
 		case 'web.ophan-esm':
 		case 'web':
-			return swcLoader(getBrowserTargets());
+			return swcLoader(browserTargets.getBrowserTargets());
 	}
 };
 
@@ -89,7 +91,8 @@ const getLoaders = (build) => {
  * @param {{ build: Build, sessionId: string }} options
  * @returns {import('webpack').Configuration}
  */
-module.exports = ({ build, sessionId }) => ({
+// eslint-disable-next-line import/no-default-export -- this is what Webpack wants
+export default ({ build, sessionId }) => ({
 	entry: {
 		index: getEntryIndex(build),
 		debug: './src/client/debug/index.ts',
@@ -135,7 +138,7 @@ module.exports = ({ build, sessionId }) => ({
 	output: {
 		filename: (data) => {
 			// We don't want to hash the debug script so it can be used in bookmarklets
-			if (data.chunk.name === 'debug') return `[name].js`;
+			if (data.chunk?.name === 'debug') return `[name].js`;
 			return generateName(build);
 		},
 		chunkFilename: generateName(build),
@@ -160,7 +163,7 @@ module.exports = ({ build, sessionId }) => ({
 		rules: [
 			{
 				test: /\.[jt]sx?|mjs$/,
-				exclude: module.exports.babelExclude,
+				exclude: babelExclude,
 				use: getLoaders(build),
 			},
 			{
@@ -175,7 +178,7 @@ module.exports = ({ build, sessionId }) => ({
 	},
 });
 
-module.exports.babelExclude = {
+export const babelExclude = {
 	and: [/node_modules/],
 	not: [
 		// Include all @guardian modules, except automat-modules
@@ -185,4 +188,4 @@ module.exports.babelExclude = {
 	],
 };
 
-module.exports.getLoaders = getLoaders;
+export { getLoaders };

--- a/dotcom-rendering/scripts/webpack/webpack.config.dev-server.mjs
+++ b/dotcom-rendering/scripts/webpack/webpack.config.dev-server.mjs
@@ -1,11 +1,12 @@
 // @ts-check
-const path = require('node:path');
-const bodyParser = require('body-parser');
-const chalk = require('chalk');
-const webpackHotServerMiddleware = require('webpack-hot-server-middleware');
-const {
-	getContentFromURLMiddleware,
-} = require('../../src/server/lib/get-content-from-url');
+import path, { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import bodyParser from 'body-parser';
+import chalk from 'chalk';
+import webpackHotServerMiddleware from 'webpack-hot-server-middleware';
+import { getContentFromURLMiddleware } from '../../src/server/lib/get-content-from-url.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 const port = 3030;
 
@@ -15,7 +16,8 @@ console.log(
 	)}`,
 );
 
-module.exports = {
+// eslint-disable-next-line import/no-default-export -- this is what Webpack wants
+export default {
 	/** @type {import('webpack-dev-server').Configuration} */
 	devServer: {
 		compress: false,

--- a/dotcom-rendering/scripts/webpack/webpack.config.server.mjs
+++ b/dotcom-rendering/scripts/webpack/webpack.config.server.mjs
@@ -1,11 +1,11 @@
 // @ts-check
-const nodeExternals = require('webpack-node-externals');
-const swcConfig = require('./.swcrc.json');
+import nodeExternals from 'webpack-node-externals';
+import swcConfig from './.swcrc.json' assert { type: 'json' };
 
 const DEV = process.env.NODE_ENV === 'development';
 const nodeVersion = process.versions.node;
 
-const swcLoader = [
+export const swcLoader = [
 	{
 		loader: 'swc-loader',
 		options: {
@@ -21,7 +21,8 @@ const swcLoader = [
 ];
 
 /** @type {(options: { sessionId: string } ) => import('webpack').Configuration} */
-module.exports = ({ sessionId }) => ({
+// eslint-disable-next-line import/no-default-export -- this is what Webpack wants
+export default ({ sessionId }) => ({
 	entry: {
 		server: './src/server/index.ts',
 	},

--- a/dotcom-rendering/src/client/sentryLoader/index.ts
+++ b/dotcom-rendering/src/client/sentryLoader/index.ts
@@ -1,7 +1,7 @@
 import {
 	BUILD_VARIANT,
 	dcrJavascriptBundle,
-} from '../../../scripts/webpack/bundles';
+} from '../../../scripts/webpack/bundles.mjs';
 import { loadSentryOnError, stubSentry } from './loadSentry';
 
 type IsSentryEnabled = {

--- a/dotcom-rendering/src/client/sentryLoader/sentry.ts
+++ b/dotcom-rendering/src/client/sentryLoader/sentry.ts
@@ -5,7 +5,7 @@ import {
 	BUILD_VARIANT,
 	dcrJavascriptBundle,
 	ophanEsm,
-} from '../../../scripts/webpack/bundles';
+} from '../../../scripts/webpack/bundles.mjs';
 
 const allowUrls: BrowserOptions['allowUrls'] = [
 	/webpack-internal/,

--- a/dotcom-rendering/src/lib/assets.test.ts
+++ b/dotcom-rendering/src/lib/assets.test.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'node:fs';
-import { BUILD_VARIANT } from '../../scripts/webpack/bundles';
+import { BUILD_VARIANT } from '../../scripts/webpack/bundles.mjs';
 import {
 	APPS_SCRIPT,
 	decideAssetOrigin,

--- a/dotcom-rendering/src/lib/assets.ts
+++ b/dotcom-rendering/src/lib/assets.ts
@@ -5,7 +5,7 @@ import {
 	BUILD_VARIANT,
 	dcrJavascriptBundle,
 	ophanEsm,
-} from '../../scripts/webpack/bundles';
+} from '../../scripts/webpack/bundles.mjs';
 import type { ServerSideTests, Switches } from '../types/config';
 import { makeMemoizedFunction } from './memoize';
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Refactor Webpack configs to use ES Modules explicitely

## Why?

Split out from #8535 to keep changes small
