### PR TITLE
Rely on `useCallback` instead of `useRef`

### DIFF
--- a/dotcom-rendering/src/components/ChartAtom.stories.tsx
+++ b/dotcom-rendering/src/components/ChartAtom.stories.tsx
@@ -38,7 +38,7 @@ const Wrapper = ({ children }: { children: React.ReactNode }) => (
 export const BarChart = () => {
 	return (
 		<Wrapper>
-			<ChartAtom id="123abc" html={barChartHtml} />
+			<ChartAtom id="123abc" html={barChartHtml} title={''} />
 		</Wrapper>
 	);
 };
@@ -46,7 +46,7 @@ BarChart.decorators = [splitTheme([defaultFormat])];
 export const LineChart = () => {
 	return (
 		<Wrapper>
-			<ChartAtom id="123abc" html={lineChartHtml} />
+			<ChartAtom id="123abc" html={lineChartHtml} title={''} />
 		</Wrapper>
 	);
 };

--- a/dotcom-rendering/src/components/Picture.tsx
+++ b/dotcom-rendering/src/components/Picture.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import { ArticleDesign, ArticleDisplay } from '@guardian/libs';
 import { breakpoints } from '@guardian/source-foundations';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { generateImageURL } from '../lib/image';
 import type { RoleType } from '../types/content';
 
@@ -321,15 +321,14 @@ export const Picture = ({
 	orientation = 'landscape',
 	onLoad,
 }: Props) => {
-	const ref = useRef<HTMLImageElement>(null);
 	const [loaded, setLoaded] = useState(false);
-
-	useEffect(() => {
-		if (!ref.current) return;
-
-		if (ref.current.complete) return setLoaded(true);
-		ref.current.addEventListener('load', () => setLoaded(true));
-	}, [ref]);
+	const ref = useCallback((node: HTMLImageElement) => {
+		if (node.complete) {
+			setLoaded(true);
+		} else {
+			node.addEventListener('load', () => setLoaded(true));
+		}
+	}, []);
 
 	useEffect(() => {
 		if (loaded && onLoad) onLoad();

--- a/dotcom-rendering/src/components/Picture.tsx
+++ b/dotcom-rendering/src/components/Picture.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import { ArticleDesign, ArticleDisplay } from '@guardian/libs';
 import { breakpoints } from '@guardian/source-foundations';
-import React, { useCallback, useEffect, useState } from 'react';
+import { Fragment, useCallback, useEffect, useState } from 'react';
 import { generateImageURL } from '../lib/image';
 import type { RoleType } from '../types/content';
 
@@ -290,7 +290,7 @@ export const Sources = ({ sources }: { sources: ImageSource[] }) => {
 		<>
 			{sources.map((source) => {
 				return (
-					<React.Fragment key={source.breakpoint}>
+					<Fragment key={source.breakpoint}>
 						{/* High resolution (HDPI) sources*/}
 						<source
 							srcSet={source.hiResUrl}
@@ -301,7 +301,7 @@ export const Sources = ({ sources }: { sources: ImageSource[] }) => {
 							srcSet={source.lowResUrl}
 							media={`(min-width: ${source.breakpoint}px)`}
 						/>
-					</React.Fragment>
+					</Fragment>
 				);
 			})}
 		</>


### PR DESCRIPTION
## What does this change?

Improve reliability of when an `Picture`’s `onLoad` event is called.

## Why?

https://github.com/guardian/dotcom-rendering/pull/9987#discussion_r1433879291