### PR TITLE
Adjust latency thresholds for facia-rendering app

### DIFF
--- a/dotcom-rendering/cdk/bin/cdk.ts
+++ b/dotcom-rendering/cdk/bin/cdk.ts
@@ -80,18 +80,18 @@ new RenderingCDKStack(cdkApp, 'FaciaRendering-PROD', {
 		maximumInstances: 24,
 		policy: {
 			scalingStepsOut: [
-				// No scaling up effect when latency is lower than 0.3s
-				{ lower: 0, upper: 0.3, change: 0 },
-				// When latency is higher than 0.3s we scale up by 50%
-				{ lower: 0.3, change: 50 },
-				// When latency is higher than 0.4s we scale up by 80%
-				{ lower: 0.4, change: 80 },
+				// No scaling up effect when latency is lower than 0.4s
+				{ lower: 0, upper: 0.4, change: 0 },
+				// When latency is higher than 0.4s we scale up by 50%
+				{ lower: 0.4, change: 50 },
+				// When latency is higher than 0.5s we scale up by 80%
+				{ lower: 0.5, change: 80 },
 			],
 			scalingStepsIn: [
-				// No scaling down effect when latency is higher than 0.27s
-				{ lower: 0.27, change: 0 },
-				// When latency is lower than 0.27s we scale down by 1
-				{ upper: 0.27, lower: 0, change: -1 },
+				// No scaling down effect when latency is higher than 0.35s
+				{ lower: 0.35, change: 0 },
+				// When latency is lower than 0.35s we scale down by 1
+				{ upper: 0.35, lower: 0, change: -1 },
 			],
 		},
 	},


### PR DESCRIPTION
## What does this change?

Increases latency threshold for scale up and scale down events for the `facia-rendering` app.

## Why?

We're seeing a lot of scaling events that could be avoided by having higher `TargetResponseTime` thresholds on the scaling steps

<img width="1492" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/43961396/a4cc8d00-658b-4405-88ff-a2f83b9a104e">

