### PR TITLE
Make `SignInGateSelector` Island server safe

### DIFF
--- a/dotcom-rendering/src/components/Island.test.tsx
+++ b/dotcom-rendering/src/components/Island.test.tsx
@@ -14,6 +14,7 @@ import { Liveness } from './Liveness.importable';
 import { Metrics } from './Metrics.importable';
 import { OnwardsUpper } from './OnwardsUpper.importable';
 import { SetABTests } from './SetABTests.importable';
+import { SignInGateSelector } from './SignInGateSelector.importable';
 import { SlotBodyEnd } from './SlotBodyEnd.importable';
 import { Snow } from './Snow.importable';
 import { StickyBottomBanner } from './StickyBottomBanner.importable';
@@ -207,6 +208,25 @@ describe('Island: server-side rendering', () => {
 					pageIsSensitive={false}
 					abTestSwitches={{}}
 				/>,
+			),
+		).not.toThrow();
+	});
+
+	test('SignInGateSelector', () => {
+		expect(() =>
+			renderToString(
+				<ConfigProvider
+					value={{ renderingTarget: 'Web', darkModeAvailable: false }}
+				>
+					<SignInGateSelector
+						contentType={''}
+						tags={[]}
+						isPaidContent={false}
+						isPreview={false}
+						pageId={''}
+						switches={{}}
+					/>
+				</ConfigProvider>,
 			),
 		).not.toThrow();
 	});

--- a/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
+++ b/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
@@ -1,11 +1,13 @@
-import { getCookie } from '@guardian/libs';
+import { getCookie, isUndefined } from '@guardian/libs';
 import { useEffect, useState } from 'react';
+import { getOphan } from '../client/ophan/ophan';
 import { parseCheckoutCompleteCookieData } from '../lib/parser/parseCheckoutOutCookieData';
 import { constructQuery } from '../lib/querystring';
 import { useAuthStatus } from '../lib/useAuthStatus';
 import { useOnce } from '../lib/useOnce';
 import { useSignInGateSelector } from '../lib/useSignInGateSelector';
 import type { Switches } from '../types/config';
+import type { RenderingTarget } from '../types/renderingTarget';
 import type { TagType } from '../types/tag';
 import { useConfig } from './ConfigContext';
 import type { ComponentEventParams } from './SignInGate/componentEventTracking';
@@ -149,6 +151,41 @@ const ShowSignInGate = ({
 	return <></>;
 };
 
+const usePageViewId = (renderingTarget: RenderingTarget) => {
+	const [id, setId] = useState<string>();
+
+	useEffect(() => {
+		getOphan(renderingTarget)
+			.then(({ pageViewId }) => {
+				setId(pageViewId);
+			})
+			.catch(() => {
+				setId('no-page-view-id-available');
+			});
+	}, [renderingTarget]);
+
+	return id;
+};
+
+const useCheckoutCompleteCookieData = () => {
+	const [data, setData] = useState<CheckoutCompleteCookieData>();
+
+	useEffect(() => {
+		const rawCookie = getCookie({
+			name: 'GU_CO_COMPLETE',
+			shouldMemoize: true,
+		});
+
+		if (rawCookie === null) return;
+
+		const parsedCookieData = parseCheckoutCompleteCookieData(rawCookie);
+
+		if (parsedCookieData) setData(parsedCookieData);
+	}, []);
+
+	return data;
+};
+
 // component with conditional logic which determines if a sign in gate
 // should be shown on the current page
 export const SignInGateSelector = ({
@@ -177,19 +214,13 @@ export const SignInGateSelector = ({
 	>(undefined);
 	const [canShowGate, setCanShowGate] = useState(false);
 
+	const { renderingTarget } = useConfig();
 	const gateSelector = useSignInGateSelector();
-	const { pageViewId } = window.guardian.config.ophan;
+	const pageViewId = usePageViewId(renderingTarget);
 
 	// START: Checkout Complete Personalisation
 	const [personaliseSwitch, setPersonaliseSwitch] = useState(false);
-	const checkOutCompleteString = getCookie({
-		name: 'GU_CO_COMPLETE',
-		shouldMemoize: true,
-	});
-	const checkoutCompleteCookieData: CheckoutCompleteCookieData | undefined =
-		checkOutCompleteString !== null
-			? parseCheckoutCompleteCookieData(checkOutCompleteString)
-			: undefined;
+	const checkoutCompleteCookieData = useCheckoutCompleteCookieData();
 
 	const personaliseComponentId = (
 		currentComponentId: string | undefined,
@@ -258,7 +289,7 @@ export const SignInGateSelector = ({
 		isPreview,
 	]);
 
-	if (!currentTest || !gateVariant) {
+	if (!currentTest || !gateVariant || isUndefined(pageViewId)) {
 		return null;
 	}
 	const signInGateComponentId = signInGateTestIdToComponentId[currentTest.id];
@@ -274,7 +305,7 @@ export const SignInGateSelector = ({
 		idUrl,
 		currentTest,
 		componentId,
-	};
+	} satisfies Parameters<typeof generateGatewayUrl>[1];
 
 	return (
 		<>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Use hooks to make the `SignInGateSelector` run in a server context.

Looping in @guardian/identity for visibility.

## Why?

No assumption should be made about where components are run

- Split out from #8991 for easier review
- Enables the work from #8948 to proceed safely.

## Screenshots

N/A