### PR TITLE
Refactor Dismiss Gate to use `@guardian/libs` storage

### DIFF
--- a/dotcom-rendering/src/components/SignInGate/dismissGate.ts
+++ b/dotcom-rendering/src/components/SignInGate/dismissGate.ts
@@ -1,7 +1,8 @@
-// TODO: Add localstorage lib from https://github.com/guardian/libs/pull/1 when it is merged
+import { isObject, isString, isUndefined, storage } from '@guardian/libs';
+
 const localStorageKey = `gu.prefs.sign-in-gate`;
 
-// We use this key for storing the date the gate was dismissed against
+/** We use this key for storing the date the gate was dismissed against */
 const localStorageDismissedDateKey = (
 	variant: string,
 	name: string,
@@ -9,7 +10,7 @@ const localStorageDismissedDateKey = (
 	return `${name}-${variant}`;
 };
 
-// We use this key for storing the gate dismissed count against
+/** We use this key for storing the gate dismissed count against */
 const localStorageDismissedCountKey = (
 	variant: string,
 	name: string,
@@ -17,119 +18,96 @@ const localStorageDismissedCountKey = (
 	return `gate-dismissed-count-${name}-${variant}`;
 };
 
+const isKeyValuePair = (
+	object: Record<string | number | symbol, unknown>,
+): object is Record<string, string | number> =>
+	Object.entries(object).every(
+		([key, value]) =>
+			isString(key) && ['string', 'number'].includes(typeof value),
+	);
+
 // Invalid json stored against `localStorageKey` should not break signin gate for a user forever
-const getSigninGatePrefsSafely = (): { [key: string]: any } => {
-	try {
-		const prefs: { [key: string]: any } = JSON.parse(
-			// eslint-disable-next-line no-restricted-syntax -- FIXME-libs-storage
-			localStorage.getItem(localStorageKey) ?? '{}',
-		);
-
-		if (typeof prefs === 'object' && typeof prefs.value === 'object') {
-			return prefs.value;
-		}
-		return {};
-	} catch (e) {
-		return {};
-	}
+const getSigninGatePrefsSafely = (): Record<string, string | number> => {
+	const prefs = storage.local.get(localStorageKey);
+	return isObject(prefs) && isKeyValuePair(prefs) ? prefs : {};
 };
 
-const setSigninGatePrefs = (prefs: any) => {
-	// eslint-disable-next-line no-restricted-syntax -- FIXME-libs-storage
-	localStorage.setItem(localStorageKey, JSON.stringify({ value: prefs }));
+const setSigninGatePrefs = (prefs: Record<string, string | number>) => {
+	storage.local.set(localStorageKey, prefs);
 };
 
-// set in user preferences that the user has dismissed the gate, set the value to the current ISO date string
-// name is optional, but can be used to differentiate between multiple sign in gate tests
-//
-//
-// This is set in local storage with the following shape:
-//
-// key:   gu.prefs.sign-in-gate
-// value: {"testVariantName":"2020-07-01T10:55:09.085Z"}
-//
-// We set the value using the key, which remains constant
-// and add an entry to the object with the testname and variant, and use current ISO date string as the value
+/**
+ * set in user preferences that the user has dismissed the gate, set the value to the current ISO date string
+ * name is optional, but can be used to differentiate between multiple sign in gate tests
+ *
+ *
+ * This is set in local storage with the following shape:
+ *
+ * key:   gu.prefs.sign-in-gate
+ * value: {"testVariantName":"2020-07-01T10:55:09.085Z"}
+ *
+ * We set the value using the key, which remains constant
+ * and add an entry to the object with the testname and variant, and use current ISO date string as the value
+ */
 export const setUserDismissedGate = (variant: string, name: string): void => {
-	try {
-		const prefs = getSigninGatePrefsSafely();
-		prefs[localStorageDismissedDateKey(variant, name)] =
-			new Date().toISOString();
-		setSigninGatePrefs(prefs);
-	} catch (error) {
-		// Alas, sometimes localstorage isn't available
-	}
+	const prefs = getSigninGatePrefsSafely();
+	prefs[localStorageDismissedDateKey(variant, name)] =
+		new Date().toISOString();
+	setSigninGatePrefs(prefs);
 };
 
 export const unsetUserDismissedGate = (variant: string, name: string): void => {
-	try {
-		const prefs = getSigninGatePrefsSafely();
-		delete prefs[localStorageDismissedDateKey(variant, name)];
-		setSigninGatePrefs(prefs);
-	} catch (error) {
-		// Alas, sometimes localstorage isn't available
-	}
+	const prefs = getSigninGatePrefsSafely();
+	delete prefs[localStorageDismissedDateKey(variant, name)];
+	setSigninGatePrefs(prefs);
 };
 
-// Check if the user has dismissed the gate by checking the user preferences,
-// name is optional, but can be used to differentiate between multiple sign in gate tests
-//
-// This is set in local storage with the following shape:
-//
-// key:   gu.prefs.sign-in-gate
-// value: {"testVariantName":"2020-07-01T10:55:09.085Z"}
-//
-// We extract the value using the key, which remains constant
-// and the from within the value object we look up the variant we are looking for
+/**
+ * Check if the user has dismissed the gate by checking the user preferences,
+ * name is optional, but can be used to differentiate between multiple sign in gate tests
+ *
+ * This is set in local storage with the following shape:
+ *
+ * key:   gu.prefs.sign-in-gate
+ * value: {"testVariantName":"2020-07-01T10:55:09.085Z"}
+ *
+ * We extract the value using the key, which remains constant
+ * and the from within the value object we look up the variant we are looking for
+ */
 export const hasUserDismissedGate = (
 	variant: string,
 	name: string,
-	window?: number, // represents hours - only use if the gate should reshow after X hrs (dismissal window)
+	dismissalWindow?: number, // represents hours - only use if the gate should reshow after X hrs (dismissal window)
 ): boolean => {
-	try {
-		const prefs = getSigninGatePrefsSafely();
-		// checks if a dismissal occurred within a given window timeframe in hours
-		if (window !== undefined) {
-			// checks if prefs is empty, ie. the user has not dismissed gate before.
-			if (!prefs[localStorageDismissedDateKey(variant, name)]) {
-				return false;
-			}
-
-			const dismissalTZ = Date.parse(
-				prefs[localStorageDismissedDateKey(variant, name)],
-			);
-			const hours = (Date.now() - dismissalTZ) / 36e5; //  36e5 is the scientific notation for 60*60*1000, which converts the milliseconds difference into hours.
-
-			if (hours >= window) {
-				unsetUserDismissedGate(variant, name);
-				return false;
-			}
-			return true;
+	const prefs = getSigninGatePrefsSafely();
+	const pref = prefs[localStorageDismissedDateKey(variant, name)];
+	// checks if a dismissal occurred within a given window timeframe in hours
+	if (dismissalWindow !== undefined) {
+		// checks if prefs is empty, ie. the user has not dismissed gate before.
+		if (isUndefined(pref) || typeof pref === 'number') {
+			return false;
 		}
 
-		return !!prefs[localStorageDismissedDateKey(variant, name)];
-	} catch (error) {
-		// Alas, sometimes localstorage isn't available. Please have a sign in gate as an apology
-		return false;
+		const hours = (Date.now() - new Date(pref).getTime()) / 36e5; //  36e5 is the scientific notation for 60*60*1000, which converts the milliseconds difference into hours.
+
+		if (hours >= dismissalWindow) {
+			unsetUserDismissedGate(variant, name);
+			return false;
+		}
+		return true;
 	}
+
+	return !(pref == null);
 };
 
 const retrieveDismissedCount = (variant: string, name: string): number => {
-	try {
-		const prefs = getSigninGatePrefsSafely();
-		const dismissed: any =
-			prefs[localStorageDismissedCountKey(variant, name)];
+	const prefs = getSigninGatePrefsSafely();
+	const dismissed = prefs[localStorageDismissedCountKey(variant, name)];
 
-		if (Number.isFinite(dismissed)) {
-			return dismissed;
-		}
-		return 0;
-	} catch (error) {
-		return 0;
-	}
+	return typeof dismissed === 'number' && dismissed > 0 ? dismissed : 0;
 };
 
-// Test whether the user has dismissed the gate variant more than `count` times
+/** Test whether the user has dismissed the gate variant more than `count` times */
 export const hasUserDismissedGateMoreThanCount = (
 	variant: string,
 	name: string,
@@ -138,17 +116,13 @@ export const hasUserDismissedGateMoreThanCount = (
 	return retrieveDismissedCount(variant, name) > count;
 };
 
-// Increment the number of times a user has dismissed this gate variant
+/** Increment the number of times a user has dismissed this gate variant */
 export const incrementUserDismissedGateCount = (
 	variant: string,
 	name: string,
 ): void => {
-	try {
-		const prefs = getSigninGatePrefsSafely();
-		prefs[localStorageDismissedCountKey(variant, name)] =
-			retrieveDismissedCount(variant, name) + 1;
-		setSigninGatePrefs(prefs);
-	} catch (error) {
-		// localstorage isn't available so show the gate
-	}
+	const prefs = getSigninGatePrefsSafely();
+	const key = localStorageDismissedCountKey(variant, name);
+	prefs[key] = retrieveDismissedCount(variant, name) + 1;
+	setSigninGatePrefs(prefs);
 };


### PR DESCRIPTION
## What does this change?

Refactor `dismissGate` to use `@guardian/libs`’s Storage rather than `localStorage` directly

cc. @guardian/identity as this touches the sign-in gate

## Why?

Follow-up on:
- #9994 