### PR TITLE
Move discussion state into reducer

### DIFF
--- a/dotcom-rendering/src/components/Discussion.tsx
+++ b/dotcom-rendering/src/components/Discussion.tsx
@@ -115,7 +115,7 @@ type Action =
 	  }
 	| { type: 'expandComments' }
 	| { type: 'addComment'; comment: CommentType }
-	| { type: 'updateCommentPage'; commentPage: number; isExpanded: boolean }
+	| { type: 'updateCommentPage'; commentPage: number; shouldExpand: boolean }
 	| {
 			type: 'updateFilters';
 			filters: FilterOptions;
@@ -145,7 +145,7 @@ const reducer = (state: State, action: Action): State => {
 			return {
 				...state,
 				commentPage: action.commentPage,
-				isExpanded: action.isExpanded,
+				isExpanded: action.shouldExpand ? true : state.isExpanded,
 			};
 		case 'updateFilters':
 			return {
@@ -230,8 +230,11 @@ export const Discussion = ({
 		if (hashCommentId !== undefined) {
 			getCommentContext(discussionApiUrl, hashCommentId)
 				.then((context) => {
-					setCommentPage(context.page);
-					setIsExpanded(true);
+					dispatch({
+						type: 'updateCommentPage',
+						commentPage: context.page,
+						shouldExpand: true,
+					});
 				})
 				.catch((e) =>
 					console.error(`getCommentContext - error: ${String(e)}`),
@@ -290,11 +293,11 @@ export const Discussion = ({
 					}}
 					idApiUrl={idApiUrl}
 					page={commentPage}
-					setPage={(page: number) => {
+					setPage={(page: number, shouldExpand: boolean) => {
 						dispatch({
 							type: 'updateCommentPage',
 							commentPage: page,
-							isExpanded: true,
+							shouldExpand,
 						});
 					}}
 					filters={validFilters}

--- a/dotcom-rendering/src/components/Discussion.tsx
+++ b/dotcom-rendering/src/components/Discussion.tsx
@@ -214,7 +214,7 @@ export const Discussion = ({
 		// Put this comment id into the hashCommentId state which will
 		// trigger an api call to get the comment context and then expand
 		// and reload the discussion based on the resuts
-		setHashCommentId(commentId);
+		dispatch({ type: 'updateHashCommentId', hashCommentId: commentId });
 		return false;
 	};
 

--- a/dotcom-rendering/src/components/Discussion.tsx
+++ b/dotcom-rendering/src/components/Discussion.tsx
@@ -293,8 +293,10 @@ export const Discussion = ({
 					setPage={setCommentPage}
 					filters={validFilters}
 					setFilters={(newFilters) => {
-						setHashCommentId(undefined);
-						setFilters(newFilters);
+						dispatch({
+							type: 'updateFilters',
+							filters: newFilters,
+						});
 					}}
 					commentCount={commentCount ?? 0}
 					loading={loading}

--- a/dotcom-rendering/src/components/Discussion.tsx
+++ b/dotcom-rendering/src/components/Discussion.tsx
@@ -205,12 +205,11 @@ export const Discussion = ({
 	const commentCount = useCommentCount(discussionApiUrl, shortUrlId);
 
 	useEffect(() => {
-		const id = commentIdFromUrl();
-		console.log('id', id);
-		if (id !== undefined) {
+		const newHashCommentId = commentIdFromUrl();
+		if (newHashCommentId !== undefined) {
 			dispatch({
 				type: 'updateHashCommentId',
-				hashCommentId: id,
+				hashCommentId: newHashCommentId,
 			});
 		}
 	}, []);

--- a/dotcom-rendering/src/components/Discussion.tsx
+++ b/dotcom-rendering/src/components/Discussion.tsx
@@ -311,7 +311,9 @@ export const Discussion = ({
 					loading={loading}
 					totalPages={totalPages}
 					comments={comments}
-					setComments={setComments}
+					setComment={(comment: CommentType) => {
+						dispatch({ type: 'addComment', comment });
+					}}
 				/>
 				{!isExpanded && (
 					<div id="discussion-overlay" css={overlayStyles} />

--- a/dotcom-rendering/src/components/Discussion.tsx
+++ b/dotcom-rendering/src/components/Discussion.tsx
@@ -106,7 +106,7 @@ const initialState: State = {
 	isExpanded: false,
 	commentPage: 1,
 	filters: initFiltersFromLocalStorage(),
-	hashCommentId: commentIdFromUrl(),
+	hashCommentId: undefined,
 	totalPages: 0,
 	loading: true,
 };
@@ -197,6 +197,16 @@ export const Discussion = ({
 
 	const commentCount = useCommentCount(discussionApiUrl, shortUrlId);
 
+	useEffect(() => {
+		const id = commentIdFromUrl();
+
+		if (id) {
+			dispatch({
+				type: 'updateHashCommentId',
+				hashCommentId: id,
+			});
+		}
+	}, []);
 	useEffect(() => {
 		dispatch({ type: 'setLoading', loading: true });
 		void getDiscussion(shortUrlId, { ...filters, page: commentPage })

--- a/dotcom-rendering/src/components/Discussion.tsx
+++ b/dotcom-rendering/src/components/Discussion.tsx
@@ -167,6 +167,13 @@ const reducer = (state: State, action: Action): State => {
 				loading: action.loading,
 			};
 		}
+		case 'updateHashCommentId': {
+			return {
+				...state,
+				hashCommentId: action.hashCommentId,
+				isExpanded: true,
+			};
+		}
 		default:
 			return state;
 	}
@@ -199,6 +206,7 @@ export const Discussion = ({
 
 	useEffect(() => {
 		const id = commentIdFromUrl();
+		console.log('id', id);
 		if (id !== undefined) {
 			dispatch({
 				type: 'updateHashCommentId',

--- a/dotcom-rendering/src/components/Discussion.tsx
+++ b/dotcom-rendering/src/components/Discussion.tsx
@@ -124,7 +124,6 @@ type Action =
 	| { type: 'updateCommentPage'; commentPage: number; shouldExpand: boolean }
 	| { type: 'updateHashCommentId'; hashCommentId: number | undefined }
 	| { type: 'filterChange'; filters: FilterOptions; commentPage?: number }
-	| { type: 'updateTotalPages'; totalPages: number }
 	| { type: 'setLoading'; loading: boolean };
 
 const reducer = (state: State, action: Action): State => {

--- a/dotcom-rendering/src/components/Discussion.tsx
+++ b/dotcom-rendering/src/components/Discussion.tsx
@@ -290,7 +290,13 @@ export const Discussion = ({
 					}}
 					idApiUrl={idApiUrl}
 					page={commentPage}
-					setPage={setCommentPage}
+					setPage={(page: number) => {
+						dispatch({
+							type: 'updateCommentPage',
+							commentPage: page,
+							isExpanded: true,
+						});
+					}}
 					filters={validFilters}
 					setFilters={(newFilters) => {
 						dispatch({

--- a/dotcom-rendering/src/components/Discussion.tsx
+++ b/dotcom-rendering/src/components/Discussion.tsx
@@ -241,14 +241,14 @@ export const Discussion = ({
 
 	useEffect(() => {
 		if (window.location.hash === '#comments') {
-			setIsExpanded(true);
+			dispatch({ type: 'expandComments' });
 		}
 	}, []);
 
 	useEffect(() => {
 		// There's no point showing the view more button if there isn't much more to view
 		if (commentCount === 0 || commentCount === 1 || commentCount === 2) {
-			setIsExpanded(true);
+			dispatch({ type: 'expandComments' });
 		}
 	}, [commentCount]);
 
@@ -286,7 +286,7 @@ export const Discussion = ({
 					onPermalinkClick={handlePermalink}
 					apiKey="dotcom-rendering"
 					onExpand={() => {
-						setIsExpanded(true);
+						dispatch({ type: 'expandComments' });
 					}}
 					idApiUrl={idApiUrl}
 					page={commentPage}

--- a/dotcom-rendering/src/components/Discussion.tsx
+++ b/dotcom-rendering/src/components/Discussion.tsx
@@ -139,7 +139,7 @@ const reducer = (state: State, action: Action): State => {
 		case 'addComment':
 			return {
 				...state,
-				comments: [action.comment, ...state.comments.slice(0, -1)],
+				comments: [action.comment, ...state.comments.slice(0, -1)], // Remove last item from our local array Replace it with this new comment at the start
 				isExpanded: true,
 			};
 		case 'expandComments':
@@ -199,8 +199,7 @@ export const Discussion = ({
 
 	useEffect(() => {
 		const id = commentIdFromUrl();
-
-		if (id) {
+		if (id !== undefined) {
 			dispatch({
 				type: 'updateHashCommentId',
 				hashCommentId: id,

--- a/dotcom-rendering/src/components/Discussion.tsx
+++ b/dotcom-rendering/src/components/Discussion.tsx
@@ -309,7 +309,7 @@ export const Discussion = ({
 			{!isExpanded && (
 				<Button
 					onClick={() => {
-						setIsExpanded(true);
+						dispatch({ type: 'expandComments' });
 						dispatchCommentsExpandedEvent();
 					}}
 					icon={<SvgPlus />}

--- a/dotcom-rendering/src/components/Discussion.tsx
+++ b/dotcom-rendering/src/components/Discussion.tsx
@@ -96,6 +96,7 @@ type State = {
 	commentPage: number;
 	filters: FilterOptions;
 	hashCommentId: number | undefined;
+	totalPages: number;
 };
 
 const initialState: State = {
@@ -105,6 +106,7 @@ const initialState: State = {
 	commentPage: 1,
 	filters: initFiltersFromLocalStorage(),
 	hashCommentId: commentIdFromUrl(),
+	totalPages: 0,
 };
 
 type Action =
@@ -117,7 +119,8 @@ type Action =
 	| { type: 'addComment'; comment: CommentType }
 	| { type: 'updateCommentPage'; commentPage: number; shouldExpand: boolean }
 	| { type: 'updateHashCommentId'; hashCommentId: number | undefined }
-	| { type: 'filterChange'; filters: FilterOptions; commentPage?: number };
+	| { type: 'filterChange'; filters: FilterOptions; commentPage?: number }
+	| { type: 'updateTotalPages'; totalPages: number };
 
 const reducer = (state: State, action: Action): State => {
 	switch (action.type) {
@@ -152,6 +155,11 @@ const reducer = (state: State, action: Action): State => {
 				isExpanded: true,
 				commentPage: action.commentPage ?? state.commentPage,
 			};
+		case 'updateTotalPages':
+			return {
+				...state,
+				totalPages: action.totalPages,
+			};
 		default:
 			return state;
 	}
@@ -174,11 +182,11 @@ export const Discussion = ({
 			commentPage,
 			filters,
 			hashCommentId,
+			totalPages,
 		},
 		dispatch,
 	] = useReducer(reducer, initialState);
 	const [loading, setLoading] = useState(true);
-	const [totalPages, setTotalPages] = useState(0);
 
 	const commentCount = useCommentCount(discussionApiUrl, shortUrlId);
 

--- a/dotcom-rendering/src/components/Discussion.tsx
+++ b/dotcom-rendering/src/components/Discussion.tsx
@@ -3,6 +3,7 @@ import { storage } from '@guardian/libs';
 import { palette, space } from '@guardian/source-foundations';
 import { Button, SvgPlus } from '@guardian/source-react-components';
 import { useEffect, useReducer } from 'react';
+import { assertUnreachable } from '../lib/assert-unreachable';
 import { getDiscussion } from '../lib/discussionApi';
 import {
 	getCommentContext,
@@ -18,7 +19,6 @@ import type {
 import { Comments } from './Discussion/Comments';
 import { Hide } from './Hide';
 import { SignedInAs } from './SignedInAs';
-import { assertUnreachable } from 'src/lib/assert-unreachable';
 
 export type Props = {
 	discussionApiUrl: string;

--- a/dotcom-rendering/src/components/Discussion.tsx
+++ b/dotcom-rendering/src/components/Discussion.tsx
@@ -152,6 +152,7 @@ const reducer = (state: State, action: Action): State => {
 				...state,
 				filters: action.filters,
 				hashCommentId: undefined,
+				isExpanded: true,
 			};
 		default:
 			return state;

--- a/dotcom-rendering/src/components/Discussion.tsx
+++ b/dotcom-rendering/src/components/Discussion.tsx
@@ -18,6 +18,7 @@ import type {
 import { Comments } from './Discussion/Comments';
 import { Hide } from './Hide';
 import { SignedInAs } from './SignedInAs';
+import { assertUnreachable } from 'src/lib/assert-unreachable';
 
 export type Props = {
 	discussionApiUrl: string;
@@ -175,6 +176,7 @@ const reducer = (state: State, action: Action): State => {
 			};
 		}
 		default:
+			assertUnreachable(action);
 			return state;
 	}
 };

--- a/dotcom-rendering/src/components/Discussion.tsx
+++ b/dotcom-rendering/src/components/Discussion.tsx
@@ -167,16 +167,17 @@ export const Discussion = ({
 	user,
 	idApiUrl,
 }: Props) => {
-	const [commentPage, setCommentPage] = useState(1);
-	const [comments, setComments] = useState<CommentType[]>([]);
-	const [isClosedForComments, setIsClosedForComments] = useState(false);
-	const [isExpanded, setIsExpanded] = useState(false);
-	const [hashCommentId, setHashCommentId] = useState<number | undefined>(
-		commentIdFromUrl(),
-	);
-	const [filters, setFilters] = useState<FilterOptions>(
-		initFiltersFromLocalStorage(),
-	);
+	const [
+		{
+			comments,
+			isClosedForComments,
+			isExpanded,
+			commentPage,
+			filters,
+			hashCommentId,
+		},
+		dispatch,
+	] = useReducer(reducer, initialState);
 	const [loading, setLoading] = useState(true);
 	const [totalPages, setTotalPages] = useState(0);
 

--- a/dotcom-rendering/src/components/Discussion.tsx
+++ b/dotcom-rendering/src/components/Discussion.tsx
@@ -116,11 +116,8 @@ type Action =
 	| { type: 'expandComments' }
 	| { type: 'addComment'; comment: CommentType }
 	| { type: 'updateCommentPage'; commentPage: number; shouldExpand: boolean }
-	| {
-			type: 'updateFilters';
-			filters: FilterOptions;
-	  }
-	| { type: 'updateHashCommentId'; hashCommentId: number | undefined };
+	| { type: 'updateHashCommentId'; hashCommentId: number | undefined }
+	| { type: 'filterChange'; filters: FilterOptions; commentPage?: number };
 
 const reducer = (state: State, action: Action): State => {
 	switch (action.type) {
@@ -147,12 +144,13 @@ const reducer = (state: State, action: Action): State => {
 				commentPage: action.commentPage,
 				isExpanded: action.shouldExpand ? true : state.isExpanded,
 			};
-		case 'updateFilters':
+		case 'filterChange':
 			return {
 				...state,
 				filters: action.filters,
 				hashCommentId: undefined,
 				isExpanded: true,
+				commentPage: action.commentPage ?? state.commentPage,
 			};
 		default:
 			return state;
@@ -289,9 +287,6 @@ export const Discussion = ({
 					commentToScrollTo={hashCommentId}
 					onPermalinkClick={handlePermalink}
 					apiKey="dotcom-rendering"
-					onExpand={() => {
-						dispatch({ type: 'expandComments' });
-					}}
 					idApiUrl={idApiUrl}
 					page={commentPage}
 					setPage={(page: number, shouldExpand: boolean) => {
@@ -302,18 +297,22 @@ export const Discussion = ({
 						});
 					}}
 					filters={validFilters}
-					setFilters={(newFilters) => {
-						dispatch({
-							type: 'updateFilters',
-							filters: newFilters,
-						});
-					}}
 					commentCount={commentCount ?? 0}
 					loading={loading}
 					totalPages={totalPages}
 					comments={comments}
 					setComment={(comment: CommentType) => {
 						dispatch({ type: 'addComment', comment });
+					}}
+					handleFilterChange={(
+						newFilters: FilterOptions,
+						page?: number,
+					) => {
+						dispatch({
+							type: 'filterChange',
+							filters: newFilters,
+							commentPage: page,
+						});
 					}}
 				/>
 				{!isExpanded && (

--- a/dotcom-rendering/src/components/Discussion/Comments.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comments.stories.tsx
@@ -57,18 +57,17 @@ export const LoggedOutHiddenPicks = () => (
 			}}
 			expanded={false}
 			onPermalinkClick={() => {}}
-			onExpand={() => {}}
 			apiKey=""
 			idApiUrl="https://idapi.theguardian.com"
 			page={3}
 			setPage={() => {}}
 			filters={filters}
-			setFilters={() => {}}
+			handleFilterChange={() => {}}
 			commentCount={discussionMock.discussion.commentCount}
 			loading={false}
 			totalPages={discussionMock.pages}
 			comments={discussionMock.discussion.comments}
-			setComments={() => {}}
+			setComment={() => {}}
 		/>
 	</div>
 );
@@ -99,18 +98,17 @@ export const InitialPage = () => (
 			}}
 			expanded={true}
 			onPermalinkClick={() => {}}
-			onExpand={() => {}}
 			apiKey=""
 			idApiUrl="https://idapi.theguardian.com"
 			page={1}
 			setPage={() => {}}
 			filters={filters}
-			setFilters={() => {}}
+			handleFilterChange={() => {}}
 			commentCount={discussionMock.discussion.commentCount}
 			loading={false}
 			totalPages={discussionMock.pages}
 			comments={discussionMock.discussion.comments}
-			setComments={() => {}}
+			setComment={() => {}}
 		/>
 	</div>
 );
@@ -142,18 +140,17 @@ export const LoggedInHiddenNoPicks = () => (
 			}}
 			expanded={false}
 			onPermalinkClick={() => {}}
-			onExpand={() => {}}
 			apiKey=""
 			idApiUrl="https://idapi.theguardian.com"
 			page={3}
 			setPage={() => {}}
 			filters={filters}
-			setFilters={() => {}}
+			handleFilterChange={() => {}}
 			commentCount={discussionMock.discussion.commentCount}
 			loading={false}
 			totalPages={discussionMock.pages}
 			comments={discussionMock.discussion.comments}
-			setComments={() => {}}
+			setComment={() => {}}
 		/>
 	</div>
 );
@@ -179,18 +176,17 @@ export const LoggedIn = () => (
 			}}
 			expanded={true}
 			onPermalinkClick={() => {}}
-			onExpand={() => {}}
 			apiKey=""
 			idApiUrl="https://idapi.theguardian.com"
 			page={3}
 			setPage={() => {}}
 			filters={filters}
-			setFilters={() => {}}
+			handleFilterChange={() => {}}
 			commentCount={discussionMock.discussion.commentCount}
 			loading={false}
 			totalPages={discussionMock.pages}
 			comments={discussionMock.discussion.comments}
-			setComments={() => {}}
+			setComment={() => {}}
 		/>
 	</div>
 );
@@ -215,18 +211,17 @@ export const LoggedInShortDiscussion = () => (
 			}}
 			expanded={true}
 			onPermalinkClick={() => {}}
-			onExpand={() => {}}
 			apiKey=""
 			idApiUrl="https://idapi.theguardian.com"
 			page={3}
 			setPage={() => {}}
 			filters={filters}
-			setFilters={() => {}}
+			handleFilterChange={() => {}}
 			commentCount={discussionWithTwoComments.discussion.commentCount}
 			loading={false}
 			totalPages={discussionWithTwoComments.pages}
 			comments={discussionWithTwoComments.discussion.comments}
-			setComments={() => {}}
+			setComment={() => {}}
 		/>
 	</div>
 );
@@ -250,18 +245,17 @@ export const LoggedOutHiddenNoPicks = () => (
 			}}
 			expanded={false}
 			onPermalinkClick={() => {}}
-			onExpand={() => {}}
 			apiKey=""
 			idApiUrl="https://idapi.theguardian.com"
 			page={3}
 			setPage={() => {}}
 			filters={filters}
-			setFilters={() => {}}
+			handleFilterChange={() => {}}
 			commentCount={discussionMock.discussion.commentCount}
 			loading={false}
 			totalPages={0}
 			comments={discussionMock.discussion.comments}
-			setComments={() => {}}
+			setComment={() => {}}
 		/>
 	</div>
 );
@@ -294,18 +288,17 @@ export const Closed = () => (
 			}}
 			expanded={true}
 			onPermalinkClick={() => {}}
-			onExpand={() => {}}
 			apiKey=""
 			idApiUrl="https://idapi.theguardian.com"
 			page={3}
 			setPage={() => {}}
 			filters={filters}
-			setFilters={() => {}}
+			handleFilterChange={() => {}}
 			commentCount={discussionMock.discussion.commentCount}
 			loading={false}
 			totalPages={discussionMock.pages}
 			comments={discussionMock.discussion.comments}
-			setComments={() => {}}
+			setComment={() => {}}
 		/>
 	</div>
 );
@@ -336,18 +329,17 @@ export const NoComments = () => (
 			}}
 			expanded={false}
 			onPermalinkClick={() => {}}
-			onExpand={() => {}}
 			apiKey=""
 			idApiUrl="https://idapi.theguardian.com"
 			page={3}
 			setPage={() => {}}
 			filters={filters}
-			setFilters={() => {}}
+			handleFilterChange={() => {}}
 			commentCount={0}
 			loading={false}
 			totalPages={0}
 			comments={[]}
-			setComments={() => {}}
+			setComment={() => {}}
 		/>
 	</div>
 );
@@ -378,20 +370,19 @@ export const LegacyDiscussion = () => (
 			}}
 			expanded={false}
 			onPermalinkClick={() => {}}
-			onExpand={() => {}}
 			apiKey=""
 			idApiUrl="https://idapi.theguardian.com"
 			page={3}
 			setPage={() => {}}
 			filters={filters}
-			setFilters={() => {}}
+			handleFilterChange={() => {}}
 			commentCount={
 				legacyDiscussionWithoutThreading.discussion.commentCount
 			}
 			loading={false}
 			totalPages={legacyDiscussionWithoutThreading.pages}
 			comments={legacyDiscussionWithoutThreading.discussion.comments}
-			setComments={() => {}}
+			setComment={() => {}}
 		/>
 	</div>
 );

--- a/dotcom-rendering/src/components/Discussion/Comments.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comments.stories.tsx
@@ -62,12 +62,12 @@ export const LoggedOutHiddenPicks = () => (
 			page={3}
 			setPage={() => {}}
 			filters={filters}
-			handleFilterChange={() => {}}
 			commentCount={discussionMock.discussion.commentCount}
 			loading={false}
 			totalPages={discussionMock.pages}
 			comments={discussionMock.discussion.comments}
 			setComment={() => {}}
+			handleFilterChange={() => {}}
 		/>
 	</div>
 );
@@ -103,12 +103,12 @@ export const InitialPage = () => (
 			page={1}
 			setPage={() => {}}
 			filters={filters}
-			handleFilterChange={() => {}}
 			commentCount={discussionMock.discussion.commentCount}
 			loading={false}
 			totalPages={discussionMock.pages}
 			comments={discussionMock.discussion.comments}
 			setComment={() => {}}
+			handleFilterChange={() => {}}
 		/>
 	</div>
 );
@@ -145,12 +145,12 @@ export const LoggedInHiddenNoPicks = () => (
 			page={3}
 			setPage={() => {}}
 			filters={filters}
-			handleFilterChange={() => {}}
 			commentCount={discussionMock.discussion.commentCount}
 			loading={false}
 			totalPages={discussionMock.pages}
 			comments={discussionMock.discussion.comments}
 			setComment={() => {}}
+			handleFilterChange={() => {}}
 		/>
 	</div>
 );
@@ -181,12 +181,12 @@ export const LoggedIn = () => (
 			page={3}
 			setPage={() => {}}
 			filters={filters}
-			handleFilterChange={() => {}}
 			commentCount={discussionMock.discussion.commentCount}
 			loading={false}
 			totalPages={discussionMock.pages}
 			comments={discussionMock.discussion.comments}
 			setComment={() => {}}
+			handleFilterChange={() => {}}
 		/>
 	</div>
 );
@@ -216,16 +216,15 @@ export const LoggedInShortDiscussion = () => (
 			page={3}
 			setPage={() => {}}
 			filters={filters}
-			handleFilterChange={() => {}}
 			commentCount={discussionWithTwoComments.discussion.commentCount}
 			loading={false}
 			totalPages={discussionWithTwoComments.pages}
 			comments={discussionWithTwoComments.discussion.comments}
 			setComment={() => {}}
+			handleFilterChange={() => {}}
 		/>
 	</div>
 );
-LoggedInShortDiscussion.storyName = 'when logged in but only two comments made';
 LoggedInShortDiscussion.decorators = [splitTheme([format])];
 
 export const LoggedOutHiddenNoPicks = () => (
@@ -250,12 +249,12 @@ export const LoggedOutHiddenNoPicks = () => (
 			page={3}
 			setPage={() => {}}
 			filters={filters}
-			handleFilterChange={() => {}}
 			commentCount={discussionMock.discussion.commentCount}
 			loading={false}
 			totalPages={0}
 			comments={discussionMock.discussion.comments}
 			setComment={() => {}}
+			handleFilterChange={() => {}}
 		/>
 	</div>
 );
@@ -293,12 +292,12 @@ export const Closed = () => (
 			page={3}
 			setPage={() => {}}
 			filters={filters}
-			handleFilterChange={() => {}}
 			commentCount={discussionMock.discussion.commentCount}
 			loading={false}
 			totalPages={discussionMock.pages}
 			comments={discussionMock.discussion.comments}
 			setComment={() => {}}
+			handleFilterChange={() => {}}
 		/>
 	</div>
 );
@@ -334,12 +333,12 @@ export const NoComments = () => (
 			page={3}
 			setPage={() => {}}
 			filters={filters}
-			handleFilterChange={() => {}}
 			commentCount={0}
 			loading={false}
 			totalPages={0}
 			comments={[]}
 			setComment={() => {}}
+			handleFilterChange={() => {}}
 		/>
 	</div>
 );
@@ -375,7 +374,6 @@ export const LegacyDiscussion = () => (
 			page={3}
 			setPage={() => {}}
 			filters={filters}
-			handleFilterChange={() => {}}
 			commentCount={
 				legacyDiscussionWithoutThreading.discussion.commentCount
 			}
@@ -383,6 +381,7 @@ export const LegacyDiscussion = () => (
 			totalPages={legacyDiscussionWithoutThreading.pages}
 			comments={legacyDiscussionWithoutThreading.discussion.comments}
 			setComment={() => {}}
+			handleFilterChange={() => {}}
 		/>
 	</div>
 );

--- a/dotcom-rendering/src/components/Discussion/Comments.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comments.tsx
@@ -38,7 +38,7 @@ type Props = {
 	onExpand: () => void;
 	idApiUrl: string;
 	page: number;
-	setPage: (page: number) => void;
+	setPage: (page: number, shouldExpand: boolean) => void;
 	filters: FilterOptions;
 	setFilters: (filters: FilterOptions) => void;
 	commentCount: number;
@@ -190,7 +190,7 @@ export const Comments = ({
 			commentCount / newFilterObject.pageSize,
 		);
 
-		if (page > maxPagePossible) setPage(maxPagePossible);
+		if (page > maxPagePossible) setPage(maxPagePossible, false);
 
 		setFilters(newFilterObject);
 		// Filters also show when the view is not expanded but we want to expand when they're changed
@@ -227,7 +227,7 @@ export const Comments = ({
 	};
 
 	const onPageChange = (pageNumber: number) => {
-		setPage(pageNumber);
+		setPage(pageNumber, true);
 	};
 
 	initialiseApi({ additionalHeaders, baseUrl, apiKey, idApiUrl });

--- a/dotcom-rendering/src/components/Discussion/Comments.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comments.tsx
@@ -184,14 +184,15 @@ export const Comments = ({
 		 * To respect the reader's preference to stay on the last page,
 		 * we calculate and use the maximum possible page instead.
 		 */
+
 		const maxPagePossible = Math.ceil(
 			commentCount / newFilterObject.pageSize,
 		);
 
 		if (page > maxPagePossible) {
-			handleFilterChange(filters, maxPagePossible);
+			handleFilterChange(newFilterObject, maxPagePossible);
 		} else {
-			handleFilterChange(filters);
+			handleFilterChange(newFilterObject);
 		}
 	};
 

--- a/dotcom-rendering/src/components/Discussion/Comments.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comments.tsx
@@ -213,10 +213,7 @@ export const Comments = ({
 		setMutes(updatedMutes); // Update local state
 	};
 	const onAddComment = (comment: CommentType) => {
-		// Remove last item from our local array
-		// Replace it with this new comment at the start
 		setComment(comment);
-
 		const commentElement = document.getElementById(`comment-${comment.id}`);
 		commentElement?.scrollIntoView();
 	};

--- a/dotcom-rendering/src/components/Discussion/Comments.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comments.tsx
@@ -193,8 +193,6 @@ export const Comments = ({
 		if (page > maxPagePossible) setPage(maxPagePossible, false);
 
 		setFilters(newFilterObject);
-		// Filters also show when the view is not expanded but we want to expand when they're changed
-		onExpand();
 	};
 
 	useEffect(() => {

--- a/dotcom-rendering/src/components/Discussion/Comments.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comments.tsx
@@ -228,7 +228,6 @@ export const Comments = ({
 
 	const onPageChange = (pageNumber: number) => {
 		setPage(pageNumber);
-		onExpand();
 	};
 
 	initialiseApi({ additionalHeaders, baseUrl, apiKey, idApiUrl });

--- a/dotcom-rendering/src/components/Discussion/Comments.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comments.tsx
@@ -35,17 +35,16 @@ type Props = {
 	onComment?: ReturnType<typeof comment>;
 	onReply?: ReturnType<typeof reply>;
 	onPreview?: typeof preview;
-	onExpand: () => void;
 	idApiUrl: string;
 	page: number;
 	setPage: (page: number, shouldExpand: boolean) => void;
 	filters: FilterOptions;
-	setFilters: (filters: FilterOptions) => void;
 	commentCount: number;
 	loading: boolean;
 	totalPages: number;
 	comments: CommentType[];
 	setComment: (comment: CommentType) => void;
+	handleFilterChange: (newFilters: FilterOptions, page?: number) => void;
 };
 
 const footerStyles = css`
@@ -112,17 +111,16 @@ export const Comments = ({
 	onComment,
 	onReply,
 	onPreview,
-	onExpand,
 	idApiUrl,
 	page,
 	setPage,
 	filters,
-	setFilters,
 	commentCount,
 	loading,
 	totalPages,
 	comments,
 	setComment,
+	handleFilterChange,
 }: Props) => {
 	const [picks, setPicks] = useState<CommentType[]>([]);
 	const [commentBeingRepliedTo, setCommentBeingRepliedTo] =
@@ -190,9 +188,11 @@ export const Comments = ({
 			commentCount / newFilterObject.pageSize,
 		);
 
-		if (page > maxPagePossible) setPage(maxPagePossible, false);
-
-		setFilters(newFilterObject);
+		if (page > maxPagePossible) {
+			handleFilterChange(filters, maxPagePossible);
+		} else {
+			handleFilterChange(filters);
+		}
 	};
 
 	useEffect(() => {

--- a/dotcom-rendering/src/components/Discussion/Comments.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comments.tsx
@@ -45,7 +45,7 @@ type Props = {
 	loading: boolean;
 	totalPages: number;
 	comments: CommentType[];
-	setComments: (comments: CommentType[]) => void;
+	setComment: (comment: CommentType) => void;
 };
 
 const footerStyles = css`
@@ -122,7 +122,7 @@ export const Comments = ({
 	loading,
 	totalPages,
 	comments,
-	setComments,
+	setComment,
 }: Props) => {
 	const [picks, setPicks] = useState<CommentType[]>([]);
 	const [commentBeingRepliedTo, setCommentBeingRepliedTo] =
@@ -217,10 +217,7 @@ export const Comments = ({
 	const onAddComment = (comment: CommentType) => {
 		// Remove last item from our local array
 		// Replace it with this new comment at the start
-		setComments([comment, ...comments.slice(0, -1)]);
-
-		// It's possible to post a comment without the view being expanded
-		onExpand();
+		setComment(comment);
 
 		const commentElement = document.getElementById(`comment-${comment.id}`);
 		commentElement?.scrollIntoView();


### PR DESCRIPTION
## What does this change?
The change involves migrating the state management in the Discussion component from using React's useState hook to utilise useReducer instead.

## Why?
UseReducer is preferred for handling more complex state management. It provides a more structured approach compared to useState, which can become unwieldy with increasing complexity. It allows for a more explicit definition of state transitions and actions, which can enhance readability and maintainability of the codebase. Finally, code utilising useReducer tends to be easier to test, as the state transitions are typically well-defined and isolated within the reducer function.

As the Discussion app has been identified as an area prone to errors and bugs, employing useReducer can potentially reduce these issues by providing clearer state management. It can also facilitate lifting state up from child components, such as the comment form, making it easier to manage and synchronise state across the application.

Overall, the migration to useReducer aims to enhance the reliability, scalability, and maintainability of the Discussion component within the DCR application.
