### PR TITLE
refactor(AdPlaceholder): aside element

### DIFF
--- a/dotcom-rendering/src/components/AdPlaceholder.apps.tsx
+++ b/dotcom-rendering/src/components/AdPlaceholder.apps.tsx
@@ -15,14 +15,14 @@ const rightAdsStyles = css`
  * client-side. See `AdPortals.importable.tsx` for more details.
  */
 const RightAdsPlaceholder = () => (
-	<div className={rightAdsPlaceholderClass} css={rightAdsStyles}></div>
+	<aside className={rightAdsPlaceholderClass} css={rightAdsStyles} />
 );
 
 /**
  * A server-side ad placeholder for apps, into which ads are inserted
  * client-side. See `AdPortals.importable.tsx` for more details.
  */
-const AdPlaceholder = () => <div className={adPlaceholderClass} />;
+const AdPlaceholder = () => <aside className={adPlaceholderClass} />;
 
 export {
 	AdPlaceholder,


### PR DESCRIPTION
## What does this change?

Move from using `div` to `aside` for ad placeholders.

## Why?

The [`aside` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/aside) better represents what contains an Ad.

## Screenshots

N/A – Identical