### PR TITLE
Surface front-level branding

### DIFF
--- a/dotcom-rendering/src/components/FrontSection.stories.tsx
+++ b/dotcom-rendering/src/components/FrontSection.stories.tsx
@@ -267,7 +267,7 @@ export const MultipleOnAPaidFront = () => {
 			aboutThisLink:
 				'https://www.theguardian.com/info/2016/jan/25/content-funding',
 		},
-	};
+	} as const;
 
 	return (
 		<>

--- a/dotcom-rendering/src/components/FrontSection.tsx
+++ b/dotcom-rendering/src/components/FrontSection.tsx
@@ -16,12 +16,8 @@ import { decideContainerOverrides } from '../lib/decideContainerOverrides';
 import type { EditionId } from '../lib/edition';
 import { hideAge } from '../lib/hideAge';
 import type { DCRBadgeType } from '../types/badge';
-import type { Branding } from '../types/branding';
-import type {
-	DCRContainerPalette,
-	DCRFrontType,
-	TreatType,
-} from '../types/front';
+import type { Branding, EditionBranding } from '../types/branding';
+import type { DCRContainerPalette, TreatType } from '../types/front';
 import type { DCRFrontPagination } from '../types/tagFront';
 import { isAustralianTerritory, type Territory } from '../types/territory';
 import { AustralianTerritorySwitcher } from './AustralianTerritorySwitcher.importable';
@@ -96,7 +92,7 @@ type Props = {
 	 */
 	hasPageSkin?: boolean;
 	discussionApiUrl: string;
-	frontBranding?: DCRFrontType['pressedPage']['frontProperties']['commercial']['editionBrandings'][number];
+	frontBranding?: EditionBranding;
 	containerBranding?: Branding;
 };
 

--- a/dotcom-rendering/src/lib/branding.ts
+++ b/dotcom-rendering/src/lib/branding.ts
@@ -1,0 +1,10 @@
+import type { Branding, EditionBranding } from '../types/branding';
+import type { EditionId } from './edition';
+
+export const pickBrandingForEdition = (
+	editionBrandings: EditionBranding[],
+	editionId: EditionId,
+): Branding | undefined =>
+	editionBrandings.find(
+		({ edition, branding }) => edition.id === editionId && branding,
+	)?.branding;

--- a/dotcom-rendering/src/model/enhanceCollections.ts
+++ b/dotcom-rendering/src/model/enhanceCollections.ts
@@ -1,6 +1,6 @@
 import { isNonNullable } from '@guardian/libs';
 import type { EditionId } from '../lib/edition';
-import type { Branding } from '../types/branding';
+import { type Branding, pickBrandingForEdition } from '../types/branding';
 import type {
 	DCRCollectionType,
 	FECollectionType,
@@ -35,12 +35,8 @@ function getBrandingFromCards(
 	editionId: EditionId,
 ): Branding[] {
 	return allCards
-		.map(
-			(card) =>
-				card.properties.editionBrandings.find(
-					(editionBranding) =>
-						editionBranding.edition.id === editionId,
-				)?.branding,
+		.map((card) =>
+			pickBrandingForEdition(card.properties.editionBrandings, editionId),
 		)
 		.filter(isNonNullable);
 }

--- a/dotcom-rendering/src/model/enhanceCollections.ts
+++ b/dotcom-rendering/src/model/enhanceCollections.ts
@@ -50,7 +50,7 @@ export const enhanceCollections = ({
 	editionId,
 	pageId,
 	discussionApiUrl,
-	editionHasBranding,
+	frontBranding,
 	onPageDescription,
 	isPaidContent,
 }: {
@@ -58,7 +58,7 @@ export const enhanceCollections = ({
 	editionId: EditionId;
 	pageId: string;
 	discussionApiUrl: string;
-	editionHasBranding: boolean;
+	frontBranding: Branding | undefined;
 	onPageDescription?: string;
 	isPaidContent?: boolean;
 }): DCRCollectionType[] => {
@@ -106,7 +106,8 @@ export const enhanceCollections = ({
 			sponsoredContentBranding: decideSponsoredContentBranding(
 				allCards.length,
 				allBranding,
-				editionHasBranding,
+				// TODO Use front branding directly
+				!!frontBranding,
 				collectionType,
 			),
 			grouped: groupCards(

--- a/dotcom-rendering/src/model/enhanceCollections.ts
+++ b/dotcom-rendering/src/model/enhanceCollections.ts
@@ -1,6 +1,7 @@
 import { isNonNullable } from '@guardian/libs';
+import { pickBrandingForEdition } from '../lib/branding';
 import type { EditionId } from '../lib/edition';
-import { type Branding, pickBrandingForEdition } from '../types/branding';
+import type { Branding } from '../types/branding';
 import type {
 	DCRCollectionType,
 	FECollectionType,
@@ -102,7 +103,7 @@ export const enhanceCollections = ({
 			sponsoredContentBranding: decideSponsoredContentBranding(
 				allCards.length,
 				allBranding,
-				// TODO Use front branding directly
+				// TODO(@chrislomaxjones) Read the full front branding value
 				!!frontBranding,
 				collectionType,
 			),

--- a/dotcom-rendering/src/model/front-schema.json
+++ b/dotcom-rendering/src/model/front-schema.json
@@ -2768,7 +2768,7 @@
                     "type": "object",
                     "properties": {
                         "id": {
-                            "type": "string"
+                            "$ref": "#/definitions/EditionId"
                         }
                     },
                     "required": [
@@ -2782,6 +2782,16 @@
             "required": [
                 "edition"
             ]
+        },
+        "EditionId": {
+            "enum": [
+                "AU",
+                "EUR",
+                "INT",
+                "UK",
+                "US"
+            ],
+            "type": "string"
         },
         "Branding": {
             "type": "object",
@@ -3296,16 +3306,6 @@
                 "support",
                 "supporter"
             ]
-        },
-        "EditionId": {
-            "enum": [
-                "AU",
-                "EUR",
-                "INT",
-                "UK",
-                "US"
-            ],
-            "type": "string"
         },
         "Switches": {
             "type": "object",

--- a/dotcom-rendering/src/model/front-schema.json
+++ b/dotcom-rendering/src/model/front-schema.json
@@ -450,86 +450,7 @@
                                 "editionBrandings": {
                                     "type": "array",
                                     "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "edition": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "id": {
-                                                        "type": "string"
-                                                    }
-                                                },
-                                                "required": [
-                                                    "id"
-                                                ]
-                                            },
-                                            "branding": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "brandingType": {
-                                                        "type": "object",
-                                                        "properties": {
-                                                            "name": {
-                                                                "type": "string"
-                                                            }
-                                                        },
-                                                        "required": [
-                                                            "name"
-                                                        ]
-                                                    },
-                                                    "sponsorName": {
-                                                        "type": "string"
-                                                    },
-                                                    "logo": {
-                                                        "type": "object",
-                                                        "properties": {
-                                                            "src": {
-                                                                "type": "string"
-                                                            },
-                                                            "dimensions": {
-                                                                "type": "object",
-                                                                "properties": {
-                                                                    "width": {
-                                                                        "type": "number"
-                                                                    },
-                                                                    "height": {
-                                                                        "type": "number"
-                                                                    }
-                                                                },
-                                                                "required": [
-                                                                    "height",
-                                                                    "width"
-                                                                ]
-                                                            },
-                                                            "link": {
-                                                                "type": "string"
-                                                            },
-                                                            "label": {
-                                                                "type": "string"
-                                                            }
-                                                        },
-                                                        "required": [
-                                                            "dimensions",
-                                                            "label",
-                                                            "link",
-                                                            "src"
-                                                        ]
-                                                    },
-                                                    "aboutThisLink": {
-                                                        "type": "string"
-                                                    }
-                                                },
-                                                "required": [
-                                                    "aboutThisLink",
-                                                    "brandingType",
-                                                    "logo",
-                                                    "sponsorName"
-                                                ]
-                                            }
-                                        },
-                                        "required": [
-                                            "edition"
-                                        ]
+                                        "$ref": "#/definitions/EditionBranding"
                                     }
                                 },
                                 "editionAdTargetings": {},
@@ -924,26 +845,7 @@
                                                 "editionBrandings": {
                                                     "type": "array",
                                                     "items": {
-                                                        "type": "object",
-                                                        "properties": {
-                                                            "edition": {
-                                                                "type": "object",
-                                                                "properties": {
-                                                                    "id": {
-                                                                        "$ref": "#/definitions/EditionId"
-                                                                    }
-                                                                },
-                                                                "required": [
-                                                                    "id"
-                                                                ]
-                                                            },
-                                                            "branding": {
-                                                                "$ref": "#/definitions/Branding"
-                                                            }
-                                                        },
-                                                        "required": [
-                                                            "edition"
-                                                        ]
+                                                        "$ref": "#/definitions/EditionBranding"
                                                     }
                                                 },
                                                 "href": {
@@ -1653,26 +1555,7 @@
                                                 "editionBrandings": {
                                                     "type": "array",
                                                     "items": {
-                                                        "type": "object",
-                                                        "properties": {
-                                                            "edition": {
-                                                                "type": "object",
-                                                                "properties": {
-                                                                    "id": {
-                                                                        "$ref": "#/definitions/EditionId"
-                                                                    }
-                                                                },
-                                                                "required": [
-                                                                    "id"
-                                                                ]
-                                                            },
-                                                            "branding": {
-                                                                "$ref": "#/definitions/Branding"
-                                                            }
-                                                        },
-                                                        "required": [
-                                                            "edition"
-                                                        ]
+                                                        "$ref": "#/definitions/EditionBranding"
                                                     }
                                                 },
                                                 "href": {
@@ -2382,26 +2265,7 @@
                                                 "editionBrandings": {
                                                     "type": "array",
                                                     "items": {
-                                                        "type": "object",
-                                                        "properties": {
-                                                            "edition": {
-                                                                "type": "object",
-                                                                "properties": {
-                                                                    "id": {
-                                                                        "$ref": "#/definitions/EditionId"
-                                                                    }
-                                                                },
-                                                                "required": [
-                                                                    "id"
-                                                                ]
-                                                            },
-                                                            "branding": {
-                                                                "$ref": "#/definitions/Branding"
-                                                            }
-                                                        },
-                                                        "required": [
-                                                            "edition"
-                                                        ]
+                                                        "$ref": "#/definitions/EditionBranding"
                                                     }
                                                 },
                                                 "href": {
@@ -2897,6 +2761,125 @@
                 "seoData"
             ]
         },
+        "EditionBranding": {
+            "type": "object",
+            "properties": {
+                "edition": {
+                    "type": "object",
+                    "properties": {
+                        "id": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "id"
+                    ]
+                },
+                "branding": {
+                    "$ref": "#/definitions/Branding"
+                }
+            },
+            "required": [
+                "edition"
+            ]
+        },
+        "Branding": {
+            "type": "object",
+            "properties": {
+                "brandingType": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "name"
+                    ]
+                },
+                "sponsorName": {
+                    "type": "string"
+                },
+                "logo": {
+                    "type": "object",
+                    "properties": {
+                        "src": {
+                            "type": "string"
+                        },
+                        "link": {
+                            "type": "string"
+                        },
+                        "label": {
+                            "type": "string"
+                        },
+                        "dimensions": {
+                            "type": "object",
+                            "properties": {
+                                "width": {
+                                    "type": "number"
+                                },
+                                "height": {
+                                    "type": "number"
+                                }
+                            },
+                            "required": [
+                                "height",
+                                "width"
+                            ]
+                        }
+                    },
+                    "required": [
+                        "dimensions",
+                        "label",
+                        "link",
+                        "src"
+                    ]
+                },
+                "aboutThisLink": {
+                    "type": "string"
+                },
+                "logoForDarkBackground": {
+                    "type": "object",
+                    "properties": {
+                        "src": {
+                            "type": "string"
+                        },
+                        "link": {
+                            "type": "string"
+                        },
+                        "label": {
+                            "type": "string"
+                        },
+                        "dimensions": {
+                            "type": "object",
+                            "properties": {
+                                "width": {
+                                    "type": "number"
+                                },
+                                "height": {
+                                    "type": "number"
+                                }
+                            },
+                            "required": [
+                                "height",
+                                "width"
+                            ]
+                        }
+                    },
+                    "required": [
+                        "dimensions",
+                        "label",
+                        "link",
+                        "src"
+                    ]
+                }
+            },
+            "required": [
+                "aboutThisLink",
+                "logo",
+                "sponsorName"
+            ]
+        },
         "FEDesign": {
             "enum": [
                 "AnalysisDesign",
@@ -3066,113 +3049,6 @@
                 "mediaType",
                 "mimeType",
                 "url"
-            ]
-        },
-        "EditionId": {
-            "enum": [
-                "AU",
-                "EUR",
-                "INT",
-                "UK",
-                "US"
-            ],
-            "type": "string"
-        },
-        "Branding": {
-            "type": "object",
-            "properties": {
-                "brandingType": {
-                    "type": "object",
-                    "properties": {
-                        "name": {
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "name"
-                    ]
-                },
-                "sponsorName": {
-                    "type": "string"
-                },
-                "logo": {
-                    "type": "object",
-                    "properties": {
-                        "src": {
-                            "type": "string"
-                        },
-                        "link": {
-                            "type": "string"
-                        },
-                        "label": {
-                            "type": "string"
-                        },
-                        "dimensions": {
-                            "type": "object",
-                            "properties": {
-                                "width": {
-                                    "type": "number"
-                                },
-                                "height": {
-                                    "type": "number"
-                                }
-                            },
-                            "required": [
-                                "height",
-                                "width"
-                            ]
-                        }
-                    },
-                    "required": [
-                        "dimensions",
-                        "label",
-                        "link",
-                        "src"
-                    ]
-                },
-                "aboutThisLink": {
-                    "type": "string"
-                },
-                "logoForDarkBackground": {
-                    "type": "object",
-                    "properties": {
-                        "src": {
-                            "type": "string"
-                        },
-                        "link": {
-                            "type": "string"
-                        },
-                        "label": {
-                            "type": "string"
-                        },
-                        "dimensions": {
-                            "type": "object",
-                            "properties": {
-                                "width": {
-                                    "type": "number"
-                                },
-                                "height": {
-                                    "type": "number"
-                                }
-                            },
-                            "required": [
-                                "height",
-                                "width"
-                            ]
-                        }
-                    },
-                    "required": [
-                        "dimensions",
-                        "label",
-                        "link",
-                        "src"
-                    ]
-                }
-            },
-            "required": [
-                "aboutThisLink",
-                "logo",
-                "sponsorName"
             ]
         },
         "FEFrontCardStyle": {
@@ -3420,6 +3296,16 @@
                 "support",
                 "supporter"
             ]
+        },
+        "EditionId": {
+            "enum": [
+                "AU",
+                "EUR",
+                "INT",
+                "UK",
+                "US"
+            ],
+            "type": "string"
         },
         "Switches": {
             "type": "object",

--- a/dotcom-rendering/src/model/tag-front-schema.json
+++ b/dotcom-rendering/src/model/tag-front-schema.json
@@ -359,26 +359,7 @@
                             "editionBrandings": {
                                 "type": "array",
                                 "items": {
-                                    "type": "object",
-                                    "properties": {
-                                        "edition": {
-                                            "type": "object",
-                                            "properties": {
-                                                "id": {
-                                                    "$ref": "#/definitions/EditionId"
-                                                }
-                                            },
-                                            "required": [
-                                                "id"
-                                            ]
-                                        },
-                                        "branding": {
-                                            "$ref": "#/definitions/Branding"
-                                        }
-                                    },
-                                    "required": [
-                                        "edition"
-                                    ]
+                                    "$ref": "#/definitions/EditionBranding"
                                 }
                             },
                             "href": {
@@ -1369,15 +1350,27 @@
                 "url"
             ]
         },
-        "EditionId": {
-            "enum": [
-                "AU",
-                "EUR",
-                "INT",
-                "UK",
-                "US"
-            ],
-            "type": "string"
+        "EditionBranding": {
+            "type": "object",
+            "properties": {
+                "edition": {
+                    "type": "object",
+                    "properties": {
+                        "id": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "id"
+                    ]
+                },
+                "branding": {
+                    "$ref": "#/definitions/Branding"
+                }
+            },
+            "required": [
+                "edition"
+            ]
         },
         "Branding": {
             "type": "object",
@@ -1658,6 +1651,16 @@
                 "support",
                 "supporter"
             ]
+        },
+        "EditionId": {
+            "enum": [
+                "AU",
+                "EUR",
+                "INT",
+                "UK",
+                "US"
+            ],
+            "type": "string"
         },
         "Switches": {
             "type": "object",

--- a/dotcom-rendering/src/model/tag-front-schema.json
+++ b/dotcom-rendering/src/model/tag-front-schema.json
@@ -1357,7 +1357,7 @@
                     "type": "object",
                     "properties": {
                         "id": {
-                            "type": "string"
+                            "$ref": "#/definitions/EditionId"
                         }
                     },
                     "required": [
@@ -1371,6 +1371,16 @@
             "required": [
                 "edition"
             ]
+        },
+        "EditionId": {
+            "enum": [
+                "AU",
+                "EUR",
+                "INT",
+                "UK",
+                "US"
+            ],
+            "type": "string"
         },
         "Branding": {
             "type": "object",
@@ -1651,16 +1661,6 @@
                 "support",
                 "supporter"
             ]
-        },
-        "EditionId": {
-            "enum": [
-                "AU",
-                "EUR",
-                "INT",
-                "UK",
-                "US"
-            ],
-            "type": "string"
         },
         "Switches": {
             "type": "object",

--- a/dotcom-rendering/src/server/index.front.web.ts
+++ b/dotcom-rendering/src/server/index.front.web.ts
@@ -11,18 +11,11 @@ import { injectMpuIntoGroupedTrails } from '../model/injectMpuIntoGroupedTrails'
 import { getSpeedFromTrails } from '../model/slowOrFastByTrails';
 import { validateAsFrontType, validateAsTagFrontType } from '../model/validate';
 import { recordTypeAndPlatform } from '../server/lib/logging-store';
-import type { Branding } from '../types/branding';
+import { pickBrandingForEdition } from '../types/branding';
 import type { DCRFrontType, FEFrontType } from '../types/front';
 import type { DCRTagFrontType, FETagFrontType } from '../types/tagFront';
 import { makePrefetchHeader } from './lib/header';
 import { renderFront, renderTagFront } from './render.front.web';
-
-const getFrontBranding = (data: FEFrontType): Branding | undefined =>
-	data.pressedPage.frontProperties.commercial.editionBrandings.find(
-		(editionBranding) =>
-			editionBranding.edition.id === data.editionId &&
-			!!editionBranding.branding,
-	)?.branding;
 
 const enhanceFront = (body: unknown): DCRFrontType => {
 	const data: FEFrontType = validateAsFrontType(body);
@@ -42,7 +35,11 @@ const enhanceFront = (body: unknown): DCRFrontType => {
 					data.pressedPage.frontProperties.onPageDescription,
 				isPaidContent: data.config.isPaidContent,
 				discussionApiUrl: data.config.discussionApiUrl,
-				frontBranding: getFrontBranding(data),
+				frontBranding: pickBrandingForEdition(
+					data.pressedPage.frontProperties.commercial
+						.editionBrandings,
+					data.editionId,
+				),
 			}),
 		},
 		mostViewed: data.mostViewed.map((trail) => decideTrail(trail)),

--- a/dotcom-rendering/src/server/index.front.web.ts
+++ b/dotcom-rendering/src/server/index.front.web.ts
@@ -11,19 +11,21 @@ import { injectMpuIntoGroupedTrails } from '../model/injectMpuIntoGroupedTrails'
 import { getSpeedFromTrails } from '../model/slowOrFastByTrails';
 import { validateAsFrontType, validateAsTagFrontType } from '../model/validate';
 import { recordTypeAndPlatform } from '../server/lib/logging-store';
+import type { Branding } from '../types/branding';
 import type { DCRFrontType, FEFrontType } from '../types/front';
 import type { DCRTagFrontType, FETagFrontType } from '../types/tagFront';
 import { makePrefetchHeader } from './lib/header';
 import { renderFront, renderTagFront } from './render.front.web';
 
+const getFrontBranding = (data: FEFrontType): Branding | undefined =>
+	data.pressedPage.frontProperties.commercial.editionBrandings.find(
+		(editionBranding) =>
+			editionBranding.edition.id === data.editionId &&
+			!!editionBranding.branding,
+	)?.branding;
+
 const enhanceFront = (body: unknown): DCRFrontType => {
 	const data: FEFrontType = validateAsFrontType(body);
-	const editionHasBranding = () =>
-		!!data.pressedPage.frontProperties.commercial.editionBrandings.find(
-			(editionBranding) =>
-				editionBranding.edition.id === data.editionId &&
-				!!editionBranding.branding,
-		);
 
 	return {
 		...data,
@@ -40,7 +42,7 @@ const enhanceFront = (body: unknown): DCRFrontType => {
 					data.pressedPage.frontProperties.onPageDescription,
 				isPaidContent: data.config.isPaidContent,
 				discussionApiUrl: data.config.discussionApiUrl,
-				editionHasBranding: editionHasBranding(),
+				frontBranding: getFrontBranding(data),
 			}),
 		},
 		mostViewed: data.mostViewed.map((trail) => decideTrail(trail)),

--- a/dotcom-rendering/src/server/index.front.web.ts
+++ b/dotcom-rendering/src/server/index.front.web.ts
@@ -1,4 +1,5 @@
 import type { RequestHandler } from 'express';
+import { pickBrandingForEdition } from '../lib/branding';
 import { decideTrail } from '../lib/decideTrail';
 import { enhanceCards } from '../model/enhanceCards';
 import { enhanceCollections } from '../model/enhanceCollections';
@@ -11,7 +12,6 @@ import { injectMpuIntoGroupedTrails } from '../model/injectMpuIntoGroupedTrails'
 import { getSpeedFromTrails } from '../model/slowOrFastByTrails';
 import { validateAsFrontType, validateAsTagFrontType } from '../model/validate';
 import { recordTypeAndPlatform } from '../server/lib/logging-store';
-import { pickBrandingForEdition } from '../types/branding';
 import type { DCRFrontType, FEFrontType } from '../types/front';
 import type { DCRTagFrontType, FETagFrontType } from '../types/tagFront';
 import { makePrefetchHeader } from './lib/header';

--- a/dotcom-rendering/src/types/branding.ts
+++ b/dotcom-rendering/src/types/branding.ts
@@ -1,3 +1,5 @@
+import type { EditionId } from '../lib/edition';
+
 type BrandingLogo = {
 	src: string;
 	link: string;
@@ -12,3 +14,18 @@ export interface Branding {
 	aboutThisLink: string;
 	logoForDarkBackground?: BrandingLogo;
 }
+
+export interface EditionBranding {
+	edition: {
+		id: string; // Check not EditionId?
+	};
+	branding?: Branding;
+}
+
+export const pickBrandingForEdition = (
+	editionBrandings: EditionBranding[],
+	editionId: EditionId,
+): Branding | undefined =>
+	editionBrandings.find(
+		({ edition, branding }) => edition.id === editionId && branding,
+	)?.branding;

--- a/dotcom-rendering/src/types/branding.ts
+++ b/dotcom-rendering/src/types/branding.ts
@@ -1,3 +1,5 @@
+import type { EditionId } from '../lib/edition';
+
 type BrandingLogo = {
 	src: string;
 	link: string;
@@ -15,7 +17,7 @@ export interface Branding {
 
 export interface EditionBranding {
 	edition: {
-		id: string;
+		id: EditionId;
 	};
 	branding?: Branding;
 }

--- a/dotcom-rendering/src/types/branding.ts
+++ b/dotcom-rendering/src/types/branding.ts
@@ -1,5 +1,3 @@
-import type { EditionId } from '../lib/edition';
-
 type BrandingLogo = {
 	src: string;
 	link: string;
@@ -17,15 +15,7 @@ export interface Branding {
 
 export interface EditionBranding {
 	edition: {
-		id: string; // Check not EditionId?
+		id: string;
 	};
 	branding?: Branding;
 }
-
-export const pickBrandingForEdition = (
-	editionBrandings: EditionBranding[],
-	editionId: EditionId,
-): Branding | undefined =>
-	editionBrandings.find(
-		({ edition, branding }) => edition.id === editionId && branding,
-	)?.branding;

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -2,7 +2,7 @@ import type { ArticleSpecial, Pillar } from '@guardian/libs';
 import type { SharedAdTargeting } from '../lib/ad-targeting';
 import type { EditionId } from '../lib/edition';
 import type { DCRBadgeType } from './badge';
-import type { Branding } from './branding';
+import type { Branding, EditionBranding } from './branding';
 import type { ServerSideTests, Switches } from './config';
 import type { Image } from './content';
 import type { FooterType } from './footer';
@@ -228,7 +228,7 @@ export type FEFrontCard = {
 		webTitle: string;
 		linkText?: string;
 		webUrl?: string;
-		editionBrandings: { edition: { id: EditionId }; branding?: Branding }[];
+		editionBrandings: EditionBranding[];
 		href?: string;
 		embedUri?: string;
 	};
@@ -508,12 +508,7 @@ type FESeoDataType = {
 type FEFrontPropertiesType = {
 	isImageDisplayed: boolean;
 	commercial: {
-		editionBrandings: Array<{
-			edition: {
-				id: string;
-			};
-			branding?: Branding;
-		}>;
+		editionBrandings: EditionBranding[];
 		editionAdTargetings: unknown;
 		prebidIndexSites?: unknown;
 	};

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -512,22 +512,7 @@ type FEFrontPropertiesType = {
 			edition: {
 				id: string;
 			};
-			branding?: {
-				brandingType: {
-					name: string;
-				};
-				sponsorName: string;
-				logo: {
-					src: string;
-					dimensions: {
-						width: number;
-						height: number;
-					};
-					link: string;
-					label: string;
-				};
-				aboutThisLink: string;
-			};
+			branding?: Branding;
 		}>;
 		editionAdTargetings: unknown;
 		prebidIndexSites?: unknown;


### PR DESCRIPTION
## What does this change?

This PR makes a few small adjustments to how we handle branding on fronts.

- Create an `EditionBranding` type that associates a particular edition with a branding object.
- Regenerate the schema with these new types, which should tighten up the validation on the data model slightly.
- Extract out a common `pickBrandingForEdition` into `./src/lib/branding.ts` - we'll add more functions here later.
- Instead of detecting the presence of front-wide branding, actually pass that branding object down into `enhanceCollections`. Note for now we don't do anything with it - see the `// TODO`.

## Why?

This PR is mostly a no-op, it shouldn't change the rendered fronts at all. However, it should make some subsequent PRs a little simpler and easier to review. The only material change is to slightly tighten up some of the schema validation, so we know that edition ids are from a set enum, rather than a plain string.