### PR TITLE
Make `id` required in `Video`

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -473,10 +473,7 @@ export const Card = ({
 											defer={{ until: 'visible' }}
 										>
 											<YoutubeBlockComponent
-												id={
-													media.mainMedia.id ??
-													'unknown-media-id'
-												}
+												id={media.mainMedia.id}
 												assetId={
 													media.mainMedia.videoId
 												}

--- a/dotcom-rendering/src/model/article-schema.json
+++ b/dotcom-rendering/src/model/article-schema.json
@@ -4441,6 +4441,7 @@
                         "duration",
                         "expired",
                         "height",
+                        "id",
                         "images",
                         "origin",
                         "title",

--- a/dotcom-rendering/src/model/front-schema.json
+++ b/dotcom-rendering/src/model/front-schema.json
@@ -3624,6 +3624,7 @@
                         "duration",
                         "expired",
                         "height",
+                        "id",
                         "images",
                         "origin",
                         "title",

--- a/dotcom-rendering/src/types/mainMedia.ts
+++ b/dotcom-rendering/src/types/mainMedia.ts
@@ -6,7 +6,7 @@ type Media = {
 type Video = Media & {
 	type: 'Video';
 	/** @see https://github.com/guardian/frontend/blob/8e7e4d0e/common/app/model/content/Atom.scala#L159 */
-	id?: string;
+	id: string;
 	videoId: string;
 	height: number;
 	width: number;


### PR DESCRIPTION
## What does this change?

Make `id` required in `Video`

## Why?

It’s actually sent throught. This was incorrectly identified as a source of error:
- #10252

## Screenshots

N/A