### PR TITLE
Revert "fix: remove most of the .snyk file bar ignoring AGPL licensing for pm2"

### DIFF
--- a/dotcom-rendering/.snyk
+++ b/dotcom-rendering/.snyk
@@ -1,15 +1,1882 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-version: v3.0.0
-# We should only ignore license warnings in here. Any other vulnerabilities should be fixed
-# or ignored in the Snyk console.
+version: v1.13.5
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
+  SNYK-JS-PATHPARSE-1077067:
+    - '@babel/core > resolve > path-parse':
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.854Z'
+    - '@guardian/discussion-rendering > babel-plugin-emotion > babel-plugin-macros > resolve > path-parse':
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.854Z'
+    - eslint-import-resolver-babel-module > resolve > path-parse:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.858Z'
+    - eslint-plugin-import > resolve > path-parse:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.858Z'
+    - eslint-plugin-import > eslint-import-resolver-node > resolve > path-parse:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.858Z'
+    - eslint-plugin-import > read-pkg-up > read-pkg > normalize-package-data > resolve > path-parse:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.858Z'
+    - eslint-plugin-react > resolve > path-parse:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.881Z'
+  SNYK-JS-MINIMIST-559764:
+    - '@emotion/server > html-tokenize > minimist':
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.854Z'
+    - eslint-plugin-import > tsconfig-paths > minimist:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.858Z'
+    - eslint-plugin-import > tsconfig-paths > json5 > minimist:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.858Z'
+    - json5 > minimist:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.858Z'
+    - loader-utils > json5 > minimist:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.858Z'
+    - terser-webpack-plugin > json5 > minimist:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.869Z'
+    - terser-webpack-plugin > loader-utils > json5 > minimist:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.869Z'
+    - terser-webpack-plugin > webpack > loader-utils > json5 > minimist:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.869Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > fsevents > node-pre-gyp > rc > minimist:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.869Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > fsevents > node-pre-gyp > rc > minimist:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.869Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > fsevents > node-pre-gyp > mkdirp > minimist:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.869Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > fsevents > node-pre-gyp > mkdirp > minimist:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.870Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > fsevents > node-pre-gyp > tar > mkdirp > minimist:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.870Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > fsevents > node-pre-gyp > tar > mkdirp > minimist:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.870Z'
+    - watchpack > watchpack-chokidar2 > chokidar > fsevents > node-pre-gyp > rc > minimist:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.874Z'
+    - watchpack > watchpack-chokidar2 > chokidar > fsevents > node-pre-gyp > mkdirp > minimist:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.874Z'
+    - watchpack > watchpack-chokidar2 > chokidar > fsevents > node-pre-gyp > tar > mkdirp > minimist:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.874Z'
+    - webpack > loader-utils > json5 > minimist:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.880Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > fsevents > node-pre-gyp > rc > minimist:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.880Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > fsevents > node-pre-gyp > mkdirp > minimist:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.880Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > fsevents > node-pre-gyp > tar > mkdirp > minimist:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.880Z'
+    - node-pre-gyp > rc > minimist:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.881Z'
+  SNYK-JS-KINDOF-537849:
+    - '@hkdobrev/run-if-changed > micromatch > kind-of':
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.854Z'
+    - '@hkdobrev/run-if-changed > micromatch > nanomatch > kind-of':
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.854Z'
+    - '@hkdobrev/run-if-changed > micromatch > define-property > is-descriptor > kind-of':
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.854Z'
+    - '@hkdobrev/run-if-changed > micromatch > define-property > is-descriptor > is-accessor-descriptor > kind-of':
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.854Z'
+    - '@hkdobrev/run-if-changed > micromatch > define-property > is-descriptor > is-data-descriptor > kind-of':
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.854Z'
+    - '@hkdobrev/run-if-changed > micromatch > extglob > define-property > is-descriptor > kind-of':
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.854Z'
+    - '@hkdobrev/run-if-changed > micromatch > to-regex > define-property > is-descriptor > kind-of':
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.854Z'
+    - '@hkdobrev/run-if-changed > micromatch > nanomatch > define-property > is-descriptor > kind-of':
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.854Z'
+    - '@hkdobrev/run-if-changed > micromatch > extglob > define-property > is-descriptor > is-accessor-descriptor > kind-of':
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.854Z'
+    - '@hkdobrev/run-if-changed > micromatch > to-regex > define-property > is-descriptor > is-accessor-descriptor > kind-of':
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.854Z'
+    - '@hkdobrev/run-if-changed > micromatch > nanomatch > define-property > is-descriptor > is-accessor-descriptor > kind-of':
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.854Z'
+    - '@hkdobrev/run-if-changed > micromatch > extglob > define-property > is-descriptor > is-data-descriptor > kind-of':
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.854Z'
+    - '@hkdobrev/run-if-changed > micromatch > to-regex > define-property > is-descriptor > is-data-descriptor > kind-of':
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.854Z'
+    - '@hkdobrev/run-if-changed > micromatch > nanomatch > define-property > is-descriptor > is-data-descriptor > kind-of':
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.855Z'
+    - '@hkdobrev/run-if-changed > micromatch > snapdragon > base > define-property > is-descriptor > kind-of':
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.855Z'
+    - '@hkdobrev/run-if-changed > micromatch > braces > snapdragon-node > define-property > is-descriptor > kind-of':
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.855Z'
+    - '@hkdobrev/run-if-changed > micromatch > braces > to-regex > define-property > is-descriptor > kind-of':
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.855Z'
+    - '@hkdobrev/run-if-changed > micromatch > extglob > to-regex > define-property > is-descriptor > kind-of':
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.855Z'
+    - '@hkdobrev/run-if-changed > micromatch > nanomatch > to-regex > define-property > is-descriptor > kind-of':
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.855Z'
+    - '@hkdobrev/run-if-changed > micromatch > snapdragon > base > define-property > is-descriptor > is-accessor-descriptor > kind-of':
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.855Z'
+    - '@hkdobrev/run-if-changed > micromatch > braces > snapdragon-node > define-property > is-descriptor > is-accessor-descriptor > kind-of':
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.855Z'
+    - '@hkdobrev/run-if-changed > micromatch > braces > to-regex > define-property > is-descriptor > is-accessor-descriptor > kind-of':
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.855Z'
+    - '@hkdobrev/run-if-changed > micromatch > extglob > to-regex > define-property > is-descriptor > is-accessor-descriptor > kind-of':
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.855Z'
+    - '@hkdobrev/run-if-changed > micromatch > nanomatch > to-regex > define-property > is-descriptor > is-accessor-descriptor > kind-of':
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.855Z'
+    - '@hkdobrev/run-if-changed > micromatch > snapdragon > base > define-property > is-descriptor > is-data-descriptor > kind-of':
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.855Z'
+    - '@hkdobrev/run-if-changed > micromatch > braces > snapdragon-node > define-property > is-descriptor > is-data-descriptor > kind-of':
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.855Z'
+    - '@hkdobrev/run-if-changed > micromatch > braces > to-regex > define-property > is-descriptor > is-data-descriptor > kind-of':
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.855Z'
+    - '@hkdobrev/run-if-changed > micromatch > extglob > to-regex > define-property > is-descriptor > is-data-descriptor > kind-of':
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.855Z'
+    - '@hkdobrev/run-if-changed > micromatch > nanomatch > to-regex > define-property > is-descriptor > is-data-descriptor > kind-of':
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.855Z'
+    - '@hkdobrev/run-if-changed > micromatch > braces > snapdragon > base > define-property > is-descriptor > kind-of':
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.855Z'
+    - '@hkdobrev/run-if-changed > micromatch > extglob > snapdragon > base > define-property > is-descriptor > kind-of':
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.855Z'
+    - '@hkdobrev/run-if-changed > micromatch > nanomatch > snapdragon > base > define-property > is-descriptor > kind-of':
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.855Z'
+    - '@hkdobrev/run-if-changed > micromatch > extglob > expand-brackets > to-regex > define-property > is-descriptor > kind-of':
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.855Z'
+    - '@hkdobrev/run-if-changed > micromatch > braces > snapdragon > base > define-property > is-descriptor > is-accessor-descriptor > kind-of':
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.855Z'
+    - '@hkdobrev/run-if-changed > micromatch > extglob > snapdragon > base > define-property > is-descriptor > is-accessor-descriptor > kind-of':
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.855Z'
+    - '@hkdobrev/run-if-changed > micromatch > nanomatch > snapdragon > base > define-property > is-descriptor > is-accessor-descriptor > kind-of':
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.855Z'
+    - '@hkdobrev/run-if-changed > micromatch > extglob > expand-brackets > to-regex > define-property > is-descriptor > is-accessor-descriptor > kind-of':
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.855Z'
+    - '@hkdobrev/run-if-changed > micromatch > braces > snapdragon > base > define-property > is-descriptor > is-data-descriptor > kind-of':
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.855Z'
+    - '@hkdobrev/run-if-changed > micromatch > extglob > snapdragon > base > define-property > is-descriptor > is-data-descriptor > kind-of':
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.855Z'
+    - '@hkdobrev/run-if-changed > micromatch > nanomatch > snapdragon > base > define-property > is-descriptor > is-data-descriptor > kind-of':
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.855Z'
+    - '@hkdobrev/run-if-changed > micromatch > extglob > expand-brackets > to-regex > define-property > is-descriptor > is-data-descriptor > kind-of':
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.855Z'
+    - '@hkdobrev/run-if-changed > micromatch > extglob > expand-brackets > snapdragon > base > define-property > is-descriptor > kind-of':
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.855Z'
+    - '@hkdobrev/run-if-changed > micromatch > extglob > expand-brackets > snapdragon > base > define-property > is-descriptor > is-accessor-descriptor > kind-of':
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.855Z'
+    - '@hkdobrev/run-if-changed > micromatch > extglob > expand-brackets > snapdragon > base > define-property > is-descriptor > is-data-descriptor > kind-of':
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.855Z'
+    - cpy > globby > fast-glob > micromatch > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.855Z'
+    - cpy > globby > fast-glob > micromatch > nanomatch > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.855Z'
+    - cpy > globby > fast-glob > micromatch > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.855Z'
+    - cpy > globby > fast-glob > micromatch > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.855Z'
+    - cpy > globby > fast-glob > micromatch > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.855Z'
+    - cpy > globby > fast-glob > micromatch > extglob > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.855Z'
+    - cpy > globby > fast-glob > micromatch > to-regex > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.855Z'
+    - cpy > globby > fast-glob > micromatch > nanomatch > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.855Z'
+    - cpy > globby > fast-glob > micromatch > extglob > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.855Z'
+    - cpy > globby > fast-glob > micromatch > to-regex > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.856Z'
+    - cpy > globby > fast-glob > micromatch > nanomatch > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.856Z'
+    - cpy > globby > fast-glob > micromatch > extglob > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.857Z'
+    - cpy > globby > fast-glob > micromatch > to-regex > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.857Z'
+    - cpy > globby > fast-glob > micromatch > nanomatch > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.857Z'
+    - cpy > globby > fast-glob > micromatch > snapdragon > base > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.857Z'
+    - cpy > globby > fast-glob > micromatch > braces > snapdragon-node > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.857Z'
+    - cpy > globby > fast-glob > micromatch > braces > to-regex > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.857Z'
+    - cpy > globby > fast-glob > micromatch > extglob > to-regex > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.857Z'
+    - cpy > globby > fast-glob > micromatch > nanomatch > to-regex > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.857Z'
+    - cpy > globby > fast-glob > micromatch > snapdragon > base > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.857Z'
+    - cpy > globby > fast-glob > micromatch > braces > snapdragon-node > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.857Z'
+    - cpy > globby > fast-glob > micromatch > braces > to-regex > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.857Z'
+    - cpy > globby > fast-glob > micromatch > extglob > to-regex > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.857Z'
+    - cpy > globby > fast-glob > micromatch > nanomatch > to-regex > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.857Z'
+    - cpy > globby > fast-glob > micromatch > snapdragon > base > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.857Z'
+    - cpy > globby > fast-glob > micromatch > braces > snapdragon-node > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.857Z'
+    - cpy > globby > fast-glob > micromatch > braces > to-regex > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.857Z'
+    - cpy > globby > fast-glob > micromatch > extglob > to-regex > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.857Z'
+    - cpy > globby > fast-glob > micromatch > nanomatch > to-regex > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.857Z'
+    - cpy > globby > fast-glob > micromatch > braces > snapdragon > base > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.858Z'
+    - cpy > globby > fast-glob > micromatch > extglob > snapdragon > base > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.858Z'
+    - cpy > globby > fast-glob > micromatch > nanomatch > snapdragon > base > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.858Z'
+    - cpy > globby > fast-glob > micromatch > extglob > expand-brackets > to-regex > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.858Z'
+    - cpy > globby > fast-glob > micromatch > braces > snapdragon > base > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.858Z'
+    - cpy > globby > fast-glob > micromatch > extglob > snapdragon > base > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.858Z'
+    - cpy > globby > fast-glob > micromatch > nanomatch > snapdragon > base > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.858Z'
+    - cpy > globby > fast-glob > micromatch > extglob > expand-brackets > to-regex > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.858Z'
+    - cpy > globby > fast-glob > micromatch > braces > snapdragon > base > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.858Z'
+    - cpy > globby > fast-glob > micromatch > extglob > snapdragon > base > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.858Z'
+    - cpy > globby > fast-glob > micromatch > nanomatch > snapdragon > base > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.858Z'
+    - cpy > globby > fast-glob > micromatch > extglob > expand-brackets > to-regex > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.858Z'
+    - cpy > globby > fast-glob > micromatch > extglob > expand-brackets > snapdragon > base > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.858Z'
+    - cpy > globby > fast-glob > micromatch > extglob > expand-brackets > snapdragon > base > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.858Z'
+    - cpy > globby > fast-glob > micromatch > extglob > expand-brackets > snapdragon > base > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.858Z'
+    - terser-webpack-plugin > webpack > micromatch > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.858Z'
+    - terser-webpack-plugin > webpack > micromatch > nanomatch > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.858Z'
+    - terser-webpack-plugin > webpack > micromatch > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.858Z'
+    - terser-webpack-plugin > webpack > micromatch > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.858Z'
+    - terser-webpack-plugin > webpack > micromatch > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.858Z'
+    - terser-webpack-plugin > webpack > micromatch > extglob > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.859Z'
+    - terser-webpack-plugin > webpack > micromatch > to-regex > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.859Z'
+    - terser-webpack-plugin > webpack > micromatch > nanomatch > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.859Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.859Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.859Z'
+    - terser-webpack-plugin > webpack > micromatch > extglob > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.859Z'
+    - terser-webpack-plugin > webpack > micromatch > to-regex > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.859Z'
+    - terser-webpack-plugin > webpack > micromatch > nanomatch > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.859Z'
+    - terser-webpack-plugin > webpack > micromatch > extglob > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.859Z'
+    - terser-webpack-plugin > webpack > micromatch > to-regex > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.859Z'
+    - terser-webpack-plugin > webpack > micromatch > nanomatch > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.859Z'
+    - terser-webpack-plugin > webpack > micromatch > snapdragon > base > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.859Z'
+    - terser-webpack-plugin > webpack > micromatch > braces > snapdragon-node > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.859Z'
+    - terser-webpack-plugin > webpack > micromatch > braces > to-regex > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.859Z'
+    - terser-webpack-plugin > webpack > micromatch > extglob > to-regex > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.859Z'
+    - terser-webpack-plugin > webpack > micromatch > nanomatch > to-regex > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.859Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > nanomatch > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.859Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > nanomatch > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.859Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.859Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.859Z'
+    - terser-webpack-plugin > webpack > micromatch > snapdragon > base > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.859Z'
+    - terser-webpack-plugin > webpack > micromatch > braces > snapdragon-node > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.859Z'
+    - terser-webpack-plugin > webpack > micromatch > braces > to-regex > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.859Z'
+    - terser-webpack-plugin > webpack > micromatch > extglob > to-regex > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.859Z'
+    - terser-webpack-plugin > webpack > micromatch > nanomatch > to-regex > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.859Z'
+    - terser-webpack-plugin > webpack > micromatch > snapdragon > base > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.859Z'
+    - terser-webpack-plugin > webpack > micromatch > braces > snapdragon-node > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.859Z'
+    - terser-webpack-plugin > webpack > micromatch > braces > to-regex > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.859Z'
+    - terser-webpack-plugin > webpack > micromatch > extglob > to-regex > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.859Z'
+    - terser-webpack-plugin > webpack > micromatch > nanomatch > to-regex > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.859Z'
+    - terser-webpack-plugin > webpack > micromatch > braces > snapdragon > base > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.859Z'
+    - terser-webpack-plugin > webpack > micromatch > extglob > snapdragon > base > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.859Z'
+    - terser-webpack-plugin > webpack > micromatch > nanomatch > snapdragon > base > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.859Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > braces > snapdragon-node > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.859Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > braces > to-regex > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.860Z'
+    - terser-webpack-plugin > webpack > micromatch > extglob > expand-brackets > to-regex > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.860Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.860Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.860Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > nanomatch > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.860Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > nanomatch > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.860Z'
+    - terser-webpack-plugin > webpack > micromatch > braces > snapdragon > base > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.860Z'
+    - terser-webpack-plugin > webpack > micromatch > extglob > snapdragon > base > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.860Z'
+    - terser-webpack-plugin > webpack > micromatch > nanomatch > snapdragon > base > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.860Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > braces > snapdragon-node > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.860Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > braces > to-regex > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.860Z'
+    - terser-webpack-plugin > webpack > micromatch > extglob > expand-brackets > to-regex > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.860Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.860Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.860Z'
+    - terser-webpack-plugin > webpack > micromatch > braces > snapdragon > base > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.860Z'
+    - terser-webpack-plugin > webpack > micromatch > extglob > snapdragon > base > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.860Z'
+    - terser-webpack-plugin > webpack > micromatch > nanomatch > snapdragon > base > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.860Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > braces > snapdragon-node > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.860Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > braces > to-regex > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.860Z'
+    - terser-webpack-plugin > webpack > micromatch > extglob > expand-brackets > to-regex > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.860Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.860Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.861Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > braces > snapdragon > base > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.861Z'
+    - terser-webpack-plugin > webpack > micromatch > extglob > expand-brackets > snapdragon > base > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.861Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > braces > snapdragon-node > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.861Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > extglob > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.861Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > extglob > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.861Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > braces > to-regex > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.861Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > to-regex > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.861Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > to-regex > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.861Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > nanomatch > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.861Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > nanomatch > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.861Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.861Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.861Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > braces > snapdragon > base > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.862Z'
+    - terser-webpack-plugin > webpack > micromatch > extglob > expand-brackets > snapdragon > base > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.862Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > braces > snapdragon-node > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.862Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > extglob > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.862Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > extglob > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.862Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > braces > to-regex > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.862Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > to-regex > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.862Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > to-regex > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.862Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > nanomatch > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.862Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > nanomatch > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.862Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.862Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.862Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > braces > snapdragon > base > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.862Z'
+    - terser-webpack-plugin > webpack > micromatch > extglob > expand-brackets > snapdragon > base > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.862Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > braces > snapdragon-node > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.862Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > extglob > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.862Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > extglob > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.862Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > braces > to-regex > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.862Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > to-regex > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.862Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > to-regex > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.862Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > nanomatch > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.862Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > nanomatch > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.862Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.862Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.862Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > braces > snapdragon > base > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.862Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > snapdragon > base > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.862Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > snapdragon > base > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.862Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > braces > snapdragon-node > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.862Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > braces > snapdragon-node > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.862Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > extglob > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.862Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > extglob > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.863Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > braces > to-regex > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.863Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > braces > to-regex > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.863Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > extglob > to-regex > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.863Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > extglob > to-regex > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.863Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > nanomatch > to-regex > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.863Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > nanomatch > to-regex > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.863Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > to-regex > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.863Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > to-regex > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.863Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > nanomatch > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.863Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > nanomatch > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.863Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > braces > snapdragon > base > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.863Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > snapdragon > base > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.863Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > snapdragon > base > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.863Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > braces > snapdragon-node > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.863Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > braces > snapdragon-node > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.863Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > extglob > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.863Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > extglob > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.863Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > braces > to-regex > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.863Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > braces > to-regex > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.863Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > extglob > to-regex > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.864Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > extglob > to-regex > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.864Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > nanomatch > to-regex > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.864Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > nanomatch > to-regex > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.864Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > to-regex > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.864Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > to-regex > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.864Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > nanomatch > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.864Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > nanomatch > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.864Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > braces > snapdragon > base > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.864Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > snapdragon > base > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.864Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > snapdragon > base > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.864Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > braces > snapdragon-node > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.864Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > braces > snapdragon-node > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.864Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > extglob > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.864Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > extglob > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.864Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > braces > to-regex > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.864Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > braces > to-regex > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.864Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > extglob > to-regex > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.864Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > extglob > to-regex > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.864Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > nanomatch > to-regex > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.864Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > nanomatch > to-regex > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.864Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > to-regex > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.864Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > to-regex > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.864Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > nanomatch > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.865Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > nanomatch > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.865Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > braces > snapdragon > base > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.865Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > braces > snapdragon > base > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.865Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > extglob > snapdragon > base > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.865Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > extglob > snapdragon > base > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.865Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > nanomatch > snapdragon > base > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.865Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > nanomatch > snapdragon > base > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.865Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > snapdragon > base > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.865Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > snapdragon > base > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.865Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > braces > snapdragon-node > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.865Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > braces > snapdragon-node > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.865Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > braces > to-regex > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.865Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > braces > to-regex > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.865Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > extglob > expand-brackets > to-regex > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.865Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > extglob > expand-brackets > to-regex > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.865Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > extglob > to-regex > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.865Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > extglob > to-regex > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.865Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > nanomatch > to-regex > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.865Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > nanomatch > to-regex > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.865Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > braces > snapdragon > base > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.865Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > braces > snapdragon > base > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.865Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > extglob > snapdragon > base > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.865Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > extglob > snapdragon > base > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.866Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > nanomatch > snapdragon > base > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.866Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > nanomatch > snapdragon > base > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.866Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > snapdragon > base > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.866Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > snapdragon > base > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.866Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > braces > snapdragon-node > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.866Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > braces > snapdragon-node > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.866Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > braces > to-regex > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.867Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > braces > to-regex > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.867Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > extglob > expand-brackets > to-regex > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.867Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > extglob > expand-brackets > to-regex > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.867Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > extglob > to-regex > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.867Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > extglob > to-regex > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.867Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > nanomatch > to-regex > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.867Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > nanomatch > to-regex > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.867Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > braces > snapdragon > base > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.867Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > braces > snapdragon > base > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.867Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > extglob > snapdragon > base > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.867Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > extglob > snapdragon > base > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.867Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > nanomatch > snapdragon > base > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.867Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > nanomatch > snapdragon > base > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.867Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > snapdragon > base > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.867Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > snapdragon > base > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.867Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > braces > snapdragon-node > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.867Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > braces > snapdragon-node > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.867Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > braces > to-regex > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.867Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > braces > to-regex > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.867Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > extglob > expand-brackets > to-regex > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.867Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > extglob > expand-brackets > to-regex > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.867Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > extglob > to-regex > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.867Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > extglob > to-regex > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.867Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > nanomatch > to-regex > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.868Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > nanomatch > to-regex > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.868Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > braces > snapdragon > base > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.868Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > braces > snapdragon > base > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.868Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > extglob > expand-brackets > snapdragon > base > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.868Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > extglob > expand-brackets > snapdragon > base > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.868Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > extglob > snapdragon > base > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.868Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > extglob > snapdragon > base > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.868Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > nanomatch > snapdragon > base > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.868Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > nanomatch > snapdragon > base > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.868Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > extglob > expand-brackets > to-regex > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.868Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > extglob > expand-brackets > to-regex > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.868Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > braces > snapdragon > base > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.868Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > braces > snapdragon > base > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.868Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > extglob > expand-brackets > snapdragon > base > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.868Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > extglob > expand-brackets > snapdragon > base > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.868Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > extglob > snapdragon > base > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.868Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > extglob > snapdragon > base > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.868Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > nanomatch > snapdragon > base > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.868Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > nanomatch > snapdragon > base > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.868Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > extglob > expand-brackets > to-regex > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.868Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > extglob > expand-brackets > to-regex > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.868Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > braces > snapdragon > base > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.869Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > braces > snapdragon > base > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.869Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > extglob > expand-brackets > snapdragon > base > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.869Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > extglob > expand-brackets > snapdragon > base > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.869Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > extglob > snapdragon > base > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.869Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > extglob > snapdragon > base > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.869Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > nanomatch > snapdragon > base > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.869Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > nanomatch > snapdragon > base > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.869Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > extglob > expand-brackets > to-regex > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.869Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > extglob > expand-brackets > to-regex > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.869Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > extglob > expand-brackets > snapdragon > base > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.869Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > extglob > expand-brackets > snapdragon > base > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.869Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > extglob > expand-brackets > snapdragon > base > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.869Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > extglob > expand-brackets > snapdragon > base > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.869Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > extglob > expand-brackets > snapdragon > base > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.869Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > extglob > expand-brackets > snapdragon > base > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.869Z'
+    - watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.870Z'
+    - watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.870Z'
+    - watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > nanomatch > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.870Z'
+    - watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > nanomatch > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.870Z'
+    - watchpack > watchpack-chokidar2 > chokidar > braces > snapdragon-node > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.870Z'
+    - watchpack > watchpack-chokidar2 > chokidar > braces > to-regex > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.870Z'
+    - watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.870Z'
+    - watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.870Z'
+    - watchpack > watchpack-chokidar2 > chokidar > braces > snapdragon-node > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.870Z'
+    - watchpack > watchpack-chokidar2 > chokidar > braces > to-regex > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.870Z'
+    - watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.870Z'
+    - watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.870Z'
+    - watchpack > watchpack-chokidar2 > chokidar > braces > snapdragon-node > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.870Z'
+    - watchpack > watchpack-chokidar2 > chokidar > braces > to-regex > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.870Z'
+    - watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.870Z'
+    - watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.870Z'
+    - watchpack > watchpack-chokidar2 > chokidar > braces > snapdragon > base > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.870Z'
+    - watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > extglob > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.870Z'
+    - watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > extglob > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.870Z'
+    - watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > to-regex > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.871Z'
+    - watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > to-regex > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.871Z'
+    - watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > nanomatch > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.871Z'
+    - watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > nanomatch > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.871Z'
+    - watchpack > watchpack-chokidar2 > chokidar > braces > snapdragon > base > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.871Z'
+    - watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > extglob > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.871Z'
+    - watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > extglob > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.871Z'
+    - watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > to-regex > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.871Z'
+    - watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > to-regex > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.871Z'
+    - watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > nanomatch > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.871Z'
+    - watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > nanomatch > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.871Z'
+    - watchpack > watchpack-chokidar2 > chokidar > braces > snapdragon > base > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.871Z'
+    - watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > extglob > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.871Z'
+    - watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > extglob > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.871Z'
+    - watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > to-regex > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.871Z'
+    - watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > to-regex > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.871Z'
+    - watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > nanomatch > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.872Z'
+    - watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > nanomatch > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.872Z'
+    - watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > snapdragon > base > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.872Z'
+    - watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > snapdragon > base > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.872Z'
+    - watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > braces > snapdragon-node > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.872Z'
+    - watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > braces > snapdragon-node > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.872Z'
+    - watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > braces > to-regex > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.872Z'
+    - watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > braces > to-regex > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.872Z'
+    - watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > extglob > to-regex > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.872Z'
+    - watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > extglob > to-regex > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.872Z'
+    - watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > nanomatch > to-regex > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.872Z'
+    - watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > nanomatch > to-regex > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.872Z'
+    - watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > snapdragon > base > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.872Z'
+    - watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > snapdragon > base > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.872Z'
+    - watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > braces > snapdragon-node > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.872Z'
+    - watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > braces > snapdragon-node > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.872Z'
+    - watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > braces > to-regex > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.872Z'
+    - watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > braces > to-regex > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.872Z'
+    - watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > extglob > to-regex > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.872Z'
+    - watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > extglob > to-regex > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.872Z'
+    - watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > nanomatch > to-regex > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.872Z'
+    - watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > nanomatch > to-regex > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.872Z'
+    - watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > snapdragon > base > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.872Z'
+    - watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > snapdragon > base > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.872Z'
+    - watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > braces > snapdragon-node > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.872Z'
+    - watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > braces > snapdragon-node > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.873Z'
+    - watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > braces > to-regex > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.873Z'
+    - watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > braces > to-regex > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.873Z'
+    - watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > extglob > to-regex > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.873Z'
+    - watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > extglob > to-regex > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.873Z'
+    - watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > nanomatch > to-regex > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.873Z'
+    - watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > nanomatch > to-regex > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.873Z'
+    - watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > braces > snapdragon > base > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.873Z'
+    - watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > braces > snapdragon > base > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.873Z'
+    - watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > extglob > snapdragon > base > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.873Z'
+    - watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > extglob > snapdragon > base > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.873Z'
+    - watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > nanomatch > snapdragon > base > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.873Z'
+    - watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > nanomatch > snapdragon > base > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.873Z'
+    - watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > extglob > expand-brackets > to-regex > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.873Z'
+    - watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > extglob > expand-brackets > to-regex > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.873Z'
+    - watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > braces > snapdragon > base > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.873Z'
+    - watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > braces > snapdragon > base > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.873Z'
+    - watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > extglob > snapdragon > base > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.873Z'
+    - watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > extglob > snapdragon > base > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.873Z'
+    - watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > nanomatch > snapdragon > base > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.874Z'
+    - watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > nanomatch > snapdragon > base > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.874Z'
+    - watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > extglob > expand-brackets > to-regex > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.874Z'
+    - watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > extglob > expand-brackets > to-regex > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.874Z'
+    - watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > braces > snapdragon > base > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.874Z'
+    - watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > braces > snapdragon > base > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.874Z'
+    - watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > extglob > snapdragon > base > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.874Z'
+    - watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > extglob > snapdragon > base > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.874Z'
+    - watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > nanomatch > snapdragon > base > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.874Z'
+    - watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > nanomatch > snapdragon > base > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.874Z'
+    - watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > extglob > expand-brackets > to-regex > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.874Z'
+    - watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > extglob > expand-brackets > to-regex > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.874Z'
+    - watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > extglob > expand-brackets > snapdragon > base > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.874Z'
+    - watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > extglob > expand-brackets > snapdragon > base > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.874Z'
+    - watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > extglob > expand-brackets > snapdragon > base > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.874Z'
+    - watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > extglob > expand-brackets > snapdragon > base > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.874Z'
+    - watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > extglob > expand-brackets > snapdragon > base > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.874Z'
+    - watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > extglob > expand-brackets > snapdragon > base > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.874Z'
+    - webpack > micromatch > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.874Z'
+    - webpack > micromatch > nanomatch > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.874Z'
+    - webpack > micromatch > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.874Z'
+    - webpack > micromatch > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.874Z'
+    - webpack > micromatch > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.874Z'
+    - webpack > micromatch > extglob > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.875Z'
+    - webpack > micromatch > to-regex > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.875Z'
+    - webpack > micromatch > nanomatch > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.875Z'
+    - webpack > micromatch > extglob > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.875Z'
+    - webpack > micromatch > to-regex > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.875Z'
+    - webpack > micromatch > nanomatch > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.875Z'
+    - webpack > micromatch > extglob > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.875Z'
+    - webpack > micromatch > to-regex > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.875Z'
+    - webpack > micromatch > nanomatch > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.875Z'
+    - webpack > micromatch > snapdragon > base > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.875Z'
+    - webpack > micromatch > braces > snapdragon-node > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.875Z'
+    - webpack > micromatch > braces > to-regex > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.875Z'
+    - webpack > micromatch > extglob > to-regex > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.875Z'
+    - webpack > micromatch > nanomatch > to-regex > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.875Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.875Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.875Z'
+    - webpack > micromatch > snapdragon > base > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.875Z'
+    - webpack > micromatch > braces > snapdragon-node > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.875Z'
+    - webpack > micromatch > braces > to-regex > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.875Z'
+    - webpack > micromatch > extglob > to-regex > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.875Z'
+    - webpack > micromatch > nanomatch > to-regex > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.875Z'
+    - webpack > micromatch > snapdragon > base > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.875Z'
+    - webpack > micromatch > braces > snapdragon-node > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.875Z'
+    - webpack > micromatch > braces > to-regex > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.875Z'
+    - webpack > micromatch > extglob > to-regex > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.875Z'
+    - webpack > micromatch > nanomatch > to-regex > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.876Z'
+    - webpack > micromatch > braces > snapdragon > base > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.876Z'
+    - webpack > micromatch > extglob > snapdragon > base > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.876Z'
+    - webpack > micromatch > nanomatch > snapdragon > base > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.876Z'
+    - webpack > micromatch > extglob > expand-brackets > to-regex > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.876Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > nanomatch > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.876Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > nanomatch > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.876Z'
+    - webpack > micromatch > braces > snapdragon > base > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.876Z'
+    - webpack > micromatch > extglob > snapdragon > base > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.876Z'
+    - webpack > micromatch > nanomatch > snapdragon > base > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.876Z'
+    - webpack > micromatch > extglob > expand-brackets > to-regex > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.876Z'
+    - webpack > micromatch > braces > snapdragon > base > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.876Z'
+    - webpack > micromatch > extglob > snapdragon > base > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.876Z'
+    - webpack > micromatch > nanomatch > snapdragon > base > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.876Z'
+    - webpack > micromatch > extglob > expand-brackets > to-regex > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.876Z'
+    - webpack > micromatch > extglob > expand-brackets > snapdragon > base > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.876Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > braces > snapdragon-node > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.876Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > braces > to-regex > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.876Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.876Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.876Z'
+    - webpack > micromatch > extglob > expand-brackets > snapdragon > base > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.876Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > braces > snapdragon-node > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.876Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > braces > to-regex > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.876Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.876Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.876Z'
+    - webpack > micromatch > extglob > expand-brackets > snapdragon > base > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.876Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > braces > snapdragon-node > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.876Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > braces > to-regex > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.877Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.877Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.877Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > braces > snapdragon > base > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.877Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > extglob > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.877Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > extglob > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.877Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > to-regex > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.877Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > to-regex > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.877Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > nanomatch > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.877Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > nanomatch > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.877Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > braces > snapdragon > base > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.877Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > extglob > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.878Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > extglob > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.878Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > to-regex > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.878Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > to-regex > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.878Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > nanomatch > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.878Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > nanomatch > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.878Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > braces > snapdragon > base > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.878Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > extglob > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.878Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > extglob > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.878Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > to-regex > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.878Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > to-regex > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.878Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > nanomatch > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.878Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > nanomatch > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.878Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > snapdragon > base > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.878Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > snapdragon > base > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.878Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > braces > snapdragon-node > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.878Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > braces > snapdragon-node > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.878Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > braces > to-regex > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.878Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > braces > to-regex > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.878Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > extglob > to-regex > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.878Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > extglob > to-regex > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.878Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > nanomatch > to-regex > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.878Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > nanomatch > to-regex > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.878Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > snapdragon > base > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.878Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > snapdragon > base > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.879Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > braces > snapdragon-node > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.879Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > braces > snapdragon-node > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.879Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > braces > to-regex > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.879Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > braces > to-regex > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.879Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > extglob > to-regex > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.879Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > extglob > to-regex > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.879Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > nanomatch > to-regex > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.879Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > nanomatch > to-regex > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.879Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > snapdragon > base > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.879Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > snapdragon > base > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.879Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > braces > snapdragon-node > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.879Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > braces > snapdragon-node > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.879Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > braces > to-regex > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.879Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > braces > to-regex > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.879Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > extglob > to-regex > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.879Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > extglob > to-regex > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.879Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > nanomatch > to-regex > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.879Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > nanomatch > to-regex > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.879Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > braces > snapdragon > base > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.879Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > braces > snapdragon > base > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.879Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > extglob > snapdragon > base > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.879Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > extglob > snapdragon > base > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.879Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > nanomatch > snapdragon > base > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.879Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > nanomatch > snapdragon > base > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.879Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > extglob > expand-brackets > to-regex > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.879Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > extglob > expand-brackets > to-regex > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.880Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > braces > snapdragon > base > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.880Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > braces > snapdragon > base > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.880Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > extglob > snapdragon > base > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.880Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > extglob > snapdragon > base > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.880Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > nanomatch > snapdragon > base > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.880Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > nanomatch > snapdragon > base > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.880Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > extglob > expand-brackets > to-regex > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.880Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > extglob > expand-brackets > to-regex > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.880Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > braces > snapdragon > base > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.880Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > braces > snapdragon > base > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.880Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > extglob > snapdragon > base > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.880Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > extglob > snapdragon > base > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.880Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > nanomatch > snapdragon > base > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.880Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > nanomatch > snapdragon > base > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.880Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > extglob > expand-brackets > to-regex > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.880Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > extglob > expand-brackets > to-regex > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.880Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > extglob > expand-brackets > snapdragon > base > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.880Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > extglob > expand-brackets > snapdragon > base > define-property > is-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.880Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > extglob > expand-brackets > snapdragon > base > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.880Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > extglob > expand-brackets > snapdragon > base > define-property > is-descriptor > is-accessor-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.880Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > anymatch > micromatch > extglob > expand-brackets > snapdragon > base > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.880Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > readdirp > micromatch > extglob > expand-brackets > snapdragon > base > define-property > is-descriptor > is-data-descriptor > kind-of:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.880Z'
+  SNYK-JS-Y18N-1021887:
+    - cacache > y18n:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.855Z'
+    - terser-webpack-plugin > cacache > y18n:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.870Z'
+    - terser-webpack-plugin > terser-webpack-plugin > cacache > y18n:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.870Z'
+    - terser-webpack-plugin > webpack > terser-webpack-plugin > cacache > y18n:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.870Z'
+    - webpack > terser-webpack-plugin > cacache > y18n:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.880Z'
+  SNYK-JS-GLOBPARENT-1016905:
+    - eslint-config-airbnb-typescript > @typescript-eslint/parser > @typescript-eslint/typescript-estree > globby > fast-glob > glob-parent:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.858Z'
+    - prettier-eslint > eslint > glob-parent:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.858Z'
+    - terser-webpack-plugin > watchpack > chokidar > glob-parent:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.858Z'
+    - terser-webpack-plugin > webpack > watchpack > chokidar > glob-parent:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.858Z'
+    - watchpack > chokidar > glob-parent:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.870Z'
+    - webpack > watchpack > chokidar > glob-parent:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.874Z'
+    - cpy > globby > fast-glob > glob-parent:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.880Z'
+    - watchpack > watchpack-chokidar2 > chokidar > glob-parent:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.880Z'
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > glob-parent:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.880Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > glob-parent:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.880Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > glob-parent:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.881Z'
+  SNYK-JS-HOSTEDGITINFO-1088355:
+    - eslint-plugin-import > read-pkg-up > read-pkg > normalize-package-data > hosted-git-info:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.858Z'
+  SNYK-JS-WS-1296835:
+    - jsdom > ws:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.858Z'
+  SNYK-JS-POSTCSS-1090595:
+    - sanitize-html > postcss:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.858Z'
+  SNYK-JS-POSTCSS-1255640:
+    - sanitize-html > postcss:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.858Z'
+  SNYK-JS-INI-1048974:
+    - terser-webpack-plugin > watchpack > watchpack-chokidar2 > chokidar > fsevents > node-pre-gyp > rc > ini:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.858Z'
+    - terser-webpack-plugin > webpack > watchpack > watchpack-chokidar2 > chokidar > fsevents > node-pre-gyp > rc > ini:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.858Z'
+    - watchpack > watchpack-chokidar2 > chokidar > fsevents > node-pre-gyp > rc > ini:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.870Z'
+    - webpack > watchpack > watchpack-chokidar2 > chokidar > fsevents > node-pre-gyp > rc > ini:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.874Z'
+  SNYK-JS-NETMASK-1089716:
+    - pm2 > @pm2/io > @pm2/agent-node > proxy-agent > pac-proxy-agent > pac-resolver > netmask:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.881Z'
+  'snyk:lic:npm:axe-core:MPL-2.0':
+    - eslint-plugin-jsx-a11y > axe-core:
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.881Z'
   'snyk:lic:npm:pm2:AGPL-3.0':
     - pm2:
-        reason: We're happy that this license does not impose any restriction on our app
-        expires: '2024-01-051T10:00:00.000Z'
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.881Z'
   'snyk:lic:npm:pm2:agent:AGPL-3.0':
     - pm2 > @pm2/agent:
-        reason: We're happy that this license does not impose any restriction on our app
-        expires: '2024-01-051T10:00:00.000Z'
+        reason: No update or patch available
+        expires: '2021-07-10T11:44:50.881Z'
 patch: {}


### PR DESCRIPTION
Reverts guardian/dotcom-rendering#8963 as Snyk run failed on merge to main for this PR (due to Snyk version `3.0.0` not existing)