### PR TITLE
Make `CommentCount` Island server-safe

### DIFF
--- a/dotcom-rendering/src/components/ArticleMeta.tsx
+++ b/dotcom-rendering/src/components/ArticleMeta.tsx
@@ -446,7 +446,6 @@ export const ArticleMeta = ({
 								{isCommentable && (
 									<Island
 										priority="feature"
-										clientOnly={true}
 										defer={{ until: 'idle' }}
 									>
 										<CommentCount

--- a/dotcom-rendering/src/components/CommentCount.importable.tsx
+++ b/dotcom-rendering/src/components/CommentCount.importable.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import { isUndefined } from '@guardian/libs';
 import { between, textSans, until } from '@guardian/source-foundations';
 import { decidePalette } from '../lib/decidePalette';
 import { formatCount } from '../lib/formatCount';
@@ -90,7 +91,7 @@ export const CommentCount = ({
 	const commentCount = useCommentCount(discussionApiUrl, shortUrlId);
 
 	// If the comment count is 0 we still want to display it
-	if (commentCount === undefined) return null;
+	if (isUndefined(commentCount)) return null;
 
 	const { short, long } = formatCount(commentCount);
 	const palette = decidePalette(format);

--- a/dotcom-rendering/src/components/Island.test.tsx
+++ b/dotcom-rendering/src/components/Island.test.tsx
@@ -7,6 +7,7 @@ import { renderToString } from 'react-dom/server';
 import { AlreadyVisited } from './AlreadyVisited.importable';
 import { BrazeMessaging } from './BrazeMessaging.importable';
 import { CardCommentCount } from './CardCommentCount.importable';
+import { CommentCount } from './CommentCount.importable';
 import { ConfigProvider } from './ConfigContext';
 import { EnhancePinnedPost } from './EnhancePinnedPost.importable';
 import { FocusStyles } from './FocusStyles.importable';
@@ -117,6 +118,22 @@ describe('Island: server-side rendering', () => {
 					}}
 					discussionApiUrl=""
 					discussionId=""
+				/>,
+			),
+		).not.toThrow();
+	});
+
+	test('CommentCount', () => {
+		expect(() =>
+			renderToString(
+				<CommentCount
+					format={{
+						theme: Pillar.News,
+						design: ArticleDesign.Standard,
+						display: ArticleDisplay.Standard,
+					}}
+					discussionApiUrl=""
+					shortUrlId=""
 				/>,
 			),
 		).not.toThrow();


### PR DESCRIPTION
## What does this change?

Ensure `CommentCount` Island is server safe, and no longer client-side only.

## Why?

No assumption should be made about where components are run

- Split out from #8991 for easier review
- Enables the work from #8948 to proceed safely.