### PR TITLE
Disable `article-rendering` scaling alarm notifications in CODE

### DIFF
--- a/dotcom-rendering/cdk/lib/__snapshots__/renderingStack.test.ts.snap
+++ b/dotcom-rendering/cdk/lib/__snapshots__/renderingStack.test.ts.snap
@@ -665,18 +665,6 @@ exports[`The RenderingCDKStack matches the snapshot 1`] = `
           {
             "Ref": "LatencyScaleUpPolicyUpperPolicy4A22B34C",
           },
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:aws:sns:eu-west-1:",
-                {
-                  "Ref": "AWS::AccountId",
-                },
-                ":Frontend-TEST-CriticalAlerts",
-              ],
-            ],
-          },
         ],
         "AlarmDescription": "Upper threshold scaling alarm",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",

--- a/dotcom-rendering/cdk/lib/renderingStack.ts
+++ b/dotcom-rendering/cdk/lib/renderingStack.ts
@@ -186,8 +186,10 @@ export class RenderingCDKStack extends CDKStack {
 		);
 		const criticalAlertsSnsAction = new SnsAction(criticalAlertsTopic);
 
-		/** Adds a notification action to the scale out policy alarm */
-		scaleOutPolicy.upperAlarm?.addAlarmAction(criticalAlertsSnsAction);
+		/** Adds a notification action in PROD to the scale out policy alarm */
+		if (stage === 'PROD') {
+			scaleOutPolicy.upperAlarm?.addAlarmAction(criticalAlertsSnsAction);
+		}
 
 		/** Scale in policy on latency below 0.15s */
 		new StepScalingPolicy(this, 'LatencyScaleDownPolicy', {


### PR DESCRIPTION
## What does this change?

Disables scaling alarm email notifications in CODE

## Why?

They're happening a lot and are quite noisy.

We should adjust the alarm threshold in CODE anyway as we don't want to keep scaling up and down all the time
