### PR TITLE
Remove SWR keys from server render

### DIFF
--- a/dotcom-rendering/scripts/jest/setup.ts
+++ b/dotcom-rendering/scripts/jest/setup.ts
@@ -1,6 +1,7 @@
 // add some helpful assertions
 import '@testing-library/jest-dom/extend-expect';
 import { TextDecoder, TextEncoder } from 'node:util';
+import { isServer } from '../../src/lib/isServer';
 import type { Guardian } from '../../src/model/guardian';
 
 const windowGuardianConfig = {
@@ -66,7 +67,7 @@ const windowGuardian = {
 // We should never be able to directly set things to the global window object.
 // But in this case we want to stub things for testing, so it's ok to ignore this rule
 // @ts-expect-error
-window.guardian = windowGuardian;
+!isServer && (window.guardian = windowGuardian);
 
 // Mock Local Storage
 // See: https://github.com/facebook/jest/issues/2098#issuecomment-260733457
@@ -91,9 +92,10 @@ const localStorageMock = (function () {
 	};
 })();
 
-Object.defineProperty(window, 'localStorage', {
-	value: localStorageMock,
-});
+!isServer &&
+	Object.defineProperty(window, 'localStorage', {
+		value: localStorageMock,
+	});
 
 /**
  * This is to polyfill `TextEncoder` and `TextDecoder`.

--- a/dotcom-rendering/src/components/Liveness.importable.test.tsx
+++ b/dotcom-rendering/src/components/Liveness.importable.test.tsx
@@ -1,0 +1,31 @@
+/**
+ * @jest-environment node
+ */
+
+import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
+import { renderToString } from 'react-dom/server';
+import { Liveness } from './Liveness.importable';
+
+describe('Liveness', () => {
+	it('Does not throw in Node render', () => {
+		const html = renderToString(
+			<Liveness
+				webTitle=""
+				ajaxUrl=""
+				pageId=""
+				filterKeyEvents={false}
+				format={{
+					theme: Pillar.News,
+					design: ArticleDesign.Standard,
+					display: ArticleDisplay.Standard,
+				}}
+				enhanceTweetsSwitch={false}
+				onFirstPage={true}
+				webURL=""
+				mostRecentBlockId=""
+				hasPinnedPost={false}
+			/>,
+		);
+		expect(html).toBe('');
+	});
+});

--- a/dotcom-rendering/src/components/Liveness.importable.tsx
+++ b/dotcom-rendering/src/components/Liveness.importable.tsx
@@ -221,7 +221,7 @@ export const Liveness = ({
 	 * updates with whatever html and properties it wants
 	 *
 	 */
-	window.mockLiveUpdate = onSuccess;
+	!isServer && (window.mockLiveUpdate = onSuccess);
 
 	/**
 	 * We do not want to fetch a key on the server

--- a/dotcom-rendering/src/components/Liveness.importable.tsx
+++ b/dotcom-rendering/src/components/Liveness.importable.tsx
@@ -112,6 +112,7 @@ function getKey(
 	filterKeyEvents: boolean,
 	selectedTopics?: Topic[],
 ): string | undefined {
+	if (isServer) return undefined;
 	try {
 		// Construct the url to poll
 		const url = new URL(`${pageId}.json`, ajaxUrl);
@@ -222,15 +223,26 @@ export const Liveness = ({
 	 */
 	window.mockLiveUpdate = onSuccess;
 
+	/**
+	 * We do not want to fetch a key on the server
+	 * @see https://swr.vercel.app/docs/conditional-fetching#conditional
+	 */
+	const key = isServer
+		? undefined
+		: getKey(
+				pageId,
+				ajaxUrl,
+				latestBlockId,
+				filterKeyEvents,
+				selectedTopics,
+		  );
+
 	// useApi returns { data, loading, error } but we're not using them here
-	useApi(
-		getKey(pageId, ajaxUrl, latestBlockId, filterKeyEvents, selectedTopics),
-		{
-			refreshInterval: 10_000,
-			refreshWhenHidden: true,
-			onSuccess,
-		},
-	);
+	useApi(key, {
+		refreshInterval: 10_000,
+		refreshWhenHidden: true,
+		onSuccess,
+	});
 
 	useEffect(() => {
 		document.title =


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Make SWR key `undefined` on the server in `Liveness.importable.tsx`

## Why?

We’re getting error in the `catch` block on the preview app.

## Screenshots

N/A