### PR TITLE
Reduce number of instances used for `rendering` app

### DIFF
--- a/dotcom-rendering/cdk/bin/cdk.ts
+++ b/dotcom-rendering/cdk/bin/cdk.ts
@@ -15,8 +15,8 @@ new DotcomRendering(cdkApp, 'DotcomRendering-PROD', {
 	...sharedProps,
 	app: 'rendering',
 	stage: 'PROD',
-	minCapacity: 27,
-	maxCapacity: 120,
+	minCapacity: 18,
+	maxCapacity: 80,
 	instanceType: 't4g.small',
 });
 new DotcomRendering(cdkApp, 'DotcomRendering-CODE', {


### PR DESCRIPTION
## What does this change?

Reduces the number of instances from 27 down to 18 for the `rendering` app (`DotcomRendering` in CDK), now that most of the traffic has been diverted to the `article-rendering` app (`RenderingCDKStack` in CDK).

Also reduces the maximum number of instances from 120 down to 80.

## Why?

We don't need as many instances as we're using.
We also want to see if it will even _improve_ performance as there's a theory that spreading the traffic across so many instances means that we are experiencing slow starts from each instance running the application.

Resolves #10396