### PR TITLE
"More on this story" darkmode updates

### DIFF
--- a/dotcom-rendering/src/components/Carousel.stories.tsx
+++ b/dotcom-rendering/src/components/Carousel.stories.tsx
@@ -10,6 +10,7 @@ import fetchMock from 'fetch-mock';
 import { splitTheme } from '../../.storybook/decorators/splitThemeDecorator';
 import type { StoryProps } from '../../.storybook/decorators/splitThemeDecorator';
 import { discussionApiUrl } from '../../fixtures/manual/discussionApiUrl';
+import { palette } from '../palette';
 import type { TrailType } from '../types/trails';
 import { Carousel } from './Carousel.importable';
 import { Section } from './Section';
@@ -233,7 +234,10 @@ const sportFormat = {
 export const Headlines: StoryObj = ({ format }: StoryProps) => {
 	mockCommentCount();
 	return (
-		<Section fullWidth={true}>
+		<Section
+			fullWidth={true}
+			backgroundColour={palette('--article-background')}
+		>
 			<Carousel
 				heading="More on this story"
 				trails={trails}
@@ -254,7 +258,10 @@ Headlines.decorators = [
 export const SingleItemCarousel = () => {
 	mockCommentCount();
 	return (
-		<Section fullWidth={true}>
+		<Section
+			fullWidth={true}
+			backgroundColour={palette('--article-background')}
+		>
 			<Carousel
 				heading="More on this story"
 				trails={trails.slice(1, 2)}
@@ -297,7 +304,10 @@ export const SingleOpinionCarousel = () => {
 	};
 
 	return (
-		<Section fullWidth={true}>
+		<Section
+			fullWidth={true}
+			backgroundColour={palette('--article-background')}
+		>
 			<Carousel
 				heading="More on this story"
 				trails={[comment]}
@@ -323,7 +333,10 @@ export const Immersive = () => {
 	mockCommentCount();
 	return (
 		<>
-			<Section fullWidth={true}>
+			<Section
+				fullWidth={true}
+				backgroundColour={palette('--article-background')}
+			>
 				<Carousel
 					heading="Sport"
 					trails={immersiveTrails}
@@ -367,7 +380,10 @@ export const SpecialReportAlt = () => {
 		trail.format = specialReportAltFormat;
 
 	return (
-		<Section fullWidth={true}>
+		<Section
+			fullWidth={true}
+			backgroundColour={palette('--article-background')}
+		>
 			<Carousel
 				heading="SpecialReportAlt"
 				trails={specialReportTrails}
@@ -550,7 +566,10 @@ export const AllCards = () => {
 	];
 
 	return (
-		<Section fullWidth={true}>
+		<Section
+			fullWidth={true}
+			backgroundColour={palette('--article-background')}
+		>
 			<Carousel
 				heading="All the card types"
 				trails={allCardTypesTrail}
@@ -563,6 +582,9 @@ export const AllCards = () => {
 	);
 };
 AllCards.storyName = 'Carousel with all card types';
+AllCards.decorators = [
+	splitTheme([defaultFormat], { orientation: 'vertical' }),
+];
 
 export const FrontCarousel = () => (
 	<>

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -2330,7 +2330,7 @@ const onwardContentCardBackgroundDark: PaletteFunction = ({
 							return pillarPalette(theme, 200);
 					}
 				default:
-					return sourcePalette.neutral[0];
+					return sourcePalette.neutral[10];
 			}
 	}
 };

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -3884,7 +3884,7 @@ const carouselArrowDark: PaletteFunction = () => sourcePalette.neutral[0];
 const carouselArrowBackgroundLight: PaletteFunction = () =>
 	sourcePalette.neutral[0];
 const carouselArrowBackgroundDark: PaletteFunction = () =>
-	sourcePalette.neutral[100];
+	sourcePalette.neutral[86];
 
 const carouselArrowBackgroundHoverLight: PaletteFunction = () =>
 	sourcePalette.brandAlt[400];


### PR DESCRIPTION
## What does this change?

- Change background of actionable buttons from neutral.100 to neutral.86
- Change background of cards to neutral.10, i.e. the overall page background colour

## Screenshots

| Before | After |
|--------|--------|
| <img width="1366" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/705427/7d8b887e-e27f-4511-ad70-c60d80ebf1ce"> | <img width="1359" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/705427/97fd0ba7-cec5-4f6b-a4d7-a90183f4685d"> |

Closes https://github.com/guardian/dotcom-rendering/issues/10187