### PR TITLE
Better `--interactive-block-background` integration

### DIFF
--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -3724,7 +3724,8 @@ const syndicationButtonBorder: PaletteFunction = ({ design, theme }) => {
 			return sourcePalette.neutral[86];
 	}
 };
-const interactiveBlockBackground = () => sourcePalette.neutral[100];
+const interactiveBlockBackgroundLight = () => 'transparent';
+const interactiveBlockBackgroundDark = () => sourcePalette.neutral[100];
 
 const mostViewedHeadlineLight = (): string => sourcePalette.neutral[7];
 const mostViewedHeadlineDark = (): string => sourcePalette.neutral[86];
@@ -5397,8 +5398,8 @@ const paletteColours = {
 		dark: appsEpicBorderDark,
 	},
 	'--interactive-block-background': {
-		light: interactiveBlockBackground,
-		dark: interactiveBlockBackground,
+		light: interactiveBlockBackgroundLight,
+		dark: interactiveBlockBackgroundDark,
 	},
 	'--most-viewed-headline': {
 		light: mostViewedHeadlineLight,


### PR DESCRIPTION
## What does this change?

In light scheme, set the interactive block’s background to `transparent`, so it integrates better with its surrounding.

The darks scheme still adds a `white` background to ensure contrast is sufficient.

## Why?

Discussed with @benwuersching as a solution to the current jarring graphs that we introduced with #9577

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |
| ![before2][] | ![after2][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/76776/a9bbd189-a565-4475-b403-686844d613e7
[after]: https://github.com/guardian/dotcom-rendering/assets/76776/ac80671f-c6b5-49bb-9da1-30720222a48f

[before2]: https://github.com/guardian/dotcom-rendering/assets/76776/02cc38e1-2a23-46d9-8ca9-52e3964e31ef
[after2]: https://github.com/guardian/dotcom-rendering/assets/76776/e4dcf319-1f14-4953-8453-f8e957d9d3f1

## Next steps

We should consider whether it would be benefical to send information to interactive blocks about the surrouding context, especially the `--article-background` and `--article-text`