### PR TITLE
Be liberal in what `splitTheme` accept

### DIFF
--- a/dotcom-rendering/.storybook/decorators/splitThemeDecorator.tsx
+++ b/dotcom-rendering/.storybook/decorators/splitThemeDecorator.tsx
@@ -131,7 +131,10 @@ const defaultFormats = [
  */
 export const splitTheme =
 	(
-		formats: readonly [ArticleFormat, ...ArticleFormat[]] = defaultFormats,
+		formats: [ArticleFormat, ...ArticleFormat[]] = [
+			defaultFormats[0],
+			...defaultFormats.slice(1),
+		],
 		{ orientation = 'horizontal' }: Orientation = {},
 	): Decorator =>
 	(Story, context) =>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Do not require the formats to be read-only.

## Why?

It’s causing issues for consumers.

Follow-up on #9430 