### PR TITLE
Respect branding tag for sponsored and paid-content

### DIFF
--- a/dotcom-rendering/src/components/FrontSectionTitle.tsx
+++ b/dotcom-rendering/src/components/FrontSectionTitle.tsx
@@ -58,20 +58,25 @@ export const FrontSectionTitle = ({ title, collectionBranding }: Props) => {
 		case 'foundation': {
 			const {
 				branding: { logo },
+				isFrontBranding,
 			} = collectionBranding;
-			return (
-				<>
-					<Hide until="leftCol">
-						<Badge imageSrc={logo.src} href={logo.link} />
-					</Hide>
-					<div css={titleStyle}>
-						<Hide from="leftCol">
+			if (isFrontBranding) {
+				return (
+					<>
+						<Hide until="leftCol">
 							<Badge imageSrc={logo.src} href={logo.link} />
 						</Hide>
-						{title}
-					</div>
-				</>
-			);
+						<div css={titleStyle}>
+							<Hide from="leftCol">
+								<Badge imageSrc={logo.src} href={logo.link} />
+							</Hide>
+							{title}
+						</div>
+					</>
+				);
+			}
+
+			return <div css={titleStyle}>{title}</div>;
 		}
 		case 'paid-content': {
 			const {
@@ -120,19 +125,23 @@ export const FrontSectionTitle = ({ title, collectionBranding }: Props) => {
 		case 'sponsored': {
 			const {
 				branding: { logo, aboutThisLink },
+				isFrontBranding,
 			} = collectionBranding;
-			return (
-				<div css={titleStyle}>
-					{title}
-					<>
-						<p css={labelStyles}>{logo.label}</p>
-						<Badge imageSrc={logo.src} href={logo.link} />
-						<a href={aboutThisLink} css={aboutThisLinkStyles}>
-							About this content
-						</a>
-					</>
-				</div>
-			);
+			if (isFrontBranding) {
+				return (
+					<div css={titleStyle}>
+						{title}
+						<>
+							<p css={labelStyles}>{logo.label}</p>
+							<Badge imageSrc={logo.src} href={logo.link} />
+							<a href={aboutThisLink} css={aboutThisLinkStyles}>
+								About this content
+							</a>
+						</>
+					</div>
+				);
+			}
+			return <div css={titleStyle}>{title}</div>;
 		}
 		case undefined: {
 			return <div css={titleStyle}>{title}</div>;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Adds a check to paid-for and sponsored containers to make sure the isFrontBranded flag is true before rendering a branded logo.
 
## Why?
The isFrontBranded flag correlates to the branded tag which is set in the fronts tool in the container config. We should only show a branded logo is this tag has been added, otherwise we just show the container title. 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/20416599/c6d55ab7-71f1-41ce-b23c-d69b868b9eb6
[after]: https://github.com/guardian/dotcom-rendering/assets/20416599/d757113f-5c6f-48ff-b639-df4e5cf91b92


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
