### PR TITLE
Allow GIFs in `ImageComponent`

### DIFF
--- a/dotcom-rendering/src/components/ImageComponent.tsx
+++ b/dotcom-rendering/src/components/ImageComponent.tsx
@@ -225,7 +225,7 @@ const CaptionToggle = () => (
 );
 
 const isSupported = (imageUrl: string): boolean => {
-	const supportedImages = ['jpg', 'jpeg', 'png'];
+	const supportedImages = ['jpg', 'jpeg', 'png', 'gif'];
 	return supportedImages.some((extension) =>
 		imageUrl.endsWith(`.${extension}`),
 	);


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Add `.gif` to the list of supported extensions.

## Why?

These can be sent by the platforms, and they pass through the Fastly Image Optimiser as-is.

**Note to GIFs producer:** be kind and compress ’em!

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/76776/2208a7c0-db7d-437a-8d3c-9bb521505a7e
[after]: https://github.com/guardian/dotcom-rendering/assets/76776/d0ec37c9-048f-402a-9b9a-93104b3a09e1
