### PR TITLE
Move full-width class to fronts-banner container

### DIFF
--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -257,10 +257,18 @@ const frontsBannerAdTopContainerStyles = css`
 `;
 
 const frontsBannerAdContainerStyles = css`
-	/* Native templates require a width (or min-width) to be explicitly set */
-	width: 100%;
 	display: flex;
 	justify-content: center;
+
+	/* Native templates require a width (or min-width) to be explicitly set */
+	width: ${breakpoints['wide']}px;
+	/* This is similar to fluid ads, except this class is applied using messenger */
+	&.ad-slot--full-width {
+		width: 100%;
+		.ad-slot {
+			max-width: 100%;
+		}
+	}
 `;
 
 const frontsBannerCollapseStyles = css`
@@ -270,16 +278,11 @@ const frontsBannerCollapseStyles = css`
 const frontsBannerAdStyles = css`
 	position: relative;
 	min-height: ${frontsBannerMinHeight}px;
-	max-width: ${breakpoints['wide']}px;
 	/* No banner should be taller than 600px */
 	max-height: ${600 + labelHeight}px;
+	max-width: ${breakpoints['wide']}px;
 	overflow: hidden;
 	padding-bottom: ${frontsBannerPaddingHeight}px;
-
-	/* This is similar to fluid ads, except this class is applied using messenger */
-	&.ad-slot--full-width {
-		max-width: 100%;
-	}
 `;
 
 const articleEndAdStyles = css`


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

The `ad-slot--full-width` class that allows the fronts-banner ad slot to display full width ads has been moved to the ad slot container

## Why?

A `max-width` set to a value on the ad slot container means that GAM knows the maximum width a slot can be. This means that GAM will not fill the slot with ads that are too wide for the container. For ads that need to be full-width, we overwrite this value

<!--
## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
