### PR TITLE
Fix tag fronts that were missing a bio/description

### DIFF
--- a/dotcom-rendering/src/model/front-schema.json
+++ b/dotcom-rendering/src/model/front-schema.json
@@ -711,6 +711,9 @@
                                                                                     "bio": {
                                                                                         "type": "string"
                                                                                     },
+                                                                                    "description": {
+                                                                                        "type": "string"
+                                                                                    },
                                                                                     "bylineImageUrl": {
                                                                                         "type": "string"
                                                                                     },
@@ -1421,6 +1424,9 @@
                                                                                     "bio": {
                                                                                         "type": "string"
                                                                                     },
+                                                                                    "description": {
+                                                                                        "type": "string"
+                                                                                    },
                                                                                     "bylineImageUrl": {
                                                                                         "type": "string"
                                                                                     },
@@ -2129,6 +2135,9 @@
                                                                                         "type": "string"
                                                                                     },
                                                                                     "bio": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "description": {
                                                                                         "type": "string"
                                                                                     },
                                                                                     "bylineImageUrl": {

--- a/dotcom-rendering/src/model/tag-front-schema.json
+++ b/dotcom-rendering/src/model/tag-front-schema.json
@@ -225,6 +225,9 @@
                                                                 "bio": {
                                                                     "type": "string"
                                                                 },
+                                                                "description": {
+                                                                    "type": "string"
+                                                                },
                                                                 "bylineImageUrl": {
                                                                     "type": "string"
                                                                 },
@@ -736,6 +739,9 @@
                                         "type": "string"
                                     },
                                     "bio": {
+                                        "type": "string"
+                                    },
+                                    "description": {
                                         "type": "string"
                                     },
                                     "bylineImageUrl": {

--- a/dotcom-rendering/src/server/index.front.web.ts
+++ b/dotcom-rendering/src/server/index.front.web.ts
@@ -90,7 +90,9 @@ const enhanceTagFront = (body: unknown): DCRTagFrontType => {
 		trendingTopics: extractTrendingTopics(data.contents, data.pageId),
 		header: {
 			title: data.webTitle,
-			description: data.tags.tags[0]?.properties.bio,
+			description:
+				data.tags.tags[0]?.properties.bio ||
+				data.tags.tags[0]?.properties.description,
 			image: data.tags.tags[0]?.properties.bylineImageUrl,
 		},
 	};

--- a/dotcom-rendering/src/server/index.front.web.ts
+++ b/dotcom-rendering/src/server/index.front.web.ts
@@ -91,7 +91,7 @@ const enhanceTagFront = (body: unknown): DCRTagFrontType => {
 		header: {
 			title: data.webTitle,
 			description:
-				data.tags.tags[0]?.properties.bio ||
+				data.tags.tags[0]?.properties.bio ??
 				data.tags.tags[0]?.properties.description,
 			image: data.tags.tags[0]?.properties.bylineImageUrl,
 		},

--- a/dotcom-rendering/src/types/tag.ts
+++ b/dotcom-rendering/src/types/tag.ts
@@ -10,6 +10,7 @@ export type FETagType = {
 		webTitle: string;
 		/* bio is html */
 		bio?: string;
+		description?: string;
 		bylineImageUrl?: string;
 		bylineLargeImageUrl?: string;
 		contributorLargeImagePath?: string;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Fixes an issue where some tag fronts were missing their bio/description

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/9575458/b18d2e64-ce6b-47e3-ae3b-19af9ec42590
[after]: https://github.com/guardian/dotcom-rendering/assets/9575458/3b61650a-0c8f-4cb6-8612-4ef2b3a98104

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
