### PR TITLE
Group Dependabot Storybook Updates In DCR And AR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,13 @@ updates:
         - dependency-name: 'aws-cdk-lib'
         - dependency-name: 'constructs'
       open-pull-requests-limit: 10
+      groups:
+        # Most storybook dependencies are released with synchronised versions
+        # and therefore should be updated together.
+        storybook:
+          patterns:
+            - "@storybook/*"
+            - "storybook"
     - package-ecosystem: 'npm'
       directory: '/apps-rendering'
       schedule:
@@ -36,6 +43,13 @@ updates:
             - "version-update:semver-major"
             - "version-update:semver-minor"
       open-pull-requests-limit: 7
+      groups:
+        # Most storybook dependencies are released with synchronised versions
+        # and therefore should be updated together.
+        storybook:
+          patterns:
+            - "@storybook/*"
+            - "storybook"
     - package-ecosystem: 'github-actions'
       directory: '/'
       schedule:


### PR DESCRIPTION
Currently dependabot is bumping storybook dependencies in independent PRs. Most storybook packages are released with synchronised versions and therefore should be updated together. A single PR also has less overhead in developer time and CI runs.

The `csnx` and `csti-interactives` repos are already grouping storybook updates in this way.

See the docs on grouping[^1] for more details on how this works.

[^1]: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups
