### PR TITLE
Remove Duplicate Build Command Step From Docs

### DIFF
--- a/dotcom-rendering/docs/testing.md
+++ b/dotcom-rendering/docs/testing.md
@@ -75,10 +75,6 @@ Running Playwright locally requires having a DCR server running.
 
 #### Against the PROD server
 
-First create the prod build:
-
-`make build`
-
 To run the tests on the command line in headless mode:
 
 `make playwright`


### PR DESCRIPTION
The `playwright` and `playwright-open` rules already include `build` in their list of pre-requisites, so it's run when they're run.
