### PR TITLE
Tag front design tidy

### DIFF
--- a/dotcom-rendering/src/components/FrontPagination.tsx
+++ b/dotcom-rendering/src/components/FrontPagination.tsx
@@ -35,6 +35,7 @@ const paginationItemContainerCss = css`
 	display: flex;
 	flex-direction: row;
 	align-items: center;
+	gap: 2px;
 `;
 
 const paginationItemCss = css`
@@ -44,7 +45,6 @@ const paginationItemCss = css`
 
 	min-width: 25px;
 	padding: 3px ${space[1]}px;
-	margin: ${space[1]}px;
 
 	${textSans.xxsmall({ fontWeight: 'bold' })}
 	text-decoration: none;
@@ -71,7 +71,7 @@ const activePaginationItemCss = css`
 const paginationDotsCss = css`
 	${textSans.xxsmall({ fontWeight: 'bold' })}
 	color: ${palette.neutral[46]};
-	padding: ${space[1]}px;
+	text-align: center;
 `;
 
 const paginationArrowsCss = css`
@@ -80,7 +80,6 @@ const paginationArrowsCss = css`
 	border: 1px solid ${palette.neutral[86]};
 
 	border-radius: 20px;
-
 	padding: 2px;
 
 	svg {
@@ -167,7 +166,16 @@ export const FrontPagination = ({
 								</a>
 							)}
 							{shouldSuffixDots && (
-								<span css={paginationDotsCss}>...</span>
+								<span
+									css={[
+										paginationDotsCss,
+										css`
+											margin-right: ${space[1]}px;
+										`,
+									]}
+								>
+									...
+								</span>
 							)}
 						</Fragment>
 					);

--- a/dotcom-rendering/src/components/TagFrontHeader.tsx
+++ b/dotcom-rendering/src/components/TagFrontHeader.tsx
@@ -3,6 +3,7 @@ import {
 	breakpoints,
 	from,
 	headline,
+	neutral,
 	palette,
 	space,
 	until,
@@ -12,7 +13,6 @@ import { decideContainerOverrides } from '../lib/decideContainerOverrides';
 import { isElement, parseHtml } from '../lib/domUtils';
 import { logger } from '../server/lib/logging';
 import type { DCRContainerPalette } from '../types/front';
-import { ContainerTitle } from './ContainerTitle';
 import { generateSources, Sources } from './Picture';
 
 type Props = {
@@ -141,20 +141,6 @@ const sectionHeadline = css`
 
 	display: flex;
 	flex-direction: column;
-
-	${from.leftCol} {
-		position: relative;
-		::after {
-			content: '';
-			display: block;
-			width: 1px;
-			top: 0;
-			height: 1.875rem;
-			right: -10px;
-			position: absolute;
-			background-color: ${palette.neutral[86]};
-		}
-	}
 `;
 
 const paddings = css`
@@ -198,7 +184,7 @@ const sideBorders = css`
 	}
 `;
 
-const titleStyle = css`
+const titleContainerStyle = css`
 	${until.leftCol} {
 		max-width: 74%;
 	}
@@ -207,6 +193,13 @@ const titleStyle = css`
 const paragraphStyle = css`
 	${headline.xxxsmall()}
 	color: ${palette.neutral[46]};
+`;
+
+const titleStyle = css`
+	${headline.xxsmall({ fontWeight: 'bold' })};
+	color: ${neutral[7]};
+	padding-bottom: ${space[1]}px;
+	overflow-wrap: break-word; /*if a single word is too long, this will break the word up rather than have the display be affected*/
 `;
 
 const buildElementTree = (node: Node): ReactNode => {
@@ -280,28 +273,20 @@ export const TagFrontHeader = ({
 		? parseHtml(description)
 		: undefined;
 
-	/**
-	 * id is being used to set the containerId in @see {ShowMore.importable.tsx}
-	 * this id pre-existed showMore so is probably also being used for something else.
-	 */
 	return (
 		<section
 			css={[
 				fallbackStyles,
 				containerStyles,
 				css`
-					background-color: ${overrides?.background?.container};
+					background-color: ${overrides?.background.container};
 				`,
 			]}
 		>
 			<div css={[decoration, sideBorders]} />
 
-			<div css={[sectionHeadline, titleStyle, paddings]}>
-				<ContainerTitle
-					title={title}
-					fontColour={overrides?.text?.container}
-					containerPalette={containerPalette}
-				/>
+			<div css={[sectionHeadline, titleContainerStyle, paddings]}>
+				<h2 css={titleStyle}>{title}</h2>
 			</div>
 
 			{image !== undefined && (

--- a/dotcom-rendering/src/layouts/TagFrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/TagFrontLayout.tsx
@@ -1,11 +1,13 @@
 import { css } from '@emotion/react';
 import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
 import {
+	body,
 	brandBackground,
 	brandBorder,
 	brandLine,
 	neutral,
 	news,
+	space,
 } from '@guardian/source-foundations';
 import { StraightLines } from '@guardian/source-react-components-development-kitchen';
 import { Fragment, useRef } from 'react';
@@ -61,6 +63,48 @@ const getContainerId = (date: Date, locale: string, hasDay: boolean) => {
 			year: 'numeric',
 		})}`;
 	}
+};
+
+const titleStyle = css`
+	${body.medium({ fontWeight: 'regular' })};
+	color: ${neutral[7]};
+	padding-bottom: ${space[1]}px;
+	padding-top: ${space[1]}px;
+	overflow-wrap: break-word; /*if a single word is too long, this will break the word up rather than have the display be affected*/
+`;
+
+const linkStyle = css`
+	text-decoration: none;
+	color: ${neutral[7]};
+
+	&:hover {
+		text-decoration: underline;
+	}
+`;
+
+const SectionLeftContent = ({
+	url,
+	title,
+	dateString,
+}: {
+	title: string;
+	dateString: string;
+	url?: string;
+}) => {
+	if (url !== undefined) {
+		return (
+			<header css={titleStyle}>
+				<a href={url} css={linkStyle}>
+					<time dateTime={dateString}>{title}</time>
+				</a>
+			</header>
+		);
+	}
+	return (
+		<header css={titleStyle}>
+			<time dateTime={dateString}>{title}</time>
+		</header>
+	);
 };
 
 export const TagFrontLayout = ({ tagFront, NAV }: Props) => {
@@ -241,15 +285,30 @@ export const TagFrontLayout = ({ tagFront, NAV }: Props) => {
 								null,
 							)}
 							<FrontSection
-								title={date.toLocaleDateString('en-GB', {
-									day:
-										groupedTrails.day !== undefined
-											? 'numeric'
-											: undefined,
-									month: 'long',
-									year: 'numeric',
-								})}
-								url={url}
+								leftContent={
+									<SectionLeftContent
+										url={url}
+										title={date.toLocaleDateString(
+											'en-GB',
+											{
+												day:
+													groupedTrails.day !==
+													undefined
+														? 'numeric'
+														: undefined,
+												month: 'long',
+												year: 'numeric',
+											},
+										)}
+										dateString={`${groupedTrails.year}-${
+											groupedTrails.month
+										}${
+											groupedTrails.day !== undefined
+												? `-${groupedTrails.day}`
+												: ''
+										}`}
+									/>
+								}
 								showTopBorder={true}
 								ophanComponentLink={`container-${index} | ${containedId}`}
 								ophanComponentName={containedId}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

Closes #8318 and #8317 

## What does this change?

Fixes three areas of design for tag fronts
- Header title / tag title size & styling
- Container title size & styling
- Spacing on pagination component

> Note: Perfect parity with Frontend was not achieved, mostly as the exact same font weights & sizes are not used in DCR - so this PR has gone for 'closest' options.

## Screenshots

| Before      | After      | Frontend      |
| ----------- | ---------- |---------- |
| ![before][] | ![after][] | ![frontend][] |
| ![before1][] | ![after1][] | ![frontend1][] |
| ![before2][] | ![after2][] | ![frontend2][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/9575458/a762185a-ab4d-4be6-bb53-70795bbd42ec
[after]: https://github.com/guardian/dotcom-rendering/assets/9575458/56f04045-6c79-4d98-8292-c05171eab87c
[frontend]: https://github.com/guardian/dotcom-rendering/assets/9575458/0c7a36e1-402c-4e89-b3ca-b11d79109f68

[before1]: https://github.com/guardian/dotcom-rendering/assets/9575458/9fb7d754-464d-411f-8ad6-d89ba6a90c3b
[after1]: https://github.com/guardian/dotcom-rendering/assets/9575458/30431896-25a4-4a2f-a4a3-51ee594cccf2
[frontend1]: https://github.com/guardian/dotcom-rendering/assets/9575458/d356b31d-8f4f-412c-ae0b-200dabe6a702

[before2]: https://github.com/guardian/dotcom-rendering/assets/9575458/21507ad8-4cd1-4779-bca0-29af696e27d8

[after2]: https://github.com/guardian/dotcom-rendering/assets/9575458/97e650cf-a1e0-42de-b6a4-2dd4fa96b623

[frontend2]: https://github.com/guardian/dotcom-rendering/assets/9575458/8849465a-29cd-4bf8-9dfa-fbe98d9565b6





<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
