### PR TITLE
Stop building the variant bundle

### DIFF
--- a/dotcom-rendering/scripts/webpack/bundles.js
+++ b/dotcom-rendering/scripts/webpack/bundles.js
@@ -9,7 +9,7 @@
  *
  * @type {boolean} prevent TS from narrowing this to its current value
  */
-const BUILD_VARIANT = true;
+const BUILD_VARIANT = false;
 
 /**
  * Server-side test names for running variant test.


### PR DESCRIPTION
## What does this change?

Stop building the variant bundle.

## Why?

No tests are currently running with this build.

This will speed up build times.

## Screenshots

N/A