### PR TITLE
Bump `ts-jest` to to v29

### DIFF
--- a/apps-rendering/package.json
+++ b/apps-rendering/package.json
@@ -103,7 +103,7 @@
 		"require-from-string": "2.0.2",
 		"storybook": "7.6.6",
 		"thrift": "0.19.0",
-		"ts-jest": "28.0.8",
+		"ts-jest": "29.1.1",
 		"ts-loader": "9.4.3",
 		"tslib": "2.6.2",
 		"tsx": "4.6.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -240,8 +240,8 @@ importers:
         specifier: 0.19.0
         version: 0.19.0
       ts-jest:
-        specifier: 28.0.8
-        version: 28.0.8(@babel/core@7.23.2)(esbuild@0.18.20)(jest@29.5.0)(typescript@5.3.3)
+        specifier: 29.1.1
+        version: 29.1.1(@babel/core@7.23.2)(esbuild@0.18.20)(jest@29.5.0)(typescript@5.3.3)
       ts-loader:
         specifier: 9.4.3
         version: 9.4.3(typescript@5.3.3)(webpack@5.89.0)
@@ -5340,13 +5340,6 @@ packages:
       - supports-color
     dev: false
 
-  /@jest/schemas@28.1.3:
-    resolution: {integrity: sha512-/l/VWsdt/aBXgjshLWOFyFt3IVdYypu5y2Wn2rOO1un6nkqIn8SLXzgIMYXFyYsRWDyF5EthmKJMIdJvk08grg==}
-    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
-    dependencies:
-      '@sinclair/typebox': 0.24.51
-    dev: false
-
   /@jest/schemas@29.6.3:
     resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -5414,18 +5407,6 @@ packages:
       '@types/istanbul-reports': 3.0.4
       '@types/node': 18.18.14
       '@types/yargs': 16.0.9
-      chalk: 4.1.2
-    dev: false
-
-  /@jest/types@28.1.3:
-    resolution: {integrity: sha512-RyjiyMUZrKz/c+zlMFO1pm70DcIlST8AeWTkoUdZevew44wcNZQHsEVOiCVtgVnlFFD82FPaXycys58cf2muVQ==}
-    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
-    dependencies:
-      '@jest/schemas': 28.1.3
-      '@types/istanbul-lib-coverage': 2.0.6
-      '@types/istanbul-reports': 3.0.4
-      '@types/node': 18.18.14
-      '@types/yargs': 17.0.32
       chalk: 4.1.2
     dev: false
 
@@ -6395,10 +6376,6 @@ packages:
 
   /@sideway/pinpoint@2.0.0:
     resolution: {integrity: sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==}
-    dev: false
-
-  /@sinclair/typebox@0.24.51:
-    resolution: {integrity: sha512-1P1OROm/rdubP5aFDSZQILU0vrLCJ4fvHt6EoqHEM+2D/G5MK3bIaymUKLit8Js9gbns5UyJnkP/TZROLw4tUA==}
     dev: false
 
   /@sinclair/typebox@0.27.8:
@@ -14774,18 +14751,6 @@ packages:
       - supports-color
     dev: false
 
-  /jest-util@28.1.3:
-    resolution: {integrity: sha512-XdqfpHwpcSRko/C35uLYFM2emRAltIIKZiJ9eAmhjsj0CqZMa0p1ib0R5fWIqGhn1a103DebTbpqIaP1qCQ6tQ==}
-    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
-    dependencies:
-      '@jest/types': 28.1.3
-      '@types/node': 18.18.14
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      graceful-fs: 4.2.11
-      picomatch: 2.3.1
-    dev: false
-
   /jest-util@29.7.0:
     resolution: {integrity: sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -19160,17 +19125,17 @@ packages:
     engines: {node: '>=6.10'}
     dev: false
 
-  /ts-jest@28.0.8(@babel/core@7.23.2)(esbuild@0.18.20)(jest@29.5.0)(typescript@5.3.3):
-    resolution: {integrity: sha512-5FaG0lXmRPzApix8oFG8RKjAz4ehtm8yMKOTy5HX3fY6W8kmvOrmcY0hKDElW52FJov+clhUbrKAqofnj4mXTg==}
-    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+  /ts-jest@29.1.1(@babel/core@7.23.2)(esbuild@0.18.20)(jest@29.5.0)(typescript@5.3.3):
+    resolution: {integrity: sha512-D6xjnnbP17cC85nliwGiL+tpoKN0StpgE0TeOjXQTU6MVCfsB4v7aW05CgQ/1OywGb0x/oy9hHFnN+sczTiRaA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
     peerDependencies:
       '@babel/core': '>=7.0.0-beta.0 <8'
-      '@jest/types': ^28.0.0
-      babel-jest: ^28.0.0
+      '@jest/types': ^29.0.0
+      babel-jest: ^29.0.0
       esbuild: '*'
-      jest: ^28.0.0
-      typescript: '>=4.3'
+      jest: ^29.0.0
+      typescript: '>=4.3 <6'
     peerDependenciesMeta:
       '@babel/core':
         optional: true
@@ -19186,7 +19151,7 @@ packages:
       esbuild: 0.18.20
       fast-json-stable-stringify: 2.1.0
       jest: 29.5.0(@types/node@18.18.14)
-      jest-util: 28.1.3
+      jest-util: 29.7.0
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6


### PR DESCRIPTION
## What does this change?

Bump `ts-jest` to v29

## Why?

address peer dependency mismatch:
- #10085 

```shell
apps-rendering
└─┬ ts-jest 28.0.8
  └── ✕ unmet peer jest@^28.0.0: found 29.5.0
``` 