### PR TITLE
Ld add md change

### DIFF
--- a/dotcom-rendering/docs/contributing/how-to.md
+++ b/dotcom-rendering/docs/contributing/how-to.md
@@ -60,3 +60,5 @@ We currently use [SWR](https://swr.vercel.app/) to manage AJAX requests on the
 client. Your starting point should be the [`useApi` hook](../../src/web/lib/useApi.tsx),
 which is DCR's wrapper around SWR's own hook. Because this hook requires
 client-side React code, you will need to place your component in an `<Island>` wrapper.
+
+Adding some notes to markdown

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -3,7 +3,6 @@
 	"description": "theguardian.com rendering tier",
 	"version": "0.1.0-alpha",
 	"license": "Apache-2.0",
-	"tocList": "README.md docs/contributing/**",
 	"private": true,
 	"scripts": {
 		"preinstall": "../scripts/preinstall.mjs",
@@ -17,8 +16,8 @@
 		"test": "jest --maxWorkers=50%",
 		"test:watch": "jest --watch --maxWorkers=25%",
 		"test:ci": "jest --runInBand",
-		"createtoc": "doctoc $npm_package_tocList --github --update-only --title '<!-- Automatically created by running `yarn createtoc` in a pre-commit hook -->' ",
-		"addandcommittoc": "git add $npm_package_tocList && git commit -m 'Add TOC update' || true",
+		"createtoc": "doctoc README.md docs/contributing/** --github --update-only --title '<!-- Automatically created by running `yarn createtoc` in a pre-commit hook -->' ",
+		"addandcommittoc": "git add README.md docs/contributing/** && git commit -m 'Add TOC update' || true",
 		"playwright:open": "playwright test --ui",
 		"playwright:run": "playwright test",
 		"cypress:open": "cypress open",


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
