### PR TITLE
Lower scale down threshold for asrticle rendering app in PROD

### DIFF
--- a/dotcom-rendering/cdk/lib/__snapshots__/renderingStack.test.ts.snap
+++ b/dotcom-rendering/cdk/lib/__snapshots__/renderingStack.test.ts.snap
@@ -638,7 +638,7 @@ exports[`The RenderingCDKStack matches the snapshot 1`] = `
         "Namespace": "AWS/ApplicationELB",
         "Period": 30,
         "Statistic": "Average",
-        "Threshold": 0.15,
+        "Threshold": 0.12,
       },
       "Type": "AWS::CloudWatch::Alarm",
     },

--- a/dotcom-rendering/cdk/lib/renderingStack.ts
+++ b/dotcom-rendering/cdk/lib/renderingStack.ts
@@ -199,12 +199,12 @@ export class RenderingCDKStack extends CDKStack {
 				{
 					// No scaling down effect when latency is higher than 0.15s
 					change: 0,
-					lower: 0.15,
+					lower: 0.12,
 				},
 				{
 					// When latency is lower than 0.15s we scale down by 1
 					change: -1,
-					upper: 0.15,
+					upper: 0.12,
 					lower: 0,
 				},
 			],


### PR DESCRIPTION
## What does this change?

Lower the scale down threshold. 

## Why?

Follow up on https://github.com/guardian/dotcom-rendering/pull/10287
Because we are still scaling down too soon. 
