### PR TITLE
DCAR: Fix Bridget TagClient follow/unfollow to respect native success…

### DIFF
--- a/dotcom-rendering/src/components/FollowWrapper.importable.tsx
+++ b/dotcom-rendering/src/components/FollowWrapper.importable.tsx
@@ -62,7 +62,9 @@ export const FollowWrapper = ({ id, displayName }: Props) => {
 		isFollowingTag
 			? void getTagClient()
 					.unfollow(topic)
-					.then(() => setIsFollowingTag(false))
+					.then((success) => {
+						success && setIsFollowingTag(false);
+					})
 					.catch((e) =>
 						log(
 							'dotcom',
@@ -72,7 +74,9 @@ export const FollowWrapper = ({ id, displayName }: Props) => {
 					)
 			: void getTagClient()
 					.follow(topic)
-					.then(() => setIsFollowingTag(true))
+					.then((success) => {
+						success && setIsFollowingTag(true);
+					})
 					.catch((e) =>
 						log('dotcom', 'Bridget getTagClient.follow Error:', e),
 					);
@@ -88,7 +92,9 @@ export const FollowWrapper = ({ id, displayName }: Props) => {
 		isFollowingNotifications
 			? void getNotificationsClient()
 					.unfollow(topic)
-					.then(() => setIsFollowingNotifications(false))
+					.then((success) => {
+						success && setIsFollowingNotifications(false);
+					})
 					.catch((e) =>
 						log(
 							'dotcom',
@@ -98,7 +104,9 @@ export const FollowWrapper = ({ id, displayName }: Props) => {
 					)
 			: void getNotificationsClient()
 					.follow(topic)
-					.then(() => setIsFollowingNotifications(true))
+					.then((success) => {
+						success && setIsFollowingNotifications(true);
+					})
 					.catch((e) =>
 						log(
 							'dotcom',


### PR DESCRIPTION
… result

<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Ensures that the Follow Tag and Follow Notification buttons only update UI if bridget returns a success=true.

This means that in iOS, if a non-signed in user tries to follow a tag, but cancel the sign in flow, then the UI button is not incorrectly updated.

In Android, Bridget is implemented syncronously so so tagClient.follow will always return true regardless of sign in success. This was discussed by the team and accepted as the other option of returning false would negatively impact more users. 


This changes was already rolled out in AR here: https://github.com/guardian/dotcom-rendering/blob/5aae1b63f47ede3333d12dc0cfcba29616c8f4c6/apps-rendering/src/client/article.ts#L85-L97

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
