### PR TITLE
Change AMP data-block-on-consent var from _till_accepted to till_responded

### DIFF
--- a/dotcom-rendering/src/components/Ad.amp.tsx
+++ b/dotcom-rendering/src/components/Ad.amp.tsx
@@ -104,7 +104,7 @@ export const Ad = ({
 
 	return (
 		<amp-ad
-			data-block-on-consent="_till_accepted"
+			data-block-on-consent="_till_responded"
 			// Primary ad size width and height
 			width={width}
 			height={height}

--- a/dotcom-rendering/src/components/Analytics.amp.tsx
+++ b/dotcom-rendering/src/components/Analytics.amp.tsx
@@ -29,7 +29,7 @@ export const Analytics = ({
 }: Props) => {
 	const scripts: string[] = [
 		`<amp-analytics config="https://ophan.theguardian.com/amp.json" data-credentials="include" ></amp-analytics>`,
-		`<amp-analytics data-block-on-consent type="googleanalytics" id="google-analytics">
+		`<amp-analytics data-block-on-consent="_till_responded" type="googleanalytics" id="google-analytics">
              <script type="application/json">
                {
                  "requests": {
@@ -57,7 +57,7 @@ export const Analytics = ({
                }
                </script>
             </amp-analytics>`,
-		`<amp-analytics data-block-on-consent id="comscore" type="comscore">
+		`<amp-analytics data-block-on-consent="_till_responded" id="comscore" type="comscore">
             <script type="application/json">
                 {
                     "vars": {"c2": "${comscoreID}"},
@@ -78,7 +78,7 @@ export const Analytics = ({
                 }
             </script>
         </amp-analytics>`,
-		`<amp-analytics data-block-on-consent config="https://uk-script.dotmetrics.net/AmpConfig.json?dom=www.theguardian.com&tag=${ipsosSectionName}">
+		`<amp-analytics data-block-on-consent="_till_accepted" config="https://uk-script.dotmetrics.net/AmpConfig.json?dom=www.theguardian.com&tag=${ipsosSectionName}">
             <script type="application/json">
                 {
                     "enabled": "$EQUALS(\${ampGeo(ISOCountry)}, gb)"

--- a/dotcom-rendering/src/components/AnalyticsIframe.amp.tsx
+++ b/dotcom-rendering/src/components/AnalyticsIframe.amp.tsx
@@ -17,7 +17,7 @@ export const AnalyticsIframe = ({ url }: Props) => {
 				return (
 					<amp-iframe
 						class={prebidIframeStyle}
-						data-block-on-consent="_till_accepted"
+						data-block-on-consent="_till_responded" // TODO: TO CONFIRM
 						title="Analytics Iframe"
 						height="1"
 						width="1"

--- a/dotcom-rendering/src/components/AnalyticsIframe.amp.tsx
+++ b/dotcom-rendering/src/components/AnalyticsIframe.amp.tsx
@@ -17,7 +17,7 @@ export const AnalyticsIframe = ({ url }: Props) => {
 				return (
 					<amp-iframe
 						class={prebidIframeStyle}
-						data-block-on-consent="_till_responded" // TODO: TO CONFIRM
+						data-block-on-consent="_till_responded"
 						title="Analytics Iframe"
 						height="1"
 						width="1"

--- a/dotcom-rendering/src/components/Permutive.amp.tsx
+++ b/dotcom-rendering/src/components/Permutive.amp.tsx
@@ -78,7 +78,7 @@ export const Permutive = ({ apiKey, projectId, payload }: PermutiveModel) => {
 				}}
 			></script>
 			<amp-script
-				data-block-on-consent="_till_responded" // TODO: Check if it is IAB Compliant
+				data-block-on-consent="_till_responded"
 				id="permutiveSdk"
 				// Empty string required to pass AMP validation
 				sandboxed=""

--- a/dotcom-rendering/src/components/Permutive.amp.tsx
+++ b/dotcom-rendering/src/components/Permutive.amp.tsx
@@ -37,17 +37,17 @@ export const Permutive = ({ apiKey, projectId, payload }: PermutiveModel) => {
 	return (
 		<>
 			<amp-state
-				data-block-on-consent=""
+				data-block-on-consent="_till_responded"
 				id="permutiveConfig"
 				dangerouslySetInnerHTML={{ __html: permutiveConfig }}
 			/>
 			<amp-analytics
-				data-block-on-consent=""
+				data-block-on-consent="_till_responded"
 				type="permutive-ampscript"
 				dangerouslySetInnerHTML={{ __html: permutiveAmpScript }}
 			/>
 			<amp-script
-				data-block-on-consent=""
+				data-block-on-consent="_till_responded"
 				id="permutiveCachedTargeting"
 				// Empty string required to pass AMP validation
 				sandboxed=""
@@ -63,7 +63,7 @@ export const Permutive = ({ apiKey, projectId, payload }: PermutiveModel) => {
 				}}
 			></script>
 			<amp-script
-				data-block-on-consent=""
+				data-block-on-consent="_till_responded"
 				// Empty string required to pass AMP validation
 				sandboxed=""
 				script="pamp-json"
@@ -78,7 +78,7 @@ export const Permutive = ({ apiKey, projectId, payload }: PermutiveModel) => {
 				}}
 			></script>
 			<amp-script
-				data-block-on-consent=""
+				data-block-on-consent="_till_responded" // TODO: Check if it is IAB Compliant
 				id="permutiveSdk"
 				// Empty string required to pass AMP validation
 				sandboxed=""

--- a/dotcom-rendering/src/components/VideoYoutubeBlockComponent.amp.tsx
+++ b/dotcom-rendering/src/components/VideoYoutubeBlockComponent.amp.tsx
@@ -19,7 +19,7 @@ export const VideoYoutubeBlockComponent = ({ element, pillar }: Props) => {
 	return (
 		<Caption captionText={element.caption} pillar={pillar}>
 			<amp-youtube
-				data-block-on-consent=""
+				data-block-on-consent="_till_accepted"
 				data-videoid={youtubeId}
 				layout="responsive"
 				width={element.width}

--- a/dotcom-rendering/src/components/YoutubeBlockComponent.amp.tsx
+++ b/dotcom-rendering/src/components/YoutubeBlockComponent.amp.tsx
@@ -59,7 +59,7 @@ export const YoutubeBlockComponent = ({
 		layout: 'responsive',
 		width: '16',
 		height: '9',
-		'data-block-on-consent': '', // Block player until consent is obtained
+		'data-block-on-consent': '_till_accepted', // Block player until consent is obtained
 		'data-param-modestbranding': true, // Remove YouTube logo
 		credentials: 'omit',
 	};


### PR DESCRIPTION
## What does this change?

Switching AMP components that use the `data-block-on-consent` attribute from the value `_till_accepted` (the default) to `_till_responded`

https://docs.sourcepoint.com/hc/en-us/articles/5490459963923-Block-component-via-data-block-on-consent
  
This is to ensure requests are made for users who provide partial consent to IAB-compliant vendors i.e. google analytics, comscore, prebid (pubmatic, criteo, ozone, amazon, permutive ) and permutive.

Current Behaviour with `data-block-on-consent=_till_accepted` :
- Accept all consent
  - Bid requests are made to pubmatic, criteo, ozone, amazon, permutive and google.
- Partial consent
  - No requests are made.
- Reject all consent
  - No requests are made.

New Behaviour:
- Accept all consent
  - Bid requests are made to pubmatic, criteo, ozone, amazon, permutive and google (doubleclick).
- Partial consent
  - Bid requests are made google (doubleclick) 
  - Ads are not shown when the following purposes are deselected:
    - Use limited data
    - Measure advertising performance
    - Develop and improve services
    - Understand audiences through statistics or combinations of data from different sources
- Reject all consent
  - Bid requests are made google (doubleclick)
  - Ads are not shown

Other AMP components that are relying on the value of `data-block-on-consent` to default to `_till_accepted` have been updated to explicitly state `data-block-on-consent=_till_accepted`

## Why?

Currently, users have given partial consent are not shown any ads due to the `data-block-on-consent=_till_accepted` property.

Josie from Sourcepoint recommended we use the  `data-block-on-consent=_till_responded`  for IAB-compliant vendors.

In this scenario, we trust the IAB-complaint vendors to consider the user consent before processing the request.

[Document detailing changes](https://docs.google.com/document/d/1qo2CY8cgIe5RAiqH1iP6daa-ixuBcD70s2BR8nHmIJU/edit?usp=sharing)
 
