### PR TITLE
Island handle their own placeholders

### DIFF
--- a/dotcom-rendering/cypress/e2e/parallel-3/article.interactivity.cy.js
+++ b/dotcom-rendering/cypress/e2e/parallel-3/article.interactivity.cy.js
@@ -62,7 +62,7 @@ describe('Interactivity', function () {
 			cy.get('gu-island[name=DiscussionContainer]').should(
 				'have.attr',
 				'data-island-status',
-				'rendered',
+				'hydrated',
 			);
 			cy.get('[id=comment-154433663]').should('be.visible');
 		});

--- a/dotcom-rendering/cypress/e2e/parallel-4/signedin.cy.js
+++ b/dotcom-rendering/cypress/e2e/parallel-4/signedin.cy.js
@@ -111,7 +111,7 @@ describe('Signed in readers', function () {
 		cy.get('gu-island[name=DiscussionContainer]').should(
 			'have.attr',
 			'data-island-status',
-			'rendered',
+			'hydrated',
 		);
 		// Check that the page is showing the reader as signed out
 		cy.contains('Sign in or create');

--- a/dotcom-rendering/cypress/e2e/parallel-6/paid.content.cy.js
+++ b/dotcom-rendering/cypress/e2e/parallel-6/paid.content.cy.js
@@ -109,7 +109,7 @@ describe('Paid content tests', function () {
 		cy.get('gu-island[name=OnwardsUpper]', { timeout: 30000 }).should(
 			'have.attr',
 			'data-island-status',
-			'rendered',
+			'hydrated',
 		);
 
 		cy.get('[data-cy=card-branding-logo]').should('be.visible');

--- a/dotcom-rendering/src/components/Discussion.tsx
+++ b/dotcom-rendering/src/components/Discussion.tsx
@@ -6,6 +6,7 @@ import { EditorialButton } from '@guardian/source-react-components-development-k
 import { useEffect, useState } from 'react';
 import { decidePalette } from '../lib/decidePalette';
 import { getCommentContext } from '../lib/getCommentContext';
+import { isServer } from '../lib/isServer';
 import { revealStyles } from '../lib/revealStyles';
 import { useDiscussion } from '../lib/useDiscussion';
 import type { SignedInUser } from '../types/discussion';
@@ -87,11 +88,10 @@ export const Discussion = ({
 
 	const palette = decidePalette(format);
 
-	const hasCommentsHash =
-		typeof window !== 'undefined' && window.location.hash === '#comments';
+	const hasCommentsHash = !isServer && window.location.hash === '#comments';
 
 	const handlePermalink = (commentId: number) => {
-		if (typeof window === 'undefined') return false;
+		if (isServer) return false;
 		window.location.hash = `#comment-${commentId}`;
 		// Put this comment id into the hashCommentId state which will
 		// trigger an api call to get the comment context and then expand
@@ -101,6 +101,7 @@ export const Discussion = ({
 	};
 
 	const dispatchCommentsExpandedEvent = () => {
+		if (isServer) return;
 		const event = new CustomEvent('comments-expanded');
 		document.dispatchEvent(event);
 	};
@@ -130,6 +131,7 @@ export const Discussion = ({
 	}, [hasCommentsHash]);
 
 	useEffect(() => {
+		if (isServer) return;
 		const pendingElements = document.querySelectorAll<HTMLElement>(
 			'.discussion > .pending',
 		);

--- a/dotcom-rendering/src/components/DiscussionContainer.importable.tsx
+++ b/dotcom-rendering/src/components/DiscussionContainer.importable.tsx
@@ -1,5 +1,5 @@
-import { isServer } from '../lib/isServer';
 import { useAuthStatus } from '../lib/useAuthStatus';
+import { useHydrated } from '../lib/useHydrated';
 import type { Props as DiscussionProps } from './Discussion';
 import { Discussion } from './Discussion';
 import { DiscussionWhenSignedIn } from './DiscussionWhenSignedIn';
@@ -30,9 +30,10 @@ import { Placeholder } from './Placeholder';
  */
 
 export const DiscussionContainer = (props: DiscussionProps) => {
+	const hydrated = useHydrated();
 	const authStatus = useAuthStatus();
 
-	if (isServer) return <Placeholder height={324} />;
+	if (!hydrated) return <Placeholder height={324} />;
 
 	const isSignedIn =
 		authStatus.kind === 'SignedInWithOkta' ||

--- a/dotcom-rendering/src/components/DiscussionContainer.importable.tsx
+++ b/dotcom-rendering/src/components/DiscussionContainer.importable.tsx
@@ -1,7 +1,9 @@
+import { isServer } from '../lib/isServer';
 import { useAuthStatus } from '../lib/useAuthStatus';
 import type { Props as DiscussionProps } from './Discussion';
 import { Discussion } from './Discussion';
 import { DiscussionWhenSignedIn } from './DiscussionWhenSignedIn';
+import { Placeholder } from './Placeholder';
 
 /**
  * A wrapper component that decides if the user is signed in or not.
@@ -29,6 +31,9 @@ import { DiscussionWhenSignedIn } from './DiscussionWhenSignedIn';
 
 export const DiscussionContainer = (props: DiscussionProps) => {
 	const authStatus = useAuthStatus();
+
+	if (isServer) return <Placeholder height={324} />;
+
 	const isSignedIn =
 		authStatus.kind === 'SignedInWithOkta' ||
 		authStatus.kind === 'SignedInWithCookies';

--- a/dotcom-rendering/src/components/DiscussionLayout.tsx
+++ b/dotcom-rendering/src/components/DiscussionLayout.tsx
@@ -69,11 +69,7 @@ export const DiscussionLayout = ({
 							max-width: 100%;
 						`}
 					>
-						<Island
-							clientOnly={true}
-							deferUntil="visible"
-							placeholderHeight={324}
-						>
+						<Island deferUntil="visible">
 							<DiscussionContainer
 								format={format}
 								discussionApiUrl={discussionApiUrl}

--- a/dotcom-rendering/src/components/EmailSignUpSwitcher.tsx
+++ b/dotcom-rendering/src/components/EmailSignUpSwitcher.tsx
@@ -19,7 +19,7 @@ export const EmailSignUpSwitcher = ({
 	const { renderingTarget } = useConfig();
 
 	return renderingTarget === 'Apps' ? (
-		<Island clientOnly={true} deferUntil={'idle'}>
+		<Island clientOnly={true} deferUntil="idle">
 			<AppEmailSignUp skipToIndex={index} {...emailSignUpProps} />
 		</Island>
 	) : (

--- a/dotcom-rendering/src/components/OnwardsUpper.importable.tsx
+++ b/dotcom-rendering/src/components/OnwardsUpper.importable.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import { joinUrl, Pillar } from '@guardian/libs';
 import type { EditionId } from '../lib/edition';
-import { isServer } from '../lib/isServer';
+import { useHydrated } from '../lib/useHydrated';
 import type { OnwardsSource } from '../types/onwards';
 import type { TagType } from '../types/tag';
 import { FetchOnwardsData } from './FetchOnwardsData.importable';
@@ -206,7 +206,8 @@ export const OnwardsUpper = ({
 	shortUrlId,
 	discussionApiUrl,
 }: Props) => {
-	if (isServer) return <Placeholder height={600} />;
+	const hydrated = useHydrated();
+	if (!hydrated) return <Placeholder height={600} />;
 
 	// Related content can be a collection of articles based on
 	// two things, 1: A popular tag, or 2: A generic text match

--- a/dotcom-rendering/src/components/OnwardsUpper.importable.tsx
+++ b/dotcom-rendering/src/components/OnwardsUpper.importable.tsx
@@ -1,9 +1,11 @@
 import { css } from '@emotion/react';
 import { joinUrl, Pillar } from '@guardian/libs';
 import type { EditionId } from '../lib/edition';
+import { isServer } from '../lib/isServer';
 import type { OnwardsSource } from '../types/onwards';
 import type { TagType } from '../types/tag';
 import { FetchOnwardsData } from './FetchOnwardsData.importable';
+import { Placeholder } from './Placeholder';
 import { Section } from './Section';
 
 type PillarForContainer =
@@ -204,6 +206,8 @@ export const OnwardsUpper = ({
 	shortUrlId,
 	discussionApiUrl,
 }: Props) => {
+	if (isServer) return <Placeholder height={600} />;
+
 	// Related content can be a collection of articles based on
 	// two things, 1: A popular tag, or 2: A generic text match
 	const tagToFilterBy = firstPopularTag(keywordIds, isPaidContent);

--- a/dotcom-rendering/src/components/SecureSignup.tsx
+++ b/dotcom-rendering/src/components/SecureSignup.tsx
@@ -68,7 +68,7 @@ export const SecureSignup = ({
 
 	return (
 		<>
-			<Island clientOnly={true} deferUntil="idle">
+			<Island deferUntil="idle">
 				<SecureSignupIframe
 					name={name}
 					html={html}

--- a/dotcom-rendering/src/components/SecureSignup.tsx
+++ b/dotcom-rendering/src/components/SecureSignup.tsx
@@ -68,11 +68,7 @@ export const SecureSignup = ({
 
 	return (
 		<>
-			<Island
-				clientOnly={true}
-				deferUntil={'idle'}
-				placeholderHeight={65}
-			>
+			<Island clientOnly={true} deferUntil="idle">
 				<SecureSignupIframe
 					name={name}
 					html={html}

--- a/dotcom-rendering/src/components/SecureSignupIframe.importable.tsx
+++ b/dotcom-rendering/src/components/SecureSignupIframe.importable.tsx
@@ -20,6 +20,7 @@ import {
 	submitComponentEvent,
 } from '../client/ophan/ophan';
 import { isServer } from '../lib/isServer';
+import { Placeholder } from './Placeholder';
 
 // The Google documentation specifies that if the 'recaptcha-badge' is hidden,
 // their T+C's must be displayed instead. While this component hides the
@@ -208,6 +209,8 @@ export const SecureSignupIframe = ({
 	const [errorMessage, setErrorMessage] = useState<string | undefined>(
 		undefined,
 	);
+
+	if (isServer) return <Placeholder height={65} />;
 
 	const hasResponse = typeof responseOk === 'boolean';
 

--- a/dotcom-rendering/src/components/SecureSignupIframe.importable.tsx
+++ b/dotcom-rendering/src/components/SecureSignupIframe.importable.tsx
@@ -20,6 +20,7 @@ import {
 	submitComponentEvent,
 } from '../client/ophan/ophan';
 import { isServer } from '../lib/isServer';
+import { useHydrated } from '../lib/useHydrated';
 import { Placeholder } from './Placeholder';
 
 // The Google documentation specifies that if the 'recaptcha-badge' is hidden,
@@ -210,7 +211,8 @@ export const SecureSignupIframe = ({
 		undefined,
 	);
 
-	if (isServer) return <Placeholder height={65} />;
+	const hydrated = useHydrated();
+	if (!hydrated) return <Placeholder height={65} />;
 
 	const hasResponse = typeof responseOk === 'boolean';
 

--- a/dotcom-rendering/src/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/layouts/CommentLayout.tsx
@@ -720,11 +720,7 @@ export const CommentLayout = ({ article, NAV, format }: Props) => {
 					</Section>
 				)}
 
-				<Island
-					clientOnly={true}
-					deferUntil="visible"
-					placeholderHeight={600}
-				>
+				<Island clientOnly={true} deferUntil="visible">
 					<OnwardsUpper
 						ajaxUrl={article.config.ajaxUrl}
 						hasRelated={article.hasRelated}
@@ -840,7 +836,7 @@ export const CommentLayout = ({ article, NAV, format }: Props) => {
 			</Section>
 
 			<BannerWrapper>
-				<Island deferUntil="idle" clientOnly={true}>
+				<Island clientOnly={true} deferUntil="idle">
 					<StickyBottomBanner
 						contentType={article.contentType}
 						contributionsServiceUrl={contributionsServiceUrl}

--- a/dotcom-rendering/src/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/layouts/CommentLayout.tsx
@@ -720,7 +720,7 @@ export const CommentLayout = ({ article, NAV, format }: Props) => {
 					</Section>
 				)}
 
-				<Island clientOnly={true} deferUntil="visible">
+				<Island deferUntil="visible">
 					<OnwardsUpper
 						ajaxUrl={article.config.ajaxUrl}
 						hasRelated={article.hasRelated}
@@ -836,7 +836,7 @@ export const CommentLayout = ({ article, NAV, format }: Props) => {
 			</Section>
 
 			<BannerWrapper>
-				<Island clientOnly={true} deferUntil="idle">
+				<Island deferUntil="idle" clientOnly={true}>
 					<StickyBottomBanner
 						contentType={article.contentType}
 						contributionsServiceUrl={contributionsServiceUrl}

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -192,7 +192,7 @@ const decideLeftContent = (
 		!hasPageSkin
 	) {
 		return (
-			<Island deferUntil={'idle'}>
+			<Island deferUntil="idle">
 				<WeatherWrapper
 					ajaxUrl={front.config.ajaxUrl}
 					edition={front.editionId}
@@ -679,7 +679,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 									}
 									hasPageSkin={hasPageSkin}
 								>
-									<Island deferUntil={'visible'}>
+									<Island deferUntil="visible">
 										<Carousel
 											heading={collection.displayName}
 											trails={trails}

--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -768,11 +768,7 @@ export const ImmersiveLayout = ({ article, NAV, format }: Props) => {
 					</Section>
 				)}
 
-				<Island
-					clientOnly={true}
-					deferUntil="visible"
-					placeholderHeight={600}
-				>
+				<Island deferUntil="visible">
 					<OnwardsUpper
 						ajaxUrl={article.config.ajaxUrl}
 						hasRelated={article.hasRelated}

--- a/dotcom-rendering/src/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/InteractiveLayout.tsx
@@ -636,11 +636,7 @@ export const InteractiveLayout = ({ article, NAV, format }: Props) => {
 					</Section>
 				)}
 
-				<Island
-					clientOnly={true}
-					deferUntil="visible"
-					placeholderHeight={600}
-				>
+				<Island deferUntil="visible">
 					<OnwardsUpper
 						ajaxUrl={article.config.ajaxUrl}
 						hasRelated={article.hasRelated}

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -451,11 +451,7 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 							/>
 						</Hide>
 
-						<Island
-							deferUntil="visible"
-							clientOnly={true}
-							placeholderHeight={230}
-						>
+						<Island deferUntil="visible">
 							<GetMatchNav
 								matchUrl={footballMatchUrl}
 								format={format}
@@ -678,10 +674,7 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 							<GridItem area="media">
 								<div css={maxWidth}>
 									{!!footballMatchUrl && (
-										<Island
-											clientOnly={true}
-											placeholderHeight={40}
-										>
+										<Island>
 											<GetMatchTabs
 												matchUrl={footballMatchUrl}
 												format={format}
@@ -689,10 +682,7 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 										</Island>
 									)}
 									{!!cricketMatchUrl && (
-										<Island
-											clientOnly={true}
-											placeholderHeight={172}
-										>
+										<Island>
 											<GetCricketScoreboard
 												matchUrl={cricketMatchUrl}
 												format={format}
@@ -778,11 +768,7 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 								)}
 								{/* Match stats */}
 								{!!footballMatchUrl && (
-									<Island
-										deferUntil="visible"
-										clientOnly={true}
-										placeholderHeight={800}
-									>
+									<Island deferUntil="visible">
 										<GetMatchStats
 											matchUrl={footballMatchUrl}
 											format={format}
@@ -1179,11 +1165,7 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 						</Section>
 					)}
 
-					<Island
-						clientOnly={true}
-						deferUntil="visible"
-						placeholderHeight={600}
-					>
+					<Island deferUntil="visible">
 						<OnwardsUpper
 							ajaxUrl={article.config.ajaxUrl}
 							hasRelated={article.hasRelated}

--- a/dotcom-rendering/src/layouts/NewsletterSignupLayout.tsx
+++ b/dotcom-rendering/src/layouts/NewsletterSignupLayout.tsx
@@ -518,11 +518,7 @@ export const NewsletterSignupLayout = ({ article, NAV, format }: Props) => {
 					</Section>
 				)}
 
-				<Island
-					clientOnly={true}
-					deferUntil="visible"
-					placeholderHeight={600}
-				>
+				<Island deferUntil="visible">
 					<OnwardsUpper
 						ajaxUrl={article.config.ajaxUrl}
 						hasRelated={article.hasRelated}

--- a/dotcom-rendering/src/layouts/PictureLayout.tsx
+++ b/dotcom-rendering/src/layouts/PictureLayout.tsx
@@ -75,7 +75,7 @@ const PictureGrid = ({ children }: { children: React.ReactNode }) => (
 					Vertical grey border
 					Main content
 					Right Column
-					
+
 				*/
 				${from.wide} {
 					grid-template-columns: 219px 1px 1fr;
@@ -591,11 +591,7 @@ export const PictureLayout = ({ article, NAV, format }: Props) => {
 					</Section>
 				)}
 
-				<Island
-					clientOnly={true}
-					deferUntil="visible"
-					placeholderHeight={600}
-				>
+				<Island deferUntil="visible">
 					<OnwardsUpper
 						ajaxUrl={article.config.ajaxUrl}
 						hasRelated={article.hasRelated}

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -688,11 +688,7 @@ export const ShowcaseLayout = ({ article, NAV, format }: Props) => {
 					</Section>
 				)}
 
-				<Island
-					clientOnly={true}
-					deferUntil="visible"
-					placeholderHeight={600}
-				>
+				<Island deferUntil="visible">
 					<OnwardsUpper
 						ajaxUrl={article.config.ajaxUrl}
 						hasRelated={article.hasRelated}

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -493,11 +493,7 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 						<GridItem area="matchNav" element="aside">
 							<div css={maxWidth}>
 								{isMatchReport && (
-									<Island
-										deferUntil="visible"
-										clientOnly={true}
-										placeholderHeight={230}
-									>
+									<Island deferUntil="visible">
 										<GetMatchNav
 											matchUrl={footballMatchUrl}
 											format={format}
@@ -514,10 +510,7 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 						<GridItem area="matchtabs" element="aside">
 							<div css={maxWidth}>
 								{isMatchReport && (
-									<Island
-										clientOnly={true}
-										placeholderHeight={40}
-									>
+									<Island>
 										<GetMatchTabs
 											matchUrl={footballMatchUrl}
 											format={format}
@@ -671,11 +664,7 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 								/>
 								{format.design === ArticleDesign.MatchReport &&
 									!!footballMatchUrl && (
-										<Island
-											deferUntil="visible"
-											clientOnly={true}
-											placeholderHeight={800}
-										>
+										<Island deferUntil="visible">
 											<GetMatchStats
 												matchUrl={footballMatchUrl}
 												format={format}
@@ -815,11 +804,7 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 
 				{isWeb && (
 					<>
-						<Island
-							clientOnly={true}
-							deferUntil="visible"
-							placeholderHeight={600}
-						>
+						<Island deferUntil="visible">
 							<OnwardsUpper
 								ajaxUrl={article.config.ajaxUrl}
 								hasRelated={article.hasRelated}

--- a/dotcom-rendering/src/lib/useHydrated.ts
+++ b/dotcom-rendering/src/lib/useHydrated.ts
@@ -1,0 +1,11 @@
+import { useState } from 'react';
+import { useOnce } from './useOnce';
+
+export const useHydrated = (): boolean => {
+	const [hydrated, setHydrated] = useState(false);
+	useOnce(() => {
+		setHydrated(true);
+	}, []);
+
+	return hydrated;
+};


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

- remove's `placeholderHeight` prop from `Island`
- means components that are rendered in client-side-only `Island`s must explicitly provide their own server-rendered placeholder

## Why?

Describing the fallback should be the component's role, not the `Island`'s.

_N.B. nearly all uses of `placeholderHeight` also rendered their own `Placeholder` (cleared up here), which suggests that the API was unclear..._

## Screenshots

N/A – identical look and behaviour