### PR TITLE
DCAR: add layouts scaffolding

### DIFF
--- a/dotcom-rendering/src/layouts/DecideLayout.tsx
+++ b/dotcom-rendering/src/layouts/DecideLayout.tsx
@@ -31,16 +31,21 @@ interface WebProps extends BaseProps {
 const DecideLayoutApps = ({ article, format, renderingTarget }: AppProps) => {
 	const notSupported = <pre>Not supported</pre>;
 	switch (format.display) {
-		case ArticleDisplay.Standard: {
+		case ArticleDisplay.Immersive: {
 			switch (format.design) {
-				case ArticleDesign.Standard:
-					return (
-						<StandardLayout
-							article={article}
-							format={format}
-							renderingTarget={renderingTarget}
-						/>
-					);
+				case ArticleDesign.Interactive: {
+					// Should be InteractiveLayout once implemented for apps
+					return notSupported;
+				}
+				default: {
+					// Should be FullPageInteractiveLayout once implemented for apps
+					return notSupported;
+				}
+			}
+		}
+		case ArticleDisplay.NumberedList:
+		case ArticleDisplay.Showcase: {
+			switch (format.design) {
 				case ArticleDesign.LiveBlog:
 				case ArticleDesign.DeadBlog:
 					return (
@@ -50,12 +55,55 @@ const DecideLayoutApps = ({ article, format, renderingTarget }: AppProps) => {
 							renderingTarget={renderingTarget}
 						/>
 					);
+				case ArticleDesign.Comment:
+				case ArticleDesign.Editorial:
+				case ArticleDesign.Letter:
+					// Should be CommentLayout once implemented for apps
+					return notSupported;
+				case ArticleDesign.Picture:
+					// Should be PictureLayout once implemented for apps
+					return notSupported;
 				default:
+					// Should be ShowcaseLayout once implemented for apps
 					return notSupported;
 			}
 		}
-		default:
-			return notSupported;
+		case ArticleDisplay.Standard:
+		default: {
+			switch (format.design) {
+				case ArticleDesign.Interactive:
+					// Should be InteractiveLayout once implemented for apps
+					return notSupported;
+				case ArticleDesign.FullPageInteractive: {
+					// Should be FullPageInteractiveLayout once implemented for apps
+					return notSupported;
+				}
+				case ArticleDesign.LiveBlog:
+				case ArticleDesign.DeadBlog:
+					return (
+						<LiveLayout
+							article={article}
+							format={format}
+							renderingTarget={renderingTarget}
+						/>
+					);
+				case ArticleDesign.Comment:
+				case ArticleDesign.Editorial:
+				case ArticleDesign.Letter:
+					// Should be CommentLayout once implemented for apps
+					return notSupported;
+				case ArticleDesign.NewsletterSignup:
+					return notSupported;
+				default:
+					return (
+						<StandardLayout
+							article={article}
+							format={format}
+							renderingTarget={renderingTarget}
+						/>
+					);
+			}
+		}
 	}
 };
 


### PR DESCRIPTION
DCAR currently only supports the Standard layout. This change adds scaffolding so we can support the remaining layout types more easily. The layout picker logic is the same as that used by DCR.

In the future, when more layouts support apps, we might be able to combine the `DecideLayoutApps` and `DecideLayoutWeb` functions into one.