### PR TITLE
Add support for newsletter pages on DCAR

### DIFF
--- a/dotcom-rendering/src/components/AppEmailSignUp.tsx
+++ b/dotcom-rendering/src/components/AppEmailSignUp.tsx
@@ -1,9 +1,9 @@
-import { useIsBridgetCompatible } from '../lib/useIsBridgetCompatible';
 import type { EmailSignUpProps } from './EmailSignup';
 import { EmailSignup } from './EmailSignup';
 import { InlineSkipToWrapper } from './InlineSkipToWrapper';
+import { Island } from './Island';
 import { NewsletterPrivacyMessage } from './NewsletterPrivacyMessage';
-import { SecureReCAPTCHASignup } from './SecureReCAPTCHASignup';
+import { SecureReCAPTCHASignup } from './SecureReCAPTCHASignup.importable';
 
 interface AppEmailSignupProps extends EmailSignUpProps {
 	skipToIndex: number;
@@ -17,22 +17,18 @@ export const AppEmailSignUp = ({
 	skipToIndex,
 	...emailSignUpProps
 }: AppEmailSignupProps) => {
-	const isCompatible = useIsBridgetCompatible();
-
-	if (!isCompatible) {
-		return null;
-	}
-
 	return (
 		<InlineSkipToWrapper
 			id={`EmailSignup-skip-link-${skipToIndex}`}
 			blockDescription="newsletter promotion"
 		>
 			<EmailSignup {...emailSignUpProps}>
-				<SecureReCAPTCHASignup
-					newsletterId={emailSignUpProps.identityName}
-					successDescription={emailSignUpProps.successDescription}
-				/>
+				<Island priority="feature" defer={{ until: 'idle' }}>
+					<SecureReCAPTCHASignup
+						newsletterId={emailSignUpProps.identityName}
+						successDescription={emailSignUpProps.successDescription}
+					/>
+				</Island>
 				{!emailSignUpProps.hidePrivacyMessage && (
 					<NewsletterPrivacyMessage />
 				)}

--- a/dotcom-rendering/src/components/EmailSignUpSwitcher.tsx
+++ b/dotcom-rendering/src/components/EmailSignUpSwitcher.tsx
@@ -1,7 +1,6 @@
-import { AppEmailSignUp } from './AppEmailSignUp.importable';
+import { AppEmailSignUp } from './AppEmailSignUp';
 import { useConfig } from './ConfigContext';
 import type { EmailSignUpProps } from './EmailSignup';
-import { Island } from './Island';
 import { WebEmailSignUp } from './WebEmailSignup';
 
 interface EmailSignUpSwitcherProps extends EmailSignUpProps {
@@ -19,12 +18,8 @@ export const EmailSignUpSwitcher = ({
 	const { renderingTarget } = useConfig();
 
 	return renderingTarget === 'Apps' ? (
-		<Island priority="feature" defer={{ until: 'idle' }}>
-			<AppEmailSignUp skipToIndex={index} {...emailSignUpProps} />
-		</Island>
+		<AppEmailSignUp skipToIndex={index} {...emailSignUpProps} />
 	) : (
-		<>
-			<WebEmailSignUp index={index} {...emailSignUpProps} />
-		</>
+		<WebEmailSignUp index={index} {...emailSignUpProps} />
 	);
 };

--- a/dotcom-rendering/src/components/Island.test.tsx
+++ b/dotcom-rendering/src/components/Island.test.tsx
@@ -6,7 +6,6 @@ import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
 import { renderToString } from 'react-dom/server';
 import { AdPortals } from './AdPortals.importable';
 import { AlreadyVisited } from './AlreadyVisited.importable';
-import { AppEmailSignUp } from './AppEmailSignUp.importable';
 import { AppsEpic } from './AppsEpic.importable';
 import { BrazeMessaging } from './BrazeMessaging.importable';
 import { CardCommentCount } from './CardCommentCount.importable';
@@ -83,22 +82,6 @@ describe('Island: server-side rendering', () => {
 
 	test('AlreadyVisited', () => {
 		expect(() => renderToString(<AlreadyVisited />)).not.toThrow();
-	});
-
-	test('AppEmailSignup', () => {
-		expect(() =>
-			renderToString(
-				<AppEmailSignUp
-					skipToIndex={0}
-					identityName={''}
-					successDescription={''}
-					name={''}
-					description={''}
-					frequency={''}
-					theme={''}
-				/>,
-			),
-		).not.toThrow();
 	});
 
 	test('AppsEpic', () => {

--- a/dotcom-rendering/src/components/SecureReCAPTCHASignup.importable.tsx
+++ b/dotcom-rendering/src/components/SecureReCAPTCHASignup.importable.tsx
@@ -284,24 +284,22 @@ export const SecureReCAPTCHASignup = ({
 		const emailAddress: string = input?.value ?? '';
 
 		sendTracking(newsletterId, 'form-submission', renderingTarget);
-		if (renderingTarget === 'Web') {
-			const response = await postFormData(
-				window.guardian.config.page.ajaxUrl + '/email',
-				buildFormData(emailAddress, newsletterId, token),
-			);
+		const response = await postFormData(
+			window.guardian.config.page.ajaxUrl + '/email',
+			buildFormData(emailAddress, newsletterId, token),
+		);
 
-			// The response body could be accessed with await response.text()
-			// here and added to state but the response is not informative
-			// enough to convey the actualreason for a failure to the user,
-			// so a generic failure message is used.
-			setIsWaitingForResponse(false);
-			setResponseOk(response.ok);
-			sendTracking(
-				newsletterId,
-				response.ok ? 'submission-confirmed' : 'submission-failed',
-				renderingTarget,
-			);
-		}
+		// The response body could be accessed with await response.text()
+		// here and added to state but the response is not informative
+		// enough to convey the actualreason for a failure to the user,
+		// so a generic failure message is used.
+		setIsWaitingForResponse(false);
+		setResponseOk(response.ok);
+		sendTracking(
+			newsletterId,
+			response.ok ? 'submission-confirmed' : 'submission-failed',
+			renderingTarget,
+		);
 	};
 
 	const resetForm: ReactEventHandler<HTMLButtonElement> = () => {

--- a/dotcom-rendering/src/layouts/DecideLayout.tsx
+++ b/dotcom-rendering/src/layouts/DecideLayout.tsx
@@ -116,8 +116,13 @@ const DecideLayoutApps = ({ article, format, renderingTarget }: AppProps) => {
 						/>
 					);
 				case ArticleDesign.NewsletterSignup:
-					// Should be NewsletterSignup once implemented for apps
-					return notSupported;
+					return (
+						<NewsletterSignupLayout
+							article={article}
+							format={format}
+							renderingTarget={renderingTarget}
+						/>
+					);
 				default:
 					return (
 						<StandardLayout
@@ -257,6 +262,7 @@ const DecideLayoutWeb = ({
 							article={article}
 							NAV={NAV}
 							format={format}
+							renderingTarget={renderingTarget}
 						/>
 					);
 				default:

--- a/dotcom-rendering/src/layouts/NewsletterSignupLayout.tsx
+++ b/dotcom-rendering/src/layouts/NewsletterSignupLayout.tsx
@@ -35,7 +35,7 @@ import { NewsletterFrequency } from '../components/NewsletterFrequency';
 import { NewsletterPrivacyMessage } from '../components/NewsletterPrivacyMessage';
 import { OnwardsUpper } from '../components/OnwardsUpper.importable';
 import { Section } from '../components/Section';
-import { SecureReCAPTCHASignup } from '../components/SecureReCAPTCHASignup';
+import { SecureReCAPTCHASignup } from '../components/SecureReCAPTCHASignup.importable';
 import { SecureSignup } from '../components/SecureSignup';
 import { ShareIcons } from '../components/ShareIcons';
 import { Standfirst } from '../components/Standfirst';
@@ -47,7 +47,7 @@ import { isValidUrl } from '../lib/isValidUrl';
 import type { NavType } from '../model/extract-nav';
 import { palette as themePalette } from '../palette';
 import type { DCRArticle } from '../types/frontend';
-import { RenderingTarget } from '../types/renderingTarget';
+import type { RenderingTarget } from '../types/renderingTarget';
 import { BannerWrapper, Stuck } from './lib/stickiness';
 
 interface CommonProps {

--- a/dotcom-rendering/src/layouts/NewsletterSignupLayout.tsx
+++ b/dotcom-rendering/src/layouts/NewsletterSignupLayout.tsx
@@ -20,6 +20,7 @@ import {
 } from '@guardian/source-react-components';
 import { StraightLines } from '@guardian/source-react-components-development-kitchen';
 import { AdSlot, MobileStickyContainer } from '../components/AdSlot.web';
+import { AppsFooter } from '../components/AppsFooter.importable';
 import { ArticleHeadline } from '../components/ArticleHeadline';
 import { Carousel } from '../components/Carousel.importable';
 import { Footer } from '../components/Footer';
@@ -34,6 +35,7 @@ import { NewsletterFrequency } from '../components/NewsletterFrequency';
 import { NewsletterPrivacyMessage } from '../components/NewsletterPrivacyMessage';
 import { OnwardsUpper } from '../components/OnwardsUpper.importable';
 import { Section } from '../components/Section';
+import { SecureReCAPTCHASignup } from '../components/SecureReCAPTCHASignup';
 import { SecureSignup } from '../components/SecureSignup';
 import { ShareIcons } from '../components/ShareIcons';
 import { Standfirst } from '../components/Standfirst';
@@ -45,13 +47,23 @@ import { isValidUrl } from '../lib/isValidUrl';
 import type { NavType } from '../model/extract-nav';
 import { palette as themePalette } from '../palette';
 import type { DCRArticle } from '../types/frontend';
+import { RenderingTarget } from '../types/renderingTarget';
 import { BannerWrapper, Stuck } from './lib/stickiness';
 
-type Props = {
+interface CommonProps {
 	article: DCRArticle;
-	NAV: NavType;
 	format: ArticleFormat;
-};
+	renderingTarget: RenderingTarget;
+}
+
+interface WebProps extends CommonProps {
+	NAV: NavType;
+	renderingTarget: 'Web';
+}
+
+interface AppsProps extends CommonProps {
+	renderingTarget: 'Apps';
+}
 
 const mainColWrapperStyle = css`
 	display: flex;
@@ -186,7 +198,11 @@ const getMainMediaCaptions = (article: DCRArticle): (string | undefined)[] =>
 			: undefined,
 	);
 
-export const NewsletterSignupLayout = ({ article, NAV, format }: Props) => {
+export const NewsletterSignupLayout = (props: WebProps | AppsProps) => {
+	const { article, format, renderingTarget } = props;
+	const isWeb = renderingTarget === 'Web';
+	const isApps = renderingTarget === 'Apps';
+
 	const {
 		promotedNewsletter,
 		config: { host },
@@ -213,122 +229,139 @@ export const NewsletterSignupLayout = ({ article, NAV, format }: Props) => {
 
 	return (
 		<>
-			<div data-print-layout="hide" id="bannerandheader">
-				{renderAds && (
-					<Stuck>
+			{isWeb && (
+				<>
+					<div data-print-layout="hide" id="bannerandheader">
+						{renderAds && (
+							<Stuck>
+								<Section
+									fullWidth={true}
+									showTopBorder={false}
+									showSideBorders={false}
+									padSides={false}
+									shouldCenter={false}
+								>
+									<HeaderAdSlot />
+								</Section>
+							</Stuck>
+						)}
+
 						<Section
 							fullWidth={true}
+							shouldCenter={false}
 							showTopBorder={false}
 							showSideBorders={false}
 							padSides={false}
-							shouldCenter={false}
+							backgroundColour={sourcePalette.brand[400]}
+							element="header"
 						>
-							<HeaderAdSlot />
-						</Section>
-					</Stuck>
-				)}
-
-				<Section
-					fullWidth={true}
-					shouldCenter={false}
-					showTopBorder={false}
-					showSideBorders={false}
-					padSides={false}
-					backgroundColour={sourcePalette.brand[400]}
-					element="header"
-				>
-					<Header
-						editionId={article.editionId}
-						idUrl={article.config.idUrl}
-						mmaUrl={article.config.mmaUrl}
-						discussionApiUrl={article.config.discussionApiUrl}
-						urls={article.nav.readerRevenueLinks.header}
-						remoteHeader={!!article.config.switches.remoteHeader}
-						contributionsServiceUrl={contributionsServiceUrl}
-						idApiUrl={article.config.idApiUrl}
-						headerTopBarSearchCapiSwitch={
-							!!article.config.switches.headerTopBarSearchCapi
-						}
-					/>
-				</Section>
-
-				<Section
-					fullWidth={true}
-					borderColour={sourcePalette.brand[600]}
-					showTopBorder={false}
-					padSides={false}
-					backgroundColour={sourcePalette.brand[400]}
-					element="nav"
-				>
-					<Nav
-						nav={NAV}
-						isImmersive={
-							format.display === ArticleDisplay.Immersive
-						}
-						displayRoundel={
-							format.display === ArticleDisplay.Immersive ||
-							format.theme === ArticleSpecial.Labs
-						}
-						selectedPillar={NAV.selectedPillar}
-						subscribeUrl={
-							article.nav.readerRevenueLinks.header.subscribe
-						}
-						editionId={article.editionId}
-						headerTopBarSwitch={
-							!!article.config.switches.headerTopNav
-						}
-					/>
-				</Section>
-
-				{!!NAV.subNavSections && (
-					<>
-						<Section
-							fullWidth={true}
-							backgroundColour={themePalette(
-								'--article-background',
-							)}
-							padSides={false}
-							showTopBorder={false}
-							element="aside"
-						>
-							<Island
-								priority="enhancement"
-								defer={{ until: 'idle' }}
-							>
-								<SubNav
-									subNavSections={NAV.subNavSections}
-									currentNavLink={NAV.currentNavLink}
-									linkHoverColour={themePalette(
-										'--article-link-text-hover',
-									)}
-									borderColour={themePalette(
-										'--sub-nav-border',
-									)}
-								/>
-							</Island>
-						</Section>
-						<Section
-							fullWidth={true}
-							backgroundColour={themePalette(
-								'--article-background',
-							)}
-							padSides={false}
-							showTopBorder={false}
-						>
-							<StraightLines
-								count={4}
-								cssOverrides={css`
-									display: block;
-								`}
-								color={themePalette('--straight-lines')}
+							<Header
+								editionId={article.editionId}
+								idUrl={article.config.idUrl}
+								mmaUrl={article.config.mmaUrl}
+								discussionApiUrl={
+									article.config.discussionApiUrl
+								}
+								urls={article.nav.readerRevenueLinks.header}
+								remoteHeader={
+									!!article.config.switches.remoteHeader
+								}
+								contributionsServiceUrl={
+									contributionsServiceUrl
+								}
+								idApiUrl={article.config.idApiUrl}
+								headerTopBarSearchCapiSwitch={
+									!!article.config.switches
+										.headerTopBarSearchCapi
+								}
 							/>
 						</Section>
-					</>
-				)}
-			</div>
 
-			{renderAds && !!article.config.switches.surveys && (
-				<AdSlot position="survey" display={format.display} />
+						<Section
+							fullWidth={true}
+							borderColour={sourcePalette.brand[600]}
+							showTopBorder={false}
+							padSides={false}
+							backgroundColour={sourcePalette.brand[400]}
+							element="nav"
+						>
+							<Nav
+								nav={props.NAV}
+								isImmersive={
+									format.display === ArticleDisplay.Immersive
+								}
+								displayRoundel={
+									format.display ===
+										ArticleDisplay.Immersive ||
+									format.theme === ArticleSpecial.Labs
+								}
+								selectedPillar={props.NAV.selectedPillar}
+								subscribeUrl={
+									article.nav.readerRevenueLinks.header
+										.subscribe
+								}
+								editionId={article.editionId}
+								headerTopBarSwitch={
+									!!article.config.switches.headerTopNav
+								}
+							/>
+						</Section>
+
+						{!!props.NAV.subNavSections && (
+							<>
+								<Section
+									fullWidth={true}
+									backgroundColour={themePalette(
+										'--article-background',
+									)}
+									padSides={false}
+									showTopBorder={false}
+									element="aside"
+								>
+									<Island
+										priority="enhancement"
+										defer={{ until: 'idle' }}
+									>
+										<SubNav
+											subNavSections={
+												props.NAV.subNavSections
+											}
+											currentNavLink={
+												props.NAV.currentNavLink
+											}
+											linkHoverColour={themePalette(
+												'--article-link-text-hover',
+											)}
+											borderColour={themePalette(
+												'--sub-nav-border',
+											)}
+										/>
+									</Island>
+								</Section>
+								<Section
+									fullWidth={true}
+									backgroundColour={themePalette(
+										'--article-background',
+									)}
+									padSides={false}
+									showTopBorder={false}
+								>
+									<StraightLines
+										count={4}
+										cssOverrides={css`
+											display: block;
+										`}
+										color={themePalette('--straight-lines')}
+									/>
+								</Section>
+							</>
+						)}
+					</div>
+
+					{renderAds && !!article.config.switches.surveys && (
+						<AdSlot position="survey" display={format.display} />
+					)}
+				</>
 			)}
 
 			<main data-layout="NewsletterSignupLayout">
@@ -445,17 +478,33 @@ export const NewsletterSignupLayout = ({ article, NAV, format }: Props) => {
 										/>
 									</div>
 
-									<SecureSignup
-										name={promotedNewsletter.name}
-										newsletterId={
-											promotedNewsletter.identityName
-										}
-										successDescription={
-											promotedNewsletter.successDescription
-										}
-										hidePrivacyMessage={true}
-									/>
-
+									{isApps && (
+										<Island
+											priority="feature"
+											defer={{ until: 'idle' }}
+										>
+											<SecureReCAPTCHASignup
+												newsletterId={
+													promotedNewsletter.identityName
+												}
+												successDescription={
+													promotedNewsletter.successDescription
+												}
+											/>
+										</Island>
+									)}
+									{isWeb && (
+										<SecureSignup
+											name={promotedNewsletter.name}
+											newsletterId={
+												promotedNewsletter.identityName
+											}
+											successDescription={
+												promotedNewsletter.successDescription
+											}
+											hidePrivacyMessage={true}
+										/>
+									)}
 									<Hide from="desktop">
 										<NewsletterPrivacyMessage />
 									</Hide>
@@ -543,29 +592,48 @@ export const NewsletterSignupLayout = ({ article, NAV, format }: Props) => {
 					/>
 				</Island>
 			</main>
+			{isWeb && (
+				<>
+					<Section
+						fullWidth={true}
+						data-print-layout="hide"
+						padSides={false}
+						showTopBorder={false}
+						backgroundColour={sourcePalette.brand[400]}
+						borderColour={sourcePalette.brand[600]}
+						showSideBorders={false}
+						element="footer"
+					>
+						<Footer
+							pageFooter={article.pageFooter}
+							selectedPillar={props.NAV.selectedPillar}
+							pillars={props.NAV.pillars}
+							urls={article.nav.readerRevenueLinks.header}
+							editionId={article.editionId}
+							contributionsServiceUrl={
+								article.contributionsServiceUrl
+							}
+						/>
+					</Section>
 
-			<Section
-				fullWidth={true}
-				data-print-layout="hide"
-				padSides={false}
-				showTopBorder={false}
-				backgroundColour={sourcePalette.brand[400]}
-				borderColour={sourcePalette.brand[600]}
-				showSideBorders={false}
-				element="footer"
-			>
-				<Footer
-					pageFooter={article.pageFooter}
-					selectedPillar={NAV.selectedPillar}
-					pillars={NAV.pillars}
-					urls={article.nav.readerRevenueLinks.header}
-					editionId={article.editionId}
-					contributionsServiceUrl={article.contributionsServiceUrl}
-				/>
-			</Section>
-
-			<BannerWrapper data-print-layout="hide" />
-			<MobileStickyContainer data-print-layout="hide" />
+					<BannerWrapper data-print-layout="hide" />
+					<MobileStickyContainer data-print-layout="hide" />
+				</>
+			)}
+			{isApps && (
+				<Section
+					fullWidth={true}
+					data-print-layout="hide"
+					backgroundColour={themePalette('--apps-footer-background')}
+					padSides={false}
+					showSideBorders={false}
+					element="footer"
+				>
+					<Island priority="critical">
+						<AppsFooter />
+					</Island>
+				</Section>
+			)}
 		</>
 	);
 };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Adds support for the newsletters page for 
## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
