### PR TITLE
PillarButton - Fix hover state

### DIFF
--- a/dotcom-rendering/src/components/Discussion/PillarButton.tsx
+++ b/dotcom-rendering/src/components/Discussion/PillarButton.tsx
@@ -48,6 +48,9 @@ const buttonOverrides = (priority: 'primary' | 'secondary' | 'subdued') => {
 						background-color: ${themePalette(
 							'--discussion-button-hover',
 						)};
+						border: 1px solid
+							${themePalette('--discussion-button-hover')};
+						color: ${sourcePalette.neutral[100]};
 					}
 				}
 			`;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Updates the primary pillar button, so that hovering doesn't turn the button the same colour as the text

## Why?
Bug introduced accidentally as part of 
Reported via email
Resolves https://github.com/guardian/dotcom-rendering/issues/9927
## Screenshots

| Before      | After      |
| ----------- | ---------- |
| <img width="1161" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/e45d2da8-bfb5-4d85-88ef-0b58d069205b"> | <img width="1161" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/7519c170-7b47-4d05-91b8-fcf28a01c55c">|
