### PR TITLE
Darkmode - Code Block

### DIFF
--- a/dotcom-rendering/src/components/CodeBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/components/CodeBlockComponent.stories.tsx
@@ -1,5 +1,5 @@
-import { splitTheme } from '../../.storybook/decorators/splitThemeDecorator';
 import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
+import { splitTheme } from '../../.storybook/decorators/splitThemeDecorator';
 import { CodeBlockComponent } from './CodeBlockComponent';
 import { Section } from './Section';
 

--- a/dotcom-rendering/src/components/CodeBlockComponent.tsx
+++ b/dotcom-rendering/src/components/CodeBlockComponent.tsx
@@ -16,8 +16,8 @@ const codeStyles = css`
     * Based on dabblet (http://dabblet.com)
     * @author Lea Verou
     */
-	color: 'inherit';
-	text-shadow: 0 1px white;
+	color: inherit;
+	text-shadow: 0 1px ${palette('--code-block-text-shadow')};
 	/* The GU fonts don't work here */
 	/* stylelint-disable-next-line property-disallowed-list */
 	font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -4649,6 +4649,10 @@ sourcePalette.neutral[0];
 const codeBlockBackgroundLight: PaletteFunction = () => '#f5f2f0';
 const codeBlockBackgroundDark: PaletteFunction = () =>
 	sourcePalette.neutral[38];
+const codeBlockTextShadowLight: PaletteFunction = () =>
+	sourcePalette.neutral[100];
+const codeBlockTextShadowDark: PaletteFunction = () => sourcePalette.neutral[0];
+sourcePalette.neutral[38];
 
 // ----- Palette ----- //
 
@@ -5480,6 +5484,10 @@ const paletteColours = {
 	'--code-block-background': {
 		light: codeBlockBackgroundLight,
 		dark: codeBlockBackgroundDark,
+	},
+	'--code-block-text-shadow': {
+		light: codeBlockTextShadowLight,
+		dark: codeBlockTextShadowDark,
 	},
 } satisfies PaletteColours;
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Supports darkmode for the code block

## Why?
Part of a wider body of work to support dark mode
Resolves https://github.com/guardian/dotcom-rendering/issues/9746

## Screenshots

| Before      | After      |
| ----------- | ---------- |
|<img width="607" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/a84e07bf-ef12-4320-a4cb-c71108a395f6"> |<img width="607" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/26366706/b415f07f-b73d-46d3-8af6-984f7b5205b1"> |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
