### PR TITLE
Only one `make build`

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -23,8 +23,7 @@
 		"cypress:run:e2e": "cypress run --spec 'cypress/e2e/**/*'",
 		"unused-exports": "pnpm ts-unused-exports ./tsconfig.json --ignoreFiles='(/(fixtures|__mocks__)/|.+\\.(stories|mocks))' --exitWithCount",
 		"storybook": "storybook dev -p 4002",
-		"build-storybook": "storybook build",
-		"makeBuild": "NODE_ENV=production CI_ENV=github webpack --config ./webpack/webpack.config.js"
+		"build-storybook": "storybook build"
 	},
 	"dependencies": {
 		"@aws-sdk/client-cloudwatch": "3.350.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 		"build-storybook": "pnpm '/^build-storybook:.*/'",
 		"build-storybook:ar": "pnpm --filter apps-rendering build-storybook",
 		"build-storybook:dcr": "pnpm --filter @guardian/dotcom-rendering build-storybook",
-		"build:dcr": "pnpm --filter @guardian/dotcom-rendering makeBuild",
+		"build:dcr": "cd dotcom-rendering && make build",
 		"chromatic": "chromatic --build-script-name=build-storybook --exit-zero-on-changes",
 		"prepare": "husky install",
 		"lint-staged": "lint-staged",


### PR DESCRIPTION
## What does this change?

Replace custom `makeBuild` with the usual `make build`

`cd` in scripts does not actually changes the current directory where executed.

## Why?

One way to do things!