### PR TITLE
Increase number of `article-rendering` instances from 15 to 24

### DIFF
--- a/dotcom-rendering/cdk/bin/cdk.ts
+++ b/dotcom-rendering/cdk/bin/cdk.ts
@@ -41,8 +41,8 @@ new RenderingCDKStack(cdkApp, 'ArticleRendering-PROD', {
 	stage: 'PROD',
 	domainName: 'article-rendering.guardianapis.com',
 	scaling: {
-		minimumInstances: 15,
-		maximumInstances: 60,
+		minimumInstances: 24,
+		maximumInstances: 96,
 		policy: {
 			scalingStepsOut: [
 				// No scaling up effect when latency is lower than 0.2s


### PR DESCRIPTION
## What does this change?

Updates `article-rendering` app to run 24 instances rather than 15

## Why?

We are seeing lots of errors from the `article-rendering` app which triggers the DCR circuit breaker to trip in frontend.

As part of experimenting to find good infrastructure provisioning, we are increasing the number of instances to try to reduce the CPU usage

## Screenshots

The below screenshot shows how a manual increase of instances from 15 to 20 over the weekend reduced the variation in latency:

<img width="932" alt="Screenshot 2024-02-26 at 12 22 19" src="https://github.com/guardian/dotcom-rendering/assets/43961396/583097ba-d3b3-4927-8471-a5bc3b4abb0d">

The CPU usage over the same time period:

<img width="930" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/43961396/939901a8-0354-430f-9b3d-cd4b3639d60d">
