### PR TITLE
Onward content cards should not have corners on hover

### DIFF
--- a/dotcom-rendering/src/components/Card/components/CardWrapper.tsx
+++ b/dotcom-rendering/src/components/Card/components/CardWrapper.tsx
@@ -22,7 +22,7 @@ type Props = {
 	isOnwardContent?: boolean;
 };
 
-const baseCardStyles = css`
+const baseCardStyles = (isOnwardContent: boolean) => css`
 	display: flex;
 	flex-direction: column;
 	justify-content: space-between;
@@ -50,6 +50,7 @@ const baseCardStyles = css`
 		left: 0;
 		background-color: ${sourcePalette.neutral[7]};
 		opacity: 0.1;
+		border-radius: ${isOnwardContent ? space[2] : 0}px;
 	}
 
 	/* a tag specific styles */
@@ -184,7 +185,7 @@ export const CardWrapper = ({
 			>
 				<div
 					css={[
-						baseCardStyles,
+						baseCardStyles(isOnwardContent),
 						containerPalette &&
 							containerPaletteStyles(containerPalette),
 						isOnwardContent ? onwardContentCardStyles : cardStyles,


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Updates the onwards content card, so that on hover it doesn't take a square corner

## Why?
There is some card baseStyles code, that wasn't including the border radius for onwardContent cards

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| <img width="500" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/3c52a06d-b89c-47e3-b2c5-694544579b45">| <img width="500" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/9503ecfd-5bc4-41b5-9995-6312e12a4b92">|
|<img width="500" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/f3e2adfe-9ad1-40ed-9dd0-87508a31c32c">|<img width="500" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/e929ca7f-bb65-4588-8937-2f9cf8003541">|

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
