### PR TITLE
Discussion sign in for apps

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -45,7 +45,7 @@
 		"@emotion/server": "11.11.0",
 		"@guardian/ab-core": "7.0.1",
 		"@guardian/braze-components": "18.1.0",
-		"@guardian/bridget": "3.0.0",
+		"@guardian/bridget": "4.0.0",
 		"@guardian/browserslist-config": "6.1.0",
 		"@guardian/cdk": "50.13.0",
 		"@guardian/commercial": "17.9.0",

--- a/dotcom-rendering/playwright/tests/signedin.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/signedin.e2e.spec.ts
@@ -2,7 +2,7 @@ import { expect, test } from '@playwright/test';
 import { Standard as standardArticle } from '../../fixtures/generated/fe-articles/Standard';
 import { disableCMP } from '../lib/cmp';
 import { addCookie } from '../lib/cookies';
-// import { waitForIsland } from '../lib/islands';
+import { waitForIsland } from '../lib/islands';
 import { loadPageNoOkta } from '../lib/load-page';
 import { stubResponse } from '../lib/network';
 
@@ -114,22 +114,22 @@ test.describe('Signed in readers', () => {
 		);
 	});
 
-	// test('should not display signed in texts when users are not signed in', async ({
-	// 	context,
-	// 	page,
-	// }) => {
-	// 	await disableCMP(context);
-	// 	await loadPageNoOkta(page, standardArticle);
+	test('should not display signed in texts when users are not signed in', async ({
+		context,
+		page,
+	}) => {
+		await disableCMP(context);
+		await loadPageNoOkta(page, standardArticle);
 
-	// 	await waitForIsland(page, 'DiscussionWeb');
+		await waitForIsland(page, 'DiscussionWeb');
 
-	// 	// Check that the discussion container is showing the reader as signed out
-	// 	const discussionText = await page
-	// 		.locator('[data-testid=discussion]')
-	// 		.textContent();
+		// Check that the discussion container is showing the reader as signed out
+		const discussionText = await page
+			.locator('[data-testid=discussion]')
+			.textContent();
 
-	// 	expect(discussionText).toContain(
-	// 		'Sign in or create your Guardian account to join the discussion',
-	// 	);
-	// });
+		expect(discussionText).toContain(
+			'Sign in or create your Guardian account to join the discussion',
+		);
+	});
 });

--- a/dotcom-rendering/playwright/tests/signedin.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/signedin.e2e.spec.ts
@@ -2,7 +2,7 @@ import { expect, test } from '@playwright/test';
 import { Standard as standardArticle } from '../../fixtures/generated/fe-articles/Standard';
 import { disableCMP } from '../lib/cmp';
 import { addCookie } from '../lib/cookies';
-import { waitForIsland } from '../lib/islands';
+// import { waitForIsland } from '../lib/islands';
 import { loadPageNoOkta } from '../lib/load-page';
 import { stubResponse } from '../lib/network';
 
@@ -114,22 +114,22 @@ test.describe('Signed in readers', () => {
 		);
 	});
 
-	test('should not display signed in texts when users are not signed in', async ({
-		context,
-		page,
-	}) => {
-		await disableCMP(context);
-		await loadPageNoOkta(page, standardArticle);
+	// test('should not display signed in texts when users are not signed in', async ({
+	// 	context,
+	// 	page,
+	// }) => {
+	// 	await disableCMP(context);
+	// 	await loadPageNoOkta(page, standardArticle);
 
-		await waitForIsland(page, 'DiscussionWeb');
+	// 	await waitForIsland(page, 'DiscussionWeb');
 
-		// Check that the discussion container is showing the reader as signed out
-		const discussionText = await page
-			.locator('[data-testid=discussion]')
-			.textContent();
+	// 	// Check that the discussion container is showing the reader as signed out
+	// 	const discussionText = await page
+	// 		.locator('[data-testid=discussion]')
+	// 		.textContent();
 
-		expect(discussionText).toContain(
-			'Sign in or create your Guardian account to join the discussion',
-		);
-	});
+	// 	expect(discussionText).toContain(
+	// 		'Sign in or create your Guardian account to join the discussion',
+	// 	);
+	// });
 });

--- a/dotcom-rendering/src/components/DiscussionApps.importable.tsx
+++ b/dotcom-rendering/src/components/DiscussionApps.importable.tsx
@@ -1,6 +1,6 @@
 import { DiscussionResponseType } from '@guardian/bridget';
 import { useEffect, useState } from 'react';
-import { getDiscussionClient } from '../lib/bridgetApi';
+import { getDiscussionClient, getUserClient } from '../lib/bridgetApi';
 import type { Reader, UserProfile } from '../lib/discussion';
 import type { CommentResponse } from '../lib/discussionApi';
 import { reportAbuse as reportAbuseWeb } from '../lib/discussionApi';
@@ -71,7 +71,13 @@ export const DiscussionApps = (props: Props) => {
 	const [user, setUser] = useState<Reader>();
 
 	useEffect(() => {
-		void getUser().then(setUser);
+		void getUserClient()
+			.isSignedIn()
+			.then((signedIn) => {
+				if (signedIn) {
+					void getUser().then(setUser);
+				}
+			});
 	}, [setUser]);
 
 	return (

--- a/dotcom-rendering/src/components/Island.test.tsx
+++ b/dotcom-rendering/src/components/Island.test.tsx
@@ -118,11 +118,16 @@ describe('Island: server-side rendering', () => {
 	test('DiscussionMeta', () => {
 		expect(() =>
 			renderToString(
-				<DiscussionMeta
-					discussionApiUrl={''}
-					shortUrlId={''}
-					enableDiscussionSwitch={false}
-				/>,
+				<ConfigProvider
+					value={{ renderingTarget: 'Web', darkModeAvailable: false }}
+				>
+					<DiscussionMeta
+						discussionApiUrl={''}
+						shortUrlId={''}
+						enableDiscussionSwitch={false}
+					/>
+					,
+				</ConfigProvider>,
 			),
 		).not.toThrow();
 	});

--- a/dotcom-rendering/src/components/SignedInAs.tsx
+++ b/dotcom-rendering/src/components/SignedInAs.tsx
@@ -127,10 +127,17 @@ const Heading = ({ count }: { count?: number }) => {
 };
 
 const signIn = async (): Promise<void> => {
-	void getUserClient().signIn(
-		SignInScreenReason.accessDiscussion,
-		SignInScreenReferrer.accessDiscussion,
-	);
+	console.log('signing in...');
+	void getUserClient()
+		.signIn(
+			SignInScreenReason.accessDiscussion,
+			SignInScreenReferrer.accessDiscussion,
+		)
+		.then((signedIn) => {
+			signedIn
+				? console.log('sign in successful')
+				: console.log('sign in failed');
+		});
 };
 
 export const SignedInAs = ({
@@ -147,7 +154,7 @@ export const SignedInAs = ({
 	const SignInApps = () => {
 		return (
 			<>
-				<LinkButton onClick={signIn}>sign in</LinkButton> or{' '}
+				<LinkButton onClick={signIn}>Sign in</LinkButton> or{' '}
 				<LinkButton onClick={signIn}>
 					create your Guardian account
 				</LinkButton>{' '}
@@ -164,7 +171,7 @@ export const SignedInAs = ({
 					)}`}
 					css={linkStyles}
 				>
-					sign in
+					Sign in
 				</a>
 				or
 				<a

--- a/dotcom-rendering/src/components/SignedInAs.tsx
+++ b/dotcom-rendering/src/components/SignedInAs.tsx
@@ -1,4 +1,6 @@
 import { css } from '@emotion/react';
+import { SignInScreenReason } from '@guardian/bridget/SignInScreenReason';
+import { SignInScreenReferrer } from '@guardian/bridget/SignInScreenReferrer';
 import {
 	headline,
 	palette as sourcePalette,
@@ -6,9 +8,11 @@ import {
 	textSans,
 	until,
 } from '@guardian/source-foundations';
+import { getUserClient } from '../lib/bridgetApi';
 import type { UserProfile } from '../lib/discussion';
 import { createAuthenticationEventParams } from '../lib/identity-component-event';
 import { palette as themePalette } from '../palette';
+import { useConfig } from './ConfigContext';
 
 type Props = {
 	commentCount?: number;
@@ -80,6 +84,33 @@ const rowUntilDesktop = css`
 	}
 `;
 
+const linkButton = css`
+	background: none;
+	border: none;
+	padding: 0;
+	font: inherit;
+	cursor: pointer;
+	outline: none;
+`;
+
+const LinkButton = ({
+	onClick,
+	children,
+}: {
+	onClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
+	children: string;
+}) => {
+	return (
+		<button
+			css={[linkButton, linkStyles]}
+			className="link-button"
+			onClick={onClick}
+		>
+			{children}
+		</button>
+	);
+};
+
 const Heading = ({ count }: { count?: number }) => {
 	return (
 		<h2 css={headingStyles}>
@@ -95,6 +126,13 @@ const Heading = ({ count }: { count?: number }) => {
 	);
 };
 
+const signIn = async (): Promise<void> => {
+	void getUserClient().signIn(
+		SignInScreenReason.accessDiscussion,
+		SignInScreenReferrer.accessDiscussion,
+	);
+};
+
 export const SignedInAs = ({
 	commentCount,
 	enableDiscussionSwitch,
@@ -102,6 +140,44 @@ export const SignedInAs = ({
 	isClosedForComments,
 }: Props) => {
 	const isBanned = user?.privateFields && !user.privateFields.canPostComment;
+	const { renderingTarget } = useConfig();
+	const isWeb = renderingTarget === 'Web';
+	const isApps = renderingTarget === 'Apps';
+
+	const SignInApps = () => {
+		return (
+			<>
+				<LinkButton onClick={signIn}>sign in</LinkButton> or{' '}
+				<LinkButton onClick={signIn}>
+					create your Guardian account
+				</LinkButton>{' '}
+			</>
+		);
+	};
+
+	const SignInWeb = () => {
+		return (
+			<>
+				<a
+					href={`https://profile.theguardian.com/signin?INTCMP=DOTCOM_COMMENTS_SIGNIN&${createAuthenticationEventParams(
+						'signin_to_comment',
+					)}`}
+					css={linkStyles}
+				>
+					sign in
+				</a>
+				or
+				<a
+					href={`https://profile.theguardian.com/register?INTCMP=DOTCOM_COMMENTS_REG&${createAuthenticationEventParams(
+						'register_to_comment',
+					)}`}
+					css={linkStyles}
+				>
+					create your Guardian account
+				</a>{' '}
+			</>
+		);
+	};
 
 	if (!enableDiscussionSwitch) {
 		// Discussion is disabled sitewide and user is signed in
@@ -121,23 +197,8 @@ export const SignedInAs = ({
 				<Heading count={commentCount} />
 				<span css={headlineStyles}>
 					Commenting has been disabled at this time but you can still{' '}
-					<a
-						href={`https://profile.theguardian.com/signin?INTCMP=DOTCOM_COMMENTS_SIGNIN&${createAuthenticationEventParams(
-							'signin_to_comment',
-						)}`}
-						css={linkStyles}
-					>
-						sign in
-					</a>{' '}
-					or{' '}
-					<a
-						href={`https://profile.theguardian.com/register?INTCMP=DOTCOM_COMMENTS_REG&${createAuthenticationEventParams(
-							'register_to_comment',
-						)}`}
-						css={linkStyles}
-					>
-						create your Guardian account
-					</a>{' '}
+					{isWeb && SignInWeb()}
+					{isApps && SignInApps()}
 					to join the discussion when it&apos;s back
 				</span>
 			</div>
@@ -182,23 +243,8 @@ export const SignedInAs = ({
 				<Heading count={commentCount} />
 				<span css={headlineStyles}>
 					This discussion is now closed for comments but you can still{' '}
-					<a
-						href={`https://profile.theguardian.com/signin?INTCMP=DOTCOM_COMMENTS_SIGNIN&${createAuthenticationEventParams(
-							'signin_to_comment',
-						)}`}
-						css={linkStyles}
-					>
-						sign in
-					</a>{' '}
-					or{' '}
-					<a
-						href={`https://profile.theguardian.com/register?INTCMP=DOTCOM_COMMENTS_REG&${createAuthenticationEventParams(
-							'register_to_comment',
-						)}`}
-						css={linkStyles}
-					>
-						create your Guardian account
-					</a>{' '}
+					{isWeb && SignInWeb()}
+					{isApps && SignInApps()}
 					to join the discussion next time
 				</span>
 			</div>
@@ -211,23 +257,8 @@ export const SignedInAs = ({
 			<div css={containerStyles}>
 				<Heading count={commentCount} />
 				<span css={headlineStyles}>
-					<a
-						href={`https://profile.theguardian.com/signin?INTCMP=DOTCOM_COMMENTS_SIGNIN&${createAuthenticationEventParams(
-							'signin_to_comment',
-						)}`}
-						css={linkStyles}
-					>
-						Sign in
-					</a>{' '}
-					or{' '}
-					<a
-						href={`https://profile.theguardian.com/register?INTCMP=DOTCOM_COMMENTS_REG&${createAuthenticationEventParams(
-							'register_to_comment',
-						)}`}
-						css={linkStyles}
-					>
-						create your Guardian account
-					</a>{' '}
+					{isWeb && SignInWeb()}
+					{isApps && SignInApps()}
 					to join the discussion
 				</span>
 			</div>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -345,8 +345,8 @@ importers:
         specifier: 18.1.0
         version: 18.1.0(@emotion/react@11.11.1)(@guardian/libs@16.1.0)(@guardian/source-foundations@14.1.4)(@guardian/source-react-components-development-kitchen@19.0.0)(@guardian/source-react-components@22.0.1)(react@18.2.0)
       '@guardian/bridget':
-        specifier: 3.0.0
-        version: 3.0.0
+        specifier: 4.0.0
+        version: 4.0.0
       '@guardian/browserslist-config':
         specifier: 6.1.0
         version: 6.1.0(browserslist@4.21.9)(tslib@2.6.2)
@@ -4271,8 +4271,8 @@ packages:
     resolution: {integrity: sha512-kYlRZC5/9ImY2wQJfnteanjfLclmSU0wcsyt2CWl5YXHmc3gGnxZM+H/Y6KVqwxj0v5cGrvUuFJ7Zvk570dchQ==}
     dev: false
 
-  /@guardian/bridget@3.0.0:
-    resolution: {integrity: sha512-mXmju3+PB3frDmvBt5D/HkFwCXdGarRsNsgPpKH9XGzTIRAwS25kQbmeRURkchEG1LAQQsIuv9KfZJRPQwetHQ==}
+  /@guardian/bridget@4.0.0:
+    resolution: {integrity: sha512-U31oGUqCLTdPHPIuvn+y0hQfW0eQkrVZgUEvvjQGHBeFZhjwr9N4zCvCDFNcYydU4bocakO+O5jrUasGqCJ23g==}
     dev: false
 
   /@guardian/browserslist-config@6.1.0(browserslist@4.21.9)(tslib@2.6.2):


### PR DESCRIPTION
## What does this change?

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
