### PR TITLE
Enable Split Theme decorator to receive multiple formats

### DIFF
--- a/dotcom-rendering/.storybook/decorators/splitThemeDecorator.tsx
+++ b/dotcom-rendering/.storybook/decorators/splitThemeDecorator.tsx
@@ -1,44 +1,128 @@
 // ----- Imports ----- //
 import { css } from '@emotion/react';
-import { paletteDeclarations } from '../../src/palette';
-import { palette as sourcePalette, space } from '@guardian/source-foundations';
+import {
+	ArticleDesign,
+	ArticleDisplay,
+	ArticleFormat,
+	ArticleSpecial,
+	Pillar,
+} from '@guardian/libs';
+import {
+	palette as sourcePalette,
+	space,
+	textSans,
+} from '@guardian/source-foundations';
 import { Decorator } from '@storybook/react';
-import { ArticleFormat } from '@guardian/libs';
+import { paletteDeclarations } from '../../src/palette';
 
 interface Orientation {
 	orientation?: 'horizontal' | 'vertical';
 }
 
 const headerCss = css`
-	font-size: 18px;
-	width: 100%;
+	${textSans.large({ fontWeight: 'bold' })}
 	text-align: center;
-	font-weight: bold;
-	padding-bottom: ${space[5]}px;
+	padding: ${space[2]}px;
 `;
 
-const splitCss = css`
-	padding: ${space[4]}px;
+const styles = css`
+	display: grid;
+	max-width: 100%;
 `;
 
-const darkStoryCss = css`
-	background-color: ${sourcePalette.neutral[0]};
-	color: ${sourcePalette.neutral[100]};
-`;
-const lightStoryCss = css`
-	background-color: ${sourcePalette.neutral[100]};
-	color: ${sourcePalette.neutral[0]};
-`;
-const rowCss = css`
-	display: flex;
-	flex-direction: row;
-`;
-const columnCss = css`
-	display: flex;
-	flex-direction: column;
-`;
-
+const FormatHeading = ({ format }: { format: ArticleFormat }) => (
+	<h3
+		css={css`
+			${textSans.medium()}
+			text-align: center;
+			padding: ${space[1]}px;
+			opacity: 0.75;
+		`}
+	>
+		{[
+			`Display: ${ArticleDisplay[format.display]}`,
+			`Design: ${ArticleDesign[format.design]}`,
+			`Theme: ${Pillar[format.theme] || ArticleSpecial[format.theme]}`,
+		]
+			.map((line) => line.replaceAll(' ', ' ')) // non-breaking spaces
+			.join(', ')}
+	</h3>
+);
 // ----- Decorators ----- //
+
+/** A list of the most typical formats */
+const defaultFormats = [
+	{
+		display: ArticleDisplay.Standard,
+		design: ArticleDesign.Standard,
+		theme: Pillar.News,
+	},
+	{
+		display: ArticleDisplay.Standard,
+		design: ArticleDesign.Standard,
+		theme: Pillar.Sport,
+	},
+	{
+		display: ArticleDisplay.Standard,
+		design: ArticleDesign.Standard,
+		theme: Pillar.Opinion,
+	},
+	{
+		display: ArticleDisplay.Standard,
+		design: ArticleDesign.Standard,
+		theme: Pillar.Culture,
+	},
+	{
+		display: ArticleDisplay.Standard,
+		design: ArticleDesign.Standard,
+		theme: Pillar.Lifestyle,
+	},
+	{
+		display: ArticleDisplay.Standard,
+		design: ArticleDesign.Standard,
+		theme: ArticleSpecial.Labs,
+	},
+	{
+		display: ArticleDisplay.Standard,
+		design: ArticleDesign.Standard,
+		theme: ArticleSpecial.SpecialReport,
+	},
+	{
+		display: ArticleDisplay.Standard,
+		design: ArticleDesign.Standard,
+		theme: ArticleSpecial.SpecialReportAlt,
+	},
+	{
+		display: ArticleDisplay.Immersive,
+		design: ArticleDesign.Standard,
+		theme: Pillar.News,
+	},
+	{
+		display: ArticleDisplay.Standard,
+		design: ArticleDesign.Gallery,
+		theme: Pillar.News,
+	},
+	{
+		display: ArticleDisplay.Standard,
+		design: ArticleDesign.LiveBlog,
+		theme: Pillar.News,
+	},
+	{
+		display: ArticleDisplay.Standard,
+		design: ArticleDesign.LiveBlog,
+		theme: Pillar.Sport,
+	},
+	{
+		display: ArticleDisplay.Standard,
+		design: ArticleDesign.DeadBlog,
+		theme: Pillar.News,
+	},
+	{
+		display: ArticleDisplay.Standard,
+		design: ArticleDesign.DeadBlog,
+		theme: Pillar.Sport,
+	},
+] as const satisfies readonly ArticleFormat[];
 
 /**
  * Creates storybook decorator used to render a component twice
@@ -47,35 +131,53 @@ const columnCss = css`
  */
 export const splitTheme =
 	(
-		format: ArticleFormat,
+		formats: readonly [ArticleFormat, ...ArticleFormat[]] = defaultFormats,
 		{ orientation = 'horizontal' }: Orientation = {},
 	): Decorator =>
 	(Story) =>
 		(
-			<>
-				<div css={[orientation === 'horizontal' ? rowCss : columnCss]}>
-					<div
-						className="left-lightTheme"
-						css={[
-							splitCss,
-							lightStoryCss,
-							css(paletteDeclarations(format, 'light')),
-						]}
-					>
-						<div css={headerCss}>Light Theme ☀️</div>
-						<Story />
-					</div>
-					<div
-						className="right-darkTheme"
-						css={[
-							splitCss,
-							darkStoryCss,
-							css(paletteDeclarations(format, 'dark')),
-						]}
-					>
-						<div css={headerCss}>Dark Theme 🌙</div>
-						<Story />
-					</div>
+			<div
+				css={styles}
+				style={{
+					gridTemplateColumns:
+						orientation === 'horizontal' ? '1fr 1fr' : '1fr',
+				}}
+			>
+				<div
+					className="light"
+					css={[
+						css`
+							background-color: ${sourcePalette.neutral[100]};
+							color: ${sourcePalette.neutral[0]};
+						`,
+						css(paletteDeclarations(defaultFormats[0], 'light')),
+					]}
+				>
+					<h2 css={headerCss}>Light Theme ☀️</h2>
+					{formats.map((format) => (
+						<div css={css(paletteDeclarations(format, 'light'))}>
+							<FormatHeading format={format} />
+							<Story format={format} />
+						</div>
+					))}
 				</div>
-			</>
+				<div
+					className="dark"
+					css={[
+						css`
+							background-color: ${sourcePalette.neutral[0]};
+							color: ${sourcePalette.neutral[100]};
+						`,
+						css(paletteDeclarations(defaultFormats[0], 'dark')),
+					]}
+				>
+					<h2 css={headerCss}>Dark Theme 🌙</h2>
+					{formats.map((format) => (
+						<div css={css(paletteDeclarations(format, 'dark'))}>
+							<FormatHeading format={format} />
+							<Story format={format} />
+						</div>
+					))}
+				</div>
+			</div>
 		);

--- a/dotcom-rendering/src/components/Accordion.stories.tsx
+++ b/dotcom-rendering/src/components/Accordion.stories.tsx
@@ -67,7 +67,7 @@ export default {
 			viewports: [breakpoints.mobile, breakpoints.tablet],
 		},
 	},
-	decorators: [splitTheme(articleFormat)],
+	decorators: [splitTheme([articleFormat])],
 };
 
 export const Default = () => (

--- a/dotcom-rendering/src/components/AdSlot.apps.stories.tsx
+++ b/dotcom-rendering/src/components/AdSlot.apps.stories.tsx
@@ -20,11 +20,13 @@ export default {
 	},
 	decorators: [
 		splitTheme(
-			{
-				design: ArticleDesign.Standard,
-				display: ArticleDisplay.Standard,
-				theme: Pillar.News,
-			},
+			[
+				{
+					design: ArticleDesign.Standard,
+					display: ArticleDisplay.Standard,
+					theme: Pillar.News,
+				},
+			],
 			{ orientation: 'vertical' },
 		),
 	],

--- a/dotcom-rendering/src/components/AdSlot.apps.stories.tsx
+++ b/dotcom-rendering/src/components/AdSlot.apps.stories.tsx
@@ -1,8 +1,22 @@
+import { css } from '@emotion/react';
 import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
-import { breakpoints } from '@guardian/source-foundations';
+import { breakpoints, space } from '@guardian/source-foundations';
+import type { Decorator } from '@storybook/react';
 import { useRef } from 'react';
 import { splitTheme } from '../../.storybook/decorators/splitThemeDecorator';
 import { AdSlot, type Props } from './AdSlot.apps';
+
+const Wrapper: Decorator = (Story) => (
+	<div
+		css={css`
+			/* this matches the negative margin in AdSlot.apps */
+			padding: ${space[3]}px;
+			width: 100%;
+		`}
+	>
+		<Story />
+	</div>
+);
 
 export default {
 	component: AdSlot,
@@ -19,6 +33,7 @@ export default {
 		onClickSupportButton: { action: 'clicked' },
 	},
 	decorators: [
+		Wrapper,
 		splitTheme(
 			[
 				{

--- a/dotcom-rendering/src/components/AppsFooter.importable.stories.tsx
+++ b/dotcom-rendering/src/components/AppsFooter.importable.stories.tsx
@@ -6,11 +6,13 @@ export default {
 	component: AppsFooter,
 	title: 'AppsFooter',
 	decorators: [
-		splitTheme({
-			design: ArticleDesign.Standard,
-			display: ArticleDisplay.Standard,
-			theme: Pillar.News,
-		}),
+		splitTheme([
+			{
+				design: ArticleDesign.Standard,
+				display: ArticleDisplay.Standard,
+				theme: Pillar.News,
+			},
+		]),
 	],
 };
 

--- a/dotcom-rendering/src/components/Avatar.stories.tsx
+++ b/dotcom-rendering/src/components/Avatar.stories.tsx
@@ -35,10 +35,12 @@ export const defaultStory: Story = () => (
 );
 defaultStory.storyName = 'Medium, Opinion (Rich Links)';
 defaultStory.decorators = [
-	splitTheme({
-		...format,
-		theme: Pillar.Opinion,
-	}),
+	splitTheme([
+		{
+			...format,
+			theme: Pillar.Opinion,
+		},
+	]),
 ];
 
 export const largeStory: Story = () => (
@@ -48,10 +50,12 @@ export const largeStory: Story = () => (
 );
 largeStory.storyName = 'Large, Lifestyle (Byline image - Desktop)';
 largeStory.decorators = [
-	splitTheme({
-		...format,
-		theme: Pillar.Lifestyle,
-	}),
+	splitTheme([
+		{
+			...format,
+			theme: Pillar.Lifestyle,
+		},
+	]),
 ];
 
 export const largeStoryNews: Story = () => (
@@ -60,7 +64,7 @@ export const largeStoryNews: Story = () => (
 	</div>
 );
 largeStoryNews.storyName = 'Large, News (Byline image - Desktop)';
-largeStoryNews.decorators = [splitTheme(format)];
+largeStoryNews.decorators = [splitTheme([format])];
 
 export const largeStoryCulture: Story = () => (
 	<div style={{ width: '140px', height: '140px' }}>
@@ -69,10 +73,12 @@ export const largeStoryCulture: Story = () => (
 );
 largeStoryCulture.storyName = 'Large, Culture (Byline image - Desktop)';
 largeStoryCulture.decorators = [
-	splitTheme({
-		...format,
-		theme: Pillar.Culture,
-	}),
+	splitTheme([
+		{
+			...format,
+			theme: Pillar.Culture,
+		},
+	]),
 ];
 
 export const SpecialReport: Story = () => (
@@ -82,10 +88,12 @@ export const SpecialReport: Story = () => (
 );
 SpecialReport.storyName = 'Large SpecialReport';
 SpecialReport.decorators = [
-	splitTheme({
-		...format,
-		theme: ArticleSpecial.SpecialReport,
-	}),
+	splitTheme([
+		{
+			...format,
+			theme: ArticleSpecial.SpecialReport,
+		},
+	]),
 ];
 
 export const SpecialReportAlt: Story = () => (
@@ -95,10 +103,12 @@ export const SpecialReportAlt: Story = () => (
 );
 SpecialReportAlt.storyName = 'Large SpecialReportAlt';
 SpecialReportAlt.decorators = [
-	splitTheme({
-		...format,
-		theme: ArticleSpecial.SpecialReportAlt,
-	}),
+	splitTheme([
+		{
+			...format,
+			theme: ArticleSpecial.SpecialReportAlt,
+		},
+	]),
 ];
 
 export const smallStory: Story = () => (
@@ -108,8 +118,10 @@ export const smallStory: Story = () => (
 );
 smallStory.storyName = 'Small, Sport (Byline image - Mobile)';
 smallStory.decorators = [
-	splitTheme({
-		...format,
-		theme: Pillar.Sport,
-	}),
+	splitTheme([
+		{
+			...format,
+			theme: Pillar.Sport,
+		},
+	]),
 ];

--- a/dotcom-rendering/src/components/BlockquoteBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/components/BlockquoteBlockComponent.stories.tsx
@@ -35,11 +35,13 @@ export const Unquoted = () => {
 };
 Unquoted.storyName = 'Unquoted';
 Unquoted.decorators = [
-	splitTheme({
-		design: ArticleDesign.Standard,
-		display: ArticleDisplay.Standard,
-		theme: Pillar.News,
-	}),
+	splitTheme([
+		{
+			design: ArticleDesign.Standard,
+			display: ArticleDisplay.Standard,
+			theme: Pillar.News,
+		},
+	]),
 ];
 
 export const News = () => {
@@ -53,11 +55,13 @@ export const News = () => {
 
 News.storyName = 'News';
 News.decorators = [
-	splitTheme({
-		design: ArticleDesign.Standard,
-		display: ArticleDisplay.Standard,
-		theme: Pillar.News,
-	}),
+	splitTheme([
+		{
+			design: ArticleDesign.Standard,
+			display: ArticleDisplay.Standard,
+			theme: Pillar.News,
+		},
+	]),
 ];
 
 export const Sport = () => {
@@ -71,11 +75,13 @@ export const Sport = () => {
 
 Sport.storyName = 'Sport';
 Sport.decorators = [
-	splitTheme({
-		design: ArticleDesign.Standard,
-		display: ArticleDisplay.Standard,
-		theme: Pillar.Sport,
-	}),
+	splitTheme([
+		{
+			design: ArticleDesign.Standard,
+			display: ArticleDisplay.Standard,
+			theme: Pillar.Sport,
+		},
+	]),
 ];
 
 export const Culture = () => {
@@ -89,11 +95,13 @@ export const Culture = () => {
 
 Culture.storyName = 'Culture';
 Culture.decorators = [
-	splitTheme({
-		design: ArticleDesign.Standard,
-		display: ArticleDisplay.Standard,
-		theme: Pillar.Culture,
-	}),
+	splitTheme([
+		{
+			design: ArticleDesign.Standard,
+			display: ArticleDisplay.Standard,
+			theme: Pillar.Culture,
+		},
+	]),
 ];
 
 export const Lifestyle = () => {
@@ -107,11 +115,13 @@ export const Lifestyle = () => {
 
 Lifestyle.storyName = 'Lifestyle';
 Lifestyle.decorators = [
-	splitTheme({
-		design: ArticleDesign.Standard,
-		display: ArticleDisplay.Standard,
-		theme: Pillar.Lifestyle,
-	}),
+	splitTheme([
+		{
+			design: ArticleDesign.Standard,
+			display: ArticleDisplay.Standard,
+			theme: Pillar.Lifestyle,
+		},
+	]),
 ];
 
 export const Opinion = () => {
@@ -125,11 +135,13 @@ export const Opinion = () => {
 
 Opinion.storyName = 'Opinion';
 Opinion.decorators = [
-	splitTheme({
-		design: ArticleDesign.Standard,
-		display: ArticleDisplay.Standard,
-		theme: Pillar.Opinion,
-	}),
+	splitTheme([
+		{
+			design: ArticleDesign.Standard,
+			display: ArticleDisplay.Standard,
+			theme: Pillar.Opinion,
+		},
+	]),
 ];
 
 export const SpecialReport = () => {
@@ -143,11 +155,13 @@ export const SpecialReport = () => {
 
 SpecialReport.storyName = 'SpecialReport';
 SpecialReport.decorators = [
-	splitTheme({
-		design: ArticleDesign.Standard,
-		display: ArticleDisplay.Standard,
-		theme: ArticleSpecial.SpecialReport,
-	}),
+	splitTheme([
+		{
+			design: ArticleDesign.Standard,
+			display: ArticleDisplay.Standard,
+			theme: ArticleSpecial.SpecialReport,
+		},
+	]),
 ];
 
 export const Labs = () => {
@@ -161,11 +175,13 @@ export const Labs = () => {
 
 Labs.storyName = 'Labs';
 Labs.decorators = [
-	splitTheme({
-		design: ArticleDesign.Standard,
-		display: ArticleDisplay.Standard,
-		theme: ArticleSpecial.Labs,
-	}),
+	splitTheme([
+		{
+			design: ArticleDesign.Standard,
+			display: ArticleDisplay.Standard,
+			theme: ArticleSpecial.Labs,
+		},
+	]),
 ];
 
 export const LiveBlogNews = () => {
@@ -179,11 +195,13 @@ export const LiveBlogNews = () => {
 
 LiveBlogNews.storyName = 'LiveBlogNews';
 LiveBlogNews.decorators = [
-	splitTheme({
-		design: ArticleDesign.LiveBlog,
-		display: ArticleDisplay.Standard,
-		theme: Pillar.News,
-	}),
+	splitTheme([
+		{
+			design: ArticleDesign.LiveBlog,
+			display: ArticleDisplay.Standard,
+			theme: Pillar.News,
+		},
+	]),
 ];
 
 export const DeadBlogNews = () => {
@@ -197,11 +215,13 @@ export const DeadBlogNews = () => {
 
 DeadBlogNews.storyName = 'DeadBlogNews';
 DeadBlogNews.decorators = [
-	splitTheme({
-		design: ArticleDesign.DeadBlog,
-		display: ArticleDisplay.Standard,
-		theme: Pillar.News,
-	}),
+	splitTheme([
+		{
+			design: ArticleDesign.DeadBlog,
+			display: ArticleDisplay.Standard,
+			theme: Pillar.News,
+		},
+	]),
 ];
 
 export const LiveBlogSport = () => {
@@ -215,11 +235,13 @@ export const LiveBlogSport = () => {
 
 LiveBlogSport.storyName = 'LiveBlogSport';
 LiveBlogSport.decorators = [
-	splitTheme({
-		design: ArticleDesign.LiveBlog,
-		display: ArticleDisplay.Standard,
-		theme: Pillar.Sport,
-	}),
+	splitTheme([
+		{
+			design: ArticleDesign.LiveBlog,
+			display: ArticleDisplay.Standard,
+			theme: Pillar.Sport,
+		},
+	]),
 ];
 
 export const DeadBlogSport = () => {
@@ -232,11 +254,13 @@ export const DeadBlogSport = () => {
 };
 DeadBlogSport.storyName = 'DeadBlogSport';
 DeadBlogSport.decorators = [
-	splitTheme({
-		design: ArticleDesign.DeadBlog,
-		display: ArticleDisplay.Standard,
-		theme: Pillar.Sport,
-	}),
+	splitTheme([
+		{
+			design: ArticleDesign.DeadBlog,
+			display: ArticleDisplay.Standard,
+			theme: Pillar.Sport,
+		},
+	]),
 ];
 
 export const SpecialReportAltStandard = () => {
@@ -249,11 +273,13 @@ export const SpecialReportAltStandard = () => {
 };
 SpecialReportAltStandard.storyName = 'SpecialReportAltStandard';
 SpecialReportAltStandard.decorators = [
-	splitTheme({
-		design: ArticleDesign.Standard,
-		display: ArticleDisplay.Standard,
-		theme: ArticleSpecial.SpecialReportAlt,
-	}),
+	splitTheme([
+		{
+			design: ArticleDesign.Standard,
+			display: ArticleDisplay.Standard,
+			theme: ArticleSpecial.SpecialReportAlt,
+		},
+	]),
 ];
 
 export const SpecialReportAltComment = () => {
@@ -266,9 +292,11 @@ export const SpecialReportAltComment = () => {
 };
 SpecialReportAltComment.storyName = 'SpecialReportAltComment';
 SpecialReportAltComment.decorators = [
-	splitTheme({
-		design: ArticleDesign.Comment,
-		display: ArticleDisplay.Standard,
-		theme: ArticleSpecial.SpecialReportAlt,
-	}),
+	splitTheme([
+		{
+			design: ArticleDesign.Comment,
+			display: ArticleDisplay.Standard,
+			theme: ArticleSpecial.SpecialReportAlt,
+		},
+	]),
 ];

--- a/dotcom-rendering/src/components/ClickToView.stories.tsx
+++ b/dotcom-rendering/src/components/ClickToView.stories.tsx
@@ -134,7 +134,7 @@ export const InlineStory = () => {
 	);
 };
 InlineStory.storyName = "Click to view in 'inline' role";
-InlineStory.decorators = [splitTheme(defaultFormat)];
+InlineStory.decorators = [splitTheme([defaultFormat])];
 
 export const SupportingStory = () => {
 	return (
@@ -149,7 +149,7 @@ export const SupportingStory = () => {
 	);
 };
 SupportingStory.storyName = "Click to view in 'supporting' role";
-SupportingStory.decorators = [splitTheme(defaultFormat)];
+SupportingStory.decorators = [splitTheme([defaultFormat])];
 
 export const ShowcaseStory = () => {
 	return (
@@ -164,7 +164,7 @@ export const ShowcaseStory = () => {
 	);
 };
 ShowcaseStory.storyName = "Click to view in 'showcase' role";
-ShowcaseStory.decorators = [splitTheme(defaultFormat)];
+ShowcaseStory.decorators = [splitTheme([defaultFormat])];
 
 export const HalfWidthStory = () => {
 	return (
@@ -179,7 +179,7 @@ export const HalfWidthStory = () => {
 	);
 };
 HalfWidthStory.storyName = "Click to view in 'halfWidth' role";
-HalfWidthStory.decorators = [splitTheme(defaultFormat)];
+HalfWidthStory.decorators = [splitTheme([defaultFormat])];
 
 export const ThumbnailStory = () => {
 	return (
@@ -194,7 +194,7 @@ export const ThumbnailStory = () => {
 	);
 };
 ThumbnailStory.storyName = "Click to view in 'thumbnail' role";
-ThumbnailStory.decorators = [splitTheme(defaultFormat)];
+ThumbnailStory.decorators = [splitTheme([defaultFormat])];
 
 const Inline: RoleType = 'inline';
 
@@ -655,7 +655,7 @@ export const EmbedBlockComponentStory = () => {
 };
 EmbedBlockComponentStory.storyName =
 	'Click to view wrapping EmbedBlockComponent';
-EmbedBlockComponentStory.decorators = [splitTheme(defaultFormat)];
+EmbedBlockComponentStory.decorators = [splitTheme([defaultFormat])];
 
 export const UnsafeEmbedBlockComponentStory = () => {
 	return (
@@ -793,7 +793,7 @@ export const UnsafeEmbedBlockComponentStory = () => {
 };
 UnsafeEmbedBlockComponentStory.storyName =
 	'Click to view wrapping UnsafeEmbedBlockComponent';
-UnsafeEmbedBlockComponentStory.decorators = [splitTheme(defaultFormat)];
+UnsafeEmbedBlockComponentStory.decorators = [splitTheme([defaultFormat])];
 
 export const VimeoBlockComponentStory = () => {
 	return (
@@ -848,7 +848,7 @@ export const VimeoBlockComponentStory = () => {
 };
 VimeoBlockComponentStory.storyName =
 	'Click to view wrapping VimeoBlockComponent';
-VimeoBlockComponentStory.decorators = [splitTheme(defaultFormat)];
+VimeoBlockComponentStory.decorators = [splitTheme([defaultFormat])];
 
 export const DocumentBlockComponentStory = () => {
 	return (
@@ -901,7 +901,7 @@ export const DocumentBlockComponentStory = () => {
 };
 DocumentBlockComponentStory.storyName =
 	'Click to view wrapping DocumentBlockComponentStory';
-DocumentBlockComponentStory.decorators = [splitTheme(defaultFormat)];
+DocumentBlockComponentStory.decorators = [splitTheme([defaultFormat])];
 
 export const SoundCloudBlockComponentStory = () => {
 	return (
@@ -972,7 +972,7 @@ export const SoundCloudBlockComponentStory = () => {
 };
 SoundCloudBlockComponentStory.storyName =
 	'Click to view wrapping SoundCloudBlockComponent';
-SoundCloudBlockComponentStory.decorators = [splitTheme(defaultFormat)];
+SoundCloudBlockComponentStory.decorators = [splitTheme([defaultFormat])];
 
 export const SpotifyBlockComponentStory = () => {
 	return (
@@ -1030,7 +1030,7 @@ export const SpotifyBlockComponentStory = () => {
 
 SpotifyBlockComponentStory.storyName =
 	'Click to view wrapping SpotifyBlockComponent';
-SpotifyBlockComponentStory.decorators = [splitTheme(defaultFormat)];
+SpotifyBlockComponentStory.decorators = [splitTheme([defaultFormat])];
 
 export const TweetBlockComponentStory = () => {
 	return (
@@ -1076,7 +1076,7 @@ export const TweetBlockComponentStory = () => {
 };
 TweetBlockComponentStory.storyName =
 	'Click to view wrapping TweetBlockComponent';
-TweetBlockComponentStory.decorators = [splitTheme(defaultFormat)];
+TweetBlockComponentStory.decorators = [splitTheme([defaultFormat])];
 
 export const InstagramBlockComponentStory = () => {
 	return (
@@ -1120,7 +1120,7 @@ export const InstagramBlockComponentStory = () => {
 };
 InstagramBlockComponentStory.storyName =
 	'Click to view wrapping InstagramBlockComponent';
-InstagramBlockComponentStory.decorators = [splitTheme(defaultFormat)];
+InstagramBlockComponentStory.decorators = [splitTheme([defaultFormat])];
 
 export const MapBlockComponentStory = () => {
 	return (
@@ -1176,7 +1176,7 @@ export const MapBlockComponentStory = () => {
 };
 MapBlockComponentStory.storyName =
 	'Click to view wrapping MapEmbedBlockComponent';
-MapBlockComponentStory.decorators = [splitTheme(defaultFormat)];
+MapBlockComponentStory.decorators = [splitTheme([defaultFormat])];
 
 export const VineBlockComponentStory = () => {
 	return (
@@ -1224,4 +1224,4 @@ export const VineBlockComponentStory = () => {
 	);
 };
 VineBlockComponentStory.storyName = 'Click to view wrapping VineBlockComponent';
-VineBlockComponentStory.decorators = [splitTheme(defaultFormat)];
+VineBlockComponentStory.decorators = [splitTheme([defaultFormat])];

--- a/dotcom-rendering/src/components/Discussion/Pagination.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/Pagination.stories.tsx
@@ -59,7 +59,7 @@ export const WithBackground = () => {
 	);
 };
 WithBackground.storyName = 'with a dark background';
-WithBackground.decorators = [splitTheme(articleFormat)];
+WithBackground.decorators = [splitTheme([articleFormat])];
 
 export const ThreePages = () => {
 	const [page, setCurrentPage] = useState(1);

--- a/dotcom-rendering/src/components/FollowButton.stories.tsx
+++ b/dotcom-rendering/src/components/FollowButton.stories.tsx
@@ -17,11 +17,13 @@ export const NotFollowing = () => {
 	);
 };
 NotFollowing.decorators = [
-	splitTheme({
-		display: ArticleDisplay.Standard,
-		design: ArticleDesign.Standard,
-		theme: Pillar.News,
-	}),
+	splitTheme([
+		{
+			display: ArticleDisplay.Standard,
+			design: ArticleDesign.Standard,
+			theme: Pillar.News,
+		},
+	]),
 ];
 
 export const Following = () => {
@@ -34,9 +36,11 @@ export const Following = () => {
 	);
 };
 Following.decorators = [
-	splitTheme({
-		display: ArticleDisplay.Standard,
-		design: ArticleDesign.Standard,
-		theme: Pillar.Opinion,
-	}),
+	splitTheme([
+		{
+			display: ArticleDisplay.Standard,
+			design: ArticleDesign.Standard,
+			theme: Pillar.Opinion,
+		},
+	]),
 ];

--- a/dotcom-rendering/src/components/Standfirst.stories.tsx
+++ b/dotcom-rendering/src/components/Standfirst.stories.tsx
@@ -30,7 +30,7 @@ export const Article = () => {
 	);
 };
 Article.storyName = 'Article';
-Article.decorators = [splitTheme(articleFormat)];
+Article.decorators = [splitTheme([articleFormat])];
 
 const commentFormat = {
 	display: ArticleDisplay.Standard,
@@ -48,7 +48,7 @@ export const Comment = () => {
 	);
 };
 Comment.storyName = 'Comment';
-Comment.decorators = [splitTheme(commentFormat)];
+Comment.decorators = [splitTheme([commentFormat])];
 
 const letterFormat = {
 	display: ArticleDisplay.Standard,
@@ -66,7 +66,7 @@ export const Letter = () => {
 	);
 };
 Letter.storyName = 'Letter';
-Letter.decorators = [splitTheme(letterFormat)];
+Letter.decorators = [splitTheme([letterFormat])];
 
 const featureFormat = {
 	display: ArticleDisplay.Standard,
@@ -84,7 +84,7 @@ export const Feature = () => {
 	);
 };
 Feature.storyName = 'Feature';
-Feature.decorators = [splitTheme(featureFormat)];
+Feature.decorators = [splitTheme([featureFormat])];
 
 const immersiveFormat = {
 	display: ArticleDisplay.Immersive,
@@ -102,7 +102,7 @@ export const Immersive = () => {
 	);
 };
 Immersive.storyName = 'Immersive';
-Immersive.decorators = [splitTheme(immersiveFormat)];
+Immersive.decorators = [splitTheme([immersiveFormat])];
 
 const reviewFormat = {
 	display: ArticleDisplay.Standard,
@@ -120,7 +120,7 @@ export const Review = () => {
 	);
 };
 Review.storyName = 'Review';
-Review.decorators = [splitTheme(reviewFormat)];
+Review.decorators = [splitTheme([reviewFormat])];
 
 const liveblogFormat = {
 	display: ArticleDisplay.Standard,
@@ -151,7 +151,7 @@ LiveBlog.story = {
 		},
 	},
 };
-LiveBlog.decorators = [splitTheme(liveblogFormat)];
+LiveBlog.decorators = [splitTheme([liveblogFormat])];
 
 const deadblogFormat = {
 	display: ArticleDisplay.Standard,
@@ -169,7 +169,7 @@ export const DeadBlog = () => {
 	);
 };
 DeadBlog.storyName = 'DeadBlog';
-DeadBlog.decorators = [splitTheme(deadblogFormat)];
+DeadBlog.decorators = [splitTheme([deadblogFormat])];
 
 const interviewFormat = {
 	display: ArticleDisplay.Standard,
@@ -187,7 +187,7 @@ export const Interview = () => {
 	);
 };
 Interview.storyName = 'Interview';
-Interview.decorators = [splitTheme(interviewFormat)];
+Interview.decorators = [splitTheme([interviewFormat])];
 
 const analysisFormat = {
 	display: ArticleDisplay.Standard,
@@ -205,7 +205,7 @@ export const Analysis = () => {
 	);
 };
 Analysis.storyName = 'Analysis';
-Analysis.decorators = [splitTheme(analysisFormat)];
+Analysis.decorators = [splitTheme([analysisFormat])];
 
 const ExplainerFormat = {
 	display: ArticleDisplay.Standard,
@@ -223,7 +223,7 @@ export const Explainer = () => {
 	);
 };
 Explainer.storyName = 'Explainer';
-Explainer.decorators = [splitTheme(ExplainerFormat)];
+Explainer.decorators = [splitTheme([ExplainerFormat])];
 
 const GalleryFormat = {
 	display: ArticleDisplay.Standard,
@@ -241,7 +241,7 @@ export const Gallery = () => {
 	);
 };
 Gallery.storyName = 'Gallery';
-Gallery.decorators = [splitTheme(GalleryFormat)];
+Gallery.decorators = [splitTheme([GalleryFormat])];
 
 const audioFormat = {
 	display: ArticleDisplay.Standard,
@@ -259,7 +259,7 @@ export const Audio = () => {
 	);
 };
 Audio.storyName = 'Audio';
-Audio.decorators = [splitTheme(audioFormat)];
+Audio.decorators = [splitTheme([audioFormat])];
 
 const videoFormat = {
 	display: ArticleDisplay.Standard,
@@ -277,7 +277,7 @@ export const Video = () => {
 	);
 };
 Video.storyName = 'Video';
-Video.decorators = [splitTheme(videoFormat)];
+Video.decorators = [splitTheme([videoFormat])];
 
 const recipeFormat = {
 	display: ArticleDisplay.Standard,
@@ -295,7 +295,7 @@ export const Recipe = () => {
 	);
 };
 Recipe.storyName = 'Recipe';
-Recipe.decorators = [splitTheme(recipeFormat)];
+Recipe.decorators = [splitTheme([recipeFormat])];
 
 const matchReportFormat = {
 	display: ArticleDisplay.Standard,
@@ -313,7 +313,7 @@ export const MatchReport = () => {
 	);
 };
 MatchReport.storyName = 'MatchReport';
-MatchReport.decorators = [splitTheme(matchReportFormat)];
+MatchReport.decorators = [splitTheme([matchReportFormat])];
 
 const quizFormat = {
 	display: ArticleDisplay.Standard,
@@ -331,7 +331,7 @@ export const Quiz = () => {
 	);
 };
 Quiz.storyName = 'Quiz';
-Quiz.decorators = [splitTheme(quizFormat)];
+Quiz.decorators = [splitTheme([quizFormat])];
 
 const specialReport = {
 	display: ArticleDisplay.Standard,
@@ -349,7 +349,7 @@ export const SpecialReport = () => {
 	);
 };
 SpecialReport.storyName = 'SpecialReport';
-SpecialReport.decorators = [splitTheme(specialReport)];
+SpecialReport.decorators = [splitTheme([specialReport])];
 
 const SpecialReportAltFormat = {
 	display: ArticleDisplay.Standard,
@@ -367,7 +367,7 @@ export const SpecialReportAlt = () => {
 	);
 };
 SpecialReportAlt.storyName = 'SpecialReportAlt';
-SpecialReportAlt.decorators = [splitTheme(SpecialReportAltFormat)];
+SpecialReportAlt.decorators = [splitTheme([SpecialReportAltFormat])];
 
 const editorialFormat = {
 	display: ArticleDisplay.Standard,
@@ -385,7 +385,7 @@ export const Editorial = () => {
 	);
 };
 Editorial.storyName = 'Editorial';
-Editorial.decorators = [splitTheme(editorialFormat)];
+Editorial.decorators = [splitTheme([editorialFormat])];
 
 const photoFormat = {
 	display: ArticleDisplay.Standard,
@@ -403,7 +403,7 @@ export const PhotoEssay = () => {
 	);
 };
 PhotoEssay.storyName = 'PhotoEssay';
-PhotoEssay.decorators = [splitTheme(photoFormat)];
+PhotoEssay.decorators = [splitTheme([photoFormat])];
 
 const labsWithLinkFormat = {
 	display: ArticleDisplay.Standard,
@@ -421,4 +421,4 @@ export const LabsWithLink = () => {
 	);
 };
 LabsWithLink.storyName = 'LabsWithLink';
-LabsWithLink.decorators = [splitTheme(labsWithLinkFormat)];
+LabsWithLink.decorators = [splitTheme([labsWithLinkFormat])];

--- a/dotcom-rendering/src/components/StarRating/StarRating.stories.tsx
+++ b/dotcom-rendering/src/components/StarRating/StarRating.stories.tsx
@@ -38,7 +38,7 @@ export const AllSizeStars = () => (
 	</>
 );
 AllSizeStars.storyName = 'All Sizes';
-AllSizeStars.decorators = [splitTheme(articleFormat)];
+AllSizeStars.decorators = [splitTheme([articleFormat])];
 
 export const SmallStory = () => (
 	<>
@@ -62,7 +62,7 @@ export const SmallStory = () => (
 	</>
 );
 SmallStory.storyName = 'Small Stars';
-SmallStory.decorators = [splitTheme(articleFormat)];
+SmallStory.decorators = [splitTheme([articleFormat])];
 
 export const MediumStory = () => (
 	<>
@@ -86,7 +86,7 @@ export const MediumStory = () => (
 	</>
 );
 MediumStory.storyName = 'Medium stars';
-MediumStory.decorators = [splitTheme(articleFormat)];
+MediumStory.decorators = [splitTheme([articleFormat])];
 
 export const LargeStory = () => (
 	<>
@@ -110,7 +110,7 @@ export const LargeStory = () => (
 	</>
 );
 LargeStory.storyName = 'Large stars';
-LargeStory.decorators = [splitTheme(articleFormat)];
+LargeStory.decorators = [splitTheme([articleFormat])];
 
 export const StarColours = () => (
 	<>

--- a/dotcom-rendering/src/components/StarRatingBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/components/StarRatingBlockComponent.stories.tsx
@@ -31,4 +31,4 @@ export const AllSizes = () => (
 	</>
 );
 AllSizes.storyName = 'All stars sizes';
-AllSizes.decorators = [splitTheme(articleFormat)];
+AllSizes.decorators = [splitTheme([articleFormat])];

--- a/dotcom-rendering/src/components/TableOfContents.stories.tsx
+++ b/dotcom-rendering/src/components/TableOfContents.stories.tsx
@@ -64,7 +64,7 @@ export const defaultStory = () => {
 };
 
 defaultStory.storyName = 'default';
-defaultStory.decorators = [splitTheme(format)];
+defaultStory.decorators = [splitTheme([format])];
 
 export const immersive = () => {
 	return (
@@ -78,7 +78,7 @@ export const immersive = () => {
 };
 
 immersive.storyName = 'immersive';
-immersive.decorators = [splitTheme(immersiveDisplayFormat)];
+immersive.decorators = [splitTheme([immersiveDisplayFormat])];
 
 export const numberedList = () => {
 	return (
@@ -92,4 +92,4 @@ export const numberedList = () => {
 };
 
 numberedList.storyName = 'numberedList';
-numberedList.decorators = [splitTheme(numberedListDisplayFormat)];
+numberedList.decorators = [splitTheme([numberedListDisplayFormat])];


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

This expands the existing `splitTheme` decorator so that we can test multiple variations of formats by passing an array of typical formats to test, with a sensible default of 12 typical formats.

## Why?

It’s been partially implemented in #9312

## Screenshots

See Chromatic!

<img width="1022" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/76776/37829df1-4930-4cf7-be06-a498b1e25c4b">
