### PR TITLE
Fix fronts badges size in all breakpoints 

### DIFF
--- a/dotcom-rendering/src/components/Badge.tsx
+++ b/dotcom-rendering/src/components/Badge.tsx
@@ -3,11 +3,7 @@ import { from } from '@guardian/source-foundations';
 
 const frontsSectionBadgeSizingStyles = css`
 	height: auto;
-	width: 100px;
-
-	${from.phablet} {
-		width: 120px;
-	}
+	width: 120px;
 
 	${from.tablet} {
 		width: 140px;
@@ -27,14 +23,11 @@ const labsSectionBadgeSizingStyles = css`
 	}
 `;
 
-const imageStyles = (isInLabsSection: boolean) => css`
+const imageStyles = css`
 	display: block;
 	width: auto;
 	max-width: 100%;
 	object-fit: contain;
-	${isInLabsSection
-		? labsSectionBadgeSizingStyles
-		: frontsSectionBadgeSizingStyles}
 `;
 
 const badgeLink = css`
@@ -50,7 +43,16 @@ type Props = {
 export const Badge = ({ imageSrc, href, isInLabsSection = false }: Props) => {
 	return (
 		<a href={href} css={badgeLink} role="button">
-			<img css={imageStyles(isInLabsSection)} src={imageSrc} alt="" />
+			<img
+				css={[
+					imageStyles,
+					isInLabsSection
+						? labsSectionBadgeSizingStyles
+						: frontsSectionBadgeSizingStyles,
+				]}
+				src={imageSrc}
+				alt=""
+			/>
 		</a>
 	);
 };

--- a/dotcom-rendering/src/components/Badge.tsx
+++ b/dotcom-rendering/src/components/Badge.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import { from } from '@guardian/source-foundations';
 
-const badgeSizingStyles = css`
+const frontsSectionBadgeSizingStyles = css`
 	height: auto;
 	width: 100px;
 
@@ -18,12 +18,23 @@ const badgeSizingStyles = css`
 	}
 `;
 
-const imageStyles = css`
+const labsSectionBadgeSizingStyles = css`
+	height: auto;
+	width: 100px;
+
+	${from.phablet} {
+		width: 120px;
+	}
+`;
+
+const imageStyles = (isInLabsSection: boolean) => css`
 	display: block;
 	width: auto;
 	max-width: 100%;
 	object-fit: contain;
-	${badgeSizingStyles}
+	${isInLabsSection
+		? labsSectionBadgeSizingStyles
+		: frontsSectionBadgeSizingStyles}
 `;
 
 const badgeLink = css`
@@ -33,12 +44,13 @@ const badgeLink = css`
 type Props = {
 	imageSrc: string;
 	href: string;
+	isInLabsSection?: boolean;
 };
 
-export const Badge = ({ imageSrc, href }: Props) => {
+export const Badge = ({ imageSrc, href, isInLabsSection = false }: Props) => {
 	return (
 		<a href={href} css={badgeLink} role="button">
-			<img css={imageStyles} src={imageSrc} alt="" />
+			<img css={imageStyles(isInLabsSection)} src={imageSrc} alt="" />
 		</a>
 	);
 };

--- a/dotcom-rendering/src/components/Badge.tsx
+++ b/dotcom-rendering/src/components/Badge.tsx
@@ -1,37 +1,29 @@
 import { css } from '@emotion/react';
 import { from } from '@guardian/source-foundations';
 
-const articleBadgeSizingStyles = css`
-	height: 42px;
-	${from.leftCol} {
-		height: 54px;
-	}
-`;
-
-const frontBadgeSizingStyles = css`
-	height: 50px;
+const badgeSizingStyles = css`
+	height: auto;
+	width: 100px;
 
 	${from.phablet} {
-		height: 90px;
+		width: 120px;
+	}
+
+	${from.tablet} {
+		width: 140px;
 	}
 
 	${from.leftCol} {
-		height: 100px;
-	}
-
-	${from.wide} {
-		height: 140px;
+		width: 200px;
 	}
 `;
 
-const imageStyles = (isFrontNonEditorialBadge: boolean) => css`
+const imageStyles = css`
 	display: block;
 	width: auto;
 	max-width: 100%;
 	object-fit: contain;
-	${isFrontNonEditorialBadge
-		? frontBadgeSizingStyles
-		: articleBadgeSizingStyles}
+	${badgeSizingStyles}
 `;
 
 const badgeLink = css`
@@ -41,29 +33,12 @@ const badgeLink = css`
 type Props = {
 	imageSrc: string;
 	href: string;
-	isFrontNonEditorialBadge?: boolean;
 };
 
-export const Badge = ({
-	imageSrc,
-	href,
-	isFrontNonEditorialBadge = false,
-}: Props) => {
+export const Badge = ({ imageSrc, href }: Props) => {
 	return (
-		<div
-			css={
-				isFrontNonEditorialBadge
-					? frontBadgeSizingStyles
-					: articleBadgeSizingStyles
-			}
-		>
-			<a href={href} css={badgeLink} role="button">
-				<img
-					css={imageStyles(isFrontNonEditorialBadge)}
-					src={imageSrc}
-					alt=""
-				/>
-			</a>
-		</div>
+		<a href={href} css={badgeLink} role="button">
+			<img css={imageStyles} src={imageSrc} alt="" />
+		</a>
 	);
 };

--- a/dotcom-rendering/src/components/Badge.tsx
+++ b/dotcom-rendering/src/components/Badge.tsx
@@ -1,19 +1,37 @@
 import { css } from '@emotion/react';
 import { from } from '@guardian/source-foundations';
 
-const badgeSizingStyles = css`
+const articleBadgeSizingStyles = css`
 	height: 42px;
 	${from.leftCol} {
 		height: 54px;
 	}
 `;
 
-const imageStyles = css`
+const frontBadgeSizingStyles = css`
+	height: 50px;
+
+	${from.phablet} {
+		height: 90px;
+	}
+
+	${from.leftCol} {
+		height: 100px;
+	}
+
+	${from.wide} {
+		height: 140px;
+	}
+`;
+
+const imageStyles = (isFrontNonEditorialBadge: boolean) => css`
 	display: block;
 	width: auto;
 	max-width: 100%;
 	object-fit: contain;
-	${badgeSizingStyles}
+	${isFrontNonEditorialBadge
+		? frontBadgeSizingStyles
+		: articleBadgeSizingStyles}
 `;
 
 const badgeLink = css`
@@ -23,13 +41,28 @@ const badgeLink = css`
 type Props = {
 	imageSrc: string;
 	href: string;
+	isFrontNonEditorialBadge?: boolean;
 };
 
-export const Badge = ({ imageSrc, href }: Props) => {
+export const Badge = ({
+	imageSrc,
+	href,
+	isFrontNonEditorialBadge = false,
+}: Props) => {
 	return (
-		<div css={badgeSizingStyles}>
+		<div
+			css={
+				isFrontNonEditorialBadge
+					? frontBadgeSizingStyles
+					: articleBadgeSizingStyles
+			}
+		>
 			<a href={href} css={badgeLink} role="button">
-				<img css={imageStyles} src={imageSrc} alt="" />
+				<img
+					css={imageStyles(isFrontNonEditorialBadge)}
+					src={imageSrc}
+					alt=""
+				/>
 			</a>
 		</div>
 	);

--- a/dotcom-rendering/src/components/FrontSectionTitle.tsx
+++ b/dotcom-rendering/src/components/FrontSectionTitle.tsx
@@ -47,11 +47,19 @@ export const FrontSectionTitle = ({ title, collectionBranding }: Props) => {
 				return (
 					<>
 						<Hide until="leftCol">
-							<Badge imageSrc={logo.src} href={logo.link} />
+							<Badge
+								imageSrc={logo.src}
+								href={logo.link}
+								isFrontNonEditorialBadge={true}
+							/>
 						</Hide>
 						<div css={titleStyle}>
 							<Hide from="leftCol">
-								<Badge imageSrc={logo.src} href={logo.link} />
+								<Badge
+									imageSrc={logo.src}
+									href={logo.link}
+									isFrontNonEditorialBadge={true}
+								/>
 							</Hide>
 							{title}
 						</div>
@@ -86,7 +94,11 @@ export const FrontSectionTitle = ({ title, collectionBranding }: Props) => {
 							`}
 						>
 							Paid for by
-							<Badge imageSrc={logo.src} href={logo.link} />
+							<Badge
+								imageSrc={logo.src}
+								href={logo.link}
+								isFrontNonEditorialBadge={true}
+							/>
 						</div>
 					</div>
 				);
@@ -95,11 +107,19 @@ export const FrontSectionTitle = ({ title, collectionBranding }: Props) => {
 			return (
 				<>
 					<Hide until="leftCol">
-						<Badge imageSrc={logo.src} href={logo.link} />
+						<Badge
+							imageSrc={logo.src}
+							href={logo.link}
+							isFrontNonEditorialBadge={true}
+						/>
 					</Hide>
 					<div css={titleStyle}>
 						<Hide from="leftCol">
-							<Badge imageSrc={logo.src} href={logo.link} />
+							<Badge
+								imageSrc={logo.src}
+								href={logo.link}
+								isFrontNonEditorialBadge={true}
+							/>
 						</Hide>
 						{title}
 					</div>
@@ -118,7 +138,11 @@ export const FrontSectionTitle = ({ title, collectionBranding }: Props) => {
 						{title}
 						<>
 							<p css={labelStyles}>{logo.label}</p>
-							<Badge imageSrc={logo.src} href={logo.link} />
+							<Badge
+								imageSrc={logo.src}
+								href={logo.link}
+								isFrontNonEditorialBadge={true}
+							/>
 							<a href={aboutThisLink} css={aboutThisLinkStyles}>
 								About this content
 							</a>

--- a/dotcom-rendering/src/components/FrontSectionTitle.tsx
+++ b/dotcom-rendering/src/components/FrontSectionTitle.tsx
@@ -47,19 +47,11 @@ export const FrontSectionTitle = ({ title, collectionBranding }: Props) => {
 				return (
 					<>
 						<Hide until="leftCol">
-							<Badge
-								imageSrc={logo.src}
-								href={logo.link}
-								isFrontNonEditorialBadge={true}
-							/>
+							<Badge imageSrc={logo.src} href={logo.link} />
 						</Hide>
 						<div css={titleStyle}>
 							<Hide from="leftCol">
-								<Badge
-									imageSrc={logo.src}
-									href={logo.link}
-									isFrontNonEditorialBadge={true}
-								/>
+								<Badge imageSrc={logo.src} href={logo.link} />
 							</Hide>
 							{title}
 						</div>
@@ -94,11 +86,7 @@ export const FrontSectionTitle = ({ title, collectionBranding }: Props) => {
 							`}
 						>
 							Paid for by
-							<Badge
-								imageSrc={logo.src}
-								href={logo.link}
-								isFrontNonEditorialBadge={true}
-							/>
+							<Badge imageSrc={logo.src} href={logo.link} />
 						</div>
 					</div>
 				);
@@ -107,19 +95,11 @@ export const FrontSectionTitle = ({ title, collectionBranding }: Props) => {
 			return (
 				<>
 					<Hide until="leftCol">
-						<Badge
-							imageSrc={logo.src}
-							href={logo.link}
-							isFrontNonEditorialBadge={true}
-						/>
+						<Badge imageSrc={logo.src} href={logo.link} />
 					</Hide>
 					<div css={titleStyle}>
 						<Hide from="leftCol">
-							<Badge
-								imageSrc={logo.src}
-								href={logo.link}
-								isFrontNonEditorialBadge={true}
-							/>
+							<Badge imageSrc={logo.src} href={logo.link} />
 						</Hide>
 						{title}
 					</div>
@@ -138,11 +118,7 @@ export const FrontSectionTitle = ({ title, collectionBranding }: Props) => {
 						{title}
 						<>
 							<p css={labelStyles}>{logo.label}</p>
-							<Badge
-								imageSrc={logo.src}
-								href={logo.link}
-								isFrontNonEditorialBadge={true}
-							/>
+							<Badge imageSrc={logo.src} href={logo.link} />
 							<a href={aboutThisLink} css={aboutThisLinkStyles}>
 								About this content
 							</a>

--- a/dotcom-rendering/src/components/LabsSection.tsx
+++ b/dotcom-rendering/src/components/LabsSection.tsx
@@ -464,6 +464,7 @@ export const LabsSection = ({
 							<Badge
 								imageSrc={badge.imageSrc}
 								href={badge.href}
+								isInLabsSection={true}
 							/>
 						</div>
 					)}


### PR DESCRIPTION
Closes https://github.com/guardian/dotcom-rendering/issues/7973

## What does this change?
Fixes fronts badges size in all breakpoints

## Why?
Achieves parity with frontend for wide and leftCol. For lower breakpoints I ignored frontend because it is broken.
Editorial front badges are left as they are (screenshots provided).

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/ad8de14e-dcae-40da-b082-bbed941f4d06) | ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/62d80f25-7336-4c74-8b7e-5fe2a344fd73) |
| ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/37b6fe8b-e6bf-4d5a-bf73-31358079bd16)] | ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/b8204391-d2f1-4f18-8d74-67ae8ff98923) |
| ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/c96fb38b-1677-4db5-bc66-02ff496a3e98) | ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/66020573-13e2-4186-9ec8-e70a86470c09) |
| ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/ad33d358-034e-402f-aef6-cb2a499c6d79) | ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/1ddc6a98-2a09-49d8-9e34-28630e501693) |
| ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/0060633e-7bcb-44b2-87cb-d156a80de848) | ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/3c065fa6-87d7-441e-99bd-12086acc67ba) |
| <img width="1449" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/19683595/8786d1a2-acb1-497a-8226-dae85c722b2b"> | <img width="1319" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/19683595/ecf54042-2cbb-44ae-9eda-227a5bda377b"> |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
