### PR TITLE
AR: Allow drop cap after section break

### DIFF
--- a/apps-rendering/src/renderer.test.ts
+++ b/apps-rendering/src/renderer.test.ts
@@ -539,7 +539,7 @@ describe('Transforms hrefs', () => {
 describe('Shows drop caps', () => {
 	const paragraph = new Array(50).fill('word').join(' ');
 	const isEditions = true;
-	const isFirstParagraph = true;
+	const positionAllowsDropCap = true;
 	const format = {
 		display: ArticleDisplay.Standard,
 		theme: ArticlePillar.Culture,
@@ -561,7 +561,7 @@ describe('Shows drop caps', () => {
 		const showDropCap = shouldShowDropCap(
 			unicodeLatin,
 			format,
-			isFirstParagraph,
+			positionAllowsDropCap,
 			!isEditions,
 		);
 		expect(showDropCap).toBe(true);
@@ -573,7 +573,7 @@ describe('Shows drop caps', () => {
 		const showDropCap = shouldShowDropCap(
 			shortParagraph,
 			format,
-			isFirstParagraph,
+			positionAllowsDropCap,
 			!isEditions,
 		);
 		expect(showDropCap).toBe(false);
@@ -583,7 +583,7 @@ describe('Shows drop caps', () => {
 		const showDropCap = shouldShowDropCap(
 			paragraph,
 			mockFormat,
-			isFirstParagraph,
+			positionAllowsDropCap,
 			!isEditions,
 		);
 		expect(showDropCap).toBe(false);
@@ -593,7 +593,7 @@ describe('Shows drop caps', () => {
 		const showDropCap = shouldShowDropCap(
 			paragraph,
 			format,
-			isFirstParagraph,
+			positionAllowsDropCap,
 			isEditions,
 		);
 		expect(showDropCap).toBe(false);
@@ -603,7 +603,7 @@ describe('Shows drop caps', () => {
 		const showDropCap = shouldShowDropCap(
 			paragraph,
 			format,
-			!isFirstParagraph,
+			!positionAllowsDropCap,
 			!isEditions,
 		);
 		expect(showDropCap).toBe(false);

--- a/apps-rendering/src/renderer.ts
+++ b/apps-rendering/src/renderer.ts
@@ -197,14 +197,15 @@ const textElement =
 		);
 		switch (node.nodeName) {
 			case 'P': {
-				if (text === '* * *') {
+				const dinkus = '* * *';
+				if (text === dinkus) {
 					return children;
 				}
 
 				const isFirstParagraph = node.previousSibling === null;
 				const isAfterDinkus =
 					node.previousSibling?.previousSibling?.textContent ===
-					'* * *';
+					dinkus;
 
 				const showDropCap = shouldShowDropCap(
 					text,

--- a/apps-rendering/src/renderer.ts
+++ b/apps-rendering/src/renderer.ts
@@ -177,13 +177,15 @@ const plainTextElement = (node: Node, key: number): ReactNode => {
 const shouldShowDropCap = (
 	text: string,
 	format: ArticleFormat,
-	isFirstParagraph: boolean,
+	positionAllowsDropCap: boolean,
 	isEditions: boolean,
 ): boolean => {
 	if (isEditions) {
 		return false;
 	}
-	return allowsDropCaps(format) && text.length >= 200 && isFirstParagraph;
+	return (
+		allowsDropCaps(format) && text.length >= 200 && positionAllowsDropCap
+	);
 };
 
 const textElement =
@@ -200,10 +202,14 @@ const textElement =
 				}
 
 				const isFirstParagraph = node.previousSibling === null;
+				const isAfterDinkus =
+					node.previousSibling?.previousSibling?.textContent ===
+					'* * *';
+
 				const showDropCap = shouldShowDropCap(
 					text,
 					format,
-					isFirstParagraph,
+					isFirstParagraph || isAfterDinkus,
 					isEditions,
 				);
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

AR should show a drop cap after a section break. 
This is a follow up on #10005

## Why?

Drop caps should appear after section breaks like they do on DCR 

Example article: https://www.theguardian.com/news/2023/dec/21/sanctuary-i-grew-up-in-the-troubles-and-have-been-seeking-a-place-of-peace-ever-since

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/1229808/dec91d9f-ff9d-43d8-8ca5-1391b8a7f951
[after]: https://github.com/guardian/dotcom-rendering/assets/1229808/7a441ee2-1fe7-4f48-9ddd-619ff0a208b8


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
