### PR TITLE
`CartoonComponent`: Only show lightbox toggle if in experiment

### DIFF
--- a/dotcom-rendering/src/components/CartoonComponent.tsx
+++ b/dotcom-rendering/src/components/CartoonComponent.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/react';
 import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
 import { Hide } from '@guardian/source-react-components';
 import { isWideEnough } from '../lib/lightbox';
-import type { Switches } from '../types/config';
+import type { ServerSideTests } from '../types/config';
 import type { CartoonBlockElement, Image } from '../types/content';
 import { AppsLightboxImage } from './AppsLightboxImage.importable';
 import { Caption } from './Caption';
@@ -14,10 +14,10 @@ import { Picture } from './Picture';
 type Props = {
 	format: ArticleFormat;
 	element: CartoonBlockElement;
-	switches?: Switches;
+	abTests?: ServerSideTests;
 };
 
-export const CartoonComponent = ({ format, element, switches }: Props) => {
+export const CartoonComponent = ({ format, element, abTests }: Props) => {
 	const { renderingTarget } = useConfig();
 	const smallVariant = element.variants.find(
 		(variant) => variant.viewportSize === 'small',
@@ -25,6 +25,9 @@ export const CartoonComponent = ({ format, element, switches }: Props) => {
 	const largeVariant = element.variants.find(
 		(variant) => variant.viewportSize === 'large',
 	);
+
+	const isInLightboxTest = abTests?.lightboxVariant === 'variant';
+	const webLightbox = renderingTarget === 'Web' && isInLightboxTest;
 
 	const render = (image: Image) => {
 		const altText = `${element.alt ? `${element.alt}, ` : ''}panel ${
@@ -62,7 +65,7 @@ export const CartoonComponent = ({ format, element, switches }: Props) => {
 					/>
 				)}
 
-				{switches?.lightbox === true &&
+				{webLightbox &&
 					isWideEnough(image) &&
 					element.position !== undefined && (
 						<LightboxLink

--- a/dotcom-rendering/src/lib/renderElement.tsx
+++ b/dotcom-rendering/src/lib/renderElement.tsx
@@ -211,7 +211,7 @@ export const renderElement = ({
 				<CartoonComponent
 					format={format}
 					element={element}
-					switches={switches}
+					abTests={abTests}
 				/>
 			);
 		case 'model.dotcomrendering.pageElements.ChartAtomBlockElement':


### PR DESCRIPTION
## What does this change?

- Only shows the lightbox toggle in the `CartoonComponent` if the user is enrolled in the lightbox experiment. 

Closes https://github.com/guardian/dotcom-rendering/issues/10276

Separately, it would be good to understand if there's a way to make it clearer that checking the switch state isn't enough when the switch is part of an experiment.