### PR TITLE
Revert "Updates the Standfirst for Standard article/design"

### DIFF
--- a/dotcom-rendering/src/components/Standfirst.tsx
+++ b/dotcom-rendering/src/components/Standfirst.tsx
@@ -183,19 +183,12 @@ const standfirstStyles = (format: ArticleFormat, palette: Palette) => {
 						default:
 							return css`
 								${headline.xxxsmall({
-									fontWeight: 'medium',
+									fontWeight: 'bold',
 								})};
 								line-height: 20px;
 								margin-bottom: ${space[3]}px;
-								max-width: 90%;
+								max-width: 540px;
 								color: ${palette.text.standfirst};
-
-								${from.tablet} {
-									${headline.xsmall({
-										fontWeight: 'medium',
-									})};
-									max-width: 80%;
-								}
 							`;
 					}
 			}


### PR DESCRIPTION
Reverts guardian/dotcom-rendering#9148

Standfirst fonts look larger than expected, CP and Editorial would like a revert.
