### PR TITLE
Lift `previewBody` state from `CommentForm` to `Comments`

### DIFF
--- a/dotcom-rendering/src/components/Discussion/CommentContainer.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentContainer.stories.tsx
@@ -197,6 +197,8 @@ export const defaultStory = () => (
 		setUserNameMissing={() => {}}
 		body={''}
 		setBody={() => {}}
+		previewBody={''}
+		setPreviewBody={() => {}}
 	/>
 );
 defaultStory.storyName = 'default';
@@ -231,6 +233,8 @@ export const threadedComment = () => (
 		setUserNameMissing={() => {}}
 		body={''}
 		setBody={() => {}}
+		previewBody={''}
+		setPreviewBody={() => {}}
 	/>
 );
 threadedComment.storyName = 'threaded';
@@ -265,6 +269,8 @@ export const threadedCommentWithShowMore = () => (
 		setUserNameMissing={() => {}}
 		body={''}
 		setBody={() => {}}
+		previewBody={''}
+		setPreviewBody={() => {}}
 	/>
 );
 threadedCommentWithShowMore.storyName = 'threaded with show more button';
@@ -299,6 +305,8 @@ export const threadedCommentWithLongUsernames = () => (
 		setUserNameMissing={() => {}}
 		body={''}
 		setBody={() => {}}
+		previewBody={''}
+		setPreviewBody={() => {}}
 	/>
 );
 threadedCommentWithLongUsernames.storyName = 'threaded with long usernames';
@@ -333,6 +341,8 @@ export const threadedCommentWithLongUsernamesMobile = () => (
 		setUserNameMissing={() => {}}
 		body={''}
 		setBody={() => {}}
+		previewBody={''}
+		setPreviewBody={() => {}}
 	/>
 );
 threadedCommentWithLongUsernamesMobile.storyName =

--- a/dotcom-rendering/src/components/Discussion/CommentContainer.test.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentContainer.test.tsx
@@ -74,6 +74,8 @@ describe('CommentContainer', () => {
 				setUserNameMissing={() => {}}
 				body={newCommentText}
 				setBody={() => {}}
+				previewBody={''}
+				setPreviewBody={() => {}}
 			/>,
 		);
 
@@ -119,6 +121,8 @@ describe('CommentContainer', () => {
 				setUserNameMissing={() => {}}
 				body={''}
 				setBody={() => {}}
+				previewBody={''}
+				setPreviewBody={() => {}}
 			/>,
 		);
 
@@ -163,6 +167,8 @@ describe('CommentContainer', () => {
 				setUserNameMissing={() => {}}
 				body={newCommentText}
 				setBody={() => {}}
+				previewBody={''}
+				setPreviewBody={() => {}}
 			/>,
 		);
 
@@ -208,6 +214,8 @@ describe('CommentContainer', () => {
 				setUserNameMissing={() => {}}
 				body={''}
 				setBody={() => {}}
+				previewBody={''}
+				setPreviewBody={() => {}}
 			/>,
 		);
 

--- a/dotcom-rendering/src/components/Discussion/CommentContainer.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentContainer.tsx
@@ -38,6 +38,8 @@ type Props = {
 	setUserNameMissing: (isUserNameMissing: boolean) => void;
 	body: string;
 	setBody: (body: string) => void;
+	previewBody: string;
+	setPreviewBody: (body: string) => void;
 };
 
 const nestingStyles = css`
@@ -97,6 +99,8 @@ export const CommentContainer = ({
 	setUserNameMissing,
 	body,
 	setBody,
+	previewBody,
+	setPreviewBody,
 }: Props) => {
 	// Filter logic
 	const [expanded, setExpanded] = useState<boolean>(threads === 'expanded');
@@ -242,6 +246,8 @@ export const CommentContainer = ({
 								setUserNameMissing={setUserNameMissing}
 								body={body}
 								setBody={setBody}
+								previewBody={previewBody}
+								setPreviewBody={setPreviewBody}
 							/>
 						</div>
 					)}

--- a/dotcom-rendering/src/components/Discussion/CommentForm.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentForm.stories.tsx
@@ -78,6 +78,8 @@ export const Default = () => {
 			setUserNameMissing={() => {}}
 			body={body}
 			setBody={setBody}
+			previewBody={''}
+			setPreviewBody={() => {}}
 		/>
 	);
 };
@@ -103,6 +105,8 @@ export const Error = () => {
 			setUserNameMissing={setUserNameMissing}
 			body={body}
 			setBody={setBody}
+			previewBody={''}
+			setPreviewBody={() => {}}
 		/>
 	);
 };
@@ -126,6 +130,8 @@ export const Active = () => {
 			setUserNameMissing={() => {}}
 			body={body}
 			setBody={setBody}
+			previewBody={''}
+			setPreviewBody={() => {}}
 		/>
 	);
 };
@@ -169,6 +175,8 @@ export const Premoderated = () => {
 			setUserNameMissing={() => {}}
 			body={body}
 			setBody={setBody}
+			previewBody={''}
+			setPreviewBody={() => {}}
 		/>
 	);
 };

--- a/dotcom-rendering/src/components/Discussion/CommentForm.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentForm.tsx
@@ -36,6 +36,8 @@ type Props = {
 	setUserNameMissing: (isUserNameMissing: boolean) => void;
 	body: string;
 	setBody: (body: string) => void;
+	previewBody: string;
+	setPreviewBody: (body: string) => void;
 };
 
 const boldString = (str: string) => `<b>${str}</b>`;
@@ -227,8 +229,9 @@ export const CommentForm = ({
 	setUserNameMissing,
 	body,
 	setBody,
+	previewBody,
+	setPreviewBody,
 }: Props) => {
-	const [previewBody, setPreviewBody] = useState<string>('');
 	const [error, setError] = useState<string>('');
 	const [info, setInfo] = useState<string>('');
 	const textAreaRef = useRef<HTMLTextAreaElement>(null);

--- a/dotcom-rendering/src/components/Discussion/Comments.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comments.tsx
@@ -135,6 +135,7 @@ export const Comments = ({
 	);
 	const [userNameMissing, setUserNameMissing] = useState<boolean>(false);
 	const [body, setBody] = useState('');
+	const [previewBody, setPreviewBody] = useState<string>('');
 
 	const loadingMore = !loading && comments.length !== numberOfCommentsToShow;
 
@@ -305,6 +306,8 @@ export const Comments = ({
 											}
 											body={body}
 											setBody={setBody}
+											previewBody={previewBody}
+											setPreviewBody={setPreviewBody}
 										/>
 									</li>
 								))}
@@ -334,6 +337,8 @@ export const Comments = ({
 					setUserNameMissing={setUserNameMissing}
 					body={body}
 					setBody={setBody}
+					previewBody={previewBody}
+					setPreviewBody={setPreviewBody}
 				/>
 			)}
 			{!!picks.length && (
@@ -396,6 +401,8 @@ export const Comments = ({
 									setUserNameMissing={setUserNameMissing}
 									body={body}
 									setBody={setBody}
+									previewBody={previewBody}
+									setPreviewBody={setPreviewBody}
 								/>
 							</li>
 						))}
@@ -429,6 +436,8 @@ export const Comments = ({
 					setUserNameMissing={setUserNameMissing}
 					body={body}
 					setBody={setBody}
+					previewBody={previewBody}
+					setPreviewBody={setPreviewBody}
 				/>
 			)}
 		</div>


### PR DESCRIPTION
## What does this change?

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
