### PR TITLE
Add margin-bottom to merch-high and merch in Fronts and Articles

### DIFF
--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -194,6 +194,11 @@ const topAboveNavStyles = css`
 const merchandisingAdContainerStyles = css`
 	display: flex;
 	justify-content: center;
+	margin: 0 auto 12px;
+
+	${from.desktop} {
+		margin: 0 auto 20px;
+	}
 `;
 
 const merchandisingAdStyles = css`

--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -194,16 +194,17 @@ const topAboveNavStyles = css`
 const merchandisingAdContainerStyles = css`
 	display: flex;
 	justify-content: center;
-	margin: 0 auto 12px;
-
-	${from.desktop} {
-		margin: 0 auto 20px;
-	}
 `;
 
 const merchandisingAdStyles = css`
 	position: relative;
 	min-height: ${adSizes.billboard.height}px;
+	margin: 12px auto;
+
+	${from.tablet} {
+		margin: 0
+		padding-bottom: 20px;
+	}
 `;
 
 const inlineAdStyles = css`

--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -202,7 +202,7 @@ const merchandisingAdStyles = css`
 	margin: 12px auto;
 
 	${from.tablet} {
-		margin: 0
+		margin: 0;
 		padding-bottom: 20px;
 	}
 `;

--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -201,7 +201,7 @@ const merchandisingAdStyles = css`
 	min-height: ${adSizes.billboard.height}px;
 	margin: 12px auto;
 
-	${from.tablet} {
+	${from.desktop} {
 		margin: 0;
 		padding-bottom: 20px;
 	}

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -689,7 +689,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 			{NAV.subNavSections && (
 				<Section
 					fullWidth={true}
-					showTopBorder={hasPageSkin}
+					showTopBorder={true}
 					data-print-layout="hide"
 					padSides={false}
 					element="aside"

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -689,7 +689,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 			{NAV.subNavSections && (
 				<Section
 					fullWidth={true}
-					showTopBorder={true}
+					showTopBorder={hasPageSkin}
 					data-print-layout="hide"
 					padSides={false}
 					element="aside"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

This PR adds more space to the bottom of the merch-high and merch containers.  

1. Added `12px` margin top and bottom to merch-high and merch in Fronts and Articles on mobile.
2. Added `0` margin and `20px` padding bottom to merch and merch-high in Articles and merch in Fronts on desktop.  

## Why?

Better UI before Black Friday!

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![image](https://github.com/guardian/dotcom-rendering/assets/23424805/618de87c-51bd-4e01-a594-27ab29f1f093) | ![image](https://github.com/guardian/dotcom-rendering/assets/23424805/ea7bd357-44d5-4118-b25f-a58c7c0235c4) |
| ![image](https://github.com/guardian/dotcom-rendering/assets/23424805/fa27a3cf-6a95-4d59-b851-7f143e0c4a6c) | ![image](https://github.com/guardian/dotcom-rendering/assets/23424805/2f8eee15-ca5c-4005-a50a-e796c44473df) |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
