### PR TITLE
Replace useOnce with useEffect when no dependencies

### DIFF
--- a/dotcom-rendering/src/components/Discussion.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion.stories.tsx
@@ -1,10 +1,10 @@
 import { ArticleDesign, ArticleDisplay, Pillar, storage } from '@guardian/libs';
+import { useEffect } from 'react';
 import { doStorybookHydration } from '../client/islands/doStorybookHydration';
-import { useOnce } from '../lib/useOnce';
 import { DiscussionLayout } from './DiscussionLayout';
 
 const HydratedLayout = ({ children }: { children: React.ReactNode }) => {
-	useOnce(doStorybookHydration, []);
+	useEffect(doStorybookHydration, []);
 	return <>{children}</>;
 };
 

--- a/dotcom-rendering/src/components/LightboxHash.importable.tsx
+++ b/dotcom-rendering/src/components/LightboxHash.importable.tsx
@@ -1,5 +1,5 @@
 import { log } from '@guardian/libs';
-import { useOnce } from '../lib/useOnce';
+import { useEffect } from 'react';
 
 /**
  * This small snippet of javascript is executed at page load. It checks to
@@ -23,7 +23,7 @@ import { useOnce } from '../lib/useOnce';
  * Does not render **anything**.
  */
 export const LightboxHash = () => {
-	useOnce(() => {
+	useEffect(() => {
 		const hash = window.location.hash;
 		if (hash.startsWith('#img-')) {
 			log(

--- a/dotcom-rendering/src/components/PrivacySettingsLink.importable.tsx
+++ b/dotcom-rendering/src/components/PrivacySettingsLink.importable.tsx
@@ -3,8 +3,7 @@ import { cmp, onConsent } from '@guardian/consent-management-platform';
 import type { Framework } from '@guardian/consent-management-platform/dist/types';
 import { palette } from '@guardian/source-foundations';
 import { ButtonLink } from '@guardian/source-react-components';
-import { useState } from 'react';
-import { useOnce } from '../lib/useOnce';
+import { useEffect, useState } from 'react';
 
 const footerLink = css`
 	color: inherit;
@@ -38,7 +37,7 @@ type Props = {
 export const PrivacySettingsLink = ({ extraClasses }: Props) => {
 	const [framework, setFramework] = useState<Framework>();
 
-	useOnce(() => {
+	useEffect(() => {
 		void onConsent().then((consentState) => {
 			setFramework(consentState.framework ?? undefined);
 		});

--- a/dotcom-rendering/src/components/RecipeMultiplier.importable.tsx
+++ b/dotcom-rendering/src/components/RecipeMultiplier.importable.tsx
@@ -5,7 +5,6 @@ import { Button, SvgMinus, SvgPlus } from '@guardian/source-react-components';
 import type { ChangeEventHandler } from 'react';
 import { useEffect, useState } from 'react';
 import { isServer } from '../lib/isServer';
-import { useOnce } from '../lib/useOnce';
 
 const colours = `
 gu-recipe {
@@ -132,7 +131,7 @@ export const RecipeMultiplier = () => {
 	const [servings, setServings] = useState<number>(serves);
 	const [multiplier, setMultiplier] = useState(1);
 
-	useOnce(() => {
+	useEffect(() => {
 		log('dotcom', 'Injecting multiplier');
 		const style = document.createElement('style');
 		style.innerHTML = colours;

--- a/dotcom-rendering/src/components/ShowHideContainers.importable.tsx
+++ b/dotcom-rendering/src/components/ShowHideContainers.importable.tsx
@@ -1,5 +1,5 @@
 import { isObject, isString, storage } from '@guardian/libs';
-import { useOnce } from '../lib/useOnce';
+import { useEffect } from 'react';
 
 type ContainerStates = { [id: string]: string };
 
@@ -19,7 +19,7 @@ const getContainerStates = (): ContainerStates => {
 };
 
 export const ShowHideContainers = () => {
-	useOnce(() => {
+	useEffect(() => {
 		const containerStates = getContainerStates();
 
 		const toggleContainer = (sectionId: string, element: HTMLElement) => {

--- a/dotcom-rendering/src/components/ShowMore.importable.tsx
+++ b/dotcom-rendering/src/components/ShowMore.importable.tsx
@@ -16,7 +16,6 @@ import { useEffect, useState } from 'react';
 import { shouldPadWrappableRows } from '../lib/dynamicSlices';
 import type { EditionId } from '../lib/edition';
 import { useApi } from '../lib/useApi';
-import { useOnce } from '../lib/useOnce';
 import { enhanceCards } from '../model/enhanceCards';
 import type { DCRContainerPalette, FEFrontCard } from '../types/front';
 import { LI } from './Card/components/LI';
@@ -93,7 +92,7 @@ export const ShowMore = ({
 	 * allow us to filter out duplicated stories when we load them from the
 	 * 'show-more' endpoint.
 	 */
-	useOnce(() => {
+	useEffect(() => {
 		const container = document.getElementById(`container-${sectionId}`);
 		const containerLinks = Array.from(
 			container?.querySelectorAll('a') ?? [],
@@ -102,7 +101,7 @@ export const ShowMore = ({
 			.filter(isNonNullable);
 
 		setExistingCardLinks(containerLinks);
-	}, []);
+	}, [sectionId]);
 
 	/** We only pass an actual URL to SWR when 'showMore' is true.
 	 * Toggling 'isOpen' will trigger a re-render

--- a/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
+++ b/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
@@ -196,8 +196,7 @@ export const SignInGateSelector = ({
 	const shouldPersonaliseComponentId = (): boolean => {
 		return personaliseSwitch && !!checkoutCompleteCookieData;
 	};
-	const personaliseSignInGateAfterCheckout =
-		switches.personaliseSignInGateAfterCheckout;
+	const { personaliseSignInGateAfterCheckout } = switches;
 	// END: Checkout Complete Personalisation
 
 	useOnce(() => {

--- a/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
+++ b/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
@@ -196,6 +196,8 @@ export const SignInGateSelector = ({
 	const shouldPersonaliseComponentId = (): boolean => {
 		return personaliseSwitch && !!checkoutCompleteCookieData;
 	};
+	const personaliseSignInGateAfterCheckout =
+		switches.personaliseSignInGateAfterCheckout;
 	// END: Checkout Complete Personalisation
 
 	useOnce(() => {
@@ -220,11 +222,11 @@ export const SignInGateSelector = ({
 		}
 	}, [gateSelector]);
 
-	useOnce(() => {
-		if (switches.personaliseSignInGateAfterCheckout) {
-			setPersonaliseSwitch(switches.personaliseSignInGateAfterCheckout);
+	useEffect(() => {
+		if (personaliseSignInGateAfterCheckout) {
+			setPersonaliseSwitch(personaliseSignInGateAfterCheckout);
 		} else setPersonaliseSwitch(false);
-	}, []);
+	}, [personaliseSignInGateAfterCheckout]);
 
 	useEffect(() => {
 		if (gateVariant && currentTest) {

--- a/dotcom-rendering/src/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/dotcom-rendering/src/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -9,8 +9,12 @@ import type {
 	ModuleData,
 	ModuleDataResponse,
 } from '@guardian/support-dotcom-components/dist/dotcom/src/types';
+<<<<<<< HEAD
 import type { TestTracking } from '@guardian/support-dotcom-components/dist/shared/src/types/abTests/shared';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+=======
+import { useEffect, useState } from 'react';
+>>>>>>> f02ae776a (Correct useOnce usage when no dependencies provided)
 import { trackNonClickInteraction } from '../../client/ga/ga';
 import { submitComponentEvent } from '../../client/ophan/ophan';
 import type { ArticleCounts } from '../../lib/articleCount';
@@ -320,7 +324,11 @@ const RemoteBanner = ({
 		debounce: true,
 	});
 
-	useOnce(() => {
+	useEffect(() => {
+		if (meta === undefined) {
+			return;
+		}
+
 		setAutomat();
 
 		window
@@ -330,14 +338,12 @@ const RemoteBanner = ({
 			})
 			.catch((error) => {
 				const msg = `Error importing RR banner: ${String(error)}`;
-
-				console.log(msg);
 				window.guardian.modules.sentry.reportError(
 					new Error(msg),
 					'rr-banner',
 				);
 			});
-	}, []);
+	}, [meta, module]);
 
 	useOnce(() => {
 		const { componentType } = meta;

--- a/dotcom-rendering/src/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/dotcom-rendering/src/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -9,12 +9,8 @@ import type {
 	ModuleData,
 	ModuleDataResponse,
 } from '@guardian/support-dotcom-components/dist/dotcom/src/types';
-<<<<<<< HEAD
 import type { TestTracking } from '@guardian/support-dotcom-components/dist/shared/src/types/abTests/shared';
 import { useEffect, useState } from 'react';
-=======
-import { useEffect, useState } from 'react';
->>>>>>> f02ae776a (Correct useOnce usage when no dependencies provided)
 import { trackNonClickInteraction } from '../../client/ga/ga';
 import { submitComponentEvent } from '../../client/ophan/ophan';
 import type { ArticleCounts } from '../../lib/articleCount';
@@ -325,10 +321,6 @@ const RemoteBanner = ({
 	});
 
 	useEffect(() => {
-		if (meta === undefined) {
-			return;
-		}
-
 		setAutomat();
 
 		window
@@ -343,7 +335,7 @@ const RemoteBanner = ({
 					'rr-banner',
 				);
 			});
-	}, [meta, module]);
+	}, [module]);
 
 	useOnce(() => {
 		const { componentType } = meta;

--- a/dotcom-rendering/src/lib/contributions.ts
+++ b/dotcom-rendering/src/lib/contributions.ts
@@ -1,13 +1,12 @@
 import { onConsentChange } from '@guardian/consent-management-platform';
 import { getCookie } from '@guardian/libs';
 import type { HeaderPayload } from '@guardian/support-dotcom-components/dist/dotcom/src/types';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { DCRFrontType } from '../types/front';
 import type { DCRArticle } from '../types/frontend';
 import type { IdApiUserData } from './getIdapiUserData';
 import { getIdApiUserData } from './getIdapiUserData';
 import { eitherInOktaTestOrElse } from './useAuthStatus';
-import { useOnce } from './useOnce';
 
 // User Atributes API cookies (dropped on sign-in)
 export const HIDE_SUPPORT_MESSAGING_COOKIE = 'gu_hide_support_messaging';
@@ -193,7 +192,7 @@ export const useHasOptedOutOfArticleCount = (): boolean | 'Pending' => {
 		'Pending',
 	);
 
-	useOnce(() => {
+	useEffect(() => {
 		hasOptedOutOfArticleCount()
 			.then(setHasOptedOut)
 			.catch(() => setHasOptedOut(true));

--- a/dotcom-rendering/src/lib/tuple.ts
+++ b/dotcom-rendering/src/lib/tuple.ts
@@ -82,3 +82,8 @@ export const takeFirst = <
 ): SlicedTuple<T, N> =>
 	//@ts-expect-error – this output is tested by jest and it’s a very helpful method
 	array.slice(0, count);
+
+/**
+ * Type representing an array with at least one element
+ */
+export type NonEmptyArray<T> = [T, ...T[]];

--- a/dotcom-rendering/src/lib/useHydrated.ts
+++ b/dotcom-rendering/src/lib/useHydrated.ts
@@ -1,9 +1,8 @@
-import { useState } from 'react';
-import { useOnce } from './useOnce';
+import { useEffect, useState } from 'react';
 
 export const useHydrated = (): boolean => {
 	const [hydrated, setHydrated] = useState(false);
-	useOnce(() => {
+	useEffect(() => {
 		setHydrated(true);
 	}, []);
 

--- a/dotcom-rendering/src/lib/useOnce.ts
+++ b/dotcom-rendering/src/lib/useOnce.ts
@@ -1,6 +1,5 @@
 import { useEffect, useState } from 'react';
-
-type ArrayOfAtLeastOne<T> = [T, ...T[]];
+import type { NonEmptyArray } from './tuple';
 
 /**
  * Ensures that the given task is only run once and only after all items in waitFor are defined
@@ -9,7 +8,7 @@ type ArrayOfAtLeastOne<T> = [T, ...T[]];
  * */
 export const useOnce = (
 	task: () => void,
-	waitFor: ArrayOfAtLeastOne<unknown>,
+	waitFor: NonEmptyArray<unknown>,
 ): void => {
 	const [alreadyRun, setAlreadyRun] = useState(false);
 	const isReady = waitFor.every((dep) => dep !== undefined);

--- a/dotcom-rendering/src/lib/useOnce.ts
+++ b/dotcom-rendering/src/lib/useOnce.ts
@@ -1,18 +1,18 @@
 import { useEffect, useState } from 'react';
 
+type ArrayOfAtLeastOne<T> = [T, ...T[]];
+
 /**
  * Ensures that the given task is only run once and only after all items in waitFor are defined
  * @param {Function} task - The task to execute once
  * @param {Array} waitFor - An array of variables that must be defined before the task is executed
  * */
-export const useOnce = (task: () => void, waitFor: unknown[]): void => {
+export const useOnce = (
+	task: () => void,
+	waitFor: ArrayOfAtLeastOne<unknown>,
+): void => {
 	const [alreadyRun, setAlreadyRun] = useState(false);
 	const isReady = waitFor.every((dep) => dep !== undefined);
-	if (waitFor.length === 0) {
-		throw new Error(
-			'useOnce must be passed at least one variable to wait for',
-		);
-	}
 	useEffect(() => {
 		if (!alreadyRun && isReady) {
 			task();

--- a/dotcom-rendering/src/lib/useOnce.ts
+++ b/dotcom-rendering/src/lib/useOnce.ts
@@ -8,6 +8,11 @@ import { useEffect, useState } from 'react';
 export const useOnce = (task: () => void, waitFor: unknown[]): void => {
 	const [alreadyRun, setAlreadyRun] = useState(false);
 	const isReady = waitFor.every((dep) => dep !== undefined);
+	if (waitFor.length === 0) {
+		throw new Error(
+			'useOnce must be passed at least one variable to wait for',
+		);
+	}
 	useEffect(() => {
 		if (!alreadyRun && isReady) {
 			task();

--- a/dotcom-rendering/src/lib/useShouldAdapt.ts
+++ b/dotcom-rendering/src/lib/useShouldAdapt.ts
@@ -1,6 +1,5 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { shouldAdapt as checkShouldAdapt } from '../client/adaptiveSite';
-import { useOnce } from './useOnce';
 
 /**
  * A hook that reports whether we should adapt the current page
@@ -9,7 +8,7 @@ import { useOnce } from './useOnce';
 export const useShouldAdapt = (): boolean => {
 	const [shouldAdapt, setShouldAdapt] = useState(false);
 
-	useOnce(() => {
+	useEffect(() => {
 		void checkShouldAdapt().then(setShouldAdapt);
 	}, []);
 


### PR DESCRIPTION
## What does this change?

`useOnce` is designed to run a function when all its dependencies are defined:

https://github.com/guardian/dotcom-rendering/blob/7f58f8f27c2f36538ec4594a20d690370475de16/dotcom-rendering/src/lib/useOnce.ts#L4-L6

We have many usages of `useOnce` with no dependencies defined e.g.:

```js
useOnce(() => {
//
}, [])
```

This has a few issues:

- not using `useOnce` as intended
- useEffect linting rules do not apply to custom hook dependencies so it's masking potential errors in the provided function's usage of dependencies
- it is the equivalent of a useEffect with an empty dependency array which does allow linting

As mentioned `useOnce` with an empty dependency array can be replaced with a more idiomatic React `useEffect` with an empty dependency array e.g.:

```js
useEffect(() => {
//
}, [])
```

This PR:

- replaces all instances of `useOnce` with an empty dependency array with `useEffect` with an empty dependency array.
- applies linting rules for `useEffect` where they have not been followed
- a type of [`ArrayOfAtLeastOne`](https://github.com/guardian/dotcom-rendering/blob/faa02c259bdc7a3ef08550a57795321a2c419f11/dotcom-rendering/src/lib/useOnce.ts#L3) has been added to `useOnce` to ensure a non-empty dependency array is passed

## Why?

Stricter use of `useOnce`, catch linting errors and moving closer to idiomatic React conventions.

## Notes

Converting to `useEffect` means normal linting now applies so I've followed the rules in adding dependencies back where applicable, however this may introduce unintended behaviour. I will contact Reader Revenue to double check their hooks as they are primarily affected.

We can do more to tighten up usage of `useOnce` and possibly deprecate it as these style of lifecycle custom hooks are [discouraged by the React docs](https://react.dev/learn/reusing-logic-with-custom-hooks#keep-your-custom-hooks-focused-on-concrete-high-level-use-cases).
