### PR TITLE
chore: remove unused and deprecated babel plugin

### DIFF
--- a/dotcom-rendering/babel.config.js
+++ b/dotcom-rendering/babel.config.js
@@ -4,7 +4,6 @@ module.exports = {
 		// They can dramatically alter the build size
 		'@babel/plugin-syntax-dynamic-import',
 		'@babel/plugin-transform-react-jsx',
-		'@babel/plugin-proposal-class-properties',
 		'@babel/plugin-proposal-optional-chaining',
 		'@babel/plugin-proposal-nullish-coalescing-operator',
 		'babel-plugin-px-to-rem',

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -26,7 +26,6 @@
 		"@babel/core": "7.23.2",
 		"@babel/helper-compilation-targets": "7.20.0",
 		"@babel/helper-create-regexp-features-plugin": "7.20.5",
-		"@babel/plugin-proposal-class-properties": "7.18.6",
 		"@babel/plugin-proposal-nullish-coalescing-operator": "7.18.6",
 		"@babel/plugin-proposal-object-rest-spread": "7.20.7",
 		"@babel/plugin-proposal-optional-chaining": "7.20.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -290,9 +290,6 @@ importers:
       '@babel/helper-create-regexp-features-plugin':
         specifier: 7.20.5
         version: 7.20.5(@babel/core@7.23.2)
-      '@babel/plugin-proposal-class-properties':
-        specifier: 7.18.6
-        version: 7.18.6(@babel/core@7.23.2)
       '@babel/plugin-proposal-nullish-coalescing-operator':
         specifier: 7.18.6
         version: 7.18.6(@babel/core@7.23.2)
@@ -2551,18 +2548,6 @@ packages:
     dependencies:
       '@babel/core': 7.23.2
       '@babel/helper-environment-visitor': 7.22.20
-      '@babel/helper-plugin-utils': 7.22.5
-    dev: false
-
-  /@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.23.2):
-    resolution: {integrity: sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==}
-    engines: {node: '>=6.9.0'}
-    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-class-properties instead.
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.23.2
-      '@babel/helper-create-class-features-plugin': 7.23.6(@babel/core@7.23.2)
       '@babel/helper-plugin-utils': 7.22.5
     dev: false
 


### PR DESCRIPTION
## What does this change?

Removes deprecated babel plugin

## Why?

When running `pnpm install --resolution-only` it is marked as deprecated:

```
WARN  deprecated @babel/plugin-proposal-class-properties@7.18.6: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-class-properties instead.
```
