### PR TITLE
Use storage api in article count

### DIFF
--- a/dotcom-rendering/src/components/marketing/lib/articleCountOptOut.ts
+++ b/dotcom-rendering/src/components/marketing/lib/articleCountOptOut.ts
@@ -3,7 +3,7 @@
  * This file was migrated from:
  * https://github.com/guardian/support-dotcom-components/blob/9c3eae7cb0b159db4a1c40679d6b37710b0bb937/packages/modules/src/modules/shared/helpers/articleCountOptOut.ts
  */
-import { getCookie, removeCookie, setCookie } from '@guardian/libs';
+import { getCookie, removeCookie, setCookie, storage } from '@guardian/libs';
 
 const ARTICLE_COUNT_OPT_OUT_COOKIE = {
 	name: 'gu_article_count_opt_out',
@@ -25,12 +25,9 @@ export const removeArticleCountOptOutCookie = (): void =>
 	removeCookie({ name: ARTICLE_COUNT_OPT_OUT_COOKIE.name });
 
 export const removeArticleCountFromLocalStorage = (): void => {
-	// eslint-disable-next-line no-restricted-syntax -- FIXME-libs-storage
-	localStorage.removeItem(DAILY_ARTICLE_COUNT_STORAGE_KEY);
-	// eslint-disable-next-line no-restricted-syntax -- FIXME-libs-storage
-	localStorage.removeItem(WEEKLY_ARTICLE_COUNT_STORAGE_KEY);
-	// eslint-disable-next-line no-restricted-syntax -- FIXME-libs-storage
-	localStorage.removeItem(ARTICLES_THIS_WEEK_STORAGE_KEY);
+	storage.local.remove(DAILY_ARTICLE_COUNT_STORAGE_KEY);
+	storage.local.remove(WEEKLY_ARTICLE_COUNT_STORAGE_KEY);
+	storage.local.remove(ARTICLES_THIS_WEEK_STORAGE_KEY);
 };
 
 export const hasArticleCountOptOutCookie = (): boolean =>


### PR DESCRIPTION
## What does this change?
- use [`@guardian/libs`’s storage](https://github.com/guardian/csnx/tree/5fd3a390496ad7781e14068b36f45148b66bad6b/libs/@guardian/libs/src/storage) class instead of `localStorage`

## Why?
Follow-up on:
- #9994

Fixes #10078