### PR TITLE
Do not render the carousel on Android devices

### DIFF
--- a/dotcom-rendering/src/components/Carousel.importable.tsx
+++ b/dotcom-rendering/src/components/Carousel.importable.tsx
@@ -982,133 +982,128 @@ export const Carousel = ({
 		[],
 	);
 
+	if (isAndroid) {
+		return null;
+	}
+
 	return (
-		<>
-			{!isAndroid && (
-				<div
-					css={wrapperStyle(trails.length)}
-					data-link-name={formatAttrString(heading)}
-					data-component={
-						isVideoContainer ? 'video-playlist' : undefined
-					}
+		<div
+			css={wrapperStyle(trails.length)}
+			data-link-name={formatAttrString(heading)}
+			data-component={isVideoContainer ? 'video-playlist' : undefined}
+		>
+			<LeftColumn
+				borderType="partial"
+				size={leftColSize}
+				borderColour={carouselColours.borderColour}
+				hasPageSkin={hasPageSkin}
+			>
+				<HeaderAndNav
+					heading={heading}
+					trails={trails}
+					activeDotColour={carouselColours.activeDotColour}
+					titleColour={carouselColours.titleColour}
+					titleHighlightColour={carouselColours.titleHighlightColour}
+					index={index}
+					isCuratedContent={isCuratedContent}
+					goToIndex={goToIndex}
+					url={props.url}
+				/>
+			</LeftColumn>
+			<InlineChevrons
+				trails={trails}
+				carouselColours={carouselColours}
+				index={index}
+				prev={prev}
+				next={next}
+				arrowName={arrowName}
+				isVideoContainer={isVideoContainer}
+				leftColSize={leftColSize}
+				hasPageSkin={hasPageSkin}
+			/>
+			<div
+				css={[
+					containerStyles,
+					containerMargins,
+					!hasPageSkin && containerMarginsFromLeftCol,
+					isVideoContainer && videoContainerMargins,
+				]}
+				data-component={onwardsSource}
+				data-link={formatAttrString(heading)}
+			>
+				<Header
+					heading={heading}
+					trails={trails}
+					carouselColours={carouselColours}
+					index={index}
+					goToIndex={goToIndex}
+					prev={prev}
+					next={next}
+					arrowName={arrowName}
+					isCuratedContent={isCuratedContent}
+					containerType={containerType}
+					hasPageSkin={hasPageSkin}
+					url={props.url}
+				/>
+				<ul
+					css={[
+						carouselStyle,
+						isVideoContainer && videoContainerHeight,
+					]}
+					ref={carouselRef}
+					data-component={`carousel-small | maxIndex-${maxIndex}`}
 				>
-					<LeftColumn
-						borderType="partial"
-						size={leftColSize}
-						borderColour={carouselColours.borderColour}
-						hasPageSkin={hasPageSkin}
-					>
-						<HeaderAndNav
-							heading={heading}
-							trails={trails}
-							activeDotColour={carouselColours.activeDotColour}
-							titleColour={carouselColours.titleColour}
-							titleHighlightColour={
-								carouselColours.titleHighlightColour
-							}
-							index={index}
-							isCuratedContent={isCuratedContent}
-							goToIndex={goToIndex}
-							url={props.url}
-						/>
-					</LeftColumn>
-					<InlineChevrons
-						trails={trails}
-						carouselColours={carouselColours}
-						index={index}
-						prev={prev}
-						next={next}
-						arrowName={arrowName}
-						isVideoContainer={isVideoContainer}
-						leftColSize={leftColSize}
-						hasPageSkin={hasPageSkin}
-					/>
-					<div
-						css={[
-							containerStyles,
-							containerMargins,
-							!hasPageSkin && containerMarginsFromLeftCol,
-							isVideoContainer && videoContainerMargins,
-						]}
-						data-component={onwardsSource}
-						data-link={formatAttrString(heading)}
-					>
-						<Header
-							heading={heading}
-							trails={trails}
-							carouselColours={carouselColours}
-							index={index}
-							goToIndex={goToIndex}
-							prev={prev}
-							next={next}
-							arrowName={arrowName}
-							isCuratedContent={isCuratedContent}
-							containerType={containerType}
-							hasPageSkin={hasPageSkin}
-							url={props.url}
-						/>
-						<ul
-							css={[
-								carouselStyle,
-								isVideoContainer && videoContainerHeight,
-							]}
-							ref={carouselRef}
-							data-component={`carousel-small | maxIndex-${maxIndex}`}
-						>
-							{trails.map((trail, i) => {
-								const {
-									url: linkTo,
-									headline: headlineText,
-									webPublicationDate,
-									format: trailFormat,
-									image,
-									kickerText,
-									branding,
-									discussion,
-									mainMedia,
-								} = trail;
+					{trails.map((trail, i) => {
+						const {
+							url: linkTo,
+							headline: headlineText,
+							webPublicationDate,
+							format: trailFormat,
+							image,
+							kickerText,
+							branding,
+							discussion,
+							mainMedia,
+						} = trail;
 
-								// Don't try to render cards that have no publication date. This property is technically optional
-								// but we rarely if ever expect it not to exist
-								if (!webPublicationDate) return null;
+						// Don't try to render cards that have no publication date. This property is technically optional
+						// but we rarely if ever expect it not to exist
+						if (!webPublicationDate) return null;
 
-								const imageUrl =
-									image && getSourceImageUrl(image);
+						const imageUrl = image && getSourceImageUrl(image);
 
-								const imageLoading = i > 3 ? 'lazy' : 'eager';
+						const imageLoading = i > 3 ? 'lazy' : 'eager';
 
-								return (
-									<CarouselCard
-										key={`${trail.url}${i}`}
-										isFirst={i === 0}
-										format={trailFormat}
-										linkTo={linkTo}
-										headlineText={headlineText}
-										webPublicationDate={webPublicationDate}
-										imageUrl={imageUrl}
-										kickerText={kickerText}
-										dataLinkName={`carousel-small-card-position-${i}`}
-										discussionId={
-											discussion?.isCommentable
-												? discussion.discussionId
-												: undefined
-										}
-										branding={branding}
-										mainMedia={mainMedia}
-										verticalDividerColour={
-											carouselColours.borderColour
-										}
-										onwardsSource={onwardsSource}
-										containerType={containerType}
-										imageLoading={imageLoading}
-										discussionApiUrl={discussionApiUrl}
-									/>
-								);
-							})}
-						</ul>
-					</div>
-				</div>
-			)}
-		</>
+						return (
+							<CarouselCard
+								key={`${trail.url}${i}`}
+								isFirst={i === 0}
+								format={trailFormat}
+								linkTo={linkTo}
+								headlineText={headlineText}
+								webPublicationDate={webPublicationDate}
+								imageUrl={imageUrl}
+								kickerText={kickerText}
+								dataLinkName={`carousel-small-card-position-${i}`}
+								discussionId={
+									discussion?.isCommentable
+										? discussion.discussionId
+										: undefined
+								}
+								branding={branding}
+								mainMedia={mainMedia}
+								verticalDividerColour={
+									carouselColours.borderColour
+								}
+								onwardsSource={onwardsSource}
+								containerType={containerType}
+								imageLoading={imageLoading}
+								discussionApiUrl={discussionApiUrl}
+							/>
+						);
+					})}
+				</ul>
+			</div>
+		</div>
 	);
 };

--- a/dotcom-rendering/src/components/Carousel.importable.tsx
+++ b/dotcom-rendering/src/components/Carousel.importable.tsx
@@ -868,6 +868,7 @@ export const Carousel = ({
 
 	const [index, setIndex] = useState(0);
 	const [maxIndex, setMaxIndex] = useState(0);
+	const [isAndroid, setIsAndroid] = useState(false);
 
 	const arrowName = 'carousel-small-arrow';
 
@@ -976,124 +977,138 @@ export const Carousel = ({
 	// when index changes and compare it against the prior maxIndex only.
 	useEffect(() => setMaxIndex((m) => Math.max(index, m)), [index]);
 
+	useEffect(
+		() => setIsAndroid(() => /android/i.test(window.navigator.userAgent)),
+		[],
+	);
+
 	return (
-		<div
-			css={wrapperStyle(trails.length)}
-			data-link-name={formatAttrString(heading)}
-			data-component={isVideoContainer ? 'video-playlist' : undefined}
-		>
-			<LeftColumn
-				borderType="partial"
-				size={leftColSize}
-				borderColour={carouselColours.borderColour}
-				hasPageSkin={hasPageSkin}
-			>
-				<HeaderAndNav
-					heading={heading}
-					trails={trails}
-					activeDotColour={carouselColours.activeDotColour}
-					titleColour={carouselColours.titleColour}
-					titleHighlightColour={carouselColours.titleHighlightColour}
-					index={index}
-					isCuratedContent={isCuratedContent}
-					goToIndex={goToIndex}
-					url={props.url}
-				/>
-			</LeftColumn>
-			<InlineChevrons
-				trails={trails}
-				carouselColours={carouselColours}
-				index={index}
-				prev={prev}
-				next={next}
-				arrowName={arrowName}
-				isVideoContainer={isVideoContainer}
-				leftColSize={leftColSize}
-				hasPageSkin={hasPageSkin}
-			/>
-			<div
-				css={[
-					containerStyles,
-					containerMargins,
-					!hasPageSkin && containerMarginsFromLeftCol,
-					isVideoContainer && videoContainerMargins,
-				]}
-				data-component={onwardsSource}
-				data-link={formatAttrString(heading)}
-			>
-				<Header
-					heading={heading}
-					trails={trails}
-					carouselColours={carouselColours}
-					index={index}
-					goToIndex={goToIndex}
-					prev={prev}
-					next={next}
-					arrowName={arrowName}
-					isCuratedContent={isCuratedContent}
-					containerType={containerType}
-					hasPageSkin={hasPageSkin}
-					url={props.url}
-				/>
-				<ul
-					css={[
-						carouselStyle,
-						isVideoContainer && videoContainerHeight,
-					]}
-					ref={carouselRef}
-					data-component={`carousel-small | maxIndex-${maxIndex}`}
+		<>
+			{!isAndroid && (
+				<div
+					css={wrapperStyle(trails.length)}
+					data-link-name={formatAttrString(heading)}
+					data-component={
+						isVideoContainer ? 'video-playlist' : undefined
+					}
 				>
-					{trails.map((trail, i) => {
-						const {
-							url: linkTo,
-							headline: headlineText,
-							webPublicationDate,
-							format: trailFormat,
-							image,
-							kickerText,
-							branding,
-							discussion,
-							mainMedia,
-						} = trail;
+					<LeftColumn
+						borderType="partial"
+						size={leftColSize}
+						borderColour={carouselColours.borderColour}
+						hasPageSkin={hasPageSkin}
+					>
+						<HeaderAndNav
+							heading={heading}
+							trails={trails}
+							activeDotColour={carouselColours.activeDotColour}
+							titleColour={carouselColours.titleColour}
+							titleHighlightColour={
+								carouselColours.titleHighlightColour
+							}
+							index={index}
+							isCuratedContent={isCuratedContent}
+							goToIndex={goToIndex}
+							url={props.url}
+						/>
+					</LeftColumn>
+					<InlineChevrons
+						trails={trails}
+						carouselColours={carouselColours}
+						index={index}
+						prev={prev}
+						next={next}
+						arrowName={arrowName}
+						isVideoContainer={isVideoContainer}
+						leftColSize={leftColSize}
+						hasPageSkin={hasPageSkin}
+					/>
+					<div
+						css={[
+							containerStyles,
+							containerMargins,
+							!hasPageSkin && containerMarginsFromLeftCol,
+							isVideoContainer && videoContainerMargins,
+						]}
+						data-component={onwardsSource}
+						data-link={formatAttrString(heading)}
+					>
+						<Header
+							heading={heading}
+							trails={trails}
+							carouselColours={carouselColours}
+							index={index}
+							goToIndex={goToIndex}
+							prev={prev}
+							next={next}
+							arrowName={arrowName}
+							isCuratedContent={isCuratedContent}
+							containerType={containerType}
+							hasPageSkin={hasPageSkin}
+							url={props.url}
+						/>
+						<ul
+							css={[
+								carouselStyle,
+								isVideoContainer && videoContainerHeight,
+							]}
+							ref={carouselRef}
+							data-component={`carousel-small | maxIndex-${maxIndex}`}
+						>
+							{trails.map((trail, i) => {
+								const {
+									url: linkTo,
+									headline: headlineText,
+									webPublicationDate,
+									format: trailFormat,
+									image,
+									kickerText,
+									branding,
+									discussion,
+									mainMedia,
+								} = trail;
 
-						// Don't try to render cards that have no publication date. This property is technically optional
-						// but we rarely if ever expect it not to exist
-						if (!webPublicationDate) return null;
+								// Don't try to render cards that have no publication date. This property is technically optional
+								// but we rarely if ever expect it not to exist
+								if (!webPublicationDate) return null;
 
-						const imageUrl = image && getSourceImageUrl(image);
+								const imageUrl =
+									image && getSourceImageUrl(image);
 
-						const imageLoading = i > 3 ? 'lazy' : 'eager';
+								const imageLoading = i > 3 ? 'lazy' : 'eager';
 
-						return (
-							<CarouselCard
-								key={`${trail.url}${i}`}
-								isFirst={i === 0}
-								format={trailFormat}
-								linkTo={linkTo}
-								headlineText={headlineText}
-								webPublicationDate={webPublicationDate}
-								imageUrl={imageUrl}
-								kickerText={kickerText}
-								dataLinkName={`carousel-small-card-position-${i}`}
-								discussionId={
-									discussion?.isCommentable
-										? discussion.discussionId
-										: undefined
-								}
-								branding={branding}
-								mainMedia={mainMedia}
-								verticalDividerColour={
-									carouselColours.borderColour
-								}
-								onwardsSource={onwardsSource}
-								containerType={containerType}
-								imageLoading={imageLoading}
-								discussionApiUrl={discussionApiUrl}
-							/>
-						);
-					})}
-				</ul>
-			</div>
-		</div>
+								return (
+									<CarouselCard
+										key={`${trail.url}${i}`}
+										isFirst={i === 0}
+										format={trailFormat}
+										linkTo={linkTo}
+										headlineText={headlineText}
+										webPublicationDate={webPublicationDate}
+										imageUrl={imageUrl}
+										kickerText={kickerText}
+										dataLinkName={`carousel-small-card-position-${i}`}
+										discussionId={
+											discussion?.isCommentable
+												? discussion.discussionId
+												: undefined
+										}
+										branding={branding}
+										mainMedia={mainMedia}
+										verticalDividerColour={
+											carouselColours.borderColour
+										}
+										onwardsSource={onwardsSource}
+										containerType={containerType}
+										imageLoading={imageLoading}
+										discussionApiUrl={discussionApiUrl}
+									/>
+								);
+							})}
+						</ul>
+					</div>
+				</div>
+			)}
+		</>
 	);
 };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

This change removes the carousel on Android devices. 

## Why?

This platform does not yet support horizontal scrolling so trying to scroll the carousel does not work. Instead it triggers scrolling to the next article. This is a mitigation while we work on supporting horizontal scrolling in the webview on Android 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/1229808/50b7767f-56fd-4c78-a56b-538dc09980c5
[after]: https://github.com/guardian/dotcom-rendering/assets/1229808/2aa9d267-52e9-444d-b12b-5dd5f3ef8b3c

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->

Fixes https://github.com/guardian/dotcom-rendering/issues/9250
