### PR TITLE
Only hide carousel on android if its in the app

### DIFF
--- a/dotcom-rendering/src/components/Carousel.importable.tsx
+++ b/dotcom-rendering/src/components/Carousel.importable.tsx
@@ -24,6 +24,7 @@ import type { TrailType } from '../types/trails';
 import { Card } from './Card/Card';
 import { LI } from './Card/components/LI';
 import type { Loading } from './CardPicture';
+import { useConfig } from './ConfigContext';
 import { Hide } from './Hide';
 import { LeftColumn } from './LeftColumn';
 
@@ -862,6 +863,9 @@ export const Carousel = ({
 	discussionApiUrl,
 	...props
 }: ArticleProps | FrontProps) => {
+	const { renderingTarget } = useConfig();
+	const isApps = renderingTarget === 'Apps';
+
 	const carouselColours = decideCarouselColours(props);
 
 	const carouselRef = useRef<HTMLUListElement>(null);
@@ -982,7 +986,7 @@ export const Carousel = ({
 		[],
 	);
 
-	if (isAndroid) {
+	if (isApps && isAndroid) {
 		return null;
 	}
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Adds a check for `isApps`, so we only hide the carousel in the webview in the app on an android device.

The change to remove the carousel for all android devices (https://github.com/guardian/dotcom-rendering/pull/9714) also hid the carousel for the browsers on any android device.

## Screenshots (testing in browserstack)

| Before      | After      |
| ----------- | ---------- |
| ![image](https://github.com/guardian/dotcom-rendering/assets/26366706/f010066e-ba0c-4e00-95bc-1c66b82624ac) | ![image](https://github.com/guardian/dotcom-rendering/assets/26366706/51be973e-da97-4c2f-ade0-d2fa67140ac6) |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
