### PR TITLE
fix: add prout back into the container workflow

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -25,6 +25,11 @@ jobs:
       - name: Set up Node environment
         uses: ./.github/actions/setup-node-env
 
+      - name: Add commit hash for PRout
+        working-directory: dotcom-rendering
+        run: |
+          echo 'export const GIT_COMMIT_HASH = "${{ github.sha }}";' > src/server/prout.ts
+
       - name: Generate production bundle
         run: make riffraff-bundle
         working-directory: dotcom-rendering


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Writes Git commit hash in the container Github workflow, so that we can inject it into the HTML response for [PRout](https://github.com/guardian/prout)

## Why?

It was accidentally removed here https://github.com/guardian/dotcom-rendering/pull/9652/files#diff-87249919b62f3d7f70416176a4254d5df6e59eab47c6de2a2a4fbbcf4138cbac
