### PR TITLE
Make `AdPortals` Island server safe

### DIFF
--- a/dotcom-rendering/.storybook/mocks/bridgetApi.ts
+++ b/dotcom-rendering/.storybook/mocks/bridgetApi.ts
@@ -30,3 +30,5 @@ export const getNotificationsClient: () => Partial<
 > = () => ({
 	isFollowing: async () => false,
 });
+
+export const getCommercialClient = () => undefined;

--- a/dotcom-rendering/.storybook/mocks/bridgetApi.ts
+++ b/dotcom-rendering/.storybook/mocks/bridgetApi.ts
@@ -1,19 +1,42 @@
-import * as User from '@guardian/bridget/User';
-import * as Acquisitions from '@guardian/bridget/Acquisitions';
-import * as Notifications from '@guardian/bridget/Notifications';
+type BridgeModule = typeof import('../../src/lib/bridgetApi');
+
+type BridgetApi<T extends keyof BridgeModule> = () => Partial<
+	ReturnType<BridgeModule[T]>
+>;
+
 /**
  * This is a mock logger to replace [bridgetApi.ts][]
  *
  * [bridgetApi.ts]: ../../src/lib/bridgetApi.ts
  */
 
-export const getUserClient: () => Partial<User.Client<void>> = () => ({
+export const getUserClient: BridgetApi<'getUserClient'> = () => ({
 	isPremium: async () => false,
 	doesCcpaApply: async () => false,
 });
 
-export const getAcquisitionsClient: () => Partial<
-	Acquisitions.Client<void>
+export const getEnvironmentClient: BridgetApi<
+	'getEnvironmentClient'
+> = () => ({});
+
+export const getGalleryClient: BridgetApi<'getGalleryClient'> = () => ({});
+
+export const getVideoClient: BridgetApi<'getVideoClient'> = () => ({});
+
+export const getMetricsClient: BridgetApi<'getMetricsClient'> = () => ({});
+
+export const getAnalyticsClient: BridgetApi<'getAnalyticsClient'> = () => ({});
+
+export const getNavigationClient: BridgetApi<
+	'getNavigationClient'
+> = () => ({});
+
+export const getNewslettersClient: BridgetApi<
+	'getNewslettersClient'
+> = () => ({});
+
+export const getAcquisitionsClient: BridgetApi<
+	'getAcquisitionsClient'
 > = () => ({
 	getEpics: async () => ({
 		epic: {
@@ -25,10 +48,29 @@ export const getAcquisitionsClient: () => Partial<
 	epicSeen: async () => {},
 });
 
-export const getNotificationsClient: () => Partial<
-	Notifications.Client<void>
+export const getNotificationsClient: BridgetApi<
+	'getNotificationsClient'
 > = () => ({
 	isFollowing: async () => false,
 });
 
-export const getCommercialClient = () => undefined;
+export const getCommercialClient: BridgetApi<'getCommercialClient'> = () => ({
+	insertAdverts: () => Promise.resolve(),
+	updateAdverts: () => Promise.resolve(),
+});
+
+export const ensure_all_exports_are_present = {
+	getUserClient,
+	getAcquisitionsClient,
+	getNotificationsClient,
+	getCommercialClient,
+	getEnvironmentClient,
+	getGalleryClient,
+	getVideoClient,
+	getMetricsClient,
+	getAnalyticsClient,
+	getNavigationClient,
+	getNewslettersClient,
+} satisfies {
+	[Method in keyof BridgeModule]: BridgetApi<Method>;
+};

--- a/dotcom-rendering/src/components/Island.test.tsx
+++ b/dotcom-rendering/src/components/Island.test.tsx
@@ -4,6 +4,7 @@
 
 import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
 import { renderToString } from 'react-dom/server';
+import { AdPortals } from './AdPortals.importable';
 import { AlreadyVisited } from './AlreadyVisited.importable';
 import { AppEmailSignUp } from './AppEmailSignUp.importable';
 import { AppsEpic } from './AppsEpic.importable';
@@ -99,6 +100,10 @@ const Mock = () => <>🏝️</>;
 // Jest tests
 
 describe('Island: server-side rendering', () => {
+	test('AdPortals', () => {
+		expect(() => renderToString(<AdPortals />)).not.toThrow();
+	});
+
 	test('AlreadyVisited', () => {
 		expect(() => renderToString(<AlreadyVisited />)).not.toThrow();
 	});

--- a/dotcom-rendering/src/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/layouts/CommentLayout.tsx
@@ -435,7 +435,7 @@ export const CommentLayout = (props: WebProps | AppsProps) => {
 
 			<main data-layout="CommentLayout">
 				{renderingTarget === 'Apps' && (
-					<Island priority="critical" clientOnly={true}>
+					<Island priority="critical">
 						<AdPortals />
 					</Island>
 				)}

--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -463,7 +463,7 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 
 			<main data-layout="ImmersiveLayout">
 				{renderingTarget === 'Apps' && (
-					<Island priority="critical" clientOnly={true}>
+					<Island priority="critical">
 						<AdPortals />
 					</Island>
 				)}

--- a/dotcom-rendering/src/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/InteractiveLayout.tsx
@@ -400,7 +400,7 @@ export const InteractiveLayout = (props: WebProps | AppsProps) => {
 			)}
 			<main data-layout="InteractiveLayout">
 				{isApps && (
-					<Island priority="critical" clientOnly={true}>
+					<Island priority="critical">
 						<AdPortals />
 					</Island>
 				)}

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -424,7 +424,7 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 			)}
 			<main data-layout="LiveLayout">
 				{isApps && (
-					<Island priority="critical" clientOnly={true}>
+					<Island priority="critical">
 						<AdPortals rightAlignFrom="wide" />
 					</Island>
 				)}

--- a/dotcom-rendering/src/layouts/PictureLayout.tsx
+++ b/dotcom-rendering/src/layouts/PictureLayout.tsx
@@ -413,7 +413,7 @@ export const PictureLayout = (props: WebProps | AppsProps) => {
 				dir={decideLanguageDirection(article.isRightToLeftLang)}
 			>
 				{isApps && (
-					<Island priority="critical" clientOnly={true}>
+					<Island priority="critical">
 						<AdPortals />
 					</Island>
 				)}

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -471,7 +471,7 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 				dir={decideLanguageDirection(article.isRightToLeftLang)}
 			>
 				{renderingTarget === 'Apps' && (
-					<Island priority="critical" clientOnly={true}>
+					<Island priority="critical">
 						<AdPortals />
 					</Island>
 				)}

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -488,7 +488,7 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 
 			<main data-layout="StandardLayout">
 				{isApps && (
-					<Island priority="critical" clientOnly={true}>
+					<Island priority="critical">
 						<AdPortals />
 					</Island>
 				)}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

- Refactor `useMatchMedia` so it works in context where window is `undefined`
- Add a test to demonstrate AdPortals is now server-safe

## Why?

No assumption should be made about where components are run.

- Split out from #8991 for easier review
- Enables the work from #8948 to proceed safely.