### PR TITLE
Allow Chromatic label helper to run on non-draft PRs

### DIFF
--- a/.github/workflows/chromatic-label-helper.yml
+++ b/.github/workflows/chromatic-label-helper.yml
@@ -7,13 +7,16 @@ name: Chromatic Label Helper
 
 on:
   pull_request:
-    types: [synchronize]
+    types: [opened, ready_for_review]
 
 jobs:
   write_comment:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+
+    # We only comment on pull requests that have been marked as ready for review
+    if: ${{ github.event.pull_request.draft == false}}
 
     steps:
       - uses: actions/github-script@v7


### PR DESCRIPTION
## What does this change?

Changes workflow to run on pull request `synchronize` events rather than just `ready_to_review` 

This changes the logic to only comment on a PR if the comment has not been found on the PR already.

## Why?

Not everyone opens PRs in draft mode first and this causes confusion when the checks never pass and the developer has less feedback to understand the next steps.
