### PR TITLE
Fix weather component chevron direction

### DIFF
--- a/dotcom-rendering/src/components/Weather.tsx
+++ b/dotcom-rendering/src/components/Weather.tsx
@@ -248,8 +248,13 @@ export const Weather = ({ location, now, forecast, edition }: WeatherProps) => {
 			<div css={[nowCSS, slotCSS]} className="now">
 				<WeatherSlot {...now} edition={edition} />
 				<label htmlFor={checkboxId} className="checkbox-label">
-					<SvgChevronDownSingle size="xsmall"></SvgChevronDownSingle>
+					{/*
+					Ordering matters here!
+					1st SVG is displayed when opened
+					2nd SVG is displayed when collapsed
+					*/}
 					<SvgChevronUpSingle size="xsmall"></SvgChevronUpSingle>
+					<SvgChevronDownSingle size="xsmall"></SvgChevronDownSingle>
 				</label>
 			</div>
 


### PR DESCRIPTION
As a pattern, we use a chevron pointing "down" to indicate a component can be opened. The weather component did not follow this pattern.

Closes #10068

## Screenshots

| State | Before | After |
| - |--------|--------|
| Collapsed | ![Screen Shot 2024-01-05 at 16 59 22](https://github.com/guardian/dotcom-rendering/assets/705427/31427593-c412-4c67-a6d9-47dc125286f3) | ![Screen Shot 2024-01-05 at 16 59 08](https://github.com/guardian/dotcom-rendering/assets/705427/d590f4f5-8a33-47b3-86d5-bf166acbbd58) | 
| Opened | ![Screen Shot 2024-01-05 at 17 00 06](https://github.com/guardian/dotcom-rendering/assets/705427/653e586c-ff3a-4fdc-b76c-dac61dad7112) | ![Screen Shot 2024-01-05 at 17 00 18](https://github.com/guardian/dotcom-rendering/assets/705427/08afde1c-8734-4e70-a09f-45b6def572b6) |