### PR TITLE
Lazy-load pictures on Fronts, except when in the first container

### DIFF
--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -420,11 +420,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 					// There are some containers that have zero trails. We don't want to render these
 					if (!trail) return null;
 
-					const imageLoading =
-						front.config.abTests.lazyLoadImagesVariant ===
-							'variant' && index > 0
-							? 'lazy'
-							: 'eager';
+					const imageLoading = index > 0 ? 'lazy' : 'eager';
 
 					const ophanName = ophanComponentId(collection.displayName);
 					const ophanComponentLink = `container-${

--- a/dotcom-rendering/src/layouts/TagFrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/TagFrontLayout.tsx
@@ -211,11 +211,7 @@ export const TagFrontLayout = ({ tagFront, NAV }: Props) => {
 						groupedTrails.day !== undefined,
 					);
 
-					const imageLoading =
-						tagFront.config.abTests.lazyLoadImagesVariant ===
-							'variant' && index > 0
-							? 'lazy'
-							: 'eager';
+					const imageLoading = index > 0 ? 'lazy' : 'eager';
 
 					const ContainerComponent = () => {
 						if (


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Make all `CardPicture` lazy except if they’re in the first container.

## Why?

There’s minimal impact on core web vitals, but there can be a significant reduction in bandwidth for users that scroll less.

- On a tablet for the international front, a user could save up to 400kB of the total 1.2MB.
- On wide desktop, they could save 1MB of the total 2MB.

See #8524 for CWV research findings.

## Alternative

Make all images load eagerly, if there’s no measurable impact on core web vital – it keeps things simpler.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |
| ![before-desktop][] | ![after-desktop][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/76776/ef6aed6d-1c69-4af7-8a9a-74eadc74f29b
[after]: https://github.com/guardian/dotcom-rendering/assets/76776/bce3cfe0-b8a9-44cc-99dc-9ac54282765d

[before-desktop]: https://github.com/guardian/dotcom-rendering/assets/76776/eb864656-7120-4b1c-8fff-ebb28ff4cef7
[after-desktop]: https://github.com/guardian/dotcom-rendering/assets/76776/71389137-723d-4ca7-bec9-a20fc9ef5415


