### PR TITLE
Add reportAbuse field to User

### DIFF
--- a/dotcom-rendering/src/components/Discussion.tsx
+++ b/dotcom-rendering/src/components/Discussion.tsx
@@ -4,7 +4,7 @@ import { palette, space } from '@guardian/source-foundations';
 import { Button, SvgPlus } from '@guardian/source-react-components';
 import { useEffect, useReducer } from 'react';
 import { assertUnreachable } from '../lib/assert-unreachable';
-import { getDiscussion } from '../lib/discussionApi';
+import { getDiscussion, type reportAbuse } from '../lib/discussionApi';
 import {
 	getCommentContext,
 	initFiltersFromLocalStorage,
@@ -28,6 +28,7 @@ export type Props = {
 	enableDiscussionSwitch: boolean;
 	user?: SignedInUser;
 	idApiUrl: string;
+	reportAbuseUnauthenticated: ReturnType<typeof reportAbuse>;
 };
 
 const overlayStyles = css`
@@ -348,6 +349,7 @@ export const Discussion = ({
 	enableDiscussionSwitch,
 	user,
 	idApiUrl,
+	reportAbuseUnauthenticated,
 }: Props) => {
 	const [
 		{
@@ -597,6 +599,11 @@ export const Discussion = ({
 					topForm={topForm}
 					replyForm={replyForm}
 					bottomForm={bottomForm}
+					reportAbuse={
+						user !== undefined
+							? user.reportAbuse
+							: reportAbuseUnauthenticated
+					}
 				/>
 				{!isExpanded && (
 					<div id="discussion-overlay" css={overlayStyles} />

--- a/dotcom-rendering/src/components/Discussion/AbuseReportForm.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/AbuseReportForm.stories.tsx
@@ -18,7 +18,7 @@ export const Dialog = () => (
 		<AbuseReportForm
 			toggleSetShowForm={() => {}}
 			commentId={123}
-			authStatus={undefined}
+			reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
 		/>
 	</div>
 );

--- a/dotcom-rendering/src/components/Discussion/AbuseReportForm.test.tsx
+++ b/dotcom-rendering/src/components/Discussion/AbuseReportForm.test.tsx
@@ -1,6 +1,7 @@
 import '@testing-library/jest-dom/extend-expect';
 import { fireEvent, render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { reportAbuse } from '../../lib/discussionApi';
 import { mockRESTCalls } from '../../lib/mockRESTCalls';
 import { AbuseReportForm } from './AbuseReportForm';
 
@@ -12,7 +13,7 @@ describe('Dropdown', () => {
 			<AbuseReportForm
 				toggleSetShowForm={() => undefined}
 				commentId={123}
-				authStatus={undefined}
+				reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
 			/>,
 		);
 
@@ -26,7 +27,7 @@ describe('Dropdown', () => {
 			<AbuseReportForm
 				toggleSetShowForm={() => undefined}
 				commentId={123}
-				authStatus={undefined}
+				reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
 			/>,
 		);
 
@@ -42,7 +43,7 @@ describe('Dropdown', () => {
 			<AbuseReportForm
 				toggleSetShowForm={() => undefined}
 				commentId={123}
-				authStatus={undefined}
+				reportAbuse={reportAbuse(undefined)}
 			/>,
 		);
 

--- a/dotcom-rendering/src/components/Discussion/AbuseReportForm.tsx
+++ b/dotcom-rendering/src/components/Discussion/AbuseReportForm.tsx
@@ -3,8 +3,7 @@ import { log } from '@guardian/libs';
 import { space, textSans } from '@guardian/source-foundations';
 import { Button, SvgCross } from '@guardian/source-react-components';
 import { useEffect, useRef, useState } from 'react';
-import { reportAbuse } from '../../lib/discussionApi';
-import type { SignedInWithCookies, SignedInWithOkta } from '../../lib/identity';
+import type { reportAbuse } from '../../lib/discussionApi';
 import { palette as schemedPalette } from '../../palette';
 
 type FormData = {
@@ -59,13 +58,13 @@ const errorMessageStyles = css`
 type Props = {
 	commentId: number;
 	toggleSetShowForm: () => void;
-	authStatus?: SignedInWithCookies | SignedInWithOkta;
+	reportAbuse: ReturnType<typeof reportAbuse>;
 };
 
 export const AbuseReportForm = ({
 	commentId,
 	toggleSetShowForm,
-	authStatus,
+	reportAbuse,
 }: Props) => {
 	const modalRef = useRef<HTMLDivElement>(null);
 	// TODO: use ref once forwardRef is implemented @guardian/src-button
@@ -164,7 +163,6 @@ export const AbuseReportForm = ({
 			reason,
 			email,
 			commentId,
-			authStatus,
 		})
 			.then((response) => {
 				if (response.kind === 'error') {

--- a/dotcom-rendering/src/components/Discussion/Comment.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comment.stories.tsx
@@ -129,7 +129,7 @@ const user: Reader = {
 	onReply: () => Promise.resolve(commentResponseError),
 	onRecommend: () => Promise.resolve(true),
 	addUsername: () => Promise.resolve({ kind: 'ok', value: true }),
-	authStatus: { kind: 'SignedInWithCookies' },
+	reportAbuse: () => Promise.resolve({ kind: 'ok', value: true }),
 };
 
 const staffUser: Staff = {
@@ -154,7 +154,7 @@ const staffUser: Staff = {
 	addUsername: () => Promise.resolve({ kind: 'ok', value: true }),
 	onPick: () => Promise.resolve(commentResponseError),
 	onUnpick: () => Promise.resolve(commentResponseError),
-	authStatus: { kind: 'SignedInWithCookies' },
+	reportAbuse: () => Promise.resolve({ kind: 'ok', value: true }),
 };
 
 const defaultFormat = {
@@ -174,6 +174,7 @@ export const Root = () => (
 		onPermalinkClick={() => {}}
 		error={''}
 		setError={() => {}}
+		reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
 	/>
 );
 Root.storyName = 'A root comment on desktop view';
@@ -196,6 +197,7 @@ export const RootMobile = () => (
 		onPermalinkClick={() => {}}
 		error={''}
 		setError={() => {}}
+		reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
 	/>
 );
 RootMobile.storyName = 'A root comment on mobile view';
@@ -228,6 +230,7 @@ export const ReplyComment = () => (
 		onPermalinkClick={() => {}}
 		error={''}
 		setError={() => {}}
+		reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
 	/>
 );
 ReplyComment.storyName = 'A reply on desktop view';
@@ -260,6 +263,7 @@ export const MobileReply = () => (
 		onPermalinkClick={() => {}}
 		error={''}
 		setError={() => {}}
+		reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
 	/>
 );
 MobileReply.storyName = 'A reply on mobile view';
@@ -292,6 +296,7 @@ export const LongMobileReply = () => (
 		onPermalinkClick={() => {}}
 		error={''}
 		setError={() => {}}
+		reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
 	/>
 );
 LongMobileReply.storyName = 'A long username reply on mobile view';
@@ -324,6 +329,7 @@ export const LongBothMobileReply = () => (
 		onPermalinkClick={() => {}}
 		error={''}
 		setError={() => {}}
+		reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
 	/>
 );
 LongBothMobileReply.storyName = 'Both long usernames replying on mobile view';
@@ -359,6 +365,7 @@ export const PickedComment = () => (
 		onPermalinkClick={() => {}}
 		error={''}
 		setError={() => {}}
+		reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
 	/>
 );
 PickedComment.storyName = 'Picked Comment';
@@ -385,6 +392,7 @@ export const StaffUserComment = () => (
 		onPermalinkClick={() => {}}
 		error={''}
 		setError={() => {}}
+		reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
 	/>
 );
 StaffUserComment.storyName = 'Staff User Comment';
@@ -411,6 +419,7 @@ export const ContributorUserComment = () => (
 		onPermalinkClick={() => {}}
 		error={''}
 		setError={() => {}}
+		reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
 	/>
 );
 ContributorUserComment.storyName = 'Contributor User Comment';
@@ -440,6 +449,7 @@ export const PickedStaffUserComment = () => (
 		onPermalinkClick={() => {}}
 		error={''}
 		setError={() => {}}
+		reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
 	/>
 );
 PickedStaffUserComment.storyName = 'with staff and picked badges on desktop';
@@ -467,6 +477,7 @@ export const PickedStaffUserCommentMobile = () => (
 		onPermalinkClick={() => {}}
 		error={''}
 		setError={() => {}}
+		reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
 	/>
 );
 PickedStaffUserCommentMobile.storyName =
@@ -503,6 +514,7 @@ export const ContributorUserCommentDesktop = () => (
 		onPermalinkClick={() => {}}
 		error={''}
 		setError={() => {}}
+		reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
 	/>
 );
 ContributorUserCommentDesktop.storyName =
@@ -531,6 +543,7 @@ export const ContributorUserCommentMobile = () => (
 		onPermalinkClick={() => {}}
 		error={''}
 		setError={() => {}}
+		reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
 	/>
 );
 ContributorUserCommentMobile.storyName =
@@ -565,6 +578,7 @@ export const LoggedInAsModerator = () => (
 		onPermalinkClick={() => {}}
 		error={''}
 		setError={() => {}}
+		reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
 	/>
 );
 LoggedInAsModerator.storyName = 'Logged in as moderator';
@@ -592,6 +606,7 @@ export const LoggedInAsUser = () => (
 		onPermalinkClick={() => {}}
 		error={''}
 		setError={() => {}}
+		reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
 	/>
 );
 LoggedInAsUser.storyName = 'Logged in as normal user';
@@ -618,6 +633,7 @@ export const BlockedComment = () => (
 		onPermalinkClick={() => {}}
 		error={''}
 		setError={() => {}}
+		reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
 	/>
 );
 BlockedComment.storyName = 'Blocked comment';
@@ -644,6 +660,7 @@ export const MutedComment = () => (
 		onPermalinkClick={() => {}}
 		error={''}
 		setError={() => {}}
+		reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
 	/>
 );
 MutedComment.storyName = 'Muted comment';
@@ -670,6 +687,7 @@ export const ClosedForComments = () => (
 		onPermalinkClick={() => {}}
 		error={''}
 		setError={() => {}}
+		reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
 	/>
 );
 ClosedForComments.storyName = 'A closed comment on desktop view';

--- a/dotcom-rendering/src/components/Discussion/Comment.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comment.tsx
@@ -9,6 +9,7 @@ import {
 } from '@guardian/source-foundations';
 import { Button, Link, SvgIndent } from '@guardian/source-react-components';
 import { useState } from 'react';
+import type { reportAbuse } from '../../lib/discussionApi';
 import { createAuthenticationEventParams } from '../../lib/identity-component-event';
 import { palette as schemedPalette } from '../../palette';
 import type { CommentType, SignedInUser, Staff } from '../../types/discussion';
@@ -32,6 +33,7 @@ type Props = {
 	onPermalinkClick: (commentId: number) => void;
 	error: string;
 	setError: (error: string) => void;
+	reportAbuse: ReturnType<typeof reportAbuse>;
 };
 
 const commentControlsLink = css`
@@ -302,6 +304,7 @@ export const Comment = ({
 	onPermalinkClick,
 	error,
 	setError,
+	reportAbuse,
 }: Props) => {
 	const [isHighlighted, setIsHighlighted] = useState<boolean>(
 		comment.isHighlighted,
@@ -780,7 +783,7 @@ export const Comment = ({
 													toggleSetShowForm
 												}
 												commentId={comment.id}
-												authStatus={user?.authStatus}
+												reportAbuse={reportAbuse}
 											/>
 										</div>
 									)}

--- a/dotcom-rendering/src/components/Discussion/CommentContainer.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentContainer.stories.tsx
@@ -158,7 +158,7 @@ const aUser: Reader = {
 	onReply: () => Promise.resolve(commentResponseError),
 	onRecommend: () => Promise.resolve(true),
 	addUsername: () => Promise.resolve({ kind: 'ok', value: true }),
-	authStatus: { kind: 'SignedInWithCookies' },
+	reportAbuse: () => Promise.resolve({ kind: 'ok', value: true }),
 };
 
 const commentDataThreaded: CommentType = {
@@ -211,6 +211,7 @@ export const defaultStory = () => (
 		setPreviewBody={() => {}}
 		body={''}
 		setBody={() => {}}
+		reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
 	/>
 );
 defaultStory.storyName = 'default';
@@ -249,6 +250,7 @@ export const threadedComment = () => (
 		setPreviewBody={() => {}}
 		body={''}
 		setBody={() => {}}
+		reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
 	/>
 );
 threadedComment.storyName = 'threaded';
@@ -287,6 +289,7 @@ export const threadedCommentWithShowMore = () => (
 		setPreviewBody={() => {}}
 		body={''}
 		setBody={() => {}}
+		reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
 	/>
 );
 threadedCommentWithShowMore.storyName = 'threaded with show more button';
@@ -325,6 +328,7 @@ export const threadedCommentWithLongUsernames = () => (
 		setPreviewBody={() => {}}
 		body={''}
 		setBody={() => {}}
+		reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
 	/>
 );
 threadedCommentWithLongUsernames.storyName = 'threaded with long usernames';
@@ -363,6 +367,7 @@ export const threadedCommentWithLongUsernamesMobile = () => (
 		setPreviewBody={() => {}}
 		body={''}
 		setBody={() => {}}
+		reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
 	/>
 );
 threadedCommentWithLongUsernamesMobile.storyName =

--- a/dotcom-rendering/src/components/Discussion/CommentContainer.test.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentContainer.test.tsx
@@ -50,7 +50,7 @@ const aUser: SignedInUser = {
 	onReply: () => Promise.resolve(commentResponseSuccess),
 	onRecommend: () => Promise.resolve(true),
 	addUsername: () => Promise.resolve({ kind: 'ok', value: true }),
-	authStatus: { kind: 'SignedInWithCookies' },
+	reportAbuse: () => Promise.resolve({ kind: 'ok', value: true }),
 };
 
 describe('CommentContainer', () => {
@@ -93,6 +93,7 @@ describe('CommentContainer', () => {
 				setPreviewBody={() => {}}
 				body={newCommentText}
 				setBody={() => {}}
+				reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
 			/>,
 		);
 
@@ -142,6 +143,7 @@ describe('CommentContainer', () => {
 				setPreviewBody={() => {}}
 				body={''}
 				setBody={() => {}}
+				reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
 			/>,
 		);
 
@@ -190,6 +192,7 @@ describe('CommentContainer', () => {
 				setPreviewBody={() => {}}
 				body={newCommentText}
 				setBody={() => {}}
+				reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
 			/>,
 		);
 
@@ -239,6 +242,7 @@ describe('CommentContainer', () => {
 				setPreviewBody={() => {}}
 				body={''}
 				setBody={() => {}}
+				reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
 			/>,
 		);
 

--- a/dotcom-rendering/src/components/Discussion/CommentContainer.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentContainer.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/react';
 import { palette as sourcePalette, space } from '@guardian/source-foundations';
 import { SvgPlus } from '@guardian/source-react-components';
 import { useEffect, useState } from 'react';
-import type { preview } from '../../lib/discussionApi';
+import type { preview, reportAbuse } from '../../lib/discussionApi';
 import { getMoreResponses } from '../../lib/discussionApi';
 import type {
 	CommentType,
@@ -39,6 +39,7 @@ type Props = {
 	setPreviewBody: (previewBody: string) => void;
 	body: string;
 	setBody: (body: string) => void;
+	reportAbuse: ReturnType<typeof reportAbuse>;
 };
 
 const nestingStyles = css`
@@ -99,6 +100,7 @@ export const CommentContainer = ({
 	setPreviewBody,
 	body,
 	setBody,
+	reportAbuse,
 }: Props) => {
 	// Filter logic
 	const [expanded, setExpanded] = useState<boolean>(threads === 'expanded');
@@ -153,6 +155,7 @@ export const CommentContainer = ({
 				onPermalinkClick={onPermalinkClick}
 				error={error}
 				setError={setError}
+				reportAbuse={reportAbuse}
 			/>
 
 			<>
@@ -182,6 +185,7 @@ export const CommentContainer = ({
 										onPermalinkClick={onPermalinkClick}
 										error={error}
 										setError={setError}
+										reportAbuse={reportAbuse}
 									/>
 								</li>
 							))}

--- a/dotcom-rendering/src/components/Discussion/CommentForm.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentForm.stories.tsx
@@ -39,7 +39,7 @@ const aUser: Reader = {
 	onReply: () => Promise.resolve(commentResponseError),
 	onRecommend: () => Promise.resolve(true),
 	addUsername: () => Promise.resolve({ kind: 'ok', value: true }),
-	authStatus: { kind: 'SignedInWithCookies' },
+	reportAbuse: () => Promise.resolve({ kind: 'ok', value: true }),
 };
 
 const aComment: CommentType = {

--- a/dotcom-rendering/src/components/Discussion/Comments.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comments.stories.tsx
@@ -36,7 +36,7 @@ const aUser: Reader = {
 	onReply: () => Promise.resolve(commentResponseError),
 	onRecommend: () => Promise.resolve(true),
 	addUsername: () => Promise.resolve({ kind: 'ok', value: true }),
-	authStatus: { kind: 'SignedInWithCookies' },
+	reportAbuse: () => Promise.resolve({ kind: 'ok', value: true }),
 };
 
 const format = {
@@ -106,6 +106,7 @@ export const LoggedOutHiddenPicks = () => (
 			topForm={defaultCommentForm}
 			replyForm={defaultCommentForm}
 			bottomForm={defaultCommentForm}
+			reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
 		/>
 	</div>
 );
@@ -166,6 +167,7 @@ export const InitialPage = () => (
 			topForm={defaultCommentForm}
 			replyForm={defaultCommentForm}
 			bottomForm={defaultCommentForm}
+			reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
 		/>
 	</div>
 );
@@ -231,6 +233,7 @@ export const LoggedInHiddenNoPicks = () => {
 				topForm={defaultCommentForm}
 				replyForm={{ ...defaultCommentForm, isActive, body }}
 				bottomForm={defaultCommentForm}
+				reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
 			/>
 		</div>
 	);
@@ -307,6 +310,7 @@ export const LoggedIn = () => {
 					isActive: isBottomFormActive,
 					body: bottomFormBody,
 				}}
+				reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
 			/>
 		</div>
 	);
@@ -376,6 +380,7 @@ export const LoggedInShortDiscussion = () => {
 					body: replyFormBody,
 				}}
 				bottomForm={defaultCommentForm}
+				reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
 			/>
 		</div>
 	);
@@ -429,6 +434,7 @@ export const LoggedOutHiddenNoPicks = () => (
 			topForm={defaultCommentForm}
 			replyForm={defaultCommentForm}
 			bottomForm={defaultCommentForm}
+			reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
 		/>
 	</div>
 );
@@ -491,6 +497,7 @@ export const Closed = () => (
 			topForm={defaultCommentForm}
 			replyForm={defaultCommentForm}
 			bottomForm={defaultCommentForm}
+			reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
 		/>
 	</div>
 );
@@ -549,6 +556,7 @@ export const NoComments = () => (
 			topForm={defaultCommentForm}
 			replyForm={defaultCommentForm}
 			bottomForm={defaultCommentForm}
+			reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
 		/>
 	</div>
 );
@@ -609,6 +617,7 @@ export const LegacyDiscussion = () => (
 			topForm={defaultCommentForm}
 			replyForm={defaultCommentForm}
 			bottomForm={defaultCommentForm}
+			reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
 		/>
 	</div>
 );

--- a/dotcom-rendering/src/components/Discussion/Comments.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comments.tsx
@@ -6,7 +6,7 @@ import {
 	textSans,
 } from '@guardian/source-foundations';
 import { useEffect, useState } from 'react';
-import type { preview } from '../../lib/discussionApi';
+import type { preview, reportAbuse } from '../../lib/discussionApi';
 import { getPicks, initialiseApi } from '../../lib/discussionApi';
 import type {
 	AdditionalHeadersType,
@@ -61,6 +61,7 @@ type Props = {
 	topForm: Form;
 	replyForm: Form;
 	bottomForm: Form;
+	reportAbuse: ReturnType<typeof reportAbuse>;
 };
 
 /**
@@ -166,6 +167,7 @@ export const Comments = ({
 	topForm,
 	replyForm,
 	bottomForm,
+	reportAbuse,
 }: Props) => {
 	const [picks, setPicks] = useState<CommentType[]>([]);
 	const [commentBeingRepliedTo, setCommentBeingRepliedTo] =
@@ -350,6 +352,7 @@ export const Comments = ({
 											}
 											body={replyForm.body}
 											setBody={setReplyFormBody}
+											reportAbuse={reportAbuse}
 										/>
 									</li>
 								))}
@@ -441,6 +444,7 @@ export const Comments = ({
 									setPreviewBody={setReplyFormPreviewBody}
 									body={replyForm.body}
 									setBody={setReplyFormBody}
+									reportAbuse={reportAbuse}
 								/>
 							</li>
 						))}

--- a/dotcom-rendering/src/components/Discussion/Discussion.test.tsx
+++ b/dotcom-rendering/src/components/Discussion/Discussion.test.tsx
@@ -20,6 +20,9 @@ describe('App', () => {
 				discussionApiClientHeader="testClientHeader"
 				enableDiscussionSwitch={true}
 				idApiUrl="https://idapi.theguardian.com"
+				reportAbuseUnauthenticated={() =>
+					Promise.resolve({ kind: 'ok', value: true })
+				}
 			/>,
 		);
 

--- a/dotcom-rendering/src/components/Discussion/RecommendationCount.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/RecommendationCount.stories.tsx
@@ -31,7 +31,7 @@ const aUser = {
 	onReply: () => Promise.resolve(commentResponseError),
 	onRecommend: () => Promise.resolve(true),
 	addUsername: () => Promise.resolve({ kind: 'ok', value: true }),
-	authStatus: { kind: 'SignedInWithCookies' },
+	reportAbuse: () => Promise.resolve({ kind: 'ok', value: true }),
 } satisfies SignedInUser;
 
 const Wrapper = ({ children }: { children: React.ReactNode }) => (

--- a/dotcom-rendering/src/components/Discussion/TopPick.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/TopPick.stories.tsx
@@ -102,7 +102,7 @@ const aUser = {
 	onReply: () => Promise.resolve(commentResponseError),
 	onRecommend: () => Promise.resolve(true),
 	addUsername: () => Promise.resolve({ kind: 'ok', value: true }),
-	authStatus: { kind: 'SignedInWithCookies' },
+	reportAbuse: () => Promise.resolve({ kind: 'ok', value: true }),
 } satisfies SignedInUser;
 
 export const LongPick = () => (

--- a/dotcom-rendering/src/components/Discussion/TopPicks.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/TopPicks.stories.tsx
@@ -81,7 +81,7 @@ const aUser = {
 	onReply: () => Promise.resolve(commentResponseError),
 	onRecommend: () => Promise.resolve(true),
 	addUsername: () => Promise.resolve({ kind: 'ok', value: true }),
-	authStatus: { kind: 'SignedInWithCookies' },
+	reportAbuse: () => Promise.resolve({ kind: 'ok', value: true }),
 } satisfies SignedInUser;
 
 export const SingleComment = () => (

--- a/dotcom-rendering/src/components/DiscussionContainer.importable.tsx
+++ b/dotcom-rendering/src/components/DiscussionContainer.importable.tsx
@@ -6,6 +6,7 @@ import {
 	pickComment,
 	recommend,
 	reply,
+	reportAbuse,
 	unPickComment,
 } from '../lib/discussionApi';
 import type { SignedInWithCookies, SignedInWithOkta } from '../lib/identity';
@@ -48,7 +49,7 @@ const getUser = async ({
 				onPick: pickComment(authStatus),
 				onUnpick: unPickComment(authStatus),
 				addUsername: addUserName(authStatus),
-				authStatus,
+				reportAbuse: reportAbuse(authStatus),
 		  }
 		: {
 				kind: 'Reader',
@@ -57,7 +58,7 @@ const getUser = async ({
 				onReply: reply(authStatus),
 				onRecommend: recommend(authStatus),
 				addUsername: addUserName(authStatus),
-				authStatus,
+				reportAbuse: reportAbuse(authStatus),
 		  };
 };
 
@@ -84,7 +85,9 @@ const getUser = async ({
  *
  * (No visual story exist)
  */
-export const DiscussionContainer = (props: Omit<DiscussionProps, 'user'>) => {
+export const DiscussionContainer = (
+	props: Omit<DiscussionProps, 'user' | 'reportAbuseUnauthenticated'>,
+) => {
 	const hydrated = useHydrated();
 	const authStatus = useAuthStatus();
 	const [user, setUser] = useState<SignedInUser>();
@@ -103,5 +106,11 @@ export const DiscussionContainer = (props: Omit<DiscussionProps, 'user'>) => {
 
 	if (!hydrated) return <Placeholder height={324} />;
 
-	return <Discussion user={user} {...props} />;
+	return (
+		<Discussion
+			user={user}
+			{...props}
+			reportAbuseUnauthenticated={reportAbuse(undefined)}
+		/>
+	);
 };

--- a/dotcom-rendering/src/lib/discussionApi.tsx
+++ b/dotcom-rendering/src/lib/discussionApi.tsx
@@ -250,56 +250,56 @@ export const getPicks = async (
 	return { kind: 'ok', value: result.output.discussion.comments };
 };
 
-export const reportAbuse = async ({
-	commentId,
-	categoryId,
-	email,
-	reason,
-	authStatus,
-}: {
-	commentId: number;
-	categoryId: number;
-	reason?: string;
-	email?: string;
-	authStatus?: SignedInWithCookies | SignedInWithOkta;
-}): Promise<Result<string, true>> => {
-	const url =
-		joinUrl(
-			options.baseUrl,
-			'comment',
-			commentId.toString(),
-			'reportAbuse',
-		) + objAsParams(defaultParams);
+export const reportAbuse =
+	(authStatus?: SignedInWithCookies | SignedInWithOkta) =>
+	async ({
+		commentId,
+		categoryId,
+		email,
+		reason,
+	}: {
+		commentId: number;
+		categoryId: number;
+		reason?: string;
+		email?: string;
+	}): Promise<Result<string, true>> => {
+		const url =
+			joinUrl(
+				options.baseUrl,
+				'comment',
+				commentId.toString(),
+				'reportAbuse',
+			) + objAsParams(defaultParams);
 
-	const data = new URLSearchParams();
-	data.append('categoryId', categoryId.toString());
-	email && data.append('email', email.toString());
-	reason && data.append('reason', reason);
+		const data = new URLSearchParams();
+		data.append('categoryId', categoryId.toString());
+		email && data.append('email', email.toString());
+		reason && data.append('reason', reason);
 
-	const authOptions = authStatus
-		? getOptionsHeadersWithOkta(authStatus)
-		: undefined;
+		const authOptions = authStatus
+			? getOptionsHeadersWithOkta(authStatus)
+			: undefined;
 
-	const jsonResult = await fetchJSON(url, {
-		method: 'POST',
-		body: data.toString(),
-		headers: {
-			'Content-Type': 'application/x-www-form-urlencoded',
-			...options.headers,
-			...authOptions?.headers,
-		},
-		credentials: authOptions?.credentials,
-	});
+		const jsonResult = await fetchJSON(url, {
+			method: 'POST',
+			body: data.toString(),
+			headers: {
+				'Content-Type': 'application/x-www-form-urlencoded',
+				...options.headers,
+				...authOptions?.headers,
+			},
+			credentials: authOptions?.credentials,
+		});
 
-	if (jsonResult.kind === 'error') {
-		return {
-			kind: 'error',
-			error: 'An unknown error occured',
-		};
-	}
+		if (jsonResult.kind === 'error') {
+			return {
+				kind: 'error',
+				error: 'An unknown error occured',
+			};
+		}
 
-	return parseAbuseResponse(jsonResult.value);
-};
+		return parseAbuseResponse(jsonResult.value);
+	};
 
 export const recommend =
 	(authStatus: SignedInWithCookies | SignedInWithOkta) =>

--- a/dotcom-rendering/src/types/discussion.ts
+++ b/dotcom-rendering/src/types/discussion.ts
@@ -22,11 +22,11 @@ import type {
 	recommend as onRecommend,
 	reply as onReply,
 	pickComment,
+	reportAbuse,
 	unPickComment,
 } from '../lib/discussionApi';
 import type { Guard } from '../lib/guard';
 import { guard } from '../lib/guard';
-import type { SignedInWithCookies, SignedInWithOkta } from '../lib/identity';
 import type { Result } from '../lib/result';
 
 export type CAPIPillar =
@@ -296,7 +296,7 @@ type UserFields = {
 	onReply: ReturnType<typeof onReply>;
 	onRecommend: ReturnType<typeof onRecommend>;
 	addUsername: ReturnType<typeof addUserName>;
-	authStatus: SignedInWithCookies | SignedInWithOkta;
+	reportAbuse: ReturnType<typeof reportAbuse>;
 };
 
 export type Reader = UserFields & {


### PR DESCRIPTION
Recommend reviewing with "Hide whitespace"

Co-authored-by: Jamie B <53781962+JamieB-gu@users.noreply.github.com>
Co-authored-by: George B <705427+georgeblahblah@users.noreply.github.com>

## What does this change?
* Removes `authStatus` field from `User`
* Adds `reportAbuse` field to `User`
* Adds a `reportAbuseUnauthenticated` function as a separate callback when the user is not signed in.

## Why?
* We want to inject side-effect for dependencies from the top of the tree because this make it easier to manage
* This makes it easier to swap side-effects between app and web
* We removed authStatus because it's only available on web, so `Discussion` should not know about it, it should be handled at the level where we're swapping between app and web.


<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
