### PR TITLE
Update storybook decorators to use correct light/dark text colours

### DIFF
--- a/dotcom-rendering/.storybook/decorators/themeDecorator.tsx
+++ b/dotcom-rendering/.storybook/decorators/themeDecorator.tsx
@@ -12,11 +12,11 @@ import { ArticleFormat } from '@guardian/libs';
 
 const darkStoryCss = css`
 	background-color: ${sourcePalette.neutral[0]};
-	color: ${sourcePalette.neutral[100]};
+	color: ${sourcePalette.neutral[97]};
 `;
 const lightStoryCss = css`
 	background-color: ${sourcePalette.neutral[100]};
-	color: ${sourcePalette.neutral[0]};
+	color: ${sourcePalette.neutral[7]};
 `;
 
 // ----- Decorators ----- //


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Update storybook decorators to use correct text colours for light and dark mode. 


## Screenshots
See chromatic
Note: There are a lot of chromatic changes for this PR. This is because all of the default colour text has been updated from neutral[0] to neutral[7] which affects all stories. I've reviewed a random subset and then approved the others as there's >400 and they're expected changes.

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
