### PR TITLE
Lift state for `userNameMissing` to `Comments`

### DIFF
--- a/dotcom-rendering/src/components/Discussion/CommentContainer.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentContainer.stories.tsx
@@ -191,6 +191,8 @@ export const defaultStory = () => (
 		onPermalinkClick={() => {}}
 		isCommentFormActive={false}
 		setIsCommentFormActive={() => {}}
+		userNameMissing={false}
+		setUserNameMissing={() => {}}
 	/>
 );
 defaultStory.storyName = 'default';
@@ -219,6 +221,8 @@ export const threadedComment = () => (
 		onPermalinkClick={() => {}}
 		isCommentFormActive={false}
 		setIsCommentFormActive={() => {}}
+		userNameMissing={false}
+		setUserNameMissing={() => {}}
 	/>
 );
 threadedComment.storyName = 'threaded';
@@ -247,6 +251,8 @@ export const threadedCommentWithShowMore = () => (
 		onPermalinkClick={() => {}}
 		isCommentFormActive={false}
 		setIsCommentFormActive={() => {}}
+		userNameMissing={false}
+		setUserNameMissing={() => {}}
 	/>
 );
 threadedCommentWithShowMore.storyName = 'threaded with show more button';
@@ -275,6 +281,8 @@ export const threadedCommentWithLongUsernames = () => (
 		onPermalinkClick={() => {}}
 		isCommentFormActive={false}
 		setIsCommentFormActive={() => {}}
+		userNameMissing={false}
+		setUserNameMissing={() => {}}
 	/>
 );
 threadedCommentWithLongUsernames.storyName = 'threaded with long usernames';
@@ -303,6 +311,8 @@ export const threadedCommentWithLongUsernamesMobile = () => (
 		onPermalinkClick={() => {}}
 		isCommentFormActive={false}
 		setIsCommentFormActive={() => {}}
+		userNameMissing={false}
+		setUserNameMissing={() => {}}
 	/>
 );
 threadedCommentWithLongUsernamesMobile.storyName =

--- a/dotcom-rendering/src/components/Discussion/CommentContainer.test.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentContainer.test.tsx
@@ -68,6 +68,8 @@ describe('CommentContainer', () => {
 				onPermalinkClick={() => {}}
 				isCommentFormActive={true}
 				setIsCommentFormActive={() => {}}
+				userNameMissing={false}
+				setUserNameMissing={() => {}}
 			/>,
 		);
 
@@ -107,6 +109,8 @@ describe('CommentContainer', () => {
 				onPermalinkClick={() => {}}
 				isCommentFormActive={true}
 				setIsCommentFormActive={() => {}}
+				userNameMissing={false}
+				setUserNameMissing={() => {}}
 			/>,
 		);
 
@@ -145,6 +149,8 @@ describe('CommentContainer', () => {
 				onPermalinkClick={() => {}}
 				isCommentFormActive={true}
 				setIsCommentFormActive={() => {}}
+				userNameMissing={false}
+				setUserNameMissing={() => {}}
 			/>,
 		);
 
@@ -184,6 +190,8 @@ describe('CommentContainer', () => {
 				onPermalinkClick={() => {}}
 				isCommentFormActive={true}
 				setIsCommentFormActive={() => {}}
+				userNameMissing={false}
+				setUserNameMissing={() => {}}
 			/>,
 		);
 

--- a/dotcom-rendering/src/components/Discussion/CommentContainer.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentContainer.tsx
@@ -36,6 +36,8 @@ type Props = {
 	onPreview?: (body: string) => Promise<string>;
 	isCommentFormActive: boolean;
 	setIsCommentFormActive: (isActive: boolean) => void;
+	userNameMissing: boolean;
+	setUserNameMissing: (isUserNameMissing: boolean) => void;
 };
 
 const nestingStyles = css`
@@ -89,6 +91,8 @@ export const CommentContainer = ({
 	onPreview,
 	isCommentFormActive,
 	setIsCommentFormActive,
+	userNameMissing,
+	setUserNameMissing,
 }: Props) => {
 	// Filter logic
 	const [expanded, setExpanded] = useState<boolean>(threads === 'expanded');
@@ -228,6 +232,8 @@ export const CommentContainer = ({
 								onPreview={onPreview}
 								isActive={isCommentFormActive}
 								setIsActive={setIsCommentFormActive}
+								userNameMissing={userNameMissing}
+								setUserNameMissing={setUserNameMissing}
 							/>
 						</div>
 					)}

--- a/dotcom-rendering/src/components/Discussion/CommentForm.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentForm.stories.tsx
@@ -67,6 +67,8 @@ export const Default = () => (
 		onAddComment={(comment) => {}}
 		isActive={false}
 		setIsActive={() => {}}
+		userNameMissing={false}
+		setUserNameMissing={() => {}}
 	/>
 );
 Default.storyName = 'default';
@@ -80,6 +82,8 @@ export const Error = () => (
 		onAddComment={(comment) => {}}
 		isActive={false}
 		setIsActive={() => {}}
+		userNameMissing={false}
+		setUserNameMissing={() => {}}
 	/>
 );
 Error.storyName = 'form with errors';
@@ -93,6 +97,8 @@ export const Active = () => (
 		commentBeingRepliedTo={aComment}
 		isActive={true}
 		setIsActive={() => {}}
+		userNameMissing={false}
+		setUserNameMissing={() => {}}
 	/>
 );
 Active.storyName = 'form is active';
@@ -126,6 +132,8 @@ export const Premoderated = () => (
 		commentBeingRepliedTo={aComment}
 		isActive={true}
 		setIsActive={() => {}}
+		userNameMissing={false}
+		setUserNameMissing={() => {}}
 	/>
 );
 Premoderated.storyName = 'user is premoderated';

--- a/dotcom-rendering/src/components/Discussion/CommentForm.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentForm.tsx
@@ -38,6 +38,8 @@ type Props = {
 	onPreview?: (body: string) => Promise<string>;
 	isActive: boolean;
 	setIsActive: (isActive: boolean) => void;
+	userNameMissing: boolean;
+	setUserNameMissing: (isUserNameMissing: boolean) => void;
 };
 
 const boldString = (str: string) => `<b>${str}</b>`;
@@ -219,8 +221,9 @@ export const CommentForm = ({
 	onPreview,
 	isActive,
 	setIsActive,
+	userNameMissing,
+	setUserNameMissing,
 }: Props) => {
-	const [userNameMissing, setUserNameMissing] = useState<boolean>(false);
 	const [body, setBody] = useState<string>('');
 	const [previewBody, setPreviewBody] = useState<string>('');
 	const [error, setError] = useState<string>('');

--- a/dotcom-rendering/src/components/Discussion/Comments.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comments.tsx
@@ -136,6 +136,7 @@ export const Comments = ({
 	const [isCommentFormActive, setIsCommentFormActive] = useState<boolean>(
 		!!commentBeingRepliedTo,
 	);
+	const [userNameMissing, setUserNameMissing] = useState<boolean>(false);
 
 	const loadingMore = !loading && comments.length !== numberOfCommentsToShow;
 
@@ -298,6 +299,10 @@ export const Comments = ({
 											setIsCommentFormActive={
 												setIsCommentFormActive
 											}
+											userNameMissing={userNameMissing}
+											setUserNameMissing={
+												setUserNameMissing
+											}
 										/>
 									</li>
 								))}
@@ -321,6 +326,8 @@ export const Comments = ({
 					onPreview={onPreview}
 					isActive={isCommentFormActive}
 					setIsActive={setIsCommentFormActive}
+					userNameMissing={userNameMissing}
+					setUserNameMissing={setUserNameMissing}
 				/>
 			)}
 			{!!picks.length && (
@@ -377,6 +384,8 @@ export const Comments = ({
 									setIsCommentFormActive={
 										setIsCommentFormActive
 									}
+									userNameMissing={userNameMissing}
+									setUserNameMissing={setUserNameMissing}
 								/>
 							</li>
 						))}
@@ -404,6 +413,8 @@ export const Comments = ({
 					onPreview={onPreview}
 					isActive={isCommentFormActive}
 					setIsActive={setIsCommentFormActive}
+					userNameMissing={userNameMissing}
+					setUserNameMissing={setUserNameMissing}
 				/>
 			)}
 		</div>


### PR DESCRIPTION
Part of #10225 

## What does this change?
Lifts state for `userNameMissing` from `CommentForm` to `Comments`

## Why?
We want `Discussion` to be the source of truth for shared state. This makes the discussion app easier to read and reason about.

## Testing
Tested in CODE

https://github.com/guardian/dotcom-rendering/assets/19683595/04244f16-b2b5-4f1a-b7d9-c73cf70d5b69



<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
