### PR TITLE
Bump braze-components dependency

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -55,7 +55,7 @@
 		"@emotion/react": "11.11.1",
 		"@emotion/server": "11.11.0",
 		"@guardian/ab-core": "5.0.0",
-		"@guardian/braze-components": "16.1.1",
+		"@guardian/braze-components": "16.2.0",
 		"@guardian/bridget": "2.5.0",
 		"@guardian/browserslist-config": "5.0.0",
 		"@guardian/cdk": "50.10.6",

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -55,7 +55,7 @@
 		"@emotion/react": "11.11.1",
 		"@emotion/server": "11.11.0",
 		"@guardian/ab-core": "5.0.0",
-		"@guardian/braze-components": "16.1.0",
+		"@guardian/braze-components": "16.1.1",
 		"@guardian/bridget": "2.5.0",
 		"@guardian/browserslist-config": "5.0.0",
 		"@guardian/cdk": "50.10.6",

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -55,7 +55,7 @@
 		"@emotion/react": "11.11.1",
 		"@emotion/server": "11.11.0",
 		"@guardian/ab-core": "5.0.0",
-		"@guardian/braze-components": "15.0.1",
+		"@guardian/braze-components": "16.1.0",
 		"@guardian/bridget": "2.5.0",
 		"@guardian/browserslist-config": "5.0.0",
 		"@guardian/cdk": "50.10.6",

--- a/dotcom-rendering/src/components/SlotBodyEnd/BrazeEpic.stories.tsx
+++ b/dotcom-rendering/src/components/SlotBodyEnd/BrazeEpic.stories.tsx
@@ -123,9 +123,9 @@ export const BrazeEpic_DefaultWithReminder_Component = (
 			buttonUrl: args.buttonUrl,
 			hidePaymentIcons: args.hidePaymentIcons,
 			ophanComponentId: args.ophanComponentId,
-			remindMeButtonText: args.remindMeButtonText,
-			remindMeConfirmationText: args.remindMeConfirmationText,
-			remindMeConfirmationHeaderText: args.remindMeConfirmationHeaderText,
+			reminderStage: args.reminderStage,
+			reminderOption: args.reminderOption,
+			showPrivacyText: args.showPrivacyText,
 		};
 
 		return (
@@ -165,9 +165,9 @@ BrazeEpic_DefaultWithReminder_Component.args = {
 	ophanComponentId: 'example_ophan_component_id',
 	slotName: 'EndOfArticle',
 	componentName: 'Epic',
-	remindMeButtonText: 'Remind me in May',
-	remindMeConfirmationText: "Okay, we'll send you an email in May.",
-	remindMeConfirmationHeaderText: 'Thank you! Your reminder is set.',
+	reminderStage: 'PRE',
+	reminderOption: 'recurring-contribution-upsell',
+	showPrivacyText: 'true',
 };
 
 BrazeEpic_DefaultWithReminder_Component.storyName =

--- a/dotcom-rendering/src/components/StickyBottomBanner/BrazeBanner.stories.tsx
+++ b/dotcom-rendering/src/components/StickyBottomBanner/BrazeBanner.stories.tsx
@@ -271,6 +271,13 @@ export const BrazeStyleableBannerComponent = (
 			styleCloseBackground: args.styleCloseBackground,
 			styleCloseHover: args.styleCloseHover,
 			ophanComponentId: args.ophanComponentId,
+			reminderStage: args.reminderStage,
+			reminderOption: args.reminderOption,
+			showPrivacyText: args.showPrivacyText,
+			styleReminderButton: args.styleReminderButton,
+			styleReminderButtonBackground: args.styleReminderButtonBackground,
+			styleReminderButtonHover: args.styleReminderButtonHover,
+			styleReminderAnimation: args.styleReminderAnimation,
 		};
 
 		return (
@@ -323,6 +330,13 @@ BrazeStyleableBannerComponent.args = {
 	styleCloseHover: '#e5e5e5',
 	componentName: 'StyleableBannerWithLink',
 	ophanComponentId: 'change_me_ophan_component_id',
+	reminderStage: 'PRE',
+	reminderOption: 'recurring-contribution-upsell',
+	showPrivacyText: 'false',
+	styleReminderButton: '#121212',
+	styleReminderButtonBackground: '#ededed',
+	styleReminderButtonHover: '#dcdcdc',
+	styleReminderAnimation: '#707070',
 };
 
 BrazeStyleableBannerComponent.storyName = 'StyleableBannerWithLink';

--- a/yarn.lock
+++ b/yarn.lock
@@ -5950,9 +5950,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@guardian/braze-components@npm:15.0.1":
-  version: 15.0.1
-  resolution: "@guardian/braze-components@npm:15.0.1"
+"@guardian/braze-components@npm:16.1.1":
+  version: 16.1.1
+  resolution: "@guardian/braze-components@npm:16.1.1"
   peerDependencies:
     "@emotion/react": ^11.1.2
     "@guardian/libs": ^15.1.0
@@ -5960,7 +5960,7 @@ __metadata:
     "@guardian/source-react-components": ^15.0.1
     "@guardian/source-react-components-development-kitchen": ^13.0.1
     react: 17.0.2 || 18.2.0
-  checksum: 4701b74287587746985f0df15f90d6bb2c83f42d829d45fc6c8e64b5a82ed7e5b2751553d19cd01b903d62be341b2a93a8213a255005f845b9de4de2bb754aef
+  checksum: ed14b5f275683f1ab60c7d9c128fae2d104aef1d7570f0452290792544a5683e4621008ea261a25550f37efdb43d85e84285a5dc2b133eeb8a643b2a8c46ccca
   languageName: node
   linkType: hard
 
@@ -6162,7 +6162,7 @@ __metadata:
     "@emotion/react": "npm:11.11.1"
     "@emotion/server": "npm:11.11.0"
     "@guardian/ab-core": "npm:5.0.0"
-    "@guardian/braze-components": "npm:15.0.1"
+    "@guardian/braze-components": "npm:16.1.1"
     "@guardian/bridget": "npm:2.5.0"
     "@guardian/browserslist-config": "npm:5.0.0"
     "@guardian/cdk": "npm:50.10.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5950,9 +5950,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@guardian/braze-components@npm:16.1.1":
-  version: 16.1.1
-  resolution: "@guardian/braze-components@npm:16.1.1"
+"@guardian/braze-components@npm:16.2.0":
+  version: 16.2.0
+  resolution: "@guardian/braze-components@npm:16.2.0"
   peerDependencies:
     "@emotion/react": ^11.1.2
     "@guardian/libs": ^15.1.0
@@ -5960,7 +5960,7 @@ __metadata:
     "@guardian/source-react-components": ^15.0.1
     "@guardian/source-react-components-development-kitchen": ^13.0.1
     react: 17.0.2 || 18.2.0
-  checksum: ed14b5f275683f1ab60c7d9c128fae2d104aef1d7570f0452290792544a5683e4621008ea261a25550f37efdb43d85e84285a5dc2b133eeb8a643b2a8c46ccca
+  checksum: 60f7367b09914b6a51a65d9b76bd7308b4825a7230916def94e67936c5dd50335d2c471da50dd34a6846b2d59b772d1cd1d2fd4eeca0a9c03a4f787539831866
   languageName: node
   linkType: hard
 
@@ -6162,7 +6162,7 @@ __metadata:
     "@emotion/react": "npm:11.11.1"
     "@emotion/server": "npm:11.11.0"
     "@guardian/ab-core": "npm:5.0.0"
-    "@guardian/braze-components": "npm:16.1.1"
+    "@guardian/braze-components": "npm:16.2.0"
     "@guardian/bridget": "npm:2.5.0"
     "@guardian/browserslist-config": "npm:5.0.0"
     "@guardian/cdk": "npm:50.10.6"


### PR DESCRIPTION
## What does this change?
Bump the braze components dependency to latest v16.2.0.

## Why?
We have updated the optional one-click contributions reminder button in the Braze epic, and added the button to the styleable Braze banner. The updated button uses the same functionality as exists for RRCP banners, to set a contribution reminder email flag for a reader.

## Screenshots
The changes to the relevant Braze banner and epic components are minor, and have been tested/approved in the braze-components repo. DCR Storybook has been updated to match BC Storybook.