### PR TITLE
Always show `LabsSection` component if front collection is "branded"

### DIFF
--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -451,10 +451,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 						);
 					}
 
-					if (
-						collection.containerPalette === 'Branded' &&
-						renderAds
-					) {
+					if (collection.containerPalette === 'Branded') {
 						return (
 							<Fragment key={ophanName}>
 								<LabsSection


### PR DESCRIPTION
## What does this change?

Removes the condition `renderAds` in the logic to decide whether to render a `LabsSection`

## Why?

When `renderAds` is false, it's not that we don't show the labs section at all, it's that we show a "standard" section instead i.e. a non-labs branded section. This results in a substandard experience viewing the [Guardian Labs front](https://www.theguardian.com/guardian-labs) as the titles are unreadable due to the lack of sufficient contrast between the text and background.

The following thread is from the initial implementation of this logic: https://github.com/guardian/dotcom-rendering/pull/7813/files#r1219703824

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/43961396/1bdd5b22-b871-46a0-ac91-93bb25b55538
[after]: https://github.com/guardian/dotcom-rendering/assets/43961396/75dec98d-e640-402e-a9a9-e30b79b46b14
