### PR TITLE
Stop sending alreadyVisited to SDC

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -75,7 +75,7 @@
 		"@guardian/source-foundations": "13.2.0",
 		"@guardian/source-react-components": "16.0.1",
 		"@guardian/source-react-components-development-kitchen": "15.0.0",
-		"@guardian/support-dotcom-components": "1.0.8",
+		"@guardian/support-dotcom-components": "1.1.0",
 		"@guardian/tsconfig": "0.2.0",
 		"@playwright/test": "1.39.0",
 		"@sentry/browser": "7.75.1",

--- a/dotcom-rendering/src/components/StickyBottomBanner.importable.tsx
+++ b/dotcom-rendering/src/components/StickyBottomBanner.importable.tsx
@@ -5,7 +5,6 @@ import type {
 import { cmp } from '@guardian/consent-management-platform';
 import type { CountryCode } from '@guardian/libs';
 import { useEffect, useState } from 'react';
-import { getAlreadyVisitedCount } from '../lib/alreadyVisited';
 import { getArticleCounts } from '../lib/articleCount';
 import type { ArticleCounts } from '../lib/articleCount';
 import type {
@@ -142,7 +141,6 @@ const buildRRBannerConfigWith = ({
 						isSensitive,
 						tags,
 						contributionsServiceUrl,
-						alreadyVisitedCount: getAlreadyVisitedCount(),
 						engagementBannerLastClosedAt: getBannerLastClosedAt(
 							'engagementBannerLastClosedAt',
 						),

--- a/dotcom-rendering/src/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/dotcom-rendering/src/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -45,7 +45,6 @@ type BaseProps = {
 	isSensitive: boolean;
 	tags: TagType[];
 	contributionsServiceUrl: string;
-	alreadyVisitedCount: number;
 	engagementBannerLastClosedAt?: string;
 	subscriptionBannerLastClosedAt?: string;
 	signInBannerLastClosedAt?: string;
@@ -92,7 +91,6 @@ const buildPayload = async ({
 	isSignedIn,
 	shouldHideReaderRevenue,
 	isPaidContent,
-	alreadyVisitedCount,
 	engagementBannerLastClosedAt,
 	subscriptionBannerLastClosedAt,
 	signInBannerLastClosedAt,
@@ -117,7 +115,6 @@ const buildPayload = async ({
 			referrerUrl: window.location.origin + window.location.pathname,
 		},
 		targeting: {
-			alreadyVisitedCount,
 			shouldHideReaderRevenue,
 			isPaidContent,
 			showSupportMessaging: !shouldHideSupportMessaging(isSignedIn),
@@ -157,7 +154,6 @@ export const canShowRRBanner: CanShowFunctionType<BannerProps> = async ({
 	isSensitive,
 	tags,
 	contributionsServiceUrl,
-	alreadyVisitedCount,
 	engagementBannerLastClosedAt,
 	subscriptionBannerLastClosedAt,
 	signInBannerLastClosedAt,
@@ -214,7 +210,6 @@ export const canShowRRBanner: CanShowFunctionType<BannerProps> = async ({
 		tags,
 		contributionsServiceUrl,
 		isSensitive,
-		alreadyVisitedCount,
 		engagementBannerLastClosedAt,
 		subscriptionBannerLastClosedAt,
 		signInBannerLastClosedAt,
@@ -254,7 +249,6 @@ export const canShowPuzzlesBanner: CanShowFunctionType<BannerProps> = async ({
 	isSensitive,
 	tags,
 	contributionsServiceUrl,
-	alreadyVisitedCount,
 	engagementBannerLastClosedAt,
 	subscriptionBannerLastClosedAt,
 	asyncArticleCounts,
@@ -281,7 +275,6 @@ export const canShowPuzzlesBanner: CanShowFunctionType<BannerProps> = async ({
 			tags,
 			contributionsServiceUrl,
 			isSensitive,
-			alreadyVisitedCount,
 			engagementBannerLastClosedAt,
 			subscriptionBannerLastClosedAt,
 			optedOutOfArticleCount,

--- a/yarn.lock
+++ b/yarn.lock
@@ -6491,7 +6491,7 @@ __metadata:
     "@guardian/source-foundations": "npm:13.2.0"
     "@guardian/source-react-components": "npm:16.0.1"
     "@guardian/source-react-components-development-kitchen": "npm:15.0.0"
-    "@guardian/support-dotcom-components": "npm:1.0.8"
+    "@guardian/support-dotcom-components": "npm:1.1.0"
     "@guardian/tsconfig": "npm:0.2.0"
     "@playwright/test": "npm:1.39.0"
     "@sentry/browser": "npm:7.75.1"
@@ -6951,10 +6951,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@guardian/support-dotcom-components@npm:1.0.8":
-  version: 1.0.8
-  resolution: "@guardian/support-dotcom-components@npm:1.0.8"
-  checksum: a56d04c966d0b609d3325592e2d8047282de3339f6efd5d1ac4e199b7db3d113dbb3178d0278b9bb92c8063d156d00f65533fc95b0b91982f2702ab2269794ad
+"@guardian/support-dotcom-components@npm:1.1.0":
+  version: 1.1.0
+  resolution: "@guardian/support-dotcom-components@npm:1.1.0"
+  checksum: 081ea35c68e4cb04c597b2a99e0c939051771119a5282dbbd0d3847bd4e8b95b03c366d4cf25c9eeec08666a06220bf9d7dda0360556719f5522739dd62ca584
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Currently DCR and Frontend maintain a pageview counter in local storage called `gu.alreadyVisited`.
It's listed as essential, but wasn't really doing what Marketing needed, so we've [stopped using it in the Marketing API](https://github.com/guardian/support-dotcom-components/pull/1024).

With this PR we stop sending it to the API (SDC).

Still TODO - change the logic that maintains `gu.alreadyVisited` to only do so if user has the right consent. It's still used for advertising.