### PR TITLE
Show caption and credit on Labs main media

### DIFF
--- a/dotcom-rendering/src/model/enhance-images.ts
+++ b/dotcom-rendering/src/model/enhance-images.ts
@@ -452,6 +452,7 @@ export const enhanceElementsImages = (
 	imagesForLightbox: ImageForLightbox[],
 ): FEElement[] =>
 	enhance(elements, {
-		isPhotoEssay: format.design === 'PhotoEssayDesign',
+		isPhotoEssay:
+			format.design === 'PhotoEssayDesign' && format.theme !== 'Labs',
 		imagesForLightbox,
 	});


### PR DESCRIPTION
## What does this change?
Excludes labs main media from having their credit and caption stripped. 

## Why?
Labs use the photoessay design. By default, all images in a photo essay have their caption and credit removed when they get enhanced. For labs articles, we would like to show the credit and caption for the main media so we exclude labs articles from the check.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/20416599/5b0690f0-ba61-47c8-85b9-1a263da9f6a5
[after]: https://github.com/guardian/dotcom-rendering/assets/20416599/24bad677-896c-4a31-b0f8-cb772d412552


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
