### PR TITLE
Add remaining darkmode styles for onwards

### DIFF
--- a/dotcom-rendering/src/components/Carousel.importable.tsx
+++ b/dotcom-rendering/src/components/Carousel.importable.tsx
@@ -394,6 +394,7 @@ const headerRowStyles = css`
 const headerStyles = css`
 	${headline.xsmall({ fontWeight: 'bold' })};
 	color: ${sourcePalette.neutral[7]};
+	color: ${themePalette('--carousel-text')};
 	${headline.xsmall({ fontWeight: 'bold' })};
 	padding-bottom: ${space[2]}px;
 	padding-top: ${space[1]}px;

--- a/dotcom-rendering/src/components/OnwardsUpper.importable.tsx
+++ b/dotcom-rendering/src/components/OnwardsUpper.importable.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/react';
 import { joinUrl, Pillar } from '@guardian/libs';
 import type { EditionId } from '../lib/edition';
 import { useHydrated } from '../lib/useHydrated';
+import { palette } from '../palette';
 import type { OnwardsSource } from '../types/onwards';
 import type { TagType } from '../types/tag';
 import { FetchOnwardsData } from './FetchOnwardsData.importable';
@@ -65,6 +66,7 @@ const firstPopularTag = (keywordIds: string, isPaidContent: boolean) => {
 
 const onwardsWrapper = css`
 	width: 100%;
+	background: ${palette('--article-section-background')};
 `;
 
 // TODO: EUR edition urls are currently pointing to INT edition
@@ -288,7 +290,10 @@ export const OnwardsUpper = ({
 	return (
 		<div css={onwardsWrapper}>
 			{!!url && (
-				<Section fullWidth={true}>
+				<Section
+					fullWidth={true}
+					borderColour={palette('--article-border')}
+				>
 					<FetchOnwardsData
 						url={url}
 						limit={8}
@@ -299,7 +304,10 @@ export const OnwardsUpper = ({
 				</Section>
 			)}
 			{!!(!isPaidContent && curatedDataUrl) && (
-				<Section fullWidth={true}>
+				<Section
+					fullWidth={true}
+					borderColour={palette('--article-border')}
+				>
 					<FetchOnwardsData
 						url={curatedDataUrl}
 						limit={20}


### PR DESCRIPTION
## Why?

We want to enable more onwards containers for DCAR (#10142), but some components in these containers do not have darkmode yet. This change adds the remaining darkmode colours so we can show these containers on apps articles.

> [!NOTE]
> Merging this will not show the onwards containers on apps articles. That work is covered in https://github.com/guardian/dotcom-rendering/pull/10152

Closes https://github.com/guardian/dotcom-rendering/issues/10162

## Screenshots

| Before | After |
|--------|--------|
| ![image](https://github.com/guardian/dotcom-rendering/assets/705427/ac3288aa-5d93-4bbf-8321-5aef684668fc) | <img width="1379" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/705427/3ba1cd38-29eb-42d9-99d8-ad552b525438"> | 
