### PR TITLE
Fix liveblog epic ophan view event

### DIFF
--- a/dotcom-rendering/src/components/marketing/epics/utils/ophan.ts
+++ b/dotcom-rendering/src/components/marketing/epics/utils/ophan.ts
@@ -40,7 +40,7 @@ export const OPHAN_COMPONENT_EVENT_CTAS_VIEW: OphanComponentEvent = {
 		componentType: 'ACQUISITIONS_OTHER',
 		id: OPHAN_COMPONENT_ID_CTAS_VIEW,
 	},
-	action: 'CLICK',
+	action: 'VIEW',
 };
 
 export const OPHAN_COMPONENT_EVENT_REMINDER_OPEN: OphanComponentEvent = {


### PR DESCRIPTION
Duplicate of this SDC PR: https://github.com/guardian/support-dotcom-components/pull/1033

This event tracks when the ctas component of the epic comes into view. It incorrectly has action `CLICK`.
We're mid-migration of these components to DCR, which is why it has to be done in 2 places.