### PR TITLE
Assume old browsers experience poor page performance

### DIFF
--- a/dotcom-rendering/src/client/performanceMonitoring.ts
+++ b/dotcom-rendering/src/client/performanceMonitoring.ts
@@ -48,7 +48,7 @@ export const performanceMonitoring = async (): Promise<void> => {
 		const [fcp, ttfb] = await Promise.all([
 			getFirstContentfulPaint(),
 			getTimeToFirstByte(),
-		]);
+		]).catch(() => [FCP_THRESHOLD + 1, TTFB_THRESHOLD + 1]);
 
 		if (ttfb > TTFB_THRESHOLD && fcp > FCP_THRESHOLD) {
 			/** Not sure here if we should duplicate “dotcom-rendering” */


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Consider that if TTFB or FCP cannot be obtained, the browser is experiencing `poor-page-performance`.

## Why?

We do not want to run non-critical tasks for browsers that are that old.

Browsers that [do not support `PerformanceObserver`](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceObserver#browser_compatibility), which is required to get FCP are:

- Chrome < 52
- Edge < 79
- Firefox < 57
- Opera < 39
- Safari < 11

Browsers that [do no support `PerformanceTiming`](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceTiming#browser_compatibility), which is required to get TTFB are:
- Chrome < 6
- Edge < 12
- Firefox < 7
- Safari < 9 (8 on macOS)

## Screenshots

N/A