### PR TITLE
remove code endpoint for PRout

### DIFF
--- a/dotcom-rendering/.prout.json
+++ b/dotcom-rendering/.prout.json
@@ -3,10 +3,6 @@
 		"PROD": {
 			"url": "https://www.theguardian.com/uk",
 			"overdue": "30M"
-		},
-		"CODE": {
-			"url": "https://m.code.dev-theguardian.com/uk",
-			"overdue": "30M"
 		}
 	}
 }


### PR DESCRIPTION
## What does this change?

Post #9692, removes the PRout endpoint for the CODE environment.

## Why?

This is an unstable environment and constantly changing. It's not a suitable place for PRout to be checking as deployments are manual and random.
The UK front on CODE is not guaranteed to be using DCR either.
