### PR TITLE
hide mostpop ad slot

### DIFF
--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -10,6 +10,7 @@ import {
 	textSans,
 	until,
 } from '@guardian/source-foundations';
+import { Hide } from '@guardian/source-react-components';
 import { getZIndex } from '../lib/getZIndex';
 import { TopRightAdSlot } from './TopRightAdSlot';
 
@@ -502,29 +503,31 @@ export const AdSlot = ({
 		}
 		case 'mostpop': {
 			return (
-				<div
-					className="ad-slot-container"
-					css={[adContainerStyles, mostPopContainerStyles]}
-				>
+				<Hide until="tablet">
 					<div
-						id="dfp-ad--mostpop"
-						className={[
-							'js-ad-slot',
-							'ad-slot',
-							'ad-slot--mostpop',
-							'ad-slot--mpu-banner-ad',
-							'ad-slot--rendered',
-						].join(' ')}
-						css={[
-							fluidAdStyles,
-							fluidFullWidthAdStyles,
-							mostPopAdStyles,
-						]}
-						data-link-name="ad slot mostpop"
-						data-name="mostpop"
-						aria-hidden="true"
-					/>
-				</div>
+						className="ad-slot-container"
+						css={[adContainerStyles, mostPopContainerStyles]}
+					>
+						<div
+							id="dfp-ad--mostpop"
+							className={[
+								'js-ad-slot',
+								'ad-slot',
+								'ad-slot--mostpop',
+								'ad-slot--mpu-banner-ad',
+								'ad-slot--rendered',
+							].join(' ')}
+							css={[
+								fluidAdStyles,
+								fluidFullWidthAdStyles,
+								mostPopAdStyles,
+							]}
+							data-link-name="ad slot mostpop"
+							data-name="mostpop"
+							aria-hidden="true"
+						/>
+					</div>
+				</Hide>
 			);
 		}
 		case 'merchandising-high': {


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Currently when in mobile mode in the browser the `mostpop` ad slot appears just above the `merchandising` slot.
This removes the ad slot but **only** from the mobile and phablet view.

It will not affect the `mostpop` ad slot in the `Desktop` view

## Why?
We would like that proliferation of advertisements not to appear so closely.


## Screenshots
#### Mobile View 
#### BEFORE - with stacked ad slots

|  Plain      | w/ slot name      |
| ----------- | ---------- |
| <img width="220" alt="Screenshot 2023-11-24 at 19 55 55" src="https://github.com/guardian/dotcom-rendering/assets/49187886/7f6cac85-e814-4376-ac0d-ccf9300cf123"> | <img width="220" alt="Screenshot 2023-11-24 at 19 56 41" src="https://github.com/guardian/dotcom-rendering/assets/49187886/b6a19b14-a9ed-4710-9449-64eba1f98290"> |

#### Mobile View 
#### AFTER - with removed `mostpop` ad slot

|  Plain      | w/ slot name      |
| ----------- | ---------- |
| <img width="220" alt="Screenshot 2023-11-24 at 20 04 35" src="https://github.com/guardian/dotcom-rendering/assets/49187886/72c6d75f-cd12-4d09-a152-1eb55dfad852"> | <img width="220" alt="Screenshot 2023-11-24 at 20 01 19" src="https://github.com/guardian/dotcom-rendering/assets/49187886/e119419b-331b-46b5-a3dc-2e8556c6a256">  |



<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
