### PR TITLE
Fix missing containers on tag fronts

### DIFF
--- a/dotcom-rendering/src/model/injectMpuIntoGroupedTrails.ts
+++ b/dotcom-rendering/src/model/injectMpuIntoGroupedTrails.ts
@@ -17,14 +17,10 @@ export const injectMpuIntoGroupedTrails = (
 	speed: 'slow' | 'fast',
 ): Array<GroupedTrails | GroupedTrailsFastMpu | GroupedTrailsSlowMpu> => {
 	let injected = false;
-	const result: Array<
-		GroupedTrails | GroupedTrailsFastMpu | GroupedTrailsSlowMpu
-	> = [];
 
-	for (const grouped of groupedTrails) {
+	return groupedTrails.map((grouped) => {
 		if (injected) {
-			result.push(grouped);
-			continue;
+			return grouped;
 		}
 
 		if (speed === 'fast') {
@@ -39,18 +35,16 @@ export const injectMpuIntoGroupedTrails = (
 				case 6:
 				case 9:
 					injected = true;
-					result.push({
+					return {
 						day: grouped.day,
 						month: grouped.month,
 						year: grouped.year,
 						trails: fastTrails,
 						injected: true,
 						speed: 'fast',
-					});
-					break;
+					};
 				default:
-					result.push(grouped);
-					break;
+					return grouped;
 			}
 		} else {
 			// By taking the first 12, we get the benefit of being able to use
@@ -63,21 +57,17 @@ export const injectMpuIntoGroupedTrails = (
 				case 5:
 				case 7:
 					injected = true;
-					result.push({
+					return {
 						day: grouped.day,
 						month: grouped.month,
 						year: grouped.year,
 						trails: slowTrails,
 						injected: true,
 						speed: 'slow',
-					});
-					break;
+					};
 				default:
-					result.push(grouped);
-					break;
+					return grouped;
 			}
 		}
-	}
-
-	return result;
+	});
 };

--- a/dotcom-rendering/src/model/injectMpuIntoGroupedTrails.ts
+++ b/dotcom-rendering/src/model/injectMpuIntoGroupedTrails.ts
@@ -49,6 +49,7 @@ export const injectMpuIntoGroupedTrails = (
 					});
 					break;
 				default:
+					result.push(grouped);
 					break;
 			}
 		} else {
@@ -72,6 +73,7 @@ export const injectMpuIntoGroupedTrails = (
 					});
 					break;
 				default:
+					result.push(grouped);
 					break;
 			}
 		}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Fixes a bug where on some tag fronts containers would be missing

## What was the fix?

It turns out there was a bug on the code we use to inject MPUs in tag front containers - where any container that came before the first suitable container wasn't being added to the `result` array. 

This PR both fixes the issue & refactors the code so that it would be harder to regress.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/9575458/625ceffe-3e3f-402a-bebb-8009a1fb4522
[after]: https://github.com/guardian/dotcom-rendering/assets/9575458/b7503eee-fdf3-4ee8-befe-0b46741bbaaa

