### PR TITLE
Support non boot interactives in apps articles

### DIFF
--- a/dotcom-rendering/src/server/render.article.apps.tsx
+++ b/dotcom-rendering/src/server/render.article.apps.tsx
@@ -59,7 +59,7 @@ export const renderArticle = (
 	const clientScripts = [
 		getPathFromManifest('client.apps', 'index.js'),
 		pageHasNonBootInteractiveElements &&
-			`${ASSET_ORIGIN}assets/static/js/curl-with-js-and-domReady.js`,
+			`${ASSET_ORIGIN}static/frontend/js/curl-with-js-and-domReady.js`,
 	].filter(isString);
 	const scriptTags = generateScriptTags([...clientScripts]);
 


### PR DESCRIPTION
## What does this change?

- Adds support for non-boot interactives in apps articles by including the necessary scripts if the article includes a non-boot interactive.

Closes https://github.com/guardian/dotcom-rendering/issues/10292

## Screenshots

I've clipped the screenshot because it's graphic. The white box in "before" is because the interactive doesn't load.

| Before      | After      |
| ----------- | ---------- |
| <img width="816" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/705427/63af4f5b-0ffa-46f6-a0ca-433a76ecd4a5"> | <img width="1223" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/705427/c5f980b3-4ff2-4018-8bf8-89f0b2632812"> |
