### PR TITLE
Tweak link colours and area alignment in picture (cartoons) layout

### DIFF
--- a/dotcom-rendering/src/layouts/PictureLayout.tsx
+++ b/dotcom-rendering/src/layouts/PictureLayout.tsx
@@ -84,22 +84,20 @@ const PictureGrid = ({ children }: { children: React.ReactNode }) => (
 					grid-template-columns: 219px 1px 1fr;
 					grid-template-areas:
 						'title  border  headline'
-						'lines  border  standfirst'
+						'.      border  standfirst'
+						'lines  border  media'
 						'meta   border  media'
-						'meta   border  media'
-						'.      border  submeta'
-						'.      border  .';
+						'meta   border  submeta';
 				}
 
 				${until.wide} {
 					grid-template-columns: 140px 1px 1fr 300px;
 					grid-template-areas:
 						'title  border  headline    headline'
-						'lines  border  standfirst  standfirst'
+						'.      border  standfirst  standfirst'
+						'lines  border  media       media'
 						'meta   border  media       media'
-						'meta   border  media       media'
-						'.      border  submeta     submeta'
-						'.      border  .           . ';
+						'meta   border  submeta     submeta';
 				}
 
 				/*

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -559,7 +559,7 @@ const standfirstLinkTextLight = ({ design, theme }: ArticleFormat): string => {
 				case Pillar.Opinion:
 					return sourcePalette.opinion[500];
 				case Pillar.Sport:
-					return sourcePalette.sport[400];
+					return sourcePalette.sport[500];
 				case Pillar.Culture:
 					return sourcePalette.culture[500];
 				case Pillar.Lifestyle:


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Couple of small tweaks: 

- the colour of standfirst links on sport cartoons is a bit brighter
- the lines in the left column now line up with the top of the cartoon

## Why?

Looks better (and more accessible) this way. 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/102960844/7d4e2b50-0f4f-4ed5-b86a-5b584247880f
[after]: https://github.com/guardian/dotcom-rendering/assets/102960844/27ec030c-14c5-4b2c-9713-d035cc6c3908