### PR TITLE
Update old article banner logic

### DIFF
--- a/dotcom-rendering/src/lib/age-warning.test.ts
+++ b/dotcom-rendering/src/lib/age-warning.test.ts
@@ -1,0 +1,54 @@
+import { getAgeWarning } from './age-warning';
+import { TagType } from '../types/tag';
+
+describe('getAgeWarning', () => {
+	const infoTag: TagType = {
+		id: 'info/info',
+		type: 'info',
+		title: 'info',
+	};
+	const studentsTag: TagType = {
+		id: 'education/students',
+		type: 'topic',
+		title: 'info',
+	};
+
+	const today = new Date();
+	const oneMonthOld = new Date(
+		new Date().setDate(today.getDate() - 31),
+	).toDateString();
+	const twoMonthsOld = new Date(
+		new Date().setDate(today.getDate() - 65),
+	).toDateString();
+	const oneYearOld = new Date(
+		new Date().setDate(today.getDate() - 370),
+	).toDateString();
+	const twoYearsOld = new Date(
+		new Date().setDate(today.getDate() - 750),
+	).toDateString();
+
+	it('shows age warning when publication date is more than 1 month ago', () => {
+		const testTags = [studentsTag];
+		expect(getAgeWarning(testTags, oneMonthOld)).toEqual('1 month old');
+	});
+
+	it('shows age warning when publication date is more than 2 months ago', () => {
+		const testTags = [studentsTag];
+		expect(getAgeWarning(testTags, twoMonthsOld)).toEqual('2 months old');
+	});
+
+	it('shows age warning when publication date is more than 1 year ago', () => {
+		const testTags = [studentsTag];
+		expect(getAgeWarning(testTags, oneYearOld)).toEqual('1 year old');
+	});
+
+	it('shows age warning when publication date is more than 2 years ago', () => {
+		const testTags = [studentsTag];
+		expect(getAgeWarning(testTags, twoYearsOld)).toEqual('2 years old');
+	});
+
+	it('is undefined if one of the tags is excluded from age warning', () => {
+		const testTags = [studentsTag, infoTag];
+		expect(getAgeWarning(testTags, oneMonthOld)).toEqual(undefined);
+	});
+});

--- a/dotcom-rendering/src/lib/age-warning.test.ts
+++ b/dotcom-rendering/src/lib/age-warning.test.ts
@@ -1,5 +1,5 @@
+import type { TagType } from '../types/tag';
 import { getAgeWarning } from './age-warning';
-import { TagType } from '../types/tag';
 
 describe('getAgeWarning', () => {
 	const infoTag: TagType = {

--- a/dotcom-rendering/src/lib/age-warning.ts
+++ b/dotcom-rendering/src/lib/age-warning.ts
@@ -14,6 +14,7 @@ export const getAgeWarning = (
 		'the-scott-trust/the-scott-trust',
 		'type/signup',
 		'info/newsletter-sign-up',
+		'guardian-live-events/guardian-live-events',
 	];
 	const showAge = !tags.some(({ id }) => tagsWithoutAgeWarning.includes(id));
 

--- a/dotcom-rendering/src/lib/age-warning.ts
+++ b/dotcom-rendering/src/lib/age-warning.ts
@@ -4,20 +4,33 @@ export const getAgeWarning = (
 	tags: TagType[],
 	webPublicationDate: string,
 ): string | undefined => {
-	const isRecipe = tags.some((t) => t.id === 'tone/recipes');
 	const isHelp = tags.some((t) => t.id === 'tone/help');
-	const isSignup = tags.some(
-		(t) => t.id === 'signup' || t.id === 'info/newsletter-sign-up',
-	);
+	const isInfo = tags.some((t) => t.id === 'info/info');
+	const isRecipe = tags.some((t) => t.id === 'tone/recipes');
 	const isSudoku = tags.some((t) => t.id === 'lifeandstyle/series/sudoku');
 	const isCrossword = tags.some((t) => t.id === 'crossword');
 	const isKakuro = tags.some((t) => t.id === 'lifeandstyle/series/kakuro');
+	const isScottTrust = tags.some(
+		(t) => t.id === 'the-scott-trust/the-scott-trust',
+	);
+	const isSignup = tags.some(
+		(t) => t.id === 'signup' || t.id === 'info/newsletter-sign-up',
+	);
 
 	let message;
 
 	// Only show an age warning for news or opinion pieces
 	if (
-		!(isRecipe || isHelp || isSignup || isSudoku || isCrossword || isKakuro)
+		!(
+			isHelp ||
+			isInfo ||
+			isScottTrust ||
+			isSignup ||
+			isRecipe ||
+			isSudoku ||
+			isCrossword ||
+			isKakuro
+		)
 	) {
 		const warnLimitDays = 30;
 		const currentDate = new Date();

--- a/dotcom-rendering/src/lib/age-warning.ts
+++ b/dotcom-rendering/src/lib/age-warning.ts
@@ -4,15 +4,21 @@ export const getAgeWarning = (
 	tags: TagType[],
 	webPublicationDate: string,
 ): string | undefined => {
-	const isNews = tags.some((t) => t.id === 'tone/news');
-	const isOpinion = tags.some((t) => t.id === 'tone/comment');
-	const isCottonCapital = tags.some(
-		(t) => t.id === 'news/series/cotton-capital',
+	const isRecipe = tags.some((t) => t.id === 'tone/recipes');
+	const isHelp = tags.some((t) => t.id === 'tone/help');
+	const isSignup = tags.some(
+		(t) => t.id === 'signup' || t.id === 'info/newsletter-sign-up',
 	);
+	const isSudoku = tags.some((t) => t.id === 'lifeandstyle/series/sudoku');
+	const isCrossword = tags.some((t) => t.id === 'crossword');
+	const isKakuro = tags.some((t) => t.id === 'lifeandstyle/series/kakuro');
+
 	let message;
 
 	// Only show an age warning for news or opinion pieces
-	if ((isNews || isOpinion) && !isCottonCapital) {
+	if (
+		!(isRecipe || isHelp || isSignup || isSudoku || isCrossword || isKakuro)
+	) {
 		const warnLimitDays = 30;
 		const currentDate = new Date();
 		const dateThreshold = new Date();

--- a/dotcom-rendering/src/lib/age-warning.ts
+++ b/dotcom-rendering/src/lib/age-warning.ts
@@ -19,7 +19,6 @@ export const getAgeWarning = (
 
 	let message;
 
-	// Only show an age warning for news or opinion pieces
 	if (showAge) {
 		const warnLimitDays = 30;
 		const currentDate = new Date();

--- a/dotcom-rendering/src/lib/age-warning.ts
+++ b/dotcom-rendering/src/lib/age-warning.ts
@@ -9,10 +9,10 @@ export const getAgeWarning = (
 		'info/info',
 		'tone/recipes',
 		'lifeandstyle/series/sudoku',
-		'crossword',
+		'type/crossword',
 		'lifeandstyle/series/kakuro',
 		'the-scott-trust/the-scott-trust',
-		'signup',
+		'type/signup',
 		'info/newsletter-sign-up',
 	];
 	const showAge = !tags.some(({ id }) => tagsWithoutAgeWarning.includes(id));

--- a/dotcom-rendering/src/lib/age-warning.ts
+++ b/dotcom-rendering/src/lib/age-warning.ts
@@ -4,34 +4,23 @@ export const getAgeWarning = (
 	tags: TagType[],
 	webPublicationDate: string,
 ): string | undefined => {
-	const isHelp = tags.some((t) => t.id === 'tone/help');
-	const isInfo = tags.some((t) => t.id === 'info/info');
-	const isRecipe = tags.some((t) => t.id === 'tone/recipes');
-	const isSudoku = tags.some((t) => t.id === 'lifeandstyle/series/sudoku');
-	const isCrossword = tags.some((t) => t.id === 'crossword');
-	const isKakuro = tags.some((t) => t.id === 'lifeandstyle/series/kakuro');
-	const isScottTrust = tags.some(
-		(t) => t.id === 'the-scott-trust/the-scott-trust',
-	);
-	const isSignup = tags.some(
-		(t) => t.id === 'signup' || t.id === 'info/newsletter-sign-up',
-	);
+	const tagsWithoutAgeWarning = [
+		'tone/help',
+		'info/info',
+		'tone/recipes',
+		'lifeandstyle/series/sudoku',
+		'crossword',
+		'lifeandstyle/series/kakuro',
+		'the-scott-trust/the-scott-trust',
+		'signup',
+		'info/newsletter-sign-up',
+	];
+	const showAge = !tags.some(({ id }) => tagsWithoutAgeWarning.includes(id));
 
 	let message;
 
 	// Only show an age warning for news or opinion pieces
-	if (
-		!(
-			isHelp ||
-			isInfo ||
-			isScottTrust ||
-			isSignup ||
-			isRecipe ||
-			isSudoku ||
-			isCrossword ||
-			isKakuro
-		)
-	) {
+	if (showAge) {
 		const warnLimitDays = 30;
 		const currentDate = new Date();
 		const dateThreshold = new Date();


### PR DESCRIPTION
## What does this change?

Instead of only showing old article banner for tone/news and tone/comment tags, show it on all articles except a specific list of tags

* tone/recipes
* tone/help
* type/signup
* type/sudoku
* type/crossword
* lifeandstyle/series/kakuro 

## Why?

Editorial request. 
Fixes https://github.com/guardian/dotcom-rendering/issues/10223

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/1229808/af6524bb-1437-49f7-ab1b-20fc9c8d354f
[after]: https://github.com/guardian/dotcom-rendering/assets/1229808/425976b8-ba65-4a8e-9d2c-bd1ee1bc222b


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
