### PR TITLE
Lift `previewBody` state from `FirstCommentWelcome`

### DIFF
--- a/dotcom-rendering/src/components/Discussion/CommentContainer.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentContainer.stories.tsx
@@ -198,7 +198,7 @@ export const defaultStory = () => (
 		userNameMissing={false}
 		setUserNameMissing={() => {}}
 		previewBody=""
-		setPreviewBody={() => undefined}
+		setPreviewBody={() => {}}
 	/>
 );
 defaultStory.storyName = 'default';
@@ -234,7 +234,7 @@ export const threadedComment = () => (
 		userNameMissing={false}
 		setUserNameMissing={() => {}}
 		previewBody=""
-		setPreviewBody={() => undefined}
+		setPreviewBody={() => {}}
 	/>
 );
 threadedComment.storyName = 'threaded';
@@ -270,7 +270,7 @@ export const threadedCommentWithShowMore = () => (
 		userNameMissing={false}
 		setUserNameMissing={() => {}}
 		previewBody=""
-		setPreviewBody={() => undefined}
+		setPreviewBody={() => {}}
 	/>
 );
 threadedCommentWithShowMore.storyName = 'threaded with show more button';
@@ -306,7 +306,7 @@ export const threadedCommentWithLongUsernames = () => (
 		userNameMissing={false}
 		setUserNameMissing={() => {}}
 		previewBody=""
-		setPreviewBody={() => undefined}
+		setPreviewBody={() => {}}
 	/>
 );
 threadedCommentWithLongUsernames.storyName = 'threaded with long usernames';
@@ -342,7 +342,7 @@ export const threadedCommentWithLongUsernamesMobile = () => (
 		userNameMissing={false}
 		setUserNameMissing={() => {}}
 		previewBody=""
-		setPreviewBody={() => undefined}
+		setPreviewBody={() => {}}
 	/>
 );
 threadedCommentWithLongUsernamesMobile.storyName =

--- a/dotcom-rendering/src/components/Discussion/CommentContainer.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentContainer.stories.tsx
@@ -197,6 +197,8 @@ export const defaultStory = () => (
 		setError={() => {}}
 		userNameMissing={false}
 		setUserNameMissing={() => {}}
+		previewBody=""
+		setPreviewBody={() => undefined}
 	/>
 );
 defaultStory.storyName = 'default';
@@ -231,6 +233,8 @@ export const threadedComment = () => (
 		setError={() => {}}
 		userNameMissing={false}
 		setUserNameMissing={() => {}}
+		previewBody=""
+		setPreviewBody={() => undefined}
 	/>
 );
 threadedComment.storyName = 'threaded';
@@ -265,6 +269,8 @@ export const threadedCommentWithShowMore = () => (
 		setError={() => {}}
 		userNameMissing={false}
 		setUserNameMissing={() => {}}
+		previewBody=""
+		setPreviewBody={() => undefined}
 	/>
 );
 threadedCommentWithShowMore.storyName = 'threaded with show more button';
@@ -299,6 +305,8 @@ export const threadedCommentWithLongUsernames = () => (
 		setError={() => {}}
 		userNameMissing={false}
 		setUserNameMissing={() => {}}
+		previewBody=""
+		setPreviewBody={() => undefined}
 	/>
 );
 threadedCommentWithLongUsernames.storyName = 'threaded with long usernames';
@@ -333,6 +341,8 @@ export const threadedCommentWithLongUsernamesMobile = () => (
 		setError={() => {}}
 		userNameMissing={false}
 		setUserNameMissing={() => {}}
+		previewBody=""
+		setPreviewBody={() => undefined}
 	/>
 );
 threadedCommentWithLongUsernamesMobile.storyName =

--- a/dotcom-rendering/src/components/Discussion/CommentContainer.test.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentContainer.test.tsx
@@ -75,7 +75,7 @@ describe('CommentContainer', () => {
 				userNameMissing={false}
 				setUserNameMissing={() => {}}
 				previewBody=""
-				setPreviewBody={() => undefined}
+				setPreviewBody={() => {}}
 			/>,
 		);
 
@@ -122,7 +122,7 @@ describe('CommentContainer', () => {
 				userNameMissing={false}
 				setUserNameMissing={() => {}}
 				previewBody=""
-				setPreviewBody={() => undefined}
+				setPreviewBody={() => {}}
 			/>,
 		);
 
@@ -168,7 +168,7 @@ describe('CommentContainer', () => {
 				userNameMissing={false}
 				setUserNameMissing={() => {}}
 				previewBody=""
-				setPreviewBody={() => undefined}
+				setPreviewBody={() => {}}
 			/>,
 		);
 
@@ -215,7 +215,7 @@ describe('CommentContainer', () => {
 				userNameMissing={false}
 				setUserNameMissing={() => {}}
 				previewBody=""
-				setPreviewBody={() => undefined}
+				setPreviewBody={() => {}}
 			/>,
 		);
 

--- a/dotcom-rendering/src/components/Discussion/CommentContainer.test.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentContainer.test.tsx
@@ -74,6 +74,8 @@ describe('CommentContainer', () => {
 				setError={() => {}}
 				userNameMissing={false}
 				setUserNameMissing={() => {}}
+				previewBody=""
+				setPreviewBody={() => undefined}
 			/>,
 		);
 
@@ -119,6 +121,8 @@ describe('CommentContainer', () => {
 				setError={() => {}}
 				userNameMissing={false}
 				setUserNameMissing={() => {}}
+				previewBody=""
+				setPreviewBody={() => undefined}
 			/>,
 		);
 
@@ -163,6 +167,8 @@ describe('CommentContainer', () => {
 				setError={() => {}}
 				userNameMissing={false}
 				setUserNameMissing={() => {}}
+				previewBody=""
+				setPreviewBody={() => undefined}
 			/>,
 		);
 
@@ -208,6 +214,8 @@ describe('CommentContainer', () => {
 				setError={() => {}}
 				userNameMissing={false}
 				setUserNameMissing={() => {}}
+				previewBody=""
+				setPreviewBody={() => undefined}
 			/>,
 		);
 

--- a/dotcom-rendering/src/components/Discussion/CommentContainer.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentContainer.tsx
@@ -38,6 +38,8 @@ type Props = {
 	setError: (error: string) => void;
 	userNameMissing: boolean;
 	setUserNameMissing: (isUserNameMissing: boolean) => void;
+	previewBody: string;
+	setPreviewBody: (previewBody: string) => void;
 };
 
 const nestingStyles = css`
@@ -97,6 +99,8 @@ export const CommentContainer = ({
 	setError,
 	userNameMissing,
 	setUserNameMissing,
+	previewBody,
+	setPreviewBody,
 }: Props) => {
 	// Filter logic
 	const [expanded, setExpanded] = useState<boolean>(threads === 'expanded');
@@ -246,6 +250,8 @@ export const CommentContainer = ({
 								setError={setError}
 								userNameMissing={userNameMissing}
 								setUserNameMissing={setUserNameMissing}
+								previewBody={previewBody}
+								setPreviewBody={setPreviewBody}
 							/>
 						</div>
 					)}

--- a/dotcom-rendering/src/components/Discussion/CommentForm.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentForm.stories.tsx
@@ -77,6 +77,8 @@ export const Default = () => {
 			setUserNameMissing={() => {}}
 			error={''}
 			setError={() => {}}
+			previewBody=""
+			setPreviewBody={() => undefined}
 		/>
 	);
 };
@@ -102,6 +104,8 @@ export const Error = () => {
 			setUserNameMissing={setUserNameMissing}
 			error={''}
 			setError={() => {}}
+			previewBody=""
+			setPreviewBody={() => undefined}
 		/>
 	);
 };
@@ -123,6 +127,8 @@ export const Active = () => (
 		setError={() => {}}
 		userNameMissing={false}
 		setUserNameMissing={() => {}}
+		previewBody=""
+		setPreviewBody={() => undefined}
 	/>
 );
 Active.storyName = 'form is active';
@@ -162,6 +168,8 @@ export const Premoderated = () => (
 		setError={() => {}}
 		userNameMissing={false}
 		setUserNameMissing={() => {}}
+		previewBody=""
+		setPreviewBody={() => undefined}
 	/>
 );
 Premoderated.storyName = 'user is premoderated';

--- a/dotcom-rendering/src/components/Discussion/CommentForm.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentForm.stories.tsx
@@ -78,7 +78,7 @@ export const Default = () => {
 			error={''}
 			setError={() => {}}
 			previewBody=""
-			setPreviewBody={() => undefined}
+			setPreviewBody={() => {}}
 		/>
 	);
 };
@@ -105,7 +105,7 @@ export const Error = () => {
 			error={''}
 			setError={() => {}}
 			previewBody=""
-			setPreviewBody={() => undefined}
+			setPreviewBody={() => {}}
 		/>
 	);
 };
@@ -128,7 +128,7 @@ export const Active = () => (
 		userNameMissing={false}
 		setUserNameMissing={() => {}}
 		previewBody=""
-		setPreviewBody={() => undefined}
+		setPreviewBody={() => {}}
 	/>
 );
 Active.storyName = 'form is active';
@@ -169,7 +169,7 @@ export const Premoderated = () => (
 		userNameMissing={false}
 		setUserNameMissing={() => {}}
 		previewBody=""
-		setPreviewBody={() => undefined}
+		setPreviewBody={() => {}}
 	/>
 );
 Premoderated.storyName = 'user is premoderated';

--- a/dotcom-rendering/src/components/Discussion/CommentForm.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentForm.tsx
@@ -36,6 +36,8 @@ type Props = {
 	setError: (error: string) => void;
 	userNameMissing: boolean;
 	setUserNameMissing: (isUserNameMissing: boolean) => void;
+	previewBody: string;
+	setPreviewBody: (previewBody: string) => void;
 };
 
 const boldString = (str: string) => `<b>${str}</b>`;
@@ -227,9 +229,10 @@ export const CommentForm = ({
 	setError,
 	userNameMissing,
 	setUserNameMissing,
+	previewBody,
+	setPreviewBody,
 }: Props) => {
 	const [body, setBody] = useState<string>('');
-	const [previewBody, setPreviewBody] = useState<string>('');
 	const [info, setInfo] = useState<string>('');
 	const textAreaRef = useRef<HTMLTextAreaElement>(null);
 
@@ -431,11 +434,10 @@ export const CommentForm = ({
 	if (userNameMissing && body) {
 		return (
 			<FirstCommentWelcome
-				body={body}
 				error={error}
 				submitForm={submitUserName}
 				cancelSubmit={() => setUserNameMissing(false)}
-				onPreview={onPreview}
+				previewBody={previewBody}
 			/>
 		);
 	}

--- a/dotcom-rendering/src/components/Discussion/Comments.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comments.tsx
@@ -135,6 +135,7 @@ export const Comments = ({
 	);
 	const [error, setError] = useState<string>('');
 	const [userNameMissing, setUserNameMissing] = useState<boolean>(false);
+	const [previewBody, setPreviewBody] = useState<string>('');
 
 	const loadingMore = !loading && comments.length !== numberOfCommentsToShow;
 
@@ -305,6 +306,8 @@ export const Comments = ({
 											setUserNameMissing={
 												setUserNameMissing
 											}
+											previewBody={previewBody}
+											setPreviewBody={setPreviewBody}
 										/>
 									</li>
 								))}
@@ -334,6 +337,8 @@ export const Comments = ({
 					setError={setError}
 					userNameMissing={userNameMissing}
 					setUserNameMissing={setUserNameMissing}
+					previewBody={previewBody}
+					setPreviewBody={setPreviewBody}
 				/>
 			)}
 			{!!picks.length && (
@@ -396,6 +401,8 @@ export const Comments = ({
 									setError={setError}
 									userNameMissing={userNameMissing}
 									setUserNameMissing={setUserNameMissing}
+									previewBody={previewBody}
+									setPreviewBody={setPreviewBody}
 								/>
 							</li>
 						))}
@@ -429,6 +436,8 @@ export const Comments = ({
 					setError={setError}
 					userNameMissing={userNameMissing}
 					setUserNameMissing={setUserNameMissing}
+					previewBody={previewBody}
+					setPreviewBody={setPreviewBody}
 				/>
 			)}
 		</div>

--- a/dotcom-rendering/src/components/Discussion/FirstCommentWelcome.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/FirstCommentWelcome.stories.tsx
@@ -6,9 +6,9 @@ export default { title: 'Discussion/FirstCommentWelcome' };
 
 export const defaultStory = () => (
 	<FirstCommentWelcome
-		body="My first message ever!!"
 		submitForm={() => Promise.resolve()}
 		cancelSubmit={() => undefined}
+		previewBody=""
 	/>
 );
 defaultStory.storyName = 'Welcome message';
@@ -27,10 +27,10 @@ defaultStory.decorators = [
 
 export const CommentWithError = () => (
 	<FirstCommentWelcome
-		body="My first message ever!!"
 		error="This is a custom user name error message"
 		submitForm={() => Promise.resolve()}
 		cancelSubmit={() => undefined}
+		previewBody=""
 	/>
 );
 CommentWithError.storyName = 'Welcome message with error';

--- a/dotcom-rendering/src/components/Discussion/FirstCommentWelcome.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/FirstCommentWelcome.stories.tsx
@@ -8,7 +8,7 @@ export const defaultStory = () => (
 	<FirstCommentWelcome
 		submitForm={() => Promise.resolve()}
 		cancelSubmit={() => undefined}
-		previewBody=""
+		previewBody="My first comment!!"
 	/>
 );
 defaultStory.storyName = 'Welcome message';
@@ -30,7 +30,7 @@ export const CommentWithError = () => (
 		error="This is a custom user name error message"
 		submitForm={() => Promise.resolve()}
 		cancelSubmit={() => undefined}
-		previewBody=""
+		previewBody="My first comment!!"
 	/>
 );
 CommentWithError.storyName = 'Welcome message with error';

--- a/dotcom-rendering/src/components/Discussion/FirstCommentWelcome.tsx
+++ b/dotcom-rendering/src/components/Discussion/FirstCommentWelcome.tsx
@@ -1,19 +1,10 @@
 import { css } from '@emotion/react';
 import { headline, space, textSans } from '@guardian/source-foundations';
 import { Link, TextInput } from '@guardian/source-react-components';
-import { useEffect, useState } from 'react';
-import { preview as defaultPreview } from '../../lib/discussionApi';
+import { useState } from 'react';
 import { palette as schemedPalette } from '../../palette';
 import { PillarButton } from './PillarButton';
 import { Row } from './Row';
-
-type Props = {
-	body: string;
-	error?: string;
-	submitForm: (userName: string) => Promise<void>;
-	cancelSubmit: () => void;
-	onPreview?: (body: string) => Promise<string>;
-};
 
 const previewStyle = css`
 	padding: ${space[2]}px;
@@ -53,28 +44,20 @@ const textInputStyles = css`
 	color: inherit;
 `;
 
+type Props = {
+	error?: string;
+	submitForm: (userName: string) => Promise<void>;
+	cancelSubmit: () => void;
+	previewBody: string;
+};
+
 export const FirstCommentWelcome = ({
-	body,
 	error = '',
 	submitForm,
 	cancelSubmit,
-	onPreview,
+	previewBody,
 }: Props) => {
-	const [previewBody, setPreviewBody] = useState<string>('');
 	const [userName, setUserName] = useState<string>('');
-
-	useEffect(() => {
-		const fetchShowPreview = async () => {
-			try {
-				const preview = onPreview ?? defaultPreview;
-				const response = await preview(body);
-				setPreviewBody(response);
-			} catch (e) {
-				setPreviewBody('');
-			}
-		};
-		void fetchShowPreview();
-	}, [body, onPreview]);
 
 	return (
 		<div


### PR DESCRIPTION
## What does this change?

- Lifts `previewBody` state from `FirstCommentWelcome` to `Comments`

Tested on [CODE](https://riffraff.gutools.co.uk/deployment/view/f89d05de-e0ee-466d-98ce-b39c6594b661) and seems to work!

Closes https://github.com/guardian/dotcom-rendering/issues/10224