### PR TITLE
Add dark mode to key events 🌞 🌚 

### DIFF
--- a/dotcom-rendering/src/components/KeyEventCard.stories.tsx
+++ b/dotcom-rendering/src/components/KeyEventCard.stories.tsx
@@ -44,7 +44,6 @@ const SummaryCard = ({ theme }: { theme: ArticleTheme }) => (
 			id={events[0].id}
 			blockFirstPublished={events[0].blockFirstPublished}
 			title={events[0].title}
-			format={getFormat(theme)}
 			filterKeyEvents={false}
 			isSummary={true}
 		/>
@@ -67,7 +66,6 @@ const StandardCard = ({
 				title={event.title}
 				isSummary={event.isSummary}
 				filterKeyEvents={false}
-				format={getFormat(theme)}
 			/>
 		))}
 	</ul>

--- a/dotcom-rendering/src/components/KeyEventCard.stories.tsx
+++ b/dotcom-rendering/src/components/KeyEventCard.stories.tsx
@@ -5,27 +5,39 @@ import {
 	ArticleSpecial,
 	Pillar,
 } from '@guardian/libs';
-import { from, neutral } from '@guardian/source-foundations';
+import { from } from '@guardian/source-foundations';
+import { splitTheme } from '../../.storybook/decorators/splitThemeDecorator';
 import type { KeyEventCard as KeyEventCardType } from '../../fixtures/manual/key-events';
 import { events } from '../../fixtures/manual/key-events';
+import { palette } from '../palette';
 import { KeyEventCard } from './KeyEventCard';
 
-const getFormat = (theme: ArticleTheme) => {
-	return {
-		design: ArticleDesign.Standard,
-		display: ArticleDisplay.Standard,
-		theme,
-	};
+export default {
+	component: KeyEventCard,
+	title: 'Components/KeyEventCard',
 };
+const standardFormat = {
+	display: ArticleDisplay.Standard,
+	design: ArticleDesign.LiveBlog,
+	theme: Pillar.News,
+};
+const liveBlogFormats: [ArticleFormat, ...ArticleFormat[]] = [
+	{ ...standardFormat, theme: Pillar.News },
+	{ ...standardFormat, theme: Pillar.Sport },
+	{ ...standardFormat, theme: Pillar.Opinion },
+	{ ...standardFormat, theme: Pillar.Culture },
+	{ ...standardFormat, theme: Pillar.Lifestyle },
+	{ ...standardFormat, theme: ArticleSpecial.Labs },
+];
 
 const wrapperStyles = css`
 	padding-left: 20px;
 	display: inline-flex;
-	background-color: ${neutral[97]};
+	background-color: ${palette('--key-event-background')};
 	margin: 10px 0;
 
 	${from.desktop} {
-		background-color: ${neutral[93]};
+		background-color: ${palette('--key-event-background-desktop')};
 	}
 
 	ul {
@@ -38,7 +50,7 @@ const wrapperStyles = css`
 	}
 `;
 
-const SummaryCard = ({ theme }: { theme: ArticleTheme }) => (
+export const SummaryCard = () => (
 	<ul css={wrapperStyles}>
 		<KeyEventCard
 			id={events[0].id}
@@ -49,16 +61,27 @@ const SummaryCard = ({ theme }: { theme: ArticleTheme }) => (
 		/>
 	</ul>
 );
+SummaryCard.storyName = 'Summary Card';
+SummaryCard.decorators = [splitTheme(liveBlogFormats)];
 
-const StandardCard = ({
-	theme,
-	count,
-}: {
-	theme: ArticleTheme;
-	count: number;
-}) => (
+export const StandardCard = () => (
 	<ul css={wrapperStyles}>
-		{events.slice(0, count).map((event: KeyEventCardType) => (
+		<KeyEventCard
+			key={events[0].id}
+			id={events[0].id}
+			blockFirstPublished={events[0].blockFirstPublished}
+			title={events[0].title}
+			isSummary={events[0].isSummary}
+			filterKeyEvents={false}
+		/>
+	</ul>
+);
+StandardCard.storyName = 'Standard Card';
+StandardCard.decorators = [splitTheme(liveBlogFormats)];
+
+export const MultipleCards = () => (
+	<ul css={wrapperStyles}>
+		{events.slice(0, 7).map((event: KeyEventCardType) => (
 			<KeyEventCard
 				key={event.id}
 				id={event.id}
@@ -70,44 +93,5 @@ const StandardCard = ({
 		))}
 	</ul>
 );
-
-const Summary = () => (
-	<>
-		<SummaryCard theme={Pillar.News} />
-		<SummaryCard theme={Pillar.Culture} />
-		<SummaryCard theme={Pillar.Lifestyle} />
-		<SummaryCard theme={Pillar.Sport} />
-		<SummaryCard theme={Pillar.Opinion} />
-		<SummaryCard theme={ArticleSpecial.SpecialReport} />
-	</>
-);
-
-const KeyEvent = () => (
-	<>
-		<StandardCard theme={Pillar.News} count={1} />
-		<StandardCard theme={Pillar.Culture} count={1} />
-		<StandardCard theme={Pillar.Lifestyle} count={1} />
-		<StandardCard theme={Pillar.Sport} count={1} />
-		<StandardCard theme={Pillar.Opinion} count={1} />
-		<StandardCard theme={ArticleSpecial.SpecialReport} count={1} />
-	</>
-);
-
-const Multiple = () => (
-	<>
-		<StandardCard theme={Pillar.News} count={7} />
-		<StandardCard theme={Pillar.Culture} count={7} />
-		<StandardCard theme={Pillar.Lifestyle} count={7} />
-		<StandardCard theme={Pillar.Sport} count={7} />
-		<StandardCard theme={Pillar.Culture} count={7} />
-		<StandardCard theme={Pillar.Opinion} count={7} />
-		<StandardCard theme={ArticleSpecial.SpecialReport} count={7} />
-	</>
-);
-
-export default {
-	component: KeyEventCard,
-	title: 'Components/KeyEventCard',
-};
-
-export { Summary, KeyEvent, Multiple };
+MultipleCards.storyName = 'Multiple Standard Cards';
+MultipleCards.decorators = [splitTheme(liveBlogFormats)];

--- a/dotcom-rendering/src/components/KeyEventCard.tsx
+++ b/dotcom-rendering/src/components/KeyEventCard.tsx
@@ -96,7 +96,7 @@ const textStyles = css`
 
 const timeStyles = css`
 	${textSans.xsmall({ fontWeight: 'bold', lineHeight: 'tight' })};
-	color: ${palette('--key-event-time')};
+	color: ${palette('--key-event-title')};
 	display: block;
 `;
 

--- a/dotcom-rendering/src/components/KeyEventCard.tsx
+++ b/dotcom-rendering/src/components/KeyEventCard.tsx
@@ -1,9 +1,9 @@
 import { css } from '@emotion/react';
 import { from, space, textSans } from '@guardian/source-foundations';
 import { Link } from '@guardian/source-react-components';
+import { palette } from '../palette';
 import { Island } from './Island';
 import { RelativeTime } from './RelativeTime.importable';
-import { palette } from '../palette';
 
 interface Props {
 	id: string;

--- a/dotcom-rendering/src/components/KeyEventCard.tsx
+++ b/dotcom-rendering/src/components/KeyEventCard.tsx
@@ -1,10 +1,9 @@
 import { css } from '@emotion/react';
 import { from, space, textSans } from '@guardian/source-foundations';
 import { Link } from '@guardian/source-react-components';
-import { decidePalette } from '../lib/decidePalette';
-import type { Palette } from '../types/palette';
 import { Island } from './Island';
 import { RelativeTime } from './RelativeTime.importable';
+import { palette } from '../palette';
 
 interface Props {
 	id: string;
@@ -12,11 +11,10 @@ interface Props {
 	title: string;
 	isSummary: boolean;
 	filterKeyEvents: boolean;
-	format: ArticleFormat;
 	cardPosition?: string;
 }
 
-const linkStyles = (palette: Palette) => css`
+const linkStyles = css`
 	text-decoration: none;
 
 	&::before {
@@ -26,7 +24,7 @@ const linkStyles = (palette: Palette) => css`
 		height: 13px;
 		width: 13px;
 		border-radius: 50%;
-		background-color: ${palette.background.keyEventBullet};
+		background-color: ${palette('--key-event-bullet')};
 		margin-bottom: ${space[1]}px;
 		z-index: 2;
 
@@ -37,36 +35,33 @@ const linkStyles = (palette: Palette) => css`
 	}
 
 	&:hover::before {
-		background-color: ${palette.hover.keyEventBullet};
+		background-color: ${palette('--key-event-bullet-hover')};
 	}
 
 	&:hover {
-		span {
-			border-bottom: 1px solid ${palette.hover.keyEventLink};
-		}
 		div {
-			text-decoration: underline ${palette.text.keyEvent};
+			text-decoration: underline ${palette('--key-event-text')};
 			text-underline-offset: 1px;
 		}
 	}
 `;
 
-const summaryStyles = (palette: Palette) => css`
+const summaryStyles = css`
 	&::before {
-		background-color: ${palette.background.summaryEventBullet};
+		background-color: ${palette('--summary-event-bullet')};
 	}
 
 	&:hover::before {
-		background-color: ${palette.hover.summaryEventBullet};
+		background-color: ${palette('--summary-event-bullet-hover')};
 	}
 `;
 
-const listItemStyles = (palette: Palette) => css`
+const listItemStyles = css`
 	position: relative;
 	padding-bottom: ${space[3]}px;
 	padding-top: ${space[3]}px;
 	padding-right: ${space[3]}px;
-	background-color: ${palette.background.keyEvent};
+	background-color: ${palette('--key-event-background')};
 	list-style: none;
 	display: block;
 	width: 162px;
@@ -74,7 +69,7 @@ const listItemStyles = (palette: Palette) => css`
 
 	${from.desktop} {
 		padding-bottom: ${space[3]}px;
-		background-color: ${palette.background.keyEventFromDesktop};
+		background-color: ${palette('--key-event-background-desktop')};
 		width: 200px;
 		padding-right: ${space[5]}px;
 	}
@@ -83,7 +78,7 @@ const listItemStyles = (palette: Palette) => css`
 		content: '';
 		display: block;
 		position: absolute;
-		border-top: 1px dotted ${palette.border.keyEvent};
+		border-top: 1px dotted ${palette('--key-event-border')};
 		left: 0;
 		right: 0;
 		top: 19px;
@@ -94,14 +89,14 @@ const listItemStyles = (palette: Palette) => css`
 	}
 `;
 
-const textStyles = (palette: Palette) => css`
+const textStyles = css`
 	${textSans.small({ fontWeight: 'regular', lineHeight: 'regular' })};
-	color: ${palette.text.keyEvent};
+	color: ${palette('--key-event-text')};
 `;
 
-const timeStyles = (palette: Palette) => css`
+const timeStyles = css`
 	${textSans.xsmall({ fontWeight: 'bold', lineHeight: 'tight' })};
-	color: ${palette.text.keyEventTime};
+	color: ${palette('--key-event-time')};
 	display: block;
 `;
 
@@ -111,27 +106,25 @@ export const KeyEventCard = ({
 	isSummary,
 	title,
 	filterKeyEvents,
-	format,
 	cardPosition = 'unknown position',
 }: Props) => {
-	const palette = decidePalette(format);
 	const url = `?filterKeyEvents=${String(
 		filterKeyEvents,
 	)}&page=with:block-${id}#block-${id}`;
 	return (
-		<li css={listItemStyles(palette)}>
+		<li css={listItemStyles}>
 			<Link
 				priority="secondary"
-				css={[linkStyles(palette), isSummary && summaryStyles(palette)]}
+				css={[linkStyles, isSummary && summaryStyles]}
 				href={url}
 				data-link-name={`key event card | ${cardPosition}`}
 			>
-				<div css={timeStyles(palette)}>
+				<div css={timeStyles}>
 					<Island priority="enhancement" defer={{ until: 'visible' }}>
 						<RelativeTime then={blockFirstPublished} />
 					</Island>
 				</div>
-				<div css={textStyles(palette)}>{title}</div>
+				<div css={textStyles}>{title}</div>
 			</Link>
 		</li>
 	);

--- a/dotcom-rendering/src/components/KeyEventsCarousel.importable.tsx
+++ b/dotcom-rendering/src/components/KeyEventsCarousel.importable.tsx
@@ -7,8 +7,8 @@ import {
 	SvgChevronRightSingle,
 } from '@guardian/source-react-components';
 import { useRef } from 'react';
-import { KeyEventCard } from './KeyEventCard';
 import { palette } from '../palette';
+import { KeyEventCard } from './KeyEventCard';
 
 interface Props {
 	keyEvents: Block[];

--- a/dotcom-rendering/src/components/KeyEventsCarousel.importable.tsx
+++ b/dotcom-rendering/src/components/KeyEventsCarousel.importable.tsx
@@ -134,7 +134,6 @@ export const KeyEventsCarousel = ({
 						return (
 							<KeyEventCard
 								key={keyEvent.id}
-								format={format}
 								filterKeyEvents={filterKeyEvents}
 								id={keyEvent.id}
 								blockFirstPublished={

--- a/dotcom-rendering/src/components/KeyEventsCarousel.importable.tsx
+++ b/dotcom-rendering/src/components/KeyEventsCarousel.importable.tsx
@@ -1,22 +1,18 @@
 import { css } from '@emotion/react';
-import type { ArticleFormat } from '@guardian/libs';
 import { from, headline, space } from '@guardian/source-foundations';
 import {
 	Button,
-	buttonThemeBrandAlt,
 	Hide,
 	SvgChevronLeftSingle,
 	SvgChevronRightSingle,
 } from '@guardian/source-react-components';
 import { useRef } from 'react';
-import { decidePalette } from '../lib/decidePalette';
-import type { Palette } from '../types/palette';
 import { KeyEventCard } from './KeyEventCard';
+import { palette } from '../palette';
 
 interface Props {
 	keyEvents: Block[];
 	filterKeyEvents: boolean;
-	format: ArticleFormat;
 	id: 'key-events-carousel-desktop' | 'key-events-carousel-mobile';
 }
 type ValidBlock = Block & {
@@ -24,8 +20,8 @@ type ValidBlock = Block & {
 	blockFirstPublished: number;
 };
 
-const carouselStyles = (palette: Palette) => css`
-	background-color: ${palette.background.keyEvent};
+const carouselStyles = css`
+	background-color: ${palette('--key-event-background')};
 	scroll-snap-type: x mandatory;
 	scroll-behavior: smooth;
 	overflow-x: auto;
@@ -37,7 +33,7 @@ const carouselStyles = (palette: Palette) => css`
 
 	${from.desktop} {
 		margin-right: 0px;
-		background-color: ${palette.background.keyEventFromDesktop};
+		background-color: ${palette('--key-event-background-desktop')};
 		scrollbar-width: none;
 		&::-webkit-scrollbar {
 			display: none;
@@ -58,6 +54,7 @@ const marginBottomStyles = css`
 const titleStyles = css`
 	${headline.xxxsmall({ fontWeight: 'bold', lineHeight: 'regular' })};
 	padding-top: ${space[3]}px;
+	color: ${palette('--key-event-title')};
 `;
 
 const containerStyles = css`
@@ -73,11 +70,14 @@ const buttonStyles = css`
 	position: absolute;
 	bottom: 0;
 	margin-bottom: ${space[4]}px;
-	background-color: ${buttonThemeBrandAlt.button.backgroundPrimary};
+	background-color: ${palette('--key-event-button')};
 	&:active,
 	&:hover {
 		outline: none;
-		background-color: ${buttonThemeBrandAlt.button.backgroundTertiaryHover};
+		background-color: ${palette('--key-event-button-hover')};
+	}
+	svg {
+		fill: ${palette('--key-event-button-fill')};
 	}
 `;
 
@@ -98,11 +98,9 @@ const isValidKeyEvent = (keyEvent: Block): keyEvent is ValidBlock => {
 export const KeyEventsCarousel = ({
 	keyEvents,
 	filterKeyEvents,
-	format,
 	id,
 }: Props) => {
 	const carousel = useRef<HTMLDivElement | null>(null);
-	const palette = decidePalette(format);
 	const cardWidth = 200;
 
 	const goPrevious = () => {
@@ -124,10 +122,7 @@ export const KeyEventsCarousel = ({
 			<div
 				ref={carousel}
 				id="key-events-carousel"
-				css={[
-					carouselStyles(palette),
-					shortCarousel && leftMarginStyles,
-				]}
+				css={[carouselStyles, shortCarousel && leftMarginStyles]}
 			>
 				<ul css={[containerStyles, longCarousel && marginBottomStyles]}>
 					{filteredKeyEvents.map((keyEvent, index) => {

--- a/dotcom-rendering/src/components/KeyEventsCarousel.stories.tsx
+++ b/dotcom-rendering/src/components/KeyEventsCarousel.stories.tsx
@@ -1,27 +1,46 @@
 import { css } from '@emotion/react';
-import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
+import {
+	ArticleDesign,
+	ArticleDisplay,
+	ArticleSpecial,
+	Pillar,
+} from '@guardian/libs';
 import { from } from '@guardian/source-foundations';
+import { splitTheme } from '../../.storybook/decorators/splitThemeDecorator';
 import {
 	LongKeyEvents,
 	ShortKeyEvents,
 	SingleKeyEvent,
 } from '../../fixtures/manual/live-blog-key-events';
+import { palette } from '../palette';
 import { KeyEventsCarousel } from './KeyEventsCarousel.importable';
 
-const getFormat = (theme: ArticleTheme) => {
-	return {
-		design: ArticleDesign.Standard,
-		display: ArticleDisplay.Standard,
-		theme,
-	};
+const standardFormat = {
+	display: ArticleDisplay.Standard,
+	design: ArticleDesign.LiveBlog,
+	theme: Pillar.News,
 };
-
-const format = getFormat(Pillar.News);
+const liveBlogFormats: [ArticleFormat, ...ArticleFormat[]] = [
+	{ ...standardFormat, theme: Pillar.News },
+	{ ...standardFormat, theme: Pillar.Sport },
+	{ ...standardFormat, theme: Pillar.Opinion },
+	{ ...standardFormat, theme: Pillar.Culture },
+	{ ...standardFormat, theme: Pillar.Lifestyle },
+	{ ...standardFormat, theme: ArticleSpecial.Labs },
+];
 
 const Wrapper = ({ children }: { children: React.ReactNode }) => {
 	return (
 		<div
 			css={css`
+				padding-left: 20px;
+				background-color: ${palette('--key-event-background')};
+
+				${from.desktop} {
+					background-color: ${palette(
+						'--key-event-background-desktop',
+					)};
+				}
 				position: relative;
 				max-width: 700px;
 				${from.tablet} {
@@ -34,47 +53,47 @@ const Wrapper = ({ children }: { children: React.ReactNode }) => {
 	);
 };
 
-const SingleKeyEventCarousel = () => {
-	return (
-		<Wrapper>
-			<KeyEventsCarousel
-				keyEvents={SingleKeyEvent}
-				filterKeyEvents={false}
-				format={format}
-				id="key-events-carousel-desktop"
-			/>
-		</Wrapper>
-	);
-};
-const ShortKeyEventCarousel = () => {
-	return (
-		<Wrapper>
-			<KeyEventsCarousel
-				keyEvents={ShortKeyEvents}
-				filterKeyEvents={false}
-				format={format}
-				id="key-events-carousel-desktop"
-			/>
-		</Wrapper>
-	);
-};
-
-const LongKeyEventCarousel = () => {
-	return (
-		<Wrapper>
-			<KeyEventsCarousel
-				keyEvents={LongKeyEvents}
-				filterKeyEvents={false}
-				format={format}
-				id="key-events-carousel-desktop"
-			/>
-		</Wrapper>
-	);
-};
-
 export default {
 	component: KeyEventsCarousel,
 	title: 'Components/KeyEventsCarousel',
 };
 
-export { SingleKeyEventCarousel, ShortKeyEventCarousel, LongKeyEventCarousel };
+export const SingleKeyEventCarousel = () => {
+	return (
+		<Wrapper>
+			<KeyEventsCarousel
+				keyEvents={SingleKeyEvent}
+				filterKeyEvents={false}
+				id="key-events-carousel-desktop"
+			/>
+		</Wrapper>
+	);
+};
+SingleKeyEventCarousel.storyName = 'Single Key Event Carousel';
+SingleKeyEventCarousel.decorators = [splitTheme(liveBlogFormats)];
+export const ShortKeyEventCarousel = () => {
+	return (
+		<Wrapper>
+			<KeyEventsCarousel
+				keyEvents={ShortKeyEvents}
+				filterKeyEvents={false}
+				id="key-events-carousel-desktop"
+			/>
+		</Wrapper>
+	);
+};
+ShortKeyEventCarousel.storyName = 'Short Key Event Carousel';
+ShortKeyEventCarousel.decorators = [splitTheme(liveBlogFormats)];
+export const LongKeyEventCarousel = () => {
+	return (
+		<Wrapper>
+			<KeyEventsCarousel
+				keyEvents={LongKeyEvents}
+				filterKeyEvents={false}
+				id="key-events-carousel-desktop"
+			/>
+		</Wrapper>
+	);
+};
+LongKeyEventCarousel.storyName = 'Long Key Event Carousel';
+LongKeyEventCarousel.decorators = [splitTheme(liveBlogFormats)];

--- a/dotcom-rendering/src/components/LiveBlogRenderer.tsx
+++ b/dotcom-rendering/src/components/LiveBlogRenderer.tsx
@@ -99,7 +99,6 @@ export const LiveBlogRenderer = ({
 						<KeyEventsCarousel
 							keyEvents={keyEvents}
 							filterKeyEvents={filterKeyEvents}
-							format={format}
 							id={'key-events-carousel-mobile'}
 						/>
 					</Island>

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -1,17 +1,18 @@
 import { css } from '@emotion/react';
-import { ArticleDesign } from '@guardian/libs';
 import type { ArticleFormat } from '@guardian/libs';
+import { ArticleDesign } from '@guardian/libs';
 import {
 	brandBackground,
 	brandBorder,
 	brandLine,
 	from,
-	neutral,
+	palette as sourcePalette,
 	space,
 	until,
 } from '@guardian/source-foundations';
 import { Hide } from '@guardian/source-react-components';
 import { StraightLines } from '@guardian/source-react-components-development-kitchen';
+import { palette as darkModePalette } from '../../src/palette';
 import { Accordion } from '../components/Accordion';
 import { RightAdsPlaceholder } from '../components/AdPlaceholder.apps';
 import { AdPortals } from '../components/AdPortals.importable';
@@ -64,7 +65,6 @@ import { palette as themePalette } from '../palette';
 import type { DCRArticle } from '../types/frontend';
 import type { RenderingTarget } from '../types/renderingTarget';
 import { BannerWrapper, SendToBack, Stuck } from './lib/stickiness';
-import { palette as darkModePalette } from '../../src/palette';
 
 const HeadlineGrid = ({ children }: { children: React.ReactNode }) => (
 	<div
@@ -1159,7 +1159,7 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 							padSides={false}
 							showTopBorder={false}
 							showSideBorders={false}
-							backgroundColour={neutral[93]}
+							backgroundColour={sourcePalette.neutral[93]}
 							element="aside"
 						>
 							<AdSlot
@@ -1278,7 +1278,7 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 							padSides={false}
 							showTopBorder={false}
 							showSideBorders={false}
-							backgroundColour={neutral[93]}
+							backgroundColour={sourcePalette.neutral[93]}
 							element="aside"
 						>
 							<AdSlot

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -64,6 +64,7 @@ import { palette as themePalette } from '../palette';
 import type { DCRArticle } from '../types/frontend';
 import type { RenderingTarget } from '../types/renderingTarget';
 import { BannerWrapper, SendToBack, Stuck } from './lib/stickiness';
+import { palette as darkModePalette } from '../../src/palette';
 
 const HeadlineGrid = ({ children }: { children: React.ReactNode }) => (
 	<div
@@ -596,9 +597,9 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 					<Section
 						fullWidth={true}
 						showTopBorder={false}
-						backgroundColour={
-							palette.background.keyEventFromDesktop
-						}
+						backgroundColour={darkModePalette(
+							'--key-event-background-desktop',
+						)}
 						borderColour={palette.border.article}
 					>
 						<Hide until={'desktop'}>
@@ -609,7 +610,6 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 								<KeyEventsCarousel
 									keyEvents={article.keyEvents}
 									filterKeyEvents={article.filterKeyEvents}
-									format={format}
 									id={'key-events-carousel-desktop'}
 								/>
 							</Island>

--- a/dotcom-rendering/src/lib/decidePalette.ts
+++ b/dotcom-rendering/src/lib/decidePalette.ts
@@ -463,48 +463,6 @@ const textPullQuote = (format: ArticleFormat): string => {
 	return pillarPalette[format.theme].dark;
 };
 
-const textKeyEvent = (format: ArticleFormat): string => {
-	switch (format.theme) {
-		case Pillar.News:
-			return news[300];
-		case Pillar.Sport:
-			return sport[300];
-		case Pillar.Lifestyle:
-			return lifestyle[300];
-		case Pillar.Culture:
-			return culture[300];
-		case Pillar.Opinion:
-			return opinion[300];
-		case ArticleSpecial.Labs:
-			return labs[300];
-		case ArticleSpecial.SpecialReport:
-			return specialReport[300];
-		case ArticleSpecial.SpecialReportAlt:
-			return news[300];
-	}
-};
-
-const textKeyEventFromDesktop = ({ theme }: ArticleFormat) => {
-	switch (theme) {
-		case Pillar.News:
-			return news[400];
-		case Pillar.Sport:
-			return sport[300];
-		case Pillar.Lifestyle:
-			return lifestyle[300];
-		case Pillar.Culture:
-			return culture[300];
-		case Pillar.Opinion:
-			return opinion[300];
-		case ArticleSpecial.Labs:
-			return labs[300];
-		case ArticleSpecial.SpecialReport:
-			return specialReport[300];
-		case ArticleSpecial.SpecialReportAlt:
-			return news[400];
-	}
-};
-
 const textStandfirstLink = (format: ArticleFormat): string => {
 	if (format.design === ArticleDesign.LiveBlog) return WHITE;
 	if (format.design === ArticleDesign.DeadBlog) {
@@ -1629,8 +1587,6 @@ const borderCricketScoreboardDivider = (): string => {
 	return neutral[86];
 };
 
-const borderKeyEvent = (): string => neutral[46];
-
 const borderFilterButton = (): string => neutral[60];
 
 const borderSecondary = (format: ArticleFormat) => {
@@ -1804,8 +1760,6 @@ const textNumberedPosition = (): string => {
 	return text.supporting;
 };
 
-const textKeyEventTime = (): string => neutral[7];
-
 const textFilterButton = (): string => neutral[7];
 
 const textFilterButtonHover = (): string => neutral[100];
@@ -1852,33 +1806,6 @@ const backgroundMatchStats = (format: ArticleFormat): string => {
 	}
 };
 
-const backgroundKeyEventBullet = (): string => neutral[46];
-
-const backgroundKeyEvent = (): string => neutral[97];
-
-const backgroundKeyEventFromDesktop = (): string => neutral[93];
-
-const backgroundSummaryEventBullet = (format: ArticleFormat): string => {
-	switch (format.theme) {
-		case Pillar.News:
-			return news[400];
-		case Pillar.Sport:
-			return sport[400];
-		case Pillar.Lifestyle:
-			return lifestyle[400];
-		case Pillar.Culture:
-			return culture[400];
-		case Pillar.Opinion:
-			return opinion[400];
-		case ArticleSpecial.Labs:
-			return labs[400];
-		case ArticleSpecial.SpecialReport:
-			return specialReport[400];
-		case ArticleSpecial.SpecialReportAlt:
-			return news[400];
-	}
-};
-
 const backgroundTreat = (format: ArticleFormat): string => {
 	switch (format.theme) {
 		case Pillar.News:
@@ -1918,50 +1845,6 @@ const backgroundDesignTag = (format: ArticleFormat): string => {
 			return specialReport[300];
 		case ArticleSpecial.SpecialReportAlt:
 			return palette.specialReportAlt[100];
-	}
-};
-
-const hoverKeyEventLink = (format: ArticleFormat): string => {
-	switch (format.theme) {
-		case Pillar.News:
-			return news[400];
-		case Pillar.Sport:
-			return sport[400];
-		case Pillar.Lifestyle:
-			return lifestyle[400];
-		case Pillar.Culture:
-			return culture[400];
-		case Pillar.Opinion:
-			return opinion[400];
-		case ArticleSpecial.Labs:
-			return labs[400];
-		case ArticleSpecial.SpecialReport:
-			return specialReport[400];
-		case ArticleSpecial.SpecialReportAlt:
-			return news[400];
-	}
-};
-
-const hoverKeyEventBullet = (): string => neutral[0];
-
-const hoverSummaryEventBullet = (format: ArticleFormat): string => {
-	switch (format.theme) {
-		case Pillar.News:
-			return news[200];
-		case Pillar.Sport:
-			return sport[200];
-		case Pillar.Lifestyle:
-			return lifestyle[200];
-		case Pillar.Culture:
-			return culture[200];
-		case Pillar.Opinion:
-			return opinion[200];
-		case ArticleSpecial.Labs:
-			return labs[200];
-		case ArticleSpecial.SpecialReport:
-			return specialReport[200];
-		case ArticleSpecial.SpecialReportAlt:
-			return news[200];
 	}
 };
 
@@ -2221,9 +2104,6 @@ export const decidePalette = (
 			numberedTitle: textNumberedTitle(format),
 			numberedPosition: textNumberedPosition(),
 			cricketScoreboardLink: textCricketScoreboardLink(),
-			keyEvent: textKeyEvent(format),
-			keyEventFromDesktop: textKeyEventFromDesktop(format),
-			keyEventTime: textKeyEventTime(),
 			filterButton: textFilterButton(),
 			filterButtonHover: textFilterButtonHover(),
 			filterButtonActive: textFilterButtonActive(),
@@ -2260,10 +2140,6 @@ export const decidePalette = (
 			analysisUnderline: backgroundUnderline(format),
 			matchStats: backgroundMatchStats(format),
 			ageWarning: backgroundAgeWarning(format),
-			keyEventBullet: backgroundKeyEventBullet(),
-			summaryEventBullet: backgroundSummaryEventBullet(format),
-			keyEvent: backgroundKeyEvent(),
-			keyEventFromDesktop: backgroundKeyEventFromDesktop(),
 			filterButton: backgroundFilterButton(),
 			filterButtonHover: backgroundFilterButtonHover(format),
 			filterButtonActive: backgroundFilterButtonActive(format),
@@ -2308,7 +2184,6 @@ export const decidePalette = (
 			matchTab: matchTab(),
 			activeMatchTab: activeMatchTab(),
 			cardSupporting: borderCardSupporting(format),
-			keyEvent: borderKeyEvent(),
 			filterButton: borderFilterButton(),
 			secondary: borderSecondary(format),
 			pagination: borderPagination(),
@@ -2319,9 +2194,6 @@ export const decidePalette = (
 		hover: {
 			headlineByline: hoverHeadlineByline(format),
 			standfirstLink: hoverStandfirstLink(format),
-			keyEventLink: hoverKeyEventLink(format),
-			keyEventBullet: hoverKeyEventBullet(),
-			summaryEventBullet: hoverSummaryEventBullet(format),
 			pagination: hoverPagination(format),
 		},
 		discussionGeneric: discussion(format),

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -800,6 +800,145 @@ const captionLink = ({ design, theme }: ArticleFormat): string => {
 const captionOverlayText = (): string => {
 	return sourcePalette.neutral[100];
 };
+
+const keyEventBulletLight = (): string => sourcePalette.neutral[46];
+const keyEventBulletDark = (): string => sourcePalette.neutral[60];
+
+const keyEventBulletHoverLight = (): string => sourcePalette.neutral[0];
+const keyEventBulletHoverDark = (): string => sourcePalette.neutral[86];
+
+const keyEventTimeLight = (): string => sourcePalette.neutral[7];
+const keyEventTimeDark = (): string => sourcePalette.neutral[86];
+
+const keyEventTextLight = ({ theme }: ArticleFormat): string => {
+	switch (theme) {
+		case Pillar.News:
+			return sourcePalette.news[300];
+		case Pillar.Sport:
+			return sourcePalette.sport[300];
+		case Pillar.Lifestyle:
+			return sourcePalette.lifestyle[300];
+		case Pillar.Culture:
+			return sourcePalette.culture[300];
+		case Pillar.Opinion:
+			return sourcePalette.opinion[300];
+		case ArticleSpecial.Labs:
+			return sourcePalette.labs[300];
+		case ArticleSpecial.SpecialReport:
+			return sourcePalette.specialReport[300];
+		case ArticleSpecial.SpecialReportAlt:
+			return sourcePalette.news[300];
+	}
+};
+const keyEventTextDark = ({ theme }: ArticleFormat): string => {
+	switch (theme) {
+		case Pillar.News:
+			return sourcePalette.news[500];
+		case Pillar.Opinion:
+			return sourcePalette.opinion[500];
+		case Pillar.Sport:
+			return sourcePalette.sport[500];
+		case Pillar.Culture:
+			return sourcePalette.culture[500];
+		case Pillar.Lifestyle:
+			return sourcePalette.lifestyle[500];
+		case ArticleSpecial.SpecialReport:
+			return sourcePalette.specialReport[500];
+		case ArticleSpecial.Labs:
+			return sourcePalette.labs[400];
+		case ArticleSpecial.SpecialReportAlt:
+			return sourcePalette.specialReportAlt[300];
+	}
+};
+
+const keyEventBackgroundLight = (): string => sourcePalette.neutral[97];
+const keyEventBackgroundDark = (): string => sourcePalette.neutral[7];
+
+const keyEventBackgroundDesktopLight = (): string => sourcePalette.neutral[93];
+
+const keyEventBorderLight = (): string => sourcePalette.neutral[46];
+const keyEventBorderDark = (): string => sourcePalette.neutral[60];
+
+const summaryEventBulletLight = ({ theme }: ArticleFormat): string => {
+	switch (theme) {
+		case Pillar.News:
+			return sourcePalette.news[400];
+		case Pillar.Sport:
+			return sourcePalette.sport[400];
+		case Pillar.Lifestyle:
+			return sourcePalette.lifestyle[400];
+		case Pillar.Culture:
+			return sourcePalette.culture[400];
+		case Pillar.Opinion:
+			return sourcePalette.opinion[400];
+		case ArticleSpecial.Labs:
+			return sourcePalette.labs[400];
+		case ArticleSpecial.SpecialReport:
+			return sourcePalette.specialReport[400];
+		case ArticleSpecial.SpecialReportAlt:
+			return sourcePalette.news[400];
+	}
+};
+const summaryEventBulletDark = ({ theme }: ArticleFormat): string => {
+	switch (theme) {
+		case Pillar.News:
+			return sourcePalette.news[500];
+		case Pillar.Sport:
+			return sourcePalette.sport[500];
+		case Pillar.Lifestyle:
+			return sourcePalette.lifestyle[500];
+		case Pillar.Culture:
+			return sourcePalette.culture[500];
+		case Pillar.Opinion:
+			return sourcePalette.opinion[500];
+		case ArticleSpecial.Labs:
+			return sourcePalette.labs[400];
+		case ArticleSpecial.SpecialReport:
+			return sourcePalette.specialReport[500];
+		case ArticleSpecial.SpecialReportAlt:
+			return sourcePalette.news[500];
+	}
+};
+const summaryEventBulletHoverLight = ({ theme }: ArticleFormat): string => {
+	switch (theme) {
+		case Pillar.News:
+			return sourcePalette.news[200];
+		case Pillar.Sport:
+			return sourcePalette.sport[200];
+		case Pillar.Lifestyle:
+			return sourcePalette.lifestyle[200];
+		case Pillar.Culture:
+			return sourcePalette.culture[200];
+		case Pillar.Opinion:
+			return sourcePalette.opinion[200];
+		case ArticleSpecial.Labs:
+			return sourcePalette.labs[200];
+		case ArticleSpecial.SpecialReport:
+			return sourcePalette.specialReport[200];
+		case ArticleSpecial.SpecialReportAlt:
+			return sourcePalette.news[200];
+	}
+};
+const summaryEventBulletHoverDark = ({ theme }: ArticleFormat): string => {
+	switch (theme) {
+		case Pillar.News:
+			return sourcePalette.news[550];
+		case Pillar.Sport:
+			return sourcePalette.sport[600];
+		case Pillar.Lifestyle:
+			return sourcePalette.lifestyle[600];
+		case Pillar.Culture:
+			return sourcePalette.culture[600];
+		case Pillar.Opinion:
+			return sourcePalette.opinion[550];
+		case ArticleSpecial.Labs:
+			return sourcePalette.labs[400];
+		case ArticleSpecial.SpecialReport:
+			return sourcePalette.specialReport[400];
+		case ArticleSpecial.SpecialReportAlt:
+			return sourcePalette.news[600];
+	}
+};
 // ----- Palette ----- //
 
 /**
@@ -976,6 +1115,42 @@ const paletteColours = {
 	'--caption-overlay-text': {
 		light: captionOverlayText,
 		dark: captionOverlayText,
+	},
+	'--key-event-bullet': {
+		light: keyEventBulletLight,
+		dark: keyEventBulletDark,
+	},
+	'--key-event-bullet-hover': {
+		light: keyEventBulletHoverLight,
+		dark: keyEventBulletHoverDark,
+	},
+	'--key-event-time': {
+		light: keyEventTimeLight,
+		dark: keyEventTimeDark,
+	},
+	'--key-event-text': {
+		light: keyEventTextLight,
+		dark: keyEventTextDark,
+	},
+	'--key-event-background': {
+		light: keyEventBackgroundLight,
+		dark: keyEventBackgroundDark,
+	},
+	'--key-event-background-desktop': {
+		light: keyEventBackgroundDesktopLight,
+		dark: keyEventBackgroundDark,
+	},
+	'--key-event-border': {
+		light: keyEventBorderLight,
+		dark: keyEventBorderDark,
+	},
+	'--summary-event-bullet': {
+		light: summaryEventBulletLight,
+		dark: summaryEventBulletDark,
+	},
+	'--summary-event-bullet-hover': {
+		light: summaryEventBulletHoverLight,
+		dark: summaryEventBulletHoverDark,
 	},
 } satisfies PaletteColours;
 

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -807,8 +807,8 @@ const keyEventBulletDark = (): string => sourcePalette.neutral[60];
 const keyEventBulletHoverLight = (): string => sourcePalette.neutral[0];
 const keyEventBulletHoverDark = (): string => sourcePalette.neutral[86];
 
-const keyEventTimeLight = (): string => sourcePalette.neutral[7];
-const keyEventTimeDark = (): string => sourcePalette.neutral[86];
+const keyEventTitleLight = (): string => sourcePalette.neutral[7];
+const keyEventTitleDark = (): string => sourcePalette.neutral[86];
 
 const keyEventTextLight = ({ theme }: ArticleFormat): string => {
 	switch (theme) {
@@ -852,12 +852,19 @@ const keyEventTextDark = ({ theme }: ArticleFormat): string => {
 };
 
 const keyEventBackgroundLight = (): string => sourcePalette.neutral[97];
-const keyEventBackgroundDark = (): string => sourcePalette.neutral[7];
+const keyEventBackgroundDark = (): string => sourcePalette.neutral[10];
 
 const keyEventBackgroundDesktopLight = (): string => sourcePalette.neutral[93];
+const keyEventBackgroundDesktopDark = (): string => sourcePalette.neutral[7];
 
 const keyEventBorderLight = (): string => sourcePalette.neutral[46];
 const keyEventBorderDark = (): string => sourcePalette.neutral[60];
+const keyEventButtonLight = (): string => sourcePalette.neutral[7];
+const keyEventButtonDark = (): string => sourcePalette.neutral[86];
+const keyEventButtonHoverLight = (): string => sourcePalette.brandAlt[300];
+const keyEventButtonHoverDark = (): string => sourcePalette.neutral[60];
+const keyEventButtonFillLight = (): string => sourcePalette.neutral[100];
+const keyEventButtonFillDark = (): string => sourcePalette.neutral[7];
 
 const summaryEventBulletLight = ({ theme }: ArticleFormat): string => {
 	switch (theme) {
@@ -1124,9 +1131,9 @@ const paletteColours = {
 		light: keyEventBulletHoverLight,
 		dark: keyEventBulletHoverDark,
 	},
-	'--key-event-time': {
-		light: keyEventTimeLight,
-		dark: keyEventTimeDark,
+	'--key-event-title': {
+		light: keyEventTitleLight,
+		dark: keyEventTitleDark,
 	},
 	'--key-event-text': {
 		light: keyEventTextLight,
@@ -1138,11 +1145,23 @@ const paletteColours = {
 	},
 	'--key-event-background-desktop': {
 		light: keyEventBackgroundDesktopLight,
-		dark: keyEventBackgroundDark,
+		dark: keyEventBackgroundDesktopDark,
 	},
 	'--key-event-border': {
 		light: keyEventBorderLight,
 		dark: keyEventBorderDark,
+	},
+	'--key-event-button': {
+		light: keyEventButtonLight,
+		dark: keyEventButtonDark,
+	},
+	'--key-event-button-hover': {
+		light: keyEventButtonHoverLight,
+		dark: keyEventButtonHoverDark,
+	},
+	'--key-event-button-fill': {
+		light: keyEventButtonFillLight,
+		dark: keyEventButtonFillDark,
 	},
 	'--summary-event-bullet': {
 		light: summaryEventBulletLight,

--- a/dotcom-rendering/src/types/palette.ts
+++ b/dotcom-rendering/src/types/palette.ts
@@ -45,9 +45,6 @@ export type Palette = {
 		numberedTitle: Colour;
 		numberedPosition: Colour;
 		cricketScoreboardLink: Colour;
-		keyEvent: Colour;
-		keyEventFromDesktop: Colour;
-		keyEventTime: Colour;
 		filterButton: Colour;
 		filterButtonHover: Colour;
 		filterButtonActive: Colour;
@@ -83,10 +80,6 @@ export type Palette = {
 		analysisUnderline: Colour;
 		matchStats: Colour;
 		ageWarning: Colour;
-		keyEventBullet: Colour;
-		summaryEventBullet: Colour;
-		keyEvent: Colour;
-		keyEventFromDesktop: Colour;
 		filterButton: Colour;
 		filterButtonHover: Colour;
 		filterButtonActive: Colour;
@@ -130,7 +123,6 @@ export type Palette = {
 		cricketScoreboardTop: Colour;
 		cricketScoreboardDivider: Colour;
 		cardSupporting: Colour;
-		keyEvent: Colour;
 		filterButton: Colour;
 		secondary: Colour;
 		pagination: Colour;
@@ -141,9 +133,6 @@ export type Palette = {
 	hover: {
 		headlineByline: Colour;
 		standfirstLink: Colour;
-		keyEventLink: Colour;
-		keyEventBullet: Colour;
-		summaryEventBullet: Colour;
 		pagination: Colour;
 	};
 	discussionGeneric: Colour;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Updates the key events card and key events carousel to expect dark mode colours. It removes unused colours from the pre-existing palette.

## Why?
This is part of a wider body of work to implement dark mode for app articles.

## Screenshots

### Key Events Card
![Screenshot 2023-11-08 at 09 50 20](https://github.com/guardian/dotcom-rendering/assets/20416599/9917ac88-d21e-4544-8838-1e830f492dd1)

### Key Events Carousel
![Screenshot 2023-11-08 at 09 55 26](https://github.com/guardian/dotcom-rendering/assets/20416599/b9ac6672-1ce2-4123-9ddb-e65fa928e2b1)

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
