### PR TITLE
Restrict fronts banner max height to 600px + label

### DIFF
--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -274,6 +274,8 @@ const frontsBannerCollapseStyles = css`
 const frontsBannerAdStyles = css`
 	position: relative;
 	max-width: ${breakpoints['wide']}px;
+	/* No banner should be taller than 600px */
+	max-height: ${600 + labelHeight}px;
 	overflow: hidden;
 	padding-bottom: ${frontsBannerPaddingHeight}px;
 


### PR DESCRIPTION
## What does this change?
Restrict fronts banner max height to 600px + label height

## Why?

These ads can expand in size occasionally, the largest height ad we ever expect is 600px, so I think it makes sense to restrict the `max-height` of the slot, and ensure fronts banner ads don't unintentionally get taller than this.

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
