### PR TITLE
If there is a trail image for a fronts card, we should use it instead of the video thumbnail

### DIFF
--- a/dotcom-rendering/src/components/AppsLightboxImage.importable.tsx
+++ b/dotcom-rendering/src/components/AppsLightboxImage.importable.tsx
@@ -44,7 +44,7 @@ export const AppsLightboxImage = ({
 							width: image.width,
 							height: image.height,
 							url: generateImageURL({
-								master: image.masterUrl,
+								mainImage: image.masterUrl,
 								imageWidth,
 								resolution,
 							}),

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -211,7 +211,11 @@ const getMedia = ({
 	isPlayableMediaCard?: boolean;
 }) => {
 	if (mainMedia && mainMedia.type === 'Video' && !!isPlayableMediaCard) {
-		return { type: 'video', mainMedia } as const;
+		return {
+			type: 'video',
+			mainMedia,
+			...(imageUrl && { imageUrl }),
+		} as const;
 	}
 	if (slideshowImages) return { type: 'slideshow', slideshowImages } as const;
 	if (avatarUrl) return { type: 'avatar', avatarUrl } as const;
@@ -451,6 +455,7 @@ export const Card = ({
 										assetId={media.mainMedia.videoId}
 										duration={media.mainMedia.duration}
 										posterImage={media.mainMedia.images}
+										overrideImage={media.imageUrl}
 										width={media.mainMedia.width}
 										height={media.mainMedia.height}
 										origin={media.mainMedia.origin}
@@ -475,7 +480,7 @@ export const Card = ({
 						{media.type === 'picture' && (
 							<>
 								<CardPicture
-									master={media.imageUrl}
+									mainImage={media.imageUrl}
 									imageSize={imageSize}
 									alt={media.imageAltText}
 									loading={imageLoading}

--- a/dotcom-rendering/src/components/CardPicture.tsx
+++ b/dotcom-rendering/src/components/CardPicture.tsx
@@ -10,7 +10,7 @@ export type Loading = NonNullable<ImgHTMLAttributes<unknown>['loading']>;
 
 type Props = {
 	imageSize: ImageSizeType;
-	master: string;
+	mainImage: string;
 	loading: Loading;
 	alt?: string;
 };
@@ -94,8 +94,8 @@ const aspectRatio = css`
 	}
 `;
 
-export const CardPicture = ({ master, alt, imageSize, loading }: Props) => {
-	const sources = generateSources(master, decideImageWidths(imageSize));
+export const CardPicture = ({ mainImage, alt, imageSize, loading }: Props) => {
+	const sources = generateSources(mainImage, decideImageWidths(imageSize));
 
 	const fallbackSource = getFallbackSource(sources);
 

--- a/dotcom-rendering/src/components/NewsletterCard.tsx
+++ b/dotcom-rendering/src/components/NewsletterCard.tsx
@@ -206,7 +206,7 @@ export const NewsletterCard = ({
 					<CardPicture
 						imageSize="carousel"
 						alt=""
-						master={newsletter.illustrationCard}
+						mainImage={newsletter.illustrationCard}
 						loading="lazy"
 					/>
 				</div>

--- a/dotcom-rendering/src/components/Picture.tsx
+++ b/dotcom-rendering/src/components/Picture.tsx
@@ -230,11 +230,11 @@ type ImageSource = {
 /**
  * Generate image sources for an image.
  *
- * @param master source image URL
+ * @param mainImage source image URL
  * @param imageWidths list of image widths
  */
 export const generateSources = (
-	master: string,
+	mainImage: string,
 	imageWidths: readonly [ImageWidthType, ...ImageWidthType[]],
 ): ImageSource[] =>
 	imageWidths
@@ -245,12 +245,12 @@ export const generateSources = (
 				breakpoint,
 				width: imageWidth,
 				hiResUrl: generateImageURL({
-					master,
+					mainImage,
 					imageWidth,
 					resolution: 'high',
 				}),
 				lowResUrl: generateImageURL({
-					master,
+					mainImage,
 					imageWidth,
 					resolution: 'low',
 				}),

--- a/dotcom-rendering/src/components/Slideshow.tsx
+++ b/dotcom-rendering/src/components/Slideshow.tsx
@@ -179,7 +179,7 @@ export const Slideshow = ({
 					css={styles}
 				>
 					<CardPicture
-						master={slideshowImage.imageSrc}
+						mainImage={slideshowImage.imageSrc}
 						imageSize={imageSize}
 						alt={slideshowImage.imageCaption}
 						loading={loading}

--- a/dotcom-rendering/src/lib/image.ts
+++ b/dotcom-rendering/src/lib/image.ts
@@ -34,15 +34,15 @@ const getServiceFromUrl = (url: URL): string => {
  *
  */
 export const generateImageURL = ({
-	master,
+	mainImage,
 	imageWidth,
 	resolution,
 }: {
-	master: string;
+	mainImage: string;
 	imageWidth: number;
 	resolution: 'low' | 'high';
 }): string => {
-	const url = new URL(master);
+	const url = new URL(mainImage);
 
 	// In CODE, we do not generate optimised replacement images
 	if (url.hostname === 's3-eu-west-1.amazonaws.com') return url.href;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

- Makes use of the YoutubeBlockComponent's overrideImage prop, to pass down the imageUrl (if it exists) for mainVideos.
- Renames a prop from `master` -> `mainImage`, not strictly related so could be split out but I noticed it and its a pretty small pr

Closes https://github.com/guardian/dotcom-rendering/issues/8791

## Why?
Editorial would prefer that if there is a trail image for a video card, then we should use it instead of the media images.

## Screenshots

| | Before      | After      |
| ----------- | ----------- | ---------- |
| With no trail image | <img width="1499" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/5c2e07ff-6a99-45a2-9da8-219e01ed2234">| <img width="1499" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/a1af9b8d-4e30-4ec4-b5e3-c04cbfeaff2d">|
| With trail image | <img width="1499" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/bc9c14b3-f26a-472e-a13d-a7082aa82eb5"> | <img width="1499" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/0232d907-a852-4467-b92c-3dcce997d943"> |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
