### PR TITLE
Migrate Timeline atom from atoms-rendering

### DIFF
--- a/dotcom-rendering/fixtures/manual/timelineAtom.tsx
+++ b/dotcom-rendering/fixtures/manual/timelineAtom.tsx
@@ -1,0 +1,357 @@
+import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
+
+const format: ArticleFormat = {
+	display: ArticleDisplay.Standard,
+	design: ArticleDesign.Standard,
+	theme: Pillar.News,
+};
+
+const NewsEvents = [
+	{
+		title: '',
+		date: '1999',
+		body: '<p>In the early 90s, <b>Ghislaine Maxwell</b>, the daughter of British media tycoon Robert Maxwell, met investment banker and financier <b>Jeffrey Epstein</b>. Their relationship was initially romantic, but it evolved into something more akin to that of Maxwell being a close friend, confidante and personal assistant.&nbsp;</p><p>The Duke of York, <b>Prince Andrew</b>, was reportedly introduced to Epstein through their mutual friend Maxwell in 1999, and Epstein reportedly visited <b>the Queen</b>’s private retreat\nin Aberdeenshire.</p><p>Some have suggested the introduction was made earlier. A 2011&nbsp;<a href="https://www.itv.com/news/2019-11-20/prince-andrew-and-jeffrey-epstein-met-in-early-1990s-not-1999-as-claimed-in-interview/">letter to the Times of London</a>&nbsp;from the prince’s then private secretary, Alastair Watson, suggests Andrew and Epstein knew each other from the early 90s.</p>',
+		unixDate: 915148800000,
+	},
+	{
+		title: '',
+		date: '2000',
+		body: '<p>\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\nAndrew, Maxwell and Epstein are seen together at <b>Donald\nTrump</b>’s Mar-a-Lago club in Florida. Later that year, Epstein and Maxwell\nattend a joint birthday party at Windsor Castle hosted by the Queen.</p>',
+		unixDate: 946684800000,
+	},
+	{
+		title: '',
+		date: '2001',
+		body: '<p>Andrew and Epstein holiday together and are pictured on a yacht in Phuket, Thailand,&nbsp;<a href="https://www.thetimes.co.uk/article/andrew-relaxes-on-epsteins-yacht-after-hard-year-on-holiday-5qjz0nh0rkz">surrounded by topless women</a>. The Times of London reported the prince’s holiday was paid for by Epstein.</p><p>In the same year, <b>Virginia Giuffre</b>, then 17, claims to have had sex\nwith Andrew in Maxwell’s home in Belgravia, London. Giuffre, whose surname was \nRoberts at the time of the alleged incidents, says she slept with Andrew\n twice more, at Epstein’s\nNew York home and at an “orgy” on his private island in the Caribbean.</p>',
+		unixDate: 978307200000,
+	},
+	{
+		title: '',
+		date: '2008',
+		body: '<p>\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\nEpstein is jailed for 18 months by a Florida&nbsp;state court after pleading guilty to\nprostituting minors.</p>',
+		unixDate: 1199145600000,
+	},
+	{
+		title: '',
+		date: '2010',
+		body: '<p>\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\nSoon after his release, Epstein is visited by\nAndrew in New York. The pair are photographed together in Central Park. Footage\nemerges years later, reportedly shot on 6 December, that appears to show Andrew\ninside Epstein’s Manhattan mansion waving goodbye to a woman from behind a door.</p>',
+		unixDate: 1262304000000,
+	},
+	{
+		title: '',
+		date: '2011',
+		body: '<p>\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\nAndrew quits his role as UK trade envoy following a\nfurore over the Central Park photos.</p>',
+		unixDate: 1293840000000,
+	},
+	{
+		title: '',
+		date: '2015',
+		body: '<p>\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\nAllegations that Andrew had sex with Giuffre emerge\nin court documents in Florida related to Epstein. The papers say she was forced to have sex with Andrew when she was 17, which is under the\nage of consent under Florida law. Buckingham Palace denies the allegations. The claims against Andrew are later struck from US civil\ncourt records following a federal judge’s ruling.</p>',
+		unixDate: 1420070400000,
+	},
+	{
+		title: '',
+		date: '2019',
+		body: "<p>Andrew is accused of sexual\nimpropriety by a second alleged Epstein victim, <b>Johanna Sjoberg</b>. She claims he\ntouched her breast at the billionaire’s Manhattan apartment in 2001.\nBuckingham Palace says the allegations are 'categorically untrue'.</p>",
+		unixDate: 1546300800000,
+	},
+	{
+		title: ' ',
+		date: '10 August 2019',
+		body: '<p>Epstein is found dead in his jail cell after being re-arrested and charged with sex trafficking. <a href="https://www.theguardian.com/us-news/2019/aug/16/jeffrey-epstein-cause-of-death-coroner-report">A medical examiner says the death was a suicide</a>.</p><p>A pilot on Epstein’s private jet later that month claims Andrew was a passenger on past flights with the financier and Giuffre.</p>',
+		unixDate: 1565395200000,
+	},
+	{
+		title: ' ',
+		date: 'November 2019',
+		body: '<p>Andrew takes part in a disastrous BBC TV interview during which he claims he could not have had&nbsp;<a href="https://www.theguardian.com/uk-news/2019/sep/20/prince-andrew-abuser-claims-virginia-giuffre-tv-interview">sex with Giuffre</a>&nbsp;because he was at home after&nbsp;<a href="https://www.theguardian.com/uk-news/2019/nov/17/wokings-pizza-express-customers-struggle-to-remember-first-visit">a visit to Pizza Express in Woking</a>, and that her description of his dancing with her beforehand could not be true because he was unable to sweat, and that he had "no recollection of ever meeting this lady". After several days of negative reaction, Andrew announces he is to step back from public duties \'for the foreseeable future\'.</p>',
+		unixDate: 1574208000000,
+	},
+	{
+		title: ' ',
+		date: '27 January 2020',
+		body: "<p>US prosecutor <b>Geoffrey Berman</b> gives a public statement suggesting there has been 'zero cooperation' with the investigation from Andrew.</p>",
+		unixDate: 1580083200000,
+	},
+	{
+		title: ' ',
+		date: '9 June 2020',
+		body: "<p>After Berman again claims the prince has 'completely shut the door' on cooperating with the US investigation in March, lawyers for Andrew insist he has repeatedly offered to cooperate and accuse US prosecutors of misleading the public and breaching confidentiality.</p>",
+		unixDate: 1591632988000,
+	},
+	{
+		title: ' ',
+		date: 'July 2020',
+		body: '<p>Maxwell, who has seldom been seen in public in recent years, is <a href="https://www.theguardian.com/us-news/2020/jul/02/ghislaine-maxwell-arrest-jeffrey-epstein-charges-latest-fbi">arrested by the FBI</a>&nbsp;on charges related to Epstein. Unsealed testimony from a 2015 civil case reveal a series of claims about her role in Epstein sex-trafficking ring, including allegations that she <a href="https://www.theguardian.com/us-news/2020/jul/31/ghislaine-maxwell-underage-girls-sex-jeffrey-epstein">trained underage girls as sex slaves</a>.</p>',
+		unixDate: 1593706442000,
+	},
+];
+
+const SportEvents = [
+	{
+		title: ' First Grand Tour win',
+		date: 'September 2011',
+		body: '<p>Froome outshines his team leader, Bradley Wiggins, to finish second at the 2011 Vuelta. He is later upgraded to first place after the original winner, Juan José Cobo, was disqualified for drug offences</p>',
+		unixDate: 1315526400000,
+	},
+	{
+		title: ' Tour de France breakthrough',
+		date: 'July 2013',
+		body: '<p>Froome came second to Wiggins at the 2012 Tour but was the team leader at the next edition, where a memorable surge up Mont Ventoux leads him to his first Tour de France title</p>',
+		unixDate: 1373155200000,
+	},
+	{
+		title: 'Hat-trick of Tour titles',
+		date: 'July 2016',
+		body: '<p>After crashing out early in 2014, Froome bounces back to win the 2015 edition after a battle through the mountains with Nairo Quintana. Froome defends his title in all-action style in 2016, even running a few yards up Ventoux when his bike is damaged</p>',
+		unixDate: 1467849600000,
+	},
+	{
+		title: 'Tour-Vuelta double',
+		date: 'September 2017',
+		body: '<p>Froome wins his fourth Tour de France, and third in succession, in 2017 and follows it up with a second Vuelta title. He becomes the first rider from outside France to win the Tour and Vuelta back-to-back</p>',
+		unixDate: 1504915200000,
+	},
+	{
+		title: ' Giro win completes collection',
+		date: 'June 2018',
+		body: '<p>Froome gets the better of Simon Yates in a spectacular ride on the Colle delle Finestre to win his first Giro and complete his Grand Tour collection. At the 2018 Tour, he ends up working to lead his teammate, Geraint Thomas, to overall victory</p>',
+		unixDate: 1528243200000,
+	},
+];
+
+const DateToEvents = [
+	{
+		title: ' ',
+		date: 'June 2010',
+		body: '<p>WikiLeaks releases about 470,000 classified military documents concerning American diplomacy and the wars in Afghanistan and Iraq. It later releases a further tranche of more than 250,000 classified US diplomatic cables.</p>',
+		toDate: 'October 2010',
+		unixDate: 1275350400000,
+		toUnixDate: 1285891200000,
+	},
+	{
+		title: ' ',
+		date: 'November 2010',
+		body: '<p>A Swedish prosecutor issues a European arrest warrant for Assange over sexual assault allegations involving two Swedish women. Assange denies the claims.</p>',
+		toDate: 'December 2010',
+		unixDate: 1288569600000,
+		toUnixDate: 1291680000000,
+	},
+	{
+		title: ' ',
+		date: 'December 2010',
+		body: '<p><a href="https://www.theguardian.com/news/blog/2010/dec/07/wikileaks-us-embassy-cables-live-updates">He turns himself in to police in London</a> and is placed in custody. He is later released on bail and calls the Swedish allegations a smear campaign.</p>',
+		toDate: 'February 2011',
+		unixDate: 1291680000000,
+		toUnixDate: 1296518400000,
+	},
+	{
+		title: ' ',
+		date: 'February 2011',
+		body: '<p>A British judge rules that Assange can be extradited to Sweden. Assange fears Sweden will hand him over to US authorities who could prosecute him.</p>',
+		toDate: 'June 2012',
+		unixDate: 1296518400000,
+		toUnixDate: 1340064000000,
+	},
+	{
+		title: ' ',
+		date: 'June 2012',
+		body: '<p><a href="https://www.theguardian.com/media/2012/jun/19/julian-assange-wikileaks-asylum-ecuador">He takes refuge in the Ecuadorian embassy</a> in London. He requests, and is later granted, political asylum.</p>',
+		toDate: 'November 2016',
+		unixDate: 1340064000000,
+		toUnixDate: 1479081600000,
+	},
+	{
+		title: ' ',
+		date: 'November 2016',
+		body: '<p>Assange&nbsp;<a href="https://www.theguardian.com/media/2016/nov/14/julian-assange-to-face-swedish-prosecutors-over-accusation">is questioned</a>&nbsp;in a two-day interview over the allegations at the Ecuadorian embassy by Swedish authorities.</p>',
+		toDate: 'January 2017',
+		unixDate: 1479081600000,
+		toUnixDate: 1479081600000,
+	},
+	{
+		title: ' ',
+		date: 'January 2017',
+		body: "<p>WikiLeaks says <a href=\"https://www.theguardian.com/media/2017/jan/19/julian-assange-confirms-he-is-willing-to-travel-to-us-after-manning-decision\">Assange could travel to the United States to face investigation</a> if his rights are 'guaranteed'. It comes after one of the site's main sources of leaked documents, Chelsea Manning, is given clemency.</p>",
+		toDate: 'May 2017',
+		unixDate: 1484784000000,
+		toUnixDate: 1495152000000,
+	},
+	{
+		title: ' ',
+		date: 'May 2017',
+		body: '<p>Swedish prosecutors say they have <a href="https://www.theguardian.com/media/2017/may/19/julian-assange-signals-he-will-stay-in-ecuadorian-embassy">closed their seven-year sex assault investigation into Assange</a>. British police say they would still arrest him if he leaves the embassy as he breached the terms of his bail in 2012.</p>',
+		toDate: 'January 2018',
+		unixDate: 1495152000000,
+		toUnixDate: 1515628800000,
+	},
+	{
+		title: ' ',
+		date: 'January 2018',
+		body: "<p>Britain refuses Ecuador's request to accord Assange diplomatic status, which would allow him to leave the embassy without being arrested.</p>",
+		toDate: 'February 2018',
+		unixDate: 1515628800000,
+		toUnixDate: 1518480000000,
+	},
+	{
+		title: ' ',
+		date: 'February 2018',
+		body: '<p><a href="https://www.theguardian.com/media/2018/feb/13/judge-refuses-to-withdraw-julian-assange-arrest-warrant">He loses a bid to have his British arrest warrant cancelled</a> on health grounds.</p>',
+		toDate: 'March 2018',
+		unixDate: 1518480000000,
+		toUnixDate: 1522195200000,
+	},
+	{
+		title: ' ',
+		date: 'March 2018',
+		body: '<p><a href="https://www.theguardian.com/media/2018/mar/28/julian-assange-internet-connection-ecuador-embassy-cut-off-wikileaks">Ecuador cuts off Assange\'s internet access</a> alleging he broke an agreement on interfering in other countries\' affairs.</p>',
+		toDate: 'November 2018',
+		unixDate: 1522195200000,
+		toUnixDate: 1542326400000,
+	},
+	{
+		title: ' ',
+		date: 'November 2018',
+		body: '<p>US prosecutors inadvertently disclose <a href="https://www.theguardian.com/media/2018/nov/16/julian-assange-charged-in-secret-mistake-on-us-court-filing-suggests">the existence of a sealed indictment against Assange</a>.</p>',
+		toDate: '2 April 2019',
+		unixDate: 1542326400000,
+		toUnixDate: 1554163200000,
+	},
+	{
+		title: ' ',
+		date: '2 April 2019',
+		body: "<p>Ecuador's President Lenin Moreno says Assange has <a href=\"https://www.theguardian.com/world/2019/apr/02/julian-assange-wikileaks-asylum-ecuador-violated\">'repeatedly violated' the conditions of his asylum</a> at the embassy.</p>",
+		toDate: '11 April 2019',
+		unixDate: 1554163200000,
+		toUnixDate: 1554977694000,
+	},
+	{
+		title: ' ',
+		date: '11 April 2019',
+		body: '<p><a href="https://www.theguardian.com/uk-news/2019/apr/11/julian-assange-arrested-at-ecuadorian-embassy-wikileaks">Police arrest Assange at the embassy</a>&nbsp;on behalf of the US after his asylum was withdrawn. He is charged by the US with \'a federal charge of conspiracy to commit computer intrusion for agreeing to break a password to a classified U.S. government computer.\'</p>',
+		toDate: '1 May 2019',
+		unixDate: 1554977694000,
+		toUnixDate: 1556717256000,
+	},
+	{
+		title: ' ',
+		date: '1 May 2019',
+		body: '<p><a href="https://www.theguardian.com/media/2019/may/01/julian-assange-jailed-for-50-weeks-for-breaching-bail-in-2012">He is jailed for 50 weeks</a>&nbsp;in the UK for breaching his bail conditions back in 2012. An apology letter from Assange is read out in court, but the judge rules that he had engaged in a \'deliberate attempt to evade justice\'. On the following day <a href="https://www.theguardian.com/media/2019/may/02/us-begins-extradition-case-against-julian-assange-in-london">the US extradition proceedings were formally started</a>.&nbsp;</p>',
+		toDate: '13 May 2019',
+		unixDate: 1556717256000,
+		toUnixDate: 1557738992000,
+	},
+	{
+		title: ' ',
+		date: '13 May 2019',
+		body: '<p>Swedish prosecutors announce they are <a href="https://www.theguardian.com/media/2019/may/13/sweden-reopens-case-against-julian-assange">reopening an investigation into a rape allegation</a> against Julian Assange.</p><p><br></p>',
+		toDate: '13 June 2019',
+		unixDate: 1557738992000,
+		toUnixDate: 1560414280000,
+	},
+	{
+		title: ' ',
+		date: '13 June 2019',
+		body: '<p>Home secretary Sajid Javid reveals he has <a href="https://www.theguardian.com/media/2019/jun/13/julian-assange-sajid-javid-signs-us-extradition-order">signed the US extradition order for Assange</a> paving the way for it to be heard in court.</p>',
+		toDate: '24 February 2020',
+		unixDate: 1560414280000,
+		toUnixDate: 1582502400000,
+	},
+	{
+		title: ' ',
+		date: '24 February 2020',
+		body: '<p>Assange\'s <a href="https://www.theguardian.com/uk-news/2020/feb/24/julian-assange-hearing-journalism-is-no-excuse-for-breaking-law">extradition hearing begins</a> at Woolwich crown court in south-east London. After a week of opening arguments, the extradition case is to \nbe adjourned until May. Further delays are caused by the coronavirus outbreak.</p>',
+		toDate: '15 September 2020',
+		unixDate: 1582502400000,
+		toUnixDate: 1600150732000,
+	},
+	{
+		title: ' ',
+		date: '15 September 2020',
+		body: '<p>A hearing scheduled for four weeks <a href="https://www.theguardian.com/media/2020/sep/07/julian-assange-due-court-latest-stage-fight-against-us-extradition">begins at the Old Bailey</a> with the US government expected to make their case that Assange tried to recruit hackers to find classified government information. If the courts approve extradition, the British government will still have the final say.</p>',
+		toDate: '1 October 2020',
+		unixDate: 160150732000,
+		toUnixDate: 1601510400000,
+	},
+	{
+		title: ' ',
+		date: '1 October 2020',
+		body: '<p>Judge Vanessa Baraitser adjourns the case.</p>',
+		toDate: '26 November 2020',
+		unixDate: 1601510400000,
+		toUnixDate: 1606348800000,
+	},
+	{
+		title: ' ',
+		date: '26 November 2020',
+		body: '<p>Stella Moris urges Donald Trump to pardon Assange before he leaves office.</p>',
+		toDate: '4 January 2020',
+		unixDate: 1606348800000,
+		toUnixDate: 1609718400000,
+	},
+	{
+		title: ' ',
+		date: '4 January 2021',
+		body: '<p>A British judge rules that Assange cannot be extradited to the US. The US has 15 days to appeal against the judgment.</p>',
+		unixDate: 1609718400000,
+	},
+];
+
+export const noTimelineEventsStoryExpanded = {
+	id: '9704dbd0-0273-49d2-8425-c58ccf9a1951',
+	description:
+		'<p><b>January 2015</b></p><p>Hamilton, a new musical written by and starring <a href="https://www.theguardian.com/stage/2016/sep/25/lin-manuel-miranda-broadway-smash-hamilton-hip-hop-musical-school-of-eminem">Lin-Manuel Miranda</a>, has its first performances off-Broadway at the Public theater in New York. Its subject is the US founding father who was the first secretary of the Treasury.&nbsp;</p><p><b>February 2015</b><br></p><p>As the show opens officially, it wins praise from critics, particularly for its innovative blend of musical styles, from rap to operetta. In her <a href="https://www.theguardian.com/stage/2015/feb/18/hamilton-review-founding-father-gets-a-hip-hop-makeover">four-star review</a>, the Guardian’s Alexis Soloski calls the show "brash, nimble, historically engaged and startlingly contemporary".</p><p><b>August 2015</b><br></p><p>After selling out its run at the Public, the show opens on Broadway at the Richard Rodgers theatre and there is huge demand for tickets.</p><p><b>February 2016</b><br></p><p>The original Broadway cast recording wins a Grammy award for best musical theatre album.</p><p><b>March 2016</b><br></p><p>Miranda visits the White House to perform songs from the musical and a <a href="https://www.theguardian.com/stage/video/2016/mar/15/hamilton-star-freestyle-raps-with-obama-at-the-white-house-video">video of him freestyling</a> in the Rose Garden with President Barack Obama goes viral. First lady Michelle Obama calls the show “the best piece of art in any form that I have ever seen in my life”.</p><p><b>April 2016</b><br></p><p>Hamilton wins the Pulitzer prize for drama.</p><p><b>June 2016</b>&nbsp;<br></p><p>The musical breaks records, winning 11 Tony awards – at a ceremony that takes place after news breaks of a mass shooting in Orlando, Florida. Miranda performs a sonnet in praise of his wife and son, ending with the words: “Now fill the world with music, love and pride.”</p><p><b>July 2016</b><br></p><p>Miranda stops performing in the show to pursue other opportunities, including starring in a sequel to Mary Poppins. A spoof version of the musical, Spamilton, opens in New York.</p><p><b>&nbsp;October 2016</b></p><p>A production of Hamilton opens in Chicago and runs concurrently with the Broadway version.</p><p><b>November 2016</b><br></p><p>Vice-president-elect <a href="https://www.theguardian.com/us-news/video/2016/nov/19/mike-pence-told-at-hamilton-we-are-anxious-you-will-not-protect-us-video">Mike Pence</a> sees the show in New York. From the stage, actor Brandon Victor Dixon addresses him directly, saying: “We are the diverse America who are alarmed and anxious that your new administration will not protect us.” On Twitter, Donald Trump condemns their “terrible behaviour” and says he hears the show is “highly overrated”.<br></p><p><b>January 2017</b><br></p><p>The first cast members are revealed for a West End production of Hamilton.&nbsp;</p><p><b>December 2017</b><br></p><p>The show opens to five-star reviews at the newly renovated Victoria Palace theatre in London.</p><p><b>March 2018</b></p><p>The London production of Hamilton gets 13 Olivier nominations, making it the most nominated show in the history of the awards.</p><p><b>July 2020</b></p><p>A filmed version of the Broadway production debuts on the Disney+ streaming service, warmly welcomed while the world is still in lockdown over the coronavirus crisis.&nbsp;</p>',
+	title: 'How Hamilton the Musical became a smash hit',
+	format: { ...format, theme: Pillar.News },
+	expandForStorybook: true,
+	likeHandler: (): null => null,
+	dislikeHandler: (): null => null,
+	expandCallback: (): null => null,
+};
+
+// Non-expanded version for Cypress, it fails if the atom loads already expanded
+export const noTimelineEventsStory = {
+	id: '9704dbd0-0273-49d2-8425-c58ccf9a1951',
+	description:
+		'<p><b>January 2015</b></p><p>Hamilton, a new musical written by and starring <a href="https://www.theguardian.com/stage/2016/sep/25/lin-manuel-miranda-broadway-smash-hamilton-hip-hop-musical-school-of-eminem">Lin-Manuel Miranda</a>, has its first performances off-Broadway at the Public theater in New York. Its subject is the US founding father who was the first secretary of the Treasury.&nbsp;</p><p><b>February 2015</b><br></p><p>As the show opens officially, it wins praise from critics, particularly for its innovative blend of musical styles, from rap to operetta. In her <a href="https://www.theguardian.com/stage/2015/feb/18/hamilton-review-founding-father-gets-a-hip-hop-makeover">four-star review</a>, the Guardian’s Alexis Soloski calls the show "brash, nimble, historically engaged and startlingly contemporary".</p><p><b>August 2015</b><br></p><p>After selling out its run at the Public, the show opens on Broadway at the Richard Rodgers theatre and there is huge demand for tickets.</p><p><b>February 2016</b><br></p><p>The original Broadway cast recording wins a Grammy award for best musical theatre album.</p><p><b>March 2016</b><br></p><p>Miranda visits the White House to perform songs from the musical and a <a href="https://www.theguardian.com/stage/video/2016/mar/15/hamilton-star-freestyle-raps-with-obama-at-the-white-house-video">video of him freestyling</a> in the Rose Garden with President Barack Obama goes viral. First lady Michelle Obama calls the show “the best piece of art in any form that I have ever seen in my life”.</p><p><b>April 2016</b><br></p><p>Hamilton wins the Pulitzer prize for drama.</p><p><b>June 2016</b>&nbsp;<br></p><p>The musical breaks records, winning 11 Tony awards – at a ceremony that takes place after news breaks of a mass shooting in Orlando, Florida. Miranda performs a sonnet in praise of his wife and son, ending with the words: “Now fill the world with music, love and pride.”</p><p><b>July 2016</b><br></p><p>Miranda stops performing in the show to pursue other opportunities, including starring in a sequel to Mary Poppins. A spoof version of the musical, Spamilton, opens in New York.</p><p><b>&nbsp;October 2016</b></p><p>A production of Hamilton opens in Chicago and runs concurrently with the Broadway version.</p><p><b>November 2016</b><br></p><p>Vice-president-elect <a href="https://www.theguardian.com/us-news/video/2016/nov/19/mike-pence-told-at-hamilton-we-are-anxious-you-will-not-protect-us-video">Mike Pence</a> sees the show in New York. From the stage, actor Brandon Victor Dixon addresses him directly, saying: “We are the diverse America who are alarmed and anxious that your new administration will not protect us.” On Twitter, Donald Trump condemns their “terrible behaviour” and says he hears the show is “highly overrated”.<br></p><p><b>January 2017</b><br></p><p>The first cast members are revealed for a West End production of Hamilton.&nbsp;</p><p><b>December 2017</b><br></p><p>The show opens to five-star reviews at the newly renovated Victoria Palace theatre in London.</p><p><b>March 2018</b></p><p>The London production of Hamilton gets 13 Olivier nominations, making it the most nominated show in the history of the awards.</p><p><b>July 2020</b></p><p>A filmed version of the Broadway production debuts on the Disney+ streaming service, warmly welcomed while the world is still in lockdown over the coronavirus crisis.&nbsp;</p>',
+	title: 'How Hamilton the Musical became a smash hit',
+	format: { ...format, theme: Pillar.Culture },
+	likeHandler: (): null => null,
+	dislikeHandler: (): null => null,
+	expandCallback: (): null => null,
+};
+
+export const newsTimelineStoryNoDescriptionExpanded = {
+	id: 'a10c1968-908d-4ec5-86ef-05b45468c0de',
+	title: 'Jeffrey Epstein, Ghislaine Maxwell and Prince Andrew',
+	format: { ...format, theme: Pillar.News },
+	events: NewsEvents,
+	expandForStorybook: true,
+	likeHandler: (): null => null,
+	dislikeHandler: (): null => null,
+	expandCallback: (): null => null,
+};
+
+export const sportTimelineStoryWithDescriptionAndEventsExpanded = {
+	id: '15418150-6d0c-4bd1-86a2-be894e5fe928',
+	title: "Froome's golden decade with Team Sky",
+	format: { ...format, theme: Pillar.Sport },
+	description:
+		'<p><i>Chris Froome has won seven Grand Tours since joining Team Sky in 2010</i></p>',
+	events: SportEvents,
+	expandForStorybook: true,
+	likeHandler: (): null => null,
+	dislikeHandler: (): null => null,
+	expandCallback: (): null => null,
+};
+
+export const newsStoryWithDatesToExpanded = {
+	id: 'd7cdd1bd-7b85-4ad0-8368-3fb0d5b20593',
+	title: 'Julian Assange extradition battle',
+	format: { ...format, theme: Pillar.News },
+	events: DateToEvents,
+	expandForStorybook: true,
+	likeHandler: (): null => null,
+	dislikeHandler: (): null => null,
+	expandCallback: (): null => null,
+};

--- a/dotcom-rendering/src/components/TimelineAtom.importable.tsx
+++ b/dotcom-rendering/src/components/TimelineAtom.importable.tsx
@@ -1,11 +1,5 @@
 import { css } from '@emotion/react';
-import {
-	body,
-	brandAlt,
-	neutral,
-	remSpace,
-	space,
-} from '@guardian/source-foundations';
+import { body, palette, remSpace, space } from '@guardian/source-foundations';
 import { submitComponentEvent } from '../client/ophan/ophan';
 import type { TimelineAtomType, TimelineEvent } from '../types/content';
 import { Body } from './ExpandableAtom/Body';
@@ -14,7 +8,7 @@ import { Footer } from './ExpandableAtom/Footer';
 
 const Snippet = css`
 	:not(:last-child) {
-		border-left: 0.0625rem solid ${neutral[60]};
+		border-left: 0.0625rem solid ${palette.neutral[60]};
 		padding-bottom: ${remSpace[4]};
 	}
 	padding-left: ${space[4]}px;
@@ -36,7 +30,7 @@ const EventDateBullet = css`
 	float: left;
 	position: relative;
 	left: -24px;
-	background-color: #121212;
+	background-color: ${palette.neutral[7]};
 `;
 
 const EventDate = css`
@@ -44,7 +38,7 @@ const EventDate = css`
 		${EventDateBullet}
 	}
 	margin-left: -16px;
-	background: ${brandAlt[400]};
+	background: ${palette.brandAlt[400]};
 	${body.medium({
 		lineHeight: 'tight',
 		fontWeight: 'bold',
@@ -52,7 +46,7 @@ const EventDate = css`
 `;
 
 const EventToDate = css`
-	background: ${brandAlt[400]};
+	background: ${palette.brandAlt[400]};
 	${body.medium({
 		lineHeight: 'tight',
 		fontWeight: 'bold',

--- a/dotcom-rendering/src/components/TimelineAtom.importable.tsx
+++ b/dotcom-rendering/src/components/TimelineAtom.importable.tsx
@@ -1,0 +1,172 @@
+import { css } from '@emotion/react';
+import {
+	body,
+	brandAlt,
+	neutral,
+	remSpace,
+	space,
+} from '@guardian/source-foundations';
+import { submitComponentEvent } from '../client/ophan/ophan';
+import type { TimelineAtomType, TimelineEvent } from '../types/content';
+import { Body } from './ExpandableAtom/Body';
+import { Container } from './ExpandableAtom/Container';
+import { Footer } from './ExpandableAtom/Footer';
+
+const Snippet = css`
+	:not(:last-child) {
+		border-left: 0.0625rem solid ${neutral[60]};
+		padding-bottom: ${remSpace[4]};
+	}
+	padding-left: ${space[4]}px;
+	margin-left: ${space[2]}px;
+`;
+
+const EventTitle = css`
+	${body.medium({
+		lineHeight: 'tight',
+		fontWeight: 'bold',
+	})};
+`;
+
+const EventDateBullet = css`
+	content: '';
+	width: ${space[4]}px;
+	height: ${space[4]}px;
+	border-radius: 100%;
+	float: left;
+	position: relative;
+	left: -24px;
+	background-color: #121212;
+`;
+
+const EventDate = css`
+	::before {
+		${EventDateBullet}
+	}
+	margin-left: -16px;
+	background: ${brandAlt[400]};
+	${body.medium({
+		lineHeight: 'tight',
+		fontWeight: 'bold',
+	})};
+`;
+
+const EventToDate = css`
+	background: ${brandAlt[400]};
+	${body.medium({
+		lineHeight: 'tight',
+		fontWeight: 'bold',
+	})};
+`;
+
+const TimelineContents = ({
+	events,
+	format,
+}: {
+	events: TimelineEvent[];
+	format: ArticleFormat;
+}): JSX.Element => {
+	return (
+		<div>
+			{events.map((event, index) => {
+				const time = new Date(event.unixDate).toISOString();
+				const toTime =
+					event.toUnixDate !== undefined
+						? new Date(event.toUnixDate).toISOString()
+						: '';
+				return (
+					<div key={index} data-type="event-snippet" css={Snippet}>
+						<div>
+							<time dateTime={time} css={EventDate}>
+								{event.date}
+							</time>
+							{!!event.toDate && (
+								<span>
+									{' '}
+									-{' '}
+									<time dateTime={toTime} css={EventToDate}>
+										{event.toDate}
+									</time>
+								</span>
+							)}
+						</div>
+						{!!event.title && (
+							<div css={EventTitle}>{event.title}</div>
+						)}
+						{!!event.body && (
+							<Body html={event.body} format={format} />
+						)}
+					</div>
+				);
+			})}
+		</div>
+	);
+};
+
+export const TimelineAtom = ({
+	id,
+	events,
+	description,
+	title,
+	format,
+	expandForStorybook,
+	likeHandler,
+	dislikeHandler,
+	expandCallback,
+}: TimelineAtomType): JSX.Element => {
+	return (
+		<Container
+			atomType="timeline"
+			atomTypeTitle="Timeline"
+			id={id}
+			format={format}
+			expandForStorybook={expandForStorybook}
+			title={title}
+			expandCallback={
+				expandCallback ??
+				(() =>
+					submitComponentEvent({
+						component: {
+							componentType: 'TIMELINE_ATOM',
+							id,
+							products: [],
+							labels: [],
+						},
+						action: 'EXPAND',
+					}))
+			}
+		>
+			{!!description && <Body html={description} format={format} />}
+			{events && <TimelineContents events={events} format={format} />}
+			<Footer
+				format={format}
+				dislikeHandler={
+					dislikeHandler ??
+					(() =>
+						submitComponentEvent({
+							component: {
+								componentType: 'TIMELINE_ATOM',
+								id,
+								products: [],
+								labels: [],
+							},
+							action: 'DISLIKE',
+						}))
+				}
+				likeHandler={
+					likeHandler ??
+					(() =>
+						submitComponentEvent({
+							component: {
+								componentType: 'TIMELINE_ATOM',
+								id,
+								products: [],
+								labels: [],
+							},
+							action: 'LIKE',
+						}))
+				}
+			/>
+		</Container>
+	);
+};

--- a/dotcom-rendering/src/components/TimelineAtom.importable.tsx
+++ b/dotcom-rendering/src/components/TimelineAtom.importable.tsx
@@ -59,7 +59,7 @@ const TimelineContents = ({
 }: {
 	events: TimelineEvent[];
 	format: ArticleFormat;
-}): JSX.Element => {
+}) => {
 	return (
 		<div>
 			{events.map((event, index) => {
@@ -107,7 +107,7 @@ export const TimelineAtom = ({
 	likeHandler,
 	dislikeHandler,
 	expandCallback,
-}: TimelineAtomType): JSX.Element => {
+}: TimelineAtomType) => {
 	return (
 		<Container
 			atomType="timeline"

--- a/dotcom-rendering/src/components/TimelineAtom.stories.tsx
+++ b/dotcom-rendering/src/components/TimelineAtom.stories.tsx
@@ -1,0 +1,37 @@
+import {
+	newsStoryWithDatesToExpanded,
+	newsTimelineStoryNoDescriptionExpanded,
+	noTimelineEventsStoryExpanded,
+	sportTimelineStoryWithDescriptionAndEventsExpanded,
+} from '../../fixtures/manual/timelineAtom';
+import { TimelineAtom } from './TimelineAtom.importable';
+
+export default {
+	title: 'TimelineAtom',
+	component: TimelineAtom,
+};
+
+// Based on https://www.theguardian.com/stage/2018/mar/06/hamilton-nominated-olivier-awards
+export const NoTimelineEventsStoryExpanded = (): JSX.Element => {
+	return <TimelineAtom {...noTimelineEventsStoryExpanded} />;
+};
+
+// Based on https://www.theguardian.com/uk-news/2020/jul/21/importance-of-prince-andrew-interview-became-clear-in-editing-suite-says-maitlis
+export const NewsTimelineStoryNoDescriptionExpanded = (): JSX.Element => {
+	return <TimelineAtom {...newsTimelineStoryNoDescriptionExpanded} />;
+};
+
+// Based on https://www.theguardian.com/sport/blog/2020/jul/09/why-chris-froome-and-team-ineos-parting-of-the-ways-cycling
+export const SportTimelineStoryWithDescriptionAndEventsExpanded =
+	(): JSX.Element => {
+		return (
+			<TimelineAtom
+				{...sportTimelineStoryWithDescriptionAndEventsExpanded}
+			/>
+		);
+	};
+
+// Based on https://www.theguardian.com/media/2019/jun/13/julian-assange-sajid-javid-signs-us-extradition-order
+export const NewsStoryWithDatesToExpanded = (): JSX.Element => {
+	return <TimelineAtom {...newsStoryWithDatesToExpanded} />;
+};

--- a/dotcom-rendering/src/components/TimelineAtom.stories.tsx
+++ b/dotcom-rendering/src/components/TimelineAtom.stories.tsx
@@ -12,26 +12,23 @@ export default {
 };
 
 // Based on https://www.theguardian.com/stage/2018/mar/06/hamilton-nominated-olivier-awards
-export const NoTimelineEventsStoryExpanded = (): JSX.Element => {
+export const NoTimelineEventsStoryExpanded = () => {
 	return <TimelineAtom {...noTimelineEventsStoryExpanded} />;
 };
 
 // Based on https://www.theguardian.com/uk-news/2020/jul/21/importance-of-prince-andrew-interview-became-clear-in-editing-suite-says-maitlis
-export const NewsTimelineStoryNoDescriptionExpanded = (): JSX.Element => {
+export const NewsTimelineStoryNoDescriptionExpanded = () => {
 	return <TimelineAtom {...newsTimelineStoryNoDescriptionExpanded} />;
 };
 
 // Based on https://www.theguardian.com/sport/blog/2020/jul/09/why-chris-froome-and-team-ineos-parting-of-the-ways-cycling
-export const SportTimelineStoryWithDescriptionAndEventsExpanded =
-	(): JSX.Element => {
-		return (
-			<TimelineAtom
-				{...sportTimelineStoryWithDescriptionAndEventsExpanded}
-			/>
-		);
-	};
+export const SportTimelineStoryWithDescriptionAndEventsExpanded = () => {
+	return (
+		<TimelineAtom {...sportTimelineStoryWithDescriptionAndEventsExpanded} />
+	);
+};
 
 // Based on https://www.theguardian.com/media/2019/jun/13/julian-assange-sajid-javid-signs-us-extradition-order
-export const NewsStoryWithDatesToExpanded = (): JSX.Element => {
+export const NewsStoryWithDatesToExpanded = () => {
 	return <TimelineAtom {...newsStoryWithDatesToExpanded} />;
 };

--- a/dotcom-rendering/src/components/TimelineAtom.test.tsx
+++ b/dotcom-rendering/src/components/TimelineAtom.test.tsx
@@ -1,0 +1,59 @@
+import { fireEvent, render } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import { noTimelineEventsStory } from '../../fixtures/manual/timelineAtom';
+import { TimelineAtom } from './TimelineAtom.importable';
+
+describe('TimelineAtom', () => {
+	it('should render', () => {
+		const { getByText, queryByText } = render(
+			<TimelineAtom {...noTimelineEventsStory} />,
+		);
+
+		expect(getByText('Timeline')).toBeInTheDocument();
+
+		// Test that the 'Show' part of the expand switch is hidden on expand
+		expect(getByText('Show')).toBeInTheDocument();
+		fireEvent.click(getByText('Show'));
+		expect(queryByText('Show')).toBe(null);
+		// Test that 'Hide' is hidden after closing the Guide
+		expect(getByText('Hide')).toBeInTheDocument();
+		fireEvent.click(getByText('Hide'));
+		expect(queryByText('Hide')).toBe(null);
+	});
+
+	it('Show feedback on like', () => {
+		const { getByText, queryByText, queryByTestId } = render(
+			<TimelineAtom {...noTimelineEventsStory} />,
+		);
+
+		// Expand Timeline
+		fireEvent.click(getByText('Show'));
+		// Like button should be visibile and feedback not visibile
+		expect(queryByTestId('like')).toBeVisible();
+		expect(queryByText('Thank you for your feedback.')).not.toBeVisible();
+
+		// Fire like event
+		fireEvent.click(queryByTestId('like') as HTMLElement);
+		// Feedback should be visible, like button should be hidden
+		expect(queryByText('Thank you for your feedback.')).toBeVisible();
+		expect(queryByTestId('like')).not.toBeVisible();
+	});
+
+	it('Show feedback on dislike', () => {
+		const { getByText, queryByText, queryByTestId } = render(
+			<TimelineAtom {...noTimelineEventsStory} />,
+		);
+
+		// Timeline Guide
+		fireEvent.click(getByText('Show'));
+		// Like button should be visibile and feedback not visibile
+		expect(queryByTestId('dislike')).toBeVisible();
+		expect(queryByText('Thank you for your feedback.')).not.toBeVisible();
+
+		// Fire dislike event
+		fireEvent.click(queryByTestId('dislike') as HTMLElement);
+		// Feedback should be visible, like button should be hidden
+		expect(queryByText('Thank you for your feedback.')).toBeVisible();
+		expect(queryByTestId('dislike')).not.toBeVisible();
+	});
+});

--- a/dotcom-rendering/src/components/TimelineAtomWrapper.importable.tsx
+++ b/dotcom-rendering/src/components/TimelineAtomWrapper.importable.tsx
@@ -1,6 +1,0 @@
-import { TimelineAtom } from '@guardian/atoms-rendering';
-import type { TimelineAtomType } from '@guardian/atoms-rendering';
-
-export const TimelineAtomWrapper = (props: TimelineAtomType) => {
-	return <TimelineAtom {...props} />;
-};

--- a/dotcom-rendering/src/lib/renderElement.tsx
+++ b/dotcom-rendering/src/lib/renderElement.tsx
@@ -46,7 +46,7 @@ import { StarRatingBlockComponent } from '../components/StarRatingBlockComponent
 import { SubheadingBlockComponent } from '../components/SubheadingBlockComponent';
 import { TableBlockComponent } from '../components/TableBlockComponent';
 import { TextBlockComponent } from '../components/TextBlockComponent';
-import { TimelineAtomWrapper } from '../components/TimelineAtomWrapper.importable';
+import { TimelineAtom } from '../components/TimelineAtom.importable';
 import { TweetBlockComponent } from '../components/TweetBlockComponent.importable';
 import { UnsafeEmbedBlockComponent } from '../components/UnsafeEmbedBlockComponent.importable';
 import { VideoAtom } from '../components/VideoAtom';
@@ -614,10 +614,10 @@ export const renderElement = ({
 		case 'model.dotcomrendering.pageElements.TimelineBlockElement':
 			return (
 				<Island priority="feature" defer={{ until: 'visible' }}>
-					<TimelineAtomWrapper
+					<TimelineAtom
 						id={element.id}
 						title={element.title}
-						pillar={format.theme}
+						format={format}
 						events={element.events}
 						description={element.description}
 					/>

--- a/dotcom-rendering/src/types/content.ts
+++ b/dotcom-rendering/src/types/content.ts
@@ -752,7 +752,7 @@ interface VideoAssets {
 	};
 }
 
-interface TimelineEvent {
+export interface TimelineEvent {
 	title: string;
 	date: string;
 	unixDate: number;
@@ -760,6 +760,18 @@ interface TimelineEvent {
 	toDate?: string;
 	toUnixDate?: number;
 }
+
+export type TimelineAtomType = {
+	id: string;
+	events?: TimelineEvent[];
+	title: string;
+	format: ArticleFormat;
+	description?: string;
+	expandForStorybook?: boolean;
+	likeHandler?: () => void;
+	dislikeHandler?: () => void;
+	expandCallback?: () => void;
+};
 
 export type RatingSizeType = 'large' | 'medium' | 'small';
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Migrate Timeline atom from atoms-rendering

## Why?

We're moving them all over.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/77005274/e093b0f2-2b15-495d-a8aa-ba46623a0335
[after]: https://github.com/guardian/dotcom-rendering/assets/77005274/daa52e33-c598-473c-8362-20476da17569

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

