### PR TITLE
Adequate fullscreen delay

### DIFF
--- a/dotcom-rendering/src/components/LightboxJavascript.importable.tsx
+++ b/dotcom-rendering/src/components/LightboxJavascript.importable.tsx
@@ -58,8 +58,8 @@ const getTabbableElements = (
 	}
 };
 
-/** Reject a Promise after a delay (defaults to 120ms)  */
-const timeout = <T,>(promise: Promise<T>, delay = 120) =>
+/** Reject a Promise after a delay  */
+const timeout = <T,>(promise: Promise<T>, delay = 1200) =>
 	Promise.race([
 		promise,
 		new Promise<void>((_, reject) => {


### PR DESCRIPTION
## What does this change?

Make the fullscreen promise timeout after 1.2s

## Why?

The 120ms delay is too short and did not allow for enough time for the lightbox to go fullscreen on Firefox

## Screenshots

Clicking the 5th image:

| Before     | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/76776/821d4d73-72ce-445d-8c94-ca8b73d06803
[after]: https://github.com/guardian/dotcom-rendering/assets/76776/ef319ab0-2535-47a6-96ba-3dea84d63497
