### PR TITLE
Playwright local tweaks

### DIFF
--- a/dotcom-rendering/playwright.config.ts
+++ b/dotcom-rendering/playwright.config.ts
@@ -5,13 +5,14 @@ import { defineConfig, devices } from '@playwright/test';
  */
 export default defineConfig({
 	testDir: './playwright/tests',
-	// Run tests in files in parallel
-	fullyParallel: true,
+	// Don't run tests _within_ files in parallel as this causes flakiness locally - investigating
+	// Test files still run in parallel as per the number of workers set below
+	fullyParallel: false,
 	// Fail the build on CI if you accidentally left test.only in the source code
 	forbidOnly: !!process.env.CI,
 	// Retry on CI only
-	retries: process.env.CI ? 3 : 0,
-	// Max parallel tests on CI
+	retries: process.env.CI ? 3 : 1,
+	// Workers run tests files in parallel
 	workers: process.env.CI ? 4 : undefined,
 	// Reporter to use. See https://playwright.dev/docs/test-reporters
 	reporter: [['line'], ['html', { open: 'never' }]],

--- a/dotcom-rendering/playwright/lib/load-page.ts
+++ b/dotcom-rendering/playwright/lib/load-page.ts
@@ -14,7 +14,7 @@ const BASE_URL = `http://localhost:${PORT}`;
 const loadPage = async (
 	page: Page,
 	path: string,
-	waitUntil: 'load' | 'domcontentloaded' = 'load',
+	waitUntil: 'load' | 'domcontentloaded' = 'domcontentloaded',
 	region = 'GB',
 	preventSupportBanner = true,
 ): Promise<void> => {
@@ -34,8 +34,8 @@ const loadPage = async (
 		},
 		{ region, preventSupportBanner },
 	);
-	// The default waitUntil: 'load' ensures all requests have completed
-	// For specific cases that do not rely on JS use 'domcontentloaded' to speed up tests
+	// The default Playwright waitUntil: 'load' ensures all requests have completed
+	// Use 'domcontentloaded' to speed up tests and prevent hanging requests from timing out tests
 	await page.goto(`${BASE_URL}${path}`, { waitUntil });
 };
 
@@ -88,7 +88,7 @@ const loadPageNoOkta = async (
 		switchOverrides?: Record<string, unknown>;
 	},
 ): Promise<void> => {
-	return loadPageWithOverrides(page, article, {
+	await loadPageWithOverrides(page, article, {
 		configOverrides: overrides?.configOverrides,
 		switchOverrides: {
 			...overrides?.switchOverrides,
@@ -113,7 +113,7 @@ const fetchAndloadPageWithOverrides = async (
 	const article = validateAsArticleType(
 		await fetch(`${url}.json?dcr`).then((res) => res.json()),
 	);
-	return loadPageWithOverrides(page, article, {
+	await loadPageWithOverrides(page, article, {
 		configOverrides: overrides?.configOverrides,
 		switchOverrides: {
 			...overrides?.switchOverrides,

--- a/dotcom-rendering/tsconfig.json
+++ b/dotcom-rendering/tsconfig.json
@@ -16,5 +16,11 @@
 		},
 		"preserveConstEnums": true
 	},
-	"exclude": ["storybook-static", "target", "dist", "node_modules"]
+	"exclude": [
+		"storybook-static",
+		"target",
+		"dist",
+		"node_modules",
+		"playwright-report"
+	]
 }


### PR DESCRIPTION
## What does this change?

Playwright tests are stable on CI but can be flaky locally.

Investigating this led to the following tweaks:

- turn off [fullyParallel](https://playwright.dev/docs/api/class-testconfig#test-config-fully-parallel) which makes running local tests much more stable (1-2 failures out of 100 vs 10-15)
- enable a single retry locally
- using await on all page loading utility lib functions as a precaution to ensure promises run in order
- switch back to `domcontentloaded` as the load event for page loading. I noticed hanging requests can cause the page to never reach `load` and cause the tests to timeout.
- added `playwright-report` to the directories ignored by tsconfig. When creating a trace the output JS would get type checked.

Interestingly turning off `fullyParallel` does not impact the overall time taken to run the tests which could suggest some blocking behaviour protecting a constrained resource.

I have a theory that running locally on an M1 with the [default](https://playwright.dev/docs/api/class-testconfig#test-config-workers) of 5 workers and using `fullyParallel` maxes out the network connections available to the chromium browser and network requests are blocked eventually causing tests to timeout.

Will continue to investigate.


