### PR TITLE
Remove deeply read switch check and enable permanently

### DIFF
--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -152,10 +152,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 		: [];
 
 	const showMostPopular =
-		front.config.switches.deeplyRead &&
-		front.isNetworkFront &&
-		front.deeplyRead &&
-		front.deeplyRead.length > 0;
+		front.isNetworkFront && front.deeplyRead && front.deeplyRead.length > 0;
 
 	const contributionsServiceUrl = getContributionsServiceUrl(front);
 


### PR DESCRIPTION
## What does this change?

Permanently enables the Deeply Read feature.
Follow up on https://github.com/guardian/dotcom-rendering/pull/10159

## Why?

The A/B test we ran for a week was conclusively successful: 
https://docs.google.com/presentation/d/14uepErsEHYWX7mhTQKXqSiK6kQMY2AmP2UagdGkcsv0/edit#slide=id.g1e6e565e980_0_24

## Note
This change will only take effect once we remove the switch from frontend as well, which only sends deeply read data when the user is participating in the test: https://github.com/guardian/frontend/pull/26927

Fixes https://github.com/guardian/dotcom-rendering/issues/10348
