### PR TITLE
Bump `pnpm` and remove `prebid` protocol override

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,10 +30,5 @@
 		"prettier": "3.0.3",
 		"tslib": "2.6.2"
 	},
-	"packageManager": "pnpm@8.12.1",
-	"pnpm": {
-		"overrides": {
-			"prebid.js": "github:guardian/prebid.js#91cabf5cdfc3c01745f4b10e55044f95a9d7d1b4"
-		}
-	}
+	"packageManager": "pnpm@8.12.1"
 }

--- a/package.json
+++ b/package.json
@@ -30,5 +30,5 @@
 		"prettier": "3.0.3",
 		"tslib": "2.6.2"
 	},
-	"packageManager": "pnpm@8.12.1"
+	"packageManager": "pnpm@8.14.3"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,9 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  prebid.js: github:guardian/prebid.js#91cabf5cdfc3c01745f4b10e55044f95a9d7d1b4
-
 importers:
 
   .:


### PR DESCRIPTION
## What does this change?

- bumps `pnpm`
- removes `prebid` protocol override

## Why?

dependabot actions are failing to install prebid from our fork.

i'm not sure why this has only come to light now. my hunch is that it was introduced in #9476, but there has not been enough action on dependabot PRs since it merged for anyone to notice.

#10332 triggered a lot of dependabot activity, which is why i think it's become so obvious now...

https://github.com/dependabot/dependabot-core/issues/7258 suggests there was a problem with pnpm, but i added the prebid dep to CSNX to test it, and it ran fine: https://github.com/guardian/csnx/actions/runs/7666076186/job/20893168900?pr=1112

there are various improvements to how pnpm handles installing from git [the releases to the version in csnx and the version in this repo](https://github.com/pnpm/pnpm/compare/v8.12.1...v8.14.3), so i'm really hoping that will be the fix!



