### PR TITLE
Add badges to tag pages

### DIFF
--- a/dotcom-rendering/makefile
+++ b/dotcom-rendering/makefile
@@ -178,7 +178,7 @@ gen-schema:
 	@git add src/model/article-schema.json
 	@git add src/model/front-schema.json
 	@git add src/model/block-schema.json
-	@git add src/model/tag-front-schema.json
+	@git add src/model/tag-page-schema.json
 
 check-stories:
 	$(call log, "Checking Storybook stories")

--- a/dotcom-rendering/src/components/ContainerTitle.tsx
+++ b/dotcom-rendering/src/components/ContainerTitle.tsx
@@ -21,6 +21,7 @@ type Props = {
 	containerPalette?: DCRContainerPalette;
 	showDateHeader?: boolean;
 	editionId?: EditionId;
+	lightweightHeader?: boolean;
 };
 
 const linkStyles = css`
@@ -88,6 +89,7 @@ const dateStyles = css`
  */
 export const ContainerTitle = ({
 	title,
+	lightweightHeader,
 	fontColour,
 	description,
 	url,
@@ -112,12 +114,25 @@ export const ContainerTitle = ({
 					href={url}
 					data-link-name="section heading"
 				>
-					<h2 css={[headerStylesWithUrl, headerStyles(fontColour)]}>
+					<h2
+						css={[
+							headerStylesWithUrl,
+							headerStyles(fontColour),
+							lightweightHeader &&
+								body.medium({ fontWeight: 'regular' }),
+						]}
+					>
 						{localisedTitle(title, editionId)}
 					</h2>
 				</a>
 			) : (
-				<h2 css={headerStyles(fontColour)}>
+				<h2
+					css={[
+						headerStyles(fontColour),
+						lightweightHeader &&
+							body.medium({ fontWeight: 'regular' }),
+					]}
+				>
 					{localisedTitle(title, editionId)}
 				</h2>
 			)}

--- a/dotcom-rendering/src/components/FrontSection.tsx
+++ b/dotcom-rendering/src/components/FrontSection.tsx
@@ -86,6 +86,7 @@ type Props = {
 	hasPageSkin?: boolean;
 	discussionApiUrl: string;
 	collectionBranding?: CollectionBranding;
+	isTagPage?: boolean;
 };
 
 const width = (columns: number, columnWidth: number, columnGap: number) =>
@@ -460,6 +461,7 @@ export const FrontSection = ({
 	hasPageSkin = false,
 	discussionApiUrl,
 	collectionBranding,
+	isTagPage,
 }: Props) => {
 	const overrides =
 		containerPalette && decideContainerOverrides(containerPalette);
@@ -526,6 +528,7 @@ export const FrontSection = ({
 					title={
 						<ContainerTitle
 							title={title}
+							lightweightHeader={isTagPage}
 							fontColour={overrides?.text.container}
 							description={description}
 							// On paid fronts the title is not treated as a link
@@ -537,6 +540,7 @@ export const FrontSection = ({
 					}
 					collectionBranding={collectionBranding}
 				/>
+
 				{leftContent}
 			</div>
 

--- a/dotcom-rendering/src/components/FrontSection.tsx
+++ b/dotcom-rendering/src/components/FrontSection.tsx
@@ -461,7 +461,7 @@ export const FrontSection = ({
 	hasPageSkin = false,
 	discussionApiUrl,
 	collectionBranding,
-	isTagPage,
+	isTagPage = false,
 }: Props) => {
 	const overrides =
 		containerPalette && decideContainerOverrides(containerPalette);

--- a/dotcom-rendering/src/components/FrontSectionTitle.tsx
+++ b/dotcom-rendering/src/components/FrontSectionTitle.tsx
@@ -25,6 +25,7 @@ const labelStyles = css`
 	padding-right: 0.625rem;
 	padding-bottom: 0.625rem;
 	text-align: left;
+	border-top: 1px dotted ${palette.neutral[86]};
 `;
 
 const aboutThisLinkStyles = css`

--- a/dotcom-rendering/src/layouts/TagPageLayout.tsx
+++ b/dotcom-rendering/src/layouts/TagPageLayout.tsx
@@ -5,8 +5,8 @@ import { Fragment } from 'react';
 import { DecideContainerByTrails } from '../components/DecideContainerByTrails';
 import {
 	decideFrontsBannerAdSlot,
-	decideMerchHighAndMobileAdSlots,
 	decideMerchandisingSlot,
+	decideMerchHighAndMobileAdSlots,
 } from '../components/DecideFrontsAdSlots';
 import { Footer } from '../components/Footer';
 import { FrontSection } from '../components/FrontSection';

--- a/dotcom-rendering/src/layouts/TagPageLayout.tsx
+++ b/dotcom-rendering/src/layouts/TagPageLayout.tsx
@@ -1,12 +1,12 @@
 import { css } from '@emotion/react';
-import { body, palette, space } from '@guardian/source-foundations';
+import { palette } from '@guardian/source-foundations';
 import { StraightLines } from '@guardian/source-react-components-development-kitchen';
 import { Fragment } from 'react';
 import { DecideContainerByTrails } from '../components/DecideContainerByTrails';
 import {
 	decideFrontsBannerAdSlot,
-	decideMerchandisingSlot,
 	decideMerchHighAndMobileAdSlots,
+	decideMerchandisingSlot,
 } from '../components/DecideFrontsAdSlots';
 import { Footer } from '../components/Footer';
 import { FrontSection } from '../components/FrontSection';
@@ -54,48 +54,6 @@ const getContainerId = (date: Date, locale: string, hasDay: boolean) => {
 			year: 'numeric',
 		})}`;
 	}
-};
-
-const titleStyle = css`
-	${body.medium({ fontWeight: 'regular' })};
-	color: ${palette.neutral[7]};
-	padding-bottom: ${space[1]}px;
-	padding-top: ${space[1]}px;
-	overflow-wrap: break-word; /*if a single word is too long, this will break the word up rather than have the display be affected*/
-`;
-
-const linkStyle = css`
-	text-decoration: none;
-	color: ${palette.neutral[7]};
-
-	&:hover {
-		text-decoration: underline;
-	}
-`;
-
-const SectionLeftContent = ({
-	url,
-	title,
-	dateString,
-}: {
-	title: string;
-	dateString: string;
-	url?: string;
-}) => {
-	if (url !== undefined) {
-		return (
-			<header css={titleStyle}>
-				<a href={url} css={linkStyle}>
-					<time dateTime={dateString}>{title}</time>
-				</a>
-			</header>
-		);
-	}
-	return (
-		<header css={titleStyle}>
-			<time dateTime={dateString}>{title}</time>
-		</header>
-	);
 };
 
 export const TagPageLayout = ({ tagPage, NAV }: Props) => {
@@ -271,18 +229,11 @@ export const TagPageLayout = ({ tagPage, NAV }: Props) => {
 								desktopAdPositions,
 							)}
 							<FrontSection
-								leftContent={
-									<SectionLeftContent
-										url={url}
-										title={title}
-										dateString={`${groupedTrails.year}-${
-											groupedTrails.month
-										}${
-											groupedTrails.day !== undefined
-												? `-${groupedTrails.day}`
-												: ''
-										}`}
-									/>
+								title={title}
+								url={url}
+								isTagPage={true}
+								collectionBranding={
+									index === 0 ? tagPage.branding : undefined
 								}
 								showTopBorder={true}
 								ophanComponentLink={`container-${index} | ${containedId}`}

--- a/dotcom-rendering/src/lib/branding.test.ts
+++ b/dotcom-rendering/src/lib/branding.test.ts
@@ -655,9 +655,15 @@ describe('decideTagPageBranding', () => {
 			hasMultipleBranding: false,
 		});
 	});
-	it('is undefined when no branding is present', () => {
+	it('is undefined when branding does not have a brandingType name present', () => {
+		const branding = {
+			sponsorName: 'Guardian.org',
+			aboutThisLink: '',
+			logo,
+		};
+
 		const tagPageBranding = decideTagPageBranding({
-			branding: undefined,
+			branding,
 		});
 		expect(tagPageBranding).toBeUndefined();
 	});

--- a/dotcom-rendering/src/lib/branding.test.ts
+++ b/dotcom-rendering/src/lib/branding.test.ts
@@ -1,5 +1,5 @@
 import type { Branding } from '../types/branding';
-import { decideCollectionBranding } from './branding';
+import { decideCollectionBranding, decideTagPageBranding } from './branding';
 
 // For the purpose of these tests we don't care about the contents of the logo objects
 const logo = {} as Branding['logo'];
@@ -627,5 +627,37 @@ describe('decideCollectionBranding', () => {
 			isContainerBranding: false,
 		});
 		expect(collectionBranding).toBeUndefined();
+	});
+});
+
+describe('decideTagPageBranding', () => {
+	it('picks branding from a tag page by their edition', () => {
+		const branding = {
+			brandingType: { name: 'sponsored' as const },
+			sponsorName: 'Guardian.org',
+			aboutThisLink: '',
+			logo,
+		};
+		const tagPageBranding = decideTagPageBranding({
+			branding,
+		});
+
+		expect(tagPageBranding).toMatchObject({
+			kind: 'sponsored',
+			isFrontBranding: true,
+			branding: {
+				brandingType: { name: 'sponsored' as const },
+				sponsorName: 'Guardian.org',
+				aboutThisLink: '',
+			},
+			isContainerBranding: false,
+			hasMultipleBranding: false,
+		});
+	});
+	it('is undefined when no branding is present', () => {
+		const tagPageBranding = decideTagPageBranding({
+			branding: undefined,
+		});
+		expect(tagPageBranding).toBeUndefined();
 	});
 });

--- a/dotcom-rendering/src/lib/branding.test.ts
+++ b/dotcom-rendering/src/lib/branding.test.ts
@@ -633,11 +633,12 @@ describe('decideCollectionBranding', () => {
 describe('decideTagPageBranding', () => {
 	it('picks branding from a tag page by their edition', () => {
 		const branding = {
-			brandingType: { name: 'sponsored' as const },
+			brandingType: { name: 'sponsored' },
 			sponsorName: 'Guardian.org',
 			aboutThisLink: '',
 			logo,
-		};
+		} satisfies Branding;
+
 		const tagPageBranding = decideTagPageBranding({
 			branding,
 		});
@@ -646,7 +647,7 @@ describe('decideTagPageBranding', () => {
 			kind: 'sponsored',
 			isFrontBranding: true,
 			branding: {
-				brandingType: { name: 'sponsored' as const },
+				brandingType: { name: 'sponsored' },
 				sponsorName: 'Guardian.org',
 				aboutThisLink: '',
 			},

--- a/dotcom-rendering/src/lib/branding.ts
+++ b/dotcom-rendering/src/lib/branding.ts
@@ -199,10 +199,8 @@ export const decideCollectionBranding = ({
 export const decideTagPageBranding = ({
 	branding,
 }: {
-	branding: Branding | undefined;
+	branding: Branding;
 }): CollectionBranding | undefined => {
-	if (branding === undefined) return undefined;
-
 	// If this tagpage is eligible to display branding
 	// AND there is branding defined, we should display it
 	const kind = getBrandingType([branding]);

--- a/dotcom-rendering/src/lib/branding.ts
+++ b/dotcom-rendering/src/lib/branding.ts
@@ -195,3 +195,23 @@ export const decideCollectionBranding = ({
 		hasMultipleBranding,
 	};
 };
+
+export const decideTagPageBranding = ({
+	branding,
+}: {
+	branding: Branding | undefined;
+}): CollectionBranding | undefined => {
+	if (branding === undefined) return undefined;
+
+	// If this tagpage is eligible to display branding
+	// AND there is branding defined, we should display it
+	const kind = getBrandingType([branding]);
+	if (!kind) return undefined;
+	return {
+		kind,
+		isFrontBranding: true,
+		branding,
+		isContainerBranding: false,
+		hasMultipleBranding: false,
+	};
+};

--- a/dotcom-rendering/src/model/tag-page-schema.json
+++ b/dotcom-rendering/src/model/tag-page-schema.json
@@ -1156,7 +1156,7 @@
             ]
         },
         "commercialProperties": {
-            "$ref": "#/definitions/Record<string,unknown>"
+            "$ref": "#/definitions/CommercialProperties"
         },
         "pageFooter": {
             "$ref": "#/definitions/FooterType"
@@ -1717,8 +1717,74 @@
             ],
             "type": "string"
         },
-        "Record<string,unknown>": {
-            "type": "object"
+        "CommercialProperties": {
+            "type": "object",
+            "properties": {
+                "UK": {
+                    "$ref": "#/definitions/EditionCommercialProperties"
+                },
+                "US": {
+                    "$ref": "#/definitions/EditionCommercialProperties"
+                },
+                "AU": {
+                    "$ref": "#/definitions/EditionCommercialProperties"
+                },
+                "INT": {
+                    "$ref": "#/definitions/EditionCommercialProperties"
+                },
+                "EUR": {
+                    "$ref": "#/definitions/EditionCommercialProperties"
+                }
+            },
+            "required": [
+                "AU",
+                "EUR",
+                "INT",
+                "UK",
+                "US"
+            ]
+        },
+        "EditionCommercialProperties": {
+            "type": "object",
+            "properties": {
+                "adTargeting": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/AdTargetParam"
+                    }
+                },
+                "branding": {
+                    "$ref": "#/definitions/Branding"
+                }
+            },
+            "required": [
+                "adTargeting"
+            ]
+        },
+        "AdTargetParam": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "value": {
+                    "anyOf": [
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name",
+                "value"
+            ]
         },
         "FooterType": {
             "type": "object",

--- a/dotcom-rendering/src/server/handler.front.web.ts
+++ b/dotcom-rendering/src/server/handler.front.web.ts
@@ -1,5 +1,5 @@
 import type { RequestHandler } from 'express';
-import { pickBrandingForEdition } from '../lib/branding';
+import { decideTagPageBranding, pickBrandingForEdition } from '../lib/branding';
 import { decideTrail } from '../lib/decideTrail';
 import { enhanceCards } from '../model/enhanceCards';
 import { enhanceCollections } from '../model/enhanceCollections';
@@ -74,6 +74,12 @@ const enhanceTagPage = (body: unknown): DCRTagPageType => {
 		speed === 'slow' || data.forceDay,
 	);
 
+	const branding = data.commercialProperties[data.editionId].branding;
+
+	const tagPageBranding = decideTagPageBranding({
+		branding,
+	});
+
 	return {
 		...data,
 		webTitle: tagPageWebTitle(data),
@@ -98,6 +104,7 @@ const enhanceTagPage = (body: unknown): DCRTagPageType => {
 				data.tags.tags[0]?.properties.description,
 			image: data.tags.tags[0]?.properties.bylineImageUrl,
 		},
+		branding: tagPageBranding,
 	};
 };
 

--- a/dotcom-rendering/src/server/handler.front.web.ts
+++ b/dotcom-rendering/src/server/handler.front.web.ts
@@ -76,9 +76,11 @@ const enhanceTagPage = (body: unknown): DCRTagPageType => {
 
 	const branding = data.commercialProperties[data.editionId].branding;
 
-	const tagPageBranding = decideTagPageBranding({
-		branding,
-	});
+	const tagPageBranding = branding
+		? decideTagPageBranding({
+				branding,
+		  })
+		: undefined;
 
 	return {
 		...data,

--- a/dotcom-rendering/src/types/tagPage.ts
+++ b/dotcom-rendering/src/types/tagPage.ts
@@ -1,5 +1,7 @@
 import type { EditionId } from '../lib/edition';
 import type { Tuple } from '../lib/tuple';
+import type { CollectionBranding } from './branding';
+import type { CommercialProperties } from './commercial';
 import type { FooterType } from './footer';
 import type { DCRFrontCard, FEFrontCard, FEFrontConfigType } from './front';
 import type { FETagType } from './tag';
@@ -17,7 +19,7 @@ export interface FETagPageType {
 	webTitle: string;
 	webURL: string;
 	config: FEFrontConfigType;
-	commercialProperties: Record<string, unknown>;
+	commercialProperties: CommercialProperties;
 	pageFooter: FooterType;
 	isAdFreeUser: boolean;
 	forceDay: boolean;
@@ -62,7 +64,7 @@ export interface DCRTagPageType {
 	webTitle: string;
 	webURL: string;
 	config: FEFrontConfigType;
-	commercialProperties: Record<string, unknown>;
+	commercialProperties: CommercialProperties;
 	pageFooter: FooterType;
 	isAdFreeUser: boolean;
 	trendingTopics?: FETagType[];
@@ -73,6 +75,7 @@ export interface DCRTagPageType {
 		description?: string;
 		image?: string;
 	};
+	branding: CollectionBranding | undefined;
 }
 
 export interface DCRFrontPagination {


### PR DESCRIPTION
## What does this change?
Adds badges to tag pages where branding applies.
## Why?
Sometimes tag pages are sponsored or paid for by a third party and will have branding. When this is available, we want to display a badge on the page. This is inline with exisiting behaviour on Frontend.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/20416599/20e2ee9d-b7ea-465b-8e1c-0c6d06910633
[after]: https://github.com/guardian/dotcom-rendering/assets/20416599/24fce86b-5da3-4d84-9ba5-43d13a3eefe3

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
