### PR TITLE
Enable scrolly articles in sandboxed `iframe`

### DIFF
--- a/dotcom-rendering/src/components/InteractiveAtom.stories.tsx
+++ b/dotcom-rendering/src/components/InteractiveAtom.stories.tsx
@@ -1,5 +1,4 @@
 import { css } from '@emotion/react';
-import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
 import {
 	BlockElement,
 	MainMedia,
@@ -26,11 +25,6 @@ export const DefaultStory = (): JSX.Element => {
 				elementJs={js}
 				elementCss={atomCss}
 				title="Superb Stuff"
-				format={{
-					display: ArticleDisplay.Standard,
-					design: ArticleDesign.Standard,
-					theme: ArticlePillar.News,
-				}}
 			/>
 		</div>
 	);
@@ -56,11 +50,6 @@ export const ImmersiveMainMediaStory = (): JSX.Element => {
 				elementCss={atomCss}
 				isMainMedia={true}
 				title="Superb Stuff"
-				format={{
-					display: ArticleDisplay.Immersive,
-					design: ArticleDesign.Standard,
-					theme: ArticlePillar.News,
-				}}
 			/>
 		</div>
 	);

--- a/dotcom-rendering/src/components/InteractiveAtomMessenger.importable.tsx
+++ b/dotcom-rendering/src/components/InteractiveAtomMessenger.importable.tsx
@@ -1,0 +1,91 @@
+import { isObject, log } from '@guardian/libs';
+import { useCallback, useEffect, useState } from 'react';
+
+type InteractiveMessage =
+	| {
+			kind: 'interactive:scroll';
+			scroll: number;
+	  }
+	| {
+			kind: 'interactive:height';
+			height: number;
+	  };
+
+type Props = {
+	id: string;
+};
+
+/**
+ * Send and receive messages from interactive Atoms.
+ *
+ * Currently supported messages:
+ * - `interactive:scroll`
+ * - `interactive:height`
+ *
+ * ## Why does this need to be an Island?
+ *
+ * It needs to send information to an adjoining `InteractiveAtom`
+ */
+export const InteractiveAtomMessenger = ({ id }: Props) => {
+	const [container, setContainer] = useState<HTMLDivElement>();
+	const [iframe, setIframe] = useState<HTMLIFrameElement>();
+	const [scroll, setScroll] = useState(0);
+
+	const postMessage = useCallback(
+		(message: InteractiveMessage) => {
+			iframe?.contentWindow?.postMessage(message, '*');
+		},
+		[iframe],
+	);
+
+	useEffect(() => {
+		const found = document.querySelector<HTMLIFrameElement>(
+			`iframe[id="${id}"]`,
+		);
+		if (!found) return;
+
+		setIframe(found);
+	}, [id]);
+
+	useEffect(() => {
+		if (!(iframe?.parentElement instanceof HTMLDivElement)) return;
+
+		setContainer(iframe.parentElement);
+	}, [iframe]);
+
+	useEffect(() => {
+		if (!iframe) return;
+		if (!container) return;
+
+		const listener = () => {
+			const { top, height } = container.getBoundingClientRect();
+			if (top > 0) return setScroll(0);
+			if (top < -height) return setScroll(1);
+			setScroll(-top);
+		};
+		window.addEventListener('scroll', listener);
+
+		window.addEventListener('message', (event: MessageEvent<unknown>) => {
+			log('dotcom', '📜 received message', event.source, event.data);
+
+			if (
+				event.source === iframe.contentWindow &&
+				isObject(event.data) &&
+				'kind' in event.data &&
+				event.data.kind === 'interactive:size' &&
+				'height' in event.data &&
+				typeof event.data.height === 'number'
+			) {
+				container.style.height = `${event.data.height}px`;
+			}
+		});
+
+		return () => window.removeEventListener('scroll', listener);
+	}, [iframe, container]);
+
+	useEffect(() => {
+		postMessage({ kind: 'interactive:scroll', scroll });
+	}, [postMessage, scroll]);
+
+	return null;
+};

--- a/dotcom-rendering/src/lib/renderElement.tsx
+++ b/dotcom-rendering/src/lib/renderElement.tsx
@@ -386,7 +386,6 @@ export const renderElement = ({
 					elementHtml={element.html}
 					elementJs={element.js}
 					elementCss={element.css}
-					format={format}
 					title={element.title}
 				/>
 			);


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Start sending messages to the `iframe`s which indicate how far the user has currently scrolled.

```ts
type InteractiveMessage =
	| {
			kind: 'interactive:scroll';
			scroll: number;
	  }
	| {
			kind: 'interactive:height';
			height: number;
	  };
```

<img width="571" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/76776/3e956c54-5cf7-4bee-85ff-b2fd9e1b7c5e">


## Why?

A step towards the following goals:
- #9657 
- #9271

## Screenshots

It’s nearly identical!

| Before | After |
|--------|--------|
| <img width="1728" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/76776/6a8d015e-c58b-40ab-a370-edf7b869ce99"> | <img width="1728" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/76776/51ace6d2-be32-4928-b45e-bee14a4c24f8"> | 