### PR TITLE
Only show CommentReplyPreview if three or more replies

### DIFF
--- a/dotcom-rendering/src/components/Discussion/CommentContainer.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentContainer.tsx
@@ -229,9 +229,14 @@ export const CommentContainer = ({
 							id={`comment-reply-form-${commentBeingRepliedTo.id}`}
 							css={nestingStyles}
 						>
-							<CommentReplyPreview
-								commentBeingRepliedTo={commentBeingRepliedTo}
-							/>
+							{(commentBeingRepliedTo?.numResponses ?? 0) >=
+								3 && (
+								<CommentReplyPreview
+									commentBeingRepliedTo={
+										commentBeingRepliedTo
+									}
+								/>
+							)}
 							<CommentForm
 								shortUrl={shortUrl}
 								onAddComment={onAddComment}


### PR DESCRIPTION
## What does this change?
Adds a conditional to only show CommentReplyPreview if the comment being replied to has three or more replies
## Why?
This component serves to remind the user of the comment they are replying to. This is unnecessary if the original comment is within the viewport which is the case if the comment being replied to has no or few replies (as in the majority of cases).
## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
