### PR TITLE
Migrate `alreadyVisited` to new localStorage API

### DIFF
--- a/dotcom-rendering/src/lib/alreadyVisited.ts
+++ b/dotcom-rendering/src/lib/alreadyVisited.ts
@@ -1,4 +1,5 @@
 import { onConsent } from '@guardian/consent-management-platform';
+import { storage } from '@guardian/libs';
 
 /**
  * This local storage item is used to target ads if a user has the correct consents
@@ -7,8 +8,7 @@ const AlreadyVisitedKey = 'gu.alreadyVisited';
 
 const getAlreadyVisitedCount = (): number => {
 	const alreadyVisited = parseInt(
-		// eslint-disable-next-line no-restricted-syntax -- FIXME-libs-storage
-		localStorage.getItem(AlreadyVisitedKey) ?? '',
+		storage.local.getRaw(AlreadyVisitedKey) ?? '',
 		10,
 	);
 	return !Number.isNaN(alreadyVisited) ? alreadyVisited : 0;
@@ -18,10 +18,8 @@ export const incrementAlreadyVisited = async (): Promise<void> => {
 	const { canTarget } = await onConsent();
 	if (canTarget) {
 		const alreadyVisited = getAlreadyVisitedCount() + 1;
-		// eslint-disable-next-line no-restricted-syntax -- FIXME-libs-storage
-		localStorage.setItem(AlreadyVisitedKey, alreadyVisited.toString());
+		storage.local.setRaw(AlreadyVisitedKey, alreadyVisited.toString());
 	} else {
-		// eslint-disable-next-line no-restricted-syntax -- FIXME-libs-storage
-		localStorage.removeItem(AlreadyVisitedKey);
+		storage.local.remove(AlreadyVisitedKey);
 	}
 };


### PR DESCRIPTION
Migrates the `alreadyVisited` module to use the redesigned `localStorage` API from `@guardian/libs`.

## Considerations

* Maybe it's worth refactoring to use `set` instead of `setRaw` so that we don't have to deal with string conversions.

Closes https://github.com/guardian/dotcom-rendering/issues/10074