### PR TITLE
What if we made the `id` of Video Main Media optional?

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -472,7 +472,10 @@ export const Card = ({
 											defer={{ until: 'visible' }}
 										>
 											<YoutubeBlockComponent
-												id={media.mainMedia.id}
+												id={
+													media.mainMedia.id ??
+													'something-very-odd-happened-but-let-us-crack-on'
+												}
 												assetId={
 													media.mainMedia.videoId
 												}

--- a/dotcom-rendering/src/model/article-schema.json
+++ b/dotcom-rendering/src/model/article-schema.json
@@ -4441,7 +4441,6 @@
                         "duration",
                         "expired",
                         "height",
-                        "id",
                         "images",
                         "origin",
                         "title",

--- a/dotcom-rendering/src/model/front-schema.json
+++ b/dotcom-rendering/src/model/front-schema.json
@@ -3624,7 +3624,6 @@
                         "duration",
                         "expired",
                         "height",
-                        "id",
                         "images",
                         "origin",
                         "title",

--- a/dotcom-rendering/src/types/mainMedia.ts
+++ b/dotcom-rendering/src/types/mainMedia.ts
@@ -6,7 +6,7 @@ type Media = {
 type Video = Media & {
 	type: 'Video';
 	/** @see https://github.com/guardian/frontend/blob/8e7e4d0e/common/app/model/content/Atom.scala#L159 */
-	id: string;
+	id?: string;
 	videoId: string;
 	height: number;
 	width: number;


### PR DESCRIPTION
## What does this change?

Revert #10255

## Why?

Part of an experiment from @JamieB-gu & @alinaboghiu