### PR TITLE
Remove Google Analytics from apps articles

### DIFF
--- a/dotcom-rendering/src/client/index.apps.ts
+++ b/dotcom-rendering/src/client/index.apps.ts
@@ -21,14 +21,6 @@ void startup(
 );
 
 void startup(
-	'ga',
-	() => import(/* webpackMode: "eager" */ './ga').then(({ ga }) => ga()),
-	{
-		priority: 'critical',
-	},
-);
-
-void startup(
 	'sentryLoader',
 	() =>
 		import(/* webpackMode: "eager" */ './sentryLoader').then(


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Remove Google Analytics from the apps index file so that it does not run on apps articles rendered through DCR.

## Why?
We want to remove GA from the Apps index file, as native should be doing all the tracking on apps.

## Screenshots

| Web Article      | App Article      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/20416599/d24635f6-1ff2-470f-91f4-970620e60d7d
[after]: https://github.com/guardian/dotcom-rendering/assets/20416599/c13e55cb-2b84-4f16-a8d0-d7a7ad53b1f3


<!--


You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
