### PR TITLE
Fix headline byline yellow box dark mode text colour

### DIFF
--- a/dotcom-rendering/src/components/HeadlineByline.tsx
+++ b/dotcom-rendering/src/components/HeadlineByline.tsx
@@ -36,7 +36,7 @@ const yellowBoxStyles = (format: ArticleFormat) => css`
 	box-decoration-break: clone;
 
 	a {
-		color: inherit;
+		color: ${schemedPalette('--byline-yellowbox-anchor-colour')};
 		text-decoration: none;
 		:hover {
 			text-decoration: underline;

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -589,6 +589,8 @@ const bylineAnchorDark: PaletteFunction = ({ design, theme }) => {
 	}
 };
 
+const bylineYellowBoxColour: PaletteFunction = () => sourcePalette.neutral[7];
+
 const bylineHoverLight: PaletteFunction = ({ design, theme }) => {
 	switch (design) {
 		case ArticleDesign.Analysis:
@@ -4872,6 +4874,10 @@ const paletteColours = {
 	'--byline-hover': {
 		light: bylineHoverLight,
 		dark: bylineHoverDark,
+	},
+	'--byline-yellowbox-anchor-colour': {
+		light: bylineYellowBoxColour,
+		dark: bylineYellowBoxColour,
 	},
 	'--callout-prompt': {
 		light: calloutPromptLight,


### PR DESCRIPTION
## What does this change?

- Fixes the text colour in Headline bylines displayed in the yellow box.

## Screenshots

| Before | After |
|--------|--------|
| ![Screen Shot 2024-01-16 at 08 18 40](https://github.com/guardian/dotcom-rendering/assets/705427/3d17ca08-438f-4e6c-93e2-edd41251db6c) | ![Screen Shot 2024-01-16 at 08 18 14](https://github.com/guardian/dotcom-rendering/assets/705427/de605839-3e1c-4b5e-ba46-13612135cce4) | 
| ![Screen Shot 2024-01-16 at 08 19 03](https://github.com/guardian/dotcom-rendering/assets/705427/428a06ab-34ed-489b-b174-e2c721a30596) | ![Screen Shot 2024-01-16 at 08 19 24](https://github.com/guardian/dotcom-rendering/assets/705427/b30625d1-5b2c-4d9d-85ef-92e36c96c98e) |