### PR TITLE
Add tests for `decideCaption`

### DIFF
--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -45,13 +45,13 @@ import { SubMeta } from '../components/SubMeta';
 import { SubNav } from '../components/SubNav.importable';
 import { canRenderAds } from '../lib/canRenderAds';
 import { getContributionsServiceUrl } from '../lib/contributions';
+import { decideMainMediaCaption } from '../lib/decide-caption';
 import { decidePalette } from '../lib/decidePalette';
 import { decideTrail } from '../lib/decideTrail';
 import { getZIndex } from '../lib/getZIndex';
 import { LABS_HEADER_HEIGHT } from '../lib/labs-constants';
 import { parse } from '../lib/slot-machine-flags';
 import type { NavType } from '../model/extract-nav';
-import type { FEElement } from '../types/content';
 import type { DCRArticle } from '../types/frontend';
 import type { Palette } from '../types/palette';
 import { BannerWrapper, Stuck } from './lib/stickiness';
@@ -186,31 +186,6 @@ interface Props {
 	format: ArticleFormat;
 }
 
-const decideCaption = (mainMedia: FEElement | undefined): string => {
-	const caption: string[] = [];
-
-	switch (mainMedia?._type) {
-		case 'model.dotcomrendering.pageElements.ImageBlockElement':
-			if (mainMedia.data.caption) {
-				caption.push(mainMedia.data.caption);
-			}
-
-			if (mainMedia.displayCredit && mainMedia.data.credit) {
-				caption.push(mainMedia.data.credit);
-			}
-			return caption.join(' ');
-
-		case 'model.dotcomrendering.pageElements.EmbedBlockElement':
-			if (mainMedia.caption) {
-				caption.push(mainMedia.caption);
-			}
-			return caption.join(' ');
-
-		default:
-			return caption.join(' ');
-	}
-};
-
 const Box = ({
 	palette,
 	children,
@@ -265,7 +240,7 @@ export const ImmersiveLayout = ({ article, NAV, format }: Props) => {
 
 	const mainMedia = article.mainMediaElements[0];
 
-	const captionText = decideCaption(mainMedia);
+	const captionText = decideMainMediaCaption(mainMedia);
 	const HEADLINE_OFFSET = mainMedia ? 120 : 0;
 	const { branding } = article.commercialProperties[article.editionId];
 

--- a/dotcom-rendering/src/lib/decide-caption.ts
+++ b/dotcom-rendering/src/lib/decide-caption.ts
@@ -1,0 +1,28 @@
+import type { FEElement } from '../types/content';
+
+export const decideMainMediaCaption = (
+	mainMedia: FEElement | undefined,
+): string => {
+	const caption: string[] = [];
+
+	switch (mainMedia?._type) {
+		case 'model.dotcomrendering.pageElements.ImageBlockElement':
+			if (mainMedia.data.caption) {
+				caption.push(mainMedia.data.caption);
+			}
+
+			if (mainMedia.displayCredit && mainMedia.data.credit) {
+				caption.push(mainMedia.data.credit);
+			}
+			return caption.join(' ');
+
+		case 'model.dotcomrendering.pageElements.EmbedBlockElement':
+			if (mainMedia.caption) {
+				caption.push(mainMedia.caption);
+			}
+			return caption.join(' ');
+
+		default:
+			return caption.join(' ');
+	}
+};

--- a/dotcom-rendering/src/lib/decide-cation.test.ts
+++ b/dotcom-rendering/src/lib/decide-cation.test.ts
@@ -1,0 +1,109 @@
+import type {
+	EmbedBlockElement,
+	ImageBlockElement,
+	TextBlockElement,
+} from '../types/content';
+import { decideMainMediaCaption } from './decide-caption';
+
+describe('decideMainMediaCaption', () => {
+	describe('when mainMedia is not supported', () => {
+		it('undefined returns an empty string', () => {
+			expect(decideMainMediaCaption(undefined)).toEqual('');
+		});
+		it('a text block returns an empty string', () => {
+			expect(
+				decideMainMediaCaption({
+					elementId: 'test-id',
+					html: '<p>test</p>',
+					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				} as TextBlockElement),
+			).toEqual('');
+		});
+	});
+
+	describe('ImageBlockElement', () => {
+		const mockImageBlockElement = {
+			elementId: 'mock-element-id',
+			data: {},
+			role: 'inline',
+			_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
+		} as ImageBlockElement;
+
+		it('returns an empty string if there is no caption, displayCredit, or credit', () => {
+			expect(decideMainMediaCaption(mockImageBlockElement)).toEqual('');
+		});
+
+		it('includes the caption, if it exists', () => {
+			expect(
+				decideMainMediaCaption({
+					...mockImageBlockElement,
+					data: {
+						caption: 'image block caption',
+					},
+				}),
+			).toEqual('image block caption');
+		});
+
+		it('includes the credit, if it should be displayed', () => {
+			expect(
+				decideMainMediaCaption({
+					...mockImageBlockElement,
+					displayCredit: true,
+					data: {
+						credit: 'image block display credit',
+					},
+				}),
+			).toEqual('image block display credit');
+		});
+
+		it('does not include the credit, if it should not be displayed', () => {
+			expect(
+				decideMainMediaCaption({
+					...mockImageBlockElement,
+					displayCredit: false,
+					data: {
+						credit: 'image block display credit',
+					},
+				}),
+			).toEqual('');
+		});
+
+		it('includes both the credit and caption, if they exist', () => {
+			expect(
+				decideMainMediaCaption({
+					...mockImageBlockElement,
+					displayCredit: true,
+					data: {
+						caption: 'mock caption',
+						credit: 'mock display credit',
+					},
+				}),
+			).toEqual('mock caption mock display credit');
+		});
+	});
+
+	describe('EmbedBlockElement', () => {
+		it('returns an empty string if there is no caption', () => {
+			expect(
+				decideMainMediaCaption({
+					elementId: 'test-id',
+					html: '<p>test</p>',
+					isMandatory: false,
+					_type: 'model.dotcomrendering.pageElements.EmbedBlockElement',
+				} as EmbedBlockElement),
+			).toEqual('');
+		});
+
+		it('returns the correct caption, if exists', () => {
+			expect(
+				decideMainMediaCaption({
+					elementId: 'test-id',
+					html: '<p>test</p>',
+					isMandatory: true,
+					caption: 'test caption',
+					_type: 'model.dotcomrendering.pageElements.EmbedBlockElement',
+				} as EmbedBlockElement),
+			).toEqual('test caption');
+		});
+	});
+});


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
This extracts and adds tests for the `decideCaption` function.
This function was extended as part of https://github.com/guardian/dotcom-rendering/pull/8957, so we should add tests to fully capture the functionality