### PR TITLE
Use `PaletteFunction` type explicitely

### DIFF
--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -38,7 +38,7 @@ const pillarPalette = (
 	}
 };
 
-const headlineColourLight = ({ design }: ArticleFormat): string => {
+const headlineColourLight: PaletteFunction = ({ design }) => {
 	switch (design) {
 		case ArticleDesign.Feature:
 			return sourcePalette.news[300];
@@ -46,7 +46,7 @@ const headlineColourLight = ({ design }: ArticleFormat): string => {
 			return sourcePalette.neutral[10];
 	}
 };
-const headlineColourDark = ({ design }: ArticleFormat): string => {
+const headlineColourDark: PaletteFunction = ({ design }) => {
 	switch (design) {
 		case ArticleDesign.Feature:
 			return sourcePalette.news[600];
@@ -54,7 +54,7 @@ const headlineColourDark = ({ design }: ArticleFormat): string => {
 			return sourcePalette.neutral[97];
 	}
 };
-const headlineBackgroundLight = ({ design }: ArticleFormat): string => {
+const headlineBackgroundLight: PaletteFunction = ({ design }) => {
 	switch (design) {
 		case ArticleDesign.LiveBlog:
 			return sourcePalette.news[400];
@@ -62,7 +62,7 @@ const headlineBackgroundLight = ({ design }: ArticleFormat): string => {
 			return sourcePalette.neutral[100];
 	}
 };
-const headlineBackgroundDark = ({ design }: ArticleFormat): string => {
+const headlineBackgroundDark: PaletteFunction = ({ design }) => {
 	switch (design) {
 		case ArticleDesign.LiveBlog:
 			return sourcePalette.news[200];
@@ -71,7 +71,7 @@ const headlineBackgroundDark = ({ design }: ArticleFormat): string => {
 	}
 };
 
-const bylineLight = ({ design, theme }: ArticleFormat): string => {
+const bylineLight: PaletteFunction = ({ design, theme }) => {
 	switch (design) {
 		case ArticleDesign.Analysis:
 			return sourcePalette.neutral[46];
@@ -138,7 +138,7 @@ const bylineLight = ({ design, theme }: ArticleFormat): string => {
 	}
 };
 
-const bylineDark = ({ design, theme }: ArticleFormat): string => {
+const bylineDark: PaletteFunction = ({ design, theme }) => {
 	switch (design) {
 		case ArticleDesign.Standard:
 		case ArticleDesign.Review:
@@ -526,7 +526,7 @@ const bylineUnderline: PaletteFunction = ({ theme }) => {
 	}
 };
 
-const headlineBorder = ({ design }: ArticleFormat): string => {
+const headlineBorder: PaletteFunction = ({ design }) => {
 	switch (design) {
 		case ArticleDesign.LiveBlog:
 			return 'rgba(255,255,255, 0.2)';
@@ -537,7 +537,7 @@ const headlineBorder = ({ design }: ArticleFormat): string => {
 	}
 };
 
-const avatarLight = ({ design, theme }: ArticleFormat): string => {
+const avatarLight: PaletteFunction = ({ design, theme }) => {
 	switch (design) {
 		case ArticleDesign.Standard:
 		case ArticleDesign.Review:
@@ -592,7 +592,7 @@ const avatarLight = ({ design, theme }: ArticleFormat): string => {
 	}
 };
 
-const avatarDark = ({ design, theme }: ArticleFormat): string => {
+const avatarDark: PaletteFunction = ({ design, theme }) => {
 	switch (design) {
 		case ArticleDesign.Standard:
 		case ArticleDesign.Review:
@@ -618,7 +618,7 @@ const avatarDark = ({ design, theme }: ArticleFormat): string => {
 	}
 };
 
-const followTextLight = ({ design }: ArticleFormat): string => {
+const followTextLight: PaletteFunction = ({ design }) => {
 	switch (design) {
 		case ArticleDesign.Gallery:
 			return sourcePalette.neutral[86];
@@ -629,7 +629,7 @@ const followTextLight = ({ design }: ArticleFormat): string => {
 			return sourcePalette.neutral[7];
 	}
 };
-const followTextDark = ({ design }: ArticleFormat): string => {
+const followTextDark: PaletteFunction = ({ design }) => {
 	switch (design) {
 		case ArticleDesign.LiveBlog:
 		case ArticleDesign.DeadBlog:
@@ -641,10 +641,7 @@ const followTextDark = ({ design }: ArticleFormat): string => {
 	}
 };
 
-const followIconBackgroundLight = ({
-	design,
-	theme,
-}: ArticleFormat): string => {
+const followIconBackgroundLight: PaletteFunction = ({ design, theme }) => {
 	switch (design) {
 		case ArticleDesign.LiveBlog:
 			switch (theme) {
@@ -697,7 +694,7 @@ const followIconBackgroundLight = ({
 			return sourcePalette.neutral[100];
 	}
 };
-const followIconBackgroundDark = ({ theme, design }: ArticleFormat): string => {
+const followIconBackgroundDark: PaletteFunction = ({ theme, design }) => {
 	switch (design) {
 		case ArticleDesign.DeadBlog:
 			return sourcePalette.neutral[7];
@@ -726,7 +723,7 @@ const followIconBackgroundDark = ({ theme, design }: ArticleFormat): string => {
 	}
 };
 
-const followIconFillLight = ({ design, theme }: ArticleFormat): string => {
+const followIconFillLight: PaletteFunction = ({ design, theme }) => {
 	switch (design) {
 		case ArticleDesign.Gallery:
 			switch (theme) {
@@ -834,7 +831,7 @@ const followIconFillLight = ({ design, theme }: ArticleFormat): string => {
 			}
 	}
 };
-const followIconFillDark = ({ theme, design }: ArticleFormat): string => {
+const followIconFillDark: PaletteFunction = ({ theme, design }) => {
 	switch (design) {
 		case ArticleDesign.LiveBlog:
 			return sourcePalette.neutral[93];
@@ -910,14 +907,16 @@ const followIconFillDark = ({ theme, design }: ArticleFormat): string => {
 	}
 };
 
-const starRatingFillColourLight = (): string => sourcePalette.neutral[7];
-const starRatingFillColourDark = (): string => sourcePalette.neutral[0];
-const starRatingBackgroundColourLight = (): string =>
+const starRatingFillColourLight: PaletteFunction = () =>
+	sourcePalette.neutral[7];
+const starRatingFillColourDark: PaletteFunction = () =>
+	sourcePalette.neutral[0];
+const starRatingBackgroundColourLight: PaletteFunction = () =>
 	sourcePalette.brandAlt[400];
-const starRatingBackgroundColourDark = (): string =>
+const starRatingBackgroundColourDark: PaletteFunction = () =>
 	sourcePalette.brandAlt[200];
 
-const blockQuoteFillLight = ({ design, theme }: ArticleFormat): string => {
+const blockQuoteFillLight: PaletteFunction = ({ design, theme }) => {
 	switch (design) {
 		case ArticleDesign.LiveBlog:
 		case ArticleDesign.DeadBlog: {
@@ -982,7 +981,7 @@ const blockQuoteFillLight = ({ design, theme }: ArticleFormat): string => {
 		}
 	}
 };
-const blockQuoteFillDark = ({ design, theme }: ArticleFormat): string => {
+const blockQuoteFillDark: PaletteFunction = ({ design, theme }) => {
 	switch (design) {
 		case ArticleDesign.DeadBlog:
 		case ArticleDesign.LiveBlog:
@@ -1032,7 +1031,7 @@ const blockQuoteFillDark = ({ design, theme }: ArticleFormat): string => {
 			}
 	}
 };
-const quotedBlockquoteStylesLight = (format: ArticleFormat): string => {
+const quotedBlockquoteStylesLight: PaletteFunction = (format): string => {
 	if (format.theme === ArticleSpecial.SpecialReportAlt)
 		return sourcePalette.neutral[7];
 
@@ -1046,68 +1045,80 @@ const quotedBlockquoteStylesLight = (format: ArticleFormat): string => {
 			return sourcePalette.neutral[46];
 	}
 };
-const quotedBlockquoteStylesDark = (): string => sourcePalette.neutral[100];
+const quotedBlockquoteStylesDark: PaletteFunction = () =>
+	sourcePalette.neutral[100];
 
-const accordionTitleRowFillLight = (): string => sourcePalette.neutral[46];
-const accordionTitleRowFillDark = (): string => sourcePalette.neutral[60];
-const accordionTitleRowBackgroundLight = (): string =>
+const accordionTitleRowFillLight: PaletteFunction = () =>
+	sourcePalette.neutral[46];
+const accordionTitleRowFillDark: PaletteFunction = () =>
+	sourcePalette.neutral[60];
+const accordionTitleRowBackgroundLight: PaletteFunction = () =>
 	sourcePalette.neutral[100];
-const accordionTitleRowBackgroundDark = (): string => sourcePalette.neutral[10];
-const accordionTitleRowBorderTopLight = (): string => sourcePalette.neutral[86];
-const accordionTitleRowBorderTopDark = (): string => sourcePalette.neutral[20];
-const accordionTitleLight = (): string => sourcePalette.neutral[7];
-const accordionTitleDark = (): string => sourcePalette.neutral[86];
-const accordionKeyEventsBackgroundLight = (): string =>
+const accordionTitleRowBackgroundDark: PaletteFunction = () =>
+	sourcePalette.neutral[10];
+const accordionTitleRowBorderTopLight: PaletteFunction = () =>
+	sourcePalette.neutral[86];
+const accordionTitleRowBorderTopDark: PaletteFunction = () =>
+	sourcePalette.neutral[20];
+const accordionTitleLight: PaletteFunction = () => sourcePalette.neutral[7];
+const accordionTitleDark: PaletteFunction = () => sourcePalette.neutral[86];
+const accordionKeyEventsBackgroundLight: PaletteFunction = () =>
 	sourcePalette.neutral[100];
-const accordionBackgroundDark = (): string => sourcePalette.neutral[10];
-const accordionLiveFeedBackgroundLight = (): string =>
+const accordionBackgroundDark: PaletteFunction = () =>
+	sourcePalette.neutral[10];
+const accordionLiveFeedBackgroundLight: PaletteFunction = () =>
 	sourcePalette.neutral[97];
 
-const tableOfContentsLight = (): string => sourcePalette.neutral[7];
-const tableOfContentsDark = (): string => sourcePalette.neutral[86];
-const tableOfContentsBorderLight = (): string => sourcePalette.neutral[86];
-const tableOfContentsBorderDark = (): string => sourcePalette.neutral[20];
+const tableOfContentsLight: PaletteFunction = () => sourcePalette.neutral[7];
+const tableOfContentsDark: PaletteFunction = () => sourcePalette.neutral[86];
+const tableOfContentsBorderLight: PaletteFunction = () =>
+	sourcePalette.neutral[86];
+const tableOfContentsBorderDark: PaletteFunction = () =>
+	sourcePalette.neutral[20];
 
-const adLabelsTextLight = (): string => {
+const adLabelsTextLight: PaletteFunction = () => {
 	return sourcePalette.neutral[20];
 };
-const adLabelsTextDark = (): string => {
+const adLabelsTextDark: PaletteFunction = () => {
 	return sourcePalette.neutral[100];
 };
-const adBackgroundLight = (): string => {
+const adBackgroundLight: PaletteFunction = () => {
 	return sourcePalette.neutral[97];
 };
-const adBackgroundDark = (): string => {
+const adBackgroundDark: PaletteFunction = () => {
 	return sourcePalette.neutral[20];
 };
-const adSupportBannerBackgroundLight = (): string => {
+const adSupportBannerBackgroundLight: PaletteFunction = () => {
 	return sourcePalette.neutral[93];
 };
-const adSupportBannerBackgroundDark = (): string => {
+const adSupportBannerBackgroundDark: PaletteFunction = () => {
 	return sourcePalette.neutral[46];
 };
-const adSupportBannerButtonBackgroundLight = (): string => {
+const adSupportBannerButtonBackgroundLight: PaletteFunction = () => {
 	return sourcePalette.brand[400];
 };
-const adSupportBannerButtonBackgroundDark = (): string => {
+const adSupportBannerButtonBackgroundDark: PaletteFunction = () => {
 	return sourcePalette.neutral[100];
 };
-const adSupportBannerButtonTextLight = (): string => {
+const adSupportBannerButtonTextLight: PaletteFunction = () => {
 	return sourcePalette.neutral[100];
 };
-const adSupportBannerButtonTextDark = (): string => {
+const adSupportBannerButtonTextDark: PaletteFunction = () => {
 	return sourcePalette.neutral[0];
 };
-const adSupportBannerTextLight = (): string => {
+const adSupportBannerTextLight: PaletteFunction = () => {
 	return sourcePalette.brand[400];
 };
-const adSupportBannerTextDark = (): string => {
+const adSupportBannerTextDark: PaletteFunction = () => {
 	return sourcePalette.neutral[100];
 };
 
-const appsFooterLinksTextLight = (): string => sourcePalette.neutral[7];
-const appsFooterLinksTextDark = (): string => sourcePalette.neutral[60];
-const appsFooterLinksBackgroundLight = (): string => sourcePalette.neutral[97];
+const appsFooterLinksTextLight: PaletteFunction = () =>
+	sourcePalette.neutral[7];
+const appsFooterLinksTextDark: PaletteFunction = () =>
+	sourcePalette.neutral[60];
+const appsFooterLinksBackgroundLight: PaletteFunction = () =>
+	sourcePalette.neutral[97];
 const appsFooterLinksBackgroundDark = (format: ArticleFormat): string => {
 	switch (format.design) {
 		case ArticleDesign.Gallery:
@@ -1116,22 +1127,26 @@ const appsFooterLinksBackgroundDark = (format: ArticleFormat): string => {
 			return sourcePalette.neutral[0];
 	}
 };
-const clickToViewBackgroundLight = (): string => sourcePalette.neutral[97];
-const clickToViewBackgroundDark = (): string => sourcePalette.neutral[20];
-const clickToViewBorderLight = (): string => sourcePalette.neutral[86];
-const clickToViewBorderDark = (): string => sourcePalette.neutral[46];
-const clickToViewButtonLight = (): string => sourcePalette.brand[400];
-const clickToViewButtonDark = (): string => sourcePalette.neutral[97];
-const clickToViewButtonTextLight = (): string =>
+const clickToViewBackgroundLight: PaletteFunction = () =>
+	sourcePalette.neutral[97];
+const clickToViewBackgroundDark: PaletteFunction = () =>
+	sourcePalette.neutral[20];
+const clickToViewBorderLight: PaletteFunction = () => sourcePalette.neutral[86];
+const clickToViewBorderDark: PaletteFunction = () => sourcePalette.neutral[46];
+const clickToViewButtonLight: PaletteFunction = () => sourcePalette.brand[400];
+const clickToViewButtonDark: PaletteFunction = () => sourcePalette.neutral[97];
+const clickToViewButtonTextLight: PaletteFunction = () =>
 	buttonThemeDefault.button.textPrimary;
-const clickToViewButtonTextDark = (): string => sourcePalette.neutral[7];
-const clickToViewButtonHoverLight = (): string =>
+const clickToViewButtonTextDark: PaletteFunction = () =>
+	sourcePalette.neutral[7];
+const clickToViewButtonHoverLight: PaletteFunction = () =>
 	buttonThemeDefault.button.backgroundPrimaryHover;
-const clickToViewButtonHoverDark = (): string => sourcePalette.neutral[86];
+const clickToViewButtonHoverDark: PaletteFunction = () =>
+	sourcePalette.neutral[86];
 
-const brandingLabelLight = (): string => sourcePalette.neutral[20];
-const brandingLabelDark = (): string => sourcePalette.neutral[86];
-const brandingLinkLight = ({ design, theme }: ArticleFormat): string => {
+const brandingLabelLight: PaletteFunction = () => sourcePalette.neutral[20];
+const brandingLabelDark: PaletteFunction = () => sourcePalette.neutral[86];
+const brandingLinkLight: PaletteFunction = ({ design, theme }) => {
 	switch (theme) {
 		case ArticleSpecial.Labs:
 			return sourcePalette.neutral[7];
@@ -1150,7 +1165,7 @@ const brandingLinkLight = ({ design, theme }: ArticleFormat): string => {
 			return pillarPalette(theme, 400);
 	}
 };
-const brandingLinkDark = ({ design, theme }: ArticleFormat): string => {
+const brandingLinkDark: PaletteFunction = ({ design, theme }) => {
 	switch (design) {
 		case ArticleDesign.Standard:
 		case ArticleDesign.Review:
@@ -1197,7 +1212,7 @@ const brandingLinkDark = ({ design, theme }: ArticleFormat): string => {
 	}
 };
 
-const standfirstBulletDark = ({ design, theme }: ArticleFormat): string => {
+const standfirstBulletDark: PaletteFunction = ({ design, theme }) => {
 	switch (design) {
 		case ArticleDesign.DeadBlog:
 			return sourcePalette.neutral[46];
@@ -1238,7 +1253,7 @@ const standfirstBulletDark = ({ design, theme }: ArticleFormat): string => {
 	}
 };
 
-const standfirstBulletLight = ({ design, theme }: ArticleFormat): string => {
+const standfirstBulletLight: PaletteFunction = ({ design, theme }) => {
 	switch (design) {
 		case ArticleDesign.DeadBlog:
 		case ArticleDesign.Analysis:
@@ -1272,10 +1287,7 @@ const standfirstBulletLight = ({ design, theme }: ArticleFormat): string => {
 	}
 };
 
-const standfirstLinkBorderLight = ({
-	design,
-	theme,
-}: ArticleFormat): string => {
+const standfirstLinkBorderLight: PaletteFunction = ({ design, theme }) => {
 	switch (design) {
 		case ArticleDesign.LiveBlog:
 			switch (theme) {
@@ -1309,15 +1321,11 @@ const standfirstLinkBorderLight = ({
 			}
 	}
 };
-const standfirstLinkBorderDark = (): string => {
+const standfirstLinkBorderDark: PaletteFunction = () => {
 	return sourcePalette.neutral[46];
 };
 
-const standfirstBackground = ({
-	design,
-	display,
-	theme,
-}: ArticleFormat): string => {
+const standfirstBackground: PaletteFunction = ({ design, display, theme }) => {
 	switch (design) {
 		case ArticleDesign.LiveBlog:
 			switch (theme) {
@@ -1344,7 +1352,7 @@ const standfirstBackground = ({
 	}
 };
 
-const standfirstBorder = ({ design }: ArticleFormat): string => {
+const standfirstBorder: PaletteFunction = ({ design }) => {
 	switch (design) {
 		case ArticleDesign.LiveBlog:
 			return 'rgba(255,255,255, 0.2)';
@@ -1355,7 +1363,7 @@ const standfirstBorder = ({ design }: ArticleFormat): string => {
 	}
 };
 
-const standfirstLinkTextLight = ({ design, theme }: ArticleFormat): string => {
+const standfirstLinkTextLight: PaletteFunction = ({ design, theme }) => {
 	switch (design) {
 		case ArticleDesign.LiveBlog:
 			return sourcePalette.neutral[100];
@@ -1437,7 +1445,7 @@ const standfirstLinkTextLight = ({ design, theme }: ArticleFormat): string => {
 			}
 	}
 };
-const standfirstLinkTextDark = ({ design, theme }: ArticleFormat): string => {
+const standfirstLinkTextDark: PaletteFunction = ({ design, theme }) => {
 	switch (design) {
 		case ArticleDesign.LiveBlog:
 		case ArticleDesign.DeadBlog:
@@ -1489,7 +1497,7 @@ const standfirstLinkTextDark = ({ design, theme }: ArticleFormat): string => {
 	}
 };
 
-const standfirstTextLight = (format: ArticleFormat): string => {
+const standfirstTextLight: PaletteFunction = (format) => {
 	switch (format.design) {
 		case ArticleDesign.LiveBlog:
 			return sourcePalette.neutral[100];
@@ -1506,11 +1514,7 @@ const standfirstTextLight = (format: ArticleFormat): string => {
 	}
 };
 
-const standfirstTextDark = ({
-	design,
-	display,
-	theme,
-}: ArticleFormat): string => {
+const standfirstTextDark: PaletteFunction = ({ design, display, theme }) => {
 	switch (design) {
 		case ArticleDesign.LiveBlog:
 		case ArticleDesign.DeadBlog:
@@ -1546,7 +1550,7 @@ const standfirstTextDark = ({
 	}
 };
 
-const captionTextLight = ({ design, theme }: ArticleFormat): string => {
+const captionTextLight: PaletteFunction = ({ design, theme }) => {
 	switch (theme) {
 		case ArticleSpecial.SpecialReport:
 			return sourcePalette.specialReport[100];
@@ -1592,7 +1596,7 @@ const captionTextLight = ({ design, theme }: ArticleFormat): string => {
 	}
 };
 
-const captionTextDark = ({ design, theme }: ArticleFormat): string => {
+const captionTextDark: PaletteFunction = ({ design, theme }) => {
 	switch (design) {
 		case ArticleDesign.Standard:
 		case ArticleDesign.Review:
@@ -1617,7 +1621,7 @@ const captionTextDark = ({ design, theme }: ArticleFormat): string => {
 	}
 };
 
-const captionLink = ({ design, theme }: ArticleFormat): string => {
+const captionLink: PaletteFunction = ({ design, theme }) => {
 	if (design === ArticleDesign.NewsletterSignup)
 		return sourcePalette.neutral[0];
 	if (design === ArticleDesign.Analysis && theme === Pillar.News)
@@ -1642,20 +1646,22 @@ const captionLink = ({ design, theme }: ArticleFormat): string => {
 	}
 };
 
-const captionOverlayText = (): string => {
+const captionOverlayText: PaletteFunction = () => {
 	return sourcePalette.neutral[100];
 };
 
-const keyEventBulletLight = (): string => sourcePalette.neutral[46];
-const keyEventBulletDark = (): string => sourcePalette.neutral[60];
+const keyEventBulletLight: PaletteFunction = () => sourcePalette.neutral[46];
+const keyEventBulletDark: PaletteFunction = () => sourcePalette.neutral[60];
 
-const keyEventBulletHoverLight = (): string => sourcePalette.neutral[0];
-const keyEventBulletHoverDark = (): string => sourcePalette.neutral[86];
+const keyEventBulletHoverLight: PaletteFunction = () =>
+	sourcePalette.neutral[0];
+const keyEventBulletHoverDark: PaletteFunction = () =>
+	sourcePalette.neutral[86];
 
-const keyEventTitleLight = (): string => sourcePalette.neutral[7];
-const keyEventTitleDark = (): string => sourcePalette.neutral[86];
+const keyEventTitleLight: PaletteFunction = () => sourcePalette.neutral[7];
+const keyEventTitleDark: PaletteFunction = () => sourcePalette.neutral[86];
 
-const keyEventTextLight = ({ theme }: ArticleFormat): string => {
+const keyEventTextLight: PaletteFunction = ({ theme }) => {
 	switch (theme) {
 		case Pillar.News:
 			return sourcePalette.news[300];
@@ -1675,7 +1681,7 @@ const keyEventTextLight = ({ theme }: ArticleFormat): string => {
 			return sourcePalette.news[300];
 	}
 };
-const keyEventTextDark = ({ theme }: ArticleFormat): string => {
+const keyEventTextDark: PaletteFunction = ({ theme }) => {
 	switch (theme) {
 		case Pillar.News:
 			return sourcePalette.news[500];
@@ -1696,22 +1702,28 @@ const keyEventTextDark = ({ theme }: ArticleFormat): string => {
 	}
 };
 
-const keyEventBackgroundLight = (): string => sourcePalette.neutral[97];
-const keyEventBackgroundDark = (): string => sourcePalette.neutral[10];
+const keyEventBackgroundLight: PaletteFunction = () =>
+	sourcePalette.neutral[97];
+const keyEventBackgroundDark: PaletteFunction = () => sourcePalette.neutral[10];
 
-const keyEventBackgroundDesktopLight = (): string => sourcePalette.neutral[93];
-const keyEventBackgroundDesktopDark = (): string => sourcePalette.neutral[7];
+const keyEventBackgroundDesktopLight: PaletteFunction = () =>
+	sourcePalette.neutral[93];
+const keyEventBackgroundDesktopDark: PaletteFunction = () =>
+	sourcePalette.neutral[7];
 
-const keyEventBorderLight = (): string => sourcePalette.neutral[46];
-const keyEventBorderDark = (): string => sourcePalette.neutral[60];
-const keyEventButtonLight = (): string => sourcePalette.neutral[7];
-const keyEventButtonDark = (): string => sourcePalette.neutral[86];
-const keyEventButtonHoverLight = (): string => sourcePalette.brandAlt[300];
-const keyEventButtonHoverDark = (): string => sourcePalette.neutral[60];
-const keyEventButtonFillLight = (): string => sourcePalette.neutral[100];
-const keyEventButtonFillDark = (): string => sourcePalette.neutral[7];
+const keyEventBorderLight: PaletteFunction = () => sourcePalette.neutral[46];
+const keyEventBorderDark: PaletteFunction = () => sourcePalette.neutral[60];
+const keyEventButtonLight: PaletteFunction = () => sourcePalette.neutral[7];
+const keyEventButtonDark: PaletteFunction = () => sourcePalette.neutral[86];
+const keyEventButtonHoverLight: PaletteFunction = () =>
+	sourcePalette.brandAlt[300];
+const keyEventButtonHoverDark: PaletteFunction = () =>
+	sourcePalette.neutral[60];
+const keyEventButtonFillLight: PaletteFunction = () =>
+	sourcePalette.neutral[100];
+const keyEventButtonFillDark: PaletteFunction = () => sourcePalette.neutral[7];
 
-const summaryEventBulletLight = ({ theme }: ArticleFormat): string => {
+const summaryEventBulletLight: PaletteFunction = ({ theme }) => {
 	switch (theme) {
 		case Pillar.News:
 			return sourcePalette.news[400];
@@ -1731,7 +1743,7 @@ const summaryEventBulletLight = ({ theme }: ArticleFormat): string => {
 			return sourcePalette.news[400];
 	}
 };
-const summaryEventBulletDark = ({ theme }: ArticleFormat): string => {
+const summaryEventBulletDark: PaletteFunction = ({ theme }) => {
 	switch (theme) {
 		case Pillar.News:
 			return sourcePalette.news[500];
@@ -1751,7 +1763,7 @@ const summaryEventBulletDark = ({ theme }: ArticleFormat): string => {
 			return sourcePalette.news[500];
 	}
 };
-const summaryEventBulletHoverLight = ({ theme }: ArticleFormat): string => {
+const summaryEventBulletHoverLight: PaletteFunction = ({ theme }) => {
 	switch (theme) {
 		case Pillar.News:
 			return sourcePalette.news[200];
@@ -1771,7 +1783,7 @@ const summaryEventBulletHoverLight = ({ theme }: ArticleFormat): string => {
 			return sourcePalette.news[200];
 	}
 };
-const summaryEventBulletHoverDark = ({ theme }: ArticleFormat): string => {
+const summaryEventBulletHoverDark: PaletteFunction = ({ theme }) => {
 	switch (theme) {
 		case Pillar.News:
 			return sourcePalette.news[550];
@@ -1792,7 +1804,11 @@ const summaryEventBulletHoverDark = ({ theme }: ArticleFormat): string => {
 	}
 };
 
-const articleBackgroundLight = ({ design, display, theme }: ArticleFormat) => {
+const articleBackgroundLight: PaletteFunction = ({
+	design,
+	display,
+	theme,
+}) => {
 	switch (design) {
 		case ArticleDesign.LiveBlog:
 		case ArticleDesign.DeadBlog:
@@ -1843,7 +1859,7 @@ const articleBackgroundLight = ({ design, display, theme }: ArticleFormat) => {
 	}
 };
 
-const articleBackgroundDark = ({ design, theme }: ArticleFormat) => {
+const articleBackgroundDark: PaletteFunction = ({ design, theme }) => {
 	switch (design) {
 		case ArticleDesign.DeadBlog:
 			return sourcePalette.neutral[7];
@@ -1872,9 +1888,10 @@ const articleBackgroundDark = ({ design, theme }: ArticleFormat) => {
 	}
 };
 
-const articleSectionBackground = () => sourcePalette.brand[400];
+const articleSectionBackground: PaletteFunction = () =>
+	sourcePalette.brand[400];
 
-const articleLinkTextLight = ({ design, theme }: ArticleFormat): string => {
+const articleLinkTextLight: PaletteFunction = ({ design, theme }) => {
 	if (design === ArticleDesign.Analysis) return sourcePalette.news[300];
 	switch (theme) {
 		case Pillar.Lifestyle:
@@ -1890,9 +1907,9 @@ const articleLinkTextLight = ({ design, theme }: ArticleFormat): string => {
 	}
 };
 
-const articleLinkTextDark = (): string => sourcePalette.neutral[86];
+const articleLinkTextDark: PaletteFunction = () => sourcePalette.neutral[86];
 
-const articleLinkBorderLight = ({ design, theme }: ArticleFormat): string => {
+const articleLinkBorderLight: PaletteFunction = ({ design, theme }) => {
 	if (theme === ArticleSpecial.Labs) return sourcePalette.neutral[60];
 
 	if (theme === ArticleSpecial.SpecialReport)
@@ -1908,9 +1925,9 @@ const articleLinkBorderLight = ({ design, theme }: ArticleFormat): string => {
 	return sourcePalette.neutral[86];
 };
 
-const articleLinkBorderDark = () => sourcePalette.neutral[46];
+const articleLinkBorderDark: PaletteFunction = () => sourcePalette.neutral[46];
 
-const articleLinkHoverLight = ({ design, theme }: ArticleFormat): string => {
+const articleLinkHoverLight: PaletteFunction = ({ design, theme }) => {
 	switch (design) {
 		case ArticleDesign.DeadBlog:
 			switch (theme) {
@@ -1977,12 +1994,9 @@ const articleLinkHoverLight = ({ design, theme }: ArticleFormat): string => {
 	}
 };
 
-const articleLinkHoverDark = () => articleLinkTextDark();
+const articleLinkHoverDark: PaletteFunction = (f) => articleLinkTextDark(f);
 
-const articleLinkBorderHoverLight = ({
-	design,
-	theme,
-}: ArticleFormat): string => {
+const articleLinkBorderHoverLight: PaletteFunction = ({ design, theme }) => {
 	if (theme === ArticleSpecial.Labs) return sourcePalette.neutral[7];
 	if (theme === ArticleSpecial.SpecialReport)
 		return sourcePalette.specialReport[100];
@@ -2002,9 +2016,10 @@ const articleLinkBorderHoverLight = ({
 	return pillarPalette(theme, 400);
 };
 
-const articleLinkBorderHoverDark = () => articleLinkTextDark();
+const articleLinkBorderHoverDark: PaletteFunction = (f) =>
+	articleLinkTextDark(f);
 
-const articleBorder = ({ design, theme }: ArticleFormat): string => {
+const articleBorder: PaletteFunction = ({ design, theme }) => {
 	switch (theme) {
 		case ArticleSpecial.SpecialReportAlt:
 			return transparentColour(sourcePalette.neutral[60], 0.3);
@@ -2020,7 +2035,7 @@ const articleBorder = ({ design, theme }: ArticleFormat): string => {
 	}
 };
 
-const articleBorderSecondary = (format: ArticleFormat) => {
+const articleBorderSecondary: PaletteFunction = (format) => {
 	if (format.theme === ArticleSpecial.SpecialReportAlt)
 		return transparentColour(sourcePalette.neutral[60], 0.3);
 	if (format.design === ArticleDesign.Picture)
@@ -2028,7 +2043,7 @@ const articleBorderSecondary = (format: ArticleFormat) => {
 	return sourcePalette.neutral[86];
 };
 
-const subNavBorder = ({ design, theme }: ArticleFormat): string => {
+const subNavBorder: PaletteFunction = ({ design, theme }) => {
 	switch (design) {
 		case ArticleDesign.Analysis:
 			switch (theme) {
@@ -2071,7 +2086,7 @@ const subNavBorder = ({ design, theme }: ArticleFormat): string => {
 	}
 };
 
-const shareIconFillLight = ({ design, theme, display }: ArticleFormat) => {
+const shareIconFillLight: PaletteFunction = ({ design, theme, display }) => {
 	switch (design) {
 		case ArticleDesign.DeadBlog:
 			switch (theme) {
@@ -2125,9 +2140,9 @@ const shareIconFillLight = ({ design, theme, display }: ArticleFormat) => {
 	}
 };
 
-const shareIconFillDark = () => sourcePalette.neutral[60];
+const shareIconFillDark: PaletteFunction = () => sourcePalette.neutral[60];
 
-const shareIconFillBlogLight = ({ design, theme }: ArticleFormat) => {
+const shareIconFillBlogLight: PaletteFunction = ({ design, theme }) => {
 	switch (design) {
 		case ArticleDesign.LiveBlog:
 		case ArticleDesign.DeadBlog:
@@ -2156,13 +2171,15 @@ const shareIconFillBlogLight = ({ design, theme }: ArticleFormat) => {
 	}
 };
 
-const shareIconFillBlogDark = () => sourcePalette.neutral[60];
-const matchNavBackground = () => sourcePalette.brandAlt[400];
+const shareIconFillBlogDark: PaletteFunction = () => sourcePalette.neutral[60];
+const matchNavBackground: PaletteFunction = () => sourcePalette.brandAlt[400];
 
-const liveBlockContainerBackgroundLight = () => sourcePalette.neutral[100];
-const liveBlockContainerBackgroundDark = () => sourcePalette.neutral[10];
+const liveBlockContainerBackgroundLight: PaletteFunction = () =>
+	sourcePalette.neutral[100];
+const liveBlockContainerBackgroundDark: PaletteFunction = () =>
+	sourcePalette.neutral[10];
 
-const liveBlockBorderTopLight = ({ design, theme }: ArticleFormat) => {
+const liveBlockBorderTopLight: PaletteFunction = ({ design, theme }) => {
 	if (design === ArticleDesign.DeadBlog) {
 		switch (theme) {
 			case Pillar.Culture:
@@ -2185,12 +2202,14 @@ const liveBlockBorderTopLight = ({ design, theme }: ArticleFormat) => {
 	}
 };
 
-const liveBlockBorderTopDark = () => sourcePalette.neutral[60];
+const liveBlockBorderTopDark: PaletteFunction = () => sourcePalette.neutral[60];
 
-const liveBlockBorderBottomLight = () => sourcePalette.neutral[86];
-const liveBlockBorderBottomDark = () => sourcePalette.neutral[46];
+const liveBlockBorderBottomLight: PaletteFunction = () =>
+	sourcePalette.neutral[86];
+const liveBlockBorderBottomDark: PaletteFunction = () =>
+	sourcePalette.neutral[46];
 
-const subMetaLabelTextLight = ({ theme, design }: ArticleFormat): string => {
+const subMetaLabelTextLight: PaletteFunction = ({ theme, design }) => {
 	switch (theme) {
 		case ArticleSpecial.Labs:
 			return sourcePalette.neutral[7];
@@ -2213,10 +2232,14 @@ const subMetaLabelTextLight = ({ theme, design }: ArticleFormat): string => {
 			}
 	}
 };
-const subMetaLabelTextDark = (): string => {
+const subMetaLabelTextDark: PaletteFunction = () => {
 	return sourcePalette.neutral[86];
 };
-const subMetaBackgroundLight = ({ design, theme, display }: ArticleFormat) => {
+const subMetaBackgroundLight: PaletteFunction = ({
+	design,
+	theme,
+	display,
+}) => {
 	switch (design) {
 		case ArticleDesign.LiveBlog:
 		case ArticleDesign.DeadBlog:
@@ -2266,7 +2289,7 @@ const subMetaBackgroundLight = ({ design, theme, display }: ArticleFormat) => {
 	}
 };
 
-const subMetaBackgroundDark = ({ design, theme }: ArticleFormat): string => {
+const subMetaBackgroundDark: PaletteFunction = ({ design, theme }) => {
 	switch (design) {
 		case ArticleDesign.DeadBlog:
 			return sourcePalette.neutral[7];
@@ -2295,7 +2318,7 @@ const subMetaBackgroundDark = ({ design, theme }: ArticleFormat): string => {
 	}
 };
 
-const subMetaTextLight = ({ design, theme }: ArticleFormat): string => {
+const subMetaTextLight: PaletteFunction = ({ design, theme }) => {
 	switch (theme) {
 		case ArticleSpecial.Labs:
 			return sourcePalette.neutral[7];
@@ -2342,7 +2365,7 @@ const subMetaTextLight = ({ design, theme }: ArticleFormat): string => {
 	}
 };
 
-const subMetaTextDark = ({ theme }: ArticleFormat): string => {
+const subMetaTextDark: PaletteFunction = ({ theme }) => {
 	switch (theme) {
 		case ArticleSpecial.SpecialReport:
 			return sourcePalette.specialReport[700];
@@ -2357,9 +2380,9 @@ const subMetaTextDark = ({ theme }: ArticleFormat): string => {
 	}
 };
 
-const subMetaTextHoverLight = () => sourcePalette.neutral[100];
+const subMetaTextHoverLight: PaletteFunction = () => sourcePalette.neutral[100];
 
-const syndicationButtonText = ({ design, theme }: ArticleFormat): string => {
+const syndicationButtonText: PaletteFunction = ({ design, theme }) => {
 	switch (theme) {
 		case ArticleSpecial.Labs:
 			return sourcePalette.neutral[7];
@@ -2378,7 +2401,7 @@ const syndicationButtonText = ({ design, theme }: ArticleFormat): string => {
 	}
 };
 
-const syndicationButtonBorder = ({ design, theme }: ArticleFormat): string => {
+const syndicationButtonBorder: PaletteFunction = ({ design, theme }) => {
 	switch (theme) {
 		case ArticleSpecial.Labs:
 			return sourcePalette.neutral[60];


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Use `PaletteFunction` type directly to all functions inside `palette.ts`.

## Why?

Bring consistency to the existing patterns, and get TS errors at the production site rather than the consumption site.

When writing a new function, you want to make sure that it will be able to accept an `ArticleFormat` and return a `string`. If the function signature does not match `PaletteFunction`, the error will be raised by TS inside `paletteColours` declaration rather than as part of the function declaration.