### PR TITLE
Remove unused `/TagFront` endpoints

### DIFF
--- a/dotcom-rendering/src/server/server.prod.ts
+++ b/dotcom-rendering/src/server/server.prod.ts
@@ -70,14 +70,6 @@ export const prodServer = (): void => {
 	app.post('/FrontJSON', logRenderTime, handleFrontJson);
 	app.post('/TagPage', logRenderTime, handleTagPage);
 	app.post('/TagPageJSON', logRenderTime, handleTagPageJson);
-	/** Temporary duplicate while we redirect frontend requests
-	 * to the /TagPage endpoint
-	 *
-	 * @todo 09/02/2024 - remove these
-	 */
-	app.post('/TagFront', logRenderTime, handleTagPage);
-	app.post('/TagFrontJSON', logRenderTime, handleTagPageJson);
-	/** End of duplicated section */
 
 	app.post(
 		'/EmailNewsletters',
@@ -128,25 +120,6 @@ export const prodServer = (): void => {
 		getContentFromURLMiddleware,
 		handleTagPageJson,
 	);
-
-	/** Temporary duplicate while we redirect frontend requests
-	 * to the /TagPage endpoint
-	 *
-	 * @todo 09/02/2024 - remove these
-	 */
-	app.get(
-		'/TagFront/*',
-		logRenderTime,
-		getContentFromURLMiddleware,
-		handleTagPage,
-	);
-	app.get(
-		'/TagFrontJSON/*',
-		logRenderTime,
-		getContentFromURLMiddleware,
-		handleTagPageJson,
-	);
-	/** End of duplicated section */
 
 	app.get(
 		'/EmailNewsletters',


### PR DESCRIPTION
## What does this change?

Removes the `/TagFront` and `/TagFrontJSON` endpoints from `server.prod.ts` now that we're using the `/TagPage` and `/TagPageJSON` endpoints instead.

## Why?

In the tools/platforms regular catch up meeting, we decided that we're going to stick with one term to refer to these pages and that's "tag pages". This is the final part of the DCR renaming work since https://github.com/guardian/dotcom-rendering/pull/10540 was merged to enforce the new naming convention and https://github.com/guardian/frontend/pull/26895 was merged to start sending traffic to the `/TagPage` endpoints.

This is in preparation for the start of the [1% test](https://github.com/guardian/frontend/pull/26883) as it'll be more fiddly to update this once it's in use in PROD.
