### PR TITLE
Handle YouTube IMA script loading error and refactor loadYouTubeApi

### DIFF
--- a/dotcom-rendering/src/components/YoutubeAtom/loadYouTubeApi.ts
+++ b/dotcom-rendering/src/components/YoutubeAtom/loadYouTubeApi.ts
@@ -1,76 +1,74 @@
 import { loadScript, log } from '@guardian/libs';
 
-let scriptsPromise: Promise<Array<Event | undefined>> | undefined;
-let youtubeAPIReadyPromise: Promise<typeof YT> | undefined;
+let scriptsPromise: Promise<Array<Event | undefined | void>> | undefined;
+let youTubeAPIPromise: Promise<typeof YT> | undefined;
+
+const loadScriptAndCatch = (src: string) =>
+	loadScript(src).catch((e) => {
+		log('dotcom', `loadYouTubeAPI: failed to load script ${src}`, e);
+	});
 
 const loadScripts = (enableIma = false) => {
 	/**
-	 * Since loadScripts can be called multiple times on the same page for pages with more than one video,
-	 * only attempt to load the scripts if this is the first call and otherwise return the same promise.
+	 * loadScripts can be called multiple times on pages with more than one video
+	 * Only attempt to load scripts if this is the first call and otherwise return the same promise
 	 */
 	if (scriptsPromise) {
 		return scriptsPromise;
 	}
 	let scripts;
 	if (enableIma) {
-		log('dotcom', 'loadYouTubeAPI: loading YT & IMA script');
+		log('dotcom', 'loadYouTubeAPI: loading YouTube & IMA script');
 		scripts = [
-			/**
-			 * The IMA version of the iframe api script can only be fetched from
-			 * a domain that is on YouTube's allow list (theguardian.com, thegulocal.com, gutools.co.uk).
-			 * If the request is made from a domain that isn't on the list (e.g. localhost),
-			 * the standard, non-IMA version will be returned and IMA functionality will fail silently.
-			 */
-			loadScript('https://www.youtube.com/iframe_api?ima=1'),
-			loadScript('//imasdk.googleapis.com/js/sdkloader/ima3.js'),
+			loadScriptAndCatch('https://www.youtube.com/iframe_api?ima=1'),
+			loadScriptAndCatch(
+				'https://imasdk.googleapis.com/js/sdkloader/ima3.js',
+			),
 		];
 	} else {
-		log('dotcom', 'loadYouTubeAPI: loading YT script');
-		scripts = [loadScript('https://www.youtube.com/iframe_api')];
+		log('dotcom', 'loadYouTubeAPI: loading YouTube script');
+		scripts = [loadScriptAndCatch('https://www.youtube.com/iframe_api')];
 	}
 	scriptsPromise = Promise.all(scripts);
 	return scriptsPromise;
 };
 
 /**
- * The YouTube IFrame API will call `window.onYouTubeIframeAPIReady`
- * when it has downloaded and is ready
+ * The YouTube IFrame API will call `window.onYouTubeIframeAPIReady` when it is ready
  */
-const youtubeAPIReady = () => {
+const getYouTubeAPIPromise = (): Promise<typeof YT> => {
 	/**
-	 * Since youtubeAPIReady can be called multiple times on the same page for pages with more than one video,
-	 * only overwrite window.onYouTubeIframeAPIReady if this is the first call and return the same promise otherwise.
+	 * youtubeAPIReady can be called multiple times on pages with more than one video
+	 * Only set window.onYouTubeIframeAPIReady if this is the first call and otherwise return the same promise
 	 */
-	if (youtubeAPIReadyPromise) {
-		return youtubeAPIReadyPromise;
+	if (youTubeAPIPromise) {
+		return youTubeAPIPromise;
 	}
 
-	youtubeAPIReadyPromise = new Promise((resolve) => {
+	youTubeAPIPromise = new Promise((resolve) => {
 		window.onYouTubeIframeAPIReady = () => {
-			log('dotcom', 'loadYouTubeAPI: resolving YTAPI promise');
+			log('dotcom', 'loadYouTubeAPI: resolving YouTube API promise');
 			resolve(window.YT);
 		};
 	});
-	return youtubeAPIReadyPromise;
+	return youTubeAPIPromise;
 };
 
 const loadYouTubeAPI = (enableIma = false): Promise<typeof YT> => {
 	/* If another part of the code has already loaded youtube api, return early. */
 	// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- @types/youtube insists that window.YT cannot be undefined. This is very much untrue.
 	if (window.YT?.Player instanceof Function) {
-		log('dotcom', 'loadYouTubeAPI: returning window.YT');
+		log('dotcom', 'loadYouTubeAPI: returning existing window.YT');
 		return Promise.resolve(window.YT);
 	}
 
-	/* Create youtubeAPIReady promise before loading scripts so that
+	/* Create youtubeAPI promise before loading scripts so that
 	 * window.onYouTubeIframeAPIReady is guaranteed to be defined
-	 * by the time the youtube script calls it.
+	 * when the YouYube script laods and calls it.
 	 */
-	const youtubeAPI = youtubeAPIReady();
+	const youtubeAPI = getYouTubeAPIPromise();
 
-	return loadScripts(enableIma).then(() => {
-		return youtubeAPI;
-	});
+	return loadScripts(enableIma).then(() => youtubeAPI);
 };
 
 export { loadYouTubeAPI };


### PR DESCRIPTION
## What does this change?

Handle YouTube IMA script error and refactor loadYouTubeApi

## Why?

Ad blockers block the IMA script (ima3.js) causing an uncaught error in the YouTube API loading process and prevents the player from loading. This change adds error handling to the loading of  the YouTube API and IMA scripts so that the player can resume and continue playing.

## Screenshots

With the request to ima3.js blocked:

![Screenshot 2024-02-12 at 10 43 48](https://github.com/guardian/dotcom-rendering/assets/7014230/68846a7e-e2b4-47d8-822a-b0d065484af8)

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/7014230/e84ac7b6-7e5d-47f0-a16a-bce978a72dc9
[after]: https://github.com/guardian/dotcom-rendering/assets/7014230/f26fac6c-5a62-4db4-86cf-95871bcdaf29


