### PR TITLE
Give Card comment count an accessible name

### DIFF
--- a/dotcom-rendering/src/components/CardCommentCount.importable.tsx
+++ b/dotcom-rendering/src/components/CardCommentCount.importable.tsx
@@ -1,5 +1,9 @@
 import { css } from '@emotion/react';
-import { between, textSans } from '@guardian/source-foundations';
+import {
+	between,
+	textSans,
+	visuallyHidden,
+} from '@guardian/source-foundations';
 import { formatCount } from '../lib/formatCount';
 import { useCommentCount } from '../lib/useCommentCount';
 import { palette as themePalette } from '../palette';
@@ -83,12 +87,18 @@ export const CardCommentCount = ({
 				<div css={svgStyles(isDynamo, isOnwardContent)}>
 					<CommentIcon />
 				</div>
-				<div css={longStyles} aria-hidden="true">
-					{long}
-				</div>
+				<div css={longStyles}>{long}</div>
 				<div css={shortStyles} aria-hidden="true">
 					{short}
 				</div>
+				<span
+					css={css`
+						${visuallyHidden}
+					`}
+				>
+					{' '}
+					comments
+				</span>
 			</div>
 		</ContainerOverrides>
 	);


### PR DESCRIPTION
## What does this change?

Exposes the comment count of the article as its accessible name in the `CardCommentCount` component.

## Why?

All links should have accessible names, but all text content inside this component had `aria-hidden=true` set on it. 

An example of how this poses a problem: Screenreaders don't know how to describe this element; Voiceover with Chrome, for example, just reads out the url, and doesn't actually include the `#comment` fragment, so users would have no way of knowing that this links to comments.

<img width="771" alt="Google lighthouse screenshot showing many comment links with no accessible name" src="https://github.com/guardian/dotcom-rendering/assets/37048459/e1b4237d-4be7-467f-b6d0-ce4d53c798a8">

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| <img width="757" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/37048459/8aa73c4e-cb59-44a2-bd05-1fca20636464"> | <img width="755" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/37048459/dd6d0b59-5241-4499-baf5-80b8e80e2abd"> |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
