### PR TITLE
Add palette declarations to root CSS of other pages

### DIFF
--- a/dotcom-rendering/src/components/AllEditorialNewslettersPage.tsx
+++ b/dotcom-rendering/src/components/AllEditorialNewslettersPage.tsx
@@ -1,8 +1,13 @@
 import { css, Global } from '@emotion/react';
-import { brandAlt, focusHalo, neutral } from '@guardian/source-foundations';
+import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
+import {
+	focusHalo,
+	palette as sourcePalette,
+} from '@guardian/source-foundations';
 import { StrictMode } from 'react';
 import { AllEditorialNewslettersPageLayout } from '../layouts/AllEditorialNewslettersPageLayout';
 import type { NavType } from '../model/extract-nav';
+import { paletteDeclarations } from '../palette';
 import type { DCRNewslettersPageType } from '../types/newslettersPage';
 import { AlreadyVisited } from './AlreadyVisited.importable';
 import { FocusStyles } from './FocusStyles.importable';
@@ -28,18 +33,33 @@ export const AllEditorialNewslettersPage = ({
 	newslettersPage,
 	NAV,
 }: Props) => {
+	/* We use this as our "base" or default format */
+	const format = {
+		display: ArticleDisplay.Standard,
+		design: ArticleDesign.Standard,
+		theme: Pillar.News,
+	};
+
 	return (
 		<StrictMode>
 			<Global
 				styles={css`
+					:root {
+						/* Light palette is default on all platforms */
+						/* We do not support dark mode on tag pages */
+						${paletteDeclarations(format, 'light')}
+						body {
+							color: ${sourcePalette.neutral[7]};
+						}
+					}
 					/* Crude but effective mechanism. Specific components may need to improve on this behaviour. */
 					/* The not(.src...) selector is to work with Source's FocusStyleManager. */
 					*:focus {
 						${focusHalo}
 					}
 					::selection {
-						background: ${brandAlt[400]};
-						color: ${neutral[7]};
+						background: ${sourcePalette.brandAlt[400]};
+						color: ${sourcePalette.neutral[7]};
 					}
 				`}
 			/>

--- a/dotcom-rendering/src/components/FrontPage.tsx
+++ b/dotcom-rendering/src/components/FrontPage.tsx
@@ -1,10 +1,15 @@
 import { css, Global } from '@emotion/react';
-import { brandAlt, focusHalo, neutral } from '@guardian/source-foundations';
+import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
+import {
+	focusHalo,
+	palette as sourcePalette,
+} from '@guardian/source-foundations';
 import { StrictMode } from 'react';
 import { FrontLayout } from '../layouts/FrontLayout';
 import { buildAdTargeting } from '../lib/ad-targeting';
 import { filterABTestSwitches } from '../model/enhance-switches';
 import type { NavType } from '../model/extract-nav';
+import { paletteDeclarations } from '../palette';
 import type { DCRFrontType } from '../types/front';
 import { AlreadyVisited } from './AlreadyVisited.importable';
 import { BrazeMessaging } from './BrazeMessaging.importable';
@@ -40,18 +45,33 @@ export const FrontPage = ({ front, NAV }: Props) => {
 		adUnit: front.config.adUnit,
 	});
 
+	/* We use this as our "base" or default format */
+	const format = {
+		display: ArticleDisplay.Standard,
+		design: ArticleDesign.Standard,
+		theme: Pillar.News,
+	};
+
 	return (
 		<StrictMode>
 			<Global
 				styles={css`
+					:root {
+						/* Light palette is default on all platforms */
+						/* We do not support dark mode on front pages */
+						${paletteDeclarations(format, 'light')}
+						body {
+							color: ${sourcePalette.neutral[7]};
+						}
+					}
 					/* Crude but effective mechanism. Specific components may need to improve on this behaviour. */
 					/* The not(.src...) selector is to work with Source's FocusStyleManager. */
 					*:focus {
 						${focusHalo}
 					}
 					::selection {
-						background: ${brandAlt[400]};
-						color: ${neutral[7]};
+						background: ${sourcePalette.brandAlt[400]};
+						color: ${sourcePalette.neutral[7]};
 					}
 				`}
 			/>

--- a/dotcom-rendering/src/components/TagFrontPage.tsx
+++ b/dotcom-rendering/src/components/TagFrontPage.tsx
@@ -1,10 +1,15 @@
 import { css, Global } from '@emotion/react';
-import { brandAlt, focusHalo, neutral } from '@guardian/source-foundations';
+import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
+import {
+	focusHalo,
+	palette as sourcePalette,
+} from '@guardian/source-foundations';
 import { StrictMode } from 'react';
 import { TagFrontLayout } from '../layouts/TagFrontLayout';
 import { buildAdTargeting } from '../lib/ad-targeting';
 import { filterABTestSwitches } from '../model/enhance-switches';
 import type { NavType } from '../model/extract-nav';
+import { paletteDeclarations } from '../palette';
 import type { DCRTagFrontType } from '../types/tagFront';
 import { AlreadyVisited } from './AlreadyVisited.importable';
 import { FocusStyles } from './FocusStyles.importable';
@@ -37,18 +42,33 @@ export const TagFrontPage = ({ tagFront, NAV }: Props) => {
 		adUnit: tagFront.config.adUnit,
 	});
 
+	/* We use this as our "base" or default format */
+	const format = {
+		display: ArticleDisplay.Standard,
+		design: ArticleDesign.Standard,
+		theme: Pillar.News,
+	};
+
 	return (
 		<StrictMode>
 			<Global
 				styles={css`
+					:root {
+						/* Light palette is default on all platforms */
+						/* We do not support dark mode on tag pages */
+						${paletteDeclarations(format, 'light')}
+						body {
+							color: ${sourcePalette.neutral[7]};
+						}
+					}
 					/* Crude but effective mechanism. Specific components may need to improve on this behaviour. */
 					/* The not(.src...) selector is to work with Source's FocusStyleManager. */
 					*:focus {
 						${focusHalo}
 					}
 					::selection {
-						background: ${brandAlt[400]};
-						color: ${neutral[7]};
+						background: ${sourcePalette.brandAlt[400]};
+						color: ${sourcePalette.neutral[7]};
 					}
 				`}
 			/>

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -6,9 +6,7 @@ import {
 	brandBackground,
 	brandBorder,
 	brandLine,
-	labs,
-	neutral,
-	news,
+	palette as sourcePalette,
 } from '@guardian/source-foundations';
 import { StraightLines } from '@guardian/source-react-components-development-kitchen';
 import { Fragment } from 'react';
@@ -261,8 +259,10 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 									<SubNav
 										subNavSections={NAV.subNavSections}
 										currentNavLink={NAV.currentNavLink}
-										linkHoverColour={news[400]}
-										borderColour={neutral[46]}
+										linkHoverColour={
+											sourcePalette.news[400]
+										}
+										borderColour={sourcePalette.neutral[46]}
 									/>
 								</Island>
 							</Section>
@@ -286,7 +286,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 						<Section
 							fullWidth={true}
 							showTopBorder={false}
-							backgroundColour={labs[400]}
+							backgroundColour={sourcePalette.labs[400]}
 							borderColour={border.primary}
 							sectionId="labs-header"
 						>
@@ -691,8 +691,8 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 						<SubNav
 							subNavSections={NAV.subNavSections}
 							currentNavLink={NAV.currentNavLink}
-							linkHoverColour={news[400]}
-							borderColour={neutral[46]}
+							linkHoverColour={sourcePalette.news[400]}
+							borderColour={sourcePalette.neutral[46]}
 						/>
 					</Island>
 				</Section>


### PR DESCRIPTION
## What does this change?

Adds `paletteDeclarations` for light mode and "standard" format to non article pages (Tag Pages, Front Pages, All Newsletter Page)

### Even better if...

There was a way to bring through the `palette` colours without needing to specify a "format" since this is a concept very specific to articles.

## Why?
Some pages might use components designed for articles and as such might contain CSS variables This change ensures that the CSS vars will return a value for these pages and as such they wont display unwanted visual regressions

As action from PR comment https://github.com/guardian/dotcom-rendering/pull/9713/files#r1410934191
