### PR TITLE
Port the `devServer` to the new Webpack config 

### DIFF
--- a/dotcom-rendering/configs/webpack/.test.mjs
+++ b/dotcom-rendering/configs/webpack/.test.mjs
@@ -4,6 +4,8 @@ import newWeb from './client.web.mjs';
 import newWebLegacy from './client.web.legacy.mjs';
 import newApps from './client.apps.mjs';
 import newServer from './server.mjs';
+import newDevServer from './server.dev.mjs';
+import { isProd } from './utils/env.mjs';
 
 const [server, web, webLegacy, apps] = current;
 
@@ -47,4 +49,4 @@ const compareConfigs = (current, proposed) => {
 compareConfigs(web, newWeb);
 compareConfigs(webLegacy, newWebLegacy);
 compareConfigs(apps, newApps);
-compareConfigs(server, newServer);
+compareConfigs(server, isProd ? newServer : newDevServer);

--- a/dotcom-rendering/webpack.config.mjs
+++ b/dotcom-rendering/webpack.config.mjs
@@ -21,8 +21,8 @@ const dirname = fileURLToPath(new URL('.', import.meta.url));
 
 const configsDirectory = resolve(dirname, 'configs', 'webpack');
 
-const bundleConfigs = await readdir(configsDirectory).then((files) =>
-	files.filter((file) => file.startsWith('bundle')),
+const clientConfigs = await readdir(configsDirectory).then((files) =>
+	files.filter((file) => file.startsWith('client.')),
 );
 
 // Create a bundles manifest for the TypesScript compiler so we get type safely
@@ -37,13 +37,13 @@ await writeFile(
 
 /** generated from webpack.config.js */
 export const bundles = /** @type {const} @satisfies {readonly string[]} */ ([
-\t${bundleConfigs.map((name) => `"${basename(name, '.mjs')}"`).join(',\n\t')},
+\t${clientConfigs.map((name) => `"${basename(name, '.mjs')}"`).join(',\n\t')},
 ]);
 `,
 	'utf-8',
 );
 
-export default bundleConfigs.map((name) =>
+export default clientConfigs.map((name) =>
 	// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return -- can't know what we are importing
 	import(`${configsDirectory}/${name}`).then((config) => config.default),
 );

--- a/dotcom-rendering/webpack.config.mjs
+++ b/dotcom-rendering/webpack.config.mjs
@@ -16,6 +16,9 @@
 import { mkdir, readdir, writeFile } from 'node:fs/promises';
 import { basename, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import devServer from './configs/webpack/server.dev.mjs';
+import prodServer from './configs/webpack/server.mjs';
+import { isDev } from './configs/webpack/utils/env.mjs';
 
 const dirname = fileURLToPath(new URL('.', import.meta.url));
 
@@ -43,7 +46,9 @@ export const bundles = /** @type {const} @satisfies {readonly string[]} */ ([
 	'utf-8',
 );
 
-export default clientConfigs.map((name) =>
-	// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return -- can't know what we are importing
-	import(`${configsDirectory}/${name}`).then((config) => config.default),
+export default [isDev ? devServer : prodServer].concat(
+	clientConfigs.map((name) =>
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return -- can't know what we are importing
+		import(`${configsDirectory}/${name}`).then((config) => config.default),
+	),
 );


### PR DESCRIPTION
## What does this change?

Make `dotcom-rendering/configs/webpack/server.dev.mjs` work as a fully-working development server

## Why?

Follow-up on:
- #8777 
- #10033 

## Screenshots

`NODE_ENV=development pnpm webpack serve`

<img width="336" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/76776/5da8cd46-5590-4191-a3f6-3f76cf6659b0">
