### PR TITLE
Standard article Standfirst design updates

### DIFF
--- a/dotcom-rendering/src/components/Standfirst.tsx
+++ b/dotcom-rendering/src/components/Standfirst.tsx
@@ -191,7 +191,7 @@ const standfirstStyles = (format: ArticleFormat, palette: Palette) => {
 								color: ${palette.text.standfirst};
 
 								${from.tablet} {
-									${headline.xsmall({
+									${headline.xxsmall({
 										fontWeight: 'medium',
 									})};
 									max-width: 80%;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
Resolves https://github.com/guardian/dotcom-rendering/issues/9082

## What does this change?
Updates the Standfirst on standard article/design

- Tablet or smaller
  - Font weight was 700, now 500
  - Max width was 540px, now 90%
  - Font size remains the same (17px)
 - Tablet, or larger
   - Font weight was 700, now 500
   - Max width was 540px, now 90%
   - Font size was 17px, now 240px
  

## Why?
As per designs

## Screenshots

| | Before      | After      |
|-----------| ----------- | ---------- |
|Mobile |<img width="690" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/13bfa4bd-ad82-43b1-a8e0-ffe5a71a16c1">|  <img width="690" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/e60dec11-c1a5-4e61-aa13-df8cf8254343"> | 
|Desktop | <img width="1353" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/d8fcbd15-dfbc-4a20-bde8-634dd3eda551"> | <img width="1353" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/8a4c8ddc-1a40-411e-ab86-cb775291c138"> | 

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
