### PR TITLE
Fix Dev Server Static Assets Path

### DIFF
--- a/dotcom-rendering/webpack/webpack.config.dev-server.js
+++ b/dotcom-rendering/webpack/webpack.config.dev-server.js
@@ -27,7 +27,7 @@ module.exports = {
 		},
 		port,
 		static: {
-			directory: path.join(__dirname, '..', '..', 'src', 'static'),
+			directory: path.join(__dirname, '..', 'src', 'static'),
 			publicPath: '/static/frontend',
 		},
 		allowedHosts: ['r.thegulocal.com'],


### PR DESCRIPTION
This relies on a path that's relative to the location of the webpack config file. This config file was moved up a directory in #9579.
