### PR TITLE
Deeply read take 2

### DIFF
--- a/dotcom-rendering/src/components/FrontMostViewed.tsx
+++ b/dotcom-rendering/src/components/FrontMostViewed.tsx
@@ -85,7 +85,6 @@ export const FrontMostViewed = ({
 				<MostPopularFooterGrid
 					mostViewed={mostViewedItems}
 					deeplyRead={deeplyReadType}
-					sectionName="Most popular"
 					hasPageSkin={hasPageSkin}
 				/>
 			) : (

--- a/dotcom-rendering/src/components/FrontMostViewed.tsx
+++ b/dotcom-rendering/src/components/FrontMostViewed.tsx
@@ -3,7 +3,6 @@ import type { DCRFrontCard } from '../types/front';
 import type { TrailTabType, TrailType } from '../types/trails';
 import { Island } from './Island';
 import { localisedTitle } from './Localisation';
-import { MostPopularFooterGrid } from './MostPopularFooterGrid';
 import { MostViewedFooter } from './MostViewedFooter.importable';
 import { MostViewedFooterLayout } from './MostViewedFooterLayout';
 
@@ -62,7 +61,6 @@ export const FrontMostViewed = ({
 			: undefined;
 
 	const mostViewedItems = tabs.length > 0 ? tabs[0] : undefined;
-	const showMostPopular = !!deeplyReadType && !!mostViewedItems;
 
 	return (
 		<MostViewedFooterLayout
@@ -81,18 +79,14 @@ export const FrontMostViewed = ({
 						hasPageSkin={hasPageSkin}
 					/>
 				</Island>
-			) : showMostPopular ? (
-				<MostPopularFooterGrid
-					mostViewed={mostViewedItems}
-					deeplyRead={deeplyReadType}
-					hasPageSkin={hasPageSkin}
-				/>
 			) : (
 				<MostViewedFooter
 					tabs={tabs}
 					sectionId="Most viewed"
 					mostCommented={mostCommented}
 					mostShared={mostShared}
+					mostViewed={mostViewedItems}
+					deeplyRead={deeplyReadType}
 					hasPageSkin={hasPageSkin}
 				/>
 			)}

--- a/dotcom-rendering/src/components/MostPopularFooterGrid.tsx
+++ b/dotcom-rendering/src/components/MostPopularFooterGrid.tsx
@@ -110,11 +110,8 @@ const deeplyOverridesStyle = (index: number, mostViewedLength: number) => {
 	`;
 };
 
-const ophanLinkName = (name: string) => name.toLowerCase().replace(/ /g, '-');
-
 type Props = {
 	mostViewed: TrailTabType;
-	sectionName?: string;
 	deeplyRead: TrailTabType;
 	hasPageSkin?: boolean;
 };
@@ -122,7 +119,6 @@ type Props = {
 export const MostPopularFooterGrid = ({
 	mostViewed,
 	deeplyRead,
-	sectionName = '',
 	hasPageSkin = false,
 }: Props) => {
 	const shortenedMostViewed = mostViewed.trails.slice(0, 5);
@@ -130,8 +126,8 @@ export const MostPopularFooterGrid = ({
 
 	return (
 		<div
-			data-component={ophanLinkName(sectionName)}
-			data-link-name={ophanLinkName(sectionName)}
+			data-component="most-popular"
+			data-link-name="most-popular"
 			css={
 				hasPageSkin
 					? gridContainerStyleWithPageSkin

--- a/dotcom-rendering/src/components/MostPopularFooterGrid.tsx
+++ b/dotcom-rendering/src/components/MostPopularFooterGrid.tsx
@@ -188,7 +188,6 @@ export const MostPopularFooterGrid = ({
 								j,
 								shortenedMostViewed.length,
 							)}
-							image={trail.image}
 							hasPageSkin={hasPageSkin}
 						/>
 					))}

--- a/dotcom-rendering/src/components/MostPopularFooterGrid.tsx
+++ b/dotcom-rendering/src/components/MostPopularFooterGrid.tsx
@@ -161,7 +161,6 @@ export const MostPopularFooterGrid = ({
 							headlineText={trail.headline}
 							ageWarning={trail.ageWarning}
 							cssOverrides={mostViewedOverridesStyle(j)}
-							image={trail.image}
 							hasPageSkin={hasPageSkin}
 						/>
 					))}

--- a/dotcom-rendering/src/components/MostViewedFooter.importable.tsx
+++ b/dotcom-rendering/src/components/MostViewedFooter.importable.tsx
@@ -11,8 +11,8 @@ type Props = {
 	selectedColour?: string;
 	mostCommented?: TrailType;
 	mostShared?: TrailType;
-	mostViewed: TrailTabType;
-	deeplyRead: TrailTabType;
+	mostViewed?: TrailTabType;
+	deeplyRead?: TrailTabType;
 	abTestCypressDataAttr?: string;
 	variantFromRunnable?: string;
 	sectionId?: string;
@@ -69,7 +69,7 @@ export const MostViewedFooter = ({
 			data-testid="mostviewed-footer"
 			data-testid-ab-user-in-variant={abTestCypressDataAttr}
 			data-testid-ab-runnable-test={variantFromRunnable}
-			data-link-name="most popular"
+			data-link-name="most-viewed"
 		>
 			{showDeeplyRead ? (
 				<MostPopularFooterGrid

--- a/dotcom-rendering/src/components/MostViewedFooter.importable.tsx
+++ b/dotcom-rendering/src/components/MostViewedFooter.importable.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/react';
 import type { Breakpoint } from '@guardian/source-foundations';
 import { from, palette as sourcePalette } from '@guardian/source-foundations';
 import type { TrailTabType, TrailType } from '../types/trails';
+import { MostPopularFooterGrid } from './MostPopularFooterGrid';
 import { MostViewedFooterGrid } from './MostViewedFooterGrid';
 import { MostViewedFooterSecondTierItem } from './MostViewedFooterSecondTierItem';
 
@@ -10,6 +11,8 @@ type Props = {
 	selectedColour?: string;
 	mostCommented?: TrailType;
 	mostShared?: TrailType;
+	mostViewed: TrailTabType;
+	deeplyRead: TrailTabType;
 	abTestCypressDataAttr?: string;
 	variantFromRunnable?: string;
 	sectionId?: string;
@@ -49,12 +52,15 @@ export const MostViewedFooter = ({
 	tabs,
 	mostCommented,
 	mostShared,
+	mostViewed,
+	deeplyRead,
 	abTestCypressDataAttr,
 	variantFromRunnable,
 	sectionId,
 	selectedColour,
 	hasPageSkin = false,
 }: Props) => {
+	const showDeeplyRead = !!deeplyRead && !!mostViewed;
 	return (
 		<div
 			css={css`
@@ -65,12 +71,20 @@ export const MostViewedFooter = ({
 			data-testid-ab-runnable-test={variantFromRunnable}
 			data-link-name="most popular"
 		>
-			<MostViewedFooterGrid
-				data={tabs}
-				sectionId={sectionId}
-				selectedColour={selectedColour}
-				hasPageSkin={hasPageSkin}
-			/>
+			{showDeeplyRead ? (
+				<MostPopularFooterGrid
+					mostViewed={mostViewed}
+					deeplyRead={deeplyRead}
+					hasPageSkin={hasPageSkin}
+				/>
+			) : (
+				<MostViewedFooterGrid
+					data={tabs}
+					sectionId={sectionId}
+					selectedColour={selectedColour}
+					hasPageSkin={hasPageSkin}
+				/>
+			)}
 			<div css={[stackBelow('tablet'), secondTierStyles]}>
 				{mostCommented && (
 					<MostViewedFooterSecondTierItem

--- a/dotcom-rendering/src/components/MostViewedFooterItem.tsx
+++ b/dotcom-rendering/src/components/MostViewedFooterItem.tsx
@@ -2,7 +2,6 @@ import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import { ArticleDesign } from '@guardian/libs';
 import {
-	breakpoints,
 	headline,
 	palette as sourcePalette,
 	until,
@@ -12,12 +11,8 @@ import { AgeWarning } from './AgeWarning';
 import { BigNumber } from './BigNumber';
 import { FormatBoundary } from './FormatBoundary';
 import { LinkHeadline } from './LinkHeadline';
-import { generateSources } from './Picture';
 
-const gridItem = (
-	position: number,
-	hasPageSkin: boolean,
-) => {
+const gridItem = (position: number, hasPageSkin: boolean) => {
 	const borderTop = hasPageSkin
 		? css`
 				border-top: 1px solid ${sourcePalette.neutral[86]};
@@ -94,10 +89,6 @@ const imageStyles = css`
 	top: 6px;
 `;
 
-const textPaddingWithImage = css`
-	padding-left: 122px;
-`;
-
 type Props = {
 	position: number;
 	url: string;
@@ -106,11 +97,6 @@ type Props = {
 	ageWarning?: string;
 	cssOverrides?: SerializedStyles | SerializedStyles[];
 	hasPageSkin?: boolean;
-};
-
-type MiniImageProps = {
-	image: string;
-	alt: string;
 };
 
 export const MostViewedFooterItem = ({

--- a/dotcom-rendering/src/components/MostViewedFooterItem.tsx
+++ b/dotcom-rendering/src/components/MostViewedFooterItem.tsx
@@ -80,15 +80,6 @@ const ageWarningStyles = css`
 	margin-bottom: 16px;
 `;
 
-const imageStyles = css`
-	width: 53px;
-	height: 53px;
-	object-fit: cover;
-	position: absolute;
-	left: 59px;
-	top: 6px;
-`;
-
 type Props = {
 	position: number;
 	url: string;

--- a/dotcom-rendering/src/components/MostViewedFooterItem.tsx
+++ b/dotcom-rendering/src/components/MostViewedFooterItem.tsx
@@ -16,7 +16,6 @@ import { generateSources } from './Picture';
 
 const gridItem = (
 	position: number,
-	isWithImage: boolean,
 	hasPageSkin: boolean,
 ) => {
 	const borderTop = hasPageSkin
@@ -42,7 +41,7 @@ const gridItem = (
 
 		/* The left border is set on the container */
 		border-right: 1px solid ${sourcePalette.neutral[86]};
-		min-height: ${isWithImage ? '4rem' : '3.25rem'};
+		min-height: 52px;
 
 		&:hover {
 			cursor: pointer;
@@ -57,16 +56,16 @@ const gridItem = (
 
 const bigNumber = css`
 	position: absolute;
-	top: 0.375rem;
-	left: 0.625rem;
+	top: 6px;
+	left: 10px;
 	fill: ${palette('--article-text')};
 	svg {
-		height: 2.5rem;
+		height: 40px;
 	}
 `;
 
 const headlineHeader = css`
-	padding: 0.1875rem 0.625rem 1.125rem 4.6875rem;
+	padding: 3px 10px 18px 75px;
 	word-wrap: break-word;
 	overflow: hidden;
 `;
@@ -81,7 +80,7 @@ const headlineLink = css`
 `;
 
 const ageWarningStyles = css`
-	padding-left: 4.6875rem;
+	padding-left: 75px;
 	margin-top: -16px;
 	margin-bottom: 16px;
 `;
@@ -106,39 +105,12 @@ type Props = {
 	headlineText: string;
 	ageWarning?: string;
 	cssOverrides?: SerializedStyles | SerializedStyles[];
-	image?: string;
 	hasPageSkin?: boolean;
 };
 
 type MiniImageProps = {
 	image: string;
 	alt: string;
-};
-
-const MiniImage = ({ image, alt }: MiniImageProps) => {
-	// We need to have a square image with 53px width and height
-	// We first get a source for a landscape image with height 53
-	// (requesting a width of 89px from grid)
-	// we then crop the image to give it a width of 53px using css
-	const [source] = generateSources(image, [
-		{ breakpoint: breakpoints.desktop, width: 89 },
-	]);
-
-	if (!source) throw new Error(`Missing source for ${image}`);
-
-	return (
-		<picture>
-			{/* High resolution (HDPI) sources*/}
-			<source
-				srcSet={source.hiResUrl}
-				media={`(-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)`}
-			/>
-			{/* Low resolution (MDPI) source*/}
-			<source srcSet={source.lowResUrl} />
-
-			<img alt={alt} src={source.lowResUrl} css={imageStyles} />
-		</picture>
-	);
 };
 
 export const MostViewedFooterItem = ({
@@ -148,19 +120,17 @@ export const MostViewedFooterItem = ({
 	headlineText,
 	ageWarning,
 	cssOverrides,
-	image,
 	hasPageSkin = false,
 }: Props) => (
 	<li
-		css={[gridItem(position, !!image, hasPageSkin), cssOverrides]}
+		css={[gridItem(position, !!hasPageSkin), cssOverrides]}
 		data-link-name={`${position} | text`}
 	>
 		<a css={headlineLink} href={url} data-link-name="article">
 			<span css={bigNumber}>
 				<BigNumber index={position} />
 			</span>
-			{!!image && <MiniImage image={image} alt={headlineText} />}
-			<div css={[headlineHeader, !!image && textPaddingWithImage]}>
+			<div css={[headlineHeader]}>
 				<FormatBoundary format={format}>
 					{format.design === ArticleDesign.LiveBlog ? (
 						<LinkHeadline


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Brings the deeply read test more in line with the current most viewed behaviour. 

i.e. 
- removes images
- adds most shared and most commented
- corrects the mostviewedfotoer ophan data-link-name 

## Why?

We think this will make for a more accurate a/b test
Fixes: https://github.com/guardian/dotcom-rendering/issues/8807

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/1229808/e44cea25-d4cd-4f83-97c3-4dd7973b5572
[after]: https://github.com/guardian/dotcom-rendering/assets/1229808/348c4d00-7fcf-470e-aed1-f3583fff1a6e
