### PR TITLE
Handle lack of `row-gap` support in `UL`’s flex column

### DIFF
--- a/dotcom-rendering/src/components/Card/components/UL.tsx
+++ b/dotcom-rendering/src/components/Card/components/UL.tsx
@@ -16,6 +16,12 @@ const ulStyles = (direction: Direction) => css`
 		flex-direction: column;
 		width: 100%;
 	}
+
+	@supports not (row-gap: 12px) {
+		& > li {
+			margin-bottom: 12px;
+		}
+	}
 `;
 
 const wrapStyles = css`

--- a/dotcom-rendering/src/components/Card/components/UL.tsx
+++ b/dotcom-rendering/src/components/Card/components/UL.tsx
@@ -11,16 +11,21 @@ const ulStyles = (direction: Direction) => css`
 	position: relative;
 	display: flex;
 	flex-direction: ${direction};
-	row-gap: 12px;
 	${until.tablet} {
 		flex-direction: column;
 		width: 100%;
 	}
 
-	@supports not (row-gap: 12px) {
+	& > li {
+		margin-bottom: ${space[3]}px;
+	}
+
+	@supports (row-gap: 1em) {
 		& > li {
-			margin-bottom: 12px;
+			margin-bottom: 0;
 		}
+		/* Supported in flex layout is lacking: https://developer.mozilla.org/en-US/docs/Web/CSS/row-gap#browser_compatibility */
+		row-gap: ${space[3]}px;
 	}
 `;
 


### PR DESCRIPTION
## What does this change?

Have a fallback margin for column flex gaps in browser that do not support the syntax

## Why?

On older browser, we still want space between rows of cards on fronts.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/76776/59d69be7-e8a0-42e6-8c2c-7e495e6b6528
[after]: https://github.com/guardian/dotcom-rendering/assets/76776/e8e34801-2ff6-460c-97cb-9022b3718f42