### PR TITLE
Add new `interactive-rendering` app to CDK

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,6 @@ jobs:
           rm -r rendering/*
           mv rendering.tar.gz rendering/
 
-      # TODO - add other rendering apps when ready
       - name: Compress article-rendering app server files
         run: |
           tar -zcf article-rendering.tar.gz article-rendering
@@ -48,6 +47,12 @@ jobs:
           tar -zcf facia-rendering.tar.gz facia-rendering
           rm -r facia-rendering/*
           mv facia-rendering.tar.gz facia-rendering/
+
+      - name: Compress interactive-rendering app server files
+        run: |
+          tar -zcf interactive-rendering.tar.gz interactive-rendering
+          rm -r interactive-rendering/*
+          mv interactive-rendering.tar.gz interactive-rendering/
 
       - uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -75,5 +80,9 @@ jobs:
               - facia-rendering-cfn
             facia-rendering:
               - facia-rendering
+            interactive-rendering-cfn:
+              - interactive-rendering-cfn
+            interactive-rendering:
+              - interactive-rendering
             frontend-static:
               - frontend-static

--- a/dotcom-rendering/cdk/bin/cdk.ts
+++ b/dotcom-rendering/cdk/bin/cdk.ts
@@ -28,7 +28,7 @@ new DotcomRendering(cdkApp, 'DotcomRendering-CODE', {
 	instanceType: 't4g.micro',
 });
 
-/** NEW article stack */
+/** Article */
 new RenderingCDKStack(cdkApp, 'ArticleRendering-CODE', {
 	guApp: 'article-rendering',
 	stage: 'CODE',
@@ -98,34 +98,37 @@ new RenderingCDKStack(cdkApp, 'FaciaRendering-PROD', {
 	instanceSize: InstanceSize.SMALL,
 });
 
-/** Misc */
-// new RenderingCDKStack(cdkApp, 'MiscRendering-CODE', {
-// 	guApp: 'misc-rendering',
-// 	stage: 'CODE',
-//	domainName: 'misc-rendering.code.dev-guardianapis.com',
-// 	scaling: { minimumInstances: 1, maximumInstances: 2 },
-//  instanceSize: InstanceSize.MICRO,
-// });
-// new RenderingCDKStack(cdkApp, 'MiscRenderingPROD', {
-// 	guApp: 'misc-rendering',
-// 	stage: 'PROD',
-//	domainName: 'misc-rendering.guardianapis.com',
-// 	scaling: { minimumInstances: 1, maximumInstances: 2 },
-//  instanceSize: InstanceSize.MICRO,
-// });
-
 /** Interactive */
-// new RenderingCDKStack(cdkApp, 'InteractiveRendering-CODE', {
-// 	guApp: 'interactive-rendering',
-// 	stage: 'CODE',
-//	domainName: 'interactive-rendering.code.dev-guardianapis.com',
-// 	scaling: { minimumInstances: 1, maximumInstances: 2 },
-//  instanceSize: InstanceSize.MICRO,
-// });
-// new RenderingCDKStack(cdkApp, 'InteractiveRenderingPROD', {
-// 	guApp: 'interactive-rendering',
-// 	stage: 'PROD',
-//	domainName: 'interactive-rendering.guardianapis.com',
-// 	scaling: { minimumInstances: 1, maximumInstances: 2 },
-//  instanceSize: InstanceSize.MICRO,
-// });
+new RenderingCDKStack(cdkApp, 'InteractiveRendering-CODE', {
+	guApp: 'interactive-rendering',
+	stage: 'CODE',
+	domainName: 'interactive-rendering.code.dev-guardianapis.com',
+	scaling: { minimumInstances: 1, maximumInstances: 4 },
+	instanceSize: InstanceSize.MICRO,
+});
+new RenderingCDKStack(cdkApp, 'InteractiveRendering-PROD', {
+	guApp: 'interactive-rendering',
+	stage: 'PROD',
+	domainName: 'interactive-rendering.guardianapis.com',
+	scaling: {
+		minimumInstances: 6,
+		maximumInstances: 24,
+		policy: {
+			scalingStepsOut: [
+				// No scaling up effect when latency is lower than 0.2s
+				{ lower: 0, upper: 0.2, change: 0 },
+				// When latency is higher than 0.3s we scale up by 50%
+				{ lower: 0.2, change: 50 },
+				// When latency is higher than 0.3s we scale up by 80%
+				{ lower: 0.3, change: 80 },
+			],
+			scalingStepsIn: [
+				// No scaling down effect when latency is higher than 0.15s
+				{ lower: 0.15, change: 0 },
+				// When latency is lower than 0.15s we scale down by 1
+				{ upper: 0.15, lower: 0, change: -1 },
+			],
+		},
+	},
+	instanceSize: InstanceSize.SMALL,
+});

--- a/dotcom-rendering/cdk/lib/renderingStack.ts
+++ b/dotcom-rendering/cdk/lib/renderingStack.ts
@@ -20,16 +20,16 @@ import { Topic } from 'aws-cdk-lib/aws-sns';
 import { StringParameter } from 'aws-cdk-lib/aws-ssm';
 import { getUserData } from './userData';
 
-type ScalingPolicy = {
-	scalingStepsOut: ScalingInterval[];
-	scalingStepsIn: ScalingInterval[];
-};
-
 export interface RenderingCDKStackProps extends Omit<GuStackProps, 'stack'> {
-	guApp: `${'article' | 'facia' | 'misc' | 'interactive'}-rendering`;
+	guApp: `${'article' | 'facia' | 'interactive'}-rendering`;
 	domainName: string;
 	instanceSize: InstanceSize;
-	scaling: GuAsgCapacity & { policy?: ScalingPolicy };
+	scaling: GuAsgCapacity & {
+		policy?: {
+			scalingStepsOut: ScalingInterval[];
+			scalingStepsIn: ScalingInterval[];
+		};
+	};
 }
 
 /** DCR infrastructure provisioning via CDK */

--- a/dotcom-rendering/scripts/deploy/build-riffraff-bundle.mjs
+++ b/dotcom-rendering/scripts/deploy/build-riffraff-bundle.mjs
@@ -14,9 +14,8 @@ const target = path.resolve(dirname, '../..', 'target');
  * ├── ${copyFrontendStatic()}
  * ├── ${copyApp('rendering')} // existing rendering app
  * ├── ${copyApp('article-rendering')} // new article-rendering app
- * ├── ${copyApp('facia-rendering')} // To be implemented
- * ├── ${copyApp('misc-rendering')} // To be implemented
- * └── ${copyApp('interactive-rendering')} // To be implemented
+ * ├── ${copyApp('facia-rendering')} // new facia-rendering app
+ * └── ${copyApp('interactive-rendering')} // new interactive-rendering app
  */
 
 /**
@@ -34,7 +33,7 @@ const target = path.resolve(dirname, '../..', 'target');
  *
  *  Except for the instance where appName === 'rendering' due to backwards compatibility
  *
- * @param guAppName {`${'article' | 'facia' | 'misc' | 'interactive'}-rendering` | 'rendering'}
+ * @param guAppName {`${'article' | 'facia' | 'interactive'}-rendering` | 'rendering'}
  **/
 const copyApp = (guAppName) => {
 	/**
@@ -155,8 +154,7 @@ Promise.all([
 	...copyApp('rendering'), // existing rendering app
 	...copyApp('article-rendering'),
 	...copyApp('facia-rendering'),
-	// ...copyApp('misc-rendering'), // To be implemented
-	// ...copyApp('interactive-rendering'), // To be implemented
+	...copyApp('interactive-rendering'),
 	...copyFrontendStatic(),
 	copyRiffRaff(),
 ]).catch((err) => {

--- a/dotcom-rendering/scripts/deploy/riff-raff.yaml
+++ b/dotcom-rendering/scripts/deploy/riff-raff.yaml
@@ -86,6 +86,23 @@ deployments:
     dependencies:
       - frontend-static
       - facia-rendering-cfn
-  # To be implemented:
-  # - misc-rendering
-  # - interactive-rendering
+  # interactive-rendering cloudformation
+  interactive-rendering-cfn:
+    template: cloudformation
+    parameters:
+      templateStagePaths:
+        CODE: InteractiveRendering-CODE.template.json
+        PROD: InteractiveRendering-PROD.template.json
+      cloudFormationStackByTags: false
+      cloudFormationStackName: interactive-rendering
+      amiParameter: AMIInteractiverendering
+  # interactive-rendering autoscaling
+  interactive-rendering:
+    type: autoscaling
+    parameters:
+      bucketSsmKey: /account/services/dotcom-artifact.bucket
+      # Default is 900 (15 mins), this is 25 mins
+      secondsToWait: 1500
+    dependencies:
+      - frontend-static
+      - interactive-rendering-cfn


### PR DESCRIPTION
## What does this change?

- Adds new `interactive-rendering` app to continue the [DCR traffic splitting](https://github.com/guardian/dotcom-rendering/issues/8351)
- Removes references to the `misc` app as this is over-engineering at this stage since the only other page that doesn't fall into other category is the "all email newsletters" page. We can revisit the need for a fourth rendering app in the future if it becomes necessary.

## Why?

Continuing the work to split the DCR apps in order to be able to scale them individually to their needs.

Resolves https://github.com/guardian/dotcom-rendering/issues/9324
