### PR TITLE
Replace imports for deprecated border colours

### DIFF
--- a/dotcom-rendering/src/components/ArticleMeta.tsx
+++ b/dotcom-rendering/src/components/ArticleMeta.tsx
@@ -8,8 +8,8 @@ import {
 } from '@guardian/libs';
 import {
 	between,
-	border,
 	from,
+	palette,
 	space,
 	until,
 } from '@guardian/source-foundations';
@@ -345,7 +345,7 @@ export const ArticleMeta = ({
 						<StraightLines
 							cssOverrides={stretchLines}
 							count={1}
-							color={border.primary}
+							color={palette.neutral[60]}
 						/>
 						<div
 							css={css`

--- a/dotcom-rendering/src/components/Epic.amp.tsx
+++ b/dotcom-rendering/src/components/Epic.amp.tsx
@@ -2,7 +2,6 @@
 import { css } from '@emotion/react';
 import {
 	body,
-	border,
 	brandBackground,
 	headline,
 	palette,
@@ -20,7 +19,7 @@ export const epicChoiceCardCss = `
 		color: ${palette.neutral[46]};
 		cursor: pointer;
 		border-radius: 4px;
-		box-shadow: inset 0 0 0 2px ${border.primary};
+		box-shadow: inset 0 0 0 2px ${palette.neutral[60]};
 		box-sizing: border-box;
 		min-height: 44px;
 		margin: 0 0 8px 0;

--- a/dotcom-rendering/src/components/GuardianLabsLines.tsx
+++ b/dotcom-rendering/src/components/GuardianLabsLines.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { border, space } from '@guardian/source-foundations';
+import { palette, space } from '@guardian/source-foundations';
 import {
 	DottedLines,
 	StraightLines,
@@ -11,12 +11,20 @@ const block = css`
 
 export const GuardianLabsLines = () => (
 	<>
-		<StraightLines cssOverrides={block} count={1} color={border.primary} />
+		<StraightLines
+			cssOverrides={block}
+			count={1}
+			color={palette.neutral[60]}
+		/>
 		<div
 			css={css`
 				height: ${space[2]}px;
 			`}
 		/>
-		<DottedLines cssOverrides={block} count={1} color={border.primary} />
+		<DottedLines
+			cssOverrides={block}
+			count={1}
+			color={palette.neutral[60]}
+		/>
 	</>
 );

--- a/dotcom-rendering/src/components/InlineSkipToWrapper.tsx
+++ b/dotcom-rendering/src/components/InlineSkipToWrapper.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { border, palette, textSans } from '@guardian/source-foundations';
+import { palette, textSans } from '@guardian/source-foundations';
 import type { ReactNode } from 'react';
 
 type Props = {
@@ -24,7 +24,7 @@ const skipLinkCss = css`
 	color: ${palette.neutral[0]};
 	&:focus,
 	&:active {
-		border: 5px solid ${border.focusHalo};
+		border: 5px solid ${palette.focus[400]};
 		position: static;
 	}
 	&:visited,

--- a/dotcom-rendering/src/components/LabsHeader.stories.tsx
+++ b/dotcom-rendering/src/components/LabsHeader.stories.tsx
@@ -1,4 +1,4 @@
-import { border, labs } from '@guardian/source-foundations';
+import { palette } from '@guardian/source-foundations';
 import { LabsHeader } from './LabsHeader';
 import { Section } from './Section';
 
@@ -12,8 +12,8 @@ export const Default = () => {
 		<Section
 			fullWidth={true}
 			showTopBorder={false}
-			backgroundColour={labs[400]}
-			borderColour={border.primary}
+			backgroundColour={palette.labs[400]}
+			borderColour={palette.neutral[60]}
 		>
 			<LabsHeader />
 		</Section>

--- a/dotcom-rendering/src/components/LabsHeader.tsx
+++ b/dotcom-rendering/src/components/LabsHeader.tsx
@@ -1,11 +1,5 @@
 import { css } from '@emotion/react';
-import {
-	border,
-	from,
-	palette,
-	space,
-	textSans,
-} from '@guardian/source-foundations';
+import { from, palette, space, textSans } from '@guardian/source-foundations';
 import {
 	Link,
 	LinkButton,
@@ -58,7 +52,7 @@ const HeaderSection = ({
 }) => (
 	<div
 		css={css`
-			border-right: 1px solid ${border.primary};
+			border-right: 1px solid ${palette.neutral[60]};
 			height: 100%;
 			display: flex;
 			align-items: center;
@@ -91,7 +85,7 @@ const About = () => (
 		css={css`
 			${textSans.small()};
 			background-color: ${palette.labs[400]};
-			border-top: 1px solid ${border.primary};
+			border-top: 1px solid ${palette.neutral[60]};
 
 			width: 100vw;
 			${from.desktop} {

--- a/dotcom-rendering/src/components/SkipTo.tsx
+++ b/dotcom-rendering/src/components/SkipTo.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { border, palette, textSans } from '@guardian/source-foundations';
+import { palette, textSans } from '@guardian/source-foundations';
 import { nestedOphanComponents } from '../lib/ophan-helpers';
 
 type Identifier =
@@ -35,7 +35,7 @@ export const SkipTo = ({ id, label }: Props) => {
 				color: ${palette.neutral[0]};
 				&:focus,
 				&:active {
-					border: 5px solid ${border.focusHalo};
+					border: 5px solid ${palette.focus[400]};
 					position: static;
 				}
 				&:visited,

--- a/dotcom-rendering/src/components/TableBlockComponent.tsx
+++ b/dotcom-rendering/src/components/TableBlockComponent.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { border, palette, text, textSans } from '@guardian/source-foundations';
+import { palette, text, textSans } from '@guardian/source-foundations';
 import { unescapeData } from '../lib/escapeData';
 import type { TableBlockElement } from '../types/content';
 
@@ -7,7 +7,7 @@ const tableEmbed = css`
 	.table--football {
 		width: 100%;
 		background: ${palette.neutral[97]};
-		border-top: 0.0625rem solid ${border.focusHalo};
+		border-top: 0.0625rem solid ${palette.focus[400]};
 		border-collapse: inherit;
 		tr:nth-child(odd) > td {
 			background-color: ${palette.neutral[93]};

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -2,7 +2,6 @@ import { css } from '@emotion/react';
 import { ArticleDisplay } from '@guardian/libs';
 import {
 	background,
-	border,
 	brandBackground,
 	brandBorder,
 	brandLine,
@@ -287,7 +286,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 							fullWidth={true}
 							showTopBorder={false}
 							backgroundColour={sourcePalette.labs[400]}
-							borderColour={border.primary}
+							borderColour={sourcePalette.neutral[60]}
 							sectionId="labs-header"
 						>
 							<LabsHeader />

--- a/dotcom-rendering/src/lib/decidePalette.ts
+++ b/dotcom-rendering/src/lib/decidePalette.ts
@@ -1,7 +1,6 @@
 import type { ArticleFormat } from '@guardian/libs';
 import { ArticleDesign, ArticleSpecial, Pillar } from '@guardian/libs';
 import {
-	border,
 	brandAlt,
 	brandAltBackground,
 	culture,
@@ -292,7 +291,7 @@ const borderStandfirstLink = (format: ArticleFormat): string => {
 	if (format.theme === ArticleSpecial.SpecialReportAlt)
 		return transparentColour(neutral[60], 0.3);
 
-	return border.secondary;
+	return palette.neutral[86];
 };
 
 const borderHeadline = (format: ArticleFormat): string => {
@@ -300,7 +299,7 @@ const borderHeadline = (format: ArticleFormat): string => {
 		return 'rgba(255,255,255, 0.2)';
 	}
 	if (format.design === ArticleDesign.DeadBlog) return '#CDCDCD';
-	return border.secondary;
+	return palette.neutral[86];
 };
 
 const borderCardSupporting = (format: ArticleFormat): string => {

--- a/dotcom-rendering/src/lib/pillars.ts
+++ b/dotcom-rendering/src/lib/pillars.ts
@@ -1,16 +1,6 @@
 import type { ArticleTheme } from '@guardian/libs';
 import { ArticleSpecial, Pillar } from '@guardian/libs';
-import {
-	border,
-	culture,
-	labs,
-	lifestyle,
-	news,
-	opinion,
-	palette,
-	specialReport,
-	sport,
-} from '@guardian/source-foundations';
+import { palette } from '@guardian/source-foundations';
 
 type ColourType = string;
 
@@ -67,82 +57,82 @@ export const pillarPalette_DO_NOT_USE: Record<
 	PillarPalette | SpecialPalette | LabsPalette | SpecialAltPalette
 > = {
 	[Pillar.News]: {
-		dark: news[300],
-		main: news[400],
-		bright: news[500],
-		pastel: news[600],
-		faded: news[800],
-		300: news[300],
-		400: news[400],
-		500: news[500],
-		600: news[600],
-		800: news[800],
+		dark: palette.news[300],
+		main: palette.news[400],
+		bright: palette.news[500],
+		pastel: palette.news[600],
+		faded: palette.news[800],
+		300: palette.news[300],
+		400: palette.news[400],
+		500: palette.news[500],
+		600: palette.news[600],
+		800: palette.news[800],
 	},
 	[Pillar.Opinion]: {
-		dark: opinion[300],
-		main: opinion[300],
-		bright: opinion[500],
-		pastel: opinion[600],
-		faded: opinion[800],
-		300: opinion[300],
-		400: opinion[400],
-		500: opinion[500],
-		600: opinion[600],
-		800: opinion[800],
+		dark: palette.opinion[300],
+		main: palette.opinion[300],
+		bright: palette.opinion[500],
+		pastel: palette.opinion[600],
+		faded: palette.opinion[800],
+		300: palette.opinion[300],
+		400: palette.opinion[400],
+		500: palette.opinion[500],
+		600: palette.opinion[600],
+		800: palette.opinion[800],
 	},
 	[Pillar.Sport]: {
-		dark: sport[300],
-		main: sport[400],
-		bright: sport[500],
-		pastel: sport[600],
-		faded: sport[800],
-		300: sport[300],
-		400: sport[400],
-		500: sport[500],
-		600: sport[600],
-		800: sport[800],
+		dark: palette.sport[300],
+		main: palette.sport[400],
+		bright: palette.sport[500],
+		pastel: palette.sport[600],
+		faded: palette.sport[800],
+		300: palette.sport[300],
+		400: palette.sport[400],
+		500: palette.sport[500],
+		600: palette.sport[600],
+		800: palette.sport[800],
 	},
 	[Pillar.Culture]: {
-		dark: culture[300],
-		main: culture[400],
-		bright: culture[500],
-		pastel: culture[600],
-		faded: culture[800],
-		300: culture[300],
-		400: culture[400],
-		500: culture[500],
-		600: culture[600],
-		800: culture[800],
+		dark: palette.culture[300],
+		main: palette.culture[400],
+		bright: palette.culture[500],
+		pastel: palette.culture[600],
+		faded: palette.culture[800],
+		300: palette.culture[300],
+		400: palette.culture[400],
+		500: palette.culture[500],
+		600: palette.culture[600],
+		800: palette.culture[800],
 	},
 	[Pillar.Lifestyle]: {
-		dark: lifestyle[300],
-		main: lifestyle[400],
-		bright: lifestyle[500],
-		pastel: lifestyle[600],
-		faded: lifestyle[800],
-		300: lifestyle[300],
-		400: lifestyle[400],
-		500: lifestyle[500],
-		600: lifestyle[600],
-		800: lifestyle[800],
+		dark: palette.lifestyle[300],
+		main: palette.lifestyle[400],
+		bright: palette.lifestyle[500],
+		pastel: palette.lifestyle[600],
+		faded: palette.lifestyle[800],
+		300: palette.lifestyle[300],
+		400: palette.lifestyle[400],
+		500: palette.lifestyle[500],
+		600: palette.lifestyle[600],
+		800: palette.lifestyle[800],
 	},
 	[ArticleSpecial.Labs]: {
-		dark: labs[300],
-		main: labs[400],
-		bright: labs[400], // bright teal
-		faded: labs[300], // dark teal
-		300: labs[300],
-		400: labs[400],
+		dark: palette.labs[300],
+		main: palette.labs[400],
+		bright: palette.labs[400], // bright teal
+		faded: palette.labs[300], // dark teal
+		300: palette.labs[300],
+		400: palette.labs[400],
 	},
 	[ArticleSpecial.SpecialReport]: {
-		dark: specialReport[300],
-		main: specialReport[400],
-		bright: specialReport[500],
-		faded: specialReport[800],
-		300: specialReport[300],
-		400: specialReport[400],
-		500: specialReport[500],
-		800: specialReport[800],
+		dark: palette.specialReport[300],
+		main: palette.specialReport[400],
+		bright: palette.specialReport[500],
+		faded: palette.specialReport[800],
+		300: palette.specialReport[300],
+		400: palette.specialReport[400],
+		500: palette.specialReport[500],
+		800: palette.specialReport[800],
 	},
 	[ArticleSpecial.SpecialReportAlt]: {
 		dark: palette.specialReportAlt[100],
@@ -184,8 +174,8 @@ Further notes on this function:
 export const neutralBorder = (pillar: ArticleTheme): ColourType => {
 	switch (pillar) {
 		case ArticleSpecial.Labs:
-			return border.primary; // 'dark' theme
+			return palette.neutral[60]; // 'dark' theme
 		default:
-			return border.secondary;
+			return palette.neutral[86];
 	}
 };


### PR DESCRIPTION
## What does this change?

In `dotcom-rendering`, stops using `border` directly from source and uses colours available within the `palette` object instead.

Additionally updates `pillar` file to use `palette` colours.

## Why?

[Using `border` directly is deprecated](https://github.com/guardian/csnx/blob/c750f01faab412a24d82e5bead94132ab35af8f8/libs/%40guardian/source-foundations/src/colour/palette.ts#L88-L107)
