### PR TITLE
Add Labs layout stories

### DIFF
--- a/dotcom-rendering/scripts/gen-stories/get-stories.mjs
+++ b/dotcom-rendering/scripts/gen-stories/get-stories.mjs
@@ -169,7 +169,7 @@ const generateLayoutStory = (displayName, designName, theme, config) => {
 		];`
 				: ''
 		}
-	`;
+`;
 };
 
 /**
@@ -245,6 +245,30 @@ const testLayoutFormats =
 			design: 'Standard',
 			theme: 'NewsPillar',
 			config: { renderingTarget: 'Apps', darkModeAvailable: false },
+		},
+		{
+			display: 'Immersive',
+			design: 'PhotoEssay',
+			theme: 'Labs',
+			config: { renderingTarget: 'Web', darkModeAvailable: false },
+		},
+		{
+			display: 'Standard',
+			design: 'Standard',
+			theme: 'Labs',
+			config: { renderingTarget: 'Web', darkModeAvailable: false },
+		},
+		{
+			display: 'Standard',
+			design: 'Feature',
+			theme: 'Labs',
+			config: { renderingTarget: 'Web', darkModeAvailable: false },
+		},
+		{
+			display: 'Standard',
+			design: 'Recipe',
+			theme: 'Labs',
+			config: { renderingTarget: 'Web', darkModeAvailable: false },
 		},
 	]);
 

--- a/dotcom-rendering/stories/generated/Layout.stories.tsx
+++ b/dotcom-rendering/stories/generated/Layout.stories.tsx
@@ -42,7 +42,7 @@ export default {
 		];
 
 		
-	
+
 		export const AppsStandardStandardNewsPillarLight = () => {
 			return (
 				<HydratedLayoutWrapper
@@ -84,7 +84,7 @@ export default {
 				}]
 			),
 		];
-	
+
 		export const AppsShowcaseStandardNewsPillarLight = () => {
 			return (
 				<HydratedLayoutWrapper
@@ -107,7 +107,7 @@ export default {
 		];
 
 		
-	
+
 		export const WebShowcasePictureOpinionPillarLight = () => {
 			return (
 				<HydratedLayoutWrapper
@@ -130,7 +130,7 @@ export default {
 		];
 
 		
-	
+
 		export const AppsShowcasePictureOpinionPillarLight = () => {
 			return (
 				<HydratedLayoutWrapper
@@ -153,7 +153,7 @@ export default {
 		];
 
 		
-	
+
 		export const AppsStandardCommentNewsPillarLight = () => {
 			return (
 				<HydratedLayoutWrapper
@@ -176,7 +176,7 @@ export default {
 		];
 
 		
-	
+
 		export const AppsStandardInteractiveNewsPillarLight = () => {
 			return (
 				<HydratedLayoutWrapper
@@ -199,7 +199,7 @@ export default {
 		];
 
 		
-	
+
 		export const AppsImmersiveStandardNewsPillarLight = () => {
 			return (
 				<HydratedLayoutWrapper
@@ -222,4 +222,95 @@ export default {
 		];
 
 		
-	
+
+		export const WebImmersivePhotoEssayLabsLight = () => {
+			return (
+				<HydratedLayoutWrapper
+					displayName="Immersive"
+					designName="PhotoEssay"
+					theme="Labs"
+					renderingTarget="Web"
+				/>
+			);
+		};
+		WebImmersivePhotoEssayLabsLight.storyName = 'Web: Display: Immersive, Design: PhotoEssay, Theme: Labs, Mode: Light';
+		WebImmersivePhotoEssayLabsLight.parameters = { config: {"renderingTarget":"Web","darkModeAvailable":false} };
+		WebImmersivePhotoEssayLabsLight.decorators = [lightDecorator(
+				[{
+					display:  ArticleDisplay.Immersive,
+					design: ArticleDesign.PhotoEssay,
+					theme: {...ArticleSpecial, ...Pillar}.Labs,
+				}]
+			),
+		];
+
+		
+
+		export const WebStandardStandardLabsLight = () => {
+			return (
+				<HydratedLayoutWrapper
+					displayName="Standard"
+					designName="Standard"
+					theme="Labs"
+					renderingTarget="Web"
+				/>
+			);
+		};
+		WebStandardStandardLabsLight.storyName = 'Web: Display: Standard, Design: Standard, Theme: Labs, Mode: Light';
+		WebStandardStandardLabsLight.parameters = { config: {"renderingTarget":"Web","darkModeAvailable":false} };
+		WebStandardStandardLabsLight.decorators = [lightDecorator(
+				[{
+					display:  ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: {...ArticleSpecial, ...Pillar}.Labs,
+				}]
+			),
+		];
+
+		
+
+		export const WebStandardFeatureLabsLight = () => {
+			return (
+				<HydratedLayoutWrapper
+					displayName="Standard"
+					designName="Feature"
+					theme="Labs"
+					renderingTarget="Web"
+				/>
+			);
+		};
+		WebStandardFeatureLabsLight.storyName = 'Web: Display: Standard, Design: Feature, Theme: Labs, Mode: Light';
+		WebStandardFeatureLabsLight.parameters = { config: {"renderingTarget":"Web","darkModeAvailable":false} };
+		WebStandardFeatureLabsLight.decorators = [lightDecorator(
+				[{
+					display:  ArticleDisplay.Standard,
+					design: ArticleDesign.Feature,
+					theme: {...ArticleSpecial, ...Pillar}.Labs,
+				}]
+			),
+		];
+
+		
+
+		export const WebStandardRecipeLabsLight = () => {
+			return (
+				<HydratedLayoutWrapper
+					displayName="Standard"
+					designName="Recipe"
+					theme="Labs"
+					renderingTarget="Web"
+				/>
+			);
+		};
+		WebStandardRecipeLabsLight.storyName = 'Web: Display: Standard, Design: Recipe, Theme: Labs, Mode: Light';
+		WebStandardRecipeLabsLight.parameters = { config: {"renderingTarget":"Web","darkModeAvailable":false} };
+		WebStandardRecipeLabsLight.decorators = [lightDecorator(
+				[{
+					display:  ArticleDisplay.Standard,
+					design: ArticleDesign.Recipe,
+					theme: {...ArticleSpecial, ...Pillar}.Labs,
+				}]
+			),
+		];
+
+		


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Add three Labs stories.

## Why?

These types of stories are used frequently and we need not forget them

## Screenshots

https://www.theguardian.com/help-at-home/2023/oct/31/i-lost-myself-looking-after-my-dad-with-dementia-how-home-carers-enabled-a-daughter-to-regain-her-independence

<img width="1728" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/76776/c2fa8948-bab3-4ab8-9f11-c91169b2ba9a">

https://www.theguardian.com/spread-deliciousness/2023/nov/15/brioche-and-chocolate-spread-i-call-it-pure-nostalgia-ilhan-mohameds-week-in-snacks

<img width="1728" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/76776/a988f1f4-76e2-4d3b-a8a8-ba1352d69e73">

https://www.theguardian.com/making-modern-teachers/2023/nov/01/children-make-you-laugh-so-much-three-teachers-on-the-joys-and-challenges-of-teaching

<img width="1322" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/76776/313d6a4e-d050-4c8b-aa59-10b2bbf8cbb0">
