### PR TITLE
Removed Ambient Types For `ArticleDesign` And `ArticleDisplay`

### DIFF
--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -71,8 +71,6 @@ type FEFormat = {
 	display: FEDisplay;
 };
 
-type ArticleDisplay = import('@guardian/libs').ArticleDisplay;
-type ArticleDesign = import('@guardian/libs').ArticleDesign;
 type ArticleTheme = import('@guardian/libs').ArticleTheme;
 type ArticleFormat = import('@guardian/libs').ArticleFormat;
 

--- a/dotcom-rendering/src/components/MostViewedRightWithAd.tsx
+++ b/dotcom-rendering/src/components/MostViewedRightWithAd.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import type { ArticleDisplay } from '@guardian/libs';
 import { RightAdsPlaceholder } from './AdPlaceholder.apps';
 import { AdSlot } from './AdSlot.web';
 import { useConfig } from './ConfigContext';

--- a/dotcom-rendering/src/lib/format.ts
+++ b/dotcom-rendering/src/lib/format.ts
@@ -1,4 +1,4 @@
-import type { ArticleDesign } from '@guardian/libs';
+import type { ArticleDesign, ArticleDisplay } from '@guardian/libs';
 import { ArticleSpecial, isString, Pillar } from '@guardian/libs';
 
 export const getThemeNameAsString = (format: ArticleFormat): string => {


### PR DESCRIPTION
We prefer imports over ambient types for a number of reasons, such as a smaller type namespace in each file, and a reduction in the possibility of clashes/shadowing for type identifiers.

I've left `ArticleTheme` and `ArticleFormat` for now because they're used much more widely. I will try to remove their usages incrementally.
