### PR TITLE
Remove `format` Field From `NumberedTitleBlockElement`

### DIFF
--- a/dotcom-rendering/fixtures/generated/articles/NumberedList.ts
+++ b/dotcom-rendering/fixtures/generated/articles/NumberedList.ts
@@ -2362,11 +2362,6 @@ export const NumberedList: DCRArticle = {
 					elementId: 'ee82ede2-2ead-41d2-b0a6-e0136663aad7',
 					position: 1,
 					html: "<h2 id='ee82ede2-2ead-41d2-b0a6-e0136663aad7'><strong>Best overall: </strong>OnePlus 7T Pro</h2>",
-					format: {
-						design: 'ReviewDesign',
-						theme: 'NewsPillar',
-						display: 'NumberedListDisplay',
-					},
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
@@ -2777,11 +2772,6 @@ export const NumberedList: DCRArticle = {
 					elementId: '181d42e3-e911-4e0f-bbb4-f51a017d2c23',
 					position: 2,
 					html: "<h2 id='181d42e3-e911-4e0f-bbb4-f51a017d2c23'><strong>Best iOS:</strong> Apple iPhone 11 Pro</h2>",
-					format: {
-						design: 'ReviewDesign',
-						theme: 'NewsPillar',
-						display: 'NumberedListDisplay',
-					},
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
@@ -3192,11 +3182,6 @@ export const NumberedList: DCRArticle = {
 					elementId: 'cd0bace7-dc0c-4adf-b2ef-35cfa1c0d051',
 					position: 3,
 					html: "<h2 id='cd0bace7-dc0c-4adf-b2ef-35cfa1c0d051'><strong>Best smaller Android:</strong> Samsung Galaxy S10</h2>",
-					format: {
-						design: 'ReviewDesign',
-						theme: 'NewsPillar',
-						display: 'NumberedListDisplay',
-					},
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
@@ -3602,11 +3587,6 @@ export const NumberedList: DCRArticle = {
 					elementId: '7044a3dc-ad10-4075-a18a-c759d65175d1',
 					position: 4,
 					html: "<h2 id='7044a3dc-ad10-4075-a18a-c759d65175d1'><strong>Best camera: </strong>Huawei P30 Pro</h2>",
-					format: {
-						design: 'ReviewDesign',
-						theme: 'NewsPillar',
-						display: 'NumberedListDisplay',
-					},
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
@@ -4012,11 +3992,6 @@ export const NumberedList: DCRArticle = {
 					elementId: '300cbdad-e842-4cd9-abb3-ba5c66066484',
 					position: 5,
 					html: "<h2 id='300cbdad-e842-4cd9-abb3-ba5c66066484'><strong>Best value:</strong> OnePlus 7T</h2>",
-					format: {
-						design: 'ReviewDesign',
-						theme: 'NewsPillar',
-						display: 'NumberedListDisplay',
-					},
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
@@ -4426,11 +4401,6 @@ export const NumberedList: DCRArticle = {
 					elementId: 'f1ce3426-3fb2-4ab6-afdd-a8e3c3438e68',
 					position: 6,
 					html: "<h2 id='f1ce3426-3fb2-4ab6-afdd-a8e3c3438e68'>Runners up</h2>",
-					format: {
-						design: 'ReviewDesign',
-						theme: 'NewsPillar',
-						display: 'NumberedListDisplay',
-					},
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
@@ -7624,11 +7594,6 @@ export const NumberedList: DCRArticle = {
 					elementId: '4b644a27-f660-4cb7-87c3-78fe5e9cfc95',
 					position: 7,
 					html: "<h2 id='4b644a27-f660-4cb7-87c3-78fe5e9cfc95'>Not recommended</h2>",
-					format: {
-						design: 'ReviewDesign',
-						theme: 'NewsPillar',
-						display: 'NumberedListDisplay',
-					},
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',

--- a/dotcom-rendering/src/model/article-schema.json
+++ b/dotcom-rendering/src/model/article-schema.json
@@ -2483,87 +2483,14 @@
                 },
                 "html": {
                     "type": "string"
-                },
-                "format": {
-                    "type": "object",
-                    "properties": {
-                        "design": {
-                            "$ref": "#/definitions/FEDesign"
-                        },
-                        "theme": {
-                            "$ref": "#/definitions/FETheme"
-                        },
-                        "display": {
-                            "$ref": "#/definitions/FEDisplay"
-                        }
-                    },
-                    "required": [
-                        "design",
-                        "display",
-                        "theme"
-                    ]
                 }
             },
             "required": [
                 "_type",
                 "elementId",
-                "format",
                 "html",
                 "position"
             ]
-        },
-        "FEDesign": {
-            "enum": [
-                "AnalysisDesign",
-                "ArticleDesign",
-                "AudioDesign",
-                "CommentDesign",
-                "DeadBlogDesign",
-                "EditorialDesign",
-                "ExplainerDesign",
-                "FeatureDesign",
-                "FullPageInteractiveDesign",
-                "GalleryDesign",
-                "InteractiveDesign",
-                "InterviewDesign",
-                "LetterDesign",
-                "LiveBlogDesign",
-                "MatchReportDesign",
-                "NewsletterSignupDesign",
-                "ObituaryDesign",
-                "PhotoEssayDesign",
-                "PictureDesign",
-                "PrintShopDesign",
-                "ProfileDesign",
-                "QuizDesign",
-                "RecipeDesign",
-                "ReviewDesign",
-                "TimelineDesign",
-                "VideoDesign"
-            ],
-            "type": "string"
-        },
-        "FETheme": {
-            "enum": [
-                "CulturePillar",
-                "Labs",
-                "LifestylePillar",
-                "NewsPillar",
-                "OpinionPillar",
-                "SpecialReportAltTheme",
-                "SpecialReportTheme",
-                "SportPillar"
-            ],
-            "type": "string"
-        },
-        "FEDisplay": {
-            "enum": [
-                "ImmersiveDisplay",
-                "NumberedListDisplay",
-                "ShowcaseDisplay",
-                "StandardDisplay"
-            ],
-            "type": "string"
         },
         "InteractiveContentsBlockElement": {
             "type": "object",
@@ -3804,6 +3731,59 @@
                 "INT",
                 "UK",
                 "US"
+            ],
+            "type": "string"
+        },
+        "FEDesign": {
+            "enum": [
+                "AnalysisDesign",
+                "ArticleDesign",
+                "AudioDesign",
+                "CommentDesign",
+                "DeadBlogDesign",
+                "EditorialDesign",
+                "ExplainerDesign",
+                "FeatureDesign",
+                "FullPageInteractiveDesign",
+                "GalleryDesign",
+                "InteractiveDesign",
+                "InterviewDesign",
+                "LetterDesign",
+                "LiveBlogDesign",
+                "MatchReportDesign",
+                "NewsletterSignupDesign",
+                "ObituaryDesign",
+                "PhotoEssayDesign",
+                "PictureDesign",
+                "PrintShopDesign",
+                "ProfileDesign",
+                "QuizDesign",
+                "RecipeDesign",
+                "ReviewDesign",
+                "TimelineDesign",
+                "VideoDesign"
+            ],
+            "type": "string"
+        },
+        "FETheme": {
+            "enum": [
+                "CulturePillar",
+                "Labs",
+                "LifestylePillar",
+                "NewsPillar",
+                "OpinionPillar",
+                "SpecialReportAltTheme",
+                "SpecialReportTheme",
+                "SportPillar"
+            ],
+            "type": "string"
+        },
+        "FEDisplay": {
+            "enum": [
+                "ImmersiveDisplay",
+                "NumberedListDisplay",
+                "ShowcaseDisplay",
+                "StandardDisplay"
             ],
             "type": "string"
         },

--- a/dotcom-rendering/src/model/block-schema.json
+++ b/dotcom-rendering/src/model/block-schema.json
@@ -2072,87 +2072,14 @@
                 },
                 "html": {
                     "type": "string"
-                },
-                "format": {
-                    "type": "object",
-                    "properties": {
-                        "design": {
-                            "$ref": "#/definitions/FEDesign"
-                        },
-                        "theme": {
-                            "$ref": "#/definitions/FETheme"
-                        },
-                        "display": {
-                            "$ref": "#/definitions/FEDisplay"
-                        }
-                    },
-                    "required": [
-                        "design",
-                        "display",
-                        "theme"
-                    ]
                 }
             },
             "required": [
                 "_type",
                 "elementId",
-                "format",
                 "html",
                 "position"
             ]
-        },
-        "FEDesign": {
-            "enum": [
-                "AnalysisDesign",
-                "ArticleDesign",
-                "AudioDesign",
-                "CommentDesign",
-                "DeadBlogDesign",
-                "EditorialDesign",
-                "ExplainerDesign",
-                "FeatureDesign",
-                "FullPageInteractiveDesign",
-                "GalleryDesign",
-                "InteractiveDesign",
-                "InterviewDesign",
-                "LetterDesign",
-                "LiveBlogDesign",
-                "MatchReportDesign",
-                "NewsletterSignupDesign",
-                "ObituaryDesign",
-                "PhotoEssayDesign",
-                "PictureDesign",
-                "PrintShopDesign",
-                "ProfileDesign",
-                "QuizDesign",
-                "RecipeDesign",
-                "ReviewDesign",
-                "TimelineDesign",
-                "VideoDesign"
-            ],
-            "type": "string"
-        },
-        "FETheme": {
-            "enum": [
-                "CulturePillar",
-                "Labs",
-                "LifestylePillar",
-                "NewsPillar",
-                "OpinionPillar",
-                "SpecialReportAltTheme",
-                "SpecialReportTheme",
-                "SportPillar"
-            ],
-            "type": "string"
-        },
-        "FEDisplay": {
-            "enum": [
-                "ImmersiveDisplay",
-                "NumberedListDisplay",
-                "ShowcaseDisplay",
-                "StandardDisplay"
-            ],
-            "type": "string"
         },
         "InteractiveContentsBlockElement": {
             "type": "object",

--- a/dotcom-rendering/src/model/enhance-numbered-lists.test.ts
+++ b/dotcom-rendering/src/model/enhance-numbered-lists.test.ts
@@ -656,7 +656,6 @@ describe('Enhance Numbered Lists', () => {
 						elementId: 'mockId',
 						position: 1,
 						html: '<h2 data-ignore="global-h2-styling">Some text</h2>',
-						format: NumberedList.format,
 					},
 				],
 			},
@@ -711,7 +710,6 @@ describe('Enhance Numbered Lists', () => {
 						elementId: 'mockId1',
 						position: 1,
 						html: '<h2 data-ignore="global-h2-styling">Some text</h2>',
-						format: NumberedList.format,
 					},
 					{
 						...images[0],
@@ -727,7 +725,6 @@ describe('Enhance Numbered Lists', () => {
 						elementId: 'mockId2',
 						position: 2,
 						html: '<h2 data-ignore="global-h2-styling">Other text</h2>',
-						format: NumberedList.format,
 					},
 					{
 						_type: 'model.dotcomrendering.pageElements.DividerBlockElement',
@@ -740,7 +737,6 @@ describe('Enhance Numbered Lists', () => {
 						elementId: 'mockId3',
 						position: 3,
 						html: '<h2 data-ignore="global-h2-styling">More text</h2>',
-						format: NumberedList.format,
 					},
 				],
 			},

--- a/dotcom-rendering/src/model/enhance-numbered-lists.ts
+++ b/dotcom-rendering/src/model/enhance-numbered-lists.ts
@@ -291,7 +291,7 @@ const addItemLinks = (elements: FEElement[]): FEElement[] => {
 	return withItemLink;
 };
 
-const addTitles = (elements: FEElement[], format: FEFormat): FEElement[] => {
+const addTitles = (elements: FEElement[]): FEElement[] => {
 	/**
 	 * Why not just add H3s in Composer?
 	 * Truth is, you can't. So to get around this there's a convention that says if
@@ -321,7 +321,6 @@ const addTitles = (elements: FEElement[], format: FEFormat): FEElement[] => {
 					elementId: thisElement.elementId,
 					position,
 					html,
-					format,
 				},
 			);
 			position += 1;
@@ -336,11 +335,8 @@ const addTitles = (elements: FEElement[], format: FEFormat): FEElement[] => {
 class Enhancer {
 	elements: FEElement[];
 
-	format: FEFormat;
-
-	constructor(elements: FEElement[], format: FEFormat) {
+	constructor(elements: FEElement[]) {
 		this.elements = elements;
-		this.format = format;
 	}
 
 	makeThumbnailsRound() {
@@ -349,7 +345,7 @@ class Enhancer {
 	}
 
 	addTitles() {
-		this.elements = addTitles(this.elements, this.format);
+		this.elements = addTitles(this.elements);
 		return this;
 	}
 
@@ -379,9 +375,9 @@ class Enhancer {
 	}
 }
 
-const enhance = (elements: FEElement[], format: FEFormat): FEElement[] => {
+const enhance = (elements: FEElement[]): FEElement[] => {
 	return (
-		new Enhancer(elements, format)
+		new Enhancer(elements)
 			// Add the data-ignore='global-h2-styling' attribute
 			.removeGlobalH2Styles()
 			// Turn false h3s into real ones
@@ -412,7 +408,7 @@ export const enhanceNumberedLists = (
 	return blocks.map((block: Block) => {
 		return {
 			...block,
-			elements: enhance(block.elements, format),
+			elements: enhance(block.elements),
 		};
 	});
 };

--- a/dotcom-rendering/src/types/content.ts
+++ b/dotcom-rendering/src/types/content.ts
@@ -357,7 +357,6 @@ interface NumberedTitleBlockElement {
 	elementId: string;
 	position: number;
 	html: string;
-	format: FEFormat;
 }
 
 export interface InteractiveContentsBlockElement {


### PR DESCRIPTION
It's not used. In addition, although `NumberedTitleBlockElement` is present in the `FEElement` type, it doesn't appear to exist in `frontend`, so this shouldn't require an equivalent change there.
