### PR TITLE
Update "Most Viewed" dark mode border colour

### DIFF
--- a/dotcom-rendering/src/components/MostViewedFooterData.importable.tsx
+++ b/dotcom-rendering/src/components/MostViewedFooterData.importable.tsx
@@ -1,10 +1,10 @@
 import { joinUrl, log } from '@guardian/libs';
 import { abTestTest } from '../experiments/tests/ab-test-test';
-import { decidePalette } from '../lib/decidePalette';
 import { decideTrail } from '../lib/decideTrail';
 import type { EditionId } from '../lib/edition';
 import { useAB } from '../lib/useAB';
 import { useApi } from '../lib/useApi';
+import { palette } from '../palette';
 import type { FETrailTabType, TrailTabType } from '../types/trails';
 import { MostViewedFooter } from './MostViewedFooter.importable';
 import { Placeholder } from './Placeholder';
@@ -56,7 +56,6 @@ export const MostViewedFooterData = ({
 	ajaxUrl,
 	edition,
 }: Props) => {
-	const palette = decidePalette(format);
 	// Example usage of AB Tests
 	// Used in the Cypress tests as smoke test of the AB tests framework integration
 	const ABTestAPI = useAB()?.api;
@@ -88,7 +87,7 @@ export const MostViewedFooterData = ({
 				abTestCypressDataAttr={abTestCypressDataAttr}
 				variantFromRunnable={variantFromRunnable}
 				sectionId={sectionId}
-				selectedColour={palette.background.mostViewedTab}
+				selectedColour={palette('--most-viewed-tab-border')}
 			/>
 		);
 	}

--- a/dotcom-rendering/src/components/MostViewedFooterLayout.stories.tsx
+++ b/dotcom-rendering/src/components/MostViewedFooterLayout.stories.tsx
@@ -2,6 +2,7 @@ import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
 import type { StoryObj } from '@storybook/react';
 import { splitTheme } from '../../.storybook/decorators/splitThemeDecorator';
 import { trails } from '../../fixtures/manual/trails';
+import { palette } from '../palette';
 import { MostViewedFooter } from './MostViewedFooter.importable';
 import { MostViewedFooterLayout } from './MostViewedFooterLayout';
 import { Section } from './Section';
@@ -30,6 +31,7 @@ export const withTwoTabsAdFree: StoryObj = () => {
 						{ heading: 'Tab 1', trails: trails.slice(0, 10) },
 						{ heading: 'Tab 2', trails: trails.slice(5, 15) },
 					]}
+					selectedColour={palette('--most-viewed-tab-border')}
 				/>
 			</MostViewedFooterLayout>
 		</Section>
@@ -48,6 +50,7 @@ export const withOneTabsAdFree: StoryObj = () => {
 							trails: trails.slice(0, 10),
 						},
 					]}
+					selectedColour={palette('--most-viewed-tab-border')}
 				/>
 			</MostViewedFooterLayout>
 		</Section>
@@ -64,6 +67,7 @@ export const withTwoTabs: StoryObj = () => {
 						{ heading: 'Tab 1', trails: trails.slice(0, 10) },
 						{ heading: 'Tab 2', trails: trails.slice(5, 15) },
 					]}
+					selectedColour={palette('--most-viewed-tab-border')}
 				/>
 			</MostViewedFooterLayout>
 		</Section>
@@ -82,6 +86,7 @@ export const withOneTabs: StoryObj = () => {
 							trails: trails.slice(0, 10),
 						},
 					]}
+					selectedColour={palette('--most-viewed-tab-border')}
 				/>
 			</MostViewedFooterLayout>
 		</Section>

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -3963,6 +3963,40 @@ const mostViewedFooterHoverLight: PaletteFunction = () =>
 const mostViewedFooterHoverDark: PaletteFunction = () =>
 	sourcePalette.neutral[20];
 
+const mostViewedTabBorderDark: PaletteFunction = ({ theme }) => {
+	switch (theme) {
+		case Pillar.News:
+		case Pillar.Lifestyle:
+		case Pillar.Sport:
+		case Pillar.Culture:
+		case Pillar.Opinion:
+			return pillarPalette(theme, 500);
+		case ArticleSpecial.Labs:
+			return sourcePalette.labs[400];
+		case ArticleSpecial.SpecialReport:
+			return sourcePalette.specialReport[500];
+		case ArticleSpecial.SpecialReportAlt:
+			return sourcePalette.specialReportAlt[300];
+	}
+};
+
+const mostViewedTabBorderLight: PaletteFunction = ({ theme }) => {
+	switch (theme) {
+		case Pillar.News:
+		case Pillar.Lifestyle:
+		case Pillar.Sport:
+		case Pillar.Culture:
+		case Pillar.Opinion:
+			return pillarPalette(theme, 300);
+		case ArticleSpecial.Labs:
+			return sourcePalette.labs[300];
+		case ArticleSpecial.SpecialReport:
+			return sourcePalette.specialReport[300];
+		case ArticleSpecial.SpecialReportAlt:
+			return sourcePalette.specialReportAlt[300];
+	}
+};
+
 const richLinkTextLight: PaletteFunction = ({ design, theme }) => {
 	if (design === ArticleDesign.Analysis) return sourcePalette.news[300];
 	switch (theme) {
@@ -5290,6 +5324,10 @@ const paletteColours = {
 	'--most-viewed-headline': {
 		light: mostViewedHeadlineLight,
 		dark: mostViewedHeadlineDark,
+	},
+	'--most-viewed-tab-border': {
+		light: mostViewedTabBorderLight,
+		dark: mostViewedTabBorderDark,
 	},
 	'--link-kicker-text': {
 		light: linkKickerTextLight,


### PR DESCRIPTION
## What does this change?

- Updates most viewed dark mode border colour to `500` where `500` is available.

## Screenshots

| Pillar | Before | After |
|--------|--------|--------|
| News | <img width="483" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/705427/58f7d019-48b1-411c-9821-d0c55ef57b30"> | <img width="495" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/705427/a6629b99-16c0-4a22-a6d9-321ce4bab4c6"> |
| Labs | <img width="486" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/705427/cf522a3c-e36e-4594-9a17-1efc28590c7f"> | <img width="505" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/705427/9036d00b-ed5a-4156-9899-cda87ac804ad"> |
| Special Report | <img width="490" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/705427/dfabcfa2-89f7-4c4f-a31a-a55f79d4feba"> | <img width="495" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/705427/368d5eaf-d62f-4c1c-b822-a24f035b4da8"> | 
| Special Report Alt | <img width="485" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/705427/1f01d8ac-5500-4fe0-bcb9-9357d1dc8aa9"> | <img width="489" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/705427/77257e0b-ae81-45a8-a25d-ce83642d9bbe"> | 