### PR TITLE
Remove storybook commands from root package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Run `pnpm` in the root directory of this project to install packages.
 
 ## Run
 
-You should always `cd` into the correct subdirectory before running commands (e.g `make dev` for dotcom-rendering, or `pnpm watch` for apps-rendering).
+You should generally `cd` into the correct subdirectory before running commands (e.g `make dev` for dotcom-rendering, or `pnpm watch` for apps-rendering) except for running or building storybook for multiple apps.
 
 ### `apps rendering`
 
@@ -35,3 +35,18 @@ Go to [apps rendering](apps-rendering/README.md) for more details.
 ### `dotcom rendering`
 
 Go to [dotcom rendering](dotcom-rendering/README.md) for more details.
+
+## Root actions
+
+Most commands are run from within each project but the following are managed from the monorepo root:
+
+### Storybook/Chromatic
+
+`pnpm storybook` - Runs Storybook for all projects
+`pnpm build-storybook` - Builds Storybook for all projects
+
+Chromatic now runs at project level. `cd` into the project dir and run `pnpm chromatic -t [CHROMATIC PROJECT TOKEN]`
+
+You can find the token in the project Chromatic instance.
+
+To run Chromatic in CI on your pr, add the `run_chromatic` label once you're ready to check for visual regressions.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Run `pnpm` in the root directory of this project to install packages.
 
 ## Run
 
-You should always `cd` into the correct subdirectory before running commands (e.g `make dev` for dotcom-rendering, or `pnpm watch` for apps-rendering) except for storybook.
+You should always `cd` into the correct subdirectory before running commands (e.g `make dev` for dotcom-rendering, or `pnpm watch` for apps-rendering).
 
 ### `apps rendering`
 
@@ -35,18 +35,3 @@ Go to [apps rendering](apps-rendering/README.md) for more details.
 ### `dotcom rendering`
 
 Go to [dotcom rendering](dotcom-rendering/README.md) for more details.
-
-## Root actions
-
-Most commands are run from within each project but the following are managed from the monorepo root:
-
-### Storybook/Chromatic
-
-`pnpm storybook` - Runs Storybook for all projects
-`pnpm build-storybook` - Builds Storybook for all projects
-
-Chromatic now runs at project level. `cd` into the project dir and run `pnpm chromatic -t [CHROMATIC PROJECT TOKEN]`
-
-You can find the token in the project Chromatic instance.
-
-To run Chromatic in CI on your pr, add the `run_chromatic` label once you're ready to check for visual regressions.

--- a/package.json
+++ b/package.json
@@ -6,12 +6,6 @@
 	"private": true,
 	"scripts": {
 		"postinstall": "./scripts/postinstall.sh",
-		"storybook": "pnpm '/^storybook:.*/'",
-		"storybook:dcr": "pnpm --filter @guardian/dotcom-rendering storybook --no-open --quiet",
-		"storybook:ar": "pnpm --filter apps-rendering storybook --no-open --quiet",
-		"build-storybook": "pnpm '/^build-storybook:.*/'",
-		"build-storybook:ar": "pnpm --filter apps-rendering build-storybook",
-		"build-storybook:dcr": "pnpm --filter @guardian/dotcom-rendering build-storybook",
 		"build:dcr": "cd dotcom-rendering && make build",
 		"chromatic": "chromatic --build-script-name=build-storybook --exit-zero-on-changes",
 		"prepare": "husky install",

--- a/package.json
+++ b/package.json
@@ -6,8 +6,9 @@
 	"private": true,
 	"scripts": {
 		"postinstall": "./scripts/postinstall.sh",
-		"build:dcr": "cd dotcom-rendering && make build",
 		"chromatic": "chromatic --build-script-name=build-storybook --exit-zero-on-changes",
+		"storybook:all": "pnpm '/^storybook:.*/'",
+		"build-storybook:all": "pnpm '/^build-storybook:.*/'",
 		"prepare": "husky install",
 		"lint-staged": "lint-staged",
 		"prettier:check": "prettier --ignore-unknown --check --cache .",


### PR DESCRIPTION
## What does this change?

Removes `storybook` commands from the root `package.json`

## Why?

We don't generally recommend running things from the root directory and instead prefer that developers `cd` into the directory they intend on working in and running things from there instead.

