### PR TITLE
add banner to tablet front

### DIFF
--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -252,6 +252,8 @@ const mobileFrontAdStyles = css`
 `;
 
 const frontsBannerPaddingHeight = 20;
+const frontsBannerMinHeightTablet =
+	adSizes.leaderboard.height + labelHeight + frontsBannerPaddingHeight;
 const frontsBannerMinHeight =
 	adSizes.billboard.height + labelHeight + frontsBannerPaddingHeight;
 
@@ -263,6 +265,9 @@ const frontsBannerAdTopContainerStyles = css`
 
 	${until.tablet} {
 		display: none;
+	}
+	${until.desktop} {
+		min-height: ${frontsBannerMinHeightTablet}px;
 	}
 `;
 
@@ -295,6 +300,7 @@ const frontsBannerAdStyles = css`
 	padding-bottom: ${frontsBannerPaddingHeight}px;
 	${between.tablet.and.desktop} {
 		max-width: ${adSizes.leaderboard.width}px;
+		max-height: ${90 + labelHeight}px;
 	}
 `;
 

--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -258,16 +258,15 @@ const frontsBannerMinHeight =
 	adSizes.billboard.height + labelHeight + frontsBannerPaddingHeight;
 
 const frontsBannerAdTopContainerStyles = css`
-	display: flex;
-	justify-content: center;
-	min-height: ${frontsBannerMinHeight}px;
-	background-color: ${palette.neutral[97]};
-
-	${until.tablet} {
-		display: none;
-	}
-	${until.desktop} {
+	display: none;
+	${from.tablet} {
+		display: flex;
+		justify-content: center;
 		min-height: ${frontsBannerMinHeightTablet}px;
+		background-color: ${palette.neutral[97]};
+	}
+	${from.desktop} {
+		min-height: ${frontsBannerMinHeight}px;
 	}
 `;
 
@@ -292,13 +291,13 @@ const frontsBannerCollapseStyles = css`
 
 const frontsBannerAdStyles = css`
 	position: relative;
-	min-height: ${frontsBannerMinHeight}px;
-	/* No banner should be taller than 600px */
+	min-height: ${frontsBannerMinHeightTablet}px;
 	max-width: ${adSizes.leaderboard.width}px;
 	max-height: ${adSizes.leaderboard.height + labelHeight}px;
 	overflow: hidden;
 	padding-bottom: ${frontsBannerPaddingHeight}px;
 	${from.desktop} {
+		/* No banner should be taller than 600px */
 		max-height: ${600 + labelHeight}px;
 		max-width: ${breakpoints['wide']}px;
 	}

--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -261,7 +261,7 @@ const frontsBannerAdTopContainerStyles = css`
 	min-height: ${frontsBannerMinHeight}px;
 	background-color: ${palette.neutral[97]};
 
-	${until.desktop} {
+	${until.tablet} {
 		display: none;
 	}
 `;
@@ -293,6 +293,9 @@ const frontsBannerAdStyles = css`
 	max-width: ${breakpoints['wide']}px;
 	overflow: hidden;
 	padding-bottom: ${frontsBannerPaddingHeight}px;
+	${between.tablet.and.desktop} {
+		max-width: ${adSizes.leaderboard.width}px;
+	}
 `;
 
 const articleEndAdStyles = css`

--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -294,13 +294,13 @@ const frontsBannerAdStyles = css`
 	position: relative;
 	min-height: ${frontsBannerMinHeight}px;
 	/* No banner should be taller than 600px */
-	max-height: ${600 + labelHeight}px;
-	max-width: ${breakpoints['wide']}px;
+	max-width: ${adSizes.leaderboard.width}px;
+	max-height: ${adSizes.leaderboard.height + labelHeight}px;
 	overflow: hidden;
 	padding-bottom: ${frontsBannerPaddingHeight}px;
-	${between.tablet.and.desktop} {
-		max-width: ${adSizes.leaderboard.width}px;
-		max-height: ${90 + labelHeight}px;
+	${from.desktop} {
+		max-height: ${600 + labelHeight}px;
+		max-width: ${breakpoints['wide']}px;
 	}
 `;
 


### PR DESCRIPTION
## What does this change?
This PR adds `fronts-banner` on the `fronts` for the tablet breakpoint, using the `Leaderboard` size ad.

## Why?
Currently, we show fronts-banner ads from the desktop viewport (>=980px) and mobile ads up until the tablet viewport (<740px).

We wan to extend the advert banners to work in all breakpoints, to now include tablet.

This uses the same algorithm for `fronts-banner` and adds styling to detect the screen size and set a width accordingly, in order to request the desired leaderboard size.

**note: this relates to the change made in the `commercial` repo: https://github.com/guardian/commercial/pull/1285
## Screenshots

| Before | After  |
| ----------- | ---------- |
| <img width="300" alt="Screenshot 2024-02-28 at 13 20 39" src="https://github.com/guardian/dotcom-rendering/assets/49187886/b65f9a5d-c56e-4841-9a4a-22e2ad5cc5a3"> | <img width="300" alt="Screenshot 2024-02-28 at 13 21 40" src="https://github.com/guardian/dotcom-rendering/assets/49187886/3a7dd6b2-6eae-4a36-89ed-ee8f2a861bf8">
  |

| Goggletag View | 
| ----------- | 
| <img width="270" alt="Screenshot 2024-02-28 at 13 23 56" src="https://github.com/guardian/dotcom-rendering/assets/49187886/df52ff2d-4586-4d7a-aa4c-9d8fa8c0d2fd"> | 



<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

You can then reference the labels and map them to corresponding links.




[after2]: https://example.com/after2.png
-->


<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
