### PR TITLE
Add CSTI to CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,15 @@
-*			@guardian/dotcom-platform
+# This file is matched from top down; subsequent matches override previous matches.
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
-dotcom-rendering/src/components/marketing/ @guardian/tx-engineers
-dotcom-rendering/src/client/userFeatures/ @guardian/supporter-revenue-stream
+# By default all files are owned by these teams:
+* 												@guardian/dotcom-platform @guardian/client-side-infra
+
+# These folders and all their contents are owned by the following teams.
+/dotcom-rendering/ 								@guardian/dotcom-platform
+/apps-rendering/ 								@guardian/dotcom-platform
+/dotcom-rendering/src/components/marketing/ 	@guardian/tx-engineers
+/dotcom-rendering/src/client/userFeatures/ 		@guardian/supporter-revenue-stream
+
+# These file types, wherever they are, are co-owned by the following teams.
+package.json 									@guardian/dotcom-platform @guardian/client-side-infra
+tsconfig.json 									@guardian/dotcom-platform @guardian/client-side-infra


### PR DESCRIPTION
## What does this change?
Adds @guardian/client-side-infra  as joint code owners of the root and some config files.
## Why?
@guardian/client-side-infra  are trialing working more within dotcom-rendering repo.

Co-authored-by: Alex Sanders <alex@sndrs.dev>
