### PR TITLE
Make `DiscussionMeta` Island no longer client-side only

### DIFF
--- a/dotcom-rendering/src/components/DiscussionLayout.tsx
+++ b/dotcom-rendering/src/components/DiscussionLayout.tsx
@@ -44,11 +44,7 @@ export const DiscussionLayout = ({
 				// If we're not hiding an advert stretch to the right
 				stretchRight={!hideAd}
 				leftContent={
-					<Island
-						priority="feature"
-						clientOnly={true}
-						defer={{ until: 'visible' }}
-					>
+					<Island priority="feature" defer={{ until: 'visible' }}>
 						<DiscussionMeta
 							format={format}
 							discussionApiUrl={discussionApiUrl}

--- a/dotcom-rendering/src/components/Island.test.tsx
+++ b/dotcom-rendering/src/components/Island.test.tsx
@@ -9,6 +9,7 @@ import { BrazeMessaging } from './BrazeMessaging.importable';
 import { CardCommentCount } from './CardCommentCount.importable';
 import { CommentCount } from './CommentCount.importable';
 import { ConfigProvider } from './ConfigContext';
+import { DiscussionMeta } from './DiscussionMeta.importable';
 import { EnhancePinnedPost } from './EnhancePinnedPost.importable';
 import { FocusStyles } from './FocusStyles.importable';
 import { InteractiveSupportButton } from './InteractiveSupportButton.importable';
@@ -137,6 +138,23 @@ describe('Island: server-side rendering', () => {
 				/>,
 			),
 		).not.toThrow();
+	});
+
+	test('DiscussionMeta', () => {
+		expect(() =>
+			renderToString(
+				<DiscussionMeta
+					format={{
+						theme: Pillar.News,
+						design: ArticleDesign.Standard,
+						display: ArticleDisplay.Standard,
+					}}
+					discussionApiUrl={''}
+					shortUrlId={''}
+					enableDiscussionSwitch={false}
+				/>,
+			),
+		);
 	});
 
 	test('EnhancePinnedPost', () => {


### PR DESCRIPTION
## What does this change?

Ensure the `DiscussionMeta` Island is server safe, and no longer client-side only.

This means that it nows render some placeholder content on the server that instead of a 🕳️.

## Why?

No assumption should be made about where components are run

- Split out from #8991 for easier review
- Enables the work from #8948 to proceed safely.

## Screenshots

A much better server palceholder!

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/76776/c616b551-e2e5-41ba-9c68-686d41b64d03
[after]: https://github.com/guardian/dotcom-rendering/assets/76776/b0c1360d-ff74-484f-9597-37e888b7ad63
