### PR TITLE
Increase size of `facia-rendering` app instances

### DIFF
--- a/dotcom-rendering/cdk/bin/cdk.ts
+++ b/dotcom-rendering/cdk/bin/cdk.ts
@@ -95,7 +95,7 @@ new RenderingCDKStack(cdkApp, 'FaciaRendering-PROD', {
 			],
 		},
 	},
-	instanceSize: InstanceSize.SMALL,
+	instanceSize: InstanceSize.MEDIUM,
 });
 
 /** Interactive */


### PR DESCRIPTION
## What does this change?

Updates `facia-rendering` EC2 instances to use a T4G medium rather than a T4G small.

## Why?

We've been seeing a lot of DCR Timeout exceptions on the `facia-rendering` app since splitting the DCR traffic. This PR aims to reduce these errors.