### PR TITLE
Ld/fix follow alignment bug on ipad v2

### DIFF
--- a/dotcom-rendering/src/components/FollowButtons.tsx
+++ b/dotcom-rendering/src/components/FollowButtons.tsx
@@ -46,7 +46,7 @@ const FollowIcon = ({
 	</div>
 );
 
-const buttonStyles = (withExtraBottomMargin: boolean) => css`
+const buttonStyles = css`
 	${textSans.small()}
 	color: ${palette('--follow-text')};
 	background: none;
@@ -56,7 +56,7 @@ const buttonStyles = (withExtraBottomMargin: boolean) => css`
 	min-height: ${space[6]}px;
 	padding: 0;
 	text-align: left;
-	${withExtraBottomMargin && `margin-bottom: ${space[2]}px;`}
+	margin-bottom: ${space[2]}px;
 `;
 
 const containerStyles = css`
@@ -92,14 +92,9 @@ type ButtonProps = {
 export const FollowNotificationsButton = ({
 	isFollowing,
 	onClickHandler,
-	withExtraBottomMargin = false,
-}: ButtonProps & { withExtraBottomMargin?: boolean }) => {
+}: ButtonProps) => {
 	return (
-		<button
-			onClick={onClickHandler}
-			type="button"
-			css={[buttonStyles(withExtraBottomMargin)]}
-		>
+		<button onClick={onClickHandler} type="button" css={[buttonStyles]}>
 			<span css={containerStyles}>
 				<FollowIcon
 					isFollowing={isFollowing}
@@ -116,14 +111,9 @@ export const FollowTagButton = ({
 	isFollowing,
 	displayName = '',
 	onClickHandler,
-	withExtraBottomMargin = false,
-}: ButtonProps & { displayName: string; withExtraBottomMargin?: boolean }) => {
+}: ButtonProps & { displayName: string }) => {
 	return (
-		<button
-			onClick={onClickHandler}
-			type="button"
-			css={[buttonStyles(withExtraBottomMargin)]}
-		>
+		<button onClick={onClickHandler} type="button" css={[buttonStyles]}>
 			<span css={containerStyles}>
 				<FollowIcon
 					isFollowing={isFollowing}

--- a/dotcom-rendering/src/components/FollowWrapper.importable.tsx
+++ b/dotcom-rendering/src/components/FollowWrapper.importable.tsx
@@ -124,7 +124,6 @@ export const FollowWrapper = ({ id, displayName }: Props) => {
 
 				${from.phablet} {
 					display: inline-flex;
-					flex-direction: column;
 
 					button:first-of-type {
 						margin-right: ${space[5]}px;
@@ -141,7 +140,6 @@ export const FollowWrapper = ({ id, displayName }: Props) => {
 							? tagHandler
 							: () => undefined
 					}
-					withExtraBottomMargin={true}
 				/>
 			)}
 			<FollowNotificationsButton

--- a/dotcom-rendering/src/components/FollowWrapper.importable.tsx
+++ b/dotcom-rendering/src/components/FollowWrapper.importable.tsx
@@ -124,6 +124,7 @@ export const FollowWrapper = ({ id, displayName }: Props) => {
 
 				${from.phablet} {
 					display: inline-flex;
+					flex-direction: column;
 
 					button:first-of-type {
 						margin-right: ${space[5]}px;


### PR DESCRIPTION
## What does this change?
This fixes a bug with the byline follow buttons where on an iPad these are appearing on the same line but are not horizontally aligned.

This approach adds a margin bottom to the second button, so that when they display on one line they display horizontally aligned. This does add additional white space on a smaller screen when the buttons display on top of each other, so we would probably want to do a media query to detect whether it's an ipad screen before adding the extra margin if we take this approach



## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![alignment-bug][] | ![alignment-bug-magin-bottom-ipad][] |
| ![alignment-bug-pixel][] | ![alignment-bug-margin-bottom-phone][] |

[alignment-bug]: https://github.com/guardian/dotcom-rendering/assets/1202622/40a38a3c-64ab-40d7-b92e-96affdb199b7
[alignment-bug-pixel]: https://github.com/guardian/dotcom-rendering/assets/1202622/af6adaa6-8db5-47d2-8a49-8a3c8d461996


[alignment-bug-magin-bottom-ipad]: https://github.com/guardian/dotcom-rendering/assets/1202622/930701c3-0966-443b-8929-b58700a803b2
[alignment-bug-margin-bottom-phone]: https://github.com/guardian/dotcom-rendering/assets/1202622/99111e29-3fa1-4221-93b5-58d73f439d3c


<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
