### PR TITLE
add styling for keeping slot for mobile device

### DIFF
--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -3,6 +3,7 @@ import type { SlotName } from '@guardian/commercial';
 import { adSizes, constants } from '@guardian/commercial';
 import { ArticleDisplay } from '@guardian/libs';
 import {
+	between,
 	breakpoints,
 	from,
 	palette,
@@ -142,7 +143,7 @@ const adSlotCollapseStyles = css`
 		display: none;
 	}
 	&.ad-slot--collapse-below-desktop {
-		${until.desktop} {
+		${between.tablet.and.desktop} {
 			display: none;
 		}
 	}

--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -142,11 +142,6 @@ const adSlotCollapseStyles = css`
 	&.ad-slot.ad-slot--collapse {
 		display: none;
 	}
-	&.ad-slot--collapse-below-desktop {
-		${between.tablet.and.desktop} {
-			display: none;
-		}
-	}
 `;
 
 /**
@@ -208,6 +203,11 @@ const merchandisingAdStyles = css`
 		margin: 0;
 		padding-bottom: 20px;
 		min-height: ${adSizes.billboard.height + labelHeight + 20}px;
+	}
+	&:not(.ad-slot--fluid).ad-slot--rendered {
+		${between.phablet.and.desktop} {
+			display: none;
+		}
 	}
 `;
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

## Why?
This PR aims to build on the work done in: https://github.com/guardian/commercial/pull/1194 and sbsequently : https://github.com/guardian/dotcom-rendering/pull/9991

As a result of the styling removing the `merchandise` ad slot  from mobile devices, which was unwanted. 

## Screenshots

| MPU ad populate merch slot        |
| ------------ |
| <img width="250" alt="Screenshot 2024-01-08 at 10 51 31" src="https://github.com/guardian/dotcom-rendering/assets/49187886/d01f7d33-0311-4640-b474-e110940fc6f5"> |


| Smaller than Desktop mostpop ad without merch ad |
| ------------ |
| <img width="1386" alt="Screenshot 2024-01-08 at 10 46 05" src="https://github.com/guardian/dotcom-rendering/assets/49187886/f6a4f3a0-df21-4b78-b768-b5db4f798fb1"> |


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
