### PR TITLE
add instance type to CDK props and use higher instance size for facia

### DIFF
--- a/dotcom-rendering/cdk/bin/cdk.ts
+++ b/dotcom-rendering/cdk/bin/cdk.ts
@@ -1,5 +1,5 @@
 import { App } from 'aws-cdk-lib';
-import { InstanceSize } from 'aws-cdk-lib/aws-ec2';
+import { InstanceClass, InstanceSize, InstanceType } from 'aws-cdk-lib/aws-ec2';
 import { DotcomRendering } from '../lib/dotcom-rendering';
 import { RenderingCDKStack } from '../lib/renderingStack';
 
@@ -34,7 +34,7 @@ new RenderingCDKStack(cdkApp, 'ArticleRendering-CODE', {
 	stage: 'CODE',
 	domainName: 'article-rendering.code.dev-guardianapis.com',
 	scaling: { minimumInstances: 1, maximumInstances: 4 },
-	instanceSize: InstanceSize.MICRO,
+	instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MICRO),
 });
 new RenderingCDKStack(cdkApp, 'ArticleRendering-PROD', {
 	guApp: 'article-rendering',
@@ -60,7 +60,7 @@ new RenderingCDKStack(cdkApp, 'ArticleRendering-PROD', {
 			],
 		},
 	},
-	instanceSize: InstanceSize.SMALL,
+	instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.SMALL),
 });
 
 /** Facia */
@@ -69,7 +69,7 @@ new RenderingCDKStack(cdkApp, 'FaciaRendering-CODE', {
 	stage: 'CODE',
 	domainName: 'facia-rendering.code.dev-guardianapis.com',
 	scaling: { minimumInstances: 1, maximumInstances: 4 },
-	instanceSize: InstanceSize.MICRO,
+	instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MICRO),
 });
 new RenderingCDKStack(cdkApp, 'FaciaRendering-PROD', {
 	guApp: 'facia-rendering',
@@ -95,7 +95,7 @@ new RenderingCDKStack(cdkApp, 'FaciaRendering-PROD', {
 			],
 		},
 	},
-	instanceSize: InstanceSize.SMALL,
+	instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
 });
 
 /** Interactive */
@@ -104,7 +104,7 @@ new RenderingCDKStack(cdkApp, 'InteractiveRendering-CODE', {
 	stage: 'CODE',
 	domainName: 'interactive-rendering.code.dev-guardianapis.com',
 	scaling: { minimumInstances: 1, maximumInstances: 4 },
-	instanceSize: InstanceSize.MICRO,
+	instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MICRO),
 });
 new RenderingCDKStack(cdkApp, 'InteractiveRendering-PROD', {
 	guApp: 'interactive-rendering',
@@ -130,5 +130,5 @@ new RenderingCDKStack(cdkApp, 'InteractiveRendering-PROD', {
 			],
 		},
 	},
-	instanceSize: InstanceSize.SMALL,
+	instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.SMALL),
 });

--- a/dotcom-rendering/cdk/lib/renderingStack.test.ts
+++ b/dotcom-rendering/cdk/lib/renderingStack.test.ts
@@ -1,6 +1,6 @@
 import { App } from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
-import { InstanceSize } from 'aws-cdk-lib/aws-ec2';
+import { InstanceClass, InstanceSize, InstanceType } from 'aws-cdk-lib/aws-ec2';
 import { RenderingCDKStack } from './renderingStack';
 
 /**
@@ -29,7 +29,10 @@ describe('The RenderingCDKStack', () => {
 					],
 				},
 			},
-			instanceSize: InstanceSize.MICRO,
+			instanceType: InstanceType.of(
+				InstanceClass.T4G,
+				InstanceSize.MICRO,
+			),
 		});
 		const template = Template.fromStack(stack);
 		expect(template.toJSON()).toMatchSnapshot();

--- a/dotcom-rendering/cdk/lib/renderingStack.ts
+++ b/dotcom-rendering/cdk/lib/renderingStack.ts
@@ -14,8 +14,7 @@ import type { ScalingInterval } from 'aws-cdk-lib/aws-applicationautoscaling';
 import { AdjustmentType, StepScalingPolicy } from 'aws-cdk-lib/aws-autoscaling';
 import { Metric } from 'aws-cdk-lib/aws-cloudwatch';
 import { SnsAction } from 'aws-cdk-lib/aws-cloudwatch-actions';
-import type { InstanceSize } from 'aws-cdk-lib/aws-ec2';
-import { InstanceClass, InstanceType, Peer } from 'aws-cdk-lib/aws-ec2';
+import { type InstanceType, Peer } from 'aws-cdk-lib/aws-ec2';
 import { Topic } from 'aws-cdk-lib/aws-sns';
 import { StringParameter } from 'aws-cdk-lib/aws-ssm';
 import { getUserData } from './userData';
@@ -23,7 +22,7 @@ import { getUserData } from './userData';
 export interface RenderingCDKStackProps extends Omit<GuStackProps, 'stack'> {
 	guApp: `${'article' | 'facia' | 'interactive'}-rendering`;
 	domainName: string;
-	instanceSize: InstanceSize;
+	instanceType: InstanceType;
 	scaling: GuAsgCapacity & {
 		policy?: {
 			scalingStepsOut: ScalingInterval[];
@@ -44,7 +43,7 @@ export class RenderingCDKStack extends CDKStack {
 		});
 
 		const { stack: guStack, region, account } = this;
-		const { guApp, stage, instanceSize, scaling, domainName } = props;
+		const { guApp, stage, instanceType, scaling, domainName } = props;
 
 		const artifactsBucket =
 			GuDistributionBucketParameter.getInstance(this).valueAsString;
@@ -83,7 +82,7 @@ export class RenderingCDKStack extends CDKStack {
 			// instead of the default 8080 which is unreachable.
 			certificateProps: { domainName },
 			healthcheck: { path: '/_healthcheck' },
-			instanceType: InstanceType.of(InstanceClass.T4G, instanceSize),
+			instanceType,
 			monitoringConfiguration,
 			roleConfiguration: {
 				additionalPolicies: [


### PR DESCRIPTION
## What does this change?


## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
