### PR TITLE
Reverse recent AMP ad changes

### DIFF
--- a/dotcom-rendering/src/components/Ad.amp.tsx
+++ b/dotcom-rendering/src/components/Ad.amp.tsx
@@ -111,8 +111,7 @@ export const Ad = ({
 			// corresponding primary size.
 			data-multi-size-validation="false"
 			data-npa-on-unknown-consent={true}
-			data-lazy-fetch="true"
-			data-loading-strategy="0.5"
+			data-loading-strategy="prefer-viewability-over-views"
 			data-enable-refresh="30"
 			layout="fixed"
 			type="doubleclick"


### PR DESCRIPTION
## What does this change?
Reverses the changes in these two PR's:
https://github.com/guardian/dotcom-rendering/pull/9302
https://github.com/guardian/dotcom-rendering/pull/9379

## Why?
These changes were made in an attempt to boost the visibility of AMP ads. However, we haven't observed any positive effect from making them, so we're putting the settings back to how they were before.
