### PR TITLE
Change min instance count for article-rendering to 18

### DIFF
--- a/dotcom-rendering/cdk/bin/cdk.ts
+++ b/dotcom-rendering/cdk/bin/cdk.ts
@@ -40,7 +40,7 @@ new RenderingCDKStack(cdkApp, 'ArticleRendering-PROD', {
 	guApp: 'article-rendering',
 	stage: 'PROD',
 	domainName: 'article-rendering.guardianapis.com',
-	scaling: { minimumInstances: 12, maximumInstances: 120 },
+	scaling: { minimumInstances: 18, maximumInstances: 120 },
 	instanceSize: InstanceSize.SMALL,
 });
 


### PR DESCRIPTION
## What does this change?

Increase min count of instances again, to prevent lots of scaling, until we understand why the latency is so high with only 12 instances

## Why?

To prevent lots of scaling up and down.. 
