### PR TITLE
Fix Dropdown story so that expanded state is toggleable

### DIFF
--- a/dotcom-rendering/src/components/Dropdown.tsx
+++ b/dotcom-rendering/src/components/Dropdown.tsx
@@ -394,6 +394,7 @@ export const Dropdown = ({
 }: Props) => {
 	const [isExpanded, setIsExpanded] = useState(defaultIsExpanded);
 	const [noJS, setNoJS] = useState(true);
+	const [buttonRef, setButtonRef] = useState<HTMLButtonElement | null>(null);
 
 	useEffect(() => {
 		// If hook runs we know client-side JS is enabled
@@ -414,20 +415,30 @@ export const Dropdown = ({
 	}, [isExpanded]);
 
 	useEffect(() => {
-		const dismissOnClick = (event: MouseEvent) => {
-			if (isExpanded) {
-				event.stopPropagation();
-				setIsExpanded(false);
+		if (!isExpanded || !buttonRef) {
+			return;
+		}
+
+		const dismissOnClickAway = (event: MouseEvent) => {
+			// If the source of the click is the button, do nothing as the
+			// button's click handler will have already toggled the isExpanded
+			// state
+			if (buttonRef === event.target) {
+				return;
 			}
+			event.stopPropagation();
+			setIsExpanded(false);
 		};
 
-		document.addEventListener('click', dismissOnClick, false);
+		document.addEventListener('click', dismissOnClickAway, false);
 
 		// Remove listener on unmount
-		return () => document.removeEventListener('click', dismissOnClick);
-	}, [isExpanded]);
+		return () => document.removeEventListener('click', dismissOnClickAway);
+	}, [isExpanded, buttonRef]);
 
-	const handleToggle = () => setIsExpanded(!isExpanded);
+	const handleToggle = () => {
+		setIsExpanded(!isExpanded);
+	};
 
 	// needs to be unique to allow multiple dropdowns on same page
 	const dropdownID = `dropbox-id-${id}`;
@@ -498,6 +509,7 @@ export const Dropdown = ({
 						data-link-name={dataLinkName}
 						data-testid="dropdown-button"
 						type="button"
+						ref={setButtonRef}
 					>
 						{label}
 						{notificationCount > 0 && (


### PR DESCRIPTION
## What does this change?

In the `Dropdown` component, when it's expanded, only handle a click away to close if the target of the event isn't the dropdown button.

## Why?

Before there was an issue where the interaction between the click away to close behaviour and clicking of the dropdown button itself were cancelling each other out and the expanded state went from false -> true -> false immediately. This made it hard to use Storybook to preview the Dropdown component in its expanded state, as you couldn't get the component into it's expanded state. This issue only affected the story, perhaps it's due to subtle differences between React and Preact?

## Screenshots

Screen recording showing the behaviour is still correct on the website:

https://github.com/guardian/dotcom-rendering/assets/379839/ae1ddda7-59f1-455b-861d-72e061281249

Screen recording showing the (fixed) correct behaviour in Storybook:


https://github.com/guardian/dotcom-rendering/assets/379839/e83f210c-50fb-4990-b24e-90402d0179b8



<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
