### PR TITLE
Add headline container overrides stories

### DIFF
--- a/dotcom-rendering/src/components/CardHeadline.stories.tsx
+++ b/dotcom-rendering/src/components/CardHeadline.stories.tsx
@@ -5,6 +5,9 @@ import {
 	Pillar,
 } from '@guardian/libs';
 import { breakpoints, specialReport } from '@guardian/source-foundations';
+import type { StoryObj } from '@storybook/react';
+import { splitTheme } from '../../.storybook/decorators/splitThemeDecorator';
+import type { DCRContainerPalette } from '../types/front';
 import { CardHeadline } from './CardHeadline';
 import { Section } from './Section';
 
@@ -438,3 +441,47 @@ export const Byline = () => (
 	</>
 );
 Byline.storyName = 'With byline';
+
+const containerPalettes = [
+	'EventPalette',
+	'SombreAltPalette',
+	'EventAltPalette',
+	'InvestigationPalette',
+	'LongRunningAltPalette',
+	'LongRunningPalette',
+	'SombrePalette',
+	'BreakingPalette',
+	'SpecialReportAltPalette',
+	'Branded',
+	'MediaPalette',
+	'PodcastPalette',
+] as const satisfies readonly DCRContainerPalette[];
+export const WithContainerOverrides: StoryObj = ({
+	format,
+}: {
+	format: ArticleFormat;
+}) => (
+	<>
+		{containerPalettes.map((containerPalette) => (
+			<Section
+				key={containerPalette}
+				fullWidth={true}
+				showSideBorders={false}
+				containerPalette={containerPalette}
+			>
+				<CardHeadline
+					headlineText={`This is a ${
+						Pillar[format.theme] ??
+						ArticleSpecial[format.theme] ??
+						'Unknown'
+					} headline`}
+					containerPalette={containerPalette}
+					format={format}
+					byline={`inside a ${containerPalette} container`}
+					showByline={true}
+				/>
+			</Section>
+		))}
+	</>
+);
+WithContainerOverrides.decorators = [splitTheme()];


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Add a visual story for container overrides.

## Why?

Demonstrates that there are no chromatic diffs in #9441

## Screenshots

<img width="1301" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/76776/57b00f0c-043f-4ba6-9aab-35eaab8e8b9c">
