### PR TITLE
Immersive articles should render captions for main media videos

### DIFF
--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -187,22 +187,28 @@ interface Props {
 }
 
 const decideCaption = (mainMedia: FEElement | undefined): string => {
-	const caption = [];
+	const caption: string[] = [];
 
-	if (
-		mainMedia?._type ===
-		'model.dotcomrendering.pageElements.ImageBlockElement'
-	) {
-		if (mainMedia.data.caption) {
-			caption.push(mainMedia.data.caption);
-		}
+	switch (mainMedia?._type) {
+		case 'model.dotcomrendering.pageElements.ImageBlockElement':
+			if (mainMedia.data.caption) {
+				caption.push(mainMedia.data.caption);
+			}
 
-		if (mainMedia.displayCredit && mainMedia.data.credit) {
-			caption.push(mainMedia.data.credit);
-		}
+			if (mainMedia.displayCredit && mainMedia.data.credit) {
+				caption.push(mainMedia.data.credit);
+			}
+			return caption.join(' ');
+
+		case 'model.dotcomrendering.pageElements.EmbedBlockElement':
+			if (mainMedia.caption) {
+				caption.push(mainMedia.caption);
+			}
+			return caption.join(' ');
+
+		default:
+			return caption.join(' ');
 	}
-
-	return caption.join(' ');
 };
 
 const Box = ({


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change? 
Extends the `decideCaption` function in an immersive article, so that if the mainMedia is of type `EmbedBlockElement` we pull out and use the caption. 

Fixes https://github.com/guardian/dotcom-rendering/issues/7553

## Screenshots

| | Before      | After      |
| ----------- | ----------- | ---------- |
| Mobile - video  | <img width="338" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/848bea69-0ebc-49a0-9bcd-bdc2d6ce7d5d"> | <img width="340" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/bc0a051a-06e0-4efc-9209-74ee6a22fc3c"> |
| Desktop - video | <img width="1510" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/32cf761f-55ba-4090-b436-5316c90a489a"> | <img width="1507" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/7264817a-3a41-46ba-8de1-3793e613dddb">|
| Desktop - video with no caption (no change) | <img width="1510" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/a3361a31-cee4-4b74-b14b-fbcd05ebff04">| <img width="1510" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/0e4edb16-ef48-4dc8-b9b5-4af3ff983afa"> |
| Desktop - image (no change) | <img width="1510" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/db68e740-4eb3-485c-9f95-03b360bae46b"> | <img width="1510" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/106a612e-6bcc-499e-8b29-fb1ede35f11b"> |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
