### PR TITLE
Add note about enabling Corepack per Node to `preinstall` script

### DIFF
--- a/scripts/preinstall.mjs
+++ b/scripts/preinstall.mjs
@@ -55,7 +55,7 @@ if (process.execPath?.includes('asdf')) {
 
 console.log(``);
 log(
-	`You will still be able to use ${packageManager} in other projects, as before.`,
+	`You will still be able to use ${packageManager} in other projects, but you will need to run 'corepack enable' in each version of Node you use.`,
 );
 log(`See https://github.com/nodejs/corepack for more information.`);
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

adds a note explaining that `corepack enable` needs to be run for each version of Node you use

## Why?

it wasn't clear from the instructions that that is the case

