### PR TITLE
Hide merchandising slots from desktop breakpoints when there is a page skin

### DIFF
--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
-import { adSizes, constants } from '@guardian/commercial';
 import type { SlotName } from '@guardian/commercial';
+import { adSizes, constants } from '@guardian/commercial';
 import { ArticleDisplay } from '@guardian/libs';
 import {
 	breakpoints,
@@ -10,7 +10,6 @@ import {
 	textSans,
 	until,
 } from '@guardian/source-foundations';
-import { pageSkinContainer } from '../layouts/lib/pageSkin';
 import { getZIndex } from '../lib/getZIndex';
 import { TopRightAdSlot } from './TopRightAdSlot';
 

--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -526,11 +526,7 @@ export const AdSlot = ({
 			return (
 				<div
 					className="ad-slot-container"
-					css={[
-						merchandisingAdContainerStyles,
-						hasPageskin && pageSkinContainer,
-						adContainerStyles,
-					]}
+					css={[merchandisingAdContainerStyles, adContainerStyles]}
 				>
 					<div
 						id="dfp-ad--merchandising-high"

--- a/dotcom-rendering/src/components/DecideFrontsAdSlots.tsx
+++ b/dotcom-rendering/src/components/DecideFrontsAdSlots.tsx
@@ -1,6 +1,9 @@
+import { neutral } from '@guardian/source-foundations';
 import { Hide } from '@guardian/source-react-components';
+import type { ReactNode } from 'react';
 import { getMerchHighPosition } from '../lib/getFrontsAdPositions';
 import { AdSlot } from './AdSlot.web';
+import { Section } from './Section';
 
 export const decideMerchHighAndMobileAdSlots = (
 	renderAds: boolean,
@@ -42,6 +45,42 @@ export const decideMerchHighAndMobileAdSlots = (
 	}
 
 	return null;
+};
+
+/**
+ * Hide the merchandising slot if there is a page skin and above desktop breakpoint
+ * Page skins are only active above desktop breakpoints
+ *
+ */
+export const decideMerchandisingSlot = (
+	renderAds: boolean,
+	hasPageSkin: boolean,
+) => {
+	if (!renderAds) return null;
+	const MerchandisingSection = ({ children }: { children: ReactNode }) => (
+		<Section
+			fullWidth={true}
+			data-print-layout="hide"
+			padSides={false}
+			showTopBorder={false}
+			showSideBorders={false}
+			backgroundColour={neutral[93]}
+			element="aside"
+		>
+			{children}
+		</Section>
+	);
+	return hasPageSkin ? (
+		<MerchandisingSection>
+			<Hide from="desktop">
+				<AdSlot data-print-layout="hide" position="merchandising" />
+			</Hide>
+		</MerchandisingSection>
+	) : (
+		<MerchandisingSection>
+			<AdSlot data-print-layout="hide" position="merchandising" />
+		</MerchandisingSection>
+	);
 };
 
 /**

--- a/dotcom-rendering/src/components/DecideFrontsAdSlots.tsx
+++ b/dotcom-rendering/src/components/DecideFrontsAdSlots.tsx
@@ -14,6 +14,7 @@ export const decideMerchHighAndMobileAdSlots = (
 
 	const minContainers = isPaidContent ? 1 : 2;
 	const shouldInsertMerchHighSlot =
+		!hasPageSkin &&
 		collectionCount > minContainers &&
 		index === getMerchHighPosition(collectionCount);
 
@@ -23,7 +24,6 @@ export const decideMerchHighAndMobileAdSlots = (
 				<AdSlot
 					data-print-layout="hide"
 					position="merchandising-high"
-					hasPageskin={hasPageSkin}
 				/>
 			</Hide>
 		);

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -18,6 +18,7 @@ import { CPScottHeader } from '../components/CPScottHeader';
 import { DecideContainer } from '../components/DecideContainer';
 import {
 	decideFrontsBannerAdSlot,
+	decideMerchandisingSlot,
 	decideMerchHighAndMobileAdSlots,
 } from '../components/DecideFrontsAdSlots';
 import { Footer } from '../components/Footer';
@@ -662,6 +663,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 					);
 				})}
 			</main>
+
 			<Section
 				fullWidth={true}
 				showTopBorder={false}
@@ -671,19 +673,8 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 			>
 				<TrendingTopics trendingTopics={front.trendingTopics} />
 			</Section>
-			{renderAds && !hasPageSkin && (
-				<Section
-					fullWidth={true}
-					data-print-layout="hide"
-					padSides={false}
-					showTopBorder={false}
-					showSideBorders={false}
-					backgroundColour={neutral[93]}
-					element="aside"
-				>
-					<AdSlot position="merchandising" />
-				</Section>
-			)}
+
+			{decideMerchandisingSlot(renderAds, hasPageSkin)}
 
 			{NAV.subNavSections && (
 				<Section

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -671,7 +671,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 			>
 				<TrendingTopics trendingTopics={front.trendingTopics} />
 			</Section>
-			{renderAds && (
+			{renderAds && !hasPageSkin && (
 				<Section
 					fullWidth={true}
 					data-print-layout="hide"
@@ -680,7 +680,6 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 					showSideBorders={false}
 					backgroundColour={neutral[93]}
 					element="aside"
-					hasPageSkin={hasPageSkin}
 				>
 					<AdSlot position="merchandising" />
 				</Section>

--- a/dotcom-rendering/src/layouts/TagFrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/TagFrontLayout.tsx
@@ -340,17 +340,19 @@ export const TagFrontLayout = ({ tagFront, NAV }: Props) => {
 			>
 				<TrendingTopics trendingTopics={tagFront.trendingTopics} />
 			</Section>
-			<Section
-				fullWidth={true}
-				data-print-layout="hide"
-				padSides={false}
-				showTopBorder={false}
-				showSideBorders={false}
-				backgroundColour={neutral[93]}
-				element="aside"
-			>
-				<AdSlot position="merchandising" display={format.display} />
-			</Section>
+			{renderAds && !hasPageSkin && (
+				<Section
+					fullWidth={true}
+					data-print-layout="hide"
+					padSides={false}
+					showTopBorder={false}
+					showSideBorders={false}
+					backgroundColour={neutral[93]}
+					element="aside"
+				>
+					<AdSlot position="merchandising" display={format.display} />
+				</Section>
+			)}
 
 			{NAV.subNavSections && (
 				<Section

--- a/dotcom-rendering/src/layouts/TagFrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/TagFrontLayout.tsx
@@ -11,10 +11,10 @@ import {
 } from '@guardian/source-foundations';
 import { StraightLines } from '@guardian/source-react-components-development-kitchen';
 import { Fragment } from 'react';
-import { AdSlot } from '../components/AdSlot.web';
 import { DecideContainerByTrails } from '../components/DecideContainerByTrails';
 import {
 	decideFrontsBannerAdSlot,
+	decideMerchandisingSlot,
 	decideMerchHighAndMobileAdSlots,
 } from '../components/DecideFrontsAdSlots';
 import { Footer } from '../components/Footer';
@@ -333,6 +333,7 @@ export const TagFrontLayout = ({ tagFront, NAV }: Props) => {
 					);
 				})}
 			</main>
+
 			<Section
 				fullWidth={true}
 				showTopBorder={false}
@@ -340,19 +341,8 @@ export const TagFrontLayout = ({ tagFront, NAV }: Props) => {
 			>
 				<TrendingTopics trendingTopics={tagFront.trendingTopics} />
 			</Section>
-			{renderAds && !hasPageSkin && (
-				<Section
-					fullWidth={true}
-					data-print-layout="hide"
-					padSides={false}
-					showTopBorder={false}
-					showSideBorders={false}
-					backgroundColour={neutral[93]}
-					element="aside"
-				>
-					<AdSlot position="merchandising" display={format.display} />
-				</Section>
-			)}
+
+			{decideMerchandisingSlot(renderAds, hasPageSkin)}
 
 			{NAV.subNavSections && (
 				<Section


### PR DESCRIPTION
## What does this change?

The merchandising slots (`merchandising-high` and `merchandising`) although ad slots are typically used for internal marketing.

For Black Friday we want to experiment with running ads in merchandising slots rather than internal marketing.

This means if there is a page skin takeover we should not render the merchandising slots as they may contain ads which break the 'takeover' agreement i.e. we only show ads for one client and they takeover the page.

A slight detail is that page skins are only shown from desktop breakpoints onwards. Given we SSR the front layout we don't know the active breakpoint at render time. So instead we use media queries to hide the merch slots above desktop if there is a page skin.

This change updates the front layouts (regular and tag) to not show the merchandising slots when there is a page skin.

