### PR TITLE
Reintroduce Article Metadata From `leftCol` Breakpoint Upwards On Apps

### DIFF
--- a/dotcom-rendering/src/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/layouts/CommentLayout.tsx
@@ -569,32 +569,62 @@ export const CommentLayout = (props: WebProps | AppsProps) => {
 						<GridItem area="meta" element="aside">
 							<div css={maxWidth}>
 								{isApps ? (
-									<Hide when="above" breakpoint="leftCol">
-										<ArticleMetaApps
-											branding={branding}
-											format={format}
-											pageId={article.pageId}
-											webTitle={article.webTitle}
-											byline={article.byline}
-											tags={article.tags}
-											primaryDateline={
-												article.webPublicationDateDisplay
-											}
-											secondaryDateline={
-												article.webPublicationSecondaryDateDisplay
-											}
-											isCommentable={
-												article.isCommentable
-											}
-											discussionApiUrl={
-												article.config.discussionApiUrl
-											}
-											shortUrlId={
-												article.config.shortUrlId
-											}
-											ajaxUrl={article.config.ajaxUrl}
-										></ArticleMetaApps>
-									</Hide>
+									<>
+										<Hide when="above" breakpoint="leftCol">
+											<ArticleMetaApps
+												branding={branding}
+												format={format}
+												pageId={article.pageId}
+												webTitle={article.webTitle}
+												byline={article.byline}
+												tags={article.tags}
+												primaryDateline={
+													article.webPublicationDateDisplay
+												}
+												secondaryDateline={
+													article.webPublicationSecondaryDateDisplay
+												}
+												isCommentable={
+													article.isCommentable
+												}
+												discussionApiUrl={
+													article.config
+														.discussionApiUrl
+												}
+												shortUrlId={
+													article.config.shortUrlId
+												}
+												ajaxUrl={article.config.ajaxUrl}
+											></ArticleMetaApps>
+										</Hide>
+										<Hide when="below" breakpoint="leftCol">
+											<ArticleMeta
+												branding={branding}
+												format={format}
+												pageId={article.pageId}
+												webTitle={article.webTitle}
+												byline={article.byline}
+												tags={article.tags}
+												primaryDateline={
+													article.webPublicationDateDisplay
+												}
+												secondaryDateline={
+													article.webPublicationSecondaryDateDisplay
+												}
+												isCommentable={
+													article.isCommentable
+												}
+												discussionApiUrl={
+													article.config
+														.discussionApiUrl
+												}
+												shortUrlId={
+													article.config.shortUrlId
+												}
+												ajaxUrl={article.config.ajaxUrl}
+											/>
+										</Hide>
+									</>
 								) : (
 									<ArticleMeta
 										branding={branding}

--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -596,32 +596,62 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 						<GridItem area="meta" element="aside">
 							<div css={maxWidth}>
 								{isApps ? (
-									<Hide when="above" breakpoint="leftCol">
-										<ArticleMetaApps
-											branding={branding}
-											format={format}
-											pageId={article.pageId}
-											webTitle={article.webTitle}
-											byline={article.byline}
-											tags={article.tags}
-											primaryDateline={
-												article.webPublicationDateDisplay
-											}
-											secondaryDateline={
-												article.webPublicationSecondaryDateDisplay
-											}
-											isCommentable={
-												article.isCommentable
-											}
-											discussionApiUrl={
-												article.config.discussionApiUrl
-											}
-											shortUrlId={
-												article.config.shortUrlId
-											}
-											ajaxUrl={article.config.ajaxUrl}
-										></ArticleMetaApps>
-									</Hide>
+									<>
+										<Hide when="above" breakpoint="leftCol">
+											<ArticleMetaApps
+												branding={branding}
+												format={format}
+												pageId={article.pageId}
+												webTitle={article.webTitle}
+												byline={article.byline}
+												tags={article.tags}
+												primaryDateline={
+													article.webPublicationDateDisplay
+												}
+												secondaryDateline={
+													article.webPublicationSecondaryDateDisplay
+												}
+												isCommentable={
+													article.isCommentable
+												}
+												discussionApiUrl={
+													article.config
+														.discussionApiUrl
+												}
+												shortUrlId={
+													article.config.shortUrlId
+												}
+												ajaxUrl={article.config.ajaxUrl}
+											></ArticleMetaApps>
+										</Hide>
+										<Hide when="below" breakpoint="leftCol">
+											<ArticleMeta
+												branding={branding}
+												format={format}
+												pageId={article.pageId}
+												webTitle={article.webTitle}
+												byline={article.byline}
+												tags={article.tags}
+												primaryDateline={
+													article.webPublicationDateDisplay
+												}
+												secondaryDateline={
+													article.webPublicationSecondaryDateDisplay
+												}
+												isCommentable={
+													article.isCommentable
+												}
+												discussionApiUrl={
+													article.config
+														.discussionApiUrl
+												}
+												shortUrlId={
+													article.config.shortUrlId
+												}
+												ajaxUrl={article.config.ajaxUrl}
+											/>
+										</Hide>
+									</>
 								) : (
 									<ArticleMeta
 										branding={branding}

--- a/dotcom-rendering/src/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/InteractiveLayout.tsx
@@ -514,33 +514,68 @@ export const InteractiveLayout = (props: WebProps | AppsProps) => {
 							<GridItem area="meta" element="aside">
 								<div css={maxWidth}>
 									{isApps ? (
-										<Hide from="leftCol">
-											<ArticleMetaApps
-												branding={branding}
-												format={format}
-												pageId={article.pageId}
-												webTitle={article.webTitle}
-												byline={article.byline}
-												tags={article.tags}
-												primaryDateline={
-													article.webPublicationDateDisplay
-												}
-												secondaryDateline={
-													article.webPublicationSecondaryDateDisplay
-												}
-												isCommentable={
-													article.isCommentable
-												}
-												discussionApiUrl={
-													article.config
-														.discussionApiUrl
-												}
-												shortUrlId={
-													article.config.shortUrlId
-												}
-												ajaxUrl={article.config.ajaxUrl}
-											></ArticleMetaApps>
-										</Hide>
+										<>
+											<Hide from="leftCol">
+												<ArticleMetaApps
+													branding={branding}
+													format={format}
+													pageId={article.pageId}
+													webTitle={article.webTitle}
+													byline={article.byline}
+													tags={article.tags}
+													primaryDateline={
+														article.webPublicationDateDisplay
+													}
+													secondaryDateline={
+														article.webPublicationSecondaryDateDisplay
+													}
+													isCommentable={
+														article.isCommentable
+													}
+													discussionApiUrl={
+														article.config
+															.discussionApiUrl
+													}
+													shortUrlId={
+														article.config
+															.shortUrlId
+													}
+													ajaxUrl={
+														article.config.ajaxUrl
+													}
+												></ArticleMetaApps>
+											</Hide>
+											<Hide until="leftCol">
+												<ArticleMeta
+													branding={branding}
+													format={format}
+													pageId={article.pageId}
+													webTitle={article.webTitle}
+													byline={article.byline}
+													tags={article.tags}
+													primaryDateline={
+														article.webPublicationDateDisplay
+													}
+													secondaryDateline={
+														article.webPublicationSecondaryDateDisplay
+													}
+													isCommentable={
+														article.isCommentable
+													}
+													discussionApiUrl={
+														article.config
+															.discussionApiUrl
+													}
+													shortUrlId={
+														article.config
+															.shortUrlId
+													}
+													ajaxUrl={
+														article.config.ajaxUrl
+													}
+												/>
+											</Hide>
+										</>
 									) : (
 										<ArticleMeta
 											branding={branding}

--- a/dotcom-rendering/src/layouts/PictureLayout.tsx
+++ b/dotcom-rendering/src/layouts/PictureLayout.tsx
@@ -571,32 +571,62 @@ export const PictureLayout = (props: WebProps | AppsProps) => {
 						<GridItem area="meta" element="aside">
 							<div>
 								{isApps ? (
-									<Hide from="leftCol">
-										<ArticleMetaApps
-											branding={branding}
-											format={format}
-											pageId={article.pageId}
-											webTitle={article.webTitle}
-											byline={article.byline}
-											tags={article.tags}
-											primaryDateline={
-												article.webPublicationDateDisplay
-											}
-											secondaryDateline={
-												article.webPublicationSecondaryDateDisplay
-											}
-											isCommentable={
-												article.isCommentable
-											}
-											discussionApiUrl={
-												article.config.discussionApiUrl
-											}
-											shortUrlId={
-												article.config.shortUrlId
-											}
-											ajaxUrl={article.config.ajaxUrl}
-										></ArticleMetaApps>
-									</Hide>
+									<>
+										<Hide from="leftCol">
+											<ArticleMetaApps
+												branding={branding}
+												format={format}
+												pageId={article.pageId}
+												webTitle={article.webTitle}
+												byline={article.byline}
+												tags={article.tags}
+												primaryDateline={
+													article.webPublicationDateDisplay
+												}
+												secondaryDateline={
+													article.webPublicationSecondaryDateDisplay
+												}
+												isCommentable={
+													article.isCommentable
+												}
+												discussionApiUrl={
+													article.config
+														.discussionApiUrl
+												}
+												shortUrlId={
+													article.config.shortUrlId
+												}
+												ajaxUrl={article.config.ajaxUrl}
+											></ArticleMetaApps>
+										</Hide>
+										<Hide until="leftCol">
+											<ArticleMeta
+												branding={branding}
+												format={format}
+												pageId={article.pageId}
+												webTitle={article.webTitle}
+												byline={article.byline}
+												tags={article.tags}
+												primaryDateline={
+													article.webPublicationDateDisplay
+												}
+												secondaryDateline={
+													article.webPublicationSecondaryDateDisplay
+												}
+												isCommentable={
+													article.isCommentable
+												}
+												discussionApiUrl={
+													article.config
+														.discussionApiUrl
+												}
+												shortUrlId={
+													article.config.shortUrlId
+												}
+												ajaxUrl={article.config.ajaxUrl}
+											/>
+										</Hide>
+									</>
 								) : (
 									<ArticleMeta
 										branding={branding}

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -581,32 +581,62 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 						<GridItem area="meta" element="aside">
 							<div css={maxWidth}>
 								{isApps ? (
-									<Hide from="leftCol">
-										<ArticleMetaApps
-											branding={branding}
-											format={format}
-											pageId={article.pageId}
-											webTitle={article.webTitle}
-											byline={article.byline}
-											tags={article.tags}
-											primaryDateline={
-												article.webPublicationDateDisplay
-											}
-											secondaryDateline={
-												article.webPublicationSecondaryDateDisplay
-											}
-											isCommentable={
-												article.isCommentable
-											}
-											discussionApiUrl={
-												article.config.discussionApiUrl
-											}
-											shortUrlId={
-												article.config.shortUrlId
-											}
-											ajaxUrl={article.config.ajaxUrl}
-										></ArticleMetaApps>
-									</Hide>
+									<>
+										<Hide from="leftCol">
+											<ArticleMetaApps
+												branding={branding}
+												format={format}
+												pageId={article.pageId}
+												webTitle={article.webTitle}
+												byline={article.byline}
+												tags={article.tags}
+												primaryDateline={
+													article.webPublicationDateDisplay
+												}
+												secondaryDateline={
+													article.webPublicationSecondaryDateDisplay
+												}
+												isCommentable={
+													article.isCommentable
+												}
+												discussionApiUrl={
+													article.config
+														.discussionApiUrl
+												}
+												shortUrlId={
+													article.config.shortUrlId
+												}
+												ajaxUrl={article.config.ajaxUrl}
+											></ArticleMetaApps>
+										</Hide>
+										<Hide until="leftCol">
+											<ArticleMeta
+												branding={branding}
+												format={format}
+												pageId={article.pageId}
+												webTitle={article.webTitle}
+												byline={article.byline}
+												tags={article.tags}
+												primaryDateline={
+													article.webPublicationDateDisplay
+												}
+												secondaryDateline={
+													article.webPublicationSecondaryDateDisplay
+												}
+												isCommentable={
+													article.isCommentable
+												}
+												discussionApiUrl={
+													article.config
+														.discussionApiUrl
+												}
+												shortUrlId={
+													article.config.shortUrlId
+												}
+												ajaxUrl={article.config.ajaxUrl}
+											/>
+										</Hide>
+									</>
 								) : (
 									<ArticleMeta
 										branding={branding}

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -639,34 +639,66 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 						</GridItem>
 						<GridItem area="meta" element="aside">
 							{isApps ? (
-								<Hide from="leftCol">
-									<div css={maxWidth}>
-										<ArticleMetaApps
-											branding={branding}
-											format={format}
-											pageId={article.pageId}
-											webTitle={article.webTitle}
-											byline={article.byline}
-											tags={article.tags}
-											primaryDateline={
-												article.webPublicationDateDisplay
-											}
-											secondaryDateline={
-												article.webPublicationSecondaryDateDisplay
-											}
-											isCommentable={
-												article.isCommentable
-											}
-											discussionApiUrl={
-												article.config.discussionApiUrl
-											}
-											shortUrlId={
-												article.config.shortUrlId
-											}
-											ajaxUrl={article.config.ajaxUrl}
-										></ArticleMetaApps>
-									</div>
-								</Hide>
+								<>
+									<Hide from="leftCol">
+										<div css={maxWidth}>
+											<ArticleMetaApps
+												branding={branding}
+												format={format}
+												pageId={article.pageId}
+												webTitle={article.webTitle}
+												byline={article.byline}
+												tags={article.tags}
+												primaryDateline={
+													article.webPublicationDateDisplay
+												}
+												secondaryDateline={
+													article.webPublicationSecondaryDateDisplay
+												}
+												isCommentable={
+													article.isCommentable
+												}
+												discussionApiUrl={
+													article.config
+														.discussionApiUrl
+												}
+												shortUrlId={
+													article.config.shortUrlId
+												}
+												ajaxUrl={article.config.ajaxUrl}
+											></ArticleMetaApps>
+										</div>
+									</Hide>
+									<Hide until="leftCol">
+										<div css={maxWidth}>
+											<ArticleMeta
+												branding={branding}
+												format={format}
+												pageId={article.pageId}
+												webTitle={article.webTitle}
+												byline={article.byline}
+												tags={article.tags}
+												primaryDateline={
+													article.webPublicationDateDisplay
+												}
+												secondaryDateline={
+													article.webPublicationSecondaryDateDisplay
+												}
+												isCommentable={
+													article.isCommentable
+												}
+												discussionApiUrl={
+													article.config
+														.discussionApiUrl
+												}
+												shortUrlId={
+													article.config.shortUrlId
+												}
+												ajaxUrl={article.config.ajaxUrl}
+											/>
+										</div>
+									</Hide>
+								</>
 							) : (
 								<div css={maxWidth}>
 									<ArticleMeta


### PR DESCRIPTION
Fixes a bug where the article metadata was visible below this breakpoint but hidden above it on apps. This may have happened in #9783. I think the consequence of that change is that there's no metadata available on the page from `leftCol` upwards?

This PR reintroduces the `ArticleMeta` component from this breakpoint, as the new `ArticleMetaApps` component isn't supported at this width based on the description in the above PR.

**Note:** It may be a good idea to turn on "Hide whitespace" to read the diff.

## Screenshots

| Before | After |
| - | - |
| ![meta-before] | ![meta-after] |

[meta-after]: https://github.com/guardian/dotcom-rendering/assets/53781962/35e5a4a5-9e51-416e-90b3-79234f7c3c72
[meta-before]: https://github.com/guardian/dotcom-rendering/assets/53781962/c7d0e9f1-6c9a-4d7b-87a6-184ac37c0ba7
