### PR TITLE
Make `Metrics` Island server safe

### DIFF
--- a/dotcom-rendering/src/components/AllEditorialNewslettersPage.tsx
+++ b/dotcom-rendering/src/components/AllEditorialNewslettersPage.tsx
@@ -64,6 +64,7 @@ export const AllEditorialNewslettersPage = ({
 					commercialMetricsEnabled={
 						!!newslettersPage.config.switches.commercialMetrics
 					}
+					tests={newslettersPage.config.abTests}
 				/>
 			</Island>
 			<AllEditorialNewslettersPageLayout

--- a/dotcom-rendering/src/components/ArticlePage.tsx
+++ b/dotcom-rendering/src/components/ArticlePage.tsx
@@ -136,6 +136,7 @@ export const ArticlePage = (props: WebProps | AppProps) => {
 							commercialMetricsEnabled={
 								!!article.config.switches.commercialMetrics
 							}
+							tests={article.config.abTests}
 						/>
 					</Island>
 					<Island

--- a/dotcom-rendering/src/components/FrontPage.tsx
+++ b/dotcom-rendering/src/components/FrontPage.tsx
@@ -76,6 +76,7 @@ export const FrontPage = ({ front, NAV }: Props) => {
 					commercialMetricsEnabled={
 						!!front.config.switches.commercialMetrics
 					}
+					tests={front.config.abTests}
 				/>
 			</Island>
 			<Island

--- a/dotcom-rendering/src/components/Island.test.tsx
+++ b/dotcom-rendering/src/components/Island.test.tsx
@@ -11,6 +11,7 @@ import { InteractiveSupportButton } from './InteractiveSupportButton.importable'
 import { Island } from './Island';
 import { LiveBlogEpic } from './LiveBlogEpic.importable';
 import { Liveness } from './Liveness.importable';
+import { Metrics } from './Metrics.importable';
 import { OnwardsUpper } from './OnwardsUpper.importable';
 import { SetABTests } from './SetABTests.importable';
 import { Snow } from './Snow.importable';
@@ -179,6 +180,16 @@ describe('Island: server-side rendering', () => {
 					pageId={''}
 					keywordIds={''}
 				/>,
+			),
+		).not.toThrow();
+	});
+
+	test('Metrics', () => {
+		expect(() =>
+			renderToString(
+				<ConfigProvider value={{ renderingTarget: 'Web' }}>
+					<Metrics commercialMetricsEnabled={true} tests={{}} />
+				</ConfigProvider>,
 			),
 		).not.toThrow();
 	});

--- a/dotcom-rendering/src/components/Metrics.importable.tsx
+++ b/dotcom-rendering/src/components/Metrics.importable.tsx
@@ -7,16 +7,21 @@ import {
 	bypassCoreWebVitalsSampling,
 	initCoreWebVitals,
 } from '@guardian/core-web-vitals';
-import { getCookie } from '@guardian/libs';
+import { getCookie, isUndefined } from '@guardian/libs';
+import { useCallback, useEffect, useState } from 'react';
+import { getOphan } from '../client/ophan/ophan';
 import { billboardsInMerchHigh } from '../experiments/tests/billboards-in-merch-high';
 import { eagerPrebid } from '../experiments/tests/eager-prebid';
 import { integrateIma } from '../experiments/tests/integrate-ima';
 import { useAB } from '../lib/useAB';
 import { useAdBlockInUse } from '../lib/useAdBlockInUse';
-import { useOnce } from '../lib/useOnce';
+import type { ServerSideTests } from '../types/config';
+import type { RenderingTarget } from '../types/renderingTarget';
+import { useConfig } from './ConfigContext';
 
 type Props = {
 	commercialMetricsEnabled: boolean;
+	tests: ServerSideTests;
 };
 
 const sampling = 1 / 100;
@@ -31,33 +36,78 @@ const clientSideTestsToForceMetrics: ABTest[] = [
 	eagerPrebid,
 ];
 
-export const Metrics = ({ commercialMetricsEnabled }: Props) => {
+const useBrowserId = () => {
+	const [browserId, setBrowserId] = useState<string>();
+
+	useEffect(() => {
+		const cookie = getCookie({ name: 'bwid', shouldMemoize: true });
+
+		if (cookie) setBrowserId(cookie);
+	}, []);
+
+	return browserId;
+};
+
+const usePageViewId = (renderingTarget: RenderingTarget) => {
+	const [id, setId] = useState<string>();
+
+	useEffect(() => {
+		getOphan(renderingTarget)
+			.then(({ pageViewId }) => {
+				setId(pageViewId);
+			})
+			.catch(() => {
+				/* do nothing */
+			});
+	}, [renderingTarget]);
+
+	return id;
+};
+
+const useDev = () => {
+	const [isDev, setIsDev] = useState<boolean>();
+
+	useEffect(() => {
+		setIsDev(
+			!!window.guardian.config.page.isDev ||
+				window.location.hostname === 'm.code.dev-theguardian.com' ||
+				window.location.hostname ===
+					(process.env.HOSTNAME ?? 'localhost') ||
+				window.location.hostname === 'preview.gutools.co.uk',
+		);
+	}, []);
+
+	return isDev;
+};
+
+export const Metrics = ({ commercialMetricsEnabled, tests }: Props) => {
 	const abTestApi = useAB()?.api;
 	const adBlockerInUse = useAdBlockInUse();
 
-	const browserId = getCookie({ name: 'bwid', shouldMemoize: true });
-	const { pageViewId } = window.guardian.config.ophan;
+	const { renderingTarget } = useConfig();
+	const browserId = useBrowserId();
+	const pageViewId = usePageViewId(renderingTarget);
 
-	const isDev =
-		!!window.guardian.config.page.isDev ||
-		window.location.hostname === 'm.code.dev-theguardian.com' ||
-		window.location.hostname === (process.env.HOSTNAME ?? 'localhost') ||
-		window.location.hostname === 'preview.gutools.co.uk';
+	const isDev = useDev();
 
-	const userInServerSideTest =
-		Object.keys(window.guardian.config.tests).length > 0;
+	const userInServerSideTest = Object.keys(tests).length > 0;
 
-	const shouldBypassSampling = (api: ABTestAPI) =>
-		willRecordCoreWebVitals ||
-		userInServerSideTest ||
-		clientSideTestsToForceMetrics.some((test) => api.runnableTest(test));
+	const shouldBypassSampling = useCallback(
+		(api: ABTestAPI) =>
+			willRecordCoreWebVitals ||
+			userInServerSideTest ||
+			clientSideTestsToForceMetrics.some((test) =>
+				api.runnableTest(test),
+			),
+		[userInServerSideTest],
+	);
 
-	useOnce(
+	useEffect(
 		function coreWebVitals() {
-			// abTestApi should be defined inside useOnce
-			const bypassSampling = abTestApi
-				? shouldBypassSampling(abTestApi)
-				: false;
+			if (isUndefined(abTestApi)) return;
+			if (isUndefined(isDev)) return;
+
+			const bypassSampling = shouldBypassSampling(abTestApi);
 
 			/**
 			 * We rely on `bypassSampling` rather than the built-in sampling,
@@ -76,18 +126,19 @@ export const Metrics = ({ commercialMetricsEnabled }: Props) => {
 			if (bypassSampling || isDev)
 				void bypassCoreWebVitalsSampling('commercial');
 		},
-		[abTestApi],
+		[abTestApi, browserId, isDev, pageViewId, shouldBypassSampling],
 	);
 
-	useOnce(
+	useEffect(
 		function commercialMetrics() {
 			// Only send metrics if the switch is enabled
 			if (!commercialMetricsEnabled) return;
 
-			// abTestApi should be defined inside useOnce
-			const bypassSampling = abTestApi
-				? shouldBypassSampling(abTestApi)
-				: false;
+			if (isUndefined(pageViewId)) return;
+			if (isUndefined(abTestApi)) return;
+			if (isUndefined(isDev)) return;
+
+			const bypassSampling = shouldBypassSampling(abTestApi);
 
 			initCommercialMetrics({
 				pageViewId,
@@ -106,7 +157,15 @@ export const Metrics = ({ commercialMetricsEnabled }: Props) => {
 					),
 				);
 		},
-		[abTestApi, adBlockerInUse, commercialMetricsEnabled],
+		[
+			abTestApi,
+			adBlockerInUse,
+			browserId,
+			commercialMetricsEnabled,
+			isDev,
+			pageViewId,
+			shouldBypassSampling,
+		],
 	);
 
 	// We don’t render anything

--- a/dotcom-rendering/src/components/TagFrontPage.tsx
+++ b/dotcom-rendering/src/components/TagFrontPage.tsx
@@ -73,6 +73,7 @@ export const TagFrontPage = ({ tagFront, NAV }: Props) => {
 					commercialMetricsEnabled={
 						!!tagFront.config.switches.commercialMetrics
 					}
+					tests={tagFront.config.abTests}
 				/>
 			</Island>
 			<Island priority="critical" clientOnly={true}>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

- cookies are now read in `useEffect`
- reduce the usage of `useOnce` aligned with changes from #9176 
- `tests` is now a property receiving server-side tests

## Why?

No assumption should be made about where components are run

- Split out from #8991 for easier review
- Enables the work from #8948 to proceed safely.

## Screenshots

N/A