### PR TITLE
Highlight selected nav with pillar colour on tag pages

### DIFF
--- a/dotcom-rendering/src/server/render.front.web.tsx
+++ b/dotcom-rendering/src/server/render.front.web.tsx
@@ -22,8 +22,8 @@ interface Props {
 	front: DCRFrontType;
 }
 
-const extractFrontNav = (front: DCRFrontType): NavType => {
-	const NAV = extractNAV(front.nav);
+const extractFrontNav = (nav: FENavType): NavType => {
+	const NAV = extractNAV(nav);
 	const { currentNavLink } = NAV;
 
 	// Is the `currentNavLink` a pillar?
@@ -74,7 +74,7 @@ export const renderFront = ({
 	front,
 }: Props): { html: string; prefetchScripts: string[] } => {
 	const title = front.webTitle;
-	const NAV = extractFrontNav(front);
+	const NAV = extractFrontNav(front.nav);
 
 	// Fronts are not supported in Apps
 	const config: Config = { renderingTarget: 'Web', darkModeAvailable: false };
@@ -160,7 +160,7 @@ export const renderTagPage = ({
 	tagPage: DCRTagPageType;
 }): { html: string; prefetchScripts: string[] } => {
 	const title = tagPage.webTitle;
-	const NAV = extractNAV(tagPage.nav);
+	const NAV = extractFrontNav(tagPage.nav);
 
 	// Fronts are not supported in Apps
 	const config: Config = { renderingTarget: 'Web', darkModeAvailable: false };


### PR DESCRIPTION
## What does this change?
Highlight selected nav with pillar colour on tag pages

## Why?
We want to indicate to users which nav section they are in by highlighting the selected nav section with its pillar colour. This reinstates tag page behaviour from frontend. 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
