### PR TITLE
Bump @guardian/commercial@11.19.0

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -65,7 +65,7 @@
 		"@guardian/bridget": "2.3.0",
 		"@guardian/browserslist-config": "5.0.0",
 		"@guardian/cdk": "50.10.6",
-		"@guardian/commercial": "11.17.2",
+		"@guardian/commercial": "11.19.0",
 		"@guardian/consent-management-platform": "13.7.1",
 		"@guardian/core-web-vitals": "5.1.0",
 		"@guardian/eslint-config": "4.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3192,17 +3192,17 @@
     read-pkg-up "7.0.1"
     yargs "^17.6.2"
 
-"@guardian/commercial@11.17.2":
-  version "11.17.2"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-11.17.2.tgz#0745c0888925d6c880bc41f0cd7f0369d64d498d"
-  integrity sha512-vgijbkjLQ+9nr04Pim2XIDIlL/xpw6coFV7BDNzWqP5MBib1k2NeVqoHlp2geKGP+AbA77Rt1CZpB+5mh+f4iQ==
+"@guardian/commercial@11.19.0":
+  version "11.19.0"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-11.19.0.tgz#dcb51eab371d2230bc5e0afde8d145a9af259dee"
+  integrity sha512-LbuX2dZM98QrUijaTPeI9wYARTD7o4xTCoX4EBeNnoJ4k5APOCl0OkxuBHlD06RCmNZ0ERMCQx7bse3rDFwaZQ==
   dependencies:
     "@changesets/cli" "^2.26.2"
     "@octokit/core" "^4.0.5"
     fastdom "^1.0.11"
     lodash-es "^4.17.21"
     ophan-tracker-js "^2.0.1"
-    prebid.js guardian/prebid.js#ddf4251
+    prebid.js guardian/prebid.js#0b4cccd
     process "^0.11.10"
     raven-js "^3.27.2"
     tslib "^2.5.3"
@@ -8606,15 +8606,10 @@ cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-crypto-js@4.2.0:
+crypto-js@4.2.0, crypto-js@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-4.2.0.tgz#4d931639ecdfd12ff80e8186dba6af2c2e856631"
   integrity sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==
-
-crypto-js@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-3.3.0.tgz#846dd1cce2f68aacfa156c8578f926a609b7976b"
-  integrity sha512-DIT51nX0dCfKltpRiXV+/TVZq+Qq2NgF4644+K7Ttnla7zEzqc+kjJyiB96BHNyUTBxyjzRcZYpUdZa+QAqi6Q==
 
 crypto-random-string@^2.0.0:
   version "2.0.0"
@@ -15100,9 +15095,9 @@ preact@10.15.1:
   resolved "https://registry.yarnpkg.com/preact/-/preact-10.15.1.tgz#a1de60c9fc0c79a522d969c65dcaddc5d994eede"
   integrity sha512-qs2ansoQEwzNiV5eAcRT1p1EC/dmEzaATVDJNiB3g2sRDWdA7b7MurXdJjB2+/WQktGWZwxvDrnuRFbWuIr64g==
 
-prebid.js@guardian/prebid.js#ddf4251:
+prebid.js@guardian/prebid.js#0b4cccd:
   version "7.54.5"
-  resolved "https://codeload.github.com/guardian/prebid.js/tar.gz/ddf4251b19c95878af00f640211c0c31ac3e7ac2"
+  resolved "https://codeload.github.com/guardian/prebid.js/tar.gz/0b4cccd55ab4e170b36bb944e9bdd2807a9da1c5"
   dependencies:
     "@babel/core" "^7.23.2"
     "@babel/plugin-transform-runtime" "^7.18.9"
@@ -15112,7 +15107,7 @@ prebid.js@guardian/prebid.js#ddf4251:
     core-js "^3.13.0"
     core-js-pure "^3.13.0"
     criteo-direct-rsa-validate "^1.1.0"
-    crypto-js "^3.3.0"
+    crypto-js "^4.2.0"
     dlv "1.1.3"
     dset "3.1.2"
     express "^4.15.4"


### PR DESCRIPTION
## What does this change?

Bump @guardian/commercial@11.19.0

Resolves crypto-js CVE

