### PR TITLE
Simplify `OnwardsUpper` by removing its placeholder

### DIFF
--- a/dotcom-rendering/src/components/OnwardsUpper.importable.tsx
+++ b/dotcom-rendering/src/components/OnwardsUpper.importable.tsx
@@ -1,13 +1,11 @@
 import { css } from '@emotion/react';
 import { joinUrl, Pillar } from '@guardian/libs';
 import type { EditionId } from '../lib/edition';
-import { useHydrated } from '../lib/useHydrated';
 import { useIsAndroid } from '../lib/useIsAndroid';
 import { palette } from '../palette';
 import type { OnwardsSource } from '../types/onwards';
 import type { TagType } from '../types/tag';
 import { FetchOnwardsData } from './FetchOnwardsData.importable';
-import { Placeholder } from './Placeholder';
 import { Section } from './Section';
 
 type PillarForContainer =
@@ -211,9 +209,7 @@ export const OnwardsUpper = ({
 }: Props) => {
 	const isAndroid = useIsAndroid();
 
-	const hydrated = useHydrated();
 	if (isAndroid) return null;
-	if (!hydrated) return <Placeholder height={600} />;
 
 	// Related content can be a collection of articles based on
 	// two things, 1: A popular tag, or 2: A generic text match


### PR DESCRIPTION
## What does this change?

The right number of onward items is known on the server, so we can have a much better guess at the final height by having `Placeholder` elements inside `FetchOnwardsData` directly.

## Why?

- fix background colour for dark mode
- reduce CLS and page jitter
- remove unnecessary slow reveal.

## Screenshots

https://github.com/guardian/dotcom-rendering/assets/76776/e5ea6711-f472-4493-ac8f-e5105bbf6483

https://github.com/guardian/dotcom-rendering/assets/76776/5dcb0bdc-115b-4437-a9c3-73fe2c8def3b