### PR TITLE
Make `ReaderRevenueLinks` Island server-safe

### DIFF
--- a/dotcom-rendering/.storybook/preview.ts
+++ b/dotcom-rendering/.storybook/preview.ts
@@ -74,6 +74,7 @@ window.guardian = {
 	},
 	ophan: {
 		record: ({}) => {},
+		pageViewId: 'storybook-does-not-have-a-page-view-id',
 	},
 	modules: {
 		sentry: {

--- a/dotcom-rendering/src/components/Footer.tsx
+++ b/dotcom-rendering/src/components/Footer.tsx
@@ -275,11 +275,7 @@ const FooterLinks = ({
 
 	const rrLinks = (
 		<div css={readerRevenueLinks}>
-			<Island
-				priority="feature"
-				defer={{ until: 'visible' }}
-				clientOnly={true}
-			>
+			<Island priority="feature" defer={{ until: 'visible' }}>
 				<ReaderRevenueLinks
 					urls={urls}
 					editionId={editionId}

--- a/dotcom-rendering/src/components/Island.test.tsx
+++ b/dotcom-rendering/src/components/Island.test.tsx
@@ -21,6 +21,7 @@ import { Liveness } from './Liveness.importable';
 import { Metrics } from './Metrics.importable';
 import { OnwardsUpper } from './OnwardsUpper.importable';
 import { ReaderRevenueDev } from './ReaderRevenueDev.importable';
+import { ReaderRevenueLinks } from './ReaderRevenueLinks.importable';
 import { RecipeMultiplier } from './RecipeMultiplier.importable';
 import { SendTargetingParams } from './SendTargetingParams.importable';
 import { SetABTests } from './SetABTests.importable';
@@ -286,6 +287,29 @@ describe('Island: server-side rendering', () => {
 		expect(() =>
 			renderToString(
 				<ReaderRevenueDev shouldHideReaderRevenue={false} />,
+			),
+		).not.toThrow();
+	});
+
+	test('ReaderRevenueLinks', () => {
+		expect(() =>
+			renderToString(
+				<ConfigProvider
+					value={{ renderingTarget: 'Web', darkModeAvailable: false }}
+				>
+					<ReaderRevenueLinks
+						editionId={'UK'}
+						dataLinkNamePrefix={''}
+						inHeader={false}
+						remoteHeader={false}
+						contributionsServiceUrl={''}
+						urls={{
+							subscribe: '',
+							support: '',
+							contribute: '',
+						}}
+					/>
+				</ConfigProvider>,
 			),
 		).not.toThrow();
 	});

--- a/dotcom-rendering/src/components/Metrics.importable.tsx
+++ b/dotcom-rendering/src/components/Metrics.importable.tsx
@@ -9,12 +9,11 @@ import {
 } from '@guardian/core-web-vitals';
 import { getCookie, isString, isUndefined } from '@guardian/libs';
 import { useCallback, useEffect, useState } from 'react';
-import { getOphan } from '../client/ophan/ophan';
 import { integrateIma } from '../experiments/tests/integrate-ima';
 import { useAB } from '../lib/useAB';
 import { useAdBlockInUse } from '../lib/useAdBlockInUse';
+import { usePageViewId } from '../lib/usePageViewId';
 import type { ServerSideTests } from '../types/config';
-import type { RenderingTarget } from '../types/renderingTarget';
 import { useConfig } from './ConfigContext';
 
 type Props = {
@@ -44,22 +43,6 @@ const useBrowserId = () => {
 	}, []);
 
 	return browserId;
-};
-
-const usePageViewId = (renderingTarget: RenderingTarget) => {
-	const [id, setId] = useState<string>();
-
-	useEffect(() => {
-		getOphan(renderingTarget)
-			.then(({ pageViewId }) => {
-				setId(pageViewId);
-			})
-			.catch(() => {
-				setId('no-page-view-id-available');
-			});
-	}, [renderingTarget]);
-
-	return id;
 };
 
 const useDev = () => {

--- a/dotcom-rendering/src/components/ReaderRevenueLinks.importable.tsx
+++ b/dotcom-rendering/src/components/ReaderRevenueLinks.importable.tsx
@@ -30,9 +30,9 @@ import {
 	shouldHideSupportMessaging,
 } from '../lib/contributions';
 import type { EditionId } from '../lib/edition';
-import { getLocaleCode } from '../lib/getCountryCode';
 import { setAutomat } from '../lib/setAutomat';
 import { useAuthStatus } from '../lib/useAuthStatus';
+import { useCountryCode } from '../lib/useCountryCode';
 import { useIsInView } from '../lib/useIsInView';
 import { useOnce } from '../lib/useOnce';
 import ArrowRightIcon from '../static/icons/arrow-right.svg';
@@ -409,21 +409,8 @@ export const ReaderRevenueLinks = ({
 	urls,
 	contributionsServiceUrl,
 }: Props) => {
-	const [countryCode, setCountryCode] = useState<string>();
+	const countryCode = useCountryCode('reader-revenue-links');
 	const pageViewId = window.guardian.config.ophan.pageViewId;
-
-	useEffect(() => {
-		const callFetch = () => {
-			getLocaleCode()
-				.then((cc) => {
-					setCountryCode(cc ?? '');
-				})
-				.catch((e) =>
-					console.error(`countryCodePromise - error: ${String(e)}`),
-				);
-		};
-		callFetch();
-	}, []);
 
 	if (countryCode) {
 		if (inHeader && remoteHeader) {

--- a/dotcom-rendering/src/components/ReaderRevenueLinks.importable.tsx
+++ b/dotcom-rendering/src/components/ReaderRevenueLinks.importable.tsx
@@ -35,6 +35,7 @@ import { useAuthStatus } from '../lib/useAuthStatus';
 import { useCountryCode } from '../lib/useCountryCode';
 import { useIsInView } from '../lib/useIsInView';
 import { useOnce } from '../lib/useOnce';
+import { usePageViewId } from '../lib/usePageViewId';
 import ArrowRightIcon from '../static/icons/arrow-right.svg';
 import { useConfig } from './ConfigContext';
 
@@ -409,10 +410,11 @@ export const ReaderRevenueLinks = ({
 	urls,
 	contributionsServiceUrl,
 }: Props) => {
+	const { renderingTarget } = useConfig();
 	const countryCode = useCountryCode('reader-revenue-links');
-	const pageViewId = window.guardian.config.ophan.pageViewId;
+	const pageViewId = usePageViewId(renderingTarget);
 
-	if (countryCode) {
+	if (countryCode && pageViewId) {
 		if (inHeader && remoteHeader) {
 			return (
 				<ReaderRevenueLinksRemote

--- a/dotcom-rendering/src/components/ReaderRevenueLinks.test.tsx
+++ b/dotcom-rendering/src/components/ReaderRevenueLinks.test.tsx
@@ -11,7 +11,8 @@ const shouldHideSupportMessaging: {
 // @swc/jest does not seem to handle dynamic import of ophan.ng.js
 // We get a “define is not defined” in Jest, but it seems to work in browsers
 jest.mock('../client/ophan/ophan', () => ({
-	getOphan: () => Promise.resolve({ record: () => jest.fn() }),
+	getOphan: () =>
+		Promise.resolve({ record: () => jest.fn(), pageViewId: 'abc123' }),
 	sendOphanComponentEvent: jest.fn(),
 }));
 
@@ -20,6 +21,7 @@ jest.mock('../lib/contributions', () => ({
 }));
 
 jest.mock('@guardian/libs', () => ({
+	...jest.requireActual('@guardian/libs'),
 	getLocale: async () => {
 		return 'GB';
 	},

--- a/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
+++ b/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
@@ -1,13 +1,12 @@
 import { getCookie, isUndefined } from '@guardian/libs';
 import { useEffect, useState } from 'react';
-import { getOphan } from '../client/ophan/ophan';
 import { parseCheckoutCompleteCookieData } from '../lib/parser/parseCheckoutOutCookieData';
 import { constructQuery } from '../lib/querystring';
 import { useAuthStatus } from '../lib/useAuthStatus';
 import { useOnce } from '../lib/useOnce';
+import { usePageViewId } from '../lib/usePageViewId';
 import { useSignInGateSelector } from '../lib/useSignInGateSelector';
 import type { Switches } from '../types/config';
-import type { RenderingTarget } from '../types/renderingTarget';
 import type { TagType } from '../types/tag';
 import { useConfig } from './ConfigContext';
 import type { ComponentEventParams } from './SignInGate/componentEventTracking';
@@ -149,22 +148,6 @@ const ShowSignInGate = ({
 	}
 	// return nothing if no gate needs to be shown
 	return <></>;
-};
-
-const usePageViewId = (renderingTarget: RenderingTarget) => {
-	const [id, setId] = useState<string>();
-
-	useEffect(() => {
-		getOphan(renderingTarget)
-			.then(({ pageViewId }) => {
-				setId(pageViewId);
-			})
-			.catch(() => {
-				setId('no-page-view-id-available');
-			});
-	}, [renderingTarget]);
-
-	return id;
 };
 
 const useCheckoutCompleteCookieData = () => {

--- a/dotcom-rendering/src/components/SupportTheG.importable.tsx
+++ b/dotcom-rendering/src/components/SupportTheG.importable.tsx
@@ -30,11 +30,11 @@ import {
 	shouldHideSupportMessaging,
 } from '../lib/contributions';
 import type { EditionId } from '../lib/edition';
-import { getLocaleCode } from '../lib/getCountryCode';
 import type { AuthStatus } from '../lib/identity';
 import { nestedOphanComponents } from '../lib/ophan-helpers';
 import { setAutomat } from '../lib/setAutomat';
 import { useAuthStatus } from '../lib/useAuthStatus';
+import { useCountryCode } from '../lib/useCountryCode';
 import { useIsInView } from '../lib/useIsInView';
 import { useOnce } from '../lib/useOnce';
 import ArrowRightIcon from '../static/icons/arrow-right.svg';
@@ -435,21 +435,8 @@ export const SupportTheG = ({
 	contributionsServiceUrl,
 	hasPageSkin = false,
 }: Props) => {
-	const [countryCode, setCountryCode] = useState<string>();
+	const countryCode = useCountryCode('support-the-Guardian');
 	const pageViewId = window.guardian.config.ophan.pageViewId;
-
-	useEffect(() => {
-		const callFetch = () => {
-			getLocaleCode()
-				.then((cc) => {
-					setCountryCode(cc ?? '');
-				})
-				.catch((e) =>
-					console.error(`countryCodePromise - error: ${String(e)}`),
-				);
-		};
-		callFetch();
-	}, []);
 
 	if (countryCode) {
 		if (inHeader && remoteHeader) {

--- a/dotcom-rendering/src/lib/usePageViewId.ts
+++ b/dotcom-rendering/src/lib/usePageViewId.ts
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react';
+import { getOphan } from '../client/ophan/ophan';
+import type { RenderingTarget } from '../types/renderingTarget';
+
+export const usePageViewId = (
+	renderingTarget: RenderingTarget,
+): string | undefined => {
+	const [id, setId] = useState<string>();
+
+	useEffect(() => {
+		getOphan(renderingTarget)
+			.then(({ pageViewId }) => {
+				setId(pageViewId);
+			})
+			.catch(() => {
+				setId('no-page-view-id-available');
+			});
+	}, [renderingTarget]);
+
+	return id;
+};


### PR DESCRIPTION
## What does this change?

- Upgrade `useCountryCode` to the library and use it in three distinct instances
- Upgrade `usePageViewId` to the library and use it in three distinct instances
- Ensure the `ReaderRevenueLinks` Island is server safe, and no longer client-side only.

## Why?

No assumption should be made about where components are run.

- Split out from #8991 for easier review
- Enables the work from #8948 to proceed safely.