### PR TITLE
Ab/fronts

### DIFF
--- a/dotcom-rendering/src/components/LiveUpdateToast.importable.tsx
+++ b/dotcom-rendering/src/components/LiveUpdateToast.importable.tsx
@@ -1,0 +1,156 @@
+import { css } from '@emotion/react';
+import { space } from '@guardian/source-foundations';
+import { Hide } from '@guardian/source-react-components';
+import { EditorialButton } from '@guardian/source-react-components-development-kitchen';
+import { useCallback, useEffect, useState } from 'react';
+import ReactDOM from 'react-dom';
+import { isServer } from '../lib/isServer';
+
+type ToastProps = {
+	count: number;
+	onClick: () => void;
+	format: ArticleFormat;
+};
+
+/** This icon will be added to Source at a subsequent time */
+const SvgReload = ({ size }: { size: 12 | 16 | 18 | 24 | 26 | 28 | 30 }) => {
+	const tight = size <= 24;
+	const padding = tight ? 0 : (size - 24) / 2;
+	return (
+		<svg
+			viewBox={
+				tight ? '0 0 24 24' : `-${padding} -${padding} ${size} ${size}`
+			}
+			width={size}
+			height={size}
+		>
+			<path d="M11.588 1a10.928 10.928 0 0 0-9.046 4.786l.126.676.877.527.676-.176C5.85 4.508 8.506 2.98 11.588 2.98c4.936 0 8.995 4.059 8.995 9.045 0 4.961-4.059 8.995-8.995 8.995-2.832 0-5.262-1.252-6.94-3.257l3.632-.601v-1.253H1.866l-.476.476V23h1.227l.627-3.784C5.248 21.546 8.205 23 11.588 23c6.089 0 11.025-4.911 11.025-10.975A11.01 11.01 0 0 0 11.588 1Z" />
+		</svg>
+	);
+};
+
+/**
+ * A button to scroll to the top when new content exists.
+ *
+ * This element is rendered using a Portal into the `toast-root` div. This
+ * root div has position: sticky
+ */
+export const Toast = ({ count, onClick, format }: ToastProps) => {
+	return (
+		<div
+			css={css`
+				position: absolute;
+				top: ${space[2]}px;
+			`}
+			data-cy="toast"
+		>
+			<Hide above="phablet">
+				<EditorialButton
+					size="xsmall" // <-- Mobile version is xsmall
+					onClick={onClick}
+					format={format}
+					icon={<SvgReload size={30} />}
+				>
+					{' '}
+					new updates available
+				</EditorialButton>
+			</Hide>
+			<Hide below="phablet">
+				<EditorialButton
+					size="small" // <-- Desktop version is small
+					onClick={onClick}
+					format={format}
+					icon={<SvgReload size={30} />}
+				>
+					new updates available
+				</EditorialButton>
+			</Hide>
+		</div>
+	);
+};
+
+type Props = {
+	format: ArticleFormat;
+	webURL: string;
+	channel: string;
+};
+
+const toastRoot: Element | null = !isServer
+	? window.document.getElementById('toast-root')
+	: null;
+
+export const LiveUpdateToast = ({ format, webURL, channel }: Props) => {
+	const [showToast, setShowToast] = useState(false);
+	console.log('WEBSOCKET', channel);
+
+	useEffect(() => {
+		console.log('WEBSOCKET::: inside use effect');
+		const socket = new WebSocket(
+			`wss://gu-fanout.edgecompute.app/${channel}`,
+		);
+
+		// WebSocket event listeners
+		socket.onopen = (e) => {
+			console.log('WebSocket connection established.', e);
+		};
+
+		socket.onmessage = (event) => {
+			console.log('WEBSOCKET::: Received message:', event.data);
+			setShowToast(true);
+		};
+
+		socket.onclose = (event) => {
+			if (event.wasClean) {
+				console.log(
+					`WebSocket connection closed cleanly, code=${event.code}, reason=${event.reason}`,
+				);
+			} else {
+				console.error('WebSocket connection died');
+			}
+		};
+
+		return () => {
+			// Cleanup when the component unmounts
+			socket.close();
+		};
+	}, []);
+
+	const handleToastClick = useCallback(() => {
+		const placeToScrollTo = 'maincontent';
+		setShowToast(false);
+
+		document.getElementById(placeToScrollTo)?.scrollIntoView({
+			behavior: 'smooth',
+		});
+
+		// window.history.replaceState({}, '', `#${placeToScrollTo}`);
+		// } else {
+		window.location.href = `${webURL}#${placeToScrollTo}`;
+		// }
+	}, [webURL]);
+
+	if (toastRoot && showToast) {
+		/**
+		 * Why `createPortal`?
+		 *
+		 * We use a Portal because of a the way different browsers implement `position: sticky`.
+		 * A [stickily positioned element][] depends on its [containing block][] to determine
+		 * when to become stuck.
+		 *
+		 * In Safari the containing block is set to the immediate parent
+		 * whereas Chrome, Firefox and other browser are more forgiving.
+		 *
+		 * By using a Portal we can insert the Toast as a sibling to the Island, which works around
+		 * Safari's behaviour.
+		 *
+		 * [stickily positioned element]: https://developer.mozilla.org/en-US/docs/Web/CSS/position#types_of_positioning
+		 * [containing block]: https://developer.mozilla.org/en-US/docs/Web/CSS/Containing_block#identifying_the_containing_block
+		 */
+		return ReactDOM.createPortal(
+			<Toast onClick={handleToastClick} count={0} format={format} />,
+			toastRoot,
+		);
+	}
+
+	return null;
+};

--- a/dotcom-rendering/src/components/LiveUpdateToast.importable.tsx
+++ b/dotcom-rendering/src/components/LiveUpdateToast.importable.tsx
@@ -113,7 +113,7 @@ export const LiveUpdateToast = ({ format, webURL, channel }: Props) => {
 			// Cleanup when the component unmounts
 			socket.close();
 		};
-	}, []);
+	}, [channel]);
 
 	const handleToastClick = useCallback(() => {
 		const placeToScrollTo = 'maincontent';

--- a/dotcom-rendering/src/components/LiveUpdateToast.importable.tsx
+++ b/dotcom-rendering/src/components/LiveUpdateToast.importable.tsx
@@ -76,7 +76,7 @@ type Props = {
 };
 
 const toastRoot: Element | null = !isServer
-	? window.document.getElementById('toast-root')
+	? window.document.getElementById('fronts-toast-root')
 	: null;
 
 export const LiveUpdateToast = ({ format, webURL, channel }: Props) => {
@@ -116,17 +116,18 @@ export const LiveUpdateToast = ({ format, webURL, channel }: Props) => {
 	}, [channel]);
 
 	const handleToastClick = useCallback(() => {
-		const placeToScrollTo = 'maincontent';
-		setShowToast(false);
+		window.stop();
+		window.location.reload();
 
-		document.getElementById(placeToScrollTo)?.scrollIntoView({
-			behavior: 'smooth',
-		});
-
-		// window.history.replaceState({}, '', `#${placeToScrollTo}`);
-		// } else {
-		window.location.href = `${webURL}#${placeToScrollTo}`;
-		// }
+		// const placeToScrollTo = 'maincontent';
+		// setShowToast(false);
+		// document.getElementById(placeToScrollTo)?.scrollIntoView({
+		// 	behavior: 'smooth',
+		// });
+		// // window.history.replaceState({}, '', `#${placeToScrollTo}`);
+		// // } else {
+		// window.location.href = `${webURL}#${placeToScrollTo}`;
+		// // }
 	}, [webURL]);
 
 	if (toastRoot && showToast) {

--- a/dotcom-rendering/src/components/LiveUpdateToast.importable.tsx
+++ b/dotcom-rendering/src/components/LiveUpdateToast.importable.tsx
@@ -128,7 +128,8 @@ export const LiveUpdateToast = ({ format, webURL, channel }: Props) => {
 		// // } else {
 		// window.location.href = `${webURL}#${placeToScrollTo}`;
 		// // }
-	}, [webURL]);
+		// }, [webURL]);
+	}, []);
 
 	if (toastRoot && showToast) {
 		/**

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -10,13 +10,13 @@ import {
 import { StraightLines } from '@guardian/source-react-components-development-kitchen';
 import { Fragment } from 'react';
 import { AdSlot } from '../components/AdSlot.web';
-import { CPScottHeader } from '../components/CPScottHeader';
 import { Carousel } from '../components/Carousel.importable';
+import { CPScottHeader } from '../components/CPScottHeader';
 import { DecideContainer } from '../components/DecideContainer';
 import {
 	decideFrontsBannerAdSlot,
-	decideMerchHighAndMobileAdSlots,
 	decideMerchandisingSlot,
+	decideMerchHighAndMobileAdSlots,
 } from '../components/DecideFrontsAdSlots';
 import { Footer } from '../components/Footer';
 import { FrontMostViewed } from '../components/FrontMostViewed';

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -176,7 +176,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 			</Island>
 			{/* The Toast component is inserted into this div using a Portal */}
 			<div
-				id="toast-root"
+				id="fronts-toast-root"
 				css={css`
 					position: sticky;
 					top: 0;

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { ArticleDisplay } from '@guardian/libs';
+import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
 import {
 	background,
 	brandBackground,
@@ -10,13 +10,13 @@ import {
 import { StraightLines } from '@guardian/source-react-components-development-kitchen';
 import { Fragment } from 'react';
 import { AdSlot } from '../components/AdSlot.web';
-import { Carousel } from '../components/Carousel.importable';
 import { CPScottHeader } from '../components/CPScottHeader';
+import { Carousel } from '../components/Carousel.importable';
 import { DecideContainer } from '../components/DecideContainer';
 import {
 	decideFrontsBannerAdSlot,
-	decideMerchandisingSlot,
 	decideMerchHighAndMobileAdSlots,
+	decideMerchandisingSlot,
 } from '../components/DecideFrontsAdSlots';
 import { Footer } from '../components/Footer';
 import { FrontMostViewed } from '../components/FrontMostViewed';
@@ -26,6 +26,7 @@ import { HeaderAdSlot } from '../components/HeaderAdSlot';
 import { Island } from '../components/Island';
 import { LabsHeader } from '../components/LabsHeader';
 import { LabsSection } from '../components/LabsSection';
+import { LiveUpdateToast } from '../components/LiveUpdateToast.importable';
 import { Nav } from '../components/Nav/Nav';
 import { Section } from '../components/Section';
 import { Snap } from '../components/Snap';
@@ -42,6 +43,7 @@ import {
 	getFrontsBannerAdPositions,
 	getMobileAdPositions,
 } from '../lib/getFrontsAdPositions';
+import { getZIndex } from '../lib/getZIndex';
 import { hideAge } from '../lib/hideAge';
 import type { NavType } from '../model/extract-nav';
 import type { DCRCollectionType, DCRFrontType } from '../types/front';
@@ -158,9 +160,31 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 		front.deeplyRead.length > 0;
 
 	const contributionsServiceUrl = getContributionsServiceUrl(front);
-
+	console.log('pressed page id ====', front.pressedPage.id);
 	return (
 		<>
+			<Island priority="critical">
+				<LiveUpdateToast
+					format={{
+						design: ArticleDesign.Standard,
+						theme: Pillar.News,
+						display: ArticleDisplay.Standard,
+					}}
+					webURL={''}
+					channel={front.pressedPage.id}
+				/>
+			</Island>
+			{/* The Toast component is inserted into this div using a Portal */}
+			<div
+				id="toast-root"
+				css={css`
+					position: sticky;
+					top: 0;
+					${getZIndex('toast')};
+					display: flex;
+					justify-content: center;
+				`}
+			/>
 			<div data-print-layout="hide" id="bannerandheader">
 				<>
 					{renderAds && (
@@ -697,7 +721,6 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 					</Island>
 				</Section>
 			)}
-
 			<Section
 				fullWidth={true}
 				data-print-layout="hide"
@@ -717,7 +740,6 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 					contributionsServiceUrl={contributionsServiceUrl}
 				/>
 			</Section>
-
 			<BannerWrapper data-print-layout="hide">
 				<Island priority="feature" defer={{ until: 'idle' }}>
 					<StickyBottomBanner

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -46,6 +46,7 @@ export interface DCRFrontType {
 	deeplyRead?: TrailType[];
 	trendingTopics?: FETagType[];
 	contributionsServiceUrl: string;
+	webURL: string;
 }
 
 interface FEPressedPageType {


### PR DESCRIPTION
## What does this change?

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
