### PR TITLE
Bump support-dotcom-components

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -63,7 +63,7 @@
 		"@guardian/source-foundations": "14.1.4",
 		"@guardian/source-react-components": "18.0.0",
 		"@guardian/source-react-components-development-kitchen": "16.0.0",
-		"@guardian/support-dotcom-components": "1.1.2",
+		"@guardian/support-dotcom-components": "1.1.3",
 		"@guardian/tsconfig": "0.2.0",
 		"@playwright/test": "1.40.1",
 		"@sentry/browser": "7.75.1",

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -63,7 +63,7 @@
 		"@guardian/source-foundations": "14.1.4",
 		"@guardian/source-react-components": "18.0.0",
 		"@guardian/source-react-components-development-kitchen": "16.0.0",
-		"@guardian/support-dotcom-components": "1.1.1",
+		"@guardian/support-dotcom-components": "1.1.2",
 		"@guardian/tsconfig": "0.2.0",
 		"@playwright/test": "1.40.1",
 		"@sentry/browser": "7.75.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -402,8 +402,8 @@ importers:
         specifier: 16.0.0
         version: 16.0.0(@emotion/react@11.11.1)(@guardian/libs@16.0.1)(@guardian/source-foundations@14.1.4)(@guardian/source-react-components@18.0.0)(react@18.2.0)(tslib@2.6.2)(typescript@5.3.3)
       '@guardian/support-dotcom-components':
-        specifier: 1.1.1
-        version: 1.1.1
+        specifier: 1.1.2
+        version: 1.1.2
       '@guardian/tsconfig':
         specifier: 0.2.0
         version: 0.2.0
@@ -4315,7 +4315,7 @@ packages:
       '@guardian/ophan-tracker-js': 2.0.4
       '@guardian/prebid.js': 8.34.0(tslib@2.6.2)(typescript@5.3.3)
       '@guardian/source-foundations': 14.1.4(tslib@2.6.2)(typescript@5.3.3)
-      '@guardian/support-dotcom-components': 1.1.1
+      '@guardian/support-dotcom-components': 1.1.2
       '@octokit/core': 4.2.4
       fastdom: 1.0.11
       lodash-es: 4.17.21
@@ -4758,8 +4758,8 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@guardian/support-dotcom-components@1.1.1:
-    resolution: {integrity: sha512-MnplfuFdfzHgxW6Lh3sZiQy/hxSN/rwIVIm0H+mnFiJGfeV5uqfXbwwb8b9HTt9WaO3JxEhoKTvJmCH4nw9lEw==}
+  /@guardian/support-dotcom-components@1.1.2:
+    resolution: {integrity: sha512-qW2H1sMI9v7D0N+TyY/my8l/0tsTG9/ccbaB3dGrAK0druTWw13r1uWDQHTckElNY1zNFItW8JnZjc+nEwLsrQ==}
     dev: false
 
   /@guardian/tsconfig@0.2.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -402,8 +402,8 @@ importers:
         specifier: 16.0.0
         version: 16.0.0(@emotion/react@11.11.1)(@guardian/libs@16.0.1)(@guardian/source-foundations@14.1.4)(@guardian/source-react-components@18.0.0)(react@18.2.0)(tslib@2.6.2)(typescript@5.3.3)
       '@guardian/support-dotcom-components':
-        specifier: 1.1.2
-        version: 1.1.2
+        specifier: 1.1.3
+        version: 1.1.3
       '@guardian/tsconfig':
         specifier: 0.2.0
         version: 0.2.0
@@ -4315,7 +4315,7 @@ packages:
       '@guardian/ophan-tracker-js': 2.0.4
       '@guardian/prebid.js': 8.34.0(tslib@2.6.2)(typescript@5.3.3)
       '@guardian/source-foundations': 14.1.4(tslib@2.6.2)(typescript@5.3.3)
-      '@guardian/support-dotcom-components': 1.1.2
+      '@guardian/support-dotcom-components': 1.1.3
       '@octokit/core': 4.2.4
       fastdom: 1.0.11
       lodash-es: 4.17.21
@@ -4758,8 +4758,8 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@guardian/support-dotcom-components@1.1.2:
-    resolution: {integrity: sha512-qW2H1sMI9v7D0N+TyY/my8l/0tsTG9/ccbaB3dGrAK0druTWw13r1uWDQHTckElNY1zNFItW8JnZjc+nEwLsrQ==}
+  /@guardian/support-dotcom-components@1.1.3:
+    resolution: {integrity: sha512-EMS7oxOLijCFw9u63BN3Ou+KqMmDiNvDpHZ+vDrdsUhB7bs+eDDRr01Bzg7BokqKQuW0g+oyYOCLctabx8Ngag==}
     dev: false
 
   /@guardian/tsconfig@0.2.0:


### PR DESCRIPTION
## What does this change?
We've recently changed the models in SDC to be inferred from zod schemas. This is because we're being more careful to validate data server-side, and we don't want to maintain separate models and schemas.
[See PR.](https://github.com/guardian/support-dotcom-components/pull/1058)

The epic component uses these models, so this PR updates DCR to use the latest npm package. There should not be any functional change here.