### PR TITLE
chore(deps): bump construct to compatible version

### DIFF
--- a/apps-rendering/package.json
+++ b/apps-rendering/package.json
@@ -84,7 +84,7 @@
 		"clean-css": "5.3.3",
 		"compare-versions": "6.1.0",
 		"compression": "1.7.4",
-		"constructs": "10.2.69",
+		"constructs": "10.3.0",
 		"core-js": "3.33.3",
 		"eslint": "8.54.0",
 		"eslint-plugin-jsx-a11y": "6.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,7 +68,7 @@ importers:
         version: 2.6.0
       '@guardian/cdk':
         specifier: 50.13.0
-        version: 50.13.0(@swc/core@1.3.93)(@types/node@18.18.14)(aws-cdk-lib@2.100.0)(aws-cdk@2.100.0)(constructs@10.2.69)(typescript@5.1.3)
+        version: 50.13.0(@swc/core@1.3.93)(@types/node@18.18.14)(aws-cdk-lib@2.100.0)(aws-cdk@2.100.0)(constructs@10.3.0)(typescript@5.1.3)
       '@guardian/content-api-models':
         specifier: 17.8.0
         version: 17.8.0
@@ -170,7 +170,7 @@ importers:
         version: 2.100.0
       aws-cdk-lib:
         specifier: 2.100.0
-        version: 2.100.0(constructs@10.2.69)
+        version: 2.100.0(constructs@10.3.0)
       babel-loader:
         specifier: 9.1.3
         version: 9.1.3(@babel/core@7.23.2)(webpack@5.89.0)
@@ -187,8 +187,8 @@ importers:
         specifier: 1.7.4
         version: 1.7.4
       constructs:
-        specifier: 10.2.69
-        version: 10.2.69
+        specifier: 10.3.0
+        version: 10.3.0
       core-js:
         specifier: 3.33.3
         version: 3.33.3
@@ -3862,6 +3862,10 @@ packages:
       to-fast-properties: 2.0.0
     dev: false
 
+  /@balena/dockerignore@1.0.2:
+    resolution: {integrity: sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==}
+    dev: false
+
   /@base2/pretty-print-object@1.0.1:
     resolution: {integrity: sha512-4iri8i1AqYHJE2DstZYkyEprg6Pq6sKx3xn5FpySk9sNhH7qN2LLlHJCfDTZRILNwQNPD7mATWM0TBui7uC1pA==}
     dev: false
@@ -4830,35 +4834,6 @@ packages:
     dependencies:
       browserslist: 4.21.9
       tslib: 2.6.2
-    dev: false
-
-  /@guardian/cdk@50.13.0(@swc/core@1.3.93)(@types/node@18.18.14)(aws-cdk-lib@2.100.0)(aws-cdk@2.100.0)(constructs@10.2.69)(typescript@5.1.3):
-    resolution: {integrity: sha512-Yv/FUTN7GGydGwYC9cf/ZmOWXTK4c7Xe28WG+jmB1kJWG6L3JoXRnI9J9Z5V0Fz7eqkjkay7wiuU99gYzCCDEw==}
-    hasBin: true
-    peerDependencies:
-      aws-cdk: 2.100.0
-      aws-cdk-lib: 2.100.0
-      constructs: 10.3.0
-    dependencies:
-      '@oclif/core': 2.15.0(@swc/core@1.3.93)(@types/node@18.18.14)(typescript@5.1.3)
-      aws-cdk: 2.100.0
-      aws-cdk-lib: 2.100.0(constructs@10.2.69)
-      aws-sdk: 2.1519.0
-      chalk: 4.1.2
-      codemaker: 1.93.0
-      constructs: 10.2.69
-      git-url-parse: 13.1.1
-      js-yaml: 4.1.0
-      lodash.camelcase: 4.3.0
-      lodash.kebabcase: 4.1.1
-      lodash.upperfirst: 4.3.1
-      read-pkg-up: 7.0.1
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@swc/core'
-      - '@swc/wasm'
-      - '@types/node'
-      - typescript
     dev: false
 
   /@guardian/cdk@50.13.0(@swc/core@1.3.93)(@types/node@18.18.14)(aws-cdk-lib@2.100.0)(aws-cdk@2.100.0)(constructs@10.3.0)(typescript@5.1.3):
@@ -10430,29 +10405,6 @@ packages:
     engines: {node: '>= 0.4'}
     dev: false
 
-  /aws-cdk-lib@2.100.0(constructs@10.2.69):
-    resolution: {integrity: sha512-oWDPcbdqD69wDIUvcGdbDxmKcDfkCg515wf8JkiQLnhAI/AFyKAVTEWhbSUi00lvJQNUjX8Mal2lbKlCRA4hjQ==}
-    engines: {node: '>= 14.15.0'}
-    peerDependencies:
-      constructs: ^10.0.0
-    dependencies:
-      '@aws-cdk/asset-awscli-v1': 2.2.201
-      '@aws-cdk/asset-kubectl-v20': 2.1.2
-      '@aws-cdk/asset-node-proxy-agent-v6': 2.0.1
-      constructs: 10.2.69
-    dev: false
-    bundledDependencies:
-      - '@balena/dockerignore'
-      - case
-      - fs-extra
-      - ignore
-      - jsonschema
-      - minimatch
-      - punycode
-      - semver
-      - table
-      - yaml
-
   /aws-cdk-lib@2.100.0(constructs@10.3.0):
     resolution: {integrity: sha512-oWDPcbdqD69wDIUvcGdbDxmKcDfkCg515wf8JkiQLnhAI/AFyKAVTEWhbSUi00lvJQNUjX8Mal2lbKlCRA4hjQ==}
     engines: {node: '>= 14.15.0'}
@@ -10462,7 +10414,17 @@ packages:
       '@aws-cdk/asset-awscli-v1': 2.2.201
       '@aws-cdk/asset-kubectl-v20': 2.1.2
       '@aws-cdk/asset-node-proxy-agent-v6': 2.0.1
+      '@balena/dockerignore': 1.0.2
+      case: 1.6.3
       constructs: 10.3.0
+      fs-extra: 11.2.0
+      ignore: 5.3.0
+      jsonschema: 1.4.1
+      minimatch: 3.1.2
+      punycode: 2.3.1
+      semver: 7.5.4
+      table: 6.8.1
+      yaml: 1.10.2
     dev: false
     bundledDependencies:
       - '@balena/dockerignore'
@@ -11139,6 +11101,11 @@ packages:
     engines: {node: '>=4'}
     dev: false
 
+  /case@1.6.3:
+    resolution: {integrity: sha512-mzDSXIPaFwVDvZAHqZ9VlbyF4yyXRuX6IvB06WvPYkqJVO24kX1PPhv9bfpKNFZyxYFmmgo03HUiD8iklmJYRQ==}
+    engines: {node: '>= 0.8.0'}
+    dev: false
+
   /caseless@0.12.0:
     resolution: {integrity: sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==}
     dev: false
@@ -11580,11 +11547,6 @@ packages:
 
   /constants-browserify@1.0.0:
     resolution: {integrity: sha512-xFxOwqIzR/e1k1gLiWEophSCMqXcwVHIH7akf7b/vxcUeGunlj3hvZaaqxwHsTgn+IndtkQJgSztIDWeumWJDQ==}
-    dev: false
-
-  /constructs@10.2.69:
-    resolution: {integrity: sha512-0AiM/uQe5Uk6JVe/62oolmSN2MjbFQkOlYrM3fFGZLKuT+g7xlAI10EebFhyCcZwI2JAcWuWCmmCAyCothxjuw==}
-    engines: {node: '>= 16.14.0'}
     dev: false
 
   /constructs@10.3.0:
@@ -16937,6 +16899,10 @@ packages:
       universalify: 2.0.1
     optionalDependencies:
       graceful-fs: 4.2.11
+    dev: false
+
+  /jsonschema@1.4.1:
+    resolution: {integrity: sha512-S6cATIPVv1z0IlxdN+zUk5EPjkGCdnhN4wVSBlvoUO1tOLJootbo9CquNJmbIh4yikWHiUedhRYrNPn1arpEmQ==}
     dev: false
 
   /jsprim@2.0.2:


### PR DESCRIPTION
## What does this change?

Bump `constructs` to v10.3.0 as required by `@guardian/cdk` v50.13.0

## Why?

Flagged up by `pnpm`

```sh
WARN  Issues with peer dependencies found
apps-rendering
└─┬ @guardian/cdk 50.13.0
  └── ✕ unmet peer constructs@10.3.0: found 10.2.69
```