### PR TITLE
Fix rendering of notification badge in expanded dropdown

### DIFF
--- a/dotcom-rendering/src/components/Dropdown.stories.tsx
+++ b/dotcom-rendering/src/components/Dropdown.stories.tsx
@@ -146,3 +146,20 @@ export const DropdownWithNotifications = () => (
 );
 
 DropdownWithNotifications.storyName = 'Dropdown with notifications';
+
+export const DropdownExpandedWithNotifications = () => (
+	<Header>
+		<Nav>
+			<Dropdown
+				id="d3"
+				label="My Account"
+				links={linksWithNotifications}
+				dataLinkName="linkname3"
+				defaultIsExpanded={true}
+			/>
+		</Nav>
+	</Header>
+);
+
+DropdownExpandedWithNotifications.storyName =
+	'Dropdown expanded with notifications';

--- a/dotcom-rendering/src/components/Dropdown.tsx
+++ b/dotcom-rendering/src/components/Dropdown.tsx
@@ -187,7 +187,7 @@ const buttonExpanded = css`
 
 const notificationColor = palette.error[400];
 
-const notificationBadgeStyles = (diameter: number) => css`
+const notificationBadgeStyles = css`
 	background-color: ${notificationColor};
 	color: ${palette.neutral[100]};
 	text-align: center;
@@ -196,10 +196,6 @@ const notificationBadgeStyles = (diameter: number) => css`
 	align-items: center;
 	${textSans.xsmall()};
 	line-height: 1;
-
-	width: ${diameter}px;
-	height: ${diameter}px;
-	border-radius: ${diameter}px;
 `;
 
 const dropdownButtonNotificationBadgeStyles = css`
@@ -252,7 +248,14 @@ const addTrackingToUrl = (
 
 const NotificationBadge = ({ diameter }: { diameter: number }) => {
 	return (
-		<div css={notificationBadgeStyles(diameter)}>
+		<div
+			css={notificationBadgeStyles}
+			style={{
+				width: `${diameter}px`,
+				height: `${diameter}px`,
+				borderRadius: `${diameter}px`,
+			}}
+		>
 			<span>!</span>
 		</div>
 	);

--- a/dotcom-rendering/src/components/Dropdown.tsx
+++ b/dotcom-rendering/src/components/Dropdown.tsx
@@ -87,11 +87,12 @@ const displayNone = css`
 const linkStyles = css`
 	${textSans.small()};
 	color: ${sourcePalette.neutral[7]};
-	position: relative;
 	transition: color 80ms ease-out;
 	margin: -1px 0 0 0;
 	text-decoration: none;
-	display: block;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
 	padding: 10px 18px 15px 30px;
 
 	:hover {
@@ -207,14 +208,6 @@ const dropdownButtonNotificationBadgeStyles = css`
 	left: 0;
 	margin-left: -10px;
 	margin-top: -3px;
-`;
-
-const dropdownItemContainerStyles = css`
-	display: flex;
-`;
-
-const dropdownItemTextContainerStyles = css`
-	display: block;
 `;
 
 const notificationTextStyles = css`
@@ -371,26 +364,16 @@ const DropdownLink = ({ link, index }: DropdownLinkProps) => {
 					}
 				}}
 			>
-				<div css={dropdownItemContainerStyles}>
-					<div css={dropdownItemTextContainerStyles}>
-						{link.title}
-						{link.notifications?.map((notification) => (
-							<NotificationMessage
-								notification={notification}
-								key={notification.id}
-							/>
-						))}
-					</div>
-					{hasNotifications && (
-						<div
-							css={css`
-								margin-left: 10px;
-							`}
-						>
-							<NotificationBadge diameter={22} />
-						</div>
-					)}
+				<div>
+					{link.title}
+					{link.notifications?.map((notification) => (
+						<NotificationMessage
+							notification={notification}
+							key={notification.id}
+						/>
+					))}
 				</div>
+				{hasNotifications && <NotificationBadge diameter={22} />}
 			</a>
 		</li>
 	);

--- a/dotcom-rendering/src/components/Dropdown.tsx
+++ b/dotcom-rendering/src/components/Dropdown.tsx
@@ -196,6 +196,7 @@ const notificationBadgeStyles = css`
 	align-items: center;
 	${textSans.xsmall()};
 	line-height: 1;
+	flex-shrink: 0;
 `;
 
 const dropdownButtonNotificationBadgeStyles = css`
@@ -376,11 +377,7 @@ const DropdownLink = ({ link, index }: DropdownLinkProps) => {
 						/>
 					))}
 				</div>
-				{hasNotifications && (
-					<div style={{ display: 'block' }}>
-						<NotificationBadge diameter={22} />
-					</div>
-				)}
+				{hasNotifications && <NotificationBadge diameter={22} />}
 			</a>
 		</li>
 	);

--- a/dotcom-rendering/src/components/Dropdown.tsx
+++ b/dotcom-rendering/src/components/Dropdown.tsx
@@ -35,6 +35,7 @@ interface Props {
 	dataLinkName: string;
 	cssOverrides?: SerializedStyles;
 	children?: React.ReactNode;
+	defaultIsExpanded?: boolean;
 }
 
 const ulStyles = css`
@@ -208,6 +209,14 @@ const dropdownButtonNotificationBadgeStyles = css`
 	margin-top: -3px;
 `;
 
+const dropdownItemContainerStyles = css`
+	display: flex;
+`;
+
+const dropdownItemTextContainerStyles = css`
+	display: block;
+`;
+
 const notificationTextStyles = css`
 	${textSans.xxsmall()};
 `;
@@ -362,25 +371,27 @@ const DropdownLink = ({ link, index }: DropdownLinkProps) => {
 					}
 				}}
 			>
-				{link.title}
-				{link.notifications?.map((notification) => (
-					<NotificationMessage
-						notification={notification}
-						key={notification.id}
-					/>
-				))}
-			</a>
-
-			{hasNotifications && (
-				<div
-					css={css`
-						margin-top: 12px;
-						margin-right: 8px;
-					`}
-				>
-					<NotificationBadge diameter={22} />
+				<div css={dropdownItemContainerStyles}>
+					<div css={dropdownItemTextContainerStyles}>
+						{link.title}
+						{link.notifications?.map((notification) => (
+							<NotificationMessage
+								notification={notification}
+								key={notification.id}
+							/>
+						))}
+					</div>
+					{hasNotifications && (
+						<div
+							css={css`
+								margin-left: 10px;
+							`}
+						>
+							<NotificationBadge diameter={22} />
+						</div>
+					)}
 				</div>
-			)}
+			</a>
 		</li>
 	);
 };
@@ -392,8 +403,9 @@ export const Dropdown = ({
 	dataLinkName,
 	cssOverrides,
 	children,
+	defaultIsExpanded = false,
 }: Props) => {
-	const [isExpanded, setIsExpanded] = useState(false);
+	const [isExpanded, setIsExpanded] = useState(defaultIsExpanded);
 	const [noJS, setNoJS] = useState(true);
 
 	useEffect(() => {

--- a/dotcom-rendering/src/components/Dropdown.tsx
+++ b/dotcom-rendering/src/components/Dropdown.tsx
@@ -376,7 +376,11 @@ const DropdownLink = ({ link, index }: DropdownLinkProps) => {
 						/>
 					))}
 				</div>
-				{hasNotifications && <NotificationBadge diameter={22} />}
+				{hasNotifications && (
+					<div style={{ display: 'block' }}>
+						<NotificationBadge diameter={22} />
+					</div>
+				)}
 			</a>
 		</li>
 	);

--- a/dotcom-rendering/src/components/Dropdown.tsx
+++ b/dotcom-rendering/src/components/Dropdown.tsx
@@ -91,7 +91,7 @@ const linkStyles = css`
 	margin: -1px 0 0 0;
 	text-decoration: none;
 	display: flex;
-	align-items: center;
+	align-items: flex-start;
 	justify-content: space-between;
 	padding: 10px 18px 15px 30px;
 


### PR DESCRIPTION
## What does this change?

Fixes the styling of a dropdown item with a notification.

## Why?

The styles were changed in #7671 to increase the clickable area of each menu item. But the removal of a `display: flex` had the effect of causing the badge for a menu item (when expanded) to appear below the item instead of to the right as intended. This fixes the issue, while keeping the larger clickable area.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |
| ![beforemobile][] | ![aftermobile][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/379839/34385aca-f9a0-48b6-93e3-017be2868bba
[after]: https://github.com/guardian/dotcom-rendering/assets/379839/8d893f9a-3a52-4d45-ab62-892e162aa2ab
[beforemobile]: https://github.com/guardian/dotcom-rendering/assets/379839/b96e8d59-ac8e-47e9-a1bf-1a6cbfac8f7b
[aftermobile]: https://github.com/guardian/dotcom-rendering/assets/379839/b1e28df4-06bd-40c3-8894-c33d3adb0883



(See #6556 for the original intended design).

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.



You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
