### PR TITLE
`font-size` And `line-height` Should Be In `rem`

### DIFF
--- a/dotcom-rendering/src/components/ArticleHeadline.tsx
+++ b/dotcom-rendering/src/components/ArticleHeadline.tsx
@@ -44,10 +44,10 @@ const standardFont = css`
 
 const labsFont = css`
 	${textSans.xlarge({ fontWeight: 'bold' })};
-	line-height: 32px;
+	line-height: 2rem;
 	${from.tablet} {
 		${textSans.xxxlarge({ fontWeight: 'bold' })};
-		line-height: 38px;
+		line-height: 2.375rem;
 	}
 `;
 
@@ -60,7 +60,7 @@ const boldFont = css`
 
 const jumboFont = css`
 	${headline.xlarge({ fontWeight: 'bold' })};
-	line-height: 56px;
+	line-height: 3.5rem;
 	${until.desktop} {
 		${headline.medium({ fontWeight: 'bold' })};
 	}
@@ -68,21 +68,20 @@ const jumboFont = css`
 
 const jumboLabsFont = css`
 	${textSans.xxxlarge({ fontWeight: 'bold' })};
-	font-size: 50px;
-	line-height: 56px;
+	font-size: 3.125rem;
+	line-height: 3.5rem;
 	${until.desktop} {
-		${textSans.xxlarge({ fontWeight: 'bold' })};
-		font-size: 34px;
-		line-height: 38px;
+		${textSans.xxxlarge({ fontWeight: 'bold' })};
+		line-height: 2.375rem;
 	}
 `;
 
 const invertedFont = css`
 	${headline.medium({ fontWeight: 'bold' })};
-	line-height: 42px;
+	line-height: 2.625rem;
 	${until.tablet} {
 		${headline.small({ fontWeight: 'bold' })};
-		line-height: 35px;
+		line-height: 2.1875rem;
 	}
 `;
 


### PR DESCRIPTION
So that text can scale correctly. For example, in apps scaling is achieved by increasing the root font size. Text sizes must be expressed in `rem`s to be scaled proportional to this root font size change.

Fixes #10266.

## Screenshots

Consequences for `ArticleDesign.Interview` headlines, when scaled to 1.5x:

| Before | After |
| - | - |
| ![text-scale-before] | ![text-scale-after] |

[text-scale-after]: https://github.com/guardian/dotcom-rendering/assets/53781962/33d16023-7ed9-464d-90ce-43d9b515d697
[text-scale-before]: https://github.com/guardian/dotcom-rendering/assets/53781962/6598168b-022f-44f2-aeba-13fb8ebdc75b
