### PR TITLE
Fix Kinesis Config

### DIFF
--- a/dotcom-rendering/cdk/lib/__snapshots__/dotcom-rendering.test.ts.snap
+++ b/dotcom-rendering/cdk/lib/__snapshots__/dotcom-rendering.test.ts.snap
@@ -1035,7 +1035,7 @@ sudo NODE_ENV=$NODE_ENV GU_STAGE=$GU_STAGE -u dotcom-rendering -g frontend make 
                   {
                     "Ref": "ELKStreamId",
                   },
-                  " /var/log/dotcom-rendering/dotcom-rendering.log",
+                  " "/var/log/dotcom-rendering/dotcom-rendering.log"",
                 ],
               ],
             },

--- a/dotcom-rendering/cdk/lib/userData.ts
+++ b/dotcom-rendering/cdk/lib/userData.ts
@@ -34,7 +34,7 @@ export const getUserData = ({
 
 		`sudo NODE_ENV=$NODE_ENV GU_STAGE=$GU_STAGE -u dotcom-rendering -g frontend make prod`,
 
-		`/opt/aws-kinesis-agent/configure-aws-kinesis-agent ${region} ${elkStreamId} /var/log/dotcom-rendering/dotcom-rendering.log`,
+		`/opt/aws-kinesis-agent/configure-aws-kinesis-agent ${region} ${elkStreamId} "/var/log/dotcom-rendering/dotcom-rendering.log"`,
 	].join('\n');
 
 	return userData;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

add quotes around the log file path to ensure the kinesis config file receives the correct log file name 

## Why?

we noticed logs were not being sent to ELK from the instances
identified that the kinesis config in /etc/aws-kinesis/agent.json was containing default values 
adding quotes around the lof file name seems to fix this line that fills in the config correctly

