### PR TITLE
Don't apply flex-end alignment to fronts-banner containers

### DIFF
--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -152,8 +152,10 @@ const adSlotCollapseStyles = css`
  * For CSS in Frontend, see mark: 9473ae05-a901-4a8d-a51d-1b9c894d6e1f
  */
 const fluidAdStyles = css`
-	&.ad-slot--fluid {
+	&.ad-slot--fluid:not([class*='ad-slot--fronts-banner']) {
 		min-height: 250px;
+	}
+	&.ad-slot--fluid {
 		line-height: 10px;
 		padding: 0;
 		margin: 0;

--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -152,10 +152,8 @@ const adSlotCollapseStyles = css`
  * For CSS in Frontend, see mark: 9473ae05-a901-4a8d-a51d-1b9c894d6e1f
  */
 const fluidAdStyles = css`
-	&.ad-slot--fluid:not([class*='ad-slot--fronts-banner']) {
-		min-height: 250px;
-	}
 	&.ad-slot--fluid {
+		min-height: 250px;
 		line-height: 10px;
 		padding: 0;
 		margin: 0;
@@ -263,10 +261,6 @@ const frontsBannerAdContainerStyles = css`
 	width: 100%;
 	display: flex;
 	justify-content: center;
-
-	/* This stops the visual effect where the advert renders at the
-	   top of the ad slot, then is pushed down 24px when the label renders */
-	align-items: flex-end;
 `;
 
 const frontsBannerCollapseStyles = css`


### PR DESCRIPTION
## What does this change?
Removes `align-items: flex end` from the fronts-banner container styles.

## Why?
The fluid min-height of 250px is smaller than the min-height of the container, resulting in a space appearing above the ad because it was aligned to the bottom of the container.

## Screenshots
Before:
<img width="1429" alt="Screenshot 2023-10-19 at 12 49 49" src="https://github.com/guardian/dotcom-rendering/assets/108270776/7f91d01f-3af5-4390-a332-735aedd6cf41">

After:
<img width="1501" alt="Screenshot 2023-10-19 at 12 44 10" src="https://github.com/guardian/dotcom-rendering/assets/108270776/b32086b6-ad2f-4463-abf4-2d18b78ddd1c">


