### PR TITLE
Increase number of `facia-rendering` instances

### DIFF
--- a/dotcom-rendering/cdk/bin/cdk.ts
+++ b/dotcom-rendering/cdk/bin/cdk.ts
@@ -42,7 +42,7 @@ new RenderingCDKStack(cdkApp, 'ArticleRendering-PROD', {
 	domainName: 'article-rendering.guardianapis.com',
 	scaling: {
 		minimumInstances: 12,
-		maximumInstances: 120,
+		maximumInstances: 48,
 		policy: {
 			scalingStepsOut: [
 				// No scaling up effect when latency is lower than 0.2s
@@ -76,8 +76,8 @@ new RenderingCDKStack(cdkApp, 'FaciaRendering-PROD', {
 	stage: 'PROD',
 	domainName: 'facia-rendering.guardianapis.com',
 	scaling: {
-		minimumInstances: 6,
-		maximumInstances: 24,
+		minimumInstances: 12,
+		maximumInstances: 48,
 		policy: {
 			scalingStepsOut: [
 				// No scaling up effect when latency is lower than 0.4s


### PR DESCRIPTION
## What does this change?

Doubles the number of `facia-rendering` instances

## Why?

We're seeing lots of timeout errors on this app so experimenting with increasing instances before increasing the instance size any further.

See https://github.com/guardian/dotcom-rendering/pull/10641 for previous instance size update