### PR TITLE
Improve stories for discussion components

### DIFF
--- a/dotcom-rendering/src/components/Discussion/AbuseReportForm.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/AbuseReportForm.stories.tsx
@@ -3,7 +3,15 @@ import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
 import { splitTheme } from '../../../.storybook/decorators/splitThemeDecorator';
 import { AbuseReportForm } from './AbuseReportForm';
 
-export default { title: 'Discussion/Abuse Report Form' };
+type Props = Parameters<typeof AbuseReportForm>[0];
+
+export default {
+	title: 'Discussion/Abuse Report Form',
+	component: AbuseReportForm,
+	argTypes: {
+		toggleSetShowForm: { action: 'toggleSetShowForm' },
+	},
+};
 
 const wrapperStyles = css`
 	padding: 20px;
@@ -13,10 +21,10 @@ const wrapperStyles = css`
 	position: relative;
 `;
 
-export const Dialog = () => (
+export const Dialog = (args: Props) => (
 	<div css={wrapperStyles}>
 		<AbuseReportForm
-			toggleSetShowForm={() => {}}
+			toggleSetShowForm={args.toggleSetShowForm}
 			commentId={123}
 			reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
 		/>

--- a/dotcom-rendering/src/components/Discussion/Avatar.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/Avatar.stories.tsx
@@ -1,25 +1,28 @@
+import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
+import { splitTheme } from '../../../.storybook/decorators/splitThemeDecorator';
 import { Avatar } from './Avatar';
 
-export default { component: Avatar, title: 'Discussion/Avatar' };
+export default {
+	component: Avatar,
+	title: 'Discussion/Avatar',
+	decorators: splitTheme([
+		{
+			display: ArticleDisplay.Standard,
+			design: ArticleDesign.Standard,
+			theme: Pillar.Opinion,
+		},
+	]),
+};
 
 export const Sizes = () => {
+	const src = 'https://avatar.guim.co.uk/user/101885881';
+	const displayName = 'John Doe';
+
 	return (
 		<>
-			<Avatar
-				imageUrl="https://avatar.guim.co.uk/no-user-image.gif"
-				size="small"
-				displayName=""
-			/>
-			<Avatar
-				imageUrl="https://avatar.guim.co.uk/no-user-image.gif"
-				size="medium"
-				displayName=""
-			/>
-			<Avatar
-				imageUrl="https://avatar.guim.co.uk/no-user-image.gif"
-				size="large"
-				displayName=""
-			/>
+			<Avatar imageUrl={src} size="small" displayName={displayName} />
+			<Avatar imageUrl={src} size="medium" displayName={displayName} />
+			<Avatar imageUrl={src} size="large" displayName={displayName} />
 		</>
 	);
 };
@@ -28,7 +31,7 @@ Sizes.storyName = 'different sizes';
 export const NoImage = () => {
 	return (
 		<>
-			<Avatar size="medium" displayName="" />
+			<Avatar size="medium" displayName="John Doe" />
 		</>
 	);
 };

--- a/dotcom-rendering/src/components/Discussion/Badges.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/Badges.stories.tsx
@@ -1,0 +1,27 @@
+import { css } from '@emotion/react';
+import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
+import { splitTheme } from '../../../.storybook/decorators/splitThemeDecorator';
+import { GuardianContributor, GuardianPick, GuardianStaff } from './Badges';
+
+export default {
+	title: 'Discussion/Badges',
+	decorators: splitTheme([
+		{
+			display: ArticleDisplay.Standard,
+			design: ArticleDesign.Standard,
+			theme: Pillar.Opinion,
+		},
+	]),
+};
+
+export const Badges = () => (
+	<div
+		css={css`
+			padding: 6px;
+		`}
+	>
+		<GuardianStaff />
+		<GuardianContributor />
+		<GuardianPick />
+	</div>
+);

--- a/dotcom-rendering/src/components/Discussion/Comment.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comment.stories.tsx
@@ -3,7 +3,7 @@ import { splitTheme } from '../../../.storybook/decorators/splitThemeDecorator';
 import type { CommentType, Reader, Staff } from '../../types/discussion';
 import { Comment } from './Comment';
 
-export default { title: 'Discussion/Comment' };
+type Props = Parameters<typeof Comment>[0];
 
 const commentData: CommentType = {
 	id: 25487686,
@@ -163,19 +163,28 @@ const defaultFormat = {
 	theme: Pillar.News,
 };
 
-export const Root = () => (
-	<Comment
-		comment={commentData}
-		isClosedForComments={false}
-		setCommentBeingRepliedTo={() => {}}
-		isReply={false}
-		isMuted={false}
-		toggleMuteStatus={() => {}}
-		onPermalinkClick={() => {}}
-		pickError={''}
-		setPickError={() => {}}
-		reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
-	/>
+export default {
+	title: 'Discussion/Comment',
+	component: Comment,
+	argTypes: {
+		setCommentBeingRepliedTo: { action: 'setCommentBeingRepliedTo' },
+		toggleMuteStatus: { action: 'toggleMuteStatus' },
+		onPermalinkClick: { action: 'onPermalinkClick' },
+		setPickError: { action: 'setError' },
+		reportAbuse: { action: 'reportAbuse' },
+	},
+	args: {
+		comment: commentData,
+		isClosedForComments: false,
+		isReply: false,
+		isMuted: false,
+		wasScrolledTo: false,
+		pickError: '',
+	},
+};
+
+export const Root = (args: Props) => (
+	<Comment {...args} comment={commentData} />
 );
 Root.storyName = 'A root comment on desktop view';
 Root.story = {
@@ -186,20 +195,7 @@ Root.story = {
 };
 Root.decorators = [splitTheme([defaultFormat], { orientation: 'vertical' })];
 
-export const RootMobile = () => (
-	<Comment
-		comment={commentData}
-		setCommentBeingRepliedTo={() => {}}
-		isReply={false}
-		isClosedForComments={false}
-		isMuted={false}
-		toggleMuteStatus={() => {}}
-		onPermalinkClick={() => {}}
-		pickError={''}
-		setPickError={() => {}}
-		reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
-	/>
-);
+export const RootMobile = Root.bind({});
 RootMobile.storyName = 'A root comment on mobile view';
 RootMobile.story = {
 	parameters: {
@@ -219,19 +215,8 @@ RootMobile.decorators = [
 	),
 ];
 
-export const ReplyComment = () => (
-	<Comment
-		comment={replyCommentData}
-		isClosedForComments={false}
-		setCommentBeingRepliedTo={() => {}}
-		isReply={true}
-		isMuted={false}
-		toggleMuteStatus={() => {}}
-		onPermalinkClick={() => {}}
-		pickError={''}
-		setPickError={() => {}}
-		reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
-	/>
+export const ReplyComment = (args: Props) => (
+	<Comment {...args} comment={replyCommentData} isReply={true} />
 );
 ReplyComment.storyName = 'A reply on desktop view';
 ReplyComment.story = {
@@ -252,20 +237,7 @@ ReplyComment.decorators = [
 	),
 ];
 
-export const MobileReply = () => (
-	<Comment
-		comment={replyCommentData}
-		setCommentBeingRepliedTo={() => {}}
-		isReply={true}
-		isClosedForComments={false}
-		isMuted={false}
-		toggleMuteStatus={() => {}}
-		onPermalinkClick={() => {}}
-		pickError={''}
-		setPickError={() => {}}
-		reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
-	/>
-);
+export const MobileReply = ReplyComment.bind({});
 MobileReply.storyName = 'A reply on mobile view';
 MobileReply.story = {
 	parameters: {
@@ -285,20 +257,10 @@ MobileReply.decorators = [
 	),
 ];
 
-export const LongMobileReply = () => (
-	<Comment
-		comment={longReplyCommentData}
-		setCommentBeingRepliedTo={() => {}}
-		isReply={true}
-		isClosedForComments={false}
-		isMuted={false}
-		toggleMuteStatus={() => {}}
-		onPermalinkClick={() => {}}
-		pickError={''}
-		setPickError={() => {}}
-		reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
-	/>
+export const LongMobileReply = (args: Props) => (
+	<Comment {...args} comment={longReplyCommentData} />
 );
+
 LongMobileReply.storyName = 'A long username reply on mobile view';
 LongMobileReply.story = {
 	parameters: {
@@ -318,19 +280,8 @@ LongMobileReply.decorators = [
 	),
 ];
 
-export const LongBothMobileReply = () => (
-	<Comment
-		comment={longBothReplyCommentData}
-		setCommentBeingRepliedTo={() => {}}
-		isReply={true}
-		isClosedForComments={false}
-		isMuted={false}
-		toggleMuteStatus={() => {}}
-		onPermalinkClick={() => {}}
-		pickError={''}
-		setPickError={() => {}}
-		reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
-	/>
+export const LongBothMobileReply = (args: Props) => (
+	<Comment {...args} comment={longBothReplyCommentData} />
 );
 LongBothMobileReply.storyName = 'Both long usernames replying on mobile view';
 LongBothMobileReply.story = {
@@ -351,21 +302,13 @@ LongBothMobileReply.decorators = [
 	),
 ];
 
-export const PickedComment = () => (
+export const PickedComment = (args: Props) => (
 	<Comment
+		{...args}
 		comment={{
 			...commentData,
 			isHighlighted: true,
 		}}
-		isClosedForComments={false}
-		setCommentBeingRepliedTo={() => {}}
-		isReply={false}
-		isMuted={false}
-		toggleMuteStatus={() => {}}
-		onPermalinkClick={() => {}}
-		pickError={''}
-		setPickError={() => {}}
-		reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
 	/>
 );
 PickedComment.storyName = 'Picked Comment';
@@ -381,19 +324,8 @@ PickedComment.decorators = [
 	),
 ];
 
-export const StaffUserComment = () => (
-	<Comment
-		comment={commentStaffData}
-		isClosedForComments={false}
-		setCommentBeingRepliedTo={() => {}}
-		isReply={false}
-		isMuted={false}
-		toggleMuteStatus={() => {}}
-		onPermalinkClick={() => {}}
-		pickError={''}
-		setPickError={() => {}}
-		reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
-	/>
+export const StaffUserComment = (args: Props) => (
+	<Comment {...args} comment={commentStaffData} />
 );
 StaffUserComment.storyName = 'Staff User Comment';
 StaffUserComment.decorators = [
@@ -408,19 +340,8 @@ StaffUserComment.decorators = [
 	),
 ];
 
-export const ContributorUserComment = () => (
-	<Comment
-		comment={commentContributorData}
-		isClosedForComments={false}
-		setCommentBeingRepliedTo={() => {}}
-		isReply={false}
-		isMuted={false}
-		toggleMuteStatus={() => {}}
-		onPermalinkClick={() => {}}
-		pickError={''}
-		setPickError={() => {}}
-		reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
-	/>
+export const ContributorUserComment = (args: Props) => (
+	<Comment {...args} comment={commentContributorData} />
 );
 ContributorUserComment.storyName = 'Contributor User Comment';
 ContributorUserComment.decorators = [
@@ -435,21 +356,13 @@ ContributorUserComment.decorators = [
 	),
 ];
 
-export const PickedStaffUserComment = () => (
+export const PickedStaffUserComment = (args: Props) => (
 	<Comment
+		{...args}
 		comment={{
 			...commentStaffData,
 			isHighlighted: true,
 		}}
-		isClosedForComments={false}
-		setCommentBeingRepliedTo={() => {}}
-		isReply={false}
-		isMuted={false}
-		toggleMuteStatus={() => {}}
-		onPermalinkClick={() => {}}
-		pickError={''}
-		setPickError={() => {}}
-		reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
 	/>
 );
 PickedStaffUserComment.storyName = 'with staff and picked badges on desktop';
@@ -463,23 +376,7 @@ PickedStaffUserComment.decorators = [
 	splitTheme([defaultFormat], { orientation: 'vertical' }),
 ];
 
-export const PickedStaffUserCommentMobile = () => (
-	<Comment
-		comment={{
-			...commentStaffData,
-			isHighlighted: true,
-		}}
-		isClosedForComments={false}
-		setCommentBeingRepliedTo={() => {}}
-		isReply={false}
-		isMuted={false}
-		toggleMuteStatus={() => {}}
-		onPermalinkClick={() => {}}
-		pickError={''}
-		setPickError={() => {}}
-		reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
-	/>
-);
+export const PickedStaffUserCommentMobile = PickedStaffUserComment.bind({});
 PickedStaffUserCommentMobile.storyName =
 	'with staff and picked badges on mobile';
 PickedStaffUserCommentMobile.story = {
@@ -500,21 +397,13 @@ PickedStaffUserCommentMobile.decorators = [
 	),
 ];
 
-export const ContributorUserCommentDesktop = () => (
+export const ContributorUserCommentDesktop = (args: Props) => (
 	<Comment
+		{...args}
 		comment={{
 			...commentContributorData,
 			isHighlighted: true,
 		}}
-		isClosedForComments={false}
-		setCommentBeingRepliedTo={() => {}}
-		isReply={false}
-		isMuted={false}
-		toggleMuteStatus={() => {}}
-		onPermalinkClick={() => {}}
-		pickError={''}
-		setPickError={() => {}}
-		reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
 	/>
 );
 ContributorUserCommentDesktop.storyName =
@@ -529,22 +418,8 @@ ContributorUserCommentDesktop.decorators = [
 	splitTheme([defaultFormat], { orientation: 'vertical' }),
 ];
 
-export const ContributorUserCommentMobile = () => (
-	<Comment
-		comment={{
-			...commentContributorData,
-			isHighlighted: true,
-		}}
-		isClosedForComments={false}
-		setCommentBeingRepliedTo={() => {}}
-		isReply={false}
-		isMuted={false}
-		toggleMuteStatus={() => {}}
-		onPermalinkClick={() => {}}
-		pickError={''}
-		setPickError={() => {}}
-		reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
-	/>
+export const ContributorUserCommentMobile = ContributorUserCommentDesktop.bind(
+	{},
 );
 ContributorUserCommentMobile.storyName =
 	'with contributor and picked badges on mobile';
@@ -566,20 +441,8 @@ ContributorUserCommentMobile.decorators = [
 	),
 ];
 
-export const LoggedInAsModerator = () => (
-	<Comment
-		comment={commentData}
-		isClosedForComments={false}
-		setCommentBeingRepliedTo={() => {}}
-		user={staffUser}
-		isReply={false}
-		isMuted={false}
-		toggleMuteStatus={() => {}}
-		onPermalinkClick={() => {}}
-		pickError={''}
-		setPickError={() => {}}
-		reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
-	/>
+export const LoggedInAsModerator = (args: Props) => (
+	<Comment {...args} comment={commentData} user={staffUser} />
 );
 LoggedInAsModerator.storyName = 'Logged in as moderator';
 LoggedInAsModerator.decorators = [
@@ -594,20 +457,8 @@ LoggedInAsModerator.decorators = [
 	),
 ];
 
-export const LoggedInAsUser = () => (
-	<Comment
-		comment={commentData}
-		isClosedForComments={false}
-		setCommentBeingRepliedTo={() => {}}
-		user={user}
-		isReply={false}
-		isMuted={false}
-		toggleMuteStatus={() => {}}
-		onPermalinkClick={() => {}}
-		pickError={''}
-		setPickError={() => {}}
-		reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
-	/>
+export const LoggedInAsUser = (args: Props) => (
+	<Comment {...args} comment={commentData} user={user} />
 );
 LoggedInAsUser.storyName = 'Logged in as normal user';
 LoggedInAsUser.decorators = [
@@ -622,19 +473,8 @@ LoggedInAsUser.decorators = [
 	),
 ];
 
-export const BlockedComment = () => (
-	<Comment
-		comment={blockedCommentData}
-		isClosedForComments={false}
-		setCommentBeingRepliedTo={() => {}}
-		isReply={false}
-		isMuted={false}
-		toggleMuteStatus={() => {}}
-		onPermalinkClick={() => {}}
-		pickError={''}
-		setPickError={() => {}}
-		reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
-	/>
+export const BlockedComment = (args: Props) => (
+	<Comment {...args} comment={blockedCommentData} />
 );
 BlockedComment.storyName = 'Blocked comment';
 BlockedComment.decorators = [
@@ -649,19 +489,8 @@ BlockedComment.decorators = [
 	),
 ];
 
-export const MutedComment = () => (
-	<Comment
-		comment={blockedCommentData}
-		isClosedForComments={false}
-		setCommentBeingRepliedTo={() => {}}
-		isReply={false}
-		isMuted={true}
-		toggleMuteStatus={() => {}}
-		onPermalinkClick={() => {}}
-		pickError={''}
-		setPickError={() => {}}
-		reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
-	/>
+export const MutedComment = (args: Props) => (
+	<Comment {...args} comment={blockedCommentData} isMuted={true} />
 );
 MutedComment.storyName = 'Muted comment';
 MutedComment.decorators = [
@@ -676,19 +505,8 @@ MutedComment.decorators = [
 	),
 ];
 
-export const ClosedForComments = () => (
-	<Comment
-		comment={commentData}
-		isClosedForComments={true}
-		setCommentBeingRepliedTo={() => {}}
-		isReply={false}
-		isMuted={false}
-		toggleMuteStatus={() => {}}
-		onPermalinkClick={() => {}}
-		pickError={''}
-		setPickError={() => {}}
-		reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
-	/>
+export const ClosedForComments = (args: Props) => (
+	<Comment {...args} comment={commentData} isClosedForComments={true} />
 );
 ClosedForComments.storyName = 'A closed comment on desktop view';
 ClosedForComments.story = {

--- a/dotcom-rendering/src/components/Discussion/LoadingComments.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/LoadingComments.stories.tsx
@@ -1,8 +1,19 @@
+import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
+import { splitTheme } from '../../../.storybook/decorators/splitThemeDecorator';
 import { LoadingComments } from './LoadingComments';
 
 export default {
 	component: LoadingComments,
 	title: 'Discussion/LoadingComments',
+	decorators: [
+		splitTheme([
+			{
+				theme: Pillar.Opinion,
+				display: ArticleDisplay.Standard,
+				design: ArticleDesign.Comment,
+			},
+		]),
+	],
 };
 
 export const Default = () => <LoadingComments />;

--- a/dotcom-rendering/src/components/Discussion/LoadingComments.tsx
+++ b/dotcom-rendering/src/components/Discussion/LoadingComments.tsx
@@ -3,6 +3,7 @@ import { palette as sourcePalette, space } from '@guardian/source-foundations';
 import { Column } from './Column';
 import { Row } from './Row';
 
+/** @TODO adapt for dark mode */
 const BACKGROUND_COLOUR = sourcePalette.neutral[93];
 
 const shimmer = keyframes`

--- a/dotcom-rendering/src/components/Discussion/LoadingPicks.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/LoadingPicks.stories.tsx
@@ -1,6 +1,20 @@
+import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
+import { splitTheme } from '../../../.storybook/decorators/splitThemeDecorator';
 import { LoadingPicks } from './LoadingPicks';
 
-export default { component: LoadingPicks, title: 'Discussion/LoadingPicks' };
+export default {
+	component: LoadingPicks,
+	title: 'Discussion/LoadingPicks',
+	decorators: [
+		splitTheme([
+			{
+				theme: Pillar.Opinion,
+				display: ArticleDisplay.Standard,
+				design: ArticleDesign.Comment,
+			},
+		]),
+	],
+};
 
 export const Default = () => <LoadingPicks />;
 Default.storyName = 'default';

--- a/dotcom-rendering/src/components/Discussion/LoadingPicks.tsx
+++ b/dotcom-rendering/src/components/Discussion/LoadingPicks.tsx
@@ -2,6 +2,7 @@ import { css, keyframes } from '@emotion/react';
 import { palette as sourcePalette, space } from '@guardian/source-foundations';
 import { Row } from './Row';
 
+/** @TODO adapt for dark mode */
 const BACKGROUND_COLOUR = sourcePalette.neutral[93];
 
 const shimmer = keyframes`

--- a/dotcom-rendering/src/components/Discussion/Preview.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/Preview.stories.tsx
@@ -1,34 +1,49 @@
 import { css } from '@emotion/react';
+import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
+import { splitTheme } from '../../../.storybook/decorators/splitThemeDecorator';
 import { Preview } from './Preview';
 
-export default { component: Preview, title: 'Discussion/Preview' };
+export default {
+	component: Preview,
+	title: 'Discussion/Preview',
+	decorators: [
+		splitTheme([
+			{
+				theme: Pillar.Opinion,
+				display: ArticleDisplay.Standard,
+				design: ArticleDesign.Comment,
+			},
+		]),
+	],
+};
 
-export const PreviewStory = () => (
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
 	<div
 		css={css`
 			padding: 20px;
 			width: 700px;
 		`}
 	>
+		{children}
+	</div>
+);
+
+export const PreviewStory = () => (
+	<Wrapper>
 		<Preview
 			showSpout={true}
 			previewHtml="<p>This is some preview text</p>"
 		/>
-	</div>
+	</Wrapper>
 );
 PreviewStory.storyName = 'default';
 
 export const PreviewStoryLinebreaks = () => (
-	<div
-		css={css`
-			padding: 20px;
-			width: 700px;
-		`}
-	>
+	<Wrapper>
 		<Preview
 			showSpout={true}
 			previewHtml="<p>Hello world!<br>this is a line break </p> <p>this is two</p> <p><br>this is three</p>"
 		/>
-	</div>
+	</Wrapper>
 );
 PreviewStoryLinebreaks.storyName = 'Preview comment with linebreaks';

--- a/dotcom-rendering/src/components/Discussion/Preview.tsx
+++ b/dotcom-rendering/src/components/Discussion/Preview.tsx
@@ -10,6 +10,7 @@ type Props = {
 	showSpout: boolean;
 };
 
+/** @TODO adapt for dark mode */
 const previewStyle = css`
 	${textSans.small()}
 	padding: ${space[2]}px ${space[4]}px;

--- a/dotcom-rendering/src/components/Discussion/Timestamp.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/Timestamp.stories.tsx
@@ -1,45 +1,58 @@
+import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
+import { splitTheme } from '../../../.storybook/decorators/splitThemeDecorator';
 import { Timestamp } from './Timestamp';
 
-export default { component: Timestamp, title: 'Discussion/Timestamp' };
+type Props = Parameters<typeof Timestamp>[0];
+
+export default {
+	component: Timestamp,
+	title: 'Discussion/Timestamp',
+	argTypes: {
+		onPermalinkClick: { action: 'onPermalinkClick' },
+		webUrl: { text: '' },
+		commentId: { number: 123 },
+	},
+	decorators: [
+		splitTheme([
+			{
+				theme: Pillar.Opinion,
+				display: ArticleDisplay.Standard,
+				design: ArticleDesign.Comment,
+			},
+		]),
+	],
+};
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+	<div style={{ padding: '12px' }}>{children}</div>
+);
 
 // Date is mocked to "Fri March 27 2020 12:00:00 GMT+0000 (Greenwich Mean Time)" in config
 
-export const TwoMonths = () => (
-	<Timestamp
-		isoDateTime={'2021-10-31T14:22:39Z'}
-		webUrl=""
-		commentId={123}
-		onPermalinkClick={() => {}}
-	/>
+export const TwoMonths = (args: Props) => (
+	<Wrapper>
+		<Timestamp {...args} isoDateTime={'2021-10-31T14:22:39Z'} />
+	</Wrapper>
 );
 TwoMonths.storyName = 'Two months';
 
-export const OneHour = () => (
-	<Timestamp
-		isoDateTime={'2022-01-01T11:00:00Z'}
-		webUrl=""
-		commentId={123}
-		onPermalinkClick={() => {}}
-	/>
+export const OneHour = (args: Props) => (
+	<Wrapper>
+		<Timestamp {...args} isoDateTime={'2022-01-01T11:00:00Z'} />
+	</Wrapper>
 );
 OneHour.storyName = 'One Hour';
 
-export const TwentyThreeHours = () => (
-	<Timestamp
-		isoDateTime={'2021-12-31T13:00:00Z'}
-		webUrl=""
-		commentId={123}
-		onPermalinkClick={() => {}}
-	/>
+export const TwentyThreeHours = (args: Props) => (
+	<Wrapper>
+		<Timestamp {...args} isoDateTime={'2021-12-31T13:00:00Z'} />
+	</Wrapper>
 );
 TwentyThreeHours.storyName = 'Twenty three hours';
 
-export const TwentyFiveHours = () => (
-	<Timestamp
-		isoDateTime={'2021-12-31T11:00:00Z'}
-		webUrl=""
-		commentId={123}
-		onPermalinkClick={() => {}}
-	/>
+export const TwentyFiveHours = (args: Props) => (
+	<Wrapper>
+		<Timestamp {...args} isoDateTime={'2021-12-31T11:00:00Z'} />
+	</Wrapper>
 );
 TwentyFiveHours.storyName = 'Twenty five hours';


### PR DESCRIPTION
## What does this change?

- Adds split theme decorator to discussion components without it
- Uses [CSF](https://storybook.js.org/docs/api/csf) to provide sensible default values for some discussion stories 
- Adds `@todo` comments for dark mode issues that need addressing
- Updates `Avatar` story to have a non-placeholder image

## Why?

So that we can better understand how compatible discussion components are with dark mode.
Resolves #10444
