### PR TITLE
Adjust padding on share icon SVG for callouts

### DIFF
--- a/dotcom-rendering/src/components/Callout/CalloutComponents.tsx
+++ b/dotcom-rendering/src/components/Callout/CalloutComponents.tsx
@@ -130,7 +130,7 @@ const shareIconStyles = css`
 
 	box-sizing: border-box;
 	fill: ${palette('--article-link-text')};
-	padding: 0.5px 0;
+	padding: 0 1px 0 0;
 `;
 
 export const CalloutShare = ({


### PR DESCRIPTION
## What does this change?

Adjust padding of share icon on callout

## Why?

@paperboyo spotted it looked slightly wonky

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/43961396/6a60ecaf-68ab-4e02-9cca-0a62d0217cb2
[after]: https://github.com/guardian/dotcom-rendering/assets/43961396/b3a134df-7225-4c9c-9fd4-73c6845b4938

