### PR TITLE
Ensure server-side tests are available where required

### DIFF
--- a/dotcom-rendering/src/components/ArticleBody.tsx
+++ b/dotcom-rendering/src/components/ArticleBody.tsx
@@ -39,7 +39,7 @@ type Props = {
 	filterKeyEvents?: boolean;
 	availableTopics?: Topic[];
 	selectedTopics?: Topic[];
-	abTests?: ServerSideTests;
+	abTests: ServerSideTests;
 	tableOfContents?: TableOfContentsItem[];
 	lang?: string;
 	isRightToLeftLang?: boolean;
@@ -164,6 +164,7 @@ export const ArticleBody = ({
 					pageId={pageId}
 					webTitle={webTitle}
 					ajaxUrl={ajaxUrl}
+					abTests={abTests}
 					switches={switches}
 					isAdFreeUser={isAdFreeUser}
 					isSensitive={isSensitive}

--- a/dotcom-rendering/src/components/ArticleHeadline.stories.tsx
+++ b/dotcom-rendering/src/components/ArticleHeadline.stories.tsx
@@ -112,6 +112,7 @@ export const ShowcaseInterview: StoryObj = ({ format }: StoryArgs) => {
 						ajaxUrl=""
 						isAdFreeUser={false}
 						isSensitive={false}
+						abTests={{}}
 						switches={{}}
 					/>
 				</ArticleContainer>
@@ -157,6 +158,7 @@ export const ShowcaseInterviewNobyline: StoryObj = ({ format }: StoryArgs) => {
 						ajaxUrl=""
 						isAdFreeUser={false}
 						isSensitive={false}
+						abTests={{}}
 						switches={{}}
 					/>
 				</ArticleContainer>
@@ -200,6 +202,7 @@ export const Interview: StoryObj = ({ format }: StoryArgs) => {
 						ajaxUrl=""
 						isAdFreeUser={false}
 						isSensitive={false}
+						abTests={{}}
 						switches={{}}
 					/>
 				</ArticleContainer>
@@ -243,6 +246,7 @@ export const InterviewSpecialReport: StoryObj = ({ format }: StoryArgs) => {
 						ajaxUrl=""
 						isAdFreeUser={false}
 						isSensitive={false}
+						abTests={{}}
 						switches={{}}
 					/>
 				</ArticleContainer>
@@ -287,6 +291,7 @@ export const InterviewNoByline: StoryObj = ({ format }: StoryArgs) => {
 						ajaxUrl=""
 						isAdFreeUser={false}
 						isSensitive={false}
+						abTests={{}}
 						switches={{}}
 					/>
 				</ArticleContainer>

--- a/dotcom-rendering/src/components/LiveBlock.stories.tsx
+++ b/dotcom-rendering/src/components/LiveBlock.stories.tsx
@@ -76,6 +76,7 @@ export const VideoAsSecond = () => {
 				ajaxUrl=""
 				isAdFreeUser={false}
 				isSensitive={false}
+				abTests={{}}
 				switches={{}}
 				isPinnedPost={false}
 			/>
@@ -121,6 +122,7 @@ export const Title = () => {
 				ajaxUrl=""
 				isAdFreeUser={false}
 				isSensitive={false}
+				abTests={{}}
 				switches={{}}
 				isPinnedPost={false}
 			/>
@@ -187,6 +189,7 @@ export const Video = () => {
 				ajaxUrl=""
 				isAdFreeUser={false}
 				isSensitive={false}
+				abTests={{}}
 				switches={{}}
 				isPinnedPost={false}
 			/>
@@ -228,6 +231,7 @@ export const RichLink = () => {
 				ajaxUrl=""
 				isAdFreeUser={false}
 				isSensitive={false}
+				abTests={{}}
 				switches={{}}
 				isPinnedPost={false}
 			/>
@@ -260,6 +264,7 @@ export const FirstImage = () => {
 				ajaxUrl=""
 				isAdFreeUser={false}
 				isSensitive={false}
+				abTests={{}}
 				switches={{}}
 				isPinnedPost={false}
 			/>
@@ -316,6 +321,7 @@ export const ImageRoles = () => {
 				pageId=""
 				webTitle=""
 				ajaxUrl=""
+				abTests={{}}
 				switches={{}}
 				isPinnedPost={false}
 				isAdFreeUser={false}
@@ -363,6 +369,7 @@ export const Thumbnail = () => {
 				pageId=""
 				webTitle=""
 				ajaxUrl=""
+				abTests={{}}
 				switches={{}}
 				isPinnedPost={false}
 				isAdFreeUser={false}
@@ -398,6 +405,7 @@ export const ImageAndTitle = () => {
 				ajaxUrl=""
 				isAdFreeUser={false}
 				isSensitive={false}
+				abTests={{}}
 				switches={{}}
 				isPinnedPost={false}
 			/>
@@ -427,6 +435,7 @@ export const Updated = () => {
 				ajaxUrl=""
 				isAdFreeUser={false}
 				isSensitive={false}
+				abTests={{}}
 				switches={{}}
 				isPinnedPost={false}
 			/>
@@ -458,6 +467,7 @@ export const Contributor = () => {
 				pageId=""
 				webTitle=""
 				ajaxUrl=""
+				abTests={{}}
 				switches={{}}
 				isPinnedPost={false}
 				isAdFreeUser={false}
@@ -489,6 +499,7 @@ export const NoAvatar = () => {
 				pageId=""
 				webTitle=""
 				ajaxUrl=""
+				abTests={{}}
 				switches={{}}
 				isPinnedPost={false}
 				isAdFreeUser={false}
@@ -523,6 +534,7 @@ export const TitleAndContributor = () => {
 				pageId=""
 				webTitle=""
 				ajaxUrl=""
+				abTests={{}}
 				switches={{}}
 				isPinnedPost={false}
 				isAdFreeUser={false}

--- a/dotcom-rendering/src/components/LiveBlock.tsx
+++ b/dotcom-rendering/src/components/LiveBlock.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import { RenderArticleElement } from '../lib/renderElement';
-import type { Switches } from '../types/config';
+import type { ServerSideTests, Switches } from '../types/config';
 import { LastUpdated } from './LastUpdated';
 import { LiveBlockContainer } from './LiveBlockContainer';
 import { ShareIcons } from './ShareIcons';
@@ -14,6 +14,7 @@ type Props = {
 	ajaxUrl: string;
 	isAdFreeUser: boolean;
 	isSensitive: boolean;
+	abTests: ServerSideTests;
 	switches: Switches;
 	isLiveUpdate?: boolean;
 	isPinnedPost: boolean;
@@ -29,6 +30,7 @@ export const LiveBlock = ({
 	ajaxUrl,
 	isAdFreeUser,
 	isSensitive,
+	abTests,
 	switches,
 	isLiveUpdate,
 	isPinnedPost,
@@ -74,6 +76,7 @@ export const LiveBlock = ({
 					webTitle={webTitle}
 					isAdFreeUser={isAdFreeUser}
 					isSensitive={isSensitive}
+					abTests={abTests}
 					switches={switches}
 					isPinnedPost={isPinnedPost}
 				/>

--- a/dotcom-rendering/src/components/LiveBlogBlocksAndAdverts.tsx
+++ b/dotcom-rendering/src/components/LiveBlogBlocksAndAdverts.tsx
@@ -1,6 +1,6 @@
 import { Fragment } from 'react';
 import { getLiveblogAdPositions } from '../lib/getLiveblogAdPositions';
-import type { Switches } from '../types/config';
+import type { ServerSideTests, Switches } from '../types/config';
 import { AdPlaceholder } from './AdPlaceholder.apps';
 import { AdSlot } from './AdSlot.web';
 import { useConfig } from './ConfigContext';
@@ -14,6 +14,7 @@ type Props = {
 	pageId: string;
 	webTitle: string;
 	ajaxUrl: string;
+	abTests: ServerSideTests;
 	switches: Switches;
 	isAdFreeUser: boolean;
 	isSensitive: boolean;
@@ -47,6 +48,7 @@ export const LiveBlogBlocksAndAdverts = ({
 	pageId,
 	webTitle,
 	ajaxUrl,
+	abTests,
 	switches,
 	isAdFreeUser,
 	isSensitive,
@@ -66,6 +68,7 @@ export const LiveBlogBlocksAndAdverts = ({
 				host={host}
 				ajaxUrl={ajaxUrl}
 				isLiveUpdate={isLiveUpdate}
+				abTests={abTests}
 				switches={switches}
 				isAdFreeUser={!isAdFreeUser}
 				isSensitive={isSensitive}

--- a/dotcom-rendering/src/components/LiveBlogRenderer.tsx
+++ b/dotcom-rendering/src/components/LiveBlogRenderer.tsx
@@ -1,5 +1,5 @@
 import { Hide } from '@guardian/source-react-components';
-import type { Switches } from '../types/config';
+import type { ServerSideTests, Switches } from '../types/config';
 import type { TagType } from '../types/tag';
 import { useConfig } from './ConfigContext';
 import { EnhancePinnedPost } from './EnhancePinnedPost.importable';
@@ -22,6 +22,7 @@ type Props = {
 	ajaxUrl: string;
 	isAdFreeUser: boolean;
 	isSensitive: boolean;
+	abTests: ServerSideTests;
 	switches: Switches;
 	isLiveUpdate?: boolean;
 	sectionId: string;
@@ -45,6 +46,7 @@ export const LiveBlogRenderer = ({
 	pageId,
 	webTitle,
 	ajaxUrl,
+	abTests,
 	switches,
 	isAdFreeUser,
 	isSensitive,
@@ -83,6 +85,7 @@ export const LiveBlogRenderer = ({
 							host={host}
 							ajaxUrl={ajaxUrl}
 							isLiveUpdate={isLiveUpdate}
+							abTests={abTests}
 							switches={switches}
 							isAdFreeUser={isAdFreeUser}
 							isSensitive={isSensitive}
@@ -135,6 +138,7 @@ export const LiveBlogRenderer = ({
 				host={host}
 				ajaxUrl={ajaxUrl}
 				isLiveUpdate={isLiveUpdate}
+				abTests={abTests}
 				switches={switches}
 				isAdFreeUser={isAdFreeUser}
 				isSensitive={isSensitive}

--- a/dotcom-rendering/src/components/MainMedia.tsx
+++ b/dotcom-rendering/src/components/MainMedia.tsx
@@ -3,7 +3,7 @@ import { ArticleDesign, ArticleDisplay } from '@guardian/libs';
 import { until } from '@guardian/source-foundations';
 import { getZIndex } from '../lib/getZIndex';
 import { RenderArticleElement } from '../lib/renderElement';
-import type { Switches } from '../types/config';
+import type { ServerSideTests, Switches } from '../types/config';
 import type { FEElement } from '../types/content';
 
 const mainMedia = css`
@@ -72,6 +72,7 @@ type Props = {
 	ajaxUrl: string;
 	isAdFreeUser: boolean;
 	isSensitive: boolean;
+	abTests: ServerSideTests;
 	switches: Switches;
 };
 
@@ -86,6 +87,7 @@ export const MainMedia = ({
 	ajaxUrl,
 	isAdFreeUser,
 	isSensitive,
+	abTests,
 	switches,
 }: Props) => {
 	return (
@@ -104,6 +106,7 @@ export const MainMedia = ({
 					webTitle={webTitle}
 					isAdFreeUser={isAdFreeUser}
 					isSensitive={isSensitive}
+					abTests={abTests}
 					switches={switches}
 					hideCaption={hideCaption}
 					starRating={starRating}

--- a/dotcom-rendering/src/components/PinnedPost.stories.tsx
+++ b/dotcom-rendering/src/components/PinnedPost.stories.tsx
@@ -81,6 +81,7 @@ export const Sport = () => {
 					ajaxUrl=""
 					isAdFreeUser={false}
 					isSensitive={false}
+					abTests={{}}
 					switches={{}}
 					isPinnedPost={true}
 				/>
@@ -126,6 +127,7 @@ export const News = () => {
 					ajaxUrl=""
 					isAdFreeUser={false}
 					isSensitive={false}
+					abTests={{}}
 					switches={{}}
 					isPinnedPost={true}
 				/>
@@ -171,6 +173,7 @@ export const Culture = () => {
 					ajaxUrl=""
 					isAdFreeUser={false}
 					isSensitive={false}
+					abTests={{}}
 					switches={{}}
 					isPinnedPost={true}
 				/>
@@ -216,6 +219,7 @@ export const Lifestyle = () => {
 					ajaxUrl=""
 					isAdFreeUser={false}
 					isSensitive={false}
+					abTests={{}}
 					switches={{}}
 					isPinnedPost={true}
 				/>
@@ -261,6 +265,7 @@ export const Opinion = () => {
 					ajaxUrl=""
 					isAdFreeUser={false}
 					isSensitive={false}
+					abTests={{}}
 					switches={{}}
 					isPinnedPost={true}
 				/>
@@ -306,6 +311,7 @@ export const SpecialReport = () => {
 					ajaxUrl=""
 					isAdFreeUser={false}
 					isSensitive={false}
+					abTests={{}}
 					switches={{}}
 					isPinnedPost={true}
 				/>
@@ -351,6 +357,7 @@ export const Labs = () => {
 					ajaxUrl=""
 					isAdFreeUser={false}
 					isSensitive={false}
+					abTests={{}}
 					switches={{}}
 					isPinnedPost={true}
 				/>

--- a/dotcom-rendering/src/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/layouts/CommentLayout.tsx
@@ -477,6 +477,7 @@ export const CommentLayout = (props: WebProps | AppsProps) => {
 									pageId={article.pageId}
 									webTitle={article.webTitle}
 									ajaxUrl={article.config.ajaxUrl}
+									abTests={article.config.abTests}
 									switches={article.config.switches}
 									isAdFreeUser={article.isAdFreeUser}
 									isSensitive={article.config.isSensitive}

--- a/dotcom-rendering/src/layouts/FullPageInteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/FullPageInteractiveLayout.tsx
@@ -25,7 +25,7 @@ import { decideLanguage, decideLanguageDirection } from '../lib/lang';
 import { renderElement } from '../lib/renderElement';
 import type { NavType } from '../model/extract-nav';
 import { palette as themePalette } from '../palette';
-import type { Switches } from '../types/config';
+import type { ServerSideTests, Switches } from '../types/config';
 import type { FEElement } from '../types/content';
 import type { DCRArticle } from '../types/frontend';
 import { interactiveGlobalStyles } from './lib/interactiveLegacyStyling';
@@ -46,6 +46,7 @@ type RendererProps = {
 	ajaxUrl: string;
 	isAdFreeUser: boolean;
 	isSensitive: boolean;
+	abTests: ServerSideTests;
 	switches: Switches;
 };
 
@@ -58,6 +59,7 @@ const Renderer = ({
 	ajaxUrl,
 	isAdFreeUser,
 	isSensitive,
+	abTests,
 	switches,
 }: RendererProps) => {
 	// const cleanedElements = elements.map(element =>
@@ -77,6 +79,7 @@ const Renderer = ({
 			ajaxUrl,
 			isAdFreeUser,
 			isSensitive,
+			abTests,
 			switches,
 		});
 
@@ -331,6 +334,7 @@ export const FullPageInteractiveLayout = ({ article, NAV, format }: Props) => {
 						pageId={article.pageId}
 						webTitle={article.webTitle}
 						ajaxUrl={article.config.ajaxUrl}
+						abTests={article.config.abTests}
 						switches={article.config.switches}
 						isAdFreeUser={article.isAdFreeUser}
 						isSensitive={article.config.isSensitive}

--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -394,6 +394,7 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 						pageId={article.pageId}
 						webTitle={article.webTitle}
 						ajaxUrl={article.config.ajaxUrl}
+						abTests={article.config.abTests}
 						switches={article.config.switches}
 						isAdFreeUser={article.isAdFreeUser}
 						isSensitive={article.config.isSensitive}

--- a/dotcom-rendering/src/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/InteractiveLayout.tsx
@@ -432,6 +432,7 @@ export const InteractiveLayout = (props: WebProps | AppsProps) => {
 										pageId={article.pageId}
 										webTitle={article.webTitle}
 										ajaxUrl={article.config.ajaxUrl}
+										abTests={article.config.abTests}
 										switches={article.config.switches}
 										isAdFreeUser={article.isAdFreeUser}
 										isSensitive={article.config.isSensitive}
@@ -535,6 +536,7 @@ export const InteractiveLayout = (props: WebProps | AppsProps) => {
 										pageId={article.pageId}
 										webTitle={article.webTitle}
 										ajaxUrl={article.config.ajaxUrl}
+										abTests={article.config.abTests}
 										switches={article.config.switches}
 										isSensitive={article.config.isSensitive}
 										isAdFreeUser={article.isAdFreeUser}

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -724,6 +724,7 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 										pageId={article.pageId}
 										webTitle={article.webTitle}
 										ajaxUrl={article.config.ajaxUrl}
+										abTests={article.config.abTests}
 										switches={article.config.switches}
 										isSensitive={article.config.isSensitive}
 										isAdFreeUser={article.isAdFreeUser}
@@ -857,6 +858,9 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 													}
 													sectionId={
 														article.config.section
+													}
+													abTests={
+														article.config.abTests
 													}
 													switches={
 														article.config.switches
@@ -1001,6 +1005,9 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 													}
 													sectionId={
 														article.config.section
+													}
+													abTests={
+														article.config.abTests
 													}
 													switches={
 														article.config.switches

--- a/dotcom-rendering/src/layouts/NewsletterSignupLayout.tsx
+++ b/dotcom-rendering/src/layouts/NewsletterSignupLayout.tsx
@@ -488,6 +488,7 @@ export const NewsletterSignupLayout = ({ article, NAV, format }: Props) => {
 									pageId={article.pageId}
 									webTitle={article.webTitle}
 									ajaxUrl={article.config.ajaxUrl}
+									abTests={article.config.abTests}
 									switches={article.config.switches}
 									isAdFreeUser={article.isAdFreeUser}
 									isSensitive={article.config.isSensitive}

--- a/dotcom-rendering/src/layouts/PictureLayout.tsx
+++ b/dotcom-rendering/src/layouts/PictureLayout.tsx
@@ -531,6 +531,7 @@ export const PictureLayout = (props: WebProps | AppsProps) => {
 									pageId={article.pageId}
 									webTitle={article.webTitle}
 									ajaxUrl={article.config.ajaxUrl}
+									abTests={article.config.abTests}
 									switches={article.config.switches}
 									isAdFreeUser={article.isAdFreeUser}
 									isSensitive={article.config.isSensitive}

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -516,6 +516,7 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 									pageId={article.pageId}
 									webTitle={article.webTitle}
 									ajaxUrl={article.config.ajaxUrl}
+									abTests={article.config.abTests}
 									switches={article.config.switches}
 									isAdFreeUser={article.isAdFreeUser}
 									isSensitive={article.config.isSensitive}

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -553,6 +553,7 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 									pageId={article.pageId}
 									webTitle={article.webTitle}
 									ajaxUrl={article.config.ajaxUrl}
+									abTests={article.config.abTests}
 									switches={article.config.switches}
 									isAdFreeUser={article.isAdFreeUser}
 									isSensitive={article.config.isSensitive}

--- a/dotcom-rendering/src/lib/ArticleRenderer.tsx
+++ b/dotcom-rendering/src/lib/ArticleRenderer.tsx
@@ -41,7 +41,7 @@ type Props = {
 	isDev: boolean;
 	isAdFreeUser: boolean;
 	isSensitive: boolean;
-	abTests?: ServerSideTests;
+	abTests: ServerSideTests;
 };
 
 export const ArticleRenderer = ({

--- a/dotcom-rendering/src/lib/renderElement.tsx
+++ b/dotcom-rendering/src/lib/renderElement.tsx
@@ -80,7 +80,7 @@ type Props = {
 	isSensitive: boolean;
 	switches: Switches;
 	isPinnedPost?: boolean;
-	abTests?: ServerSideTests;
+	abTests: ServerSideTests;
 };
 
 // updateRole modifies the role of an element in a way appropriate for most

--- a/dotcom-rendering/src/server/render.article.web.tsx
+++ b/dotcom-rendering/src/server/render.article.web.tsx
@@ -268,6 +268,7 @@ export const renderBlocks = ({
 				ajaxUrl={ajaxUrl}
 				isSensitive={isSensitive}
 				isAdFreeUser={isAdFreeUser}
+				abTests={{}} // @TODO: start passing `abTests` to the block endpoint
 				switches={switches}
 				isLiveUpdate={true}
 				sectionId={section}


### PR DESCRIPTION
## What does this change?

Make `abTests` required.

For the blocks endpoint, default to an empty object.

## Why?

Partial reimplementation of #10090 
