### PR TITLE
Fix `pick` & `unpick` discussion API response

### DIFF
--- a/dotcom-rendering/src/components/Discussion/Comment.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comment.tsx
@@ -318,9 +318,9 @@ export const Comment = ({
 
 		const response = await pickComment(staffUser.authStatus, comment.id);
 		if (response.kind === 'error') {
-			setError(response.error.message);
+			setError(response.error);
 		} else {
-			setIsHighlighted(true);
+			setIsHighlighted(response.value);
 		}
 	};
 
@@ -328,9 +328,9 @@ export const Comment = ({
 		setError('');
 		const response = await unPickComment(staffUser.authStatus, comment.id);
 		if (response.kind === 'error') {
-			setError(response.error.message);
+			setError(response.error);
 		} else {
-			setIsHighlighted(false);
+			setIsHighlighted(response.value);
 		}
 	};
 

--- a/dotcom-rendering/src/lib/discussionApi.tsx
+++ b/dotcom-rendering/src/lib/discussionApi.tsx
@@ -391,7 +391,7 @@ export const pickComment = async (
 		headers: {
 			'Content-Type': 'application/x-www-form-urlencoded',
 			...options.headers,
-			...(authOptions.headers !== undefined ? authOptions.headers : {}),
+			...authOptions.headers,
 		},
 		credentials: authOptions.credentials,
 	});
@@ -420,8 +420,8 @@ export const unPickComment = async (
 			commentId.toString(),
 			'unhighlight',
 		) + objAsParams(defaultParams);
-	const authOptions = getOptionsHeadersWithOkta(authStatus);
 
+	const authOptions = getOptionsHeadersWithOkta(authStatus);
 	const jsonResult = await fetchJSON(url, {
 		method: 'POST',
 		headers: {

--- a/dotcom-rendering/src/lib/discussionApi.tsx
+++ b/dotcom-rendering/src/lib/discussionApi.tsx
@@ -14,6 +14,7 @@ import {
 	parseAbuseResponse,
 	parseCommentRepliesResponse,
 	parseCommentResponse,
+	pickResponseSchema,
 	postUsernameResponseSchema,
 } from '../types/discussion';
 import type { SignedInWithCookies, SignedInWithOkta } from './identity';
@@ -380,7 +381,7 @@ export const addUserName = async (
 export const pickComment = async (
 	authStatus: SignedInWithCookies | SignedInWithOkta,
 	commentId: number,
-): Promise<CommentResponse> => {
+): Promise<Result<GetDiscussionError, true>> => {
 	const url =
 		joinUrl(options.baseUrl, 'comment', commentId.toString(), 'highlight') +
 		objAsParams(defaultParams);
@@ -396,23 +397,19 @@ export const pickComment = async (
 		credentials: authOptions.credentials,
 	});
 
-	if (jsonResult.kind === 'error') {
-		return {
-			kind: 'error',
-			error: {
-				code: jsonResult.error,
-				message: 'Could not retrieve the comment',
-			},
-		};
-	}
+	if (jsonResult.kind === 'error') return jsonResult;
 
-	return parseCommentResponse(jsonResult.value);
+	const result = safeParse(pickResponseSchema, jsonResult.value);
+
+	if (!result.success) return { kind: 'error', error: 'ParsingError' };
+
+	return { kind: 'ok', value: true };
 };
 
 export const unPickComment = async (
 	authStatus: SignedInWithCookies | SignedInWithOkta,
 	commentId: number,
-): Promise<CommentResponse> => {
+): Promise<Result<GetDiscussionError, false>> => {
 	const url =
 		joinUrl(
 			options.baseUrl,
@@ -432,17 +429,13 @@ export const unPickComment = async (
 		credentials: authOptions.credentials,
 	});
 
-	if (jsonResult.kind === 'error') {
-		return {
-			kind: 'error',
-			error: {
-				code: jsonResult.error,
-				message: 'Could not retrieve the comment',
-			},
-		};
-	}
+	if (jsonResult.kind === 'error') return jsonResult;
 
-	return parseCommentResponse(jsonResult.value);
+	const result = safeParse(pickResponseSchema, jsonResult.value);
+
+	if (!result.success) return { kind: 'error', error: 'ParsingError' };
+
+	return { kind: 'ok', value: false };
 };
 
 export const getMoreResponses = async (

--- a/dotcom-rendering/src/types/discussion.ts
+++ b/dotcom-rendering/src/types/discussion.ts
@@ -363,3 +363,9 @@ export type DropdownOptionType = {
 	disabled?: boolean;
 	isActive?: boolean;
 };
+
+export const pickResponseSchema = object({
+	status: literal('ok'),
+	statusCode: literal(200),
+	message: string(),
+});


### PR DESCRIPTION
## What does this change?

Simply expect a minimal object in the following shape:

```json
{
	"status": "ok",
	"statusCode": 200,
	"message": "… is un/highlighted …"
}
```

Look for the `addHighlight` & `removeHighlight` methods in the `discussion-api` repo for more details.

## Why?

Currently, when moderators pick comments they are shown an error, despite the backend correctly receiving and saving their request. [Link to email thread](https://groups.google.com/a/guardian.co.uk/g/dotcom.platform/c/DENF_NRkBB0/m/uqB-3R0yAAAJ).

## Screenshots

![image](https://github.com/guardian/dotcom-rendering/assets/76776/024a08f3-c339-4b91-a9b7-48c564a28aab)