### PR TITLE
Rename ads in merch test

### DIFF
--- a/dotcom-rendering/cypress/fixtures/manual/standard-article.js
+++ b/dotcom-rendering/cypress/fixtures/manual/standard-article.js
@@ -1388,7 +1388,7 @@ export const Standard = {
 			verticalVideo: false,
 			abPublicGoodTest: false,
 			registerWithPhone: false,
-			abBillboardsInMerchHigh: true,
+			abAdsInMerch: true,
 			keyEventsCarousel: true,
 			targeting: true,
 			remoteHeader: true,

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -61,7 +61,7 @@
 		"@guardian/bridget": "2.3.0",
 		"@guardian/browserslist-config": "5.0.0",
 		"@guardian/cdk": "50.10.6",
-		"@guardian/commercial": "11.19.0",
+		"@guardian/commercial": "11.20.0",
 		"@guardian/consent-management-platform": "13.7.1",
 		"@guardian/core-web-vitals": "5.1.0",
 		"@guardian/eslint-config": "4.1.0",

--- a/dotcom-rendering/playwright/fixtures/manual/standard-article.js
+++ b/dotcom-rendering/playwright/fixtures/manual/standard-article.js
@@ -1388,7 +1388,7 @@ export const Standard = {
 			verticalVideo: false,
 			abPublicGoodTest: false,
 			registerWithPhone: false,
-			abBillboardsInMerchHigh: true,
+			abAdsInMerch: true,
 			keyEventsCarousel: true,
 			targeting: true,
 			remoteHeader: true,

--- a/dotcom-rendering/scripts/perf/k6/article-nier-automata.json
+++ b/dotcom-rendering/scripts/perf/k6/article-nier-automata.json
@@ -1562,7 +1562,7 @@
 			"remarketing": true,
 			"verticalVideo": false,
 			"registerWithPhone": false,
-			"abBillboardsInMerchHigh": true,
+			"abAdsInMerch": true,
 			"keyEventsCarousel": true,
 			"targeting": true,
 			"remoteHeader": true,

--- a/dotcom-rendering/src/components/Metrics.importable.tsx
+++ b/dotcom-rendering/src/components/Metrics.importable.tsx
@@ -10,7 +10,7 @@ import {
 import { getCookie, isString, isUndefined } from '@guardian/libs';
 import { useCallback, useEffect, useState } from 'react';
 import { getOphan } from '../client/ophan/ophan';
-import { billboardsInMerchHigh } from '../experiments/tests/billboards-in-merch-high';
+import { adsInMerch } from '../experiments/tests/ads-in-merch-high';
 import { integrateIma } from '../experiments/tests/integrate-ima';
 import { useAB } from '../lib/useAB';
 import { useAdBlockInUse } from '../lib/useAdBlockInUse';
@@ -31,7 +31,7 @@ const willRecordCoreWebVitals = Math.random() < sampling;
 const clientSideTestsToForceMetrics: ABTest[] = [
 	/* keep array multi-line */
 	integrateIma,
-	billboardsInMerchHigh,
+	adsInMerch,
 ];
 
 const useBrowserId = () => {

--- a/dotcom-rendering/src/experiments/ab-tests.ts
+++ b/dotcom-rendering/src/experiments/ab-tests.ts
@@ -1,6 +1,6 @@
 import type { ABTest } from '@guardian/ab-core';
 import { abTestTest } from './tests/ab-test-test';
-import { billboardsInMerchHigh } from './tests/billboards-in-merch-high';
+import { adsInMerch } from './tests/ads-in-merch-high';
 import { consentlessAds } from './tests/consentless-ads';
 import { elementsManager } from './tests/elements-manager';
 import { integrateIma } from './tests/integrate-ima';
@@ -15,6 +15,6 @@ export const tests: ABTest[] = [
 	signInGateMainControl,
 	consentlessAds,
 	integrateIma,
-	billboardsInMerchHigh,
+	adsInMerch,
 	elementsManager,
 ];

--- a/dotcom-rendering/src/experiments/tests/ads-in-merch-high.ts
+++ b/dotcom-rendering/src/experiments/tests/ads-in-merch-high.ts
@@ -1,7 +1,7 @@
 import type { ABTest } from '@guardian/ab-core';
 
-export const billboardsInMerchHigh: ABTest = {
-	id: 'BillboardsInMerchHigh',
+export const adsInMerch: ABTest = {
+	id: 'AdsInMerch',
 	author: '@commercial-dev',
 	start: '2022-12-07',
 	expiry: '2023-11-30',
@@ -10,9 +10,9 @@ export const billboardsInMerchHigh: ABTest = {
 	audienceOffset: 0 / 100,
 	audienceCriteria: 'Opt in only',
 	successMeasure:
-		'Test the commercial impact of showing billboard adverts in merchandising-high slots',
+		'Test the commercial impact of showing adverts in merchandising-high and merchandising slots',
 	description:
-		'Show billboard adverts in merchandising-high slots to browsers in the variant',
+		'Show adverts in merchandising-high and merchandising slots to browsers in the variant',
 	variants: [
 		{
 			id: 'control',

--- a/yarn.lock
+++ b/yarn.lock
@@ -822,7 +822,7 @@
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.22.9.tgz#71cdb00a1ce3a329ce4cbec3a44f9fef35669730"
   integrity sha512-5UamI7xkUcJ3i9qVDS+KFDEK8/7oJ55/sJMB1Ge7IEapr7KfdfV/HErR+koZwOfd+SgtFKOKRhRakdg++DcJpQ==
 
-"@babel/core@7.23.2", "@babel/core@^7.16.7", "@babel/core@^7.22.0":
+"@babel/core@7.23.2", "@babel/core@^7.22.0":
   version "7.23.2"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.23.2.tgz#ed10df0d580fff67c5f3ee70fd22e2e4c90a9f94"
   integrity sha512-n7s51eWdaWZ3vGT2tD4T7J6eJs3QoBXydv7vkUM06Bf1cbVD2Kc2UrkzhiQwobfV7NwOnQXYL7UBJ5VPU+RGoQ==
@@ -885,6 +885,27 @@
     json5 "^2.2.2"
     semver "^6.3.1"
 
+"@babel/core@^7.23.2":
+  version "7.23.3"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.23.3.tgz#5ec09c8803b91f51cc887dedc2654a35852849c9"
+  integrity sha512-Jg+msLuNuCJDyBvFv5+OKOUjWMZgd85bKjbICd3zWrKAo+bJ49HJufi7CQE0q0uR8NGyO6xkCACScNqyjHSZew==
+  dependencies:
+    "@ampproject/remapping" "^2.2.0"
+    "@babel/code-frame" "^7.22.13"
+    "@babel/generator" "^7.23.3"
+    "@babel/helper-compilation-targets" "^7.22.15"
+    "@babel/helper-module-transforms" "^7.23.3"
+    "@babel/helpers" "^7.23.2"
+    "@babel/parser" "^7.23.3"
+    "@babel/template" "^7.22.15"
+    "@babel/traverse" "^7.23.3"
+    "@babel/types" "^7.23.3"
+    convert-source-map "^2.0.0"
+    debug "^4.1.0"
+    gensync "^1.0.0-beta.2"
+    json5 "^2.2.3"
+    semver "^6.3.1"
+
 "@babel/generator@^7.12.11", "@babel/generator@^7.22.5", "@babel/generator@^7.7.2":
   version "7.22.5"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.22.5.tgz#1e7bf768688acfb05cf30b2369ef855e82d984f7"
@@ -911,6 +932,16 @@
   integrity sha512-lN85QRR+5IbYrMWM6Y4pE/noaQtg4pNiqeNGX60eqOfo6gtEj6uw/JagelB8vVztSd7R6M5n1+PQkDbHbBRU4g==
   dependencies:
     "@babel/types" "^7.23.0"
+    "@jridgewell/gen-mapping" "^0.3.2"
+    "@jridgewell/trace-mapping" "^0.3.17"
+    jsesc "^2.5.1"
+
+"@babel/generator@^7.23.3":
+  version "7.23.3"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.23.3.tgz#86e6e83d95903fbe7613f448613b8b319f330a8e"
+  integrity sha512-keeZWAV4LU3tW0qRi19HRpabC/ilM0HRBBzf9/k8FFiG4KVpiv0FIy4hHfLfFQZNhziCTPTmd59zoyv6DNISzg==
+  dependencies:
+    "@babel/types" "^7.23.3"
     "@jridgewell/gen-mapping" "^0.3.2"
     "@jridgewell/trace-mapping" "^0.3.17"
     jsesc "^2.5.1"
@@ -1154,6 +1185,17 @@
     "@babel/helper-split-export-declaration" "^7.22.6"
     "@babel/helper-validator-identifier" "^7.22.20"
 
+"@babel/helper-module-transforms@^7.23.3":
+  version "7.23.3"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.23.3.tgz#d7d12c3c5d30af5b3c0fcab2a6d5217773e2d0f1"
+  integrity sha512-7bBs4ED9OmswdfDzpz4MpWgSrV7FXlc3zIagvLFjS5H+Mk7Snr21vQ6QwrsoCGMfNC4e4LQPdoULEt4ykz0SRQ==
+  dependencies:
+    "@babel/helper-environment-visitor" "^7.22.20"
+    "@babel/helper-module-imports" "^7.22.15"
+    "@babel/helper-simple-access" "^7.22.5"
+    "@babel/helper-split-export-declaration" "^7.22.6"
+    "@babel/helper-validator-identifier" "^7.22.20"
+
 "@babel/helper-optimise-call-expression@^7.18.6", "@babel/helper-optimise-call-expression@^7.22.5":
   version "7.22.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.22.5.tgz#f21531a9ccbff644fdd156b4077c16ff0c3f609e"
@@ -1310,6 +1352,11 @@
   version "7.22.7"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.22.7.tgz#df8cf085ce92ddbdbf668a7f186ce848c9036cae"
   integrity sha512-7NF8pOkHP5o2vpmGgNGcfAeCvOYhGLyA3Z4eBQkT1RJlWu47n63bCs93QfJ2hIAFCil7L5P2IWhs1oToVgrL0Q==
+
+"@babel/parser@^7.23.3":
+  version "7.23.3"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.23.3.tgz#0ce0be31a4ca4f1884b5786057cadcb6c3be58f9"
+  integrity sha512-uVsWNvlVsIninV2prNz/3lHCb+5CJ+e+IUBfbjToAHODtfGYLfCFuY4AU7TskI+dAKk+njsPiBjq1gKTvZOBaw==
 
 "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@^7.22.5":
   version "7.22.5"
@@ -2457,6 +2504,22 @@
     debug "^4.1.0"
     globals "^11.1.0"
 
+"@babel/traverse@^7.23.3":
+  version "7.23.3"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.23.3.tgz#26ee5f252e725aa7aca3474aa5b324eaf7908b5b"
+  integrity sha512-+K0yF1/9yR0oHdE0StHuEj3uTPzwwbrLGfNOndVJVV2TqA5+j3oljJUb4nmB954FLGjNem976+B+eDuLIjesiQ==
+  dependencies:
+    "@babel/code-frame" "^7.22.13"
+    "@babel/generator" "^7.23.3"
+    "@babel/helper-environment-visitor" "^7.22.20"
+    "@babel/helper-function-name" "^7.23.0"
+    "@babel/helper-hoist-variables" "^7.22.5"
+    "@babel/helper-split-export-declaration" "^7.22.6"
+    "@babel/parser" "^7.23.3"
+    "@babel/types" "^7.23.3"
+    debug "^4.1.0"
+    globals "^11.1.0"
+
 "@babel/types@^7.0.0", "@babel/types@^7.2.0", "@babel/types@^7.20.7", "@babel/types@^7.22.5", "@babel/types@^7.3.3", "@babel/types@^7.4.4":
   version "7.22.5"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.22.5.tgz#cd93eeaab025880a3a47ec881f4b096a5b786fbe"
@@ -2470,6 +2533,15 @@
   version "7.23.0"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.23.0.tgz#8c1f020c9df0e737e4e247c0619f58c68458aaeb"
   integrity sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==
+  dependencies:
+    "@babel/helper-string-parser" "^7.22.5"
+    "@babel/helper-validator-identifier" "^7.22.20"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.23.3":
+  version "7.23.3"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.23.3.tgz#d5ea892c07f2ec371ac704420f4dcdb07b5f9598"
+  integrity sha512-OZnvoH2l8PK5eUvEcUyCt/sXgr/h+UWpVuBbOljwcrAgUl6lpchoQ++PHGyQy1AtYnVA6CEq3y5xeEI10brpXw==
   dependencies:
     "@babel/helper-string-parser" "^7.22.5"
     "@babel/helper-validator-identifier" "^7.22.20"
@@ -3192,17 +3264,17 @@
     read-pkg-up "7.0.1"
     yargs "^17.6.2"
 
-"@guardian/commercial@11.19.0":
-  version "11.19.0"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-11.19.0.tgz#dcb51eab371d2230bc5e0afde8d145a9af259dee"
-  integrity sha512-LbuX2dZM98QrUijaTPeI9wYARTD7o4xTCoX4EBeNnoJ4k5APOCl0OkxuBHlD06RCmNZ0ERMCQx7bse3rDFwaZQ==
+"@guardian/commercial@11.20.0":
+  version "11.20.0"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-11.20.0.tgz#6a07246c157ba8ef365e790b8417fe6042be54dc"
+  integrity sha512-kA6hHf9o9u57qteMSmk8t9Eu2xWb6IvrnnS1hVBhvMum6b1pmzVqHUxSb3oKqb7AFz7Jq7zjweOiITfJpr3BNg==
   dependencies:
     "@changesets/cli" "^2.26.2"
     "@octokit/core" "^4.0.5"
     fastdom "^1.0.11"
     lodash-es "^4.17.21"
     ophan-tracker-js "^2.0.1"
-    prebid.js guardian/prebid.js#0b4cccd
+    prebid.js guardian/prebid.js#0b4cccd55ab4e170b36bb944e9bdd2807a9da1c5
     process "^0.11.10"
     raven-js "^3.27.2"
     tslib "^2.5.3"
@@ -8615,15 +8687,10 @@ cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-crypto-js@4.2.0:
+crypto-js@4.2.0, crypto-js@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-4.2.0.tgz#4d931639ecdfd12ff80e8186dba6af2c2e856631"
   integrity sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==
-
-crypto-js@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-3.3.0.tgz#846dd1cce2f68aacfa156c8578f926a609b7976b"
-  integrity sha512-DIT51nX0dCfKltpRiXV+/TVZq+Qq2NgF4644+K7Ttnla7zEzqc+kjJyiB96BHNyUTBxyjzRcZYpUdZa+QAqi6Q==
 
 crypto-random-string@^2.0.0:
   version "2.0.0"
@@ -15131,11 +15198,11 @@ preact@10.15.1:
   resolved "https://registry.yarnpkg.com/preact/-/preact-10.15.1.tgz#a1de60c9fc0c79a522d969c65dcaddc5d994eede"
   integrity sha512-qs2ansoQEwzNiV5eAcRT1p1EC/dmEzaATVDJNiB3g2sRDWdA7b7MurXdJjB2+/WQktGWZwxvDrnuRFbWuIr64g==
 
-prebid.js@guardian/prebid.js#0b4cccd:
+"prebid.js@github:guardian/prebid.js#0b4cccd55ab4e170b36bb944e9bdd2807a9da1c5":
   version "7.54.5"
   resolved "https://codeload.github.com/guardian/prebid.js/tar.gz/0b4cccd55ab4e170b36bb944e9bdd2807a9da1c5"
   dependencies:
-    "@babel/core" "^7.16.7"
+    "@babel/core" "^7.23.2"
     "@babel/plugin-transform-runtime" "^7.18.9"
     "@babel/preset-env" "^7.16.8"
     "@babel/runtime" "^7.18.9"


### PR DESCRIPTION
## What does this change?

Updates names of tests, descriptions and files to reflect new scope.

## Why?

We will soon be extending the scope of this test, so that ads of Billboard and MPU sizes will be added to `merchandising` and `merchandising-high` slots.

## TODO

- [x] Bump `@guardian/commercial` once published

## Related PRs

- guardian/commercial#1135
- guardian/frontend#26682