### PR TITLE
Allow typos in Youtube ids for AMP

### DIFF
--- a/dotcom-rendering/src/components/VideoYoutubeBlockComponent.amp.tsx
+++ b/dotcom-rendering/src/components/VideoYoutubeBlockComponent.amp.tsx
@@ -10,7 +10,7 @@ type Props = {
 export const VideoYoutubeBlockComponent = ({ element, pillar }: Props) => {
 	const youtubeId = getIdFromUrl(
 		element.originalUrl || element.url,
-		'^[a-zA-Z0-9_-]{11}$', // Alpha numeric, underscores and hyphens, exactly 11 numbers long
+		'^[a-zA-Z0-9_-]{11,}$', // Alphanumeric, underscores and hyphens, 11 or more characters long
 		true,
 		'v',
 	);

--- a/dotcom-rendering/src/lib/get-video-id.amp.test.ts
+++ b/dotcom-rendering/src/lib/get-video-id.amp.test.ts
@@ -2,12 +2,16 @@ import { getIdFromUrl } from './get-video-id.amp';
 
 describe('getIdFromUrl', () => {
 	it('Returns matching ID for YouTube formats', () => {
-		const youtubeRegEx = '^[a-zA-Z0-9_-]{11}$';
+		const youtubeRegEx = '^[a-zA-Z0-9_-]{11,}$';
 
 		const formats = [
 			{
 				url: 'http://www.youtube.com/ytscreeningroom?v=NRHEIGHTx8I',
 				id: 'NRHEIGHTx8I',
+			},
+			{
+				url: 'http://www.youtube.com/ytscreeningroom?v=NRHEIGHTx8Ixyz',
+				id: 'NRHEIGHTx8Ixyz',
 			},
 			{
 				url: 'http://www.youtube.com/ytscreeningroom?v=NRH_IGHTx8I',


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Allows youtube ids to be longer than 11 characters as youtube has inbuilt resilience to this and Composer also allows for these typos. So sometimes we may receive a youtube URL where someone accidentally typed extra characters at the end. This is fine: 

e.g. in this article https://www.theguardian.com/tv-and-radio/2017/feb/08/legion-review-marvel-mental-health-superhero the originalUrl is `https://www.youtube.com/watch?v=4SZ3rMMYBLYc` instead of the correct `https://www.youtube.com/watch?v=4SZ3rMMYBLY`

## Why?

It breaks AMP in these situations. 
It's causing lots of errors in the logs and it's noisy. 

## Screenshots

| Before (AMP)     | After (AMP)      |
| ----------- | ---------- |
| <img width="1297" alt="Screenshot 2023-12-22 at 17 57 56" src="https://github.com/guardian/dotcom-rendering/assets/1229808/08fc6b1d-fa8a-4ba8-9396-78f82e613e2b"> | <img width="605" alt="Screenshot 2023-12-22 at 17 52 50" src="https://github.com/guardian/dotcom-rendering/assets/1229808/761eadba-2a77-4965-b39b-14fb9e114797"> |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
