### PR TITLE
Fix `splitTheme` decorator’s arguments and simplify stories using it

### DIFF
--- a/dotcom-rendering/.storybook/decorators/splitThemeDecorator.tsx
+++ b/dotcom-rendering/.storybook/decorators/splitThemeDecorator.tsx
@@ -134,7 +134,7 @@ export const splitTheme =
 		formats: readonly [ArticleFormat, ...ArticleFormat[]] = defaultFormats,
 		{ orientation = 'horizontal' }: Orientation = {},
 	): Decorator =>
-	(Story) =>
+	(Story, context) =>
 		(
 			<div
 				css={styles}
@@ -157,7 +157,7 @@ export const splitTheme =
 					{formats.map((format) => (
 						<div css={css(paletteDeclarations(format, 'light'))}>
 							<FormatHeading format={format} />
-							<Story format={format} />
+							<Story args={{ ...context.args, format }} />
 						</div>
 					))}
 				</div>
@@ -175,7 +175,7 @@ export const splitTheme =
 					{formats.map((format) => (
 						<div css={css(paletteDeclarations(format, 'dark'))}>
 							<FormatHeading format={format} />
-							<Story format={format} />
+							<Story args={{ ...context.args, format }} />
 						</div>
 					))}
 				</div>

--- a/dotcom-rendering/src/components/Caption.stories.tsx
+++ b/dotcom-rendering/src/components/Caption.stories.tsx
@@ -6,6 +6,7 @@ import {
 	Pillar,
 } from '@guardian/libs';
 import { breakpoints, palette } from '@guardian/source-foundations';
+import type { StoryObj } from '@storybook/react';
 import { splitTheme } from '../../.storybook/decorators/splitThemeDecorator';
 import { Caption } from './Caption';
 import { Section } from './Section';
@@ -34,105 +35,132 @@ const articleFormat: ArticleFormat = {
     isOverlaid?: boolean; // Not tested here as this option only works in the context of the ImageComponent
  */
 
-export const Article = () => (
+export const Article: StoryObj = ({ format }: { format: ArticleFormat }) => (
 	<Section fullWidth={true} showTopBorder={false} showSideBorders={false}>
 		<Caption
 			captionText="This is how an Article caption looks"
-			format={articleFormat}
+			format={format}
 		/>
 	</Section>
 );
 Article.storyName = 'Article';
 Article.decorators = [splitTheme([articleFormat])];
 
-const analysisFormat = {
-	display: ArticleDisplay.Standard,
-	design: ArticleDesign.Analysis,
-	theme: Pillar.News,
-};
-export const Analysis = () => (
+export const Analysis: StoryObj = ({ format }: { format: ArticleFormat }) => (
 	<Section fullWidth={true} showTopBorder={false} showSideBorders={false}>
 		<Caption
 			captionText="This is how an Analysis caption looks"
-			format={analysisFormat}
+			format={format}
 		/>
 	</Section>
 );
 Analysis.storyName = 'Analysis';
-Analysis.decorators = [splitTheme([analysisFormat])];
+Analysis.decorators = [
+	splitTheme([
+		{
+			display: ArticleDisplay.Standard,
+			design: ArticleDesign.Analysis,
+			theme: Pillar.News,
+		},
+	]),
+];
 
-const photoEssayFormat = {
-	display: ArticleDisplay.Immersive,
-	design: ArticleDesign.PhotoEssay,
-	theme: Pillar.News,
-};
-export const PhotoEssay = () => (
+export const PhotoEssay: StoryObj = ({ format }: { format: ArticleFormat }) => (
 	<Section fullWidth={true} showTopBorder={false} showSideBorders={false}>
 		<Caption
 			captionText="<ul><li>This is how a PhotoEssay caption looks</li></ul>"
-			format={photoEssayFormat}
+			format={format}
 		/>
 	</Section>
 );
 PhotoEssay.storyName = 'PhotoEssay';
-PhotoEssay.decorators = [splitTheme([photoEssayFormat])];
+PhotoEssay.decorators = [
+	splitTheme([
+		{
+			display: ArticleDisplay.Immersive,
+			design: ArticleDesign.PhotoEssay,
+			theme: Pillar.News,
+		},
+	]),
+];
 
-const specialReportFormat = {
-	display: ArticleDisplay.Standard,
-	design: ArticleDesign.Standard,
-	theme: ArticleSpecial.SpecialReport,
-};
-export const SpecialReport = () => (
+export const SpecialReport: StoryObj = ({
+	format,
+}: {
+	format: ArticleFormat;
+}) => (
 	<Section fullWidth={true} showTopBorder={false} showSideBorders={false}>
 		<Caption
 			captionText="This is how a SpecialReport caption looks"
-			format={specialReportFormat}
+			format={format}
 		/>
 	</Section>
 );
 SpecialReport.storyName = 'SpecialReport';
-SpecialReport.decorators = [splitTheme([specialReportFormat])];
+SpecialReport.decorators = [
+	splitTheme([
+		{
+			display: ArticleDisplay.Standard,
+			design: ArticleDesign.Standard,
+			theme: ArticleSpecial.SpecialReport,
+		},
+	]),
+];
 
-const immersivePhotoFormat = {
-	display: ArticleDisplay.Immersive,
-	design: ArticleDesign.PhotoEssay,
-	theme: Pillar.News,
-};
-export const PhotoEssayLimitedWidth = () => (
+export const PhotoEssayLimitedWidth: StoryObj = ({
+	format,
+}: {
+	format: ArticleFormat;
+}) => (
 	<Section fullWidth={true} showTopBorder={false} showSideBorders={false}>
 		<Caption
 			captionText="<ul><li>This is how a PhotoEssay caption looks when width is limited</li></ul>"
-			format={immersivePhotoFormat}
+			format={format}
 			shouldLimitWidth={true}
 		/>
 	</Section>
 );
 PhotoEssayLimitedWidth.storyName = 'PhotoEssay with width limited';
-PhotoEssayLimitedWidth.decorators = [splitTheme([immersivePhotoFormat])];
+PhotoEssayLimitedWidth.decorators = [
+	splitTheme([
+		{
+			display: ArticleDisplay.Immersive,
+			design: ArticleDesign.PhotoEssay,
+			theme: Pillar.News,
+		},
+	]),
+];
 
-const featureFormat = {
-	display: ArticleDisplay.Standard,
-	design: ArticleDesign.Feature,
-	theme: Pillar.News,
-};
-export const Credit = () => (
+export const Credit: StoryObj = ({ format }: { format: ArticleFormat }) => (
 	<Section fullWidth={true} showTopBorder={false} showSideBorders={false}>
 		<Caption
 			captionText="This is how a Feature caption looks with credit showing"
-			format={featureFormat}
+			format={format}
 			credit="Credited to Able Jones"
 			displayCredit={true}
 		/>
 	</Section>
 );
 Credit.storyName = 'with credit';
-Credit.decorators = [splitTheme([featureFormat])];
+Credit.decorators = [
+	splitTheme([
+		{
+			display: ArticleDisplay.Standard,
+			design: ArticleDesign.Feature,
+			theme: Pillar.News,
+		},
+	]),
+];
 
-export const WidthLimited = () => (
+export const WidthLimited: StoryObj = ({
+	format,
+}: {
+	format: ArticleFormat;
+}) => (
 	<Section fullWidth={true} showTopBorder={false} showSideBorders={false}>
 		<Caption
 			captionText="This is how a caption looks with width limited"
-			format={articleFormat}
+			format={format}
 			shouldLimitWidth={true}
 		/>
 	</Section>
@@ -140,11 +168,11 @@ export const WidthLimited = () => (
 WidthLimited.storyName = 'with width limited';
 WidthLimited.decorators = [splitTheme([articleFormat])];
 
-export const Padded = () => (
+export const Padded: StoryObj = ({ format }: { format: ArticleFormat }) => (
 	<Section fullWidth={true} showTopBorder={false} showSideBorders={false}>
 		<Caption
 			captionText="This is how a caption looks when padded"
-			format={articleFormat}
+			format={format}
 			padCaption={true}
 		/>
 	</Section>
@@ -152,7 +180,7 @@ export const Padded = () => (
 Padded.storyName = 'when padded';
 Padded.decorators = [splitTheme([articleFormat])];
 
-export const Overlaid = () => (
+export const Overlaid: StoryObj = ({ format }: { format: ArticleFormat }) => (
 	<Section fullWidth={true} showTopBorder={false} showSideBorders={false}>
 		<div
 			css={css`
@@ -174,7 +202,7 @@ export const Overlaid = () => (
 			<Caption
 				isOverlaid={true}
 				captionText="This is how a caption looks when it's overlaid"
-				format={articleFormat}
+				format={format}
 				padCaption={true}
 			/>
 		</div>
@@ -183,12 +211,11 @@ export const Overlaid = () => (
 Overlaid.storyName = 'when overlaid';
 Overlaid.decorators = [splitTheme([articleFormat])];
 
-const reviewFormat = {
-	display: ArticleDisplay.Showcase,
-	design: ArticleDesign.Review,
-	theme: Pillar.News,
-};
-export const OverlaidWithStars = () => (
+export const OverlaidWithStars: StoryObj = ({
+	format,
+}: {
+	format: ArticleFormat;
+}) => (
 	<Section fullWidth={true} showTopBorder={false} showSideBorders={false}>
 		<div
 			css={css`
@@ -210,7 +237,7 @@ export const OverlaidWithStars = () => (
 			<Caption
 				isOverlaid={true}
 				captionText="This is how a caption looks when it's overlaid with stars"
-				format={reviewFormat}
+				format={format}
 				padCaption={true}
 			/>
 			<div
@@ -227,13 +254,25 @@ export const OverlaidWithStars = () => (
 	</Section>
 );
 OverlaidWithStars.storyName = 'when overlaid on stars';
-OverlaidWithStars.decorators = [splitTheme([reviewFormat])];
+OverlaidWithStars.decorators = [
+	splitTheme([
+		{
+			display: ArticleDisplay.Showcase,
+			design: ArticleDesign.Review,
+			theme: Pillar.News,
+		},
+	]),
+];
 
-export const VideoCaption = () => (
+export const VideoCaption: StoryObj = ({
+	format,
+}: {
+	format: ArticleFormat;
+}) => (
 	<Section fullWidth={true} showTopBorder={false} showSideBorders={false}>
 		<Caption
 			captionText="This is how an Article caption looks"
-			format={articleFormat}
+			format={format}
 			mediaType="Video"
 		/>
 	</Section>

--- a/dotcom-rendering/src/components/ClickToView.stories.tsx
+++ b/dotcom-rendering/src/components/ClickToView.stories.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react';
 import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
 import { textSans } from '@guardian/source-foundations';
+import type { StoryObj } from '@storybook/react';
 import { splitTheme } from '../../.storybook/decorators/splitThemeDecorator';
 import type {
 	DocumentBlockElement,
@@ -49,9 +50,11 @@ const paragraphStyle = css`
 const RoleStory = ({
 	children,
 	role,
+	format,
 }: {
 	children: React.ReactNode;
 	role: RoleType;
+	format: ArticleFormat;
 }) => {
 	return (
 		<Section
@@ -76,7 +79,7 @@ const RoleStory = ({
 					level. Truffaut street art edison bulb, banh mi cliche
 					post-ironic mixtape
 				</p>
-				<Figure format={defaultFormat} isMainMedia={false} role={role}>
+				<Figure format={format} isMainMedia={false} role={role}>
 					<ClickToView
 						role={role}
 						isTracking={true}
@@ -121,9 +124,13 @@ const RoleStory = ({
 	);
 };
 
-export const InlineStory = () => {
+export const InlineStory: StoryObj = ({
+	format,
+}: {
+	format: ArticleFormat;
+}) => {
 	return (
-		<RoleStory role="inline">
+		<RoleStory role="inline" format={format}>
 			<img
 				src="http://placekitten.com/g/620/400"
 				width="620"
@@ -136,9 +143,13 @@ export const InlineStory = () => {
 InlineStory.storyName = "Click to view in 'inline' role";
 InlineStory.decorators = [splitTheme([defaultFormat])];
 
-export const SupportingStory = () => {
+export const SupportingStory: StoryObj = ({
+	format,
+}: {
+	format: ArticleFormat;
+}) => {
 	return (
-		<RoleStory role="supporting">
+		<RoleStory role="supporting" format={format}>
 			<img
 				src="http://placekitten.com/g/380/300"
 				width="380"
@@ -151,9 +162,13 @@ export const SupportingStory = () => {
 SupportingStory.storyName = "Click to view in 'supporting' role";
 SupportingStory.decorators = [splitTheme([defaultFormat])];
 
-export const ShowcaseStory = () => {
+export const ShowcaseStory: StoryObj = ({
+	format,
+}: {
+	format: ArticleFormat;
+}) => {
 	return (
-		<RoleStory role="showcase">
+		<RoleStory role="showcase" format={format}>
 			<img
 				src="http://placekitten.com/g/860/560"
 				width="860"
@@ -166,9 +181,13 @@ export const ShowcaseStory = () => {
 ShowcaseStory.storyName = "Click to view in 'showcase' role";
 ShowcaseStory.decorators = [splitTheme([defaultFormat])];
 
-export const HalfWidthStory = () => {
+export const HalfWidthStory: StoryObj = ({
+	format,
+}: {
+	format: ArticleFormat;
+}) => {
 	return (
-		<RoleStory role="halfWidth">
+		<RoleStory role="halfWidth" format={format}>
 			<img
 				src="http://placekitten.com/g/860/560"
 				width="310"
@@ -181,9 +200,13 @@ export const HalfWidthStory = () => {
 HalfWidthStory.storyName = "Click to view in 'halfWidth' role";
 HalfWidthStory.decorators = [splitTheme([defaultFormat])];
 
-export const ThumbnailStory = () => {
+export const ThumbnailStory: StoryObj = ({
+	format,
+}: {
+	format: ArticleFormat;
+}) => {
 	return (
-		<RoleStory role="thumbnail">
+		<RoleStory role="thumbnail" format={format}>
 			<img
 				src="http://placekitten.com/g/140/105"
 				width="140"
@@ -479,7 +502,11 @@ const vineEmbedEmbed: VineBlockElement = {
 	isThirdPartyTracking: false,
 };
 
-export const EmbedBlockComponentStory = () => {
+export const EmbedBlockComponentStory: StoryObj = ({
+	format,
+}: {
+	format: ArticleFormat;
+}) => {
 	return (
 		<Section
 			showTopBorder={false}
@@ -501,11 +528,7 @@ export const EmbedBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure
-					format={defaultFormat}
-					isMainMedia={false}
-					role="inline"
-				>
+				<Figure format={format} isMainMedia={false} role="inline">
 					<EmbedBlockComponent
 						key={1}
 						html={facebookEmbed.html}
@@ -523,11 +546,7 @@ export const EmbedBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure
-					format={defaultFormat}
-					isMainMedia={false}
-					role="inline"
-				>
+				<Figure format={format} isMainMedia={false} role="inline">
 					<EmbedBlockComponent
 						key={1}
 						html={vimeoEmbedEmbed.html}
@@ -545,11 +564,7 @@ export const EmbedBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure
-					format={defaultFormat}
-					isMainMedia={false}
-					role="inline"
-				>
+				<Figure format={format} isMainMedia={false} role="inline">
 					<EmbedBlockComponent
 						key={1}
 						html={youtubeEmbedEmbed.html}
@@ -567,11 +582,7 @@ export const EmbedBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure
-					format={defaultFormat}
-					isMainMedia={false}
-					role="inline"
-				>
+				<Figure format={format} isMainMedia={false} role="inline">
 					<EmbedBlockComponent
 						key={1}
 						html={spotifyEmbedEmbed.html}
@@ -589,11 +600,7 @@ export const EmbedBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure
-					format={defaultFormat}
-					isMainMedia={false}
-					role="inline"
-				>
+				<Figure format={format} isMainMedia={false} role="inline">
 					<EmbedBlockComponent
 						key={1}
 						html={bandcampEmbedEmbed.html}
@@ -611,11 +618,7 @@ export const EmbedBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure
-					format={defaultFormat}
-					isMainMedia={false}
-					role="inline"
-				>
+				<Figure format={format} isMainMedia={false} role="inline">
 					<EmbedBlockComponent
 						key={1}
 						html={ourworldindataEmbedEmbed.html}
@@ -633,11 +636,7 @@ export const EmbedBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure
-					format={defaultFormat}
-					isMainMedia={false}
-					role="inline"
-				>
+				<Figure format={format} isMainMedia={false} role="inline">
 					<EmbedBlockComponent
 						key={1}
 						html={bbcEmbedEmbed.html}
@@ -657,7 +656,11 @@ EmbedBlockComponentStory.storyName =
 	'Click to view wrapping EmbedBlockComponent';
 EmbedBlockComponentStory.decorators = [splitTheme([defaultFormat])];
 
-export const UnsafeEmbedBlockComponentStory = () => {
+export const UnsafeEmbedBlockComponentStory: StoryObj = ({
+	format,
+}: {
+	format: ArticleFormat;
+}) => {
 	return (
 		<Section
 			showTopBorder={false}
@@ -679,11 +682,7 @@ export const UnsafeEmbedBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure
-					format={defaultFormat}
-					isMainMedia={false}
-					role="inline"
-				>
+				<Figure format={format} isMainMedia={false} role="inline">
 					<UnsafeEmbedBlockComponent
 						key="1"
 						html={instagramEmbedEmbed.html}
@@ -701,11 +700,7 @@ export const UnsafeEmbedBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure
-					format={defaultFormat}
-					isMainMedia={false}
-					role="inline"
-				>
+				<Figure format={format} isMainMedia={false} role="inline">
 					<UnsafeEmbedBlockComponent
 						key="2"
 						html={formStackEmbed.html}
@@ -724,11 +719,7 @@ export const UnsafeEmbedBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure
-					format={defaultFormat}
-					isMainMedia={false}
-					role="inline"
-				>
+				<Figure format={format} isMainMedia={false} role="inline">
 					<UnsafeEmbedBlockComponent
 						key="3"
 						html={scribdEmbedEmbed.html}
@@ -747,11 +738,7 @@ export const UnsafeEmbedBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure
-					format={defaultFormat}
-					isMainMedia={false}
-					role="inline"
-				>
+				<Figure format={format} isMainMedia={false} role="inline">
 					<UnsafeEmbedBlockComponent
 						key="4"
 						html={tiktokEmbedEmbed.html}
@@ -770,11 +757,7 @@ export const UnsafeEmbedBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure
-					format={defaultFormat}
-					isMainMedia={false}
-					role="inline"
-				>
+				<Figure format={format} isMainMedia={false} role="inline">
 					<UnsafeEmbedBlockComponent
 						key="5"
 						html={twitterEmbedEmbed.html}
@@ -795,7 +778,11 @@ UnsafeEmbedBlockComponentStory.storyName =
 	'Click to view wrapping UnsafeEmbedBlockComponent';
 UnsafeEmbedBlockComponentStory.decorators = [splitTheme([defaultFormat])];
 
-export const VimeoBlockComponentStory = () => {
+export const VimeoBlockComponentStory: StoryObj = ({
+	format,
+}: {
+	format: ArticleFormat;
+}) => {
 	return (
 		<Section
 			showTopBorder={false}
@@ -818,11 +805,7 @@ export const VimeoBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure
-					format={defaultFormat}
-					isMainMedia={false}
-					role="inline"
-				>
+				<Figure format={format} isMainMedia={false} role="inline">
 					<ClickToView
 						isTracking={true}
 						source={vimeoVideoEmbed.source}
@@ -830,7 +813,7 @@ export const VimeoBlockComponentStory = () => {
 						role="inline"
 					>
 						<VimeoBlockComponent
-							format={defaultFormat}
+							format={format}
 							embedUrl={vimeoVideoEmbed.embedUrl}
 							height={vimeoVideoEmbed.height}
 							width={vimeoVideoEmbed.width}
@@ -850,7 +833,11 @@ VimeoBlockComponentStory.storyName =
 	'Click to view wrapping VimeoBlockComponent';
 VimeoBlockComponentStory.decorators = [splitTheme([defaultFormat])];
 
-export const DocumentBlockComponentStory = () => {
+export const DocumentBlockComponentStory: StoryObj = ({
+	format,
+}: {
+	format: ArticleFormat;
+}) => {
 	return (
 		<Section
 			showTopBorder={false}
@@ -873,11 +860,7 @@ export const DocumentBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure
-					format={defaultFormat}
-					isMainMedia={false}
-					role="inline"
-				>
+				<Figure format={format} isMainMedia={false} role="inline">
 					<ClickToView
 						isTracking={true}
 						source={scribdDocumentEmbed.source}
@@ -903,7 +886,11 @@ DocumentBlockComponentStory.storyName =
 	'Click to view wrapping DocumentBlockComponentStory';
 DocumentBlockComponentStory.decorators = [splitTheme([defaultFormat])];
 
-export const SoundCloudBlockComponentStory = () => {
+export const SoundCloudBlockComponentStory: StoryObj = ({
+	format,
+}: {
+	format: ArticleFormat;
+}) => {
 	return (
 		<Section
 			showTopBorder={false}
@@ -926,11 +913,7 @@ export const SoundCloudBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure
-					format={defaultFormat}
-					isMainMedia={false}
-					role="inline"
-				>
+				<Figure format={format} isMainMedia={false} role="inline">
 					<ClickToView
 						isTracking={true}
 						source={soundcloudAudioEmbed.source}
@@ -949,11 +932,7 @@ export const SoundCloudBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure
-					format={defaultFormat}
-					isMainMedia={false}
-					role="inline"
-				>
+				<Figure format={format} isMainMedia={false} role="inline">
 					<ClickToView
 						isTracking={true}
 						source={soundcloudEmbedEmbed.source}
@@ -974,7 +953,11 @@ SoundCloudBlockComponentStory.storyName =
 	'Click to view wrapping SoundCloudBlockComponent';
 SoundCloudBlockComponentStory.decorators = [splitTheme([defaultFormat])];
 
-export const SpotifyBlockComponentStory = () => {
+export const SpotifyBlockComponentStory: StoryObj = ({
+	format,
+}: {
+	format: ArticleFormat;
+}) => {
 	return (
 		<Section
 			showTopBorder={false}
@@ -997,11 +980,7 @@ export const SpotifyBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure
-					format={defaultFormat}
-					isMainMedia={false}
-					role="inline"
-				>
+				<Figure format={format} isMainMedia={false} role="inline">
 					<ClickToView
 						isTracking={true}
 						source={spotifyAudioEmbed.source}
@@ -1014,7 +993,7 @@ export const SpotifyBlockComponentStory = () => {
 							width={spotifyAudioEmbed.width}
 							title={spotifyAudioEmbed.title}
 							caption={spotifyAudioEmbed.caption}
-							format={defaultFormat}
+							format={format}
 							credit="Spotify"
 							role="inline"
 							isTracking={false}
@@ -1032,7 +1011,11 @@ SpotifyBlockComponentStory.storyName =
 	'Click to view wrapping SpotifyBlockComponent';
 SpotifyBlockComponentStory.decorators = [splitTheme([defaultFormat])];
 
-export const TweetBlockComponentStory = () => {
+export const TweetBlockComponentStory: StoryObj = ({
+	format,
+}: {
+	format: ArticleFormat;
+}) => {
 	return (
 		<Section
 			showTopBorder={false}
@@ -1055,11 +1038,7 @@ export const TweetBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure
-					format={defaultFormat}
-					isMainMedia={false}
-					role="inline"
-				>
+				<Figure format={format} isMainMedia={false} role="inline">
 					<ClickToView
 						isTracking={true}
 						source={twitterTweetEmbed.source}
@@ -1078,7 +1057,11 @@ TweetBlockComponentStory.storyName =
 	'Click to view wrapping TweetBlockComponent';
 TweetBlockComponentStory.decorators = [splitTheme([defaultFormat])];
 
-export const InstagramBlockComponentStory = () => {
+export const InstagramBlockComponentStory: StoryObj = ({
+	format,
+}: {
+	format: ArticleFormat;
+}) => {
 	return (
 		<Section
 			showTopBorder={false}
@@ -1101,11 +1084,7 @@ export const InstagramBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure
-					format={defaultFormat}
-					isMainMedia={false}
-					role="inline"
-				>
+				<Figure format={format} isMainMedia={false} role="inline">
 					<InstagramBlockComponent
 						key={1}
 						element={instagramInstramEmbed}
@@ -1122,7 +1101,11 @@ InstagramBlockComponentStory.storyName =
 	'Click to view wrapping InstagramBlockComponent';
 InstagramBlockComponentStory.decorators = [splitTheme([defaultFormat])];
 
-export const MapBlockComponentStory = () => {
+export const MapBlockComponentStory: StoryObj = ({
+	format,
+}: {
+	format: ArticleFormat;
+}) => {
 	return (
 		<Section
 			showTopBorder={false}
@@ -1144,11 +1127,7 @@ export const MapBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure
-					format={defaultFormat}
-					isMainMedia={false}
-					role="inline"
-				>
+				<Figure format={format} isMainMedia={false} role="inline">
 					<ClickToView
 						isTracking={true}
 						source={mapEmbedEmbed.source}
@@ -1161,7 +1140,7 @@ export const MapBlockComponentStory = () => {
 							width={mapEmbedEmbed.width}
 							title={mapEmbedEmbed.title}
 							caption={mapEmbedEmbed.caption}
-							format={defaultFormat}
+							format={format}
 							credit="Google Maps"
 							role="inline"
 							isTracking={false}
@@ -1178,7 +1157,11 @@ MapBlockComponentStory.storyName =
 	'Click to view wrapping MapEmbedBlockComponent';
 MapBlockComponentStory.decorators = [splitTheme([defaultFormat])];
 
-export const VineBlockComponentStory = () => {
+export const VineBlockComponentStory: StoryObj = ({
+	format,
+}: {
+	format: ArticleFormat;
+}) => {
 	return (
 		<Section
 			title="Embedded Content"
@@ -1200,11 +1183,7 @@ export const VineBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure
-					format={defaultFormat}
-					isMainMedia={false}
-					role="inline"
-				>
+				<Figure format={format} isMainMedia={false} role="inline">
 					<ClickToView
 						isTracking={true}
 						source={vineEmbedEmbed.source}

--- a/dotcom-rendering/src/components/Standfirst.stories.tsx
+++ b/dotcom-rendering/src/components/Standfirst.stories.tsx
@@ -5,6 +5,7 @@ import {
 	Pillar,
 } from '@guardian/libs';
 import { palette as sourcePalette } from '@guardian/source-foundations';
+import type { StoryObj } from '@storybook/react';
 import { splitTheme } from '../../.storybook/decorators/splitThemeDecorator';
 import { Section } from './Section';
 import { Standfirst } from './Standfirst';
@@ -19,11 +20,11 @@ const articleFormat = {
 	design: ArticleDesign.Standard,
 	theme: Pillar.News,
 };
-export const Article = () => {
+export const Article: StoryObj = ({ format }: { format: ArticleFormat }) => {
 	return (
 		<Section fullWidth={true}>
 			<Standfirst
-				format={articleFormat}
+				format={format}
 				standfirst="This is how Article standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas <ul><li><a href=\'https://www.theguardian.com/uk'>Bullet 1</a></li><li><a href=\'https://www.theguardian.com/uk'>Bullet 2</a></li></ul>"
 			/>
 		</Section>
@@ -32,106 +33,116 @@ export const Article = () => {
 Article.storyName = 'Article';
 Article.decorators = [splitTheme([articleFormat])];
 
-const commentFormat = {
-	display: ArticleDisplay.Standard,
-	design: ArticleDesign.Comment,
-	theme: Pillar.News,
-};
-export const Comment = () => {
+export const Comment: StoryObj = ({ format }: { format: ArticleFormat }) => {
 	return (
 		<Section fullWidth={true}>
 			<Standfirst
-				format={commentFormat}
+				format={format}
 				standfirst="This is how Comment standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas <ul><li><a href=\'https://www.theguardian.com/uk'>Bullet 1</a></li><li><a href=\'https://www.theguardian.com/uk'>Bullet 2</a></li></ul>"
 			/>
 		</Section>
 	);
 };
 Comment.storyName = 'Comment';
-Comment.decorators = [splitTheme([commentFormat])];
+Comment.decorators = [
+	splitTheme([
+		{
+			display: ArticleDisplay.Standard,
+			design: ArticleDesign.Comment,
+			theme: Pillar.News,
+		},
+	]),
+];
 
-const letterFormat = {
-	display: ArticleDisplay.Standard,
-	design: ArticleDesign.Letter,
-	theme: Pillar.News,
-};
-export const Letter = () => {
+export const Letter: StoryObj = ({ format }: { format: ArticleFormat }) => {
 	return (
 		<Section fullWidth={true}>
 			<Standfirst
-				format={letterFormat}
+				format={format}
 				standfirst="This is how Letter standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas <ul><li><a href=\'https://www.theguardian.com/uk'>Bullet 1</a></li><li><a href=\'https://www.theguardian.com/uk'>Bullet 2</a></li></ul>"
 			/>
 		</Section>
 	);
 };
 Letter.storyName = 'Letter';
-Letter.decorators = [splitTheme([letterFormat])];
+Letter.decorators = [
+	splitTheme([
+		{
+			display: ArticleDisplay.Standard,
+			design: ArticleDesign.Letter,
+			theme: Pillar.News,
+		},
+	]),
+];
 
-const featureFormat = {
-	display: ArticleDisplay.Standard,
-	design: ArticleDesign.Feature,
-	theme: Pillar.News,
-};
-export const Feature = () => {
+export const Feature: StoryObj = ({ format }: { format: ArticleFormat }) => {
 	return (
 		<Section fullWidth={true}>
 			<Standfirst
-				format={featureFormat}
+				format={format}
 				standfirst="This is how Feature standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas <ul><li><a href=\'https://www.theguardian.com/uk'>Bullet 1</a></li><li><a href=\'https://www.theguardian.com/uk'>Bullet 2</a></li></ul>"
 			/>
 		</Section>
 	);
 };
 Feature.storyName = 'Feature';
-Feature.decorators = [splitTheme([featureFormat])];
+Feature.decorators = [
+	splitTheme([
+		{
+			display: ArticleDisplay.Standard,
+			design: ArticleDesign.Feature,
+			theme: Pillar.News,
+		},
+	]),
+];
 
-const immersiveFormat = {
-	display: ArticleDisplay.Immersive,
-	design: ArticleDesign.Standard,
-	theme: Pillar.News,
-};
-export const Immersive = () => {
+export const Immersive: StoryObj = ({ format }: { format: ArticleFormat }) => {
 	return (
 		<Section fullWidth={true}>
 			<Standfirst
-				format={immersiveFormat}
+				format={format}
 				standfirst="This is how Immersive standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas <ul><li><a href=\'https://www.theguardian.com/uk'>Bullet 1</a></li><li><a href=\'https://www.theguardian.com/uk'>Bullet 2</a></li></ul>"
 			/>
 		</Section>
 	);
 };
 Immersive.storyName = 'Immersive';
-Immersive.decorators = [splitTheme([immersiveFormat])];
+Immersive.decorators = [
+	splitTheme([
+		{
+			display: ArticleDisplay.Immersive,
+			design: ArticleDesign.Standard,
+			theme: Pillar.News,
+		},
+	]),
+];
 
-const reviewFormat = {
-	display: ArticleDisplay.Standard,
-	design: ArticleDesign.Review,
-	theme: Pillar.News,
-};
-export const Review = () => {
+export const Review: StoryObj = ({ format }: { format: ArticleFormat }) => {
 	return (
 		<Section fullWidth={true}>
 			<Standfirst
-				format={reviewFormat}
+				format={format}
 				standfirst="This is how Review standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas <ul><li><a href=\'https://www.theguardian.com/uk'>Bullet 1</a></li><li><a href=\'https://www.theguardian.com/uk'>Bullet 2</a></li></ul>"
 			/>
 		</Section>
 	);
 };
 Review.storyName = 'Review';
-Review.decorators = [splitTheme([reviewFormat])];
+Review.decorators = [
+	splitTheme([
+		{
+			display: ArticleDisplay.Standard,
+			design: ArticleDesign.Review,
+			theme: Pillar.News,
+		},
+	]),
+];
 
-const liveblogFormat = {
-	display: ArticleDisplay.Standard,
-	design: ArticleDesign.LiveBlog,
-	theme: Pillar.News,
-};
-export const LiveBlog = () => {
+export const LiveBlog: StoryObj = ({ format }: { format: ArticleFormat }) => {
 	return (
 		<Section fullWidth={true}>
 			<Standfirst
-				format={liveblogFormat}
+				format={format}
 				standfirst="<p>This is how a Liveblog with bullets looks. Aut explicabo officia delectus omnis repellendus voluptas</p> <ul><li><a href=\'https://www.theguardian.com/uk'>Bullet 1</a></li><li><a href=\'https://www.theguardian.com/uk'>Bullet 2</a></li></ul>"
 			/>
 		</Section>
@@ -151,274 +162,343 @@ LiveBlog.story = {
 		},
 	},
 };
-LiveBlog.decorators = [splitTheme([liveblogFormat])];
+LiveBlog.decorators = [
+	splitTheme([
+		{
+			display: ArticleDisplay.Standard,
+			design: ArticleDesign.LiveBlog,
+			theme: Pillar.News,
+		},
+	]),
+];
 
-const deadblogFormat = {
-	display: ArticleDisplay.Standard,
-	design: ArticleDesign.DeadBlog,
-	theme: Pillar.News,
-};
-export const DeadBlog = () => {
+export const DeadBlog: StoryObj = ({ format }: { format: ArticleFormat }) => {
 	return (
 		<Section fullWidth={true}>
 			<Standfirst
-				format={deadblogFormat}
+				format={format}
 				standfirst="<p>This is how a Deadblog with bullets looks. Aut explicabo officia delectus omnis repellendus voluptas</p> <ul><li><a href=\'https://www.theguardian.com/uk'>Bullet 1</a></li><li><a href=\'https://www.theguardian.com/uk'>Bullet 2</a></li></ul>"
 			/>
 		</Section>
 	);
 };
 DeadBlog.storyName = 'DeadBlog';
-DeadBlog.decorators = [splitTheme([deadblogFormat])];
+DeadBlog.decorators = [
+	splitTheme([
+		{
+			display: ArticleDisplay.Standard,
+			design: ArticleDesign.DeadBlog,
+			theme: Pillar.News,
+		},
+	]),
+];
 
-const interviewFormat = {
-	display: ArticleDisplay.Standard,
-	design: ArticleDesign.Interview,
-	theme: Pillar.News,
-};
-export const Interview = () => {
+export const Interview: StoryObj = ({ format }: { format: ArticleFormat }) => {
 	return (
 		<Section fullWidth={true}>
 			<Standfirst
-				format={interviewFormat}
+				format={format}
 				standfirst="This is how Interview standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas <ul><li><a href=\'https://www.theguardian.com/uk'>Bullet 1</a></li><li><a href=\'https://www.theguardian.com/uk'>Bullet 2</a></li></ul>"
 			/>
 		</Section>
 	);
 };
 Interview.storyName = 'Interview';
-Interview.decorators = [splitTheme([interviewFormat])];
+Interview.decorators = [
+	splitTheme([
+		{
+			display: ArticleDisplay.Standard,
+			design: ArticleDesign.Interview,
+			theme: Pillar.News,
+		},
+	]),
+];
 
-const analysisFormat = {
-	display: ArticleDisplay.Standard,
-	design: ArticleDesign.Analysis,
-	theme: Pillar.News,
-};
-export const Analysis = () => {
+export const Analysis: StoryObj = ({ format }: { format: ArticleFormat }) => {
 	return (
 		<Section fullWidth={true}>
 			<Standfirst
-				format={analysisFormat}
+				format={format}
 				standfirst="This is how Analysis standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas <ul><li><a href=\'https://www.theguardian.com/uk'>Bullet 1</a></li><li><a href=\'https://www.theguardian.com/uk'>Bullet 2</a></li></ul>"
 			/>
 		</Section>
 	);
 };
 Analysis.storyName = 'Analysis';
-Analysis.decorators = [splitTheme([analysisFormat])];
+Analysis.decorators = [
+	splitTheme([
+		{
+			display: ArticleDisplay.Standard,
+			design: ArticleDesign.Analysis,
+			theme: Pillar.News,
+		},
+	]),
+];
 
-const ExplainerFormat = {
-	display: ArticleDisplay.Standard,
-	design: ArticleDesign.Explainer,
-	theme: Pillar.News,
-};
-export const Explainer = () => {
+export const Explainer: StoryObj = ({ format }: { format: ArticleFormat }) => {
 	return (
 		<Section fullWidth={true}>
 			<Standfirst
-				format={ExplainerFormat}
+				format={format}
 				standfirst="This is how Explainer standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas <ul><li><a href=\'https://www.theguardian.com/uk'>Bullet 1</a></li><li><a href=\'https://www.theguardian.com/uk'>Bullet 2</a></li></ul>"
 			/>
 		</Section>
 	);
 };
 Explainer.storyName = 'Explainer';
-Explainer.decorators = [splitTheme([ExplainerFormat])];
+Explainer.decorators = [
+	splitTheme([
+		{
+			display: ArticleDisplay.Standard,
+			design: ArticleDesign.Explainer,
+			theme: Pillar.News,
+		},
+	]),
+];
 
-const GalleryFormat = {
-	display: ArticleDisplay.Standard,
-	design: ArticleDesign.Gallery,
-	theme: Pillar.Culture,
-};
-export const Gallery = () => {
+export const Gallery: StoryObj = ({ format }: { format: ArticleFormat }) => {
 	return (
 		<Section fullWidth={true}>
 			<Standfirst
-				format={GalleryFormat}
+				format={format}
 				standfirst="This is how Gallery standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas <ul><li><a href=\'https://www.theguardian.com/uk'>Bullet 1</a></li><li><a href=\'https://www.theguardian.com/uk'>Bullet 2</a></li></ul>"
 			/>
 		</Section>
 	);
 };
 Gallery.storyName = 'Gallery';
-Gallery.decorators = [splitTheme([GalleryFormat])];
+Gallery.decorators = [
+	splitTheme([
+		{
+			display: ArticleDisplay.Standard,
+			design: ArticleDesign.Gallery,
+			theme: Pillar.Culture,
+		},
+	]),
+];
 
-const audioFormat = {
-	display: ArticleDisplay.Standard,
-	design: ArticleDesign.Audio,
-	theme: Pillar.Culture,
-};
-export const Audio = () => {
+export const Audio: StoryObj = ({ format }: { format: ArticleFormat }) => {
 	return (
 		<Section fullWidth={true}>
 			<Standfirst
-				format={audioFormat}
+				format={format}
 				standfirst="This is how Audio standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas <ul><li><a href=\'https://www.theguardian.com/uk'>Bullet 1</a></li><li><a href=\'https://www.theguardian.com/uk'>Bullet 2</a></li></ul>"
 			/>
 		</Section>
 	);
 };
 Audio.storyName = 'Audio';
-Audio.decorators = [splitTheme([audioFormat])];
+Audio.decorators = [
+	splitTheme([
+		{
+			display: ArticleDisplay.Standard,
+			design: ArticleDesign.Audio,
+			theme: Pillar.Culture,
+		},
+	]),
+];
 
-const videoFormat = {
-	display: ArticleDisplay.Standard,
-	design: ArticleDesign.Video,
-	theme: Pillar.Culture,
-};
-export const Video = () => {
+export const Video: StoryObj = ({ format }: { format: ArticleFormat }) => {
 	return (
 		<Section fullWidth={true}>
 			<Standfirst
-				format={videoFormat}
+				format={format}
 				standfirst="This is how Video standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas <ul><li><a href=\'https://www.theguardian.com/uk'>Bullet 1</a></li><li><a href=\'https://www.theguardian.com/uk'>Bullet 2</a></li></ul>"
 			/>
 		</Section>
 	);
 };
 Video.storyName = 'Video';
-Video.decorators = [splitTheme([videoFormat])];
+Video.decorators = [
+	splitTheme([
+		{
+			display: ArticleDisplay.Standard,
+			design: ArticleDesign.Video,
+			theme: Pillar.Culture,
+		},
+	]),
+];
 
-const recipeFormat = {
-	display: ArticleDisplay.Standard,
-	design: ArticleDesign.Recipe,
-	theme: Pillar.Lifestyle,
-};
-export const Recipe = () => {
+export const Recipe: StoryObj = ({ format }: { format: ArticleFormat }) => {
 	return (
 		<Section fullWidth={true}>
 			<Standfirst
-				format={recipeFormat}
+				format={format}
 				standfirst="This is how Recipe standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas <ul><li><a href=\'https://www.theguardian.com/uk'>Bullet 1</a></li><li><a href=\'https://www.theguardian.com/uk'>Bullet 2</a></li></ul>"
 			/>
 		</Section>
 	);
 };
 Recipe.storyName = 'Recipe';
-Recipe.decorators = [splitTheme([recipeFormat])];
+Recipe.decorators = [
+	splitTheme([
+		{
+			display: ArticleDisplay.Standard,
+			design: ArticleDesign.Recipe,
+			theme: Pillar.Lifestyle,
+		},
+	]),
+];
 
-const matchReportFormat = {
-	display: ArticleDisplay.Standard,
-	design: ArticleDesign.MatchReport,
-	theme: Pillar.Sport,
-};
-export const MatchReport = () => {
+export const MatchReport: StoryObj = ({
+	format,
+}: {
+	format: ArticleFormat;
+}) => {
 	return (
 		<Section fullWidth={true}>
 			<Standfirst
-				format={matchReportFormat}
+				format={format}
 				standfirst="This is how MatchReport standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas <ul><li><a href=\'https://www.theguardian.com/uk'>Bullet 1</a></li><li><a href=\'https://www.theguardian.com/uk'>Bullet 2</a></li></ul>"
 			/>
 		</Section>
 	);
 };
 MatchReport.storyName = 'MatchReport';
-MatchReport.decorators = [splitTheme([matchReportFormat])];
+MatchReport.decorators = [
+	splitTheme([
+		{
+			display: ArticleDisplay.Standard,
+			design: ArticleDesign.MatchReport,
+			theme: Pillar.Sport,
+		},
+	]),
+];
 
-const quizFormat = {
-	display: ArticleDisplay.Standard,
-	design: ArticleDesign.Quiz,
-	theme: Pillar.Lifestyle,
-};
-export const Quiz = () => {
+export const Quiz: StoryObj = ({ format }: { format: ArticleFormat }) => {
 	return (
 		<Section fullWidth={true}>
 			<Standfirst
-				format={quizFormat}
+				format={format}
 				standfirst="This is how Quiz standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas <ul><li><a href=\'https://www.theguardian.com/uk'>Bullet 1</a></li><li><a href=\'https://www.theguardian.com/uk'>Bullet 2</a></li></ul>"
 			/>
 		</Section>
 	);
 };
 Quiz.storyName = 'Quiz';
-Quiz.decorators = [splitTheme([quizFormat])];
+Quiz.decorators = [
+	splitTheme([
+		{
+			display: ArticleDisplay.Standard,
+			design: ArticleDesign.Quiz,
+			theme: Pillar.Lifestyle,
+		},
+	]),
+];
 
-const specialReport = {
-	display: ArticleDisplay.Standard,
-	design: ArticleDesign.Standard,
-	theme: ArticleSpecial.SpecialReport,
-};
-export const SpecialReport = () => {
+export const SpecialReport: StoryObj = ({
+	format,
+}: {
+	format: ArticleFormat;
+}) => {
 	return (
 		<Section fullWidth={true}>
 			<Standfirst
-				format={specialReport}
+				format={format}
 				standfirst="This is how SpecialReport standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas <ul><li><a href=\'https://www.theguardian.com/uk'>Bullet 1</a></li><li><a href=\'https://www.theguardian.com/uk'>Bullet 2</a></li></ul>"
 			/>
 		</Section>
 	);
 };
 SpecialReport.storyName = 'SpecialReport';
-SpecialReport.decorators = [splitTheme([specialReport])];
+SpecialReport.decorators = [
+	splitTheme([
+		{
+			display: ArticleDisplay.Standard,
+			design: ArticleDesign.Standard,
+			theme: ArticleSpecial.SpecialReport,
+		},
+	]),
+];
 
-const SpecialReportAltFormat = {
-	display: ArticleDisplay.Standard,
-	design: ArticleDesign.Standard,
-	theme: ArticleSpecial.SpecialReportAlt,
-};
-export const SpecialReportAlt = () => {
+export const SpecialReportAlt: StoryObj = ({
+	format,
+}: {
+	format: ArticleFormat;
+}) => {
 	return (
 		<Section fullWidth={true}>
 			<Standfirst
-				format={SpecialReportAltFormat}
+				format={format}
 				standfirst="This is how SpecialReportAlt standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas <ul><li><a href=\'https://www.theguardian.com/uk'>Bullet 1</a></li><li><a href=\'https://www.theguardian.com/uk'>Bullet 2</a></li></ul>"
 			/>
 		</Section>
 	);
 };
 SpecialReportAlt.storyName = 'SpecialReportAlt';
-SpecialReportAlt.decorators = [splitTheme([SpecialReportAltFormat])];
+SpecialReportAlt.decorators = [
+	splitTheme([
+		{
+			display: ArticleDisplay.Standard,
+			design: ArticleDesign.Standard,
+			theme: ArticleSpecial.SpecialReportAlt,
+		},
+	]),
+];
 
-const editorialFormat = {
-	display: ArticleDisplay.Standard,
-	design: ArticleDesign.Editorial,
-	theme: Pillar.Opinion,
-};
-export const Editorial = () => {
+export const Editorial: StoryObj = ({ format }: { format: ArticleFormat }) => {
 	return (
 		<Section fullWidth={true}>
 			<Standfirst
-				format={editorialFormat}
+				format={format}
 				standfirst="This is how Editorial standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas <ul><li><a href=\'https://www.theguardian.com/uk'>Bullet 1</a></li><li><a href=\'https://www.theguardian.com/uk'>Bullet 2</a></li></ul>"
 			/>
 		</Section>
 	);
 };
 Editorial.storyName = 'Editorial';
-Editorial.decorators = [splitTheme([editorialFormat])];
+Editorial.decorators = [
+	splitTheme([
+		{
+			display: ArticleDisplay.Standard,
+			design: ArticleDesign.Editorial,
+			theme: Pillar.Opinion,
+		},
+	]),
+];
 
-const photoFormat = {
-	display: ArticleDisplay.Standard,
-	design: ArticleDesign.PhotoEssay,
-	theme: Pillar.News,
-};
-export const PhotoEssay = () => {
+export const PhotoEssay: StoryObj = ({ format }: { format: ArticleFormat }) => {
 	return (
 		<Section fullWidth={true}>
 			<Standfirst
-				format={photoFormat}
+				format={format}
 				standfirst="This is how PhotoEssay standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas <ul><li><a href=\'https://www.theguardian.com/uk'>Bullet 1</a></li><li><a href=\'https://www.theguardian.com/uk'>Bullet 2</a></li></ul>"
 			/>
 		</Section>
 	);
 };
 PhotoEssay.storyName = 'PhotoEssay';
-PhotoEssay.decorators = [splitTheme([photoFormat])];
+PhotoEssay.decorators = [
+	splitTheme([
+		{
+			display: ArticleDisplay.Standard,
+			design: ArticleDesign.PhotoEssay,
+			theme: Pillar.News,
+		},
+	]),
+];
 
-const labsWithLinkFormat = {
-	display: ArticleDisplay.Standard,
-	design: ArticleDesign.Standard,
-	theme: ArticleSpecial.Labs,
-};
-export const LabsWithLink = () => {
+export const LabsWithLink: StoryObj = ({
+	format,
+}: {
+	format: ArticleFormat;
+}) => {
 	return (
 		<Section fullWidth={true}>
 			<Standfirst
-				format={labsWithLinkFormat}
+				format={format}
 				standfirst='<p>Whether your holiday priorities are sampling gastronomic delights, visiting cultural landmarks, adventuring in the great outdoors or just having an easy time with the kids, this quiz will help you plan your itinerary for Brittany, Normandy and the Atlantic Loire Valley</p> <ul> <li>National restrictions may apply, please consult <a href="https://www.gov.uk/guidance/travel-advice-novel-coronavirus" rel="nofollow">government advice</a> before planning travel</li> </ul>'
 			/>
 		</Section>
 	);
 };
 LabsWithLink.storyName = 'LabsWithLink';
-LabsWithLink.decorators = [splitTheme([labsWithLinkFormat])];
+LabsWithLink.decorators = [
+	splitTheme([
+		{
+			display: ArticleDisplay.Standard,
+			design: ArticleDesign.Standard,
+			theme: ArticleSpecial.Labs,
+		},
+	]),
+];

--- a/dotcom-rendering/src/components/TableOfContents.stories.tsx
+++ b/dotcom-rendering/src/components/TableOfContents.stories.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
+import type { StoryObj } from '@storybook/react';
 import { splitTheme } from '../../.storybook/decorators/splitThemeDecorator';
 import type { TableOfContentsItem } from '../types/frontend';
 import { TableOfContents } from './TableOfContents.importable';
@@ -35,27 +36,13 @@ const headline3: TableOfContentsItem = {
 	title: 'Third h2 text',
 };
 
-const format: ArticleFormat = {
-	design: ArticleDesign.Standard,
-	display: ArticleDisplay.Standard,
-	theme: Pillar.News,
-};
-
-const immersiveDisplayFormat: ArticleFormat = {
-	design: ArticleDesign.Standard,
-	display: ArticleDisplay.Immersive,
-	theme: Pillar.News,
-};
-
-const numberedListDisplayFormat: ArticleFormat = {
-	design: ArticleDesign.Standard,
-	display: ArticleDisplay.NumberedList,
-	theme: Pillar.News,
-};
-
 const tableItems = [headline1, headline2, headline3];
 
-export const defaultStory = () => {
+export const defaultStory: StoryObj = ({
+	format,
+}: {
+	format: ArticleFormat;
+}) => {
 	return (
 		<Wrapper>
 			<TableOfContents tableOfContents={tableItems} format={format} />
@@ -64,32 +51,54 @@ export const defaultStory = () => {
 };
 
 defaultStory.storyName = 'default';
-defaultStory.decorators = [splitTheme([format])];
+defaultStory.decorators = [
+	splitTheme([
+		{
+			design: ArticleDesign.Standard,
+			display: ArticleDisplay.Standard,
+			theme: Pillar.News,
+		},
+	]),
+];
 
-export const immersive = () => {
+export const immersive: StoryObj = ({ format }: { format: ArticleFormat }) => {
 	return (
 		<Wrapper>
-			<TableOfContents
-				tableOfContents={tableItems}
-				format={immersiveDisplayFormat}
-			/>
+			<TableOfContents tableOfContents={tableItems} format={format} />
 		</Wrapper>
 	);
 };
 
 immersive.storyName = 'immersive';
-immersive.decorators = [splitTheme([immersiveDisplayFormat])];
+immersive.decorators = [
+	splitTheme([
+		{
+			design: ArticleDesign.Standard,
+			display: ArticleDisplay.Immersive,
+			theme: Pillar.News,
+		},
+	]),
+];
 
-export const numberedList = () => {
+export const numberedList: StoryObj = ({
+	format,
+}: {
+	format: ArticleFormat;
+}) => {
 	return (
 		<Wrapper>
-			<TableOfContents
-				tableOfContents={tableItems}
-				format={numberedListDisplayFormat}
-			/>
+			<TableOfContents tableOfContents={tableItems} format={format} />
 		</Wrapper>
 	);
 };
 
 numberedList.storyName = 'numberedList';
-numberedList.decorators = [splitTheme([numberedListDisplayFormat])];
+numberedList.decorators = [
+	splitTheme([
+		{
+			design: ArticleDesign.Standard,
+			display: ArticleDisplay.NumberedList,
+			theme: Pillar.News,
+		},
+	]),
+];


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Use the decorator [context’s `args`](https://storybook.js.org/docs/react/writing-stories/args) to provide a `format` prop to consuming stories.

Refactor existing stories to consume this arg, leading to more consistency.

## Why?

This is a new and growing pattern, so reaching consistency now is valuable.

## Screenshots

See Chromatic: everything is identical.