### PR TITLE
Make `SupportTheG` Island server safe

### DIFF
--- a/dotcom-rendering/playwright/tests/parallel-3/article.interactivity.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/parallel-3/article.interactivity.e2e.spec.ts
@@ -128,7 +128,7 @@ test.describe('Interactivity', () => {
 		}) => {
 			await disableCMP(context);
 			await loadPage(page, `/Article/${articleUrl}`);
-			await waitForIsland(page, 'SupportTheG');
+			await waitForIsland(page, 'SupportTheG', { status: 'hydrated' });
 			await expect(
 				page
 					.locator('header')

--- a/dotcom-rendering/src/components/Header.tsx
+++ b/dotcom-rendering/src/components/Header.tsx
@@ -81,11 +81,7 @@ export const Header = ({
 				<Snow />
 			</Island>
 			<Logo editionId={editionId} hasPageSkin={hasPageSkin} />
-			<Island
-				priority="feature"
-				defer={{ until: 'idle' }}
-				clientOnly={true}
-			>
+			<Island priority="feature" defer={{ until: 'idle' }}>
 				<SupportTheG
 					urls={urls}
 					editionId={editionId}

--- a/dotcom-rendering/src/components/Island.test.tsx
+++ b/dotcom-rendering/src/components/Island.test.tsx
@@ -31,6 +31,7 @@ import { SignInGateSelector } from './SignInGateSelector.importable';
 import { SlotBodyEnd } from './SlotBodyEnd.importable';
 import { Snow } from './Snow.importable';
 import { StickyBottomBanner } from './StickyBottomBanner.importable';
+import { SupportTheG } from './SupportTheG.importable';
 
 // Type tests
 // Test that impossible prop combinations are caught by TypeScript.
@@ -435,6 +436,29 @@ describe('Island: server-side rendering', () => {
 						remoteBannerSwitch={true}
 						puzzleBannerSwitch={false}
 						isSensitive={false}
+					/>
+				</ConfigProvider>,
+			),
+		).not.toThrow();
+	});
+
+	test('SupportTheG', () => {
+		expect(() =>
+			renderToString(
+				<ConfigProvider
+					value={{ renderingTarget: 'Web', darkModeAvailable: false }}
+				>
+					<SupportTheG
+						editionId={'UK'}
+						dataLinkNamePrefix={''}
+						inHeader={false}
+						remoteHeader={false}
+						contributionsServiceUrl={''}
+						urls={{
+							subscribe: '',
+							support: '',
+							contribute: '',
+						}}
 					/>
 				</ConfigProvider>,
 			),

--- a/dotcom-rendering/src/components/SupportTheG.importable.tsx
+++ b/dotcom-rendering/src/components/SupportTheG.importable.tsx
@@ -37,6 +37,7 @@ import { useAuthStatus } from '../lib/useAuthStatus';
 import { useCountryCode } from '../lib/useCountryCode';
 import { useIsInView } from '../lib/useIsInView';
 import { useOnce } from '../lib/useOnce';
+import { usePageViewId } from '../lib/usePageViewId';
 import ArrowRightIcon from '../static/icons/arrow-right.svg';
 import { useConfig } from './ConfigContext';
 
@@ -435,10 +436,11 @@ export const SupportTheG = ({
 	contributionsServiceUrl,
 	hasPageSkin = false,
 }: Props) => {
+	const { renderingTarget } = useConfig();
 	const countryCode = useCountryCode('support-the-Guardian');
-	const pageViewId = window.guardian.config.ophan.pageViewId;
+	const pageViewId = usePageViewId(renderingTarget);
 
-	if (countryCode) {
+	if (countryCode && pageViewId) {
 		if (inHeader && remoteHeader) {
 			return (
 				<ReaderRevenueLinksRemote

--- a/dotcom-rendering/src/components/SupportTheG.importable.tsx
+++ b/dotcom-rendering/src/components/SupportTheG.importable.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import type { OphanABTestMeta, OphanComponentEvent } from '@guardian/libs';
-import { getCookie } from '@guardian/libs';
+import { getCookie, isUndefined } from '@guardian/libs';
 import {
 	brandAlt,
 	brandText,
@@ -440,27 +440,22 @@ export const SupportTheG = ({
 	const countryCode = useCountryCode('support-the-Guardian');
 	const pageViewId = usePageViewId(renderingTarget);
 
-	if (countryCode && pageViewId) {
-		if (inHeader && remoteHeader) {
-			return (
-				<ReaderRevenueLinksRemote
-					countryCode={countryCode}
-					pageViewId={pageViewId}
-					contributionsServiceUrl={contributionsServiceUrl}
-				/>
-			);
-		}
-		return (
-			<ReaderRevenueLinksNative
-				editionId={editionId}
-				dataLinkNamePrefix={dataLinkNamePrefix}
-				inHeader={inHeader}
-				urls={urls}
-				pageViewId={pageViewId}
-				hasPageSkin={hasPageSkin}
-			/>
-		);
-	}
+	if (isUndefined(countryCode) || isUndefined(pageViewId)) return null;
 
-	return null;
+	return inHeader && remoteHeader ? (
+		<ReaderRevenueLinksRemote
+			countryCode={countryCode}
+			pageViewId={pageViewId}
+			contributionsServiceUrl={contributionsServiceUrl}
+		/>
+	) : (
+		<ReaderRevenueLinksNative
+			editionId={editionId}
+			dataLinkNamePrefix={dataLinkNamePrefix}
+			inHeader={inHeader}
+			urls={urls}
+			pageViewId={pageViewId}
+			hasPageSkin={hasPageSkin}
+		/>
+	);
 };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

- Make `SupportTheG` Island server safe
- Add a test to prove it
- Refactor with early reaturns to reduce intendation, see #8784 

## Why?

No assumption should be made about where components are run.

- Split out from #8991 for easier review
- Enables the work from #8948 to proceed safely.