### PR TITLE
Make `InteractiveSupportButton` Island server safe

### DIFF
--- a/dotcom-rendering/src/components/InteractiveSupportButton.importable.tsx
+++ b/dotcom-rendering/src/components/InteractiveSupportButton.importable.tsx
@@ -5,6 +5,7 @@ import {
 	LinkButton,
 	SvgArrowRightStraight,
 } from '@guardian/source-react-components';
+import { useEffect, useState } from 'react';
 import { shouldHideSupportMessaging } from '../lib/contributions';
 import type { EditionId } from '../lib/edition';
 import { nestedOphanComponents } from '../lib/ophan-helpers';
@@ -30,7 +31,11 @@ export const InteractiveSupportButton = ({
 	editionId,
 	subscribeUrl,
 }: InteractiveSupportButtonProps) => {
-	const hideSupportMessaging = shouldHideSupportMessaging();
+	const [hideSupportMessaging, setHideSupportMessaging] = useState(true);
+
+	useEffect(() => {
+		setHideSupportMessaging(shouldHideSupportMessaging());
+	}, []);
 
 	if (!hideSupportMessaging) {
 		return (

--- a/dotcom-rendering/src/components/Island.test.tsx
+++ b/dotcom-rendering/src/components/Island.test.tsx
@@ -6,6 +6,7 @@ import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
 import { renderToString } from 'react-dom/server';
 import { CardCommentCount } from './CardCommentCount.importable';
 import { EnhancePinnedPost } from './EnhancePinnedPost.importable';
+import { InteractiveSupportButton } from './InteractiveSupportButton.importable';
 import { Island } from './Island';
 import { Liveness } from './Liveness.importable';
 import { OnwardsUpper } from './OnwardsUpper.importable';
@@ -92,6 +93,14 @@ describe('Island: server-side rendering', () => {
 
 	test('EnhancePinnedPost', () => {
 		expect(() => renderToString(<EnhancePinnedPost />)).not.toThrow();
+	});
+
+	test('InteractiveSupportButton', () => {
+		expect(() =>
+			renderToString(
+				<InteractiveSupportButton editionId="UK" subscribeUrl="" />,
+			),
+		).not.toThrow();
 	});
 
 	test('Snow', () => {


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Call `shouldHideSupportMessaging` in a `useEffect` to ensure it only runs on the client-side.

## Why?

Islands should render independently of their execution context. `shouldHideSupportMessaging` relies on reading cookie, which is not possible in our server context.

- Split out from #8991 for easier review

## Screenshots

N/A