### PR TITLE
Fix text colour copied button on hover

### DIFF
--- a/dotcom-rendering/src/components/ShareButton.importable.tsx
+++ b/dotcom-rendering/src/components/ShareButton.importable.tsx
@@ -37,7 +37,9 @@ const sharedButtonStyles = (sizeXSmall: boolean, isCopied: boolean) => css`
 const copiedButtonStyles = (sizeXSmall: boolean) => css`
 	color: ${themePalette('--share-button-copied')};
 	padding: ${sizeXSmall ? '0 4px' : '0 10px'};
-
+	:hover {
+		color: inherit;
+	}
 	svg {
 		fill: ${palette.success[400]};
 	}


### PR DESCRIPTION
## What does this change?
Fixes text colour for copied link button on hover.
## Why?
This is showing incorrectly on gallery pages.
## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/110032454/1c862db7-b471-46f8-a927-26926d149356
[after]: https://github.com/guardian/dotcom-rendering/assets/110032454/85436f65-ab0f-4e9b-8d66-0466b74d2aae

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
