### PR TITLE
Add dark mode to most viewed right and footer 🌞 🌚 

### DIFF
--- a/dotcom-rendering/src/components/LinkHeadline.stories.tsx
+++ b/dotcom-rendering/src/components/LinkHeadline.stories.tsx
@@ -1,9 +1,4 @@
-import {
-	ArticleDesign,
-	ArticleDisplay,
-	ArticleSpecial,
-	Pillar,
-} from '@guardian/libs';
+import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
 import type { StoryObj } from '@storybook/react';
 import type { StoryProps } from '../../.storybook/decorators/splitThemeDecorator';
 import { splitTheme } from '../../.storybook/decorators/splitThemeDecorator';
@@ -14,6 +9,25 @@ export default {
 	component: LinkHeadline,
 	title: 'Components/LinkHeadline',
 };
+type StoryArgs = { format: ArticleFormat };
+
+const defaultFormat = {
+	display: ArticleDisplay.Standard,
+	design: ArticleDesign.Standard,
+	theme: Pillar.News,
+};
+
+export const defaultStory: StoryObj = ({ format }: StoryProps) => (
+	<Section fullWidth={true} showTopBorder={false} showSideBorders={false}>
+		<LinkHeadline
+			headlineText="This is how a headline with each pillar looks"
+			format={format}
+			kickerText="The kicker text"
+		/>
+	</Section>
+);
+defaultStory.storyName = 'Default Link Headline';
+defaultStory.decorators = [splitTheme()];
 
 export const xsmallStory: StoryObj = ({ format }: StoryProps) => (
 	<Section fullWidth={true} showTopBorder={false} showSideBorders={false}>
@@ -25,15 +39,7 @@ export const xsmallStory: StoryObj = ({ format }: StoryProps) => (
 	</Section>
 );
 xsmallStory.storyName = 'Size | large';
-xsmallStory.decorators = [
-	splitTheme([
-		{
-			display: ArticleDisplay.Standard,
-			design: ArticleDesign.Standard,
-			theme: Pillar.News,
-		},
-	]),
-];
+xsmallStory.decorators = [splitTheme([defaultFormat])];
 
 export const liveStory: StoryObj = ({ format }: StoryProps) => (
 	<Section fullWidth={true} showTopBorder={false} showSideBorders={false}>
@@ -45,17 +51,9 @@ export const liveStory: StoryObj = ({ format }: StoryProps) => (
 	</Section>
 );
 liveStory.storyName = 'With Live kicker';
-liveStory.decorators = [
-	splitTheme([
-		{
-			display: ArticleDisplay.Standard,
-			design: ArticleDesign.Standard,
-			theme: Pillar.News,
-		},
-	]),
-];
+liveStory.decorators = [splitTheme([defaultFormat])];
 
-export const noLinebreak: StoryObj = ({ format }: StoryProps) => (
+export const noLinebreak: StoryObj = ({ format }: StoryArgs) => (
 	<Section fullWidth={true} showTopBorder={false} showSideBorders={false}>
 		<LinkHeadline
 			headlineText="This is how a headline with no kicker line break looks"
@@ -66,17 +64,9 @@ export const noLinebreak: StoryObj = ({ format }: StoryProps) => (
 	</Section>
 );
 noLinebreak.storyName = 'With Live kicker but no line break';
-noLinebreak.decorators = [
-	splitTheme([
-		{
-			display: ArticleDisplay.Standard,
-			design: ArticleDesign.Standard,
-			theme: Pillar.News,
-		},
-	]),
-];
+noLinebreak.decorators = [splitTheme([defaultFormat])];
 
-export const pulsingDot: StoryObj = ({ format }: StoryProps) => (
+export const pulsingDot: StoryObj = ({ format }: StoryArgs) => (
 	<Section fullWidth={true} showTopBorder={false} showSideBorders={false}>
 		<LinkHeadline
 			headlineText="This is how a headline with a pulsing dot looks"
@@ -87,35 +77,7 @@ export const pulsingDot: StoryObj = ({ format }: StoryProps) => (
 	</Section>
 );
 pulsingDot.storyName = 'With pulsing dot';
-pulsingDot.decorators = [
-	splitTheme([
-		{
-			display: ArticleDisplay.Standard,
-			design: ArticleDesign.Standard,
-			theme: Pillar.News,
-		},
-	]),
-];
-
-export const cultureVariant: StoryObj = ({ format }: StoryProps) => (
-	<Section fullWidth={true} showTopBorder={false} showSideBorders={false}>
-		<LinkHeadline
-			headlineText="This is how a headline with the culture pillar looks"
-			format={format}
-			kickerText="Art and stuff"
-		/>
-	</Section>
-);
-cultureVariant.storyName = 'With a culture kicker';
-cultureVariant.decorators = [
-	splitTheme([
-		{
-			display: ArticleDisplay.Standard,
-			design: ArticleDesign.Standard,
-			theme: Pillar.Culture,
-		},
-	]),
-];
+pulsingDot.decorators = [splitTheme([defaultFormat])];
 
 export const opinionxxxsmall: StoryObj = ({ format }: StoryProps) => (
 	<Section fullWidth={true} showTopBorder={false} showSideBorders={false}>
@@ -139,48 +101,6 @@ opinionxxxsmall.decorators = [
 	]),
 ];
 
-export const OpinionKicker: StoryObj = ({ format }: StoryProps) => (
-	<Section fullWidth={true} showTopBorder={false} showSideBorders={false}>
-		<LinkHeadline
-			headlineText="This is how an opinion headline with a kicker looks"
-			format={format}
-			showQuotes={true}
-			kickerText="George Monbiot"
-		/>
-	</Section>
-);
-OpinionKicker.storyName = 'With an opinion kicker';
-OpinionKicker.decorators = [
-	splitTheme([
-		{
-			display: ArticleDisplay.Standard,
-			design: ArticleDesign.Comment,
-			theme: Pillar.Opinion,
-		},
-	]),
-];
-
-export const SpecialReport: StoryObj = ({ format }: StoryProps) => (
-	<Section fullWidth={true} showTopBorder={false} showSideBorders={false}>
-		<LinkHeadline
-			headlineText="This is how a Special Report headline with a kicker looks"
-			format={format}
-			showQuotes={true}
-			kickerText="Special Report"
-		/>
-	</Section>
-);
-SpecialReport.storyName = 'when Special Report';
-SpecialReport.decorators = [
-	splitTheme([
-		{
-			display: ArticleDisplay.Standard,
-			design: ArticleDesign.Comment,
-			theme: ArticleSpecial.SpecialReport,
-		},
-	]),
-];
-
 export const InUnderlinedState: StoryObj = ({ format }: StoryProps) => (
 	<Section fullWidth={true} showTopBorder={false} showSideBorders={false}>
 		<LinkHeadline
@@ -196,15 +116,7 @@ export const InUnderlinedState: StoryObj = ({ format }: StoryProps) => (
 	</Section>
 );
 InUnderlinedState.storyName = 'With showUnderline true';
-InUnderlinedState.decorators = [
-	splitTheme([
-		{
-			display: ArticleDisplay.Standard,
-			design: ArticleDesign.Standard,
-			theme: Pillar.News,
-		},
-	]),
-];
+InUnderlinedState.decorators = [splitTheme([defaultFormat])];
 
 export const linkStory: StoryObj = ({ format }: StoryProps) => (
 	<Section fullWidth={true} showTopBorder={false} showSideBorders={false}>

--- a/dotcom-rendering/src/components/LinkHeadline.tsx
+++ b/dotcom-rendering/src/components/LinkHeadline.tsx
@@ -4,6 +4,7 @@ import { palette } from '../palette';
 import { Byline } from './Byline';
 import { Kicker } from './Kicker';
 import { QuoteIcon } from './QuoteIcon';
+
 type Props = {
 	headlineText: string; // The text shown
 	format: ArticleFormat;
@@ -50,7 +51,7 @@ const textDecorationUnderline = css`
 
 const linkStyles = css`
 	position: relative;
-	color: inherit;
+	color: ${palette('--article-text')};
 	text-decoration: none;
 	:hover {
 		text-decoration: underline;
@@ -76,14 +77,7 @@ export const LinkHeadline = ({
 	byline,
 }: Props) => {
 	return (
-		<h4
-			css={[
-				fontStyles(size),
-				css`
-					color: ${palette('--most-viewed-headline')};
-				`,
-			]}
-		>
+		<h4 css={[fontStyles(size)]}>
 			{!!kickerText && (
 				<Kicker
 					text={kickerText}

--- a/dotcom-rendering/src/components/LinkHeadline.tsx
+++ b/dotcom-rendering/src/components/LinkHeadline.tsx
@@ -1,10 +1,9 @@
 import { css } from '@emotion/react';
 import { headline } from '@guardian/source-foundations';
-import { decidePalette } from '../lib/decidePalette';
+import { palette } from '../palette';
 import { Byline } from './Byline';
 import { Kicker } from './Kicker';
 import { QuoteIcon } from './QuoteIcon';
-
 type Props = {
 	headlineText: string; // The text shown
 	format: ArticleFormat;
@@ -76,19 +75,24 @@ export const LinkHeadline = ({
 	link,
 	byline,
 }: Props) => {
-	const palette = decidePalette(format);
-
 	return (
-		<h4 css={fontStyles(size)}>
+		<h4
+			css={[
+				fontStyles(size),
+				css`
+					color: ${palette('--most-viewed-headline')};
+				`,
+			]}
+		>
 			{!!kickerText && (
 				<Kicker
 					text={kickerText}
-					color={palette.text.linkKicker}
+					color={palette('--link-kicker-text')}
 					showPulsingDot={showPulsingDot}
 					hideLineBreak={hideLineBreak}
 				/>
 			)}
-			{showQuotes && <QuoteIcon colour={palette.text.linkKicker} />}
+			{showQuotes && <QuoteIcon colour={palette('--link-kicker-text')} />}
 			{link ? (
 				// We were passed a link object so headline should be a link, with link styling
 				<>

--- a/dotcom-rendering/src/components/MostViewedFooterGrid.tsx
+++ b/dotcom-rendering/src/components/MostViewedFooterGrid.tsx
@@ -8,6 +8,7 @@ import {
 	visuallyHidden,
 } from '@guardian/source-foundations';
 import { useState } from 'react';
+import { palette } from '../palette';
 import type { TrailTabType, TrailType } from '../types/trails';
 import { MostViewedFooterItem } from './MostViewedFooterItem';
 
@@ -66,7 +67,7 @@ const unselectedStyles = css`
 
 const buttonStyles = (isSelected: boolean) => css`
 	${headline.xxxsmall()};
-	color: ${neutral[7]};
+	color: ${palette('--article-text')};
 	margin: 0;
 	border: 0;
 	background: transparent;

--- a/dotcom-rendering/src/components/MostViewedFooterItem.tsx
+++ b/dotcom-rendering/src/components/MostViewedFooterItem.tsx
@@ -5,12 +5,12 @@ import {
 	border,
 	breakpoints,
 	headline,
-	neutral,
-	text,
 	until,
 } from '@guardian/source-foundations';
+import { palette } from '../palette';
 import { AgeWarning } from './AgeWarning';
 import { BigNumber } from './BigNumber/BigNumber';
+import { FormatBoundary } from './FormatBoundary';
 import { LinkHeadline } from './LinkHeadline';
 import { generateSources } from './Picture';
 
@@ -50,7 +50,7 @@ const gridItem = (
 
 		&:hover,
 		:focus {
-			background: ${neutral[97]};
+			background: ${palette('--most-viewed-footer-hover')};
 		}
 	`;
 };
@@ -59,7 +59,7 @@ const bigNumber = css`
 	position: absolute;
 	top: 0.375rem;
 	left: 0.625rem;
-	fill: ${text.primary};
+	fill: ${palette('--article-text')};
 `;
 
 const headlineHeader = css`
@@ -70,7 +70,7 @@ const headlineHeader = css`
 
 const headlineLink = css`
 	text-decoration: none;
-	color: ${text.anchorSecondary};
+	color: ${palette('--article-text')};
 	font-weight: 500;
 	${headline.xxxsmall()};
 
@@ -158,27 +158,29 @@ export const MostViewedFooterItem = ({
 			</span>
 			{!!image && <MiniImage image={image} alt={headlineText} />}
 			<div css={[headlineHeader, !!image && textPaddingWithImage]}>
-				{format.design === ArticleDesign.LiveBlog ? (
-					<LinkHeadline
-						headlineText={headlineText}
-						format={format}
-						size="small"
-						kickerText="Live"
-						hideLineBreak={false}
-						showPulsingDot={true}
-						showQuotes={false}
-					/>
-				) : (
-					<LinkHeadline
-						headlineText={headlineText}
-						format={format}
-						size="small"
-						showQuotes={
-							format.design === ArticleDesign.Comment ||
-							format.design === ArticleDesign.Letter
-						}
-					/>
-				)}
+				<FormatBoundary format={format}>
+					{format.design === ArticleDesign.LiveBlog ? (
+						<LinkHeadline
+							headlineText={headlineText}
+							format={format}
+							size="small"
+							kickerText="Live"
+							hideLineBreak={false}
+							showPulsingDot={true}
+							showQuotes={false}
+						/>
+					) : (
+						<LinkHeadline
+							headlineText={headlineText}
+							format={format}
+							size="small"
+							showQuotes={
+								format.design === ArticleDesign.Comment ||
+								format.design === ArticleDesign.Letter
+							}
+						/>
+					)}
+				</FormatBoundary>
 			</div>
 			{!!ageWarning && (
 				<div css={ageWarningStyles}>

--- a/dotcom-rendering/src/components/MostViewedFooterLayout.stories.tsx
+++ b/dotcom-rendering/src/components/MostViewedFooterLayout.stories.tsx
@@ -1,9 +1,18 @@
+import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
+import type { StoryObj } from '@storybook/react';
 import React, { useEffect } from 'react';
+import { splitTheme } from '../../.storybook/decorators/splitThemeDecorator';
 import { trails } from '../../fixtures/manual/trails';
 import { doStorybookHydration } from '../client/islands/doStorybookHydration';
 import { MostViewedFooter } from './MostViewedFooter.importable';
 import { MostViewedFooterLayout } from './MostViewedFooterLayout';
 import { Section } from './Section';
+
+const standardFormat = {
+	display: ArticleDisplay.Standard,
+	design: ArticleDesign.Standard,
+	theme: Pillar.News,
+};
 
 const Hydrated = ({ children }: { children: React.ReactNode }) => {
 	useEffect(() => {
@@ -18,9 +27,10 @@ export default {
 	parameters: {
 		chromatic: { diffThreshold: 0.2 },
 	},
+	decorators: [splitTheme([standardFormat], { orientation: 'vertical' })],
 };
 
-export const withTwoTabsAdFree = () => {
+export const withTwoTabsAdFree: StoryObj = () => {
 	return (
 		<Hydrated>
 			<Section>
@@ -38,7 +48,7 @@ export const withTwoTabsAdFree = () => {
 };
 withTwoTabsAdFree.storyName = 'with two tabs ad free';
 
-export const withOneTabsAdFree = () => {
+export const withOneTabsAdFree: StoryObj = () => {
 	return (
 		<Hydrated>
 			<Section>
@@ -58,7 +68,7 @@ export const withOneTabsAdFree = () => {
 };
 withOneTabsAdFree.storyName = 'with one tab ad free';
 
-export const withTwoTabs = () => {
+export const withTwoTabs: StoryObj = () => {
 	return (
 		<Hydrated>
 			<Section>
@@ -76,7 +86,7 @@ export const withTwoTabs = () => {
 };
 withTwoTabs.storyName = 'with two tabs';
 
-export const withOneTabs = () => {
+export const withOneTabs: StoryObj = () => {
 	return (
 		<Hydrated>
 			<Section>

--- a/dotcom-rendering/src/components/MostViewedRight.stories.tsx
+++ b/dotcom-rendering/src/components/MostViewedRight.stories.tsx
@@ -1,5 +1,10 @@
 import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
+import type { StoryObj } from '@storybook/react';
 import fetchMock from 'fetch-mock';
+import {
+	splitTheme,
+	type StoryProps,
+} from '../../.storybook/decorators/splitThemeDecorator';
 import { ArticleContainer } from './ArticleContainer';
 import { Flex } from './Flex';
 import { LeftColumn } from './LeftColumn';
@@ -8,15 +13,22 @@ import { MostViewedRight } from './MostViewedRight';
 import { RightColumn } from './RightColumn';
 import { Section } from './Section';
 
+const standardFormat = {
+	display: ArticleDisplay.Standard,
+	design: ArticleDesign.Standard,
+	theme: Pillar.News,
+};
+
 export default {
 	component: MostViewedRight,
 	title: 'Components/MostViewedRight',
 	parameters: {
 		chromatic: { diffThreshold: 0.2 },
 	},
+	decorators: [splitTheme([standardFormat], { orientation: 'vertical' })],
 };
 
-export const defaultStory = () => {
+export const defaultStory: StoryObj = ({ format }: StoryProps) => {
 	fetchMock
 		.restore()
 		.getOnce('*', {
@@ -31,13 +43,7 @@ export const defaultStory = () => {
 				<LeftColumn borderType="partial">
 					<></>
 				</LeftColumn>
-				<ArticleContainer
-					format={{
-						display: ArticleDisplay.Standard,
-						design: ArticleDesign.Standard,
-						theme: Pillar.News,
-					}}
-				>
+				<ArticleContainer format={format}>
 					<></>
 				</ArticleContainer>
 				<RightColumn>
@@ -56,7 +62,7 @@ export const defaultStory = () => {
 };
 defaultStory.storyName = 'default';
 
-export const limitItemsStory = () => {
+export const limitItemsStory: StoryObj = ({ format }: StoryProps) => {
 	fetchMock
 		.restore()
 		.getOnce('*', {
@@ -71,13 +77,7 @@ export const limitItemsStory = () => {
 				<LeftColumn>
 					<></>
 				</LeftColumn>
-				<ArticleContainer
-					format={{
-						display: ArticleDisplay.Standard,
-						design: ArticleDesign.Standard,
-						theme: Pillar.News,
-					}}
-				>
+				<ArticleContainer format={format}>
 					<></>
 				</ArticleContainer>
 				<RightColumn>
@@ -96,7 +96,7 @@ export const limitItemsStory = () => {
 };
 limitItemsStory.storyName = 'with a limit of 3 items';
 
-export const outsideContextStory = () => {
+export const outsideContextStory: StoryObj = () => {
 	fetchMock
 		.restore()
 		.getOnce('*', {

--- a/dotcom-rendering/src/components/MostViewedRightItem.tsx
+++ b/dotcom-rendering/src/components/MostViewedRightItem.tsx
@@ -1,7 +1,12 @@
 import { css } from '@emotion/react';
 import { ArticleDesign } from '@guardian/libs';
-import { border, headline, neutral, text } from '@guardian/source-foundations';
+import {
+	border,
+	headline,
+	palette as sourcePalette,
+} from '@guardian/source-foundations';
 import { useHover } from '../lib/useHover';
+import { palette as themePalette } from '../palette';
 import type { TrailType } from '../types/trails';
 import { AgeWarning } from './AgeWarning';
 import { Avatar } from './Avatar';
@@ -35,11 +40,11 @@ const linkTagStyles = css`
 
 	&:link,
 	&:active {
-		color: ${text.anchorSecondary};
+		color: ${themePalette('--article-text')};
 	}
 
 	&:visited h4 {
-		color: ${neutral[46]};
+		color: ${sourcePalette.neutral[46]};
 	}
 
 	&:hover h4 {

--- a/dotcom-rendering/src/lib/decidePalette.ts
+++ b/dotcom-rendering/src/lib/decidePalette.ts
@@ -543,18 +543,6 @@ const textCardFooter = (format: ArticleFormat): string => {
 	}
 };
 
-const textLinkKicker = (format: ArticleFormat): string => {
-	if (format.design === ArticleDesign.Analysis) {
-		switch (format.theme) {
-			case Pillar.News:
-				return news[300];
-			default:
-				return pillarPalette[format.theme].main;
-		}
-	}
-	return pillarPalette[format.theme].main;
-};
-
 const textCricketScoreboardLink = (): string => {
 	return sport[300];
 };
@@ -1779,7 +1767,6 @@ export const decidePalette = (
 			cardKicker: overrides?.text.cardKicker ?? textCardKicker(format),
 			dynamoKicker:
 				overrides?.text.dynamoKicker ?? textCardKicker(format),
-			linkKicker: textLinkKicker(format),
 			cardStandfirst:
 				overrides?.text.cardStandfirst ?? textCardStandfirst(format),
 			cardFooter: overrides?.text.cardFooter ?? textCardFooter(format),

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -2886,10 +2886,10 @@ const appsEpicBackgroundDark: PaletteFunction = () => sourcePalette.neutral[20];
 const appsEpicBorderLight: PaletteFunction = () => sourcePalette.brandAlt[400];
 const appsEpicBorderDark: PaletteFunction = () => sourcePalette.brandAlt[200];
 
-const linkKickerText = (format: ArticleFormat): string => {
-	switch (format.design) {
+const linkKickerTextLight: PaletteFunction = ({ design, theme }) => {
+	switch (design) {
 		case ArticleDesign.Analysis:
-			switch (format.theme) {
+			switch (theme) {
 				case Pillar.News:
 					return sourcePalette.news[300];
 				case Pillar.Opinion:
@@ -2908,9 +2908,9 @@ const linkKickerText = (format: ArticleFormat): string => {
 					return sourcePalette.specialReportAlt[200];
 			}
 		default:
-			switch (format.theme) {
+			switch (theme) {
 				case Pillar.News:
-					return sourcePalette.news[200];
+					return sourcePalette.news[400];
 				case Pillar.Opinion:
 					return sourcePalette.opinion[300];
 				case Pillar.Sport:
@@ -2928,6 +2928,37 @@ const linkKickerText = (format: ArticleFormat): string => {
 			}
 	}
 };
+
+const linkKickerTextDark: PaletteFunction = ({ theme }) => {
+	switch (theme) {
+		case Pillar.News:
+			return sourcePalette.news[500];
+		case Pillar.Opinion:
+			return sourcePalette.opinion[500];
+		case Pillar.Sport:
+			return sourcePalette.sport[500];
+		case Pillar.Culture:
+			return sourcePalette.culture[500];
+		case Pillar.Lifestyle:
+			return sourcePalette.lifestyle[500];
+		case ArticleSpecial.SpecialReport:
+			return sourcePalette.news[500];
+		case ArticleSpecial.Labs:
+			return sourcePalette.labs[400];
+		case ArticleSpecial.SpecialReportAlt:
+			return sourcePalette.specialReportAlt[200];
+	}
+};
+
+const articleTextLight: PaletteFunction = () => sourcePalette.neutral[7];
+const articleTextDark: PaletteFunction = () => sourcePalette.neutral[86];
+
+const mostViewedFooterHoverLight: PaletteFunction = () =>
+	sourcePalette.neutral[97];
+const mostViewedFooterHoverDark: PaletteFunction = () =>
+	sourcePalette.neutral[20];
+
+// '--most-viewed-footer-tab
 // ----- Palette ----- //
 
 /**
@@ -3330,8 +3361,16 @@ const paletteColours = {
 		dark: mostViewedHeadlineDark,
 	},
 	'--link-kicker-text': {
-		light: linkKickerText,
-		dark: linkKickerText,
+		light: linkKickerTextLight,
+		dark: linkKickerTextDark,
+	},
+	'--article-text': {
+		light: articleTextLight,
+		dark: articleTextDark,
+	},
+	'--most-viewed-footer-hover': {
+		light: mostViewedFooterHoverLight,
+		dark: mostViewedFooterHoverDark,
 	},
 } satisfies PaletteColours;
 

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -2876,6 +2876,8 @@ const syndicationButtonBorder: PaletteFunction = ({ design, theme }) => {
 			return sourcePalette.neutral[86];
 	}
 };
+const mostViewedHeadlineLight = (): string => sourcePalette.neutral[7];
+const mostViewedHeadlineDark = (): string => sourcePalette.neutral[86];
 
 const appsEpicBackgroundLight: PaletteFunction = () =>
 	sourcePalette.neutral[97];
@@ -2884,6 +2886,48 @@ const appsEpicBackgroundDark: PaletteFunction = () => sourcePalette.neutral[20];
 const appsEpicBorderLight: PaletteFunction = () => sourcePalette.brandAlt[400];
 const appsEpicBorderDark: PaletteFunction = () => sourcePalette.brandAlt[200];
 
+const linkKickerText = (format: ArticleFormat): string => {
+	switch (format.design) {
+		case ArticleDesign.Analysis:
+			switch (format.theme) {
+				case Pillar.News:
+					return sourcePalette.news[300];
+				case Pillar.Opinion:
+					return sourcePalette.opinion[300];
+				case Pillar.Sport:
+					return sourcePalette.sport[400];
+				case Pillar.Culture:
+					return sourcePalette.culture[400];
+				case Pillar.Lifestyle:
+					return sourcePalette.lifestyle[400];
+				case ArticleSpecial.SpecialReport:
+					return sourcePalette.specialReport[400];
+				case ArticleSpecial.Labs:
+					return sourcePalette.labs[400];
+				case ArticleSpecial.SpecialReportAlt:
+					return sourcePalette.specialReportAlt[200];
+			}
+		default:
+			switch (format.theme) {
+				case Pillar.News:
+					return sourcePalette.news[200];
+				case Pillar.Opinion:
+					return sourcePalette.opinion[300];
+				case Pillar.Sport:
+					return sourcePalette.sport[400];
+				case Pillar.Culture:
+					return sourcePalette.culture[400];
+				case Pillar.Lifestyle:
+					return sourcePalette.lifestyle[400];
+				case ArticleSpecial.SpecialReport:
+					return sourcePalette.specialReport[400];
+				case ArticleSpecial.Labs:
+					return sourcePalette.labs[400];
+				case ArticleSpecial.SpecialReportAlt:
+					return sourcePalette.specialReportAlt[200];
+			}
+	}
+};
 // ----- Palette ----- //
 
 /**
@@ -3280,6 +3324,14 @@ const paletteColours = {
 	'--apps-epic-border': {
 		light: appsEpicBorderLight,
 		dark: appsEpicBorderDark,
+	},
+	'--most-viewed-headline': {
+		light: mostViewedHeadlineLight,
+		dark: mostViewedHeadlineDark,
+	},
+	'--link-kicker-text': {
+		light: linkKickerText,
+		dark: linkKickerText,
 	},
 } satisfies PaletteColours;
 

--- a/dotcom-rendering/src/types/palette.ts
+++ b/dotcom-rendering/src/types/palette.ts
@@ -16,7 +16,6 @@ export type Palette = {
 		dynamoHeadline: Colour;
 		dynamoKicker: Colour;
 		dynamoMeta: Colour;
-		linkKicker: Colour;
 		cardStandfirst: Colour;
 		cardFooter: Colour;
 		standfirst: Colour;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Updates the most viewed footer and right container to implement dark mode. 

## Why?
This is part of the wider body of work to implement dark mode for apps articles.
## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
