### PR TITLE
Only jump to comment when fully loaded

### DIFF
--- a/dotcom-rendering/src/components/Discussion/Comments.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comments.tsx
@@ -172,11 +172,12 @@ export const Comments = ({
 	 * */
 	useEffect(() => {
 		if (commentToScrollTo === undefined) return;
+		if (loading) return;
 
 		document
 			.getElementById(`comment-${commentToScrollTo}`)
 			?.scrollIntoView();
-	}, [commentToScrollTo]);
+	}, [commentToScrollTo, loading]);
 
 	const onFilterChange = (newFilterObject: FilterOptions) => {
 		/**


### PR DESCRIPTION
## What does this change?

Reintroduce the check for `loading` before scrolling to a comment

## Why?

Otherwise, it’s possible that a comment is not yet loaded when a user wants to scroll to it.

Small fixup on https://github.com/guardian/dotcom-rendering/pull/10589#discussion_r1490947536

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/76776/fb55717d-73ac-4dfc-adb9-21dadbceb747
[after]: https://github.com/guardian/dotcom-rendering/assets/76776/93b5e3c6-aa91-425b-a07a-319e5cb2b50c