### PR TITLE
Add `userNameMissing` `CommentForm` state to the `Discussion` reducer

### DIFF
--- a/dotcom-rendering/src/components/Discussion.tsx
+++ b/dotcom-rendering/src/components/Discussion.tsx
@@ -12,6 +12,7 @@ import {
 import { useCommentCount } from '../lib/useCommentCount';
 import { palette as themePalette } from '../palette';
 import type {
+	CommentForm,
 	CommentType,
 	FilterOptions,
 	SignedInUser,
@@ -99,9 +100,14 @@ type State = {
 	hashCommentId: number | undefined;
 	totalPages: number;
 	loading: boolean;
-	topForm: { isActive: boolean };
-	replyForm: { isActive: boolean };
-	bottomForm: { isActive: boolean };
+	topForm: CommentForm;
+	replyForm: CommentForm;
+	bottomForm: CommentForm;
+};
+
+const initialCommentFormState = {
+	isActive: false,
+	userNameMissing: false,
 };
 
 const initialState: State = {
@@ -113,9 +119,9 @@ const initialState: State = {
 	hashCommentId: undefined,
 	totalPages: 0,
 	loading: true,
-	topForm: { isActive: false },
-	replyForm: { isActive: false },
-	bottomForm: { isActive: false },
+	topForm: initialCommentFormState,
+	replyForm: initialCommentFormState,
+	bottomForm: initialCommentFormState,
 };
 
 type Action =
@@ -133,7 +139,10 @@ type Action =
 	| { type: 'setLoading'; loading: boolean }
 	| { type: 'setTopFormActive'; isActive: boolean }
 	| { type: 'setReplyFormActive'; isActive: boolean }
-	| { type: 'setBottomFormActive'; isActive: boolean };
+	| { type: 'setBottomFormActive'; isActive: boolean }
+	| { type: 'setTopFormUserMissing'; userNameMissing: boolean }
+	| { type: 'setReplyFormUserMissing'; userNameMissing: boolean }
+	| { type: 'setBottomFormUserMissing'; userNameMissing: boolean };
 
 const reducer = (state: State, action: Action): State => {
 	switch (action.type) {
@@ -186,19 +195,46 @@ const reducer = (state: State, action: Action): State => {
 		case 'setTopFormActive': {
 			return {
 				...state,
-				topForm: { isActive: action.isActive },
+				topForm: { ...state.topForm, isActive: action.isActive },
 			};
 		}
 		case 'setReplyFormActive': {
 			return {
 				...state,
-				replyForm: { isActive: action.isActive },
+				replyForm: { ...state.replyForm, isActive: action.isActive },
 			};
 		}
 		case 'setBottomFormActive': {
 			return {
 				...state,
-				bottomForm: { isActive: action.isActive },
+				bottomForm: { ...state.bottomForm, isActive: action.isActive },
+			};
+		}
+		case 'setTopFormUserMissing': {
+			return {
+				...state,
+				topForm: {
+					...state.topForm,
+					userNameMissing: action.userNameMissing,
+				},
+			};
+		}
+		case 'setReplyFormUserMissing': {
+			return {
+				...state,
+				replyForm: {
+					...state.replyForm,
+					userNameMissing: action.userNameMissing,
+				},
+			};
+		}
+		case 'setBottomFormUserMissing': {
+			return {
+				...state,
+				bottomForm: {
+					...state.bottomForm,
+					userNameMissing: action.userNameMissing,
+				},
 			};
 		}
 
@@ -389,9 +425,27 @@ export const Discussion = ({
 					setBottomFormActive={(isActive) =>
 						dispatch({ type: 'setBottomFormActive', isActive })
 					}
-					isTopFormActive={topForm.isActive}
-					isReplyFormActive={replyForm.isActive}
-					isBottomFormActive={bottomForm.isActive}
+					setTopFormUserMissing={(userNameMissing) =>
+						dispatch({
+							type: 'setTopFormUserMissing',
+							userNameMissing,
+						})
+					}
+					setReplyFormUserMissing={(userNameMissing) =>
+						dispatch({
+							type: 'setReplyFormUserMissing',
+							userNameMissing,
+						})
+					}
+					setBottomFormUserMissing={(userNameMissing) =>
+						dispatch({
+							type: 'setBottomFormUserMissing',
+							userNameMissing,
+						})
+					}
+					topForm={topForm}
+					replyForm={replyForm}
+					bottomForm={bottomForm}
 				/>
 				{!isExpanded && (
 					<div id="discussion-overlay" css={overlayStyles} />

--- a/dotcom-rendering/src/components/Discussion/Comments.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comments.stories.tsx
@@ -48,6 +48,8 @@ const filters: FilterOptions = {
 	orderBy: 'newest',
 };
 
+const defaultCommentForm = { isActive: false, userNameMissing: false };
+
 export const LoggedOutHiddenPicks = () => (
 	<div
 		css={css`
@@ -79,9 +81,12 @@ export const LoggedOutHiddenPicks = () => (
 			setTopFormActive={() => {}}
 			setReplyFormActive={() => {}}
 			setBottomFormActive={() => {}}
-			isTopFormActive={false}
-			isReplyFormActive={false}
-			isBottomFormActive={false}
+			setTopFormUserMissing={() => {}}
+			setReplyFormUserMissing={() => {}}
+			setBottomFormUserMissing={() => {}}
+			topForm={defaultCommentForm}
+			replyForm={defaultCommentForm}
+			bottomForm={defaultCommentForm}
 		/>
 	</div>
 );
@@ -126,9 +131,12 @@ export const InitialPage = () => (
 			setTopFormActive={() => {}}
 			setReplyFormActive={() => {}}
 			setBottomFormActive={() => {}}
-			isTopFormActive={false}
-			isReplyFormActive={false}
-			isBottomFormActive={false}
+			setTopFormUserMissing={() => {}}
+			setReplyFormUserMissing={() => {}}
+			setBottomFormUserMissing={() => {}}
+			topForm={defaultCommentForm}
+			replyForm={defaultCommentForm}
+			bottomForm={defaultCommentForm}
 		/>
 	</div>
 );
@@ -177,9 +185,12 @@ export const LoggedInHiddenNoPicks = () => {
 				setTopFormActive={() => {}}
 				setReplyFormActive={setActive}
 				setBottomFormActive={() => {}}
-				isTopFormActive={false}
-				isReplyFormActive={isActive}
-				isBottomFormActive={false}
+				setTopFormUserMissing={() => {}}
+				setReplyFormUserMissing={() => {}}
+				setBottomFormUserMissing={() => {}}
+				topForm={defaultCommentForm}
+				replyForm={{ ...defaultCommentForm, isActive }}
+				bottomForm={defaultCommentForm}
 			/>
 		</div>
 	);
@@ -224,9 +235,18 @@ export const LoggedIn = () => {
 				setTopFormActive={() => {}}
 				setReplyFormActive={setReplyFormActive}
 				setBottomFormActive={setBottomFormActive}
-				isTopFormActive={false}
-				isReplyFormActive={isReplyFormActive}
-				isBottomFormActive={isBottomFormActive}
+				setTopFormUserMissing={() => {}}
+				setReplyFormUserMissing={() => {}}
+				setBottomFormUserMissing={() => {}}
+				topForm={defaultCommentForm}
+				replyForm={{
+					...defaultCommentForm,
+					isActive: isReplyFormActive,
+				}}
+				bottomForm={{
+					...defaultCommentForm,
+					isActive: isBottomFormActive,
+				}}
 			/>
 		</div>
 	);
@@ -270,9 +290,15 @@ export const LoggedInShortDiscussion = () => {
 				setTopFormActive={setTopFormActive}
 				setReplyFormActive={setReplyFormActive}
 				setBottomFormActive={() => {}}
-				isTopFormActive={isTopFormActive}
-				isReplyFormActive={isReplyFormActive}
-				isBottomFormActive={false}
+				setTopFormUserMissing={() => {}}
+				setReplyFormUserMissing={() => {}}
+				setBottomFormUserMissing={() => {}}
+				topForm={{ ...defaultCommentForm, isActive: isTopFormActive }}
+				replyForm={{
+					...defaultCommentForm,
+					isActive: isReplyFormActive,
+				}}
+				bottomForm={defaultCommentForm}
 			/>
 		</div>
 	);
@@ -310,9 +336,12 @@ export const LoggedOutHiddenNoPicks = () => (
 			setTopFormActive={() => {}}
 			setReplyFormActive={() => {}}
 			setBottomFormActive={() => {}}
-			isTopFormActive={false}
-			isReplyFormActive={false}
-			isBottomFormActive={false}
+			setTopFormUserMissing={() => {}}
+			setReplyFormUserMissing={() => {}}
+			setBottomFormUserMissing={() => {}}
+			topForm={defaultCommentForm}
+			replyForm={defaultCommentForm}
+			bottomForm={defaultCommentForm}
 		/>
 	</div>
 );
@@ -359,9 +388,12 @@ export const Closed = () => (
 			setTopFormActive={() => {}}
 			setReplyFormActive={() => {}}
 			setBottomFormActive={() => {}}
-			isTopFormActive={false}
-			isReplyFormActive={false}
-			isBottomFormActive={false}
+			setTopFormUserMissing={() => {}}
+			setReplyFormUserMissing={() => {}}
+			setBottomFormUserMissing={() => {}}
+			topForm={defaultCommentForm}
+			replyForm={defaultCommentForm}
+			bottomForm={defaultCommentForm}
 		/>
 	</div>
 );
@@ -406,9 +438,12 @@ export const NoComments = () => (
 			setTopFormActive={() => {}}
 			setReplyFormActive={() => {}}
 			setBottomFormActive={() => {}}
-			isTopFormActive={false}
-			isReplyFormActive={false}
-			isBottomFormActive={false}
+			setTopFormUserMissing={() => {}}
+			setReplyFormUserMissing={() => {}}
+			setBottomFormUserMissing={() => {}}
+			topForm={defaultCommentForm}
+			replyForm={defaultCommentForm}
+			bottomForm={defaultCommentForm}
 		/>
 	</div>
 );
@@ -455,9 +490,12 @@ export const LegacyDiscussion = () => (
 			setTopFormActive={() => {}}
 			setReplyFormActive={() => {}}
 			setBottomFormActive={() => {}}
-			isTopFormActive={false}
-			isReplyFormActive={false}
-			isBottomFormActive={false}
+			setTopFormUserMissing={() => {}}
+			setReplyFormUserMissing={() => {}}
+			setBottomFormUserMissing={() => {}}
+			topForm={defaultCommentForm}
+			replyForm={defaultCommentForm}
+			bottomForm={defaultCommentForm}
 		/>
 	</div>
 );

--- a/dotcom-rendering/src/components/Discussion/Comments.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comments.tsx
@@ -12,6 +12,7 @@ import type {
 	AdditionalHeadersType,
 	CommentType,
 	FilterOptions,
+	CommentForm as Form,
 	SignedInUser,
 } from '../../types/discussion';
 import { CommentContainer } from './CommentContainer';
@@ -46,9 +47,12 @@ type Props = {
 	setTopFormActive: (isActive: boolean) => void;
 	setReplyFormActive: (isActive: boolean) => void;
 	setBottomFormActive: (isActive: boolean) => void;
-	isTopFormActive: boolean;
-	isReplyFormActive: boolean;
-	isBottomFormActive: boolean;
+	setTopFormUserMissing: (isUserMissing: boolean) => void;
+	setReplyFormUserMissing: (isUserMissing: boolean) => void;
+	setBottomFormUserMissing: (isUserMissing: boolean) => void;
+	topForm: Form;
+	replyForm: Form;
+	bottomForm: Form;
 };
 
 const footerStyles = css`
@@ -126,9 +130,12 @@ export const Comments = ({
 	setTopFormActive,
 	setReplyFormActive,
 	setBottomFormActive,
-	isTopFormActive,
-	isReplyFormActive,
-	isBottomFormActive,
+	setTopFormUserMissing,
+	setReplyFormUserMissing,
+	setBottomFormUserMissing,
+	topForm,
+	replyForm,
+	bottomForm,
 }: Props) => {
 	const [picks, setPicks] = useState<CommentType[]>([]);
 	const [commentBeingRepliedTo, setCommentBeingRepliedTo] =
@@ -137,7 +144,6 @@ export const Comments = ({
 	const [mutes, setMutes] = useState<string[]>(readMutes());
 	const [showPreview, setShowPreview] = useState<boolean>(false);
 	const [error, setError] = useState<string>('');
-	const [userNameMissing, setUserNameMissing] = useState<boolean>(false);
 	const [previewBody, setPreviewBody] = useState<string>('');
 
 	const loadingMore = !loading && comments.length !== numberOfCommentsToShow;
@@ -291,16 +297,18 @@ export const Comments = ({
 											showPreview={showPreview}
 											setShowPreview={setShowPreview}
 											isCommentFormActive={
-												isReplyFormActive
+												replyForm.isActive
 											}
 											setIsCommentFormActive={
 												setReplyFormActive
 											}
 											error={error}
 											setError={setError}
-											userNameMissing={userNameMissing}
+											userNameMissing={
+												replyForm.userNameMissing
+											}
 											setUserNameMissing={
-												setUserNameMissing
+												setReplyFormUserMissing
 											}
 											previewBody={previewBody}
 											setPreviewBody={setPreviewBody}
@@ -325,12 +333,12 @@ export const Comments = ({
 					onPreview={onPreview}
 					showPreview={showPreview}
 					setShowPreview={setShowPreview}
-					isActive={isTopFormActive}
+					isActive={topForm.isActive}
 					setIsActive={setTopFormActive}
 					error={error}
 					setError={setError}
-					userNameMissing={userNameMissing}
-					setUserNameMissing={setUserNameMissing}
+					userNameMissing={topForm.userNameMissing}
+					setUserNameMissing={setTopFormUserMissing}
 					previewBody={previewBody}
 					setPreviewBody={setPreviewBody}
 				/>
@@ -386,12 +394,12 @@ export const Comments = ({
 									onRecommend={onRecommend}
 									showPreview={showPreview}
 									setShowPreview={setShowPreview}
-									isCommentFormActive={isReplyFormActive}
+									isCommentFormActive={replyForm.isActive}
 									setIsCommentFormActive={setReplyFormActive}
 									error={error}
 									setError={setError}
-									userNameMissing={userNameMissing}
-									setUserNameMissing={setUserNameMissing}
+									userNameMissing={replyForm.userNameMissing}
+									setUserNameMissing={setReplyFormUserMissing}
 									previewBody={previewBody}
 									setPreviewBody={setPreviewBody}
 								/>
@@ -419,12 +427,12 @@ export const Comments = ({
 					onPreview={onPreview}
 					showPreview={showPreview}
 					setShowPreview={setShowPreview}
-					isActive={isBottomFormActive}
+					isActive={bottomForm.isActive}
 					setIsActive={setBottomFormActive}
 					error={error}
 					setError={setError}
-					userNameMissing={userNameMissing}
-					setUserNameMissing={setUserNameMissing}
+					userNameMissing={bottomForm.userNameMissing}
+					setUserNameMissing={setBottomFormUserMissing}
 					previewBody={previewBody}
 					setPreviewBody={setPreviewBody}
 				/>

--- a/dotcom-rendering/src/types/discussion.ts
+++ b/dotcom-rendering/src/types/discussion.ts
@@ -375,3 +375,8 @@ export const pickResponseSchema = object({
 	statusCode: literal(200),
 	message: string(),
 });
+
+export type CommentForm = {
+	isActive: boolean;
+	userNameMissing: boolean;
+};


### PR DESCRIPTION
Closes #10430 

## What does this change?
Adds `userNameMissing` state to the `Discussion` reducer.

## Why?
* All state will be lifted in the reducer eventually
* We want each form to have its own state

## Testing
In CODE

https://github.com/guardian/dotcom-rendering/assets/19683595/38b57046-d4c1-44e2-883a-2c9033d29b11

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
