### PR TITLE
Create a lightbox for cartoon elements in the app

### DIFF
--- a/dotcom-rendering/src/components/CartoonComponent.tsx
+++ b/dotcom-rendering/src/components/CartoonComponent.tsx
@@ -7,6 +7,9 @@ import type { CartoonBlockElement, Image } from '../types/content';
 import { Caption } from './Caption';
 import { LightboxLink } from './LightboxLink';
 import { Picture } from './Picture';
+import {Island} from "./Island";
+import {AppsLightboxImage} from "./AppsLightboxImage.importable";
+import {useConfig} from "./ConfigContext";
 
 type Props = {
 	format: ArticleFormat;
@@ -15,6 +18,7 @@ type Props = {
 };
 
 export const CartoonComponent = ({ format, element, switches }: Props) => {
+	const { renderingTarget } = useConfig();
 	const smallVariant = element.variants.find(
 		(variant) => variant.viewportSize === 'small',
 	);
@@ -25,17 +29,36 @@ export const CartoonComponent = ({ format, element, switches }: Props) => {
 	const render = (image: Image) => {
 		return (
 			<>
-				<Picture
-					master={image.url}
-					role={element.role}
-					format={format}
-					alt={`${element.alt ? `${element.alt}, ` : ''}panel ${
-						image.index + 1
-					}`}
-					height={parseInt(image.fields.height, 10)}
-					width={parseInt(image.fields.width, 10)}
-					key={image.index}
-				/>
+				{renderingTarget === 'Apps' ? (
+					<Island priority="critical">
+						<AppsLightboxImage
+							elementId={element.elementId}
+							role={element.role}
+							format={format}
+							master={image.url}
+							alt={`${element.alt ? `${element.alt}, ` : ''}panel ${
+								image.index + 1
+							}`}
+							height={parseInt(image.fields.height, 10)}
+							width={parseInt(image.fields.width, 10)}
+							isLazy={true}
+							isMainMedia={true}
+						/>
+					</Island>
+				) : (
+					<Picture
+						master={image.url}
+						role={element.role}
+						format={format}
+						alt={`${element.alt ? `${element.alt}, ` : ''}panel ${
+							image.index + 1
+						}`}
+						height={parseInt(image.fields.height, 10)}
+						width={parseInt(image.fields.width, 10)}
+						key={image.index}
+					/>
+				)}
+
 				{switches?.lightbox === true &&
 					isWideEnough(image) &&
 					element.position !== undefined && (

--- a/dotcom-rendering/src/components/CartoonComponent.tsx
+++ b/dotcom-rendering/src/components/CartoonComponent.tsx
@@ -4,12 +4,12 @@ import { Hide } from '@guardian/source-react-components';
 import { isWideEnough } from '../lib/lightbox';
 import type { Switches } from '../types/config';
 import type { CartoonBlockElement, Image } from '../types/content';
+import { AppsLightboxImage } from './AppsLightboxImage.importable';
 import { Caption } from './Caption';
+import { useConfig } from './ConfigContext';
+import { Island } from './Island';
 import { LightboxLink } from './LightboxLink';
 import { Picture } from './Picture';
-import {Island} from "./Island";
-import {AppsLightboxImage} from "./AppsLightboxImage.importable";
-import {useConfig} from "./ConfigContext";
 
 type Props = {
 	format: ArticleFormat;
@@ -36,9 +36,9 @@ export const CartoonComponent = ({ format, element, switches }: Props) => {
 							role={element.role}
 							format={format}
 							master={image.url}
-							alt={`${element.alt ? `${element.alt}, ` : ''}panel ${
-								image.index + 1
-							}`}
+							alt={`${
+								element.alt ? `${element.alt}, ` : ''
+							}panel ${image.index + 1}`}
 							height={parseInt(image.fields.height, 10)}
 							width={parseInt(image.fields.width, 10)}
 							isLazy={true}

--- a/dotcom-rendering/src/components/CartoonComponent.tsx
+++ b/dotcom-rendering/src/components/CartoonComponent.tsx
@@ -27,6 +27,12 @@ export const CartoonComponent = ({ format, element, switches }: Props) => {
 	);
 
 	const render = (image: Image) => {
+		const altText = `${element.alt ? `${element.alt}, ` : ''}panel ${
+			image.index + 1
+		}`;
+		const height = parseInt(image.fields.height, 10);
+		const width = parseInt(image.fields.width, 10);
+
 		return (
 			<>
 				{renderingTarget === 'Apps' ? (
@@ -36,11 +42,9 @@ export const CartoonComponent = ({ format, element, switches }: Props) => {
 							role={element.role}
 							format={format}
 							master={image.url}
-							alt={`${
-								element.alt ? `${element.alt}, ` : ''
-							}panel ${image.index + 1}`}
-							height={parseInt(image.fields.height, 10)}
-							width={parseInt(image.fields.width, 10)}
+							alt={altText}
+							height={height}
+							width={width}
 							isLazy={true}
 							isMainMedia={true}
 						/>
@@ -50,11 +54,9 @@ export const CartoonComponent = ({ format, element, switches }: Props) => {
 						master={image.url}
 						role={element.role}
 						format={format}
-						alt={`${element.alt ? `${element.alt}, ` : ''}panel ${
-							image.index + 1
-						}`}
-						height={parseInt(image.fields.height, 10)}
-						width={parseInt(image.fields.width, 10)}
+						alt={altText}
+						height={height}
+						width={width}
 						key={image.index}
 					/>
 				)}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Wraps the cartoon element in a lightbox when rendered in the Apps. This is mimicking the regular image element behaviour. Cartoons should behave in the same way. 

We have made a choice here to only display the desktop version of the cartoon in the lightbox, which is the same as mobile web behaviour. This can be changed if we receive feedback from users or stakeholders. 

## Why?

Cartoons should be clickable and opendable in lightbox jsut like normal images. 

## Screenshots

https://github.com/guardian/dotcom-rendering/assets/1229808/6aa82480-bd67-4fe8-957f-53b1eea1febc



