### PR TITLE
Increase image sizes for Picture content type (Cartoons)

### DIFF
--- a/dotcom-rendering/src/components/Picture.tsx
+++ b/dotcom-rendering/src/components/Picture.tsx
@@ -79,6 +79,19 @@ const decideImageWidths = ({
 				];
 		}
 	}
+	if (format.design === ArticleDesign.Picture) {
+		// the order is important here. Picture content type images come through as main media, so needs to appear
+		// above `isMainMedia`, so the images do not appear low quality.
+		return [
+			{ breakpoint: breakpoints.mobile, width: 480 },
+			{ breakpoint: breakpoints.mobileLandscape, width: 660 },
+			{ breakpoint: breakpoints.phablet, width: 740 },
+			{ breakpoint: breakpoints.tablet, width: 980 },
+			{ breakpoint: breakpoints.desktop, width: 1140 },
+			{ breakpoint: breakpoints.leftCol, width: 1300 },
+			{ breakpoint: breakpoints.wide, width: 1900 },
+		];
+	}
 	if (isMainMedia) {
 		switch (format.display) {
 			case ArticleDisplay.Immersive: {


### PR DESCRIPTION
## What does this change?
This creates a new case in the `decideImageWidths` function for the Picture content type, with larger images than standard main media.

## Why?
The Picture content type was previously rendered in frontend, but we now render Pictures with Cartoon elements in DCR. As part of that migration, we did not migrate across the image widths for this content type (https://github.com/guardian/frontend/blob/5cd5c17049e47fd0e425155e88296f0e8c8ffd40/common/app/layout/ContentWidths.scala#L184), so it is applying the article defaults which are too small. The result is cartoon images look blurred on lower resolution screens.

In the DCR-rendered Picture, the image width is a little larger than what was originally in frontend, so we have opted with the same breakpoints as would be applied if the image had the role `immersive`.

NB: on the tooling side, we shall be removing the 'role' field, as it will not be respected in the rendering platform. 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/33927854/eeb82aeb-369f-49de-ac6f-c9a00b0c265b
[after]: https://github.com/guardian/dotcom-rendering/assets/33927854/62d974f0-eb5e-4d0c-a138-7e67838d993f

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
