### PR TITLE
Un-drill `imagesForAppsLightbox` prop

### DIFF
--- a/dotcom-rendering/src/components/ArticleBody.tsx
+++ b/dotcom-rendering/src/components/ArticleBody.tsx
@@ -5,7 +5,6 @@ import { between, body, headline, space } from '@guardian/source-foundations';
 import { ArticleRenderer } from '../lib/ArticleRenderer';
 import { decideLanguage, decideLanguageDirection } from '../lib/lang';
 import { revealStyles } from '../lib/revealStyles';
-import type { ImageForAppsLightbox } from '../model/appsLightboxImages';
 import { palette as themePalette } from '../palette';
 import type { ServerSideTests, Switches } from '../types/config';
 import type { TableOfContentsItem } from '../types/frontend';
@@ -44,7 +43,6 @@ type Props = {
 	tableOfContents?: TableOfContentsItem[];
 	lang?: string;
 	isRightToLeftLang?: boolean;
-	imagesForAppsLightbox: ImageForAppsLightbox[];
 };
 
 const globalH2Styles = (display: ArticleDisplay) => css`
@@ -133,7 +131,6 @@ export const ArticleBody = ({
 	tableOfContents,
 	lang,
 	isRightToLeftLang = false,
-	imagesForAppsLightbox,
 }: Props) => {
 	const isInteractive = format.design === ArticleDesign.Interactive;
 	const language = decideLanguage(lang);
@@ -227,7 +224,6 @@ export const ArticleBody = ({
 					isAdFreeUser={isAdFreeUser}
 					isSensitive={isSensitive}
 					abTests={abTests}
-					imagesForAppsLightbox={imagesForAppsLightbox}
 				/>
 			</div>
 		</>

--- a/dotcom-rendering/src/components/ArticleHeadline.stories.tsx
+++ b/dotcom-rendering/src/components/ArticleHeadline.stories.tsx
@@ -108,7 +108,6 @@ export const ShowcaseInterview = () => {
 						isAdFreeUser={false}
 						isSensitive={false}
 						switches={{}}
-						imagesForAppsLightbox={[]}
 					/>
 				</ArticleContainer>
 			</Flex>
@@ -153,7 +152,6 @@ export const ShowcaseInterviewNobyline = () => {
 						isAdFreeUser={false}
 						isSensitive={false}
 						switches={{}}
-						imagesForAppsLightbox={[]}
 					/>
 				</ArticleContainer>
 			</Flex>
@@ -196,7 +194,6 @@ export const Interview = () => {
 						isAdFreeUser={false}
 						isSensitive={false}
 						switches={{}}
-						imagesForAppsLightbox={[]}
 					/>
 				</ArticleContainer>
 			</Flex>
@@ -239,7 +236,6 @@ export const InterviewSpecialReport = () => {
 						isAdFreeUser={false}
 						isSensitive={false}
 						switches={{}}
-						imagesForAppsLightbox={[]}
 					/>
 				</ArticleContainer>
 			</Flex>
@@ -283,7 +279,6 @@ export const InterviewNoByline = () => {
 						isAdFreeUser={false}
 						isSensitive={false}
 						switches={{}}
-						imagesForAppsLightbox={[]}
 					/>
 				</ArticleContainer>
 			</Flex>

--- a/dotcom-rendering/src/components/ImageBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/components/ImageBlockComponent.stories.tsx
@@ -67,7 +67,6 @@ export const StandardArticle = () => {
 						design: ArticleDesign.Standard,
 						theme: Pillar.News,
 					}}
-					imagesForAppsLightbox={[]}
 				/>
 			</Figure>
 		</Wrapper>
@@ -94,7 +93,6 @@ export const Immersive = () => {
 						design: ArticleDesign.Standard,
 						theme: Pillar.News,
 					}}
-					imagesForAppsLightbox={[]}
 				/>
 			</Figure>
 		</Wrapper>
@@ -121,7 +119,6 @@ export const Showcase = () => {
 						design: ArticleDesign.Standard,
 						theme: Pillar.News,
 					}}
-					imagesForAppsLightbox={[]}
 				/>
 			</Figure>
 		</Wrapper>
@@ -148,7 +145,6 @@ export const Thumbnail = () => {
 						design: ArticleDesign.Standard,
 						theme: Pillar.News,
 					}}
-					imagesForAppsLightbox={[]}
 				/>
 			</Figure>
 		</Wrapper>
@@ -175,7 +171,6 @@ export const Supporting = () => {
 						design: ArticleDesign.Standard,
 						theme: Pillar.News,
 					}}
-					imagesForAppsLightbox={[]}
 				/>
 			</Figure>
 		</Wrapper>
@@ -203,7 +198,6 @@ export const HideCaption = () => {
 						theme: Pillar.News,
 					}}
 					hideCaption={true}
-					imagesForAppsLightbox={[]}
 				/>
 			</Figure>
 		</Wrapper>
@@ -232,7 +226,6 @@ export const InlineTitle = () => {
 					}}
 					title="This is the title text"
 					hideCaption={true}
-					imagesForAppsLightbox={[]}
 				/>
 			</Figure>
 		</Wrapper>
@@ -267,7 +260,6 @@ export const InlineTitleMobile = () => {
 					}}
 					title="This is the title text"
 					hideCaption={true}
-					imagesForAppsLightbox={[]}
 				/>
 			</Figure>
 		</Wrapper>
@@ -302,7 +294,6 @@ export const ImmersiveTitle = () => {
 					}}
 					title="This is the title text"
 					hideCaption={true}
-					imagesForAppsLightbox={[]}
 				/>
 			</Figure>
 		</Wrapper>
@@ -331,7 +322,6 @@ export const ShowcaseTitle = () => {
 					}}
 					title="This is the title text"
 					hideCaption={true}
-					imagesForAppsLightbox={[]}
 				/>
 			</Figure>
 		</Wrapper>
@@ -384,7 +374,6 @@ export const HalfWidth = () => {
 						design: ArticleDesign.Standard,
 						theme: Pillar.News,
 					}}
-					imagesForAppsLightbox={[]}
 				/>
 			</Figure>
 			<p>
@@ -453,7 +442,6 @@ export const HalfWidthMobile = () => {
 						design: ArticleDesign.Standard,
 						theme: Pillar.News,
 					}}
-					imagesForAppsLightbox={[]}
 				/>
 			</Figure>
 			<p>
@@ -522,7 +510,6 @@ export const HalfWidthWide = () => {
 						design: ArticleDesign.Standard,
 						theme: Pillar.News,
 					}}
-					imagesForAppsLightbox={[]}
 				/>
 			</Figure>
 			<p>

--- a/dotcom-rendering/src/components/ImageBlockComponent.tsx
+++ b/dotcom-rendering/src/components/ImageBlockComponent.tsx
@@ -1,4 +1,3 @@
-import type { ImageForAppsLightbox } from '../model/appsLightboxImages';
 import type { Switches } from '../types/config';
 import type { ImageBlockElement } from '../types/content';
 import { ImageComponent } from './ImageComponent';
@@ -12,7 +11,6 @@ type Props = {
 	starRating?: number;
 	isAvatar?: boolean;
 	switches?: Switches;
-	imagesForAppsLightbox: ImageForAppsLightbox[];
 };
 
 export const ImageBlockComponent = ({
@@ -24,7 +22,6 @@ export const ImageBlockComponent = ({
 	starRating,
 	isAvatar,
 	switches,
-	imagesForAppsLightbox,
 }: Props) => {
 	const { role } = element;
 	return (
@@ -38,7 +35,6 @@ export const ImageBlockComponent = ({
 			title={title}
 			isAvatar={isAvatar}
 			switches={switches}
-			imagesForAppsLightbox={imagesForAppsLightbox}
 		/>
 	);
 };

--- a/dotcom-rendering/src/components/ImageComponent.tsx
+++ b/dotcom-rendering/src/components/ImageComponent.tsx
@@ -10,7 +10,6 @@ import {
 import { decidePalette } from '../lib/decidePalette';
 import { getLargest, getMaster } from '../lib/image';
 import { isWideEnough } from '../lib/lightbox';
-import type { ImageForAppsLightbox } from '../model/appsLightboxImages';
 import { palette as themePalette } from '../palette';
 import type { Switches } from '../types/config';
 import type { ImageBlockElement, RoleType } from '../types/content';
@@ -34,8 +33,6 @@ type Props = {
 	title?: string;
 	isAvatar?: boolean;
 	switches?: Switches;
-	// eslint-disable-next-line react/no-unused-prop-types -- keep this so the diff isn't too big
-	imagesForAppsLightbox: ImageForAppsLightbox[];
 };
 
 const starsWrapper = css`

--- a/dotcom-rendering/src/components/LiveBlock.tsx
+++ b/dotcom-rendering/src/components/LiveBlock.tsx
@@ -76,7 +76,6 @@ export const LiveBlock = ({
 					isSensitive={isSensitive}
 					switches={switches}
 					isPinnedPost={isPinnedPost}
-					imagesForAppsLightbox={[]}
 				/>
 			))}
 			<footer

--- a/dotcom-rendering/src/components/MainMedia.tsx
+++ b/dotcom-rendering/src/components/MainMedia.tsx
@@ -3,7 +3,6 @@ import { ArticleDesign, ArticleDisplay } from '@guardian/libs';
 import { until } from '@guardian/source-foundations';
 import { getZIndex } from '../lib/getZIndex';
 import { RenderArticleElement } from '../lib/renderElement';
-import type { ImageForAppsLightbox } from '../model/appsLightboxImages';
 import type { Switches } from '../types/config';
 import type { FEElement } from '../types/content';
 
@@ -74,7 +73,6 @@ type Props = {
 	isAdFreeUser: boolean;
 	isSensitive: boolean;
 	switches: Switches;
-	imagesForAppsLightbox: ImageForAppsLightbox[];
 };
 
 export const MainMedia = ({
@@ -89,7 +87,6 @@ export const MainMedia = ({
 	isAdFreeUser,
 	isSensitive,
 	switches,
-	imagesForAppsLightbox,
 }: Props) => {
 	return (
 		<div css={[mainMedia, chooseWrapper(format)]}>
@@ -110,7 +107,6 @@ export const MainMedia = ({
 					switches={switches}
 					hideCaption={hideCaption}
 					starRating={starRating}
-					imagesForAppsLightbox={imagesForAppsLightbox}
 				/>
 			))}
 		</div>

--- a/dotcom-rendering/src/components/MultiImageBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/components/MultiImageBlockComponent.stories.tsx
@@ -23,7 +23,6 @@ export const SingleImage = () => {
 					theme: Pillar.News,
 				}}
 				images={oneImage}
-				imagesForAppsLightbox={[]}
 			/>
 		</Section>
 	);
@@ -41,7 +40,6 @@ export const SingleImageWithCaption = () => {
 				}}
 				images={oneImage}
 				caption="This is the caption for a single image"
-				imagesForAppsLightbox={[]}
 			/>
 		</Section>
 	);
@@ -58,7 +56,6 @@ export const SideBySide = () => {
 					theme: Pillar.News,
 				}}
 				images={twoImages}
-				imagesForAppsLightbox={[]}
 			/>
 		</Section>
 	);
@@ -76,7 +73,6 @@ export const SideBySideWithCaption = () => {
 				}}
 				images={twoImages}
 				caption="This is the caption for side by side"
-				imagesForAppsLightbox={[]}
 			/>
 		</Section>
 	);
@@ -93,7 +89,6 @@ export const OneAboveTwo = () => {
 					theme: Pillar.News,
 				}}
 				images={threeImages}
-				imagesForAppsLightbox={[]}
 			/>
 		</Section>
 	);
@@ -111,7 +106,6 @@ export const OneAboveTwoWithCaption = () => {
 				}}
 				images={threeImages}
 				caption="This is the caption for one above two"
-				imagesForAppsLightbox={[]}
 			/>
 		</Section>
 	);
@@ -128,7 +122,6 @@ export const GridOfFour = () => {
 					theme: Pillar.News,
 				}}
 				images={fourImages}
-				imagesForAppsLightbox={[]}
 			/>
 		</Section>
 	);
@@ -146,7 +139,6 @@ export const GridOfFourWithCaption = () => {
 				}}
 				images={fourImages}
 				caption="This is the caption for grid of four"
-				imagesForAppsLightbox={[]}
 			/>
 		</Section>
 	);

--- a/dotcom-rendering/src/components/MultiImageBlockComponent.tsx
+++ b/dotcom-rendering/src/components/MultiImageBlockComponent.tsx
@@ -1,6 +1,5 @@
 import { css } from '@emotion/react';
 import { from, space, until } from '@guardian/source-foundations';
-import type { ImageForAppsLightbox } from '../model/appsLightboxImages';
 import type { Switches } from '../types/config';
 import type { ImageBlockElement } from '../types/content';
 import { Caption } from './Caption';
@@ -12,7 +11,6 @@ type Props = {
 	format: ArticleFormat;
 	caption?: string;
 	switches?: Switches;
-	imagesForAppsLightbox: ImageForAppsLightbox[];
 };
 
 const ieFallback = css`
@@ -107,13 +105,11 @@ const OneImage = ({
 	format,
 	caption,
 	switches,
-	imagesForAppsLightbox,
 }: {
 	images: [ImageBlockElement];
 	format: ArticleFormat;
 	caption?: string;
 	switches?: Switches;
-	imagesForAppsLightbox: ImageForAppsLightbox[];
 }) => (
 	<div css={wrapper}>
 		<ImageComponent
@@ -122,7 +118,6 @@ const OneImage = ({
 			hideCaption={true}
 			role={images[0].role}
 			switches={switches}
-			imagesForAppsLightbox={imagesForAppsLightbox}
 		/>
 		{!!caption && (
 			<Caption
@@ -139,13 +134,11 @@ const TwoImage = ({
 	format,
 	caption,
 	switches,
-	imagesForAppsLightbox,
 }: {
 	images: [ImageBlockElement, ImageBlockElement];
 	format: ArticleFormat;
 	caption?: string;
 	switches?: Switches;
-	imagesForAppsLightbox: ImageForAppsLightbox[];
 }) => (
 	<div css={wrapper}>
 		<SideBySideGrid>
@@ -156,7 +149,6 @@ const TwoImage = ({
 					hideCaption={true}
 					role={images[0].role}
 					switches={switches}
-					imagesForAppsLightbox={imagesForAppsLightbox}
 				/>
 			</GridItem>
 			<GridItem area="second">
@@ -166,7 +158,6 @@ const TwoImage = ({
 					hideCaption={true}
 					role={images[1].role}
 					switches={switches}
-					imagesForAppsLightbox={imagesForAppsLightbox}
 				/>
 			</GridItem>
 		</SideBySideGrid>
@@ -185,13 +176,11 @@ const ThreeImage = ({
 	format,
 	caption,
 	switches,
-	imagesForAppsLightbox,
 }: {
 	images: [ImageBlockElement, ImageBlockElement, ImageBlockElement];
 	format: ArticleFormat;
 	caption?: string;
 	switches?: Switches;
-	imagesForAppsLightbox: ImageForAppsLightbox[];
 }) => (
 	<div css={wrapper}>
 		<OneAboveTwoGrid>
@@ -202,7 +191,6 @@ const ThreeImage = ({
 					hideCaption={true}
 					role={images[0].role}
 					switches={switches}
-					imagesForAppsLightbox={imagesForAppsLightbox}
 				/>
 			</GridItem>
 			<GridItem area="second">
@@ -212,7 +200,6 @@ const ThreeImage = ({
 					hideCaption={true}
 					role={images[1].role}
 					switches={switches}
-					imagesForAppsLightbox={imagesForAppsLightbox}
 				/>
 			</GridItem>
 			<GridItem area="third">
@@ -222,7 +209,6 @@ const ThreeImage = ({
 					hideCaption={true}
 					role={images[2].role}
 					switches={switches}
-					imagesForAppsLightbox={imagesForAppsLightbox}
 				/>
 			</GridItem>
 		</OneAboveTwoGrid>
@@ -241,7 +227,6 @@ const FourImage = ({
 	format,
 	caption,
 	switches,
-	imagesForAppsLightbox,
 }: {
 	images: [
 		ImageBlockElement,
@@ -252,7 +237,6 @@ const FourImage = ({
 	format: ArticleFormat;
 	caption?: string;
 	switches?: Switches;
-	imagesForAppsLightbox: ImageForAppsLightbox[];
 }) => (
 	<div css={wrapper}>
 		<GridOfFour>
@@ -263,7 +247,6 @@ const FourImage = ({
 					hideCaption={true}
 					role={images[0].role}
 					switches={switches}
-					imagesForAppsLightbox={imagesForAppsLightbox}
 				/>
 			</GridItem>
 			<GridItem area="second">
@@ -273,7 +256,6 @@ const FourImage = ({
 					hideCaption={true}
 					role={images[1].role}
 					switches={switches}
-					imagesForAppsLightbox={imagesForAppsLightbox}
 				/>
 			</GridItem>
 			<GridItem area="third">
@@ -283,7 +265,6 @@ const FourImage = ({
 					hideCaption={true}
 					role={images[2].role}
 					switches={switches}
-					imagesForAppsLightbox={imagesForAppsLightbox}
 				/>
 			</GridItem>
 			<GridItem area="forth">
@@ -293,7 +274,6 @@ const FourImage = ({
 					hideCaption={true}
 					role={images[3].role}
 					switches={switches}
-					imagesForAppsLightbox={[]}
 				/>
 			</GridItem>
 		</GridOfFour>
@@ -312,7 +292,6 @@ export const MultiImageBlockComponent = ({
 	format,
 	caption,
 	switches,
-	imagesForAppsLightbox,
 }: Props) => {
 	const [one, two, three, four] = images;
 
@@ -323,7 +302,6 @@ export const MultiImageBlockComponent = ({
 				format={format}
 				caption={caption}
 				switches={switches}
-				imagesForAppsLightbox={imagesForAppsLightbox}
 			/>
 		);
 	}
@@ -335,7 +313,6 @@ export const MultiImageBlockComponent = ({
 				format={format}
 				caption={caption}
 				switches={switches}
-				imagesForAppsLightbox={imagesForAppsLightbox}
 			/>
 		);
 	}
@@ -347,7 +324,6 @@ export const MultiImageBlockComponent = ({
 				format={format}
 				caption={caption}
 				switches={switches}
-				imagesForAppsLightbox={imagesForAppsLightbox}
 			/>
 		);
 	}
@@ -359,7 +335,6 @@ export const MultiImageBlockComponent = ({
 				format={format}
 				caption={caption}
 				switches={switches}
-				imagesForAppsLightbox={imagesForAppsLightbox}
 			/>
 		);
 	}

--- a/dotcom-rendering/src/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/layouts/CommentLayout.tsx
@@ -482,9 +482,6 @@ export const CommentLayout = (props: WebProps | AppsProps) => {
 									switches={article.config.switches}
 									isAdFreeUser={article.isAdFreeUser}
 									isSensitive={article.config.isSensitive}
-									imagesForAppsLightbox={
-										article.imagesForAppsLightbox
-									}
 								/>
 							</div>
 						</GridItem>
@@ -630,9 +627,6 @@ export const CommentLayout = (props: WebProps | AppsProps) => {
 										lang={article.lang}
 										isRightToLeftLang={
 											article.isRightToLeftLang
-										}
-										imagesForAppsLightbox={
-											article.imagesForAppsLightbox
 										}
 									/>
 									{showBodyEndSlot && (

--- a/dotcom-rendering/src/layouts/FullPageInteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/FullPageInteractiveLayout.tsx
@@ -73,7 +73,6 @@ const Renderer = ({
 	const output = elements.map((element, index) => {
 		const el = renderElement({
 			format,
-
 			element,
 			host,
 			index,
@@ -84,7 +83,6 @@ const Renderer = ({
 			isAdFreeUser,
 			isSensitive,
 			switches,
-			imagesForAppsLightbox: [],
 		});
 
 		switch (element._type) {

--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -391,7 +391,6 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 						switches={article.config.switches}
 						isAdFreeUser={article.isAdFreeUser}
 						isSensitive={article.config.isSensitive}
-						imagesForAppsLightbox={article.imagesForAppsLightbox}
 					/>
 				</div>
 				{mainMedia && (
@@ -634,9 +633,6 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 									lang={article.lang}
 									isRightToLeftLang={
 										article.isRightToLeftLang
-									}
-									imagesForAppsLightbox={
-										article.imagesForAppsLightbox
 									}
 								/>
 								{showBodyEndSlot && (

--- a/dotcom-rendering/src/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/InteractiveLayout.tsx
@@ -435,7 +435,6 @@ export const InteractiveLayout = (props: WebProps | AppsProps) => {
 										switches={article.config.switches}
 										isAdFreeUser={article.isAdFreeUser}
 										isSensitive={article.config.isSensitive}
-										imagesForAppsLightbox={[]}
 									/>
 								</div>
 							</GridItem>
@@ -562,7 +561,6 @@ export const InteractiveLayout = (props: WebProps | AppsProps) => {
 										isRightToLeftLang={
 											article.isRightToLeftLang
 										}
-										imagesForAppsLightbox={[]}
 									/>
 								</ArticleContainer>
 							</GridItem>

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -727,9 +727,6 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 										switches={article.config.switches}
 										isSensitive={article.config.isSensitive}
 										isAdFreeUser={article.isAdFreeUser}
-										imagesForAppsLightbox={
-											article.imagesForAppsLightbox
-										}
 									/>
 								</div>
 							</GridItem>
@@ -915,9 +912,6 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 														article.config
 															.keywordIds
 													}
-													imagesForAppsLightbox={
-														article.imagesForAppsLightbox
-													}
 												/>
 												{pagination.totalPages > 1 && (
 													<Pagination
@@ -1066,7 +1060,6 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 													isRightToLeftLang={
 														article.isRightToLeftLang
 													}
-													imagesForAppsLightbox={[]}
 												/>
 												{pagination.totalPages > 1 && (
 													<Pagination

--- a/dotcom-rendering/src/layouts/NewsletterSignupLayout.tsx
+++ b/dotcom-rendering/src/layouts/NewsletterSignupLayout.tsx
@@ -490,7 +490,6 @@ export const NewsletterSignupLayout = ({ article, NAV, format }: Props) => {
 									isAdFreeUser={article.isAdFreeUser}
 									isSensitive={article.config.isSensitive}
 									hideCaption={true}
-									imagesForAppsLightbox={[]}
 								/>
 							</div>
 						</Column>

--- a/dotcom-rendering/src/layouts/PictureLayout.tsx
+++ b/dotcom-rendering/src/layouts/PictureLayout.tsx
@@ -531,9 +531,6 @@ export const PictureLayout = (props: WebProps | AppsProps) => {
 									switches={article.config.switches}
 									isAdFreeUser={article.isAdFreeUser}
 									isSensitive={article.config.isSensitive}
-									imagesForAppsLightbox={
-										article.imagesForAppsLightbox
-									}
 								/>
 							</div>
 						</GridItem>

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -513,9 +513,6 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 									switches={article.config.switches}
 									isAdFreeUser={article.isAdFreeUser}
 									isSensitive={article.config.isSensitive}
-									imagesForAppsLightbox={
-										article.imagesForAppsLightbox
-									}
 								/>
 							</div>
 						</GridItem>
@@ -623,9 +620,6 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 									lang={article.lang}
 									isRightToLeftLang={
 										article.isRightToLeftLang
-									}
-									imagesForAppsLightbox={
-										article.imagesForAppsLightbox
 									}
 								/>
 								{showBodyEndSlot && (

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -552,9 +552,6 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 									switches={article.config.switches}
 									isAdFreeUser={article.isAdFreeUser}
 									isSensitive={article.config.isSensitive}
-									imagesForAppsLightbox={
-										article.imagesForAppsLightbox
-									}
 								/>
 							</div>
 						</GridItem>
@@ -682,9 +679,6 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 									lang={article.lang}
 									isRightToLeftLang={
 										article.isRightToLeftLang
-									}
-									imagesForAppsLightbox={
-										article.imagesForAppsLightbox
 									}
 								/>
 								{format.design === ArticleDesign.MatchReport &&

--- a/dotcom-rendering/src/lib/ArticleRenderer.tsx
+++ b/dotcom-rendering/src/lib/ArticleRenderer.tsx
@@ -4,7 +4,6 @@ import { ArticleDesign } from '@guardian/libs';
 import { adContainerStyles } from '../components/AdSlot.web';
 import { useConfig } from '../components/ConfigContext';
 import { interactiveLegacyClasses } from '../layouts/lib/interactiveLegacyStyling';
-import type { ImageForAppsLightbox } from '../model/appsLightboxImages';
 import type { ServerSideTests, Switches } from '../types/config';
 import type { FEElement } from '../types/content';
 import type { TagType } from '../types/tag';
@@ -43,7 +42,6 @@ type Props = {
 	isAdFreeUser: boolean;
 	isSensitive: boolean;
 	abTests?: ServerSideTests;
-	imagesForAppsLightbox: ImageForAppsLightbox[];
 };
 
 export const ArticleRenderer = ({
@@ -64,7 +62,6 @@ export const ArticleRenderer = ({
 	isSensitive,
 	isDev,
 	abTests,
-	imagesForAppsLightbox,
 }: Props) => {
 	const renderedElements = elements.map((element, index) => {
 		return (
@@ -83,7 +80,6 @@ export const ArticleRenderer = ({
 				isSensitive={isSensitive}
 				switches={switches}
 				abTests={abTests}
-				imagesForAppsLightbox={imagesForAppsLightbox}
 			/>
 		);
 	});

--- a/dotcom-rendering/src/lib/renderElement.tsx
+++ b/dotcom-rendering/src/lib/renderElement.tsx
@@ -63,7 +63,6 @@ import {
 	isInteractive,
 } from '../layouts/lib/interactiveLegacyStyling';
 import { getSharingUrls } from '../lib/sharing-urls';
-import type { ImageForAppsLightbox } from '../model/appsLightboxImages';
 import type { ServerSideTests, Switches } from '../types/config';
 import type { FEElement, RoleType } from '../types/content';
 import { decidePalette } from './decidePalette';
@@ -84,7 +83,6 @@ type Props = {
 	switches: Switches;
 	isPinnedPost?: boolean;
 	abTests?: ServerSideTests;
-	imagesForAppsLightbox: ImageForAppsLightbox[];
 };
 
 // updateRole modifies the role of an element in a way appropriate for most
@@ -139,7 +137,6 @@ export const renderElement = ({
 	isSensitive,
 	isPinnedPost,
 	abTests,
-	imagesForAppsLightbox,
 }: Props) => {
 	const palette = decidePalette(format);
 
@@ -355,7 +352,6 @@ export const renderElement = ({
 					title={element.title}
 					isAvatar={element.isAvatar}
 					switches={switches}
-					imagesForAppsLightbox={imagesForAppsLightbox}
 				/>
 			);
 		case 'model.dotcomrendering.pageElements.InstagramBlockElement':
@@ -458,7 +454,6 @@ export const renderElement = ({
 					images={element.images}
 					caption={element.caption}
 					switches={switches}
-					imagesForAppsLightbox={imagesForAppsLightbox}
 				/>
 			);
 		case 'model.dotcomrendering.pageElements.NewsletterSignupBlockElement':
@@ -807,7 +802,6 @@ export const RenderArticleElement = ({
 	switches,
 	isPinnedPost,
 	abTests,
-	imagesForAppsLightbox,
 }: Props) => {
 	const withUpdatedRole = updateRole(element, format);
 
@@ -827,7 +821,6 @@ export const RenderArticleElement = ({
 		switches,
 		isPinnedPost,
 		abTests,
-		imagesForAppsLightbox,
 	});
 
 	const needsFigure = !bareElements.has(element._type);


### PR DESCRIPTION
The need for this prop was removed in https://github.com/guardian/dotcom-rendering/pull/9701, and so it can be removed.