### PR TITLE
Make targeting Islands server-safe

### DIFF
--- a/dotcom-rendering/src/components/ArticlePage.tsx
+++ b/dotcom-rendering/src/components/ArticlePage.tsx
@@ -174,7 +174,7 @@ export const ArticlePage = (props: WebProps | AppProps) => {
 					<SetAdTargeting adTargeting={adTargeting} />
 				</Island>
 			) : (
-				<Island clientOnly={true} priority="critical">
+				<Island priority="critical">
 					<SendTargetingParams
 						editionCommercialProperties={
 							article.commercialProperties[article.editionId]

--- a/dotcom-rendering/src/components/ArticlePage.tsx
+++ b/dotcom-rendering/src/components/ArticlePage.tsx
@@ -170,7 +170,7 @@ export const ArticlePage = (props: WebProps | AppProps) => {
 				</>
 			)}
 			{renderingTarget === 'Web' ? (
-				<Island clientOnly={true} priority="critical">
+				<Island priority="critical">
 					<SetAdTargeting adTargeting={adTargeting} />
 				</Island>
 			) : (

--- a/dotcom-rendering/src/components/FrontPage.tsx
+++ b/dotcom-rendering/src/components/FrontPage.tsx
@@ -94,7 +94,7 @@ export const FrontPage = ({ front, NAV }: Props) => {
 				/>
 			</Island>
 
-			<Island priority="critical" clientOnly={true}>
+			<Island priority="critical">
 				<SetAdTargeting adTargeting={adTargeting} />
 			</Island>
 			<Island

--- a/dotcom-rendering/src/components/Island.test.tsx
+++ b/dotcom-rendering/src/components/Island.test.tsx
@@ -22,6 +22,7 @@ import { ReaderRevenueDev } from './ReaderRevenueDev.importable';
 import { RecipeMultiplier } from './RecipeMultiplier.importable';
 import { SendTargetingParams } from './SendTargetingParams.importable';
 import { SetABTests } from './SetABTests.importable';
+import { SetAdTargeting } from './SetAdTargeting.importable';
 import { SignInGateSelector } from './SignInGateSelector.importable';
 import { SlotBodyEnd } from './SlotBodyEnd.importable';
 import { Snow } from './Snow.importable';
@@ -275,6 +276,18 @@ describe('Island: server-side rendering', () => {
 					isDev={false}
 					pageIsSensitive={false}
 					abTestSwitches={{}}
+				/>,
+			),
+		).not.toThrow();
+	});
+
+	test('SetAdTargeting', () => {
+		expect(() =>
+			renderToString(
+				<SetAdTargeting
+					adTargeting={{
+						disableAds: true,
+					}}
 				/>,
 			),
 		).not.toThrow();

--- a/dotcom-rendering/src/components/Island.test.tsx
+++ b/dotcom-rendering/src/components/Island.test.tsx
@@ -20,6 +20,7 @@ import { Metrics } from './Metrics.importable';
 import { OnwardsUpper } from './OnwardsUpper.importable';
 import { ReaderRevenueDev } from './ReaderRevenueDev.importable';
 import { RecipeMultiplier } from './RecipeMultiplier.importable';
+import { SendTargetingParams } from './SendTargetingParams.importable';
 import { SetABTests } from './SetABTests.importable';
 import { SignInGateSelector } from './SignInGateSelector.importable';
 import { SlotBodyEnd } from './SlotBodyEnd.importable';
@@ -255,6 +256,16 @@ describe('Island: server-side rendering', () => {
 
 	test('RecipeMultiplier', () => {
 		expect(() => renderToString(<RecipeMultiplier />)).not.toThrow();
+	});
+
+	test('SendTargetingParams', () => {
+		expect(() =>
+			renderToString(
+				<SendTargetingParams
+					editionCommercialProperties={{ adTargeting: [] }}
+				/>,
+			),
+		).not.toThrow();
 	});
 
 	test('SetABTests', () => {

--- a/dotcom-rendering/src/components/SendTargetingParams.importable.tsx
+++ b/dotcom-rendering/src/components/SendTargetingParams.importable.tsx
@@ -1,7 +1,6 @@
 import { log } from '@guardian/libs';
 import { useEffect } from 'react';
 import { getAnalyticsClient } from '../lib/bridgetApi';
-import { isServer } from '../lib/isServer';
 import { getTargetingParams } from '../lib/sendTargetingParams.apps';
 import type { EditionCommercialProperties } from '../types/commercial';
 
@@ -10,10 +9,6 @@ type Props = {
 };
 
 export const SendTargetingParams = ({ editionCommercialProperties }: Props) => {
-	if (isServer) {
-		throw new Error('SendTargetingParams is client only');
-	}
-
 	useEffect(() => {
 		void getAnalyticsClient()
 			.sendTargetingParams(

--- a/dotcom-rendering/src/components/SetAdTargeting.importable.tsx
+++ b/dotcom-rendering/src/components/SetAdTargeting.importable.tsx
@@ -1,5 +1,4 @@
 import { log } from '@guardian/libs';
-import { isServer } from '../lib/isServer';
 import { setAdTargeting } from '../lib/useAdTargeting';
 
 type Props = {
@@ -7,10 +6,6 @@ type Props = {
 };
 
 export const SetAdTargeting = ({ adTargeting }: Props) => {
-	if (isServer) {
-		throw new Error('SetAdTargeting is client only');
-	}
-
 	setAdTargeting(adTargeting);
 	log('commercial', '🎯 Ad targeting', adTargeting);
 

--- a/dotcom-rendering/src/components/TagFrontPage.tsx
+++ b/dotcom-rendering/src/components/TagFrontPage.tsx
@@ -85,7 +85,7 @@ export const TagFrontPage = ({ tagFront, NAV }: Props) => {
 					isDev={!!tagFront.config.isDev}
 				/>
 			</Island>
-			<Island priority="critical" clientOnly={true}>
+			<Island priority="critical">
 				<SetAdTargeting adTargeting={adTargeting} />
 			</Island>
 			<TagFrontLayout tagFront={tagFront} NAV={NAV} />


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Make `SetAdTargeting` and `SendTargetingParams` server-safe by remove unnecessary errors.

## Why?

No assumption should be made about where components are run

- Split out from #8991 for easier review
- Enables the work from #8948 to proceed safely.

## Screenshots

N/A