### PR TITLE
Make `SetABTests` no longer client-side only

### DIFF
--- a/dotcom-rendering/src/components/ArticlePage.tsx
+++ b/dotcom-rendering/src/components/ArticlePage.tsx
@@ -153,7 +153,7 @@ export const ArticlePage = (props: WebProps | AppProps) => {
 							}
 						/>
 					</Island>
-					<Island clientOnly={true} priority="critical">
+					<Island priority="critical">
 						<SetABTests
 							abTestSwitches={filterABTestSwitches(
 								article.config.switches,

--- a/dotcom-rendering/src/components/FrontPage.tsx
+++ b/dotcom-rendering/src/components/FrontPage.tsx
@@ -74,7 +74,7 @@ export const FrontPage = ({ front, NAV }: Props) => {
 			<Island priority="enhancement" defer={{ until: 'idle' }}>
 				<ShowHideContainers />
 			</Island>
-			<Island priority="critical" clientOnly={true}>
+			<Island priority="critical">
 				<SetABTests
 					abTestSwitches={filterABTestSwitches(front.config.switches)}
 					pageIsSensitive={front.config.isSensitive}

--- a/dotcom-rendering/src/components/TagFrontPage.tsx
+++ b/dotcom-rendering/src/components/TagFrontPage.tsx
@@ -68,7 +68,7 @@ export const TagFrontPage = ({ tagFront, NAV }: Props) => {
 					tests={tagFront.config.abTests}
 				/>
 			</Island>
-			<Island priority="critical" clientOnly={true}>
+			<Island priority="critical">
 				<SetABTests
 					abTestSwitches={filterABTestSwitches(
 						tagFront.config.switches,


### PR DESCRIPTION
## What does this change?

Make `SetABTests` no longer a `clientOnly` Island.

## Why?

This island is already server-safe.

Follow-up on #9162 

Allows #8991 to proceed safely