### PR TITLE
Set width in AMP `Branding` image

### DIFF
--- a/dotcom-rendering/src/components/Branding.amp.tsx
+++ b/dotcom-rendering/src/components/Branding.amp.tsx
@@ -20,7 +20,6 @@ const LinkStyle = (pillar: ArticleTheme) => css`
 
 const brandingStyle = (pillar: ArticleTheme) => css`
 	padding: 10px 0;
-	width: 160px;
 	${LinkStyle(pillar)}
 
 	a, a:hover {
@@ -58,10 +57,11 @@ export const Branding = ({ branding, pillar }: BrandingProps) => {
 			>
 				<amp-img
 					src={logo.src}
-					width="1.33"
-					height="1"
+					width={logo.dimensions.width}
+					height={logo.dimensions.height}
 					layout="responsive"
 					alt={sponsorName}
+					style={{ width: '140px' }}
 				/>
 			</a>
 			<a href={branding.aboutThisLink}>About this content</a>

--- a/dotcom-rendering/src/components/Branding.amp.tsx
+++ b/dotcom-rendering/src/components/Branding.amp.tsx
@@ -20,6 +20,7 @@ const LinkStyle = (pillar: ArticleTheme) => css`
 
 const brandingStyle = (pillar: ArticleTheme) => css`
 	padding: 10px 0;
+	width: 160px;
 	${LinkStyle(pillar)}
 
 	a, a:hover {
@@ -57,8 +58,9 @@ export const Branding = ({ branding, pillar }: BrandingProps) => {
 			>
 				<amp-img
 					src={logo.src}
-					width={logo.dimensions.width}
-					height={logo.dimensions.height}
+					width="1.33"
+					height="1"
+					layout="responsive"
 					alt={sponsorName}
 				/>
 			</a>


### PR DESCRIPTION
Fixes https://github.com/guardian/dotcom-rendering/issues/9408

<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Specifies width in AMP `Branding` image.

## Why?
Currently it takes the width of the image as it comes from the JSON data and sometimes this can be quite big.

![image](https://github.com/guardian/dotcom-rendering/assets/19683595/a461c831-471d-461c-be50-26da62b4d550)

![image](https://github.com/guardian/dotcom-rendering/assets/19683595/847b9baf-ebdd-43bf-9171-627c4d57b6a2)

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/4e8974d8-6c02-42fa-a115-298f5ae863ba) | ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/a3b0669f-bb37-4828-933b-e31a6e6e634b) |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
