### PR TITLE
Refactor `dailyArticleCount` to `@guardian/libs/storage`

### DIFF
--- a/dotcom-rendering/src/lib/dailyArticleCount.test.ts
+++ b/dotcom-rendering/src/lib/dailyArticleCount.test.ts
@@ -1,4 +1,3 @@
-import { storage } from '@guardian/libs';
 import type { DailyArticle, DailyArticleHistory } from './dailyArticleCount';
 import {
 	DailyArticleCountKey,
@@ -25,7 +24,8 @@ const validDailyArticleCount: [DailyArticle, DailyArticle, DailyArticle] = [
 
 describe('dailyArticleCount', () => {
 	beforeEach(() => {
-		storage.local.clear();
+		// eslint-disable-next-line no-restricted-syntax -- FIXME-libs-storage
+		localStorage.clear();
 	});
 
 	it('gets undefined if no article count in local storage', () => {
@@ -35,7 +35,7 @@ describe('dailyArticleCount', () => {
 	});
 
 	it('returns array of valid daily article counts if they exist', () => {
-		storage.local.set(
+		localStorage.setItem(
 			DailyArticleCountKey,
 			JSON.stringify({ value: validDailyArticleCount }),
 		);
@@ -46,16 +46,16 @@ describe('dailyArticleCount', () => {
 	});
 
 	it('returns undefined if failed to parse local storage, and remove the key from localStorage', () => {
-		storage.local.set(DailyArticleCountKey, 'not a valid json string');
+		localStorage.setItem(DailyArticleCountKey, 'not a valid json string');
 
 		const output = getDailyArticleCount();
 
 		expect(output).toEqual(undefined);
-		expect(storage.local.get(DailyArticleCountKey)).toBeNull();
+		expect(localStorage.getItem(DailyArticleCountKey)).toBeNull();
 	});
 
 	it('returns undefined if invalid json format, and removes the key from localStorage', () => {
-		storage.local.set(
+		localStorage.setItem(
 			DailyArticleCountKey,
 			JSON.stringify(validDailyArticleCount), // invalid format (array only, not it { value: array } format)
 		);
@@ -63,7 +63,7 @@ describe('dailyArticleCount', () => {
 		const output = getDailyArticleCount();
 
 		expect(output).toEqual(undefined);
-		expect(storage.local.get(DailyArticleCountKey)).toBeNull();
+		expect(localStorage.getItem(DailyArticleCountKey)).toBeNull();
 	});
 
 	it('increments daily article count for today if daily article count does not exist', () => {
@@ -84,7 +84,7 @@ describe('dailyArticleCount', () => {
 
 	it('increments daily article count if it exists for today', () => {
 		// set localstorage to mock daily count
-		storage.local.set(
+		localStorage.setItem(
 			DailyArticleCountKey,
 			JSON.stringify({ value: validDailyArticleCount }),
 		);
@@ -106,7 +106,7 @@ describe('dailyArticleCount', () => {
 		const [, ...mocked] = validDailyArticleCount;
 
 		// set localstorage to mock daily count
-		storage.local.set(
+		localStorage.setItem(
 			DailyArticleCountKey,
 			JSON.stringify({ value: mocked }),
 		);
@@ -137,7 +137,7 @@ describe('dailyArticleCount', () => {
 		];
 
 		// set localstorage to mock daily count
-		storage.local.set(
+		localStorage.setItem(
 			DailyArticleCountKey,
 			JSON.stringify({ value: mocked }),
 		);

--- a/dotcom-rendering/src/lib/dailyArticleCount.test.ts
+++ b/dotcom-rendering/src/lib/dailyArticleCount.test.ts
@@ -1,3 +1,4 @@
+import { storage } from '@guardian/libs';
 import type { DailyArticle, DailyArticleHistory } from './dailyArticleCount';
 import {
 	DailyArticleCountKey,
@@ -24,8 +25,7 @@ const validDailyArticleCount: [DailyArticle, DailyArticle, DailyArticle] = [
 
 describe('dailyArticleCount', () => {
 	beforeEach(() => {
-		// eslint-disable-next-line no-restricted-syntax -- FIXME-libs-storage
-		localStorage.clear();
+		storage.local.clear();
 	});
 
 	it('gets undefined if no article count in local storage', () => {
@@ -35,7 +35,7 @@ describe('dailyArticleCount', () => {
 	});
 
 	it('returns array of valid daily article counts if they exist', () => {
-		localStorage.setItem(
+		storage.local.set(
 			DailyArticleCountKey,
 			JSON.stringify({ value: validDailyArticleCount }),
 		);
@@ -46,16 +46,16 @@ describe('dailyArticleCount', () => {
 	});
 
 	it('returns undefined if failed to parse local storage, and remove the key from localStorage', () => {
-		localStorage.setItem(DailyArticleCountKey, 'not a valid json string');
+		storage.local.set(DailyArticleCountKey, 'not a valid json string');
 
 		const output = getDailyArticleCount();
 
 		expect(output).toEqual(undefined);
-		expect(localStorage.getItem(DailyArticleCountKey)).toBeNull();
+		expect(storage.local.get(DailyArticleCountKey)).toBeNull();
 	});
 
 	it('returns undefined if invalid json format, and removes the key from localStorage', () => {
-		localStorage.setItem(
+		storage.local.set(
 			DailyArticleCountKey,
 			JSON.stringify(validDailyArticleCount), // invalid format (array only, not it { value: array } format)
 		);
@@ -63,7 +63,7 @@ describe('dailyArticleCount', () => {
 		const output = getDailyArticleCount();
 
 		expect(output).toEqual(undefined);
-		expect(localStorage.getItem(DailyArticleCountKey)).toBeNull();
+		expect(storage.local.get(DailyArticleCountKey)).toBeNull();
 	});
 
 	it('increments daily article count for today if daily article count does not exist', () => {
@@ -84,7 +84,7 @@ describe('dailyArticleCount', () => {
 
 	it('increments daily article count if it exists for today', () => {
 		// set localstorage to mock daily count
-		localStorage.setItem(
+		storage.local.set(
 			DailyArticleCountKey,
 			JSON.stringify({ value: validDailyArticleCount }),
 		);
@@ -106,7 +106,7 @@ describe('dailyArticleCount', () => {
 		const [, ...mocked] = validDailyArticleCount;
 
 		// set localstorage to mock daily count
-		localStorage.setItem(
+		storage.local.set(
 			DailyArticleCountKey,
 			JSON.stringify({ value: mocked }),
 		);
@@ -137,7 +137,7 @@ describe('dailyArticleCount', () => {
 		];
 
 		// set localstorage to mock daily count
-		localStorage.setItem(
+		storage.local.set(
 			DailyArticleCountKey,
 			JSON.stringify({ value: mocked }),
 		);

--- a/dotcom-rendering/src/lib/dailyArticleCount.ts
+++ b/dotcom-rendering/src/lib/dailyArticleCount.ts
@@ -1,4 +1,4 @@
-import { storage } from '@guardian/libs';
+import { isObject, storage } from '@guardian/libs';
 
 export interface DailyArticle {
 	day: number;
@@ -9,15 +9,23 @@ export type DailyArticleHistory = Array<DailyArticle>;
 
 export const DailyArticleCountKey = 'gu.history.dailyArticleCount';
 
+const isValidHistory = (history: unknown): history is DailyArticleHistory =>
+	Array.isArray(history) &&
+	history.every(
+		(daily) =>
+			isObject(daily) &&
+			'day' in daily &&
+			'count' in daily &&
+			typeof daily.day === 'number' &&
+			typeof daily.count === 'number',
+	);
+
 // Returns undefined if no daily article count in local storage
 export const getDailyArticleCount = (): DailyArticleHistory | undefined => {
 	try {
-		const dailyCount = storage.local.get(
-			DailyArticleCountKey,
-		) as DailyArticleHistory;
+		const dailyCount = storage.local.get(DailyArticleCountKey);
 
-		// check if value parsed correctly
-		if (!dailyCount.length) {
+		if (!isValidHistory(dailyCount)) {
 			throw new Error('Invalid gu.history.dailyArticleCount value');
 		}
 

--- a/dotcom-rendering/src/lib/dailyArticleCount.ts
+++ b/dotcom-rendering/src/lib/dailyArticleCount.ts
@@ -1,4 +1,4 @@
-import { isObject, isString, storage } from '@guardian/libs';
+import { storage } from '@guardian/libs';
 
 export interface DailyArticle {
 	day: number;

--- a/dotcom-rendering/src/lib/dailyArticleCount.ts
+++ b/dotcom-rendering/src/lib/dailyArticleCount.ts
@@ -1,4 +1,4 @@
-import { storage } from '@guardian/libs';
+import { isObject, isString, storage } from '@guardian/libs';
 
 export interface DailyArticle {
 	day: number;
@@ -7,30 +7,21 @@ export interface DailyArticle {
 
 export type DailyArticleHistory = Array<DailyArticle>;
 
-// in localStorage, has format {"value":[{"day":18459,"count":1},{"day":18457,"count":1},{"day":18446,"count":1}]} to match frontend
-interface DailyArticleCountLocalStorage {
-	value: DailyArticleHistory;
-}
-
 export const DailyArticleCountKey = 'gu.history.dailyArticleCount';
 
 // Returns undefined if no daily article count in local storage
 export const getDailyArticleCount = (): DailyArticleHistory | undefined => {
-	const dailyCount = storage.local.get(DailyArticleCountKey);
-
-	if (!dailyCount || typeof dailyCount !== 'string') {
-		return undefined;
-	}
-
 	try {
-		const { value }: DailyArticleCountLocalStorage = JSON.parse(dailyCount);
+		const dailyCount = storage.local.get(
+			DailyArticleCountKey,
+		) as DailyArticleHistory;
 
 		// check if value parsed correctly
-		if (!value.length) {
+		if (!dailyCount.length) {
 			throw new Error('Invalid gu.history.dailyArticleCount value');
 		}
 
-		return value;
+		return dailyCount;
 	} catch (e) {
 		// error parsing the string, so remove the key
 		storage.local.remove(DailyArticleCountKey);
@@ -67,10 +58,5 @@ export const incrementDailyArticleCount = (): void => {
 	}
 
 	// set the latest article count
-	storage.local.set(
-		DailyArticleCountKey,
-		JSON.stringify({
-			value: dailyArticleCount,
-		}),
-	);
+	storage.local.set(DailyArticleCountKey, dailyArticleCount);
 };

--- a/dotcom-rendering/src/lib/dailyArticleCount.ts
+++ b/dotcom-rendering/src/lib/dailyArticleCount.ts
@@ -1,3 +1,5 @@
+import { storage } from '@guardian/libs';
+
 export interface DailyArticle {
 	day: number;
 	count: number;
@@ -14,10 +16,9 @@ export const DailyArticleCountKey = 'gu.history.dailyArticleCount';
 
 // Returns undefined if no daily article count in local storage
 export const getDailyArticleCount = (): DailyArticleHistory | undefined => {
-	// eslint-disable-next-line no-restricted-syntax -- FIXME-libs-storage
-	const dailyCount = localStorage.getItem(DailyArticleCountKey);
+	const dailyCount = storage.local.get(DailyArticleCountKey);
 
-	if (!dailyCount) {
+	if (!dailyCount || typeof dailyCount !== 'string') {
 		return undefined;
 	}
 
@@ -32,8 +33,7 @@ export const getDailyArticleCount = (): DailyArticleHistory | undefined => {
 		return value;
 	} catch (e) {
 		// error parsing the string, so remove the key
-		// eslint-disable-next-line no-restricted-syntax -- FIXME-libs-storage
-		localStorage.removeItem(DailyArticleCountKey);
+		storage.local.remove(DailyArticleCountKey);
 		return undefined;
 	}
 };
@@ -67,11 +67,10 @@ export const incrementDailyArticleCount = (): void => {
 	}
 
 	// set the latest article count
-	// eslint-disable-next-line no-restricted-syntax -- FIXME-libs-storage
-	localStorage.setItem(
+	storage.local.set(
 		DailyArticleCountKey,
 		JSON.stringify({
 			value: dailyArticleCount,
-		} as DailyArticleCountLocalStorage),
+		}),
 	);
 };


### PR DESCRIPTION
As part of https://github.com/guardian/dotcom-rendering/issues/10052, refactor the `dailyArticleCount` module. Keep tests the same for now to validate the behaviour is unchanged. Test refactor to follow.

Part of #10053
