### PR TITLE
URI Encode Branding `src` To Make Sure It's Valid

### DIFF
--- a/dotcom-rendering/src/components/Branding.importable.tsx
+++ b/dotcom-rendering/src/components/Branding.importable.tsx
@@ -83,7 +83,7 @@ function decideLogo(
 				<source
 					width={maybeDarkLogo.dimensions.width}
 					height={maybeDarkLogo.dimensions.height}
-					srcSet={maybeDarkLogo.src}
+					srcSet={encodeURI(maybeDarkLogo.src)}
 					media={`(max-width: ${breakpoints.desktop - 1}px)`}
 				/>
 			)}
@@ -92,7 +92,7 @@ function decideLogo(
 				<source
 					width={branding.logoForDarkBackground.dimensions.width}
 					height={branding.logoForDarkBackground.dimensions.height}
-					srcSet={branding.logoForDarkBackground.src}
+					srcSet={encodeURI(branding.logoForDarkBackground.src)}
 					media={'(prefers-color-scheme: dark)'}
 				/>
 			)}
@@ -100,7 +100,7 @@ function decideLogo(
 			<img
 				width={branding.logo.dimensions.width}
 				height={branding.logo.dimensions.height}
-				src={branding.logo.src}
+				src={encodeURI(branding.logo.src)}
 				alt={branding.sponsorName}
 			/>
 		</picture>


### PR DESCRIPTION
Branding asset URLs sometimes include spaces, which are not valid URI characters. This doesn't necessarily cause a problem when used in a `src`[^1] attribute, as browsers can encode them automatically. However, in the `srcset`[^2] attribute, whitespace is used to separate URLs and condition descriptors, so it doesn't automatically get encoded.

In most cases in light mode, an `img` with a `src` attribute is used for branding logos. So if the asset URL contains spaces it is still displayed correctly. However, in dark mode, and in some cases on liveblogs, a `source` with a `srcset` attribute is used, so an asset URL with spaces will not display correctly. This was spotted by @benwuersching

This change uses `encodeURI`[^3] for all logo assets, in light and dark mode, to make sure they display correctly. Something similar happens in AR:

https://github.com/guardian/dotcom-rendering/blob/161204d89b89d9d54cebec5586d336995a87d420/apps-rendering/src/components/Logo/index.tsx#L103-L104

[^1]: https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/src
[^2]: https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/srcset
[^3]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURI

## Screenshots

| | Before | After |
| - | - | - |
| Light Mode | ![before-light-mode] | ![after-light-mode] |
| Dark Mode | ![before-dark-mode] | ![after-dark-mode] |

[before-light-mode]: https://github.com/guardian/dotcom-rendering/assets/53781962/350e6735-376f-47ea-b242-0ad0ce95b100
[before-dark-mode]: https://github.com/guardian/dotcom-rendering/assets/53781962/31db2958-27dc-47c5-850b-cb365a6297a0
[after-dark-mode]: https://github.com/guardian/dotcom-rendering/assets/53781962/12ebe95a-13ed-42f5-93d9-9440f287ece6
[after-light-mode]: https://github.com/guardian/dotcom-rendering/assets/53781962/a2ff17c2-346f-4dd1-a549-cb18c2336c56
