### PR TITLE
fix: use correct riff-raff dependency for front-web

### DIFF
--- a/dotcom-rendering/scripts/deploy/riff-raff.yaml
+++ b/dotcom-rendering/scripts/deploy/riff-raff.yaml
@@ -44,7 +44,7 @@ deployments:
       bucketSsmKey: /account/services/dotcom-artifact.bucket
     dependencies:
       - frontend-static
-      - frontend-cfn
+      - front-web-cfn
   frontend-static:
     type: aws-s3
     parameters:


### PR DESCRIPTION
## What does this change?
Fixes the dependency for `front-web` from `frontend-cfn` => `front-web-cfn`.

