### PR TITLE
Fix dev server get-content-from-url errors

### DIFF
--- a/dotcom-rendering/src/server/server.dev.ts
+++ b/dotcom-rendering/src/server/server.dev.ts
@@ -21,7 +21,7 @@ import {
 /** article URLs contain a part that looks like “2022/nov/25” */
 const ARTICLE_URL = /\/\d{4}\/[a-z]{3}\/\d{2}\//;
 /** fronts are a series of lowercase strings, dashes and forward slashes */
-const FRONT_URL = /^\/[a-z-/]+/;
+const FRONT_URL = /^\/[a-z-/]+(?<!\.css)$/;
 /** This is imperfect, but covers *some* cases of tag fronts, consider expanding in the future */
 const TAG_FRONT_URL = /^\/(tone|series|profile)\/[a-z-]+/;
 /** assets are paths like /assets/index.xxx.js */


### PR DESCRIPTION
## What does this change?
This adds a check to the FRONT_URL regex to not match urls ending in .css 
## Why?
We do not want it to handle this url https://www.theguardian.com/static/frontend/css/print.css or redirect.

Fixes https://github.com/guardian/dotcom-rendering/issues/9795
## Screenshots

| Before 🤬     | After 😎      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/110032454/c0ee20b1-fcda-4f80-b8ce-5e41f04ac1c2
[after]: https://github.com/guardian/dotcom-rendering/assets/110032454/e265a96f-5df4-4af1-b803-2b09a5695c0d

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
