### PR TITLE
Make the content of `RecipeMultiplier` Island empty if no hash

### DIFF
--- a/dotcom-rendering/src/components/ArticleBody.tsx
+++ b/dotcom-rendering/src/components/ArticleBody.tsx
@@ -217,11 +217,7 @@ export const ArticleBody = ({
 				dir={languageDirection}
 			>
 				{isRecipe(tags) && (
-					<Island
-						priority="feature"
-						defer={{ until: 'hash' }}
-						clientOnly={true}
-					>
+					<Island priority="feature" defer={{ until: 'hash' }}>
 						<RecipeMultiplier />
 					</Island>
 				)}

--- a/dotcom-rendering/src/components/Island.test.tsx
+++ b/dotcom-rendering/src/components/Island.test.tsx
@@ -370,6 +370,7 @@ describe('Island: server-side rendering', () => {
 
 	test('RecipeMultiplier', () => {
 		expect(() => renderToString(<RecipeMultiplier />)).not.toThrow();
+		expect(renderToString(<RecipeMultiplier />)).toBe('');
 	});
 
 	test('SendTargetingParams', () => {

--- a/dotcom-rendering/src/components/RecipeMultiplier.importable.tsx
+++ b/dotcom-rendering/src/components/RecipeMultiplier.importable.tsx
@@ -4,6 +4,7 @@ import { palette, space, textSans } from '@guardian/source-foundations';
 import { Button, SvgMinus, SvgPlus } from '@guardian/source-react-components';
 import type { ChangeEventHandler } from 'react';
 import { useEffect, useState } from 'react';
+import { onNavigation } from '../client/islands/onNavigation';
 
 const colours = `
 gu-recipe {
@@ -120,10 +121,17 @@ const transform = ({
 };
 
 export const RecipeMultiplier = () => {
+	const [enabled, setEnabled] = useState(false);
 	const [servesElement, setServesElement] = useState<HTMLElement>();
 	const [serves, setServes] = useState<number>(1);
 	const [servings, setServings] = useState<number>(serves);
 	const [multiplier, setMultiplier] = useState(1);
+
+	useEffect(() => {
+		onNavigation(() => {
+			setEnabled(window.location.hash === `#RecipeMultiplier`);
+		});
+	}, []);
 
 	useEffect(() => {
 		if (!servesElement) return;
@@ -137,6 +145,7 @@ export const RecipeMultiplier = () => {
 	}, [servesElement]);
 
 	useEffect(() => {
+		if (!enabled) return;
 		log('dotcom', 'Injecting multiplier');
 		const style = document.createElement('style');
 		style.innerHTML = colours;
@@ -223,7 +232,7 @@ export const RecipeMultiplier = () => {
 				log('design', index, length, node.textContent);
 			}
 		}
-	}, []);
+	}, [enabled]);
 
 	useEffect(() => {
 		if (servesElement) servesElement.innerText = servings.toString();
@@ -258,6 +267,8 @@ export const RecipeMultiplier = () => {
 
 		if (!Number.isNaN(float)) setServings(float);
 	};
+
+	if (!enabled) return null;
 
 	return (
 		<ul css={styles}>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Make RecipeMultiplier more server-safe, including in Storybook.

## Why?

We do not want this Island to return anything outside of clients that have explicitely asked for this enhancement. Part of a hack day project in #6562 and building on #9383 

Enables the work in #8991 to proceed safely.

## Considered alternatives?

We could also remove `RecipeMultiplier` entirely as it’s not being used by actual users.