### PR TITLE
Darkmode - timeline atom

### DIFF
--- a/dotcom-rendering/src/components/TimelineAtom.importable.tsx
+++ b/dotcom-rendering/src/components/TimelineAtom.importable.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react';
 import { body, palette, remSpace, space } from '@guardian/source-foundations';
 import { submitComponentEvent } from '../client/ophan/ophan';
+import { palette as schemedPalette } from '../palette';
 import type { TimelineAtomType, TimelineEvent } from '../types/content';
 import { useConfig } from './ConfigContext';
 import { Body } from './ExpandableAtom/Body';
@@ -31,7 +32,7 @@ const EventDateBullet = css`
 	float: left;
 	position: relative;
 	left: -24px;
-	background-color: ${palette.neutral[7]};
+	background-color: ${schemedPalette('--timeline-atom-bullet')};
 `;
 
 const EventDate = css`
@@ -39,7 +40,8 @@ const EventDate = css`
 		${EventDateBullet}
 	}
 	margin-left: -16px;
-	background: ${palette.brandAlt[400]};
+	background: ${schemedPalette('--timeline-atom-highlight-text-background')};
+	color: ${schemedPalette('--timeline-atom-highlight-text')};
 	${body.medium({
 		lineHeight: 'tight',
 		fontWeight: 'bold',
@@ -47,7 +49,8 @@ const EventDate = css`
 `;
 
 const EventToDate = css`
-	background: ${palette.brandAlt[400]};
+	background: ${schemedPalette('--timeline-atom-highlight-text-background')};
+	color: ${schemedPalette('--timeline-atom-highlight-text')};
 	${body.medium({
 		lineHeight: 'tight',
 		fontWeight: 'bold',

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -4527,6 +4527,19 @@ const expandingAtomButtonTextLight: PaletteFunction = () =>
 const expandingAtomButtonTextDark: PaletteFunction = () =>
 	sourcePalette.neutral[0];
 
+const timelineAtomBulletLight: PaletteFunction = () => sourcePalette.neutral[7];
+const timelineAtomBulletDark: PaletteFunction = () => sourcePalette.neutral[93];
+sourcePalette.neutral[0];
+
+const timelineAtomHighlightText: PaletteFunction = () =>
+	sourcePalette.neutral[0];
+
+const timelineAtomHighlightTextBackgroundLight: PaletteFunction = () =>
+	sourcePalette.brandAlt[400];
+const timelineAtomHighlightTextBackgroundDark: PaletteFunction = () =>
+	sourcePalette.brandAlt[200];
+sourcePalette.neutral[0];
+
 // ----- Palette ----- //
 
 /**
@@ -5309,6 +5322,18 @@ const paletteColours = {
 	'--expanding-atom-button-text': {
 		light: expandingAtomButtonTextLight,
 		dark: expandingAtomButtonTextDark,
+	},
+	'--timeline-atom-bullet': {
+		light: timelineAtomBulletLight,
+		dark: timelineAtomBulletDark,
+	},
+	'--timeline-atom-highlight-text': {
+		light: timelineAtomHighlightText,
+		dark: timelineAtomHighlightText,
+	},
+	'--timeline-atom-highlight-text-background': {
+		light: timelineAtomHighlightTextBackgroundLight,
+		dark: timelineAtomHighlightTextBackgroundDark,
 	},
 } satisfies PaletteColours;
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

## Why?
Resolves https://github.com/guardian/dotcom-rendering/issues/9948

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
