### PR TITLE
feat: update newsletter grouping

### DIFF
--- a/dotcom-rendering/src/model/newsletter-grouping.ts
+++ b/dotcom-rendering/src/model/newsletter-grouping.ts
@@ -56,6 +56,7 @@ export const groups: Partial<Record<EditionId, StaticGroups>> = {
 			title: 'The world explained',
 			newsletters: [
 				'trump-on-trial',
+				'follow-margaret-sullivan',
 				'global-dispatch',
 				'documentaries',
 				'her-stage',
@@ -108,6 +109,7 @@ export const groups: Partial<Record<EditionId, StaticGroups>> = {
 				'headlines-europe',
 				'green-light', // Down to Earth
 				'trump-on-trial',
+				'follow-margaret-sullivan',
 				'best-of-opinion-us',
 				'patriarchy',
 				'bookmarks',
@@ -242,6 +244,7 @@ export const groups: Partial<Record<EditionId, StaticGroups>> = {
 			title: 'The world explained',
 			newsletters: [
 				'trump-on-trial',
+				'follow-margaret-sullivan',
 				'global-dispatch',
 				'cotton-capital',
 				'documentaries',


### PR DESCRIPTION
## What does this change?

Updates the newsletter grouping for the Australian edition of the all newsletters page.

Also adds the `follow-margaret-sullivan` newsletter to the US, UK and AUS editions.

## Why?

Resolves #9406 
Resolves #9605 

## Screenshots

### AUS edition

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |
| ![before2][] | ![after2][] |
| ![before3][] | ![after3][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/43961396/be477ca6-947b-4c00-9519-1e2e996f9062
[before2]: https://github.com/guardian/dotcom-rendering/assets/43961396/0f3fee36-5608-4266-b458-68e89254ecee
[before3]: https://github.com/guardian/dotcom-rendering/assets/43961396/a382baef-db4e-4b1d-947d-1fce04345b18
[after]: https://github.com/guardian/dotcom-rendering/assets/43961396/f0e60686-2ca5-49e0-b943-17ef18c592e2
[after2]: https://github.com/guardian/dotcom-rendering/assets/43961396/8447c6ee-bdb4-434f-a9d5-e6b5650fd571
[after3]: https://github.com/guardian/dotcom-rendering/assets/43961396/b5337464-5771-448c-8b38-bba5f647a46f