### PR TITLE
Use interaction test in Dropdown story

### DIFF
--- a/dotcom-rendering/src/components/Dropdown.stories.tsx
+++ b/dotcom-rendering/src/components/Dropdown.stories.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import { brandBackground } from '@guardian/source-foundations';
+import { userEvent, within } from '@storybook/testing-library';
 import type { DropdownLinkType } from './Dropdown';
 import { Dropdown } from './Dropdown';
 
@@ -155,11 +156,26 @@ export const DropdownExpandedWithNotifications = () => (
 				label="My Account"
 				links={linksWithNotifications}
 				dataLinkName="linkname3"
-				defaultIsExpanded={true}
 			/>
 		</Nav>
 	</Header>
 );
+
+/**
+ * Open the dropdown so that Chromatic can capture the component in its
+ * `expanded` state.
+ */
+DropdownExpandedWithNotifications.play = async ({
+	canvasElement,
+}: {
+	canvasElement: HTMLElement;
+}) => {
+	const canvas = within(canvasElement);
+	// We need to wait for this button to be available, which it isn't initially
+	// because of the noJS behaviour in Dropdown.
+	const button = await canvas.findByTestId('dropdown-button');
+	await userEvent.click(button);
+};
 
 DropdownExpandedWithNotifications.storyName =
 	'Dropdown expanded with notifications';

--- a/dotcom-rendering/src/components/Dropdown.tsx
+++ b/dotcom-rendering/src/components/Dropdown.tsx
@@ -35,7 +35,6 @@ interface Props {
 	dataLinkName: string;
 	cssOverrides?: SerializedStyles;
 	children?: React.ReactNode;
-	defaultIsExpanded?: boolean;
 }
 
 const ulStyles = css`
@@ -390,9 +389,8 @@ export const Dropdown = ({
 	dataLinkName,
 	cssOverrides,
 	children,
-	defaultIsExpanded = false,
 }: Props) => {
-	const [isExpanded, setIsExpanded] = useState(defaultIsExpanded);
+	const [isExpanded, setIsExpanded] = useState(false);
 	const [noJS, setNoJS] = useState(true);
 	const [buttonRef, setButtonRef] = useState<HTMLButtonElement | null>(null);
 


### PR DESCRIPTION
## What does this change?

Test the expanded state of the `Dropdown` component using a storybook interaction test.

## Why?

In #10131 a story was added to catch visual regressions of the `Dropdown` component in its expanded state.

In order to do this, a prop was added (`defaultIsExpanded`) purely to support rendering the dropdown in its expanded state in the story. Instead of doing this, here we replicate the interaction the user will perform with the Dropdown which is to expand it by clicking (and so can lose the recently added prop, cleaning up the interface of this component).

## Screenshots

![Screenshot 2024-01-17 at 16 32 09](https://github.com/guardian/dotcom-rendering/assets/379839/27d1d7a5-62ce-41e8-917c-449fcfe0a2e1)


<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
