### PR TITLE
Enable Lightbox when in test

### DIFF
--- a/dotcom-rendering/src/components/ArticlePage.tsx
+++ b/dotcom-rendering/src/components/ArticlePage.tsx
@@ -58,6 +58,10 @@ export const ArticlePage = (props: WebProps | AppProps) => {
 		adUnit: article.config.adUnit,
 	});
 
+	const lightboxEnabled =
+		!!article.config.switches.lightbox ||
+		article.config.abTests.lightboxVariant === 'variant';
+
 	return (
 		<StrictMode>
 			<Global
@@ -94,7 +98,7 @@ export const ArticlePage = (props: WebProps | AppProps) => {
 			/>
 			<SkipTo id="maincontent" label="Skip to main content" />
 			<SkipTo id="navigation" label="Skip to navigation" />
-			{article.config.switches.lightbox && article.imagesForLightbox && (
+			{lightboxEnabled && article.imagesForLightbox.length > 0 && (
 				<>
 					<LightboxLayout
 						imageCount={article.imagesForLightbox.length}

--- a/dotcom-rendering/src/types/frontend.ts
+++ b/dotcom-rendering/src/types/frontend.ts
@@ -125,7 +125,7 @@ export interface FEArticleType {
  * receiving the data from Frontend.
  */
 export type DCRArticle = FEArticleType & {
-	imagesForLightbox?: ImageForLightbox[];
+	imagesForLightbox: ImageForLightbox[];
 	imagesForAppsLightbox: ImageForAppsLightbox[];
 	tableOfContents?: TableOfContentsItem[];
 };


### PR DESCRIPTION
## What does this change?

Enable Lightbox for users in the server-side test variant.

## Why?

We have had [a 0% test running for a long time](https://github.com/guardian/frontend/blob/7a03596e7d4b2c2d8a83665e2479952a2fec5ea3/common/app/experiments/Experiments.scala#L31-L38), but it will now be pushed to 5%:
- https://github.com/guardian/frontend/pull/26797

Since #10066 we are confident in maintaining this feature

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/76776/92dda897-4cbf-49ac-9c47-b96dcba5648d
[after]: https://github.com/guardian/dotcom-rendering/assets/76776/955b89a6-0a82-47ae-93ea-5b71f2ca1e22
