### PR TITLE
Set ID on newsletter field explicitly

### DIFF
--- a/apps-rendering/src/components/EmailSignupForm/index.tsx
+++ b/apps-rendering/src/components/EmailSignupForm/index.tsx
@@ -134,6 +134,7 @@ const EmailSignupForm: FC<Props> = ({
 						type="email"
 						width={30}
 						hideLabel
+						id={`email-signup-${identityName}`}
 						label="Enter your email address"
 						cssOverrides={css`
 							height: ${remSpace[9]};


### PR DESCRIPTION
## What does this change?

Sets the ID for newsletter email fields based on the newsletter ID. 

## Why?

The default behaviour uses an inconsistent autogenerated id from Source. This inconsistency leads to etags changing unnecessarily which degrades cache performance.
