### PR TITLE
Contain layout on Front secions

### DIFF
--- a/dotcom-rendering/src/components/FrontSection.tsx
+++ b/dotcom-rendering/src/components/FrontSection.tsx
@@ -120,6 +120,7 @@ const fallbackStyles = css`
 `;
 
 const containerStylesUntilLeftCol = css`
+	contain: layout;
 	display: grid;
 
 	grid-template-rows:


### PR DESCRIPTION
this fixes a bug in Firefox and helps
the browser make the rendering of sections
faster

<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Assert that Front sections contain their layout.

See https://developer.mozilla.org/en-US/docs/Web/CSS/contain

## Why?

Fixes a bug in Firefox.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/76776/db3123fb-2d25-49d3-9b3b-0b639ed228c4
[after]: https://github.com/guardian/dotcom-rendering/assets/76776/2de6fe72-912b-4df1-bb6d-8a7bf694ef06