### PR TITLE
Update placeholder to use min-height

### DIFF
--- a/dotcom-rendering/src/components/Placeholder.tsx
+++ b/dotcom-rendering/src/components/Placeholder.tsx
@@ -51,7 +51,7 @@ export const Placeholder = ({
 	>
 		<div
 			css={css`
-				height: ${height}px;
+				min-height: ${height}px;
 				width: ${width !== undefined ? `${width}px` : '100%'};
 				margin-bottom: ${spaceBelow && space[spaceBelow]}px;
 				margin-left: ${spaceLeft && space[spaceLeft]}px;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Updates the placeholder component to use min-height rather than height. This is so things rendered on the serverside (like getMatchStats) don't break if their content is taller than the placeholder height.

Closes https://github.com/guardian/dotcom-rendering/issues/9006


## Screenshots

| Before      | After Server side     | After Client Side
| ----------- | ---------- |---------- |
| <img width="1499" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/9954ce74-0aa1-4ddb-bfc1-b2ed9208d875" /> |<img width="1499" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/e1c5cf2f-81b6-41eb-80a1-fe6308fa47ba"> |<img width="1499" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/0b46fb9e-0c30-4695-86d9-c52f67815b9d"> |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
