### PR TITLE
AR: Only use drop cap on the first paragraph

### DIFF
--- a/apps-rendering/src/renderer.test.ts
+++ b/apps-rendering/src/renderer.test.ts
@@ -539,6 +539,7 @@ describe('Transforms hrefs', () => {
 describe('Shows drop caps', () => {
 	const paragraph = new Array(50).fill('word').join(' ');
 	const isEditions = true;
+	const isFirstParagraph = true;
 	const format = {
 		display: ArticleDisplay.Standard,
 		theme: ArticlePillar.Culture,
@@ -555,7 +556,7 @@ describe('Shows drop caps', () => {
 		const showDropCap = shouldShowDropCap(
 			unicodeLatin,
 			format,
-			true,
+			isFirstParagraph,
 			!isEditions,
 		);
 		expect(showDropCap).toBe(true);
@@ -567,7 +568,7 @@ describe('Shows drop caps', () => {
 		const showDropCap = shouldShowDropCap(
 			shortParagraph,
 			format,
-			true,
+			isFirstParagraph,
 			!isEditions,
 		);
 		expect(showDropCap).toBe(false);
@@ -577,7 +578,7 @@ describe('Shows drop caps', () => {
 		const showDropCap = shouldShowDropCap(
 			paragraph,
 			mockFormat,
-			true,
+			isFirstParagraph,
 			!isEditions,
 		);
 		expect(showDropCap).toBe(false);
@@ -587,8 +588,18 @@ describe('Shows drop caps', () => {
 		const showDropCap = shouldShowDropCap(
 			paragraph,
 			mockFormat,
-			true,
+			isFirstParagraph,
 			isEditions,
+		);
+		expect(showDropCap).toBe(false);
+	});
+
+	test('Does not show drop cap if the paragraph is not the first paragraph', () => {
+		const showDropCap = shouldShowDropCap(
+			paragraph,
+			mockFormat,
+			!isFirstParagraph,
+			!isEditions,
 		);
 		expect(showDropCap).toBe(false);
 	});

--- a/apps-rendering/src/renderer.test.ts
+++ b/apps-rendering/src/renderer.test.ts
@@ -546,7 +546,7 @@ describe('Shows drop caps', () => {
 	};
 
 	test('Shows drop cap if the paragraph is at least 200 characters long, and the article has the correct design', () => {
-		const showDropCap = shouldShowDropCap(paragraph, format, !isEditions);
+		const showDropCap = shouldShowDropCap(paragraph, format, true, !isEditions);
 		expect(showDropCap).toBe(true);
 	});
 
@@ -555,6 +555,7 @@ describe('Shows drop caps', () => {
 		const showDropCap = shouldShowDropCap(
 			unicodeLatin,
 			format,
+			true,
 			!isEditions,
 		);
 		expect(showDropCap).toBe(true);
@@ -566,6 +567,7 @@ describe('Shows drop caps', () => {
 		const showDropCap = shouldShowDropCap(
 			shortParagraph,
 			format,
+			true,
 			!isEditions,
 		);
 		expect(showDropCap).toBe(false);
@@ -575,6 +577,7 @@ describe('Shows drop caps', () => {
 		const showDropCap = shouldShowDropCap(
 			paragraph,
 			mockFormat,
+			true,
 			!isEditions,
 		);
 		expect(showDropCap).toBe(false);
@@ -584,6 +587,7 @@ describe('Shows drop caps', () => {
 		const showDropCap = shouldShowDropCap(
 			paragraph,
 			mockFormat,
+			true,
 			isEditions,
 		);
 		expect(showDropCap).toBe(false);

--- a/apps-rendering/src/renderer.test.ts
+++ b/apps-rendering/src/renderer.test.ts
@@ -587,7 +587,7 @@ describe('Shows drop caps', () => {
 	test('Does not show drop cap if the article is an Editions article', () => {
 		const showDropCap = shouldShowDropCap(
 			paragraph,
-			mockFormat,
+			format,
 			isFirstParagraph,
 			isEditions,
 		);
@@ -597,7 +597,7 @@ describe('Shows drop caps', () => {
 	test('Does not show drop cap if the paragraph is not the first paragraph', () => {
 		const showDropCap = shouldShowDropCap(
 			paragraph,
-			mockFormat,
+			format,
 			!isFirstParagraph,
 			!isEditions,
 		);

--- a/apps-rendering/src/renderer.test.ts
+++ b/apps-rendering/src/renderer.test.ts
@@ -547,7 +547,12 @@ describe('Shows drop caps', () => {
 	};
 
 	test('Shows drop cap if the paragraph is at least 200 characters long, and the article has the correct design', () => {
-		const showDropCap = shouldShowDropCap(paragraph, format, true, !isEditions);
+		const showDropCap = shouldShowDropCap(
+			paragraph,
+			format,
+			true,
+			!isEditions,
+		);
 		expect(showDropCap).toBe(true);
 	});
 

--- a/apps-rendering/src/renderer.ts
+++ b/apps-rendering/src/renderer.ts
@@ -200,7 +200,12 @@ const textElement =
 				}
 
 				const isFirstParagraph = node.previousSibling === null;
-				const showDropCap = shouldShowDropCap(text, format, isFirstParagraph, isEditions);
+				const showDropCap = shouldShowDropCap(
+					text,
+					format,
+					isFirstParagraph,
+					isEditions,
+				);
 
 				return h(
 					Paragraph,

--- a/apps-rendering/src/renderer.ts
+++ b/apps-rendering/src/renderer.ts
@@ -177,12 +177,13 @@ const plainTextElement = (node: Node, key: number): ReactNode => {
 const shouldShowDropCap = (
 	text: string,
 	format: ArticleFormat,
+	isFirstParagraph: boolean,
 	isEditions: boolean,
 ): boolean => {
 	if (isEditions) {
 		return false;
 	}
-	return allowsDropCaps(format) && text.length >= 200;
+	return allowsDropCaps(format) && text.length >= 200 && isFirstParagraph;
 };
 
 const textElement =
@@ -198,7 +199,8 @@ const textElement =
 					return children;
 				}
 
-				const showDropCap = shouldShowDropCap(text, format, isEditions);
+				const isFirstParagraph = node.previousSibling === null;
+				const showDropCap = shouldShowDropCap(text, format, isFirstParagraph, isEditions);
 
 				return h(
 					Paragraph,


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Only add drop cap on the first paragraph of an article 

## Why?

Can otherwise introduce drop caps further down in the article. Example in the screenshots.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/1229808/eab98eb8-7db2-4fd8-a5af-dac884a41f1c

[after]: https://github.com/guardian/dotcom-rendering/assets/1229808/45708b8e-47e3-4bd2-afe6-e64560850f03


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
