### PR TITLE
Add darkmode to submeta 🌔 

### DIFF
--- a/dotcom-rendering/src/components/SubMeta.stories.tsx
+++ b/dotcom-rendering/src/components/SubMeta.stories.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import { ArticleDesign, ArticleDisplay } from '@guardian/libs';
 import type { StoryProps } from '../../.storybook/decorators/splitThemeDecorator';
-import { lightDecorator } from '../../.storybook/decorators/themeDecorator';
+import { splitTheme } from '../../.storybook/decorators/splitThemeDecorator';
 import { getAllThemes } from '../lib/format';
 import { SubMeta } from './SubMeta';
 
@@ -55,11 +55,6 @@ const subMetaSectionLinks = [
 	},
 ];
 
-const allStandardThemes = getAllThemes({
-	display: ArticleDisplay.Standard,
-	design: ArticleDesign.Standard,
-});
-
 export const StandardStory = ({ format }: StoryProps) => {
 	return (
 		<Wrapper key={JSON.stringify(format)}>
@@ -76,7 +71,7 @@ export const StandardStory = ({ format }: StoryProps) => {
 	);
 };
 StandardStory.storyName = 'Standard - All pillars';
-StandardStory.decorators = [lightDecorator(allStandardThemes)];
+StandardStory.decorators = [splitTheme()];
 
 const allDeadBlogThemes = getAllThemes({
 	display: ArticleDisplay.Standard,
@@ -99,4 +94,4 @@ export const DeadBlogStory = ({ format }: StoryProps) => {
 	);
 };
 DeadBlogStory.storyName = 'Deadblog - All pillars';
-DeadBlogStory.decorators = [lightDecorator(allDeadBlogThemes)];
+DeadBlogStory.decorators = [splitTheme(allDeadBlogThemes)];

--- a/dotcom-rendering/src/components/SubMeta.tsx
+++ b/dotcom-rendering/src/components/SubMeta.tsx
@@ -2,23 +2,22 @@ import { css } from '@emotion/react';
 import { ArticleDesign } from '@guardian/libs';
 import {
 	from,
-	neutral,
+	palette as sourcePalette,
 	space,
 	textSans,
 	until,
 } from '@guardian/source-foundations';
 import { LinkButton } from '@guardian/source-react-components';
-import { decidePalette } from '../lib/decidePalette';
 import type { BaseLinkType } from '../model/extract-nav';
 import type { DCRBadgeType } from '../types/badge';
-import type { Palette } from '../types/palette';
 import { Badge } from './Badge';
 import { ShareIcons } from './ShareIcons';
+import { palette } from '../palette';
 
-const labelStyles = (palette: Palette) => css`
+const labelStyles = css`
 	${textSans.xxsmall()};
 	display: block;
-	color: ${palette.text.subMetaLabel};
+	color: ${palette('--sub-meta-label-text')};
 	margin-bottom: 8px;
 `;
 
@@ -34,7 +33,7 @@ const bottomPadding = css`
 	}
 `;
 
-const setMetaWidth = (palette: Palette) => css`
+const setMetaWidth = css`
 	position: relative;
 	${from.tablet} {
 		max-width: 620px;
@@ -46,14 +45,14 @@ const setMetaWidth = (palette: Palette) => css`
 	${from.leftCol} {
 		margin-left: 150px;
 		padding-left: 10px;
-		border-left: 1px solid ${palette.border.article};
+		border-left: 1px solid ${palette('--article-border')};
 	}
 	${from.wide} {
 		margin-left: 229px;
 	}
 `;
 
-const listStyleNone = (palette: Palette) => css`
+const listStyleNone = css`
 	list-style: none;
 	/* https://developer.mozilla.org/en-US/docs/Web/CSS/list-style#accessibility_concerns */
 	/* Needs double escape char: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#es2018_revision_of_illegal_escape_sequences */
@@ -68,17 +67,17 @@ const listStyleNone = (palette: Palette) => css`
 	gap: 1.5rem 0.25rem;
 	background-image: repeating-linear-gradient(
 			to bottom,
-			${palette.background.subMeta} 0px,
-			${palette.background.subMeta} 36px,
+			${palette('--sub-meta-background')} 0px,
+			${palette('--sub-meta-background')} 36px,
 			transparent 36px,
 			transparent 37px,
-			${palette.background.subMeta} 37px,
-			${palette.background.subMeta} 48px
+			${palette('--sub-meta-background')} 37px,
+			${palette('--sub-meta-background')} 48px
 		),
 		repeating-linear-gradient(
 			to right,
-			${neutral[86]} 0px,
-			${neutral[86]} 3px,
+			${sourcePalette.neutral[86]} 0px,
+			${sourcePalette.neutral[86]} 3px,
 			transparent 3px,
 			transparent 5px
 		);
@@ -86,15 +85,15 @@ const listStyleNone = (palette: Palette) => css`
 	background-repeat: no-repeat;
 `;
 
-const listWrapper = (palette: Palette) => css`
+const listWrapper = css`
 	padding-bottom: 12px;
 	margin-bottom: 6px;
-	border-bottom: 1px solid ${palette.border.article};
+	border-bottom: 1px solid ${palette('--article-border')};
 `;
 
-const listItemStyles = (palette: Palette) => css`
+const listItemStyles = css`
 	${textSans.xsmall()};
-	border: 1px solid ${palette.text.subMeta};
+	border: 1px solid ${palette('--sub-meta-text')};
 	border-radius: 12px;
 	padding: 2px 9px;
 	a {
@@ -108,12 +107,12 @@ const listItemStyles = (palette: Palette) => css`
 	}
 `;
 
-const linkStyles = (palette: Palette) => css`
+const linkStyles = css`
 	text-decoration: none;
 	:hover {
 		text-decoration: underline;
 	}
-	color: ${palette.text.subMeta};
+	color: ${palette('--sub-meta-text')};
 `;
 
 type Props = {
@@ -127,10 +126,10 @@ type Props = {
 	badge?: DCRBadgeType;
 };
 
-const syndicationButtonOverrides = (palette: Palette) => css`
+const syndicationButtonOverrides = css`
 	> a {
-		color: ${palette.text.syndicationButton};
-		border-color: ${palette.border.syndicationButton};
+		color: ${palette('--syndication-button-text')};
+		border-color: ${palette('--syndication-button-border')};
 		font-weight: normal;
 	}
 `;
@@ -145,7 +144,6 @@ export const SubMeta = ({
 	showBottomSocialButtons,
 	badge,
 }: Props) => {
-	const palette = decidePalette(format);
 	const createLinks = () => {
 		const links: BaseLinkType[] = [];
 		if (subMetaSectionLinks.length > 0) links.push(...subMetaSectionLinks);
@@ -161,7 +159,7 @@ export const SubMeta = ({
 			data-print-layout="hide"
 			css={
 				format.design === ArticleDesign.Interactive
-					? [bottomPadding, setMetaWidth(palette)]
+					? [bottomPadding, setMetaWidth]
 					: bottomPadding
 			}
 		>
@@ -172,20 +170,12 @@ export const SubMeta = ({
 			)}
 			{hasLinks && (
 				<>
-					<span css={labelStyles(palette)}>
-						Explore more on these topics
-					</span>
-					<div css={listWrapper(palette)}>
-						<ul css={listStyleNone(palette)}>
+					<span css={labelStyles}>Explore more on these topics</span>
+					<div css={listWrapper}>
+						<ul css={listStyleNone}>
 							{links.map((link) => (
-								<li
-									css={listItemStyles(palette)}
-									key={link.url}
-								>
-									<a
-										css={linkStyles(palette)}
-										href={link.url}
-									>
+								<li css={listItemStyles} key={link.url}>
+									<a css={linkStyles} href={link.url}>
 										{link.title}
 									</a>
 								</li>
@@ -216,7 +206,7 @@ export const SubMeta = ({
 						size="medium"
 						context="SubMeta"
 					/>
-					<div css={syndicationButtonOverrides(palette)}>
+					<div css={syndicationButtonOverrides}>
 						{format.design === ArticleDesign.Interactive ? null : (
 							<LinkButton
 								priority="tertiary"

--- a/dotcom-rendering/src/components/SubMeta.tsx
+++ b/dotcom-rendering/src/components/SubMeta.tsx
@@ -9,10 +9,10 @@ import {
 } from '@guardian/source-foundations';
 import { LinkButton } from '@guardian/source-react-components';
 import type { BaseLinkType } from '../model/extract-nav';
+import { palette } from '../palette';
 import type { DCRBadgeType } from '../types/badge';
 import { Badge } from './Badge';
 import { ShareIcons } from './ShareIcons';
-import { palette } from '../palette';
 
 const labelStyles = css`
 	${textSans.xxsmall()};

--- a/dotcom-rendering/src/lib/decidePalette.ts
+++ b/dotcom-rendering/src/lib/decidePalette.ts
@@ -323,64 +323,6 @@ const textTwitterHandleBelowDesktop = (format: ArticleFormat): string => {
 	return textTwitterHandle(format);
 };
 
-const textSubMeta = (format: ArticleFormat): string => {
-	if (format.theme === ArticleSpecial.Labs) return BLACK;
-	if (format.design === ArticleDesign.Picture) return palette.neutral[86];
-	if (format.theme === ArticleSpecial.SpecialReport)
-		return specialReport[100];
-	if (
-		format.design === ArticleDesign.DeadBlog ||
-		format.design === ArticleDesign.LiveBlog
-	)
-		return blogsGrayBackgroundPalette(format);
-	if (format.design === ArticleDesign.Analysis) {
-		switch (format.theme) {
-			case Pillar.News:
-				return news[300];
-			default:
-				return pillarPalette[format.theme].main;
-		}
-	}
-	return pillarPalette[format.theme].main;
-};
-
-const textSubMetaLabel = (format: ArticleFormat): string => {
-	if (format.theme === ArticleSpecial.Labs) return BLACK;
-	if (format.theme === ArticleSpecial.SpecialReport)
-		return specialReport[300];
-	if (
-		format.theme === ArticleSpecial.SpecialReportAlt &&
-		format.design !== ArticleDesign.LiveBlog &&
-		format.design != ArticleDesign.DeadBlog
-	)
-		return palette.specialReportAlt[100];
-	if (format.design === ArticleDesign.Picture) return palette.neutral[60];
-	return text.supporting;
-};
-
-const textSubMetaLink = (format: ArticleFormat): string => {
-	if (format.theme === ArticleSpecial.Labs) return BLACK;
-	if (format.design === ArticleDesign.Picture) return palette.neutral[86];
-	if (format.theme === ArticleSpecial.SpecialReport)
-		return specialReport[300];
-	return text.supporting;
-};
-
-const textSyndicationButton = (format: ArticleFormat): string => {
-	if (format.theme === ArticleSpecial.Labs) return BLACK;
-	if (format.theme === ArticleSpecial.SpecialReport)
-		return specialReport[100];
-
-	if (
-		format.theme === ArticleSpecial.SpecialReportAlt &&
-		format.design !== ArticleDesign.LiveBlog &&
-		format.design !== ArticleDesign.DeadBlog
-	)
-		return palette.specialReportAlt[100];
-
-	return text.supporting;
-};
-
 /** @deprecated this has been moved to the theme palette (--article-link-text) */
 const textArticleLink = (format: ArticleFormat): string => {
 	if (format.design === ArticleDesign.DeadBlog) {
@@ -1146,18 +1088,6 @@ const fillTwitterHandle = (format: ArticleFormat): string => {
 		return palette.specialReportAlt[100];
 
 	return neutral[46];
-};
-
-const borderSyndicationButton = (format: ArticleFormat): string => {
-	if (format.theme === ArticleSpecial.Labs) return neutral[60];
-	if (
-		format.theme === ArticleSpecial.SpecialReportAlt &&
-		format.design !== ArticleDesign.DeadBlog &&
-		format.design !== ArticleDesign.LiveBlog
-	)
-		return palette.specialReportAlt[100];
-
-	return border.secondary;
 };
 
 /** @deprecated this has been moved to the theme palette */
@@ -1928,48 +1858,6 @@ const backgroundDiscussionPillarButton = (format: ArticleFormat) => {
 	}
 };
 
-const backgroundSubmeta = (format: ArticleFormat) => {
-	// specialreport blogs should have specialreport background
-	if (
-		(format.design === ArticleDesign.LiveBlog ||
-			format.design === ArticleDesign.DeadBlog) &&
-		format.theme !== ArticleSpecial.SpecialReport
-	)
-		return neutral[97];
-
-	// Order matters. We want comment special report pieces to have the opinion background
-	if (format.design === ArticleDesign.Letter) return opinion[800];
-
-	if (format.design === ArticleDesign.Comment) {
-		if (format.theme === ArticleSpecial.SpecialReportAlt)
-			return palette.specialReportAlt[800];
-
-		return opinion[800];
-	}
-	if (format.design === ArticleDesign.Editorial) return opinion[800];
-
-	if (format.design === ArticleDesign.Analysis) {
-		if (format.theme === ArticleSpecial.SpecialReportAlt)
-			return palette.specialReportAlt[800];
-		else return news[800];
-	}
-
-	if (format.theme === ArticleSpecial.SpecialReport)
-		return specialReport[800]; // Note, check theme rather than design here
-
-	if (format.theme === ArticleSpecial.SpecialReportAlt)
-		return palette.specialReportAlt[800];
-
-	if (
-		format.theme === ArticleSpecial.Labs &&
-		format.display !== ArticleDisplay.Immersive
-	)
-		return neutral[97];
-	if (format.design === ArticleDesign.Picture) return BLACK;
-
-	return neutral[100];
-};
-
 const textYoutubeOverlayKicker = (format: ArticleFormat) => {
 	switch (format.theme) {
 		case Pillar.News:
@@ -2010,10 +1898,6 @@ export const decidePalette = (
 			byline: textByline(format),
 			twitterHandle: textTwitterHandle(format),
 			twitterHandleBelowDesktop: textTwitterHandleBelowDesktop(format),
-			subMeta: textSubMeta(format),
-			subMetaLabel: textSubMetaLabel(format),
-			subMetaLink: textSubMetaLink(format),
-			syndicationButton: textSyndicationButton(format),
 			articleLink: textArticleLink(format),
 			articleLinkHover: textArticleLinkHover(format),
 			cardHeadline:
@@ -2092,7 +1976,6 @@ export const decidePalette = (
 			pullQuote: backgroundPullQuote(format),
 			messageForm: backgroundMessageForm(format),
 			discussionPillarButton: backgroundDiscussionPillarButton(format),
-			subMeta: backgroundSubmeta(format),
 			dynamoSublink:
 				overrides?.background.dynamoSublink ??
 				backgroundDynamoSublink(format),
@@ -2108,7 +1991,6 @@ export const decidePalette = (
 			guardianLogo: fillGuardianLogo(format),
 		},
 		border: {
-			syndicationButton: borderSyndicationButton(format),
 			subNav: borderSubNav(format),
 			articleLink: borderArticleLink(format),
 			articleLinkHover: borderArticleLinkHover(format),

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -1599,6 +1599,209 @@ const liveBlockBorderTopDark = () => sourcePalette.neutral[60];
 const liveBlockBorderBottomLight = () => sourcePalette.neutral[86];
 const liveBlockBorderBottomDark = () => sourcePalette.neutral[46];
 
+const subMetaLabelTextLight = ({ theme, design }: ArticleFormat): string => {
+	switch (theme) {
+		case ArticleSpecial.Labs:
+			return sourcePalette.neutral[7];
+		case ArticleSpecial.SpecialReport:
+			return sourcePalette.specialReport[300];
+		case ArticleSpecial.SpecialReportAlt:
+			switch (design) {
+				case ArticleDesign.LiveBlog:
+				case ArticleDesign.DeadBlog:
+					return sourcePalette.neutral[46];
+				default:
+					return sourcePalette.specialReportAlt[100];
+			}
+		default:
+			switch (design) {
+				case ArticleDesign.Picture:
+					return sourcePalette.neutral[60];
+				default:
+					return sourcePalette.neutral[46];
+			}
+	}
+};
+const subMetaLabelTextDark = (): string => {
+	return sourcePalette.neutral[86];
+};
+const subMetaBackgroundLight = ({ design, theme, display }: ArticleFormat) => {
+	switch (design) {
+		case ArticleDesign.LiveBlog:
+		case ArticleDesign.DeadBlog:
+			switch (theme) {
+				// specialreport blogs should have specialreport background
+				case ArticleSpecial.SpecialReport:
+					return sourcePalette.neutral[100];
+				default:
+					return sourcePalette.neutral[97];
+			}
+		case ArticleDesign.Letter:
+			return sourcePalette.opinion[800];
+		case ArticleDesign.Comment:
+			switch (theme) {
+				case ArticleSpecial.SpecialReportAlt:
+					return sourcePalette.specialReportAlt[800];
+				default:
+					return sourcePalette.opinion[800];
+			}
+		case ArticleDesign.Editorial:
+			return sourcePalette.opinion[800];
+		case ArticleDesign.Analysis:
+			switch (theme) {
+				case ArticleSpecial.SpecialReportAlt:
+					return sourcePalette.specialReportAlt[800];
+				default:
+					return sourcePalette.news[800];
+			}
+		case ArticleDesign.Picture:
+			return sourcePalette.neutral[7];
+		default:
+			switch (theme) {
+				case ArticleSpecial.SpecialReport:
+					return sourcePalette.specialReport[800];
+				case ArticleSpecial.SpecialReportAlt:
+					return sourcePalette.specialReportAlt[800];
+				case ArticleSpecial.Labs:
+					switch (display) {
+						case ArticleDisplay.Immersive:
+							return sourcePalette.neutral[100];
+						default:
+							return sourcePalette.neutral[97];
+					}
+				default:
+					return sourcePalette.neutral[100];
+			}
+	}
+};
+
+const subMetaBackgroundDark = ({ design, theme }: ArticleFormat): string => {
+	switch (design) {
+		case ArticleDesign.DeadBlog:
+			return sourcePalette.neutral[7];
+		case ArticleDesign.LiveBlog:
+			return sourcePalette.neutral[0];
+		case ArticleDesign.Standard:
+		case ArticleDesign.Review:
+		case ArticleDesign.Explainer:
+		case ArticleDesign.Feature:
+		case ArticleDesign.Interview:
+		case ArticleDesign.Interactive:
+		case ArticleDesign.PhotoEssay:
+		case ArticleDesign.FullPageInteractive:
+		case ArticleDesign.NewsletterSignup:
+		case ArticleDesign.Comment:
+		case ArticleDesign.Letter:
+		case ArticleDesign.Editorial:
+			switch (theme) {
+				case ArticleSpecial.SpecialReportAlt:
+					return sourcePalette.specialReportAlt[100];
+				default:
+					return sourcePalette.neutral[10];
+			}
+		default:
+			return sourcePalette.neutral[10];
+	}
+};
+
+const subMetaTextLight = ({ design, theme }: ArticleFormat): string => {
+	switch (theme) {
+		case ArticleSpecial.Labs:
+			return sourcePalette.neutral[7];
+		case ArticleSpecial.SpecialReport:
+			return sourcePalette.specialReport[100];
+		default:
+			switch (design) {
+				case ArticleDesign.Picture:
+					return sourcePalette.neutral[86];
+				case ArticleDesign.DeadBlog:
+				case ArticleDesign.LiveBlog:
+					switch (theme) {
+						case Pillar.News:
+							return sourcePalette.news[400];
+						case ArticleSpecial.SpecialReportAlt:
+							return sourcePalette.news[400];
+						default:
+							return pillarPalette(theme, 300);
+					}
+				case ArticleDesign.Analysis:
+					switch (theme) {
+						case Pillar.News:
+							return sourcePalette.news[300];
+						default:
+							switch (theme) {
+								case Pillar.Opinion:
+									return sourcePalette.opinion[300];
+								case ArticleSpecial.SpecialReportAlt:
+									return sourcePalette.specialReportAlt[200];
+								default:
+									return pillarPalette(theme, 400);
+							}
+					}
+				default:
+					switch (theme) {
+						case Pillar.Opinion:
+							return sourcePalette.opinion[300];
+						case ArticleSpecial.SpecialReportAlt:
+							return sourcePalette.specialReportAlt[200];
+						default:
+							return pillarPalette(theme, 400);
+					}
+			}
+	}
+};
+
+const subMetaTextDark = ({ theme }: ArticleFormat): string => {
+	switch (theme) {
+		case ArticleSpecial.SpecialReport:
+			return sourcePalette.specialReport[700];
+
+		case ArticleSpecial.Labs:
+			return sourcePalette.labs[400];
+
+		case ArticleSpecial.SpecialReportAlt:
+			return sourcePalette.specialReportAlt[300];
+		default:
+			return pillarPalette(theme, 500);
+	}
+};
+
+const syndicationButtonText = ({ design, theme }: ArticleFormat): string => {
+	switch (theme) {
+		case ArticleSpecial.Labs:
+			return sourcePalette.neutral[7];
+		case ArticleSpecial.SpecialReport:
+			return sourcePalette.specialReport[100];
+		case ArticleSpecial.SpecialReportAlt:
+			switch (design) {
+				case ArticleDesign.LiveBlog:
+				case ArticleDesign.DeadBlog:
+					return sourcePalette.neutral[46];
+				default:
+					return sourcePalette.specialReportAlt[100];
+			}
+		default:
+			return sourcePalette.neutral[46];
+	}
+};
+
+const syndicationButtonBorder = ({ design, theme }: ArticleFormat): string => {
+	switch (theme) {
+		case ArticleSpecial.Labs:
+			return sourcePalette.neutral[60];
+		case ArticleSpecial.SpecialReportAlt:
+			switch (design) {
+				case ArticleDesign.DeadBlog:
+				case ArticleDesign.LiveBlog:
+					return sourcePalette.neutral[86];
+				default:
+					return sourcePalette.specialReportAlt[100];
+			}
+		default:
+			return sourcePalette.neutral[86];
+	}
+};
+
 // ----- Palette ----- //
 
 /**
@@ -1903,6 +2106,26 @@ const paletteColours = {
 	'--live-block-border-bottom': {
 		light: liveBlockBorderBottomLight,
 		dark: liveBlockBorderBottomDark,
+	},
+	'--sub-meta-background': {
+		light: subMetaBackgroundLight,
+		dark: subMetaBackgroundDark,
+	},
+	'--sub-meta-label-text': {
+		light: subMetaLabelTextLight,
+		dark: subMetaLabelTextDark,
+	},
+	'--sub-meta-text': {
+		light: subMetaTextLight,
+		dark: subMetaTextDark,
+	},
+	'--syndication-button-text': {
+		light: syndicationButtonText,
+		dark: syndicationButtonText,
+	},
+	'--syndication-button-border': {
+		light: syndicationButtonBorder,
+		dark: syndicationButtonBorder,
 	},
 } satisfies PaletteColours;
 

--- a/dotcom-rendering/src/types/palette.ts
+++ b/dotcom-rendering/src/types/palette.ts
@@ -10,10 +10,6 @@ export type Palette = {
 		byline: Colour;
 		twitterHandle: Colour;
 		twitterHandleBelowDesktop: Colour;
-		subMeta: Colour;
-		subMetaLabel: Colour;
-		subMetaLink: Colour;
-		syndicationButton: Colour;
 		articleLink: Colour;
 		articleLinkHover: Colour;
 		cardHeadline: Colour;
@@ -88,7 +84,6 @@ export type Palette = {
 		lightboxDivider: Colour;
 		messageForm: Colour;
 		discussionPillarButton: Colour;
-		subMeta: Colour;
 		dynamoSublink: Colour;
 	};
 	fill: {
@@ -102,7 +97,6 @@ export type Palette = {
 		guardianLogo: Colour;
 	};
 	border: {
-		syndicationButton: Colour;
 		subNav: Colour;
 		articleLink: Colour;
 		articleLinkHover: Colour;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Updates the submeta component to use light / dark mode palettes. 

## Why?
This is part of a wider body of work to implement dark mode on  app articles.
## Screenshots

![Screenshot 2023-11-14 at 17 09 02](https://github.com/guardian/dotcom-rendering/assets/20416599/85d8b0e6-4076-4b2a-aa5c-1486b32396f4)

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
