### PR TITLE
Don't refresh ad-1 and ad-2 AMP ads

### DIFF
--- a/dotcom-rendering/src/components/Ad.amp.tsx
+++ b/dotcom-rendering/src/components/Ad.amp.tsx
@@ -98,7 +98,7 @@ export const Ad = ({
 		adType,
 	);
 
-	let refreshValue = id === 'ad-1' || id === 'ad-2' ? 'false' : '30';
+	const refreshValue = id === 'ad-1' || id === 'ad-2' ? 'false' : '30';
 
 	return (
 		<amp-ad

--- a/dotcom-rendering/src/components/Ad.amp.tsx
+++ b/dotcom-rendering/src/components/Ad.amp.tsx
@@ -98,6 +98,8 @@ export const Ad = ({
 		adType,
 	);
 
+	let refreshValue = id === 'ad-1' || id === 'ad-2' ? 'false' : '30';
+
 	return (
 		<amp-ad
 			data-block-on-consent="_till_accepted"
@@ -112,7 +114,7 @@ export const Ad = ({
 			data-multi-size-validation="false"
 			data-npa-on-unknown-consent={true}
 			data-loading-strategy="prefer-viewability-over-views"
-			data-enable-refresh="30"
+			data-enable-refresh={refreshValue}
 			layout="fixed"
 			type="doubleclick"
 			json={stringify(

--- a/dotcom-rendering/src/components/Ad.amp.tsx
+++ b/dotcom-rendering/src/components/Ad.amp.tsx
@@ -98,6 +98,8 @@ export const Ad = ({
 		adType,
 	);
 
+	// we don't want teads ads to refresh, as this seems to reduce their visibility
+	// teads ads only target the ad-1 and ad-2 slots, so we prevent these from refreshing
 	const refreshValue = id === 'ad-1' || id === 'ad-2' ? 'false' : '30';
 
 	return (


### PR DESCRIPTION
## What does this change?
Prevents AMP ads with the id **ad-1** and **ad-2** from refreshing. Other AMP slots refresh every 30s, as they did before. 

## Why?
We've seen a drop in visibility of teads ads since introducing refresh to AMP ads. Teads ads only target the **ad-1** and **ad-2** slots. By preventing these slots from refreshing, we hope to reverse the effect of introducing AMP ad refresh to the teads visibility.

## Screenshots
The screen recording below shows slot ad-2 at the top, and ad-3 at the bottom. Youy can see that ad-3 refreshes as normal, whereas ad-2 doesn't.


https://github.com/guardian/dotcom-rendering/assets/108270776/5aafa801-7f2e-40af-b965-056b601d8a3e

