### PR TITLE
remove logic for user-features switch

### DIFF
--- a/dotcom-rendering/src/client/main.web.ts
+++ b/dotcom-rendering/src/client/main.web.ts
@@ -94,16 +94,14 @@ void (async () => {
 		},
 	);
 
-	if (window.guardian.config.switches.userFeaturesDcr === true) {
-		void startup(
-			'userFeatures',
-			() =>
-				import(
-					/* webpackMode: 'eager' */ './userFeatures/user-features'
-				).then(({ refresh }) => refresh()),
-			{ priority: 'critical' },
-		);
-	}
+	void startup(
+		'userFeatures',
+		() =>
+			import(
+				/* webpackMode: 'eager' */ './userFeatures/user-features'
+			).then(({ refresh }) => refresh()),
+		{ priority: 'critical' },
+	);
 
 	/*************************************************************
 	 *


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Currently `user-features` is in both `commercial` and `dcr`, loading conditionally based on the state of the feature switch in `frontend`: https://github.com/guardian/frontend/pull/26687/files.

This removes logic that conditionally loads the user-features module from here in dotcom-rendering.


## Why?
This will mean the `user-features` will load unconditionally on dcr articles. (the feature switch will no longer exist in frontend)

## Screenshots

<img width="1148" alt="Screenshot 2023-12-04 at 15 37 34" src="https://github.com/guardian/dotcom-rendering/assets/49187886/004cc92e-ca11-4371-9ab8-94f248791397">

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
