### PR TITLE
Add `AbortController` to Discussion for guaranteed data freshness

### DIFF
--- a/dotcom-rendering/src/components/Discussion.tsx
+++ b/dotcom-rendering/src/components/Discussion.tsx
@@ -423,11 +423,14 @@ export const Discussion = ({
 	useEffect(() => {
 		dispatch({ type: 'setLoading', loading: true });
 
-		void getDiscussion(
-			shortUrlId,
-			commentPage,
-			remapToValidFilters(filters, hashCommentId),
-		)
+		const controller = new AbortController();
+
+		void getDiscussion({
+			shortUrl: shortUrlId,
+			page: commentPage,
+			filters: remapToValidFilters(filters, hashCommentId),
+			signal: controller.signal,
+		})
 			.then((result) => {
 				if (result.kind === 'error') {
 					console.error(`getDiscussion - error: ${result.error}`);
@@ -447,6 +450,8 @@ export const Discussion = ({
 			.catch(() => {
 				// do nothing
 			});
+
+		return () => controller.abort();
 	}, [commentPage, filters, hashCommentId, shortUrlId]);
 
 	const validFilters = remapToValidFilters(filters, hashCommentId);


### PR DESCRIPTION
## What does this change?

Pass an `AbortSignal` to `getDiscussion` that is aborted on re-renders of the containing `useEffect`.

## Why?

Whenever the `useEffect` where we call `getDiscussion` is re-run, we want to ensure that a preceding call does not respond after the latest run in order to ensure the data is always correct. We also potentially save bandwith for our users.

```js
// ensure your network speed is throttled to make bug more reproducible
(async () => {
  for await (const i of [1,3,1]) {
    await new Promise((resolve) => setTimeout(resolve, 1));
    const selector = `ul#dropbox-id-threads-dropdown li:nth-of-type(${i}) button`;
    document.querySelector(selector)?.click();
  }
})();
```

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/76776/42f50b45-f9fd-4e6d-b383-2f377832355c
[after]: https://github.com/guardian/dotcom-rendering/assets/76776/240343b3-f11f-4d2e-b68d-8ac9d0280f86

> When a permalink is present, we make a new request where the override the filters threads to `expanded`. e.g.: https://www.theguardian.com/food/2024/feb/02/vanilla-lime-dill-tea-cake-recipe-philip-khoury#comment-166348765


<img width="787" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/76776/5594ed9d-8dd7-4f29-8cd6-2569028d72ef">
