### PR TITLE
Fix discussion app hydration bug

### DIFF
--- a/dotcom-rendering/src/client/discussion.ts
+++ b/dotcom-rendering/src/client/discussion.ts
@@ -1,6 +1,7 @@
 import { doHydration } from './islands/doHydration';
 import { getEmotionCache } from './islands/emotion';
 import { getConfig } from './islands/getConfig';
+import { getName } from './islands/getName';
 import { getProps } from './islands/getProps';
 
 const forceHydration = async (): Promise<void> => {
@@ -14,7 +15,7 @@ const forceHydration = async (): Promise<void> => {
 		if (!guElement) return;
 		if (rest.length > 0) return;
 
-		const name = guElement.getAttribute('name');
+		const name = getName(guElement);
 		if (!name) return;
 
 		// Read the props and config from where they have been serialised in the dom using an Island

--- a/dotcom-rendering/src/client/discussion.ts
+++ b/dotcom-rendering/src/client/discussion.ts
@@ -5,13 +5,17 @@ import { getProps } from './islands/getProps';
 
 const forceHydration = async (): Promise<void> => {
 	try {
-		const name = 'DiscussionContainer';
-
 		// Select the Discussion island element
-		const guElement = document.querySelector<HTMLElement>(
-			`gu-island[name=${name}]`,
+		const [guElement, ...rest] = document.querySelectorAll<HTMLElement>(
+			`gu-island[name=DiscussionWeb],gu-island[name=DiscussionApps]`,
 		);
+
+		// If no discussion island is found, or if there are multiple discussion islands, then we don't want to force hydration
 		if (!guElement) return;
+		if (rest.length > 0) return;
+
+		const name = guElement.getAttribute('name');
+		if (!name) return;
 
 		// Read the props and config from where they have been serialised in the dom using an Island
 		const props = getProps(guElement);


### PR DESCRIPTION
## What does this change?
Updates the query selector to check for either either the web or apps variant of the discussion app, after the name was updated. 

## Why?
We need this to make sure the discussion app is hydrated if a hash or permalink is used. 
