### PR TITLE
Add a test for Islands rendering on the server

### DIFF
--- a/dotcom-rendering/scripts/jest/setup.ts
+++ b/dotcom-rendering/scripts/jest/setup.ts
@@ -1,6 +1,7 @@
 // add some helpful assertions
 import '@testing-library/jest-dom/extend-expect';
 import { TextDecoder, TextEncoder } from 'node:util';
+import { isServer } from '../../src/lib/isServer';
 import type { Guardian } from '../../src/model/guardian';
 
 const windowGuardianConfig = {
@@ -66,7 +67,7 @@ const windowGuardian = {
 // We should never be able to directly set things to the global window object.
 // But in this case we want to stub things for testing, so it's ok to ignore this rule
 // @ts-expect-error
-window.guardian = windowGuardian;
+!isServer && (window.guardian = windowGuardian);
 
 // Mock Local Storage
 // See: https://github.com/facebook/jest/issues/2098#issuecomment-260733457
@@ -91,9 +92,10 @@ const localStorageMock = (function () {
 	};
 })();
 
-Object.defineProperty(window, 'localStorage', {
-	value: localStorageMock,
-});
+!isServer &&
+	Object.defineProperty(window, 'localStorage', {
+		value: localStorageMock,
+	});
 
 /**
  * This is to polyfill `TextEncoder` and `TextDecoder`.

--- a/dotcom-rendering/src/components/Island.test.tsx
+++ b/dotcom-rendering/src/components/Island.test.tsx
@@ -1,16 +1,18 @@
 /**
- * @file
- * Test that impossible prop combinations are caught by TypeScript.
- *
- * What we're really testing is that this file compiles.
- *
- * The tests themselves are not really testing anything, but because it's a
- * *.test.tsx, Jest will run it.
- *
- * The test are just there to stop Jest blowing up when it gets the compiled version.
+ * @jest-environment node
  */
 
+import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
+import { renderToString } from 'react-dom/server';
+import { CardCommentCount } from './CardCommentCount.importable';
+import { EnhancePinnedPost } from './EnhancePinnedPost.importable';
 import { Island } from './Island';
+import { OnwardsUpper } from './OnwardsUpper.importable';
+import { Snow } from './Snow.importable';
+
+// Type tests
+// Test that impossible prop combinations are caught by TypeScript.
+// What we're really testing is that this file compiles.
 
 const Mock = () => <>🏝️</>;
 
@@ -67,6 +69,58 @@ const Mock = () => <>🏝️</>;
 	</Island>
 );
 
-// this is just to stop Jest complaining about no tests
-test('this is not a real test, ignore it, it tells you nothing useful 💃', () =>
-	undefined);
+// Jest tests
+
+describe('Island: server-side rendering', () => {
+	test('CardCommentCount', () => {
+		expect(() =>
+			renderToString(
+				<CardCommentCount
+					format={{
+						theme: Pillar.News,
+						design: ArticleDesign.Standard,
+						display: ArticleDisplay.Standard,
+					}}
+					discussionApiUrl=""
+					discussionId=""
+				/>,
+			),
+		).not.toThrow();
+	});
+
+	test('EnhancePinnedPost', () => {
+		expect(() => renderToString(<EnhancePinnedPost />)).not.toThrow();
+	});
+
+	test('Snow', () => {
+		expect(() => renderToString(<Snow />)).not.toThrow();
+	});
+
+	test('OnwardsUpper', () => {
+		expect(() =>
+			renderToString(
+				<OnwardsUpper
+					contentType=""
+					tags={[]}
+					isPaidContent={false}
+					pageId=""
+					keywordIds=""
+					ajaxUrl=""
+					hasRelated={true}
+					hasStoryPackage={true}
+					isAdFreeUser={false}
+					showRelatedContent={true}
+					format={{
+						theme: Pillar.News,
+						design: ArticleDesign.Standard,
+						display: ArticleDisplay.Standard,
+					}}
+					pillar={Pillar.News}
+					editionId="UK"
+					shortUrlId=""
+					discussionApiUrl=""
+				/>,
+			),
+		).not.toThrow();
+	});
+});


### PR DESCRIPTION
## What does this change?

Add a test to ensure that Islands do not throw in a rendering on the server.

## Why?

Several Islands (`*.importable.tsx` components) cannot run in a context where `window` and `document` are `undefined`: this test ensures that we can capture all the ones that are already safe to prevent regressions.

- Split out from #8991 for easier review

## Screenshots

N/A