### PR TITLE
Provide a typescript transpiler for `apps-rendering`'s webpack config

### DIFF
--- a/apps-rendering/package.json
+++ b/apps-rendering/package.json
@@ -65,6 +65,7 @@
 		"@storybook/react": "7.6.4",
 		"@storybook/react-webpack5": "7.6.4",
 		"@storybook/theming": "7.6.4",
+		"@swc/register": "0.1.10",
 		"@types/clean-css": "4.2.11",
 		"@types/compression": "1.7.2",
 		"@types/express": "4.17.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8444,6 +8444,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@swc/register@npm:0.1.10":
+  version: 0.1.10
+  resolution: "@swc/register@npm:0.1.10"
+  dependencies:
+    lodash.clonedeep: "npm:^4.5.0"
+    pirates: "npm:^4.0.1"
+    source-map-support: "npm:^0.5.13"
+  peerDependencies:
+    "@swc/core": ^1.0.46
+  bin:
+    swc-node: bin/swc-node
+  checksum: 58c2517c6565f7bd28bf6d494fb2691572c29bade7a1652056549adc0646481935b700e5bc1ee6e5ac628b91abfd0a39719a7470873b38593b522de6ac26ea80
+  languageName: node
+  linkType: hard
+
 "@swc/types@npm:^0.1.5":
   version: 0.1.5
   resolution: "@swc/types@npm:0.1.5"
@@ -10895,6 +10910,7 @@ __metadata:
     "@storybook/react": "npm:7.6.4"
     "@storybook/react-webpack5": "npm:7.6.4"
     "@storybook/theming": "npm:7.6.4"
+    "@swc/register": "npm:0.1.10"
     "@types/clean-css": "npm:4.2.11"
     "@types/compression": "npm:1.7.2"
     "@types/express": "npm:4.17.21"
@@ -19792,6 +19808,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lodash.clonedeep@npm:^4.5.0":
+  version: 4.5.0
+  resolution: "lodash.clonedeep@npm:4.5.0"
+  checksum: 2caf0e4808f319d761d2939ee0642fa6867a4bbf2cfce43276698828380756b99d4c4fa226d881655e6ac298dd453fe12a5ec8ba49861777759494c534936985
+  languageName: node
+  linkType: hard
+
 "lodash.debounce@npm:4.0.6":
   version: 4.0.6
   resolution: "lodash.debounce@npm:4.0.6"
@@ -22198,7 +22221,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pirates@npm:^4.0.4, pirates@npm:^4.0.5":
+"pirates@npm:^4.0.1, pirates@npm:^4.0.4, pirates@npm:^4.0.5":
   version: 4.0.6
   resolution: "pirates@npm:4.0.6"
   checksum: 00d5fa51f8dded94d7429700fb91a0c1ead00ae2c7fd27089f0c5b63e6eca36197fe46384631872690a66f390c5e27198e99006ab77ae472692ab9c2ca903f36
@@ -24389,7 +24412,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"source-map-support@npm:^0.5.16, source-map-support@npm:^0.5.3, source-map-support@npm:~0.5.20":
+"source-map-support@npm:^0.5.13, source-map-support@npm:^0.5.16, source-map-support@npm:^0.5.3, source-map-support@npm:~0.5.20":
   version: 0.5.21
   resolution: "source-map-support@npm:0.5.21"
   dependencies:


### PR DESCRIPTION


<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

adds `@swc/register` as a direct dependency of `apps-rendering`.

## Why?

the webpack config in `apps-rendering` is written in typescript. webpack [needs a transpiler installed](https://github.com/guardian/dotcom-rendering/actions/runs/7221890059/job/19677808964?pr=9476#step:4:917) to be able to read it. currently, it uses a transitively installed `ts-node` (discovered in #9476). 

this explicitly provides `@swc/register`, since `swc` is used elsewhere.

