### PR TITLE
Update copy of dark mode message

### DIFF
--- a/dotcom-rendering/src/components/DarkModeMessage.tsx
+++ b/dotcom-rendering/src/components/DarkModeMessage.tsx
@@ -75,7 +75,7 @@ export const DarkModeMessage = () => (
 		>
 			We hope you are enjoying the updates we are implementing on
 			articles. Unfortunately, some are still missing a dark mode view.
-			But rest assured this will be fixed in a forthcoming beta release.
+			Rest assured this will be fixed in a forthcoming beta release.
 		</p>
 	</aside>
 );

--- a/dotcom-rendering/src/components/DarkModeMessage.tsx
+++ b/dotcom-rendering/src/components/DarkModeMessage.tsx
@@ -73,9 +73,9 @@ export const DarkModeMessage = () => (
 				grid-column: centre-column;
 			`}
 		>
-			As part of this beta release, some articles are currently lacking
-			support for dark mode. We are working to fix this in the next beta
-			release.
+			We hope you are enjoying the updates we are implementing on
+			articles. Unfortunately, some are still missing a dark mode view.
+			But rest assured this will be fixed in a forthcoming beta release.
 		</p>
 	</aside>
 );


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

The copy of dark mode message:

> We hope you are enjoying the updates we are implementing on articles. Unfortunately, some are still missing a dark mode view. But rest assured this will be fixed in a forthcoming beta release.

## Why?

Discussed with @aoifemcl15 and Alex B

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/76776/db55a274-4a63-4166-98fc-84a81bdbfa54
[after]: https://github.com/guardian/dotcom-rendering/assets/76776/19da402f-5a9c-4db4-8cd8-9c301dc96b99