### PR TITLE
Remove explicit line height on series section link

### DIFF
--- a/dotcom-rendering/src/components/SeriesSectionLink.tsx
+++ b/dotcom-rendering/src/components/SeriesSectionLink.tsx
@@ -128,7 +128,6 @@ const secondaryFontStyles = (format: ArticleFormat) => {
 	}
 	return css`
 		${headline.xxxsmall({ fontWeight: 'regular' })}
-		line-height: 20px;
 	`;
 };
 


### PR DESCRIPTION
## What does this change?

Removes explicit line height from series section link component

## Why?

It was overriding line height from source, making it look wonky on DCAR with font sizing adjustments

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/43961396/315858d6-47b0-432d-99cb-c1639596e094
[after]: https://github.com/guardian/dotcom-rendering/assets/43961396/75793c6f-c062-4af5-9546-8fccfbd3a05a
