### PR TITLE
Upgrade  `guardian/actions-riff-raff` to version 4

### DIFF
--- a/.github/workflows/ar-ci.yml
+++ b/.github/workflows/ar-ci.yml
@@ -39,17 +39,11 @@ jobs:
           pnpm synth
           zip -j dist/server/mobile-apps-rendering.zip dist/server/*
 
-      - name: AWS Auth
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
-          aws-region: eu-west-1
-          mask-aws-account-id: true
-
       - name: Upload to riff-raff
-        uses: guardian/actions-riff-raff@v3
+        uses: guardian/actions-riff-raff@v4
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
+          roleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
           configPath: apps-rendering/riff-raff.yaml
           projectName: Mobile::mobile-apps-rendering
           buildNumberOffset: 27000 # This is the last build number from TeamCity

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -36,7 +36,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
-      pull-requests: write # required by guardian/actions-riff-raff@v3
+      pull-requests: write # required by riff-raff action
     needs: [container, prettier, jest, lint, playwright, amp]
     uses: ./.github/workflows/publish.yml
     with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,17 +54,12 @@ jobs:
           rm -r interactive-rendering/*
           mv interactive-rendering.tar.gz interactive-rendering/
 
-      - uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-region: eu-west-1
-          role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
-          mask-aws-account-id: true
-
       # All rendering apps deployment
       - name: Upload rendering apps to RiffRaff
-        uses: guardian/actions-riff-raff@v3
+        uses: guardian/actions-riff-raff@v4
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
+          roleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
           projectName: dotcom:rendering-all
           configPath: riff-raff.yaml
           contentDirectories: |


### PR DESCRIPTION
## What does this change?

Bumps `guardian/actions-riff-raff@v3` to `guardian/actions-riff-raff@v4`

This has a breaking change as requiring the AWS role ARN to be provided directly to the action as opposed to supplying to the environment.

## Why?

Part of #10600


## Screenshots

Riffraff successfully picked up the new build for DCR:
<img width="554" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/43961396/6ebc7596-4468-4da9-ba14-3dc879b52220">

And for AR: 
<img width="559" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/43961396/5380d0ed-b415-45f2-9889-7fb003b00188">

And have successfully [deployed](https://riffraff.gutools.co.uk/deployment/view/311dce6d-e36a-41ac-aa1d-f3551e2688f0) [both](https://riffraff.gutools.co.uk/deployment/view/4f01e8e6-76d5-472c-b77c-828a5ef0e171) to the CODE environment to double check