### PR TITLE
ShareIcons - darkmode

### DIFF
--- a/dotcom-rendering/src/components/ShareIcons.stories.tsx
+++ b/dotcom-rendering/src/components/ShareIcons.stories.tsx
@@ -1,4 +1,6 @@
 import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
+import { splitTheme } from '../../.storybook/decorators/splitThemeDecorator';
+import type { StoryProps } from '../../.storybook/decorators/splitThemeDecorator';
 import { ShareIcons } from './ShareIcons';
 
 export default {
@@ -12,7 +14,7 @@ const defaultFormat = {
 	theme: Pillar.News,
 };
 
-export const Medium = () => {
+export const Medium = ({ format }: StoryProps) => {
 	return (
 		<ShareIcons
 			pageId=""
@@ -25,15 +27,16 @@ export const Medium = () => {
 				'twitter',
 				'whatsApp',
 			]}
-			format={defaultFormat}
+			format={format}
 			size="medium"
 			context="LiveBlock"
 		/>
 	);
 };
 Medium.storyName = 'Medium';
+Medium.decorators = [splitTheme([defaultFormat])];
 
-export const Small = () => {
+export const Small = ({ format }: StoryProps) => {
 	return (
 		<ShareIcons
 			pageId=""
@@ -46,10 +49,11 @@ export const Small = () => {
 				'twitter',
 				'whatsApp',
 			]}
-			format={defaultFormat}
+			format={format}
 			size="small"
 			context="LiveBlock"
 		/>
 	);
 };
 Small.storyName = 'Small';
+Small.decorators = [splitTheme([defaultFormat])];

--- a/dotcom-rendering/src/components/ShareIcons.tsx
+++ b/dotcom-rendering/src/components/ShareIcons.tsx
@@ -1,14 +1,13 @@
 import { css } from '@emotion/react';
 import { ArticleDesign } from '@guardian/libs';
 import { from, until } from '@guardian/source-foundations';
-import { decidePalette } from '../lib/decidePalette';
+import { palette as themePalette } from '../palette';
 import EmailIcon from '../static/icons/email.svg';
 import FacebookIcon from '../static/icons/facebook.svg';
 import LinkedInIcon from '../static/icons/linked-in.svg';
 import MessengerIcon from '../static/icons/messenger.svg';
 import TwitterIconPadded from '../static/icons/twitter-padded.svg';
 import WhatsAppIcon from '../static/icons/whatsapp.svg';
-import type { Palette } from '../types/palette';
 import { Hide } from './Hide';
 
 type Context = 'ArticleMeta' | 'LiveBlock' | 'SubMeta';
@@ -43,20 +42,19 @@ const topMarginStlyes = css`
 `;
 
 const decideIconColor = (format: ArticleFormat, context: Context) => {
-	const palette = decidePalette(format);
 	if (format.design === ArticleDesign.LiveBlog) {
 		if (context === 'ArticleMeta') {
 			return css`
-				fill: ${palette.fill.shareIconGrayBackground};
+				fill: ${themePalette('--share-icon-blog-fill')};
 				${until.desktop} {
-					fill: ${palette.text.standfirst};
+					fill: ${themePalette('--standfirst-text')};
 				}
 			`;
 		}
 
 		if (context === 'SubMeta') {
 			return css`
-				fill: ${palette.fill.shareIconGrayBackground};
+				fill: ${themePalette('--share-icon-blog-fill')};
 			`;
 		}
 	}
@@ -65,16 +63,15 @@ const decideIconColor = (format: ArticleFormat, context: Context) => {
 		(context === 'SubMeta' || context === 'ArticleMeta')
 	) {
 		return css`
-			fill: ${palette.fill.shareIconGrayBackground};
+			fill: ${themePalette('--share-icon-blog-fill')};
 		`;
 	}
 	return css`
-		fill: ${palette.fill.shareIcon};
+		fill: ${themePalette('--share-icon-fill')};
 	`;
 };
 
 const decideIconColorOnHover = (format: ArticleFormat, context: Context) => {
-	const palette = decidePalette(format);
 	if (
 		(format.design === ArticleDesign.LiveBlog ||
 			format.design === ArticleDesign.DeadBlog) &&
@@ -82,8 +79,8 @@ const decideIconColorOnHover = (format: ArticleFormat, context: Context) => {
 	) {
 		return css`
 			:hover {
-				background-color: ${palette.fill.shareIconGrayBackground};
-				border-color: ${palette.fill.shareIconGrayBackground};
+				background-color: ${themePalette('--share-icon-blog-fill')};
+				border-color: ${themePalette('--share-icon-blog-fill')};
 				fill: white;
 			}
 		`;
@@ -91,29 +88,23 @@ const decideIconColorOnHover = (format: ArticleFormat, context: Context) => {
 	if (format.design === ArticleDesign.Picture) {
 		return css`
 			:hover {
-				background-color: ${palette.fill.shareIcon};
-				border-color: ${palette.fill.shareIcon};
+				background-color: ${themePalette('--share-icon-fill')};
+				border-color: ${themePalette('--share-icon-fill')};
 				fill: black;
 			}
 		`;
 	}
 	return css`
 		:hover {
-			background-color: ${palette.fill.shareIcon};
-			border-color: ${palette.fill.shareIcon};
+			background-color: ${themePalette('--share-icon-fill')};
+			border-color: ${themePalette('--share-icon-fill')};
 			fill: white;
 		}
 	`;
 };
 
-const iconStyles = ({
-	palette,
-	size,
-}: {
-	palette: Palette;
-	size: ShareIconSize;
-}) => css`
-	border: 1px solid ${palette.border.article};
+const iconStyles = (size: ShareIconSize) => css`
+	border: 1px solid ${themePalette('--article-border')};
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
@@ -171,7 +162,6 @@ export const ShareIcons = ({
 	size,
 	context,
 }: Props) => {
-	const palette = decidePalette(format);
 	return (
 		<ul css={ulStyles}>
 			{displayIcons.includes('facebook') && (
@@ -195,7 +185,7 @@ export const ShareIcons = ({
 					>
 						<span
 							css={[
-								iconStyles({ palette, size }),
+								iconStyles(size),
 								decideIconColor(format, context),
 								decideIconColorOnHover(format, context),
 							]}
@@ -227,7 +217,7 @@ export const ShareIcons = ({
 					>
 						<span
 							css={[
-								iconStyles({ palette, size }),
+								iconStyles(size),
 								decideIconColor(format, context),
 								decideIconColorOnHover(format, context),
 							]}
@@ -259,7 +249,7 @@ export const ShareIcons = ({
 					>
 						<span
 							css={[
-								iconStyles({ palette, size }),
+								iconStyles(size),
 								decideIconColor(format, context),
 								decideIconColorOnHover(format, context),
 							]}
@@ -289,7 +279,7 @@ export const ShareIcons = ({
 					>
 						<span
 							css={[
-								iconStyles({ palette, size }),
+								iconStyles(size),
 								decideIconColor(format, context),
 								decideIconColorOnHover(format, context),
 							]}
@@ -322,7 +312,7 @@ export const ShareIcons = ({
 						>
 							<span
 								css={[
-									iconStyles({ palette, size }),
+									iconStyles(size),
 									decideIconColor(format, context),
 									decideIconColorOnHover(format, context),
 								]}
@@ -354,7 +344,7 @@ export const ShareIcons = ({
 						>
 							<span
 								css={[
-									iconStyles({ palette, size }),
+									iconStyles(size),
 									decideIconColor(format, context),
 									decideIconColorOnHover(format, context),
 								]}

--- a/dotcom-rendering/src/lib/decidePalette.ts
+++ b/dotcom-rendering/src/lib/decidePalette.ts
@@ -1055,90 +1055,6 @@ const fillCommentCountUntilDesktop = (format: ArticleFormat): string => {
 	return fillCommentCount(format);
 };
 
-const fillShareIcon = (format: ArticleFormat): string => {
-	if (format.design === ArticleDesign.DeadBlog) {
-		switch (format.theme) {
-			case Pillar.Culture:
-				return culture[350];
-			case Pillar.News:
-				return news[400];
-			case Pillar.Lifestyle:
-				return lifestyle[400];
-			case Pillar.Sport:
-				return sport[400];
-			case Pillar.Opinion:
-				return opinion[300];
-			case ArticleSpecial.Labs:
-				return BLACK;
-			case ArticleSpecial.SpecialReport:
-				return specialReport[300];
-			case ArticleSpecial.SpecialReportAlt:
-				return news[400];
-		}
-	}
-	if (format.design === ArticleDesign.Analysis) {
-		switch (format.theme) {
-			case Pillar.Culture:
-				return culture[350];
-			case Pillar.News:
-				return news[300];
-			case Pillar.Lifestyle:
-				return lifestyle[400];
-			case Pillar.Sport:
-				return sport[400];
-			case Pillar.Opinion:
-				return opinion[300];
-			case ArticleSpecial.Labs:
-				return BLACK;
-			case ArticleSpecial.SpecialReport:
-				return specialReport[300];
-			case ArticleSpecial.SpecialReportAlt:
-				return palette.specialReportAlt[100];
-		}
-	}
-	if (
-		format.design === ArticleDesign.NewsletterSignup &&
-		format.display === ArticleDisplay.Standard
-	)
-		return BLACK;
-
-	if (format.design === ArticleDesign.Picture) return palette.neutral[86];
-	if (format.theme === ArticleSpecial.Labs) return BLACK;
-	if (format.theme === ArticleSpecial.SpecialReport)
-		return specialReport[300];
-
-	if (
-		format.theme === ArticleSpecial.SpecialReportAlt &&
-		format.design !== ArticleDesign.LiveBlog
-	)
-		return palette.specialReportAlt[100];
-
-	switch (format.theme) {
-		case Pillar.News:
-			return news[400];
-		case Pillar.Opinion:
-			return opinion[400];
-		case Pillar.Sport:
-			return sport[400];
-		case Pillar.Culture:
-			return culture[400];
-		case Pillar.Lifestyle:
-			return lifestyle[400];
-		case ArticleSpecial.SpecialReportAlt:
-			return news[400];
-	}
-};
-
-const fillShareIconGrayBackground = (format: ArticleFormat): string => {
-	switch (format.design) {
-		case ArticleDesign.LiveBlog:
-		case ArticleDesign.DeadBlog:
-			return blogsGrayBackgroundPalette(format);
-		default:
-			return pillarPalette[format.theme].dark;
-	}
-};
-
 const fillBlockquoteIcon = (format: ArticleFormat): string => {
 	switch (format.design) {
 		case ArticleDesign.LiveBlog:
@@ -2179,8 +2095,6 @@ export const decidePalette = (
 		fill: {
 			commentCount: fillCommentCount(format),
 			commentCountUntilDesktop: fillCommentCountUntilDesktop(format),
-			shareIcon: fillShareIcon(format),
-			shareIconGrayBackground: fillShareIconGrayBackground(format),
 			richLink: fillRichLink(format),
 			quoteIcon: fillQuoteIcon(format),
 			blockquoteIcon: fillBlockquoteIcon(format),

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -1427,6 +1427,93 @@ const subNavBorder = ({ design, theme }: ArticleFormat): string => {
 	}
 };
 
+const shareIconFillLight = ({ design, theme, display }: ArticleFormat) => {
+	switch (design) {
+		case ArticleDesign.DeadBlog:
+			switch (theme) {
+				case ArticleSpecial.SpecialReport:
+					return sourcePalette.specialReport[300];
+				case ArticleSpecial.SpecialReportAlt:
+					return sourcePalette.news[400];
+				case ArticleSpecial.Labs:
+					return sourcePalette.neutral[7];
+				default:
+					return pillarPalette(theme, 400);
+			}
+		case ArticleDesign.Analysis:
+			switch (theme) {
+				case Pillar.News:
+					return sourcePalette.news[300];
+				case ArticleSpecial.Labs:
+					return sourcePalette.neutral[7];
+				case ArticleSpecial.SpecialReport:
+					return sourcePalette.specialReport[300];
+				case ArticleSpecial.SpecialReportAlt:
+					return sourcePalette.specialReportAlt[100];
+				default:
+					return pillarPalette(theme, 400);
+			}
+		case ArticleDesign.Picture:
+			return sourcePalette.neutral[86];
+		default:
+			switch (theme) {
+				case ArticleSpecial.Labs:
+					return sourcePalette.neutral[7];
+				case ArticleSpecial.SpecialReport:
+					return sourcePalette.specialReport[300];
+				default:
+					if (
+						design === ArticleDesign.NewsletterSignup &&
+						display === ArticleDisplay.Standard
+					) {
+						return sourcePalette.neutral[7];
+					}
+					if (
+						theme === ArticleSpecial.SpecialReportAlt &&
+						design !== ArticleDesign.LiveBlog
+					) {
+						return sourcePalette.specialReportAlt[100];
+					}
+					if (theme === ArticleSpecial.SpecialReportAlt)
+						return sourcePalette.news[400];
+					return pillarPalette(theme, 400);
+			}
+	}
+};
+
+const shareIconFillDark = () => sourcePalette.neutral[60];
+
+const shareIconFillBlogLight = ({ design, theme }: ArticleFormat) => {
+	switch (design) {
+		case ArticleDesign.LiveBlog:
+		case ArticleDesign.DeadBlog:
+			switch (theme) {
+				case Pillar.News:
+				case ArticleSpecial.SpecialReportAlt:
+					return sourcePalette.news[400];
+				case ArticleSpecial.SpecialReport:
+					return sourcePalette.specialReport[300];
+				case ArticleSpecial.Labs:
+					return sourcePalette.labs[300];
+				default:
+					return pillarPalette(theme, 300);
+			}
+		default:
+			switch (theme) {
+				case ArticleSpecial.Labs:
+					return sourcePalette.labs[300];
+				case ArticleSpecial.SpecialReport:
+					return sourcePalette.specialReport[300];
+				case ArticleSpecial.SpecialReportAlt:
+					return sourcePalette.specialReportAlt[300];
+				default:
+					return pillarPalette(theme, 300);
+			}
+	}
+};
+
+const shareIconFillBlogDark = () => sourcePalette.neutral[60];
+
 // ----- Palette ----- //
 
 /**
@@ -1695,6 +1782,14 @@ const paletteColours = {
 	'--sub-nav-border': {
 		light: subNavBorder,
 		dark: subNavBorder,
+	},
+	'--share-icon-fill': {
+		light: shareIconFillLight,
+		dark: shareIconFillDark,
+	},
+	'--share-icon-blog-fill': {
+		light: shareIconFillBlogLight,
+		dark: shareIconFillBlogDark,
 	},
 } satisfies PaletteColours;
 

--- a/dotcom-rendering/src/types/palette.ts
+++ b/dotcom-rendering/src/types/palette.ts
@@ -94,8 +94,6 @@ export type Palette = {
 	fill: {
 		commentCount: Colour;
 		commentCountUntilDesktop: Colour;
-		shareIcon: Colour;
-		shareIconGrayBackground: Colour;
 		richLink: Colour;
 		quoteIcon: Colour;
 		blockquoteIcon: Colour;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
What does this change?
Updates the ShareIcons to implement darkmode.

## Why?
Ahead of the changes to the live article, as the icons need to be darkmode compatible
Resolves https://github.com/guardian/dotcom-rendering/issues/9556

## Why?

## Screenshots
![image](https://github.com/guardian/dotcom-rendering/assets/26366706/2f01a806-cf58-4a76-bbcc-b5d7be773cbd)



<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
