### PR TITLE
Catch Bridget errors

### DIFF
--- a/dotcom-rendering/src/components/AdPortals.importable.tsx
+++ b/dotcom-rendering/src/components/AdPortals.importable.tsx
@@ -70,7 +70,9 @@ const adsHaveMoved = (
 	});
 
 const updateAds = (positions: BridgetAdSlot[]) =>
-	getCommercialClient().updateAdverts(positions);
+	getCommercialClient()
+		.updateAdverts(positions)
+		.catch(() => console.error('Error updating adverts'));
 
 const debounceUpdateAds = libDebounce(updateAds, 100, { leading: true });
 
@@ -151,7 +153,8 @@ export const AdPortals = ({
 						)[0],
 					);
 				}
-			});
+			})
+			.catch(() => console.error('Error setting up ads'));
 	}, []);
 
 	/**
@@ -183,7 +186,9 @@ export const AdPortals = ({
 		) {
 			adPositions.current = calculateAdPositions(adSlots.current);
 			bodyHeight.current = document.body.clientHeight;
-			void getCommercialClient().insertAdverts(adPositions.current);
+			void getCommercialClient()
+				.insertAdverts(adPositions.current)
+				.catch(() => console.error('Error inserting ads'));
 
 			resizeObserver = new ResizeObserver((entries) => {
 				if (
@@ -209,9 +214,9 @@ export const AdPortals = ({
 	}, [adPlaceholders]);
 
 	const handleClickSupportButton = () => {
-		void getAcquisitionsClient().launchPurchaseScreen(
-			PurchaseScreenReason.hideAds,
-		);
+		void getAcquisitionsClient()
+			.launchPurchaseScreen(PurchaseScreenReason.hideAds)
+			.catch(() => console.error('Error launching purchase screen'));
 	};
 
 	const renderAdSlot = (id: string, index: number) => (

--- a/dotcom-rendering/src/lib/useReportNativeElementPositionChanges.ts
+++ b/dotcom-rendering/src/lib/useReportNativeElementPositionChanges.ts
@@ -2,8 +2,7 @@ import type { AdSlot } from '@guardian/bridget/AdSlot';
 import type { IRect } from '@guardian/bridget/Rect';
 import type { VideoSlot } from '@guardian/bridget/VideoSlot';
 import { useEffect, useRef } from 'react';
-import { getVideoClient } from './bridgetApi';
-import { getCommercialClient } from './bridgetApi';
+import { getCommercialClient, getVideoClient } from './bridgetApi';
 
 type Slot = AdSlot | VideoSlot;
 
@@ -40,20 +39,16 @@ export const useReportNativeElementPositionChanges = (
 
 	useEffect(() => {
 		const positionChangedCallback = function (): void {
-			try {
-				if (positionChanged(adSlots, previous?.adSlots)) {
-					void getCommercialClient().updateAdverts(adSlots);
-				}
-			} catch (error) {
-				console.log('Exception updating ads');
+			if (positionChanged(adSlots, previous?.adSlots)) {
+				void getCommercialClient()
+					.updateAdverts(adSlots)
+					.catch(() => console.error('Exception updating ads'));
 			}
 
-			try {
-				if (positionChanged(videoSlots, previous?.videoSlots)) {
-					void getVideoClient().updateVideos(videoSlots);
-				}
-			} catch (error) {
-				console.log('Exception updating videos');
+			if (positionChanged(videoSlots, previous?.videoSlots)) {
+				void getVideoClient()
+					.updateVideos(videoSlots)
+					.catch(() => console.error('Exception updating videos'));
 			}
 		};
 


### PR DESCRIPTION
Otherwise they can cause an overlay on the dev server screen which can be annoying.

Closes https://github.com/guardian/dotcom-rendering/issues/10208

## Screenshots

Taken after a 60s delay after opening the page

| Before | After |
|--------|--------|
| ![image](https://github.com/guardian/dotcom-rendering/assets/705427/6aa0c48b-d1f9-43e3-a6d1-a71219df1cb4) | <img width="1434" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/705427/388ce3d6-7f79-43de-bd07-4a9dbc6c8688"> | 