### PR TITLE
Don't show banner ads on cotton capital front

### DIFF
--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -79,7 +79,9 @@ const isToggleable = (
 			collection.displayName.toLowerCase() != 'headlines' &&
 			!isNavList(collection)
 		);
-	} else return index != 0 && !isNavList(collection);
+	}
+
+	return index != 0 && !isNavList(collection);
 };
 
 const decideLeftContent = (

--- a/dotcom-rendering/src/layouts/lib/decideAdSlots.test.ts
+++ b/dotcom-rendering/src/layouts/lib/decideAdSlots.test.ts
@@ -1,5 +1,8 @@
 import type { MutableRefObject } from 'react';
-import { frontsBannerExcludedCollections } from '../../lib/frontsBannerExclusions';
+import {
+	frontsBannerExcludedCollections,
+	frontsBannerExcludedPages,
+} from '../../lib/frontsBannerExclusions';
 import {
 	decideFrontsBannerAdSlot,
 	decideMerchHighAndMobileAdSlots,
@@ -197,6 +200,42 @@ describe('decideFrontsBannerAdSlot', () => {
 			);
 
 			expect(result).toBeNull();
+		});
+
+		it('should return null if there is an exclusion for the page', () => {
+			frontsBannerExcludedPages.push('Excluded page');
+
+			const result = decideFrontsBannerAdSlot(
+				renderAds,
+				hasPageSkin,
+				numBannerAdsInserted,
+				showBannerAds,
+				index,
+				'Excluded page',
+				collectionName,
+				isInFrontsBannerTest,
+				[],
+			);
+
+			expect(result).toBeNull();
+		});
+
+		it('should NOT return null if there is not an exclusion for the page', () => {
+			frontsBannerExcludedPages.push('Excluded page');
+
+			const result = decideFrontsBannerAdSlot(
+				renderAds,
+				hasPageSkin,
+				numBannerAdsInserted,
+				showBannerAds,
+				index,
+				'Included page',
+				collectionName,
+				isInFrontsBannerTest,
+				[],
+			);
+
+			expect(result).not.toBeNull();
 		});
 
 		it('should return null if the maximum number of ads have been inserted', () => {

--- a/dotcom-rendering/src/layouts/lib/decideAdSlots.tsx
+++ b/dotcom-rendering/src/layouts/lib/decideAdSlots.tsx
@@ -2,8 +2,41 @@ import { Hide } from '@guardian/source-react-components';
 import { AdSlot } from '../../components/AdSlot.web';
 import { MAX_FRONTS_BANNER_ADS } from '../../lib/commercial-constants';
 import { frontsBannerAdCollections } from '../../lib/frontsBannerAbTestAdPositions';
-import { frontsBannerExcludedCollections } from '../../lib/frontsBannerExclusions';
+import {
+	frontsBannerExcludedCollections,
+	frontsBannerExcludedPages,
+} from '../../lib/frontsBannerExclusions';
 import { getMerchHighPosition } from '../../lib/getAdPositions';
+
+const isCollectionExclusionPresent = (
+	pageId: string,
+	collectionName: string | null,
+): boolean => {
+	// Tag Fronts collections don't have names, so no exclusions can be present.
+	if (!collectionName) {
+		return false;
+	}
+
+	return Boolean(
+		frontsBannerExcludedCollections[pageId]?.includes(collectionName),
+	);
+};
+
+/**
+ * There are some pages (e.g. /news/series/cotton-capital) and some
+ * collections (e.g.: "Ukraine invasion") that we don't want to show ads above.
+ * This is usually because we don't want to take the focus away from important content.
+ */
+const isExclusionPresent = (
+	pageId: string,
+	collectionName: string | null,
+): boolean => {
+	if (frontsBannerExcludedPages.includes(pageId)) {
+		return true;
+	}
+
+	return isCollectionExclusionPresent(pageId, collectionName);
+};
 
 export const decideMerchHighAndMobileAdSlots = (
 	renderAds: boolean,
@@ -120,7 +153,7 @@ export const decideFrontsBannerAdSlot = (
 		showBannerAds &&
 		numBannerAdsInserted.current < MAX_FRONTS_BANNER_ADS &&
 		index % 3 === 2 && // Insert above the 3rd, 6th, ..., container
-		!isCollectionExclusionPresent(pageId, collectionName)
+		!isExclusionPresent(pageId, collectionName)
 	) {
 		numBannerAdsInserted.current = numBannerAdsInserted.current + 1;
 
@@ -135,18 +168,4 @@ export const decideFrontsBannerAdSlot = (
 	}
 
 	return null;
-};
-
-const isCollectionExclusionPresent = (
-	pageId: string,
-	collectionName: string | null,
-): boolean => {
-	// Tag Fronts collections don't have names, so no exclusions can be present.
-	if (!collectionName) {
-		return false;
-	}
-
-	return Boolean(
-		frontsBannerExcludedCollections[pageId]?.includes(collectionName),
-	);
 };

--- a/dotcom-rendering/src/lib/frontsBannerExclusions.ts
+++ b/dotcom-rendering/src/lib/frontsBannerExclusions.ts
@@ -1,7 +1,7 @@
 import type { FrontsBannerAdCollections } from '../types/commercial';
 
 /**
- * This file is temporary.
+ * This constant is temporary.
  *
  * When inserting advert slots into fronts pages, there are some containers in which
  * we do not want to insert slots above, to ensure good page aesthetics. An example is
@@ -15,7 +15,10 @@ import type { FrontsBannerAdCollections } from '../types/commercial';
  *
  * Contact Dominik Lander or the commercial dev team for more information.
  */
-
 export const frontsBannerExcludedCollections: FrontsBannerAdCollections = {
 	uk: ['Ukraine invasion'],
 };
+
+export const frontsBannerExcludedPages: string[] = [
+	'news/series/cotton-capital',
+];


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

- Prevents fronts-banner ads showing on the Cotton Capital front.
- Provides a mechanism for preventing fronts-banner ads from appearing on certain sensitive pages in the future

## Why?

- Interrupting the content flow on https://www.theguardian.com/news/series/cotton-capital with ads ruins the well-crafted content.
 
## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/9574885/08a00e7b-6149-4503-babf-8e2ca1c88cdf
[after]: https://github.com/guardian/dotcom-rendering/assets/9574885/5dd96b4c-e52d-41f6-9e25-928b199dc6a4

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
