### PR TITLE
Sharebutton sync svg hover transition

### DIFF
--- a/dotcom-rendering/src/components/ShareButton.importable.tsx
+++ b/dotcom-rendering/src/components/ShareButton.importable.tsx
@@ -47,6 +47,7 @@ const buttonStyles = css`
 	color: ${themePalette('--share-button')};
 	svg {
 		fill: ${themePalette('--share-button')};
+		transition: inherit;
 	}
 	:hover {
 		background-color: ${themePalette('--share-button')};


### PR DESCRIPTION
## What does this change?
This syncs the svg hover transition with the button text.
## Why?

## Screenshots



before:  

https://github.com/guardian/dotcom-rendering/assets/110032454/45ee9f74-bd2e-4f75-9190-eee641c1ac7b


after: 

https://github.com/guardian/dotcom-rendering/assets/110032454/c51de155-fa21-4145-9502-e9f2673b57d6


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
