### PR TITLE
Fix Reply & Comment parsing

### DIFF
--- a/dotcom-rendering/src/components/Discussion.test.tsx
+++ b/dotcom-rendering/src/components/Discussion.test.tsx
@@ -1,57 +1,59 @@
+import { parse } from 'valibot';
 import type { CommentType, ReplyType, UserProfile } from '../lib/discussion';
+import { discussionApiResponseSchema } from '../lib/discussion';
 import { replaceMatchingCommentResponses } from './Discussion';
+
+const userProfile = {
+	userId: '12345678',
+	displayName: 'Some reply person',
+	webUrl: 'https://profile.theguardian.com/user/id/12345678',
+	apiUrl: 'https://discussion.guardianapis.com/discussion-api/profile/12345678',
+	avatar: 'https://avatar.guim.co.uk/user/12345678',
+	secureAvatarUrl: 'https://avatar.guim.co.uk/user/12345678',
+	badge: [],
+} satisfies UserProfile;
+
+const createComment = (
+	id: number,
+	body: string,
+	responses: ReplyType[],
+): CommentType => ({
+	id,
+	body,
+	userProfile,
+	responses,
+	apiUrl: '',
+	webUrl: '',
+	date: 'something',
+	isHighlighted: false,
+	isoDateTime: '2024-01-01T00:00:01Z',
+	numRecommends: 0,
+	status: 'visible',
+});
+
+const createReply = (id: number, body: string): ReplyType => ({
+	id,
+	body,
+	userProfile,
+	apiUrl: '',
+	webUrl: '',
+	date: 'something',
+	isHighlighted: false,
+	isoDateTime: '2024-01-01T00:00:01Z',
+	numRecommends: 0,
+	status: 'visible',
+	responseTo: {
+		date: '',
+		isoDateTime: '',
+		displayName: '',
+		commentApiUrl: '',
+		commentId: '',
+		commentWebUrl: '',
+	},
+});
 
 describe('Discussion', () => {
 	describe('Action: expandCommentReplies', () => {
-		const userProfile = {
-			userId: '12345678',
-			displayName: 'Some reply person',
-			webUrl: 'https://profile.theguardian.com/user/id/12345678',
-			apiUrl: 'https://discussion.guardianapis.com/discussion-api/profile/12345678',
-			avatar: 'https://avatar.guim.co.uk/user/12345678',
-			secureAvatarUrl: 'https://avatar.guim.co.uk/user/12345678',
-			badge: [],
-		} satisfies UserProfile;
-
-		const createComment = (
-			id: number,
-			body: string,
-			responses: ReplyType[],
-		): CommentType => ({
-			id,
-			body,
-			userProfile,
-			responses,
-			apiUrl: '',
-			webUrl: '',
-			date: 'something',
-			isHighlighted: false,
-			isoDateTime: '2024-01-01T00:00:01Z',
-			numRecommends: 0,
-			status: 'visible',
-		});
-
-		const createReply = (id: number, body: string): ReplyType => ({
-			id,
-			body,
-			userProfile,
-			apiUrl: '',
-			webUrl: '',
-			date: 'something',
-			isHighlighted: false,
-			isoDateTime: '2024-01-01T00:00:01Z',
-			numRecommends: 0,
-			status: 'visible',
-			responseTo: {
-				date: '',
-				isoDateTime: '',
-				displayName: '',
-				commentApiUrl: '',
-				commentId: '',
-				commentWebUrl: '',
-			},
-		});
-
 		it('Will not do anything if no comment matches', () => {
 			const replacer = replaceMatchingCommentResponses({
 				type: 'expandCommentReplies',
@@ -107,6 +109,82 @@ describe('Discussion', () => {
 				createComment(234_000, 'Or other', []),
 				createComment(456_000, 'Is to be said', []),
 			]);
+		});
+	});
+
+	describe('Parsing comments and replies', () => {
+		it('can find 4 comments at the top level', () => {
+			const result = parse(discussionApiResponseSchema, {
+				status: 'ok',
+				currentPage: 1,
+				pages: 1,
+				pageSize: 4,
+				orderBy: 'recommendations',
+				discussion: {
+					key: 'test',
+					webUrl: '',
+					apiUrl: '',
+					commentCount: 4,
+					topLevelCommentCount: 4,
+					isClosedForComments: true,
+					isClosedForRecommendation: true,
+					isThreaded: false,
+					title: '',
+					comments: [
+						createComment(10, 'first', []),
+						createComment(20, 'second', [
+							createReply(21, 'second reply'),
+						]),
+						createComment(30, 'third', []),
+						createComment(40, 'fourth', []),
+					],
+				},
+			});
+
+			expect(result.status).toBe('ok');
+			if (result.status !== 'ok') return;
+
+			expect(result.discussion.comments.length).toBe(4);
+		});
+
+		it('can find 2 comments and 2 replies at the top level', () => {
+			const result = parse(discussionApiResponseSchema, {
+				status: 'ok',
+				currentPage: 1,
+				pages: 1,
+				pageSize: 4,
+				orderBy: 'recommendations',
+				discussion: {
+					key: 'test',
+					webUrl: '',
+					apiUrl: '',
+					commentCount: 4,
+					topLevelCommentCount: 4,
+					isClosedForComments: true,
+					isClosedForRecommendation: true,
+					isThreaded: false,
+					title: '',
+					comments: [
+						createComment(10, 'first', []),
+						createComment(20, 'second', []),
+						createReply(11, 'first reply'),
+						createReply(21, 'second reply'),
+						createReply(22, 'second reply again'),
+					],
+				},
+			});
+
+			expect(result.status).toBe('ok');
+			if (result.status !== 'ok') return;
+
+			const comments = result.discussion.comments.filter(
+				({ responses }) => responses,
+			);
+			const replies = result.discussion.comments.filter(
+				({ responseTo }) => responseTo,
+			);
+			expect(comments.length).toBe(2);
+			expect(replies.length).toBe(3);
 		});
 	});
 });

--- a/dotcom-rendering/src/components/Discussion.tsx
+++ b/dotcom-rendering/src/components/Discussion.tsx
@@ -224,7 +224,7 @@ const reducer = (state: State, action: Action): State => {
 			return {
 				...state,
 				comments: state.comments.map((comment) =>
-					'responses' in comment &&
+					comment.responses &&
 					comment.id === Number(action.comment.responseTo.commentId)
 						? {
 								...comment,

--- a/dotcom-rendering/src/components/Discussion/Comment.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comment.stories.tsx
@@ -72,6 +72,7 @@ const blockedCommentData = {
 
 const replyCommentData: ReplyType = {
 	...commentData,
+	responses: undefined,
 	responseTo: {
 		displayName: 'ArtVandelay',
 		commentApiUrl: '',
@@ -84,6 +85,7 @@ const replyCommentData: ReplyType = {
 
 const longReplyCommentData: ReplyType = {
 	...commentData,
+	responses: undefined,
 	responseTo: {
 		displayName: 'ArtVandelayWithAVeryLongUserName',
 		commentApiUrl: '',
@@ -96,6 +98,7 @@ const longReplyCommentData: ReplyType = {
 
 const longBothReplyCommentData: ReplyType = {
 	...commentData,
+	responses: undefined,
 	userProfile: {
 		...commentData.userProfile,
 		displayName: 'AVeryLongUserNameForThisUserToo',

--- a/dotcom-rendering/src/components/Discussion/Comment.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comment.tsx
@@ -389,7 +389,7 @@ export const Comment = ({
 							<Column>
 								<div
 									css={[
-										'responseTo' in comment &&
+										comment.responseTo &&
 											hideBelowMobileLandscape,
 										hideAboveMobileLandscape,
 									]}
@@ -445,7 +445,7 @@ export const Comment = ({
 								</div>
 								<div
 									css={[
-										!('responseTo' in comment) &&
+										!comment.responseTo &&
 											hideBelowMobileLandscape,
 									]}
 								>
@@ -470,7 +470,7 @@ export const Comment = ({
 												}
 											</Link>
 										</div>
-										{'responseTo' in comment ? (
+										{comment.responseTo ? (
 											<div
 												css={[
 													colourStyles,
@@ -498,7 +498,7 @@ export const Comment = ({
 										<div
 											css={[
 												timestampWrapperStyles,
-												'responseTo' in comment &&
+												comment.responseTo &&
 													hideBelowMobileLandscape,
 											]}
 										>
@@ -551,7 +551,7 @@ export const Comment = ({
 
 					<div
 						css={[
-							'responseTo' in comment && hideBelowMobileLandscape,
+							comment.responseTo && hideBelowMobileLandscape,
 							hideAboveMobileLandscape,
 						]}
 					>

--- a/dotcom-rendering/src/components/Discussion/CommentContainer.test.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentContainer.test.tsx
@@ -92,7 +92,7 @@ describe('CommentContainer', () => {
 				reportAbuse={() => Promise.resolve(ok(true))}
 				expandCommentReplies={(id, responses) => {
 					if (commentBeingRepliedTo?.id !== id) return;
-					if (!('responses' in commentBeingRepliedTo)) return;
+					if (!commentBeingRepliedTo.responses) return;
 					commentBeingRepliedTo.responses = responses;
 				}}
 			/>,
@@ -189,7 +189,7 @@ describe('CommentContainer', () => {
 				reportAbuse={() => Promise.resolve(ok(true))}
 				expandCommentReplies={(id, responses) => {
 					if (commentBeingRepliedTo?.id !== id) return;
-					if (!('responses' in commentBeingRepliedTo)) return;
+					if (!commentBeingRepliedTo.responses) return;
 					commentBeingRepliedTo.responses = responses;
 				}}
 			/>,

--- a/dotcom-rendering/src/components/Discussion/CommentContainer.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentContainer.tsx
@@ -100,7 +100,7 @@ export const CommentContainer = ({
 	reportAbuse,
 	expandCommentReplies,
 }: Props) => {
-	const responses = 'responses' in comment ? comment.responses : [];
+	const responses = comment.responses ? comment.responses : [];
 	const totalResponseCount = comment.metaData?.responseCount ?? 0;
 
 	// Filter logic

--- a/dotcom-rendering/src/components/Discussion/Comments.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comments.tsx
@@ -131,8 +131,8 @@ export const Comments = ({
 	comments,
 	pickError,
 	setPickError,
-	addComment: addTopLevelComment,
-	addReply: addReplyComment,
+	addComment,
+	addReply,
 	handleFilterChange,
 	setTopFormUserMissing,
 	setReplyFormUserMissing,
@@ -218,10 +218,10 @@ export const Comments = ({
 		setMutes(updatedMutes); // Update local state
 	};
 	const onAddComment = (comment: CommentType | ReplyType) => {
-		if ('responses' in comment) {
-			addTopLevelComment(comment);
+		if (comment.responses) {
+			addComment(comment);
 		} else {
-			addReplyComment(comment);
+			addReply(comment);
 		}
 		const commentElement = document.getElementById(`comment-${comment.id}`);
 		commentElement?.scrollIntoView();

--- a/dotcom-rendering/src/lib/discussion.ts
+++ b/dotcom-rendering/src/lib/discussion.ts
@@ -13,6 +13,7 @@ import {
 	safeParse,
 	string,
 	transform,
+	undefined_,
 	union,
 	variant,
 } from 'valibot';
@@ -111,6 +112,7 @@ export type ReplyType = Output<typeof replySchema>;
 const replySchema = merge([
 	baseCommentSchema,
 	object({
+		responses: optional(undefined_(), undefined),
 		responseTo: object({
 			displayName: string(),
 			commentApiUrl: string(),
@@ -128,6 +130,7 @@ const commentSchema = merge([
 	baseCommentSchema,
 	object({
 		responses: optional(array(replySchema), []),
+		responseTo: optional(undefined_(), undefined),
 	}),
 ]);
 
@@ -300,7 +303,7 @@ const discussionApiSuccessSchema = object({
 		isClosedForRecommendation: boolean(),
 		isThreaded: boolean(),
 		title: string(),
-		comments: array(union([commentSchema, replySchema])),
+		comments: array(union([replySchema, commentSchema])),
 	}),
 });
 


### PR DESCRIPTION
## What does this change?

Better parsing on `Comment` and `Reply`

## Why?

Fixes #10597 

Follow-up on #10563 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/76776/0350cdcb-99f9-45d4-b099-fde2ce3ba617
[after]: https://github.com/guardian/dotcom-rendering/assets/76776/f5e68d0f-fa4a-4ba8-b0e3-28fb61b08321


Running the test on `main` correctly identifies the issue:

<img width="865" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/76776/c968b50d-0f03-4571-aa8d-3f1f43d660bd">
