### PR TITLE
Respect the follow status returned from bridget

### DIFF
--- a/apps-rendering/src/client/article.ts
+++ b/apps-rendering/src/client/article.ts
@@ -82,10 +82,10 @@ function followToggle(
 	if (!followStatus) return;
 	void bridgetClient.isFollowing(topic).then((following) => {
 		if (following) {
-			void bridgetClient.unfollow(topic).then((_) => {
+			void bridgetClient.unfollow(topic).then((isFollowing) => {
 				ReactDOM.render(
 					h(followStatusComponent, {
-						isFollowing: false,
+						isFollowing,
 						contributorName: topic.displayName,
 					}),
 					followStatus,

--- a/apps-rendering/src/client/article.ts
+++ b/apps-rendering/src/client/article.ts
@@ -92,10 +92,10 @@ function followToggle(
 				);
 			});
 		} else {
-			void bridgetClient.follow(topic).then((following) => {
+			void bridgetClient.follow(topic).then((isFollowing) => {
 				ReactDOM.render(
 					h(followStatusComponent, {
-						isFollowing: following,
+						isFollowing,
 						contributorName: topic.displayName,
 					}),
 					followStatus,

--- a/apps-rendering/src/client/article.ts
+++ b/apps-rendering/src/client/article.ts
@@ -92,10 +92,10 @@ function followToggle(
 				);
 			});
 		} else {
-			void bridgetClient.follow(topic).then((_) => {
+			void bridgetClient.follow(topic).then((following) => {
 				ReactDOM.render(
 					h(followStatusComponent, {
-						isFollowing: true,
+						isFollowing: following,
 						contributorName: topic.displayName,
 					}),
 					followStatus,


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
This sets the following status in accordance to what the app returns after clicking the follow button, rather than defaulting to true.

## Why?
There are cases where the follow button can be clicked, but may not necessarily be successfully following. For example if a user is in a signed out state, the native app will initiate the sign in flow and return false. In this case we don't want the user to be shown a successful following. 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
