### PR TITLE
`useMatchMedia` For Ads

### DIFF
--- a/dotcom-rendering/src/components/AdPortals.importable.tsx
+++ b/dotcom-rendering/src/components/AdPortals.importable.tsx
@@ -10,6 +10,7 @@ import {
 	getCommercialClient,
 	getUserClient,
 } from '../lib/bridgetApi';
+import { useMatchMedia } from '../lib/useMatchMedia';
 import { AdSlot } from './AdSlot.apps';
 
 const calculateAdPosition = (element: Element): BridgetRect => {
@@ -74,10 +75,13 @@ export const AdPortals = () => {
 	const [rightAdPlaceholder, setRightAdPlaceholder] = useState<Element>();
 	// References to client-side rendered ad slots.
 	const adSlots = useRef<HTMLDivElement[]>([]);
+	// Reset list of ad slot references, they're re-populated during rendering
+	adSlots.current = [];
 	// Positions of client-side rendered ad slots.
 	const adPositions = useRef<BridgetAdSlot[]>([]);
 	// The height of the body element.
 	const bodyHeight = useRef(0);
+	const isDesktop = useMatchMedia(`(min-width: ${breakpoints.desktop}px)`);
 
 	/**
 	 * Setup Ads
@@ -180,11 +184,6 @@ export const AdPortals = () => {
 			}}
 		/>
 	);
-
-	// We need to do this in js, rather than in css
-	// because we want to conditionally create the portals
-	const isDesktop = window.innerWidth >= breakpoints.desktop;
-
 	if (isDesktop && rightAdPlaceholder) {
 		return (
 			<>

--- a/dotcom-rendering/src/lib/useMatchMedia.ts
+++ b/dotcom-rendering/src/lib/useMatchMedia.ts
@@ -25,11 +25,11 @@ const useMatchMedia = (query: string): boolean => {
 	}
 
 	return useSyncExternalStore(
-		(changed) => {
-			mediaQuery.addEventListener('change', changed);
+		(callback) => {
+			mediaQuery.addEventListener('change', callback);
 
 			return () => {
-				mediaQuery.removeEventListener('change', changed);
+				mediaQuery.removeEventListener('change', callback);
 			};
 		},
 		() => mediaQuery.matches,

--- a/dotcom-rendering/src/lib/useMatchMedia.ts
+++ b/dotcom-rendering/src/lib/useMatchMedia.ts
@@ -1,0 +1,39 @@
+import { useSyncExternalStore } from 'react';
+
+/**
+ * Stores constructed media queries by their query string, so they don't have
+ * to be recreated on each render. Also allows multiple components to use the
+ * same media query.
+ */
+const cachedQueries = new Map<string, MediaQueryList>();
+
+/**
+ * A custom hook to test the provided media query. Will return a `boolean`
+ * signifying whether the media query currently matches, and will trigger a
+ * re-render whenever the match status changes in either direction;
+ * e.g. from `true` to `false`, or from `false` to `true`.
+ *
+ * @param query A media query string for use with `window.matchMedia`
+ * @returns A `boolean` signifying whether the media query currently matches
+ */
+const useMatchMedia = (query: string): boolean => {
+	const maybeQuery = cachedQueries.get(query);
+	const mediaQuery = maybeQuery ?? window.matchMedia(query);
+
+	if (maybeQuery === undefined) {
+		cachedQueries.set(query, mediaQuery);
+	}
+
+	return useSyncExternalStore(
+		(changed) => {
+			mediaQuery.addEventListener('change', changed);
+
+			return () => {
+				mediaQuery.removeEventListener('change', changed);
+			};
+		},
+		() => mediaQuery.matches,
+	);
+};
+
+export { useMatchMedia };


### PR DESCRIPTION
On narrow breakpoints we want ads to appear in line in the body of the article, and on wider ones we want them to appear in the right column. When the user transitions between breakpoints (e.g. rotates their device or resizes in some other way) we want the native ads to be re-drawn in their new positions: right column to inline or inline to right column.

To observe breakpoint changes in JavaScript, `window.matchMedia`[^1] and an event listener can be used[^2][^3]. This change creates a custom hook[^4], `useMatchMedia`, to surface the match status of a given media query to components. Any change will trigger a re-render and provide a new value.

In the case of `AdPortals`, the re-render will move ads between their inline and right column slots. This will in turn change the height of the page and so trigger a Bridget call to update the native ad positions.

[^1]: https://developer.mozilla.org/en-US/docs/Web/API/Window/matchMedia
[^2]: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_media_queries/Testing_media_queries#receiving_query_notifications
[^3]: https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList/change_event
[^4]: https://react.dev/reference/react/useSyncExternalStore#extracting-the-logic-to-a-custom-hook
