### PR TITLE
Bump `screenfull` to v6

### DIFF
--- a/dotcom-rendering/jest.config.js
+++ b/dotcom-rendering/jest.config.js
@@ -1,10 +1,12 @@
 const swcConfig = require('./webpack/.swcrc.json');
 
+const esModules = ['@guardian/', 'screenfull'].join('|');
+
 module.exports = {
 	testEnvironment: 'jsdom',
 	moduleDirectories: ['node_modules', 'src'],
 	transform: {
-		'^.+\\.(ts|tsx)$': ['@swc/jest', swcConfig],
+		'^.+\\.(js|ts|tsx)$': ['@swc/jest', swcConfig],
 	},
 	testMatch: ['**/*.test.+(ts|tsx|js)'],
 	setupFilesAfterEnv: ['<rootDir>/scripts/jest/setup.ts'],
@@ -12,6 +14,6 @@ module.exports = {
 		'^svgs/(.*)$': '<rootDir>/__mocks__/svgMock.tsx',
 		'^(.*)\\.svg$': '<rootDir>/__mocks__/svgMock.tsx',
 	},
-	transformIgnorePatterns: ['/node_modules/(?!@guardian/)'],
+	transformIgnorePatterns: [`/node_modules/(?!${esModules})`],
 	collectCoverageFrom: ['src/**/*.{ts,tsx}'],
 };

--- a/dotcom-rendering/jest.config.js
+++ b/dotcom-rendering/jest.config.js
@@ -14,6 +14,6 @@ module.exports = {
 		'^svgs/(.*)$': '<rootDir>/__mocks__/svgMock.tsx',
 		'^(.*)\\.svg$': '<rootDir>/__mocks__/svgMock.tsx',
 	},
-	transformIgnorePatterns: [`/node_modules/(?!${esModules})`],
+	transformIgnorePatterns: [`/node_modules/.pnpm/(?!${esModules})`],
 	collectCoverageFrom: ['src/**/*.{ts,tsx}'],
 };

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -213,7 +213,7 @@
 		"response-time": "2.3.2",
 		"sanitize-html": "2.11.0",
 		"scheduler": "0.23.0",
-		"screenfull": "5.2.0",
+		"screenfull": "6.0.2",
 		"semver": "7.5.4",
 		"serve-static": "1.15.0",
 		"simple-progress-webpack-plugin": "2.0.0",

--- a/dotcom-rendering/webpack/webpack.config.server.js
+++ b/dotcom-rendering/webpack/webpack.config.server.js
@@ -43,7 +43,11 @@ module.exports = {
 		...(DEV
 			? [
 					nodeExternals({
-						allowlist: [/^@guardian/],
+						allowlist: [
+							/^@guardian/,
+							// this project is ESM-only and throws an error when bundled
+							'screenfull',
+						],
 						additionalModuleDirs: [
 							// Since we use workspaces for the monorepo, node_modules will be co-located
 							// both in the '(project-root)/dotcom-rendering/node_modules' directory (default for webpack-node-externals)

--- a/dotcom-rendering/webpack/webpack.config.server.js
+++ b/dotcom-rendering/webpack/webpack.config.server.js
@@ -45,7 +45,7 @@ module.exports = {
 					nodeExternals({
 						allowlist: [
 							/^@guardian/,
-							// this project is ESM-only and throws an error when bundled
+							// this project is ESM-only and throws an error when not bundled
 							'screenfull',
 						],
 						additionalModuleDirs: [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -837,8 +837,8 @@ importers:
         specifier: 0.23.0
         version: 0.23.0
       screenfull:
-        specifier: 5.2.0
-        version: 5.2.0
+        specifier: 6.0.2
+        version: 6.0.2
       semver:
         specifier: 7.5.4
         version: 7.5.4
@@ -19639,9 +19639,9 @@ packages:
       ajv-keywords: 5.1.0(ajv@8.12.0)
     dev: false
 
-  /screenfull@5.2.0:
-    resolution: {integrity: sha512-9BakfsO2aUQN2K9Fdbj87RJIEZ82Q9IGim7FqM5OsebfoFC6ZHXgDq/KvniuLTPdeM8wY2o6Dj3WQ7KeQCj3cA==}
-    engines: {node: '>=0.10.0'}
+  /screenfull@6.0.2:
+    resolution: {integrity: sha512-AQdy8s4WhNvUZ6P8F6PB21tSPIYKniic+Ogx0AacBMjKP1GUHN2E9URxQHtCusiwxudnCKkdy4GrHXPPJSkCCw==}
+    engines: {node: ^14.13.1 || >=16.0.0}
     dev: false
 
   /select-hose@2.0.0:


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Bump `screenfull` to [v6](https://github.com/sindresorhus/screenfull/releases/tag/v6.0.0)

Transform it with SWC for Jest as it is an ESM-only package.

## Why?

The types are fixed and `screenfull.isEnabled` is now a `boolean` rather than `true`