### PR TITLE
Update the URL for "reuse this content" for new form

### DIFF
--- a/dotcom-rendering/src/components/SubMeta.tsx
+++ b/dotcom-rendering/src/components/SubMeta.tsx
@@ -185,7 +185,7 @@ export const SubMeta = ({
 								priority="tertiary"
 								size="xsmall"
 								data-link-name="meta-syndication-article"
-								href={`https://syndication.theguardian.com/automation/?url=${encodeURIComponent(
+								href={`https://syndication.theguardian.com/?url=${encodeURIComponent(
 									webUrl,
 								)}&type=article&internalpagecode=${pageId}`}
 								target="_blank"


### PR DESCRIPTION
## What does this change?

Removes the `/automation` path from the syndication.guardianapis.com URL that sits behind "Reuse this content"

## Why?

We have rolled out a new form that does not need this indirection.

## Screenshots

No visual changes.

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
