### PR TITLE
Remove `default` Case From `pillarPalette` Function

### DIFF
--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -33,8 +33,6 @@ const pillarPalette = (
 			return sourcePalette.culture[lightness];
 		case Pillar.Opinion:
 			return sourcePalette.opinion[lightness];
-		default:
-			return sourcePalette.news[lightness];
 	}
 };
 


### PR DESCRIPTION
This default case is unnecessary, as all cases of `Pillar` are handled.

Default cases can mask changes to types. For example, if a new `Pillar` were added, we might want TypeScript to prompt us to handle this change rather than catching it silently in the `default` case.

Some background here: https://github.com/guardian/typescript-school/blob/da713476acb4885eab4856edfbd6ab5bd9546f24/4-narrowing/slides.md#default-cases
