### PR TITLE
Remove `isServer` helper

### DIFF
--- a/dotcom-rendering/scripts/jest/setup.ts
+++ b/dotcom-rendering/scripts/jest/setup.ts
@@ -2,7 +2,6 @@
 // add some helpful assertions
 import '@testing-library/jest-dom/extend-expect';
 import { TextDecoder, TextEncoder } from 'node:util';
-import { isServer } from '../../src/lib/isServer';
 import type { Guardian } from '../../src/model/guardian';
 
 const windowGuardianConfig = {
@@ -68,7 +67,7 @@ const windowGuardian = {
 // We should never be able to directly set things to the global window object.
 // But in this case we want to stub things for testing, so it's ok to ignore this rule
 // @ts-expect-error
-!isServer && (window.guardian = windowGuardian);
+window.guardian = windowGuardian;
 
 // Mock Local Storage
 // See: https://github.com/facebook/jest/issues/2098#issuecomment-260733457
@@ -93,10 +92,9 @@ const localStorageMock = (function () {
 	};
 })();
 
-!isServer &&
-	Object.defineProperty(window, 'localStorage', {
-		value: localStorageMock,
-	});
+Object.defineProperty(window, 'localStorage', {
+	value: localStorageMock,
+});
 
 /**
  * This is to polyfill `TextEncoder` and `TextDecoder`.

--- a/dotcom-rendering/src/client/adaptiveSite.ts
+++ b/dotcom-rendering/src/client/adaptiveSite.ts
@@ -1,5 +1,4 @@
 import { log } from '@guardian/libs';
-import { isServer } from '../lib/isServer';
 import { setSchedulerPriorityLastStartTime } from '../lib/scheduler';
 import type { RenderingTarget } from '../types/renderingTarget';
 import { recordExperiences } from './ophan/ophan';
@@ -11,7 +10,6 @@ import { recordExperiences } from './ophan/ophan';
  * complete if you're in the adaptive site test variant.
  */
 export const shouldAdapt = async (): Promise<boolean> => {
-	if (isServer) return false;
 	if (window.location.hash === '#adapt') return true;
 	if (window.guardian.config.tests.adaptiveSiteVariant !== 'variant') {
 		return false;

--- a/dotcom-rendering/src/components/SignInGate/componentEventTracking.tsx
+++ b/dotcom-rendering/src/components/SignInGate/componentEventTracking.tsx
@@ -1,6 +1,5 @@
 import type { OphanComponent, OphanComponentEvent } from '@guardian/libs';
 import { getOphan } from '../../client/ophan/ophan';
-import { isServer } from '../../lib/isServer';
 import type { RenderingTarget } from '../../types/renderingTarget';
 import type { CurrentSignInGateABTest } from './types';
 
@@ -18,8 +17,6 @@ const submitComponentEventTracking = async (
 	componentEvent: OphanComponentEvent,
 	renderingTarget: RenderingTarget,
 ) => {
-	if (isServer) return;
-
 	const ophan = await getOphan(renderingTarget);
 	ophan.record({ componentEvent });
 };

--- a/dotcom-rendering/src/lib/isServer.ts
+++ b/dotcom-rendering/src/lib/isServer.ts
@@ -1,1 +1,0 @@
-export const isServer = typeof window === 'undefined';


### PR DESCRIPTION


<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Remove `isServer` helper

## Why?

It should not be relied upon