### PR TITLE
Add rugbyMatchType to dcr data

### DIFF
--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -213,7 +213,7 @@ type PageTypeType = {
 	isSensitive: boolean;
 };
 
-type MatchType = 'CricketMatchType' | 'FootballMatchType';
+type MatchType = 'CricketMatchType' | 'FootballMatchType' | 'RugbyMatchType';
 
 type CricketTeam = {
 	name: string;

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -63,6 +63,7 @@ import { palette as themePalette } from '../palette';
 import type { DCRArticle } from '../types/frontend';
 import type { RenderingTarget } from '../types/renderingTarget';
 import { BannerWrapper, SendToBack, Stuck } from './lib/stickiness';
+import { GetRugbyMatchNav } from '../components/GetRugbyMatchNav.importable';
 
 const HeadlineGrid = ({ children }: { children: React.ReactNode }) => (
 	<div
@@ -297,6 +298,9 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 	const cricketMatchUrl =
 		article.matchType === 'CricketMatchType' ? article.matchUrl : undefined;
 
+	const rugbyMatchUrl =
+		article.matchType === 'RugbyMatchType' ? article.matchUrl : undefined;
+
 	const showTopicFilterBank =
 		!!article.config.switches.automaticFilters &&
 		hasRelevantTopics(article.availableTopics);
@@ -494,6 +498,52 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 							/>
 						</Island>
 					</Section>
+				) : rugbyMatchUrl ? (
+					<Section
+						showTopBorder={false}
+						backgroundColour={themePalette(
+							'--match-nav-background',
+						)}
+						borderColour={themePalette('--headline-border')}
+						leftContent={
+							<ArticleTitle
+								format={format}
+								tags={article.tags}
+								sectionLabel={article.sectionLabel}
+								sectionUrl={article.sectionUrl}
+								guardianBaseURL={article.guardianBaseURL}
+								badge={article.badge?.enhanced}
+								isMatch={true}
+							/>
+						}
+						leftColSize="wide"
+						padContent={false}
+						verticalMargins={false}
+					>
+						<Hide above="leftCol">
+							<ArticleTitle
+								format={format}
+								tags={article.tags}
+								sectionLabel={article.sectionLabel}
+								sectionUrl={article.sectionUrl}
+								guardianBaseURL={article.guardianBaseURL}
+								badge={article.badge?.enhanced}
+								isMatch={true}
+							/>
+						</Hide>
+
+						<Island priority="critical">
+							<GetRugbyMatchNav
+								matchUrl={rugbyMatchUrl}
+								format={format}
+								headlineString={article.headline}
+								tags={article.tags}
+								webPublicationDateDeprecated={
+									article.webPublicationDateDeprecated
+								}
+							/>
+						</Island>
+					</Section>
 				) : (
 					<Section
 						fullWidth={true}
@@ -516,7 +566,7 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 							</GridItem>
 							<GridItem area="headline">
 								<div css={maxWidth}>
-									{!footballMatchUrl && (
+									{!footballMatchUrl && !rugbyMatchUrl && (
 										<ArticleHeadline
 											format={format}
 											headlineString={article.headline}
@@ -539,9 +589,7 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 											size="large"
 										/>
 									</div>
-								) : (
-									<></>
-								)}
+								) : null}
 							</GridItem>
 						</HeadlineGrid>
 					</Section>

--- a/dotcom-rendering/src/model/article-schema.json
+++ b/dotcom-rendering/src/model/article-schema.json
@@ -4794,7 +4794,8 @@
         "MatchType": {
             "enum": [
                 "CricketMatchType",
-                "FootballMatchType"
+                "FootballMatchType",
+                "RugbyMatchType"
             ],
             "type": "string"
         },


### PR DESCRIPTION
## What does this change?

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
