### PR TITLE
Remove Section Fronts AB test

### DIFF
--- a/dotcom-rendering/cypress/fixtures/manual/standard-article.js
+++ b/dotcom-rendering/cypress/fixtures/manual/standard-article.js
@@ -1478,7 +1478,6 @@ export const Standard = {
 			serverSideLiveblogInlineAds: true,
 			discussionPageSize: true,
 			smartAppBanner: false,
-			sectionFrontsBannerAds: true,
 			abPrebidKargo: true,
 			boostGaUserTimingFidelity: false,
 			historyTags: true,

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -37,10 +37,7 @@ import { WeatherWrapper } from '../components/WeatherWrapper.importable';
 import { canRenderAds } from '../lib/canRenderAds';
 import { getContributionsServiceUrl } from '../lib/contributions';
 import { decideContainerOverrides } from '../lib/decideContainerOverrides';
-import {
-	networkFrontsBannerAdCollections,
-	sectionFrontsBannerAdCollections,
-} from '../lib/frontsBannerAbTestAdPositions';
+import { frontsBannerAdCollections } from '../lib/frontsBannerAbTestAdPositions';
 import {
 	getDesktopAdPositions,
 	getMerchHighPosition,
@@ -89,8 +86,7 @@ export const decideAdSlot = (
 	isPaidContent: boolean | undefined,
 	mobileAdPositions: (number | undefined)[],
 	hasPageSkin: boolean,
-	isInNetworkFrontsBannerTest?: boolean,
-	isInSectionFrontsBannerTest?: boolean,
+	isInFrontsBannerTest?: boolean,
 ) => {
 	if (!renderAds) return null;
 
@@ -99,7 +95,7 @@ export const decideAdSlot = (
 		collectionCount > minContainers &&
 		index === getMerchHighPosition(collectionCount)
 	) {
-		if (isInNetworkFrontsBannerTest || isInSectionFrontsBannerTest) {
+		if (isInFrontsBannerTest) {
 			return (
 				<Hide from="desktop">
 					<AdSlot
@@ -219,24 +215,14 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 
 	const hasPageSkin = hasPageSkinConfig && renderAds;
 
-	const isInNetworkFrontsBannerTest =
+	const isInFrontsBannerTest =
 		!!switches.frontsBannerAdsDcr &&
 		abTests.frontsBannerAdsDcrVariant === 'variant' &&
-		Object.keys(networkFrontsBannerAdCollections).includes(
-			front.config.pageId,
-		);
-	const isInSectionFrontsBannerTest =
-		!!switches.sectionFrontsBannerAds &&
-		abTests.sectionFrontsBannerAdsVariant === 'variant' &&
-		Object.keys(sectionFrontsBannerAdCollections).includes(
-			front.config.pageId,
-		);
+		Object.keys(frontsBannerAdCollections).includes(front.config.pageId);
 
-	// This will be the targeted collections, if the current page is in the fronts banner AB test.
-	const frontsBannerTargetedCollections = isInNetworkFrontsBannerTest
-		? networkFrontsBannerAdCollections[front.config.pageId]
-		: isInSectionFrontsBannerTest
-		? sectionFrontsBannerAdCollections[front.config.pageId]
+	// This will be the targeted collections if the current page is in the fronts banner AB test.
+	const frontsBannerTargetedCollections = isInFrontsBannerTest
+		? frontsBannerAdCollections[front.config.pageId]
 		: [];
 
 	const merchHighPosition = getMerchHighPosition(
@@ -253,10 +239,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 
 	const numBannerAdsInserted = useRef(0);
 
-	const renderMpuAds =
-		renderAds &&
-		!isInNetworkFrontsBannerTest &&
-		!isInSectionFrontsBannerTest;
+	const renderMpuAds = renderAds && !isInFrontsBannerTest;
 
 	const showMostPopular =
 		front.config.switches.deeplyRead &&
@@ -497,8 +480,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 											.isPaidContent,
 										mobileAdPositions,
 										hasPageSkin,
-										isInNetworkFrontsBannerTest,
-										isInSectionFrontsBannerTest,
+										isInFrontsBannerTest,
 									)}
 								</div>
 							</Fragment>
@@ -577,8 +559,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 										.isPaidContent,
 									mobileAdPositions,
 									hasPageSkin,
-									isInNetworkFrontsBannerTest,
-									isInSectionFrontsBannerTest,
+									isInFrontsBannerTest,
 								)}
 							</>
 						);
@@ -632,8 +613,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 										.isPaidContent,
 									mobileAdPositions,
 									hasPageSkin,
-									isInNetworkFrontsBannerTest,
-									isInSectionFrontsBannerTest,
+									isInFrontsBannerTest,
 								)}
 							</Fragment>
 						);
@@ -715,8 +695,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 										.isPaidContent,
 									mobileAdPositions,
 									hasPageSkin,
-									isInNetworkFrontsBannerTest,
-									isInSectionFrontsBannerTest,
+									isInFrontsBannerTest,
 								)}
 							</Fragment>
 						);
@@ -800,8 +779,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 								front.pressedPage.frontProperties.isPaidContent,
 								mobileAdPositions,
 								hasPageSkin,
-								isInNetworkFrontsBannerTest,
-								isInSectionFrontsBannerTest,
+								isInFrontsBannerTest,
 							)}
 						</Fragment>
 					);

--- a/dotcom-rendering/src/lib/frontsBannerAbTestAdPositions.ts
+++ b/dotcom-rendering/src/lib/frontsBannerAbTestAdPositions.ts
@@ -13,7 +13,7 @@ type FrontsBannerAdCollections = {
 	[key: string]: string[];
 };
 
-export const networkFrontsBannerAdCollections: FrontsBannerAdCollections = {
+export const frontsBannerAdCollections: FrontsBannerAdCollections = {
 	uk: [
 		'Spotlight',
 		'Opinion',
@@ -49,9 +49,6 @@ export const networkFrontsBannerAdCollections: FrontsBannerAdCollections = {
 		'Around the world',
 		'Take part',
 	],
-};
-
-export const sectionFrontsBannerAdCollections: FrontsBannerAdCollections = {
 	'uk/sport': [
 		'News and features',
 		// 'football', has football weekly thrasher above atm


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

- Remove Section Fronts AB test. 
- Retains the section front page-collection key value pairs for testing, as the ads team would still like to be able to test campaigns. Therefore, the network fronts server-side AB test has not been removed and the targeted collections for section fronts has been combined with the targeted collections for the network front. This AB test will be removed once campaign testing is complete.

## Why?

The test has ended.
