### PR TITLE
Add Reclaim Your Brain newsletter to All Newsletters page

### DIFF
--- a/dotcom-rendering/src/model/newsletter-grouping.ts
+++ b/dotcom-rendering/src/model/newsletter-grouping.ts
@@ -16,6 +16,7 @@ export const groups: Partial<Record<EditionId, StaticGroups>> = {
 				'this-is-europe',
 				'the-guide-staying-in',
 				'the-long-read',
+				'reclaim-your-brain',
 			],
 		},
 		{
@@ -107,12 +108,13 @@ export const groups: Partial<Record<EditionId, StaticGroups>> = {
 			newsletters: [
 				'us-morning-newsletter', // First Thing
 				'today-us', // Headlines US
-				'headlines-europe',
-				'green-light', // Down to Earth
 				'trump-on-trial',
+				'reclaim-your-brain',
 				'follow-margaret-sullivan',
 				'follow-robert-reich',
 				'best-of-opinion-us',
+				'headlines-europe',
+				'green-light', // Down to Earth
 				'patriarchy',
 				'bookmarks',
 			],
@@ -204,6 +206,7 @@ export const groups: Partial<Record<EditionId, StaticGroups>> = {
 				'afternoon-update',
 				'first-dog',
 				'the-rural-network',
+				'reclaim-your-brain',
 			],
 		},
 		{


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Adds the Reclaim you brain newsletter to the all newsletter page 

## Why?

As per editorial request, they launched a new newsletter

## Screenshots

Example for UK: 

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/1229808/697abca5-5317-48d6-820e-74fac42917ae
[after]: https://github.com/guardian/dotcom-rendering/assets/1229808/21a6b939-434f-4c02-bf54-93e3123c5cb3


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
