### PR TITLE
AMP: Fix youtube id to 11 characters

### DIFF
--- a/dotcom-rendering/src/components/VideoYoutubeBlockComponent.amp.tsx
+++ b/dotcom-rendering/src/components/VideoYoutubeBlockComponent.amp.tsx
@@ -10,7 +10,7 @@ type Props = {
 export const VideoYoutubeBlockComponent = ({ element, pillar }: Props) => {
 	const youtubeId = getIdFromUrl(
 		element.originalUrl || element.url,
-		'^[a-zA-Z0-9_-]{11,}$', // Alphanumeric, underscores and hyphens, 11 or more characters long
+		'^[a-zA-Z0-9_-]{11}$', // Alphanumeric, underscores and hyphens, 11 characters long
 		true,
 		'v',
 	);

--- a/dotcom-rendering/src/lib/get-video-id.amp.test.ts
+++ b/dotcom-rendering/src/lib/get-video-id.amp.test.ts
@@ -11,7 +11,7 @@ describe('getIdFromUrl', () => {
 			},
 			{
 				url: 'http://www.youtube.com/ytscreeningroom?v=NRHEIGHTx8Ixyz',
-				id: 'NRHEIGHTx8Ixyz',
+				id: 'NRHEIGHTx8I',
 			},
 			{
 				url: 'http://www.youtube.com/ytscreeningroom?v=NRH_IGHTx8I',

--- a/dotcom-rendering/src/lib/get-video-id.amp.ts
+++ b/dotcom-rendering/src/lib/get-video-id.amp.ts
@@ -21,7 +21,7 @@ export const getIdFromUrl = (
 			? new URLSearchParams(url.query ?? '').get(tryQueryParam)
 			: undefined,
 		tryInPath ? (url.pathname ?? '').split('/').at(-1) : undefined,
-	].filter(isString);
+	].filter(isString).map(id => id.slice(0,11));
 
 	if (!ids.length)
 		logErr(


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Fixes the length of youtube ids for AMP articles at 11, but allows for typos. 
This follows up on https://github.com/guardian/dotcom-rendering/pull/10003 which prevented the entire article from breaking. 

## Why?

It seems the <amp-youtube> element doesn't handle ids longer that 11 characters, causing an error when playback is attempted. 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/1229808/fa918c37-ebac-49ad-ab3e-40cb3dbc853c
[after]: https://github.com/guardian/dotcom-rendering/assets/1229808/144a19be-bd47-48c7-b93d-40598475e6c9

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
