### PR TITLE
Stop sending Okta errors to Sentry

### DIFF
--- a/dotcom-rendering/src/lib/identity.ts
+++ b/dotcom-rendering/src/lib/identity.ts
@@ -1,6 +1,5 @@
 import type { CustomClaims, IdentityAuthState } from '@guardian/identity-auth';
 import { getIdentityAuth } from '@guardian/identity-auth-frontend';
-import { reportError } from '../client/sentryLoader/sentry';
 
 export type CustomIdTokenClaims = CustomClaims & {
 	email: string;
@@ -13,9 +12,8 @@ export async function isSignedInWithOktaAuthState(): Promise<
 	return getIdentityAuth()
 		.isSignedInWithAuthState()
 		.catch((e) => {
-			if (e instanceof Error) {
-				reportError(e, 'okta');
-			}
+			// eslint-disable-next-line no-console -- we want to log the error to console, not Sentry
+			console.error(e);
 
 			return {
 				isAuthenticated: false,


### PR DESCRIPTION
Since rolling out Okta to 100% of readers, we have seen a spike in dropped errors in Sentry. Dropped errors are bad because it means we might lose sight of errors we care about. This change stops sending errors originating from the Okta flow to Sentry, instead just logging them to console.