### PR TITLE
Make `EnhancedPinnedPost` no longer client-side only

### DIFF
--- a/dotcom-rendering/src/components/LiveBlogRenderer.tsx
+++ b/dotcom-rendering/src/components/LiveBlogRenderer.tsx
@@ -73,11 +73,7 @@ export const LiveBlogRenderer = ({
 		<>
 			{pinnedPost && onFirstPage && !filtered && (
 				<>
-					<Island
-						clientOnly={true}
-						defer={{ until: 'idle' }}
-						priority="feature"
-					>
+					<Island defer={{ until: 'idle' }} priority="feature">
 						<EnhancePinnedPost />
 					</Island>
 					<PinnedPost pinnedPost={pinnedPost} format={format}>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Use hooks to ensure this component can run on client and server (isomorphism), rather than `isServer` checks.

## Why?

Allows #8991 to proceed safely