### PR TITLE
Add light/dark mode stories to expanding atoms

### DIFF
--- a/dotcom-rendering/src/components/GuideAtom/GuideAtom.stories.tsx
+++ b/dotcom-rendering/src/components/GuideAtom/GuideAtom.stories.tsx
@@ -1,56 +1,112 @@
 import { css } from '@emotion/react';
-import { palette as sourcePalette } from '@guardian/source-foundations';
+import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
+import { splitTheme } from '../../../.storybook/decorators/splitThemeDecorator';
 import {
 	analysisStoryExpanded,
+	defaultStory,
 	defaultStoryExpanded,
 	imageStoryExpanded,
 	lifestylePillarStoryExpanded,
 	listStoryExpanded,
 	orderedListStoryExpanded,
 } from '../../../fixtures/manual/guideAtom';
+import { palette } from '../../palette';
 import { GuideAtom } from './GuideAtom';
+
+const format = {
+	display: ArticleDisplay.Standard,
+	design: ArticleDesign.Standard,
+	theme: Pillar.Sport,
+};
 
 export default {
 	title: 'Components/GuideAtom',
 	component: GuideAtom,
 };
 
+export const DefaultStoryCollapsed = (): JSX.Element => {
+	// Modelled after: https://www.theguardian.com/sport/2020/may/19/pinatubo-has-probably-trained-on-for-the-2000-guineas-says-charlie-appleby
+	return <GuideAtom {...defaultStory} />;
+};
+DefaultStoryCollapsed.decorators = [splitTheme([format])];
+
 export const DefaultStoryExpanded = (): JSX.Element => {
 	// Modelled after: https://www.theguardian.com/sport/2020/may/19/pinatubo-has-probably-trained-on-for-the-2000-guineas-says-charlie-appleby
 	return <GuideAtom {...defaultStoryExpanded} />;
 };
+DefaultStoryExpanded.decorators = [splitTheme([format])];
 
 export const ListStoryExpanded = (): JSX.Element => {
 	//Modelled after: https://www.theguardian.com/business/2020/jan/27/global-markets-slide-on-back-of-coronavirus-concerns-in-china-stocks
 	return <GuideAtom {...listStoryExpanded} />;
 };
+ListStoryExpanded.decorators = [
+	splitTheme([
+		{
+			...format,
+			theme: Pillar.News,
+		},
+	]),
+];
 
 export const OrderedListStoryExpanded = (): JSX.Element => {
 	//Modelled after: https://www.theguardian.com/environment/2020/aug/01/plan-to-curb-englands-most-polluted-spot-divides-residents
 	return <GuideAtom {...orderedListStoryExpanded} />;
 };
+OrderedListStoryExpanded.decorators = [
+	splitTheme([
+		{
+			...format,
+			theme: Pillar.News,
+		},
+	]),
+];
 
 export const ImageStoryExpanded = (): JSX.Element => {
 	//Modelled after: https://www.theguardian.com/politics/2019/jul/06/tory-member-questions-boris-johnsons-ability-to-represent-minorities
 	return <GuideAtom {...imageStoryExpanded} />;
 };
+ImageStoryExpanded.decorators = [
+	splitTheme([
+		{
+			...format,
+			theme: Pillar.Culture,
+		},
+	]),
+];
 
 export const LifestylePillarStoryExpanded = (): JSX.Element => {
 	//Modelled after: https://www.theguardian.com/money/2020/aug/07/energy-bills-to-be-cut-by-84-pounds-for-11m-uk-households-ofgem
 	return <GuideAtom {...lifestylePillarStoryExpanded} />;
 };
+LifestylePillarStoryExpanded.decorators = [
+	splitTheme([
+		{
+			...format,
+			theme: Pillar.Lifestyle,
+		},
+	]),
+];
 
 export const AnalysisStoryExpanded = (): JSX.Element => {
 	// Modelled after: https://www.theguardian.com/football/2022/dec/11/gareth-southgate-england-world-cup-qatar
 	return (
 		<div
 			css={css`
-				background-color: ${sourcePalette.news[800]};
+				background-color: ${palette('--article-background')};
 			`}
 		>
-			Analysis Articles have a different color background, so quick guide
-			atoms should too.
+			Analysis Articles have a different color background in light mode,
+			so quick guide atoms should too.
 			<GuideAtom {...analysisStoryExpanded} />
 		</div>
 	);
 };
+AnalysisStoryExpanded.decorators = [
+	splitTheme([
+		{
+			...format,
+			design: ArticleDesign.Analysis,
+		},
+	]),
+];

--- a/dotcom-rendering/src/components/ProfileAtom.stories.tsx
+++ b/dotcom-rendering/src/components/ProfileAtom.stories.tsx
@@ -1,4 +1,5 @@
 import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
+import { splitTheme } from '../../.storybook/decorators/splitThemeDecorator';
 import { ProfileAtom } from './ProfileAtom.importable';
 
 export default {
@@ -16,12 +17,12 @@ export const NewsProfileStory = (): JSX.Element => {
 	// Based on: https://www.theguardian.com/us-news/2020/jul/13/ghislaine-maxwell-court-sex-trafficking-trial-epstein
 	return (
 		<ProfileAtom
+			format={format}
 			id="830f7948-c436-4a8d-9361-e4220444d49f"
 			image="https://i.guim.co.uk/img/media/cde1f62b34d6a110c7847af64864a4fc308b7967/464_266_975_975/975.jpg?width=620&quality=85&auto=format&fit=max&s=0e45463eaeec14d4e430220a925e665e"
 			title="Who is Ghislaine Maxwell?"
 			html="<p>Born in Maisons-Laffitte, Île-de-France, in 1961, Ghislaine Maxwell is the youngest of the nine children of Betty and Robert Maxwell, the media tycoon owner of the Mirror Group.</p><p>Ghislaine was rumoured to be his favourite child, and the former Labour MP named his £15m ($18.6m) yacht Lady Ghislaine after her. He put his daughter in charge of the football club he owned, Oxford United, and when he acquired the New York Daily News, he reportedly sent Ghislaine to warm up Manhattan society for his arrival.</p><p>Following her father’s death in 1991 – after apparently falling overboard from Lady Ghislaine near the Canary Islands – Ghislaine Maxwell flew to New York onboard a Concorde. She left behind a huge uproar over&nbsp;<a href='https://www.theguardian.com/business/2004/aug/26/money2'>$460m&nbsp;</a><a href='https://www.theguardian.com/business/2004/aug/26/money2'>found to be missing from her father’s companies’ pensions funds</a>.</p><p>Her family’s wealth, status and influence considerably depleted, Maxwell found something of a replacement in her relationship with&nbsp; Jeffrey Epstein. Their relationship was initially romantic, but it evolved into something more akin to that of a close friend, confidante and personal assistant. Epstein was later convicted of sex offences, and subsequently died in prison in 2019.</p><p>In 2015, Virginia Giuffre, one of Epstein’s accusers, sued Maxwell, alleging Epstein's confidante defamed her by claiming she was a liar in her accusations against the pair. Giuffre has accused Maxwell of recruiting her to work as Epstein’s masseuse at the age 15, when she was a locker-room attendant at Donald Trump’s Mar-a-Lago club in south Florida. Documents released as part of the lawsuit contain <a href='https://www.theguardian.com/us-news/2019/aug/09/ghislaine-maxwell-lawsuit-files-jeffrey-epstein'>lurid claims about the alleged sex trafficking</a>.</p><p>In July 2020, after having been in hiding, Maxwell was <a href='https://www.theguardian.com/us-news/2020/jul/02/ghislaine-maxwell-arrest-jeffrey-epstein-charges-latest-fbi'>arrested by the FBI</a> on charges related to Jeffrey Epstein. She has pleaded not guilty, was refused bail, and will remain in custody.</p><p>She is charged in a 17-page indictment with conspiracy to entice minors to travel to engage in illegal sex acts, enticement of a minor to travel to engage in illegal sex acts, conspiracy to transport minors with intent to engage in criminal sexual activity, transportation of a minor with intent to engage in criminal sexual activity, and perjury. If convicted, Maxwell faces up to 35 years in federal prison.</p>"
 			credit="Photograph: Laura Cavanaugh/Getty Images North America"
-			format={format}
 			expandForStorybook={true}
 			likeHandler={() => {
 				console.log('LIKED');
@@ -38,17 +39,18 @@ export const NewsProfileStory = (): JSX.Element => {
 		/>
 	);
 };
+NewsProfileStory.decorators = [splitTheme([format])];
 
 export const NewsProfileStory2 = (): JSX.Element => {
 	// Based on: https://www.theguardian.com/business/2020/may/11/richard-branson-to-sell-500m-worth-of-virgin-galactic-shares
 	return (
 		<ProfileAtom
+			format={format}
 			id="da5cfac0-b259-4db9-92a9-80a9a7cfe5f4"
 			image="https://i.guim.co.uk/img/media/d02ae7bbf3763747535a1b8be375396de7ae1666/439_557_2733_1640/2733.jpg?width=620&quality=85&auto=format&fit=max&s=2ed128901b717d8c01bc60b18894306a"
 			title="Virgin Galactic"
 			html="<p><strong>What is Virgin Galactic?</strong></p><p><b>Sir Richard Branson</b> unveiled his ambition to ferry tourists into outer space and back in 2004, initially proposing a maiden voyage by 2009.</p><p>More than a decade later, and after <a href='https://www.theguardian.com/science/2014/oct/31/branson-virgin-galactic-space-travel-failures'>several false dawns</a> when the first trip appeared tantalisingly close, would-be private astronauts are still waiting to climb on board a Virgin Galactic flight.</p><p>More than 600 have already put down deposits for the pleasure of suborbital space flight, with <b>tickets selling for $250,000</b> (£202,000).</p><p>Buyers will have to travel from Spaceport America in New Mexico, the home of the SpaceShipTwo craft.</p><p>The rocket-powered plane will be launched from the air by another plane, Scaled Composites Model 348 White Knight Two, reaching 68 miles above the Earth, where passengers will experience weightlessness before returning via a conventional runway landing.</p><p>The project suffered a setback in 2014 when a version of SpaceShipTwo disintegrated mid-air owing to what an investigation found was a <a href='https://www.theguardian.com/science/2015/jul/28/virgin-galactic-spaceshiptwo-crash-cause'>combination of pilot error and inadequate safety procedures</a>. Co-pilot Michael Alsbury was killed, while pilot Peter Siebold was seriously injured.</p><p>Branson <a href='https://www.theguardian.com/science/2019/oct/28/virgin-galactic-spce-launches-new-york-stock-exchange-richard-branson'>floated Virgin Galactic on the stock market</a> last year, securing $450m investment from the former Facebook executive Chamath Palihapitiya.</p><p>But while Branson said in 2019 that the first flights could follow this year, Virgin Galactic remains rooted to the launchpad.-</p>"
 			credit="Photograph: Virgin Galactic"
-			format={format}
 			expandForStorybook={true}
 			likeHandler={() => {
 				console.log('LIKED');
@@ -65,15 +67,16 @@ export const NewsProfileStory2 = (): JSX.Element => {
 		/>
 	);
 };
+NewsProfileStory2.decorators = [splitTheme([format])];
 
 export const NoProfileImageStory = (): JSX.Element => {
 	// Modelled after: https://www.theguardian.com/politics/2020/jan/24/labour-leadership-unite-backs-brilliant-rebecca-long-bailey
 	return (
 		<ProfileAtom
+			format={format}
 			id="1fba49a4-81c6-49e4-b7fa-fd66d1512360"
 			title="Who is Jon Lansman?"
 			html="<p>A 62-year-old Labour veteran who joined the party in 1974 and worked for Labour icon Tony Benn during his deputy leadership campaign in the 1980s. Lansman served as director of operations for Corbyn’s leadership campaign. After Corbyn was elected as the leader of the Labour party in 2015, Lansman founded Momentum, a pro-Corbyn campaign group.<br></p>"
-			format={format}
 			expandForStorybook={true}
 			likeHandler={() => {
 				console.log('LIKED');
@@ -90,3 +93,4 @@ export const NoProfileImageStory = (): JSX.Element => {
 		/>
 	);
 };
+NoProfileImageStory.decorators = [splitTheme([format])];

--- a/dotcom-rendering/src/components/QandaAtom.stories.tsx
+++ b/dotcom-rendering/src/components/QandaAtom.stories.tsx
@@ -1,26 +1,50 @@
+import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
+import type { Meta, StoryObj } from '@storybook/react';
+import { splitTheme } from '../../.storybook/decorators/splitThemeDecorator';
 import {
 	imageStoryExpanded,
 	imageStoryWithCreditExpanded,
 	listStoryExpanded,
 } from '../../fixtures/manual/qandaAtom';
-import { QandaAtom } from './QandaAtom.importable';
+import { getAllThemes } from '../lib/format';
+import { QandaAtom as QandaAtomComponent } from './QandaAtom.importable';
 
-export default {
-	title: 'QandaAtom',
-	component: QandaAtom,
+const meta: Meta<typeof QandaAtomComponent> = {
+	title: 'Components/Q and A Atom',
+	component: QandaAtomComponent,
+};
+
+type Story = StoryObj<typeof QandaAtomComponent>;
+
+const defaultFormat = {
+	display: ArticleDisplay.Standard,
+	design: ArticleDesign.Standard,
+	theme: Pillar.News,
 };
 
 // Based on https://www.theguardian.com/technology/2018/sep/19/time-to-regulate-bitcoin-says-treasury-committee-report
-export const NewsStoryExpanded = (): JSX.Element => {
-	return <QandaAtom {...imageStoryExpanded} />;
+export const DefaultStoryExpanded: Story = {
+	args: { ...imageStoryExpanded },
+	decorators: [
+		splitTheme(
+			getAllThemes({
+				display: ArticleDisplay.Standard,
+				design: ArticleDesign.Standard,
+			}),
+		),
+	],
 };
 
 // Based on https://www.theguardian.com/world/2020/mar/17/israel-to-track-mobile-phones-of-suspected-coronavirus-cases
-export const ListStoryExpanded = (): JSX.Element => {
-	return <QandaAtom {...listStoryExpanded} />;
+export const ListStoryExpanded: Story = {
+	args: { ...listStoryExpanded },
+	decorators: [splitTheme([defaultFormat])],
 };
 
 // Based on https://www.theguardian.com/world/2020/aug/06/coronavirus-global-report-germany-and-france-record-biggest-rise-in-cases-since-may
-export const ImageStoryWithCreditExpanded = (): JSX.Element => {
-	return <QandaAtom {...imageStoryWithCreditExpanded} />;
+export const ImageStoryWithCreditExpanded: Story = {
+	args: { ...imageStoryWithCreditExpanded },
+	decorators: [splitTheme([defaultFormat])],
 };
+
+export default meta;

--- a/dotcom-rendering/src/components/TimelineAtom.stories.tsx
+++ b/dotcom-rendering/src/components/TimelineAtom.stories.tsx
@@ -25,7 +25,7 @@ const defaultFormat = {
 // Based on https://www.theguardian.com/stage/2018/mar/06/hamilton-nominated-olivier-awards
 export const NoTimelineEventsStoryExpanded: Story = {
 	args: { ...noTimelineEventsStoryExpanded },
-	decorators: [splitTheme()],
+	decorators: [splitTheme([defaultFormat])],
 };
 
 // Based on https://www.theguardian.com/uk-news/2020/jul/21/importance-of-prince-andrew-interview-became-clear-in-editing-suite-says-maitlis

--- a/dotcom-rendering/src/components/TimelineAtom.stories.tsx
+++ b/dotcom-rendering/src/components/TimelineAtom.stories.tsx
@@ -1,34 +1,57 @@
+import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
+import type { Meta, StoryObj } from '@storybook/react';
+import { splitTheme } from '../../.storybook/decorators/splitThemeDecorator';
 import {
 	newsStoryWithDatesToExpanded,
 	newsTimelineStoryNoDescriptionExpanded,
 	noTimelineEventsStoryExpanded,
 	sportTimelineStoryWithDescriptionAndEventsExpanded,
 } from '../../fixtures/manual/timelineAtom';
-import { TimelineAtom } from './TimelineAtom.importable';
+import { TimelineAtom as TimelineAtomComponent } from './TimelineAtom.importable';
 
-export default {
-	title: 'TimelineAtom',
-	component: TimelineAtom,
+const meta: Meta<typeof TimelineAtomComponent> = {
+	title: 'Components/Timeline Atom',
+	component: TimelineAtomComponent,
+};
+
+type Story = StoryObj<typeof TimelineAtomComponent>;
+
+const defaultFormat = {
+	display: ArticleDisplay.Standard,
+	design: ArticleDesign.Standard,
+	theme: Pillar.News,
 };
 
 // Based on https://www.theguardian.com/stage/2018/mar/06/hamilton-nominated-olivier-awards
-export const NoTimelineEventsStoryExpanded = () => {
-	return <TimelineAtom {...noTimelineEventsStoryExpanded} />;
+export const NoTimelineEventsStoryExpanded: Story = {
+	args: { ...noTimelineEventsStoryExpanded },
+	decorators: [splitTheme()],
 };
 
 // Based on https://www.theguardian.com/uk-news/2020/jul/21/importance-of-prince-andrew-interview-became-clear-in-editing-suite-says-maitlis
-export const NewsTimelineStoryNoDescriptionExpanded = () => {
-	return <TimelineAtom {...newsTimelineStoryNoDescriptionExpanded} />;
+export const NewsTimelineStoryNoDescriptionExpanded: Story = {
+	args: { ...newsTimelineStoryNoDescriptionExpanded },
+	decorators: [splitTheme([defaultFormat])],
 };
 
 // Based on https://www.theguardian.com/sport/blog/2020/jul/09/why-chris-froome-and-team-ineos-parting-of-the-ways-cycling
-export const SportTimelineStoryWithDescriptionAndEventsExpanded = () => {
-	return (
-		<TimelineAtom {...sportTimelineStoryWithDescriptionAndEventsExpanded} />
-	);
+export const SportTimelineStoryWithDescriptionAndEventsExpanded: Story = {
+	args: { ...sportTimelineStoryWithDescriptionAndEventsExpanded },
+	decorators: [
+		splitTheme([
+			{
+				display: ArticleDisplay.Standard,
+				design: ArticleDesign.LiveBlog,
+				theme: Pillar.Sport,
+			},
+		]),
+	],
 };
 
 // Based on https://www.theguardian.com/media/2019/jun/13/julian-assange-sajid-javid-signs-us-extradition-order
-export const NewsStoryWithDatesToExpanded = () => {
-	return <TimelineAtom {...newsStoryWithDatesToExpanded} />;
+export const NewsStoryWithDatesToExpanded: Story = {
+	args: { ...newsStoryWithDatesToExpanded },
+	decorators: [splitTheme([defaultFormat])],
 };
+
+export default meta;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Updates stories for
- profile atom
- q and a atom
- timeline atom
- guide atom

Adds light and dark mode stories to the expanding atom components.
It also modernises the story syntax to the CSF3 format.

## Why?
This will allow us to make sure we are not making any regressions to the light mode atoms in upcoming prs which will implement dark mode themes in all of these atoms.
## Screenshots
see chromatic diff
| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
