### PR TITLE
Add DCAR indicator to the apps footer

### DIFF
--- a/dotcom-rendering/src/components/AppsFooter.importable.tsx
+++ b/dotcom-rendering/src/components/AppsFooter.importable.tsx
@@ -87,7 +87,7 @@ export const AppsFooter = () => {
 	return (
 		<div css={footerStyles}>
 			&#169; {year} Guardian News and Media Limited or its affiliated
-			companies. All rights reserved. (modern)
+			companies. All rights reserved. (dcar)
 			<br />
 			<PrivacySettings
 				isCcpa={isCcpa}


### PR DESCRIPTION
So it's easier to tell that the article was rendered by DCAR.

![image](https://github.com/guardian/dotcom-rendering/assets/705427/3d47e28e-0fd6-4134-a4b4-449cb3887213)
