### PR TITLE
Make Liveness server safe

### DIFF
--- a/dotcom-rendering/src/components/Island.test.tsx
+++ b/dotcom-rendering/src/components/Island.test.tsx
@@ -7,6 +7,7 @@ import { renderToString } from 'react-dom/server';
 import { CardCommentCount } from './CardCommentCount.importable';
 import { EnhancePinnedPost } from './EnhancePinnedPost.importable';
 import { Island } from './Island';
+import { Liveness } from './Liveness.importable';
 import { OnwardsUpper } from './OnwardsUpper.importable';
 import { Snow } from './Snow.importable';
 
@@ -119,6 +120,29 @@ describe('Island: server-side rendering', () => {
 					editionId="UK"
 					shortUrlId=""
 					discussionApiUrl=""
+				/>,
+			),
+		).not.toThrow();
+	});
+
+	test('Liveness', () => {
+		expect(() =>
+			renderToString(
+				<Liveness
+					webTitle=""
+					ajaxUrl=""
+					pageId=""
+					filterKeyEvents={false}
+					format={{
+						theme: Pillar.News,
+						design: ArticleDesign.Standard,
+						display: ArticleDisplay.Standard,
+					}}
+					enhanceTweetsSwitch={false}
+					onFirstPage={true}
+					webURL=""
+					mostRecentBlockId=""
+					hasPinnedPost={false}
 				/>,
 			),
 		).not.toThrow();

--- a/dotcom-rendering/src/components/Liveness.importable.tsx
+++ b/dotcom-rendering/src/components/Liveness.importable.tsx
@@ -177,6 +177,7 @@ export const Liveness = ({
 	const [topOfBlogVisible, setTopOfBlogVisible] = useState<boolean>();
 	const [numHiddenBlocks, setNumHiddenBlocks] = useState(0);
 	const [latestBlockId, setLatestBlockId] = useState(mostRecentBlockId);
+	const [key, setKey] = useState<string>();
 
 	/**
 	 * This function runs (once) after every successful useApi call. This is useful because it
@@ -222,25 +223,36 @@ export const Liveness = ({
 		[onFirstPage, topOfBlogVisible, numHiddenBlocks, enhanceTweetsSwitch],
 	);
 
-	/**
-	 * This is a utility used by our Cypress end to end tests
-	 *
-	 * Rather than expect these scripts to depend on polling, we
-	 * expose this function to allow Cypress to manually trigger
-	 * updates with whatever html and properties it wants
-	 *
-	 */
-	window.mockLiveUpdate = onSuccess;
+	useEffect(() => {
+		/**
+		 * This is a utility used by our Cypress end to end tests
+		 *
+		 * Rather than expect these scripts to depend on polling, we
+		 * expose this function to allow Cypress to manually trigger
+		 * updates with whatever html and properties it wants
+		 *
+		 */
+		window.mockLiveUpdate = onSuccess;
+	}, [onSuccess]);
+
+	useEffect(() => {
+		setKey(
+			getKey(
+				pageId,
+				ajaxUrl,
+				latestBlockId,
+				filterKeyEvents,
+				selectedTopics,
+			),
+		);
+	}, [pageId, ajaxUrl, latestBlockId, filterKeyEvents, selectedTopics]);
 
 	// useApi returns { data, loading, error } but we're not using them here
-	useApi(
-		getKey(pageId, ajaxUrl, latestBlockId, filterKeyEvents, selectedTopics),
-		{
-			refreshInterval: 10_000,
-			refreshWhenHidden: true,
-			onSuccess,
-		},
-	);
+	useApi(key, {
+		refreshInterval: 10_000,
+		refreshWhenHidden: true,
+		onSuccess,
+	});
 
 	useEffect(() => {
 		document.title =


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

- prevent assigning `window.mockLiveUpdate` on the server
- prevent catch block of `getKey` from being run on the server, as it expects `window.guardian.modules.sentry.reportError`

## Why?

No assumption should be made about where components are run

- Split out from #8991 for easier review
- Enables the work from #8948 to proceed safely.

## Screenshots

N/A