### PR TITLE
chore: ensure working directory specified for DCR for eslint in vscode

### DIFF
--- a/.vscode/settings.json.required
+++ b/.vscode/settings.json.required
@@ -6,5 +6,6 @@
 	"deno.lint": true,
 	"deno.unstable": false,
 	"typescript.tsdk": "node_modules/typescript/lib",
-	"git.branchProtection": ["main"]
+	"git.branchProtection": ["main"],
+	"eslint.workingDirectories": ["./dotcom-rendering"],
 }


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Off the back of #9342, adapts the required settings for VSCode so that the tsconfig errors don't appear for the eslint plugin.

## Why?

The `settings.json.required` file wasn't sufficient to fix the underlying cause of the linting errors. Now that we automatically copy the file over, this should ensure that there is no strange behaviour for developers using VScode who check out this repo for the first time.
