### PR TITLE
Stub Ophan `record` method in DCAR

### DIFF
--- a/dotcom-rendering/src/client/adaptiveSite.ts
+++ b/dotcom-rendering/src/client/adaptiveSite.ts
@@ -33,7 +33,7 @@ const hideAdaptedIslands = () => {
 };
 
 const recordAdaptedSite = (renderingTarget: RenderingTarget) =>
-	recordExperiences(renderingTarget, 'adapted');
+	recordExperiences(renderingTarget, ['adapted']);
 
 export const adaptSite = (renderingTarget: RenderingTarget): void => {
 	log('openJournalism', '🎛️ Adapting');

--- a/dotcom-rendering/src/client/adaptiveSite.ts
+++ b/dotcom-rendering/src/client/adaptiveSite.ts
@@ -2,6 +2,7 @@ import { log } from '@guardian/libs';
 import { isServer } from '../lib/isServer';
 import { setSchedulerPriorityLastStartTime } from '../lib/scheduler';
 import { recordExperiences } from './ophan/ophan';
+import { RenderingTarget } from '../types/renderingTarget';
 
 /**
  * Whether we should adapt the current page to address poor performance issues.
@@ -31,9 +32,10 @@ const hideAdaptedIslands = () => {
 	document.head.appendChild(style);
 };
 
-const recordAdaptedSite = () => recordExperiences('adapted');
+const recordAdaptedSite = (renderingTarget: RenderingTarget) =>
+	recordExperiences(renderingTarget, 'adapted');
 
-export const adaptSite = (): void => {
+export const adaptSite = (renderingTarget: RenderingTarget): void => {
 	log('openJournalism', '🎛️ Adapting');
 
 	// disable all tasks except critical ones
@@ -41,5 +43,5 @@ export const adaptSite = (): void => {
 	setSchedulerPriorityLastStartTime('enhancement', 0);
 	hideAdaptedIslands();
 
-	void recordAdaptedSite();
+	void recordAdaptedSite(renderingTarget);
 };

--- a/dotcom-rendering/src/client/adaptiveSite.ts
+++ b/dotcom-rendering/src/client/adaptiveSite.ts
@@ -1,8 +1,8 @@
 import { log } from '@guardian/libs';
 import { isServer } from '../lib/isServer';
 import { setSchedulerPriorityLastStartTime } from '../lib/scheduler';
+import type { RenderingTarget } from '../types/renderingTarget';
 import { recordExperiences } from './ophan/ophan';
-import { RenderingTarget } from '../types/renderingTarget';
 
 /**
  * Whether we should adapt the current page to address poor performance issues.

--- a/dotcom-rendering/src/client/bootCmp.ts
+++ b/dotcom-rendering/src/client/bootCmp.ts
@@ -7,8 +7,8 @@ import type {
 } from '@guardian/libs';
 import { getCookie, log } from '@guardian/libs';
 import { getLocaleCode } from '../lib/getCountryCode';
+import type { RenderingTarget } from '../types/renderingTarget';
 import { submitComponentEvent } from './ophan/ophan';
-import { RenderingTarget } from '../types/renderingTarget';
 
 const submitConsentEventsToOphan = (renderingTarget: RenderingTarget) =>
 	onConsent().then((consentState: ConsentState) => {

--- a/dotcom-rendering/src/client/bootCmp.ts
+++ b/dotcom-rendering/src/client/bootCmp.ts
@@ -8,8 +8,9 @@ import type {
 import { getCookie, log } from '@guardian/libs';
 import { getLocaleCode } from '../lib/getCountryCode';
 import { submitComponentEvent } from './ophan/ophan';
+import { RenderingTarget } from '../types/renderingTarget';
 
-const submitConsentEventsToOphan = () =>
+const submitConsentEventsToOphan = (renderingTarget: RenderingTarget) =>
 	onConsent().then((consentState: ConsentState) => {
 		// eslint-disable-next-line @typescript-eslint/strict-boolean-expressions, @typescript-eslint/no-unnecessary-condition -- Review if this check is needed
 		if (!consentState) return;
@@ -77,7 +78,7 @@ const submitConsentEventsToOphan = () =>
 			action,
 		} satisfies OphanComponentEvent;
 
-		return submitComponentEvent(event);
+		return submitComponentEvent(event, renderingTarget);
 	});
 
 const initialiseCmp = () =>
@@ -111,12 +112,14 @@ const eagerlyImportPrivacySettingsLinkIsland = () =>
  * Keep this file in sync with CONSENT_TIMING in static/src/javascripts/boot.js in frontend
  * mark: CONSENT_TIMING
  */
-export const bootCmp = async (): Promise<void> => {
+export const bootCmp = async (
+	renderingTarget: RenderingTarget,
+): Promise<void> => {
 	if (!window.guardian.config.switches.consentManagement) return; // CMP turned off!
 
 	await Promise.all([
 		initialiseCmp(),
 		eagerlyImportPrivacySettingsLinkIsland(),
-		submitConsentEventsToOphan(),
+		submitConsentEventsToOphan(renderingTarget),
 	]);
 };

--- a/dotcom-rendering/src/client/index.ts
+++ b/dotcom-rendering/src/client/index.ts
@@ -4,7 +4,7 @@ import { startup } from './startup';
 
 void (async () => {
 	if (await shouldAdapt()) {
-		adaptSite();
+		adaptSite('Web');
 	}
 
 	/*************************************************************
@@ -19,7 +19,7 @@ void (async () => {
 		'bootCmp',
 		() =>
 			import(/* webpackMode: "eager" */ './bootCmp').then(({ bootCmp }) =>
-				bootCmp(),
+				bootCmp('Web'),
 			),
 		{
 			priority: 'critical',
@@ -31,7 +31,9 @@ void (async () => {
 		() =>
 			import(
 				/* webpackMode: "eager" */ './ophan/recordInitialPageEvents'
-			).then(({ recordInitialPageEvents }) => recordInitialPageEvents()),
+			).then(({ recordInitialPageEvents }) =>
+				recordInitialPageEvents('Web'),
+			),
 		{
 			priority: 'critical',
 		},
@@ -83,7 +85,7 @@ void (async () => {
 		() =>
 			import(
 				/* webpackMode: "eager" */ './poorPerformanceMonitoring'
-			).then(({ recordPoorPerformance }) => recordPoorPerformance()),
+			).then(({ recordPoorPerformance }) => recordPoorPerformance('Web')),
 		{
 			priority: 'critical',
 		},

--- a/dotcom-rendering/src/client/ophan/ophan.ts
+++ b/dotcom-rendering/src/client/ophan/ophan.ts
@@ -7,7 +7,7 @@ import type {
 } from '@guardian/libs';
 import { log } from '@guardian/libs';
 import type { ServerSideTests } from '../../types/config';
-import { RenderingTarget } from '../../types/renderingTarget';
+import type { RenderingTarget } from '../../types/renderingTarget';
 
 export type OphanRecordFunction = (
 	event: { [key: string]: unknown } & {

--- a/dotcom-rendering/src/client/ophan/ophan.ts
+++ b/dotcom-rendering/src/client/ophan/ophan.ts
@@ -39,12 +39,14 @@ export const getOphan = async (
 		cachedOphan = {
 			setEventEmitter: () => undefined, // We don't currently have a custom eventEmitter on DCR - like 'mediator' in Frontend.
 			trackComponentAttention: () => undefined,
-			record: (event) =>
-				log(
-					'dotcom',
-					"🧿 We're not recording this event because we are in DCAR",
-					event,
-				),
+			record: (e) => {
+				if (e instanceof Error) {
+					window.guardian.modules.sentry.reportError(
+						e,
+						"We are in DCAR but Ophan record method got called. This shouldn't have happened. Please investigate why",
+					);
+				}
+			},
 			viewId: 'Apps',
 			pageViewId: 'Apps',
 		};
@@ -176,7 +178,7 @@ export const recordPerformance = async (
 const experiencesSet = new Set(['dotcom-rendering']);
 export const recordExperiences = async (
 	renderingTarget: RenderingTarget,
-	...experiences: string[]
+	experiences: string[],
 ): Promise<void> => {
 	for (const experience of experiences) {
 		experiencesSet.add(experience);

--- a/dotcom-rendering/src/client/ophan/recordInitialPageEvents.ts
+++ b/dotcom-rendering/src/client/ophan/recordInitialPageEvents.ts
@@ -1,10 +1,10 @@
+import type { RenderingTarget } from '../../types/renderingTarget';
 import {
 	abTestPayload,
 	getOphan,
 	recordExperiences,
 	recordPerformance,
 } from './ophan';
-import { RenderingTarget } from '../../types/renderingTarget';
 
 export const recordInitialPageEvents = async (
 	renderingTarget: RenderingTarget,

--- a/dotcom-rendering/src/client/ophan/recordInitialPageEvents.ts
+++ b/dotcom-rendering/src/client/ophan/recordInitialPageEvents.ts
@@ -11,7 +11,7 @@ export const recordInitialPageEvents = async (
 ): Promise<void> => {
 	const { record } = await getOphan(renderingTarget);
 
-	void recordExperiences(renderingTarget, 'dotcom-rendering');
+	void recordExperiences(renderingTarget, ['dotcom-rendering']);
 	record({ edition: window.guardian.config.page.edition });
 
 	// Record server-side AB test variants (i.e. control or variant)

--- a/dotcom-rendering/src/client/ophan/recordInitialPageEvents.ts
+++ b/dotcom-rendering/src/client/ophan/recordInitialPageEvents.ts
@@ -4,11 +4,14 @@ import {
 	recordExperiences,
 	recordPerformance,
 } from './ophan';
+import { RenderingTarget } from '../../types/renderingTarget';
 
-export const recordInitialPageEvents = async (): Promise<void> => {
-	const { record } = await getOphan();
+export const recordInitialPageEvents = async (
+	renderingTarget: RenderingTarget,
+): Promise<void> => {
+	const { record } = await getOphan(renderingTarget);
 
-	void recordExperiences('dotcom-rendering');
+	void recordExperiences(renderingTarget, 'dotcom-rendering');
 	record({ edition: window.guardian.config.page.edition });
 
 	// Record server-side AB test variants (i.e. control or variant)
@@ -16,7 +19,7 @@ export const recordInitialPageEvents = async (): Promise<void> => {
 
 	// We wait for the load event so that we can be sure our assetPerformance is reported as expected.
 	window.addEventListener('load', function load() {
-		void recordPerformance();
+		void recordPerformance(renderingTarget);
 		window.removeEventListener('load', load, false);
 	});
 };

--- a/dotcom-rendering/src/client/poorPerformanceMonitoring.ts
+++ b/dotcom-rendering/src/client/poorPerformanceMonitoring.ts
@@ -1,6 +1,6 @@
 import { log } from '@guardian/libs';
+import type { RenderingTarget } from '../types/renderingTarget';
 import { recordExperiences } from './ophan/ophan';
-import { RenderingTarget } from '../types/renderingTarget';
 
 const logPerformanceInfo = (name: string, data?: unknown) =>
 	log('openJournalism', '⏱', name, data);

--- a/dotcom-rendering/src/client/poorPerformanceMonitoring.ts
+++ b/dotcom-rendering/src/client/poorPerformanceMonitoring.ts
@@ -78,7 +78,9 @@ export const recordPoorPerformance = async (
 	try {
 		if (await isPerformingPoorly()) {
 			log('openJournalism', `🐌 Poor page performance`);
-			return recordExperiences(renderingTarget, 'poor-page-performance');
+			return recordExperiences(renderingTarget, [
+				'poor-page-performance',
+			]);
 		}
 	} catch (error) {
 		// do nothing if the performance API is not available

--- a/dotcom-rendering/src/client/poorPerformanceMonitoring.ts
+++ b/dotcom-rendering/src/client/poorPerformanceMonitoring.ts
@@ -1,5 +1,6 @@
 import { log } from '@guardian/libs';
 import { recordExperiences } from './ophan/ophan';
+import { RenderingTarget } from '../types/renderingTarget';
 
 const logPerformanceInfo = (name: string, data?: unknown) =>
 	log('openJournalism', '⏱', name, data);
@@ -71,11 +72,13 @@ export const isPerformingPoorly = async (): Promise<boolean> =>
 		(await isFirstContentfulPaintAboveThreshold()));
 
 /** If the current page is performing poorly, record it in Ophan */
-export const recordPoorPerformance = async (): Promise<void> => {
+export const recordPoorPerformance = async (
+	renderingTarget: RenderingTarget,
+): Promise<void> => {
 	try {
 		if (await isPerformingPoorly()) {
 			log('openJournalism', `🐌 Poor page performance`);
-			return recordExperiences('poor-page-performance');
+			return recordExperiences(renderingTarget, 'poor-page-performance');
 		}
 	} catch (error) {
 		// do nothing if the performance API is not available

--- a/dotcom-rendering/src/components/BrazeMessaging.importable.tsx
+++ b/dotcom-rendering/src/components/BrazeMessaging.importable.tsx
@@ -1,5 +1,6 @@
 import { log } from '@guardian/libs';
 import { useBraze } from '../lib/useBraze';
+import { useConfig } from './ConfigContext';
 
 type Props = {
 	idApiUrl: string;
@@ -18,7 +19,9 @@ type Props = {
  * Does not render **anything**.
  */
 export const BrazeMessaging = ({ idApiUrl }: Props) => {
-	const { brazeMessages, brazeCards } = useBraze(idApiUrl);
+	const { renderingTarget } = useConfig();
+
+	const { brazeMessages, brazeCards } = useBraze(idApiUrl, renderingTarget);
 
 	if (brazeMessages) {
 		log('tx', 'Braze Messages Interface loaded', brazeMessages);

--- a/dotcom-rendering/src/components/Dropdown.test.tsx
+++ b/dotcom-rendering/src/components/Dropdown.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render } from '@testing-library/react';
 import type { DropdownLinkType } from './Dropdown';
 import { Dropdown } from './Dropdown';
+import { ConfigProvider } from './ConfigContext';
 
 const links: [
 	DropdownLinkType,
@@ -40,12 +41,14 @@ const LABEL = 'Dropdown label';
 describe('Dropdown', () => {
 	it('should display the given label', () => {
 		const { getByText } = render(
-			<Dropdown
-				id="abc"
-				label={LABEL}
-				links={links}
-				dataLinkName="linkname"
-			/>,
+			<ConfigProvider value={{ renderingTarget: 'Web' }}>
+				<Dropdown
+					id="abc"
+					label={LABEL}
+					links={links}
+					dataLinkName="linkname"
+				/>
+			</ConfigProvider>,
 		);
 
 		expect(getByText(LABEL)).toBeInTheDocument();
@@ -53,12 +56,14 @@ describe('Dropdown', () => {
 
 	it('should display link titles', () => {
 		const { getByText } = render(
-			<Dropdown
-				id="abc"
-				label={LABEL}
-				links={links}
-				dataLinkName="linkname"
-			/>,
+			<ConfigProvider value={{ renderingTarget: 'Web' }}>
+				<Dropdown
+					id="abc"
+					label={LABEL}
+					links={links}
+					dataLinkName="linkname"
+				/>
+			</ConfigProvider>,
 		);
 
 		expect(getByText(links[0].title)).toBeInTheDocument();
@@ -69,12 +74,14 @@ describe('Dropdown', () => {
 
 	it('should render the correct number of link items', () => {
 		const { container } = render(
-			<Dropdown
-				id="abc"
-				label={LABEL}
-				links={links}
-				dataLinkName="linkname"
-			/>,
+			<ConfigProvider value={{ renderingTarget: 'Web' }}>
+				<Dropdown
+					id="abc"
+					label={LABEL}
+					links={links}
+					dataLinkName="linkname"
+				/>
+			</ConfigProvider>,
 		);
 
 		const listItems = container.querySelectorAll('li');
@@ -84,12 +91,14 @@ describe('Dropdown', () => {
 
 	it('should expand the menu when clicked upon', () => {
 		const { container, getByRole } = render(
-			<Dropdown
-				id="abc"
-				label={LABEL}
-				links={links}
-				dataLinkName="linkname"
-			/>,
+			<ConfigProvider value={{ renderingTarget: 'Web' }}>
+				<Dropdown
+					id="abc"
+					label={LABEL}
+					links={links}
+					dataLinkName="linkname"
+				/>
+			</ConfigProvider>,
 		);
 
 		const ulElement = container.querySelector('ul');
@@ -101,12 +110,14 @@ describe('Dropdown', () => {
 
 	it('should close the expanded menu when they click away', () => {
 		const { container, getByRole } = render(
-			<Dropdown
-				id="abc"
-				label={LABEL}
-				links={links}
-				dataLinkName="linkname"
-			/>,
+			<ConfigProvider value={{ renderingTarget: 'Web' }}>
+				<Dropdown
+					id="abc"
+					label={LABEL}
+					links={links}
+					dataLinkName="linkname"
+				/>
+			</ConfigProvider>,
 		);
 
 		const ulElement = container.querySelector('ul');
@@ -119,12 +130,14 @@ describe('Dropdown', () => {
 
 	it('should close the expanded menu when blurred', () => {
 		const { container, getByRole } = render(
-			<Dropdown
-				id="abc"
-				label={LABEL}
-				links={links}
-				dataLinkName="linkname"
-			/>,
+			<ConfigProvider value={{ renderingTarget: 'Web' }}>
+				<Dropdown
+					id="abc"
+					label={LABEL}
+					links={links}
+					dataLinkName="linkname"
+				/>
+			</ConfigProvider>,
 		);
 
 		const ulElement = container.querySelector('ul');

--- a/dotcom-rendering/src/components/Dropdown.test.tsx
+++ b/dotcom-rendering/src/components/Dropdown.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render } from '@testing-library/react';
+import { ConfigProvider } from './ConfigContext';
 import type { DropdownLinkType } from './Dropdown';
 import { Dropdown } from './Dropdown';
-import { ConfigProvider } from './ConfigContext';
 
 const links: [
 	DropdownLinkType,

--- a/dotcom-rendering/src/components/Dropdown.tsx
+++ b/dotcom-rendering/src/components/Dropdown.tsx
@@ -21,6 +21,7 @@ import { linkNotificationCount } from '../lib/linkNotificationCount';
 import type { Notification } from '../lib/notification';
 import { useIsInView } from '../lib/useIsInView';
 import { useOnce } from '../lib/useOnce';
+import { useConfig } from './ConfigContext';
 
 const NOTIFICATION_COMPONENT_TYPE = 'RETENTION_HEADER';
 export interface DropdownLinkType {
@@ -279,6 +280,8 @@ const DropdownLink = ({ link, index }: DropdownLinkProps) => {
 		[link],
 	);
 
+	const { renderingTarget } = useConfig();
+
 	const [hasBeenSeen, setNode] = useIsInView({
 		debounce: true,
 	});
@@ -306,10 +309,13 @@ const DropdownLink = ({ link, index }: DropdownLinkProps) => {
 				notification.logImpression?.();
 			}
 
-			void submitComponentEvent({
-				component: ophanComponent,
-				action: 'VIEW',
-			});
+			void submitComponentEvent(
+				{
+					component: ophanComponent,
+					action: 'VIEW',
+				},
+				renderingTarget,
+			);
 		}
 	}, [
 		hasBeenSeen,
@@ -321,10 +327,13 @@ const DropdownLink = ({ link, index }: DropdownLinkProps) => {
 
 	useOnce(() => {
 		if (ophanComponent) {
-			void submitComponentEvent({
-				component: ophanComponent,
-				action: 'INSERT',
-			});
+			void submitComponentEvent(
+				{
+					component: ophanComponent,
+					action: 'INSERT',
+				},
+				renderingTarget,
+			);
 		}
 	}, [ophanComponent]);
 
@@ -347,10 +356,13 @@ const DropdownLink = ({ link, index }: DropdownLinkProps) => {
 				data-link-name={link.dataLinkName}
 				onClick={() => {
 					if (ophanComponent) {
-						void submitComponentEvent({
-							component: ophanComponent,
-							action: 'CLICK',
-						});
+						void submitComponentEvent(
+							{
+								component: ophanComponent,
+								action: 'CLICK',
+							},
+							renderingTarget,
+						);
 					}
 				}}
 			>

--- a/dotcom-rendering/src/components/Dropdown.tsx
+++ b/dotcom-rendering/src/components/Dropdown.tsx
@@ -323,6 +323,7 @@ const DropdownLink = ({ link, index }: DropdownLinkProps) => {
 		link.notifications,
 		hasSentViewEvent,
 		link.id,
+		renderingTarget,
 	]);
 
 	useOnce(() => {

--- a/dotcom-rendering/src/components/EnhancePinnedPost.importable.tsx
+++ b/dotcom-rendering/src/components/EnhancePinnedPost.importable.tsx
@@ -3,6 +3,8 @@ import { useEffect, useRef, useState } from 'react';
 import { submitComponentEvent } from '../client/ophan/ophan';
 import { isServer } from '../lib/isServer';
 import { useIsInView } from '../lib/useIsInView';
+import { useConfig } from './ConfigContext';
+import { RenderingTarget } from '../types/renderingTarget';
 
 const pinnedPost: HTMLElement | null = !isServer
 	? window.document.querySelector('[data-gu-marker=pinned-post]')
@@ -56,26 +58,32 @@ function scrollOnCollapse() {
 	}
 }
 
-const handleClickTracking = () => {
+const handleClickTracking = (renderingTarget: RenderingTarget) => {
 	if (pinnedPostCheckBox instanceof HTMLInputElement) {
 		if (pinnedPostCheckBox.checked) {
-			void submitComponentEvent({
-				component: {
-					componentType: 'LIVE_BLOG_PINNED_POST',
-					id: pinnedPost?.id,
+			void submitComponentEvent(
+				{
+					component: {
+						componentType: 'LIVE_BLOG_PINNED_POST',
+						id: pinnedPost?.id,
+					},
+					action: 'CLICK',
+					value: 'show-more',
 				},
-				action: 'CLICK',
-				value: 'show-more',
-			});
+				renderingTarget,
+			);
 		} else {
-			void submitComponentEvent({
-				component: {
-					componentType: 'LIVE_BLOG_PINNED_POST',
-					id: pinnedPost?.id,
+			void submitComponentEvent(
+				{
+					component: {
+						componentType: 'LIVE_BLOG_PINNED_POST',
+						id: pinnedPost?.id,
+					},
+					action: 'CLICK',
+					value: 'show-less',
 				},
-				action: 'CLICK',
-				value: 'show-less',
-			});
+				renderingTarget,
+			);
 			scrollOnCollapse();
 		}
 	}
@@ -88,6 +96,8 @@ export const EnhancePinnedPost = () => {
 		repeat: true,
 		node: pinnedPost ?? undefined,
 	});
+
+	const { renderingTarget } = useConfig();
 
 	const pinnedPostTiming =
 		useRef<ReturnType<typeof startPerformanceMeasure>>();
@@ -122,12 +132,13 @@ export const EnhancePinnedPost = () => {
 	}, []);
 
 	useEffect(() => {
-		pinnedPostCheckBox?.addEventListener('change', handleClickTracking);
+		pinnedPostCheckBox?.addEventListener('change', () =>
+			handleClickTracking(renderingTarget),
+		);
 
 		return () => {
-			pinnedPostCheckBox?.removeEventListener(
-				'change',
-				handleClickTracking,
+			pinnedPostCheckBox?.removeEventListener('change', () =>
+				handleClickTracking(renderingTarget),
 			);
 		};
 	}, []);
@@ -147,14 +158,17 @@ export const EnhancePinnedPost = () => {
 			const timeTaken = pinnedPostTiming.current?.endPerformanceMeasure();
 			if (timeTaken !== undefined) {
 				const timeTakenInSeconds = timeTaken / 1000;
-				void submitComponentEvent({
-					component: {
-						componentType: 'LIVE_BLOG_PINNED_POST',
-						id: pinnedPost.id,
+				void submitComponentEvent(
+					{
+						component: {
+							componentType: 'LIVE_BLOG_PINNED_POST',
+							id: pinnedPost.id,
+						},
+						action: 'VIEW',
+						value: timeTakenInSeconds.toString(),
 					},
-					action: 'VIEW',
-					value: timeTakenInSeconds.toString(),
-				});
+					renderingTarget,
+				);
 			}
 		}
 	}, [isInView, hasBeenSeen]);

--- a/dotcom-rendering/src/components/EnhancePinnedPost.importable.tsx
+++ b/dotcom-rendering/src/components/EnhancePinnedPost.importable.tsx
@@ -3,8 +3,8 @@ import { useEffect, useRef, useState } from 'react';
 import { submitComponentEvent } from '../client/ophan/ophan';
 import { isServer } from '../lib/isServer';
 import { useIsInView } from '../lib/useIsInView';
+import type { RenderingTarget } from '../types/renderingTarget';
 import { useConfig } from './ConfigContext';
-import { RenderingTarget } from '../types/renderingTarget';
 
 const pinnedPost: HTMLElement | null = !isServer
 	? window.document.querySelector('[data-gu-marker=pinned-post]')
@@ -141,7 +141,7 @@ export const EnhancePinnedPost = () => {
 				handleClickTracking(renderingTarget),
 			);
 		};
-	}, []);
+	}, [renderingTarget]);
 
 	// calculate duration when user is viewing pinned post
 	// and emit ophan events when the pinned post goes out of view
@@ -171,6 +171,6 @@ export const EnhancePinnedPost = () => {
 				);
 			}
 		}
-	}, [isInView, hasBeenSeen]);
+	}, [isInView, hasBeenSeen, renderingTarget]);
 	return null;
 };

--- a/dotcom-rendering/src/components/GuideAtom/GuideAtom.test.tsx
+++ b/dotcom-rendering/src/components/GuideAtom/GuideAtom.test.tsx
@@ -2,11 +2,14 @@ import { fireEvent, render } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import { defaultStory } from '../../../fixtures/manual/guideAtom';
 import { GuideAtom } from './GuideAtom';
+import { ConfigProvider } from '../ConfigContext';
 
 describe('GuideAtom', () => {
 	it('should render', () => {
 		const { getByText, queryByText } = render(
-			<GuideAtom {...defaultStory} />,
+			<ConfigProvider value={{ renderingTarget: 'Web' }}>
+				<GuideAtom {...defaultStory} />
+			</ConfigProvider>,
 		);
 
 		expect(getByText('Quick Guide')).toBeInTheDocument();
@@ -23,7 +26,9 @@ describe('GuideAtom', () => {
 
 	it('Show feedback on like', () => {
 		const { getByText, queryByText, queryByTestId } = render(
-			<GuideAtom {...defaultStory} />,
+			<ConfigProvider value={{ renderingTarget: 'Web' }}>
+				<GuideAtom {...defaultStory} />
+			</ConfigProvider>,
 		);
 
 		// Expand Guide
@@ -41,7 +46,9 @@ describe('GuideAtom', () => {
 
 	it('Show feedback on dislike', () => {
 		const { getByText, queryByText, queryByTestId } = render(
-			<GuideAtom {...defaultStory} />,
+			<ConfigProvider value={{ renderingTarget: 'Web' }}>
+				<GuideAtom {...defaultStory} />
+			</ConfigProvider>,
 		);
 
 		// Expand Guide

--- a/dotcom-rendering/src/components/GuideAtom/GuideAtom.test.tsx
+++ b/dotcom-rendering/src/components/GuideAtom/GuideAtom.test.tsx
@@ -1,8 +1,8 @@
 import { fireEvent, render } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import { defaultStory } from '../../../fixtures/manual/guideAtom';
-import { GuideAtom } from './GuideAtom';
 import { ConfigProvider } from '../ConfigContext';
+import { GuideAtom } from './GuideAtom';
 
 describe('GuideAtom', () => {
 	it('should render', () => {

--- a/dotcom-rendering/src/components/GuideAtom/GuideAtom.tsx
+++ b/dotcom-rendering/src/components/GuideAtom/GuideAtom.tsx
@@ -1,9 +1,9 @@
 import type { ArticleFormat } from '@guardian/libs';
 import { submitComponentEvent } from '../../client/ophan/ophan';
+import { useConfig } from '../ConfigContext';
 import { Body } from '../ExpandableAtom/Body';
 import { Container } from '../ExpandableAtom/Container';
 import { Footer } from '../ExpandableAtom/Footer';
-import { useConfig } from '../ConfigContext';
 
 export type GuideAtomProps = {
 	id: string;

--- a/dotcom-rendering/src/components/GuideAtom/GuideAtom.tsx
+++ b/dotcom-rendering/src/components/GuideAtom/GuideAtom.tsx
@@ -3,6 +3,7 @@ import { submitComponentEvent } from '../../client/ophan/ophan';
 import { Body } from '../ExpandableAtom/Body';
 import { Container } from '../ExpandableAtom/Container';
 import { Footer } from '../ExpandableAtom/Footer';
+import { useConfig } from '../ConfigContext';
 
 export type GuideAtomProps = {
 	id: string;
@@ -29,6 +30,8 @@ export const GuideAtom = ({
 	dislikeHandler,
 	expandCallback,
 }: GuideAtomProps): JSX.Element => {
+	const { renderingTarget } = useConfig();
+
 	return (
 		<Container
 			id={id}
@@ -40,15 +43,18 @@ export const GuideAtom = ({
 			expandCallback={
 				expandCallback ??
 				(() =>
-					submitComponentEvent({
-						component: {
-							componentType: 'GUIDE_ATOM',
-							id,
-							products: [],
-							labels: [],
+					submitComponentEvent(
+						{
+							component: {
+								componentType: 'GUIDE_ATOM',
+								id,
+								products: [],
+								labels: [],
+							},
+							action: 'EXPAND',
 						},
-						action: 'EXPAND',
-					}))
+						renderingTarget,
+					))
 			}
 		>
 			<Body html={html} image={image} credit={credit} format={format} />
@@ -57,28 +63,34 @@ export const GuideAtom = ({
 				dislikeHandler={
 					dislikeHandler ??
 					(() =>
-						submitComponentEvent({
-							component: {
-								componentType: 'GUIDE_ATOM',
-								id,
-								products: [],
-								labels: [],
+						submitComponentEvent(
+							{
+								component: {
+									componentType: 'GUIDE_ATOM',
+									id,
+									products: [],
+									labels: [],
+								},
+								action: 'DISLIKE',
 							},
-							action: 'DISLIKE',
-						}))
+							renderingTarget,
+						))
 				}
 				likeHandler={
 					likeHandler ??
 					(() =>
-						submitComponentEvent({
-							component: {
-								componentType: 'GUIDE_ATOM',
-								id,
-								products: [],
-								labels: [],
+						submitComponentEvent(
+							{
+								component: {
+									componentType: 'GUIDE_ATOM',
+									id,
+									products: [],
+									labels: [],
+								},
+								action: 'LIKE',
 							},
-							action: 'LIKE',
-						}))
+							renderingTarget,
+						))
 				}
 			></Footer>
 		</Container>

--- a/dotcom-rendering/src/components/HeaderTopBarMyAccount.tsx
+++ b/dotcom-rendering/src/components/HeaderTopBarMyAccount.tsx
@@ -20,6 +20,8 @@ import { useBraze } from '../lib/useBraze';
 import ProfileIcon from '../static/icons/profile.svg';
 import type { DropdownLinkType } from './Dropdown';
 import { Dropdown } from './Dropdown';
+import { RenderingTarget } from '../types/renderingTarget';
+import { useConfig } from './ConfigContext';
 
 interface MyAccountProps {
 	mmaUrl: string;
@@ -32,6 +34,7 @@ interface MyAccountProps {
 //when SignedIn, authStatus can only be one of the two SignedIn states
 type SignedInProps = MyAccountProps & {
 	authStatus: SignedInWithCookies | SignedInWithOkta;
+	renderingTarget: RenderingTarget;
 };
 
 const myAccountStyles = css`
@@ -254,8 +257,13 @@ const SignedInWithNotifications = ({
 	);
 };
 
-const SignedIn = ({ idApiUrl, authStatus, ...props }: SignedInProps) => {
-	const { brazeCards } = useBraze(idApiUrl);
+const SignedIn = ({
+	idApiUrl,
+	authStatus,
+	renderingTarget,
+	...props
+}: SignedInProps) => {
+	const { brazeCards } = useBraze(idApiUrl, renderingTarget);
 	const [brazeNotifications, setBrazeNotifications] = useState<
 		Notification[]
 	>([]);
@@ -285,19 +293,24 @@ export const MyAccount = ({
 	discussionApiUrl,
 	idApiUrl,
 	authStatus,
-}: MyAccountProps) => (
-	<div css={myAccountStyles}>
-		{authStatus.kind === 'SignedInWithOkta' ||
-		authStatus.kind === 'SignedInWithCookies' ? (
-			<SignedIn
-				mmaUrl={mmaUrl}
-				idUrl={idUrl}
-				discussionApiUrl={discussionApiUrl}
-				idApiUrl={idApiUrl}
-				authStatus={authStatus}
-			/>
-		) : (
-			<SignIn idUrl={idUrl} />
-		)}
-	</div>
-);
+}: MyAccountProps) => {
+	const { renderingTarget } = useConfig();
+
+	return (
+		<div css={myAccountStyles}>
+			{authStatus.kind === 'SignedInWithOkta' ||
+			authStatus.kind === 'SignedInWithCookies' ? (
+				<SignedIn
+					mmaUrl={mmaUrl}
+					idUrl={idUrl}
+					discussionApiUrl={discussionApiUrl}
+					idApiUrl={idApiUrl}
+					authStatus={authStatus}
+					renderingTarget={renderingTarget}
+				/>
+			) : (
+				<SignIn idUrl={idUrl} />
+			)}
+		</div>
+	);
+};

--- a/dotcom-rendering/src/components/HeaderTopBarMyAccount.tsx
+++ b/dotcom-rendering/src/components/HeaderTopBarMyAccount.tsx
@@ -18,10 +18,10 @@ import type {
 } from '../lib/useAuthStatus';
 import { useBraze } from '../lib/useBraze';
 import ProfileIcon from '../static/icons/profile.svg';
+import type { RenderingTarget } from '../types/renderingTarget';
+import { useConfig } from './ConfigContext';
 import type { DropdownLinkType } from './Dropdown';
 import { Dropdown } from './Dropdown';
-import { RenderingTarget } from '../types/renderingTarget';
-import { useConfig } from './ConfigContext';
 
 interface MyAccountProps {
 	mmaUrl: string;

--- a/dotcom-rendering/src/components/Island.test.tsx
+++ b/dotcom-rendering/src/components/Island.test.tsx
@@ -12,6 +12,7 @@ import { Liveness } from './Liveness.importable';
 import { OnwardsUpper } from './OnwardsUpper.importable';
 import { SetABTests } from './SetABTests.importable';
 import { Snow } from './Snow.importable';
+import { ConfigProvider } from './ConfigContext';
 
 // Type tests
 // Test that impossible prop combinations are caught by TypeScript.
@@ -92,7 +93,13 @@ describe('Island: server-side rendering', () => {
 	});
 
 	test('EnhancePinnedPost', () => {
-		expect(() => renderToString(<EnhancePinnedPost />)).not.toThrow();
+		expect(() =>
+			renderToString(
+				<ConfigProvider value={{ renderingTarget: 'Web' }}>
+					<EnhancePinnedPost />
+				</ConfigProvider>,
+			),
+		).not.toThrow();
 	});
 
 	test('InteractiveSupportButton', () => {

--- a/dotcom-rendering/src/components/Island.test.tsx
+++ b/dotcom-rendering/src/components/Island.test.tsx
@@ -5,6 +5,7 @@
 import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
 import { renderToString } from 'react-dom/server';
 import { CardCommentCount } from './CardCommentCount.importable';
+import { ConfigProvider } from './ConfigContext';
 import { EnhancePinnedPost } from './EnhancePinnedPost.importable';
 import { InteractiveSupportButton } from './InteractiveSupportButton.importable';
 import { Island } from './Island';
@@ -12,7 +13,6 @@ import { Liveness } from './Liveness.importable';
 import { OnwardsUpper } from './OnwardsUpper.importable';
 import { SetABTests } from './SetABTests.importable';
 import { Snow } from './Snow.importable';
-import { ConfigProvider } from './ConfigContext';
 
 // Type tests
 // Test that impossible prop combinations are caught by TypeScript.

--- a/dotcom-rendering/src/components/ManyNewsletterSignUp.importable.tsx
+++ b/dotcom-rendering/src/components/ManyNewsletterSignUp.importable.tsx
@@ -22,6 +22,7 @@ import { Flex } from './Flex';
 import { ManyNewslettersForm } from './ManyNewslettersForm';
 import { BUTTON_ROLE, BUTTON_SELECTED_CLASS } from './NewsletterCard';
 import { Section } from './Section';
+import { useConfig } from './ConfigContext';
 
 const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 type FormStatus = 'NotSent' | 'Loading' | 'Success' | 'Failed' | 'InvalidEmail';
@@ -142,6 +143,7 @@ export const ManyNewsletterSignUp = () => {
 	const captchaSiteKey = useReCaptcha ? getCaptchaSiteKey() : undefined;
 
 	const userCanInteract = status !== 'Success' && status !== 'Loading';
+	const { renderingTarget } = useConfig();
 
 	const toggleNewsletter = useCallback(
 		(event: Event) => {
@@ -228,9 +230,14 @@ export const ManyNewsletterSignUp = () => {
 			(newsletter) => newsletter.listId,
 		);
 
-		void reportTrackingEvent('ManyNewsletterSignUp', 'form-submit', {
-			listIds,
-		});
+		void reportTrackingEvent(
+			'ManyNewsletterSignUp',
+			'form-submit',
+			renderingTarget,
+			{
+				listIds,
+			},
+		);
 
 		const response = await requestMultipleSignUps(
 			email,
@@ -247,6 +254,7 @@ export const ManyNewsletterSignUp = () => {
 			void reportTrackingEvent(
 				'ManyNewsletterSignUp',
 				'failure-response',
+				renderingTarget,
 				{
 					listIds,
 					// If the backend handles the failure and responds with an informative
@@ -261,9 +269,14 @@ export const ManyNewsletterSignUp = () => {
 			return setStatus('Failed');
 		}
 
-		void reportTrackingEvent('ManyNewsletterSignUp', 'success-response', {
-			listIds,
-		});
+		void reportTrackingEvent(
+			'ManyNewsletterSignUp',
+			'success-response',
+			renderingTarget,
+			{
+				listIds,
+			},
+		);
 		setStatus('Success');
 	};
 
@@ -287,30 +300,48 @@ export const ManyNewsletterSignUp = () => {
 			void reportTrackingEvent(
 				'ManyNewsletterSignUp',
 				'captcha-not-loaded-when-needed',
+				renderingTarget,
 			);
 			return;
 		}
 		setStatus('Loading');
 		// successful execution triggers a call to sendRequest
 		// with the onChange prop on the captcha Component
-		void reportTrackingEvent('ManyNewsletterSignUp', 'captcha-execute');
+		void reportTrackingEvent(
+			'ManyNewsletterSignUp',
+			'captcha-execute',
+			renderingTarget,
+		);
 		const result = await reCaptchaRef.current.executeAsync();
 
 		if (typeof result !== 'string') {
-			void reportTrackingEvent('ManyNewsletterSignUp', 'captcha-failure');
+			void reportTrackingEvent(
+				'ManyNewsletterSignUp',
+				'captcha-failure',
+				renderingTarget,
+			);
 			setStatus('Failed');
 			return;
 		}
 
-		void reportTrackingEvent('ManyNewsletterSignUp', 'captcha-success');
+		void reportTrackingEvent(
+			'ManyNewsletterSignUp',
+			'captcha-success',
+			renderingTarget,
+		);
 		return sendRequest(result);
 	};
 
 	const handleCaptchaError: ReactEventHandler<HTMLDivElement> = (event) => {
-		void reportTrackingEvent('ManyNewsletterSignUp', 'captcha-error', {
-			eventType: event.type,
-			status,
-		});
+		void reportTrackingEvent(
+			'ManyNewsletterSignUp',
+			'captcha-error',
+			renderingTarget,
+			{
+				eventType: event.type,
+				status,
+			},
+		);
 		reCaptchaRef.current?.reset();
 	};
 

--- a/dotcom-rendering/src/components/ManyNewsletterSignUp.importable.tsx
+++ b/dotcom-rendering/src/components/ManyNewsletterSignUp.importable.tsx
@@ -18,11 +18,11 @@ import {
 	reportTrackingEvent,
 	requestMultipleSignUps,
 } from '../lib/newsletter-sign-up-requests';
+import { useConfig } from './ConfigContext';
 import { Flex } from './Flex';
 import { ManyNewslettersForm } from './ManyNewslettersForm';
 import { BUTTON_ROLE, BUTTON_SELECTED_CLASS } from './NewsletterCard';
 import { Section } from './Section';
-import { useConfig } from './ConfigContext';
 
 const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 type FormStatus = 'NotSent' | 'Loading' | 'Success' | 'Failed' | 'InvalidEmail';

--- a/dotcom-rendering/src/components/NewsletterCard.tsx
+++ b/dotcom-rendering/src/components/NewsletterCard.tsx
@@ -15,8 +15,8 @@ import { submitComponentEvent } from '../client/ophan/ophan';
 import { useIsInView } from '../lib/useIsInView';
 import type { Newsletter } from '../types/content';
 import { CardPicture } from './CardPicture';
-import { NewsletterDetail } from './NewsletterDetail';
 import { useConfig } from './ConfigContext';
+import { NewsletterDetail } from './NewsletterDetail';
 
 interface Props {
 	newsletter: Newsletter;
@@ -178,7 +178,13 @@ export const NewsletterCard = ({
 			},
 			renderingTarget,
 		);
-	}, [cardPosition, carouselPosition, groupTitle, newsletter.identityName]);
+	}, [
+		cardPosition,
+		carouselPosition,
+		groupTitle,
+		newsletter.identityName,
+		renderingTarget,
+	]);
 
 	useEffect(() => {
 		if (hasBeenSeen && !haveReportedBeingSeen) {

--- a/dotcom-rendering/src/components/NewsletterCard.tsx
+++ b/dotcom-rendering/src/components/NewsletterCard.tsx
@@ -16,6 +16,7 @@ import { useIsInView } from '../lib/useIsInView';
 import type { Newsletter } from '../types/content';
 import { CardPicture } from './CardPicture';
 import { NewsletterDetail } from './NewsletterDetail';
+import { useConfig } from './ConfigContext';
 
 interface Props {
 	newsletter: Newsletter;
@@ -154,6 +155,7 @@ export const NewsletterCard = ({
 }: Props) => {
 	const [hasBeenSeen, setIsInViewRef] = useIsInView({ threshold: 0.9 });
 	const [haveReportedBeingSeen, setHaveReportedBeingSeen] = useState(false);
+	const { renderingTarget } = useConfig();
 
 	const reportSeen = useCallback(() => {
 		const valueData = {
@@ -165,14 +167,17 @@ export const NewsletterCard = ({
 			timestamp: Date.now(),
 		};
 
-		void submitComponentEvent({
-			component: {
-				componentType: 'CARD',
-				id: `DCR NewsletterCard ${newsletter.identityName}`,
+		void submitComponentEvent(
+			{
+				component: {
+					componentType: 'CARD',
+					id: `DCR NewsletterCard ${newsletter.identityName}`,
+				},
+				action: 'VIEW',
+				value: JSON.stringify(valueData),
 			},
-			action: 'VIEW',
-			value: JSON.stringify(valueData),
-		});
+			renderingTarget,
+		);
 	}, [cardPosition, carouselPosition, groupTitle, newsletter.identityName]);
 
 	useEffect(() => {

--- a/dotcom-rendering/src/components/ProfileAtom.importable.tsx
+++ b/dotcom-rendering/src/components/ProfileAtom.importable.tsx
@@ -3,6 +3,7 @@ import { submitComponentEvent } from '../client/ophan/ophan';
 import { Body } from './ExpandableAtom/Body';
 import { Container } from './ExpandableAtom/Container';
 import { Footer } from './ExpandableAtom/Footer';
+import { useConfig } from './ConfigContext';
 
 export interface ProfileAtomProps {
 	id: string;
@@ -28,6 +29,8 @@ export const ProfileAtom = ({
 	dislikeHandler,
 	expandCallback,
 }: ProfileAtomProps) => {
+	const { renderingTarget } = useConfig();
+
 	return (
 		<Container
 			id={id}
@@ -39,15 +42,18 @@ export const ProfileAtom = ({
 			expandCallback={
 				expandCallback ??
 				(() =>
-					submitComponentEvent({
-						component: {
-							componentType: 'PROFILE_ATOM',
-							id,
-							products: [],
-							labels: [],
+					submitComponentEvent(
+						{
+							component: {
+								componentType: 'PROFILE_ATOM',
+								id,
+								products: [],
+								labels: [],
+							},
+							action: 'EXPAND',
 						},
-						action: 'EXPAND',
-					}))
+						renderingTarget,
+					))
 			}
 		>
 			<Body html={html} image={image} credit={credit} format={format} />
@@ -56,28 +62,34 @@ export const ProfileAtom = ({
 				dislikeHandler={
 					dislikeHandler ??
 					(() =>
-						submitComponentEvent({
-							component: {
-								componentType: 'PROFILE_ATOM',
-								id,
-								products: [],
-								labels: [],
+						submitComponentEvent(
+							{
+								component: {
+									componentType: 'PROFILE_ATOM',
+									id,
+									products: [],
+									labels: [],
+								},
+								action: 'DISLIKE',
 							},
-							action: 'DISLIKE',
-						}))
+							renderingTarget,
+						))
 				}
 				likeHandler={
 					likeHandler ??
 					(() =>
-						submitComponentEvent({
-							component: {
-								componentType: 'PROFILE_ATOM',
-								id,
-								products: [],
-								labels: [],
+						submitComponentEvent(
+							{
+								component: {
+									componentType: 'PROFILE_ATOM',
+									id,
+									products: [],
+									labels: [],
+								},
+								action: 'LIKE',
 							},
-							action: 'LIKE',
-						}))
+							renderingTarget,
+						))
 				}
 			></Footer>
 		</Container>

--- a/dotcom-rendering/src/components/ProfileAtom.importable.tsx
+++ b/dotcom-rendering/src/components/ProfileAtom.importable.tsx
@@ -1,9 +1,9 @@
 import type { ArticleFormat } from '@guardian/libs';
 import { submitComponentEvent } from '../client/ophan/ophan';
+import { useConfig } from './ConfigContext';
 import { Body } from './ExpandableAtom/Body';
 import { Container } from './ExpandableAtom/Container';
 import { Footer } from './ExpandableAtom/Footer';
-import { useConfig } from './ConfigContext';
 
 export interface ProfileAtomProps {
 	id: string;

--- a/dotcom-rendering/src/components/ProfileAtom.test.tsx
+++ b/dotcom-rendering/src/components/ProfileAtom.test.tsx
@@ -1,6 +1,7 @@
 import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
 import { fireEvent, render } from '@testing-library/react';
 import { ProfileAtom } from './ProfileAtom.importable';
+import { ConfigProvider } from './ConfigContext';
 
 const format: ArticleFormat = {
 	theme: Pillar.News,
@@ -10,22 +11,24 @@ const format: ArticleFormat = {
 describe('ProfileAtom', () => {
 	it('should render', () => {
 		const { getByText, queryByText } = render(
-			<ProfileAtom
-				id="1fba49a4-81c6-49e4-b7fa-fd66d1512360"
-				title="Who is Jon Lansman?"
-				html="<p>A 62-year-old Labour veteran who joined the party in 1974 and worked for Labour icon Tony Benn during his deputy leadership campaign in the 1980s. Lansman served as director of operations for Corbyn’s leadership campaign. After Corbyn was elected as the leader of the Labour party in 2015, Lansman founded Momentum, a pro-Corbyn campaign group.<br></p>"
-				credit=""
-				format={format}
-				likeHandler={() => {
-					return null;
-				}}
-				dislikeHandler={() => {
-					return null;
-				}}
-				expandCallback={() => {
-					return null;
-				}}
-			/>,
+			<ConfigProvider value={{ renderingTarget: 'Web' }}>
+				<ProfileAtom
+					id="1fba49a4-81c6-49e4-b7fa-fd66d1512360"
+					title="Who is Jon Lansman?"
+					html="<p>A 62-year-old Labour veteran who joined the party in 1974 and worked for Labour icon Tony Benn during his deputy leadership campaign in the 1980s. Lansman served as director of operations for Corbyn’s leadership campaign. After Corbyn was elected as the leader of the Labour party in 2015, Lansman founded Momentum, a pro-Corbyn campaign group.<br></p>"
+					credit=""
+					format={format}
+					likeHandler={() => {
+						return null;
+					}}
+					dislikeHandler={() => {
+						return null;
+					}}
+					expandCallback={() => {
+						return null;
+					}}
+				/>
+			</ConfigProvider>,
 		);
 
 		expect(getByText('Profile')).toBeInTheDocument();
@@ -42,22 +45,24 @@ describe('ProfileAtom', () => {
 
 	it('Show feedback on like', () => {
 		const { getByText, queryByText, queryByTestId } = render(
-			<ProfileAtom
-				id="1fba49a4-81c6-49e4-b7fa-fd66d1512360"
-				format={format}
-				title="Who is Jon Lansman?"
-				html="<p>A 62-year-old Labour veteran who joined the party in 1974 and worked for Labour icon Tony Benn during his deputy leadership campaign in the 1980s. Lansman served as director of operations for Corbyn’s leadership campaign. After Corbyn was elected as the leader of the Labour party in 2015, Lansman founded Momentum, a pro-Corbyn campaign group.<br></p>"
-				credit=""
-				likeHandler={() => {
-					return null;
-				}}
-				dislikeHandler={() => {
-					return null;
-				}}
-				expandCallback={() => {
-					return null;
-				}}
-			/>,
+			<ConfigProvider value={{ renderingTarget: 'Web' }}>
+				<ProfileAtom
+					id="1fba49a4-81c6-49e4-b7fa-fd66d1512360"
+					format={format}
+					title="Who is Jon Lansman?"
+					html="<p>A 62-year-old Labour veteran who joined the party in 1974 and worked for Labour icon Tony Benn during his deputy leadership campaign in the 1980s. Lansman served as director of operations for Corbyn’s leadership campaign. After Corbyn was elected as the leader of the Labour party in 2015, Lansman founded Momentum, a pro-Corbyn campaign group.<br></p>"
+					credit=""
+					likeHandler={() => {
+						return null;
+					}}
+					dislikeHandler={() => {
+						return null;
+					}}
+					expandCallback={() => {
+						return null;
+					}}
+				/>
+			</ConfigProvider>,
 		);
 
 		// Expand Profile
@@ -75,22 +80,24 @@ describe('ProfileAtom', () => {
 
 	it('Show feedback on dislike', () => {
 		const { getByText, queryByText, queryByTestId } = render(
-			<ProfileAtom
-				id="1fba49a4-81c6-49e4-b7fa-fd66d1512360"
-				format={format}
-				title="Who is Jon Lansman?"
-				html="<p>A 62-year-old Labour veteran who joined the party in 1974 and worked for Labour icon Tony Benn during his deputy leadership campaign in the 1980s. Lansman served as director of operations for Corbyn’s leadership campaign. After Corbyn was elected as the leader of the Labour party in 2015, Lansman founded Momentum, a pro-Corbyn campaign group.<br></p>"
-				credit=""
-				likeHandler={() => {
-					return null;
-				}}
-				dislikeHandler={() => {
-					return null;
-				}}
-				expandCallback={() => {
-					return null;
-				}}
-			/>,
+			<ConfigProvider value={{ renderingTarget: 'Web' }}>
+				<ProfileAtom
+					id="1fba49a4-81c6-49e4-b7fa-fd66d1512360"
+					format={format}
+					title="Who is Jon Lansman?"
+					html="<p>A 62-year-old Labour veteran who joined the party in 1974 and worked for Labour icon Tony Benn during his deputy leadership campaign in the 1980s. Lansman served as director of operations for Corbyn’s leadership campaign. After Corbyn was elected as the leader of the Labour party in 2015, Lansman founded Momentum, a pro-Corbyn campaign group.<br></p>"
+					credit=""
+					likeHandler={() => {
+						return null;
+					}}
+					dislikeHandler={() => {
+						return null;
+					}}
+					expandCallback={() => {
+						return null;
+					}}
+				/>
+			</ConfigProvider>,
 		);
 
 		// Expand Profile

--- a/dotcom-rendering/src/components/ProfileAtom.test.tsx
+++ b/dotcom-rendering/src/components/ProfileAtom.test.tsx
@@ -1,7 +1,7 @@
 import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
 import { fireEvent, render } from '@testing-library/react';
-import { ProfileAtom } from './ProfileAtom.importable';
 import { ConfigProvider } from './ConfigContext';
+import { ProfileAtom } from './ProfileAtom.importable';
 
 const format: ArticleFormat = {
 	theme: Pillar.News,

--- a/dotcom-rendering/src/components/QandaAtom.importable.tsx
+++ b/dotcom-rendering/src/components/QandaAtom.importable.tsx
@@ -2,6 +2,7 @@ import { submitComponentEvent } from '../client/ophan/ophan';
 import { Body } from './ExpandableAtom/Body';
 import { Container } from './ExpandableAtom/Container';
 import { Footer } from './ExpandableAtom/Footer';
+import { useConfig } from './ConfigContext';
 
 export type QandaAtomProps = {
 	id: string;
@@ -26,57 +27,70 @@ export const QandaAtom = ({
 	likeHandler,
 	dislikeHandler,
 	expandCallback,
-}: QandaAtomProps): JSX.Element => (
-	<Container
-		id={id}
-		title={title}
-		atomType="qanda"
-		atomTypeTitle="Q&A"
-		format={format}
-		expandForStorybook={expandForStorybook}
-		expandCallback={
-			expandCallback ??
-			(() =>
-				submitComponentEvent({
-					component: {
-						componentType: 'QANDA_ATOM',
-						id,
-						products: [],
-						labels: [],
-					},
-					action: 'EXPAND',
-				}))
-		}
-	>
-		<Body html={html} image={image} credit={credit} format={format} />
-		<Footer
+}: QandaAtomProps): JSX.Element => {
+	const { renderingTarget } = useConfig();
+
+	return (
+		<Container
+			id={id}
+			title={title}
+			atomType="qanda"
+			atomTypeTitle="Q&A"
 			format={format}
-			dislikeHandler={
-				dislikeHandler ??
+			expandForStorybook={expandForStorybook}
+			expandCallback={
+				expandCallback ??
 				(() =>
-					submitComponentEvent({
-						component: {
-							componentType: 'QANDA_ATOM',
-							id,
-							products: [],
-							labels: [],
+					submitComponentEvent(
+						{
+							component: {
+								componentType: 'QANDA_ATOM',
+								id,
+								products: [],
+								labels: [],
+							},
+							action: 'EXPAND',
 						},
-						action: 'DISLIKE',
-					}))
+						renderingTarget,
+					))
 			}
-			likeHandler={
-				likeHandler ??
-				(() =>
-					submitComponentEvent({
-						component: {
-							componentType: 'QANDA_ATOM',
-							id,
-							products: [],
-							labels: [],
-						},
-						action: 'LIKE',
-					}))
-			}
-		></Footer>
-	</Container>
-);
+		>
+			<Body html={html} image={image} credit={credit} format={format} />
+			<Footer
+				format={format}
+				dislikeHandler={
+					dislikeHandler ??
+					(() =>
+						submitComponentEvent(
+							{
+								component: {
+									componentType: 'QANDA_ATOM',
+									id,
+									products: [],
+									labels: [],
+								},
+								action: 'DISLIKE',
+							},
+							renderingTarget,
+						))
+				}
+				likeHandler={
+					likeHandler ??
+					(() =>
+						submitComponentEvent(
+							{
+								component: {
+									componentType: 'QANDA_ATOM',
+									id,
+									products: [],
+									labels: [],
+								},
+								action: 'LIKE',
+							},
+							renderingTarget,
+						))
+				}
+			></Footer>
+		</Container>
+	);
+};

--- a/dotcom-rendering/src/components/QandaAtom.importable.tsx
+++ b/dotcom-rendering/src/components/QandaAtom.importable.tsx
@@ -1,8 +1,8 @@
 import { submitComponentEvent } from '../client/ophan/ophan';
+import { useConfig } from './ConfigContext';
 import { Body } from './ExpandableAtom/Body';
 import { Container } from './ExpandableAtom/Container';
 import { Footer } from './ExpandableAtom/Footer';
-import { useConfig } from './ConfigContext';
 
 export type QandaAtomProps = {
 	id: string;

--- a/dotcom-rendering/src/components/QandaAtom.test.tsx
+++ b/dotcom-rendering/src/components/QandaAtom.test.tsx
@@ -2,11 +2,14 @@ import { fireEvent, render } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import { imageStory } from '../../fixtures/manual/qandaAtom';
 import { QandaAtom } from './QandaAtom.importable';
+import { ConfigProvider } from './ConfigContext';
 
 describe('QandaAtom', () => {
 	it('should render & expand works', () => {
 		const { getByText, queryByText } = render(
-			<QandaAtom {...imageStory} />,
+			<ConfigProvider value={{ renderingTarget: 'Web' }}>
+				<QandaAtom {...imageStory} />
+			</ConfigProvider>,
 		);
 
 		expect(getByText('Q&A')).toBeInTheDocument();
@@ -23,7 +26,9 @@ describe('QandaAtom', () => {
 
 	it('Show feedback on like', () => {
 		const { getByText, queryByText, queryByTestId } = render(
-			<QandaAtom {...imageStory} />,
+			<ConfigProvider value={{ renderingTarget: 'Web' }}>
+				<QandaAtom {...imageStory} />
+			</ConfigProvider>,
 		);
 
 		// Expand Q&A
@@ -41,7 +46,9 @@ describe('QandaAtom', () => {
 
 	it('Show feedback on dislike', () => {
 		const { getByText, queryByText, queryByTestId } = render(
-			<QandaAtom {...imageStory} />,
+			<ConfigProvider value={{ renderingTarget: 'Web' }}>
+				<QandaAtom {...imageStory} />
+			</ConfigProvider>,
 		);
 
 		// Expand Q&A

--- a/dotcom-rendering/src/components/QandaAtom.test.tsx
+++ b/dotcom-rendering/src/components/QandaAtom.test.tsx
@@ -1,8 +1,8 @@
 import { fireEvent, render } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import { imageStory } from '../../fixtures/manual/qandaAtom';
-import { QandaAtom } from './QandaAtom.importable';
 import { ConfigProvider } from './ConfigContext';
+import { QandaAtom } from './QandaAtom.importable';
 
 describe('QandaAtom', () => {
 	it('should render & expand works', () => {

--- a/dotcom-rendering/src/components/ReaderRevenueLinks.importable.tsx
+++ b/dotcom-rendering/src/components/ReaderRevenueLinks.importable.tsx
@@ -36,6 +36,7 @@ import { useAuthStatus } from '../lib/useAuthStatus';
 import { useIsInView } from '../lib/useIsInView';
 import { useOnce } from '../lib/useOnce';
 import ArrowRightIcon from '../static/icons/arrow-right.svg';
+import { useConfig } from './ConfigContext';
 
 type Props = {
 	editionId: EditionId;
@@ -180,6 +181,8 @@ const ReaderRevenueLinksRemote = ({
 		authStatus.kind === 'SignedInWithOkta' ||
 		authStatus.kind === 'SignedInWithCookies';
 
+	const { renderingTarget } = useConfig();
+
 	useOnce((): void => {
 		setAutomat();
 
@@ -241,7 +244,12 @@ const ReaderRevenueLinksRemote = ({
 				<SupportHeader
 					submitComponentEvent={(
 						componentEvent: OphanComponentEvent,
-					) => void submitComponentEvent(componentEvent)}
+					) =>
+						void submitComponentEvent(
+							componentEvent,
+							renderingTarget,
+						)
+					}
 					{...supportHeaderResponse.props}
 				/>
 			</div>
@@ -287,16 +295,18 @@ const ReaderRevenueLinksNative = ({
 		debounce: true,
 	});
 
+	const { renderingTarget } = useConfig();
+
 	useEffect(() => {
 		if (!hideSupportMessaging && inHeader) {
-			void sendOphanComponentEvent('INSERT', tracking);
+			void sendOphanComponentEvent('INSERT', tracking, renderingTarget);
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 
 	useEffect(() => {
 		if (hasBeenSeen && inHeader) {
-			void sendOphanComponentEvent('VIEW', tracking);
+			void sendOphanComponentEvent('VIEW', tracking, renderingTarget);
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [hasBeenSeen]);

--- a/dotcom-rendering/src/components/ReaderRevenueLinks.test.tsx
+++ b/dotcom-rendering/src/components/ReaderRevenueLinks.test.tsx
@@ -1,8 +1,8 @@
 import { render, waitFor } from '@testing-library/react';
 import { shouldHideSupportMessaging as shouldHideSupportMessaging_ } from '../lib/contributions';
 import type { EditionId } from '../lib/edition';
-import { ReaderRevenueLinks } from './ReaderRevenueLinks.importable';
 import { ConfigProvider } from './ConfigContext';
+import { ReaderRevenueLinks } from './ReaderRevenueLinks.importable';
 
 const shouldHideSupportMessaging: {
 	[key: string]: any;

--- a/dotcom-rendering/src/components/ReaderRevenueLinks.test.tsx
+++ b/dotcom-rendering/src/components/ReaderRevenueLinks.test.tsx
@@ -2,6 +2,7 @@ import { render, waitFor } from '@testing-library/react';
 import { shouldHideSupportMessaging as shouldHideSupportMessaging_ } from '../lib/contributions';
 import type { EditionId } from '../lib/edition';
 import { ReaderRevenueLinks } from './ReaderRevenueLinks.importable';
+import { ConfigProvider } from './ConfigContext';
 
 const shouldHideSupportMessaging: {
 	[key: string]: any;
@@ -39,14 +40,16 @@ describe('ReaderRevenueLinks', () => {
 		shouldHideSupportMessaging.mockReturnValue(true);
 
 		const { getByText } = render(
-			<ReaderRevenueLinks
-				urls={urls}
-				editionId="US"
-				dataLinkNamePrefix="nav2 : "
-				inHeader={true}
-				remoteHeader={false}
-				contributionsServiceUrl={contributionsServiceUrl}
-			/>,
+			<ConfigProvider value={{ renderingTarget: 'Web' }}>
+				<ReaderRevenueLinks
+					urls={urls}
+					editionId="US"
+					dataLinkNamePrefix="nav2 : "
+					inHeader={true}
+					remoteHeader={false}
+					contributionsServiceUrl={contributionsServiceUrl}
+				/>
+			</ConfigProvider>,
 		);
 
 		await waitFor(() => expect(getByText('Thank you')).toBeInTheDocument());
@@ -56,14 +59,16 @@ describe('ReaderRevenueLinks', () => {
 		shouldHideSupportMessaging.mockReturnValue(false);
 
 		const { getByText } = render(
-			<ReaderRevenueLinks
-				urls={urls}
-				editionId={edition}
-				dataLinkNamePrefix="nav2 : "
-				inHeader={true}
-				remoteHeader={false}
-				contributionsServiceUrl={contributionsServiceUrl}
-			/>,
+			<ConfigProvider value={{ renderingTarget: 'Web' }}>
+				<ReaderRevenueLinks
+					urls={urls}
+					editionId={edition}
+					dataLinkNamePrefix="nav2 : "
+					inHeader={true}
+					remoteHeader={false}
+					contributionsServiceUrl={contributionsServiceUrl}
+				/>
+			</ConfigProvider>,
 		);
 
 		await waitFor(() =>

--- a/dotcom-rendering/src/components/SecureReCAPTCHASignup.tsx
+++ b/dotcom-rendering/src/components/SecureReCAPTCHASignup.tsx
@@ -18,7 +18,7 @@ import { useRef, useState } from 'react';
 // Use the default export instead.
 import ReactGoogleRecaptcha from 'react-google-recaptcha';
 import { submitComponentEvent } from '../client/ophan/ophan';
-import { RenderingTarget } from '../types/renderingTarget';
+import type { RenderingTarget } from '../types/renderingTarget';
 import { useConfig } from './ConfigContext';
 
 // The Google documentation specifies that if the 'recaptcha-badge' is hidden,

--- a/dotcom-rendering/src/components/SecureSignupIframe.importable.tsx
+++ b/dotcom-rendering/src/components/SecureSignupIframe.importable.tsx
@@ -18,9 +18,9 @@ import ReactGoogleRecaptcha from 'react-google-recaptcha';
 import { submitComponentEvent } from '../client/ophan/ophan';
 import { isServer } from '../lib/isServer';
 import { useHydrated } from '../lib/useHydrated';
-import { Placeholder } from './Placeholder';
-import { RenderingTarget } from '../types/renderingTarget';
+import type { RenderingTarget } from '../types/renderingTarget';
 import { useConfig } from './ConfigContext';
+import { Placeholder } from './Placeholder';
 
 // The Google documentation specifies that if the 'recaptcha-badge' is hidden,
 // their T+C's must be displayed instead. While this component hides the

--- a/dotcom-rendering/src/components/SecureSignupIframe.importable.tsx
+++ b/dotcom-rendering/src/components/SecureSignupIframe.importable.tsx
@@ -19,6 +19,8 @@ import { submitComponentEvent } from '../client/ophan/ophan';
 import { isServer } from '../lib/isServer';
 import { useHydrated } from '../lib/useHydrated';
 import { Placeholder } from './Placeholder';
+import { RenderingTarget } from '../types/renderingTarget';
+import { useConfig } from './ConfigContext';
 
 // The Google documentation specifies that if the 'recaptcha-badge' is hidden,
 // their T+C's must be displayed instead. While this component hides the
@@ -125,6 +127,7 @@ type EventDescription =
 const sendTracking = (
 	newsletterId: string,
 	eventDescription: EventDescription,
+	renderingTarget: RenderingTarget,
 ): void => {
 	let action: OphanAction = 'CLICK';
 
@@ -161,14 +164,17 @@ const sendTracking = (
 		timestamp: Date.now(),
 	});
 
-	void submitComponentEvent({
-		action,
-		value,
-		component: {
-			componentType: 'NEWSLETTER_SUBSCRIPTION',
-			id: `DCR SecureSignupIframe ${newsletterId}`,
+	void submitComponentEvent(
+		{
+			action,
+			value,
+			component: {
+				componentType: 'NEWSLETTER_SUBSCRIPTION',
+				id: `DCR SecureSignupIframe ${newsletterId}`,
+			},
 		},
-	});
+		renderingTarget,
+	);
 };
 
 /**
@@ -203,6 +209,8 @@ export const SecureSignupIframe = ({
 		undefined,
 	);
 
+	const { renderingTarget } = useConfig();
+
 	const hydrated = useHydrated();
 	if (!hydrated) return <Placeholder height={65} />;
 
@@ -215,7 +223,7 @@ export const SecureSignupIframe = ({
 			null;
 		const emailAddress: string = input?.value ?? '';
 
-		sendTracking(newsletterId, 'form-submission');
+		sendTracking(newsletterId, 'form-submission', renderingTarget);
 		const response = await postFormData(
 			window.guardian.config.page.ajaxUrl + '/email',
 			buildFormData(emailAddress, newsletterId, token),
@@ -231,6 +239,7 @@ export const SecureSignupIframe = ({
 		sendTracking(
 			newsletterId,
 			response.ok ? 'submission-confirmed' : 'submission-failed',
+			renderingTarget,
 		);
 	};
 
@@ -241,22 +250,22 @@ export const SecureSignupIframe = ({
 	};
 
 	const handleCaptchaLoadError: ReactEventHandler<HTMLDivElement> = () => {
-		sendTracking(newsletterId, 'captcha-load-error');
+		sendTracking(newsletterId, 'captcha-load-error', renderingTarget);
 		setErrorMessage(`Sorry, the reCAPTCHA failed to load.`);
 		recaptchaRef.current?.reset();
 	};
 
 	const handleCaptchaComplete = (token: string | null) => {
 		if (!token) {
-			sendTracking(newsletterId, 'captcha-not-passed');
+			sendTracking(newsletterId, 'captcha-not-passed', renderingTarget);
 			return;
 		}
-		sendTracking(newsletterId, 'captcha-passed');
+		sendTracking(newsletterId, 'captcha-passed', renderingTarget);
 		setIsWaitingForResponse(true);
 		submitForm(token).catch((error) => {
 			// eslint-disable-next-line no-console -- unexpected error
 			console.error(error);
-			sendTracking(newsletterId, 'form-submit-error');
+			sendTracking(newsletterId, 'form-submit-error', renderingTarget);
 			setErrorMessage(`Sorry, there was an error signing you up.`);
 			setIsWaitingForResponse(false);
 		});
@@ -282,7 +291,7 @@ export const SecureSignupIframe = ({
 	};
 
 	const handleClickInIFrame = (): void => {
-		sendTracking(newsletterId, 'click-button');
+		sendTracking(newsletterId, 'click-button', renderingTarget);
 	};
 
 	const handleSubmitInIFrame = (event: Event): void => {
@@ -291,7 +300,7 @@ export const SecureSignupIframe = ({
 			return;
 		}
 		setErrorMessage(undefined);
-		sendTracking(newsletterId, 'open-captcha');
+		sendTracking(newsletterId, 'open-captcha', renderingTarget);
 		recaptchaRef.current?.execute();
 	};
 

--- a/dotcom-rendering/src/components/SignInGate/componentEventTracking.tsx
+++ b/dotcom-rendering/src/components/SignInGate/componentEventTracking.tsx
@@ -1,8 +1,8 @@
 import type { OphanComponent, OphanComponentEvent } from '@guardian/libs';
 import { getOphan } from '../../client/ophan/ophan';
 import { isServer } from '../../lib/isServer';
+import type { RenderingTarget } from '../../types/renderingTarget';
 import type { CurrentSignInGateABTest } from './types';
-import { RenderingTarget } from '../../types/renderingTarget';
 
 export type ComponentEventParams = {
 	componentType: string;

--- a/dotcom-rendering/src/components/SignInGate/componentEventTracking.tsx
+++ b/dotcom-rendering/src/components/SignInGate/componentEventTracking.tsx
@@ -2,6 +2,7 @@ import type { OphanComponent, OphanComponentEvent } from '@guardian/libs';
 import { getOphan } from '../../client/ophan/ophan';
 import { isServer } from '../../lib/isServer';
 import type { CurrentSignInGateABTest } from './types';
+import { RenderingTarget } from '../../types/renderingTarget';
 
 export type ComponentEventParams = {
 	componentType: string;
@@ -15,28 +16,37 @@ export type ComponentEventParams = {
 // ophan helper methods
 const submitComponentEventTracking = async (
 	componentEvent: OphanComponentEvent,
+	renderingTarget: RenderingTarget,
 ) => {
 	if (isServer) return;
 
-	const ophan = await getOphan();
+	const ophan = await getOphan(renderingTarget);
 	ophan.record({ componentEvent });
 };
 
 export const submitViewEventTracking = (
 	componentEvent: Omit<OphanComponentEvent, 'action'>,
+	renderingTarget: RenderingTarget,
 ) =>
-	void submitComponentEventTracking({
-		...componentEvent,
-		action: 'VIEW',
-	});
+	void submitComponentEventTracking(
+		{
+			...componentEvent,
+			action: 'VIEW',
+		},
+		renderingTarget,
+	);
 
 const submitClickEventTracking = (
 	componentEvent: Omit<OphanComponentEvent, 'action'>,
+	renderingTarget: RenderingTarget,
 ) =>
-	void submitComponentEventTracking({
-		...componentEvent,
-		action: 'CLICK',
-	});
+	void submitComponentEventTracking(
+		{
+			...componentEvent,
+			action: 'CLICK',
+		},
+		renderingTarget,
+	);
 
 export const withComponentId: (id: string) => OphanComponent = (id = '') => ({
 	componentType: 'SIGN_IN_GATE',
@@ -46,13 +56,17 @@ export const withComponentId: (id: string) => OphanComponent = (id = '') => ({
 export const trackLink = (
 	componentId: string,
 	value: string,
+	renderingTarget: RenderingTarget,
 	abTest?: CurrentSignInGateABTest,
 ): void => {
 	const component = withComponentId(componentId);
 
-	submitClickEventTracking({
-		component,
-		abTest,
-		value,
-	});
+	submitClickEventTracking(
+		{
+			component,
+			abTest,
+			value,
+		},
+		renderingTarget,
+	);
 };

--- a/dotcom-rendering/src/components/SignInGate/gateDesigns/SignInGateFakeSocial.tsx
+++ b/dotcom-rendering/src/components/SignInGate/gateDesigns/SignInGateFakeSocial.tsx
@@ -25,6 +25,7 @@ import {
 	signInGateContainer,
 	signInLink,
 } from './shared';
+import { useConfig } from '../../ConfigContext';
 
 const heading = css`
 	${headline.small({ fontWeight: 'bold' })};
@@ -292,6 +293,8 @@ export const SignInGateFakeSocial = ({
 	const verticalButtonStack =
 		abTest?.variant === 'fake-social-variant-vertical';
 
+	const { renderingTarget } = useConfig();
+
 	return (
 		<div css={signInGateContainer} data-cy="sign-in-gate-fake-social">
 			<style>{hideElementsCss}</style>
@@ -315,7 +318,12 @@ export const SignInGateFakeSocial = ({
 					css={privacyLink}
 					onClick={() => {
 						cmp.showPrivacyManager();
-						trackLink(ophanComponentId, 'privacy', abTest);
+						trackLink(
+							ophanComponentId,
+							'privacy',
+							renderingTarget,
+							abTest,
+						);
 					}}
 				>
 					privacy settings
@@ -331,7 +339,12 @@ export const SignInGateFakeSocial = ({
 					size="small"
 					href={registerUrl}
 					onClick={() => {
-						trackLink(ophanComponentId, 'register-link', abTest);
+						trackLink(
+							ophanComponentId,
+							'register-link',
+							renderingTarget,
+							abTest,
+						);
 					}}
 				>
 					Register for free
@@ -345,7 +358,12 @@ export const SignInGateFakeSocial = ({
 					size="small"
 					onClick={() => {
 						dismissGate();
-						trackLink(ophanComponentId, 'not-now', abTest);
+						trackLink(
+							ophanComponentId,
+							'not-now',
+							renderingTarget,
+							abTest,
+						);
 					}}
 				>
 					I’ll do it later
@@ -360,7 +378,12 @@ export const SignInGateFakeSocial = ({
 					css={[signInLink, inlineLink, fakeSocialSignInLink]}
 					href={signInUrl}
 					onClick={() => {
-						trackLink(ophanComponentId, 'sign-in-link', abTest);
+						trackLink(
+							ophanComponentId,
+							'sign-in-link',
+							renderingTarget,
+							abTest,
+						);
 					}}
 				>
 					Sign In
@@ -386,7 +409,12 @@ export const SignInGateFakeSocial = ({
 					css={iconButton(verticalButtonStack)}
 					href={signInUrl}
 					onClick={() => {
-						trackLink(ophanComponentId, 'facebook-button', abTest);
+						trackLink(
+							ophanComponentId,
+							'facebook-button',
+							renderingTarget,
+							abTest,
+						);
 					}}
 					iconSide="left"
 					icon={facebookIcon}
@@ -401,7 +429,12 @@ export const SignInGateFakeSocial = ({
 					css={iconButton(verticalButtonStack)}
 					href={signInUrl}
 					onClick={() => {
-						trackLink(ophanComponentId, 'google-button', abTest);
+						trackLink(
+							ophanComponentId,
+							'google-button',
+							renderingTarget,
+							abTest,
+						);
 					}}
 					iconSide="left"
 					icon={googleIcon}
@@ -416,7 +449,12 @@ export const SignInGateFakeSocial = ({
 					css={iconButton(verticalButtonStack)}
 					href={signInUrl}
 					onClick={() => {
-						trackLink(ophanComponentId, 'apple-button', abTest);
+						trackLink(
+							ophanComponentId,
+							'apple-button',
+							renderingTarget,
+							abTest,
+						);
 					}}
 					iconSide="left"
 					icon={appleIcon}
@@ -430,7 +468,12 @@ export const SignInGateFakeSocial = ({
 					data-ignore="global-link-styling"
 					href={`${guUrl}/membership/2019/dec/20/signing-in-to-the-guardian`}
 					onClick={() => {
-						trackLink(ophanComponentId, 'how-link', abTest);
+						trackLink(
+							ophanComponentId,
+							'how-link',
+							renderingTarget,
+							abTest,
+						);
 					}}
 				>
 					Why register & how does it help?
@@ -440,7 +483,12 @@ export const SignInGateFakeSocial = ({
 					data-ignore="global-link-styling"
 					href={`${guUrl}/info/2014/nov/03/why-your-data-matters-to-us-full-text`}
 					onClick={() => {
-						trackLink(ophanComponentId, 'why-link', abTest);
+						trackLink(
+							ophanComponentId,
+							'why-link',
+							renderingTarget,
+							abTest,
+						);
 					}}
 				>
 					How will my information & data be used?
@@ -450,7 +498,12 @@ export const SignInGateFakeSocial = ({
 					data-ignore="global-link-styling"
 					href={`${guUrl}/help/identity-faq`}
 					onClick={() => {
-						trackLink(ophanComponentId, 'help-link', abTest);
+						trackLink(
+							ophanComponentId,
+							'help-link',
+							renderingTarget,
+							abTest,
+						);
 					}}
 				>
 					Get help with registering or signing in.

--- a/dotcom-rendering/src/components/SignInGate/gateDesigns/SignInGateFakeSocial.tsx
+++ b/dotcom-rendering/src/components/SignInGate/gateDesigns/SignInGateFakeSocial.tsx
@@ -9,6 +9,7 @@ import {
 	until,
 } from '@guardian/source-foundations';
 import { Button, Link, LinkButton } from '@guardian/source-react-components';
+import { useConfig } from '../../ConfigContext';
 import { trackLink } from '../componentEventTracking';
 import type { SignInGateProps } from '../types';
 import {
@@ -25,7 +26,6 @@ import {
 	signInGateContainer,
 	signInLink,
 } from './shared';
-import { useConfig } from '../../ConfigContext';
 
 const heading = css`
 	${headline.small({ fontWeight: 'bold' })};

--- a/dotcom-rendering/src/components/SignInGate/gateDesigns/SignInGateMain.tsx
+++ b/dotcom-rendering/src/components/SignInGate/gateDesigns/SignInGateMain.tsx
@@ -18,6 +18,7 @@ import {
 	signInHeader,
 	signInLink,
 } from './shared';
+import { useConfig } from '../../ConfigContext';
 
 export const SignInGateMain = ({
 	signInUrl,
@@ -28,6 +29,8 @@ export const SignInGateMain = ({
 	ophanComponentId,
 	isMandatory = false,
 }: SignInGateProps) => {
+	const { renderingTarget } = useConfig();
+
 	return (
 		<div css={signInGateContainer} data-cy="sign-in-gate-main">
 			<style>{hideElementsCss}</style>
@@ -47,7 +50,12 @@ export const SignInGateMain = ({
 					css={privacyLink}
 					onClick={() => {
 						cmp.showPrivacyManager();
-						trackLink(ophanComponentId, 'privacy', abTest);
+						trackLink(
+							ophanComponentId,
+							'privacy',
+							renderingTarget,
+							abTest,
+						);
 					}}
 				>
 					privacy settings
@@ -63,7 +71,12 @@ export const SignInGateMain = ({
 					size="small"
 					href={registerUrl}
 					onClick={() => {
-						trackLink(ophanComponentId, 'register-link', abTest);
+						trackLink(
+							ophanComponentId,
+							'register-link',
+							renderingTarget,
+							abTest,
+						);
 					}}
 				>
 					Register for free
@@ -77,7 +90,12 @@ export const SignInGateMain = ({
 						size="small"
 						onClick={() => {
 							dismissGate();
-							trackLink(ophanComponentId, 'not-now', abTest);
+							trackLink(
+								ophanComponentId,
+								'not-now',
+								renderingTarget,
+								abTest,
+							);
 						}}
 					>
 						I’ll do it later
@@ -95,7 +113,12 @@ export const SignInGateMain = ({
 				css={signInLink}
 				href={signInUrl}
 				onClick={() => {
-					trackLink(ophanComponentId, 'sign-in-link', abTest);
+					trackLink(
+						ophanComponentId,
+						'sign-in-link',
+						renderingTarget,
+						abTest,
+					);
 				}}
 			>
 				Sign In
@@ -106,7 +129,12 @@ export const SignInGateMain = ({
 					data-ignore="global-link-styling"
 					href={`${guUrl}/membership/2019/dec/20/signing-in-to-the-guardian`}
 					onClick={() => {
-						trackLink(ophanComponentId, 'how-link', abTest);
+						trackLink(
+							ophanComponentId,
+							'how-link',
+							renderingTarget,
+							abTest,
+						);
 					}}
 				>
 					Why register & how does it help?
@@ -116,7 +144,12 @@ export const SignInGateMain = ({
 					data-ignore="global-link-styling"
 					href={`${guUrl}/info/2014/nov/03/why-your-data-matters-to-us-full-text`}
 					onClick={() => {
-						trackLink(ophanComponentId, 'why-link', abTest);
+						trackLink(
+							ophanComponentId,
+							'why-link',
+							renderingTarget,
+							abTest,
+						);
 					}}
 				>
 					How will my information & data be used?
@@ -126,7 +159,12 @@ export const SignInGateMain = ({
 					data-ignore="global-link-styling"
 					href={`${guUrl}/help/identity-faq`}
 					onClick={() => {
-						trackLink(ophanComponentId, 'help-link', abTest);
+						trackLink(
+							ophanComponentId,
+							'help-link',
+							renderingTarget,
+							abTest,
+						);
 					}}
 				>
 					Get help with registering or signing in

--- a/dotcom-rendering/src/components/SignInGate/gateDesigns/SignInGateMain.tsx
+++ b/dotcom-rendering/src/components/SignInGate/gateDesigns/SignInGateMain.tsx
@@ -1,5 +1,6 @@
 import { cmp } from '@guardian/consent-management-platform';
 import { Button, Link, LinkButton } from '@guardian/source-react-components';
+import { useConfig } from '../../ConfigContext';
 import { trackLink } from '../componentEventTracking';
 import type { SignInGateProps } from '../types';
 import {
@@ -18,7 +19,6 @@ import {
 	signInHeader,
 	signInLink,
 } from './shared';
-import { useConfig } from '../../ConfigContext';
 
 export const SignInGateMain = ({
 	signInUrl,

--- a/dotcom-rendering/src/components/SignInGate/gateDesigns/SignInGateMainCheckoutComplete.tsx
+++ b/dotcom-rendering/src/components/SignInGate/gateDesigns/SignInGateMainCheckoutComplete.tsx
@@ -8,6 +8,7 @@ import {
 	space,
 } from '@guardian/source-foundations';
 import { Button, Link, LinkButton } from '@guardian/source-react-components';
+import { useConfig } from '../../ConfigContext';
 import { trackLink } from '../componentEventTracking';
 import type { Product, SignInGateProps, UserType } from '../types';
 import {
@@ -17,7 +18,6 @@ import {
 	signInGateContainer,
 } from './shared';
 import { SignInGateMain } from './SignInGateMain';
-import { useConfig } from '../../ConfigContext';
 
 const personalisedHeadingStyles = css`
 	${headline.small({ fontWeight: 'bold' })};
@@ -175,6 +175,8 @@ export const SignInGateMainCheckoutComplete = ({
 	isMandatory = false,
 	checkoutCompleteCookieData,
 }: SignInGateProps) => {
+	const { renderingTarget } = useConfig();
+
 	// There is a type check above which means this shouldn't be
 	// possible to be undefined here, so this is just handling
 	// the fact that the type is optional.
@@ -194,8 +196,6 @@ export const SignInGateMainCheckoutComplete = ({
 		);
 	}
 	const { userType, product } = checkoutCompleteCookieData;
-
-	const { renderingTarget } = useConfig();
 
 	// send new/guest userType to the /register page instead of /signin
 	const personaliseSignInURl = (url: string): string => {

--- a/dotcom-rendering/src/components/SignInGate/gateDesigns/SignInGateMainCheckoutComplete.tsx
+++ b/dotcom-rendering/src/components/SignInGate/gateDesigns/SignInGateMainCheckoutComplete.tsx
@@ -17,6 +17,7 @@ import {
 	signInGateContainer,
 } from './shared';
 import { SignInGateMain } from './SignInGateMain';
+import { useConfig } from '../../ConfigContext';
 
 const personalisedHeadingStyles = css`
 	${headline.small({ fontWeight: 'bold' })};
@@ -194,6 +195,8 @@ export const SignInGateMainCheckoutComplete = ({
 	}
 	const { userType, product } = checkoutCompleteCookieData;
 
+	const { renderingTarget } = useConfig();
+
 	// send new/guest userType to the /register page instead of /signin
 	const personaliseSignInURl = (url: string): string => {
 		if (userType === 'new' || userType == 'guest') {
@@ -231,7 +234,12 @@ export const SignInGateMainCheckoutComplete = ({
 					size="small"
 					href={personaliseSignInURl(signInUrl)}
 					onClick={() => {
-						trackLink(ophanComponentId, 'register-link', abTest);
+						trackLink(
+							ophanComponentId,
+							'register-link',
+							renderingTarget,
+							abTest,
+						);
 					}}
 				>
 					{getButtonText(userType)}
@@ -245,7 +253,12 @@ export const SignInGateMainCheckoutComplete = ({
 						size="small"
 						onClick={() => {
 							dismissGate();
-							trackLink(ophanComponentId, 'not-now', abTest);
+							trackLink(
+								ophanComponentId,
+								'not-now',
+								renderingTarget,
+								abTest,
+							);
 						}}
 					>
 						Not now
@@ -258,7 +271,12 @@ export const SignInGateMainCheckoutComplete = ({
 					data-ignore="global-link-styling"
 					href={`${guUrl}/info/2014/nov/03/why-your-data-matters-to-us-full-text`}
 					onClick={() => {
-						trackLink(ophanComponentId, 'why-link', abTest);
+						trackLink(
+							ophanComponentId,
+							'why-link',
+							renderingTarget,
+							abTest,
+						);
 					}}
 				>
 					How will my information & data be used?
@@ -268,7 +286,12 @@ export const SignInGateMainCheckoutComplete = ({
 					data-ignore="global-link-styling"
 					href={`${guUrl}/help/identity-faq`}
 					onClick={() => {
-						trackLink(ophanComponentId, 'help-link', abTest);
+						trackLink(
+							ophanComponentId,
+							'help-link',
+							renderingTarget,
+							abTest,
+						);
 					}}
 				>
 					Get help with registering or signing in

--- a/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
+++ b/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
@@ -7,6 +7,7 @@ import { useOnce } from '../lib/useOnce';
 import { useSignInGateSelector } from '../lib/useSignInGateSelector';
 import type { Switches } from '../types/config';
 import type { TagType } from '../types/tag';
+import { useConfig } from './ConfigContext';
 import type { ComponentEventParams } from './SignInGate/componentEventTracking';
 import {
 	submitViewEventTracking,
@@ -22,7 +23,6 @@ import type {
 	CurrentSignInGateABTest,
 	SignInGateComponent,
 } from './SignInGate/types';
-import { useConfig } from './ConfigContext';
 
 type Props = {
 	contentType: string;
@@ -125,7 +125,7 @@ const ShowSignInGate = ({
 			},
 			renderingTarget,
 		);
-	}, [abTest, componentId]);
+	}, [abTest, componentId, renderingTarget]);
 
 	// some sign in gate ab test variants may not need to show a gate
 	// therefore the gate is optional

--- a/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
+++ b/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
@@ -22,6 +22,7 @@ import type {
 	CurrentSignInGateABTest,
 	SignInGateComponent,
 } from './SignInGate/types';
+import { useConfig } from './ConfigContext';
 
 type Props = {
 	contentType: string;
@@ -113,12 +114,17 @@ const ShowSignInGate = ({
 	checkoutCompleteCookieData,
 	personaliseSignInGateAfterCheckoutSwitch,
 }: ShowSignInGateProps) => {
+	const { renderingTarget } = useConfig();
+
 	// use effect hook to fire view event tracking only on initial render
 	useEffect(() => {
-		submitViewEventTracking({
-			component: withComponentId(componentId),
-			abTest,
-		});
+		submitViewEventTracking(
+			{
+				component: withComponentId(componentId),
+				abTest,
+			},
+			renderingTarget,
+		);
 	}, [abTest, componentId]);
 
 	// some sign in gate ab test variants may not need to show a gate

--- a/dotcom-rendering/src/components/SlotBodyEnd.importable.tsx
+++ b/dotcom-rendering/src/components/SlotBodyEnd.importable.tsx
@@ -27,6 +27,7 @@ import type {
 	CanShowData as RRCanShowData,
 	EpicConfig as RREpicConfig,
 } from './SlotBodyEnd/ReaderRevenueEpic';
+import { useConfig } from './ConfigContext';
 
 type Props = {
 	contentType: string;
@@ -120,7 +121,8 @@ export const SlotBodyEnd = ({
 	renderAds,
 	isLabs,
 }: Props) => {
-	const { brazeMessages } = useBraze(idApiUrl);
+	const { renderingTarget } = useConfig();
+	const { brazeMessages } = useBraze(idApiUrl, renderingTarget);
 	const [countryCode, setCountryCode] = useState<string>();
 	const isSignedIn = getIsSignedIn(useAuthStatus());
 	const browserId = getCookie({ name: 'bwid', shouldMemoize: true });
@@ -193,7 +195,7 @@ export const SlotBodyEnd = ({
 			name: 'slotBodyEnd',
 		};
 
-		pickMessage(epicConfig)
+		pickMessage(epicConfig, renderingTarget)
 			.then((PickedEpic: () => MaybeFC) => setSelectedEpic(PickedEpic))
 			.catch((e) =>
 				console.error(`SlotBodyEnd pickMessage - error: ${String(e)}`),

--- a/dotcom-rendering/src/components/SlotBodyEnd.importable.tsx
+++ b/dotcom-rendering/src/components/SlotBodyEnd.importable.tsx
@@ -18,6 +18,7 @@ import { useBraze } from '../lib/useBraze';
 import { useOnce } from '../lib/useOnce';
 import type { TagType } from '../types/tag';
 import { AdSlot } from './AdSlot.web';
+import { useConfig } from './ConfigContext';
 import { canShowBrazeEpic, MaybeBrazeEpic } from './SlotBodyEnd/BrazeEpic';
 import {
 	canShowReaderRevenueEpic,
@@ -27,7 +28,6 @@ import type {
 	CanShowData as RRCanShowData,
 	EpicConfig as RREpicConfig,
 } from './SlotBodyEnd/ReaderRevenueEpic';
-import { useConfig } from './ConfigContext';
 
 type Props = {
 	contentType: string;

--- a/dotcom-rendering/src/components/SlotBodyEnd/BrazeEpic.tsx
+++ b/dotcom-rendering/src/components/SlotBodyEnd/BrazeEpic.tsx
@@ -143,7 +143,7 @@ const BrazeEpicWithSatisfiedDependencies = ({
 				renderingTarget,
 			);
 		}
-	}, [hasBeenSeen, meta]);
+	}, [hasBeenSeen, meta, renderingTarget]);
 
 	const componentName = meta.dataFromBraze.componentName;
 	if (!componentName) return null;

--- a/dotcom-rendering/src/components/SlotBodyEnd/BrazeEpic.tsx
+++ b/dotcom-rendering/src/components/SlotBodyEnd/BrazeEpic.tsx
@@ -17,6 +17,7 @@ import {
 import { useIsInView } from '../../lib/useIsInView';
 import { useOnce } from '../../lib/useOnce';
 import type { TagType } from '../../types/tag';
+import { useConfig } from '../ConfigContext';
 
 const wrapperMargins = css`
 	margin: 18px 0;
@@ -111,14 +112,19 @@ const BrazeEpicWithSatisfiedDependencies = ({
 
 	const epicRef = useRef(null);
 
+	const { renderingTarget } = useConfig();
+
 	useOnce(() => {
-		void submitComponentEvent({
-			component: {
-				componentType: COMPONENT_TYPE,
-				id: meta.dataFromBraze.ophanComponentId,
+		void submitComponentEvent(
+			{
+				component: {
+					componentType: COMPONENT_TYPE,
+					id: meta.dataFromBraze.ophanComponentId,
+				},
+				action: 'INSERT',
 			},
-			action: 'INSERT',
-		});
+			renderingTarget,
+		);
 	}, [meta.dataFromBraze, epicRef.current]);
 
 	useEffect(() => {
@@ -126,13 +132,16 @@ const BrazeEpicWithSatisfiedDependencies = ({
 			meta.logImpressionWithBraze();
 
 			// Log VIEW event with Ophan
-			void submitComponentEvent({
-				component: {
-					componentType: COMPONENT_TYPE,
-					id: meta.dataFromBraze.ophanComponentId,
+			void submitComponentEvent(
+				{
+					component: {
+						componentType: COMPONENT_TYPE,
+						id: meta.dataFromBraze.ophanComponentId,
+					},
+					action: 'VIEW',
 				},
-				action: 'VIEW',
-			});
+				renderingTarget,
+			);
 		}
 	}, [hasBeenSeen, meta]);
 
@@ -169,7 +178,7 @@ const BrazeEpicWithSatisfiedDependencies = ({
 					subscribeToNewsletter={subscribeToNewsletter}
 					countryCode={countryCode}
 					logButtonClickWithBraze={meta.logButtonClickWithBraze}
-					submitComponentEvent={submitComponentEvent}
+					submitComponentEvent={() => submitComponentEvent}
 					fetchEmail={fetchEmail}
 				/>
 			</div>

--- a/dotcom-rendering/src/components/SlotBodyEnd/BrazeEpic.tsx
+++ b/dotcom-rendering/src/components/SlotBodyEnd/BrazeEpic.tsx
@@ -178,7 +178,9 @@ const BrazeEpicWithSatisfiedDependencies = ({
 					subscribeToNewsletter={subscribeToNewsletter}
 					countryCode={countryCode}
 					logButtonClickWithBraze={meta.logButtonClickWithBraze}
-					submitComponentEvent={() => submitComponentEvent}
+					submitComponentEvent={(event) =>
+						void submitComponentEvent(event, renderingTarget)
+					}
 					fetchEmail={fetchEmail}
 				/>
 			</div>

--- a/dotcom-rendering/src/components/SlotBodyEnd/ReaderRevenueEpic.tsx
+++ b/dotcom-rendering/src/components/SlotBodyEnd/ReaderRevenueEpic.tsx
@@ -199,7 +199,7 @@ export const ReaderRevenueEpic = ({
 				<Epic
 					{...module.props}
 					fetchEmail={fetchEmail}
-					submitComponentEvent={submitComponentEvent}
+					submitComponentEvent={() => submitComponentEvent}
 					openCmp={openCmp}
 					hasConsentForArticleCount={hasConsentForArticleCount}
 					stage={stage}

--- a/dotcom-rendering/src/components/SlotBodyEnd/ReaderRevenueEpic.tsx
+++ b/dotcom-rendering/src/components/SlotBodyEnd/ReaderRevenueEpic.tsx
@@ -24,6 +24,7 @@ import {
 import type { CanShowResult } from '../../lib/messagePicker';
 import { setAutomat } from '../../lib/setAutomat';
 import type { TagType } from '../../types/tag';
+import { useConfig } from '../ConfigContext';
 
 export type EpicConfig = {
 	module: ModuleData;
@@ -158,6 +159,7 @@ export const ReaderRevenueEpic = ({
 	stage,
 }: EpicConfig) => {
 	const [Epic, setEpic] = useState<EpicType>();
+	const { renderingTarget } = useConfig();
 
 	const openCmp = () => {
 		cmp.showPrivacyManager();
@@ -199,7 +201,9 @@ export const ReaderRevenueEpic = ({
 				<Epic
 					{...module.props}
 					fetchEmail={fetchEmail}
-					submitComponentEvent={() => submitComponentEvent}
+					submitComponentEvent={(event) =>
+						void submitComponentEvent(event, renderingTarget)
+					}
 					openCmp={openCmp}
 					hasConsentForArticleCount={hasConsentForArticleCount}
 					stage={stage}

--- a/dotcom-rendering/src/components/StickyBottomBanner.importable.tsx
+++ b/dotcom-rendering/src/components/StickyBottomBanner.importable.tsx
@@ -33,6 +33,7 @@ import type {
 	BannerProps,
 	CanShowFunctionType,
 } from './StickyBottomBanner/ReaderRevenueBanner';
+import { useConfig } from './ConfigContext';
 
 type Props = {
 	contentType: string;
@@ -240,7 +241,8 @@ export const StickyBottomBanner = ({
 	puzzleBannerSwitch: boolean;
 	isSensitive: boolean;
 }) => {
-	const { brazeMessages } = useBraze(idApiUrl);
+	const { renderingTarget } = useConfig();
+	const { brazeMessages } = useBraze(idApiUrl, renderingTarget);
 
 	const asyncCountryCode = getLocaleCode();
 	const authStatus = useAuthStatus();
@@ -317,7 +319,7 @@ export const StickyBottomBanner = ({
 			name: 'banner',
 		};
 
-		pickMessage(bannerConfig)
+		pickMessage(bannerConfig, renderingTarget)
 			.then((PickedBanner: () => MaybeFC) =>
 				setSelectedBanner(PickedBanner),
 			)

--- a/dotcom-rendering/src/components/StickyBottomBanner.importable.tsx
+++ b/dotcom-rendering/src/components/StickyBottomBanner.importable.tsx
@@ -19,6 +19,7 @@ import { useBraze } from '../lib/useBraze';
 import { useOnce } from '../lib/useOnce';
 import { useSignInGateWillShow } from '../lib/useSignInGateWillShow';
 import type { TagType } from '../types/tag';
+import { useConfig } from './ConfigContext';
 import {
 	BrazeBanner,
 	canShowBrazeBanner,
@@ -33,7 +34,6 @@ import type {
 	BannerProps,
 	CanShowFunctionType,
 } from './StickyBottomBanner/ReaderRevenueBanner';
-import { useConfig } from './ConfigContext';
 
 type Props = {
 	contentType: string;

--- a/dotcom-rendering/src/components/StickyBottomBanner/BrazeBanner.tsx
+++ b/dotcom-rendering/src/components/StickyBottomBanner/BrazeBanner.tsx
@@ -16,6 +16,7 @@ import {
 	useAuthStatus,
 } from '../../lib/useAuthStatus';
 import type { TagType } from '../../types/tag';
+import { useConfig } from '../ConfigContext';
 
 type Meta = {
 	dataFromBraze: { [key: string]: string };
@@ -110,21 +111,25 @@ const BrazeBannerWithSatisfiedDependencies = ({
 	idApiUrl,
 }: InnerProps) => {
 	const authStatus = useAuthStatus();
+	const { renderingTarget } = useConfig();
 
 	useEffect(() => {
 		// Log the impression with Braze
 		meta.logImpressionWithBraze();
 
 		// Log VIEW event with Ophan
-		void submitComponentEvent({
-			component: {
-				componentType: 'RETENTION_ENGAGEMENT_BANNER',
-				id:
-					meta.dataFromBraze.ophanComponentId ??
-					meta.dataFromBraze.componentName,
+		void submitComponentEvent(
+			{
+				component: {
+					componentType: 'RETENTION_ENGAGEMENT_BANNER',
+					id:
+						meta.dataFromBraze.ophanComponentId ??
+						meta.dataFromBraze.componentName,
+				},
+				action: 'VIEW',
 			},
-			action: 'VIEW',
-		});
+			renderingTarget,
+		);
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 
@@ -156,7 +161,7 @@ const BrazeBannerWithSatisfiedDependencies = ({
 		<div css={containerStyles}>
 			<BrazeComponent
 				logButtonClickWithBraze={meta.logButtonClickWithBraze}
-				submitComponentEvent={submitComponentEvent}
+				submitComponentEvent={() => submitComponentEvent}
 				componentName={componentName}
 				brazeMessageProps={meta.dataFromBraze}
 				subscribeToNewsletter={subscribeToNewsletter}

--- a/dotcom-rendering/src/components/StickyBottomBanner/BrazeBanner.tsx
+++ b/dotcom-rendering/src/components/StickyBottomBanner/BrazeBanner.tsx
@@ -161,7 +161,9 @@ const BrazeBannerWithSatisfiedDependencies = ({
 		<div css={containerStyles}>
 			<BrazeComponent
 				logButtonClickWithBraze={meta.logButtonClickWithBraze}
-				submitComponentEvent={() => submitComponentEvent}
+				submitComponentEvent={(event) =>
+					void submitComponentEvent(event, renderingTarget)
+				}
 				componentName={componentName}
 				brazeMessageProps={meta.dataFromBraze}
 				subscribeToNewsletter={subscribeToNewsletter}

--- a/dotcom-rendering/src/components/SupportTheG.importable.tsx
+++ b/dotcom-rendering/src/components/SupportTheG.importable.tsx
@@ -38,6 +38,7 @@ import { useAuthStatus } from '../lib/useAuthStatus';
 import { useIsInView } from '../lib/useIsInView';
 import { useOnce } from '../lib/useOnce';
 import ArrowRightIcon from '../static/icons/arrow-right.svg';
+import { useConfig } from './ConfigContext';
 
 type Props = {
 	editionId: EditionId;
@@ -188,6 +189,8 @@ const ReaderRevenueLinksRemote = ({
 		useState<React.ElementType | null>(null);
 	const isSignedIn = getIsSignedIn(useAuthStatus());
 
+	const { renderingTarget } = useConfig();
+
 	useOnce((): void => {
 		setAutomat();
 
@@ -249,7 +252,12 @@ const ReaderRevenueLinksRemote = ({
 				<SupportHeader
 					submitComponentEvent={(
 						componentEvent: OphanComponentEvent,
-					) => void submitComponentEvent(componentEvent)}
+					) =>
+						void submitComponentEvent(
+							componentEvent,
+							renderingTarget,
+						)
+					}
 					{...supportHeaderResponse.props}
 				/>
 			</div>
@@ -292,6 +300,8 @@ const ReaderRevenueLinksNative = ({
 		campaignCode,
 	};
 
+	const { renderingTarget } = useConfig();
+
 	const [hasBeenSeen, setNode] = useIsInView({
 		threshold: 0,
 		debounce: true,
@@ -299,14 +309,14 @@ const ReaderRevenueLinksNative = ({
 
 	useEffect(() => {
 		if (!hideSupportMessaging && inHeader) {
-			void sendOphanComponentEvent('INSERT', tracking);
+			void sendOphanComponentEvent('INSERT', tracking, renderingTarget);
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 
 	useEffect(() => {
 		if (hasBeenSeen && inHeader) {
-			void sendOphanComponentEvent('VIEW', tracking);
+			void sendOphanComponentEvent('VIEW', tracking, renderingTarget);
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [hasBeenSeen]);

--- a/dotcom-rendering/src/components/TimelineAtom.importable.tsx
+++ b/dotcom-rendering/src/components/TimelineAtom.importable.tsx
@@ -2,10 +2,10 @@ import { css } from '@emotion/react';
 import { body, palette, remSpace, space } from '@guardian/source-foundations';
 import { submitComponentEvent } from '../client/ophan/ophan';
 import type { TimelineAtomType, TimelineEvent } from '../types/content';
+import { useConfig } from './ConfigContext';
 import { Body } from './ExpandableAtom/Body';
 import { Container } from './ExpandableAtom/Container';
 import { Footer } from './ExpandableAtom/Footer';
-import { useConfig } from './ConfigContext';
 
 const Snippet = css`
 	:not(:last-child) {

--- a/dotcom-rendering/src/components/TimelineAtom.importable.tsx
+++ b/dotcom-rendering/src/components/TimelineAtom.importable.tsx
@@ -5,6 +5,7 @@ import type { TimelineAtomType, TimelineEvent } from '../types/content';
 import { Body } from './ExpandableAtom/Body';
 import { Container } from './ExpandableAtom/Container';
 import { Footer } from './ExpandableAtom/Footer';
+import { useConfig } from './ConfigContext';
 
 const Snippet = css`
 	:not(:last-child) {
@@ -108,6 +109,8 @@ export const TimelineAtom = ({
 	dislikeHandler,
 	expandCallback,
 }: TimelineAtomType) => {
+	const { renderingTarget } = useConfig();
+
 	return (
 		<Container
 			atomType="timeline"
@@ -119,15 +122,18 @@ export const TimelineAtom = ({
 			expandCallback={
 				expandCallback ??
 				(() =>
-					submitComponentEvent({
-						component: {
-							componentType: 'TIMELINE_ATOM',
-							id,
-							products: [],
-							labels: [],
+					submitComponentEvent(
+						{
+							component: {
+								componentType: 'TIMELINE_ATOM',
+								id,
+								products: [],
+								labels: [],
+							},
+							action: 'EXPAND',
 						},
-						action: 'EXPAND',
-					}))
+						renderingTarget,
+					))
 			}
 		>
 			{!!description && <Body html={description} format={format} />}
@@ -137,28 +143,34 @@ export const TimelineAtom = ({
 				dislikeHandler={
 					dislikeHandler ??
 					(() =>
-						submitComponentEvent({
-							component: {
-								componentType: 'TIMELINE_ATOM',
-								id,
-								products: [],
-								labels: [],
+						submitComponentEvent(
+							{
+								component: {
+									componentType: 'TIMELINE_ATOM',
+									id,
+									products: [],
+									labels: [],
+								},
+								action: 'DISLIKE',
 							},
-							action: 'DISLIKE',
-						}))
+							renderingTarget,
+						))
 				}
 				likeHandler={
 					likeHandler ??
 					(() =>
-						submitComponentEvent({
-							component: {
-								componentType: 'TIMELINE_ATOM',
-								id,
-								products: [],
-								labels: [],
+						submitComponentEvent(
+							{
+								component: {
+									componentType: 'TIMELINE_ATOM',
+									id,
+									products: [],
+									labels: [],
+								},
+								action: 'LIKE',
 							},
-							action: 'LIKE',
-						}))
+							renderingTarget,
+						))
 				}
 			/>
 		</Container>

--- a/dotcom-rendering/src/components/TimelineAtom.test.tsx
+++ b/dotcom-rendering/src/components/TimelineAtom.test.tsx
@@ -2,11 +2,14 @@ import { fireEvent, render } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import { noTimelineEventsStory } from '../../fixtures/manual/timelineAtom';
 import { TimelineAtom } from './TimelineAtom.importable';
+import { ConfigProvider } from './ConfigContext';
 
 describe('TimelineAtom', () => {
 	it('should render', () => {
 		const { getByText, queryByText } = render(
-			<TimelineAtom {...noTimelineEventsStory} />,
+			<ConfigProvider value={{ renderingTarget: 'Web' }}>
+				<TimelineAtom {...noTimelineEventsStory} />
+			</ConfigProvider>,
 		);
 
 		expect(getByText('Timeline')).toBeInTheDocument();
@@ -23,7 +26,9 @@ describe('TimelineAtom', () => {
 
 	it('Show feedback on like', () => {
 		const { getByText, queryByText, queryByTestId } = render(
-			<TimelineAtom {...noTimelineEventsStory} />,
+			<ConfigProvider value={{ renderingTarget: 'Web' }}>
+				<TimelineAtom {...noTimelineEventsStory} />
+			</ConfigProvider>,
 		);
 
 		// Expand Timeline
@@ -41,7 +46,9 @@ describe('TimelineAtom', () => {
 
 	it('Show feedback on dislike', () => {
 		const { getByText, queryByText, queryByTestId } = render(
-			<TimelineAtom {...noTimelineEventsStory} />,
+			<ConfigProvider value={{ renderingTarget: 'Web' }}>
+				<TimelineAtom {...noTimelineEventsStory} />
+			</ConfigProvider>,
 		);
 
 		// Timeline Guide

--- a/dotcom-rendering/src/components/TimelineAtom.test.tsx
+++ b/dotcom-rendering/src/components/TimelineAtom.test.tsx
@@ -1,8 +1,8 @@
 import { fireEvent, render } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import { noTimelineEventsStory } from '../../fixtures/manual/timelineAtom';
-import { TimelineAtom } from './TimelineAtom.importable';
 import { ConfigProvider } from './ConfigContext';
+import { TimelineAtom } from './TimelineAtom.importable';
 
 describe('TimelineAtom', () => {
 	it('should render', () => {

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.test.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.test.tsx
@@ -3,6 +3,7 @@ import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
 import '@testing-library/jest-dom/extend-expect';
 import { fireEvent, render } from '@testing-library/react';
 import { YoutubeAtom } from './YoutubeAtom';
+import { ConfigProvider } from '../ConfigContext';
 
 const overlayImage =
 	'https://i.guim.co.uk/img/media/4b3808707ec341629932a9d443ff5a812cf4df14/0_309_1800_1081/master/1800.jpg?width=1200&height=630&quality=85&auto=format&fit=crop&overlay-align=bottom%2Cleft&overlay-width=100p&overlay-base64=L2ltZy9zdGF0aWMvb3ZlcmxheXMvdGctZGVmYXVsdC5wbmc&enable=upscale&s=aff4b8255693eb449f13070df88e9cac';
@@ -23,24 +24,26 @@ const consentStateCanTarget: ConsentState = {
 describe('YoutubeAtom', () => {
 	it('Player initialises when no overlay and has consent state', () => {
 		const atom = (
-			<YoutubeAtom
-				elementId="xyz"
-				title="My Youtube video!"
-				videoId="ZCvZmYlQD8"
-				alt=""
-				adTargeting={{ disableAds: true }}
-				eventEmitters={[]}
-				format={{
-					theme: Pillar.News,
-					design: ArticleDesign.Standard,
-					display: ArticleDisplay.Standard,
-				}}
-				consentState={consentStateCanTarget}
-				shouldStick={false}
-				isMainMedia={false}
-				imaEnabled={false}
-				abTestParticipations={{}}
-			/>
+			<ConfigProvider value={{ renderingTarget: 'Web' }}>
+				<YoutubeAtom
+					elementId="xyz"
+					title="My Youtube video!"
+					videoId="ZCvZmYlQD8"
+					alt=""
+					adTargeting={{ disableAds: true }}
+					eventEmitters={[]}
+					format={{
+						theme: Pillar.News,
+						design: ArticleDesign.Standard,
+						display: ArticleDisplay.Standard,
+					}}
+					consentState={consentStateCanTarget}
+					shouldStick={false}
+					isMainMedia={false}
+					imaEnabled={false}
+					abTestParticipations={{}}
+				/>
+			</ConfigProvider>
 		);
 		const { getByTestId } = render(atom);
 		const playerDiv = getByTestId('youtube-video-ZCvZmYlQD8-xyz');
@@ -49,25 +52,27 @@ describe('YoutubeAtom', () => {
 
 	it('Player initialises when overlay clicked and has consent state', () => {
 		const atom = (
-			<YoutubeAtom
-				elementId="xyz"
-				title="My Youtube video!"
-				videoId="ZCvZmYlQD8"
-				alt=""
-				adTargeting={{ disableAds: true }}
-				eventEmitters={[]}
-				format={{
-					theme: Pillar.News,
-					design: ArticleDesign.Standard,
-					display: ArticleDisplay.Standard,
-				}}
-				consentState={consentStateCanTarget}
-				overrideImage={overlayImage}
-				shouldStick={false}
-				isMainMedia={false}
-				imaEnabled={false}
-				abTestParticipations={{}}
-			/>
+			<ConfigProvider value={{ renderingTarget: 'Web' }}>
+				<YoutubeAtom
+					elementId="xyz"
+					title="My Youtube video!"
+					videoId="ZCvZmYlQD8"
+					alt=""
+					adTargeting={{ disableAds: true }}
+					eventEmitters={[]}
+					format={{
+						theme: Pillar.News,
+						design: ArticleDesign.Standard,
+						display: ArticleDisplay.Standard,
+					}}
+					consentState={consentStateCanTarget}
+					overrideImage={overlayImage}
+					shouldStick={false}
+					isMainMedia={false}
+					imaEnabled={false}
+					abTestParticipations={{}}
+				/>
+			</ConfigProvider>
 		);
 		const { getByTestId } = render(atom);
 		const overlay = getByTestId('youtube-overlay-ZCvZmYlQD8-xyz');
@@ -84,24 +89,26 @@ describe('YoutubeAtom', () => {
 		const title = 'My Youtube video!';
 
 		const atom = (
-			<YoutubeAtom
-				elementId="xyz"
-				title="My Youtube video!"
-				videoId="ZCvZmYlQD8"
-				alt=""
-				adTargeting={{ disableAds: true }}
-				eventEmitters={[]}
-				format={{
-					theme: Pillar.News,
-					design: ArticleDesign.Standard,
-					display: ArticleDisplay.Standard,
-				}}
-				consentState={consentStateCanTarget}
-				shouldStick={false}
-				isMainMedia={false}
-				imaEnabled={false}
-				abTestParticipations={{}}
-			/>
+			<ConfigProvider value={{ renderingTarget: 'Web' }}>
+				<YoutubeAtom
+					elementId="xyz"
+					title="My Youtube video!"
+					videoId="ZCvZmYlQD8"
+					alt=""
+					adTargeting={{ disableAds: true }}
+					eventEmitters={[]}
+					format={{
+						theme: Pillar.News,
+						design: ArticleDesign.Standard,
+						display: ArticleDisplay.Standard,
+					}}
+					consentState={consentStateCanTarget}
+					shouldStick={false}
+					isMainMedia={false}
+					imaEnabled={false}
+					abTestParticipations={{}}
+				/>
+			</ConfigProvider>
 		);
 		const { getByTestId } = render(atom);
 		const playerDiv = getByTestId('youtube-video-ZCvZmYlQD8-xyz');
@@ -111,25 +118,27 @@ describe('YoutubeAtom', () => {
 	it('overlay has correct aria-label', () => {
 		const title = 'My Youtube video!';
 		const atom = (
-			<YoutubeAtom
-				elementId="xyz"
-				title="My Youtube video!"
-				videoId="ZCvZmYlQD8"
-				alt=""
-				adTargeting={{ disableAds: true }}
-				eventEmitters={[]}
-				format={{
-					theme: Pillar.News,
-					design: ArticleDesign.Standard,
-					display: ArticleDisplay.Standard,
-				}}
-				consentState={consentStateCanTarget}
-				overrideImage={overlayImage}
-				shouldStick={false}
-				isMainMedia={false}
-				imaEnabled={false}
-				abTestParticipations={{}}
-			/>
+			<ConfigProvider value={{ renderingTarget: 'Web' }}>
+				<YoutubeAtom
+					elementId="xyz"
+					title="My Youtube video!"
+					videoId="ZCvZmYlQD8"
+					alt=""
+					adTargeting={{ disableAds: true }}
+					eventEmitters={[]}
+					format={{
+						theme: Pillar.News,
+						design: ArticleDesign.Standard,
+						display: ArticleDisplay.Standard,
+					}}
+					consentState={consentStateCanTarget}
+					overrideImage={overlayImage}
+					shouldStick={false}
+					isMainMedia={false}
+					imaEnabled={false}
+					abTestParticipations={{}}
+				/>
+			</ConfigProvider>
 		);
 		const { getByTestId } = render(atom);
 		const overlay = getByTestId('youtube-overlay-ZCvZmYlQD8-xyz');
@@ -140,23 +149,25 @@ describe('YoutubeAtom', () => {
 
 	it('shows a placeholder if overlay is missing', () => {
 		const atom = (
-			<YoutubeAtom
-				elementId="xyz"
-				title="My Youtube video!"
-				videoId="ZCvZmYlQD8"
-				alt=""
-				adTargeting={{ disableAds: true }}
-				eventEmitters={[]}
-				format={{
-					theme: Pillar.News,
-					design: ArticleDesign.Standard,
-					display: ArticleDisplay.Standard,
-				}}
-				shouldStick={false}
-				isMainMedia={false}
-				imaEnabled={false}
-				abTestParticipations={{}}
-			/>
+			<ConfigProvider value={{ renderingTarget: 'Web' }}>
+				<YoutubeAtom
+					elementId="xyz"
+					title="My Youtube video!"
+					videoId="ZCvZmYlQD8"
+					alt=""
+					adTargeting={{ disableAds: true }}
+					eventEmitters={[]}
+					format={{
+						theme: Pillar.News,
+						design: ArticleDesign.Standard,
+						display: ArticleDisplay.Standard,
+					}}
+					shouldStick={false}
+					isMainMedia={false}
+					imaEnabled={false}
+					abTestParticipations={{}}
+				/>
+			</ConfigProvider>
 		);
 		const { getByTestId } = render(atom);
 		const placeholder = getByTestId('youtube-placeholder-ZCvZmYlQD8-xyz');
@@ -165,62 +176,7 @@ describe('YoutubeAtom', () => {
 
 	it('shows an overlay if present', () => {
 		const atom = (
-			<YoutubeAtom
-				elementId="xyz"
-				title="My Youtube video!"
-				videoId="ZCvZmYlQD8"
-				alt=""
-				adTargeting={{ disableAds: true }}
-				eventEmitters={[]}
-				format={{
-					theme: Pillar.News,
-					design: ArticleDesign.Standard,
-					display: ArticleDisplay.Standard,
-				}}
-				overrideImage={overlayImage}
-				shouldStick={false}
-				isMainMedia={false}
-				imaEnabled={false}
-				abTestParticipations={{}}
-			/>
-		);
-		const { getByTestId } = render(atom);
-		const overlay = getByTestId('youtube-overlay-ZCvZmYlQD8-xyz');
-		expect(overlay).toBeInTheDocument();
-	});
-
-	it('hides an overlay once it is clicked', () => {
-		const atom = (
-			<YoutubeAtom
-				elementId="xyz"
-				title="My Youtube video!"
-				videoId="ZCvZmYlQD8"
-				alt=""
-				adTargeting={{ disableAds: true }}
-				eventEmitters={[]}
-				format={{
-					theme: Pillar.News,
-					design: ArticleDesign.Standard,
-					display: ArticleDisplay.Standard,
-				}}
-				overrideImage={overlayImage}
-				shouldStick={false}
-				isMainMedia={false}
-				imaEnabled={false}
-				abTestParticipations={{}}
-			/>
-		);
-		const { getByTestId } = render(atom);
-		const overlay = getByTestId('youtube-overlay-ZCvZmYlQD8-xyz');
-		expect(overlay).toBeInTheDocument();
-
-		fireEvent.click(getByTestId('youtube-overlay-ZCvZmYlQD8-xyz'));
-		expect(overlay).not.toBeInTheDocument();
-	});
-
-	it('when two Atoms - hides the overlay of the correct player if clicked', () => {
-		const atom = (
-			<>
+			<ConfigProvider value={{ renderingTarget: 'Web' }}>
 				<YoutubeAtom
 					elementId="xyz"
 					title="My Youtube video!"
@@ -239,10 +195,20 @@ describe('YoutubeAtom', () => {
 					imaEnabled={false}
 					abTestParticipations={{}}
 				/>
+			</ConfigProvider>
+		);
+		const { getByTestId } = render(atom);
+		const overlay = getByTestId('youtube-overlay-ZCvZmYlQD8-xyz');
+		expect(overlay).toBeInTheDocument();
+	});
+
+	it('hides an overlay once it is clicked', () => {
+		const atom = (
+			<ConfigProvider value={{ renderingTarget: 'Web' }}>
 				<YoutubeAtom
 					elementId="xyz"
-					title="My Youtube video 2!"
-					videoId="ZCvZmYlQD8_2"
+					title="My Youtube video!"
+					videoId="ZCvZmYlQD8"
 					alt=""
 					adTargeting={{ disableAds: true }}
 					eventEmitters={[]}
@@ -257,6 +223,57 @@ describe('YoutubeAtom', () => {
 					imaEnabled={false}
 					abTestParticipations={{}}
 				/>
+			</ConfigProvider>
+		);
+		const { getByTestId } = render(atom);
+		const overlay = getByTestId('youtube-overlay-ZCvZmYlQD8-xyz');
+		expect(overlay).toBeInTheDocument();
+
+		fireEvent.click(getByTestId('youtube-overlay-ZCvZmYlQD8-xyz'));
+		expect(overlay).not.toBeInTheDocument();
+	});
+
+	it('when two Atoms - hides the overlay of the correct player if clicked', () => {
+		const atom = (
+			<>
+				<ConfigProvider value={{ renderingTarget: 'Web' }}>
+					<YoutubeAtom
+						elementId="xyz"
+						title="My Youtube video!"
+						videoId="ZCvZmYlQD8"
+						alt=""
+						adTargeting={{ disableAds: true }}
+						eventEmitters={[]}
+						format={{
+							theme: Pillar.News,
+							design: ArticleDesign.Standard,
+							display: ArticleDisplay.Standard,
+						}}
+						overrideImage={overlayImage}
+						shouldStick={false}
+						isMainMedia={false}
+						imaEnabled={false}
+						abTestParticipations={{}}
+					/>
+					<YoutubeAtom
+						elementId="xyz"
+						title="My Youtube video 2!"
+						videoId="ZCvZmYlQD8_2"
+						alt=""
+						adTargeting={{ disableAds: true }}
+						eventEmitters={[]}
+						format={{
+							theme: Pillar.News,
+							design: ArticleDesign.Standard,
+							display: ArticleDisplay.Standard,
+						}}
+						overrideImage={overlayImage}
+						shouldStick={false}
+						isMainMedia={false}
+						imaEnabled={false}
+						abTestParticipations={{}}
+					/>
+				</ConfigProvider>
 			</>
 		);
 		const { getByTestId } = render(atom);

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.test.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.test.tsx
@@ -2,8 +2,8 @@ import type { ConsentState } from '@guardian/consent-management-platform/dist/ty
 import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
 import '@testing-library/jest-dom/extend-expect';
 import { fireEvent, render } from '@testing-library/react';
-import { YoutubeAtom } from './YoutubeAtom';
 import { ConfigProvider } from '../ConfigContext';
+import { YoutubeAtom } from './YoutubeAtom';
 
 const overlayImage =
 	'https://i.guim.co.uk/img/media/4b3808707ec341629932a9d443ff5a812cf4df14/0_309_1800_1081/master/1800.jpg?width=1200&height=630&quality=85&auto=format&fit=crop&overlay-align=bottom%2Cleft&overlay-width=100p&overlay-base64=L2ltZy9zdGF0aWMvb3ZlcmxheXMvdGctZGVmYXVsdC5wbmc&enable=upscale&s=aff4b8255693eb449f13070df88e9cac';

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomSticky.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomSticky.tsx
@@ -6,8 +6,8 @@ import detectMobile from 'is-mobile';
 import { useEffect, useState } from 'react';
 import { submitComponentEvent } from '../../client/ophan/ophan';
 import { useIsInView } from '../../lib/useIsInView';
-import type { VideoEventKey } from './YoutubeAtom';
 import { useConfig } from '../ConfigContext';
+import type { VideoEventKey } from './YoutubeAtom';
 
 const buttonStyles = css`
 	position: absolute;
@@ -168,8 +168,6 @@ export const YoutubeAtomSticky = ({
 			msg: 'Close',
 		});
 
-		const { renderingTarget } = useConfig();
-
 		// submit a 'close' event to Ophan
 		void submitComponentEvent(
 			{
@@ -249,7 +247,7 @@ export const YoutubeAtomSticky = ({
 				renderingTarget,
 			);
 		}
-	}, [isSticky, stickEventSent, videoId, eventEmitters]);
+	}, [isSticky, stickEventSent, videoId, eventEmitters, renderingTarget]);
 
 	/**
 	 * useEffect for mobile only sticky overlay

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomSticky.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomSticky.tsx
@@ -7,6 +7,7 @@ import { useEffect, useState } from 'react';
 import { submitComponentEvent } from '../../client/ophan/ophan';
 import { useIsInView } from '../../lib/useIsInView';
 import type { VideoEventKey } from './YoutubeAtom';
+import { useConfig } from '../ConfigContext';
 
 const buttonStyles = css`
 	position: absolute;
@@ -139,6 +140,7 @@ export const YoutubeAtomSticky = ({
 	const [isSticky, setIsSticky] = useState<boolean>(false);
 	const [stickEventSent, setStickEventSent] = useState<boolean>(false);
 	const [showOverlay, setShowOverlay] = useState<boolean>(isMobile);
+	const { renderingTarget } = useConfig();
 
 	const [isIntersecting, setRef] = useIsInView({
 		threshold: 0.5,
@@ -166,14 +168,19 @@ export const YoutubeAtomSticky = ({
 			msg: 'Close',
 		});
 
+		const { renderingTarget } = useConfig();
+
 		// submit a 'close' event to Ophan
-		void submitComponentEvent({
-			component: {
-				componentType: 'STICKY_VIDEO',
-				id: videoId,
+		void submitComponentEvent(
+			{
+				component: {
+					componentType: 'STICKY_VIDEO',
+					id: videoId,
+				},
+				action: 'CLOSE',
 			},
-			action: 'CLOSE',
-		});
+			renderingTarget,
+		);
 	};
 
 	/**
@@ -231,13 +238,16 @@ export const YoutubeAtomSticky = ({
 				msg: 'Stick',
 			});
 
-			void submitComponentEvent({
-				component: {
-					componentType: 'STICKY_VIDEO',
-					id: videoId,
+			void submitComponentEvent(
+				{
+					component: {
+						componentType: 'STICKY_VIDEO',
+						id: videoId,
+					},
+					action: 'STICK',
 				},
-				action: 'STICK',
-			});
+				renderingTarget,
+			);
 		}
 	}, [isSticky, stickEventSent, videoId, eventEmitters]);
 

--- a/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
@@ -180,7 +180,7 @@ export const YoutubeBlockComponent = ({
 
 	const ophanTracking = async (trackingEvent: string): Promise<void> => {
 		if (!id) return;
-		const ophan = await getOphan();
+		const ophan = await getOphan(renderingTarget);
 		ophan.record({
 			video: {
 				id: `gu-video-youtube-${id}`,

--- a/dotcom-rendering/src/lib/braze/buildBrazeMessaging.ts
+++ b/dotcom-rendering/src/lib/braze/buildBrazeMessaging.ts
@@ -18,6 +18,7 @@ import {
 } from '../hasCurrentBrazeUser';
 import { checkBrazeDependencies } from './checkBrazeDependencies';
 import { getInitialisedAppboy } from './initialiseAppboy';
+import { RenderingTarget } from '../../types/renderingTarget';
 
 const maybeWipeUserData = async (
 	apiKey?: string,
@@ -51,6 +52,7 @@ const maybeWipeUserData = async (
 export const buildBrazeMessaging = async (
 	idApiUrl: string,
 	isSignedIn: boolean,
+	renderingTarget: RenderingTarget,
 ): Promise<{
 	brazeMessages: BrazeMessagesInterface;
 	brazeCards: BrazeCardsInterface;
@@ -103,7 +105,7 @@ export const buildBrazeMessaging = async (
 		);
 
 		const sdkLoadTimeTaken = endPerformanceMeasure();
-		const ophan = await getOphan();
+		const ophan = await getOphan(renderingTarget);
 		ophan.record({
 			component: 'braze-sdk-load-timing',
 			value: sdkLoadTimeTaken,

--- a/dotcom-rendering/src/lib/braze/buildBrazeMessaging.ts
+++ b/dotcom-rendering/src/lib/braze/buildBrazeMessaging.ts
@@ -11,6 +11,7 @@ import {
 } from '@guardian/braze-components/logic';
 import { log, startPerformanceMeasure, storage } from '@guardian/libs';
 import { getOphan } from '../../client/ophan/ophan';
+import type { RenderingTarget } from '../../types/renderingTarget';
 import {
 	clearHasCurrentBrazeUser,
 	hasCurrentBrazeUser,
@@ -18,7 +19,6 @@ import {
 } from '../hasCurrentBrazeUser';
 import { checkBrazeDependencies } from './checkBrazeDependencies';
 import { getInitialisedAppboy } from './initialiseAppboy';
-import { RenderingTarget } from '../../types/renderingTarget';
 
 const maybeWipeUserData = async (
 	apiKey?: string,

--- a/dotcom-rendering/src/lib/messagePicker.test.tsx
+++ b/dotcom-rendering/src/lib/messagePicker.test.tsx
@@ -56,7 +56,7 @@ describe('pickMessage', () => {
 			],
 		};
 
-		const got = await pickMessage(config);
+		const got = await pickMessage(config, 'Web');
 
 		expect(got()).toEqual(ChosenMockComponent);
 	});
@@ -86,7 +86,7 @@ describe('pickMessage', () => {
 			],
 		};
 
-		const got = await pickMessage(config);
+		const got = await pickMessage(config, 'Web');
 
 		expect(got()).toEqual(null);
 	});
@@ -127,7 +127,7 @@ describe('pickMessage', () => {
 			],
 		};
 
-		const messagePromise = pickMessage(config);
+		const messagePromise = pickMessage(config, 'Web');
 		jest.advanceTimersByTime(260);
 		const got = await messagePromise;
 
@@ -180,7 +180,7 @@ describe('pickMessage', () => {
 			],
 		};
 
-		const messagePromise = pickMessage(config);
+		const messagePromise = pickMessage(config, 'Web');
 		jest.advanceTimersByTime(260);
 		const got = await messagePromise;
 
@@ -211,7 +211,7 @@ describe('pickMessage', () => {
 			],
 		};
 
-		const show = await pickMessage(config);
+		const show = await pickMessage(config, 'Web');
 		show();
 
 		expect(renderComponent).toHaveBeenCalledWith(meta);
@@ -244,7 +244,7 @@ describe('pickMessage', () => {
 			],
 		};
 
-		const messagePromise = pickMessage(config);
+		const messagePromise = pickMessage(config, 'Web');
 		jest.advanceTimersByTime(250);
 		const got = await messagePromise;
 
@@ -304,7 +304,7 @@ describe('pickMessage', () => {
 			],
 		};
 
-		const messagePromise = pickMessage(config);
+		const messagePromise = pickMessage(config, 'Web');
 		jest.advanceTimersByTime(150);
 		await messagePromise;
 

--- a/dotcom-rendering/src/lib/messagePicker.ts
+++ b/dotcom-rendering/src/lib/messagePicker.ts
@@ -1,6 +1,6 @@
 import { startPerformanceMeasure } from '@guardian/libs';
 import { getOphan } from '../client/ophan/ophan';
-import { RenderingTarget } from '../types/renderingTarget';
+import type { RenderingTarget } from '../types/renderingTarget';
 
 export type MaybeFC = React.FC | null;
 type ShowMessage<T> = (meta: T) => MaybeFC;

--- a/dotcom-rendering/src/lib/newsletter-sign-up-requests.ts
+++ b/dotcom-rendering/src/lib/newsletter-sign-up-requests.ts
@@ -1,5 +1,6 @@
 import type { OphanAction } from '@guardian/libs';
 import { submitComponentEvent } from '../client/ophan/ophan';
+import { RenderingTarget } from '../types/renderingTarget';
 
 const isServer = typeof window === 'undefined';
 
@@ -129,6 +130,7 @@ const trackingEventDescriptionToOphanAction = (
 export const reportTrackingEvent = (
 	componentName: string,
 	eventDescription: TrackingEventDescription,
+	renderingTarget: RenderingTarget,
 	extraDetails?: Partial<
 		Record<string, string | string[] | number | number[]>
 	>,
@@ -138,12 +140,15 @@ export const reportTrackingEvent = (
 		message: eventDescription,
 		timestamp: Date.now(),
 	};
-	void submitComponentEvent({
-		component: {
-			componentType: 'NEWSLETTER_SUBSCRIPTION',
-			id: componentName,
+	void submitComponentEvent(
+		{
+			component: {
+				componentType: 'NEWSLETTER_SUBSCRIPTION',
+				id: componentName,
+			},
+			action: trackingEventDescriptionToOphanAction(eventDescription),
+			value: JSON.stringify(payload),
 		},
-		action: trackingEventDescriptionToOphanAction(eventDescription),
-		value: JSON.stringify(payload),
-	});
+		renderingTarget,
+	);
 };

--- a/dotcom-rendering/src/lib/newsletter-sign-up-requests.ts
+++ b/dotcom-rendering/src/lib/newsletter-sign-up-requests.ts
@@ -1,6 +1,6 @@
 import type { OphanAction } from '@guardian/libs';
 import { submitComponentEvent } from '../client/ophan/ophan';
-import { RenderingTarget } from '../types/renderingTarget';
+import type { RenderingTarget } from '../types/renderingTarget';
 
 const isServer = typeof window === 'undefined';
 

--- a/dotcom-rendering/src/lib/useBraze.ts
+++ b/dotcom-rendering/src/lib/useBraze.ts
@@ -7,9 +7,9 @@ import {
 	NullBrazeMessages,
 } from '@guardian/braze-components/logic';
 import useSWRImmutable from 'swr/immutable';
+import type { RenderingTarget } from '../types/renderingTarget';
 import { buildBrazeMessaging } from './braze/buildBrazeMessaging';
 import { useAuthStatus } from './useAuthStatus';
-import { RenderingTarget } from '../types/renderingTarget';
 
 /**
  * Returns brazeMessaging as BrazeMessagesInterface and BrazeCardsInterface

--- a/dotcom-rendering/src/lib/useBraze.ts
+++ b/dotcom-rendering/src/lib/useBraze.ts
@@ -9,6 +9,7 @@ import {
 import useSWRImmutable from 'swr/immutable';
 import { buildBrazeMessaging } from './braze/buildBrazeMessaging';
 import { useAuthStatus } from './useAuthStatus';
+import { RenderingTarget } from '../types/renderingTarget';
 
 /**
  * Returns brazeMessaging as BrazeMessagesInterface and BrazeCardsInterface
@@ -21,6 +22,7 @@ import { useAuthStatus } from './useAuthStatus';
  */
 export const useBraze = (
 	idApiUrl: string,
+	renderingTarget: RenderingTarget,
 ): {
 	brazeMessages: BrazeMessagesInterface | undefined;
 	brazeCards: BrazeCardsInterface | undefined;
@@ -32,7 +34,7 @@ export const useBraze = (
 
 	const { data, error } = useSWRImmutable(
 		authStatus.kind !== 'Pending' ? 'braze-message' : null,
-		() => buildBrazeMessaging(idApiUrl, isSignedIn),
+		() => buildBrazeMessaging(idApiUrl, isSignedIn, renderingTarget),
 	);
 
 	if (error) {


### PR DESCRIPTION
Closes #9085 

<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
* After removing `ophan-tracker-js` from Apps bundle in Apps: https://github.com/guardian/dotcom-rendering/pull/9137, this PR:
* Passes `renderingTarget` to `getOphan` and if `renderingTarget` is "Apps" it stubs `window.guardian.ophan`. 
* Uses context in a number of components to get `renderingTarget` and pass it as an argument to various methods that call `getOphan`.
* Wraps components that make a call to `useConfig` to `ConfigProvider` in their unit tests.

## Why?
* We want to make sure DCAR does not send any tracking to Ophan. Tracking is handled natively. 

## Things we're unsure about
A lot of these changes is providing context to eventually pass `renderingTarget` to `getOphan`. An alternative would be to make `renderingTarget` available on the client somehow but this introduces a side-effect. What do people think?

## Testing / Screenshots
Tested in CODE

### Web

`window.guardian.ophan` is still present
![image](https://github.com/guardian/dotcom-rendering/assets/19683595/aaea1cc4-58b5-4555-a576-f6a1a92492fb)


Fronts and web articles still make calls to Ophan
![image](https://github.com/guardian/dotcom-rendering/assets/19683595/9a1751ee-83c5-4433-93bf-85c5ad498138)

![image](https://github.com/guardian/dotcom-rendering/assets/19683595/c20c3d30-eaff-4ec7-8911-4d9ace5d1295)

### Apps

If I visit an article in CODE with `?dcr=apps`
`window.guardian.ophan` is undefined

![image](https://github.com/guardian/dotcom-rendering/assets/19683595/d626618d-362e-49d1-ae6d-109da91a91a3)

No calls to Ophan are made
![image](https://github.com/guardian/dotcom-rendering/assets/19683595/1d4c6c8d-3f74-461e-99b4-935520b6f178)

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
