### PR TITLE
refactor how we pass the css in `QuoteIcon`

### DIFF
--- a/dotcom-rendering/src/components/QuoteIcon.tsx
+++ b/dotcom-rendering/src/components/QuoteIcon.tsx
@@ -1,13 +1,11 @@
 import { css } from '@emotion/react';
 
-const quoteStyles = (colour: string) => css`
+const base = css`
 	height: 0.7em;
 	width: auto;
 	vertical-align: baseline;
-	fill: ${colour};
 	margin-right: 4px;
 `;
-
 type Props = {
 	colour: string;
 };
@@ -17,7 +15,7 @@ type Props = {
  */
 export const QuoteIcon = ({ colour }: Props) => (
 	/* This viewBox is narrower than Source’s SvgQuote */
-	<svg viewBox="0 0 22 14" css={quoteStyles(colour)}>
+	<svg viewBox="0 0 22 14" css={base} style={{ fill: colour }}>
 		<path d="M5.255 0h4.75c-.572 4.53-1.077 8.972-1.297 13.941H0C.792 9.104 2.44 4.53 5.255 0Zm11.061 0H21c-.506 4.53-1.077 8.972-1.297 13.941h-8.686c.902-4.837 2.485-9.411 5.3-13.941Z" />
 	</svg>
 );


### PR DESCRIPTION
## What does this change?
Refactors how we pass the css in `QuoteIcon`.

## Why?
To align with Emotion Best Practices: https://emotion.sh/docs/best-practices#use-the-style-prop-for-dynamic-styles

Coming from a [suggestion](https://github.com/guardian/dotcom-rendering/pull/9312#discussion_r1402213922) by @mxdvl in:

* https://github.com/guardian/dotcom-rendering/pull/9312


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
