### PR TITLE
Temporarily Make All AMP Interactives Not Renderable

### DIFF
--- a/dotcom-rendering/src/server/handler.article.amp.tsx
+++ b/dotcom-rendering/src/server/handler.article.amp.tsx
@@ -19,6 +19,14 @@ export const handleAMPArticle: RequestHandler = ({ body }, res, next) => {
 	(async () => {
 		recordTypeAndPlatform('article', 'amp');
 		const article = validateAsArticleType(body);
+
+		if (
+			article.format.design === 'InteractiveDesign' ||
+			article.format.design === 'FullPageInteractiveDesign'
+		) {
+			throw new NotRenderableInDCR();
+		}
+
 		const { linkedData } = article;
 		const { config } = article;
 		const elements = await enhance(

--- a/dotcom-rendering/src/server/render.article.web.tsx
+++ b/dotcom-rendering/src/server/render.article.web.tsx
@@ -161,6 +161,13 @@ export const renderHtml = ({
 
 	const getAmpLink = (tags: TagType[]) => {
 		if (
+			article.format.design === 'InteractiveDesign' ||
+			article.format.design === 'FullPageInteractiveDesign'
+		) {
+			return undefined;
+		}
+
+		if (
 			!isAmpSupported({
 				format: article.format,
 				tags,


### PR DESCRIPTION
This should result in 415s being returned from DCR, and 404s from frontend. AMP interactives seem to result in very expensive requests, and we'd like to figure out whether this is responsible for #10265.

We plan to leave this in production for 24 hours, and we don't think this will cause too many problems because many of these already return 404s or have AMP validation issues.

Paired with @alinaboghiu and @georgeblahblah 
