### PR TITLE
Fix drop caps with invisible elements

### DIFF
--- a/dotcom-rendering/src/components/TextBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/components/TextBlockComponent.stories.tsx
@@ -41,6 +41,8 @@ const nestedParagraphs =
 	'<p>Wee wee wee cried this little piggy</p>' +
 	'<p>Wee wee wee cried this little piggy</p>' +
 	'<p>All the way home</p></p>';
+const wigglyStrong =
+	'<p>The YouTube clip I return to most often is David Bowie being interviewed by Jeremy Paxman on Newsnight in 1999. Bowie is talking about what the internet might do: “I don’t think we’ve even seen the tip of the iceberg. I<strong> </strong>think that the potential of what the internet is going to do to society, both good and bad, is unimaginable. I think we’re on the cusp of something exhilarating and terrifying.”</p>';
 
 const containerStyles = css`
 	max-width: 620px;
@@ -297,3 +299,20 @@ export const nestedParagraphsStory = () => {
 	);
 };
 nestedParagraphsStory.storyName = 'Nested paragraphs';
+
+export const InvisibleStrong = () => {
+	return (
+		<div css={containerStyles}>
+			<TextBlockComponent
+				html={wigglyStrong}
+				format={{
+					theme: Pillar.Culture,
+					design: ArticleDesign.Feature,
+					display: ArticleDisplay.Immersive,
+				}}
+				isFirstParagraph={true}
+			/>
+		</div>
+	);
+};
+InvisibleStrong.storyName = 'Invisible Strong';

--- a/dotcom-rendering/src/components/TextBlockComponent.tsx
+++ b/dotcom-rendering/src/components/TextBlockComponent.tsx
@@ -258,6 +258,8 @@ const buildElementTree =
 						: undefined;
 					if (
 						dropCappedSentence &&
+						// This node is the first node
+						node.previousSibling === null &&
 						// The node is the first in this text block
 						node.parentNode?.parentNode?.firstChild?.contains(
 							node,

--- a/dotcom-rendering/src/components/TextBlockComponent.tsx
+++ b/dotcom-rendering/src/components/TextBlockComponent.tsx
@@ -266,7 +266,7 @@ const buildElementTree =
 						) &&
 						// The node is at the root of the document avoiding nodes like <a>
 						// tags embedded in <p> tags dropping their cap
-						node.parentNode?.parentNode?.nodeName ===
+						node.parentNode.parentNode.nodeName ===
 							'#document-fragment'
 					) {
 						const { dropCap, restOfSentence } = dropCappedSentence;


### PR DESCRIPTION
## What does this change?

Ensure that the dropped cap element is the first node.

## Why?

It’s causing an issue on a unreleased piece.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/76776/8de6d6f6-daf1-424b-be9b-a45f191fcd56
[after]: https://github.com/guardian/dotcom-rendering/assets/76776/25bdcce3-ec5e-4cb1-a621-a7b5003bb85f