### PR TITLE
Fix `StickyBottomBanner` issues

### DIFF
--- a/dotcom-rendering/src/components/Island.test.tsx
+++ b/dotcom-rendering/src/components/Island.test.tsx
@@ -198,22 +198,24 @@ describe('Island: server-side rendering', () => {
 	test('StickyBottomBanner', () => {
 		expect(() =>
 			renderToString(
-				<StickyBottomBanner
-					contentType=""
-					tags={[]}
-					sectionId=""
-					isPaidContent={false}
-					isPreview={false}
-					shouldHideReaderRevenue={false}
-					isMinuteArticle={false}
-					contributionsServiceUrl=""
-					idApiUrl=""
-					pageId=""
-					keywordIds=""
-					remoteBannerSwitch={true}
-					puzzleBannerSwitch={false}
-					isSensitive={false}
-				/>,
+				<ConfigProvider value={{ renderingTarget: 'Web' }}>
+					<StickyBottomBanner
+						contentType=""
+						tags={[]}
+						sectionId=""
+						isPaidContent={false}
+						isPreview={false}
+						shouldHideReaderRevenue={false}
+						isMinuteArticle={false}
+						contributionsServiceUrl=""
+						idApiUrl=""
+						pageId=""
+						keywordIds=""
+						remoteBannerSwitch={true}
+						puzzleBannerSwitch={false}
+						isSensitive={false}
+					/>
+				</ConfigProvider>,
 			),
 		).not.toThrow();
 	});

--- a/dotcom-rendering/src/components/StickyBottomBanner.importable.tsx
+++ b/dotcom-rendering/src/components/StickyBottomBanner.importable.tsx
@@ -213,7 +213,7 @@ const buildBrazeBanner = (
 
 const useCountryCode = (): CountryCode | undefined => {
 	const [localeCode, setLocaleCode] = useState<CountryCode | null>(null);
-	useOnce(() => {
+	useEffect(() => {
 		getLocaleCode()
 			.then((code) => {
 				setLocaleCode(code);


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

- Use `useEffect` instead of `useOnce` in `useCountryCode`.
- Ensure the server-side rendering test wraps it in a `ConfigProvider`

## Why?

We have tighter rules around `useOnce` since #9176 

## Screenshots

N/A