### PR TITLE
fix: address issue in cypress test for affiliate links

### DIFF
--- a/dotcom-rendering/cypress/e2e/parallel-1/article.elements.cy.js
+++ b/dotcom-rendering/cypress/e2e/parallel-1/article.elements.cy.js
@@ -220,7 +220,7 @@ describe('Elements', function () {
 				'/Article/https://www.theguardian.com/music/2020/jun/15/pet-shop-boys-where-to-start-in-their-back-catalogue',
 			);
 
-			getBody().contains('affiliate links');
+			getBody().contains('affiliate link');
 		});
 	});
 });


### PR DESCRIPTION

## What does this change?

Fixes failing Cypress test
Supersedes https://github.com/guardian/dotcom-rendering/pull/9781

## Why?

Cypress 1 GH action, as part of DCR CICD, was breaking and preventing deploys.
This should unblock.
