### PR TITLE
Stop the support us button dissapearing

### DIFF
--- a/dotcom-rendering/src/components/SupportTheG.importable.tsx
+++ b/dotcom-rendering/src/components/SupportTheG.importable.tsx
@@ -60,6 +60,10 @@ const headerStyles = css`
 	padding-left: 10px;
 	max-width: 310px;
 
+	${until.mobile} {
+		max-width: 80px;
+	}
+
 	${from.mobileMedium} {
 		padding-top: 44px;
 	}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Adds a max-width to stop the button hiding
## Why?
Accessibility for users with font-scaling
## Screenshots

https://github.com/guardian/dotcom-rendering/assets/110032454/defc0dc3-3d61-41fe-a4b2-d4d4bb7bb455

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
