### PR TITLE
refactor(stories): use SplitThemeStory type

### DIFF
--- a/dotcom-rendering/.storybook/decorators/splitThemeDecorator.tsx
+++ b/dotcom-rendering/.storybook/decorators/splitThemeDecorator.tsx
@@ -12,7 +12,7 @@ import {
 	space,
 	textSans,
 } from '@guardian/source-foundations';
-import { Decorator } from '@storybook/react';
+import { Decorator, StoryObj } from '@storybook/react';
 import { paletteDeclarations } from '../../src/palette';
 
 interface Orientation {
@@ -180,3 +180,7 @@ export const splitTheme =
 			</div>
 		</div>
 	);
+
+export type SplitThemeStory = StoryObj<
+	(props: { format: ArticleFormat }) => React.ReactElement
+> & { render: {}; decorators: {} };

--- a/dotcom-rendering/src/components/CardHeadline.stories.tsx
+++ b/dotcom-rendering/src/components/CardHeadline.stories.tsx
@@ -6,7 +6,7 @@ import {
 	Pillar,
 } from '@guardian/libs';
 import { breakpoints, palette } from '@guardian/source-foundations';
-import type { StoryObj } from '@storybook/react';
+import type { SplitThemeStory } from '../../.storybook/decorators/splitThemeDecorator';
 import { splitTheme } from '../../.storybook/decorators/splitThemeDecorator';
 import type { DCRContainerPalette } from '../types/front';
 import { CardHeadline } from './CardHeadline';
@@ -27,176 +27,169 @@ const smallHeadlineSizes: SmallHeadlineSize[] = [
 	'tiny',
 ];
 
-export const Article = () => (
-	<Section fullWidth={true} showTopBorder={false} showSideBorders={false}>
-		<CardHeadline
-			headlineText="This is how an Article card headline looks"
-			format={{
+export const Article: SplitThemeStory = {
+	render: ({ format }) => (
+		<Section fullWidth={true} showTopBorder={false} showSideBorders={false}>
+			<CardHeadline
+				headlineText="This is how an Article card headline looks"
+				format={format}
+			/>
+		</Section>
+	),
+	decorators: [
+		splitTheme([
+			{
 				display: ArticleDisplay.Standard,
 				design: ArticleDesign.Standard,
 				theme: Pillar.News,
-			}}
-		/>
-	</Section>
-);
-Article.storyName = 'Article';
+			},
+		]),
+	],
+};
 
-const specialReport = {
-	display: ArticleDisplay.Standard,
-	design: ArticleDesign.Analysis,
-	theme: ArticleSpecial.SpecialReport,
-} satisfies ArticleFormat;
-export const Analysis = () => (
-	<>
-		{smallHeadlineSizes.map((size) => (
-			<div key={size}>
-				<Section
-					fullWidth={true}
-					showTopBorder={false}
-					showSideBorders={false}
-				>
-					<CardHeadline
-						headlineText={`This is how a ${size} Analysis card headline looks`}
-						format={{
-							display: ArticleDisplay.Standard,
-							design: ArticleDesign.Analysis,
-							theme: Pillar.News,
-						}}
-						size={size}
-					/>
-				</Section>
-				<br />
-			</div>
-		))}
-		<br />
-		<Section fullWidth={true} showTopBorder={false} showSideBorders={false}>
-			<CardHeadline
-				headlineText="This is how an Sport Analysis card headline looks"
-				format={{
-					display: ArticleDisplay.Standard,
-					design: ArticleDesign.Analysis,
-					theme: Pillar.Sport,
-				}}
-			/>
-		</Section>
-		<br />
-		<Section fullWidth={true} showTopBorder={false} showSideBorders={false}>
-			<CardHeadline
-				headlineText="This is how an Culture Analysis card headline looks"
-				format={{
-					display: ArticleDisplay.Standard,
-					design: ArticleDesign.Analysis,
-					theme: Pillar.Culture,
-				}}
-			/>
-		</Section>
-		<br />
-		<Section fullWidth={true} showTopBorder={false} showSideBorders={false}>
-			<CardHeadline
-				headlineText="This is how an Opinion Analysis card headline looks"
-				format={{
-					display: ArticleDisplay.Standard,
-					design: ArticleDesign.Analysis,
-					theme: Pillar.Opinion,
-				}}
-			/>
-		</Section>
-		<br />
-		<Section fullWidth={true} showTopBorder={false} showSideBorders={false}>
-			<CardHeadline
-				headlineText="This is how an Lifestyle Analysis card headline looks"
-				format={{
-					display: ArticleDisplay.Standard,
-					design: ArticleDesign.Analysis,
-					theme: Pillar.Lifestyle,
-				}}
-			/>
-		</Section>
-		<br />
-		<Section
-			fullWidth={true}
-			showTopBorder={false}
-			showSideBorders={false}
-			backgroundColour={palette.specialReport[300]}
-		>
-			<ContainerOverrides isDynamo={false}>
-				<CardHeadline
-					headlineText="This is how an Special Report Analysis card headline looks"
-					format={specialReport}
-				/>
-			</ContainerOverrides>
-		</Section>
-	</>
-);
-Analysis.storyName = 'Analysis';
+export const Analysis: SplitThemeStory = {
+	render: ({ format }) => (
+		<>
+			{smallHeadlineSizes.map((size) => (
+				<div key={size}>
+					<Section
+						fullWidth={true}
+						showTopBorder={false}
+						showSideBorders={false}
+					>
+						<CardHeadline
+							headlineText={`This is how a ${size} ${
+								Pillar[format.theme] ??
+								ArticleSpecial[format.theme] ??
+								'Unknown'
+							} card headline looks`}
+							format={format}
+							size={size}
+						/>
+					</Section>
+				</div>
+			))}
+		</>
+	),
+	decorators: [
+		splitTheme([
+			{
+				display: ArticleDisplay.Standard,
+				design: ArticleDesign.Analysis,
+				theme: Pillar.News,
+			},
+			{
+				display: ArticleDisplay.Standard,
+				design: ArticleDesign.Analysis,
+				theme: Pillar.Sport,
+			},
+			{
+				display: ArticleDisplay.Standard,
+				design: ArticleDesign.Analysis,
+				theme: Pillar.Culture,
+			},
+			{
+				display: ArticleDisplay.Standard,
+				design: ArticleDesign.Analysis,
+				theme: Pillar.Opinion,
+			},
+			{
+				display: ArticleDisplay.Standard,
+				design: ArticleDesign.Analysis,
+				theme: Pillar.Lifestyle,
+			},
+			{
+				display: ArticleDisplay.Standard,
+				design: ArticleDesign.Analysis,
+				theme: ArticleSpecial.SpecialReport,
+			},
+		]),
+	],
+};
 
-export const Feature = () => (
-	<Section fullWidth={true} showTopBorder={false} showSideBorders={false}>
-		<CardHeadline
-			headlineText="This is how a Feature card headline looks"
-			format={{
+export const Feature: SplitThemeStory = {
+	render: ({ format }) => (
+		<Section fullWidth={true} showTopBorder={false} showSideBorders={false}>
+			<CardHeadline
+				headlineText="This is how a Feature card headline looks"
+				format={format}
+			/>
+		</Section>
+	),
+	decorators: [
+		splitTheme([
+			{
 				display: ArticleDisplay.Standard,
 				design: ArticleDesign.Feature,
 				theme: Pillar.News,
-			}}
-		/>
-	</Section>
-);
-Feature.storyName = 'Feature';
+			},
+		]),
+	],
+};
 
-export const Size = () => (
-	<>
-		{smallHeadlineSizes.map((size) => (
-			<div key={size}>
-				<Section
-					fullWidth={true}
-					showTopBorder={false}
-					showSideBorders={false}
-				>
-					<CardHeadline
-						headlineText={`This is how a ${size} card headline looks`}
-						format={{
-							display: ArticleDisplay.Standard,
-							design: ArticleDesign.Standard,
-							theme: Pillar.News,
-						}}
-						size={size}
-					/>
-				</Section>
-				<br />
-			</div>
-		))}
-	</>
-);
-Size.storyName = 'Size';
+export const Size: SplitThemeStory = {
+	render: ({ format }: { format: ArticleFormat }) => (
+		<>
+			{smallHeadlineSizes.map((size) => (
+				<div key={size}>
+					<Section
+						fullWidth={true}
+						showTopBorder={false}
+						showSideBorders={false}
+					>
+						<CardHeadline
+							headlineText={`This is how a ${size} card headline looks`}
+							format={format}
+							size={size}
+						/>
+					</Section>
+					<br />
+				</div>
+			))}
+		</>
+	),
+	decorators: [
+		splitTheme([
+			{
+				display: ArticleDisplay.Standard,
+				design: ArticleDesign.Standard,
+				theme: Pillar.News,
+			},
+		]),
+	],
+};
 
-export const MobileSize = () => (
-	<>
-		{smallHeadlineSizes.map((size) => (
-			<div key={size}>
-				<Section
-					fullWidth={true}
-					showTopBorder={false}
-					showSideBorders={false}
-				>
-					<CardHeadline
-						headlineText={`This is how a mobile ${size} card headline looks`}
-						format={{
-							display: ArticleDisplay.Standard,
-							design: ArticleDesign.Standard,
-							theme: Pillar.News,
-						}}
-						size="medium"
-						sizeOnMobile={size}
-					/>
-				</Section>
-				<br />
-			</div>
-		))}
-	</>
-);
-MobileSize.storyName = 'MobileSize';
-MobileSize.story = {
+export const MobileSize: SplitThemeStory = {
+	render: ({ format }: { format: ArticleFormat }) => (
+		<>
+			{smallHeadlineSizes.map((size) => (
+				<div key={size}>
+					<Section
+						fullWidth={true}
+						showTopBorder={false}
+						showSideBorders={false}
+					>
+						<CardHeadline
+							headlineText={`This is how a mobile ${size} card headline looks`}
+							format={format}
+							size="medium"
+							sizeOnMobile={size}
+						/>
+					</Section>
+					<br />
+				</div>
+			))}
+		</>
+	),
+	decorators: [
+		splitTheme([
+			{
+				display: ArticleDisplay.Standard,
+				design: ArticleDesign.Standard,
+				theme: Pillar.News,
+			},
+		]),
+	],
 	parameters: {
 		chromatic: {
 			viewports: [breakpoints.mobile],
@@ -204,222 +197,273 @@ MobileSize.story = {
 	},
 };
 
-export const liveStory = () => (
-	<Section fullWidth={true} showTopBorder={false} showSideBorders={false}>
-		<CardHeadline
-			headlineText="This is how a card headline with a live kicker looks"
-			format={{
+export const liveStory: SplitThemeStory = {
+	storyName: 'With Live kicker',
+	render: ({ format }: { format: ArticleFormat }) => (
+		<Section fullWidth={true} showTopBorder={false} showSideBorders={false}>
+			<CardHeadline
+				headlineText="This is how a card headline with a live kicker looks"
+				format={format}
+				kickerText="Live"
+			/>
+		</Section>
+	),
+	decorators: [
+		splitTheme([
+			{
 				display: ArticleDisplay.Standard,
 				design: ArticleDesign.Standard,
 				theme: Pillar.News,
-			}}
-			kickerText="Live"
-		/>
-	</Section>
-);
-liveStory.storyName = 'With Live kicker';
+			},
+		]),
+	],
+};
 
-export const noLineBreak = () => (
-	<Section fullWidth={true} showTopBorder={false} showSideBorders={false}>
-		<CardHeadline
-			headlineText="This is how a card headline with no kicker linebreak looks"
-			format={{
+export const noLineBreak: SplitThemeStory = {
+	storyName: 'With Live kicker but no line break',
+	render: ({ format }) => (
+		<Section fullWidth={true} showTopBorder={false} showSideBorders={false}>
+			<CardHeadline
+				headlineText="This is how a card headline with no kicker linebreak looks"
+				format={format}
+				kickerText="Live"
+				hideLineBreak={true}
+			/>
+		</Section>
+	),
+	decorators: [
+		splitTheme([
+			{
 				display: ArticleDisplay.Standard,
 				design: ArticleDesign.Standard,
 				theme: Pillar.News,
-			}}
-			kickerText="Live"
-			hideLineBreak={true}
-		/>
-	</Section>
-);
-noLineBreak.storyName = 'With Live kicker but no line break';
+			},
+		]),
+	],
+};
 
-export const pulsingDot = () => (
-	<Section fullWidth={true} showTopBorder={false} showSideBorders={false}>
-		<CardHeadline
-			headlineText="This is how a card headline with a pulsing dot looks"
-			format={{
+export const pulsingDot: SplitThemeStory = {
+	storyName: 'With pulsing dot',
+	render: ({ format }: { format: ArticleFormat }) => (
+		<Section fullWidth={true} showTopBorder={false} showSideBorders={false}>
+			<CardHeadline
+				headlineText="This is how a card headline with a pulsing dot looks"
+				format={format}
+				kickerText="Live"
+				showPulsingDot={true}
+			/>
+		</Section>
+	),
+	decorators: [
+		splitTheme([
+			{
 				display: ArticleDisplay.Standard,
 				design: ArticleDesign.Standard,
 				theme: Pillar.News,
-			}}
-			kickerText="Live"
-			showPulsingDot={true}
-		/>
-	</Section>
-);
-pulsingDot.storyName = 'With pulsing dot';
+			},
+		]),
+	],
+};
 
-export const cultureVariant = () => (
-	<Section fullWidth={true} showTopBorder={false} showSideBorders={false}>
-		<CardHeadline
-			headlineText="This is how a Feature card headline with the culture pillar looks"
-			format={{
+export const cultureVariant: SplitThemeStory = {
+	storyName: 'With a culture kicker',
+	render: ({ format }) => (
+		<Section fullWidth={true} showTopBorder={false} showSideBorders={false}>
+			<CardHeadline
+				headlineText="This is how a Feature card headline with the culture pillar looks"
+				format={format}
+				kickerText="Art and stuff"
+			/>
+		</Section>
+	),
+	decorators: [
+		splitTheme([
+			{
 				display: ArticleDisplay.Standard,
 				design: ArticleDesign.Feature,
 				theme: Pillar.Culture,
-			}}
-			kickerText="Art and stuff"
-		/>
-	</Section>
-);
-cultureVariant.storyName = 'With a culture kicker';
+			},
+		]),
+	],
+};
 
-export const Opinion = () => (
-	<Section fullWidth={true} showTopBorder={false} showSideBorders={false}>
-		<CardHeadline
-			headlineText="This is how small card headline for opinion articles look"
-			format={{
+export const Opinion: SplitThemeStory = {
+	storyName: 'Opinion (Quotes)',
+	render: ({ format }: { format: ArticleFormat }) => (
+		<Section fullWidth={true} showTopBorder={false} showSideBorders={false}>
+			<CardHeadline
+				headlineText="This is how small card headline for opinion articles look"
+				format={format}
+				showQuotes={true}
+				size="small"
+			/>
+		</Section>
+	),
+	decorators: [
+		splitTheme([
+			{
 				display: ArticleDisplay.Standard,
 				design: ArticleDesign.Comment,
 				theme: Pillar.Opinion,
-			}}
-			showQuotes={true}
-			size="small"
-		/>
-	</Section>
-);
-Opinion.storyName = 'Opinion (Quotes)';
-
-export const OpinionKicker = () => (
-	<>
-		{smallHeadlineSizes.map((size) => (
-			<div key={size}>
-				<Section
-					fullWidth={true}
-					showTopBorder={false}
-					showSideBorders={false}
-				>
-					<CardHeadline
-						headlineText={`This is how a ${size} opinion card headline with a kicker and quotes looks`}
-						format={{
-							display: ArticleDisplay.Standard,
-							design: ArticleDesign.Standard,
-							theme: Pillar.Opinion,
-						}}
-						showQuotes={true}
-						kickerText="George Monbiot"
-						size={size}
-					/>
-				</Section>
-				<br />
-			</div>
-		))}
-	</>
-);
-OpinionKicker.storyName = 'With an opinion kicker';
-
-export const SpecialReport: StoryObj = ({
-	format,
-}: {
-	format: ArticleFormat;
-}) => (
-	<Section
-		fullWidth={true}
-		showTopBorder={false}
-		showSideBorders={false}
-		backgroundColour="grey"
-	>
-		<ContainerOverrides isDynamo={false}>
-			<CardHeadline
-				headlineText="This is how a Special Report card headline with kicker and quotes looks"
-				format={format}
-				showQuotes={true}
-				kickerText="Special Report"
-			/>
-		</ContainerOverrides>
-	</Section>
-);
-SpecialReport.storyName = 'With theme SpecialReport';
-SpecialReport.args = {
-	format: {
-		display: ArticleDisplay.Standard,
-		design: ArticleDesign.Standard,
-		theme: ArticleSpecial.SpecialReport,
-	},
+			},
+		]),
+	],
 };
 
-export const Busy = () => (
-	<Section fullWidth={true} showTopBorder={false} showSideBorders={false}>
-		<CardHeadline
-			headlineText="I look life a buffoon. I feel incredible. And then I vomit"
-			format={{
+export const OpinionKicker: SplitThemeStory = {
+	storyName: 'With an opinion kicker',
+	render: ({ format }) => (
+		<>
+			{smallHeadlineSizes.map((size) => (
+				<div key={size}>
+					<Section
+						fullWidth={true}
+						showTopBorder={false}
+						showSideBorders={false}
+					>
+						<CardHeadline
+							headlineText={`This is how a ${size} opinion card headline with a kicker and quotes looks`}
+							format={format}
+							showQuotes={true}
+							kickerText="George Monbiot"
+							size={size}
+						/>
+					</Section>
+					<br />
+				</div>
+			))}
+		</>
+	),
+	decorators: [
+		splitTheme([
+			{
 				display: ArticleDisplay.Standard,
-				design: ArticleDesign.Feature,
-				theme: Pillar.Lifestyle,
-			}}
-			showQuotes={true}
-			kickerText="Aerial Yoga"
-		/>
-	</Section>
-);
-Busy.storyName = 'Lifestyle opinion';
+				design: ArticleDesign.Standard,
+				theme: Pillar.Opinion,
+			},
+		]),
+	],
+};
 
-export const Byline: StoryObj = ({ format }: { format: ArticleFormat }) => (
-	<Section
-		fullWidth={true}
-		showSideBorders={false}
-		backgroundColour={
-			format.theme === ArticleSpecial.SpecialReport
-				? palette.specialReport[300]
-				: undefined
-		}
-	>
-		<ContainerOverrides isDynamo={false}>
+export const SpecialReport: SplitThemeStory = {
+	storyName: 'With theme SpecialReport',
+	render: ({ format }) => (
+		<Section
+			fullWidth={true}
+			showTopBorder={false}
+			showSideBorders={false}
+			backgroundColour="grey"
+		>
+			<ContainerOverrides isDynamo={false}>
+				<CardHeadline
+					headlineText="This is how a Special Report card headline with kicker and quotes looks"
+					format={format}
+					showQuotes={true}
+					kickerText="Special Report"
+				/>
+			</ContainerOverrides>
+		</Section>
+	),
+	decorators: [
+		splitTheme([
+			{
+				display: ArticleDisplay.Standard,
+				design: ArticleDesign.Standard,
+				theme: ArticleSpecial.SpecialReport,
+			},
+		]),
+	],
+};
+
+export const Busy: SplitThemeStory = {
+	storyName: 'Lifestyle opinion',
+	render: ({ format }: { format: ArticleFormat }) => (
+		<Section fullWidth={true} showTopBorder={false} showSideBorders={false}>
 			<CardHeadline
 				headlineText="I look life a buffoon. I feel incredible. And then I vomit"
 				format={format}
-				byline={`${
-					Pillar[format.theme] ??
-					ArticleSpecial[format.theme] ??
-					'Unknown'
-				} byline`}
-				showByline={true}
+				showQuotes={true}
+				kickerText="Aerial Yoga"
 			/>
-		</ContainerOverrides>
-	</Section>
-);
-Byline.storyName = 'With byline';
-Byline.decorators = [
-	splitTheme([
-		{
-			display: ArticleDisplay.Standard,
-			design: ArticleDesign.Feature,
-			theme: ArticleSpecial.Labs,
-		},
-		{
-			display: ArticleDisplay.Standard,
-			design: ArticleDesign.Feature,
-			theme: Pillar.News,
-		},
-		{
-			display: ArticleDisplay.Standard,
-			design: ArticleDesign.Feature,
-			theme: Pillar.Sport,
-		},
-		{
-			display: ArticleDisplay.Standard,
-			design: ArticleDesign.Feature,
-			theme: Pillar.Culture,
-		},
-		{
-			display: ArticleDisplay.Standard,
-			design: ArticleDesign.Feature,
-			theme: Pillar.Lifestyle,
-		},
-		{
-			display: ArticleDisplay.Standard,
-			design: ArticleDesign.Feature,
-			theme: Pillar.Opinion,
-		},
-		{
-			display: ArticleDisplay.Standard,
-			design: ArticleDesign.Feature,
-			theme: ArticleSpecial.SpecialReport,
-		},
-	]),
-];
+		</Section>
+	),
+	decorators: [
+		splitTheme([
+			{
+				display: ArticleDisplay.Standard,
+				design: ArticleDesign.Feature,
+				theme: Pillar.Lifestyle,
+			},
+		]),
+	],
+};
+
+export const Byline: SplitThemeStory = {
+	storyName: 'With byline',
+	render: ({ format }) => (
+		<Section
+			fullWidth={true}
+			showSideBorders={false}
+			backgroundColour={
+				format.theme === ArticleSpecial.SpecialReport
+					? palette.specialReport[300]
+					: undefined
+			}
+		>
+			<ContainerOverrides isDynamo={false}>
+				<CardHeadline
+					headlineText="I look life a buffoon. I feel incredible. And then I vomit"
+					format={format}
+					byline={`${
+						Pillar[format.theme] ??
+						ArticleSpecial[format.theme] ??
+						'Unknown'
+					} byline`}
+					showByline={true}
+				/>
+			</ContainerOverrides>
+		</Section>
+	),
+	decorators: [
+		splitTheme([
+			{
+				display: ArticleDisplay.Standard,
+				design: ArticleDesign.Feature,
+				theme: ArticleSpecial.Labs,
+			},
+			{
+				display: ArticleDisplay.Standard,
+				design: ArticleDesign.Feature,
+				theme: Pillar.News,
+			},
+			{
+				display: ArticleDisplay.Standard,
+				design: ArticleDesign.Feature,
+				theme: Pillar.Sport,
+			},
+			{
+				display: ArticleDisplay.Standard,
+				design: ArticleDesign.Feature,
+				theme: Pillar.Culture,
+			},
+			{
+				display: ArticleDisplay.Standard,
+				design: ArticleDesign.Feature,
+				theme: Pillar.Lifestyle,
+			},
+			{
+				display: ArticleDisplay.Standard,
+				design: ArticleDesign.Feature,
+				theme: Pillar.Opinion,
+			},
+			{
+				display: ArticleDisplay.Standard,
+				design: ArticleDesign.Feature,
+				theme: ArticleSpecial.SpecialReport,
+			},
+		]),
+	],
+};
 
 const containerPalettes = [
 	'EventPalette',
@@ -435,37 +479,35 @@ const containerPalettes = [
 	'MediaPalette',
 	'PodcastPalette',
 ] as const satisfies readonly DCRContainerPalette[];
-export const WithContainerOverrides: StoryObj = ({
-	format,
-}: {
-	format: ArticleFormat;
-}) => (
-	<>
-		{containerPalettes.map((containerPalette) => (
-			<Section
-				key={containerPalette}
-				fullWidth={true}
-				showSideBorders={false}
-				containerPalette={containerPalette}
-			>
-				<ContainerOverrides
+export const WithContainerOverrides: SplitThemeStory = {
+	render: ({ format }) => (
+		<>
+			{containerPalettes.map((containerPalette) => (
+				<Section
+					key={containerPalette}
+					fullWidth={true}
+					showSideBorders={false}
 					containerPalette={containerPalette}
-					isDynamo={false}
 				>
-					<CardHeadline
-						headlineText={`This is a ${
-							Pillar[format.theme] ??
-							ArticleSpecial[format.theme] ??
-							'Unknown'
-						} headline`}
+					<ContainerOverrides
 						containerPalette={containerPalette}
-						format={format}
-						byline={`inside a ${containerPalette} container`}
-						showByline={true}
-					/>
-				</ContainerOverrides>
-			</Section>
-		))}
-	</>
-);
-WithContainerOverrides.decorators = [splitTheme()];
+						isDynamo={false}
+					>
+						<CardHeadline
+							headlineText={`This is a ${
+								Pillar[format.theme] ??
+								ArticleSpecial[format.theme] ??
+								'Unknown'
+							} headline`}
+							containerPalette={containerPalette}
+							format={format}
+							byline={`inside a ${containerPalette} container`}
+							showByline={true}
+						/>
+					</ContainerOverrides>
+				</Section>
+			))}
+		</>
+	),
+	decorators: [splitTheme()],
+};


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Create a custom type that helps create CSF v3 stories when using `splitTheme`, so that we get the format inferred automatically.

## Why?

It can get pretty confusing otherwise

Follow-up on #9430