### PR TITLE
Fix standfirst font scaling

### DIFF
--- a/dotcom-rendering/src/components/Standfirst.tsx
+++ b/dotcom-rendering/src/components/Standfirst.tsx
@@ -63,7 +63,6 @@ const nestedStyles = (format: ArticleFormat) => {
 const baseStyles = css`
 	margin-top: ${space[2]}px;
 	margin-bottom: ${space[3]}px;
-	line-height: 22px;
 	max-width: 540px;
 	color: ${palette('--standfirst-text')};
 `;
@@ -89,7 +88,6 @@ const standfirstStyles = ({ display, design, theme }: ArticleFormat) => {
 									fontWeight: 'light',
 							  })};
 						padding-top: ${space[4]}px;
-						line-height: none;
 						margin-bottom: none;
 						margin-top: none;
 						max-width: 280px;
@@ -109,7 +107,6 @@ const standfirstStyles = ({ display, design, theme }: ArticleFormat) => {
 				${headline.xxsmall({
 					fontWeight: 'bold',
 				})};
-				line-height: none;
 				margin-top: none;
 			`;
 
@@ -131,7 +128,6 @@ const standfirstStyles = ({ display, design, theme }: ArticleFormat) => {
 						${headline.xxsmall({
 							fontWeight: 'light',
 						})};
-						line-height: none;
 						margin-top: none;
 
 						li:before {
@@ -145,7 +141,6 @@ const standfirstStyles = ({ display, design, theme }: ArticleFormat) => {
 						${headline.xxxsmall({
 							fontWeight: 'bold',
 						})};
-						line-height: 20px;
 						margin-top: ${space[1]}px;
 					`;
 				case ArticleDesign.Analysis:
@@ -165,7 +160,6 @@ const standfirstStyles = ({ display, design, theme }: ArticleFormat) => {
 								${headline.xxxsmall({
 									fontWeight: 'bold',
 								})};
-								line-height: 20px;
 								margin-top: none;
 							`;
 					}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Uses the line height provided by `source` rather than overriding it in the component styles.
Post refactor (#9750)

## Why?

When the base font size is adjusted in the browser settings, the line height does not scale with the font size for the `Standfirst` component. This results in it looking strange and almost unreadable for a "very large" font scaling adjustment.
 
Resolves #9676 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
