### PR TITLE
Add `rp` (rendering-platform) ad targeting property to apps

### DIFF
--- a/dotcom-rendering/src/lib/sendTargetingParams.apps.test.ts
+++ b/dotcom-rendering/src/lib/sendTargetingParams.apps.test.ts
@@ -60,6 +60,7 @@ describe('getTargetingParams', () => {
 			['edition', 'uk'],
 			['tn', 'news'],
 			['p', 'app'],
+			['rp', 'dotcom-rendering'],
 			['k', 'us-politics,state-of-georgia,us-crime,us-news,donaldtrump'],
 		]);
 

--- a/dotcom-rendering/src/lib/sendTargetingParams.apps.ts
+++ b/dotcom-rendering/src/lib/sendTargetingParams.apps.ts
@@ -14,5 +14,7 @@ export const getTargetingParams = (
 					? adTargetingParam.value.join(',')
 					: adTargetingParam.value,
 			]),
-	).set('p', 'app');
+	)
+		.set('p', 'app')
+		.set('rp', 'dotcom-rendering');
 };


### PR DESCRIPTION
## What does this change?

Add `rp` (rendering-platform) ad targeting property to DCAR.

## Why?

We want to be able to distinguish between AR and DCAR ad requests so we can confirm that there is no adverse impact to ad metrics when rolling out DCAR.