### PR TITLE
Fix missing darkModeAvailable value in ConfigProvider in test

### DIFF
--- a/dotcom-rendering/src/components/Island.test.tsx
+++ b/dotcom-rendering/src/components/Island.test.tsx
@@ -189,7 +189,9 @@ describe('Island: server-side rendering', () => {
 	test('Metrics', () => {
 		expect(() =>
 			renderToString(
-				<ConfigProvider value={{ renderingTarget: 'Web' }}>
+				<ConfigProvider
+					value={{ renderingTarget: 'Web', darkModeAvailable: false }}
+				>
 					<Metrics commercialMetricsEnabled={true} tests={{}} />
 				</ConfigProvider>,
 			),


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

This value was made required in https://github.com/guardian/dotcom-rendering/pull/9315, which was merged before the test was added in https://github.com/guardian/dotcom-rendering/pull/9313.

As they were merged to main close together, something probably went wrong with the rebase before merging, and so we now have a failing [test on main](https://github.com/guardian/dotcom-rendering/actions/runs/6664531781/job/18112342194)
