### PR TITLE
Simpify assets path selection

### DIFF
--- a/dotcom-rendering/src/client/decidePublicPath.test.ts
+++ b/dotcom-rendering/src/client/decidePublicPath.test.ts
@@ -1,14 +1,5 @@
 import { decidePublicPath } from './decidePublicPath';
 
-const mockHostname = (hostname: string | undefined) => {
-	Object.defineProperty(window, 'location', {
-		value: {
-			hostname,
-		},
-		writable: true,
-	});
-};
-
 const mockFrontendAssetsFullURL = (frontendAssetsFullURL: string) => {
 	Object.defineProperty(window, 'guardian', {
 		value: {
@@ -24,54 +15,22 @@ describe('decidePublicPath', () => {
 	beforeEach(() => {
 		jest.resetModules();
 
-		// Ensures we always set a hostname in the test
-		// and the default hostname isn't accidentally used
-		mockHostname(undefined);
-
 		mockFrontendAssetsFullURL('https://assets.guim.co.uk/');
 
 		process.env = { NODE_ENV: undefined, HOSTNAME: undefined };
 	});
 
-	it('localhost with development flag', () => {
+	it('with development flag', () => {
 		process.env.NODE_ENV = 'development';
-		mockHostname('localhost');
-		expect(decidePublicPath()).toEqual('http://localhost:3030/assets/');
+		expect(decidePublicPath()).toEqual('/assets/');
 	});
 
-	it('localhost with production flag', () => {
+	it('with production flag', () => {
 		process.env.NODE_ENV = 'production';
-		mockHostname('localhost');
-		expect(decidePublicPath()).toEqual('/assets/');
+		expect(decidePublicPath()).toEqual('https://assets.guim.co.uk/assets/');
 	});
 
-	it('localhost with no flag', () => {
-		mockHostname('localhost');
-		expect(decidePublicPath()).toEqual('/assets/');
-	});
-
-	it('hostname set with development flag', () => {
-		process.env.NODE_ENV = 'development';
-		process.env.HOSTNAME = 'some-other-hostname.com';
-		mockHostname('some-other-hostname.com');
-		expect(decidePublicPath()).toEqual('/assets/');
-	});
-
-	it('hostname set with production flag', () => {
-		process.env.NODE_ENV = 'production';
-		process.env.HOSTNAME = 'some-other-hostname.com';
-		mockHostname('some-other-hostname.com');
-		expect(decidePublicPath()).toEqual('/assets/');
-	});
-
-	it('hostname set with no flag', () => {
-		process.env.HOSTNAME = 'some-other-hostname.com';
-		mockHostname('some-other-hostname.com');
-		expect(decidePublicPath()).toEqual('/assets/');
-	});
-
-	it('no hostname env or flag set', () => {
-		mockHostname('theguardian.com');
+	it('with no flag', () => {
 		expect(decidePublicPath()).toEqual('https://assets.guim.co.uk/assets/');
 	});
 });

--- a/dotcom-rendering/src/client/decidePublicPath.test.ts
+++ b/dotcom-rendering/src/client/decidePublicPath.test.ts
@@ -1,5 +1,14 @@
 import { decidePublicPath } from './decidePublicPath';
 
+const mockHostname = (hostname: string | undefined) => {
+	Object.defineProperty(window, 'location', {
+		value: {
+			hostname,
+		},
+		writable: true,
+	});
+};
+
 const mockFrontendAssetsFullURL = (frontendAssetsFullURL: string) => {
 	Object.defineProperty(window, 'guardian', {
 		value: {
@@ -15,6 +24,8 @@ describe('decidePublicPath', () => {
 	beforeEach(() => {
 		jest.resetModules();
 
+		mockHostname(undefined);
+
 		mockFrontendAssetsFullURL('https://assets.guim.co.uk/');
 
 		process.env = { NODE_ENV: undefined, HOSTNAME: undefined };
@@ -28,6 +39,12 @@ describe('decidePublicPath', () => {
 	it('with production flag', () => {
 		process.env.NODE_ENV = 'production';
 		expect(decidePublicPath()).toEqual('https://assets.guim.co.uk/assets/');
+	});
+
+	it('with production flag and localhost', () => {
+		process.env.NODE_ENV = 'production';
+		mockHostname('localhost');
+		expect(decidePublicPath()).toEqual('/assets/');
 	});
 
 	it('with no flag', () => {

--- a/dotcom-rendering/src/client/decidePublicPath.ts
+++ b/dotcom-rendering/src/client/decidePublicPath.ts
@@ -5,7 +5,9 @@
  */
 export const decidePublicPath = (): string => {
 	const isDev = process.env.NODE_ENV === 'development';
-	return isDev
+	const isLocalHost = window.location.hostname === 'localhost';
+	// Use relative path if running locally or in CI
+	return isDev || isLocalHost
 		? '/assets/'
 		: `${window.guardian.config.frontendAssetsFullURL}assets/`;
 };

--- a/dotcom-rendering/src/client/decidePublicPath.ts
+++ b/dotcom-rendering/src/client/decidePublicPath.ts
@@ -5,17 +5,7 @@
  */
 export const decidePublicPath = (): string => {
 	const isDev = process.env.NODE_ENV === 'development';
-	if (isDev && window.location.hostname === 'localhost') {
-		// Use the absolute path when in development mode and running locally
-		// Ensures asset paths are correct relative to Frontend
-		return 'http://localhost:3030/assets/';
-	} else if (
-		window.location.hostname === (process.env.HOSTNAME ?? 'localhost')
-	) {
-		// Use a relative path when hostname is set or using localhost in non-dev environments
-		// e.g. when using a reverse proxy, or running in CI
-		return '/assets/';
-	} else {
-		return `${window.guardian.config.frontendAssetsFullURL}assets/`;
-	}
+	return isDev
+		? '/assets/'
+		: `${window.guardian.config.frontendAssetsFullURL}assets/`;
 };

--- a/dotcom-rendering/src/components/StickyBottomBanner.importable.tsx
+++ b/dotcom-rendering/src/components/StickyBottomBanner.importable.tsx
@@ -64,7 +64,7 @@ const getBannerLastClosedAt = (key: string): string | undefined => {
 	return isString(item) ? item : undefined;
 };
 
-const DEFAULT_BANNER_TIMEOUT_MILLIS = 200000;
+const DEFAULT_BANNER_TIMEOUT_MILLIS = 2000;
 
 const buildCmpBannerConfig = (): CandidateConfig<void> => ({
 	candidate: {

--- a/dotcom-rendering/src/components/StickyBottomBanner.importable.tsx
+++ b/dotcom-rendering/src/components/StickyBottomBanner.importable.tsx
@@ -64,7 +64,7 @@ const getBannerLastClosedAt = (key: string): string | undefined => {
 	return isString(item) ? item : undefined;
 };
 
-const DEFAULT_BANNER_TIMEOUT_MILLIS = 2000;
+const DEFAULT_BANNER_TIMEOUT_MILLIS = 200000;
 
 const buildCmpBannerConfig = (): CandidateConfig<void> => ({
 	candidate: {

--- a/dotcom-rendering/src/lib/assets.test.ts
+++ b/dotcom-rendering/src/lib/assets.test.ts
@@ -15,39 +15,24 @@ jest.mock('node:path');
 
 describe('decideAssetOrigin for stage', () => {
 	it('PROD', () => {
-		expect(decideAssetOrigin('PROD', false)).toEqual(
-			'https://assets.guim.co.uk/',
-		);
-		expect(decideAssetOrigin('PROD', true)).toEqual(
-			'https://assets.guim.co.uk/',
-		);
-		expect(decideAssetOrigin('prod', true)).toEqual(
-			'https://assets.guim.co.uk/',
-		);
+		expect(decideAssetOrigin('PROD')).toEqual('https://assets.guim.co.uk/');
+		expect(decideAssetOrigin('PROD')).toEqual('https://assets.guim.co.uk/');
+		expect(decideAssetOrigin('prod')).toEqual('https://assets.guim.co.uk/');
 	});
 	it('CODE', () => {
-		expect(decideAssetOrigin('CODE', false)).toEqual(
+		expect(decideAssetOrigin('CODE')).toEqual(
 			'https://assets-code.guim.co.uk/',
 		);
-		expect(decideAssetOrigin('CODE', true)).toEqual(
+		expect(decideAssetOrigin('CODE')).toEqual(
 			'https://assets-code.guim.co.uk/',
 		);
-		expect(decideAssetOrigin('code', true)).toEqual(
+		expect(decideAssetOrigin('code')).toEqual(
 			'https://assets-code.guim.co.uk/',
 		);
 	});
 	it('DEV', () => {
-		expect(decideAssetOrigin('DEV', false)).toEqual('/');
-		expect(decideAssetOrigin(undefined, false)).toEqual('/');
-		expect(decideAssetOrigin('DEV', true)).toEqual(
-			'http://localhost:3030/',
-		);
-		expect(decideAssetOrigin('dev', true)).toEqual(
-			'http://localhost:3030/',
-		);
-		expect(decideAssetOrigin(undefined, true)).toEqual(
-			'http://localhost:3030/',
-		);
+		expect(decideAssetOrigin('DEV')).toEqual('/');
+		expect(decideAssetOrigin(undefined)).toEqual('/');
 	});
 });
 

--- a/dotcom-rendering/src/lib/assets.test.ts
+++ b/dotcom-rendering/src/lib/assets.test.ts
@@ -16,13 +16,9 @@ jest.mock('node:path');
 describe('decideAssetOrigin for stage', () => {
 	it('PROD', () => {
 		expect(decideAssetOrigin('PROD')).toEqual('https://assets.guim.co.uk/');
-		expect(decideAssetOrigin('PROD')).toEqual('https://assets.guim.co.uk/');
 		expect(decideAssetOrigin('prod')).toEqual('https://assets.guim.co.uk/');
 	});
 	it('CODE', () => {
-		expect(decideAssetOrigin('CODE')).toEqual(
-			'https://assets-code.guim.co.uk/',
-		);
 		expect(decideAssetOrigin('CODE')).toEqual(
 			'https://assets-code.guim.co.uk/',
 		);
@@ -32,6 +28,7 @@ describe('decideAssetOrigin for stage', () => {
 	});
 	it('DEV', () => {
 		expect(decideAssetOrigin('DEV')).toEqual('/');
+		expect(decideAssetOrigin('dev')).toEqual('/');
 		expect(decideAssetOrigin(undefined)).toEqual('/');
 	});
 });

--- a/dotcom-rendering/src/lib/assets.ts
+++ b/dotcom-rendering/src/lib/assets.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
-import { isObject, isString, isUndefined } from '@guardian/libs';
+import { isObject, isString } from '@guardian/libs';
 import { BUILD_VARIANT, dcrJavascriptBundle } from '../../webpack/bundles';
 import type { ServerSideTests, Switches } from '../types/config';
 import { makeMemoizedFunction } from './memoize';
@@ -15,30 +15,20 @@ interface AssetHash {
  * @param {'PROD' | 'CODE' | undefined} stage the environment code is executing in
  * @returns {string}
  */
-export const decideAssetOrigin = (
-	stage: string | undefined,
-	isDev: boolean,
-): string => {
+export const decideAssetOrigin = (stage: string | undefined): string => {
 	switch (stage?.toUpperCase()) {
 		case 'PROD':
 			return 'https://assets.guim.co.uk/';
 		case 'CODE':
 			return 'https://assets-code.guim.co.uk/';
-		default: {
-			if (isDev && isUndefined(process.env.HOSTNAME)) {
-				// Use absolute asset paths in development mode
-				// This is so paths are correct when treated as relative to Frontend
-				return 'http://localhost:3030/';
-			} else {
-				return '/';
-			}
-		}
+		default:
+			return '/';
 	}
 };
 
 const isDev = process.env.NODE_ENV === 'development';
 
-export const ASSET_ORIGIN = decideAssetOrigin(process.env.GU_STAGE, isDev);
+export const ASSET_ORIGIN = decideAssetOrigin(process.env.GU_STAGE);
 
 const isAssetHash = (manifest: unknown): manifest is AssetHash =>
 	isObject(manifest) &&


### PR DESCRIPTION
## What does this change?
Simplifies how DCR chooses the path for public assets.
This PR changes two functions:
- `decideAssetOrigin`
- `decidePublicPath`

The assumption here is that we always want to use `/assets` when running locally.

## Why?
I recently had issues while testing against a local instance of DCR through Browserstack Local. These changes should simplify how we test DCR locally.


## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
