### PR TITLE
Narrower Edition from ID

### DIFF
--- a/dotcom-rendering/src/lib/edition.ts
+++ b/dotcom-rendering/src/lib/edition.ts
@@ -46,7 +46,9 @@ export const editionList = [
 	},
 ] as const;
 
-export const getEditionFromId = (editionId: EditionId): EditionLinkType => {
+export const getEditionFromId = (
+	editionId: EditionId,
+): (typeof editionList)[number] => {
 	return (
 		editionList.find((edition) => edition.editionId === editionId) ??
 		editionList[0]


### PR DESCRIPTION
## What does this change?

Narrow the return type of `getEditionFromId`

## Why?

Narrower is tighter