### PR TITLE
Remove an accidental comma on Fronts

### DIFF
--- a/dotcom-rendering/src/server/render.front.web.tsx
+++ b/dotcom-rendering/src/server/render.front.web.tsx
@@ -82,7 +82,7 @@ export const renderFront = ({
 
 	const { html, extractedCss } = renderToStringWithEmotion(
 		<ConfigProvider value={config}>
-			<FrontPage front={front} NAV={NAV} />,
+			<FrontPage front={front} NAV={NAV} />
 		</ConfigProvider>,
 	);
 

--- a/dotcom-rendering/src/server/render.front.web.tsx
+++ b/dotcom-rendering/src/server/render.front.web.tsx
@@ -176,7 +176,7 @@ export const renderTagFront = ({
 
 	const { html, extractedCss } = renderToStringWithEmotion(
 		<ConfigProvider value={config}>
-			<TagFrontPage tagFront={tagFront} NAV={NAV} />,
+			<TagFrontPage tagFront={tagFront} NAV={NAV} />
 		</ConfigProvider>,
 	);
 


### PR DESCRIPTION
Removes an accidental comma appearing at the end of the `body` markup on Fronts.

| Before | After |
|--------|--------|
| ![image](https://github.com/guardian/dotcom-rendering/assets/705427/a0552eec-e916-4e24-b953-9d761e290e1f) | ![image](https://github.com/guardian/dotcom-rendering/assets/705427/48ac96b8-93bc-40ee-a09b-3b73bba41d03) | 