### PR TITLE
Use `C7g` medium instances for `PROD`

### DIFF
--- a/dotcom-rendering/cdk/bin/cdk.ts
+++ b/dotcom-rendering/cdk/bin/cdk.ts
@@ -34,7 +34,7 @@ new RenderingCDKStack(cdkApp, 'ArticleRendering-CODE', {
 	stage: 'CODE',
 	domainName: 'article-rendering.code.dev-guardianapis.com',
 	scaling: { minimumInstances: 1, maximumInstances: 4 },
-	instanceType: InstanceType.of(InstanceClass.C7G, InstanceSize.MEDIUM),
+	instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MICRO),
 });
 new RenderingCDKStack(cdkApp, 'ArticleRendering-PROD', {
 	guApp: 'article-rendering',
@@ -95,7 +95,7 @@ new RenderingCDKStack(cdkApp, 'FaciaRendering-PROD', {
 			],
 		},
 	},
-	instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
+	instanceType: InstanceType.of(InstanceClass.C7G, InstanceSize.MEDIUM),
 });
 
 /** Interactive */
@@ -130,5 +130,5 @@ new RenderingCDKStack(cdkApp, 'InteractiveRendering-PROD', {
 			],
 		},
 	},
-	instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.SMALL),
+	instanceType: InstanceType.of(InstanceClass.C7G, InstanceSize.MEDIUM),
 });


### PR DESCRIPTION
## What does this change?

- Swaps production rendering app instance classes to be `C7g` rather than `T4g`. 
- Continues using `T4g` instances for `CODE` as they are cheap to run on a non-production, low-traffic environment.

## Why?

After an experiment with `C7g` medium sized instances in `article-rendering` (#10780), we found the average target response time (latency) reduced, in comparison with the same number of `T4g` instances.

We also discovered we are unable to "spend" CPU credits on burstable instances in an efficient way as they are reset when an instance is terminated. Since we deploy several times a day during weekdays, and this results in CPU credits being reset due to terminating and spawning instances, we don't accrue enough to spend during high traffic periods.


## Screenshots

This graph shows an annotation line with the time of the deployment of #10870 and the difference that made to the response time, even with fewer instances running (there were 30 before the change and 24 after the change)

<img width="1183" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/43961396/ca7733e9-d28f-46c7-9fbd-f76a4e4fcb79">
