### PR TITLE
Reduce the kicker's underline offset

### DIFF
--- a/dotcom-rendering/src/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/components/CardHeadline.tsx
@@ -175,6 +175,7 @@ const sublinkStyles = css`
 		color: inherit;
 		text-decoration: none;
 		.show-underline {
+			text-underline-offset: -5%;
 			text-decoration: underline;
 		}
 	}


### PR DESCRIPTION
The underline was touching the top of the line below

## Screenshots

| Before | After |
|--------|--------|
| ![image](https://github.com/guardian/dotcom-rendering/assets/705427/a832274f-7fdb-4b94-ba54-7ec6feda02b2) | ![image](https://github.com/guardian/dotcom-rendering/assets/705427/0b6ef155-ed72-4ccb-810e-0d9acc59f7d4) |
| ![image](https://github.com/guardian/dotcom-rendering/assets/705427/7740207d-8720-41e3-8757-31a1ddc33c12) | ![image](https://github.com/guardian/dotcom-rendering/assets/705427/bc8bd9e6-0221-45ae-b67a-0bd383767c1f) |