### PR TITLE
feat(email-newsletters): update newsletters grouping

### DIFF
--- a/dotcom-rendering/src/model/newsletter-grouping.ts
+++ b/dotcom-rendering/src/model/newsletter-grouping.ts
@@ -12,8 +12,8 @@ export const groups: Partial<Record<EditionId, StaticGroups>> = {
 			title: 'Get started',
 			newsletters: [
 				'morning-briefing', // First Edition
+				'word-of-mouth', // Feast
 				'this-is-europe',
-				'green-light', // Down to Earth
 				'the-guide-staying-in',
 				'the-long-read',
 			],
@@ -21,9 +21,9 @@ export const groups: Partial<Record<EditionId, StaticGroups>> = {
 		{
 			title: 'In depth',
 			newsletters: [
+				'green-light', // Down to Earth
 				'whats-on',
 				'tech-scape',
-				'word-of-mouth', // Feast
 				'fashion-statement',
 				'pushing-buttons',
 				'cotton-capital',


### PR DESCRIPTION
## What does this change?

Updates the newsletter grouping as requested by editorial newsletters team, ahead of the relaunch of `Word of Mouth` as `Feast` 

Also adds helpful inline comments where the branding of newsletters has changed since the ID was created

## Why?

Resolves #9042 

## Screenshots

|             | UK Edition  |
| ----------- | ----------  |
| Before      | ![before][] |
| After       | ![after][]  |


[before]: https://github.com/guardian/dotcom-rendering/assets/43961396/ca9f000d-3ddb-4421-80f1-0bc33aa46491
[after]: https://github.com/guardian/dotcom-rendering/assets/43961396/79eb300a-b0da-482d-b789-3e18dbec8b68

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
