### PR TITLE
Log failure (and success) in callout forms

### DIFF
--- a/dotcom-rendering/src/components/Callout/Form.tsx
+++ b/dotcom-rendering/src/components/Callout/Form.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import { log } from '@guardian/libs';
 import {
 	headline,
 	palette,
@@ -9,7 +10,6 @@ import {
 import { Button, SvgTickRound } from '@guardian/source-react-components';
 import { ErrorSummary } from '@guardian/source-react-components-development-kitchen';
 import { useState } from 'react';
-import { logger } from '../../server/lib/logging';
 import type { CampaignFieldType } from '../../types/content';
 import { CalloutTermsAndConditions } from './CalloutComponents';
 import { FormField } from './FormField';
@@ -167,10 +167,11 @@ export const Form = ({
 		})
 			.then((resp) => {
 				if (resp.status === 201) {
-					logger.info('Submission of callout form succeeded');
+					log('dotcom', 'Submission of callout form succeeded');
 					setSubmissionSuccess(true);
 				} else {
-					logger.error(
+					log(
+						'dotcom',
 						`Submission of callout form failed: ${JSON.stringify(
 							resp.body,
 						)}`,

--- a/dotcom-rendering/src/components/Callout/Form.tsx
+++ b/dotcom-rendering/src/components/Callout/Form.tsx
@@ -9,6 +9,7 @@ import {
 import { Button, SvgTickRound } from '@guardian/source-react-components';
 import { ErrorSummary } from '@guardian/source-react-components-development-kitchen';
 import { useState } from 'react';
+import { logger } from '../../server/lib/logging';
 import type { CampaignFieldType } from '../../types/content';
 import { CalloutTermsAndConditions } from './CalloutComponents';
 import { FormField } from './FormField';
@@ -166,8 +167,14 @@ export const Form = ({
 		})
 			.then((resp) => {
 				if (resp.status === 201) {
+					logger.info('Submission of callout form succeeded');
 					setSubmissionSuccess(true);
 				} else {
+					logger.error(
+						`Submission of callout form failed: ${JSON.stringify(
+							resp.body,
+						)}`,
+					);
 					setNetworkError(
 						'Sorry, there was a problem submitting your form. Please try again later.',
 					);


### PR DESCRIPTION
We will only keep logging for failure. Success is only for testing.

<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
