### PR TITLE
YouTube tests override `youtube-ima` switch to false

### DIFF
--- a/dotcom-rendering/playwright/lib/load-page.ts
+++ b/dotcom-rendering/playwright/lib/load-page.ts
@@ -1,5 +1,5 @@
 import type { Page } from '@playwright/test';
-import type { DCRArticle } from '../../src/types/frontend';
+import type { DCRArticle, FEArticleType } from '../../src/types/frontend';
 
 const PORT = 9000;
 const BASE_URL = `http://localhost:${PORT}`;
@@ -41,7 +41,7 @@ const loadPage = async (
  */
 const loadPageWithOverrides = async (
 	page: Page,
-	article: DCRArticle,
+	article: DCRArticle | FEArticleType,
 	overrides?: {
 		configOverrides?: Record<string, unknown>;
 		switchOverrides?: Record<string, unknown>;
@@ -95,4 +95,32 @@ const loadPageNoOkta = async (
 	});
 };
 
-export { BASE_URL, loadPage, loadPageWithOverrides, loadPageNoOkta };
+/**
+ * Fetch the page json from PROD then load it as a POST with overrides
+ */
+const fetchAndloadPageWithOverrides = async (
+	page: Page,
+	url: string,
+	overrides?: {
+		configOverrides?: Record<string, unknown>;
+		switchOverrides?: Record<string, unknown>;
+	},
+): Promise<void> => {
+	const article = (await fetch(`${url}.json?dcr`).then((res) =>
+		res.json(),
+	)) as FEArticleType;
+	return loadPageWithOverrides(page, article, {
+		configOverrides: overrides?.configOverrides,
+		switchOverrides: {
+			...overrides?.switchOverrides,
+		},
+	});
+};
+
+export {
+	BASE_URL,
+	loadPage,
+	loadPageWithOverrides,
+	loadPageNoOkta,
+	fetchAndloadPageWithOverrides,
+};

--- a/dotcom-rendering/playwright/tests/parallel-5/atom.video.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/parallel-5/atom.video.e2e.spec.ts
@@ -4,7 +4,7 @@ import { expect, test } from '@playwright/test';
 import { expectToBeVisible, expectToNotExist } from 'playwright/lib/locators';
 import { cmpAcceptAll, cmpRejectAll } from '../../lib/cmp';
 import { waitForIsland } from '../../lib/islands';
-import { loadPage } from '../../lib/load-page';
+import { fetchAndloadPageWithOverrides } from '../../lib/load-page';
 
 type YouTubeEmbedConfig = {
 	adsConfig: {
@@ -121,9 +121,10 @@ const muteYouTube = async (page: Page, iframeSelector: string) => {
 
 test.describe('YouTube Atom', () => {
 	test('plays main media video', async ({ page }) => {
-		await loadPage(
+		await fetchAndloadPageWithOverrides(
 			page,
-			'/Article/https://www.theguardian.com/uk-news/2020/dec/04/edinburgh-hit-by-thundersnow-as-sonic-boom-wakes-residents',
+			'https://www.theguardian.com/uk-news/2020/dec/04/edinburgh-hit-by-thundersnow-as-sonic-boom-wakes-residents',
+			{ switchOverrides: { youtubeIma: false } },
 		);
 		await cmpAcceptAll(page);
 
@@ -171,9 +172,10 @@ test.describe('YouTube Atom', () => {
 	});
 
 	test('plays in body video', async ({ page }) => {
-		await loadPage(
+		await fetchAndloadPageWithOverrides(
 			page,
-			'/Article/https://www.theguardian.com/environment/2021/oct/05/volcanoes-are-life-how-the-ocean-is-enriched-by-eruptions-devastating-on-land',
+			'https://www.theguardian.com/environment/2021/oct/05/volcanoes-are-life-how-the-ocean-is-enriched-by-eruptions-devastating-on-land',
+			{ switchOverrides: { youtubeIma: false } },
 		);
 		await cmpAcceptAll(page);
 
@@ -223,9 +225,10 @@ test.describe('YouTube Atom', () => {
 	test('each video plays when the same video exists both in body and in main media of a blog', async ({
 		page,
 	}) => {
-		await loadPage(
+		await fetchAndloadPageWithOverrides(
 			page,
-			'/Article/https://www.theguardian.com/world/live/2022/mar/28/russia-ukraine-war-latest-news-zelenskiy-putin-live-updates?dcr=true',
+			'https://www.theguardian.com/world/live/2022/mar/28/russia-ukraine-war-latest-news-zelenskiy-putin-live-updates',
+			{ switchOverrides: { youtubeIma: false } },
 		);
 		await cmpAcceptAll(page);
 
@@ -327,10 +330,12 @@ test.describe('YouTube Atom', () => {
 	});
 
 	test('plays the video if the reader rejects consent', async ({ page }) => {
-		await loadPage(
+		await fetchAndloadPageWithOverrides(
 			page,
-			'/Article/https://www.theguardian.com/environment/2021/oct/05/volcanoes-are-life-how-the-ocean-is-enriched-by-eruptions-devastating-on-land',
+			'https://www.theguardian.com/environment/2021/oct/05/volcanoes-are-life-how-the-ocean-is-enriched-by-eruptions-devastating-on-land',
+			{ switchOverrides: { youtubeIma: false } },
 		);
+
 		await cmpRejectAll(page);
 
 		await waitForIsland(page, 'YoutubeBlockComponent');
@@ -379,9 +384,10 @@ test.describe('YouTube Atom', () => {
 	test('video is sticky when the user plays a video then scrolls the video out of the viewport', async ({
 		page,
 	}) => {
-		await loadPage(
+		await fetchAndloadPageWithOverrides(
 			page,
-			'/Article/https://www.theguardian.com/world/live/2022/mar/28/russia-ukraine-war-latest-news-zelenskiy-putin-live-updates?dcr=true',
+			'https://www.theguardian.com/world/live/2022/mar/28/russia-ukraine-war-latest-news-zelenskiy-putin-live-updates',
+			{ switchOverrides: { youtubeIma: false } },
 		);
 		await cmpAcceptAll(page);
 


### PR DESCRIPTION
## What does this change?

Set YouTube `atom.video.e2e.spec.ts` tests to override `youtube-ima` switch to false

## Why?

When the switch is true the current `atom.video` tests will fail as the IMA integration will not not load locally on a http scheme. This has been raised with Google but until then we nede to force the switch `youtube-ima` switch to be off when running e2e tests.

This also adds a new Playwright utility `fetchAndloadPageWithOverrides` which will fetch the article json from production and use that to then override the config and switches and perform a POST request to the server.

This is in contrast to the current `loadPage` utils which use fixtures whereas the new method allows the test to load any production article and force overrides.