### PR TITLE
Rearrange all newsletters page for US edition

### DIFF
--- a/dotcom-rendering/src/model/newsletter-grouping.ts
+++ b/dotcom-rendering/src/model/newsletter-grouping.ts
@@ -109,52 +109,48 @@ export const groups: Partial<Record<EditionId, StaticGroups>> = {
 			title: 'Get started',
 			newsletters: [
 				'us-morning-newsletter', // First Thing
-				'saturday-edition',
-				'today-us', // Headlines US
-				'trump-on-trial',
 				'reclaim-your-brain',
-				'follow-margaret-sullivan',
-				'follow-robert-reich',
-				'best-of-opinion-us',
-				'headlines-europe',
-				'green-light', // Down to Earth
-				'patriarchy',
-				'bookmarks',
+				'trump-on-trial',
+				'today-us', // Headlines US
+				'soccer-with-jonathan-wilson',
 			],
 		},
 		{
 			title: 'In depth',
 			newsletters: [
+				'green-light', // Down to Earth
+				'soccer-with-jonathan-wilson',
+				'follow-robert-reich',
+				'follow-margaret-sullivan',
+				'patriarchy',
 				'this-is-europe',
-				'the-guide-staying-in',
 				'tech-scape',
 				'fashion-statement',
-				'word-of-mouth', // Feast
-				'pushing-buttons',
 			],
 		},
 		{
 			title: 'Culture picks',
 			newsletters: [
 				'swift-notes',
+				'the-guide-staying-in',
 				'film-today',
 				'sleeve-notes',
 				'whats-on',
 				'hear-here',
 				'art-weekly',
 				'design-review',
+				'documentaries',
 			],
 		},
 		{
 			title: 'Weekend reads',
 			newsletters: [
 				'inside-saturday',
-				'house-to-home',
-				'saved-for-later',
 				'five-great-reads',
 				'the-upside',
 				'the-long-read',
-				'observer-food',
+				'saved-for-later',
+				'house-to-home',
 			],
 		},
 		{
@@ -162,16 +158,14 @@ export const groups: Partial<Record<EditionId, StaticGroups>> = {
 			newsletters: [
 				'global-dispatch',
 				'cotton-capital',
-				'business-today',
-				'documentaries',
-				'her-stage',
 				'guardian-traveller',
+				'her-stage',
+				'the-crunch',
 			],
 		},
 		{
 			title: 'Sport',
 			newsletters: [
-				'soccer-with-jonathan-wilson',
 				'the-fiver', // Football Daily
 				'moving-the-goalposts',
 				'the-spin',
@@ -183,11 +177,13 @@ export const groups: Partial<Record<EditionId, StaticGroups>> = {
 		{
 			title: 'In brief',
 			newsletters: [
+				'best-of-opinion-us',
 				'today-uk', // Headlines UK
-				'today-au', // Headlines AUS
-				'headlines-europe',
 				'best-of-opinion',
+				'today-au', // Headlines AUS
 				'best-of-opinion-au',
+				'headlines-europe',
+				'business-today',
 			],
 		},
 		{
@@ -197,8 +193,6 @@ export const groups: Partial<Record<EditionId, StaticGroups>> = {
 				'saturday-edition',
 				'morning-mail',
 				'afternoon-update',
-				'first-dog',
-				'the-rural-network',
 				'australian-politics',
 			],
 		},


### PR DESCRIPTION
Closes https://github.com/guardian/dotcom-rendering/issues/10650

## What does this change?
Re-arranges the newsletters page for US edition

## Why?
To match [order requested by editorial](https://docs.google.com/spreadsheets/d/1Pfdow0Yj8OzkrnIWqIC-oSzVhwtwwDBdLmFx5hY-Gt4/edit#gid=1937396091)

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| <img width="1344" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/19683595/80a17b94-4bf8-416e-9dd8-d78c167a95e8"> | <img width="1310" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/19683595/d0d28787-8a7b-41f2-9425-2d5f9e470a28"> |
| <img width="1314" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/19683595/322a26cc-fe74-4afe-9dbe-fbff770ea22e"> | <img width="1333" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/19683595/c050f7fb-b0e8-424b-9466-9a67abfa7da8"> |
| <img width="1343" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/19683595/c4b63837-424d-4e29-aeb5-dc3a7d851537"> | <img width="1323" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/19683595/25c02521-e359-4c95-a0fc-6526a20aedaa"> |
| <img width="1314" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/19683595/f3aea3cc-2c74-490d-bb18-f4a5b6a81246"> | <img width="1309" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/19683595/080f3edf-3597-444d-aef8-ad828cc34f37"> |

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
