### PR TITLE
Reduce number of AR instances in PROD

### DIFF
--- a/apps-rendering/cdk/bin/cdk.ts
+++ b/apps-rendering/cdk/bin/cdk.ts
@@ -25,8 +25,8 @@ new MobileAppsRendering(app, 'MobileAppsRendering-PROD', {
 	stage: 'PROD',
 	recordPrefix: 'mobile-rendering',
 	asgCapacity: {
-		minimumInstances: 6,
-		maximumInstances: 24,
+		minimumInstances: 3,
+		maximumInstances: 12,
 	},
 	instanceSize: InstanceSize.SMALL,
 	appsRenderingDomain: 'mobile-aws.guardianapis.com',


### PR DESCRIPTION
## What does this change?

Halves the number of `apps-rendering` instances for the PROD environment.

## Why?

We're sending much less traffic to AR now that we've got standard articles on mobile fronts rendering via DCAR. We can scale this down further later on if we find that we are still over-provisioned.