### PR TITLE
Add new Saturday Edition newsletter to all newsletter apge

### DIFF
--- a/dotcom-rendering/src/model/newsletter-grouping.ts
+++ b/dotcom-rendering/src/model/newsletter-grouping.ts
@@ -12,6 +12,7 @@ export const groups: Partial<Record<EditionId, StaticGroups>> = {
 			title: 'Get started',
 			newsletters: [
 				'morning-briefing', // First Edition
+				'saturday-edition',
 				'word-of-mouth', // Feast
 				'this-is-europe',
 				'the-guide-staying-in',
@@ -107,6 +108,7 @@ export const groups: Partial<Record<EditionId, StaticGroups>> = {
 			title: 'Get started',
 			newsletters: [
 				'us-morning-newsletter', // First Thing
+				'saturday-edition',
 				'today-us', // Headlines US
 				'trump-on-trial',
 				'reclaim-your-brain',
@@ -190,6 +192,7 @@ export const groups: Partial<Record<EditionId, StaticGroups>> = {
 			title: 'International correspondents',
 			newsletters: [
 				'morning-briefing', // First Edition
+				'saturday-edition',
 				'morning-mail',
 				'afternoon-update',
 				'first-dog',
@@ -204,6 +207,7 @@ export const groups: Partial<Record<EditionId, StaticGroups>> = {
 			newsletters: [
 				'morning-mail',
 				'afternoon-update',
+				'saturday-edition',
 				'first-dog',
 				'the-rural-network',
 				'reclaim-your-brain',


### PR DESCRIPTION
## What does this change?

Adds Saturday Edition to the all newsletters page 

## Why?

This newsletter is being launched on Friday

## Screenshots

No change yet, as the newsletter launch is still pending
