### PR TITLE
Temporarily Increase Instance Startup Wait Time

### DIFF
--- a/dotcom-rendering/scripts/deploy/riff-raff.yaml
+++ b/dotcom-rendering/scripts/deploy/riff-raff.yaml
@@ -26,6 +26,8 @@ deployments:
     type: autoscaling
     parameters:
       bucketSsmKey: /account/services/dotcom-artifact.bucket
+      # Default is 900 (15 mins), this is 25 mins
+      secondsToWait: 1500
     dependencies:
       - frontend-static
       - frontend-cfn
@@ -42,6 +44,8 @@ deployments:
     type: autoscaling
     parameters:
       bucketSsmKey: /account/services/dotcom-artifact.bucket
+      # Default is 900 (15 mins), this is 25 mins
+      secondsToWait: 1500
     dependencies:
       - frontend-static
       - front-web-cfn


### PR DESCRIPTION
The default is 900 seconds, which is 15mins. This new value is 25 mins.

Instances that fail to start up appear to get terminated after about 20 mins, and new ones are brought up in their place. This should leave us with a large enough buffer for this to happen and the deploy to complete.

This should be considered a temporary mitigation, rather than a solution to the underlying problem.
