### PR TITLE
Remove `.snyk` file

### DIFF
--- a/dotcom-rendering/.snyk
+++ b/dotcom-rendering/.snyk
@@ -1,7 +1,0 @@
-# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-version: v1.1229.0
-# We should only ignore license warnings in here. Any other vulnerabilities should be fixed
-# or ignored in the Snyk console.
-# ignores vulnerabilities until expiry date; change duration by modifying expiry date
-ignore:
-patch: {}


### PR DESCRIPTION
## What does this change?

Following #9489 we can remove the `.snyk` file as it only existing to ignore AGPL license issues raised by pm2.

