### PR TITLE
Reduce article rendering min instance count to 15

### DIFF
--- a/dotcom-rendering/cdk/bin/cdk.ts
+++ b/dotcom-rendering/cdk/bin/cdk.ts
@@ -41,7 +41,7 @@ new RenderingCDKStack(cdkApp, 'ArticleRendering-PROD', {
 	stage: 'PROD',
 	domainName: 'article-rendering.guardianapis.com',
 	scaling: {
-		minimumInstances: 18,
+		minimumInstances: 15,
 		maximumInstances: 120,
 		policy: {
 			scalingStepsOut: [


### PR DESCRIPTION
## What does this change?

Reduce article rendering min instance count to 15

## Why?

According to our load testing we should be able to meet min latency with as few as 12 instances, this is a step towards that. 
