### PR TITLE
Make `Picture` loading explicit

### DIFF
--- a/dotcom-rendering/src/components/AppsLightboxImage.importable.tsx
+++ b/dotcom-rendering/src/components/AppsLightboxImage.importable.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react';
 import { type RoleType } from '../types/content';
 import { openLightboxForImageId } from './AppsLightboxImageStore.importable';
+import type { Loading } from './CardPicture';
 import { Picture } from './Picture';
 
 type Props = {
@@ -11,8 +12,8 @@ type Props = {
 	alt: string;
 	height: number;
 	width: number;
+	loading: Loading;
 	isMainMedia?: boolean;
-	isLazy?: boolean;
 };
 
 export const AppsLightboxImage = ({
@@ -24,7 +25,7 @@ export const AppsLightboxImage = ({
 	height,
 	width,
 	isMainMedia = false,
-	isLazy = true,
+	loading = 'lazy',
 }: Props) => {
 	const picture = (
 		<Picture
@@ -34,7 +35,7 @@ export const AppsLightboxImage = ({
 			alt={alt}
 			width={width}
 			height={height}
-			isLazy={isLazy}
+			loading={loading}
 			isMainMedia={isMainMedia}
 		/>
 	);

--- a/dotcom-rendering/src/components/CartoonComponent.tsx
+++ b/dotcom-rendering/src/components/CartoonComponent.tsx
@@ -35,6 +35,7 @@ export const CartoonComponent = ({ format, element, switches }: Props) => {
 					height={parseInt(image.fields.height, 10)}
 					width={parseInt(image.fields.width, 10)}
 					key={image.index}
+					loading="lazy"
 				/>
 				{switches?.lightbox === true &&
 					isWideEnough(image) &&

--- a/dotcom-rendering/src/components/ImageComponent.tsx
+++ b/dotcom-rendering/src/components/ImageComponent.tsx
@@ -278,6 +278,8 @@ export const ImageComponent = ({
 
 	const palette = decidePalette(format);
 
+	const loading = isMainMedia ? 'eager' : 'lazy';
+
 	if (
 		isMainMedia &&
 		format.display === ArticleDisplay.Immersive &&
@@ -325,7 +327,7 @@ export const ImageComponent = ({
 							alt={element.data.alt ?? ''}
 							width={imageWidth}
 							height={imageHeight}
-							isLazy={!isMainMedia}
+							loading={loading}
 							isMainMedia={isMainMedia}
 						/>
 					</Island>
@@ -337,7 +339,7 @@ export const ImageComponent = ({
 						alt={element.data.alt ?? ''}
 						width={imageWidth}
 						height={imageHeight}
-						isLazy={!isMainMedia}
+						loading={loading}
 						isMainMedia={isMainMedia}
 					/>
 				)}
@@ -389,7 +391,7 @@ export const ImageComponent = ({
 							alt={element.data.alt ?? ''}
 							width={imageWidth}
 							height={imageHeight}
-							isLazy={!isMainMedia}
+							loading={loading}
 							isMainMedia={isMainMedia}
 						/>
 					</Island>
@@ -401,7 +403,7 @@ export const ImageComponent = ({
 						alt={element.data.alt ?? ''}
 						width={imageWidth}
 						height={imageHeight}
-						isLazy={!isMainMedia}
+						loading={loading}
 						isMainMedia={isMainMedia}
 					/>
 				)}
@@ -456,7 +458,7 @@ export const ImageComponent = ({
 							alt={element.data.alt ?? ''}
 							width={imageWidth}
 							height={imageHeight}
-							isLazy={!isMainMedia}
+							loading={loading}
 							isMainMedia={isMainMedia}
 						/>
 					</Island>
@@ -468,7 +470,7 @@ export const ImageComponent = ({
 						alt={element.data.alt ?? ''}
 						width={imageWidth}
 						height={imageHeight}
-						isLazy={!isMainMedia}
+						loading={loading}
 						isMainMedia={isMainMedia}
 					/>
 				)}

--- a/dotcom-rendering/src/components/LightboxImages.tsx
+++ b/dotcom-rendering/src/components/LightboxImages.tsx
@@ -226,6 +226,7 @@ export const LightboxImages = ({ format, images }: Props) => {
 								isLightbox={true}
 								orientation={orientation}
 								onLoad={onLoad}
+								loading="lazy"
 							/>
 							<aside css={asideStyles}>
 								{!!image.title && (

--- a/dotcom-rendering/src/components/Picture.tsx
+++ b/dotcom-rendering/src/components/Picture.tsx
@@ -4,6 +4,7 @@ import { breakpoints } from '@guardian/source-foundations';
 import { Fragment, useCallback, useEffect, useState } from 'react';
 import { generateImageURL } from '../lib/image';
 import type { RoleType } from '../types/content';
+import type { Loading } from './CardPicture';
 
 /**
  * Working on this file? Checkout out 027-pictures.md & 029-signing-image-urls.md for background information & context
@@ -18,8 +19,8 @@ type Props = {
 	alt: string;
 	height: number;
 	width: number;
+	loading: Loading;
 	isMainMedia?: boolean;
-	isLazy?: boolean;
 	isLightbox?: boolean;
 	orientation?: Orientation;
 	onLoad?: () => void;
@@ -316,7 +317,7 @@ export const Picture = ({
 	height,
 	width,
 	isMainMedia = false,
-	isLazy = true,
+	loading,
 	isLightbox = false,
 	orientation = 'landscape',
 	onLoad,
@@ -403,9 +404,7 @@ export const Picture = ({
 				src={fallbackSource.lowResUrl}
 				width={fallbackSource.width}
 				height={fallbackSource.width * ratio}
-				loading={
-					isLazy && !Picture.disableLazyLoading ? 'lazy' : undefined
-				}
+				loading={Picture.disableLazyLoading ? undefined : loading}
 				css={isLightbox ? flex : block}
 			/>
 		</picture>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Convert the `isLazy` parameter to [`HTMLImageElement`’s `loading`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#loading), forcing consumers to make a decision about when an image should be rendered.

## Why?

The intent is clearer and a decision must be made. Similar to #8524

## Screenshots

N/A