### PR TITLE
Error on SSR-unfriendly scripts

### DIFF
--- a/dotcom-rendering/.eslintrc.js
+++ b/dotcom-rendering/.eslintrc.js
@@ -170,9 +170,6 @@ module.exports = {
 
 		'unicorn/prefer-node-protocol': 'error',
 
-		'ssr-friendly/no-dom-globals-in-module-scope': 'warn',
-		'ssr-friendly/no-dom-globals-in-react-fc': 'warn',
-
 		'no-restricted-syntax': [
 			'error',
 			{


### PR DESCRIPTION
## What does this change?

Turn the ssr-friendly ESLint warnings into errors

## Why?

- #9757 