### PR TITLE
Move `discussion` Out Of `types` Into `lib`

### DIFF
--- a/dotcom-rendering/fixtures/manual/comment.ts
+++ b/dotcom-rendering/fixtures/manual/comment.ts
@@ -1,4 +1,4 @@
-import type { CommentType } from '../../src/types/discussion';
+import type { CommentType } from '../../src/lib/discussion';
 
 export const comment = {
 	id: 138809272,

--- a/dotcom-rendering/fixtures/manual/discussion-no-top-comments.ts
+++ b/dotcom-rendering/fixtures/manual/discussion-no-top-comments.ts
@@ -1,4 +1,4 @@
-import type { GetDiscussionSuccess } from '../../src/types/discussion';
+import type { GetDiscussionSuccess } from '../../src/lib/discussion';
 
 export const discussionNoTopComments = {
 	status: 'ok',

--- a/dotcom-rendering/fixtures/manual/discussion.ts
+++ b/dotcom-rendering/fixtures/manual/discussion.ts
@@ -1,4 +1,4 @@
-import type { GetDiscussionSuccess } from '../../src/types/discussion';
+import type { GetDiscussionSuccess } from '../../src/lib/discussion';
 
 export const discussion = {
 	status: 'ok',

--- a/dotcom-rendering/fixtures/manual/discussionWithNoComments.ts
+++ b/dotcom-rendering/fixtures/manual/discussionWithNoComments.ts
@@ -1,4 +1,4 @@
-import type { GetDiscussionSuccess } from '../../src/types/discussion';
+import type { GetDiscussionSuccess } from '../../src/lib/discussion';
 
 export const discussionWithNoComments = {
 	status: 'ok',

--- a/dotcom-rendering/fixtures/manual/discussionWithTwoComments.ts
+++ b/dotcom-rendering/fixtures/manual/discussionWithTwoComments.ts
@@ -1,4 +1,4 @@
-import type { GetDiscussionSuccess } from '../../src/types/discussion';
+import type { GetDiscussionSuccess } from '../../src/lib/discussion';
 
 export const discussionWithTwoComments = {
 	status: 'ok',

--- a/dotcom-rendering/fixtures/manual/short-discussion.ts
+++ b/dotcom-rendering/fixtures/manual/short-discussion.ts
@@ -1,4 +1,4 @@
-import type { GetDiscussionSuccess } from '../../src/types/discussion';
+import type { GetDiscussionSuccess } from '../../src/lib/discussion';
 
 export const shortDiscussion = {
 	status: 'ok',

--- a/dotcom-rendering/fixtures/manual/topPicks.ts
+++ b/dotcom-rendering/fixtures/manual/topPicks.ts
@@ -1,4 +1,4 @@
-import type { GetDiscussionSuccess } from '../../src/types/discussion';
+import type { GetDiscussionSuccess } from '../../src/lib/discussion';
 
 export const topPicks = {
 	status: 'ok',

--- a/dotcom-rendering/src/components/Discussion.tsx
+++ b/dotcom-rendering/src/components/Discussion.tsx
@@ -4,18 +4,18 @@ import { palette, space } from '@guardian/source-foundations';
 import { Button, SvgPlus } from '@guardian/source-react-components';
 import { useEffect, useReducer } from 'react';
 import { assertUnreachable } from '../lib/assert-unreachable';
+import type {
+	CommentForm,
+	CommentType,
+	FilterOptions,
+	SignedInUser,
+} from '../lib/discussion';
 import { getDiscussion, type reportAbuse } from '../lib/discussionApi';
 import {
 	getCommentContext,
 	initFiltersFromLocalStorage,
 } from '../lib/getCommentContext';
 import { palette as themePalette } from '../palette';
-import type {
-	CommentForm,
-	CommentType,
-	FilterOptions,
-	SignedInUser,
-} from '../types/discussion';
 import { Comments } from './Discussion/Comments';
 import { Hide } from './Hide';
 import { SignedInAs } from './SignedInAs';

--- a/dotcom-rendering/src/components/Discussion/Comment.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comment.stories.tsx
@@ -1,7 +1,7 @@
 import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
 import { splitTheme } from '../../../.storybook/decorators/splitThemeDecorator';
+import type { CommentType, Reader, Staff } from '../../lib/discussion';
 import { ok } from '../../lib/result';
-import type { CommentType, Reader, Staff } from '../../types/discussion';
 import { Comment } from './Comment';
 
 type Props = Parameters<typeof Comment>[0];

--- a/dotcom-rendering/src/components/Discussion/Comment.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comment.tsx
@@ -9,10 +9,10 @@ import {
 } from '@guardian/source-foundations';
 import { Button, Link, SvgIndent } from '@guardian/source-react-components';
 import { useState } from 'react';
+import type { CommentType, SignedInUser, Staff } from '../../lib/discussion';
 import type { reportAbuse } from '../../lib/discussionApi';
 import { createAuthenticationEventParams } from '../../lib/identity-component-event';
 import { palette as schemedPalette } from '../../palette';
-import type { CommentType, SignedInUser, Staff } from '../../types/discussion';
 import { AbuseReportForm } from './AbuseReportForm';
 import { Avatar } from './Avatar';
 import { GuardianContributor, GuardianPick, GuardianStaff } from './Badges';

--- a/dotcom-rendering/src/components/Discussion/CommentContainer.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentContainer.stories.tsx
@@ -1,7 +1,7 @@
 import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
 import { splitTheme } from '../../../.storybook/decorators/splitThemeDecorator';
+import type { CommentType, Reader } from '../../lib/discussion';
 import { ok } from '../../lib/result';
-import type { CommentType, Reader } from '../../types/discussion';
 import { CommentContainer } from './CommentContainer';
 
 export default { title: 'Discussion/CommentContainer' };

--- a/dotcom-rendering/src/components/Discussion/CommentContainer.test.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentContainer.test.tsx
@@ -1,9 +1,9 @@
 import '@testing-library/jest-dom/extend-expect';
 import { fireEvent, render, waitFor } from '@testing-library/react';
 import { comment } from '../../../fixtures/manual/comment';
+import type { CommentType, SignedInUser } from '../../lib/discussion';
 import { mockedMessageID, mockRESTCalls } from '../../lib/mockRESTCalls';
 import { error, ok } from '../../lib/result';
-import type { CommentType, SignedInUser } from '../../types/discussion';
 import { CommentContainer } from './CommentContainer';
 
 mockRESTCalls();

--- a/dotcom-rendering/src/components/Discussion/CommentContainer.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentContainer.tsx
@@ -2,13 +2,13 @@ import { css } from '@emotion/react';
 import { palette as sourcePalette, space } from '@guardian/source-foundations';
 import { SvgPlus } from '@guardian/source-react-components';
 import { useEffect, useState } from 'react';
-import type { preview, reportAbuse } from '../../lib/discussionApi';
-import { getMoreResponses } from '../../lib/discussionApi';
 import type {
 	CommentType,
 	SignedInUser,
 	ThreadsType,
-} from '../../types/discussion';
+} from '../../lib/discussion';
+import type { preview, reportAbuse } from '../../lib/discussionApi';
+import { getMoreResponses } from '../../lib/discussionApi';
 import { Comment } from './Comment';
 import { CommentForm } from './CommentForm';
 import { CommentReplyPreview } from './CommentReplyPreview';

--- a/dotcom-rendering/src/components/Discussion/CommentForm.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentForm.stories.tsx
@@ -1,8 +1,8 @@
 import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
 import { useState } from 'react';
 import { splitTheme } from '../../../.storybook/decorators/splitThemeDecorator';
+import type { CommentType, Reader } from '../../lib/discussion';
 import { ok } from '../../lib/result';
-import type { CommentType, Reader } from '../../types/discussion';
 import { CommentForm } from './CommentForm';
 
 export default { component: CommentForm, title: 'Discussion/CommentForm' };

--- a/dotcom-rendering/src/components/Discussion/CommentForm.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentForm.tsx
@@ -6,13 +6,13 @@ import {
 	textSans,
 } from '@guardian/source-foundations';
 import { useEffect, useRef } from 'react';
-import { preview as defaultPreview } from '../../lib/discussionApi';
-import { palette as schemedPalette } from '../../palette';
 import type {
 	CommentType,
 	SignedInUser,
 	UserProfile,
-} from '../../types/discussion';
+} from '../../lib/discussion';
+import { preview as defaultPreview } from '../../lib/discussionApi';
+import { palette as schemedPalette } from '../../palette';
 import { FirstCommentWelcome } from './FirstCommentWelcome';
 import { PillarButton } from './PillarButton';
 import { Preview } from './Preview';

--- a/dotcom-rendering/src/components/Discussion/CommentReplyPreview.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentReplyPreview.stories.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
 import { splitTheme } from '../../../.storybook/decorators/splitThemeDecorator';
-import type { CommentType } from '../../types/discussion';
+import type { CommentType } from '../../lib/discussion';
 import { CommentReplyPreview, Preview } from './CommentReplyPreview';
 
 const defaultFormat = {

--- a/dotcom-rendering/src/components/Discussion/CommentReplyPreview.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentReplyPreview.tsx
@@ -6,8 +6,8 @@ import {
 } from '@guardian/source-foundations';
 import { Button, SvgIndent } from '@guardian/source-react-components';
 import { useState } from 'react';
+import type { CommentType } from '../../lib/discussion';
 import { palette as schemedPalette } from '../../palette';
-import type { CommentType } from '../../types/discussion';
 import { Row } from './Row';
 
 type Props = {

--- a/dotcom-rendering/src/components/Discussion/Comments.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comments.stories.tsx
@@ -6,8 +6,8 @@ import { lightDecorator } from '../../../.storybook/decorators/themeDecorator';
 import { discussion as discussionMock } from '../../../fixtures/manual/discussion';
 import { discussionWithTwoComments } from '../../../fixtures/manual/discussionWithTwoComments';
 import { legacyDiscussionWithoutThreading } from '../../../fixtures/manual/legacyDiscussionWithoutThreading';
+import type { FilterOptions, Reader } from '../../lib/discussion';
 import { ok } from '../../lib/result';
-import type { FilterOptions, Reader } from '../../types/discussion';
 import { Comments } from './Comments';
 
 export default { component: Comments, title: 'Discussion/App' };

--- a/dotcom-rendering/src/components/Discussion/Comments.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comments.tsx
@@ -6,15 +6,15 @@ import {
 	textSans,
 } from '@guardian/source-foundations';
 import { useEffect, useState } from 'react';
-import type { preview, reportAbuse } from '../../lib/discussionApi';
-import { getPicks, initialiseApi } from '../../lib/discussionApi';
 import type {
 	AdditionalHeadersType,
 	CommentType,
 	FilterOptions,
 	CommentForm as Form,
 	SignedInUser,
-} from '../../types/discussion';
+} from '../../lib/discussion';
+import type { preview, reportAbuse } from '../../lib/discussionApi';
+import { getPicks, initialiseApi } from '../../lib/discussionApi';
 import { CommentContainer } from './CommentContainer';
 import { CommentForm } from './CommentForm';
 import { Filters } from './Filters';

--- a/dotcom-rendering/src/components/Discussion/Dropdown.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/Dropdown.stories.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/react';
 import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
 import { useState } from 'react';
 import { splitTheme } from '../../../.storybook/decorators/splitThemeDecorator';
-import type { DropdownOptionType } from '../../types/discussion';
+import type { DropdownOptionType } from '../../lib/discussion';
 import { Dropdown } from './Dropdown';
 
 const Container = ({ children }: { children: React.ReactNode }) => (

--- a/dotcom-rendering/src/components/Discussion/Dropdown.test.tsx
+++ b/dotcom-rendering/src/components/Discussion/Dropdown.test.tsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom/extend-expect';
 import { fireEvent, render, screen } from '@testing-library/react';
-import type { DropdownOptionType } from '../../types/discussion';
+import type { DropdownOptionType } from '../../lib/discussion';
 import { Dropdown } from './Dropdown';
 
 const threadOptions: [

--- a/dotcom-rendering/src/components/Discussion/Dropdown.tsx
+++ b/dotcom-rendering/src/components/Discussion/Dropdown.tsx
@@ -6,8 +6,8 @@ import {
 	until,
 } from '@guardian/source-foundations';
 import { useEffect, useState } from 'react';
+import type { DropdownOptionType } from '../../lib/discussion';
 import { palette as schemedPalette } from '../../palette';
-import type { DropdownOptionType } from '../../types/discussion';
 
 type Props = {
 	id: string;

--- a/dotcom-rendering/src/components/Discussion/Filters.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/Filters.stories.tsx
@@ -1,7 +1,7 @@
 import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
 import { useState } from 'react';
 import { splitTheme } from '../../../.storybook/decorators/splitThemeDecorator';
-import type { FilterOptions } from '../../types/discussion';
+import type { FilterOptions } from '../../lib/discussion';
 import { Filters } from './Filters';
 
 export default { title: 'Discussion/Filters' };

--- a/dotcom-rendering/src/components/Discussion/Filters.tsx
+++ b/dotcom-rendering/src/components/Discussion/Filters.tsx
@@ -5,7 +5,7 @@ import type {
 	OrderByType,
 	PageSizeType,
 	ThreadsType,
-} from '../../types/discussion';
+} from '../../lib/discussion';
 import { Dropdown } from './Dropdown';
 
 type Props = {

--- a/dotcom-rendering/src/components/Discussion/Pagination.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/Pagination.stories.tsx
@@ -1,7 +1,7 @@
 import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
 import { useState } from 'react';
 import { splitTheme } from '../../../.storybook/decorators/splitThemeDecorator';
-import type { FilterOptions } from '../../types/discussion';
+import type { FilterOptions } from '../../lib/discussion';
 import { Pagination } from './Pagination';
 
 const articleFormat: ArticleFormat = {

--- a/dotcom-rendering/src/components/Discussion/Pagination.test.tsx
+++ b/dotcom-rendering/src/components/Discussion/Pagination.test.tsx
@@ -1,5 +1,5 @@
 import { render } from '@testing-library/react';
-import type { FilterOptions } from '../../types/discussion';
+import type { FilterOptions } from '../../lib/discussion';
 import { Pagination } from './Pagination';
 
 const DEFAULT_FILTERS: FilterOptions = {

--- a/dotcom-rendering/src/components/Discussion/Pagination.tsx
+++ b/dotcom-rendering/src/components/Discussion/Pagination.tsx
@@ -10,8 +10,8 @@ import {
 	SvgChevronLeftSingle,
 	SvgChevronRightSingle,
 } from '@guardian/source-react-components';
+import type { FilterOptions } from '../../lib/discussion';
 import { palette as schemedPalette } from '../../palette';
-import type { FilterOptions } from '../../types/discussion';
 
 type Props = {
 	currentPage: number;

--- a/dotcom-rendering/src/components/Discussion/RecommendationCount.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/RecommendationCount.stories.tsx
@@ -1,8 +1,8 @@
 import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
 import { splitTheme } from '../../../.storybook/decorators/splitThemeDecorator';
+import type { SignedInUser } from '../../lib/discussion';
 import { ok } from '../../lib/result';
 import { palette as themePalette } from '../../palette';
-import type { SignedInUser } from '../../types/discussion';
 import { RecommendationCount } from './RecommendationCount';
 
 export default { title: 'Discussion/RecommendationCount' };

--- a/dotcom-rendering/src/components/Discussion/RecommendationCount.tsx
+++ b/dotcom-rendering/src/components/Discussion/RecommendationCount.tsx
@@ -3,8 +3,8 @@ import { textSans } from '@guardian/source-foundations';
 import { SvgArrowUpStraight } from '@guardian/source-react-components';
 import type { MouseEventHandler } from 'react';
 import { useState } from 'react';
+import type { SignedInUser } from '../../lib/discussion';
 import { palette as themePalette } from '../../palette';
-import type { SignedInUser } from '../../types/discussion';
 import { Row } from './Row';
 
 type Props = {

--- a/dotcom-rendering/src/components/Discussion/TopPick.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/TopPick.stories.tsx
@@ -1,8 +1,8 @@
 import { css } from '@emotion/react';
 import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
 import { splitTheme } from '../../../.storybook/decorators/splitThemeDecorator';
+import type { CommentType, SignedInUser } from '../../lib/discussion';
 import { ok } from '../../lib/result';
-import type { CommentType, SignedInUser } from '../../types/discussion';
 import { TopPick } from './TopPick';
 
 export default { component: TopPick, title: 'Discussion/TopPick' };

--- a/dotcom-rendering/src/components/Discussion/TopPick.tsx
+++ b/dotcom-rendering/src/components/Discussion/TopPick.tsx
@@ -6,8 +6,8 @@ import {
 	textSans,
 } from '@guardian/source-foundations';
 import { Link } from '@guardian/source-react-components';
+import type { CommentType, SignedInUser } from '../../lib/discussion';
 import { palette as themePalette } from '../../palette';
-import type { CommentType, SignedInUser } from '../../types/discussion';
 import { Avatar } from './Avatar';
 import { GuardianContributor, GuardianStaff } from './Badges';
 import { Column } from './Column';

--- a/dotcom-rendering/src/components/Discussion/TopPicks.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/TopPicks.stories.tsx
@@ -1,7 +1,7 @@
 import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
 import { splitTheme } from '../../../.storybook/decorators/splitThemeDecorator';
+import type { CommentType, SignedInUser } from '../../lib/discussion';
 import { ok } from '../../lib/result';
-import type { CommentType, SignedInUser } from '../../types/discussion';
 import { TopPicks } from './TopPicks';
 
 export default { component: TopPicks, title: 'Discussion/TopPicks' };

--- a/dotcom-rendering/src/components/Discussion/TopPicks.tsx
+++ b/dotcom-rendering/src/components/Discussion/TopPicks.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import { from, until } from '@guardian/source-foundations';
-import type { CommentType, SignedInUser } from '../../types/discussion';
+import type { CommentType, SignedInUser } from '../../lib/discussion';
 import { TopPick } from './TopPick';
 
 type Props = {

--- a/dotcom-rendering/src/components/DiscussionContainer.importable.tsx
+++ b/dotcom-rendering/src/components/DiscussionContainer.importable.tsx
@@ -1,5 +1,6 @@
 import { isObject, joinUrl } from '@guardian/libs';
 import { useEffect, useState } from 'react';
+import type { SignedInUser, UserProfile } from '../lib/discussion';
 import {
 	addUserName,
 	comment,
@@ -13,7 +14,6 @@ import type { SignedInWithCookies, SignedInWithOkta } from '../lib/identity';
 import { getOptionsHeadersWithOkta } from '../lib/identity';
 import { useAuthStatus } from '../lib/useAuthStatus';
 import { useHydrated } from '../lib/useHydrated';
-import type { SignedInUser, UserProfile } from '../types/discussion';
 import type { Props as DiscussionProps } from './Discussion';
 import { Discussion } from './Discussion';
 import { Placeholder } from './Placeholder';

--- a/dotcom-rendering/src/components/DiscussionMeta.importable.tsx
+++ b/dotcom-rendering/src/components/DiscussionMeta.importable.tsx
@@ -1,9 +1,9 @@
 import { joinUrl } from '@guardian/libs';
+import type { GetDiscussionSuccess, UserProfile } from '../lib/discussion';
 import { getOptionsHeadersWithOkta } from '../lib/identity';
 import { useApi } from '../lib/useApi';
 import { useAuthStatus } from '../lib/useAuthStatus';
 import { useCommentCount } from '../lib/useCommentCount';
-import type { GetDiscussionSuccess, UserProfile } from '../types/discussion';
 import { SignedInAs } from './SignedInAs';
 
 type Props = {

--- a/dotcom-rendering/src/components/HeaderTopBarMyAccount.tsx
+++ b/dotcom-rendering/src/components/HeaderTopBarMyAccount.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/react';
 import { joinUrl } from '@guardian/libs';
 import { from, palette, textSans } from '@guardian/source-foundations';
 import { useEffect, useState } from 'react';
+import type { UserProfile } from '../lib/discussion';
 import { getZIndex } from '../lib/getZIndex';
 import type {
 	AuthStatus,
@@ -18,7 +19,6 @@ import { nestedOphanComponents } from '../lib/ophan-helpers';
 import { useApi } from '../lib/useApi';
 import { useBraze } from '../lib/useBraze';
 import ProfileIcon from '../static/icons/profile.svg';
-import type { UserProfile } from '../types/discussion';
 import type { RenderingTarget } from '../types/renderingTarget';
 import { useConfig } from './ConfigContext';
 import type { DropdownLinkType } from './Dropdown';

--- a/dotcom-rendering/src/components/SignedInAs.tsx
+++ b/dotcom-rendering/src/components/SignedInAs.tsx
@@ -6,9 +6,9 @@ import {
 	textSans,
 	until,
 } from '@guardian/source-foundations';
+import type { UserProfile } from '../lib/discussion';
 import { createAuthenticationEventParams } from '../lib/identity-component-event';
 import { palette as themePalette } from '../palette';
-import type { UserProfile } from '../types/discussion';
 
 type Props = {
 	commentCount?: number;

--- a/dotcom-rendering/src/lib/discussion.ts
+++ b/dotcom-rendering/src/lib/discussion.ts
@@ -24,10 +24,10 @@ import type {
 	pickComment,
 	reportAbuse,
 	unPickComment,
-} from '../lib/discussionApi';
-import type { Guard } from '../lib/guard';
-import { guard } from '../lib/guard';
-import { error, ok, type Result } from '../lib/result';
+} from './discussionApi';
+import type { Guard } from './guard';
+import { guard } from './guard';
+import { error, ok, type Result } from './result';
 
 export type CAPIPillar =
 	| 'news'

--- a/dotcom-rendering/src/lib/discussionApi.tsx
+++ b/dotcom-rendering/src/lib/discussionApi.tsx
@@ -6,7 +6,7 @@ import type {
 	DiscussionOptions,
 	FilterOptions,
 	GetDiscussionSuccess,
-} from '../types/discussion';
+} from './discussion';
 import {
 	discussionApiResponseSchema,
 	parseAbuseResponse,
@@ -14,7 +14,7 @@ import {
 	parseCommentResponse,
 	pickResponseSchema,
 	postUsernameResponseSchema,
-} from '../types/discussion';
+} from './discussion';
 import type { SignedInWithCookies, SignedInWithOkta } from './identity';
 import { getOptionsHeadersWithOkta } from './identity';
 import { fetchJSON } from './json';


### PR DESCRIPTION
It contains more than just types now. It would also be useful to move the discussion reducer into this file to make use of React's context API (which can't be used while the reducer code lives in the component file).
