### PR TITLE
Fix `SecureSignup` grid areas

### DIFF
--- a/dotcom-rendering/src/components/SecureSignup.importable.tsx
+++ b/dotcom-rendering/src/components/SecureSignup.importable.tsx
@@ -72,8 +72,8 @@ const formStylesWhenSignedIn = {
 	gridTemplateColumns: 'auto 1fr',
 	gridTemplateAreas: [
 		// this is easier to parse over multiple lines
-		'label  label',
-		'button input',
+		'"label  label"',
+		'"button input"',
 	].join(' '),
 } satisfies CSSProperties;
 


### PR DESCRIPTION
## What does this change?

Correct the syntax introduced in #10570 

## Why?

It looks naff otherwise

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/76776/c51efcec-915b-40e2-b344-50e037bc0caa
[after]: https://github.com/guardian/dotcom-rendering/assets/76776/36d57853-9ed4-4807-9e20-b160dbfd78bc