### PR TITLE
Adaptive site: `Metrics` is critical

### DIFF
--- a/dotcom-rendering/src/components/AllEditorialNewslettersPage.tsx
+++ b/dotcom-rendering/src/components/AllEditorialNewslettersPage.tsx
@@ -59,11 +59,7 @@ export const AllEditorialNewslettersPage = ({
 			>
 				<FocusStyles />
 			</Island>
-			<Island
-				priority="feature"
-				clientOnly={true}
-				defer={{ until: 'idle' }}
-			>
+			<Island priority="critical" clientOnly={true}>
 				<Metrics
 					commercialMetricsEnabled={
 						!!newslettersPage.config.switches.commercialMetrics

--- a/dotcom-rendering/src/components/ArticlePage.tsx
+++ b/dotcom-rendering/src/components/ArticlePage.tsx
@@ -116,11 +116,7 @@ export const ArticlePage = (props: WebProps | AppProps) => {
 					>
 						<AlreadyVisited />
 					</Island>
-					<Island
-						priority="feature"
-						clientOnly={true}
-						defer={{ until: 'idle' }}
-					>
+					<Island priority="critical" clientOnly={true}>
 						<Metrics
 							commercialMetricsEnabled={
 								!!article.config.switches.commercialMetrics

--- a/dotcom-rendering/src/components/FrontPage.tsx
+++ b/dotcom-rendering/src/components/FrontPage.tsx
@@ -71,11 +71,7 @@ export const FrontPage = ({ front, NAV }: Props) => {
 			>
 				<FocusStyles />
 			</Island>
-			<Island
-				priority="feature"
-				clientOnly={true}
-				defer={{ until: 'idle' }}
-			>
+			<Island priority="critical" clientOnly={true}>
 				<Metrics
 					commercialMetricsEnabled={
 						!!front.config.switches.commercialMetrics

--- a/dotcom-rendering/src/components/TagFrontPage.tsx
+++ b/dotcom-rendering/src/components/TagFrontPage.tsx
@@ -68,11 +68,7 @@ export const TagFrontPage = ({ tagFront, NAV }: Props) => {
 			>
 				<FocusStyles />
 			</Island>
-			<Island
-				priority="feature"
-				clientOnly={true}
-				defer={{ until: 'idle' }}
-			>
+			<Island priority="critical" clientOnly={true}>
 				<Metrics
 					commercialMetricsEnabled={
 						!!tagFront.config.switches.commercialMetrics


### PR DESCRIPTION
## What does this change?

Mark the `Metrics` island as critical.

## Why?

Otherwise we cannot gather any web vitals information when we adapt – as non-critical islands are not run!

## Screenshots

N/A
