### PR TITLE
Add Constructors For `Result`

### DIFF
--- a/dotcom-rendering/src/components/Discussion/AbuseReportForm.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/AbuseReportForm.stories.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react';
 import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
 import { splitTheme } from '../../../.storybook/decorators/splitThemeDecorator';
+import { ok } from '../../lib/result';
 import { AbuseReportForm } from './AbuseReportForm';
 
 type Props = Parameters<typeof AbuseReportForm>[0];
@@ -26,7 +27,7 @@ export const Dialog = (args: Props) => (
 		<AbuseReportForm
 			toggleSetShowForm={args.toggleSetShowForm}
 			commentId={123}
-			reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
+			reportAbuse={() => Promise.resolve(ok(true))}
 		/>
 	</div>
 );

--- a/dotcom-rendering/src/components/Discussion/AbuseReportForm.test.tsx
+++ b/dotcom-rendering/src/components/Discussion/AbuseReportForm.test.tsx
@@ -3,6 +3,7 @@ import { fireEvent, render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { reportAbuse } from '../../lib/discussionApi';
 import { mockRESTCalls } from '../../lib/mockRESTCalls';
+import { ok } from '../../lib/result';
 import { AbuseReportForm } from './AbuseReportForm';
 
 const fetchMock = mockRESTCalls();
@@ -13,7 +14,7 @@ describe('Dropdown', () => {
 			<AbuseReportForm
 				toggleSetShowForm={() => undefined}
 				commentId={123}
-				reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
+				reportAbuse={() => Promise.resolve(ok(true))}
 			/>,
 		);
 
@@ -27,7 +28,7 @@ describe('Dropdown', () => {
 			<AbuseReportForm
 				toggleSetShowForm={() => undefined}
 				commentId={123}
-				reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
+				reportAbuse={() => Promise.resolve(ok(true))}
 			/>,
 		);
 

--- a/dotcom-rendering/src/components/Discussion/Comment.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comment.stories.tsx
@@ -1,5 +1,6 @@
 import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
 import { splitTheme } from '../../../.storybook/decorators/splitThemeDecorator';
+import { ok } from '../../lib/result';
 import type { CommentType, Reader, Staff } from '../../types/discussion';
 import { Comment } from './Comment';
 
@@ -128,8 +129,8 @@ const user: Reader = {
 	onComment: () => Promise.resolve(commentResponseError),
 	onReply: () => Promise.resolve(commentResponseError),
 	onRecommend: () => Promise.resolve(true),
-	addUsername: () => Promise.resolve({ kind: 'ok', value: true }),
-	reportAbuse: () => Promise.resolve({ kind: 'ok', value: true }),
+	addUsername: () => Promise.resolve(ok(true)),
+	reportAbuse: () => Promise.resolve(ok(true)),
 };
 
 const staffUser: Staff = {
@@ -151,10 +152,10 @@ const staffUser: Staff = {
 	onComment: () => Promise.resolve(commentResponseError),
 	onReply: () => Promise.resolve(commentResponseError),
 	onRecommend: () => Promise.resolve(true),
-	addUsername: () => Promise.resolve({ kind: 'ok', value: true }),
+	addUsername: () => Promise.resolve(ok(true)),
 	onPick: () => Promise.resolve(commentResponseError),
 	onUnpick: () => Promise.resolve(commentResponseError),
-	reportAbuse: () => Promise.resolve({ kind: 'ok', value: true }),
+	reportAbuse: () => Promise.resolve(ok(true)),
 };
 
 const defaultFormat = {

--- a/dotcom-rendering/src/components/Discussion/CommentContainer.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentContainer.stories.tsx
@@ -1,5 +1,6 @@
 import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
 import { splitTheme } from '../../../.storybook/decorators/splitThemeDecorator';
+import { ok } from '../../lib/result';
 import type { CommentType, Reader } from '../../types/discussion';
 import { CommentContainer } from './CommentContainer';
 
@@ -157,8 +158,8 @@ const aUser: Reader = {
 	onComment: () => Promise.resolve(commentResponseError),
 	onReply: () => Promise.resolve(commentResponseError),
 	onRecommend: () => Promise.resolve(true),
-	addUsername: () => Promise.resolve({ kind: 'ok', value: true }),
-	reportAbuse: () => Promise.resolve({ kind: 'ok', value: true }),
+	addUsername: () => Promise.resolve(ok(true)),
+	reportAbuse: () => Promise.resolve(ok(true)),
 };
 
 const commentDataThreaded: CommentType = {
@@ -213,7 +214,7 @@ export const defaultStory = () => (
 		setPreviewBody={() => {}}
 		body={''}
 		setBody={() => {}}
-		reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
+		reportAbuse={() => Promise.resolve(ok(true))}
 	/>
 );
 defaultStory.storyName = 'default';
@@ -254,7 +255,7 @@ export const threadedComment = () => (
 		setPreviewBody={() => {}}
 		body={''}
 		setBody={() => {}}
-		reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
+		reportAbuse={() => Promise.resolve(ok(true))}
 	/>
 );
 threadedComment.storyName = 'threaded';
@@ -295,7 +296,7 @@ export const threadedCommentWithShowMore = () => (
 		setPreviewBody={() => {}}
 		body={''}
 		setBody={() => {}}
-		reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
+		reportAbuse={() => Promise.resolve(ok(true))}
 	/>
 );
 threadedCommentWithShowMore.storyName = 'threaded with show more button';
@@ -336,7 +337,7 @@ export const threadedCommentWithLongUsernames = () => (
 		setPreviewBody={() => {}}
 		body={''}
 		setBody={() => {}}
-		reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
+		reportAbuse={() => Promise.resolve(ok(true))}
 	/>
 );
 threadedCommentWithLongUsernames.storyName = 'threaded with long usernames';
@@ -377,7 +378,7 @@ export const threadedCommentWithLongUsernamesMobile = () => (
 		setPreviewBody={() => {}}
 		body={''}
 		setBody={() => {}}
-		reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
+		reportAbuse={() => Promise.resolve(ok(true))}
 	/>
 );
 threadedCommentWithLongUsernamesMobile.storyName =

--- a/dotcom-rendering/src/components/Discussion/CommentContainer.test.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentContainer.test.tsx
@@ -2,7 +2,7 @@ import '@testing-library/jest-dom/extend-expect';
 import { fireEvent, render, waitFor } from '@testing-library/react';
 import { comment } from '../../../fixtures/manual/comment';
 import { mockedMessageID, mockRESTCalls } from '../../lib/mockRESTCalls';
-import type { Result } from '../../lib/result';
+import { error, ok } from '../../lib/result';
 import type { CommentType, SignedInUser } from '../../types/discussion';
 import { CommentContainer } from './CommentContainer';
 
@@ -20,15 +20,9 @@ const commentWithoutReply = {
 	responses: [],
 } satisfies CommentType;
 
-const commentResponseError = {
-	kind: 'error',
-	error: 'NetworkError',
-} as const satisfies Result<unknown, unknown>;
+const commentResponseError = error<'NetworkError', number>('NetworkError');
 
-const commentResponseSuccess = {
-	kind: 'ok',
-	value: 123456,
-} as const satisfies Result<unknown, unknown>;
+const commentResponseSuccess = ok<'NetworkError', number>(123456);
 
 const aUser: SignedInUser = {
 	kind: 'Reader',
@@ -49,8 +43,8 @@ const aUser: SignedInUser = {
 	onComment: () => Promise.resolve(commentResponseError),
 	onReply: () => Promise.resolve(commentResponseSuccess),
 	onRecommend: () => Promise.resolve(true),
-	addUsername: () => Promise.resolve({ kind: 'ok', value: true }),
-	reportAbuse: () => Promise.resolve({ kind: 'ok', value: true }),
+	addUsername: () => Promise.resolve(ok(true)),
+	reportAbuse: () => Promise.resolve(ok(true)),
 };
 
 describe('CommentContainer', () => {
@@ -95,7 +89,7 @@ describe('CommentContainer', () => {
 				setPreviewBody={() => {}}
 				body={newCommentText}
 				setBody={() => {}}
-				reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
+				reportAbuse={() => Promise.resolve(ok(true))}
 			/>,
 		);
 
@@ -147,7 +141,7 @@ describe('CommentContainer', () => {
 				setPreviewBody={() => {}}
 				body={''}
 				setBody={() => {}}
-				reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
+				reportAbuse={() => Promise.resolve(ok(true))}
 			/>,
 		);
 
@@ -198,7 +192,7 @@ describe('CommentContainer', () => {
 				setPreviewBody={() => {}}
 				body={newCommentText}
 				setBody={() => {}}
-				reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
+				reportAbuse={() => Promise.resolve(ok(true))}
 			/>,
 		);
 
@@ -250,7 +244,7 @@ describe('CommentContainer', () => {
 				setPreviewBody={() => {}}
 				body={''}
 				setBody={() => {}}
-				reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
+				reportAbuse={() => Promise.resolve(ok(true))}
 			/>,
 		);
 

--- a/dotcom-rendering/src/components/Discussion/CommentForm.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentForm.stories.tsx
@@ -1,6 +1,7 @@
 import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
 import { useState } from 'react';
 import { splitTheme } from '../../../.storybook/decorators/splitThemeDecorator';
+import { ok } from '../../lib/result';
 import type { CommentType, Reader } from '../../types/discussion';
 import { CommentForm } from './CommentForm';
 
@@ -38,8 +39,8 @@ const aUser: Reader = {
 	onComment: () => Promise.resolve(commentResponseError),
 	onReply: () => Promise.resolve(commentResponseError),
 	onRecommend: () => Promise.resolve(true),
-	addUsername: () => Promise.resolve({ kind: 'ok', value: true }),
-	reportAbuse: () => Promise.resolve({ kind: 'ok', value: true }),
+	addUsername: () => Promise.resolve(ok(true)),
+	reportAbuse: () => Promise.resolve(ok(true)),
 };
 
 const aComment: CommentType = {

--- a/dotcom-rendering/src/components/Discussion/Comments.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comments.stories.tsx
@@ -6,6 +6,7 @@ import { lightDecorator } from '../../../.storybook/decorators/themeDecorator';
 import { discussion as discussionMock } from '../../../fixtures/manual/discussion';
 import { discussionWithTwoComments } from '../../../fixtures/manual/discussionWithTwoComments';
 import { legacyDiscussionWithoutThreading } from '../../../fixtures/manual/legacyDiscussionWithoutThreading';
+import { ok } from '../../lib/result';
 import type { FilterOptions, Reader } from '../../types/discussion';
 import { Comments } from './Comments';
 
@@ -35,8 +36,8 @@ const aUser: Reader = {
 	onComment: () => Promise.resolve(commentResponseError),
 	onReply: () => Promise.resolve(commentResponseError),
 	onRecommend: () => Promise.resolve(true),
-	addUsername: () => Promise.resolve({ kind: 'ok', value: true }),
-	reportAbuse: () => Promise.resolve({ kind: 'ok', value: true }),
+	addUsername: () => Promise.resolve(ok(true)),
+	reportAbuse: () => Promise.resolve(ok(true)),
 };
 
 const format = {
@@ -112,7 +113,7 @@ export const LoggedOutHiddenPicks = () => (
 			topForm={defaultCommentForm}
 			replyForm={defaultCommentForm}
 			bottomForm={defaultCommentForm}
-			reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
+			reportAbuse={() => Promise.resolve(ok(true))}
 		/>
 	</div>
 );
@@ -178,7 +179,7 @@ export const InitialPage = () => (
 			topForm={defaultCommentForm}
 			replyForm={defaultCommentForm}
 			bottomForm={defaultCommentForm}
-			reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
+			reportAbuse={() => Promise.resolve(ok(true))}
 		/>
 	</div>
 );
@@ -249,7 +250,7 @@ export const LoggedInHiddenNoPicks = () => {
 				topForm={defaultCommentForm}
 				replyForm={{ ...defaultCommentForm, isActive, body }}
 				bottomForm={defaultCommentForm}
-				reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
+				reportAbuse={() => Promise.resolve(ok(true))}
 			/>
 		</div>
 	);
@@ -331,7 +332,7 @@ export const LoggedIn = () => {
 					isActive: isBottomFormActive,
 					body: bottomFormBody,
 				}}
-				reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
+				reportAbuse={() => Promise.resolve(ok(true))}
 			/>
 		</div>
 	);
@@ -406,7 +407,7 @@ export const LoggedInShortDiscussion = () => {
 					body: replyFormBody,
 				}}
 				bottomForm={defaultCommentForm}
-				reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
+				reportAbuse={() => Promise.resolve(ok(true))}
 			/>
 		</div>
 	);
@@ -465,7 +466,7 @@ export const LoggedOutHiddenNoPicks = () => (
 			topForm={defaultCommentForm}
 			replyForm={defaultCommentForm}
 			bottomForm={defaultCommentForm}
-			reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
+			reportAbuse={() => Promise.resolve(ok(true))}
 		/>
 	</div>
 );
@@ -533,7 +534,7 @@ export const Closed = () => (
 			topForm={defaultCommentForm}
 			replyForm={defaultCommentForm}
 			bottomForm={defaultCommentForm}
-			reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
+			reportAbuse={() => Promise.resolve(ok(true))}
 		/>
 	</div>
 );
@@ -597,7 +598,7 @@ export const NoComments = () => (
 			topForm={defaultCommentForm}
 			replyForm={defaultCommentForm}
 			bottomForm={defaultCommentForm}
-			reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
+			reportAbuse={() => Promise.resolve(ok(true))}
 		/>
 	</div>
 );
@@ -663,7 +664,7 @@ export const LegacyDiscussion = () => (
 			topForm={defaultCommentForm}
 			replyForm={defaultCommentForm}
 			bottomForm={defaultCommentForm}
-			reportAbuse={() => Promise.resolve({ kind: 'ok', value: true })}
+			reportAbuse={() => Promise.resolve(ok(true))}
 		/>
 	</div>
 );

--- a/dotcom-rendering/src/components/Discussion/Discussion.test.tsx
+++ b/dotcom-rendering/src/components/Discussion/Discussion.test.tsx
@@ -5,6 +5,7 @@ import {
 	waitForElementToBeRemoved,
 } from '@testing-library/react';
 import { mockRESTCalls } from '../../lib/mockRESTCalls';
+import { ok } from '../../lib/result';
 import { Discussion } from '../Discussion';
 
 mockRESTCalls();
@@ -20,9 +21,7 @@ describe('App', () => {
 				discussionApiClientHeader="testClientHeader"
 				enableDiscussionSwitch={true}
 				idApiUrl="https://idapi.theguardian.com"
-				reportAbuseUnauthenticated={() =>
-					Promise.resolve({ kind: 'ok', value: true })
-				}
+				reportAbuseUnauthenticated={() => Promise.resolve(ok(true))}
 			/>,
 		);
 

--- a/dotcom-rendering/src/components/Discussion/RecommendationCount.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/RecommendationCount.stories.tsx
@@ -1,5 +1,6 @@
 import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
 import { splitTheme } from '../../../.storybook/decorators/splitThemeDecorator';
+import { ok } from '../../lib/result';
 import { palette as themePalette } from '../../palette';
 import type { SignedInUser } from '../../types/discussion';
 import { RecommendationCount } from './RecommendationCount';
@@ -30,8 +31,8 @@ const aUser = {
 	onComment: () => Promise.resolve(commentResponseError),
 	onReply: () => Promise.resolve(commentResponseError),
 	onRecommend: () => Promise.resolve(true),
-	addUsername: () => Promise.resolve({ kind: 'ok', value: true }),
-	reportAbuse: () => Promise.resolve({ kind: 'ok', value: true }),
+	addUsername: () => Promise.resolve(ok(true)),
+	reportAbuse: () => Promise.resolve(ok(true)),
 } satisfies SignedInUser;
 
 const Wrapper = ({ children }: { children: React.ReactNode }) => (

--- a/dotcom-rendering/src/components/Discussion/TopPick.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/TopPick.stories.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react';
 import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
 import { splitTheme } from '../../../.storybook/decorators/splitThemeDecorator';
+import { ok } from '../../lib/result';
 import type { CommentType, SignedInUser } from '../../types/discussion';
 import { TopPick } from './TopPick';
 
@@ -101,8 +102,8 @@ const aUser = {
 	onComment: () => Promise.resolve(commentResponseError),
 	onReply: () => Promise.resolve(commentResponseError),
 	onRecommend: () => Promise.resolve(true),
-	addUsername: () => Promise.resolve({ kind: 'ok', value: true }),
-	reportAbuse: () => Promise.resolve({ kind: 'ok', value: true }),
+	addUsername: () => Promise.resolve(ok(true)),
+	reportAbuse: () => Promise.resolve(ok(true)),
 } satisfies SignedInUser;
 
 export const LongPick = () => (

--- a/dotcom-rendering/src/components/Discussion/TopPicks.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/TopPicks.stories.tsx
@@ -1,5 +1,6 @@
 import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
 import { splitTheme } from '../../../.storybook/decorators/splitThemeDecorator';
+import { ok } from '../../lib/result';
 import type { CommentType, SignedInUser } from '../../types/discussion';
 import { TopPicks } from './TopPicks';
 
@@ -80,8 +81,8 @@ const aUser = {
 	onComment: () => Promise.resolve(commentResponseError),
 	onReply: () => Promise.resolve(commentResponseError),
 	onRecommend: () => Promise.resolve(true),
-	addUsername: () => Promise.resolve({ kind: 'ok', value: true }),
-	reportAbuse: () => Promise.resolve({ kind: 'ok', value: true }),
+	addUsername: () => Promise.resolve(ok(true)),
+	reportAbuse: () => Promise.resolve(ok(true)),
 } satisfies SignedInUser;
 
 export const SingleComment = () => (

--- a/dotcom-rendering/src/lib/discussionApi.tsx
+++ b/dotcom-rendering/src/lib/discussionApi.tsx
@@ -19,7 +19,7 @@ import {
 import type { SignedInWithCookies, SignedInWithOkta } from './identity';
 import { getOptionsHeadersWithOkta } from './identity';
 import { fetchJSON } from './json';
-import type { Result } from './result';
+import { error, ok, type Result } from './result';
 
 const options = {
 	// Defaults
@@ -101,7 +101,7 @@ export const getDiscussion = async (
 
 	const result = safeParse(discussionApiResponseSchema, jsonResult.value);
 	if (!result.success) {
-		return { kind: 'error', error: 'ParsingError' };
+		return error('ParsingError');
 	}
 	if (
 		result.output.status === 'error' &&
@@ -116,13 +116,10 @@ export const getDiscussion = async (
 		});
 	}
 	if (result.output.status === 'error') {
-		return {
-			kind: 'error',
-			error: 'ApiError',
-		};
+		return error('ApiError');
 	}
 
-	return { kind: 'ok', value: result.output };
+	return ok(result.output);
 };
 
 export const preview = async (
@@ -146,11 +143,8 @@ export const preview = async (
 	if (jsonResult.kind === 'error') return jsonResult;
 
 	return isObject(jsonResult.value) && isString(jsonResult.value.commentBody)
-		? { kind: 'ok', value: jsonResult.value.commentBody }
-		: {
-				kind: 'error',
-				error: 'ParsingError',
-		  };
+		? ok(jsonResult.value.commentBody)
+		: error('ParsingError');
 };
 
 type CommentResponse = Result<
@@ -241,13 +235,13 @@ export const getPicks = async (
 	const result = safeParse(discussionApiResponseSchema, jsonResult.value);
 
 	if (!result.success) {
-		return { kind: 'error', error: 'ParsingError' };
+		return error('ParsingError');
 	}
 	if (result.output.status === 'error') {
-		return { kind: 'error', error: 'ApiError' };
+		return error('ApiError');
 	}
 
-	return { kind: 'ok', value: result.output.discussion.comments };
+	return ok(result.output.discussion.comments);
 };
 
 export const reportAbuse =
@@ -292,10 +286,7 @@ export const reportAbuse =
 		});
 
 		if (jsonResult.kind === 'error') {
-			return {
-				kind: 'error',
-				error: 'An unknown error occured',
-			};
+			return error('An unknown error occured');
 		}
 
 		return parseAbuseResponse(jsonResult.value);
@@ -354,18 +345,15 @@ export const addUserName =
 		const result = safeParse(postUsernameResponseSchema, jsonResult.value);
 
 		if (!result.success) {
-			return { kind: 'error', error: 'An unknown error occured' };
+			return error('An unknown error occured');
 		}
 		if (result.output.status === 'error') {
-			return {
-				kind: 'error',
-				error: result.output.errors
-					.map(({ message }) => message)
-					.join('\n'),
-			};
+			return error(
+				result.output.errors.map(({ message }) => message).join('\n'),
+			);
 		}
 
-		return { kind: 'ok', value: true };
+		return ok(true);
 	};
 
 export const pickComment =
@@ -394,9 +382,9 @@ export const pickComment =
 
 		const result = safeParse(pickResponseSchema, jsonResult.value);
 
-		if (!result.success) return { kind: 'error', error: 'ParsingError' };
+		if (!result.success) return error('ParsingError');
 
-		return { kind: 'ok', value: true };
+		return ok(true);
 	};
 
 export const unPickComment =
@@ -425,9 +413,9 @@ export const unPickComment =
 
 		const result = safeParse(pickResponseSchema, jsonResult.value);
 
-		if (!result.success) return { kind: 'error', error: 'ParsingError' };
+		if (!result.success) return error('ParsingError');
 
-		return { kind: 'ok', value: false };
+		return ok(false);
 	};
 
 export const getMoreResponses = async (

--- a/dotcom-rendering/src/lib/json.ts
+++ b/dotcom-rendering/src/lib/json.ts
@@ -1,4 +1,4 @@
-import type { Result } from './result';
+import { error, ok, type Result } from './result';
 
 /**
  * Safely fetch JSON from a URL.
@@ -10,12 +10,12 @@ export const fetchJSON = async (
 ): Promise<Result<'ApiError' | 'NetworkError', unknown>> => {
 	try {
 		const response = await fetch(...args);
-		return { kind: 'ok', value: await response.json() };
-	} catch (error) {
-		if (error instanceof SyntaxError) {
-			return { kind: 'error', error: 'ApiError' };
+		return ok(await response.json());
+	} catch (err) {
+		if (err instanceof SyntaxError) {
+			return error('ApiError');
 		}
 
-		return { kind: 'error', error: 'NetworkError' };
+		return error('NetworkError');
 	}
 };

--- a/dotcom-rendering/src/lib/result.ts
+++ b/dotcom-rendering/src/lib/result.ts
@@ -8,4 +8,16 @@ type Result<Err, Value> =
 			error: Err;
 	  };
 
+const ok = <Err, Value>(value: Value): Result<Err, Value> => ({
+	kind: 'ok',
+	value,
+});
+
+const error = <Err, Value>(err: Err): Result<Err, Value> => ({
+	kind: 'error',
+	error: err,
+});
+
 export type { Result };
+
+export { ok, error };

--- a/dotcom-rendering/src/types/discussion.ts
+++ b/dotcom-rendering/src/types/discussion.ts
@@ -27,7 +27,7 @@ import type {
 } from '../lib/discussionApi';
 import type { Guard } from '../lib/guard';
 import { guard } from '../lib/guard';
-import type { Result } from '../lib/result';
+import { error, ok, type Result } from '../lib/result';
 
 export type CAPIPillar =
 	| 'news'
@@ -132,12 +132,12 @@ export const parseCommentRepliesResponse = (
 ): Result<'ParsingError' | 'ApiError', CommentType[]> => {
 	const result = safeParse(discussionApiCommentSuccessSchema, data);
 	if (!result.success) {
-		return { kind: 'error', error: 'ParsingError' };
+		return error('ParsingError');
 	}
 	if (result.output.status === 'error') {
-		return { kind: 'error', error: 'ApiError' };
+		return error('ApiError');
 	}
-	return { kind: 'ok', value: result.output.comment.responses ?? [] };
+	return ok(result.output.comment.responses ?? []);
 };
 
 export interface CommentType {
@@ -220,20 +220,14 @@ export const parseCommentResponse = (
 ): Result<'ParsingError' | CommentResponseErrorCodes, number> => {
 	const { success, output } = safeParse(commentResponseSchema, data);
 	if (!success) {
-		return {
-			kind: 'error',
-			error: 'ParsingError',
-		};
+		return error('ParsingError');
 	}
 
 	if (output.status === 'error') {
-		return {
-			kind: 'error',
-			error: output.errorCode,
-		};
+		return error(output.errorCode);
 	}
 
-	return { kind: 'ok', value: output.message };
+	return ok(output.message);
 };
 
 const abuseResponseSchema = variant('status', [
@@ -249,11 +243,9 @@ const abuseResponseSchema = variant('status', [
 export const parseAbuseResponse = (data: unknown): Result<string, true> => {
 	const { success, output } = safeParse(abuseResponseSchema, data);
 	if (!success) {
-		return { kind: 'error', error: 'An unknown error occured' };
+		return error('An unknown error occured');
 	}
-	return output.status === 'ok'
-		? { kind: 'ok', value: true }
-		: { kind: 'error', error: output.message };
+	return output.status === 'ok' ? ok(true) : error(output.message);
 };
 
 export const postUsernameResponseSchema = variant('status', [


### PR DESCRIPTION
To reduce the boilerplate when creating new values of `Result`. This doesn't preclude writing out the values in full if required, these are just for convenience.
