### PR TITLE
Refactor readerRevenueDevUtils to use @guardian/libs storage

### DIFF
--- a/dotcom-rendering/src/lib/readerRevenueDevUtils.ts
+++ b/dotcom-rendering/src/lib/readerRevenueDevUtils.ts
@@ -17,16 +17,12 @@ const readerRevenueCookies = [
 ];
 
 const clearEpicViewLog = (): void =>
-	// eslint-disable-next-line no-restricted-syntax -- FIXME-libs-storage
-	localStorage.removeItem('gu.contributions.views');
+	storage.local.remove('gu.contributions.views');
 
 const clearBannerLastClosedAt = (): void => {
-	// eslint-disable-next-line no-restricted-syntax -- FIXME-libs-storage
-	localStorage.removeItem('gu.prefs.engagementBannerLastClosedAt');
-	// eslint-disable-next-line no-restricted-syntax -- FIXME-libs-storage
-	localStorage.removeItem('gu.prefs.subscriptionBannerLastClosedAt');
-	// eslint-disable-next-line no-restricted-syntax -- FIXME-libs-storage
-	localStorage.removeItem('gu.noRRBannerTimestamp');
+	storage.local.remove('gu.prefs.engagementBannerLastClosedAt');
+	storage.local.remove('gu.prefs.subscriptionBannerLastClosedAt');
+	storage.local.remove('gu.noRRBannerTimestamp');
 };
 
 const fakeOneOffContributor = (): void =>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?
Refactor readerRevenueDevUtils to use @guardian/libs storage as part of https://github.com/guardian/dotcom-rendering/issues/10052

## Why?
Closes https://github.com/guardian/dotcom-rendering/issues/10100

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
