### PR TITLE
Fix rendering of videos in apps

### DIFF
--- a/apps-rendering/src/capi.ts
+++ b/apps-rendering/src/capi.ts
@@ -93,37 +93,32 @@ const articleMainMedia = (
 	content: Content,
 	context: Context,
 ): Optional<MainMedia> => {
-	const elementType: ElementType | undefined = (content.blocks?.main
-		?.elements ?? [])[0]?.type;
+	const element = content.blocks?.main?.elements[0];
 
-	switch (elementType) {
-		case ElementType.IMAGE:
+	if (element) {
+		if (isImage(element)) {
 			return articleMainImage(content)
 				.flatMap(parseImage(context))
 				.map<MainMedia>((image) => ({
 					kind: MainMediaKind.Image,
 					image,
 				}));
-		case ElementType.VIDEO:
+		} else if (isVideo(element)) {
 			return articleMainVideo(content)
 				.flatMap(parseVideo(content.atoms))
 				.map<MainMedia>((video) => ({
 					kind: MainMediaKind.Video,
 					video,
 				}));
-		case ElementType.CARTOON:
-			if (context.app === 'Editions') {
-				return articleMainCartoon(content)
-					.flatMap(parseCartoon(context))
-					.map<MainMedia>((cartoon) => ({
-						kind: MainMediaKind.Cartoon,
-						cartoon,
-					}));
-			} else {
-				return Optional.none();
-			}
-		default:
-			return Optional.none();
+		} else if (isCartoon(element) && context.app === 'Editions') {
+			return articleMainCartoon(content)
+				.flatMap(parseCartoon(context))
+				.map<MainMedia>((cartoon) => ({
+					kind: MainMediaKind.Cartoon,
+					cartoon,
+				}));
+		}
+		return Optional.none();
 	}
 };
 

--- a/apps-rendering/src/capi.ts
+++ b/apps-rendering/src/capi.ts
@@ -117,7 +117,10 @@ const articleMainMedia = (
 					kind: MainMediaKind.Cartoon,
 					cartoon,
 				}));
+		} else {
+			return Optional.none();
 		}
+	} else {
 		return Optional.none();
 	}
 };


### PR DESCRIPTION
## What does this change?
This [pr](https://github.com/guardian/dotcom-rendering/pull/9416) broke rendering video elements in the main media on apps. We believe the reason is that is because of changes to how we parse the CAPI response. Previously this was a ternary statement that assumed that anything that wasn't an image was a video. This was changed to a switch statement on element type to allow for cartoon elements to be rendered in main media. Because the video elements don't actually come in with the element type 'video' (they come in as 'contentatom'), they are not currently being picked up and are returning as None.

This is fixed by using the `isVideo` check to ensure we are accurately identifying video elements. 


## Why?

Resolves #9585 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
