### PR TITLE
Add data-lazy-fetch="true" to AMP ads

### DIFF
--- a/dotcom-rendering/src/components/Ad.amp.tsx
+++ b/dotcom-rendering/src/components/Ad.amp.tsx
@@ -111,6 +111,7 @@ export const Ad = ({
 			// corresponding primary size.
 			data-multi-size-validation="false"
 			data-npa-on-unknown-consent={true}
+			data-lazy-fetch="true"
 			data-loading-strategy="0.5"
 			data-enable-refresh="30"
 			layout="fixed"


### PR DESCRIPTION
## What does this change?
Adds the data-lazy-fetch="true" parameter to AMP ads. This delays the ad request until the user is the number of viewports away specified by data-loading-strategy.

See docs [here](https://github.com/ampproject/amphtml/blob/main/extensions/amp-ad-network-doubleclick-impl/lazy-fetch.md).

## Why?
We're hoping this will boost visibility of ads on AMP. We'll be keeping an eye on the metrics to monitor any changes in visibility or revenue.
