### PR TITLE
Implement use effect reducer hook in Discussion

### DIFF
--- a/dotcom-rendering/src/components/Discussion.tsx
+++ b/dotcom-rendering/src/components/Discussion.tsx
@@ -3,7 +3,7 @@ import { storage } from '@guardian/libs';
 import { space } from '@guardian/source-foundations';
 import { SvgPlus } from '@guardian/source-react-components';
 import { useEffect } from 'react';
-import { useEffectReducer } from 'src/lib/UseEffectReducer';
+import { useEffectReducer } from '../lib/UseEffectReducer';
 import { assertUnreachable } from '../lib/assert-unreachable';
 import type {
 	CommentFormProps,

--- a/dotcom-rendering/src/components/DispatchContext.tsx
+++ b/dotcom-rendering/src/components/DispatchContext.tsx
@@ -32,7 +32,8 @@ export type Action =
 	| { type: 'setBottomFormError'; error: string }
 	| { type: 'setTopFormPreviewBody'; previewBody: string }
 	| { type: 'setReplyFormPreviewBody'; previewBody: string }
-	| { type: 'setBottomFormPreviewBody'; previewBody: string };
+	| { type: 'setBottomFormPreviewBody'; previewBody: string }
+	| { type: 'storeShortUrlId'; shortUrlId: string };
 
 const DispatchContext = createContext<Dispatch<Action>>(() => {
 	debug(

--- a/dotcom-rendering/src/components/DispatchContext.tsx
+++ b/dotcom-rendering/src/components/DispatchContext.tsx
@@ -33,7 +33,8 @@ export type Action =
 	| { type: 'setTopFormPreviewBody'; previewBody: string }
 	| { type: 'setReplyFormPreviewBody'; previewBody: string }
 	| { type: 'setBottomFormPreviewBody'; previewBody: string }
-	| { type: 'storeShortUrlId'; shortUrlId: string };
+	| { type: 'storeShortUrlId'; shortUrlId: string }
+	| { type: 'commentsLoadedFailed' };
 
 const DispatchContext = createContext<Dispatch<Action>>(() => {
 	debug(

--- a/dotcom-rendering/src/lib/UseEffectReducer.ts
+++ b/dotcom-rendering/src/lib/UseEffectReducer.ts
@@ -1,0 +1,79 @@
+import type { Dispatch } from 'react';
+import { useEffect, useReducer, useRef } from 'react';
+
+type StateAndEffect<State, Effect> = {
+	state: State;
+	effect?: Effect;
+};
+
+/**
+ * @param reducer Very similar to the reducer normally passed to
+ * {@linkcode React.useReducer}, but also returns a description of effects
+ * alongside the state.
+ *
+ * @param effectReducer A handler for effects. It takes a description of an
+ * effect and decides how to run that effect, returning an `Action` that will
+ * be fed back into the next loop of the `reducer`.
+ *
+ * Depending on how an application is written, different `effectReducer`s can
+ * be passed in different environments. So in production this might run actual
+ * effects, whereas in tests it might run mocked versions.
+ *
+ * *Note:* The value used will be the one passed on the initial render; the
+ * argument is ignored after this point.
+ *
+ * @param initialState The state at the start of the application; the same
+ * as the `initialState` argument usually passed to
+ * {@linkcode React.useReducer}.
+ *
+ * @param initialEffect Optionally, an effect to run at the start of the
+ * application.
+ *
+ * @returns State and a `dispatch` function, the same as
+ * {@linkcode React.useReducer}.
+ */
+const useEffectReducer = <State, Effect, Action>(
+	reducer: (
+		state: State,
+		action: Action,
+	) => { state: State; effect?: Effect },
+	effectReducer: (effect: Effect) => Action | Promise<Action>,
+	initialState: State,
+	initialEffect: Effect | undefined,
+): [State, Dispatch<Action>] => {
+	/**
+	 * Guards against effect reducers being changed over time. If this were to
+	 * be allowed, the `effectReducer` would have to be a dependency of the
+	 * `useEffect` below. Were this the case, every time it changed the
+	 * `useEffect` callback would run, potentially duplicating effects.
+	 */
+	const cachedEffectReducer = useRef(effectReducer);
+
+	const reducerWrapper = (
+		stateAndEffect: StateAndEffect<State, Effect>,
+		action: Action,
+	): StateAndEffect<State, Effect> => reducer(stateAndEffect.state, action);
+
+	const [{ state, effect }, dispatch] = useReducer(reducerWrapper, {
+		state: initialState,
+		effect: initialEffect,
+	});
+
+	useEffect(() => {
+		if (effect !== undefined) {
+			const result = cachedEffectReducer.current(effect);
+
+			if (result instanceof Promise) {
+				result.then(dispatch).catch(() => {
+					console.error('Failed to run effect!');
+				});
+			} else {
+				dispatch(result);
+			}
+		}
+	}, [effect]);
+
+	return [state, dispatch];
+};
+
+export { useEffectReducer };


### PR DESCRIPTION
## What does this change?
Implements the useEffectReducer introduced [here](https://github.com/guardian/dotcom-rendering/pull/10454) to the Discussion app.

## Why?
This part of the code base is considered to be hard to reason about and work with. The intention here is to more closely couple actions and effects by co-locating them in side a reducer, making it easier to track what causes side effects in the app than searching through for useEffects, for example.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
