### PR TITLE
Remove `ophan-tracker-js` from webpack config

### DIFF
--- a/dotcom-rendering/scripts/webpack/webpack.config.client.js
+++ b/dotcom-rendering/scripts/webpack/webpack.config.client.js
@@ -147,6 +147,7 @@ module.exports = ({ build, sessionId }) => ({
 			  ]
 			: []),
 	],
+	externals: getExternalModules(build),
 	module: {
 		rules: [
 			{
@@ -177,3 +178,7 @@ module.exports.babelExclude = {
 };
 
 module.exports.getLoaders = getLoaders;
+
+// We are making "ophan-tracker-js" external to the apps bundle because we never expect to use it in apps pages. Tracking is done natively.
+const getExternalModules = (build) =>
+	build === 'apps' ? { 'ophan-tracker-js': 'ophan-tracker-js' } : {};

--- a/dotcom-rendering/src/client/index.apps.ts
+++ b/dotcom-rendering/src/client/index.apps.ts
@@ -10,17 +10,6 @@ import { startup } from './startup';
  *************************************************************/
 
 void startup(
-	'recordInitialPageEvents',
-	() =>
-		import(
-			/* webpackMode: "eager" */ './ophan/recordInitialPageEvents'
-		).then(({ recordInitialPageEvents }) => recordInitialPageEvents()),
-	{
-		priority: 'critical',
-	},
-);
-
-void startup(
 	'sentryLoader',
 	() =>
 		import(/* webpackMode: "eager" */ './sentryLoader').then(

--- a/dotcom-rendering/src/client/ophan/ophan.ts
+++ b/dotcom-rendering/src/client/ophan/ophan.ts
@@ -157,9 +157,12 @@ export const recordExperiences = async (
 	for (const experience of experiences) {
 		experiencesSet.add(experience);
 	}
+
 	const { record } = await getOphan();
 
 	// this is the only allowed usage of sending experiences!
 	// otherwise, race conditions might lead to different results
-	record({ ['experiences' as string]: [...experiencesSet].sort().join(',') });
+	record({
+		['experiences' as string]: [...experiencesSet].sort().join(','),
+	});
 };

--- a/dotcom-rendering/src/client/ophan/ophan.ts
+++ b/dotcom-rendering/src/client/ophan/ophan.ts
@@ -34,6 +34,7 @@ export const getOphan = async (): Promise<
 		return cachedOphan;
 	}
 
+	// We've taken 'ophan-tracker-js' out of the apps client bundle (made it external in webpack) because we don't ever expect this method to be called. Tracking in apps is done natively.
 	// @ts-expect-error -- side effect only
 	await import(/* webpackMode: "eager" */ 'ophan-tracker-js');
 

--- a/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
@@ -8,6 +8,7 @@ import { getOphan } from '../client/ophan/ophan';
 import { useAB } from '../lib/useAB';
 import { useAdTargeting } from '../lib/useAdTargeting';
 import { Caption } from './Caption';
+import { useConfig } from './ConfigContext';
 import { YoutubeAtom } from './YoutubeAtom/YoutubeAtom';
 
 type Props = {
@@ -112,6 +113,7 @@ export const YoutubeBlockComponent = ({
 	);
 
 	const adTargeting = useAdTargeting(duration);
+	const { renderingTarget } = useConfig();
 
 	const abTests = useAB();
 	const abTestsApi = abTests?.api;
@@ -209,7 +211,11 @@ export const YoutubeBlockComponent = ({
 				width={width}
 				title={mediaTitle}
 				duration={duration}
-				eventEmitters={[ophanTracking, gaTracking]}
+				eventEmitters={
+					renderingTarget === 'Web'
+						? [ophanTracking, gaTracking]
+						: [gaTracking]
+				}
 				format={format}
 				origin={process.env.NODE_ENV === 'development' ? '' : origin}
 				shouldStick={stickyVideos}

--- a/dotcom-rendering/src/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/layouts/CommentLayout.tsx
@@ -618,47 +618,49 @@ export const CommentLayout = (props: WebProps | AppsProps) => {
 											article.imagesForAppsLightbox
 										}
 									/>
-									{showBodyEndSlot && (
-										<Island
-											priority="feature"
-											defer={{ until: 'visible' }}
-											clientOnly={true}
-										>
-											<SlotBodyEnd
-												contentType={
-													article.contentType
-												}
-												contributionsServiceUrl={
-													contributionsServiceUrl
-												}
-												idApiUrl={
-													article.config.idApiUrl
-												}
-												isMinuteArticle={
-													article.pageType
-														.isMinuteArticle
-												}
-												isPaidContent={
-													article.pageType
-														.isPaidContent
-												}
-												keywordIds={
-													article.config.keywordIds
-												}
-												pageId={article.pageId}
-												sectionId={
-													article.config.section
-												}
-												shouldHideReaderRevenue={
-													article.shouldHideReaderRevenue
-												}
-												stage={article.config.stage}
-												tags={article.tags}
-												renderAds={renderAds}
-												isLabs={false}
-											/>
-										</Island>
-									)}
+									{renderingTarget === 'Web' &&
+										showBodyEndSlot && (
+											<Island
+												priority="feature"
+												defer={{ until: 'visible' }}
+												clientOnly={true}
+											>
+												<SlotBodyEnd
+													contentType={
+														article.contentType
+													}
+													contributionsServiceUrl={
+														contributionsServiceUrl
+													}
+													idApiUrl={
+														article.config.idApiUrl
+													}
+													isMinuteArticle={
+														article.pageType
+															.isMinuteArticle
+													}
+													isPaidContent={
+														article.pageType
+															.isPaidContent
+													}
+													keywordIds={
+														article.config
+															.keywordIds
+													}
+													pageId={article.pageId}
+													sectionId={
+														article.config.section
+													}
+													shouldHideReaderRevenue={
+														article.shouldHideReaderRevenue
+													}
+													stage={article.config.stage}
+													tags={article.tags}
+													renderAds={renderAds}
+													isLabs={false}
+												/>
+											</Island>
+										)}
 									<StraightLines
 										count={4}
 										cssOverrides={css`

--- a/dotcom-rendering/src/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/layouts/CommentLayout.tsx
@@ -282,8 +282,9 @@ export const CommentLayout = (props: WebProps | AppsProps) => {
 	} = article;
 
 	const showBodyEndSlot =
-		parse(article.slotMachineFlags ?? '').showBodyEnd ||
-		article.config.switches.slotBodyEnd;
+		renderingTarget === 'Web' &&
+		(parse(article.slotMachineFlags ?? '').showBodyEnd ||
+			article.config.switches.slotBodyEnd);
 
 	// TODO:
 	// 1) Read 'forceEpic' value from URL parameter and use it to force the slot to render
@@ -618,49 +619,47 @@ export const CommentLayout = (props: WebProps | AppsProps) => {
 											article.imagesForAppsLightbox
 										}
 									/>
-									{renderingTarget === 'Web' &&
-										showBodyEndSlot && (
-											<Island
-												priority="feature"
-												defer={{ until: 'visible' }}
-												clientOnly={true}
-											>
-												<SlotBodyEnd
-													contentType={
-														article.contentType
-													}
-													contributionsServiceUrl={
-														contributionsServiceUrl
-													}
-													idApiUrl={
-														article.config.idApiUrl
-													}
-													isMinuteArticle={
-														article.pageType
-															.isMinuteArticle
-													}
-													isPaidContent={
-														article.pageType
-															.isPaidContent
-													}
-													keywordIds={
-														article.config
-															.keywordIds
-													}
-													pageId={article.pageId}
-													sectionId={
-														article.config.section
-													}
-													shouldHideReaderRevenue={
-														article.shouldHideReaderRevenue
-													}
-													stage={article.config.stage}
-													tags={article.tags}
-													renderAds={renderAds}
-													isLabs={false}
-												/>
-											</Island>
-										)}
+									{showBodyEndSlot && (
+										<Island
+											priority="feature"
+											defer={{ until: 'visible' }}
+											clientOnly={true}
+										>
+											<SlotBodyEnd
+												contentType={
+													article.contentType
+												}
+												contributionsServiceUrl={
+													contributionsServiceUrl
+												}
+												idApiUrl={
+													article.config.idApiUrl
+												}
+												isMinuteArticle={
+													article.pageType
+														.isMinuteArticle
+												}
+												isPaidContent={
+													article.pageType
+														.isPaidContent
+												}
+												keywordIds={
+													article.config.keywordIds
+												}
+												pageId={article.pageId}
+												sectionId={
+													article.config.section
+												}
+												shouldHideReaderRevenue={
+													article.shouldHideReaderRevenue
+												}
+												stage={article.config.stage}
+												tags={article.tags}
+												renderAds={renderAds}
+												isLabs={false}
+											/>
+										</Island>
+									)}
 									<StraightLines
 										count={4}
 										cssOverrides={css`

--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -240,8 +240,9 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 	} = article;
 
 	const showBodyEndSlot =
-		parse(article.slotMachineFlags ?? '').showBodyEnd ||
-		article.config.switches.slotBodyEnd;
+		renderingTarget === 'Web' &&
+		(parse(article.slotMachineFlags ?? '').showBodyEnd ||
+			article.config.switches.slotBodyEnd);
 
 	// TODO:
 	// 1) Read 'forceEpic' value from URL parameter and use it to force the slot to render
@@ -639,48 +640,39 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 										article.imagesForAppsLightbox
 									}
 								/>
-								{renderingTarget === 'Web' &&
-									showBodyEndSlot && (
-										<Island
-											priority="feature"
-											defer={{ until: 'visible' }}
-											clientOnly={true}
-										>
-											<SlotBodyEnd
-												contentType={
-													article.contentType
-												}
-												contributionsServiceUrl={
-													contributionsServiceUrl
-												}
-												idApiUrl={
-													article.config.idApiUrl
-												}
-												isMinuteArticle={
-													article.pageType
-														.isMinuteArticle
-												}
-												isPaidContent={
-													article.pageType
-														.isPaidContent
-												}
-												keywordIds={
-													article.config.keywordIds
-												}
-												pageId={article.pageId}
-												sectionId={
-													article.config.section
-												}
-												shouldHideReaderRevenue={
-													article.shouldHideReaderRevenue
-												}
-												stage={article.config.stage}
-												tags={article.tags}
-												renderAds={renderAds}
-												isLabs={isLabs}
-											/>
-										</Island>
-									)}
+								{showBodyEndSlot && (
+									<Island
+										priority="feature"
+										defer={{ until: 'visible' }}
+										clientOnly={true}
+									>
+										<SlotBodyEnd
+											contentType={article.contentType}
+											contributionsServiceUrl={
+												contributionsServiceUrl
+											}
+											idApiUrl={article.config.idApiUrl}
+											isMinuteArticle={
+												article.pageType.isMinuteArticle
+											}
+											isPaidContent={
+												article.pageType.isPaidContent
+											}
+											keywordIds={
+												article.config.keywordIds
+											}
+											pageId={article.pageId}
+											sectionId={article.config.section}
+											shouldHideReaderRevenue={
+												article.shouldHideReaderRevenue
+											}
+											stage={article.config.stage}
+											tags={article.tags}
+											renderAds={renderAds}
+											isLabs={isLabs}
+										/>
+									</Island>
+								)}
 								<StraightLines
 									count={4}
 									color={

--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -639,39 +639,48 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 										article.imagesForAppsLightbox
 									}
 								/>
-								{showBodyEndSlot && (
-									<Island
-										priority="feature"
-										defer={{ until: 'visible' }}
-										clientOnly={true}
-									>
-										<SlotBodyEnd
-											contentType={article.contentType}
-											contributionsServiceUrl={
-												contributionsServiceUrl
-											}
-											idApiUrl={article.config.idApiUrl}
-											isMinuteArticle={
-												article.pageType.isMinuteArticle
-											}
-											isPaidContent={
-												article.pageType.isPaidContent
-											}
-											keywordIds={
-												article.config.keywordIds
-											}
-											pageId={article.pageId}
-											sectionId={article.config.section}
-											shouldHideReaderRevenue={
-												article.shouldHideReaderRevenue
-											}
-											stage={article.config.stage}
-											tags={article.tags}
-											renderAds={renderAds}
-											isLabs={isLabs}
-										/>
-									</Island>
-								)}
+								{renderingTarget === 'Web' &&
+									showBodyEndSlot && (
+										<Island
+											priority="feature"
+											defer={{ until: 'visible' }}
+											clientOnly={true}
+										>
+											<SlotBodyEnd
+												contentType={
+													article.contentType
+												}
+												contributionsServiceUrl={
+													contributionsServiceUrl
+												}
+												idApiUrl={
+													article.config.idApiUrl
+												}
+												isMinuteArticle={
+													article.pageType
+														.isMinuteArticle
+												}
+												isPaidContent={
+													article.pageType
+														.isPaidContent
+												}
+												keywordIds={
+													article.config.keywordIds
+												}
+												pageId={article.pageId}
+												sectionId={
+													article.config.section
+												}
+												shouldHideReaderRevenue={
+													article.shouldHideReaderRevenue
+												}
+												stage={article.config.stage}
+												tags={article.tags}
+												renderAds={renderAds}
+												isLabs={isLabs}
+											/>
+										</Island>
+									)}
 								<StraightLines
 									count={4}
 									color={

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -226,8 +226,9 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 	} = article;
 
 	const showBodyEndSlot =
-		parse(article.slotMachineFlags ?? '').showBodyEnd ||
-		article.config.switches.slotBodyEnd;
+		renderingTarget === 'Web' &&
+		(parse(article.slotMachineFlags ?? '').showBodyEnd ||
+			article.config.switches.slotBodyEnd);
 
 	// TODO:
 	// 1) Read 'forceEpic' value from URL parameter and use it to force the slot to render
@@ -618,48 +619,39 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 										article.imagesForAppsLightbox
 									}
 								/>
-								{renderingTarget === 'Web' &&
-									showBodyEndSlot && (
-										<Island
-											priority="feature"
-											defer={{ until: 'visible' }}
-											clientOnly={true}
-										>
-											<SlotBodyEnd
-												contentType={
-													article.contentType
-												}
-												contributionsServiceUrl={
-													contributionsServiceUrl
-												}
-												idApiUrl={
-													article.config.idApiUrl
-												}
-												isMinuteArticle={
-													article.pageType
-														.isMinuteArticle
-												}
-												isPaidContent={
-													article.pageType
-														.isPaidContent
-												}
-												keywordIds={
-													article.config.keywordIds
-												}
-												pageId={article.pageId}
-												sectionId={
-													article.config.section
-												}
-												shouldHideReaderRevenue={
-													article.shouldHideReaderRevenue
-												}
-												stage={article.config.stage}
-												tags={article.tags}
-												renderAds={renderAds}
-												isLabs={isLabs}
-											/>
-										</Island>
-									)}
+								{showBodyEndSlot && (
+									<Island
+										priority="feature"
+										defer={{ until: 'visible' }}
+										clientOnly={true}
+									>
+										<SlotBodyEnd
+											contentType={article.contentType}
+											contributionsServiceUrl={
+												contributionsServiceUrl
+											}
+											idApiUrl={article.config.idApiUrl}
+											isMinuteArticle={
+												article.pageType.isMinuteArticle
+											}
+											isPaidContent={
+												article.pageType.isPaidContent
+											}
+											keywordIds={
+												article.config.keywordIds
+											}
+											pageId={article.pageId}
+											sectionId={article.config.section}
+											shouldHideReaderRevenue={
+												article.shouldHideReaderRevenue
+											}
+											stage={article.config.stage}
+											tags={article.tags}
+											renderAds={renderAds}
+											isLabs={isLabs}
+										/>
+									</Island>
+								)}
 								<StraightLines
 									count={4}
 									color={palette.border.secondary}

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -618,39 +618,48 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 										article.imagesForAppsLightbox
 									}
 								/>
-								{showBodyEndSlot && (
-									<Island
-										priority="feature"
-										defer={{ until: 'visible' }}
-										clientOnly={true}
-									>
-										<SlotBodyEnd
-											contentType={article.contentType}
-											contributionsServiceUrl={
-												contributionsServiceUrl
-											}
-											idApiUrl={article.config.idApiUrl}
-											isMinuteArticle={
-												article.pageType.isMinuteArticle
-											}
-											isPaidContent={
-												article.pageType.isPaidContent
-											}
-											keywordIds={
-												article.config.keywordIds
-											}
-											pageId={article.pageId}
-											sectionId={article.config.section}
-											shouldHideReaderRevenue={
-												article.shouldHideReaderRevenue
-											}
-											stage={article.config.stage}
-											tags={article.tags}
-											renderAds={renderAds}
-											isLabs={isLabs}
-										/>
-									</Island>
-								)}
+								{renderingTarget === 'Web' &&
+									showBodyEndSlot && (
+										<Island
+											priority="feature"
+											defer={{ until: 'visible' }}
+											clientOnly={true}
+										>
+											<SlotBodyEnd
+												contentType={
+													article.contentType
+												}
+												contributionsServiceUrl={
+													contributionsServiceUrl
+												}
+												idApiUrl={
+													article.config.idApiUrl
+												}
+												isMinuteArticle={
+													article.pageType
+														.isMinuteArticle
+												}
+												isPaidContent={
+													article.pageType
+														.isPaidContent
+												}
+												keywordIds={
+													article.config.keywordIds
+												}
+												pageId={article.pageId}
+												sectionId={
+													article.config.section
+												}
+												shouldHideReaderRevenue={
+													article.shouldHideReaderRevenue
+												}
+												stage={article.config.stage}
+												tags={article.tags}
+												renderAds={renderAds}
+												isLabs={isLabs}
+											/>
+										</Island>
+									)}
 								<StraightLines
 									count={4}
 									color={palette.border.secondary}

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -308,9 +308,13 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 		config: { isPaidContent, host },
 	} = article;
 
+	const isWeb = renderingTarget === 'Web';
+	const isApps = renderingTarget === 'Apps';
+
 	const showBodyEndSlot =
-		parse(article.slotMachineFlags ?? '').showBodyEnd ||
-		article.config.switches.slotBodyEnd;
+		isWeb &&
+		(parse(article.slotMachineFlags ?? '').showBodyEnd ||
+			article.config.switches.slotBodyEnd);
 
 	// TODO:
 	// 1) Read 'forceEpic' value from URL parameter and use it to force the slot to render
@@ -333,9 +337,6 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 	const contributionsServiceUrl = getContributionsServiceUrl(article);
 
 	const isLabs = format.theme === ArticleSpecial.Labs;
-
-	const isWeb = renderingTarget === 'Web';
-	const isApps = renderingTarget === 'Apps';
 
 	const renderAds = isWeb && canRenderAds(article);
 
@@ -695,7 +696,7 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 									</Island>
 								)}
 
-								{isWeb && showBodyEndSlot && (
+								{showBodyEndSlot && (
 									<Island
 										priority="feature"
 										defer={{ until: 'visible' }}

--- a/dotcom-rendering/src/lib/braze/buildBrazeMessaging.ts
+++ b/dotcom-rendering/src/lib/braze/buildBrazeMessaging.ts
@@ -103,7 +103,6 @@ export const buildBrazeMessaging = async (
 		);
 
 		const sdkLoadTimeTaken = endPerformanceMeasure();
-
 		const ophan = await getOphan();
 		ophan.record({
 			component: 'braze-sdk-load-timing',

--- a/dotcom-rendering/src/lib/braze/buildBrazeMessaging.ts
+++ b/dotcom-rendering/src/lib/braze/buildBrazeMessaging.ts
@@ -103,6 +103,7 @@ export const buildBrazeMessaging = async (
 		);
 
 		const sdkLoadTimeTaken = endPerformanceMeasure();
+
 		const ophan = await getOphan();
 		ophan.record({
 			component: 'braze-sdk-load-timing',


### PR DESCRIPTION
Part of #9085 

<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

Co-authored-by: George B <705427+georgeblahblah@users.noreply.github.com>

## What does this change?

* Removes call to `recordInitialPageEvents` from `index.apps.ts`
* Removes `ophan-tracker-js` from apps bundle. 
* Renders `SlotBodyEnd` only when `renderingTarget` == "Web". We're following what [`StandardLayout`](https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/src/layouts/StandardLayout.tsx#L698-L704) does. It was missed from earlier PRs. 

TODO in following PR: Refactor so that we make sure we only call [`getOphan`](https://github.com/guardian/dotcom-rendering/blob/a42d0e5d2492b813353cd7534171a07c597970ea/dotcom-rendering/src/client/ophan/ophan.ts#L30) method when `renderingTarget` == "Web".

## Why?
DCAR should not send any tracking data to Ophan. All tracking is handled natively. 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/3f323b77-0152-4c7d-8cb8-84d07d00a4b2) | <img width="1131" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/19683595/6d245470-975c-45ab-a766-ae26dfadef56"> |
| ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/76083c3b-052b-4fb2-8bdd-6873de5b14b3) | ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/261203ab-4e62-47bc-9604-9a0d8f4106f2) |

### Web bundle still has `ophan-tracker-js` after this change

<img width="1128" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/19683595/ac2655dd-3fd3-4f06-9302-bfda047dffb6">


[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
