### PR TITLE
fix: update snyk version

### DIFF
--- a/dotcom-rendering/.snyk
+++ b/dotcom-rendering/.snyk
@@ -1,5 +1,5 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-version: v3.0.0
+version: v1.1229.0
 # We should only ignore license warnings in here. Any other vulnerabilities should be fixed
 # or ignored in the Snyk console.
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

As a follow-up from #8963, changes the version of snyk in the `.snyk` file to the latest version as of today (`1.1299.0`)

## Why?

[Snyk run was failing](https://github.com/guardian/dotcom-rendering/actions/runs/6390728745/job/17347245046) on merge due to not recognising the version number (`3.0.0`)
