### PR TITLE
Interactive Atoms Use Light Background In Dark Mode

### DIFF
--- a/dotcom-rendering/src/components/InteractiveAtom.tsx
+++ b/dotcom-rendering/src/components/InteractiveAtom.tsx
@@ -2,13 +2,15 @@ import { css } from '@emotion/react';
 import type { ArticleFormat } from '@guardian/libs';
 import { ArticleDisplay } from '@guardian/libs';
 import { unifyPageContent } from '../lib/unifyPageContent';
+import { palette } from '../palette';
 
 const containerStyles = css`
 	margin: 0;
 `;
 
-const fullWidthStyles = css`
+const styles = css`
 	width: 100%;
+	background-color: ${palette('--interactive-atom-background')};
 `;
 const fullHeightStyles = css`
 	height: 100%;
@@ -42,7 +44,7 @@ export const InteractiveAtom = ({
 			title={title}
 			id={id}
 			css={[
-				fullWidthStyles,
+				styles,
 				isMainMedia &&
 					format.display === ArticleDisplay.Immersive &&
 					fullHeightStyles,

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -4862,6 +4862,10 @@ const lastUpdatedText: PaletteFunction = ({ theme, design }) => {
 	}
 };
 
+const interactiveAtomBackgroundLight: PaletteFunction = () => 'transparent';
+const interactiveAtomBackgroundDark: PaletteFunction = () =>
+	sourcePalette.neutral[100];
+
 // ----- Palette ----- //
 
 /**
@@ -5744,6 +5748,10 @@ const paletteColours = {
 	'--last-updated-text': {
 		light: lastUpdatedText,
 		dark: lastUpdatedText,
+	},
+	'--interactive-atom-background': {
+		light: interactiveAtomBackgroundLight,
+		dark: interactiveAtomBackgroundDark,
 	},
 } satisfies PaletteColours;
 


### PR DESCRIPTION
Part of the work for #10212.

## Screenshots

| Before | After |
| - | - |
| ![first-atom-before] ![second-atom-before] | ![first-atom-after] ![second-atom-after] |

[second-atom-after]: https://github.com/guardian/dotcom-rendering/assets/53781962/70738acd-fc49-4186-a769-ba5fde4a6615
[second-atom-before]: https://github.com/guardian/dotcom-rendering/assets/53781962/513db8df-e84d-42d4-944c-ab8cd492c136
[first-atom-after]: https://github.com/guardian/dotcom-rendering/assets/53781962/abcbfd7a-590b-458b-9592-60c0e6de0965
[first-atom-before]: https://github.com/guardian/dotcom-rendering/assets/53781962/7f70f7e7-e350-4067-81db-fb9d9677a7c4
