### PR TITLE
Increase instance size of `article-rendering` app to t4g medium

### DIFF
--- a/dotcom-rendering/cdk/bin/cdk.ts
+++ b/dotcom-rendering/cdk/bin/cdk.ts
@@ -60,7 +60,7 @@ new RenderingCDKStack(cdkApp, 'ArticleRendering-PROD', {
 			],
 		},
 	},
-	instanceSize: InstanceSize.SMALL,
+	instanceSize: InstanceSize.MEDIUM,
 });
 
 /** Facia */


### PR DESCRIPTION
## What does this change?

Swaps PROD `article-rendering` instance size from small to medium. 

## Why?

We'd already increased the number of instances running in https://github.com/guardian/dotcom-rendering/pull/10721. This did reduce CPU but not enough to start accruing CPU credits. 

See graph of the last 7 days of CPU credit balance, showing we are not earning CPU credits

<img width="1479" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/43961396/32ad8c0a-171c-421b-ab33-69c1006ad7d6">
 
Plus last 7 days of CPU usage:

<img width="1478" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/43961396/2b9ed933-f14c-4f3e-b13a-23668102244d">


The baseline CPU usage for T4G small is 20% and if we continue using this [burstable instance type](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/burstable-performance-instances.html) we want to be running at less than this value for most of the time, allowing for periods of bursts where we can use credits built up over low CPU usage to burst above the 20% threshold for short periods of time. We are not running under 20% for large periods of time at the moment.


Part of #10705
