### PR TITLE
Simplify the Lightbox DOM tree

### DIFF
--- a/dotcom-rendering/src/client/islands/initHydration.ts
+++ b/dotcom-rendering/src/client/islands/initHydration.ts
@@ -18,8 +18,7 @@ import { whenVisible } from './whenVisible';
  */
 function hasLightboxHash(name: string) {
 	return (
-		name === 'LightboxJavascript' &&
-		window.location.hash.startsWith('#img-')
+		name === 'LightboxLayout' && window.location.hash.startsWith('#img-')
 	);
 }
 

--- a/dotcom-rendering/src/components/ArticlePage.tsx
+++ b/dotcom-rendering/src/components/ArticlePage.tsx
@@ -18,8 +18,7 @@ import { DarkModeMessage } from './DarkModeMessage';
 import { FocusStyles } from './FocusStyles.importable';
 import { Island } from './Island';
 import { LightboxHash } from './LightboxHash.importable';
-import { LightboxJavascript } from './LightboxJavascript.importable';
-import { LightboxLayout } from './LightboxLayout';
+import { LightboxLayout } from './LightboxLayout.importable';
 import { Metrics } from './Metrics.importable';
 import { ReaderRevenueDev } from './ReaderRevenueDev.importable';
 import { SendTargetingParams } from './SendTargetingParams.importable';
@@ -101,17 +100,14 @@ export const ArticlePage = (props: WebProps | AppProps) => {
 			<SkipTo id="navigation" label="Skip to navigation" />
 			{webLightbox && article.imagesForLightbox.length > 0 && (
 				<>
-					<LightboxLayout
-						imageCount={article.imagesForLightbox.length}
-					/>
-					<Island priority="feature" defer={{ until: 'idle' }}>
-						<LightboxHash />
-					</Island>
 					<Island priority="feature" defer={{ until: 'hash' }}>
-						<LightboxJavascript
+						<LightboxLayout
 							format={format}
 							images={article.imagesForLightbox}
 						/>
+					</Island>
+					<Island priority="feature" defer={{ until: 'idle' }}>
+						<LightboxHash />
 					</Island>
 				</>
 			)}

--- a/dotcom-rendering/src/components/Island.test.tsx
+++ b/dotcom-rendering/src/components/Island.test.tsx
@@ -18,7 +18,7 @@ import { FocusStyles } from './FocusStyles.importable';
 import { InteractiveSupportButton } from './InteractiveSupportButton.importable';
 import { Island } from './Island';
 import { LightboxHash } from './LightboxHash.importable';
-import { LightboxJavascript } from './LightboxJavascript.importable';
+import { LightboxJavascript } from './LightboxJavascript';
 import { LiveBlogEpic } from './LiveBlogEpic.importable';
 import { Liveness } from './Liveness.importable';
 import { Metrics } from './Metrics.importable';

--- a/dotcom-rendering/src/components/Lightbox.stories.tsx
+++ b/dotcom-rendering/src/components/Lightbox.stories.tsx
@@ -3,13 +3,13 @@ import {
 	ArticleDisplay,
 	ArticleSpecial,
 	Pillar,
+	storage,
 } from '@guardian/libs';
 import { breakpoints } from '@guardian/source-foundations';
+import { userEvent, within } from '@storybook/testing-library';
 import { useEffect } from 'react';
-import { render } from 'react-dom';
 import type { ImageForLightbox } from '../types/content';
-import { LightboxImages } from './LightboxImages';
-import { LightboxLayout } from './LightboxLayout';
+import { LightboxLayout } from './LightboxLayout.importable';
 
 const testImage: ImageForLightbox = {
 	elementId: 'mockId',
@@ -38,43 +38,12 @@ export default {
 	},
 };
 
-function showLightbox(lightbox: HTMLElement) {
-	lightbox.removeAttribute('hidden');
-}
-
-function showInfo(lightbox: HTMLElement) {
-	lightbox.classList.remove('hide-info');
-}
-
-function hideInfo(lightbox: HTMLElement) {
-	lightbox.classList.add('hide-info');
-}
-
-const Initialise = ({
-	children,
-	shouldShowInfo = true,
-	format,
-	images,
-}: {
-	children: React.ReactNode;
-	shouldShowInfo?: boolean;
-	format: ArticleFormat;
-	images: ImageForLightbox[];
-}) => {
+const Initialise = ({ children }: { children: React.ReactNode }) => {
 	useEffect(() => {
 		const lightbox =
 			document.querySelector<HTMLDialogElement>('#gu-lightbox');
-		if (!lightbox) return;
-		showLightbox(lightbox);
-		if (shouldShowInfo) {
-			showInfo(lightbox);
-		} else {
-			hideInfo(lightbox);
-		}
-		const imageRoot = document.querySelector('ul#lightbox-images');
-		if (!imageRoot) return;
-		render(<LightboxImages format={format} images={images} />, imageRoot);
-	}, [format, images, shouldShowInfo]);
+		lightbox?.removeAttribute('hidden');
+	}, []);
 
 	return <div style={{ height: '100vh' }}>{children}</div>;
 };
@@ -87,8 +56,8 @@ export const Default = () => {
 	};
 	const images = [{ ...testImage }];
 	return (
-		<Initialise format={format} images={images}>
-			<LightboxLayout imageCount={images.length} />
+		<Initialise>
+			<LightboxLayout format={format} images={images} />
 		</Initialise>
 	);
 };
@@ -101,8 +70,8 @@ export const WithTitle = () => {
 	};
 	const images = [{ ...testImage, title: 'Title' }];
 	return (
-		<Initialise format={format} images={images}>
-			<LightboxLayout imageCount={images.length} />
+		<Initialise>
+			<LightboxLayout format={format} images={images} />
 		</Initialise>
 	);
 };
@@ -115,8 +84,8 @@ export const WithCredit = () => {
 	};
 	const images = [{ ...testImage, displayCredit: true }];
 	return (
-		<Initialise format={format} images={images}>
-			<LightboxLayout imageCount={images.length} />
+		<Initialise>
+			<LightboxLayout format={format} images={images} />
 		</Initialise>
 	);
 };
@@ -129,8 +98,8 @@ export const WithRating = () => {
 	};
 	const images = [{ ...testImage, starRating: 3 }];
 	return (
-		<Initialise format={format} images={images}>
-			<LightboxLayout imageCount={images.length} />
+		<Initialise>
+			<LightboxLayout format={format} images={images} />
 		</Initialise>
 	);
 };
@@ -152,8 +121,8 @@ export const WhenLiveBlog = () => {
 		},
 	];
 	return (
-		<Initialise format={format} images={images}>
-			<LightboxLayout imageCount={images.length} />
+		<Initialise>
+			<LightboxLayout format={format} images={images} />
 		</Initialise>
 	);
 };
@@ -173,8 +142,8 @@ export const WithEverything = () => {
 		},
 	];
 	return (
-		<Initialise format={format} images={images}>
-			<LightboxLayout imageCount={images.length} />
+		<Initialise>
+			<LightboxLayout format={format} images={images} />
 		</Initialise>
 	);
 };
@@ -187,10 +156,23 @@ export const WithoutCaption = () => {
 	};
 	const images = [{ ...testImage }];
 	return (
-		<Initialise shouldShowInfo={false} format={format} images={images}>
-			<LightboxLayout imageCount={images.length} />
+		<Initialise>
+			<LightboxLayout format={format} images={images} />
 		</Initialise>
 	);
+};
+/**
+ * We manually click the [i] button to close the caption
+ */
+WithoutCaption.play = async ({
+	canvasElement,
+}: {
+	canvasElement: HTMLElement;
+}) => {
+	const canvas = within(canvasElement);
+	storage.local.clear();
+	await userEvent.click(canvas.getByTitle('Toggle caption [i]'));
+	storage.local.clear();
 };
 
 export const WithSport = () => {
@@ -208,8 +190,8 @@ export const WithSport = () => {
 		},
 	];
 	return (
-		<Initialise format={format} images={images}>
-			<LightboxLayout imageCount={images.length} />
+		<Initialise>
+			<LightboxLayout format={format} images={images} />
 		</Initialise>
 	);
 };
@@ -229,8 +211,8 @@ export const WithCulture = () => {
 		},
 	];
 	return (
-		<Initialise format={format} images={images}>
-			<LightboxLayout imageCount={images.length} />
+		<Initialise>
+			<LightboxLayout format={format} images={images} />
 		</Initialise>
 	);
 };
@@ -250,8 +232,8 @@ export const WithLifestyle = () => {
 		},
 	];
 	return (
-		<Initialise format={format} images={images}>
-			<LightboxLayout imageCount={images.length} />
+		<Initialise>
+			<LightboxLayout format={format} images={images} />
 		</Initialise>
 	);
 };
@@ -271,8 +253,8 @@ export const WithOpinion = () => {
 		},
 	];
 	return (
-		<Initialise format={format} images={images}>
-			<LightboxLayout imageCount={images.length} />
+		<Initialise>
+			<LightboxLayout format={format} images={images} />
 		</Initialise>
 	);
 };
@@ -292,8 +274,8 @@ export const WithSpecialReport = () => {
 		},
 	];
 	return (
-		<Initialise format={format} images={images}>
-			<LightboxLayout imageCount={images.length} />
+		<Initialise>
+			<LightboxLayout format={format} images={images} />
 		</Initialise>
 	);
 };
@@ -313,8 +295,8 @@ export const WithSpecialReportAlt = () => {
 		},
 	];
 	return (
-		<Initialise format={format} images={images}>
-			<LightboxLayout imageCount={images.length} />
+		<Initialise>
+			<LightboxLayout format={format} images={images} />
 		</Initialise>
 	);
 };
@@ -334,8 +316,8 @@ export const WithLabs = () => {
 		},
 	];
 	return (
-		<Initialise format={format} images={images}>
-			<LightboxLayout imageCount={images.length} />
+		<Initialise>
+			<LightboxLayout format={format} images={images} />
 		</Initialise>
 	);
 };

--- a/dotcom-rendering/src/components/LightboxImages.tsx
+++ b/dotcom-rendering/src/components/LightboxImages.tsx
@@ -120,9 +120,8 @@ const figureStyles = css`
 	height: 100%;
 	justify-content: space-between;
 
-	${until.tablet} {
-		flex-direction: column;
-	}
+	flex-direction: column;
+
 	${from.tablet} {
 		flex-direction: row;
 	}
@@ -178,7 +177,7 @@ export const LightboxImages = ({ format, images }: Props) => {
 
 	useEffect(() => {
 		log('dotcom', '💡 images loaded:', loaded);
-	});
+	}, [loaded]);
 
 	return (
 		<>

--- a/dotcom-rendering/src/components/LightboxJavascript.tsx
+++ b/dotcom-rendering/src/components/LightboxJavascript.tsx
@@ -1,7 +1,8 @@
+import { css } from '@emotion/react';
 import { isUndefined, log, storage } from '@guardian/libs';
+import { from, space } from '@guardian/source-foundations';
 import libDebounce from 'lodash.debounce';
 import { useEffect, useState } from 'react';
-import { createPortal } from 'react-dom';
 import screenfull from 'screenfull';
 import type { ImageForLightbox } from '../types/content';
 import { LightboxImages } from './LightboxImages';
@@ -516,6 +517,33 @@ const useElementById = (id: string) => {
 	return element;
 };
 
+const ulStyles = css`
+	display: grid;
+	grid-auto-flow: column;
+	grid-auto-columns: 100%;
+	height: 100%;
+	width: 100%;
+	scroll-snap-type: x mandatory;
+	overflow-x: scroll;
+	overflow-y: hidden;
+	scroll-behavior: auto;
+	overscroll-behavior: contain;
+	${from.tablet} {
+		margin-left: ${space[5]}px;
+	}
+	/**
+	* Hide scrollbars
+	* See: https://stackoverflow.com/a/38994837
+	*
+	* Removing the scrollbars here is okay because we offer multiple other methods for
+	* navigation which are obvious and accessible to readers
+	*/
+	::-webkit-scrollbar {
+		display: none; /* Safari and Chrome */
+	}
+	scrollbar-width: none; /* Firefox */
+`;
+
 export const LightboxJavascript = ({
 	format,
 	images,
@@ -535,7 +563,6 @@ export const LightboxJavascript = ({
 	 * is so verbose) and we don't want every page view to have to download it, only those that are opening
 	 * lightbox
 	 */
-	const root = useElementById('lightbox-images');
 	const lightbox = useElementById('gu-lightbox');
 	const [initialised, setInitialised] = useState(false);
 
@@ -549,11 +576,12 @@ export const LightboxJavascript = ({
 		setInitialised(true);
 	}, [initialised, lightbox]);
 
-	if (!root || !lightbox) return null;
+	if (!lightbox) return null;
 
 	log('dotcom', '💡 Generating HTML for lightbox images...');
-	return createPortal(
-		<LightboxImages format={format} images={images} />,
-		root,
+	return (
+		<ul css={ulStyles} aria-label="All images">
+			<LightboxImages format={format} images={images} />;
+		</ul>
 	);
 };

--- a/dotcom-rendering/src/components/LightboxLayout.importable.tsx
+++ b/dotcom-rendering/src/components/LightboxLayout.importable.tsx
@@ -14,9 +14,12 @@ import {
 	SvgCross,
 } from '@guardian/source-react-components';
 import { getZIndex } from '../lib/getZIndex';
+import type { ImageForLightbox } from '../types/content';
+import { LightboxJavascript } from './LightboxJavascript';
 
 type Props = {
-	imageCount: number;
+	format: ArticleFormat;
+	images: ImageForLightbox[];
 };
 
 const lightboxStyles = css`
@@ -78,31 +81,6 @@ const navStyles = css`
 		border-left: 1px solid ${palette.neutral[20]};
 	}
 	background-color: ${palette.neutral[7]};
-`;
-
-const ulStyles = css`
-	display: flex;
-	height: 100%;
-	width: 100%;
-	scroll-snap-type: x mandatory;
-	overflow-x: scroll;
-	overflow-y: hidden;
-	scroll-behavior: auto;
-	overscroll-behavior: contain;
-	${from.tablet} {
-		margin-left: ${space[5]}px;
-	}
-	/**
-	 * Hide scrollbars
-	 * See: https://stackoverflow.com/a/38994837
-	 *
-	 * Removing the scrollbars here is okay because we offer multiple other methods for
-	 * navigation which are obvious and accessible to readers
-	 */
-	::-webkit-scrollbar {
-		display: none; /* Safari and Chrome */
-	}
-	scrollbar-width: none; /* Firefox */
 `;
 
 const buttonStyles = css`
@@ -217,7 +195,7 @@ const Selection = ({
 	);
 };
 
-export const LightboxLayout = ({ imageCount }: Props) => {
+export const LightboxLayout = ({ format, images }: Props) => {
 	return (
 		<>
 			<Global
@@ -243,11 +221,7 @@ export const LightboxLayout = ({ imageCount }: Props) => {
 				hidden={true}
 			>
 				<div css={containerStyles}>
-					<ul
-						id="lightbox-images"
-						css={ulStyles}
-						aria-label="All images"
-					></ul>
+					<LightboxJavascript format={format} images={images} />
 					<nav css={navStyles}>
 						<button
 							type="button"
@@ -265,7 +239,7 @@ export const LightboxLayout = ({ imageCount }: Props) => {
 							</span>
 						</button>
 						<Hide until="tablet">
-							<Selection countOfImages={imageCount} />
+							<Selection countOfImages={images.length} />
 						</Hide>
 						<button
 							type="button"

--- a/dotcom-rendering/src/components/Picture.tsx
+++ b/dotcom-rendering/src/components/Picture.tsx
@@ -323,7 +323,8 @@ export const Picture = ({
 	onLoad,
 }: Props) => {
 	const [loaded, setLoaded] = useState(false);
-	const ref = useCallback((node: HTMLImageElement) => {
+	const ref = useCallback((node: HTMLImageElement | null) => {
+		if (!node) return;
 		if (node.complete) {
 			setLoaded(true);
 		} else {


### PR DESCRIPTION
## What does this change?

- The `LightboxImages` and `LightboxJavascript` inserted as a child of `LightboxLayout`, which is now the containing island
- Display images as grid, so the exact size of each component can therefore be known before images are loaded
- Use @storybook/testing-library to interact with the lightbox and disable the captions

## Why?

The `LightboxLayout` would [is only ~3kB heavier an Island](https://github.com/guardian/dotcom-rendering/pull/10137#issuecomment-1885207595) than `LightboxJavascript`, and this paves the way having the state better controlled from React, including attaching event handlers to `button`s. 

Part of #10102 

## Screenshots

N/A – identical