### PR TITLE
Fix deeply read link hover colour

### DIFF
--- a/dotcom-rendering/src/components/MostPopularFooterGrid.tsx
+++ b/dotcom-rendering/src/components/MostPopularFooterGrid.tsx
@@ -83,6 +83,10 @@ const descriptionStyle = css`
 	line-height: 125%;
 	color: ${palette.neutral[46]};
 	overflow-wrap: break-word;
+
+	&:hover a {
+		color: ${palette.neutral[7]};
+	}
 `;
 
 const displayContent = css`


### PR DESCRIPTION
## What does this change?

Corrects the hover colour for the deeply read explainer link
Fixes https://github.com/guardian/dotcom-rendering/issues/10781

## Why?

Design: https://www.figma.com/proto/UkxMfTjHuxY4stmfFh2McC/Deeply-read-(homepage-component)?page-id=4672%3A204&type=design&node-id=4681-662&viewport=-420%2C398%2C0.52&t=JqFtSd7o7APCYUfO-1&scaling=min-zoom&starting-point-node-id=4681%3A662&show-proto-sidebar=1

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/1229808/22c0899a-ba15-4a0a-ad0c-deb724944911
[after]: https://github.com/guardian/dotcom-rendering/assets/1229808/aba870cb-2b04-45c1-b65d-17fb9a684589
