### PR TITLE
Check consents for gu.alreadyVisited

### DIFF
--- a/dotcom-rendering/src/components/AlreadyVisited.importable.tsx
+++ b/dotcom-rendering/src/components/AlreadyVisited.importable.tsx
@@ -14,7 +14,7 @@ import { incrementAlreadyVisited } from '../lib/alreadyVisited';
  */
 export const AlreadyVisited = () => {
 	useEffect(() => {
-		incrementAlreadyVisited();
+		void incrementAlreadyVisited();
 	}, []);
 	// Nothing is rendered by this component
 	return null;

--- a/dotcom-rendering/src/lib/alreadyVisited.ts
+++ b/dotcom-rendering/src/lib/alreadyVisited.ts
@@ -13,15 +13,11 @@ const getAlreadyVisitedCount = (): number => {
 	return !Number.isNaN(alreadyVisited) ? alreadyVisited : 0;
 };
 
-const setAlreadyVisited = (count: number): void => {
-	localStorage.setItem(AlreadyVisitedKey, count.toString());
-};
-
 export const incrementAlreadyVisited = async (): Promise<void> => {
 	const { canTarget } = await onConsent();
 	if (canTarget) {
-		const alreadyVisited = getAlreadyVisitedCount();
-		setAlreadyVisited(alreadyVisited + 1);
+		const alreadyVisited = getAlreadyVisitedCount() + 1;
+		localStorage.setItem(AlreadyVisitedKey, alreadyVisited.toString());
 	} else {
 		localStorage.removeItem(AlreadyVisitedKey);
 	}

--- a/dotcom-rendering/src/lib/alreadyVisited.ts
+++ b/dotcom-rendering/src/lib/alreadyVisited.ts
@@ -1,26 +1,9 @@
 import { onConsent } from '@guardian/consent-management-platform';
-import type { ConsentState } from '@guardian/consent-management-platform/dist/types';
 
 /**
  * This local storage item is used to target ads if a user has the correct consents
  */
 const AlreadyVisitedKey = 'gu.alreadyVisited';
-
-// Matches consents in the Commercial repo: https://github.com/guardian/commercial/blob/16c4358c727e7a5bdbd4e85aea8a08ac3aa80c0b/src/core/targeting/personalised.ts#L125
-const hasConsentForAlreadyVisitedCount = (
-	consentState: ConsentState,
-): boolean => {
-	if (consentState.tcfv2) {
-		if (consentState.tcfv2.consents['1']) return true;
-	}
-	if (consentState.ccpa) {
-		if (!consentState.ccpa.doNotSell) return true;
-	}
-	if (consentState.aus) {
-		if (consentState.aus.personalisedAdvertising) return true;
-	}
-	return false;
-};
 
 const getAlreadyVisitedCount = (): number => {
 	const alreadyVisited = parseInt(
@@ -36,7 +19,7 @@ const setAlreadyVisited = (count: number): void => {
 
 export const incrementAlreadyVisited = (): Promise<void> =>
 	onConsent().then((consentState) => {
-		if (hasConsentForAlreadyVisitedCount(consentState)) {
+		if (consentState.canTarget) {
 			const alreadyVisited = getAlreadyVisitedCount();
 			setAlreadyVisited(alreadyVisited + 1);
 		} else {

--- a/dotcom-rendering/src/lib/alreadyVisited.ts
+++ b/dotcom-rendering/src/lib/alreadyVisited.ts
@@ -17,12 +17,12 @@ const setAlreadyVisited = (count: number): void => {
 	localStorage.setItem(AlreadyVisitedKey, count.toString());
 };
 
-export const incrementAlreadyVisited = (): Promise<void> =>
-	onConsent().then((consentState) => {
-		if (consentState.canTarget) {
-			const alreadyVisited = getAlreadyVisitedCount();
-			setAlreadyVisited(alreadyVisited + 1);
-		} else {
-			localStorage.removeItem(AlreadyVisitedKey);
-		}
-	});
+export const incrementAlreadyVisited = async (): Promise<void> => {
+	const { canTarget } = await onConsent();
+	if (canTarget) {
+		const alreadyVisited = getAlreadyVisitedCount();
+		setAlreadyVisited(alreadyVisited + 1);
+	} else {
+		localStorage.removeItem(AlreadyVisitedKey);
+	}
+};

--- a/dotcom-rendering/src/lib/alreadyVisited.ts
+++ b/dotcom-rendering/src/lib/alreadyVisited.ts
@@ -1,6 +1,28 @@
+import { onConsent } from '@guardian/consent-management-platform';
+import type { ConsentState } from '@guardian/consent-management-platform/dist/types';
+
+/**
+ * This local storage item is used to target ads if a user has the correct consents
+ */
 const AlreadyVisitedKey = 'gu.alreadyVisited';
 
-export const getAlreadyVisitedCount = (): number => {
+// Matches consents in the Commercial repo: https://github.com/guardian/commercial/blob/16c4358c727e7a5bdbd4e85aea8a08ac3aa80c0b/src/core/targeting/personalised.ts#L125
+const hasConsentForAlreadyVisitedCount = (
+	consentState: ConsentState,
+): boolean => {
+	if (consentState.tcfv2) {
+		if (consentState.tcfv2.consents['1']) return true;
+	}
+	if (consentState.ccpa) {
+		if (!consentState.ccpa.doNotSell) return true;
+	}
+	if (consentState.aus) {
+		if (consentState.aus.personalisedAdvertising) return true;
+	}
+	return false;
+};
+
+const getAlreadyVisitedCount = (): number => {
 	const alreadyVisited = parseInt(
 		localStorage.getItem(AlreadyVisitedKey) ?? '',
 		10,
@@ -8,11 +30,16 @@ export const getAlreadyVisitedCount = (): number => {
 	return !Number.isNaN(alreadyVisited) ? alreadyVisited : 0;
 };
 
-export const setAlreadyVisited = (count: number): void => {
+const setAlreadyVisited = (count: number): void => {
 	localStorage.setItem(AlreadyVisitedKey, count.toString());
 };
 
-export const incrementAlreadyVisited = (): void => {
-	const alreadyVisited = getAlreadyVisitedCount();
-	setAlreadyVisited(alreadyVisited + 1);
-};
+export const incrementAlreadyVisited = (): Promise<void> =>
+	onConsent().then((consentState) => {
+		if (hasConsentForAlreadyVisitedCount(consentState)) {
+			const alreadyVisited = getAlreadyVisitedCount();
+			setAlreadyVisited(alreadyVisited + 1);
+		} else {
+			localStorage.removeItem(AlreadyVisitedKey);
+		}
+	});

--- a/dotcom-rendering/src/lib/readerRevenueDevUtils.ts
+++ b/dotcom-rendering/src/lib/readerRevenueDevUtils.ts
@@ -1,5 +1,4 @@
 import { getCookie, removeCookie, setCookie, storage } from '@guardian/libs';
-import { setAlreadyVisited } from './alreadyVisited';
 import {
 	HIDE_SUPPORT_MESSAGING_COOKIE,
 	RECURRING_CONTRIBUTOR_COOKIE,
@@ -102,7 +101,6 @@ const showMeTheBanner = (
 	shouldHideReaderRevenue: boolean,
 ): void => {
 	clearBannerLastClosedAt();
-	setAlreadyVisited(2);
 	clearCommonReaderRevenueStateAndReload(
 		asExistingSupporter,
 		shouldHideReaderRevenue,


### PR DESCRIPTION
In a [previous PR](https://github.com/guardian/dotcom-rendering/pull/9847) we stopped using the `alreadyVisited` local storage item for Marketing targeting. It can now be considered non-essential, as it's only used for ads targeting.

With this PR, the `alreadyVisited` counter will now only be maintained for users with the right consent.