### PR TITLE
Require reason to report comment with "Other" category

### DIFF
--- a/dotcom-rendering/src/components/Discussion/AbuseReportForm.tsx
+++ b/dotcom-rendering/src/components/Discussion/AbuseReportForm.tsx
@@ -177,6 +177,10 @@ export const AbuseReportForm = ({
 			});
 	};
 
+	// If the "Other" category is selected, you must supply a reason
+	const otherCategoryId = 9;
+	const isReasonRequired = formVariables.categoryId === otherCategoryId;
+
 	return (
 		<div aria-modal="true" ref={modalRef}>
 			<form css={formWrapper} onSubmit={onSubmit}>
@@ -208,7 +212,7 @@ export const AbuseReportForm = ({
 						</option>
 						<option value="7">Copyright</option>
 						<option value="8">Spam</option>
-						<option value="9">Other</option>
+						<option value={otherCategoryId}>Other</option>
 					</select>
 					{!!errors.categoryId && (
 						<span css={errorMessageStyles}>
@@ -219,7 +223,7 @@ export const AbuseReportForm = ({
 
 				<div css={inputWrapper}>
 					<label css={labelStyles} htmlFor="reason">
-						Reason (optional)
+						Reason {isReasonRequired ? `` : `(optional)`}
 					</label>
 					<textarea
 						name="reason"
@@ -231,6 +235,7 @@ export const AbuseReportForm = ({
 							})
 						}
 						value={formVariables.reason}
+						required={isReasonRequired}
 					></textarea>
 					{!!errors.reason && (
 						<span css={errorMessageStyles}>{errors.reason}</span>

--- a/dotcom-rendering/src/components/Discussion/AbuseReportForm.tsx
+++ b/dotcom-rendering/src/components/Discussion/AbuseReportForm.tsx
@@ -177,7 +177,7 @@ export const AbuseReportForm = ({
 			});
 	};
 
-	// If the "Other" category is selected, you must supply a reason
+	/** If the "Other" category is selected, you must supply a reason */
 	const otherCategoryId = 9;
 	const isReasonRequired = formVariables.categoryId === otherCategoryId;
 


### PR DESCRIPTION
## What does this change?

To report a comment with the reason category "Other" requires you to include a reason, but the UI does not reflect this.

- Removes the `(optional)` label on the reason field when reporting a comment with reason category "Other"
- Sets the `required` attribute of the `reason` field when reporting a comment with reason category "Other"

Closes #10583

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![image](https://github.com/guardian/dotcom-rendering/assets/705427/89803d72-4fee-4803-845a-ee6b820a0ec2) | <img width="347" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/705427/af3e6801-f514-473a-a106-27c5e7ecf87b"> |
<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
