### PR TITLE
ci: update AMI recipe to one using cdk-base

### DIFF
--- a/dotcom-rendering/scripts/check-node-versions.mjs
+++ b/dotcom-rendering/scripts/check-node-versions.mjs
@@ -35,8 +35,7 @@ const requiredNodeVersionMatches =
 		},
 		{
 			filepath: 'scripts/deploy/riff-raff.yaml',
-			pattern:
-				/^ +Recipe: dotcom-rendering.*-node-(\d+\.\d+\.\d+)(-v.*)?$/m,
+			pattern: /^ +Recipe: dotcom-rendering.*-node-(\d+\.\d+\.\d+).*?$/m,
 		},
 		{
 			filepath: '../apps-rendering/riff-raff.yaml',

--- a/dotcom-rendering/scripts/deploy/riff-raff.yaml
+++ b/dotcom-rendering/scripts/deploy/riff-raff.yaml
@@ -10,7 +10,7 @@ templates:
       amiEncrypted: true
       amiTags:
         # Keep the Node version in sync with `.nvmrc`
-        Recipe: dotcom-rendering-ARM-jammy-node-18.18.2-v2
+        Recipe: dotcom-rendering-ARM-jammy-node-18.18.2-cdk-base
         AmigoStage: PROD
 deployments:
   frontend-cfn:


### PR DESCRIPTION
## What does this change?

Adds new Amigo recipe to DCR, with `cdk-base` included

## Why?

We want to start using `devx-logs` which is shipped with the `cdk-base` amigo role.

Splits off smaller changes from PR #9924. 
Part of #9912

