### PR TITLE
Fix Sublinks on Supporting Content Extending Past Card Image

### DIFF
--- a/dotcom-rendering/src/components/SupportingContent.tsx
+++ b/dotcom-rendering/src/components/SupportingContent.tsx
@@ -85,7 +85,7 @@ const dynamoLiStyles = (
 	position: relative;
 	border-top: 1px solid;
 	/* 20% is arbitrary, but the cards should expand thanks for flex-grow */
-	flex: 1 0 25%;
+	flex: 1 0 20%;
 	margin: 0;
 `;
 


### PR DESCRIPTION
We set the `flex-basis` [^1] of Supporting Content sublinks to at least 25% of the container's width regardless of their content.  We also set a `5px` column gap between each item, causing them to overflow their container (because `100% < (25*4)% + (5*3)px`) and extend past the main image's right-hand border on tablet breakpoints or wider.

## Screenshots

> [!WARNING]
> The container where this bug originally appeared, and where the screenshots are taken from, features a slideshow of images from the Israel-Hamas war. Please only review the screenshots if you feel comfortable.

[Link to screenshots document](https://docs.google.com/document/d/19VQzybzByxxVT5dl1JzVmoujfeFGm02zFUMGwMoZAi8/edit?usp=sharing)

Fixes https://github.com/guardian/dotcom-rendering/issues/9131

[^1]: https://developer.mozilla.org/en-US/docs/Web/CSS/flex-basis
