### PR TITLE
Make `ManyNewsletterSignUp` use props instead of the window global

### DIFF
--- a/dotcom-rendering/.storybook/preview.ts
+++ b/dotcom-rendering/.storybook/preview.ts
@@ -64,11 +64,7 @@ window.guardian = {
 			pageViewId: 'mockPageViewId',
 		},
 		page: {
-			googleRecaptchaSiteKey: 'TEST_RECAPTCHA_SITE_KEY',
 			ajaxUrl: 'https://api.nextgen.guardianapps.co.uk',
-		},
-		switches: {
-			emailSignupRecaptcha: false,
 		},
 		tests: {},
 	},

--- a/dotcom-rendering/src/components/ManyNewsletterSignUp.importable.tsx
+++ b/dotcom-rendering/src/components/ManyNewsletterSignUp.importable.tsx
@@ -12,9 +12,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 // that version will compile and render but is non-functional.
 // Use the default export instead.
 import ReactGoogleRecaptcha from 'react-google-recaptcha';
-import { isServer } from '../lib/isServer';
 import {
-	getCaptchaSiteKey,
 	reportTrackingEvent,
 	requestMultipleSignUps,
 } from '../lib/newsletter-sign-up-requests';
@@ -125,7 +123,15 @@ const attributeToNumber = (
 	return numericValue;
 };
 
-export const ManyNewsletterSignUp = () => {
+type Props = {
+	useReCaptcha: boolean;
+	captchaSiteKey?: string;
+};
+
+export const ManyNewsletterSignUp = ({
+	useReCaptcha,
+	captchaSiteKey,
+}: Props) => {
 	const [newslettersToSignUpFor, setNewslettersToSignUpFor] = useState<
 		{
 			/** unique identifier for the newsletter in kebab-case format */
@@ -137,10 +143,6 @@ export const ManyNewsletterSignUp = () => {
 	const [status, setStatus] = useState<FormStatus>('NotSent');
 	const [email, setEmail] = useState('');
 	const reCaptchaRef = useRef<ReactGoogleRecaptcha>(null);
-	const useReCaptcha = isServer
-		? false
-		: !!window.guardian.config.switches['emailSignupRecaptcha'];
-	const captchaSiteKey = useReCaptcha ? getCaptchaSiteKey() : undefined;
 
 	const userCanInteract = status !== 'Success' && status !== 'Loading';
 	const { renderingTarget } = useConfig();

--- a/dotcom-rendering/src/components/ManyNewsletterSignUp.stories.tsx
+++ b/dotcom-rendering/src/components/ManyNewsletterSignUp.stories.tsx
@@ -44,7 +44,10 @@ export const Default = () => {
 					],
 				}}
 			/>
-			<ManyNewsletterSignUp />
+			<ManyNewsletterSignUp
+				useReCaptcha={false}
+				captchaSiteKey="TEST_RECAPTCHA_SITE_KEY"
+			/>
 		</>
 	);
 };

--- a/dotcom-rendering/src/layouts/AllEditorialNewslettersPageLayout.tsx
+++ b/dotcom-rendering/src/layouts/AllEditorialNewslettersPageLayout.tsx
@@ -161,7 +161,15 @@ export const AllEditorialNewslettersPageLayout = ({
 					groupedNewsletters={newslettersPage.groupedNewsletters}
 				/>
 				<Island priority="feature" defer={{ until: 'idle' }}>
-					<ManyNewsletterSignUp />
+					<ManyNewsletterSignUp
+						useReCaptcha={
+							!!newslettersPage.config.switches
+								.emailSignupRecaptcha
+						}
+						captchaSiteKey={
+							newslettersPage.config.googleRecaptchaSiteKey
+						}
+					/>
 				</Island>
 			</main>
 

--- a/dotcom-rendering/src/lib/newsletter-sign-up-requests.ts
+++ b/dotcom-rendering/src/lib/newsletter-sign-up-requests.ts
@@ -2,11 +2,6 @@ import type { OphanAction } from '@guardian/libs';
 import { submitComponentEvent } from '../client/ophan/ophan';
 import type { RenderingTarget } from '../types/renderingTarget';
 
-const isServer = typeof window === 'undefined';
-
-export const getCaptchaSiteKey = (): string | undefined =>
-	isServer ? undefined : window.guardian.config.page.googleRecaptchaSiteKey;
-
 const buildNewsletterSignUpFormData = (
 	emailAddress: string,
 	newsletterIdOrList: string | string[],


### PR DESCRIPTION


<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Pass switches values as props to the `ManyNewsletterSignUp` component.

## Why?

No need to access the window for information that is available in the config at page initialisation.

Follow-up on:
- #8991 