### PR TITLE
Prettify suitable files across the repo (not just in DCR) 💄🌍

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -6,4 +6,4 @@
 
 . "$(dirname "$0")/_/husky.sh"
 
-yarn workspace @guardian/dotcom-rendering lint-staged
+yarn lint-staged

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,7 @@
+dist
+.yarn
+deno
+
+# generated files
+dotcom-rendering/src/model/*-schema.json
+dotcom-rendering/stories/generated

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -11,7 +11,6 @@
 		"lint:src": "eslint . --ext .ts,.tsx --quiet",
 		"lint:scripts": "eslint scripts --quiet",
 		"lint:cypress": "eslint ./cypress",
-		"lint-staged": "lint-staged",
 		"prettier:check": "prettier . --check --cache",
 		"prettier:fix": "prettier . --write --cache",
 		"lintstats": "yarn lint --format node_modules/eslint-stats/byError.js",
@@ -32,9 +31,6 @@
 		"cdk:build": "tsc -p ./tsconfig.cdk.json",
 		"cdk:synth": "cdk synth --path-metadata false --version-reporting false",
 		"cdk:diff": "cdk diff --path-metadata false --version-reporting false"
-	},
-	"lint-staged": {
-		"*.{js,jsx,ts,tsx,cjs,mjs,cts,mts,json,css,html,md,mdx}": "prettier --write"
 	},
 	"dependencies": {
 		"@aws-sdk/client-cloudwatch": "3.350.0",
@@ -205,7 +201,6 @@
 		"jest-environment-jsdom": "29.5.0",
 		"jest-teamcity-reporter": "0.9.0",
 		"jsdom": "22.1.0",
-		"lint-staged": "13.2.1",
 		"load-json-file": "6.2.0",
 		"lodash.debounce": "4.0.8",
 		"lodash.get": "4.4.2",

--- a/package.json
+++ b/package.json
@@ -26,12 +26,17 @@
 		"build-storybook:dcr": "yarn workspace @guardian/dotcom-rendering build-storybook",
 		"build:dcr": "cd ./dotcom-rendering && yarn makeBuild",
 		"chromatic": "chromatic --build-script-name=build-storybook --exit-zero-on-changes",
-		"prepare": "husky install"
+		"prepare": "husky install",
+		"lint-staged": "lint-staged"
+	},
+	"lint-staged": {
+		"*": "prettier --ignore-unknown --write"
 	},
 	"dependencies": {
 		"@guardian/prettier": "^4.0.0",
 		"chromatic": "^6.19.9",
 		"husky": "^8.0.3",
+		"lint-staged": "13.2.1",
 		"npm-run-all": "^4.1.5",
 		"prettier": "^2.8.8",
 		"typescript": "5.1.3"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

- moves the DRC prettier pre-commit hook to the root
- adds a `.prettierignore` to the root

## Why?

Lots of files in the repo do not conform to the prettier config. If you have `format-on-save` enabled, editing them generates loads of unrelated changes.

This change makes sure you can't commit a non-pretty change anywhere in the repo (if prettier cares about that file). 

This behaviour already existed in DCR, this PR just applies it everywhere.

A second PR (#9425) will include all (and only) prettification to bring everything into line in one go.

