### PR TITLE
feat: increase max-height on stickiness from 80 -> 95

### DIFF
--- a/dotcom-rendering/src/layouts/lib/stickiness.tsx
+++ b/dotcom-rendering/src/layouts/lib/stickiness.tsx
@@ -36,7 +36,7 @@ const bannerWrapper = css`
 	position: fixed !important;
 	bottom: 0;
 	${getZIndexImportant('banner')}
-	max-height: 80vh;
+	max-height: 95vh;
 	overflow: auto;
 	/* stylelint-disable-next-line declaration-no-important */
 	width: 100% !important;


### PR DESCRIPTION
## What does this change?
Increase the vh of the banners to support the Guardian.

A previous PR made sure we could at least scroll the support CTA into view, my hunch is that most people won't bother.

This should account for even quite small viewports (see Google Pixel 2 below).

This is an extension of a short-term solution while we work on a longer term solution.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/31692/a1ddf2d4-a528-47c5-a605-24261523d148
[after]: https://github.com/guardian/dotcom-rendering/assets/31692/edc5b137-592b-45e1-9037-7818efdb7cfd
