### PR TITLE
Fix height in Immersive article main media

### DIFF
--- a/dotcom-rendering/src/components/ImageComponent.tsx
+++ b/dotcom-rendering/src/components/ImageComponent.tsx
@@ -294,16 +294,12 @@ export const ImageComponent = ({
 					/* These styles depend on the containing layout component wrapping the main media
                     with a div set to 100vh. This is the case for ImmersiveLayout which should
                     always be used if display === 'immersive' */
-					height: 80vh;
+					height: 100%;
 					width: 100%;
 					min-height: 25rem;
 
 					${from.desktop} {
-						height: 100vh;
 						min-height: 31.25rem;
-					}
-					${from.wide} {
-						min-height: 50rem;
 					}
 					img {
 						object-fit: cover;


### PR DESCRIPTION
Closes #10685 

## What does this change?
Sets height to 95% in Immersive articles main media for breakpoints between desktop and wide

## Why?
Fixes the way the image is cropped

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/db141d28-663b-49a2-8b1c-f1bbb44cd05b) | ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/2a9097ad-4c03-47a1-a62e-acd1aaa115dc) |

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
