### PR TITLE
ci: stop running AR CI gh workflow for changes unrelated to AR

### DIFF
--- a/.github/workflows/ar-ci.yml
+++ b/.github/workflows/ar-ci.yml
@@ -2,6 +2,8 @@ name: AR CI
 
 on:
   push:
+    paths-ignore:
+      - 'dotcom-rendering/**'
   workflow_dispatch:
 
 # Allow queued workflows to interrupt previous runs


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Adds `paths-ignore` condition to `on:push` in Github workflow file

## Why?

We shouldn't be running AR CI for changes that don't affect AR?
