### PR TITLE
Add credit and caption to PhotoEssay main image

### DIFF
--- a/dotcom-rendering/docs/patterns/enhance-capi.md
+++ b/dotcom-rendering/docs/patterns/enhance-capi.md
@@ -25,8 +25,6 @@ There are some conventions that can result in images appearing differently, we n
 Multi images. Consecutive sequences of two halfWidth images will be merged into a MultiImageBlockElement and shown side by side
 Captions. A `ul`/`li` tag directly after an image will replace the preceding image's caption
 
-In particular, Photo essay articles needs a lot of cleaning to achieve the intended designs. They use special caption styles and can sometimes have titles overlaying images.
-
 In DCR we support these conventions using [enhance-images.ts](/dotcom-rendering/src/model/enhance-images.ts)
 
 ## How remove these enhancement functions

--- a/dotcom-rendering/src/model/enhance-images.test.ts
+++ b/dotcom-rendering/src/model/enhance-images.test.ts
@@ -38,7 +38,7 @@ describe('Enhance Images', () => {
 						...image.data,
 						caption:
 							'<ul><li>This new caption replaces the one on the image object.</li></ul>',
-						credit: '',
+								credit: 'Photograph: Cat Vinton/The Guardian',
 					},
 				},
 			];
@@ -71,7 +71,7 @@ describe('Enhance Images', () => {
 							data: {
 								...image.data,
 								caption: '',
-								credit: '',
+										credit: 'Photograph: Cat Vinton/The Guardian',
 							},
 						},
 						{
@@ -81,7 +81,7 @@ describe('Enhance Images', () => {
 							data: {
 								...image.data,
 								caption: '',
-								credit: '',
+										credit: 'Photograph: Cat Vinton/The Guardian',
 							},
 						},
 					],
@@ -113,8 +113,8 @@ describe('Enhance Images', () => {
 					displayCredit: false,
 					data: {
 						...image.data,
-						caption: '',
-						credit: '',
+								caption: 'The original caption',
+								credit: 'Photograph: Cat Vinton/The Guardian',
 					},
 				},
 				{
@@ -125,7 +125,7 @@ describe('Enhance Images', () => {
 						...image.data,
 						caption:
 							'<ul><li><p>Judy, just sitting in the square on her own in Walworth.</p></li></ul>',
-						credit: '',
+								credit: 'Photograph: Cat Vinton/The Guardian',
 					},
 				},
 			];
@@ -154,7 +154,7 @@ describe('Enhance Images', () => {
 						...image.data,
 						caption:
 							'<ul><li><p>Judy, just sitting in the square on her own in Walworth.</p></li></ul>',
-						credit: '',
+								credit: 'Photograph: Cat Vinton/The Guardian',
 					},
 				},
 			];
@@ -180,8 +180,8 @@ describe('Enhance Images', () => {
 					displayCredit: false,
 					data: {
 						...image.data,
-						caption: '',
-						credit: '',
+								caption: 'The original caption',
+								credit: 'Photograph: Cat Vinton/The Guardian',
 					},
 					title: 'Example title text',
 				},
@@ -218,8 +218,9 @@ describe('Enhance Images', () => {
 					displayCredit: false,
 					data: {
 						...image.data,
-						caption: '<ul><li><p>This is the caption</p></li></ul>',
-						credit: '',
+								caption:
+									'<ul><li><p>This is the caption</p></li></ul>',
+								credit: 'Photograph: Cat Vinton/The Guardian',
 					},
 					title: 'The title',
 				},
@@ -259,7 +260,7 @@ describe('Enhance Images', () => {
 							data: {
 								...image.data,
 								caption: '',
-								credit: '',
+										credit: 'Photograph: Cat Vinton/The Guardian',
 							},
 						},
 						{
@@ -269,7 +270,7 @@ describe('Enhance Images', () => {
 							data: {
 								...image.data,
 								caption: '',
-								credit: '',
+										credit: 'Photograph: Cat Vinton/The Guardian',
 							},
 						},
 					],
@@ -280,8 +281,9 @@ describe('Enhance Images', () => {
 					displayCredit: false,
 					data: {
 						...image.data,
-						caption: '<ul><li><p>This is the caption</p></li></ul>',
-						credit: '',
+								caption:
+									'<ul><li><p>This is the caption</p></li></ul>',
+								credit: 'Photograph: Cat Vinton/The Guardian',
 					},
 				},
 			];
@@ -317,8 +319,9 @@ describe('Enhance Images', () => {
 					displayCredit: false,
 					data: {
 						...image.data,
-						caption: '<ul><li><p>This is the caption</p></li></ul>',
-						credit: '',
+								caption:
+									'<ul><li><p>This is the caption</p></li></ul>',
+								credit: 'Photograph: Cat Vinton/The Guardian',
 					},
 					title: 'The title',
 				},
@@ -343,8 +346,8 @@ describe('Enhance Images', () => {
 					displayCredit: false,
 					data: {
 						...image.data,
-						caption: '',
-						credit: '',
+								caption: 'The original caption',
+								credit: 'Photograph: Cat Vinton/The Guardian',
 					},
 				},
 			];
@@ -381,8 +384,9 @@ describe('Enhance Images', () => {
 					displayCredit: false,
 					data: {
 						...image.data,
-						caption: '<ul><li><p>This is the caption</p></li></ul>',
-						credit: '',
+								caption:
+									'<ul><li><p>This is the caption</p></li></ul>',
+								credit: 'Photograph: Cat Vinton/The Guardian',
 					},
 					title: 'The title',
 				},
@@ -397,8 +401,8 @@ describe('Enhance Images', () => {
 					displayCredit: false,
 					data: {
 						...image.data,
-						caption: '',
-						credit: '',
+								caption: 'The original caption',
+								credit: 'Photograph: Cat Vinton/The Guardian',
 					},
 				},
 				{
@@ -407,8 +411,8 @@ describe('Enhance Images', () => {
 					displayCredit: false,
 					data: {
 						...image.data,
-						caption: '',
-						credit: '',
+								caption: 'The original caption',
+								credit: 'Photograph: Cat Vinton/The Guardian',
 					},
 				},
 			];
@@ -449,8 +453,8 @@ describe('Enhance Images', () => {
 					displayCredit: false,
 					data: {
 						...image.data,
-						caption: '',
-						credit: '',
+								caption: 'The original caption',
+								credit: 'Photograph: Cat Vinton/The Guardian',
 					},
 					title: 'The title',
 				},
@@ -541,9 +545,8 @@ describe('Enhance Images', () => {
 					...image,
 					role: 'inline',
 					data: {
-						caption:
-							'This text starts in data but gets removed for photo essays',
-						credit: 'but it is copied into the lightbox property so we can use it there',
+								caption: 'The original caption',
+								credit: 'Photograph: Cat Vinton/The Guardian',
 					},
 				},
 			];
@@ -554,8 +557,8 @@ describe('Enhance Images', () => {
 					position: 4,
 					role: 'inline',
 					data: {
-						caption: '',
-						credit: '',
+								caption: 'The original caption',
+								credit: 'Photograph: Cat Vinton/The Guardian',
 					},
 				},
 			];

--- a/dotcom-rendering/src/model/enhance-images.test.ts
+++ b/dotcom-rendering/src/model/enhance-images.test.ts
@@ -38,7 +38,7 @@ describe('Enhance Images', () => {
 						...image.data,
 						caption:
 							'<ul><li>This new caption replaces the one on the image object.</li></ul>',
-								credit: 'Photograph: Cat Vinton/The Guardian',
+						credit: 'Photograph: Cat Vinton/The Guardian',
 					},
 				},
 			];
@@ -71,7 +71,7 @@ describe('Enhance Images', () => {
 							data: {
 								...image.data,
 								caption: '',
-										credit: 'Photograph: Cat Vinton/The Guardian',
+								credit: 'Photograph: Cat Vinton/The Guardian',
 							},
 						},
 						{
@@ -81,7 +81,7 @@ describe('Enhance Images', () => {
 							data: {
 								...image.data,
 								caption: '',
-										credit: 'Photograph: Cat Vinton/The Guardian',
+								credit: 'Photograph: Cat Vinton/The Guardian',
 							},
 						},
 					],
@@ -113,8 +113,8 @@ describe('Enhance Images', () => {
 					displayCredit: false,
 					data: {
 						...image.data,
-								caption: 'The original caption',
-								credit: 'Photograph: Cat Vinton/The Guardian',
+						caption: 'The original caption',
+						credit: 'Photograph: Cat Vinton/The Guardian',
 					},
 				},
 				{
@@ -125,7 +125,7 @@ describe('Enhance Images', () => {
 						...image.data,
 						caption:
 							'<ul><li><p>Judy, just sitting in the square on her own in Walworth.</p></li></ul>',
-								credit: 'Photograph: Cat Vinton/The Guardian',
+						credit: 'Photograph: Cat Vinton/The Guardian',
 					},
 				},
 			];
@@ -154,7 +154,7 @@ describe('Enhance Images', () => {
 						...image.data,
 						caption:
 							'<ul><li><p>Judy, just sitting in the square on her own in Walworth.</p></li></ul>',
-								credit: 'Photograph: Cat Vinton/The Guardian',
+						credit: 'Photograph: Cat Vinton/The Guardian',
 					},
 				},
 			];
@@ -180,8 +180,8 @@ describe('Enhance Images', () => {
 					displayCredit: false,
 					data: {
 						...image.data,
-								caption: 'The original caption',
-								credit: 'Photograph: Cat Vinton/The Guardian',
+						caption: 'The original caption',
+						credit: 'Photograph: Cat Vinton/The Guardian',
 					},
 					title: 'Example title text',
 				},
@@ -218,9 +218,8 @@ describe('Enhance Images', () => {
 					displayCredit: false,
 					data: {
 						...image.data,
-								caption:
-									'<ul><li><p>This is the caption</p></li></ul>',
-								credit: 'Photograph: Cat Vinton/The Guardian',
+						caption: '<ul><li><p>This is the caption</p></li></ul>',
+						credit: 'Photograph: Cat Vinton/The Guardian',
 					},
 					title: 'The title',
 				},
@@ -260,7 +259,7 @@ describe('Enhance Images', () => {
 							data: {
 								...image.data,
 								caption: '',
-										credit: 'Photograph: Cat Vinton/The Guardian',
+								credit: 'Photograph: Cat Vinton/The Guardian',
 							},
 						},
 						{
@@ -270,7 +269,7 @@ describe('Enhance Images', () => {
 							data: {
 								...image.data,
 								caption: '',
-										credit: 'Photograph: Cat Vinton/The Guardian',
+								credit: 'Photograph: Cat Vinton/The Guardian',
 							},
 						},
 					],
@@ -281,9 +280,8 @@ describe('Enhance Images', () => {
 					displayCredit: false,
 					data: {
 						...image.data,
-								caption:
-									'<ul><li><p>This is the caption</p></li></ul>',
-								credit: 'Photograph: Cat Vinton/The Guardian',
+						caption: '<ul><li><p>This is the caption</p></li></ul>',
+						credit: 'Photograph: Cat Vinton/The Guardian',
 					},
 				},
 			];
@@ -319,9 +317,8 @@ describe('Enhance Images', () => {
 					displayCredit: false,
 					data: {
 						...image.data,
-								caption:
-									'<ul><li><p>This is the caption</p></li></ul>',
-								credit: 'Photograph: Cat Vinton/The Guardian',
+						caption: '<ul><li><p>This is the caption</p></li></ul>',
+						credit: 'Photograph: Cat Vinton/The Guardian',
 					},
 					title: 'The title',
 				},
@@ -346,8 +343,8 @@ describe('Enhance Images', () => {
 					displayCredit: false,
 					data: {
 						...image.data,
-								caption: 'The original caption',
-								credit: 'Photograph: Cat Vinton/The Guardian',
+						caption: 'The original caption',
+						credit: 'Photograph: Cat Vinton/The Guardian',
 					},
 				},
 			];
@@ -384,9 +381,8 @@ describe('Enhance Images', () => {
 					displayCredit: false,
 					data: {
 						...image.data,
-								caption:
-									'<ul><li><p>This is the caption</p></li></ul>',
-								credit: 'Photograph: Cat Vinton/The Guardian',
+						caption: '<ul><li><p>This is the caption</p></li></ul>',
+						credit: 'Photograph: Cat Vinton/The Guardian',
 					},
 					title: 'The title',
 				},
@@ -401,8 +397,8 @@ describe('Enhance Images', () => {
 					displayCredit: false,
 					data: {
 						...image.data,
-								caption: 'The original caption',
-								credit: 'Photograph: Cat Vinton/The Guardian',
+						caption: 'The original caption',
+						credit: 'Photograph: Cat Vinton/The Guardian',
 					},
 				},
 				{
@@ -411,8 +407,8 @@ describe('Enhance Images', () => {
 					displayCredit: false,
 					data: {
 						...image.data,
-								caption: 'The original caption',
-								credit: 'Photograph: Cat Vinton/The Guardian',
+						caption: 'The original caption',
+						credit: 'Photograph: Cat Vinton/The Guardian',
 					},
 				},
 			];
@@ -453,8 +449,8 @@ describe('Enhance Images', () => {
 					displayCredit: false,
 					data: {
 						...image.data,
-								caption: 'The original caption',
-								credit: 'Photograph: Cat Vinton/The Guardian',
+						caption: 'The original caption',
+						credit: 'Photograph: Cat Vinton/The Guardian',
 					},
 					title: 'The title',
 				},
@@ -545,8 +541,8 @@ describe('Enhance Images', () => {
 					...image,
 					role: 'inline',
 					data: {
-								caption: 'The original caption',
-								credit: 'Photograph: Cat Vinton/The Guardian',
+						caption: 'The original caption',
+						credit: 'Photograph: Cat Vinton/The Guardian',
 					},
 				},
 			];
@@ -557,8 +553,8 @@ describe('Enhance Images', () => {
 					position: 4,
 					role: 'inline',
 					data: {
-								caption: 'The original caption',
-								credit: 'Photograph: Cat Vinton/The Guardian',
+						caption: 'The original caption',
+						credit: 'Photograph: Cat Vinton/The Guardian',
 					},
 				},
 			];

--- a/dotcom-rendering/src/model/enhance-images.ts
+++ b/dotcom-rendering/src/model/enhance-images.ts
@@ -424,8 +424,6 @@ const enhance =
 	(elements: FEElement[]): FEElement[] => {
 		if (isPhotoEssay) {
 			return new Enhancer(elements)
-				.stripCaptions()
-				.removeCredit()
 				.addMultiImageElements()
 				.addTitles()
 				.addCaptionsToMultis()

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -2687,7 +2687,7 @@ const captionTextLight: PaletteFunction = ({ design, theme }) => {
 				case ArticleDesign.PhotoEssay:
 					switch (theme as ArticleTheme) {
 						case Pillar.News:
-							return sourcePalette.news[300];
+							return sourcePalette.neutral[46];
 						case Pillar.Opinion:
 							return sourcePalette.opinion[300];
 						case Pillar.Sport:

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -2685,24 +2685,7 @@ const captionTextLight: PaletteFunction = ({ design, theme }) => {
 		default:
 			switch (design) {
 				case ArticleDesign.PhotoEssay:
-					switch (theme as ArticleTheme) {
-						case Pillar.News:
-							return sourcePalette.neutral[46];
-						case Pillar.Opinion:
-							return sourcePalette.opinion[300];
-						case Pillar.Sport:
-							return sourcePalette.sport[300];
-						case Pillar.Culture:
-							return sourcePalette.culture[300];
-						case Pillar.Lifestyle:
-							return sourcePalette.lifestyle[300];
-						case ArticleSpecial.Labs:
-							return sourcePalette.labs[300];
-						case ArticleSpecial.SpecialReport:
-							return sourcePalette.specialReport[300];
-						case ArticleSpecial.SpecialReportAlt:
-							return sourcePalette.news[100];
-					}
+					return sourcePalette.neutral[46];
 
 				case ArticleDesign.Picture:
 					return sourcePalette.neutral[86];


### PR DESCRIPTION
Closes #10631

## What does this change?
Adds back credit and caption to Photo Essay articles.

## Why?
There was a decision to remove them in the past but we had a request from CP to add them back because there is a discrepancy with frontend in this article: https://www.theguardian.com/environment/2024/feb/19/like-the-flip-of-a-switch-its-gone-has-the-ecosystem-of-the-uk-largest-lake-collapsed-aoe

https://github.com/guardian/dotcom-rendering/blob/78f81ae8306ccd410ef0f005ea7e3176c236d094/dotcom-rendering/docs/patterns/enhance-capi.md?plain=1#L21-L30

I'm a bit skeptical as to whether this is still an issue because from testing some recent photo essays, it doesn't look like there is a problem. I'm proposing we add them back and see if we get any reports.

## Screenshots

| Before | After | frontend |
|--------|-------|----------|
| <img width="1483" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/19683595/18ab4e44-9904-475e-b634-ee9c4e26f396"> | <img width="1063" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/19683595/6ab33ccf-f34a-478a-a9b0-cafdb279f323"> | <img width="996" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/19683595/ef0459f5-82f2-40c4-9eb1-4d7f8bb52da0"> |
| <img width="1483" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/19683595/18ab4e44-9904-475e-b634-ee9c4e26f396"> | <img width="940" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/19683595/0308f5b7-7d7a-4c34-9391-ed0fa94fc6e2"> | <img width="922" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/19683595/d01328fe-cf2d-4522-9bd4-d481abfdc5db"> |
| <img width="926" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/19683595/b224268f-f40c-4d18-8276-a7a4915a05b3"> | <img width="886" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/19683595/ab3ca323-ce33-4af8-99eb-c4caaf15f5de"> | <img width="947" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/19683595/709edd44-fcde-4d2b-a28c-2878ce5beee0"> |











[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
