### PR TITLE
Add Swift Notes in the all newsletters page

### DIFF
--- a/dotcom-rendering/src/model/newsletter-grouping.ts
+++ b/dotcom-rendering/src/model/newsletter-grouping.ts
@@ -12,6 +12,7 @@ export const groups: Partial<Record<EditionId, StaticGroups>> = {
 			title: 'Get started',
 			newsletters: [
 				'morning-briefing', // First Edition
+				'swift-notes',
 				'saturday-edition',
 				'word-of-mouth', // Feast
 				'this-is-europe',
@@ -135,6 +136,7 @@ export const groups: Partial<Record<EditionId, StaticGroups>> = {
 		{
 			title: 'Culture picks',
 			newsletters: [
+				'swift-notes',
 				'film-today',
 				'sleeve-notes',
 				'whats-on',
@@ -207,6 +209,7 @@ export const groups: Partial<Record<EditionId, StaticGroups>> = {
 			newsletters: [
 				'morning-mail',
 				'afternoon-update',
+				'swift-notes',
 				'saturday-edition',
 				'first-dog',
 				'the-rural-network',


### PR DESCRIPTION
Closes https://github.com/guardian/dotcom-rendering/issues/10621

## What does this change?
Adds Swift Notes to the all newsletters page

## Why?
It will be launched this week

## Screenshots
No change yet, as the newsletter launch is still pending


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
