### PR TITLE
Lift info state from CommentForm to the Discussion reducer

### DIFF
--- a/dotcom-rendering/src/components/Discussion.tsx
+++ b/dotcom-rendering/src/components/Discussion.tsx
@@ -108,6 +108,7 @@ type State = {
 const initialCommentFormState = {
 	isActive: false,
 	userNameMissing: false,
+	info: '',
 };
 
 const initialState: State = {
@@ -142,7 +143,10 @@ type Action =
 	| { type: 'setBottomFormActive'; isActive: boolean }
 	| { type: 'setTopFormUserMissing'; userNameMissing: boolean }
 	| { type: 'setReplyFormUserMissing'; userNameMissing: boolean }
-	| { type: 'setBottomFormUserMissing'; userNameMissing: boolean };
+	| { type: 'setBottomFormUserMissing'; userNameMissing: boolean }
+	| { type: 'setTopFormInfo'; info: string }
+	| { type: 'setReplyFormInfo'; info: string }
+	| { type: 'setBottomFormInfo'; info: string };
 
 const reducer = (state: State, action: Action): State => {
 	switch (action.type) {
@@ -234,6 +238,33 @@ const reducer = (state: State, action: Action): State => {
 				bottomForm: {
 					...state.bottomForm,
 					userNameMissing: action.userNameMissing,
+				},
+			};
+		}
+		case 'setTopFormInfo': {
+			return {
+				...state,
+				topForm: {
+					...state.topForm,
+					info: action.info,
+				},
+			};
+		}
+		case 'setReplyFormInfo': {
+			return {
+				...state,
+				replyForm: {
+					...state.replyForm,
+					info: action.info,
+				},
+			};
+		}
+		case 'setBottomFormInfo': {
+			return {
+				...state,
+				bottomForm: {
+					...state.bottomForm,
+					info: action.info,
 				},
 			};
 		}
@@ -441,6 +472,24 @@ export const Discussion = ({
 						dispatch({
 							type: 'setBottomFormUserMissing',
 							userNameMissing,
+						})
+					}
+					setTopFormInfo={(info) =>
+						dispatch({
+							type: 'setTopFormInfo',
+							info,
+						})
+					}
+					setReplyFormInfo={(info) =>
+						dispatch({
+							type: 'setReplyFormInfo',
+							info,
+						})
+					}
+					setBottomFormInfo={(info) =>
+						dispatch({
+							type: 'setBottomFormInfo',
+							info,
 						})
 					}
 					topForm={topForm}

--- a/dotcom-rendering/src/components/Discussion/CommentContainer.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentContainer.stories.tsx
@@ -207,6 +207,8 @@ export const defaultStory = () => (
 		setUserNameMissing={() => {}}
 		previewBody=""
 		setPreviewBody={() => {}}
+		info={''}
+		setInfo={() => {}}
 	/>
 );
 defaultStory.storyName = 'default';
@@ -243,6 +245,8 @@ export const threadedComment = () => (
 		setUserNameMissing={() => {}}
 		previewBody=""
 		setPreviewBody={() => {}}
+		info={''}
+		setInfo={() => {}}
 	/>
 );
 threadedComment.storyName = 'threaded';
@@ -279,6 +283,8 @@ export const threadedCommentWithShowMore = () => (
 		setUserNameMissing={() => {}}
 		previewBody=""
 		setPreviewBody={() => {}}
+		info={''}
+		setInfo={() => {}}
 	/>
 );
 threadedCommentWithShowMore.storyName = 'threaded with show more button';
@@ -315,6 +321,8 @@ export const threadedCommentWithLongUsernames = () => (
 		setUserNameMissing={() => {}}
 		previewBody=""
 		setPreviewBody={() => {}}
+		info={''}
+		setInfo={() => {}}
 	/>
 );
 threadedCommentWithLongUsernames.storyName = 'threaded with long usernames';
@@ -351,6 +359,8 @@ export const threadedCommentWithLongUsernamesMobile = () => (
 		setUserNameMissing={() => {}}
 		previewBody=""
 		setPreviewBody={() => {}}
+		info={''}
+		setInfo={() => {}}
 	/>
 );
 threadedCommentWithLongUsernamesMobile.storyName =

--- a/dotcom-rendering/src/components/Discussion/CommentContainer.test.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentContainer.test.tsx
@@ -89,6 +89,8 @@ describe('CommentContainer', () => {
 				setUserNameMissing={() => {}}
 				previewBody=""
 				setPreviewBody={() => {}}
+				info={''}
+				setInfo={() => {}}
 			/>,
 		);
 
@@ -136,6 +138,8 @@ describe('CommentContainer', () => {
 				setUserNameMissing={() => {}}
 				previewBody=""
 				setPreviewBody={() => {}}
+				info={''}
+				setInfo={() => {}}
 			/>,
 		);
 
@@ -182,6 +186,8 @@ describe('CommentContainer', () => {
 				setUserNameMissing={() => {}}
 				previewBody=""
 				setPreviewBody={() => {}}
+				info={''}
+				setInfo={() => {}}
 			/>,
 		);
 
@@ -229,6 +235,8 @@ describe('CommentContainer', () => {
 				setUserNameMissing={() => {}}
 				previewBody=""
 				setPreviewBody={() => {}}
+				info={''}
+				setInfo={() => {}}
 			/>,
 		);
 

--- a/dotcom-rendering/src/components/Discussion/CommentContainer.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentContainer.tsx
@@ -37,6 +37,8 @@ type Props = {
 	setUserNameMissing: (isUserNameMissing: boolean) => void;
 	previewBody: string;
 	setPreviewBody: (previewBody: string) => void;
+	info: string;
+	setInfo: (info: string) => void;
 };
 
 const nestingStyles = css`
@@ -95,6 +97,8 @@ export const CommentContainer = ({
 	setUserNameMissing,
 	previewBody,
 	setPreviewBody,
+	info,
+	setInfo,
 }: Props) => {
 	// Filter logic
 	const [expanded, setExpanded] = useState<boolean>(threads === 'expanded');
@@ -247,6 +251,8 @@ export const CommentContainer = ({
 								setUserNameMissing={setUserNameMissing}
 								previewBody={previewBody}
 								setPreviewBody={setPreviewBody}
+								info={info}
+								setInfo={setInfo}
 							/>
 						</div>
 					)}

--- a/dotcom-rendering/src/components/Discussion/CommentForm.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentForm.stories.tsx
@@ -87,6 +87,8 @@ export const Default = () => {
 			setError={() => {}}
 			previewBody=""
 			setPreviewBody={() => {}}
+			info={''}
+			setInfo={() => {}}
 		/>
 	);
 };
@@ -114,6 +116,8 @@ export const Error = () => {
 			setError={() => {}}
 			previewBody=""
 			setPreviewBody={() => {}}
+			info={''}
+			setInfo={() => {}}
 		/>
 	);
 };
@@ -137,6 +141,8 @@ export const Active = () => (
 		setUserNameMissing={() => {}}
 		previewBody=""
 		setPreviewBody={() => {}}
+		info={''}
+		setInfo={() => {}}
 	/>
 );
 Active.storyName = 'form is active';
@@ -178,6 +184,8 @@ export const Premoderated = () => (
 		setUserNameMissing={() => {}}
 		previewBody=""
 		setPreviewBody={() => {}}
+		info={''}
+		setInfo={() => {}}
 	/>
 );
 Premoderated.storyName = 'user is premoderated';

--- a/dotcom-rendering/src/components/Discussion/CommentForm.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentForm.tsx
@@ -38,6 +38,8 @@ type Props = {
 	setUserNameMissing: (isUserNameMissing: boolean) => void;
 	previewBody: string;
 	setPreviewBody: (previewBody: string) => void;
+	info: string;
+	setInfo: (info: string) => void;
 };
 
 const boldString = (str: string) => `<b>${str}</b>`;
@@ -222,9 +224,10 @@ export const CommentForm = ({
 	setUserNameMissing,
 	previewBody,
 	setPreviewBody,
+	info,
+	setInfo,
 }: Props) => {
 	const [body, setBody] = useState<string>('');
-	const [info, setInfo] = useState<string>('');
 	const textAreaRef = useRef<HTMLTextAreaElement>(null);
 
 	useEffect(() => {

--- a/dotcom-rendering/src/components/Discussion/Comments.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comments.stories.tsx
@@ -49,7 +49,11 @@ const filters: FilterOptions = {
 	orderBy: 'newest',
 };
 
-const defaultCommentForm = { isActive: false, userNameMissing: false };
+const defaultCommentForm = {
+	isActive: false,
+	userNameMissing: false,
+	info: '',
+};
 
 export const LoggedOutHiddenPicks = () => (
 	<div
@@ -85,6 +89,9 @@ export const LoggedOutHiddenPicks = () => (
 			setTopFormUserMissing={() => {}}
 			setReplyFormUserMissing={() => {}}
 			setBottomFormUserMissing={() => {}}
+			setTopFormInfo={() => {}}
+			setReplyFormInfo={() => {}}
+			setBottomFormInfo={() => {}}
 			topForm={defaultCommentForm}
 			replyForm={defaultCommentForm}
 			bottomForm={defaultCommentForm}
@@ -135,6 +142,9 @@ export const InitialPage = () => (
 			setTopFormUserMissing={() => {}}
 			setReplyFormUserMissing={() => {}}
 			setBottomFormUserMissing={() => {}}
+			setTopFormInfo={() => {}}
+			setReplyFormInfo={() => {}}
+			setBottomFormInfo={() => {}}
 			topForm={defaultCommentForm}
 			replyForm={defaultCommentForm}
 			bottomForm={defaultCommentForm}
@@ -189,6 +199,9 @@ export const LoggedInHiddenNoPicks = () => {
 				setTopFormUserMissing={() => {}}
 				setReplyFormUserMissing={() => {}}
 				setBottomFormUserMissing={() => {}}
+				setTopFormInfo={() => {}}
+				setReplyFormInfo={() => {}}
+				setBottomFormInfo={() => {}}
 				topForm={defaultCommentForm}
 				replyForm={{ ...defaultCommentForm, isActive }}
 				bottomForm={defaultCommentForm}
@@ -239,6 +252,9 @@ export const LoggedIn = () => {
 				setTopFormUserMissing={() => {}}
 				setReplyFormUserMissing={() => {}}
 				setBottomFormUserMissing={() => {}}
+				setTopFormInfo={() => {}}
+				setReplyFormInfo={() => {}}
+				setBottomFormInfo={() => {}}
 				topForm={defaultCommentForm}
 				replyForm={{
 					...defaultCommentForm,
@@ -294,6 +310,9 @@ export const LoggedInShortDiscussion = () => {
 				setTopFormUserMissing={() => {}}
 				setReplyFormUserMissing={() => {}}
 				setBottomFormUserMissing={() => {}}
+				setTopFormInfo={() => {}}
+				setReplyFormInfo={() => {}}
+				setBottomFormInfo={() => {}}
 				topForm={{ ...defaultCommentForm, isActive: isTopFormActive }}
 				replyForm={{
 					...defaultCommentForm,
@@ -340,6 +359,9 @@ export const LoggedOutHiddenNoPicks = () => (
 			setTopFormUserMissing={() => {}}
 			setReplyFormUserMissing={() => {}}
 			setBottomFormUserMissing={() => {}}
+			setTopFormInfo={() => {}}
+			setReplyFormInfo={() => {}}
+			setBottomFormInfo={() => {}}
 			topForm={defaultCommentForm}
 			replyForm={defaultCommentForm}
 			bottomForm={defaultCommentForm}
@@ -392,6 +414,9 @@ export const Closed = () => (
 			setTopFormUserMissing={() => {}}
 			setReplyFormUserMissing={() => {}}
 			setBottomFormUserMissing={() => {}}
+			setTopFormInfo={() => {}}
+			setReplyFormInfo={() => {}}
+			setBottomFormInfo={() => {}}
 			topForm={defaultCommentForm}
 			replyForm={defaultCommentForm}
 			bottomForm={defaultCommentForm}
@@ -442,6 +467,9 @@ export const NoComments = () => (
 			setTopFormUserMissing={() => {}}
 			setReplyFormUserMissing={() => {}}
 			setBottomFormUserMissing={() => {}}
+			setTopFormInfo={() => {}}
+			setReplyFormInfo={() => {}}
+			setBottomFormInfo={() => {}}
 			topForm={defaultCommentForm}
 			replyForm={defaultCommentForm}
 			bottomForm={defaultCommentForm}
@@ -494,6 +522,9 @@ export const LegacyDiscussion = () => (
 			setTopFormUserMissing={() => {}}
 			setReplyFormUserMissing={() => {}}
 			setBottomFormUserMissing={() => {}}
+			setTopFormInfo={() => {}}
+			setReplyFormInfo={() => {}}
+			setBottomFormInfo={() => {}}
 			topForm={defaultCommentForm}
 			replyForm={defaultCommentForm}
 			bottomForm={defaultCommentForm}

--- a/dotcom-rendering/src/components/Discussion/Comments.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comments.tsx
@@ -50,6 +50,9 @@ type Props = {
 	setTopFormUserMissing: (isUserMissing: boolean) => void;
 	setReplyFormUserMissing: (isUserMissing: boolean) => void;
 	setBottomFormUserMissing: (isUserMissing: boolean) => void;
+	setTopFormInfo: (info: string) => void;
+	setReplyFormInfo: (info: string) => void;
+	setBottomFormInfo: (info: string) => void;
 	topForm: Form;
 	replyForm: Form;
 	bottomForm: Form;
@@ -133,6 +136,9 @@ export const Comments = ({
 	setTopFormUserMissing,
 	setReplyFormUserMissing,
 	setBottomFormUserMissing,
+	setTopFormInfo,
+	setReplyFormInfo,
+	setBottomFormInfo,
 	topForm,
 	replyForm,
 	bottomForm,
@@ -310,6 +316,8 @@ export const Comments = ({
 											}
 											previewBody={previewBody}
 											setPreviewBody={setPreviewBody}
+											info={replyForm.info}
+											setInfo={setReplyFormInfo}
 										/>
 									</li>
 								))}
@@ -339,6 +347,8 @@ export const Comments = ({
 					setUserNameMissing={setTopFormUserMissing}
 					previewBody={previewBody}
 					setPreviewBody={setPreviewBody}
+					info={topForm.info}
+					setInfo={setTopFormInfo}
 				/>
 			)}
 			{!!picks.length && (
@@ -398,6 +408,8 @@ export const Comments = ({
 									setUserNameMissing={setReplyFormUserMissing}
 									previewBody={previewBody}
 									setPreviewBody={setPreviewBody}
+									info={replyForm.info}
+									setInfo={setReplyFormInfo}
 								/>
 							</li>
 						))}
@@ -431,6 +443,8 @@ export const Comments = ({
 					setUserNameMissing={setBottomFormUserMissing}
 					previewBody={previewBody}
 					setPreviewBody={setPreviewBody}
+					info={bottomForm.info}
+					setInfo={setBottomFormInfo}
 				/>
 			)}
 		</div>

--- a/dotcom-rendering/src/types/discussion.ts
+++ b/dotcom-rendering/src/types/discussion.ts
@@ -381,4 +381,5 @@ export const pickResponseSchema = object({
 export type CommentForm = {
 	isActive: boolean;
 	userNameMissing: boolean;
+	info: string;
 };


### PR DESCRIPTION
## What does this change?
Lifts info state from CommentForm to the Discussion reducer
## Why?
Resolves https://github.com/guardian/dotcom-rendering/issues/10440
## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
