### PR TITLE
Added Background Colours For Interactive Elements

### DIFF
--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -3724,7 +3724,50 @@ const syndicationButtonBorder: PaletteFunction = ({ design, theme }) => {
 			return sourcePalette.neutral[86];
 	}
 };
-const interactiveBlockBackgroundLight = () => 'transparent';
+
+const interactiveBlockBackgroundLight: PaletteFunction = ({
+	design,
+	theme,
+	display,
+}) => {
+	switch (design) {
+		case ArticleDesign.Letter:
+			return sourcePalette.opinion[800];
+		case ArticleDesign.Comment:
+			switch (theme) {
+				case ArticleSpecial.SpecialReportAlt:
+					return sourcePalette.specialReportAlt[800];
+				default:
+					return sourcePalette.opinion[800];
+			}
+		case ArticleDesign.Editorial:
+			return sourcePalette.opinion[800];
+		case ArticleDesign.Analysis:
+			switch (theme) {
+				case ArticleSpecial.SpecialReportAlt:
+					return sourcePalette.specialReportAlt[800];
+				default:
+					return sourcePalette.news[800];
+			}
+		default:
+			switch (theme) {
+				case ArticleSpecial.SpecialReport:
+					return sourcePalette.specialReport[800];
+				case ArticleSpecial.SpecialReportAlt:
+					return sourcePalette.specialReportAlt[800];
+				case ArticleSpecial.Labs:
+					switch (display) {
+						case ArticleDisplay.Immersive:
+							return sourcePalette.neutral[100];
+						default:
+							return sourcePalette.neutral[97];
+					}
+				default:
+					return sourcePalette.neutral[100];
+			}
+	}
+};
+
 const interactiveBlockBackgroundDark = () => sourcePalette.neutral[100];
 
 const mostViewedHeadlineLight = (): string => sourcePalette.neutral[7];


### PR DESCRIPTION
`transparent` doesn't work when these elements have other roles, like "supporting" or "immersive". The left margin overlaps with the element. By setting a background, and given that these elements appear in front of the left margin, the background will hide the margin line under the element.

## Screenshots

| Before | After |
|--------|--------|
| ![interactive-element-before] | ![interactive-element-after] |

[interactive-element-after]: https://github.com/guardian/dotcom-rendering/assets/53781962/3f05a6db-9c5a-467a-8d02-474e6535a1f9
[interactive-element-before]: https://github.com/guardian/dotcom-rendering/assets/53781962/f788669b-16ff-4d2c-848c-f123ba24a17c
