### PR TITLE
Swap `article-rendering` instance class to C7G 

### DIFF
--- a/dotcom-rendering/cdk/bin/cdk.ts
+++ b/dotcom-rendering/cdk/bin/cdk.ts
@@ -1,5 +1,5 @@
 import { App } from 'aws-cdk-lib';
-import { InstanceSize } from 'aws-cdk-lib/aws-ec2';
+import { InstanceClass, InstanceSize, InstanceType } from 'aws-cdk-lib/aws-ec2';
 import { DotcomRendering } from '../lib/dotcom-rendering';
 import { RenderingCDKStack } from '../lib/renderingStack';
 
@@ -34,7 +34,7 @@ new RenderingCDKStack(cdkApp, 'ArticleRendering-CODE', {
 	stage: 'CODE',
 	domainName: 'article-rendering.code.dev-guardianapis.com',
 	scaling: { minimumInstances: 1, maximumInstances: 4 },
-	instanceSize: InstanceSize.MICRO,
+	instanceType: InstanceType.of(InstanceClass.C7G, InstanceSize.MEDIUM),
 });
 new RenderingCDKStack(cdkApp, 'ArticleRendering-PROD', {
 	guApp: 'article-rendering',
@@ -60,7 +60,7 @@ new RenderingCDKStack(cdkApp, 'ArticleRendering-PROD', {
 			],
 		},
 	},
-	instanceSize: InstanceSize.MEDIUM,
+	instanceType: InstanceType.of(InstanceClass.C7G, InstanceSize.MEDIUM),
 });
 
 /** Facia */
@@ -69,7 +69,7 @@ new RenderingCDKStack(cdkApp, 'FaciaRendering-CODE', {
 	stage: 'CODE',
 	domainName: 'facia-rendering.code.dev-guardianapis.com',
 	scaling: { minimumInstances: 1, maximumInstances: 4 },
-	instanceSize: InstanceSize.MICRO,
+	instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.SMALL),
 });
 new RenderingCDKStack(cdkApp, 'FaciaRendering-PROD', {
 	guApp: 'facia-rendering',
@@ -95,7 +95,7 @@ new RenderingCDKStack(cdkApp, 'FaciaRendering-PROD', {
 			],
 		},
 	},
-	instanceSize: InstanceSize.MEDIUM,
+	instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
 });
 
 /** Interactive */
@@ -104,7 +104,7 @@ new RenderingCDKStack(cdkApp, 'InteractiveRendering-CODE', {
 	stage: 'CODE',
 	domainName: 'interactive-rendering.code.dev-guardianapis.com',
 	scaling: { minimumInstances: 1, maximumInstances: 4 },
-	instanceSize: InstanceSize.MICRO,
+	instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MICRO),
 });
 new RenderingCDKStack(cdkApp, 'InteractiveRendering-PROD', {
 	guApp: 'interactive-rendering',
@@ -130,5 +130,5 @@ new RenderingCDKStack(cdkApp, 'InteractiveRendering-PROD', {
 			],
 		},
 	},
-	instanceSize: InstanceSize.SMALL,
+	instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.SMALL),
 });

--- a/dotcom-rendering/cdk/lib/renderingStack.test.ts
+++ b/dotcom-rendering/cdk/lib/renderingStack.test.ts
@@ -1,6 +1,6 @@
 import { App } from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
-import { InstanceSize } from 'aws-cdk-lib/aws-ec2';
+import { InstanceClass, InstanceSize, InstanceType } from 'aws-cdk-lib/aws-ec2';
 import { RenderingCDKStack } from './renderingStack';
 
 /**
@@ -29,7 +29,10 @@ describe('The RenderingCDKStack', () => {
 					],
 				},
 			},
-			instanceSize: InstanceSize.MICRO,
+			instanceType: InstanceType.of(
+				InstanceClass.T4G,
+				InstanceSize.MICRO,
+			),
 		});
 		const template = Template.fromStack(stack);
 		expect(template.toJSON()).toMatchSnapshot();

--- a/dotcom-rendering/cdk/lib/renderingStack.ts
+++ b/dotcom-rendering/cdk/lib/renderingStack.ts
@@ -14,8 +14,8 @@ import type { ScalingInterval } from 'aws-cdk-lib/aws-applicationautoscaling';
 import { AdjustmentType, StepScalingPolicy } from 'aws-cdk-lib/aws-autoscaling';
 import { Metric } from 'aws-cdk-lib/aws-cloudwatch';
 import { SnsAction } from 'aws-cdk-lib/aws-cloudwatch-actions';
-import type { InstanceSize } from 'aws-cdk-lib/aws-ec2';
-import { InstanceClass, InstanceType, Peer } from 'aws-cdk-lib/aws-ec2';
+import type { InstanceType } from 'aws-cdk-lib/aws-ec2';
+import { Peer } from 'aws-cdk-lib/aws-ec2';
 import { Subscription, SubscriptionProtocol, Topic } from 'aws-cdk-lib/aws-sns';
 import { StringParameter } from 'aws-cdk-lib/aws-ssm';
 import { getUserData } from './userData';
@@ -23,7 +23,7 @@ import { getUserData } from './userData';
 export interface RenderingCDKStackProps extends Omit<GuStackProps, 'stack'> {
 	guApp: `${'article' | 'facia' | 'interactive'}-rendering`;
 	domainName: string;
-	instanceSize: InstanceSize;
+	instanceType: InstanceType;
 	scaling: GuAsgCapacity & {
 		policy?: {
 			scalingStepsOut: ScalingInterval[];
@@ -44,7 +44,7 @@ export class RenderingCDKStack extends CDKStack {
 		});
 
 		const { stack: guStack, region, account } = this;
-		const { guApp, stage, instanceSize, scaling, domainName } = props;
+		const { guApp, stage, instanceType, scaling, domainName } = props;
 
 		const artifactsBucket =
 			GuDistributionBucketParameter.getInstance(this).valueAsString;
@@ -83,7 +83,7 @@ export class RenderingCDKStack extends CDKStack {
 			// instead of the default 8080 which is unreachable.
 			certificateProps: { domainName },
 			healthcheck: { path: '/_healthcheck' },
-			instanceType: InstanceType.of(InstanceClass.T4G, instanceSize),
+			instanceType,
 			monitoringConfiguration,
 			roleConfiguration: {
 				additionalPolicies: [


### PR DESCRIPTION
## What does this change?

- Specifies `instanceType` as a CDK prop instead of just `instanceSize`, allowing us to have more control over the class of instance per app as well as just the size.
- Uses `C7G` medium for the `article-rendering` app


## Why?

Burstable instances want low CPU usage for most of the time, allowing for short periods of high traffic before returning to baseline. Despite upping to a medium size and increasing the number of instances running, the CPU usage does not fall within the range we want. We would need to use a T4G large instance in order to see benefits from the burstable instance type. Since this is more expensive than using a fixed instance type, it's worth exploring whether our app would be better suited to a fixed type.
