### PR TITLE
Reduce ASG size to 24 instances

### DIFF
--- a/dotcom-rendering/cdk/bin/cdk.ts
+++ b/dotcom-rendering/cdk/bin/cdk.ts
@@ -15,7 +15,7 @@ new DotcomRendering(cdkApp, 'DotcomRendering-PROD', {
 	...sharedProps,
 	app: 'rendering',
 	stage: 'PROD',
-	minCapacity: 27,
+	minCapacity: 24,
 	maxCapacity: 120,
 	instanceType: 't4g.small',
 });


### PR DESCRIPTION
We have not seen any problems with 27 and so a further reduction might be possible. After merging, monitor latency and CPU utilisation Cloudwatch and Grafana.