### PR TITLE
refactor validateResponse function

### DIFF
--- a/dotcom-rendering/src/client/userFeatures/user-features.ts
+++ b/dotcom-rendering/src/client/userFeatures/user-features.ts
@@ -54,13 +54,14 @@ const userHasData = () => {
 const validateResponse = (
 	response: unknown,
 ): response is UserFeaturesResponse => {
-	if (!isObject(response)) return false;
-	if (!isBoolean(response.showSupportMessaging)) return false;
-	if (!isObject(response.contentAccess)) return false;
-	if (!isBoolean(response.contentAccess.paidMember)) return false;
-	if (!isBoolean(response.contentAccess.recurringContributor)) return false;
-	if (!isBoolean(response.contentAccess.digitalPack)) return false;
-	return true;
+	return (
+		isObject(response) &&
+		isBoolean(response.showSupportMessaging) &&
+		isObject(response.contentAccess) &&
+		isBoolean(response.contentAccess.paidMember) &&
+		isBoolean(response.contentAccess.recurringContributor) &&
+		isBoolean(response.contentAccess.digitalPack)
+	);
 };
 
 const persistResponse = (JsonResponse: UserFeaturesResponse) => {

--- a/dotcom-rendering/src/client/userFeatures/user-features.ts
+++ b/dotcom-rendering/src/client/userFeatures/user-features.ts
@@ -4,7 +4,13 @@
  * https://github.com/guardian/commercial/blob/1a429d6be05657f20df4ca909df7d01a5c3d7402/src/lib/user-features.ts
  */
 
-import { getCookie, isObject, removeCookie, setCookie } from '@guardian/libs';
+import {
+	getCookie,
+	isBoolean,
+	isObject,
+	removeCookie,
+	setCookie,
+} from '@guardian/libs';
 import {
 	getAuthStatus,
 	getOptionsHeadersWithOkta,
@@ -49,18 +55,12 @@ const validateResponse = (
 	response: unknown,
 ): response is UserFeaturesResponse => {
 	if (!isObject(response)) return false;
-
-	if (
-		typeof response.showSupportMessaging === 'boolean' &&
-		isObject(response.contentAccess) &&
-		typeof response.contentAccess.paidMember === 'boolean' &&
-		typeof response.contentAccess.recurringContributor === 'boolean' &&
-		typeof response.contentAccess.digitalPack === 'boolean'
-	) {
-		return true;
-	}
-
-	return false;
+	if (!isBoolean(response.showSupportMessaging)) return false;
+	if (!isObject(response.contentAccess)) return false;
+	if (!isBoolean(response.contentAccess.paidMember)) return false;
+	if (!isBoolean(response.contentAccess.recurringContributor)) return false;
+	if (!isBoolean(response.contentAccess.digitalPack)) return false;
+	return true;
 };
 
 const persistResponse = (JsonResponse: UserFeaturesResponse) => {


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
A simple refactor for the `validateResponse` function.

## Why?
A consistent approach across code base

