### PR TITLE
Remove `UserProfile` ambient type

### DIFF
--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -319,23 +319,6 @@ type UserBadge = {
 	name: string;
 };
 
-type UserProfile = {
-	userId: string;
-	displayName: string;
-	webUrl: string;
-	apiUrl: string;
-	avatar: string;
-	secureAvatarUrl: string;
-	badge: UserBadge[];
-
-	// only included from /profile/me endpoint
-	privateFields?: {
-		canPostComment: boolean;
-		isPremoderated: boolean;
-		hasCommented: boolean;
-	};
-};
-
 /**
  * Football
  */

--- a/dotcom-rendering/src/components/Discussion/CommentForm.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentForm.tsx
@@ -13,7 +13,11 @@ import {
 	reply as defaultReply,
 } from '../../lib/discussionApi';
 import { palette as schemedPalette } from '../../palette';
-import type { CommentType, SignedInUser } from '../../types/discussion';
+import type {
+	CommentType,
+	SignedInUser,
+	UserProfile,
+} from '../../types/discussion';
 import { FirstCommentWelcome } from './FirstCommentWelcome';
 import { PillarButton } from './PillarButton';
 import { Preview } from './Preview';

--- a/dotcom-rendering/src/components/DiscussionContainer.importable.tsx
+++ b/dotcom-rendering/src/components/DiscussionContainer.importable.tsx
@@ -4,7 +4,7 @@ import type { SignedInWithCookies, SignedInWithOkta } from '../lib/identity';
 import { getOptionsHeadersWithOkta } from '../lib/identity';
 import { useAuthStatus } from '../lib/useAuthStatus';
 import { useHydrated } from '../lib/useHydrated';
-import type { SignedInUser } from '../types/discussion';
+import type { SignedInUser, UserProfile } from '../types/discussion';
 import type { Props as DiscussionProps } from './Discussion';
 import { Discussion } from './Discussion';
 import { Placeholder } from './Placeholder';
@@ -25,7 +25,7 @@ const getUser = async ({
 
 	if (!isObject(data)) return;
 	if (!isObject(data.userProfile)) return;
-	const profile = data.userProfile as UserProfile;
+	const profile = data.userProfile as unknown as UserProfile;
 	return { profile, authStatus };
 };
 

--- a/dotcom-rendering/src/components/DiscussionMeta.importable.tsx
+++ b/dotcom-rendering/src/components/DiscussionMeta.importable.tsx
@@ -3,7 +3,7 @@ import { getOptionsHeadersWithOkta } from '../lib/identity';
 import { useApi } from '../lib/useApi';
 import { useAuthStatus } from '../lib/useAuthStatus';
 import { useCommentCount } from '../lib/useCommentCount';
-import type { GetDiscussionSuccess } from '../types/discussion';
+import type { GetDiscussionSuccess, UserProfile } from '../types/discussion';
 import { SignedInAs } from './SignedInAs';
 
 type Props = {

--- a/dotcom-rendering/src/components/HeaderTopBarMyAccount.tsx
+++ b/dotcom-rendering/src/components/HeaderTopBarMyAccount.tsx
@@ -18,6 +18,7 @@ import { nestedOphanComponents } from '../lib/ophan-helpers';
 import { useApi } from '../lib/useApi';
 import { useBraze } from '../lib/useBraze';
 import ProfileIcon from '../static/icons/profile.svg';
+import type { UserProfile } from '../types/discussion';
 import type { RenderingTarget } from '../types/renderingTarget';
 import { useConfig } from './ConfigContext';
 import type { DropdownLinkType } from './Dropdown';

--- a/dotcom-rendering/src/components/SignedInAs.tsx
+++ b/dotcom-rendering/src/components/SignedInAs.tsx
@@ -8,6 +8,7 @@ import {
 } from '@guardian/source-foundations';
 import { createAuthenticationEventParams } from '../lib/identity-component-event';
 import { palette as themePalette } from '../palette';
+import type { UserProfile } from '../types/discussion';
 
 type Props = {
 	commentCount?: number;


### PR DESCRIPTION
## What does this change?

Remove the ambient `UserProfile` type declaration.

## Why?

It exists as an exported `interface` from discussion.ts.

A step towards:
- #7638

## Screenshots

N/A