### PR TITLE
Increase scale down threashold

### DIFF
--- a/dotcom-rendering/cdk/lib/__snapshots__/renderingStack.test.ts.snap
+++ b/dotcom-rendering/cdk/lib/__snapshots__/renderingStack.test.ts.snap
@@ -633,7 +633,7 @@ exports[`The RenderingCDKStack matches the snapshot 1`] = `
             },
           },
         ],
-        "EvaluationPeriods": 1,
+        "EvaluationPeriods": 10,
         "MetricName": "TargetResponseTime",
         "Namespace": "AWS/ApplicationELB",
         "Period": 30,

--- a/dotcom-rendering/cdk/lib/renderingStack.ts
+++ b/dotcom-rendering/cdk/lib/renderingStack.ts
@@ -209,7 +209,7 @@ export class RenderingCDKStack extends CDKStack {
 				},
 			],
 			adjustmentType: AdjustmentType.CHANGE_IN_CAPACITY,
-			evaluationPeriods: 1,
+			evaluationPeriods: 10,
 		});
 
 		// Saves the value of the rendering base URL to SSM for frontend apps to use


### PR DESCRIPTION
## What does this change?

Increase the period count for the scale down policy

## Why?

Because we only want to scale down if we are consistently over resourced. At the moment we scale down a bit too soon and we end up with the ALB doing this: 

<img width="1439" alt="Screenshot 2024-01-22 at 17 12 20" src="https://github.com/guardian/dotcom-rendering/assets/1229808/c8d8d5bf-652e-4603-8bfc-a707acd1d024">
