### PR TITLE
Override role styles for interactive block main media

### DIFF
--- a/dotcom-rendering/src/components/InteractiveBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/components/InteractiveBlockComponent.importable.tsx
@@ -115,6 +115,10 @@ const placeholderLinkStyle = css`
 	left: ${space[1]}px;
 `;
 
+const mainMediaFigureStyles = css`
+	height: 100%;
+`;
+
 // https://interactive.guim.co.uk/embed/iframe-wrapper/0.1/boot.js
 const setupWindowListeners = (iframe: HTMLIFrameElement) => {
 	// Calls func on trailing edge of the wait period
@@ -294,7 +298,9 @@ export const InteractiveBlockComponent = ({
 				id={elementId} // boot scripts use id when inserting interactive content
 				ref={wrapperRef}
 				css={[
-					defaultRoleStyles(role, format),
+					isMainMedia
+						? mainMediaFigureStyles
+						: defaultRoleStyles(role, format),
 					wrapperStyle({ format, role, loaded }),
 				]}
 				className={interactiveLegacyFigureClasses(


### PR DESCRIPTION
## What does this change?

For `InteractiveBlockComponent`, stops using `defaultRoleStyles` when it is a main media element.

This stops interactive main media with "showcase" weighting from using the left col and overlapping with the article meta.

## Why?

Resolves #10073 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/43961396/65d6615c-d029-4d7c-868a-754285cb3222
[after]: https://github.com/guardian/dotcom-rendering/assets/43961396/de90dc99-3bea-44f1-95e0-54b7a60a5ad1

