### PR TITLE
Enable `video` element to maintain aspect ratio

### DIFF
--- a/dotcom-rendering/src/components/MaintainAspectRatio.tsx
+++ b/dotcom-rendering/src/components/MaintainAspectRatio.tsx
@@ -14,7 +14,8 @@ export const MaintainAspectRatio = ({ height, width, children }: Props) => (
 			position: relative;
 			padding-bottom: ${(height / width) * 100}%;
 
-			iframe {
+			& > iframe,
+			& > video {
 				width: 100%;
 				height: 100%;
 				position: absolute;


### PR DESCRIPTION
## What does this change?

Enable direct children of `MaintainAspectRatio` to do so if they are `iframe` or `video`

## Why?

`video` elements should get the same treatment as `iframe` ones

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/76776/41880672-6196-4fd3-aafb-bc686aa8570c
[after]: https://github.com/guardian/dotcom-rendering/assets/76776/3a35367a-9018-4a86-8bb2-02d876bd345b

## Next steps

This is a quick fix, let’s get some stories.