### PR TITLE
Update border colours in dark mode

### DIFF
--- a/dotcom-rendering/src/components/MostViewedFooterGrid.tsx
+++ b/dotcom-rendering/src/components/MostViewedFooterGrid.tsx
@@ -11,7 +11,7 @@ import { palette } from '../palette';
 import type { TrailTabType, TrailType } from '../types/trails';
 import { MostViewedFooterItem } from './MostViewedFooterItem';
 
-const thinGreySolid = `1px solid ${sourcePalette.neutral[86]}`;
+const thinGreySolid = `1px solid ${palette('--article-border')}`;
 
 const hidePanel = css`
 	display: none;
@@ -99,7 +99,7 @@ const gridContainer = css`
 
 	/* We set left border on the grid container, and then right border on
     the gridItems to prevent borders doubling up */
-	border-left: 1px solid ${sourcePalette.neutral[86]};
+	border-left: 1px solid ${palette('--article-border')};
 `;
 
 type Props = {

--- a/dotcom-rendering/src/components/MostViewedFooterItem.tsx
+++ b/dotcom-rendering/src/components/MostViewedFooterItem.tsx
@@ -1,11 +1,7 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import { ArticleDesign } from '@guardian/libs';
-import {
-	headline,
-	palette as sourcePalette,
-	until,
-} from '@guardian/source-foundations';
+import { headline, until } from '@guardian/source-foundations';
 import { palette } from '../palette';
 import { AgeWarning } from './AgeWarning';
 import { BigNumber } from './BigNumber';

--- a/dotcom-rendering/src/components/MostViewedFooterItem.tsx
+++ b/dotcom-rendering/src/components/MostViewedFooterItem.tsx
@@ -15,12 +15,12 @@ import { LinkHeadline } from './LinkHeadline';
 const gridItem = (position: number, hasPageSkin: boolean) => {
 	const borderTop = hasPageSkin
 		? css`
-				border-top: 1px solid ${sourcePalette.neutral[86]};
+				border-top: 1px solid ${palette('--article-border')};
 		  `
 		: css`
 				/* Below leftCol always set top border */
 				${until.leftCol} {
-					border-top: 1px solid ${sourcePalette.neutral[86]};
+					border-top: 1px solid ${palette('--article-border')};
 				}
 		  `;
 	return css`
@@ -32,10 +32,10 @@ const gridItem = (position: number, hasPageSkin: boolean) => {
 		items to prevent double borders */
 		border-top: ${position !== 1 &&
 		position !== 6 &&
-		`1px solid ${sourcePalette.neutral[86]}`};
+		`1px solid ${palette('--article-border')};`};
 
 		/* The left border is set on the container */
-		border-right: 1px solid ${sourcePalette.neutral[86]};
+		border-right: 1px solid ${palette('--article-border')};
 		min-height: 52px;
 
 		&:hover {

--- a/dotcom-rendering/src/components/MostViewedRightItem.tsx
+++ b/dotcom-rendering/src/components/MostViewedRightItem.tsx
@@ -24,7 +24,7 @@ const listItemStyles = css`
 	}
 	padding-top: 4px;
 	margin-bottom: 12px;
-	border-top: 1px solid ${sourcePalette.neutral[86]};
+	border-top: 1px solid ${themePalette('--article-border')};
 
 	&:first-of-type {
 		padding-top: 0;

--- a/dotcom-rendering/src/components/SubMeta.tsx
+++ b/dotcom-rendering/src/components/SubMeta.tsx
@@ -76,8 +76,8 @@ const listStyleNone = css`
 		),
 		repeating-linear-gradient(
 			to right,
-			${sourcePalette.neutral[86]} 0px,
-			${sourcePalette.neutral[86]} 3px,
+			${palette('--article-border')} 0px,
+			${palette('--article-border')} 3px,
 			transparent 3px,
 			transparent 5px
 		);

--- a/dotcom-rendering/src/components/SubMeta.tsx
+++ b/dotcom-rendering/src/components/SubMeta.tsx
@@ -1,12 +1,6 @@
 import { css } from '@emotion/react';
 import { ArticleDesign } from '@guardian/libs';
-import {
-	from,
-	palette as sourcePalette,
-	space,
-	textSans,
-	until,
-} from '@guardian/source-foundations';
+import { from, space, textSans, until } from '@guardian/source-foundations';
 import { LinkButton } from '@guardian/source-react-components';
 import type { BaseLinkType } from '../model/extract-nav';
 import { palette } from '../palette';

--- a/dotcom-rendering/src/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/layouts/CommentLayout.tsx
@@ -966,6 +966,7 @@ export const CommentLayout = (props: WebProps | AppsProps) => {
 					fullWidth={true}
 					data-print-layout="hide"
 					backgroundColour={themePalette('--apps-footer-background')}
+					borderColour={themePalette('--article-border')}
 					padSides={false}
 					showSideBorders={false}
 					element="footer"

--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -991,6 +991,7 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 					fullWidth={true}
 					data-print-layout="hide"
 					backgroundColour={themePalette('--apps-footer-background')}
+					borderColour={themePalette('--article-border')}
 					padSides={false}
 					showSideBorders={false}
 					element="footer"

--- a/dotcom-rendering/src/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/InteractiveLayout.tsx
@@ -909,6 +909,7 @@ export const InteractiveLayout = (props: WebProps | AppsProps) => {
 					fullWidth={true}
 					data-print-layout="hide"
 					backgroundColour={themePalette('--apps-footer-background')}
+					borderColour={themePalette('--article-border')}
 					padSides={false}
 					showSideBorders={false}
 					element="footer"

--- a/dotcom-rendering/src/layouts/PictureLayout.tsx
+++ b/dotcom-rendering/src/layouts/PictureLayout.tsx
@@ -861,6 +861,7 @@ export const PictureLayout = (props: WebProps | AppsProps) => {
 					fullWidth={true}
 					data-print-layout="hide"
 					backgroundColour={themePalette('--apps-footer-background')}
+					borderColour={themePalette('--article-border')}
 					padSides={false}
 					showSideBorders={false}
 					element="footer"

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -967,6 +967,7 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 					fullWidth={true}
 					data-print-layout="hide"
 					backgroundColour={themePalette('--apps-footer-background')}
+					borderColour={themePalette('--article-border')}
 					padSides={false}
 					showSideBorders={false}
 					element="footer"

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -1069,6 +1069,7 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 						backgroundColour={themePalette(
 							'--article-section-background',
 						)}
+						borderColour={themePalette('--article-border')}
 						padSides={false}
 						showSideBorders={false}
 						element="footer"

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -3160,7 +3160,7 @@ const articleBorderLight: PaletteFunction = ({ design, theme }) => {
 	}
 };
 
-const articleBorderDark: PaletteFunction = () => sourcePalette.neutral[38];
+const articleBorderDark: PaletteFunction = () => sourcePalette.neutral[20];
 
 const straightLinesLight: PaletteFunction = (format) => {
 	if (format.theme === ArticleSpecial.SpecialReportAlt)

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -3048,7 +3048,7 @@ const articleMetaLinesDark: PaletteFunction = ({ design }) => {
 		case ArticleDesign.Interactive:
 			return sourcePalette.neutral[46];
 		default:
-			return sourcePalette.neutral[46];
+			return sourcePalette.neutral[20];
 	}
 };
 


### PR DESCRIPTION
## What does this change?

- Sets dark mode article border colour to `neutral[20]` as described in #10166.

Closes #10166

## Screenshots

| Component | Before | After |
|--------|--------|--------|
| Footer | <img width="721" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/705427/868b75d1-0692-4761-8df9-377e98ac140d"> | <img width="736" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/705427/c2d34184-7713-497a-a530-a97c7554809b"> |
| More on this story | <img width="292" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/705427/88f04e47-2289-4189-a933-880848b3685d"> | <img width="276" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/705427/93f753fe-7015-43de-b674-e967ebe0bbfe"> |
| Most viewed right | <img width="319" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/705427/490edb07-a9fb-493e-9a31-604c6590e401"> | <img width="331" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/705427/17433eed-d561-4ba5-b111-8845dcf23151"> | 
| Most viewed bottom | <img width="661" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/705427/8e653d04-0a0d-4c66-a39a-204f60ab5607"> | <img width="709" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/705427/b551c698-b84f-419e-9dad-8d581607e2fb"> |
| Most viewed | <img width="1361" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/705427/07f47afc-8646-47c6-adbc-0e0ce85fc9d7"> | <img width="1258" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/705427/99107ede-3894-4090-a506-e7544fa48e98"> | 
| Byline | <img width="438" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/705427/3bf6be59-b542-404f-8d13-74d0fa4a0d85"> | <img width="422" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/705427/0e987676-865d-4a9d-92ea-cc188e97d75e"> |
| Explore more | <img width="258" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/705427/29eec586-8e4b-4419-9669-ced1b573adbe"> | <img width="255" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/705427/027bc878-41e1-4b86-b05c-8476f1359a88"> |