### PR TITLE
fix path for index html in webpack dev config

### DIFF
--- a/dotcom-rendering/webpack/webpack.config.dev-server.js
+++ b/dotcom-rendering/webpack/webpack.config.dev-server.js
@@ -66,7 +66,6 @@ module.exports = {
 					path.join(
 						__dirname,
 						'..',
-						'..',
 						'src',
 						'server',
 						'dev-index.html',


### PR DESCRIPTION
## What does this change?

Fixes the pathname for the `dev-index.html` file in the webpack config

## Why?

`make dev` was broken (could not load the local development server homepage)

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/43961396/54da9317-76ec-4795-a60e-0faa3a6d36a2
[after]: https://github.com/guardian/dotcom-rendering/assets/43961396/1bed28c2-63cf-4ab7-8203-661dffcf9fc4
