### PR TITLE
Remove `source-map-support`

### DIFF
--- a/apps-rendering/cdk/bin/cdk.ts
+++ b/apps-rendering/cdk/bin/cdk.ts
@@ -1,4 +1,3 @@
-import 'source-map-support/register';
 import { App } from 'aws-cdk-lib';
 import { MobileAppsRendering } from '../lib/mobile-apps-rendering';
 import { InstanceSize } from 'aws-cdk-lib/aws-ec2';

--- a/apps-rendering/package.json
+++ b/apps-rendering/package.json
@@ -108,7 +108,6 @@
 		"react-dom": "^18.2.0",
 		"react-test-renderer": "^18.2.0",
 		"require-from-string": "^2.0.2",
-		"source-map-support": "^0.5.21",
 		"storybook": "^7.2.0",
 		"thrift": "^0.16.0",
 		"ts-jest": "^28.0.7",

--- a/apps-rendering/src/server/server.ts
+++ b/apps-rendering/src/server/server.ts
@@ -1,6 +1,5 @@
 // ----- Imports ----- //
 
-import 'source-map-support/register'; // activating the source map support
 import path from 'path';
 import { Edition } from '@guardian/apps-rendering-api-models/edition';
 import type { RelatedContent } from '@guardian/apps-rendering-api-models/relatedContent';

--- a/apps-rendering/yarn.lock
+++ b/apps-rendering/yarn.lock
@@ -12095,7 +12095,7 @@ source-map-support@0.5.13:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
 
-source-map-support@^0.5.16, source-map-support@^0.5.21, source-map-support@~0.5.20:
+source-map-support@^0.5.16, source-map-support@~0.5.20:
   version "0.5.21"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f"
   integrity sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==

--- a/dotcom-rendering/cdk/bin/cdk.ts
+++ b/dotcom-rendering/cdk/bin/cdk.ts
@@ -1,4 +1,3 @@
-import 'source-map-support/register';
 import { App } from 'aws-cdk-lib';
 import { DotcomRendering } from '../lib/dotcom-rendering';
 

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -241,7 +241,6 @@
 		"simple-progress-webpack-plugin": "2.0.0",
 		"snyk": "1.1103.0",
 		"source-map": "0.7.4",
-		"source-map-support": "0.5.21",
 		"start-server-and-test": "1.15.5",
 		"storybook": "7.5.1",
 		"storybook-addon-turbo-build": "2.0.1",


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Remove the explicit dependency on [`source-map-support`](https://www.npmjs.com/package/source-map-support)

## Why?

`source-map-support` is no longer needed [since Node >=12.12.0](https://github.com/evanw/node-source-map-support#node-12120)

> **Note**
> It still makes its way into the lockfile as it’s a dependency of at least:
> - webpack-hot-server-middleware
> - webpack-sources
> - @babel/register
> - jest-runner
> - pm2
> - html-minifier-terser

## Screenshots

N/A