### PR TITLE
Fix stretched IMA video container

### DIFF
--- a/dotcom-rendering/src/components/MaintainAspectRatio.tsx
+++ b/dotcom-rendering/src/components/MaintainAspectRatio.tsx
@@ -21,6 +21,24 @@ export const MaintainAspectRatio = ({ height, width, children }: Props) => (
 				top: 0;
 				left: 0;
 			}
+
+			/*
+                The IMA script gives the following styles to the ad container element:
+                    width: [pixel value equal to the youtube iframe's width]
+                    height: [pixel value equal to the youtube iframe's height]
+                    position: relative;
+                    display: block;
+                We need to override these styles to make sure that the ad container overlays
+                the youtube player exactly and to avoid a player-sized white space underneath the ad.
+            */
+			[data-atom-type='ima-ad-container'] {
+				width: 100%;
+				height: 100%;
+				position: absolute !important;
+				top: 0;
+				left: 0;
+				display: none;
+			}
 		`}
 	>
 		{children}

--- a/dotcom-rendering/src/components/MaintainAspectRatio.tsx
+++ b/dotcom-rendering/src/components/MaintainAspectRatio.tsx
@@ -34,6 +34,7 @@ export const MaintainAspectRatio = ({ height, width, children }: Props) => (
 			[data-atom-type='ima-ad-container'] {
 				width: 100%;
 				height: 100%;
+				/* stylelint-disable-next-line declaration-no-important -- we need this to override inline styles added by youtube */
 				position: absolute !important;
 				top: 0;
 				left: 0;

--- a/dotcom-rendering/src/components/MaintainAspectRatio.tsx
+++ b/dotcom-rendering/src/components/MaintainAspectRatio.tsx
@@ -21,25 +21,6 @@ export const MaintainAspectRatio = ({ height, width, children }: Props) => (
 				top: 0;
 				left: 0;
 			}
-
-			/*
-                The IMA script gives the following styles to the ad container element:
-                    width: [pixel value equal to the youtube iframe's width]
-                    height: [pixel value equal to the youtube iframe's height]
-                    position: relative;
-                    display: block;
-                We need to override these styles to make sure that the ad container overlays
-                the youtube player exactly and to avoid a player-sized white space underneath the ad.
-            */
-			[data-atom-type='ima-ad-container'] {
-				width: 100%;
-				height: 100%;
-				/* stylelint-disable-next-line declaration-no-important -- we need this to override inline styles added by youtube */
-				position: absolute !important;
-				top: 0;
-				left: 0;
-				display: none;
-			}
 		`}
 	>
 		{children}

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPlayer.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPlayer.tsx
@@ -1,3 +1,4 @@
+import { css } from '@emotion/react';
 import type { Participations } from '@guardian/ab-core';
 import type { AdsConfig } from '@guardian/commercial';
 import {
@@ -80,6 +81,27 @@ type PlayerListeners = Array<PlayerListener<PlayerListenerName>>;
  * return its event type (e.g. OnStateChangeEvent)
  */
 type ExtractEventType<T> = T extends YT.PlayerEventHandler<infer X> ? X : never;
+
+const imaAdContainerStyles = css`
+	/*
+		The IMA script gives the following styles to the ad container element:
+			width: [pixel value equal to the youtube iframe's width]
+			height: [pixel value equal to the youtube iframe's height]
+			position: relative;
+			display: block;
+		We need to override these styles to make sure that the ad container overlays
+		the youtube player exactly and to avoid a player-sized white space underneath the ad.
+	*/
+	/* stylelint-disable-next-line declaration-no-important -- we need this to override inline styles added by youtube */
+	width: 100% !important;
+	/* stylelint-disable-next-line declaration-no-important -- we need this to override inline styles added by youtube */
+	height: 100% !important;
+	/* stylelint-disable-next-line declaration-no-important -- we need this to override inline styles added by youtube */
+	position: absolute !important;
+	top: 0;
+	left: 0;
+	display: none;
+`;
 
 const dispatchCustomPlayEvent = (uniqueId: string) => {
 	document.dispatchEvent(
@@ -630,6 +652,7 @@ export const YoutubeAtomPlayer = ({
 				<div
 					id={imaAdContainerId}
 					data-atom-type="ima-ad-container"
+					css={imaAdContainerStyles}
 				></div>
 			)}
 		</>


### PR DESCRIPTION
## What does this change?
Add CSS for YouTube IMA ad container

## Why?
I belive during in [this PR](https://github.com/guardian/dotcom-rendering/pull/8836) the CSS didn't make it as the `MaintainAspectRatio` component already existed, but did not have this snippet that is present in https://github.com/guardian/csnx/blob/main/libs/%40guardian/atoms-rendering/src/common/MaintainAspectRatio.tsx#L36-L43 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/1731150/a89e9d06-9c6a-45d6-aaac-25855b82e854
[after]: https://github.com/guardian/dotcom-rendering/assets/1731150/2e6fdad8-6edc-4e4a-8923-b588a089a382

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
