### PR TITLE
AMP Handlers Use `ArticleFormat`

### DIFF
--- a/dotcom-rendering/src/components/Elements.amp.tsx
+++ b/dotcom-rendering/src/components/Elements.amp.tsx
@@ -1,4 +1,8 @@
-import { isNonNullable } from '@guardian/libs';
+import {
+	ArticleDesign,
+	type ArticleFormat,
+	isNonNullable,
+} from '@guardian/libs';
 import { NotRenderableInDCR } from '../lib/errors/not-renderable-in-dcr';
 import type { Switches } from '../types/config';
 import type { FEElement } from '../types/content';
@@ -66,13 +70,13 @@ export const isAmpSupported = ({
 	switches,
 	main,
 }: {
-	format: FEFormat;
+	format: ArticleFormat;
 	tags: TagType[];
 	elements: FEElement[];
 	switches: Switches;
 	main: string;
 }): boolean => {
-	if (format.design === 'InteractiveDesign') {
+	if (format.design === ArticleDesign.Interactive) {
 		const hasAmpInteractiveTag = tags.some(
 			(tag) => tag.id === 'tracking/platformfunctional/ampinteractive',
 		);
@@ -92,7 +96,7 @@ export const isAmpSupported = ({
 			return false;
 	}
 
-	if (format.design === 'LiveBlogDesign') {
+	if (format.design === ArticleDesign.LiveBlog) {
 		const isSwitchedOn = switches.ampLiveblogSwitch;
 		if (!isSwitchedOn) return false;
 	}

--- a/dotcom-rendering/src/server/handler.article.amp.tsx
+++ b/dotcom-rendering/src/server/handler.article.amp.tsx
@@ -1,9 +1,11 @@
+import { ArticleDesign } from '@guardian/libs';
 import type { RequestHandler } from 'express';
 import { Standard as ExampleArticle } from '../../fixtures/generated/articles/Standard';
 import type { AnalyticsModel } from '../components/Analytics.amp';
 import { AmpArticlePage } from '../components/ArticlePage.amp';
 import { isAmpSupported } from '../components/Elements.amp';
 import type { PermutiveModel } from '../components/Permutive.amp';
+import { decideFormat } from '../lib/decideFormat';
 import { enhance } from '../lib/enhance.amp';
 import { NotRenderableInDCR } from '../lib/errors/not-renderable-in-dcr';
 import { generatePermutivePayload } from '../lib/permutive.amp';
@@ -19,10 +21,11 @@ export const handleAMPArticle: RequestHandler = ({ body }, res, next) => {
 	(async () => {
 		recordTypeAndPlatform('article', 'amp');
 		const article = validateAsArticleType(body);
+		const format = decideFormat(article.format);
 
 		if (
-			article.format.design === 'InteractiveDesign' ||
-			article.format.design === 'FullPageInteractiveDesign'
+			format.design === ArticleDesign.Interactive ||
+			format.design === ArticleDesign.FullPageInteractive
 		) {
 			throw new NotRenderableInDCR();
 		}
@@ -35,7 +38,7 @@ export const handleAMPArticle: RequestHandler = ({ body }, res, next) => {
 
 		if (
 			!isAmpSupported({
-				format: article.format,
+				format,
 				tags: article.tags,
 				elements,
 				switches: article.config.switches,

--- a/dotcom-rendering/src/server/render.article.web.tsx
+++ b/dotcom-rendering/src/server/render.article.web.tsx
@@ -153,15 +153,15 @@ export const renderHtml = ({
 
 	const getAmpLink = (tags: TagType[]) => {
 		if (
-			article.format.design === 'InteractiveDesign' ||
-			article.format.design === 'FullPageInteractiveDesign'
+			format.design === ArticleDesign.Interactive ||
+			format.design === ArticleDesign.FullPageInteractive
 		) {
 			return undefined;
 		}
 
 		if (
 			!isAmpSupported({
-				format: article.format,
+				format,
 				tags,
 				elements: article.blocks.flatMap((block) => block.elements),
 				switches: article.config.switches,


### PR DESCRIPTION
Part of a series of changes to get DCR using `ArticleFormat` exclusively, rather than a mix of that and `FEFormat`.
