### PR TITLE
Add video atom

### DIFF
--- a/dotcom-rendering/src/components/VideoAtom.stories.tsx
+++ b/dotcom-rendering/src/components/VideoAtom.stories.tsx
@@ -11,7 +11,7 @@ export default {
 	},
 };
 
-export const DefaultStory = (): JSX.Element => {
+export const DefaultStory = () => {
 	return (
 		<div
 			css={css`
@@ -32,7 +32,7 @@ export const DefaultStory = (): JSX.Element => {
 	);
 };
 
-export const LargeStory = (): JSX.Element => {
+export const LargeStory = () => {
 	return (
 		<div
 			css={css`
@@ -55,7 +55,7 @@ export const LargeStory = (): JSX.Element => {
 	);
 };
 
-export const NoPosterStory = (): JSX.Element => {
+export const NoPosterStory = () => {
 	return (
 		<div
 			css={css`

--- a/dotcom-rendering/src/components/VideoAtom.stories.tsx
+++ b/dotcom-rendering/src/components/VideoAtom.stories.tsx
@@ -1,0 +1,76 @@
+import { css } from '@emotion/react';
+import { VideoAtom } from './VideoAtom';
+
+export default {
+	title: 'VideoAtom',
+	component: VideoAtom,
+	parameters: {
+		// Chromatic ignores video elements by design so there's no point trying to snapshot here
+		// https://www.chromatic.com/docs/ignoring-elements
+		chromatic: { disable: true },
+	},
+};
+
+export const DefaultStory = (): JSX.Element => {
+	return (
+		<div
+			css={css`
+				width: 800px;
+				margin: 25px;
+			`}
+		>
+			<VideoAtom
+				poster="https://media.guim.co.uk/29638c3179baea589b10fbd4dbbc223ea77027ae/0_0_3589_2018/master/3589.jpg"
+				assets={[
+					{
+						url: 'https://uploads.guim.co.uk/2020%2F23%2F04%2Ffor+testing+purposes+only--ef8e62ab-bc06-4892-8da1-65a7e5bacb77-1.mp4',
+						mimeType: 'video/mp4',
+					},
+				]}
+			/>
+		</div>
+	);
+};
+
+export const LargeStory = (): JSX.Element => {
+	return (
+		<div
+			css={css`
+				width: 800px;
+				margin: 25px;
+			`}
+		>
+			<VideoAtom
+				poster="https://media.guim.co.uk/29638c3179baea589b10fbd4dbbc223ea77027ae/0_0_3589_2018/master/3589.jpg"
+				assets={[
+					{
+						url: 'https://uploads.guim.co.uk/2020%2F23%2F04%2Ffor+testing+purposes+only--ef8e62ab-bc06-4892-8da1-65a7e5bacb77-1.mp4',
+						mimeType: 'video/mp4',
+					},
+				]}
+				height={500}
+				width={880}
+			/>
+		</div>
+	);
+};
+
+export const NoPosterStory = (): JSX.Element => {
+	return (
+		<div
+			css={css`
+				width: 800px;
+				margin: 25px;
+			`}
+		>
+			<VideoAtom
+				assets={[
+					{
+						url: 'https://uploads.guim.co.uk/2020%2F23%2F04%2Ffor+testing+purposes+only--ef8e62ab-bc06-4892-8da1-65a7e5bacb77-1.mp4',
+						mimeType: 'video/mp4',
+					},
+				]}
+			/>
+		</div>
+	);
+};

--- a/dotcom-rendering/src/components/VideoAtom.tsx
+++ b/dotcom-rendering/src/components/VideoAtom.tsx
@@ -21,8 +21,9 @@ export const VideoAtom = ({
 	if (assets.length === 0) return null; // Handle empty assets array
 	return (
 		<MaintainAspectRatio height={height} width={width}>
+			{/* eslint-disable-next-line jsx-a11y/media-has-caption */}
 			<video
-				controls
+				controls={true}
 				preload="metadata"
 				width={width}
 				height={height}

--- a/dotcom-rendering/src/components/VideoAtom.tsx
+++ b/dotcom-rendering/src/components/VideoAtom.tsx
@@ -1,0 +1,41 @@
+import { MaintainAspectRatio } from './MaintainAspectRatio';
+
+type AssetType = {
+	url: string;
+	mimeType: string;
+};
+
+interface Props {
+	assets: AssetType[];
+	poster?: string;
+	height?: number;
+	width?: number;
+}
+
+export const VideoAtom = ({
+	assets,
+	poster,
+	height = 259,
+	width = 460,
+}: Props) => {
+	if (assets.length === 0) return null; // Handle empty assets array
+	return (
+		<MaintainAspectRatio height={height} width={width}>
+			<video
+				controls
+				preload="metadata"
+				width={width}
+				height={height}
+				poster={poster}
+			>
+				{assets.map((asset, index) => (
+					<source key={index} src={asset.url} type={asset.mimeType} />
+				))}
+				<p>
+					{`Your browser doesn't support HTML5 video. Here is a `}
+					<a href={assets[0]?.url}>link to the video</a> instead.
+				</p>
+			</video>
+		</MaintainAspectRatio>
+	);
+};

--- a/dotcom-rendering/src/lib/renderElement.tsx
+++ b/dotcom-rendering/src/lib/renderElement.tsx
@@ -1,7 +1,6 @@
 import {
 	InteractiveAtom,
 	InteractiveLayoutAtom,
-	VideoAtom,
 } from '@guardian/atoms-rendering';
 import type { ArticleFormat } from '@guardian/libs';
 import { ArticleDesign } from '@guardian/libs';
@@ -50,6 +49,7 @@ import { TextBlockComponent } from '../components/TextBlockComponent';
 import { TimelineAtomWrapper } from '../components/TimelineAtomWrapper.importable';
 import { TweetBlockComponent } from '../components/TweetBlockComponent.importable';
 import { UnsafeEmbedBlockComponent } from '../components/UnsafeEmbedBlockComponent.importable';
+import { VideoAtom } from '../components/VideoAtom';
 import { VideoFacebookBlockComponent } from '../components/VideoFacebookBlockComponent.importable';
 import { VimeoBlockComponent } from '../components/VimeoBlockComponent';
 import { VineBlockComponent } from '../components/VineBlockComponent.importable';


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Moves video atom into DCR

## Why?

We're migrating all atoms from atoms-rendering

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/77005274/0de661b2-2561-4cca-b940-7c052e6c421f
[after]: https://github.com/guardian/dotcom-rendering/assets/77005274/3fcbb6f6-e2c5-4e42-be57-2898dffe8750

