### PR TITLE
Remove dvh from banner wrapper

### DIFF
--- a/dotcom-rendering/src/layouts/lib/stickiness.tsx
+++ b/dotcom-rendering/src/layouts/lib/stickiness.tsx
@@ -37,7 +37,6 @@ const bannerWrapper = css`
 	bottom: 0;
 	${getZIndexImportant('banner')}
 	max-height: 80vh;
-	max-height: 80dvh;
 	overflow: visible;
 	/* stylelint-disable-next-line declaration-no-important */
 	width: 100% !important;


### PR DESCRIPTION
This removes a change from [this PR](https://github.com/guardian/dotcom-rendering/pull/9837/files#diff-c181827c05ba2818c90ce64d8c15dde3449e18386d01c0db9130b861c002be9dR40)

Setting `dvh` can cause the main cta of the 'designable' banner to disappear below the _bottom_ navbar on some mobile browsers (until the user scrolls a little). The previous PR fixed a similar problem where the close button was being hidden by the top navbar.

<img width="420" alt="Screenshot 2023-12-22 at 08 57 12" src="https://github.com/guardian/dotcom-rendering/assets/1513454/59baa210-805c-432a-a35d-0f52ad0924d0">
