### PR TITLE
Fix labeler v5 format

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,4 +1,8 @@
 # https://github.com/marketplace/actions/labeler
 
-dotcom-rendering: dotcom-rendering/**/*
-apps-rendering: apps-rendering/**/*
+dotcom-rendering:
+  - changed-files:
+      - any-glob-to-any-file: 'dotcom-rendering/**/*'
+apps-rendering:
+  - changed-files:
+      - any-glob-to-any-file: 'apps-rendering/**/*'


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Update the Yaml

## Why?

It broke when we (I) updated in #9766 