### PR TITLE
Comments duplicated filters

### DIFF
--- a/dotcom-rendering/playwright/tests/parallel-3/article.interactivity.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/parallel-3/article.interactivity.e2e.spec.ts
@@ -72,11 +72,10 @@ test.describe('Interactivity', () => {
 			context,
 			page,
 		}) => {
-			// The permalink feature is not currently working but once it does we want this test ready to go
 			await disableCMP(context);
 			await loadPage(
 				page,
-				`/Article/https://www.theguardian.com/commentisfree/2022/jan/20/uk-government-yemen-war-saudi-arabia-westminster#comments`,
+				`/Article/https://www.theguardian.com/commentisfree/2022/jan/20/uk-government-yemen-war-saudi-arabia-westminster#comment-154433663`,
 			);
 			await waitForIsland(page, 'DiscussionContainer', {});
 			await expectToBeVisible(page, '[id=comment-154433663]');

--- a/dotcom-rendering/src/components/Discussion.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion.stories.tsx
@@ -65,3 +65,42 @@ Basic.decorators = [
 		{ orientation: 'vertical' },
 	),
 ];
+
+export const Overrides: StoryObj = ({ format }: StoryProps) => {
+	// Aiming to stop flakiness in Chromatic visual diffs by explicitly
+	// setting the desired comments sorting order in local storage
+	storage.local.set('gu.prefs.discussion.order', 'newest');
+
+	// overide the default page size
+	storage.local.set('gu.prefs.discussion.pagesize', 50);
+
+	return (
+		<SectionWrapper>
+			<DiscussionLayout
+				discussionApiUrl="https://discussion.theguardian.com/discussion-api"
+				shortUrlId="/p/4v8kk"
+				format={format}
+				discussionD2Uid="zHoBy6HNKsk"
+				discussionApiClientHeader="nextgen"
+				enableDiscussionSwitch={true}
+				isAdFreeUser={false}
+				shouldHideAds={false}
+				idApiUrl="https://idapi.theguardian.com"
+			/>
+		</SectionWrapper>
+	);
+};
+
+Overrides.storyName = 'A discussion with page number default overridden to 50';
+Overrides.decorators = [
+	splitTheme(
+		[
+			{
+				design: ArticleDesign.Standard,
+				display: ArticleDisplay.Standard,
+				theme: Pillar.Culture,
+			},
+		],
+		{ orientation: 'vertical' },
+	),
+];

--- a/dotcom-rendering/src/components/Discussion.tsx
+++ b/dotcom-rendering/src/components/Discussion.tsx
@@ -109,8 +109,6 @@ export const Discussion = ({
 
 	useEffect(() => {
 		rememberFilters(filters);
-		// Filters also show when the view is not expanded but we want to expand when they're changed
-		setIsExpanded(true);
 	}, [filters]);
 
 	const handlePermalink = (commentId: number) => {

--- a/dotcom-rendering/src/components/Discussion.tsx
+++ b/dotcom-rendering/src/components/Discussion.tsx
@@ -106,7 +106,6 @@ export const Discussion = ({
 		const orderByClosed = isClosedForComments ? 'oldest' : undefined;
 
 		setFilters((prevFilters) => ({
-			...prevFilters,
 			orderBy: commentOrderBy ?? orderByClosed ?? prevFilters.orderBy,
 			pageSize: commentPageSize ?? prevFilters.pageSize,
 			threads:

--- a/dotcom-rendering/src/components/Discussion.tsx
+++ b/dotcom-rendering/src/components/Discussion.tsx
@@ -72,7 +72,7 @@ const commentIdFromUrl = () => {
 
 const filterByPermalinks = (
 	threads: ThreadsType,
-	hashCommentId: Number | undefined,
+	hashCommentId: number | undefined,
 ) => {
 	const permalinkBeingUsed =
 		hashCommentId !== undefined && !Number.isNaN(hashCommentId);

--- a/dotcom-rendering/src/components/Discussion.tsx
+++ b/dotcom-rendering/src/components/Discussion.tsx
@@ -70,6 +70,18 @@ const commentIdFromUrl = () => {
 	return parseInt(commentId, 10);
 };
 
+const filterByPermalinks = (
+	threads: ThreadsType,
+	hashCommentId: Number | undefined,
+) => {
+	const permalinkBeingUsed =
+		hashCommentId !== undefined && !Number.isNaN(hashCommentId);
+
+	return threads === 'collapsed' && permalinkBeingUsed
+		? 'expanded'
+		: undefined;
+};
+
 export const Discussion = ({
 	discussionApiUrl,
 	shortUrlId,
@@ -97,19 +109,14 @@ export const Discussion = ({
 	);
 
 	useEffect(() => {
-		const permalinkBeingUsed =
-			hashCommentId !== undefined && !Number.isNaN(hashCommentId);
-		const filterByPermalinks = (threads: ThreadsType) =>
-			threads === 'collapsed' && permalinkBeingUsed
-				? 'expanded'
-				: undefined;
 		const orderByClosed = isClosedForComments ? 'oldest' : undefined;
 
 		setFilters((prevFilters) => ({
 			orderBy: commentOrderBy ?? orderByClosed ?? prevFilters.orderBy,
 			pageSize: commentPageSize ?? prevFilters.pageSize,
 			threads:
-				filterByPermalinks(prevFilters.threads) ?? prevFilters.threads,
+				filterByPermalinks(prevFilters.threads, hashCommentId) ??
+				prevFilters.threads,
 		}));
 	}, [commentPageSize, commentOrderBy, isClosedForComments, hashCommentId]);
 

--- a/dotcom-rendering/src/components/Discussion.tsx
+++ b/dotcom-rendering/src/components/Discussion.tsx
@@ -10,7 +10,11 @@ import {
 import { revealStyles } from '../lib/revealStyles';
 import { useDiscussion } from '../lib/useDiscussion';
 import { palette as themePalette } from '../palette';
-import type { FilterOptions, SignedInUser } from '../types/discussion';
+import type {
+	FilterOptions,
+	SignedInUser,
+	ThreadsType,
+} from '../types/discussion';
 import { Comments } from './Discussion/Comments';
 import { Hide } from './Hide';
 import { SignedInAs } from './SignedInAs';
@@ -95,8 +99,8 @@ export const Discussion = ({
 	useEffect(() => {
 		const permalinkBeingUsed =
 			hashCommentId !== undefined && !Number.isNaN(hashCommentId);
-		const filterByPermalinks =
-			filters.threads === 'collapsed' && permalinkBeingUsed
+		const filterByPermalinks = (threads: ThreadsType) =>
+			threads === 'collapsed' && permalinkBeingUsed
 				? 'expanded'
 				: undefined;
 		const orderByClosed = isClosedForComments ? 'oldest' : undefined;
@@ -105,7 +109,8 @@ export const Discussion = ({
 			...prevFilters,
 			orderBy: commentOrderBy ?? orderByClosed ?? prevFilters.orderBy,
 			pageSize: commentPageSize ?? prevFilters.pageSize,
-			threads: filterByPermalinks ?? prevFilters.threads,
+			threads:
+				filterByPermalinks(prevFilters.threads) ?? prevFilters.threads,
 		}));
 	}, [commentPageSize, commentOrderBy, isClosedForComments, hashCommentId]);
 

--- a/dotcom-rendering/src/components/Discussion.tsx
+++ b/dotcom-rendering/src/components/Discussion.tsx
@@ -3,7 +3,10 @@ import { joinUrl, storage } from '@guardian/libs';
 import { palette, space } from '@guardian/source-foundations';
 import { Button, SvgPlus } from '@guardian/source-react-components';
 import { useEffect, useState } from 'react';
-import { getCommentContext } from '../lib/getCommentContext';
+import {
+	getCommentContext,
+	initFiltersFromLocalStorage,
+} from '../lib/getCommentContext';
 import { revealStyles } from '../lib/revealStyles';
 import { useDiscussion } from '../lib/useDiscussion';
 import { palette as themePalette } from '../palette';
@@ -11,7 +14,6 @@ import type { FilterOptions, SignedInUser } from '../types/discussion';
 import { Comments } from './Discussion/Comments';
 import { Hide } from './Hide';
 import { SignedInAs } from './SignedInAs';
-import { initFiltersFromLocalStorage } from '../lib/getCommentContext';
 
 export type Props = {
 	discussionApiUrl: string;

--- a/dotcom-rendering/src/components/Discussion.tsx
+++ b/dotcom-rendering/src/components/Discussion.tsx
@@ -121,7 +121,7 @@ export const Discussion = ({
 		}),
 	);
 
-	// If these override props are updated we want to respect them
+	// If these override values are updated we want to respect them
 	useEffect(() => {
 		const newFilters = {
 			...filters,

--- a/dotcom-rendering/src/components/Discussion/Comments.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comments.stories.tsx
@@ -111,44 +111,6 @@ InitialPage.decorators = [
 	]),
 ];
 
-// we dont need this now but the logic should be tested in discussion tests
-// export const Overrides = () => (
-// 	<div
-// 		css={css`
-// 			width: 100%;
-// 			max-width: 620px;
-// 		`}
-// 	>
-// 		<Comments
-// 			shortUrl="p/39f5z"
-// 			baseUrl="https://discussion.theguardian.com/discussion-api"
-// 			isClosedForComments={false}
-// 			additionalHeaders={{
-// 				'D2-X-UID': 'testD2Header',
-// 				'GU-Client': 'testClientHeader',
-// 			}}
-// 			expanded={true}
-// 			onPermalinkClick={() => {}}
-// 			onExpand={() => {}}
-// 			apiKey=""
-// 			idApiUrl="https://idapi.theguardian.com"
-// 			page={3}
-// 			setPage={() => {}}
-// 			filters={filters}
-// 			setFilters={() => {}}
-// 		/>
-// 	</div>
-// );
-// Overrides.storyName = 'with page size overridden to 50';
-// Overrides.decorators = [
-// 	splitTheme([
-// 		{
-// 			...format,
-// 			theme: Pillar.Opinion,
-// 		},
-// 	]),
-// ];
-
 export const LoggedInHiddenNoPicks = () => (
 	<div
 		css={css`

--- a/dotcom-rendering/src/components/Discussion/Comments.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comments.stories.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/react';
 import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
 import { splitTheme } from '../../../.storybook/decorators/splitThemeDecorator';
 import { lightDecorator } from '../../../.storybook/decorators/themeDecorator';
-import type { SignedInUser } from '../../types/discussion';
+import type { FilterOptions, SignedInUser } from '../../types/discussion';
 import { Comments } from './Comments';
 
 export default { component: Comments, title: 'Discussion/App' };
@@ -31,6 +31,12 @@ const format = {
 	theme: Pillar.News,
 };
 
+const filters: FilterOptions = {
+	threads: 'collapsed',
+	pageSize: 25,
+	orderBy: 'newest',
+};
+
 export const LoggedOutHiddenPicks = () => (
 	<div
 		css={css`
@@ -53,6 +59,8 @@ export const LoggedOutHiddenPicks = () => (
 			idApiUrl="https://idapi.theguardian.com"
 			page={3}
 			setPage={() => {}}
+			filters={filters}
+			setFilters={() => {}}
 		/>
 	</div>
 );
@@ -88,6 +96,8 @@ export const InitialPage = () => (
 			idApiUrl="https://idapi.theguardian.com"
 			page={3}
 			setPage={() => {}}
+			filters={filters}
+			setFilters={() => {}}
 		/>
 	</div>
 );
@@ -101,42 +111,43 @@ InitialPage.decorators = [
 	]),
 ];
 
-export const Overrides = () => (
-	<div
-		css={css`
-			width: 100%;
-			max-width: 620px;
-		`}
-	>
-		<Comments
-			shortUrl="p/39f5z"
-			pageSizeOverride={50}
-			orderByOverride="recommendations"
-			baseUrl="https://discussion.theguardian.com/discussion-api"
-			isClosedForComments={false}
-			additionalHeaders={{
-				'D2-X-UID': 'testD2Header',
-				'GU-Client': 'testClientHeader',
-			}}
-			expanded={true}
-			onPermalinkClick={() => {}}
-			onExpand={() => {}}
-			apiKey=""
-			idApiUrl="https://idapi.theguardian.com"
-			page={3}
-			setPage={() => {}}
-		/>
-	</div>
-);
-Overrides.storyName = 'with page size overridden to 50';
-Overrides.decorators = [
-	splitTheme([
-		{
-			...format,
-			theme: Pillar.Opinion,
-		},
-	]),
-];
+// we dont need this now but the logic should be tested in discussion tests
+// export const Overrides = () => (
+// 	<div
+// 		css={css`
+// 			width: 100%;
+// 			max-width: 620px;
+// 		`}
+// 	>
+// 		<Comments
+// 			shortUrl="p/39f5z"
+// 			baseUrl="https://discussion.theguardian.com/discussion-api"
+// 			isClosedForComments={false}
+// 			additionalHeaders={{
+// 				'D2-X-UID': 'testD2Header',
+// 				'GU-Client': 'testClientHeader',
+// 			}}
+// 			expanded={true}
+// 			onPermalinkClick={() => {}}
+// 			onExpand={() => {}}
+// 			apiKey=""
+// 			idApiUrl="https://idapi.theguardian.com"
+// 			page={3}
+// 			setPage={() => {}}
+// 			filters={filters}
+// 			setFilters={() => {}}
+// 		/>
+// 	</div>
+// );
+// Overrides.storyName = 'with page size overridden to 50';
+// Overrides.decorators = [
+// 	splitTheme([
+// 		{
+// 			...format,
+// 			theme: Pillar.Opinion,
+// 		},
+// 	]),
+// ];
 
 export const LoggedInHiddenNoPicks = () => (
 	<div
@@ -161,6 +172,8 @@ export const LoggedInHiddenNoPicks = () => (
 			idApiUrl="https://idapi.theguardian.com"
 			page={3}
 			setPage={() => {}}
+			filters={filters}
+			setFilters={() => {}}
 		/>
 	</div>
 );
@@ -191,6 +204,8 @@ export const LoggedIn = () => (
 			idApiUrl="https://idapi.theguardian.com"
 			page={3}
 			setPage={() => {}}
+			filters={filters}
+			setFilters={() => {}}
 		/>
 	</div>
 );
@@ -220,6 +235,8 @@ export const LoggedInShortDiscussion = () => (
 			idApiUrl="https://idapi.theguardian.com"
 			page={3}
 			setPage={() => {}}
+			filters={filters}
+			setFilters={() => {}}
 		/>
 	</div>
 );
@@ -248,6 +265,8 @@ export const LoggedOutHiddenNoPicks = () => (
 			idApiUrl="https://idapi.theguardian.com"
 			page={3}
 			setPage={() => {}}
+			filters={filters}
+			setFilters={() => {}}
 		/>
 	</div>
 );
@@ -285,6 +304,8 @@ export const Closed = () => (
 			idApiUrl="https://idapi.theguardian.com"
 			page={3}
 			setPage={() => {}}
+			filters={filters}
+			setFilters={() => {}}
 		/>
 	</div>
 );
@@ -320,6 +341,8 @@ export const NoComments = () => (
 			idApiUrl="https://idapi.theguardian.com"
 			page={3}
 			setPage={() => {}}
+			filters={filters}
+			setFilters={() => {}}
 		/>
 	</div>
 );
@@ -355,6 +378,8 @@ export const LegacyDiscussion = () => (
 			idApiUrl="https://idapi.theguardian.com"
 			page={3}
 			setPage={() => {}}
+			filters={filters}
+			setFilters={() => {}}
 		/>
 	</div>
 );

--- a/dotcom-rendering/src/components/Discussion/Comments.test.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comments.test.tsx
@@ -29,6 +29,12 @@ describe('App', () => {
 				idApiUrl="https://idapi.theguardian.com"
 				page={3}
 				setPage={() => {}}
+				filters={{
+					threads: 'collapsed',
+					pageSize: 25,
+					orderBy: 'newest',
+				}}
+				setFilters={() => {}}
 			/>,
 		);
 

--- a/dotcom-rendering/src/components/Discussion/Comments.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comments.tsx
@@ -24,6 +24,7 @@ import { Filters } from './Filters';
 import { LoadingComments } from './LoadingComments';
 import { Pagination } from './Pagination';
 import { TopPicks } from './TopPicks';
+
 type Props = {
 	shortUrl: string;
 	baseUrl: string;

--- a/dotcom-rendering/src/components/Discussion/Comments.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comments.tsx
@@ -202,6 +202,8 @@ export const Comments = ({
 		if (page > maxPagePossible) setPage(maxPagePossible);
 
 		setFilters(newFilterObject);
+		// Filters also show when the view is not expanded but we want to expand when they're changed
+		onExpand();
 	};
 
 	useEffect(() => {

--- a/dotcom-rendering/src/components/Discussion/Comments.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comments.tsx
@@ -172,11 +172,11 @@ export const Comments = ({
 		void fetchPicks();
 	}, [shortUrl]);
 
-	// Check if there is a comment to scroll to and if
-	// so, scroll to the div with this id.
-	// We need to do this in javascript like this because the comments list isn't
-	// loaded on the inital page load and only gets added to the dom later, after
-	// an api call is made.
+	/**
+	 * Verify if there is a comment to scroll to; if found, scroll to the corresponding div.
+	 * This JavaScript is necessary because the comments list isn't initially loaded with the
+	 * page and is added to the DOM later, following an API call.
+	 * */
 	useEffect(() => {
 		if (commentToScrollTo !== undefined) {
 			const commentElement = document.getElementById(
@@ -188,14 +188,12 @@ export const Comments = ({
 
 	const onFilterChange = (newFilterObject: FilterOptions) => {
 		/**
-		 *
-		 * If we're reducing the page size, we might need to adjust the current page to avoid
-		 * requesting non-existent pages. For example, if we initially had 102 comments with a
-		 * page size of 25, the current page could be 5 (showing 2 comments).
-		 *
-		 * If we then change the page size to 50, there's no longer a page 5. To respect the
-		 * reader's desire to stay on the last page, we calculate the maximum possible page
-		 * and use that instead.
+		 * When decreasing the page size, we adjust the current page
+		 * to avoid requesting non-existent pages. For example,
+		 * if we had 102 comments with a page size of 25, and the current
+		 * page was 5 (showing 2 comments), reducing the page size to 50 eliminates page 5.
+		 * To respect the reader's preference to stay on the last page,
+		 * we calculate and use the maximum possible page instead.
 		 */
 		const maxPagePossible = Math.ceil(
 			commentCount / newFilterObject.pageSize,

--- a/dotcom-rendering/src/components/Discussion/Comments.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comments.tsx
@@ -314,7 +314,7 @@ export const Comments = ({
 	useEffect(() => {
 		const element = document.getElementById('comment-filters');
 		element?.scrollIntoView();
-	}, [page]);
+	}, [page, onExpand]);
 
 	const toggleMuteStatus = (userId: string) => {
 		let updatedMutes;

--- a/dotcom-rendering/src/components/Discussion/Comments.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comments.tsx
@@ -314,7 +314,7 @@ export const Comments = ({
 	useEffect(() => {
 		const element = document.getElementById('comment-filters');
 		element?.scrollIntoView();
-	}, [page, onExpand]);
+	}, [page]);
 
 	const toggleMuteStatus = (userId: string) => {
 		let updatedMutes;

--- a/dotcom-rendering/src/components/Discussion/Comments.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comments.tsx
@@ -238,7 +238,7 @@ export const Comments = ({
 		commentElement?.scrollIntoView();
 	};
 
-	const handleSetPage = (pageNumber: number) => {
+	const onPageChange = (pageNumber: number) => {
 		setPage(pageNumber);
 		onExpand();
 	};
@@ -274,7 +274,7 @@ export const Comments = ({
 							<Pagination
 								totalPages={totalPages}
 								currentPage={page}
-								setCurrentPage={handleSetPage}
+								setCurrentPage={onPageChange}
 								commentCount={commentCount}
 								filters={filters}
 							/>
@@ -343,7 +343,7 @@ export const Comments = ({
 				<Pagination
 					totalPages={totalPages}
 					currentPage={page}
-					setCurrentPage={handleSetPage}
+					setCurrentPage={onPageChange}
 					commentCount={commentCount}
 					filters={filters}
 				/>
@@ -387,7 +387,7 @@ export const Comments = ({
 					<Pagination
 						totalPages={totalPages}
 						currentPage={page}
-						setCurrentPage={handleSetPage}
+						setCurrentPage={onPageChange}
 						commentCount={commentCount}
 						filters={filters}
 					/>

--- a/dotcom-rendering/src/components/Discussion/Filters.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/Filters.stories.tsx
@@ -16,7 +16,6 @@ export const Default = () => {
 		<Filters
 			filters={filters}
 			onFilterChange={setFilters}
-			totalPages={5}
 			commentCount={74}
 		/>
 	);

--- a/dotcom-rendering/src/components/Discussion/Filters.tsx
+++ b/dotcom-rendering/src/components/Discussion/Filters.tsx
@@ -11,7 +11,6 @@ import { Dropdown } from './Dropdown';
 type Props = {
 	filters: FilterOptions;
 	onFilterChange: (newFilterObject: FilterOptions) => void;
-	totalPages: number;
 	commentCount: number;
 };
 
@@ -44,12 +43,7 @@ const filterPadding = css`
 	padding-right: ${space[3]}px;
 `;
 
-export const Filters = ({
-	filters,
-	onFilterChange,
-	totalPages,
-	commentCount,
-}: Props) => (
+export const Filters = ({ filters, onFilterChange, commentCount }: Props) => (
 	<div id="comment-filters" css={filterBar}>
 		<div css={filterPadding}>
 			<Dropdown

--- a/dotcom-rendering/src/lib/getCommentContext.ts
+++ b/dotcom-rendering/src/lib/getCommentContext.ts
@@ -41,17 +41,24 @@ interface FilterOptions {
 	threads: ThreadsType;
 }
 
-const getOrderByType = (value: unknown) =>
-	isString(value) && isOneOf(orderByTypes)(value) ? value : 'newest';
+const getOrderByType = (value: unknown, isClosedForComment?: boolean) =>
+	isString(value) && isOneOf(orderByTypes)(value)
+		? value
+		: isClosedForComment
+		? 'oldest'
+		: 'newest';
 const getThreadType = (value: unknown) =>
 	isString(value) && isOneOf(threadTypes)(value) ? value : 'collapsed';
 const getPageSizeType = (value: unknown) =>
 	typeof value === 'number' && isOneOf(pageSizeTypes)(value) ? value : 25;
 
 /** Retrieves stored values from local storage if available, otherwise it returns defaults */
-const initFiltersFromLocalStorage = (): FilterOptions => {
+export const initFiltersFromLocalStorage = (
+	isClosedForComment?: boolean,
+): FilterOptions => {
 	const orderBy: OrderByType = getOrderByType(
 		storage.local.get('gu.prefs.discussion.order'),
+		isClosedForComment,
 	);
 	const threads: ThreadsType = getThreadType(
 		storage.local.get('gu.prefs.discussion.threading'),

--- a/dotcom-rendering/src/lib/getCommentContext.ts
+++ b/dotcom-rendering/src/lib/getCommentContext.ts
@@ -41,12 +41,8 @@ interface FilterOptions {
 	threads: ThreadsType;
 }
 
-const getOrderByType = (value: unknown, isClosedForComment?: boolean) =>
-	isString(value) && isOneOf(orderByTypes)(value)
-		? value
-		: isClosedForComment
-		? 'oldest'
-		: 'newest';
+const getOrderByType = (value: unknown) =>
+	isString(value) && isOneOf(orderByTypes)(value) ? value : 'newest';
 const getThreadType = (value: unknown) =>
 	isString(value) && isOneOf(threadTypes)(value) ? value : 'collapsed';
 const getPageSizeType = (value: unknown) =>
@@ -58,7 +54,6 @@ export const initFiltersFromLocalStorage = (
 ): FilterOptions => {
 	const orderBy: OrderByType = getOrderByType(
 		storage.local.get('gu.prefs.discussion.order'),
-		isClosedForComment,
 	);
 	const threads: ThreadsType = getThreadType(
 		storage.local.get('gu.prefs.discussion.threading'),

--- a/dotcom-rendering/src/lib/getCommentContext.ts
+++ b/dotcom-rendering/src/lib/getCommentContext.ts
@@ -49,9 +49,7 @@ const getPageSizeType = (value: unknown) =>
 	typeof value === 'number' && isOneOf(pageSizeTypes)(value) ? value : 25;
 
 /** Retrieves stored values from local storage if available, otherwise it returns defaults */
-export const initFiltersFromLocalStorage = (
-	isClosedForComment?: boolean,
-): FilterOptions => {
+export const initFiltersFromLocalStorage = (): FilterOptions => {
 	const orderBy: OrderByType = getOrderByType(
 		storage.local.get('gu.prefs.discussion.order'),
 	);


### PR DESCRIPTION
## What does this change?
Lifts the state ownership of filters up to discussion out of comments.

## Why?

 Previously, we initialised filters in discussion then passed them down with overrides to comments for them to be re-initialised. Now, discussions is responsible to initialising updating and storing filter preferences, removing duplicated state.

This is part of https://github.com/guardian/dotcom-rendering/issues/10228