### PR TITLE
feat(pulls.ts): gather daily merged PRs

### DIFF
--- a/scripts/deno/pulls.ts
+++ b/scripts/deno/pulls.ts
@@ -1,0 +1,50 @@
+import { octokit } from "./github.ts";
+
+const get_pulls = async (page: number) => {
+  if (!octokit) throw Error("No Octokit");
+
+  const { data: pulls } = await octokit.request(
+    "GET /repos/{owner}/{repo}/pulls",
+    {
+      owner: "guardian",
+      repo: "dotcom-rendering",
+      headers: {
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+      per_page: 100,
+      state: "closed",
+      sort: "updated",
+      direction: "desc",
+      page,
+    },
+  );
+
+  return pulls;
+};
+
+async function* get_all_pulls(max_page: number) {
+  let page = 1;
+  const pulls = await get_pulls(page++);
+
+  while (page <= max_page) {
+    if (pulls.length === 0) {
+      pulls.push(...(await get_pulls(page++)));
+    }
+    const pull = pulls.shift();
+    if (!pull) return;
+    yield pull;
+  }
+}
+
+const dates = new Map<string, number>();
+
+for await (const pull of get_all_pulls(20)) {
+  if (!pull.merged_at) continue;
+  const date = pull.merged_at.slice(0, 10);
+  const count = dates.get(date) ?? 0;
+  dates.set(date, count + 1);
+}
+
+for (const [date, count] of dates) {
+  console.log(`${date}\t${count}`);
+}


### PR DESCRIPTION
## What does this change?

Add a script to measure number of PRs merged per day

## Why?

Interest

## Screenshots

<img width="893" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/76776/8fd1ef1d-b696-4afe-a260-88eaa37d9a6d">
