### PR TITLE
Oa/add qanda atom

### DIFF
--- a/dotcom-rendering/fixtures/manual/qandaAtom.tsx
+++ b/dotcom-rendering/fixtures/manual/qandaAtom.tsx
@@ -1,0 +1,77 @@
+import { ArticleDesign, ArticleDisplay, Pillar } from "@guardian/libs";
+
+const format:ArticleFormat = {
+	design: ArticleDesign.Quiz,
+	display: ArticleDisplay.Standard,
+	theme: Pillar.News
+
+}
+
+// Non-expanded version for Cypress tests
+export const imageStory = {
+	id: '78014307-ca67-47dc-b524-d5f24f3dbcd8',
+	title: 'What is bitcoin?',
+	html: "<p>Bitcoin is the first, and the biggest, 'cryptocurrency' – a decentralised tradeable digital asset. The lack of any central authority oversight is one of the attraction.&nbsp;</p><p>Cryptocurrencies can be used to send transactions between two parties via the use of private and public keys. These transfers can be done with minimal processing cost, allowing users to avoid the fees charged by traditional financial institutions - as well as the oversight and regulation that entails.</p><p>This means it has attracted a range of backers, from libertarian monetarists who enjoy the idea of a currency with no inflation and no central bank, to drug dealers who like the fact that it is hard (but not impossible) to trace a bitcoin transaction back to a physical person.</p><p>The exchange rate has been volatile, making it a risky investment. Whether it is a bad investment is yet to be seen. In practice it has been far more important for the dark economy than it has for most legitimate uses, but with Facebook's announcement that it is launching a new digital currency - <a href='https://www.theguardian.com/technology/2019/jun/18/what-is-libra-facebook-new-cryptocurrency'>Libra</a> - mainstream interest in bitcoin has surged.<br></p>",
+	format,
+	image:
+		'https://i.guim.co.uk/img/media/5f74d365b0a3072c2edcd764cf08d6fa4fcd873b/0_59_5190_3114/5190.jpg?width=620&quality=85&auto=format&fit=max&s=ed95a62cd07881336635129287b406a1',
+	expandForStorybook: false,
+	likeHandler: (): null => null,
+	dislikeHandler: (): null => null,
+	expandCallback: (): null => null,
+};
+
+export const imageStoryExpanded = {
+	id: '78014307-ca67-47dc-b524-d5f24f3dbcd8',
+	title: 'What is bitcoin?',
+	html: "<p>Bitcoin is the first, and the biggest, 'cryptocurrency' – a decentralised tradeable digital asset. The lack of any central authority oversight is one of the attraction.&nbsp;</p><p>Cryptocurrencies can be used to send transactions between two parties via the use of private and public keys. These transfers can be done with minimal processing cost, allowing users to avoid the fees charged by traditional financial institutions - as well as the oversight and regulation that entails.</p><p>This means it has attracted a range of backers, from libertarian monetarists who enjoy the idea of a currency with no inflation and no central bank, to drug dealers who like the fact that it is hard (but not impossible) to trace a bitcoin transaction back to a physical person.</p><p>The exchange rate has been volatile, making it a risky investment. Whether it is a bad investment is yet to be seen. In practice it has been far more important for the dark economy than it has for most legitimate uses, but with Facebook's announcement that it is launching a new digital currency - <a href='https://www.theguardian.com/technology/2019/jun/18/what-is-libra-facebook-new-cryptocurrency'>Libra</a> - mainstream interest in bitcoin has surged.<br></p>",
+	format,
+	image:
+		'https://i.guim.co.uk/img/media/5f74d365b0a3072c2edcd764cf08d6fa4fcd873b/0_59_5190_3114/5190.jpg?width=620&quality=85&auto=format&fit=max&s=ed95a62cd07881336635129287b406a1',
+	expandForStorybook: true,
+	likeHandler: (): null => null,
+	dislikeHandler: (): null => null,
+	expandCallback: (): null => null,
+};
+
+export const imageStoryWithCreditExpanded = {
+	id: '78014307-ca67-47dc-b524-d5f24f3dbcd8',
+	title: 'Coronavirus pandemic: 10 countries of concern',
+	html: `<p><b>Brazil&nbsp;</b>67,964 deaths, 1,713,160 cases</p><p>President Jair Bolsonaro dismissed the disease as a “little flu” as it rampaged through his country and mocked measures&nbsp;such as wearing masks. Two health ministers have quit and Brazil's outbreak is the second-deadliest in the world.<br> </p><p><b>India&nbsp;</b>21,129 deaths, 767,296 cases</p><p>India brought in a strict nationwide lockdown in March that slowed the spread of the virus but did not bring it under control. As the country began easing controls, cases surged and it now has the third highest number. Mortality rates are low, but it is unclear if this reflects reporting problems or a relatively resilient population.</p>
+    <p><b>Iran&nbsp;</b>250,458 cases, 12,305 deaths</p>
+    <p>Iran had one of the first major outbreaks outside China. A lockdown slowed its spread but after that was eased in April, cases rebounded. Several senior officials have tested positive, and the government has strengthened controls, including making masks obligatory in public places.</p>
+    <p><b>Israel&nbsp;</b>33,947 cases, 346 deaths</p>
+    <p>Israel had an early travel ban and strict lockdowns, and in April the prime minister, Benjamin Netanyahu, declared the country an example to the world in controlling Covid-19. But cases that in May were down to just 20 a day, skyrocketed after the country started opening up. Partial controls have been brought back with warnings more could follow.</p>
+    <p><b>Mexico&nbsp;</b>275,003 cases, 32,796 deaths</p>
+    <p>President Andrés Manuel López Obrador joined other populists from across the political spectrum in dismissing the threat from coronavirus; when schools closed in March he shared a video of himself hugging fans and kissing a baby. The outbreak is now one of the worst on the continent.</p>
+    <p><b>Philippines&nbsp;</b>51,754 cases, 1,314 deaths</p>
+    <p>A strict lockdown from March to June kept the disease under control but shrank the economy for the first time in 20 years. Cases have climbed steadily since the country started coming out of lockdown, and President Rodrigo Duterte has said the country cannot afford to fully reopen because it would be overwhelmed by another spike.</p>
+    <p><b>Russia&nbsp;</b>706,179 cases, 10,825 deaths</p>
+    <p>Coronavirus was slow to arrive in Russia, and travel bans and a lockdown initially slowed its spread, but controls were lifted twice for political reasons – a military parade and a referendum on allowing Putin to stay in power longer. Despite having the fourth biggest outbreak in the world controls are now being eased nationwide.</p>
+    <p><b>Serbia&nbsp;</b>17,342 cases, 352 deaths</p>
+    <p>Cases are rising rapidly, hospitals are full and doctors exhausted. But the government has rowed back from plans to bring back lockdown controls, after two days of violent protests. Critics blame the sharp rise in cases on authorities who allowed mass gatherings in May and elections in June. Officials say it is due to a lack of sanitary discipline, especially in nightclubs.</p>
+    <p><b>South Africa&nbsp;</b>224,664 cases, 3,602 deaths</p>
+    <p>South Africa has by far the largest outbreak on the African continent, despite one of the strictest lockdowns in the world. Sales of alcohol and cigarettes were even banned. But it began reopening in May, apparently fuelling the recent rise in cases which have more than doubled over the last two weeks.</p>
+    <p><b>US&nbsp;</b>132,310 deaths, 3,055,491 cases</p>
+    <p>The US ban on travellers from overseas came too late, and though most states had lockdowns of some form in spring, they varied in length and strictness. Some places that were among the earliest to lift them are now battling fast-rising outbreaks, and the country has the highest number of confirmed cases and deaths. Opposition to lockdowns and mask-wearing remains widespread.</p>
+    <p>Source: Johns Hopkins CSSE, 9 July</p>`,
+	format,
+	image:
+		'https://i.guim.co.uk/img/media/1cd3cc5864d9e6fc0b74134eaff7ab329cb89678/914_0_1757_1757/1757.jpg?width=620&quality=85&auto=format&fit=max&s=c1aadf54045c6a8c11e9c077324e238f',
+	credit: 'Photograph: Mark R Cristino/EPA',
+	expandForStorybook: true,
+	likeHandler: (): null => null,
+	dislikeHandler: (): null => null,
+	expandCallback: (): null => null,
+};
+
+export const listStoryExpanded = {
+	id: '7a6078f6-5a66-4d3e-9339-5610fe320767',
+	title: 'How can I protect myself and others from the coronavirus outbreak?',
+	html: '<p>The World Health Organization is recommending that people take simple precautions to reduce exposure to and transmission of the coronavirus, for which there is no specific cure or vaccine.</p> <p>The UN agency&nbsp;<a href="https://www.who.int/emergencies/diseases/novel-coronavirus-2019/advice-for-public">advises</a>&nbsp;people to:</p> <ul> <li>Frequently wash their hands with an alcohol-based hand rub or warm water and soap</li> <li>Cover their mouth and nose with a flexed elbow or tissue when sneezing or coughing</li> <li>Avoid close contact with anyone who has a fever or cough</li> <li>Seek early medical help if they have a fever, cough and difficulty breathing, and share their travel history with healthcare providers</li> <li>Advice about face masks varies. Wearing them while out and about may offer some protection against both spreading and catching the virus via coughs and sneezes, but it is not a cast-iron guarantee of protection</li> </ul> <p>Many countries are now enforcing or recommending curfews or lockdowns. <b>Check with your local authorities for up-to-date information about the situation in your area.</b>&nbsp;</p> <p>In the UK, NHS advice is that anyone with symptoms should&nbsp;<b>stay at home for at least 7 days</b>.</p> <p>If you live with other people,&nbsp;<b>they should stay at home for at least 14 days</b>, to avoid spreading the infection outside the home.</p>',
+	format,
+	expandForStorybook: true,
+	likeHandler: (): null => null,
+	dislikeHandler: (): null => null,
+	expandCallback: (): null => null,
+};

--- a/dotcom-rendering/src/components/QandaAtom.importable.tsx
+++ b/dotcom-rendering/src/components/QandaAtom.importable.tsx
@@ -1,0 +1,82 @@
+import { submitComponentEvent } from '../client/ophan/ophan';
+import { Body } from './ExpandableAtom/Body';
+import { Container } from './ExpandableAtom/Container';
+import { Footer } from './ExpandableAtom/Footer';
+
+export type QandaAtomProps = {
+	id: string;
+	title: string;
+	image?: string;
+	html: string;
+	credit?: string;
+	format: ArticleFormat;
+	expandForStorybook?: boolean;
+	likeHandler?: () => void;
+	dislikeHandler?: () => void;
+	expandCallback?: () => void;
+};
+export const QandaAtom = ({
+	id,
+	title,
+	image,
+	html,
+	credit,
+	format,
+	expandForStorybook,
+	likeHandler,
+	dislikeHandler,
+	expandCallback,
+}: QandaAtomProps): JSX.Element => (
+	<Container
+		id={id}
+		title={title}
+		atomType="qanda"
+		atomTypeTitle="Q&A"
+		format={format}
+		expandForStorybook={expandForStorybook}
+		expandCallback={
+			expandCallback ??
+			(() =>
+				submitComponentEvent({
+					component: {
+						componentType: 'QANDA_ATOM',
+						id,
+						products: [],
+						labels: [],
+					},
+					action: 'EXPAND',
+				}))
+		}
+	>
+		<Body html={html} image={image} credit={credit} format={format} />
+		<Footer
+			format={format}
+			dislikeHandler={
+				dislikeHandler ??
+				(() =>
+					submitComponentEvent({
+						component: {
+							componentType: 'QANDA_ATOM',
+							id,
+							products: [],
+							labels: [],
+						},
+						action: 'DISLIKE',
+					}))
+			}
+			likeHandler={
+				likeHandler ??
+				(() =>
+					submitComponentEvent({
+						component: {
+							componentType: 'QANDA_ATOM',
+							id,
+							products: [],
+							labels: [],
+						},
+						action: 'LIKE',
+					}))
+			}
+		></Footer>
+	</Container>
+);

--- a/dotcom-rendering/src/components/QandaAtom.stories.tsx
+++ b/dotcom-rendering/src/components/QandaAtom.stories.tsx
@@ -1,0 +1,26 @@
+import {
+	imageStoryExpanded,
+	imageStoryWithCreditExpanded,
+	listStoryExpanded,
+} from '../../fixtures/manual/qandaAtom';
+import { QandaAtom } from './QandaAtom.importable';
+
+export default {
+	title: 'QandaAtom',
+	component: QandaAtom,
+};
+
+// Based on https://www.theguardian.com/technology/2018/sep/19/time-to-regulate-bitcoin-says-treasury-committee-report
+export const NewsStoryExpanded = (): JSX.Element => {
+	return <QandaAtom {...imageStoryExpanded} />;
+};
+
+// Based on https://www.theguardian.com/world/2020/mar/17/israel-to-track-mobile-phones-of-suspected-coronavirus-cases
+export const ListStoryExpanded = (): JSX.Element => {
+	return <QandaAtom {...listStoryExpanded} />;
+};
+
+// Based on https://www.theguardian.com/world/2020/aug/06/coronavirus-global-report-germany-and-france-record-biggest-rise-in-cases-since-may
+export const ImageStoryWithCreditExpanded = (): JSX.Element => {
+	return <QandaAtom {...imageStoryWithCreditExpanded} />;
+};

--- a/dotcom-rendering/src/components/QandaAtom.test.tsx
+++ b/dotcom-rendering/src/components/QandaAtom.test.tsx
@@ -1,0 +1,59 @@
+import { fireEvent, render } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import { QandaAtom } from './QandaAtom.importable';
+import { imageStory } from './QandaAtom.stories';
+
+describe('QandaAtom', () => {
+	it('should render & expand works', () => {
+		const { getByText, queryByText } = render(
+			<QandaAtom {...imageStory} />,
+		);
+
+		expect(getByText('Q&A')).toBeInTheDocument();
+
+		// Test that the 'Show' part of the expand switch is hidden on expand
+		expect(getByText('Show')).toBeInTheDocument();
+		fireEvent.click(getByText('Show'));
+		expect(queryByText('Show')).toBe(null);
+		// Test that 'Hide' is hidden after closing the Q & A
+		expect(getByText('Hide')).toBeInTheDocument();
+		fireEvent.click(getByText('Hide'));
+		expect(queryByText('Hide')).toBe(null);
+	});
+
+	it('Show feedback on like', () => {
+		const { getByText, queryByText, queryByTestId } = render(
+			<QandaAtom {...imageStory} />,
+		);
+
+		// Expand Q&A
+		fireEvent.click(getByText('Show'));
+		// Like button should be visibile and feedback not visibile
+		expect(queryByTestId('like')).toBeVisible();
+		expect(queryByText('Thank you for your feedback.')).not.toBeVisible();
+
+		// Fire like event
+		fireEvent.click(queryByTestId('like') as HTMLElement);
+		// Feedback should be visible, like button should be hidden
+		expect(queryByText('Thank you for your feedback.')).toBeVisible();
+		expect(queryByTestId('like')).not.toBeVisible();
+	});
+
+	it('Show feedback on dislike', () => {
+		const { getByText, queryByText, queryByTestId } = render(
+			<QandaAtom {...imageStory} />,
+		);
+
+		// Expand Q&A
+		fireEvent.click(getByText('Show'));
+		// Like button should be visibile and feedback not visibile
+		expect(queryByTestId('dislike')).toBeVisible();
+		expect(queryByText('Thank you for your feedback.')).not.toBeVisible();
+
+		// Fire dislike event
+		fireEvent.click(queryByTestId('dislike') as HTMLElement);
+		// Feedback should be visible, like button should be hidden
+		expect(queryByText('Thank you for your feedback.')).toBeVisible();
+		expect(queryByTestId('dislike')).not.toBeVisible();
+	});
+});

--- a/dotcom-rendering/src/components/QandaAtom.test.tsx
+++ b/dotcom-rendering/src/components/QandaAtom.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
+import { imageStory } from '../../fixtures/manual/qandaAtom';
 import { QandaAtom } from './QandaAtom.importable';
-import { imageStory } from './QandaAtom.stories';
 
 describe('QandaAtom', () => {
 	it('should render & expand works', () => {

--- a/dotcom-rendering/src/components/QandaAtomWrapper.importable.tsx
+++ b/dotcom-rendering/src/components/QandaAtomWrapper.importable.tsx
@@ -1,6 +1,0 @@
-import { QandaAtom } from '@guardian/atoms-rendering';
-import type { QandaAtomType } from '@guardian/atoms-rendering';
-
-export const QandaAtomWrapper = (props: QandaAtomType) => {
-	return <QandaAtom {...props} />;
-};

--- a/dotcom-rendering/src/lib/renderElement.tsx
+++ b/dotcom-rendering/src/lib/renderElement.tsx
@@ -38,7 +38,7 @@ import { NumberedTitleBlockComponent } from '../components/NumberedTitleBlockCom
 import { PersonalityQuizAtom } from '../components/PersonalityQuizAtom.importable';
 import { ProfileAtomWrapper } from '../components/ProfileAtomWrapper.importable';
 import { PullQuoteBlockComponent } from '../components/PullQuoteBlockComponent';
-import { QandaAtomWrapper } from '../components/QandaAtomWrapper.importable';
+import { QandaAtom } from '../components/QandaAtom.importable';
 import { RichLinkComponent } from '../components/RichLinkComponent.importable';
 import { SoundcloudBlockComponent } from '../components/SoundcloudBlockComponent';
 import { SpotifyBlockComponent } from '../components/SpotifyBlockComponent.importable';
@@ -513,13 +513,13 @@ export const renderElement = ({
 		case 'model.dotcomrendering.pageElements.QABlockElement':
 			return (
 				<Island priority="feature" defer={{ until: 'visible' }}>
-					<QandaAtomWrapper
+					<QandaAtom
 						id={element.id}
 						title={element.title}
 						html={element.html}
 						image={element.img}
 						credit={element.credit}
-						pillar={format.theme}
+						format={format}
 					/>
 				</Island>
 			);

--- a/dotcom-rendering/src/server/dev-index.html
+++ b/dotcom-rendering/src/server/dev-index.html
@@ -352,7 +352,7 @@
 				{
 					name: 'Q&A Atom',
 					article:
-						'/world/2020/jul/16/a-single-use-face-mask-or-one-like-amber-heards-how-i-learnt-to-choose-wisely',
+						'/film/2023/jul/30/disaster-movies-films-climate-crisis-documentaries',
 				},
 				{
 					name: 'Quiz Atom',


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Moving the Q&A atom out of atoms-rendering and into DCR. 

## Why?

Trying to remove atoms rendering all together

## Screenshots

| Before      | After      |
| ----------- | ---------- |
|[https://github.com/guardian/dotcom-rendering/assets/40648315/be9f6113-372e-4cb6-98f4-65305cab5ccc] |[https://github.com/guardian/dotcom-rendering/assets/40648315/98a3a95a-f065-4c61-9a80-ddc0feeda10c] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
