### PR TITLE
Lift comment forms `isActive` state to the `Discussion` reducer

### DIFF
--- a/dotcom-rendering/src/components/Discussion.tsx
+++ b/dotcom-rendering/src/components/Discussion.tsx
@@ -227,6 +227,9 @@ export const Discussion = ({
 			hashCommentId,
 			totalPages,
 			loading,
+			topForm,
+			replyForm,
+			bottomForm,
 		},
 		dispatch,
 	] = useReducer(reducer, initialState);
@@ -386,6 +389,9 @@ export const Discussion = ({
 					setBottomFormActive={(isActive) =>
 						dispatch({ type: 'setBottomFormActive', isActive })
 					}
+					isTopFormActive={topForm.isActive}
+					isReplyFormActive={replyForm.isActive}
+					isBottomFormActive={bottomForm.isActive}
 				/>
 				{!isExpanded && (
 					<div id="discussion-overlay" css={overlayStyles} />

--- a/dotcom-rendering/src/components/Discussion.tsx
+++ b/dotcom-rendering/src/components/Discussion.tsx
@@ -99,6 +99,9 @@ type State = {
 	hashCommentId: number | undefined;
 	totalPages: number;
 	loading: boolean;
+	topForm: { isActive: boolean };
+	replyForm: { isActive: boolean };
+	bottomForm: { isActive: boolean };
 };
 
 const initialState: State = {
@@ -110,6 +113,9 @@ const initialState: State = {
 	hashCommentId: undefined,
 	totalPages: 0,
 	loading: true,
+	topForm: { isActive: false },
+	replyForm: { isActive: false },
+	bottomForm: { isActive: false },
 };
 
 type Action =
@@ -124,7 +130,10 @@ type Action =
 	| { type: 'updateCommentPage'; commentPage: number; shouldExpand: boolean }
 	| { type: 'updateHashCommentId'; hashCommentId: number | undefined }
 	| { type: 'filterChange'; filters: FilterOptions; commentPage?: number }
-	| { type: 'setLoading'; loading: boolean };
+	| { type: 'setLoading'; loading: boolean }
+	| { type: 'setTopFormActive'; isActive: boolean }
+	| { type: 'setReplyFormActive'; isActive: boolean }
+	| { type: 'setBottomFormActive'; isActive: boolean };
 
 const reducer = (state: State, action: Action): State => {
 	switch (action.type) {
@@ -174,6 +183,25 @@ const reducer = (state: State, action: Action): State => {
 				isExpanded: true,
 			};
 		}
+		case 'setTopFormActive': {
+			return {
+				...state,
+				topForm: { isActive: action.isActive },
+			};
+		}
+		case 'setReplyFormActive': {
+			return {
+				...state,
+				replyForm: { isActive: action.isActive },
+			};
+		}
+		case 'setBottomFormActive': {
+			return {
+				...state,
+				bottomForm: { isActive: action.isActive },
+			};
+		}
+
 		default:
 			assertUnreachable(action);
 			return state;
@@ -349,6 +377,15 @@ export const Discussion = ({
 							commentPage: page,
 						});
 					}}
+					setTopFormActive={(isActive) =>
+						dispatch({ type: 'setTopFormActive', isActive })
+					}
+					setReplyFormActive={(isActive) =>
+						dispatch({ type: 'setReplyFormActive', isActive })
+					}
+					setBottomFormActive={(isActive) =>
+						dispatch({ type: 'setBottomFormActive', isActive })
+					}
 				/>
 				{!isExpanded && (
 					<div id="discussion-overlay" css={overlayStyles} />

--- a/dotcom-rendering/src/components/Discussion/Comments.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comments.stories.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
+import { useState } from 'react';
 import { splitTheme } from '../../../.storybook/decorators/splitThemeDecorator';
 import { lightDecorator } from '../../../.storybook/decorators/themeDecorator';
 import { discussion as discussionMock } from '../../../fixtures/manual/discussion';
@@ -78,6 +79,9 @@ export const LoggedOutHiddenPicks = () => (
 			setTopFormActive={() => {}}
 			setReplyFormActive={() => {}}
 			setBottomFormActive={() => {}}
+			isTopFormActive={false}
+			isReplyFormActive={false}
+			isBottomFormActive={false}
 		/>
 	</div>
 );
@@ -122,6 +126,9 @@ export const InitialPage = () => (
 			setTopFormActive={() => {}}
 			setReplyFormActive={() => {}}
 			setBottomFormActive={() => {}}
+			isTopFormActive={false}
+			isReplyFormActive={false}
+			isBottomFormActive={false}
 		/>
 	</div>
 );
@@ -135,118 +142,141 @@ InitialPage.decorators = [
 	]),
 ];
 
-export const LoggedInHiddenNoPicks = () => (
-	<div
-		css={css`
-			width: 100%;
-			max-width: 620px;
-		`}
-	>
-		<Comments
-			shortUrl="p/abc123"
-			isClosedForComments={false}
-			user={aUser}
-			baseUrl="https://discussion.theguardian.com/discussion-api"
-			additionalHeaders={{
-				'D2-X-UID': 'testD2Header',
-				'GU-Client': 'testClientHeader',
-			}}
-			expanded={false}
-			onPermalinkClick={() => {}}
-			apiKey=""
-			idApiUrl="https://idapi.theguardian.com"
-			page={3}
-			setPage={() => {}}
-			filters={filters}
-			commentCount={discussionMock.discussion.commentCount}
-			loading={false}
-			totalPages={discussionMock.pages}
-			comments={discussionMock.discussion.comments}
-			setComment={() => {}}
-			handleFilterChange={() => {}}
-			setTopFormActive={() => {}}
-			setReplyFormActive={() => {}}
-			setBottomFormActive={() => {}}
-		/>
-	</div>
-);
+export const LoggedInHiddenNoPicks = () => {
+	const [isActive, setActive] = useState(false);
+
+	return (
+		<div
+			css={css`
+				width: 100%;
+				max-width: 620px;
+			`}
+		>
+			<Comments
+				shortUrl="p/abc123"
+				isClosedForComments={false}
+				user={aUser}
+				baseUrl="https://discussion.theguardian.com/discussion-api"
+				additionalHeaders={{
+					'D2-X-UID': 'testD2Header',
+					'GU-Client': 'testClientHeader',
+				}}
+				expanded={false}
+				onPermalinkClick={() => {}}
+				apiKey=""
+				idApiUrl="https://idapi.theguardian.com"
+				page={3}
+				setPage={() => {}}
+				filters={filters}
+				commentCount={discussionMock.discussion.commentCount}
+				loading={false}
+				totalPages={discussionMock.pages}
+				comments={discussionMock.discussion.comments}
+				setComment={() => {}}
+				handleFilterChange={() => {}}
+				setTopFormActive={() => {}}
+				setReplyFormActive={setActive}
+				setBottomFormActive={() => {}}
+				isTopFormActive={false}
+				isReplyFormActive={isActive}
+				isBottomFormActive={false}
+			/>
+		</div>
+	);
+};
 LoggedInHiddenNoPicks.storyName =
 	'when logged in, with no picks and not expanded';
 LoggedInHiddenNoPicks.decorators = [splitTheme([format])];
 
-export const LoggedIn = () => (
-	<div
-		css={css`
-			width: 100%;
-			max-width: 620px;
-		`}
-	>
-		<Comments
-			shortUrl="p/abc123"
-			isClosedForComments={false}
-			user={aUser}
-			baseUrl="https://discussion.theguardian.com/discussion-api"
-			additionalHeaders={{
-				'D2-X-UID': 'testD2Header',
-				'GU-Client': 'testClientHeader',
-			}}
-			expanded={true}
-			onPermalinkClick={() => {}}
-			apiKey=""
-			idApiUrl="https://idapi.theguardian.com"
-			page={3}
-			setPage={() => {}}
-			filters={filters}
-			commentCount={discussionMock.discussion.commentCount}
-			loading={false}
-			totalPages={discussionMock.pages}
-			comments={discussionMock.discussion.comments}
-			setComment={() => {}}
-			handleFilterChange={() => {}}
-			setTopFormActive={() => {}}
-			setReplyFormActive={() => {}}
-			setBottomFormActive={() => {}}
-		/>
-	</div>
-);
+export const LoggedIn = () => {
+	const [isReplyFormActive, setReplyFormActive] = useState(false);
+	const [isBottomFormActive, setBottomFormActive] = useState(false);
+
+	return (
+		<div
+			css={css`
+				width: 100%;
+				max-width: 620px;
+			`}
+		>
+			<Comments
+				shortUrl="p/abc123"
+				isClosedForComments={false}
+				user={aUser}
+				baseUrl="https://discussion.theguardian.com/discussion-api"
+				additionalHeaders={{
+					'D2-X-UID': 'testD2Header',
+					'GU-Client': 'testClientHeader',
+				}}
+				expanded={true}
+				onPermalinkClick={() => {}}
+				apiKey=""
+				idApiUrl="https://idapi.theguardian.com"
+				page={3}
+				setPage={() => {}}
+				filters={filters}
+				commentCount={discussionMock.discussion.commentCount}
+				loading={false}
+				totalPages={discussionMock.pages}
+				comments={discussionMock.discussion.comments}
+				setComment={() => {}}
+				handleFilterChange={() => {}}
+				setTopFormActive={() => {}}
+				setReplyFormActive={setReplyFormActive}
+				setBottomFormActive={setBottomFormActive}
+				isTopFormActive={false}
+				isReplyFormActive={isReplyFormActive}
+				isBottomFormActive={isBottomFormActive}
+			/>
+		</div>
+	);
+};
 LoggedIn.storyName = 'when logged in and expanded';
 LoggedIn.decorators = [lightDecorator([format])];
 
-export const LoggedInShortDiscussion = () => (
-	<div
-		css={css`
-			width: 100%;
-			max-width: 620px;
-		`}
-	>
-		<Comments
-			shortUrl={discussionWithTwoComments.discussion.key} // Two comments"
-			isClosedForComments={false}
-			user={aUser}
-			baseUrl="https://discussion.theguardian.com/discussion-api"
-			additionalHeaders={{
-				'D2-X-UID': 'testD2Header',
-				'GU-Client': 'testClientHeader',
-			}}
-			expanded={true}
-			onPermalinkClick={() => {}}
-			apiKey=""
-			idApiUrl="https://idapi.theguardian.com"
-			page={3}
-			setPage={() => {}}
-			filters={filters}
-			commentCount={discussionWithTwoComments.discussion.commentCount}
-			loading={false}
-			totalPages={discussionWithTwoComments.pages}
-			comments={discussionWithTwoComments.discussion.comments}
-			setComment={() => {}}
-			handleFilterChange={() => {}}
-			setTopFormActive={() => {}}
-			setReplyFormActive={() => {}}
-			setBottomFormActive={() => {}}
-		/>
-	</div>
-);
+export const LoggedInShortDiscussion = () => {
+	const [isTopFormActive, setTopFormActive] = useState(false);
+	const [isReplyFormActive, setReplyFormActive] = useState(false);
+
+	return (
+		<div
+			css={css`
+				width: 100%;
+				max-width: 620px;
+			`}
+		>
+			<Comments
+				shortUrl={discussionWithTwoComments.discussion.key} // Two comments"
+				isClosedForComments={false}
+				user={aUser}
+				baseUrl="https://discussion.theguardian.com/discussion-api"
+				additionalHeaders={{
+					'D2-X-UID': 'testD2Header',
+					'GU-Client': 'testClientHeader',
+				}}
+				expanded={true}
+				onPermalinkClick={() => {}}
+				apiKey=""
+				idApiUrl="https://idapi.theguardian.com"
+				page={3}
+				setPage={() => {}}
+				filters={filters}
+				commentCount={discussionWithTwoComments.discussion.commentCount}
+				loading={false}
+				totalPages={discussionWithTwoComments.pages}
+				comments={discussionWithTwoComments.discussion.comments}
+				setComment={() => {}}
+				handleFilterChange={() => {}}
+				setTopFormActive={setTopFormActive}
+				setReplyFormActive={setReplyFormActive}
+				setBottomFormActive={() => {}}
+				isTopFormActive={isTopFormActive}
+				isReplyFormActive={isReplyFormActive}
+				isBottomFormActive={false}
+			/>
+		</div>
+	);
+};
 LoggedInShortDiscussion.decorators = [splitTheme([format])];
 
 export const LoggedOutHiddenNoPicks = () => (
@@ -280,6 +310,9 @@ export const LoggedOutHiddenNoPicks = () => (
 			setTopFormActive={() => {}}
 			setReplyFormActive={() => {}}
 			setBottomFormActive={() => {}}
+			isTopFormActive={false}
+			isReplyFormActive={false}
+			isBottomFormActive={false}
 		/>
 	</div>
 );
@@ -326,6 +359,9 @@ export const Closed = () => (
 			setTopFormActive={() => {}}
 			setReplyFormActive={() => {}}
 			setBottomFormActive={() => {}}
+			isTopFormActive={false}
+			isReplyFormActive={false}
+			isBottomFormActive={false}
 		/>
 	</div>
 );
@@ -370,6 +406,9 @@ export const NoComments = () => (
 			setTopFormActive={() => {}}
 			setReplyFormActive={() => {}}
 			setBottomFormActive={() => {}}
+			isTopFormActive={false}
+			isReplyFormActive={false}
+			isBottomFormActive={false}
 		/>
 	</div>
 );
@@ -416,6 +455,9 @@ export const LegacyDiscussion = () => (
 			setTopFormActive={() => {}}
 			setReplyFormActive={() => {}}
 			setBottomFormActive={() => {}}
+			isTopFormActive={false}
+			isReplyFormActive={false}
+			isBottomFormActive={false}
 		/>
 	</div>
 );

--- a/dotcom-rendering/src/components/Discussion/Comments.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comments.stories.tsx
@@ -75,6 +75,9 @@ export const LoggedOutHiddenPicks = () => (
 			comments={discussionMock.discussion.comments}
 			setComment={() => {}}
 			handleFilterChange={() => {}}
+			setTopFormActive={() => {}}
+			setReplyFormActive={() => {}}
+			setBottomFormActive={() => {}}
 		/>
 	</div>
 );
@@ -116,6 +119,9 @@ export const InitialPage = () => (
 			comments={discussionMock.discussion.comments}
 			setComment={() => {}}
 			handleFilterChange={() => {}}
+			setTopFormActive={() => {}}
+			setReplyFormActive={() => {}}
+			setBottomFormActive={() => {}}
 		/>
 	</div>
 );
@@ -158,6 +164,9 @@ export const LoggedInHiddenNoPicks = () => (
 			comments={discussionMock.discussion.comments}
 			setComment={() => {}}
 			handleFilterChange={() => {}}
+			setTopFormActive={() => {}}
+			setReplyFormActive={() => {}}
+			setBottomFormActive={() => {}}
 		/>
 	</div>
 );
@@ -194,6 +203,9 @@ export const LoggedIn = () => (
 			comments={discussionMock.discussion.comments}
 			setComment={() => {}}
 			handleFilterChange={() => {}}
+			setTopFormActive={() => {}}
+			setReplyFormActive={() => {}}
+			setBottomFormActive={() => {}}
 		/>
 	</div>
 );
@@ -229,6 +241,9 @@ export const LoggedInShortDiscussion = () => (
 			comments={discussionWithTwoComments.discussion.comments}
 			setComment={() => {}}
 			handleFilterChange={() => {}}
+			setTopFormActive={() => {}}
+			setReplyFormActive={() => {}}
+			setBottomFormActive={() => {}}
 		/>
 	</div>
 );
@@ -262,6 +277,9 @@ export const LoggedOutHiddenNoPicks = () => (
 			comments={discussionMock.discussion.comments}
 			setComment={() => {}}
 			handleFilterChange={() => {}}
+			setTopFormActive={() => {}}
+			setReplyFormActive={() => {}}
+			setBottomFormActive={() => {}}
 		/>
 	</div>
 );
@@ -305,6 +323,9 @@ export const Closed = () => (
 			comments={discussionMock.discussion.comments}
 			setComment={() => {}}
 			handleFilterChange={() => {}}
+			setTopFormActive={() => {}}
+			setReplyFormActive={() => {}}
+			setBottomFormActive={() => {}}
 		/>
 	</div>
 );
@@ -346,6 +367,9 @@ export const NoComments = () => (
 			comments={[]}
 			setComment={() => {}}
 			handleFilterChange={() => {}}
+			setTopFormActive={() => {}}
+			setReplyFormActive={() => {}}
+			setBottomFormActive={() => {}}
 		/>
 	</div>
 );
@@ -389,6 +413,9 @@ export const LegacyDiscussion = () => (
 			comments={legacyDiscussionWithoutThreading.discussion.comments}
 			setComment={() => {}}
 			handleFilterChange={() => {}}
+			setTopFormActive={() => {}}
+			setReplyFormActive={() => {}}
+			setBottomFormActive={() => {}}
 		/>
 	</div>
 );

--- a/dotcom-rendering/src/components/Discussion/Comments.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comments.tsx
@@ -43,6 +43,9 @@ type Props = {
 	comments: CommentType[];
 	setComment: (comment: CommentType) => void;
 	handleFilterChange: (newFilters: FilterOptions, page?: number) => void;
+	setTopFormActive: (isActive: boolean) => void;
+	setReplyFormActive: (isActive: boolean) => void;
+	setBottomFormActive: (isActive: boolean) => void;
 };
 
 const footerStyles = css`
@@ -117,6 +120,9 @@ export const Comments = ({
 	comments,
 	setComment,
 	handleFilterChange,
+	setTopFormActive,
+	setReplyFormActive,
+	setBottomFormActive,
 }: Props) => {
 	const [picks, setPicks] = useState<CommentType[]>([]);
 	const [commentBeingRepliedTo, setCommentBeingRepliedTo] =
@@ -317,7 +323,7 @@ export const Comments = ({
 					showPreview={showPreview}
 					setShowPreview={setShowPreview}
 					isActive={isCommentFormActive}
-					setIsActive={setIsCommentFormActive}
+					setIsActive={setTopFormActive}
 					error={error}
 					setError={setError}
 					userNameMissing={userNameMissing}
@@ -378,9 +384,7 @@ export const Comments = ({
 									showPreview={showPreview}
 									setShowPreview={setShowPreview}
 									isCommentFormActive={isCommentFormActive}
-									setIsCommentFormActive={
-										setIsCommentFormActive
-									}
+									setIsCommentFormActive={setReplyFormActive}
 									error={error}
 									setError={setError}
 									userNameMissing={userNameMissing}
@@ -413,7 +417,7 @@ export const Comments = ({
 					showPreview={showPreview}
 					setShowPreview={setShowPreview}
 					isActive={isCommentFormActive}
-					setIsActive={setIsCommentFormActive}
+					setIsActive={setBottomFormActive}
 					error={error}
 					setError={setError}
 					userNameMissing={userNameMissing}

--- a/dotcom-rendering/src/components/Discussion/Comments.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comments.tsx
@@ -46,6 +46,9 @@ type Props = {
 	setTopFormActive: (isActive: boolean) => void;
 	setReplyFormActive: (isActive: boolean) => void;
 	setBottomFormActive: (isActive: boolean) => void;
+	isTopFormActive: boolean;
+	isReplyFormActive: boolean;
+	isBottomFormActive: boolean;
 };
 
 const footerStyles = css`
@@ -123,6 +126,9 @@ export const Comments = ({
 	setTopFormActive,
 	setReplyFormActive,
 	setBottomFormActive,
+	isTopFormActive,
+	isReplyFormActive,
+	isBottomFormActive,
 }: Props) => {
 	const [picks, setPicks] = useState<CommentType[]>([]);
 	const [commentBeingRepliedTo, setCommentBeingRepliedTo] =
@@ -130,9 +136,6 @@ export const Comments = ({
 	const [numberOfCommentsToShow, setNumberOfCommentsToShow] = useState(10);
 	const [mutes, setMutes] = useState<string[]>(readMutes());
 	const [showPreview, setShowPreview] = useState<boolean>(false);
-	const [isCommentFormActive, setIsCommentFormActive] = useState<boolean>(
-		!!commentBeingRepliedTo,
-	);
 	const [error, setError] = useState<string>('');
 	const [userNameMissing, setUserNameMissing] = useState<boolean>(false);
 	const [previewBody, setPreviewBody] = useState<string>('');
@@ -288,10 +291,10 @@ export const Comments = ({
 											showPreview={showPreview}
 											setShowPreview={setShowPreview}
 											isCommentFormActive={
-												isCommentFormActive
+												isReplyFormActive
 											}
 											setIsCommentFormActive={
-												setIsCommentFormActive
+												setReplyFormActive
 											}
 											error={error}
 											setError={setError}
@@ -322,7 +325,7 @@ export const Comments = ({
 					onPreview={onPreview}
 					showPreview={showPreview}
 					setShowPreview={setShowPreview}
-					isActive={isCommentFormActive}
+					isActive={isTopFormActive}
 					setIsActive={setTopFormActive}
 					error={error}
 					setError={setError}
@@ -383,7 +386,7 @@ export const Comments = ({
 									onRecommend={onRecommend}
 									showPreview={showPreview}
 									setShowPreview={setShowPreview}
-									isCommentFormActive={isCommentFormActive}
+									isCommentFormActive={isReplyFormActive}
 									setIsCommentFormActive={setReplyFormActive}
 									error={error}
 									setError={setError}
@@ -416,7 +419,7 @@ export const Comments = ({
 					onPreview={onPreview}
 					showPreview={showPreview}
 					setShowPreview={setShowPreview}
-					isActive={isCommentFormActive}
+					isActive={isBottomFormActive}
 					setIsActive={setBottomFormActive}
 					error={error}
 					setError={setError}


### PR DESCRIPTION
Paired with @JamieB-gu and @abeddow91 

I recommend reviewing with "Hide whitespace"

## What does this change?
Adds `isFormActive` state in the reducer. At this point we're adding separate state for the three existing forms on the page, top, reply and bottom form.

## Why?
* We want to lift all state in the reducer in Discussion
* We want each form to have its own state
* Fixes the following bug

https://github.com/guardian/dotcom-rendering/assets/19683595/780ee5e1-8b1c-498c-90eb-d78a7372dd25


## Testing
Tested in CODE

https://github.com/guardian/dotcom-rendering/assets/19683595/55563844-3fc9-4326-a584-925c47bf7af1







