### PR TITLE
Fade `ShareButton` in smoothly

### DIFF
--- a/dotcom-rendering/src/components/ShareButton.importable.tsx
+++ b/dotcom-rendering/src/components/ShareButton.importable.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/react';
+import { css, keyframes } from '@emotion/react';
 import { ArticleDesign } from '@guardian/libs';
 import { palette, until } from '@guardian/source-foundations';
 import type { Size } from '@guardian/source-react-components';
@@ -57,6 +57,13 @@ const buttonStyles = css`
 			fill: ${themePalette('--share-button-hover')};
 		}
 	}
+
+	animation: ${keyframes`
+			0% { opacity: 0; }
+			100% { opacity: 1; }
+		`} 240ms ease-out backwards;
+	/** It is unlikely a user will want to share quicker than this… */
+	animation-delay: 1.2s;
 `;
 
 const nativeShare = (sizeXSmall: boolean) => css`


### PR DESCRIPTION
## What does this change?

Adds a fade in animation for the `ShareButton` with a 1.2s delay before initialisation.

## Why?

Prevents a flash of content due to JS initialisation and hydration of the button and share capabilities.

The delay value of 1.2s has been chosen as the threshold below which users are likely to be compelled to share an article. We hope that by that point most users will have hydrated the button.

## Screen captures

https://github.com/guardian/dotcom-rendering/assets/76776/e0655023-d18f-4d32-aba8-8b1613b88fb2

https://github.com/guardian/dotcom-rendering/assets/76776/0a9fb18d-4789-4060-907f-86374961e80d
