### PR TITLE
Make `SlotBodyEnd` Island no longer client-side only

### DIFF
--- a/dotcom-rendering/src/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/layouts/CommentLayout.tsx
@@ -628,7 +628,6 @@ export const CommentLayout = (props: WebProps | AppsProps) => {
 										<Island
 											priority="feature"
 											defer={{ until: 'visible' }}
-											clientOnly={true}
 										>
 											<SlotBodyEnd
 												contentType={

--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -645,7 +645,6 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 									<Island
 										priority="feature"
 										defer={{ until: 'visible' }}
-										clientOnly={true}
 									>
 										<SlotBodyEnd
 											contentType={article.contentType}

--- a/dotcom-rendering/src/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/InteractiveLayout.tsx
@@ -576,11 +576,7 @@ export const InteractiveLayout = (props: WebProps | AppsProps) => {
 							max-width: 620px;
 						`}
 					>
-						<Island
-							priority="feature"
-							defer={{ until: 'visible' }}
-							clientOnly={true}
-						>
+						<Island priority="feature" defer={{ until: 'visible' }}>
 							<SlotBodyEnd
 								contentType={article.contentType}
 								contributionsServiceUrl={

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -621,7 +621,6 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 									<Island
 										priority="feature"
 										defer={{ until: 'visible' }}
-										clientOnly={true}
 									>
 										<SlotBodyEnd
 											contentType={article.contentType}

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -706,7 +706,6 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 									<Island
 										priority="feature"
 										defer={{ until: 'visible' }}
-										clientOnly={true}
 									>
 										<SlotBodyEnd
 											contentType={article.contentType}


### PR DESCRIPTION
## What does this change?

Make `SlotBodyEnd` no longer `clientOnly`

## Why?

This Island is already server-safe, so we should render it on the server. Follow-up on #9353 

Allows the work in #8991 to proceed safely