### PR TITLE
Add darkmode to the expanding wrapper component

### DIFF
--- a/dotcom-rendering/src/components/ExpandableAtom/Body.tsx
+++ b/dotcom-rendering/src/components/ExpandableAtom/Body.tsx
@@ -5,7 +5,7 @@ import {
 	textSans,
 } from '@guardian/source-foundations';
 import { SvgInfo } from '@guardian/source-react-components';
-import { decidePalette } from '../../lib/decidePalette';
+import { palette as themePalette } from '../../palette';
 
 const imageStyling = css`
 	float: left;
@@ -75,9 +75,9 @@ const bodyStyling = css`
 	}
 `;
 
-const linkStyling = (format: ArticleFormat) => css`
+const linkStyling = css`
 	a {
-		color: ${decidePalette(format).text.expandableAtom};
+		color: ${themePalette('--expandable-atom-text-hover')};
 		text-decoration: none;
 		border-bottom: 0.0625rem solid ${sourcePalette.neutral[86]};
 		transition: border-color 0.15s ease-out;
@@ -85,7 +85,7 @@ const linkStyling = (format: ArticleFormat) => css`
 
 	a:hover {
 		border-bottom: solid 0.0625rem
-			${decidePalette(format).text.expandableAtomHover};
+			${themePalette('--expandable-atom-text-hover')};
 	}
 `;
 
@@ -104,7 +104,7 @@ export const Body = ({
 		<div>
 			{!!image && <img css={imageStyling} src={image} alt="" />}
 			<div
-				css={[bodyStyling, linkStyling(format)]}
+				css={[bodyStyling, linkStyling]}
 				dangerouslySetInnerHTML={{
 					__html: html,
 				}}

--- a/dotcom-rendering/src/components/ExpandableAtom/Container.tsx
+++ b/dotcom-rendering/src/components/ExpandableAtom/Container.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
-import type { SerializedStyles } from '@emotion/react';
 import { ArticleDesign } from '@guardian/libs';
-import { palette as sourcePalette, text } from '@guardian/source-foundations';
+import { palette as sourcePalette } from '@guardian/source-foundations';
+import { palette as themePalette } from '../../palette';
 import { Summary } from './Summary';
 
 const containerStyling = css`
@@ -9,43 +9,33 @@ const containerStyling = css`
 	position: relative;
 `;
 
-export const detailStyling = (design?: ArticleDesign): SerializedStyles => {
-	// One off background colour for analysis articles
-	const background =
-		design === ArticleDesign.Analysis
-			? '#F2E8E6'
-			: sourcePalette.neutral[93];
-	return css`
-		margin: 16px 0 36px;
-		background: ${background};
-		color: ${text.primary};
-		padding: 0 5px 6px;
-		border-image: repeating-linear-gradient(
-				to bottom,
-				${sourcePalette.neutral[86]},
-				${sourcePalette.neutral[86]} 1px,
-				transparent 1px,
-				transparent 4px
-			)
-			13;
-		border-top: 13px solid black;
-		position: relative;
-		summary {
-			list-style: none;
-			margin: 0 0 16px;
-		}
-
-		/* https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details#Customizing_the_disclosure_widget */
-		summary::-webkit-details-marker {
-			display: none;
-		}
-
-		summary:focus {
-			outline: none;
-		}
-	`;
-};
-
+export const detailStyling = css`
+	margin: 16px 0 36px;
+	background: ${themePalette('--expandable-atom-background')};
+	color: ${themePalette('--article-text')};
+	padding: 0 5px 6px;
+	border-image: repeating-linear-gradient(
+			to bottom,
+			${themePalette('--expandable-atom-border')},
+			${themePalette('--expandable-atom-border')}1px,
+			transparent 1px,
+			transparent 4px
+		)
+		13;
+	border-top: 13px solid ${sourcePalette.neutral[0]};
+	position: relative;
+	summary {
+		list-style: none;
+		margin: 0 0 16px;
+	}
+	/* https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details#Customizing_the_disclosure_widget */
+	summary::-webkit-details-marker {
+		display: none;
+	}
+	summary:focus {
+		outline: none;
+	}
+`;
 export const Container = ({
 	id,
 	title,
@@ -68,7 +58,7 @@ export const Container = ({
 }): JSX.Element => (
 	<div css={containerStyling} data-atom-id={id} data-atom-type={atomType}>
 		<details
-			css={detailStyling(format.design)}
+			css={detailStyling}
 			data-atom-id={id}
 			data-snippet-type={atomType}
 			open={expandForStorybook}

--- a/dotcom-rendering/src/components/ExpandableAtom/Container.tsx
+++ b/dotcom-rendering/src/components/ExpandableAtom/Container.tsx
@@ -1,5 +1,4 @@
 import { css } from '@emotion/react';
-import { ArticleDesign } from '@guardian/libs';
 import { palette as sourcePalette } from '@guardian/source-foundations';
 import { palette as themePalette } from '../../palette';
 import { Summary } from './Summary';
@@ -48,7 +47,6 @@ export const Container = ({
 }: {
 	id: string;
 	title: string;
-	design?: ArticleDesign;
 	format: ArticleFormat;
 	expandForStorybook?: boolean;
 	atomType: string;

--- a/dotcom-rendering/src/components/ExpandableAtom/Footer.tsx
+++ b/dotcom-rendering/src/components/ExpandableAtom/Footer.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import { textSans } from '@guardian/source-foundations';
 import { useState } from 'react';
-import { decidePalette } from '../../lib/decidePalette';
+import { palette as themePalette } from '../../palette';
 
 /// LIKE/DISLIKE FEEDBACK FOOTER
 const footerStyling = css`
@@ -44,8 +44,8 @@ export const Footer = ({
 		cursor: pointer;
 		align-items: center;
 		justify-content: center;
-		background: black;
-		color: white;
+		background: ${'--expandable-atom-button'};
+		color: ${'--expandable-atom-button-fill'};
 		border-style: hidden;
 		border-radius: 100%;
 		margin: 0 0 0 5px;
@@ -53,7 +53,7 @@ export const Footer = ({
 		width: 28px;
 		height: 28px;
 		:hover {
-			background: ${decidePalette(format).text.expandableAtomHover};
+			background: ${themePalette('--expandable-atom-text-hover')};
 		}
 		:focus {
 			border: none;

--- a/dotcom-rendering/src/components/ExpandableAtom/Footer.tsx
+++ b/dotcom-rendering/src/components/ExpandableAtom/Footer.tsx
@@ -21,10 +21,7 @@ const ThumbImage = () => {
 			`}
 			viewBox="0 0 40 40"
 		>
-			<path
-				fill="#FFF"
-				d="M33.78 22.437l-4.228 13.98L27.93 37.5 5.062 34.14V15.503l7.8-1.517L24.354 2.5h1.624L28.9 5.426l-4.548 8.67h.107l10.477 1.31"
-			></path>
+			<path d="M33.78 22.437l-4.228 13.98L27.93 37.5 5.062 34.14V15.503l7.8-1.517L24.354 2.5h1.624L28.9 5.426l-4.548 8.67h.107l10.477 1.31"></path>
 		</svg>
 	);
 };
@@ -44,8 +41,7 @@ export const Footer = ({
 		cursor: pointer;
 		align-items: center;
 		justify-content: center;
-		background: ${'--expandable-atom-button'};
-		color: ${'--expandable-atom-button-fill'};
+		background: ${themePalette('--expandable-atom-button')};
 		border-style: hidden;
 		border-radius: 100%;
 		margin: 0 0 0 5px;
@@ -57,6 +53,9 @@ export const Footer = ({
 		}
 		:focus {
 			border: none;
+		}
+		svg {
+			fill: ${themePalette('--expandable-atom-button-fill')};
 		}
 	`;
 	const [showThankYou, setShowThankYou] = useState(false);

--- a/dotcom-rendering/src/components/ExpandableAtom/Summary.tsx
+++ b/dotcom-rendering/src/components/ExpandableAtom/Summary.tsx
@@ -2,7 +2,6 @@ import { css } from '@emotion/react';
 import { body, headline, textSans } from '@guardian/source-foundations';
 import { SvgMinus, SvgPlus } from '@guardian/source-react-components';
 import { useState } from 'react';
-import { decidePalette } from '../../lib/decidePalette';
 import { palette as themePalette } from '../../palette';
 
 /// SUMMARY ELEMENT

--- a/dotcom-rendering/src/components/ExpandableAtom/Summary.tsx
+++ b/dotcom-rendering/src/components/ExpandableAtom/Summary.tsx
@@ -1,13 +1,9 @@
 import { css } from '@emotion/react';
-import {
-	body,
-	headline,
-	palette as sourcePalette,
-	textSans,
-} from '@guardian/source-foundations';
+import { body, headline, textSans } from '@guardian/source-foundations';
 import { SvgMinus, SvgPlus } from '@guardian/source-react-components';
 import { useState } from 'react';
 import { decidePalette } from '../../lib/decidePalette';
+import { palette as themePalette } from '../../palette';
 
 /// SUMMARY ELEMENT
 
@@ -23,7 +19,7 @@ const plusStyling = css`
 	margin-right: 12px;
 	margin-bottom: 6px;
 	width: 33px;
-	fill: white;
+	fill: ${themePalette('--expandable-atom-button-fill')};
 	height: 28px;
 `;
 
@@ -31,7 +27,7 @@ const minusStyling = css`
 	margin-right: 14px;
 	margin-bottom: 6px;
 	width: 30px;
-	fill: white;
+	fill: ${themePalette('--expandable-atom-button-fill')};
 	height: 25px;
 	padding-left: 4px;
 `;
@@ -59,12 +55,12 @@ export const Summary = ({
 			lineHeight: 'tight',
 			fontWeight: 'bold',
 		})};
-		color: ${decidePalette(format).text.expandableAtomHover};
+		color: ${themePalette('--expandable-atom-text-hover')};
 	`;
 
 	const showHideStyling = css`
-		background: ${sourcePalette.neutral[7]};
-		color: ${sourcePalette.neutral[100]};
+		background: ${themePalette('--expandable-atom-button')};
+		color: ${themePalette('--expandable-atom-button-fill')};
 		height: 2rem;
 		position: absolute;
 		bottom: 0;
@@ -77,7 +73,7 @@ export const Summary = ({
 		border: 0;
 		margin: 0;
 		:hover {
-			background: ${decidePalette(format).text.expandableAtomHover};
+			background: ${themePalette('--expandable-atom-text-hover')};
 		}
 	`;
 	const [hasBeenExpanded, setHasBeenExpanded] = useState(false);

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -4582,6 +4582,57 @@ const audioAtomProgressBarLight: PaletteFunction = () =>
 const audioAtomProgressBarDark: PaletteFunction = () =>
 	sourcePalette.neutral[60];
 
+const expandableAtomBackgroundLight: PaletteFunction = ({ design }) => {
+	switch (design) {
+		case ArticleDesign.Analysis:
+			return '#F2E8E6';
+		default:
+			return sourcePalette.neutral[93];
+	}
+};
+const expandableAtomBackgroundDark: PaletteFunction = () =>
+	sourcePalette.neutral[20];
+
+const expandableAtomTextHoverLight: PaletteFunction = ({ theme }) => {
+	switch (theme) {
+		case ArticleSpecial.Labs:
+			return sourcePalette.lifestyle[400];
+		case ArticleSpecial.SpecialReport:
+		case ArticleSpecial.SpecialReportAlt:
+			return sourcePalette.news[400];
+		default:
+			return pillarPalette(theme, 400);
+	}
+};
+
+const expandableAtomTextHoverDark: PaletteFunction = ({ theme }) => {
+	switch (theme) {
+		case Pillar.News:
+		case Pillar.Lifestyle:
+		case Pillar.Sport:
+		case Pillar.Culture:
+		case Pillar.Opinion:
+			return pillarPalette(theme, 500);
+		case ArticleSpecial.Labs:
+			return sourcePalette.lifestyle[500];
+		case ArticleSpecial.SpecialReport:
+		case ArticleSpecial.SpecialReportAlt:
+			return sourcePalette.news[500];
+	}
+};
+const expandableAtomBorderLight: PaletteFunction = () =>
+	sourcePalette.neutral[86];
+const expandableAtomBorderDark: PaletteFunction = () =>
+	sourcePalette.neutral[38];
+const expandableAtomButtonLight: PaletteFunction = () =>
+	sourcePalette.neutral[0];
+const expandableAtomButtonDark: PaletteFunction = () =>
+	sourcePalette.neutral[86];
+const expandableAtomButtonFillLight: PaletteFunction = () =>
+	sourcePalette.neutral[100];
+const expandableAtomButtonFillDark: PaletteFunction = () =>
+	sourcePalette.neutral[7];
+
 // ----- Palette ----- //
 
 /**
@@ -5376,6 +5427,26 @@ const paletteColours = {
 	'--audio-atom-progress-bar': {
 		light: audioAtomProgressBarLight,
 		dark: audioAtomProgressBarDark,
+	},
+	'--expandable-atom-background': {
+		light: expandableAtomBackgroundLight,
+		dark: expandableAtomBackgroundDark,
+	},
+	'--expandable-atom-text-hover': {
+		light: expandableAtomTextHoverLight,
+		dark: expandableAtomTextHoverDark,
+	},
+	'--expandable-atom-border': {
+		light: expandableAtomBorderLight,
+		dark: expandableAtomBorderDark,
+	},
+	'--expandable-atom-button': {
+		light: expandableAtomButtonLight,
+		dark: expandableAtomButtonDark,
+	},
+	'--expandable-atom-button-fill': {
+		light: expandableAtomButtonFillLight,
+		dark: expandableAtomButtonFillDark,
 	},
 } satisfies PaletteColours;
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Adds darkmode to the expanding wrapper component. This is used by several atoms (profile, q and a, timeline, guide) so adding this as a small pr here allows us to incrementally update the atoms to darkmode compatible.
## Why?
We want to prevent any regressions to light mode and implement dark mode iteratively.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
