### PR TITLE
Don't run chromatic on draft PRs

### DIFF
--- a/.github/workflows/ar-chromatic.yml
+++ b/.github/workflows/ar-chromatic.yml
@@ -10,6 +10,8 @@ jobs:
   chromatic:
     name: Chromatic
     runs-on: ubuntu-latest
+    # Don't run Chromatic on draft PRs unless `run_chromatic` label has been applied.
+    if: (contains(github.event.pull_request.labels.*.name, 'run_chromatic') || github.event.pull_request.draft == false)
     steps:
       - name: Checkout - On Pull Request
         uses: actions/checkout@v4
@@ -36,9 +38,7 @@ jobs:
 
       - name: Chromatic - Apps Rendering
         uses: chromaui/action@v1
-        # Run Chromatic only if `run_chromatic` label has been applied or we're
-        # pushing to `main`.
-        if: (contains(github.event.pull_request.labels.*.name, 'run_chromatic') ||  github.ref == 'refs/heads/main')
+
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN__APPS_RENDERING }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dcr-chromatic.yml
+++ b/.github/workflows/dcr-chromatic.yml
@@ -10,6 +10,8 @@ jobs:
   chromatic:
     name: Chromatic
     runs-on: ubuntu-latest
+    # Don't run Chromatic on draft PRs unless `run_chromatic` label has been applied.
+    if: (contains(github.event.pull_request.labels.*.name, 'run_chromatic') || github.event.pull_request.draft == false)
     steps:
       - name: Checkout - On Pull Request
         uses: actions/checkout@v4
@@ -36,9 +38,6 @@ jobs:
 
       - name: Chromatic - DCR
         uses: chromaui/action@v1
-        # Run Chromatic only if `run_chromatic` label has been applied or we're
-        # pushing to `main`.
-        if: (contains(github.event.pull_request.labels.*.name, 'run_chromatic')  ||  github.ref == 'refs/heads/main')
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN__DOTCOM_RENDERING }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/yarn.lock
+++ b/yarn.lock
@@ -15191,7 +15191,7 @@ preact@10.15.1:
   resolved "https://registry.yarnpkg.com/preact/-/preact-10.15.1.tgz#a1de60c9fc0c79a522d969c65dcaddc5d994eede"
   integrity sha512-qs2ansoQEwzNiV5eAcRT1p1EC/dmEzaATVDJNiB3g2sRDWdA7b7MurXdJjB2+/WQktGWZwxvDrnuRFbWuIr64g==
 
-"prebid.js@github:guardian/prebid.js#0b4cccd55ab4e170b36bb944e9bdd2807a9da1c5":
+prebid.js@guardian/prebid.js#0b4cccd55ab4e170b36bb944e9bdd2807a9da1c5:
   version "7.54.5"
   resolved "https://codeload.github.com/guardian/prebid.js/tar.gz/0b4cccd55ab4e170b36bb944e9bdd2807a9da1c5"
   dependencies:
@@ -15203,7 +15203,7 @@ preact@10.15.1:
     core-js "^3.13.0"
     core-js-pure "^3.13.0"
     criteo-direct-rsa-validate "^1.1.0"
-    crypto-js "^3.3.0"
+    crypto-js "^4.2.0"
     dlv "1.1.3"
     dset "3.1.2"
     express "^4.15.4"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

This PR changes the Chromatic workflows so the `run_chromatic` label is no longer required to run Chromatic on PRs within this repo.

This should reduce friction for contributions and remove some of the confusion around getting the Chromatic tests to pass.

We're hoping that developers will create draft PRs for any work that isn't ready for review, meaning less Chromatic snapshots are created. In this instance Chromatic will not run by default.

If a developer wants to run Chromatic on a draft PR they still have the option to add the `run_chromatic` label and trigger a run.

