### PR TITLE
ci: Update to guardian/actions-riff-raff v3

### DIFF
--- a/.github/workflows/ar-ci.yml
+++ b/.github/workflows/ar-ci.yml
@@ -13,6 +13,7 @@ concurrency:
 permissions:
   id-token: write
   contents: read
+  pull-requests: write # required by guardian/actions-riff-raff@v3
 
 jobs:
   build:
@@ -46,8 +47,9 @@ jobs:
           mask-aws-account-id: true
 
       - name: Upload to riff-raff
-        uses: guardian/actions-riff-raff@v2.2.2
+        uses: guardian/actions-riff-raff@v3
         with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
           configPath: apps-rendering/riff-raff.yaml
           projectName: Mobile::mobile-apps-rendering
           buildNumberOffset: 27000 # This is the last build number from TeamCity

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -43,6 +43,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      pull-requests: write # required by guardian/actions-riff-raff@v3
     needs: [container, prettier, jest, lint, cypress, playwright, amp]
     uses: ./.github/workflows/publish.yml
     with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ permissions:
   # Allow GitHub to request an OIDC JWT ID token, for exchange with `aws-actions/configure-aws-credentials`
   # See https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services#updating-your-github-actions-workflow
   id-token: write
-
+  pull-requests: write # required by guardian/actions-riff-raff@v3
 jobs:
   riffraff:
     runs-on: ubuntu-latest
@@ -45,8 +45,9 @@ jobs:
           role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
           mask-aws-account-id: true
 
-      - uses: guardian/actions-riff-raff@v2
+      - uses: guardian/actions-riff-raff@v3
         with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
           projectName: dotcom:rendering
           configPath: riff-raff.yaml
           buildNumberOffset: 38860


### PR DESCRIPTION
> [!NOTE]
> ~Requires https://github.com/guardian/actions-riff-raff/pull/94, and https://github.com/guardian/actions-riff-raff/pull/95 to be released first.~ UPDATE: Done!

## What does this change?
Update the version of guardian/actions-riff-raff to gain PR comments (see https://github.com/guardian/actions-riff-raff/pull/85).

## Why?
Provides a shorter route to deploying to CODE, as we'd simply click a link vs opening Riff-Raff and filling out the deployment form.

---
Closes https://github.com/guardian/dotcom-rendering/pull/9581.