### PR TITLE
Refactor page state in discussions

### DIFF
--- a/dotcom-rendering/src/components/Discussion.tsx
+++ b/dotcom-rendering/src/components/Discussion.tsx
@@ -66,7 +66,7 @@ export const Discussion = ({
 	user,
 	idApiUrl,
 }: Props) => {
-	const [page, setPage] = useState<number>(1);
+	const [commentPage, setCommentPage] = useState<number>(1);
 	const [commentPageSize, setCommentPageSize] = useState<25 | 50 | 100>();
 	const [commentOrderBy, setCommentOrderBy] = useState<
 		'newest' | 'oldest' | 'recommendations'
@@ -101,7 +101,7 @@ export const Discussion = ({
 		if (hashCommentId !== undefined) {
 			getCommentContext(discussionApiUrl, hashCommentId)
 				.then((context) => {
-					setPage(context.page);
+					setCommentPage(context.page);
 					setCommentPageSize(context.pageSize);
 					setCommentOrderBy(context.orderBy);
 					setIsExpanded(true);
@@ -178,8 +178,8 @@ export const Discussion = ({
 							setIsExpanded(true);
 						}}
 						idApiUrl={idApiUrl}
-						page={page}
-						setPage={setPage}
+						page={commentPage}
+						setPage={setCommentPage}
 					/>
 					{!isExpanded && (
 						<div id="discussion-overlay" css={overlayStyles} />

--- a/dotcom-rendering/src/components/Discussion.tsx
+++ b/dotcom-rendering/src/components/Discussion.tsx
@@ -66,7 +66,7 @@ export const Discussion = ({
 	user,
 	idApiUrl,
 }: Props) => {
-	const [commentPage, setCommentPage] = useState<number>();
+	const [page, setPage] = useState<number>(1);
 	const [commentPageSize, setCommentPageSize] = useState<25 | 50 | 100>();
 	const [commentOrderBy, setCommentOrderBy] = useState<
 		'newest' | 'oldest' | 'recommendations'
@@ -101,7 +101,7 @@ export const Discussion = ({
 		if (hashCommentId !== undefined) {
 			getCommentContext(discussionApiUrl, hashCommentId)
 				.then((context) => {
-					setCommentPage(context.page);
+					setPage(context.page);
 					setCommentPageSize(context.pageSize);
 					setCommentOrderBy(context.orderBy);
 					setIsExpanded(true);
@@ -160,7 +160,6 @@ export const Discussion = ({
 					<Comments
 						user={user}
 						baseUrl={discussionApiUrl}
-						initialPage={commentPage}
 						pageSizeOverride={commentPageSize}
 						isClosedForComments={
 							!!isClosedForComments || !enableDiscussionSwitch
@@ -179,6 +178,8 @@ export const Discussion = ({
 							setIsExpanded(true);
 						}}
 						idApiUrl={idApiUrl}
+						page={page}
+						setPage={setPage}
 					/>
 					{!isExpanded && (
 						<div id="discussion-overlay" css={overlayStyles} />

--- a/dotcom-rendering/src/components/Discussion/Comments.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comments.stories.tsx
@@ -51,6 +51,8 @@ export const LoggedOutHiddenPicks = () => (
 			onExpand={() => {}}
 			apiKey=""
 			idApiUrl="https://idapi.theguardian.com"
+			page={3}
+			setPage={() => {}}
 		/>
 	</div>
 );
@@ -73,7 +75,6 @@ export const InitialPage = () => (
 	>
 		<Comments
 			shortUrl="p/39f5z"
-			initialPage={3}
 			baseUrl="https://discussion.theguardian.com/discussion-api"
 			isClosedForComments={false}
 			additionalHeaders={{
@@ -85,6 +86,8 @@ export const InitialPage = () => (
 			onExpand={() => {}}
 			apiKey=""
 			idApiUrl="https://idapi.theguardian.com"
+			page={3}
+			setPage={() => {}}
 		/>
 	</div>
 );
@@ -107,7 +110,6 @@ export const Overrides = () => (
 	>
 		<Comments
 			shortUrl="p/39f5z"
-			initialPage={3}
 			pageSizeOverride={50}
 			orderByOverride="recommendations"
 			baseUrl="https://discussion.theguardian.com/discussion-api"
@@ -121,6 +123,8 @@ export const Overrides = () => (
 			onExpand={() => {}}
 			apiKey=""
 			idApiUrl="https://idapi.theguardian.com"
+			page={3}
+			setPage={() => {}}
 		/>
 	</div>
 );
@@ -155,6 +159,8 @@ export const LoggedInHiddenNoPicks = () => (
 			onExpand={() => {}}
 			apiKey=""
 			idApiUrl="https://idapi.theguardian.com"
+			page={3}
+			setPage={() => {}}
 		/>
 	</div>
 );
@@ -183,6 +189,8 @@ export const LoggedIn = () => (
 			onExpand={() => {}}
 			apiKey=""
 			idApiUrl="https://idapi.theguardian.com"
+			page={3}
+			setPage={() => {}}
 		/>
 	</div>
 );
@@ -210,6 +218,8 @@ export const LoggedInShortDiscussion = () => (
 			onExpand={() => {}}
 			apiKey=""
 			idApiUrl="https://idapi.theguardian.com"
+			page={3}
+			setPage={() => {}}
 		/>
 	</div>
 );
@@ -236,6 +246,8 @@ export const LoggedOutHiddenNoPicks = () => (
 			onExpand={() => {}}
 			apiKey=""
 			idApiUrl="https://idapi.theguardian.com"
+			page={3}
+			setPage={() => {}}
 		/>
 	</div>
 );
@@ -271,6 +283,8 @@ export const Closed = () => (
 			onExpand={() => {}}
 			apiKey=""
 			idApiUrl="https://idapi.theguardian.com"
+			page={3}
+			setPage={() => {}}
 		/>
 	</div>
 );
@@ -304,6 +318,8 @@ export const NoComments = () => (
 			onExpand={() => {}}
 			apiKey=""
 			idApiUrl="https://idapi.theguardian.com"
+			page={3}
+			setPage={() => {}}
 		/>
 	</div>
 );
@@ -337,6 +353,8 @@ export const LegacyDiscussion = () => (
 			onExpand={() => {}}
 			apiKey=""
 			idApiUrl="https://idapi.theguardian.com"
+			page={3}
+			setPage={() => {}}
 		/>
 	</div>
 );

--- a/dotcom-rendering/src/components/Discussion/Comments.test.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comments.test.tsx
@@ -27,6 +27,8 @@ describe('App', () => {
 				}}
 				apiKey=""
 				idApiUrl="https://idapi.theguardian.com"
+				page={3}
+				setPage={() => {}}
 			/>,
 		);
 

--- a/dotcom-rendering/src/components/Discussion/Comments.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comments.tsx
@@ -11,18 +11,16 @@ import {
 	getPicks,
 	initialiseApi,
 } from '../../lib/discussionApi';
-import {
-	type AdditionalHeadersType,
-	type CommentResponse,
-	type CommentType,
-	type FilterOptions,
-	isOrderBy,
-	isPageSize,
-	isThreads,
-	type OrderByType,
-	type PageSizeType,
-	type SignedInUser,
+import type {
+	AdditionalHeadersType,
+	CommentResponse,
+	CommentType,
+	FilterOptions,
+	OrderByType,
+	PageSizeType,
+	SignedInUser,
 } from '../../types/discussion';
+import { isOrderBy, isPageSize, isThreads } from '../../types/discussion';
 import { CommentContainer } from './CommentContainer';
 import { CommentForm } from './CommentForm';
 import { Filters } from './Filters';
@@ -345,9 +343,8 @@ export const Comments = ({
 		commentElement?.scrollIntoView();
 	};
 
-	// where should the responsibility for this be?
-	const handleSetPage = (page: number) => {
-		setPage(page);
+	const handleSetPage = (pageNumber: number) => {
+		setPage(pageNumber);
 		onExpand();
 	};
 

--- a/dotcom-rendering/src/components/Discussion/Comments.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comments.tsx
@@ -35,7 +35,6 @@ type Props = {
 	baseUrl: string;
 	isClosedForComments: boolean;
 	commentToScrollTo?: number;
-	initialPage?: number;
 	pageSizeOverride?: PageSizeType;
 	orderByOverride?: OrderByType;
 	user?: SignedInUser;
@@ -53,7 +52,8 @@ type Props = {
 	onPreview?: (body: string) => Promise<string>;
 	onExpand: () => void;
 	idApiUrl: string;
-	parentPage?: string;
+	page: number;
+	setPage: (page: number) => void;
 };
 
 const footerStyles = css`
@@ -186,7 +186,6 @@ export const Comments = ({
 	baseUrl,
 	shortUrl,
 	isClosedForComments,
-	initialPage,
 	commentToScrollTo,
 	pageSizeOverride,
 	orderByOverride,
@@ -201,7 +200,8 @@ export const Comments = ({
 	onPreview,
 	onExpand,
 	idApiUrl,
-	parentPage,
+	page,
+	setPage,
 }: Props) => {
 	const [filters, setFilters] = useState<FilterOptions>(
 		initialiseFilters({
@@ -216,7 +216,6 @@ export const Comments = ({
 
 	const [loading, setLoading] = useState<boolean>(true);
 	const [totalPages, setTotalPages] = useState<number>(0);
-	const [page, setPage] = useState<number>(initialPage ?? 1);
 	const [picks, setPicks] = useState<CommentType[]>([]);
 	const [commentBeingRepliedTo, setCommentBeingRepliedTo] =
 		useState<CommentType>();
@@ -278,14 +277,6 @@ export const Comments = ({
 		});
 	}, [pageSizeOverride, orderByOverride]);
 
-	// Keep initialPage prop in sync with page
-	useEffect(() => {
-		if (initialPage !== undefined) setPage(initialPage);
-		// We added commentToScrollTo to the deps here because the initialPage alone wasn't triggered the effect
-		// and we want to ensure the discussion rerenders with the right page when the reader clicks Jump To Comment
-		// for a comment on a different page
-	}, [initialPage, commentToScrollTo]);
-
 	// Check if there is a comment to scroll to and if
 	// so, scroll to the div with this id.
 	// We need to do this in javascript like this because the comments list isn't
@@ -327,7 +318,7 @@ export const Comments = ({
 		onExpand();
 		const element = document.getElementById('comment-filters');
 		element?.scrollIntoView();
-	}, [page]);
+	}, [page, onExpand]);
 
 	const toggleMuteStatus = (userId: string) => {
 		let updatedMutes;

--- a/dotcom-rendering/src/components/Discussion/Comments.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comments.tsx
@@ -53,6 +53,7 @@ type Props = {
 	onPreview?: (body: string) => Promise<string>;
 	onExpand: () => void;
 	idApiUrl: string;
+	parentPage?: string;
 };
 
 const footerStyles = css`
@@ -200,6 +201,7 @@ export const Comments = ({
 	onPreview,
 	onExpand,
 	idApiUrl,
+	parentPage,
 }: Props) => {
 	const [filters, setFilters] = useState<FilterOptions>(
 		initialiseFilters({
@@ -320,14 +322,12 @@ export const Comments = ({
 		onExpand();
 		setFilters(newFilterObject);
 	};
-
-	const onPageChange = (pageNumber: number) => {
+	useEffect(() => {
 		// Pagination also show when the view is not expanded so we want to expand when clicked
 		onExpand();
 		const element = document.getElementById('comment-filters');
 		element?.scrollIntoView();
-		setPage(pageNumber);
-	};
+	}, [page]);
 
 	const toggleMuteStatus = (userId: string) => {
 		let updatedMutes;
@@ -388,9 +388,7 @@ export const Comments = ({
 							<Pagination
 								totalPages={totalPages}
 								currentPage={page}
-								setCurrentPage={(newPage: number) => {
-									onPageChange(newPage);
-								}}
+								setCurrentPage={setPage}
 								commentCount={commentCount}
 								filters={filters}
 							/>
@@ -460,9 +458,7 @@ export const Comments = ({
 				<Pagination
 					totalPages={totalPages}
 					currentPage={page}
-					setCurrentPage={(newPage: number) => {
-						onPageChange(newPage);
-					}}
+					setCurrentPage={setPage}
 					commentCount={commentCount}
 					filters={filters}
 				/>
@@ -506,9 +502,7 @@ export const Comments = ({
 					<Pagination
 						totalPages={totalPages}
 						currentPage={page}
-						setCurrentPage={(newPage: number) => {
-							onPageChange(newPage);
-						}}
+						setCurrentPage={setPage}
 						commentCount={commentCount}
 						filters={filters}
 					/>

--- a/dotcom-rendering/src/components/Discussion/Comments.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comments.tsx
@@ -314,11 +314,9 @@ export const Comments = ({
 		setFilters(newFilterObject);
 	};
 	useEffect(() => {
-		// Pagination also show when the view is not expanded so we want to expand when clicked
-		onExpand();
 		const element = document.getElementById('comment-filters');
 		element?.scrollIntoView();
-	}, [page, onExpand]);
+	}, [page]);
 
 	const toggleMuteStatus = (userId: string) => {
 		let updatedMutes;
@@ -345,6 +343,12 @@ export const Comments = ({
 
 		const commentElement = document.getElementById(`comment-${comment.id}`);
 		commentElement?.scrollIntoView();
+	};
+
+	// where should the responsibility for this be?
+	const handleSetPage = (page: number) => {
+		setPage(page);
+		onExpand();
 	};
 
 	initialiseApi({ additionalHeaders, baseUrl, apiKey, idApiUrl });
@@ -379,7 +383,7 @@ export const Comments = ({
 							<Pagination
 								totalPages={totalPages}
 								currentPage={page}
-								setCurrentPage={setPage}
+								setCurrentPage={handleSetPage}
 								commentCount={commentCount}
 								filters={filters}
 							/>
@@ -449,7 +453,7 @@ export const Comments = ({
 				<Pagination
 					totalPages={totalPages}
 					currentPage={page}
-					setCurrentPage={setPage}
+					setCurrentPage={handleSetPage}
 					commentCount={commentCount}
 					filters={filters}
 				/>
@@ -493,7 +497,7 @@ export const Comments = ({
 					<Pagination
 						totalPages={totalPages}
 						currentPage={page}
-						setCurrentPage={setPage}
+						setCurrentPage={handleSetPage}
 						commentCount={commentCount}
 						filters={filters}
 					/>


### PR DESCRIPTION
## What does this change?
Lifts the page state out of comments and into its parent, discussion. 
## Why?
Previously we handled initial page in the parent and reset this where necessary in the child. This meant that discussion and comment had different page numbers, even though they should both be the same, meaning we had duplicated state that grew out of date. 

This is the first step in https://github.com/guardian/dotcom-rendering/issues/10228