### PR TITLE
👋 `yarn@1`: set `max-old-space-size` size for chromatic in CI config

### DIFF
--- a/.github/workflows/ar-chromatic.yml
+++ b/.github/workflows/ar-chromatic.yml
@@ -37,6 +37,8 @@ jobs:
       - run: yarn install --frozen-lockfile
 
       - name: Chromatic - Apps Rendering
+        env:
+          NODE_OPTIONS: '--max_old_space_size=4096'
         uses: chromaui/action@v1
 
         with:

--- a/.github/workflows/ar-chromatic.yml
+++ b/.github/workflows/ar-chromatic.yml
@@ -48,3 +48,4 @@ jobs:
           exitOnceUploaded: true
           onlyChanged: '!(main)' # only turbosnap on non-main branches
           workingDir: apps-rendering
+          buildScriptName: 'build-storybook'

--- a/.github/workflows/dcr-chromatic.yml
+++ b/.github/workflows/dcr-chromatic.yml
@@ -37,6 +37,8 @@ jobs:
       - run: yarn install --frozen-lockfile
 
       - name: Chromatic - DCR
+        env:
+          NODE_OPTIONS: '--max_old_space_size=4096'
         uses: chromaui/action@v1
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN__DOTCOM_RENDERING }}

--- a/.github/workflows/dcr-chromatic.yml
+++ b/.github/workflows/dcr-chromatic.yml
@@ -47,3 +47,4 @@ jobs:
           onlyChanged: true
           untraced: '**/(package*.json|yarn.lock|preview.js)'
           workingDir: dotcom-rendering
+          buildScriptName: 'build-storybook'

--- a/apps-rendering/package.json
+++ b/apps-rendering/package.json
@@ -28,7 +28,7 @@
 		"synth": "cdk synth --path-metadata false --version-reporting false",
 		"diff": "cdk diff --path-metadata false --version-reporting false",
 		"storybook": "storybook dev -p 4003",
-		"build-storybook": "node --max-old-space-size=4096 $(yarn bin)/storybook build"
+		"build-storybook": "storybook build"
 	},
 	"author": "",
 	"license": "ISC",

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -26,7 +26,7 @@
 		"cypress:run:e2e": "cypress run --spec 'cypress/e2e/**/*'",
 		"unused-exports": "yarn ts-unused-exports ./tsconfig.json --ignoreFiles='(/(fixtures|__mocks__)/|.+\\.(stories|mocks))' --exitWithCount",
 		"storybook": "storybook dev -p 4002",
-		"build-storybook": "node --max-old-space-size=4096 $(yarn bin)/storybook build",
+		"build-storybook": "storybook build",
 		"makeBuild": "NODE_ENV=production CI_ENV=github webpack --config ./webpack/webpack.config.js",
 		"cdk:build": "tsc -p ./tsconfig.cdk.json",
 		"cdk:synth": "cdk synth --path-metadata false --version-reporting false",


### PR DESCRIPTION
## What does this change?

sets `max-old-space-size` for storybook building in the CI task directly.

## Why?

means a much more orthodox npm-script, and remove direct ref the yarn binary

