### PR TITLE
Add canonical link to apps articles

### DIFF
--- a/dotcom-rendering/src/server/render.article.apps.tsx
+++ b/dotcom-rendering/src/server/render.article.apps.tsx
@@ -65,6 +65,7 @@ export const renderArticle = (
 		renderingTarget: 'Apps',
 		offerHttp3: false,
 		weAreHiring: !!article.config.switches.weAreHiring,
+		canonicalUrl: article.canonicalUrl,
 	});
 
 	return {


### PR DESCRIPTION
DCAR articles should also include a canonical link!

## What are canonical links, and why do we want them?

When web crawlers index a website, they might encounter duplicate pages. Canonicalisation is a process of choosing a representative URL for the content which has the effect of de-duplicating it. A page might have duplicate versions for regional or device variants.

Providing a canonical link in the page markup hints to the web crawler which URL it should use as the representative version in search results. It's important to note that this is just a hint; the crawler might choose any of the variants based on various factors. [^1]

[^1]: https://developers.google.com/search/docs/crawling-indexing/canonicalization