### PR TITLE
Set body colour in darkmode

### DIFF
--- a/dotcom-rendering/src/components/ArticlePage.tsx
+++ b/dotcom-rendering/src/components/ArticlePage.tsx
@@ -67,9 +67,12 @@ export const ArticlePage = (props: WebProps | AppProps) => {
 					:root {
 						/* Light palette is default on all platforms */
 						${paletteDeclarations(format, 'light')}
-
+						body {
+							color: ${sourcePalette.neutral[7]};
+						}
 						/* Dark palette only for apps and only if switch turned on */
-						${article.config.switches.darkModeInApps && renderingTarget === 'Apps'
+						${article.config.switches.darkModeInApps &&
+						renderingTarget === 'Apps'
 							? css`
 									@media (prefers-color-scheme: dark) {
 										${paletteDeclarations(format, 'dark')}

--- a/dotcom-rendering/src/components/ArticlePage.tsx
+++ b/dotcom-rendering/src/components/ArticlePage.tsx
@@ -1,6 +1,11 @@
 import { css, Global } from '@emotion/react';
 import { ArticleDesign } from '@guardian/libs';
-import { brandAlt, focusHalo, neutral } from '@guardian/source-foundations';
+import {
+	brandAlt,
+	focusHalo,
+	neutral,
+	palette as sourcePalette,
+} from '@guardian/source-foundations';
 import { StrictMode } from 'react';
 import { DecideLayout } from '../layouts/DecideLayout';
 import { buildAdTargeting } from '../lib/ad-targeting';
@@ -68,6 +73,9 @@ export const ArticlePage = (props: WebProps | AppProps) => {
 							? css`
 									@media (prefers-color-scheme: dark) {
 										${paletteDeclarations(format, 'dark')}
+										body {
+											color: ${sourcePalette.neutral[86]};
+										}
 									}
 							  `
 							: ''}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Sets the dark mode body colour in the global styles.

## Why?
We use source's css resets to define our body colour. We need to reset the reset when the user is in dark mode so that body text displays correctly. By co-locating this with the dark mode palette, we don't need to add any further checks elsewhere to see if the user is in darkmode. 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/20416599/001433c2-95cf-4cc0-8055-43e423ba21e6
[after]: https://github.com/guardian/dotcom-rendering/assets/20416599/51ddd794-cbe0-4d6b-9f56-fa3aeee736a3

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
