### PR TITLE
Fix RichLink scaling

### DIFF
--- a/dotcom-rendering/src/components/Figure.tsx
+++ b/dotcom-rendering/src/components/Figure.tsx
@@ -108,7 +108,10 @@ const roleCss = {
 		width: 8.75rem;
 		margin-right: 20px;
 
-		/* Acts as until.mobileMedium but accounts for font scaling */
+		/*
+		 Acts as until.mobileMedium but accounts for font scaling. On small screens and/or
+		 at certain font sizes, the RichLink will change to a full width version
+		*/
 		@media (max-width: 23.4rem) {
 			width: 100%;
 			box-sizing: border-box;

--- a/dotcom-rendering/src/components/RichLink.tsx
+++ b/dotcom-rendering/src/components/RichLink.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react';
 import type { ArticleFormat } from '@guardian/libs';
 import { ArticleDesign, ArticleSpecial } from '@guardian/libs';
+import type { FontScaleArgs } from '@guardian/source-foundations';
 import { from, headline, textSans } from '@guardian/source-foundations';
 import { palette as themePalette } from '../palette';
 import ArrowInCircle from '../static/icons/arrow-in-circle.svg';
@@ -62,50 +63,41 @@ const headerStyles = css`
 	color: ${themePalette('--rich-link-header')};
 `;
 
-const smallFontStyles = css`
+/** Re-sizes the headline.xxxsmall to 14px / 0.875rem as this isn't available in source */
+const miniHeadlineOverrideStyles = (fontArgs: FontScaleArgs) => css`
+	${headline.xxxsmall(fontArgs)};
 	font-size: 0.875rem;
 `;
 
-const titleStyles = () => {
-	const fontWeight = 'regular';
+const titleStyles = (parentIsBlog: boolean) => css`
+	${parentIsBlog
+		? headline.xxxsmall({ fontWeight: 'regular' })
+		: miniHeadlineOverrideStyles({ fontWeight: 'regular' })};
+	padding-top: 1px;
+	padding-bottom: 1px;
 
-	return css`
-		${headline.xxxsmall({ fontWeight })};
-		padding-top: 1px;
-		padding-bottom: 1px;
+	${from.wide} {
+		${headline.xxsmall({ fontWeight: 'regular' })};
+		padding-bottom: 5px;
+	}
+`;
 
-		${from.wide} {
-			${headline.xxsmall({ fontWeight })};
-			padding-bottom: 5px;
-		}
-	`;
-};
+const labsTitleStyles = css`
+	${textSans.small({ fontWeight: 'bold' })}
 
-const labsTitleStyles = () => {
-	const fontWeight = 'bold';
+	${from.wide} {
+		${textSans.medium({ fontWeight: 'bold' })}
+	}
+`;
 
-	return css`
-		${textSans.small({ fontWeight })}
+const bylineStyles = css`
+	color: ${themePalette('--rich-link-text')};
+	${miniHeadlineOverrideStyles({ fontStyle: 'italic' })};
 
-		${from.wide} {
-			${textSans.medium({ fontWeight })}
-		}
-	`;
-};
-
-const bylineStyles = () => {
-	const fontStyle = 'italic';
-
-	return css`
-		color: ${themePalette('--rich-link-text')};
-		${headline.xxxsmall({ fontStyle })};
-		${smallFontStyles}
-
-		${from.wide} {
-			${headline.xxsmall({ fontStyle })};
-		}
-	`;
-};
+	${from.wide} {
+		${headline.xxsmall({ fontStyle: 'italic' })};
+	}
+`;
 
 const contributorWrapperStyles = css`
 	width: 5rem;
@@ -140,21 +132,16 @@ const readMoreStyles = css`
 	padding-bottom: 6px;
 `;
 
-const readMoreTextStyle = () => {
-	const fontWeight = 'medium';
+const readMoreTextStyle = css`
+	${miniHeadlineOverrideStyles({ fontWeight: 'medium' })};
+	color: ${themePalette('--rich-link-text')};
+	padding-left: 4px;
+	text-decoration: none;
 
-	return css`
-		${headline.xxxsmall({ fontWeight })};
-		${smallFontStyles}
-		color: ${themePalette('--rich-link-text')};
-		padding-left: 4px;
-		text-decoration: none;
-
-		${from.wide} {
-			${headline.xxxsmall({ fontWeight })}
-		}
-	`;
-};
+	${from.wide} {
+		${headline.xxxsmall({ fontWeight: 'medium' })}
+	}
+`;
 
 const labsReadMoreTextStyle = css`
 	${textSans.medium({ fontWeight: 'regular' })}
@@ -246,8 +233,7 @@ export const RichLink = ({
 						<div css={headerStyles}>
 							<div
 								css={[
-									titleStyles,
-									!parentIsBlog && smallFontStyles,
+									titleStyles(parentIsBlog),
 									isLabs && labsTitleStyles,
 								]}
 							>
@@ -300,9 +286,7 @@ export const RichLink = ({
 							<div
 								css={[
 									readMoreTextStyle,
-									isLabs
-										? labsReadMoreTextStyle
-										: smallFontStyles,
+									isLabs && labsReadMoreTextStyle,
 								]}
 							>
 								{readMoreText(contentType)}


### PR DESCRIPTION
## What does this change?

Refactors styles in RichLink component and adapts sizing of fonts and spacing so that it looks better on different font zooms and scales in a more proportional way.

## Why?

Addresses the large discrepancy in font sizes when changing the base font size for the browser (currently the method of scaling/zooming in apps articles).
Resolves #9675.

### Even better if...
...the "Read more" text didn't wrap on large viewports with large font magnification (though this is very unlikely to happen on apps due to them often being used on smaller screens)

## Screenshots

| 320px   | Before      | After      |
| ------  | ----------- | ---------- |
| V small | ![b320_2][] | ![a320_2][] |
| Medium  | ![b320_1][] | ![a320_1][] |
| V large | ![b320_3][] | ![a320_3][] |


| 660px   | Before      | After      |
| -----   | ----------- | ---------- |
| V small | ![b660_2][] | ![a660_2][] |
| Medium  | ![b660_1][] | ![a660_1][] |
| V large | ![b660_3][] | ![a660_3][] |

| 1140px  | Before       | After      |
| -----   | -----------  | ---------- |
| V small | ![b1140_2][] | ![a1140_2][] |
| Medium  | ![b1140_1][]  | ![a1140_1][] |
| V large | ![b1140_3][]  | ![a1140_3][] |

[b320_1]: https://github.com/guardian/dotcom-rendering/assets/43961396/41711b9e-1bdd-4b4f-a393-9cac6e932487
[a320_1]: https://github.com/guardian/dotcom-rendering/assets/43961396/9eb94455-1ccb-4ba6-afc3-33862e181838
[b320_2]:https://github.com/guardian/dotcom-rendering/assets/43961396/b575c945-4b77-498a-a33e-aaba13881ddd
[a320_2]:https://github.com/guardian/dotcom-rendering/assets/43961396/2ee8e10b-f86c-4fb1-a56c-72c4ce6e78ec
[b320_3]: https://github.com/guardian/dotcom-rendering/assets/43961396/bcd02f12-3811-47be-bec9-268456eb9029
[a320_3]: https://github.com/guardian/dotcom-rendering/assets/43961396/64d3c972-7b05-4d10-9c86-e352702d2c5e

[b660_1]: https://github.com/guardian/dotcom-rendering/assets/43961396/60731e80-259a-4d00-9798-86b691a7c2a1
[a660_1]: https://github.com/guardian/dotcom-rendering/assets/43961396/06cd0931-c103-4814-839c-a101d83e3959
[b660_2]: https://github.com/guardian/dotcom-rendering/assets/43961396/b87516ae-fe30-4a53-8b90-5f7def3f4ab5
[a660_2]: https://github.com/guardian/dotcom-rendering/assets/43961396/15ad5594-13a1-4f5e-9e5c-d127c33a43a3
[b660_3]: https://github.com/guardian/dotcom-rendering/assets/43961396/a7c4b5c1-de9c-46a7-8af9-bd171825b76c
[a660_3]: https://github.com/guardian/dotcom-rendering/assets/43961396/16228027-5d10-46bd-9a39-0bfc6505d423

[b1140_1]:https://github.com/guardian/dotcom-rendering/assets/43961396/87e44d64-6c01-445c-9c16-0141638c86d9
[a1140_1]:https://github.com/guardian/dotcom-rendering/assets/43961396/22288602-aeae-4cdb-8056-72803260890d
[b1140_2]: https://github.com/guardian/dotcom-rendering/assets/43961396/c18027d4-dff0-4dce-8d9d-bea2b8de98fc
[a1140_2]: https://github.com/guardian/dotcom-rendering/assets/43961396/69faface-2274-4845-99c9-79ef1723c7ff
[b1140_3]: https://github.com/guardian/dotcom-rendering/assets/43961396/d5d4447e-6ca0-4fd1-ac63-3b55075d4431
[a1140_3]:https://github.com/guardian/dotcom-rendering/assets/43961396/3a6fa02c-6362-4dd0-85c4-4754d7a676a8
