### PR TITLE
Re introduce run_chromatic label

### DIFF
--- a/.github/workflows/ar-chromatic.yml
+++ b/.github/workflows/ar-chromatic.yml
@@ -4,14 +4,19 @@ on:
   push:
     branches: [main]
   pull_request:
-    types: [opened, labeled, synchronize, ready_for_review]
+    types: [opened, labeled, synchronize]
 
 jobs:
   chromatic:
     name: Chromatic
     runs-on: ubuntu-latest
-    # Don't run Chromatic on draft PRs unless `run_chromatic` label has been applied.
-    if: (contains(github.event.pull_request.labels.*.name, 'run_chromatic') || github.event.pull_request.draft == false)
+    # Run Chromatic only if `run_chromatic` label has been applied or we're
+    # pushing to `main`. Skip if this is a Dependabot PR as this is handled
+    # by the subsequent job.
+    if: |
+      (contains(github.event.pull_request.labels.*.name, 'run_chromatic') ||  github.ref == 'refs/heads/main') &&
+      (!contains(github.event.pull_request.labels.*.name, 'dependencies') &&
+      github.event.pull_request.user.login != 'dependabot')
     steps:
       - name: Checkout - On Pull Request
         uses: actions/checkout@v4

--- a/.github/workflows/dcr-chromatic.yml
+++ b/.github/workflows/dcr-chromatic.yml
@@ -4,14 +4,19 @@ on:
   push:
     branches: [main]
   pull_request:
-    types: [opened, labeled, synchronize, ready_for_review]
+    types: [opened, labeled, synchronize]
 
 jobs:
   chromatic:
     name: Chromatic
     runs-on: ubuntu-latest
-    # Don't run Chromatic on draft PRs unless `run_chromatic` label has been applied.
-    if: (contains(github.event.pull_request.labels.*.name, 'run_chromatic') || github.event.pull_request.draft == false)
+    # Run Chromatic only if `run_chromatic` label has been applied or we're
+    # pushing to `main`. Skip if this is a Dependabot PR as this is handled
+    # by the subsequent job.
+    if: |
+      (contains(github.event.pull_request.labels.*.name, 'run_chromatic')  ||  github.ref == 'refs/heads/main') &&
+      (!contains(github.event.pull_request.labels.*.name, 'dependencies') &&
+      github.event.pull_request.user.login != 'dependabot')
     steps:
       - name: Checkout - On Pull Request
         uses: actions/checkout@v4


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Re introduces the `run_chromatic` label. 

## Why?

Since we removed it in November, Chromatic costs went up massively.

