### PR TITLE
Dark Mode For Audio Atoms

### DIFF
--- a/dotcom-rendering/src/components/AudioAtom/AudioAtom.stories.tsx
+++ b/dotcom-rendering/src/components/AudioAtom/AudioAtom.stories.tsx
@@ -1,80 +1,24 @@
-import { css } from '@emotion/react';
-import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
-import { AudioAtom } from './AudioAtom';
+import { AudioAtom as AudioAtomComponent } from './AudioAtom';
+import type { Meta, StoryObj } from '@storybook/react';
+import { splitTheme } from '../../../.storybook/decorators/splitThemeDecorator';
 
-export default {
-	title: 'Components/AudioAtom',
-	component: AudioAtom,
+const meta: Meta<typeof AudioAtomComponent> = {
+	title: 'Components/Audio Atom',
+	component: AudioAtomComponent,
 };
 
-export const SportStory = (): JSX.Element => {
-	return (
-		<div
-			css={css`
-				width: 700px;
-				padding: 15px;
-			`}
-		>
-			<AudioAtom
-				id="d6d509cf-ca10-407f-8913-e16a3712f415"
-				trackUrl="https://audio.guim.co.uk/2020/05/05-61553-gnl.fw.200505.jf.ch7DW.mp3"
-				kicker="Football Weekly Extra Extra"
-				title="Q&A and Detective Wilson"
-				format={{
-					display: ArticleDisplay.Standard,
-					design: ArticleDesign.Standard,
-					theme: Pillar.Sport,
-				}}
-				duration={849}
-			/>
-		</div>
-	);
+type Story = StoryObj<typeof AudioAtomComponent>;
+
+export const AudioAtom: Story = {
+	args: {
+		id: 'd6d509cf-ca10-407f-8913-e16a3712f415',
+		trackUrl:
+			'https://audio.guim.co.uk/2020/05/05-61553-gnl.fw.200505.jf.ch7DW.mp3',
+		kicker: 'Football Weekly Extra Extra',
+		title: 'Q&A and Detective Wilson',
+		duration: 849,
+	},
+	decorators: [splitTheme()],
 };
 
-export const NewsStory = (): JSX.Element => {
-	return (
-		<div
-			css={css`
-				width: 700px;
-				padding: 15px;
-			`}
-		>
-			<AudioAtom
-				id="d6d509cf-ca10-407f-8913-e16a3712f415"
-				trackUrl="https://audio.guim.co.uk/2020/05/05-61553-gnl.fw.200505.jf.ch7DW.mp3"
-				kicker="Football Weekly Extra Extra"
-				title="Q&A and Detective Wilson"
-				format={{
-					display: ArticleDisplay.Standard,
-					design: ArticleDesign.Standard,
-					theme: Pillar.News,
-				}}
-				duration={849}
-			/>
-		</div>
-	);
-};
-
-export const CultureStory = (): JSX.Element => {
-	return (
-		<div
-			css={css`
-				width: 700px;
-				padding: 15px;
-			`}
-		>
-			<AudioAtom
-				id="d6d509cf-ca10-407f-8913-e16a3712f415"
-				trackUrl="https://audio.guim.co.uk/2020/05/05-61553-gnl.fw.200505.jf.ch7DW.mp3"
-				kicker="Football Weekly Extra Extra"
-				title="Q&A and Detective Wilson"
-				format={{
-					display: ArticleDisplay.Standard,
-					design: ArticleDesign.Standard,
-					theme: Pillar.Culture,
-				}}
-				duration={849}
-			/>
-		</div>
-	);
-};
+export default meta;

--- a/dotcom-rendering/src/components/AudioAtom/AudioAtom.stories.tsx
+++ b/dotcom-rendering/src/components/AudioAtom/AudioAtom.stories.tsx
@@ -1,6 +1,6 @@
-import { AudioAtom as AudioAtomComponent } from './AudioAtom';
 import type { Meta, StoryObj } from '@storybook/react';
 import { splitTheme } from '../../../.storybook/decorators/splitThemeDecorator';
+import { AudioAtom as AudioAtomComponent } from './AudioAtom';
 
 const meta: Meta<typeof AudioAtomComponent> = {
 	title: 'Components/Audio Atom',

--- a/dotcom-rendering/src/components/AudioAtom/AudioAtom.tsx
+++ b/dotcom-rendering/src/components/AudioAtom/AudioAtom.tsx
@@ -1,26 +1,21 @@
 import { css } from '@emotion/react';
-import {
-	focusHalo,
-	headline,
-	neutral,
-	textSans,
-} from '@guardian/source-foundations';
+import { focusHalo, headline, textSans } from '@guardian/source-foundations';
 import type { MouseEvent } from 'react';
 import { useEffect, useRef, useState } from 'react';
-import { decidePalette } from '../../lib/decidePalette';
+import { palette } from '../../palette';
 
 const wrapperStyles = css`
 	width: 100%;
 	border-image: repeating-linear-gradient(
 			to bottom,
-			${neutral[86]},
-			${neutral[86]} 1px,
+			${palette('--audio-atom-border')},
+			${palette('--audio-atom-border')} 1px,
 			transparent 1px,
 			transparent 4px
 		)
 		13;
 	border-top: 13px solid black;
-	background-color: ${neutral[97]};
+	background-color: ${palette('--audio-atom-background')};
 	position: relative;
 	padding-left: 5px;
 	padding-right: 5px;
@@ -28,8 +23,8 @@ const wrapperStyles = css`
 	margin: 16px 0 36px;
 `;
 
-const kickerStyle = (color: string) => css`
-	color: ${color};
+const kickerStyle = css`
+	color: ${palette('--audio-atom-kicker')};
 	${headline.xxxsmall({ fontWeight: 'bold' })};
 `;
 
@@ -98,10 +93,14 @@ const progressBarStyle = css`
 	display: block;
 `;
 
-const progressBarInputStyle = (color: string) => css`
+const progressBarInputStyle = css`
 	width: 100%;
 	appearance: none;
-	background-image: linear-gradient(to right, ${color} 0%, ${neutral[60]} 0%);
+	background-image: linear-gradient(
+		to right,
+		${palette('--audio-atom-icons')} 0%,
+		${palette('--audio-atom-progress-bar')} 0%
+	);
 	height: 6px;
 	outline: 0;
 	cursor: pointer;
@@ -113,21 +112,21 @@ const progressBarInputStyle = (color: string) => css`
 
 	/* Use the pillar to style the colour of the range thumb */
 	&::-webkit-slider-thumb {
-		background: ${color};
+		background: ${palette('--audio-atom-icons')};
 		-webkit-appearance: none; /* stylelint-disable-line property-no-vendor-prefix */
 		width: 14px;
 		height: 14px;
 		border-radius: 50px;
 	}
 	&::-moz-range-thumb {
-		background: ${color};
+		background: ${palette('--audio-atom-icons')};
 		width: 14px;
 		height: 14px;
 		border: none;
 		border-radius: 50px;
 	}
 	&::-ms-thumb {
-		background: ${color};
+		background: ${palette('--audio-atom-icons')};
 		width: 14px;
 		height: 14px;
 		border: none;
@@ -155,24 +154,34 @@ const formatTime = (t: number) => {
 	return `${formatNum(hour)}:${formatNum(minute)}:${formatNum(second)}`;
 };
 
-const PauseSVG = ({ circleFill }: { circleFill: string }) => (
+const PauseSVG = () => (
 	<svg css={svgPauseStyle} width="30px" height="30px" viewBox="0 0 30 30">
 		<g fill="none" fillRule="evenodd">
-			<circle fill={circleFill} cx="15" cy="15" r="15"></circle>
+			<circle
+				fill={palette('--audio-atom-icons')}
+				cx="15"
+				cy="15"
+				r="15"
+			></circle>
 			<path
 				d="M9.429 7.286h3.429v15.429h-3.43zm7.286 0h3.429v15.429h-3.43z"
-				fill={neutral[100]}
+				fill={palette('--audio-atom-background')}
 			></path>
 		</g>
 	</svg>
 );
 
-const PlaySVG = ({ circleFill }: { circleFill: string }) => (
+const PlaySVG = () => (
 	<svg css={svgPlayStyle} width="30px" height="30px" viewBox="0 0 30 30">
 		<g fill="none" fillRule="evenodd">
-			<circle fill={circleFill} cx="15" cy="15" r="15"></circle>
+			<circle
+				fill={palette('--audio-atom-icons')}
+				cx="15"
+				cy="15"
+				r="15"
+			></circle>
 			<path
-				fill={neutral[100]}
+				fill={palette('--audio-atom-background')}
 				d="M10.113 8.571l-.47.366V20.01l.472.347 13.456-5.593v-.598z"
 			></path>
 		</g>
@@ -206,7 +215,6 @@ export const AudioAtom = ({
 }: Props): JSX.Element => {
 	const audioEl = useRef<HTMLAudioElement>(null);
 	const [isPlaying, setIsPlaying] = useState<boolean>(false);
-	const palette = decidePalette(format);
 
 	// update current time and progress bar position
 	const [currentTime, setCurrentTime] = useState<number>(0);
@@ -320,9 +328,7 @@ export const AudioAtom = ({
 					padding-left: 5px;
 				`}
 			>
-				<span css={kickerStyle(palette.background.audioAtom)}>
-					{kicker}
-				</span>
+				<span css={kickerStyle}>{kicker}</span>
 				<h4 css={titleStyle}>{title}</h4>
 			</div>
 			<div css={audioBodyStyle}>
@@ -349,15 +355,7 @@ export const AudioAtom = ({
 						onClick={() => (isPlaying ? pauseAudio() : playAudio())}
 						css={buttonStyle}
 					>
-						{isPlaying ? (
-							<PauseSVG
-								circleFill={palette.background.audioAtom}
-							/>
-						) : (
-							<PlaySVG
-								circleFill={palette.background.audioAtom}
-							/>
-						)}
+						{isPlaying ? <PauseSVG /> : <PlaySVG />}
 					</button>
 				</div>
 				<div css={timingStyle}>
@@ -366,9 +364,7 @@ export const AudioAtom = ({
 					</div>
 					<div css={progressBarStyle}>
 						<input
-							css={progressBarInputStyle(
-								palette.background.audioAtom,
-							)}
+							css={progressBarInputStyle}
 							ref={progressBarEl}
 							type="range"
 							min="0"

--- a/dotcom-rendering/src/lib/decidePalette.ts
+++ b/dotcom-rendering/src/lib/decidePalette.ts
@@ -508,27 +508,6 @@ const backgroundDesignTag = (format: ArticleFormat): string => {
 	}
 };
 
-const backgroundAudioAtom = (format: ArticleFormat) => {
-	switch (format.theme) {
-		case Pillar.News:
-			return news[400];
-		case Pillar.Lifestyle:
-			return lifestyle[400];
-		case Pillar.Sport:
-			return sport[400];
-		case Pillar.Culture:
-			return culture[400];
-		case Pillar.Opinion:
-			return opinion[400];
-		case ArticleSpecial.Labs:
-			return lifestyle[400];
-		case ArticleSpecial.SpecialReport:
-			return news[400];
-		case ArticleSpecial.SpecialReportAlt:
-			return news[400];
-	}
-};
-
 const textExpandableAtom = (format: ArticleFormat) => {
 	switch (format.theme) {
 		case Pillar.News:
@@ -623,7 +602,6 @@ export const decidePalette = (
 		background: {
 			analysisContrast: backgroundAnalysisContrastColour(),
 			analysisContrastHover: backgroundAnalysisContrastHoverColour(),
-			audioAtom: backgroundAudioAtom(format),
 			bullet: backgroundBullet(format),
 			bulletStandfirst: backgroundBulletStandfirst(format),
 			imageTitle: backgroundImageTitle(format),

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -4451,6 +4451,83 @@ const paginationTextLight: PaletteFunction = ({ theme }) => {
 };
 const paginationTextDark: PaletteFunction = () => sourcePalette.neutral[86];
 
+const audioAtomBackgroundLight: PaletteFunction = () =>
+	sourcePalette.neutral[97];
+const audioAtomBackgroundDark: PaletteFunction = () =>
+	sourcePalette.neutral[20];
+
+const audioAtomKickerLight: PaletteFunction = ({ theme }) => {
+	switch (theme) {
+		case Pillar.News:
+		case Pillar.Lifestyle:
+		case Pillar.Sport:
+		case Pillar.Culture:
+		case Pillar.Opinion:
+			return pillarPalette(theme, 400);
+		case ArticleSpecial.Labs:
+			return sourcePalette.lifestyle[400];
+		case ArticleSpecial.SpecialReport:
+		case ArticleSpecial.SpecialReportAlt:
+			return sourcePalette.news[400];
+	}
+};
+
+const audioAtomKickerDark: PaletteFunction = ({ theme }) => {
+	switch (theme) {
+		case Pillar.News:
+		case Pillar.Lifestyle:
+		case Pillar.Sport:
+		case Pillar.Culture:
+		case Pillar.Opinion:
+			return pillarPalette(theme, 500);
+		case ArticleSpecial.Labs:
+			return sourcePalette.lifestyle[500];
+		case ArticleSpecial.SpecialReport:
+		case ArticleSpecial.SpecialReportAlt:
+			return sourcePalette.news[500];
+	}
+};
+
+const audioAtomBorderLight: PaletteFunction = () => sourcePalette.neutral[86];
+const audioAtomBorderDark: PaletteFunction = () => sourcePalette.neutral[38];
+
+const audioAtomIconsLight: PaletteFunction = ({ theme }) => {
+	switch (theme) {
+		case Pillar.News:
+		case Pillar.Lifestyle:
+		case Pillar.Sport:
+		case Pillar.Culture:
+		case Pillar.Opinion:
+			return pillarPalette(theme, 400);
+		case ArticleSpecial.Labs:
+			return sourcePalette.lifestyle[400];
+		case ArticleSpecial.SpecialReport:
+		case ArticleSpecial.SpecialReportAlt:
+			return sourcePalette.news[400];
+	}
+};
+
+const audioAtomIconsDark: PaletteFunction = ({ theme }) => {
+	switch (theme) {
+		case Pillar.News:
+		case Pillar.Lifestyle:
+		case Pillar.Sport:
+		case Pillar.Culture:
+		case Pillar.Opinion:
+			return pillarPalette(theme, 500);
+		case ArticleSpecial.Labs:
+			return sourcePalette.lifestyle[500];
+		case ArticleSpecial.SpecialReport:
+		case ArticleSpecial.SpecialReportAlt:
+			return sourcePalette.news[500];
+	}
+};
+
+const audioAtomProgressBarLight: PaletteFunction = () =>
+	sourcePalette.neutral[60];
+const audioAtomProgressBarDark: PaletteFunction = () =>
+	sourcePalette.neutral[60];
+
 // ----- Palette ----- //
 
 /**
@@ -5209,6 +5286,26 @@ const paletteColours = {
 	'--pagination-text': {
 		light: paginationTextLight,
 		dark: paginationTextDark,
+	},
+	'--audio-atom-background': {
+		light: audioAtomBackgroundLight,
+		dark: audioAtomBackgroundDark,
+	},
+	'--audio-atom-kicker': {
+		light: audioAtomKickerLight,
+		dark: audioAtomKickerDark,
+	},
+	'--audio-atom-border': {
+		light: audioAtomBorderLight,
+		dark: audioAtomBorderDark,
+	},
+	'--audio-atom-icons': {
+		light: audioAtomIconsLight,
+		dark: audioAtomIconsDark,
+	},
+	'--audio-atom-progress-bar': {
+		light: audioAtomProgressBarLight,
+		dark: audioAtomProgressBarDark,
 	},
 } satisfies PaletteColours;
 

--- a/dotcom-rendering/src/types/palette.ts
+++ b/dotcom-rendering/src/types/palette.ts
@@ -22,7 +22,6 @@ export type Palette = {
 	background: {
 		analysisContrast: Colour;
 		analysisContrastHover: Colour;
-		audioAtom: Colour;
 		bullet: Colour;
 		bulletStandfirst: Colour;
 		imageTitle: Colour;


### PR DESCRIPTION
The audio atom now uses the new `palette` module for colours rather than `decidePalette`, and dark mode colours have been added.

This also updates the paths of the play/pause icons to use the background colour (i.e. appear transparent), rather than white, to match how other, similar icons appear elsewhere.

The stories have been updated to CSF 3, and now make use of the `splitTheme` decorator to generate multiple atoms, using different colour schemes and formats, in the same story.

This also removes an audio atom entry from `decidePalette`.

## Screenshots

### On An Article

![audio-atom-article](https://github.com/guardian/dotcom-rendering/assets/53781962/efa30f08-7e4e-442d-a87f-fff2295883b6)

### Stories

![audio-atoms](https://github.com/guardian/dotcom-rendering/assets/53781962/79d2b2a8-8e2a-4383-b66c-37cf22728c47)
