### PR TITLE
Style for tablet

### DIFF
--- a/dotcom-rendering/src/components/AdSlot.apps.tsx
+++ b/dotcom-rendering/src/components/AdSlot.apps.tsx
@@ -46,10 +46,14 @@ const adSlotStyles = css`
 
 const adSlotSquareStyles = css`
 	${adSlotStyles}
+	${until.phablet} {
+		width: 320px;
+		margin-left: 10px;
+		margin-right: 10px;
+	}
+
 	height: 344px;
-	width: 320px;
-	margin-left: 10px;
-	margin-right: 10px;
+	width: 300px;
 	padding-bottom: 0;
 `;
 


### PR DESCRIPTION
## What does this change?
Adjust styling for ads on tablet so that they stay in position within the ad placeholder

## Why?
Ads were breaking out of the placeholder because the shape was incorrect

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/20416599/1986bf7e-1d8c-42f8-ab1e-6aa6ccac0854
[after]: https://github.com/guardian/dotcom-rendering/assets/20416599/5450a6d4-ac1d-4bc4-9a51-09c778b51e9f

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
