### PR TITLE
Fix overflowing show more/less button on fronts

### DIFF
--- a/dotcom-rendering/src/components/ShowMore.importable.tsx
+++ b/dotcom-rendering/src/components/ShowMore.importable.tsx
@@ -210,7 +210,7 @@ export const ShowMore = ({
 							margin-left: 10px;
 						}
 						/* On smaller screens, button text overflows the container so we wrap to prevent it */
-						${until.mobileMedium} {
+						${until.phablet} {
 							text-wrap: wrap;
 							height: unset;
 						}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Adds text wrapping to the show more/less button for small screens. 
Also replaces deprecated `neutral` with source's palette neutral

## Why?
We had a report of this button being too long and causing horizontal scrolling on mobile

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![image](https://github.com/guardian/dotcom-rendering/assets/26366706/ddbf9c45-d25e-4de4-863c-771c9f2fe3c6)| ![image](https://github.com/guardian/dotcom-rendering/assets/26366706/f3f58d02-4a82-4731-9b7f-d4b3c3f464e3) |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
