### PR TITLE
Fix permalinks on collapsed threads

### DIFF
--- a/dotcom-rendering/src/components/Discussion.tsx
+++ b/dotcom-rendering/src/components/Discussion.tsx
@@ -140,7 +140,7 @@ type Action =
 	  }
 	| { type: 'expandComments' }
 	| { type: 'addComment'; comment: CommentType }
-	| { type: 'updateCommentPage'; commentPage: number; shouldExpand: boolean }
+	| { type: 'updateCommentPage'; commentPage: number }
 	| { type: 'updateHashCommentId'; hashCommentId: number | undefined }
 	| { type: 'filterChange'; filters: FilterOptions; commentPage?: number }
 	| { type: 'setLoading'; loading: boolean }
@@ -189,7 +189,7 @@ const reducer = (state: State, action: Action): State => {
 			return {
 				...state,
 				commentPage: action.commentPage,
-				isExpanded: action.shouldExpand ? true : state.isExpanded,
+				isExpanded: true,
 			};
 		case 'filterChange':
 			return {
@@ -412,7 +412,12 @@ export const Discussion = ({
 
 	useEffect(() => {
 		dispatch({ type: 'setLoading', loading: true });
-		void getDiscussion(shortUrlId, { ...filters, page: commentPage })
+
+		void getDiscussion(
+			shortUrlId,
+			commentPage,
+			remapToValidFilters(filters, hashCommentId),
+		)
 			.then((result) => {
 				if (result.kind === 'error') {
 					console.error(`getDiscussion - error: ${result.error}`);
@@ -432,7 +437,7 @@ export const Discussion = ({
 			.catch(() => {
 				// do nothing
 			});
-	}, [filters, commentPage, shortUrlId]);
+	}, [commentPage, filters, hashCommentId, shortUrlId]);
 
 	const validFilters = remapToValidFilters(filters, hashCommentId);
 
@@ -459,19 +464,22 @@ export const Discussion = ({
 	// on.
 	useEffect(() => {
 		if (hashCommentId !== undefined) {
-			getCommentContext(discussionApiUrl, hashCommentId)
+			getCommentContext(
+				discussionApiUrl,
+				hashCommentId,
+				remapToValidFilters(filters, hashCommentId),
+			)
 				.then((context) => {
 					dispatch({
 						type: 'updateCommentPage',
 						commentPage: context.page,
-						shouldExpand: true,
 					});
 				})
 				.catch((e) =>
 					console.error(`getCommentContext - error: ${String(e)}`),
 				);
 		}
-	}, [discussionApiUrl, hashCommentId]);
+	}, [filters, discussionApiUrl, hashCommentId]);
 
 	useEffect(() => {
 		if (window.location.hash === '#comments') {
@@ -522,11 +530,10 @@ export const Discussion = ({
 					apiKey="dotcom-rendering"
 					idApiUrl={idApiUrl}
 					page={commentPage}
-					setPage={(page: number, shouldExpand: boolean) => {
+					setPage={(page: number) => {
 						dispatch({
 							type: 'updateCommentPage',
 							commentPage: page,
-							shouldExpand,
 						});
 					}}
 					filters={validFilters}

--- a/dotcom-rendering/src/components/Discussion/Comments.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comments.tsx
@@ -36,7 +36,7 @@ type Props = {
 	onPreview?: typeof preview;
 	idApiUrl: string;
 	page: number;
-	setPage: (page: number, shouldExpand: boolean) => void;
+	setPage: (page: number) => void;
 	filters: FilterOptions;
 	topLevelCommentCount: number;
 	loading: boolean;
@@ -273,7 +273,7 @@ export const Comments = ({
 	};
 
 	const onPageChange = (pageNumber: number) => {
-		setPage(pageNumber, true);
+		setPage(pageNumber);
 	};
 
 	initialiseApi({ additionalHeaders, baseUrl, apiKey, idApiUrl });

--- a/dotcom-rendering/src/lib/getCommentContext.ts
+++ b/dotcom-rendering/src/lib/getCommentContext.ts
@@ -1,20 +1,5 @@
 import { isOneOf, isString, joinUrl, storage } from '@guardian/libs';
 
-// GET http://discussion.guardianapis.com/discussion-api/comment/3519111/context
-// {
-//     status: 'ok',
-//     commentId: 3519111,
-//     commentAncestorId: 3519111,
-//     discussionKey: '/p/27y27',
-//     discussionWebUrl:
-//         'https://www.theguardian.com/commentisfree/cifamerica/2009/may/14/washington-post-torture-libel',
-//     discussionApiUrl:
-//         'https://discussion.guardianapis.com/discussion-api/discussion//p/27y27?orderBy=oldest&pageSize=20&page=1',
-//     orderBy: 'oldest',
-//     pageSize: 20,
-//     page: 1,
-// };
-
 const orderByTypes = ['newest', 'oldest', 'recommendations'] as const;
 const threadTypes = ['collapsed', 'expanded', 'unthreaded'] as const;
 const pageSizeTypes = [25, 50, 100] as const;
@@ -23,6 +8,9 @@ type OrderByType = (typeof orderByTypes)[number];
 type ThreadsType = (typeof threadTypes)[number];
 type PageSizeType = (typeof pageSizeTypes)[number];
 
+/**
+ * @see http://discussion.guardianapis.com/discussion-api/comment/3519111/context
+ */
 type CommentContextType = {
 	status: 'ok' | 'error';
 	commentId: number;
@@ -68,7 +56,7 @@ export const initFiltersFromLocalStorage = (): FilterOptions => {
 };
 
 const buildParams = (filters: FilterOptions) => {
-	return {
+	return new URLSearchParams({
 		// Frontend uses the 'recommendations' key to store this options but the api expects
 		// 'mostRecommended' so we have to map here to support both
 		orderBy:
@@ -79,16 +67,17 @@ const buildParams = (filters: FilterOptions) => {
 		displayThreaded: String(
 			filters.threads === 'collapsed' || filters.threads === 'expanded',
 		),
-	};
+	});
 };
 
 export const getCommentContext = async (
 	ajaxUrl: string,
 	commentId: number,
+	filters: FilterOptions,
 ): Promise<CommentContextType> => {
 	const url = joinUrl(ajaxUrl, 'comment', commentId.toString(), 'context');
-	const filters = initFiltersFromLocalStorage();
-	const params = new URLSearchParams(buildParams(filters));
+
+	const params = buildParams(filters);
 
 	return fetch(url + '?' + params.toString())
 		.then((response) => {


### PR DESCRIPTION
## What does this change?

- Ensure that requests to `getDiscussion` and `getCommentContext` use valid filters
- pass the filters to `getCommentContext` to make it more pure

## Why?

When getting the comment context and discussion, we need to use a valid set of filters.
    
Adding `validFilters` to the list of dependencies for the hooks results in infinite loops, so it must be called inside the callbacks.


Fixes #10497

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/76776/1283905b-9019-49b6-9179-1687c4d89115
[after]: https://github.com/guardian/dotcom-rendering/assets/76776/f729d4b9-9bd7-4ecc-8ed1-82d7e2ab182d
