### PR TITLE
Make `discussionApi` functions async

### DIFF
--- a/dotcom-rendering/src/components/DiscussionContainer.importable.tsx
+++ b/dotcom-rendering/src/components/DiscussionContainer.importable.tsx
@@ -52,7 +52,6 @@ const getUser = async ({
  *
  * (No visual story exist)
  */
-
 export const DiscussionContainer = (props: Omit<DiscussionProps, 'user'>) => {
 	const hydrated = useHydrated();
 	const authStatus = useAuthStatus();

--- a/dotcom-rendering/src/lib/discussionApi.tsx
+++ b/dotcom-rendering/src/lib/discussionApi.tsx
@@ -92,20 +92,15 @@ export const getDiscussion = async (
 
 	const json = await resp.json();
 
-	if (
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-		json.errorCode === 'DISCUSSION_ONLY_AVAILABLE_IN_LINEAR_FORMAT'
-	) {
+	// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+	return json.errorCode === 'DISCUSSION_ONLY_AVAILABLE_IN_LINEAR_FORMAT' ?
 		// We need force a refetch with unthreaded set, as we don't know
 		// that this discussion is only available in linear format until
 		// we get the response to tell us
-		return getDiscussion(shortUrl, {
+		getDiscussion(shortUrl, {
 			...opts,
 			...{ threads: 'unthreaded' },
-		});
-	}
-
-	return json;
+		}) : json
 };
 
 export const preview = async (body: string): Promise<string> => {

--- a/dotcom-rendering/src/lib/discussionApi.tsx
+++ b/dotcom-rendering/src/lib/discussionApi.tsx
@@ -93,14 +93,15 @@ export const getDiscussion = async (
 	const json = await resp.json();
 
 	// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-	return json.errorCode === 'DISCUSSION_ONLY_AVAILABLE_IN_LINEAR_FORMAT' ?
-		// We need force a refetch with unthreaded set, as we don't know
-		// that this discussion is only available in linear format until
-		// we get the response to tell us
-		getDiscussion(shortUrl, {
-			...opts,
-			...{ threads: 'unthreaded' },
-		}) : json
+	return json.errorCode === 'DISCUSSION_ONLY_AVAILABLE_IN_LINEAR_FORMAT'
+		? // We need force a refetch with unthreaded set, as we don't know
+		  // that this discussion is only available in linear format until
+		  // we get the response to tell us
+		  getDiscussion(shortUrl, {
+				...opts,
+				...{ threads: 'unthreaded' },
+		  })
+		: json;
 };
 
 export const preview = async (body: string): Promise<string> => {
@@ -180,7 +181,7 @@ export const reply =
 			credentials: authOptions.credentials,
 		});
 
-		return await resp.json();
+		return resp.json();
 	};
 
 //todo: come back and parse the response properly and set a proper return type for the error case


### PR DESCRIPTION
## What does this change?

Apply VSCode suggestions by making `discussionApi` methods asynchronous

## Why?

Easier to read and more focussed ESLint warnings

## Screenshots

N/A