### PR TITLE
Add an extra comment without removing the last one

### DIFF
--- a/dotcom-rendering/src/components/Discussion.tsx
+++ b/dotcom-rendering/src/components/Discussion.tsx
@@ -139,7 +139,7 @@ const reducer = (state: State, action: Action): State => {
 		case 'addComment':
 			return {
 				...state,
-				comments: [action.comment, ...state.comments.slice(0, -1)], // Remove last item from our local array Replace it with this new comment at the start
+				comments: [action.comment, ...state.comments],
 				isExpanded: true,
 			};
 		case 'expandComments':


### PR DESCRIPTION
## What does this change?
Stops removing the last comment on a page when we artificially add a new one into the list.

## Why?
Historically, when a user adds a comment, we add it to the top of the list of comments and pop the last comment off (because we limit the number of comments on a page to 25/50/100). We do this so the user gets immediate feedback that there comment has been posted without the need to wait for caching (which is quite slow). 

However, popping the last comment off the page means this comment might never be seen as it won't pushed to the top of the next page. 

Instead we will just add the comment on to the top and show +1 more comments than should be visible.
