### PR TITLE
Age warning should not show on Cotton Capital or Ad Feature articles

### DIFF
--- a/dotcom-rendering/src/lib/age-warning.ts
+++ b/dotcom-rendering/src/lib/age-warning.ts
@@ -16,6 +16,7 @@ export const getAgeWarning = (
 		'info/newsletter-sign-up',
 		'guardian-live-events/guardian-live-events',
 		'news/series/cotton-capital',
+		'tone/advertisement-features',
 	];
 	const showAge = !tags.some(({ id }) => tagsWithoutAgeWarning.includes(id));
 

--- a/dotcom-rendering/src/lib/age-warning.ts
+++ b/dotcom-rendering/src/lib/age-warning.ts
@@ -15,6 +15,7 @@ export const getAgeWarning = (
 		'type/signup',
 		'info/newsletter-sign-up',
 		'guardian-live-events/guardian-live-events',
+		'news/series/cotton-capital',
 	];
 	const showAge = !tags.some(({ id }) => tagsWithoutAgeWarning.includes(id));
 


### PR DESCRIPTION
## What does this change?

Prevents age warning from appearing on Cotton Capital articles
Prevents age warning from appearing on advertisement feature articles

## Why?

Because they are timeless series. 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |
| ![before2][] | ![after2][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/1229808/0769be22-9a7d-4194-9ba2-7ab5bcd52621
[after]: https://github.com/guardian/dotcom-rendering/assets/1229808/17ddbffe-e995-4de4-9528-13a008a1378d
[before2]: https://github.com/guardian/dotcom-rendering/assets/1229808/d737dbc2-a2f7-4a7b-8a28-5c31835b2bfd
[after2]: https://github.com/guardian/dotcom-rendering/assets/1229808/fe5bf3e5-927c-4d63-b7e4-ad5088f0b3bf


