### PR TITLE
Refactor `fillBlockquoteIcon` and `BlockquoteBlockComponent.stories`

### DIFF
--- a/dotcom-rendering/.storybook/decorators/splitThemeDecorator.tsx
+++ b/dotcom-rendering/.storybook/decorators/splitThemeDecorator.tsx
@@ -131,10 +131,7 @@ const defaultFormats = [
  */
 export const splitTheme =
 	(
-		formats: [ArticleFormat, ...ArticleFormat[]] = [
-			defaultFormats[0],
-			...defaultFormats.slice(1),
-		],
+		formats: ArticleFormat[] = [...defaultFormats],
 		{ orientation = 'horizontal' }: Orientation = {},
 	): Decorator =>
 	(Story, context) => (

--- a/dotcom-rendering/src/components/BlockquoteBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/components/BlockquoteBlockComponent.stories.tsx
@@ -44,145 +44,33 @@ Unquoted.decorators = [
 	]),
 ];
 
-export const News = () => {
+const themeVariations = [
+	Pillar.Sport,
+	Pillar.News,
+	Pillar.Culture,
+	Pillar.Opinion,
+	Pillar.Lifestyle,
+	ArticleSpecial.SpecialReport,
+	ArticleSpecial.SpecialReportAlt,
+	ArticleSpecial.Labs,
+];
+
+const allThemeStandardVariations = themeVariations.map((theme) => ({
+	design: ArticleDesign.Standard,
+	display: ArticleDisplay.Standard,
+	theme,
+}));
+
+export const StandardDesign = () => {
 	return (
 		<div>
-			<h1>News</h1>
 			<BlockquoteBlockComponent html={blockquoteHtml} quoted={true} />
 		</div>
 	);
 };
 
-News.storyName = 'News';
-News.decorators = [
-	splitTheme([
-		{
-			design: ArticleDesign.Standard,
-			display: ArticleDisplay.Standard,
-			theme: Pillar.News,
-		},
-	]),
-];
-
-export const Sport = () => {
-	return (
-		<div>
-			<h1>Sport</h1>
-			<BlockquoteBlockComponent html={blockquoteHtml} quoted={true} />
-		</div>
-	);
-};
-
-Sport.storyName = 'Sport';
-Sport.decorators = [
-	splitTheme([
-		{
-			design: ArticleDesign.Standard,
-			display: ArticleDisplay.Standard,
-			theme: Pillar.Sport,
-		},
-	]),
-];
-
-export const Culture = () => {
-	return (
-		<div>
-			<h1>Culture</h1>
-			<BlockquoteBlockComponent html={blockquoteHtml} quoted={true} />
-		</div>
-	);
-};
-
-Culture.storyName = 'Culture';
-Culture.decorators = [
-	splitTheme([
-		{
-			design: ArticleDesign.Standard,
-			display: ArticleDisplay.Standard,
-			theme: Pillar.Culture,
-		},
-	]),
-];
-
-export const Lifestyle = () => {
-	return (
-		<div>
-			<h1>Lifestyle</h1>
-			<BlockquoteBlockComponent html={blockquoteHtml} quoted={true} />
-		</div>
-	);
-};
-
-Lifestyle.storyName = 'Lifestyle';
-Lifestyle.decorators = [
-	splitTheme([
-		{
-			design: ArticleDesign.Standard,
-			display: ArticleDisplay.Standard,
-			theme: Pillar.Lifestyle,
-		},
-	]),
-];
-
-export const Opinion = () => {
-	return (
-		<div>
-			<h1>Opinion</h1>
-			<BlockquoteBlockComponent html={blockquoteHtml} quoted={true} />
-		</div>
-	);
-};
-
-Opinion.storyName = 'Opinion';
-Opinion.decorators = [
-	splitTheme([
-		{
-			design: ArticleDesign.Standard,
-			display: ArticleDisplay.Standard,
-			theme: Pillar.Opinion,
-		},
-	]),
-];
-
-export const SpecialReport = () => {
-	return (
-		<div>
-			<h1>SpecialReport</h1>
-			<BlockquoteBlockComponent html={blockquoteHtml} quoted={true} />
-		</div>
-	);
-};
-
-SpecialReport.storyName = 'SpecialReport';
-SpecialReport.decorators = [
-	splitTheme([
-		{
-			design: ArticleDesign.Standard,
-			display: ArticleDisplay.Standard,
-			theme: ArticleSpecial.SpecialReport,
-		},
-	]),
-];
-
-export const Labs = () => {
-	return (
-		<div>
-			<h1>Labs</h1>
-			<BlockquoteBlockComponent html={blockquoteHtml} quoted={true} />
-		</div>
-	);
-};
-
-Labs.storyName = 'Labs';
-Labs.decorators = [
-	splitTheme([
-		{
-			design: ArticleDesign.Standard,
-			display: ArticleDisplay.Standard,
-			theme: ArticleSpecial.Labs,
-		},
-	]),
-];
+StandardDesign.storyName = 'Standard Design - All theme variations';
+StandardDesign.decorators = [splitTheme(allThemeStandardVariations)];
 
 export const LiveBlogNews = () => {
 	return (
@@ -259,25 +147,6 @@ DeadBlogSport.decorators = [
 			design: ArticleDesign.DeadBlog,
 			display: ArticleDisplay.Standard,
 			theme: Pillar.Sport,
-		},
-	]),
-];
-
-export const SpecialReportAltStandard = () => {
-	return (
-		<div css={containerStyles}>
-			<h1>SpecialReportAlt Standard</h1>
-			<BlockquoteBlockComponent html={blockquoteHtml} quoted={true} />
-		</div>
-	);
-};
-SpecialReportAltStandard.storyName = 'SpecialReportAltStandard';
-SpecialReportAltStandard.decorators = [
-	splitTheme([
-		{
-			design: ArticleDesign.Standard,
-			display: ArticleDisplay.Standard,
-			theme: ArticleSpecial.SpecialReportAlt,
 		},
 	]),
 ];

--- a/dotcom-rendering/src/lib/decidePalette.ts
+++ b/dotcom-rendering/src/lib/decidePalette.ts
@@ -1150,40 +1150,69 @@ const fillShareIconGrayBackground = (format: ArticleFormat): string => {
 };
 
 const fillBlockquoteIcon = (format: ArticleFormat): string => {
-	if (format.design === ArticleDesign.Analysis) {
-		switch (format.theme) {
-			case Pillar.News:
-				return news[300];
-			default:
-				return pillarPalette[format.theme].main;
+	switch (format.design) {
+		case ArticleDesign.LiveBlog:
+		case ArticleDesign.DeadBlog: {
+			switch (format.theme) {
+				case Pillar.News:
+					return news[400];
+				case Pillar.Opinion:
+					return opinion[400];
+				case Pillar.Sport:
+					return sport[400];
+				case Pillar.Culture:
+					return culture[400];
+				case Pillar.Lifestyle:
+					return lifestyle[400];
+				case ArticleSpecial.SpecialReport:
+					return specialReport[400];
+				case ArticleSpecial.SpecialReportAlt:
+					return news[400];
+				case ArticleSpecial.Labs:
+					return labs[400];
+			}
+		}
+		case ArticleDesign.Analysis: {
+			switch (format.theme) {
+				case Pillar.News:
+					return news[300];
+				case Pillar.Opinion:
+					return opinion[300];
+				case Pillar.Sport:
+					return sport[400];
+				case Pillar.Culture:
+					return culture[400];
+				case Pillar.Lifestyle:
+					return lifestyle[400];
+				case ArticleSpecial.SpecialReport:
+					return specialReport[400];
+				case ArticleSpecial.SpecialReportAlt:
+					return palette.specialReportAlt[200];
+				case ArticleSpecial.Labs:
+					return labs[400];
+			}
+		}
+		default: {
+			switch (format.theme) {
+				case Pillar.News:
+					return news[400];
+				case Pillar.Opinion:
+					return opinion[300];
+				case Pillar.Sport:
+					return sport[400];
+				case Pillar.Culture:
+					return culture[400];
+				case Pillar.Lifestyle:
+					return lifestyle[400];
+				case ArticleSpecial.SpecialReport:
+					return specialReport[400];
+				case ArticleSpecial.SpecialReportAlt:
+					return palette.specialReportAlt[200];
+				case ArticleSpecial.Labs:
+					return labs[400];
+			}
 		}
 	}
-
-	if (
-		format.design === ArticleDesign.DeadBlog ||
-		format.design === ArticleDesign.LiveBlog
-	) {
-		switch (format.theme) {
-			case Pillar.News:
-				return news[400];
-			case Pillar.Opinion:
-				return opinion[400];
-			case Pillar.Sport:
-				return sport[400];
-			case Pillar.Culture:
-				return culture[400];
-			case Pillar.Lifestyle:
-				return lifestyle[400];
-			case ArticleSpecial.SpecialReport:
-				return specialReport[400];
-			case ArticleSpecial.SpecialReportAlt:
-				return news[400];
-			case ArticleSpecial.Labs:
-				return labs[400];
-		}
-	}
-
-	return pillarPalette[format.theme].main;
 };
 
 const fillTwitterHandleBelowDesktop = (format: ArticleFormat): string => {


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Refactors `fillBlockquoteIcon` method in `decidePalette` and `BlockquoteBlockComponent.stories.txs`

## Why?
It will make it easier to add the changes for this ticket:
* https://github.com/guardian/dotcom-rendering/issues/9300

in:
* https://github.com/guardian/dotcom-rendering/pull/9312

which is already a big PR. I did as much as refactoring as I could separately because Design would like the changes for pullquotes and blockquotes to be merged together. 


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
