### PR TITLE
Exclude Storybook From Webpack Dependency Group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -53,6 +53,8 @@ updates:
         patterns:
           - '*webpack*'
           - '*-loader'
+        exclude-patterns:
+          - '@storybook/*'
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:


### PR DESCRIPTION
Dependabot is not including the `react-webpack5` dependency in the storybook group. It is instead including it in the `webpack` dependency group.

Dependabot is meant to include a dependency in the first group it matches with [^1], and storybook is higher in the list. However, it may be that if a PR for a group lower down in the list is already open, Dependabot doesn't go back and change that to remove the dependency, it just excludes it from the new PR [^2].

This change is an experiment to see if excluding storybook dependencies from the webpack group fixes the problem.

[^1]: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups
[^2]: https://github.com/dependabot/dependabot-core/pull/8106
