### PR TITLE
Revert "Show ads on mobile discussion"

### DIFF
--- a/dotcom-rendering/src/components/Discussion.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion.stories.tsx
@@ -44,7 +44,6 @@ export const Basic: StoryObj = ({ format }: StoryProps) => {
 				discussionD2Uid="zHoBy6HNKsk"
 				discussionApiClientHeader="nextgen"
 				enableDiscussionSwitch={true}
-				enableMobileDiscussionAdsSwitch={true}
 				isAdFreeUser={false}
 				shouldHideAds={false}
 				idApiUrl="https://idapi.theguardian.com"
@@ -84,7 +83,6 @@ export const Overrides: StoryObj = ({ format }: StoryProps) => {
 				discussionD2Uid="zHoBy6HNKsk"
 				discussionApiClientHeader="nextgen"
 				enableDiscussionSwitch={true}
-				enableMobileDiscussionAdsSwitch={true}
 				isAdFreeUser={false}
 				shouldHideAds={false}
 				idApiUrl="https://idapi.theguardian.com"

--- a/dotcom-rendering/src/components/Discussion.tsx
+++ b/dotcom-rendering/src/components/Discussion.tsx
@@ -31,7 +31,6 @@ export type Props = {
 	discussionD2Uid: string;
 	discussionApiClientHeader: string;
 	enableDiscussionSwitch: boolean;
-	enableMobileDiscussionAdsSwitch: boolean;
 	user?: SignedInUser;
 	idApiUrl: string;
 	reportAbuseUnauthenticated: ReturnType<typeof reportAbuse>;
@@ -350,7 +349,6 @@ export const Discussion = ({
 	discussionD2Uid,
 	discussionApiClientHeader,
 	enableDiscussionSwitch,
-	enableMobileDiscussionAdsSwitch,
 	user,
 	idApiUrl,
 	reportAbuseUnauthenticated,
@@ -526,9 +524,6 @@ export const Discussion = ({
 						user !== undefined
 							? user.reportAbuse
 							: reportAbuseUnauthenticated
-					}
-					enableMobileDiscussionAdsSwitch={
-						enableMobileDiscussionAdsSwitch
 					}
 				/>
 				{!isExpanded && (

--- a/dotcom-rendering/src/components/Discussion/Comments.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comments.stories.tsx
@@ -92,7 +92,6 @@ export const LoggedOutHiddenPicks = () => (
 			replyForm={defaultCommentForm}
 			bottomForm={defaultCommentForm}
 			reportAbuse={() => Promise.resolve(ok(true))}
-			enableMobileDiscussionAdsSwitch={true}
 		/>
 	</div>
 );
@@ -137,7 +136,6 @@ export const InitialPage = () => (
 			replyForm={defaultCommentForm}
 			bottomForm={defaultCommentForm}
 			reportAbuse={() => Promise.resolve(ok(true))}
-			enableMobileDiscussionAdsSwitch={true}
 		/>
 	</div>
 );
@@ -184,7 +182,6 @@ export const LoggedInHiddenNoPicks = () => {
 				replyForm={{ ...defaultCommentForm }}
 				bottomForm={defaultCommentForm}
 				reportAbuse={() => Promise.resolve(ok(true))}
-				enableMobileDiscussionAdsSwitch={true}
 			/>
 		</div>
 	);
@@ -226,7 +223,6 @@ export const LoggedIn = () => {
 				replyForm={defaultCommentForm}
 				bottomForm={defaultCommentForm}
 				reportAbuse={() => Promise.resolve(ok(true))}
-				enableMobileDiscussionAdsSwitch={true}
 			/>
 		</div>
 	);
@@ -267,7 +263,6 @@ export const LoggedInShortDiscussion = () => {
 				replyForm={defaultCommentForm}
 				bottomForm={defaultCommentForm}
 				reportAbuse={() => Promise.resolve(ok(true))}
-				enableMobileDiscussionAdsSwitch={true}
 			/>
 		</div>
 	);
@@ -305,7 +300,6 @@ export const LoggedOutHiddenNoPicks = () => (
 			replyForm={defaultCommentForm}
 			bottomForm={defaultCommentForm}
 			reportAbuse={() => Promise.resolve(ok(true))}
-			enableMobileDiscussionAdsSwitch={true}
 		/>
 	</div>
 );
@@ -352,7 +346,6 @@ export const Closed = () => (
 			replyForm={defaultCommentForm}
 			bottomForm={defaultCommentForm}
 			reportAbuse={() => Promise.resolve(ok(true))}
-			enableMobileDiscussionAdsSwitch={true}
 		/>
 	</div>
 );
@@ -395,7 +388,6 @@ export const NoComments = () => (
 			replyForm={defaultCommentForm}
 			bottomForm={defaultCommentForm}
 			reportAbuse={() => Promise.resolve(ok(true))}
-			enableMobileDiscussionAdsSwitch={true}
 		/>
 	</div>
 );
@@ -440,7 +432,6 @@ export const LegacyDiscussion = () => (
 			replyForm={defaultCommentForm}
 			bottomForm={defaultCommentForm}
 			reportAbuse={() => Promise.resolve(ok(true))}
-			enableMobileDiscussionAdsSwitch={true}
 		/>
 	</div>
 );

--- a/dotcom-rendering/src/components/Discussion/Comments.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comments.tsx
@@ -13,8 +13,6 @@ import type {
 import type { preview, reportAbuse } from '../../lib/discussionApi';
 import { getPicks, initialiseApi } from '../../lib/discussionApi';
 import { palette as schemedPalette } from '../../palette';
-import { labelStyles } from '../AdSlot.web';
-import { useConfig } from '../ConfigContext';
 import { useDispatch } from '../DispatchContext';
 import { CommentContainer } from './CommentContainer';
 import { CommentForm } from './CommentForm';
@@ -46,7 +44,6 @@ type Props = {
 	replyForm: CommentFormProps;
 	bottomForm: CommentFormProps;
 	reportAbuse: ReturnType<typeof reportAbuse>;
-	enableMobileDiscussionAdsSwitch: boolean;
 };
 
 const footerStyles = css`
@@ -122,15 +119,12 @@ export const Comments = ({
 	replyForm,
 	bottomForm,
 	reportAbuse,
-	enableMobileDiscussionAdsSwitch,
 }: Props) => {
 	const [picks, setPicks] = useState<Array<CommentType | ReplyType>>([]);
 	const [commentBeingRepliedTo, setCommentBeingRepliedTo] = useState<
 		CommentType | ReplyType
 	>();
 	const [mutes, setMutes] = useState<string[]>(readMutes());
-	const { renderingTarget } = useConfig();
-	const isWeb = renderingTarget === 'Web';
 
 	const dispatch = useDispatch();
 
@@ -221,15 +215,6 @@ export const Comments = ({
 	};
 
 	useEffect(() => {
-		if (isWeb && expanded && !loading && enableMobileDiscussionAdsSwitch) {
-			const event = new CustomEvent('comments-loaded');
-			document.dispatchEvent(event);
-		}
-	}, [isWeb, expanded, loading, enableMobileDiscussionAdsSwitch]);
-
-	const commentsStateChangeEvent = new CustomEvent('comments-state-change');
-
-	useEffect(() => {
 		void getPicks(shortUrl).then((result) => {
 			if (result.kind === 'error') {
 				console.error(result.error);
@@ -272,10 +257,6 @@ export const Comments = ({
 		} else {
 			handleFilterChange(newFilterObject);
 		}
-
-		isWeb &&
-			enableMobileDiscussionAdsSwitch &&
-			document.dispatchEvent(commentsStateChangeEvent);
 	};
 
 	useEffect(() => {
@@ -307,9 +288,6 @@ export const Comments = ({
 
 	const onPageChange = (pageNumber: number) => {
 		setPage(pageNumber);
-		isWeb &&
-			enableMobileDiscussionAdsSwitch &&
-			document.dispatchEvent(commentsStateChangeEvent);
 	};
 
 	initialiseApi({ additionalHeaders, baseUrl, apiKey, idApiUrl });
@@ -438,10 +416,7 @@ export const Comments = ({
 			) : !comments.length ? (
 				<NoComments />
 			) : (
-				<ul
-					css={[commentContainerStyles, labelStyles]}
-					data-commercial-id="comments-column"
-				>
+				<ul css={commentContainerStyles}>
 					{comments.map((comment) => (
 						<li key={comment.id}>
 							<CommentContainer

--- a/dotcom-rendering/src/components/Discussion/Discussion.test.tsx
+++ b/dotcom-rendering/src/components/Discussion/Discussion.test.tsx
@@ -6,7 +6,6 @@ import {
 } from '@testing-library/react';
 import { mockRESTCalls } from '../../lib/mockRESTCalls';
 import { ok } from '../../lib/result';
-import { ConfigProvider } from '../ConfigContext';
 import { Discussion } from '../Discussion';
 
 mockRESTCalls();
@@ -14,22 +13,16 @@ mockRESTCalls();
 describe('App', () => {
 	it('should not render the comment form if user is logged out', async () => {
 		render(
-			<ConfigProvider
-				value={{ renderingTarget: 'Web', darkModeAvailable: false }}
-			>
-				<Discussion
-					user={undefined}
-					discussionApiUrl="https://discussion.theguardian.com/discussion-api"
-					shortUrlId="p/39f5z"
-					discussionD2Uid="testD2Header"
-					discussionApiClientHeader="testClientHeader"
-					enableDiscussionSwitch={true}
-					enableMobileDiscussionAdsSwitch={true}
-					idApiUrl="https://idapi.theguardian.com"
-					reportAbuseUnauthenticated={() => Promise.resolve(ok(true))}
-				/>
-				,
-			</ConfigProvider>,
+			<Discussion
+				user={undefined}
+				discussionApiUrl="https://discussion.theguardian.com/discussion-api"
+				shortUrlId="p/39f5z"
+				discussionD2Uid="testD2Header"
+				discussionApiClientHeader="testClientHeader"
+				enableDiscussionSwitch={true}
+				idApiUrl="https://idapi.theguardian.com"
+				reportAbuseUnauthenticated={() => Promise.resolve(ok(true))}
+			/>,
 		);
 
 		await waitForElementToBeRemoved(() =>

--- a/dotcom-rendering/src/components/DiscussionLayout.tsx
+++ b/dotcom-rendering/src/components/DiscussionLayout.tsx
@@ -19,7 +19,6 @@ type Props = {
 	discussionD2Uid: string;
 	discussionApiClientHeader: string;
 	enableDiscussionSwitch: boolean;
-	enableMobileDiscussionAdsSwitch: boolean;
 	isAdFreeUser: boolean;
 	shouldHideAds: boolean;
 	idApiUrl: string;
@@ -35,7 +34,6 @@ const DiscussionIsland = ({
 	discussionD2Uid: string;
 	discussionApiClientHeader: string;
 	enableDiscussionSwitch: boolean;
-	enableMobileDiscussionAdsSwitch: boolean;
 	idApiUrl: string;
 }) => {
 	switch (renderingTarget) {
@@ -61,7 +59,6 @@ export const DiscussionLayout = ({
 	discussionD2Uid,
 	discussionApiClientHeader,
 	enableDiscussionSwitch,
-	enableMobileDiscussionAdsSwitch,
 	isAdFreeUser,
 	shouldHideAds,
 	idApiUrl,
@@ -111,9 +108,6 @@ export const DiscussionLayout = ({
 								discussionApiClientHeader
 							}
 							enableDiscussionSwitch={enableDiscussionSwitch}
-							enableMobileDiscussionAdsSwitch={
-								enableMobileDiscussionAdsSwitch
-							}
 							idApiUrl={idApiUrl}
 							renderingTarget={renderingTarget}
 						/>

--- a/dotcom-rendering/src/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/layouts/CommentLayout.tsx
@@ -866,9 +866,6 @@ export const CommentLayout = (props: WebProps | AppsProps) => {
 							enableDiscussionSwitch={
 								!!article.config.switches.enableDiscussionSwitch
 							}
-							enableMobileDiscussionAdsSwitch={
-								!!article.config.switches.mobileDiscussionAds
-							}
 							isAdFreeUser={article.isAdFreeUser}
 							shouldHideAds={article.shouldHideAds}
 							idApiUrl={article.config.idApiUrl}

--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -891,9 +891,6 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 							enableDiscussionSwitch={
 								!!article.config.switches.enableDiscussionSwitch
 							}
-							enableMobileDiscussionAdsSwitch={
-								!!article.config.switches.mobileDiscussionAds
-							}
 							isAdFreeUser={article.isAdFreeUser}
 							shouldHideAds={article.shouldHideAds}
 							idApiUrl={article.config.idApiUrl}

--- a/dotcom-rendering/src/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/InteractiveLayout.tsx
@@ -806,9 +806,6 @@ export const InteractiveLayout = (props: WebProps | AppsProps) => {
 							enableDiscussionSwitch={
 								!!article.config.switches.enableDiscussionSwitch
 							}
-							enableMobileDiscussionAdsSwitch={
-								!!article.config.switches.mobileDiscussionAds
-							}
 							isAdFreeUser={article.isAdFreeUser}
 							shouldHideAds={article.shouldHideAds}
 							idApiUrl={article.config.idApiUrl}

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -1294,10 +1294,6 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 									!!article.config.switches
 										.enableDiscussionSwitch
 								}
-								enableMobileDiscussionAdsSwitch={
-									!!article.config.switches
-										.mobileDiscussionAds
-								}
 								isAdFreeUser={article.isAdFreeUser}
 								shouldHideAds={article.shouldHideAds}
 								idApiUrl={article.config.idApiUrl}

--- a/dotcom-rendering/src/layouts/PictureLayout.tsx
+++ b/dotcom-rendering/src/layouts/PictureLayout.tsx
@@ -759,9 +759,6 @@ export const PictureLayout = (props: WebProps | AppsProps) => {
 							enableDiscussionSwitch={
 								!!article.config.switches.enableDiscussionSwitch
 							}
-							enableMobileDiscussionAdsSwitch={
-								!!article.config.switches.mobileDiscussionAds
-							}
 							isAdFreeUser={article.isAdFreeUser}
 							shouldHideAds={article.shouldHideAds}
 							idApiUrl={article.config.idApiUrl}

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -865,9 +865,6 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 							enableDiscussionSwitch={
 								!!article.config.switches.enableDiscussionSwitch
 							}
-							enableMobileDiscussionAdsSwitch={
-								!!article.config.switches.mobileDiscussionAds
-							}
 							isAdFreeUser={article.isAdFreeUser}
 							shouldHideAds={article.shouldHideAds}
 							idApiUrl={article.config.idApiUrl}

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -957,9 +957,6 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 							enableDiscussionSwitch={
 								!!article.config.switches.enableDiscussionSwitch
 							}
-							enableMobileDiscussionAdsSwitch={
-								!!article.config.switches.mobileDiscussionAds
-							}
 							isAdFreeUser={article.isAdFreeUser}
 							shouldHideAds={article.shouldHideAds}
 							idApiUrl={article.config.idApiUrl}


### PR DESCRIPTION
Reverts guardian/dotcom-rendering#10448 due to errors in PROD

Error message is ```CustomEvent is not defined```

See logs mentioning `CustomEvent`: https://logs.gutools.co.uk/s/dotcom/goto/98b280e0-d178-11ee-9f2c-97fe2aa7897d