### PR TITLE
Refactor contributions to use `@guardian/libs` storage

### DIFF
--- a/dotcom-rendering/src/lib/contributions.ts
+++ b/dotcom-rendering/src/lib/contributions.ts
@@ -1,5 +1,5 @@
 import { onConsentChange } from '@guardian/consent-management-platform';
-import { getCookie } from '@guardian/libs';
+import { getCookie, storage } from '@guardian/libs';
 import type { HeaderPayload } from '@guardian/support-dotcom-components/dist/dotcom/src/types';
 import { useEffect, useState } from 'react';
 import type { DCRFrontType } from '../types/front';
@@ -24,7 +24,9 @@ export const SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE =
 //  Local storage keys
 const DAILY_ARTICLE_COUNT_KEY = 'gu.history.dailyArticleCount';
 const WEEKLY_ARTICLE_COUNT_KEY = 'gu.history.weeklyArticleCount';
-export const NO_RR_BANNER_TIMESTAMP_KEY = 'gu.noRRBannerTimestamp'; // timestamp of when we were last told not to show a RR banner
+/** @deprecated */
+const NO_RR_BANNER_TIMESTAMP_KEY = 'gu.noRRBannerTimestamp'; // timestamp of when we were last told not to show a RR banner
+const NO_RR_BANNER_KEY = 'gu.noRRBanner';
 
 // See https://github.com/guardian/support-dotcom-components/blob/main/module-versions.md
 export const MODULES_VERSION = 'v3';
@@ -153,10 +155,8 @@ export const hasArticleCountOptOutCookie = (): boolean =>
 	getCookie({ name: OPT_OUT_OF_ARTICLE_COUNT_COOKIE }) !== null;
 
 const removeArticleCountsFromLocalStorage = () => {
-	// eslint-disable-next-line no-restricted-syntax -- FIXME-libs-storage
-	window.localStorage.removeItem(DAILY_ARTICLE_COUNT_KEY);
-	// eslint-disable-next-line no-restricted-syntax -- FIXME-libs-storage
-	window.localStorage.removeItem(WEEKLY_ARTICLE_COUNT_KEY);
+	storage.local.remove(DAILY_ARTICLE_COUNT_KEY);
+	storage.local.remove(WEEKLY_ARTICLE_COUNT_KEY);
 };
 
 export const hasCmpConsentForArticleCount = (): Promise<boolean> => {
@@ -220,25 +220,36 @@ export const hasCmpConsentForBrowserId = (): Promise<boolean> =>
 		});
 	});
 
-const twentyMins = 20 * 60000;
-export const withinLocalNoBannerCachePeriod = (): boolean => {
-	// eslint-disable-next-line no-restricted-syntax -- FIXME-libs-storage
-	const item = window.localStorage.getItem(NO_RR_BANNER_TIMESTAMP_KEY);
-	if (item && !Number.isNaN(parseInt(item, 10))) {
-		const withinCachePeriod = parseInt(item, 10) + twentyMins > Date.now();
-		if (!withinCachePeriod) {
-			// Expired
-			// eslint-disable-next-line no-restricted-syntax -- FIXME-libs-storage
-			window.localStorage.removeItem(NO_RR_BANNER_TIMESTAMP_KEY);
-		}
-		return withinCachePeriod;
+/**
+ * This is used for old keys that were set using localStorage
+ * directly instead of the using the @guardian/libs storage class
+ */
+const getBannerTimestamp = (): number | undefined => {
+	try {
+		// eslint-disable-next-line no-restricted-syntax -- we need to handle old keys
+		const item = localStorage.getItem(NO_RR_BANNER_TIMESTAMP_KEY);
+		if (!item) return;
+		const timestamp = parseInt(item, 10);
+		if (Number.isNaN(timestamp)) return;
+		return timestamp;
+	} catch (error) {
+		console.error(error);
 	}
-	return false;
+	return;
 };
 
-export const setLocalNoBannerCachePeriod = (): void =>
-	// eslint-disable-next-line no-restricted-syntax -- FIXME-libs-storage
-	window.localStorage.setItem(NO_RR_BANNER_TIMESTAMP_KEY, `${Date.now()}`);
+const twentyMins = 20 * 60000;
+export const withinLocalNoBannerCachePeriod = (): boolean => {
+	const timestamp = getBannerTimestamp();
+	if (typeof timestamp === 'number') {
+		setLocalNoBannerCachePeriod(timestamp);
+	}
+
+	return !!storage.local.get(NO_RR_BANNER_KEY);
+};
+
+export const setLocalNoBannerCachePeriod = (timestamp = Date.now()): void =>
+	storage.local.set(NO_RR_BANNER_KEY, true, timestamp + twentyMins);
 
 // Returns true if banner was closed in the last hour
 const ONE_HOUR_IN_MS = 1000 * 60 * 60;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

- use [`@guardian/libs`’s storage](https://github.com/guardian/csnx/tree/5fd3a390496ad7781e14068b36f45148b66bad6b/libs/@guardian/libs/src/storage) class instead of `localStorage`
- instead of implementing an 20m expiry mechanism, use the provided [expiry option from `storage`](https://github.com/guardian/csnx/tree/5fd3a390496ad7781e14068b36f45148b66bad6b/libs/@guardian/libs/src/storage#expires)
- add a mechanism to upgrade old existing keys to the new one:
  - `getBannerTimestamp` checks if there is an old key that exists
  - we then remove the old key if this is found, and set the expiry adequately

## Why?

Follow-up on:
- #9994