### PR TITLE
CLS Fix: Update height for latest links

### DIFF
--- a/dotcom-rendering/src/components/LatestLinks.importable.tsx
+++ b/dotcom-rendering/src/components/LatestLinks.importable.tsx
@@ -22,12 +22,6 @@ type Props = {
 	containerPalette?: DCRContainerPalette;
 };
 
-const style = css`
-	display: flex;
-	gap: 5px;
-	padding-bottom: ${space[2]}px;
-`;
-
 const horizontal = css`
 	flex-direction: row;
 `;
@@ -121,21 +115,22 @@ export const LatestLinks = ({
 			: palette.neutral[86]};
 	`;
 
-	const li = [
-		linkStyles,
-		isDynamo
-			? css`
-					max-height: calc(5px + 4 * ${lineHeights.regular}em);
-			  `
-			: css`
-					max-height: calc(4 * ${lineHeights.regular}em);
-			  `,
-	];
+	const height = isDynamo
+		? `calc(5px + 4 * ${lineHeights.regular}em)`
+		: `calc(4 * ${lineHeights.regular}em)`;
+
+	const ulStyle = css`
+		display: flex;
+		gap: 5px;
+		padding-bottom: ${space[2]}px;
+		box-sizing: border-box;
+		height: ${height};
+	`;
 
 	return (
 		<ul
 			css={[
-				style,
+				ulStyle,
 				revealStyles,
 				isDynamo || direction === 'horizontal' ? horizontal : vertical,
 				css`
@@ -152,7 +147,11 @@ export const LatestLinks = ({
 								css={[dividerStyles, dividerColour]}
 							></li>
 						)}
-						<li key={block.id} css={li} className={'reveal'}>
+						<li
+							key={block.id}
+							css={linkStyles}
+							className={'reveal'}
+						>
 							<WithLink
 								linkTo={`${id}?page=with:block-${block.id}#block-${block.id}`}
 								isDynamo={isDynamo}
@@ -171,11 +170,11 @@ export const LatestLinks = ({
 				))
 			) : (
 				<>
-					<li css={li} />
+					<li css={linkStyles} />
 					<li css={[dividerStyles, transparent]} />
-					<li css={li} />
+					<li css={linkStyles} />
 					<li css={[dividerStyles, transparent]} />
-					<li css={li} />
+					<li css={linkStyles} />
 				</>
 			)}
 		</ul>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Updates latest links height, so we prevent CLS when the latest links data is loading

## Why?
We were seeing CLS when latest links were loading on a page
Resolves https://github.com/guardian/dotcom-rendering/issues/9075

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![cls-before](https://github.com/guardian/dotcom-rendering/assets/26366706/e356eca9-f6e1-437c-9760-c42d3bfd2d5f) | ![desktop-cls-after](https://github.com/guardian/dotcom-rendering/assets/26366706/4ee7beb5-10e8-4a29-b67f-a74c2aa51483) |
| ![mobile-cls-before](https://github.com/guardian/dotcom-rendering/assets/26366706/691c5e2b-562b-45c1-9bfd-ac1f91234328) | ![mobile-cls-after](https://github.com/guardian/dotcom-rendering/assets/26366706/d3ea0506-a49a-4606-9381-5945e73220ea) |
| ![snaplink-latest-cls-desktop](https://github.com/guardian/dotcom-rendering/assets/26366706/f839a034-9418-4da2-b562-eac532fafee1) |![snaplink-latest-cls-desktop-after](https://github.com/guardian/dotcom-rendering/assets/26366706/8c625405-d914-452b-91b8-6cf6d0694c37) |



<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
