### PR TITLE
Remove puzzles banner

### DIFF
--- a/dotcom-rendering/fixtures/config.js
+++ b/dotcom-rendering/fixtures/config.js
@@ -10,7 +10,6 @@ module.exports = {
 		switches: {
 			prebidAppnexusUkRow: true,
 			clickToView: true,
-			abPuzzlesBanner: true,
 			prebidTrustx: true,
 			scAdFreeBanner: false,
 			compareVariantDecision: false,

--- a/dotcom-rendering/fixtures/generated/articles/Analysis.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Analysis.ts
@@ -2212,7 +2212,6 @@ export const Analysis: DCRArticle = {
 		switches: {
 			prebidAppnexusUkRow: true,
 			clickToView: true,
-			abPuzzlesBanner: true,
 			prebidTrustx: true,
 			scAdFreeBanner: false,
 			compareVariantDecision: false,

--- a/dotcom-rendering/fixtures/generated/articles/Audio.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Audio.ts
@@ -2066,7 +2066,6 @@ export const Audio: DCRArticle = {
 		switches: {
 			prebidAppnexusUkRow: true,
 			clickToView: true,
-			abPuzzlesBanner: true,
 			prebidTrustx: true,
 			scAdFreeBanner: false,
 			compareVariantDecision: false,

--- a/dotcom-rendering/fixtures/generated/articles/Comment.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Comment.ts
@@ -1936,7 +1936,6 @@ export const Comment: DCRArticle = {
 		switches: {
 			prebidAppnexusUkRow: true,
 			clickToView: true,
-			abPuzzlesBanner: true,
 			prebidTrustx: true,
 			scAdFreeBanner: false,
 			compareVariantDecision: false,

--- a/dotcom-rendering/fixtures/generated/articles/Dead.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Dead.ts
@@ -4500,7 +4500,6 @@ export const Dead: DCRArticle = {
 		switches: {
 			prebidAppnexusUkRow: true,
 			clickToView: true,
-			abPuzzlesBanner: true,
 			prebidTrustx: true,
 			scAdFreeBanner: false,
 			compareVariantDecision: false,

--- a/dotcom-rendering/fixtures/generated/articles/Editorial.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Editorial.ts
@@ -1840,7 +1840,6 @@ export const Editorial: DCRArticle = {
 		switches: {
 			prebidAppnexusUkRow: true,
 			clickToView: true,
-			abPuzzlesBanner: true,
 			prebidTrustx: true,
 			scAdFreeBanner: false,
 			compareVariantDecision: false,

--- a/dotcom-rendering/fixtures/generated/articles/Explainer.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Explainer.ts
@@ -2751,7 +2751,6 @@ export const Explainer: DCRArticle = {
 		switches: {
 			prebidAppnexusUkRow: true,
 			clickToView: true,
-			abPuzzlesBanner: true,
 			prebidTrustx: true,
 			scAdFreeBanner: false,
 			compareVariantDecision: false,

--- a/dotcom-rendering/fixtures/generated/articles/Feature.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Feature.ts
@@ -2343,7 +2343,6 @@ export const Feature: DCRArticle = {
 		switches: {
 			prebidAppnexusUkRow: true,
 			clickToView: true,
-			abPuzzlesBanner: true,
 			prebidTrustx: true,
 			scAdFreeBanner: false,
 			compareVariantDecision: false,

--- a/dotcom-rendering/fixtures/generated/articles/Gallery.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Gallery.ts
@@ -2066,7 +2066,6 @@ export const Gallery: DCRArticle = {
 		switches: {
 			prebidAppnexusUkRow: true,
 			clickToView: true,
-			abPuzzlesBanner: true,
 			prebidTrustx: true,
 			scAdFreeBanner: false,
 			compareVariantDecision: false,

--- a/dotcom-rendering/fixtures/generated/articles/Interview.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Interview.ts
@@ -3677,7 +3677,6 @@ export const Interview: DCRArticle = {
 		switches: {
 			prebidAppnexusUkRow: true,
 			clickToView: true,
-			abPuzzlesBanner: true,
 			prebidTrustx: true,
 			scAdFreeBanner: false,
 			compareVariantDecision: false,

--- a/dotcom-rendering/fixtures/generated/articles/Labs.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Labs.ts
@@ -2822,7 +2822,6 @@ export const Labs: DCRArticle = {
 		switches: {
 			prebidAppnexusUkRow: true,
 			clickToView: true,
-			abPuzzlesBanner: true,
 			prebidTrustx: true,
 			scAdFreeBanner: false,
 			compareVariantDecision: false,

--- a/dotcom-rendering/fixtures/generated/articles/Letter.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Letter.ts
@@ -1704,7 +1704,6 @@ export const Letter: DCRArticle = {
 		switches: {
 			prebidAppnexusUkRow: true,
 			clickToView: true,
-			abPuzzlesBanner: true,
 			prebidTrustx: true,
 			scAdFreeBanner: false,
 			compareVariantDecision: false,

--- a/dotcom-rendering/fixtures/generated/articles/Live.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Live.ts
@@ -4500,7 +4500,6 @@ export const Live: DCRArticle = {
 		switches: {
 			prebidAppnexusUkRow: true,
 			clickToView: true,
-			abPuzzlesBanner: true,
 			prebidTrustx: true,
 			scAdFreeBanner: false,
 			compareVariantDecision: false,

--- a/dotcom-rendering/fixtures/generated/articles/LiveBlogSingleContributor.ts
+++ b/dotcom-rendering/fixtures/generated/articles/LiveBlogSingleContributor.ts
@@ -5612,7 +5612,6 @@ export const LiveBlogSingleContributor: DCRArticle = {
 		switches: {
 			prebidAppnexusUkRow: true,
 			clickToView: true,
-			abPuzzlesBanner: true,
 			prebidTrustx: true,
 			scAdFreeBanner: false,
 			compareVariantDecision: false,

--- a/dotcom-rendering/fixtures/generated/articles/MatchReport.ts
+++ b/dotcom-rendering/fixtures/generated/articles/MatchReport.ts
@@ -1835,7 +1835,6 @@ export const MatchReport: DCRArticle = {
 		switches: {
 			prebidAppnexusUkRow: true,
 			clickToView: true,
-			abPuzzlesBanner: true,
 			prebidTrustx: true,
 			scAdFreeBanner: false,
 			compareVariantDecision: false,

--- a/dotcom-rendering/fixtures/generated/articles/NewsletterSignup.ts
+++ b/dotcom-rendering/fixtures/generated/articles/NewsletterSignup.ts
@@ -1781,7 +1781,6 @@ export const NewsletterSignup: DCRArticle = {
 		switches: {
 			prebidAppnexusUkRow: true,
 			clickToView: true,
-			abPuzzlesBanner: true,
 			prebidTrustx: true,
 			scAdFreeBanner: false,
 			compareVariantDecision: false,

--- a/dotcom-rendering/fixtures/generated/articles/NumberedList.ts
+++ b/dotcom-rendering/fixtures/generated/articles/NumberedList.ts
@@ -7805,7 +7805,6 @@ export const NumberedList: DCRArticle = {
 		switches: {
 			prebidAppnexusUkRow: true,
 			clickToView: true,
-			abPuzzlesBanner: true,
 			prebidTrustx: true,
 			scAdFreeBanner: false,
 			compareVariantDecision: false,

--- a/dotcom-rendering/fixtures/generated/articles/PhotoEssay.ts
+++ b/dotcom-rendering/fixtures/generated/articles/PhotoEssay.ts
@@ -8929,7 +8929,6 @@ export const PhotoEssay: DCRArticle = {
 		switches: {
 			prebidAppnexusUkRow: true,
 			clickToView: true,
-			abPuzzlesBanner: true,
 			prebidTrustx: true,
 			scAdFreeBanner: false,
 			compareVariantDecision: false,

--- a/dotcom-rendering/fixtures/generated/articles/Picture.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Picture.ts
@@ -1739,7 +1739,6 @@ export const Picture: DCRArticle = {
 		switches: {
 			prebidAppnexusUkRow: true,
 			clickToView: true,
-			abPuzzlesBanner: true,
 			prebidTrustx: true,
 			scAdFreeBanner: false,
 			compareVariantDecision: false,

--- a/dotcom-rendering/fixtures/generated/articles/PrintShop.ts
+++ b/dotcom-rendering/fixtures/generated/articles/PrintShop.ts
@@ -1812,7 +1812,6 @@ export const PrintShop: DCRArticle = {
 		switches: {
 			prebidAppnexusUkRow: true,
 			clickToView: true,
-			abPuzzlesBanner: true,
 			prebidTrustx: true,
 			scAdFreeBanner: false,
 			compareVariantDecision: false,

--- a/dotcom-rendering/fixtures/generated/articles/Quiz.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Quiz.ts
@@ -2356,7 +2356,6 @@ export const Quiz: DCRArticle = {
 		switches: {
 			prebidAppnexusUkRow: true,
 			clickToView: true,
-			abPuzzlesBanner: true,
 			prebidTrustx: true,
 			scAdFreeBanner: false,
 			compareVariantDecision: false,

--- a/dotcom-rendering/fixtures/generated/articles/Recipe.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Recipe.ts
@@ -1914,7 +1914,6 @@ export const Recipe: DCRArticle = {
 		switches: {
 			prebidAppnexusUkRow: true,
 			clickToView: true,
-			abPuzzlesBanner: true,
 			prebidTrustx: true,
 			scAdFreeBanner: false,
 			compareVariantDecision: false,

--- a/dotcom-rendering/fixtures/generated/articles/Review.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Review.ts
@@ -2193,7 +2193,6 @@ export const Review: DCRArticle = {
 		switches: {
 			prebidAppnexusUkRow: true,
 			clickToView: true,
-			abPuzzlesBanner: true,
 			prebidTrustx: true,
 			scAdFreeBanner: false,
 			compareVariantDecision: false,

--- a/dotcom-rendering/fixtures/generated/articles/SpecialReport.ts
+++ b/dotcom-rendering/fixtures/generated/articles/SpecialReport.ts
@@ -2243,7 +2243,6 @@ export const SpecialReport: DCRArticle = {
 		switches: {
 			prebidAppnexusUkRow: true,
 			clickToView: true,
-			abPuzzlesBanner: true,
 			prebidTrustx: true,
 			scAdFreeBanner: false,
 			compareVariantDecision: false,

--- a/dotcom-rendering/fixtures/generated/articles/Standard.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Standard.ts
@@ -2066,7 +2066,6 @@ export const Standard: DCRArticle = {
 		switches: {
 			prebidAppnexusUkRow: true,
 			clickToView: true,
-			abPuzzlesBanner: true,
 			prebidTrustx: true,
 			scAdFreeBanner: false,
 			compareVariantDecision: false,

--- a/dotcom-rendering/fixtures/generated/articles/Video.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Video.ts
@@ -2066,7 +2066,6 @@ export const Video: DCRArticle = {
 		switches: {
 			prebidAppnexusUkRow: true,
 			clickToView: true,
-			abPuzzlesBanner: true,
 			prebidTrustx: true,
 			scAdFreeBanner: false,
 			compareVariantDecision: false,

--- a/dotcom-rendering/playwright/fixtures/manual/standard-article.js
+++ b/dotcom-rendering/playwright/fixtures/manual/standard-article.js
@@ -1406,7 +1406,6 @@ export const standardArticle = {
 			verticalVideoSurvey: false,
 			okta: true,
 			abDeeplyReadArticleFooter: false,
-			puzzlesBanner: false,
 			imrWorldwide: true,
 			acast: true,
 			automaticFilters: true,

--- a/dotcom-rendering/scripts/perf/k6/article-nier-automata.json
+++ b/dotcom-rendering/scripts/perf/k6/article-nier-automata.json
@@ -1581,7 +1581,6 @@
 			"verticalVideoSurvey": false,
 			"okta": true,
 			"abDeeplyReadArticleFooter": false,
-			"puzzlesBanner": false,
 			"imrWorldwide": true,
 			"acast": true,
 			"automaticFilters": true,

--- a/dotcom-rendering/src/components/Island.test.tsx
+++ b/dotcom-rendering/src/components/Island.test.tsx
@@ -414,7 +414,6 @@ describe('Island: server-side rendering', () => {
 						pageId=""
 						keywordIds=""
 						remoteBannerSwitch={true}
-						puzzleBannerSwitch={false}
 						isSensitive={false}
 					/>
 				</ConfigProvider>,

--- a/dotcom-rendering/src/components/StickyBottomBanner.importable.tsx
+++ b/dotcom-rendering/src/components/StickyBottomBanner.importable.tsx
@@ -26,9 +26,7 @@ import {
 	canShowBrazeBanner,
 } from './StickyBottomBanner/BrazeBanner';
 import {
-	canShowPuzzlesBanner,
 	canShowRRBanner,
-	PuzzlesBanner,
 	ReaderRevenueBanner,
 } from './StickyBottomBanner/ReaderRevenueBanner';
 import type {
@@ -166,14 +164,6 @@ const buildRRBannerConfigWith = ({
 	};
 };
 
-const buildPuzzlesBannerConfig = (isEnabled: boolean) =>
-	buildRRBannerConfigWith({
-		id: 'puzzles-banner',
-		BannerComponent: PuzzlesBanner,
-		canShowFn: canShowPuzzlesBanner,
-		isEnabled,
-	});
-
 const buildReaderRevenueBannerConfig = (isEnabled: boolean) =>
 	buildRRBannerConfigWith({
 		id: 'reader-revenue-banner',
@@ -230,10 +220,8 @@ export const StickyBottomBanner = ({
 	pageId,
 	keywordIds,
 	remoteBannerSwitch,
-	puzzleBannerSwitch,
 }: Props & {
 	remoteBannerSwitch: boolean;
-	puzzleBannerSwitch: boolean;
 	isSensitive: boolean;
 }) => {
 	const { renderingTarget } = useConfig();
@@ -263,23 +251,7 @@ export const StickyBottomBanner = ({
 	useOnce(() => {
 		if (!countryCode) return;
 		const CMP = buildCmpBannerConfig();
-		const puzzlesBanner = buildPuzzlesBannerConfig(puzzleBannerSwitch)({
-			isSignedIn,
-			countryCode,
-			isPreview,
-			asyncArticleCounts: asyncArticleCounts as Promise<
-				ArticleCounts | undefined
-			>,
-			contentType,
-			sectionId,
-			shouldHideReaderRevenue,
-			isMinuteArticle,
-			isPaidContent,
-			isSensitive,
-			tags,
-			contributionsServiceUrl,
-			idApiUrl,
-		});
+
 		const readerRevenue = buildReaderRevenueBannerConfig(
 			remoteBannerSwitch,
 		)({
@@ -311,7 +283,7 @@ export const StickyBottomBanner = ({
 			shouldHideReaderRevenue,
 		);
 		const bannerConfig: SlotConfig = {
-			candidates: [CMP, brazeBanner, puzzlesBanner, readerRevenue],
+			candidates: [CMP, brazeBanner, readerRevenue],
 			name: 'banner',
 		};
 

--- a/dotcom-rendering/src/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/dotcom-rendering/src/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -1,10 +1,7 @@
 import { css } from '@emotion/react';
 import type { CountryCode } from '@guardian/libs';
 import { getCookie } from '@guardian/libs';
-import {
-	getBanner,
-	getPuzzlesBanner,
-} from '@guardian/support-dotcom-components';
+import { getBanner } from '@guardian/support-dotcom-components';
 import type {
 	BannerPayload,
 	ModuleData,
@@ -237,64 +234,6 @@ export const canShowRRBanner: CanShowFunctionType<BannerProps> = async ({
 	return { show: true, meta: { module, meta, fetchEmail } };
 };
 
-export const canShowPuzzlesBanner: CanShowFunctionType<BannerProps> = async ({
-	remoteBannerConfig,
-	isSignedIn,
-	countryCode,
-	contentType,
-	sectionId,
-	shouldHideReaderRevenue,
-	isMinuteArticle,
-	isPaidContent,
-	isSensitive,
-	tags,
-	contributionsServiceUrl,
-	engagementBannerLastClosedAt,
-	subscriptionBannerLastClosedAt,
-	asyncArticleCounts,
-}) => {
-	const isPuzzlesPage =
-		sectionId === 'crosswords' ||
-		tags.some((tag) => tag.type === 'Series' && tag.title === 'Sudoku');
-
-	if (shouldHideReaderRevenue) {
-		// We never serve Reader Revenue banners in this case
-		return { show: false };
-	}
-
-	if (isPuzzlesPage && remoteBannerConfig) {
-		const optedOutOfArticleCount = await hasOptedOutOfArticleCount();
-		const bannerPayload = await buildPayload({
-			isSignedIn,
-			countryCode,
-			contentType,
-			sectionId,
-			shouldHideReaderRevenue,
-			isMinuteArticle,
-			isPaidContent,
-			tags,
-			contributionsServiceUrl,
-			isSensitive,
-			engagementBannerLastClosedAt,
-			subscriptionBannerLastClosedAt,
-			optedOutOfArticleCount,
-			asyncArticleCounts,
-		});
-		return getPuzzlesBanner(contributionsServiceUrl, bannerPayload).then(
-			(response: ModuleDataResponse) => {
-				if (!response.data) {
-					return { show: false };
-				}
-
-				const { module, meta } = response.data;
-				return { show: true, meta: { module, meta } };
-			},
-		);
-	}
-
-	return { show: false };
-};
-
 export type BannerProps = {
 	meta: TestTracking;
 	module: ModuleData;
@@ -381,14 +320,5 @@ export const ReaderRevenueBanner = ({
 		meta={meta}
 		module={module}
 		fetchEmail={fetchEmail}
-	/>
-);
-
-export const PuzzlesBanner = ({ meta, module }: BannerProps) => (
-	<RemoteBanner
-		componentTypeName="ACQUISITIONS_OTHER"
-		displayEvent="puzzles-banner : display"
-		meta={meta}
-		module={module}
 	/>
 );

--- a/dotcom-rendering/src/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/layouts/CommentLayout.tsx
@@ -983,9 +983,6 @@ export const CommentLayout = (props: WebProps | AppsProps) => {
 								remoteBannerSwitch={
 									!!article.config.switches.remoteBanner
 								}
-								puzzleBannerSwitch={
-									!!article.config.switches.puzzlesBanner
-								}
 								tags={article.tags}
 							/>
 						</Island>

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -733,9 +733,6 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 						remoteBannerSwitch={
 							!!front.config.switches.remoteBanner
 						}
-						puzzleBannerSwitch={
-							!!front.config.switches.puzzlesBanner
-						}
 						tags={[]} // a front doesn't have tags
 					/>
 				</Island>

--- a/dotcom-rendering/src/layouts/FullPageInteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/FullPageInteractiveLayout.tsx
@@ -406,9 +406,6 @@ export const FullPageInteractiveLayout = ({ article, NAV, format }: Props) => {
 						remoteBannerSwitch={
 							!!article.config.switches.remoteBanner
 						}
-						puzzleBannerSwitch={
-							!!article.config.switches.puzzlesBanner
-						}
 						tags={article.tags}
 					/>
 				</Island>

--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -1008,9 +1008,6 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 								remoteBannerSwitch={
 									!!article.config.switches.remoteBanner
 								}
-								puzzleBannerSwitch={
-									!!article.config.switches.puzzlesBanner
-								}
 								tags={article.tags}
 							/>
 						</Island>

--- a/dotcom-rendering/src/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/InteractiveLayout.tsx
@@ -931,9 +931,6 @@ export const InteractiveLayout = (props: WebProps | AppsProps) => {
 								remoteBannerSwitch={
 									!!article.config.switches.remoteBanner
 								}
-								puzzleBannerSwitch={
-									!!article.config.switches.puzzlesBanner
-								}
 								tags={article.tags}
 							/>
 						</Island>

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -1432,9 +1432,6 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 								remoteBannerSwitch={
 									!!article.config.switches.remoteBanner
 								}
-								puzzleBannerSwitch={
-									!!article.config.switches.puzzlesBanner
-								}
 								tags={article.tags}
 							/>
 						</Island>

--- a/dotcom-rendering/src/layouts/PictureLayout.tsx
+++ b/dotcom-rendering/src/layouts/PictureLayout.tsx
@@ -877,9 +877,6 @@ export const PictureLayout = (props: WebProps | AppsProps) => {
 								remoteBannerSwitch={
 									!!article.config.switches.remoteBanner
 								}
-								puzzleBannerSwitch={
-									!!article.config.switches.puzzlesBanner
-								}
 								tags={article.tags}
 							/>
 						</Island>

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -983,9 +983,6 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 								remoteBannerSwitch={
 									!!article.config.switches.remoteBanner
 								}
-								puzzleBannerSwitch={
-									!!article.config.switches.puzzlesBanner
-								}
 								tags={article.tags}
 							/>
 						</Island>

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -1084,9 +1084,6 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 								remoteBannerSwitch={
 									!!article.config.switches.remoteBanner
 								}
-								puzzleBannerSwitch={
-									!!article.config.switches.puzzlesBanner
-								}
 								tags={article.tags}
 							/>
 						</Island>

--- a/dotcom-rendering/src/layouts/lib/stickiness.tsx
+++ b/dotcom-rendering/src/layouts/lib/stickiness.tsx
@@ -30,7 +30,6 @@ const headerWrapper = css`
 `;
 
 // The css overrides here are necessary because ad-takeovers can inject css that breaks the banner
-// Overflow is visible because puzzles banner needs it to render correctly
 const bannerWrapper = css`
 	/* stylelint-disable-next-line declaration-no-important */
 	position: fixed !important;

--- a/dotcom-rendering/src/lib/useSDC.ts
+++ b/dotcom-rendering/src/lib/useSDC.ts
@@ -3,7 +3,6 @@ import {
 	getBanner,
 	getEpic,
 	getLiveblogEpic,
-	getPuzzlesBanner,
 } from '@guardian/support-dotcom-components';
 import type {
 	BannerPayload,
@@ -40,6 +39,3 @@ export const useSDCLiveblogEpic: UseSDC<EpicPayload> = (baseUrl, payload) =>
 
 export const useSDCBanner: UseSDC<BannerPayload> = (baseUrl, payload) =>
 	useSDC('banner', () => getBanner(baseUrl, payload));
-
-export const useSDCPuzzlesBanner: UseSDC<BannerPayload> = (baseUrl, payload) =>
-	useSDC('puzzles', () => getPuzzlesBanner(baseUrl, payload));


### PR DESCRIPTION
## What does this change?
Removes the puzzles banner from the StickyBottomBanner island.

## Why?
We no longer need it, and it's [being removed from SDC](https://github.com/guardian/support-dotcom-components/pull/1047) as well.

[Frontend PR](https://github.com/guardian/frontend/pull/26829)

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
