### PR TITLE
Refactor `getDiscussion`

### DIFF
--- a/dotcom-rendering/fixtures/manual/discussion-no-top-comments.ts
+++ b/dotcom-rendering/fixtures/manual/discussion-no-top-comments.ts
@@ -1,4 +1,4 @@
-import type { DiscussionSuccess } from '../../src/types/discussion';
+import type { GetDiscussionSuccess } from '../../src/types/discussion';
 
 export const discussionNoTopComments = {
 	status: 'ok',
@@ -18,4 +18,4 @@ export const discussionNoTopComments = {
 		webUrl: 'https://www.theguardian.com/music/2014/jul/25/stevie-nicks-ro-release-double-album-of-songs-from-her-past',
 		comments: [],
 	},
-} satisfies DiscussionSuccess;
+} satisfies GetDiscussionSuccess;

--- a/dotcom-rendering/fixtures/manual/discussion-no-top-comments.ts
+++ b/dotcom-rendering/fixtures/manual/discussion-no-top-comments.ts
@@ -1,4 +1,4 @@
-import type { DiscussionResponse } from '../../src/types/discussion';
+import type { DiscussionSuccess } from '../../src/types/discussion';
 
 export const discussionNoTopComments = {
 	status: 'ok',
@@ -18,4 +18,4 @@ export const discussionNoTopComments = {
 		webUrl: 'https://www.theguardian.com/music/2014/jul/25/stevie-nicks-ro-release-double-album-of-songs-from-her-past',
 		comments: [],
 	},
-} satisfies DiscussionResponse;
+} satisfies DiscussionSuccess;

--- a/dotcom-rendering/fixtures/manual/discussion.ts
+++ b/dotcom-rendering/fixtures/manual/discussion.ts
@@ -1,4 +1,4 @@
-import type { DiscussionSuccess } from '../../src/types/discussion';
+import type { GetDiscussionSuccess } from '../../src/types/discussion';
 
 export const discussion = {
 	status: 'ok',
@@ -1183,4 +1183,4 @@ export const discussion = {
 			},
 		],
 	},
-} satisfies DiscussionSuccess;
+} satisfies GetDiscussionSuccess;

--- a/dotcom-rendering/fixtures/manual/discussion.ts
+++ b/dotcom-rendering/fixtures/manual/discussion.ts
@@ -1,4 +1,4 @@
-import type { DiscussionResponse } from '../../src/types/discussion';
+import type { DiscussionSuccess } from '../../src/types/discussion';
 
 export const discussion = {
 	status: 'ok',
@@ -1183,4 +1183,4 @@ export const discussion = {
 			},
 		],
 	},
-} satisfies DiscussionResponse;
+} satisfies DiscussionSuccess;

--- a/dotcom-rendering/fixtures/manual/discussionWithNoComments.ts
+++ b/dotcom-rendering/fixtures/manual/discussionWithNoComments.ts
@@ -1,4 +1,4 @@
-import type { DiscussionSuccess } from '../../src/types/discussion';
+import type { GetDiscussionSuccess } from '../../src/types/discussion';
 
 export const discussionWithNoComments = {
 	status: 'ok',
@@ -18,4 +18,4 @@ export const discussionWithNoComments = {
 		title: 'Mystery bird: black-and-red broadbill, Cymbirhynchus macrorhynchos story',
 		comments: [],
 	},
-} satisfies DiscussionSuccess;
+} satisfies GetDiscussionSuccess;

--- a/dotcom-rendering/fixtures/manual/discussionWithNoComments.ts
+++ b/dotcom-rendering/fixtures/manual/discussionWithNoComments.ts
@@ -1,4 +1,4 @@
-import type { DiscussionResponse } from '../../src/types/discussion';
+import type { DiscussionSuccess } from '../../src/types/discussion';
 
 export const discussionWithNoComments = {
 	status: 'ok',
@@ -18,4 +18,4 @@ export const discussionWithNoComments = {
 		title: 'Mystery bird: black-and-red broadbill, Cymbirhynchus macrorhynchos story',
 		comments: [],
 	},
-} satisfies DiscussionResponse;
+} satisfies DiscussionSuccess;

--- a/dotcom-rendering/fixtures/manual/discussionWithTwoComments.ts
+++ b/dotcom-rendering/fixtures/manual/discussionWithTwoComments.ts
@@ -1,4 +1,4 @@
-import type { DiscussionSuccess } from '../../src/types/discussion';
+import type { GetDiscussionSuccess } from '../../src/types/discussion';
 
 export const discussionWithTwoComments = {
 	status: 'ok',
@@ -63,4 +63,4 @@ export const discussionWithTwoComments = {
 			},
 		],
 	},
-} satisfies DiscussionSuccess;
+} satisfies GetDiscussionSuccess;

--- a/dotcom-rendering/fixtures/manual/discussionWithTwoComments.ts
+++ b/dotcom-rendering/fixtures/manual/discussionWithTwoComments.ts
@@ -1,4 +1,4 @@
-import type { DiscussionResponse } from '../../src/types/discussion';
+import type { DiscussionSuccess } from '../../src/types/discussion';
 
 export const discussionWithTwoComments = {
 	status: 'ok',
@@ -63,4 +63,4 @@ export const discussionWithTwoComments = {
 			},
 		],
 	},
-} satisfies DiscussionResponse;
+} satisfies DiscussionSuccess;

--- a/dotcom-rendering/fixtures/manual/short-discussion.ts
+++ b/dotcom-rendering/fixtures/manual/short-discussion.ts
@@ -1,4 +1,4 @@
-import type { DiscussionResponse } from '../../src/types/discussion';
+import type { DiscussionSuccess } from '../../src/types/discussion';
 
 export const shortDiscussion = {
 	status: 'ok',
@@ -59,4 +59,4 @@ export const shortDiscussion = {
 			},
 		],
 	},
-} satisfies DiscussionResponse;
+} satisfies DiscussionSuccess;

--- a/dotcom-rendering/fixtures/manual/short-discussion.ts
+++ b/dotcom-rendering/fixtures/manual/short-discussion.ts
@@ -1,4 +1,4 @@
-import type { DiscussionSuccess } from '../../src/types/discussion';
+import type { GetDiscussionSuccess } from '../../src/types/discussion';
 
 export const shortDiscussion = {
 	status: 'ok',
@@ -59,4 +59,4 @@ export const shortDiscussion = {
 			},
 		],
 	},
-} satisfies DiscussionSuccess;
+} satisfies GetDiscussionSuccess;

--- a/dotcom-rendering/src/components/Discussion.tsx
+++ b/dotcom-rendering/src/components/Discussion.tsx
@@ -112,15 +112,21 @@ export const Discussion = ({
 	useEffect(() => {
 		setLoading(true);
 		void getDiscussion(shortUrlId, { ...filters, page: commentPage })
-			.then((json) => {
-				setLoading(false);
-				if (json && json.status !== 'error') {
-					setComments(json.discussion.comments);
-					setIsClosedForComments(json.discussion.isClosedForComments);
+			.then((result) => {
+				if (result.kind === 'error') {
+					console.error(`getDiscussion - error: ${result.error}`);
+					return;
 				}
-				if (json?.pages != null) setTotalPages(json.pages);
+
+				setLoading(false);
+				const { pages, discussion } = result.value;
+				setComments(discussion.comments);
+				setIsClosedForComments(discussion.isClosedForComments);
+				setTotalPages(pages);
 			})
-			.catch((e) => console.error(`getDiscussion - error: ${String(e)}`));
+			.catch(() => {
+				// do nothing
+			});
 	}, [filters, commentPage, shortUrlId]);
 
 	const validFilters = remapFilters(filters, hashCommentId);

--- a/dotcom-rendering/src/components/DiscussionMeta.importable.tsx
+++ b/dotcom-rendering/src/components/DiscussionMeta.importable.tsx
@@ -3,34 +3,13 @@ import { getOptionsHeadersWithOkta } from '../lib/identity';
 import { useApi } from '../lib/useApi';
 import { useAuthStatus } from '../lib/useAuthStatus';
 import { useCommentCount } from '../lib/useCommentCount';
+import type { GetDiscussionSuccess } from '../types/discussion';
 import { SignedInAs } from './SignedInAs';
 
 type Props = {
 	discussionApiUrl: string;
 	shortUrlId: string;
 	enableDiscussionSwitch: boolean;
-};
-
-/** @deprecated when we unify the state we will no longer need this extra network call */
-type DiscussionResponse = {
-	// status: string;
-	// errorCode?: string;
-	// currentPage: number;
-	// pages: number;
-	// pageSize: number;
-	// orderBy: string;
-	discussion: {
-		// key: string;
-		// webUrl: string;
-		// apiUrl: string;
-		// commentCount: number;
-		// topLevelCommentCount: number;
-		isClosedForComments: boolean;
-		// isClosedForRecommendation: boolean;
-		// isThreaded: boolean;
-		// title: string;
-		// comments: CommentType[];
-	};
 };
 
 export const DiscussionMeta = ({
@@ -41,7 +20,7 @@ export const DiscussionMeta = ({
 	const authStatus = useAuthStatus();
 	const commentCount = useCommentCount(discussionApiUrl, shortUrlId);
 
-	const { data: discussionData } = useApi<DiscussionResponse>(
+	const { data: discussionData } = useApi<GetDiscussionSuccess>(
 		joinUrl(discussionApiUrl, 'discussion', shortUrlId),
 		{
 			// The default for dedupingInterval is 2 seconds but we want to wait longer here because the cache time

--- a/dotcom-rendering/src/components/DiscussionMeta.importable.tsx
+++ b/dotcom-rendering/src/components/DiscussionMeta.importable.tsx
@@ -3,13 +3,34 @@ import { getOptionsHeadersWithOkta } from '../lib/identity';
 import { useApi } from '../lib/useApi';
 import { useAuthStatus } from '../lib/useAuthStatus';
 import { useCommentCount } from '../lib/useCommentCount';
-import type { DiscussionResponse } from '../types/discussion';
 import { SignedInAs } from './SignedInAs';
 
 type Props = {
 	discussionApiUrl: string;
 	shortUrlId: string;
 	enableDiscussionSwitch: boolean;
+};
+
+/** @deprecated when we unify the state we will no longer need this extra network call */
+type DiscussionResponse = {
+	// status: string;
+	// errorCode?: string;
+	// currentPage: number;
+	// pages: number;
+	// pageSize: number;
+	// orderBy: string;
+	discussion: {
+		// key: string;
+		// webUrl: string;
+		// apiUrl: string;
+		// commentCount: number;
+		// topLevelCommentCount: number;
+		isClosedForComments: boolean;
+		// isClosedForRecommendation: boolean;
+		// isThreaded: boolean;
+		// title: string;
+		// comments: CommentType[];
+	};
 };
 
 export const DiscussionMeta = ({

--- a/dotcom-rendering/src/lib/discussionApi.tsx
+++ b/dotcom-rendering/src/lib/discussionApi.tsx
@@ -5,7 +5,7 @@ import type {
 	CommentResponse,
 	CommentType,
 	DiscussionOptions,
-	DiscussionSuccess,
+	GetDiscussionSuccess,
 	OrderByType,
 	ThreadsType,
 	UserNameResponse,
@@ -69,7 +69,7 @@ export const getDiscussion = async (
 		threads: ThreadsType;
 		page: number;
 	},
-): Promise<Result<GetDiscussionError, DiscussionSuccess>> => {
+): Promise<Result<GetDiscussionError, GetDiscussionSuccess>> => {
 	const apiOpts: DiscussionOptions = {
 		...defaultParams,
 		...{

--- a/dotcom-rendering/src/lib/json.ts
+++ b/dotcom-rendering/src/lib/json.ts
@@ -1,0 +1,21 @@
+import type { Result } from './result';
+
+/**
+ * Safely fetch JSON from a URL.
+ *
+ * If successful, the value is typed as `unknown`.
+ */
+export const fetchJSON = async (
+	...args: Parameters<typeof fetch>
+): Promise<Result<'ApiError' | 'NetworkError', unknown>> => {
+	try {
+		const response = await fetch(...args);
+		return { kind: 'ok', value: await response.json() };
+	} catch (error) {
+		if (error instanceof SyntaxError) {
+			return { kind: 'error', error: 'ApiError' };
+		}
+
+		return { kind: 'error', error: 'NetworkError' };
+	}
+};

--- a/dotcom-rendering/src/lib/result.ts
+++ b/dotcom-rendering/src/lib/result.ts
@@ -1,0 +1,11 @@
+type Result<Err, Value> =
+	| {
+			kind: 'ok';
+			value: Value;
+	  }
+	| {
+			kind: 'error';
+			error: Err;
+	  };
+
+export type { Result };

--- a/dotcom-rendering/src/types/discussion.ts
+++ b/dotcom-rendering/src/types/discussion.ts
@@ -235,7 +235,7 @@ const discussionApiErrorSchema = object({
 	errorCode: optional(string()),
 });
 
-export type DiscussionSuccess = {
+export type GetDiscussionSuccess = {
 	status: 'ok';
 	currentPage: number;
 	pages: number;


### PR DESCRIPTION
## What does this change?

- More accurate parsing and safer error handling in `getDiscussion`
- introduce `Result` which is a discriminated union with a success and failure variant 
- introduce `fetchJSON` which returns a `Result<'ApiError' | 'NetworkError', unknown>`, and allows safely deserialising any JSON from a URL

## Why?

Part of #8745 

## Screenshots

No change (tested locally)