### PR TITLE
Adds An Example Of A `useEffectReducer` Custom Hook

### DIFF
--- a/dotcom-rendering/src/components/DiscussionExample/EffectReducerExample.stories.tsx
+++ b/dotcom-rendering/src/components/DiscussionExample/EffectReducerExample.stories.tsx
@@ -1,0 +1,15 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { EffectReducerExample } from './EffectReducerExample';
+
+const meta: Meta<typeof EffectReducerExample> = {
+	title: 'components/EffectReducerExample',
+	component: EffectReducerExample,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof EffectReducerExample>;
+
+export const Default: Story = {
+	args: {},
+};

--- a/dotcom-rendering/src/components/DiscussionExample/EffectReducerExample.tsx
+++ b/dotcom-rendering/src/components/DiscussionExample/EffectReducerExample.tsx
@@ -1,0 +1,109 @@
+import { useEffectReducer } from '../../useEffectReducer';
+
+type State = {
+	counter: number;
+	random: number;
+};
+
+type Action =
+	| {
+			kind: 'increment';
+	  }
+	| {
+			kind: 'decrement';
+	  }
+	| {
+			kind: 'getRandomNumber';
+	  }
+	| {
+			kind: 'randomNumber';
+			num: number;
+	  }
+	| {
+			kind: 'sleptResult';
+			num: number;
+	  };
+
+type Effect =
+	| {
+			kind: 'RandomNumber';
+	  }
+	| {
+			kind: 'SleepNumber';
+			value: number;
+	  };
+
+/**
+ * Generates a random number, and returns an action with that number.
+ */
+const getRandomNumber = (): Action => ({
+	kind: 'randomNumber',
+	num: Math.random(),
+});
+
+/**
+ * Takes a number, waits 2 seconds, then returns an action with that number.
+ */
+const sleepNumber = (num: number): Promise<Action> =>
+	new Promise((res) =>
+		setTimeout(() => res({ kind: 'sleptResult', num }), 2000),
+	);
+
+const effectReducer = (effect: Effect): Action | Promise<Action> => {
+	switch (effect.kind) {
+		case 'RandomNumber':
+			return getRandomNumber();
+		case 'SleepNumber':
+			return sleepNumber(effect.value);
+	}
+};
+
+const reducer = (
+	state: State,
+	action: Action,
+): { state: State; effect?: Effect } => {
+	switch (action.kind) {
+		case 'increment':
+			return { state: { ...state, counter: state.counter + 1 } };
+		case 'decrement':
+			return { state: { ...state, counter: state.counter - 1 } };
+		case 'getRandomNumber':
+			return { state, effect: { kind: 'RandomNumber' } };
+		case 'randomNumber':
+			return { state: { ...state, random: action.num } };
+		case 'sleptResult':
+			return { state: { ...state, counter: action.num } };
+	}
+};
+
+/**
+ * A counter application with three features:
+ *
+ * 1. '+' and '-' buttons to increment and decrement the counter.
+ * 2. A timer that waits 2 seconds and then sets the counter value.
+ * 3. A button to get and display random numbers.
+ *
+ * See the corresponding story for a demonstration.
+ */
+const EffectReducerExample = () => {
+	const [state, dispatch] = useEffectReducer(
+		reducer,
+		effectReducer,
+		{ counter: 0, random: 0 },
+		{ kind: 'SleepNumber', value: 3 },
+	);
+
+	return (
+		<>
+			<button onClick={() => dispatch({ kind: 'decrement' })}>-</button>
+			Counter: {state.counter}
+			<button onClick={() => dispatch({ kind: 'increment' })}>+</button>
+			Random: {state.random}
+			<button onClick={() => dispatch({ kind: 'getRandomNumber' })}>
+				Get Random
+			</button>
+		</>
+	);
+};
+
+export { EffectReducerExample };

--- a/dotcom-rendering/src/useEffectReducer.ts
+++ b/dotcom-rendering/src/useEffectReducer.ts
@@ -1,0 +1,79 @@
+import type { Dispatch } from 'react';
+import { useEffect, useReducer, useRef } from 'react';
+
+type StateAndEffect<State, Effect> = {
+	state: State;
+	effect?: Effect;
+};
+
+/**
+ * @param reducer Very similar to the reducer normally passed to
+ * {@linkcode React.useReducer}, but also returns a description of effects
+ * alongside the state.
+ *
+ * @param effectReducer A handler for effects. It takes a description of an
+ * effect and decides how to run that effect, returning an `Action` that will
+ * be fed back into the next loop of the `reducer`.
+ *
+ * Depending on how an application is written, different `effectReducer`s can
+ * be passed in different environments. So in production this might run actual
+ * effects, whereas in tests it might run mocked versions.
+ *
+ * *Note:* The value used will be the one passed on the initial render; the
+ * argument is ignored after this point.
+ *
+ * @param initialState The state at the start of the application; the same
+ * as the `initialState` argument usually passed to
+ * {@linkcode React.useReducer}.
+ *
+ * @param initialEffect Optionally, an effect to run at the start of the
+ * application.
+ *
+ * @returns State and a `dispatch` function, the same as
+ * {@linkcode React.useReducer}.
+ */
+const useEffectReducer = <State, Effect, Action>(
+	reducer: (
+		state: State,
+		action: Action,
+	) => { state: State; effect?: Effect },
+	effectReducer: (effect: Effect) => Action | Promise<Action>,
+	initialState: State,
+	initialEffect: Effect | undefined,
+): [State, Dispatch<Action>] => {
+	/**
+	 * Guards against effect reducers being changed over time. If this were to
+	 * be allowed, the `effectReducer` would have to be a dependency of the
+	 * `useEffect` below. Were this the case, every time it changed the
+	 * `useEffect` callback would run, potentially duplicating effects.
+	 */
+	const cachedEffectReducer = useRef(effectReducer);
+
+	const reducerWrapper = (
+		stateAndEffect: StateAndEffect<State, Effect>,
+		action: Action,
+	): StateAndEffect<State, Effect> => reducer(stateAndEffect.state, action);
+
+	const [{ state, effect }, dispatch] = useReducer(reducerWrapper, {
+		state: initialState,
+		effect: initialEffect,
+	});
+
+	useEffect(() => {
+		if (effect !== undefined) {
+			const result = cachedEffectReducer.current(effect);
+
+			if (result instanceof Promise) {
+				result.then(dispatch).catch(() => {
+					console.error('Failed to run effect!');
+				});
+			} else {
+				dispatch(result);
+			}
+		}
+	}, [effect]);
+
+	return [state, dispatch];
+};
+
+export { useEffectReducer };


### PR DESCRIPTION
A possible way to make it easier to manage effects in areas where we're using `useReducer`, such as discussion.

I've opened this PR mainly for people to have a look and give feedback, rather than assuming this will get merged in its current state.
