### PR TITLE
Show ads on mobile discussion

### DIFF
--- a/dotcom-rendering/src/components/Discussion.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion.stories.tsx
@@ -44,6 +44,7 @@ export const Basic: StoryObj = ({ format }: StoryProps) => {
 				discussionD2Uid="zHoBy6HNKsk"
 				discussionApiClientHeader="nextgen"
 				enableDiscussionSwitch={true}
+				enableMobileDiscussionAdsSwitch={true}
 				isAdFreeUser={false}
 				shouldHideAds={false}
 				idApiUrl="https://idapi.theguardian.com"
@@ -83,6 +84,7 @@ export const Overrides: StoryObj = ({ format }: StoryProps) => {
 				discussionD2Uid="zHoBy6HNKsk"
 				discussionApiClientHeader="nextgen"
 				enableDiscussionSwitch={true}
+				enableMobileDiscussionAdsSwitch={true}
 				isAdFreeUser={false}
 				shouldHideAds={false}
 				idApiUrl="https://idapi.theguardian.com"

--- a/dotcom-rendering/src/components/Discussion.tsx
+++ b/dotcom-rendering/src/components/Discussion.tsx
@@ -31,6 +31,7 @@ export type Props = {
 	discussionD2Uid: string;
 	discussionApiClientHeader: string;
 	enableDiscussionSwitch: boolean;
+	enableMobileDiscussionAdsSwitch: boolean;
 	user?: SignedInUser;
 	idApiUrl: string;
 	reportAbuseUnauthenticated: ReturnType<typeof reportAbuse>;
@@ -349,6 +350,7 @@ export const Discussion = ({
 	discussionD2Uid,
 	discussionApiClientHeader,
 	enableDiscussionSwitch,
+	enableMobileDiscussionAdsSwitch,
 	user,
 	idApiUrl,
 	reportAbuseUnauthenticated,
@@ -524,6 +526,9 @@ export const Discussion = ({
 						user !== undefined
 							? user.reportAbuse
 							: reportAbuseUnauthenticated
+					}
+					enableMobileDiscussionAdsSwitch={
+						enableMobileDiscussionAdsSwitch
 					}
 				/>
 				{!isExpanded && (

--- a/dotcom-rendering/src/components/Discussion/Comments.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comments.stories.tsx
@@ -92,6 +92,7 @@ export const LoggedOutHiddenPicks = () => (
 			replyForm={defaultCommentForm}
 			bottomForm={defaultCommentForm}
 			reportAbuse={() => Promise.resolve(ok(true))}
+			enableMobileDiscussionAdsSwitch={true}
 		/>
 	</div>
 );
@@ -136,6 +137,7 @@ export const InitialPage = () => (
 			replyForm={defaultCommentForm}
 			bottomForm={defaultCommentForm}
 			reportAbuse={() => Promise.resolve(ok(true))}
+			enableMobileDiscussionAdsSwitch={true}
 		/>
 	</div>
 );
@@ -182,6 +184,7 @@ export const LoggedInHiddenNoPicks = () => {
 				replyForm={{ ...defaultCommentForm }}
 				bottomForm={defaultCommentForm}
 				reportAbuse={() => Promise.resolve(ok(true))}
+				enableMobileDiscussionAdsSwitch={true}
 			/>
 		</div>
 	);
@@ -223,6 +226,7 @@ export const LoggedIn = () => {
 				replyForm={defaultCommentForm}
 				bottomForm={defaultCommentForm}
 				reportAbuse={() => Promise.resolve(ok(true))}
+				enableMobileDiscussionAdsSwitch={true}
 			/>
 		</div>
 	);
@@ -263,6 +267,7 @@ export const LoggedInShortDiscussion = () => {
 				replyForm={defaultCommentForm}
 				bottomForm={defaultCommentForm}
 				reportAbuse={() => Promise.resolve(ok(true))}
+				enableMobileDiscussionAdsSwitch={true}
 			/>
 		</div>
 	);
@@ -300,6 +305,7 @@ export const LoggedOutHiddenNoPicks = () => (
 			replyForm={defaultCommentForm}
 			bottomForm={defaultCommentForm}
 			reportAbuse={() => Promise.resolve(ok(true))}
+			enableMobileDiscussionAdsSwitch={true}
 		/>
 	</div>
 );
@@ -346,6 +352,7 @@ export const Closed = () => (
 			replyForm={defaultCommentForm}
 			bottomForm={defaultCommentForm}
 			reportAbuse={() => Promise.resolve(ok(true))}
+			enableMobileDiscussionAdsSwitch={true}
 		/>
 	</div>
 );
@@ -388,6 +395,7 @@ export const NoComments = () => (
 			replyForm={defaultCommentForm}
 			bottomForm={defaultCommentForm}
 			reportAbuse={() => Promise.resolve(ok(true))}
+			enableMobileDiscussionAdsSwitch={true}
 		/>
 	</div>
 );
@@ -432,6 +440,7 @@ export const LegacyDiscussion = () => (
 			replyForm={defaultCommentForm}
 			bottomForm={defaultCommentForm}
 			reportAbuse={() => Promise.resolve(ok(true))}
+			enableMobileDiscussionAdsSwitch={true}
 		/>
 	</div>
 );

--- a/dotcom-rendering/src/components/Discussion/Comments.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comments.tsx
@@ -227,8 +227,6 @@ export const Comments = ({
 		}
 	}, [isWeb, expanded, loading, enableMobileDiscussionAdsSwitch]);
 
-	const commentsStateChangeEvent = new CustomEvent('comments-state-change');
-
 	useEffect(() => {
 		void getPicks(shortUrl).then((result) => {
 			if (result.kind === 'error') {
@@ -275,7 +273,7 @@ export const Comments = ({
 
 		isWeb &&
 			enableMobileDiscussionAdsSwitch &&
-			document.dispatchEvent(commentsStateChangeEvent);
+			document.dispatchEvent(new CustomEvent('comments-state-change'));
 	};
 
 	useEffect(() => {
@@ -309,7 +307,7 @@ export const Comments = ({
 		setPage(pageNumber);
 		isWeb &&
 			enableMobileDiscussionAdsSwitch &&
-			document.dispatchEvent(commentsStateChangeEvent);
+			document.dispatchEvent(new CustomEvent('comments-state-change'));
 	};
 
 	initialiseApi({ additionalHeaders, baseUrl, apiKey, idApiUrl });

--- a/dotcom-rendering/src/components/Discussion/Comments.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comments.tsx
@@ -99,11 +99,7 @@ const writeMutes = (mutes: string[]) => {
 	storage.local.set('gu.prefs.discussion.mutes', mutes);
 };
 
-/**
- * Dispatches a custom event which is handled by @guardian/commercial
- *
- * @see https://github.com/guardian/commercial/blob/9175e572a5a81e334208775c64b7b479dd544c6c/src/insert/comments-expanded-advert.ts#L197
- */
+/** Dispatches a custom event which is handled by @guardian/commercial */
 const dispatchCommentsStateChange = () =>
 	document.dispatchEvent(new CustomEvent('comments-state-change'));
 

--- a/dotcom-rendering/src/components/Discussion/Comments.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comments.tsx
@@ -99,6 +99,14 @@ const writeMutes = (mutes: string[]) => {
 	storage.local.set('gu.prefs.discussion.mutes', mutes);
 };
 
+/**
+ * Dispatches a custom event which is handled by @guardian/commercial
+ *
+ * @see https://github.com/guardian/commercial/blob/9175e572a5a81e334208775c64b7b479dd544c6c/src/insert/comments-expanded-advert.ts#L197
+ */
+const dispatchCommentsStateChange = () =>
+	document.dispatchEvent(new CustomEvent('comments-state-change'));
+
 export const Comments = ({
 	baseUrl,
 	shortUrl,
@@ -273,7 +281,7 @@ export const Comments = ({
 
 		isWeb &&
 			enableMobileDiscussionAdsSwitch &&
-			document.dispatchEvent(new CustomEvent('comments-state-change'));
+			dispatchCommentsStateChange();
 	};
 
 	useEffect(() => {
@@ -307,7 +315,7 @@ export const Comments = ({
 		setPage(pageNumber);
 		isWeb &&
 			enableMobileDiscussionAdsSwitch &&
-			document.dispatchEvent(new CustomEvent('comments-state-change'));
+			dispatchCommentsStateChange();
 	};
 
 	initialiseApi({ additionalHeaders, baseUrl, apiKey, idApiUrl });

--- a/dotcom-rendering/src/components/Discussion/Discussion.test.tsx
+++ b/dotcom-rendering/src/components/Discussion/Discussion.test.tsx
@@ -6,6 +6,7 @@ import {
 } from '@testing-library/react';
 import { mockRESTCalls } from '../../lib/mockRESTCalls';
 import { ok } from '../../lib/result';
+import { ConfigProvider } from '../ConfigContext';
 import { Discussion } from '../Discussion';
 
 mockRESTCalls();
@@ -13,16 +14,21 @@ mockRESTCalls();
 describe('App', () => {
 	it('should not render the comment form if user is logged out', async () => {
 		render(
-			<Discussion
-				user={undefined}
-				discussionApiUrl="https://discussion.theguardian.com/discussion-api"
-				shortUrlId="p/39f5z"
-				discussionD2Uid="testD2Header"
-				discussionApiClientHeader="testClientHeader"
-				enableDiscussionSwitch={true}
-				idApiUrl="https://idapi.theguardian.com"
-				reportAbuseUnauthenticated={() => Promise.resolve(ok(true))}
-			/>,
+			<ConfigProvider
+				value={{ renderingTarget: 'Web', darkModeAvailable: false }}
+			>
+				<Discussion
+					user={undefined}
+					discussionApiUrl="https://discussion.theguardian.com/discussion-api"
+					shortUrlId="p/39f5z"
+					discussionD2Uid="testD2Header"
+					discussionApiClientHeader="testClientHeader"
+					enableDiscussionSwitch={true}
+					enableMobileDiscussionAdsSwitch={true}
+					idApiUrl="https://idapi.theguardian.com"
+					reportAbuseUnauthenticated={() => Promise.resolve(ok(true))}
+				/>
+			</ConfigProvider>,
 		);
 
 		await waitForElementToBeRemoved(() =>

--- a/dotcom-rendering/src/components/DiscussionLayout.tsx
+++ b/dotcom-rendering/src/components/DiscussionLayout.tsx
@@ -19,6 +19,7 @@ type Props = {
 	discussionD2Uid: string;
 	discussionApiClientHeader: string;
 	enableDiscussionSwitch: boolean;
+	enableMobileDiscussionAdsSwitch: boolean;
 	isAdFreeUser: boolean;
 	shouldHideAds: boolean;
 	idApiUrl: string;
@@ -34,6 +35,7 @@ const DiscussionIsland = ({
 	discussionD2Uid: string;
 	discussionApiClientHeader: string;
 	enableDiscussionSwitch: boolean;
+	enableMobileDiscussionAdsSwitch: boolean;
 	idApiUrl: string;
 }) => {
 	switch (renderingTarget) {
@@ -59,6 +61,7 @@ export const DiscussionLayout = ({
 	discussionD2Uid,
 	discussionApiClientHeader,
 	enableDiscussionSwitch,
+	enableMobileDiscussionAdsSwitch,
 	isAdFreeUser,
 	shouldHideAds,
 	idApiUrl,
@@ -108,6 +111,9 @@ export const DiscussionLayout = ({
 								discussionApiClientHeader
 							}
 							enableDiscussionSwitch={enableDiscussionSwitch}
+							enableMobileDiscussionAdsSwitch={
+								enableMobileDiscussionAdsSwitch
+							}
 							idApiUrl={idApiUrl}
 							renderingTarget={renderingTarget}
 						/>

--- a/dotcom-rendering/src/components/Island.test.tsx
+++ b/dotcom-rendering/src/components/Island.test.tsx
@@ -140,6 +140,7 @@ describe('Island: server-side rendering', () => {
 						discussionD2Uid="testD2Header"
 						discussionApiClientHeader="testClientHeader"
 						enableDiscussionSwitch={true}
+						enableMobileDiscussionAdsSwitch={true}
 						idApiUrl="https://idapi.theguardian.com"
 						format={{
 							theme: Pillar.News,

--- a/dotcom-rendering/src/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/layouts/CommentLayout.tsx
@@ -866,6 +866,9 @@ export const CommentLayout = (props: WebProps | AppsProps) => {
 							enableDiscussionSwitch={
 								!!article.config.switches.enableDiscussionSwitch
 							}
+							enableMobileDiscussionAdsSwitch={
+								!!article.config.switches.mobileDiscussionAds
+							}
 							isAdFreeUser={article.isAdFreeUser}
 							shouldHideAds={article.shouldHideAds}
 							idApiUrl={article.config.idApiUrl}

--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -891,6 +891,9 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 							enableDiscussionSwitch={
 								!!article.config.switches.enableDiscussionSwitch
 							}
+							enableMobileDiscussionAdsSwitch={
+								!!article.config.switches.mobileDiscussionAds
+							}
 							isAdFreeUser={article.isAdFreeUser}
 							shouldHideAds={article.shouldHideAds}
 							idApiUrl={article.config.idApiUrl}

--- a/dotcom-rendering/src/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/InteractiveLayout.tsx
@@ -806,6 +806,9 @@ export const InteractiveLayout = (props: WebProps | AppsProps) => {
 							enableDiscussionSwitch={
 								!!article.config.switches.enableDiscussionSwitch
 							}
+							enableMobileDiscussionAdsSwitch={
+								!!article.config.switches.mobileDiscussionAds
+							}
 							isAdFreeUser={article.isAdFreeUser}
 							shouldHideAds={article.shouldHideAds}
 							idApiUrl={article.config.idApiUrl}

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -1294,6 +1294,10 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 									!!article.config.switches
 										.enableDiscussionSwitch
 								}
+								enableMobileDiscussionAdsSwitch={
+									!!article.config.switches
+										.mobileDiscussionAds
+								}
 								isAdFreeUser={article.isAdFreeUser}
 								shouldHideAds={article.shouldHideAds}
 								idApiUrl={article.config.idApiUrl}

--- a/dotcom-rendering/src/layouts/PictureLayout.tsx
+++ b/dotcom-rendering/src/layouts/PictureLayout.tsx
@@ -759,6 +759,9 @@ export const PictureLayout = (props: WebProps | AppsProps) => {
 							enableDiscussionSwitch={
 								!!article.config.switches.enableDiscussionSwitch
 							}
+							enableMobileDiscussionAdsSwitch={
+								!!article.config.switches.mobileDiscussionAds
+							}
 							isAdFreeUser={article.isAdFreeUser}
 							shouldHideAds={article.shouldHideAds}
 							idApiUrl={article.config.idApiUrl}

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -865,6 +865,9 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 							enableDiscussionSwitch={
 								!!article.config.switches.enableDiscussionSwitch
 							}
+							enableMobileDiscussionAdsSwitch={
+								!!article.config.switches.mobileDiscussionAds
+							}
 							isAdFreeUser={article.isAdFreeUser}
 							shouldHideAds={article.shouldHideAds}
 							idApiUrl={article.config.idApiUrl}

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -957,6 +957,9 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 							enableDiscussionSwitch={
 								!!article.config.switches.enableDiscussionSwitch
 							}
+							enableMobileDiscussionAdsSwitch={
+								!!article.config.switches.mobileDiscussionAds
+							}
 							isAdFreeUser={article.isAdFreeUser}
 							shouldHideAds={article.shouldHideAds}
 							idApiUrl={article.config.idApiUrl}


### PR DESCRIPTION
## What does this change?
Implements ads in discussion articles on mobile. See [the original PR](https://github.com/guardian/dotcom-rendering/pull/10448) for details about the change. Co-authored by @deedeeh.

## Why?
The original implementation of this feature had to be reverted as it was causing a rendering error in comments pages in app. This is because the node version on app (v18) does not support `CustomEvent` (requires v19), and there was a custom event definition that hadn't been wrapped in a check to ensure the rendering platform was web. In this PR we've ensured that any dispatch or definition of a custom event is wrapped in a rendering platform and switch check.

We have checked that this resolves the error by checking articles with comments locally when rendered using `AppsArticle`, and by checking articles with comments on CODE by appending `?dcr=apps`.