### PR TITLE
Separate Out The Two Parts Of `make fix`

### DIFF
--- a/dotcom-rendering/makefile
+++ b/dotcom-rendering/makefile
@@ -129,10 +129,16 @@ tsc: clean-dist install
 	$(call log, "checking for type errors")
 	@tsc
 
-fix: clear clean-dist install
+lint-fix:
 	$(call log, "attempting to fix lint errors")
 	@yarn lint:fix
+
+prettier:
+	$(call log, "attempting to fix prettier errors")
 	@cd .. && yarn prettier:write
+
+fix: clear clean-dist install lint-fix prettier
+	$(call log, "everything fixed")
 
 snapshot: clear clean-dist install
 	$(call log, "taking snapshots")


### PR DESCRIPTION
Allows them to be run independently if needed.
