### PR TITLE
Reduce Article Stack Instance Count

### DIFF
--- a/dotcom-rendering/cdk/bin/cdk.ts
+++ b/dotcom-rendering/cdk/bin/cdk.ts
@@ -40,7 +40,7 @@ new RenderingCDKStack(cdkApp, 'ArticleRendering-PROD', {
 	guApp: 'article-rendering',
 	stage: 'PROD',
 	domainName: 'article-rendering.guardianapis.com',
-	scaling: { minimumInstances: 24, maximumInstances: 120 },
+	scaling: { minimumInstances: 12, maximumInstances: 120 },
 	instanceSize: InstanceSize.SMALL,
 });
 


### PR DESCRIPTION
## What does this change?

Reduces the min cluster size of the article stack to 12 from 24. 

## Why?

This is because we have conducted extensive load tests to understand the ideal latency of article rendering and the cluster configuration that can support this: 

https://docs.google.com/spreadsheets/d/135iqkVeIo-ou6SWnDl83n35wbu7TCuaW9y2qy87t8c4/edit#gid=0
