### PR TITLE
Use textSansSizes over textSans

### DIFF
--- a/dotcom-rendering/src/components/ArticleHeadline.tsx
+++ b/dotcom-rendering/src/components/ArticleHeadline.tsx
@@ -6,6 +6,7 @@ import {
 	headline,
 	space,
 	textSans,
+	textSansSizes,
 	until,
 } from '@guardian/source-foundations';
 import { interactiveLegacyClasses } from '../layouts/lib/interactiveLegacyStyling';
@@ -46,7 +47,7 @@ const labsFont = css`
 	${textSans.xlarge({ fontWeight: 'bold' })};
 	line-height: 32px;
 	${from.tablet} {
-		${textSans.xxxlarge({ fontWeight: 'bold' })};
+		font-size: ${textSansSizes.xxxlarge};
 		line-height: 38px;
 	}
 `;

--- a/dotcom-rendering/src/components/ArticleHeadline.tsx
+++ b/dotcom-rendering/src/components/ArticleHeadline.tsx
@@ -4,6 +4,7 @@ import { ArticleDesign, ArticleDisplay, ArticleSpecial } from '@guardian/libs';
 import {
 	from,
 	headline,
+	lineHeights,
 	space,
 	textSans,
 	textSansSizes,
@@ -48,7 +49,7 @@ const labsFont = css`
 	line-height: 32px;
 	${from.tablet} {
 		font-size: ${textSansSizes.xxxlarge};
-		line-height: 38px;
+		line-height: ${lineHeights.regular};
 	}
 `;
 


### PR DESCRIPTION
## Example PR to help with illustrate some examples to discuss

In Supporter revenue, we were wondering about how we override `font-size` for an element for different media queries. 

There seems to be two ways that we do this:
1. [Override then with absolute values e.g. `font-size: 24px`](https://github.com/guardian/dotcom-rendering/blob/513d3439c90201c31ef0c1d592bef666460c435e/dotcom-rendering/src/components/ArticleHeadline.tsx#L69-L78)
1. [Use the full ${font.size()} in the media query](https://github.com/guardian/dotcom-rendering/blob/513d3439c90201c31ef0c1d592bef666460c435e/dotcom-rendering/src/components/ArticleHeadline.tsx#L38-L43)

There are cons to both:
1. Override
    1. Values are then out of sync with our design system
    1. Doesn't include the related `font-weight` and `line-height` values 
    1. Creates design discrepancies
    1. Potentially adds to clutter from inconsistencies
    1. Design debt
    1. Making it harder for engineers to just choose a size when building features
2. Generates repeated CSS thus file-size overhead by repeating the whole css block, specifically the `font-family` property ([you can see this here](https://codesandbox.io/p/sandbox/emotion-playground-forked-qsgs6r?file=%2Fsrc%2Findex.js%3A29%2C54&layout=%257B%2522sidebarPanel%2522%253A%2522EXPLORER%2522%252C%2522rootPanelGroup%2522%253A%257B%2522direction%2522%253A%2522horizontal%2522%252C%2522contentType%2522%253A%2522UNKNOWN%2522%252C%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522id%2522%253A%2522ROOT_LAYOUT%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522UNKNOWN%2522%252C%2522direction%2522%253A%2522vertical%2522%252C%2522id%2522%253A%2522clr6i29tc00063b6kssv3j0n1%2522%252C%2522sizes%2522%253A%255B70%252C30%255D%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522EDITOR%2522%252C%2522direction%2522%253A%2522horizontal%2522%252C%2522id%2522%253A%2522EDITOR%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522EDITOR%2522%252C%2522id%2522%253A%2522clr6i29tc00023b6kd09aye5z%2522%257D%255D%257D%252C%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522SHELLS%2522%252C%2522direction%2522%253A%2522horizontal%2522%252C%2522id%2522%253A%2522SHELLS%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522SHELLS%2522%252C%2522id%2522%253A%2522clr6i29tc00033b6kwgool7hy%2522%257D%255D%252C%2522sizes%2522%253A%255B100%255D%257D%255D%257D%252C%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522DEVTOOLS%2522%252C%2522direction%2522%253A%2522vertical%2522%252C%2522id%2522%253A%2522DEVTOOLS%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522DEVTOOLS%2522%252C%2522id%2522%253A%2522clr6i29tc00053b6kxu8n9lcc%2522%257D%255D%252C%2522sizes%2522%253A%255B100%255D%257D%255D%252C%2522sizes%2522%253A%255B50%252C50%255D%257D%252C%2522tabbedPanels%2522%253A%257B%2522clr6i29tc00023b6kd09aye5z%2522%253A%257B%2522id%2522%253A%2522clr6i29tc00023b6kd09aye5z%2522%252C%2522tabs%2522%253A%255B%257B%2522id%2522%253A%2522clr6i36bf00303b6jyz0129a9%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522FILE%2522%252C%2522initialSelections%2522%253A%255B%257B%2522startLineNumber%2522%253A29%252C%2522startColumn%2522%253A54%252C%2522endLineNumber%2522%253A29%252C%2522endColumn%2522%253A54%257D%255D%252C%2522filepath%2522%253A%2522%252Fsrc%252Findex.js%2522%252C%2522state%2522%253A%2522IDLE%2522%257D%255D%252C%2522activeTabId%2522%253A%2522clr6i36bf00303b6jyz0129a9%2522%257D%252C%2522clr6i29tc00053b6kxu8n9lcc%2522%253A%257B%2522tabs%2522%253A%255B%257B%2522id%2522%253A%2522clr6i29tc00043b6khlvg3xd9%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522UNASSIGNED_PORT%2522%252C%2522port%2522%253A0%252C%2522path%2522%253A%2522%252F%2522%257D%255D%252C%2522id%2522%253A%2522clr6i29tc00053b6kxu8n9lcc%2522%252C%2522activeTabId%2522%253A%2522clr6i29tc00043b6khlvg3xd9%2522%257D%252C%2522clr6i29tc00033b6kwgool7hy%2522%253A%257B%2522tabs%2522%253A%255B%255D%252C%2522id%2522%253A%2522clr6i29tc00033b6kwgool7hy%2522%257D%257D%252C%2522showDevtools%2522%253Atrue%252C%2522showShells%2522%253Atrue%252C%2522showSidebar%2522%253Atrue%252C%2522sidebarPanelSize%2522%253A15%257D))

It feels like we should avoid option `1` where possible for design reasons.

Option `2` feels like the nicer option from a design perspective, but has the potential to add a lot of file-size overhead.

This example PR suggests a third way, which uses the design system, and avoids repetition of CSS. 

It does however suffer from needing to remember to include both `line-height` and `font-size` (and potentially `font-weight`).

Another solution could be that we have a property to the method to avoid re-iterating the `font-family` e.g. `textSans.xxxlarge({ excludeFamily: true })`.

Or to have another method - e.g. `textSansSize.xxxlarge()`?

Has anyone else come up against this, or are the above used methods good enough?

