### PR TITLE
Record site was adapted

### DIFF
--- a/dotcom-rendering/src/client/adaptiveSite.ts
+++ b/dotcom-rendering/src/client/adaptiveSite.ts
@@ -1,6 +1,7 @@
 import { log } from '@guardian/libs';
 import { isServer } from '../lib/isServer';
 import { setSchedulerPriorityLastStartTime } from '../lib/scheduler';
+import { recordExperiences } from './ophan/ophan';
 
 /**
  * Whether we should adapt the current page to address poor performance issues.
@@ -30,6 +31,8 @@ const hideAdaptedIslands = () => {
 	document.head.appendChild(style);
 };
 
+const recordAdaptedSite = () => recordExperiences('adapted');
+
 export const adaptSite = (): void => {
 	log('openJournalism', '🎛️ Adapting');
 
@@ -37,4 +40,6 @@ export const adaptSite = (): void => {
 	setSchedulerPriorityLastStartTime('feature', 0);
 	setSchedulerPriorityLastStartTime('enhancement', 0);
 	hideAdaptedIslands();
+
+	void recordAdaptedSite();
 };

--- a/dotcom-rendering/src/client/ophan/ophan.ts
+++ b/dotcom-rendering/src/client/ophan/ophan.ts
@@ -9,7 +9,13 @@ import { log } from '@guardian/libs';
 import type { ServerSideTests } from '../../types/config';
 
 export type OphanRecordFunction = (
-	event: { [key: string]: unknown },
+	event: { [key: string]: unknown } & {
+		/**
+		 * the experiences key will override previously set values.
+		 * Use `recordExperiences` instead.
+		 */
+		experiences?: never;
+	},
 	callback?: () => void,
 ) => void;
 
@@ -152,5 +158,8 @@ export const recordExperiences = async (
 		experiencesSet.add(experience);
 	}
 	const { record } = await getOphan();
-	record({ experiences: [...experiencesSet].join(',') });
+
+	// this is the only allowed usage of sending experiences!
+	// otherwise, race conditions might lead to different results
+	record({ ['experiences' as string]: [...experiencesSet].sort().join(',') });
 };

--- a/dotcom-rendering/src/client/ophan/ophan.ts
+++ b/dotcom-rendering/src/client/ophan/ophan.ts
@@ -143,3 +143,14 @@ export const recordPerformance = async (): Promise<void> => {
 		performance,
 	});
 };
+
+const experiencesSet = new Set(['dotcom-rendering']);
+export const recordExperiences = async (
+	...experiences: string[]
+): Promise<void> => {
+	for (const experience of experiences) {
+		experiencesSet.add(experience);
+	}
+	const { record } = await getOphan();
+	record({ experiences: [...experiencesSet].join(',') });
+};

--- a/dotcom-rendering/src/client/ophan/recordInitialPageEvents.ts
+++ b/dotcom-rendering/src/client/ophan/recordInitialPageEvents.ts
@@ -1,9 +1,14 @@
-import { abTestPayload, getOphan, recordPerformance } from './ophan';
+import {
+	abTestPayload,
+	getOphan,
+	recordExperiences,
+	recordPerformance,
+} from './ophan';
 
 export const recordInitialPageEvents = async (): Promise<void> => {
 	const { record } = await getOphan();
 
-	record({ experiences: 'dotcom-rendering' });
+	void recordExperiences('dotcom-rendering');
 	record({ edition: window.guardian.config.page.edition });
 
 	// Record server-side AB test variants (i.e. control or variant)

--- a/dotcom-rendering/src/client/poorPerformanceMonitoring.ts
+++ b/dotcom-rendering/src/client/poorPerformanceMonitoring.ts
@@ -1,5 +1,5 @@
 import { log } from '@guardian/libs';
-import { getOphan } from './ophan/ophan';
+import { recordExperiences } from './ophan/ophan';
 
 const logPerformanceInfo = (name: string, data?: unknown) =>
 	log('openJournalism', '⏱', name, data);
@@ -74,14 +74,8 @@ export const isPerformingPoorly = async (): Promise<boolean> =>
 export const recordPoorPerformance = async (): Promise<void> => {
 	try {
 		if (await isPerformingPoorly()) {
-			/** Not sure here if we should duplicate “dotcom-rendering” */
-			const experiences = [
-				'dotcom-rendering',
-				'poor-page-performance',
-			].join(',');
 			log('openJournalism', `🐌 Poor page performance`);
-			const { record } = await getOphan();
-			record({ experiences });
+			return recordExperiences('poor-page-performance');
 		}
 	} catch (error) {
 		// do nothing if the performance API is not available


### PR DESCRIPTION
## What does this change?

1. Create a helper to record experiences to Ophan.

2. Use it to record to Ophan that we adapted the site.

## Why?

1. The helper ensures that race conditions do not lead to data being overwritten, as the last value sent overrides previous values, as confirmed by @guardian/ophan.

2. The current reliance on the `poor-page-performance` indicator was deemed to brittle by D&I.

## Screenshots

<img width="804" alt="console log showing event recorded" src="https://github.com/guardian/dotcom-rendering/assets/76776/b01740ea-6fc1-4777-a194-ffaaead7b66d">
