### PR TITLE
Simplify label styles

### DIFF
--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -94,22 +94,10 @@ export const labelStyles = css`
 		visibility: hidden;
 	}
 
-	.ad-slot[data-label-show='true']:not(.ad-slot--interscroller):not(
-			.ad-slot--merchandising
-		):not(.ad-slot--merchandising-high)::before {
+	.ad-slot[data-label-show='true']:not(.ad-slot--interscroller)::before {
 		content: attr(ad-label-text);
 		display: block;
 		position: relative;
-		${individualLabelCSS}
-	}
-
-	.ad-slot--merchandising[data-label-show='true']::before,
-	.ad-slot--merchandising-high[data-label-show='true']::before {
-		content: attr(ad-label-text);
-		display: block;
-		position: relative;
-		max-width: 970px;
-		margin: auto;
 		${individualLabelCSS}
 	}
 


### PR DESCRIPTION
## What does this change?
We no longer set a fixed max-width on merchandising slots containing ads.

## Why?
We want the label to stretch to fit fabric ads in these slots.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![Screenshot 2023-09-22 at 12 24 50 (1)](https://github.com/guardian/dotcom-rendering/assets/108270776/7bb912f0-c455-4963-a46c-4d27e7ca7cd0) | <img width="1341" alt="Screenshot 2023-11-15 at 12 05 58" src="https://github.com/guardian/dotcom-rendering/assets/108270776/88a722f2-02fb-4fab-9fd3-6fff5a936374"> |

