### PR TITLE
Fix byline link style

### DIFF
--- a/dotcom-rendering/src/components/HeadlineByline.tsx
+++ b/dotcom-rendering/src/components/HeadlineByline.tsx
@@ -81,7 +81,7 @@ const analysisStyles = css`
 	})}
 	line-height: 38px;
 	font-style: italic;
-	color: ${schemedPalette('--byline')};
+	color: ${schemedPalette('--byline-anchor')};
 
 	${until.tablet} {
 		${headline.small({


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Fix byline link style appearing in wrong colour on analysis articles
<img width="584" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/110032454/d0fd4282-9b7a-4436-ad91-71694245a1f2">

## Why?
Resolves https://github.com/guardian/dotcom-rendering/issues/9875
## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/110032454/8befa6dd-2f45-4f06-9c47-bc8d9488d053
[after]: https://github.com/guardian/dotcom-rendering/assets/110032454/781f6b43-13d0-4f28-a4d6-d8e37553f235

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
