### PR TITLE
use `getOphan` everywhere

### DIFF
--- a/dotcom-rendering/src/client/bootCmp.ts
+++ b/dotcom-rendering/src/client/bootCmp.ts
@@ -77,7 +77,7 @@ const submitConsentEventsToOphan = () =>
 			action,
 		} satisfies OphanComponentEvent;
 
-		submitComponentEvent(event);
+		return submitComponentEvent(event);
 	});
 
 const initialiseCmp = () =>

--- a/dotcom-rendering/src/client/ophan/ophan.ts
+++ b/dotcom-rendering/src/client/ophan/ophan.ts
@@ -14,11 +14,20 @@ export type OphanRecordFunction = (
 ) => void;
 
 /**
+ * Store a reference to Ophan so that we don't need to load/enhance it more than once.
+ */
+let cachedOphan: typeof window.guardian.ophan;
+
+/**
  * Loads Ophan (if it hasn't already been loaded) and returns a promise of Ophan's methods.
  */
 export const getOphan = async (): Promise<
 	NonNullable<typeof window.guardian.ophan>
 > => {
+	if (cachedOphan) {
+		return cachedOphan;
+	}
+
 	// @ts-expect-error -- side effect only
 	await import(/* webpackMode: "eager" */ 'ophan-tracker-js');
 
@@ -45,10 +54,8 @@ export const getOphan = async (): Promise<
 		});
 	};
 
-	// this is the future of `getOphan`'s API, but we need to move to a
-	// dynamic import of the Ophan library to get there, so just returning a
-	// meaningless promise for now, for future-proofing
-	return Promise.resolve({ ...ophan, record, trackComponentAttention });
+	cachedOphan = { ...ophan, record, trackComponentAttention };
+	return cachedOphan;
 };
 
 export const submitComponentEvent = async (

--- a/dotcom-rendering/src/client/ophan/recordInitialPageEvents.ts
+++ b/dotcom-rendering/src/client/ophan/recordInitialPageEvents.ts
@@ -11,7 +11,7 @@ export const recordInitialPageEvents = async (): Promise<void> => {
 
 	// We wait for the load event so that we can be sure our assetPerformance is reported as expected.
 	window.addEventListener('load', function load() {
-		recordPerformance();
+		void recordPerformance();
 		window.removeEventListener('load', load, false);
 	});
 };

--- a/dotcom-rendering/src/components/Dropdown.tsx
+++ b/dotcom-rendering/src/components/Dropdown.tsx
@@ -306,7 +306,7 @@ const DropdownLink = ({ link, index }: DropdownLinkProps) => {
 				notification.logImpression?.();
 			}
 
-			submitComponentEvent({
+			void submitComponentEvent({
 				component: ophanComponent,
 				action: 'VIEW',
 			});
@@ -321,7 +321,7 @@ const DropdownLink = ({ link, index }: DropdownLinkProps) => {
 
 	useOnce(() => {
 		if (ophanComponent) {
-			submitComponentEvent({
+			void submitComponentEvent({
 				component: ophanComponent,
 				action: 'INSERT',
 			});
@@ -347,7 +347,7 @@ const DropdownLink = ({ link, index }: DropdownLinkProps) => {
 				data-link-name={link.dataLinkName}
 				onClick={() => {
 					if (ophanComponent) {
-						submitComponentEvent({
+						void submitComponentEvent({
 							component: ophanComponent,
 							action: 'CLICK',
 						});

--- a/dotcom-rendering/src/components/EnhancePinnedPost.importable.tsx
+++ b/dotcom-rendering/src/components/EnhancePinnedPost.importable.tsx
@@ -59,7 +59,7 @@ function scrollOnCollapse() {
 const handleClickTracking = () => {
 	if (pinnedPostCheckBox instanceof HTMLInputElement) {
 		if (pinnedPostCheckBox.checked) {
-			submitComponentEvent({
+			void submitComponentEvent({
 				component: {
 					componentType: 'LIVE_BLOG_PINNED_POST',
 					id: pinnedPost?.id,
@@ -68,7 +68,7 @@ const handleClickTracking = () => {
 				value: 'show-more',
 			});
 		} else {
-			submitComponentEvent({
+			void submitComponentEvent({
 				component: {
 					componentType: 'LIVE_BLOG_PINNED_POST',
 					id: pinnedPost?.id,
@@ -147,7 +147,7 @@ export const EnhancePinnedPost = () => {
 			const timeTaken = pinnedPostTiming.current?.endPerformanceMeasure();
 			if (timeTaken !== undefined) {
 				const timeTakenInSeconds = timeTaken / 1000;
-				submitComponentEvent({
+				void submitComponentEvent({
 					component: {
 						componentType: 'LIVE_BLOG_PINNED_POST',
 						id: pinnedPost.id,

--- a/dotcom-rendering/src/components/NewsletterCard.tsx
+++ b/dotcom-rendering/src/components/NewsletterCard.tsx
@@ -11,10 +11,7 @@ import {
 	SvgPlus,
 } from '@guardian/source-react-components';
 import { useCallback, useEffect, useState } from 'react';
-import {
-	getOphanRecordFunction,
-	submitComponentEvent,
-} from '../client/ophan/ophan';
+import { submitComponentEvent } from '../client/ophan/ophan';
 import { useIsInView } from '../lib/useIsInView';
 import type { Newsletter } from '../types/content';
 import { CardPicture } from './CardPicture';
@@ -159,7 +156,6 @@ export const NewsletterCard = ({
 	const [haveReportedBeingSeen, setHaveReportedBeingSeen] = useState(false);
 
 	const reportSeen = useCallback(() => {
-		const record = getOphanRecordFunction();
 		const valueData = {
 			eventDescription: 'card-viewed',
 			newsletterId: newsletter.identityName,
@@ -169,17 +165,14 @@ export const NewsletterCard = ({
 			timestamp: Date.now(),
 		};
 
-		submitComponentEvent(
-			{
-				component: {
-					componentType: 'CARD',
-					id: `DCR NewsletterCard ${newsletter.identityName}`,
-				},
-				action: 'VIEW',
-				value: JSON.stringify(valueData),
+		void submitComponentEvent({
+			component: {
+				componentType: 'CARD',
+				id: `DCR NewsletterCard ${newsletter.identityName}`,
 			},
-			record,
-		);
+			action: 'VIEW',
+			value: JSON.stringify(valueData),
+		});
 	}, [cardPosition, carouselPosition, groupTitle, newsletter.identityName]);
 
 	useEffect(() => {

--- a/dotcom-rendering/src/components/ReaderRevenueLinks.importable.tsx
+++ b/dotcom-rendering/src/components/ReaderRevenueLinks.importable.tsx
@@ -18,9 +18,7 @@ import type {
 	ModuleDataResponse,
 } from '@guardian/support-dotcom-components/dist/dotcom/src/types';
 import { useEffect, useState } from 'react';
-import type { OphanRecordFunction } from '../client/ophan/ophan';
 import {
-	getOphanRecordFunction,
 	sendOphanComponentEvent,
 	submitComponentEvent,
 } from '../client/ophan/ophan';
@@ -166,14 +164,12 @@ type ReaderRevenueLinksRemoteProps = {
 	countryCode: string;
 	pageViewId: string;
 	contributionsServiceUrl: string;
-	ophanRecord: OphanRecordFunction;
 };
 
 const ReaderRevenueLinksRemote = ({
 	countryCode,
 	pageViewId,
 	contributionsServiceUrl,
-	ophanRecord,
 }: ReaderRevenueLinksRemoteProps) => {
 	const [supportHeaderResponse, setSupportHeaderResponse] =
 		useState<ModuleData | null>(null);
@@ -245,7 +241,7 @@ const ReaderRevenueLinksRemote = ({
 				<SupportHeader
 					submitComponentEvent={(
 						componentEvent: OphanComponentEvent,
-					) => submitComponentEvent(componentEvent, ophanRecord)}
+					) => void submitComponentEvent(componentEvent)}
 					{...supportHeaderResponse.props}
 				/>
 			</div>
@@ -264,7 +260,6 @@ type ReaderRevenueLinksNativeProps = {
 		support: string;
 		contribute: string;
 	};
-	ophanRecord: OphanRecordFunction;
 	pageViewId: string;
 };
 
@@ -273,7 +268,6 @@ const ReaderRevenueLinksNative = ({
 	dataLinkNamePrefix,
 	inHeader,
 	urls,
-	ophanRecord,
 	pageViewId,
 }: ReaderRevenueLinksNativeProps) => {
 	const hideSupportMessaging = shouldHideSupportMessaging();
@@ -295,14 +289,14 @@ const ReaderRevenueLinksNative = ({
 
 	useEffect(() => {
 		if (!hideSupportMessaging && inHeader) {
-			sendOphanComponentEvent('INSERT', tracking, ophanRecord);
+			void sendOphanComponentEvent('INSERT', tracking);
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 
 	useEffect(() => {
 		if (hasBeenSeen && inHeader) {
-			sendOphanComponentEvent('VIEW', tracking, ophanRecord);
+			void sendOphanComponentEvent('VIEW', tracking);
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [hasBeenSeen]);
@@ -407,7 +401,6 @@ export const ReaderRevenueLinks = ({
 }: Props) => {
 	const [countryCode, setCountryCode] = useState<string>();
 	const pageViewId = window.guardian.config.ophan.pageViewId;
-	const ophanRecord = getOphanRecordFunction();
 
 	useEffect(() => {
 		const callFetch = () => {
@@ -429,7 +422,6 @@ export const ReaderRevenueLinks = ({
 					countryCode={countryCode}
 					pageViewId={pageViewId}
 					contributionsServiceUrl={contributionsServiceUrl}
-					ophanRecord={ophanRecord}
 				/>
 			);
 		}
@@ -439,7 +431,6 @@ export const ReaderRevenueLinks = ({
 				dataLinkNamePrefix={dataLinkNamePrefix}
 				inHeader={inHeader}
 				urls={urls}
-				ophanRecord={ophanRecord}
 				pageViewId={pageViewId}
 			/>
 		);

--- a/dotcom-rendering/src/components/ReaderRevenueLinks.test.tsx
+++ b/dotcom-rendering/src/components/ReaderRevenueLinks.test.tsx
@@ -7,9 +7,17 @@ const shouldHideSupportMessaging: {
 	[key: string]: any;
 } = shouldHideSupportMessaging_;
 
+// @swc/jest does not seem to handle dynamic import of ophan.ng.js
+// We get a “define is not defined” in Jest, but it seems to work in browsers
+jest.mock('../client/ophan/ophan', () => ({
+	getOphan: () => Promise.resolve({ record: () => jest.fn() }),
+	sendOphanComponentEvent: jest.fn(),
+}));
+
 jest.mock('../lib/contributions', () => ({
 	shouldHideSupportMessaging: jest.fn(() => true),
 }));
+
 jest.mock('@guardian/libs', () => ({
 	getLocale: async () => {
 		return 'GB';

--- a/dotcom-rendering/src/components/SecureReCAPTCHASignup.tsx
+++ b/dotcom-rendering/src/components/SecureReCAPTCHASignup.tsx
@@ -17,10 +17,7 @@ import { useRef, useState } from 'react';
 // that version will compile and render but is non-functional.
 // Use the default export instead.
 import ReactGoogleRecaptcha from 'react-google-recaptcha';
-import {
-	getOphanRecordFunction,
-	submitComponentEvent,
-} from '../client/ophan/ophan';
+import { submitComponentEvent } from '../client/ophan/ophan';
 
 // The Google documentation specifies that if the 'recaptcha-badge' is hidden,
 // their T+C's must be displayed instead. While this component hides the
@@ -156,8 +153,6 @@ const sendTracking = (
 	newsletterId: string,
 	eventDescription: EventDescription,
 ): void => {
-	const ophanRecord = getOphanRecordFunction();
-
 	let action: OphanAction = 'CLICK';
 
 	switch (eventDescription) {
@@ -193,18 +188,15 @@ const sendTracking = (
 		timestamp: Date.now(),
 	});
 
-	submitComponentEvent(
-		{
-			action,
-			value,
-			//check if this can be used or needs to be added
-			component: {
-				componentType: 'NEWSLETTER_SUBSCRIPTION',
-				id: `AR SecureSignup ${newsletterId}`,
-			},
+	void submitComponentEvent({
+		action,
+		value,
+		//check if this can be used or needs to be added
+		component: {
+			componentType: 'NEWSLETTER_SUBSCRIPTION',
+			id: `AR SecureSignup ${newsletterId}`,
 		},
-		ophanRecord,
-	);
+	});
 };
 
 /**

--- a/dotcom-rendering/src/components/SecureSignupIframe.importable.tsx
+++ b/dotcom-rendering/src/components/SecureSignupIframe.importable.tsx
@@ -15,10 +15,7 @@ import { useRef, useState } from 'react';
 // that version will compile and render but is non-functional.
 // Use the default export instead.
 import ReactGoogleRecaptcha from 'react-google-recaptcha';
-import {
-	getOphanRecordFunction,
-	submitComponentEvent,
-} from '../client/ophan/ophan';
+import { submitComponentEvent } from '../client/ophan/ophan';
 import { isServer } from '../lib/isServer';
 import { useHydrated } from '../lib/useHydrated';
 import { Placeholder } from './Placeholder';
@@ -129,8 +126,6 @@ const sendTracking = (
 	newsletterId: string,
 	eventDescription: EventDescription,
 ): void => {
-	const ophanRecord = getOphanRecordFunction();
-
 	let action: OphanAction = 'CLICK';
 
 	switch (eventDescription) {
@@ -166,17 +161,14 @@ const sendTracking = (
 		timestamp: Date.now(),
 	});
 
-	submitComponentEvent(
-		{
-			action,
-			value,
-			component: {
-				componentType: 'NEWSLETTER_SUBSCRIPTION',
-				id: `DCR SecureSignupIframe ${newsletterId}`,
-			},
+	void submitComponentEvent({
+		action,
+		value,
+		component: {
+			componentType: 'NEWSLETTER_SUBSCRIPTION',
+			id: `DCR SecureSignupIframe ${newsletterId}`,
 		},
-		ophanRecord,
-	);
+	});
 };
 
 /**

--- a/dotcom-rendering/src/components/SetABTests.importable.tsx
+++ b/dotcom-rendering/src/components/SetABTests.importable.tsx
@@ -1,7 +1,6 @@
 import { AB } from '@guardian/ab-core';
 import type { CoreAPIConfig } from '@guardian/ab-core';
 import { getCookie, log } from '@guardian/libs';
-import { getOphanRecordFunction } from '../client/ophan/ophan';
 import { tests } from '../experiments/ab-tests';
 import { getCypressSwitches } from '../experiments/cypress-switches';
 import { runnableTestsToParticipations } from '../experiments/lib/ab-participations';
@@ -43,8 +42,6 @@ export const SetABTests = ({
 		console.log('There is no MVT ID set, see SetABTests.importable.tsx');
 	}
 
-	const ophanRecord = getOphanRecordFunction();
-
 	// Get the forced switches to use for when running within cypress
 	// Is empty object if not in cypress
 	const cypressAbSwitches = getCypressSwitches();
@@ -62,7 +59,6 @@ export const SetABTests = ({
 			...cypressAbSwitches, // by adding cypress switches below CAPI, we can override any production switch in Cypress
 		},
 		arrayOfTestObjects: tests,
-		ophanRecord,
 		forcedTestVariants: allForcedTestVariants,
 	});
 	const allRunnableTests = ab.allRunnableTests(tests);

--- a/dotcom-rendering/src/components/SignInGate/componentEventTracking.tsx
+++ b/dotcom-rendering/src/components/SignInGate/componentEventTracking.tsx
@@ -1,4 +1,5 @@
 import type { OphanComponent, OphanComponentEvent } from '@guardian/libs';
+import { getOphan } from '../../client/ophan/ophan';
 import { isServer } from '../../lib/isServer';
 import type { CurrentSignInGateABTest } from './types';
 
@@ -11,17 +12,20 @@ export type ComponentEventParams = {
 	browserId?: string;
 };
 
-const ophan = isServer ? undefined : window.guardian.ophan;
-
 // ophan helper methods
-const submitComponentEventTracking = (componentEvent: OphanComponentEvent) => {
-	ophan?.record({ componentEvent });
+const submitComponentEventTracking = async (
+	componentEvent: OphanComponentEvent,
+) => {
+	if (isServer) return;
+
+	const ophan = await getOphan();
+	ophan.record({ componentEvent });
 };
 
 export const submitViewEventTracking = (
 	componentEvent: Omit<OphanComponentEvent, 'action'>,
 ) =>
-	submitComponentEventTracking({
+	void submitComponentEventTracking({
 		...componentEvent,
 		action: 'VIEW',
 	});
@@ -29,7 +33,7 @@ export const submitViewEventTracking = (
 const submitClickEventTracking = (
 	componentEvent: Omit<OphanComponentEvent, 'action'>,
 ) =>
-	submitComponentEventTracking({
+	void submitComponentEventTracking({
 		...componentEvent,
 		action: 'CLICK',
 	});

--- a/dotcom-rendering/src/components/SlotBodyEnd/BrazeEpic.tsx
+++ b/dotcom-rendering/src/components/SlotBodyEnd/BrazeEpic.tsx
@@ -112,7 +112,7 @@ const BrazeEpicWithSatisfiedDependencies = ({
 	const epicRef = useRef(null);
 
 	useOnce(() => {
-		submitComponentEvent({
+		void submitComponentEvent({
 			component: {
 				componentType: COMPONENT_TYPE,
 				id: meta.dataFromBraze.ophanComponentId,
@@ -126,7 +126,7 @@ const BrazeEpicWithSatisfiedDependencies = ({
 			meta.logImpressionWithBraze();
 
 			// Log VIEW event with Ophan
-			submitComponentEvent({
+			void submitComponentEvent({
 				component: {
 					componentType: COMPONENT_TYPE,
 					id: meta.dataFromBraze.ophanComponentId,

--- a/dotcom-rendering/src/components/StickyBottomBanner/BrazeBanner.tsx
+++ b/dotcom-rendering/src/components/StickyBottomBanner/BrazeBanner.tsx
@@ -116,7 +116,7 @@ const BrazeBannerWithSatisfiedDependencies = ({
 		meta.logImpressionWithBraze();
 
 		// Log VIEW event with Ophan
-		submitComponentEvent({
+		void submitComponentEvent({
 			component: {
 				componentType: 'RETENTION_ENGAGEMENT_BANNER',
 				id:

--- a/dotcom-rendering/src/components/SupportTheG.importable.tsx
+++ b/dotcom-rendering/src/components/SupportTheG.importable.tsx
@@ -18,9 +18,7 @@ import type {
 	ModuleDataResponse,
 } from '@guardian/support-dotcom-components/dist/dotcom/src/types';
 import { useEffect, useState } from 'react';
-import type { OphanRecordFunction } from '../client/ophan/ophan';
 import {
-	getOphanRecordFunction,
 	sendOphanComponentEvent,
 	submitComponentEvent,
 } from '../client/ophan/ophan';
@@ -164,7 +162,6 @@ type ReaderRevenueLinksRemoteProps = {
 	countryCode: string;
 	pageViewId: string;
 	contributionsServiceUrl: string;
-	ophanRecord: OphanRecordFunction;
 };
 
 function getIsSignedIn(authStatus: AuthStatus): boolean | undefined {
@@ -184,7 +181,6 @@ const ReaderRevenueLinksRemote = ({
 	countryCode,
 	pageViewId,
 	contributionsServiceUrl,
-	ophanRecord,
 }: ReaderRevenueLinksRemoteProps) => {
 	const [supportHeaderResponse, setSupportHeaderResponse] =
 		useState<ModuleData | null>(null);
@@ -253,7 +249,7 @@ const ReaderRevenueLinksRemote = ({
 				<SupportHeader
 					submitComponentEvent={(
 						componentEvent: OphanComponentEvent,
-					) => submitComponentEvent(componentEvent, ophanRecord)}
+					) => void submitComponentEvent(componentEvent)}
 					{...supportHeaderResponse.props}
 				/>
 			</div>
@@ -272,7 +268,6 @@ type ReaderRevenueLinksNativeProps = {
 		support: string;
 		contribute: string;
 	};
-	ophanRecord: OphanRecordFunction;
 	pageViewId: string;
 	hasPageSkin: boolean;
 };
@@ -282,7 +277,6 @@ const ReaderRevenueLinksNative = ({
 	dataLinkNamePrefix,
 	inHeader,
 	urls,
-	ophanRecord,
 	pageViewId,
 	hasPageSkin,
 }: ReaderRevenueLinksNativeProps) => {
@@ -305,14 +299,14 @@ const ReaderRevenueLinksNative = ({
 
 	useEffect(() => {
 		if (!hideSupportMessaging && inHeader) {
-			sendOphanComponentEvent('INSERT', tracking, ophanRecord);
+			void sendOphanComponentEvent('INSERT', tracking);
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 
 	useEffect(() => {
 		if (hasBeenSeen && inHeader) {
-			sendOphanComponentEvent('VIEW', tracking, ophanRecord);
+			void sendOphanComponentEvent('VIEW', tracking);
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [hasBeenSeen]);
@@ -433,7 +427,6 @@ export const SupportTheG = ({
 }: Props) => {
 	const [countryCode, setCountryCode] = useState<string>();
 	const pageViewId = window.guardian.config.ophan.pageViewId;
-	const ophanRecord = getOphanRecordFunction();
 
 	useEffect(() => {
 		const callFetch = () => {
@@ -455,7 +448,6 @@ export const SupportTheG = ({
 					countryCode={countryCode}
 					pageViewId={pageViewId}
 					contributionsServiceUrl={contributionsServiceUrl}
-					ophanRecord={ophanRecord}
 				/>
 			);
 		}
@@ -465,7 +457,6 @@ export const SupportTheG = ({
 				dataLinkNamePrefix={dataLinkNamePrefix}
 				inHeader={inHeader}
 				urls={urls}
-				ophanRecord={ophanRecord}
 				pageViewId={pageViewId}
 				hasPageSkin={hasPageSkin}
 			/>

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomSticky.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomSticky.tsx
@@ -167,7 +167,7 @@ export const YoutubeAtomSticky = ({
 		});
 
 		// submit a 'close' event to Ophan
-		submitComponentEvent({
+		void submitComponentEvent({
 			component: {
 				componentType: 'STICKY_VIDEO',
 				id: videoId,
@@ -231,7 +231,7 @@ export const YoutubeAtomSticky = ({
 				msg: 'Stick',
 			});
 
-			submitComponentEvent({
+			void submitComponentEvent({
 				component: {
 					componentType: 'STICKY_VIDEO',
 					id: videoId,

--- a/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
@@ -4,7 +4,7 @@ import { body, neutral, space } from '@guardian/source-foundations';
 import { SvgAlertRound } from '@guardian/source-react-components';
 import { useEffect, useState } from 'react';
 import { trackVideoInteraction } from '../client/ga/ga';
-import { record } from '../client/ophan/ophan';
+import { getOphan } from '../client/ophan/ophan';
 import { useAB } from '../lib/useAB';
 import { useAdTargeting } from '../lib/useAdTargeting';
 import type { RoleType } from '../types/content';
@@ -170,9 +170,10 @@ export const YoutubeBlockComponent = ({
 		);
 	}
 
-	const ophanTracking = (trackingEvent: string) => {
+	const ophanTracking = async (trackingEvent: string): Promise<void> => {
 		if (!id) return;
-		record({
+		const ophan = await getOphan();
+		ophan.record({
 			video: {
 				id: `gu-video-youtube-${id}`,
 				eventType: `video:content:${trackingEvent}`,

--- a/dotcom-rendering/src/lib/braze/buildBrazeMessaging.ts
+++ b/dotcom-rendering/src/lib/braze/buildBrazeMessaging.ts
@@ -10,7 +10,7 @@ import {
 	NullBrazeMessages,
 } from '@guardian/braze-components/logic';
 import { log, startPerformanceMeasure, storage } from '@guardian/libs';
-import { record } from '../../client/ophan/ophan';
+import { getOphan } from '../../client/ophan/ophan';
 import {
 	clearHasCurrentBrazeUser,
 	hasCurrentBrazeUser,
@@ -103,7 +103,8 @@ export const buildBrazeMessaging = async (
 		);
 
 		const sdkLoadTimeTaken = endPerformanceMeasure();
-		record({
+		const ophan = await getOphan();
+		ophan.record({
 			component: 'braze-sdk-load-timing',
 			value: sdkLoadTimeTaken,
 		});

--- a/dotcom-rendering/src/lib/messagePicker.test.tsx
+++ b/dotcom-rendering/src/lib/messagePicker.test.tsx
@@ -1,10 +1,10 @@
 import { setImmediate } from 'node:timers';
-import { record } from '../client/ophan/ophan';
 import type { CanShowResult, SlotConfig } from './messagePicker';
 import { pickMessage } from './messagePicker';
 
+const ophanRecordSpy = jest.fn();
 jest.mock('../client/ophan/ophan', () => ({
-	record: jest.fn(),
+	getOphan: () => Promise.resolve({ record: ophanRecordSpy }),
 }));
 
 jest.useFakeTimers();
@@ -249,7 +249,8 @@ describe('pickMessage', () => {
 		const got = await messagePromise;
 
 		expect(got()).toEqual(null);
-		expect(record).toHaveBeenCalledWith({
+
+		expect(ophanRecordSpy).toHaveBeenCalledWith({
 			component: 'banner-picker-timeout-dcr',
 			value: config.candidates[0]?.candidate.id,
 		});
@@ -307,13 +308,13 @@ describe('pickMessage', () => {
 		jest.advanceTimersByTime(150);
 		await messagePromise;
 
-		expect(record).toHaveBeenCalledWith(
+		expect(ophanRecordSpy).toHaveBeenCalledWith(
 			expect.objectContaining({
 				component: 'messagePicker-canShow-candidate-1',
 			}),
 		);
 
-		expect(record).not.toHaveBeenCalledWith(
+		expect(ophanRecordSpy).not.toHaveBeenCalledWith(
 			expect.objectContaining({
 				component: 'messagePicker-canShow-candidate-2',
 			}),

--- a/dotcom-rendering/src/lib/messagePicker.ts
+++ b/dotcom-rendering/src/lib/messagePicker.ts
@@ -1,5 +1,5 @@
 import { startPerformanceMeasure } from '@guardian/libs';
-import { record } from '../client/ophan/ophan';
+import { getOphan } from '../client/ophan/ophan';
 
 export type MaybeFC = React.FC | null;
 type ShowMessage<T> = (meta: T) => MaybeFC;
@@ -34,11 +34,16 @@ export type SlotConfig = {
 	name: string;
 };
 
-const recordMessageTimeoutInOphan = (candidateId: string, slotName: string) =>
-	record({
+const recordMessageTimeoutInOphan = async (
+	candidateId: string,
+	slotName: string,
+) => {
+	const ophan = await getOphan();
+	ophan.record({
 		component: `${slotName}-picker-timeout-dcr`,
 		value: candidateId,
 	});
+};
 
 const timeoutify = <T>(
 	candidateConfig: CandidateConfig<T>,
@@ -56,7 +61,7 @@ const timeoutify = <T>(
 
 			if (candidateConfig.timeoutMillis !== null) {
 				timer = window.setTimeout(() => {
-					recordMessageTimeoutInOphan(
+					void recordMessageTimeoutInOphan(
 						candidateConfig.candidate.id,
 						slotName,
 					);
@@ -72,9 +77,11 @@ const timeoutify = <T>(
 					const canShowTimeTaken = endPerformanceMeasure();
 
 					if (candidateConfig.reportTiming) {
-						record({
-							component: perfName,
-							value: canShowTimeTaken,
+						void getOphan().then((ophan) => {
+							ophan.record({
+								component: perfName,
+								value: canShowTimeTaken,
+							});
 						});
 					}
 				})

--- a/dotcom-rendering/src/lib/newsletter-sign-up-requests.ts
+++ b/dotcom-rendering/src/lib/newsletter-sign-up-requests.ts
@@ -1,5 +1,5 @@
 import type { OphanAction } from '@guardian/libs';
-import { getOphan, submitComponentEvent } from '../client/ophan/ophan';
+import { submitComponentEvent } from '../client/ophan/ophan';
 
 const isServer = typeof window === 'undefined';
 
@@ -126,29 +126,24 @@ const trackingEventDescriptionToOphanAction = (
 	}
 };
 
-export const reportTrackingEvent = async (
+export const reportTrackingEvent = (
 	componentName: string,
 	eventDescription: TrackingEventDescription,
 	extraDetails?: Partial<
 		Record<string, string | string[] | number | number[]>
 	>,
-): Promise<void> => {
-	const ophan = await getOphan();
-
+): void => {
 	const payload = {
 		...extraDetails,
 		message: eventDescription,
 		timestamp: Date.now(),
 	};
-	submitComponentEvent(
-		{
-			component: {
-				componentType: 'NEWSLETTER_SUBSCRIPTION',
-				id: componentName,
-			},
-			action: trackingEventDescriptionToOphanAction(eventDescription),
-			value: JSON.stringify(payload),
+	void submitComponentEvent({
+		component: {
+			componentType: 'NEWSLETTER_SUBSCRIPTION',
+			id: componentName,
 		},
-		ophan.record,
-	);
+		action: trackingEventDescriptionToOphanAction(eventDescription),
+		value: JSON.stringify(payload),
+	});
 };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

- replaces (almost) all references to `window.guardian.ophan` with the centralised method that also loads it if necessary
- uses this internally for `submitComponentEvent` and `sendOphanComponentEvent`, rather than consumers needing to dep-inject it
- caches the `ophan` object instead of recreating it each time

## Why?

global scope is brittle, as is having to dep inject ophan record everywhere. 

is also fixed a race condition where code that runs before ophan loads may try to use it before it's available (e.g. in the CMP).

_Finalised version of #8511 and #8523._
