### PR TITLE
Simplify CSS styles and Add Chromatic tests to Nav with PageSkins 

### DIFF
--- a/dotcom-rendering/src/components/Nav/ExpandedMenu/Column.tsx
+++ b/dotcom-rendering/src/components/Nav/ExpandedMenu/Column.tsx
@@ -191,21 +191,14 @@ const columnStyle = css`
 			width: 123px;
 		}
 	}
+`;
+
+const columnStyleFromLeftCol = css`
 	${from.leftCol} {
 		width: 160px;
 
 		:first-of-type {
 			width: 150px;
-		}
-	}
-`;
-
-const columnStyleWithPageSkin = css`
-	${from.leftCol} {
-		width: 134px;
-
-		:first-of-type {
-			width: 123px;
 		}
 	}
 `;
@@ -232,7 +225,7 @@ export const Column = ({
 		<li
 			css={[
 				columnStyle,
-				hasPageSkin && columnStyleWithPageSkin,
+				!hasPageSkin && columnStyleFromLeftCol,
 				pillarDivider,
 			]}
 			role="none"

--- a/dotcom-rendering/src/components/Nav/ExpandedMenu/Columns.tsx
+++ b/dotcom-rendering/src/components/Nav/ExpandedMenu/Columns.tsx
@@ -36,17 +36,14 @@ const columnsStyle = (isImmersive: boolean) => css`
 		border-left: ${isImmersive ? 'none' : `1px solid ${brand[600]}`};
 		border-right: ${isImmersive ? 'none' : `1px solid ${brand[600]}`};
 	}
+`;
+
+const columnsStyleFromLeftCol = css`
 	${from.leftCol} {
 		max-width: 1140px;
 	}
 	${from.wide} {
 		max-width: 1300px;
-	}
-`;
-
-const columnsStyleWithPageSkin = css`
-	${from.leftCol} {
-		max-width: 980px;
 	}
 `;
 
@@ -80,17 +77,14 @@ const brandExtensionList = css`
 	display: flex;
 	flex-direction: column;
 	padding-bottom: 0;
+`;
+
+const brandExtensionListFromLeftCol = css`
 	${from.leftCol} {
 		width: 140px;
 	}
 	${from.wide} {
 		width: 300px;
-	}
-`;
-
-const brandExtenstionListWithPageSkin = css`
-	${from.leftCol} {
-		width: 131px;
 	}
 `;
 
@@ -121,9 +115,6 @@ const brandExtensionLink = css`
 	${from.desktop} {
 		padding: 6px 0;
 	}
-	${from.wide} {
-		font-size: 24px;
-	}
 	:hover,
 	:focus {
 		color: ${brandAlt[400]};
@@ -133,9 +124,9 @@ const brandExtensionLink = css`
 	}
 `;
 
-const brandExtensionLinkWithPageSkin = css`
+const brandExtensionLinkFromLeftCol = css`
 	${from.wide} {
-		font-size: 1.25rem;
+		font-size: 24px;
 	}
 `;
 
@@ -244,7 +235,7 @@ export const Columns = ({
 		<ul
 			css={[
 				columnsStyle(isImmersive),
-				hasPageSkin && columnsStyleWithPageSkin,
+				!hasPageSkin && columnsStyleFromLeftCol,
 			]}
 			role="menubar"
 			data-cy="nav-menu-columns"
@@ -347,7 +338,7 @@ export const Columns = ({
 				<ul
 					css={[
 						brandExtensionList,
-						hasPageSkin && brandExtenstionListWithPageSkin,
+						!hasPageSkin && brandExtensionListFromLeftCol,
 					]}
 					role="menu"
 				>
@@ -360,8 +351,8 @@ export const Columns = ({
 								className="selectableMenuItem"
 								css={[
 									brandExtensionLink,
-									hasPageSkin &&
-										brandExtensionLinkWithPageSkin,
+									!hasPageSkin &&
+										brandExtensionLinkFromLeftCol,
 								]}
 								href={brandExtension.url}
 								key={brandExtension.title}

--- a/dotcom-rendering/src/components/Nav/ExpandedMenu/MoreColumn.tsx
+++ b/dotcom-rendering/src/components/Nav/ExpandedMenu/MoreColumn.tsx
@@ -49,15 +49,11 @@ const columnStyle = css`
 			content: none;
 		}
 	}
-
-	${from.leftCol} {
-		width: 160px;
-	}
 `;
 
-const columnStyleWithPageSkin = css`
+const columnStyleFromLeftCol = css`
 	${from.leftCol} {
-		width: 140px;
+		width: 160px;
 	}
 `;
 
@@ -152,7 +148,6 @@ const columnLinkTitle = css`
 		font-size: 16px;
 		padding: 6px 0;
 	}
-
 	:hover,
 	:focus {
 		color: ${brandAlt[400]};
@@ -209,7 +204,7 @@ export const MoreColumn = ({
 			<li
 				css={[
 					columnStyle,
-					hasPageSkin && columnStyleWithPageSkin,
+					!hasPageSkin && columnStyleFromLeftCol,
 					pillarDivider,
 					pillarDividerExtended,
 				]}
@@ -247,7 +242,7 @@ export const MoreColumn = ({
 			{/** Social buttons hidden from menus from desktop */}
 			<Hide from="desktop">
 				<li
-					css={[columnStyle, hasPageSkin && columnStyleWithPageSkin]}
+					css={[columnStyle, !hasPageSkin && columnStyleFromLeftCol]}
 					role="none"
 				>
 					<ul css={[columnLinks]} role="menu">

--- a/dotcom-rendering/src/components/Nav/Nav.stories.tsx
+++ b/dotcom-rendering/src/components/Nav/Nav.stories.tsx
@@ -132,3 +132,39 @@ ExpandedMenuStory.play = async ({
 	await userEvent.click(canvas.getByLabelText(/More/));
 };
 ExpandedMenuStory.storyName = 'ExpandedMenu';
+
+export const ExpandedMenuWithPageSkinStory = () => {
+	return (
+		<Section
+			fullWidth={true}
+			showSideBorders={true}
+			borderColour={brandBorder.primary}
+			showTopBorder={false}
+			padSides={false}
+			backgroundColour={brandBackground.primary}
+			hasPageSkin={true}
+			hasPageSkinContentSelfConstrain={true}
+		>
+			<Nav
+				selectedPillar={Pillar.News}
+				displayRoundel={false}
+				isImmersive={false}
+				nav={nav}
+				subscribeUrl=""
+				editionId="UK"
+				headerTopBarSwitch={false}
+				hasPageSkin={true}
+			/>
+		</Section>
+	);
+};
+
+ExpandedMenuWithPageSkinStory.play = async ({
+	canvasElement,
+}: {
+	canvasElement: HTMLElement;
+}) => {
+	const canvas = within(canvasElement);
+	await userEvent.click(canvas.getByLabelText(/More/));
+};
+ExpandedMenuWithPageSkinStory.storyName = 'ExpandedMenu With PageSkin';

--- a/dotcom-rendering/src/components/Pillars.tsx
+++ b/dotcom-rendering/src/components/Pillars.tsx
@@ -44,9 +44,6 @@ const pillarsStyles = (isImmersive: boolean) => css`
 		${from.desktop} {
 			width: ${preLeftColPillarWidth}px;
 		}
-		${from.leftCol} {
-			width: ${pillarWidth}px;
-		}
 		/* https://developer.mozilla.org/en-US/docs/Web/CSS/list-style#accessibility_concerns */
 		/* Needs double escape char: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#es2018_revision_of_illegal_escape_sequences */
 		&::before {
@@ -75,22 +72,10 @@ const pillarsStyles = (isImmersive: boolean) => css`
 	}
 `;
 
-const pillarsStylesWithPageSkin = css`
+const pillarsStylesFromLeftCol = css`
 	li {
-		float: left;
-		display: block;
-		position: relative;
-		width: ${preDesktopPillarWidth};
-		${from.desktop} {
-			width: ${preLeftColPillarWidth}px;
-		}
-		/* https://developer.mozilla.org/en-US/docs/Web/CSS/list-style#accessibility_concerns */
-		/* Needs double escape char: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#es2018_revision_of_illegal_escape_sequences */
-		&::before {
-			content: '\\200B'; /* Zero width space */
-			display: block;
-			height: 0;
-			width: 0;
+		${from.leftCol} {
+			width: ${pillarWidth}px;
 		}
 	}
 `;
@@ -130,10 +115,6 @@ const pillarStyle = css`
 		${from.desktop} {
 			width: ${preLeftColFirstPillarWidth}px;
 		}
-
-		${from.leftCol} {
-			width: ${firstPillarWidth}px;
-		}
 		a {
 			padding-left: 20px;
 		}
@@ -146,17 +127,10 @@ const pillarStyle = css`
 	}
 `;
 
-const pillarStyleWithPageSkin = css`
+const pillarStyleFromLeftCol = css`
 	:first-of-type {
-		margin-left: -20px;
-		width: ${preDesktopPillarWidth};
-
-		${from.desktop} {
-			width: ${preLeftColFirstPillarWidth}px;
-		}
-
-		a {
-			padding-left: 20px;
+		${from.leftCol} {
+			width: ${firstPillarWidth}px;
 		}
 	}
 `;
@@ -226,11 +200,6 @@ const linkStyle = (isImmersive: boolean) => css`
 		height: ${isImmersive ? '48px' : '42px'};
 	}
 
-	${from.wide} {
-		padding-top: ${isImmersive ? '10px' : '7px'};
-		font-size: 24px;
-	}
-
 	:focus:after {
 		transform: translateY(4px);
 	}
@@ -242,10 +211,10 @@ const linkStyle = (isImmersive: boolean) => css`
 	}
 `;
 
-const linkStyleWithPageSkin = (isImmersive: boolean) => css`
+const linkStyleFromWide = (isImmersive: boolean) => css`
 	${from.wide} {
-		padding-top: ${isImmersive ? '9px' : '5px'};
-		font-size: 22px;
+		padding-top: ${isImmersive ? '10px' : '7px'};
+		font-size: 24px;
 	}
 `;
 
@@ -303,7 +272,7 @@ export const Pillars = ({
 		data-testid="pillar-list"
 		css={[
 			pillarsStyles(isImmersive),
-			hasPageSkin && pillarsStylesWithPageSkin,
+			!hasPageSkin && pillarsStylesFromLeftCol,
 		]}
 	>
 		{pillars.map((p, i) => {
@@ -313,12 +282,12 @@ export const Pillars = ({
 			return (
 				<li
 					key={p.title}
-					css={[pillarStyle, hasPageSkin && pillarStyleWithPageSkin]}
+					css={[pillarStyle, !hasPageSkin && pillarStyleFromLeftCol]}
 				>
 					<a
 						css={[
 							linkStyle(isImmersive),
-							hasPageSkin && linkStyleWithPageSkin(isImmersive),
+							!hasPageSkin && linkStyleFromWide(isImmersive),
 							pillarUnderline(
 								decidePalette({
 									display: ArticleDisplay.Standard,


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

This PR a follow-up work to simplify the CSS and avoid overriding rules to prevent DCR from styles complexity. There shouldn't be any changes with PROD UI as it is all refactoring. Check #9390 for more details.

@arelra suggested to have Chromatic tests to Nav/ExpandedMenu with PageSkins to stop having broken Nav layout. You can see that in Storybook under `Nav` and the component name `ExpandedMenu with PageSkin`

## Why?

Remove CSS complexity and prevent broken Nav UI with PageSkins.



[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
