### PR TITLE
Modify NumberedList dark mode styles

### DIFF
--- a/dotcom-rendering/src/components/NumberedTitleBlockComponent.tsx
+++ b/dotcom-rendering/src/components/NumberedTitleBlockComponent.tsx
@@ -13,6 +13,7 @@ type Props = {
 const titleStyles = css`
 	h2 {
 		${headline.medium({ fontWeight: 'light' })}
+		color: ${themePalette('--numbered-list-heading')}
 	}
 
 	strong {
@@ -25,7 +26,7 @@ const titleStyles = css`
 const numberStyles = (palette: Palette) => css`
 	${headline.large({ fontWeight: 'bold' })}
 	font-size: 56px;
-	color: ${palette.text.numberedPosition};
+	color: ${themePalette('--numbered-list-number')};
 `;
 
 export const NumberedTitleBlockComponent = ({

--- a/dotcom-rendering/src/lib/decidePalette.ts
+++ b/dotcom-rendering/src/lib/decidePalette.ts
@@ -13,7 +13,6 @@ import {
 	palette,
 	specialReport,
 	sport,
-	text,
 } from '@guardian/source-foundations';
 // Here is the one place where we use `pillarPalette`
 import { pillarPalette_DO_NOT_USE as pillarPalette } from '../lib/pillars';
@@ -447,10 +446,6 @@ const textDateLine = (format: ArticleFormat): string => {
 	return neutral[46];
 };
 
-const textNumberedPosition = (): string => {
-	return text.supporting;
-};
-
 const textFilterButton = (): string => neutral[7];
 
 const textFilterButtonHover = (): string => neutral[100];
@@ -631,7 +626,6 @@ export const decidePalette = (
 			standfirstLink: textStandfirstLink(format),
 			lastUpdated: textLastUpdated(format),
 			disclaimerLink: textDisclaimerLink(format),
-			numberedPosition: textNumberedPosition(),
 			cricketScoreboardLink: textCricketScoreboardLink(),
 			filterButton: textFilterButton(),
 			filterButtonHover: textFilterButtonHover(),

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -2726,6 +2726,11 @@ const keyEventButtonFillLight: PaletteFunction = () =>
 	sourcePalette.neutral[100];
 const keyEventButtonFillDark: PaletteFunction = () => sourcePalette.neutral[7];
 
+const numberedListNumberLight: PaletteFunction = () =>
+	sourcePalette.neutral[46];
+
+const numberedListNumberDark: PaletteFunction = () => sourcePalette.neutral[60];
+
 const numberedListTitleLight: PaletteFunction = ({ theme }) => {
 	switch (theme) {
 		case Pillar.News:
@@ -2744,8 +2749,32 @@ const numberedListTitleLight: PaletteFunction = ({ theme }) => {
 };
 
 const numberedListTitleDark: PaletteFunction = ({ theme }) => {
-	return sourcePalette.neutral[86];
+	switch (theme) {
+		case Pillar.News:
+		case Pillar.Sport:
+		case Pillar.Lifestyle:
+		case Pillar.Culture:
+		case Pillar.Opinion:
+			return pillarPalette(theme, 500);
+		case ArticleSpecial.Labs:
+			return sourcePalette.labs[400];
+		case ArticleSpecial.SpecialReport:
+			return sourcePalette.specialReport[500];
+		case ArticleSpecial.SpecialReportAlt:
+			return sourcePalette.specialReportAlt[300];
+	}
 };
+const numberedListHeadingLight: PaletteFunction = () =>
+	sourcePalette.neutral[7];
+
+const numberedListHeadingDark: PaletteFunction = () =>
+	sourcePalette.neutral[86];
+
+const numberedListLinksLight: PaletteFunction = (format: ArticleFormat) =>
+	numberedListTitleLight(format);
+
+const numberedListLinksDark: PaletteFunction = (format: ArticleFormat) =>
+	numberedListTitleDark(format);
 
 const summaryEventBulletLight: PaletteFunction = ({ theme }) => {
 	switch (theme) {
@@ -2940,7 +2969,28 @@ const articleLinkTextLight: PaletteFunction = ({ design, theme }) => {
 	}
 };
 
-const articleLinkTextDark: PaletteFunction = () => sourcePalette.neutral[86];
+const articleLinkTextDark: PaletteFunction = ({ display, theme }) => {
+	switch (display) {
+		case ArticleDisplay.NumberedList: {
+			switch (theme) {
+				case Pillar.News:
+				case Pillar.Sport:
+				case Pillar.Lifestyle:
+				case Pillar.Culture:
+				case Pillar.Opinion:
+					return pillarPalette(theme, 500);
+				case ArticleSpecial.Labs:
+					return sourcePalette.labs[400];
+				case ArticleSpecial.SpecialReport:
+					return sourcePalette.specialReport[500];
+				case ArticleSpecial.SpecialReportAlt:
+					return sourcePalette.specialReportAlt[300];
+			}
+		}
+		default:
+			return sourcePalette.neutral[86];
+	}
+};
 
 const articleLinkBorderLight: PaletteFunction = ({ design, theme }) => {
 	if (theme === ArticleSpecial.Labs) return sourcePalette.neutral[60];
@@ -4798,9 +4848,21 @@ const paletteColours = {
 		light: keyEventButtonFillLight,
 		dark: keyEventButtonFillDark,
 	},
+	'--numbered-list-number': {
+		light: numberedListNumberLight,
+		dark: numberedListNumberDark,
+	},
 	'--numbered-list-title': {
 		light: numberedListTitleLight,
 		dark: numberedListTitleDark,
+	},
+	'--numbered-list-links': {
+		light: numberedListLinksLight,
+		dark: numberedListLinksDark,
+	},
+	'--numbered-list-heading': {
+		light: numberedListHeadingLight,
+		dark: numberedListHeadingDark,
 	},
 	'--summary-event-bullet': {
 		light: summaryEventBulletLight,

--- a/dotcom-rendering/src/types/palette.ts
+++ b/dotcom-rendering/src/types/palette.ts
@@ -7,7 +7,6 @@ export type Palette = {
 		standfirstLink: Colour;
 		lastUpdated: Colour;
 		disclaimerLink: Colour;
-		numberedPosition: Colour;
 		cricketScoreboardLink: Colour;
 		filterButton: Colour;
 		filterButtonHover: Colour;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Tweaks styles for `NumberedList` display in dark mode.

## Why?
To match the new design: https://www.figma.com/file/oNsBRC808POFF0EyZFWSUi/New-Formats-2023?type=design&node-id=1292-25450&mode=design&t=k8h3agwvItDg1oDv-0

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/34d8f3f9-fb76-4b83-adb1-6bd03b06356f) | ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/7dd8ea1b-c4a2-4b86-825e-c7043f9d09a7) |
| ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/4f37f223-6ab1-446a-abdc-8678e8117cb5) | ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/747ec60f-f13d-48c3-b168-6fca7e5d2a0d) |


[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
