### PR TITLE
Only build fonts CSS once

### DIFF
--- a/dotcom-rendering/.storybook/preview.ts
+++ b/dotcom-rendering/.storybook/preview.ts
@@ -10,7 +10,7 @@ import { AB } from '@guardian/ab-core';
 import isChromatic from 'chromatic/isChromatic';
 import MockDate from 'mockdate';
 
-import { getFontsCss } from '../src/lib/fonts-css';
+import { fontsCss } from '../src/lib/fonts-css';
 
 import { resets } from '@guardian/source-foundations';
 
@@ -44,7 +44,7 @@ setABTests(
 );
 
 // Add base css for the site
-let css = `${getFontsCss()}${resets.resetCSS}`;
+let css = `${fontsCss}${resets.resetCSS}`;
 let head = document.getElementsByTagName('head')[0];
 let style = document.createElement('style');
 head.appendChild(style);

--- a/dotcom-rendering/src/lib/fonts-css.ts
+++ b/dotcom-rendering/src/lib/fonts-css.ts
@@ -252,26 +252,20 @@ const fontList: FontDisplay[] = [
 const getFontUrl = (path: string): string =>
 	`https://assets.guim.co.uk/static/frontend/${path}`;
 
-export const getFontsCss = (): string => {
-	let fontCss = '';
+const rawFontsCss = fontList
+	.map(
+		(font) => `
+@font-face {
+	font-family: "${font.family}";
+	src: url(${getFontUrl(font.woff2)}) format("woff2"),
+			url(${getFontUrl(font.woff)}) format("woff"),
+			url(${getFontUrl(font.ttf)}) format("truetype");
+	font-weight: ${font.weight};
+	font-style: ${font.style};
+	font-display: swap;
+}
+`,
+	)
+	.join('\n');
 
-	for (const font of fontList) {
-		const woff2 = getFontUrl(font.woff2);
-		const woff = getFontUrl(font.woff);
-		const ttf = getFontUrl(font.ttf);
-
-		fontCss += `
-			@font-face {
-				font-family: "${font.family}";
-				src: url(${woff2}) format("woff2"),
-						url(${woff}) format("woff"),
-						url(${ttf}) format("truetype");
-				font-weight: ${font.weight};
-				font-style: ${font.style};
-				font-display: swap;
-			}
-		`;
-	}
-
-	return new CleanCSS().minify(fontCss).styles;
-};
+export const fontsCss = new CleanCSS().minify(rawFontsCss).styles;

--- a/dotcom-rendering/src/server/htmlPageTemplate.ts
+++ b/dotcom-rendering/src/server/htmlPageTemplate.ts
@@ -2,7 +2,7 @@ import { resets, palette as sourcePalette } from '@guardian/source-foundations';
 import he from 'he';
 import { ASSET_ORIGIN } from '../lib/assets';
 import { escapeData } from '../lib/escapeData';
-import { getFontsCss } from '../lib/fonts-css';
+import { fontsCss } from '../lib/fonts-css';
 import type { Guardian } from '../model/guardian';
 import type { RenderingTarget } from '../types/renderingTarget';
 import { GIT_COMMIT_HASH } from './prout';
@@ -362,7 +362,7 @@ https://workforus.theguardian.com/careers/product-engineering/
 						: ''
 				}
                 ${scriptTags.join('\n')}
-                <style class="webfont">${getFontsCss()}</style>
+                <style class="webfont">${fontsCss}</style>
                 <style>${resets.resetCSS}</style>
 				${css}
 				<link rel="stylesheet" media="print" href="${ASSET_ORIGIN}static/frontend/css/print.css">

--- a/dotcom-rendering/src/server/render.article.amp.tsx
+++ b/dotcom-rendering/src/server/render.article.amp.tsx
@@ -8,7 +8,7 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import { ConfigProvider } from '../components/ConfigContext';
 import { epicChoiceCardCss } from '../components/Epic.amp';
 import { stickyAdLabelCss } from '../components/StickyAd.amp';
-import { getFontsCss } from '../lib/fonts-css';
+import { fontsCss } from '../lib/fonts-css';
 import type { Config } from '../types/configContext';
 
 interface RenderToStringResult {
@@ -103,7 +103,7 @@ export const renderArticle = ({
     ${scripts.join(' ')}
 
     <style amp-custom>
-        ${getFontsCss()}
+        ${fontsCss}
         ${resets.resetCSS}
         ${css}
 		${stickyAdLabelCss}


### PR DESCRIPTION
## What does this change?

Turn the `getFontsCss` function into a static string called at module initialisation.

## Why?

No need to minify the styles on every request.

## Screenshots

Identical, see Chromatic