### PR TITLE
Use `Preview` component for `FirstCommentWelcome`

### DIFF
--- a/dotcom-rendering/src/components/Discussion/CommentForm.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentForm.tsx
@@ -629,7 +629,9 @@ export const CommentForm = ({
 				</div>
 			</form>
 
-			{showPreview && <Preview previewHtml={previewBody} />}
+			{showPreview && (
+				<Preview previewHtml={previewBody} showSpout={true} />
+			)}
 		</>
 	);
 };

--- a/dotcom-rendering/src/components/Discussion/FirstCommentWelcome.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/FirstCommentWelcome.stories.tsx
@@ -8,7 +8,7 @@ export const defaultStory = () => (
 	<FirstCommentWelcome
 		submitForm={() => Promise.resolve()}
 		cancelSubmit={() => undefined}
-		previewBody="My first comment!!"
+		previewBody="My first <b>comment</b>!!"
 	/>
 );
 defaultStory.storyName = 'Welcome message';

--- a/dotcom-rendering/src/components/Discussion/FirstCommentWelcome.tsx
+++ b/dotcom-rendering/src/components/Discussion/FirstCommentWelcome.tsx
@@ -4,21 +4,8 @@ import { Link, TextInput } from '@guardian/source-react-components';
 import { useState } from 'react';
 import { palette as schemedPalette } from '../../palette';
 import { PillarButton } from './PillarButton';
+import { Preview } from './Preview';
 import { Row } from './Row';
-
-const previewStyle = css`
-	padding: ${space[2]}px;
-	background-color: ${schemedPalette('--first-comment-preview')};
-	color: inherit;
-	margin-bottom: ${space[5]}px;
-	position: relative;
-	min-height: ${space[9]}px;
-
-	/* p is returned by API and this is the only way to apply styles */
-	p {
-		padding-left: ${space[2]}px;
-	}
-`;
 
 const textStyling = css`
 	${textSans.small()};
@@ -122,10 +109,7 @@ export const FirstCommentWelcome = ({
 					Please preview your comment below and click ‘post’ when
 					you’re happy with it.
 				</Text>
-				<div
-					css={[previewStyle, textStyling]}
-					dangerouslySetInnerHTML={{ __html: previewBody || '' }}
-				/>
+				<Preview previewHtml={previewBody} showSpout={false} />
 				<Row>
 					<PillarButton
 						onClick={() => void submitForm(userName)}

--- a/dotcom-rendering/src/components/Discussion/Preview.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/Preview.stories.tsx
@@ -10,7 +10,10 @@ export const PreviewStory = () => (
 			width: 700px;
 		`}
 	>
-		<Preview previewHtml="<p>This is some preview text</p>" />
+		<Preview
+			showSpout={true}
+			previewHtml="<p>This is some preview text</p>"
+		/>
 	</div>
 );
 PreviewStory.storyName = 'default';
@@ -22,7 +25,10 @@ export const PreviewStoryLinebreaks = () => (
 			width: 700px;
 		`}
 	>
-		<Preview previewHtml="<p>Hello world!<br>this is a line break </p> <p>this is two</p> <p><br>this is three</p>" />
+		<Preview
+			showSpout={true}
+			previewHtml="<p>Hello world!<br>this is a line break </p> <p>this is two</p> <p><br>this is three</p>"
+		/>
 	</div>
 );
 PreviewStoryLinebreaks.storyName = 'Preview comment with linebreaks';

--- a/dotcom-rendering/src/components/Discussion/Preview.tsx
+++ b/dotcom-rendering/src/components/Discussion/Preview.tsx
@@ -7,6 +7,7 @@ import {
 
 type Props = {
 	previewHtml: string;
+	showSpout: boolean;
 };
 
 const previewStyle = css`
@@ -63,9 +64,9 @@ const spout = css`
 	border-right-style: inset;
 `;
 
-export const Preview = ({ previewHtml }: Props) => (
+export const Preview = ({ previewHtml, showSpout }: Props) => (
 	<>
-		<div css={spout} />
+		{showSpout && <div css={spout} />}
 		<div
 			css={previewStyle}
 			dangerouslySetInnerHTML={{ __html: previewHtml || '' }}


### PR DESCRIPTION
## What does this change?

- Uses the `Preview` component for displaying the `FirstCommentWelcome` preview.
- Adds a `showSpout` prop so the spout is only shown when necessary.

Closes https://github.com/guardian/dotcom-rendering/issues/10375

## Screenshots

| Before | After |
|--------|--------|
| ![image](https://github.com/guardian/dotcom-rendering/assets/705427/cb1dcf59-ea7f-49f2-b98e-7d0c2b26ea11) | ![image](https://github.com/guardian/dotcom-rendering/assets/705427/f7ebc8d6-4adf-423e-8c1e-77e8c22410c0) | 