### PR TITLE
Refactor Apps Lightbox

### DIFF
--- a/dotcom-rendering/src/components/AppsLightboxImage.importable.tsx
+++ b/dotcom-rendering/src/components/AppsLightboxImage.importable.tsx
@@ -1,6 +1,9 @@
 import { css } from '@emotion/react';
 import { type RoleType } from '../types/content';
-import { openLightboxForImageId } from './AppsLightboxImageStore.importable';
+import {
+	imageHasLightbox,
+	openLightboxForImageId,
+} from './AppsLightboxImageStore.importable';
 import { Picture } from './Picture';
 
 type Props = {
@@ -38,7 +41,7 @@ export const AppsLightboxImage = ({
 			isMainMedia={isMainMedia}
 		/>
 	);
-	return (
+	return imageHasLightbox(elementId) ? (
 		<button
 			onClick={() => openLightboxForImageId(elementId)}
 			type="button"
@@ -52,5 +55,7 @@ export const AppsLightboxImage = ({
 		>
 			{picture}
 		</button>
+	) : (
+		picture
 	);
 };

--- a/dotcom-rendering/src/components/AppsLightboxImage.importable.tsx
+++ b/dotcom-rendering/src/components/AppsLightboxImage.importable.tsx
@@ -1,9 +1,6 @@
 import { css } from '@emotion/react';
 import { type RoleType } from '../types/content';
-import {
-	imageHasLightbox,
-	openLightboxForImageId,
-} from './AppsLightboxImageStore.importable';
+import { openLightboxForImageId } from './AppsLightboxImageStore.importable';
 import { Picture } from './Picture';
 
 type Props = {
@@ -41,7 +38,7 @@ export const AppsLightboxImage = ({
 			isMainMedia={isMainMedia}
 		/>
 	);
-	return imageHasLightbox(elementId) ? (
+	return (
 		<button
 			onClick={() => openLightboxForImageId(elementId)}
 			type="button"
@@ -55,7 +52,5 @@ export const AppsLightboxImage = ({
 		>
 			{picture}
 		</button>
-	) : (
-		picture
 	);
 };

--- a/dotcom-rendering/src/components/AppsLightboxImage.importable.tsx
+++ b/dotcom-rendering/src/components/AppsLightboxImage.importable.tsx
@@ -1,11 +1,9 @@
 import { css } from '@emotion/react';
 import { type RoleType } from '../types/content';
+import { onImageClick } from './AppsLightboxImageStore.importable';
 import { Picture } from './Picture';
-import { getOnClickHandler } from './Foo.importable';
-import { element } from 'screenfull';
 
 type Props = {
-	currentIndex: number;
 	elementId: string;
 	role: RoleType;
 	format: ArticleFormat;
@@ -18,7 +16,6 @@ type Props = {
 };
 
 export const AppsLightboxImage = ({
-	currentIndex,
 	elementId,
 	role,
 	format,
@@ -29,7 +26,6 @@ export const AppsLightboxImage = ({
 	isMainMedia = false,
 	isLazy = true,
 }: Props) => {
-	const hasLightbox = currentIndex !== -1;
 	const picture = (
 		<Picture
 			role={role}
@@ -42,9 +38,9 @@ export const AppsLightboxImage = ({
 			isMainMedia={isMainMedia}
 		/>
 	);
-	return hasLightbox ? (
+	return (
 		<button
-			onClick={getOnClickHandler(elementId)}
+			onClick={() => onImageClick(elementId)}
 			type="button"
 			css={css`
 				border: none;
@@ -56,7 +52,5 @@ export const AppsLightboxImage = ({
 		>
 			{picture}
 		</button>
-	) : (
-		picture
 	);
 };

--- a/dotcom-rendering/src/components/AppsLightboxImage.importable.tsx
+++ b/dotcom-rendering/src/components/AppsLightboxImage.importable.tsx
@@ -1,14 +1,12 @@
 import { css } from '@emotion/react';
-import { Image } from '@guardian/bridget/Image';
-import { getGalleryClient } from '../lib/bridgetApi';
-import { generateImageURL } from '../lib/image';
-import type { ImageForAppsLightbox } from '../model/appsLightboxImages';
 import { type RoleType } from '../types/content';
 import { Picture } from './Picture';
+import { getOnClickHandler } from './Foo.importable';
+import { element } from 'screenfull';
 
 type Props = {
-	images: ImageForAppsLightbox[];
 	currentIndex: number;
+	elementId: string;
 	role: RoleType;
 	format: ArticleFormat;
 	master: string;
@@ -20,8 +18,8 @@ type Props = {
 };
 
 export const AppsLightboxImage = ({
-	images,
 	currentIndex,
+	elementId,
 	role,
 	format,
 	master,
@@ -32,32 +30,6 @@ export const AppsLightboxImage = ({
 	isLazy = true,
 }: Props) => {
 	const hasLightbox = currentIndex !== -1;
-	const onClick = () => {
-		// Handle the case the device is rotated
-		const imageWidth = Math.max(window.innerHeight, window.innerWidth);
-		const resolution = window.devicePixelRatio >= 2 ? 'high' : 'low';
-		void getGalleryClient()
-			.launchSlideshow(
-				images.map(
-					(image) =>
-						new Image({
-							width: image.width,
-							height: image.height,
-							url: generateImageURL({
-								mainImage: image.masterUrl,
-								imageWidth,
-								resolution,
-							}),
-							caption: image.caption,
-							credit: image.credit,
-						}),
-				),
-				currentIndex,
-				document.title,
-			)
-			// we don't need to handle this error
-			.catch(() => undefined);
-	};
 	const picture = (
 		<Picture
 			role={role}
@@ -72,7 +44,7 @@ export const AppsLightboxImage = ({
 	);
 	return hasLightbox ? (
 		<button
-			onClick={onClick}
+			onClick={getOnClickHandler(elementId)}
 			type="button"
 			css={css`
 				border: none;

--- a/dotcom-rendering/src/components/AppsLightboxImage.importable.tsx
+++ b/dotcom-rendering/src/components/AppsLightboxImage.importable.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import { type RoleType } from '../types/content';
-import { onImageClick } from './AppsLightboxImageStore.importable';
+import { openLightboxForImageId } from './AppsLightboxImageStore.importable';
 import { Picture } from './Picture';
 
 type Props = {
@@ -40,7 +40,7 @@ export const AppsLightboxImage = ({
 	);
 	return (
 		<button
-			onClick={() => onImageClick(elementId)}
+			onClick={() => openLightboxForImageId(elementId)}
 			type="button"
 			css={css`
 				border: none;

--- a/dotcom-rendering/src/components/AppsLightboxImageStore.importable.tsx
+++ b/dotcom-rendering/src/components/AppsLightboxImageStore.importable.tsx
@@ -1,0 +1,54 @@
+import { Image } from '@guardian/bridget/Image';
+import { getGalleryClient } from '../lib/bridgetApi';
+import { generateImageURL } from '../lib/image';
+import type { ImageForAppsLightbox } from '../model/appsLightboxImages';
+
+// Gets assigned a value when the component is rendered
+let imageStore: ImageForAppsLightbox[];
+
+export const getOnClickHandler = (elementId: string): (() => void) => {
+	const currentIndex = imageStore.findIndex(
+		(img) => img.elementId === elementId,
+	);
+
+	// Don't open the lightbox if the currentIndex couldn't be found
+	if (currentIndex == -1) {
+		return () => undefined;
+	}
+
+	return () => {
+		// Handle the case the device is rotated
+		const imageWidth = Math.max(window.innerHeight, window.innerWidth);
+		const resolution = window.devicePixelRatio >= 2 ? 'high' : 'low';
+		void getGalleryClient()
+			.launchSlideshow(
+				imageStore.map(
+					(image) =>
+						new Image({
+							width: image.width,
+							height: image.height,
+							url: generateImageURL({
+								mainImage: image.masterUrl,
+								imageWidth,
+								resolution,
+							}),
+							caption: image.caption,
+							credit: image.credit,
+						}),
+				),
+				currentIndex,
+				document.title,
+			)
+			// we don't need to handle this error
+			.catch(() => undefined);
+	};
+};
+
+export const AppsLightboxImageStore = ({
+	images,
+}: {
+	images: ImageForAppsLightbox[];
+}) => {
+	imageStore = images;
+	return null;
+};

--- a/dotcom-rendering/src/components/AppsLightboxImageStore.importable.tsx
+++ b/dotcom-rendering/src/components/AppsLightboxImageStore.importable.tsx
@@ -46,6 +46,9 @@ export const openLightboxForImageId = (elementId: string): void => {
 		.catch(() => undefined);
 };
 
+export const imageHasLightbox = (elementId: string): boolean =>
+	imageStore.some((img) => img.elementId === elementId);
+
 export const AppsLightboxImageStore = ({
 	images,
 }: {

--- a/dotcom-rendering/src/components/AppsLightboxImageStore.importable.tsx
+++ b/dotcom-rendering/src/components/AppsLightboxImageStore.importable.tsx
@@ -3,8 +3,8 @@ import { getGalleryClient } from '../lib/bridgetApi';
 import { generateImageURL } from '../lib/image';
 import type { ImageForAppsLightbox } from '../model/appsLightboxImages';
 
-// Gets assigned a value when the component is rendered
-let imageStore: ImageForAppsLightbox[];
+// Populated when the component is rendered
+let imageStore: ImageForAppsLightbox[] = [];
 
 /**
  * Uses Bridget's Gallery service to open the native lightbox at the provided image element ID.
@@ -15,8 +15,8 @@ export const openLightboxForImageId = (elementId: string): void => {
 		(img) => img.elementId === elementId,
 	);
 
-	// Don't open the lightbox if the currentIndex couldn't be found
-	if (currentIndex == -1) {
+	// Don't open the lightbox if the image wasn't found
+	if (currentIndex === -1) {
 		return;
 	}
 

--- a/dotcom-rendering/src/components/AppsLightboxImageStore.importable.tsx
+++ b/dotcom-rendering/src/components/AppsLightboxImageStore.importable.tsx
@@ -46,9 +46,6 @@ export const openLightboxForImageId = (elementId: string): void => {
 		.catch(() => undefined);
 };
 
-export const imageHasLightbox = (elementId: string): boolean =>
-	imageStore.some((img) => img.elementId === elementId);
-
 export const AppsLightboxImageStore = ({
 	images,
 }: {

--- a/dotcom-rendering/src/components/AppsLightboxImageStore.importable.tsx
+++ b/dotcom-rendering/src/components/AppsLightboxImageStore.importable.tsx
@@ -6,42 +6,40 @@ import type { ImageForAppsLightbox } from '../model/appsLightboxImages';
 // Gets assigned a value when the component is rendered
 let imageStore: ImageForAppsLightbox[];
 
-export const getOnClickHandler = (elementId: string): (() => void) => {
+export const onImageClick = (elementId: string): void => {
 	const currentIndex = imageStore.findIndex(
 		(img) => img.elementId === elementId,
 	);
 
 	// Don't open the lightbox if the currentIndex couldn't be found
 	if (currentIndex == -1) {
-		return () => undefined;
+		return;
 	}
 
-	return () => {
-		// Handle the case the device is rotated
-		const imageWidth = Math.max(window.innerHeight, window.innerWidth);
-		const resolution = window.devicePixelRatio >= 2 ? 'high' : 'low';
-		void getGalleryClient()
-			.launchSlideshow(
-				imageStore.map(
-					(image) =>
-						new Image({
-							width: image.width,
-							height: image.height,
-							url: generateImageURL({
-								mainImage: image.masterUrl,
-								imageWidth,
-								resolution,
-							}),
-							caption: image.caption,
-							credit: image.credit,
+	// Handle the case the device is rotated
+	const imageWidth = Math.max(window.innerHeight, window.innerWidth);
+	const resolution = window.devicePixelRatio >= 2 ? 'high' : 'low';
+	void getGalleryClient()
+		.launchSlideshow(
+			imageStore.map(
+				(image) =>
+					new Image({
+						width: image.width,
+						height: image.height,
+						url: generateImageURL({
+							mainImage: image.masterUrl,
+							imageWidth,
+							resolution,
 						}),
-				),
-				currentIndex,
-				document.title,
-			)
-			// we don't need to handle this error
-			.catch(() => undefined);
-	};
+						caption: image.caption,
+						credit: image.credit,
+					}),
+			),
+			currentIndex,
+			document.title,
+		)
+		// we don't need to handle this error
+		.catch(() => undefined);
 };
 
 export const AppsLightboxImageStore = ({

--- a/dotcom-rendering/src/components/AppsLightboxImageStore.importable.tsx
+++ b/dotcom-rendering/src/components/AppsLightboxImageStore.importable.tsx
@@ -6,7 +6,11 @@ import type { ImageForAppsLightbox } from '../model/appsLightboxImages';
 // Gets assigned a value when the component is rendered
 let imageStore: ImageForAppsLightbox[];
 
-export const onImageClick = (elementId: string): void => {
+/**
+ * Uses Bridget's Gallery service to open the native lightbox at the provided image element ID.
+ * This function should never be called server-side.
+ */
+export const openLightboxForImageId = (elementId: string): void => {
 	const currentIndex = imageStore.findIndex(
 		(img) => img.elementId === elementId,
 	);

--- a/dotcom-rendering/src/components/ImageComponent.tsx
+++ b/dotcom-rendering/src/components/ImageComponent.tsx
@@ -10,7 +10,6 @@ import {
 import { decidePalette } from '../lib/decidePalette';
 import { getLargest, getMaster } from '../lib/image';
 import { isWideEnough } from '../lib/lightbox';
-import type { ImageForAppsLightbox } from '../model/appsLightboxImages';
 import { palette as themePalette } from '../palette';
 import type { Switches } from '../types/config';
 import type { ImageBlockElement, RoleType } from '../types/content';
@@ -34,7 +33,6 @@ type Props = {
 	title?: string;
 	isAvatar?: boolean;
 	switches?: Switches;
-	imagesForAppsLightbox: ImageForAppsLightbox[];
 };
 
 const starsWrapper = css`
@@ -241,7 +239,6 @@ export const ImageComponent = ({
 	title,
 	isAvatar,
 	switches,
-	imagesForAppsLightbox,
 }: Props) => {
 	const { renderingTarget } = useConfig();
 	// Its possible the tools wont send us any images urls
@@ -321,10 +318,7 @@ export const ImageComponent = ({
 				{renderingTarget === 'Apps' ? (
 					<Island priority="critical">
 						<AppsLightboxImage
-							images={imagesForAppsLightbox}
-							currentIndex={imagesForAppsLightbox.findIndex(
-								(img) => img.elementId === element.elementId,
-							)}
+							elementId={element.elementId}
 							role={role}
 							format={format}
 							master={image.url}
@@ -388,10 +382,7 @@ export const ImageComponent = ({
 				{renderingTarget === 'Apps' ? (
 					<Island priority="critical">
 						<AppsLightboxImage
-							images={imagesForAppsLightbox}
-							currentIndex={imagesForAppsLightbox.findIndex(
-								(img) => img.elementId === element.elementId,
-							)}
+							elementId={element.elementId}
 							role={role}
 							format={format}
 							master={image.url}
@@ -458,10 +449,7 @@ export const ImageComponent = ({
 				{renderingTarget === 'Apps' ? (
 					<Island priority="critical">
 						<AppsLightboxImage
-							images={imagesForAppsLightbox}
-							currentIndex={imagesForAppsLightbox.findIndex(
-								(img) => img.elementId === element.elementId,
-							)}
+							elementId={element.elementId}
 							role={role}
 							format={format}
 							master={image.url}

--- a/dotcom-rendering/src/components/ImageComponent.tsx
+++ b/dotcom-rendering/src/components/ImageComponent.tsx
@@ -10,6 +10,7 @@ import {
 import { decidePalette } from '../lib/decidePalette';
 import { getLargest, getMaster } from '../lib/image';
 import { isWideEnough } from '../lib/lightbox';
+import type { ImageForAppsLightbox } from '../model/appsLightboxImages';
 import { palette as themePalette } from '../palette';
 import type { Switches } from '../types/config';
 import type { ImageBlockElement, RoleType } from '../types/content';
@@ -33,6 +34,8 @@ type Props = {
 	title?: string;
 	isAvatar?: boolean;
 	switches?: Switches;
+	// eslint-disable-next-line react/no-unused-prop-types -- keep this so the diff isn't too big
+	imagesForAppsLightbox: ImageForAppsLightbox[];
 };
 
 const starsWrapper = css`

--- a/dotcom-rendering/src/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/layouts/CommentLayout.tsx
@@ -10,6 +10,7 @@ import { StraightLines } from '@guardian/source-react-components-development-kit
 import { AdPortals } from '../components/AdPortals.importable';
 import { AdSlot, MobileStickyContainer } from '../components/AdSlot.web';
 import { AppsFooter } from '../components/AppsFooter.importable';
+import { AppsLightboxImageStore } from '../components/AppsLightboxImageStore.importable';
 import { ArticleBody } from '../components/ArticleBody';
 import { ArticleContainer } from '../components/ArticleContainer';
 import { ArticleHeadline } from '../components/ArticleHeadline';
@@ -438,9 +439,16 @@ export const CommentLayout = (props: WebProps | AppsProps) => {
 
 			<main data-layout="CommentLayout">
 				{isApps && (
-					<Island priority="critical">
-						<AdPortals />
-					</Island>
+					<>
+						<Island priority="critical">
+							<AdPortals />
+						</Island>
+						<Island priority="critical">
+							<AppsLightboxImageStore
+								images={article.imagesForAppsLightbox}
+							/>
+						</Island>
+					</>
 				)}
 				<Section
 					fullWidth={true}
@@ -474,9 +482,6 @@ export const CommentLayout = (props: WebProps | AppsProps) => {
 									switches={article.config.switches}
 									isAdFreeUser={article.isAdFreeUser}
 									isSensitive={article.config.isSensitive}
-									imagesForAppsLightbox={
-										article.imagesForAppsLightbox
-									}
 								/>
 							</div>
 						</GridItem>
@@ -622,9 +627,6 @@ export const CommentLayout = (props: WebProps | AppsProps) => {
 										lang={article.lang}
 										isRightToLeftLang={
 											article.isRightToLeftLang
-										}
-										imagesForAppsLightbox={
-											article.imagesForAppsLightbox
 										}
 									/>
 									{showBodyEndSlot && (

--- a/dotcom-rendering/src/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/layouts/CommentLayout.tsx
@@ -443,7 +443,7 @@ export const CommentLayout = (props: WebProps | AppsProps) => {
 						<Island priority="critical">
 							<AdPortals />
 						</Island>
-						<Island priority="critical">
+						<Island priority="feature" defer={{ until: 'idle' }}>
 							<AppsLightboxImageStore
 								images={article.imagesForAppsLightbox}
 							/>

--- a/dotcom-rendering/src/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/layouts/CommentLayout.tsx
@@ -482,6 +482,9 @@ export const CommentLayout = (props: WebProps | AppsProps) => {
 									switches={article.config.switches}
 									isAdFreeUser={article.isAdFreeUser}
 									isSensitive={article.config.isSensitive}
+									imagesForAppsLightbox={
+										article.imagesForAppsLightbox
+									}
 								/>
 							</div>
 						</GridItem>
@@ -627,6 +630,9 @@ export const CommentLayout = (props: WebProps | AppsProps) => {
 										lang={article.lang}
 										isRightToLeftLang={
 											article.isRightToLeftLang
+										}
+										imagesForAppsLightbox={
+											article.imagesForAppsLightbox
 										}
 									/>
 									{showBodyEndSlot && (

--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -15,6 +15,7 @@ import { StraightLines } from '@guardian/source-react-components-development-kit
 import { AdPortals } from '../components/AdPortals.importable';
 import { AdSlot, MobileStickyContainer } from '../components/AdSlot.web';
 import { AppsFooter } from '../components/AppsFooter.importable';
+import { AppsLightboxImageStore } from '../components/AppsLightboxImageStore.importable';
 import { ArticleBody } from '../components/ArticleBody';
 import { ArticleContainer } from '../components/ArticleContainer';
 import { ArticleHeadline } from '../components/ArticleHeadline';
@@ -457,9 +458,16 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 
 			<main data-layout="ImmersiveLayout">
 				{isApps && (
-					<Island priority="critical">
-						<AdPortals />
-					</Island>
+					<>
+						<Island priority="critical">
+							<AdPortals />
+						</Island>
+						<Island priority="critical">
+							<AppsLightboxImageStore
+								images={article.imagesForAppsLightbox}
+							/>
+						</Island>
+					</>
 				)}
 				<Section
 					fullWidth={true}

--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -462,7 +462,7 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 						<Island priority="critical">
 							<AdPortals />
 						</Island>
-						<Island priority="critical">
+						<Island priority="feature" defer={{ until: 'idle' }}>
 							<AppsLightboxImageStore
 								images={article.imagesForAppsLightbox}
 							/>

--- a/dotcom-rendering/src/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/InteractiveLayout.tsx
@@ -403,7 +403,7 @@ export const InteractiveLayout = (props: WebProps | AppsProps) => {
 						<Island priority="critical">
 							<AdPortals />
 						</Island>
-						<Island priority="critical">
+						<Island priority="feature" defer={{ until: 'idle' }}>
 							<AppsLightboxImageStore
 								images={article.imagesForAppsLightbox}
 							/>

--- a/dotcom-rendering/src/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/InteractiveLayout.tsx
@@ -11,6 +11,7 @@ import React from 'react';
 import { AdPortals } from '../components/AdPortals.importable';
 import { AdSlot, MobileStickyContainer } from '../components/AdSlot.web';
 import { AppsFooter } from '../components/AppsFooter.importable';
+import { AppsLightboxImageStore } from '../components/AppsLightboxImageStore.importable';
 import { ArticleBody } from '../components/ArticleBody';
 import { ArticleContainer } from '../components/ArticleContainer';
 import { ArticleHeadline } from '../components/ArticleHeadline';
@@ -398,9 +399,16 @@ export const InteractiveLayout = (props: WebProps | AppsProps) => {
 			)}
 			<main data-layout="InteractiveLayout">
 				{isApps && (
-					<Island priority="critical">
-						<AdPortals />
-					</Island>
+					<>
+						<Island priority="critical">
+							<AdPortals />
+						</Island>
+						<Island priority="critical">
+							<AppsLightboxImageStore
+								images={article.imagesForAppsLightbox}
+							/>
+						</Island>
+					</>
 				)}
 				<Section
 					fullWidth={true}

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -432,7 +432,7 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 						<Island priority="critical">
 							<AdPortals rightAlignFrom="wide" />
 						</Island>
-						<Island priority="critical">
+						<Island priority="feature" defer={{ until: 'idle' }}>
 							<AppsLightboxImageStore
 								images={article.imagesForAppsLightbox}
 							/>

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -14,6 +14,7 @@ import { RightAdsPlaceholder } from '../components/AdPlaceholder.apps';
 import { AdPortals } from '../components/AdPortals.importable';
 import { AdSlot, MobileStickyContainer } from '../components/AdSlot.web';
 import { AppsFooter } from '../components/AppsFooter.importable';
+import { AppsLightboxImageStore } from '../components/AppsLightboxImageStore.importable';
 import { ArticleBody } from '../components/ArticleBody';
 import { ArticleContainer } from '../components/ArticleContainer';
 import { ArticleHeadline } from '../components/ArticleHeadline';
@@ -427,9 +428,16 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 			)}
 			<main data-layout="LiveLayout">
 				{isApps && (
-					<Island priority="critical">
-						<AdPortals rightAlignFrom="wide" />
-					</Island>
+					<>
+						<Island priority="critical">
+							<AdPortals rightAlignFrom="wide" />
+						</Island>
+						<Island priority="critical">
+							<AppsLightboxImageStore
+								images={article.imagesForAppsLightbox}
+							/>
+						</Island>
+					</>
 				)}
 				{footballMatchUrl ? (
 					<Section

--- a/dotcom-rendering/src/layouts/PictureLayout.tsx
+++ b/dotcom-rendering/src/layouts/PictureLayout.tsx
@@ -13,6 +13,7 @@ import { StraightLines } from '@guardian/source-react-components-development-kit
 import { AdPortals } from '../components/AdPortals.importable';
 import { AdSlot, MobileStickyContainer } from '../components/AdSlot.web';
 import { AppsFooter } from '../components/AppsFooter.importable';
+import { AppsLightboxImageStore } from '../components/AppsLightboxImageStore.importable';
 import { ArticleContainer } from '../components/ArticleContainer';
 import { ArticleHeadline } from '../components/ArticleHeadline';
 import { ArticleMeta } from '../components/ArticleMeta';
@@ -414,9 +415,16 @@ export const PictureLayout = (props: WebProps | AppsProps) => {
 				dir={decideLanguageDirection(article.isRightToLeftLang)}
 			>
 				{isApps && (
-					<Island priority="critical">
-						<AdPortals />
-					</Island>
+					<>
+						<Island priority="critical">
+							<AdPortals />
+						</Island>
+						<Island priority="critical">
+							<AppsLightboxImageStore
+								images={article.imagesForAppsLightbox}
+							/>
+						</Island>
+					</>
 				)}
 				<Section
 					fullWidth={true}

--- a/dotcom-rendering/src/layouts/PictureLayout.tsx
+++ b/dotcom-rendering/src/layouts/PictureLayout.tsx
@@ -419,7 +419,7 @@ export const PictureLayout = (props: WebProps | AppsProps) => {
 						<Island priority="critical">
 							<AdPortals />
 						</Island>
-						<Island priority="critical">
+						<Island priority="feature" defer={{ until: 'idle' }}>
 							<AppsLightboxImageStore
 								images={article.imagesForAppsLightbox}
 							/>

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -10,6 +10,7 @@ import { StraightLines } from '@guardian/source-react-components-development-kit
 import { AdPortals } from '../components/AdPortals.importable';
 import { AdSlot, MobileStickyContainer } from '../components/AdSlot.web';
 import { AppsFooter } from '../components/AppsFooter.importable';
+import { AppsLightboxImageStore } from '../components/AppsLightboxImageStore.importable';
 import { ArticleBody } from '../components/ArticleBody';
 import { ArticleContainer } from '../components/ArticleContainer';
 import { ArticleHeadline } from '../components/ArticleHeadline';
@@ -48,7 +49,6 @@ import { palette as themePalette } from '../palette';
 import type { DCRArticle } from '../types/frontend';
 import type { RenderingTarget } from '../types/renderingTarget';
 import { BannerWrapper, SendToBack, Stuck } from './lib/stickiness';
-import { Foo } from '../components/Foo.importable';
 
 const ShowcaseGrid = ({ children }: { children: React.ReactNode }) => (
 	<div
@@ -480,7 +480,9 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 							<AdPortals />
 						</Island>
 						<Island priority="critical">
-							<Foo images={article.imagesForAppsLightbox} />
+							<AppsLightboxImageStore
+								images={article.imagesForAppsLightbox}
+							/>
 						</Island>
 					</>
 				)}

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -48,6 +48,7 @@ import { palette as themePalette } from '../palette';
 import type { DCRArticle } from '../types/frontend';
 import type { RenderingTarget } from '../types/renderingTarget';
 import { BannerWrapper, SendToBack, Stuck } from './lib/stickiness';
+import { Foo } from '../components/Foo.importable';
 
 const ShowcaseGrid = ({ children }: { children: React.ReactNode }) => (
 	<div
@@ -474,9 +475,14 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 				dir={decideLanguageDirection(article.isRightToLeftLang)}
 			>
 				{isApps && (
-					<Island priority="critical">
-						<AdPortals />
-					</Island>
+					<>
+						<Island priority="critical">
+							<AdPortals />
+						</Island>
+						<Island priority="critical">
+							<Foo images={article.imagesForAppsLightbox} />
+						</Island>
+					</>
 				)}
 				<Section
 					fullWidth={true}

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -479,7 +479,7 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 						<Island priority="critical">
 							<AdPortals />
 						</Island>
-						<Island priority="critical">
+						<Island priority="feature" defer={{ until: 'idle' }}>
 							<AppsLightboxImageStore
 								images={article.imagesForAppsLightbox}
 							/>

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -59,7 +59,6 @@ import { palette as themePalette } from '../palette';
 import type { DCRArticle } from '../types/frontend';
 import type { RenderingTarget } from '../types/renderingTarget';
 import { BannerWrapper, Stuck } from './lib/stickiness';
-import { Foo } from '../components/Foo.importable';
 
 const StandardGrid = ({
 	children,

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -16,6 +16,7 @@ import { AdPortals } from '../components/AdPortals.importable';
 import { AdSlot, MobileStickyContainer } from '../components/AdSlot.web';
 import { AppsEpic } from '../components/AppsEpic.importable';
 import { AppsFooter } from '../components/AppsFooter.importable';
+import { AppsLightboxImageStore } from '../components/AppsLightboxImageStore.importable';
 import { ArticleBody } from '../components/ArticleBody';
 import { ArticleContainer } from '../components/ArticleContainer';
 import { ArticleHeadline } from '../components/ArticleHeadline';
@@ -496,7 +497,9 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 				)}
 				{isApps && (
 					<Island priority="critical">
-						<Foo images={article.imagesForAppsLightbox} />
+						<AppsLightboxImageStore
+							images={article.imagesForAppsLightbox}
+						/>
 					</Island>
 				)}
 				<Section

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -58,6 +58,7 @@ import { palette as themePalette } from '../palette';
 import type { DCRArticle } from '../types/frontend';
 import type { RenderingTarget } from '../types/renderingTarget';
 import { BannerWrapper, Stuck } from './lib/stickiness';
+import { Foo } from '../components/Foo.importable';
 
 const StandardGrid = ({
 	children,
@@ -491,6 +492,11 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 				{isApps && (
 					<Island priority="critical">
 						<AdPortals />
+					</Island>
+				)}
+				{isApps && (
+					<Island priority="critical">
+						<Foo images={article.imagesForAppsLightbox} />
 					</Island>
 				)}
 				<Section

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -490,16 +490,16 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 
 			<main data-layout="StandardLayout">
 				{isApps && (
-					<Island priority="critical">
-						<AdPortals />
-					</Island>
-				)}
-				{isApps && (
-					<Island priority="critical">
-						<AppsLightboxImageStore
-							images={article.imagesForAppsLightbox}
-						/>
-					</Island>
+					<>
+						<Island priority="critical">
+							<AdPortals />
+						</Island>
+						<Island priority="feature" defer={{ until: 'idle' }}>
+							<AppsLightboxImageStore
+								images={article.imagesForAppsLightbox}
+							/>
+						</Island>
+					</>
 				)}
 				<Section
 					fullWidth={true}


### PR DESCRIPTION
## Why?

Articles with lots of images cause a few problems in DCAR:

- they take a long time to render (possibly timing out)
- can result in an unacceptably large HTML file size

as captured in https://github.com/guardian/dotcom-rendering/issues/9685.

This is caused by the current lightbox implementation. For each image, we pass an array of _all_ images in the article as a prop to `ImageComponent` wrapped in an `Island`. This results in bloated, repetative markup. The article in #9685 contains 205 images. Each time we render an image, we include information about all 205 images to the image island's props in the rendered markup - 42,205 times in total. This is 42,204 times too many - the page should include the list of images just once.

closes https://github.com/guardian/dotcom-rendering/issues/9685

## What does this change?

Introduces an `AppsLightboxImageStore` component which takes the lightbox image array as a prop. This component is rendered in an `Island` on each layout that supports apps lightbox images

- Takes an array of lightbox images, storing it as local data

https://github.com/guardian/dotcom-rendering/blob/a24934e4758ea1414dc64fd05f78e0714a39ede6/dotcom-rendering/src/layouts/StandardLayout.tsx#L498-L502

- Exports an `openLightboxForImageId` function. This function is used as the value for the `onclick` prop on apps images. It communicates with Bridget to open the lightbox at the correct place, using the component's local list of images.

https://github.com/guardian/dotcom-rendering/blob/a24934e4758ea1414dc64fd05f78e0714a39ede6/dotcom-rendering/src/components/AppsLightboxImage.importable.tsx#L42-L52

## Performance Improvements

Using the article mentioned in the original issue we see

- a 90% reduction in page weight (13.4MB down to 1.4MB)
- the article successfully rendering. It was timing out previously.

## Screenshots/Video

https://github.com/guardian/dotcom-rendering/assets/705427/bca712d1-3681-4d3d-a593-2fbb636f3bff

## Not included in this PR

- A full refactor to remove the prop drilling of `imagesForAppsLightbox`. It created too many diffs, making this PR hard to review.
