### PR TITLE
Test new Ophan version that enables tracking of clicks on external links

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -58,6 +58,7 @@
 		"@guardian/identity-auth-frontend": "3.0.0",
 		"@guardian/libs": "16.0.1",
 		"@guardian/ophan-tracker-js": "2.0.4",
+		"@guardian/ophan-tracker-js-next": "npm:@guardian/ophan-tracker-js@2.1.0-next.1",
 		"@guardian/shimport": "1.0.2",
 		"@guardian/source-foundations": "14.1.2",
 		"@guardian/source-react-components": "18.0.0",

--- a/dotcom-rendering/scripts/env/check-deps.js
+++ b/dotcom-rendering/scripts/env/check-deps.js
@@ -13,6 +13,7 @@ if (pkg.devDependencies) {
  */
 const exceptions = /** @type {const} */ ([
 	'github:guardian/babel-plugin-px-to-rem#v0.1.0',
+	'npm:@guardian/ophan-tracker-js@2.1.0-next.1',
 ]);
 
 const mismatches = Object.entries(pkg.dependencies)

--- a/dotcom-rendering/scripts/test/build-check.js
+++ b/dotcom-rendering/scripts/test/build-check.js
@@ -29,12 +29,14 @@ const fileExists = async (glob) => {
 	// Check that the manifest files exist
 	await fileExists('manifest.client.web.json');
 	await fileExists('manifest.client.web.legacy.json');
+	await fileExists('manifest.web.ophan-next.json');
 	if (BUILD_VARIANT) await fileExists('manifest.client.web.variant.json');
 
 	// Check that the manifest files return values for all the chunks
 	const manifests = [
 		await loadJsonFile('./dist/manifest.client.web.json'),
 		await loadJsonFile('./dist/manifest.client.web.legacy.json'),
+		await loadJsonFile('./dist/manifest.client.web.ophan-next.json'),
 	];
 	if (BUILD_VARIANT) {
 		manifests.push(

--- a/dotcom-rendering/scripts/test/build-check.js
+++ b/dotcom-rendering/scripts/test/build-check.js
@@ -29,7 +29,7 @@ const fileExists = async (glob) => {
 	// Check that the manifest files exist
 	await fileExists('manifest.client.web.json');
 	await fileExists('manifest.client.web.legacy.json');
-	await fileExists('manifest.web.ophan-next.json');
+	await fileExists('manifest.client.web.ophan-next.json');
 	if (BUILD_VARIANT) await fileExists('manifest.client.web.variant.json');
 
 	// Check that the manifest files return values for all the chunks

--- a/dotcom-rendering/src/client/sentryLoader/sentry.ts
+++ b/dotcom-rendering/src/client/sentryLoader/sentry.ts
@@ -60,7 +60,7 @@ if (
 }
 
 if (window.guardian.config.tests[ophanNextBundle('Variant')] === 'variant') {
-	Sentry.setTag('dcr.bundle', 'ophanEsm');
+	Sentry.setTag('dcr.bundle', 'ophanNext');
 }
 
 export const reportError = (error: Error, feature?: string): void => {

--- a/dotcom-rendering/src/client/sentryLoader/sentry.ts
+++ b/dotcom-rendering/src/client/sentryLoader/sentry.ts
@@ -1,7 +1,11 @@
 import * as Sentry from '@sentry/browser';
 import type { BrowserOptions } from '@sentry/browser';
 import { CaptureConsole } from '@sentry/integrations';
-import { BUILD_VARIANT, dcrJavascriptBundle } from '../../../webpack/bundles';
+import {
+	BUILD_VARIANT,
+	dcrJavascriptBundle,
+	ophanNextBundle,
+} from '../../../webpack/bundles';
 
 const allowUrls: BrowserOptions['allowUrls'] = [
 	/webpack-internal/,
@@ -53,6 +57,10 @@ if (
 	window.guardian.config.tests[dcrJavascriptBundle('Variant')] === 'variant'
 ) {
 	Sentry.setTag('dcr.bundle', dcrJavascriptBundle('Variant'));
+}
+
+if (window.guardian.config.tests[ophanNextBundle('Variant')] === 'variant') {
+	Sentry.setTag('dcr.bundle', 'ophanEsm');
 }
 
 export const reportError = (error: Error, feature?: string): void => {

--- a/dotcom-rendering/src/lib/assets.test.ts
+++ b/dotcom-rendering/src/lib/assets.test.ts
@@ -104,6 +104,14 @@ describe('getModulesBuild', () => {
 		expect(build).toBe('client.web');
 	});
 
+	it('should support Ophan next build when in test', () => {
+		const build = getModulesBuild({
+			tests: { ophanNextVariant: 'variant' },
+			switches: {},
+		});
+		expect(build).toBe('client.web.ophan-next');
+	});
+
 	it('should support variant build when in test, if enabled', () => {
 		const build = getModulesBuild({
 			tests: { dcrJavascriptBundleVariant: 'variant' },

--- a/dotcom-rendering/src/lib/assets.ts
+++ b/dotcom-rendering/src/lib/assets.ts
@@ -1,7 +1,11 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { isObject, isString } from '@guardian/libs';
-import { BUILD_VARIANT, dcrJavascriptBundle } from '../../webpack/bundles';
+import {
+	BUILD_VARIANT,
+	dcrJavascriptBundle,
+	ophanNextBundle,
+} from '../../webpack/bundles';
 import type { ServerSideTests, Switches } from '../types/config';
 import { makeMemoizedFunction } from './memoize';
 
@@ -57,6 +61,7 @@ export type Build =
 	| 'client.apps'
 	| 'client.web'
 	| 'client.web.variant'
+	| 'client.web.ophan-next'
 	| 'client.web.legacy';
 
 type ManifestPath = `./manifest.${Build}.json`;
@@ -130,6 +135,9 @@ export const getModulesBuild = ({
 }): Exclude<Extract<Build, `client.web${string}`>, 'client.web.legacy'> => {
 	if (BUILD_VARIANT && tests[dcrJavascriptBundle('Variant')] === 'variant') {
 		return 'client.web.variant';
+	}
+	if (tests[ophanNextBundle('Variant')] === 'variant') {
+		return 'client.web.ophan-next';
 	}
 	return 'client.web';
 };

--- a/dotcom-rendering/webpack/bundles.js
+++ b/dotcom-rendering/webpack/bundles.js
@@ -23,7 +23,11 @@ const BUILD_VARIANT = false;
  */
 const dcrJavascriptBundle = (variant) => `dcrJavascriptBundle${variant}`;
 
+/** @type {(variant: 'Variant' | 'Control') => import("../../src/types/config").ServerSideTestNames} */
+const ophanNextBundle = (variant) => `ophanNext${variant}`;
+
 module.exports = {
 	BUILD_VARIANT,
 	dcrJavascriptBundle,
+	ophanNextBundle,
 };

--- a/dotcom-rendering/webpack/bundles.js
+++ b/dotcom-rendering/webpack/bundles.js
@@ -23,7 +23,7 @@ const BUILD_VARIANT = false;
  */
 const dcrJavascriptBundle = (variant) => `dcrJavascriptBundle${variant}`;
 
-/** @type {(variant: 'Variant' | 'Control') => import("../../src/types/config").ServerSideTestNames} */
+/** @type {(variant: 'Variant' | 'Control') => import("../src/types/config").ServerSideTestNames} */
 const ophanNextBundle = (variant) => `ophanNext${variant}`;
 
 module.exports = {

--- a/dotcom-rendering/webpack/webpack.config.client.js
+++ b/dotcom-rendering/webpack/webpack.config.client.js
@@ -81,6 +81,7 @@ const getLoaders = (build) => {
 		case 'client.apps':
 			return swcLoader(['android >= 5', 'ios >= 12']);
 		case 'client.web.variant':
+		case 'client.web.ophan-next':
 		case 'client.web':
 			return swcLoader(getBrowserTargets());
 	}
@@ -98,7 +99,7 @@ module.exports = ({ build }) => ({
 	resolve: {
 		alias: {
 			'ophan-tracker-js':
-				build === 'web.variant'
+				build === 'client.web.ophan-next'
 					? '@guardian/ophan-tracker-js'
 					: 'ophan-tracker-js',
 		},

--- a/dotcom-rendering/webpack/webpack.config.client.js
+++ b/dotcom-rendering/webpack/webpack.config.client.js
@@ -95,6 +95,14 @@ module.exports = ({ build }) => ({
 		index: getEntryIndex(build),
 		debug: './src/client/debug/debug.ts',
 	},
+	resolve: {
+		alias: {
+			'ophan-tracker-js':
+				build === 'web.variant'
+					? '@guardian/ophan-tracker-js'
+					: 'ophan-tracker-js',
+		},
+	},
 	optimization:
 		// We don't need chunk optimization for apps as we use the 'LimitChunkCountPlugin' to produce just 1 chunk
 		build === 'client.apps'

--- a/dotcom-rendering/webpack/webpack.config.client.js
+++ b/dotcom-rendering/webpack/webpack.config.client.js
@@ -98,10 +98,10 @@ module.exports = ({ build }) => ({
 	},
 	resolve: {
 		alias: {
-			'ophan-tracker-js':
+			'@guardian/ophan-tracker-js':
 				build === 'client.web.ophan-next'
-					? '@guardian/ophan-tracker-js'
-					: 'ophan-tracker-js',
+					? '@guardian/ophan-tracker-js-next'
+					: '@guardian/ophan-tracker-js',
 		},
 	},
 	optimization:

--- a/dotcom-rendering/webpack/webpack.config.js
+++ b/dotcom-rendering/webpack/webpack.config.js
@@ -108,6 +108,7 @@ const commonConfigs = ({ platform }) => ({
 /** @type {readonly Build[]} */
 const clientBuilds = [
 	'client.web',
+	'client.web.ophan-next',
 	...((PROD && BUILD_VARIANT_SWITCH) || BUILD_VARIANT
 		? /** @type {const} */ (['client.web.variant'])
 		: []),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -386,6 +386,9 @@ importers:
       '@guardian/ophan-tracker-js':
         specifier: 2.0.4
         version: 2.0.4
+      '@guardian/ophan-tracker-js-next':
+        specifier: npm:@guardian/ophan-tracker-js@2.1.0-next.1
+        version: /@guardian/ophan-tracker-js@2.1.0-next.1
       '@guardian/shimport':
         specifier: 1.0.2
         version: 1.0.2
@@ -4764,6 +4767,11 @@ packages:
 
   /@guardian/ophan-tracker-js@2.0.4:
     resolution: {integrity: sha512-kwUNUSfnL8SQwzTlVzInYh7a6VSMFy3zEq2A6Hm7cmKSbl8D7ed03y7ANqquViFuPffRZRQ0IrkJHSbMnsRmrA==}
+    engines: {node: '>=16'}
+    dev: false
+
+  /@guardian/ophan-tracker-js@2.1.0-next.1:
+    resolution: {integrity: sha512-Qa2PMhXcGgqTcJtKo5MF0YDbjVl9ivxic7WC6PkxmEkt8h406W8OIxVhSg10RLEZYTIkYg8CRYDqJTdw2vM+Kg==}
     engines: {node: '>=16'}
     dev: false
 


### PR DESCRIPTION
## What does this change?

This adds a seperate client-side bundle loading a beta version of Ophan that enables tracking clicks on external links, to be tested with 1% of the audience.

## Why?

This is relevant for tracking interactions with things like partner logos on Labs containers, to give us greater insight into their performance.
