### PR TITLE
Fix type of Discussion API response

### DIFF
--- a/dotcom-rendering/src/lib/discussionApi.tsx
+++ b/dotcom-rendering/src/lib/discussionApi.tsx
@@ -249,6 +249,7 @@ export const getPicks = async (
 	const result = safeParse(discussionApiResponseSchema, jsonResult.value);
 
 	if (!result.success) {
+		console.error(result.issues);
 		return { kind: 'error', error: 'ParsingError' };
 	}
 	if (result.output.status === 'error') {

--- a/dotcom-rendering/src/lib/discussionApi.tsx
+++ b/dotcom-rendering/src/lib/discussionApi.tsx
@@ -249,7 +249,6 @@ export const getPicks = async (
 	const result = safeParse(discussionApiResponseSchema, jsonResult.value);
 
 	if (!result.success) {
-		console.error(result.issues);
 		return { kind: 'error', error: 'ParsingError' };
 	}
 	if (result.output.status === 'error') {

--- a/dotcom-rendering/src/types/discussion.ts
+++ b/dotcom-rendering/src/types/discussion.ts
@@ -373,7 +373,7 @@ const discussionApiSuccessSchema = object({
 		webUrl: string(),
 		apiUrl: string(),
 		commentCount: number(),
-		topLevelCommentCount: number(),
+		topLevelCommentCount: optional(number(), 0),
 		isClosedForComments: boolean(),
 		isClosedForRecommendation: boolean(),
 		isThreaded: boolean(),


### PR DESCRIPTION
## What does this change?

Handles optional `topLevelCommentCount`

## Why?

Prevents some discussion from showing Top Picks, [as reported by moderators](https://groups.google.com/a/guardian.co.uk/g/dotcom.platform/c/DENF_NRkBB0/m/8Vpgcoe6AAAJ).

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/76776/5910b0f6-3800-4f2e-b8a1-9a3d3ce58bd3
[after]: https://github.com/guardian/dotcom-rendering/assets/76776/fc7e4f7b-39df-40e0-8145-f39198786007