### PR TITLE
Implement standard interactive layout for apps

### DIFF
--- a/dotcom-rendering/scripts/gen-stories/get-stories.js
+++ b/dotcom-rendering/scripts/gen-stories/get-stories.js
@@ -171,6 +171,12 @@ const testLayoutFormats = [
 		theme: 'NewsPillar',
 		renderingTarget: 'Apps',
 	},
+	{
+		display: 'Standard',
+		design: 'Interactive',
+		theme: 'NewsPillar',
+		renderingTarget: 'Apps',
+	},
 ];
 
 const generateLayoutStories = () => {

--- a/dotcom-rendering/src/layouts/DecideLayout.tsx
+++ b/dotcom-rendering/src/layouts/DecideLayout.tsx
@@ -29,11 +29,13 @@ interface WebProps extends BaseProps {
 }
 
 const DecideLayoutApps = ({ article, format, renderingTarget }: AppProps) => {
+	console.log(format);
 	const notSupported = <pre>Not supported</pre>;
 	switch (format.display) {
 		case ArticleDisplay.Immersive: {
 			switch (format.design) {
 				case ArticleDesign.Interactive: {
+					console.log('APPS immersive interactive');
 					// Should be InteractiveLayout once implemented for apps
 					return notSupported;
 				}
@@ -83,9 +85,19 @@ const DecideLayoutApps = ({ article, format, renderingTarget }: AppProps) => {
 		default: {
 			switch (format.design) {
 				case ArticleDesign.Interactive:
-					// Should be InteractiveLayout once implemented for apps
-					return notSupported;
+					console.log('APPS standard interactive');
+
+					return (
+						<InteractiveLayout
+							article={article}
+							format={format}
+							renderingTarget={renderingTarget}
+						/>
+					);
+
 				case ArticleDesign.FullPageInteractive: {
+					console.log('APPS fullpage interactive');
+
 					// Should be FullPageInteractiveLayout once implemented for apps
 					return notSupported;
 				}
@@ -134,6 +146,8 @@ const DecideLayoutWeb = ({
 		case ArticleDisplay.Immersive: {
 			switch (format.design) {
 				case ArticleDesign.Interactive: {
+					console.log('immersive interactive layout');
+
 					// Render all 'immersive interactives' until switchover date as 'FullPageInteractive'
 					// TBD: After 'immersive interactive' changes to CAPI are merged, add logic here to either use
 					// 'InteractiveImmersiveLayout' if published after switchover date, or 'FullPageInteractiveLayout'
@@ -204,14 +218,19 @@ const DecideLayoutWeb = ({
 		default: {
 			switch (format.design) {
 				case ArticleDesign.Interactive:
+					console.log('standard interactive layout');
+
 					return (
 						<InteractiveLayout
 							article={article}
 							NAV={NAV}
 							format={format}
+							renderingTarget={renderingTarget}
 						/>
 					);
 				case ArticleDesign.FullPageInteractive: {
+					console.log('standard full page interactive layout');
+
 					return (
 						<FullPageInteractiveLayout
 							article={article}

--- a/dotcom-rendering/src/layouts/DecideLayout.tsx
+++ b/dotcom-rendering/src/layouts/DecideLayout.tsx
@@ -29,13 +29,11 @@ interface WebProps extends BaseProps {
 }
 
 const DecideLayoutApps = ({ article, format, renderingTarget }: AppProps) => {
-	console.log(format);
 	const notSupported = <pre>Not supported</pre>;
 	switch (format.display) {
 		case ArticleDisplay.Immersive: {
 			switch (format.design) {
 				case ArticleDesign.Interactive: {
-					console.log('APPS immersive interactive');
 					// Should be InteractiveLayout once implemented for apps
 					return notSupported;
 				}
@@ -85,8 +83,6 @@ const DecideLayoutApps = ({ article, format, renderingTarget }: AppProps) => {
 		default: {
 			switch (format.design) {
 				case ArticleDesign.Interactive:
-					console.log('APPS standard interactive');
-
 					return (
 						<InteractiveLayout
 							article={article}
@@ -96,8 +92,6 @@ const DecideLayoutApps = ({ article, format, renderingTarget }: AppProps) => {
 					);
 
 				case ArticleDesign.FullPageInteractive: {
-					console.log('APPS fullpage interactive');
-
 					// Should be FullPageInteractiveLayout once implemented for apps
 					return notSupported;
 				}
@@ -146,8 +140,6 @@ const DecideLayoutWeb = ({
 		case ArticleDisplay.Immersive: {
 			switch (format.design) {
 				case ArticleDesign.Interactive: {
-					console.log('immersive interactive layout');
-
 					// Render all 'immersive interactives' until switchover date as 'FullPageInteractive'
 					// TBD: After 'immersive interactive' changes to CAPI are merged, add logic here to either use
 					// 'InteractiveImmersiveLayout' if published after switchover date, or 'FullPageInteractiveLayout'
@@ -218,8 +210,6 @@ const DecideLayoutWeb = ({
 		default: {
 			switch (format.design) {
 				case ArticleDesign.Interactive:
-					console.log('standard interactive layout');
-
 					return (
 						<InteractiveLayout
 							article={article}
@@ -229,8 +219,6 @@ const DecideLayoutWeb = ({
 						/>
 					);
 				case ArticleDesign.FullPageInteractive: {
-					console.log('standard full page interactive layout');
-
 					return (
 						<FullPageInteractiveLayout
 							article={article}

--- a/dotcom-rendering/src/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/InteractiveLayout.tsx
@@ -14,7 +14,9 @@ import {
 } from '@guardian/source-foundations';
 import { StraightLines } from '@guardian/source-react-components-development-kitchen';
 import React from 'react';
+import { AdPortals } from '../components/AdPortals.importable';
 import { AdSlot, MobileStickyContainer } from '../components/AdSlot.web';
+import { AppsFooter } from '../components/AppsFooter.importable';
 import { ArticleBody } from '../components/ArticleBody';
 import { ArticleContainer } from '../components/ArticleContainer';
 import { ArticleHeadline } from '../components/ArticleHeadline';
@@ -22,7 +24,6 @@ import { ArticleMeta } from '../components/ArticleMeta';
 import { ArticleTitle } from '../components/ArticleTitle';
 import { Border } from '../components/Border';
 import { Carousel } from '../components/Carousel.importable';
-import { useConfig } from '../components/ConfigContext';
 import { DecideLines } from '../components/DecideLines';
 import { DiscussionLayout } from '../components/DiscussionLayout';
 import { Footer } from '../components/Footer';
@@ -49,6 +50,7 @@ import { decidePalette } from '../lib/decidePalette';
 import { decideTrail } from '../lib/decideTrail';
 import type { NavType } from '../model/extract-nav';
 import type { DCRArticle } from '../types/frontend';
+import type { RenderingTarget } from '../types/renderingTarget';
 import {
 	interactiveGlobalStyles,
 	interactiveLegacyClasses,
@@ -200,13 +202,23 @@ const starWrapper = css`
 	margin-left: -10px;
 `;
 
-interface Props {
+interface CommonProps {
 	article: DCRArticle;
-	NAV: NavType;
 	format: ArticleFormat;
+	renderingTarget: RenderingTarget;
 }
 
-export const InteractiveLayout = ({ article, NAV, format }: Props) => {
+interface WebProps extends CommonProps {
+	NAV: NavType;
+	renderingTarget: 'Web';
+}
+
+interface AppsProps extends CommonProps {
+	renderingTarget: 'Apps';
+}
+
+export const InteractiveLayout = (props: WebProps | AppsProps) => {
+	const { article, format, renderingTarget } = props;
 	const {
 		config: { isPaidContent, host },
 	} = article;
@@ -219,155 +231,178 @@ export const InteractiveLayout = ({ article, NAV, format }: Props) => {
 
 	const contributionsServiceUrl = getContributionsServiceUrl(article);
 
+	const isApps = renderingTarget === 'Apps';
+	const isWeb = renderingTarget === 'Web';
 	/**
 	 * This property currently only applies to the header and merchandising slots
 	 */
-	const renderAds = canRenderAds(article);
-
-	const { renderingTarget } = useConfig();
-
+	const renderAds = isWeb && canRenderAds(article);
 	return (
 		<>
-			{article.isLegacyInteractive && (
-				<Global styles={interactiveGlobalStyles} />
-			)}
+			{isWeb && (
+				<>
+					{article.isLegacyInteractive && (
+						<Global styles={interactiveGlobalStyles} />
+					)}
 
-			<div>
-				{renderAds && (
-					<Stuck>
-						<div data-print-layout="hide">
-							<Section
-								fullWidth={true}
-								showTopBorder={false}
-								showSideBorders={false}
-								padSides={false}
-								shouldCenter={false}
-							>
-								<HeaderAdSlot />
-							</Section>
-						</div>
-					</Stuck>
-				)}
+					<div>
+						{renderAds && (
+							<Stuck>
+								<div data-print-layout="hide">
+									<Section
+										fullWidth={true}
+										showTopBorder={false}
+										showSideBorders={false}
+										padSides={false}
+										shouldCenter={false}
+									>
+										<HeaderAdSlot />
+									</Section>
+								</div>
+							</Stuck>
+						)}
 
-				{format.theme !== ArticleSpecial.Labs && (
-					<div data-print-layout="hide">
+						{format.theme !== ArticleSpecial.Labs && (
+							<div data-print-layout="hide">
+								<Section
+									fullWidth={true}
+									shouldCenter={false}
+									showTopBorder={false}
+									showSideBorders={false}
+									padSides={false}
+									backgroundColour={brandBackground.primary}
+									element="header"
+								>
+									<Header
+										editionId={article.editionId}
+										idUrl={article.config.idUrl}
+										mmaUrl={article.config.mmaUrl}
+										discussionApiUrl={
+											article.config.discussionApiUrl
+										}
+										urls={
+											article.nav.readerRevenueLinks
+												.header
+										}
+										remoteHeader={
+											!!article.config.switches
+												.remoteHeader
+										}
+										contributionsServiceUrl={
+											contributionsServiceUrl
+										}
+										idApiUrl={article.config.idApiUrl}
+										headerTopBarSearchCapiSwitch={
+											!!article.config.switches
+												.headerTopBarSearchCapi
+										}
+									/>
+								</Section>
+							</div>
+						)}
+
 						<Section
 							fullWidth={true}
-							shouldCenter={false}
+							borderColour={brandLine.primary}
 							showTopBorder={false}
-							showSideBorders={false}
 							padSides={false}
 							backgroundColour={brandBackground.primary}
-							element="header"
+							element="nav"
 						>
-							<Header
+							<Nav
+								nav={props.NAV}
+								isImmersive={
+									format.display === ArticleDisplay.Immersive
+								}
+								displayRoundel={
+									format.display ===
+										ArticleDisplay.Immersive ||
+									format.theme === ArticleSpecial.Labs
+								}
+								selectedPillar={props.NAV.selectedPillar}
+								subscribeUrl={
+									article.nav.readerRevenueLinks.header
+										.subscribe
+								}
 								editionId={article.editionId}
-								idUrl={article.config.idUrl}
-								mmaUrl={article.config.mmaUrl}
-								discussionApiUrl={
-									article.config.discussionApiUrl
-								}
-								urls={article.nav.readerRevenueLinks.header}
-								remoteHeader={
-									!!article.config.switches.remoteHeader
-								}
-								contributionsServiceUrl={
-									contributionsServiceUrl
-								}
-								idApiUrl={article.config.idApiUrl}
-								headerTopBarSearchCapiSwitch={
-									!!article.config.switches
-										.headerTopBarSearchCapi
+								headerTopBarSwitch={
+									!!article.config.switches.headerTopNav
 								}
 							/>
 						</Section>
+
+						{props.NAV.subNavSections &&
+							format.theme !== ArticleSpecial.Labs && (
+								<Section
+									fullWidth={true}
+									backgroundColour={
+										palette.background.article
+									}
+									padSides={false}
+									element="aside"
+								>
+									<Island
+										priority="enhancement"
+										defer={{ until: 'idle' }}
+									>
+										<SubNav
+											subNavSections={
+												props.NAV.subNavSections
+											}
+											currentNavLink={
+												props.NAV.currentNavLink
+											}
+											linkHoverColour={
+												palette.text.articleLinkHover
+											}
+											borderColour={palette.border.subNav}
+										/>
+									</Island>
+								</Section>
+							)}
+
+						{format.theme !== ArticleSpecial.Labs && (
+							<Section
+								fullWidth={true}
+								backgroundColour={palette.background.article}
+								padSides={false}
+								showTopBorder={false}
+							>
+								<StraightLines
+									cssOverrides={css`
+										display: block;
+									`}
+									count={4}
+								/>
+							</Section>
+						)}
 					</div>
-				)}
 
-				<Section
-					fullWidth={true}
-					borderColour={brandLine.primary}
-					showTopBorder={false}
-					padSides={false}
-					backgroundColour={brandBackground.primary}
-					element="nav"
-				>
-					<Nav
-						nav={NAV}
-						isImmersive={
-							format.display === ArticleDisplay.Immersive
-						}
-						displayRoundel={
-							format.display === ArticleDisplay.Immersive ||
-							format.theme === ArticleSpecial.Labs
-						}
-						selectedPillar={NAV.selectedPillar}
-						subscribeUrl={
-							article.nav.readerRevenueLinks.header.subscribe
-						}
-						editionId={article.editionId}
-						headerTopBarSwitch={
-							!!article.config.switches.headerTopNav
-						}
-					/>
-				</Section>
+					{format.theme === ArticleSpecial.Labs && (
+						<Stuck>
+							<Section
+								fullWidth={true}
+								showTopBorder={false}
+								backgroundColour={labs[400]}
+								borderColour={border.primary}
+								sectionId="labs-header"
+							>
+								<LabsHeader />
+							</Section>
+						</Stuck>
+					)}
 
-				{NAV.subNavSections && format.theme !== ArticleSpecial.Labs && (
-					<Section
-						fullWidth={true}
-						backgroundColour={palette.background.article}
-						padSides={false}
-						element="aside"
-					>
-						<Island
-							priority="enhancement"
-							defer={{ until: 'idle' }}
-						>
-							<SubNav
-								subNavSections={NAV.subNavSections}
-								currentNavLink={NAV.currentNavLink}
-								linkHoverColour={palette.text.articleLinkHover}
-								borderColour={palette.border.subNav}
-							/>
-						</Island>
-					</Section>
-				)}
-
-				{format.theme !== ArticleSpecial.Labs && (
-					<Section
-						fullWidth={true}
-						backgroundColour={palette.background.article}
-						padSides={false}
-						showTopBorder={false}
-					>
-						<StraightLines
-							cssOverrides={css`
-								display: block;
-							`}
-							count={4}
-						/>
-					</Section>
-				)}
-			</div>
-
-			{format.theme === ArticleSpecial.Labs && (
-				<Stuck>
-					<Section
-						fullWidth={true}
-						showTopBorder={false}
-						backgroundColour={labs[400]}
-						borderColour={border.primary}
-						sectionId="labs-header"
-					>
-						<LabsHeader />
-					</Section>
-				</Stuck>
-			)}
-
-			{renderAds && article.config.switches.surveys && (
-				<AdSlot position="survey" display={format.display} />
+					{renderAds && article.config.switches.surveys && (
+						<AdSlot position="survey" display={format.display} />
+					)}
+				</>
 			)}
 			<main data-layout="InteractiveLayout">
+				{isApps && (
+					<Island priority="critical" clientOnly={true}>
+						<AdPortals />
+					</Island>
+				)}
 				<Section
 					fullWidth={true}
 					data-print-layout="hide"
@@ -731,7 +766,7 @@ export const InteractiveLayout = ({ article, NAV, format }: Props) => {
 				)}
 			</main>
 
-			{NAV.subNavSections && (
+			{isWeb && props.NAV.subNavSections && (
 				<Section
 					fullWidth={true}
 					data-print-layout="hide"
@@ -740,8 +775,8 @@ export const InteractiveLayout = ({ article, NAV, format }: Props) => {
 				>
 					<Island priority="enhancement" defer={{ until: 'visible' }}>
 						<SubNav
-							subNavSections={NAV.subNavSections}
-							currentNavLink={NAV.currentNavLink}
+							subNavSections={props.NAV.subNavSections}
+							currentNavLink={props.NAV.currentNavLink}
 							linkHoverColour={palette.text.articleLinkHover}
 							borderColour={palette.border.subNav}
 						/>
@@ -749,56 +784,80 @@ export const InteractiveLayout = ({ article, NAV, format }: Props) => {
 				</Section>
 			)}
 
-			<Section
-				fullWidth={true}
-				data-print-layout="hide"
-				padSides={false}
-				backgroundColour={brandBackground.primary}
-				borderColour={brandBorder.primary}
-				showSideBorders={false}
-				element="footer"
-			>
-				<Footer
-					pageFooter={article.pageFooter}
-					selectedPillar={NAV.selectedPillar}
-					pillars={NAV.pillars}
-					urls={article.nav.readerRevenueLinks.header}
-					editionId={article.editionId}
-					contributionsServiceUrl={article.contributionsServiceUrl}
-				/>
-			</Section>
+			{isWeb && (
+				<>
+					<Section
+						fullWidth={true}
+						data-print-layout="hide"
+						padSides={false}
+						backgroundColour={brandBackground.primary}
+						borderColour={brandBorder.primary}
+						showSideBorders={false}
+						element="footer"
+					>
+						<Footer
+							pageFooter={article.pageFooter}
+							selectedPillar={props.NAV.selectedPillar}
+							pillars={props.NAV.pillars}
+							urls={article.nav.readerRevenueLinks.header}
+							editionId={article.editionId}
+							contributionsServiceUrl={
+								article.contributionsServiceUrl
+							}
+						/>
+					</Section>
 
-			<BannerWrapper data-print-layout="hide">
-				<Island
-					priority="feature"
-					defer={{ until: 'idle' }}
-					clientOnly={true}
+					<BannerWrapper data-print-layout="hide">
+						<Island
+							priority="feature"
+							defer={{ until: 'idle' }}
+							clientOnly={true}
+						>
+							<StickyBottomBanner
+								contentType={article.contentType}
+								contributionsServiceUrl={
+									contributionsServiceUrl
+								}
+								idApiUrl={article.config.idApiUrl}
+								isMinuteArticle={
+									article.pageType.isMinuteArticle
+								}
+								isPaidContent={article.pageType.isPaidContent}
+								isPreview={!!article.config.isPreview}
+								isSensitive={article.config.isSensitive}
+								keywordIds={article.config.keywordIds}
+								pageId={article.pageId}
+								sectionId={article.config.section}
+								shouldHideReaderRevenue={
+									article.shouldHideReaderRevenue
+								}
+								remoteBannerSwitch={
+									!!article.config.switches.remoteBanner
+								}
+								puzzleBannerSwitch={
+									!!article.config.switches.puzzlesBanner
+								}
+								tags={article.tags}
+							/>
+						</Island>
+					</BannerWrapper>
+					<MobileStickyContainer data-print-layout="hide" />
+				</>
+			)}
+			{isApps && (
+				<Section
+					fullWidth={true}
+					data-print-layout="hide"
+					backgroundColour={neutral[97]}
+					padSides={false}
+					showSideBorders={false}
+					element="footer"
 				>
-					<StickyBottomBanner
-						contentType={article.contentType}
-						contributionsServiceUrl={contributionsServiceUrl}
-						idApiUrl={article.config.idApiUrl}
-						isMinuteArticle={article.pageType.isMinuteArticle}
-						isPaidContent={article.pageType.isPaidContent}
-						isPreview={!!article.config.isPreview}
-						isSensitive={article.config.isSensitive}
-						keywordIds={article.config.keywordIds}
-						pageId={article.pageId}
-						sectionId={article.config.section}
-						shouldHideReaderRevenue={
-							article.shouldHideReaderRevenue
-						}
-						remoteBannerSwitch={
-							!!article.config.switches.remoteBanner
-						}
-						puzzleBannerSwitch={
-							!!article.config.switches.puzzlesBanner
-						}
-						tags={article.tags}
-					/>
-				</Island>
-			</BannerWrapper>
-			<MobileStickyContainer data-print-layout="hide" />
+					<Island priority="critical">
+						<AppsFooter />
+					</Island>
+				</Section>
+			)}
 		</>
 	);
 };

--- a/dotcom-rendering/stories/generated/Layout.stories.tsx
+++ b/dotcom-rendering/stories/generated/Layout.stories.tsx
@@ -81,3 +81,16 @@ export const AppsStandardCommentNewsPillar = () => {
 };
 AppsStandardCommentNewsPillar.storyName = 'Apps: Display: Standard, Design: Comment, Theme: NewsPillar';
 AppsStandardCommentNewsPillar.args = { config: { renderingTarget: 'Apps' } };
+
+export const AppsStandardInteractiveNewsPillar = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="Standard"
+			designName="Interactive"
+			theme="NewsPillar"
+			renderingTarget="Apps"
+		/>
+	);
+};
+AppsStandardInteractiveNewsPillar.storyName = 'Apps: Display: Standard, Design: Interactive, Theme: NewsPillar';
+AppsStandardInteractiveNewsPillar.args = { config: { renderingTarget: 'Apps' } };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Adds support for the standard interactive layout for apps (eg http://localhost:3030/AppsArticle/https://www.theguardian.com/global-development/ng-interactive/2022/jun/09/the-black-sea-blockade-mapping-the-impact-of-war-in-ukraine-on-the-worlds-food-supply-interactive) through adapting the InteractiveLayout for apps. This follows the same patterns as [9013](https://github.com/guardian/dotcom-rendering/pull/9013) and [9034](https://github.com/guardian/dotcom-rendering/pull/9034)

Generally, apps layouts differ from web in the following ways:

- Apps do not show the web header and footer. Apps show their own footer
- Apps do not show web ads. Apps show their own ads
- Apps do not show the web onwards container
- Apps do not render the "body end slot"
- Apps do not show the most viewed in the footer

## Video
https://github.com/guardian/dotcom-rendering/assets/20416599/6da9e5bb-a45b-43f1-afd2-5dd0f17ed69b

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
