### PR TITLE
Refactor StickyBottomBanner to use @guardian/libs storage

### DIFF
--- a/dotcom-rendering/src/components/StickyBottomBanner.importable.tsx
+++ b/dotcom-rendering/src/components/StickyBottomBanner.importable.tsx
@@ -4,7 +4,7 @@ import type {
 } from '@guardian/braze-components/logic';
 import { cmp } from '@guardian/consent-management-platform';
 import type { CountryCode } from '@guardian/libs';
-import { storage } from '@guardian/libs';
+import { isString, storage } from '@guardian/libs';
 import { useEffect, useState } from 'react';
 import { getArticleCounts } from '../lib/articleCount';
 import type { ArticleCounts } from '../lib/articleCount';
@@ -60,12 +60,8 @@ type RRBannerConfig = {
 };
 
 const getBannerLastClosedAt = (key: string): string | undefined => {
-	const item = storage.local.get(`gu.prefs.${key}`) as undefined | string;
-
-	if (typeof item === 'string') {
-		return item;
-	}
-	return undefined;
+	const item = storage.local.get(`gu.prefs.${key}`);
+	return isString(item) ? item : undefined;
 };
 
 const DEFAULT_BANNER_TIMEOUT_MILLIS = 2000;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Refactor StickyBottomBanner to use @guardian/libs storage as part of https://github.com/guardian/dotcom-rendering/issues/10052

## Why?
Closes https://github.com/guardian/dotcom-rendering/issues/10055

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
