### PR TITLE
Support using `yalc` for local development

### DIFF
--- a/dotcom-rendering/scripts/env/check-deps.js
+++ b/dotcom-rendering/scripts/env/check-deps.js
@@ -20,10 +20,10 @@ const knownNonSemver = /** @type {const} */ ([
 const mismatches = Object.entries(pkg.dependencies)
 	.filter(([name, version]) => {
 		const pinned = json[name + '@' + version]?.version;
-		const isYalc = version.startsWith('file:.yalc');
-		return version !== pinned && !isYalc;
+		return version !== pinned;
 	})
-	.filter(([, version]) => !knownNonSemver.includes(version));
+	.filter(([, version]) => !knownNonSemver.includes(version))
+	.filter(([, version]) => !version.startsWith('file:.yalc'));
 
 if (mismatches.length) warn('All dependencies should be pinned');
 for (const [name, version] of mismatches) {

--- a/dotcom-rendering/scripts/env/check-deps.js
+++ b/dotcom-rendering/scripts/env/check-deps.js
@@ -20,7 +20,8 @@ const knownNonSemver = /** @type {const} */ ([
 const mismatches = Object.entries(pkg.dependencies)
 	.filter(([name, version]) => {
 		const pinned = json[name + '@' + version]?.version;
-		return version !== pinned;
+		const isYalc = version.startsWith('file:.yalc');
+		return version !== pinned && !isYalc;
 	})
 	.filter(([, version]) => !knownNonSemver.includes(version));
 


### PR DESCRIPTION
## What does this change?

Support using yalc [1] for local development against an unpublished NPM package.

[1]: https://github.com/wclr/yalc

## Why?

In the past we've used yalc for running DCR locally using a local unpublished version of @guardian/braze-components. The check-deps script now prevents this as it complains that the dependency isn't pinned. This commit updates change-deps to allow unpinned dependencies if the dependency is provided by yalc.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
