### PR TITLE
Dev Server Article Examples Table

### DIFF
--- a/dotcom-rendering/src/server/dev-index.html
+++ b/dotcom-rendering/src/server/dev-index.html
@@ -29,6 +29,52 @@
 			.test-article-header > span:nth-child(1) {
 				width: 14em !important;
 			}
+
+			.article-examples {
+				overflow-x: auto;
+			}
+
+			.article-examples__table {
+				text-align: left;
+				border-spacing: 0;
+			}
+
+			.article-examples__table th {
+				padding: 0.5rem 1rem;
+			}
+
+			.article-examples__table thead {
+				background-color: #dcdcdc;
+			}
+
+			.article-examples__table tbody tr:nth-child(even) {
+				background-color: #ededed;
+			}
+
+			.article-examples__table tbody tr:nth-child(odd) {
+				background-color: #f6f6f6;
+			}
+
+			.article-examples__table td {
+				padding: 1rem 2rem 1rem 1rem;
+				max-width: 20rem;
+				min-width: 9rem;
+			}
+
+			.article-examples__table dt {
+				font-weight: bold;
+				display: inline;
+			}
+
+			.article-examples__table dd {
+				display: inline;
+				margin: 0;
+			}
+
+			.article-examples__table .links,
+			.article-examples__table .format {
+				max-width: 9rem;
+			}
 		</style>
 	</head>
 	<body>
@@ -107,6 +153,110 @@
 				>
 			</li>
 		</ul>
+
+		<section>
+			<h2>Article Examples</h2>
+
+			<div class="article-examples">
+				<table class="article-examples__table">
+					<thead>
+						<tr>
+							<th rowspan="2">Headline</th>
+							<th rowspan="2">Format</th>
+							<th colspan="3">Links</th>
+						</tr>
+						<tr>
+							<th>PROD</th>
+							<th>CODE</th>
+							<th>DEV</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr
+							is="article-row"
+							design="Standard"
+							display="Standard"
+							theme="Lifestyle"
+							href="https://www.theguardian.com/money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software"
+							headline="Ticket touts face unlimited fines for using 'bots' to buy in bulk"
+						></tr>
+						<tr
+							is="article-row"
+							design="Feature"
+							display="Showcase"
+							theme="News"
+							href="https://www.theguardian.com/cities/2019/sep/13/reclaimed-lakes-and-giant-airports-how-mexico-city-might-have-looked"
+							headline="Reclaimed lakes and giant airports: how Mexico City might have looked"
+						></tr>
+					</tbody>
+				</table>
+			</div>
+
+			<template id="article-row-template">
+				<td class="headline"></td>
+				<td class="format">
+					<dl>
+						<dt>Design:</dt>
+						<dd class="design"></dd>
+						<dt>Display:</dt>
+						<dd class="display"></dd>
+						<dt>Theme:</dt>
+						<dd class="theme"></dd>
+					</dl>
+				</td>
+				<td class="links">
+					<article-link product="dotcom" env="PROD"></article-link>
+					<article-link product="apps" env="PROD"></article-link>
+					<article-link product="amp" env="PROD"></article-link>
+				</td>
+				<td class="links">
+					<article-link product="dotcom" env="CODE"></article-link>
+					<article-link product="apps" env="CODE"></article-link>
+					<article-link product="amp" env="CODE"></article-link>
+				</td>
+				<td class="links">
+					<article-link product="dotcom" env="DEV"></article-link>
+					<article-link product="apps" env="DEV"></article-link>
+					<article-link product="amp" env="DEV"></article-link>
+				</td>
+			</template>
+
+			<template id="article-link-template">
+				<style>
+					a {
+						border-radius: 1rem;
+						padding: 0.3rem 1rem;
+						display: inline-flex;
+						justify-content: space-between;
+						text-decoration: none;
+						margin-bottom: 0.2rem;
+					}
+
+					.arrow {
+						padding-left: 0.5rem;
+					}
+
+					:host([env='PROD']) a {
+						background-color: #052962;
+						color: white;
+					}
+
+					:host([env='CODE']) a {
+						background-color: #22874d;
+						color: white;
+					}
+
+					:host([env='DEV']) a {
+						background-color: #ffe500;
+						color: black;
+					}
+				</style>
+				<a href="">
+					<span class="link-text">Link</span>
+					<span class="arrow">→</span>
+				</a>
+			</template>
+		</section>
 
 		<h2>Test Articles By Content Type</h2>
 
@@ -657,6 +807,267 @@
 						}
 					}
 				});
+
+			class ArticleLink extends HTMLElement {
+				/**
+				 * @typedef {'dotcom' | 'apps' | 'amp'} Product
+				 * @typedef {'PROD' | 'CODE' | 'DEV'} Env
+				 */
+
+				/** @type {DocumentFragment} */
+				content;
+
+				/** @type {HTMLAnchorElement} */
+				link;
+
+				/** @type {HTMLSpanElement} */
+				linkText;
+
+				/**
+				 * @param {Product} product
+				 * @return {string}
+				 */
+				prodOrigin(product) {
+					switch (product) {
+						case 'dotcom':
+						case 'apps':
+							return 'https://www.theguardian.com';
+						case 'amp':
+							return 'https://amp.theguardian.com';
+					}
+				}
+
+				/**
+				 * @param {Product} product
+				 * @return {string}
+				 */
+				codeOrigin(product) {
+					switch (product) {
+						case 'dotcom':
+						case 'apps':
+							return 'https://m.code.dev-theguardian.com';
+						case 'amp':
+							return 'https://amp.code.dev-theguardian.com';
+					}
+				}
+
+				/**
+				 * @param {Product} product
+				 * @return {string}
+				 */
+				params(product) {
+					return product === 'apps' ? '?dcr=apps' : '';
+				}
+
+				/**
+				 * @param {Product} product
+				 * @return {string}
+				 */
+				devPath(product) {
+					switch (product) {
+						case 'dotcom':
+							return '/Article';
+						case 'apps':
+							return '/AppsArticle';
+						case 'amp':
+							return '/AMPArticle';
+					}
+				}
+
+				/**
+				 * @param {Product} product
+				 * @param {Env} env
+				 * @param {URL} url
+				 */
+				buildUrl(product, env, url) {
+					switch (env) {
+						case 'PROD':
+							return `${this.prodOrigin(product)}${
+								url.pathname
+							}${this.params(product)}`;
+						case 'CODE':
+							return `${this.codeOrigin(product)}${
+								url.pathname
+							}${this.params(product)}`;
+						case 'DEV':
+							return `${this.devPath(product)}/${url.toString()}`;
+					}
+				}
+
+				/**
+				 * @param {Product} product
+				 * @return {string}
+				 */
+				getLinkText(product) {
+					switch (product) {
+						case 'dotcom':
+							return '🌍 Dotcom';
+						case 'apps':
+							return '📱 Apps';
+						case 'amp':
+							return '⚡️ AMP';
+					}
+				}
+
+				constructor() {
+					super();
+
+					const template = document.getElementById(
+						'article-link-template',
+					);
+
+					if (!(template instanceof HTMLTemplateElement)) {
+						throw new Error(
+							"article-link: I couldn't find my template element",
+						);
+					}
+
+					const clone = template.content.cloneNode(true);
+
+					if (!(clone instanceof DocumentFragment)) {
+						throw new Error(
+							'article-link: my template content should be a DocumentFragment',
+						);
+					}
+
+					this.content = clone;
+
+					const a = this.content.querySelector('a');
+
+					if (a instanceof HTMLAnchorElement) {
+						this.link = a;
+					} else {
+						throw new Error(
+							'article-link: my template is missing an anchor',
+						);
+					}
+
+					const linkText = this.content.querySelector('.link-text');
+
+					if (linkText instanceof HTMLSpanElement) {
+						this.linkText = linkText;
+					} else {
+						throw new Error(
+							'article-link: my template is missing a link-text element',
+						);
+					}
+				}
+
+				connectedCallback() {
+					const product = this.getAttribute('product');
+					const env = this.getAttribute('env');
+					const href = this.getAttribute('href');
+
+					if (
+						product !== 'dotcom' &&
+						product !== 'apps' &&
+						product !== 'amp'
+					) {
+						this.textContent =
+							"article-link error: 'product' must be one of: 'dotcom', 'apps' or 'amp'";
+						return;
+					}
+
+					if (env !== 'PROD' && env !== 'CODE' && env !== 'DEV') {
+						this.textContent =
+							"article-link error: 'env' must be one of: 'PROD', 'CODE' or 'DEV'";
+						return;
+					}
+
+					if (href === null || href === '') {
+						this.textContent =
+							"article-link error: must have a non-empty 'href'";
+						return;
+					}
+
+					try {
+						const url = new URL(href);
+						this.link.setAttribute(
+							'href',
+							this.buildUrl(product, env, url),
+						);
+						this.linkText.textContent = this.getLinkText(product);
+
+						const shadowRoot = this.attachShadow({ mode: 'open' });
+						shadowRoot.replaceChildren(this.content);
+					} catch (error) {
+						if (
+							error instanceof TypeError &&
+							error.message === 'Invalid URL'
+						) {
+							this.textContent =
+								"article-link error: 'href' must be a valid URL";
+						} else {
+							this.textContent =
+								'article-link error: unknown problem';
+						}
+					}
+				}
+			}
+
+			class ArticleRow extends HTMLTableRowElement {
+				/** @type {DocumentFragment} */
+				content;
+
+				/**
+				 * @param {string} name
+				 * @return {void}
+				 */
+				setElementFromAttribute(name) {
+					const attribute = this.getAttribute(name);
+					const element = this.content.querySelector(`.${name}`);
+
+					if (attribute !== null && element !== null) {
+						element.textContent = attribute;
+					}
+				}
+
+				constructor() {
+					super();
+
+					const template = document.getElementById(
+						'article-row-template',
+					);
+
+					if (!(template instanceof HTMLTemplateElement)) {
+						throw new Error(
+							"article-row: I couldn't find my template element",
+						);
+					}
+
+					const clone = template.content.cloneNode(true);
+
+					if (!(clone instanceof DocumentFragment)) {
+						throw new Error(
+							'article-row: my template content should be a DocumentFragment',
+						);
+					}
+
+					this.content = clone;
+				}
+
+				connectedCallback() {
+					const href = this.getAttribute('href');
+
+					if (href !== null) {
+						this.content
+							.querySelectorAll('article-link')
+							.forEach((link) => {
+								link.setAttribute('href', href);
+							});
+					}
+
+					this.setElementFromAttribute('headline');
+					this.setElementFromAttribute('design');
+					this.setElementFromAttribute('display');
+					this.setElementFromAttribute('theme');
+
+					this.replaceChildren(this.content);
+				}
+			}
+
+			customElements.define('article-link', ArticleLink);
+			customElements.define('article-row', ArticleRow, { extends: 'tr' });
 		</script>
 		<style>
 			/* Olly N. (Nov. 2023)

--- a/dotcom-rendering/src/server/dev-index.html
+++ b/dotcom-rendering/src/server/dev-index.html
@@ -32,48 +32,48 @@
 
 			.article-examples {
 				overflow-x: auto;
-			}
 
-			.article-examples__table {
-				text-align: left;
-				border-spacing: 0;
-			}
+				table {
+					text-align: left;
+					border-spacing: 0;
+				}
 
-			.article-examples__table th {
-				padding: 0.5rem 1rem;
-			}
+				th {
+					padding: 0.5rem 1rem;
+				}
 
-			.article-examples__table thead {
-				background-color: #dcdcdc;
-			}
+				thead {
+					background-color: #dcdcdc;
+				}
 
-			.article-examples__table tbody tr:nth-child(even) {
-				background-color: #ededed;
-			}
+				tbody tr:nth-child(even) {
+					background-color: #ededed;
+				}
 
-			.article-examples__table tbody tr:nth-child(odd) {
-				background-color: #f6f6f6;
-			}
+				tbody tr:nth-child(odd) {
+					background-color: #f6f6f6;
+				}
 
-			.article-examples__table td {
-				padding: 1rem 2rem 1rem 1rem;
-				max-width: 20rem;
-				min-width: 9rem;
-			}
+				td {
+					padding: 1rem 2rem 1rem 1rem;
+					max-width: 20rem;
+					min-width: 9rem;
+				}
 
-			.article-examples__table dt {
-				font-weight: bold;
-				display: inline;
-			}
+				dt {
+					font-weight: bold;
+					display: inline;
+				}
 
-			.article-examples__table dd {
-				display: inline;
-				margin: 0;
-			}
+				dd {
+					display: inline;
+					margin: 0;
+				}
 
-			.article-examples__table .links,
-			.article-examples__table .format {
-				max-width: 9rem;
+				.links,
+				.format {
+					max-width: 9rem;
+				}
 			}
 		</style>
 	</head>

--- a/dotcom-rendering/src/server/dev-index.html
+++ b/dotcom-rendering/src/server/dev-index.html
@@ -226,7 +226,7 @@
 					a {
 						border-radius: 1rem;
 						padding: 0.3rem 1rem;
-						display: inline-flex;
+						display: flex;
 						justify-content: space-between;
 						text-decoration: none;
 						margin-bottom: 0.2rem;

--- a/dotcom-rendering/src/server/dev-index.html
+++ b/dotcom-rendering/src/server/dev-index.html
@@ -853,10 +853,12 @@
 
 				/**
 				 * @param {Product} product
-				 * @return {string}
+				 * @return {URLSearchParams}
 				 */
 				params(product) {
-					return product === 'apps' ? '?dcr=apps' : '';
+					return new URLSearchParams(
+						product === 'apps' ? { dcr: 'apps' } : undefined,
+					);
 				}
 
 				/**
@@ -875,22 +877,37 @@
 				}
 
 				/**
+				 * @param {URL} devOrigin
 				 * @param {Product} product
 				 * @param {Env} env
 				 * @param {URL} url
+				 * @return {URL}
 				 */
-				buildUrl(product, env, url) {
+				buildUrl(devOrigin, product, env, url) {
 					switch (env) {
-						case 'PROD':
-							return `${this.prodOrigin(product)}${
-								url.pathname
-							}${this.params(product)}`;
-						case 'CODE':
-							return `${this.codeOrigin(product)}${
-								url.pathname
-							}${this.params(product)}`;
+						case 'PROD': {
+							const builtUrl = new URL(
+								url.pathname,
+								this.prodOrigin(product),
+							);
+							builtUrl.search = this.params(product).toString();
+
+							return builtUrl;
+						}
+						case 'CODE': {
+							const builtUrl = new URL(
+								url.pathname,
+								this.codeOrigin(product),
+							);
+							builtUrl.search = this.params(product).toString();
+
+							return builtUrl;
+						}
 						case 'DEV':
-							return `${this.devPath(product)}/${url.toString()}`;
+							return new URL(
+								`${this.devPath(product)}/${url.toString()}`,
+								devOrigin,
+							);
 					}
 				}
 
@@ -982,9 +999,11 @@
 
 					try {
 						const url = new URL(href);
+						const devOrigin = new URL(window.location.origin);
+
 						this.link.setAttribute(
 							'href',
-							this.buildUrl(product, env, url),
+							this.buildUrl(devOrigin, product, env, url).href,
 						);
 						this.linkText.textContent = this.getLinkText(product);
 

--- a/dotcom-rendering/src/server/dev-index.html
+++ b/dotcom-rendering/src/server/dev-index.html
@@ -33,45 +33,47 @@
 			.article-examples {
 				overflow-x: auto;
 
-				table {
+				& table {
 					text-align: left;
 					border-spacing: 0;
 				}
 
-				th {
+				& th {
 					padding: 0.5rem 1rem;
 				}
 
-				thead {
+				& thead {
 					background-color: #dcdcdc;
 				}
 
-				tbody tr:nth-child(even) {
-					background-color: #ededed;
+				& tbody {
+					& tr:nth-child(even) {
+						background-color: #ededed;
+					}
+
+					& tr:nth-child(odd) {
+						background-color: #f6f6f6;
+					}
 				}
 
-				tbody tr:nth-child(odd) {
-					background-color: #f6f6f6;
-				}
-
-				td {
+				& td {
 					padding: 1rem 2rem 1rem 1rem;
 					max-width: 20rem;
 					min-width: 9rem;
 				}
 
-				dt {
+				& dt {
 					font-weight: bold;
 					display: inline;
 				}
 
-				dd {
+				& dd {
 					display: inline;
 					margin: 0;
 				}
 
-				.links,
-				.format {
+				& .links,
+				& .format {
 					max-width: 9rem;
 				}
 			}

--- a/dotcom-rendering/src/server/dev-index.html
+++ b/dotcom-rendering/src/server/dev-index.html
@@ -157,7 +157,9 @@
 		</ul>
 
 		<section>
-			<h2>Article Examples</h2>
+			<h2>
+				Article Examples <small><sup>Beta</sup></small>
+			</h2>
 
 			<div class="article-examples">
 				<table class="article-examples__table">
@@ -193,6 +195,11 @@
 					</tbody>
 				</table>
 			</div>
+
+			<small
+				>This table is in Beta because it doesn't yet work in Safari; it
+				will be updated to add support.</small
+			>
 
 			<template id="article-row-template">
 				<td class="headline"></td>


### PR DESCRIPTION
It's often useful to have examples of articles to work with when making changes. This creates a way to add new examples and view them across our different products and environments. It also displays the format of each example. Only two examples are included for now, and more can be added later.

The rows and the links for different products and environments are built using web components, rather than a framework like React, as the dev server uses JavaScript without any dependencies.

**Note:** The `table` styles are in the global `style` tag. I may isolate them, in a future change, by moving the table into its own web component with a Shadow DOM.

## Screenshot

![article-examples-correct](https://github.com/guardian/dotcom-rendering/assets/53781962/f707b6e6-3054-4d19-8fa1-1db47f23d044)
