### PR TITLE
Add new ad slot centring class

### DIFF
--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -130,8 +130,8 @@ const adContainerCollapseStyles = css`
 	}
 `;
 
-const adContainerCentredSlotStyles = css`
-	&.ad-slot-container--centred-slot {
+const adContainerCentreSlotStyles = css`
+	&.ad-slot-container--centre-slot {
 		width: fit-content;
 		margin: 0 auto;
 	}
@@ -404,7 +404,7 @@ const mobileStickyAdStyles = css`
 export const adContainerStyles = [
 	adContainerCollapseStyles,
 	labelStyles,
-	adContainerCentredSlotStyles,
+	adContainerCentreSlotStyles,
 ];
 
 export const AdSlot = ({

--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -130,6 +130,13 @@ const adContainerCollapseStyles = css`
 	}
 `;
 
+const adContainerCentredSlotStyles = css`
+	&.ad-slot-container--centred-slot {
+		width: fit-content;
+		margin: 0 auto;
+	}
+`;
+
 const adSlotCollapseStyles = css`
 	&.ad-slot.ad-slot--collapse {
 		display: none;
@@ -394,7 +401,11 @@ const mobileStickyAdStyles = css`
 	}
 `;
 
-export const adContainerStyles = [adContainerCollapseStyles, labelStyles];
+export const adContainerStyles = [
+	adContainerCollapseStyles,
+	labelStyles,
+	adContainerCentredSlotStyles,
+];
 
 export const AdSlot = ({
 	position,

--- a/dotcom-rendering/src/components/HeaderAdSlot.tsx
+++ b/dotcom-rendering/src/components/HeaderAdSlot.tsx
@@ -31,6 +31,7 @@ const headerAdWrapper = css`
 	top: 0;
 `;
 
+// Remove this once new `ad-slot-container--centre-slot` class is in place
 const topAboveNavContainer = css`
 	&[top-above-nav-ad-rendered] {
 		width: fit-content;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Add the `ad-slot-container--centre-slot` class to replace the `top-above-nav-ad-rendered` attribute.

## Why?
So it can semantically be reused for the merchandising slots

More details in the [Frontend PR](https://github.com/guardian/frontend/pull/26694)