### PR TITLE
Prove remaining Islands are server-safe

### DIFF
--- a/dotcom-rendering/cypress/e2e/parallel-3/epic.interactivity.cy.js
+++ b/dotcom-rendering/cypress/e2e/parallel-3/epic.interactivity.cy.js
@@ -32,7 +32,7 @@ describe('Epics', function () {
 		// Wait for hydration of the Epic
 		cy.get('gu-island[name=LiveBlogEpic]')
 			.first()
-			.should('have.attr', 'data-island-status', 'rendered');
+			.should('have.attr', 'data-island-status', 'hydrated');
 		cy.get('[data-cy=contributions-liveblog-epic]').scrollIntoView();
 		cy.get('[data-cy=contributions-liveblog-epic]').should('be.visible');
 	});

--- a/dotcom-rendering/cypress/e2e/parallel-5/liveblog.interactivity.cy.js
+++ b/dotcom-rendering/cypress/e2e/parallel-5/liveblog.interactivity.cy.js
@@ -47,7 +47,7 @@ describe('Liveblogs', function () {
 		// Wait for hydration
 		cy.get('gu-island[name=Liveness]')
 			.first()
-			.should('have.attr', 'data-island-status', 'rendered');
+			.should('have.attr', 'data-island-status', 'hydrated');
 		cy.scrollTo('center');
 		cy.get(`[data-testid="toast"]`).should('not.exist');
 		cy.window().then(function (win) {
@@ -75,7 +75,7 @@ describe('Liveblogs', function () {
 		// Wait for hydration
 		cy.get('gu-island[name=Liveness]')
 			.first()
-			.should('have.attr', 'data-island-status', 'rendered');
+			.should('have.attr', 'data-island-status', 'hydrated');
 		cy.window().then(function (win) {
 			win.mockLiveUpdate({
 				numNewBlocks: 1,
@@ -92,7 +92,7 @@ describe('Liveblogs', function () {
 		// Wait for hydration
 		cy.get('gu-island[name=Liveness]', { timeout: 30000 })
 			.first()
-			.should('have.attr', 'data-island-status', 'rendered');
+			.should('have.attr', 'data-island-status', 'hydrated');
 		cy.scrollTo('bottom');
 		cy.get(`[data-testid="toast"]`).should('not.exist');
 		cy.window().then(function (win) {
@@ -128,7 +128,7 @@ describe('Liveblogs', function () {
 		// Wait for hydration
 		cy.get('gu-island[name=Liveness]')
 			.first()
-			.should('have.attr', 'data-island-status', 'rendered');
+			.should('have.attr', 'data-island-status', 'hydrated');
 		cy.window().then(function (win) {
 			win.mockLiveUpdate({
 				numNewBlocks: 1,
@@ -171,7 +171,7 @@ describe('Liveblogs', function () {
 		// Wait for hydration
 		cy.get('gu-island[name=Liveness]', { timeout: 30000 })
 			.first()
-			.should('have.attr', 'data-island-status', 'rendered');
+			.should('have.attr', 'data-island-status', 'hydrated');
 		cy.scrollTo('bottom');
 		cy.get(`[data-testid="toast"]`).should('not.exist');
 		cy.window().then(function (win) {
@@ -198,7 +198,7 @@ describe('Liveblogs', function () {
 		// Wait for hydration
 		cy.get('gu-island[name=Liveness]')
 			.first()
-			.should('have.attr', 'data-island-status', 'rendered');
+			.should('have.attr', 'data-island-status', 'hydrated');
 		cy.scrollTo('bottom', { duration: 1000 });
 		cy.window().then(function (win) {
 			win.mockLiveUpdate({

--- a/dotcom-rendering/playwright/tests/parallel-1/article.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/parallel-1/article.e2e.spec.ts
@@ -78,7 +78,9 @@ test.describe('E2E Page rendering', () => {
 			).toBeVisible();
 
 			// expect most read right to be loaded, its data response and its text to be visible
-			await waitForIsland(page, 'MostViewedRightWrapper');
+			await waitForIsland(page, 'MostViewedRightWrapper', {
+				status: 'hydrated',
+			});
 			await mostReadRightResponsePromise;
 			await expect(
 				page

--- a/dotcom-rendering/playwright/tests/parallel-3/article.interactivity.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/parallel-3/article.interactivity.e2e.spec.ts
@@ -93,7 +93,9 @@ test.describe('Interactivity', () => {
 			await disableCMP(context);
 			await loadPage(page, `/Article/${articleUrl}`);
 			await expectToNotExist(page, '[data-component=geo-most-popular]');
-			await waitForIsland(page, 'MostViewedRightWrapper');
+			await waitForIsland(page, 'MostViewedRightWrapper', {
+				status: 'hydrated',
+			});
 			await expectToExist(page, '[data-component=geo-most-popular]');
 		});
 
@@ -151,7 +153,9 @@ test.describe('Interactivity', () => {
 			).toHaveCount(0);
 
 			// Wait for hydration
-			await waitForIsland(page, 'MostViewedRightWrapper');
+			await waitForIsland(page, 'MostViewedRightWrapper', {
+				status: 'hydrated',
+			});
 			await expect(
 				page
 					.locator(`gu-island[name="MostViewedRightWrapper"]`)

--- a/dotcom-rendering/src/components/EmailSignUpSwitcher.tsx
+++ b/dotcom-rendering/src/components/EmailSignUpSwitcher.tsx
@@ -19,7 +19,7 @@ export const EmailSignUpSwitcher = ({
 	const { renderingTarget } = useConfig();
 
 	return renderingTarget === 'Apps' ? (
-		<Island priority="feature" clientOnly={true} defer={{ until: 'idle' }}>
+		<Island priority="feature" defer={{ until: 'idle' }}>
 			<AppEmailSignUp skipToIndex={index} {...emailSignUpProps} />
 		</Island>
 	) : (

--- a/dotcom-rendering/src/components/FrontPage.tsx
+++ b/dotcom-rendering/src/components/FrontPage.tsx
@@ -71,11 +71,7 @@ export const FrontPage = ({ front, NAV }: Props) => {
 					tests={front.config.abTests}
 				/>
 			</Island>
-			<Island
-				priority="enhancement"
-				defer={{ until: 'idle' }}
-				clientOnly={true}
-			>
+			<Island priority="enhancement" defer={{ until: 'idle' }}>
 				<ShowHideContainers />
 			</Island>
 			<Island priority="critical" clientOnly={true}>

--- a/dotcom-rendering/src/components/Island.test.tsx
+++ b/dotcom-rendering/src/components/Island.test.tsx
@@ -5,6 +5,7 @@
 import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
 import { renderToString } from 'react-dom/server';
 import { AlreadyVisited } from './AlreadyVisited.importable';
+import { AppEmailSignUp } from './AppEmailSignUp.importable';
 import { AppsEpic } from './AppsEpic.importable';
 import { BrazeMessaging } from './BrazeMessaging.importable';
 import { CardCommentCount } from './CardCommentCount.importable';
@@ -98,6 +99,22 @@ const Mock = () => <>🏝️</>;
 describe('Island: server-side rendering', () => {
 	test('AlreadyVisited', () => {
 		expect(() => renderToString(<AlreadyVisited />)).not.toThrow();
+	});
+
+	test('AppEmailSignup', () => {
+		expect(() =>
+			renderToString(
+				<AppEmailSignUp
+					skipToIndex={0}
+					identityName={''}
+					successDescription={''}
+					name={''}
+					description={''}
+					frequency={''}
+					theme={''}
+				/>,
+			),
+		).not.toThrow();
 	});
 
 	test('AppsEpic', () => {

--- a/dotcom-rendering/src/components/Island.test.tsx
+++ b/dotcom-rendering/src/components/Island.test.tsx
@@ -30,6 +30,7 @@ import { RecipeMultiplier } from './RecipeMultiplier.importable';
 import { SendTargetingParams } from './SendTargetingParams.importable';
 import { SetABTests } from './SetABTests.importable';
 import { SetAdTargeting } from './SetAdTargeting.importable';
+import { ShowHideContainers } from './ShowHideContainers.importable';
 import { SignInGateSelector } from './SignInGateSelector.importable';
 import { SlotBodyEnd } from './SlotBodyEnd.importable';
 import { Snow } from './Snow.importable';
@@ -403,6 +404,10 @@ describe('Island: server-side rendering', () => {
 				/>,
 			),
 		).not.toThrow();
+	});
+
+	test('ShowHideContainers', () => {
+		expect(() => renderToString(<ShowHideContainers />)).not.toThrow();
 	});
 
 	test('SignInGateSelector', () => {

--- a/dotcom-rendering/src/components/Island.test.tsx
+++ b/dotcom-rendering/src/components/Island.test.tsx
@@ -22,6 +22,7 @@ import { LiveBlogEpic } from './LiveBlogEpic.importable';
 import { Liveness } from './Liveness.importable';
 import { Metrics } from './Metrics.importable';
 import { MostViewedFooterData } from './MostViewedFooterData.importable';
+import { MostViewedRightWrapper } from './MostViewedRightWrapper.importable';
 import { OnwardsUpper } from './OnwardsUpper.importable';
 import { ReaderRevenueDev } from './ReaderRevenueDev.importable';
 import { ReaderRevenueLinks } from './ReaderRevenueLinks.importable';
@@ -318,6 +319,18 @@ describe('Island: server-side rendering', () => {
 						design: ArticleDesign.Standard,
 						display: ArticleDisplay.Standard,
 					}}
+				/>,
+			),
+		).not.toThrow();
+	});
+
+	test('MostViewedRightWrapper', () => {
+		expect(() =>
+			renderToString(
+				<MostViewedRightWrapper
+					componentDataAttribute={''}
+					maxHeightPx={0}
+					renderAds={false}
 				/>,
 			),
 		).not.toThrow();

--- a/dotcom-rendering/src/components/LiveBlogRenderer.tsx
+++ b/dotcom-rendering/src/components/LiveBlogRenderer.tsx
@@ -154,7 +154,6 @@ export const LiveBlogRenderer = ({
 					// but this island manipulate the DOM via portals,
 					// its actual position has no bearing on its effect
 					defer={{ until: 'idle' }}
-					clientOnly={true}
 				>
 					<LiveBlogEpic
 						sectionId={sectionId}

--- a/dotcom-rendering/src/components/MostViewedRightWithAd.tsx
+++ b/dotcom-rendering/src/components/MostViewedRightWithAd.tsx
@@ -52,7 +52,6 @@ export const MostViewedRightWithAd = ({
 			{!isPaidContent ? (
 				<Island
 					priority="feature"
-					clientOnly={true}
 					defer={{
 						until: 'visible',
 						// Provide a much higher value for the top margin for the intersection observer

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -651,7 +651,6 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 								`}
 							/>
 							<Island
-								clientOnly={true}
 								priority="feature"
 								defer={{ until: 'idle' }}
 							>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Add tests to prove that the following islands are server safe and should no longer be client-side only:
- `AppEmailSignup`
- `MostViewedWrapper`
- `ShowHideContainer`
- `Liveness`
- `LiveBlogEpic`

## Why?

No assumption should be made about where components are run.

- Split out from #8991 for easier review
- Enables the work from #8948 to proceed safely.