### PR TITLE
Fix labs link

### DIFF
--- a/dotcom-rendering/src/components/LabsSection.tsx
+++ b/dotcom-rendering/src/components/LabsSection.tsx
@@ -201,7 +201,7 @@ const GuardianLabsTitle = ({
 }) => {
 	if (url) {
 		return (
-			<a css={linkStyles(textColour)} href={url}>
+			<a css={linkStyles(textColour)} href={`/${url}`}>
 				<h2 css={headerStyles()}>{title}</h2>
 			</a>
 		);


### PR DESCRIPTION
## What does this change?
Replaces a relative path in the labs link  with a root-relative path.

## Why?
By using the relative path in a href link, the edition was being persisted in the url slug meaning links were directing to https://www.theguardian.com/uk/innovate-with-azure instead of https://www.theguardian.com/innovate-with-azure for example which was not a correct url and resulting in a 404. By adding a slash in the href, we make sure that we append the slug to the root path only.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/20416599/f8552850-40a4-4cc6-90e8-c7533ff250d2
[after]: https://github.com/guardian/dotcom-rendering/assets/20416599/42b896a0-50ae-45b5-97d2-cc5028d7dc89

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
<img width="1678" alt="Screenshot 2024-01-10 at 13 52 25" src="https://github.com/guardian/dotcom-rendering/assets/20416599/7f6885ce-5c0a-4d84-af79-7d4724526ad2">


-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
