### PR TITLE
Create AB test and additional sizes for MPU when no epic

### DIFF
--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -291,7 +291,7 @@ const frontsBannerAdStyles = css`
 
 const articleEndAdStyles = css`
 	position: relative;
-	min-height: 250px;
+	min-height: ${adSizes.mpu.height + labelHeight}px;
 
 	&.ad-slot--fluid {
 		min-height: 450px;

--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -291,7 +291,7 @@ const frontsBannerAdStyles = css`
 
 const articleEndAdStyles = css`
 	position: relative;
-	min-height: 450px;
+	min-height: 250px;
 
 	&.ad-slot--fluid {
 		min-height: 450px;

--- a/dotcom-rendering/src/components/SlotBodyEnd.importable.tsx
+++ b/dotcom-rendering/src/components/SlotBodyEnd.importable.tsx
@@ -220,7 +220,12 @@ export const SlotBodyEnd = ({
 	useEffect(() => {
 		const additionalSizes = (): SizeMapping => {
 			if (mpuWhenNoEpicEnabled) {
-				return { mobile: [adSizes.mpu] };
+				return {
+					desktop: [
+						adSizes.outstreamDesktop,
+						adSizes.outstreamGoogleDesktop,
+					],
+				};
 			} else if (showPublicGood) {
 				return { mobile: [adSizes.fluid] };
 			}

--- a/dotcom-rendering/src/components/SlotBodyEnd.importable.tsx
+++ b/dotcom-rendering/src/components/SlotBodyEnd.importable.tsx
@@ -160,7 +160,6 @@ export const SlotBodyEnd = ({
 			countryCode === 'GB') ??
 		false;
 
-	// Show the article end slot if the epic is not shown, currently only used in the US for Public Good
 	const showArticleEndSlot =
 		renderAds &&
 		!isLabs &&
@@ -220,20 +219,20 @@ export const SlotBodyEnd = ({
 	}, [isSignedIn, countryCode, brazeMessages, asyncArticleCount, browserId]);
 
 	useEffect(() => {
-		const additionalSizes = (): SizeMapping => {
-			if (mpuWhenNoEpicEnabled) {
-				return {
-					desktop: [
-						adSizes.outstreamDesktop,
-						adSizes.outstreamGoogleDesktop,
-					],
-				};
-			} else if (showPublicGood) {
-				return { mobile: [adSizes.fluid] };
-			}
-			return {};
-		};
 		if (SelectedEpic === null && showArticleEndSlot) {
+			const additionalSizes = (): SizeMapping => {
+				if (mpuWhenNoEpicEnabled) {
+					return {
+						desktop: [
+							adSizes.outstreamDesktop,
+							adSizes.outstreamGoogleDesktop,
+						],
+					};
+				} else if (showPublicGood) {
+					return { mobile: [adSizes.fluid] };
+				}
+				return {};
+			};
 			document.dispatchEvent(
 				new CustomEvent('gu.commercial.slot.fill', {
 					detail: {

--- a/dotcom-rendering/src/components/SlotBodyEnd.importable.tsx
+++ b/dotcom-rendering/src/components/SlotBodyEnd.importable.tsx
@@ -218,17 +218,30 @@ export const SlotBodyEnd = ({
 	}, [isSignedIn, countryCode, brazeMessages, asyncArticleCount, browserId]);
 
 	useEffect(() => {
-		const additionalSizes: SizeMapping = mpuWhenNoEpicEnabled
-			? { mobile: [adSizes.mpu] }
-			: {};
+		const additionalSizes = (): SizeMapping => {
+			if (mpuWhenNoEpicEnabled) {
+				return { mobile: [adSizes.mpu] };
+			} else if (showPublicGood) {
+				return { mobile: [adSizes.fluid] };
+			}
+			return {};
+		};
 		if (SelectedEpic === null && showArticleEndSlot) {
 			document.dispatchEvent(
 				new CustomEvent('gu.commercial.slot.fill', {
-					detail: { slotId: 'dfp-ad--article-end', additionalSizes },
+					detail: {
+						slotId: 'dfp-ad--article-end',
+						additionalSizes: additionalSizes(),
+					},
 				}),
 			);
 		}
-	}, [SelectedEpic, showArticleEndSlot, mpuWhenNoEpicEnabled]);
+	}, [
+		SelectedEpic,
+		showArticleEndSlot,
+		mpuWhenNoEpicEnabled,
+		showPublicGood,
+	]);
 
 	if (SelectedEpic !== null && SelectedEpic !== undefined) {
 		return (

--- a/dotcom-rendering/src/experiments/ab-tests.ts
+++ b/dotcom-rendering/src/experiments/ab-tests.ts
@@ -2,6 +2,7 @@ import type { ABTest } from '@guardian/ab-core';
 import { abTestTest } from './tests/ab-test-test';
 import { consentlessAds } from './tests/consentless-ads';
 import { integrateIma } from './tests/integrate-ima';
+import { mpuWhenNoEpic } from './tests/mpu-when-no-epic';
 import { signInGateMainControl } from './tests/sign-in-gate-main-control';
 import { signInGateMainVariant } from './tests/sign-in-gate-main-variant';
 
@@ -13,4 +14,5 @@ export const tests: ABTest[] = [
 	signInGateMainControl,
 	consentlessAds,
 	integrateIma,
+	mpuWhenNoEpic,
 ];

--- a/dotcom-rendering/src/experiments/tests/mpu-when-no-epic.ts
+++ b/dotcom-rendering/src/experiments/tests/mpu-when-no-epic.ts
@@ -1,0 +1,29 @@
+import type { ABTest } from '@guardian/ab-core';
+
+export const mpuWhenNoEpic: ABTest = {
+	id: 'MpuWhenNoEpic',
+	author: '@commercial-dev',
+	start: '2023-11-22',
+	expiry: '2024-01-31',
+	audience: 0 / 100,
+	audienceOffset: 0 / 100,
+	audienceCriteria: '',
+	successMeasure: '',
+	description:
+		'Test MPU when there is no epic at the end of Article on the page.',
+	variants: [
+		{
+			id: 'control',
+			test: (): void => {
+				/* no-op */
+			},
+		},
+		{
+			id: 'variant',
+			test: (): void => {
+				/* no-op */
+			},
+		},
+	],
+	canRun: () => true,
+};

--- a/dotcom-rendering/src/experiments/tests/mpu-when-no-epic.ts
+++ b/dotcom-rendering/src/experiments/tests/mpu-when-no-epic.ts
@@ -5,8 +5,8 @@ export const mpuWhenNoEpic: ABTest = {
 	author: '@commercial-dev',
 	start: '2023-11-22',
 	expiry: '2024-01-31',
-	audience: 0 / 100,
-	audienceOffset: 0 / 100,
+	audience: 10 / 100,
+	audienceOffset: 5 / 100,
 	audienceCriteria: '',
 	successMeasure: '',
 	description:


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

- Adds the `MpuWhenNoEpic` AB test. 
- Updates the functionality of `showArticleEndSlot` to check if a user is in the variant and in countryCode `GB`
- Passes the additionalSizes as an optional parameter to the customEvent.

For more details check other PRs related to this work https://github.com/guardian/frontend/pull/26711 and https://github.com/guardian/commercial/pull/1157

## Why?

Use the end of Article space if reader revenue isn't showing an epic to test if that will increase revenue. 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![image](https://github.com/guardian/dotcom-rendering/assets/23424805/09cd0e4a-7b6a-4cf5-9963-29ea19dfba0a) | ![image](https://github.com/guardian/dotcom-rendering/assets/23424805/c6d757fe-a867-40cb-bb45-981b24ad6678) |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
