### PR TITLE
`DCRArticle` Uses `ArticleFormat`

### DIFF
--- a/dotcom-rendering/fixtures/generated/articles/Analysis.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Analysis.ts
@@ -1140,9 +1140,9 @@ export const Analysis: DCRArticle = {
 	designType: 'Analysis',
 	editionId: 'UK',
 	format: {
-		design: 'AnalysisDesign',
-		theme: 'NewsPillar',
-		display: 'StandardDisplay',
+		display: 0,
+		theme: 0,
+		design: 6,
 	},
 	openGraphData: {
 		'og:url':

--- a/dotcom-rendering/fixtures/generated/articles/Audio.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Audio.ts
@@ -1277,9 +1277,9 @@ export const Audio: DCRArticle = {
 	designType: 'Article',
 	editionId: 'UK',
 	format: {
-		design: 'ArticleDesign',
-		theme: 'NewsPillar',
-		display: 'StandardDisplay',
+		display: 0,
+		theme: 0,
+		design: 0,
 	},
 	openGraphData: {
 		'og:url':

--- a/dotcom-rendering/fixtures/generated/articles/Comment.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Comment.ts
@@ -1188,9 +1188,9 @@ export const Comment: DCRArticle = {
 	designType: 'Comment',
 	editionId: 'UK',
 	format: {
-		design: 'CommentDesign',
-		theme: 'OpinionPillar',
-		display: 'StandardDisplay',
+		display: 0,
+		theme: 1,
+		design: 8,
 	},
 	openGraphData: {
 		'og:url':

--- a/dotcom-rendering/fixtures/generated/articles/Dead.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Dead.ts
@@ -1321,9 +1321,9 @@ export const Dead: DCRArticle = {
 	designType: 'Article',
 	editionId: 'UK',
 	format: {
-		design: 'DeadBlogDesign',
-		theme: 'NewsPillar',
-		display: 'StandardDisplay',
+		display: 0,
+		theme: 0,
+		design: 12,
 	},
 	openGraphData: {
 		'og:url':

--- a/dotcom-rendering/fixtures/generated/articles/Editorial.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Editorial.ts
@@ -1123,9 +1123,9 @@ export const Editorial: DCRArticle = {
 	designType: 'GuardianView',
 	editionId: 'UK',
 	format: {
-		design: 'CommentDesign',
-		theme: 'OpinionPillar',
-		display: 'StandardDisplay',
+		display: 0,
+		theme: 1,
+		design: 8,
 	},
 	openGraphData: {
 		'og:url':

--- a/dotcom-rendering/fixtures/generated/articles/Explainer.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Explainer.ts
@@ -1212,9 +1212,9 @@ export const Explainer: DCRArticle = {
 	designType: 'Article',
 	editionId: 'UK',
 	format: {
-		design: 'ExplainerDesign',
-		theme: 'NewsPillar',
-		display: 'StandardDisplay',
+		display: 0,
+		theme: 0,
+		design: 7,
 	},
 	openGraphData: {
 		'og:url':

--- a/dotcom-rendering/fixtures/generated/articles/Feature.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Feature.ts
@@ -1113,9 +1113,9 @@ export const Feature: DCRArticle = {
 	designType: 'Feature',
 	editionId: 'UK',
 	format: {
-		design: 'FeatureDesign',
-		theme: 'CulturePillar',
-		display: 'StandardDisplay',
+		display: 0,
+		theme: 3,
+		design: 10,
 	},
 	openGraphData: {
 		'og:url':

--- a/dotcom-rendering/fixtures/generated/articles/Gallery.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Gallery.ts
@@ -1277,9 +1277,9 @@ export const Gallery: DCRArticle = {
 	designType: 'Article',
 	editionId: 'UK',
 	format: {
-		design: 'ArticleDesign',
-		theme: 'NewsPillar',
-		display: 'StandardDisplay',
+		display: 0,
+		theme: 0,
+		design: 0,
 	},
 	openGraphData: {
 		'og:url':

--- a/dotcom-rendering/fixtures/generated/articles/Interview.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Interview.ts
@@ -1307,9 +1307,9 @@ export const Interview: DCRArticle = {
 	designType: 'Interview',
 	editionId: 'UK',
 	format: {
-		design: 'InterviewDesign',
-		theme: 'NewsPillar',
-		display: 'ShowcaseDisplay',
+		display: 2,
+		theme: 0,
+		design: 15,
 	},
 	openGraphData: {
 		'og:url':

--- a/dotcom-rendering/fixtures/generated/articles/Labs.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Labs.ts
@@ -1082,9 +1082,9 @@ export const Labs: DCRArticle = {
 	designType: 'AdvertisementFeature',
 	editionId: 'UK',
 	format: {
-		design: 'PhotoEssayDesign',
-		theme: 'Labs',
-		display: 'ImmersiveDisplay',
+		display: 1,
+		theme: 6,
+		design: 19,
 	},
 	openGraphData: {
 		'og:url':

--- a/dotcom-rendering/fixtures/generated/articles/Letter.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Letter.ts
@@ -1069,9 +1069,9 @@ export const Letter: DCRArticle = {
 	designType: 'Comment',
 	editionId: 'UK',
 	format: {
-		design: 'LetterDesign',
-		theme: 'OpinionPillar',
-		display: 'StandardDisplay',
+		display: 0,
+		theme: 1,
+		design: 9,
 	},
 	openGraphData: {
 		'og:url':

--- a/dotcom-rendering/fixtures/generated/articles/Live.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Live.ts
@@ -1321,9 +1321,9 @@ export const Live: DCRArticle = {
 	designType: 'Article',
 	editionId: 'UK',
 	format: {
-		design: 'LiveBlogDesign',
-		theme: 'NewsPillar',
-		display: 'StandardDisplay',
+		display: 0,
+		theme: 0,
+		design: 11,
 	},
 	openGraphData: {
 		'og:url':

--- a/dotcom-rendering/fixtures/generated/articles/LiveBlogSingleContributor.ts
+++ b/dotcom-rendering/fixtures/generated/articles/LiveBlogSingleContributor.ts
@@ -1253,9 +1253,9 @@ export const LiveBlogSingleContributor: DCRArticle = {
 	designType: 'Article',
 	editionId: 'UK',
 	format: {
-		design: 'LiveBlogDesign',
-		theme: 'NewsPillar',
-		display: 'StandardDisplay',
+		display: 0,
+		theme: 0,
+		design: 11,
 	},
 	openGraphData: {
 		'og:url':

--- a/dotcom-rendering/fixtures/generated/articles/MatchReport.ts
+++ b/dotcom-rendering/fixtures/generated/articles/MatchReport.ts
@@ -1110,9 +1110,9 @@ export const MatchReport: DCRArticle = {
 	designType: 'MatchReport',
 	editionId: 'UK',
 	format: {
-		design: 'MatchReportDesign',
-		theme: 'SportPillar',
-		display: 'StandardDisplay',
+		display: 0,
+		theme: 2,
+		design: 14,
 	},
 	openGraphData: {
 		'og:url':

--- a/dotcom-rendering/fixtures/generated/articles/NewsletterSignup.ts
+++ b/dotcom-rendering/fixtures/generated/articles/NewsletterSignup.ts
@@ -1105,9 +1105,9 @@ export const NewsletterSignup: DCRArticle = {
 	designType: 'Article',
 	editionId: 'UK',
 	format: {
-		design: 'NewsletterSignupDesign',
-		theme: 'SportPillar',
-		display: 'StandardDisplay',
+		display: 0,
+		theme: 2,
+		design: 24,
 	},
 	openGraphData: {
 		'og:url':

--- a/dotcom-rendering/fixtures/generated/articles/NumberedList.ts
+++ b/dotcom-rendering/fixtures/generated/articles/NumberedList.ts
@@ -1397,9 +1397,9 @@ export const NumberedList: DCRArticle = {
 	designType: 'Review',
 	editionId: 'UK',
 	format: {
-		design: 'ReviewDesign',
-		theme: 'NewsPillar',
-		display: 'NumberedListDisplay',
+		display: 3,
+		theme: 0,
+		design: 5,
 	},
 	openGraphData: {
 		'og:url':

--- a/dotcom-rendering/fixtures/generated/articles/PhotoEssay.ts
+++ b/dotcom-rendering/fixtures/generated/articles/PhotoEssay.ts
@@ -1085,9 +1085,9 @@ export const PhotoEssay: DCRArticle = {
 	designType: 'Feature',
 	editionId: 'UK',
 	format: {
-		design: 'PhotoEssayDesign',
-		theme: 'LifestylePillar',
-		display: 'ImmersiveDisplay',
+		display: 1,
+		theme: 4,
+		design: 19,
 	},
 	openGraphData: {
 		'og:url':

--- a/dotcom-rendering/fixtures/generated/articles/Picture.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Picture.ts
@@ -1103,9 +1103,9 @@ export const Picture: DCRArticle = {
 	designType: 'Comment',
 	editionId: 'UK',
 	format: {
-		design: 'PictureDesign',
-		theme: 'OpinionPillar',
-		display: 'ShowcaseDisplay',
+		display: 2,
+		theme: 1,
+		design: 1,
 	},
 	openGraphData: {
 		'og:url':

--- a/dotcom-rendering/fixtures/generated/articles/PrintShop.ts
+++ b/dotcom-rendering/fixtures/generated/articles/PrintShop.ts
@@ -1076,9 +1076,9 @@ export const PrintShop: DCRArticle = {
 	designType: 'Immersive',
 	editionId: 'UK',
 	format: {
-		design: 'PrintShopDesign',
-		theme: 'CulturePillar',
-		display: 'ImmersiveDisplay',
+		display: 1,
+		theme: 3,
+		design: 20,
 	},
 	openGraphData: {
 		'og:url':

--- a/dotcom-rendering/fixtures/generated/articles/Quiz.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Quiz.ts
@@ -1115,9 +1115,9 @@ export const Quiz: DCRArticle = {
 	designType: 'Quiz',
 	editionId: 'UK',
 	format: {
-		design: 'QuizDesign',
-		theme: 'SportPillar',
-		display: 'ShowcaseDisplay',
+		display: 2,
+		theme: 2,
+		design: 17,
 	},
 	openGraphData: {
 		'og:url':

--- a/dotcom-rendering/fixtures/generated/articles/Recipe.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Recipe.ts
@@ -1182,9 +1182,9 @@ export const Recipe: DCRArticle = {
 	designType: 'Recipe',
 	editionId: 'UK',
 	format: {
-		design: 'RecipeDesign',
-		theme: 'LifestylePillar',
-		display: 'StandardDisplay',
+		display: 0,
+		theme: 4,
+		design: 13,
 	},
 	openGraphData: {
 		'og:url':

--- a/dotcom-rendering/fixtures/generated/articles/Review.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Review.ts
@@ -1141,9 +1141,9 @@ export const Review: DCRArticle = {
 	designType: 'Review',
 	editionId: 'UK',
 	format: {
-		design: 'ReviewDesign',
-		theme: 'CulturePillar',
-		display: 'ShowcaseDisplay',
+		display: 2,
+		theme: 3,
+		design: 5,
 	},
 	openGraphData: {
 		'og:url':

--- a/dotcom-rendering/fixtures/generated/articles/SpecialReport.ts
+++ b/dotcom-rendering/fixtures/generated/articles/SpecialReport.ts
@@ -1422,9 +1422,9 @@ export const SpecialReport: DCRArticle = {
 	designType: 'Analysis',
 	editionId: 'UK',
 	format: {
-		design: 'AnalysisDesign',
-		theme: 'SpecialReportTheme',
-		display: 'StandardDisplay',
+		display: 0,
+		theme: 5,
+		design: 6,
 	},
 	openGraphData: {
 		'og:url':

--- a/dotcom-rendering/fixtures/generated/articles/Standard.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Standard.ts
@@ -1277,9 +1277,9 @@ export const Standard: DCRArticle = {
 	designType: 'Article',
 	editionId: 'UK',
 	format: {
-		design: 'ArticleDesign',
-		theme: 'NewsPillar',
-		display: 'StandardDisplay',
+		display: 0,
+		theme: 0,
+		design: 0,
 	},
 	openGraphData: {
 		'og:url':

--- a/dotcom-rendering/fixtures/generated/articles/Video.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Video.ts
@@ -1277,9 +1277,9 @@ export const Video: DCRArticle = {
 	designType: 'Article',
 	editionId: 'UK',
 	format: {
-		design: 'ArticleDesign',
-		theme: 'NewsPillar',
-		display: 'StandardDisplay',
+		display: 0,
+		theme: 0,
+		design: 0,
 	},
 	openGraphData: {
 		'og:url':

--- a/dotcom-rendering/src/layouts/DecideLayout.stories.tsx
+++ b/dotcom-rendering/src/layouts/DecideLayout.stories.tsx
@@ -1,4 +1,10 @@
-import { isObject } from '@guardian/libs';
+import {
+	ArticleDesign,
+	ArticleDisplay,
+	ArticleSpecial,
+	isObject,
+	Pillar,
+} from '@guardian/libs';
 import { breakpoints } from '@guardian/source-foundations';
 import type { Decorator, StoryObj } from '@storybook/react';
 import { useEffect } from 'react';
@@ -14,7 +20,6 @@ import { Picture as PictureShowcaseOpinionFixture } from '../../fixtures/generat
 import { Recipe as RecipeStandardLifestyleFixture } from '../../fixtures/generated/articles/Recipe';
 import { Standard as StandardStandardNewsFixture } from '../../fixtures/generated/articles/Standard';
 import { embedIframe } from '../client/embedIframe';
-import { decideFormat } from '../lib/decideFormat';
 import { getCurrentPillar } from '../lib/layoutHelpers';
 import { mockRESTCalls } from '../lib/mockRESTCalls';
 import { extractNAV } from '../model/extract-nav';
@@ -39,7 +44,7 @@ const HydratedLayout: Decorator<
 	DecideLayoutProps & HydratedLayoutDecoratorArgs
 > = (Story, context) => {
 	const { article } = context.args;
-	const format: ArticleFormat = decideFormat(article.format);
+	const format: ArticleFormat = article.format;
 	const colourScheme =
 		(isObject(context.parameters.config) &&
 		context.parameters.config.renderingTarget === 'Apps'
@@ -137,7 +142,7 @@ const standardImmersiveNewsFixture: DCRArticle = {
 	...StandardStandardNewsFixture,
 	format: {
 		...StandardStandardNewsFixture.format,
-		display: 'ImmersiveDisplay',
+		display: ArticleDisplay.Immersive,
 	},
 };
 
@@ -198,7 +203,7 @@ const standardStandardLabsFixture: DCRArticle = {
 	...StandardStandardNewsFixture,
 	format: {
 		...StandardStandardNewsFixture.format,
-		theme: 'Labs',
+		theme: ArticleSpecial.Labs,
 	},
 };
 
@@ -231,7 +236,7 @@ export const WebFeatureStandardLabsLight: Story = {
 			...FeatureStandardCultureFixture,
 			format: {
 				...FeatureStandardCultureFixture.format,
-				theme: 'Labs',
+				theme: ArticleSpecial.Labs,
 			},
 		},
 	},
@@ -244,7 +249,7 @@ export const WebRecipeStandardLabsLight: Story = {
 			...RecipeStandardLifestyleFixture,
 			format: {
 				...RecipeStandardLifestyleFixture.format,
-				theme: 'Labs',
+				theme: ArticleSpecial.Labs,
 			},
 		},
 	},
@@ -294,7 +299,7 @@ const liveBlogStandardSportFixture: DCRArticle = {
 	...LiveBlogStandardNewsFixture,
 	format: {
 		...LiveBlogStandardNewsFixture.format,
-		theme: 'SportPillar',
+		theme: Pillar.Sport,
 	},
 };
 
@@ -318,7 +323,7 @@ const liveBlogStandardSpecialReportFixture: DCRArticle = {
 	...LiveBlogStandardNewsFixture,
 	format: {
 		...LiveBlogStandardNewsFixture.format,
-		theme: 'SpecialReportTheme',
+		theme: ArticleSpecial.SpecialReport,
 	},
 };
 
@@ -342,7 +347,7 @@ const liveBlogStandardSpecialReportAltFixture: DCRArticle = {
 	...LiveBlogStandardNewsFixture,
 	format: {
 		...LiveBlogStandardNewsFixture.format,
-		theme: 'SpecialReportAltTheme',
+		theme: ArticleSpecial.SpecialReportAlt,
 	},
 };
 
@@ -389,7 +394,7 @@ const commentStandardNewsFixture: DCRArticle = {
 	...CommentStandardOpinionFixture,
 	format: {
 		...CommentStandardOpinionFixture.format,
-		theme: 'NewsPillar',
+		theme: Pillar.News,
 	},
 };
 
@@ -413,7 +418,7 @@ const interactiveStandardNewsFixture: DCRArticle = {
 	...StandardStandardNewsFixture,
 	format: {
 		...StandardStandardNewsFixture.format,
-		design: 'InteractiveDesign',
+		design: ArticleDesign.Interactive,
 	},
 };
 
@@ -453,7 +458,7 @@ const analysisStandardCultureFixture: DCRArticle = {
 	...AnalysisStandardNewsFixture,
 	format: {
 		...AnalysisStandardNewsFixture.format,
-		theme: 'CulturePillar',
+		theme: Pillar.Culture,
 	},
 };
 

--- a/dotcom-rendering/src/lib/article.ts
+++ b/dotcom-rendering/src/lib/article.ts
@@ -49,6 +49,7 @@ export const enhanceArticleType = (
 
 	return {
 		...data,
+		format,
 		mainMediaElements,
 		blocks: enhancedBlocks,
 		pinnedPost: enhancePinnedPost(format, renderingTarget, data.pinnedPost),

--- a/dotcom-rendering/src/model/enhance-blockquotes.test.ts
+++ b/dotcom-rendering/src/model/enhance-blockquotes.test.ts
@@ -1,12 +1,11 @@
 import { ArticleDesign, type ArticleFormat } from '@guardian/libs';
 import { Standard as ExampleArticle } from '../../fixtures/generated/articles/Standard';
 import { blockMetaData } from '../../fixtures/manual/block-meta-data';
-import { decideFormat } from '../lib/decideFormat';
 import type { DCRArticle } from '../types/frontend';
 import { enhanceBlockquotes } from './enhance-blockquotes';
 
 const example: DCRArticle = ExampleArticle;
-const exampleFormat: ArticleFormat = decideFormat(example.format);
+const exampleFormat: ArticleFormat = example.format;
 
 const formatIsPhotoEssay: ArticleFormat = {
 	...exampleFormat,

--- a/dotcom-rendering/src/model/enhance-images.test.ts
+++ b/dotcom-rendering/src/model/enhance-images.test.ts
@@ -3,11 +3,10 @@ import { PhotoEssay } from '../../fixtures/generated/articles/PhotoEssay';
 import { Standard as ExampleArticle } from '../../fixtures/generated/articles/Standard';
 import { images } from '../../fixtures/generated/images';
 import { blockMetaData } from '../../fixtures/manual/block-meta-data';
-import { decideFormat } from '../lib/decideFormat';
 import { enhanceImages } from './enhance-images';
 
-const exampleArticleFormat = decideFormat(ExampleArticle.format);
-const photoEssayFormat = decideFormat(PhotoEssay.format);
+const exampleArticleFormat = ExampleArticle.format;
+const photoEssayFormat = PhotoEssay.format;
 
 const image = {
 	...images[0],

--- a/dotcom-rendering/src/model/enhance-numbered-lists.test.ts
+++ b/dotcom-rendering/src/model/enhance-numbered-lists.test.ts
@@ -2,11 +2,10 @@ import { NumberedList } from '../../fixtures/generated/articles/NumberedList';
 import { Standard as ExampleArticle } from '../../fixtures/generated/articles/Standard';
 import { images } from '../../fixtures/generated/images';
 import { blockMetaData } from '../../fixtures/manual/block-meta-data';
-import { decideFormat } from '../lib/decideFormat';
 import { enhanceNumberedLists } from './enhance-numbered-lists';
 
-const exampleArticleFormat = decideFormat(ExampleArticle.format);
-const numberedListFormat = decideFormat(NumberedList.format);
+const exampleArticleFormat = ExampleArticle.format;
+const numberedListFormat = NumberedList.format;
 
 describe('Enhance Numbered Lists', () => {
 	it('does not enhance articles if they are not numbered lists', () => {

--- a/dotcom-rendering/src/model/extract-ga.test.ts
+++ b/dotcom-rendering/src/model/extract-ga.test.ts
@@ -1,5 +1,4 @@
 import { Standard as ExampleArticle } from '../../fixtures/generated/articles/Standard';
-import { decideFormat } from '../lib/decideFormat';
 import { extractGA } from './extract-ga';
 
 const pillar: LegacyPillar = 'news';
@@ -33,7 +32,7 @@ const article = {
 		},
 	],
 	...base,
-	format: decideFormat(ExampleArticle.format),
+	format: ExampleArticle.format,
 };
 
 describe('Google Analytics extracts and formats CAPIArticle response correctly', () => {

--- a/dotcom-rendering/src/model/insertPromotedNewsletter.test.ts
+++ b/dotcom-rendering/src/model/insertPromotedNewsletter.test.ts
@@ -1,7 +1,6 @@
 import { Live as exampleLiveBlog } from '../../fixtures/generated/articles/Live';
 import { Quiz as exampleQuiz } from '../../fixtures/generated/articles/Quiz';
 import { Standard as exampleStandard } from '../../fixtures/generated/articles/Standard';
-import { decideFormat } from '../lib/decideFormat';
 import type {
 	Newsletter,
 	NewsletterSignupBlockElement,
@@ -24,7 +23,7 @@ describe('Insert Newsletter Signups', () => {
 	it('inserts a NewsletterSignupBlockElement to a standard article if there is a newsletter', () => {
 		const insertedBlock = insertPromotedNewsletter(
 			exampleStandard.blocks,
-			decideFormat(exampleStandard.format),
+			exampleStandard.format,
 			NEWSLETTER,
 		)
 			.flatMap((block) => block.elements)
@@ -44,7 +43,7 @@ describe('Insert Newsletter Signups', () => {
 		expect(
 			insertPromotedNewsletter(
 				exampleLiveBlog.blocks,
-				decideFormat(exampleLiveBlog.format),
+				exampleLiveBlog.format,
 				NEWSLETTER,
 			)
 				.flatMap((block) => block.elements)
@@ -60,7 +59,7 @@ describe('Insert Newsletter Signups', () => {
 		expect(
 			insertPromotedNewsletter(
 				exampleQuiz.blocks,
-				decideFormat(exampleQuiz.format),
+				exampleQuiz.format,
 				NEWSLETTER,
 			)
 				.flatMap((block) => block.elements)

--- a/dotcom-rendering/src/server/render.article.amp.test.tsx
+++ b/dotcom-rendering/src/server/render.article.amp.test.tsx
@@ -3,6 +3,7 @@ import { Standard as ExampleArticle } from '../../fixtures/generated/articles/St
 import type { AnalyticsModel } from '../components/Analytics.amp';
 import { AmpArticlePage } from '../components/ArticlePage.amp';
 import type { PermutiveModel } from '../components/Permutive.amp';
+import { formatToFEFormat } from '../lib/format';
 import { extractNAV } from '../model/extract-nav';
 import { renderArticle } from './render.article.amp';
 
@@ -60,7 +61,11 @@ test('produces valid AMP doc', async () => {
 		<AmpArticlePage
 			experimentsData={{}}
 			nav={nav}
-			articleData={{ ...ExampleArticle, shouldHideReaderRevenue: false }}
+			articleData={{
+				...ExampleArticle,
+				format: formatToFEFormat(ExampleArticle.format),
+				shouldHideReaderRevenue: false,
+			}}
 			config={config}
 			analytics={analytics}
 			permutive={permutive}

--- a/dotcom-rendering/src/server/render.article.apps.tsx
+++ b/dotcom-rendering/src/server/render.article.apps.tsx
@@ -6,7 +6,6 @@ import {
 	generateScriptTags,
 	getPathFromManifest,
 } from '../lib/assets';
-import { decideFormat } from '../lib/decideFormat';
 import { renderToStringWithEmotion } from '../lib/emotion';
 import { createGuardian } from '../model/guardian';
 import type { Config } from '../types/configContext';
@@ -20,7 +19,7 @@ export const renderArticle = (
 	prefetchScripts: string[];
 	html: string;
 } => {
-	const format: ArticleFormat = decideFormat(article.format);
+	const format: ArticleFormat = article.format;
 
 	const renderingTarget = 'Apps';
 	const config: Config = {

--- a/dotcom-rendering/src/server/render.article.web.tsx
+++ b/dotcom-rendering/src/server/render.article.web.tsx
@@ -10,7 +10,6 @@ import {
 	getPathFromManifest,
 } from '../lib/assets';
 import { decideFormat } from '../lib/decideFormat';
-import { decideTheme } from '../lib/decideTheme';
 import { isEditionId } from '../lib/edition';
 import { renderToStringWithEmotion } from '../lib/emotion';
 import { getCurrentPillar } from '../lib/layoutHelpers';
@@ -29,7 +28,7 @@ interface Props {
 }
 
 const decideTitle = (article: DCRArticle): string => {
-	if (decideTheme(article.format) === Pillar.Opinion && article.byline) {
+	if (article.format.theme === Pillar.Opinion && article.byline) {
 		return `${article.headline} | ${article.byline} | The Guardian`;
 	}
 	return `${article.headline} | ${article.sectionLabel} | The Guardian`;
@@ -46,7 +45,7 @@ export const renderHtml = ({
 	const title = decideTitle(article);
 	const linkedData = article.linkedData;
 
-	const format: ArticleFormat = decideFormat(article.format);
+	const format = article.format;
 
 	const renderingTarget = 'Web';
 	const config: Config = { renderingTarget, darkModeAvailable: false };

--- a/dotcom-rendering/src/types/frontend.ts
+++ b/dotcom-rendering/src/types/frontend.ts
@@ -1,3 +1,4 @@
+import type { ArticleFormat } from '@guardian/libs';
 import type { SharedAdTargeting } from '../lib/ad-targeting';
 import type { EditionId } from '../lib/edition';
 import type { ImageForAppsLightbox } from '../model/appsLightboxImages';
@@ -136,7 +137,8 @@ type PageTypeType = {
  * The `DCRArticle` type models the `FEArticleType` in addition to any enhancements DCR makes after
  * receiving the data from Frontend.
  */
-export type DCRArticle = FEArticleType & {
+export type DCRArticle = Omit<FEArticleType, 'format'> & {
+	format: ArticleFormat;
 	imagesForLightbox: ImageForLightbox[];
 	imagesForAppsLightbox: ImageForAppsLightbox[];
 	tableOfContents?: TableOfContentsItem[];


### PR DESCRIPTION
Part of a series of changes to get DCR using `ArticleFormat` exclusively, rather than a mix of that and `FEFormat`. This changes the `format` field in `DCRArticle` to be of type `ArticleFormat` instead of `FEFormat`.

Most of the files changed are fixtures, updating the content of the `format` field.
