### PR TITLE
Replace layout fragments with divs

### DIFF
--- a/dotcom-rendering/src/layouts/Layout.stories.tsx
+++ b/dotcom-rendering/src/layouts/Layout.stories.tsx
@@ -82,12 +82,14 @@ const HydratedLayout = ({
 	}, [serverArticle]);
 
 	return (
-		<DecideLayout
-			article={serverArticle}
-			NAV={NAV}
-			format={format}
-			renderingTarget={renderingTarget}
-		/>
+		<div>
+			<DecideLayout
+				article={serverArticle}
+				NAV={NAV}
+				format={format}
+				renderingTarget={renderingTarget}
+			/>
+		</div>
 	);
 };
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
This updates the Layout.Stories file to wrap the DecideLayout component in a div.

## Why?
We were seeing inconsistent errors in storybook (running locally and in chromatic)
```
Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.
```
Locally, you could get around this by refreshing, but in chromatic, this meant you had to run the whole job again.
As we have only seen the error in storybook, i've wrapped the DecideLayout in the generated stories, rather than updating every layout to use a div rather than a fragment.

This solution is based on this [github thread](https://github.com/remix-run/react-router/issues/8834). I've run it locally and in chromatic a lot, and have not seen the (previously fairly frequent error), although its hard to test for the absence of something completely so we'll have to keep an eye on it.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
