### PR TITLE
Only show Lightbox on web & in test variant

### DIFF
--- a/dotcom-rendering/playwright/tests/parallel-2/lightbox.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/parallel-2/lightbox.e2e.spec.ts
@@ -78,8 +78,10 @@ test.describe('Lightbox', () => {
 	}) => {
 		await disableCMP(context);
 		await loadPageWithOverrides(page, photoEssayArticle, {
-			switchOverrides: {
-				lightbox: true,
+			configOverrides: {
+				abTests: {
+					lightboxVariant: 'variant',
+				},
 			},
 		});
 
@@ -103,8 +105,10 @@ test.describe('Lightbox', () => {
 	}) => {
 		await disableCMP(context);
 		await loadPageWithOverrides(page, photoEssayArticle, {
-			switchOverrides: {
-				lightbox: true,
+			configOverrides: {
+				abTests: {
+					lightboxVariant: 'variant',
+				},
 			},
 		});
 
@@ -125,8 +129,10 @@ test.describe('Lightbox', () => {
 	test('should trap focus', async ({ context, page }) => {
 		await disableCMP(context);
 		await loadPageWithOverrides(page, photoEssayArticle, {
-			switchOverrides: {
-				lightbox: true,
+			configOverrides: {
+				abTests: {
+					lightboxVariant: 'variant',
+				},
 			},
 		});
 
@@ -174,8 +180,10 @@ test.describe('Lightbox', () => {
 	}) => {
 		await disableCMP(context);
 		await loadPageWithOverrides(page, photoEssayArticle, {
-			switchOverrides: {
-				lightbox: true,
+			configOverrides: {
+				abTests: {
+					lightboxVariant: 'variant',
+				},
 			},
 		});
 
@@ -265,8 +273,10 @@ test.describe('Lightbox', () => {
 
 		await disableCMP(context);
 		await loadPageWithOverrides(page, photoEssayArticle, {
-			switchOverrides: {
-				lightbox: true,
+			configOverrides: {
+				abTests: {
+					lightboxVariant: 'variant',
+				},
 			},
 		});
 
@@ -307,8 +317,10 @@ test.describe('Lightbox', () => {
 	}) => {
 		await disableCMP(context);
 		await loadPageWithOverrides(page, photoEssayArticle, {
-			switchOverrides: {
-				lightbox: true,
+			configOverrides: {
+				abTests: {
+					lightboxVariant: 'variant',
+				},
 			},
 		});
 
@@ -352,8 +364,10 @@ test.describe('Lightbox', () => {
 	}) => {
 		await disableCMP(context);
 		await loadPageWithOverrides(page, photoEssayArticle, {
-			switchOverrides: {
-				lightbox: true,
+			configOverrides: {
+				abTests: {
+					lightboxVariant: 'variant',
+				},
 			},
 		});
 
@@ -397,8 +411,10 @@ test.describe('Lightbox', () => {
 	}) => {
 		await disableCMP(context);
 		await loadPageWithOverrides(page, LiveBlog, {
-			switchOverrides: {
-				lightbox: true,
+			configOverrides: {
+				abTests: {
+					lightboxVariant: 'variant',
+				},
 			},
 		});
 
@@ -428,8 +444,10 @@ test.describe('Lightbox', () => {
 	}) => {
 		await disableCMP(context);
 		await loadPageWithOverrides(page, photoEssayArticle, {
-			switchOverrides: {
-				lightbox: true,
+			configOverrides: {
+				abTests: {
+					lightboxVariant: 'variant',
+				},
 			},
 		});
 
@@ -461,8 +479,10 @@ test.describe('Lightbox', () => {
 	}) => {
 		await disableCMP(context);
 		await loadPageWithOverrides(page, photoEssayArticle, {
-			switchOverrides: {
-				lightbox: true,
+			configOverrides: {
+				abTests: {
+					lightboxVariant: 'variant',
+				},
 			},
 		});
 

--- a/dotcom-rendering/src/components/ArticleBody.tsx
+++ b/dotcom-rendering/src/components/ArticleBody.tsx
@@ -39,7 +39,7 @@ type Props = {
 	filterKeyEvents?: boolean;
 	availableTopics?: Topic[];
 	selectedTopics?: Topic[];
-	abTests?: ServerSideTests;
+	abTests: ServerSideTests;
 	tableOfContents?: TableOfContentsItem[];
 	lang?: string;
 	isRightToLeftLang?: boolean;
@@ -165,6 +165,7 @@ export const ArticleBody = ({
 					webTitle={webTitle}
 					ajaxUrl={ajaxUrl}
 					switches={switches}
+					abTests={abTests}
 					isAdFreeUser={isAdFreeUser}
 					isSensitive={isSensitive}
 					isLiveUpdate={false}

--- a/dotcom-rendering/src/components/ArticleHeadline.stories.tsx
+++ b/dotcom-rendering/src/components/ArticleHeadline.stories.tsx
@@ -113,6 +113,7 @@ export const ShowcaseInterview: StoryObj = ({ format }: StoryArgs) => {
 						isAdFreeUser={false}
 						isSensitive={false}
 						switches={{}}
+						abTests={{}}
 					/>
 				</ArticleContainer>
 			</Flex>
@@ -158,6 +159,7 @@ export const ShowcaseInterviewNobyline: StoryObj = ({ format }: StoryArgs) => {
 						isAdFreeUser={false}
 						isSensitive={false}
 						switches={{}}
+						abTests={{}}
 					/>
 				</ArticleContainer>
 			</Flex>
@@ -201,6 +203,7 @@ export const Interview: StoryObj = ({ format }: StoryArgs) => {
 						isAdFreeUser={false}
 						isSensitive={false}
 						switches={{}}
+						abTests={{}}
 					/>
 				</ArticleContainer>
 			</Flex>
@@ -244,6 +247,7 @@ export const InterviewSpecialReport: StoryObj = ({ format }: StoryArgs) => {
 						isAdFreeUser={false}
 						isSensitive={false}
 						switches={{}}
+						abTests={{}}
 					/>
 				</ArticleContainer>
 			</Flex>
@@ -288,6 +292,7 @@ export const InterviewNoByline: StoryObj = ({ format }: StoryArgs) => {
 						isAdFreeUser={false}
 						isSensitive={false}
 						switches={{}}
+						abTests={{}}
 					/>
 				</ArticleContainer>
 			</Flex>

--- a/dotcom-rendering/src/components/ArticlePage.tsx
+++ b/dotcom-rendering/src/components/ArticlePage.tsx
@@ -58,9 +58,9 @@ export const ArticlePage = (props: WebProps | AppProps) => {
 		adUnit: article.config.adUnit,
 	});
 
-	const lightboxEnabled =
-		!!article.config.switches.lightbox ||
+	const isInLightboxTest =
 		article.config.abTests.lightboxVariant === 'variant';
+	const webLightbox = renderingTarget === 'Web' && isInLightboxTest;
 
 	return (
 		<StrictMode>
@@ -98,7 +98,7 @@ export const ArticlePage = (props: WebProps | AppProps) => {
 			/>
 			<SkipTo id="maincontent" label="Skip to main content" />
 			<SkipTo id="navigation" label="Skip to navigation" />
-			{lightboxEnabled && article.imagesForLightbox.length > 0 && (
+			{webLightbox && article.imagesForLightbox.length > 0 && (
 				<>
 					<LightboxLayout
 						imageCount={article.imagesForLightbox.length}

--- a/dotcom-rendering/src/components/CartoonComponent.stories.tsx
+++ b/dotcom-rendering/src/components/CartoonComponent.stories.tsx
@@ -58,6 +58,7 @@ export const Cartoon = () => {
 						theme: Pillar.News,
 					}}
 					element={cartoon}
+					isInLightboxTest={false}
 				/>
 			</Figure>
 		</Wrapper>
@@ -84,6 +85,7 @@ export const CartoonWithoutCredit = () => {
 						design: ArticleDesign.Standard,
 						theme: Pillar.News,
 					}}
+					isInLightboxTest={false}
 				/>
 			</Figure>
 		</Wrapper>
@@ -110,6 +112,7 @@ export const CartoonWithNoMobileImages = () => {
 						design: ArticleDesign.Standard,
 						theme: Pillar.News,
 					}}
+					isInLightboxTest={false}
 				/>
 			</Figure>
 		</Wrapper>

--- a/dotcom-rendering/src/components/CartoonComponent.tsx
+++ b/dotcom-rendering/src/components/CartoonComponent.tsx
@@ -1,8 +1,12 @@
 import { css } from '@emotion/react';
-import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
+import {
+	ArticleDesign,
+	ArticleDisplay,
+	isUndefined,
+	Pillar,
+} from '@guardian/libs';
 import { Hide } from '@guardian/source-react-components';
 import { isWideEnough } from '../lib/lightbox';
-import type { Switches } from '../types/config';
 import type { CartoonBlockElement, Image } from '../types/content';
 import { AppsLightboxImage } from './AppsLightboxImage.importable';
 import { Caption } from './Caption';
@@ -14,10 +18,14 @@ import { Picture } from './Picture';
 type Props = {
 	format: ArticleFormat;
 	element: CartoonBlockElement;
-	switches?: Switches;
+	isInLightboxTest: boolean;
 };
 
-export const CartoonComponent = ({ format, element, switches }: Props) => {
+export const CartoonComponent = ({
+	format,
+	element,
+	isInLightboxTest,
+}: Props) => {
 	const { renderingTarget } = useConfig();
 	const smallVariant = element.variants.find(
 		(variant) => variant.viewportSize === 'small',
@@ -32,6 +40,11 @@ export const CartoonComponent = ({ format, element, switches }: Props) => {
 		}`;
 		const height = parseInt(image.fields.height, 10);
 		const width = parseInt(image.fields.width, 10);
+
+		const webLightbox =
+			renderingTarget === 'Web' &&
+			isInLightboxTest &&
+			isWideEnough(image);
 
 		return (
 			<>
@@ -62,17 +75,15 @@ export const CartoonComponent = ({ format, element, switches }: Props) => {
 					/>
 				)}
 
-				{switches?.lightbox === true &&
-					isWideEnough(image) &&
-					element.position !== undefined && (
-						<LightboxLink
-							role={element.role}
-							format={format}
-							elementId={element.elementId}
-							isMainMedia={true}
-							position={element.position}
-						/>
-					)}
+				{webLightbox && !isUndefined(element.position) && (
+					<LightboxLink
+						role={element.role}
+						format={format}
+						elementId={element.elementId}
+						isMainMedia={true}
+						position={element.position}
+					/>
+				)}
 			</>
 		);
 	};

--- a/dotcom-rendering/src/components/ImageBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/components/ImageBlockComponent.stories.tsx
@@ -67,6 +67,7 @@ export const StandardArticle = () => {
 						design: ArticleDesign.Standard,
 						theme: Pillar.News,
 					}}
+					isInLightboxTest={false}
 				/>
 			</Figure>
 		</Wrapper>
@@ -93,6 +94,7 @@ export const Immersive = () => {
 						design: ArticleDesign.Standard,
 						theme: Pillar.News,
 					}}
+					isInLightboxTest={false}
 				/>
 			</Figure>
 		</Wrapper>
@@ -119,6 +121,7 @@ export const Showcase = () => {
 						design: ArticleDesign.Standard,
 						theme: Pillar.News,
 					}}
+					isInLightboxTest={false}
 				/>
 			</Figure>
 		</Wrapper>
@@ -145,6 +148,7 @@ export const Thumbnail = () => {
 						design: ArticleDesign.Standard,
 						theme: Pillar.News,
 					}}
+					isInLightboxTest={false}
 				/>
 			</Figure>
 		</Wrapper>
@@ -171,6 +175,7 @@ export const Supporting = () => {
 						design: ArticleDesign.Standard,
 						theme: Pillar.News,
 					}}
+					isInLightboxTest={false}
 				/>
 			</Figure>
 		</Wrapper>
@@ -198,6 +203,7 @@ export const HideCaption = () => {
 						theme: Pillar.News,
 					}}
 					hideCaption={true}
+					isInLightboxTest={false}
 				/>
 			</Figure>
 		</Wrapper>
@@ -226,6 +232,7 @@ export const InlineTitle = () => {
 					}}
 					title="This is the title text"
 					hideCaption={true}
+					isInLightboxTest={false}
 				/>
 			</Figure>
 		</Wrapper>
@@ -260,6 +267,7 @@ export const InlineTitleMobile = () => {
 					}}
 					title="This is the title text"
 					hideCaption={true}
+					isInLightboxTest={false}
 				/>
 			</Figure>
 		</Wrapper>
@@ -294,6 +302,7 @@ export const ImmersiveTitle = () => {
 					}}
 					title="This is the title text"
 					hideCaption={true}
+					isInLightboxTest={false}
 				/>
 			</Figure>
 		</Wrapper>
@@ -322,6 +331,7 @@ export const ShowcaseTitle = () => {
 					}}
 					title="This is the title text"
 					hideCaption={true}
+					isInLightboxTest={false}
 				/>
 			</Figure>
 		</Wrapper>
@@ -374,6 +384,7 @@ export const HalfWidth = () => {
 						design: ArticleDesign.Standard,
 						theme: Pillar.News,
 					}}
+					isInLightboxTest={false}
 				/>
 			</Figure>
 			<p>
@@ -442,6 +453,7 @@ export const HalfWidthMobile = () => {
 						design: ArticleDesign.Standard,
 						theme: Pillar.News,
 					}}
+					isInLightboxTest={false}
 				/>
 			</Figure>
 			<p>
@@ -510,6 +522,7 @@ export const HalfWidthWide = () => {
 						design: ArticleDesign.Standard,
 						theme: Pillar.News,
 					}}
+					isInLightboxTest={false}
 				/>
 			</Figure>
 			<p>

--- a/dotcom-rendering/src/components/ImageBlockComponent.tsx
+++ b/dotcom-rendering/src/components/ImageBlockComponent.tsx
@@ -1,4 +1,3 @@
-import type { Switches } from '../types/config';
 import type { ImageBlockElement } from '../types/content';
 import { ImageComponent } from './ImageComponent';
 
@@ -10,7 +9,7 @@ type Props = {
 	isMainMedia?: boolean;
 	starRating?: number;
 	isAvatar?: boolean;
-	switches?: Switches;
+	isInLightboxTest: boolean;
 };
 
 export const ImageBlockComponent = ({
@@ -21,7 +20,7 @@ export const ImageBlockComponent = ({
 	isMainMedia,
 	starRating,
 	isAvatar,
-	switches,
+	isInLightboxTest,
 }: Props) => {
 	const { role } = element;
 	return (
@@ -34,7 +33,7 @@ export const ImageBlockComponent = ({
 			role={role}
 			title={title}
 			isAvatar={isAvatar}
-			switches={switches}
+			isInLightboxTest={isInLightboxTest}
 		/>
 	);
 };

--- a/dotcom-rendering/src/components/ImageComponent.tsx
+++ b/dotcom-rendering/src/components/ImageComponent.tsx
@@ -266,13 +266,6 @@ export const ImageComponent = ({
 	const webLightbox =
 		renderingTarget === 'Web' && isInLightboxTest && isWideEnough(image);
 
-	// console.log({
-	// 	webLightbox,
-	// 	renderingTarget,
-	// 	isInLightboxTest,
-	// 	isWideEnough: isWideEnough(image),
-	// });
-
 	/**
 	 * We use height and width for two things.
 	 *

--- a/dotcom-rendering/src/components/ImageComponent.tsx
+++ b/dotcom-rendering/src/components/ImageComponent.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { ArticleDesign, ArticleDisplay } from '@guardian/libs';
+import { ArticleDesign, ArticleDisplay, isUndefined } from '@guardian/libs';
 import {
 	between,
 	from,
@@ -11,7 +11,6 @@ import { decidePalette } from '../lib/decidePalette';
 import { getLargest, getMaster } from '../lib/image';
 import { isWideEnough } from '../lib/lightbox';
 import { palette as themePalette } from '../palette';
-import type { Switches } from '../types/config';
 import type { ImageBlockElement, RoleType } from '../types/content';
 import type { Palette } from '../types/palette';
 import { AppsLightboxImage } from './AppsLightboxImage.importable';
@@ -27,12 +26,12 @@ type Props = {
 	element: ImageBlockElement;
 	role: RoleType;
 	format: ArticleFormat;
+	isInLightboxTest: boolean;
 	hideCaption?: boolean;
 	isMainMedia?: boolean;
 	starRating?: number;
 	title?: string;
 	isAvatar?: boolean;
-	switches?: Switches;
 };
 
 const starsWrapper = css`
@@ -238,7 +237,7 @@ export const ImageComponent = ({
 	starRating,
 	title,
 	isAvatar,
-	switches,
+	isInLightboxTest,
 }: Props) => {
 	const { renderingTarget } = useConfig();
 	// Its possible the tools wont send us any images urls
@@ -263,6 +262,9 @@ export const ImageComponent = ({
 		// We should only try to render images that are supported by Fastly
 		return null;
 	}
+
+	const webLightbox =
+		renderingTarget === 'Web' && isInLightboxTest && isWideEnough(image);
 
 	/**
 	 * We use height and width for two things.
@@ -347,17 +349,15 @@ export const ImageComponent = ({
 				{!!title && (
 					<ImageTitle title={title} role={role} palette={palette} />
 				)}
-				{switches?.lightbox === true &&
-					isWideEnough(image) &&
-					element.position !== undefined && (
-						<LightboxLink
-							role={role}
-							format={format}
-							elementId={element.elementId}
-							isMainMedia={isMainMedia}
-							position={element.position}
-						/>
-					)}
+				{webLightbox && !isUndefined(element.position) && (
+					<LightboxLink
+						role={role}
+						format={format}
+						elementId={element.elementId}
+						isMainMedia={isMainMedia}
+						position={element.position}
+					/>
+				)}
 			</div>
 		);
 	}
@@ -414,17 +414,15 @@ export const ImageComponent = ({
 				{!!title && (
 					<ImageTitle title={title} role={role} palette={palette} />
 				)}
-				{switches?.lightbox === true &&
-					isWideEnough(image) &&
-					element.position !== undefined && (
-						<LightboxLink
-							role={role}
-							format={format}
-							elementId={element.elementId}
-							isMainMedia={isMainMedia}
-							position={element.position}
-						/>
-					)}
+				{webLightbox && !isUndefined(element.position) && (
+					<LightboxLink
+						role={role}
+						format={format}
+						elementId={element.elementId}
+						isMainMedia={isMainMedia}
+						position={element.position}
+					/>
+				)}
 			</div>
 		);
 	}
@@ -520,17 +518,15 @@ export const ImageComponent = ({
 					<ImageTitle title={title} role={role} palette={palette} />
 				)}
 
-				{switches?.lightbox === true &&
-					isWideEnough(image) &&
-					element.position !== undefined && (
-						<LightboxLink
-							role={role}
-							format={format}
-							elementId={element.elementId}
-							isMainMedia={isMainMedia}
-							position={element.position}
-						/>
-					)}
+				{webLightbox && !isUndefined(element.position) && (
+					<LightboxLink
+						role={role}
+						format={format}
+						elementId={element.elementId}
+						isMainMedia={isMainMedia}
+						position={element.position}
+					/>
+				)}
 			</div>
 			{isMainMedia ? (
 				<Hide when="below" breakpoint="tablet">

--- a/dotcom-rendering/src/components/ImageComponent.tsx
+++ b/dotcom-rendering/src/components/ImageComponent.tsx
@@ -266,6 +266,13 @@ export const ImageComponent = ({
 	const webLightbox =
 		renderingTarget === 'Web' && isInLightboxTest && isWideEnough(image);
 
+	// console.log({
+	// 	webLightbox,
+	// 	renderingTarget,
+	// 	isInLightboxTest,
+	// 	isWideEnough: isWideEnough(image),
+	// });
+
 	/**
 	 * We use height and width for two things.
 	 *

--- a/dotcom-rendering/src/components/LiveBlock.stories.tsx
+++ b/dotcom-rendering/src/components/LiveBlock.stories.tsx
@@ -76,6 +76,7 @@ export const VideoAsSecond = () => {
 				ajaxUrl=""
 				isAdFreeUser={false}
 				isSensitive={false}
+				abTests={{}}
 				switches={{}}
 				isPinnedPost={false}
 			/>
@@ -121,6 +122,7 @@ export const Title = () => {
 				ajaxUrl=""
 				isAdFreeUser={false}
 				isSensitive={false}
+				abTests={{}}
 				switches={{}}
 				isPinnedPost={false}
 			/>
@@ -187,6 +189,7 @@ export const Video = () => {
 				ajaxUrl=""
 				isAdFreeUser={false}
 				isSensitive={false}
+				abTests={{}}
 				switches={{}}
 				isPinnedPost={false}
 			/>
@@ -228,6 +231,7 @@ export const RichLink = () => {
 				ajaxUrl=""
 				isAdFreeUser={false}
 				isSensitive={false}
+				abTests={{}}
 				switches={{}}
 				isPinnedPost={false}
 			/>
@@ -260,6 +264,7 @@ export const FirstImage = () => {
 				ajaxUrl=""
 				isAdFreeUser={false}
 				isSensitive={false}
+				abTests={{}}
 				switches={{}}
 				isPinnedPost={false}
 			/>
@@ -316,6 +321,7 @@ export const ImageRoles = () => {
 				pageId=""
 				webTitle=""
 				ajaxUrl=""
+				abTests={{}}
 				switches={{}}
 				isPinnedPost={false}
 				isAdFreeUser={false}
@@ -363,6 +369,7 @@ export const Thumbnail = () => {
 				pageId=""
 				webTitle=""
 				ajaxUrl=""
+				abTests={{}}
 				switches={{}}
 				isPinnedPost={false}
 				isAdFreeUser={false}
@@ -398,6 +405,7 @@ export const ImageAndTitle = () => {
 				ajaxUrl=""
 				isAdFreeUser={false}
 				isSensitive={false}
+				abTests={{}}
 				switches={{}}
 				isPinnedPost={false}
 			/>
@@ -427,6 +435,7 @@ export const Updated = () => {
 				ajaxUrl=""
 				isAdFreeUser={false}
 				isSensitive={false}
+				abTests={{}}
 				switches={{}}
 				isPinnedPost={false}
 			/>
@@ -458,6 +467,7 @@ export const Contributor = () => {
 				pageId=""
 				webTitle=""
 				ajaxUrl=""
+				abTests={{}}
 				switches={{}}
 				isPinnedPost={false}
 				isAdFreeUser={false}
@@ -489,6 +499,7 @@ export const NoAvatar = () => {
 				pageId=""
 				webTitle=""
 				ajaxUrl=""
+				abTests={{}}
 				switches={{}}
 				isPinnedPost={false}
 				isAdFreeUser={false}
@@ -523,6 +534,7 @@ export const TitleAndContributor = () => {
 				pageId=""
 				webTitle=""
 				ajaxUrl=""
+				abTests={{}}
 				switches={{}}
 				isPinnedPost={false}
 				isAdFreeUser={false}

--- a/dotcom-rendering/src/components/LiveBlock.tsx
+++ b/dotcom-rendering/src/components/LiveBlock.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import { RenderArticleElement } from '../lib/renderElement';
-import type { Switches } from '../types/config';
+import type { ServerSideTests, Switches } from '../types/config';
 import { LastUpdated } from './LastUpdated';
 import { LiveBlockContainer } from './LiveBlockContainer';
 import { ShareIcons } from './ShareIcons';
@@ -14,6 +14,7 @@ type Props = {
 	ajaxUrl: string;
 	isAdFreeUser: boolean;
 	isSensitive: boolean;
+	abTests: ServerSideTests;
 	switches: Switches;
 	isLiveUpdate?: boolean;
 	isPinnedPost: boolean;
@@ -29,6 +30,7 @@ export const LiveBlock = ({
 	ajaxUrl,
 	isAdFreeUser,
 	isSensitive,
+	abTests,
 	switches,
 	isLiveUpdate,
 	isPinnedPost,
@@ -74,6 +76,7 @@ export const LiveBlock = ({
 					webTitle={webTitle}
 					isAdFreeUser={isAdFreeUser}
 					isSensitive={isSensitive}
+					abTests={abTests}
 					switches={switches}
 					isPinnedPost={isPinnedPost}
 				/>

--- a/dotcom-rendering/src/components/LiveBlogBlocksAndAdverts.tsx
+++ b/dotcom-rendering/src/components/LiveBlogBlocksAndAdverts.tsx
@@ -1,6 +1,6 @@
 import { Fragment } from 'react';
 import { getLiveblogAdPositions } from '../lib/getLiveblogAdPositions';
-import type { Switches } from '../types/config';
+import type { ServerSideTests, Switches } from '../types/config';
 import { AdPlaceholder } from './AdPlaceholder.apps';
 import { AdSlot } from './AdSlot.web';
 import { useConfig } from './ConfigContext';
@@ -14,6 +14,7 @@ type Props = {
 	pageId: string;
 	webTitle: string;
 	ajaxUrl: string;
+	abTests: ServerSideTests;
 	switches: Switches;
 	isAdFreeUser: boolean;
 	isSensitive: boolean;
@@ -47,6 +48,7 @@ export const LiveBlogBlocksAndAdverts = ({
 	pageId,
 	webTitle,
 	ajaxUrl,
+	abTests,
 	switches,
 	isAdFreeUser,
 	isSensitive,
@@ -66,6 +68,7 @@ export const LiveBlogBlocksAndAdverts = ({
 				host={host}
 				ajaxUrl={ajaxUrl}
 				isLiveUpdate={isLiveUpdate}
+				abTests={abTests}
 				switches={switches}
 				isAdFreeUser={!isAdFreeUser}
 				isSensitive={isSensitive}

--- a/dotcom-rendering/src/components/LiveBlogRenderer.tsx
+++ b/dotcom-rendering/src/components/LiveBlogRenderer.tsx
@@ -1,5 +1,5 @@
 import { Hide } from '@guardian/source-react-components';
-import type { Switches } from '../types/config';
+import type { ServerSideTests, Switches } from '../types/config';
 import type { TagType } from '../types/tag';
 import { useConfig } from './ConfigContext';
 import { EnhancePinnedPost } from './EnhancePinnedPost.importable';
@@ -22,6 +22,7 @@ type Props = {
 	ajaxUrl: string;
 	isAdFreeUser: boolean;
 	isSensitive: boolean;
+	abTests: ServerSideTests;
 	switches: Switches;
 	isLiveUpdate?: boolean;
 	sectionId: string;
@@ -45,6 +46,7 @@ export const LiveBlogRenderer = ({
 	pageId,
 	webTitle,
 	ajaxUrl,
+	abTests,
 	switches,
 	isAdFreeUser,
 	isSensitive,
@@ -83,6 +85,7 @@ export const LiveBlogRenderer = ({
 							host={host}
 							ajaxUrl={ajaxUrl}
 							isLiveUpdate={isLiveUpdate}
+							abTests={abTests}
 							switches={switches}
 							isAdFreeUser={isAdFreeUser}
 							isSensitive={isSensitive}
@@ -135,6 +138,7 @@ export const LiveBlogRenderer = ({
 				host={host}
 				ajaxUrl={ajaxUrl}
 				isLiveUpdate={isLiveUpdate}
+				abTests={abTests}
 				switches={switches}
 				isAdFreeUser={isAdFreeUser}
 				isSensitive={isSensitive}

--- a/dotcom-rendering/src/components/MainMedia.tsx
+++ b/dotcom-rendering/src/components/MainMedia.tsx
@@ -3,7 +3,7 @@ import { ArticleDesign, ArticleDisplay } from '@guardian/libs';
 import { until } from '@guardian/source-foundations';
 import { getZIndex } from '../lib/getZIndex';
 import { RenderArticleElement } from '../lib/renderElement';
-import type { Switches } from '../types/config';
+import type { ServerSideTests, Switches } from '../types/config';
 import type { FEElement } from '../types/content';
 
 const mainMedia = css`
@@ -72,6 +72,7 @@ type Props = {
 	ajaxUrl: string;
 	isAdFreeUser: boolean;
 	isSensitive: boolean;
+	abTests: ServerSideTests;
 	switches: Switches;
 };
 
@@ -86,6 +87,7 @@ export const MainMedia = ({
 	ajaxUrl,
 	isAdFreeUser,
 	isSensitive,
+	abTests,
 	switches,
 }: Props) => {
 	return (
@@ -104,6 +106,7 @@ export const MainMedia = ({
 					webTitle={webTitle}
 					isAdFreeUser={isAdFreeUser}
 					isSensitive={isSensitive}
+					abTests={abTests}
 					switches={switches}
 					hideCaption={hideCaption}
 					starRating={starRating}

--- a/dotcom-rendering/src/components/MultiImageBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/components/MultiImageBlockComponent.stories.tsx
@@ -23,6 +23,7 @@ export const SingleImage = () => {
 					theme: Pillar.News,
 				}}
 				images={oneImage}
+				isInLightboxTest={false}
 			/>
 		</Section>
 	);
@@ -40,6 +41,7 @@ export const SingleImageWithCaption = () => {
 				}}
 				images={oneImage}
 				caption="This is the caption for a single image"
+				isInLightboxTest={false}
 			/>
 		</Section>
 	);
@@ -56,6 +58,7 @@ export const SideBySide = () => {
 					theme: Pillar.News,
 				}}
 				images={twoImages}
+				isInLightboxTest={false}
 			/>
 		</Section>
 	);
@@ -73,6 +76,7 @@ export const SideBySideWithCaption = () => {
 				}}
 				images={twoImages}
 				caption="This is the caption for side by side"
+				isInLightboxTest={false}
 			/>
 		</Section>
 	);
@@ -89,6 +93,7 @@ export const OneAboveTwo = () => {
 					theme: Pillar.News,
 				}}
 				images={threeImages}
+				isInLightboxTest={false}
 			/>
 		</Section>
 	);
@@ -106,6 +111,7 @@ export const OneAboveTwoWithCaption = () => {
 				}}
 				images={threeImages}
 				caption="This is the caption for one above two"
+				isInLightboxTest={false}
 			/>
 		</Section>
 	);
@@ -122,6 +128,7 @@ export const GridOfFour = () => {
 					theme: Pillar.News,
 				}}
 				images={fourImages}
+				isInLightboxTest={false}
 			/>
 		</Section>
 	);
@@ -139,6 +146,7 @@ export const GridOfFourWithCaption = () => {
 				}}
 				images={fourImages}
 				caption="This is the caption for grid of four"
+				isInLightboxTest={false}
 			/>
 		</Section>
 	);

--- a/dotcom-rendering/src/components/MultiImageBlockComponent.tsx
+++ b/dotcom-rendering/src/components/MultiImageBlockComponent.tsx
@@ -1,6 +1,5 @@
 import { css } from '@emotion/react';
 import { from, space, until } from '@guardian/source-foundations';
-import type { Switches } from '../types/config';
 import type { ImageBlockElement } from '../types/content';
 import { Caption } from './Caption';
 import { GridItem } from './GridItem';
@@ -10,7 +9,7 @@ type Props = {
 	images: ImageBlockElement[];
 	format: ArticleFormat;
 	caption?: string;
-	switches?: Switches;
+	isInLightboxTest: boolean;
 };
 
 const ieFallback = css`
@@ -104,12 +103,12 @@ const OneImage = ({
 	images,
 	format,
 	caption,
-	switches,
+	isInLightboxTest,
 }: {
 	images: [ImageBlockElement];
 	format: ArticleFormat;
 	caption?: string;
-	switches?: Switches;
+	isInLightboxTest: boolean;
 }) => (
 	<div css={wrapper}>
 		<ImageComponent
@@ -117,7 +116,7 @@ const OneImage = ({
 			element={images[0]}
 			hideCaption={true}
 			role={images[0].role}
-			switches={switches}
+			isInLightboxTest={isInLightboxTest}
 		/>
 		{!!caption && (
 			<Caption
@@ -133,12 +132,12 @@ const TwoImage = ({
 	images,
 	format,
 	caption,
-	switches,
+	isInLightboxTest,
 }: {
 	images: [ImageBlockElement, ImageBlockElement];
 	format: ArticleFormat;
 	caption?: string;
-	switches?: Switches;
+	isInLightboxTest: boolean;
 }) => (
 	<div css={wrapper}>
 		<SideBySideGrid>
@@ -148,7 +147,7 @@ const TwoImage = ({
 					format={format}
 					hideCaption={true}
 					role={images[0].role}
-					switches={switches}
+					isInLightboxTest={isInLightboxTest}
 				/>
 			</GridItem>
 			<GridItem area="second">
@@ -157,7 +156,7 @@ const TwoImage = ({
 					format={format}
 					hideCaption={true}
 					role={images[1].role}
-					switches={switches}
+					isInLightboxTest={isInLightboxTest}
 				/>
 			</GridItem>
 		</SideBySideGrid>
@@ -175,12 +174,12 @@ const ThreeImage = ({
 	images,
 	format,
 	caption,
-	switches,
+	isInLightboxTest,
 }: {
 	images: [ImageBlockElement, ImageBlockElement, ImageBlockElement];
 	format: ArticleFormat;
 	caption?: string;
-	switches?: Switches;
+	isInLightboxTest: boolean;
 }) => (
 	<div css={wrapper}>
 		<OneAboveTwoGrid>
@@ -190,7 +189,7 @@ const ThreeImage = ({
 					format={format}
 					hideCaption={true}
 					role={images[0].role}
-					switches={switches}
+					isInLightboxTest={isInLightboxTest}
 				/>
 			</GridItem>
 			<GridItem area="second">
@@ -199,7 +198,7 @@ const ThreeImage = ({
 					format={format}
 					hideCaption={true}
 					role={images[1].role}
-					switches={switches}
+					isInLightboxTest={isInLightboxTest}
 				/>
 			</GridItem>
 			<GridItem area="third">
@@ -208,7 +207,7 @@ const ThreeImage = ({
 					format={format}
 					hideCaption={true}
 					role={images[2].role}
-					switches={switches}
+					isInLightboxTest={isInLightboxTest}
 				/>
 			</GridItem>
 		</OneAboveTwoGrid>
@@ -226,7 +225,7 @@ const FourImage = ({
 	images,
 	format,
 	caption,
-	switches,
+	isInLightboxTest,
 }: {
 	images: [
 		ImageBlockElement,
@@ -236,7 +235,7 @@ const FourImage = ({
 	];
 	format: ArticleFormat;
 	caption?: string;
-	switches?: Switches;
+	isInLightboxTest: boolean;
 }) => (
 	<div css={wrapper}>
 		<GridOfFour>
@@ -246,7 +245,7 @@ const FourImage = ({
 					format={format}
 					hideCaption={true}
 					role={images[0].role}
-					switches={switches}
+					isInLightboxTest={isInLightboxTest}
 				/>
 			</GridItem>
 			<GridItem area="second">
@@ -255,7 +254,7 @@ const FourImage = ({
 					format={format}
 					hideCaption={true}
 					role={images[1].role}
-					switches={switches}
+					isInLightboxTest={isInLightboxTest}
 				/>
 			</GridItem>
 			<GridItem area="third">
@@ -264,7 +263,7 @@ const FourImage = ({
 					format={format}
 					hideCaption={true}
 					role={images[2].role}
-					switches={switches}
+					isInLightboxTest={isInLightboxTest}
 				/>
 			</GridItem>
 			<GridItem area="forth">
@@ -273,7 +272,7 @@ const FourImage = ({
 					format={format}
 					hideCaption={true}
 					role={images[3].role}
-					switches={switches}
+					isInLightboxTest={isInLightboxTest}
 				/>
 			</GridItem>
 		</GridOfFour>
@@ -291,7 +290,7 @@ export const MultiImageBlockComponent = ({
 	images,
 	format,
 	caption,
-	switches,
+	isInLightboxTest,
 }: Props) => {
 	const [one, two, three, four] = images;
 
@@ -301,7 +300,7 @@ export const MultiImageBlockComponent = ({
 				images={[one, two, three, four]}
 				format={format}
 				caption={caption}
-				switches={switches}
+				isInLightboxTest={isInLightboxTest}
 			/>
 		);
 	}
@@ -312,7 +311,7 @@ export const MultiImageBlockComponent = ({
 				images={[one, two, three]}
 				format={format}
 				caption={caption}
-				switches={switches}
+				isInLightboxTest={isInLightboxTest}
 			/>
 		);
 	}
@@ -323,7 +322,7 @@ export const MultiImageBlockComponent = ({
 				images={[one, two]}
 				format={format}
 				caption={caption}
-				switches={switches}
+				isInLightboxTest={isInLightboxTest}
 			/>
 		);
 	}
@@ -334,7 +333,7 @@ export const MultiImageBlockComponent = ({
 				images={[one]}
 				format={format}
 				caption={caption}
-				switches={switches}
+				isInLightboxTest={isInLightboxTest}
 			/>
 		);
 	}

--- a/dotcom-rendering/src/components/PinnedPost.stories.tsx
+++ b/dotcom-rendering/src/components/PinnedPost.stories.tsx
@@ -81,6 +81,7 @@ export const Sport = () => {
 					ajaxUrl=""
 					isAdFreeUser={false}
 					isSensitive={false}
+					abTests={{}}
 					switches={{}}
 					isPinnedPost={true}
 				/>
@@ -126,6 +127,7 @@ export const News = () => {
 					ajaxUrl=""
 					isAdFreeUser={false}
 					isSensitive={false}
+					abTests={{}}
 					switches={{}}
 					isPinnedPost={true}
 				/>
@@ -171,6 +173,7 @@ export const Culture = () => {
 					ajaxUrl=""
 					isAdFreeUser={false}
 					isSensitive={false}
+					abTests={{}}
 					switches={{}}
 					isPinnedPost={true}
 				/>
@@ -216,6 +219,7 @@ export const Lifestyle = () => {
 					ajaxUrl=""
 					isAdFreeUser={false}
 					isSensitive={false}
+					abTests={{}}
 					switches={{}}
 					isPinnedPost={true}
 				/>
@@ -261,6 +265,7 @@ export const Opinion = () => {
 					ajaxUrl=""
 					isAdFreeUser={false}
 					isSensitive={false}
+					abTests={{}}
 					switches={{}}
 					isPinnedPost={true}
 				/>
@@ -306,6 +311,7 @@ export const SpecialReport = () => {
 					ajaxUrl=""
 					isAdFreeUser={false}
 					isSensitive={false}
+					abTests={{}}
 					switches={{}}
 					isPinnedPost={true}
 				/>
@@ -351,6 +357,7 @@ export const Labs = () => {
 					ajaxUrl=""
 					isAdFreeUser={false}
 					isSensitive={false}
+					abTests={{}}
 					switches={{}}
 					isPinnedPost={true}
 				/>

--- a/dotcom-rendering/src/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/layouts/CommentLayout.tsx
@@ -477,6 +477,7 @@ export const CommentLayout = (props: WebProps | AppsProps) => {
 									pageId={article.pageId}
 									webTitle={article.webTitle}
 									ajaxUrl={article.config.ajaxUrl}
+									abTests={article.config.abTests}
 									switches={article.config.switches}
 									isAdFreeUser={article.isAdFreeUser}
 									isSensitive={article.config.isSensitive}

--- a/dotcom-rendering/src/layouts/FullPageInteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/FullPageInteractiveLayout.tsx
@@ -25,7 +25,7 @@ import { decideLanguage, decideLanguageDirection } from '../lib/lang';
 import { renderElement } from '../lib/renderElement';
 import type { NavType } from '../model/extract-nav';
 import { palette as themePalette } from '../palette';
-import type { Switches } from '../types/config';
+import type { ServerSideTests, Switches } from '../types/config';
 import type { FEElement } from '../types/content';
 import type { DCRArticle } from '../types/frontend';
 import { interactiveGlobalStyles } from './lib/interactiveLegacyStyling';
@@ -46,6 +46,7 @@ type RendererProps = {
 	ajaxUrl: string;
 	isAdFreeUser: boolean;
 	isSensitive: boolean;
+	abTests: ServerSideTests;
 	switches: Switches;
 };
 
@@ -58,6 +59,7 @@ const Renderer = ({
 	ajaxUrl,
 	isAdFreeUser,
 	isSensitive,
+	abTests,
 	switches,
 }: RendererProps) => {
 	// const cleanedElements = elements.map(element =>
@@ -78,6 +80,7 @@ const Renderer = ({
 			isAdFreeUser,
 			isSensitive,
 			switches,
+			abTests,
 		});
 
 		switch (element._type) {
@@ -331,6 +334,7 @@ export const FullPageInteractiveLayout = ({ article, NAV, format }: Props) => {
 						pageId={article.pageId}
 						webTitle={article.webTitle}
 						ajaxUrl={article.config.ajaxUrl}
+						abTests={article.config.abTests}
 						switches={article.config.switches}
 						isAdFreeUser={article.isAdFreeUser}
 						isSensitive={article.config.isSensitive}

--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -394,6 +394,7 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 						pageId={article.pageId}
 						webTitle={article.webTitle}
 						ajaxUrl={article.config.ajaxUrl}
+						abTests={article.config.abTests}
 						switches={article.config.switches}
 						isAdFreeUser={article.isAdFreeUser}
 						isSensitive={article.config.isSensitive}

--- a/dotcom-rendering/src/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/InteractiveLayout.tsx
@@ -432,6 +432,7 @@ export const InteractiveLayout = (props: WebProps | AppsProps) => {
 										pageId={article.pageId}
 										webTitle={article.webTitle}
 										ajaxUrl={article.config.ajaxUrl}
+										abTests={article.config.abTests}
 										switches={article.config.switches}
 										isAdFreeUser={article.isAdFreeUser}
 										isSensitive={article.config.isSensitive}
@@ -535,6 +536,7 @@ export const InteractiveLayout = (props: WebProps | AppsProps) => {
 										pageId={article.pageId}
 										webTitle={article.webTitle}
 										ajaxUrl={article.config.ajaxUrl}
+										abTests={article.config.abTests}
 										switches={article.config.switches}
 										isSensitive={article.config.isSensitive}
 										isAdFreeUser={article.isAdFreeUser}

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -724,6 +724,7 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 										pageId={article.pageId}
 										webTitle={article.webTitle}
 										ajaxUrl={article.config.ajaxUrl}
+										abTests={article.config.abTests}
 										switches={article.config.switches}
 										isSensitive={article.config.isSensitive}
 										isAdFreeUser={article.isAdFreeUser}
@@ -857,6 +858,9 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 													}
 													sectionId={
 														article.config.section
+													}
+													abTests={
+														article.config.abTests
 													}
 													switches={
 														article.config.switches
@@ -1001,6 +1005,9 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 													}
 													sectionId={
 														article.config.section
+													}
+													abTests={
+														article.config.abTests
 													}
 													switches={
 														article.config.switches

--- a/dotcom-rendering/src/layouts/NewsletterSignupLayout.tsx
+++ b/dotcom-rendering/src/layouts/NewsletterSignupLayout.tsx
@@ -488,6 +488,7 @@ export const NewsletterSignupLayout = ({ article, NAV, format }: Props) => {
 									pageId={article.pageId}
 									webTitle={article.webTitle}
 									ajaxUrl={article.config.ajaxUrl}
+									abTests={article.config.abTests}
 									switches={article.config.switches}
 									isAdFreeUser={article.isAdFreeUser}
 									isSensitive={article.config.isSensitive}

--- a/dotcom-rendering/src/layouts/PictureLayout.tsx
+++ b/dotcom-rendering/src/layouts/PictureLayout.tsx
@@ -531,6 +531,7 @@ export const PictureLayout = (props: WebProps | AppsProps) => {
 									pageId={article.pageId}
 									webTitle={article.webTitle}
 									ajaxUrl={article.config.ajaxUrl}
+									abTests={article.config.abTests}
 									switches={article.config.switches}
 									isAdFreeUser={article.isAdFreeUser}
 									isSensitive={article.config.isSensitive}

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -516,6 +516,7 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 									pageId={article.pageId}
 									webTitle={article.webTitle}
 									ajaxUrl={article.config.ajaxUrl}
+									abTests={article.config.abTests}
 									switches={article.config.switches}
 									isAdFreeUser={article.isAdFreeUser}
 									isSensitive={article.config.isSensitive}

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -553,6 +553,7 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 									pageId={article.pageId}
 									webTitle={article.webTitle}
 									ajaxUrl={article.config.ajaxUrl}
+									abTests={article.config.abTests}
 									switches={article.config.switches}
 									isAdFreeUser={article.isAdFreeUser}
 									isSensitive={article.config.isSensitive}

--- a/dotcom-rendering/src/lib/ArticleRenderer.tsx
+++ b/dotcom-rendering/src/lib/ArticleRenderer.tsx
@@ -41,7 +41,7 @@ type Props = {
 	isDev: boolean;
 	isAdFreeUser: boolean;
 	isSensitive: boolean;
-	abTests?: ServerSideTests;
+	abTests: ServerSideTests;
 };
 
 export const ArticleRenderer = ({

--- a/dotcom-rendering/src/lib/renderElement.tsx
+++ b/dotcom-rendering/src/lib/renderElement.tsx
@@ -80,7 +80,7 @@ type Props = {
 	isSensitive: boolean;
 	switches: Switches;
 	isPinnedPost?: boolean;
-	abTests?: ServerSideTests;
+	abTests: ServerSideTests;
 };
 
 // updateRole modifies the role of an element in a way appropriate for most
@@ -140,7 +140,7 @@ export const renderElement = ({
 		format.design === ArticleDesign.LiveBlog ||
 		format.design === ArticleDesign.DeadBlog;
 
-	const isInLightboxTest = abTests?.lightboxVariant === 'variant';
+	const isInLightboxTest = abTests.lightboxVariant === 'variant';
 
 	switch (element._type) {
 		case 'model.dotcomrendering.pageElements.AudioAtomBlockElement':

--- a/dotcom-rendering/src/lib/renderElement.tsx
+++ b/dotcom-rendering/src/lib/renderElement.tsx
@@ -208,7 +208,7 @@ export const renderElement = ({
 				<CartoonComponent
 					format={format}
 					element={element}
-					switches={switches}
+					isInLightboxTest={isInLightboxTest}
 				/>
 			);
 		case 'model.dotcomrendering.pageElements.ChartAtomBlockElement':

--- a/dotcom-rendering/src/lib/renderElement.tsx
+++ b/dotcom-rendering/src/lib/renderElement.tsx
@@ -140,6 +140,8 @@ export const renderElement = ({
 		format.design === ArticleDesign.LiveBlog ||
 		format.design === ArticleDesign.DeadBlog;
 
+	const isInLightboxTest = abTests?.lightboxVariant === 'variant';
+
 	switch (element._type) {
 		case 'model.dotcomrendering.pageElements.AudioAtomBlockElement':
 			return (
@@ -347,7 +349,7 @@ export const renderElement = ({
 					starRating={starRating ?? element.starRating}
 					title={element.title}
 					isAvatar={element.isAvatar}
-					switches={switches}
+					isInLightboxTest={isInLightboxTest}
 				/>
 			);
 		case 'model.dotcomrendering.pageElements.InstagramBlockElement':
@@ -450,7 +452,7 @@ export const renderElement = ({
 					key={index}
 					images={element.images}
 					caption={element.caption}
-					switches={switches}
+					isInLightboxTest={isInLightboxTest}
 				/>
 			);
 		case 'model.dotcomrendering.pageElements.NewsletterSignupBlockElement':

--- a/dotcom-rendering/src/server/handler.article.web.ts
+++ b/dotcom-rendering/src/server/handler.article.web.ts
@@ -62,6 +62,7 @@ export const handleBlocks: RequestHandler = ({ body }, res) => {
 		section,
 		sharedAdTargeting,
 		adUnit,
+		abTests,
 		switches,
 		keywordIds,
 	} =
@@ -83,6 +84,7 @@ export const handleBlocks: RequestHandler = ({ body }, res) => {
 		section,
 		sharedAdTargeting,
 		adUnit,
+		abTests,
 		switches,
 		keywordIds,
 	});

--- a/dotcom-rendering/src/server/render.article.web.tsx
+++ b/dotcom-rendering/src/server/render.article.web.tsx
@@ -249,6 +249,7 @@ export const renderBlocks = ({
 	isAdFreeUser,
 	isSensitive,
 	section,
+	abTests,
 	switches,
 	keywordIds,
 }: FEBlocksRequest): string => {
@@ -268,6 +269,7 @@ export const renderBlocks = ({
 				ajaxUrl={ajaxUrl}
 				isSensitive={isSensitive}
 				isAdFreeUser={isAdFreeUser}
+				abTests={abTests}
 				switches={switches}
 				isLiveUpdate={true}
 				sectionId={section}

--- a/dotcom-rendering/src/types/frontend.ts
+++ b/dotcom-rendering/src/types/frontend.ts
@@ -3,7 +3,7 @@ import type { EditionId } from '../lib/edition';
 import type { ImageForAppsLightbox } from '../model/appsLightboxImages';
 import type { FEArticleBadgeType } from './badge';
 import type { CommercialProperties } from './commercial';
-import type { ConfigType } from './config';
+import type { ConfigType, ServerSideTests, Switches } from './config';
 import type { FEElement, ImageForLightbox, Newsletter } from './content';
 import type { FooterType } from './footer';
 import type { FEOnwards } from './onwards';
@@ -156,6 +156,7 @@ export interface FEBlocksRequest {
 	sharedAdTargeting: SharedAdTargeting;
 	adUnit: string;
 	videoDuration?: number;
-	switches: { [key: string]: boolean };
+	switches: Switches;
+	abTests: ServerSideTests;
 	keywordIds: string;
 }


### PR DESCRIPTION
## What does this change?

Be more specific about users who get the Lightbox.

## Why?

Currently, the server-side test was only used as a switch, and we tried serving the web lightbox on apps.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/76776/71443737-f947-48ef-a328-1de88c19e420
[after]: https://github.com/guardian/dotcom-rendering/assets/76776/f84a880f-a80b-4e66-9140-c6dc177fcfd9
