### PR TITLE
Additional version bump for Ophan test version

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -58,7 +58,7 @@
 		"@guardian/identity-auth-frontend": "3.0.0",
 		"@guardian/libs": "16.0.1",
 		"@guardian/ophan-tracker-js": "2.0.4",
-		"@guardian/ophan-tracker-js-next": "npm:@guardian/ophan-tracker-js@2.1.0-next.2",
+		"@guardian/ophan-tracker-js-next": "npm:@guardian/ophan-tracker-js@2.1.0-next.3",
 		"@guardian/shimport": "1.0.2",
 		"@guardian/source-foundations": "14.1.4",
 		"@guardian/source-react-components": "18.0.0",

--- a/dotcom-rendering/scripts/env/check-deps.js
+++ b/dotcom-rendering/scripts/env/check-deps.js
@@ -13,7 +13,7 @@ if (pkg.devDependencies) {
  */
 const exceptions = /** @type {const} */ ([
 	'github:guardian/babel-plugin-px-to-rem#v0.1.0',
-	'npm:@guardian/ophan-tracker-js@2.1.0-next.2',
+	'npm:@guardian/ophan-tracker-js@2.1.0-next.3',
 ]);
 
 const mismatches = Object.entries(pkg.dependencies)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -387,8 +387,8 @@ importers:
         specifier: 2.0.4
         version: 2.0.4
       '@guardian/ophan-tracker-js-next':
-        specifier: npm:@guardian/ophan-tracker-js@2.1.0-next.2
-        version: /@guardian/ophan-tracker-js@2.1.0-next.2
+        specifier: npm:@guardian/ophan-tracker-js@2.1.0-next.3
+        version: /@guardian/ophan-tracker-js@2.1.0-next.3
       '@guardian/shimport':
         specifier: 1.0.2
         version: 1.0.2
@@ -4781,8 +4781,8 @@ packages:
     engines: {node: '>=16'}
     dev: false
 
-  /@guardian/ophan-tracker-js@2.1.0-next.2:
-    resolution: {integrity: sha512-N5WxkDYuCjhLI6IE3Npyegsr5p/3482f7A1SNxWELJdXHgSrD8wnKQ3K18vwZHv7cJN4iNg7isEtgKsb5H4LZw==}
+  /@guardian/ophan-tracker-js@2.1.0-next.3:
+    resolution: {integrity: sha512-PhkoypSxP4Afjd6OV/D/RXvNQU85qOlhPn1jC7nvp8WjzNHSLVBlnBITQMK3ASbBHBvBuFylLLZTyGAk1SUhIA==}
     engines: {node: '>=16'}
     dev: false
 


### PR DESCRIPTION
## What does this change?

This bumps the test version of Ophan again for additional changes and fixes.

See #10425 and https://github.com/guardian/ophan/pull/5808