### PR TITLE
fix: reinstate `assertUnreachable`

### DIFF
--- a/dotcom-rendering/src/components/FrontSectionTitle.tsx
+++ b/dotcom-rendering/src/components/FrontSectionTitle.tsx
@@ -132,7 +132,7 @@ export const FrontSectionTitle = ({ title, collectionBranding }: Props) => {
 			return <div css={titleStyle}>{title}</div>;
 		}
 		default: {
-			assertUnreachable();
+			assertUnreachable(collectionBranding);
 			return null;
 		}
 	}

--- a/dotcom-rendering/src/lib/assert-unreachable.ts
+++ b/dotcom-rendering/src/lib/assert-unreachable.ts
@@ -6,6 +6,7 @@
  * @see https://tinytip.co/tips/ts-switch-assert-unreachable/
  *
  */
-export const assertUnreachable = (): never => {
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- We don't actually use the value
+export const assertUnreachable = (value: never): never => {
 	throw new Error('This should be unreachable');
 };

--- a/dotcom-rendering/src/lib/branding.ts
+++ b/dotcom-rendering/src/lib/branding.ts
@@ -124,7 +124,7 @@ export const badgeFromBranding = (
 			return undefined;
 		}
 		default: {
-			return assertUnreachable();
+			return assertUnreachable(collectionBranding);
 		}
 	}
 };

--- a/dotcom-rendering/src/model/article-schema.json
+++ b/dotcom-rendering/src/model/article-schema.json
@@ -4628,7 +4628,7 @@
                     "type": "string"
                 },
                 "href": {
-                    "description": "Href can a link to an external sponsor page",
+                    "description": "Link to an external sponsor page",
                     "type": "string"
                 }
             },

--- a/dotcom-rendering/src/types/branding.ts
+++ b/dotcom-rendering/src/types/branding.ts
@@ -30,14 +30,11 @@ export interface EditionBranding {
 	branding?: Branding;
 }
 
-/**
- * Branding that can be applied to an entire collection on a front
- */
-export type CollectionBranding = {
+type BaseCollectionBranding<Kind extends BrandingType['name']> = {
 	/**
 	 * A collection has branding that is funded by a third party
 	 */
-	kind: BrandingType['name'];
+	kind: Kind;
 	branding: Branding;
 	/**
 	 * In certain circumstances a collection might display the branding on behalf of an entire front
@@ -54,3 +51,11 @@ export type CollectionBranding = {
 	 */
 	hasMultipleBranding: boolean;
 };
+
+/**
+ * Branding that can be applied to an entire collection on a front
+ */
+export type CollectionBranding =
+	| BaseCollectionBranding<'foundation'>
+	| BaseCollectionBranding<'paid-content'>
+	| BaseCollectionBranding<'sponsored'>;


### PR DESCRIPTION
`CollectionBranding` is back to being
a discriminated union:

https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#union-types

## What does this change?

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
