### PR TITLE
Run `doctoc` when committing markdown files in DCR

### DIFF
--- a/dotcom-rendering/README.md
+++ b/dotcom-rendering/README.md
@@ -4,7 +4,7 @@ Frontend rendering framework for theguardian.com. It uses [React](https://reactj
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-<!-- Automatically created with yarn run createtoc and on push hook -->
+<!-- Automatically created by running `yarn createtoc` in a pre-commit hook -->
 
 -   [Quick start](#quick-start)
     -   [Install Node.js](#install-nodejs)
@@ -16,11 +16,12 @@ Frontend rendering framework for theguardian.com. It uses [React](https://reactj
     -   [Concepts](#concepts)
     -   [Visual Debugging](#visual-debugging)
     -   [Feedback](#feedback)
--   [Where can I see Dotcom Rendering in Production?](#where-can-i-see-dotcom-rendering-in-production)
+-   [Dotcom Rendering now renders most articles and fronts in Production](#dotcom-rendering-now-renders-most-articles-and-fronts-in-production)
 -   [Code Quality](#code-quality)
     -   [Snyk Code Scanning](#snyk-code-scanning)
 -   [IDE setup](#ide-setup)
     -   [Extensions](#extensions)
+    -   [Commit hooks](#commit-hooks)
     -   [Auto fix on save](#auto-fix-on-save)
 -   [Thanks](#thanks)
 

--- a/dotcom-rendering/docs/contributing/code-style.md
+++ b/dotcom-rendering/docs/contributing/code-style.md
@@ -2,7 +2,7 @@
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-<!-- Automatically created with yarn run createtoc and on push hook -->
+<!-- Automatically created by running `yarn createtoc` in a pre-commit hook -->
 
 -   [TypeScript](#typescript)
     -   [Always used named exports](#always-used-named-exports)

--- a/dotcom-rendering/docs/contributing/detailed-setup-guide.md
+++ b/dotcom-rendering/docs/contributing/detailed-setup-guide.md
@@ -2,7 +2,7 @@
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-<!-- Automatically created with yarn run createtoc and on push hook -->
+<!-- Automatically created by running `yarn createtoc` in a pre-commit hook -->
 
 -   [High level diagram](#high-level-diagram)
 -   [Developing](#developing)

--- a/dotcom-rendering/docs/contributing/how-to.md
+++ b/dotcom-rendering/docs/contributing/how-to.md
@@ -2,12 +2,12 @@
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-<!-- Automatically created with yarn run createtoc and on push hook -->
+<!-- Automatically created by running `yarn createtoc` in a pre-commit hook -->
 
 -   [How can I add to this document?](#how-can-i-add-to-this-document)
 -   [How can I add client-side JavaScript?](#how-can-i-add-client-side-javascript)
 -   [How can I create an 'island' in DCR?](#how-can-i-create-an-island-in-dcr)
--   [How can I make an AJAX request in DCR?](#how-can-i-make-an-ajax-request-in-dcr)
+-   [How to fetch external data on the client?](#how-to-fetch-external-data-on-the-client)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 

--- a/dotcom-rendering/docs/contributing/where-should-my-code-live.md
+++ b/dotcom-rendering/docs/contributing/where-should-my-code-live.md
@@ -2,19 +2,18 @@
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-<!-- Automatically created with yarn run createtoc and on push hook -->
+<!-- Automatically created by running `yarn createtoc` in a pre-commit hook -->
 
--   [Where should my code live?](#where-should-my-code-live)
-    -   [File locations](#file-locations)
-    -   [File naming schemes](#file-naming-schemes)
-    -   [Scripts](#scripts)
-    -   [Data Sources \& Extraction](#data-sources--extraction)
-        -   [Articles](#articles)
-        -   [Fronts](#fronts)
-        -   [Other](#other)
-        -   [Considerations](#considerations)
-            -   [Favour computation on the rendering server over computation on the client](#favour-computation-on-the-rendering-server-over-computation-on-the-client)
-            -   [Minimize data over the wire](#minimize-data-over-the-wire)
+-   [File locations](#file-locations)
+-   [File naming schemes](#file-naming-schemes)
+-   [Scripts](#scripts)
+-   [Data Sources & Extraction](#data-sources--extraction)
+    -   [Articles](#articles)
+    -   [Fronts](#fronts)
+    -   [Other](#other)
+    -   [Considerations](#considerations)
+        -   [Favour computation on the rendering server over computation on the client](#favour-computation-on-the-rendering-server-over-computation-on-the-client)
+        -   [Minimize data over the wire](#minimize-data-over-the-wire)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -16,7 +16,7 @@
 		"test": "jest --maxWorkers=50%",
 		"test:watch": "jest --watch --maxWorkers=25%",
 		"test:ci": "jest --runInBand",
-		"createtoc": "doctoc $npm_package_tocList --github --update-only --title '<!-- Automatically created with yarn run createtoc and on push hook -->' ",
+		"createtoc": "doctoc $npm_package_tocList --github --update-only --title '<!-- Automatically created by running `yarn createtoc` in a pre-commit hook -->' ",
 		"addandcommittoc": "git add $npm_package_tocList && git commit -m 'Add TOC update' || true",
 		"playwright:open": "playwright test --ui",
 		"playwright:run": "playwright test",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,10 @@
 		"prettier:write": "prettier --ignore-unknown --write --cache ."
 	},
 	"lint-staged": {
+		"dotcom-rendering/**/*.md": [
+			"yarn workspace @guardian/dotcom-rendering createtoc",
+			"prettier --write --cache"
+		],
 		"*": "prettier --ignore-unknown --write --cache"
 	},
 	"dependencies": {


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

run DCR's `createtoc` script in a `pre-commit` hook if it icnludes changes to markdown files in DCR

## Why?

dotcoc is used to keep a table of contents (toc) up to date in DCR markdown files. 

It looks like it was meant to run on a `pre-push` hook, but you can't commit changes pre-push, so i'm guessing it never worked.

whenever i save a readme, it always includes reformatted toc which are also now out of date. this should keep them up to date, while not affecting commits that aren't relevant.


