### PR TITLE
Fix issue with rich link positioning when too close to the end of an article

### DIFF
--- a/dotcom-rendering/src/components/Figure.tsx
+++ b/dotcom-rendering/src/components/Figure.tsx
@@ -126,7 +126,7 @@ const roleCss = {
 			width: 140px;
 		}
 		${from.leftCol} {
-			position: relative;
+			position: absolute;
 			margin-left: -160px;
 			width: 140px;
 		}


### PR DESCRIPTION
## What does this change?

This amends the CSS positioning of the `Figure` component when used with a Rich Link

## Why?

When a Rich Link is inserted near to the end of an article, the use of `position: relative` causes it to still take up space in the main article body despite being visually positioned to the left (on desktop). This means that the epic or other slots inserted after the article end up with a mysterious chunk of empty space above them. Positioning the figure absolutely takes it out of the normal document flow and removes the unwanted whitespace.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
|![Screenshot 2024-01-23 at 11 25 03](https://github.com/guardian/dotcom-rendering/assets/29146931/e6eb5748-6a27-4f77-9040-d527811da3ea) | ![Screenshot 2024-01-23 at 11 25 29](https://github.com/guardian/dotcom-rendering/assets/29146931/8c7b26e7-57de-444d-8c70-6767009d1952) |

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
