### PR TITLE
Allow `frame-src` from `https://apps.enformant.com`

### DIFF
--- a/apps-rendering/src/server/csp.ts
+++ b/apps-rendering/src/server/csp.ts
@@ -102,7 +102,7 @@ const buildCsp = (
 			? 'https://platform.twitter.com https://cdn.syndication.twimg.com'
 			: ''
 	};
-    frame-src https://www.theguardian.com https://www.scribd.com https://www.google.com https://webstories.theguardian.com https://www.linkedin.com https://datawrapper.dwcdn.net ${
+    frame-src https://www.theguardian.com https://www.scribd.com https://www.google.com https://webstories.theguardian.com https://www.linkedin.com https://datawrapper.dwcdn.net https://apps.enformant.com ${
 		thirdPartyEmbed.instagram ? 'https://www.instagram.com' : ''
 	} https://www.facebook.com https://www.tiktok.com https://interactive.guim.co.uk ${
 		thirdPartyEmbed.spotify ? 'https://open.spotify.com' : ''


### PR DESCRIPTION
The 2023 Budget Calculator will be hosted from that domain, and it should work in AR.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| <img width="755" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/705427/55fc2389-4d8a-49e6-93ae-4a57f45a3a3c"> | <img width="825" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/705427/9e00fdcd-af00-46c9-a1bc-af5e70247a42"> |
