### PR TITLE
Bump consent-management-platform to version 13.11.1

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -49,7 +49,7 @@
 		"@guardian/browserslist-config": "6.1.0",
 		"@guardian/cdk": "50.13.0",
 		"@guardian/commercial": "14.4.1",
-		"@guardian/consent-management-platform": "13.10.0",
+		"@guardian/consent-management-platform": "13.11.1",
 		"@guardian/core-web-vitals": "6.0.0",
 		"@guardian/eslint-config": "7.0.1",
 		"@guardian/eslint-config-typescript": "9.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -358,10 +358,10 @@ importers:
         version: 50.13.0(@swc/core@1.4.0)(@types/node@18.18.14)(aws-cdk-lib@2.100.0)(aws-cdk@2.100.0)(constructs@10.3.0)(typescript@5.3.3)
       '@guardian/commercial':
         specifier: 14.4.1
-        version: 14.4.1(@guardian/ab-core@7.0.1)(@guardian/consent-management-platform@13.10.0)(@guardian/core-web-vitals@6.0.0)(@guardian/identity-auth-frontend@3.0.0)(@guardian/identity-auth@2.0.1)(@guardian/libs@16.0.1)(@guardian/source-foundations@14.1.4)(@guardian/support-dotcom-components@1.1.3)(typescript@5.3.3)
+        version: 14.4.1(@guardian/ab-core@7.0.1)(@guardian/consent-management-platform@13.11.1)(@guardian/core-web-vitals@6.0.0)(@guardian/identity-auth-frontend@3.0.0)(@guardian/identity-auth@2.0.1)(@guardian/libs@16.0.1)(@guardian/source-foundations@14.1.4)(@guardian/support-dotcom-components@1.1.3)(typescript@5.3.3)
       '@guardian/consent-management-platform':
-        specifier: 13.10.0
-        version: 13.10.0(@guardian/libs@16.0.1)
+        specifier: 13.11.1
+        version: 13.11.1(@guardian/libs@16.0.1)
       '@guardian/core-web-vitals':
         specifier: 6.0.0
         version: 6.0.0(@guardian/libs@16.0.1)(tslib@2.6.2)(typescript@5.3.3)(web-vitals@3.5.1)
@@ -4287,7 +4287,7 @@ packages:
       - typescript
     dev: false
 
-  /@guardian/commercial@14.4.1(@guardian/ab-core@7.0.1)(@guardian/consent-management-platform@13.10.0)(@guardian/core-web-vitals@6.0.0)(@guardian/identity-auth-frontend@3.0.0)(@guardian/identity-auth@2.0.1)(@guardian/libs@16.0.1)(@guardian/source-foundations@14.1.4)(@guardian/support-dotcom-components@1.1.3)(typescript@5.3.3):
+  /@guardian/commercial@14.4.1(@guardian/ab-core@7.0.1)(@guardian/consent-management-platform@13.11.1)(@guardian/core-web-vitals@6.0.0)(@guardian/identity-auth-frontend@3.0.0)(@guardian/identity-auth@2.0.1)(@guardian/libs@16.0.1)(@guardian/source-foundations@14.1.4)(@guardian/support-dotcom-components@1.1.3)(typescript@5.3.3):
     resolution: {integrity: sha512-DG6YgAfl1fRWrD/KI7l+/XeQT3EQSxR9bIwIQq0vCdN6BITutm2AJ6sc3AapuuSpdy8PBPLlrTzwzLkgcIWt3A==}
     peerDependencies:
       '@guardian/ab-core': ^7.0.1
@@ -4301,7 +4301,7 @@ packages:
     dependencies:
       '@changesets/cli': 2.27.1
       '@guardian/ab-core': 7.0.1(tslib@2.6.2)(typescript@5.3.3)
-      '@guardian/consent-management-platform': 13.10.0(@guardian/libs@16.0.1)
+      '@guardian/consent-management-platform': 13.11.1(@guardian/libs@16.0.1)
       '@guardian/core-web-vitals': 6.0.0(@guardian/libs@16.0.1)(tslib@2.6.2)(typescript@5.3.3)(web-vitals@3.5.1)
       '@guardian/identity-auth': 2.0.1(@guardian/libs@16.0.1)(tslib@2.6.2)(typescript@5.3.3)
       '@guardian/identity-auth-frontend': 3.0.0(@guardian/identity-auth@2.0.1)(@guardian/libs@16.0.1)(tslib@2.6.2)(typescript@5.3.3)
@@ -4324,8 +4324,8 @@ packages:
       - typescript
     dev: false
 
-  /@guardian/consent-management-platform@13.10.0(@guardian/libs@16.0.1):
-    resolution: {integrity: sha512-ura73/w9VOOTI+p+h52J+hePq6S4YeIV3iRiUYhc6IdqpdBkJfKKGE3zh9fxd+S/ktH8ZSQR4ebRjM2GKtMJrw==}
+  /@guardian/consent-management-platform@13.11.1(@guardian/libs@16.0.1):
+    resolution: {integrity: sha512-cU9ssmMVV6EpX7H9QVAf0gdPrIdrGkvi/5ylGXF6xGvyvJ6CwUxM+vZhhm5tujoCiq6EuAVJX1tiZ3oHQMEdZg==}
     peerDependencies:
       '@guardian/libs': ^15.0.0 || ^16.0.0
     dependencies:


### PR DESCRIPTION
## What does this change?

Bumps the version of consent-management-platform to the latest version (13.11.1)

## Why?

This bump includes: 
- bumps of consent-management-platform dependencies
- adds an optional final parameter to onConsentChange for Commercial to add a callback that will be called as a final callback.

## Screenshots

No visual change.

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
