### PR TITLE
Reduce number of ambient types

### DIFF
--- a/dotcom-rendering/fixtures/generated/match-report.ts
+++ b/dotcom-rendering/fixtures/generated/match-report.ts
@@ -11,6 +11,8 @@
  *    gen-fixtures.js directly.
  */
 
+import type { MatchReportType } from '../../src/types/matchReport';
+
 export const matchReport: MatchReportType = {
 	id: '4287704',
 	isResult: true,

--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -76,12 +76,6 @@ type ArticleDesign = import('@guardian/libs').ArticleDesign;
 type ArticleTheme = import('@guardian/libs').ArticleTheme;
 type ArticleFormat = import('@guardian/libs').ArticleFormat;
 
-// This is an object that allows you Type defaults of the designTypes.
-// The return type looks like: { Feature: any, Live: any, ...}
-// and can be used to add TypeSafety when needing to override a style in a designType
-
-type DesignTypesObj = { [key in ArticleDesign]: any };
-
 type SharePlatform =
 	| 'facebook'
 	| 'twitter'
@@ -126,7 +120,6 @@ interface ReaderRevenueCategories {
 	gifting?: string;
 }
 
-type ReaderRevenueCategory = 'contribute' | 'subscribe' | 'support';
 interface ReaderRevenuePositions {
 	header: ReaderRevenueCategories;
 	footer: ReaderRevenueCategories;
@@ -203,18 +196,6 @@ type ContentType =
 	| 'signup'
 	| 'userid';
 
-type PageTypeType = {
-	hasShowcaseMainElement: boolean;
-	isFront: boolean;
-	isLiveblog: boolean;
-	isMinuteArticle: boolean;
-	isPaidContent: boolean;
-	isPreview: boolean;
-	isSensitive: boolean;
-};
-
-type MatchType = 'CricketMatchType' | 'FootballMatchType';
-
 type CricketTeam = {
 	name: string;
 	home: boolean;
@@ -278,15 +259,6 @@ interface FENavType {
 
 type StageType = 'DEV' | 'CODE' | 'PROD';
 
-/**
- * KeyEventsRequest is the expected body format for POST requests made to /KeyEvents
- */
-interface FEKeyEventsRequest {
-	keyEvents: Block[];
-	format: FEFormat;
-	filterKeyEvents: boolean;
-}
-
 type CardImageType = 'picture' | 'avatar' | 'crossword' | 'slideshow' | 'video';
 
 type SmallHeadlineSize =
@@ -300,20 +272,6 @@ type SmallHeadlineSize =
 type MediaType = 'Video' | 'Audio' | 'Gallery';
 
 type LeftColSize = 'compact' | 'wide';
-
-type CardPercentageType =
-	| '25%'
-	| '33.333%'
-	| '50%'
-	| '66.666%'
-	| '75%'
-	| '100%';
-
-type HeadlineLink = {
-	to: string; // the href for the anchor tag
-	visitedColour?: string; // a custom colour for the :visited state
-	preventFocus?: boolean; // if true, stop the link from being tabbable and focusable
-};
 
 type UserBadge = {
 	name: string;
@@ -354,21 +312,6 @@ type EventType = {
 	eventType: 'substitution' | 'dismissal' | 'booking';
 };
 
-type MatchReportType = {
-	id: string;
-	isResult: boolean;
-	homeTeam: TeamType;
-	awayTeam: TeamType;
-	competition: {
-		fullName: string;
-	};
-	isLive: boolean;
-	venue: string;
-	comments: string;
-	minByMinUrl: string;
-	reportUrl: string;
-};
-
 interface Topic {
 	type: TopicType;
 	value: string;
@@ -380,31 +323,6 @@ type TopicType = 'ORG' | 'PRODUCT' | 'PERSON' | 'GPE' | 'WORK_OF_ART' | 'LOC';
 interface MessageUs {
 	formId: string;
 	formFields: import('./src/types/content').MessageUsFieldType[];
-}
-
-// ----------------- //
-// General DataTypes //
-// ----------------- //
-
-interface BaseTrailType {
-	url: string;
-	headline: string;
-	webPublicationDate?: string;
-	image?: string;
-	avatarUrl?: string;
-	mediaType?: MediaType;
-	mediaDuration?: number;
-	ageWarning?: string;
-	byline?: string;
-	showByline?: boolean;
-	kickerText?: string;
-	shortUrl?: string;
-	commentCount?: number;
-	starRating?: number;
-	linkText?: string;
-	branding?: import('./src/types/branding').Branding;
-	isSnap?: boolean;
-	snapData?: import('./src/types/front').DCRSnapType;
 }
 
 // ------------

--- a/dotcom-rendering/scripts/test-data/gen-fixtures.js
+++ b/dotcom-rendering/scripts/test-data/gen-fixtures.js
@@ -239,11 +239,10 @@ requests.push(
 		.then((res) => res.json())
 		.then((json) => {
 			// Write the new fixture data
-			const contents = `${HEADER}export const matchReport: MatchReportType = ${JSON.stringify(
-				json,
-				null,
-				4,
-			)}`;
+			const contents = `${HEADER}
+import type { MatchReportType } from '../../src/types/matchReport';
+
+export const matchReport: MatchReportType = ${JSON.stringify(json, null, 4)}`;
 			return fs.writeFile(
 				`${root}/fixtures/generated/match-report.ts`,
 				contents,

--- a/dotcom-rendering/src/components/Card/components/LI.tsx
+++ b/dotcom-rendering/src/components/Card/components/LI.tsx
@@ -10,6 +10,14 @@ import { verticalDivider } from '../../../lib/verticalDivider';
 import { verticalDividerWithBottomOffset } from '../../../lib/verticalDividerWithBottomOffset';
 import type { DCRContainerPalette } from '../../../types/front';
 
+type CardPercentageType =
+	| '25%'
+	| '33.333%'
+	| '50%'
+	| '66.666%'
+	| '75%'
+	| '100%';
+
 /**
  * This value needs to match the one set
  * in the `verticalDividerWithBottomOffset`

--- a/dotcom-rendering/src/components/LinkHeadline.tsx
+++ b/dotcom-rendering/src/components/LinkHeadline.tsx
@@ -5,6 +5,12 @@ import { Byline } from './Byline';
 import { Kicker } from './Kicker';
 import { QuoteIcon } from './QuoteIcon';
 
+type HeadlineLink = {
+	to: string; // the href for the anchor tag
+	visitedColour?: string; // a custom colour for the :visited state
+	preventFocus?: boolean; // if true, stop the link from being tabbable and focusable
+};
+
 type Props = {
 	headlineText: string; // The text shown
 	format: ArticleFormat;

--- a/dotcom-rendering/src/components/ReaderRevenueButton.amp.tsx
+++ b/dotcom-rendering/src/components/ReaderRevenueButton.amp.tsx
@@ -70,7 +70,7 @@ type Props = {
 	nav: NavType;
 	linkLabel: string;
 	rrLink: ReaderRevenuePosition;
-	rrCategory: ReaderRevenueCategory;
+	rrCategory: 'contribute' | 'subscribe' | 'support';
 	rightAlignIcon?: boolean;
 };
 

--- a/dotcom-rendering/src/types/frontend.ts
+++ b/dotcom-rendering/src/types/frontend.ts
@@ -120,6 +120,18 @@ export interface FEArticleType {
 	isRightToLeftLang?: boolean;
 }
 
+type MatchType = 'CricketMatchType' | 'FootballMatchType';
+
+type PageTypeType = {
+	hasShowcaseMainElement: boolean;
+	isFront: boolean;
+	isLiveblog: boolean;
+	isMinuteArticle: boolean;
+	isPaidContent: boolean;
+	isPreview: boolean;
+	isSensitive: boolean;
+};
+
 /**
  * The `DCRArticle` type models the `FEArticleType` in addition to any enhancements DCR makes after
  * receiving the data from Frontend.

--- a/dotcom-rendering/src/types/matchReport.ts
+++ b/dotcom-rendering/src/types/matchReport.ts
@@ -1,0 +1,14 @@
+export type MatchReportType = {
+	id: string;
+	isResult: boolean;
+	homeTeam: TeamType;
+	awayTeam: TeamType;
+	competition: {
+		fullName: string;
+	};
+	isLive: boolean;
+	venue: string;
+	comments: string;
+	minByMinUrl: string;
+	reportUrl: string;
+};


### PR DESCRIPTION
## What does this change?

Remove types from `index.d.ts`:
- if they are unused
- if they are used only once by moving them to the consumer
- if they are duplicated

## Why?

A step towards:
- #7638

## Screenshots

N/A