### PR TITLE
Unify Android check with custom hook

### DIFF
--- a/dotcom-rendering/src/components/Carousel.importable.tsx
+++ b/dotcom-rendering/src/components/Carousel.importable.tsx
@@ -12,6 +12,7 @@ import { useEffect, useRef, useState } from 'react';
 import { formatAttrString } from '../lib/formatAttrString';
 import { getSourceImageUrl } from '../lib/getSourceImageUrl_temp_fix';
 import { getZIndex } from '../lib/getZIndex';
+import { useIsAndroid } from '../lib/useIsAndroid';
 import { palette as themePalette } from '../palette';
 import type { Branding } from '../types/branding';
 import type {
@@ -782,13 +783,12 @@ export const Carousel = ({
 	...props
 }: ArticleProps | FrontProps) => {
 	const { renderingTarget } = useConfig();
-	const isApps = renderingTarget === 'Apps';
 
 	const carouselRef = useRef<HTMLUListElement>(null);
 
 	const [index, setIndex] = useState(0);
 	const [maxIndex, setMaxIndex] = useState(0);
-	const [isAndroid, setIsAndroid] = useState(false);
+	const isAndroid = useIsAndroid(renderingTarget);
 
 	const arrowName = 'carousel-small-arrow';
 
@@ -897,12 +897,7 @@ export const Carousel = ({
 	// when index changes and compare it against the prior maxIndex only.
 	useEffect(() => setMaxIndex((m) => Math.max(index, m)), [index]);
 
-	useEffect(
-		() => setIsAndroid(() => /android/i.test(window.navigator.userAgent)),
-		[],
-	);
-
-	if (isApps && isAndroid) {
+	if (isAndroid) {
 		return null;
 	}
 

--- a/dotcom-rendering/src/components/Carousel.importable.tsx
+++ b/dotcom-rendering/src/components/Carousel.importable.tsx
@@ -26,7 +26,6 @@ import type { TrailType } from '../types/trails';
 import { Card } from './Card/Card';
 import { LI } from './Card/components/LI';
 import type { Loading } from './CardPicture';
-import { useConfig } from './ConfigContext';
 import { ContainerOverrides } from './ContainerOverrides';
 import { FormatBoundary } from './FormatBoundary';
 import { Hide } from './Hide';
@@ -782,13 +781,11 @@ export const Carousel = ({
 	isOnwardContent = true,
 	...props
 }: ArticleProps | FrontProps) => {
-	const { renderingTarget } = useConfig();
-
 	const carouselRef = useRef<HTMLUListElement>(null);
 
 	const [index, setIndex] = useState(0);
 	const [maxIndex, setMaxIndex] = useState(0);
-	const isAndroid = useIsAndroid(renderingTarget);
+	const isAndroid = useIsAndroid();
 
 	const arrowName = 'carousel-small-arrow';
 

--- a/dotcom-rendering/src/components/Island.test.tsx
+++ b/dotcom-rendering/src/components/Island.test.tsx
@@ -153,27 +153,31 @@ describe('Island: server-side rendering', () => {
 	test('OnwardsUpper', () => {
 		expect(() =>
 			renderToString(
-				<OnwardsUpper
-					contentType=""
-					tags={[]}
-					isPaidContent={false}
-					pageId=""
-					keywordIds=""
-					ajaxUrl=""
-					hasRelated={true}
-					hasStoryPackage={true}
-					isAdFreeUser={false}
-					showRelatedContent={true}
-					format={{
-						theme: Pillar.News,
-						design: ArticleDesign.Standard,
-						display: ArticleDisplay.Standard,
-					}}
-					pillar={Pillar.News}
-					editionId="UK"
-					shortUrlId=""
-					discussionApiUrl=""
-				/>,
+				<ConfigProvider
+					value={{ renderingTarget: 'Web', darkModeAvailable: false }}
+				>
+					<OnwardsUpper
+						contentType=""
+						tags={[]}
+						isPaidContent={false}
+						pageId=""
+						keywordIds=""
+						ajaxUrl=""
+						hasRelated={true}
+						hasStoryPackage={true}
+						isAdFreeUser={false}
+						showRelatedContent={true}
+						format={{
+							theme: Pillar.News,
+							design: ArticleDesign.Standard,
+							display: ArticleDisplay.Standard,
+						}}
+						pillar={Pillar.News}
+						editionId="UK"
+						shortUrlId=""
+						discussionApiUrl=""
+					/>
+				</ConfigProvider>,
 			),
 		).not.toThrow();
 	});

--- a/dotcom-rendering/src/components/OnwardsUpper.importable.tsx
+++ b/dotcom-rendering/src/components/OnwardsUpper.importable.tsx
@@ -6,7 +6,6 @@ import { useIsAndroid } from '../lib/useIsAndroid';
 import { palette } from '../palette';
 import type { OnwardsSource } from '../types/onwards';
 import type { TagType } from '../types/tag';
-import { useConfig } from './ConfigContext';
 import { FetchOnwardsData } from './FetchOnwardsData.importable';
 import { Placeholder } from './Placeholder';
 import { Section } from './Section';
@@ -210,8 +209,7 @@ export const OnwardsUpper = ({
 	shortUrlId,
 	discussionApiUrl,
 }: Props) => {
-	const { renderingTarget } = useConfig();
-	const isAndroid = useIsAndroid(renderingTarget);
+	const isAndroid = useIsAndroid();
 
 	const hydrated = useHydrated();
 	if (isAndroid) return null;

--- a/dotcom-rendering/src/components/OnwardsUpper.importable.tsx
+++ b/dotcom-rendering/src/components/OnwardsUpper.importable.tsx
@@ -2,9 +2,11 @@ import { css } from '@emotion/react';
 import { joinUrl, Pillar } from '@guardian/libs';
 import type { EditionId } from '../lib/edition';
 import { useHydrated } from '../lib/useHydrated';
+import { useIsAndroid } from '../lib/useIsAndroid';
 import { palette } from '../palette';
 import type { OnwardsSource } from '../types/onwards';
 import type { TagType } from '../types/tag';
+import { useConfig } from './ConfigContext';
 import { FetchOnwardsData } from './FetchOnwardsData.importable';
 import { Placeholder } from './Placeholder';
 import { Section } from './Section';
@@ -208,7 +210,11 @@ export const OnwardsUpper = ({
 	shortUrlId,
 	discussionApiUrl,
 }: Props) => {
+	const { renderingTarget } = useConfig();
+	const isAndroid = useIsAndroid(renderingTarget);
+
 	const hydrated = useHydrated();
+	if (isAndroid) return null;
 	if (!hydrated) return <Placeholder height={600} />;
 
 	// Related content can be a collection of articles based on

--- a/dotcom-rendering/src/lib/useIsAndroid.ts
+++ b/dotcom-rendering/src/lib/useIsAndroid.ts
@@ -1,14 +1,14 @@
 import { useEffect, useState } from 'react';
-import type { RenderingTarget } from '../types/renderingTarget';
+import { useConfig } from '../components/ConfigContext';
 
 /**
  * @deprecated this is a temporary solution to handle the fact
  * that horizontal scrolling is broken in the android app for
  * web views
  */
-export const useIsAndroid = (
-	renderingTarget: RenderingTarget,
-): boolean | undefined => {
+export const useIsAndroid = (): boolean | undefined => {
+	const { renderingTarget } = useConfig();
+
 	const [isAndroid, setIsAndroid] = useState<boolean | undefined>(
 		renderingTarget === 'Web' ? false : undefined,
 	);

--- a/dotcom-rendering/src/lib/useIsAndroid.ts
+++ b/dotcom-rendering/src/lib/useIsAndroid.ts
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react';
+import type { RenderingTarget } from '../types/renderingTarget';
+
+/**
+ * @deprecated this is a temporary solution to handle the fact
+ * that horizontal scrolling is broken in the android app for
+ * web views
+ */
+export const useIsAndroid = (
+	renderingTarget: RenderingTarget,
+): boolean | undefined => {
+	const [isAndroid, setIsAndroid] = useState<boolean | undefined>(
+		renderingTarget === 'Web' ? false : undefined,
+	);
+
+	useEffect(() => {
+		if (renderingTarget === 'Web') {
+			return setIsAndroid(false);
+		}
+		setIsAndroid(() => /android/i.test(window.navigator.userAgent));
+	}, [renderingTarget]);
+
+	return isAndroid;
+};


### PR DESCRIPTION
## What does this change?

Add a useIsAndroid custom hook, which is marked as deprecated to indicate that this is a temporary fix

## Why?

We want to prevent showing the `Carousel`, but also any of its parents, if inside a WebView on the Android rendered by for DCAR.

Follow-up on:
- #9714
- #9780

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/76776/5f67cd67-09c6-45b5-908a-3e5dd7779d12
[after]: https://github.com/guardian/dotcom-rendering/assets/76776/d420df97-5eb3-4636-bb76-3c2f7c8e88f7