### PR TITLE
Scaling policy

### DIFF
--- a/dotcom-rendering/cdk/lib/__snapshots__/dotcom-rendering.test.ts.snap
+++ b/dotcom-rendering/cdk/lib/__snapshots__/dotcom-rendering.test.ts.snap
@@ -309,7 +309,7 @@ exports[`The DotcomRendering stack matches the snapshot 1`] = `
         "Namespace": "AWS/ELB",
         "Period": 60,
         "Statistic": "Average",
-        "Threshold": 200,
+        "Threshold": 0.2,
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
@@ -324,12 +324,7 @@ exports[`The DotcomRendering stack matches the snapshot 1`] = `
         "PolicyType": "StepScaling",
         "StepAdjustments": [
           {
-            "MetricIntervalLowerBound": -100,
             "MetricIntervalUpperBound": 0,
-            "ScalingAdjustment": 1,
-          },
-          {
-            "MetricIntervalUpperBound": -100,
             "ScalingAdjustment": 1,
           },
         ],
@@ -350,7 +345,7 @@ exports[`The DotcomRendering stack matches the snapshot 1`] = `
         "Namespace": "AWS/ELB",
         "Period": 60,
         "Statistic": "Average",
-        "Threshold": 200,
+        "Threshold": 0.2,
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
@@ -366,11 +361,11 @@ exports[`The DotcomRendering stack matches the snapshot 1`] = `
         "StepAdjustments": [
           {
             "MetricIntervalLowerBound": 0,
-            "MetricIntervalUpperBound": 100,
+            "MetricIntervalUpperBound": 0.09999999999999998,
             "ScalingAdjustment": 4,
           },
           {
-            "MetricIntervalLowerBound": 100,
+            "MetricIntervalLowerBound": 0.09999999999999998,
             "ScalingAdjustment": 7,
           },
         ],

--- a/dotcom-rendering/cdk/lib/__snapshots__/dotcom-rendering.test.ts.snap
+++ b/dotcom-rendering/cdk/lib/__snapshots__/dotcom-rendering.test.ts.snap
@@ -295,83 +295,6 @@ exports[`The DotcomRendering stack matches the snapshot 1`] = `
       },
       "Type": "AWS::AutoScaling::AutoScalingGroup",
     },
-    "AutoscalingGroupRenderingLatencyStepScalingPolicyLowerAlarmC8893E45": {
-      "Properties": {
-        "AlarmActions": [
-          {
-            "Ref": "AutoscalingGroupRenderingLatencyStepScalingPolicyLowerPolicy76D73EE7",
-          },
-        ],
-        "AlarmDescription": "Lower threshold scaling alarm",
-        "ComparisonOperator": "LessThanOrEqualToThreshold",
-        "EvaluationPeriods": 1,
-        "MetricName": "Latency",
-        "Namespace": "AWS/ELB",
-        "Period": 60,
-        "Statistic": "Average",
-        "Threshold": 0.2,
-      },
-      "Type": "AWS::CloudWatch::Alarm",
-    },
-    "AutoscalingGroupRenderingLatencyStepScalingPolicyLowerPolicy76D73EE7": {
-      "Properties": {
-        "AdjustmentType": "ExactCapacity",
-        "AutoScalingGroupName": {
-          "Ref": "AutoscalingGroup",
-        },
-        "Cooldown": "120",
-        "MetricAggregationType": "Average",
-        "PolicyType": "StepScaling",
-        "StepAdjustments": [
-          {
-            "MetricIntervalUpperBound": 0,
-            "ScalingAdjustment": 1,
-          },
-        ],
-      },
-      "Type": "AWS::AutoScaling::ScalingPolicy",
-    },
-    "AutoscalingGroupRenderingLatencyStepScalingPolicyUpperAlarmD121CE9C": {
-      "Properties": {
-        "AlarmActions": [
-          {
-            "Ref": "AutoscalingGroupRenderingLatencyStepScalingPolicyUpperPolicy08A879B8",
-          },
-        ],
-        "AlarmDescription": "Upper threshold scaling alarm",
-        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
-        "EvaluationPeriods": 1,
-        "MetricName": "Latency",
-        "Namespace": "AWS/ELB",
-        "Period": 60,
-        "Statistic": "Average",
-        "Threshold": 0.2,
-      },
-      "Type": "AWS::CloudWatch::Alarm",
-    },
-    "AutoscalingGroupRenderingLatencyStepScalingPolicyUpperPolicy08A879B8": {
-      "Properties": {
-        "AdjustmentType": "ExactCapacity",
-        "AutoScalingGroupName": {
-          "Ref": "AutoscalingGroup",
-        },
-        "Cooldown": "120",
-        "MetricAggregationType": "Average",
-        "PolicyType": "StepScaling",
-        "StepAdjustments": [
-          {
-            "MetricIntervalLowerBound": 0,
-            "MetricIntervalUpperBound": 0.09999999999999998,
-            "ScalingAdjustment": 4,
-          },
-          {
-            "MetricIntervalLowerBound": 0.09999999999999998,
-            "ScalingAdjustment": 7,
-          },
-        ],
-      },
-      "Type": "AWS::AutoScaling::ScalingPolicy",
-    },
     "Backend5xxAlarm": {
       "Properties": {
         "ActionsEnabled": false,
@@ -561,6 +484,40 @@ exports[`The DotcomRendering stack matches the snapshot 1`] = `
         ],
       },
       "Type": "AWS::IAM::Policy",
+    },
+    "HighLatencyBDC1CAA1": {
+      "Properties": {
+        "ActionsEnabled": true,
+        "AlarmActions": [
+          {
+            "Ref": "ScaleUpAF7DDD3C",
+          },
+        ],
+        "AlarmDescription": "Latency alarm for autoscaling",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 2,
+        "Dimensions": [
+          {
+            "Name": "AutoScalingGroupName",
+            "Value": {
+              "Ref": "AutoscalingGroup",
+            },
+          },
+        ],
+        "EvaluationPeriods": 30,
+        "MetricName": "Latency",
+        "Namespace": "AWS/ELB",
+        "OKActions": [
+          {
+            "Ref": "ScaleDown2D6349BF",
+          },
+        ],
+        "Period": 1,
+        "Statistic": "Average",
+        "Threshold": 0.2,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
     },
     "InstanceRole": {
       "Properties": {
@@ -910,6 +867,40 @@ exports[`The DotcomRendering stack matches the snapshot 1`] = `
         ],
       },
       "Type": "AWS::IAM::Policy",
+    },
+    "ScaleDown2D6349BF": {
+      "Properties": {
+        "AdjustmentType": "ChangeInCapacity",
+        "AutoScalingGroupName": {
+          "Ref": "AutoscalingGroup",
+        },
+        "Cooldown": "15",
+        "PolicyType": "StepScaling",
+        "StepAdjustments": [
+          {
+            "MetricIntervalLowerBound": 0,
+            "ScalingAdjustment": -1,
+          },
+        ],
+      },
+      "Type": "AWS::AutoScaling::ScalingPolicy",
+    },
+    "ScaleUpAF7DDD3C": {
+      "Properties": {
+        "AdjustmentType": "PercentChangeInCapacity",
+        "AutoScalingGroupName": {
+          "Ref": "AutoscalingGroup",
+        },
+        "Cooldown": "30",
+        "PolicyType": "StepScaling",
+        "StepAdjustments": [
+          {
+            "MetricIntervalLowerBound": 0,
+            "ScalingAdjustment": 100,
+          },
+        ],
+      },
+      "Type": "AWS::AutoScaling::ScalingPolicy",
     },
     "WazuhSecurityGroup": {
       "Properties": {

--- a/dotcom-rendering/cdk/lib/__snapshots__/dotcom-rendering.test.ts.snap
+++ b/dotcom-rendering/cdk/lib/__snapshots__/dotcom-rendering.test.ts.snap
@@ -307,7 +307,7 @@ exports[`The DotcomRendering stack matches the snapshot 1`] = `
         "EvaluationPeriods": 1,
         "MetricName": "Latency",
         "Namespace": "AWS/ELB",
-        "Period": 300,
+        "Period": 60,
         "Statistic": "Average",
         "Threshold": 200,
       },
@@ -319,17 +319,18 @@ exports[`The DotcomRendering stack matches the snapshot 1`] = `
         "AutoScalingGroupName": {
           "Ref": "AutoscalingGroup",
         },
+        "Cooldown": "120",
         "MetricAggregationType": "Average",
         "PolicyType": "StepScaling",
         "StepAdjustments": [
           {
             "MetricIntervalLowerBound": -100,
             "MetricIntervalUpperBound": 0,
-            "ScalingAdjustment": 12,
+            "ScalingAdjustment": 1,
           },
           {
             "MetricIntervalUpperBound": -100,
-            "ScalingAdjustment": 12,
+            "ScalingAdjustment": 1,
           },
         ],
       },
@@ -347,7 +348,7 @@ exports[`The DotcomRendering stack matches the snapshot 1`] = `
         "EvaluationPeriods": 1,
         "MetricName": "Latency",
         "Namespace": "AWS/ELB",
-        "Period": 300,
+        "Period": 60,
         "Statistic": "Average",
         "Threshold": 200,
       },
@@ -359,22 +360,18 @@ exports[`The DotcomRendering stack matches the snapshot 1`] = `
         "AutoScalingGroupName": {
           "Ref": "AutoscalingGroup",
         },
+        "Cooldown": "120",
         "MetricAggregationType": "Average",
         "PolicyType": "StepScaling",
         "StepAdjustments": [
           {
             "MetricIntervalLowerBound": 0,
             "MetricIntervalUpperBound": 100,
-            "ScalingAdjustment": 15,
+            "ScalingAdjustment": 4,
           },
           {
             "MetricIntervalLowerBound": 100,
-            "MetricIntervalUpperBound": 200,
-            "ScalingAdjustment": 18,
-          },
-          {
-            "MetricIntervalLowerBound": 200,
-            "ScalingAdjustment": 21,
+            "ScalingAdjustment": 7,
           },
         ],
       },
@@ -841,14 +838,6 @@ exports[`The DotcomRendering stack matches the snapshot 1`] = `
     "LatencyScalingAlarm": {
       "Properties": {
         "ActionsEnabled": true,
-        "AlarmActions": [
-          {
-            "Fn::GetAtt": [
-              "ScaleUpPolicy",
-              "Arn",
-            ],
-          },
-        ],
         "AlarmDescription": "Scale up if latency is GreaterThanOrEqualToThreshold of 0.2 over 1 period(s) of 60 seconds",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
         "Dimensions": [
@@ -862,14 +851,6 @@ exports[`The DotcomRendering stack matches the snapshot 1`] = `
         "EvaluationPeriods": 1,
         "MetricName": "Latency",
         "Namespace": "AWS/ELB",
-        "OKActions": [
-          {
-            "Fn::GetAtt": [
-              "ScaleDownPolicy",
-              "Arn",
-            ],
-          },
-        ],
         "Period": 60,
         "Statistic": "Average",
         "Threshold": 0.2,
@@ -934,28 +915,6 @@ exports[`The DotcomRendering stack matches the snapshot 1`] = `
         ],
       },
       "Type": "AWS::IAM::Policy",
-    },
-    "ScaleDownPolicy": {
-      "Properties": {
-        "AdjustmentType": "ChangeInCapacity",
-        "AutoScalingGroupName": {
-          "Ref": "AutoscalingGroup",
-        },
-        "Cooldown": "120",
-        "ScalingAdjustment": -1,
-      },
-      "Type": "AWS::AutoScaling::ScalingPolicy",
-    },
-    "ScaleUpPolicy": {
-      "Properties": {
-        "AdjustmentType": "PercentChangeInCapacity",
-        "AutoScalingGroupName": {
-          "Ref": "AutoscalingGroup",
-        },
-        "Cooldown": "600",
-        "ScalingAdjustment": 100,
-      },
-      "Type": "AWS::AutoScaling::ScalingPolicy",
     },
     "WazuhSecurityGroup": {
       "Properties": {

--- a/dotcom-rendering/cdk/lib/__snapshots__/dotcom-rendering.test.ts.snap
+++ b/dotcom-rendering/cdk/lib/__snapshots__/dotcom-rendering.test.ts.snap
@@ -485,7 +485,7 @@ exports[`The DotcomRendering stack matches the snapshot 1`] = `
       },
       "Type": "AWS::IAM::Policy",
     },
-    "HighLatencyBDC1CAA1": {
+    "HighLatencyAlarm61213652": {
       "Properties": {
         "ActionsEnabled": true,
         "AlarmActions": [
@@ -504,7 +504,7 @@ exports[`The DotcomRendering stack matches the snapshot 1`] = `
             },
           },
         ],
-        "EvaluationPeriods": 30,
+        "EvaluationPeriods": 3,
         "MetricName": "Latency",
         "Namespace": "AWS/ELB",
         "OKActions": [
@@ -512,7 +512,7 @@ exports[`The DotcomRendering stack matches the snapshot 1`] = `
             "Ref": "ScaleDown2D6349BF",
           },
         ],
-        "Period": 1,
+        "Period": 10,
         "Statistic": "Average",
         "Threshold": 0.2,
         "TreatMissingData": "missing",

--- a/dotcom-rendering/cdk/lib/__snapshots__/dotcom-rendering.test.ts.snap
+++ b/dotcom-rendering/cdk/lib/__snapshots__/dotcom-rendering.test.ts.snap
@@ -295,6 +295,91 @@ exports[`The DotcomRendering stack matches the snapshot 1`] = `
       },
       "Type": "AWS::AutoScaling::AutoScalingGroup",
     },
+    "AutoscalingGroupRenderingLatencyStepScalingPolicyLowerAlarmC8893E45": {
+      "Properties": {
+        "AlarmActions": [
+          {
+            "Ref": "AutoscalingGroupRenderingLatencyStepScalingPolicyLowerPolicy76D73EE7",
+          },
+        ],
+        "AlarmDescription": "Lower threshold scaling alarm",
+        "ComparisonOperator": "LessThanOrEqualToThreshold",
+        "EvaluationPeriods": 1,
+        "MetricName": "Latency",
+        "Namespace": "AWS/ELB",
+        "Period": 300,
+        "Statistic": "Average",
+        "Threshold": 200,
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "AutoscalingGroupRenderingLatencyStepScalingPolicyLowerPolicy76D73EE7": {
+      "Properties": {
+        "AdjustmentType": "ExactCapacity",
+        "AutoScalingGroupName": {
+          "Ref": "AutoscalingGroup",
+        },
+        "MetricAggregationType": "Average",
+        "PolicyType": "StepScaling",
+        "StepAdjustments": [
+          {
+            "MetricIntervalLowerBound": -100,
+            "MetricIntervalUpperBound": 0,
+            "ScalingAdjustment": 12,
+          },
+          {
+            "MetricIntervalUpperBound": -100,
+            "ScalingAdjustment": 12,
+          },
+        ],
+      },
+      "Type": "AWS::AutoScaling::ScalingPolicy",
+    },
+    "AutoscalingGroupRenderingLatencyStepScalingPolicyUpperAlarmD121CE9C": {
+      "Properties": {
+        "AlarmActions": [
+          {
+            "Ref": "AutoscalingGroupRenderingLatencyStepScalingPolicyUpperPolicy08A879B8",
+          },
+        ],
+        "AlarmDescription": "Upper threshold scaling alarm",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "EvaluationPeriods": 1,
+        "MetricName": "Latency",
+        "Namespace": "AWS/ELB",
+        "Period": 300,
+        "Statistic": "Average",
+        "Threshold": 200,
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "AutoscalingGroupRenderingLatencyStepScalingPolicyUpperPolicy08A879B8": {
+      "Properties": {
+        "AdjustmentType": "ExactCapacity",
+        "AutoScalingGroupName": {
+          "Ref": "AutoscalingGroup",
+        },
+        "MetricAggregationType": "Average",
+        "PolicyType": "StepScaling",
+        "StepAdjustments": [
+          {
+            "MetricIntervalLowerBound": 0,
+            "MetricIntervalUpperBound": 100,
+            "ScalingAdjustment": 15,
+          },
+          {
+            "MetricIntervalLowerBound": 100,
+            "MetricIntervalUpperBound": 200,
+            "ScalingAdjustment": 18,
+          },
+          {
+            "MetricIntervalLowerBound": 200,
+            "ScalingAdjustment": 21,
+          },
+        ],
+      },
+      "Type": "AWS::AutoScaling::ScalingPolicy",
+    },
     "Backend5xxAlarm": {
       "Properties": {
         "ActionsEnabled": false,
@@ -755,7 +840,7 @@ exports[`The DotcomRendering stack matches the snapshot 1`] = `
     },
     "LatencyScalingAlarm": {
       "Properties": {
-        "ActionsEnabled": false,
+        "ActionsEnabled": true,
         "AlarmActions": [
           {
             "Fn::GetAtt": [

--- a/dotcom-rendering/cdk/lib/dotcom-rendering.ts
+++ b/dotcom-rendering/cdk/lib/dotcom-rendering.ts
@@ -17,12 +17,7 @@ import {
 import { GuClassicLoadBalancer } from '@guardian/cdk/lib/constructs/loadbalancing';
 import type { App } from 'aws-cdk-lib';
 import { CfnOutput, Duration, Tags } from 'aws-cdk-lib';
-import {
-	AdjustmentType,
-	HealthCheck,
-	MetricAggregationType,
-	StepScalingPolicy,
-} from 'aws-cdk-lib/aws-autoscaling';
+import { AdjustmentType, HealthCheck } from 'aws-cdk-lib/aws-autoscaling';
 import { CfnAlarm, Metric } from 'aws-cdk-lib/aws-cloudwatch';
 import { InstanceType, Peer } from 'aws-cdk-lib/aws-ec2';
 import { LoadBalancingProtocol } from 'aws-cdk-lib/aws-elasticloadbalancing';
@@ -285,55 +280,11 @@ export class DotcomRendering extends GuStack {
 		// 	scalingAdjustment: -1,
 		// });
 
-		// @ts-ignore
-		const latencyStepScalingPolicy = new StepScalingPolicy(
-			this,
-			'LatencyStepScalingPolicy',
-			{
-				autoScalingGroup: asg,
-				metricAggregationType: MetricAggregationType.AVERAGE,
-				adjustmentType: AdjustmentType.EXACT_CAPACITY,
-				scalingSteps: [
-					{
-						lower: 0,
-						upper: 100,
-						change: props.minCapacity,
-					},
-					{
-						lower: 100,
-						upper: 200,
-						change: props.minCapacity,
-					},
-					{
-						change: props.minCapacity + 3,
-						lower: 200,
-						upper: 300,
-					},
-					{
-						change: props.minCapacity + 6,
-						lower: 300,
-						upper: undefined,
-					},
-				],
-				cooldown: Duration.seconds(60),
-				metric: new Metric({
-					namespace: 'AWS/ELB',
-					metricName: 'Latency',
-					period: Duration.minutes(1),
-				}),
-			},
-		);
-
-		// TODO: Link with CloudWatch alarms
-		// latencyStepScalingPolicy.lowerAlarm
-		// latencyStepScalingPolicy.upperAlarm
-		// latencyStepScalingPolicy.upperAction
-		// latencyStepScalingPolicy.lowerAction
-
 		asg.scaleOnMetric('LatencyStepScalingPolicy', {
 			metric: new Metric({
 				metricName: 'Latency',
 				namespace: 'AWS/ELB',
+				period: Duration.minutes(1),
 			}),
 			scalingSteps: [
 				{
@@ -358,7 +309,7 @@ export class DotcomRendering extends GuStack {
 				},
 			],
 			adjustmentType: AdjustmentType.EXACT_CAPACITY,
-			cooldown: Duration.minutes(1),
+			cooldown: Duration.minutes(2),
 			evaluationPeriods: 1,
 		});
 

--- a/dotcom-rendering/cdk/lib/dotcom-rendering.ts
+++ b/dotcom-rendering/cdk/lib/dotcom-rendering.ts
@@ -280,32 +280,30 @@ export class DotcomRendering extends GuStack {
 		// 	scalingAdjustment: -1,
 		// });
 
+		const latencyMetric = new Metric({
+			metricName: 'Latency',
+			namespace: 'AWS/ELB',
+			period: Duration.minutes(1),
+			statistic: 'Average',
+		});
+
 		asg.scaleOnMetric('LatencyStepScalingPolicy', {
-			metric: new Metric({
-				metricName: 'Latency',
-				namespace: 'AWS/ELB',
-				period: Duration.minutes(1),
-			}),
+			metric: latencyMetric,
 			scalingSteps: [
 				{
 					lower: 0,
-					upper: 100,
+					upper: 0.2,
 					change: props.minCapacity,
 				},
 				{
-					lower: 100,
-					upper: 200,
-					change: props.minCapacity,
-				},
-				{
+					lower: 0.2,
+					upper: 0.3,
 					change: props.minCapacity + 3,
-					lower: 200,
-					upper: 300,
 				},
 				{
-					change: props.minCapacity + 6,
-					lower: 300,
+					lower: 0.3,
 					upper: undefined,
+					change: props.minCapacity + 6,
 				},
 			],
 			adjustmentType: AdjustmentType.EXACT_CAPACITY,

--- a/dotcom-rendering/cdk/lib/dotcom-rendering.ts
+++ b/dotcom-rendering/cdk/lib/dotcom-rendering.ts
@@ -301,7 +301,7 @@ export class DotcomRendering extends GuStack {
 			comparisonOperator: 'GreaterThanOrEqualToThreshold',
 		};
 		new CfnAlarm(this, 'LatencyScalingAlarm', {
-			actionsEnabled: stage === 'PROD',
+			actionsEnabled: true,
 			alarmDescription: getAlarmDescription({
 				title: 'Scale up if latency',
 				...latencyScalingAlarmConfig,

--- a/dotcom-rendering/cdk/lib/dotcom-rendering.ts
+++ b/dotcom-rendering/cdk/lib/dotcom-rendering.ts
@@ -276,7 +276,8 @@ export class DotcomRendering extends GuStack {
 			cooldown: '600',
 			scalingAdjustment: 100,
 		});
-		const minAsgSize = 27;
+
+		const minAsgSize = 12;
 
 		asg.scaleOnMetric('LatencyStepScalingPolicy', {
 			metric: new Metric({
@@ -285,14 +286,29 @@ export class DotcomRendering extends GuStack {
 			}),
 			scalingSteps: [
 				{
-					change: minAsgSize + 3,
-					lower: 200,
-					upper: 300,
+					lower: 0,
+					upper: 100,
+					change: minAsgSize,
 				},
 				{
 					change: minAsgSize,
 					lower: 100,
 					upper: 200,
+				},
+				{
+					change: minAsgSize + 3,
+					lower: 200,
+					upper: 300,
+				},
+				{
+					change: minAsgSize + 6,
+					lower: 300,
+					upper: 400,
+				},
+				{
+					change: minAsgSize + 9,
+					lower: 400,
+					upper: undefined,
 				},
 			],
 			adjustmentType: AdjustmentType.EXACT_CAPACITY,

--- a/dotcom-rendering/cdk/lib/dotcom-rendering.ts
+++ b/dotcom-rendering/cdk/lib/dotcom-rendering.ts
@@ -23,7 +23,7 @@ import {
 	HealthCheck,
 	StepScalingPolicy,
 } from 'aws-cdk-lib/aws-autoscaling';
-import {CfnAlarm, Metric} from 'aws-cdk-lib/aws-cloudwatch';
+import { CfnAlarm, Metric } from 'aws-cdk-lib/aws-cloudwatch';
 import { InstanceType, Peer } from 'aws-cdk-lib/aws-ec2';
 import { LoadBalancingProtocol } from 'aws-cdk-lib/aws-elasticloadbalancing';
 import { StringParameter } from 'aws-cdk-lib/aws-ssm';
@@ -278,11 +278,14 @@ export class DotcomRendering extends GuStack {
 			scalingAdjustment: 100,
 		});
 		const minAsgSize = 27;
+
+		// @ts-ignore
 		const scaleUpPolicy2 = new StepScalingPolicy(this, 'ScaleUp', {
 			autoScalingGroup: asg,
 			metric: new Metric({
 				metricName: 'Latency',
-				namespace: 'AWS/ELB',}),
+				namespace: 'AWS/ELB',
+			}),
 			scalingSteps: [
 				{
 					change: minAsgSize + 3,

--- a/dotcom-rendering/cdk/lib/dotcom-rendering.ts
+++ b/dotcom-rendering/cdk/lib/dotcom-rendering.ts
@@ -291,20 +291,20 @@ export class DotcomRendering extends GuStack {
 		// 	scalingAdjustment: -1,
 		// });
 
-		const latencyHighAlarm = new Alarm(this, 'HighLatency', {
+		const latencyHighAlarm = new Alarm(this, 'HighLatencyAlarm', {
 			actionsEnabled: true,
 			alarmDescription: 'Latency alarm for autoscaling',
 			threshold: 0.2,
 			comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
 			datapointsToAlarm: 2,
-			evaluationPeriods: 30,
+			evaluationPeriods: 3,
 			metric: new Metric({
 				dimensionsMap: {
 					AutoScalingGroupName: asg.autoScalingGroupName,
 				},
 				metricName: 'Latency',
 				namespace: 'AWS/ELB',
-				period: Duration.seconds(1),
+				period: Duration.seconds(10),
 				statistic: 'Average',
 			}),
 

--- a/dotcom-rendering/cdk/lib/dotcom-rendering.ts
+++ b/dotcom-rendering/cdk/lib/dotcom-rendering.ts
@@ -21,7 +21,6 @@ import {
 	AdjustmentType,
 	CfnScalingPolicy,
 	HealthCheck,
-	StepScalingPolicy,
 } from 'aws-cdk-lib/aws-autoscaling';
 import { CfnAlarm, Metric } from 'aws-cdk-lib/aws-cloudwatch';
 import { InstanceType, Peer } from 'aws-cdk-lib/aws-ec2';
@@ -279,9 +278,7 @@ export class DotcomRendering extends GuStack {
 		});
 		const minAsgSize = 27;
 
-		// @ts-ignore
-		const scaleUpPolicy2 = new StepScalingPolicy(this, 'ScaleUp', {
-			autoScalingGroup: asg,
+		asg.scaleOnMetric('LatencyStepScalingPolicy', {
 			metric: new Metric({
 				metricName: 'Latency',
 				namespace: 'AWS/ELB',
@@ -300,6 +297,7 @@ export class DotcomRendering extends GuStack {
 			],
 			adjustmentType: AdjustmentType.EXACT_CAPACITY,
 		});
+
 		const scaleDownPolicy = new CfnScalingPolicy(this, 'ScaleDownPolicy', {
 			adjustmentType: AdjustmentType.CHANGE_IN_CAPACITY,
 			autoScalingGroupName: asg.autoScalingGroupName,


### PR DESCRIPTION
## Our current scaling policy

* We're using Simple Scaling Policy and are scaling based on `ELB/Latency` metric.
* Scaling up by doubling capacity every 10 minutes
* Scaling down by removing an instance every 2 minutes until we reach `minSize` of the ASG.

## Background

* AWS have [deprecated Simple Scaling Policy](https://docs.aws.amazon.com/autoscaling/ec2/userguide/ec2-auto-scaling-scaling-cooldowns.html) and recommending trying a target tracking scaling policy or step scaling policy for better scaling performance. 
* AWS recommends **target tracking** for a scaling policy that changes the size of the ASG proportionally as the value of the scaling metric decreases or increases, e.g. Average CPU utilization of the Auto Scaling group, see [AR example](https://github.com/guardian/dotcom-rendering/blob/e234547e28cb1071b83c526fdbae7df5c361f522/apps-rendering/cdk/lib/mobile-apps-rendering.ts#L104-L106). 
* The current metric we're using, i.e. `ELB/Latency` [does not work for target tracking](https://docs.aws.amazon.com/autoscaling/ec2/userguide/as-scaling-target-tracking.html#target-tracking-choose-metrics). According to the docs: "Request latency can increase based on increasing utilization, but doesn't necessarily change proportionally." 
* Also, `Latency` is an [`ELB` CloudWatch metric](https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-cloudwatch-metrics.html) and we're [moving away from ELB to ALB](https://github.com/guardian/dotcom-rendering/issues/9310). [ALB CloudWatch metrics](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-cloudwatch-metrics.html) do not have `Latency` so once we swap from ELB to ALB we will have to change the metric anyway.
* [ALB CloudWatch metrics](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-cloudwatch-metrics.html) that seem appropriate:
   - `RequestCountPerTarget`: "The average number of requests received by each target in a target group." (can be used with target tracking scaling) 
   - `TargetResponseTime`: "The time elapsed, in seconds, after the request leaves the load balancer until a response from the target is received." Worth noting the [SLI DevX dashboard](https://metrics.gutools.co.uk/d/zM0ouzs4z/sli-dashboard-debug-view?orgId=1&editPanel=109) uses `ELB/Latency` and `ApplicationELB/TargetResponseTime` as equivalent metrics to calculate Latency and it [looks like for the purposes of scaling they _are_ equivalent](https://repost.aws/questions/QUghsSU7OTSFOvClGSIR_9jA/alb-metric-equivalent-of-latency-metric-in-classic-load-balancer). (can be used with step scaling)
   
<br> 
<img width="1306" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/19683595/45b0840d-a302-4613-a2ba-82986a19e323">
<br>
<br>
   
* As per [AWS docs](https://docs.aws.amazon.com/autoscaling/ec2/userguide/as-scaling-simple-step.html): "We strongly recommend that you use target tracking scaling policies to scale on metrics like average CPU utilization or average request count per target."
* Created this [dashboard](https://metrics.gutools.co.uk/d/-RjgjKdIz/scaling-policy-useful-metrics?from=now-1y&to=now) to see the relationship between metrics that can be used for the scaling policy. e.g. here's the relationship between CPU usage and latency for the last year.

<img width="1653" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/19683595/40ce9b6e-a861-4864-a672-917487015e48">


## Next steps


UPDATED:
We're going to do the following (see also [release plan]( https://docs.google.com/document/d/1EK-tS0NP0yhuuEl_kM9mBPvmwaWH3r3UTcsVLy-WXm0/edit?usp=sharing)) ~~It looks like we have the following options~~:
1. Complete the [migration from ELB to ALB](https://github.com/guardian/dotcom-rendering/issues/9310). Will be done by:
* https://github.com/guardian/dotcom-rendering/pull/9955
 ~~using the current Simple Scaling Policy. Once that's done, change our scaling policy to Step scaling on `ALB/TargetResponseTime`~~. No scaling policy at this point. No traffic will be sent to the article app.
2. Add the scaling policy using `ALB/TargetResponseTime` ~~Implement Step Scaling on `ELB/Latency` before we migrate from ELB to ALB. Once we migrate, we should change the metric to `ALB/TargetResponseTime`.~~
3. Consider whether we also want to scale on `CPUUtilisation` and / or `RequestCountPerTarget`.

