### PR TITLE
Auto-updating `RelativeTime` once hydrated

### DIFF
--- a/dotcom-rendering/src/components/Liveness.importable.tsx
+++ b/dotcom-rendering/src/components/Liveness.importable.tsx
@@ -1,4 +1,3 @@
-import { isString, timeAgo } from '@guardian/libs';
 import { useCallback, useEffect, useState } from 'react';
 import ReactDOM from 'react-dom';
 import { getEmotionCache } from '../client/islands/emotion';
@@ -25,23 +24,9 @@ const topOfBlog: Element | null = !isServer
 	? window.document.getElementById('top-of-blog')
 	: null;
 
-const lastUpdated: Element | null = !isServer
-	? window.document.querySelector('[data-gu-marker=liveblog-last-updated]')
-	: null;
-
 const toastRoot: Element | null = !isServer
 	? window.document.getElementById('toast-root')
 	: null;
-
-let timer: NodeJS.Timer | number | undefined;
-const updateTimeElement = (time: HTMLTimeElement) => {
-	clearTimeout(timer);
-	const then = new Date(time.dateTime).getTime();
-	const newText = timeAgo(then);
-	if (!isString(newText) || newText === time.innerText) return;
-	time.innerText = newText;
-	timer = setTimeout(() => updateTimeElement(time), 15_000);
-};
 
 /**
  * insert
@@ -194,11 +179,6 @@ export const Liveness = ({
 					} catch (e) {
 						console.log('>> failed >>', e);
 					}
-				}
-
-				if (lastUpdated instanceof HTMLTimeElement) {
-					lastUpdated.dateTime = new Date().toString();
-					updateTimeElement(lastUpdated);
 				}
 
 				if (


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Remove the unnecessary manual updating of relative times coming in new live blocks.

## Why?

It’s already handled by #9080 

## Screenshots

The time is updated when a mock live update is performed!

<img width="1653" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/76776/76cf5c81-ce2a-4f05-a7a2-632689ba4c79">
