### PR TITLE
Interactive Atoms `in-app` Class

### DIFF
--- a/dotcom-rendering/src/components/InteractiveAtom.tsx
+++ b/dotcom-rendering/src/components/InteractiveAtom.tsx
@@ -3,6 +3,7 @@ import type { ArticleFormat } from '@guardian/libs';
 import { ArticleDisplay } from '@guardian/libs';
 import { unifyPageContent } from '../lib/unifyPageContent';
 import { palette } from '../palette';
+import { useConfig } from './ConfigContext';
 
 const containerStyles = css`
 	margin: 0;
@@ -34,23 +35,32 @@ export const InteractiveAtom = ({
 	isMainMedia,
 	format,
 	title,
-}: InteractiveAtomType) => (
-	<div
-		css={[containerStyles, isMainMedia && fullHeightStyles]}
-		data-atom-id={id}
-		data-atom-type="interactive"
-	>
-		<iframe
-			title={title}
-			id={id}
-			css={[
-				styles,
-				isMainMedia &&
-					format.display === ArticleDisplay.Immersive &&
-					fullHeightStyles,
-			]}
-			srcDoc={unifyPageContent({ elementJs, elementCss, elementHtml })}
-			frameBorder="0"
-		/>
-	</div>
-);
+}: InteractiveAtomType) => {
+	const { renderingTarget } = useConfig();
+
+	return (
+		<div
+			css={[containerStyles, isMainMedia && fullHeightStyles]}
+			data-atom-id={id}
+			data-atom-type="interactive"
+		>
+			<iframe
+				title={title}
+				id={id}
+				css={[
+					styles,
+					isMainMedia &&
+						format.display === ArticleDisplay.Immersive &&
+						fullHeightStyles,
+				]}
+				srcDoc={unifyPageContent({
+					elementJs,
+					elementCss,
+					elementHtml,
+					renderingTarget,
+				})}
+				frameBorder="0"
+			/>
+		</div>
+	);
+};

--- a/dotcom-rendering/src/lib/unifyPageContent.test.tsx
+++ b/dotcom-rendering/src/lib/unifyPageContent.test.tsx
@@ -8,37 +8,68 @@ describe('unifyPageContent', () => {
 	const elementJs = `console.log('hello world!')`;
 
 	it('should each content', () => {
-		const outputHTML = unifyPageContent({
+		const outputHTMLWeb = unifyPageContent({
 			elementHtml,
 			elementCss,
 			elementJs,
+			renderingTarget: 'Web',
 		});
-		expect(outputHTML).toContain(elementHtml);
-		expect(outputHTML).toContain(elementCss);
-		expect(outputHTML).toContain(elementJs);
+		const outputHTMLApps = unifyPageContent({
+			elementHtml,
+			elementCss,
+			elementJs,
+			renderingTarget: 'Apps',
+		});
+		expect(outputHTMLWeb).toContain(elementHtml);
+		expect(outputHTMLWeb).toContain(elementCss);
+		expect(outputHTMLWeb).toContain(elementJs);
+		expect(outputHTMLApps).toContain(elementHtml);
+		expect(outputHTMLApps).toContain(elementCss);
+		expect(outputHTMLApps).toContain(elementJs);
 	});
 
 	it('should not render style tag', () => {
-		const outputHTML = unifyPageContent({
+		const outputHTMLWeb = unifyPageContent({
 			elementHtml,
 			elementJs,
+			renderingTarget: 'Web',
 		});
-		expect(outputHTML).not.toContain(`<style`);
+		const outputHTMLApps = unifyPageContent({
+			elementHtml,
+			elementJs,
+			renderingTarget: 'Apps',
+		});
+		expect(outputHTMLWeb).not.toContain(`<style`);
+		expect(outputHTMLApps).not.toContain(`<style`);
 	});
 
 	it('should not render div tag', () => {
-		const outputHTML = unifyPageContent({
+		const outputHTMLWeb = unifyPageContent({
 			elementCss,
 			elementJs,
+			renderingTarget: 'Web',
 		});
-		expect(outputHTML).not.toContain(`<div`);
+		const outputHTMLApps = unifyPageContent({
+			elementCss,
+			elementJs,
+			renderingTarget: 'Apps',
+		});
+		expect(outputHTMLWeb).not.toContain(`<div`);
+		expect(outputHTMLApps).not.toContain(`<div`);
 	});
 
 	it('should render successfully when no elementJs', () => {
-		const outputHTML = unifyPageContent({
+		const outputHTMLWeb = unifyPageContent({
 			elementCss,
 			elementHtml,
+			renderingTarget: 'Web',
 		});
-		expect(outputHTML).not.toContain(elementJs);
+		const outputHTMLApps = unifyPageContent({
+			elementCss,
+			elementHtml,
+			renderingTarget: 'Apps',
+		});
+		expect(outputHTMLWeb).not.toContain(elementJs);
+		expect(outputHTMLApps).not.toContain(elementJs);
 	});
 });

--- a/dotcom-rendering/src/lib/unifyPageContent.tsx
+++ b/dotcom-rendering/src/lib/unifyPageContent.tsx
@@ -1,13 +1,16 @@
 import { renderToString } from 'react-dom/server';
+import type { RenderingTarget } from '../types/renderingTarget';
 
 export const unifyPageContent = ({
 	elementCss,
 	elementJs,
 	elementHtml,
+	renderingTarget,
 }: {
 	elementCss?: string;
 	elementJs?: string;
 	elementHtml?: string;
+	renderingTarget: RenderingTarget;
 }): string =>
 	renderToString(
 		<html lang="en">
@@ -21,7 +24,7 @@ export const unifyPageContent = ({
 					<style dangerouslySetInnerHTML={{ __html: elementCss }} />
 				)}
 			</head>
-			<body>
+			<body className={renderingTarget === 'Apps' ? 'in-app' : undefined}>
 				{!!elementHtml && (
 					<div dangerouslySetInnerHTML={{ __html: elementHtml }} />
 				)}


### PR DESCRIPTION
Completes the second part of #10212, and currently based on the changes in #10291, which completes the first part.

Interactive atoms have populated this class themselves on other platforms (AR, templates), to know whether they're in apps and therefore make adjustments like dark mode support. This adds this class at the platform level in DCAR, so existing atoms can continue to rely on its presence.

Also updated the tests to check web and apps variants.

**Note:** I recommend using "hide whitespace" to view the changes.

## Screenshots

- https://www.theguardian.com/world/2020/jul/16/uk-government-orders-halt-randox-covid-19-tests-over-safety-issues
- https://www.theguardian.com/us-news/2024/jan/12/us-elections-2024-calendar-key-events

| | Before | After |
| - | - | - |
| Atom With Dark Mode Support | ![dark-mode-before] | ![dark-mode-after] |
| Atom Without Dark Mode Support | ![light-mode-before] | ![light-mode-after] |

[dark-mode-before]: https://github.com/guardian/dotcom-rendering/assets/53781962/68042694-b88c-4086-99e0-f9b370e549f3
[light-mode-before]: https://github.com/guardian/dotcom-rendering/assets/53781962/13e40220-8237-4226-a2ee-85cf3bef6bf0
[light-mode-after]: https://github.com/guardian/dotcom-rendering/assets/53781962/d3679914-b388-445f-8636-245809c27538
[dark-mode-after]: https://github.com/guardian/dotcom-rendering/assets/53781962/3341231f-a3d7-49b2-90d8-9d557c276fbb
