### PR TITLE
Message for beta apps user about missing dark mode

### DIFF
--- a/dotcom-rendering/src/components/ArticlePage.tsx
+++ b/dotcom-rendering/src/components/ArticlePage.tsx
@@ -181,7 +181,8 @@ export const ArticlePage = (props: WebProps | AppProps) => {
 					/>
 				</Island>
 			)}
-			{renderingTarget === 'Apps' && <DarkModeMessage />}
+			{renderingTarget === 'Apps' &&
+				!article.config.switches.darkModeInApps && <DarkModeMessage />}
 			{renderingTarget === 'Apps' ? (
 				<DecideLayout
 					article={article}

--- a/dotcom-rendering/src/components/ArticlePage.tsx
+++ b/dotcom-rendering/src/components/ArticlePage.tsx
@@ -11,6 +11,7 @@ import type { DCRArticle } from '../types/frontend';
 import type { RenderingTarget } from '../types/renderingTarget';
 import { AlreadyVisited } from './AlreadyVisited.importable';
 import { BrazeMessaging } from './BrazeMessaging.importable';
+import { DarkModeMessage } from './DarkModeMessage';
 import { FocusStyles } from './FocusStyles.importable';
 import { Island } from './Island';
 import { LightboxHash } from './LightboxHash.importable';
@@ -180,6 +181,7 @@ export const ArticlePage = (props: WebProps | AppProps) => {
 					/>
 				</Island>
 			)}
+			{renderingTarget === 'Apps' && <DarkModeMessage />}
 			{renderingTarget === 'Apps' ? (
 				<DecideLayout
 					article={article}

--- a/dotcom-rendering/src/components/DarkModeMessage.tsx
+++ b/dotcom-rendering/src/components/DarkModeMessage.tsx
@@ -1,22 +1,76 @@
 import { css } from '@emotion/react';
-import { palette, space, textSans } from '@guardian/source-foundations';
+import { from, palette, space, textSans } from '@guardian/source-foundations';
 
 export const DarkModeMessage = () => (
 	<aside
 		css={css`
 			display: none;
 			@media (prefers-color-scheme: dark) {
-				padding: ${space[4]}px;
 				${textSans.medium()}
-				display: block;
 				background-color: ${palette.neutral[7]};
 				color: ${palette.neutral[97]};
+
+				display: grid;
+				grid-template-columns:
+					0px
+					[centre-column-start]
+					repeat(4, 1fr)
+					[centre-column-end]
+					0px;
+				column-gap: 12px;
+
+				${from.mobileLandscape} {
+					column-gap: 20px;
+				}
+
+				${from.tablet} {
+					grid-template-columns:
+						1fr
+						[centre-column-start]
+						repeat(12, 40px)
+						[centre-column-end]
+						1fr;
+				}
+
+				${from.desktop} {
+					grid-template-columns:
+						1fr
+						[centre-column-start]
+						repeat(8, 60px)
+						[centre-column-end]
+						repeat(4, 60px)
+						1fr;
+				}
+
+				${from.leftCol} {
+					grid-template-columns:
+						1fr
+						repeat(2, 60px)
+						[centre-column-start]
+						repeat(8, 60px)
+						[centre-column-end]
+						repeat(4, 60px)
+						1fr;
+				}
+
+				${from.wide} {
+					grid-template-columns:
+						1fr
+						repeat(3, 60px)
+						[centre-column-start]
+						repeat(8, 60px)
+						[centre-column-end]
+						repeat(5, 60px)
+						1fr;
+				}
 			}
 		`}
 	>
 		<p
 			css={css`
 				max-width: 60ch;
+				padding: ${space[4]}px 0;
+				grid-column: centre-column;
 			`}
 		>
 			As part of this beta release, we are currently lacking support for

--- a/dotcom-rendering/src/components/DarkModeMessage.tsx
+++ b/dotcom-rendering/src/components/DarkModeMessage.tsx
@@ -73,10 +73,9 @@ export const DarkModeMessage = () => (
 				grid-column: centre-column;
 			`}
 		>
-			As part of this beta release, we are currently lacking support for
-			“dark mode.” We hope to make it available in the coming weeks. In
-			the meantime, you can use the main app or see articles in “light
-			mode.”
+			As part of this beta release, some articles are currently lacking
+			support for dark mode. We are working to fix this in the next beta
+			release.
 		</p>
 	</aside>
 );

--- a/dotcom-rendering/src/components/DarkModeMessage.tsx
+++ b/dotcom-rendering/src/components/DarkModeMessage.tsx
@@ -1,0 +1,28 @@
+import { css } from '@emotion/react';
+import { palette, space, textSans } from '@guardian/source-foundations';
+
+export const DarkModeMessage = () => (
+	<aside
+		css={css`
+			display: none;
+			@media (prefers-color-scheme: dark) {
+				padding: ${space[4]}px;
+				${textSans.medium()}
+				display: block;
+				background-color: ${palette.neutral[7]};
+				color: ${palette.neutral[97]};
+			}
+		`}
+	>
+		<p
+			css={css`
+				max-width: 60ch;
+			`}
+		>
+			As part of this beta release, we are currently lacking support for
+			“dark mode.” We hope to make it available in the coming weeks. In
+			the meantime, you can use the main app or see articles in “light
+			mode.”
+		</p>
+	</aside>
+);


### PR DESCRIPTION
## What does this change?

Add a message for beta users in dark mode about it being currently missing.

This message will only be show to users that have set their app or device to dark mode, and are also visiting an article rendered by DCAR. 

## Why?

It won’t be available on the beta release. We want to inform users that this is a known issue.

Closes #9245 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |
| ![before w][] | ![after w][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/76776/b8c62512-ef0f-45fb-8b5a-1c3550f67e71
[before w]: https://github.com/guardian/dotcom-rendering/assets/76776/f2d1ae9e-7075-485d-8096-7e77db3197e2
[after]: https://github.com/guardian/dotcom-rendering/assets/76776/323e6ec0-6697-4225-8f59-faae0923061d
[after w]: https://github.com/guardian/dotcom-rendering/assets/76776/f52b336f-b6be-4206-a1b4-1ba8e92d832a

