### PR TITLE
Make the `Metrics` Island no longer client-side only

### DIFF
--- a/dotcom-rendering/src/components/AllEditorialNewslettersPage.tsx
+++ b/dotcom-rendering/src/components/AllEditorialNewslettersPage.tsx
@@ -51,7 +51,7 @@ export const AllEditorialNewslettersPage = ({
 			<Island priority="feature" defer={{ until: 'idle' }}>
 				<FocusStyles />
 			</Island>
-			<Island priority="critical" clientOnly={true}>
+			<Island priority="critical">
 				<Metrics
 					commercialMetricsEnabled={
 						!!newslettersPage.config.switches.commercialMetrics

--- a/dotcom-rendering/src/components/ArticlePage.tsx
+++ b/dotcom-rendering/src/components/ArticlePage.tsx
@@ -134,7 +134,7 @@ export const ArticlePage = (props: WebProps | AppProps) => {
 					<Island priority="feature" defer={{ until: 'idle' }}>
 						<AlreadyVisited />
 					</Island>
-					<Island priority="critical" clientOnly={true}>
+					<Island priority="critical">
 						<Metrics
 							commercialMetricsEnabled={
 								!!article.config.switches.commercialMetrics

--- a/dotcom-rendering/src/components/FrontPage.tsx
+++ b/dotcom-rendering/src/components/FrontPage.tsx
@@ -63,7 +63,7 @@ export const FrontPage = ({ front, NAV }: Props) => {
 			<Island priority="enhancement" defer={{ until: 'idle' }}>
 				<FocusStyles />
 			</Island>
-			<Island priority="critical" clientOnly={true}>
+			<Island priority="critical">
 				<Metrics
 					commercialMetricsEnabled={
 						!!front.config.switches.commercialMetrics

--- a/dotcom-rendering/src/components/Metrics.importable.tsx
+++ b/dotcom-rendering/src/components/Metrics.importable.tsx
@@ -61,6 +61,20 @@ const useDev = () => {
 	return isDev;
 };
 
+/**
+ * Record relevant metrics to our data warehouse:
+ * - Core Web Vitals
+ * - Commercial Metrics
+ *
+ * ## Why does this need to be an Island?
+ *
+ * Metrics are tied to a single page view and are gathered
+ * on the client-side exclusively.
+ *
+ * ---
+ *
+ * (No visual story exists as this does not render anything)
+ */
 export const Metrics = ({ commercialMetricsEnabled, tests }: Props) => {
 	const abTestApi = useAB()?.api;
 	const adBlockerInUse = useAdBlockInUse();

--- a/dotcom-rendering/src/components/TagFrontPage.tsx
+++ b/dotcom-rendering/src/components/TagFrontPage.tsx
@@ -60,7 +60,7 @@ export const TagFrontPage = ({ tagFront, NAV }: Props) => {
 			<Island priority="feature" defer={{ until: 'idle' }}>
 				<FocusStyles />
 			</Island>
-			<Island priority="critical" clientOnly={true}>
+			<Island priority="critical">
 				<Metrics
 					commercialMetricsEnabled={
 						!!tagFront.config.switches.commercialMetrics


### PR DESCRIPTION
## What does this change?

Render the Metrics Island on the server, too.

## Why?

this island is already server-safe, so we should render it on the server.

Follow-up on #9313 

Prepare for #8991 