### PR TITLE
Add `addUsername` Method To `user`

### DIFF
--- a/dotcom-rendering/src/components/Discussion/Comment.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comment.stories.tsx
@@ -128,6 +128,7 @@ const user: Reader = {
 	onComment: () => Promise.resolve(commentResponseError),
 	onReply: () => Promise.resolve(commentResponseError),
 	onRecommend: () => Promise.resolve(true),
+	addUsername: () => Promise.resolve({ kind: 'ok', value: true }),
 	authStatus: { kind: 'SignedInWithCookies' },
 };
 
@@ -150,6 +151,7 @@ const staffUser: Staff = {
 	onComment: () => Promise.resolve(commentResponseError),
 	onReply: () => Promise.resolve(commentResponseError),
 	onRecommend: () => Promise.resolve(true),
+	addUsername: () => Promise.resolve({ kind: 'ok', value: true }),
 	onPick: () => Promise.resolve(commentResponseError),
 	onUnpick: () => Promise.resolve(commentResponseError),
 	authStatus: { kind: 'SignedInWithCookies' },

--- a/dotcom-rendering/src/components/Discussion/CommentContainer.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentContainer.stories.tsx
@@ -157,6 +157,7 @@ const aUser: Reader = {
 	onComment: () => Promise.resolve(commentResponseError),
 	onReply: () => Promise.resolve(commentResponseError),
 	onRecommend: () => Promise.resolve(true),
+	addUsername: () => Promise.resolve({ kind: 'ok', value: true }),
 	authStatus: { kind: 'SignedInWithCookies' },
 };
 

--- a/dotcom-rendering/src/components/Discussion/CommentContainer.test.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentContainer.test.tsx
@@ -49,6 +49,7 @@ const aUser: SignedInUser = {
 	onComment: () => Promise.resolve(commentResponseError),
 	onReply: () => Promise.resolve(commentResponseSuccess),
 	onRecommend: () => Promise.resolve(true),
+	addUsername: () => Promise.resolve({ kind: 'ok', value: true }),
 	authStatus: { kind: 'SignedInWithCookies' },
 };
 

--- a/dotcom-rendering/src/components/Discussion/CommentForm.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentForm.stories.tsx
@@ -38,6 +38,7 @@ const aUser: Reader = {
 	onComment: () => Promise.resolve(commentResponseError),
 	onReply: () => Promise.resolve(commentResponseError),
 	onRecommend: () => Promise.resolve(true),
+	addUsername: () => Promise.resolve({ kind: 'ok', value: true }),
 	authStatus: { kind: 'SignedInWithCookies' },
 };
 

--- a/dotcom-rendering/src/components/Discussion/CommentForm.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentForm.tsx
@@ -6,10 +6,7 @@ import {
 	textSans,
 } from '@guardian/source-foundations';
 import { useEffect, useRef, useState } from 'react';
-import {
-	addUserName,
-	preview as defaultPreview,
-} from '../../lib/discussionApi';
+import { preview as defaultPreview } from '../../lib/discussionApi';
 import { palette as schemedPalette } from '../../palette';
 import type {
 	CommentType,
@@ -409,7 +406,7 @@ export const CommentForm = ({
 			return;
 		}
 
-		const response = await addUserName(user.authStatus, userName);
+		const response = await user.addUsername(userName);
 		if (response.kind === 'ok') {
 			// If we are able to submit userName we should continue with submitting comment
 			void submitForm();

--- a/dotcom-rendering/src/components/Discussion/Comments.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comments.stories.tsx
@@ -35,6 +35,7 @@ const aUser: Reader = {
 	onComment: () => Promise.resolve(commentResponseError),
 	onReply: () => Promise.resolve(commentResponseError),
 	onRecommend: () => Promise.resolve(true),
+	addUsername: () => Promise.resolve({ kind: 'ok', value: true }),
 	authStatus: { kind: 'SignedInWithCookies' },
 };
 

--- a/dotcom-rendering/src/components/Discussion/RecommendationCount.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/RecommendationCount.stories.tsx
@@ -30,6 +30,7 @@ const aUser = {
 	onComment: () => Promise.resolve(commentResponseError),
 	onReply: () => Promise.resolve(commentResponseError),
 	onRecommend: () => Promise.resolve(true),
+	addUsername: () => Promise.resolve({ kind: 'ok', value: true }),
 	authStatus: { kind: 'SignedInWithCookies' },
 } satisfies SignedInUser;
 

--- a/dotcom-rendering/src/components/Discussion/TopPick.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/TopPick.stories.tsx
@@ -101,6 +101,7 @@ const aUser = {
 	onComment: () => Promise.resolve(commentResponseError),
 	onReply: () => Promise.resolve(commentResponseError),
 	onRecommend: () => Promise.resolve(true),
+	addUsername: () => Promise.resolve({ kind: 'ok', value: true }),
 	authStatus: { kind: 'SignedInWithCookies' },
 } satisfies SignedInUser;
 

--- a/dotcom-rendering/src/components/Discussion/TopPicks.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/TopPicks.stories.tsx
@@ -80,6 +80,7 @@ const aUser = {
 	onComment: () => Promise.resolve(commentResponseError),
 	onReply: () => Promise.resolve(commentResponseError),
 	onRecommend: () => Promise.resolve(true),
+	addUsername: () => Promise.resolve({ kind: 'ok', value: true }),
 	authStatus: { kind: 'SignedInWithCookies' },
 } satisfies SignedInUser;
 

--- a/dotcom-rendering/src/components/DiscussionContainer.importable.tsx
+++ b/dotcom-rendering/src/components/DiscussionContainer.importable.tsx
@@ -1,6 +1,7 @@
 import { isObject, joinUrl } from '@guardian/libs';
 import { useEffect, useState } from 'react';
 import {
+	addUserName,
 	comment,
 	pickComment,
 	recommend,
@@ -46,6 +47,7 @@ const getUser = async ({
 				onRecommend: recommend(authStatus),
 				onPick: pickComment(authStatus),
 				onUnpick: unPickComment(authStatus),
+				addUsername: addUserName(authStatus),
 				authStatus,
 		  }
 		: {
@@ -54,6 +56,7 @@ const getUser = async ({
 				onComment: comment(authStatus),
 				onReply: reply(authStatus),
 				onRecommend: recommend(authStatus),
+				addUsername: addUserName(authStatus),
 				authStatus,
 		  };
 };

--- a/dotcom-rendering/src/lib/discussionApi.tsx
+++ b/dotcom-rendering/src/lib/discussionApi.tsx
@@ -326,48 +326,47 @@ export const recommend =
 		}).then((resp) => resp.ok);
 	};
 
-export const addUserName = async (
-	authStatus: SignedInWithCookies | SignedInWithOkta,
-	userName: string,
-): Promise<Result<string, true>> => {
-	const url = options.idApiUrl + `/user/me/username`;
-	const authOptions = getOptionsHeadersWithOkta(authStatus);
+export const addUserName =
+	(authStatus: SignedInWithCookies | SignedInWithOkta) =>
+	async (userName: string): Promise<Result<string, true>> => {
+		const url = options.idApiUrl + `/user/me/username`;
+		const authOptions = getOptionsHeadersWithOkta(authStatus);
 
-	const jsonResult = await fetchJSON(url, {
-		method: 'POST',
-		body: JSON.stringify({
-			publicFields: {
-				username: userName,
-				displayName: userName,
+		const jsonResult = await fetchJSON(url, {
+			method: 'POST',
+			body: JSON.stringify({
+				publicFields: {
+					username: userName,
+					displayName: userName,
+				},
+			}),
+			headers: {
+				'Content-Type': 'application/json',
+				...authOptions.headers,
 			},
-		}),
-		headers: {
-			'Content-Type': 'application/json',
-			...authOptions.headers,
-		},
-		credentials: authOptions.credentials,
-	});
+			credentials: authOptions.credentials,
+		});
 
-	if (jsonResult.kind === 'error') {
-		return jsonResult;
-	}
+		if (jsonResult.kind === 'error') {
+			return jsonResult;
+		}
 
-	const result = safeParse(postUsernameResponseSchema, jsonResult.value);
+		const result = safeParse(postUsernameResponseSchema, jsonResult.value);
 
-	if (!result.success) {
-		return { kind: 'error', error: 'An unknown error occured' };
-	}
-	if (result.output.status === 'error') {
-		return {
-			kind: 'error',
-			error: result.output.errors
-				.map(({ message }) => message)
-				.join('\n'),
-		};
-	}
+		if (!result.success) {
+			return { kind: 'error', error: 'An unknown error occured' };
+		}
+		if (result.output.status === 'error') {
+			return {
+				kind: 'error',
+				error: result.output.errors
+					.map(({ message }) => message)
+					.join('\n'),
+			};
+		}
 
-	return { kind: 'ok', value: true };
-};
+		return { kind: 'ok', value: true };
+	};
 
 export const pickComment =
 	(authStatus: SignedInWithCookies | SignedInWithOkta) =>

--- a/dotcom-rendering/src/types/discussion.ts
+++ b/dotcom-rendering/src/types/discussion.ts
@@ -17,6 +17,7 @@ import {
 	variant,
 } from 'valibot';
 import type {
+	addUserName,
 	comment as onComment,
 	recommend as onRecommend,
 	reply as onReply,
@@ -294,6 +295,7 @@ type UserFields = {
 	onComment: ReturnType<typeof onComment>;
 	onReply: ReturnType<typeof onReply>;
 	onRecommend: ReturnType<typeof onRecommend>;
+	addUsername: ReturnType<typeof addUserName>;
 	authStatus: SignedInWithCookies | SignedInWithOkta;
 };
 


### PR DESCRIPTION
Similar to other changes we've made to add effectful methods to this `user` object. It means that these are passed down from the top of the application, rather than imported further down the tree. This will make it easier to swap between side effects on different platforms (apps, web, etc.).

See also #10462 and #10403.
