### PR TITLE
Fix Playwright `article.interactivity` nav tests

### DIFF
--- a/dotcom-rendering/playwright/tests/parallel-3/article.interactivity.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/parallel-3/article.interactivity.e2e.spec.ts
@@ -179,10 +179,8 @@ test.describe('Interactivity', () => {
 			// Open pillar menu
 			await page.locator('[data-testid=nav-show-more-button]').click();
 			await expect(
-				page
-					.locator('[data-testid=expanded-menu]')
-					.filter({ hasText: 'Columnists' }),
-			).toBeVisible();
+				page.locator('data-testid=expanded-menu'),
+			).toContainText('Columnists');
 
 			// Assert newslinks second item (first visible) is focused
 			// TODO e2e find a better way to filter on visible list items :visible doesn't work

--- a/dotcom-rendering/playwright/tests/parallel-3/article.interactivity.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/parallel-3/article.interactivity.e2e.spec.ts
@@ -208,21 +208,15 @@ test.describe('Interactivity', () => {
 
 				await page.locator('[data-testid=veggie-burger]').click();
 				await expect(
-					page
-						.locator('nav')
-						.first()
-						.filter({ hasText: 'Crosswords' }),
-				).toBeVisible();
+					page.locator('data-testid=expanded-menu'),
+				).toContainText('Crosswords');
 
 				await page
 					.locator('[data-testid=column-collapse-Opinion]')
 					.click();
 				await expect(
-					page
-						.locator('nav')
-						.first()
-						.filter({ hasText: 'Columnists' }),
-				).toBeVisible();
+					page.locator('data-testid=expanded-menu'),
+				).toContainText('Columnists');
 
 				await page.locator('body').press('Escape');
 				await expect(

--- a/dotcom-rendering/src/components/Nav/ExpandedMenu/ExpandedMenu.tsx
+++ b/dotcom-rendering/src/components/Nav/ExpandedMenu/ExpandedMenu.tsx
@@ -122,8 +122,12 @@ export const ExpandedMenu = ({
 		<div id="expanded-menu-root">
 			<ShowMoreMenu isImmersive={isImmersive} />
 			<VeggieBurgerMenu isImmersive={isImmersive} />
-			<div id="expanded-menu" css={wrapperMainMenuStyles}>
-				<div css={mainMenuStyles} data-testid="expanded-menu">
+			<div
+				id="expanded-menu"
+				data-testid="expanded-menu"
+				css={wrapperMainMenuStyles}
+			>
+				<div css={mainMenuStyles}>
 					<Columns
 						editionId={editionId}
 						isImmersive={isImmersive}


### PR DESCRIPTION
## What does this change?

The following `article.interactivity` nav tests started failing:

- `should expand the mobile pillar menu when the VeggieBurger is clicked`
- `hould expand and close the desktop pillar menu when More is clicked`

This PR changes the assertion to look for the expected text at a higher level in the expanded menu element.

Also moved the `data-testid=expanded-menu` up one level to sit with its matching `id`.

