### PR TITLE
Hide video duration on card when zero

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.stories.tsx
+++ b/dotcom-rendering/src/components/Card/Card.stories.tsx
@@ -288,6 +288,18 @@ export const WithMediaType = () => {
 					{...basicCardProps}
 					format={{
 						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Video,
+						theme: Pillar.Sport,
+					}}
+					mainMedia={{ ...mainVideo, duration: 0 }}
+					headlineText="Video without duration"
+				/>
+			</CardWrapper>
+			<CardWrapper>
+				<Card
+					{...basicCardProps}
+					format={{
+						display: ArticleDisplay.Standard,
 						design: ArticleDesign.Audio,
 						theme: Pillar.Sport,
 					}}

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -541,7 +541,7 @@ export const Card = ({
 									loading={imageLoading}
 									roundedCorners={isOnwardContent}
 								/>
-								{showPlayIcon && ( mainMedia.duration > 0 &&
+								{showPlayIcon && mainMedia.duration > 0 && (
 									<MediaDuration
 										mediaDuration={mainMedia.duration}
 										imagePosition={imagePosition}

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -541,7 +541,7 @@ export const Card = ({
 									loading={imageLoading}
 									roundedCorners={isOnwardContent}
 								/>
-								{showPlayIcon && (
+								{showPlayIcon && ( mainMedia.duration > 0 &&
 									<MediaDuration
 										mediaDuration={mainMedia.duration}
 										imagePosition={imagePosition}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Hides the video duration from a card when the video length is zero 

## Why?

Design and UX wise it feels better than showing an empty box

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[after]: https://github.com/guardian/dotcom-rendering/assets/1229808/30ab9bd8-ec43-45d3-8041-a1a302591302
[before]: https://github.com/guardian/dotcom-rendering/assets/1229808/52eeaefe-8969-4fcf-acc3-bdf219b925d7

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
