### PR TITLE
Use `DateTime` in `LastUpdated`

### DIFF
--- a/dotcom-rendering/src/components/ArticleBody.tsx
+++ b/dotcom-rendering/src/components/ArticleBody.tsx
@@ -3,6 +3,7 @@ import { ArticleDesign, ArticleDisplay } from '@guardian/libs';
 import type { ArticleFormat } from '@guardian/libs';
 import { between, body, headline, space } from '@guardian/source-foundations';
 import { ArticleRenderer } from '../lib/ArticleRenderer';
+import type { EditionId } from '../lib/edition';
 import { decideLanguage, decideLanguageDirection } from '../lib/lang';
 import { revealStyles } from '../lib/revealStyles';
 import { palette as themePalette } from '../palette';
@@ -16,6 +17,7 @@ import { TableOfContents } from './TableOfContents.importable';
 type Props = {
 	format: ArticleFormat;
 	blocks: Block[];
+	editionId: EditionId;
 	pinnedPost?: Block;
 	host?: string;
 	pageId: string;
@@ -131,6 +133,7 @@ export const ArticleBody = ({
 	tableOfContents,
 	lang,
 	isRightToLeftLang = false,
+	editionId,
 }: Props) => {
 	const isInteractive = format.design === ArticleDesign.Interactive;
 	const language = decideLanguage(lang);
@@ -180,6 +183,7 @@ export const ArticleBody = ({
 					availableTopics={availableTopics}
 					selectedTopics={selectedTopics}
 					keywordIds={keywordIds}
+					editionId={editionId}
 				/>
 			</div>
 		);

--- a/dotcom-rendering/src/components/DateTime.stories.tsx
+++ b/dotcom-rendering/src/components/DateTime.stories.tsx
@@ -4,7 +4,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { DateTime } from './DateTime';
 
 const meta: Meta<typeof DateTime> = {
-	title: 'Components/Time',
+	title: 'Components/DateTime',
 	component: DateTime,
 	decorators: (Story) => (
 		<div
@@ -24,23 +24,27 @@ type Story = StoryObj<typeof DateTime>;
 const date = new Date('2024-01-14T12:34:00.000Z');
 
 export const UK: Story = {
-	args: { date, edition: 'UK' },
+	args: { date, editionId: 'UK' },
+};
+
+export const TimeOnly: Story = {
+	args: { date, editionId: 'UK', showDate: false },
 };
 
 export const US: Story = {
-	args: { date, edition: 'US' },
+	args: { date, editionId: 'US' },
 };
 
 export const AU: Story = {
-	args: { date, edition: 'AU' },
+	args: { date, editionId: 'AU' },
 };
 
 export const EUR: Story = {
-	args: { date, edition: 'EUR' },
+	args: { date, editionId: 'EUR' },
 };
 
 export const INT: Story = {
-	args: { date, edition: 'INT' },
+	args: { date, editionId: 'INT' },
 };
 
 export default meta;

--- a/dotcom-rendering/src/components/DateTime.tsx
+++ b/dotcom-rendering/src/components/DateTime.tsx
@@ -2,11 +2,12 @@ import { type EditionId, getEditionFromId } from '../lib/edition';
 
 type Props = {
 	date: Date;
-	edition: EditionId;
+	editionId: EditionId;
+	showDate?: boolean;
 };
 
-export const DateTime = ({ date, edition }: Props) => {
-	const { locale, timeZone } = getEditionFromId(edition);
+export const DateTime = ({ date, editionId, showDate = true }: Props) => {
+	const { locale, timeZone } = getEditionFromId(editionId);
 	return (
 		<time
 			dateTime={date.toISOString()}
@@ -22,15 +23,16 @@ export const DateTime = ({ date, edition }: Props) => {
 				timeZone,
 			})}
 		>
-			{date
-				.toLocaleDateString(locale, {
-					weekday: 'short',
-					day: 'numeric',
-					month: 'short',
-					year: 'numeric',
-					timeZone,
-				})
-				.replaceAll(',', '')}{' '}
+			{showDate &&
+				date
+					.toLocaleDateString(locale, {
+						weekday: 'short',
+						day: 'numeric',
+						month: 'short',
+						year: 'numeric',
+						timeZone,
+					})
+					.replaceAll(',', '')}{' '}
 			{date
 				.toLocaleTimeString(locale, {
 					hour12: false,

--- a/dotcom-rendering/src/components/LastUpdated.stories.tsx
+++ b/dotcom-rendering/src/components/LastUpdated.stories.tsx
@@ -1,17 +1,15 @@
+import type { Meta, StoryObj } from '@storybook/react';
 import { LastUpdated } from './LastUpdated';
 
-export default {
+const meta: Meta = {
 	component: LastUpdated,
 	title: 'Components/LastUpdated',
 };
 
-export const Default = () => {
-	return (
-		<LastUpdated
-			lastUpdated={1613763519000}
-			lastUpdatedDisplay="19.38 GMT"
-		/>
-	);
+type Story = StoryObj<typeof LastUpdated>;
+
+export const Default: Story = {
+	args: { lastUpdated: 1613763519000, editionId: 'UK' },
 };
 
-Default.storyName = 'Default';
+export default meta;

--- a/dotcom-rendering/src/components/LastUpdated.tsx
+++ b/dotcom-rendering/src/components/LastUpdated.tsx
@@ -1,11 +1,13 @@
 import { css } from '@emotion/react';
 import { palette, textSans } from '@guardian/source-foundations';
+import type { EditionId } from '../lib/edition';
+import { DateTime } from './DateTime';
 
 const LastUpdated = ({
-	lastUpdatedDisplay,
+	editionId,
 	lastUpdated,
 }: {
-	lastUpdatedDisplay: string;
+	editionId: EditionId;
 	lastUpdated: number;
 }) => {
 	return (
@@ -17,23 +19,12 @@ const LastUpdated = ({
 				color: ${palette.neutral[46]};
 			`}
 		>
-			<time
-				dateTime={new Date(lastUpdated).toISOString()}
-				title={`Last updated ${new Date(lastUpdated).toLocaleDateString(
-					'en-GB',
-					{
-						hour: '2-digit',
-						minute: '2-digit',
-						weekday: 'long',
-						year: 'numeric',
-						month: 'long',
-						day: 'numeric',
-						timeZoneName: 'long',
-					},
-				)}`}
-			>
-				{`Updated at ${lastUpdatedDisplay}`}
-			</time>
+			Updated at&nbsp;
+			<DateTime
+				date={new Date(lastUpdated)}
+				editionId={editionId}
+				showDate={false}
+			/>
 		</div>
 	);
 };

--- a/dotcom-rendering/src/components/LiveBlock.stories.tsx
+++ b/dotcom-rendering/src/components/LiveBlock.stories.tsx
@@ -79,6 +79,7 @@ export const VideoAsSecond = () => {
 				abTests={{}}
 				switches={{}}
 				isPinnedPost={false}
+				editionId="UK"
 			/>
 		</Wrapper>
 	);
@@ -125,6 +126,7 @@ export const Title = () => {
 				abTests={{}}
 				switches={{}}
 				isPinnedPost={false}
+				editionId="UK"
 			/>
 		</Wrapper>
 	);
@@ -192,6 +194,7 @@ export const Video = () => {
 				abTests={{}}
 				switches={{}}
 				isPinnedPost={false}
+				editionId="UK"
 			/>
 		</Wrapper>
 	);
@@ -234,6 +237,7 @@ export const RichLink = () => {
 				abTests={{}}
 				switches={{}}
 				isPinnedPost={false}
+				editionId="UK"
 			/>
 		</Wrapper>
 	);
@@ -267,6 +271,7 @@ export const FirstImage = () => {
 				abTests={{}}
 				switches={{}}
 				isPinnedPost={false}
+				editionId="UK"
 			/>
 		</Wrapper>
 	);
@@ -326,6 +331,7 @@ export const ImageRoles = () => {
 				isPinnedPost={false}
 				isAdFreeUser={false}
 				isSensitive={false}
+				editionId="UK"
 			/>
 		</Wrapper>
 	);
@@ -374,6 +380,7 @@ export const Thumbnail = () => {
 				isPinnedPost={false}
 				isAdFreeUser={false}
 				isSensitive={false}
+				editionId="UK"
 			/>
 		</Wrapper>
 	);
@@ -408,6 +415,7 @@ export const ImageAndTitle = () => {
 				abTests={{}}
 				switches={{}}
 				isPinnedPost={false}
+				editionId="UK"
 			/>
 		</Wrapper>
 	);
@@ -438,6 +446,7 @@ export const Updated = () => {
 				abTests={{}}
 				switches={{}}
 				isPinnedPost={false}
+				editionId="UK"
 			/>
 		</Wrapper>
 	);
@@ -472,6 +481,7 @@ export const Contributor = () => {
 				isPinnedPost={false}
 				isAdFreeUser={false}
 				isSensitive={false}
+				editionId="UK"
 			/>
 		</Wrapper>
 	);
@@ -504,6 +514,7 @@ export const NoAvatar = () => {
 				isPinnedPost={false}
 				isAdFreeUser={false}
 				isSensitive={false}
+				editionId="UK"
 			/>
 		</Wrapper>
 	);
@@ -539,6 +550,7 @@ export const TitleAndContributor = () => {
 				isPinnedPost={false}
 				isAdFreeUser={false}
 				isSensitive={false}
+				editionId="UK"
 			/>
 		</Wrapper>
 	);

--- a/dotcom-rendering/src/components/LiveBlock.tsx
+++ b/dotcom-rendering/src/components/LiveBlock.tsx
@@ -1,4 +1,6 @@
 import { css } from '@emotion/react';
+import { isUndefined } from '@guardian/libs';
+import type { EditionId } from '../lib/edition';
 import { RenderArticleElement } from '../lib/renderElement';
 import type { ServerSideTests, Switches } from '../types/config';
 import { LastUpdated } from './LastUpdated';
@@ -19,6 +21,7 @@ type Props = {
 	isLiveUpdate?: boolean;
 	isPinnedPost: boolean;
 	pinnedPostId?: string;
+	editionId: EditionId;
 };
 
 export const LiveBlock = ({
@@ -35,15 +38,17 @@ export const LiveBlock = ({
 	isLiveUpdate,
 	isPinnedPost,
 	pinnedPostId,
+	editionId,
 }: Props) => {
 	if (block.elements.length === 0) return null;
 
 	// Decide if the block has been updated or not
-	const showLastUpdated: boolean =
-		!!block.blockLastUpdatedDisplay &&
-		block.blockFirstPublished !== undefined &&
-		block.blockLastUpdated !== undefined &&
-		block.blockLastUpdated > block.blockFirstPublished;
+	const lastUpdated =
+		!isUndefined(block.blockFirstPublished) &&
+		!isUndefined(block.blockLastUpdated) &&
+		block.blockLastUpdated > block.blockFirstPublished
+			? block.blockLastUpdated
+			: undefined;
 
 	const isOriginalPinnedPost = !isPinnedPost && block.id === pinnedPostId;
 
@@ -96,14 +101,12 @@ export const LiveBlock = ({
 					size="small"
 					context="LiveBlock"
 				/>
-				{showLastUpdated &&
-					block.blockLastUpdated !== undefined &&
-					!!block.blockLastUpdatedDisplay && (
-						<LastUpdated
-							lastUpdated={block.blockLastUpdated}
-							lastUpdatedDisplay={block.blockLastUpdatedDisplay}
-						/>
-					)}
+				{!isUndefined(lastUpdated) && (
+					<LastUpdated
+						lastUpdated={lastUpdated}
+						editionId={editionId}
+					/>
+				)}
 			</footer>
 		</LiveBlockContainer>
 	);

--- a/dotcom-rendering/src/components/LiveBlogBlocksAndAdverts.tsx
+++ b/dotcom-rendering/src/components/LiveBlogBlocksAndAdverts.tsx
@@ -1,4 +1,5 @@
 import { Fragment } from 'react';
+import type { EditionId } from '../lib/edition';
 import { getLiveblogAdPositions } from '../lib/getLiveblogAdPositions';
 import type { ServerSideTests, Switches } from '../types/config';
 import { AdPlaceholder } from './AdPlaceholder.apps';
@@ -9,6 +10,7 @@ import { LiveBlock } from './LiveBlock';
 type Props = {
 	format: ArticleFormat;
 	blocks: Block[];
+	editionId: EditionId;
 	pinnedPost?: Block;
 	host?: string;
 	pageId: string;
@@ -53,6 +55,7 @@ export const LiveBlogBlocksAndAdverts = ({
 	isAdFreeUser,
 	isSensitive,
 	isLiveUpdate,
+	editionId,
 }: Props) => {
 	const { renderingTarget } = useConfig();
 	const isWeb = renderingTarget === 'Web';
@@ -74,6 +77,7 @@ export const LiveBlogBlocksAndAdverts = ({
 				isSensitive={isSensitive}
 				isPinnedPost={false}
 				pinnedPostId={pinnedPost?.id}
+				editionId={editionId}
 			/>
 		);
 	};

--- a/dotcom-rendering/src/components/LiveBlogRenderer.tsx
+++ b/dotcom-rendering/src/components/LiveBlogRenderer.tsx
@@ -1,4 +1,5 @@
 import { Hide } from '@guardian/source-react-components';
+import type { EditionId } from '../lib/edition';
 import type { ServerSideTests, Switches } from '../types/config';
 import type { TagType } from '../types/tag';
 import { useConfig } from './ConfigContext';
@@ -15,6 +16,7 @@ import { hasRelevantTopics, TopicFilterBank } from './TopicFilterBank';
 type Props = {
 	format: ArticleFormat;
 	blocks: Block[];
+	editionId: EditionId;
 	pinnedPost?: Block;
 	host?: string;
 	pageId: string;
@@ -62,6 +64,7 @@ export const LiveBlogRenderer = ({
 	filterKeyEvents = false,
 	availableTopics,
 	selectedTopics,
+	editionId,
 }: Props) => {
 	const { renderingTarget } = useConfig();
 	const isWeb = renderingTarget === 'Web';
@@ -90,6 +93,7 @@ export const LiveBlogRenderer = ({
 							isAdFreeUser={isAdFreeUser}
 							isSensitive={isSensitive}
 							isPinnedPost={true}
+							editionId={editionId}
 						/>
 					</PinnedPost>
 				</>
@@ -143,6 +147,7 @@ export const LiveBlogRenderer = ({
 				isAdFreeUser={isAdFreeUser}
 				isSensitive={isSensitive}
 				pinnedPost={pinnedPost}
+				editionId={editionId}
 			/>
 			{isWeb && blocks.length > 4 && (
 				<Island

--- a/dotcom-rendering/src/components/PinnedPost.stories.tsx
+++ b/dotcom-rendering/src/components/PinnedPost.stories.tsx
@@ -84,6 +84,7 @@ export const Sport = () => {
 					abTests={{}}
 					switches={{}}
 					isPinnedPost={true}
+					editionId="UK"
 				/>
 			</PinnedPost>
 		</Wrapper>
@@ -130,6 +131,7 @@ export const News = () => {
 					abTests={{}}
 					switches={{}}
 					isPinnedPost={true}
+					editionId="UK"
 				/>
 			</PinnedPost>
 		</Wrapper>
@@ -176,6 +178,7 @@ export const Culture = () => {
 					abTests={{}}
 					switches={{}}
 					isPinnedPost={true}
+					editionId="UK"
 				/>
 			</PinnedPost>
 		</Wrapper>
@@ -222,6 +225,7 @@ export const Lifestyle = () => {
 					abTests={{}}
 					switches={{}}
 					isPinnedPost={true}
+					editionId="UK"
 				/>
 			</PinnedPost>
 		</Wrapper>
@@ -268,6 +272,7 @@ export const Opinion = () => {
 					abTests={{}}
 					switches={{}}
 					isPinnedPost={true}
+					editionId="UK"
 				/>
 			</PinnedPost>
 		</Wrapper>
@@ -314,6 +319,7 @@ export const SpecialReport = () => {
 					abTests={{}}
 					switches={{}}
 					isPinnedPost={true}
+					editionId="UK"
 				/>
 			</PinnedPost>
 		</Wrapper>
@@ -360,6 +366,7 @@ export const Labs = () => {
 					abTests={{}}
 					switches={{}}
 					isPinnedPost={true}
+					editionId="UK"
 				/>
 			</PinnedPost>
 		</Wrapper>

--- a/dotcom-rendering/src/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/layouts/CommentLayout.tsx
@@ -655,6 +655,7 @@ export const CommentLayout = (props: WebProps | AppsProps) => {
 										isRightToLeftLang={
 											article.isRightToLeftLang
 										}
+										editionId={article.editionId}
 									/>
 									{showBodyEndSlot && (
 										<Island

--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -679,6 +679,7 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 									isRightToLeftLang={
 										article.isRightToLeftLang
 									}
+									editionId={article.editionId}
 								/>
 								{showBodyEndSlot && (
 									<Island

--- a/dotcom-rendering/src/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/InteractiveLayout.tsx
@@ -604,6 +604,7 @@ export const InteractiveLayout = (props: WebProps | AppsProps) => {
 										isRightToLeftLang={
 											article.isRightToLeftLang
 										}
+										editionId={article.editionId}
 									/>
 								</ArticleContainer>
 							</GridItem>

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -960,6 +960,9 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 														article.config
 															.keywordIds
 													}
+													editionId={
+														article.editionId
+													}
 												/>
 												{pagination.totalPages > 1 && (
 													<Pagination
@@ -1110,6 +1113,9 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 													lang={article.lang}
 													isRightToLeftLang={
 														article.isRightToLeftLang
+													}
+													editionId={
+														article.editionId
 													}
 												/>
 												{pagination.totalPages > 1 && (

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -664,6 +664,7 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 									isRightToLeftLang={
 										article.isRightToLeftLang
 									}
+									editionId={article.editionId}
 								/>
 								{showBodyEndSlot && (
 									<Island

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -726,6 +726,7 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 									isRightToLeftLang={
 										article.isRightToLeftLang
 									}
+									editionId={article.editionId}
 								/>
 								{format.design === ArticleDesign.MatchReport &&
 									!!footballMatchUrl && (

--- a/dotcom-rendering/src/server/render.article.web.tsx
+++ b/dotcom-rendering/src/server/render.article.web.tsx
@@ -11,6 +11,7 @@ import {
 } from '../lib/assets';
 import { decideFormat } from '../lib/decideFormat';
 import { decideTheme } from '../lib/decideTheme';
+import { isEditionId } from '../lib/edition';
 import { renderToStringWithEmotion } from '../lib/emotion';
 import { getHttp3Url } from '../lib/getHttp3Url';
 import { getCurrentPillar } from '../lib/layoutHelpers';
@@ -252,11 +253,14 @@ export const renderBlocks = ({
 	switches,
 	keywordIds,
 	abTests = {},
+	edition,
 }: FEBlocksRequest): string => {
 	const format: ArticleFormat = decideFormat(FEFormat);
 
 	// Only currently supported for Web
 	const config: Config = { renderingTarget: 'Web', darkModeAvailable: false };
+
+	const editionId = isEditionId(edition) ? edition : 'UK';
 
 	const { html, extractedCss } = renderToStringWithEmotion(
 		<ConfigProvider value={config}>
@@ -279,6 +283,7 @@ export const renderBlocks = ({
 				isPaidContent={false}
 				contributionsServiceUrl=""
 				keywordIds={keywordIds}
+				editionId={editionId}
 			/>
 		</ConfigProvider>,
 	);


### PR DESCRIPTION
## What does this change?

Implement #10153 for `LastUpdated`

## Why?

Move towards more consistency with dates:
- #10154 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/76776/070ea436-3de5-4780-aca1-c4b28c1eef75
[after]: https://github.com/guardian/dotcom-rendering/assets/76776/59f44378-855f-4592-bc3e-b348e861362f