### PR TITLE
Make `SetABTests` Island server safe

### DIFF
--- a/dotcom-rendering/src/components/Island.test.tsx
+++ b/dotcom-rendering/src/components/Island.test.tsx
@@ -9,6 +9,7 @@ import { EnhancePinnedPost } from './EnhancePinnedPost.importable';
 import { Island } from './Island';
 import { Liveness } from './Liveness.importable';
 import { OnwardsUpper } from './OnwardsUpper.importable';
+import { SetABTests } from './SetABTests.importable';
 import { Snow } from './Snow.importable';
 
 // Type tests
@@ -143,6 +144,18 @@ describe('Island: server-side rendering', () => {
 					webURL=""
 					mostRecentBlockId=""
 					hasPinnedPost={false}
+				/>,
+			),
+		).not.toThrow();
+	});
+
+	test('SetABTests', () => {
+		expect(() =>
+			renderToString(
+				<SetABTests
+					isDev={false}
+					pageIsSensitive={false}
+					abTestSwitches={{}}
 				/>,
 			),
 		).not.toThrow();

--- a/dotcom-rendering/src/components/SetABTests.importable.tsx
+++ b/dotcom-rendering/src/components/SetABTests.importable.tsx
@@ -1,6 +1,7 @@
 import { AB } from '@guardian/ab-core';
 import type { CoreAPIConfig } from '@guardian/ab-core';
 import { getCookie, log } from '@guardian/libs';
+import { useEffect } from 'react';
 import { tests } from '../experiments/ab-tests';
 import { getCypressSwitches } from '../experiments/cypress-switches';
 import { runnableTestsToParticipations } from '../experiments/lib/ab-participations';
@@ -32,47 +33,51 @@ export const SetABTests = ({
 	abTestSwitches,
 	forcedTestVariants,
 }: Props) => {
-	const mvtId = Number(
-		(isDev &&
-			getCookie({ name: 'GU_mvt_id_local', shouldMemoize: true })) || // Simplify localhost testing by creating a different mvt id
-			getCookie({ name: 'GU_mvt_id', shouldMemoize: true }),
-	);
-	if (!mvtId) {
-		// 0 is default and falsy here
-		console.log('There is no MVT ID set, see SetABTests.importable.tsx');
-	}
+	useEffect(() => {
+		const mvtId = Number(
+			(isDev &&
+				getCookie({ name: 'GU_mvt_id_local', shouldMemoize: true })) || // Simplify localhost testing by creating a different mvt id
+				getCookie({ name: 'GU_mvt_id', shouldMemoize: true }),
+		);
+		if (!mvtId) {
+			// 0 is default and falsy here
+			console.log(
+				'There is no MVT ID set, see SetABTests.importable.tsx',
+			);
+		}
 
-	// Get the forced switches to use for when running within cypress
-	// Is empty object if not in cypress
-	const cypressAbSwitches = getCypressSwitches();
+		// Get the forced switches to use for when running within cypress
+		// Is empty object if not in cypress
+		const cypressAbSwitches = getCypressSwitches();
 
-	const allForcedTestVariants = {
-		...forcedTestVariants,
-		...getForcedParticipationsFromUrl(window.location.hash),
-	};
+		const allForcedTestVariants = {
+			...forcedTestVariants,
+			...getForcedParticipationsFromUrl(window.location.hash),
+		};
 
-	const ab = new AB({
-		mvtId,
-		pageIsSensitive,
-		abTestSwitches: {
-			...abTestSwitches,
-			...cypressAbSwitches, // by adding cypress switches below CAPI, we can override any production switch in Cypress
-		},
-		arrayOfTestObjects: tests,
-		forcedTestVariants: allForcedTestVariants,
-	});
-	const allRunnableTests = ab.allRunnableTests(tests);
-	const participations = runnableTestsToParticipations(allRunnableTests);
+		const ab = new AB({
+			mvtId,
+			pageIsSensitive,
+			abTestSwitches: {
+				...abTestSwitches,
+				...cypressAbSwitches, // by adding cypress switches below CAPI, we can override any production switch in Cypress
+			},
+			arrayOfTestObjects: tests,
+			forcedTestVariants: allForcedTestVariants,
+		});
+		const allRunnableTests = ab.allRunnableTests(tests);
+		const participations = runnableTestsToParticipations(allRunnableTests);
 
-	setABTests({
-		api: ab,
-		participations,
-	});
+		setABTests({
+			api: ab,
+			participations,
+		});
 
-	ab.trackABTests(allRunnableTests);
-	ab.registerImpressionEvents(allRunnableTests);
-	ab.registerCompleteEvents(allRunnableTests);
-	log('dotcom', 'AB tests initialised');
+		ab.trackABTests(allRunnableTests);
+		ab.registerImpressionEvents(allRunnableTests);
+		ab.registerCompleteEvents(allRunnableTests);
+		log('dotcom', 'AB tests initialised');
+	}, [abTestSwitches, forcedTestVariants, isDev, pageIsSensitive]);
 
 	// we don’t render anything
 	return null;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Wrap all client-side logic in a `useEffect` hook.

Test that it will render on a server

## Why?

Components should be able to run in any context.

- Split out from #8991 to make it easier to review

## Screenshots

N/A