### PR TITLE
add styling to detect merch billboard class

### DIFF
--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -141,6 +141,11 @@ const adSlotCollapseStyles = css`
 	&.ad-slot.ad-slot--collapse {
 		display: none;
 	}
+	&.ad-slot--merchandising-billboard {
+		${until.desktop} {
+			display: none;
+		}
+	}
 `;
 
 /**
@@ -550,6 +555,7 @@ export const AdSlot = ({
 							fluidAdStyles,
 							fluidFullWidthAdStyles,
 							merchandisingAdStyles,
+							adSlotCollapseStyles,
 						]}
 						data-link-name="ad slot merchandising-high"
 						data-name="merchandising-high"
@@ -576,6 +582,7 @@ export const AdSlot = ({
 							fluidAdStyles,
 							fluidFullWidthAdStyles,
 							merchandisingAdStyles,
+							adSlotCollapseStyles,
 						]}
 						data-link-name="ad slot merchandising"
 						data-name="merchandising"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
This PR aims to  collapse `merchandise` and `merchandise-high` slot on viewport resize if billboard ad no longer fits in viewport.

This adds CSS to  `ad-slot--merchandising-billboard` to hide the slot for tablet and mobile viewport size.

This is related to the `commercial` PR which adds a class to the elements for the merchandising and merchandising-high ad slots:  https://github.com/guardian/commercial/pull/1194

## Why?
As we are now dynamically loading the merchandise slot with a `billboard` sized ad (changed for black Friday).

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| <img width="300" alt="Screenshot 2023-12-18 at 11 17 06" src="https://github.com/guardian/dotcom-rendering/assets/49187886/bfcc6233-8426-4894-aad7-12679a833953"> | <img width="300" alt="Screenshot 2023-12-18 at 11 23 35" src="https://github.com/guardian/dotcom-rendering/assets/49187886/5ea95f54-9a2c-496e-a890-4f296a85a3f2">|


Before:

https://github.com/guardian/dotcom-rendering/assets/49187886/41311d64-a13c-4b7a-bded-acd4b26fa1e7

After:

https://github.com/guardian/dotcom-rendering/assets/49187886/cba4ae3b-2f94-4582-b931-e1341be3924b



<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
