### PR TITLE
include `.yaml` extensions in yaml formatting rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -18,6 +18,6 @@ indent_size = 2
 [makefile]
 indent_style = tab
 
-[*.yml]
+[*.{yml,yaml}]
 indent_size = 2
 indent_style = space

--- a/dotcom-rendering/scripts/deploy/riff-raff.yaml
+++ b/dotcom-rendering/scripts/deploy/riff-raff.yaml
@@ -1,60 +1,60 @@
 stacks: [frontend]
 regions: [eu-west-1]
 allowedStages:
-    - CODE
-    - PROD
+  - CODE
+  - PROD
 templates:
-    cloudformation:
-        type: cloud-formation
-        parameters:
-            amiEncrypted: true
-            amiTags:
-                # Keep the Node version in sync with `.nvmrc`
-                Recipe: dotcom-rendering-ARM-jammy-node-18.18.2-v2
-                AmigoStage: PROD
+  cloudformation:
+    type: cloud-formation
+    parameters:
+      amiEncrypted: true
+      amiTags:
+        # Keep the Node version in sync with `.nvmrc`
+        Recipe: dotcom-rendering-ARM-jammy-node-18.18.2-v2
+        AmigoStage: PROD
 deployments:
-    frontend-cfn:
-        template: cloudformation
-        parameters:
-            templateStagePaths:
-                CODE: DotcomRendering-CODE.template.json
-                PROD: DotcomRendering-PROD.template.json
-            cloudFormationStackByTags: false
-            cloudFormationStackName: rendering
-            amiParameter: AMIRendering
-    rendering:
-        type: autoscaling
-        parameters:
-            bucketSsmKey: /account/services/dotcom-artifact.bucket
-        dependencies:
-            - frontend-static
-            - frontend-cfn
-    front-web-cfn:
-        template: cloudformation
-        parameters:
-            templateStagePaths:
-                CODE: DotcomRendering-front-web-CODE.template.json
-                PROD: DotcomRendering-front-web-PROD.template.json
-            cloudFormationStackByTags: false
-            cloudFormationStackName: front-web
-            amiParameter: AMIFrontweb
-    front-web:
-        type: autoscaling
-        parameters:
-            bucketSsmKey: /account/services/dotcom-artifact.bucket
-        dependencies:
-            - frontend-static
-            - front-web-cfn
-    frontend-static:
-        type: aws-s3
-        parameters:
-            bucketSsmKey: /account/services/dotcom-static.bucket
-            cacheControl:
-                - pattern: \/stats\/ # stats file can change on each deploy
-                  value: max-age=3600 # one hour in seconds
-                  # assume all other assets are hashed and never change,
-                  # even though this is not the case–e.g. icons
-                - pattern: .*
-                  value: public, max-age=315360000, immutable # one year in seconds
-            prefixStack: false
-            publicReadAcl: false
+  frontend-cfn:
+    template: cloudformation
+    parameters:
+      templateStagePaths:
+        CODE: DotcomRendering-CODE.template.json
+        PROD: DotcomRendering-PROD.template.json
+      cloudFormationStackByTags: false
+      cloudFormationStackName: rendering
+      amiParameter: AMIRendering
+  rendering:
+    type: autoscaling
+    parameters:
+      bucketSsmKey: /account/services/dotcom-artifact.bucket
+    dependencies:
+      - frontend-static
+      - frontend-cfn
+  front-web-cfn:
+    template: cloudformation
+    parameters:
+      templateStagePaths:
+        CODE: DotcomRendering-front-web-CODE.template.json
+        PROD: DotcomRendering-front-web-PROD.template.json
+      cloudFormationStackByTags: false
+      cloudFormationStackName: front-web
+      amiParameter: AMIFrontweb
+  front-web:
+    type: autoscaling
+    parameters:
+      bucketSsmKey: /account/services/dotcom-artifact.bucket
+    dependencies:
+      - frontend-static
+      - front-web-cfn
+  frontend-static:
+    type: aws-s3
+    parameters:
+      bucketSsmKey: /account/services/dotcom-static.bucket
+      cacheControl:
+        - pattern: \/stats\/ # stats file can change on each deploy
+          value: max-age=3600 # one hour in seconds
+          # assume all other assets are hashed and never change,
+          # even though this is not the case–e.g. icons
+        - pattern: .*
+          value: public, max-age=315360000, immutable # one year in seconds
+      prefixStack: false
+      publicReadAcl: false

--- a/dotcom-rendering/scripts/nginx/nginx-mappings.yaml
+++ b/dotcom-rendering/scripts/nginx/nginx-mappings.yaml
@@ -1,5 +1,5 @@
 name: dotcom-rendering
 domain-root: thegulocal.com
 mappings:
-    - prefix: r
-      port: 3030
+  - prefix: r
+    port: 3030


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

makes sure `.yaml` files get the same treatment as `.yml` files

## Why?

consistency, and less noise in #9476 (pnpm uses the `.yaml` extension)

