### PR TITLE
Update data-loading-strategy for AMP ads

### DIFF
--- a/dotcom-rendering/src/components/Ad.amp.tsx
+++ b/dotcom-rendering/src/components/Ad.amp.tsx
@@ -111,7 +111,7 @@ export const Ad = ({
 			// corresponding primary size.
 			data-multi-size-validation="false"
 			data-npa-on-unknown-consent={true}
-			data-loading-strategy="prefer-viewability-over-views"
+			data-loading-strategy="0.5"
 			data-enable-refresh="30"
 			layout="fixed"
 			type="doubleclick"


### PR DESCRIPTION
## What does this change?
Update the data-loading-strategy for AMP ads to be 0.5. This means ads will be loaded when the user is 0.5 viewports away from the advert.

## Why?
We're making this change to see if it improves viewability. We'll be monitoring metrics closely for the first few days of the change to make sure there are no unintended negative impacts.
