### PR TITLE
Update merchandising-high and merchandising ad slot styles

### DIFF
--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -193,12 +193,13 @@ const merchandisingAdContainerStyles = css`
 
 const merchandisingAdStyles = css`
 	position: relative;
-	min-height: ${adSizes.billboard.height}px;
+	min-height: ${adSizes.billboard.height + labelHeight}px;
 	margin: 12px auto;
 
 	${from.desktop} {
 		margin: 0;
 		padding-bottom: 20px;
+		min-height: ${adSizes.billboard.height + labelHeight + 20}px;
 	}
 `;
 
@@ -212,7 +213,7 @@ const inlineAdStyles = css`
 
 const liveblogInlineAdStyles = css`
 	position: relative;
-	min-height: ${adSizes.mpu.height + constants.AD_LABEL_HEIGHT}px;
+	min-height: ${adSizes.mpu.height + labelHeight}px;
 	background-color: ${palette.neutral[93]};
 
 	${until.tablet} {
@@ -222,7 +223,7 @@ const liveblogInlineAdStyles = css`
 
 const liveblogInlineMobileAdStyles = css`
 	position: relative;
-	min-height: ${adSizes.outstreamMobile.height + constants.AD_LABEL_HEIGHT}px;
+	min-height: ${adSizes.outstreamMobile.height + labelHeight}px;
 	background-color: ${palette.neutral[93]};
 
 	${from.tablet} {

--- a/dotcom-rendering/src/components/DecideFrontsAdSlots.tsx
+++ b/dotcom-rendering/src/components/DecideFrontsAdSlots.tsx
@@ -1,4 +1,4 @@
-import { neutral } from '@guardian/source-foundations';
+import { palette } from '@guardian/source-foundations';
 import { Hide } from '@guardian/source-react-components';
 import type { ReactNode } from 'react';
 import { getMerchHighPosition } from '../lib/getFrontsAdPositions';
@@ -64,7 +64,7 @@ export const decideMerchandisingSlot = (
 			padSides={false}
 			showTopBorder={false}
 			showSideBorders={false}
-			backgroundColour={neutral[93]}
+			backgroundColour={palette.neutral[97]}
 			element="aside"
 		>
 			{children}

--- a/dotcom-rendering/src/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/layouts/CommentLayout.tsx
@@ -729,7 +729,7 @@ export const CommentLayout = (props: WebProps | AppsProps) => {
 						padSides={false}
 						showTopBorder={false}
 						showSideBorders={false}
-						backgroundColour={sourcePalette.neutral[93]}
+						backgroundColour={sourcePalette.neutral[97]}
 						element="aside"
 					>
 						<AdSlot
@@ -847,7 +847,7 @@ export const CommentLayout = (props: WebProps | AppsProps) => {
 						padSides={false}
 						showTopBorder={false}
 						showSideBorders={false}
-						backgroundColour={sourcePalette.neutral[93]}
+						backgroundColour={sourcePalette.neutral[97]}
 						element="aside"
 					>
 						<AdSlot

--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -752,7 +752,7 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 						padSides={false}
 						showTopBorder={false}
 						showSideBorders={false}
-						backgroundColour={sourcePalette.neutral[93]}
+						backgroundColour={sourcePalette.neutral[97]}
 						element="aside"
 					>
 						<AdSlot
@@ -873,7 +873,7 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 						padSides={false}
 						showTopBorder={false}
 						showSideBorders={false}
-						backgroundColour={sourcePalette.neutral[93]}
+						backgroundColour={sourcePalette.neutral[97]}
 						element="aside"
 					>
 						<AdSlot

--- a/dotcom-rendering/src/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/InteractiveLayout.tsx
@@ -650,7 +650,7 @@ export const InteractiveLayout = (props: WebProps | AppsProps) => {
 						padSides={false}
 						showTopBorder={false}
 						showSideBorders={false}
-						backgroundColour={sourcePalette.neutral[93]}
+						backgroundColour={sourcePalette.neutral[97]}
 						element="aside"
 					>
 						<AdSlot
@@ -768,7 +768,7 @@ export const InteractiveLayout = (props: WebProps | AppsProps) => {
 						padSides={false}
 						showTopBorder={false}
 						showSideBorders={false}
-						backgroundColour={sourcePalette.neutral[93]}
+						backgroundColour={sourcePalette.neutral[97]}
 						element="aside"
 					>
 						<AdSlot

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -1153,9 +1153,10 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 							fullWidth={true}
 							data-print-layout="hide"
 							padSides={false}
-							showTopBorder={false}
+							showTopBorder={true}
 							showSideBorders={false}
-							backgroundColour={sourcePalette.neutral[93]}
+							backgroundColour={sourcePalette.neutral[97]}
+							shouldCenter={false}
 							element="aside"
 						>
 							<AdSlot
@@ -1284,7 +1285,7 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 							padSides={false}
 							showTopBorder={false}
 							showSideBorders={false}
-							backgroundColour={sourcePalette.neutral[93]}
+							backgroundColour={sourcePalette.neutral[97]}
 							element="aside"
 						>
 							<AdSlot

--- a/dotcom-rendering/src/layouts/PictureLayout.tsx
+++ b/dotcom-rendering/src/layouts/PictureLayout.tsx
@@ -605,7 +605,7 @@ export const PictureLayout = (props: WebProps | AppsProps) => {
 						padSides={false}
 						showTopBorder={false}
 						showSideBorders={false}
-						backgroundColour={sourcePalette.neutral[93]}
+						backgroundColour={sourcePalette.neutral[97]}
 						element="aside"
 					>
 						<AdSlot
@@ -722,7 +722,7 @@ export const PictureLayout = (props: WebProps | AppsProps) => {
 						padSides={false}
 						showTopBorder={false}
 						showSideBorders={false}
-						backgroundColour={sourcePalette.neutral[93]}
+						backgroundColour={sourcePalette.neutral[97]}
 						element="aside"
 					>
 						<AdSlot

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -727,7 +727,7 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 						padSides={false}
 						showTopBorder={false}
 						showSideBorders={false}
-						backgroundColour={sourcePalette.neutral[93]}
+						backgroundColour={sourcePalette.neutral[97]}
 						element="aside"
 					>
 						<AdSlot
@@ -845,7 +845,7 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 						padSides={false}
 						showTopBorder={false}
 						showSideBorders={false}
-						backgroundColour={sourcePalette.neutral[93]}
+						backgroundColour={sourcePalette.neutral[97]}
 						element="aside"
 					>
 						<AdSlot

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -808,7 +808,7 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 						padSides={false}
 						showTopBorder={false}
 						showSideBorders={false}
-						backgroundColour={sourcePalette.neutral[93]}
+						backgroundColour={sourcePalette.neutral[97]}
 						element="aside"
 					>
 						<AdSlot
@@ -932,7 +932,7 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 						padSides={false}
 						showTopBorder={false}
 						showSideBorders={false}
-						backgroundColour={sourcePalette.neutral[93]}
+						backgroundColour={sourcePalette.neutral[97]}
 						element="aside"
 					>
 						<AdSlot

--- a/dotcom-rendering/src/lib/getLiveblogAdPositions.ts
+++ b/dotcom-rendering/src/lib/getLiveblogAdPositions.ts
@@ -30,9 +30,7 @@ const getAdPositionsForScreenSize = ({
 		heightSinceAd: number;
 		adPositions: number[];
 	}>(
-		(accumulator, block, index) => {
-			const { heightSinceAd, adPositions } = accumulator;
-
+		({ heightSinceAd, adPositions }, block, index) => {
 			const updatedPxSinceAd =
 				heightSinceAd +
 				calculateApproximateBlockHeight(block.elements, isMobile);

--- a/dotcom-rendering/src/lib/liveblogAdSlots.ts
+++ b/dotcom-rendering/src/lib/liveblogAdSlots.ts
@@ -312,8 +312,8 @@ const shouldDisplayAd = (
 	}
 
 	// Always show an advert after the first content block
-	const isFirstAd = block === 1;
-	if (isFirstAd) {
+	const isFirstBlock = block === 1;
+	if (isFirstBlock) {
 		return true;
 	}
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

- The background colour of merchandising slots to neutral[97] (#F6F6F6).
- Adds a border to the top of the merch-high slot on liveblogs.

## Why?

- There was a mismatch between the colour of the ad label and the background.
- Consistency. The neutral[97] colour is the standard background colour for our ad slots.
- On liveblogs, the background of the content is also neutral[97], so we introduce a thin border line above the ad slot to distinguish it from the content. This idea was Harry Fischer's. 
 
## Screenshots

### Article

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |
| ![before2][] | ![after2][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/9574885/180422de-0b90-4acf-9d4e-1cb22d5f06d0
[after]: https://github.com/guardian/dotcom-rendering/assets/9574885/251f7753-eefa-47bb-b905-fb5bfa13803f
[before2]: https://github.com/guardian/dotcom-rendering/assets/9574885/7807ec82-bfff-4902-90b9-f1d2c2bd21b2
[after2]: https://github.com/guardian/dotcom-rendering/assets/9574885/8f6daa25-586c-4a09-977b-0e0764170a8c

### Liveblog

| Before      | After      |
| ----------- | ---------- |
| ![before3][] | ![after3][] |
| ![before4][] | ![after4][] |

[before3]: https://github.com/guardian/dotcom-rendering/assets/9574885/9257978e-b95a-46a4-bbb7-5689d916660c
[after3]: https://github.com/guardian/dotcom-rendering/assets/9574885/c297e29e-e5ae-4018-948c-71d94aeec82c
[before4]: https://github.com/guardian/dotcom-rendering/assets/9574885/af69ce23-cb0b-4046-a169-664cf63ffbf1
[after4]: https://github.com/guardian/dotcom-rendering/assets/9574885/8456564e-0ddc-46e7-b153-291fce498476

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
