### PR TITLE
Adjust topic styling

### DIFF
--- a/dotcom-rendering/src/components/SubMeta.tsx
+++ b/dotcom-rendering/src/components/SubMeta.tsx
@@ -73,7 +73,7 @@ const listStyleNone = (palette: Palette) => css`
 			transparent 36px,
 			transparent 37px,
 			${palette.background.subMeta} 37px,
-			${palette.background.subMeta} 46px
+			${palette.background.subMeta} 48px
 		),
 		repeating-linear-gradient(
 			to right,

--- a/dotcom-rendering/src/components/TrendingTopics.tsx
+++ b/dotcom-rendering/src/components/TrendingTopics.tsx
@@ -48,7 +48,7 @@ const listStyleNone = css`
 			transparent 36px,
 			transparent 37px,
 			${neutral[100]} 37px,
-			${neutral[100]} 46px
+			${neutral[100]} 48px
 		),
 		repeating-linear-gradient(
 			to right,


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Adjusts the end height of the topic / submeta backround image so that the dotted line is correctly center-aligned between rows

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/20416599/ebd9723f-2917-41ad-b019-3be83e919f4a
[after]: https://github.com/guardian/dotcom-rendering/assets/20416599/9e8c2efe-4ebe-40cf-bdd6-1df2bd1981e8

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
