### PR TITLE
Support fullpage interactives on apps

### DIFF
--- a/dotcom-rendering/src/layouts/DecideLayout.tsx
+++ b/dotcom-rendering/src/layouts/DecideLayout.tsx
@@ -30,14 +30,19 @@ interface WebProps extends BaseProps {
 
 const DecideLayoutApps = ({ article, format, renderingTarget }: AppProps) => {
 	const notSupported = <pre>Not supported</pre>;
+	console.log('::: format is', format);
+
 	switch (format.display) {
 		case ArticleDisplay.Immersive: {
 			switch (format.design) {
 				case ArticleDesign.Interactive: {
+					console.log('::: APPS IMMERSIVE INTERACTIVE');
 					// Should be InteractiveLayout once implemented for apps
 					return notSupported;
 				}
 				default: {
+					console.log('::: APPS IMMERSIVE');
+
 					// Should be FullPageInteractiveLayout once implemented for apps
 					return notSupported;
 				}
@@ -87,6 +92,8 @@ const DecideLayoutApps = ({ article, format, renderingTarget }: AppProps) => {
 		default: {
 			switch (format.design) {
 				case ArticleDesign.Interactive:
+					console.log('::: APPS STANDARD INTERACTIVE');
+
 					return (
 						<InteractiveLayout
 							article={article}
@@ -96,6 +103,8 @@ const DecideLayoutApps = ({ article, format, renderingTarget }: AppProps) => {
 					);
 
 				case ArticleDesign.FullPageInteractive: {
+					console.log('::: APPS STANDARD FULL PAGE INTERACTIVE');
+
 					return (
 						<FullPageInteractiveLayout
 							article={article}

--- a/dotcom-rendering/src/layouts/DecideLayout.tsx
+++ b/dotcom-rendering/src/layouts/DecideLayout.tsx
@@ -96,8 +96,13 @@ const DecideLayoutApps = ({ article, format, renderingTarget }: AppProps) => {
 					);
 
 				case ArticleDesign.FullPageInteractive: {
-					// Should be FullPageInteractiveLayout once implemented for apps
-					return notSupported;
+					return (
+						<FullPageInteractiveLayout
+							article={article}
+							format={format}
+							renderingTarget={renderingTarget}
+						/>
+					);
 				}
 				case ArticleDesign.LiveBlog:
 				case ArticleDesign.DeadBlog:
@@ -153,6 +158,7 @@ const DecideLayoutWeb = ({
 							article={article}
 							NAV={NAV}
 							format={format}
+							renderingTarget={renderingTarget}
 						/>
 					);
 				}
@@ -229,6 +235,7 @@ const DecideLayoutWeb = ({
 							article={article}
 							NAV={NAV}
 							format={format}
+							renderingTarget="Web"
 						/>
 					);
 				}

--- a/dotcom-rendering/src/layouts/FullPageInteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/FullPageInteractiveLayout.tsx
@@ -33,9 +33,9 @@ import type { NavType } from '../model/extract-nav';
 import type { Switches } from '../types/config';
 import type { FEElement } from '../types/content';
 import type { DCRArticle } from '../types/frontend';
+import type { RenderingTarget } from '../types/renderingTarget';
 import { interactiveGlobalStyles } from './lib/interactiveLegacyStyling';
 import { BannerWrapper, Stuck } from './lib/stickiness';
-import { RenderingTarget } from 'src/types/renderingTarget';
 
 interface CommonProps {
 	article: DCRArticle;
@@ -317,7 +317,7 @@ export const FullPageInteractiveLayout = (props: WebProps | AppsProps) => {
 							article={article}
 							NAV={props.NAV}
 							format={format}
-							renderingTarget="Web"
+							renderingTarget={renderingTarget}
 						/>
 
 						{format.theme === ArticleSpecial.Labs && (

--- a/dotcom-rendering/src/layouts/FullPageInteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/FullPageInteractiveLayout.tsx
@@ -52,6 +52,12 @@ interface AppsProps extends CommonProps {
 	renderingTarget: 'Apps';
 }
 
+type HeaderProps = {
+	article: DCRArticle;
+	NAV: NavType;
+	format: ArticleFormat;
+};
+
 type RendererProps = {
 	format: ArticleFormat;
 	elements: FEElement[];
@@ -137,7 +143,7 @@ const Renderer = ({
 	return <div css={adStyles}>{output}</div>;
 };
 
-const NavHeader = ({ article, NAV, format }: WebProps) => {
+const NavHeader = ({ article, NAV, format }: HeaderProps) => {
 	// Typically immersives use the slim nav, but this switch is used to force
 	// the full nav - typically during special events such as Project 200, or
 	// the Euros. The motivation is to better onboard new visitors; interactives
@@ -317,7 +323,6 @@ export const FullPageInteractiveLayout = (props: WebProps | AppsProps) => {
 							article={article}
 							NAV={props.NAV}
 							format={format}
-							renderingTarget={renderingTarget}
 						/>
 
 						{format.theme === ArticleSpecial.Labs && (


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Adds support for the full page interactive layout for apps - [see example article here](https://www.theguardian.com/music/ng-interactive/2021/apr/12/the-months-best-albums)
through adapting the FullPageInteractive for apps. This follows the same patterns as https://github.com/guardian/dotcom-rendering/pull/9013 and https://github.com/guardian/dotcom-rendering/pull/9034

Generally, apps layouts and full page interactive layouts differ from web in the following ways:

- Full page interactives on apps do not show a header and footer
- Full page interactives on apps do not show ads. 
- Full page interactives on apps  do not show the onwards container
- Apps do not render the "body end slot"
- Apps do not show the most viewed in the footer

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
