### PR TITLE
Refactor `DateTime` to enable showing only date or time

### DIFF
--- a/dotcom-rendering/src/components/DateTime.stories.tsx
+++ b/dotcom-rendering/src/components/DateTime.stories.tsx
@@ -28,7 +28,11 @@ export const UK: Story = {
 };
 
 export const TimeOnly: Story = {
-	args: { date, editionId: 'UK', showDate: false },
+	args: { date, editionId: 'UK', show: 'time' },
+};
+
+export const DateOnly: Story = {
+	args: { date, editionId: 'UK', show: 'date' },
 };
 
 export const US: Story = {

--- a/dotcom-rendering/src/components/DateTime.tsx
+++ b/dotcom-rendering/src/components/DateTime.tsx
@@ -3,10 +3,32 @@ import { type EditionId, getEditionFromId } from '../lib/edition';
 type Props = {
 	date: Date;
 	editionId: EditionId;
-	showDate?: boolean;
+	show?: 'date & time' | 'date' | 'time';
 };
 
-export const DateTime = ({ date, editionId, showDate = true }: Props) => {
+const formatDate = (date: Date, locale: string, timeZone: string) =>
+	date
+		.toLocaleDateString(locale, {
+			weekday: 'short',
+			day: 'numeric',
+			month: 'short',
+			year: 'numeric',
+			timeZone,
+		})
+		.replaceAll(',', '');
+
+const formatTime = (date: Date, locale: string, timeZone: string) =>
+	date
+		.toLocaleTimeString(locale, {
+			hour12: false,
+			hour: '2-digit',
+			minute: '2-digit',
+			timeZoneName: 'short',
+			timeZone,
+		})
+		.replace(':', '.');
+
+export const DateTime = ({ date, editionId, show = 'date & time' }: Props) => {
 	const { locale, timeZone } = getEditionFromId(editionId);
 	return (
 		<time
@@ -23,25 +45,8 @@ export const DateTime = ({ date, editionId, showDate = true }: Props) => {
 				timeZone,
 			})}
 		>
-			{showDate &&
-				date
-					.toLocaleDateString(locale, {
-						weekday: 'short',
-						day: 'numeric',
-						month: 'short',
-						year: 'numeric',
-						timeZone,
-					})
-					.replaceAll(',', '')}{' '}
-			{date
-				.toLocaleTimeString(locale, {
-					hour12: false,
-					hour: '2-digit',
-					minute: '2-digit',
-					timeZoneName: 'short',
-					timeZone,
-				})
-				.replace(':', '.')}
+			{show.includes('date') && formatDate(date, locale, timeZone)}{' '}
+			{show.includes('time') && formatTime(date, locale, timeZone)}
 		</time>
 	);
 };

--- a/dotcom-rendering/src/components/LastUpdated.tsx
+++ b/dotcom-rendering/src/components/LastUpdated.tsx
@@ -23,7 +23,7 @@ const LastUpdated = ({
 			<DateTime
 				date={new Date(lastUpdated)}
 				editionId={editionId}
-				showDate={false}
+				show="time"
 			/>
 		</div>
 	);


### PR DESCRIPTION
## What does this change?

Refactor `DateTime`, which was introduced in #10153 

## Why?

Some usage of `time` tags expects only a date or a time, not a a full date & time. Follow-up on:
- #10148 

## Screenshots

N/A – Identical