### PR TITLE
Improve ReaderRevenueBanner types

### DIFF
--- a/dotcom-rendering/src/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/dotcom-rendering/src/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -9,6 +9,7 @@ import type {
 	ModuleData,
 	ModuleDataResponse,
 } from '@guardian/support-dotcom-components/dist/dotcom/src/types';
+import type { TestTracking } from '@guardian/support-dotcom-components/dist/shared/src/types/abTests/shared';
 import { useState } from 'react';
 import { trackNonClickInteraction } from '../../client/ga/ga';
 import { submitComponentEvent } from '../../client/ophan/ophan';
@@ -294,7 +295,7 @@ export const canShowPuzzlesBanner: CanShowFunctionType<BannerProps> = async ({
 };
 
 export type BannerProps = {
-	meta: any;
+	meta: TestTracking;
 	module: ModuleData;
 	// eslint-disable-next-line react/no-unused-prop-types -- ESLint is wrong: it is used in ReaderRevenueBanner
 	fetchEmail?: () => Promise<string | null>;
@@ -320,10 +321,6 @@ const RemoteBanner = ({
 	});
 
 	useOnce(() => {
-		if (module === undefined || meta === undefined) {
-			return;
-		}
-
 		setAutomat();
 
 		window


### PR DESCRIPTION
Here the component will only be used if `meta` and `module` are present, so the undefined checks are unnecessary.
Also, `meta` was needlessly given the `any` type