### PR TITLE
Demonstrate some Islands are server-safe

### DIFF
--- a/dotcom-rendering/src/components/Island.test.tsx
+++ b/dotcom-rendering/src/components/Island.test.tsx
@@ -5,6 +5,7 @@
 import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
 import { renderToString } from 'react-dom/server';
 import { AlreadyVisited } from './AlreadyVisited.importable';
+import { BrazeMessaging } from './BrazeMessaging.importable';
 import { CardCommentCount } from './CardCommentCount.importable';
 import { ConfigProvider } from './ConfigContext';
 import { EnhancePinnedPost } from './EnhancePinnedPost.importable';
@@ -86,6 +87,18 @@ const Mock = () => <>🏝️</>;
 describe('Island: server-side rendering', () => {
 	test('AlreadyVisited', () => {
 		expect(() => renderToString(<AlreadyVisited />)).not.toThrow();
+	});
+
+	test('BrazeMessaging', () => {
+		expect(() =>
+			renderToString(
+				<ConfigProvider
+					value={{ renderingTarget: 'Web', darkModeAvailable: false }}
+				>
+					<BrazeMessaging idApiUrl={''} />
+				</ConfigProvider>,
+			),
+		).not.toThrow();
 	});
 
 	test('CardCommentCount', () => {

--- a/dotcom-rendering/src/components/Island.test.tsx
+++ b/dotcom-rendering/src/components/Island.test.tsx
@@ -4,6 +4,7 @@
 
 import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
 import { renderToString } from 'react-dom/server';
+import { AlreadyVisited } from './AlreadyVisited.importable';
 import { CardCommentCount } from './CardCommentCount.importable';
 import { ConfigProvider } from './ConfigContext';
 import { EnhancePinnedPost } from './EnhancePinnedPost.importable';
@@ -83,6 +84,10 @@ const Mock = () => <>🏝️</>;
 // Jest tests
 
 describe('Island: server-side rendering', () => {
+	test('AlreadyVisited', () => {
+		expect(() => renderToString(<AlreadyVisited />)).not.toThrow();
+	});
+
 	test('CardCommentCount', () => {
 		expect(() =>
 			renderToString(

--- a/dotcom-rendering/src/components/Island.test.tsx
+++ b/dotcom-rendering/src/components/Island.test.tsx
@@ -9,6 +9,7 @@ import { BrazeMessaging } from './BrazeMessaging.importable';
 import { CardCommentCount } from './CardCommentCount.importable';
 import { ConfigProvider } from './ConfigContext';
 import { EnhancePinnedPost } from './EnhancePinnedPost.importable';
+import { FocusStyles } from './FocusStyles.importable';
 import { InteractiveSupportButton } from './InteractiveSupportButton.importable';
 import { Island } from './Island';
 import { LightboxHash } from './LightboxHash.importable';
@@ -127,6 +128,10 @@ describe('Island: server-side rendering', () => {
 				</ConfigProvider>,
 			),
 		).not.toThrow();
+	});
+
+	test('FocusStyles', () => {
+		expect(() => renderToString(<FocusStyles />)).not.toThrow();
 	});
 
 	test('InteractiveSupportButton', () => {

--- a/dotcom-rendering/src/components/Island.test.tsx
+++ b/dotcom-rendering/src/components/Island.test.tsx
@@ -18,6 +18,7 @@ import { LiveBlogEpic } from './LiveBlogEpic.importable';
 import { Liveness } from './Liveness.importable';
 import { Metrics } from './Metrics.importable';
 import { OnwardsUpper } from './OnwardsUpper.importable';
+import { ReaderRevenueDev } from './ReaderRevenueDev.importable';
 import { SetABTests } from './SetABTests.importable';
 import { SignInGateSelector } from './SignInGateSelector.importable';
 import { SlotBodyEnd } from './SlotBodyEnd.importable';
@@ -239,6 +240,14 @@ describe('Island: server-side rendering', () => {
 				>
 					<Metrics commercialMetricsEnabled={true} tests={{}} />
 				</ConfigProvider>,
+			),
+		).not.toThrow();
+	});
+
+	test('ReaderRevenueDev', () => {
+		expect(() =>
+			renderToString(
+				<ReaderRevenueDev shouldHideReaderRevenue={false} />,
 			),
 		).not.toThrow();
 	});


### PR DESCRIPTION
## What does this change?

Ensure the following islands are server-safe by adding them to the test:

- `AlreadyVisited`
- `BrazeMessaging`
- `FocusStyles`
- `ReaderRevenue`

## Why?

No assumption should be made about where components are run

- Split out from #8991 for easier review
- Enables the work from #8948 to proceed safely.

## Screenshots

N/A