### PR TITLE
Disable pinch to zoom in DCAR

### DIFF
--- a/dotcom-rendering/src/server/htmlPageTemplate.ts
+++ b/dotcom-rendering/src/server/htmlPageTemplate.ts
@@ -208,7 +208,9 @@ https://workforus.theguardian.com/careers/product-engineering/
 				${
 					renderingTarget === 'Web'
 						? `<meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">`
-						: `<meta name="viewport" content="initial-scale=1, maximum-scale=1, user-scalable=no">`
+						: // We want to disable the pinch-to-zoom in DCAR because
+						  // it interferes with the Android app's article navigation gestures.
+						  `<meta name="viewport" content="initial-scale=1, maximum-scale=1, user-scalable=no">`
 				}
                 ${
 					renderingTarget === 'Web'

--- a/dotcom-rendering/src/server/htmlPageTemplate.ts
+++ b/dotcom-rendering/src/server/htmlPageTemplate.ts
@@ -205,8 +205,11 @@ https://workforus.theguardian.com/careers/product-engineering/
 						: '<!-- no canonical URL -->'
 				}
                 <meta charset="utf-8">
-
-                <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+				${
+					renderingTarget === 'Web'
+						? `<meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">`
+						: `<meta name="viewport" content="initial-scale=1, maximum-scale=1, user-scalable=no">`
+				}
                 ${
 					renderingTarget === 'Web'
 						? `<meta name="theme-color" content="${brandBackground.primary}" />`


### PR DESCRIPTION
It interferes with Android's article navigation gestures. The app also offers a native "scale the article's content" slider.

Fixes https://github.com/guardian/dotcom-rendering/issues/9249.

