### PR TITLE
Updates idle timeout for load balancer to stop ELB HTTP 502s

### DIFF
--- a/dotcom-rendering/cdk/lib/__snapshots__/renderingStack.test.ts.snap
+++ b/dotcom-rendering/cdk/lib/__snapshots__/renderingStack.test.ts.snap
@@ -650,6 +650,10 @@ exports[`The RenderingCDKStack matches the snapshot 1`] = `
             "Key": "access_logs.s3.prefix",
             "Value": "ELBLogs/frontend/article-rendering/TEST",
           },
+          {
+            "Key": "idle_timeout.timeout_seconds",
+            "Value": "4",
+          },
         ],
         "Scheme": "internal",
         "SecurityGroups": [

--- a/dotcom-rendering/cdk/lib/renderingStack.ts
+++ b/dotcom-rendering/cdk/lib/renderingStack.ts
@@ -120,6 +120,16 @@ export class RenderingCDKStack extends CDKStack {
 			}),
 		});
 
+		/**
+		 * The default Node server keep alive timeout is 5 seconds
+		 * @see https://nodejs.org/api/http.html#serverkeepalivetimeout
+		 *
+		 * This ensures that the load balancer idle timeout is less than the Node server keep alive timeout
+		 * so that the Node app does not prematurely close the connection before the load balancer can accept the response.
+		 * @see https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html#connection-idle-timeout
+		 */
+		ec2App.loadBalancer.setAttribute('idle_timeout.timeout_seconds', '4');
+
 		// Maps the certificate domain name to the load balancer DNS name
 		new GuCname(this, 'LoadBalancerDNS', {
 			domainName,


### PR DESCRIPTION
## What does this change?

Updates the idle timeout on the load balancer for the new rendering apps (apps using the `RenderingCDKStack` which are currently `article-rendering` and `facia-rendering`) to be _shorter_ than the keep alive timeout on the target application (the Node app)

## Why?

There's a write up in the comments on https://github.com/guardian/dotcom-rendering/issues/10392 to explain in more detail but in summary:

- When sending traffic to the classic load balancer we were experiencing HTTP 504 errors
- When changing traffic to go to the new application load balancer, we saw the 504 errors turn into 502 errors
- The combination of these things indicated that this is related to connection timeout issues https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html#connection-idle-timeout
- The Node express server running our application had a keep alive timeout of 5 seconds (the default) and the idle timeout set on the load balancer was 60 seconds (the default). In this case, what happens is that the application server occasionally prematurely closes the connection to the load balancer (after 5 seconds of inactivity) when the load balancer believes the connection is still open, resulting in 502 errors.
- By reducing the idle timeout on the load balancer to shorter than the keep alive timeout on the application server, the load balancer will stop sending requests to the targets _before_ they close the connection.


Resolves https://github.com/guardian/dotcom-rendering/issues/10392

## Screenshots

The following screenshot shows the change in 502 errors reported on the application load balancer before and after a manual change to the idle timeout in the AWS console

<img width="890" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/43961396/c86ce896-7907-4a59-b77b-7a17071fa0ef">

------------------------------------

> [!NOTE]
> This isn't the first time this issue has been experienced in the department
> See https://github.com/guardian/apps-metering/pull/159
