### PR TITLE
Bump braze-components dependency to v16.3.0

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -50,7 +50,7 @@
 		"@emotion/react": "11.11.1",
 		"@emotion/server": "11.11.0",
 		"@guardian/ab-core": "5.0.0",
-		"@guardian/braze-components": "16.2.0",
+		"@guardian/braze-components": "16.3.0",
 		"@guardian/bridget": "2.6.0",
 		"@guardian/browserslist-config": "5.0.0",
 		"@guardian/cdk": "50.13.0",

--- a/dotcom-rendering/src/components/SlotBodyEnd/BrazeEpic.stories.tsx
+++ b/dotcom-rendering/src/components/SlotBodyEnd/BrazeEpic.stories.tsx
@@ -263,6 +263,77 @@ BrazeEpic_SpecialHeader_Component.args = {
 
 BrazeEpic_SpecialHeader_Component.storyName = 'Epic with special header';
 
+// Braze Generic Newsletter Epic
+// ---------------------------------------
+export const BrazeEpicNewsletter_Generic_Component = (
+	args: BrazeMessageProps & { componentName: string },
+): ReactElement => {
+	const [BrazeMessage, setBrazeMessage] =
+		useState<typeof BrazeEndOfArticleComponent>();
+
+	useEffect(() => {
+		import('@guardian/braze-components')
+			.then((module) => {
+				setBrazeMessage(() => module.BrazeEndOfArticleComponent);
+			})
+			.catch((e) =>
+				console.error(
+					`braze-components dynamic import - error: ${String(e)}`,
+				),
+			);
+	}, []);
+
+	if (BrazeMessage) {
+		const brazeMessageProps: BrazeMessageProps = {
+			newsletterId: args.newsletterId,
+			imageUrl: args.imageUrl,
+			header: args.header,
+			frequency: args.frequency,
+			paragraph1: args.paragraph1,
+			paragraph2: args.paragraph2,
+			ophanComponentId: args.ophanComponentId,
+		};
+
+		return (
+			<BrazeMessage
+				componentName={args.componentName}
+				subscribeToNewsletter={() => Promise.resolve()}
+				logButtonClickWithBraze={(internalButtonId) => {
+					console.log(
+						`Button with internal ID ${internalButtonId} clicked`,
+					);
+				}}
+				submitComponentEvent={(componentEvent) => {
+					console.log(
+						'submitComponentEvent called with: ',
+						componentEvent,
+					);
+				}}
+				brazeMessageProps={brazeMessageProps}
+				fetchEmail={fetchEmail}
+			/>
+		);
+	}
+	return <div>Loading...</div>;
+};
+
+BrazeEpicNewsletter_Generic_Component.args = {
+	slotName: 'EndOfArticle',
+	newsletterId: '6023',
+	imageUrl:
+		'https://i.guim.co.uk/img/media/898c5401ab51b983dc4b2508aaaf0735e6bda0e2/0_0_2000_2000/2000.png?width=400&quality=75&s=9191ec413d946058f37caced7edd0b90',
+	header: `Newsletter title`,
+	frequency: 'Frequency',
+	paragraph1:
+		'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+	paragraph2:
+		'We thought you should know this newsletter may contain information about Guardian products and services.',
+	componentName: 'NewsletterEpic',
+	ophanComponentId: 'example_ophan_component_id',
+};
+
+BrazeEpicNewsletter_Generic_Component.storyName = 'Newsletter - Generic';
+
 // Braze Newsletter Epic - UK - MorningBriefing
 // ---------------------------------------
 export const BrazeNewsletterEpic_UK_MorningBriefing_Component = (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -348,8 +348,8 @@ importers:
         specifier: 5.0.0
         version: 5.0.0(tslib@2.6.2)(typescript@5.1.3)
       '@guardian/braze-components':
-        specifier: 16.2.0
-        version: 16.2.0(@emotion/react@11.11.1)(@guardian/libs@15.7.1)(@guardian/source-foundations@13.2.0)(@guardian/source-react-components-development-kitchen@15.0.0)(@guardian/source-react-components@16.0.1)(react@18.2.0)
+        specifier: 16.3.0
+        version: 16.3.0(@emotion/react@11.11.1)(@guardian/libs@15.7.1)(@guardian/source-foundations@13.2.0)(@guardian/source-react-components-development-kitchen@15.0.0)(@guardian/source-react-components@16.0.1)(react@18.2.0)
       '@guardian/bridget':
         specifier: 2.6.0
         version: 2.6.0
@@ -4797,8 +4797,8 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@guardian/braze-components@16.2.0(@emotion/react@11.11.1)(@guardian/libs@15.7.1)(@guardian/source-foundations@13.2.0)(@guardian/source-react-components-development-kitchen@15.0.0)(@guardian/source-react-components@16.0.1)(react@18.2.0):
-    resolution: {integrity: sha512-+wRKpo0LChL0PUqgRkqg/LrDpnz5ufIML1VokPwjZtyHpDMacB3393L3pBmKH46SNyBddmkRG98opfv1hdjqVA==}
+  /@guardian/braze-components@16.3.0(@emotion/react@11.11.1)(@guardian/libs@15.7.1)(@guardian/source-foundations@13.2.0)(@guardian/source-react-components-development-kitchen@15.0.0)(@guardian/source-react-components@16.0.1)(react@18.2.0):
+    resolution: {integrity: sha512-JQ9MkrJx6+7OXxwqPy2lfFNKvvmFGTCbdOedC2KczdLKusKUSWIw3EzLwdoRpgMTXsQSVpqrJ5N/VM3wDsAAxQ==}
     engines: {node: ^18.15 || ^20.9}
     peerDependencies:
       '@emotion/react': ^11.1.2


### PR DESCRIPTION
## What does this change?
Updates the Braze-components dependency to latest v16.3.0

## Why?
We've added a new self-serve Newsletter Epic to the system, which will allow Marketing colleagues to promote any newsletter in the end-of-article slot rather than having to rely on engineers to build epics on a per-newsletter basis.

## Screenshots
n/a - change doesn't impact on DCR visual display
