### PR TITLE
Use `latest` version of Chromatic GH Action

### DIFF
--- a/.github/workflows/ar-chromatic.yml
+++ b/.github/workflows/ar-chromatic.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Chromatic - Apps Rendering
         env:
           NODE_OPTIONS: '--max_old_space_size=4096'
-        uses: chromaui/action@v1
+        uses: chromaui/action@latest
 
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN__APPS_RENDERING }}

--- a/.github/workflows/dcr-chromatic.yml
+++ b/.github/workflows/dcr-chromatic.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Chromatic - DCR
         env:
           NODE_OPTIONS: '--max_old_space_size=4096'
-        uses: chromaui/action@v1
+        uses: chromaui/action@latest
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN__DOTCOM_RENDERING }}
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What does this change?

Updates Chromatic Github workflows to use the `chromaui/action@latest` rather than a specific pinned version (e.g. `chromaui/action@v1`)

## Why?

We aren't receiving updates and this action is now on version 10 (9 ahead of the one we are using!)

This isn't the sort of dependency that needs to be pinned as it's a dev dependency and is purely for development feedback rather than any core functionality
