### PR TITLE
fix(LatestLinks): ensure links are not empty

### DIFF
--- a/dotcom-rendering/src/components/LatestLinks.importable.stories.tsx
+++ b/dotcom-rendering/src/components/LatestLinks.importable.stories.tsx
@@ -22,6 +22,8 @@ export default {
 				breakpoints.phablet,
 				breakpoints.desktop,
 			],
+			pauseAnimationAtEnd: true,
+			delay: 1200, // ensure “reveal” has finished before taking screenshot
 		},
 	},
 };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Add delay and pausing animation to the `LatestLinks` stories

## Why?

They are currently blank, probably because the animation is too slow

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/76776/2941ff6f-222d-4fb8-be8c-1cecc783b273
[after]: https://github.com/guardian/dotcom-rendering/assets/76776/310ee9d5-aa52-471f-8d7b-f47fc2a41fff