### PR TITLE
Fix reader revenue e2e check for support text

### DIFF
--- a/dotcom-rendering/playwright/tests/parallel-3/article.interactivity.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/parallel-3/article.interactivity.e2e.spec.ts
@@ -124,9 +124,7 @@ test.describe('Interactivity', () => {
 			await loadPage(page, `/Article/${articleUrl}`);
 			await waitForIsland(page, 'SupportTheG');
 			await expect(
-				page
-					.locator('header')
-					.filter({ hasText: 'Support the Guardian' }),
+				page.locator('header').filter({ hasText: 'Support' }),
 			).toBeVisible();
 		});
 	});


### PR DESCRIPTION
## What does this change?

The support message in the header has a new variant of `Support us in 2024` which causes the e2e test to fail as it is expecting `Support the Guardian`.

The test has been updated to only check for the word 'Support'.

If this changes again lets remove this check.

**Before:**
<img width="1352" alt="Screenshot 2024-01-02 at 07 28 14" src="https://github.com/guardian/dotcom-rendering/assets/7014230/37be05db-8b7f-4e72-841a-b01eeaf9e5cb">

**After:**
<img width="779" alt="Screenshot 2024-01-02 at 06 33 36" src="https://github.com/guardian/dotcom-rendering/assets/7014230/48c12f29-f995-4455-bd0a-f6b720620f94">

ps Happy New Year!