### PR TITLE
Re-introduce interactivity in `CommentForm` stories

### DIFF
--- a/dotcom-rendering/src/components/Discussion/CommentForm.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentForm.stories.tsx
@@ -1,4 +1,5 @@
 import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
+import { useState } from 'react';
 import { splitTheme } from '../../../.storybook/decorators/splitThemeDecorator';
 import type { CommentType, SignedInUser } from '../../types/discussion';
 import { CommentForm } from './CommentForm';
@@ -60,36 +61,44 @@ const aComment: CommentType = {
 	},
 };
 
-export const Default = () => (
-	<CommentForm
-		shortUrl={shortUrl}
-		user={aUser}
-		onAddComment={(comment) => {}}
-		showPreview={false}
-		setShowPreview={() => {}}
-		isActive={false}
-		setIsActive={() => {}}
-		userNameMissing={false}
-		setUserNameMissing={() => {}}
-	/>
-);
+export const Default = () => {
+	const [isActive, setIsActive] = useState(false);
+
+	return (
+		<CommentForm
+			shortUrl={shortUrl}
+			user={aUser}
+			onAddComment={(comment) => {}}
+			isActive={isActive}
+			setIsActive={setIsActive}
+			showPreview={false}
+			setShowPreview={() => {}}
+			userNameMissing={false}
+			setUserNameMissing={() => {}}
+		/>
+	);
+};
 Default.storyName = 'default';
 Default.decorators = [splitTheme([defaultFormat], { orientation: 'vertical' })];
 
 // This story has a mocked post endpoint that returns an error, see 97d6eab4a98917f63bc96a7ac64f7ca7
-export const Error = () => (
-	<CommentForm
-		shortUrl={'/p/g8g7v'}
-		user={aUser}
-		onAddComment={(comment) => {}}
-		showPreview={false}
-		setShowPreview={() => {}}
-		isActive={false}
-		setIsActive={() => {}}
-		userNameMissing={false}
-		setUserNameMissing={() => {}}
-	/>
-);
+export const Error = () => {
+	const [isActive, setIsActive] = useState(false);
+
+	return (
+		<CommentForm
+			shortUrl={'/p/g8g7v'}
+			user={aUser}
+			onAddComment={(comment) => {}}
+			isActive={isActive}
+			setIsActive={setIsActive}
+			showPreview={false}
+			setShowPreview={() => {}}
+			userNameMissing={false}
+			setUserNameMissing={() => {}}
+		/>
+	);
+};
 Error.storyName = 'form with errors';
 Error.decorators = [splitTheme([defaultFormat], { orientation: 'vertical' })];
 


### PR DESCRIPTION
## What does this change?

Re-introduces stories interactivity that was removed in:
* https://github.com/guardian/dotcom-rendering/pull/10311

## Why?
It was easy enough to re-introduce it and there's no harm. Testing these behaviours [with an integration test](https://github.com/guardian/dotcom-rendering/issues/10316) is still valid.

https://github.com/guardian/dotcom-rendering/assets/19683595/dd4ecd87-9b16-4556-851d-26638e948939

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
