### PR TITLE
Increase latency evaluation period

### DIFF
--- a/dotcom-rendering/cdk/lib/__snapshots__/renderingStack.test.ts.snap
+++ b/dotcom-rendering/cdk/lib/__snapshots__/renderingStack.test.ts.snap
@@ -688,7 +688,7 @@ exports[`The RenderingCDKStack matches the snapshot 1`] = `
             },
           },
         ],
-        "EvaluationPeriods": 1,
+        "EvaluationPeriods": 5,
         "MetricName": "TargetResponseTime",
         "Namespace": "AWS/ApplicationELB",
         "Period": 30,

--- a/dotcom-rendering/cdk/lib/renderingStack.ts
+++ b/dotcom-rendering/cdk/lib/renderingStack.ts
@@ -175,7 +175,7 @@ export class RenderingCDKStack extends CDKStack {
 					},
 				],
 				adjustmentType: AdjustmentType.PERCENT_CHANGE_IN_CAPACITY,
-				evaluationPeriods: 1,
+				evaluationPeriods: 5,
 			},
 		);
 


### PR DESCRIPTION
## What does this change?

Increase the article rendering app latency evaluation period such that we only scale up if latency is higher than 0.2s for at least 2.5 min.

## Why?

This prevents us scaling up too soon and the instance count changing like this: 

<img width="1368" alt="Screenshot 2024-01-26 at 12 46 51" src="https://github.com/guardian/dotcom-rendering/assets/1229808/c1b68295-4ce0-4118-bff1-b6747099b6ee">
