### PR TITLE
Adaptive site: recategorise some islands

### DIFF
--- a/dotcom-rendering/cypress/e2e/parallel-4/atom.interactivity.cy.js
+++ b/dotcom-rendering/cypress/e2e/parallel-4/atom.interactivity.cy.js
@@ -105,6 +105,7 @@ describe('Why do wombats do square poos?', function () {
 		// Wait for hydration
 		cy.get('gu-island[name=KnowledgeQuizAtomWrapper]')
 			.first()
+			.scrollIntoView()
 			.should('have.attr', 'data-island-status', 'hydrated');
 		// Establish that the elements showing the results are not present
 		cy.get('[data-atom-type=knowledgequiz] fieldset')
@@ -132,6 +133,7 @@ describe('Why do wombats do square poos?', function () {
 		// Wait for hydration
 		cy.get('gu-island[name=KnowledgeQuizAtomWrapper]')
 			.first()
+			.scrollIntoView()
 			.should('have.attr', 'data-island-status', 'hydrated');
 		// Establish that the elements showing the results are not present
 		cy.get('[data-atom-type=knowledgequiz] fieldset')

--- a/dotcom-rendering/cypress/e2e/parallel-5/atom.video.cy.js
+++ b/dotcom-rendering/cypress/e2e/parallel-5/atom.video.cy.js
@@ -178,6 +178,7 @@ describe('YouTube Atom', function () {
 		// Wait for hydration
 		cy.get('[data-component=youtube-atom]')
 			.parent()
+			.scrollIntoView()
 			.should('have.attr', 'data-island-status', 'hydrated');
 
 		// Make sure overlay is displayed
@@ -228,6 +229,7 @@ describe('YouTube Atom', function () {
 			.each((item) => {
 				cy.wrap(item)
 					.parent()
+					.scrollIntoView()
 					.should('have.attr', 'data-island-status', 'hydrated');
 			});
 
@@ -344,6 +346,7 @@ describe('YouTube Atom', function () {
 		// Wait for hydration
 		cy.get('[data-component=youtube-atom]')
 			.parent()
+			.scrollIntoView()
 			.should('have.attr', 'data-island-status', 'hydrated');
 
 		// Make sure overlay is displayed
@@ -394,6 +397,7 @@ describe('YouTube Atom', function () {
 			.each((item) => {
 				cy.wrap(item)
 					.parent()
+					.scrollIntoView()
 					.should('have.attr', 'data-island-status', 'hydrated');
 			});
 

--- a/dotcom-rendering/src/components/ArticleBody.tsx
+++ b/dotcom-rendering/src/components/ArticleBody.tsx
@@ -197,7 +197,7 @@ export const ArticleBody = ({
 	return (
 		<>
 			{tableOfContents && tableOfContents.length > 0 && (
-				<Island priority="critical">
+				<Island priority="critical" defer={{ until: 'visible' }}>
 					<TableOfContents
 						tableOfContents={tableOfContents}
 						format={format}

--- a/dotcom-rendering/src/components/ArticlePage.tsx
+++ b/dotcom-rendering/src/components/ArticlePage.tsx
@@ -75,7 +75,11 @@ export const ArticlePage = (props: WebProps | AppProps) => {
 					<LightboxLayout
 						imageCount={article.imagesForLightbox.length}
 					/>
-					<Island clientOnly={true} priority="critical">
+					<Island
+						clientOnly={true}
+						priority="feature"
+						defer={{ until: 'idle' }}
+					>
 						<LightboxHash />
 					</Island>
 					<Island

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -456,7 +456,10 @@ export const Card = ({
 											${getZIndex('card-nested-link')}
 										`}
 									>
-										<Island priority="critical">
+										<Island
+											priority="critical"
+											defer={{ until: 'visible' }}
+										>
 											<YoutubeBlockComponent
 												id={media.mainMedia.elementId}
 												elementId={
@@ -608,7 +611,10 @@ export const Card = ({
 								</TrailTextWrapper>
 							)}
 							{showLivePlayable && (
-								<Island priority="critical">
+								<Island
+									priority="feature"
+									defer={{ until: 'visible' }}
+								>
 									<LatestLinks
 										id={linkTo}
 										format={format}

--- a/dotcom-rendering/src/components/Footer.tsx
+++ b/dotcom-rendering/src/components/Footer.tsx
@@ -247,7 +247,10 @@ const FooterLinks = ({
 				[
 					dataLinkName === 'privacy' ? (
 						<li key="privacy-settings-link">
-							<Island priority="critical">
+							<Island
+								priority="critical"
+								defer={{ until: 'visible' }}
+							>
 								<PrivacySettingsLink
 									extraClasses={extraClasses}
 								/>
@@ -401,7 +404,7 @@ export const Footer = ({
 		<div css={copyright}>
 			© {year} Guardian News & Media Limited or its affiliated companies.
 			All rights reserved.{' '}
-			<Island priority="critical">
+			<Island priority="critical" defer={{ until: 'visible' }}>
 				<FooterLabel />
 			</Island>
 		</div>

--- a/dotcom-rendering/src/components/FrontPage.tsx
+++ b/dotcom-rendering/src/components/FrontPage.tsx
@@ -82,7 +82,11 @@ export const FrontPage = ({ front, NAV }: Props) => {
 					}
 				/>
 			</Island>
-			<Island priority="critical" clientOnly={true}>
+			<Island
+				priority="enhancement"
+				defer={{ until: 'visible' }}
+				clientOnly={true}
+			>
 				<ShowHideContainers />
 			</Island>
 			<Island priority="critical" clientOnly={true}>

--- a/dotcom-rendering/src/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/layouts/CommentLayout.tsx
@@ -620,7 +620,8 @@ export const CommentLayout = (props: WebProps | AppsProps) => {
 									/>
 									{showBodyEndSlot && (
 										<Island
-											priority="critical"
+											priority="feature"
+											defer={{ until: 'visible' }}
 											clientOnly={true}
 										>
 											<SlotBodyEnd

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -397,7 +397,11 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 					)}
 				</>
 			</div>
-			<Island priority="critical" clientOnly={true}>
+			<Island
+				priority="feature"
+				defer={{ until: 'visible' }}
+				clientOnly={true}
+			>
 				<EuropeLandingModal edition={front.editionId} />
 			</Island>
 			<main
@@ -838,7 +842,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 						hasPageSkin ? background.primary : undefined
 					}
 				>
-					<Island priority="critical" defer={{ until: 'visible' }}>
+					<Island priority="enhancement" defer={{ until: 'visible' }}>
 						<SubNav
 							subNavSections={NAV.subNavSections}
 							currentNavLink={NAV.currentNavLink}

--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -617,7 +617,8 @@ export const ImmersiveLayout = ({ article, NAV, format }: Props) => {
 								/>
 								{showBodyEndSlot && (
 									<Island
-										priority="critical"
+										priority="feature"
+										defer={{ until: 'visible' }}
 										clientOnly={true}
 									>
 										<SlotBodyEnd

--- a/dotcom-rendering/src/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/InteractiveLayout.tsx
@@ -540,7 +540,11 @@ export const InteractiveLayout = ({ article, NAV, format }: Props) => {
 							max-width: 620px;
 						`}
 					>
-						<Island priority="critical" clientOnly={true}>
+						<Island
+							priority="feature"
+							defer={{ until: 'visible' }}
+							clientOnly={true}
+						>
 							<SlotBodyEnd
 								contentType={article.contentType}
 								contributionsServiceUrl={

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -601,7 +601,10 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 						borderColour={palette.border.article}
 					>
 						<Hide until={'desktop'}>
-							<Island priority="critical">
+							<Island
+								priority="feature"
+								defer={{ until: 'visible' }}
+							>
 								<KeyEventsCarousel
 									keyEvents={article.keyEvents}
 									filterKeyEvents={article.filterKeyEvents}
@@ -681,7 +684,10 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 							<GridItem area="media">
 								<div css={maxWidth}>
 									{!!footballMatchUrl && (
-										<Island priority="critical">
+										<Island
+											priority="critical"
+											defer={{ until: 'visible' }}
+										>
 											<GetMatchTabs
 												matchUrl={footballMatchUrl}
 												format={format}
@@ -689,7 +695,10 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 										</Island>
 									)}
 									{!!cricketMatchUrl && (
-										<Island priority="critical">
+										<Island
+											priority="critical"
+											defer={{ until: 'visible' }}
+										>
 											<GetCricketScoreboard
 												matchUrl={cricketMatchUrl}
 												format={format}

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -620,7 +620,8 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 								/>
 								{showBodyEndSlot && (
 									<Island
-										priority="critical"
+										priority="feature"
+										defer={{ until: 'visible' }}
 										clientOnly={true}
 									>
 										<SlotBodyEnd

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -516,7 +516,10 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 						<GridItem area="matchtabs" element="aside">
 							<div css={maxWidth}>
 								{isMatchReport && (
-									<Island priority="critical">
+									<Island
+										priority="critical"
+										defer={{ until: 'visible' }}
+									>
 										<GetMatchTabs
 											matchUrl={footballMatchUrl}
 											format={format}
@@ -694,7 +697,8 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 
 								{isWeb && showBodyEndSlot && (
 									<Island
-										priority="critical"
+										priority="feature"
+										defer={{ until: 'visible' }}
 										clientOnly={true}
 									>
 										<SlotBodyEnd

--- a/dotcom-rendering/src/lib/LiveBlogRenderer.tsx
+++ b/dotcom-rendering/src/lib/LiveBlogRenderer.tsx
@@ -150,7 +150,10 @@ export const LiveBlogRenderer = ({
 			{blocks.length > 4 && (
 				<Island
 					priority="feature"
-					defer={{ until: 'visible' }}
+					// this should really be deferred until visible,
+					// but this island manipulate the DOM via portals,
+					// its actual position has no bearing on its effect
+					defer={{ until: 'idle' }}
 					clientOnly={true}
 				>
 					<LiveBlogEpic

--- a/dotcom-rendering/src/lib/LiveBlogRenderer.tsx
+++ b/dotcom-rendering/src/lib/LiveBlogRenderer.tsx
@@ -148,7 +148,11 @@ export const LiveBlogRenderer = ({
 				isInLiveblogAdSlotTest={isInLiveblogAdSlotTest}
 			/>
 			{blocks.length > 4 && (
-				<Island priority="critical" clientOnly={true}>
+				<Island
+					priority="feature"
+					defer={{ until: 'visible' }}
+					clientOnly={true}
+				>
 					<LiveBlogEpic
 						sectionId={sectionId}
 						shouldHideReaderRevenue={shouldHideReaderRevenue}

--- a/dotcom-rendering/src/lib/renderElement.tsx
+++ b/dotcom-rendering/src/lib/renderElement.tsx
@@ -152,7 +152,7 @@ export const renderElement = ({
 	switch (element._type) {
 		case 'model.dotcomrendering.pageElements.AudioAtomBlockElement':
 			return (
-				<Island priority="critical">
+				<Island priority="critical" defer={{ until: 'visible' }}>
 					<AudioAtomWrapper
 						id={element.id}
 						trackUrl={element.trackUrl}
@@ -527,7 +527,10 @@ export const renderElement = ({
 			return (
 				<>
 					{element.quizType === 'personality' && (
-						<Island priority="critical">
+						<Island
+							priority="critical"
+							defer={{ until: 'visible' }}
+						>
 							<PersonalityQuizAtomWrapper
 								id={element.id}
 								questions={element.questions}
@@ -538,7 +541,10 @@ export const renderElement = ({
 						</Island>
 					)}
 					{element.quizType === 'knowledge' && (
-						<Island priority="critical">
+						<Island
+							priority="critical"
+							defer={{ until: 'visible' }}
+						>
 							<KnowledgeQuizAtomWrapper
 								id={element.id}
 								questions={element.questions}
@@ -740,7 +746,7 @@ export const renderElement = ({
 		}
 		case 'model.dotcomrendering.pageElements.YoutubeBlockElement':
 			return (
-				<Island priority="critical">
+				<Island priority="critical" defer={{ until: 'visible' }}>
 					<YoutubeBlockComponent
 						format={format}
 						key={index}

--- a/dotcom-rendering/src/lib/withSignInGateSlot.tsx
+++ b/dotcom-rendering/src/lib/withSignInGateSlot.tsx
@@ -41,7 +41,11 @@ export const withSignInGateSlot = ({
 				{/* Add the placeholder div after the second article element */}
 				{i === 1 && (
 					<div id="sign-in-gate">
-						<Island priority="critical" clientOnly={true}>
+						<Island
+							priority="feature"
+							defer={{ until: 'visible' }}
+							clientOnly={true}
+						>
 							<SignInGateSelector
 								contentType={contentType}
 								sectionId={sectionId}


### PR DESCRIPTION
## What does this change?

- updates some island's `priority`
- also adjusts some `defer` options

## Why?

- it increases the number of things that will be switched of when we adapt the site[^1] for users in the `adaptive-site` test (less than 0.1% of page views)
- it means higher priority things will run sooner for everyone else (around 99.9% of page views)

[^1]: right now, only critical islands will run when the site adapts
