### PR TITLE
Ld/conditionally show follow button 1

### DIFF
--- a/apps-rendering/package.json
+++ b/apps-rendering/package.json
@@ -120,5 +120,8 @@
 		"whatwg-fetch": "^3.6.2",
 		"winston": "^3.8.2",
 		"winston-daily-rotate-file": "^4.5.5"
+	},
+	"browser": {
+		"crypto": false
 	}
 }

--- a/apps-rendering/src/components/Follow/index.tsx
+++ b/apps-rendering/src/components/Follow/index.tsx
@@ -19,6 +19,11 @@ interface Props {
 	format: ArticleFormat;
 }
 
+interface Temp {
+	contributorId: string;
+	contributorName: string;
+}
+
 const followButtonStyles: SerializedStyles = css`
 	display: flex;
 	margin: 0;
@@ -97,22 +102,6 @@ const Follow: FC<Props> = ({ contributors, format }) => {
 		return (
 			<>
 				<button
-					className="js-follow-tag"
-					css={styles(format)}
-					data-id={contributor.id}
-					data-display-name={contributor.name}
-				>
-					<span
-						className="js-follow-tag-status"
-						css={followStatusStyles}
-					>
-						{/* The FollowTagStatus component will be rendered here after
-						code in article.ts checks if bridget version is compatible
-						and client env has MyGuardian enabled */}
-					</span>
-				</button>
-
-				<button
 					className="js-follow-notifications"
 					css={styles(format)}
 					data-id={contributor.id}
@@ -135,6 +124,20 @@ const Follow: FC<Props> = ({ contributors, format }) => {
 	return null;
 };
 
+export const FollowTag: FC<Temp> = ({ contributorId, contributorName }) => {
+	return (
+		<button
+			className="js-follow-tag"
+			data-id={contributorId}
+			data-display-name={contributorName}
+		>
+			<span
+				className="js-follow-tag-status"
+				css={followStatusStyles}
+			></span>
+		</button>
+	);
+};
 // ----- Exports ----- //
 
 export default Follow;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
