### PR TITLE
Add spacing to profile/timestamp on discussion comments

### DIFF
--- a/dotcom-rendering/src/components/Discussion/Comment.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comment.tsx
@@ -296,6 +296,12 @@ const cssReplyBetaDisplayName = css`
 	}
 `;
 
+const spacedColumnStyles = css`
+	display: flex;
+	flex-direction: column;
+	gap: ${space[1]}px;
+`;
+
 const Space = ({ amount }: { amount: 1 | 2 | 3 | 4 | 5 | 6 | 9 | 12 | 24 }) => (
 	<div
 		css={css`
@@ -416,7 +422,7 @@ export const Comment = ({
 												size="small"
 											/>
 										</div>
-										<Column>
+										<div css={spacedColumnStyles}>
 											<div
 												css={[
 													colourStyles,
@@ -448,7 +454,7 @@ export const Comment = ({
 													onPermalinkClick
 												}
 											/>
-										</Column>
+										</div>
 									</Row>
 								</div>
 								<div


### PR DESCRIPTION
## What does this change?
adds a 4px gap between the profile and timestamp on comments so they don't crash into each other.

## Why?
Requested by design as part of discussion design audit

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
