### PR TITLE
Use `RelativeTime` everywhere

### DIFF
--- a/dotcom-rendering/src/components/ArticleLastUpdated.tsx
+++ b/dotcom-rendering/src/components/ArticleLastUpdated.tsx
@@ -1,10 +1,11 @@
 import { css } from '@emotion/react';
-import { ArticleDesign, timeAgo } from '@guardian/libs';
+import { ArticleDesign } from '@guardian/libs';
 import { textSans } from '@guardian/source-foundations';
 import { decidePalette } from '../lib/decidePalette';
 import type { Palette } from '../types/palette';
 import { Island } from './Island';
 import { PulsingDot } from './PulsingDot.importable';
+import { RelativeTime } from './RelativeTime.importable';
 
 const lastUpdatedStyles = (palette: Palette) => css`
 	${textSans.small()}
@@ -25,8 +26,6 @@ type Props = {
 
 export const ArticleLastUpdated = ({ format, lastUpdated }: Props) => {
 	const palette = decidePalette(format);
-	const displayString = timeAgo(lastUpdated);
-	const date = new Date(lastUpdated);
 
 	return (
 		<div css={lastUpdatedStyles(palette)}>
@@ -39,13 +38,9 @@ export const ArticleLastUpdated = ({ format, lastUpdated }: Props) => {
 				</span>
 			)}
 			&nbsp;Updated&nbsp;
-			<time
-				dateTime={date.toString()}
-				data-relativeformat="med"
-				data-gu-marker="liveblog-last-updated"
-			>
-				{displayString}
-			</time>
+			<Island priority="feature" defer={{ until: 'visible' }}>
+				<RelativeTime then={lastUpdated} />
+			</Island>
 		</div>
 	);
 };

--- a/dotcom-rendering/src/components/CricketScoreboard.tsx
+++ b/dotcom-rendering/src/components/CricketScoreboard.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/react';
 import { between, space, textSans, until } from '@guardian/source-foundations';
 import { decidePalette } from '../lib/decidePalette';
 import type { Palette } from '../types/palette';
+import { RelativeTime } from './RelativeTime.importable';
 
 const ALL_OUT_WICKETS = 10;
 
@@ -130,11 +131,10 @@ export const CricketInnings = ({
 
 export const CricketScoreboard = ({ scorecardUrl, match, format }: Props) => {
 	const palette = decidePalette(format);
-	const date = new Date(match.gameDate);
 	return (
 		<div css={containerStyle}>
 			<h2 css={screenReaderOnlyStyle}>
-				<time dateTime={date.toISOString()}>{date.toDateString()}</time>
+				<RelativeTime then={new Date(match.gameDate).getTime()} />
 				{match.competitionName}, {match.venueName}
 			</h2>
 			<table css={tableStyle}>

--- a/dotcom-rendering/src/components/Discussion/Timestamp.tsx
+++ b/dotcom-rendering/src/components/Discussion/Timestamp.tsx
@@ -1,9 +1,7 @@
 import { css } from '@emotion/react';
 import { textSans } from '@guardian/source-foundations';
-import { useState } from 'react';
-import { dateFormatter } from '../../lib/discussionDateFormatter';
-import { useInterval } from '../../lib/useInterval';
 import { palette as schemedPalette } from '../../palette';
+import { RelativeTime } from '../RelativeTime.importable';
 
 type Props = {
 	isoDateTime: string;
@@ -19,12 +17,13 @@ const linkStyles = css`
 	:focus {
 		text-decoration: underline;
 	}
-`;
-const timeStyles = css`
-	${textSans.xxsmall({ fontWeight: 'light' })}
-	min-width: 0.75rem;
-	margin-right: 0.3125rem;
-	white-space: nowrap;
+
+	time {
+		${textSans.xxsmall({ fontWeight: 'light' })}
+		min-width: 0.75rem;
+		margin-right: 0.3125rem;
+		white-space: nowrap;
+	}
 `;
 
 export const Timestamp = ({
@@ -33,12 +32,6 @@ export const Timestamp = ({
 	commentId,
 	onPermalinkClick,
 }: Props) => {
-	const [timeAgo, setTimeAgo] = useState(dateFormatter(isoDateTime));
-
-	useInterval(() => {
-		setTimeAgo(dateFormatter(isoDateTime));
-	}, 15000);
-
 	return (
 		<a
 			href={webUrl}
@@ -50,9 +43,7 @@ export const Timestamp = ({
 			}}
 			rel="nofollow"
 		>
-			<time dateTime={isoDateTime.toString()} css={timeStyles}>
-				{timeAgo}
-			</time>
+			<RelativeTime then={new Date(isoDateTime).getTime()} />
 		</a>
 	);
 };

--- a/dotcom-rendering/src/components/LastUpdated.stories.tsx
+++ b/dotcom-rendering/src/components/LastUpdated.stories.tsx
@@ -6,12 +6,7 @@ export default {
 };
 
 export const Default = () => {
-	return (
-		<LastUpdated
-			lastUpdated={1613763519000}
-			lastUpdatedDisplay="19.38 GMT"
-		/>
-	);
+	return <LastUpdated lastUpdated={1613763519000} />;
 };
 
 Default.storyName = 'Default';

--- a/dotcom-rendering/src/components/LastUpdated.tsx
+++ b/dotcom-rendering/src/components/LastUpdated.tsx
@@ -1,13 +1,8 @@
 import { css } from '@emotion/react';
 import { palette, textSans } from '@guardian/source-foundations';
+import { RelativeTime } from './RelativeTime.importable';
 
-const LastUpdated = ({
-	lastUpdatedDisplay,
-	lastUpdated,
-}: {
-	lastUpdatedDisplay: string;
-	lastUpdated: number;
-}) => {
+const LastUpdated = ({ lastUpdated }: { lastUpdated: number }) => {
 	return (
 		<div
 			css={css`
@@ -17,23 +12,7 @@ const LastUpdated = ({
 				color: ${palette.neutral[46]};
 			`}
 		>
-			<time
-				dateTime={new Date(lastUpdated).toISOString()}
-				title={`Last updated ${new Date(lastUpdated).toLocaleDateString(
-					'en-GB',
-					{
-						hour: '2-digit',
-						minute: '2-digit',
-						weekday: 'long',
-						year: 'numeric',
-						month: 'long',
-						day: 'numeric',
-						timeZoneName: 'long',
-					},
-				)}`}
-			>
-				{`Updated at ${lastUpdatedDisplay}`}
-			</time>
+			Updated <RelativeTime then={lastUpdated}></RelativeTime>
 		</div>
 	);
 };

--- a/dotcom-rendering/src/components/LightboxImages.tsx
+++ b/dotcom-rendering/src/components/LightboxImages.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { log, timeAgo } from '@guardian/libs';
+import { log } from '@guardian/libs';
 import {
 	from,
 	headline,
@@ -16,6 +16,7 @@ import type { ImageForLightbox } from '../types/content';
 import { LightboxCaption } from './LightboxCaption';
 import { LightboxLoader } from './LightboxLoader';
 import { Picture } from './Picture';
+import { RelativeTime } from './RelativeTime.importable';
 
 type Props = {
 	format: ArticleFormat;
@@ -293,21 +294,16 @@ export const LightboxImages = ({ format, images }: Props) => {
 												}
 											`}
 										>
-											<time
-												dateTime={new Date(
-													image.firstPublished,
-												).toISOString()}
-												title="View original post"
+											<span
+												css={css`
+													${visuallyHidden}
+												`}
 											>
-												<span
-													css={css`
-														${visuallyHidden}
-													`}
-												>
-													Original post published{' '}
-												</span>
-												{timeAgo(image.firstPublished)}
-											</time>
+												Original post published{' '}
+											</span>
+											<RelativeTime
+												then={image.firstPublished}
+											/>
 										</Link>
 									)}
 							</aside>

--- a/dotcom-rendering/src/components/LiveBlock.tsx
+++ b/dotcom-rendering/src/components/LiveBlock.tsx
@@ -96,10 +96,7 @@ export const LiveBlock = ({
 				{showLastUpdated &&
 					block.blockLastUpdated !== undefined &&
 					!!block.blockLastUpdatedDisplay && (
-						<LastUpdated
-							lastUpdated={block.blockLastUpdated}
-							lastUpdatedDisplay={block.blockLastUpdatedDisplay}
-						/>
+						<LastUpdated lastUpdated={block.blockLastUpdated} />
 					)}
 			</footer>
 		</LiveBlockContainer>

--- a/dotcom-rendering/src/components/WitnessBlockComponent.tsx
+++ b/dotcom-rendering/src/components/WitnessBlockComponent.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/react';
 import { body, headline, palette, space } from '@guardian/source-foundations';
 import { palette as themePalette } from '../palette';
 import type { WitnessAssetType } from '../types/content';
+import { RelativeTime } from './RelativeTime.importable';
 
 // Wrapper Styles
 const wrapperStyles = css`
@@ -112,9 +113,9 @@ const WitnessWrapper = ({
 								${body.small()}
 							`}
 						>
-							<time itemProp="dateCreated" dateTime={dateCreated}>
-								{new Date(dateCreated).toDateString()}
-							</time>
+							<RelativeTime
+								then={new Date(dateCreated).getTime()}
+							/>
 						</p>
 					</div>
 				</div>


### PR DESCRIPTION
A singular way to display time

## What does this change?

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
