### PR TITLE
Adjust rendering app instance numbers

### DIFF
--- a/dotcom-rendering/cdk/bin/cdk.ts
+++ b/dotcom-rendering/cdk/bin/cdk.ts
@@ -15,8 +15,8 @@ new DotcomRendering(cdkApp, 'DotcomRendering-PROD', {
 	...sharedProps,
 	app: 'rendering',
 	stage: 'PROD',
-	minCapacity: 18,
-	maxCapacity: 80,
+	minCapacity: 3,
+	maxCapacity: 12,
 	instanceType: 't4g.small',
 });
 new DotcomRendering(cdkApp, 'DotcomRendering-CODE', {
@@ -76,8 +76,8 @@ new RenderingCDKStack(cdkApp, 'FaciaRendering-PROD', {
 	stage: 'PROD',
 	domainName: 'facia-rendering.guardianapis.com',
 	scaling: {
-		minimumInstances: 4,
-		maximumInstances: 20,
+		minimumInstances: 6,
+		maximumInstances: 24,
 		policy: {
 			scalingStepsOut: [
 				// No scaling up effect when latency is lower than 0.3s
@@ -88,10 +88,10 @@ new RenderingCDKStack(cdkApp, 'FaciaRendering-PROD', {
 				{ lower: 0.4, change: 80 },
 			],
 			scalingStepsIn: [
-				// No scaling down effect when latency is higher than 0.25s
-				{ lower: 0.25, change: 0 },
-				// When latency is lower than 0.25s we scale down by 1
-				{ upper: 0.25, lower: 0, change: -1 },
+				// No scaling down effect when latency is higher than 0.27s
+				{ lower: 0.27, change: 0 },
+				// When latency is lower than 0.27s we scale down by 1
+				{ upper: 0.27, lower: 0, change: -1 },
 			],
 		},
 	},


### PR DESCRIPTION
## What does this change?

- Reduce `rendering` app instances
- Increase `facia-rendering` app instances
- Increase upper bound of scale in policy for `facia-rendering` so that we scale down sooner

## Why?

The `facia-rendering` app is scaling up due to high latency and not scaling down sufficiently. This currently prevents continuous integration due to being unable to scale up and down when deploying through riffraff. 

We are also about to remove the `rendering` app so scaling this down before we do.
