### PR TITLE
chore: sync lockfile

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -9336,7 +9336,7 @@ cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-crypto-js@4.2.0, crypto-js@^3.3.0:
+crypto-js@4.2.0, crypto-js@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-4.2.0.tgz#4d931639ecdfd12ff80e8186dba6af2c2e856631"
   integrity sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==
@@ -15635,7 +15635,7 @@ prebid.js@guardian/prebid.js#0b4cccd55ab4e170b36bb944e9bdd2807a9da1c5:
     core-js "^3.13.0"
     core-js-pure "^3.13.0"
     criteo-direct-rsa-validate "^1.1.0"
-    crypto-js "^4.2.0"
+    crypto-js "^3.3.0"
     dlv "1.1.3"
     dset "3.1.2"
     express "^4.15.4"


### PR DESCRIPTION
## What does this change?

Updates `yarn.lock` after mysteriously getting out of sync.

## Why?

We'd like Snyk to run properly on main and it doesn't with a lockfile that's seemingly out of sync.

Something is going on with crypto in the commercial bundle.
