### PR TITLE
Bump @guardian/commercial@11.25.0

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -61,7 +61,7 @@
 		"@guardian/bridget": "2.5.0",
 		"@guardian/browserslist-config": "5.0.0",
 		"@guardian/cdk": "50.10.6",
-		"@guardian/commercial": "11.20.0",
+		"@guardian/commercial": "11.25.0",
 		"@guardian/consent-management-platform": "13.7.1",
 		"@guardian/core-web-vitals": "5.1.0",
 		"@guardian/eslint-config": "4.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4030,17 +4030,17 @@
     read-pkg-up "7.0.1"
     yargs "^17.6.2"
 
-"@guardian/commercial@11.20.0":
-  version "11.20.0"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-11.20.0.tgz#6a07246c157ba8ef365e790b8417fe6042be54dc"
-  integrity sha512-kA6hHf9o9u57qteMSmk8t9Eu2xWb6IvrnnS1hVBhvMum6b1pmzVqHUxSb3oKqb7AFz7Jq7zjweOiITfJpr3BNg==
+"@guardian/commercial@11.25.0":
+  version "11.25.0"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-11.25.0.tgz#6af524962dc73d54de6d1d6a38c658c649946a72"
+  integrity sha512-XRMty1F237iFWr10Nf2eFpkGxzw4cCDWOPFCFTrVNpVel9pMqHF9dR1UXIzPh84SOlFsJciBEAvAN0Z2KG9V9w==
   dependencies:
     "@changesets/cli" "^2.26.2"
     "@octokit/core" "^4.0.5"
     fastdom "^1.0.11"
     lodash-es "^4.17.21"
     ophan-tracker-js "^2.0.1"
-    prebid.js guardian/prebid.js#0b4cccd55ab4e170b36bb944e9bdd2807a9da1c5
+    prebid.js guardian/prebid.js#ee7f43c7c85a5245bbe51920cfed18818866ea7b
     process "^0.11.10"
     raven-js "^3.27.2"
     tslib "^2.5.3"
@@ -9416,7 +9416,7 @@ cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-crypto-js@4.2.0, crypto-js@^3.3.0:
+crypto-js@4.2.0, crypto-js@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-4.2.0.tgz#4d931639ecdfd12ff80e8186dba6af2c2e856631"
   integrity sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==
@@ -13779,17 +13779,17 @@ listr2@^5.0.7:
     through "^2.3.8"
     wrap-ansi "^7.0.0"
 
-live-connect-common@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/live-connect-common/-/live-connect-common-1.0.0.tgz#9cb558cd665c0418271770854538243420cd1354"
-  integrity sha512-LBZsvykcGeVRYI1eqqXrrNZsoBdL2a8cpyrYPIiGAF/CpixbyRbvqGslaFw511lH294QB16J3fYYg21aYuaM2Q==
+live-connect-common@^v3.0.2:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/live-connect-common/-/live-connect-common-3.0.3.tgz#720ca29a22d59c8b26a0dac894bb4863b1b69627"
+  integrity sha512-ZPycT04ROBUvPiksnLTunrKC3ROhBSeO99fQ+4qMIkgKwP2CvS44L7fK+0WFV4nAi+65KbzSng7JWcSlckfw8w==
 
-live-connect-js@^5.0.0:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/live-connect-js/-/live-connect-js-5.0.1.tgz#152372cf757e8af8eb4829f32979669b26cd9052"
-  integrity sha512-X/fFbKGG8MahpqIuxndApAc9udj1g5NIxL95zKPzvqoipPYoeqvh7SCDly1hPvbqsfFj/DIbOfdWbttXzCSryw==
+live-connect-js@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/live-connect-js/-/live-connect-js-6.3.0.tgz#032d6015969293774430872d4d22ca8bae8ff2c9"
+  integrity sha512-1SnXQZq9gxHIb0scXPX1Da1rQ0oY2sloMGgeRreTAwhCtdQEuip/IYwgOh3/ZeZ6yT6iG9FLb7+AjORC4pO46g==
   dependencies:
-    live-connect-common "^1.0.0"
+    live-connect-common "^v3.0.2"
     tiny-hashes "1.0.1"
 
 load-json-file@6.2.0:
@@ -15698,9 +15698,9 @@ preact@10.15.1:
   resolved "https://registry.yarnpkg.com/preact/-/preact-10.15.1.tgz#a1de60c9fc0c79a522d969c65dcaddc5d994eede"
   integrity sha512-qs2ansoQEwzNiV5eAcRT1p1EC/dmEzaATVDJNiB3g2sRDWdA7b7MurXdJjB2+/WQktGWZwxvDrnuRFbWuIr64g==
 
-prebid.js@guardian/prebid.js#0b4cccd55ab4e170b36bb944e9bdd2807a9da1c5:
-  version "7.54.5"
-  resolved "https://codeload.github.com/guardian/prebid.js/tar.gz/0b4cccd55ab4e170b36bb944e9bdd2807a9da1c5"
+prebid.js@guardian/prebid.js#ee7f43c7c85a5245bbe51920cfed18818866ea7b:
+  version "8.24.0"
+  resolved "https://codeload.github.com/guardian/prebid.js/tar.gz/ee7f43c7c85a5245bbe51920cfed18818866ea7b"
   dependencies:
     "@babel/core" "^7.23.2"
     "@babel/plugin-transform-runtime" "^7.18.9"
@@ -15710,13 +15710,13 @@ prebid.js@guardian/prebid.js#0b4cccd55ab4e170b36bb944e9bdd2807a9da1c5:
     core-js "^3.13.0"
     core-js-pure "^3.13.0"
     criteo-direct-rsa-validate "^1.1.0"
-    crypto-js "^3.3.0"
+    crypto-js "^4.2.0"
     dlv "1.1.3"
     dset "3.1.2"
     express "^4.15.4"
     fun-hooks "^0.9.9"
     just-clone "^1.0.2"
-    live-connect-js "^5.0.0"
+    live-connect-js "^6.3.0"
   optionalDependencies:
     fsevents "^2.3.2"
 


### PR DESCRIPTION
## What does this change?

Bump `@guardian/commercial@11.25.0`

Should also remove the `crypto-js` CVE and stop the flip-flopping of yarn.lock updates
