### PR TITLE
Update submeta hover state

### DIFF
--- a/dotcom-rendering/src/components/SubMeta.tsx
+++ b/dotcom-rendering/src/components/SubMeta.tsx
@@ -96,22 +96,21 @@ const listItemStyles = css`
 	border: 1px solid ${palette('--sub-meta-text')};
 	border-radius: 12px;
 	padding: 2px 9px;
+	:hover {
+		background-color: ${palette('--sub-meta-text')};
+		a {
+			color: ${palette('--sub-meta-text-hover')};
+		}
+	}
 	a {
 		position: relative;
 		display: block;
 		text-decoration: none;
 	}
-
-	a:hover {
-		text-decoration: underline;
-	}
 `;
 
 const linkStyles = css`
 	text-decoration: none;
-	:hover {
-		text-decoration: underline;
-	}
 	color: ${palette('--sub-meta-text')};
 `;
 

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -1766,6 +1766,8 @@ const subMetaTextDark = ({ theme }: ArticleFormat): string => {
 	}
 };
 
+const subMetaTextHoverLight = () => sourcePalette.neutral[100];
+
 const syndicationButtonText = ({ design, theme }: ArticleFormat): string => {
 	switch (theme) {
 		case ArticleSpecial.Labs:
@@ -2118,6 +2120,10 @@ const paletteColours = {
 	'--sub-meta-text': {
 		light: subMetaTextLight,
 		dark: subMetaTextDark,
+	},
+	'--sub-meta-text-hover': {
+		light: subMetaTextHoverLight,
+		dark: subMetaBackgroundDark,
 	},
 	'--syndication-button-text': {
 		light: syndicationButtonText,


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Updates the hover state of submeta components as per new designs. It also adds the dark mode variant of this for articles served for app. 


## Screenshots
### Light mode

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/20416599/a499e87e-b430-407f-9435-eb5cd02900b6
[after]: https://github.com/guardian/dotcom-rendering/assets/20416599/e86e6aa2-bd24-414d-bb48-b890bbdbecd0

### Dark mode

| Before      | After      |
| ----------- | ---------- |
| ![before-d][] | ![after-d][] |

[after-d]: https://github.com/guardian/dotcom-rendering/assets/20416599/0b8e6474-c1fa-4f86-bf93-fa24664f454c
[before-d]: https://github.com/guardian/dotcom-rendering/assets/20416599/0117d363-b8e4-4700-ad8e-348595baf2fa

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
