### PR TITLE
Make `RichLinkComponent` safe with invalid URLs

### DIFF
--- a/dotcom-rendering/src/components/RichLinkComponent.importable.test.tsx
+++ b/dotcom-rendering/src/components/RichLinkComponent.importable.test.tsx
@@ -1,0 +1,29 @@
+import { ArticleDesign, ArticleDisplay, ArticleSpecial } from '@guardian/libs';
+import { renderToString } from 'react-dom/server';
+import { RichLinkComponent } from './RichLinkComponent.importable';
+
+describe('RichLinkComponent', () => {
+	it('does not fail on the server with an empty URL', () => {
+		const format = {
+			display: ArticleDisplay.Standard,
+			design: ArticleDesign.Standard,
+			theme: ArticleSpecial.SpecialReport,
+		};
+		expect(() =>
+			renderToString(
+				<RichLinkComponent
+					element={{
+						_type: 'model.dotcomrendering.pageElements.RichLinkBlockElement',
+						elementId: '',
+						url: '',
+						text: '',
+						prefix: '',
+					}}
+					ajaxUrl={''}
+					richLinkIndex={0}
+					format={format}
+				/>,
+			),
+		).not.toThrow();
+	});
+});

--- a/dotcom-rendering/src/components/RichLinkComponent.importable.tsx
+++ b/dotcom-rendering/src/components/RichLinkComponent.importable.tsx
@@ -44,12 +44,17 @@ interface ImageAssetFields {
 	width: string;
 }
 
-const buildUrl: (element: RichLinkBlockElement, ajaxUrl: string) => string = (
-	element,
-	ajaxUrl,
-) => {
-	const path = new URL(element.url).pathname;
-	return `${ajaxUrl}/embed/card${path}.json?dcr=true`;
+const buildUrl = (
+	element: RichLinkBlockElement,
+	ajaxUrl: string,
+): string | undefined => {
+	try {
+		const path = new URL(element.url).pathname;
+		return `${ajaxUrl}/embed/card${path}.json?dcr=true`;
+	} catch (error) {
+		console.error(`Failed to build a url with "${element.url}"`);
+		return undefined;
+	}
 };
 
 /**


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Catch errors when building invalid URLs and return `undefined` instead.

## Why?

Closes #8678

Allows the following article to work: https://www.theguardian.com/lifeandstyle/2016/sep/27/tinder-online-dating-apps-blind-dates-love