### PR TITLE
Support apps article scaling in Android

### DIFF
--- a/dotcom-rendering/src/server/htmlPageTemplate.ts
+++ b/dotcom-rendering/src/server/htmlPageTemplate.ts
@@ -374,6 +374,16 @@ https://workforus.theguardian.com/careers/product-engineering/
 				${css}
 				<link rel="stylesheet" media="print" href="${ASSET_ORIGIN}static/frontend/css/print.css">
 
+				${
+					/**
+					 * fontSize.css does not exist. The Android app intercepts this request
+					 * in order to support article scaling.
+					 */
+					renderingTarget === 'Apps'
+						? `<link rel="stylesheet" type="text/css" href="/fontSize.css">`
+						: ``
+				}
+
 			</head>
 
 			<body class="${hasPageSkin ? 'has-page-skin' : ''}">


### PR DESCRIPTION
## What does this change?

- Includes a link to `fontSize.css` for apps articles. Although this file doesn't really exist, the request to load it is intercepted by the Android app. The Android app injects CSS into the response to support article scaling, as shown in the screenshots below.

[This mechanism was also used on AR](https://github.com/guardian/dotcom-rendering/blob/e56d0e8f6aa97793fdcc317207b648ecf3288104/apps-rendering/src/server/page.tsx#L109).

Closes https://github.com/guardian/dotcom-rendering/issues/9760.

## Screenshots

|  |  |   |
|--------|--------|--------|
| ![image](https://github.com/guardian/dotcom-rendering/assets/705427/fb1f33d9-b216-4dfe-98a5-7e5f576d7146) | ![image](https://github.com/guardian/dotcom-rendering/assets/705427/a0086053-5575-4088-8bc5-02452940337d) |![image](https://github.com/guardian/dotcom-rendering/assets/705427/5cfa6f1e-12db-4c9f-9f57-5e2368863def) |
| ![image](https://github.com/guardian/dotcom-rendering/assets/705427/f7f33885-c692-4757-adcb-f5ed4a444d1d) | ![image](https://github.com/guardian/dotcom-rendering/assets/705427/e90fa62f-0347-44c6-a14e-8971b5a07323) | ![image](https://github.com/guardian/dotcom-rendering/assets/705427/25cb6ae4-7145-477e-8db1-5556a3fdeb4f) |
| ![image](https://github.com/guardian/dotcom-rendering/assets/705427/2b9d4033-237d-42fa-8916-d740698ac1c6) | ![image](https://github.com/guardian/dotcom-rendering/assets/705427/af82067f-ba31-4092-957c-a3b89f6edb9c) | ![image](https://github.com/guardian/dotcom-rendering/assets/705427/8aa8d316-626c-4ccd-8f89-84f855c55eaf) | 