### PR TITLE
Fix article background

### DIFF
--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -497,9 +497,7 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 					fullWidth={true}
 					data-print-layout="hide"
 					showTopBorder={false}
-					backgroundColour={themePalette(
-						'--article-section-background',
-					)}
+					backgroundColour={themePalette('--article-background')}
 					borderColour={themePalette('--article-border')}
 					fontColour={themePalette('--article-section-title')}
 					element="article"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
This fixes the article background which was broken in https://github.com/guardian/dotcom-rendering/pull/9706
Accidentally made the article section use the footer section colours


## Screenshots

| Before      | After      |
| ----------- | ---------- |
| <img width="1482" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/9d1545bb-6a08-477d-9ab1-2f2d1ef7171d"> | <img width="1482" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/e64bd179-ebaa-4732-9608-83d5717137ee"> |
