### PR TITLE
[DRAFT]: Add dark mode support for Byline

### DIFF
--- a/dotcom-rendering/src/components/Byline.stories.tsx
+++ b/dotcom-rendering/src/components/Byline.stories.tsx
@@ -1,0 +1,76 @@
+import {
+	ArticleDesign,
+	ArticleDisplay,
+	ArticleSpecial,
+	Pillar,
+} from '@guardian/libs';
+import type { Meta } from '@storybook/react';
+import { splitTheme } from '../../.storybook/decorators/splitThemeDecorator';
+import { Byline } from './Byline';
+
+const meta: Meta<typeof Byline> = {
+	component: Byline,
+	title: 'Components/Byline',
+};
+export default meta;
+
+const bylineName = 'CP Scott';
+
+const StoryForFormat = (format: ArticleFormat) => {
+	return (
+		<>
+			<Byline text={bylineName} format={format} size="ginormous" />
+			<br />
+			<Byline text={bylineName} format={format} size="huge" />
+			<br />
+			<Byline text={bylineName} format={format} size="large" />
+			<br />
+			<Byline text={bylineName} format={format} size="medium" />
+			<br />
+			<Byline text={bylineName} format={format} size="small" />
+			<br />
+			<Byline text={bylineName} format={format} size="tiny" />
+		</>
+	);
+};
+
+const makeStory = (format: ArticleFormat) => ({
+	render: () => StoryForFormat(format),
+	decorators: [splitTheme(format)],
+});
+
+export const NewsThemeStandardDisplayLiveBlogDesign = makeStory({
+	display: ArticleDisplay.Standard,
+	design: ArticleDesign.LiveBlog,
+	theme: Pillar.News,
+});
+
+export const OpinionThemeNumberedListDisplayCommentDesign = makeStory({
+	display: ArticleDisplay.NumberedList,
+	design: ArticleDesign.Comment,
+	theme: Pillar.Opinion,
+});
+
+export const SportThemeStandardDisplayMatchReportDesign = makeStory({
+	display: ArticleDisplay.Standard,
+	design: ArticleDesign.MatchReport,
+	theme: Pillar.Sport,
+});
+
+export const CultureThemeStandardDisplayPhotoEssayDesign = makeStory({
+	display: ArticleDisplay.Standard,
+	design: ArticleDesign.PhotoEssay,
+	theme: Pillar.Culture,
+});
+
+export const LifestyleThemeShowcaseDisplayStandardDesign = makeStory({
+	display: ArticleDisplay.Showcase,
+	design: ArticleDesign.Standard,
+	theme: Pillar.Lifestyle,
+});
+
+export const LabsThemeStandardDisplayStandardDesign = makeStory({
+	display: ArticleDisplay.Standard,
+	design: ArticleDesign.Standard,
+	theme: ArticleSpecial.Labs,
+});

--- a/dotcom-rendering/src/components/Byline.tsx
+++ b/dotcom-rendering/src/components/Byline.tsx
@@ -1,14 +1,10 @@
 import { css } from '@emotion/react';
 import { ArticleSpecial } from '@guardian/libs';
 import { headline, textSans, until } from '@guardian/source-foundations';
-import { decidePalette } from '../lib/decidePalette';
-import type { DCRContainerPalette } from '../types/front';
-import type { Palette } from '../types/palette';
 
 type Props = {
 	text: string;
 	format: ArticleFormat;
-	containerPalette?: DCRContainerPalette;
 	size: SmallHeadlineSize;
 	isCard?: boolean;
 };
@@ -100,22 +96,15 @@ const bylineStyles = (size: SmallHeadlineSize, format: ArticleFormat) => {
 	}
 };
 
-const colourStyles = (palette: Palette, isCard: Props['isCard']) => {
+const colourStyles = (isCard: Props['isCard']) => {
 	return css`
-		color: ${isCard ? palette.text.cardByline : palette.text.byline};
+		color: ${isCard ? 'var(--byline-card-colour)' : 'var(--byline-colour)'};
 	`;
 };
 
-export const Byline = ({
-	text,
-	format,
-	containerPalette,
-	size,
-	isCard,
-}: Props) => {
-	const palette = decidePalette(format, containerPalette);
+export const Byline = ({ text, format, size, isCard }: Props) => {
 	return (
-		<span css={[bylineStyles(size, format), colourStyles(palette, isCard)]}>
+		<span css={[bylineStyles(size, format), colourStyles(isCard)]}>
 			{text}
 		</span>
 	);

--- a/dotcom-rendering/src/components/Byline.tsx
+++ b/dotcom-rendering/src/components/Byline.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react';
 import { ArticleSpecial } from '@guardian/libs';
 import { headline, textSans, until } from '@guardian/source-foundations';
+import { palette } from '../palette';
 
 type Props = {
 	text: string;
@@ -98,7 +99,9 @@ const bylineStyles = (size: SmallHeadlineSize, format: ArticleFormat) => {
 
 const colourStyles = (isCard: Props['isCard']) => {
 	return css`
-		color: ${isCard ? 'var(--byline-card-colour)' : 'var(--byline-colour)'};
+		color: ${isCard
+			? palette('--byline-card-colour')
+			: palette('--byline-colour')};
 	`;
 };
 

--- a/dotcom-rendering/src/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/components/CardHeadline.tsx
@@ -310,7 +310,6 @@ export const CardHeadline = ({
 				<Byline
 					text={byline}
 					format={format}
-					containerPalette={containerPalette}
 					size={size}
 					isCard={true}
 				/>

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -47,6 +47,25 @@ const getPillarColour =
 		}
 	};
 
+/** Used in Live Blogs and Dead Blogs */
+const blogsGrayBackgroundPalette = (theme: ArticleTheme): string => {
+	switch (theme) {
+		case Pillar.News:
+			return sourcePalette.news[400];
+		case Pillar.Opinion:
+		case Pillar.Sport:
+		case Pillar.Culture:
+		case Pillar.Lifestyle:
+			return getPillarColour(300)(theme);
+		case ArticleSpecial.SpecialReport:
+			return sourcePalette.specialReport[300];
+		case ArticleSpecial.SpecialReportAlt:
+			return sourcePalette.news[400];
+		case ArticleSpecial.Labs:
+			return sourcePalette.labs[300];
+	}
+};
+
 // ----- Palette Functions ----- //
 
 const headlineColourLight = ({ design }: ArticleFormat): string => {
@@ -92,76 +111,69 @@ const starRatingBackgroundColourLight = (): string =>
 const starRatingBackgroundColourDark = (): string =>
 	sourcePalette.brandAlt[200];
 
-const blogsGrayBackgroundPalette = (theme: ArticleTheme): string => {
-	switch (theme) {
-		case Pillar.News:
-			return sourcePalette.news[400];
-		case Pillar.Opinion:
-		case Pillar.Sport:
-		case Pillar.Culture:
-		case Pillar.Lifestyle:
-			return getPillarColour(300)(theme);
-		case ArticleSpecial.SpecialReport:
-			return sourcePalette.specialReport[300];
-		case ArticleSpecial.SpecialReportAlt:
-			return sourcePalette.news[400];
-		case ArticleSpecial.Labs:
-			return sourcePalette.labs[300];
-	}
-};
+const bylineTextLight = ({ theme, design, display }: ArticleFormat): string => {
+	switch (design) {
+		case ArticleDesign.LiveBlog:
+		case ArticleDesign.DeadBlog:
+			return blogsGrayBackgroundPalette(theme);
 
-const bylineTextLight = (format: ArticleFormat): string => {
-	if (
-		format.design === ArticleDesign.LiveBlog ||
-		format.design === ArticleDesign.DeadBlog
-	)
-		return blogsGrayBackgroundPalette(format.theme);
-
-	if (format.theme === ArticleSpecial.Labs) return BLACK;
-
-	if (format.theme === ArticleSpecial.SpecialReport)
-		return sourcePalette.specialReport[300];
-
-	if (format.theme === ArticleSpecial.SpecialReportAlt)
-		return sourcePalette.specialReportAlt[100];
-
-	switch (format.display) {
-		case ArticleDisplay.Immersive:
-			return WHITE;
-		case ArticleDisplay.Showcase:
-		case ArticleDisplay.NumberedList:
-		case ArticleDisplay.Standard:
-			switch (format.design) {
-				case ArticleDesign.Analysis: {
-					switch (format.theme) {
-						case Pillar.News:
-							return sourcePalette.news[300];
-						default:
-							return getPillarColour('main')(format.theme);
-					}
-				}
-				case ArticleDesign.Gallery: {
-					switch (format.theme) {
-						case Pillar.Culture:
-							return getPillarColour('bright')(format.theme);
-						default:
-							return getPillarColour('main')(format.theme);
-					}
-				}
-				case ArticleDesign.Interview:
-					return BLACK;
-				case ArticleDesign.Picture:
-					return sourcePalette.neutral[86];
-				default:
-					return getPillarColour('main')(format.theme);
-			}
 		default:
-			return getPillarColour('main')(format.theme);
+			switch (theme) {
+				case ArticleSpecial.Labs:
+					return BLACK;
+				case ArticleSpecial.SpecialReport:
+					return sourcePalette.specialReport[300];
+				case ArticleSpecial.SpecialReportAlt:
+					return sourcePalette.specialReportAlt[100];
+
+				default:
+					switch (display) {
+						case ArticleDisplay.Immersive:
+							return WHITE;
+						case ArticleDisplay.Showcase:
+						case ArticleDisplay.NumberedList:
+						case ArticleDisplay.Standard:
+							switch (design) {
+								case ArticleDesign.Analysis: {
+									switch (theme) {
+										case Pillar.News:
+											return sourcePalette.news[300];
+										default:
+											return getPillarColour('main')(
+												theme,
+											);
+									}
+								}
+								case ArticleDesign.Gallery: {
+									switch (theme) {
+										case Pillar.Culture:
+											return getPillarColour('bright')(
+												theme,
+											);
+										default:
+											return getPillarColour('main')(
+												theme,
+											);
+									}
+								}
+								case ArticleDesign.Interview:
+									return BLACK;
+								case ArticleDesign.Picture:
+									return sourcePalette.neutral[86];
+								default:
+									return getPillarColour('main')(theme);
+							}
+						default:
+							return getPillarColour('main')(theme);
+					}
+			}
 	}
 };
 
 const bylineTextDark = (format: ArticleFormat): string => {
-	if (format.theme === ArticleSpecial.Labs) return sourcePalette.labs[400];
+	if (format.theme === ArticleSpecial.Labs) {
+		return sourcePalette.labs[400];
+	}
 
 	switch (format.design) {
 		case ArticleDesign.LiveBlog:
@@ -172,8 +184,13 @@ const bylineTextDark = (format: ArticleFormat): string => {
 	}
 };
 
-// const bylineCardTextLight = (format: ArticleFormat): string => {};
-// const bylineCardTextDark = (format: ArticleFormat): string => {};
+// TODO
+const bylineCardTextLight = (format: ArticleFormat): string => {
+	return BLACK;
+};
+const bylineCardTextDark = (format: ArticleFormat): string => {
+	return BLACK;
+};
 
 // ----- Palette ----- //
 

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -1,7 +1,51 @@
 // ----- Imports ----- //
 
-import { ArticleDesign, type ArticleFormat } from '@guardian/libs';
+import {
+	ArticleDesign,
+	ArticleDisplay,
+	type ArticleFormat,
+	ArticleSpecial,
+	Pillar,
+} from '@guardian/libs';
 import { palette as sourcePalette } from '@guardian/source-foundations';
+
+// ----- Constants and helpers ----- //
+
+const WHITE = sourcePalette.neutral[100];
+const BLACK = sourcePalette.neutral[7];
+
+const colourMapping = {
+	dark: 300,
+	main: 400,
+	bright: 500,
+	pastel: 600,
+	faded: 800,
+} as const;
+
+type ColourMapping = typeof colourMapping;
+type ColourVariation = keyof ColourMapping | ColourMapping[keyof ColourMapping];
+
+/** Curried function to fetch pillar colours */
+const getPillarColour =
+	(colour: ColourVariation) =>
+	(theme: ArticleTheme): string => {
+		const c = typeof colour === 'string' ? colourMapping[colour] : colour;
+
+		switch (theme) {
+			case Pillar.News:
+				return sourcePalette.news[c];
+			case Pillar.Opinion:
+				return sourcePalette.opinion[c];
+			case Pillar.Sport:
+				return sourcePalette.sport[c];
+			case Pillar.Culture:
+				return sourcePalette.culture[c];
+			case Pillar.Lifestyle:
+				return sourcePalette.lifestyle[c];
+			default:
+				return sourcePalette.news[c];
+		}
+	};
 
 // ----- Palette Functions ----- //
 
@@ -47,6 +91,89 @@ const starRatingBackgroundColourLight = (): string =>
 	sourcePalette.brandAlt[400];
 const starRatingBackgroundColourDark = (): string =>
 	sourcePalette.brandAlt[200];
+
+const blogsGrayBackgroundPalette = (theme: ArticleTheme): string => {
+	switch (theme) {
+		case Pillar.News:
+			return sourcePalette.news[400];
+		case Pillar.Opinion:
+		case Pillar.Sport:
+		case Pillar.Culture:
+		case Pillar.Lifestyle:
+			return getPillarColour(300)(theme);
+		case ArticleSpecial.SpecialReport:
+			return sourcePalette.specialReport[300];
+		case ArticleSpecial.SpecialReportAlt:
+			return sourcePalette.news[400];
+		case ArticleSpecial.Labs:
+			return sourcePalette.labs[300];
+	}
+};
+
+const bylineTextLight = (format: ArticleFormat): string => {
+	if (
+		format.design === ArticleDesign.LiveBlog ||
+		format.design === ArticleDesign.DeadBlog
+	)
+		return blogsGrayBackgroundPalette(format.theme);
+
+	if (format.theme === ArticleSpecial.Labs) return BLACK;
+
+	if (format.theme === ArticleSpecial.SpecialReport)
+		return sourcePalette.specialReport[300];
+
+	if (format.theme === ArticleSpecial.SpecialReportAlt)
+		return sourcePalette.specialReportAlt[100];
+
+	switch (format.display) {
+		case ArticleDisplay.Immersive:
+			return WHITE;
+		case ArticleDisplay.Showcase:
+		case ArticleDisplay.NumberedList:
+		case ArticleDisplay.Standard:
+			switch (format.design) {
+				case ArticleDesign.Analysis: {
+					switch (format.theme) {
+						case Pillar.News:
+							return sourcePalette.news[300];
+						default:
+							return getPillarColour('main')(format.theme);
+					}
+				}
+				case ArticleDesign.Gallery: {
+					switch (format.theme) {
+						case Pillar.Culture:
+							return getPillarColour('bright')(format.theme);
+						default:
+							return getPillarColour('main')(format.theme);
+					}
+				}
+				case ArticleDesign.Interview:
+					return BLACK;
+				case ArticleDesign.Picture:
+					return sourcePalette.neutral[86];
+				default:
+					return getPillarColour('main')(format.theme);
+			}
+		default:
+			return getPillarColour('main')(format.theme);
+	}
+};
+
+const bylineTextDark = (format: ArticleFormat): string => {
+	if (format.theme === ArticleSpecial.Labs) return sourcePalette.labs[400];
+
+	switch (format.design) {
+		case ArticleDesign.LiveBlog:
+			return sourcePalette.neutral[93];
+		case ArticleDesign.DeadBlog:
+		default:
+			return sourcePalette.neutral[86];
+	}
+};
+
+// const bylineCardTextLight = (format: ArticleFormat): string => {};
+// const bylineCardTextDark = (format: ArticleFormat): string => {};
 
 // ----- Palette ----- //
 
@@ -96,6 +223,14 @@ const paletteColours = {
 	'--star-rating-background': {
 		light: starRatingBackgroundColourLight,
 		dark: starRatingBackgroundColourDark,
+	},
+	'--byline-colour': {
+		light: bylineTextLight,
+		dark: bylineTextDark,
+	},
+	'--byline-card-colour': {
+		light: bylineCardTextLight,
+		dark: bylineCardTextDark,
 	},
 } satisfies PaletteColours;
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Currently only adapts the `Byline` component and not the `HeadlineByline` component.

Adds a story for Byline variations in a few different formats, with the split screen decorator

## Why?

Resolves #9260 as part of #9110 to add dark mode support to DCAR.

## Screenshots

**TODO**

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
