### PR TITLE
Parse discussion response for top comments

### DIFF
--- a/dotcom-rendering/fixtures/manual/topPicks.ts
+++ b/dotcom-rendering/fixtures/manual/topPicks.ts
@@ -1,6 +1,8 @@
+import type { GetDiscussionSuccess } from '../../src/types/discussion';
+
 export const topPicks = {
 	status: 'ok',
-	page: 1,
+	currentPage: 1,
 	pages: 1,
 	pageSize: 50,
 	orderBy: 'oldest',
@@ -65,4 +67,4 @@ export const topPicks = {
 			},
 		],
 	},
-};
+} satisfies GetDiscussionSuccess;

--- a/dotcom-rendering/src/components/Discussion/Comments.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comments.tsx
@@ -152,15 +152,14 @@ export const Comments = ({
 		} else return;
 	}, [expanded, comments.length]);
 
-	//todo: parse this properly
 	useEffect(() => {
-		const fetchPicks = async () => {
-			const json = await getPicks(shortUrl);
-			if (json !== undefined) {
-				setPicks(json);
+		void getPicks(shortUrl).then((result) => {
+			if (result.kind === 'error') {
+				console.error(result.error);
+				return;
 			}
-		};
-		void fetchPicks();
+			setPicks(result.value);
+		});
 	}, [shortUrl]);
 
 	/**


### PR DESCRIPTION
## What does this change?


Parse the response from [`/discussion/:id/top-comments`](https://discussion.guardianapis.com/discussion-api/discussion//p/pp9fk/topcomments)

## Why?

Part of #10023 & #10369 

## Screenshots

Identical, see Chromatic