### PR TITLE
Deeply Read - Explainer Link

### DIFF
--- a/dotcom-rendering/src/components/MostPopularFooterGrid.tsx
+++ b/dotcom-rendering/src/components/MostPopularFooterGrid.tsx
@@ -6,9 +6,9 @@ import {
 	textSans,
 	until,
 } from '@guardian/source-foundations';
+import { Link } from '@guardian/source-react-components';
 import type { TrailTabType, TrailType } from '../types/trails';
 import { MostViewedFooterItem } from './MostViewedFooterItem';
-import { Link } from '@guardian/source-react-components';
 
 const gridContainerStyle = css`
 	display: grid;

--- a/dotcom-rendering/src/components/MostPopularFooterGrid.tsx
+++ b/dotcom-rendering/src/components/MostPopularFooterGrid.tsx
@@ -8,6 +8,7 @@ import {
 } from '@guardian/source-foundations';
 import type { TrailTabType, TrailType } from '../types/trails';
 import { MostViewedFooterItem } from './MostViewedFooterItem';
+import { Link } from '@guardian/source-react-components';
 
 const gridContainerStyle = css`
 	display: grid;
@@ -176,7 +177,14 @@ export const MostPopularFooterGrid = ({
 				>
 					<h3 css={titleStyle}>{deeplyRead.heading}</h3>
 					<div css={descriptionStyle}>
-						What readers are spending time with
+						What readers are spending time with (
+						<Link
+							css={descriptionStyle}
+							href="https://www.theguardian.com/info/2024/feb/15/what-is-the-deeply-read-list"
+						>
+							Learn more
+						</Link>
+						)
 					</div>
 				</div>
 				<ol css={displayContent}>


### PR DESCRIPTION
## What does this change?

Adds a "Learn more" linking to a Guardian article explaining what Deeply Read means 

## Why?

Editorial request to make the deeply read concept clearer to readers 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/1229808/e4d1c5c1-9f0e-4f0d-bdde-f5c0b8a4bcc7
[after]: https://github.com/guardian/dotcom-rendering/assets/1229808/ca684c62-0f7e-4fe5-a30f-01dd85cd1286

Fixes https://github.com/guardian/dotcom-rendering/issues/10348