### PR TITLE
Component to display date & time uniformly

### DIFF
--- a/dotcom-rendering/src/components/DateTime.stories.tsx
+++ b/dotcom-rendering/src/components/DateTime.stories.tsx
@@ -1,0 +1,46 @@
+import { css } from '@emotion/react';
+import { space, textSans } from '@guardian/source-foundations';
+import type { Meta, StoryObj } from '@storybook/react';
+import { DateTime } from './DateTime';
+
+const meta: Meta<typeof DateTime> = {
+	title: 'Components/Time',
+	component: DateTime,
+	decorators: (Story) => (
+		<div
+			css={css`
+				padding: ${space[2]}px;
+				${textSans.small()}
+			`}
+		>
+			<Story />
+		</div>
+	),
+};
+
+type Story = StoryObj<typeof DateTime>;
+
+/** January 14th, 2024, 12.34pm */
+const date = new Date('2024-01-14T12:34:00.000Z');
+
+export const UK: Story = {
+	args: { date, edition: 'UK' },
+};
+
+export const US: Story = {
+	args: { date, edition: 'US' },
+};
+
+export const AU: Story = {
+	args: { date, edition: 'AU' },
+};
+
+export const EUR: Story = {
+	args: { date, edition: 'EUR' },
+};
+
+export const INT: Story = {
+	args: { date, edition: 'INT' },
+};
+
+export default meta;

--- a/dotcom-rendering/src/components/DateTime.tsx
+++ b/dotcom-rendering/src/components/DateTime.tsx
@@ -1,0 +1,45 @@
+import { type EditionId, getEditionFromId } from '../lib/edition';
+
+type Props = {
+	date: Date;
+	edition: EditionId;
+};
+
+export const DateTime = ({ date, edition }: Props) => {
+	const { locale, timeZone } = getEditionFromId(edition);
+	return (
+		<time
+			dateTime={date.toISOString()}
+			data-locale={locale}
+			title={date.toLocaleDateString(locale, {
+				hour: '2-digit',
+				minute: '2-digit',
+				weekday: 'long',
+				year: 'numeric',
+				month: 'long',
+				day: 'numeric',
+				timeZoneName: 'long',
+				timeZone,
+			})}
+		>
+			{date
+				.toLocaleDateString(locale, {
+					weekday: 'short',
+					day: 'numeric',
+					month: 'short',
+					year: 'numeric',
+					timeZone,
+				})
+				.replaceAll(',', '')}{' '}
+			{date
+				.toLocaleTimeString(locale, {
+					hour12: false,
+					hour: '2-digit',
+					minute: '2-digit',
+					timeZoneName: 'short',
+					timeZone,
+				})
+				.replace(':', '.')}
+		</time>
+	);
+};


### PR DESCRIPTION
## What does this change?

Add a new `DateTime` component that displays dates & times uniformly based on the edition

## Why?

There are currently [many different ways of showing time](https://github.com/search?q=repo%3Aguardian%2Fdotcom-rendering%20path%3A%2Fdotcom-rendering%2F**%20%22%3Ctime%22&type=code), sometimes relative, sometimes absolute, which makes reasoning about time more difficult:

- #10148
- #5068 
- #254 
- #10154

## Screenshots

<img width="1018" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/76776/6a531268-418e-4740-9397-895f16ff1f6c">
