### PR TITLE
Better alignment for `DropCap` on Safari

### DIFF
--- a/dotcom-rendering/src/components/DropCap.tsx
+++ b/dotcom-rendering/src/components/DropCap.tsx
@@ -24,7 +24,7 @@ const innerStyles = (format: ArticleFormat) => {
 	const baseStyles = css`
 		${headline.large({ fontWeight: 'bold' })}
 		font-size: 111px;
-		line-height: 93px;
+		line-height: 92px;
 		vertical-align: text-top;
 		pointer-events: none;
 		margin-right: ${space[1]}px;


### PR DESCRIPTION
## What does this change?

Reduce the `DropCap` line-height by 1 pixel.

## Why?

This fixes an issue where dropped caps span over an extra line on Safari, iOS & macOS.

The issue was not fully fixed by #8594

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/76776/efa493ff-ded6-47c5-a230-f1c1dce6e94d
[after]: https://github.com/guardian/dotcom-rendering/assets/76776/4c105111-91a2-4884-8fdb-9bfdba86722e