### PR TITLE
Vb/newsletter embed autofill email

### DIFF
--- a/dotcom-rendering/src/components/SecureSignup.importable.tsx
+++ b/dotcom-rendering/src/components/SecureSignup.importable.tsx
@@ -54,12 +54,7 @@ const flexParentStyles = css`
 const inputContainerStyles = css`
 	margin-right: ${space[3]}px;
 	margin-bottom: ${space[2]}px;
-	flex-basis: 335px;
 	flex-shrink: 1;
-`;
-
-const removeFlexBasis = css`
-	flex-basis: 0;
 `;
 
 const textInputStyles = css`
@@ -79,10 +74,6 @@ const buttonCssOverrides = css`
 	flex-basis: 118px;
 	flex-shrink: 0;
 	margin-bottom: ${space[2]}px;
-`;
-
-const hideElement = css`
-	display: none;
 `;
 
 const ErrorMessageWithAdvice = ({ text }: { text?: string }) => (
@@ -255,7 +246,6 @@ export const SecureSignup = ({ newsletterId, successDescription }: Props) => {
 	useEffect(() => {
 		setCaptchaSiteKey(window.guardian.config.page.googleRecaptchaSiteKey);
 		void resolveEmailIfSignedIn().then((email) => {
-			console.log('resolved email:', email);
 			setSignedInUserEmail(email);
 		});
 	}, []);
@@ -329,7 +319,6 @@ export const SecureSignup = ({ newsletterId, successDescription }: Props) => {
 		sendTracking(newsletterId, 'open-captcha', renderingTarget);
 		recaptchaRef.current?.execute();
 	};
-
 	return (
 		<>
 			<form
@@ -345,26 +334,30 @@ export const SecureSignup = ({ newsletterId, successDescription }: Props) => {
 					text="Enter your email address"
 					cssOverrides={css`
 						${labelStyles};
-						${!!signedInUserEmail && hideElement};
+						display: ${!signedInUserEmail
+							? 'inline-block'
+							: 'none'};
 					`}
 				/>
 
 				<div css={flexParentStyles}>
 					<div
-						css={[
-							inputContainerStyles,
-							signedInUserEmail && removeFlexBasis,
-						]}
+						css={css`
+							${inputContainerStyles};
+							flex-basis: ${!signedInUserEmail ? '335px' : '0'};
+						`}
 					>
 						<TextInput
 							hideLabel={true}
 							name="email"
 							label="Enter your email address"
 							type="email"
-							value={signedInUserEmail ?? 'testvalue'}
+							value={signedInUserEmail}
 							cssOverrides={css`
 								${textInputStyles};
-								${!!signedInUserEmail && hideElement};
+								display: ${!signedInUserEmail
+									? 'inline-block'
+									: 'none'};
 							`}
 						/>
 					</div>
@@ -374,7 +367,7 @@ export const SecureSignup = ({ newsletterId, successDescription }: Props) => {
 						type="submit"
 						cssOverrides={buttonCssOverrides}
 					>
-						Sign upp
+						Sign up
 					</Button>
 				</div>
 			</form>

--- a/dotcom-rendering/src/lib/contributions.ts
+++ b/dotcom-rendering/src/lib/contributions.ts
@@ -268,8 +268,7 @@ export const lazyFetchEmailWithTimeout =
 	() => {
 		return new Promise((resolve) => {
 			setTimeout(() => resolve(null), 1000);
-			// eslint-disable-next-line @typescript-eslint/no-floating-promises
-			getEmail(idapiUrl).then((email) => {
+			void getEmail(idapiUrl).then((email) => {
 				if (email) {
 					resolve(email);
 				} else {

--- a/dotcom-rendering/src/model/guardian.ts
+++ b/dotcom-rendering/src/model/guardian.ts
@@ -35,6 +35,7 @@ export interface Guardian {
 			isDev?: boolean;
 			hasInlineMerchandise?: boolean;
 			userAttributesApiUrl?: string;
+			idApiUrl?: string;
 		};
 		libs: {
 			googletag: string;


### PR DESCRIPTION
## What does this change?

This implements the logic for auto-populating the newsletters sign-up form with a users email address if we already have that information into the newly refactored component. 

## Why?

There was work being done to refactor using an iframe for the sign up component https://github.com/guardian/dotcom-rendering/pull/10034 whilst this feature was being worked on. This adds the new functionality to the refactored branch. 

## Screenshots
![daily](https://github.com/guardian/dotcom-rendering/assets/1202622/17271d3d-e4c4-44e5-8707-5898e3ef0e9b)

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
