### PR TITLE
Remove `paths-ignore` exclusion on CICD workflow for docs directory

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -4,7 +4,6 @@ on:
   push:
     paths-ignore:
       - 'apps-rendering/**'
-      - 'dotcom-rendering/docs/**'
 
 jobs:
   container:


### PR DESCRIPTION
## What does this change?

Removes the `docs` directory from `paths-ignore` in the CICD workflow

## Why?

I am unable to merge [a PR that only updates documentation](https://github.com/guardian/dotcom-rendering/pull/10201) since the `publish` job is a required check for merging PRs and is not currently run on PRs that only change files in the `docs` directory
