### PR TITLE
Update the footer platform label

### DIFF
--- a/apps-rendering/src/components/FooterContent/index.tsx
+++ b/apps-rendering/src/components/FooterContent/index.tsx
@@ -44,7 +44,7 @@ const FooterContent: FC<Props> = ({ isCcpa }) => {
 	return (
 		<div id="js-footer">
 			&#169; {currentYear} Guardian News and Media Limited or its
-			affiliated companies. All rights reserved. (modern)
+			affiliated companies. All rights reserved. (ar)
 			<br />
 			<PrivacySettings isCcpa={isCcpa} />
 			<a

--- a/dotcom-rendering/README.md
+++ b/dotcom-rendering/README.md
@@ -127,7 +127,7 @@ questionnaire](https://docs.google.com/forms/d/e/1FAIpQLSdwFc05qejwW_Gtl3pyW4N22
 You can force DCR on or off explicitly with
 [`?dcr=true` or `?dcr=false`](https://github.com/guardian/frontend/pull/21753).
 
-One way to verify whether the article you're looking at is being rendered by DCR or not is to look for `(modern)` in the footer after the copyright notice.
+One way to verify whether the article you're looking at is being rendered by DCR or not is to look for `(dcr)` in the footer after the copyright notice.
 
 ## Code Quality
 

--- a/dotcom-rendering/src/components/AppsFooter.importable.tsx
+++ b/dotcom-rendering/src/components/AppsFooter.importable.tsx
@@ -87,7 +87,7 @@ export const AppsFooter = () => {
 	return (
 		<div css={footerStyles}>
 			&#169; {year} Guardian News and Media Limited or its affiliated
-			companies. All rights reserved. (modern)
+			companies. All rights reserved. (dcar)
 			<br />
 			<PrivacySettings
 				isCcpa={isCcpa}

--- a/dotcom-rendering/src/components/FooterLabel.importable.tsx
+++ b/dotcom-rendering/src/components/FooterLabel.importable.tsx
@@ -11,5 +11,5 @@ import { useShouldAdapt } from '../lib/useShouldAdapt';
 export const FooterLabel = () => {
 	const adapted = useShouldAdapt();
 
-	return adapted ? <>(modern, adapted)</> : <>(modern)</>;
+	return adapted ? <>(dcr, adapted)</> : <>(dcr)</>;
 };


### PR DESCRIPTION
If the article is rendered by DCR, display `(dcr)`. If it's rendered by Apps Rendering, display `(ar)`. If it's rendered by DCAR, display `(dcar)`

## Before merging

- [x] Send comms to CP, User Help. Sent in [this email](https://groups.google.com/a/guardian.co.uk/g/dotcom.platform/c/hwhWQMvHikM/m/LRHo8bkpAQAJ)

## Screenshots

| DCR | DCAR | AR |
|--------|--------| -- |
| ![image](https://github.com/guardian/dotcom-rendering/assets/705427/fa4f0730-34f7-43df-b8c8-a1b52fc8842a) | ![image](https://github.com/guardian/dotcom-rendering/assets/705427/6b6776f6-674f-4807-8a27-a9ef0b2e8ddc) | ![image](https://github.com/guardian/dotcom-rendering/assets/705427/50ef9cb1-d465-43b7-a6bb-fb6d92bf9587) | 