### PR TITLE
Format boundary for palettes 🎨

### DIFF
--- a/dotcom-rendering/src/components/ConfigContext.test.tsx
+++ b/dotcom-rendering/src/components/ConfigContext.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@testing-library/react';
+import type { Config } from '../types/configContext';
 import { ConfigProvider, useConfig } from './ConfigContext';
 
 const testId = 'testId';
@@ -19,10 +20,13 @@ describe('ConfigContext', () => {
 	});
 
 	describe('with ConfigProvider', () => {
-		it.each(['Web', 'Apps'] as const)(
-			'provides correct context through useConfig hook with renderingTarget: "%s"',
-			(renderingTarget) => {
-				const config = { renderingTarget };
+		it.each([
+			{ renderingTarget: 'Web' },
+			{ renderingTarget: 'Apps', darkModeAvailable: true },
+			{ renderingTarget: 'Apps', darkModeAvailable: false },
+		] as const satisfies ReadonlyArray<Config>)(
+			'useConfig hook provides correct config: "%o"',
+			(config) => {
 				const Component = () => {
 					return (
 						<ConfigProvider value={config}>
@@ -34,7 +38,7 @@ describe('ConfigContext', () => {
 
 				expect(getByTestId(testId)).toBeInTheDocument();
 				expect(getByText(/renderingTarget/)).toHaveTextContent(
-					renderingTarget,
+					config.renderingTarget,
 				);
 			},
 		);

--- a/dotcom-rendering/src/components/FormatBoundary.tsx
+++ b/dotcom-rendering/src/components/FormatBoundary.tsx
@@ -13,7 +13,7 @@ type Props = {
  * to that of the :root element
  */
 export const FormatBoundary = ({ format, children }: Props) => {
-	const { darkModeAvailable } = useConfig();
+	const { darkModeAvailable = false } = useConfig();
 
 	return (
 		<div

--- a/dotcom-rendering/src/components/FormatBoundary.tsx
+++ b/dotcom-rendering/src/components/FormatBoundary.tsx
@@ -1,0 +1,37 @@
+import { css } from '@emotion/react';
+import type { ArticleFormat } from '@guardian/libs';
+import { paletteDeclarations } from '../palette';
+import { useConfig } from './ConfigContext';
+
+type Props = {
+	format: ArticleFormat;
+	children: React.ReactNode;
+};
+
+/**
+ * Used to create a set of palette colours for a different format
+ * to that of the :root element
+ */
+export const FormatBoundary = ({ format, children }: Props) => {
+	const { darkModeAvailable } = useConfig();
+
+	return (
+		<div
+			data-format-theme={format.theme}
+			data-format-design={format.design}
+			data-format-display={format.display}
+			css={[
+				css`
+					${css(paletteDeclarations(format, 'light'))}
+					@media (prefers-color-scheme: dark) {
+						${darkModeAvailable
+							? css(paletteDeclarations(format, 'dark'))
+							: '/* dark mode unavailable */'}
+					}
+				`,
+			]}
+		>
+			{children}
+		</div>
+	);
+};

--- a/dotcom-rendering/src/components/FormatBoundary.tsx
+++ b/dotcom-rendering/src/components/FormatBoundary.tsx
@@ -23,12 +23,13 @@ export const FormatBoundary = ({ format, children }: Props) => {
 			css={[
 				css`
 					${css(paletteDeclarations(format, 'light'))}
-					@media (prefers-color-scheme: dark) {
-						${darkModeAvailable
-							? css(paletteDeclarations(format, 'dark'))
-							: '/* dark mode unavailable */'}
-					}
 				`,
+				darkModeAvailable &&
+					css`
+						@media (prefers-color-scheme: dark) {
+							${css(paletteDeclarations(format, 'dark'))}
+						}
+					`,
 			]}
 		>
 			{children}

--- a/dotcom-rendering/src/components/FormatBoundary.tsx
+++ b/dotcom-rendering/src/components/FormatBoundary.tsx
@@ -21,13 +21,11 @@ export const FormatBoundary = ({ format, children }: Props) => {
 			data-format-design={format.design}
 			data-format-display={format.display}
 			css={[
-				css`
-					${css(paletteDeclarations(format, 'light'))}
-				`,
+				paletteDeclarations(format, 'light'),
 				darkModeAvailable &&
 					css`
 						@media (prefers-color-scheme: dark) {
-							${css(paletteDeclarations(format, 'dark'))}
+							${paletteDeclarations(format, 'dark')}
 						}
 					`,
 			]}

--- a/dotcom-rendering/src/server/render.article.apps.tsx
+++ b/dotcom-rendering/src/server/render.article.apps.tsx
@@ -20,9 +20,7 @@ export const renderArticle = (
 	const renderingTarget = 'Apps';
 	const config: Config = {
 		renderingTarget,
-		darkModeAvailable: article.config.switches.darkModeInApps
-			? true
-			: undefined,
+		darkModeAvailable: !!article.config.switches.darkModeInApps,
 	};
 
 	const { html, extractedCss } = renderToStringWithEmotion(

--- a/dotcom-rendering/src/server/render.article.apps.tsx
+++ b/dotcom-rendering/src/server/render.article.apps.tsx
@@ -18,7 +18,12 @@ export const renderArticle = (
 	const format: ArticleFormat = decideFormat(article.format);
 
 	const renderingTarget = 'Apps';
-	const config: Config = { renderingTarget };
+	const config: Config = {
+		renderingTarget,
+		darkModeAvailable: article.config.switches.darkModeInApps
+			? true
+			: undefined,
+	};
 
 	const { html, extractedCss } = renderToStringWithEmotion(
 		<ConfigProvider value={config}>

--- a/dotcom-rendering/src/types/configContext.ts
+++ b/dotcom-rendering/src/types/configContext.ts
@@ -8,4 +8,5 @@ import type { RenderingTarget } from './renderingTarget';
  */
 export interface Config {
 	renderingTarget: RenderingTarget;
+	darkModeAvailable?: true;
 }

--- a/dotcom-rendering/src/types/configContext.ts
+++ b/dotcom-rendering/src/types/configContext.ts
@@ -6,7 +6,12 @@ import type { RenderingTarget } from './renderingTarget';
  * This should not contain any properties which are likely to change between re-renders
  * @see /dotcom-rendering/docs/architecture/proposed-adrs/react-context-api.md
  */
-export interface Config {
-	renderingTarget: RenderingTarget;
-	darkModeAvailable?: true;
-}
+export type Config =
+	| {
+			renderingTarget: Extract<RenderingTarget, 'Web'>;
+			darkModeAvailable?: never;
+	  }
+	| {
+			renderingTarget: Extract<RenderingTarget, 'Apps'>;
+			darkModeAvailable: boolean;
+	  };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Add a new `FormatBoundary` component. It can be used to wrap around children that should receive a different format than the main article, for example:
- Nav
- Rich links
- Onward cards
- Most popular links

This approach may have some scaling issues, as it requires every single CSS custom property to be defined at the format boundary, even if only a subset of them are used. If we have 150 colours in our palette, this could add [about 4.5kB of CSS per format variation](https://docs.google.com/spreadsheets/d/1FWKCKFidfLIpgrX7mGIoUiHEh3brOkcQLjAuU7qRW0Y/edit)

## Why?

Resolves #9112 

We need a pattern to address darkmode, which was partly introduced in #9257 

## Screenshots

<img width="319" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/76776/ecb4813f-cf16-48e5-9bbf-7090f9161f52">