### PR TITLE
Make `useIsInView` custom hook more robust and reactive

### DIFF
--- a/dotcom-rendering/src/lib/useIsInView.ts
+++ b/dotcom-rendering/src/lib/useIsInView.ts
@@ -1,63 +1,80 @@
 import libDebounce from 'lodash.debounce';
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+type Options = {
+	/**
+	 * Defaults to `undefined` (falsy),
+	 * which trigger a change the instantaneously.
+	 *
+	 * If `true`, debounce triggers by 200ms.
+	 * Enabling debouncing ensures the target element intersects
+	 * for at least 200ms before the callback is executed
+	 */
+	debounce?: true;
+	/**
+	 * Defaults to `undefined` (falsy),
+	 * which only trigger on the first intersection.
+	 *
+	 * If `true`, trigger the hook on all intersections.
+	 */
+	repeat?: true;
+	/** Set the initial HTML Element, if known. */
+	node?: HTMLElement;
+};
 
 /**
  * Custom hook around the `IntersectionObserver`.
  *
- * @param options
- * @param {boolean} [options.debouce] If `true`, debounce triggers by 200ms.
- * By default, trigger instantaneously. Enabling debouncing ensures the target
- * element intersects for at least 200ms before the callback is executed
- * @param {boolean} [options.repeat] If `true`, trigger the hook on
- * all intersections. By default, only trigger on the first intersection.
- * @param {boolean} [options.node] Set the initial node, if known.
- * @returns a tuple containing [isInView, setNode];
+ * @returns a tuple containing `[isInView, setNode]`
  */
 const useIsInView = (
-	options: IntersectionObserverInit & {
-		debounce?: true;
-		repeat?: true;
-		node?: HTMLElement;
-	},
+	options: IntersectionObserverInit & Options,
 ): [boolean, React.Dispatch<React.SetStateAction<HTMLElement | null>>] => {
 	const [isInView, setIsInView] = useState<boolean>(false);
 	const [node, setNode] = useState<HTMLElement | null>(options.node ?? null);
 
 	const observer = useRef<IntersectionObserver | null>(null);
 
-	const intersectionFn: IntersectionObserverCallback = ([entry]) => {
-		if (!entry) return;
+	const intersectionObserverCallback =
+		useCallback<IntersectionObserverCallback>(
+			([entry]) => {
+				if (!entry) return;
 
-		if (entry.isIntersecting) {
-			setIsInView(true);
-		} else if (options.repeat) {
-			setIsInView(false);
-		}
-	};
+				if (entry.isIntersecting) {
+					setIsInView(true);
+				} else if (options.repeat) {
+					setIsInView(false);
+				}
+			},
+			[options.repeat],
+		);
+
 	const intersectionCallback = options.debounce
-		? libDebounce(intersectionFn, 200)
-		: intersectionFn;
+		? libDebounce(intersectionObserverCallback, 200)
+		: intersectionObserverCallback;
 
 	useEffect(() => {
-		// TODO: can we remove this? It’s now always cleaned up
-		if (observer.current) {
-			observer.current.disconnect();
-		}
+		options.node && setNode(options.node);
+	}, [options.node]);
 
-		// eslint-disable-next-line @typescript-eslint/strict-boolean-expressions, @typescript-eslint/no-unnecessary-condition -- Safety for browser support
-		if (window.IntersectionObserver) {
-			observer.current = new window.IntersectionObserver(
-				intersectionCallback,
-				options,
-			);
+	useEffect(() => {
+		if (!node) return;
+		// Check for browser support https://caniuse.com/intersectionobserver
+		if (!('IntersectionObserver' in window)) return;
 
-			if (node) {
-				observer.current.observe(node);
-			}
-		}
+		observer.current = new window.IntersectionObserver(
+			intersectionCallback,
+			options,
+		);
+
+		observer.current.observe(node);
 
 		return () => observer.current?.disconnect();
 	}, [node, options, intersectionCallback]);
+
+	useEffect(() => {
+		if (!options.repeat && isInView) observer.current?.disconnect();
+	}, [isInView, options.repeat]);
 
 	return [isInView, setNode];
 };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Refactor `useIsInView` to make it more robust and reactive:

- ensure options changing is reflected:
  - wrap the callback in a `useCallback` with dependencies
  - if `options.node` is set after the initial render, ensure the node is updated with a
    `useEffect` with dependencies
- better documentation for consumers, with detailed defaults
- early disconnect when no repeat and node is in view

## Why?

Paves the way for refactoring `Liveness` and making it simpler:
- #9982

## Screenshots

N/A