### PR TITLE
fix(Standfirst): fetch line height from source rather than using explicit px value

### DIFF
--- a/dotcom-rendering/src/components/Standfirst.tsx
+++ b/dotcom-rendering/src/components/Standfirst.tsx
@@ -131,6 +131,7 @@ const standfirstStyles = ({ display, design, theme }: ArticleFormat) => {
 					return css`
 						${headline.xxsmall({
 							fontWeight: 'light',
+							lineHeight: 'tight',
 						})};
 						margin-bottom: ${space[3]}px;
 						max-width: 540px;
@@ -145,8 +146,8 @@ const standfirstStyles = ({ display, design, theme }: ArticleFormat) => {
 					return css`
 						${headline.xxxsmall({
 							fontWeight: 'bold',
+							lineHeight: 'tight',
 						})};
-						line-height: 20px;
 						margin-top: ${space[1]}px;
 						margin-bottom: ${space[3]}px;
 						max-width: 540px;
@@ -154,7 +155,7 @@ const standfirstStyles = ({ display, design, theme }: ArticleFormat) => {
 					`;
 				case ArticleDesign.Analysis:
 					return css`
-						${headline.xxxsmall()};
+						${headline.xxxsmall({ lineHeight: 'tight' })};
 						margin-bottom: ${space[3]}px;
 						max-width: 540px;
 						color: ${palette('--standfirst-text')};
@@ -163,7 +164,7 @@ const standfirstStyles = ({ display, design, theme }: ArticleFormat) => {
 					switch (theme) {
 						case ArticleSpecial.Labs:
 							return css`
-								${textSans.medium()}
+								${textSans.medium({ lineHeight: 'tight' })}
 								margin-bottom: ${space[3]}px;
 								max-width: 540px;
 								color: ${palette('--standfirst-text')};
@@ -177,8 +178,8 @@ const standfirstStyles = ({ display, design, theme }: ArticleFormat) => {
 							return css`
 								${headline.xxxsmall({
 									fontWeight: 'bold',
+									lineHeight: 'tight',
 								})};
-								line-height: 20px;
 								margin-bottom: ${space[3]}px;
 								max-width: 540px;
 								color: ${palette('--standfirst-text')};


### PR DESCRIPTION
## What does this change?

Uses the line height provided by `source` rather than overriding with a pixel value in the component styles.

## Why?

When the base font size is adjusted in the browser settings, the line height does not scale with the font size for the `Standfirst` component. This results in it looking strange and almost unreadable for a "very large" font scaling adjustment. 
 
Resolves #9676 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |
| ![before2][] | ![after2][] |
| ![before3][] | ![after3][] |

<!--
Unused screenshots - see below
| ![before4][] | ![after4][] |
| ![before5][] | ![after5][] |
| ![before6][] | ![after6][] |
-->

[before]: https://github.com/guardian/dotcom-rendering/assets/43961396/76986a91-2aa0-4c38-8e85-2b3ec41ece35
[after]: https://github.com/guardian/dotcom-rendering/assets/43961396/9a515909-cc88-4dd2-8e9f-ba652609d6b8
[before2]: https://github.com/guardian/dotcom-rendering/assets/43961396/3463cbb0-3ed3-492c-92ec-4e624863d6ca
[after2]: https://github.com/guardian/dotcom-rendering/assets/43961396/7cc70d80-333c-43de-a870-eb67b94f792c
[before3]: https://github.com/guardian/dotcom-rendering/assets/43961396/3cd061c4-345e-4cce-883f-af11ff648535
[after3]: https://github.com/guardian/dotcom-rendering/assets/43961396/25dffeed-2233-4023-8627-b5f55544fc79


<!--
Unused screenshots

[before4]: https://github.com/guardian/dotcom-rendering/assets/43961396/997515ed-d770-4b63-8833-5f13e49efc40
[after4]: https://github.com/guardian/dotcom-rendering/assets/43961396/d5b0acbc-40b7-4fcf-8e97-e072a1667944
[before5]: https://github.com/guardian/dotcom-rendering/assets/43961396/8e83fc6d-bb18-46c2-b467-360cc029a1c7
[after5]: https://github.com/guardian/dotcom-rendering/assets/43961396/e88fdb82-e415-4d41-8029-413bea4ab4c1
[before6]: https://github.com/guardian/dotcom-rendering/assets/43961396/99f281db-533a-4f3e-b87f-219dfcf6528b
[after6]: https://github.com/guardian/dotcom-rendering/assets/43961396/5afc6733-d6cd-4e0a-8652-ac9b7506ec9c
-->

