### PR TITLE
Adjust `article-rendering` instances

### DIFF
--- a/dotcom-rendering/cdk/bin/cdk.ts
+++ b/dotcom-rendering/cdk/bin/cdk.ts
@@ -41,8 +41,8 @@ new RenderingCDKStack(cdkApp, 'ArticleRendering-PROD', {
 	stage: 'PROD',
 	domainName: 'article-rendering.guardianapis.com',
 	scaling: {
-		minimumInstances: 24,
-		maximumInstances: 96,
+		minimumInstances: 30,
+		maximumInstances: 120,
 		policy: {
 			scalingStepsOut: [
 				// No scaling up effect when latency is lower than 0.2s
@@ -60,7 +60,7 @@ new RenderingCDKStack(cdkApp, 'ArticleRendering-PROD', {
 			],
 		},
 	},
-	instanceSize: InstanceSize.MEDIUM,
+	instanceSize: InstanceSize.SMALL,
 });
 
 /** Facia */


### PR DESCRIPTION
## What does this change?

- Use T4G small rather than medium since using a medium instance size did not appear to affect CPU or response times in a big way (see screenshots below)
- Increase minimum number of article instances from 24 to 30 to see the effect on latency and CPU usage

## Why?

Part of #10705 

## Screenshots

For both screenshots below, the vertical dotted line indicates the rough time of changing the instance size.

CPU utilisation graph for `article-rendering`:

<img width="1482" alt="Screenshot 2024-02-28 at 16 39 36" src="https://github.com/guardian/dotcom-rendering/assets/43961396/e5d067f6-2212-4ee8-b75f-e4978ac34743">


Response time graph for `article-rendering`:

<img width="1477" alt="Screenshot 2024-02-28 at 16 40 00" src="https://github.com/guardian/dotcom-rendering/assets/43961396/5a981ddb-5c2d-4798-b039-aeec91367efe">

