### PR TITLE
Simplify `enhanceBlocks`

### DIFF
--- a/dotcom-rendering/src/model/enhance-ad-placeholders.test.ts
+++ b/dotcom-rendering/src/model/enhance-ad-placeholders.test.ts
@@ -1,3 +1,4 @@
+import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
 import { blockMetaData } from '../../fixtures/manual/block-meta-data';
 import type {
 	AdPlaceholderBlockElement,
@@ -6,6 +7,12 @@ import type {
 	TextBlockElement,
 } from '../types/content';
 import { enhanceAdPlaceholders } from './enhance-ad-placeholders';
+
+const exampleFormat = {
+	design: ArticleDesign.Feature,
+	display: ArticleDisplay.Immersive,
+	theme: Pillar.Culture,
+};
 
 // Test helper functions
 
@@ -82,7 +89,7 @@ describe('Enhancing ad placeholders', () => {
 				},
 			];
 
-			const output = enhanceAdPlaceholders(input);
+			const output = enhanceAdPlaceholders(exampleFormat, 'Apps')(input);
 			const outputElements = getElementsFromBlocks(output);
 			const placeholderIndices = outputElements.flatMap((el, idx) =>
 				elementIsAdPlaceholder(el) ? [idx] : [],
@@ -118,7 +125,7 @@ describe('Enhancing ad placeholders', () => {
 			},
 		];
 
-		const output = enhanceAdPlaceholders(input);
+		const output = enhanceAdPlaceholders(exampleFormat, 'Apps')(input);
 		const outputElements = getElementsFromBlocks(output);
 		const outputPlaceholders = outputElements.filter(
 			elementIsAdPlaceholder,

--- a/dotcom-rendering/src/model/enhance-ad-placeholders.ts
+++ b/dotcom-rendering/src/model/enhance-ad-placeholders.ts
@@ -1,4 +1,6 @@
+import { ArticleDesign } from '@guardian/libs';
 import type { AdPlaceholderBlockElement, FEElement } from '../types/content';
+import type { RenderingTarget } from '../types/renderingTarget';
 
 /**
  * Positioning rules:
@@ -97,8 +99,14 @@ const insertAdPlaceholders = (elements: FEElement[]): FEElement[] => {
 	return elementsWithReducerContext.elements;
 };
 
-export const enhanceAdPlaceholders = (blocks: Block[]): Block[] =>
-	blocks.map((b) => ({
-		...b,
-		elements: insertAdPlaceholders(b.elements),
-	}));
+export const enhanceAdPlaceholders =
+	(format: ArticleFormat, renderingTarget: RenderingTarget) =>
+	(blocks: Block[]): Block[] =>
+		renderingTarget === 'Apps' &&
+		format.design !== ArticleDesign.LiveBlog &&
+		format.design !== ArticleDesign.DeadBlog
+			? blocks.map((b) => ({
+					...b,
+					elements: insertAdPlaceholders(b.elements),
+			  }))
+			: blocks;

--- a/dotcom-rendering/src/model/enhance-blockquotes.test.ts
+++ b/dotcom-rendering/src/model/enhance-blockquotes.test.ts
@@ -15,10 +15,10 @@ const formatIsPhotoEssay: ArticleFormat = {
 
 describe('Enhancing blockquotes', () => {
 	it('creates an identical but new object when no changes are needed', () => {
-		expect(enhanceBlockquotes(example.blocks, exampleFormat)).not.toBe(
+		expect(enhanceBlockquotes(exampleFormat)(example.blocks)).not.toBe(
 			example.blocks,
 		); // We created a new object
-		expect(enhanceBlockquotes(example.blocks, exampleFormat)).toEqual(
+		expect(enhanceBlockquotes(exampleFormat)(example.blocks)).toEqual(
 			example.blocks,
 		); // The new object is what we expect
 	});
@@ -51,7 +51,7 @@ describe('Enhancing blockquotes', () => {
 			},
 		];
 
-		expect(enhanceBlockquotes(input, exampleFormat)).toEqual(
+		expect(enhanceBlockquotes(exampleFormat)(input)).toEqual(
 			expectedOutput,
 		);
 	});
@@ -83,7 +83,7 @@ describe('Enhancing blockquotes', () => {
 			},
 		];
 
-		expect(enhanceBlockquotes(input, formatIsPhotoEssay)).toEqual(
+		expect(enhanceBlockquotes(formatIsPhotoEssay)(input)).toEqual(
 			expectedOutput,
 		);
 	});
@@ -116,7 +116,7 @@ describe('Enhancing blockquotes', () => {
 			},
 		];
 
-		expect(enhanceBlockquotes(input, formatIsPhotoEssay)).toEqual(
+		expect(enhanceBlockquotes(formatIsPhotoEssay)(input)).toEqual(
 			expectedOutput,
 		);
 	});
@@ -148,7 +148,7 @@ describe('Enhancing blockquotes', () => {
 			},
 		];
 
-		expect(enhanceBlockquotes(input, exampleFormat)).toEqual(
+		expect(enhanceBlockquotes(exampleFormat)(input)).toEqual(
 			expectedOutput,
 		);
 	});
@@ -180,7 +180,7 @@ describe('Enhancing blockquotes', () => {
 			},
 		];
 
-		expect(enhanceBlockquotes(input, exampleFormat)).toEqual(
+		expect(enhanceBlockquotes(exampleFormat)(input)).toEqual(
 			expectedOutput,
 		);
 	});
@@ -223,7 +223,7 @@ describe('Enhancing blockquotes', () => {
 			},
 		];
 
-		expect(enhanceBlockquotes(input, exampleFormat)).toEqual(
+		expect(enhanceBlockquotes(exampleFormat)(input)).toEqual(
 			expectedOutput,
 		);
 	});

--- a/dotcom-rendering/src/model/enhance-blockquotes.ts
+++ b/dotcom-rendering/src/model/enhance-blockquotes.ts
@@ -40,16 +40,15 @@ const enhance = (elements: FEElement[], isPhotoEssay: boolean): FEElement[] =>
 		}
 	});
 
-export const enhanceBlockquotes = (
-	blocks: Block[],
-	format: ArticleFormat,
-): Block[] => {
-	const isPhotoEssay = format.design === ArticleDesign.PhotoEssay;
+export const enhanceBlockquotes =
+	(format: ArticleFormat) =>
+	(blocks: Block[]): Block[] => {
+		const isPhotoEssay = format.design === ArticleDesign.PhotoEssay;
 
-	return blocks.map((block: Block) => {
-		return {
-			...block,
-			elements: enhance(block.elements, isPhotoEssay || false),
-		};
-	});
-};
+		return blocks.map((block: Block) => {
+			return {
+				...block,
+				elements: enhance(block.elements, isPhotoEssay || false),
+			};
+		});
+	};

--- a/dotcom-rendering/src/model/enhance-images.test.ts
+++ b/dotcom-rendering/src/model/enhance-images.test.ts
@@ -53,7 +53,7 @@ describe('Enhance Images', () => {
 				},
 			];
 
-			expect(enhanceImages(input, photoEssayFormat, [])).toEqual(
+			expect(enhanceImages(photoEssayFormat, [])(input)).toEqual(
 				expectedOutput,
 			);
 		});
@@ -110,7 +110,7 @@ describe('Enhance Images', () => {
 				},
 			];
 
-			expect(enhanceImages(input, photoEssayFormat, [])).toEqual(
+			expect(enhanceImages(photoEssayFormat, [])(input)).toEqual(
 				expectedOutput,
 			);
 		});
@@ -160,7 +160,7 @@ describe('Enhance Images', () => {
 				},
 			];
 
-			expect(enhanceImages(input, photoEssayFormat, [])).toEqual(
+			expect(enhanceImages(photoEssayFormat, [])(input)).toEqual(
 				expectedOutput,
 			);
 		});
@@ -199,7 +199,7 @@ describe('Enhance Images', () => {
 				},
 			];
 
-			expect(enhanceImages(input, photoEssayFormat, [])).toEqual(
+			expect(enhanceImages(photoEssayFormat, [])(input)).toEqual(
 				expectedOutput,
 			);
 		});
@@ -237,7 +237,7 @@ describe('Enhance Images', () => {
 				},
 			];
 
-			expect(enhanceImages(input, photoEssayFormat, [])).toEqual(
+			expect(enhanceImages(photoEssayFormat, [])(input)).toEqual(
 				expectedOutput,
 			);
 		});
@@ -291,7 +291,7 @@ describe('Enhance Images', () => {
 				},
 			];
 
-			expect(enhanceImages(input, photoEssayFormat, [])).toEqual(
+			expect(enhanceImages(photoEssayFormat, [])(input)).toEqual(
 				expectedOutput,
 			);
 		});
@@ -358,7 +358,7 @@ describe('Enhance Images', () => {
 				},
 			];
 
-			expect(enhanceImages(input, photoEssayFormat, [])).toEqual(
+			expect(enhanceImages(photoEssayFormat, [])(input)).toEqual(
 				expectedOutput,
 			);
 		});
@@ -412,7 +412,7 @@ describe('Enhance Images', () => {
 				},
 			];
 
-			expect(enhanceImages(input, photoEssayFormat, [])).toEqual(
+			expect(enhanceImages(photoEssayFormat, [])(input)).toEqual(
 				expectedOutput,
 			);
 		});
@@ -442,7 +442,7 @@ describe('Enhance Images', () => {
 				},
 			];
 
-			expect(enhanceImages(input, photoEssayFormat, [])).toEqual(
+			expect(enhanceImages(photoEssayFormat, [])(input)).toEqual(
 				expectedOutput,
 			);
 		});
@@ -517,7 +517,7 @@ describe('Enhance Images', () => {
 				},
 			];
 
-			expect(enhanceImages(input, photoEssayFormat, [])).toEqual(
+			expect(enhanceImages(photoEssayFormat, [])(input)).toEqual(
 				expectedOutput,
 			);
 		});
@@ -570,7 +570,7 @@ describe('Enhance Images', () => {
 				},
 			];
 
-			expect(enhanceImages(input, photoEssayFormat, [])).toEqual(
+			expect(enhanceImages(photoEssayFormat, [])(input)).toEqual(
 				expectedOutput,
 			);
 		});
@@ -597,7 +597,7 @@ describe('Enhance Images', () => {
 				},
 			];
 
-			expect(enhanceImages(input, exampleArticleFormat, [])).toEqual(
+			expect(enhanceImages(exampleArticleFormat, [])(input)).toEqual(
 				expectedOutput,
 			);
 		});
@@ -665,7 +665,7 @@ describe('Enhance Images', () => {
 				},
 			];
 
-			expect(enhanceImages(input, exampleArticleFormat, [])).toEqual(
+			expect(enhanceImages(exampleArticleFormat, [])(input)).toEqual(
 				expectedOutput,
 			);
 		});
@@ -706,7 +706,7 @@ describe('Enhance Images', () => {
 			];
 
 			expect(
-				enhanceImages(input, photoEssayFormat, [
+				enhanceImages(photoEssayFormat, [
 					{
 						masterUrl:
 							'https://media.guim.co.uk/7cffd9d6809318a9d92c719c473d193caf95d601/0_0_3110_2074/master/3110.jpg',
@@ -715,7 +715,7 @@ describe('Enhance Images', () => {
 						height: 2074,
 						position: 4,
 					},
-				]),
+				])(input),
 			).toEqual(expectedOutput);
 		});
 
@@ -768,7 +768,7 @@ describe('Enhance Images', () => {
 				},
 			];
 
-			expect(enhanceImages(input, exampleArticleFormat, [])).toEqual(
+			expect(enhanceImages(exampleArticleFormat, [])(input)).toEqual(
 				expectedOutput,
 			);
 		});
@@ -816,7 +816,7 @@ describe('Enhance Images', () => {
 				},
 			];
 
-			expect(enhanceImages(input, exampleArticleFormat, [])).toEqual(
+			expect(enhanceImages(exampleArticleFormat, [])(input)).toEqual(
 				expectedOutput,
 			);
 		});
@@ -839,7 +839,7 @@ describe('Enhance Images', () => {
 
 			const expectedOutput = input;
 
-			expect(enhanceImages(input, exampleArticleFormat, [])).toEqual(
+			expect(enhanceImages(exampleArticleFormat, [])(input)).toEqual(
 				expectedOutput,
 			);
 		});
@@ -863,7 +863,7 @@ describe('Enhance Images', () => {
 
 			const expectedOutput = input;
 
-			expect(enhanceImages(input, exampleArticleFormat, [])).toEqual(
+			expect(enhanceImages(exampleArticleFormat, [])(input)).toEqual(
 				expectedOutput,
 			);
 		});
@@ -885,7 +885,7 @@ describe('Enhance Images', () => {
 
 			const expectedOutput = input;
 
-			expect(enhanceImages(input, exampleArticleFormat, [])).toEqual(
+			expect(enhanceImages(exampleArticleFormat, [])(input)).toEqual(
 				expectedOutput,
 			);
 		});
@@ -938,7 +938,7 @@ describe('Enhance Images', () => {
 				},
 			];
 
-			expect(enhanceImages(input, exampleArticleFormat, [])).toEqual(
+			expect(enhanceImages(exampleArticleFormat, [])(input)).toEqual(
 				expectedOutput,
 			);
 		});
@@ -996,7 +996,7 @@ describe('Enhance Images', () => {
 				},
 			];
 
-			expect(enhanceImages(input, exampleArticleFormat, [])).toEqual(
+			expect(enhanceImages(exampleArticleFormat, [])(input)).toEqual(
 				expectedOutput,
 			);
 		});

--- a/dotcom-rendering/src/model/enhance-images.ts
+++ b/dotcom-rendering/src/model/enhance-images.ts
@@ -429,23 +429,21 @@ const enhance = (
 	);
 };
 
-export const enhanceImages = (
-	blocks: Block[],
-	format: ArticleFormat,
-	imagesForLightbox: ImageForLightbox[],
-): Block[] => {
-	const isPhotoEssay = format.design === ArticleDesign.PhotoEssay;
+export const enhanceImages =
+	(format: ArticleFormat, imagesForLightbox: ImageForLightbox[]) =>
+	(blocks: Block[]): Block[] => {
+		const isPhotoEssay = format.design === ArticleDesign.PhotoEssay;
 
-	return blocks.map((block: Block) => {
-		return {
-			...block,
-			elements: enhance(block.elements, {
-				isPhotoEssay,
-				imagesForLightbox,
-			}),
-		};
-	});
-};
+		return blocks.map((block: Block) => {
+			return {
+				...block,
+				elements: enhance(block.elements, {
+					isPhotoEssay,
+					imagesForLightbox,
+				}),
+			};
+		});
+	};
 
 export const enhanceElementsImages = (
 	elements: FEElement[],

--- a/dotcom-rendering/src/model/enhance-numbered-lists.test.ts
+++ b/dotcom-rendering/src/model/enhance-numbered-lists.test.ts
@@ -32,7 +32,7 @@ describe('Enhance Numbered Lists', () => {
 				],
 			},
 		];
-		expect(enhanceNumberedLists(input, exampleArticleFormat)).toEqual(
+		expect(enhanceNumberedLists(exampleArticleFormat)(input)).toEqual(
 			expectedOutput,
 		);
 	});
@@ -67,7 +67,7 @@ describe('Enhance Numbered Lists', () => {
 				],
 			},
 		];
-		expect(enhanceNumberedLists(input, numberedListFormat)).toEqual(
+		expect(enhanceNumberedLists(numberedListFormat)(input)).toEqual(
 			expectedOutput,
 		);
 	});
@@ -102,7 +102,7 @@ describe('Enhance Numbered Lists', () => {
 				],
 			},
 		];
-		expect(enhanceNumberedLists(input, numberedListFormat)).toEqual(
+		expect(enhanceNumberedLists(numberedListFormat)(input)).toEqual(
 			expectedOutput,
 		);
 	});
@@ -137,7 +137,7 @@ describe('Enhance Numbered Lists', () => {
 				],
 			},
 		];
-		expect(enhanceNumberedLists(input, numberedListFormat)).toEqual(
+		expect(enhanceNumberedLists(numberedListFormat)(input)).toEqual(
 			expectedOutput,
 		);
 	});
@@ -172,7 +172,7 @@ describe('Enhance Numbered Lists', () => {
 				],
 			},
 		];
-		expect(enhanceNumberedLists(input, numberedListFormat)).toEqual(
+		expect(enhanceNumberedLists(numberedListFormat)(input)).toEqual(
 			expectedOutput,
 		);
 	});
@@ -202,7 +202,7 @@ describe('Enhance Numbered Lists', () => {
 				],
 			},
 		];
-		expect(enhanceNumberedLists(input, numberedListFormat)).toEqual(
+		expect(enhanceNumberedLists(numberedListFormat)(input)).toEqual(
 			expectedOutput,
 		);
 	});
@@ -232,7 +232,7 @@ describe('Enhance Numbered Lists', () => {
 				],
 			},
 		];
-		expect(enhanceNumberedLists(input, numberedListFormat)).toEqual(
+		expect(enhanceNumberedLists(numberedListFormat)(input)).toEqual(
 			expectedOutput,
 		);
 	});
@@ -262,7 +262,7 @@ describe('Enhance Numbered Lists', () => {
 				],
 			},
 		];
-		expect(enhanceNumberedLists(input, numberedListFormat)).toEqual(
+		expect(enhanceNumberedLists(numberedListFormat)(input)).toEqual(
 			expectedOutput,
 		);
 	});
@@ -292,7 +292,7 @@ describe('Enhance Numbered Lists', () => {
 				],
 			},
 		];
-		expect(enhanceNumberedLists(input, numberedListFormat)).toEqual(
+		expect(enhanceNumberedLists(numberedListFormat)(input)).toEqual(
 			expectedOutput,
 		);
 	});
@@ -337,7 +337,7 @@ describe('Enhance Numbered Lists', () => {
 				],
 			},
 		];
-		expect(enhanceNumberedLists(input, numberedListFormat)).toEqual(
+		expect(enhanceNumberedLists(numberedListFormat)(input)).toEqual(
 			expectedOutput,
 		);
 	});
@@ -382,7 +382,7 @@ describe('Enhance Numbered Lists', () => {
 				],
 			},
 		];
-		expect(enhanceNumberedLists(input, numberedListFormat)).toEqual(
+		expect(enhanceNumberedLists(numberedListFormat)(input)).toEqual(
 			expectedOutput,
 		);
 	});
@@ -415,7 +415,7 @@ describe('Enhance Numbered Lists', () => {
 			},
 		];
 
-		expect(enhanceNumberedLists(input, numberedListFormat)).toEqual(
+		expect(enhanceNumberedLists(numberedListFormat)(input)).toEqual(
 			expectedOutput,
 		);
 	});
@@ -436,7 +436,7 @@ describe('Enhance Numbered Lists', () => {
 
 		const expectedOutput: Block[] = input;
 
-		expect(enhanceNumberedLists(input, numberedListFormat)).toEqual(
+		expect(enhanceNumberedLists(numberedListFormat)(input)).toEqual(
 			expectedOutput,
 		);
 	});
@@ -457,7 +457,7 @@ describe('Enhance Numbered Lists', () => {
 
 		const expectedOutput: Block[] = input;
 
-		expect(enhanceNumberedLists(input, numberedListFormat)).toEqual(
+		expect(enhanceNumberedLists(numberedListFormat)(input)).toEqual(
 			expectedOutput,
 		);
 	});
@@ -477,7 +477,7 @@ describe('Enhance Numbered Lists', () => {
 		];
 		const expectedOutput: Block[] = input;
 
-		expect(enhanceNumberedLists(input, numberedListFormat)).toEqual(
+		expect(enhanceNumberedLists(numberedListFormat)(input)).toEqual(
 			expectedOutput,
 		);
 	});
@@ -510,7 +510,7 @@ describe('Enhance Numbered Lists', () => {
 			},
 		];
 
-		expect(enhanceNumberedLists(input, numberedListFormat)).toEqual(
+		expect(enhanceNumberedLists(numberedListFormat)(input)).toEqual(
 			expectedOutput,
 		);
 	});
@@ -543,7 +543,7 @@ describe('Enhance Numbered Lists', () => {
 			},
 		];
 
-		expect(enhanceNumberedLists(input, numberedListFormat)).toEqual(
+		expect(enhanceNumberedLists(numberedListFormat)(input)).toEqual(
 			expectedOutput,
 		);
 	});
@@ -575,7 +575,7 @@ describe('Enhance Numbered Lists', () => {
 			},
 		];
 
-		expect(enhanceNumberedLists(input, numberedListFormat)).toEqual(
+		expect(enhanceNumberedLists(numberedListFormat)(input)).toEqual(
 			expectedOutput,
 		);
 	});
@@ -607,7 +607,7 @@ describe('Enhance Numbered Lists', () => {
 			},
 		];
 
-		expect(enhanceNumberedLists(input, numberedListFormat)).toEqual(
+		expect(enhanceNumberedLists(numberedListFormat)(input)).toEqual(
 			expectedOutput,
 		);
 	});
@@ -627,7 +627,7 @@ describe('Enhance Numbered Lists', () => {
 			},
 		];
 
-		expect(enhanceNumberedLists(input, numberedListFormat)).toEqual(
+		expect(enhanceNumberedLists(numberedListFormat)(input)).toEqual(
 			expectedOutput,
 		);
 	});
@@ -665,7 +665,7 @@ describe('Enhance Numbered Lists', () => {
 			},
 		];
 
-		expect(enhanceNumberedLists(input, numberedListFormat)).toEqual(
+		expect(enhanceNumberedLists(numberedListFormat)(input)).toEqual(
 			expectedOutput,
 		);
 	});
@@ -746,7 +746,7 @@ describe('Enhance Numbered Lists', () => {
 			},
 		];
 
-		expect(enhanceNumberedLists(input, numberedListFormat)).toEqual(
+		expect(enhanceNumberedLists(numberedListFormat)(input)).toEqual(
 			expectedOutput,
 		);
 	});

--- a/dotcom-rendering/src/model/enhance-numbered-lists.ts
+++ b/dotcom-rendering/src/model/enhance-numbered-lists.ts
@@ -396,20 +396,19 @@ const enhance = (elements: FEElement[]): FEElement[] => {
 	);
 };
 
-export const enhanceNumberedLists = (
-	blocks: Block[],
-	format: ArticleFormat,
-): Block[] => {
-	const isNumberedList = format.display === ArticleDisplay.NumberedList;
+export const enhanceNumberedLists =
+	(format: ArticleFormat) =>
+	(blocks: Block[]): Block[] => {
+		const isNumberedList = format.display === ArticleDisplay.NumberedList;
 
-	if (!isNumberedList) {
-		return blocks;
-	}
+		if (!isNumberedList) {
+			return blocks;
+		}
 
-	return blocks.map((block: Block) => {
-		return {
-			...block,
-			elements: enhance(block.elements),
-		};
-	});
-};
+		return blocks.map((block: Block) => {
+			return {
+				...block,
+				elements: enhance(block.elements),
+			};
+		});
+	};

--- a/dotcom-rendering/src/model/enhanceBlocks.ts
+++ b/dotcom-rendering/src/model/enhanceBlocks.ts
@@ -46,4 +46,4 @@ export const enhanceBlocks = (
 		enhanceTweets,
 		enhanceNewsletterSignup(format, options.promotedNewsletter),
 		enhanceAdPlaceholders(format, options.renderingTarget),
-	].reduce((prevBlocks, enhancer) => enhancer(prevBlocks), blocks);
+	].reduce((enhancedBlocks, enhancer) => enhancer(enhancedBlocks), blocks);


### PR DESCRIPTION
Each enhancer is `Block[] => Block[]`, and the initial list of blocks is piped through them. With current usage, this can be represented as a `reduce` without the additional class/fluent API.

This also moves the check for whether ad placeholders should be inserted into the `enhanceAdPlaceholders` function.

**Note:** I recommend turning on "hide whitespace" to view the diff.
