### PR TITLE
Add Type-Checking To Dev Server JS

### DIFF
--- a/dotcom-rendering/src/server/dev-index.html
+++ b/dotcom-rendering/src/server/dev-index.html
@@ -151,6 +151,7 @@
 		</ul>
 
 		<script>
+			// @ts-check
 			var testContentTypes = [
 				{
 					name: 'Live Blog',
@@ -426,7 +427,7 @@
 
 						document
 							.querySelector('#default-endpoints')
-							.appendChild(fragment);
+							?.appendChild(fragment);
 					}
 				});
 			};
@@ -446,19 +447,33 @@
 			         `;
 
 			testContentTypes.forEach((a) => {
-				document.getElementById('test-articles-by-content').innerHTML +=
-					makeTestArticle(a);
+				const testArticles = document.getElementById(
+					'test-articles-by-content',
+				);
+
+				if (testArticles !== null) {
+					testArticles.innerHTML += makeTestArticle(a);
+				}
 			});
 
 			testArticles.forEach((a) => {
-				document.getElementById('test-articles-by-element').innerHTML +=
-					makeTestArticle(a);
+				const testArticles = document.getElementById(
+					'test-articles-by-element',
+				);
+
+				if (testArticles !== null) {
+					testArticles.innerHTML += makeTestArticle(a);
+				}
 			});
 
 			testContentAtomTypes.forEach((a) => {
-				document.getElementById(
+				const testArticles = document.getElementById(
 					'test-articles-by-atom-type',
-				).innerHTML += makeTestArticle(a);
+				);
+
+				if (testArticles !== null) {
+					testArticles.innerHTML += makeTestArticle(a);
+				}
 			});
 		</script>
 	</body>


### PR DESCRIPTION
Add the `ts-check` comment[^1] to get type-checking in JS. This should work in any editor that supports this comment, like VSCode.

The changes required to make this code type-safe involve checking DOM lookups to make sure the elements are present before calling methods on them.

No refactoring other than that required for type-checking. Further changes may come later.

[^1]: https://www.typescriptlang.org/docs/handbook/intro-to-js-ts.html
