### PR TITLE
No space between the end of right column and advert in liveblogs

### DIFF
--- a/dotcom-rendering/src/components/TopRightAdSlot.tsx
+++ b/dotcom-rendering/src/components/TopRightAdSlot.tsx
@@ -29,7 +29,7 @@ export const TopRightAdSlot = ({
 				css`
 					position: static;
 					height: 100%;
-					max-height: 100%;
+					max-height: 97%;
 				`,
 				adStyles,
 			]}

--- a/dotcom-rendering/src/components/TopRightAdSlot.tsx
+++ b/dotcom-rendering/src/components/TopRightAdSlot.tsx
@@ -29,7 +29,7 @@ export const TopRightAdSlot = ({
 				css`
 					position: static;
 					height: 100%;
-					max-height: 97%;
+					max-height: 100%;
 				`,
 				adStyles,
 			]}

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -1170,6 +1170,7 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 											margin-left: 20px;
 											margin-right: -20px;
 											display: none;
+											padding-bottom: 255px;
 										}
 										${from.leftCol} {
 											/* above 1140 */

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -1170,7 +1170,6 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 											margin-left: 20px;
 											margin-right: -20px;
 											display: none;
-											padding-bottom: 255px;
 										}
 										${from.leftCol} {
 											/* above 1140 */
@@ -1179,6 +1178,7 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 										}
 										${from.wide} {
 											display: block;
+											padding-bottom: 255px;
 										}
 									`}
 								>


### PR DESCRIPTION
## What does this change?

We don't have a space between the end of the right column and advert in liveblogs and in this PR I added a `padding-bottom` in LiveLayout file so it just applies that change to liveblogs.

## Why?

To improve the page design by increasing the distance between the "Right" column ad-slot and "merchandising-high" ad-slot on liveblogs, and have a consistent padding across articles and liveblogs. 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![image](https://github.com/guardian/dotcom-rendering/assets/23424805/28ff6f39-7f93-45f3-bd83-be077ff40d97) | ![image](https://github.com/guardian/dotcom-rendering/assets/23424805/6a4fba10-d792-45c0-a1b1-3779586403b9) |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
