### PR TITLE
Revert "Filter trails"

### DIFF
--- a/dotcom-rendering/src/components/FetchOnwardsData.importable.tsx
+++ b/dotcom-rendering/src/components/FetchOnwardsData.importable.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import { ArticleDesign, isNonNullable } from '@guardian/libs';
 import { useEffect } from 'react';
-import { decideTrail, filterTrails } from '../lib/decideTrail';
+import { decideTrail } from '../lib/decideTrail';
 import { revealStyles } from '../lib/revealStyles';
 import { useApi } from '../lib/useApi';
 import { addDiscussionIds } from '../lib/useCommentCount';
@@ -42,7 +42,7 @@ export const FetchOnwardsData = ({
 		trails: FETrailType[],
 		trailLimit: number,
 	): TrailType[] => {
-		return filterTrails(trails).slice(0, trailLimit).map(decideTrail);
+		return trails.slice(0, trailLimit).map(decideTrail);
 	};
 
 	useEffect(() => {

--- a/dotcom-rendering/src/components/FrontMostViewed.tsx
+++ b/dotcom-rendering/src/components/FrontMostViewed.tsx
@@ -1,4 +1,3 @@
-import { filterTrails } from '../lib/decideTrail';
 import type { EditionId } from '../lib/edition';
 import type { DCRFrontCard } from '../types/front';
 import type { TrailTabType, TrailType } from '../types/trails';
@@ -41,7 +40,15 @@ export const FrontMostViewed = ({
 	const tabs: TrailTabType[] = [
 		{
 			heading: localisedTitle(sectionName, editionId),
-			trails: filterTrails(trails).slice(0, 10),
+			trails: trails
+				.filter(
+					(trail) =>
+						/* TODO: remove this once we have a better solution
+						for filtering undesired articles See issue:
+						https://github.com/guardian/dotcom-rendering/issues/9528 */
+						trail.url !== '/info/2023/nov/15/removed-document',
+				)
+				.slice(0, 10),
 		},
 	];
 

--- a/dotcom-rendering/src/components/FrontMostViewed.tsx
+++ b/dotcom-rendering/src/components/FrontMostViewed.tsx
@@ -40,15 +40,7 @@ export const FrontMostViewed = ({
 	const tabs: TrailTabType[] = [
 		{
 			heading: localisedTitle(sectionName, editionId),
-			trails: trails
-				.filter(
-					(trail) =>
-						/* TODO: remove this once we have a better solution
-						for filtering undesired articles See issue:
-						https://github.com/guardian/dotcom-rendering/issues/9528 */
-						trail.url !== '/info/2023/nov/15/removed-document',
-				)
-				.slice(0, 10),
+			trails: trails.slice(0, 10),
 		},
 	];
 

--- a/dotcom-rendering/src/components/MostViewedFooterData.importable.tsx
+++ b/dotcom-rendering/src/components/MostViewedFooterData.importable.tsx
@@ -1,7 +1,7 @@
 import { joinUrl, log } from '@guardian/libs';
 import { abTestTest } from '../experiments/tests/ab-test-test';
 import { decidePalette } from '../lib/decidePalette';
-import { decideTrail, filterTrails } from '../lib/decideTrail';
+import { decideTrail } from '../lib/decideTrail';
 import type { EditionId } from '../lib/edition';
 import { useAB } from '../lib/useAB';
 import { useApi } from '../lib/useApi';
@@ -45,7 +45,7 @@ function buildSectionUrl(
 function transformTabs(tabs: FETrailTabType[]): TrailTabType[] {
 	return tabs.map((tab) => ({
 		...tab,
-		trails: filterTrails(tab.trails).map((trail) => decideTrail(trail)),
+		trails: tab.trails.map((trail) => decideTrail(trail)),
 	}));
 }
 

--- a/dotcom-rendering/src/components/MostViewedRight.tsx
+++ b/dotcom-rendering/src/components/MostViewedRight.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import { headline } from '@guardian/source-foundations';
 import { StraightLines } from '@guardian/source-react-components-development-kitchen';
-import { decideTrail, filterTrails } from '../lib/decideTrail';
+import { decideTrail } from '../lib/decideTrail';
 import { useApi } from '../lib/useApi';
 import type { FETrailTabType, TrailType } from '../types/trails';
 import { MostViewedRightItem } from './MostViewedRightItem';
@@ -42,7 +42,7 @@ export const MostViewedRight = ({
 	}
 
 	if (data) {
-		const trails: TrailType[] = filterTrails(data.trails)
+		const trails: TrailType[] = data.trails
 			.slice(0, limitItems)
 			.map(decideTrail);
 

--- a/dotcom-rendering/src/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/layouts/CommentLayout.tsx
@@ -45,7 +45,7 @@ import { getSoleContributor } from '../lib/byline';
 import { canRenderAds } from '../lib/canRenderAds';
 import { getContributionsServiceUrl } from '../lib/contributions';
 import { decidePalette } from '../lib/decidePalette';
-import { decideTrail, filterTrails } from '../lib/decideTrail';
+import { decideTrail } from '../lib/decideTrail';
 import { parse } from '../lib/slot-machine-flags';
 import type { NavType } from '../model/extract-nav';
 import type { DCRArticle } from '../types/frontend';
@@ -737,9 +737,9 @@ export const CommentLayout = (props: WebProps | AppsProps) => {
 						<Island priority="feature" defer={{ until: 'visible' }}>
 							<Carousel
 								heading={article.storyPackage.heading}
-								trails={filterTrails(
-									article.storyPackage.trails,
-								).map(decideTrail)}
+								trails={article.storyPackage.trails.map(
+									decideTrail,
+								)}
 								onwardsSource="more-on-this-story"
 								format={format}
 								leftColSize={'compact'}

--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -48,7 +48,7 @@ import { canRenderAds } from '../lib/canRenderAds';
 import { getContributionsServiceUrl } from '../lib/contributions';
 import { decideMainMediaCaption } from '../lib/decide-caption';
 import { decidePalette } from '../lib/decidePalette';
-import { decideTrail, filterTrails } from '../lib/decideTrail';
+import { decideTrail } from '../lib/decideTrail';
 import { getZIndex } from '../lib/getZIndex';
 import { LABS_HEADER_HEIGHT } from '../lib/labs-constants';
 import { parse } from '../lib/slot-machine-flags';
@@ -765,9 +765,9 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 						>
 							<Carousel
 								heading={article.storyPackage.heading}
-								trails={filterTrails(
-									article.storyPackage.trails,
-								).map(decideTrail)}
+								trails={article.storyPackage.trails.map(
+									decideTrail,
+								)}
 								onwardsSource="more-on-this-story"
 								format={format}
 								leftColSize={'compact'}

--- a/dotcom-rendering/src/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/InteractiveLayout.tsx
@@ -46,7 +46,7 @@ import { SubNav } from '../components/SubNav.importable';
 import { canRenderAds } from '../lib/canRenderAds';
 import { getContributionsServiceUrl } from '../lib/contributions';
 import { decidePalette } from '../lib/decidePalette';
-import { decideTrail, filterTrails } from '../lib/decideTrail';
+import { decideTrail } from '../lib/decideTrail';
 import type { NavType } from '../model/extract-nav';
 import { palette as themePalette } from '../palette';
 import type { DCRArticle } from '../types/frontend';
@@ -663,9 +663,9 @@ export const InteractiveLayout = (props: WebProps | AppsProps) => {
 						<Island priority="feature" defer={{ until: 'visible' }}>
 							<Carousel
 								heading={article.storyPackage.heading}
-								trails={filterTrails(
-									article.storyPackage.trails,
-								).map(decideTrail)}
+								trails={article.storyPackage.trails.map(
+									decideTrail,
+								)}
 								onwardsSource="more-on-this-story"
 								format={format}
 								leftColSize={'compact'}

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -12,10 +12,7 @@ import {
 } from '@guardian/source-foundations';
 import { Hide } from '@guardian/source-react-components';
 import { StraightLines } from '@guardian/source-react-components-development-kitchen';
-import {
-	palette as darkModePalette,
-	palette as themePalette,
-} from '../../src/palette';
+import { palette as darkModePalette } from '../../src/palette';
 import { Accordion } from '../components/Accordion';
 import { RightAdsPlaceholder } from '../components/AdPlaceholder.apps';
 import { AdPortals } from '../components/AdPortals.importable';
@@ -61,9 +58,10 @@ import {
 import { canRenderAds } from '../lib/canRenderAds';
 import { getContributionsServiceUrl } from '../lib/contributions';
 import { decidePalette } from '../lib/decidePalette';
-import { decideTrail, filterTrails } from '../lib/decideTrail';
+import { decideTrail } from '../lib/decideTrail';
 import { getZIndex } from '../lib/getZIndex';
 import type { NavType } from '../model/extract-nav';
+import { palette as themePalette } from '../palette';
 import type { DCRArticle } from '../types/frontend';
 import type { RenderingTarget } from '../types/renderingTarget';
 import { BannerWrapper, SendToBack, Stuck } from './lib/stickiness';
@@ -1180,9 +1178,9 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 							>
 								<Carousel
 									heading={article.storyPackage.heading}
-									trails={filterTrails(
-										article.storyPackage.trails,
-									).map(decideTrail)}
+									trails={article.storyPackage.trails.map(
+										decideTrail,
+									)}
 									onwardsSource="more-on-this-story"
 									format={format}
 									leftColSize={'wide'}

--- a/dotcom-rendering/src/layouts/NewsletterSignupLayout.tsx
+++ b/dotcom-rendering/src/layouts/NewsletterSignupLayout.tsx
@@ -44,7 +44,7 @@ import { SubNav } from '../components/SubNav.importable';
 import { canRenderAds } from '../lib/canRenderAds';
 import { getContributionsServiceUrl } from '../lib/contributions';
 import { decidePalette } from '../lib/decidePalette';
-import { decideTrail, filterTrails } from '../lib/decideTrail';
+import { decideTrail } from '../lib/decideTrail';
 import { isValidUrl } from '../lib/isValidUrl';
 import type { NavType } from '../model/extract-nav';
 import type { DCRArticle } from '../types/frontend';
@@ -508,9 +508,9 @@ export const NewsletterSignupLayout = ({ article, NAV, format }: Props) => {
 						<Island priority="feature" defer={{ until: 'visible' }}>
 							<Carousel
 								heading={article.storyPackage.heading}
-								trails={filterTrails(
-									article.storyPackage.trails,
-								).map(decideTrail)}
+								trails={article.storyPackage.trails.map(
+									decideTrail,
+								)}
 								onwardsSource="more-on-this-story"
 								format={format}
 								leftColSize={'compact'}

--- a/dotcom-rendering/src/layouts/PictureLayout.tsx
+++ b/dotcom-rendering/src/layouts/PictureLayout.tsx
@@ -41,7 +41,7 @@ import { getSoleContributor } from '../lib/byline';
 import { canRenderAds } from '../lib/canRenderAds';
 import { getContributionsServiceUrl } from '../lib/contributions';
 import { decidePalette } from '../lib/decidePalette';
-import { decideTrail, filterTrails } from '../lib/decideTrail';
+import { decideTrail } from '../lib/decideTrail';
 import { decideLanguage, decideLanguageDirection } from '../lib/lang';
 import type { NavType } from '../model/extract-nav';
 import type { DCRArticle } from '../types/frontend';
@@ -609,9 +609,9 @@ export const PictureLayout = (props: WebProps | AppsProps) => {
 						<Island priority="feature" defer={{ until: 'visible' }}>
 							<Carousel
 								heading={article.storyPackage.heading}
-								trails={filterTrails(
-									article.storyPackage.trails,
-								).map(decideTrail)}
+								trails={article.storyPackage.trails.map(
+									decideTrail,
+								)}
 								onwardsSource="more-on-this-story"
 								format={format}
 								leftColSize={'compact'}

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -46,7 +46,7 @@ import { SubNav } from '../components/SubNav.importable';
 import { canRenderAds } from '../lib/canRenderAds';
 import { getContributionsServiceUrl } from '../lib/contributions';
 import { decidePalette } from '../lib/decidePalette';
-import { decideTrail, filterTrails } from '../lib/decideTrail';
+import { decideTrail } from '../lib/decideTrail';
 import { decideLanguage, decideLanguageDirection } from '../lib/lang';
 import { parse } from '../lib/slot-machine-flags';
 import type { NavType } from '../model/extract-nav';
@@ -730,9 +730,9 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 						<Island priority="feature" defer={{ until: 'visible' }}>
 							<Carousel
 								heading={article.storyPackage.heading}
-								trails={filterTrails(
-									article.storyPackage.trails,
-								).map(decideTrail)}
+								trails={article.storyPackage.trails.map(
+									decideTrail,
+								)}
 								onwardsSource="more-on-this-story"
 								format={format}
 								leftColSize={'compact'}

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -51,7 +51,7 @@ import { SubMeta } from '../components/SubMeta';
 import { SubNav } from '../components/SubNav.importable';
 import { canRenderAds } from '../lib/canRenderAds';
 import { getContributionsServiceUrl } from '../lib/contributions';
-import { decideTrail, filterTrails } from '../lib/decideTrail';
+import { decideTrail } from '../lib/decideTrail';
 import { parse } from '../lib/slot-machine-flags';
 import type { NavType } from '../model/extract-nav';
 import { palette as themePalette } from '../palette';
@@ -821,9 +821,9 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 						<Island priority="feature" defer={{ until: 'visible' }}>
 							<Carousel
 								heading={article.storyPackage.heading}
-								trails={filterTrails(
-									article.storyPackage.trails,
-								).map(decideTrail)}
+								trails={article.storyPackage.trails.map(
+									decideTrail,
+								)}
 								onwardsSource="more-on-this-story"
 								format={format}
 								leftColSize={'compact'}

--- a/dotcom-rendering/src/lib/decideTrail.ts
+++ b/dotcom-rendering/src/lib/decideTrail.ts
@@ -1,26 +1,13 @@
-import type { DCRFrontCard } from '../types/front';
 import type { FETrailType, TrailType } from '../types/trails';
 import { decideFormat } from './decideFormat';
 import { getDataLinkNameCard } from './getDataLinkName';
 
-const filterTrails = <T extends DCRFrontCard | TrailType | FETrailType>(
-	trails: T[],
-): T[] =>
-	trails.filter(
-		(trail) =>
-			/* TODO: remove this once we have a better solution
-						for filtering undesired articles See issue:
-						https://github.com/guardian/dotcom-rendering/issues/9528 */
-			!trail.url.includes('/info/2023/nov/15/removed-document'),
-	);
-
-const decideTrail = (trail: FETrailType, index = 0): TrailType => {
+export const decideTrail = (trail: FETrailType, index = 0): TrailType => {
 	const format: ArticleFormat = decideFormat(trail.format);
+
 	return {
 		...trail,
 		format,
 		dataLinkName: getDataLinkNameCard(format, '0', index),
 	};
 };
-
-export { decideTrail, filterTrails };

--- a/dotcom-rendering/src/server/handler.front.web.ts
+++ b/dotcom-rendering/src/server/handler.front.web.ts
@@ -1,6 +1,6 @@
 import type { RequestHandler } from 'express';
 import { pickBrandingForEdition } from '../lib/branding';
-import { decideTrail, filterTrails } from '../lib/decideTrail';
+import { decideTrail } from '../lib/decideTrail';
 import { enhanceCards } from '../model/enhanceCards';
 import { enhanceCollections } from '../model/enhanceCollections';
 import {
@@ -41,9 +41,7 @@ const enhanceFront = (body: unknown): DCRFrontType => {
 				),
 			}),
 		},
-		mostViewed: filterTrails(data.mostViewed).map((trail) =>
-			decideTrail(trail),
-		),
+		mostViewed: data.mostViewed.map((trail) => decideTrail(trail)),
 		mostCommented: data.mostCommented
 			? decideTrail(data.mostCommented)
 			: undefined,
@@ -52,9 +50,7 @@ const enhanceFront = (body: unknown): DCRFrontType => {
 			data.pressedPage.collections,
 			data.pageId,
 		),
-		deeplyRead: filterTrails(data.deeplyRead ?? []).map((trail) =>
-			decideTrail(trail),
-		),
+		deeplyRead: data.deeplyRead?.map((trail) => decideTrail(trail)),
 	};
 };
 


### PR DESCRIPTION
Reverts guardian/dotcom-rendering#9542 and #9526 as it was a quick fix to DCR and now the filter has been applied upstream in Ophan:

- https://github.com/guardian/ophan/pull/5661
- https://github.com/guardian/ophan/pull/5663