### PR TITLE
Include valibot in webpack client transpilation

### DIFF
--- a/dotcom-rendering/webpack/webpack.config.client.js
+++ b/dotcom-rendering/webpack/webpack.config.client.js
@@ -182,6 +182,7 @@ module.exports.babelExclude = {
 		/@guardian\/(?!(automat-modules))/,
 		// Include the dynamic-import-polyfill
 		/dynamic-import-polyfill/,
+		/valibot/,
 	],
 };
 


### PR DESCRIPTION
Closes https://github.com/guardian/dotcom-rendering/issues/10644

## What does this change?
Includes valibot in webpack client transpilation

## Why?
If it's not transpiled, Safari versions lower than 13.1 fail to load `DiscussionWeb` component with a syntax error:

<img width="707" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/19683595/5325cd47-1458-464a-a6ef-0f7b2216b575">


## Screenshots

| Before      | After      |
| ----------- | ---------- |
| <img width="1211" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/19683595/ccedfa6a-0a9a-45ec-ae58-015f316a6401"> | <img width="875" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/19683595/94fe25d4-36d4-402c-bfd9-47caf3f587c8"> |





<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
