### PR TITLE
Narrow branding types

### DIFF
--- a/dotcom-rendering/src/model/article-schema.json
+++ b/dotcom-rendering/src/model/article-schema.json
@@ -4222,15 +4222,7 @@
             "type": "object",
             "properties": {
                 "brandingType": {
-                    "type": "object",
-                    "properties": {
-                        "name": {
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "name"
-                    ]
+                    "$ref": "#/definitions/BrandingType"
                 },
                 "sponsorName": {
                     "type": "string"
@@ -4313,6 +4305,46 @@
                 "aboutThisLink",
                 "logo",
                 "sponsorName"
+            ]
+        },
+        "BrandingType": {
+            "anyOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "const": "paid-content"
+                        }
+                    },
+                    "required": [
+                        "name"
+                    ]
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "const": "foundation"
+                        }
+                    },
+                    "required": [
+                        "name"
+                    ]
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "const": "sponsored"
+                        }
+                    },
+                    "required": [
+                        "name"
+                    ]
+                }
             ]
         },
         "MainMedia": {

--- a/dotcom-rendering/src/model/decideBadge.test.ts
+++ b/dotcom-rendering/src/model/decideBadge.test.ts
@@ -18,7 +18,7 @@ const brandingAmazon = {
 	},
 	aboutThisLink:
 		'https://www.theguardian.com/info/2016/jan/25/content-funding',
-};
+} as const;
 
 const brandingGuardianOrg = {
 	brandingType: {
@@ -45,7 +45,7 @@ const brandingGuardianOrg = {
 	},
 	aboutThisLink:
 		'https://www.theguardian.com/global-development/2021/feb/21/about-the-rights-and-freedom-series',
-};
+} as const;
 
 describe('Decide badge', () => {
 	describe('getBadgeFromSeriesTag', () => {

--- a/dotcom-rendering/src/model/front-schema.json
+++ b/dotcom-rendering/src/model/front-schema.json
@@ -2797,15 +2797,7 @@
             "type": "object",
             "properties": {
                 "brandingType": {
-                    "type": "object",
-                    "properties": {
-                        "name": {
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "name"
-                    ]
+                    "$ref": "#/definitions/BrandingType"
                 },
                 "sponsorName": {
                     "type": "string"
@@ -2888,6 +2880,46 @@
                 "aboutThisLink",
                 "logo",
                 "sponsorName"
+            ]
+        },
+        "BrandingType": {
+            "anyOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "const": "paid-content"
+                        }
+                    },
+                    "required": [
+                        "name"
+                    ]
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "const": "foundation"
+                        }
+                    },
+                    "required": [
+                        "name"
+                    ]
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "const": "sponsored"
+                        }
+                    },
+                    "required": [
+                        "name"
+                    ]
+                }
             ]
         },
         "FEDesign": {

--- a/dotcom-rendering/src/model/tag-front-schema.json
+++ b/dotcom-rendering/src/model/tag-front-schema.json
@@ -1386,15 +1386,7 @@
             "type": "object",
             "properties": {
                 "brandingType": {
-                    "type": "object",
-                    "properties": {
-                        "name": {
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "name"
-                    ]
+                    "$ref": "#/definitions/BrandingType"
                 },
                 "sponsorName": {
                     "type": "string"
@@ -1477,6 +1469,46 @@
                 "aboutThisLink",
                 "logo",
                 "sponsorName"
+            ]
+        },
+        "BrandingType": {
+            "anyOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "const": "paid-content"
+                        }
+                    },
+                    "required": [
+                        "name"
+                    ]
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "const": "foundation"
+                        }
+                    },
+                    "required": [
+                        "name"
+                    ]
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "const": "sponsored"
+                        }
+                    },
+                    "required": [
+                        "name"
+                    ]
+                }
             ]
         },
         "FEFrontCardStyle": {

--- a/dotcom-rendering/src/types/branding.ts
+++ b/dotcom-rendering/src/types/branding.ts
@@ -7,8 +7,16 @@ type BrandingLogo = {
 	dimensions: { width: number; height: number };
 };
 
+/**
+ * @see https://github.com/guardian/commercial-shared/blob/35cdf4e1/src/main/scala/com/gu/commercial/branding/BrandingType.scala
+ */
+export type BrandingType =
+	| { name: 'paid-content' }
+	| { name: 'foundation' }
+	| { name: 'sponsored' };
+
 export interface Branding {
-	brandingType?: { name: string };
+	brandingType?: BrandingType;
 	sponsorName: string;
 	logo: BrandingLogo;
 	aboutThisLink: string;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Narrow the possible branding types we support in DCR, to match the values used in Frontend.

I've also ran `make gen-schema` to update the schema to ensure we check the shape of the incoming JSON.

## Why?

We'll be able to use this in subsequent PRs to avoid performing unecessary validation when processing fronts branding.

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
