### PR TITLE
Refactor `UL`/`LI` to promote CSS reuse

### DIFF
--- a/dotcom-rendering/src/components/Card/components/LI.tsx
+++ b/dotcom-rendering/src/components/Card/components/LI.tsx
@@ -15,8 +15,8 @@ const liStyles = css`
 	/* This position relative is needed to contain the vertical divider */
 	position: relative;
 
-	display: flex;
-	row-gap: ${GAP_SIZE};
+	display: grid;
+	border-color: inherit;
 `;
 
 const sidePaddingStylesMobile = css`
@@ -40,9 +40,8 @@ const snapAlignStartStyles = css`
 `;
 
 const decideSize = (percentage?: CardPercentageType, stretch?: boolean) => {
-	let sizeStyle;
 	if (percentage) {
-		sizeStyle = css`
+		return css`
 			flex-basis: ${percentage};
 			${stretch &&
 			css`
@@ -50,15 +49,14 @@ const decideSize = (percentage?: CardPercentageType, stretch?: boolean) => {
 			`}
 		`;
 	} else if (stretch) {
-		sizeStyle = css`
+		return css`
 			flex-grow: 1;
 		`;
 	} else {
-		sizeStyle = css`
+		return css`
 			flex: 1;
 		`;
 	}
-	return sizeStyle;
 };
 
 const decideDivider = (
@@ -75,7 +73,7 @@ const decideDivider = (
 
 	return offsetBottomPaddingOnDivider
 		? verticalDividerWithBottomOffset(paddingSize, borderColour)
-		: verticalDivider(borderColour);
+		: verticalDivider;
 };
 
 type Props = {
@@ -131,6 +129,7 @@ export const LI = ({
 				padSidesOnMobile && sidePaddingStylesMobile,
 				snapAlignStart && snapAlignStartStyles,
 			]}
+			style={{ borderColor: verticalDividerColour }}
 		>
 			{children}
 		</li>

--- a/dotcom-rendering/src/components/Card/components/UL.tsx
+++ b/dotcom-rendering/src/components/Card/components/UL.tsx
@@ -16,6 +16,12 @@ const ulStyles = (direction: Direction) => css`
 		flex-direction: column;
 		width: 100%;
 	}
+
+	@supports not (row-gap: 12px) {
+		& > li {
+			margin-bottom: 12px;
+		}
+	}
 `;
 
 const wrapStyles = css`

--- a/dotcom-rendering/src/components/Card/components/UL.tsx
+++ b/dotcom-rendering/src/components/Card/components/UL.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { from, neutral, space, until } from '@guardian/source-foundations';
+import { from, palette, space, until } from '@guardian/source-foundations';
 import { decideContainerOverrides } from '../../../lib/decideContainerOverrides';
 import { verticalDivider } from '../../../lib/verticalDivider';
 import type { DCRContainerPalette } from '../../../types/front';
@@ -30,10 +30,6 @@ const wrapStyles = css`
 	}
 `;
 
-const marginBottomStyles = css`
-	margin-bottom: ${space[3]}px;
-`;
-
 type Props = {
 	children: React.ReactNode;
 	/** Passed to flex-direction */
@@ -55,19 +51,20 @@ export const UL = ({
 	wrapCards = false,
 	containerPalette,
 }: Props) => {
-	const borderColour =
-		(containerPalette &&
-			decideContainerOverrides(containerPalette).border.container) ??
-		neutral[86];
+	const borderColor = containerPalette
+		? decideContainerOverrides(containerPalette).border.container
+		: palette.neutral[86];
+
+	const marginBottom = padBottom ? `${space[3]}px` : undefined;
 
 	return (
 		<ul
 			css={[
 				ulStyles(direction),
-				showDivider && verticalDivider(borderColour),
-				padBottom && marginBottomStyles,
+				showDivider && verticalDivider,
 				wrapCards && wrapStyles,
 			]}
+			style={{ marginBottom, borderColor }}
 		>
 			{children}
 		</ul>

--- a/dotcom-rendering/src/lib/verticalDivider.ts
+++ b/dotcom-rendering/src/lib/verticalDivider.ts
@@ -1,23 +1,19 @@
-import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import { from } from '@guardian/source-foundations';
 
-export const verticalDivider = (
-	verticalDividerColour: string,
-): SerializedStyles => {
-	return css`
-		${from.tablet} {
-			:before {
-				content: '';
-				display: block;
-				position: absolute;
-				top: 0;
-				bottom: 0;
-				left: 0;
-				width: 1px;
-				height: 100%;
-				border-left: 1px solid ${verticalDividerColour};
-			}
+export const verticalDivider = css`
+	${from.tablet} {
+		:before {
+			content: '';
+			display: block;
+			position: absolute;
+			top: 0;
+			bottom: 0;
+			left: 0;
+			width: 1px;
+			height: 100%;
+			border-left: 1px solid;
+			border-color: inherit;
 		}
-	`;
-};
+	}
+`;


### PR DESCRIPTION
- fix(UL): handle lack of row-gap support
- refactor(LI): more consistent CSS

<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
