### PR TITLE
Remove mobileDiscussionAds switch and commercial comments event

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -48,7 +48,7 @@
 		"@guardian/bridget": "2.6.0",
 		"@guardian/browserslist-config": "6.1.0",
 		"@guardian/cdk": "50.13.0",
-		"@guardian/commercial": "17.0.0",
+		"@guardian/commercial": "17.1.0",
 		"@guardian/consent-management-platform": "13.11.1",
 		"@guardian/core-web-vitals": "6.0.0",
 		"@guardian/eslint-config": "7.0.1",

--- a/dotcom-rendering/src/components/Discussion.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion.stories.tsx
@@ -44,7 +44,6 @@ export const Basic: StoryObj = ({ format }: StoryProps) => {
 				discussionD2Uid="zHoBy6HNKsk"
 				discussionApiClientHeader="nextgen"
 				enableDiscussionSwitch={true}
-				enableMobileDiscussionAdsSwitch={true}
 				isAdFreeUser={false}
 				shouldHideAds={false}
 				idApiUrl="https://idapi.theguardian.com"
@@ -84,7 +83,6 @@ export const Overrides: StoryObj = ({ format }: StoryProps) => {
 				discussionD2Uid="zHoBy6HNKsk"
 				discussionApiClientHeader="nextgen"
 				enableDiscussionSwitch={true}
-				enableMobileDiscussionAdsSwitch={true}
 				isAdFreeUser={false}
 				shouldHideAds={false}
 				idApiUrl="https://idapi.theguardian.com"

--- a/dotcom-rendering/src/components/Discussion.tsx
+++ b/dotcom-rendering/src/components/Discussion.tsx
@@ -31,7 +31,6 @@ export type Props = {
 	discussionD2Uid: string;
 	discussionApiClientHeader: string;
 	enableDiscussionSwitch: boolean;
-	enableMobileDiscussionAdsSwitch: boolean;
 	user?: SignedInUser;
 	idApiUrl: string;
 	reportAbuseUnauthenticated: ReturnType<typeof reportAbuse>;
@@ -342,7 +341,6 @@ export const Discussion = ({
 	discussionD2Uid,
 	discussionApiClientHeader,
 	enableDiscussionSwitch,
-	enableMobileDiscussionAdsSwitch,
 	user,
 	idApiUrl,
 	reportAbuseUnauthenticated,
@@ -516,9 +514,6 @@ export const Discussion = ({
 						user !== undefined
 							? user.reportAbuse
 							: reportAbuseUnauthenticated
-					}
-					enableMobileDiscussionAdsSwitch={
-						enableMobileDiscussionAdsSwitch
 					}
 				/>
 				{!isExpanded && (

--- a/dotcom-rendering/src/components/Discussion.tsx
+++ b/dotcom-rendering/src/components/Discussion.tsx
@@ -422,11 +422,6 @@ export const Discussion = ({
 		return false;
 	};
 
-	const dispatchCommentsExpandedEvent = () => {
-		const event = new CustomEvent('comments-expanded');
-		document.dispatchEvent(event);
-	};
-
 	// Check the url to see if there is a comment hash, e.g. ...crisis#comment-139113120
 	// If so, make a call to get the context of this comment so we know what page it is
 	// on.
@@ -524,7 +519,6 @@ export const Discussion = ({
 				<PillarButton
 					onClick={() => {
 						dispatch({ type: 'expandComments' });
-						dispatchCommentsExpandedEvent();
 					}}
 					icon={<SvgPlus />}
 					linkName="view-more-comments"

--- a/dotcom-rendering/src/components/Discussion/Comments.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comments.stories.tsx
@@ -91,7 +91,6 @@ export const LoggedOutHiddenPicks = () => (
 			replyForm={defaultCommentForm}
 			bottomForm={defaultCommentForm}
 			reportAbuse={() => Promise.resolve(ok(true))}
-			enableMobileDiscussionAdsSwitch={true}
 		/>
 	</div>
 );
@@ -135,7 +134,6 @@ export const InitialPage = () => (
 			replyForm={defaultCommentForm}
 			bottomForm={defaultCommentForm}
 			reportAbuse={() => Promise.resolve(ok(true))}
-			enableMobileDiscussionAdsSwitch={true}
 		/>
 	</div>
 );
@@ -181,7 +179,6 @@ export const LoggedInHiddenNoPicks = () => {
 				replyForm={{ ...defaultCommentForm }}
 				bottomForm={defaultCommentForm}
 				reportAbuse={() => Promise.resolve(ok(true))}
-				enableMobileDiscussionAdsSwitch={true}
 			/>
 		</div>
 	);
@@ -222,7 +219,6 @@ export const LoggedIn = () => {
 				replyForm={defaultCommentForm}
 				bottomForm={defaultCommentForm}
 				reportAbuse={() => Promise.resolve(ok(true))}
-				enableMobileDiscussionAdsSwitch={true}
 			/>
 		</div>
 	);
@@ -262,7 +258,6 @@ export const LoggedInShortDiscussion = () => {
 				replyForm={defaultCommentForm}
 				bottomForm={defaultCommentForm}
 				reportAbuse={() => Promise.resolve(ok(true))}
-				enableMobileDiscussionAdsSwitch={true}
 			/>
 		</div>
 	);
@@ -299,7 +294,6 @@ export const LoggedOutHiddenNoPicks = () => (
 			replyForm={defaultCommentForm}
 			bottomForm={defaultCommentForm}
 			reportAbuse={() => Promise.resolve(ok(true))}
-			enableMobileDiscussionAdsSwitch={true}
 		/>
 	</div>
 );
@@ -345,7 +339,6 @@ export const Closed = () => (
 			replyForm={defaultCommentForm}
 			bottomForm={defaultCommentForm}
 			reportAbuse={() => Promise.resolve(ok(true))}
-			enableMobileDiscussionAdsSwitch={true}
 		/>
 	</div>
 );
@@ -387,7 +380,6 @@ export const NoComments = () => (
 			replyForm={defaultCommentForm}
 			bottomForm={defaultCommentForm}
 			reportAbuse={() => Promise.resolve(ok(true))}
-			enableMobileDiscussionAdsSwitch={true}
 		/>
 	</div>
 );
@@ -431,7 +423,6 @@ export const LegacyDiscussion = () => (
 			replyForm={defaultCommentForm}
 			bottomForm={defaultCommentForm}
 			reportAbuse={() => Promise.resolve(ok(true))}
-			enableMobileDiscussionAdsSwitch={true}
 		/>
 	</div>
 );

--- a/dotcom-rendering/src/components/Discussion/Comments.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comments.tsx
@@ -45,7 +45,6 @@ type Props = {
 	replyForm: CommentFormProps;
 	bottomForm: CommentFormProps;
 	reportAbuse: ReturnType<typeof reportAbuse>;
-	enableMobileDiscussionAdsSwitch: boolean;
 };
 
 const footerStyles = css`
@@ -124,7 +123,6 @@ export const Comments = ({
 	replyForm,
 	bottomForm,
 	reportAbuse,
-	enableMobileDiscussionAdsSwitch,
 }: Props) => {
 	const [picks, setPicks] = useState<Array<CommentType | ReplyType>>([]);
 	const [commentBeingRepliedTo, setCommentBeingRepliedTo] = useState<
@@ -223,11 +221,11 @@ export const Comments = ({
 	};
 
 	useEffect(() => {
-		if (isWeb && expanded && !loading && enableMobileDiscussionAdsSwitch) {
+		if (isWeb && expanded && !loading) {
 			const event = new CustomEvent('comments-loaded');
 			document.dispatchEvent(event);
 		}
-	}, [isWeb, expanded, loading, enableMobileDiscussionAdsSwitch]);
+	}, [isWeb, expanded, loading]);
 
 	useEffect(() => {
 		void getPicks(shortUrl).then((result) => {
@@ -273,9 +271,7 @@ export const Comments = ({
 			handleFilterChange(newFilterObject);
 		}
 
-		isWeb &&
-			enableMobileDiscussionAdsSwitch &&
-			dispatchCommentsStateChange();
+		isWeb && dispatchCommentsStateChange();
 	};
 
 	useEffect(() => {
@@ -307,9 +303,7 @@ export const Comments = ({
 
 	const onPageChange = (pageNumber: number) => {
 		setPage(pageNumber);
-		isWeb &&
-			enableMobileDiscussionAdsSwitch &&
-			dispatchCommentsStateChange();
+		isWeb && dispatchCommentsStateChange();
 	};
 
 	initialiseApi({ additionalHeaders, baseUrl, apiKey, idApiUrl });

--- a/dotcom-rendering/src/components/Discussion/Discussion.test.tsx
+++ b/dotcom-rendering/src/components/Discussion/Discussion.test.tsx
@@ -24,7 +24,6 @@ describe('App', () => {
 					discussionD2Uid="testD2Header"
 					discussionApiClientHeader="testClientHeader"
 					enableDiscussionSwitch={true}
-					enableMobileDiscussionAdsSwitch={true}
 					idApiUrl="https://idapi.theguardian.com"
 					reportAbuseUnauthenticated={() => Promise.resolve(ok(true))}
 				/>

--- a/dotcom-rendering/src/components/DiscussionLayout.tsx
+++ b/dotcom-rendering/src/components/DiscussionLayout.tsx
@@ -19,7 +19,6 @@ type Props = {
 	discussionD2Uid: string;
 	discussionApiClientHeader: string;
 	enableDiscussionSwitch: boolean;
-	enableMobileDiscussionAdsSwitch: boolean;
 	isAdFreeUser: boolean;
 	shouldHideAds: boolean;
 	idApiUrl: string;
@@ -35,7 +34,6 @@ const DiscussionIsland = ({
 	discussionD2Uid: string;
 	discussionApiClientHeader: string;
 	enableDiscussionSwitch: boolean;
-	enableMobileDiscussionAdsSwitch: boolean;
 	idApiUrl: string;
 }) => {
 	switch (renderingTarget) {
@@ -61,7 +59,6 @@ export const DiscussionLayout = ({
 	discussionD2Uid,
 	discussionApiClientHeader,
 	enableDiscussionSwitch,
-	enableMobileDiscussionAdsSwitch,
 	isAdFreeUser,
 	shouldHideAds,
 	idApiUrl,
@@ -111,9 +108,6 @@ export const DiscussionLayout = ({
 								discussionApiClientHeader
 							}
 							enableDiscussionSwitch={enableDiscussionSwitch}
-							enableMobileDiscussionAdsSwitch={
-								enableMobileDiscussionAdsSwitch
-							}
 							idApiUrl={idApiUrl}
 							renderingTarget={renderingTarget}
 						/>

--- a/dotcom-rendering/src/components/Island.test.tsx
+++ b/dotcom-rendering/src/components/Island.test.tsx
@@ -140,7 +140,6 @@ describe('Island: server-side rendering', () => {
 						discussionD2Uid="testD2Header"
 						discussionApiClientHeader="testClientHeader"
 						enableDiscussionSwitch={true}
-						enableMobileDiscussionAdsSwitch={true}
 						idApiUrl="https://idapi.theguardian.com"
 						format={{
 							theme: Pillar.News,

--- a/dotcom-rendering/src/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/layouts/CommentLayout.tsx
@@ -868,9 +868,6 @@ export const CommentLayout = (props: WebProps | AppsProps) => {
 							enableDiscussionSwitch={
 								!!article.config.switches.enableDiscussionSwitch
 							}
-							enableMobileDiscussionAdsSwitch={
-								!!article.config.switches.mobileDiscussionAds
-							}
 							isAdFreeUser={article.isAdFreeUser}
 							shouldHideAds={article.shouldHideAds}
 							idApiUrl={article.config.idApiUrl}

--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -893,9 +893,6 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 							enableDiscussionSwitch={
 								!!article.config.switches.enableDiscussionSwitch
 							}
-							enableMobileDiscussionAdsSwitch={
-								!!article.config.switches.mobileDiscussionAds
-							}
 							isAdFreeUser={article.isAdFreeUser}
 							shouldHideAds={article.shouldHideAds}
 							idApiUrl={article.config.idApiUrl}

--- a/dotcom-rendering/src/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/InteractiveLayout.tsx
@@ -808,9 +808,6 @@ export const InteractiveLayout = (props: WebProps | AppsProps) => {
 							enableDiscussionSwitch={
 								!!article.config.switches.enableDiscussionSwitch
 							}
-							enableMobileDiscussionAdsSwitch={
-								!!article.config.switches.mobileDiscussionAds
-							}
 							isAdFreeUser={article.isAdFreeUser}
 							shouldHideAds={article.shouldHideAds}
 							idApiUrl={article.config.idApiUrl}

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -1294,10 +1294,6 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 									!!article.config.switches
 										.enableDiscussionSwitch
 								}
-								enableMobileDiscussionAdsSwitch={
-									!!article.config.switches
-										.mobileDiscussionAds
-								}
 								isAdFreeUser={article.isAdFreeUser}
 								shouldHideAds={article.shouldHideAds}
 								idApiUrl={article.config.idApiUrl}

--- a/dotcom-rendering/src/layouts/PictureLayout.tsx
+++ b/dotcom-rendering/src/layouts/PictureLayout.tsx
@@ -759,9 +759,6 @@ export const PictureLayout = (props: WebProps | AppsProps) => {
 							enableDiscussionSwitch={
 								!!article.config.switches.enableDiscussionSwitch
 							}
-							enableMobileDiscussionAdsSwitch={
-								!!article.config.switches.mobileDiscussionAds
-							}
 							isAdFreeUser={article.isAdFreeUser}
 							shouldHideAds={article.shouldHideAds}
 							idApiUrl={article.config.idApiUrl}

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -867,9 +867,6 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 							enableDiscussionSwitch={
 								!!article.config.switches.enableDiscussionSwitch
 							}
-							enableMobileDiscussionAdsSwitch={
-								!!article.config.switches.mobileDiscussionAds
-							}
 							isAdFreeUser={article.isAdFreeUser}
 							shouldHideAds={article.shouldHideAds}
 							idApiUrl={article.config.idApiUrl}

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -957,9 +957,6 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 							enableDiscussionSwitch={
 								!!article.config.switches.enableDiscussionSwitch
 							}
-							enableMobileDiscussionAdsSwitch={
-								!!article.config.switches.mobileDiscussionAds
-							}
 							isAdFreeUser={article.isAdFreeUser}
 							shouldHideAds={article.shouldHideAds}
 							idApiUrl={article.config.idApiUrl}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -354,8 +354,8 @@ importers:
         specifier: 50.13.0
         version: 50.13.0(@swc/core@1.4.0)(@types/node@18.18.14)(aws-cdk-lib@2.100.0)(aws-cdk@2.100.0)(constructs@10.3.0)(typescript@5.3.3)
       '@guardian/commercial':
-        specifier: 17.0.0
-        version: 17.0.0(@guardian/ab-core@7.0.1)(@guardian/consent-management-platform@13.11.1)(@guardian/core-web-vitals@6.0.0)(@guardian/identity-auth-frontend@4.0.0)(@guardian/identity-auth@2.1.0)(@guardian/libs@16.0.1)(@guardian/source-foundations@14.1.4)(@guardian/support-dotcom-components@1.1.3)(typescript@5.3.3)
+        specifier: 17.1.0
+        version: 17.1.0(@guardian/ab-core@7.0.1)(@guardian/consent-management-platform@13.11.1)(@guardian/core-web-vitals@6.0.0)(@guardian/identity-auth-frontend@4.0.0)(@guardian/identity-auth@2.1.0)(@guardian/libs@16.0.1)(@guardian/source-foundations@14.1.4)(@guardian/support-dotcom-components@1.1.3)(typescript@5.3.3)
       '@guardian/consent-management-platform':
         specifier: 13.11.1
         version: 13.11.1(@guardian/libs@16.0.1)
@@ -4284,8 +4284,8 @@ packages:
       - typescript
     dev: false
 
-  /@guardian/commercial@17.0.0(@guardian/ab-core@7.0.1)(@guardian/consent-management-platform@13.11.1)(@guardian/core-web-vitals@6.0.0)(@guardian/identity-auth-frontend@4.0.0)(@guardian/identity-auth@2.1.0)(@guardian/libs@16.0.1)(@guardian/source-foundations@14.1.4)(@guardian/support-dotcom-components@1.1.3)(typescript@5.3.3):
-    resolution: {integrity: sha512-/TMTDQg4nTuuAyoI5IMU3DxexLptqWvmoMUv9dZg21yNd6WA072iMLFlTPlFr7333gHZeK0cotCdWyOdIbD0Rw==}
+  /@guardian/commercial@17.1.0(@guardian/ab-core@7.0.1)(@guardian/consent-management-platform@13.11.1)(@guardian/core-web-vitals@6.0.0)(@guardian/identity-auth-frontend@4.0.0)(@guardian/identity-auth@2.1.0)(@guardian/libs@16.0.1)(@guardian/source-foundations@14.1.4)(@guardian/support-dotcom-components@1.1.3)(typescript@5.3.3):
+    resolution: {integrity: sha512-gDX5r1w0LeOpUKlCPAp/KiS+IpH3DdHtrhua/xQJnG04evL4NGSheKh1mLfWcs830gk9hZYt8dDZoC+xoLyamQ==}
     peerDependencies:
       '@guardian/ab-core': ^7.0.1
       '@guardian/consent-management-platform': ^13.11.1


### PR DESCRIPTION
## What does this change?

1. Removes the usages of the `mobileDiscussionAds` switch.
2. Stops sending a custom event when the "View more comments" button is clicked. 

## Why?

1. We now need to send the `comments-loaded` event on desktop screen sizes now for the commercial code to add an ad slot in the right-hand column. We _could_ check the user's screen size, or we can just remove the switch, which is what we have decided to do. This switch remains in the commercial code, so ads will still not be added on mobile screens when the switch is off. Furthermore, mobile ads on comments are now live and went live without any issues, so it is unlikely we will need this switch going forward.
2. The commercial code now listens for the `comments-loaded` event to insert a `comments-expanded` ad slot on desktop screens. [Associated commercial PR here](https://github.com/guardian/commercial/pull/1288). This brings the behaviour inline with the logic that inserts ads on mobile pages