### PR TITLE
Reduce set active and user missing actions in reducer

### DIFF
--- a/dotcom-rendering/src/components/Discussion.tsx
+++ b/dotcom-rendering/src/components/Discussion.tsx
@@ -12,6 +12,7 @@ import {
 import { palette as themePalette } from '../palette';
 import type {
 	CommentForm,
+	CommentFormId,
 	CommentType,
 	FilterOptions,
 	SignedInUser,
@@ -147,7 +148,7 @@ type Action =
 	| {
 			type: 'setFormActive';
 			isActive: boolean;
-			formId: 'top' | 'reply' | 'bottom';
+			formId: CommentFormId;
 	  }
 	| { type: 'setTopFormUserMissing'; userNameMissing: boolean }
 	| { type: 'setReplyFormUserMissing'; userNameMissing: boolean }

--- a/dotcom-rendering/src/components/Discussion.tsx
+++ b/dotcom-rendering/src/components/Discussion.tsx
@@ -150,9 +150,11 @@ type Action =
 			isActive: boolean;
 			formId: CommentFormId;
 	  }
-	| { type: 'setTopFormUserMissing'; userNameMissing: boolean }
-	| { type: 'setReplyFormUserMissing'; userNameMissing: boolean }
-	| { type: 'setBottomFormUserMissing'; userNameMissing: boolean }
+	| {
+	type: 'setUserNameMissing';
+	userNameMissing: boolean;
+	formId: CommentFormId;
+		}
 	| { type: 'setTopFormError'; error: string }
 	| { type: 'setReplyFormError'; error: string }
 	| { type: 'setBottomFormError'; error: string }
@@ -243,32 +245,33 @@ const reducer = (state: State, action: Action): State => {
 					};
 			}
 		}
-		case 'setTopFormUserMissing': {
-			return {
-				...state,
-				topForm: {
-					...state.topForm,
-					userNameMissing: action.userNameMissing,
-				},
-			};
-		}
-		case 'setReplyFormUserMissing': {
-			return {
-				...state,
-				replyForm: {
-					...state.replyForm,
-					userNameMissing: action.userNameMissing,
-				},
-			};
-		}
-		case 'setBottomFormUserMissing': {
-			return {
-				...state,
-				bottomForm: {
-					...state.bottomForm,
-					userNameMissing: action.userNameMissing,
-				},
-			};
+		case 'setUserNameMissing': {
+			switch (action.formId) {
+				case 'top':
+					return {
+						...state,
+						topForm: {
+							...state.topForm,
+							userNameMissing: action.userNameMissing,
+						},
+					};
+				case 'reply':
+					return {
+						...state,
+						replyForm: {
+							...state.replyForm,
+							userNameMissing: action.userNameMissing,
+						},
+					};
+				case 'bottom':
+					return {
+						...state,
+						bottomForm: {
+							...state.bottomForm,
+							userNameMissing: action.userNameMissing,
+						},
+					};
+			}
 		}
 		case 'setTopFormShowPreview': {
 			return {
@@ -562,22 +565,11 @@ export const Discussion = ({
 					setFormActive={(isActive, formId) => {
 						dispatch({ type: 'setFormActive', isActive, formId });
 					}}
-					setTopFormUserMissing={(userNameMissing) =>
+					setUserNameMissing={(userNameMissing, formId) =>
 						dispatch({
-							type: 'setTopFormUserMissing',
+							type: 'setUserNameMissing',
 							userNameMissing,
-						})
-					}
-					setReplyFormUserMissing={(userNameMissing) =>
-						dispatch({
-							type: 'setReplyFormUserMissing',
-							userNameMissing,
-						})
-					}
-					setBottomFormUserMissing={(userNameMissing) =>
-						dispatch({
-							type: 'setBottomFormUserMissing',
-							userNameMissing,
+							formId,
 						})
 					}
 					setTopFormError={(error) =>

--- a/dotcom-rendering/src/components/Discussion.tsx
+++ b/dotcom-rendering/src/components/Discussion.tsx
@@ -106,7 +106,7 @@ type State = {
 	bottomForm: CommentForm;
 };
 
-const initialCommentFormState = {
+const initialCommentFormState: CommentForm = {
 	isActive: false,
 	userNameMissing: false,
 	error: '',
@@ -144,9 +144,11 @@ type Action =
 	| { type: 'updateHashCommentId'; hashCommentId: number | undefined }
 	| { type: 'filterChange'; filters: FilterOptions; commentPage?: number }
 	| { type: 'setLoading'; loading: boolean }
-	| { type: 'setTopFormActive'; isActive: boolean }
-	| { type: 'setReplyFormActive'; isActive: boolean }
-	| { type: 'setBottomFormActive'; isActive: boolean }
+	| {
+			type: 'setFormActive';
+			isActive: boolean;
+			formId: 'top' | 'reply' | 'bottom';
+	  }
 	| { type: 'setTopFormUserMissing'; userNameMissing: boolean }
 	| { type: 'setReplyFormUserMissing'; userNameMissing: boolean }
 	| { type: 'setBottomFormUserMissing'; userNameMissing: boolean }
@@ -212,23 +214,33 @@ const reducer = (state: State, action: Action): State => {
 				isExpanded: true,
 			};
 		}
-		case 'setTopFormActive': {
-			return {
-				...state,
-				topForm: { ...state.topForm, isActive: action.isActive },
-			};
-		}
-		case 'setReplyFormActive': {
-			return {
-				...state,
-				replyForm: { ...state.replyForm, isActive: action.isActive },
-			};
-		}
-		case 'setBottomFormActive': {
-			return {
-				...state,
-				bottomForm: { ...state.bottomForm, isActive: action.isActive },
-			};
+		case 'setFormActive': {
+			switch (action.formId) {
+				case 'top':
+					return {
+						...state,
+						topForm: {
+							...state.topForm,
+							isActive: action.isActive,
+						},
+					};
+				case 'reply':
+					return {
+						...state,
+						replyForm: {
+							...state.replyForm,
+							isActive: action.isActive,
+						},
+					};
+				case 'bottom':
+					return {
+						...state,
+						bottomForm: {
+							...state.bottomForm,
+							isActive: action.isActive,
+						},
+					};
+			}
 		}
 		case 'setTopFormUserMissing': {
 			return {
@@ -546,15 +558,9 @@ export const Discussion = ({
 							commentPage: page,
 						});
 					}}
-					setTopFormActive={(isActive) =>
-						dispatch({ type: 'setTopFormActive', isActive })
-					}
-					setReplyFormActive={(isActive) =>
-						dispatch({ type: 'setReplyFormActive', isActive })
-					}
-					setBottomFormActive={(isActive) =>
-						dispatch({ type: 'setBottomFormActive', isActive })
-					}
+					setFormActive={(isActive, formId) => {
+						dispatch({ type: 'setFormActive', isActive, formId });
+					}}
 					setTopFormUserMissing={(userNameMissing) =>
 						dispatch({
 							type: 'setTopFormUserMissing',

--- a/dotcom-rendering/src/components/Discussion.tsx
+++ b/dotcom-rendering/src/components/Discussion.tsx
@@ -151,10 +151,10 @@ type Action =
 			formId: CommentFormId;
 	  }
 	| {
-	type: 'setUserNameMissing';
-	userNameMissing: boolean;
-	formId: CommentFormId;
-		}
+			type: 'setUserNameMissing';
+			userNameMissing: boolean;
+			formId: CommentFormId;
+	  }
 	| { type: 'setTopFormError'; error: string }
 	| { type: 'setReplyFormError'; error: string }
 	| { type: 'setBottomFormError'; error: string }

--- a/dotcom-rendering/src/components/Discussion/CommentContainer.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentContainer.stories.tsx
@@ -190,6 +190,7 @@ const format = {
 
 export const defaultStory = () => (
 	<CommentContainer
+		formId={'top'}
 		comment={commentData}
 		isClosedForComments={false}
 		shortUrl="randomShortURL"
@@ -229,6 +230,7 @@ defaultStory.decorators = [
 
 export const threadedComment = () => (
 	<CommentContainer
+		formId={'top'}
 		comment={commentDataThreaded}
 		isClosedForComments={false}
 		shortUrl="randomShortURL"
@@ -268,6 +270,7 @@ threadedComment.decorators = [
 
 export const threadedCommentWithShowMore = () => (
 	<CommentContainer
+		formId={'top'}
 		comment={commentDataThreadedWithLongThread}
 		isClosedForComments={false}
 		shortUrl="randomShortURL"
@@ -307,6 +310,7 @@ threadedCommentWithShowMore.decorators = [
 
 export const threadedCommentWithLongUsernames = () => (
 	<CommentContainer
+		formId={'top'}
 		comment={commentDataThreadedWithLongUserNames}
 		isClosedForComments={false}
 		shortUrl="randomShortURL"
@@ -346,6 +350,7 @@ threadedCommentWithLongUsernames.decorators = [
 
 export const threadedCommentWithLongUsernamesMobile = () => (
 	<CommentContainer
+		formId={'top'}
 		comment={commentDataThreadedWithLongUserNames}
 		isClosedForComments={false}
 		shortUrl="randomShortURL"

--- a/dotcom-rendering/src/components/Discussion/CommentContainer.test.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentContainer.test.tsx
@@ -71,6 +71,7 @@ describe('CommentContainer', () => {
 
 		const { getByTestId, queryByText, getByText, rerender } = render(
 			<CommentContainer
+				formId={'top'}
 				shortUrl=""
 				comment={commentWithoutReply}
 				user={aUser}
@@ -121,6 +122,7 @@ describe('CommentContainer', () => {
 		// rerender with updated commentBeingRepliedTo
 		rerender(
 			<CommentContainer
+				formId={'top'}
 				shortUrl=""
 				comment={commentWithoutReply}
 				user={aUser}
@@ -170,6 +172,7 @@ describe('CommentContainer', () => {
 
 		const { getByTestId, queryByText, getByText, rerender } = render(
 			<CommentContainer
+				formId={'top'}
 				shortUrl=""
 				comment={commentWithReply}
 				user={aUser}
@@ -220,6 +223,7 @@ describe('CommentContainer', () => {
 		// rerender with updated commentBeingRepliedTo
 		rerender(
 			<CommentContainer
+				formId={'top'}
 				shortUrl=""
 				comment={commentWithoutReply}
 				user={aUser}

--- a/dotcom-rendering/src/components/Discussion/CommentContainer.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentContainer.tsx
@@ -15,6 +15,7 @@ import { CommentReplyPreview } from './CommentReplyPreview';
 import { PillarButton } from './PillarButton';
 
 type Props = {
+	formId: 'top' | 'reply' | 'bottom';
 	comment: CommentType;
 	isClosedForComments: boolean;
 	shortUrl: string;
@@ -30,7 +31,10 @@ type Props = {
 	showPreview: boolean;
 	setShowPreview: (showPreview: boolean) => void;
 	isCommentFormActive: boolean;
-	setIsCommentFormActive: (isActive: boolean) => void;
+	setIsCommentFormActive: (
+		isActive: boolean,
+		formId: 'top' | 'reply' | 'bottom',
+	) => void;
 	error: string;
 	setError: (error: string) => void;
 	userNameMissing: boolean;
@@ -76,6 +80,7 @@ export const avatar = (avatarSize: number) => css`
 `;
 
 export const CommentContainer = ({
+	formId,
 	comment,
 	isClosedForComments,
 	user,
@@ -237,6 +242,7 @@ export const CommentContainer = ({
 								commentBeingRepliedTo={commentBeingRepliedTo}
 							/>
 							<CommentForm
+								formId={formId}
 								shortUrl={shortUrl}
 								onAddComment={onAddComment}
 								user={user}

--- a/dotcom-rendering/src/components/Discussion/CommentContainer.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentContainer.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from 'react';
 import type { preview, reportAbuse } from '../../lib/discussionApi';
 import { getMoreResponses } from '../../lib/discussionApi';
 import type {
+	CommentFormId,
 	CommentType,
 	SignedInUser,
 	ThreadsType,
@@ -15,7 +16,7 @@ import { CommentReplyPreview } from './CommentReplyPreview';
 import { PillarButton } from './PillarButton';
 
 type Props = {
-	formId: 'top' | 'reply' | 'bottom';
+	formId: CommentFormId;
 	comment: CommentType;
 	isClosedForComments: boolean;
 	shortUrl: string;
@@ -31,10 +32,7 @@ type Props = {
 	showPreview: boolean;
 	setShowPreview: (showPreview: boolean) => void;
 	isCommentFormActive: boolean;
-	setIsCommentFormActive: (
-		isActive: boolean,
-		formId: 'top' | 'reply' | 'bottom',
-	) => void;
+	setIsCommentFormActive: (isActive: boolean, formId: CommentFormId) => void;
 	error: string;
 	setError: (error: string) => void;
 	userNameMissing: boolean;

--- a/dotcom-rendering/src/components/Discussion/CommentContainer.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentContainer.tsx
@@ -36,7 +36,10 @@ type Props = {
 	error: string;
 	setError: (error: string) => void;
 	userNameMissing: boolean;
-	setUserNameMissing: (isUserNameMissing: boolean) => void;
+	setUserNameMissing: (
+		isUserNameMissing: boolean,
+		formId: CommentFormId,
+	) => void;
 	previewBody: string;
 	setPreviewBody: (previewBody: string) => void;
 	body: string;

--- a/dotcom-rendering/src/components/Discussion/CommentForm.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentForm.stories.tsx
@@ -136,7 +136,7 @@ export const Active = () => {
 
 	return (
 		<CommentForm
-		formId={'top'}
+			formId={'top'}
 			shortUrl={shortUrl}
 			user={aUser}
 			onAddComment={(comment) => {}}
@@ -174,7 +174,7 @@ export const Premoderated = () => {
 
 	return (
 		<CommentForm
-		formId={'top'}
+			formId={'top'}
 			shortUrl={shortUrl}
 			user={{
 				...aUser,

--- a/dotcom-rendering/src/components/Discussion/CommentForm.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentForm.stories.tsx
@@ -77,6 +77,7 @@ export const Default = () => {
 
 	return (
 		<CommentForm
+			formId={'top'}
 			shortUrl={shortUrl}
 			user={aUser}
 			onAddComment={(comment) => {}}
@@ -107,6 +108,7 @@ export const Error = () => {
 
 	return (
 		<CommentForm
+			formId={'top'}
 			shortUrl={'/p/g8g7v'}
 			user={aUser}
 			onAddComment={(comment) => {}}
@@ -134,6 +136,7 @@ export const Active = () => {
 
 	return (
 		<CommentForm
+		formId={'top'}
 			shortUrl={shortUrl}
 			user={aUser}
 			onAddComment={(comment) => {}}
@@ -171,6 +174,7 @@ export const Premoderated = () => {
 
 	return (
 		<CommentForm
+		formId={'top'}
 			shortUrl={shortUrl}
 			user={{
 				...aUser,

--- a/dotcom-rendering/src/components/Discussion/CommentForm.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentForm.tsx
@@ -19,6 +19,7 @@ import { Preview } from './Preview';
 import { Row } from './Row';
 
 type Props = {
+	formId: 'top' | 'reply' | 'bottom';
 	shortUrl: string;
 	user: SignedInUser;
 	onAddComment: (response: CommentType) => void;
@@ -28,7 +29,10 @@ type Props = {
 	showPreview: boolean;
 	setShowPreview: (showPreview: boolean) => void;
 	isActive: boolean;
-	setIsActive: (isActive: boolean) => void;
+	setIsActive: (
+		isActive: boolean,
+		formId: 'top' | 'reply' | 'bottom',
+	) => void;
 	error: string;
 	setError: (error: string) => void;
 	userNameMissing: boolean;
@@ -199,6 +203,7 @@ const simulateNewComment = (
 };
 
 export const CommentForm = ({
+	formId,
 	shortUrl,
 	onAddComment,
 	user,
@@ -297,7 +302,7 @@ export const CommentForm = ({
 		setError('');
 		setBody('');
 		setShowPreview(false);
-		setIsActive(false);
+		setIsActive(false, formId);
 		setCommentBeingRepliedTo?.();
 	};
 
@@ -473,7 +478,7 @@ export const CommentForm = ({
 						setBody(e.target.value || '');
 					}}
 					value={body}
-					onFocus={() => setIsActive(true)}
+					onFocus={() => setIsActive(true, formId)}
 				/>
 				<div css={bottomContainer}>
 					<Row cssOverrides={wrappingRow}>

--- a/dotcom-rendering/src/components/Discussion/CommentForm.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentForm.tsx
@@ -34,7 +34,10 @@ type Props = {
 	error: string;
 	setError: (error: string) => void;
 	userNameMissing: boolean;
-	setUserNameMissing: (isUserNameMissing: boolean) => void;
+	setUserNameMissing: (
+		isUserNameMissing: boolean,
+		formId: CommentFormId,
+	) => void;
 	previewBody: string;
 	setPreviewBody: (previewBody: string) => void;
 	body: string;
@@ -315,7 +318,7 @@ export const CommentForm = ({
 			if (response.kind === 'error') {
 				if (response.error === 'USERNAME_MISSING') {
 					// Reader has never posted before and needs to choose a username
-					setUserNameMissing(true);
+					setUserNameMissing(true, formId);
 				} else if (response.error === 'EMPTY_COMMENT_BODY') {
 					setError('Please write a comment.');
 				} else if (response.error === 'COMMENT_TOO_LONG') {
@@ -398,7 +401,7 @@ export const CommentForm = ({
 		if (response.kind === 'ok') {
 			// If we are able to submit userName we should continue with submitting comment
 			void submitForm();
-			setUserNameMissing(false);
+			setUserNameMissing(false, formId);
 		} else {
 			setError(response.error);
 		}
@@ -409,7 +412,7 @@ export const CommentForm = ({
 			<FirstCommentWelcome
 				error={error}
 				submitForm={submitUserName}
-				cancelSubmit={() => setUserNameMissing(false)}
+				cancelSubmit={() => setUserNameMissing(false, formId)}
 				previewBody={previewBody}
 			/>
 		);

--- a/dotcom-rendering/src/components/Discussion/CommentForm.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentForm.tsx
@@ -9,6 +9,7 @@ import { useEffect, useRef } from 'react';
 import { preview as defaultPreview } from '../../lib/discussionApi';
 import { palette as schemedPalette } from '../../palette';
 import type {
+	CommentFormId,
 	CommentType,
 	SignedInUser,
 	UserProfile,
@@ -19,7 +20,7 @@ import { Preview } from './Preview';
 import { Row } from './Row';
 
 type Props = {
-	formId: 'top' | 'reply' | 'bottom';
+	formId: CommentFormId;
 	shortUrl: string;
 	user: SignedInUser;
 	onAddComment: (response: CommentType) => void;
@@ -29,10 +30,7 @@ type Props = {
 	showPreview: boolean;
 	setShowPreview: (showPreview: boolean) => void;
 	isActive: boolean;
-	setIsActive: (
-		isActive: boolean,
-		formId: 'top' | 'reply' | 'bottom',
-	) => void;
+	setIsActive: (isActive: boolean, formId: CommentFormId) => void;
 	error: string;
 	setError: (error: string) => void;
 	userNameMissing: boolean;

--- a/dotcom-rendering/src/components/Discussion/Comments.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comments.stories.tsx
@@ -90,9 +90,7 @@ export const LoggedOutHiddenPicks = () => (
 			setComment={() => {}}
 			handleFilterChange={() => {}}
 			setFormActive={() => {}}
-			setTopFormUserMissing={() => {}}
-			setReplyFormUserMissing={() => {}}
-			setBottomFormUserMissing={() => {}}
+			setUserNameMissing={() => {}}
 			setTopFormError={() => {}}
 			setReplyFormError={() => {}}
 			setBottomFormError={() => {}}
@@ -152,9 +150,7 @@ export const InitialPage = () => (
 			setComment={() => {}}
 			handleFilterChange={() => {}}
 			setFormActive={() => {}}
-			setTopFormUserMissing={() => {}}
-			setReplyFormUserMissing={() => {}}
-			setBottomFormUserMissing={() => {}}
+			setUserNameMissing={() => {}}
 			setTopFormError={() => {}}
 			setReplyFormError={() => {}}
 			setBottomFormError={() => {}}
@@ -218,9 +214,7 @@ export const LoggedInHiddenNoPicks = () => {
 				setComment={() => {}}
 				handleFilterChange={() => {}}
 				setFormActive={() => {}}
-				setTopFormUserMissing={() => {}}
-				setReplyFormUserMissing={() => {}}
-				setBottomFormUserMissing={() => {}}
+				setUserNameMissing={() => {}}
 				setTopFormError={() => {}}
 				setReplyFormError={() => {}}
 				setBottomFormError={() => {}}
@@ -281,9 +275,7 @@ export const LoggedIn = () => {
 				setComment={() => {}}
 				handleFilterChange={() => {}}
 				setFormActive={() => {}}
-				setTopFormUserMissing={() => {}}
-				setReplyFormUserMissing={() => {}}
-				setBottomFormUserMissing={() => {}}
+				setUserNameMissing={() => {}}
 				setTopFormError={() => {}}
 				setReplyFormError={() => {}}
 				setBottomFormError={() => {}}
@@ -348,9 +340,7 @@ export const LoggedInShortDiscussion = () => {
 				setComment={() => {}}
 				handleFilterChange={() => {}}
 				setFormActive={() => {}}
-				setTopFormUserMissing={() => {}}
-				setReplyFormUserMissing={() => {}}
-				setBottomFormUserMissing={() => {}}
+				setUserNameMissing={() => {}}
 				setTopFormError={() => {}}
 				setReplyFormError={() => {}}
 				setBottomFormError={() => {}}
@@ -406,9 +396,7 @@ export const LoggedOutHiddenNoPicks = () => (
 			setComment={() => {}}
 			handleFilterChange={() => {}}
 			setFormActive={() => {}}
-			setTopFormUserMissing={() => {}}
-			setReplyFormUserMissing={() => {}}
-			setBottomFormUserMissing={() => {}}
+			setUserNameMissing={() => {}}
 			setTopFormError={() => {}}
 			setReplyFormError={() => {}}
 			setBottomFormError={() => {}}
@@ -470,9 +458,7 @@ export const Closed = () => (
 			setComment={() => {}}
 			handleFilterChange={() => {}}
 			setFormActive={() => {}}
-			setTopFormUserMissing={() => {}}
-			setReplyFormUserMissing={() => {}}
-			setBottomFormUserMissing={() => {}}
+			setUserNameMissing={() => {}}
 			setTopFormError={() => {}}
 			setReplyFormError={() => {}}
 			setBottomFormError={() => {}}
@@ -530,9 +516,7 @@ export const NoComments = () => (
 			setComment={() => {}}
 			handleFilterChange={() => {}}
 			setFormActive={() => {}}
-			setTopFormUserMissing={() => {}}
-			setReplyFormUserMissing={() => {}}
-			setBottomFormUserMissing={() => {}}
+			setUserNameMissing={() => {}}
 			setTopFormError={() => {}}
 			setReplyFormError={() => {}}
 			setBottomFormError={() => {}}
@@ -592,9 +576,7 @@ export const LegacyDiscussion = () => (
 			setComment={() => {}}
 			handleFilterChange={() => {}}
 			setFormActive={() => {}}
-			setTopFormUserMissing={() => {}}
-			setReplyFormUserMissing={() => {}}
-			setBottomFormUserMissing={() => {}}
+			setUserNameMissing={() => {}}
 			setTopFormError={() => {}}
 			setReplyFormError={() => {}}
 			setBottomFormError={() => {}}

--- a/dotcom-rendering/src/components/Discussion/Comments.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comments.stories.tsx
@@ -288,7 +288,7 @@ export const LoggedIn = () => {
 				setTopFormBody={setTopFormBody}
 				setReplyFormBody={setReplyFormBody}
 				setBottomFormBody={setBottomFormBody}
-				topForm={{...defaultCommentForm, body: topFormBody }}
+				topForm={{ ...defaultCommentForm, body: topFormBody }}
 				replyForm={{
 					...defaultCommentForm,
 					body: replyFormBody,
@@ -353,7 +353,7 @@ export const LoggedInShortDiscussion = () => {
 				setTopFormBody={setTopFormBody}
 				setReplyFormBody={setReplyFormBody}
 				setBottomFormBody={() => {}}
-				topForm={{ ...defaultCommentForm, body: topFormBody, }}
+				topForm={{ ...defaultCommentForm, body: topFormBody }}
 				replyForm={{
 					...defaultCommentForm,
 					body: replyFormBody,

--- a/dotcom-rendering/src/components/Discussion/Comments.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comments.stories.tsx
@@ -89,9 +89,7 @@ export const LoggedOutHiddenPicks = () => (
 			comments={discussionMock.discussion.comments}
 			setComment={() => {}}
 			handleFilterChange={() => {}}
-			setTopFormActive={() => {}}
-			setReplyFormActive={() => {}}
-			setBottomFormActive={() => {}}
+			setFormActive={() => {}}
 			setTopFormUserMissing={() => {}}
 			setReplyFormUserMissing={() => {}}
 			setBottomFormUserMissing={() => {}}
@@ -153,9 +151,7 @@ export const InitialPage = () => (
 			comments={discussionMock.discussion.comments}
 			setComment={() => {}}
 			handleFilterChange={() => {}}
-			setTopFormActive={() => {}}
-			setReplyFormActive={() => {}}
-			setBottomFormActive={() => {}}
+			setFormActive={() => {}}
 			setTopFormUserMissing={() => {}}
 			setReplyFormUserMissing={() => {}}
 			setBottomFormUserMissing={() => {}}
@@ -189,7 +185,6 @@ InitialPage.decorators = [
 ];
 
 export const LoggedInHiddenNoPicks = () => {
-	const [isActive, setActive] = useState(false);
 	const [body, setBody] = useState('');
 
 	return (
@@ -222,9 +217,7 @@ export const LoggedInHiddenNoPicks = () => {
 				comments={discussionMock.discussion.comments}
 				setComment={() => {}}
 				handleFilterChange={() => {}}
-				setTopFormActive={() => {}}
-				setReplyFormActive={setActive}
-				setBottomFormActive={() => {}}
+				setFormActive={() => {}}
 				setTopFormUserMissing={() => {}}
 				setReplyFormUserMissing={() => {}}
 				setBottomFormUserMissing={() => {}}
@@ -241,7 +234,7 @@ export const LoggedInHiddenNoPicks = () => {
 				setReplyFormBody={setBody}
 				setBottomFormBody={() => {}}
 				topForm={defaultCommentForm}
-				replyForm={{ ...defaultCommentForm, isActive, body }}
+				replyForm={{ ...defaultCommentForm, body }}
 				bottomForm={defaultCommentForm}
 				reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
 			/>
@@ -253,9 +246,6 @@ LoggedInHiddenNoPicks.storyName =
 LoggedInHiddenNoPicks.decorators = [splitTheme([format])];
 
 export const LoggedIn = () => {
-	const [isTopFormActive, setTopFormActive] = useState(false);
-	const [isReplyFormActive, setReplyFormActive] = useState(false);
-	const [isBottomFormActive, setBottomFormActive] = useState(false);
 	const [topFormBody, setTopFormBody] = useState('');
 	const [replyFormBody, setReplyFormBody] = useState('');
 	const [bottomFormBody, setBottomFormBody] = useState('');
@@ -290,9 +280,7 @@ export const LoggedIn = () => {
 				comments={discussionMock.discussion.comments}
 				setComment={() => {}}
 				handleFilterChange={() => {}}
-				setTopFormActive={setTopFormActive}
-				setReplyFormActive={setReplyFormActive}
-				setBottomFormActive={setBottomFormActive}
+				setFormActive={() => {}}
 				setTopFormUserMissing={() => {}}
 				setReplyFormUserMissing={() => {}}
 				setBottomFormUserMissing={() => {}}
@@ -308,19 +296,13 @@ export const LoggedIn = () => {
 				setTopFormBody={setTopFormBody}
 				setReplyFormBody={setReplyFormBody}
 				setBottomFormBody={setBottomFormBody}
-				topForm={{
-					...defaultCommentForm,
-					isActive: isTopFormActive,
-					body: topFormBody,
-				}}
+				topForm={{...defaultCommentForm, body: topFormBody }}
 				replyForm={{
 					...defaultCommentForm,
-					isActive: isReplyFormActive,
 					body: replyFormBody,
 				}}
 				bottomForm={{
 					...defaultCommentForm,
-					isActive: isBottomFormActive,
 					body: bottomFormBody,
 				}}
 				reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
@@ -332,8 +314,6 @@ LoggedIn.storyName = 'when logged in and expanded';
 LoggedIn.decorators = [lightDecorator([format])];
 
 export const LoggedInShortDiscussion = () => {
-	const [isTopFormActive, setTopFormActive] = useState(false);
-	const [isReplyFormActive, setReplyFormActive] = useState(false);
 	const [topFormBody, setTopFormBody] = useState('');
 	const [replyFormBody, setReplyFormBody] = useState('');
 
@@ -367,9 +347,7 @@ export const LoggedInShortDiscussion = () => {
 				comments={discussionWithTwoComments.discussion.comments}
 				setComment={() => {}}
 				handleFilterChange={() => {}}
-				setTopFormActive={setTopFormActive}
-				setReplyFormActive={setReplyFormActive}
-				setBottomFormActive={() => {}}
+				setFormActive={() => {}}
 				setTopFormUserMissing={() => {}}
 				setReplyFormUserMissing={() => {}}
 				setBottomFormUserMissing={() => {}}
@@ -385,14 +363,9 @@ export const LoggedInShortDiscussion = () => {
 				setTopFormBody={setTopFormBody}
 				setReplyFormBody={setReplyFormBody}
 				setBottomFormBody={() => {}}
-				topForm={{
-					...defaultCommentForm,
-					isActive: isTopFormActive,
-					body: topFormBody,
-				}}
+				topForm={{ ...defaultCommentForm, body: topFormBody, }}
 				replyForm={{
 					...defaultCommentForm,
-					isActive: isReplyFormActive,
 					body: replyFormBody,
 				}}
 				bottomForm={defaultCommentForm}
@@ -432,9 +405,7 @@ export const LoggedOutHiddenNoPicks = () => (
 			comments={discussionMock.discussion.comments}
 			setComment={() => {}}
 			handleFilterChange={() => {}}
-			setTopFormActive={() => {}}
-			setReplyFormActive={() => {}}
-			setBottomFormActive={() => {}}
+			setFormActive={() => {}}
 			setTopFormUserMissing={() => {}}
 			setReplyFormUserMissing={() => {}}
 			setBottomFormUserMissing={() => {}}
@@ -498,9 +469,7 @@ export const Closed = () => (
 			comments={discussionMock.discussion.comments}
 			setComment={() => {}}
 			handleFilterChange={() => {}}
-			setTopFormActive={() => {}}
-			setReplyFormActive={() => {}}
-			setBottomFormActive={() => {}}
+			setFormActive={() => {}}
 			setTopFormUserMissing={() => {}}
 			setReplyFormUserMissing={() => {}}
 			setBottomFormUserMissing={() => {}}
@@ -560,9 +529,7 @@ export const NoComments = () => (
 			comments={[]}
 			setComment={() => {}}
 			handleFilterChange={() => {}}
-			setTopFormActive={() => {}}
-			setReplyFormActive={() => {}}
-			setBottomFormActive={() => {}}
+			setFormActive={() => {}}
 			setTopFormUserMissing={() => {}}
 			setReplyFormUserMissing={() => {}}
 			setBottomFormUserMissing={() => {}}
@@ -624,9 +591,7 @@ export const LegacyDiscussion = () => (
 			comments={legacyDiscussionWithoutThreading.discussion.comments}
 			setComment={() => {}}
 			handleFilterChange={() => {}}
-			setTopFormActive={() => {}}
-			setReplyFormActive={() => {}}
-			setBottomFormActive={() => {}}
+			setFormActive={() => {}}
 			setTopFormUserMissing={() => {}}
 			setReplyFormUserMissing={() => {}}
 			setBottomFormUserMissing={() => {}}

--- a/dotcom-rendering/src/components/Discussion/Comments.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comments.tsx
@@ -10,11 +10,11 @@ import type { preview, reportAbuse } from '../../lib/discussionApi';
 import { getPicks, initialiseApi } from '../../lib/discussionApi';
 import type {
 	AdditionalHeadersType,
+	CommentFormId,
 	CommentType,
 	FilterOptions,
 	CommentForm as Form,
 	SignedInUser,
-	CommentFormId,
 } from '../../types/discussion';
 import { CommentContainer } from './CommentContainer';
 import { CommentForm } from './CommentForm';

--- a/dotcom-rendering/src/components/Discussion/Comments.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comments.tsx
@@ -45,9 +45,10 @@ type Props = {
 	setComment: (comment: CommentType) => void;
 	handleFilterChange: (newFilters: FilterOptions, page?: number) => void;
 	setFormActive: (isActive: boolean, formId: CommentFormId) => void;
-	setTopFormUserMissing: (isUserMissing: boolean) => void;
-	setReplyFormUserMissing: (isUserMissing: boolean) => void;
-	setBottomFormUserMissing: (isUserMissing: boolean) => void;
+	setUserNameMissing: (
+		isUserNameMissing: boolean,
+		formId: CommentFormId,
+	) => void;
 	setTopFormError: (error: string) => void;
 	setReplyFormError: (error: string) => void;
 	setBottomFormError: (error: string) => void;
@@ -152,9 +153,7 @@ export const Comments = ({
 	setComment,
 	handleFilterChange,
 	setFormActive,
-	setTopFormUserMissing,
-	setReplyFormUserMissing,
-	setBottomFormUserMissing,
+	 setUserNameMissing,
 	setTopFormError,
 	setReplyFormError,
 	setBottomFormError,
@@ -347,7 +346,7 @@ export const Comments = ({
 												replyForm.userNameMissing
 											}
 											setUserNameMissing={
-												setReplyFormUserMissing
+												setUserNameMissing
 											}
 											previewBody={replyForm.previewBody}
 											setPreviewBody={
@@ -383,7 +382,7 @@ export const Comments = ({
 					error={topForm.error}
 					setError={setTopFormError}
 					userNameMissing={topForm.userNameMissing}
-					setUserNameMissing={setTopFormUserMissing}
+					setUserNameMissing={setUserNameMissing}
 					previewBody={topForm.previewBody}
 					setPreviewBody={setTopFormPreviewBody}
 					body={topForm.body}
@@ -444,7 +443,7 @@ export const Comments = ({
 									error={replyForm.error}
 									setError={setReplyFormError}
 									userNameMissing={replyForm.userNameMissing}
-									setUserNameMissing={setReplyFormUserMissing}
+									setUserNameMissing={setUserNameMissing}
 									previewBody={replyForm.previewBody}
 									setPreviewBody={setReplyFormPreviewBody}
 									body={replyForm.body}
@@ -480,7 +479,7 @@ export const Comments = ({
 					error={bottomForm.error}
 					setError={setBottomFormError}
 					userNameMissing={bottomForm.userNameMissing}
-					setUserNameMissing={setBottomFormUserMissing}
+					setUserNameMissing={setUserNameMissing}
 					previewBody={bottomForm.previewBody}
 					setPreviewBody={setBottomFormPreviewBody}
 					body={bottomForm.body}

--- a/dotcom-rendering/src/components/Discussion/Comments.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comments.tsx
@@ -43,9 +43,10 @@ type Props = {
 	comments: CommentType[];
 	setComment: (comment: CommentType) => void;
 	handleFilterChange: (newFilters: FilterOptions, page?: number) => void;
-	setTopFormActive: (isActive: boolean) => void;
-	setReplyFormActive: (isActive: boolean) => void;
-	setBottomFormActive: (isActive: boolean) => void;
+	setFormActive: (
+		isActive: boolean,
+		formId: 'top' | 'reply' | 'bottom',
+	) => void;
 	setTopFormUserMissing: (isUserMissing: boolean) => void;
 	setReplyFormUserMissing: (isUserMissing: boolean) => void;
 	setBottomFormUserMissing: (isUserMissing: boolean) => void;
@@ -152,9 +153,7 @@ export const Comments = ({
 	comments,
 	setComment,
 	handleFilterChange,
-	setTopFormActive,
-	setReplyFormActive,
-	setBottomFormActive,
+	setFormActive,
 	setTopFormUserMissing,
 	setReplyFormUserMissing,
 	setBottomFormUserMissing,
@@ -317,6 +316,7 @@ export const Comments = ({
 								{comments.slice(0, 2).map((comment) => (
 									<li key={comment.id}>
 										<CommentContainer
+											formId={'reply'}
 											comment={comment}
 											isClosedForComments={
 												isClosedForComments
@@ -341,7 +341,7 @@ export const Comments = ({
 												replyForm.isActive
 											}
 											setIsCommentFormActive={
-												setReplyFormActive
+												setFormActive
 											}
 											error={replyForm.error}
 											setError={setReplyFormError}
@@ -373,6 +373,7 @@ export const Comments = ({
 		<div data-component="discussion" css={commentColumnWrapperStyles}>
 			{user && !isClosedForComments && (
 				<CommentForm
+					formId={'top'}
 					shortUrl={shortUrl}
 					onAddComment={onAddComment}
 					user={user}
@@ -380,7 +381,7 @@ export const Comments = ({
 					showPreview={topForm.showPreview}
 					setShowPreview={setTopFormShowPreview}
 					isActive={topForm.isActive}
-					setIsActive={setTopFormActive}
+					setIsActive={setFormActive}
 					error={topForm.error}
 					setError={setTopFormError}
 					userNameMissing={topForm.userNameMissing}
@@ -422,6 +423,7 @@ export const Comments = ({
 						.map((comment) => (
 							<li key={comment.id}>
 								<CommentContainer
+									formId={'reply'}
 									comment={comment}
 									isClosedForComments={isClosedForComments}
 									shortUrl={shortUrl}
@@ -440,7 +442,7 @@ export const Comments = ({
 									showPreview={replyForm.showPreview}
 									setShowPreview={setReplyFormShowPreview}
 									isCommentFormActive={replyForm.isActive}
-									setIsCommentFormActive={setReplyFormActive}
+									setIsCommentFormActive={setFormActive}
 									error={replyForm.error}
 									setError={setReplyFormError}
 									userNameMissing={replyForm.userNameMissing}
@@ -468,6 +470,7 @@ export const Comments = ({
 			)}
 			{user && !isClosedForComments && comments.length > 10 && (
 				<CommentForm
+					formId={'bottom'}
 					shortUrl={shortUrl}
 					onAddComment={onAddComment}
 					user={user}
@@ -475,7 +478,7 @@ export const Comments = ({
 					showPreview={bottomForm.showPreview}
 					setShowPreview={setBottomFormShowPreview}
 					isActive={bottomForm.isActive}
-					setIsActive={setBottomFormActive}
+					setIsActive={setFormActive}
 					error={bottomForm.error}
 					setError={setBottomFormError}
 					userNameMissing={bottomForm.userNameMissing}

--- a/dotcom-rendering/src/components/Discussion/Comments.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comments.tsx
@@ -14,6 +14,7 @@ import type {
 	FilterOptions,
 	CommentForm as Form,
 	SignedInUser,
+	CommentFormId,
 } from '../../types/discussion';
 import { CommentContainer } from './CommentContainer';
 import { CommentForm } from './CommentForm';
@@ -43,10 +44,7 @@ type Props = {
 	comments: CommentType[];
 	setComment: (comment: CommentType) => void;
 	handleFilterChange: (newFilters: FilterOptions, page?: number) => void;
-	setFormActive: (
-		isActive: boolean,
-		formId: 'top' | 'reply' | 'bottom',
-	) => void;
+	setFormActive: (isActive: boolean, formId: CommentFormId) => void;
 	setTopFormUserMissing: (isUserMissing: boolean) => void;
 	setReplyFormUserMissing: (isUserMissing: boolean) => void;
 	setBottomFormUserMissing: (isUserMissing: boolean) => void;

--- a/dotcom-rendering/src/components/Discussion/Comments.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comments.tsx
@@ -153,7 +153,7 @@ export const Comments = ({
 	setComment,
 	handleFilterChange,
 	setFormActive,
-	 setUserNameMissing,
+	setUserNameMissing,
 	setTopFormError,
 	setReplyFormError,
 	setBottomFormError,

--- a/dotcom-rendering/src/types/discussion.ts
+++ b/dotcom-rendering/src/types/discussion.ts
@@ -389,6 +389,8 @@ export const pickResponseSchema = object({
 	message: string(),
 });
 
+export type CommentFormId = 'top' | 'reply' | 'bottom';
+
 export type CommentForm = {
 	isActive: boolean;
 	userNameMissing: boolean;


### PR DESCRIPTION
## What does this change?

Refactors the `setFormActive` and `setUserNameMissing` methods in the reducer to be more generic, so that we don't have so many props down.

## Why?
Less boilerplate

## Testing
Tested in CODE. These two function behave as expected.


<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
