### PR TITLE
Refactor Discussion’s `onRecommend` to be part of the `user` prop

### DIFF
--- a/dotcom-rendering/src/components/Discussion/Comment.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comment.stories.tsx
@@ -126,6 +126,7 @@ const user: SignedInUser = {
 	},
 	onComment: () => Promise.resolve(commentResponseError),
 	onReply: () => Promise.resolve(commentResponseError),
+	onRecommend: () => Promise.resolve(true),
 	authStatus: { kind: 'SignedInWithCookies' },
 };
 
@@ -146,6 +147,7 @@ const staffUser: SignedInUser = {
 	},
 	onComment: () => Promise.resolve(commentResponseError),
 	onReply: () => Promise.resolve(commentResponseError),
+	onRecommend: () => Promise.resolve(true),
 	authStatus: { kind: 'SignedInWithCookies' },
 };
 

--- a/dotcom-rendering/src/components/Discussion/Comment.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comment.tsx
@@ -31,7 +31,6 @@ type Props = {
 	isMuted: boolean;
 	toggleMuteStatus: (userId: string) => void;
 	onPermalinkClick: (commentId: number) => void;
-	onRecommend?: (commentId: number) => Promise<boolean>;
 	error: string;
 	setError: (error: string) => void;
 };
@@ -302,7 +301,6 @@ export const Comment = ({
 	isMuted,
 	toggleMuteStatus,
 	onPermalinkClick,
-	onRecommend,
 	error,
 	setError,
 }: Props) => {
@@ -529,12 +527,10 @@ export const Comment = ({
 								commentId={comment.id}
 								initialCount={comment.numRecommends}
 								alreadyRecommended={false}
-								authStatus={user?.authStatus}
-								onRecommend={onRecommend}
+								user={user}
 								userMadeComment={
-									!!user &&
-									user.profile.userId ===
-										comment.userProfile.userId
+									user?.profile.userId ===
+									comment.userProfile.userId
 								}
 							/>
 						)}

--- a/dotcom-rendering/src/components/Discussion/CommentContainer.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentContainer.stories.tsx
@@ -155,6 +155,7 @@ const aUser: SignedInUser = {
 	},
 	onComment: () => Promise.resolve(commentResponseError),
 	onReply: () => Promise.resolve(commentResponseError),
+	onRecommend: () => Promise.resolve(true),
 	authStatus: { kind: 'SignedInWithCookies' },
 };
 

--- a/dotcom-rendering/src/components/Discussion/CommentContainer.test.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentContainer.test.tsx
@@ -47,6 +47,7 @@ const aUser: SignedInUser = {
 	},
 	onComment: () => Promise.resolve(commentResponseError),
 	onReply: () => Promise.resolve(commentResponseSuccess),
+	onRecommend: () => Promise.resolve(true),
 	authStatus: { kind: 'SignedInWithCookies' },
 };
 

--- a/dotcom-rendering/src/components/Discussion/CommentContainer.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentContainer.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/react';
 import { palette as sourcePalette, space } from '@guardian/source-foundations';
 import { SvgPlus } from '@guardian/source-react-components';
 import { useEffect, useState } from 'react';
-import type { comment, preview, reply } from '../../lib/discussionApi';
+import type { preview } from '../../lib/discussionApi';
 import { getMoreResponses } from '../../lib/discussionApi';
 import type {
 	CommentType,
@@ -26,9 +26,6 @@ type Props = {
 	mutes: string[];
 	toggleMuteStatus: (userId: string) => void;
 	onPermalinkClick: (commentId: number) => void;
-	onRecommend?: (commentId: number) => Promise<boolean>;
-	onComment?: ReturnType<typeof comment>;
-	onReply?: ReturnType<typeof reply>;
 	onPreview?: typeof preview;
 	showPreview: boolean;
 	setShowPreview: (showPreview: boolean) => void;
@@ -87,9 +84,6 @@ export const CommentContainer = ({
 	mutes,
 	toggleMuteStatus,
 	onPermalinkClick,
-	onRecommend,
-	onComment,
-	onReply,
 	onPreview,
 	showPreview,
 	setShowPreview,
@@ -153,7 +147,6 @@ export const CommentContainer = ({
 				isMuted={mutes.includes(comment.userProfile.userId)}
 				toggleMuteStatus={toggleMuteStatus}
 				onPermalinkClick={onPermalinkClick}
-				onRecommend={onRecommend}
 				error={error}
 				setError={setError}
 			/>

--- a/dotcom-rendering/src/components/Discussion/CommentForm.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentForm.stories.tsx
@@ -36,6 +36,7 @@ const aUser: SignedInUser = {
 	},
 	onComment: () => Promise.resolve(commentResponseError),
 	onReply: () => Promise.resolve(commentResponseError),
+	onRecommend: () => Promise.resolve(true),
 	authStatus: { kind: 'SignedInWithCookies' },
 };
 

--- a/dotcom-rendering/src/components/Discussion/Comments.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comments.stories.tsx
@@ -33,6 +33,7 @@ const aUser: SignedInUser = {
 	},
 	onComment: () => Promise.resolve(commentResponseError),
 	onReply: () => Promise.resolve(commentResponseError),
+	onRecommend: () => Promise.resolve(true),
 	authStatus: { kind: 'SignedInWithCookies' },
 };
 

--- a/dotcom-rendering/src/components/Discussion/Comments.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comments.tsx
@@ -243,9 +243,8 @@ export const Comments = ({
 					<div css={picksWrapper}>
 						<TopPicks
 							comments={picks.slice(0, 2)}
-							authStatus={user?.authStatus}
+							user={user}
 							onPermalinkClick={onPermalinkClick}
-							onRecommend={onRecommend}
 						/>
 					</div>
 				) : (
@@ -287,7 +286,6 @@ export const Comments = ({
 											mutes={mutes}
 											toggleMuteStatus={toggleMuteStatus}
 											onPermalinkClick={onPermalinkClick}
-											onRecommend={onRecommend}
 											showPreview={showPreview}
 											setShowPreview={setShowPreview}
 											isCommentFormActive={
@@ -338,9 +336,8 @@ export const Comments = ({
 			{!!picks.length && (
 				<TopPicks
 					comments={picks}
-					authStatus={user?.authStatus}
+					user={user}
 					onPermalinkClick={onPermalinkClick}
-					onRecommend={onRecommend}
 				/>
 			)}
 			<Filters
@@ -383,7 +380,6 @@ export const Comments = ({
 									mutes={mutes}
 									toggleMuteStatus={toggleMuteStatus}
 									onPermalinkClick={onPermalinkClick}
-									onRecommend={onRecommend}
 									showPreview={showPreview}
 									setShowPreview={setShowPreview}
 									isCommentFormActive={isReplyFormActive}

--- a/dotcom-rendering/src/components/Discussion/RecommendationCount.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/RecommendationCount.stories.tsx
@@ -1,12 +1,36 @@
 import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
 import { splitTheme } from '../../../.storybook/decorators/splitThemeDecorator';
-import type { SignedInWithCookies } from '../../lib/identity';
 import { palette as themePalette } from '../../palette';
+import type { SignedInUser } from '../../types/discussion';
 import { RecommendationCount } from './RecommendationCount';
 
 export default { title: 'Discussion/RecommendationCount' };
 
-const signedInStatus: SignedInWithCookies = { kind: 'SignedInWithCookies' };
+const commentResponseError = {
+	kind: 'error',
+	error: { code: 'NetworkError', message: 'Mocked' },
+} as const;
+
+const aUser = {
+	profile: {
+		userId: 'abc123',
+		displayName: 'Jane Smith',
+		webUrl: '',
+		apiUrl: '',
+		avatar: '',
+		secureAvatarUrl: '',
+		badge: [],
+		privateFields: {
+			canPostComment: true,
+			isPremoderated: false,
+			hasCommented: true,
+		},
+	},
+	onComment: () => Promise.resolve(commentResponseError),
+	onReply: () => Promise.resolve(commentResponseError),
+	onRecommend: () => Promise.resolve(true),
+	authStatus: { kind: 'SignedInWithCookies' },
+} satisfies SignedInUser;
 
 const Wrapper = ({ children }: { children: React.ReactNode }) => (
 	<div
@@ -31,7 +55,7 @@ export const NeverRecommended = () => (
 			commentId={123}
 			initialCount={383}
 			alreadyRecommended={false}
-			authStatus={signedInStatus}
+			user={aUser}
 			userMadeComment={false}
 		/>
 	</Wrapper>
@@ -44,7 +68,7 @@ export const AlreadyRecommended = () => (
 			commentId={123}
 			initialCount={83}
 			alreadyRecommended={true}
-			authStatus={signedInStatus}
+			user={aUser}
 			userMadeComment={false}
 		/>
 	</Wrapper>
@@ -69,7 +93,7 @@ export const OwnPost = () => (
 			commentId={123}
 			initialCount={83}
 			alreadyRecommended={false}
-			authStatus={signedInStatus}
+			user={aUser}
 			userMadeComment={true}
 		/>
 	</Wrapper>

--- a/dotcom-rendering/src/components/Discussion/TopPick.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/TopPick.stories.tsx
@@ -1,8 +1,7 @@
 import { css } from '@emotion/react';
 import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
 import { splitTheme } from '../../../.storybook/decorators/splitThemeDecorator';
-import type { SignedInWithCookies } from '../../lib/identity';
-import type { CommentType } from '../../types/discussion';
+import type { CommentType, SignedInUser } from '../../types/discussion';
 import { TopPick } from './TopPick';
 
 export default { component: TopPick, title: 'Discussion/TopPick' };
@@ -78,7 +77,31 @@ const contributorCommentWithShortBody: CommentType = {
 	body: "<p>It's still there FrankDeFord - and thanks, I will pass that on</p>",
 };
 
-const signedInStatus: SignedInWithCookies = { kind: 'SignedInWithCookies' };
+const commentResponseError = {
+	kind: 'error',
+	error: { code: 'NetworkError', message: 'Mocked' },
+} as const;
+
+const aUser = {
+	profile: {
+		userId: 'abc123',
+		displayName: 'Jane Smith',
+		webUrl: '',
+		apiUrl: '',
+		avatar: '',
+		secureAvatarUrl: '',
+		badge: [],
+		privateFields: {
+			canPostComment: true,
+			isPremoderated: false,
+			hasCommented: true,
+		},
+	},
+	onComment: () => Promise.resolve(commentResponseError),
+	onReply: () => Promise.resolve(commentResponseError),
+	onRecommend: () => Promise.resolve(true),
+	authStatus: { kind: 'SignedInWithCookies' },
+} satisfies SignedInUser;
 
 export const LongPick = () => (
 	<div
@@ -106,7 +129,7 @@ export const ShortPick = () => (
 	>
 		<TopPick
 			comment={commentWithShortBody}
-			authStatus={signedInStatus}
+			user={aUser}
 			userMadeComment={false}
 			onPermalinkClick={() => {}}
 		/>
@@ -148,7 +171,7 @@ export const ShortPickContributor = () => (
 	>
 		<TopPick
 			comment={contributorCommentWithShortBody}
-			authStatus={signedInStatus}
+			user={aUser}
 			userMadeComment={false}
 			onPermalinkClick={() => {}}
 		/>

--- a/dotcom-rendering/src/components/Discussion/TopPick.tsx
+++ b/dotcom-rendering/src/components/Discussion/TopPick.tsx
@@ -6,9 +6,8 @@ import {
 	textSans,
 } from '@guardian/source-foundations';
 import { Link } from '@guardian/source-react-components';
-import type { SignedInWithCookies, SignedInWithOkta } from '../../lib/identity';
 import { palette as themePalette } from '../../palette';
-import type { CommentType } from '../../types/discussion';
+import type { CommentType, SignedInUser } from '../../types/discussion';
 import { Avatar } from './Avatar';
 import { GuardianContributor, GuardianStaff } from './Badges';
 import { Column } from './Column';
@@ -18,10 +17,9 @@ import { Timestamp } from './Timestamp';
 
 type Props = {
 	comment: CommentType;
-	authStatus?: SignedInWithCookies | SignedInWithOkta;
 	userMadeComment: boolean;
 	onPermalinkClick: (commentId: number) => void;
-	onRecommend?: (commentId: number) => Promise<boolean>;
+	user?: SignedInUser;
 };
 
 const pickStyles = css`
@@ -168,10 +166,9 @@ const truncateText = (input: string, limit: number) => {
 
 export const TopPick = ({
 	comment,
-	authStatus,
+	user,
 	userMadeComment,
 	onPermalinkClick,
-	onRecommend,
 }: Props) => {
 	const showStaffBadge = comment.userProfile.badge.some(
 		(obj) => obj['name'] === 'Staff',
@@ -247,9 +244,8 @@ export const TopPick = ({
 					commentId={comment.id}
 					initialCount={comment.numRecommends}
 					alreadyRecommended={false}
-					authStatus={authStatus}
+					user={user}
 					userMadeComment={userMadeComment}
-					onRecommend={onRecommend}
 				/>
 			</PickMeta>
 		</div>

--- a/dotcom-rendering/src/components/Discussion/TopPicks.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/TopPicks.stories.tsx
@@ -1,7 +1,6 @@
 import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
 import { splitTheme } from '../../../.storybook/decorators/splitThemeDecorator';
-import type { SignedInWithCookies } from '../../lib/identity';
-import type { CommentType } from '../../types/discussion';
+import type { CommentType, SignedInUser } from '../../types/discussion';
 import { TopPicks } from './TopPicks';
 
 export default { component: TopPicks, title: 'Discussion/TopPicks' };
@@ -56,12 +55,37 @@ const commentWithShortBody: CommentType = {
 	...comment,
 	body: "<p>It's still there FrankDeFord - and thanks, I will pass that on</p>",
 };
-const signedInStatus: SignedInWithCookies = { kind: 'SignedInWithCookies' };
+
+const commentResponseError = {
+	kind: 'error',
+	error: { code: 'NetworkError', message: 'Mocked' },
+} as const;
+
+const aUser = {
+	profile: {
+		userId: 'abc123',
+		displayName: 'Jane Smith',
+		webUrl: '',
+		apiUrl: '',
+		avatar: '',
+		secureAvatarUrl: '',
+		badge: [],
+		privateFields: {
+			canPostComment: true,
+			isPremoderated: false,
+			hasCommented: true,
+		},
+	},
+	onComment: () => Promise.resolve(commentResponseError),
+	onReply: () => Promise.resolve(commentResponseError),
+	onRecommend: () => Promise.resolve(true),
+	authStatus: { kind: 'SignedInWithCookies' },
+} satisfies SignedInUser;
 
 export const SingleComment = () => (
 	<TopPicks
 		comments={[commentWithShortBody]}
-		authStatus={signedInStatus}
+		user={aUser}
 		onPermalinkClick={() => {}}
 	/>
 );
@@ -76,7 +100,7 @@ export const MultiColumn = () => (
 			commentWithShortBody,
 			commentWithShortBody,
 		]}
-		authStatus={signedInStatus}
+		user={aUser}
 		onPermalinkClick={() => {}}
 	/>
 );
@@ -101,7 +125,7 @@ export const SingleColumn = () => (
 			commentWithShortBody,
 			commentWithShortBody,
 		]}
-		authStatus={signedInStatus}
+		user={aUser}
 		onPermalinkClick={() => {}}
 	/>
 );

--- a/dotcom-rendering/src/components/Discussion/TopPicks.tsx
+++ b/dotcom-rendering/src/components/Discussion/TopPicks.tsx
@@ -1,15 +1,12 @@
 import { css } from '@emotion/react';
 import { from, until } from '@guardian/source-foundations';
-import type { SignedInWithCookies, SignedInWithOkta } from '../../lib/identity';
-import type { CommentType, UserProfile } from '../../types/discussion';
+import type { CommentType, SignedInUser } from '../../types/discussion';
 import { TopPick } from './TopPick';
 
 type Props = {
-	user?: UserProfile;
+	user?: SignedInUser;
 	comments: CommentType[];
-	authStatus?: SignedInWithCookies | SignedInWithOkta;
 	onPermalinkClick: (commentId: number) => void;
-	onRecommend?: (commentId: number) => Promise<boolean>;
 };
 
 const columWrapperStyles = css`
@@ -45,13 +42,7 @@ const oneColCommentsStyles = css`
 	}
 `;
 
-export const TopPicks = ({
-	user,
-	comments,
-	authStatus,
-	onPermalinkClick,
-	onRecommend,
-}: Props) => {
+export const TopPicks = ({ user, comments, onPermalinkClick }: Props) => {
 	const leftColComments: CommentType[] = [];
 	const rightColComments: CommentType[] = [];
 	for (const [index, comment] of comments.entries())
@@ -66,13 +57,12 @@ export const TopPicks = ({
 						<TopPick
 							key={comment.id}
 							comment={comment}
-							authStatus={authStatus}
+							user={user}
 							userMadeComment={
-								!!user &&
-								user.userId === comment.userProfile.userId
+								user?.profile.userId ===
+								comment.userProfile.userId
 							}
 							onPermalinkClick={onPermalinkClick}
-							onRecommend={onRecommend}
 						/>
 					))}
 				</div>
@@ -81,13 +71,12 @@ export const TopPicks = ({
 						<TopPick
 							key={comment.id}
 							comment={comment}
-							authStatus={authStatus}
+							user={user}
 							userMadeComment={
-								!!user &&
-								user.userId === comment.userProfile.userId
+								user?.profile.userId ===
+								comment.userProfile.userId
 							}
 							onPermalinkClick={onPermalinkClick}
-							onRecommend={onRecommend}
 						/>
 					))}
 				</div>
@@ -97,12 +86,10 @@ export const TopPicks = ({
 					<TopPick
 						key={comment.id}
 						comment={comment}
-						authStatus={authStatus}
 						userMadeComment={
-							!!user && user.userId === comment.userProfile.userId
+							user?.profile.userId === comment.userProfile.userId
 						}
 						onPermalinkClick={onPermalinkClick}
-						onRecommend={onRecommend}
 					/>
 				))}
 			</div>

--- a/dotcom-rendering/src/components/DiscussionContainer.importable.tsx
+++ b/dotcom-rendering/src/components/DiscussionContainer.importable.tsx
@@ -1,6 +1,6 @@
 import { isObject, joinUrl } from '@guardian/libs';
 import { useEffect, useState } from 'react';
-import { comment, reply } from '../lib/discussionApi';
+import { comment, recommend, reply } from '../lib/discussionApi';
 import type { SignedInWithCookies, SignedInWithOkta } from '../lib/identity';
 import { getOptionsHeadersWithOkta } from '../lib/identity';
 import { useAuthStatus } from '../lib/useAuthStatus';
@@ -31,6 +31,7 @@ const getUser = async ({
 		profile,
 		onComment: comment(authStatus),
 		onReply: reply(authStatus),
+		onRecommend: recommend(authStatus),
 		authStatus,
 	};
 };

--- a/dotcom-rendering/src/types/discussion.ts
+++ b/dotcom-rendering/src/types/discussion.ts
@@ -18,6 +18,7 @@ import {
 } from 'valibot';
 import type {
 	comment as onComment,
+	recommend as onRecommend,
 	reply as onReply,
 } from '../lib/discussionApi';
 import type { Guard } from '../lib/guard';
@@ -293,6 +294,7 @@ export type SignedInUser = {
 	profile: UserProfile;
 	onComment: ReturnType<typeof onComment>;
 	onReply: ReturnType<typeof onReply>;
+	onRecommend: ReturnType<typeof onRecommend>;
 	authStatus: SignedInWithCookies | SignedInWithOkta;
 };
 


### PR DESCRIPTION
## What does this change?

Tie the `onRecommend` method to the `user` prop

## Why?

It’s impossible to recommend if not signed in. Similar to:
- #10403 

## Screenshots

N/A