### PR TITLE
Fix broken star ratings on fronts cards

### DIFF
--- a/dotcom-rendering/src/components/StarRating/StarRating.tsx
+++ b/dotcom-rendering/src/components/StarRating/StarRating.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import type { Breakpoint } from '@guardian/source-foundations';
+import { palette } from '@guardian/source-foundations';
 import { Star } from '../../static/icons/Star';
 import type { RatingSizeType } from '../../types/content';
 
@@ -47,7 +48,12 @@ type Props = {
 	fill?: string;
 };
 
-export const StarRating = ({ rating, size, breakpoint, fill }: Props) => (
+export const StarRating = ({
+	rating,
+	size,
+	breakpoint,
+	fill = palette.neutral[7],
+}: Props) => (
 	<div css={determineSize(size)}>
 		<div css={starWrapper}>
 			<Star

--- a/dotcom-rendering/src/static/icons/Star.tsx
+++ b/dotcom-rendering/src/static/icons/Star.tsx
@@ -1,9 +1,9 @@
-import { palette } from '../../palette';
+import { palette } from '@guardian/source-foundations';
 
 export const Star = ({
 	starId,
 	isEmpty,
-	fill = palette('--star-rating-fill'),
+	fill = palette.neutral[7],
 }: {
 	starId: string;
 	isEmpty: boolean;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Reverts the use of the palette in favour of source-foundations palette.

## Why?
This was broken as part of https://github.com/guardian/dotcom-rendering/pull/9218 and is a quick fix

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![image](https://github.com/guardian/dotcom-rendering/assets/26366706/b9ae08e3-faa7-40cc-a81c-fb1ca9ce4a35) | ![image](https://github.com/guardian/dotcom-rendering/assets/26366706/ff7bd3cc-370e-48c9-8b7e-656f21eff39b) |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
