### PR TITLE
chore(deps): force uuid resolution to v9

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
 		"tslib": "2.6.2"
 	},
 	"resolutions": {
-		"crypto-js": "4.2.0"
+		"crypto-js": "4.2.0",
+		"uuid": "9.0.1"
 	},
 	"packageManager": "yarn@4.0.2"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -26626,30 +26626,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uuid@npm:8.0.0":
-  version: 8.0.0
-  resolution: "uuid@npm:8.0.0"
-  bin:
-    uuid: dist/bin/uuid
-  checksum: e62301a1c6102da5ce9a147b492a4b5cfa14d2e8fdf4a6ebfda7929cb72d186f84173815ec18fa4160a03bf9724b16ece3737b3ac6701815bc965f8fa4279298
-  languageName: node
-  linkType: hard
-
-"uuid@npm:9.0.1, uuid@npm:^9.0.0":
+"uuid@npm:9.0.1":
   version: 9.0.1
   resolution: "uuid@npm:9.0.1"
   bin:
     uuid: dist/bin/uuid
   checksum: 1607dd32ac7fc22f2d8f77051e6a64845c9bce5cd3dd8aa0070c074ec73e666a1f63c7b4e0f4bf2bc8b9d59dc85a15e17807446d9d2b17c8485fbc2147b27f9b
-  languageName: node
-  linkType: hard
-
-"uuid@npm:^8.3.2":
-  version: 8.3.2
-  resolution: "uuid@npm:8.3.2"
-  bin:
-    uuid: dist/bin/uuid
-  checksum: bcbb807a917d374a49f475fae2e87fdca7da5e5530820ef53f65ba1d12131bd81a92ecf259cc7ce317cbe0f289e7d79fdfebcef9bfa3087c8c8a2fa304c9be54
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What does this change?

Set the [resolution](https://yarnpkg.com/configuration/manifest#resolutions) of UUID to v9.0.1 always

## Why?

More consistency, the v9 is mainly breaking [because it drops its UMD bundle.](https://github.com/uuidjs/uuid/blob/main/CHANGELOG.md#900-2022-09-05):

> ⚠ BREAKING CHANGES
> 
> - Drop Node.js 10.x support. This library always aims at supporting one EOLed LTS release which by this time now is 12.x which has reached EOL 30 Apr 2022.
> 
> - Remove the minified UMD build from the package.
> 
>   Minified code is hard to audit and since this is a widely used library it seems more appropriate nowadays to optimize for auditability than to ship a legacy module format that, at best, serves educational purposes nowadays.
> 
>   For production browser use cases, users should be using a bundler. For educational purposes, today's online sandboxes like replit.com offer convenient ways to load npm modules, so the use case for UMD through repos like UNPKG or jsDelivr has largely vanished.
> 
> - Drop IE 11 and Safari 10 support. Drop support for browsers that don't correctly implement const/let and default arguments, and no longer transpile the browser build to ES2015.
> 
>   This also removes the fallback on msCrypto instead of the crypto API.
> 
>   Browser tests are run in the first supported version of each supported browser and in the latest (as of this commit) version available on Browserstack.
> 
