### PR TITLE
Prevent usage of `localStorage`

### DIFF
--- a/dotcom-rendering/.eslintrc.js
+++ b/dotcom-rendering/.eslintrc.js
@@ -173,6 +173,28 @@ module.exports = {
 		'ssr-friendly/no-dom-globals-in-module-scope': 'warn',
 		'ssr-friendly/no-dom-globals-in-react-fc': 'warn',
 
+		'no-restricted-syntax': [
+			'error',
+			{
+				selector: "CallExpression[callee.object.name='localStorage']",
+				message: 'Use @guardian/libs’s storage.local instead',
+			},
+			{
+				selector:
+					"CallExpression[callee.object.object.name='window'][callee.object.property.name='localStorage']",
+				message: 'Use @guardian/libs’s storage.local instead',
+			},
+			{
+				selector: "CallExpression[callee.object.name='sessionStorage']",
+				message: 'Use @guardian/libs’s storage.session instead',
+			},
+			{
+				selector:
+					"CallExpressionCallExpression[callee.object.object.name='window'][callee.object.name='sessionStorage']",
+				message: 'Use @guardian/libs’s storage.session instead',
+			},
+		],
+
 		...rulesToReview,
 		...rulesToEnforce,
 		...rulesToOverrideGuardianConfig,
@@ -198,6 +220,12 @@ module.exports = {
 			files: ['**/**.ts'],
 			rules: {
 				'@typescript-eslint/explicit-module-boundary-types': 'error',
+			},
+		},
+		{
+			files: ['**/**.test.ts', 'playwright/**/*.ts'],
+			rules: {
+				'no-restricted-syntax': 'off', // we allow native localStorage access in tests
 			},
 		},
 		{

--- a/dotcom-rendering/src/components/SignInGate/dismissGate.ts
+++ b/dotcom-rendering/src/components/SignInGate/dismissGate.ts
@@ -21,6 +21,7 @@ const localStorageDismissedCountKey = (
 const getSigninGatePrefsSafely = (): { [key: string]: any } => {
 	try {
 		const prefs: { [key: string]: any } = JSON.parse(
+			// eslint-disable-next-line no-restricted-syntax -- FIXME-libs-storage
 			localStorage.getItem(localStorageKey) ?? '{}',
 		);
 
@@ -34,6 +35,7 @@ const getSigninGatePrefsSafely = (): { [key: string]: any } => {
 };
 
 const setSigninGatePrefs = (prefs: any) => {
+	// eslint-disable-next-line no-restricted-syntax -- FIXME-libs-storage
 	localStorage.setItem(localStorageKey, JSON.stringify({ value: prefs }));
 };
 

--- a/dotcom-rendering/src/components/StickyBottomBanner.importable.tsx
+++ b/dotcom-rendering/src/components/StickyBottomBanner.importable.tsx
@@ -59,6 +59,7 @@ type RRBannerConfig = {
 };
 
 const getBannerLastClosedAt = (key: string): string | undefined => {
+	// eslint-disable-next-line no-restricted-syntax -- FIXME-libs-storage
 	const item = localStorage.getItem(`gu.prefs.${key}`) as undefined | string;
 
 	if (item) {

--- a/dotcom-rendering/src/components/marketing/lib/articleCountOptOut.ts
+++ b/dotcom-rendering/src/components/marketing/lib/articleCountOptOut.ts
@@ -25,9 +25,12 @@ export const removeArticleCountOptOutCookie = (): void =>
 	removeCookie({ name: ARTICLE_COUNT_OPT_OUT_COOKIE.name });
 
 export const removeArticleCountFromLocalStorage = (): void => {
-	window.localStorage.removeItem(DAILY_ARTICLE_COUNT_STORAGE_KEY);
-	window.localStorage.removeItem(WEEKLY_ARTICLE_COUNT_STORAGE_KEY);
-	window.localStorage.removeItem(ARTICLES_THIS_WEEK_STORAGE_KEY);
+	// eslint-disable-next-line no-restricted-syntax -- FIXME-libs-storage
+	localStorage.removeItem(DAILY_ARTICLE_COUNT_STORAGE_KEY);
+	// eslint-disable-next-line no-restricted-syntax -- FIXME-libs-storage
+	localStorage.removeItem(WEEKLY_ARTICLE_COUNT_STORAGE_KEY);
+	// eslint-disable-next-line no-restricted-syntax -- FIXME-libs-storage
+	localStorage.removeItem(ARTICLES_THIS_WEEK_STORAGE_KEY);
 };
 
 export const hasArticleCountOptOutCookie = (): boolean =>

--- a/dotcom-rendering/src/components/marketing/lib/viewLog.ts
+++ b/dotcom-rendering/src/components/marketing/lib/viewLog.ts
@@ -29,6 +29,7 @@ export const getEpicViewLog = (
 	// Return undefined instead of null if view log does not exist
 	// Needed because the localStorage API returns null for non-existing keys
 	// but Contributions API expects a view log or undefined.
+	// eslint-disable-next-line no-restricted-syntax -- FIXME-libs-storage
 	return localStorage.get(viewLogKey) || undefined;
 };
 
@@ -37,6 +38,7 @@ export const getEpicViewLog = (
  * The number of entries is limited to the number in maxLogEntries.
  */
 export const logEpicView = (testId: string): void => {
+	// eslint-disable-next-line no-restricted-syntax -- FIXME-libs-storage
 	const item = localStorage.getItem(viewLogKey);
 	// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
 	const viewLog = (item ? JSON.parse(item).value : []) as EpicView[];
@@ -50,5 +52,6 @@ export const logEpicView = (testId: string): void => {
 		value: viewLog.slice(-maxLogEntries),
 	};
 
+	// eslint-disable-next-line no-restricted-syntax -- FIXME-libs-storage
 	localStorage.setItem(viewLogKey, JSON.stringify(newValue));
 };

--- a/dotcom-rendering/src/lib/alreadyVisited.ts
+++ b/dotcom-rendering/src/lib/alreadyVisited.ts
@@ -7,6 +7,7 @@ const AlreadyVisitedKey = 'gu.alreadyVisited';
 
 const getAlreadyVisitedCount = (): number => {
 	const alreadyVisited = parseInt(
+		// eslint-disable-next-line no-restricted-syntax -- FIXME-libs-storage
 		localStorage.getItem(AlreadyVisitedKey) ?? '',
 		10,
 	);
@@ -17,8 +18,10 @@ export const incrementAlreadyVisited = async (): Promise<void> => {
 	const { canTarget } = await onConsent();
 	if (canTarget) {
 		const alreadyVisited = getAlreadyVisitedCount() + 1;
+		// eslint-disable-next-line no-restricted-syntax -- FIXME-libs-storage
 		localStorage.setItem(AlreadyVisitedKey, alreadyVisited.toString());
 	} else {
+		// eslint-disable-next-line no-restricted-syntax -- FIXME-libs-storage
 		localStorage.removeItem(AlreadyVisitedKey);
 	}
 };

--- a/dotcom-rendering/src/lib/contributions.ts
+++ b/dotcom-rendering/src/lib/contributions.ts
@@ -153,7 +153,9 @@ export const hasArticleCountOptOutCookie = (): boolean =>
 	getCookie({ name: OPT_OUT_OF_ARTICLE_COUNT_COOKIE }) !== null;
 
 const removeArticleCountsFromLocalStorage = () => {
+	// eslint-disable-next-line no-restricted-syntax -- FIXME-libs-storage
 	window.localStorage.removeItem(DAILY_ARTICLE_COUNT_KEY);
+	// eslint-disable-next-line no-restricted-syntax -- FIXME-libs-storage
 	window.localStorage.removeItem(WEEKLY_ARTICLE_COUNT_KEY);
 };
 
@@ -220,11 +222,13 @@ export const hasCmpConsentForBrowserId = (): Promise<boolean> =>
 
 const twentyMins = 20 * 60000;
 export const withinLocalNoBannerCachePeriod = (): boolean => {
+	// eslint-disable-next-line no-restricted-syntax -- FIXME-libs-storage
 	const item = window.localStorage.getItem(NO_RR_BANNER_TIMESTAMP_KEY);
 	if (item && !Number.isNaN(parseInt(item, 10))) {
 		const withinCachePeriod = parseInt(item, 10) + twentyMins > Date.now();
 		if (!withinCachePeriod) {
 			// Expired
+			// eslint-disable-next-line no-restricted-syntax -- FIXME-libs-storage
 			window.localStorage.removeItem(NO_RR_BANNER_TIMESTAMP_KEY);
 		}
 		return withinCachePeriod;
@@ -233,6 +237,7 @@ export const withinLocalNoBannerCachePeriod = (): boolean => {
 };
 
 export const setLocalNoBannerCachePeriod = (): void =>
+	// eslint-disable-next-line no-restricted-syntax -- FIXME-libs-storage
 	window.localStorage.setItem(NO_RR_BANNER_TIMESTAMP_KEY, `${Date.now()}`);
 
 // Returns true if banner was closed in the last hour

--- a/dotcom-rendering/src/lib/dailyArticleCount.test.ts
+++ b/dotcom-rendering/src/lib/dailyArticleCount.test.ts
@@ -24,6 +24,7 @@ const validDailyArticleCount: [DailyArticle, DailyArticle, DailyArticle] = [
 
 describe('dailyArticleCount', () => {
 	beforeEach(() => {
+		// eslint-disable-next-line no-restricted-syntax -- FIXME-libs-storage
 		localStorage.clear();
 	});
 

--- a/dotcom-rendering/src/lib/dailyArticleCount.ts
+++ b/dotcom-rendering/src/lib/dailyArticleCount.ts
@@ -14,6 +14,7 @@ export const DailyArticleCountKey = 'gu.history.dailyArticleCount';
 
 // Returns undefined if no daily article count in local storage
 export const getDailyArticleCount = (): DailyArticleHistory | undefined => {
+	// eslint-disable-next-line no-restricted-syntax -- FIXME-libs-storage
 	const dailyCount = localStorage.getItem(DailyArticleCountKey);
 
 	if (!dailyCount) {
@@ -31,6 +32,7 @@ export const getDailyArticleCount = (): DailyArticleHistory | undefined => {
 		return value;
 	} catch (e) {
 		// error parsing the string, so remove the key
+		// eslint-disable-next-line no-restricted-syntax -- FIXME-libs-storage
 		localStorage.removeItem(DailyArticleCountKey);
 		return undefined;
 	}
@@ -65,6 +67,7 @@ export const incrementDailyArticleCount = (): void => {
 	}
 
 	// set the latest article count
+	// eslint-disable-next-line no-restricted-syntax -- FIXME-libs-storage
 	localStorage.setItem(
 		DailyArticleCountKey,
 		JSON.stringify({

--- a/dotcom-rendering/src/lib/getCommentContext.ts
+++ b/dotcom-rendering/src/lib/getCommentContext.ts
@@ -45,12 +45,15 @@ const initFiltersFromLocalStorage = (): FilterOptions => {
 	try {
 		// Try to read from local storage
 		orderBy = JSON.parse(
+			// eslint-disable-next-line no-restricted-syntax -- FIXME-libs-storage
 			localStorage.getItem('gu.prefs.discussion.order') ?? '{}',
 		);
 		threads = JSON.parse(
+			// eslint-disable-next-line no-restricted-syntax -- FIXME-libs-storage
 			localStorage.getItem('gu.prefs.discussion.threading') ?? '{}',
 		);
 		pageSize = JSON.parse(
+			// eslint-disable-next-line no-restricted-syntax -- FIXME-libs-storage
 			localStorage.getItem('gu.prefs.discussion.pagesize') ?? '{}',
 		);
 	} catch (error) {

--- a/dotcom-rendering/src/lib/hasCurrentBrazeUser.ts
+++ b/dotcom-rendering/src/lib/hasCurrentBrazeUser.ts
@@ -1,14 +1,17 @@
 const KEY = 'gu.brazeUserSet';
 
 const hasCurrentBrazeUser = (): boolean => {
+	// eslint-disable-next-line no-restricted-syntax -- FIXME-libs-storage
 	return localStorage.getItem(KEY) === 'true';
 };
 
 const setHasCurrentBrazeUser = (): void => {
+	// eslint-disable-next-line no-restricted-syntax -- FIXME-libs-storage
 	localStorage.setItem(KEY, 'true');
 };
 
 const clearHasCurrentBrazeUser = (): void => {
+	// eslint-disable-next-line no-restricted-syntax -- FIXME-libs-storage
 	localStorage.removeItem(KEY);
 };
 

--- a/dotcom-rendering/src/lib/readerRevenueDevUtils.ts
+++ b/dotcom-rendering/src/lib/readerRevenueDevUtils.ts
@@ -17,11 +17,15 @@ const readerRevenueCookies = [
 ];
 
 const clearEpicViewLog = (): void =>
+	// eslint-disable-next-line no-restricted-syntax -- FIXME-libs-storage
 	localStorage.removeItem('gu.contributions.views');
 
 const clearBannerLastClosedAt = (): void => {
+	// eslint-disable-next-line no-restricted-syntax -- FIXME-libs-storage
 	localStorage.removeItem('gu.prefs.engagementBannerLastClosedAt');
+	// eslint-disable-next-line no-restricted-syntax -- FIXME-libs-storage
 	localStorage.removeItem('gu.prefs.subscriptionBannerLastClosedAt');
+	// eslint-disable-next-line no-restricted-syntax -- FIXME-libs-storage
 	localStorage.removeItem('gu.noRRBannerTimestamp');
 };
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

- Require explicit use of @guardian/libs’s `storage.local`
- Existing native uses are allowed with comment `FIXME-libs-storage`
- Refactors will come from relevant teams, e.g.:
  - #10047

## Why?

Follow-up on:
- #8838 

Paves the way for a future where all access to local or session storage has the adequate consents.

cc. @guardian/transparency-consent – who are proposing [adding this rule to `@guardian/eslint-config`](https://github.com/guardian/csnx/pull/1041),

## Screenshots

<img width="543" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/76776/4a071f35-ebee-474b-a872-72af92a7908e">
