### PR TITLE
Add an apps interactive endpoint to DCR

### DIFF
--- a/dotcom-rendering/src/server/dev-index.html
+++ b/dotcom-rendering/src/server/dev-index.html
@@ -60,6 +60,11 @@
 				>
 			</li>
 			<li>
+				<a
+					href="/AppsInteractive/https://www.theguardian.com/global-development/ng-interactive/2022/jun/09/the-black-sea-blockade-mapping-the-impact-of-war-in-ukraine-on-the-worlds-food-supply-interactive"
+					>Apps Interactive</a>
+			</li>
+			<li>
 				<a href="/Front/https://www.theguardian.com/international"
 					>International Front</a
 				>

--- a/dotcom-rendering/src/server/dev-server.ts
+++ b/dotcom-rendering/src/server/dev-server.ts
@@ -1,7 +1,10 @@
 import type { Handler } from 'express';
 import { handleAllEditorialNewslettersPage } from '../server/index.allEditorialNewslettersPage.web';
 import { handleAMPArticle } from '../server/index.article.amp';
-import { handleAppsArticle } from '../server/index.article.apps';
+import {
+	handleAppsArticle,
+	handleAppsInteractive,
+} from '../server/index.article.apps';
 import {
 	handleArticle,
 	handleArticleJson,
@@ -64,6 +67,8 @@ export const devServer = (): Handler => {
 				return handleAllEditorialNewslettersPage(req, res, next);
 			case 'AppsArticle':
 				return handleAppsArticle(req, res, next);
+			case 'AppsInteractive':
+				return handleAppsInteractive(req, res, next);
 			default: {
 				// Do not redirect assets urls
 				if (req.url.match(ASSETS_URL)) return next();

--- a/dotcom-rendering/src/server/index.article.apps.ts
+++ b/dotcom-rendering/src/server/index.article.apps.ts
@@ -13,3 +13,12 @@ export const handleAppsArticle: RequestHandler = ({ body }, res) => {
 	// The Android app will cache these assets to enable offline reading
 	res.set('Link', makePrefetchHeader(prefetchScripts)).send(html);
 };
+
+export const handleAppsInteractive: RequestHandler = ({ body }, res) => {
+	recordTypeAndPlatform('interactive', 'app');
+
+	const article = enhanceArticleType(body, 'Apps');
+	const { html, prefetchScripts } = renderArticle(article);
+
+	res.status(200).set('Link', makePrefetchHeader(prefetchScripts)).send(html);
+};

--- a/dotcom-rendering/src/server/prod-server.ts
+++ b/dotcom-rendering/src/server/prod-server.ts
@@ -8,7 +8,10 @@ import {
 	handleAMPArticle,
 	handlePerfTest as handleAMPArticlePerfTest,
 } from '../server/index.article.amp';
-import { handleAppsArticle } from '../server/index.article.apps';
+import {
+	handleAppsArticle,
+	handleAppsInteractive,
+} from '../server/index.article.apps';
 import {
 	handleArticle,
 	handleArticleJson,
@@ -75,6 +78,7 @@ export const prodServer = (): void => {
 		handleAllEditorialNewslettersPage,
 	);
 	app.post('/AppsArticle', logRenderTime, handleAppsArticle);
+	app.post('/AppsInteractive', logRenderTime, handleAppsInteractive);
 
 	// These GET's are for checking any given URL directly from PROD
 	app.get(
@@ -130,6 +134,13 @@ export const prodServer = (): void => {
 		logRenderTime,
 		getContentFromURLMiddleware,
 		handleAppsArticle,
+	);
+
+	app.get(
+		'/AppsInteractive/*',
+		logRenderTime,
+		getContentFromURLMiddleware,
+		handleAppsInteractive,
 	);
 
 	app.use('/ArticlePerfTest/*', handleArticlePerfTest);


### PR DESCRIPTION

## What does this change?
Adds support for an apps interactive endpoint in DCR. 

## Why?
Currently, DCR only supports the interactive endpoint for web. We have separate endpoints for platforms so that we can 
1.) log what type and platform of an article is at server level 
2.) pass the rendering target down to the components.

