### PR TITLE
Request lightbox fullscreen earlier

### DIFF
--- a/dotcom-rendering/playwright/tests/parallel-2/lightbox.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/parallel-2/lightbox.e2e.spec.ts
@@ -194,6 +194,7 @@ test.describe('Lightbox', () => {
 
 		// We should be able to navigate using arrow keys
 		await page.locator('button.open-lightbox').nth(1).click();
+		await expectToBeVisible(page, '#gu-lightbox');
 		await expectToNotBeInViewport(page, 'li[data-index="3"]');
 		await page.keyboard.press('ArrowRight');
 		await expectToBeInViewport(page, 'li[data-index="3"]');
@@ -272,6 +273,7 @@ test.describe('Lightbox', () => {
 
 		// eq(6) here means the 7th button is clicked (base zero)
 		await page.locator('button.open-lightbox').nth(6).click();
+		await expectToBeVisible(page, '#gu-lightbox');
 
 		// We validate that adjacent images get downloaded early by checking the
 		// value of the `loading` attribute
@@ -313,21 +315,26 @@ test.describe('Lightbox', () => {
 		});
 
 		await page.locator('button.open-lightbox').nth(1).click();
+		await expectToBeVisible(page, '#gu-lightbox');
 		await expectToBeVisible(page, 'li[data-index="2"] aside');
 
 		// Clicking an image toggles the caption
 		await page.locator('li[data-index="2"] img').click();
+		await expectToBeVisible(page, '#gu-lightbox');
 		await expectToNotBeVisible(page, 'li[data-index="2"] aside');
 
 		// Close lightbox
 		await page.keyboard.press('Escape');
+		await expectToNotBeVisible(page, '#gu-lightbox');
 
 		// Re-open lightbox to see if the info aside element is now open
 		await page.locator('button.open-lightbox').nth(1).click();
+		await expectToBeVisible(page, '#gu-lightbox');
 		await expectToNotBeVisible(page, 'li[data-index="2"] aside');
 
 		// Close lightbox
 		await page.keyboard.press('Escape');
+		await expectToNotBeVisible(page, '#gu-lightbox');
 
 		// Reload the page to see if my preference for having the caption hidden
 		// has been preserved
@@ -340,6 +347,7 @@ test.describe('Lightbox', () => {
 		// caption is again showing by default
 		await page.keyboard.press('i');
 		await page.reload();
+		await expectToBeVisible(page, '#gu-lightbox');
 		// TODO: this assertion is failing because the lightbox reopens on page reload
 		// double check this is the required behaviour and the test assertion is incorrect
 		// await page.locator('button.open-lightbox').nth(1).click();
@@ -358,6 +366,7 @@ test.describe('Lightbox', () => {
 		});
 
 		await page.locator('button.open-lightbox').nth(1).click();
+		await expectToBeVisible(page, '#gu-lightbox');
 		await expectToBeVisible(page, 'li[data-index="2"] img');
 
 		// Scroll the 5th image into view
@@ -434,6 +443,7 @@ test.describe('Lightbox', () => {
 		});
 
 		await page.locator('button.open-lightbox').nth(1).click();
+		await expectToBeVisible(page, '#gu-lightbox');
 		await expect(
 			page.locator('nav [data-testid="lightbox-selected"]'),
 		).toContainText('2/23');
@@ -469,6 +479,7 @@ test.describe('Lightbox', () => {
 		await expectToNotBeVisible(page, '#gu-lightbox');
 		// Open lightbox using the second button on the page (the first is main media)
 		await page.locator('button.open-lightbox').nth(1).click();
+		await expectToBeVisible(page, '#gu-lightbox');
 		await expect(
 			page.locator('nav [data-testid="lightbox-selected"]'),
 		).toContainText('2/23');

--- a/dotcom-rendering/src/components/LightboxJavascript.importable.tsx
+++ b/dotcom-rendering/src/components/LightboxJavascript.importable.tsx
@@ -58,15 +58,28 @@ const getTabbableElements = (
 	}
 };
 
+/** Reject a Promise after a delay (defaults to 120ms)  */
+const timeout = <T,>(promise: Promise<T>, delay = 120) =>
+	Promise.race([
+		promise,
+		new Promise<void>((_, reject) => {
+			const timer = setTimeout(() => {
+				reject();
+				clearTimeout(timer);
+			}, delay);
+		}),
+	]);
+
+/** will try to request fullscreen, but not wait more than 120ms */
 const requestFullscreen = async (lightbox: Element) => {
 	if (screenfull.isEnabled) {
-		return screenfull.request(lightbox);
+		return timeout(screenfull.request(lightbox));
 	}
 };
 
 const exitFullscreen = async () => {
 	if (screenfull.isEnabled && screenfull.isFullscreen) {
-		return screenfull.exit();
+		return timeout(screenfull.exit());
 	}
 };
 
@@ -105,6 +118,7 @@ const scrollTo = (
 ): void => {
 	// liWidth is the actual dom width in pixels of the containing li element for each image
 	const liWidth = lightbox.querySelector('li')?.clientWidth;
+
 	if (isUndefined(liWidth)) return;
 	switch (position) {
 		case 0:
@@ -199,6 +213,10 @@ const open = async (
 	log('dotcom', '💡 Opening lightbox.');
 	// Remember where we were so we can restore focus
 	if (document.activeElement) previouslyFocused = document.activeElement;
+	// Try to open the lightbox in fullscreen mode. This may fail
+	await requestFullscreen(lightbox).catch(() => {
+		// fullscreen request failed
+	});
 	// We use this class to prevent the main page from scrolling in the background while lightbox is open
 	document.documentElement.classList.add('lightbox-open');
 	// Show lightbox
@@ -208,12 +226,6 @@ const open = async (
 	scrollTo(position, lightbox, imageList);
 	// We only want this listener active while the lightbox is open
 	window.addEventListener('keydown', handleKeydown);
-	// Try to open the lightbox in fullscreen mode. This may fail
-	try {
-		await requestFullscreen(lightbox);
-	} catch {
-		// Do nothing, requests to open fullscreen are just requests and can fail
-	}
 };
 
 const closeLightbox = (
@@ -233,7 +245,9 @@ const close = async (
 	handleKeydown: (ev: KeyboardEvent) => void,
 ) => {
 	log('dotcom', '💡 Closing lightbox.');
-	await exitFullscreen();
+	await exitFullscreen().catch(() => {
+		// fullscreen request failed
+	});
 	closeLightbox(lightbox, handleKeydown);
 	history.back();
 	previouslyFocused && restoreFocus(previouslyFocused);


### PR DESCRIPTION
## What does this change?

Do not scroll to the current image until fullscreen is requested

Add checks for opening and closing the lightbox as it is an asynchronous function and we do not want the test to proceed until they complete.

## Why?

When the width of the window is different to the width of the screen, the position is mismatched

Part of #10102 

## Screenshots

N/A – but @georgeblahblah has a repro video