### PR TITLE
Add dependencies mismatches script

### DIFF
--- a/scripts/env/check-dependencies-mismatches.mjs
+++ b/scripts/env/check-dependencies-mismatches.mjs
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+
+// @ts-check
+
+import ar from '../../apps-rendering/package.json' assert { type: 'json' };
+import dcr from '../../dotcom-rendering/package.json' assert { type: 'json' };
+import { log, warn } from '../log.js';
+
+log('checking mistmached dependencies between AR & DCR');
+
+for (const [name, dcrVersion] of Object.entries(dcr.dependencies)) {
+	const arVersion = ar.dependencies[name];
+	if (arVersion === undefined) continue;
+	if (arVersion !== dcrVersion)
+		warn(['Mismatch:', dcrVersion, '≠', arVersion, '\t', name].join(' '));
+}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Report on mismatches between AR & DCR dependencies

Run with `$ ./scripts/env/check-dependencies-mismatches.mjs`

## Why?

Distinct dependencies increase the total size of node modules, and are probably not intentional. Since we moved to Yarn 4 #9662, it also slows down linking deps.

## Screenshots

<img width="624" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/76776/af0295fb-2dc0-40af-90eb-15cf3f30aaf5">
