### PR TITLE
Add min-height to the fronts-banner ad slot

### DIFF
--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -273,6 +273,7 @@ const frontsBannerCollapseStyles = css`
 
 const frontsBannerAdStyles = css`
 	position: relative;
+	min-height: ${frontsBannerMinHeight}px;
 	max-width: ${breakpoints['wide']}px;
 	/* No banner should be taller than 600px */
 	max-height: ${600 + labelHeight}px;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

- Adds a minimum height to the `fronts-banner` ad slot.

## Why?

- As the user scrolls down the page, if a `fronts-banner` ad is loaded when it is partially in the viewport, then the browser will move the viewport up by the height of the ad. We don't want this behaviour as it causes CLS. 
- We currently have the `min-height` of the expected advert height set on a container of the ad slot. However, it turns out that this is not sufficient to prevent CLS. The `min-height` setting needs to be on the slot itself. This is because the ad slot exists on the DOM when the page is loaded at zero height. This height is then changed to be 294px when the ad loads.


## Screenshots

#### Before

https://github.com/guardian/dotcom-rendering/assets/9574885/4e15787d-dac4-4ef8-848d-1ea46670c600

#### After

https://github.com/guardian/dotcom-rendering/assets/9574885/b5eff6f7-9ad1-484b-9a10-44d2b10494d6



<!--

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]:
[after]: 

You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
