### PR TITLE
Restrict max-width of merchandising ad slots to 1300px

### DIFF
--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -196,6 +196,7 @@ const merchandisingAdStyles = css`
 	min-height: ${adSizes.billboard.height + labelHeight}px;
 	margin: 12px auto;
 	max-width: ${breakpoints['wide']}px;
+	overflow: hidden;
 
 	${from.desktop} {
 		margin: 0;

--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -195,6 +195,7 @@ const merchandisingAdStyles = css`
 	position: relative;
 	min-height: ${adSizes.billboard.height + labelHeight}px;
 	margin: 12px auto;
+	max-width: ${breakpoints['wide']}px;
 
 	${from.desktop} {
 		margin: 0;
@@ -545,9 +546,9 @@ export const AdSlot = ({
 							'ad-slot--merchandising-high',
 						].join(' ')}
 						css={[
-							merchandisingAdStyles,
 							fluidAdStyles,
 							fluidFullWidthAdStyles,
+							merchandisingAdStyles,
 						]}
 						data-link-name="ad slot merchandising-high"
 						data-name="merchandising-high"
@@ -571,9 +572,9 @@ export const AdSlot = ({
 							'ad-slot--merchandising',
 						].join(' ')}
 						css={[
-							merchandisingAdStyles,
 							fluidAdStyles,
 							fluidFullWidthAdStyles,
+							merchandisingAdStyles,
 						]}
 						data-link-name="ad slot merchandising"
 						data-name="merchandising"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Restricts the size of merchandising ads to 1300px. Similar to `fronts-banner` slots.

## Why?

GAM will use all the space available for ads. For full-width slots like this one, we restrict GAM ads to our wide viewport of 1300px.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/9574885/710a9db3-e933-418a-a753-d9dc6492d67d
[after]: https://github.com/guardian/dotcom-rendering/assets/9574885/e6289f26-67af-4b01-9dfc-5327ef46d4a4

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
