### PR TITLE
Use dark mode colours on discussion button background

### DIFF
--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -4705,7 +4705,7 @@ const discussionSubduedDark: PaletteFunction = () => sourcePalette.neutral[60];
 const discussionLinkLight: PaletteFunction = () => sourcePalette.brand[500];
 const discussionLinkDark: PaletteFunction = () => sourcePalette.brand[800];
 
-const discussionPrimaryButtonBackground: PaletteFunction = ({ theme }) => {
+const discussionPrimaryButtonBackgroundLight: PaletteFunction = ({ theme }) => {
 	switch (theme) {
 		case Pillar.News:
 			return sourcePalette.news[300];
@@ -4721,6 +4721,21 @@ const discussionPrimaryButtonBackground: PaletteFunction = ({ theme }) => {
 			return sourcePalette.labs[300];
 		default:
 			return sourcePalette.news[300];
+	}
+};
+
+const discussionPrimaryButtonBackgroundDark: PaletteFunction = ({ theme }) => {
+	switch (theme) {
+		case Pillar.News:
+		case Pillar.Lifestyle:
+		case Pillar.Sport:
+		case Pillar.Culture:
+		case Pillar.Opinion:
+			return pillarPalette(theme, 500);
+		case ArticleSpecial.Labs:
+			return sourcePalette.labs[400];
+		default:
+			return sourcePalette.news[500];
 	}
 };
 
@@ -5779,8 +5794,8 @@ const paletteColours = {
 		dark: discussionLinkDark,
 	},
 	'--discussion-primary-button-background': {
-		light: discussionPrimaryButtonBackground,
-		dark: discussionPrimaryButtonBackground,
+		light: discussionPrimaryButtonBackgroundLight,
+		dark: discussionPrimaryButtonBackgroundDark,
 	},
 	'--discussion-button-background-hover': {
 		light: discussionButtonHover,

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -4762,7 +4762,7 @@ const discussionButtonHover: PaletteFunction = ({ theme }) => {
 const discussionButtonTextLight: PaletteFunction = () =>
 	sourcePalette.neutral[100];
 const discussionButtonTextDark: PaletteFunction = () =>
-	sourcePalette.neutral[100];
+	sourcePalette.neutral[7];
 
 const discussionReportBackgroundLight: PaletteFunction = () =>
 	sourcePalette.neutral[100];


### PR DESCRIPTION
## What does this change?
Updates dark mode colours for discussion background and font.

## Why?
Requested by design

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/20416599/49403937-0bdd-4bda-a2b9-fbb4900ec819
[after]: https://github.com/guardian/dotcom-rendering/assets/20416599/874528d3-75d6-452b-a6c1-582fe22d4a56

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
