### PR TITLE
Make the `MostViewedFooterData` Island server-safe

### DIFF
--- a/dotcom-rendering/cypress/e2e/parallel-1/article.e2e.cy.js
+++ b/dotcom-rendering/cypress/e2e/parallel-1/article.e2e.cy.js
@@ -83,7 +83,7 @@ describe('E2E Page rendering', function () {
 			cy.get('gu-island[name=MostViewedFooterData]').should(
 				'have.attr',
 				'data-island-status',
-				'rendered',
+				'hydrated',
 			);
 
 			cy.get('[data-testid-ab-user-in-variant=ab-test-variant]').should(
@@ -117,7 +117,7 @@ describe('E2E Page rendering', function () {
 			cy.get('gu-island[name=MostViewedFooterData]').should(
 				'have.attr',
 				'data-island-status',
-				'rendered',
+				'hydrated',
 			);
 
 			cy.get(

--- a/dotcom-rendering/cypress/e2e/parallel-3/article.interactivity.cy.js
+++ b/dotcom-rendering/cypress/e2e/parallel-3/article.interactivity.cy.js
@@ -100,7 +100,7 @@ describe('Interactivity', function () {
 				// Wait for hydration
 				cy.get('gu-island[name=MostViewedFooterData]')
 					.last()
-					.should('have.attr', 'data-island-status', 'rendered');
+					.should('have.attr', 'data-island-status', 'hydrated');
 				cy.wait('@getMostRead');
 				cy.wait('@getMostReadGeo');
 				cy.get('[data-testid=mostviewed-footer]').should('exist');

--- a/dotcom-rendering/playwright/tests/parallel-1/article.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/parallel-1/article.e2e.spec.ts
@@ -87,7 +87,9 @@ test.describe('E2E Page rendering', () => {
 			).toBeVisible();
 
 			// expect most read footer to be loaded, its data response and its text to be visible
-			await waitForIsland(page, 'MostViewedFooterData');
+			await waitForIsland(page, 'MostViewedFooterData', {
+				status: 'hydrated',
+			});
 			await mostReadFooterResponsePromise;
 			await expect(
 				page

--- a/dotcom-rendering/playwright/tests/parallel-3/article.interactivity.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/parallel-3/article.interactivity.e2e.spec.ts
@@ -158,7 +158,9 @@ test.describe('Interactivity', () => {
 					.filter({ hasText: 'Most Viewed' }),
 			).toBeVisible();
 
-			await waitForIsland(page, 'MostViewedFooterData');
+			await waitForIsland(page, 'MostViewedFooterData', {
+				status: 'hydrated',
+			});
 			await expect(
 				page
 					.locator(`gu-island[name="MostViewedFooterData"]`)

--- a/dotcom-rendering/src/components/Island.test.tsx
+++ b/dotcom-rendering/src/components/Island.test.tsx
@@ -19,6 +19,7 @@ import { LightboxJavascript } from './LightboxJavascript.importable';
 import { LiveBlogEpic } from './LiveBlogEpic.importable';
 import { Liveness } from './Liveness.importable';
 import { Metrics } from './Metrics.importable';
+import { MostViewedFooterData } from './MostViewedFooterData.importable';
 import { OnwardsUpper } from './OnwardsUpper.importable';
 import { ReaderRevenueDev } from './ReaderRevenueDev.importable';
 import { RecipeMultiplier } from './RecipeMultiplier.importable';
@@ -278,6 +279,22 @@ describe('Island: server-side rendering', () => {
 				>
 					<Metrics commercialMetricsEnabled={true} tests={{}} />
 				</ConfigProvider>,
+			),
+		).not.toThrow();
+	});
+
+	test('MostViewedFooterData', () => {
+		expect(() =>
+			renderToString(
+				<MostViewedFooterData
+					ajaxUrl={''}
+					edition={'UK'}
+					format={{
+						theme: Pillar.News,
+						design: ArticleDesign.Standard,
+						display: ArticleDisplay.Standard,
+					}}
+				/>,
 			),
 		).not.toThrow();
 	});

--- a/dotcom-rendering/src/components/MostViewedFooterData.importable.tsx
+++ b/dotcom-rendering/src/components/MostViewedFooterData.importable.tsx
@@ -11,6 +11,7 @@ import type {
 	TrailTabType,
 } from '../types/trails';
 import { MostViewedFooter } from './MostViewedFooter.importable';
+import { Placeholder } from './Placeholder';
 
 interface Props {
 	sectionId?: string;
@@ -108,5 +109,5 @@ export const MostViewedFooterData = ({
 		);
 	}
 
-	return null;
+	return <Placeholder height={360} />;
 };

--- a/dotcom-rendering/src/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/layouts/CommentLayout.tsx
@@ -821,7 +821,6 @@ export const CommentLayout = (props: WebProps | AppsProps) => {
 						<MostViewedFooterLayout renderAds={renderAds}>
 							<Island
 								priority="feature"
-								clientOnly={true}
 								defer={{ until: 'visible' }}
 							>
 								<MostViewedFooterData

--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -841,7 +841,6 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 						<MostViewedFooterLayout renderAds={renderAds}>
 							<Island
 								priority="feature"
-								clientOnly={true}
 								defer={{ until: 'visible' }}
 							>
 								<MostViewedFooterData

--- a/dotcom-rendering/src/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/InteractiveLayout.tsx
@@ -735,7 +735,6 @@ export const InteractiveLayout = (props: WebProps | AppsProps) => {
 						<MostViewedFooterLayout renderAds={renderAds}>
 							<Island
 								priority="feature"
-								clientOnly={true}
 								defer={{ until: 'visible' }}
 							>
 								<MostViewedFooterData

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -1260,7 +1260,6 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 							<MostViewedFooterLayout renderAds={renderAds}>
 								<Island
 									priority="feature"
-									clientOnly={true}
 									defer={{ until: 'visible' }}
 								>
 									<MostViewedFooterData

--- a/dotcom-rendering/src/layouts/PictureLayout.tsx
+++ b/dotcom-rendering/src/layouts/PictureLayout.tsx
@@ -692,7 +692,6 @@ export const PictureLayout = (props: WebProps | AppsProps) => {
 						<MostViewedFooterLayout renderAds={renderAds}>
 							<Island
 								priority="feature"
-								clientOnly={true}
 								defer={{ until: 'visible' }}
 							>
 								<MostViewedFooterData

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -805,7 +805,6 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 						<MostViewedFooterLayout renderAds={renderAds}>
 							<Island
 								priority="feature"
-								clientOnly={true}
 								defer={{ until: 'visible' }}
 							>
 								<MostViewedFooterData

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -904,7 +904,6 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 								<MostViewedFooterLayout renderAds={renderAds}>
 									<Island
 										priority="feature"
-										clientOnly={true}
 										defer={{ until: 'visible' }}
 									>
 										<MostViewedFooterData


### PR DESCRIPTION
## What does this change?

Ensure the `MostViewedFooterData` Island is server safe, and no longer client-side only.

Adds an explicit placeholder instead of nothing to reduce CLS.

## Why?

No assumption should be made about where components are run

- Split out from #8991 for easier review
- Enables the work from #8948 to proceed safely.

## Screenshots

Now with a placeholder:

<img width="1035" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/76776/4c05d76b-b540-41f4-8053-8ea75b570a26">
