### PR TITLE
feat: update text for sharing callout

### DIFF
--- a/dotcom-rendering/src/components/Callout/CalloutComponents.tsx
+++ b/dotcom-rendering/src/components/Callout/CalloutComponents.tsx
@@ -180,7 +180,6 @@ export const CalloutShare = ({
 					<SvgShare size="small" />
 				</span>
 				<div css={shareCalloutTextStyles}>
-					Know others who are affected?{' '}
 					<Button
 						size="xsmall"
 						priority="subdued"
@@ -191,7 +190,7 @@ export const CalloutShare = ({
 						}}
 						cssOverrides={shareCalloutLinkStyles}
 					>
-						Please share this callout.
+						Share this callout
 					</Button>
 					{isCopied && (
 						<span css={sharePopupStyles} role="alert">


### PR DESCRIPTION
## What does this change?

Updates the text for sharing callouts to be more generic so that it can apply to many different types of callouts.

## Why?

Resolves #10061

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/43961396/14261293-a473-4539-ae88-7bb32b5a3e87
[after]: https://github.com/guardian/dotcom-rendering/assets/43961396/e4d94a9f-b2ca-4369-8cee-71051a943785

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
