### PR TITLE
Combine container palette styles into general hover styles

### DIFF
--- a/dotcom-rendering/src/components/Card/components/CardWrapper.tsx
+++ b/dotcom-rendering/src/components/Card/components/CardWrapper.tsx
@@ -82,12 +82,20 @@ const decidePaletteBrightness = (thePalette: DCRContainerPalette) => {
 	}
 };
 
-const containerPaletteStyles = (containerPalette: DCRContainerPalette) => css`
-	:hover {
-		filter: brightness(${decidePaletteBrightness(containerPalette)});
+const hoverStyles = (
+	format: ArticleFormat,
+	containerPalette?: DCRContainerPalette,
+) => {
+	if (containerPalette) {
+		return css`
+			:hover {
+				filter: brightness(
+					${decidePaletteBrightness(containerPalette)}
+				);
+			}
+		`;
 	}
-`;
-const hoverStyles = (format: ArticleFormat) => {
+
 	if (
 		format.theme === ArticleSpecial.SpecialReport ||
 		format.theme === ArticleSpecial.SpecialReportAlt
@@ -179,12 +187,10 @@ export const CardWrapper = ({
 				<div
 					css={[
 						baseCardStyles(isOnwardContent),
-						containerPalette &&
-							containerPaletteStyles(containerPalette),
 						isOnwardContent ? onwardContentCardStyles : cardStyles,
 						isOnwardContent
 							? onwardContentHoverStyles
-							: hoverStyles(format),
+							: hoverStyles(format, containerPalette),
 						showTopBar && topBarStyles({ isDynamo }),
 					]}
 				>


### PR DESCRIPTION
## What does this change?

Combines the container palette hover styles into the general hover styles to ensure cards using container palette overrides take the relevant styles

## Why?

Resolves #10606 

## Screenshots

Shows hover state of biggest card ("Punish directors who don't make climate disclosures, says hedge fund)

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |


[before]: https://github.com/guardian/dotcom-rendering/assets/43961396/03ab98de-a6c2-4231-9bd4-fa48847364d8

[after]: https://github.com/guardian/dotcom-rendering/assets/43961396/66a18833-cab2-4d31-8a3b-886cce73f6d0
