### PR TITLE
Hook `onRecommend` to Bridget

### DIFF
--- a/dotcom-rendering/src/components/DiscussionApps.importable.tsx
+++ b/dotcom-rendering/src/components/DiscussionApps.importable.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { getdiscussionClient } from '../lib/bridgetApi';
 import type { Reader, UserProfile } from '../lib/discussion';
 import type { CommentResponse } from '../lib/discussionApi';
 import { reportAbuse as reportAbuseWeb } from '../lib/discussionApi';
@@ -17,9 +18,8 @@ const onReply = async (): Promise<CommentResponse> => {
 	return { kind: 'error', error: 'ApiError' };
 };
 
-const onRecommend = async (): Promise<boolean> => {
-	console.log('onRecommend');
-	return false;
+const onRecommend = async (commentId: number): Promise<boolean> => {
+	return getdiscussionClient().recommend(commentId);
 };
 const addUsername = async (): Promise<Result<string, true>> => {
 	console.log('addUsername');

--- a/dotcom-rendering/src/lib/bridgetApi.ts
+++ b/dotcom-rendering/src/lib/bridgetApi.ts
@@ -1,6 +1,7 @@
 import * as Acquisitions from '@guardian/bridget/Acquisitions';
 import * as Analytics from '@guardian/bridget/Analytics';
 import * as Commercial from '@guardian/bridget/Commercial';
+import * as Discussion from '@guardian/bridget/Discussion';
 import * as Environment from '@guardian/bridget/Environment';
 import * as Gallery from '@guardian/bridget/Gallery';
 import * as Metrics from '@guardian/bridget/Metrics';
@@ -150,4 +151,16 @@ export const getNewslettersClient = (): Newsletters.Client<void> => {
 		);
 	}
 	return newslettersClient;
+};
+
+let discussionClient: Discussion.Client<void> | undefined = undefined;
+export const getdiscussionClient = (): Discussion.Client<void> => {
+	if (!discussionClient) {
+		discussionClient = createAppClient<Discussion.Client<void>>(
+			Discussion.Client,
+			'buffered',
+			'compact',
+		);
+	}
+	return discussionClient;
 };


### PR DESCRIPTION
## What does this change?

Actually use Bridget for `onRecommend`

## Why?

Part of #10618 and #10544 

Depends on https://github.com/guardian/android-news-app/pull/10044

## Screenshots

<img width="363" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/76776/57f9810b-7ead-4d7e-beb7-fb677aa2939b">