### PR TITLE
Reintroduce interactivity in `CommentForm` story with errors

### DIFF
--- a/dotcom-rendering/src/components/Discussion/CommentForm.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentForm.stories.tsx
@@ -84,6 +84,7 @@ Default.decorators = [splitTheme([defaultFormat], { orientation: 'vertical' })];
 // This story has a mocked post endpoint that returns an error, see 97d6eab4a98917f63bc96a7ac64f7ca7
 export const Error = () => {
 	const [isActive, setIsActive] = useState(false);
+	const [userNameMissing, setUserNameMissing] = useState(false);
 
 	return (
 		<CommentForm
@@ -94,8 +95,8 @@ export const Error = () => {
 			setIsActive={setIsActive}
 			showPreview={false}
 			setShowPreview={() => {}}
-			userNameMissing={false}
-			setUserNameMissing={() => {}}
+			userNameMissing={userNameMissing}
+			setUserNameMissing={setUserNameMissing}
 		/>
 	);
 };


### PR DESCRIPTION
Missed from https://github.com/guardian/dotcom-rendering/pull/10327

https://github.com/guardian/dotcom-rendering/assets/19683595/885b6300-794d-4e62-a02e-df002acfb48f
