### PR TITLE
Refactor usage of `cdk` to use makefile and current package manager

### DIFF
--- a/dotcom-rendering/makefile
+++ b/dotcom-rendering/makefile
@@ -17,8 +17,13 @@ endef
 
 # deployment #########################################
 
+# https://www.npmjs.com/package/aws-cdk#cdk-synthesize
 cdk-synth:
-	@yarn cdk:synth
+	@yarn cdk synth --path-metadata false --version-reporting false
+
+# https://www.npmjs.com/package/aws-cdk#cdk-diff
+cdk-diff:
+	@yarn cdk diff --path-metadata false --version-reporting false
 
 riffraff-bundle: clean-dist build cdk-synth
 	$(call log, "creating riffraff bundle")

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -28,10 +28,7 @@
 		"unused-exports": "yarn ts-unused-exports ./tsconfig.json --ignoreFiles='(/(fixtures|__mocks__)/|.+\\.(stories|mocks))' --exitWithCount",
 		"storybook": "storybook dev -p 4002",
 		"build-storybook": "storybook build",
-		"makeBuild": "NODE_ENV=production CI_ENV=github webpack --config ./webpack/webpack.config.js",
-		"cdk:build": "tsc -p ./tsconfig.cdk.json",
-		"cdk:synth": "cdk synth --path-metadata false --version-reporting false",
-		"cdk:diff": "cdk diff --path-metadata false --version-reporting false"
+		"makeBuild": "NODE_ENV=production CI_ENV=github webpack --config ./webpack/webpack.config.js"
 	},
 	"dependencies": {
 		"@aws-sdk/client-cloudwatch": "3.350.0",


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

- Remove `cdk:synth` in favour of existing `make cdk-synth`
- Remove `cdk:diff` in favour of existing `make cdk-diff`
- Remove `cdk:build` as it is not needed when we use `ts-node`

## Why?

Keep things simple and explicit!

Previously, invoking the synth command would composed of the following steps: `make cdk-synth` &rarr; `yarn cd:synth` &rarr; `cdk synth --path-metadata false --version-reporting false` &rarr; `npx ts-node cdk/bin/cdk.ts`

Now, it is simply: `make cdk-synth` &rarr; `yarn cdk synth --path-metadata false --version-reporting false` &rarr; `npx ts-node cdk/bin/cdk.ts`

## Screenshots

N/A