### PR TITLE
Only show web lightbox in test variant

### DIFF
--- a/dotcom-rendering/playwright/tests/parallel-2/lightbox.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/parallel-2/lightbox.e2e.spec.ts
@@ -78,9 +78,7 @@ test.describe('Lightbox', () => {
 	}) => {
 		await disableCMP(context);
 		await loadPageWithOverrides(page, photoEssayArticle, {
-			switchOverrides: {
-				lightbox: true,
-			},
+			configOverrides: { abTests: { lightboxVariant: 'variant' } },
 		});
 
 		await expectToNotBeVisible(page, '#gu-lightbox');
@@ -103,8 +101,8 @@ test.describe('Lightbox', () => {
 	}) => {
 		await disableCMP(context);
 		await loadPageWithOverrides(page, photoEssayArticle, {
-			switchOverrides: {
-				lightbox: true,
+			configOverrides: {
+				abTests: { lightboxVariant: 'variant' },
 			},
 		});
 
@@ -125,8 +123,8 @@ test.describe('Lightbox', () => {
 	test('should trap focus', async ({ context, page }) => {
 		await disableCMP(context);
 		await loadPageWithOverrides(page, photoEssayArticle, {
-			switchOverrides: {
-				lightbox: true,
+			configOverrides: {
+				abTests: { lightboxVariant: 'variant' },
 			},
 		});
 
@@ -174,8 +172,8 @@ test.describe('Lightbox', () => {
 	}) => {
 		await disableCMP(context);
 		await loadPageWithOverrides(page, photoEssayArticle, {
-			switchOverrides: {
-				lightbox: true,
+			configOverrides: {
+				abTests: { lightboxVariant: 'variant' },
 			},
 		});
 
@@ -265,8 +263,8 @@ test.describe('Lightbox', () => {
 
 		await disableCMP(context);
 		await loadPageWithOverrides(page, photoEssayArticle, {
-			switchOverrides: {
-				lightbox: true,
+			configOverrides: {
+				abTests: { lightboxVariant: 'variant' },
 			},
 		});
 
@@ -307,8 +305,8 @@ test.describe('Lightbox', () => {
 	}) => {
 		await disableCMP(context);
 		await loadPageWithOverrides(page, photoEssayArticle, {
-			switchOverrides: {
-				lightbox: true,
+			configOverrides: {
+				abTests: { lightboxVariant: 'variant' },
 			},
 		});
 
@@ -352,8 +350,8 @@ test.describe('Lightbox', () => {
 	}) => {
 		await disableCMP(context);
 		await loadPageWithOverrides(page, photoEssayArticle, {
-			switchOverrides: {
-				lightbox: true,
+			configOverrides: {
+				abTests: { lightboxVariant: 'variant' },
 			},
 		});
 
@@ -397,8 +395,8 @@ test.describe('Lightbox', () => {
 	}) => {
 		await disableCMP(context);
 		await loadPageWithOverrides(page, LiveBlog, {
-			switchOverrides: {
-				lightbox: true,
+			configOverrides: {
+				abTests: { lightboxVariant: 'variant' },
 			},
 		});
 
@@ -428,8 +426,8 @@ test.describe('Lightbox', () => {
 	}) => {
 		await disableCMP(context);
 		await loadPageWithOverrides(page, photoEssayArticle, {
-			switchOverrides: {
-				lightbox: true,
+			configOverrides: {
+				abTests: { lightboxVariant: 'variant' },
 			},
 		});
 
@@ -461,8 +459,8 @@ test.describe('Lightbox', () => {
 	}) => {
 		await disableCMP(context);
 		await loadPageWithOverrides(page, photoEssayArticle, {
-			switchOverrides: {
-				lightbox: true,
+			configOverrides: {
+				abTests: { lightboxVariant: 'variant' },
 			},
 		});
 

--- a/dotcom-rendering/src/components/ArticlePage.tsx
+++ b/dotcom-rendering/src/components/ArticlePage.tsx
@@ -58,9 +58,10 @@ export const ArticlePage = (props: WebProps | AppProps) => {
 		adUnit: article.config.adUnit,
 	});
 
-	const lightboxEnabled =
-		!!article.config.switches.lightbox ||
+	const isInLightboxTest =
 		article.config.abTests.lightboxVariant === 'variant';
+
+	const webLightbox = renderingTarget === 'Web' && isInLightboxTest;
 
 	return (
 		<StrictMode>
@@ -98,7 +99,7 @@ export const ArticlePage = (props: WebProps | AppProps) => {
 			/>
 			<SkipTo id="maincontent" label="Skip to main content" />
 			<SkipTo id="navigation" label="Skip to navigation" />
-			{lightboxEnabled && article.imagesForLightbox.length > 0 && (
+			{webLightbox && article.imagesForLightbox.length > 0 && (
 				<>
 					<LightboxLayout
 						imageCount={article.imagesForLightbox.length}

--- a/dotcom-rendering/src/components/ImageBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/components/ImageBlockComponent.stories.tsx
@@ -67,6 +67,7 @@ export const StandardArticle = () => {
 						design: ArticleDesign.Standard,
 						theme: Pillar.News,
 					}}
+					isInLightboxTest={false}
 				/>
 			</Figure>
 		</Wrapper>
@@ -93,6 +94,7 @@ export const Immersive = () => {
 						design: ArticleDesign.Standard,
 						theme: Pillar.News,
 					}}
+					isInLightboxTest={false}
 				/>
 			</Figure>
 		</Wrapper>
@@ -119,6 +121,7 @@ export const Showcase = () => {
 						design: ArticleDesign.Standard,
 						theme: Pillar.News,
 					}}
+					isInLightboxTest={false}
 				/>
 			</Figure>
 		</Wrapper>
@@ -145,6 +148,7 @@ export const Thumbnail = () => {
 						design: ArticleDesign.Standard,
 						theme: Pillar.News,
 					}}
+					isInLightboxTest={false}
 				/>
 			</Figure>
 		</Wrapper>
@@ -171,6 +175,7 @@ export const Supporting = () => {
 						design: ArticleDesign.Standard,
 						theme: Pillar.News,
 					}}
+					isInLightboxTest={false}
 				/>
 			</Figure>
 		</Wrapper>
@@ -198,6 +203,7 @@ export const HideCaption = () => {
 						theme: Pillar.News,
 					}}
 					hideCaption={true}
+					isInLightboxTest={false}
 				/>
 			</Figure>
 		</Wrapper>
@@ -226,6 +232,7 @@ export const InlineTitle = () => {
 					}}
 					title="This is the title text"
 					hideCaption={true}
+					isInLightboxTest={false}
 				/>
 			</Figure>
 		</Wrapper>
@@ -260,6 +267,7 @@ export const InlineTitleMobile = () => {
 					}}
 					title="This is the title text"
 					hideCaption={true}
+					isInLightboxTest={false}
 				/>
 			</Figure>
 		</Wrapper>
@@ -294,6 +302,7 @@ export const ImmersiveTitle = () => {
 					}}
 					title="This is the title text"
 					hideCaption={true}
+					isInLightboxTest={false}
 				/>
 			</Figure>
 		</Wrapper>
@@ -322,6 +331,7 @@ export const ShowcaseTitle = () => {
 					}}
 					title="This is the title text"
 					hideCaption={true}
+					isInLightboxTest={false}
 				/>
 			</Figure>
 		</Wrapper>
@@ -374,6 +384,7 @@ export const HalfWidth = () => {
 						design: ArticleDesign.Standard,
 						theme: Pillar.News,
 					}}
+					isInLightboxTest={false}
 				/>
 			</Figure>
 			<p>
@@ -442,6 +453,7 @@ export const HalfWidthMobile = () => {
 						design: ArticleDesign.Standard,
 						theme: Pillar.News,
 					}}
+					isInLightboxTest={false}
 				/>
 			</Figure>
 			<p>
@@ -510,6 +522,7 @@ export const HalfWidthWide = () => {
 						design: ArticleDesign.Standard,
 						theme: Pillar.News,
 					}}
+					isInLightboxTest={false}
 				/>
 			</Figure>
 			<p>

--- a/dotcom-rendering/src/components/ImageBlockComponent.tsx
+++ b/dotcom-rendering/src/components/ImageBlockComponent.tsx
@@ -1,4 +1,3 @@
-import type { Switches } from '../types/config';
 import type { ImageBlockElement } from '../types/content';
 import { ImageComponent } from './ImageComponent';
 
@@ -10,7 +9,7 @@ type Props = {
 	isMainMedia?: boolean;
 	starRating?: number;
 	isAvatar?: boolean;
-	switches?: Switches;
+	isInLightboxTest: boolean;
 };
 
 export const ImageBlockComponent = ({
@@ -21,7 +20,7 @@ export const ImageBlockComponent = ({
 	isMainMedia,
 	starRating,
 	isAvatar,
-	switches,
+	isInLightboxTest,
 }: Props) => {
 	const { role } = element;
 	return (
@@ -34,7 +33,7 @@ export const ImageBlockComponent = ({
 			role={role}
 			title={title}
 			isAvatar={isAvatar}
-			switches={switches}
+			isInLightboxTest={isInLightboxTest}
 		/>
 	);
 };

--- a/dotcom-rendering/src/components/ImageComponent.tsx
+++ b/dotcom-rendering/src/components/ImageComponent.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { ArticleDesign, ArticleDisplay } from '@guardian/libs';
+import { ArticleDesign, ArticleDisplay, isUndefined } from '@guardian/libs';
 import {
 	between,
 	from,
@@ -11,7 +11,6 @@ import { decidePalette } from '../lib/decidePalette';
 import { getLargest, getMaster } from '../lib/image';
 import { isWideEnough } from '../lib/lightbox';
 import { palette as themePalette } from '../palette';
-import type { Switches } from '../types/config';
 import type { ImageBlockElement, RoleType } from '../types/content';
 import type { Palette } from '../types/palette';
 import { AppsLightboxImage } from './AppsLightboxImage.importable';
@@ -32,7 +31,7 @@ type Props = {
 	starRating?: number;
 	title?: string;
 	isAvatar?: boolean;
-	switches?: Switches;
+	isInLightboxTest: boolean;
 };
 
 const starsWrapper = css`
@@ -238,7 +237,7 @@ export const ImageComponent = ({
 	starRating,
 	title,
 	isAvatar,
-	switches,
+	isInLightboxTest,
 }: Props) => {
 	const { renderingTarget } = useConfig();
 	// Its possible the tools wont send us any images urls
@@ -264,6 +263,9 @@ export const ImageComponent = ({
 		return null;
 	}
 
+	const webLightbox =
+		renderingTarget === 'Web' && isInLightboxTest && isWideEnough(image);
+
 	/**
 	 * We use height and width for two things.
 	 *
@@ -288,7 +290,7 @@ export const ImageComponent = ({
 		return (
 			<div
 				id={
-					element.position !== undefined
+					!isUndefined(element.position)
 						? `img-${element.position}`
 						: ''
 				}
@@ -347,17 +349,15 @@ export const ImageComponent = ({
 				{!!title && (
 					<ImageTitle title={title} role={role} palette={palette} />
 				)}
-				{switches?.lightbox === true &&
-					isWideEnough(image) &&
-					element.position !== undefined && (
-						<LightboxLink
-							role={role}
-							format={format}
-							elementId={element.elementId}
-							isMainMedia={isMainMedia}
-							position={element.position}
-						/>
-					)}
+				{webLightbox && !isUndefined(element.position) && (
+					<LightboxLink
+						role={role}
+						format={format}
+						elementId={element.elementId}
+						isMainMedia={isMainMedia}
+						position={element.position}
+					/>
+				)}
 			</div>
 		);
 	}
@@ -414,17 +414,15 @@ export const ImageComponent = ({
 				{!!title && (
 					<ImageTitle title={title} role={role} palette={palette} />
 				)}
-				{switches?.lightbox === true &&
-					isWideEnough(image) &&
-					element.position !== undefined && (
-						<LightboxLink
-							role={role}
-							format={format}
-							elementId={element.elementId}
-							isMainMedia={isMainMedia}
-							position={element.position}
-						/>
-					)}
+				{webLightbox && !isUndefined(element.position) && (
+					<LightboxLink
+						role={role}
+						format={format}
+						elementId={element.elementId}
+						isMainMedia={isMainMedia}
+						position={element.position}
+					/>
+				)}
 			</div>
 		);
 	}
@@ -520,17 +518,15 @@ export const ImageComponent = ({
 					<ImageTitle title={title} role={role} palette={palette} />
 				)}
 
-				{switches?.lightbox === true &&
-					isWideEnough(image) &&
-					element.position !== undefined && (
-						<LightboxLink
-							role={role}
-							format={format}
-							elementId={element.elementId}
-							isMainMedia={isMainMedia}
-							position={element.position}
-						/>
-					)}
+				{webLightbox && !isUndefined(element.position) && (
+					<LightboxLink
+						role={role}
+						format={format}
+						elementId={element.elementId}
+						isMainMedia={isMainMedia}
+						position={element.position}
+					/>
+				)}
 			</div>
 			{isMainMedia ? (
 				<Hide when="below" breakpoint="tablet">

--- a/dotcom-rendering/src/components/MultiImageBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/components/MultiImageBlockComponent.stories.tsx
@@ -23,6 +23,7 @@ export const SingleImage = () => {
 					theme: Pillar.News,
 				}}
 				images={oneImage}
+				isInLightboxTest={false}
 			/>
 		</Section>
 	);
@@ -39,6 +40,7 @@ export const SingleImageWithCaption = () => {
 					theme: Pillar.News,
 				}}
 				images={oneImage}
+				isInLightboxTest={false}
 				caption="This is the caption for a single image"
 			/>
 		</Section>
@@ -56,6 +58,7 @@ export const SideBySide = () => {
 					theme: Pillar.News,
 				}}
 				images={twoImages}
+				isInLightboxTest={false}
 			/>
 		</Section>
 	);
@@ -72,6 +75,7 @@ export const SideBySideWithCaption = () => {
 					theme: Pillar.News,
 				}}
 				images={twoImages}
+				isInLightboxTest={false}
 				caption="This is the caption for side by side"
 			/>
 		</Section>
@@ -89,6 +93,7 @@ export const OneAboveTwo = () => {
 					theme: Pillar.News,
 				}}
 				images={threeImages}
+				isInLightboxTest={false}
 			/>
 		</Section>
 	);
@@ -105,6 +110,7 @@ export const OneAboveTwoWithCaption = () => {
 					theme: Pillar.News,
 				}}
 				images={threeImages}
+				isInLightboxTest={false}
 				caption="This is the caption for one above two"
 			/>
 		</Section>
@@ -122,6 +128,7 @@ export const GridOfFour = () => {
 					theme: Pillar.News,
 				}}
 				images={fourImages}
+				isInLightboxTest={false}
 			/>
 		</Section>
 	);
@@ -138,6 +145,7 @@ export const GridOfFourWithCaption = () => {
 					theme: Pillar.News,
 				}}
 				images={fourImages}
+				isInLightboxTest={false}
 				caption="This is the caption for grid of four"
 			/>
 		</Section>

--- a/dotcom-rendering/src/components/MultiImageBlockComponent.tsx
+++ b/dotcom-rendering/src/components/MultiImageBlockComponent.tsx
@@ -1,6 +1,5 @@
 import { css } from '@emotion/react';
 import { from, space, until } from '@guardian/source-foundations';
-import type { Switches } from '../types/config';
 import type { ImageBlockElement } from '../types/content';
 import { Caption } from './Caption';
 import { GridItem } from './GridItem';
@@ -10,7 +9,7 @@ type Props = {
 	images: ImageBlockElement[];
 	format: ArticleFormat;
 	caption?: string;
-	switches?: Switches;
+	isInLightboxTest: boolean;
 };
 
 const ieFallback = css`
@@ -104,12 +103,12 @@ const OneImage = ({
 	images,
 	format,
 	caption,
-	switches,
+	isInLightboxTest,
 }: {
 	images: [ImageBlockElement];
 	format: ArticleFormat;
 	caption?: string;
-	switches?: Switches;
+	isInLightboxTest: boolean;
 }) => (
 	<div css={wrapper}>
 		<ImageComponent
@@ -117,7 +116,7 @@ const OneImage = ({
 			element={images[0]}
 			hideCaption={true}
 			role={images[0].role}
-			switches={switches}
+			isInLightboxTest={isInLightboxTest}
 		/>
 		{!!caption && (
 			<Caption
@@ -133,12 +132,12 @@ const TwoImage = ({
 	images,
 	format,
 	caption,
-	switches,
+	isInLightboxTest,
 }: {
 	images: [ImageBlockElement, ImageBlockElement];
 	format: ArticleFormat;
 	caption?: string;
-	switches?: Switches;
+	isInLightboxTest: boolean;
 }) => (
 	<div css={wrapper}>
 		<SideBySideGrid>
@@ -148,7 +147,7 @@ const TwoImage = ({
 					format={format}
 					hideCaption={true}
 					role={images[0].role}
-					switches={switches}
+					isInLightboxTest={isInLightboxTest}
 				/>
 			</GridItem>
 			<GridItem area="second">
@@ -157,7 +156,7 @@ const TwoImage = ({
 					format={format}
 					hideCaption={true}
 					role={images[1].role}
-					switches={switches}
+					isInLightboxTest={isInLightboxTest}
 				/>
 			</GridItem>
 		</SideBySideGrid>
@@ -175,12 +174,12 @@ const ThreeImage = ({
 	images,
 	format,
 	caption,
-	switches,
+	isInLightboxTest,
 }: {
 	images: [ImageBlockElement, ImageBlockElement, ImageBlockElement];
 	format: ArticleFormat;
 	caption?: string;
-	switches?: Switches;
+	isInLightboxTest: boolean;
 }) => (
 	<div css={wrapper}>
 		<OneAboveTwoGrid>
@@ -190,7 +189,7 @@ const ThreeImage = ({
 					format={format}
 					hideCaption={true}
 					role={images[0].role}
-					switches={switches}
+					isInLightboxTest={isInLightboxTest}
 				/>
 			</GridItem>
 			<GridItem area="second">
@@ -199,7 +198,7 @@ const ThreeImage = ({
 					format={format}
 					hideCaption={true}
 					role={images[1].role}
-					switches={switches}
+					isInLightboxTest={isInLightboxTest}
 				/>
 			</GridItem>
 			<GridItem area="third">
@@ -208,7 +207,7 @@ const ThreeImage = ({
 					format={format}
 					hideCaption={true}
 					role={images[2].role}
-					switches={switches}
+					isInLightboxTest={isInLightboxTest}
 				/>
 			</GridItem>
 		</OneAboveTwoGrid>
@@ -226,7 +225,7 @@ const FourImage = ({
 	images,
 	format,
 	caption,
-	switches,
+	isInLightboxTest,
 }: {
 	images: [
 		ImageBlockElement,
@@ -236,7 +235,7 @@ const FourImage = ({
 	];
 	format: ArticleFormat;
 	caption?: string;
-	switches?: Switches;
+	isInLightboxTest: boolean;
 }) => (
 	<div css={wrapper}>
 		<GridOfFour>
@@ -246,7 +245,7 @@ const FourImage = ({
 					format={format}
 					hideCaption={true}
 					role={images[0].role}
-					switches={switches}
+					isInLightboxTest={isInLightboxTest}
 				/>
 			</GridItem>
 			<GridItem area="second">
@@ -255,7 +254,7 @@ const FourImage = ({
 					format={format}
 					hideCaption={true}
 					role={images[1].role}
-					switches={switches}
+					isInLightboxTest={isInLightboxTest}
 				/>
 			</GridItem>
 			<GridItem area="third">
@@ -264,7 +263,7 @@ const FourImage = ({
 					format={format}
 					hideCaption={true}
 					role={images[2].role}
-					switches={switches}
+					isInLightboxTest={isInLightboxTest}
 				/>
 			</GridItem>
 			<GridItem area="forth">
@@ -273,7 +272,7 @@ const FourImage = ({
 					format={format}
 					hideCaption={true}
 					role={images[3].role}
-					switches={switches}
+					isInLightboxTest={isInLightboxTest}
 				/>
 			</GridItem>
 		</GridOfFour>
@@ -291,7 +290,7 @@ export const MultiImageBlockComponent = ({
 	images,
 	format,
 	caption,
-	switches,
+	isInLightboxTest,
 }: Props) => {
 	const [one, two, three, four] = images;
 
@@ -301,7 +300,7 @@ export const MultiImageBlockComponent = ({
 				images={[one, two, three, four]}
 				format={format}
 				caption={caption}
-				switches={switches}
+				isInLightboxTest={isInLightboxTest}
 			/>
 		);
 	}
@@ -312,7 +311,7 @@ export const MultiImageBlockComponent = ({
 				images={[one, two, three]}
 				format={format}
 				caption={caption}
-				switches={switches}
+				isInLightboxTest={isInLightboxTest}
 			/>
 		);
 	}
@@ -323,7 +322,7 @@ export const MultiImageBlockComponent = ({
 				images={[one, two]}
 				format={format}
 				caption={caption}
-				switches={switches}
+				isInLightboxTest={isInLightboxTest}
 			/>
 		);
 	}
@@ -334,7 +333,7 @@ export const MultiImageBlockComponent = ({
 				images={[one]}
 				format={format}
 				caption={caption}
-				switches={switches}
+				isInLightboxTest={isInLightboxTest}
 			/>
 		);
 	}

--- a/dotcom-rendering/src/lib/renderElement.tsx
+++ b/dotcom-rendering/src/lib/renderElement.tsx
@@ -140,6 +140,8 @@ export const renderElement = ({
 		format.design === ArticleDesign.LiveBlog ||
 		format.design === ArticleDesign.DeadBlog;
 
+	const isInLightboxTest = abTests.lightboxVariant === 'variant';
+
 	switch (element._type) {
 		case 'model.dotcomrendering.pageElements.AudioAtomBlockElement':
 			return (
@@ -347,7 +349,7 @@ export const renderElement = ({
 					starRating={starRating ?? element.starRating}
 					title={element.title}
 					isAvatar={element.isAvatar}
-					switches={switches}
+					isInLightboxTest={isInLightboxTest}
 				/>
 			);
 		case 'model.dotcomrendering.pageElements.InstagramBlockElement':
@@ -450,7 +452,7 @@ export const renderElement = ({
 					key={index}
 					images={element.images}
 					caption={element.caption}
-					switches={switches}
+					isInLightboxTest={isInLightboxTest}
 				/>
 			);
 		case 'model.dotcomrendering.pageElements.NewsletterSignupBlockElement':


### PR DESCRIPTION
## What does this change?

Ensure the web lighbox is only shown for users in the server-side test variant.

## Why?

Reimplementation of #10090 

## Screenshots

<img width="1919" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/76776/fef4aa73-8b27-41c4-9892-3b9a2ce38b6b">

<img width="1920" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/76776/7523e6f4-342f-4194-9bac-bf3354fe0cba">
