### PR TITLE
refactor: consolidate styles ahead of font scaling adjustment

### DIFF
--- a/dotcom-rendering/src/components/Standfirst.tsx
+++ b/dotcom-rendering/src/components/Standfirst.tsx
@@ -60,6 +60,14 @@ const nestedStyles = (format: ArticleFormat) => {
 	`;
 };
 
+const baseStyles = css`
+	margin-top: ${space[2]}px;
+	margin-bottom: ${space[3]}px;
+	line-height: 22px;
+	max-width: 540px;
+	color: ${palette('--standfirst-text')};
+`;
+
 const standfirstStyles = ({ display, design, theme }: ArticleFormat) => {
 	switch (display) {
 		case ArticleDisplay.Immersive:
@@ -67,21 +75,11 @@ const standfirstStyles = ({ display, design, theme }: ArticleFormat) => {
 				case ArticleDesign.PhotoEssay:
 					if (theme === ArticleSpecial.Labs) {
 						return css`
-							${textSans.large({})};
-							margin-top: ${space[2]}px;
-							margin-bottom: ${space[3]}px;
-							line-height: 22px;
-							max-width: 540px;
-							color: ${palette('--standfirst-text')};
+							${textSans.large()};
 						`;
 					}
 					return css`
-						${headline.xxxsmall({})};
-						margin-top: ${space[2]}px;
-						margin-bottom: ${space[3]}px;
-						line-height: 22px;
-						max-width: 540px;
-						color: ${palette('--standfirst-text')};
+						${headline.xxxsmall()};
 					`;
 				default:
 					return css`
@@ -91,12 +89,14 @@ const standfirstStyles = ({ display, design, theme }: ArticleFormat) => {
 									fontWeight: 'light',
 							  })};
 						padding-top: ${space[4]}px;
-
+						line-height: none;
+						margin-bottom: none;
+						margin-top: none;
 						max-width: 280px;
+
 						${from.tablet} {
 							max-width: 460px;
 						}
-						color: ${palette('--standfirst-text')};
 						li:before {
 							height: 17px;
 							width: 17px;
@@ -109,9 +109,8 @@ const standfirstStyles = ({ display, design, theme }: ArticleFormat) => {
 				${headline.xxsmall({
 					fontWeight: 'bold',
 				})};
-				margin-bottom: ${space[3]}px;
-				max-width: 540px;
-				color: ${palette('--standfirst-text')};
+				line-height: none;
+				margin-top: none;
 			`;
 
 		case ArticleDisplay.Showcase:
@@ -132,9 +131,9 @@ const standfirstStyles = ({ display, design, theme }: ArticleFormat) => {
 						${headline.xxsmall({
 							fontWeight: 'light',
 						})};
-						margin-bottom: ${space[3]}px;
-						max-width: 540px;
-						color: ${palette('--standfirst-text')};
+						line-height: none;
+						margin-top: none;
+
 						li:before {
 							height: 15px;
 							width: 15px;
@@ -148,30 +147,18 @@ const standfirstStyles = ({ display, design, theme }: ArticleFormat) => {
 						})};
 						line-height: 20px;
 						margin-top: ${space[1]}px;
-						margin-bottom: ${space[3]}px;
-						max-width: 540px;
-						color: ${palette('--standfirst-text')};
 					`;
 				case ArticleDesign.Analysis:
 					return css`
 						${headline.xxxsmall()};
-						margin-bottom: ${space[3]}px;
-						max-width: 540px;
-						color: ${palette('--standfirst-text')};
+						margin-top: none;
 					`;
 				default:
 					switch (theme) {
 						case ArticleSpecial.Labs:
 							return css`
 								${textSans.medium()}
-								margin-bottom: ${space[3]}px;
-								max-width: 540px;
-								color: ${palette('--standfirst-text')};
-								a {
-									color: ${palette('--standfirst-link-text')};
-									border-bottom: 1px solid
-										${palette('--standfirst-link-border')};
-								}
+								margin-top: none;
 							`;
 						default:
 							return css`
@@ -179,9 +166,7 @@ const standfirstStyles = ({ display, design, theme }: ArticleFormat) => {
 									fontWeight: 'bold',
 								})};
 								line-height: 20px;
-								margin-bottom: ${space[3]}px;
-								max-width: 540px;
-								color: ${palette('--standfirst-text')};
+								margin-top: none;
 							`;
 					}
 			}
@@ -201,6 +186,7 @@ export const Standfirst = ({ format, standfirst }: Props) => {
 			<div
 				css={[
 					nestedStyles(format),
+					baseStyles,
 					standfirstStyles(format),
 					hoverStyles,
 				]}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Small refactor of styles ahead of PR to fix the font scaling for the `Standfirst` component.

## Why?

When adjusting the base browser font size, the line height does not scale with the font for `Standfirst`. This PR consolidates the styles ahead of changing the line height, to better monitor any visual diffs.

Part of #9676 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
