### PR TITLE
Tweak DCR stack scaling 

### DIFF
--- a/dotcom-rendering/cdk/bin/cdk.ts
+++ b/dotcom-rendering/cdk/bin/cdk.ts
@@ -111,7 +111,7 @@ new RenderingCDKStack(cdkApp, 'InteractiveRendering-PROD', {
 	stage: 'PROD',
 	domainName: 'interactive-rendering.guardianapis.com',
 	scaling: {
-		minimumInstances: 6,
+		minimumInstances: 3,
 		maximumInstances: 24,
 		policy: {
 			scalingStepsOut: [

--- a/dotcom-rendering/cdk/lib/renderingStack.ts
+++ b/dotcom-rendering/cdk/lib/renderingStack.ts
@@ -175,7 +175,7 @@ export class RenderingCDKStack extends CDKStack {
 					metric: latencyMetric,
 					scalingSteps: props.scaling.policy.scalingStepsOut,
 					adjustmentType: AdjustmentType.PERCENT_CHANGE_IN_CAPACITY,
-					evaluationPeriods: 5,
+					evaluationPeriods: 10,
 				},
 			);
 


### PR DESCRIPTION
## What does this change?

Allows for a min of 3 instances running for the interactives stack - this is because interactives don't see much traffic and there are not that many of them

Increases the scale up evaluation period to 5 minutes - this is because our response time is quite spiky so we don't want to react too soon