### PR TITLE
Refactor Expanding Atoms 

### DIFF
--- a/dotcom-rendering/fixtures/manual/guideAtom.ts
+++ b/dotcom-rendering/fixtures/manual/guideAtom.ts
@@ -1,15 +1,10 @@
-import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
+import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
 
 export const defaultStoryExpanded = {
 	id: 'a76d998e-d4b0-4d00-8afb-773eddb4064c',
 	title: "Wednesday's Hong Kong tips",
 	html: '<p><b>Happy Valley&nbsp;</b></p><p><b>11.45</b> Happy Good Guys <b>12.15</b> Salto Olimpico <b>12.45</b> Seize The Spirit <b>1.15</b> Allied Agility <b>1.45 </b>Hero Time <b>2.15</b> Simply Fluke <b>2.45</b> Brave King <b>3.15</b> Golden Dash <b>3.50</b> This Is Class</p>',
-	pillar: ArticlePillar.Sport,
-	format: {
-		display: ArticleDisplay.Standard,
-		design: ArticleDesign.Standard,
-		theme: ArticlePillar.Sport,
-	},
+	pillar: Pillar.Sport,
 	expandForStorybook: true,
 	likeHandler: (): null => null,
 	dislikeHandler: (): null => null,
@@ -21,11 +16,6 @@ export const defaultStory = {
 	id: 'a76d998e-d4b0-4d00-8afb-773eddb4064c',
 	title: "Wednesday's Hong Kong tips",
 	html: '<p><b>Happy Valley&nbsp;</b></p><p><b>11.45</b> Happy Good Guys <b>12.15</b> Salto Olimpico <b>12.45</b> Seize The Spirit <b>1.15</b> Allied Agility <b>1.45 </b>Hero Time <b>2.15</b> Simply Fluke <b>2.45</b> Brave King <b>3.15</b> Golden Dash <b>3.50</b> This Is Class</p>',
-	format: {
-		display: ArticleDisplay.Standard,
-		design: ArticleDesign.Standard,
-		theme: ArticlePillar.Sport,
-	},
 	expandForStorybook: false,
 	likeHandler: (): null => null,
 	dislikeHandler: (): null => null,
@@ -37,11 +27,6 @@ export const listStoryExpanded = {
 	label: 'Quick Guide',
 	title: 'What are coronavirus symptoms and should I go to a doctor?',
 	html: '<p>Covid-19 is caused by a member of the coronavirus family that has never been encountered before. Like other coronaviruses, it has come from animals. The World Health Organization (WHO) has declared it a pandemic.</p><p>According to the WHO, the most common symptoms of Covid-19 are fever, tiredness and a dry cough. Some patients may also have a runny nose, sore throat, nasal congestion and aches and pains or diarrhoea. Some people report losing their sense of taste and/or smell. About 80% of people who get Covid-19 experience a mild case – about as serious as a regular cold – and recover without needing any special treatment.</p><p>About one in six people, the WHO says, become seriously ill. The elderly and people with underlying medical problems like high blood pressure, heart problems or diabetes, or chronic respiratory conditions, are at a greater risk of serious illness from Covid-19.</p><p>In the UK, the National health Service (NHS) has identified the specific symptoms to look for as experiencing either:</p><ul><li>a high temperature - you feel hot to touch on your chest or back</li><li>a new continuous cough - this means you’ve started coughing repeatedly</li></ul><p>As this is viral pneumonia, antibiotics are of no use. The antiviral drugs we have against flu will not work, and there is currently no vaccine. Recovery depends on the strength of the immune system.</p><p>Medical advice varies around the world - with many countries imposing travel bans and lockdowns to try and prevent the spread of the virus. In many place people are being told to stay at home rather than visit a doctor of hospital in person. Check with your local authorities.</p><p>In the UK, NHS advice is that anyone with symptoms should<b> stay at home for at least 7 days</b>. If you live with other people, <b>they should stay at home for at least 14 days</b>, to avoid spreading the infection outside the home.</p>',
-	format: {
-		display: ArticleDisplay.Standard,
-		design: ArticleDesign.Standard,
-		theme: ArticlePillar.News,
-	},
 	expandForStorybook: true,
 	likeHandler: (): null => null,
 	dislikeHandler: (): null => null,
@@ -50,14 +35,8 @@ export const listStoryExpanded = {
 
 export const orderedListStoryExpanded = {
 	id: 'b4c77875-8ba3-40d0-926b-0cd7956eed8a',
-
 	title: 'The locations in England with the highest annual average levels of NO2',
 	html: '<ol><li>Chideock Hill, West Dorset 97.7</li><li>Station Taxi Rank, Sheffield 91.7</li><li>North Street Clock Tower, Brighton 90.8</li><li>Neville Street Tunnel, Leeds 88</li><li>Strand, City of Westminster 88</li><li>Walbrook Wharf, City of London 87</li><li>Hickleton opp Fir Tree Close, Doncaster 86</li><li>Marylebone Road, City of Westminster 85</li><li>Euston Road, London Borough of Camden 82.3</li><li>Hickleton, John O’Gaunts, Doncaster 82</li></ol><p>&nbsp;Latest data is from 2018.&nbsp; The Annual Air Quality Objective is set at 40ug/m3. Source: Friends of the Earth&nbsp;<br></p>',
-	format: {
-		display: ArticleDisplay.Standard,
-		design: ArticleDesign.Standard,
-		theme: ArticlePillar.News,
-	},
 	expandForStorybook: true,
 	likeHandler: (): null => null,
 	dislikeHandler: (): null => null,
@@ -71,11 +50,6 @@ export const imageStoryExpanded = {
 	html: "<p>As she <a href='https://www.theguardian.com/politics/video/2019/may/24/prime-minister-theresa-mays-resignation-speech-in-full-video'>announced on 24 May</a>, Theresa May stepped down formally as Conservative leader on Friday 7 June, although she remains in place as prime minister until her successor is chosen.</p><p>In a Conservative leadership contest MPs hold a series of votes, in order to narrow down the initially crowded field to two leadership hopefuls, who go to a postal ballot of members.<br></p><p><b>How does the voting work?</b></p><p>MPs choose one candidate, in a secret ballot held in a committee room in the House of Commons. The votes are tallied and the results announced on the same day.</p><p>In the first round any candidate who won the support of less than 17 MPs was eliminated. In the second round anybody reaching less than 33 votes was eliminated. In subsequent rounds the bottom placed contender drops out until there are only two left. The party membership then chooses between them.</p><p><b>When will the results be announced?</b><br></p><p>The postal ballot of members has begun, and the Tory party says it will announce the new prime minister on 23 July..</p>",
 	credit: 'Photograph: Neil Hall/EPA',
 	image: 'https://i.guim.co.uk/img/media/d032f9d883807ea5003356289b7a1e9783cc67e5/0_37_4131_2480/4131.jpg?width=620&quality=85&auto=format&fit=max&s=53971cc47cb7c125202b7a647e82a44d',
-	format: {
-		display: ArticleDisplay.Standard,
-		design: ArticleDesign.Standard,
-		theme: ArticlePillar.Culture,
-	},
 	expandForStorybook: true,
 	likeHandler: (): null => null,
 	dislikeHandler: (): null => null,
@@ -91,7 +65,7 @@ export const lifestylePillarStoryExpanded = {
 	format: {
 		display: ArticleDisplay.Standard,
 		design: ArticleDesign.Standard,
-		theme: ArticlePillar.Lifestyle,
+		theme: Pillar.Lifestyle,
 	},
 	expandForStorybook: true,
 	likeHandler: (): null => null,
@@ -104,13 +78,8 @@ export const analysisStoryExpanded = {
 	title: 'Qatar: beyond the football',
 	html: '<p>It was a World Cup like no other. For the last 12 years the Guardian has been reporting on the issues surrounding Qatar 2022, from corruption and human rights abuses to the treatment of migrant workers and discriminatory laws. <br/> The best of our journalism is gathered on our dedicated <a href="https://www.theguardian.com/news/series/qatar-beyond-the-football">Qatar: Beyond the Football</a> home page for those who want to go deeper into the issues beyond the pitch. <br/> <br/> Guardian reporting goes far beyond what happens on the pitch. Support our investigative journalism today.</p>',
 	image: 'https://i.guim.co.uk/img/media/48be60e8b3371ffecc4f784e0411526ed9f3f3ba/1700_1199_1330_1331/1330.jpg?width=620&quality=85&auto=format&fit=max&s=8b3ad26c4ab238688c860e907b2cb116',
-	pillar: ArticlePillar.Sport,
+	pillar: Pillar.Sport,
 	design: ArticleDesign.Analysis,
-	format: {
-		display: ArticleDisplay.Standard,
-		design: ArticleDesign.Analysis,
-		theme: ArticlePillar.Sport,
-	},
 	expandForStorybook: true,
 	likeHandler: (): null => null,
 	dislikeHandler: (): null => null,

--- a/dotcom-rendering/fixtures/manual/qandaAtom.tsx
+++ b/dotcom-rendering/fixtures/manual/qandaAtom.tsx
@@ -1,17 +1,8 @@
-import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
-
-const format: ArticleFormat = {
-	design: ArticleDesign.Quiz,
-	display: ArticleDisplay.Standard,
-	theme: Pillar.News,
-};
-
 // Non-expanded version for Cypress tests
 export const imageStory = {
 	id: '78014307-ca67-47dc-b524-d5f24f3dbcd8',
 	title: 'What is bitcoin?',
 	html: "<p>Bitcoin is the first, and the biggest, 'cryptocurrency' – a decentralised tradeable digital asset. The lack of any central authority oversight is one of the attraction.&nbsp;</p><p>Cryptocurrencies can be used to send transactions between two parties via the use of private and public keys. These transfers can be done with minimal processing cost, allowing users to avoid the fees charged by traditional financial institutions - as well as the oversight and regulation that entails.</p><p>This means it has attracted a range of backers, from libertarian monetarists who enjoy the idea of a currency with no inflation and no central bank, to drug dealers who like the fact that it is hard (but not impossible) to trace a bitcoin transaction back to a physical person.</p><p>The exchange rate has been volatile, making it a risky investment. Whether it is a bad investment is yet to be seen. In practice it has been far more important for the dark economy than it has for most legitimate uses, but with Facebook's announcement that it is launching a new digital currency - <a href='https://www.theguardian.com/technology/2019/jun/18/what-is-libra-facebook-new-cryptocurrency'>Libra</a> - mainstream interest in bitcoin has surged.<br></p>",
-	format,
 	image: 'https://i.guim.co.uk/img/media/5f74d365b0a3072c2edcd764cf08d6fa4fcd873b/0_59_5190_3114/5190.jpg?width=620&quality=85&auto=format&fit=max&s=ed95a62cd07881336635129287b406a1',
 	expandForStorybook: false,
 	likeHandler: (): null => null,
@@ -23,7 +14,6 @@ export const imageStoryExpanded = {
 	id: '78014307-ca67-47dc-b524-d5f24f3dbcd8',
 	title: 'What is bitcoin?',
 	html: "<p>Bitcoin is the first, and the biggest, 'cryptocurrency' – a decentralised tradeable digital asset. The lack of any central authority oversight is one of the attraction.&nbsp;</p><p>Cryptocurrencies can be used to send transactions between two parties via the use of private and public keys. These transfers can be done with minimal processing cost, allowing users to avoid the fees charged by traditional financial institutions - as well as the oversight and regulation that entails.</p><p>This means it has attracted a range of backers, from libertarian monetarists who enjoy the idea of a currency with no inflation and no central bank, to drug dealers who like the fact that it is hard (but not impossible) to trace a bitcoin transaction back to a physical person.</p><p>The exchange rate has been volatile, making it a risky investment. Whether it is a bad investment is yet to be seen. In practice it has been far more important for the dark economy than it has for most legitimate uses, but with Facebook's announcement that it is launching a new digital currency - <a href='https://www.theguardian.com/technology/2019/jun/18/what-is-libra-facebook-new-cryptocurrency'>Libra</a> - mainstream interest in bitcoin has surged.<br></p>",
-	format,
 	image: 'https://i.guim.co.uk/img/media/5f74d365b0a3072c2edcd764cf08d6fa4fcd873b/0_59_5190_3114/5190.jpg?width=620&quality=85&auto=format&fit=max&s=ed95a62cd07881336635129287b406a1',
 	expandForStorybook: true,
 	likeHandler: (): null => null,
@@ -52,7 +42,6 @@ export const imageStoryWithCreditExpanded = {
     <p><b>US&nbsp;</b>132,310 deaths, 3,055,491 cases</p>
     <p>The US ban on travellers from overseas came too late, and though most states had lockdowns of some form in spring, they varied in length and strictness. Some places that were among the earliest to lift them are now battling fast-rising outbreaks, and the country has the highest number of confirmed cases and deaths. Opposition to lockdowns and mask-wearing remains widespread.</p>
     <p>Source: Johns Hopkins CSSE, 9 July</p>`,
-	format,
 	image: 'https://i.guim.co.uk/img/media/1cd3cc5864d9e6fc0b74134eaff7ab329cb89678/914_0_1757_1757/1757.jpg?width=620&quality=85&auto=format&fit=max&s=c1aadf54045c6a8c11e9c077324e238f',
 	credit: 'Photograph: Mark R Cristino/EPA',
 	expandForStorybook: true,
@@ -65,7 +54,6 @@ export const listStoryExpanded = {
 	id: '7a6078f6-5a66-4d3e-9339-5610fe320767',
 	title: 'How can I protect myself and others from the coronavirus outbreak?',
 	html: '<p>The World Health Organization is recommending that people take simple precautions to reduce exposure to and transmission of the coronavirus, for which there is no specific cure or vaccine.</p> <p>The UN agency&nbsp;<a href="https://www.who.int/emergencies/diseases/novel-coronavirus-2019/advice-for-public">advises</a>&nbsp;people to:</p> <ul> <li>Frequently wash their hands with an alcohol-based hand rub or warm water and soap</li> <li>Cover their mouth and nose with a flexed elbow or tissue when sneezing or coughing</li> <li>Avoid close contact with anyone who has a fever or cough</li> <li>Seek early medical help if they have a fever, cough and difficulty breathing, and share their travel history with healthcare providers</li> <li>Advice about face masks varies. Wearing them while out and about may offer some protection against both spreading and catching the virus via coughs and sneezes, but it is not a cast-iron guarantee of protection</li> </ul> <p>Many countries are now enforcing or recommending curfews or lockdowns. <b>Check with your local authorities for up-to-date information about the situation in your area.</b>&nbsp;</p> <p>In the UK, NHS advice is that anyone with symptoms should&nbsp;<b>stay at home for at least 7 days</b>.</p> <p>If you live with other people,&nbsp;<b>they should stay at home for at least 14 days</b>, to avoid spreading the infection outside the home.</p>',
-	format,
 	expandForStorybook: true,
 	likeHandler: (): null => null,
 	dislikeHandler: (): null => null,

--- a/dotcom-rendering/fixtures/manual/timelineAtom.tsx
+++ b/dotcom-rendering/fixtures/manual/timelineAtom.tsx
@@ -1,11 +1,3 @@
-import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
-
-const format: ArticleFormat = {
-	display: ArticleDisplay.Standard,
-	design: ArticleDesign.Standard,
-	theme: Pillar.News,
-};
-
 const NewsEvents = [
 	{
 		title: '',
@@ -302,7 +294,6 @@ export const noTimelineEventsStoryExpanded = {
 	description:
 		'<p><b>January 2015</b></p><p>Hamilton, a new musical written by and starring <a href="https://www.theguardian.com/stage/2016/sep/25/lin-manuel-miranda-broadway-smash-hamilton-hip-hop-musical-school-of-eminem">Lin-Manuel Miranda</a>, has its first performances off-Broadway at the Public theater in New York. Its subject is the US founding father who was the first secretary of the Treasury.&nbsp;</p><p><b>February 2015</b><br></p><p>As the show opens officially, it wins praise from critics, particularly for its innovative blend of musical styles, from rap to operetta. In her <a href="https://www.theguardian.com/stage/2015/feb/18/hamilton-review-founding-father-gets-a-hip-hop-makeover">four-star review</a>, the Guardian’s Alexis Soloski calls the show "brash, nimble, historically engaged and startlingly contemporary".</p><p><b>August 2015</b><br></p><p>After selling out its run at the Public, the show opens on Broadway at the Richard Rodgers theatre and there is huge demand for tickets.</p><p><b>February 2016</b><br></p><p>The original Broadway cast recording wins a Grammy award for best musical theatre album.</p><p><b>March 2016</b><br></p><p>Miranda visits the White House to perform songs from the musical and a <a href="https://www.theguardian.com/stage/video/2016/mar/15/hamilton-star-freestyle-raps-with-obama-at-the-white-house-video">video of him freestyling</a> in the Rose Garden with President Barack Obama goes viral. First lady Michelle Obama calls the show “the best piece of art in any form that I have ever seen in my life”.</p><p><b>April 2016</b><br></p><p>Hamilton wins the Pulitzer prize for drama.</p><p><b>June 2016</b>&nbsp;<br></p><p>The musical breaks records, winning 11 Tony awards – at a ceremony that takes place after news breaks of a mass shooting in Orlando, Florida. Miranda performs a sonnet in praise of his wife and son, ending with the words: “Now fill the world with music, love and pride.”</p><p><b>July 2016</b><br></p><p>Miranda stops performing in the show to pursue other opportunities, including starring in a sequel to Mary Poppins. A spoof version of the musical, Spamilton, opens in New York.</p><p><b>&nbsp;October 2016</b></p><p>A production of Hamilton opens in Chicago and runs concurrently with the Broadway version.</p><p><b>November 2016</b><br></p><p>Vice-president-elect <a href="https://www.theguardian.com/us-news/video/2016/nov/19/mike-pence-told-at-hamilton-we-are-anxious-you-will-not-protect-us-video">Mike Pence</a> sees the show in New York. From the stage, actor Brandon Victor Dixon addresses him directly, saying: “We are the diverse America who are alarmed and anxious that your new administration will not protect us.” On Twitter, Donald Trump condemns their “terrible behaviour” and says he hears the show is “highly overrated”.<br></p><p><b>January 2017</b><br></p><p>The first cast members are revealed for a West End production of Hamilton.&nbsp;</p><p><b>December 2017</b><br></p><p>The show opens to five-star reviews at the newly renovated Victoria Palace theatre in London.</p><p><b>March 2018</b></p><p>The London production of Hamilton gets 13 Olivier nominations, making it the most nominated show in the history of the awards.</p><p><b>July 2020</b></p><p>A filmed version of the Broadway production debuts on the Disney+ streaming service, warmly welcomed while the world is still in lockdown over the coronavirus crisis.&nbsp;</p>',
 	title: 'How Hamilton the Musical became a smash hit',
-	format: { ...format, theme: Pillar.News },
 	expandForStorybook: true,
 	likeHandler: (): null => null,
 	dislikeHandler: (): null => null,
@@ -315,7 +306,6 @@ export const noTimelineEventsStory = {
 	description:
 		'<p><b>January 2015</b></p><p>Hamilton, a new musical written by and starring <a href="https://www.theguardian.com/stage/2016/sep/25/lin-manuel-miranda-broadway-smash-hamilton-hip-hop-musical-school-of-eminem">Lin-Manuel Miranda</a>, has its first performances off-Broadway at the Public theater in New York. Its subject is the US founding father who was the first secretary of the Treasury.&nbsp;</p><p><b>February 2015</b><br></p><p>As the show opens officially, it wins praise from critics, particularly for its innovative blend of musical styles, from rap to operetta. In her <a href="https://www.theguardian.com/stage/2015/feb/18/hamilton-review-founding-father-gets-a-hip-hop-makeover">four-star review</a>, the Guardian’s Alexis Soloski calls the show "brash, nimble, historically engaged and startlingly contemporary".</p><p><b>August 2015</b><br></p><p>After selling out its run at the Public, the show opens on Broadway at the Richard Rodgers theatre and there is huge demand for tickets.</p><p><b>February 2016</b><br></p><p>The original Broadway cast recording wins a Grammy award for best musical theatre album.</p><p><b>March 2016</b><br></p><p>Miranda visits the White House to perform songs from the musical and a <a href="https://www.theguardian.com/stage/video/2016/mar/15/hamilton-star-freestyle-raps-with-obama-at-the-white-house-video">video of him freestyling</a> in the Rose Garden with President Barack Obama goes viral. First lady Michelle Obama calls the show “the best piece of art in any form that I have ever seen in my life”.</p><p><b>April 2016</b><br></p><p>Hamilton wins the Pulitzer prize for drama.</p><p><b>June 2016</b>&nbsp;<br></p><p>The musical breaks records, winning 11 Tony awards – at a ceremony that takes place after news breaks of a mass shooting in Orlando, Florida. Miranda performs a sonnet in praise of his wife and son, ending with the words: “Now fill the world with music, love and pride.”</p><p><b>July 2016</b><br></p><p>Miranda stops performing in the show to pursue other opportunities, including starring in a sequel to Mary Poppins. A spoof version of the musical, Spamilton, opens in New York.</p><p><b>&nbsp;October 2016</b></p><p>A production of Hamilton opens in Chicago and runs concurrently with the Broadway version.</p><p><b>November 2016</b><br></p><p>Vice-president-elect <a href="https://www.theguardian.com/us-news/video/2016/nov/19/mike-pence-told-at-hamilton-we-are-anxious-you-will-not-protect-us-video">Mike Pence</a> sees the show in New York. From the stage, actor Brandon Victor Dixon addresses him directly, saying: “We are the diverse America who are alarmed and anxious that your new administration will not protect us.” On Twitter, Donald Trump condemns their “terrible behaviour” and says he hears the show is “highly overrated”.<br></p><p><b>January 2017</b><br></p><p>The first cast members are revealed for a West End production of Hamilton.&nbsp;</p><p><b>December 2017</b><br></p><p>The show opens to five-star reviews at the newly renovated Victoria Palace theatre in London.</p><p><b>March 2018</b></p><p>The London production of Hamilton gets 13 Olivier nominations, making it the most nominated show in the history of the awards.</p><p><b>July 2020</b></p><p>A filmed version of the Broadway production debuts on the Disney+ streaming service, warmly welcomed while the world is still in lockdown over the coronavirus crisis.&nbsp;</p>',
 	title: 'How Hamilton the Musical became a smash hit',
-	format: { ...format, theme: Pillar.Culture },
 	likeHandler: (): null => null,
 	dislikeHandler: (): null => null,
 	expandCallback: (): null => null,
@@ -324,7 +314,6 @@ export const noTimelineEventsStory = {
 export const newsTimelineStoryNoDescriptionExpanded = {
 	id: 'a10c1968-908d-4ec5-86ef-05b45468c0de',
 	title: 'Jeffrey Epstein, Ghislaine Maxwell and Prince Andrew',
-	format: { ...format, theme: Pillar.News },
 	events: NewsEvents,
 	expandForStorybook: true,
 	likeHandler: (): null => null,
@@ -335,7 +324,6 @@ export const newsTimelineStoryNoDescriptionExpanded = {
 export const sportTimelineStoryWithDescriptionAndEventsExpanded = {
 	id: '15418150-6d0c-4bd1-86a2-be894e5fe928',
 	title: "Froome's golden decade with Team Sky",
-	format: { ...format, theme: Pillar.Sport },
 	description:
 		'<p><i>Chris Froome has won seven Grand Tours since joining Team Sky in 2010</i></p>',
 	events: SportEvents,
@@ -348,7 +336,6 @@ export const sportTimelineStoryWithDescriptionAndEventsExpanded = {
 export const newsStoryWithDatesToExpanded = {
 	id: 'd7cdd1bd-7b85-4ad0-8368-3fb0d5b20593',
 	title: 'Julian Assange extradition battle',
-	format: { ...format, theme: Pillar.News },
 	events: DateToEvents,
 	expandForStorybook: true,
 	likeHandler: (): null => null,

--- a/dotcom-rendering/src/components/ExpandableAtom/Body.tsx
+++ b/dotcom-rendering/src/components/ExpandableAtom/Body.tsx
@@ -93,12 +93,10 @@ export const Body = ({
 	html,
 	image,
 	credit,
-	format,
 }: {
 	html: string;
 	image?: string;
 	credit?: string;
-	format: ArticleFormat;
 }): JSX.Element => {
 	return (
 		<div>

--- a/dotcom-rendering/src/components/ExpandableAtom/Container.tsx
+++ b/dotcom-rendering/src/components/ExpandableAtom/Container.tsx
@@ -39,7 +39,6 @@ export const Container = ({
 	id,
 	title,
 	children,
-	format,
 	expandForStorybook,
 	atomType,
 	atomTypeTitle,
@@ -47,7 +46,6 @@ export const Container = ({
 }: {
 	id: string;
 	title: string;
-	format: ArticleFormat;
 	expandForStorybook?: boolean;
 	atomType: string;
 	atomTypeTitle: string;
@@ -63,7 +61,6 @@ export const Container = ({
 		>
 			<Summary
 				sectionTitle={atomTypeTitle}
-				format={format}
 				title={title}
 				expandCallback={expandCallback}
 			/>

--- a/dotcom-rendering/src/components/ExpandableAtom/Footer.tsx
+++ b/dotcom-rendering/src/components/ExpandableAtom/Footer.tsx
@@ -27,11 +27,9 @@ const ThumbImage = () => {
 };
 
 export const Footer = ({
-	format,
 	likeHandler,
 	dislikeHandler,
 }: {
-	format: ArticleFormat;
 	likeHandler: () => void;
 	dislikeHandler: () => void;
 }): JSX.Element => {

--- a/dotcom-rendering/src/components/ExpandableAtom/Summary.tsx
+++ b/dotcom-rendering/src/components/ExpandableAtom/Summary.tsx
@@ -40,10 +40,8 @@ const iconSpacing = css`
 export const Summary = ({
 	sectionTitle,
 	title,
-	format,
 	expandCallback,
 }: {
-	format: ArticleFormat;
 	sectionTitle: string;
 	title: string;
 	expandCallback: () => void;

--- a/dotcom-rendering/src/components/GuideAtom/GuideAtom.tsx
+++ b/dotcom-rendering/src/components/GuideAtom/GuideAtom.tsx
@@ -1,4 +1,3 @@
-import type { ArticleFormat } from '@guardian/libs';
 import { submitComponentEvent } from '../../client/ophan/ophan';
 import { useConfig } from '../ConfigContext';
 import { Body } from '../ExpandableAtom/Body';
@@ -11,7 +10,6 @@ export type GuideAtomProps = {
 	image?: string;
 	html: string;
 	credit?: string;
-	format: ArticleFormat;
 	expandForStorybook?: boolean;
 	likeHandler?: () => void;
 	dislikeHandler?: () => void;
@@ -24,7 +22,6 @@ export const GuideAtom = ({
 	image,
 	html,
 	credit,
-	format,
 	expandForStorybook,
 	likeHandler,
 	dislikeHandler,
@@ -36,7 +33,6 @@ export const GuideAtom = ({
 		<Container
 			id={id}
 			title={title}
-			format={format}
 			atomType="guide"
 			atomTypeTitle="Quick Guide"
 			expandForStorybook={expandForStorybook}
@@ -57,9 +53,8 @@ export const GuideAtom = ({
 					))
 			}
 		>
-			<Body html={html} image={image} credit={credit} format={format} />
+			<Body html={html} image={image} credit={credit} />
 			<Footer
-				format={format}
 				dislikeHandler={
 					dislikeHandler ??
 					(() =>

--- a/dotcom-rendering/src/components/ProfileAtom.importable.tsx
+++ b/dotcom-rendering/src/components/ProfileAtom.importable.tsx
@@ -1,4 +1,3 @@
-import type { ArticleFormat } from '@guardian/libs';
 import { submitComponentEvent } from '../client/ophan/ophan';
 import { useConfig } from './ConfigContext';
 import { Body } from './ExpandableAtom/Body';
@@ -11,7 +10,6 @@ export interface ProfileAtomProps {
 	image?: string;
 	html: string;
 	credit?: string;
-	format: ArticleFormat;
 	expandForStorybook?: boolean;
 	likeHandler?: () => void;
 	dislikeHandler?: () => void;
@@ -23,7 +21,6 @@ export const ProfileAtom = ({
 	image,
 	html,
 	credit,
-	format,
 	expandForStorybook,
 	likeHandler,
 	dislikeHandler,
@@ -35,7 +32,6 @@ export const ProfileAtom = ({
 		<Container
 			id={id}
 			title={title}
-			format={format}
 			atomType="profile"
 			atomTypeTitle="Profile"
 			expandForStorybook={expandForStorybook}
@@ -56,9 +52,8 @@ export const ProfileAtom = ({
 					))
 			}
 		>
-			<Body html={html} image={image} credit={credit} format={format} />
+			<Body html={html} image={image} credit={credit} />
 			<Footer
-				format={format}
 				dislikeHandler={
 					dislikeHandler ??
 					(() =>

--- a/dotcom-rendering/src/components/ProfileAtom.stories.tsx
+++ b/dotcom-rendering/src/components/ProfileAtom.stories.tsx
@@ -17,7 +17,6 @@ export const NewsProfileStory = (): JSX.Element => {
 	// Based on: https://www.theguardian.com/us-news/2020/jul/13/ghislaine-maxwell-court-sex-trafficking-trial-epstein
 	return (
 		<ProfileAtom
-			format={format}
 			id="830f7948-c436-4a8d-9361-e4220444d49f"
 			image="https://i.guim.co.uk/img/media/cde1f62b34d6a110c7847af64864a4fc308b7967/464_266_975_975/975.jpg?width=620&quality=85&auto=format&fit=max&s=0e45463eaeec14d4e430220a925e665e"
 			title="Who is Ghislaine Maxwell?"
@@ -45,7 +44,6 @@ export const NewsProfileStory2 = (): JSX.Element => {
 	// Based on: https://www.theguardian.com/business/2020/may/11/richard-branson-to-sell-500m-worth-of-virgin-galactic-shares
 	return (
 		<ProfileAtom
-			format={format}
 			id="da5cfac0-b259-4db9-92a9-80a9a7cfe5f4"
 			image="https://i.guim.co.uk/img/media/d02ae7bbf3763747535a1b8be375396de7ae1666/439_557_2733_1640/2733.jpg?width=620&quality=85&auto=format&fit=max&s=2ed128901b717d8c01bc60b18894306a"
 			title="Virgin Galactic"
@@ -73,7 +71,6 @@ export const NoProfileImageStory = (): JSX.Element => {
 	// Modelled after: https://www.theguardian.com/politics/2020/jan/24/labour-leadership-unite-backs-brilliant-rebecca-long-bailey
 	return (
 		<ProfileAtom
-			format={format}
 			id="1fba49a4-81c6-49e4-b7fa-fd66d1512360"
 			title="Who is Jon Lansman?"
 			html="<p>A 62-year-old Labour veteran who joined the party in 1974 and worked for Labour icon Tony Benn during his deputy leadership campaign in the 1980s. Lansman served as director of operations for Corbyn’s leadership campaign. After Corbyn was elected as the leader of the Labour party in 2015, Lansman founded Momentum, a pro-Corbyn campaign group.<br></p>"

--- a/dotcom-rendering/src/components/ProfileAtom.test.tsx
+++ b/dotcom-rendering/src/components/ProfileAtom.test.tsx
@@ -1,13 +1,7 @@
-import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
 import { fireEvent, render } from '@testing-library/react';
 import { ConfigProvider } from './ConfigContext';
 import { ProfileAtom } from './ProfileAtom.importable';
 
-const format: ArticleFormat = {
-	theme: Pillar.News,
-	design: ArticleDesign.Analysis,
-	display: ArticleDisplay.Standard,
-};
 describe('ProfileAtom', () => {
 	it('should render', () => {
 		const { getByText, queryByText } = render(
@@ -19,7 +13,6 @@ describe('ProfileAtom', () => {
 					title="Who is Jon Lansman?"
 					html="<p>A 62-year-old Labour veteran who joined the party in 1974 and worked for Labour icon Tony Benn during his deputy leadership campaign in the 1980s. Lansman served as director of operations for Corbyn’s leadership campaign. After Corbyn was elected as the leader of the Labour party in 2015, Lansman founded Momentum, a pro-Corbyn campaign group.<br></p>"
 					credit=""
-					format={format}
 					likeHandler={() => {
 						return null;
 					}}
@@ -52,7 +45,6 @@ describe('ProfileAtom', () => {
 			>
 				<ProfileAtom
 					id="1fba49a4-81c6-49e4-b7fa-fd66d1512360"
-					format={format}
 					title="Who is Jon Lansman?"
 					html="<p>A 62-year-old Labour veteran who joined the party in 1974 and worked for Labour icon Tony Benn during his deputy leadership campaign in the 1980s. Lansman served as director of operations for Corbyn’s leadership campaign. After Corbyn was elected as the leader of the Labour party in 2015, Lansman founded Momentum, a pro-Corbyn campaign group.<br></p>"
 					credit=""
@@ -89,7 +81,6 @@ describe('ProfileAtom', () => {
 			>
 				<ProfileAtom
 					id="1fba49a4-81c6-49e4-b7fa-fd66d1512360"
-					format={format}
 					title="Who is Jon Lansman?"
 					html="<p>A 62-year-old Labour veteran who joined the party in 1974 and worked for Labour icon Tony Benn during his deputy leadership campaign in the 1980s. Lansman served as director of operations for Corbyn’s leadership campaign. After Corbyn was elected as the leader of the Labour party in 2015, Lansman founded Momentum, a pro-Corbyn campaign group.<br></p>"
 					credit=""

--- a/dotcom-rendering/src/components/QandaAtom.importable.tsx
+++ b/dotcom-rendering/src/components/QandaAtom.importable.tsx
@@ -10,7 +10,6 @@ export type QandaAtomProps = {
 	image?: string;
 	html: string;
 	credit?: string;
-	format: ArticleFormat;
 	expandForStorybook?: boolean;
 	likeHandler?: () => void;
 	dislikeHandler?: () => void;
@@ -22,7 +21,6 @@ export const QandaAtom = ({
 	image,
 	html,
 	credit,
-	format,
 	expandForStorybook,
 	likeHandler,
 	dislikeHandler,
@@ -36,7 +34,6 @@ export const QandaAtom = ({
 			title={title}
 			atomType="qanda"
 			atomTypeTitle="Q&A"
-			format={format}
 			expandForStorybook={expandForStorybook}
 			expandCallback={
 				expandCallback ??
@@ -55,9 +52,8 @@ export const QandaAtom = ({
 					))
 			}
 		>
-			<Body html={html} image={image} credit={credit} format={format} />
+			<Body html={html} image={image} credit={credit} />
 			<Footer
-				format={format}
 				dislikeHandler={
 					dislikeHandler ??
 					(() =>

--- a/dotcom-rendering/src/components/TimelineAtom.importable.tsx
+++ b/dotcom-rendering/src/components/TimelineAtom.importable.tsx
@@ -54,13 +54,7 @@ const EventToDate = css`
 	})};
 `;
 
-const TimelineContents = ({
-	events,
-	format,
-}: {
-	events: TimelineEvent[];
-	format: ArticleFormat;
-}) => {
+const TimelineContents = ({ events }: { events: TimelineEvent[] }) => {
 	return (
 		<div>
 			{events.map((event, index) => {
@@ -88,9 +82,7 @@ const TimelineContents = ({
 						{!!event.title && (
 							<div css={EventTitle}>{event.title}</div>
 						)}
-						{!!event.body && (
-							<Body html={event.body} format={format} />
-						)}
+						{!!event.body && <Body html={event.body} />}
 					</div>
 				);
 			})}
@@ -103,7 +95,6 @@ export const TimelineAtom = ({
 	events,
 	description,
 	title,
-	format,
 	expandForStorybook,
 	likeHandler,
 	dislikeHandler,
@@ -116,7 +107,6 @@ export const TimelineAtom = ({
 			atomType="timeline"
 			atomTypeTitle="Timeline"
 			id={id}
-			format={format}
 			expandForStorybook={expandForStorybook}
 			title={title}
 			expandCallback={
@@ -136,10 +126,9 @@ export const TimelineAtom = ({
 					))
 			}
 		>
-			{!!description && <Body html={description} format={format} />}
-			{events && <TimelineContents events={events} format={format} />}
+			{!!description && <Body html={description} />}
+			{events && <TimelineContents events={events} />}
 			<Footer
-				format={format}
 				dislikeHandler={
 					dislikeHandler ??
 					(() =>

--- a/dotcom-rendering/src/lib/renderElement.tsx
+++ b/dotcom-rendering/src/lib/renderElement.tsx
@@ -317,7 +317,6 @@ export const renderElement = ({
 						html={element.html}
 						image={element.img}
 						credit={element.credit}
-						format={format}
 					/>
 				</Island>
 			);
@@ -480,7 +479,6 @@ export const renderElement = ({
 						html={element.html}
 						image={element.img}
 						credit={element.credit}
-						format={format}
 					/>
 				</Island>
 			);
@@ -503,7 +501,6 @@ export const renderElement = ({
 						html={element.html}
 						image={element.img}
 						credit={element.credit}
-						format={format}
 					/>
 				</Island>
 			);
@@ -601,7 +598,6 @@ export const renderElement = ({
 					<TimelineAtom
 						id={element.id}
 						title={element.title}
-						format={format}
 						events={element.events}
 						description={element.description}
 					/>

--- a/dotcom-rendering/src/types/content.ts
+++ b/dotcom-rendering/src/types/content.ts
@@ -765,7 +765,6 @@ export type TimelineAtomType = {
 	id: string;
 	events?: TimelineEvent[];
 	title: string;
-	format: ArticleFormat;
 	description?: string;
 	expandForStorybook?: boolean;
 	likeHandler?: () => void;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Updates the expanding atoms for darkmode* removing the need for the format prop. 

*This PR does not implement dark mode in the timeline atom as this will be handled in a separate, upcoming pr.


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
