### PR TITLE
Increase number of instances for `article-rendering` app

### DIFF
--- a/dotcom-rendering/cdk/bin/cdk.ts
+++ b/dotcom-rendering/cdk/bin/cdk.ts
@@ -41,8 +41,8 @@ new RenderingCDKStack(cdkApp, 'ArticleRendering-PROD', {
 	stage: 'PROD',
 	domainName: 'article-rendering.guardianapis.com',
 	scaling: {
-		minimumInstances: 12,
-		maximumInstances: 48,
+		minimumInstances: 15,
+		maximumInstances: 60,
 		policy: {
 			scalingStepsOut: [
 				// No scaling up effect when latency is lower than 0.2s


### PR DESCRIPTION
## What does this change?

Increases the number of instances for `article-rendering` from 12 to 15 after seeing an increase in latency and excessive scaling events for 12 instances. Also increases the maximum number of instances to 60.

Previous relevant changes: 
- https://github.com/guardian/dotcom-rendering/pull/10481
- https://github.com/guardian/dotcom-rendering/pull/10517

## Why?

Seeing increased latency and errors on the article-rendering app in production since the change to reduce to 12 instances


#10517 was merged on 8th Feb at 6pm. The screenshot of the `TargetResponseTime` graph below shows that the average latency becomes slightly more variable after this time:

<img width="1101" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/43961396/4b7a0cd2-9c93-4fad-baf5-e97d4be7a759">
