### PR TITLE
Fix `crypto-js` In Lockfile

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -9336,7 +9336,7 @@ cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-crypto-js@4.2.0, crypto-js@^3.3.0:
+crypto-js@4.2.0, crypto-js@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-4.2.0.tgz#4d931639ecdfd12ff80e8186dba6af2c2e856631"
   integrity sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==
@@ -15635,7 +15635,7 @@ prebid.js@guardian/prebid.js#0b4cccd55ab4e170b36bb944e9bdd2807a9da1c5:
     core-js "^3.13.0"
     core-js-pure "^3.13.0"
     criteo-direct-rsa-validate "^1.1.0"
-    crypto-js "^4.2.0"
+    crypto-js "^3.3.0"
     dlv "1.1.3"
     dset "3.1.2"
     express "^4.15.4"


### PR DESCRIPTION
Ran `yarn` to update the lockfile and it made this change.

The version of `crypto-js` listed as resolved hasn't changed, because we have it pinned via `resolutions`:

https://github.com/guardian/dotcom-rendering/blob/cedf35a78ed67fa7a0bca3de5fc49eac107ab5b8/package.json#L47-L49

I'm not sure why it's switched to listing a requirement on `crypto-js@^4.2.0` given that it's also downgraded the version `prebid` requires to `^3.3.0`.

I think this is related to #9475, which put `crypto-js` in `dotcom-rendering/package.json`'s `resolutions` in the first place, and #9525 which moved that resolution to the top-level `package.json`. @mxdvl @abeddow91 any thoughts?

@sndrs may also be interested in this.
