### PR TITLE
Add project to our issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,7 +1,8 @@
 name: 🐞 Bug Report
 description: Let us know about something unexpected that has happened
-title: '[Bug]: '
-labels: ['bug', 'needs-triage']
+title: ''
+labels: ['bug']
+projects: ['guardian/88']
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/request-for-change.md
+++ b/.github/ISSUE_TEMPLATE/request-for-change.md
@@ -3,6 +3,7 @@ name: DCR Request for comments
 about: Tell us about a feature that you're planning to implement in dotcom rendering
 title: '[RFC]'
 labels: RFC, dotcom-rendering
+projects: ['guardian/88']
 assignees: ''
 ---
 


### PR DESCRIPTION
## What does this change?

Adds the WebX project to our issue templates
Removes the needs-triage label as status will automatically be triage as a result of adding the issue to the project

## Why?

Because we monitor the triage column in the project but not issues created outside the project 
