### PR TITLE
Decrease `minCapacity` of instances to 27

### DIFF
--- a/dotcom-rendering/cdk/bin/cdk.ts
+++ b/dotcom-rendering/cdk/bin/cdk.ts
@@ -13,7 +13,7 @@ new DotcomRendering(app, 'DotcomRendering-PROD', {
 	...sharedProps,
 	app: 'rendering',
 	stage: 'PROD',
-	minCapacity: 25,
+	minCapacity: 27,
 	maxCapacity: 120,
 	instanceType: 't4g.small',
 });

--- a/dotcom-rendering/cdk/bin/cdk.ts
+++ b/dotcom-rendering/cdk/bin/cdk.ts
@@ -13,7 +13,7 @@ new DotcomRendering(app, 'DotcomRendering-PROD', {
 	...sharedProps,
 	app: 'rendering',
 	stage: 'PROD',
-	minCapacity: 30,
+	minCapacity: 25,
 	maxCapacity: 120,
 	instanceType: 't4g.small',
 });


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Reduces DCR `minCapacity` to 27.

## Why?
`minCapacity` was bumped from 15 to 30 in 
* https://github.com/guardian/dotcom-rendering/pull/8724. 

After the fronts migration was completed, it seemed that 15 instances [weren't holding up with the new traffic](https://mail.google.com/chat/u/0/#chat/space/AAAAG9rU0m0/JpdgrlgBGEY). Bumping instances to 30 was a hotfix and there is [upcoming work to split our stacks](https://github.com/guardian/dotcom-rendering/issues/8351). Until we reach this point we would like to see whether we could handle the traffic with 27 instances. This change is a first step of the research we're doing to how to optimise DCR scaling in terms of:
* [ASG Size](https://github.com/guardian/dotcom-rendering/issues/9322)
* [Scaling Policy](https://github.com/guardian/dotcom-rendering/issues/9311)
* [ASG Instance Types](https://github.com/guardian/dotcom-rendering/issues/9321)

See [WIP document on our research and findings](https://docs.google.com/document/d/1FjDANYnddGrB3JnXdMjoHnie2kB7fL3MgJachCVZHVg/edit#heading=h.tpjxtnq2d686) so far. 

## Metrics to keep an eye on 

After the fronts migration and with DCR having a `minCapacity` of 15 @guardian/devx-reliability team had to lower the SLO target for `facia` app in https://github.com/guardian/slo-alerts/pull/37 after [ongoing issues with DCR latency](https://mail.google.com/chat/u/0/#chat/space/AAAAG9rU0m0/JpdgrlgBGEY). After increasing `minCapacity` to 30 they were able to [restore SLO to the initial target](https://github.com/guardian/slo-alerts/pull/50). We can monitor the impact of reducing `minCapacity` to 25 by checking the following dashboards:

* [Facia SLI](https://metrics.gutools.co.uk/d/zM0ouzs4z/sli-dashboard-debug-view?orgId=1&var-Period=86400&var-AWSAccount=frontend&var-StageFilter=PROD&var-ElkIndexFilter=logstash-frontend-%2A&var-ElasticSearchIndex=logstash-frontend-%2A&var-Service=frontend-PROD-facia-ELB&var-App=facia&var-Stack=frontend&var-Stage=PROD&var-ASGName=frontend-PROD-FaciaStack-1AZBJHR7UVRVD-AutoscalingGroup-1HT7KW72DG2K0)
* [Article SLI](https://metrics.gutools.co.uk/d/zM0ouzs4z/sli-dashboard-debug-view?orgId=1&var-Period=86400&var-AWSAccount=frontend&var-StageFilter=PROD&var-ElkIndexFilter=logstash-frontend-%2A&var-ElasticSearchIndex=logstash-frontend-%2A&var-Service=frontend-PROD-article-ELB&var-App=article&var-Stack=frontend&var-Stage=PROD&var-ASGName=frontend-PROD-ArticleStack-19Q4E3WH4H9CO-AutoscalingGroup-1GN65SPGDQGWI)
* [DCR latency](https://metrics.gutools.co.uk/d/zM0ouzs4z/sli-dashboard-debug-view?orgId=1&var-Period=86400&var-AWSAccount=frontend&var-StageFilter=PROD&var-ElkIndexFilter=logstash-frontend-%2A&var-ElasticSearchIndex=logstash-frontend-%2A&var-Service=frontend-PROD-rendering-ELB&var-App=rendering&var-Stack=frontend&var-Stage=PROD&var-ASGName=frontend-rendering-PROD-AutoscalingGroup-MF5R8QXZY1EX)
* [Error budget for facia](https://metrics.gutools.co.uk/d/RYuZxre4k/error-budget-analysis?orgId=1&var-AWSAccount=frontend&var-Service=frontend-PROD-facia-ELB&var-SLO=0.9995&var-Period=3600) ([SLO target](https://github.com/guardian/slo-alerts/blob/7e54f322f6efb2e2326ec9ab43a81d970a36d9c0/cdk/lib/frontend/frontend-slos.ts#L71): 0.9995)
* [Error budget for article](https://metrics.gutools.co.uk/d/RYuZxre4k/error-budget-analysis?orgId=1&var-AWSAccount=frontend&var-Service=frontend-PROD-article-ELB&var-SLO=0.9975&var-Period=3600) ([SLO target](https://github.com/guardian/slo-alerts/blob/7e54f322f6efb2e2326ec9ab43a81d970a36d9c0/cdk/lib/frontend/frontend-slos.ts#L38): 0.9975) 

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
