### PR TITLE
Increase latency threshold to 0.3 for `rendering` app

### DIFF
--- a/dotcom-rendering/cdk/lib/__snapshots__/dotcom-rendering.test.ts.snap
+++ b/dotcom-rendering/cdk/lib/__snapshots__/dotcom-rendering.test.ts.snap
@@ -764,7 +764,7 @@ exports[`The DotcomRendering stack matches the snapshot 1`] = `
             ],
           },
         ],
-        "AlarmDescription": "Scale up if latency is GreaterThanOrEqualToThreshold of 0.2 over 1 period(s) of 60 seconds",
+        "AlarmDescription": "Scale up if latency is GreaterThanOrEqualToThreshold of 0.3 over 1 period(s) of 60 seconds",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
         "Dimensions": [
           {
@@ -787,7 +787,7 @@ exports[`The DotcomRendering stack matches the snapshot 1`] = `
         ],
         "Period": 60,
         "Statistic": "Average",
-        "Threshold": 0.2,
+        "Threshold": 0.3,
       },
       "Type": "AWS::CloudWatch::Alarm",
     },

--- a/dotcom-rendering/cdk/lib/dotcom-rendering.ts
+++ b/dotcom-rendering/cdk/lib/dotcom-rendering.ts
@@ -295,7 +295,7 @@ export class DotcomRendering extends GuStack {
 
 		// Latency scaling alarm
 		const latencyScalingAlarmConfig: DCRAlarmConfig = {
-			threshold: 0.2,
+			threshold: 0.3,
 			period: 60,
 			evaluationPeriod: 1,
 			comparisonOperator: 'GreaterThanOrEqualToThreshold',


### PR DESCRIPTION
## What does this change?

Increases scaling alarm threshold for latency to 0.3 in preparation for sending article traffic to the `article-rendering` app instead

## Why?

When splitting the DCR traffic between the `rendering` and `article-rendering` apps in production, we saw the latency of the existing `rendering` app increase which triggered scaling actions. Since the types of requests served by this app take longer, increasing the number of instances does not reduce the latency and the app remains scaled up, increasing costs and preventing future deployments since it reaches its maximum capacity very quickly.

In order to go ahead with this change to split the article traffic from the rest of the DCR traffic, we need to adjust the scaling threshold to a higher value so that we avoid unnecessary scaling events.

## Screenshots

Grafana screenshot of the DevX dashboard showing how as article traffic is directed away from the `rendering` app, the latency increases (showing p90 and p99 latency)

<img width="888" alt="Screenshot 2024-01-16 at 17 37 02" src="https://github.com/guardian/dotcom-rendering/assets/43961396/98a0eec7-65f9-482b-9475-723a6c22f539">

Cloudwatch screenshot showing p90 latency on the top and average latency on the bottom. Our scaling metric is based on **average latency** so this is the one we care about in this change.

![Screenshot 2024-01-17 at 11 44 00](https://github.com/guardian/dotcom-rendering/assets/43961396/a122f80b-260c-44c4-932e-0338ed100cc2)

