### PR TITLE
ci: allow publish workflow to run without cypress or amp job succeeding

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -33,11 +33,24 @@ jobs:
     with:
       container-image: ${{ needs.container.outputs.container-image }}
 
-  publish:
+  publish-branch:
+    if: ${{ ! github.ref == 'refs/heads/main' }}
     permissions:
       id-token: write
       contents: read
     needs: [container, prettier, jest, lint]
+    uses: ./.github/workflows/publish.yml
+    with:
+      container-image: ${{ needs.container.outputs.container-image }}
+    secrets:
+      GU_RIFF_RAFF_ROLE_ARN: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+
+  publish-main:
+    if: ${{ github.ref == 'refs/heads/main' }}
+    permissions:
+      id-token: write
+      contents: read
+    needs: [container, prettier, jest, lint, cypress, amp]
     uses: ./.github/workflows/publish.yml
     with:
       container-image: ${{ needs.container.outputs.container-image }}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Changes `publish` job in `cicd.yml` so that it doesn't rely on the `cypress` or the `amp` job completing before running.

## Why?

We can reduce the wait time between pushing and deploying to the CODE env by 5 minutes by not waiting for cypress to finish before running the publish workflow.
This keeps developers happy :)

