### PR TITLE
Darkmode - discussion pagination

### DIFF
--- a/dotcom-rendering/src/components/Discussion/Pagination.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/Pagination.stories.tsx
@@ -31,6 +31,7 @@ export const Default = () => {
 	);
 };
 Default.storyName = 'default';
+Default.decorators = [splitTheme([articleFormat])];
 
 export const TwoPages = () => {
 	const [page, setCurrentPage] = useState(1);
@@ -45,21 +46,7 @@ export const TwoPages = () => {
 	);
 };
 TwoPages.storyName = 'with two pages';
-
-export const WithBackground = () => {
-	const [page, setCurrentPage] = useState(1);
-	return (
-		<Pagination
-			totalPages={2}
-			currentPage={page}
-			setCurrentPage={setCurrentPage}
-			filters={DEFAULT_FILTERS}
-			commentCount={56}
-		/>
-	);
-};
-WithBackground.storyName = 'with a dark background';
-WithBackground.decorators = [splitTheme([articleFormat])];
+TwoPages.decorators = [splitTheme([articleFormat])];
 
 export const ThreePages = () => {
 	const [page, setCurrentPage] = useState(1);
@@ -74,6 +61,7 @@ export const ThreePages = () => {
 	);
 };
 ThreePages.storyName = 'with three pages';
+ThreePages.decorators = [splitTheme([articleFormat])];
 
 export const FourPages = () => {
 	const [page, setCurrentPage] = useState(1);
@@ -88,6 +76,7 @@ export const FourPages = () => {
 	);
 };
 FourPages.storyName = 'with four pages';
+FourPages.decorators = [splitTheme([articleFormat])];
 
 export const FivePages = () => {
 	const [page, setCurrentPage] = useState(1);
@@ -102,6 +91,7 @@ export const FivePages = () => {
 	);
 };
 FivePages.storyName = 'with five pages';
+FivePages.decorators = [splitTheme([articleFormat])];
 
 export const SixPages = () => {
 	const [page, setCurrentPage] = useState(1);
@@ -116,6 +106,7 @@ export const SixPages = () => {
 	);
 };
 SixPages.storyName = 'with six pages';
+SixPages.decorators = [splitTheme([articleFormat])];
 
 export const SevenPages = () => {
 	const [page, setCurrentPage] = useState(1);
@@ -130,6 +121,7 @@ export const SevenPages = () => {
 	);
 };
 SevenPages.storyName = 'with seven pages';
+SevenPages.decorators = [splitTheme([articleFormat])];
 
 export const TwelvePages = () => {
 	const [page, setCurrentPage] = useState(1);
@@ -144,6 +136,7 @@ export const TwelvePages = () => {
 	);
 };
 TwelvePages.storyName = 'with twelve pages';
+TwelvePages.decorators = [splitTheme([articleFormat])];
 
 export const LotsOfPages = () => {
 	const [page, setCurrentPage] = useState(1);
@@ -158,6 +151,7 @@ export const LotsOfPages = () => {
 	);
 };
 LotsOfPages.storyName = 'with many pages';
+LotsOfPages.decorators = [splitTheme([articleFormat])];
 
 export const WhenExpanded = () => {
 	const [page, setCurrentPage] = useState(1);
@@ -172,6 +166,7 @@ export const WhenExpanded = () => {
 	);
 };
 WhenExpanded.storyName = 'when expanded';
+WhenExpanded.decorators = [splitTheme([articleFormat])];
 
 export const WhenCollapsed = () => {
 	const [page, setCurrentPage] = useState(1);
@@ -186,6 +181,7 @@ export const WhenCollapsed = () => {
 	);
 };
 WhenCollapsed.storyName = 'when collapsed';
+WhenCollapsed.decorators = [splitTheme([articleFormat])];
 
 export const WhenUnthreaded = () => {
 	const [page, setCurrentPage] = useState(1);
@@ -200,3 +196,4 @@ export const WhenUnthreaded = () => {
 	);
 };
 WhenUnthreaded.storyName = 'when unthreaded';
+WhenUnthreaded.decorators = [splitTheme([articleFormat])];

--- a/dotcom-rendering/src/components/Discussion/Pagination.tsx
+++ b/dotcom-rendering/src/components/Discussion/Pagination.tsx
@@ -10,6 +10,7 @@ import {
 	SvgChevronLeftSingle,
 	SvgChevronRightSingle,
 } from '@guardian/source-react-components';
+import { palette as schemedPalette } from '../../palette';
 import type { FilterOptions } from '../../types/discussion';
 
 type Props = {
@@ -29,14 +30,16 @@ const pageButtonStyles = (isSelected: boolean) => css`
 	box-sizing: border-box;
 
 	color: ${isSelected
-		? sourcePalette.neutral[100]
-		: sourcePalette.neutral[46]};
-	background-color: ${isSelected ? sourcePalette.neutral[46] : 'transparent'};
+		? schemedPalette('--discussion-pagination-background')
+		: schemedPalette('--discussion-pagination-text')};
+	background-color: ${isSelected
+		? schemedPalette('--discussion-pagination-text')
+		: 'transparent'};
 	border: none;
 	:hover {
 		border-width: 0.0625rem;
 		border-style: solid;
-		border-color: ${sourcePalette.neutral[46]};
+		border-color: ${schemedPalette('--discussion-pagination-text')};
 	}
 
 	margin-right: 5px;
@@ -58,9 +61,8 @@ const chevronButtonStyles = ({ isSelected }: { isSelected: boolean }) => css`
 	border-style: solid;
 	border-color: ${sourcePalette.neutral[86]};
 	background-color: ${isSelected
-		? sourcePalette.neutral[46]
-		: sourcePalette.neutral[100]};
-
+		? schemedPalette('--discussion-pagination-text')
+		: schemedPalette('--discussion-pagination-background')};
 	height: 22px;
 	min-height: 22px;
 	width: 22px;
@@ -70,6 +72,7 @@ const chevronButtonStyles = ({ isSelected }: { isSelected: boolean }) => css`
 		height: 22px;
 		min-height: 22px;
 		width: 22px;
+		color: ${schemedPalette('--discussion-pagination-text')};
 	}
 
 	:hover {
@@ -78,8 +81,7 @@ const chevronButtonStyles = ({ isSelected }: { isSelected: boolean }) => css`
 
 	& svg {
 		/* Make the chevrons grey */
-		/* stylelint-disable-next-line declaration-no-important */
-		fill: ${sourcePalette.neutral[46]} !important;
+		fill: currentColor;
 		/* Set the dimensions */
 		width: 22px;
 		height: 22px;
@@ -101,7 +103,7 @@ const elipsisStyles = css`
 
 const wrapperStyles = css`
 	${textSans.small()};
-	color: ${sourcePalette.neutral[46]};
+	color: ${schemedPalette('--discussion-pagination-text')};
 
 	display: flex;
 	flex-direction: row;
@@ -109,7 +111,7 @@ const wrapperStyles = css`
 	width: 100%;
 	padding-top: ${space[2]}px;
 	padding-bottom: ${space[2]}px;
-	border-top: 1px solid ${sourcePalette.neutral[86]};
+	border-top: 1px solid ${schemedPalette('--discussion-pagination-border')};
 	${until.mobileLandscape} {
 		flex-direction: column;
 	}

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -4411,6 +4411,21 @@ const firstCommentPreviewLight: PaletteFunction = () =>
 const firstCommentPreviewDark: PaletteFunction = () =>
 	sourcePalette.neutral[10];
 
+const discussionPaginationTextLight: PaletteFunction = () =>
+	sourcePalette.neutral[46];
+const discussionPaginationTextDark: PaletteFunction = () =>
+	sourcePalette.neutral[86];
+
+const discussionPaginationBorderLight: PaletteFunction = () =>
+	sourcePalette.neutral[86];
+const discussionPaginationBorderDark: PaletteFunction = () =>
+	sourcePalette.neutral[46];
+
+const discussionPaginationBackgroundLight: PaletteFunction = () =>
+	sourcePalette.neutral[100];
+const discussionPaginationBackgroundDark: PaletteFunction = () =>
+	sourcePalette.neutral[0];
+
 // ----- Palette ----- //
 
 /**
@@ -5137,6 +5152,18 @@ const paletteColours = {
 	'--discussion-report-border': {
 		light: discussionReportBorderLight,
 		dark: discussionReportBorderDark,
+	},
+	'--discussion-pagination-text': {
+		light: discussionPaginationTextLight,
+		dark: discussionPaginationTextDark,
+	},
+	'--discussion-pagination-background': {
+		light: discussionPaginationBackgroundLight,
+		dark: discussionPaginationBackgroundDark,
+	},
+	'--discussion-pagination-border': {
+		light: discussionPaginationBorderLight,
+		dark: discussionPaginationBorderDark,
 	},
 	'--comment-form-input-background': {
 		light: commentFormInputBackgroundLight,


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Updates the discussion pagination to work in darkmode

## Why?
Part of a larger body of work to get discussion working in darkmode

## Screenshots
<img width="1489" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/f7512210-6b56-45a0-adfc-6d53724699fa">
<img width="1489" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/8adb443a-85b7-4db8-9c21-27dfa6ef5581">
<img width="1489" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/2318e6ba-acf6-477a-94b1-8a8018afe0cf">
