### PR TITLE
Warn on non-SSR friendly code

### DIFF
--- a/dotcom-rendering/.eslintrc.js
+++ b/dotcom-rendering/.eslintrc.js
@@ -66,6 +66,7 @@ module.exports = {
 		// eslint-config-prettier disables formatting rules that conflict with prettier
 		// needs to go last so it can override other configuration. See https://github.com/prettier/eslint-config-prettier#installation
 		'prettier',
+		'plugin:ssr-friendly/recommended',
 	],
 	parser: '@typescript-eslint/parser',
 	parserOptions: {
@@ -82,6 +83,7 @@ module.exports = {
 		'jsx-expressions',
 		'custom-elements',
 		'unicorn',
+		'ssr-friendly',
 	],
 	rules: {
 		// React, Hooks & JSX
@@ -167,6 +169,9 @@ module.exports = {
 		],
 
 		'unicorn/prefer-node-protocol': 'error',
+
+		'ssr-friendly/no-dom-globals-in-module-scope': 'warn',
+		'ssr-friendly/no-dom-globals-in-react-fc': 'warn',
 
 		...rulesToReview,
 		...rulesToEnforce,
@@ -259,6 +264,13 @@ module.exports = {
 			],
 			rules: {
 				'import/no-default-export': 'off',
+			},
+		},
+		{
+			files: ['src/client/**/*.ts'],
+			rules: {
+				// the modules in the src/client/ directory are meant to run in a browser
+				'ssr-friendly/no-dom-globals-in-module-scope': 'off',
 			},
 		},
 	],

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -178,6 +178,7 @@
 		"eslint-plugin-mocha": "10.1.0",
 		"eslint-plugin-react": "7.33.2",
 		"eslint-plugin-react-hooks": "4.6.0",
+		"eslint-plugin-ssr-friendly": "1.3.0",
 		"eslint-plugin-unicorn": "48.0.1",
 		"eslint-stats": "1.0.1",
 		"execa": "5.1.1",

--- a/dotcom-rendering/scripts/jest/setup.ts
+++ b/dotcom-rendering/scripts/jest/setup.ts
@@ -1,3 +1,4 @@
+/* eslint-disable ssr-friendly/no-dom-globals-in-module-scope -- this runs in JSDOM */
 // add some helpful assertions
 import '@testing-library/jest-dom/extend-expect';
 import { TextDecoder, TextEncoder } from 'node:util';

--- a/yarn.lock
+++ b/yarn.lock
@@ -4546,6 +4546,7 @@ __metadata:
     eslint-plugin-mocha: "npm:10.1.0"
     eslint-plugin-react: "npm:7.33.2"
     eslint-plugin-react-hooks: "npm:4.6.0"
+    eslint-plugin-ssr-friendly: "npm:1.3.0"
     eslint-plugin-unicorn: "npm:48.0.1"
     eslint-stats: "npm:1.0.1"
     execa: "npm:5.1.1"
@@ -14661,6 +14662,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-plugin-ssr-friendly@npm:1.3.0":
+  version: 1.3.0
+  resolution: "eslint-plugin-ssr-friendly@npm:1.3.0"
+  dependencies:
+    globals: "npm:^13.8.0"
+  peerDependencies:
+    eslint: ">=0.8.0"
+  checksum: 6238caf31bca475332f8878e70865b24f23727d5f6fd568799de1290d5bc2bcd2698a343fef8de962552fad56d62ea7b244890f80f76febf75fb950a0f700197
+  languageName: node
+  linkType: hard
+
 "eslint-plugin-unicorn@npm:48.0.1":
   version: 48.0.1
   resolution: "eslint-plugin-unicorn@npm:48.0.1"
@@ -16145,6 +16157,15 @@ __metadata:
   dependencies:
     type-fest: "npm:^0.20.2"
   checksum: fc05e184b3be59bffa2580f28551a12a758c3a18df4be91444202982c76f13f52821ad54ffaf7d3f2a4d2498fdf54aeaca8d4540fd9e860a9edb09d34ef4c507
+  languageName: node
+  linkType: hard
+
+"globals@npm:^13.8.0":
+  version: 13.24.0
+  resolution: "globals@npm:13.24.0"
+  dependencies:
+    type-fest: "npm:^0.20.2"
+  checksum: d3c11aeea898eb83d5ec7a99508600fbe8f83d2cf00cbb77f873dbf2bcb39428eff1b538e4915c993d8a3b3473fa71eeebfe22c9bb3a3003d1e26b1f2c8a42cd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Add a new [ESLint rule to ensure our code is SSR friendly](https://github.com/kopiro/eslint-plugin-ssr-friendly), but set its level to **WARN**

We can make it an **ERROR** once all 19 instances of non-isomorphic code are addressed.

## Why?

Prevent regressions from happening after #8991 

Enable the work in #9757