### PR TITLE
Revert "Disable the comment recommendation button when comments are closed #8906"

### DIFF
--- a/dotcom-rendering/src/components/Discussion/Comment.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comment.tsx
@@ -538,7 +538,6 @@ export const Comment = ({
 									user.profile.userId ===
 										comment.userProfile.userId
 								}
-								isClosedForComments={isClosedForComments}
 							/>
 						)}
 					</header>

--- a/dotcom-rendering/src/components/Discussion/Comments.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comments.tsx
@@ -385,7 +385,6 @@ export const Comments = ({
 							authStatus={user?.authStatus}
 							onPermalinkClick={onPermalinkClick}
 							onRecommend={onRecommend}
-							isClosedForComments={isClosedForComments}
 						/>
 					</div>
 				) : (
@@ -464,7 +463,6 @@ export const Comments = ({
 					authStatus={user?.authStatus}
 					onPermalinkClick={onPermalinkClick}
 					onRecommend={onRecommend}
-					isClosedForComments={isClosedForComments}
 				/>
 			)}
 			<Filters

--- a/dotcom-rendering/src/components/Discussion/RecommendationCount.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/RecommendationCount.stories.tsx
@@ -12,7 +12,6 @@ export const NeverRecomended = () => (
 		alreadyRecommended={false}
 		authStatus={signedInStatus}
 		userMadeComment={false}
-		isClosedForComments={false}
 	/>
 );
 
@@ -23,7 +22,6 @@ export const AlreadyRecomended = () => (
 		alreadyRecommended={true}
 		authStatus={signedInStatus}
 		userMadeComment={false}
-		isClosedForComments={false}
 	/>
 );
 
@@ -33,7 +31,6 @@ export const NotSignedIn = () => (
 		initialCount={83}
 		alreadyRecommended={false}
 		userMadeComment={false}
-		isClosedForComments={false}
 	/>
 );
 
@@ -44,6 +41,5 @@ export const OwnPost = () => (
 		alreadyRecommended={false}
 		authStatus={signedInStatus}
 		userMadeComment={true}
-		isClosedForComments={false}
 	/>
 );

--- a/dotcom-rendering/src/components/Discussion/RecommendationCount.tsx
+++ b/dotcom-rendering/src/components/Discussion/RecommendationCount.tsx
@@ -16,7 +16,6 @@ type Props = {
 	authStatus?: SignedInWithCookies | SignedInWithOkta;
 	userMadeComment: boolean;
 	onRecommend?: (commentId: number) => Promise<boolean>;
-	isClosedForComments: boolean;
 };
 
 const countStyles = css`
@@ -53,7 +52,6 @@ export const RecommendationCount = ({
 	authStatus,
 	userMadeComment,
 	onRecommend,
-	isClosedForComments,
 }: Props) => {
 	const [count, setCount] = useState(initialCount);
 	const [recommended, setRecommended] = useState(alreadyRecommended);
@@ -84,12 +82,7 @@ export const RecommendationCount = ({
 			<button
 				css={buttonStyles(recommended, isSignedIn)}
 				onClick={tryToRecommend}
-				disabled={
-					isClosedForComments ||
-					recommended ||
-					!isSignedIn ||
-					userMadeComment
-				}
+				disabled={recommended || !isSignedIn || userMadeComment}
 				data-link-name="Recommend comment"
 				aria-label="Recommend comment"
 				type="button"

--- a/dotcom-rendering/src/components/Discussion/TopPick.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/TopPick.stories.tsx
@@ -91,7 +91,6 @@ export const LongPick = () => (
 			comment={comment}
 			userMadeComment={false}
 			onPermalinkClick={() => {}}
-			isClosedForComments={false}
 		/>
 	</div>
 );
@@ -113,7 +112,6 @@ export const ShortPick = () => (
 			authStatus={signedInStatus}
 			userMadeComment={false}
 			onPermalinkClick={() => {}}
-			isClosedForComments={false}
 		/>
 	</div>
 );
@@ -131,7 +129,6 @@ export const LongPickContributor = () => (
 			comment={commentContributor}
 			userMadeComment={false}
 			onPermalinkClick={() => {}}
-			isClosedForComments={false}
 		/>
 	</div>
 );
@@ -153,7 +150,6 @@ export const ShortPickContributor = () => (
 			authStatus={signedInStatus}
 			userMadeComment={false}
 			onPermalinkClick={() => {}}
-			isClosedForComments={false}
 		/>
 	</div>
 );

--- a/dotcom-rendering/src/components/Discussion/TopPick.tsx
+++ b/dotcom-rendering/src/components/Discussion/TopPick.tsx
@@ -27,7 +27,6 @@ type Props = {
 	userMadeComment: boolean;
 	onPermalinkClick: (commentId: number) => void;
 	onRecommend?: (commentId: number) => Promise<boolean>;
-	isClosedForComments: boolean;
 };
 
 const pickStyles = css`
@@ -170,7 +169,6 @@ export const TopPick = ({
 	userMadeComment,
 	onPermalinkClick,
 	onRecommend,
-	isClosedForComments,
 }: Props) => {
 	const showStaffBadge = comment.userProfile.badge.some(
 		(obj) => obj['name'] === 'Staff',
@@ -248,7 +246,6 @@ export const TopPick = ({
 					authStatus={authStatus}
 					userMadeComment={userMadeComment}
 					onRecommend={onRecommend}
-					isClosedForComments={isClosedForComments}
 				/>
 			</PickMeta>
 		</div>

--- a/dotcom-rendering/src/components/Discussion/TopPicks.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/TopPicks.stories.tsx
@@ -63,7 +63,6 @@ export const SingleComment = () => (
 		comments={[commentWithShortBody]}
 		authStatus={signedInStatus}
 		onPermalinkClick={() => {}}
-		isClosedForComments={false}
 	/>
 );
 SingleComment.storyName = 'Single Comment';
@@ -82,7 +81,6 @@ export const MulitColumn = () => (
 		]}
 		authStatus={signedInStatus}
 		onPermalinkClick={() => {}}
-		isClosedForComments={false}
 	/>
 );
 MulitColumn.storyName = 'Mulitple Columns Comments';
@@ -101,7 +99,6 @@ export const SingleColumn = () => (
 		]}
 		authStatus={signedInStatus}
 		onPermalinkClick={() => {}}
-		isClosedForComments={false}
 	/>
 );
 SingleColumn.storyName = 'Single Column Comments';

--- a/dotcom-rendering/src/components/Discussion/TopPicks.tsx
+++ b/dotcom-rendering/src/components/Discussion/TopPicks.tsx
@@ -14,7 +14,6 @@ type Props = {
 	authStatus?: SignedInWithCookies | SignedInWithOkta;
 	onPermalinkClick: (commentId: number) => void;
 	onRecommend?: (commentId: number) => Promise<boolean>;
-	isClosedForComments: boolean;
 };
 
 const columWrapperStyles = css`
@@ -57,7 +56,6 @@ export const TopPicks = ({
 	authStatus,
 	onPermalinkClick,
 	onRecommend,
-	isClosedForComments,
 }: Props) => {
 	const leftColComments: CommentType[] = [];
 	const rightColComments: CommentType[] = [];
@@ -81,7 +79,6 @@ export const TopPicks = ({
 							}
 							onPermalinkClick={onPermalinkClick}
 							onRecommend={onRecommend}
-							isClosedForComments={isClosedForComments}
 						/>
 					))}
 				</div>
@@ -98,7 +95,6 @@ export const TopPicks = ({
 							}
 							onPermalinkClick={onPermalinkClick}
 							onRecommend={onRecommend}
-							isClosedForComments={isClosedForComments}
 						/>
 					))}
 				</div>
@@ -115,7 +111,6 @@ export const TopPicks = ({
 						}
 						onPermalinkClick={onPermalinkClick}
 						onRecommend={onRecommend}
-						isClosedForComments={isClosedForComments}
 					/>
 				))}
 			</div>


### PR DESCRIPTION

We've been getting emails over the weekend from users about the previous change to disable the uptick button when the dicussion was closed. Previously upticking comments on closed discussions was allowed for 48hrs after closing, which is behaviour we missed when fixing the issue.

This reverts commit 0b4d4811b06a0623875f8bec5a33847484a3345b.

