### PR TITLE
chore(deps): add direct dependency on node-int64

### DIFF
--- a/apps-rendering/package.json
+++ b/apps-rendering/package.json
@@ -71,6 +71,7 @@
 		"@types/jest": "28.1.8",
 		"@types/jsdom": "16.2.15",
 		"@types/node": "18.18.14",
+		"@types/node-int64": "0.4.32",
 		"@types/react": "18.2.45",
 		"@types/react-dom": "18.2.17",
 		"@types/react-test-renderer": "18.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9230,7 +9230,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node-int64@npm:*, @types/node-int64@npm:^0.4.29":
+"@types/node-int64@npm:*, @types/node-int64@npm:0.4.32, @types/node-int64@npm:^0.4.29":
   version: 0.4.32
   resolution: "@types/node-int64@npm:0.4.32"
   dependencies:
@@ -10914,6 +10914,7 @@ __metadata:
     "@types/jest": "npm:28.1.8"
     "@types/jsdom": "npm:16.2.15"
     "@types/node": "npm:18.18.14"
+    "@types/node-int64": "npm:0.4.32"
     "@types/react": "npm:18.2.45"
     "@types/react-dom": "npm:18.2.17"
     "@types/react-test-renderer": "npm:18.0.0"


### PR DESCRIPTION
## What does this change?

Make the dependency on `@types/node-int64` direct and explicit!

## Why?

Relying on transitive dependency and hoisting is dangerous.

Enables the work in #9476 to proceed

## Known issues

This library has been deprecated and the repository archived in 2020: https://github.com/broofa/node-int64

We should probably use [`BigInt`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt) instead 