### PR TITLE
Awaited type in `SetABTest` rather than derived from window

### DIFF
--- a/dotcom-rendering/src/components/SetABTests.importable.tsx
+++ b/dotcom-rendering/src/components/SetABTests.importable.tsx
@@ -36,7 +36,7 @@ export const SetABTests = ({
 	forcedTestVariants,
 }: Props) => {
 	const { renderingTarget } = useConfig();
-	const [ophan, setOphan] = useState<typeof window.guardian.ophan>();
+	const [ophan, setOphan] = useState<Awaited<ReturnType<typeof getOphan>>>();
 
 	useEffect(() => {
 		getOphan(renderingTarget)


### PR DESCRIPTION
## What does this change?

Use hooks to ensure that `SetABTests` is server-safe, rather than `typeof window` checks.

## Why?

Follow-up on:
- #9938 
- #8991 