### PR TITLE
Make comment form actions more general

### DIFF
--- a/dotcom-rendering/src/components/Discussion.tsx
+++ b/dotcom-rendering/src/components/Discussion.tsx
@@ -108,6 +108,7 @@ type State = {
 const initialCommentFormState = {
 	isActive: false,
 	userNameMissing: false,
+	error: '',
 };
 
 const initialState: State = {
@@ -142,7 +143,10 @@ type Action =
 	| { type: 'setBottomFormActive'; isActive: boolean }
 	| { type: 'setTopFormUserMissing'; userNameMissing: boolean }
 	| { type: 'setReplyFormUserMissing'; userNameMissing: boolean }
-	| { type: 'setBottomFormUserMissing'; userNameMissing: boolean };
+	| { type: 'setBottomFormUserMissing'; userNameMissing: boolean }
+	| { type: 'setTopFormError'; error: string }
+	| { type: 'setReplyFormError'; error: string }
+	| { type: 'setBottomFormError'; error: string };
 
 const reducer = (state: State, action: Action): State => {
 	switch (action.type) {
@@ -234,6 +238,33 @@ const reducer = (state: State, action: Action): State => {
 				bottomForm: {
 					...state.bottomForm,
 					userNameMissing: action.userNameMissing,
+				},
+			};
+		}
+		case 'setTopFormError': {
+			return {
+				...state,
+				topForm: {
+					...state.topForm,
+					error: action.error,
+				},
+			};
+		}
+		case 'setReplyFormError': {
+			return {
+				...state,
+				replyForm: {
+					...state.replyForm,
+					error: action.error,
+				},
+			};
+		}
+		case 'setBottomFormError': {
+			return {
+				...state,
+				bottomForm: {
+					...state.bottomForm,
+					error: action.error,
 				},
 			};
 		}
@@ -441,6 +472,24 @@ export const Discussion = ({
 						dispatch({
 							type: 'setBottomFormUserMissing',
 							userNameMissing,
+						})
+					}
+					setTopFormError={(error) =>
+						dispatch({
+							type: 'setTopFormError',
+							error,
+						})
+					}
+					setReplyFormError={(error) =>
+						dispatch({
+							type: 'setReplyFormError',
+							error,
+						})
+					}
+					setBottomFormError={(error) =>
+						dispatch({
+							type: 'setBottomFormError',
+							error,
 						})
 					}
 					topForm={topForm}

--- a/dotcom-rendering/src/components/Discussion.tsx
+++ b/dotcom-rendering/src/components/Discussion.tsx
@@ -15,6 +15,7 @@ import type {
 	CommentForm,
 	CommentType,
 	FilterOptions,
+	FormType,
 	SignedInUser,
 } from '../types/discussion';
 import { Comments } from './Discussion/Comments';
@@ -138,15 +139,26 @@ type Action =
 	| { type: 'updateHashCommentId'; hashCommentId: number | undefined }
 	| { type: 'filterChange'; filters: FilterOptions; commentPage?: number }
 	| { type: 'setLoading'; loading: boolean }
-	| { type: 'setTopFormActive'; isActive: boolean }
-	| { type: 'setReplyFormActive'; isActive: boolean }
-	| { type: 'setBottomFormActive'; isActive: boolean }
-	| { type: 'setTopFormUserMissing'; userNameMissing: boolean }
-	| { type: 'setReplyFormUserMissing'; userNameMissing: boolean }
-	| { type: 'setBottomFormUserMissing'; userNameMissing: boolean }
-	| { type: 'setTopFormError'; error: string }
-	| { type: 'setReplyFormError'; error: string }
-	| { type: 'setBottomFormError'; error: string };
+	| {
+			type: 'setFormActive';
+			isActive: boolean;
+			form: FormType;
+	  }
+	| {
+			type: 'setFormActive';
+			isActive: boolean;
+			form: FormType;
+	  }
+	| {
+			type: 'setFormUserMissing';
+			userNameMissing: boolean;
+			form: FormType;
+	  }
+	| {
+			type: 'setFormError';
+			error: string;
+			form: FormType;
+	  };
 
 const reducer = (state: State, action: Action): State => {
 	switch (action.type) {
@@ -196,77 +208,99 @@ const reducer = (state: State, action: Action): State => {
 				isExpanded: true,
 			};
 		}
-		case 'setTopFormActive': {
-			return {
-				...state,
-				topForm: { ...state.topForm, isActive: action.isActive },
-			};
+
+		case 'setFormActive': {
+			switch (action.form) {
+				case 'top': {
+					return {
+						...state,
+						topForm: {
+							...state.topForm,
+							isActive: action.isActive,
+						},
+					};
+				}
+				case 'reply': {
+					return {
+						...state,
+						replyForm: {
+							...state.replyForm,
+							isActive: action.isActive,
+						},
+					};
+				}
+				case 'bottom': {
+					return {
+						...state,
+						bottomForm: {
+							...state.bottomForm,
+							isActive: action.isActive,
+						},
+					};
+				}
+			}
 		}
-		case 'setReplyFormActive': {
-			return {
-				...state,
-				replyForm: { ...state.replyForm, isActive: action.isActive },
-			};
+		case 'setFormUserMissing': {
+			switch (action.form) {
+				case 'top': {
+					return {
+						...state,
+						topForm: {
+							...state.topForm,
+							userNameMissing: action.userNameMissing,
+						},
+					};
+				}
+				case 'reply': {
+					return {
+						...state,
+						replyForm: {
+							...state.replyForm,
+							userNameMissing: action.userNameMissing,
+						},
+					};
+				}
+				case 'bottom': {
+					return {
+						...state,
+						bottomForm: {
+							...state.bottomForm,
+							userNameMissing: action.userNameMissing,
+						},
+					};
+				}
+			}
 		}
-		case 'setBottomFormActive': {
-			return {
-				...state,
-				bottomForm: { ...state.bottomForm, isActive: action.isActive },
-			};
-		}
-		case 'setTopFormUserMissing': {
-			return {
-				...state,
-				topForm: {
-					...state.topForm,
-					userNameMissing: action.userNameMissing,
-				},
-			};
-		}
-		case 'setReplyFormUserMissing': {
-			return {
-				...state,
-				replyForm: {
-					...state.replyForm,
-					userNameMissing: action.userNameMissing,
-				},
-			};
-		}
-		case 'setBottomFormUserMissing': {
-			return {
-				...state,
-				bottomForm: {
-					...state.bottomForm,
-					userNameMissing: action.userNameMissing,
-				},
-			};
-		}
-		case 'setTopFormError': {
-			return {
-				...state,
-				topForm: {
-					...state.topForm,
-					error: action.error,
-				},
-			};
-		}
-		case 'setReplyFormError': {
-			return {
-				...state,
-				replyForm: {
-					...state.replyForm,
-					error: action.error,
-				},
-			};
-		}
-		case 'setBottomFormError': {
-			return {
-				...state,
-				bottomForm: {
-					...state.bottomForm,
-					error: action.error,
-				},
-			};
+		case 'setFormError': {
+			switch (action.form) {
+				case 'top': {
+					return {
+						...state,
+						topForm: {
+							...state.topForm,
+							error: action.error,
+						},
+					};
+				}
+				case 'reply': {
+					return {
+						...state,
+						replyForm: {
+							...state.replyForm,
+							error: action.error,
+						},
+					};
+				}
+				case 'bottom': {
+					return {
+						...state,
+						bottomForm: {
+							...state.bottomForm,
+							error: action.error,
+						},
+					};
+				}
+			}
 		}
 
 		default:
@@ -447,49 +481,28 @@ export const Discussion = ({
 							commentPage: page,
 						});
 					}}
-					setTopFormActive={(isActive) =>
-						dispatch({ type: 'setTopFormActive', isActive })
-					}
-					setReplyFormActive={(isActive) =>
-						dispatch({ type: 'setReplyFormActive', isActive })
-					}
-					setBottomFormActive={(isActive) =>
-						dispatch({ type: 'setBottomFormActive', isActive })
-					}
-					setTopFormUserMissing={(userNameMissing) =>
+					setFormActive={(isActive: boolean, form: FormType) =>
 						dispatch({
-							type: 'setTopFormUserMissing',
+							type: 'setFormActive',
+							isActive,
+							form,
+						})
+					}
+					setFormUserMissing={(
+						userNameMissing: boolean,
+						form: FormType,
+					) =>
+						dispatch({
+							type: 'setFormUserMissing',
 							userNameMissing,
+							form,
 						})
 					}
-					setReplyFormUserMissing={(userNameMissing) =>
+					setFormError={(error: string, form: FormType) =>
 						dispatch({
-							type: 'setReplyFormUserMissing',
-							userNameMissing,
-						})
-					}
-					setBottomFormUserMissing={(userNameMissing) =>
-						dispatch({
-							type: 'setBottomFormUserMissing',
-							userNameMissing,
-						})
-					}
-					setTopFormError={(error) =>
-						dispatch({
-							type: 'setTopFormError',
+							type: 'setFormError',
 							error,
-						})
-					}
-					setReplyFormError={(error) =>
-						dispatch({
-							type: 'setReplyFormError',
-							error,
-						})
-					}
-					setBottomFormError={(error) =>
-						dispatch({
-							type: 'setBottomFormError',
-							error,
+							form,
 						})
 					}
 					topForm={topForm}

--- a/dotcom-rendering/src/components/Discussion/Comments.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comments.stories.tsx
@@ -49,7 +49,11 @@ const filters: FilterOptions = {
 	orderBy: 'newest',
 };
 
-const defaultCommentForm = { isActive: false, userNameMissing: false };
+const defaultCommentForm = {
+	isActive: false,
+	userNameMissing: false,
+	error: '',
+};
 
 export const LoggedOutHiddenPicks = () => (
 	<div
@@ -85,6 +89,9 @@ export const LoggedOutHiddenPicks = () => (
 			setTopFormUserMissing={() => {}}
 			setReplyFormUserMissing={() => {}}
 			setBottomFormUserMissing={() => {}}
+			setTopFormError={() => {}}
+			setReplyFormError={() => {}}
+			setBottomFormError={() => {}}
 			topForm={defaultCommentForm}
 			replyForm={defaultCommentForm}
 			bottomForm={defaultCommentForm}
@@ -135,6 +142,9 @@ export const InitialPage = () => (
 			setTopFormUserMissing={() => {}}
 			setReplyFormUserMissing={() => {}}
 			setBottomFormUserMissing={() => {}}
+			setTopFormError={() => {}}
+			setReplyFormError={() => {}}
+			setBottomFormError={() => {}}
 			topForm={defaultCommentForm}
 			replyForm={defaultCommentForm}
 			bottomForm={defaultCommentForm}
@@ -189,6 +199,9 @@ export const LoggedInHiddenNoPicks = () => {
 				setTopFormUserMissing={() => {}}
 				setReplyFormUserMissing={() => {}}
 				setBottomFormUserMissing={() => {}}
+				setTopFormError={() => {}}
+				setReplyFormError={() => {}}
+				setBottomFormError={() => {}}
 				topForm={defaultCommentForm}
 				replyForm={{ ...defaultCommentForm, isActive }}
 				bottomForm={defaultCommentForm}
@@ -239,6 +252,9 @@ export const LoggedIn = () => {
 				setTopFormUserMissing={() => {}}
 				setReplyFormUserMissing={() => {}}
 				setBottomFormUserMissing={() => {}}
+				setTopFormError={() => {}}
+				setReplyFormError={() => {}}
+				setBottomFormError={() => {}}
 				topForm={defaultCommentForm}
 				replyForm={{
 					...defaultCommentForm,
@@ -294,6 +310,9 @@ export const LoggedInShortDiscussion = () => {
 				setTopFormUserMissing={() => {}}
 				setReplyFormUserMissing={() => {}}
 				setBottomFormUserMissing={() => {}}
+				setTopFormError={() => {}}
+				setReplyFormError={() => {}}
+				setBottomFormError={() => {}}
 				topForm={{ ...defaultCommentForm, isActive: isTopFormActive }}
 				replyForm={{
 					...defaultCommentForm,
@@ -340,6 +359,9 @@ export const LoggedOutHiddenNoPicks = () => (
 			setTopFormUserMissing={() => {}}
 			setReplyFormUserMissing={() => {}}
 			setBottomFormUserMissing={() => {}}
+			setTopFormError={() => {}}
+			setReplyFormError={() => {}}
+			setBottomFormError={() => {}}
 			topForm={defaultCommentForm}
 			replyForm={defaultCommentForm}
 			bottomForm={defaultCommentForm}
@@ -392,6 +414,9 @@ export const Closed = () => (
 			setTopFormUserMissing={() => {}}
 			setReplyFormUserMissing={() => {}}
 			setBottomFormUserMissing={() => {}}
+			setTopFormError={() => {}}
+			setReplyFormError={() => {}}
+			setBottomFormError={() => {}}
 			topForm={defaultCommentForm}
 			replyForm={defaultCommentForm}
 			bottomForm={defaultCommentForm}
@@ -442,6 +467,9 @@ export const NoComments = () => (
 			setTopFormUserMissing={() => {}}
 			setReplyFormUserMissing={() => {}}
 			setBottomFormUserMissing={() => {}}
+			setTopFormError={() => {}}
+			setReplyFormError={() => {}}
+			setBottomFormError={() => {}}
 			topForm={defaultCommentForm}
 			replyForm={defaultCommentForm}
 			bottomForm={defaultCommentForm}
@@ -494,6 +522,9 @@ export const LegacyDiscussion = () => (
 			setTopFormUserMissing={() => {}}
 			setReplyFormUserMissing={() => {}}
 			setBottomFormUserMissing={() => {}}
+			setTopFormError={() => {}}
+			setReplyFormError={() => {}}
+			setBottomFormError={() => {}}
 			topForm={defaultCommentForm}
 			replyForm={defaultCommentForm}
 			bottomForm={defaultCommentForm}

--- a/dotcom-rendering/src/components/Discussion/Comments.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comments.tsx
@@ -13,6 +13,7 @@ import type {
 	CommentType,
 	FilterOptions,
 	CommentForm as Form,
+	FormType,
 	SignedInUser,
 } from '../../types/discussion';
 import { CommentContainer } from './CommentContainer';
@@ -44,15 +45,9 @@ type Props = {
 	comments: CommentType[];
 	setComment: (comment: CommentType) => void;
 	handleFilterChange: (newFilters: FilterOptions, page?: number) => void;
-	setTopFormActive: (isActive: boolean) => void;
-	setReplyFormActive: (isActive: boolean) => void;
-	setBottomFormActive: (isActive: boolean) => void;
-	setTopFormUserMissing: (isUserMissing: boolean) => void;
-	setReplyFormUserMissing: (isUserMissing: boolean) => void;
-	setBottomFormUserMissing: (isUserMissing: boolean) => void;
-	setTopFormError: (error: string) => void;
-	setReplyFormError: (error: string) => void;
-	setBottomFormError: (error: string) => void;
+	setFormActive: (isActive: boolean, form: FormType) => void;
+	setFormUserMissing: (isUserMissing: boolean, form: FormType) => void;
+	setFormError: (error: string, form: FormType) => void;
 	topForm: Form;
 	replyForm: Form;
 	bottomForm: Form;
@@ -130,15 +125,9 @@ export const Comments = ({
 	comments,
 	setComment,
 	handleFilterChange,
-	setTopFormActive,
-	setReplyFormActive,
-	setBottomFormActive,
-	setTopFormUserMissing,
-	setReplyFormUserMissing,
-	setBottomFormUserMissing,
-	setTopFormError,
-	setReplyFormError,
-	setBottomFormError,
+	setFormActive,
+	setFormUserMissing,
+	setFormError,
 	topForm,
 	replyForm,
 	bottomForm,
@@ -302,17 +291,27 @@ export const Comments = ({
 											isCommentFormActive={
 												replyForm.isActive
 											}
-											setIsCommentFormActive={
-												setReplyFormActive
-											}
+											setIsCommentFormActive={(
+												isActive,
+											) => {
+												setFormActive(
+													isActive,
+													'reply',
+												);
+											}}
 											error={replyForm.error}
-											setError={setReplyFormError}
+											setError={(error) => {
+												setFormError(error, 'reply');
+											}}
 											userNameMissing={
 												replyForm.userNameMissing
 											}
-											setUserNameMissing={
-												setReplyFormUserMissing
-											}
+											setUserNameMissing={(isMissing) => {
+												setFormUserMissing(
+													isMissing,
+													'reply',
+												);
+											}}
 											previewBody={previewBody}
 											setPreviewBody={setPreviewBody}
 										/>
@@ -337,11 +336,13 @@ export const Comments = ({
 					showPreview={showPreview}
 					setShowPreview={setShowPreview}
 					isActive={topForm.isActive}
-					setIsActive={setTopFormActive}
+					setIsActive={(isActive) => setFormActive(isActive, 'top')}
 					error={topForm.error}
-					setError={setTopFormError}
+					setError={(error) => setFormError(error, 'top')}
 					userNameMissing={topForm.userNameMissing}
-					setUserNameMissing={setTopFormUserMissing}
+					setUserNameMissing={(isMissing) =>
+						setFormUserMissing(isMissing, 'top')
+					}
 					previewBody={previewBody}
 					setPreviewBody={setPreviewBody}
 				/>
@@ -396,11 +397,17 @@ export const Comments = ({
 									showPreview={showPreview}
 									setShowPreview={setShowPreview}
 									isCommentFormActive={replyForm.isActive}
-									setIsCommentFormActive={setReplyFormActive}
+									setIsCommentFormActive={(isActive) =>
+										setFormActive(isActive, 'reply')
+									}
 									error={replyForm.error}
-									setError={setReplyFormError}
+									setError={(error) =>
+										setFormError(error, 'reply')
+									}
 									userNameMissing={replyForm.userNameMissing}
-									setUserNameMissing={setReplyFormUserMissing}
+									setUserNameMissing={(isMissing) =>
+										setFormUserMissing(isMissing, 'reply')
+									}
 									previewBody={previewBody}
 									setPreviewBody={setPreviewBody}
 								/>
@@ -429,11 +436,15 @@ export const Comments = ({
 					showPreview={showPreview}
 					setShowPreview={setShowPreview}
 					isActive={bottomForm.isActive}
-					setIsActive={setBottomFormActive}
+					setIsActive={(isActive) =>
+						setFormActive(isActive, 'bottom')
+					}
 					error={bottomForm.error}
-					setError={setBottomFormError}
+					setError={(error) => setFormError(error, 'bottom')}
 					userNameMissing={bottomForm.userNameMissing}
-					setUserNameMissing={setBottomFormUserMissing}
+					setUserNameMissing={(isMissing) =>
+						setFormUserMissing(isMissing, 'bottom')
+					}
 					previewBody={previewBody}
 					setPreviewBody={setPreviewBody}
 				/>

--- a/dotcom-rendering/src/components/Discussion/Comments.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comments.tsx
@@ -50,6 +50,9 @@ type Props = {
 	setTopFormUserMissing: (isUserMissing: boolean) => void;
 	setReplyFormUserMissing: (isUserMissing: boolean) => void;
 	setBottomFormUserMissing: (isUserMissing: boolean) => void;
+	setTopFormError: (error: string) => void;
+	setReplyFormError: (error: string) => void;
+	setBottomFormError: (error: string) => void;
 	topForm: Form;
 	replyForm: Form;
 	bottomForm: Form;
@@ -133,6 +136,9 @@ export const Comments = ({
 	setTopFormUserMissing,
 	setReplyFormUserMissing,
 	setBottomFormUserMissing,
+	setTopFormError,
+	setReplyFormError,
+	setBottomFormError,
 	topForm,
 	replyForm,
 	bottomForm,
@@ -143,7 +149,6 @@ export const Comments = ({
 	const [numberOfCommentsToShow, setNumberOfCommentsToShow] = useState(10);
 	const [mutes, setMutes] = useState<string[]>(readMutes());
 	const [showPreview, setShowPreview] = useState<boolean>(false);
-	const [error, setError] = useState<string>('');
 	const [previewBody, setPreviewBody] = useState<string>('');
 
 	const loadingMore = !loading && comments.length !== numberOfCommentsToShow;
@@ -300,8 +305,8 @@ export const Comments = ({
 											setIsCommentFormActive={
 												setReplyFormActive
 											}
-											error={error}
-											setError={setError}
+											error={replyForm.error}
+											setError={setReplyFormError}
 											userNameMissing={
 												replyForm.userNameMissing
 											}
@@ -333,8 +338,8 @@ export const Comments = ({
 					setShowPreview={setShowPreview}
 					isActive={topForm.isActive}
 					setIsActive={setTopFormActive}
-					error={error}
-					setError={setError}
+					error={topForm.error}
+					setError={setTopFormError}
 					userNameMissing={topForm.userNameMissing}
 					setUserNameMissing={setTopFormUserMissing}
 					previewBody={previewBody}
@@ -392,8 +397,8 @@ export const Comments = ({
 									setShowPreview={setShowPreview}
 									isCommentFormActive={replyForm.isActive}
 									setIsCommentFormActive={setReplyFormActive}
-									error={error}
-									setError={setError}
+									error={replyForm.error}
+									setError={setReplyFormError}
 									userNameMissing={replyForm.userNameMissing}
 									setUserNameMissing={setReplyFormUserMissing}
 									previewBody={previewBody}
@@ -425,8 +430,8 @@ export const Comments = ({
 					setShowPreview={setShowPreview}
 					isActive={bottomForm.isActive}
 					setIsActive={setBottomFormActive}
-					error={error}
-					setError={setError}
+					error={bottomForm.error}
+					setError={setBottomFormError}
 					userNameMissing={bottomForm.userNameMissing}
 					setUserNameMissing={setBottomFormUserMissing}
 					previewBody={previewBody}

--- a/dotcom-rendering/src/types/discussion.ts
+++ b/dotcom-rendering/src/types/discussion.ts
@@ -381,4 +381,5 @@ export const pickResponseSchema = object({
 export type CommentForm = {
 	isActive: boolean;
 	userNameMissing: boolean;
+	error: string;
 };

--- a/dotcom-rendering/src/types/discussion.ts
+++ b/dotcom-rendering/src/types/discussion.ts
@@ -383,3 +383,5 @@ export type CommentForm = {
 	userNameMissing: boolean;
 	error: string;
 };
+
+export type FormType = 'top' | 'reply' | 'bottom';


### PR DESCRIPTION
## What does this change?
Use a form type property inside the comment form callbacks rather than specific callbacks for each form type. Form type here refers to the position of the form:

- top: top of the discussion
- reply: nested inside a comment
- bottom: bottom of the discussion 

## Why?
Adding and then drilling down 3x callbacks for each piece of state will make the component props unwieldy.
