### PR TITLE
Support `ImmersiveLayout` in DCR for Apps

### DIFF
--- a/dotcom-rendering/scripts/gen-stories/get-stories.js
+++ b/dotcom-rendering/scripts/gen-stories/get-stories.js
@@ -177,6 +177,13 @@ const testLayoutFormats = [
 		theme: 'NewsPillar',
 		renderingTarget: 'Apps',
 	},
+
+	{
+		display: 'Immersive',
+		design: 'Standard',
+		theme: 'NewsPillar',
+		renderingTarget: 'Apps',
+	},
 ];
 
 const generateLayoutStories = () => {

--- a/dotcom-rendering/src/components/AppsLightboxImage.importable.tsx
+++ b/dotcom-rendering/src/components/AppsLightboxImage.importable.tsx
@@ -79,6 +79,7 @@ export const AppsLightboxImage = ({
 				background: none;
 				padding: 0;
 				width: 100%;
+				height: 100%;
 			`}
 		>
 			{picture}

--- a/dotcom-rendering/src/layouts/DecideLayout.tsx
+++ b/dotcom-rendering/src/layouts/DecideLayout.tsx
@@ -1,5 +1,5 @@
-import { ArticleDesign, ArticleDisplay } from '@guardian/libs';
 import type { ArticleFormat } from '@guardian/libs';
+import { ArticleDesign, ArticleDisplay } from '@guardian/libs';
 import type { NavType } from '../model/extract-nav';
 import type { DCRArticle } from '../types/frontend';
 import type { RenderingTarget } from '../types/renderingTarget';
@@ -38,8 +38,13 @@ const DecideLayoutApps = ({ article, format, renderingTarget }: AppProps) => {
 					return notSupported;
 				}
 				default: {
-					// Should be FullPageInteractiveLayout once implemented for apps
-					return notSupported;
+					return (
+						<ImmersiveLayout
+							article={article}
+							format={format}
+							renderingTarget={renderingTarget}
+						/>
+					);
 				}
 			}
 		}
@@ -156,8 +161,9 @@ const DecideLayoutWeb = ({
 					return (
 						<ImmersiveLayout
 							article={article}
-							NAV={NAV}
 							format={format}
+							NAV={NAV}
+							renderingTarget={renderingTarget}
 						/>
 					);
 				}

--- a/dotcom-rendering/src/layouts/DecideLayout.tsx
+++ b/dotcom-rendering/src/layouts/DecideLayout.tsx
@@ -32,21 +32,13 @@ const DecideLayoutApps = ({ article, format, renderingTarget }: AppProps) => {
 	const notSupported = <pre>Not supported</pre>;
 	switch (format.display) {
 		case ArticleDisplay.Immersive: {
-			switch (format.design) {
-				case ArticleDesign.Interactive: {
-					// Should be InteractiveLayout once implemented for apps
-					return notSupported;
-				}
-				default: {
-					return (
-						<ImmersiveLayout
-							article={article}
-							format={format}
-							renderingTarget={renderingTarget}
-						/>
-					);
-				}
-			}
+			return (
+				<ImmersiveLayout
+					article={article}
+					format={format}
+					renderingTarget={renderingTarget}
+				/>
+			);
 		}
 		case ArticleDisplay.NumberedList:
 		case ArticleDisplay.Showcase: {

--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -252,11 +252,9 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 	const mainMedia = article.mainMediaElements[0];
 
 	const captionText = decideMainMediaCaption(mainMedia);
-	const HEADLINE_OFFSET = mainMedia
-		? renderingTarget === 'Web'
-			? 120
-			: 420
-		: 0;
+
+	const HEADLINE_OFFSET = mainMedia ? 120 : 0;
+
 	const { branding } = article.commercialProperties[article.editionId];
 
 	const contributionsServiceUrl = getContributionsServiceUrl(article);

--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -12,7 +12,9 @@ import {
 	until,
 } from '@guardian/source-foundations';
 import { StraightLines } from '@guardian/source-react-components-development-kitchen';
+import { AdPortals } from '../components/AdPortals.importable';
 import { AdSlot, MobileStickyContainer } from '../components/AdSlot.web';
+import { AppsFooter } from '../components/AppsFooter.importable';
 import { ArticleBody } from '../components/ArticleBody';
 import { ArticleContainer } from '../components/ArticleContainer';
 import { ArticleHeadline } from '../components/ArticleHeadline';
@@ -21,7 +23,6 @@ import { ArticleTitle } from '../components/ArticleTitle';
 import { Border } from '../components/Border';
 import { Caption } from '../components/Caption';
 import { Carousel } from '../components/Carousel.importable';
-import { useConfig } from '../components/ConfigContext';
 import { DecideLines } from '../components/DecideLines';
 import { DiscussionLayout } from '../components/DiscussionLayout';
 import { Footer } from '../components/Footer';
@@ -180,10 +181,18 @@ const stretchLines = css`
 	}
 `;
 
-interface Props {
+interface CommonProps {
 	article: DCRArticle;
-	NAV: NavType;
 	format: ArticleFormat;
+}
+
+interface WebProps extends CommonProps {
+	NAV: NavType;
+	renderingTarget: 'Web';
+}
+
+interface AppProps extends CommonProps {
+	renderingTarget: 'Apps';
 }
 
 const Box = ({
@@ -223,7 +232,9 @@ const Box = ({
 	</div>
 );
 
-export const ImmersiveLayout = ({ article, NAV, format }: Props) => {
+export const ImmersiveLayout = (props: WebProps | AppProps) => {
+	const { article, format, renderingTarget } = props;
+
 	const {
 		config: { isPaidContent, host },
 	} = article;
@@ -241,7 +252,11 @@ export const ImmersiveLayout = ({ article, NAV, format }: Props) => {
 	const mainMedia = article.mainMediaElements[0];
 
 	const captionText = decideMainMediaCaption(mainMedia);
-	const HEADLINE_OFFSET = mainMedia ? 120 : 0;
+	const HEADLINE_OFFSET = mainMedia
+		? renderingTarget === 'Web'
+			? 120
+			: 420
+		: 0;
 	const { branding } = article.commercialProperties[article.editionId];
 
 	const contributionsServiceUrl = getContributionsServiceUrl(article);
@@ -249,8 +264,6 @@ export const ImmersiveLayout = ({ article, NAV, format }: Props) => {
 	const palette = decidePalette(format);
 
 	const isLabs = format.theme === ArticleSpecial.Labs;
-
-	const { renderingTarget } = useConfig();
 
 	/**
 	We need change the height values depending on whether the labs header is there or not to keep
@@ -297,57 +310,63 @@ export const ImmersiveLayout = ({ article, NAV, format }: Props) => {
 		</div>
 	);
 
-	const renderAds = canRenderAds(article);
+	const renderAds = renderingTarget === 'Web' && canRenderAds(article);
 
 	return (
 		<>
-			<div
-				css={css`
-					${getZIndex('headerWrapper')}
-					order: 0;
-				`}
-			>
-				<Section
-					fullWidth={true}
-					showSideBorders={false}
-					showTopBorder={false}
-					padSides={false}
-					backgroundColour={brandBackground.primary}
-					element="nav"
-				>
-					<Nav
-						isImmersive={
-							format.display === ArticleDisplay.Immersive
-						}
-						displayRoundel={
-							format.display === ArticleDisplay.Immersive ||
-							format.theme === ArticleSpecial.Labs
-						}
-						selectedPillar={NAV.selectedPillar}
-						nav={NAV}
-						subscribeUrl={
-							article.nav.readerRevenueLinks.header.contribute
-						}
-						editionId={article.editionId}
-						headerTopBarSwitch={
-							!!article.config.switches.headerTopNav
-						}
-					/>
-				</Section>
-			</div>
-
-			{format.theme === ArticleSpecial.Labs && (
-				<Stuck>
-					<Section
-						fullWidth={true}
-						showTopBorder={false}
-						backgroundColour={labs[400]}
-						borderColour={border.primary}
-						sectionId="labs-header"
+			{renderingTarget === 'Web' && (
+				<>
+					<div
+						css={css`
+							${getZIndex('headerWrapper')}
+							order: 0;
+						`}
 					>
-						<LabsHeader />
-					</Section>
-				</Stuck>
+						<Section
+							fullWidth={true}
+							showSideBorders={false}
+							showTopBorder={false}
+							padSides={false}
+							backgroundColour={brandBackground.primary}
+							element="nav"
+						>
+							<Nav
+								isImmersive={
+									format.display === ArticleDisplay.Immersive
+								}
+								displayRoundel={
+									format.display ===
+										ArticleDisplay.Immersive ||
+									format.theme === ArticleSpecial.Labs
+								}
+								selectedPillar={props.NAV.selectedPillar}
+								nav={props.NAV}
+								subscribeUrl={
+									article.nav.readerRevenueLinks.header
+										.contribute
+								}
+								editionId={article.editionId}
+								headerTopBarSwitch={
+									!!article.config.switches.headerTopNav
+								}
+							/>
+						</Section>
+					</div>
+
+					{format.theme === ArticleSpecial.Labs && (
+						<Stuck>
+							<Section
+								fullWidth={true}
+								showTopBorder={false}
+								backgroundColour={labs[400]}
+								borderColour={border.primary}
+								sectionId="labs-header"
+							>
+								<LabsHeader />
+							</Section>
+						</Stuck>
+					)}
+				</>
 			)}
 
 			<header
@@ -381,7 +400,7 @@ export const ImmersiveLayout = ({ article, NAV, format }: Props) => {
 						switches={article.config.switches}
 						isAdFreeUser={article.isAdFreeUser}
 						isSensitive={article.config.isSensitive}
-						imagesForAppsLightbox={[]}
+						imagesForAppsLightbox={article.imagesForAppsLightbox}
 					/>
 				</div>
 				{mainMedia && (
@@ -443,6 +462,11 @@ export const ImmersiveLayout = ({ article, NAV, format }: Props) => {
 			</header>
 
 			<main data-layout="ImmersiveLayout">
+				{renderingTarget === 'Apps' && (
+					<Island priority="critical" clientOnly={true}>
+						<AdPortals />
+					</Island>
+				)}
 				<Section
 					fullWidth={true}
 					showTopBorder={false}
@@ -613,7 +637,9 @@ export const ImmersiveLayout = ({ article, NAV, format }: Props) => {
 									isRightToLeftLang={
 										article.isRightToLeftLang
 									}
-									imagesForAppsLightbox={[]}
+									imagesForAppsLightbox={
+										article.imagesForAppsLightbox
+									}
 								/>
 								{showBodyEndSlot && (
 									<Island
@@ -754,25 +780,31 @@ export const ImmersiveLayout = ({ article, NAV, format }: Props) => {
 					</Section>
 				)}
 
-				<Island priority="feature" defer={{ until: 'visible' }}>
-					<OnwardsUpper
-						ajaxUrl={article.config.ajaxUrl}
-						hasRelated={article.hasRelated}
-						hasStoryPackage={article.hasStoryPackage}
-						isAdFreeUser={article.isAdFreeUser}
-						pageId={article.pageId}
-						isPaidContent={article.config.isPaidContent ?? false}
-						showRelatedContent={article.config.showRelatedContent}
-						keywordIds={article.config.keywordIds}
-						contentType={article.contentType}
-						tags={article.tags}
-						format={format}
-						pillar={format.theme}
-						editionId={article.editionId}
-						shortUrlId={article.config.shortUrlId}
-						discussionApiUrl={article.config.discussionApiUrl}
-					/>
-				</Island>
+				{renderingTarget === 'Web' && (
+					<Island priority="feature" defer={{ until: 'visible' }}>
+						<OnwardsUpper
+							ajaxUrl={article.config.ajaxUrl}
+							hasRelated={article.hasRelated}
+							hasStoryPackage={article.hasStoryPackage}
+							isAdFreeUser={article.isAdFreeUser}
+							pageId={article.pageId}
+							isPaidContent={
+								article.config.isPaidContent ?? false
+							}
+							showRelatedContent={
+								article.config.showRelatedContent
+							}
+							keywordIds={article.config.keywordIds}
+							contentType={article.contentType}
+							tags={article.tags}
+							format={format}
+							pillar={format.theme}
+							editionId={article.editionId}
+							shortUrlId={article.config.shortUrlId}
+							discussionApiUrl={article.config.discussionApiUrl}
+						/>
+					</Island>
+				)}
 
 				{!isPaidContent && showComments && (
 					<Section
@@ -797,7 +829,7 @@ export const ImmersiveLayout = ({ article, NAV, format }: Props) => {
 						/>
 					</Section>
 				)}
-				{!isPaidContent && (
+				{renderingTarget === 'Web' && !isPaidContent && (
 					<Section
 						title="Most viewed"
 						padContent={false}
@@ -840,12 +872,12 @@ export const ImmersiveLayout = ({ article, NAV, format }: Props) => {
 				)}
 			</main>
 
-			{NAV.subNavSections && (
+			{renderingTarget === 'Web' && props.NAV.subNavSections && (
 				<Section fullWidth={true} padSides={false} element="aside">
 					<Island priority="enhancement" defer={{ until: 'visible' }}>
 						<SubNav
-							subNavSections={NAV.subNavSections}
-							currentNavLink={NAV.currentNavLink}
+							subNavSections={props.NAV.subNavSections}
+							currentNavLink={props.NAV.currentNavLink}
 							linkHoverColour={palette.text.articleLinkHover}
 							borderColour={palette.border.subNav}
 						/>
@@ -853,55 +885,79 @@ export const ImmersiveLayout = ({ article, NAV, format }: Props) => {
 				</Section>
 			)}
 
-			<Section
-				fullWidth={true}
-				padSides={false}
-				backgroundColour={brandBackground.primary}
-				borderColour={brandBorder.primary}
-				showSideBorders={false}
-				element="footer"
-			>
-				<Footer
-					pageFooter={article.pageFooter}
-					selectedPillar={NAV.selectedPillar}
-					pillars={NAV.pillars}
-					urls={article.nav.readerRevenueLinks.header}
-					editionId={article.editionId}
-					contributionsServiceUrl={article.contributionsServiceUrl}
-				/>
-			</Section>
+			{renderingTarget === 'Web' && (
+				<>
+					<Section
+						fullWidth={true}
+						padSides={false}
+						backgroundColour={brandBackground.primary}
+						borderColour={brandBorder.primary}
+						showSideBorders={false}
+						element="footer"
+					>
+						<Footer
+							pageFooter={article.pageFooter}
+							selectedPillar={props.NAV.selectedPillar}
+							pillars={props.NAV.pillars}
+							urls={article.nav.readerRevenueLinks.header}
+							editionId={article.editionId}
+							contributionsServiceUrl={
+								article.contributionsServiceUrl
+							}
+						/>
+					</Section>
 
-			<BannerWrapper>
-				<Island
-					priority="feature"
-					defer={{ until: 'idle' }}
-					clientOnly={true}
+					<BannerWrapper>
+						<Island
+							priority="feature"
+							defer={{ until: 'idle' }}
+							clientOnly={true}
+						>
+							<StickyBottomBanner
+								contentType={article.contentType}
+								contributionsServiceUrl={
+									contributionsServiceUrl
+								}
+								idApiUrl={article.config.idApiUrl}
+								isMinuteArticle={
+									article.pageType.isMinuteArticle
+								}
+								isPaidContent={article.pageType.isPaidContent}
+								isPreview={!!article.config.isPreview}
+								isSensitive={article.config.isSensitive}
+								keywordIds={article.config.keywordIds}
+								pageId={article.pageId}
+								sectionId={article.config.section}
+								shouldHideReaderRevenue={
+									article.shouldHideReaderRevenue
+								}
+								remoteBannerSwitch={
+									!!article.config.switches.remoteBanner
+								}
+								puzzleBannerSwitch={
+									!!article.config.switches.puzzlesBanner
+								}
+								tags={article.tags}
+							/>
+						</Island>
+					</BannerWrapper>
+					{renderAds && <MobileStickyContainer />}
+				</>
+			)}
+			{renderingTarget === 'Apps' && (
+				<Section
+					fullWidth={true}
+					data-print-layout="hide"
+					backgroundColour={neutral[97]}
+					padSides={false}
+					showSideBorders={false}
+					element="footer"
 				>
-					<StickyBottomBanner
-						contentType={article.contentType}
-						contributionsServiceUrl={contributionsServiceUrl}
-						idApiUrl={article.config.idApiUrl}
-						isMinuteArticle={article.pageType.isMinuteArticle}
-						isPaidContent={article.pageType.isPaidContent}
-						isPreview={!!article.config.isPreview}
-						isSensitive={article.config.isSensitive}
-						keywordIds={article.config.keywordIds}
-						pageId={article.pageId}
-						sectionId={article.config.section}
-						shouldHideReaderRevenue={
-							article.shouldHideReaderRevenue
-						}
-						remoteBannerSwitch={
-							!!article.config.switches.remoteBanner
-						}
-						puzzleBannerSwitch={
-							!!article.config.switches.puzzlesBanner
-						}
-						tags={article.tags}
-					/>
-				</Island>
-			</BannerWrapper>
-			{renderAds && <MobileStickyContainer />}
+					<Island priority="critical">
+						<AppsFooter />
+					</Island>
+				</Section>
+			)}
 		</>
 	);
 };

--- a/dotcom-rendering/stories/generated/Layout.stories.tsx
+++ b/dotcom-rendering/stories/generated/Layout.stories.tsx
@@ -94,3 +94,16 @@ export const AppsStandardInteractiveNewsPillar = () => {
 };
 AppsStandardInteractiveNewsPillar.storyName = 'Apps: Display: Standard, Design: Interactive, Theme: NewsPillar';
 AppsStandardInteractiveNewsPillar.args = { config: { renderingTarget: 'Apps' } };
+
+export const AppsImmersiveStandardNewsPillar = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="Immersive"
+			designName="Standard"
+			theme="NewsPillar"
+			renderingTarget="Apps"
+		/>
+	);
+};
+AppsImmersiveStandardNewsPillar.storyName = 'Apps: Display: Immersive, Design: Standard, Theme: NewsPillar';
+AppsImmersiveStandardNewsPillar.args = { config: { renderingTarget: 'Apps' } };


### PR DESCRIPTION
Closes #8996 

<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Add support for `ImmersiveLayout` in DCR for Apps. [Example article](https://www.theguardian.com/world/2023/oct/10/the-mass-protest-decade-why-did-the-street-movements-of-the-2010s-fail)

Follows similar patterns to https://github.com/guardian/dotcom-rendering/pull/9013 and https://github.com/guardian/dotcom-rendering/pull/9034

Generally, apps layouts differ from web in the following ways:

* Apps do not show the web header and footer. Apps show their own footer
* Apps do not show web ads. Apps show their own ads
* Apps do not show the web onwards container
* Apps do not render the "body end slot"
* Apps do not show the most viewed in the footer

Will be followed by https://github.com/guardian/mobile-apps-api/pull/2719

## Why?
DCR for Apps should support all the layouts DCR supports.

## Screenshots
https://github.com/guardian/dotcom-rendering/assets/19683595/64d520bb-545c-4cf8-8044-587e4fe4188c

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
