### PR TITLE
Fix scrolling on banners

### DIFF
--- a/dotcom-rendering/src/layouts/lib/stickiness.tsx
+++ b/dotcom-rendering/src/layouts/lib/stickiness.tsx
@@ -37,7 +37,7 @@ const bannerWrapper = css`
 	bottom: 0;
 	${getZIndexImportant('banner')}
 	max-height: 80vh;
-	overflow: visible;
+	overflow: auto;
 	/* stylelint-disable-next-line declaration-no-important */
 	width: 100% !important;
 	/* stylelint-disable-next-line declaration-no-important */


### PR DESCRIPTION
The banners haven't been properly scrollable since [this change to the `overflow` property](https://github.com/guardian/dotcom-rendering/commit/4a734db493a8e0e021bcb342120cd93720f13a5c#diff-f52cd0e6b09b6e5db52a93382bc747e1e8f5c2f77e6743d93a51d4b5724a70d5R36), for the puzzles banner.
We should remove the puzzles banner before releasing this change (it's not used anymore)