### PR TITLE
Show `YoutubeAtom` placeholder reliably

### DIFF
--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.tsx
@@ -132,7 +132,7 @@ export const YoutubeAtom = ({
 	 *
 	 * - The player is not ready
 	 */
-	const showPlaceholder = (!hasOverlay ?? overlayClicked) && !playerReady;
+	const showPlaceholder = (!hasOverlay || overlayClicked) && !playerReady;
 
 	let loadPlayer;
 	if (!hasOverlay) {


### PR DESCRIPTION
## What does this change?

Fix a bug that prevents the placeholder from showing reliably

## Why?

`hasOverlay` is always a boolean & never nullish

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/76776/ff8b541e-f902-4d49-8d96-1e093839b4e3
[after]: https://github.com/guardian/dotcom-rendering/assets/76776/a3d82f27-0bd1-435a-b0e8-12f9141ee25d

