### PR TITLE
Temporarily skip `affiliate disclaimer block` cypress test

### DIFF
--- a/dotcom-rendering/cypress/e2e/parallel-1/article.elements.cy.js
+++ b/dotcom-rendering/cypress/e2e/parallel-1/article.elements.cy.js
@@ -209,7 +209,10 @@ describe('Elements', function () {
 			getBody().contains('Liverpool');
 		});
 
-		it('should render the affiliate disclaimer block', function () {
+		// Skipping for now as the change to the affiliate disclaimer block has been reverted
+		// https://github.com/guardian/frontend/pull/26749
+		// eslint-disable-next-line mocha/no-skipped-tests
+		it.skip('should render the affiliate disclaimer block', function () {
 			const getBody = () => {
 				return cy
 					.get('[data-testid="affiliate-disclaimer"]')


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
This temporarily skips the `affiliate disclaimer block` cypress test.
There has been some back and forth with this tests, and a revert in frontend seems to have broken it.

We can unskip it when its more stable

Related PRs

- https://github.com/guardian/frontend/pull/26749
- https://github.com/guardian/dotcom-rendering/pull/9782
