### PR TITLE
Fix compressed size action

### DIFF
--- a/.github/workflows/compress.yml
+++ b/.github/workflows/compress.yml
@@ -37,4 +37,4 @@ jobs:
 
           # reporting on “legacy” and “variant” bundles muddies the water
           # https://github.com/preactjs/compressed-size-action#customizing-the-list-of-files
-          pattern: "dotcom-rendering/dist/*.modern.*.js"
+          pattern: "dotcom-rendering/dist/*.web.*.js"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Adjust the pattern of `dist` output

## Why?

It was broken in #8649

## Screenshots

N/A

(See recent empty reports in any PR)