### PR TITLE
Stop main media competing for the same space as article meta for showcase display

### DIFF
--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -87,10 +87,10 @@ const ShowcaseGrid = ({ children }: { children: React.ReactNode }) => (
 					grid-template-columns: 219px 1px 1fr 300px;
 					grid-template-areas:
 						'title  border  headline    headline'
-						'lines  border  media       media'
-						'meta   border  media       media'
+						'.      border  media       media'
+						'lines  border  standfirst  right-column'
 						'meta   border  standfirst  right-column'
-						'meta   border  disclaimer  right-column'
+						'.      border  disclaimer  right-column'
 						'.      border  body        right-column'
 						'.      border  .           right-column';
 				}
@@ -99,10 +99,10 @@ const ShowcaseGrid = ({ children }: { children: React.ReactNode }) => (
 					grid-template-columns: 140px 1px 1fr 300px;
 					grid-template-areas:
 						'title  border  headline    headline'
-						'lines  border  media       media'
-						'meta   border  media       media'
+						'.      border  media       media'
+						'lines  border  standfirst  right-column'
 						'meta   border  standfirst  right-column'
-						'meta   border  disclaimer  right-column'
+						'.      border  disclaimer  right-column'
 						'.      border  body        right-column'
 						'.      border  .           right-column';
 				}


### PR DESCRIPTION
## What does this change?

For Showcase layout from `leftCol` (1140px) width, updates the grid template areas so that the main `media` and `meta` grid items do not compete for the same space on the page.

## Why?

It was causing visual bugs. Fixes #10073 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |
| ![before2][] | ![after2][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/43961396/27539605-4b57-4b8d-b43d-ee9e679e2d9f
[after]: https://github.com/guardian/dotcom-rendering/assets/43961396/48e087bd-0aab-4b96-8a8f-7c3ef7d7236f

[before2]: https://github.com/guardian/dotcom-rendering/assets/43961396/e4e801a3-4e77-4375-a2d9-a1ae931a78a6
[after2]: https://github.com/guardian/dotcom-rendering/assets/43961396/52a37c53-441e-4b72-b102-23cc0e179eb1
