### PR TITLE
Culture Live Blog has breaking news banner

### DIFF
--- a/dotcom-rendering/scripts/gen-stories/get-stories.mjs
+++ b/dotcom-rendering/scripts/gen-stories/get-stories.mjs
@@ -278,6 +278,48 @@ const testLayoutFormats =
 		{
 			display: 'Standard',
 			design: 'LiveBlog',
+			theme: 'OpinionPillar',
+			config: { renderingTarget: 'Web', darkModeAvailable: false },
+		},
+		{
+			display: 'Standard',
+			design: 'LiveBlog',
+			theme: 'SportPillar',
+			config: { renderingTarget: 'Web', darkModeAvailable: false },
+		},
+		{
+			display: 'Standard',
+			design: 'LiveBlog',
+			theme: 'CulturePillar',
+			config: { renderingTarget: 'Web', darkModeAvailable: false },
+		},
+		{
+			display: 'Standard',
+			design: 'LiveBlog',
+			theme: 'LifestylePillar',
+			config: { renderingTarget: 'Web', darkModeAvailable: false },
+		},
+		{
+			display: 'Standard',
+			design: 'LiveBlog',
+			theme: 'SpecialReportPillar',
+			config: { renderingTarget: 'Web', darkModeAvailable: false },
+		},
+		{
+			display: 'Standard',
+			design: 'LiveBlog',
+			theme: 'LabsPillar',
+			config: { renderingTarget: 'Web', darkModeAvailable: false },
+		},
+		{
+			display: 'Standard',
+			design: 'LiveBlog',
+			theme: 'SpecialReportAltPillar',
+			config: { renderingTarget: 'Web', darkModeAvailable: false },
+		},
+		{
+			display: 'Standard',
+			design: 'LiveBlog',
 			theme: 'NewsPillar',
 			config: { renderingTarget: 'Apps', darkModeAvailable: true },
 		},

--- a/dotcom-rendering/src/layouts/Layout.stories.tsx
+++ b/dotcom-rendering/src/layouts/Layout.stories.tsx
@@ -1,3 +1,4 @@
+import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
 import { useEffect } from 'react';
 import { lightDecorator } from '../../.storybook/decorators/themeDecorator';
 import { Analysis } from '../../fixtures/generated/articles/Analysis';
@@ -152,3 +153,20 @@ export const LiveblogWithNoKeyEvents = () => {
 LiveblogWithNoKeyEvents.decorators = [
 	lightDecorator([decideFormat(Live.format)]),
 ];
+
+const liveBlogCultureFormat: ArticleFormat = {
+	design: ArticleDesign.LiveBlog,
+	display: ArticleDisplay.Standard,
+	theme: Pillar.Culture,
+};
+export const LiveBlogCulture = () => {
+	return (
+		<HydratedLayout
+			serverArticle={{
+				...Live,
+			}}
+			renderingTarget="Web"
+		/>
+	);
+};
+LiveBlogCulture.decorators = [lightDecorator([liveBlogCultureFormat])];

--- a/dotcom-rendering/src/layouts/Layout.stories.tsx
+++ b/dotcom-rendering/src/layouts/Layout.stories.tsx
@@ -1,4 +1,3 @@
-import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
 import { useEffect } from 'react';
 import { lightDecorator } from '../../.storybook/decorators/themeDecorator';
 import { Analysis } from '../../fixtures/generated/articles/Analysis';
@@ -153,20 +152,3 @@ export const LiveblogWithNoKeyEvents = () => {
 LiveblogWithNoKeyEvents.decorators = [
 	lightDecorator([decideFormat(Live.format)]),
 ];
-
-const liveBlogCultureFormat: ArticleFormat = {
-	design: ArticleDesign.LiveBlog,
-	display: ArticleDisplay.Standard,
-	theme: Pillar.Culture,
-};
-export const LiveBlogCulture = () => {
-	return (
-		<HydratedLayout
-			serverArticle={{
-				...Live,
-			}}
-			renderingTarget="Web"
-		/>
-	);
-};
-LiveBlogCulture.decorators = [lightDecorator([liveBlogCultureFormat])];

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -477,7 +477,7 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 					<Section
 						fullWidth={true}
 						showTopBorder={false}
-						backgroundColour={themePalette('--headline-background')}
+						backgroundColour={themePalette('--header-background')}
 						borderColour={themePalette('--headline-border')}
 					>
 						<HeadlineGrid>

--- a/dotcom-rendering/src/lib/decidePalette.ts
+++ b/dotcom-rendering/src/lib/decidePalette.ts
@@ -735,6 +735,7 @@ const backgroundBulletStandfirst = (format: ArticleFormat): string => {
 	return neutral[86]; // default previously defined in Standfirst.tsx
 };
 
+/** @deprecated use headerBackground in palette.ts */
 const backgroundHeader = (format: ArticleFormat): string => {
 	switch (format.design) {
 		case ArticleDesign.LiveBlog:

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -54,6 +54,39 @@ const headlineColourDark: PaletteFunction = ({ design }) => {
 			return sourcePalette.neutral[97];
 	}
 };
+const headerBackgroundLight: PaletteFunction = ({ design, display, theme }) => {
+	switch (design) {
+		case ArticleDesign.LiveBlog:
+			switch (theme) {
+				case Pillar.News:
+				case ArticleSpecial.SpecialReportAlt:
+				case ArticleSpecial.Labs:
+					return sourcePalette.news[300];
+				case Pillar.Opinion:
+					return sourcePalette.opinion[300];
+				case Pillar.Sport:
+					return sourcePalette.sport[300];
+				case Pillar.Culture:
+					return sourcePalette.culture[300];
+				case Pillar.Lifestyle:
+					return sourcePalette.lifestyle[300];
+				case ArticleSpecial.SpecialReport:
+					return sourcePalette.specialReport[700];
+			}
+		default:
+			return articleBackgroundLight({ design, display, theme });
+	}
+};
+
+const headerBackgroundDark: PaletteFunction = ({ design }) => {
+	switch (design) {
+		case ArticleDesign.LiveBlog:
+			return sourcePalette.news[200];
+		default:
+			return sourcePalette.neutral[7];
+	}
+};
+
 const headlineBackgroundLight: PaletteFunction = ({ design }) => {
 	switch (design) {
 		case ArticleDesign.LiveBlog:
@@ -62,6 +95,7 @@ const headlineBackgroundLight: PaletteFunction = ({ design }) => {
 			return sourcePalette.neutral[100];
 	}
 };
+
 const headlineBackgroundDark: PaletteFunction = ({ design }) => {
 	switch (design) {
 		case ArticleDesign.LiveBlog:
@@ -2482,6 +2516,10 @@ const paletteColours = {
 	'--headline-border': {
 		light: headlineBorder,
 		dark: headlineBorder,
+	},
+	'--header-background': {
+		light: headerBackgroundLight,
+		dark: headerBackgroundDark,
 	},
 	'--star-rating-fill': {
 		light: starRatingFillColourLight,

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -87,12 +87,30 @@ const headerBackgroundDark: PaletteFunction = ({ design }) => {
 	}
 };
 
-const headlineBackgroundLight: PaletteFunction = ({ design }) => {
-	switch (design) {
-		case ArticleDesign.LiveBlog:
-			return sourcePalette.news[400];
+const headlineBackgroundLight: PaletteFunction = ({
+	display,
+	design,
+	theme,
+}) => {
+	switch (display) {
+		case ArticleDisplay.Immersive:
+			switch (theme) {
+				case ArticleSpecial.SpecialReport:
+					return sourcePalette.specialReport[300];
+				default:
+					return sourcePalette.neutral[0];
+			}
+		case ArticleDisplay.Showcase:
+		case ArticleDisplay.NumberedList:
+		case ArticleDisplay.Standard:
+			switch (design) {
+				case ArticleDesign.Interview:
+					return sourcePalette.neutral[0];
+				default:
+					return 'transparent';
+			}
 		default:
-			return sourcePalette.neutral[100];
+			return 'transparent';
 	}
 };
 

--- a/dotcom-rendering/stories/generated/Layout.stories.tsx
+++ b/dotcom-rendering/stories/generated/Layout.stories.tsx
@@ -338,6 +338,167 @@ export default {
 
 		
 
+		export const WebStandardLiveBlogOpinionPillarLight = () => {
+			return (
+				<HydratedLayoutWrapper
+					displayName="Standard"
+					designName="LiveBlog"
+					theme="OpinionPillar"
+					renderingTarget="Web"
+				/>
+			);
+		};
+		WebStandardLiveBlogOpinionPillarLight.storyName = 'Web: Display: Standard, Design: LiveBlog, Theme: OpinionPillar, Mode: Light';
+		WebStandardLiveBlogOpinionPillarLight.parameters = { config: {"renderingTarget":"Web","darkModeAvailable":false} };
+		WebStandardLiveBlogOpinionPillarLight.decorators = [lightDecorator(
+				[{
+					display:  ArticleDisplay.Standard,
+					design: ArticleDesign.LiveBlog,
+					theme: {...ArticleSpecial, ...Pillar}.Opinion,
+				}]
+			),
+		];
+
+		
+
+		export const WebStandardLiveBlogSportPillarLight = () => {
+			return (
+				<HydratedLayoutWrapper
+					displayName="Standard"
+					designName="LiveBlog"
+					theme="SportPillar"
+					renderingTarget="Web"
+				/>
+			);
+		};
+		WebStandardLiveBlogSportPillarLight.storyName = 'Web: Display: Standard, Design: LiveBlog, Theme: SportPillar, Mode: Light';
+		WebStandardLiveBlogSportPillarLight.parameters = { config: {"renderingTarget":"Web","darkModeAvailable":false} };
+		WebStandardLiveBlogSportPillarLight.decorators = [lightDecorator(
+				[{
+					display:  ArticleDisplay.Standard,
+					design: ArticleDesign.LiveBlog,
+					theme: {...ArticleSpecial, ...Pillar}.Sport,
+				}]
+			),
+		];
+
+		
+
+		export const WebStandardLiveBlogCulturePillarLight = () => {
+			return (
+				<HydratedLayoutWrapper
+					displayName="Standard"
+					designName="LiveBlog"
+					theme="CulturePillar"
+					renderingTarget="Web"
+				/>
+			);
+		};
+		WebStandardLiveBlogCulturePillarLight.storyName = 'Web: Display: Standard, Design: LiveBlog, Theme: CulturePillar, Mode: Light';
+		WebStandardLiveBlogCulturePillarLight.parameters = { config: {"renderingTarget":"Web","darkModeAvailable":false} };
+		WebStandardLiveBlogCulturePillarLight.decorators = [lightDecorator(
+				[{
+					display:  ArticleDisplay.Standard,
+					design: ArticleDesign.LiveBlog,
+					theme: {...ArticleSpecial, ...Pillar}.Culture,
+				}]
+			),
+		];
+
+		
+
+		export const WebStandardLiveBlogLifestylePillarLight = () => {
+			return (
+				<HydratedLayoutWrapper
+					displayName="Standard"
+					designName="LiveBlog"
+					theme="LifestylePillar"
+					renderingTarget="Web"
+				/>
+			);
+		};
+		WebStandardLiveBlogLifestylePillarLight.storyName = 'Web: Display: Standard, Design: LiveBlog, Theme: LifestylePillar, Mode: Light';
+		WebStandardLiveBlogLifestylePillarLight.parameters = { config: {"renderingTarget":"Web","darkModeAvailable":false} };
+		WebStandardLiveBlogLifestylePillarLight.decorators = [lightDecorator(
+				[{
+					display:  ArticleDisplay.Standard,
+					design: ArticleDesign.LiveBlog,
+					theme: {...ArticleSpecial, ...Pillar}.Lifestyle,
+				}]
+			),
+		];
+
+		
+
+		export const WebStandardLiveBlogSpecialReportPillarLight = () => {
+			return (
+				<HydratedLayoutWrapper
+					displayName="Standard"
+					designName="LiveBlog"
+					theme="SpecialReportPillar"
+					renderingTarget="Web"
+				/>
+			);
+		};
+		WebStandardLiveBlogSpecialReportPillarLight.storyName = 'Web: Display: Standard, Design: LiveBlog, Theme: SpecialReportPillar, Mode: Light';
+		WebStandardLiveBlogSpecialReportPillarLight.parameters = { config: {"renderingTarget":"Web","darkModeAvailable":false} };
+		WebStandardLiveBlogSpecialReportPillarLight.decorators = [lightDecorator(
+				[{
+					display:  ArticleDisplay.Standard,
+					design: ArticleDesign.LiveBlog,
+					theme: {...ArticleSpecial, ...Pillar}.SpecialReport,
+				}]
+			),
+		];
+
+		
+
+		export const WebStandardLiveBlogLabsPillarLight = () => {
+			return (
+				<HydratedLayoutWrapper
+					displayName="Standard"
+					designName="LiveBlog"
+					theme="LabsPillar"
+					renderingTarget="Web"
+				/>
+			);
+		};
+		WebStandardLiveBlogLabsPillarLight.storyName = 'Web: Display: Standard, Design: LiveBlog, Theme: LabsPillar, Mode: Light';
+		WebStandardLiveBlogLabsPillarLight.parameters = { config: {"renderingTarget":"Web","darkModeAvailable":false} };
+		WebStandardLiveBlogLabsPillarLight.decorators = [lightDecorator(
+				[{
+					display:  ArticleDisplay.Standard,
+					design: ArticleDesign.LiveBlog,
+					theme: {...ArticleSpecial, ...Pillar}.Labs,
+				}]
+			),
+		];
+
+		
+
+		export const WebStandardLiveBlogSpecialReportAltPillarLight = () => {
+			return (
+				<HydratedLayoutWrapper
+					displayName="Standard"
+					designName="LiveBlog"
+					theme="SpecialReportAltPillar"
+					renderingTarget="Web"
+				/>
+			);
+		};
+		WebStandardLiveBlogSpecialReportAltPillarLight.storyName = 'Web: Display: Standard, Design: LiveBlog, Theme: SpecialReportAltPillar, Mode: Light';
+		WebStandardLiveBlogSpecialReportAltPillarLight.parameters = { config: {"renderingTarget":"Web","darkModeAvailable":false} };
+		WebStandardLiveBlogSpecialReportAltPillarLight.decorators = [lightDecorator(
+				[{
+					display:  ArticleDisplay.Standard,
+					design: ArticleDesign.LiveBlog,
+					theme: {...ArticleSpecial, ...Pillar}.SpecialReportAlt,
+				}]
+			),
+		];
+
+		
+
 		export const AppsStandardLiveBlogNewsPillarLight = () => {
 			return (
 				<HydratedLayoutWrapper


### PR DESCRIPTION
## What does this change?

Adds a story to demonstrate the issue of a culture themed liveblog with a breaking news banner instead of the culture-themed one.

## Why

To replicate the issue reported in #9604 

## Screenshots

<img width="1272" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/43961396/6f01a3bf-7ce9-443b-ba6c-a8d745946405">
