### PR TITLE
Pass switches explicitely to `SlotBodyEnd`

### DIFF
--- a/dotcom-rendering/src/components/Island.test.tsx
+++ b/dotcom-rendering/src/components/Island.test.tsx
@@ -403,8 +403,9 @@ describe('Island: server-side rendering', () => {
 						stage={''}
 						pageId={''}
 						keywordIds={''}
-						renderAds={false}
+						renderAds={true}
 						isLabs={false}
+						articleEndSlot={true}
 					/>
 				</ConfigProvider>,
 			),

--- a/dotcom-rendering/src/components/SlotBodyEnd.importable.tsx
+++ b/dotcom-rendering/src/components/SlotBodyEnd.importable.tsx
@@ -45,6 +45,7 @@ type Props = {
 	keywordIds: string;
 	renderAds: boolean;
 	isLabs: boolean;
+	articleEndSlot: boolean;
 };
 
 const buildReaderRevenueEpicConfig = (
@@ -135,6 +136,7 @@ export const SlotBodyEnd = ({
 	keywordIds,
 	renderAds,
 	isLabs,
+	articleEndSlot,
 }: Props) => {
 	const { renderingTarget } = useConfig();
 	const { brazeMessages } = useBraze(idApiUrl, renderingTarget);
@@ -149,10 +151,7 @@ export const SlotBodyEnd = ({
 
 	// Show the article end slot if the epic is not shown, currently only used in the US for Public Good
 	const showArticleEndSlot =
-		renderAds &&
-		!isLabs &&
-		countryCode === 'US' &&
-		window.guardian.config.switches.articleEndSlot;
+		renderAds && !isLabs && countryCode === 'US' && articleEndSlot;
 
 	useEffect(() => {
 		setAsyncArticleCount(

--- a/dotcom-rendering/src/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/layouts/CommentLayout.tsx
@@ -662,6 +662,10 @@ export const CommentLayout = (props: WebProps | AppsProps) => {
 												tags={article.tags}
 												renderAds={renderAds}
 												isLabs={false}
+												articleEndSlot={
+													!!article.config.switches
+														.articleEndSlot
+												}
 											/>
 										</Island>
 									)}

--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -678,6 +678,10 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 											tags={article.tags}
 											renderAds={renderAds}
 											isLabs={isLabs}
+											articleEndSlot={
+												!!article.config.switches
+													.articleEndSlot
+											}
 										/>
 									</Island>
 								)}

--- a/dotcom-rendering/src/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/InteractiveLayout.tsx
@@ -604,6 +604,9 @@ export const InteractiveLayout = (props: WebProps | AppsProps) => {
 								tags={article.tags}
 								renderAds={renderAds}
 								isLabs={false}
+								articleEndSlot={
+									!!article.config.switches.articleEndSlot
+								}
 							/>
 						</Island>
 					</div>

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -662,6 +662,10 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 											tags={article.tags}
 											renderAds={renderAds}
 											isLabs={isLabs}
+											articleEndSlot={
+												!!article.config.switches
+													.articleEndSlot
+											}
 										/>
 									</Island>
 								)}

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -740,6 +740,10 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 											tags={article.tags}
 											renderAds={renderAds}
 											isLabs={isLabs}
+											articleEndSlot={
+												!!article.config.switches
+													.articleEndSlot
+											}
 										/>
 									</Island>
 								)}


### PR DESCRIPTION
## What does this change?

No window access in component, relying instead on the data model.

## Why?

Follow-up on:
- #9938 
- #8991 