### PR TITLE
fix(guide atom): fetch body from items only if items is truthy 

### DIFF
--- a/apps-rendering/src/atoms.ts
+++ b/apps-rendering/src/atoms.ts
@@ -74,7 +74,8 @@ function parseAtom(
 			const { title } = atom;
 			const image = atom.data.guide.guideImage?.master?.file;
 			const credit = atom.data.guide.guideImage?.master?.credit;
-			const { body } = atom.data.guide.items?.[0];
+			const { items } = atom.data.guide;
+			const { body } = items && items[0];
 
 			if (!title || !body) {
 				return Result.err(`No title or body for atom: ${id}`);


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Fixes the bug shown by this stack trace:

```
TypeError: Cannot destructure property 'body' of 'atom.data.guide.items[0]' as it is undefined.
    at parseAtom (/opt/mobile-apps-rendering/webpack:/apps-rendering/src/atoms.ts:47:1)
    at /opt/mobile-apps-rendering/webpack:/apps-rendering/src/bodyElement.ts:184:1
    at Array.flatMap (<anonymous>)
    at /opt/mobile-apps-rendering/webpack:/apps-rendering/src/bodyElement.ts:194:1
    at parseBody (/opt/mobile-apps-rendering/webpack:/apps-rendering/src/item.ts:118:1)
    at /opt/mobile-apps-rendering/webpack:/apps-rendering/src/item.ts:172:1
    at page_render (/opt/mobile-apps-rendering/webpack:/apps-rendering/src/server/page.tsx:95:1)
    at serveArticle (/opt/mobile-apps-rendering/webpack:/apps-rendering/src/server/server.ts:101:1)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at serveArticlePost (/opt/mobile-apps-rendering/webpack:/apps-rendering/src/server/server.ts:153:1)
```

## Why?

Stop unnecessary 500 alerts from AR
