### PR TITLE
Revert "Contain layout on Front sections"

### DIFF
--- a/dotcom-rendering/src/components/FrontSection.tsx
+++ b/dotcom-rendering/src/components/FrontSection.tsx
@@ -120,7 +120,6 @@ const fallbackStyles = css`
 `;
 
 const containerStylesUntilLeftCol = css`
-	contain: layout;
 	display: grid;
 
 	grid-template-rows:


### PR DESCRIPTION
## What does this change?

Reverts guardian/dotcom-rendering#9802

## Why?

Creating a stacking context did not solve the issue, and makes it harder for @guardian/ophan to add overlays.