### PR TITLE
Fix `doctoc` Scripts

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -3,7 +3,6 @@
 	"description": "theguardian.com rendering tier",
 	"version": "0.1.0-alpha",
 	"license": "Apache-2.0",
-	"tocList": "README.md docs/contributing/**",
 	"private": true,
 	"scripts": {
 		"preinstall": "../scripts/preinstall.mjs",
@@ -17,8 +16,8 @@
 		"test": "jest --maxWorkers=50%",
 		"test:watch": "jest --watch --maxWorkers=25%",
 		"test:ci": "jest --runInBand",
-		"createtoc": "doctoc $npm_package_tocList --github --update-only --title '<!-- Automatically created by running `yarn createtoc` in a pre-commit hook -->' ",
-		"addandcommittoc": "git add $npm_package_tocList && git commit -m 'Add TOC update' || true",
+		"createtoc": "doctoc README.md docs/contributing/** --github --update-only --title '<!-- Automatically created by running `yarn createtoc` in a pre-commit hook -->' ",
+		"addandcommittoc": "git add README.md docs/contributing/** && git commit -m 'Add TOC update' || true",
 		"playwright:open": "playwright test --ui",
 		"playwright:run": "playwright test",
 		"cypress:open": "cypress open",


### PR DESCRIPTION
This previously relied on the package manager running the script (npm, yarn etc.) including environment variables derived from fields in the `package.json` file [^1]. So a field called `tocList` would automatically create an environment variable called `npm_package_tocList`.

It appears this is no longer a feature of recent versions of these package managers [^2], so running these commands fails with `Unbound variable "npm_package_tocList"`.

Given these commands are now run by a pre-commit hook whenever one of the markdown files changes [^3], this failure prevents markdown changes being committed.

To fix this, the `tocList` field has been removed and the two entries have been inlined within the script commands.

[^1]: #592
[^2]: https://github.com/npm/rfcs/blob/d91358e1238066650bb7d1b271dfcfc8ca6c2026/implemented/0021-reduce-lifecycle-script-environment.md
[^3]: #9612
