### PR TITLE
add user features logic to dotcom

### DIFF
--- a/dotcom-rendering/cypress/e2e/parallel-6/user.features.cy.js
+++ b/dotcom-rendering/cypress/e2e/parallel-6/user.features.cy.js
@@ -1,9 +1,9 @@
-/* eslint-disable no-undef */
-/* eslint-disable func-names */
 import { Standard } from '../../fixtures/manual/standard-article';
+import { setLocalBaseUrl } from '../../lib/setLocalBaseUrl.js';
 
-const visitArticleNoOkta = () =>
-	cy.visit('http://localhost:9000/Article/', {
+const visitArticleNoOkta = () => {
+	setLocalBaseUrl();
+	cy.visit('/Article', {
 		method: 'POST',
 		body: JSON.stringify({
 			...Standard,
@@ -18,6 +18,7 @@ const visitArticleNoOkta = () =>
 					 */
 					okta: false,
 					idCookieRefresh: false,
+					userFeaturesDcr: true,
 				},
 			},
 		}),
@@ -25,6 +26,7 @@ const visitArticleNoOkta = () =>
 			'Content-Type': 'application/json',
 		},
 	});
+};
 
 describe('User cookies tests', function () {
 	it(`Request to user features API is sent when no user features expiry cookie`, function () {

--- a/dotcom-rendering/cypress/e2e/parallel-6/user.features.cy.js
+++ b/dotcom-rendering/cypress/e2e/parallel-6/user.features.cy.js
@@ -1,0 +1,83 @@
+/* eslint-disable no-undef */
+/* eslint-disable func-names */
+import { Standard } from '../../fixtures/manual/standard-article';
+
+const visitArticleNoOkta = () =>
+	cy.visit('http://localhost:9000/Article/', {
+		method: 'POST',
+		body: JSON.stringify({
+			...Standard,
+			config: {
+				...Standard.config,
+				switches: {
+					...Standard.config.switches,
+					/**
+					 * We want to continue using cookies for signed in features
+					 * until we figure out how to use Okta in Cypress.
+					 * See https://github.com/guardian/dotcom-rendering/issues/8758
+					 */
+					okta: false,
+					idCookieRefresh: false,
+				},
+			},
+		}),
+		headers: {
+			'Content-Type': 'application/json',
+		},
+	});
+
+describe('User cookies tests', function () {
+	it(`Request to user features API is sent when no user features expiry cookie`, function () {
+		cy.setCookie('GU_U', 'true', { log: true });
+
+		cy.intercept(
+			'https://members-data-api.theguardian.com/user-attributes/me',
+		).as('getUserFeatures');
+
+		visitArticleNoOkta();
+
+		cy.wait('@getUserFeatures', { timeout: 30000 });
+		cy.getCookie('GU_U').should('exist');
+	});
+
+	it(`Request to user features API is sent when user features cookie has expired`, function () {
+		cy.setCookie('GU_U', 'true', { log: true });
+
+		const currentTimestamp = new Date().getTime();
+		cy.clock(currentTimestamp); // Freeze time at a specific date
+		const expirationTimestamp = currentTimestamp - 24 * 60 * 60 * 1000; // 24 hours ago from now (frozen time)
+
+		cy.setCookie('gu_user_features_expiry', expirationTimestamp.toString());
+
+		cy.intercept(
+			'https://members-data-api.theguardian.com/user-attributes/me',
+		).as('getUserFeatures');
+
+		visitArticleNoOkta();
+
+		cy.wait('@getUserFeatures', { timeout: 30000 });
+	});
+
+	it(`Existing old cookie data is deleted when the user is signed out`, function () {
+		cy.setCookie('GU_U', 'true', { log: true });
+
+		// Setting various cookies to simulate deletion process
+		cy.clearCookie('GU_U', { log: true });
+
+		cy.setCookie('gu_user_features_expiry', 'true', { log: true });
+		cy.setCookie('GU_AF1', 'true', { log: true });
+		cy.setCookie('gu_paying_member', 'true', { log: true });
+		cy.setCookie('gu_digital_subscriber', 'true', { log: true });
+
+		cy.intercept(
+			'https://members-data-api.theguardian.com/user-attributes/me',
+		).as('getUserFeatures');
+
+		visitArticleNoOkta();
+
+		cy.getCookie('gu_user_features_expiry').should('not.exist');
+		cy.getCookie('GU_AF1').should('not.exist');
+		cy.getCookie('gu_paying_member').should('not.exist');
+		cy.getCookie('gu_digital_subscriber').should('not.exist');
+	});
+});

--- a/dotcom-rendering/src/client/main.web.ts
+++ b/dotcom-rendering/src/client/main.web.ts
@@ -94,6 +94,15 @@ void (async () => {
 		},
 	);
 
+	void startup(
+		'userFeatures',
+		() =>
+			import(/* webpackMode: 'eager' */ './userFeatures').then(
+				({ userFeatures }) => userFeatures(),
+			),
+		{ priority: 'critical' },
+	);
+
 	/*************************************************************
 	 *
 	 * The following modules are lazy loaded,

--- a/dotcom-rendering/src/client/main.web.ts
+++ b/dotcom-rendering/src/client/main.web.ts
@@ -94,14 +94,16 @@ void (async () => {
 		},
 	);
 
-	void startup(
-		'userFeatures',
-		() =>
-			import(
-				/* webpackMode: 'eager' */ './userFeatures/user-features'
-			).then(({ refresh }) => refresh()),
-		{ priority: 'critical' },
-	);
+	if (window.guardian.config.switches.userFeaturesDcr === true) {
+		void startup(
+			'userFeatures',
+			() =>
+				import(
+					/* webpackMode: 'eager' */ './userFeatures/user-features'
+				).then(({ refresh }) => refresh()),
+			{ priority: 'critical' },
+		);
+	}
 
 	/*************************************************************
 	 *

--- a/dotcom-rendering/src/client/main.web.ts
+++ b/dotcom-rendering/src/client/main.web.ts
@@ -97,9 +97,9 @@ void (async () => {
 	void startup(
 		'userFeatures',
 		() =>
-			import(/* webpackMode: 'eager' */ './userFeatures').then(
-				({ userFeatures }) => userFeatures(),
-			),
+			import(
+				/* webpackMode: 'eager' */ './userFeatures/user-features'
+			).then(({ refresh }) => refresh()),
 		{ priority: 'critical' },
 	);
 

--- a/dotcom-rendering/src/client/userFeatures/index.ts
+++ b/dotcom-rendering/src/client/userFeatures/index.ts
@@ -1,5 +1,0 @@
-import { refresh } from './user-features';
-
-export const userFeatures = async (): Promise<void> => {
-	await refresh(); // come to Promise structure
-};

--- a/dotcom-rendering/src/client/userFeatures/index.ts
+++ b/dotcom-rendering/src/client/userFeatures/index.ts
@@ -1,0 +1,5 @@
+import { refresh } from './user-features';
+
+export const userFeatures = async (): Promise<void> => {
+	await refresh(); // come to Promise structure
+};

--- a/dotcom-rendering/src/client/userFeatures/user-features-lib.ts
+++ b/dotcom-rendering/src/client/userFeatures/user-features-lib.ts
@@ -1,0 +1,170 @@
+import { getCookie, setCookie } from '@guardian/libs';
+
+const timeInDaysFromNow = (daysFromNow: number): string => {
+	const tmpDate = new Date();
+	tmpDate.setDate(tmpDate.getDate() + daysFromNow);
+	return tmpDate.getTime().toString();
+};
+
+const cookieIsExpiredOrMissing = (cookieName: string): boolean => {
+	const expiryDateFromCookie = getCookie({ name: cookieName });
+	if (!expiryDateFromCookie) return true;
+	const expiryTime = parseInt(expiryDateFromCookie, 10);
+	const timeNow = new Date().getTime();
+	return timeNow >= expiryTime;
+};
+
+const AD_FREE_USER_COOKIE = 'GU_AF1';
+
+const getAdFreeCookie = (): string | null =>
+	getCookie({ name: AD_FREE_USER_COOKIE });
+
+const adFreeDataIsPresent = (): boolean => {
+	const cookieVal = getAdFreeCookie();
+	if (!cookieVal) return false;
+	return !Number.isNaN(parseInt(cookieVal, 10));
+};
+
+/*
+ * Set the ad free cookie
+ *
+ * @param daysToLive - number of days the cookie should be valid
+ */
+const setAdFreeCookie = (daysToLive = 1): void => {
+	const expires = new Date();
+	expires.setMonth(expires.getMonth() + 6);
+	setCookie({
+		name: AD_FREE_USER_COOKIE,
+		value: expires.getTime().toString(),
+		daysToLive,
+	});
+};
+
+/**
+ * Check that path is a path-absolute-URL string as described in https://url.spec.whatwg.org/#path-absolute-url-string
+ * A path-absolute-URL string is U+002F (/) followed by a path-relative-URL string, for instance `/plop` or `/plop/plop`
+ */
+function isPathAbsoluteURL(path: string): boolean {
+	return !RegExp('^(https?:)?//').exec(path);
+}
+
+const fetchJson = async (
+	resource: string,
+	init: RequestInit = {},
+): Promise<unknown> => {
+	if (typeof resource !== 'string') {
+		throw new Error('First argument should be of type `string`');
+	}
+
+	let path = resource;
+	if (isPathAbsoluteURL(path)) {
+		path = window.guardian.config.page.ajaxUrl + resource;
+		init.mode = 'cors';
+	}
+
+	const resp = await fetch(path, init);
+	if (resp.ok) {
+		switch (resp.status) {
+			case 204:
+				return {};
+			default:
+				try {
+					return resp.json();
+				} catch (ex) {
+					throw new Error(
+						`Fetch error while requesting ${path}: Invalid JSON response`,
+					);
+				}
+		}
+	}
+	throw new Error(`Fetch error while requesting ${path}: ${resp.statusText}`);
+};
+
+const dates = {
+	1: '01',
+	2: '02',
+	3: '03',
+	4: '04',
+	5: '05',
+	6: '06',
+	7: '07',
+	8: '08',
+	9: '09',
+	10: '10',
+	11: '11',
+	12: '12',
+	13: '13',
+	14: '14',
+	15: '15',
+	16: '16',
+	17: '17',
+	18: '18',
+	19: '19',
+	20: '20',
+	21: '21',
+	22: '22',
+	23: '23',
+	24: '24',
+	25: '25',
+	26: '26',
+	27: '27',
+	28: '28',
+	29: '29',
+	30: '30',
+	31: '31',
+} as const;
+
+const months = {
+	1: '01',
+	2: '02',
+	3: '03',
+	4: '04',
+	5: '05',
+	6: '06',
+	7: '07',
+	8: '08',
+	9: '09',
+	10: '10',
+	11: '11',
+	12: '12',
+} as const;
+
+type LocalDate =
+	`${number}-${(typeof months)[keyof typeof months]}-${(typeof dates)[keyof typeof dates]}`;
+
+/**
+ * This type is manually kept in sync with the Membership API:
+ * https://github.com/guardian/members-data-api/blob/a48acdebed6a334ceb4336ece275b9cf9b3d6bb7/membership-attribute-service/app/models/Attributes.scala#L134-L151
+ */
+type UserFeaturesResponse = {
+	userId: string;
+	tier?: string;
+	recurringContributionPaymentPlan?: string;
+	oneOffContributionDate?: LocalDate;
+	membershipJoinDate?: LocalDate;
+	digitalSubscriptionExpiryDate?: LocalDate;
+	paperSubscriptionExpiryDate?: LocalDate;
+	guardianWeeklyExpiryDate?: LocalDate;
+	liveAppSubscriptionExpiryDate?: LocalDate;
+	alertAvailableFor?: string;
+	showSupportMessaging: boolean;
+	contentAccess: {
+		member: boolean;
+		paidMember: boolean;
+		recurringContributor: boolean;
+		digitalPack: boolean;
+		paperSubscriber: boolean;
+		guardianWeeklySubscriber: boolean;
+	};
+};
+
+export type { UserFeaturesResponse };
+
+export {
+	adFreeDataIsPresent,
+	cookieIsExpiredOrMissing,
+	fetchJson,
+	getAdFreeCookie,
+	setAdFreeCookie,
+	timeInDaysFromNow,
+};

--- a/dotcom-rendering/src/client/userFeatures/user-features-lib.ts
+++ b/dotcom-rendering/src/client/userFeatures/user-features-lib.ts
@@ -1,3 +1,9 @@
+/**
+ * @file Sets the user subscription and ad free cookies
+ * This file was migrated from:
+ * https://github.com/guardian/commercial/blob/1a429d6be05657f20df4ca909df7d01a5c3d7402/src/lib/user-features.ts
+ */
+
 import { getCookie, setCookie } from '@guardian/libs';
 
 const timeInDaysFromNow = (daysFromNow: number): string => {

--- a/dotcom-rendering/src/client/userFeatures/user-features.test.ts
+++ b/dotcom-rendering/src/client/userFeatures/user-features.test.ts
@@ -1,0 +1,349 @@
+import { getCookie, removeCookie, setCookie } from '@guardian/libs';
+import type { AuthStatus } from '../../lib/identity';
+import {
+	getAuthStatus as getAuthStatus_,
+	isUserLoggedInOktaRefactor as isUserLoggedInOktaRefactor_,
+} from '../../lib/identity';
+import { isDigitalSubscriber, refresh } from './user-features';
+import { fetchJson } from './user-features-lib';
+
+jest.mock('./user-features-lib', () => {
+	// Only mock the fetchJson function, rather than the whole module
+	const original = jest.requireActual('./user-features-lib');
+	return {
+		...original,
+		fetchJson: jest.fn(() => Promise.resolve()),
+	};
+});
+
+jest.mock('../../lib/identity', () => ({
+	isUserLoggedInOktaRefactor: jest.fn(),
+	getAuthStatus: jest.fn(),
+	getOptionsHeadersWithOkta: jest.fn(),
+}));
+
+const fetchJsonSpy = fetchJson as jest.MockedFunction<typeof fetchJson>;
+
+const isUserLoggedInOktaRefactor =
+	isUserLoggedInOktaRefactor_ as jest.MockedFunction<
+		typeof isUserLoggedInOktaRefactor_
+	>;
+
+const getAuthStatus = getAuthStatus_ as jest.MockedFunction<
+	typeof getAuthStatus_
+>;
+
+const PERSISTENCE_KEYS = {
+	USER_FEATURES_EXPIRY_COOKIE: 'gu_user_features_expiry',
+	PAYING_MEMBER_COOKIE: 'gu_paying_member',
+	RECURRING_CONTRIBUTOR_COOKIE: 'gu_recurring_contributor',
+	AD_FREE_USER_COOKIE: 'GU_AF1',
+	ACTION_REQUIRED_FOR_COOKIE: 'gu_action_required_for',
+	DIGITAL_SUBSCRIBER_COOKIE: 'gu_digital_subscriber',
+	SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE: 'gu.contributions.contrib-timestamp',
+	ONE_OFF_CONTRIBUTION_DATE_COOKIE: 'gu_one_off_contribution_date',
+	HIDE_SUPPORT_MESSAGING_COOKIE: 'gu_hide_support_messaging',
+	SUPPORT_MONTHLY_CONTRIBUTION_COOKIE:
+		'gu.contributions.recurring.contrib-timestamp.Monthly',
+	SUPPORT_ANNUAL_CONTRIBUTION_COOKIE:
+		'gu.contributions.recurring.contrib-timestamp.Annual',
+};
+
+const setAllFeaturesData = (opts: { isExpired: boolean }) => {
+	const currentTime = new Date().getTime();
+	const msInOneDay = 24 * 60 * 60 * 1000;
+	const expiryDate = opts.isExpired
+		? new Date(currentTime - msInOneDay)
+		: new Date(currentTime + msInOneDay);
+	const adFreeExpiryDate = opts.isExpired
+		? new Date(currentTime - msInOneDay * 2)
+		: new Date(currentTime + msInOneDay * 2);
+	setCookie({ name: PERSISTENCE_KEYS.PAYING_MEMBER_COOKIE, value: 'true' });
+	setCookie({
+		name: PERSISTENCE_KEYS.RECURRING_CONTRIBUTOR_COOKIE,
+		value: 'true',
+	});
+	setCookie({
+		name: PERSISTENCE_KEYS.DIGITAL_SUBSCRIBER_COOKIE,
+		value: 'true',
+	});
+	setCookie({
+		name: PERSISTENCE_KEYS.HIDE_SUPPORT_MESSAGING_COOKIE,
+		value: 'true',
+	});
+	setCookie({
+		name: PERSISTENCE_KEYS.AD_FREE_USER_COOKIE,
+		value: adFreeExpiryDate.getTime().toString(),
+	});
+	setCookie({
+		name: PERSISTENCE_KEYS.USER_FEATURES_EXPIRY_COOKIE,
+		value: expiryDate.getTime().toString(),
+	});
+	setCookie({
+		name: PERSISTENCE_KEYS.ACTION_REQUIRED_FOR_COOKIE,
+		value: 'test',
+	});
+};
+
+const deleteAllFeaturesData = () => {
+	removeCookie({ name: PERSISTENCE_KEYS.PAYING_MEMBER_COOKIE });
+	removeCookie({ name: PERSISTENCE_KEYS.RECURRING_CONTRIBUTOR_COOKIE });
+	removeCookie({ name: PERSISTENCE_KEYS.DIGITAL_SUBSCRIBER_COOKIE });
+	removeCookie({ name: PERSISTENCE_KEYS.USER_FEATURES_EXPIRY_COOKIE });
+	removeCookie({ name: PERSISTENCE_KEYS.AD_FREE_USER_COOKIE });
+	removeCookie({ name: PERSISTENCE_KEYS.ACTION_REQUIRED_FOR_COOKIE });
+	removeCookie({ name: PERSISTENCE_KEYS.HIDE_SUPPORT_MESSAGING_COOKIE });
+};
+
+beforeAll(() => {
+	window.guardian.config.page.userAttributesApiUrl = '';
+});
+
+describe('Refreshing the features data', () => {
+	describe('If user signed in', () => {
+		beforeEach(() => {
+			jest.resetAllMocks();
+			isUserLoggedInOktaRefactor.mockResolvedValue(true);
+			getAuthStatus.mockResolvedValue({
+				kind: 'SignedInWithOkta',
+			} as AuthStatus);
+			fetchJsonSpy.mockReturnValue(Promise.resolve());
+		});
+
+		it('Performs an update if the user has missing data', async () => {
+			deleteAllFeaturesData();
+			await refresh();
+			expect(fetchJsonSpy).toHaveBeenCalledTimes(1);
+		});
+
+		it('Performs an update if the user has expired data', async () => {
+			setAllFeaturesData({ isExpired: true });
+			await refresh();
+			expect(fetchJsonSpy).toHaveBeenCalledTimes(1);
+		});
+
+		it('Does not delete the data just because it has expired', async () => {
+			setAllFeaturesData({ isExpired: true });
+			await refresh();
+			expect(
+				getCookie({ name: PERSISTENCE_KEYS.PAYING_MEMBER_COOKIE }),
+			).toBe('true');
+			expect(
+				getCookie({
+					name: PERSISTENCE_KEYS.RECURRING_CONTRIBUTOR_COOKIE,
+				}),
+			).toBe('true');
+			expect(
+				getCookie({
+					name: PERSISTENCE_KEYS.USER_FEATURES_EXPIRY_COOKIE,
+				}),
+			).toEqual(expect.stringMatching(/\d{13}/));
+			expect(
+				getCookie({ name: PERSISTENCE_KEYS.AD_FREE_USER_COOKIE }),
+			).toEqual(expect.stringMatching(/\d{13}/));
+		});
+
+		it('Does not perform update if user has fresh feature data', async () => {
+			setAllFeaturesData({ isExpired: false });
+			await refresh();
+			expect(fetchJsonSpy).not.toHaveBeenCalled();
+		});
+
+		it('Performs an update if membership-frontend wipes just the paying-member cookie', async () => {
+			// Set everything except paying-member cookie
+			setAllFeaturesData({ isExpired: true });
+			removeCookie({ name: PERSISTENCE_KEYS.PAYING_MEMBER_COOKIE });
+
+			await refresh();
+			expect(fetchJsonSpy).toHaveBeenCalledTimes(1);
+		});
+	});
+});
+describe('If user signed out', () => {
+	beforeEach(() => {
+		jest.resetAllMocks();
+		isUserLoggedInOktaRefactor.mockResolvedValue(false);
+		fetchJsonSpy.mockReturnValue(Promise.resolve());
+	});
+
+	it('Does not perform update, even if feature data missing', async () => {
+		deleteAllFeaturesData();
+		await refresh();
+		expect(fetchJsonSpy).not.toHaveBeenCalled();
+	});
+
+	it('Deletes leftover feature data', async () => {
+		setAllFeaturesData({ isExpired: false });
+		await refresh();
+		expect(
+			getCookie({ name: PERSISTENCE_KEYS.AD_FREE_USER_COOKIE }),
+		).toBeNull();
+		expect(
+			getCookie({ name: PERSISTENCE_KEYS.PAYING_MEMBER_COOKIE }),
+		).toBeNull();
+		expect(
+			getCookie({
+				name: PERSISTENCE_KEYS.RECURRING_CONTRIBUTOR_COOKIE,
+			}),
+		).toBeNull();
+		expect(
+			getCookie({ name: PERSISTENCE_KEYS.DIGITAL_SUBSCRIBER_COOKIE }),
+		).toBeNull();
+		expect(
+			getCookie({
+				name: PERSISTENCE_KEYS.USER_FEATURES_EXPIRY_COOKIE,
+			}),
+		).toBeNull();
+	});
+});
+
+describe('The isDigitalSubscriber getter', () => {
+	it('Is false when the user is logged out', () => {
+		jest.resetAllMocks();
+		isUserLoggedInOktaRefactor.mockResolvedValue(false);
+		expect(isDigitalSubscriber()).toBe(false);
+	});
+
+	describe('When the user is logged in', () => {
+		beforeEach(() => {
+			jest.resetAllMocks();
+			isUserLoggedInOktaRefactor.mockResolvedValue(true);
+		});
+
+		it('Is true when the user has a `true` digital subscriber cookie', () => {
+			setCookie({
+				name: PERSISTENCE_KEYS.DIGITAL_SUBSCRIBER_COOKIE,
+				value: 'true',
+			});
+			expect(isDigitalSubscriber()).toBe(true);
+		});
+
+		it('Is false when the user has a `false` digital subscriber cookie', () => {
+			setCookie({
+				name: PERSISTENCE_KEYS.DIGITAL_SUBSCRIBER_COOKIE,
+				value: 'false',
+			});
+			expect(isDigitalSubscriber()).toBe(false);
+		});
+
+		it('Is false when the user has no digital subscriber cookie', () => {
+			removeCookie({ name: PERSISTENCE_KEYS.DIGITAL_SUBSCRIBER_COOKIE });
+			expect(isDigitalSubscriber()).toBe(false);
+		});
+	});
+});
+
+describe('Storing new feature data', () => {
+	beforeEach(() => {
+		const mockResponse = {
+			userId: 'abc',
+			showSupportMessaging: false,
+			contentAccess: {
+				member: false,
+				paidMember: false,
+				recurringContributor: false,
+				digitalPack: false,
+				paperSubscriber: false,
+				guardianWeeklySubscriber: false,
+			},
+		};
+
+		jest.resetAllMocks();
+		fetchJsonSpy.mockReturnValue(Promise.resolve(mockResponse));
+		deleteAllFeaturesData();
+		isUserLoggedInOktaRefactor.mockResolvedValue(true);
+		getAuthStatus.mockResolvedValue({
+			kind: 'SignedInWithOkta',
+		} as AuthStatus);
+	});
+
+	it('Puts the paying-member state and ad-free state in appropriate cookie', () => {
+		fetchJsonSpy.mockReturnValueOnce(
+			Promise.resolve({
+				contentAccess: {
+					paidMember: false,
+					recurringContributor: false,
+					digitalPack: false,
+				},
+				adFree: false,
+			}),
+		);
+		return refresh().then(() => {
+			expect(
+				getCookie({ name: PERSISTENCE_KEYS.PAYING_MEMBER_COOKIE }),
+			).toBe('false');
+			expect(
+				getCookie({
+					name: PERSISTENCE_KEYS.RECURRING_CONTRIBUTOR_COOKIE,
+				}),
+			).toBe('false');
+			expect(
+				getCookie({ name: PERSISTENCE_KEYS.DIGITAL_SUBSCRIBER_COOKIE }),
+			).toBe('false');
+			expect(
+				getCookie({ name: PERSISTENCE_KEYS.AD_FREE_USER_COOKIE }),
+			).toBeNull();
+		});
+	});
+
+	it('Puts the paying-member state and ad-free state in appropriate cookie', () => {
+		fetchJsonSpy.mockReturnValueOnce(
+			Promise.resolve({
+				contentAccess: {
+					paidMember: true,
+					recurringContributor: true,
+					digitalPack: true,
+				},
+				adFree: true,
+			}),
+		);
+		return refresh().then(() => {
+			expect(
+				getCookie({ name: PERSISTENCE_KEYS.PAYING_MEMBER_COOKIE }),
+			).toBe('true');
+			expect(
+				getCookie({
+					name: PERSISTENCE_KEYS.RECURRING_CONTRIBUTOR_COOKIE,
+				}),
+			).toBe('true');
+			expect(
+				getCookie({ name: PERSISTENCE_KEYS.DIGITAL_SUBSCRIBER_COOKIE }),
+			).toBe('true');
+			expect(
+				getCookie({ name: PERSISTENCE_KEYS.AD_FREE_USER_COOKIE }),
+			).toBeTruthy();
+			expect(
+				Number.isNaN(
+					parseInt(
+						// @ts-expect-error -- we’re testing it
+						getCookie({
+							name: PERSISTENCE_KEYS.AD_FREE_USER_COOKIE,
+						}),
+						10,
+					),
+				),
+			).toBe(false);
+		});
+	});
+
+	it('Puts an expiry date in an accompanying cookie', () =>
+		refresh().then(() => {
+			const expiryDate = getCookie({
+				name: PERSISTENCE_KEYS.USER_FEATURES_EXPIRY_COOKIE,
+			});
+			expect(expiryDate).toBeTruthy();
+			// @ts-expect-error -- we’re testing it
+			expect(Number.isNaN(parseInt(expiryDate, 10))).toBe(false);
+		}));
+
+	it('The expiry date is in the future', () =>
+		refresh().then(() => {
+			const expiryDateString = getCookie({
+				name: PERSISTENCE_KEYS.USER_FEATURES_EXPIRY_COOKIE,
+			});
+			// @ts-expect-error -- we’re testing it
+			const expiryDateEpoch = parseInt(expiryDateString, 10);
+			const currentTimeEpoch = new Date().getTime();
+			expect(currentTimeEpoch < expiryDateEpoch).toBe(true);
+		}));
+});

--- a/dotcom-rendering/src/client/userFeatures/user-features.test.ts
+++ b/dotcom-rendering/src/client/userFeatures/user-features.test.ts
@@ -260,6 +260,7 @@ describe('Storing new feature data', () => {
 	it('Puts the paying-member state and ad-free state in appropriate cookie', () => {
 		fetchJsonSpy.mockReturnValueOnce(
 			Promise.resolve({
+				showSupportMessaging: false,
 				contentAccess: {
 					paidMember: false,
 					recurringContributor: false,
@@ -289,6 +290,7 @@ describe('Storing new feature data', () => {
 	it('Puts the paying-member state and ad-free state in appropriate cookie', () => {
 		fetchJsonSpy.mockReturnValueOnce(
 			Promise.resolve({
+				showSupportMessaging: false,
 				contentAccess: {
 					paidMember: true,
 					recurringContributor: true,

--- a/dotcom-rendering/src/client/userFeatures/user-features.ts
+++ b/dotcom-rendering/src/client/userFeatures/user-features.ts
@@ -1,3 +1,5 @@
+// This file was migrated from:
+// https://github.com/guardian/commercial/blob/1a429d6be05657f20df4ca909df7d01a5c3d7402/src/lib/user-features.ts
 import { getCookie, isObject, removeCookie, setCookie } from '@guardian/libs';
 import {
 	getAuthStatus,

--- a/dotcom-rendering/src/client/userFeatures/user-features.ts
+++ b/dotcom-rendering/src/client/userFeatures/user-features.ts
@@ -56,7 +56,7 @@ const validateResponse = (
 		return true;
 	}
 
-	return true;
+	return false;
 };
 
 const persistResponse = (JsonResponse: UserFeaturesResponse) => {

--- a/dotcom-rendering/src/client/userFeatures/user-features.ts
+++ b/dotcom-rendering/src/client/userFeatures/user-features.ts
@@ -1,5 +1,9 @@
-// This file was migrated from:
-// https://github.com/guardian/commercial/blob/1a429d6be05657f20df4ca909df7d01a5c3d7402/src/lib/user-features.ts
+/**
+ * @file Sets the user subscription and ad free cookies
+ * This file was migrated from:
+ * https://github.com/guardian/commercial/blob/1a429d6be05657f20df4ca909df7d01a5c3d7402/src/lib/user-features.ts
+ */
+
 import { getCookie, isObject, removeCookie, setCookie } from '@guardian/libs';
 import {
 	getAuthStatus,

--- a/dotcom-rendering/src/client/userFeatures/user-features.ts
+++ b/dotcom-rendering/src/client/userFeatures/user-features.ts
@@ -1,0 +1,168 @@
+import { getCookie, isObject, removeCookie, setCookie } from '@guardian/libs';
+import {
+	getAuthStatus,
+	getOptionsHeadersWithOkta,
+	isUserLoggedInOktaRefactor,
+} from '../../lib/identity';
+import {
+	adFreeDataIsPresent,
+	cookieIsExpiredOrMissing,
+	fetchJson,
+	getAdFreeCookie,
+	setAdFreeCookie,
+	timeInDaysFromNow,
+} from './user-features-lib';
+import type { UserFeaturesResponse } from './user-features-lib';
+
+const USER_FEATURES_EXPIRY_COOKIE = 'gu_user_features_expiry';
+const PAYING_MEMBER_COOKIE = 'gu_paying_member';
+const ACTION_REQUIRED_FOR_COOKIE = 'gu_action_required_for';
+const DIGITAL_SUBSCRIBER_COOKIE = 'gu_digital_subscriber';
+const HIDE_SUPPORT_MESSAGING_COOKIE = 'gu_hide_support_messaging';
+const AD_FREE_USER_COOKIE = 'GU_AF1';
+
+const RECURRING_CONTRIBUTOR_COOKIE = 'gu_recurring_contributor';
+const ONE_OFF_CONTRIBUTION_DATE_COOKIE = 'gu_one_off_contribution_date';
+
+const forcedAdFreeMode = !!/[#&]noadsaf(&.*)?$/.exec(window.location.hash);
+
+const userHasData = () => {
+	const cookie =
+		getAdFreeCookie() ??
+		getCookie({ name: ACTION_REQUIRED_FOR_COOKIE }) ??
+		getCookie({ name: USER_FEATURES_EXPIRY_COOKIE }) ??
+		getCookie({ name: PAYING_MEMBER_COOKIE }) ??
+		getCookie({ name: RECURRING_CONTRIBUTOR_COOKIE }) ??
+		getCookie({ name: ONE_OFF_CONTRIBUTION_DATE_COOKIE }) ??
+		getCookie({ name: DIGITAL_SUBSCRIBER_COOKIE }) ??
+		getCookie({ name: HIDE_SUPPORT_MESSAGING_COOKIE });
+	return !!cookie;
+};
+
+const validateResponse = (
+	response: unknown,
+): response is UserFeaturesResponse => {
+	if (!isObject(response)) return false;
+
+	if (
+		typeof response.showSupportMessaging === 'boolean' &&
+		isObject(response.contentAccess) &&
+		typeof response.contentAccess.paidMember === 'boolean' &&
+		typeof response.contentAccess.recurringContributor === 'boolean' &&
+		typeof response.contentAccess.digitalPack === 'boolean'
+	) {
+		return true;
+	}
+
+	return true;
+};
+
+const persistResponse = (JsonResponse: UserFeaturesResponse) => {
+	setCookie({
+		name: USER_FEATURES_EXPIRY_COOKIE,
+		value: timeInDaysFromNow(1),
+	});
+	setCookie({
+		name: PAYING_MEMBER_COOKIE,
+		value: String(JsonResponse.contentAccess.paidMember),
+	});
+	setCookie({
+		name: RECURRING_CONTRIBUTOR_COOKIE,
+		value: String(JsonResponse.contentAccess.recurringContributor),
+	});
+	setCookie({
+		name: DIGITAL_SUBSCRIBER_COOKIE,
+		value: String(JsonResponse.contentAccess.digitalPack),
+	});
+	setCookie({
+		name: HIDE_SUPPORT_MESSAGING_COOKIE,
+		value: String(!JsonResponse.showSupportMessaging),
+	});
+	if (JsonResponse.oneOffContributionDate) {
+		setCookie({
+			name: ONE_OFF_CONTRIBUTION_DATE_COOKIE,
+			value: JsonResponse.oneOffContributionDate,
+		});
+	}
+
+	removeCookie({ name: ACTION_REQUIRED_FOR_COOKIE });
+	if (JsonResponse.alertAvailableFor) {
+		setCookie({
+			name: ACTION_REQUIRED_FOR_COOKIE,
+			value: JsonResponse.alertAvailableFor,
+		});
+	}
+
+	if (JsonResponse.contentAccess.digitalPack) {
+		setAdFreeCookie(2);
+	} else if (adFreeDataIsPresent() && !forcedAdFreeMode) {
+		removeCookie({ name: AD_FREE_USER_COOKIE });
+	}
+};
+
+const deleteOldData = (): void => {
+	removeCookie({ name: AD_FREE_USER_COOKIE });
+	removeCookie({ name: USER_FEATURES_EXPIRY_COOKIE });
+	removeCookie({ name: PAYING_MEMBER_COOKIE });
+	removeCookie({ name: RECURRING_CONTRIBUTOR_COOKIE });
+	removeCookie({ name: ACTION_REQUIRED_FOR_COOKIE });
+	removeCookie({ name: DIGITAL_SUBSCRIBER_COOKIE });
+	removeCookie({ name: HIDE_SUPPORT_MESSAGING_COOKIE });
+	removeCookie({ name: ONE_OFF_CONTRIBUTION_DATE_COOKIE });
+};
+
+const requestNewData = () => {
+	return getAuthStatus()
+		.then((authStatus) =>
+			authStatus.kind === 'SignedInWithCookies' ||
+			authStatus.kind === 'SignedInWithOkta'
+				? authStatus
+				: Promise.reject('The user is not signed in'),
+		)
+		.then((signedInAuthStatus) => {
+			return fetchJson(
+				`${
+					window.guardian.config.page.userAttributesApiUrl ??
+					'/USER_ATTRIBUTE_API_NOT_FOUND'
+				}/me`,
+				{
+					mode: 'cors',
+					...getOptionsHeadersWithOkta(signedInAuthStatus),
+				},
+			)
+				.then((response) => {
+					if (!validateResponse(response)) {
+						throw new Error('invalid response');
+					}
+					return response;
+				})
+				.then(persistResponse)
+				.catch(() => {
+					// eslint-disable-next-line no-console -- error logging
+					console.error('Error fetching user data');
+				});
+		});
+};
+
+const featuresDataIsOld = () =>
+	cookieIsExpiredOrMissing(USER_FEATURES_EXPIRY_COOKIE);
+
+const isDigitalSubscriber = (): boolean =>
+	getCookie({ name: DIGITAL_SUBSCRIBER_COOKIE }) === 'true';
+
+const userNeedsNewFeatureData = (): boolean =>
+	featuresDataIsOld() || (isDigitalSubscriber() && !adFreeDataIsPresent());
+
+const userHasDataAfterSignout = async (): Promise<boolean> =>
+	!(await isUserLoggedInOktaRefactor()) && userHasData();
+
+const refresh = async (): Promise<void> => {
+	if ((await isUserLoggedInOktaRefactor()) && userNeedsNewFeatureData()) {
+		return requestNewData();
+	} else if ((await userHasDataAfterSignout()) && !forcedAdFreeMode) {
+		deleteOldData();
+	}
+	return Promise.resolve();
+};
+
+export { refresh, isDigitalSubscriber };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
The PR establishes mechanisms for refreshing user data when necessary. It ensures that data is kept up to date, reflecting the user's current state and preferences.

This code sets the ad free cookie and the subscription cookies

This has been ported over from the `commercial` repo, to a more sensible location. 
Adding it in DCR makes it easier for those teams like  Identity and Supporter Revenue to find it and change it.

**This PR is based off the PR laying the module structure and imports appropriately in**:  https://github.com/guardian/dotcom-rendering/pull/9357

## Why?
The cookies set in User Features (including the ad free cookie) are ultimately owned by Supporter Revenue.

This specifically, deals with the cookie management:
- GU_AF1 Cookie: associated with ad-free user experience. The PR ensures that its management aligns with the desired user experience.
-  gu_digital_subscriber: the result of the cookie retrieval to determine the user's digital subscriber status, particularly in functions like isDigitalSubscriber(). 
- gu_user_features_expiry Cookie: responsible for controlling the expiration of user features. Its management has been incorporated for enhanced user data handling.

In addition further logic for:
- Request to User Features API: The system initiates a request to the user features API when either no user features expiry cookie is present or when the existing user features cookie has expired. This ensures that user data remains up to date and accurate.

- Data Cleanup on Sign-Out: When a user signs out, the implementation ensures that any existing old cookie data is promptly and appropriately deleted. This maintenance action aligns with user privacy and data management best practices.


### Testing:

Comprehensive testing has also been added to validate the functionality of the "user-features" module and the precise management of cookies. This includes Cypress E2E and unit testing.

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
