### PR TITLE
Only report on “web” bundle size

### DIFF
--- a/.github/workflows/compress.yml
+++ b/.github/workflows/compress.yml
@@ -7,8 +7,8 @@ permissions:
 on:
   pull_request:
     paths-ignore:
-      - "apps-rendering/**"
-      - "dotcom-rendering/docs/**"
+      - 'apps-rendering/**'
+      - 'dotcom-rendering/docs/**'
 
 jobs:
   compressed_size:
@@ -25,7 +25,7 @@ jobs:
 
       - uses: preactjs/compressed-size-action@v2
         with:
-          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          repo-token: '${{ secrets.GITHUB_TOKEN }}'
           build-script: build:dcr
 
           # https://github.com/preactjs/compressed-size-action#increasing-the-required-threshold
@@ -35,6 +35,6 @@ jobs:
           # The default hash digest is set to 20 chars in Webpack
           strip-hash: "\\.(\\w{20})\\.js$"
 
-          # reporting on “legacy” and “variant” bundles muddies the water
+          # report exclusively on the “web” bundle – no “apps”, “variant” or other
           # https://github.com/preactjs/compressed-size-action#customizing-the-list-of-files
-          pattern: "dotcom-rendering/dist/*.web.*.js"
+          pattern: 'dotcom-rendering/dist/*.web.????????????????????.js'

--- a/.github/workflows/compress.yml
+++ b/.github/workflows/compress.yml
@@ -37,4 +37,5 @@ jobs:
 
           # report exclusively on the “web” bundle – no “apps”, “variant” or other
           # https://github.com/preactjs/compressed-size-action#customizing-the-list-of-files
+          # The default hash digest is set to 20 chars in Webpack
           pattern: 'dotcom-rendering/dist/*.web.????????????????????.js'


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Stop reporting on `web.legacy` or `web.variant` or other bundles.

## Why?

It muddies the water.

## Screenshots

N/A – see comment below from Github Action, and compare [with a previous one](https://github.com/guardian/dotcom-rendering/pull/9313#issuecomment-1779042559).