### PR TITLE
Update deeply read test

### DIFF
--- a/dotcom-rendering/src/components/MostPopularFooterGrid.tsx
+++ b/dotcom-rendering/src/components/MostPopularFooterGrid.tsx
@@ -125,8 +125,8 @@ export const MostPopularFooterGrid = ({
 	sectionName = '',
 	hasPageSkin = false,
 }: Props) => {
-	const shortenedMostViewed = mostViewed.trails.slice(0, 5);
-	const shortenedDeeplyRead = deeplyRead.trails.slice(0, 5);
+	const shortenedMostViewed = mostViewed.trails.slice(0, 10);
+	const shortenedDeeplyRead = deeplyRead.trails.slice(0, 10);
 
 	return (
 		<div

--- a/dotcom-rendering/src/components/MostPopularFooterGrid.tsx
+++ b/dotcom-rendering/src/components/MostPopularFooterGrid.tsx
@@ -192,7 +192,6 @@ export const MostPopularFooterGrid = ({
 								j,
 								shortenedMostViewed.length,
 							)}
-							image={trail.image}
 							hasPageSkin={hasPageSkin}
 						/>
 					))}

--- a/dotcom-rendering/src/components/MostPopularFooterGrid.tsx
+++ b/dotcom-rendering/src/components/MostPopularFooterGrid.tsx
@@ -161,7 +161,6 @@ export const MostPopularFooterGrid = ({
 							headlineText={trail.headline}
 							ageWarning={trail.ageWarning}
 							cssOverrides={mostViewedOverridesStyle(j)}
-							image={trail.image}
 							hasPageSkin={hasPageSkin}
 						/>
 					))}

--- a/dotcom-rendering/src/components/MostViewedFooterItem.tsx
+++ b/dotcom-rendering/src/components/MostViewedFooterItem.tsx
@@ -90,11 +90,6 @@ type Props = {
 	hasPageSkin?: boolean;
 };
 
-type MiniImageProps = {
-	image: string;
-	alt: string;
-};
-
 export const MostViewedFooterItem = ({
 	position,
 	url,

--- a/dotcom-rendering/src/components/MostViewedFooterItem.tsx
+++ b/dotcom-rendering/src/components/MostViewedFooterItem.tsx
@@ -2,7 +2,6 @@ import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import { ArticleDesign } from '@guardian/libs';
 import {
-	breakpoints,
 	headline,
 	palette as sourcePalette,
 	until,
@@ -12,13 +11,8 @@ import { AgeWarning } from './AgeWarning';
 import { BigNumber } from './BigNumber';
 import { FormatBoundary } from './FormatBoundary';
 import { LinkHeadline } from './LinkHeadline';
-import { generateSources } from './Picture';
 
-const gridItem = (
-	position: number,
-	isWithImage: boolean,
-	hasPageSkin: boolean,
-) => {
+const gridItem = (position: number, hasPageSkin: boolean) => {
 	const borderTop = hasPageSkin
 		? css`
 				border-top: 1px solid ${sourcePalette.neutral[86]};
@@ -42,7 +36,7 @@ const gridItem = (
 
 		/* The left border is set on the container */
 		border-right: 1px solid ${sourcePalette.neutral[86]};
-		min-height: ${isWithImage ? '4rem' : '3.25rem'};
+		min-height: 52px;
 
 		&:hover {
 			cursor: pointer;
@@ -86,19 +80,6 @@ const ageWarningStyles = css`
 	margin-bottom: 16px;
 `;
 
-const imageStyles = css`
-	width: 53px;
-	height: 53px;
-	object-fit: cover;
-	position: absolute;
-	left: 59px;
-	top: 6px;
-`;
-
-const textPaddingWithImage = css`
-	padding-left: 122px;
-`;
-
 type Props = {
 	position: number;
 	url: string;
@@ -106,39 +87,12 @@ type Props = {
 	headlineText: string;
 	ageWarning?: string;
 	cssOverrides?: SerializedStyles | SerializedStyles[];
-	image?: string;
 	hasPageSkin?: boolean;
 };
 
 type MiniImageProps = {
 	image: string;
 	alt: string;
-};
-
-const MiniImage = ({ image, alt }: MiniImageProps) => {
-	// We need to have a square image with 53px width and height
-	// We first get a source for a landscape image with height 53
-	// (requesting a width of 89px from grid)
-	// we then crop the image to give it a width of 53px using css
-	const [source] = generateSources(image, [
-		{ breakpoint: breakpoints.desktop, width: 89 },
-	]);
-
-	if (!source) throw new Error(`Missing source for ${image}`);
-
-	return (
-		<picture>
-			{/* High resolution (HDPI) sources*/}
-			<source
-				srcSet={source.hiResUrl}
-				media={`(-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)`}
-			/>
-			{/* Low resolution (MDPI) source*/}
-			<source srcSet={source.lowResUrl} />
-
-			<img alt={alt} src={source.lowResUrl} css={imageStyles} />
-		</picture>
-	);
 };
 
 export const MostViewedFooterItem = ({
@@ -148,19 +102,17 @@ export const MostViewedFooterItem = ({
 	headlineText,
 	ageWarning,
 	cssOverrides,
-	image,
 	hasPageSkin = false,
 }: Props) => (
 	<li
-		css={[gridItem(position, !!image, hasPageSkin), cssOverrides]}
+		css={[gridItem(position, hasPageSkin), cssOverrides]}
 		data-link-name={`${position} | text`}
 	>
 		<a css={headlineLink} href={url} data-link-name="article">
 			<span css={bigNumber}>
 				<BigNumber index={position} />
 			</span>
-			{!!image && <MiniImage image={image} alt={headlineText} />}
-			<div css={[headlineHeader, !!image && textPaddingWithImage]}>
+			<div css={[headlineHeader]}>
 				<FormatBoundary format={format}>
 					{format.design === ArticleDesign.LiveBlog ? (
 						<LinkHeadline

--- a/dotcom-rendering/src/components/MostViewedFooterItem.tsx
+++ b/dotcom-rendering/src/components/MostViewedFooterItem.tsx
@@ -51,16 +51,16 @@ const gridItem = (position: number, hasPageSkin: boolean) => {
 
 const bigNumber = css`
 	position: absolute;
-	top: 0.375rem;
-	left: 0.625rem;
+	top: 6px;
+	left: 10px;
 	fill: ${palette('--article-text')};
 	svg {
-		height: 2.5rem;
+		height: 40px;
 	}
 `;
 
 const headlineHeader = css`
-	padding: 0.1875rem 0.625rem 1.125rem 4.6875rem;
+	padding: 3px 10px 18px 75px;
 	word-wrap: break-word;
 	overflow: hidden;
 `;
@@ -75,7 +75,7 @@ const headlineLink = css`
 `;
 
 const ageWarningStyles = css`
-	padding-left: 4.6875rem;
+	padding-left: 75px;
 	margin-top: -16px;
 	margin-bottom: 16px;
 `;


### PR DESCRIPTION
## What does this change?

* Removes images from the deeply read version of the Most Viewed component 
* Increases the number of rendered items to 10 

## Why?

This is preparing for a second deeply read test, in line with tweaks suggested by stakeholders 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/1229808/c85ba888-2929-4b2d-8122-dee908ac55c1
[after]: https://github.com/guardian/dotcom-rendering/assets/1229808/4e0a286f-641b-4512-bd7f-607be555f7ad


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->

This needs approval from design. The mobile view becomes a little long: 

<img width="217" alt="Screenshot 2024-01-12 at 10 27 34" src="https://github.com/guardian/dotcom-rendering/assets/1229808/4cb37919-0ce2-41c7-99e3-601452a512d9">

Fixes https://github.com/guardian/dotcom-rendering/issues/8807
