### PR TITLE
Make `SlotBodyEnd` Island server-safe

### DIFF
--- a/dotcom-rendering/src/components/Island.test.tsx
+++ b/dotcom-rendering/src/components/Island.test.tsx
@@ -14,6 +14,7 @@ import { Liveness } from './Liveness.importable';
 import { Metrics } from './Metrics.importable';
 import { OnwardsUpper } from './OnwardsUpper.importable';
 import { SetABTests } from './SetABTests.importable';
+import { SlotBodyEnd } from './SlotBodyEnd.importable';
 import { Snow } from './Snow.importable';
 import { StickyBottomBanner } from './StickyBottomBanner.importable';
 
@@ -206,6 +207,32 @@ describe('Island: server-side rendering', () => {
 					pageIsSensitive={false}
 					abTestSwitches={{}}
 				/>,
+			),
+		).not.toThrow();
+	});
+
+	test('SlotBodyEnd', () => {
+		expect(() =>
+			renderToString(
+				<ConfigProvider
+					value={{ renderingTarget: 'Web', darkModeAvailable: false }}
+				>
+					<SlotBodyEnd
+						contentType={''}
+						sectionId={''}
+						shouldHideReaderRevenue={false}
+						isMinuteArticle={false}
+						isPaidContent={false}
+						tags={[]}
+						contributionsServiceUrl={''}
+						idApiUrl={''}
+						stage={''}
+						pageId={''}
+						keywordIds={''}
+						renderAds={false}
+						isLabs={false}
+					/>
+				</ConfigProvider>,
 			),
 		).not.toThrow();
 	});

--- a/dotcom-rendering/src/components/LiveBlogEpic.importable.tsx
+++ b/dotcom-rendering/src/components/LiveBlogEpic.importable.tsx
@@ -1,5 +1,4 @@
 import { css } from '@emotion/react';
-import type { CountryCode } from '@guardian/libs';
 import { getCookie, log, storage } from '@guardian/libs';
 import { space } from '@guardian/source-foundations';
 import { getEpicViewLog } from '@guardian/support-dotcom-components';
@@ -14,9 +13,9 @@ import {
 	shouldHideSupportMessaging,
 	useHasOptedOutOfArticleCount,
 } from '../lib/contributions';
-import { getLocaleCode } from '../lib/getCountryCode';
 import { setAutomat } from '../lib/setAutomat';
 import { useAuthStatus } from '../lib/useAuthStatus';
+import { useCountryCode } from '../lib/useCountryCode';
 import { useSDCLiveblogEpic } from '../lib/useSDC';
 import type { TagType } from '../types/tag';
 
@@ -28,26 +27,6 @@ type Props = {
 	contributionsServiceUrl: string;
 	pageId: string;
 	keywordIds: string;
-};
-
-const useCountryCode = () => {
-	const [countryCode, setCountryCode] = useState<CountryCode | null>();
-
-	useEffect(() => {
-		getLocaleCode()
-			.then((cc) => {
-				setCountryCode(cc);
-			})
-			.catch((e) => {
-				const msg = `Error fetching country code: ${String(e)}`;
-				window.guardian.modules.sentry.reportError(
-					new Error(msg),
-					'liveblog-epic',
-				);
-			});
-	}, []);
-
-	return countryCode;
 };
 
 const useEpic = ({ url, name }: { url: string; name: string }) => {
@@ -118,7 +97,7 @@ const usePayload = ({
 }): EpicPayload | undefined => {
 	const articleCounts = useArticleCounts(pageId, keywordIds);
 	const hasOptedOutOfArticleCount = useHasOptedOutOfArticleCount();
-	const countryCode = useCountryCode();
+	const countryCode = useCountryCode('liveblog-epic');
 	const mvtId = useMvtId();
 	const authStatus = useAuthStatus();
 	const isSignedIn =

--- a/dotcom-rendering/src/components/SlotBodyEnd.importable.tsx
+++ b/dotcom-rendering/src/components/SlotBodyEnd.importable.tsx
@@ -2,7 +2,8 @@ import type {
 	BrazeArticleContext,
 	BrazeMessagesInterface,
 } from '@guardian/braze-components/logic';
-import { getCookie } from '@guardian/libs';
+import type { CountryCode } from '@guardian/libs';
+import { getCookie, isString, isUndefined } from '@guardian/libs';
 import type { WeeklyArticleHistory } from '@guardian/support-dotcom-components/dist/dotcom/src/types';
 import { useEffect, useState } from 'react';
 import { getArticleCounts } from '../lib/articleCount';
@@ -62,7 +63,7 @@ const buildReaderRevenueEpicConfig = (
 
 const buildBrazeEpicConfig = (
 	brazeMessages: BrazeMessagesInterface,
-	countryCode: string,
+	countryCode: CountryCode,
 	idApiUrl: string,
 	contentType: string,
 	brazeArticleContext: BrazeArticleContext,
@@ -106,6 +107,20 @@ function getIsSignedIn(authStatus: AuthStatus): boolean | undefined {
 	}
 }
 
+const useBrowserId = () => {
+	const [browserId, setBrowserId] = useState<string>();
+
+	useEffect(() => {
+		const cookie = getCookie({ name: 'bwid', shouldMemoize: true });
+
+		const id = isString(cookie) ? cookie : 'no-browser-id-available';
+
+		setBrowserId(id);
+	}, []);
+
+	return browserId;
+};
+
 export const SlotBodyEnd = ({
 	contentType,
 	sectionId,
@@ -125,7 +140,7 @@ export const SlotBodyEnd = ({
 	const { brazeMessages } = useBraze(idApiUrl, renderingTarget);
 	const countryCode = useCountryCode('slot-body-end');
 	const isSignedIn = getIsSignedIn(useAuthStatus());
-	const browserId = getCookie({ name: 'bwid', shouldMemoize: true });
+	const browserId = useBrowserId();
 	const [SelectedEpic, setSelectedEpic] = useState<
 		React.ElementType | null | undefined
 	>();
@@ -148,6 +163,8 @@ export const SlotBodyEnd = ({
 	}, [pageId, keywordIds]);
 
 	useOnce(() => {
+		if (isUndefined(countryCode)) return;
+
 		const readerRevenueEpic = buildReaderRevenueEpicConfig({
 			isSignedIn,
 			countryCode,
@@ -163,14 +180,14 @@ export const SlotBodyEnd = ({
 			asyncArticleCount: asyncArticleCount as Promise<
 				WeeklyArticleHistory | undefined
 			>,
-			browserId: browserId ?? undefined,
+			browserId,
 		});
 		const brazeArticleContext: BrazeArticleContext = {
 			section: sectionId,
 		};
 		const brazeEpic = buildBrazeEpicConfig(
 			brazeMessages as BrazeMessagesInterface,
-			countryCode as string,
+			countryCode,
 			idApiUrl,
 			contentType,
 			brazeArticleContext,
@@ -187,7 +204,7 @@ export const SlotBodyEnd = ({
 			.catch((e) =>
 				console.error(`SlotBodyEnd pickMessage - error: ${String(e)}`),
 			);
-	}, [isSignedIn, countryCode, brazeMessages, asyncArticleCount]);
+	}, [isSignedIn, countryCode, brazeMessages, asyncArticleCount, browserId]);
 
 	useEffect(() => {
 		if (SelectedEpic === null && showArticleEndSlot) {

--- a/dotcom-rendering/src/components/SlotBodyEnd.importable.tsx
+++ b/dotcom-rendering/src/components/SlotBodyEnd.importable.tsx
@@ -6,7 +6,6 @@ import { getCookie } from '@guardian/libs';
 import type { WeeklyArticleHistory } from '@guardian/support-dotcom-components/dist/dotcom/src/types';
 import { useEffect, useState } from 'react';
 import { getArticleCounts } from '../lib/articleCount';
-import { getLocaleCode } from '../lib/getCountryCode';
 import type {
 	CandidateConfig,
 	MaybeFC,
@@ -15,6 +14,7 @@ import type {
 import { pickMessage } from '../lib/messagePicker';
 import { type AuthStatus, useAuthStatus } from '../lib/useAuthStatus';
 import { useBraze } from '../lib/useBraze';
+import { useCountryCode } from '../lib/useCountryCode';
 import { useOnce } from '../lib/useOnce';
 import type { TagType } from '../types/tag';
 import { AdSlot } from './AdSlot.web';
@@ -123,7 +123,7 @@ export const SlotBodyEnd = ({
 }: Props) => {
 	const { renderingTarget } = useConfig();
 	const { brazeMessages } = useBraze(idApiUrl, renderingTarget);
-	const [countryCode, setCountryCode] = useState<string>();
+	const countryCode = useCountryCode('slot-body-end');
 	const isSignedIn = getIsSignedIn(useAuthStatus());
 	const browserId = getCookie({ name: 'bwid', shouldMemoize: true });
 	const [SelectedEpic, setSelectedEpic] = useState<
@@ -138,19 +138,6 @@ export const SlotBodyEnd = ({
 		!isLabs &&
 		countryCode === 'US' &&
 		window.guardian.config.switches.articleEndSlot;
-
-	useEffect(() => {
-		const callFetch = () => {
-			getLocaleCode()
-				.then((cc) => {
-					setCountryCode(cc ?? '');
-				})
-				.catch((e) =>
-					console.error(`countryCodePromise - error: ${String(e)}`),
-				);
-		};
-		callFetch();
-	}, []);
 
 	useEffect(() => {
 		setAsyncArticleCount(

--- a/dotcom-rendering/src/components/StickyBottomBanner.importable.tsx
+++ b/dotcom-rendering/src/components/StickyBottomBanner.importable.tsx
@@ -8,7 +8,6 @@ import { useEffect, useState } from 'react';
 import { getAlreadyVisitedCount } from '../lib/alreadyVisited';
 import { getArticleCounts } from '../lib/articleCount';
 import type { ArticleCounts } from '../lib/articleCount';
-import { getLocaleCode } from '../lib/getCountryCode';
 import type {
 	CandidateConfig,
 	MaybeFC,
@@ -17,6 +16,7 @@ import type {
 import { pickMessage } from '../lib/messagePicker';
 import { useAuthStatus } from '../lib/useAuthStatus';
 import { useBraze } from '../lib/useBraze';
+import { useCountryCode } from '../lib/useCountryCode';
 import { useOnce } from '../lib/useOnce';
 import { useSignInGateWillShow } from '../lib/useSignInGateWillShow';
 import type { TagType } from '../types/tag';
@@ -211,25 +211,6 @@ const buildBrazeBanner = (
 	timeoutMillis: DEFAULT_BANNER_TIMEOUT_MILLIS,
 });
 
-const useCountryCode = (): CountryCode | undefined => {
-	const [localeCode, setLocaleCode] = useState<CountryCode | null>(null);
-	useEffect(() => {
-		getLocaleCode()
-			.then((code) => {
-				setLocaleCode(code);
-			})
-			.catch((e) => {
-				const msg = `Error fetching country code: ${String(e)}`;
-				window.guardian.modules.sentry.reportError(
-					new Error(msg),
-					'liveblog-epic',
-				);
-			});
-	}, []);
-
-	return localeCode ?? undefined;
-};
-
 /**
  * The reader revenue banner at the end of articles
  *
@@ -264,7 +245,7 @@ export const StickyBottomBanner = ({
 	const { renderingTarget } = useConfig();
 	const { brazeMessages } = useBraze(idApiUrl, renderingTarget);
 
-	const countryCode = useCountryCode();
+	const countryCode = useCountryCode('sticky-bottom-banner');
 	const authStatus = useAuthStatus();
 	const isSignedIn =
 		authStatus.kind === 'SignedInWithOkta' ||

--- a/dotcom-rendering/src/lib/useCountryCode.ts
+++ b/dotcom-rendering/src/lib/useCountryCode.ts
@@ -1,0 +1,23 @@
+import { type CountryCode, isNonNullable } from '@guardian/libs';
+import { useEffect, useState } from 'react';
+import { getLocaleCode } from './getCountryCode';
+
+export const useCountryCode = (feature: string): CountryCode | undefined => {
+	const [countryCode, setCountryCode] = useState<CountryCode>();
+
+	useEffect(() => {
+		getLocaleCode()
+			.then((cc) => {
+				if (isNonNullable(cc)) setCountryCode(cc);
+			})
+			.catch((e) => {
+				const msg = `Error fetching country code: ${String(e)}`;
+				window.guardian.modules.sentry.reportError(
+					new Error(msg),
+					feature,
+				);
+			});
+	}, [feature]);
+
+	return countryCode;
+};


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Make `SlotBodyEnd` server-safe using `useEffect` hooks for methods that rely on the global `document` or `window`.

## Why?

No assumption should be made about where components are run

- Split out from #8991 for easier review
- Enables the work from #8948 to proceed safely.

## Screenshots

N/A