### PR TITLE
Defer `ShowHideContainers` island until idle

### DIFF
--- a/dotcom-rendering/src/components/FrontPage.tsx
+++ b/dotcom-rendering/src/components/FrontPage.tsx
@@ -84,7 +84,7 @@ export const FrontPage = ({ front, NAV }: Props) => {
 			</Island>
 			<Island
 				priority="enhancement"
-				defer={{ until: 'visible' }}
+				defer={{ until: 'idle' }}
 				clientOnly={true}
 			>
 				<ShowHideContainers />


### PR DESCRIPTION
Previously, we deferred until `visible`. However, the island sits in the DOM under the header. In cases where the user loads a front scrolled part-way down, like when navigating back from an article, the island doesn't load and the user can't show/hide containers.

Fixes https://github.com/guardian/dotcom-rendering/issues/9076

