### PR TITLE
Refactor Discussion to tie `onComment` & `onReply` to `user`

### DIFF
--- a/dotcom-rendering/fixtures/manual/comment.ts
+++ b/dotcom-rendering/fixtures/manual/comment.ts
@@ -1,3 +1,5 @@
+import type { CommentType } from '../../src/types/discussion';
+
 export const comment = {
 	id: 138809272,
 	body: '<p>Begone ye self-serving Tory isolationists.</p> <p>Never has there been a more significant time for Big Government and public health provision. Nature has spoken.</p>',
@@ -154,4 +156,4 @@ export const comment = {
 		blockedCount: 1,
 		responseCount: 4,
 	},
-};
+} as const satisfies CommentType;

--- a/dotcom-rendering/src/components/Discussion/Comment.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comment.stories.tsx
@@ -104,6 +104,11 @@ const longBothReplyCommentData: CommentType = {
 	},
 };
 
+const commentResponseError = {
+	kind: 'error',
+	error: { code: 'NetworkError', message: 'Mocked' },
+} as const;
+
 const user: SignedInUser = {
 	profile: {
 		userId: 'abc123',
@@ -119,6 +124,8 @@ const user: SignedInUser = {
 			hasCommented: true,
 		},
 	},
+	onComment: () => Promise.resolve(commentResponseError),
+	onReply: () => Promise.resolve(commentResponseError),
 	authStatus: { kind: 'SignedInWithCookies' },
 };
 
@@ -137,6 +144,8 @@ const staffUser: SignedInUser = {
 			hasCommented: true,
 		},
 	},
+	onComment: () => Promise.resolve(commentResponseError),
+	onReply: () => Promise.resolve(commentResponseError),
 	authStatus: { kind: 'SignedInWithCookies' },
 };
 

--- a/dotcom-rendering/src/components/Discussion/CommentContainer.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentContainer.stories.tsx
@@ -133,6 +133,11 @@ const commentDataWithLongThread: CommentType = {
 	},
 };
 
+const commentResponseError = {
+	kind: 'error',
+	error: { code: 'NetworkError', message: 'Mocked' },
+} as const;
+
 const aUser: SignedInUser = {
 	profile: {
 		userId: 'abc123',
@@ -148,6 +153,8 @@ const aUser: SignedInUser = {
 			hasCommented: true,
 		},
 	},
+	onComment: () => Promise.resolve(commentResponseError),
+	onReply: () => Promise.resolve(commentResponseError),
 	authStatus: { kind: 'SignedInWithCookies' },
 };
 

--- a/dotcom-rendering/src/components/Discussion/CommentContainer.test.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentContainer.test.tsx
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom/extend-expect';
 import { fireEvent, render, waitFor } from '@testing-library/react';
 import { comment } from '../../../fixtures/manual/comment';
 import { mockedMessageID, mockRESTCalls } from '../../lib/mockRESTCalls';
+import type { Result } from '../../lib/result';
 import type { CommentType, SignedInUser } from '../../types/discussion';
 import { CommentContainer } from './CommentContainer';
 
@@ -19,6 +20,16 @@ const commentWithoutReply = {
 	responses: [],
 } satisfies CommentType;
 
+const commentResponseError = {
+	kind: 'error',
+	error: { code: 'NetworkError', message: 'Mocked' },
+} as const satisfies Result<unknown, unknown>;
+
+const commentResponseSuccess = {
+	kind: 'ok',
+	value: 123456,
+} as const satisfies Result<unknown, unknown>;
+
 const aUser: SignedInUser = {
 	profile: {
 		userId: 'abc123',
@@ -34,6 +45,8 @@ const aUser: SignedInUser = {
 			hasCommented: true,
 		},
 	},
+	onComment: () => Promise.resolve(commentResponseError),
+	onReply: () => Promise.resolve(commentResponseSuccess),
 	authStatus: { kind: 'SignedInWithCookies' },
 };
 

--- a/dotcom-rendering/src/components/Discussion/CommentContainer.test.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentContainer.test.tsx
@@ -7,18 +7,17 @@ import { CommentContainer } from './CommentContainer';
 
 mockRESTCalls();
 
-// @ts-expect-error -- We know this is not `undefined`
-const firstCommentResponse: CommentType = comment.responses[0];
+const firstCommentResponse = comment.responses[0];
 
-const commentWithReply: CommentType = {
+const commentWithReply = {
 	...comment,
 	responses: [firstCommentResponse],
-};
+} satisfies CommentType;
 
-const commentWithoutReply: CommentType = {
+const commentWithoutReply = {
 	...comment,
 	responses: [],
-};
+} satisfies CommentType;
 
 const aUser: SignedInUser = {
 	profile: {

--- a/dotcom-rendering/src/components/Discussion/CommentContainer.test.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentContainer.test.tsx
@@ -57,7 +57,7 @@ describe('CommentContainer', () => {
 		const { getByTestId, queryByText, getByText, rerender } = render(
 			<CommentContainer
 				shortUrl=""
-				comment={commentWithoutReply} //TODO: should be comments with reponses
+				comment={commentWithoutReply}
 				user={aUser}
 				threads="collapsed"
 				commentBeingRepliedTo={commentBeingRepliedTo}
@@ -104,7 +104,7 @@ describe('CommentContainer', () => {
 		rerender(
 			<CommentContainer
 				shortUrl=""
-				comment={commentWithoutReply} //TODO: should be comments with reponses
+				comment={commentWithoutReply}
 				user={aUser}
 				threads="collapsed"
 				commentBeingRepliedTo={commentBeingRepliedTo}
@@ -150,7 +150,7 @@ describe('CommentContainer', () => {
 		const { getByTestId, queryByText, getByText, rerender } = render(
 			<CommentContainer
 				shortUrl=""
-				comment={commentWithReply} //TODO: should be comments with reponses
+				comment={commentWithReply}
 				user={aUser}
 				threads="collapsed"
 				commentBeingRepliedTo={commentBeingRepliedTo}
@@ -188,7 +188,7 @@ describe('CommentContainer', () => {
 			expect(mockSetCommentBeingRepliedTo).toHaveBeenCalledTimes(1),
 		);
 
-		// make sure the new comment appeats
+		// make sure the new comment appears
 		await waitFor(() => {
 			expect(getByTestId(mockedMessageID)).toBeInTheDocument();
 		});
@@ -197,7 +197,7 @@ describe('CommentContainer', () => {
 		rerender(
 			<CommentContainer
 				shortUrl=""
-				comment={commentWithoutReply} //TODO: should be comments with reponses
+				comment={commentWithoutReply}
 				user={aUser}
 				threads="collapsed"
 				commentBeingRepliedTo={commentBeingRepliedTo}

--- a/dotcom-rendering/src/components/Discussion/CommentContainer.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentContainer.tsx
@@ -243,8 +243,6 @@ export const CommentContainer = ({
 									setCommentBeingRepliedTo
 								}
 								commentBeingRepliedTo={commentBeingRepliedTo}
-								onComment={onComment}
-								onReply={onReply}
 								onPreview={onPreview}
 								showPreview={showPreview}
 								setShowPreview={setShowPreview}

--- a/dotcom-rendering/src/components/Discussion/CommentForm.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentForm.stories.tsx
@@ -14,6 +14,11 @@ const defaultFormat = {
 	theme: Pillar.News,
 };
 
+const commentResponseError = {
+	kind: 'error',
+	error: { code: 'NetworkError', message: 'Mocked' },
+} as const;
+
 const aUser: SignedInUser = {
 	profile: {
 		userId: 'abc123',
@@ -29,6 +34,8 @@ const aUser: SignedInUser = {
 			hasCommented: true,
 		},
 	},
+	onComment: () => Promise.resolve(commentResponseError),
+	onReply: () => Promise.resolve(commentResponseError),
 	authStatus: { kind: 'SignedInWithCookies' },
 };
 

--- a/dotcom-rendering/src/components/Discussion/CommentForm.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentForm.tsx
@@ -8,9 +8,7 @@ import {
 import { useEffect, useRef, useState } from 'react';
 import {
 	addUserName,
-	comment as defaultComment,
 	preview as defaultPreview,
-	reply as defaultReply,
 } from '../../lib/discussionApi';
 import { palette as schemedPalette } from '../../palette';
 import type {
@@ -29,8 +27,6 @@ type Props = {
 	onAddComment: (response: CommentType) => void;
 	setCommentBeingRepliedTo?: () => void;
 	commentBeingRepliedTo?: CommentType;
-	onComment?: ReturnType<typeof defaultComment>;
-	onReply?: ReturnType<typeof defaultReply>;
 	onPreview?: typeof defaultPreview;
 	showPreview: boolean;
 	setShowPreview: (showPreview: boolean) => void;
@@ -215,8 +211,6 @@ export const CommentForm = ({
 	user,
 	setCommentBeingRepliedTo,
 	commentBeingRepliedTo,
-	onComment,
-	onReply,
 	onPreview,
 	showPreview,
 	setShowPreview,
@@ -320,11 +314,9 @@ export const CommentForm = ({
 		setInfo('');
 
 		if (body) {
-			const comment = onComment ?? defaultComment(user.authStatus);
-			const reply = onReply ?? defaultReply(user.authStatus);
 			const response = commentBeingRepliedTo
-				? await reply(shortUrl, body, commentBeingRepliedTo.id)
-				: await comment(shortUrl, body);
+				? await user.onReply(shortUrl, body, commentBeingRepliedTo.id)
+				: await user.onComment(shortUrl, body);
 			// Check response message for error states
 			if (response.kind === 'error') {
 				if (response.error.code === 'USERNAME_MISSING') {

--- a/dotcom-rendering/src/components/Discussion/Comments.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comments.stories.tsx
@@ -10,6 +10,11 @@ import { Comments } from './Comments';
 
 export default { component: Comments, title: 'Discussion/App' };
 
+const commentResponseError = {
+	kind: 'error',
+	error: { code: 'NetworkError', message: 'Mocked' },
+} as const;
+
 const aUser: SignedInUser = {
 	profile: {
 		userId: 'abc123',
@@ -25,6 +30,8 @@ const aUser: SignedInUser = {
 			hasCommented: true,
 		},
 	},
+	onComment: () => Promise.resolve(commentResponseError),
+	onReply: () => Promise.resolve(commentResponseError),
 	authStatus: { kind: 'SignedInWithCookies' },
 };
 

--- a/dotcom-rendering/src/components/Discussion/Comments.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comments.tsx
@@ -6,7 +6,7 @@ import {
 	textSans,
 } from '@guardian/source-foundations';
 import { useEffect, useState } from 'react';
-import type { comment, preview, reply } from '../../lib/discussionApi';
+import type { preview } from '../../lib/discussionApi';
 import { getPicks, initialiseApi } from '../../lib/discussionApi';
 import type {
 	AdditionalHeadersType,
@@ -32,8 +32,6 @@ type Props = {
 	onPermalinkClick: (commentId: number) => void;
 	apiKey: string;
 	onRecommend?: (commentId: number) => Promise<boolean>;
-	onComment?: ReturnType<typeof comment>;
-	onReply?: ReturnType<typeof reply>;
 	onPreview?: typeof preview;
 	onExpand: () => void;
 	idApiUrl: string;
@@ -109,8 +107,6 @@ export const Comments = ({
 	onPermalinkClick,
 	apiKey,
 	onRecommend,
-	onComment,
-	onReply,
 	onPreview,
 	onExpand,
 	idApiUrl,
@@ -325,8 +321,6 @@ export const Comments = ({
 					shortUrl={shortUrl}
 					onAddComment={onAddComment}
 					user={user}
-					onComment={onComment}
-					onReply={onReply}
 					onPreview={onPreview}
 					showPreview={showPreview}
 					setShowPreview={setShowPreview}
@@ -389,7 +383,6 @@ export const Comments = ({
 									toggleMuteStatus={toggleMuteStatus}
 									onPermalinkClick={onPermalinkClick}
 									onRecommend={onRecommend}
-									onReply={onReply}
 									showPreview={showPreview}
 									setShowPreview={setShowPreview}
 									isCommentFormActive={isCommentFormActive}
@@ -424,8 +417,6 @@ export const Comments = ({
 					shortUrl={shortUrl}
 					onAddComment={onAddComment}
 					user={user}
-					onComment={onComment}
-					onReply={onReply}
 					onPreview={onPreview}
 					showPreview={showPreview}
 					setShowPreview={setShowPreview}

--- a/dotcom-rendering/src/components/DiscussionContainer.importable.tsx
+++ b/dotcom-rendering/src/components/DiscussionContainer.importable.tsx
@@ -1,5 +1,6 @@
 import { isObject, joinUrl } from '@guardian/libs';
 import { useEffect, useState } from 'react';
+import { comment, reply } from '../lib/discussionApi';
 import type { SignedInWithCookies, SignedInWithOkta } from '../lib/identity';
 import { getOptionsHeadersWithOkta } from '../lib/identity';
 import { useAuthStatus } from '../lib/useAuthStatus';
@@ -26,7 +27,12 @@ const getUser = async ({
 	if (!isObject(data)) return;
 	if (!isObject(data.userProfile)) return;
 	const profile = data.userProfile as unknown as UserProfile;
-	return { profile, authStatus };
+	return {
+		profile,
+		onComment: comment(authStatus),
+		onReply: reply(authStatus),
+		authStatus,
+	};
 };
 
 /**

--- a/dotcom-rendering/src/lib/mockRESTCalls.ts
+++ b/dotcom-rendering/src/lib/mockRESTCalls.ts
@@ -459,19 +459,6 @@ export const mockRESTCalls = (): typeof fetchMock => {
 				},
 				{ overwriteRoutes: false },
 			)
-
-			// Post comment
-			.post(
-				/.*discussion.theguardian.com\/discussion-api\/discussion\/.*/,
-				{
-					status: 200,
-					body: {
-						status: 'ok',
-						message: mockedMessageID,
-					},
-				},
-				{ overwriteRoutes: false },
-			)
 			// Get discussion
 			.get(
 				/.*discussion.theguardian.com\/discussion-api\/discussion\/.*/,

--- a/dotcom-rendering/src/types/discussion.ts
+++ b/dotcom-rendering/src/types/discussion.ts
@@ -16,6 +16,10 @@ import {
 	unknown,
 	variant,
 } from 'valibot';
+import type {
+	comment as onComment,
+	reply as onReply,
+} from '../lib/discussionApi';
 import type { Guard } from '../lib/guard';
 import { guard } from '../lib/guard';
 import type { SignedInWithCookies, SignedInWithOkta } from '../lib/identity';
@@ -287,6 +291,8 @@ export interface FilterOptions {
 
 export type SignedInUser = {
 	profile: UserProfile;
+	onComment: ReturnType<typeof onComment>;
+	onReply: ReturnType<typeof onReply>;
 	authStatus: SignedInWithCookies | SignedInWithOkta;
 };
 


### PR DESCRIPTION
## What does this change?

Refactor Discussion to tie `onComment` & `onReply` to `user`.

## Why?

These methods only make sense when a user is logged in, so they are now attached to the `user: SignedInUser`

## Screenshots

N/A