### PR TITLE
Add 5mb file warning

### DIFF
--- a/dotcom-rendering/src/components/Callout/FormField.tsx
+++ b/dotcom-rendering/src/components/Callout/FormField.tsx
@@ -102,7 +102,7 @@ export const FormField = ({
 					optional={!required}
 					error={fieldError}
 					data-testid={`form-field-${formField.id}`}
-					maxFileSize={5000000}
+					maxFileSize={5_000_000}
 					onUpload={(file: string | undefined): void =>
 						setFieldInFormData(formField.id, file)
 					}

--- a/dotcom-rendering/src/components/Callout/FormField.tsx
+++ b/dotcom-rendering/src/components/Callout/FormField.tsx
@@ -98,10 +98,11 @@ export const FormField = ({
 				<FileInput
 					label={label}
 					hideLabel={hideLabel}
-					supporting={description}
+					supporting={'Please note, the maximum file size is 5MB.'}
 					optional={!required}
 					error={fieldError}
 					data-testid={`form-field-${formField.id}`}
+					maxFileSize={5000000}
 					onUpload={(file: string | undefined): void =>
 						setFieldInFormData(formField.id, file)
 					}


### PR DESCRIPTION
## What does this change?
Adds a file size warning to the callouts 

## Why?
We can't accept files larger than 5mb so we want to display this to users. 

## Screenshots



| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/20416599/406aa0ba-b021-42d5-a4fd-4a0cc0e05507
[after]: https://github.com/guardian/dotcom-rendering/assets/20416599/81162d0d-50c5-4c5b-afe3-098310f1946c

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
