### PR TITLE
Handle optional `abTests` in Blocks endpoint

### DIFF
--- a/dotcom-rendering/src/server/handler.article.web.ts
+++ b/dotcom-rendering/src/server/handler.article.web.ts
@@ -62,6 +62,7 @@ export const handleBlocks: RequestHandler = ({ body }, res) => {
 		section,
 		sharedAdTargeting,
 		adUnit,
+		abTests,
 		switches,
 		keywordIds,
 	} =
@@ -84,6 +85,7 @@ export const handleBlocks: RequestHandler = ({ body }, res) => {
 		sharedAdTargeting,
 		adUnit,
 		switches,
+		abTests,
 		keywordIds,
 	});
 

--- a/dotcom-rendering/src/server/render.article.web.tsx
+++ b/dotcom-rendering/src/server/render.article.web.tsx
@@ -251,6 +251,7 @@ export const renderBlocks = ({
 	section,
 	switches,
 	keywordIds,
+	abTests = {},
 }: FEBlocksRequest): string => {
 	const format: ArticleFormat = decideFormat(FEFormat);
 
@@ -268,7 +269,7 @@ export const renderBlocks = ({
 				ajaxUrl={ajaxUrl}
 				isSensitive={isSensitive}
 				isAdFreeUser={isAdFreeUser}
-				abTests={{}} // @TODO: start passing `abTests` to the block endpoint
+				abTests={abTests}
 				switches={switches}
 				isLiveUpdate={true}
 				sectionId={section}

--- a/dotcom-rendering/src/types/frontend.ts
+++ b/dotcom-rendering/src/types/frontend.ts
@@ -3,7 +3,7 @@ import type { EditionId } from '../lib/edition';
 import type { ImageForAppsLightbox } from '../model/appsLightboxImages';
 import type { FEArticleBadgeType } from './badge';
 import type { CommercialProperties } from './commercial';
-import type { ConfigType } from './config';
+import type { ConfigType, ServerSideTests } from './config';
 import type { FEElement, ImageForLightbox, Newsletter } from './content';
 import type { FooterType } from './footer';
 import type { FEOnwards } from './onwards';
@@ -157,5 +157,6 @@ export interface FEBlocksRequest {
 	adUnit: string;
 	videoDuration?: number;
 	switches: { [key: string]: boolean };
+	abTests?: ServerSideTests;
 	keywordIds: string;
 }


### PR DESCRIPTION
## What does this change?

Handle `abTests` if they are sent to the Blocks endpoint.
Still default to an empty object if the key is missing.

## Why?

`abTests` are now sent to the block endpoint:
- https://github.com/guardian/frontend/pull/26802

## How to test

Deployed on CODE:
- https://code.api.nextgen.guardianapps.co.uk/world/live/2024/jan/09/russia-ukraine-war-latest-news-updates.json?lastUpdate=block-659d583d8f0879f399d82d73&isLivePage=true&dcr=true&filterKeyEvents=false
- https://code.api.nextgen.guardianapps.co.uk/world/live/2024/jan/09/russia-ukraine-war-latest-news-updates.json?lastUpdate=block-659d3a6d8f0846cda8389157&isLivePage=true&dcr=true&filterKeyEvents=false
- https://code.api.nextgen.guardianapps.co.uk/world/live/2024/jan/09/russia-ukraine-war-latest-news-updates.json?lastUpdate=block-659d3a6d8f0846cda8389157&isLivePage=true&dcr=true&filterKeyEvents=true