### PR TITLE
Fix bug issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,6 +1,6 @@
 name: 🐞 Bug Report
 description: Let us know about something unexpected that has happened
-title: ''
+title: '[Bug]: '
 labels: ['bug']
 projects: ['guardian/88']
 body:

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,7 +1,7 @@
 name: 🐞 Bug Report
 description: Let us know about something unexpected that has happened
 title: '[Bug]: '
-labels: ['bug']
+labels: ['bug', 'Rota']
 projects: ['guardian/88']
 body:
   - type: markdown


### PR DESCRIPTION
## What does this change?

Add a title to the bug template

## Why?

Github does not allow empty strings as titles. 
