### PR TITLE
Fix bug in `MostViewedDataFooter` when `section` is empty

### DIFF
--- a/dotcom-rendering/src/components/MostViewedFooterData.importable.tsx
+++ b/dotcom-rendering/src/components/MostViewedFooterData.importable.tsx
@@ -1,4 +1,4 @@
-import { joinUrl } from '@guardian/libs';
+import { joinUrl, log } from '@guardian/libs';
 import { abTestTest } from '../experiments/tests/ab-test-test';
 import { decidePalette } from '../lib/decidePalette';
 import { decideTrail } from '../lib/decideTrail';
@@ -26,12 +26,19 @@ function buildSectionUrl(
 ) {
 	const sectionsWithoutPopular = ['info', 'global'];
 	const hasSection =
-		sectionId !== undefined &&
-		sectionId.length !== 0 &&
-		!sectionsWithoutPopular.includes(sectionId);
+		!!sectionId && !sectionsWithoutPopular.includes(sectionId);
+
 	const endpoint = `/most-read${
 		hasSection ? `/${sectionId}` : ''
 	}.json?_edition=${edition}`;
+
+	if (sectionId?.length === 0) {
+		log(
+			'dotcom',
+			`DCR received empty section field. Falling back to getting most viewed data from endpoint: ${endpoint}&dcr=true`,
+		);
+	}
+
 	return joinUrl(ajaxUrl, `${endpoint}&dcr=true`);
 }
 

--- a/dotcom-rendering/src/components/MostViewedFooterData.importable.tsx
+++ b/dotcom-rendering/src/components/MostViewedFooterData.importable.tsx
@@ -26,7 +26,9 @@ function buildSectionUrl(
 ) {
 	const sectionsWithoutPopular = ['info', 'global'];
 	const hasSection =
-		sectionId !== undefined && !sectionsWithoutPopular.includes(sectionId);
+		sectionId !== undefined &&
+		sectionId.length !== 0 &&
+		!sectionsWithoutPopular.includes(sectionId);
 	const endpoint = `/most-read${
 		hasSection ? `/${sectionId}` : ''
 	}.json?_edition=${edition}`;


### PR DESCRIPTION
Fixes #9052 

<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Checks if `section` is an empty string in `MostViewedDataFooter`

## Why?
To fix bug: If `section` is an empty string, it doesn't render the component.

![image](https://github.com/guardian/dotcom-rendering/assets/19683595/52d06381-822e-4900-9fea-f8a8856bb91e)

Was producing a url that returned 500: 
 https://api.nextgen.guardianapps.co.uk/most-read/.json?_edition=UK&dcr=true

![image](https://github.com/guardian/dotcom-rendering/assets/19683595/26ccc3a5-3961-4f2e-8f10-c1d9289cf2ee)

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/7cb84efb-6b46-4a56-8061-2fe89a62157e) | ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/62fbdeb3-2dac-488f-b190-7a623f5cee4b) |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
