### PR TITLE
Comments section title should have a capital C

### DIFF
--- a/dotcom-rendering/src/components/SignedInAs.tsx
+++ b/dotcom-rendering/src/components/SignedInAs.tsx
@@ -84,7 +84,7 @@ const rowUntilDesktop = css`
 const Heading = ({ count }: { count?: number }) => {
 	return (
 		<h2 css={headingStyles}>
-			comments{' '}
+			Comments{' '}
 			<span
 				css={css`
 					color: ${sourcePalette.neutral[60]};


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Updates the Discussion section title to be `Comments` rather than `comments`.

## Why?
This was leftover from the time everything used to be lowercase
Resolves https://github.com/guardian/dotcom-rendering/issues/9864

## Screenshots

| Before      | After      |
| ----------- | ---------- |
|<img width="1181" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/cbcdb85b-7e46-4652-a4f5-eb0fa2bd3b2c">|<img width="1181" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/1a954c23-c799-47e5-832d-a282ff0178db">|

_NB: This might be my best work yet_