### PR TITLE
Fix asset paths when using `dev-nginx`

### DIFF
--- a/dotcom-rendering/src/lib/assets.ts
+++ b/dotcom-rendering/src/lib/assets.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
-import { isObject, isString } from '@guardian/libs';
+import { isObject, isString, isUndefined } from '@guardian/libs';
 import { BUILD_VARIANT, dcrJavascriptBundle } from '../../webpack/bundles';
 import type { ServerSideTests, Switches } from '../types/config';
 import { makeMemoizedFunction } from './memoize';
@@ -25,7 +25,7 @@ export const decideAssetOrigin = (
 		case 'CODE':
 			return 'https://assets-code.guim.co.uk/';
 		default: {
-			if (isDev && process.env.HOSTNAME === undefined) {
+			if (isDev && isUndefined(process.env.HOSTNAME)) {
 				// Use absolute asset paths in development mode
 				// This is so paths are correct when treated as relative to Frontend
 				return 'http://localhost:3030/';

--- a/dotcom-rendering/src/lib/assets.ts
+++ b/dotcom-rendering/src/lib/assets.ts
@@ -25,7 +25,7 @@ export const decideAssetOrigin = (
 		case 'CODE':
 			return 'https://assets-code.guim.co.uk/';
 		default: {
-			if (isDev) {
+			if (isDev && process.env.HOSTNAME === undefined) {
 				// Use absolute asset paths in development mode
 				// This is so paths are correct when treated as relative to Frontend
 				return 'http://localhost:3030/';


### PR DESCRIPTION
## What does this change?

This PR ensures that assets can be successfully retrieved when using DCR behind a dev NGINX server.

## Why?

It can sometimes be useful to run DCR locally behind NGINX, setup with the domain `r.thegulocal.com`. For example, when developing for the Youtube IMA SDK, only certain domains are allow-listed, and so `localhost` isn't suitable.

This PR fixes the asset paths so they are relative, ensuring we don't get CORS errors when attempting to fetch assets from different origins to the NGINX server.
