### PR TITLE
Update newsletters documentation

### DIFF
--- a/dotcom-rendering/docs/email-newsletters-page.md
+++ b/dotcom-rendering/docs/email-newsletters-page.md
@@ -4,7 +4,7 @@
 
 The [editorial newsletters page](https://www.theguardian.com/email-newsletters) is a dedicated page for displaying the editorial newsletters that readers can subscribe to a presenting a UI to enter their email addresses and sign up.
 
-It is served using a dedicated route handler (dotcom-rendering/src/server/index.allEditorialNewslettersPage.web.ts) and layout, but follows broadly the same pattern as the article and fronts pages, IE:
+It is served using a dedicated route handler (dotcom-rendering/src/server/handler.allEditorialNewslettersPage.web.ts) and layout, but follows broadly the same pattern as the article and fronts pages, IE:
 
 -   frontend posts a JSON body to the route for the page (https://www.theguardian.com/email-newsletters.json will output the page model)
 -   the JSON is validated against the schema for the page model
@@ -19,3 +19,7 @@ In effect, to add a new newsletter to the page, or change the ordering, update t
 dotcom-rendering/src/model/newsletter-grouping.ts
 
 The file allows for alternative arrangements of newsletters based on the `EditionId`. The property used in the arrays of newsletters is the `Newsletter.identityName`.
+
+To find the correct position of the newsletter check this [spreadsheet](https://docs.google.com/spreadsheets/d/1Pfdow0Yj8OzkrnIWqIC-oSzVhwtwwDBdLmFx5hY-Gt4/edit#gid=2084088730)
+
+To find the `identityName` of a newsletter or whether it is launched or draft check the [newsletters tool](https://newsletters-tool.gutools.co.uk/)

--- a/dotcom-rendering/docs/email-newsletters-page.md
+++ b/dotcom-rendering/docs/email-newsletters-page.md
@@ -4,11 +4,11 @@
 
 The [editorial newsletters page](https://www.theguardian.com/email-newsletters) is a dedicated page for displaying the editorial newsletters that readers can subscribe to a presenting a UI to enter their email addresses and sign up.
 
-It is served using a dedicated route handler (dotcom-rendering/src/server/handler.allEditorialNewslettersPage.web.ts) and layout, but follows broadly the same pattern as the article and fronts pages, IE:
+It is served using a dedicated route handler ([dotcom-rendering/src/server/handler.allEditorialNewslettersPage.web.ts](https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/src/server/handler.allEditorialNewslettersPage.web.ts)) and layout, but follows broadly the same pattern as the article and fronts pages, IE:
 
 -   frontend posts a JSON body to the route for the page (https://www.theguardian.com/email-newsletters.json will output the page model)
 -   the JSON is validated against the schema for the page model
--   the page model is "enhanced" (se dotcom-rendering/src/model/enhance-newsletters-page.ts)
+-   the page model is "enhanced" ([see dotcom-rendering/src/model/enhance-newsletters-page.ts](https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/src/model/enhance-newsletters-page.ts))
 -   the enhanced page model is passed to a render function to produece the HTML to return to frontend
 
 ## Arranging the Newsletters


### PR DESCRIPTION
Closes #10622 

## What does this change?
Updates newsletters documentation

## Why?
To be up-to-date

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
