### PR TITLE
Remove decidepalette in design tag

### DIFF
--- a/dotcom-rendering/src/components/DesignTag.tsx
+++ b/dotcom-rendering/src/components/DesignTag.tsx
@@ -2,19 +2,18 @@ import { css } from '@emotion/react';
 import { ArticleDesign } from '@guardian/libs';
 import { headline, space, until } from '@guardian/source-foundations';
 import { LinkButton } from '@guardian/source-react-components';
-import { decidePalette } from '../lib/decidePalette';
-import type { Palette } from '../types/palette';
+import { palette } from '../palette';
 
-const tagStyles = (palette: Palette) => css`
-	background-color: ${palette.background.designTag};
-	color: ${palette.text.designTag};
+const tagStyles = css`
+	background-color: ${palette('--design-tag-background')};
+	color: ${palette('--design-tag-text')};
 	display: inline-block;
 	padding: 2px 0 4px 0;
 	${headline.xxsmall({ fontWeight: 'bold' })}
 	line-height: 115%;
 	box-shadow:
-		6px 0 0 ${palette.background.headlineTag},
-		-6px 0 0 ${palette.background.headlineTag};
+		6px 0 0 ${palette('--design-tag-background')},
+		-6px 0 0 ${palette('--design-tag-background')};
 	box-decoration-break: clone;
 	${until.tablet} {
 		${headline.xxxsmall({ fontWeight: 'bold' })}
@@ -58,16 +57,9 @@ const Margins = ({
 	}
 };
 
-const Tag = ({
-	children,
-	format,
-}: {
-	children: React.ReactNode;
-	format: ArticleFormat;
-}) => {
-	const palette = decidePalette(format);
-	return <div css={tagStyles(palette)}>{children}</div>;
-};
+const Tag = ({ children }: { children: React.ReactNode }) => (
+	<div css={tagStyles}>{children}</div>
+);
 
 const TagLink = ({
 	children,
@@ -108,7 +100,7 @@ export const DesignTag = ({ format }: { format: ArticleFormat }) => {
 		case ArticleDesign.Analysis:
 			return (
 				<Margins format={format}>
-					<Tag format={format}>
+					<Tag>
 						<TagLink href="/tone/analysis">Analysis</TagLink>
 					</Tag>
 				</Margins>
@@ -116,7 +108,7 @@ export const DesignTag = ({ format }: { format: ArticleFormat }) => {
 		case ArticleDesign.Explainer:
 			return (
 				<Margins format={format}>
-					<Tag format={format}>
+					<Tag>
 						<TagLink href="/tone/explainers">Explainer</TagLink>
 					</Tag>
 				</Margins>
@@ -124,7 +116,7 @@ export const DesignTag = ({ format }: { format: ArticleFormat }) => {
 		case ArticleDesign.Interview:
 			return (
 				<Margins format={format}>
-					<Tag format={format}>
+					<Tag>
 						<TagLink href="/tone/interview">Interview</TagLink>
 					</Tag>
 				</Margins>
@@ -132,7 +124,7 @@ export const DesignTag = ({ format }: { format: ArticleFormat }) => {
 		case ArticleDesign.Letter:
 			return (
 				<Margins format={format}>
-					<Tag format={format}>
+					<Tag>
 						<TagLink href="/tone/letters">Letters</TagLink>
 					</Tag>
 				</Margins>
@@ -140,7 +132,7 @@ export const DesignTag = ({ format }: { format: ArticleFormat }) => {
 		case ArticleDesign.Obituary:
 			return (
 				<Margins format={format}>
-					<Tag format={format}>
+					<Tag>
 						<TagLink href="/tone/obituaries">Obituary</TagLink>
 					</Tag>
 				</Margins>
@@ -148,7 +140,7 @@ export const DesignTag = ({ format }: { format: ArticleFormat }) => {
 		case ArticleDesign.Review:
 			return (
 				<Margins format={format}>
-					<Tag format={format}>
+					<Tag>
 						<TagLink href="/tone/reviews">Review</TagLink>
 					</Tag>
 				</Margins>
@@ -156,7 +148,7 @@ export const DesignTag = ({ format }: { format: ArticleFormat }) => {
 		case ArticleDesign.Timeline:
 			return (
 				<Margins format={format}>
-					<Tag format={format}>
+					<Tag>
 						<TagLink href="/tone/timelines">Timeline</TagLink>
 					</Tag>
 				</Margins>
@@ -164,7 +156,7 @@ export const DesignTag = ({ format }: { format: ArticleFormat }) => {
 		case ArticleDesign.Profile:
 			return (
 				<Margins format={format}>
-					<Tag format={format}>
+					<Tag>
 						<TagLink href="/tone/profiles">Profile</TagLink>
 					</Tag>
 				</Margins>

--- a/dotcom-rendering/src/lib/decidePalette.ts
+++ b/dotcom-rendering/src/lib/decidePalette.ts
@@ -403,13 +403,6 @@ const backgroundMessageForm = (format: ArticleFormat): string => {
 
 const textBetaLabel = (): string => neutral[46];
 
-const textDesignTag = (format: ArticleFormat): string => {
-	if (format.theme === ArticleSpecial.SpecialReportAlt)
-		return palette.specialReportAlt[800];
-
-	return neutral[100];
-};
-
 const textDateLine = (format: ArticleFormat): string => {
 	if (
 		format.theme === ArticleSpecial.SpecialReportAlt &&
@@ -429,9 +422,6 @@ const textFilterButtonActive = (): string => neutral[100];
 
 const backgroundFilterButton = (): string => neutral[100];
 
-const backgroundHeadlineTag = (format: ArticleFormat): string =>
-	pillarPalette[format.theme].dark;
-
 const backgroundTreat = (format: ArticleFormat): string => {
 	switch (format.theme) {
 		case Pillar.News:
@@ -450,27 +440,6 @@ const backgroundTreat = (format: ArticleFormat): string => {
 			return specialReport[300];
 		case ArticleSpecial.SpecialReportAlt:
 			return news[300];
-	}
-};
-
-const backgroundDesignTag = (format: ArticleFormat): string => {
-	switch (format.theme) {
-		case Pillar.News:
-			return news[300];
-		case Pillar.Sport:
-			return sport[300];
-		case Pillar.Lifestyle:
-			return lifestyle[300];
-		case Pillar.Culture:
-			return culture[300];
-		case Pillar.Opinion:
-			return opinion[300];
-		case ArticleSpecial.Labs:
-			return labs[300];
-		case ArticleSpecial.SpecialReport:
-			return specialReport[300];
-		case ArticleSpecial.SpecialReportAlt:
-			return palette.specialReportAlt[100];
 	}
 };
 
@@ -557,7 +526,6 @@ export const decidePalette = (
 			filterButtonHover: textFilterButtonHover(),
 			filterButtonActive: textFilterButtonActive(),
 			betaLabel: textBetaLabel(),
-			designTag: textDesignTag(format),
 			dateLine: textDateLine(format),
 			expandableAtom: textExpandableAtom(format),
 			expandableAtomHover: textExpandableAtomHover(format),
@@ -571,12 +539,10 @@ export const decidePalette = (
 			imageTitle: backgroundImageTitle(format),
 			lightboxDivider: backgroundLightboxDivider(format),
 			speechBubble: backgroundSpeechBubble(format),
-			headlineTag: backgroundHeadlineTag(format),
 			filterButton: backgroundFilterButton(),
 			filterButtonHover: backgroundFilterButtonHover(format),
 			filterButtonActive: backgroundFilterButtonActive(format),
 			treat: backgroundTreat(format),
-			designTag: backgroundDesignTag(format),
 			messageForm: backgroundMessageForm(format),
 			dynamoSublink:
 				overrides?.background.dynamoSublink ??

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -4814,6 +4814,31 @@ const lastUpdatedText: PaletteFunction = ({ theme, design }) => {
 	}
 };
 
+const designTagText: PaletteFunction = ({ theme }) => {
+	switch (theme) {
+		case ArticleSpecial.SpecialReportAlt:
+			return sourcePalette.specialReportAlt[800];
+		default:
+			return sourcePalette.neutral[100];
+	}
+};
+
+const designTagBackground: PaletteFunction = ({ theme }) => {
+	switch (theme) {
+		case Pillar.News:
+		case Pillar.Sport:
+		case Pillar.Lifestyle:
+		case Pillar.Culture:
+		case Pillar.Opinion:
+			return pillarPalette(theme, 300);
+		case ArticleSpecial.Labs:
+			return sourcePalette.labs[300];
+		case ArticleSpecial.SpecialReport:
+			return sourcePalette.specialReport[300];
+		case ArticleSpecial.SpecialReportAlt:
+			return sourcePalette.specialReportAlt[100];
+	}
+};
 // ----- Palette ----- //
 
 /**
@@ -5688,6 +5713,14 @@ const paletteColours = {
 	'--last-updated-text': {
 		light: lastUpdatedText,
 		dark: lastUpdatedText,
+	},
+	'--design-tag-text': {
+		light: designTagText,
+		dark: designTagText,
+	},
+	'--design-tag-background': {
+		light: designTagBackground,
+		dark: designTagBackground,
 	},
 } satisfies PaletteColours;
 

--- a/dotcom-rendering/src/types/palette.ts
+++ b/dotcom-rendering/src/types/palette.ts
@@ -11,7 +11,6 @@ export type Palette = {
 		filterButtonHover: Colour;
 		filterButtonActive: Colour;
 		betaLabel: Colour;
-		designTag: Colour;
 		dateLine: Colour;
 		expandableAtom: Colour;
 		expandableAtomHover: Colour;
@@ -24,12 +23,10 @@ export type Palette = {
 		bulletStandfirst: Colour;
 		imageTitle: Colour;
 		speechBubble: Colour;
-		headlineTag: Colour;
 		filterButton: Colour;
 		filterButtonHover: Colour;
 		filterButtonActive: Colour;
 		treat: Colour;
-		designTag: Colour;
 		lightboxDivider: Colour;
 		messageForm: Colour;
 		dynamoSublink: Colour;


### PR DESCRIPTION
## What does this change?
Removes decidepalette decisions from design tag
## Why?
We no longer want to use decidePalette so we remove them when we spot them and migrate palettes to the theme palette

## Screenshots
Nothing should have changed so there are not any screenshots.
<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
