### PR TITLE
Only fetch liveblog epic once

### DIFF
--- a/dotcom-rendering/src/lib/useSDC.ts
+++ b/dotcom-rendering/src/lib/useSDC.ts
@@ -9,7 +9,7 @@ import type {
 	BannerPayload,
 	EpicPayload,
 } from '@guardian/support-dotcom-components/dist/dotcom/src/types';
-import useSWRImmutable from 'swr';
+import useSWRImmutable from 'swr/immutable';
 
 const useSDC = <T>(
 	key: string,

--- a/dotcom-rendering/src/lib/useSDC.ts
+++ b/dotcom-rendering/src/lib/useSDC.ts
@@ -15,7 +15,9 @@ const useSDC = <T>(
 	key: string,
 	fetcher: (baseUrl: string, payload: T) => Promise<ModuleDataResponse>,
 ): ModuleDataResponse | undefined => {
-	const { data, error } = useSWRImmutable(key, fetcher);
+	const { data, error } = useSWRImmutable(key, fetcher, {
+		revalidateOnFocus: false,
+	});
 	if (error) {
 		window.guardian.modules.sentry.reportError(error, 'rr-epic');
 	}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
I noticed that on liveblogs, the epic is fetched from SDC (the marketing API) repeatedly. It happens when you click the page (EDIT - actually, it's only when I click between the dev tools and the page!), or move back to the browser tab.
We only ever want to make one request per pageview.
<img width="459" alt="Screenshot 2023-12-08 at 14 18 08" src="https://github.com/guardian/dotcom-rendering/assets/1513454/732cbf93-da33-47b0-ac57-e0bf0eeab38a">


Setting the swr `revalidateOnFocus` flag to false fixes it.
I don't know why this only affects the liveblog epic. The same `useSDC` function (which uses swr) is used for the standard epic and banner requests, but they're unaffected.

