### PR TITLE
Validate Blocks Only When Needed

### DIFF
--- a/dotcom-rendering/src/model/enhanceBlocks.ts
+++ b/dotcom-rendering/src/model/enhanceBlocks.ts
@@ -12,7 +12,6 @@ import { enhanceInteractiveContentsElements } from './enhance-interactive-conten
 import { enhanceNumberedLists } from './enhance-numbered-lists';
 import { enhanceTweets } from './enhance-tweets';
 import { insertPromotedNewsletter } from './insertPromotedNewsletter';
-import { validateAsBlock } from './validate';
 
 class BlockEnhancer {
 	blocks: Block[];
@@ -112,9 +111,8 @@ export const enhanceBlocks = (
 	blocks: Block[],
 	format: ArticleFormat,
 	options: Options,
-): Block[] => {
-	for (const block of blocks) validateAsBlock(block);
-	return new BlockEnhancer(blocks, format, options)
+): Block[] =>
+	new BlockEnhancer(blocks, format, options)
 		.enhanceDividers()
 		.enhanceH2s()
 		.enhanceInteractiveContentsElements()
@@ -126,4 +124,3 @@ export const enhanceBlocks = (
 		.enhanceTweets()
 		.enhanceNewsletterSignup()
 		.enhanceAdPlaceholders().blocks;
-};

--- a/dotcom-rendering/src/server/handler.article.web.ts
+++ b/dotcom-rendering/src/server/handler.article.web.ts
@@ -3,6 +3,7 @@ import { Standard as ExampleArticle } from '../../fixtures/generated/articles/St
 import { enhanceArticleType } from '../lib/article';
 import { decideFormat } from '../lib/decideFormat';
 import { enhanceBlocks } from '../model/enhanceBlocks';
+import { validateAsBlock } from '../model/validate';
 import type { FEBlocksRequest } from '../types/frontend';
 import { makePrefetchHeader } from './lib/header';
 import { recordTypeAndPlatform } from './lib/logging-store';
@@ -69,6 +70,7 @@ export const handleBlocks: RequestHandler = ({ body }, res) => {
 	} =
 		// The content if body is not checked
 		body as FEBlocksRequest;
+	for (const block of blocks) validateAsBlock(block);
 
 	const enhancedBlocks = enhanceBlocks(blocks, decideFormat(format), {
 		renderingTarget: 'Web',


### PR DESCRIPTION
In most cases, calls to `enhanceBlocks` occur after the blocks have already been validated. This change updates where the validation happens, so that it's only run when needed.
