### PR TITLE
Bump guardian/libs to fix local storage expiry

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -56,7 +56,7 @@
 		"@guardian/eslint-plugin-source-react-components": "21.0.1",
 		"@guardian/identity-auth": "1.1.0",
 		"@guardian/identity-auth-frontend": "1.0.0",
-		"@guardian/libs": "16.0.0",
+		"@guardian/libs": "16.0.1",
 		"@guardian/shimport": "1.0.2",
 		"@guardian/source-foundations": "14.1.2",
 		"@guardian/source-react-components": "18.0.0",

--- a/dotcom-rendering/src/lib/contributions.test.ts
+++ b/dotcom-rendering/src/lib/contributions.test.ts
@@ -1,4 +1,5 @@
 import { setCookie, storage } from '@guardian/libs';
+import MockDate from 'mockdate';
 import {
 	getLastOneOffContributionTimestamp,
 	isRecentOneOffContributor,
@@ -84,6 +85,9 @@ describe('getLastOneOffContributionDate', () => {
 
 describe('isRecentOneOffContributor', () => {
 	beforeEach(clearAllCookies);
+	afterEach(() => {
+		MockDate.reset();
+	});
 
 	it('returns false if there is no one-off contribution cookie', () => {
 		expect(isRecentOneOffContributor()).toBe(false);
@@ -94,7 +98,8 @@ describe('isRecentOneOffContributor', () => {
 			name: ONE_OFF_CONTRIBUTION_DATE_COOKIE,
 			value: '2018-08-01',
 		});
-		global.Date.now = jest.fn(() => Date.parse('2018-08-07T10:50:34'));
+
+		MockDate.set(Date.parse('2018-08-07T10:50:34'));
 		expect(isRecentOneOffContributor()).toBe(true);
 	});
 
@@ -103,7 +108,7 @@ describe('isRecentOneOffContributor', () => {
 			name: ONE_OFF_CONTRIBUTION_DATE_COOKIE,
 			value: '2018-08-01',
 		});
-		global.Date.now = jest.fn(() => Date.parse('2018-08-01T13:00:30'));
+		MockDate.set(Date.parse('2018-08-01T13:00:30'));
 		expect(isRecentOneOffContributor()).toBe(true);
 	});
 
@@ -112,7 +117,7 @@ describe('isRecentOneOffContributor', () => {
 			name: ONE_OFF_CONTRIBUTION_DATE_COOKIE,
 			value: '2018-08-01',
 		});
-		global.Date.now = jest.fn(() => Date.parse('2019-08-01T13:00:30'));
+		MockDate.set(Date.parse('2019-08-01T13:00:30'));
 		expect(isRecentOneOffContributor()).toBe(false);
 	});
 });
@@ -196,6 +201,7 @@ describe('withinLocalNoBannerCachePeriod', () => {
 		storage.local.set(NO_RR_BANNER_KEY, true, Date.now() + 10000);
 		expect(withinLocalNoBannerCachePeriod()).toEqual(true);
 	});
+
 	it('returns false if expiry is number and expired', () => {
 		storage.local.set(NO_RR_BANNER_KEY, true, Date.now() - 10000);
 		expect(withinLocalNoBannerCachePeriod()).toEqual(false);

--- a/dotcom-rendering/src/lib/contributions.ts
+++ b/dotcom-rendering/src/lib/contributions.ts
@@ -21,7 +21,7 @@ export const SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE =
 //  Local storage keys
 const DAILY_ARTICLE_COUNT_KEY = 'gu.history.dailyArticleCount';
 const WEEKLY_ARTICLE_COUNT_KEY = 'gu.history.weeklyArticleCount';
-const NO_RR_BANNER_KEY = 'gu.noRRBanner';
+export const NO_RR_BANNER_KEY = 'gu.noRRBanner';
 
 // See https://github.com/guardian/support-dotcom-components/blob/main/module-versions.md
 export const MODULES_VERSION = 'v3';
@@ -219,8 +219,8 @@ const twentyMins = 20 * 60000;
 export const withinLocalNoBannerCachePeriod = (): boolean =>
 	!!storage.local.get(NO_RR_BANNER_KEY);
 
-export const setLocalNoBannerCachePeriod = (): void =>
-	storage.local.set(NO_RR_BANNER_KEY, true, Date.now() + twentyMins);
+export const setLocalNoBannerCachePeriod = (now: number = Date.now()): void =>
+	storage.local.set(NO_RR_BANNER_KEY, true, now + twentyMins);
 
 // Returns true if banner was closed in the last hour
 const ONE_HOUR_IN_MS = 1000 * 60 * 60;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -346,7 +346,7 @@ importers:
         version: 7.0.1(tslib@2.6.2)(typescript@5.3.3)
       '@guardian/braze-components':
         specifier: 17.0.0
-        version: 17.0.0(@emotion/react@11.11.1)(@guardian/libs@16.0.0)(@guardian/source-foundations@14.1.2)(@guardian/source-react-components-development-kitchen@16.0.0)(@guardian/source-react-components@18.0.0)(react@18.2.0)
+        version: 17.0.0(@emotion/react@11.11.1)(@guardian/libs@16.0.1)(@guardian/source-foundations@14.1.2)(@guardian/source-react-components-development-kitchen@16.0.0)(@guardian/source-react-components@18.0.0)(react@18.2.0)
       '@guardian/bridget':
         specifier: 2.6.0
         version: 2.6.0
@@ -358,13 +358,13 @@ importers:
         version: 50.13.0(@swc/core@1.3.102)(@types/node@18.18.14)(aws-cdk-lib@2.100.0)(aws-cdk@2.100.0)(constructs@10.3.0)(typescript@5.3.3)
       '@guardian/commercial':
         specifier: 12.0.0
-        version: 12.0.0(@guardian/ab-core@7.0.1)(@guardian/consent-management-platform@13.7.1)(@guardian/core-web-vitals@6.0.0)(@guardian/identity-auth-frontend@1.0.0)(@guardian/identity-auth@1.1.0)(@guardian/libs@16.0.0)(@guardian/source-foundations@14.1.2)(@guardian/support-dotcom-components@1.1.1)(typescript@5.3.3)
+        version: 12.0.0(@guardian/ab-core@7.0.1)(@guardian/consent-management-platform@13.7.1)(@guardian/core-web-vitals@6.0.0)(@guardian/identity-auth-frontend@1.0.0)(@guardian/identity-auth@1.1.0)(@guardian/libs@16.0.1)(@guardian/source-foundations@14.1.2)(@guardian/support-dotcom-components@1.1.1)(typescript@5.3.3)
       '@guardian/consent-management-platform':
         specifier: 13.7.1
-        version: 13.7.1(@guardian/libs@16.0.0)
+        version: 13.7.1(@guardian/libs@16.0.1)
       '@guardian/core-web-vitals':
         specifier: 6.0.0
-        version: 6.0.0(@guardian/libs@16.0.0)(tslib@2.6.2)(typescript@5.3.3)(web-vitals@3.5.1)
+        version: 6.0.0(@guardian/libs@16.0.1)(tslib@2.6.2)(typescript@5.3.3)(web-vitals@3.5.1)
       '@guardian/eslint-config':
         specifier: 7.0.1
         version: 7.0.1(@typescript-eslint/parser@5.61.0)(eslint-import-resolver-typescript@3.5.5)(eslint@8.56.0)(tslib@2.6.2)
@@ -373,16 +373,16 @@ importers:
         version: 9.0.1(eslint@8.56.0)(tslib@2.6.2)(typescript@5.3.3)
       '@guardian/eslint-plugin-source-react-components':
         specifier: 21.0.1
-        version: 21.0.1(@guardian/libs@16.0.0)(@guardian/source-react-components@18.0.0)(eslint@8.56.0)(react@18.2.0)(tslib@2.6.2)(typescript@5.3.3)
+        version: 21.0.1(@guardian/libs@16.0.1)(@guardian/source-react-components@18.0.0)(eslint@8.56.0)(react@18.2.0)(tslib@2.6.2)(typescript@5.3.3)
       '@guardian/identity-auth':
         specifier: 1.1.0
-        version: 1.1.0(@guardian/libs@16.0.0)(tslib@2.6.2)(typescript@5.3.3)
+        version: 1.1.0(@guardian/libs@16.0.1)(tslib@2.6.2)(typescript@5.3.3)
       '@guardian/identity-auth-frontend':
         specifier: 1.0.0
-        version: 1.0.0(@guardian/identity-auth@1.1.0)(@guardian/libs@16.0.0)(tslib@2.6.2)(typescript@5.3.3)
+        version: 1.0.0(@guardian/identity-auth@1.1.0)(@guardian/libs@16.0.1)(tslib@2.6.2)(typescript@5.3.3)
       '@guardian/libs':
-        specifier: 16.0.0
-        version: 16.0.0(tslib@2.6.2)(typescript@5.3.3)
+        specifier: 16.0.1
+        version: 16.0.1(tslib@2.6.2)(typescript@5.3.3)
       '@guardian/shimport':
         specifier: 1.0.2
         version: 1.0.2
@@ -394,7 +394,7 @@ importers:
         version: 18.0.0(@emotion/react@11.11.1)(@guardian/source-foundations@14.1.2)(react@18.2.0)(tslib@2.6.2)(typescript@5.3.3)
       '@guardian/source-react-components-development-kitchen':
         specifier: 16.0.0
-        version: 16.0.0(@emotion/react@11.11.1)(@guardian/libs@16.0.0)(@guardian/source-foundations@14.1.2)(@guardian/source-react-components@18.0.0)(react@18.2.0)(tslib@2.6.2)(typescript@5.3.3)
+        version: 16.0.0(@emotion/react@11.11.1)(@guardian/libs@16.0.1)(@guardian/source-foundations@14.1.2)(@guardian/source-react-components@18.0.0)(react@18.2.0)(tslib@2.6.2)(typescript@5.3.3)
       '@guardian/support-dotcom-components':
         specifier: 1.1.1
         version: 1.1.1
@@ -4715,7 +4715,7 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@guardian/braze-components@17.0.0(@emotion/react@11.11.1)(@guardian/libs@16.0.0)(@guardian/source-foundations@14.1.2)(@guardian/source-react-components-development-kitchen@16.0.0)(@guardian/source-react-components@18.0.0)(react@18.2.0):
+  /@guardian/braze-components@17.0.0(@emotion/react@11.11.1)(@guardian/libs@16.0.1)(@guardian/source-foundations@14.1.2)(@guardian/source-react-components-development-kitchen@16.0.0)(@guardian/source-react-components@18.0.0)(react@18.2.0):
     resolution: {integrity: sha512-Muj2fzd+gTiOEYMyP7BA5mkVMTbcUVK3IWrHUjnivo/d0cqxtSY0GLbhBTQ6MPwYtXe74H+gCWO3HNAujv0R+A==}
     engines: {node: ^18.15 || ^20.9}
     peerDependencies:
@@ -4727,10 +4727,10 @@ packages:
       react: 17.0.2 || 18.2.0
     dependencies:
       '@emotion/react': 11.11.1(@types/react@18.2.45)(react@18.2.0)
-      '@guardian/libs': 16.0.0(tslib@2.6.2)(typescript@5.3.3)
+      '@guardian/libs': 16.0.1(tslib@2.6.2)(typescript@5.3.3)
       '@guardian/source-foundations': 14.1.2(tslib@2.6.2)(typescript@5.3.3)
       '@guardian/source-react-components': 18.0.0(@emotion/react@11.11.1)(@guardian/source-foundations@14.1.2)(react@18.2.0)(tslib@2.6.2)(typescript@5.3.3)
-      '@guardian/source-react-components-development-kitchen': 16.0.0(@emotion/react@11.11.1)(@guardian/libs@16.0.0)(@guardian/source-foundations@14.1.2)(@guardian/source-react-components@18.0.0)(react@18.2.0)(tslib@2.6.2)(typescript@5.3.3)
+      '@guardian/source-react-components-development-kitchen': 16.0.0(@emotion/react@11.11.1)(@guardian/libs@16.0.1)(@guardian/source-foundations@14.1.2)(@guardian/source-react-components@18.0.0)(react@18.2.0)(tslib@2.6.2)(typescript@5.3.3)
       react: 18.2.0
     dev: false
 
@@ -4777,7 +4777,7 @@ packages:
       - typescript
     dev: false
 
-  /@guardian/commercial@12.0.0(@guardian/ab-core@7.0.1)(@guardian/consent-management-platform@13.7.1)(@guardian/core-web-vitals@6.0.0)(@guardian/identity-auth-frontend@1.0.0)(@guardian/identity-auth@1.1.0)(@guardian/libs@16.0.0)(@guardian/source-foundations@14.1.2)(@guardian/support-dotcom-components@1.1.1)(typescript@5.3.3):
+  /@guardian/commercial@12.0.0(@guardian/ab-core@7.0.1)(@guardian/consent-management-platform@13.7.1)(@guardian/core-web-vitals@6.0.0)(@guardian/identity-auth-frontend@1.0.0)(@guardian/identity-auth@1.1.0)(@guardian/libs@16.0.1)(@guardian/source-foundations@14.1.2)(@guardian/support-dotcom-components@1.1.1)(typescript@5.3.3):
     resolution: {integrity: sha512-fKViYFmMcgMOfKWPFd5RT+zBlVwe52R0PGLDy1OaEobAwWYyt1h9uJYbMSFlXrwqGBoaiOXi8eXOQ6BaYgAy9Q==}
     peerDependencies:
       '@guardian/ab-core': ^7.0.1
@@ -4791,11 +4791,11 @@ packages:
     dependencies:
       '@changesets/cli': 2.27.1
       '@guardian/ab-core': 7.0.1(tslib@2.6.2)(typescript@5.3.3)
-      '@guardian/consent-management-platform': 13.7.1(@guardian/libs@16.0.0)
-      '@guardian/core-web-vitals': 6.0.0(@guardian/libs@16.0.0)(tslib@2.6.2)(typescript@5.3.3)(web-vitals@3.5.1)
-      '@guardian/identity-auth': 1.1.0(@guardian/libs@16.0.0)(tslib@2.6.2)(typescript@5.3.3)
-      '@guardian/identity-auth-frontend': 1.0.0(@guardian/identity-auth@1.1.0)(@guardian/libs@16.0.0)(tslib@2.6.2)(typescript@5.3.3)
-      '@guardian/libs': 16.0.0(tslib@2.6.2)(typescript@5.3.3)
+      '@guardian/consent-management-platform': 13.7.1(@guardian/libs@16.0.1)
+      '@guardian/core-web-vitals': 6.0.0(@guardian/libs@16.0.1)(tslib@2.6.2)(typescript@5.3.3)(web-vitals@3.5.1)
+      '@guardian/identity-auth': 1.1.0(@guardian/libs@16.0.1)(tslib@2.6.2)(typescript@5.3.3)
+      '@guardian/identity-auth-frontend': 1.0.0(@guardian/identity-auth@1.1.0)(@guardian/libs@16.0.1)(tslib@2.6.2)(typescript@5.3.3)
+      '@guardian/libs': 16.0.1(tslib@2.6.2)(typescript@5.3.3)
       '@guardian/source-foundations': 14.1.2(tslib@2.6.2)(typescript@5.3.3)
       '@guardian/support-dotcom-components': 1.1.1
       '@octokit/core': 4.2.4
@@ -4814,12 +4814,12 @@ packages:
       - typescript
     dev: false
 
-  /@guardian/consent-management-platform@13.7.1(@guardian/libs@16.0.0):
+  /@guardian/consent-management-platform@13.7.1(@guardian/libs@16.0.1):
     resolution: {integrity: sha512-BtUNkuCqd++A0Wkk9CA4kI95yVZJk1YMjPdppEnmq3cG/ros4ElXN4cNG7pWifeTR5cUtJflAiRRO4L5ewASpQ==}
     peerDependencies:
       '@guardian/libs': ^15.0.0
     dependencies:
-      '@guardian/libs': 16.0.0(tslib@2.6.2)(typescript@5.3.3)
+      '@guardian/libs': 16.0.1(tslib@2.6.2)(typescript@5.3.3)
     dev: false
 
   /@guardian/content-api-models@17.8.0:
@@ -4862,7 +4862,7 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@guardian/core-web-vitals@6.0.0(@guardian/libs@16.0.0)(tslib@2.6.2)(typescript@5.3.3)(web-vitals@3.5.1):
+  /@guardian/core-web-vitals@6.0.0(@guardian/libs@16.0.1)(tslib@2.6.2)(typescript@5.3.3)(web-vitals@3.5.1):
     resolution: {integrity: sha512-kwH1VsQQMn+sPZis1zYYcCYzedNpen6tk3CtVjJlmtHV4nK6i6FnMfhHgbtqECDsqrHdTzRbwN2Lodh1f8D5lA==}
     peerDependencies:
       '@guardian/libs': ^16.0.0
@@ -4873,7 +4873,7 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@guardian/libs': 16.0.0(tslib@2.6.2)(typescript@5.3.3)
+      '@guardian/libs': 16.0.1(tslib@2.6.2)(typescript@5.3.3)
       tslib: 2.6.2
       typescript: 5.3.3
       web-vitals: 3.5.1
@@ -4961,7 +4961,32 @@ packages:
       - supports-color
     dev: false
 
-  /@guardian/identity-auth-frontend@1.0.0(@guardian/identity-auth@1.1.0)(@guardian/libs@16.0.0)(tslib@2.6.2)(typescript@5.3.3):
+  /@guardian/eslint-plugin-source-react-components@21.0.1(@guardian/libs@16.0.1)(@guardian/source-react-components@18.0.0)(eslint@8.56.0)(react@18.2.0)(tslib@2.6.2)(typescript@5.3.3):
+    resolution: {integrity: sha512-erMqLMhgGbzJAjViZMNtE8DjrpJuRurreBBeuttbaxrIE3eKX2p3QTYJKxE0fqAyIRhTCV3/M+sil9RTifN1Xw==}
+    peerDependencies:
+      '@guardian/libs': ^16.0.0
+      '@guardian/source-react-components': ^18.0.0
+      eslint: ^8.56.0
+      react: ^18.2.0
+      tslib: ^2.6.2
+      typescript: ~5.3.3
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@guardian/libs': 16.0.1(tslib@2.6.2)(typescript@5.3.3)
+      '@guardian/source-react-components': 18.0.0(@emotion/react@11.11.1)(@guardian/source-foundations@14.1.2)(react@18.2.0)(tslib@2.6.2)(typescript@5.3.3)
+      '@typescript-eslint/eslint-plugin': 6.18.0(@typescript-eslint/parser@6.18.0)(eslint@8.56.0)(typescript@5.3.3)
+      '@typescript-eslint/parser': 6.18.0(eslint@8.56.0)(typescript@5.3.3)
+      eslint: 8.56.0
+      react: 18.2.0
+      tslib: 2.6.2
+      typescript: 5.3.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@guardian/identity-auth-frontend@1.0.0(@guardian/identity-auth@1.1.0)(@guardian/libs@16.0.1)(tslib@2.6.2)(typescript@5.3.3):
     resolution: {integrity: sha512-lmuz8kIG5PeRjyjq1S9CMlfczOLxUdT+3UD8jYk3VZkGgLjN+3IX0e3GK7mMo/SnIojxLOD8x3tiVRCPjfiUdQ==}
     peerDependencies:
       '@guardian/identity-auth': ^1.0.0
@@ -4972,13 +4997,13 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@guardian/identity-auth': 1.1.0(@guardian/libs@16.0.0)(tslib@2.6.2)(typescript@5.3.3)
-      '@guardian/libs': 16.0.0(tslib@2.6.2)(typescript@5.3.3)
+      '@guardian/identity-auth': 1.1.0(@guardian/libs@16.0.1)(tslib@2.6.2)(typescript@5.3.3)
+      '@guardian/libs': 16.0.1(tslib@2.6.2)(typescript@5.3.3)
       tslib: 2.6.2
       typescript: 5.3.3
     dev: false
 
-  /@guardian/identity-auth@1.1.0(@guardian/libs@16.0.0)(tslib@2.6.2)(typescript@5.3.3):
+  /@guardian/identity-auth@1.1.0(@guardian/libs@16.0.1)(tslib@2.6.2)(typescript@5.3.3):
     resolution: {integrity: sha512-sL5qgjZsZ+ur+fFe+PCohTx1xryx0X4FX6f3q3yyyuzVAcQ1LY1n+Ovap0QlDSyueCfDi35rW9Pc9wlvS1Cvzg==}
     peerDependencies:
       '@guardian/libs': ^15.0.0
@@ -4988,7 +5013,7 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@guardian/libs': 16.0.0(tslib@2.6.2)(typescript@5.3.3)
+      '@guardian/libs': 16.0.1(tslib@2.6.2)(typescript@5.3.3)
       tslib: 2.6.2
       typescript: 5.3.3
     dev: false
@@ -5008,6 +5033,19 @@ packages:
 
   /@guardian/libs@16.0.0(tslib@2.6.2)(typescript@5.3.3):
     resolution: {integrity: sha512-2i9cN6htXnvABIGhfqJGb9Bh/DdQOayUjb5ruqBGTiXEeDBHztctdVsi7+rPfMlwyPxQ+0qYLhM19f6J94vvhQ==}
+    peerDependencies:
+      tslib: ^2.6.2
+      typescript: ~5.3.3
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      tslib: 2.6.2
+      typescript: 5.3.3
+    dev: false
+
+  /@guardian/libs@16.0.1(tslib@2.6.2)(typescript@5.3.3):
+    resolution: {integrity: sha512-/pgkDwWu9xp4TAEx07LFu80XsJWIti0VHRxjRRV6vNCMIb44OktONXs5Lu9deoSXWNZh+VcyAEj8vFF2DRPdMA==}
     peerDependencies:
       tslib: ^2.6.2
       typescript: ~5.3.3
@@ -5086,6 +5124,29 @@ packages:
     dependencies:
       '@emotion/react': 11.11.1(@types/react@18.2.45)(react@18.2.0)
       '@guardian/libs': 16.0.0(tslib@2.6.2)(typescript@5.3.3)
+      '@guardian/source-foundations': 14.1.2(tslib@2.6.2)(typescript@5.3.3)
+      '@guardian/source-react-components': 18.0.0(@emotion/react@11.11.1)(@guardian/source-foundations@14.1.2)(react@18.2.0)(tslib@2.6.2)(typescript@5.3.3)
+      react: 18.2.0
+      tslib: 2.6.2
+      typescript: 5.3.3
+    dev: false
+
+  /@guardian/source-react-components-development-kitchen@16.0.0(@emotion/react@11.11.1)(@guardian/libs@16.0.1)(@guardian/source-foundations@14.1.2)(@guardian/source-react-components@18.0.0)(react@18.2.0)(tslib@2.6.2)(typescript@5.3.3):
+    resolution: {integrity: sha512-wJgQgPJIuahWS3nvHYhIsb0U/nsmmWyL2F6ID+so8Ft39/gEiyssPK/agqqWA0i/zUyttv5Fn3+Hk0tijau5+A==}
+    peerDependencies:
+      '@emotion/react': ^11.11.1
+      '@guardian/libs': ^16.0.0
+      '@guardian/source-foundations': ^14.0.0
+      '@guardian/source-react-components': ^18.0.0
+      react: ^18.2.0
+      tslib: ^2.6.2
+      typescript: ~5.3.3
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@emotion/react': 11.11.1(@types/react@18.2.45)(react@18.2.0)
+      '@guardian/libs': 16.0.1(tslib@2.6.2)(typescript@5.3.3)
       '@guardian/source-foundations': 14.1.2(tslib@2.6.2)(typescript@5.3.3)
       '@guardian/source-react-components': 18.0.0(@emotion/react@11.11.1)(@guardian/source-foundations@14.1.2)(react@18.2.0)(tslib@2.6.2)(typescript@5.3.3)
       react: 18.2.0


### PR DESCRIPTION
## What does this change?
The `gu.noRRBanner` local storage item is used to cache the decision not to display a reader revenue banner. It should expire after 20mins.
A recent change to use the guardian/libs storage code has broken the expiry, because the existing version of that library does not handle numeric expiry values. This means browsers are never expiring the item, which means we're not showing banners to those users.

The latest version of guardian/libs has a fix:
https://github.com/guardian/csnx/pull/1099
