### PR TITLE
Fix Apps Article Metadata Branding Styles

### DIFF
--- a/dotcom-rendering/src/components/ArticleMeta.apps.tsx
+++ b/dotcom-rendering/src/components/ArticleMeta.apps.tsx
@@ -3,6 +3,7 @@ import type { ArticleFormat } from '@guardian/libs';
 import { ArticleDesign, ArticleDisplay } from '@guardian/libs';
 import { from, space, until } from '@guardian/source-foundations';
 import { StraightLines } from '@guardian/source-react-components-development-kitchen';
+import type { ReactNode } from 'react';
 import { interactiveLegacyClasses } from '../layouts/lib/interactiveLegacyStyling';
 import { getSoleContributor } from '../lib/byline';
 import { palette as themePalette } from '../palette';
@@ -43,7 +44,8 @@ const metaGridContainer = css`
 		'. avatar   byline   comment-count .'
 		'. avatar   byline   comment-count .'
 		'. .        .        .             .'
-		'. dateline dateline dateline      .';
+		'. dateline dateline dateline      .'
+		'. branding branding branding      .';
 
 	${from.mobileLandscape} {
 		grid-template-columns: 20px auto 1fr auto 20px;
@@ -65,7 +67,7 @@ const metaContainerMargins = css`
 	}
 `;
 
-const MetaGridAvatar = ({ children }: { children: React.ReactNode }) => (
+const MetaGridAvatar = ({ children }: { children: ReactNode }) => (
 	<div
 		css={css`
 			grid-area: avatar;
@@ -89,7 +91,7 @@ const MetaGridByline = ({
 	children,
 	isComment,
 }: {
-	children: React.ReactNode;
+	children: ReactNode;
 	isComment: boolean;
 }) => (
 	// address > div > span > svg:first-of-type - spacing for the Follow Tag buttons in follow wrapper,
@@ -124,7 +126,7 @@ const MetaGridCommentCount = ({
 	isAnalysis,
 	isLiveBlog,
 }: {
-	children: React.ReactNode;
+	children: ReactNode;
 	isPicture: boolean;
 	isComment: boolean;
 	isImmersive: boolean;
@@ -163,7 +165,7 @@ const MetaGridDateline = ({
 	children,
 	isImmersiveOrAnalysisWithMultipleAuthors,
 }: {
-	children: React.ReactNode;
+	children: ReactNode;
 	isImmersiveOrAnalysisWithMultipleAuthors: boolean;
 }) => (
 	<div
@@ -176,6 +178,16 @@ const MetaGridDateline = ({
 				? 'byline'
 				: 'dateline',
 		}}
+	>
+		{children}
+	</div>
+);
+
+const MetaGridBranding = ({ children }: { children: ReactNode }) => (
+	<div
+		css={css`
+			grid-area: branding;
+		`}
 	>
 		{children}
 	</div>
@@ -321,12 +333,14 @@ export const ArticleMetaApps = ({
 						format={format}
 					/>
 				</MetaGridDateline>
+				{branding && (
+					<MetaGridBranding>
+						<Island priority="feature" defer={{ until: 'visible' }}>
+							<Branding branding={branding} format={format} />
+						</Island>
+					</MetaGridBranding>
+				)}
 			</div>
-			{branding && (
-				<Island priority="feature" defer={{ until: 'visible' }}>
-					<Branding branding={branding} format={format} />
-				</Island>
-			)}
 		</div>
 	);
 };

--- a/dotcom-rendering/src/components/Branding.importable.tsx
+++ b/dotcom-rendering/src/components/Branding.importable.tsx
@@ -63,6 +63,11 @@ const liveBlogAboutLinkStyle = css`
 	}
 `;
 
+const imgStyles = (lightLogoWidth: number) => css`
+	max-width: ${lightLogoWidth}px;
+	height: fit-content;
+`;
+
 function decideLogo(
 	branding: BrandingType,
 	format: ArticleFormat,
@@ -102,6 +107,7 @@ function decideLogo(
 				height={branding.logo.dimensions.height}
 				src={encodeURI(branding.logo.src)}
 				alt={branding.sponsorName}
+				css={imgStyles(branding.logo.dimensions.width)}
 			/>
 		</picture>
 	);


### PR DESCRIPTION
Solves two issues:

1. The branding content was missing left and right padding. This change adds branding content to the CSS grid used for the apps article metadata, which automatically provides padding.

2. The dark mode logo was appearing much larger than the light mode equivalent. This is because we set the width and height of this logo based on the image data, and the width and height of some dark mode logo images appear to be much larger than their light mode equivalents. This change caps the width of the dark mode logo to that of the light mode version, and ensures the aspect ratio doesn't change by applying `content-fit` to the height.

| | Before | After |
| - | - | - |
| Light | ![light-before] | ![light-after] |
| Dark | ![dark-before] | ![dark-after] |

[light-before]: https://github.com/guardian/dotcom-rendering/assets/53781962/4f81d2cb-d7d7-4ea1-8674-ec0d797da9ac
[dark-before]: https://github.com/guardian/dotcom-rendering/assets/53781962/aa88f564-e3ff-4740-9a6f-20d8b0a2e1df
[light-after]: https://github.com/guardian/dotcom-rendering/assets/53781962/57698e62-66d3-4c84-9364-fd4a34efd517
[dark-after]: https://github.com/guardian/dotcom-rendering/assets/53781962/3156ed1d-3051-4fff-8dd3-dd5c0bf36abf
