### PR TITLE
Bump AMI recipe to v2 with pm2 removed

### DIFF
--- a/dotcom-rendering/scripts/check-node-versions.mjs
+++ b/dotcom-rendering/scripts/check-node-versions.mjs
@@ -35,7 +35,8 @@ const requiredNodeVersionMatches =
 		},
 		{
 			filepath: 'scripts/deploy/riff-raff.yaml',
-			pattern: /^ +Recipe: dotcom-rendering.*-node-(\d+\.\d+\.\d+)$/m,
+			pattern:
+				/^ +Recipe: dotcom-rendering.*-node-(\d+\.\d+\.\d+)(-v.*)?$/m,
 		},
 		{
 			filepath: '../apps-rendering/riff-raff.yaml',

--- a/dotcom-rendering/scripts/deploy/riff-raff.yaml
+++ b/dotcom-rendering/scripts/deploy/riff-raff.yaml
@@ -10,7 +10,7 @@ templates:
             amiEncrypted: true
             amiTags:
                 # Keep the Node version in sync with `.nvmrc`
-                Recipe: dotcom-rendering-ARM-jammy-node-18.18.2
+                Recipe: dotcom-rendering-ARM-jammy-node-18.18.2-v2
                 AmigoStage: PROD
 deployments:
     frontend-cfn:


### PR DESCRIPTION
## What does this change?

Bump AMI recipe to v2 with pm2 removed

```
before: dotcom-rendering-ARM-jammy-node-18.18.2
after : dotcom-rendering-ARM-jammy-node-18.18.2-v2
```

Tested on CODE

## Why?

We stopped DCR using pm2 and removed the local dependency here:

- #9489 

This is a follow up task to remove it as a node package from the AMI


