### PR TITLE
Make Lightbox images loading work better

### DIFF
--- a/dotcom-rendering/src/components/Lightbox.stories.tsx
+++ b/dotcom-rendering/src/components/Lightbox.stories.tsx
@@ -73,13 +73,7 @@ const Initialise = ({
 		}
 		const imageRoot = document.querySelector('ul#lightbox-images');
 		if (!imageRoot) return;
-		const loaded = new Set(
-			Array.from({ length: images.length }, (_, index) => index + 1),
-		);
-		render(
-			<LightboxImages format={format} images={images} loaded={loaded} />,
-			imageRoot,
-		);
+		render(<LightboxImages format={format} images={images} />, imageRoot);
 	}, [format, images, shouldShowInfo]);
 
 	return <div style={{ height: '100vh' }}>{children}</div>;

--- a/dotcom-rendering/src/components/LightboxImages.tsx
+++ b/dotcom-rendering/src/components/LightboxImages.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { timeAgo } from '@guardian/libs';
+import { log, timeAgo } from '@guardian/libs';
 import {
 	from,
 	headline,
@@ -11,6 +11,7 @@ import {
 } from '@guardian/source-foundations';
 import { Hide, Link } from '@guardian/source-react-components';
 import { StarRating } from '@guardian/source-react-components-development-kitchen';
+import { useEffect, useState } from 'react';
 import type { ImageForLightbox } from '../types/content';
 import { LightboxCaption } from './LightboxCaption';
 import { LightboxLoader } from './LightboxLoader';
@@ -19,7 +20,6 @@ import { Picture } from './Picture';
 type Props = {
 	format: ArticleFormat;
 	images: ImageForLightbox[];
-	loaded: Set<number>;
 };
 
 const liStyles = css`
@@ -173,7 +173,13 @@ const Selection = ({
 	);
 };
 
-export const LightboxImages = ({ format, images, loaded }: Props) => {
+export const LightboxImages = ({ format, images }: Props) => {
+	const [loaded, setLoaded] = useState(new Set<number>());
+
+	useEffect(() => {
+		log('dotcom', '💡 images loaded:', loaded);
+	});
+
 	return (
 		<>
 			{images.map((image, index) => {
@@ -181,6 +187,14 @@ export const LightboxImages = ({ format, images, loaded }: Props) => {
 					image.width > image.height ? 'landscape' : 'portrait';
 
 				const position = index + 1;
+
+				const onLoad = () =>
+					setLoaded((set) => {
+						const previousSize = set.size;
+						set.add(position);
+						const newSize = set.size;
+						return previousSize !== newSize ? new Set(set) : set;
+					});
 
 				return (
 					<li
@@ -211,6 +225,7 @@ export const LightboxImages = ({ format, images, loaded }: Props) => {
 								format={format}
 								isLightbox={true}
 								orientation={orientation}
+								onLoad={onLoad}
 							/>
 							<aside css={asideStyles}>
 								{!!image.title && (

--- a/dotcom-rendering/src/components/LightboxJavascript.importable.tsx
+++ b/dotcom-rendering/src/components/LightboxJavascript.importable.tsx
@@ -25,10 +25,7 @@ import { LightboxImages } from './LightboxImages';
  *
  */
 
-function initialiseLightbox(
-	lightbox: HTMLElement,
-	addLoaded: (id: number) => void,
-) {
+const initialiseLightbox = (lightbox: HTMLElement) => {
 	log('dotcom', '💡 Initialising lightbox');
 
 	// --------------------------------------------------------------------------------
@@ -368,16 +365,6 @@ function initialiseLightbox(
 			event.preventDefault();
 			event.stopPropagation();
 		});
-		// Remove the loader once the image has been downloaded
-		const index = picture.closest('li')?.dataset.index;
-		if (index === undefined) continue;
-		const position = parseInt(index, 10);
-		const image = picture.querySelector('img');
-		if (image?.complete) {
-			addLoaded(position);
-		} else {
-			image?.addEventListener('load', () => addLoaded(position));
-		}
 	}
 
 	imageList?.addEventListener(
@@ -480,7 +467,7 @@ function initialiseLightbox(
 
 	// Mark the lightbox as ready so that we don't try to re-initialise it later
 	lightbox.setAttribute('data-island-status', 'rendered');
-}
+};
 
 const useElementById = (id: string) => {
 	const [element, setElement] = useState<HTMLElement>();
@@ -515,29 +502,21 @@ export const LightboxJavascript = ({
 	const lightbox = useElementById('gu-lightbox');
 	const [initialised, setInitialised] = useState(false);
 
-	const [loaded, setLoaded] = useState<Set<number>>();
-
-	useEffect(() => {
-		setLoaded(new Set());
-	}, []);
-
 	useEffect(() => {
 		if (!lightbox) return;
-		if (!loaded) return;
-		log('dotcom', '💡 loaded:', loaded);
 		if (initialised) {
 			log('dotcom', '💡 Lightbox already initialised, skipping');
 			return;
 		}
-		initialiseLightbox(lightbox, (id) => setLoaded(loaded.add(id)));
+		initialiseLightbox(lightbox);
 		setInitialised(true);
-	}, [initialised, lightbox, loaded]);
+	}, [initialised, lightbox]);
 
-	if (!root || !loaded) return null;
+	if (!root || !lightbox) return null;
 
 	log('dotcom', '💡 Generating HTML for lightbox images...');
 	return createPortal(
-		<LightboxImages format={format} images={images} loaded={loaded} />,
+		<LightboxImages format={format} images={images} />,
 		root,
 	);
 };

--- a/dotcom-rendering/src/components/Picture.tsx
+++ b/dotcom-rendering/src/components/Picture.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import { ArticleDesign, ArticleDisplay } from '@guardian/libs';
 import { breakpoints } from '@guardian/source-foundations';
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { generateImageURL } from '../lib/image';
 import type { RoleType } from '../types/content';
 
@@ -22,6 +22,7 @@ type Props = {
 	isLazy?: boolean;
 	isLightbox?: boolean;
 	orientation?: Orientation;
+	onLoad?: () => void;
 };
 
 export type ImageWidthType = { breakpoint: number; width: number };
@@ -318,7 +319,22 @@ export const Picture = ({
 	isLazy = true,
 	isLightbox = false,
 	orientation = 'landscape',
+	onLoad,
 }: Props) => {
+	const ref = useRef<HTMLImageElement>(null);
+	const [loaded, setLoaded] = useState(false);
+
+	useEffect(() => {
+		if (!ref.current) return;
+
+		if (ref.current.complete) return setLoaded(true);
+		ref.current.addEventListener('load', () => setLoaded(true));
+	}, [ref]);
+
+	useEffect(() => {
+		if (loaded && onLoad) onLoad();
+	}, [loaded, onLoad]);
+
 	const sources = generateSources(
 		master,
 		decideImageWidths({
@@ -383,6 +399,7 @@ export const Picture = ({
 			)}
 			<Sources sources={sources} />
 			<img
+				ref={ref}
 				alt={alt}
 				src={fallbackSource.lowResUrl}
 				width={fallbackSource.width}


### PR DESCRIPTION
## What does this change?

The `Picture` component now has a `onLoad` prop that fires when the image is loaded. We can use this event in `LightboxImages` to know which images have been loaded.

## Why?

The fix in #9962 wasn’t sufficient as we would have to create a new `Set` in the updating method. This refactors makes this a concern of image in a more agnostic way and relies on the React lifecycle

## Screenshots

<img width="1719" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/76776/bde66241-ab2d-4019-b9d4-02d0bb0ec05d">
