### PR TITLE
Update braze components dependency to v18.1.0

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -44,7 +44,7 @@
 		"@emotion/react": "11.11.1",
 		"@emotion/server": "11.11.0",
 		"@guardian/ab-core": "7.0.1",
-		"@guardian/braze-components": "18.0.0",
+		"@guardian/braze-components": "18.1.0",
 		"@guardian/bridget": "2.6.0",
 		"@guardian/browserslist-config": "6.1.0",
 		"@guardian/cdk": "50.13.0",

--- a/dotcom-rendering/src/components/StickyBottomBanner/BrazeBanner.stories.tsx
+++ b/dotcom-rendering/src/components/StickyBottomBanner/BrazeBanner.stories.tsx
@@ -18,9 +18,9 @@ export default {
 	title: 'Components/StickyBottomBanner/BrazeBanners',
 };
 
-// Braze Banner story
+// Braze StyleableBannerWithLink story
 // ---------------------------------------
-export const BrazeBannerComponent = (
+export const BrazeStyleableBannerWithLinkComponent = (
 	args: BrazeMessageProps & { componentName: string },
 ): ReactElement => {
 	const [BrazeMessage, setBrazeMessage] =
@@ -41,11 +41,125 @@ export const BrazeBannerComponent = (
 
 	if (BrazeMessage) {
 		const brazeMessageProps: BrazeMessageProps = {
+			body: args.body,
+			buttonText: args.buttonText,
+			buttonUrl: args.buttonUrl,
 			header: args.header,
+			highlight: args.highlight,
+			imageAltText: args.imageAltText,
+			imagePosition: args.imagePosition,
+			imageUrl: args.imageUrl,
+			ophanComponentId: args.ophanComponentId,
+			reminderOption: args.reminderOption,
+			reminderStage: args.reminderStage,
+			showPaymentIcons: args.showPaymentIcons,
+			showPrivacyText: args.showPrivacyText,
+			styleBackground: args.styleBackground,
+			styleBody: args.styleBody,
+			styleButton: args.styleButton,
+			styleButtonBackground: args.styleButtonBackground,
+			styleButtonHover: args.styleButtonHover,
+			styleClose: args.styleClose,
+			styleCloseBackground: args.styleCloseBackground,
+			styleCloseHover: args.styleCloseHover,
+			styleHeader: args.styleHeader,
+			styleHighlight: args.styleHighlight,
+			styleHighlightBackground: args.styleHighlightBackground,
+			styleReminderAnimation: args.styleReminderAnimation,
+			styleReminderButton: args.styleReminderButton,
+			styleReminderButtonBackground: args.styleReminderButtonBackground,
+			styleReminderButtonHover: args.styleReminderButtonHover,
+		};
+
+		return (
+			<BrazeMessage
+				componentName={args.componentName}
+				logButtonClickWithBraze={(internalButtonId) => {
+					console.log(
+						`Button with internal ID ${internalButtonId} clicked`,
+					);
+				}}
+				submitComponentEvent={(componentEvent) => {
+					console.log(
+						'submitComponentEvent called with: ',
+						componentEvent,
+					);
+				}}
+				brazeMessageProps={brazeMessageProps}
+				subscribeToNewsletter={subscribeToNewsletter}
+				fetchEmail={fetchEmail}
+			/>
+		);
+	}
+	return <div>Loading...</div>;
+};
+
+BrazeStyleableBannerWithLinkComponent.args = {
+	body: 'Thanks to your generous support in this extraordinary year, our open, independent journalism was read by millions. From the pandemic to our urgent coverage of the climate crisis, our reporting had a powerful impact.',
+	buttonText: 'Take a look back',
+	buttonUrl:
+		'https://www.theguardian.com/info/ng-interactive/2020/dec/21/the-guardian-in-2020?INTCMP=gdnwb_mrtn_banner_edtrl_MK_SU_WorkingReport2020Canvas',
+	componentName: 'StyleableBannerWithLink',
+	header: 'The Guardian’s impact in 2021',
+	highlight:
+		'Read our look-back to see how Guardian journalism made a difference.',
+	imageAltText: 'Accessible image description',
+	imagePosition: 'bottom',
+	imageUrl:
+		'https://i.guim.co.uk/img/media/35d403182e4b262d37385281b19b763ee6b32f6a/58_0_1743_1046/master/1743.png?width=930&quality=45&auto=format&s=9ecd82413fef9883c1e7a0df2bf6abb1',
+	ophanComponentId: 'change_me_ophan_component_id',
+	reminderOption: 'recurring-contribution-upsell',
+	reminderStage: 'PRE',
+	showPaymentIcons: 'false',
+	showPrivacyText: 'false',
+	slotName: 'Banner',
+	styleBackground: '#ededed',
+	styleBody: '#333333',
+	styleButton: '#ffffff',
+	styleButtonBackground: '#052962',
+	styleButtonHover: '#234b8a',
+	styleClose: '#052962',
+	styleCloseBackground: '#ededed',
+	styleCloseHover: '#e5e5e5',
+	styleHeader: '#333333',
+	styleHighlight: '#333333',
+	styleHighlightBackground: '#ededed',
+	styleReminderAnimation: '#707070',
+	styleReminderButton: '#121212',
+	styleReminderButtonBackground: '#ededed',
+	styleReminderButtonHover: '#dcdcdc',
+};
+
+BrazeStyleableBannerWithLinkComponent.storyName = 'StyleableBannerWithLink';
+
+// Braze BannerWithLink story (uses StyleableBannerWithLink)
+// ---------------------------------------
+export const BrazeBannerWithLinkComponent = (
+	args: BrazeMessageProps & { componentName: string },
+): ReactElement => {
+	const [BrazeMessage, setBrazeMessage] =
+		useState<typeof BrazeBannerComponentType>();
+
+	useEffect(() => {
+		import('@guardian/braze-components')
+			.then((module) => {
+				console.log(module);
+				setBrazeMessage(() => module.BrazeBannerComponent);
+			})
+			.catch((e) =>
+				console.error(
+					`braze-components dynamic import - error: ${String(e)}`,
+				),
+			);
+	}, []);
+
+	if (BrazeMessage) {
+		const brazeMessageProps: BrazeMessageProps = {
 			body: args.body,
 			boldText: args.boldText,
 			buttonText: args.buttonText,
 			buttonUrl: args.buttonUrl,
+			header: args.header,
 			imageUrl: args.imageUrl,
 			ophanComponentId: args.ophanComponentId,
 		};
@@ -73,24 +187,24 @@ export const BrazeBannerComponent = (
 	return <div>Loading...</div>;
 };
 
-BrazeBannerComponent.args = {
-	slotName: 'Banner',
-	componentName: 'BannerWithLink',
-	header: 'The Guardian’s impact in 2021',
+BrazeBannerWithLinkComponent.args = {
 	body: 'Thanks to your generous support in this extraordinary year, our open, independent journalism was read by millions. From the pandemic to our urgent coverage of the climate crisis, our reporting had a powerful impact.',
-	imageUrl:
-		'https://i.guim.co.uk/img/media/35d403182e4b262d37385281b19b763ee6b32f6a/58_0_1743_1046/master/1743.png?width=930&quality=45&auto=format&s=9ecd82413fef9883c1e7a0df2bf6abb1',
+	boldText:
+		'Read our look-back to see how Guardian journalism made a difference.',
 	buttonText: 'Take a look back',
 	buttonUrl:
 		'https://www.theguardian.com/info/ng-interactive/2020/dec/21/the-guardian-in-2020?INTCMP=gdnwb_mrtn_banner_edtrl_MK_SU_WorkingReport2020Canvas',
-	boldText:
-		'Read our look-back to see how Guardian journalism made a difference.',
+	componentName: 'BannerWithLink',
+	header: 'The Guardian’s impact in 2021',
+	imageUrl:
+		'https://i.guim.co.uk/img/media/35d403182e4b262d37385281b19b763ee6b32f6a/58_0_1743_1046/master/1743.png?width=930&quality=45&auto=format&s=9ecd82413fef9883c1e7a0df2bf6abb1',
 	ophanComponentId: 'change_me_ophan_component_id',
+	slotName: 'Banner',
 };
 
-BrazeBannerComponent.storyName = 'BannerWithLink';
+BrazeBannerWithLinkComponent.storyName = 'BannerWithLink';
 
-// Braze App Banner story
+// Braze AppBanner story (uses StyleableBannerWithLink)
 // ---------------------------------------
 export const BrazeAppBannerComponent = (
 	args: BrazeMessageProps & { componentName: string },
@@ -113,9 +227,9 @@ export const BrazeAppBannerComponent = (
 
 	if (BrazeMessage) {
 		const brazeMessageProps: BrazeMessageProps = {
-			header: args.header,
 			body: args.body,
 			cta: args.cta,
+			header: args.header,
 			imageUrl: args.imageUrl,
 		};
 
@@ -143,20 +257,20 @@ export const BrazeAppBannerComponent = (
 };
 
 BrazeAppBannerComponent.args = {
-	slotName: 'Banner',
-	componentName: 'AppBanner',
-	header: 'A note to our digital subscribers',
 	body: 'Hi John, did you know that as a Guardian digital subscriber you can enjoy an enhanced experience of our quality, independent journalism on all your devices, including The Guardian Live app.',
+	componentName: 'AppBanner',
 	cta: 'Search for "Guardian live news"',
+	header: 'A note to our digital subscribers',
 	imageUrl:
 		'https://i.guim.co.uk/img/media/de6813b4dd9b9805a2d14dd6af14ae2b48e2e19e/0_0_930_520/master/930.png?quality=45&width=930&s=0beb53509265d32e3d201aa3981323bb',
+	slotName: 'Banner',
 };
 
 BrazeAppBannerComponent.storyName = 'AppBanner';
 
-// Braze Newsletter Banner story
+// Braze StyleableBannerNewsletter story
 // ---------------------------------------
-export const BrazeNewsletterBannerComponent = (
+export const BrazeStyleableBannerNewsletterComponent = (
 	args: BrazeMessageProps & { componentName: string },
 ): ReactElement => {
 	const [BrazeMessage, setBrazeMessage] =
@@ -177,107 +291,31 @@ export const BrazeNewsletterBannerComponent = (
 
 	if (BrazeMessage) {
 		const brazeMessageProps: BrazeMessageProps = {
-			header: args.header,
-			newsletterId: args.newsletterId,
-			frequency: args.frequency,
 			body: args.body,
 			boldText: args.boldText,
-			secondParagraph: args.secondParagraph,
-			imageUrl: args.imageUrl,
-			ophanComponentId: args.ophanComponentId,
-		};
-
-		return (
-			<BrazeMessage
-				componentName={args.componentName}
-				logButtonClickWithBraze={(internalButtonId) => {
-					console.log(
-						`Button with internal ID ${internalButtonId} clicked`,
-					);
-				}}
-				submitComponentEvent={(componentEvent) => {
-					console.log(
-						'submitComponentEvent called with: ',
-						componentEvent,
-					);
-				}}
-				brazeMessageProps={brazeMessageProps}
-				subscribeToNewsletter={subscribeToNewsletter}
-				fetchEmail={fetchEmail}
-			/>
-		);
-	}
-	return <div>Loading...</div>;
-};
-
-BrazeNewsletterBannerComponent.args = {
-	slotName: 'Banner',
-	componentName: 'BannerNewsletter',
-	ophanComponentId: 'change_me_ophan_component_id',
-	header: 'The Morning Briefing',
-	newsletterId: '4156',
-	frequency: 'Every day',
-	body: 'Whether it’s the latest manoeuvring in global politics or the ‘and finally’ story that everyone’s talking about, you’ll be bang up to date with the news that counts.',
-	boldText: 'Sign up today!',
-	secondParagraph:
-		'We thought you should know this newsletter may contain information about Guardian products and services.',
-	imageUrl:
-		'https://i.guim.co.uk/img/media/568c6031be78dab6f6c28336010884f3ebd0f97c/0_0_1936_1936/master/1936.png?width=196&quality=45&auto=format&s=2a3630e9625620d5726c31c5cdbf4772',
-};
-
-BrazeNewsletterBannerComponent.storyName = 'BannerNewsletter';
-
-// Braze Styleable Banner story
-// ---------------------------------------
-export const BrazeStyleableBannerComponent = (
-	args: BrazeMessageProps & { componentName: string },
-): ReactElement => {
-	const [BrazeMessage, setBrazeMessage] =
-		useState<typeof BrazeBannerComponentType>();
-
-	useEffect(() => {
-		import('@guardian/braze-components')
-			.then((module) => {
-				console.log(module);
-				setBrazeMessage(() => module.BrazeBannerComponent);
-			})
-			.catch((e) =>
-				console.error(
-					`braze-components dynamic import - error: ${String(e)}`,
-				),
-			);
-	}, []);
-
-	if (BrazeMessage) {
-		const brazeMessageProps: BrazeMessageProps = {
-			styleBackground: args.styleBackground,
+			frequency: args.frequency,
 			header: args.header,
-			styleHeader: args.styleHeader,
-			body: args.body,
-			styleBody: args.styleBody,
-			highlight: args.highlight,
-			styleHighlight: args.styleHighlight,
-			styleHighlightBackground: args.styleHighlightBackground,
-			buttonText: args.buttonText,
-			buttonUrl: args.buttonUrl,
-			showPaymentIcons: args.showPaymentIcons,
-			styleButton: args.styleButton,
-			styleButtonBackground: args.styleButtonBackground,
-			styleButtonHover: args.styleButtonHover,
 			imageUrl: args.imageUrl,
-			imageAltText: args.imageAltText,
-			imagePosition: args.imagePosition,
+			newsletterCta: args.newsletterCta,
+			newsletterId: args.newsletterId,
+			ophanComponentId: args.ophanComponentId,
+			secondParagraph: args.secondParagraph,
+			styleBackground: args.styleBackground,
+			styleBody: args.styleBody,
+			styleBoldText: args.styleBoldText,
+			styleBoldTextBackground: args.styleBoldTextBackground,
+			styleClockColor: args.styleClockColor,
 			styleClose: args.styleClose,
 			styleCloseBackground: args.styleCloseBackground,
 			styleCloseHover: args.styleCloseHover,
-			ophanComponentId: args.ophanComponentId,
-			reminderStage: args.reminderStage,
-			reminderOption: args.reminderOption,
-			showPrivacyText: args.showPrivacyText,
-			styleReminderButton: args.styleReminderButton,
-			styleReminderButtonBackground: args.styleReminderButtonBackground,
-			styleReminderButtonHover: args.styleReminderButtonHover,
+			styleFrequencyText: args.styleFrequencyText,
+			styleHeader: args.styleHeader,
+			styleNewsletterButton: args.styleNewsletterButton,
+			styleNewsletterButtonBackground:
+				args.styleNewsletterButtonBackground,
+			styleNewsletterButtonHover: args.styleNewsletterButtonHover,
 			styleReminderAnimation: args.styleReminderAnimation,
+			styleSecondParagraph: args.styleSecondParagraph,
 		};
 
 		return (
@@ -303,40 +341,108 @@ export const BrazeStyleableBannerComponent = (
 	return <div>Loading...</div>;
 };
 
-BrazeStyleableBannerComponent.args = {
-	slotName: 'Banner',
-	styleBackground: '#ededed',
-	header: 'The Guardian’s impact in 2021',
-	styleHeader: '#333333',
-	body: 'Thanks to your generous support in this extraordinary year, our open, independent journalism was read by millions. From the pandemic to our urgent coverage of the climate crisis, our reporting had a powerful impact.',
-	styleBody: '#333333',
-	highlight:
-		'Read our look-back to see how Guardian journalism made a difference.',
-	styleHighlight: '#333333',
-	styleHighlightBackground: '#ededed',
-	buttonText: 'Take a look back',
-	buttonUrl:
-		'https://www.theguardian.com/info/ng-interactive/2020/dec/21/the-guardian-in-2020?INTCMP=gdnwb_mrtn_banner_edtrl_MK_SU_WorkingReport2020Canvas',
-	showPaymentIcons: 'false',
-	styleButton: '#ffffff',
-	styleButtonBackground: '#052962',
-	styleButtonHover: '#234b8a',
+BrazeStyleableBannerNewsletterComponent.args = {
+	body: 'Whether it’s the latest manoeuvring in global politics or the ‘and finally’ story that everyone’s talking about, you’ll be bang up to date with the news that counts.',
+	boldText: 'Sign up today!',
+	componentName: 'StyleableBannerNewsletter',
+	frequency: 'Every day',
+	header: 'The Morning Briefing',
 	imageUrl:
-		'https://i.guim.co.uk/img/media/35d403182e4b262d37385281b19b763ee6b32f6a/58_0_1743_1046/master/1743.png?width=930&quality=45&auto=format&s=9ecd82413fef9883c1e7a0df2bf6abb1',
-	imageAltText: 'Accessible image description',
-	imagePosition: 'bottom',
-	styleClose: '#052962',
-	styleCloseBackground: '#ededed',
-	styleCloseHover: '#e5e5e5',
-	componentName: 'StyleableBannerWithLink',
+		'https://i.guim.co.uk/img/media/568c6031be78dab6f6c28336010884f3ebd0f97c/0_0_1936_1936/master/1936.png?width=196&quality=45&auto=format&s=2a3630e9625620d5726c31c5cdbf4772',
+	newsletterCta: 'Sign up',
+	newsletterId: '4156',
 	ophanComponentId: 'change_me_ophan_component_id',
-	reminderStage: 'PRE',
-	reminderOption: 'recurring-contribution-upsell',
-	showPrivacyText: 'false',
-	styleReminderButton: '#121212',
-	styleReminderButtonBackground: '#ededed',
-	styleReminderButtonHover: '#dcdcdc',
+	secondParagraph:
+		'We thought you should know this newsletter may contain information about Guardian products and services.',
+	slotName: 'Banner',
+	styleBackground: '#ebe8e8',
+	styleBody: '#666666',
+	styleBoldText: `#333333`,
+	styleBoldTextBackground: '#ebe8e8',
+	styleClockColor: '#999999',
+	styleClose: `#333333`,
+	styleCloseBackground: '#ebe8e8',
+	styleCloseHover: '#e5e5e5',
+	styleFrequencyText: '#333333',
+	styleHeader: `#333333`,
+	styleNewsletterButton: '#ffffff',
+	styleNewsletterButtonBackground: '#c70000',
+	styleNewsletterButtonHover: '#c70000',
 	styleReminderAnimation: '#707070',
+	styleSecondParagraph: '#666666',
 };
 
-BrazeStyleableBannerComponent.storyName = 'StyleableBannerWithLink';
+BrazeStyleableBannerNewsletterComponent.storyName = 'StyleableBannerNewsletter';
+
+// Braze BannerNewsletter story (uses StyleableBannerNewsletter)
+// ---------------------------------------
+export const BrazeBannerNewsletterComponent = (
+	args: BrazeMessageProps & { componentName: string },
+): ReactElement => {
+	const [BrazeMessage, setBrazeMessage] =
+		useState<typeof BrazeBannerComponentType>();
+
+	useEffect(() => {
+		import('@guardian/braze-components')
+			.then((module) => {
+				console.log(module);
+				setBrazeMessage(() => module.BrazeBannerComponent);
+			})
+			.catch((e) =>
+				console.error(
+					`braze-components dynamic import - error: ${String(e)}`,
+				),
+			);
+	}, []);
+
+	if (BrazeMessage) {
+		const brazeMessageProps: BrazeMessageProps = {
+			body: args.body,
+			boldText: args.boldText,
+			frequency: args.frequency,
+			header: args.header,
+			imageUrl: args.imageUrl,
+			newsletterId: args.newsletterId,
+			ophanComponentId: args.ophanComponentId,
+			secondParagraph: args.secondParagraph,
+		};
+
+		return (
+			<BrazeMessage
+				componentName={args.componentName}
+				logButtonClickWithBraze={(internalButtonId) => {
+					console.log(
+						`Button with internal ID ${internalButtonId} clicked`,
+					);
+				}}
+				submitComponentEvent={(componentEvent) => {
+					console.log(
+						'submitComponentEvent called with: ',
+						componentEvent,
+					);
+				}}
+				brazeMessageProps={brazeMessageProps}
+				subscribeToNewsletter={subscribeToNewsletter}
+				fetchEmail={fetchEmail}
+			/>
+		);
+	}
+	return <div>Loading...</div>;
+};
+
+BrazeBannerNewsletterComponent.args = {
+	body: 'Whether it’s the latest manoeuvring in global politics or the ‘and finally’ story that everyone’s talking about, you’ll be bang up to date with the news that counts.',
+	boldText: 'Sign up today!',
+	componentName: 'BannerNewsletter',
+	frequency: 'Every day',
+	header: 'The Morning Briefing',
+	imageUrl:
+		'https://i.guim.co.uk/img/media/568c6031be78dab6f6c28336010884f3ebd0f97c/0_0_1936_1936/master/1936.png?width=196&quality=45&auto=format&s=2a3630e9625620d5726c31c5cdbf4772',
+	newsletterId: '4156',
+	ophanComponentId: 'change_me_ophan_component_id',
+	secondParagraph:
+		'We thought you should know this newsletter may contain information about Guardian products and services.',
+	slotName: 'Banner',
+};
+
+BrazeBannerNewsletterComponent.storyName = 'BannerNewsletter';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -345,8 +345,8 @@ importers:
         specifier: 7.0.1
         version: 7.0.1(tslib@2.6.2)(typescript@5.3.3)
       '@guardian/braze-components':
-        specifier: 18.0.0
-        version: 18.0.0(@emotion/react@11.11.1)(@guardian/libs@16.0.1)(@guardian/source-foundations@14.1.4)(@guardian/source-react-components-development-kitchen@19.0.0)(@guardian/source-react-components@22.0.1)(react@18.2.0)
+        specifier: 18.1.0
+        version: 18.1.0(@emotion/react@11.11.1)(@guardian/libs@16.0.1)(@guardian/source-foundations@14.1.4)(@guardian/source-react-components-development-kitchen@19.0.0)(@guardian/source-react-components@22.0.1)(react@18.2.0)
       '@guardian/bridget':
         specifier: 2.6.0
         version: 2.6.0
@@ -4225,8 +4225,8 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@guardian/braze-components@18.0.0(@emotion/react@11.11.1)(@guardian/libs@16.0.1)(@guardian/source-foundations@14.1.4)(@guardian/source-react-components-development-kitchen@19.0.0)(@guardian/source-react-components@22.0.1)(react@18.2.0):
-    resolution: {integrity: sha512-tK0waGQj/dEwpssxEOlHw7/d9XXnkQqZai/2LFUSuHwDtbeTgZZfIsAd9DoX02qFHNZlzvRvbLlS48zKcPKHDw==}
+  /@guardian/braze-components@18.1.0(@emotion/react@11.11.1)(@guardian/libs@16.0.1)(@guardian/source-foundations@14.1.4)(@guardian/source-react-components-development-kitchen@19.0.0)(@guardian/source-react-components@22.0.1)(react@18.2.0):
+    resolution: {integrity: sha512-GucCQ/1ttBM3Xy/3g7X13KnlrBy5HHxNFalmVkfmOVhnmlSHm8OcF0BgNHCPR/LIwzopgV8xrM6SFa/D6MYWlQ==}
     engines: {node: ^18.15 || ^20.9}
     peerDependencies:
       '@emotion/react': ^11.1.2


### PR DESCRIPTION
## What does this change?
This PR updates the braze components dependency to latest v18.1.0

## Why?
We've added a new Braze self-serve styleable Newsletter Banner to braze components

## Screenshots
None required. This update should not change the visual display of any other part of the site.

The Braze Banners Storybook story has been updated to include the new banner.