### PR TITLE
Limit banner height

### DIFF
--- a/dotcom-rendering/src/layouts/lib/stickiness.tsx
+++ b/dotcom-rendering/src/layouts/lib/stickiness.tsx
@@ -36,7 +36,7 @@ const bannerWrapper = css`
 	position: fixed !important;
 	bottom: 0;
 	${getZIndexImportant('banner')}
-	max-height: 100vh;
+	max-height: 80vh;
 	overflow: visible;
 	/* stylelint-disable-next-line declaration-no-important */
 	width: 100% !important;

--- a/dotcom-rendering/src/layouts/lib/stickiness.tsx
+++ b/dotcom-rendering/src/layouts/lib/stickiness.tsx
@@ -37,6 +37,7 @@ const bannerWrapper = css`
 	bottom: 0;
 	${getZIndexImportant('banner')}
 	max-height: 80vh;
+	max-height: 80dvh;
 	overflow: visible;
 	/* stylelint-disable-next-line declaration-no-important */
 	width: 100% !important;

--- a/dotcom-rendering/src/layouts/lib/stickiness.tsx
+++ b/dotcom-rendering/src/layouts/lib/stickiness.tsx
@@ -36,7 +36,7 @@ const bannerWrapper = css`
 	position: fixed !important;
 	bottom: 0;
 	${getZIndexImportant('banner')}
-	max-height: 90vh;
+	max-height: 80vh;
 	overflow: visible;
 	/* stylelint-disable-next-line declaration-no-important */
 	width: 100% !important;

--- a/dotcom-rendering/src/layouts/lib/stickiness.tsx
+++ b/dotcom-rendering/src/layouts/lib/stickiness.tsx
@@ -36,7 +36,7 @@ const bannerWrapper = css`
 	position: fixed !important;
 	bottom: 0;
 	${getZIndexImportant('banner')}
-	max-height: 80vh;
+	max-height: 90vh;
 	overflow: visible;
 	/* stylelint-disable-next-line declaration-no-important */
 	width: 100% !important;


### PR DESCRIPTION
## Problem
The banner can take up the full height on mobile. Besides being bad UX generally, it's an accessibility problem for users with larger text on mobile.
Specifically, on mobile chrome the nav bar initially covers the top of the page when it loads. This can mean that the close button is hidden behind the nav bar until you start scrolling, which is not obvious. E.g.
<img src="https://github.com/guardian/dotcom-rendering/assets/1513454/fc9856dd-0c84-4759-b17e-df9a8201b7c0" width="400" />

## After
<img src="https://github.com/guardian/dotcom-rendering/assets/1513454/d988321d-9560-4677-9674-9e21d36b0f9d" width="400" />


