### PR TITLE
Fix `CommentForm` laggy input

### DIFF
--- a/dotcom-rendering/src/components/Discussion.tsx
+++ b/dotcom-rendering/src/components/Discussion.tsx
@@ -5,7 +5,7 @@ import { Button, SvgPlus } from '@guardian/source-react-components';
 import { useEffect, useReducer } from 'react';
 import { assertUnreachable } from '../lib/assert-unreachable';
 import type {
-	CommentForm,
+	CommentFormProps,
 	CommentType,
 	FilterOptions,
 	SignedInUser,
@@ -145,9 +145,9 @@ type State = {
 	hashCommentId: number | undefined;
 	pickError: string;
 	loading: boolean;
-	topForm: CommentForm;
-	replyForm: CommentForm;
-	bottomForm: CommentForm;
+	topForm: CommentFormProps;
+	replyForm: CommentFormProps;
+	bottomForm: CommentFormProps;
 };
 
 const initialCommentFormState = {
@@ -195,24 +195,15 @@ type Action =
 	| { type: 'filterChange'; filters: FilterOptions; commentPage?: number }
 	| { type: 'setLoading'; loading: boolean }
 	| { type: 'setPickError'; error: string }
-	| { type: 'setTopFormActive'; isActive: boolean }
-	| { type: 'setReplyFormActive'; isActive: boolean }
-	| { type: 'setBottomFormActive'; isActive: boolean }
 	| { type: 'setTopFormUserMissing'; userNameMissing: boolean }
 	| { type: 'setReplyFormUserMissing'; userNameMissing: boolean }
 	| { type: 'setBottomFormUserMissing'; userNameMissing: boolean }
 	| { type: 'setTopFormError'; error: string }
 	| { type: 'setReplyFormError'; error: string }
 	| { type: 'setBottomFormError'; error: string }
-	| { type: 'setTopFormShowPreview'; showPreview: boolean }
-	| { type: 'setReplyFormShowPreview'; showPreview: boolean }
-	| { type: 'setBottomFormShowPreview'; showPreview: boolean }
 	| { type: 'setTopFormPreviewBody'; previewBody: string }
 	| { type: 'setReplyFormPreviewBody'; previewBody: string }
-	| { type: 'setBottomFormPreviewBody'; previewBody: string }
-	| { type: 'setTopFormBody'; body: string }
-	| { type: 'setReplyFormBody'; body: string }
-	| { type: 'setBottomFormBody'; body: string };
+	| { type: 'setBottomFormPreviewBody'; previewBody: string };
 
 const reducer = (state: State, action: Action): State => {
 	switch (action.type) {
@@ -269,24 +260,6 @@ const reducer = (state: State, action: Action): State => {
 				pickError: action.error,
 			};
 		}
-		case 'setTopFormActive': {
-			return {
-				...state,
-				topForm: { ...state.topForm, isActive: action.isActive },
-			};
-		}
-		case 'setReplyFormActive': {
-			return {
-				...state,
-				replyForm: { ...state.replyForm, isActive: action.isActive },
-			};
-		}
-		case 'setBottomFormActive': {
-			return {
-				...state,
-				bottomForm: { ...state.bottomForm, isActive: action.isActive },
-			};
-		}
 		case 'setTopFormUserMissing': {
 			return {
 				...state,
@@ -314,33 +287,6 @@ const reducer = (state: State, action: Action): State => {
 				},
 			};
 		}
-		case 'setTopFormShowPreview': {
-			return {
-				...state,
-				topForm: {
-					...state.topForm,
-					showPreview: action.showPreview,
-				},
-			};
-		}
-		case 'setReplyFormShowPreview': {
-			return {
-				...state,
-				replyForm: {
-					...state.replyForm,
-					showPreview: action.showPreview,
-				},
-			};
-		}
-		case 'setBottomFormShowPreview': {
-			return {
-				...state,
-				bottomForm: {
-					...state.bottomForm,
-					showPreview: action.showPreview,
-				},
-			};
-		}
 		case 'setTopFormPreviewBody': {
 			return {
 				...state,
@@ -365,33 +311,6 @@ const reducer = (state: State, action: Action): State => {
 				bottomForm: {
 					...state.bottomForm,
 					previewBody: action.previewBody,
-				},
-			};
-		}
-		case 'setTopFormBody': {
-			return {
-				...state,
-				topForm: {
-					...state.topForm,
-					body: action.body,
-				},
-			};
-		}
-		case 'setReplyFormBody': {
-			return {
-				...state,
-				replyForm: {
-					...state.replyForm,
-					body: action.body,
-				},
-			};
-		}
-		case 'setBottomFormBody': {
-			return {
-				...state,
-				bottomForm: {
-					...state.bottomForm,
-					body: action.body,
 				},
 			};
 		}
@@ -632,15 +551,6 @@ export const Discussion = ({
 							commentPage: page,
 						});
 					}}
-					setTopFormActive={(isActive) =>
-						dispatch({ type: 'setTopFormActive', isActive })
-					}
-					setReplyFormActive={(isActive) =>
-						dispatch({ type: 'setReplyFormActive', isActive })
-					}
-					setBottomFormActive={(isActive) =>
-						dispatch({ type: 'setBottomFormActive', isActive })
-					}
 					setTopFormUserMissing={(userNameMissing) =>
 						dispatch({
 							type: 'setTopFormUserMissing',
@@ -677,24 +587,6 @@ export const Discussion = ({
 							error,
 						})
 					}
-					setTopFormShowPreview={(showPreview) =>
-						dispatch({
-							type: 'setTopFormShowPreview',
-							showPreview,
-						})
-					}
-					setReplyFormShowPreview={(showPreview) =>
-						dispatch({
-							type: 'setReplyFormShowPreview',
-							showPreview,
-						})
-					}
-					setBottomFormShowPreview={(showPreview) =>
-						dispatch({
-							type: 'setBottomFormShowPreview',
-							showPreview,
-						})
-					}
 					setTopFormPreviewBody={(previewBody) =>
 						dispatch({
 							type: 'setTopFormPreviewBody',
@@ -711,24 +603,6 @@ export const Discussion = ({
 						dispatch({
 							type: 'setBottomFormPreviewBody',
 							previewBody,
-						})
-					}
-					setTopFormBody={(body) =>
-						dispatch({
-							type: 'setTopFormBody',
-							body,
-						})
-					}
-					setReplyFormBody={(body) =>
-						dispatch({
-							type: 'setReplyFormBody',
-							body,
-						})
-					}
-					setBottomFormBody={(body) =>
-						dispatch({
-							type: 'setBottomFormBody',
-							body,
 						})
 					}
 					expandCommentReplies={(commentId, responses) =>

--- a/dotcom-rendering/src/components/Discussion/CommentContainer.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentContainer.stories.tsx
@@ -200,10 +200,6 @@ export const defaultStory = () => (
 		mutes={[]}
 		toggleMuteStatus={() => {}}
 		onPermalinkClick={() => {}}
-		showPreview={false}
-		setShowPreview={() => {}}
-		isCommentFormActive={false}
-		setIsCommentFormActive={() => {}}
 		error={''}
 		setError={() => {}}
 		pickError={''}
@@ -212,8 +208,6 @@ export const defaultStory = () => (
 		setUserNameMissing={() => {}}
 		previewBody=""
 		setPreviewBody={() => {}}
-		body={''}
-		setBody={() => {}}
 		reportAbuse={() => Promise.resolve(ok(true))}
 		expandCommentReplies={() => {}}
 	/>
@@ -242,10 +236,6 @@ export const threadedComment = () => (
 		mutes={[]}
 		toggleMuteStatus={() => {}}
 		onPermalinkClick={() => {}}
-		showPreview={false}
-		setShowPreview={() => {}}
-		isCommentFormActive={false}
-		setIsCommentFormActive={() => {}}
 		error={''}
 		setError={() => {}}
 		pickError={''}
@@ -254,8 +244,6 @@ export const threadedComment = () => (
 		setUserNameMissing={() => {}}
 		previewBody=""
 		setPreviewBody={() => {}}
-		body={''}
-		setBody={() => {}}
 		reportAbuse={() => Promise.resolve(ok(true))}
 		expandCommentReplies={() => {}}
 	/>
@@ -284,10 +272,6 @@ export const threadedCommentWithShowMore = () => (
 		mutes={[]}
 		toggleMuteStatus={() => {}}
 		onPermalinkClick={() => {}}
-		showPreview={false}
-		setShowPreview={() => {}}
-		isCommentFormActive={false}
-		setIsCommentFormActive={() => {}}
 		error={''}
 		setError={() => {}}
 		pickError={''}
@@ -296,8 +280,6 @@ export const threadedCommentWithShowMore = () => (
 		setUserNameMissing={() => {}}
 		previewBody=""
 		setPreviewBody={() => {}}
-		body={''}
-		setBody={() => {}}
 		reportAbuse={() => Promise.resolve(ok(true))}
 		expandCommentReplies={() => {}}
 	/>
@@ -326,10 +308,6 @@ export const threadedCommentWithLongUsernames = () => (
 		mutes={[]}
 		toggleMuteStatus={() => {}}
 		onPermalinkClick={() => {}}
-		showPreview={false}
-		setShowPreview={() => {}}
-		isCommentFormActive={false}
-		setIsCommentFormActive={() => {}}
 		error={''}
 		setError={() => {}}
 		pickError={''}
@@ -338,8 +316,6 @@ export const threadedCommentWithLongUsernames = () => (
 		setUserNameMissing={() => {}}
 		previewBody=""
 		setPreviewBody={() => {}}
-		body={''}
-		setBody={() => {}}
 		reportAbuse={() => Promise.resolve(ok(true))}
 		expandCommentReplies={() => {}}
 	/>
@@ -368,10 +344,6 @@ export const threadedCommentWithLongUsernamesMobile = () => (
 		mutes={[]}
 		toggleMuteStatus={() => {}}
 		onPermalinkClick={() => {}}
-		showPreview={false}
-		setShowPreview={() => {}}
-		isCommentFormActive={false}
-		setIsCommentFormActive={() => {}}
 		error={''}
 		setError={() => {}}
 		pickError={''}
@@ -380,8 +352,6 @@ export const threadedCommentWithLongUsernamesMobile = () => (
 		setUserNameMissing={() => {}}
 		previewBody=""
 		setPreviewBody={() => {}}
-		body={''}
-		setBody={() => {}}
 		reportAbuse={() => Promise.resolve(ok(true))}
 		expandCommentReplies={() => {}}
 	/>

--- a/dotcom-rendering/src/components/Discussion/CommentContainer.test.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentContainer.test.tsx
@@ -77,10 +77,6 @@ describe('CommentContainer', () => {
 				mutes={[]}
 				toggleMuteStatus={() => {}}
 				onPermalinkClick={() => {}}
-				showPreview={false}
-				setShowPreview={() => {}}
-				isCommentFormActive={true}
-				setIsCommentFormActive={() => {}}
 				error={''}
 				setError={() => {}}
 				pickError={''}
@@ -89,8 +85,6 @@ describe('CommentContainer', () => {
 				setUserNameMissing={() => {}}
 				previewBody=""
 				setPreviewBody={() => {}}
-				body={newCommentText}
-				setBody={() => {}}
 				reportAbuse={() => Promise.resolve(ok(true))}
 				expandCommentReplies={(id, responses) => {
 					if (commentBeingRepliedTo?.id !== id) return;
@@ -128,10 +122,6 @@ describe('CommentContainer', () => {
 				mutes={[]}
 				toggleMuteStatus={() => {}}
 				onPermalinkClick={() => {}}
-				showPreview={false}
-				setShowPreview={() => {}}
-				isCommentFormActive={true}
-				setIsCommentFormActive={() => {}}
 				error={''}
 				setError={() => {}}
 				pickError={''}
@@ -140,8 +130,6 @@ describe('CommentContainer', () => {
 				setUserNameMissing={() => {}}
 				previewBody=""
 				setPreviewBody={() => {}}
-				body={''}
-				setBody={() => {}}
 				reportAbuse={() => Promise.resolve(ok(true))}
 				expandCommentReplies={() => {}}
 			/>,
@@ -185,10 +173,6 @@ describe('CommentContainer', () => {
 				mutes={[]}
 				toggleMuteStatus={() => {}}
 				onPermalinkClick={() => {}}
-				showPreview={false}
-				setShowPreview={() => {}}
-				isCommentFormActive={true}
-				setIsCommentFormActive={() => {}}
 				error={''}
 				setError={() => {}}
 				pickError={''}
@@ -197,8 +181,6 @@ describe('CommentContainer', () => {
 				setUserNameMissing={() => {}}
 				previewBody=""
 				setPreviewBody={() => {}}
-				body={newCommentText}
-				setBody={() => {}}
 				reportAbuse={() => Promise.resolve(ok(true))}
 				expandCommentReplies={(id, responses) => {
 					if (commentBeingRepliedTo?.id !== id) return;
@@ -236,10 +218,6 @@ describe('CommentContainer', () => {
 				mutes={[]}
 				toggleMuteStatus={() => {}}
 				onPermalinkClick={() => {}}
-				showPreview={false}
-				setShowPreview={() => {}}
-				isCommentFormActive={true}
-				setIsCommentFormActive={() => {}}
 				error={''}
 				setError={() => {}}
 				pickError={''}
@@ -248,8 +226,6 @@ describe('CommentContainer', () => {
 				setUserNameMissing={() => {}}
 				previewBody=""
 				setPreviewBody={() => {}}
-				body={''}
-				setBody={() => {}}
 				reportAbuse={() => Promise.resolve(ok(true))}
 				expandCommentReplies={() => {}}
 			/>,

--- a/dotcom-rendering/src/components/Discussion/CommentContainer.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentContainer.tsx
@@ -27,10 +27,6 @@ type Props = {
 	toggleMuteStatus: (userId: string) => void;
 	onPermalinkClick: (commentId: number) => void;
 	onPreview?: typeof preview;
-	showPreview: boolean;
-	setShowPreview: (showPreview: boolean) => void;
-	isCommentFormActive: boolean;
-	setIsCommentFormActive: (isActive: boolean) => void;
 	error: string;
 	setError: (error: string) => void;
 	pickError: string;
@@ -39,8 +35,6 @@ type Props = {
 	setUserNameMissing: (isUserNameMissing: boolean) => void;
 	previewBody: string;
 	setPreviewBody: (previewBody: string) => void;
-	body: string;
-	setBody: (body: string) => void;
 	reportAbuse: ReturnType<typeof reportAbuse>;
 	expandCommentReplies: (commentId: number, responses: CommentType[]) => void;
 };
@@ -91,10 +85,6 @@ export const CommentContainer = ({
 	toggleMuteStatus,
 	onPermalinkClick,
 	onPreview,
-	showPreview,
-	setShowPreview,
-	isCommentFormActive,
-	setIsCommentFormActive,
 	error,
 	setError,
 	pickError,
@@ -103,8 +93,6 @@ export const CommentContainer = ({
 	setUserNameMissing,
 	previewBody,
 	setPreviewBody,
-	body,
-	setBody,
 	reportAbuse,
 	expandCommentReplies,
 }: Props) => {
@@ -241,18 +229,12 @@ export const CommentContainer = ({
 								}
 								commentBeingRepliedTo={commentBeingRepliedTo}
 								onPreview={onPreview}
-								showPreview={showPreview}
-								setShowPreview={setShowPreview}
-								isActive={isCommentFormActive}
-								setIsActive={setIsCommentFormActive}
 								error={error}
 								setError={setError}
 								userNameMissing={userNameMissing}
 								setUserNameMissing={setUserNameMissing}
 								previewBody={previewBody}
 								setPreviewBody={setPreviewBody}
-								body={body}
-								setBody={setBody}
 							/>
 						</div>
 					)}

--- a/dotcom-rendering/src/components/Discussion/CommentForm.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentForm.stories.tsx
@@ -73,26 +73,17 @@ const aComment: CommentType = {
 };
 
 export const Default = () => {
-	const [isActive, setIsActive] = useState(false);
-	const [body, setBody] = useState('');
-
 	return (
 		<CommentForm
 			shortUrl={shortUrl}
 			user={aUser}
 			onAddComment={(comment) => {}}
-			isActive={isActive}
-			setIsActive={setIsActive}
-			showPreview={false}
-			setShowPreview={() => {}}
 			userNameMissing={false}
 			setUserNameMissing={() => {}}
 			error={''}
 			setError={() => {}}
 			previewBody=""
 			setPreviewBody={() => {}}
-			body={body}
-			setBody={setBody}
 		/>
 	);
 };
@@ -102,27 +93,19 @@ Default.decorators = [splitTheme([defaultFormat], { orientation: 'vertical' })];
 // This story has a mocked post endpoint that returns an error, see 97d6eab4a98917f63bc96a7ac64f7ca7
 
 export const Error = () => {
-	const [isActive, setIsActive] = useState(false);
 	const [userNameMissing, setUserNameMissing] = useState(false);
-	const [body, setBody] = useState('');
 
 	return (
 		<CommentForm
 			shortUrl={'/p/g8g7v'}
 			user={aUser}
 			onAddComment={(comment) => {}}
-			isActive={isActive}
-			setIsActive={setIsActive}
-			showPreview={false}
-			setShowPreview={() => {}}
 			userNameMissing={userNameMissing}
 			setUserNameMissing={setUserNameMissing}
 			error={''}
 			setError={() => {}}
 			previewBody=""
 			setPreviewBody={() => {}}
-			body={body}
-			setBody={setBody}
 		/>
 	);
 };
@@ -131,26 +114,18 @@ Error.storyName = 'form with errors';
 Error.decorators = [splitTheme([defaultFormat], { orientation: 'vertical' })];
 
 export const Active = () => {
-	const [body, setBody] = useState('');
-
 	return (
 		<CommentForm
 			shortUrl={shortUrl}
 			user={aUser}
 			onAddComment={(comment) => {}}
 			commentBeingRepliedTo={aComment}
-			showPreview={false}
-			setShowPreview={() => {}}
-			isActive={true}
-			setIsActive={() => {}}
 			error={''}
 			setError={() => {}}
 			userNameMissing={false}
 			setUserNameMissing={() => {}}
 			previewBody=""
 			setPreviewBody={() => {}}
-			body={body}
-			setBody={setBody}
 		/>
 	);
 };
@@ -168,8 +143,6 @@ Active.decorators = [
 ];
 
 export const Premoderated = () => {
-	const [body, setBody] = useState('');
-
 	return (
 		<CommentForm
 			shortUrl={shortUrl}
@@ -186,18 +159,12 @@ export const Premoderated = () => {
 			}}
 			onAddComment={(comment) => {}}
 			commentBeingRepliedTo={aComment}
-			showPreview={false}
-			setShowPreview={() => {}}
-			isActive={true}
-			setIsActive={() => {}}
 			error={''}
 			setError={() => {}}
 			userNameMissing={false}
 			setUserNameMissing={() => {}}
 			previewBody=""
 			setPreviewBody={() => {}}
-			body={body}
-			setBody={setBody}
 		/>
 	);
 };

--- a/dotcom-rendering/src/components/Discussion/Comments.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comments.stories.tsx
@@ -1,12 +1,15 @@
 import { css } from '@emotion/react';
 import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
-import { useState } from 'react';
 import { splitTheme } from '../../../.storybook/decorators/splitThemeDecorator';
 import { lightDecorator } from '../../../.storybook/decorators/themeDecorator';
 import { discussion as discussionMock } from '../../../fixtures/manual/discussion';
 import { discussionWithTwoComments } from '../../../fixtures/manual/discussionWithTwoComments';
 import { legacyDiscussionWithoutThreading } from '../../../fixtures/manual/legacyDiscussionWithoutThreading';
-import type { FilterOptions, Reader } from '../../lib/discussion';
+import type {
+	CommentFormProps,
+	FilterOptions,
+	Reader,
+} from '../../lib/discussion';
 import { ok } from '../../lib/result';
 import { Comments } from './Comments';
 
@@ -53,13 +56,10 @@ const filters: FilterOptions = {
 };
 
 const defaultCommentForm = {
-	isActive: false,
 	userNameMissing: false,
 	error: '',
-	showPreview: false,
 	previewBody: '',
-	body: '',
-};
+} satisfies CommentFormProps;
 
 export const LoggedOutHiddenPicks = () => (
 	<div
@@ -90,24 +90,15 @@ export const LoggedOutHiddenPicks = () => (
 			comments={discussionMock.discussion.comments}
 			setComment={() => {}}
 			handleFilterChange={() => {}}
-			setTopFormActive={() => {}}
-			setReplyFormActive={() => {}}
-			setBottomFormActive={() => {}}
 			setTopFormUserMissing={() => {}}
 			setReplyFormUserMissing={() => {}}
 			setBottomFormUserMissing={() => {}}
 			setTopFormError={() => {}}
 			setReplyFormError={() => {}}
 			setBottomFormError={() => {}}
-			setTopFormShowPreview={() => {}}
-			setReplyFormShowPreview={() => {}}
-			setBottomFormShowPreview={() => {}}
 			setTopFormPreviewBody={() => {}}
 			setReplyFormPreviewBody={() => {}}
 			setBottomFormPreviewBody={() => {}}
-			setTopFormBody={() => {}}
-			setReplyFormBody={() => {}}
-			setBottomFormBody={() => {}}
 			pickError=""
 			setPickError={() => {}}
 			topForm={defaultCommentForm}
@@ -157,24 +148,15 @@ export const InitialPage = () => (
 			comments={discussionMock.discussion.comments}
 			setComment={() => {}}
 			handleFilterChange={() => {}}
-			setTopFormActive={() => {}}
-			setReplyFormActive={() => {}}
-			setBottomFormActive={() => {}}
 			setTopFormUserMissing={() => {}}
 			setReplyFormUserMissing={() => {}}
 			setBottomFormUserMissing={() => {}}
 			setTopFormError={() => {}}
 			setReplyFormError={() => {}}
 			setBottomFormError={() => {}}
-			setTopFormShowPreview={() => {}}
-			setReplyFormShowPreview={() => {}}
-			setBottomFormShowPreview={() => {}}
 			setTopFormPreviewBody={() => {}}
 			setReplyFormPreviewBody={() => {}}
 			setBottomFormPreviewBody={() => {}}
-			setTopFormBody={() => {}}
-			setReplyFormBody={() => {}}
-			setBottomFormBody={() => {}}
 			pickError=""
 			setPickError={() => {}}
 			topForm={defaultCommentForm}
@@ -196,9 +178,6 @@ InitialPage.decorators = [
 ];
 
 export const LoggedInHiddenNoPicks = () => {
-	const [isActive, setActive] = useState(false);
-	const [body, setBody] = useState('');
-
 	return (
 		<div
 			css={css`
@@ -229,28 +208,19 @@ export const LoggedInHiddenNoPicks = () => {
 				comments={discussionMock.discussion.comments}
 				setComment={() => {}}
 				handleFilterChange={() => {}}
-				setTopFormActive={() => {}}
-				setReplyFormActive={setActive}
-				setBottomFormActive={() => {}}
 				setTopFormUserMissing={() => {}}
 				setReplyFormUserMissing={() => {}}
 				setBottomFormUserMissing={() => {}}
 				setTopFormError={() => {}}
 				setReplyFormError={() => {}}
 				setBottomFormError={() => {}}
-				setTopFormShowPreview={() => {}}
-				setReplyFormShowPreview={() => {}}
-				setBottomFormShowPreview={() => {}}
 				setTopFormPreviewBody={() => {}}
 				setReplyFormPreviewBody={() => {}}
 				setBottomFormPreviewBody={() => {}}
-				setTopFormBody={() => {}}
-				setReplyFormBody={setBody}
-				setBottomFormBody={() => {}}
 				pickError=""
 				setPickError={() => {}}
 				topForm={defaultCommentForm}
-				replyForm={{ ...defaultCommentForm, isActive, body }}
+				replyForm={{ ...defaultCommentForm }}
 				bottomForm={defaultCommentForm}
 				reportAbuse={() => Promise.resolve(ok(true))}
 				expandCommentReplies={() => {}}
@@ -263,13 +233,6 @@ LoggedInHiddenNoPicks.storyName =
 LoggedInHiddenNoPicks.decorators = [splitTheme([format])];
 
 export const LoggedIn = () => {
-	const [isTopFormActive, setTopFormActive] = useState(false);
-	const [isReplyFormActive, setReplyFormActive] = useState(false);
-	const [isBottomFormActive, setBottomFormActive] = useState(false);
-	const [topFormBody, setTopFormBody] = useState('');
-	const [replyFormBody, setReplyFormBody] = useState('');
-	const [bottomFormBody, setBottomFormBody] = useState('');
-
 	return (
 		<div
 			css={css`
@@ -300,41 +263,20 @@ export const LoggedIn = () => {
 				comments={discussionMock.discussion.comments}
 				setComment={() => {}}
 				handleFilterChange={() => {}}
-				setTopFormActive={setTopFormActive}
-				setReplyFormActive={setReplyFormActive}
-				setBottomFormActive={setBottomFormActive}
 				setTopFormUserMissing={() => {}}
 				setReplyFormUserMissing={() => {}}
 				setBottomFormUserMissing={() => {}}
 				setTopFormError={() => {}}
 				setReplyFormError={() => {}}
 				setBottomFormError={() => {}}
-				setTopFormShowPreview={() => {}}
-				setReplyFormShowPreview={() => {}}
-				setBottomFormShowPreview={() => {}}
 				setTopFormPreviewBody={() => {}}
 				setReplyFormPreviewBody={() => {}}
 				setBottomFormPreviewBody={() => {}}
 				pickError=""
 				setPickError={() => {}}
-				setTopFormBody={setTopFormBody}
-				setReplyFormBody={setReplyFormBody}
-				setBottomFormBody={setBottomFormBody}
-				topForm={{
-					...defaultCommentForm,
-					isActive: isTopFormActive,
-					body: topFormBody,
-				}}
-				replyForm={{
-					...defaultCommentForm,
-					isActive: isReplyFormActive,
-					body: replyFormBody,
-				}}
-				bottomForm={{
-					...defaultCommentForm,
-					isActive: isBottomFormActive,
-					body: bottomFormBody,
-				}}
+				topForm={defaultCommentForm}
+				replyForm={defaultCommentForm}
+				bottomForm={defaultCommentForm}
 				reportAbuse={() => Promise.resolve(ok(true))}
 				expandCommentReplies={() => {}}
 			/>
@@ -345,11 +287,6 @@ LoggedIn.storyName = 'when logged in and expanded';
 LoggedIn.decorators = [lightDecorator([format])];
 
 export const LoggedInShortDiscussion = () => {
-	const [isTopFormActive, setTopFormActive] = useState(false);
-	const [isReplyFormActive, setReplyFormActive] = useState(false);
-	const [topFormBody, setTopFormBody] = useState('');
-	const [replyFormBody, setReplyFormBody] = useState('');
-
 	return (
 		<div
 			css={css`
@@ -380,36 +317,19 @@ export const LoggedInShortDiscussion = () => {
 				comments={discussionWithTwoComments.discussion.comments}
 				setComment={() => {}}
 				handleFilterChange={() => {}}
-				setTopFormActive={setTopFormActive}
-				setReplyFormActive={setReplyFormActive}
-				setBottomFormActive={() => {}}
 				setTopFormUserMissing={() => {}}
 				setReplyFormUserMissing={() => {}}
 				setBottomFormUserMissing={() => {}}
 				setTopFormError={() => {}}
 				setReplyFormError={() => {}}
 				setBottomFormError={() => {}}
-				setTopFormShowPreview={() => {}}
-				setReplyFormShowPreview={() => {}}
-				setBottomFormShowPreview={() => {}}
 				setTopFormPreviewBody={() => {}}
 				setReplyFormPreviewBody={() => {}}
 				setBottomFormPreviewBody={() => {}}
-				setTopFormBody={setTopFormBody}
-				setReplyFormBody={setReplyFormBody}
-				setBottomFormBody={() => {}}
 				pickError=""
 				setPickError={() => {}}
-				topForm={{
-					...defaultCommentForm,
-					isActive: isTopFormActive,
-					body: topFormBody,
-				}}
-				replyForm={{
-					...defaultCommentForm,
-					isActive: isReplyFormActive,
-					body: replyFormBody,
-				}}
+				topForm={defaultCommentForm}
+				replyForm={defaultCommentForm}
 				bottomForm={defaultCommentForm}
 				reportAbuse={() => Promise.resolve(ok(true))}
 				expandCommentReplies={() => {}}
@@ -448,24 +368,15 @@ export const LoggedOutHiddenNoPicks = () => (
 			comments={discussionMock.discussion.comments}
 			setComment={() => {}}
 			handleFilterChange={() => {}}
-			setTopFormActive={() => {}}
-			setReplyFormActive={() => {}}
-			setBottomFormActive={() => {}}
 			setTopFormUserMissing={() => {}}
 			setReplyFormUserMissing={() => {}}
 			setBottomFormUserMissing={() => {}}
 			setTopFormError={() => {}}
 			setReplyFormError={() => {}}
 			setBottomFormError={() => {}}
-			setTopFormShowPreview={() => {}}
-			setReplyFormShowPreview={() => {}}
-			setBottomFormShowPreview={() => {}}
 			setTopFormPreviewBody={() => {}}
 			setReplyFormPreviewBody={() => {}}
 			setBottomFormPreviewBody={() => {}}
-			setTopFormBody={() => {}}
-			setReplyFormBody={() => {}}
-			setBottomFormBody={() => {}}
 			pickError=""
 			setPickError={() => {}}
 			topForm={defaultCommentForm}
@@ -517,24 +428,15 @@ export const Closed = () => (
 			comments={discussionMock.discussion.comments}
 			setComment={() => {}}
 			handleFilterChange={() => {}}
-			setTopFormActive={() => {}}
-			setReplyFormActive={() => {}}
-			setBottomFormActive={() => {}}
 			setTopFormUserMissing={() => {}}
 			setReplyFormUserMissing={() => {}}
 			setBottomFormUserMissing={() => {}}
 			setTopFormError={() => {}}
 			setReplyFormError={() => {}}
 			setBottomFormError={() => {}}
-			setTopFormShowPreview={() => {}}
-			setReplyFormShowPreview={() => {}}
-			setBottomFormShowPreview={() => {}}
 			setTopFormPreviewBody={() => {}}
 			setReplyFormPreviewBody={() => {}}
 			setBottomFormPreviewBody={() => {}}
-			setTopFormBody={() => {}}
-			setReplyFormBody={() => {}}
-			setBottomFormBody={() => {}}
 			pickError=""
 			setPickError={() => {}}
 			topForm={defaultCommentForm}
@@ -582,24 +484,15 @@ export const NoComments = () => (
 			comments={[]}
 			setComment={() => {}}
 			handleFilterChange={() => {}}
-			setTopFormActive={() => {}}
-			setReplyFormActive={() => {}}
-			setBottomFormActive={() => {}}
 			setTopFormUserMissing={() => {}}
 			setReplyFormUserMissing={() => {}}
 			setBottomFormUserMissing={() => {}}
 			setTopFormError={() => {}}
 			setReplyFormError={() => {}}
 			setBottomFormError={() => {}}
-			setTopFormShowPreview={() => {}}
-			setReplyFormShowPreview={() => {}}
-			setBottomFormShowPreview={() => {}}
 			setTopFormPreviewBody={() => {}}
 			setReplyFormPreviewBody={() => {}}
 			setBottomFormPreviewBody={() => {}}
-			setTopFormBody={() => {}}
-			setReplyFormBody={() => {}}
-			setBottomFormBody={() => {}}
 			pickError=""
 			setPickError={() => {}}
 			topForm={defaultCommentForm}
@@ -649,24 +542,15 @@ export const LegacyDiscussion = () => (
 			comments={legacyDiscussionWithoutThreading.discussion.comments}
 			setComment={() => {}}
 			handleFilterChange={() => {}}
-			setTopFormActive={() => {}}
-			setReplyFormActive={() => {}}
-			setBottomFormActive={() => {}}
 			setTopFormUserMissing={() => {}}
 			setReplyFormUserMissing={() => {}}
 			setBottomFormUserMissing={() => {}}
 			setTopFormError={() => {}}
 			setReplyFormError={() => {}}
 			setBottomFormError={() => {}}
-			setTopFormShowPreview={() => {}}
-			setReplyFormShowPreview={() => {}}
-			setBottomFormShowPreview={() => {}}
 			setTopFormPreviewBody={() => {}}
 			setReplyFormPreviewBody={() => {}}
 			setBottomFormPreviewBody={() => {}}
-			setTopFormBody={() => {}}
-			setReplyFormBody={() => {}}
-			setBottomFormBody={() => {}}
 			pickError=""
 			setPickError={() => {}}
 			topForm={defaultCommentForm}

--- a/dotcom-rendering/src/components/Discussion/Comments.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comments.tsx
@@ -8,9 +8,9 @@ import {
 import { useEffect, useState } from 'react';
 import type {
 	AdditionalHeadersType,
+	CommentFormProps,
 	CommentType,
 	FilterOptions,
-	CommentForm as Form,
 	SignedInUser,
 } from '../../lib/discussion';
 import type { preview, reportAbuse } from '../../lib/discussionApi';
@@ -45,27 +45,18 @@ type Props = {
 	handleFilterChange: (newFilters: FilterOptions, page?: number) => void;
 	pickError: string;
 	setPickError: (error: string) => void;
-	setTopFormActive: (isActive: boolean) => void;
-	setReplyFormActive: (isActive: boolean) => void;
-	setBottomFormActive: (isActive: boolean) => void;
 	setTopFormUserMissing: (isUserMissing: boolean) => void;
 	setReplyFormUserMissing: (isUserMissing: boolean) => void;
 	setBottomFormUserMissing: (isUserMissing: boolean) => void;
 	setTopFormError: (error: string) => void;
 	setReplyFormError: (error: string) => void;
 	setBottomFormError: (error: string) => void;
-	setTopFormShowPreview: (showPreview: boolean) => void;
-	setReplyFormShowPreview: (showPreview: boolean) => void;
-	setBottomFormShowPreview: (showPreview: boolean) => void;
 	setTopFormPreviewBody: (previewBody: string) => void;
 	setReplyFormPreviewBody: (previewBody: string) => void;
 	setBottomFormPreviewBody: (previewBody: string) => void;
-	setTopFormBody: (body: string) => void;
-	setReplyFormBody: (body: string) => void;
-	setBottomFormBody: (body: string) => void;
-	topForm: Form;
-	replyForm: Form;
-	bottomForm: Form;
+	topForm: CommentFormProps;
+	replyForm: CommentFormProps;
+	bottomForm: CommentFormProps;
 	reportAbuse: ReturnType<typeof reportAbuse>;
 	expandCommentReplies: (commentId: number, responses: CommentType[]) => void;
 };
@@ -157,24 +148,15 @@ export const Comments = ({
 	setPickError,
 	setComment,
 	handleFilterChange,
-	setTopFormActive,
-	setReplyFormActive,
-	setBottomFormActive,
 	setTopFormUserMissing,
 	setReplyFormUserMissing,
 	setBottomFormUserMissing,
 	setTopFormError,
 	setReplyFormError,
 	setBottomFormError,
-	setTopFormShowPreview,
-	setReplyFormShowPreview,
-	setBottomFormShowPreview,
 	setTopFormPreviewBody,
 	setReplyFormPreviewBody,
 	setBottomFormPreviewBody,
-	setTopFormBody,
-	setReplyFormBody,
-	setBottomFormBody,
 	topForm,
 	replyForm,
 	bottomForm,
@@ -339,16 +321,6 @@ export const Comments = ({
 											mutes={mutes}
 											toggleMuteStatus={toggleMuteStatus}
 											onPermalinkClick={onPermalinkClick}
-											showPreview={replyForm.showPreview}
-											setShowPreview={
-												setReplyFormShowPreview
-											}
-											isCommentFormActive={
-												replyForm.isActive
-											}
-											setIsCommentFormActive={
-												setReplyFormActive
-											}
 											error={replyForm.error}
 											setError={setReplyFormError}
 											pickError={pickError}
@@ -363,8 +335,6 @@ export const Comments = ({
 											setPreviewBody={
 												setReplyFormPreviewBody
 											}
-											body={replyForm.body}
-											setBody={setReplyFormBody}
 											reportAbuse={reportAbuse}
 											expandCommentReplies={
 												expandCommentReplies
@@ -388,18 +358,12 @@ export const Comments = ({
 					onAddComment={onAddComment}
 					user={user}
 					onPreview={onPreview}
-					showPreview={topForm.showPreview}
-					setShowPreview={setTopFormShowPreview}
-					isActive={topForm.isActive}
-					setIsActive={setTopFormActive}
 					error={topForm.error}
 					setError={setTopFormError}
 					userNameMissing={topForm.userNameMissing}
 					setUserNameMissing={setTopFormUserMissing}
 					previewBody={topForm.previewBody}
 					setPreviewBody={setTopFormPreviewBody}
-					body={topForm.body}
-					setBody={setTopFormBody}
 				/>
 			)}
 			{!!picks.length && (
@@ -448,10 +412,6 @@ export const Comments = ({
 									mutes={mutes}
 									toggleMuteStatus={toggleMuteStatus}
 									onPermalinkClick={onPermalinkClick}
-									showPreview={replyForm.showPreview}
-									setShowPreview={setReplyFormShowPreview}
-									isCommentFormActive={replyForm.isActive}
-									setIsCommentFormActive={setReplyFormActive}
 									error={replyForm.error}
 									setError={setReplyFormError}
 									pickError={pickError}
@@ -460,8 +420,6 @@ export const Comments = ({
 									setUserNameMissing={setReplyFormUserMissing}
 									previewBody={replyForm.previewBody}
 									setPreviewBody={setReplyFormPreviewBody}
-									body={replyForm.body}
-									setBody={setReplyFormBody}
 									reportAbuse={reportAbuse}
 									expandCommentReplies={expandCommentReplies}
 								/>
@@ -486,18 +444,12 @@ export const Comments = ({
 					onAddComment={onAddComment}
 					user={user}
 					onPreview={onPreview}
-					showPreview={bottomForm.showPreview}
-					setShowPreview={setBottomFormShowPreview}
-					isActive={bottomForm.isActive}
-					setIsActive={setBottomFormActive}
 					error={bottomForm.error}
 					setError={setBottomFormError}
 					userNameMissing={bottomForm.userNameMissing}
 					setUserNameMissing={setBottomFormUserMissing}
 					previewBody={bottomForm.previewBody}
 					setPreviewBody={setBottomFormPreviewBody}
-					body={bottomForm.body}
-					setBody={setBottomFormBody}
 				/>
 			)}
 		</div>

--- a/dotcom-rendering/src/lib/discussion.ts
+++ b/dotcom-rendering/src/lib/discussion.ts
@@ -381,13 +381,10 @@ export const pickResponseSchema = object({
 	message: string(),
 });
 
-export type CommentForm = {
-	isActive: boolean;
+export type CommentFormProps = {
 	userNameMissing: boolean;
 	error: string;
-	showPreview: boolean;
 	previewBody: string;
-	body: string;
 };
 
 export const getCommentContextResponseSchema = object({
@@ -401,3 +398,30 @@ export const getCommentContextResponseSchema = object({
 	pageSize: picklist(pageSize),
 	page: number(),
 });
+
+/** for development purposes only! */
+export const stubUser = {
+	kind: 'Reader',
+	addUsername: () => Promise.resolve(error('This is a stub user')),
+	onComment: () =>
+		Promise.resolve(
+			ok(Number.MAX_SAFE_INTEGER - Math.ceil(Math.random() * 12_000)),
+		),
+	onRecommend: () => Promise.resolve(true),
+	onReply: () => Promise.resolve(error('API_ERROR')),
+	reportAbuse: () => Promise.resolve(error('Invalid')),
+	profile: {
+		userId: 'stub-user-000',
+		displayName: 'Stub User',
+		webUrl: '',
+		apiUrl: '',
+		avatar: '',
+		secureAvatarUrl: '',
+		badge: [],
+		privateFields: {
+			canPostComment: true,
+			isPremoderated: false,
+			hasCommented: true,
+		},
+	},
+} satisfies Reader;


### PR DESCRIPTION
## What does this change?

Brings part of the the state of `CommentForm` back down from `Discussion` into the component. Reverts part of #10225.

- `showPreview` is removed in favour of checking whether the preview body is empty
- the `CommentForm` type is renamed to `CommentFormProps` to avoid clashes with the JSX Component
- a `stubUser` is added for testing things locally, but currently not imported anywhere

## Why?

The React docs recommend [avoiding duplicate state](https://react.dev/learn/choosing-the-state-structure#avoid-duplication-in-state), but we went a bit too far with the `CommentForm`, as none of the parent or sibling components need to know about the `body`, `active` or `showPreview` state.

Users have started reporting a very laggy input of their comment, which we are able to reproduce. It gets worse with the amount of comments, with 100 collapsed comment resulting on a delay of up to 1.5s

## Screenshots

N/A – Behaviour is identical

## Alternatives to consider

- [`useMemo`](https://react.dev/reference/react/useMemo#skipping-re-rendering-of-components)
- [`useContext`](https://react.dev/reference/react/useContext#optimizing-re-renders-when-passing-objects-and-functions)
- [`@preact/signals`](https://www.npmjs.com/package/@preact/signals) 😜 