### PR TITLE
Revert "Stop main media competing for the same space as article meta for showcase display"

### DIFF
--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -87,10 +87,10 @@ const ShowcaseGrid = ({ children }: { children: React.ReactNode }) => (
 					grid-template-columns: 219px 1px 1fr 300px;
 					grid-template-areas:
 						'title  border  headline    headline'
-						'.      border  media       media'
-						'lines  border  standfirst  right-column'
+						'lines  border  media       media'
+						'meta   border  media       media'
 						'meta   border  standfirst  right-column'
-						'.      border  disclaimer  right-column'
+						'meta   border  disclaimer  right-column'
 						'.      border  body        right-column'
 						'.      border  .           right-column';
 				}
@@ -99,10 +99,10 @@ const ShowcaseGrid = ({ children }: { children: React.ReactNode }) => (
 					grid-template-columns: 140px 1px 1fr 300px;
 					grid-template-areas:
 						'title  border  headline    headline'
-						'.      border  media       media'
-						'lines  border  standfirst  right-column'
+						'lines  border  media       media'
+						'meta   border  media       media'
 						'meta   border  standfirst  right-column'
-						'.      border  disclaimer  right-column'
+						'meta   border  disclaimer  right-column'
 						'.      border  body        right-column'
 						'.      border  .           right-column';
 				}


### PR DESCRIPTION
Reverts guardian/dotcom-rendering#10076