### PR TITLE
Add darkmode to showcase layout

### DIFF
--- a/dotcom-rendering/scripts/gen-stories/get-stories.mjs
+++ b/dotcom-rendering/scripts/gen-stories/get-stories.mjs
@@ -220,7 +220,7 @@ const testLayoutFormats =
 			display: 'Showcase',
 			design: 'Standard',
 			theme: 'NewsPillar',
-			config: { renderingTarget: 'Apps', darkModeAvailable: false },
+			config: { renderingTarget: 'Apps', darkModeAvailable: true },
 		},
 		{
 			display: 'Showcase',

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -44,7 +44,7 @@ import { decideTrail } from '../lib/decideTrail';
 import { decideLanguage, decideLanguageDirection } from '../lib/lang';
 import { parse } from '../lib/slot-machine-flags';
 import type { NavType } from '../model/extract-nav';
-import { palette } from '../palette';
+import { palette as themePalette } from '../palette';
 import type { DCRArticle } from '../types/frontend';
 import type { RenderingTarget } from '../types/renderingTarget';
 import { BannerWrapper, SendToBack, Stuck } from './lib/stickiness';
@@ -337,7 +337,7 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 									{props.NAV.subNavSections && (
 										<Section
 											fullWidth={true}
-											backgroundColour={palette(
+											backgroundColour={themePalette(
 												'--article-background',
 											)}
 											padSides={false}
@@ -355,13 +355,13 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 													currentNavLink={
 														props.NAV.currentNavLink
 													}
-													linkHoverColour={palette(
+													linkHoverColour={themePalette(
 														'--article-link-text-hover',
 													)}
-													borderColour={palette(
+													borderColour={themePalette(
 														'--sub-nav-border',
 													)}
-													subNavLinkColour={palette(
+													subNavLinkColour={themePalette(
 														'--sub-nav-link',
 													)}
 												/>
@@ -371,18 +371,18 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 
 									<Section
 										fullWidth={true}
-										backgroundColour={palette(
+										backgroundColour={themePalette(
 											'--article-background',
 										)}
 										padSides={false}
 										showTopBorder={false}
-										borderColour={palette(
+										borderColour={themePalette(
 											'--article-border-secondary',
 										)}
 									>
 										<StraightLines
 											count={4}
-											color={palette(
+											color={themePalette(
 												'--article-border-secondary',
 											)}
 											cssOverrides={css`
@@ -478,9 +478,9 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 				<Section
 					fullWidth={true}
 					showTopBorder={false}
-					backgroundColour={palette('--article-background')}
+					backgroundColour={themePalette('--article-background')}
 					element="article"
-					borderColour={palette('--article-border-secondary')}
+					borderColour={themePalette('--article-border-secondary')}
 				>
 					<ShowcaseGrid>
 						<GridItem area="media">
@@ -548,7 +548,7 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 								<div css={stretchLines}>
 									<DecideLines
 										format={format}
-										color={palette(
+										color={themePalette(
 											'--article-border-secondary',
 										)}
 									/>
@@ -652,7 +652,7 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 								)}
 								<StraightLines
 									count={4}
-									color={palette(
+									color={themePalette(
 										'--article-border-secondary',
 									)}
 									cssOverrides={css`
@@ -842,10 +842,10 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 						<SubNav
 							subNavSections={props.NAV.subNavSections}
 							currentNavLink={props.NAV.currentNavLink}
-							linkHoverColour={palette(
+							linkHoverColour={themePalette(
 								'--article-link-text-hover',
 							)}
-							borderColour={palette('--sub-nav-border')}
+							borderColour={themePalette('--sub-nav-border')}
 						/>
 					</Island>
 				</Section>

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -2,13 +2,8 @@ import { css } from '@emotion/react';
 import type { ArticleFormat } from '@guardian/libs';
 import { ArticleDesign, ArticleDisplay, ArticleSpecial } from '@guardian/libs';
 import {
-	border,
-	brandBackground,
-	brandBorder,
-	brandLine,
 	from,
-	labs,
-	neutral,
+	palette as sourcePalette,
 	until,
 } from '@guardian/source-foundations';
 import { StraightLines } from '@guardian/source-react-components-development-kitchen';
@@ -45,11 +40,11 @@ import { SubMeta } from '../components/SubMeta';
 import { SubNav } from '../components/SubNav.importable';
 import { canRenderAds } from '../lib/canRenderAds';
 import { getContributionsServiceUrl } from '../lib/contributions';
-import { decidePalette } from '../lib/decidePalette';
 import { decideTrail } from '../lib/decideTrail';
 import { decideLanguage, decideLanguageDirection } from '../lib/lang';
 import { parse } from '../lib/slot-machine-flags';
 import type { NavType } from '../model/extract-nav';
+import { palette } from '../palette';
 import type { DCRArticle } from '../types/frontend';
 import type { RenderingTarget } from '../types/renderingTarget';
 import { BannerWrapper, SendToBack, Stuck } from './lib/stickiness';
@@ -238,8 +233,6 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 
 	const { branding } = article.commercialProperties[article.editionId];
 
-	const palette = decidePalette(format);
-
 	const contributionsServiceUrl = getContributionsServiceUrl(article);
 
 	const renderAds = renderingTarget === 'Web' && canRenderAds(article);
@@ -274,7 +267,7 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 										showSideBorders={false}
 										padSides={false}
 										backgroundColour={
-											brandBackground.primary
+											sourcePalette.brand[400]
 										}
 										element="header"
 									>
@@ -305,11 +298,11 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 									</Section>
 									<Section
 										fullWidth={true}
-										borderColour={brandLine.primary}
+										borderColour={sourcePalette.brand[600]}
 										showTopBorder={false}
 										padSides={false}
 										backgroundColour={
-											brandBackground.primary
+											sourcePalette.brand[400]
 										}
 										element="nav"
 										format={format}
@@ -344,9 +337,9 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 									{props.NAV.subNavSections && (
 										<Section
 											fullWidth={true}
-											backgroundColour={
-												palette.background.article
-											}
+											backgroundColour={palette(
+												'--article-background',
+											)}
 											padSides={false}
 											element="aside"
 											format={format}
@@ -362,16 +355,15 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 													currentNavLink={
 														props.NAV.currentNavLink
 													}
-													linkHoverColour={
-														palette.text
-															.articleLinkHover
-													}
-													borderColour={
-														palette.border.subNav
-													}
-													subNavLinkColour={
-														palette.text.subNavLink
-													}
+													linkHoverColour={palette(
+														'--article-link-text-hover',
+													)}
+													borderColour={palette(
+														'--sub-nav-border',
+													)}
+													subNavLinkColour={palette(
+														'--sub-nav-link',
+													)}
 												/>
 											</Island>
 										</Section>
@@ -379,16 +371,20 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 
 									<Section
 										fullWidth={true}
-										backgroundColour={
-											palette.background.article
-										}
+										backgroundColour={palette(
+											'--article-background',
+										)}
 										padSides={false}
 										showTopBorder={false}
-										borderColour={palette.border.secondary}
+										borderColour={palette(
+											'--article-border-secondary',
+										)}
 									>
 										<StraightLines
 											count={4}
-											color={palette.border.secondary}
+											color={palette(
+												'--article-border-secondary',
+											)}
 											cssOverrides={css`
 												display: block;
 											`}
@@ -416,11 +412,11 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 								<Stuck zIndex="stickyAdWrapperNav">
 									<Section
 										fullWidth={true}
-										borderColour={brandLine.primary}
+										borderColour={sourcePalette.brand[600]}
 										showTopBorder={false}
 										padSides={false}
 										backgroundColour={
-											brandBackground.primary
+											sourcePalette.brand[400]
 										}
 										element="nav"
 									>
@@ -456,8 +452,8 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 								<Section
 									fullWidth={true}
 									showTopBorder={false}
-									backgroundColour={labs[400]}
-									borderColour={border.primary}
+									backgroundColour={sourcePalette.labs[400]}
+									borderColour={sourcePalette.neutral[60]}
 									sectionId="labs-header"
 								>
 									<LabsHeader />
@@ -482,9 +478,9 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 				<Section
 					fullWidth={true}
 					showTopBorder={false}
-					backgroundColour={palette.background.article}
+					backgroundColour={palette('--article-background')}
 					element="article"
-					borderColour={palette.border.secondary}
+					borderColour={palette('--article-border-secondary')}
 				>
 					<ShowcaseGrid>
 						<GridItem area="media">
@@ -552,7 +548,9 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 								<div css={stretchLines}>
 									<DecideLines
 										format={format}
-										color={palette.border.secondary}
+										color={palette(
+											'--article-border-secondary',
+										)}
 									/>
 								</div>
 							</div>
@@ -654,7 +652,9 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 								)}
 								<StraightLines
 									count={4}
-									color={palette.border.secondary}
+									color={palette(
+										'--article-border-secondary',
+									)}
 									cssOverrides={css`
 										display: block;
 									`}
@@ -715,7 +715,7 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 						padSides={false}
 						showTopBorder={false}
 						showSideBorders={false}
-						backgroundColour={neutral[93]}
+						backgroundColour={sourcePalette.neutral[93]}
 						element="aside"
 					>
 						<AdSlot
@@ -825,7 +825,7 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 						padSides={false}
 						showTopBorder={false}
 						showSideBorders={false}
-						backgroundColour={neutral[93]}
+						backgroundColour={sourcePalette.neutral[93]}
 						element="aside"
 					>
 						<AdSlot
@@ -842,8 +842,10 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 						<SubNav
 							subNavSections={props.NAV.subNavSections}
 							currentNavLink={props.NAV.currentNavLink}
-							linkHoverColour={palette.text.articleLinkHover}
-							borderColour={palette.border.subNav}
+							linkHoverColour={palette(
+								'--article-link-text-hover',
+							)}
+							borderColour={palette('--sub-nav-border')}
 						/>
 					</Island>
 				</Section>
@@ -854,8 +856,8 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 					<Section
 						fullWidth={true}
 						padSides={false}
-						backgroundColour={brandBackground.primary}
-						borderColour={brandBorder.primary}
+						backgroundColour={sourcePalette.brand[400]}
+						borderColour={sourcePalette.brand[600]}
 						showSideBorders={false}
 						element="footer"
 					>
@@ -913,7 +915,7 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 				<Section
 					fullWidth={true}
 					data-print-layout="hide"
-					backgroundColour={neutral[97]}
+					backgroundColour={sourcePalette.neutral[97]}
 					padSides={false}
 					showSideBorders={false}
 					element="footer"

--- a/dotcom-rendering/src/lib/decidePalette.ts
+++ b/dotcom-rendering/src/lib/decidePalette.ts
@@ -1693,6 +1693,7 @@ const textExpandableAtomHover = (format: ArticleFormat) => {
 	}
 };
 
+/** @deprecated use subNavLink in src/palette.ts */
 const textSubNavLink = (format: ArticleFormat) => {
 	switch (format.design) {
 		case ArticleDesign.Picture:

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -2280,6 +2280,14 @@ const subNavBorder: PaletteFunction = ({ design, theme }) => {
 			}
 	}
 };
+const subNavLink = (format: ArticleFormat) => {
+	switch (format.design) {
+		case ArticleDesign.Picture:
+			return sourcePalette.neutral[100];
+		default:
+			return sourcePalette.neutral[7];
+	}
+};
 
 const shareIconFillLight: PaletteFunction = ({ design, theme, display }) => {
 	switch (design) {
@@ -2953,6 +2961,10 @@ const paletteColours = {
 	'--sub-nav-border': {
 		light: subNavBorder,
 		dark: subNavBorder,
+	},
+	'--sub-nav-link': {
+		light: subNavLink,
+		dark: subNavLink,
 	},
 	'--share-icon-fill': {
 		light: shareIconFillLight,

--- a/dotcom-rendering/stories/generated/Layout.stories.tsx
+++ b/dotcom-rendering/stories/generated/Layout.stories.tsx
@@ -96,7 +96,7 @@ export default {
 			);
 		};
 		AppsShowcaseStandardNewsPillarLight.storyName = 'Apps: Display: Showcase, Design: Standard, Theme: NewsPillar, Mode: Light';
-		AppsShowcaseStandardNewsPillarLight.parameters = { config: {"renderingTarget":"Apps","darkModeAvailable":false} };
+		AppsShowcaseStandardNewsPillarLight.parameters = { config: {"renderingTarget":"Apps","darkModeAvailable":true} };
 		AppsShowcaseStandardNewsPillarLight.decorators = [lightDecorator(
 				[{
 					display:  ArticleDisplay.Showcase,
@@ -106,7 +106,26 @@ export default {
 			),
 		];
 
-		
+		export const AppsShowcaseStandardNewsPillarDark = () => {
+			return (
+				<HydratedLayoutWrapper
+					displayName="Showcase"
+					designName="Standard"
+					theme="NewsPillar"
+					renderingTarget="Apps"
+				/>
+			);
+		};
+		AppsShowcaseStandardNewsPillarDark.storyName = 'Apps: Display: Showcase, Design: Standard, Theme: NewsPillar, Mode: Dark';
+		AppsShowcaseStandardNewsPillarDark.parameters = { config: {"renderingTarget":"Apps","darkModeAvailable":true} };
+		AppsShowcaseStandardNewsPillarDark.decorators = [darkDecorator(
+				[{
+					display:  ArticleDisplay.Showcase,
+					design: ArticleDesign.Standard,
+					theme: {...ArticleSpecial, ...Pillar}.News,
+				}]
+			),
+		];
 
 		export const WebShowcasePictureOpinionPillarLight = () => {
 			return (


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Adds darkmode colours for a showcase article.

> NOTE: Layout stories appear incomplete in dark mode. This is expected. Certain components (eg headline) have not had darkmode implemented yet. Adding these stories now is another way to understand which components still need dark mode. 

## Why?
This is part of a larger body of work to support dark mode on apps.

## Screenshots
![Screenshot 2023-11-21 at 16 25 28](https://github.com/guardian/dotcom-rendering/assets/20416599/38fee0a9-7a81-4e6a-9be9-8d1d15a0d00b)

See chromatic for further screenshots

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
