### PR TITLE
Prevent Interactive Atoms Accessing Main Page

### DIFF
--- a/dotcom-rendering/src/components/InteractiveAtom.tsx
+++ b/dotcom-rendering/src/components/InteractiveAtom.tsx
@@ -46,6 +46,13 @@ export const InteractiveAtom = ({
 			title={id}
 			srcDoc={unifyPageContent({ elementJs, elementCss, elementHtml })}
 			frameBorder="0"
+			/**
+			 * Do NOT add `allow-same-origin` to this attribute if `allow-scripts` is present.
+			 * This undermines the sandbox when using `srcdoc` (which is used here), because a
+			 * `srcdoc` has the same origin as the embedding page:
+			 * https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#sect6
+			 */
+			sandbox="allow-scripts"
 		/>
 	</div>
 );

--- a/dotcom-rendering/src/lib/unifyPageContent.tsx
+++ b/dotcom-rendering/src/lib/unifyPageContent.tsx
@@ -25,6 +25,9 @@ export const unifyPageContent = ({
 				{!!elementHtml && (
 					<div dangerouslySetInnerHTML={{ __html: elementHtml }} />
 				)}
+				{/* Interactive atoms on standard articles are not meant to access
+				the main page; this is what interactive articles are for. */}
+				<script>window.parent = window;</script>
 			</body>
 			{/* JS need to load on body render */}
 			{!!elementJs && (

--- a/dotcom-rendering/src/lib/unifyPageContent.tsx
+++ b/dotcom-rendering/src/lib/unifyPageContent.tsx
@@ -25,9 +25,6 @@ export const unifyPageContent = ({
 				{!!elementHtml && (
 					<div dangerouslySetInnerHTML={{ __html: elementHtml }} />
 				)}
-				{/* Interactive atoms on standard articles are not meant to access
-				the main page; this is what interactive articles are for. */}
-				<script>window.parent = window;</script>
 			</body>
 			{/* JS need to load on body render */}
 			{!!elementJs && (


### PR DESCRIPTION
## Why?

Interactive atoms on standard articles are not meant to access the main page. This can cause bugs on publication, as standard articles are not set up to support this. In addition, the standard page structure is not guaranteed to be consistent over time, so any code that relies on it may break as that structure inevitably changes.

In scenarios where custom page designs are desired there is another mechanism available: interactive articles.

Paired with @georgeblahblah 

fixes #9268

## Changes

~At the moment interactive atoms are able to access the main page via `window.parent`, which provides access to the parent page's `window` object[^1].~

~This change updates our interactive atom wrapper code, setting `window.parent` to `window` (i.e. the `iframe`'s own `window` object) inside the iframe. This is standard behaviour where a parent is not available: the window's `parent` property becomes a reference to itself[^1]. This is desirable over setting `window.parent` to something like `null` or `undefined`, which could cause crashes in existing code. The `iframe`'s `window` object should have the same API as its parent previously would have done.~

After further discussion we've decided to opt instead for using the `sandbox` attribute[^2], which leverages the browser's built-in sandboxing. For now we've gone with the minimum permission we believe that interactive atoms need, which is the ability to run JavaScript via the `allow-scripts` token.

[^1]: https://developer.mozilla.org/en-US/docs/Web/API/Window/parent
[^2]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#sandbox
