### PR TITLE
Make `StickyBottomBanner` Island server safe

### DIFF
--- a/dotcom-rendering/src/components/Island.test.tsx
+++ b/dotcom-rendering/src/components/Island.test.tsx
@@ -11,6 +11,7 @@ import { Liveness } from './Liveness.importable';
 import { OnwardsUpper } from './OnwardsUpper.importable';
 import { SetABTests } from './SetABTests.importable';
 import { Snow } from './Snow.importable';
+import { StickyBottomBanner } from './StickyBottomBanner.importable';
 
 // Type tests
 // Test that impossible prop combinations are caught by TypeScript.
@@ -156,6 +157,29 @@ describe('Island: server-side rendering', () => {
 					isDev={false}
 					pageIsSensitive={false}
 					abTestSwitches={{}}
+				/>,
+			),
+		).not.toThrow();
+	});
+
+	test('StickyBottomBanner', () => {
+		expect(() =>
+			renderToString(
+				<StickyBottomBanner
+					contentType=""
+					tags={[]}
+					sectionId=""
+					isPaidContent={false}
+					isPreview={false}
+					shouldHideReaderRevenue={false}
+					isMinuteArticle={false}
+					contributionsServiceUrl=""
+					idApiUrl=""
+					pageId=""
+					keywordIds=""
+					remoteBannerSwitch={true}
+					puzzleBannerSwitch={false}
+					isSensitive={false}
 				/>,
 			),
 		).not.toThrow();

--- a/dotcom-rendering/src/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/dotcom-rendering/src/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import type { CountryCode } from '@guardian/libs';
 import { getCookie } from '@guardian/libs';
 import {
 	getBanner,
@@ -56,7 +57,7 @@ type BuildPayloadProps = BaseProps & {
 };
 
 type CanShowProps = BaseProps & {
-	asyncCountryCode: Promise<string>;
+	countryCode: CountryCode;
 	remoteBannerConfig: boolean;
 	isPreview: boolean;
 	idApiUrl: string;
@@ -146,7 +147,7 @@ const buildPayload = async ({
 export const canShowRRBanner: CanShowFunctionType<BannerProps> = async ({
 	remoteBannerConfig,
 	isSignedIn,
-	asyncCountryCode,
+	countryCode,
 	contentType,
 	sectionId,
 	shouldHideReaderRevenue,
@@ -192,7 +193,6 @@ export const canShowRRBanner: CanShowFunctionType<BannerProps> = async ({
 		return { show: false };
 	}
 
-	const countryCode = await asyncCountryCode;
 	const optedOutOfArticleCount = await hasOptedOutOfArticleCount();
 	const bannerPayload = await buildPayload({
 		isSignedIn,
@@ -236,7 +236,7 @@ export const canShowRRBanner: CanShowFunctionType<BannerProps> = async ({
 export const canShowPuzzlesBanner: CanShowFunctionType<BannerProps> = async ({
 	remoteBannerConfig,
 	isSignedIn,
-	asyncCountryCode,
+	countryCode,
 	contentType,
 	sectionId,
 	shouldHideReaderRevenue,
@@ -260,7 +260,6 @@ export const canShowPuzzlesBanner: CanShowFunctionType<BannerProps> = async ({
 	}
 
 	if (isPuzzlesPage && remoteBannerConfig) {
-		const countryCode = await asyncCountryCode;
 		const optedOutOfArticleCount = await hasOptedOutOfArticleCount();
 		const bannerPayload = await buildPayload({
 			isSignedIn,


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Set `countryCode` via a `useEffect` hook so it’s synchronously defined.

## Why?

Islands should render independently of their execution context

- Split out from #8991 for easier review

## Screenshots

N/A