### PR TITLE
Override `crypto-js` resolution

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -272,5 +272,8 @@
 		"webpack-node-externals": "3.0.0",
 		"webpack-sources": "3.2.3",
 		"zod": "3.22.3"
+	},
+	"resolutions": {
+		"**/crypto-js": "4.2.0"
 	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -15191,7 +15191,7 @@ preact@10.15.1:
   resolved "https://registry.yarnpkg.com/preact/-/preact-10.15.1.tgz#a1de60c9fc0c79a522d969c65dcaddc5d994eede"
   integrity sha512-qs2ansoQEwzNiV5eAcRT1p1EC/dmEzaATVDJNiB3g2sRDWdA7b7MurXdJjB2+/WQktGWZwxvDrnuRFbWuIr64g==
 
-"prebid.js@github:guardian/prebid.js#0b4cccd55ab4e170b36bb944e9bdd2807a9da1c5":
+prebid.js@guardian/prebid.js#0b4cccd55ab4e170b36bb944e9bdd2807a9da1c5:
   version "7.54.5"
   resolved "https://codeload.github.com/guardian/prebid.js/tar.gz/0b4cccd55ab4e170b36bb944e9bdd2807a9da1c5"
   dependencies:
@@ -15203,7 +15203,7 @@ preact@10.15.1:
     core-js "^3.13.0"
     core-js-pure "^3.13.0"
     criteo-direct-rsa-validate "^1.1.0"
-    crypto-js "^3.3.0"
+    crypto-js "^4.2.0"
     dlv "1.1.3"
     dset "3.1.2"
     express "^4.15.4"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Ensure that all versions of `crypto-js` use **4.2.0**

https://classic.yarnpkg.com/lang/en/docs/selective-version-resolutions/
https://github.com/yarnpkg/rfcs/blob/master/implemented/0000-selective-versions-resolutions.md

## Why?

Resolves #9472 

## Screenshots

N/A