### PR TITLE
prep identity and useAuthStatus modules for user-features addition 

### DIFF
--- a/dotcom-rendering/src/components/Discussion/AbuseReportForm.tsx
+++ b/dotcom-rendering/src/components/Discussion/AbuseReportForm.tsx
@@ -5,10 +5,7 @@ import { Button, SvgCross } from '@guardian/source-react-components';
 import { useEffect, useRef, useState } from 'react';
 import { decidePalette } from '../../lib/decidePalette';
 import { reportAbuse } from '../../lib/discussionApi';
-import type {
-	SignedInWithCookies,
-	SignedInWithOkta,
-} from '../../lib/useAuthStatus';
+import type { SignedInWithCookies, SignedInWithOkta } from '../../lib/identity';
 
 type FormData = {
 	categoryId: number;

--- a/dotcom-rendering/src/components/Discussion/RecommendationCount.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/RecommendationCount.stories.tsx
@@ -1,4 +1,4 @@
-import type { SignedInWithCookies } from '../../lib/useAuthStatus';
+import type { SignedInWithCookies } from '../../lib/identity';
 import { RecommendationCount } from './RecommendationCount';
 
 export default { title: 'Discussion/RecommendationCount' };

--- a/dotcom-rendering/src/components/Discussion/RecommendationCount.tsx
+++ b/dotcom-rendering/src/components/Discussion/RecommendationCount.tsx
@@ -3,10 +3,7 @@ import { brand, neutral, textSans } from '@guardian/source-foundations';
 import { SvgArrowUpStraight } from '@guardian/source-react-components';
 import { useState } from 'react';
 import { recommend as recommendDefault } from '../../lib/discussionApi';
-import type {
-	SignedInWithCookies,
-	SignedInWithOkta,
-} from '../../lib/useAuthStatus';
+import type { SignedInWithCookies, SignedInWithOkta } from '../../lib/identity';
 import { Row } from './Row';
 
 type Props = {

--- a/dotcom-rendering/src/components/Discussion/TopPick.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/TopPick.stories.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
-import type { SignedInWithCookies } from '../../lib/useAuthStatus';
+import type { SignedInWithCookies } from '../../lib/identity';
 import type { CommentType } from '../../types/discussion';
 import { TopPick } from './TopPick';
 

--- a/dotcom-rendering/src/components/Discussion/TopPick.tsx
+++ b/dotcom-rendering/src/components/Discussion/TopPick.tsx
@@ -8,10 +8,7 @@ import {
 } from '@guardian/source-foundations';
 import { Link } from '@guardian/source-react-components';
 import { decidePalette } from '../../lib/decidePalette';
-import type {
-	SignedInWithCookies,
-	SignedInWithOkta,
-} from '../../lib/useAuthStatus';
+import type { SignedInWithCookies, SignedInWithOkta } from '../../lib/identity';
 import type { CommentType } from '../../types/discussion';
 import { Avatar } from './Avatar';
 import { GuardianContributor, GuardianStaff } from './Badges';

--- a/dotcom-rendering/src/components/Discussion/TopPicks.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/TopPicks.stories.tsx
@@ -1,5 +1,5 @@
 import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
-import type { SignedInWithCookies } from '../../lib/useAuthStatus';
+import type { SignedInWithCookies } from '../../lib/identity';
 import type { CommentType } from '../../types/discussion';
 import { TopPicks } from './TopPicks';
 

--- a/dotcom-rendering/src/components/Discussion/TopPicks.tsx
+++ b/dotcom-rendering/src/components/Discussion/TopPicks.tsx
@@ -1,9 +1,6 @@
 import { css } from '@emotion/react';
 import { from, until } from '@guardian/source-foundations';
-import type {
-	SignedInWithCookies,
-	SignedInWithOkta,
-} from '../../lib/useAuthStatus';
+import type { SignedInWithCookies, SignedInWithOkta } from '../../lib/identity';
 import type { CommentType, UserProfile } from '../../types/discussion';
 import { TopPick } from './TopPick';
 

--- a/dotcom-rendering/src/components/DiscussionMeta.importable.tsx
+++ b/dotcom-rendering/src/components/DiscussionMeta.importable.tsx
@@ -1,7 +1,8 @@
 import { joinUrl } from '@guardian/libs';
 import { decidePalette } from '../lib/decidePalette';
+import { getOptionsHeadersWithOkta } from '../lib/identity';
 import { useApi } from '../lib/useApi';
-import { getOptionsHeadersWithOkta, useAuthStatus } from '../lib/useAuthStatus';
+import { useAuthStatus } from '../lib/useAuthStatus';
 import { useDiscussion } from '../lib/useDiscussion';
 import { SignedInAs } from './SignedInAs';
 

--- a/dotcom-rendering/src/components/DiscussionWhenSignedIn.tsx
+++ b/dotcom-rendering/src/components/DiscussionWhenSignedIn.tsx
@@ -1,10 +1,7 @@
 import { joinUrl } from '@guardian/libs';
+import { getOptionsHeadersWithOkta } from '../lib/identity';
+import type { SignedInWithCookies, SignedInWithOkta } from '../lib/identity';
 import { useApi } from '../lib/useApi';
-import type {
-	SignedInWithCookies,
-	SignedInWithOkta,
-} from '../lib/useAuthStatus';
-import { getOptionsHeadersWithOkta } from '../lib/useAuthStatus';
 import type { Props as DiscussionProps } from './Discussion';
 import { Discussion } from './Discussion';
 

--- a/dotcom-rendering/src/components/HeaderTopBarMyAccount.stories.tsx
+++ b/dotcom-rendering/src/components/HeaderTopBarMyAccount.stories.tsx
@@ -1,4 +1,4 @@
-import type { AuthStatus } from '../lib/useAuthStatus';
+import type { AuthStatus } from '../lib/identity';
 import { MyAccount } from './HeaderTopBarMyAccount';
 
 export default {

--- a/dotcom-rendering/src/components/HeaderTopBarMyAccount.tsx
+++ b/dotcom-rendering/src/components/HeaderTopBarMyAccount.tsx
@@ -3,6 +3,11 @@ import { joinUrl } from '@guardian/libs';
 import { brand, from, neutral, textSans } from '@guardian/source-foundations';
 import { useEffect, useState } from 'react';
 import { getZIndex } from '../lib/getZIndex';
+import type {
+	AuthStatus,
+	SignedInWithCookies,
+	SignedInWithOkta,
+} from '../lib/identity';
 import { createAuthenticationEventParams } from '../lib/identity-component-event';
 import {
 	addNotificationsToDropdownLinks,
@@ -11,11 +16,6 @@ import {
 import type { Notification } from '../lib/notification';
 import { nestedOphanComponents } from '../lib/ophan-helpers';
 import { useApi } from '../lib/useApi';
-import type {
-	AuthStatus,
-	SignedInWithCookies,
-	SignedInWithOkta,
-} from '../lib/useAuthStatus';
 import { useBraze } from '../lib/useBraze';
 import ProfileIcon from '../static/icons/profile.svg';
 import type { RenderingTarget } from '../types/renderingTarget';

--- a/dotcom-rendering/src/components/SlotBodyEnd.importable.tsx
+++ b/dotcom-rendering/src/components/SlotBodyEnd.importable.tsx
@@ -7,13 +7,14 @@ import { getCookie, isString, isUndefined } from '@guardian/libs';
 import type { WeeklyArticleHistory } from '@guardian/support-dotcom-components/dist/dotcom/src/types';
 import { useEffect, useState } from 'react';
 import { getArticleCounts } from '../lib/articleCount';
+import type { AuthStatus } from '../lib/identity';
 import type {
 	CandidateConfig,
 	MaybeFC,
 	SlotConfig,
 } from '../lib/messagePicker';
 import { pickMessage } from '../lib/messagePicker';
-import { type AuthStatus, useAuthStatus } from '../lib/useAuthStatus';
+import { useAuthStatus } from '../lib/useAuthStatus';
 import { useBraze } from '../lib/useBraze';
 import { useCountryCode } from '../lib/useCountryCode';
 import { useOnce } from '../lib/useOnce';

--- a/dotcom-rendering/src/components/SlotBodyEnd/BrazeEpic.tsx
+++ b/dotcom-rendering/src/components/SlotBodyEnd/BrazeEpic.tsx
@@ -9,11 +9,9 @@ import { submitComponentEvent } from '../../client/ophan/ophan';
 import { getBrazeMetaFromUrlFragment } from '../../lib/braze/forceBrazeMessage';
 import { suppressForTaylorReport } from '../../lib/braze/taylorReport';
 import { lazyFetchEmailWithTimeout } from '../../lib/contributions';
+import { getOptionsHeadersWithOkta } from '../../lib/identity';
 import type { CanShowResult } from '../../lib/messagePicker';
-import {
-	getOptionsHeadersWithOkta,
-	useAuthStatus,
-} from '../../lib/useAuthStatus';
+import { useAuthStatus } from '../../lib/useAuthStatus';
 import { useIsInView } from '../../lib/useIsInView';
 import { useOnce } from '../../lib/useOnce';
 import type { TagType } from '../../types/tag';

--- a/dotcom-rendering/src/components/StickyBottomBanner/BrazeBanner.tsx
+++ b/dotcom-rendering/src/components/StickyBottomBanner/BrazeBanner.tsx
@@ -10,11 +10,9 @@ import { getBrazeMetaFromUrlFragment } from '../../lib/braze/forceBrazeMessage';
 import { suppressForTaylorReport } from '../../lib/braze/taylorReport';
 import { lazyFetchEmailWithTimeout } from '../../lib/contributions';
 import { getZIndex } from '../../lib/getZIndex';
+import { getOptionsHeadersWithOkta } from '../../lib/identity';
 import type { CanShowResult } from '../../lib/messagePicker';
-import {
-	getOptionsHeadersWithOkta,
-	useAuthStatus,
-} from '../../lib/useAuthStatus';
+import { useAuthStatus } from '../../lib/useAuthStatus';
 import type { TagType } from '../../types/tag';
 import { useConfig } from '../ConfigContext';
 

--- a/dotcom-rendering/src/components/SupportTheG.importable.tsx
+++ b/dotcom-rendering/src/components/SupportTheG.importable.tsx
@@ -31,9 +31,9 @@ import {
 } from '../lib/contributions';
 import type { EditionId } from '../lib/edition';
 import { getLocaleCode } from '../lib/getCountryCode';
+import type { AuthStatus } from '../lib/identity';
 import { nestedOphanComponents } from '../lib/ophan-helpers';
 import { setAutomat } from '../lib/setAutomat';
-import type { AuthStatus } from '../lib/useAuthStatus';
 import { useAuthStatus } from '../lib/useAuthStatus';
 import { useIsInView } from '../lib/useIsInView';
 import { useOnce } from '../lib/useOnce';

--- a/dotcom-rendering/src/lib/contributions.ts
+++ b/dotcom-rendering/src/lib/contributions.ts
@@ -6,8 +6,7 @@ import type { DCRFrontType } from '../types/front';
 import type { DCRArticle } from '../types/frontend';
 import type { IdApiUserData } from './getIdapiUserData';
 import { getIdApiUserData } from './getIdapiUserData';
-import { eitherInOktaTestOrElse } from './useAuthStatus';
-
+import { eitherInOktaTestOrElse } from './identity';
 // User Atributes API cookies (dropped on sign-in)
 export const HIDE_SUPPORT_MESSAGING_COOKIE = 'gu_hide_support_messaging';
 export const RECURRING_CONTRIBUTOR_COOKIE = 'gu_recurring_contributor';

--- a/dotcom-rendering/src/lib/discussionApi.tsx
+++ b/dotcom-rendering/src/lib/discussionApi.tsx
@@ -9,8 +9,8 @@ import type {
 	ThreadsType,
 	UserNameResponse,
 } from '../types/discussion';
-import type { SignedInWithCookies, SignedInWithOkta } from './useAuthStatus';
-import { getOptionsHeadersWithOkta } from './useAuthStatus';
+import type { SignedInWithCookies, SignedInWithOkta } from './identity';
+import { getOptionsHeadersWithOkta } from './identity';
 
 const options = {
 	// Defaults

--- a/dotcom-rendering/src/lib/getBrazeUuid.ts
+++ b/dotcom-rendering/src/lib/getBrazeUuid.ts
@@ -1,6 +1,6 @@
 import type { IdApiUserIdentifiers } from './getIdapiUserData';
 import { getIdapiUserIdentifiers } from './getIdapiUserData';
-import { eitherInOktaTestOrElse } from './useAuthStatus';
+import { eitherInOktaTestOrElse } from './identity';
 
 export const getBrazeUuid = async (ajaxUrl: string): Promise<string | void> =>
 	// TODO Okta: Remove either when at 100% in oktaVariant test, and just use idToken

--- a/dotcom-rendering/src/lib/identity.ts
+++ b/dotcom-rendering/src/lib/identity.ts
@@ -76,27 +76,32 @@ const getUserFromCookie = (): IdentityUserFromCache => {
 		const cookieData = getCookie({ name: 'GU_U', shouldMemoize: true });
 
 		if (cookieData) {
-			const userData = JSON.parse(
-				decodeBase64(cookieData.split('.')[0] ?? ''),
-			) as string[];
+			try {
+				const userData = JSON.parse(
+					decodeBase64(cookieData.split('.')[0] ?? ''),
+				) as string[];
 
-			const id = parseInt(userData[0] ?? '', 10);
-			const displayName = decodeURIComponent(userData[2] ?? '');
-			const accountCreatedDate = userData[6];
-			const userEmailValidated = Boolean(userData[7]);
+				const id = parseInt(userData[0] ?? '', 10);
+				const displayName = decodeURIComponent(userData[2] ?? '');
+				const accountCreatedDate = userData[6];
+				const userEmailValidated = Boolean(userData[7]);
 
-			if (id && accountCreatedDate) {
-				userFromCookieCache = {
-					id,
-					publicFields: {
-						displayName,
-					},
-					dates: { accountCreatedDate },
-					statusFields: {
-						userEmailValidated,
-					},
-					rawResponse: cookieData,
-				};
+				if (id && accountCreatedDate) {
+					userFromCookieCache = {
+						id,
+						publicFields: {
+							displayName,
+						},
+						dates: { accountCreatedDate },
+						statusFields: {
+							userEmailValidated,
+						},
+						rawResponse: cookieData,
+					};
+				}
+			} catch (e) {
+				// eslint-disable-next-line no-console -- we want to log the error to console, not Sentry
+				console.error('Error parsing GU_U cookie', e);
 			}
 		}
 	}

--- a/dotcom-rendering/src/lib/identity.ts
+++ b/dotcom-rendering/src/lib/identity.ts
@@ -61,8 +61,7 @@ type IdentityUserFromCache = {
 } | null;
 
 let userFromCookieCache: IdentityUserFromCache = null;
-const cookieName = 'GU_U';
-const getUserCookie = (): string | null => getCookie({ name: cookieName });
+
 const decodeBase64 = (str: string): string =>
 	decodeURIComponent(
 		escape(
@@ -74,7 +73,7 @@ const decodeBase64 = (str: string): string =>
 
 const getUserFromCookie = (): IdentityUserFromCache => {
 	if (userFromCookieCache === null) {
-		const cookieData = getUserCookie();
+		const cookieData = getCookie({ name: 'GU_U', shouldMemoize: true });
 
 		if (cookieData) {
 			const userData = JSON.parse(

--- a/dotcom-rendering/src/lib/identity.ts
+++ b/dotcom-rendering/src/lib/identity.ts
@@ -1,5 +1,11 @@
-import type { CustomClaims, IdentityAuthState } from '@guardian/identity-auth';
+import type {
+	AccessToken,
+	CustomClaims,
+	IdentityAuthState,
+	IDToken,
+} from '@guardian/identity-auth';
 import { getIdentityAuth } from '@guardian/identity-auth-frontend';
+import { getCookie } from '@guardian/libs';
 
 export type CustomIdTokenClaims = CustomClaims & {
 	email: string;
@@ -22,3 +28,159 @@ export async function isSignedInWithOktaAuthState(): Promise<
 			};
 		});
 }
+
+type OktaAuthState = IdentityAuthState<never, CustomIdTokenClaims>;
+
+type SignedOutWithCookies = { kind: 'SignedOutWithCookies' };
+export type SignedInWithCookies = { kind: 'SignedInWithCookies' };
+type SignedOutWithOkta = { kind: 'SignedOutWithOkta' };
+export type SignedInWithOkta = {
+	kind: 'SignedInWithOkta';
+	accessToken: AccessToken<never>;
+	idToken: IDToken<CustomIdTokenClaims>;
+};
+
+export type AuthStatus =
+	| { kind: 'Pending' }
+	| SignedOutWithCookies
+	| SignedInWithCookies
+	| SignedOutWithOkta
+	| SignedInWithOkta;
+
+// relates to getUserFromCookie() below but not used in user-features - however may be useful for other purposes
+type IdentityUserFromCache = {
+	dates: { accountCreatedDate: string };
+	publicFields: {
+		displayName: string;
+	};
+	statusFields: {
+		userEmailValidated: boolean;
+	};
+	id: number;
+	rawResponse: string;
+} | null;
+
+let userFromCookieCache: IdentityUserFromCache = null;
+const cookieName = 'GU_U';
+const getUserCookie = (): string | null => getCookie({ name: cookieName });
+const decodeBase64 = (str: string): string =>
+	decodeURIComponent(
+		escape(
+			window.atob(
+				str.replace(/-/g, '+').replace(/_/g, '/').replace(/,/g, '='),
+			),
+		),
+	);
+
+const getUserFromCookie = (): IdentityUserFromCache => {
+	if (userFromCookieCache === null) {
+		const cookieData = getUserCookie();
+
+		if (cookieData) {
+			const userData = JSON.parse(
+				decodeBase64(cookieData.split('.')[0] ?? ''),
+			) as string[];
+
+			const id = parseInt(userData[0] ?? '', 10);
+			const displayName = decodeURIComponent(userData[2] ?? '');
+			const accountCreatedDate = userData[6];
+			const userEmailValidated = Boolean(userData[7]);
+
+			if (id && accountCreatedDate) {
+				userFromCookieCache = {
+					id,
+					publicFields: {
+						displayName,
+					},
+					dates: { accountCreatedDate },
+					statusFields: {
+						userEmailValidated,
+					},
+					rawResponse: cookieData,
+				};
+			}
+		}
+	}
+
+	return userFromCookieCache;
+};
+
+export const isUserLoggedIn = (): boolean => getUserFromCookie() !== null;
+
+export const getOptionsHeadersWithOkta = (
+	authStatus: SignedInWithCookies | SignedInWithOkta,
+): RequestInit => {
+	if (authStatus.kind === 'SignedInWithCookies') {
+		return {
+			credentials: 'include',
+		};
+	}
+
+	return {
+		headers: {
+			Authorization: `Bearer ${authStatus.accessToken.accessToken}`,
+			'X-GU-IS-OAUTH': 'true',
+		},
+	};
+};
+
+export async function getAuthState(): Promise<OktaAuthState> {
+	const authState = await isSignedInWithOktaAuthState();
+	return authState;
+}
+
+export async function eitherInOktaTestOrElse<A, B>(
+	inOktaTestFunction: (authState: OktaAuthState) => A,
+	notInOktaTestFunction: () => B,
+): Promise<A | B> {
+	const useOkta = !!window.guardian.config.switches.okta;
+
+	if (useOkta) {
+		const authState = await getAuthState();
+		return inOktaTestFunction(authState);
+	} else {
+		return notInOktaTestFunction();
+	}
+}
+
+export function getSignedInStatusWithOkta(
+	authState: OktaAuthState,
+): SignedOutWithOkta | SignedInWithOkta {
+	if (authState.isAuthenticated) {
+		return {
+			kind: 'SignedInWithOkta',
+			accessToken: authState.accessToken,
+			idToken: authState.idToken,
+		};
+	}
+
+	return { kind: 'SignedOutWithOkta' };
+}
+
+export const isUserLoggedInOktaRefactor = (): Promise<boolean> =>
+	getAuthStatus().then((authStatus) =>
+		authStatus.kind === 'SignedInWithCookies' ||
+		authStatus.kind === 'SignedInWithOkta'
+			? true
+			: false,
+	);
+
+export function getSignedInStatusWithCookies():
+	| SignedOutWithCookies
+	| SignedInWithCookies {
+	const GU_UCookie = getCookie({ name: 'GU_U', shouldMemoize: true });
+	return GU_UCookie === null || GU_UCookie === ''
+		? { kind: 'SignedOutWithCookies' }
+		: { kind: 'SignedInWithCookies' };
+}
+
+export const getAuthStatus = async (): Promise<AuthStatus> => {
+	const useOkta = !!window.guardian.config.switches.okta;
+
+	if (useOkta) {
+		const authState = await getAuthState();
+		return getSignedInStatusWithOkta(authState);
+	} else {
+		return getSignedInStatusWithCookies();
+	}
+};

--- a/dotcom-rendering/src/lib/identity.ts
+++ b/dotcom-rendering/src/lib/identity.ts
@@ -61,6 +61,9 @@ type IdentityUserFromCache = {
 } | null;
 
 let userFromCookieCache: IdentityUserFromCache = null;
+const cookieName = 'GU_U';
+const getUserCookie = (): string | null =>
+	getCookie({ name: cookieName, shouldMemoize: true });
 
 const decodeBase64 = (str: string): string =>
 	decodeURIComponent(
@@ -73,7 +76,7 @@ const decodeBase64 = (str: string): string =>
 
 const getUserFromCookie = (): IdentityUserFromCache => {
 	if (userFromCookieCache === null) {
-		const cookieData = getCookie({ name: 'GU_U', shouldMemoize: true });
+		const cookieData = getUserCookie();
 
 		if (cookieData) {
 			try {
@@ -101,7 +104,7 @@ const getUserFromCookie = (): IdentityUserFromCache => {
 				}
 			} catch (e) {
 				// eslint-disable-next-line no-console -- we want to log the error to console, not Sentry
-				console.error('Error parsing GU_U cookie', e);
+				console.error('Cookie value is malformed', e);
 			}
 		}
 	}
@@ -172,7 +175,7 @@ export const isUserLoggedInOktaRefactor = (): Promise<boolean> =>
 export function getSignedInStatusWithCookies():
 	| SignedOutWithCookies
 	| SignedInWithCookies {
-	const GU_UCookie = getCookie({ name: 'GU_U', shouldMemoize: true });
+	const GU_UCookie = getUserCookie();
 	return GU_UCookie === null || GU_UCookie === ''
 		? { kind: 'SignedOutWithCookies' }
 		: { kind: 'SignedInWithCookies' };

--- a/dotcom-rendering/src/lib/useAuthStatus.ts
+++ b/dotcom-rendering/src/lib/useAuthStatus.ts
@@ -1,89 +1,10 @@
-import type {
-	AccessToken,
-	IdentityAuthState,
-	IDToken,
-} from '@guardian/identity-auth';
-import { getCookie } from '@guardian/libs';
 import { useEffect, useState } from 'react';
-import type { CustomIdTokenClaims } from './identity';
-
-type OktaAuthState = IdentityAuthState<never, CustomIdTokenClaims>;
-
-type SignedOutWithCookies = { kind: 'SignedOutWithCookies' };
-export type SignedInWithCookies = { kind: 'SignedInWithCookies' };
-type SignedOutWithOkta = { kind: 'SignedOutWithOkta' };
-export type SignedInWithOkta = {
-	kind: 'SignedInWithOkta';
-	accessToken: AccessToken<never>;
-	idToken: IDToken<CustomIdTokenClaims>;
-};
-
-export type AuthStatus =
-	| { kind: 'Pending' }
-	| SignedOutWithCookies
-	| SignedInWithCookies
-	| SignedOutWithOkta
-	| SignedInWithOkta;
-
-export const getOptionsHeadersWithOkta = (
-	authStatus: SignedInWithCookies | SignedInWithOkta,
-): RequestInit => {
-	if (authStatus.kind === 'SignedInWithCookies') {
-		return {
-			credentials: 'include',
-		};
-	}
-
-	return {
-		headers: {
-			Authorization: `Bearer ${authStatus.accessToken.accessToken}`,
-			'X-GU-IS-OAUTH': 'true',
-		},
-	};
-};
-
-export async function getAuthState(): Promise<OktaAuthState> {
-	const { isSignedInWithOktaAuthState } = await import('./identity');
-	const authState = await isSignedInWithOktaAuthState();
-	return authState;
-}
-
-export async function eitherInOktaTestOrElse<A, B>(
-	inOktaTestFunction: (authState: OktaAuthState) => A,
-	notInOktaTestFunction: () => B,
-): Promise<A | B> {
-	const useOkta = !!window.guardian.config.switches.okta;
-
-	if (useOkta) {
-		const authState = await getAuthState();
-		return inOktaTestFunction(authState);
-	} else {
-		return notInOktaTestFunction();
-	}
-}
-
-function getSignedInStatusWithOkta(
-	authState: OktaAuthState,
-): SignedOutWithOkta | SignedInWithOkta {
-	if (authState.isAuthenticated) {
-		return {
-			kind: 'SignedInWithOkta',
-			accessToken: authState.accessToken,
-			idToken: authState.idToken,
-		};
-	}
-
-	return { kind: 'SignedOutWithOkta' };
-}
-
-function getSignedInStatusWithCookies():
-	| SignedOutWithCookies
-	| SignedInWithCookies {
-	const GU_UCookie = getCookie({ name: 'GU_U', shouldMemoize: true });
-	return GU_UCookie === null || GU_UCookie === ''
-		? { kind: 'SignedOutWithCookies' }
-		: { kind: 'SignedInWithCookies' };
-}
+import type { AuthStatus } from './identity';
+import {
+	eitherInOktaTestOrElse,
+	getSignedInStatusWithCookies,
+	getSignedInStatusWithOkta,
+} from './identity';
 
 export const useAuthStatus = (): AuthStatus => {
 	const [authStatus, setAuthStatus] = useState<AuthStatus>({

--- a/dotcom-rendering/src/model/guardian.ts
+++ b/dotcom-rendering/src/model/guardian.ts
@@ -34,6 +34,7 @@ export interface Guardian {
 			isPaidContent?: boolean;
 			isDev?: boolean;
 			hasInlineMerchandise?: boolean;
+			userAttributesApiUrl?: string;
 		};
 		libs: {
 			googletag: string;

--- a/dotcom-rendering/src/types/discussion.ts
+++ b/dotcom-rendering/src/types/discussion.ts
@@ -1,9 +1,6 @@
 import type { Guard } from '../lib/guard';
 import { guard } from '../lib/guard';
-import type {
-	SignedInWithCookies,
-	SignedInWithOkta,
-} from '../lib/useAuthStatus';
+import type { SignedInWithCookies, SignedInWithOkta } from '../lib/identity';
 
 export type CAPIPillar =
 	| 'news'


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
This PR establishes the foundation for integrating the user-features functionality into this repository.

The user-features will be ported over in this PR: https://github.com/guardian/dotcom-rendering/pull/9362

#### Changes Made:
- Refactored existing functions, relocating them to the identity module for enhanced organisation and accessibility.
- Updated import paths for existing files for modules  in `DCR` that consume these functions.

## Why?
The ultimate aim is to handle the setting and getting of cookies, which ultimately looks to facilitate the user getting an ad free experience, we are setting supporter revenue cookies in commercial which would be better served in `dotcom-rendering`  (Move user-features out of the commercial bundle)

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
