### PR TITLE
Use a strict boolean for dark mode available in Config

### DIFF
--- a/dotcom-rendering/.storybook/decorators/configContextDecorator.tsx
+++ b/dotcom-rendering/.storybook/decorators/configContextDecorator.tsx
@@ -2,7 +2,7 @@ import { ConfigProvider } from '../../src/components/ConfigContext';
 import type { Decorator } from '@storybook/react';
 import { Config } from '../../src/types/configContext';
 
-const defaultConfig = { renderingTarget: 'Web' } satisfies Config;
+const defaultConfig = { renderingTarget: 'Web', darkModeAvailable: false } satisfies Config;
 
 export const ConfigContextDecorator: Decorator<{
 	config: Config;

--- a/dotcom-rendering/.storybook/preview.ts
+++ b/dotcom-rendering/.storybook/preview.ts
@@ -153,7 +153,7 @@ const defaultFormat = {
 
 export default {
 	args: {
-		config: { renderingTarget: 'Web' },
+		config: { renderingTarget: 'Web', darkModeAvailable: false },
 	},
 	decorators: [
 		// @ts-expect-error -- this global decorator takes an option parameter

--- a/dotcom-rendering/scripts/gen-stories/get-stories.mjs
+++ b/dotcom-rendering/scripts/gen-stories/get-stories.mjs
@@ -1,16 +1,15 @@
-/* eslint-disable @typescript-eslint/restrict-plus-operands -- We don't have types here */
-/* eslint-disable @typescript-eslint/no-unsafe-assignment -- We don't have types here */
-/* eslint-disable @typescript-eslint/restrict-template-expressions -- We don't have types here */
-/*
+// @ts-check
 
-Use: node dotcom-rendering/scripts/gen-stories/gen-stories.js
-
-This script was created as a replacement for storiesOf to generate all of the possible variants
-of our Card and Layout components.
-
-It should be run whenever any of the Display, Design, or Theme `format` properties change
-
-*/
+/** @fileoverview
+ *
+ * Use: node dotcom-rendering/scripts/gen-stories/gen-stories.js
+ *
+ * This script was created as a replacement for storiesOf to generate all of the possible variants
+ * of our Card and Layout components.
+ *
+ * It should be run whenever any of the Display, Design, or Theme `format` properties change
+ *
+ */
 
 import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
@@ -26,6 +25,7 @@ const STORIES_PATH = resolve(
 );
 const LAYOUT_STORIES_FILE = resolve(STORIES_PATH, 'Layout.stories.tsx');
 const CARD_STORIES_FILE = resolve(STORIES_PATH, 'Card.stories.tsx');
+/** @param {string} componentName */
 const README_FILE = (componentName) =>
 	resolve(STORIES_PATH, `${componentName}Readme.stories.jsx`);
 
@@ -72,6 +72,7 @@ export default {
 };
 `;
 
+/** @param {string} componentName */
 const README_TEMPLATE = (componentName) => `
 import { css } from '@emotion/react';
 
@@ -102,12 +103,16 @@ export default {
 export const Readme = () => <ReadMe />;
 `;
 
-const generateLayoutStory = (
-	displayName,
-	designName,
-	theme,
-	renderingTarget,
-) => {
+/**
+ * @param {string} displayName
+ * @param {string} designName
+ * @param {string} theme
+ * @param {import('../../src/types/configContext.js').Config} config
+ *
+ */
+const generateLayoutStory = (displayName, designName, theme, config) => {
+	const { renderingTarget } = config;
+
 	const storyVariableName =
 		renderingTarget + displayName + designName + theme;
 
@@ -123,7 +128,7 @@ export const ${storyVariableName} = () => {
 	);
 };
 ${storyVariableName}.storyName = '${renderingTarget}: Display: ${displayName}, Design: ${designName}, Theme: ${theme}';
-${storyVariableName}.args = { config: { renderingTarget: '${renderingTarget}' } };
+${storyVariableName}.args = { config: ${JSON.stringify(config)} };
 ${storyVariableName}.decorators = [lightDecorator({
 	display: ArticleDisplay.${displayName},
 	design: ArticleDesign.${designName},
@@ -132,6 +137,10 @@ ${storyVariableName}.decorators = [lightDecorator({
 `;
 };
 
+/**
+ * @param {string} displayName
+ * @param {string} designName
+ */
 const generateCardStory = (displayName, designName) => {
 	const storyName = displayName + designName;
 
@@ -149,75 +158,68 @@ ${storyName}.storyName = '${displayName}Display ${designName}Design';
 `;
 };
 
-const testLayoutFormats = [
-	{
-		display: 'Standard',
-		design: 'Standard',
-		theme: 'NewsPillar',
-		renderingTarget: 'Web',
-	},
-	{
-		display: 'Standard',
-		design: 'Standard',
-		theme: 'NewsPillar',
-		renderingTarget: 'Apps',
-	},
-	{
-		display: 'Showcase',
-		design: 'Standard',
-		theme: 'NewsPillar',
-		renderingTarget: 'Apps',
-	},
-	{
-		display: 'Showcase',
-		design: 'Picture',
-		theme: 'OpinionPillar',
-		renderingTarget: 'Web',
-	},
-	{
-		display: 'Showcase',
-		design: 'Picture',
-		theme: 'OpinionPillar',
-		renderingTarget: 'Apps',
-	},
-	{
-		display: 'Standard',
-		design: 'Comment',
-		theme: 'NewsPillar',
-		renderingTarget: 'Apps',
-	},
-	{
-		display: 'Standard',
-		design: 'Interactive',
-		theme: 'NewsPillar',
-		renderingTarget: 'Apps',
-	},
+/** @typedef {{display: string, design: string, theme: string, config: import('../../src/types/configContext.js').Config}} TestFormat */
 
-	{
-		display: 'Immersive',
-		design: 'Standard',
-		theme: 'NewsPillar',
-		renderingTarget: 'Apps',
-	},
-];
+const testLayoutFormats =
+	/** @type {const} @satisfies {ReadonlyArray<TestFormat>} */ ([
+		{
+			display: 'Standard',
+			design: 'Standard',
+			theme: 'NewsPillar',
+			config: { renderingTarget: 'Web', darkModeAvailable: false },
+		},
+		{
+			display: 'Standard',
+			design: 'Standard',
+			theme: 'NewsPillar',
+			config: { renderingTarget: 'Apps', darkModeAvailable: false },
+		},
+		{
+			display: 'Showcase',
+			design: 'Standard',
+			theme: 'NewsPillar',
+			config: { renderingTarget: 'Apps', darkModeAvailable: false },
+		},
+		{
+			display: 'Showcase',
+			design: 'Picture',
+			theme: 'OpinionPillar',
+			config: { renderingTarget: 'Web', darkModeAvailable: false },
+		},
+		{
+			display: 'Showcase',
+			design: 'Picture',
+			theme: 'OpinionPillar',
+			config: { renderingTarget: 'Apps', darkModeAvailable: false },
+		},
+		{
+			display: 'Standard',
+			design: 'Comment',
+			theme: 'NewsPillar',
+			config: { renderingTarget: 'Apps', darkModeAvailable: false },
+		},
+		{
+			display: 'Standard',
+			design: 'Interactive',
+			theme: 'NewsPillar',
+			config: { renderingTarget: 'Apps', darkModeAvailable: false },
+		},
+
+		{
+			display: 'Immersive',
+			design: 'Standard',
+			theme: 'NewsPillar',
+			config: { renderingTarget: 'Apps', darkModeAvailable: false },
+		},
+	]);
 
 const generateLayoutStories = () => {
 	log('[scripts/gen-stories] Generating layout stories.');
 	let stories = 0;
 	let template = LAYOUT_TEMPLATE_HEADER;
 
-	for (const {
-		display,
-		design,
-		theme,
-		renderingTarget,
-	} of testLayoutFormats) {
-		template += generateLayoutStory(
-			display,
-			design,
-			theme,
-			renderingTarget,
-		);
+	for (const { display, design, theme, config } of testLayoutFormats) {
+		template += generateLayoutStory(display, design, theme, config);
 		stories++;
 	}
 

--- a/dotcom-rendering/src/components/ArticleMeta.test.tsx
+++ b/dotcom-rendering/src/components/ArticleMeta.test.tsx
@@ -15,7 +15,9 @@ describe('ArticleMeta', () => {
 		};
 
 		const { container } = render(
-			<ConfigProvider value={{ renderingTarget: 'Web' }}>
+			<ConfigProvider
+				value={{ renderingTarget: 'Web', darkModeAvailable: false }}
+			>
 				<ArticleMeta
 					format={format}
 					pageId="1234"
@@ -56,7 +58,9 @@ describe('ArticleMeta', () => {
 		};
 
 		const { container } = render(
-			<ConfigProvider value={{ renderingTarget: 'Web' }}>
+			<ConfigProvider
+				value={{ renderingTarget: 'Web', darkModeAvailable: false }}
+			>
 				<ArticleMeta
 					format={format}
 					pageId="1234"

--- a/dotcom-rendering/src/components/BylineLink.test.tsx
+++ b/dotcom-rendering/src/components/BylineLink.test.tsx
@@ -104,7 +104,9 @@ describe('BylineLink', () => {
 		];
 
 		const { container } = render(
-			<ConfigProvider value={{ renderingTarget: 'Web' }}>
+			<ConfigProvider
+				value={{ renderingTarget: 'Web', darkModeAvailable: false }}
+			>
 				<BylineLink
 					byline={byline}
 					tags={tags}
@@ -139,7 +141,9 @@ describe('BylineLink', () => {
 			},
 		];
 		const { container } = render(
-			<ConfigProvider value={{ renderingTarget: 'Web' }}>
+			<ConfigProvider
+				value={{ renderingTarget: 'Web', darkModeAvailable: false }}
+			>
 				<BylineLink
 					byline={byline}
 					tags={tags}
@@ -176,7 +180,9 @@ describe('BylineLink', () => {
 		];
 
 		const { container } = render(
-			<ConfigProvider value={{ renderingTarget: 'Web' }}>
+			<ConfigProvider
+				value={{ renderingTarget: 'Web', darkModeAvailable: false }}
+			>
 				<BylineLink
 					byline={byline}
 					tags={tags}

--- a/dotcom-rendering/src/components/ConfigContext.test.tsx
+++ b/dotcom-rendering/src/components/ConfigContext.test.tsx
@@ -21,7 +21,7 @@ describe('ConfigContext', () => {
 
 	describe('with ConfigProvider', () => {
 		it.each([
-			{ renderingTarget: 'Web' },
+			{ renderingTarget: 'Web', darkModeAvailable: false },
 			{ renderingTarget: 'Apps', darkModeAvailable: true },
 			{ renderingTarget: 'Apps', darkModeAvailable: false },
 		] as const satisfies ReadonlyArray<Config>)(

--- a/dotcom-rendering/src/components/Contributor.test.tsx
+++ b/dotcom-rendering/src/components/Contributor.test.tsx
@@ -15,7 +15,9 @@ describe('Contributor', () => {
 		};
 
 		const { container } = render(
-			<ConfigProvider value={{ renderingTarget: 'Web' }}>
+			<ConfigProvider
+				value={{ renderingTarget: 'Web', darkModeAvailable: false }}
+			>
 				<Contributor
 					format={format}
 					byline="Observer writers"
@@ -43,7 +45,9 @@ describe('Contributor', () => {
 		};
 
 		const { container } = render(
-			<ConfigProvider value={{ renderingTarget: 'Web' }}>
+			<ConfigProvider
+				value={{ renderingTarget: 'Web', darkModeAvailable: false }}
+			>
 				<Contributor
 					format={format}
 					byline="Observer writers"

--- a/dotcom-rendering/src/components/Dropdown.test.tsx
+++ b/dotcom-rendering/src/components/Dropdown.test.tsx
@@ -41,7 +41,9 @@ const LABEL = 'Dropdown label';
 describe('Dropdown', () => {
 	it('should display the given label', () => {
 		const { getByText } = render(
-			<ConfigProvider value={{ renderingTarget: 'Web' }}>
+			<ConfigProvider
+				value={{ renderingTarget: 'Web', darkModeAvailable: false }}
+			>
 				<Dropdown
 					id="abc"
 					label={LABEL}
@@ -56,7 +58,9 @@ describe('Dropdown', () => {
 
 	it('should display link titles', () => {
 		const { getByText } = render(
-			<ConfigProvider value={{ renderingTarget: 'Web' }}>
+			<ConfigProvider
+				value={{ renderingTarget: 'Web', darkModeAvailable: false }}
+			>
 				<Dropdown
 					id="abc"
 					label={LABEL}
@@ -74,7 +78,9 @@ describe('Dropdown', () => {
 
 	it('should render the correct number of link items', () => {
 		const { container } = render(
-			<ConfigProvider value={{ renderingTarget: 'Web' }}>
+			<ConfigProvider
+				value={{ renderingTarget: 'Web', darkModeAvailable: false }}
+			>
 				<Dropdown
 					id="abc"
 					label={LABEL}
@@ -91,7 +97,9 @@ describe('Dropdown', () => {
 
 	it('should expand the menu when clicked upon', () => {
 		const { container, getByRole } = render(
-			<ConfigProvider value={{ renderingTarget: 'Web' }}>
+			<ConfigProvider
+				value={{ renderingTarget: 'Web', darkModeAvailable: false }}
+			>
 				<Dropdown
 					id="abc"
 					label={LABEL}
@@ -110,7 +118,9 @@ describe('Dropdown', () => {
 
 	it('should close the expanded menu when they click away', () => {
 		const { container, getByRole } = render(
-			<ConfigProvider value={{ renderingTarget: 'Web' }}>
+			<ConfigProvider
+				value={{ renderingTarget: 'Web', darkModeAvailable: false }}
+			>
 				<Dropdown
 					id="abc"
 					label={LABEL}
@@ -130,7 +140,9 @@ describe('Dropdown', () => {
 
 	it('should close the expanded menu when blurred', () => {
 		const { container, getByRole } = render(
-			<ConfigProvider value={{ renderingTarget: 'Web' }}>
+			<ConfigProvider
+				value={{ renderingTarget: 'Web', darkModeAvailable: false }}
+			>
 				<Dropdown
 					id="abc"
 					label={LABEL}

--- a/dotcom-rendering/src/components/GuideAtom/GuideAtom.test.tsx
+++ b/dotcom-rendering/src/components/GuideAtom/GuideAtom.test.tsx
@@ -7,7 +7,9 @@ import { GuideAtom } from './GuideAtom';
 describe('GuideAtom', () => {
 	it('should render', () => {
 		const { getByText, queryByText } = render(
-			<ConfigProvider value={{ renderingTarget: 'Web' }}>
+			<ConfigProvider
+				value={{ renderingTarget: 'Web', darkModeAvailable: false }}
+			>
 				<GuideAtom {...defaultStory} />
 			</ConfigProvider>,
 		);
@@ -26,7 +28,9 @@ describe('GuideAtom', () => {
 
 	it('Show feedback on like', () => {
 		const { getByText, queryByText, queryByTestId } = render(
-			<ConfigProvider value={{ renderingTarget: 'Web' }}>
+			<ConfigProvider
+				value={{ renderingTarget: 'Web', darkModeAvailable: false }}
+			>
 				<GuideAtom {...defaultStory} />
 			</ConfigProvider>,
 		);
@@ -46,7 +50,9 @@ describe('GuideAtom', () => {
 
 	it('Show feedback on dislike', () => {
 		const { getByText, queryByText, queryByTestId } = render(
-			<ConfigProvider value={{ renderingTarget: 'Web' }}>
+			<ConfigProvider
+				value={{ renderingTarget: 'Web', darkModeAvailable: false }}
+			>
 				<GuideAtom {...defaultStory} />
 			</ConfigProvider>,
 		);

--- a/dotcom-rendering/src/components/Island.test.tsx
+++ b/dotcom-rendering/src/components/Island.test.tsx
@@ -97,7 +97,9 @@ describe('Island: server-side rendering', () => {
 	test('EnhancePinnedPost', () => {
 		expect(() =>
 			renderToString(
-				<ConfigProvider value={{ renderingTarget: 'Web' }}>
+				<ConfigProvider
+					value={{ renderingTarget: 'Web', darkModeAvailable: false }}
+				>
 					<EnhancePinnedPost />
 				</ConfigProvider>,
 			),
@@ -198,7 +200,9 @@ describe('Island: server-side rendering', () => {
 	test('StickyBottomBanner', () => {
 		expect(() =>
 			renderToString(
-				<ConfigProvider value={{ renderingTarget: 'Web' }}>
+				<ConfigProvider
+					value={{ renderingTarget: 'Web', darkModeAvailable: false }}
+				>
 					<StickyBottomBanner
 						contentType=""
 						tags={[]}

--- a/dotcom-rendering/src/components/KeyEventsContainer.test.tsx
+++ b/dotcom-rendering/src/components/KeyEventsContainer.test.tsx
@@ -14,7 +14,9 @@ const baseProperties = {
 describe('KeyEventsContainer', () => {
 	it('It should render KeyEventsContainer as expected', () => {
 		const { container } = render(
-			<ConfigProvider value={{ renderingTarget: 'Web' }}>
+			<ConfigProvider
+				value={{ renderingTarget: 'Web', darkModeAvailable: false }}
+			>
 				<KeyEventsContainer
 					format={{
 						display: ArticleDisplay.Standard,
@@ -37,7 +39,9 @@ describe('KeyEventsContainer', () => {
 
 	it('It should not render events without a blockFirstPublished property', () => {
 		const { container } = render(
-			<ConfigProvider value={{ renderingTarget: 'Web' }}>
+			<ConfigProvider
+				value={{ renderingTarget: 'Web', darkModeAvailable: false }}
+			>
 				<KeyEventsContainer
 					format={{
 						display: ArticleDisplay.Standard,
@@ -62,7 +66,9 @@ describe('KeyEventsContainer', () => {
 
 	it('It should not render events without a title property', () => {
 		const { container } = render(
-			<ConfigProvider value={{ renderingTarget: 'Web' }}>
+			<ConfigProvider
+				value={{ renderingTarget: 'Web', darkModeAvailable: false }}
+			>
 				<KeyEventsContainer
 					format={{
 						display: ArticleDisplay.Standard,

--- a/dotcom-rendering/src/components/MostViewedFooter.test.tsx
+++ b/dotcom-rendering/src/components/MostViewedFooter.test.tsx
@@ -23,7 +23,9 @@ describe('MostViewedFooterData', () => {
 		useApi.mockReturnValue({ data: responseWithTwoTabs, loading: false });
 
 		const { getByText, getAllByText, getByTestId } = render(
-			<ConfigProvider value={{ renderingTarget: 'Web' }}>
+			<ConfigProvider
+				value={{ renderingTarget: 'Web', darkModeAvailable: false }}
+			>
 				<MostViewedFooterData
 					sectionId="Section Name"
 					format={{
@@ -62,7 +64,9 @@ describe('MostViewedFooterData', () => {
 		useApi.mockReturnValue({ data: responseWithTwoTabs, loading: false });
 
 		const { getByTestId, getByText } = render(
-			<ConfigProvider value={{ renderingTarget: 'Web' }}>
+			<ConfigProvider
+				value={{ renderingTarget: 'Web', darkModeAvailable: false }}
+			>
 				<MostViewedFooterData
 					sectionId="Section Name"
 					format={{
@@ -122,7 +126,9 @@ describe('MostViewedFooterData', () => {
 		});
 
 		const { getByText } = render(
-			<ConfigProvider value={{ renderingTarget: 'Web' }}>
+			<ConfigProvider
+				value={{ renderingTarget: 'Web', darkModeAvailable: false }}
+			>
 				<MostViewedFooterData
 					sectionId="Section Name"
 					format={{
@@ -167,7 +173,9 @@ describe('MostViewedFooterData', () => {
 		});
 
 		const { queryByText } = render(
-			<ConfigProvider value={{ renderingTarget: 'Web' }}>
+			<ConfigProvider
+				value={{ renderingTarget: 'Web', darkModeAvailable: false }}
+			>
 				<MostViewedFooterData
 					sectionId="Section Name"
 					format={{
@@ -188,7 +196,9 @@ describe('MostViewedFooterData', () => {
 		useApi.mockReturnValue({ data: responseWithTwoTabs, loading: false });
 
 		const { asFragment } = render(
-			<ConfigProvider value={{ renderingTarget: 'Web' }}>
+			<ConfigProvider
+				value={{ renderingTarget: 'Web', darkModeAvailable: false }}
+			>
 				<MostViewedFooterData
 					sectionId="Section Name"
 					format={{

--- a/dotcom-rendering/src/components/ProfileAtom.test.tsx
+++ b/dotcom-rendering/src/components/ProfileAtom.test.tsx
@@ -11,7 +11,9 @@ const format: ArticleFormat = {
 describe('ProfileAtom', () => {
 	it('should render', () => {
 		const { getByText, queryByText } = render(
-			<ConfigProvider value={{ renderingTarget: 'Web' }}>
+			<ConfigProvider
+				value={{ renderingTarget: 'Web', darkModeAvailable: false }}
+			>
 				<ProfileAtom
 					id="1fba49a4-81c6-49e4-b7fa-fd66d1512360"
 					title="Who is Jon Lansman?"
@@ -45,7 +47,9 @@ describe('ProfileAtom', () => {
 
 	it('Show feedback on like', () => {
 		const { getByText, queryByText, queryByTestId } = render(
-			<ConfigProvider value={{ renderingTarget: 'Web' }}>
+			<ConfigProvider
+				value={{ renderingTarget: 'Web', darkModeAvailable: false }}
+			>
 				<ProfileAtom
 					id="1fba49a4-81c6-49e4-b7fa-fd66d1512360"
 					format={format}
@@ -80,7 +84,9 @@ describe('ProfileAtom', () => {
 
 	it('Show feedback on dislike', () => {
 		const { getByText, queryByText, queryByTestId } = render(
-			<ConfigProvider value={{ renderingTarget: 'Web' }}>
+			<ConfigProvider
+				value={{ renderingTarget: 'Web', darkModeAvailable: false }}
+			>
 				<ProfileAtom
 					id="1fba49a4-81c6-49e4-b7fa-fd66d1512360"
 					format={format}

--- a/dotcom-rendering/src/components/QandaAtom.test.tsx
+++ b/dotcom-rendering/src/components/QandaAtom.test.tsx
@@ -7,7 +7,9 @@ import { QandaAtom } from './QandaAtom.importable';
 describe('QandaAtom', () => {
 	it('should render & expand works', () => {
 		const { getByText, queryByText } = render(
-			<ConfigProvider value={{ renderingTarget: 'Web' }}>
+			<ConfigProvider
+				value={{ renderingTarget: 'Web', darkModeAvailable: false }}
+			>
 				<QandaAtom {...imageStory} />
 			</ConfigProvider>,
 		);
@@ -26,7 +28,9 @@ describe('QandaAtom', () => {
 
 	it('Show feedback on like', () => {
 		const { getByText, queryByText, queryByTestId } = render(
-			<ConfigProvider value={{ renderingTarget: 'Web' }}>
+			<ConfigProvider
+				value={{ renderingTarget: 'Web', darkModeAvailable: false }}
+			>
 				<QandaAtom {...imageStory} />
 			</ConfigProvider>,
 		);
@@ -46,7 +50,9 @@ describe('QandaAtom', () => {
 
 	it('Show feedback on dislike', () => {
 		const { getByText, queryByText, queryByTestId } = render(
-			<ConfigProvider value={{ renderingTarget: 'Web' }}>
+			<ConfigProvider
+				value={{ renderingTarget: 'Web', darkModeAvailable: false }}
+			>
 				<QandaAtom {...imageStory} />
 			</ConfigProvider>,
 		);

--- a/dotcom-rendering/src/components/ReaderRevenueLinks.test.tsx
+++ b/dotcom-rendering/src/components/ReaderRevenueLinks.test.tsx
@@ -40,7 +40,9 @@ describe('ReaderRevenueLinks', () => {
 		shouldHideSupportMessaging.mockReturnValue(true);
 
 		const { getByText } = render(
-			<ConfigProvider value={{ renderingTarget: 'Web' }}>
+			<ConfigProvider
+				value={{ renderingTarget: 'Web', darkModeAvailable: false }}
+			>
 				<ReaderRevenueLinks
 					urls={urls}
 					editionId="US"
@@ -59,7 +61,9 @@ describe('ReaderRevenueLinks', () => {
 		shouldHideSupportMessaging.mockReturnValue(false);
 
 		const { getByText } = render(
-			<ConfigProvider value={{ renderingTarget: 'Web' }}>
+			<ConfigProvider
+				value={{ renderingTarget: 'Web', darkModeAvailable: false }}
+			>
 				<ReaderRevenueLinks
 					urls={urls}
 					editionId={edition}

--- a/dotcom-rendering/src/components/TimelineAtom.test.tsx
+++ b/dotcom-rendering/src/components/TimelineAtom.test.tsx
@@ -7,7 +7,9 @@ import { TimelineAtom } from './TimelineAtom.importable';
 describe('TimelineAtom', () => {
 	it('should render', () => {
 		const { getByText, queryByText } = render(
-			<ConfigProvider value={{ renderingTarget: 'Web' }}>
+			<ConfigProvider
+				value={{ renderingTarget: 'Web', darkModeAvailable: false }}
+			>
 				<TimelineAtom {...noTimelineEventsStory} />
 			</ConfigProvider>,
 		);
@@ -26,7 +28,9 @@ describe('TimelineAtom', () => {
 
 	it('Show feedback on like', () => {
 		const { getByText, queryByText, queryByTestId } = render(
-			<ConfigProvider value={{ renderingTarget: 'Web' }}>
+			<ConfigProvider
+				value={{ renderingTarget: 'Web', darkModeAvailable: false }}
+			>
 				<TimelineAtom {...noTimelineEventsStory} />
 			</ConfigProvider>,
 		);
@@ -46,7 +50,9 @@ describe('TimelineAtom', () => {
 
 	it('Show feedback on dislike', () => {
 		const { getByText, queryByText, queryByTestId } = render(
-			<ConfigProvider value={{ renderingTarget: 'Web' }}>
+			<ConfigProvider
+				value={{ renderingTarget: 'Web', darkModeAvailable: false }}
+			>
 				<TimelineAtom {...noTimelineEventsStory} />
 			</ConfigProvider>,
 		);

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.test.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.test.tsx
@@ -24,7 +24,9 @@ const consentStateCanTarget: ConsentState = {
 describe('YoutubeAtom', () => {
 	it('Player initialises when no overlay and has consent state', () => {
 		const atom = (
-			<ConfigProvider value={{ renderingTarget: 'Web' }}>
+			<ConfigProvider
+				value={{ renderingTarget: 'Web', darkModeAvailable: false }}
+			>
 				<YoutubeAtom
 					elementId="xyz"
 					title="My Youtube video!"
@@ -52,7 +54,9 @@ describe('YoutubeAtom', () => {
 
 	it('Player initialises when overlay clicked and has consent state', () => {
 		const atom = (
-			<ConfigProvider value={{ renderingTarget: 'Web' }}>
+			<ConfigProvider
+				value={{ renderingTarget: 'Web', darkModeAvailable: false }}
+			>
 				<YoutubeAtom
 					elementId="xyz"
 					title="My Youtube video!"
@@ -89,7 +93,9 @@ describe('YoutubeAtom', () => {
 		const title = 'My Youtube video!';
 
 		const atom = (
-			<ConfigProvider value={{ renderingTarget: 'Web' }}>
+			<ConfigProvider
+				value={{ renderingTarget: 'Web', darkModeAvailable: false }}
+			>
 				<YoutubeAtom
 					elementId="xyz"
 					title="My Youtube video!"
@@ -118,7 +124,9 @@ describe('YoutubeAtom', () => {
 	it('overlay has correct aria-label', () => {
 		const title = 'My Youtube video!';
 		const atom = (
-			<ConfigProvider value={{ renderingTarget: 'Web' }}>
+			<ConfigProvider
+				value={{ renderingTarget: 'Web', darkModeAvailable: false }}
+			>
 				<YoutubeAtom
 					elementId="xyz"
 					title="My Youtube video!"
@@ -149,7 +157,9 @@ describe('YoutubeAtom', () => {
 
 	it('shows a placeholder if overlay is missing', () => {
 		const atom = (
-			<ConfigProvider value={{ renderingTarget: 'Web' }}>
+			<ConfigProvider
+				value={{ renderingTarget: 'Web', darkModeAvailable: false }}
+			>
 				<YoutubeAtom
 					elementId="xyz"
 					title="My Youtube video!"
@@ -176,7 +186,9 @@ describe('YoutubeAtom', () => {
 
 	it('shows an overlay if present', () => {
 		const atom = (
-			<ConfigProvider value={{ renderingTarget: 'Web' }}>
+			<ConfigProvider
+				value={{ renderingTarget: 'Web', darkModeAvailable: false }}
+			>
 				<YoutubeAtom
 					elementId="xyz"
 					title="My Youtube video!"
@@ -204,7 +216,9 @@ describe('YoutubeAtom', () => {
 
 	it('hides an overlay once it is clicked', () => {
 		const atom = (
-			<ConfigProvider value={{ renderingTarget: 'Web' }}>
+			<ConfigProvider
+				value={{ renderingTarget: 'Web', darkModeAvailable: false }}
+			>
 				<YoutubeAtom
 					elementId="xyz"
 					title="My Youtube video!"
@@ -236,7 +250,9 @@ describe('YoutubeAtom', () => {
 	it('when two Atoms - hides the overlay of the correct player if clicked', () => {
 		const atom = (
 			<>
-				<ConfigProvider value={{ renderingTarget: 'Web' }}>
+				<ConfigProvider
+					value={{ renderingTarget: 'Web', darkModeAvailable: false }}
+				>
 					<YoutubeAtom
 						elementId="xyz"
 						title="My Youtube video!"

--- a/dotcom-rendering/src/server/render.allEditorialNewslettersPage.web.tsx
+++ b/dotcom-rendering/src/server/render.allEditorialNewslettersPage.web.tsx
@@ -25,7 +25,7 @@ export const renderEditorialNewslettersPage = ({
 	const NAV = extractNAV(newslettersPage.nav);
 
 	// The newsletters page is currently only supported on Web
-	const config: Config = { renderingTarget: 'Web' };
+	const config: Config = { renderingTarget: 'Web', darkModeAvailable: false };
 
 	const { html, extractedCss } = renderToStringWithEmotion(
 		<ConfigProvider value={config}>

--- a/dotcom-rendering/src/server/render.article.amp.tsx
+++ b/dotcom-rendering/src/server/render.article.amp.tsx
@@ -40,7 +40,7 @@ export const renderArticle = ({
 	const { extractCritical } = createEmotionServer(cache);
 
 	// We are currently considering AMP to be a renderingTarget of Web
-	const config: Config = { renderingTarget: 'Web' };
+	const config: Config = { renderingTarget: 'Web', darkModeAvailable: false };
 
 	const { html, css }: RenderToStringResult = extractCritical(
 		renderToStaticMarkup(

--- a/dotcom-rendering/src/server/render.article.web.tsx
+++ b/dotcom-rendering/src/server/render.article.web.tsx
@@ -50,7 +50,7 @@ export const renderHtml = ({
 	const format: ArticleFormat = decideFormat(article.format);
 
 	const renderingTarget = 'Web';
-	const config: Config = { renderingTarget };
+	const config: Config = { renderingTarget, darkModeAvailable: false };
 
 	const { html, extractedCss } = renderToStringWithEmotion(
 		<ConfigProvider value={config}>
@@ -256,7 +256,7 @@ export const renderBlocks = ({
 	const format: ArticleFormat = decideFormat(FEFormat);
 
 	// Only currently supported for Web
-	const config: Config = { renderingTarget: 'Web' };
+	const config: Config = { renderingTarget: 'Web', darkModeAvailable: false };
 
 	const { html, extractedCss } = renderToStringWithEmotion(
 		<ConfigProvider value={config}>
@@ -296,7 +296,7 @@ export const renderKeyEvents = ({
 	format: FEFormat,
 	filterKeyEvents,
 }: FEKeyEventsRequest): string => {
-	const config: Config = { renderingTarget: 'Web' };
+	const config: Config = { renderingTarget: 'Web', darkModeAvailable: false };
 
 	const { html, extractedCss } = renderToStringWithEmotion(
 		<ConfigProvider value={config}>

--- a/dotcom-rendering/src/server/render.front.web.tsx
+++ b/dotcom-rendering/src/server/render.front.web.tsx
@@ -78,7 +78,7 @@ export const renderFront = ({
 	const NAV = extractFrontNav(front);
 
 	// Fronts are not supported in Apps
-	const config: Config = { renderingTarget: 'Web' };
+	const config: Config = { renderingTarget: 'Web', darkModeAvailable: false };
 
 	const { html, extractedCss } = renderToStringWithEmotion(
 		<ConfigProvider value={config}>
@@ -172,7 +172,7 @@ export const renderTagFront = ({
 	const NAV = extractNAV(tagFront.nav);
 
 	// Fronts are not supported in Apps
-	const config: Config = { renderingTarget: 'Web' };
+	const config: Config = { renderingTarget: 'Web', darkModeAvailable: false };
 
 	const { html, extractedCss } = renderToStringWithEmotion(
 		<ConfigProvider value={config}>

--- a/dotcom-rendering/src/types/configContext.ts
+++ b/dotcom-rendering/src/types/configContext.ts
@@ -9,7 +9,7 @@ import type { RenderingTarget } from './renderingTarget';
 export type Config =
 	| {
 			renderingTarget: Extract<RenderingTarget, 'Web'>;
-			darkModeAvailable?: never;
+			darkModeAvailable: false;
 	  }
 	| {
 			renderingTarget: Extract<RenderingTarget, 'Apps'>;

--- a/dotcom-rendering/stories/generated/Layout.stories.tsx
+++ b/dotcom-rendering/stories/generated/Layout.stories.tsx
@@ -7,7 +7,7 @@ import { ArticleDesign, ArticleDisplay, ArticleSpecial, Pillar } from '@guardian
 import { lightDecorator } from '../../.storybook/decorators/themeDecorator';
 import { HydratedLayoutWrapper } from '../../src/layouts/Layout.stories';
 
-// eslint-disable-next-line import/no-default-export -- we need a default here
+ 
 export default {
 	title: 'Components/Layout/Format Variations',
 	component: HydratedLayoutWrapper,
@@ -31,7 +31,7 @@ export const WebStandardStandardNewsPillar = () => {
 	);
 };
 WebStandardStandardNewsPillar.storyName = 'Web: Display: Standard, Design: Standard, Theme: NewsPillar';
-WebStandardStandardNewsPillar.args = { config: { renderingTarget: 'Web' } };
+WebStandardStandardNewsPillar.args = { config: { renderingTarget: 'Web', darkModeAvailable: false } };
 WebStandardStandardNewsPillar.decorators = [lightDecorator({
 	display: ArticleDisplay.Standard,
 	design: ArticleDesign.Standard,
@@ -85,7 +85,7 @@ export const WebShowcasePictureOpinionPillar = () => {
 	);
 };
 WebShowcasePictureOpinionPillar.storyName = 'Web: Display: Showcase, Design: Picture, Theme: OpinionPillar';
-WebShowcasePictureOpinionPillar.args = { config: { renderingTarget: 'Web' } };
+WebShowcasePictureOpinionPillar.args = { config: { renderingTarget: 'Web', darkModeAvailable: false } };
 WebShowcasePictureOpinionPillar.decorators = [lightDecorator({
 	display: ArticleDisplay.Showcase,
 	design: ArticleDesign.Picture,

--- a/dotcom-rendering/stories/generated/Layout.stories.tsx
+++ b/dotcom-rendering/stories/generated/Layout.stories.tsx
@@ -7,7 +7,7 @@ import { ArticleDesign, ArticleDisplay, ArticleSpecial, Pillar } from '@guardian
 import { lightDecorator } from '../../.storybook/decorators/themeDecorator';
 import { HydratedLayoutWrapper } from '../../src/layouts/Layout.stories';
 
- 
+// eslint-disable-next-line import/no-default-export -- we need a default here
 export default {
 	title: 'Components/Layout/Format Variations',
 	component: HydratedLayoutWrapper,
@@ -31,7 +31,7 @@ export const WebStandardStandardNewsPillar = () => {
 	);
 };
 WebStandardStandardNewsPillar.storyName = 'Web: Display: Standard, Design: Standard, Theme: NewsPillar';
-WebStandardStandardNewsPillar.args = { config: { renderingTarget: 'Web', darkModeAvailable: false } };
+WebStandardStandardNewsPillar.args = { config: {"renderingTarget":"Web","darkModeAvailable":false} };
 WebStandardStandardNewsPillar.decorators = [lightDecorator({
 	display: ArticleDisplay.Standard,
 	design: ArticleDesign.Standard,
@@ -49,7 +49,7 @@ export const AppsStandardStandardNewsPillar = () => {
 	);
 };
 AppsStandardStandardNewsPillar.storyName = 'Apps: Display: Standard, Design: Standard, Theme: NewsPillar';
-AppsStandardStandardNewsPillar.args = { config: { renderingTarget: 'Apps' } };
+AppsStandardStandardNewsPillar.args = { config: {"renderingTarget":"Apps","darkModeAvailable":false} };
 AppsStandardStandardNewsPillar.decorators = [lightDecorator({
 	display: ArticleDisplay.Standard,
 	design: ArticleDesign.Standard,
@@ -67,7 +67,7 @@ export const AppsShowcaseStandardNewsPillar = () => {
 	);
 };
 AppsShowcaseStandardNewsPillar.storyName = 'Apps: Display: Showcase, Design: Standard, Theme: NewsPillar';
-AppsShowcaseStandardNewsPillar.args = { config: { renderingTarget: 'Apps' } };
+AppsShowcaseStandardNewsPillar.args = { config: {"renderingTarget":"Apps","darkModeAvailable":false} };
 AppsShowcaseStandardNewsPillar.decorators = [lightDecorator({
 	display: ArticleDisplay.Showcase,
 	design: ArticleDesign.Standard,
@@ -85,7 +85,7 @@ export const WebShowcasePictureOpinionPillar = () => {
 	);
 };
 WebShowcasePictureOpinionPillar.storyName = 'Web: Display: Showcase, Design: Picture, Theme: OpinionPillar';
-WebShowcasePictureOpinionPillar.args = { config: { renderingTarget: 'Web', darkModeAvailable: false } };
+WebShowcasePictureOpinionPillar.args = { config: {"renderingTarget":"Web","darkModeAvailable":false} };
 WebShowcasePictureOpinionPillar.decorators = [lightDecorator({
 	display: ArticleDisplay.Showcase,
 	design: ArticleDesign.Picture,
@@ -103,7 +103,7 @@ export const AppsShowcasePictureOpinionPillar = () => {
 	);
 };
 AppsShowcasePictureOpinionPillar.storyName = 'Apps: Display: Showcase, Design: Picture, Theme: OpinionPillar';
-AppsShowcasePictureOpinionPillar.args = { config: { renderingTarget: 'Apps' } };
+AppsShowcasePictureOpinionPillar.args = { config: {"renderingTarget":"Apps","darkModeAvailable":false} };
 AppsShowcasePictureOpinionPillar.decorators = [lightDecorator({
 	display: ArticleDisplay.Showcase,
 	design: ArticleDesign.Picture,
@@ -121,7 +121,7 @@ export const AppsStandardCommentNewsPillar = () => {
 	);
 };
 AppsStandardCommentNewsPillar.storyName = 'Apps: Display: Standard, Design: Comment, Theme: NewsPillar';
-AppsStandardCommentNewsPillar.args = { config: { renderingTarget: 'Apps' } };
+AppsStandardCommentNewsPillar.args = { config: {"renderingTarget":"Apps","darkModeAvailable":false} };
 AppsStandardCommentNewsPillar.decorators = [lightDecorator({
 	display: ArticleDisplay.Standard,
 	design: ArticleDesign.Comment,
@@ -139,7 +139,7 @@ export const AppsStandardInteractiveNewsPillar = () => {
 	);
 };
 AppsStandardInteractiveNewsPillar.storyName = 'Apps: Display: Standard, Design: Interactive, Theme: NewsPillar';
-AppsStandardInteractiveNewsPillar.args = { config: { renderingTarget: 'Apps' } };
+AppsStandardInteractiveNewsPillar.args = { config: {"renderingTarget":"Apps","darkModeAvailable":false} };
 AppsStandardInteractiveNewsPillar.decorators = [lightDecorator({
 	display: ArticleDisplay.Standard,
 	design: ArticleDesign.Interactive,
@@ -157,7 +157,7 @@ export const AppsImmersiveStandardNewsPillar = () => {
 	);
 };
 AppsImmersiveStandardNewsPillar.storyName = 'Apps: Display: Immersive, Design: Standard, Theme: NewsPillar';
-AppsImmersiveStandardNewsPillar.args = { config: { renderingTarget: 'Apps' } };
+AppsImmersiveStandardNewsPillar.args = { config: {"renderingTarget":"Apps","darkModeAvailable":false} };
 AppsImmersiveStandardNewsPillar.decorators = [lightDecorator({
 	display: ArticleDisplay.Immersive,
 	design: ArticleDesign.Standard,


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Use a strict `boolean` instead of `true | undefined`

## Why?

More semantic, easier to reason about

## Screenshots

N/A