### PR TITLE
Add follow robert reich newsletter to AU, UK and US

### DIFF
--- a/dotcom-rendering/src/model/newsletter-grouping.ts
+++ b/dotcom-rendering/src/model/newsletter-grouping.ts
@@ -57,6 +57,7 @@ export const groups: Partial<Record<EditionId, StaticGroups>> = {
 			newsletters: [
 				'trump-on-trial',
 				'follow-margaret-sullivan',
+				'follow-robert-reich',
 				'global-dispatch',
 				'documentaries',
 				'her-stage',
@@ -110,6 +111,7 @@ export const groups: Partial<Record<EditionId, StaticGroups>> = {
 				'green-light', // Down to Earth
 				'trump-on-trial',
 				'follow-margaret-sullivan',
+				'follow-robert-reich',
 				'best-of-opinion-us',
 				'patriarchy',
 				'bookmarks',
@@ -245,6 +247,7 @@ export const groups: Partial<Record<EditionId, StaticGroups>> = {
 			newsletters: [
 				'trump-on-trial',
 				'follow-margaret-sullivan',
+				'follow-robert-reich',
 				'global-dispatch',
 				'cotton-capital',
 				'documentaries',


### PR DESCRIPTION
## What does this change?
Also adds the `follow-robert-reich` newsletter to the US, UK and AUS editions.

> [!IMPORTANT]  
We are holding off merging until we have a date for release from the email team.

## Why?

Resolves #9702 

## Screenshots

### AUS edition

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

### US edition

| Before      | After      |
| ----------- | ---------- |
| ![before2][] | ![after2][] |

### UK edition

| Before      | After      |
| ----------- | ---------- |
| ![before3][] | ![after3][] |


[before]: https://github.com/guardian/dotcom-rendering/assets/20416599/5a1479ae-9464-49aa-991d-37cc06d59bb0
[before2]: https://github.com/guardian/dotcom-rendering/assets/20416599/aac0bffa-ba6a-41d2-9be2-f761079e3939
[before3]: https://github.com/guardian/dotcom-rendering/assets/20416599/ca84198b-d50b-4722-9e8e-dda14a83950a
[after]: https://github.com/guardian/dotcom-rendering/assets/20416599/fef3a612-a32f-497a-b86d-76aa52f15828
[after2]: https://github.com/guardian/dotcom-rendering/assets/20416599/90cd8eac-fc3c-4d61-9123-25a1f7209809
[after3]: https://github.com/guardian/dotcom-rendering/assets/20416599/9d26cf65-1be8-4a98-99d6-7e45106868b2

