### PR TITLE
Enhance Elements More Often Than Enhancing Blocks

### DIFF
--- a/dotcom-rendering/src/components/InteractiveContentsBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/components/InteractiveContentsBlockComponent.stories.tsx
@@ -7,10 +7,10 @@ import type { InteractiveContentsBlockElement } from '../types/content';
 import { InteractiveContentsBlockComponent } from './InteractiveContentsBlockComponent.importable';
 
 const interactiveContentsBlock = enhanceInteractiveContentsElements(
-	NumberedList.blocks,
-)[0]?.elements.find(
-	(block): block is InteractiveContentsBlockElement =>
-		block._type ===
+	NumberedList.blocks[0]?.elements ?? [],
+).find(
+	(element): element is InteractiveContentsBlockElement =>
+		element._type ===
 		'model.dotcomrendering.pageElements.InteractiveContentsBlockElement',
 );
 

--- a/dotcom-rendering/src/lib/article.ts
+++ b/dotcom-rendering/src/lib/article.ts
@@ -42,10 +42,9 @@ export const enhanceArticleType = (
 	});
 
 	const mainMediaElements = enhanceElementsImages(
-		data.mainMediaElements,
-		data.format,
+		format,
 		imagesForLightbox,
-	);
+	)(data.mainMediaElements);
 
 	return {
 		...data,

--- a/dotcom-rendering/src/model/enhance-H2s.test.ts
+++ b/dotcom-rendering/src/model/enhance-H2s.test.ts
@@ -1,89 +1,59 @@
-import { blockMetaData } from '../../fixtures/manual/block-meta-data';
+import type { FEElement } from '../types/content';
 import { enhanceH2s } from './enhance-H2s';
 
 describe('Enhance h2 Embeds', () => {
 	it('sets an id when it is an h2 of type SubheadingBlockElement', () => {
-		const input: Block[] = [
+		const input: FEElement[] = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
-						elementId: 'mockId',
-						html: '<h2>I should get an id.</h2>',
-					},
-				],
+				_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
+				elementId: 'mockId',
+				html: '<h2>I should get an id.</h2>',
 			},
 		];
 
 		const expectedOutput = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
-						elementId: 'mockId',
-						html: "<h2 id='i-should-get-an-id'>I should get an id.</h2>",
-					},
-				],
+				_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
+				elementId: 'mockId',
+				html: "<h2 id='i-should-get-an-id'>I should get an id.</h2>",
 			},
 		];
 
 		expect(enhanceH2s(input)).toEqual(expectedOutput);
 	});
 	it('does not set an id for h2s of type TextBlockElement', () => {
-		const input: Block[] = [
+		const input: FEElement[] = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'mockId',
-						html: '<h2>I should NOT get an id.</h2>',
-					},
-				],
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				elementId: 'mockId',
+				html: '<h2>I should NOT get an id.</h2>',
 			},
 		];
 
 		const expectedOutput = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'mockId',
-						html: '<h2>I should NOT get an id.</h2>',
-					},
-				],
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				elementId: 'mockId',
+				html: '<h2>I should NOT get an id.</h2>',
 			},
 		];
 
 		expect(enhanceH2s(input)).toEqual(expectedOutput);
 	});
 	it('does not set an id when it is of type SubheadingBlockElement but not an h2', () => {
-		const input: Block[] = [
+		const input: FEElement[] = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
-						elementId: 'mockId',
-						html: '<p>I should NOT get an id.</p>',
-					},
-				],
+				_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
+				elementId: 'mockId',
+				html: '<p>I should NOT get an id.</p>',
 			},
 		];
 
 		const expectedOutput = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
-						elementId: 'mockId',
-						html: '<p>I should NOT get an id.</p>',
-					},
-				],
+				_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
+				elementId: 'mockId',
+				html: '<p>I should NOT get an id.</p>',
 			},
 		];
 
@@ -91,49 +61,39 @@ describe('Enhance h2 Embeds', () => {
 	});
 
 	it('should add the number of occurences to the slug if it is not unique', () => {
-		const input: Block[] = [
+		const input: FEElement[] = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
-						elementId: 'mockId',
-						html: '<h2>I am not unique.</h2>',
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
-						elementId: 'mockId',
-						html: '<h2>I am not unique.</h2>',
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
-						elementId: 'mockId',
-						html: '<h2>I am not unique.</h2>',
-					},
-				],
+				_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
+				elementId: 'mockId',
+				html: '<h2>I am not unique.</h2>',
+			},
+			{
+				_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
+				elementId: 'mockId',
+				html: '<h2>I am not unique.</h2>',
+			},
+			{
+				_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
+				elementId: 'mockId',
+				html: '<h2>I am not unique.</h2>',
 			},
 		];
 
 		const expectedOutput = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
-						elementId: 'mockId',
-						html: "<h2 id='i-am-not-unique'>I am not unique.</h2>",
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
-						elementId: 'mockId',
-						html: "<h2 id='i-am-not-unique-1'>I am not unique.</h2>",
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
-						elementId: 'mockId',
-						html: "<h2 id='i-am-not-unique-2'>I am not unique.</h2>",
-					},
-				],
+				_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
+				elementId: 'mockId',
+				html: "<h2 id='i-am-not-unique'>I am not unique.</h2>",
+			},
+			{
+				_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
+				elementId: 'mockId',
+				html: "<h2 id='i-am-not-unique-1'>I am not unique.</h2>",
+			},
+			{
+				_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
+				elementId: 'mockId',
+				html: "<h2 id='i-am-not-unique-2'>I am not unique.</h2>",
 			},
 		];
 
@@ -141,29 +101,19 @@ describe('Enhance h2 Embeds', () => {
 	});
 
 	it('should only have lower case letters in the id', () => {
-		const input: Block[] = [
+		const input: FEElement[] = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
-						elementId: 'mockId',
-						html: '<h2>I SHOULD BE a LOWeR cAsE id.</h2>',
-					},
-				],
+				_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
+				elementId: 'mockId',
+				html: '<h2>I SHOULD BE a LOWeR cAsE id.</h2>',
 			},
 		];
 
 		const expectedOutput = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
-						elementId: 'mockId',
-						html: "<h2 id='i-should-be-a-lower-case-id'>I SHOULD BE a LOWeR cAsE id.</h2>",
-					},
-				],
+				_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
+				elementId: 'mockId',
+				html: "<h2 id='i-should-be-a-lower-case-id'>I SHOULD BE a LOWeR cAsE id.</h2>",
 			},
 		];
 
@@ -171,29 +121,19 @@ describe('Enhance h2 Embeds', () => {
 	});
 
 	it('should remove trailing whitespace and replace non-trailing whitespace with hyphens for the id', () => {
-		const input: Block[] = [
+		const input: FEElement[] = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
-						elementId: 'mockId',
-						html: '<h2> no white space </h2>',
-					},
-				],
+				_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
+				elementId: 'mockId',
+				html: '<h2> no white space </h2>',
 			},
 		];
 
 		const expectedOutput = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
-						elementId: 'mockId',
-						html: "<h2 id='no-white-space'> no white space </h2>",
-					},
-				],
+				_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
+				elementId: 'mockId',
+				html: "<h2 id='no-white-space'> no white space </h2>",
 			},
 		];
 
@@ -201,29 +141,19 @@ describe('Enhance h2 Embeds', () => {
 	});
 
 	it('should remove all non-word characters and trailing hyphens from the id ', () => {
-		const input: Block[] = [
+		const input: FEElement[] = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
-						elementId: 'mockId',
-						html: '<h2>	Jurassic Park III, 2001 - ★★★ </h2>',
-					},
-				],
+				_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
+				elementId: 'mockId',
+				html: '<h2>	Jurassic Park III, 2001 - ★★★ </h2>',
 			},
 		];
 
 		const expectedOutput = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
-						elementId: 'mockId',
-						html: "<h2 id='jurassic-park-iii-2001'>	Jurassic Park III, 2001 - ★★★ </h2>",
-					},
-				],
+				_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
+				elementId: 'mockId',
+				html: "<h2 id='jurassic-park-iii-2001'>	Jurassic Park III, 2001 - ★★★ </h2>",
 			},
 		];
 
@@ -231,29 +161,19 @@ describe('Enhance h2 Embeds', () => {
 	});
 
 	it('should replace multiple "-" with single "-" from the id', () => {
-		const input: Block[] = [
+		const input: FEElement[] = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
-						elementId: 'mockId',
-						html: '<h2>	Jurassic Park III --- 2001 -- ★★★ </h2>',
-					},
-				],
+				_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
+				elementId: 'mockId',
+				html: '<h2>	Jurassic Park III --- 2001 -- ★★★ </h2>',
 			},
 		];
 
 		const expectedOutput = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
-						elementId: 'mockId',
-						html: "<h2 id='jurassic-park-iii-2001'>	Jurassic Park III --- 2001 -- ★★★ </h2>",
-					},
-				],
+				_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
+				elementId: 'mockId',
+				html: "<h2 id='jurassic-park-iii-2001'>	Jurassic Park III --- 2001 -- ★★★ </h2>",
 			},
 		];
 

--- a/dotcom-rendering/src/model/enhance-H2s.ts
+++ b/dotcom-rendering/src/model/enhance-H2s.ts
@@ -61,7 +61,7 @@ const generateId = (element: SubheadingBlockElement, existingIds: string[]) => {
  * If our h2 element is a subheading then we want to insert a humanised slug of the header text as its ID.
  * We make sure to store each slug inside an array so that we can verify if this slug already exists as an id. If it does, we add the number of times it appears on the page to make sure the id is always unique.
  */
-const enhance = (elements: FEElement[]): FEElement[] => {
+export const enhanceH2s = (elements: FEElement[]): FEElement[] => {
 	const slugifiedIds: string[] = [];
 	const shouldUseElementId = shouldUseLegacyIDs(elements);
 	return elements.map<FEElement>((element) => {
@@ -86,14 +86,5 @@ const enhance = (elements: FEElement[]): FEElement[] => {
 			// Otherwise, do nothing
 			return element;
 		}
-	});
-};
-
-export const enhanceH2s = (blocks: Block[]): Block[] => {
-	return blocks.map((block: Block) => {
-		return {
-			...block,
-			elements: enhance(block.elements),
-		};
 	});
 };

--- a/dotcom-rendering/src/model/enhance-ad-placeholders.test.ts
+++ b/dotcom-rendering/src/model/enhance-ad-placeholders.test.ts
@@ -1,5 +1,4 @@
 import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
-import { blockMetaData } from '../../fixtures/manual/block-meta-data';
 import type {
 	AdPlaceholderBlockElement,
 	FEElement,
@@ -38,9 +37,6 @@ const elementIsAdPlaceholder = (
 ): element is AdPlaceholderBlockElement =>
 	element._type ===
 	'model.dotcomrendering.pageElements.AdPlaceholderBlockElement';
-
-const getElementsFromBlocks = (blocks: Block[]): FEElement[] =>
-	blocks.flatMap(({ elements }) => elements);
 
 // Tests
 describe('Enhancing ad placeholders', () => {
@@ -81,17 +77,10 @@ describe('Enhancing ad placeholders', () => {
 		({ paragraphs, expectedPositions }) => {
 			const elements = getTestParagraphElements(paragraphs);
 			const expectedPlaceholders = expectedPositions.length;
-
-			const input: Block[] = [
-				{
-					...blockMetaData,
-					elements,
-				},
-			];
+			const input: FEElement[] = elements;
 
 			const output = enhanceAdPlaceholders(exampleFormat, 'Apps')(input);
-			const outputElements = getElementsFromBlocks(output);
-			const placeholderIndices = outputElements.flatMap((el, idx) =>
+			const placeholderIndices = output.flatMap((el, idx) =>
 				elementIsAdPlaceholder(el) ? [idx] : [],
 			);
 
@@ -118,22 +107,14 @@ describe('Enhancing ad placeholders', () => {
 			...threeParagraphs,
 		];
 
-		const input: Block[] = [
-			{
-				...blockMetaData,
-				elements,
-			},
-		];
+		const input: FEElement[] = elements;
 
 		const output = enhanceAdPlaceholders(exampleFormat, 'Apps')(input);
-		const outputElements = getElementsFromBlocks(output);
-		const outputPlaceholders = outputElements.filter(
-			elementIsAdPlaceholder,
-		);
+		const outputPlaceholders = output.filter(elementIsAdPlaceholder);
 
 		expect(outputPlaceholders.length).toEqual(1);
 
-		const placeholderIndices = outputElements.flatMap((el, idx) =>
+		const placeholderIndices = output.flatMap((el, idx) =>
 			elementIsAdPlaceholder(el) ? [idx] : [],
 		);
 

--- a/dotcom-rendering/src/model/enhance-ad-placeholders.ts
+++ b/dotcom-rendering/src/model/enhance-ad-placeholders.ts
@@ -101,12 +101,9 @@ const insertAdPlaceholders = (elements: FEElement[]): FEElement[] => {
 
 export const enhanceAdPlaceholders =
 	(format: ArticleFormat, renderingTarget: RenderingTarget) =>
-	(blocks: Block[]): Block[] =>
+	(elements: FEElement[]): FEElement[] =>
 		renderingTarget === 'Apps' &&
 		format.design !== ArticleDesign.LiveBlog &&
 		format.design !== ArticleDesign.DeadBlog
-			? blocks.map((b) => ({
-					...b,
-					elements: insertAdPlaceholders(b.elements),
-			  }))
-			: blocks;
+			? insertAdPlaceholders(elements)
+			: elements;

--- a/dotcom-rendering/src/model/enhance-blockquotes.test.ts
+++ b/dotcom-rendering/src/model/enhance-blockquotes.test.ts
@@ -1,7 +1,7 @@
 import { ArticleDesign, type ArticleFormat } from '@guardian/libs';
 import { Standard as ExampleArticle } from '../../fixtures/generated/articles/Standard';
-import { blockMetaData } from '../../fixtures/manual/block-meta-data';
 import { decideFormat } from '../lib/decideFormat';
+import type { FEElement } from '../types/content';
 import type { DCRArticle } from '../types/frontend';
 import { enhanceBlockquotes } from './enhance-blockquotes';
 
@@ -15,39 +15,26 @@ const formatIsPhotoEssay: ArticleFormat = {
 
 describe('Enhancing blockquotes', () => {
 	it('creates an identical but new object when no changes are needed', () => {
-		expect(enhanceBlockquotes(exampleFormat)(example.blocks)).not.toBe(
-			example.blocks,
-		); // We created a new object
-		expect(enhanceBlockquotes(exampleFormat)(example.blocks)).toEqual(
-			example.blocks,
-		); // The new object is what we expect
+		const elements = example.blocks[0]?.elements ?? [];
+		expect(enhanceBlockquotes(exampleFormat)(elements)).not.toBe(elements); // We created a new object
+		expect(enhanceBlockquotes(exampleFormat)(elements)).toEqual(elements); // The new object is what we expect
 	});
 
 	it('adds the quoted prop when the quoted class was found', () => {
-		const input: Block[] = [
+		const input: FEElement[] = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.BlockquoteBlockElement',
-						elementId: 'mockId',
-						html: '<blockquote class="quoted">This is a quote</blockquote>',
-					},
-				],
+				_type: 'model.dotcomrendering.pageElements.BlockquoteBlockElement',
+				elementId: 'mockId',
+				html: '<blockquote class="quoted">This is a quote</blockquote>',
 			},
 		];
 
 		const expectedOutput = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.BlockquoteBlockElement',
-						elementId: 'mockId',
-						html: '<blockquote class="quoted">This is a quote</blockquote>',
-						quoted: true,
-					},
-				],
+				_type: 'model.dotcomrendering.pageElements.BlockquoteBlockElement',
+				elementId: 'mockId',
+				html: '<blockquote class="quoted">This is a quote</blockquote>',
+				quoted: true,
 			},
 		];
 
@@ -57,29 +44,19 @@ describe('Enhancing blockquotes', () => {
 	});
 
 	it('transforms simple blockquotes to highlight elements for photo essays', () => {
-		const input: Block[] = [
+		const input: FEElement[] = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.BlockquoteBlockElement',
-						elementId: 'mockId',
-						html: '<blockquote>This is not a quote</blockquote>',
-					},
-				],
+				_type: 'model.dotcomrendering.pageElements.BlockquoteBlockElement',
+				elementId: 'mockId',
+				html: '<blockquote>This is not a quote</blockquote>',
 			},
 		];
 
 		const expectedOutput = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.HighlightBlockElement',
-						elementId: 'mockId',
-						html: '<blockquote>This is not a quote</blockquote>',
-					},
-				],
+				_type: 'model.dotcomrendering.pageElements.HighlightBlockElement',
+				elementId: 'mockId',
+				html: '<blockquote>This is not a quote</blockquote>',
 			},
 		];
 
@@ -89,30 +66,20 @@ describe('Enhancing blockquotes', () => {
 	});
 
 	it("doesn't transform quoted blockquotes to highlight elements for photo essays", () => {
-		const input: Block[] = [
+		const input: FEElement[] = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.BlockquoteBlockElement',
-						elementId: 'mockId',
-						html: '<blockquote class="quoted">This is a quoted blockquote</blockquote>',
-					},
-				],
+				_type: 'model.dotcomrendering.pageElements.BlockquoteBlockElement',
+				elementId: 'mockId',
+				html: '<blockquote class="quoted">This is a quoted blockquote</blockquote>',
 			},
 		];
 
 		const expectedOutput = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.BlockquoteBlockElement',
-						elementId: 'mockId',
-						html: '<blockquote class="quoted">This is a quoted blockquote</blockquote>',
-						quoted: true,
-					},
-				],
+				_type: 'model.dotcomrendering.pageElements.BlockquoteBlockElement',
+				elementId: 'mockId',
+				html: '<blockquote class="quoted">This is a quoted blockquote</blockquote>',
+				quoted: true,
 			},
 		];
 
@@ -122,29 +89,19 @@ describe('Enhancing blockquotes', () => {
 	});
 
 	it('passes through simple blockquotes', () => {
-		const input: Block[] = [
+		const input: FEElement[] = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.BlockquoteBlockElement',
-						elementId: 'mockId',
-						html: '<blockquote>This is a quote</blockquote>',
-					},
-				],
+				_type: 'model.dotcomrendering.pageElements.BlockquoteBlockElement',
+				elementId: 'mockId',
+				html: '<blockquote>This is a quote</blockquote>',
 			},
 		];
 
 		const expectedOutput = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.BlockquoteBlockElement',
-						elementId: 'mockId',
-						html: '<blockquote>This is a quote</blockquote>',
-					},
-				],
+				_type: 'model.dotcomrendering.pageElements.BlockquoteBlockElement',
+				elementId: 'mockId',
+				html: '<blockquote>This is a quote</blockquote>',
 			},
 		];
 
@@ -154,29 +111,19 @@ describe('Enhancing blockquotes', () => {
 	});
 
 	it('ignores blockquotes with other classnames', () => {
-		const input: Block[] = [
+		const input: FEElement[] = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.BlockquoteBlockElement',
-						elementId: 'mockId',
-						html: '<blockquote class="somethingelse">This is a simple blockquote</blockquote>',
-					},
-				],
+				_type: 'model.dotcomrendering.pageElements.BlockquoteBlockElement',
+				elementId: 'mockId',
+				html: '<blockquote class="somethingelse">This is a simple blockquote</blockquote>',
 			},
 		];
 
 		const expectedOutput = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.BlockquoteBlockElement',
-						elementId: 'mockId',
-						html: '<blockquote class="somethingelse">This is a simple blockquote</blockquote>',
-					},
-				],
+				_type: 'model.dotcomrendering.pageElements.BlockquoteBlockElement',
+				elementId: 'mockId',
+				html: '<blockquote class="somethingelse">This is a simple blockquote</blockquote>',
 			},
 		];
 
@@ -186,40 +133,30 @@ describe('Enhancing blockquotes', () => {
 	});
 
 	it('handles both quoted and simple blockquotes in the same array', () => {
-		const input: Block[] = [
+		const input: FEElement[] = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.BlockquoteBlockElement',
-						elementId: 'mockId',
-						html: '<blockquote class="quoted">This is a quoted quote</blockquote>',
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.BlockquoteBlockElement',
-						elementId: 'mockId',
-						html: '<blockquote>This is a simple quote</blockquote>',
-					},
-				],
+				_type: 'model.dotcomrendering.pageElements.BlockquoteBlockElement',
+				elementId: 'mockId',
+				html: '<blockquote class="quoted">This is a quoted quote</blockquote>',
+			},
+			{
+				_type: 'model.dotcomrendering.pageElements.BlockquoteBlockElement',
+				elementId: 'mockId',
+				html: '<blockquote>This is a simple quote</blockquote>',
 			},
 		];
 
 		const expectedOutput = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.BlockquoteBlockElement',
-						elementId: 'mockId',
-						html: '<blockquote class="quoted">This is a quoted quote</blockquote>',
-						quoted: true,
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.BlockquoteBlockElement',
-						elementId: 'mockId',
-						html: '<blockquote>This is a simple quote</blockquote>',
-					},
-				],
+				_type: 'model.dotcomrendering.pageElements.BlockquoteBlockElement',
+				elementId: 'mockId',
+				html: '<blockquote class="quoted">This is a quoted quote</blockquote>',
+				quoted: true,
+			},
+			{
+				_type: 'model.dotcomrendering.pageElements.BlockquoteBlockElement',
+				elementId: 'mockId',
+				html: '<blockquote>This is a simple quote</blockquote>',
 			},
 		];
 

--- a/dotcom-rendering/src/model/enhance-blockquotes.ts
+++ b/dotcom-rendering/src/model/enhance-blockquotes.ts
@@ -8,47 +8,39 @@ const isQuoted = (element: BlockquoteBlockElement): boolean => {
 	return !!frag.querySelector('.quoted');
 };
 
-const enhance = (elements: FEElement[], isPhotoEssay: boolean): FEElement[] =>
-	// Loops the array of article elements looking for BlockquoteBlockElements to enhance
-	elements.map<FEElement>((element) => {
-		switch (element._type) {
-			case 'model.dotcomrendering.pageElements.BlockquoteBlockElement':
-				if (isQuoted(element)) {
-					// When blockquotes have the `quoted` class we represent this using
-					// the quoted prop
-					return {
-						_type: 'model.dotcomrendering.pageElements.BlockquoteBlockElement',
-						elementId: element.elementId,
-						html: element.html,
-						quoted: true,
-					};
-				} else if (isPhotoEssay) {
-					// If a blockquote is not queoted it is a Simple Blockquote and for
-					// photo essays we transform these into HighlightBlockElements
-					return {
-						_type: 'model.dotcomrendering.pageElements.HighlightBlockElement',
-						elementId: element.elementId,
-						html: element.html,
-					};
-				} else {
-					// Otherwise we don't transform anything and pass the element through
-					return element;
-				}
-				break;
-			default:
-				return element;
-		}
-	});
-
 export const enhanceBlockquotes =
 	(format: ArticleFormat) =>
-	(blocks: Block[]): Block[] => {
+	(elements: FEElement[]): FEElement[] => {
 		const isPhotoEssay = format.design === ArticleDesign.PhotoEssay;
 
-		return blocks.map((block: Block) => {
-			return {
-				...block,
-				elements: enhance(block.elements, isPhotoEssay || false),
-			};
+		// Loops the array of article elements looking for BlockquoteBlockElements to enhance
+		return elements.map<FEElement>((element) => {
+			switch (element._type) {
+				case 'model.dotcomrendering.pageElements.BlockquoteBlockElement':
+					if (isQuoted(element)) {
+						// When blockquotes have the `quoted` class we represent this using
+						// the quoted prop
+						return {
+							_type: 'model.dotcomrendering.pageElements.BlockquoteBlockElement',
+							elementId: element.elementId,
+							html: element.html,
+							quoted: true,
+						};
+					} else if (isPhotoEssay) {
+						// If a blockquote is not queoted it is a Simple Blockquote and for
+						// photo essays we transform these into HighlightBlockElements
+						return {
+							_type: 'model.dotcomrendering.pageElements.HighlightBlockElement',
+							elementId: element.elementId,
+							html: element.html,
+						};
+					} else {
+						// Otherwise we don't transform anything and pass the element through
+						return element;
+					}
+					break;
+				default:
+					return element;
+			}
 		});
 	};

--- a/dotcom-rendering/src/model/enhance-dividers.test.ts
+++ b/dotcom-rendering/src/model/enhance-dividers.test.ts
@@ -1,68 +1,59 @@
 import { Standard as ExampleArticle } from '../../fixtures/generated/articles/Standard';
-import { blockMetaData } from '../../fixtures/manual/block-meta-data';
+import type { FEElement } from '../types/content';
 import { enhanceDividers } from './enhance-dividers';
 
 const example = ExampleArticle;
 
 describe('Dividers and Drop Caps', () => {
 	it('creates an identical but new object when no changes are needed', () => {
-		expect(enhanceDividers(example.blocks)).not.toBe(example.blocks); // We created a new object
-		expect(enhanceDividers(example.blocks)).toEqual(example.blocks); // The new object is what we expect
+		const elements = example.blocks[0]?.elements ?? [];
+		expect(enhanceDividers(elements)).not.toBe(elements); // We created a new object
+		expect(enhanceDividers(elements)).toEqual(elements); // The new object is what we expect
 	});
 
 	it('sets the divider flag correctly', () => {
-		const input: Block[] = [
+		const input: FEElement[] = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'mockId',
-						html: '<p>I am the first paragraph</p>',
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
-						elementId: 'mockId',
-						html: '<p>* * *</p>',
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'mockId',
-						html: '<p>I should become a drop cap.</p>',
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'mockId',
-						html: '<p>I should NOT become a drop cap.</p>',
-					},
-				],
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				elementId: 'mockId',
+				html: '<p>I am the first paragraph</p>',
+			},
+			{
+				_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
+				elementId: 'mockId',
+				html: '<p>* * *</p>',
+			},
+			{
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				elementId: 'mockId',
+				html: '<p>I should become a drop cap.</p>',
+			},
+			{
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				elementId: 'mockId',
+				html: '<p>I should NOT become a drop cap.</p>',
 			},
 		];
 
-		const expectedOutput: Block[] = [
+		const expectedOutput: FEElement[] = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'mockId',
-						html: '<p>I am the first paragraph</p>',
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.DividerBlockElement',
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						dropCap: true,
-						elementId: 'mockId',
-						html: '<p>I should become a drop cap.</p>',
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'mockId',
-						html: '<p>I should NOT become a drop cap.</p>',
-					},
-				],
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				elementId: 'mockId',
+				html: '<p>I am the first paragraph</p>',
+			},
+			{
+				_type: 'model.dotcomrendering.pageElements.DividerBlockElement',
+			},
+			{
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				dropCap: true,
+				elementId: 'mockId',
+				html: '<p>I should become a drop cap.</p>',
+			},
+			{
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				elementId: 'mockId',
+				html: '<p>I should NOT become a drop cap.</p>',
 			},
 		];
 
@@ -70,48 +61,38 @@ describe('Dividers and Drop Caps', () => {
 	});
 
 	it('handles dot dinkuses as text elements', () => {
-		const input: Block[] = [
+		const input: FEElement[] = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'mockId',
-						html: '<p>I am the first paragraph</p>',
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'mockId',
-						html: '<p>•••</p>',
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'mockId',
-						html: '<p>I should become a drop cap.</p>',
-					},
-				],
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				elementId: 'mockId',
+				html: '<p>I am the first paragraph</p>',
+			},
+			{
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				elementId: 'mockId',
+				html: '<p>•••</p>',
+			},
+			{
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				elementId: 'mockId',
+				html: '<p>I should become a drop cap.</p>',
 			},
 		];
 
-		const expectedOutput: Block[] = [
+		const expectedOutput: FEElement[] = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'mockId',
-						html: '<p>I am the first paragraph</p>',
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.DividerBlockElement',
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						dropCap: true,
-						elementId: 'mockId',
-						html: '<p>I should become a drop cap.</p>',
-					},
-				],
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				elementId: 'mockId',
+				html: '<p>I am the first paragraph</p>',
+			},
+			{
+				_type: 'model.dotcomrendering.pageElements.DividerBlockElement',
+			},
+			{
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				dropCap: true,
+				elementId: 'mockId',
+				html: '<p>I should become a drop cap.</p>',
 			},
 		];
 
@@ -119,48 +100,38 @@ describe('Dividers and Drop Caps', () => {
 	});
 
 	it('handles when there are no spaces in the dinkus', () => {
-		const input: Block[] = [
+		const input: FEElement[] = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'mockId',
-						html: '<p>I am the first paragraph</p>',
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
-						elementId: 'mockId',
-						html: '<p>***</p>',
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'mockId',
-						html: '<p>I should become a drop cap.</p>',
-					},
-				],
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				elementId: 'mockId',
+				html: '<p>I am the first paragraph</p>',
+			},
+			{
+				_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
+				elementId: 'mockId',
+				html: '<p>***</p>',
+			},
+			{
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				elementId: 'mockId',
+				html: '<p>I should become a drop cap.</p>',
 			},
 		];
 
-		const expectedOutput: Block[] = [
+		const expectedOutput: FEElement[] = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'mockId',
-						html: '<p>I am the first paragraph</p>',
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.DividerBlockElement',
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						dropCap: true,
-						elementId: 'mockId',
-						html: '<p>I should become a drop cap.</p>',
-					},
-				],
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				elementId: 'mockId',
+				html: '<p>I am the first paragraph</p>',
+			},
+			{
+				_type: 'model.dotcomrendering.pageElements.DividerBlockElement',
+			},
+			{
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				dropCap: true,
+				elementId: 'mockId',
+				html: '<p>I should become a drop cap.</p>',
 			},
 		];
 
@@ -168,58 +139,48 @@ describe('Dividers and Drop Caps', () => {
 	});
 
 	it('handles divider flags wrapped in h2 tags', () => {
-		const input: Block[] = [
+		const input: FEElement[] = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'mockId',
-						html: '<p>I am the first paragraph</p>',
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
-						elementId: 'mockId',
-						html: '<h2><strong>* * *</strong></h2>',
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'mockId',
-						html: '<p>I should become a drop cap.</p>',
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'mockId',
-						html: '<p>I should NOT become a drop cap.</p>',
-					},
-				],
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				elementId: 'mockId',
+				html: '<p>I am the first paragraph</p>',
+			},
+			{
+				_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
+				elementId: 'mockId',
+				html: '<h2><strong>* * *</strong></h2>',
+			},
+			{
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				elementId: 'mockId',
+				html: '<p>I should become a drop cap.</p>',
+			},
+			{
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				elementId: 'mockId',
+				html: '<p>I should NOT become a drop cap.</p>',
 			},
 		];
 
-		const expectedOutput: Block[] = [
+		const expectedOutput: FEElement[] = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'mockId',
-						html: '<p>I am the first paragraph</p>',
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.DividerBlockElement',
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						dropCap: true,
-						elementId: 'mockId',
-						html: '<p>I should become a drop cap.</p>',
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'mockId',
-						html: '<p>I should NOT become a drop cap.</p>',
-					},
-				],
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				elementId: 'mockId',
+				html: '<p>I am the first paragraph</p>',
+			},
+			{
+				_type: 'model.dotcomrendering.pageElements.DividerBlockElement',
+			},
+			{
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				dropCap: true,
+				elementId: 'mockId',
+				html: '<p>I should become a drop cap.</p>',
+			},
+			{
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				elementId: 'mockId',
+				html: '<p>I should NOT become a drop cap.</p>',
 			},
 		];
 
@@ -227,77 +188,67 @@ describe('Dividers and Drop Caps', () => {
 	});
 
 	it('handles multiple divider flags', () => {
-		const input: Block[] = [
+		const input: FEElement[] = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'mockId',
-						html: '<p>I am the first paragraph</p>',
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
-						elementId: 'mockId',
-						html: '<p>* * *</p>',
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'mockId',
-						html: '<p>I should become a drop cap.</p>',
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
-						elementId: 'mockId',
-						html: '<h2><strong>***</strong></h2>',
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'mockId',
-						html: '<p>I should also become a drop cap.</p>',
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'mockId',
-						html: '<p>I should NOT become a drop cap.</p>',
-					},
-				],
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				elementId: 'mockId',
+				html: '<p>I am the first paragraph</p>',
+			},
+			{
+				_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
+				elementId: 'mockId',
+				html: '<p>* * *</p>',
+			},
+			{
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				elementId: 'mockId',
+				html: '<p>I should become a drop cap.</p>',
+			},
+			{
+				_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
+				elementId: 'mockId',
+				html: '<h2><strong>***</strong></h2>',
+			},
+			{
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				elementId: 'mockId',
+				html: '<p>I should also become a drop cap.</p>',
+			},
+			{
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				elementId: 'mockId',
+				html: '<p>I should NOT become a drop cap.</p>',
 			},
 		];
 
-		const expectedOutput: Block[] = [
+		const expectedOutput: FEElement[] = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'mockId',
-						html: '<p>I am the first paragraph</p>',
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.DividerBlockElement',
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						dropCap: true,
-						elementId: 'mockId',
-						html: '<p>I should become a drop cap.</p>',
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.DividerBlockElement',
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						dropCap: true,
-						elementId: 'mockId',
-						html: '<p>I should also become a drop cap.</p>',
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'mockId',
-						html: '<p>I should NOT become a drop cap.</p>',
-					},
-				],
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				elementId: 'mockId',
+				html: '<p>I am the first paragraph</p>',
+			},
+			{
+				_type: 'model.dotcomrendering.pageElements.DividerBlockElement',
+			},
+			{
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				dropCap: true,
+				elementId: 'mockId',
+				html: '<p>I should become a drop cap.</p>',
+			},
+			{
+				_type: 'model.dotcomrendering.pageElements.DividerBlockElement',
+			},
+			{
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				dropCap: true,
+				elementId: 'mockId',
+				html: '<p>I should also become a drop cap.</p>',
+			},
+			{
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				elementId: 'mockId',
+				html: '<p>I should NOT become a drop cap.</p>',
 			},
 		];
 
@@ -305,63 +256,53 @@ describe('Dividers and Drop Caps', () => {
 	});
 
 	it('handles divider flags being put before elements that are not text', () => {
-		const input: Block[] = [
+		const input: FEElement[] = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'mockId',
-						html: '<p>I am the first paragraph</p>',
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
-						elementId: 'mockId',
-						html: '<h2><strong>* * *</strong></h2>',
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.InstagramBlockElement',
-						elementId: 'mockId',
-						isThirdPartyTracking: true,
-						html: '',
-						url: '',
-						hasCaption: false,
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'mockId',
-						html: '<p>I should NOT become a drop cap.</p>',
-					},
-				],
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				elementId: 'mockId',
+				html: '<p>I am the first paragraph</p>',
+			},
+			{
+				_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
+				elementId: 'mockId',
+				html: '<h2><strong>* * *</strong></h2>',
+			},
+			{
+				_type: 'model.dotcomrendering.pageElements.InstagramBlockElement',
+				elementId: 'mockId',
+				isThirdPartyTracking: true,
+				html: '',
+				url: '',
+				hasCaption: false,
+			},
+			{
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				elementId: 'mockId',
+				html: '<p>I should NOT become a drop cap.</p>',
 			},
 		];
 
-		const expectedOutput: Block[] = [
+		const expectedOutput: FEElement[] = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'mockId',
-						html: '<p>I am the first paragraph</p>',
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.DividerBlockElement',
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.InstagramBlockElement',
-						elementId: 'mockId',
-						isThirdPartyTracking: true,
-						html: '',
-						url: '',
-						hasCaption: false,
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'mockId',
-						html: '<p>I should NOT become a drop cap.</p>',
-					},
-				],
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				elementId: 'mockId',
+				html: '<p>I am the first paragraph</p>',
+			},
+			{
+				_type: 'model.dotcomrendering.pageElements.DividerBlockElement',
+			},
+			{
+				_type: 'model.dotcomrendering.pageElements.InstagramBlockElement',
+				elementId: 'mockId',
+				isThirdPartyTracking: true,
+				html: '',
+				url: '',
+				hasCaption: false,
+			},
+			{
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				elementId: 'mockId',
+				html: '<p>I should NOT become a drop cap.</p>',
 			},
 		];
 
@@ -369,74 +310,64 @@ describe('Dividers and Drop Caps', () => {
 	});
 
 	it('handles multiple divider flags in sequence', () => {
-		const input: Block[] = [
+		const input: FEElement[] = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'mockId',
-						html: '<p>I should NOT become a drop cap.</p>',
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
-						elementId: 'mockId',
-						html: '<p>* * *</p>',
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
-						elementId: 'mockId',
-						html: '<p>* * *</p>',
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
-						elementId: 'mockId',
-						html: '<p>* * *</p>',
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'mockId',
-						html: '<p>I should become a drop cap.</p>',
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'mockId',
-						html: '<p>I should NOT become a drop cap.</p>',
-					},
-				],
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				elementId: 'mockId',
+				html: '<p>I should NOT become a drop cap.</p>',
+			},
+			{
+				_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
+				elementId: 'mockId',
+				html: '<p>* * *</p>',
+			},
+			{
+				_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
+				elementId: 'mockId',
+				html: '<p>* * *</p>',
+			},
+			{
+				_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
+				elementId: 'mockId',
+				html: '<p>* * *</p>',
+			},
+			{
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				elementId: 'mockId',
+				html: '<p>I should become a drop cap.</p>',
+			},
+			{
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				elementId: 'mockId',
+				html: '<p>I should NOT become a drop cap.</p>',
 			},
 		];
 
-		const expectedOutput: Block[] = [
+		const expectedOutput: FEElement[] = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'mockId',
-						html: '<p>I should NOT become a drop cap.</p>',
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.DividerBlockElement',
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.DividerBlockElement',
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.DividerBlockElement',
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						dropCap: true,
-						elementId: 'mockId',
-						html: '<p>I should become a drop cap.</p>',
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'mockId',
-						html: '<p>I should NOT become a drop cap.</p>',
-					},
-				],
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				elementId: 'mockId',
+				html: '<p>I should NOT become a drop cap.</p>',
+			},
+			{
+				_type: 'model.dotcomrendering.pageElements.DividerBlockElement',
+			},
+			{
+				_type: 'model.dotcomrendering.pageElements.DividerBlockElement',
+			},
+			{
+				_type: 'model.dotcomrendering.pageElements.DividerBlockElement',
+			},
+			{
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				dropCap: true,
+				elementId: 'mockId',
+				html: '<p>I should become a drop cap.</p>',
+			},
+			{
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				elementId: 'mockId',
+				html: '<p>I should NOT become a drop cap.</p>',
 			},
 		];
 

--- a/dotcom-rendering/src/model/enhance-dividers.ts
+++ b/dotcom-rendering/src/model/enhance-dividers.ts
@@ -21,7 +21,7 @@ const isDinkus = (element: FEElement): boolean => {
 	);
 };
 
-const checkForDividers = (elements: FEElement[]): FEElement[] =>
+export const enhanceDividers = (elements: FEElement[]): FEElement[] =>
 	// checkForDividers loops the array of article elements looking for star flags and
 	// enhancing the data accordingly. In short, if a h2 tag is equal to * * * then we
 	// insert a divider and any the text element immediately afterwards should have dropCap
@@ -52,12 +52,4 @@ const checkForDividers = (elements: FEElement[]): FEElement[] =>
 			// Otherwise, do nothing
 			return element;
 		}
-	});
-
-export const enhanceDividers = (blocks: Block[]): Block[] =>
-	blocks.map((block: Block) => {
-		return {
-			...block,
-			elements: checkForDividers(block.elements),
-		};
 	});

--- a/dotcom-rendering/src/model/enhance-dots.test.ts
+++ b/dotcom-rendering/src/model/enhance-dots.test.ts
@@ -1,41 +1,31 @@
-import { blockMetaData } from '../../fixtures/manual/block-meta-data';
+import type { FEElement } from '../types/content';
 import { enhanceDots } from './enhance-dots';
 
 describe('Middot Tests', () => {
 	it('Output should not be the same as input as dot has been replaced', () => {
-		const input: Block[] = [
+		const input: FEElement[] = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'mockId',
-						html: '<p>I am the first paragraph</p>',
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'mockId',
-						html: '<p>• I should have a dot.</p>',
-					},
-				],
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				elementId: 'mockId',
+				html: '<p>I am the first paragraph</p>',
+			},
+			{
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				elementId: 'mockId',
+				html: '<p>• I should have a dot.</p>',
 			},
 		];
 
-		const expectedOutput: Block[] = [
+		const expectedOutput: FEElement[] = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'mockId',
-						html: '<p>I am the first paragraph</p>',
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'mockId',
-						html: '<p><span data-dcr-style="bullet"></span> I should have have a dot.</p>',
-					},
-				],
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				elementId: 'mockId',
+				html: '<p>I am the first paragraph</p>',
+			},
+			{
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				elementId: 'mockId',
+				html: '<p><span data-dcr-style="bullet"></span> I should have have a dot.</p>',
 			},
 		];
 
@@ -43,50 +33,40 @@ describe('Middot Tests', () => {
 	});
 
 	it('It does not incorrectly replace * with dot spans', () => {
-		const input: Block[] = [
+		const input: FEElement[] = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'mockId',
-						html: '<p>I am the first paragraph</p>',
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'mockId',
-						html: '<p>*</p>',
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'mockId',
-						html: '<p>I am text.</p>',
-					},
-				],
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				elementId: 'mockId',
+				html: '<p>I am the first paragraph</p>',
+			},
+			{
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				elementId: 'mockId',
+				html: '<p>*</p>',
+			},
+			{
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				elementId: 'mockId',
+				html: '<p>I am text.</p>',
 			},
 		];
 
-		const expectedOutput: Block[] = [
+		const expectedOutput: FEElement[] = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'mockId',
-						html: '<p>I am the first paragraph</p>',
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'mockId',
-						html: '<p>*</p>',
-					},
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				elementId: 'mockId',
+				html: '<p>I am the first paragraph</p>',
+			},
+			{
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				elementId: 'mockId',
+				html: '<p>*</p>',
+			},
 
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'mockId',
-						html: '<p>I am text.</p>',
-					},
-				],
+			{
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				elementId: 'mockId',
+				html: '<p>I am text.</p>',
 			},
 		];
 

--- a/dotcom-rendering/src/model/enhance-dots.ts
+++ b/dotcom-rendering/src/model/enhance-dots.ts
@@ -1,7 +1,7 @@
 import type { FEElement } from '../types/content';
 import { transformDots } from './transformDots';
 
-const checkForDots = (elements: FEElement[]): FEElement[] =>
+export const enhanceDots = (elements: FEElement[]): FEElement[] =>
 	// Loop over elements and check if a dot is in the TextBlockElement
 	elements.map<FEElement>((element, i) => {
 		if (
@@ -23,12 +23,4 @@ const checkForDots = (elements: FEElement[]): FEElement[] =>
 		} else {
 			return element;
 		}
-	});
-
-export const enhanceDots = (blocks: Block[]): Block[] =>
-	blocks.map((block: Block) => {
-		return {
-			...block,
-			elements: checkForDots(block.elements),
-		};
 	});

--- a/dotcom-rendering/src/model/enhance-embeds.test.ts
+++ b/dotcom-rendering/src/model/enhance-embeds.test.ts
@@ -1,53 +1,44 @@
 import { Standard as ExampleArticle } from '../../fixtures/generated/articles/Standard';
-import { blockMetaData } from '../../fixtures/manual/block-meta-data';
+import type { FEElement } from '../types/content';
 import { enhanceEmbeds } from './enhance-embeds';
 
 const example = ExampleArticle;
 
 describe('Enhance Embeds', () => {
 	it('creates an identical but new object when no changes are needed', () => {
-		expect(enhanceEmbeds(example.blocks)).not.toBe(example.blocks); // We created a new object
-		expect(enhanceEmbeds(example.blocks)).toEqual(example.blocks); // The new object is what we expect
+		const elements = example.blocks[0]?.elements ?? [];
+		expect(enhanceEmbeds(elements)).not.toBe(elements); // We created a new object
+		expect(enhanceEmbeds(elements)).toEqual(elements); // The new object is what we expect
 	});
 
 	it('sets the divider flag correctly', () => {
-		const input: Block[] = [
+		const input: FEElement[] = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						html: '<iframe id="the-fiver" name="the-fiver" src="https://www.theguardian.com/email/form/plaintone/the-fiver" scrolling="no" seamless="" class="iframed--overflow-hidden email-sub__iframe" height="52px" frameborder="0" data-component="email-embed--the-fiver"></iframe>',
-						safe: true,
-						alt: 'Sign up to The Fiver',
-						isMandatory: true,
-						isThirdPartyTracking: false,
-						source: 'The Guardian',
-						sourceDomain: 'theguardian.com',
-						_type: 'model.dotcomrendering.pageElements.EmbedBlockElement',
-						elementId: '17bb4750-37c3-4cef-a535-82a5c40509fd',
-						caption: 'Sign up to the Fiver',
-					},
-				],
+				html: '<iframe id="the-fiver" name="the-fiver" src="https://www.theguardian.com/email/form/plaintone/the-fiver" scrolling="no" seamless="" class="iframed--overflow-hidden email-sub__iframe" height="52px" frameborder="0" data-component="email-embed--the-fiver"></iframe>',
+				safe: true,
+				alt: 'Sign up to The Fiver',
+				isMandatory: true,
+				isThirdPartyTracking: false,
+				source: 'The Guardian',
+				sourceDomain: 'theguardian.com',
+				_type: 'model.dotcomrendering.pageElements.EmbedBlockElement',
+				elementId: '17bb4750-37c3-4cef-a535-82a5c40509fd',
+				caption: 'Sign up to the Fiver',
 			},
 		];
 
 		const expectedOutput = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						html: '<iframe id="the-fiver" name="the-fiver" src="https://www.theguardian.com/email/form/plaintone/the-fiver" scrolling="no" seamless="" class="iframed--overflow-hidden email-sub__iframe" height="52px" frameborder="0" data-component="email-embed--the-fiver" title="Sign up to The Fiver"></iframe>',
-						safe: true,
-						alt: 'Sign up to The Fiver',
-						isMandatory: true,
-						isThirdPartyTracking: false,
-						source: 'The Guardian',
-						sourceDomain: 'theguardian.com',
-						_type: 'model.dotcomrendering.pageElements.EmbedBlockElement',
-						elementId: '17bb4750-37c3-4cef-a535-82a5c40509fd',
-						caption: 'Sign up to the Fiver',
-					},
-				],
+				html: '<iframe id="the-fiver" name="the-fiver" src="https://www.theguardian.com/email/form/plaintone/the-fiver" scrolling="no" seamless="" class="iframed--overflow-hidden email-sub__iframe" height="52px" frameborder="0" data-component="email-embed--the-fiver" title="Sign up to The Fiver"></iframe>',
+				safe: true,
+				alt: 'Sign up to The Fiver',
+				isMandatory: true,
+				isThirdPartyTracking: false,
+				source: 'The Guardian',
+				sourceDomain: 'theguardian.com',
+				_type: 'model.dotcomrendering.pageElements.EmbedBlockElement',
+				elementId: '17bb4750-37c3-4cef-a535-82a5c40509fd',
+				caption: 'Sign up to the Fiver',
 			},
 		];
 

--- a/dotcom-rendering/src/model/enhance-embeds.ts
+++ b/dotcom-rendering/src/model/enhance-embeds.ts
@@ -1,7 +1,7 @@
 import { JSDOM } from 'jsdom';
 import type { FEElement } from '../types/content';
 
-const addTitleToIframe = (elements: FEElement[]): FEElement[] =>
+export const enhanceEmbeds = (elements: FEElement[]): FEElement[] =>
 	elements.map<FEElement>((element) => {
 		switch (element._type) {
 			case 'model.dotcomrendering.pageElements.EmbedBlockElement':
@@ -25,12 +25,4 @@ const addTitleToIframe = (elements: FEElement[]): FEElement[] =>
 			default:
 				return element;
 		}
-	});
-
-export const enhanceEmbeds = (blocks: Block[]): Block[] =>
-	blocks.map((block: Block) => {
-		return {
-			...block,
-			elements: addTitleToIframe(block.elements),
-		};
 	});

--- a/dotcom-rendering/src/model/enhance-images.test.ts
+++ b/dotcom-rendering/src/model/enhance-images.test.ts
@@ -2,8 +2,8 @@ import { Pillar } from '@guardian/libs';
 import { PhotoEssay } from '../../fixtures/generated/articles/PhotoEssay';
 import { Standard as ExampleArticle } from '../../fixtures/generated/articles/Standard';
 import { images } from '../../fixtures/generated/images';
-import { blockMetaData } from '../../fixtures/manual/block-meta-data';
 import { decideFormat } from '../lib/decideFormat';
+import type { FEElement } from '../types/content';
 import { enhanceImages } from './enhance-images';
 
 const exampleArticleFormat = decideFormat(ExampleArticle.format);
@@ -20,36 +20,26 @@ const image = {
 describe('Enhance Images', () => {
 	describe('for photo essays', () => {
 		it('sets the caption for an image if the following element is a text element with ul and li tags', () => {
-			const input: Block[] = [
+			const input: FEElement[] = [
+				image,
 				{
-					...blockMetaData,
-					elements: [
-						image,
-						{
-							_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-							elementId: 'mockId',
-							html: '<ul><li>This new caption replaces the one on the image object.</li></ul>',
-						},
-					],
+					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+					elementId: 'mockId',
+					html: '<ul><li>This new caption replaces the one on the image object.</li></ul>',
 				},
 			];
 
-			const expectedOutput: Block[] = [
+			const expectedOutput: FEElement[] = [
 				{
-					...blockMetaData,
-					elements: [
-						{
-							...image,
-							role: 'showcase',
-							displayCredit: false,
-							data: {
-								...image.data,
-								caption:
-									'<ul><li>This new caption replaces the one on the image object.</li></ul>',
-								credit: '',
-							},
-						},
-					],
+					...image,
+					role: 'showcase',
+					displayCredit: false,
+					data: {
+						...image.data,
+						caption:
+							'<ul><li>This new caption replaces the one on the image object.</li></ul>',
+						credit: '',
+					},
 				},
 			];
 
@@ -59,54 +49,44 @@ describe('Enhance Images', () => {
 		});
 
 		it('creates a multi image element if 2 images in a row are halfWidth', () => {
-			const input: Block[] = [
+			const input: FEElement[] = [
+				{ ...image, role: 'halfWidth' },
+				{ ...image, role: 'halfWidth' },
 				{
-					...blockMetaData,
-					elements: [
-						{ ...image, role: 'halfWidth' },
-						{ ...image, role: 'halfWidth' },
-						{
-							_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-							elementId: 'mockId',
-							html: '<ul><li><p>Judy, just sitting in the square on her own in Walworth.</p></li></ul>',
-						},
-					],
+					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+					elementId: 'mockId',
+					html: '<ul><li><p>Judy, just sitting in the square on her own in Walworth.</p></li></ul>',
 				},
 			];
 
-			const expectedOutput: Block[] = [
+			const expectedOutput: FEElement[] = [
 				{
-					...blockMetaData,
-					elements: [
+					_type: 'model.dotcomrendering.pageElements.MultiImageBlockElement',
+					elementId: images[0].elementId,
+					images: [
 						{
-							_type: 'model.dotcomrendering.pageElements.MultiImageBlockElement',
-							elementId: images[0].elementId,
-							images: [
-								{
-									...image,
-									role: 'halfWidth',
-									displayCredit: false,
-									data: {
-										...image.data,
-										caption: '',
-										credit: '',
-									},
-								},
-								{
-									...image,
-									role: 'halfWidth',
-									displayCredit: false,
-									data: {
-										...image.data,
-										caption: '',
-										credit: '',
-									},
-								},
-							],
-							caption:
-								'<ul><li><p>Judy, just sitting in the square on her own in Walworth.</p></li></ul>',
+							...image,
+							role: 'halfWidth',
+							displayCredit: false,
+							data: {
+								...image.data,
+								caption: '',
+								credit: '',
+							},
+						},
+						{
+							...image,
+							role: 'halfWidth',
+							displayCredit: false,
+							data: {
+								...image.data,
+								caption: '',
+								credit: '',
+							},
 						},
 					],
+					caption:
+						'<ul><li><p>Judy, just sitting in the square on her own in Walworth.</p></li></ul>',
 				},
 			];
 
@@ -116,47 +96,37 @@ describe('Enhance Images', () => {
 		});
 
 		it('does not create a multi image element if roles are not halfWidth', () => {
-			const input: Block[] = [
+			const input: FEElement[] = [
+				{ ...image, role: 'inline' },
+				{ ...image, role: 'showcase' },
 				{
-					...blockMetaData,
-					elements: [
-						{ ...image, role: 'inline' },
-						{ ...image, role: 'showcase' },
-						{
-							_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-							elementId: 'mockId',
-							html: '<ul><li><p>Judy, just sitting in the square on her own in Walworth.</p></li></ul>',
-						},
-					],
+					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+					elementId: 'mockId',
+					html: '<ul><li><p>Judy, just sitting in the square on her own in Walworth.</p></li></ul>',
 				},
 			];
 
-			const expectedOutput: Block[] = [
+			const expectedOutput: FEElement[] = [
 				{
-					...blockMetaData,
-					elements: [
-						{
-							...image,
-							role: 'inline',
-							displayCredit: false,
-							data: {
-								...image.data,
-								caption: '',
-								credit: '',
-							},
-						},
-						{
-							...image,
-							role: 'showcase',
-							displayCredit: false,
-							data: {
-								...image.data,
-								caption:
-									'<ul><li><p>Judy, just sitting in the square on her own in Walworth.</p></li></ul>',
-								credit: '',
-							},
-						},
-					],
+					...image,
+					role: 'inline',
+					displayCredit: false,
+					data: {
+						...image.data,
+						caption: '',
+						credit: '',
+					},
+				},
+				{
+					...image,
+					role: 'showcase',
+					displayCredit: false,
+					data: {
+						...image.data,
+						caption:
+							'<ul><li><p>Judy, just sitting in the square on her own in Walworth.</p></li></ul>',
+						credit: '',
+					},
 				},
 			];
 
@@ -166,36 +136,26 @@ describe('Enhance Images', () => {
 		});
 
 		it('does not use a multi block element for a single image, even when halfWidth', () => {
-			const input: Block[] = [
+			const input: FEElement[] = [
+				{ ...image, role: 'halfWidth' },
 				{
-					...blockMetaData,
-					elements: [
-						{ ...image, role: 'halfWidth' },
-						{
-							_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-							elementId: 'mockId',
-							html: '<ul><li><p>Judy, just sitting in the square on her own in Walworth.</p></li></ul>',
-						},
-					],
+					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+					elementId: 'mockId',
+					html: '<ul><li><p>Judy, just sitting in the square on her own in Walworth.</p></li></ul>',
 				},
 			];
 
-			const expectedOutput: Block[] = [
+			const expectedOutput: FEElement[] = [
 				{
-					...blockMetaData,
-					elements: [
-						{
-							...image,
-							role: 'halfWidth',
-							displayCredit: false,
-							data: {
-								...image.data,
-								caption:
-									'<ul><li><p>Judy, just sitting in the square on her own in Walworth.</p></li></ul>',
-								credit: '',
-							},
-						},
-					],
+					...image,
+					role: 'halfWidth',
+					displayCredit: false,
+					data: {
+						...image.data,
+						caption:
+							'<ul><li><p>Judy, just sitting in the square on her own in Walworth.</p></li></ul>',
+						credit: '',
+					},
 				},
 			];
 
@@ -205,35 +165,25 @@ describe('Enhance Images', () => {
 		});
 
 		it('sets the title prop for the previous image element when a h2 caption is found', () => {
-			const input: Block[] = [
+			const input: FEElement[] = [
+				image,
 				{
-					...blockMetaData,
-					elements: [
-						image,
-						{
-							_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
-							elementId: 'mockId',
-							html: '<h2>Example title text</h2>',
-						},
-					],
+					_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
+					elementId: 'mockId',
+					html: '<h2>Example title text</h2>',
 				},
 			];
 
-			const expectedOutput: Block[] = [
+			const expectedOutput: FEElement[] = [
 				{
-					...blockMetaData,
-					elements: [
-						{
-							...image,
-							displayCredit: false,
-							data: {
-								...image.data,
-								caption: '',
-								credit: '',
-							},
-							title: 'Example title text',
-						},
-					],
+					...image,
+					displayCredit: false,
+					data: {
+						...image.data,
+						caption: '',
+						credit: '',
+					},
+					title: 'Example title text',
 				},
 			];
 
@@ -243,51 +193,40 @@ describe('Enhance Images', () => {
 		});
 
 		it('handles when a caption, then a title follow an image, both are used', () => {
-			const input: Block[] = [
+			const input: FEElement[] = [
+				image,
 				{
-					...blockMetaData,
-					elements: [
-						image,
-						{
-							_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-							elementId: 'mockId',
-							html: '<ul><li><p>This is the caption</p></li></ul>',
-						},
-						{
-							_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
-							elementId: 'mockId',
-							html: '<h2>The title</h2>',
-						},
-						{
-							_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-							elementId: 'mockId',
-							html: '<p>Just some normal text</p>',
-						},
-					],
+					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+					elementId: 'mockId',
+					html: '<ul><li><p>This is the caption</p></li></ul>',
+				},
+				{
+					_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
+					elementId: 'mockId',
+					html: '<h2>The title</h2>',
+				},
+				{
+					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+					elementId: 'mockId',
+					html: '<p>Just some normal text</p>',
 				},
 			];
 
-			const expectedOutput: Block[] = [
+			const expectedOutput: FEElement[] = [
 				{
-					...blockMetaData,
-					elements: [
-						{
-							...image,
-							displayCredit: false,
-							data: {
-								...image.data,
-								caption:
-									'<ul><li><p>This is the caption</p></li></ul>',
-								credit: '',
-							},
-							title: 'The title',
-						},
-						{
-							_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-							elementId: 'mockId',
-							html: '<p>Just some normal text</p>',
-						},
-					],
+					...image,
+					displayCredit: false,
+					data: {
+						...image.data,
+						caption: '<ul><li><p>This is the caption</p></li></ul>',
+						credit: '',
+					},
+					title: 'The title',
+				},
+				{
+					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+					elementId: 'mockId',
+					html: '<p>Just some normal text</p>',
 				},
 			];
 
@@ -297,51 +236,31 @@ describe('Enhance Images', () => {
 		});
 
 		it('halfWidth images without an image to be paired with are placed as single images by themselves', () => {
-			const input: Block[] = [
+			const input: FEElement[] = [
+				{ ...image, role: 'halfWidth' },
+				{ ...image, role: 'halfWidth' },
+				{ ...image, role: 'halfWidth' },
 				{
-					...blockMetaData,
-					elements: [
-						{ ...image, role: 'halfWidth' },
-						{ ...image, role: 'halfWidth' },
-						{ ...image, role: 'halfWidth' },
-						{
-							_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-							elementId: 'mockId',
-							html: '<ul><li><p>This is the caption</p></li></ul>',
-						},
-					],
+					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+					elementId: 'mockId',
+					html: '<ul><li><p>This is the caption</p></li></ul>',
 				},
 			];
 
-			const expectedOutput: Block[] = [
+			const expectedOutput: FEElement[] = [
 				{
-					...blockMetaData,
-					elements: [
+					_type: 'model.dotcomrendering.pageElements.MultiImageBlockElement',
+					elementId: images[0].elementId,
+					images: [
 						{
-							_type: 'model.dotcomrendering.pageElements.MultiImageBlockElement',
-							elementId: images[0].elementId,
-							images: [
-								{
-									...image,
-									role: 'halfWidth',
-									displayCredit: false,
-									data: {
-										...image.data,
-										caption: '',
-										credit: '',
-									},
-								},
-								{
-									...image,
-									role: 'halfWidth',
-									displayCredit: false,
-									data: {
-										...image.data,
-										caption: '',
-										credit: '',
-									},
-								},
-							],
+							...image,
+							role: 'halfWidth',
+							displayCredit: false,
+							data: {
+								...image.data,
+								caption: '',
+								credit: '',
+							},
 						},
 						{
 							...image,
@@ -349,12 +268,21 @@ describe('Enhance Images', () => {
 							displayCredit: false,
 							data: {
 								...image.data,
-								caption:
-									'<ul><li><p>This is the caption</p></li></ul>',
+								caption: '',
 								credit: '',
 							},
 						},
 					],
+				},
+				{
+					...image,
+					role: 'halfWidth',
+					displayCredit: false,
+					data: {
+						...image.data,
+						caption: '<ul><li><p>This is the caption</p></li></ul>',
+						credit: '',
+					},
 				},
 			];
 
@@ -364,51 +292,40 @@ describe('Enhance Images', () => {
 		});
 
 		it('handles when a title, then a caption follow an image, both are used', () => {
-			const input: Block[] = [
+			const input: FEElement[] = [
+				image,
 				{
-					...blockMetaData,
-					elements: [
-						image,
-						{
-							_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
-							elementId: 'mockId',
-							html: '<h2>The title</h2>',
-						},
-						{
-							_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-							elementId: 'mockId',
-							html: '<ul><li><p>This is the caption</p></li></ul>',
-						},
-						{
-							_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-							elementId: 'mockId',
-							html: '<p>Just some normal text</p>',
-						},
-					],
+					_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
+					elementId: 'mockId',
+					html: '<h2>The title</h2>',
+				},
+				{
+					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+					elementId: 'mockId',
+					html: '<ul><li><p>This is the caption</p></li></ul>',
+				},
+				{
+					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+					elementId: 'mockId',
+					html: '<p>Just some normal text</p>',
 				},
 			];
 
-			const expectedOutput: Block[] = [
+			const expectedOutput: FEElement[] = [
 				{
-					...blockMetaData,
-					elements: [
-						{
-							...image,
-							displayCredit: false,
-							data: {
-								...image.data,
-								caption:
-									'<ul><li><p>This is the caption</p></li></ul>',
-								credit: '',
-							},
-							title: 'The title',
-						},
-						{
-							_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-							elementId: 'mockId',
-							html: '<p>Just some normal text</p>',
-						},
-					],
+					...image,
+					displayCredit: false,
+					data: {
+						...image.data,
+						caption: '<ul><li><p>This is the caption</p></li></ul>',
+						credit: '',
+					},
+					title: 'The title',
+				},
+				{
+					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+					elementId: 'mockId',
+					html: '<p>Just some normal text</p>',
 				},
 			];
 
@@ -418,27 +335,17 @@ describe('Enhance Images', () => {
 		});
 
 		it('removes default captions for photo essays and sets none at all if no ul element is found', () => {
-			const input: Block[] = [
-				{
-					...blockMetaData,
-					elements: [image],
-				},
-			];
+			const input: FEElement[] = [image];
 
-			const expectedOutput: Block[] = [
+			const expectedOutput: FEElement[] = [
 				{
-					...blockMetaData,
-					elements: [
-						{
-							...image,
-							displayCredit: false,
-							data: {
-								...image.data,
-								caption: '',
-								credit: '',
-							},
-						},
-					],
+					...image,
+					displayCredit: false,
+					data: {
+						...image.data,
+						caption: '',
+						credit: '',
+					},
 				},
 			];
 
@@ -447,73 +354,62 @@ describe('Enhance Images', () => {
 			);
 		});
 		it('handles if the last few images are not followed by any caption or title', () => {
-			const input: Block[] = [
+			const input: FEElement[] = [
+				image,
 				{
-					...blockMetaData,
-					elements: [
-						image,
-						{
-							_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
-							elementId: 'mockId',
-							html: '<h2>The title</h2>',
-						},
-						{
-							_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-							elementId: 'mockId',
-							html: '<ul><li><p>This is the caption</p></li></ul>',
-						},
-						{
-							_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-							elementId: 'mockId',
-							html: '<p>Just some normal text</p>',
-						},
-						{ ...image, role: 'inline' },
-						{ ...image, role: 'immersive' },
-					],
+					_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
+					elementId: 'mockId',
+					html: '<h2>The title</h2>',
 				},
+				{
+					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+					elementId: 'mockId',
+					html: '<ul><li><p>This is the caption</p></li></ul>',
+				},
+				{
+					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+					elementId: 'mockId',
+					html: '<p>Just some normal text</p>',
+				},
+				{ ...image, role: 'inline' },
+				{ ...image, role: 'immersive' },
 			];
 
-			const expectedOutput: Block[] = [
+			const expectedOutput: FEElement[] = [
 				{
-					...blockMetaData,
-					elements: [
-						{
-							...image,
-							displayCredit: false,
-							data: {
-								...image.data,
-								caption:
-									'<ul><li><p>This is the caption</p></li></ul>',
-								credit: '',
-							},
-							title: 'The title',
-						},
-						{
-							_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-							elementId: 'mockId',
-							html: '<p>Just some normal text</p>',
-						},
-						{
-							...image,
-							role: 'inline',
-							displayCredit: false,
-							data: {
-								...image.data,
-								caption: '',
-								credit: '',
-							},
-						},
-						{
-							...image,
-							role: 'immersive',
-							displayCredit: false,
-							data: {
-								...image.data,
-								caption: '',
-								credit: '',
-							},
-						},
-					],
+					...image,
+					displayCredit: false,
+					data: {
+						...image.data,
+						caption: '<ul><li><p>This is the caption</p></li></ul>',
+						credit: '',
+					},
+					title: 'The title',
+				},
+				{
+					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+					elementId: 'mockId',
+					html: '<p>Just some normal text</p>',
+				},
+				{
+					...image,
+					role: 'inline',
+					displayCredit: false,
+					data: {
+						...image.data,
+						caption: '',
+						credit: '',
+					},
+				},
+				{
+					...image,
+					role: 'immersive',
+					displayCredit: false,
+					data: {
+						...image.data,
+						caption: '',
+						credit: '',
+					},
 				},
 			];
 
@@ -523,50 +419,40 @@ describe('Enhance Images', () => {
 		});
 
 		it('will pass through other element types', () => {
-			const input: Block[] = [
+			const input: FEElement[] = [
 				{
-					...blockMetaData,
-					elements: [
-						{
-							// @ts-expect-error -- Need to ignore TS to check test works for other element types
-							_type: 'model.dotcomrendering.pageElements.model.dotcomrendering.pageElements.PullquoteBlockElement',
-							elementId: 'mockId',
-							html: '<p>A Pullquote</p>',
-							pillar: Pillar.News,
-							role: 'inline',
-						},
-						image,
-						{
-							_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
-							elementId: 'mockId',
-							html: '<h2>The title</h2>',
-						},
-					],
+					// @ts-expect-error -- Need to ignore TS to check test works for other element types
+					_type: 'model.dotcomrendering.pageElements.model.dotcomrendering.pageElements.PullquoteBlockElement',
+					elementId: 'mockId',
+					html: '<p>A Pullquote</p>',
+					pillar: Pillar.News,
+					role: 'inline',
+				},
+				image,
+				{
+					_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
+					elementId: 'mockId',
+					html: '<h2>The title</h2>',
 				},
 			];
 
 			const expectedOutput = [
 				{
-					...blockMetaData,
-					elements: [
-						{
-							_type: 'model.dotcomrendering.pageElements.model.dotcomrendering.pageElements.PullquoteBlockElement',
-							elementId: 'mockId',
-							html: '<p>A Pullquote</p>',
-							pillar: Pillar.News,
-							role: 'inline',
-						},
-						{
-							...image,
-							displayCredit: false,
-							data: {
-								...image.data,
-								caption: '',
-								credit: '',
-							},
-							title: 'The title',
-						},
-					],
+					_type: 'model.dotcomrendering.pageElements.model.dotcomrendering.pageElements.PullquoteBlockElement',
+					elementId: 'mockId',
+					html: '<p>A Pullquote</p>',
+					pillar: Pillar.News,
+					role: 'inline',
+				},
+				{
+					...image,
+					displayCredit: false,
+					data: {
+						...image.data,
+						caption: '',
+						credit: '',
+					},
+					title: 'The title',
 				},
 			];
 
@@ -578,22 +464,12 @@ describe('Enhance Images', () => {
 
 	describe('for normal articles', () => {
 		it('keeps default captions for articles other than photo essays', () => {
-			const input: Block[] = [
-				{
-					...blockMetaData,
-					elements: [image],
-				},
-			];
+			const input: FEElement[] = [image];
 
 			const expectedOutput = [
 				{
-					...blockMetaData,
-					elements: [
-						{
-							...image,
-							displayCredit: false,
-						},
-					],
+					...image,
+					displayCredit: false,
 				},
 			];
 
@@ -602,66 +478,55 @@ describe('Enhance Images', () => {
 			);
 		});
 		it('creates two sets of multi image elements when there are 4 halfWidths images in a row', () => {
-			const input: Block[] = [
+			const input: FEElement[] = [
+				{ ...image, role: 'halfWidth' },
+				{ ...image, role: 'halfWidth' },
+				{ ...image, role: 'halfWidth' },
+				{ ...image, role: 'halfWidth' },
 				{
-					...blockMetaData,
-					elements: [
-						{ ...image, role: 'halfWidth' },
-						{ ...image, role: 'halfWidth' },
-						{ ...image, role: 'halfWidth' },
-						{ ...image, role: 'halfWidth' },
-						{
-							_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-							elementId: 'mockId',
-							html: '<ul><li><p>This is the caption</p></li></ul>',
-						},
-					],
+					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+					elementId: 'mockId',
+					html: '<ul><li><p>This is the caption</p></li></ul>',
 				},
 			];
 
 			const expectedOutput = [
 				{
-					...blockMetaData,
-					elements: [
+					_type: 'model.dotcomrendering.pageElements.MultiImageBlockElement',
+					elementId: images[0].elementId,
+					images: [
 						{
-							_type: 'model.dotcomrendering.pageElements.MultiImageBlockElement',
-							elementId: images[0].elementId,
-							images: [
-								{
-									...image,
-									role: 'halfWidth',
-									displayCredit: false,
-									data: { ...image.data, caption: '' },
-								},
-								{
-									...image,
-									role: 'halfWidth',
-									displayCredit: false,
-									data: { ...image.data, caption: '' },
-								},
-							],
+							...image,
+							role: 'halfWidth',
+							displayCredit: false,
+							data: { ...image.data, caption: '' },
 						},
 						{
-							_type: 'model.dotcomrendering.pageElements.MultiImageBlockElement',
-							elementId: images[0].elementId,
-							images: [
-								{
-									...image,
-									role: 'halfWidth',
-									displayCredit: false,
-									data: { ...image.data, caption: '' },
-								},
-								{
-									...image,
-									role: 'halfWidth',
-									displayCredit: false,
-									data: { ...image.data, caption: '' },
-								},
-							],
-							caption:
-								'<ul><li><p>This is the caption</p></li></ul>',
+							...image,
+							role: 'halfWidth',
+							displayCredit: false,
+							data: { ...image.data, caption: '' },
 						},
 					],
+				},
+				{
+					_type: 'model.dotcomrendering.pageElements.MultiImageBlockElement',
+					elementId: images[0].elementId,
+					images: [
+						{
+							...image,
+							role: 'halfWidth',
+							displayCredit: false,
+							data: { ...image.data, caption: '' },
+						},
+						{
+							...image,
+							role: 'halfWidth',
+							displayCredit: false,
+							data: { ...image.data, caption: '' },
+						},
+					],
+					caption: '<ul><li><p>This is the caption</p></li></ul>',
 				},
 			];
 
@@ -671,37 +536,27 @@ describe('Enhance Images', () => {
 		});
 
 		it('adds the lightbox position for a valid image', () => {
-			const input: Block[] = [
+			const input: FEElement[] = [
 				{
-					...blockMetaData,
-					elements: [
-						{
-							...image,
-							role: 'inline',
-							data: {
-								caption:
-									'This text starts in data but gets removed for photo essays',
-								credit: 'but it is copied into the lightbox property so we can use it there',
-							},
-						},
-					],
+					...image,
+					role: 'inline',
+					data: {
+						caption:
+							'This text starts in data but gets removed for photo essays',
+						credit: 'but it is copied into the lightbox property so we can use it there',
+					},
 				},
 			];
 
-			const expectedOutput: Block[] = [
+			const expectedOutput: FEElement[] = [
 				{
-					...blockMetaData,
-					elements: [
-						{
-							...image,
-							position: 4,
-							role: 'inline',
-							data: {
-								caption: '',
-								credit: '',
-							},
-						},
-					],
+					...image,
+					position: 4,
+					role: 'inline',
+					data: {
+						caption: '',
+						credit: '',
+					},
 				},
 			];
 
@@ -720,51 +575,41 @@ describe('Enhance Images', () => {
 		});
 
 		it('does not strip the captions from any preceding halfwidth images if the special caption is not placed immediately after them', () => {
-			const input: Block[] = [
+			const input: FEElement[] = [
+				{ ...image, role: 'halfWidth' },
+				{ ...image, role: 'halfWidth' },
+				{ ...image, role: 'inline' },
 				{
-					...blockMetaData,
-					elements: [
-						{ ...image, role: 'halfWidth' },
-						{ ...image, role: 'halfWidth' },
-						{ ...image, role: 'inline' },
-						{
-							_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-							elementId: 'mockId',
-							html: '<ul><li><p>This is the caption</p></li></ul>',
-						},
-					],
+					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+					elementId: 'mockId',
+					html: '<ul><li><p>This is the caption</p></li></ul>',
 				},
 			];
 
 			const expectedOutput = [
 				{
-					...blockMetaData,
-					elements: [
+					_type: 'model.dotcomrendering.pageElements.MultiImageBlockElement',
+					elementId: images[0].elementId,
+					images: [
 						{
-							_type: 'model.dotcomrendering.pageElements.MultiImageBlockElement',
-							elementId: images[0].elementId,
-							images: [
-								{
-									...image,
-									role: 'halfWidth',
-									displayCredit: false,
-									data: { ...image.data, caption: '' },
-								},
-								{
-									...image,
-									role: 'halfWidth',
-									displayCredit: false,
-									data: { ...image.data, caption: '' },
-								},
-							],
+							...image,
+							role: 'halfWidth',
+							displayCredit: false,
+							data: { ...image.data, caption: '' },
 						},
-						{ ...image, role: 'inline' },
 						{
-							_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-							elementId: 'mockId',
-							html: '<ul><li><p>This is the caption</p></li></ul>',
+							...image,
+							role: 'halfWidth',
+							displayCredit: false,
+							data: { ...image.data, caption: '' },
 						},
 					],
+				},
+				{ ...image, role: 'inline' },
+				{
+					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+					elementId: 'mockId',
+					html: '<ul><li><p>This is the caption</p></li></ul>',
 				},
 			];
 
@@ -773,46 +618,36 @@ describe('Enhance Images', () => {
 			);
 		});
 		it('keeps the original captions and positions if there are 3 inline images in a row', () => {
-			const input: Block[] = [
-				{
-					...blockMetaData,
-					elements: [
-						{ ...image, role: 'inline' },
-						{ ...image, role: 'inline' },
-						{ ...image, role: 'inline' },
-					],
-				},
+			const input: FEElement[] = [
+				{ ...image, role: 'inline' },
+				{ ...image, role: 'inline' },
+				{ ...image, role: 'inline' },
 			];
 
 			const expectedOutput = [
 				{
-					...blockMetaData,
-					elements: [
-						{
-							...image,
-							role: 'inline',
-							displayCredit: false,
-							data: {
-								...image.data,
-							},
-						},
-						{
-							...image,
-							role: 'inline',
-							displayCredit: false,
-							data: {
-								...image.data,
-							},
-						},
-						{
-							...image,
-							role: 'inline',
-							displayCredit: false,
-							data: {
-								...image.data,
-							},
-						},
-					],
+					...image,
+					role: 'inline',
+					displayCredit: false,
+					data: {
+						...image.data,
+					},
+				},
+				{
+					...image,
+					role: 'inline',
+					displayCredit: false,
+					data: {
+						...image.data,
+					},
+				},
+				{
+					...image,
+					role: 'inline',
+					displayCredit: false,
+					data: {
+						...image.data,
+					},
 				},
 			];
 
@@ -821,19 +656,14 @@ describe('Enhance Images', () => {
 			);
 		});
 		it('does not strip captions if not a photo essay and there are no halfWidth images in the buffer', () => {
-			const input: Block[] = [
+			const input: FEElement[] = [
+				{ ...image, role: 'inline' },
+				{ ...image, role: 'inline' },
+				{ ...image, role: 'inline' },
 				{
-					...blockMetaData,
-					elements: [
-						{ ...image, role: 'inline' },
-						{ ...image, role: 'inline' },
-						{ ...image, role: 'inline' },
-						{
-							_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-							elementId: 'mockId',
-							html: '<ul><li><p>This is the caption</p></li></ul>',
-						},
-					],
+					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+					elementId: 'mockId',
+					html: '<ul><li><p>This is the caption</p></li></ul>',
 				},
 			];
 
@@ -845,19 +675,14 @@ describe('Enhance Images', () => {
 		});
 
 		it('does not strip captions if not a photo essay and there is only one halfWidth image in the buffer', () => {
-			const input: Block[] = [
+			const input: FEElement[] = [
+				{ ...image, role: 'inline' },
+				{ ...image, role: 'inline' },
+				{ ...image, role: 'halfWidth' },
 				{
-					...blockMetaData,
-					elements: [
-						{ ...image, role: 'inline' },
-						{ ...image, role: 'inline' },
-						{ ...image, role: 'halfWidth' },
-						{
-							_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-							elementId: 'mockId',
-							html: '<ul><li><p>This is the caption</p></li></ul>',
-						},
-					],
+					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+					elementId: 'mockId',
+					html: '<ul><li><p>This is the caption</p></li></ul>',
 				},
 			];
 
@@ -869,17 +694,12 @@ describe('Enhance Images', () => {
 		});
 
 		it('should only treat h2 text following an image as the image title on photo essays', () => {
-			const input: Block[] = [
+			const input: FEElement[] = [
+				image,
 				{
-					...blockMetaData,
-					elements: [
-						image,
-						{
-							_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
-							elementId: 'mockId',
-							html: '<h2>Example title text</h2>',
-						},
-					],
+					_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
+					elementId: 'mockId',
+					html: '<h2>Example title text</h2>',
 				},
 			];
 
@@ -891,50 +711,40 @@ describe('Enhance Images', () => {
 		});
 
 		it('does not use the special caption outside photo essays if it does not immediately follow the halfWidth images', () => {
-			const input: Block[] = [
+			const input: FEElement[] = [
+				{ ...image, role: 'halfWidth' },
+				{ ...image, role: 'halfWidth' },
+				{ ...image, role: 'inline' },
 				{
-					...blockMetaData,
-					elements: [
-						{ ...image, role: 'halfWidth' },
-						{ ...image, role: 'halfWidth' },
-						{ ...image, role: 'inline' },
-						{
-							_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-							elementId: 'mockId',
-							html: '<ul><li><p>This is the caption</p></li></ul>',
-						},
-					],
+					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+					elementId: 'mockId',
+					html: '<ul><li><p>This is the caption</p></li></ul>',
 				},
 			];
 			const expectedOutput = [
 				{
-					...blockMetaData,
-					elements: [
+					_type: 'model.dotcomrendering.pageElements.MultiImageBlockElement',
+					elementId: images[0].elementId,
+					images: [
 						{
-							_type: 'model.dotcomrendering.pageElements.MultiImageBlockElement',
-							elementId: images[0].elementId,
-							images: [
-								{
-									...image,
-									role: 'halfWidth',
-									displayCredit: false,
-									data: { ...image.data, caption: '' },
-								},
-								{
-									...image,
-									role: 'halfWidth',
-									displayCredit: false,
-									data: { ...image.data, caption: '' },
-								},
-							],
+							...image,
+							role: 'halfWidth',
+							displayCredit: false,
+							data: { ...image.data, caption: '' },
 						},
-						{ ...image, role: 'inline' },
 						{
-							_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-							elementId: 'mockId',
-							html: '<ul><li><p>This is the caption</p></li></ul>',
+							...image,
+							role: 'halfWidth',
+							displayCredit: false,
+							data: { ...image.data, caption: '' },
 						},
 					],
+				},
+				{ ...image, role: 'inline' },
+				{
+					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+					elementId: 'mockId',
+					html: '<ul><li><p>This is the caption</p></li></ul>',
 				},
 			];
 
@@ -944,55 +754,44 @@ describe('Enhance Images', () => {
 		});
 
 		it('replaces the caption outside photo essays if there are two or more halfWidth images at the end of the buffer', () => {
-			const input: Block[] = [
+			const input: FEElement[] = [
+				{ ...image, role: 'inline' },
+				{ ...image, role: 'halfWidth' },
+				{ ...image, role: 'halfWidth' },
 				{
-					...blockMetaData,
-					elements: [
-						{ ...image, role: 'inline' },
-						{ ...image, role: 'halfWidth' },
-						{ ...image, role: 'halfWidth' },
-						{
-							_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-							elementId: 'mockId',
-							html: '<ul><li><p>This is the caption</p></li></ul>',
-						},
-					],
+					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+					elementId: 'mockId',
+					html: '<ul><li><p>This is the caption</p></li></ul>',
 				},
 			];
 
 			const expectedOutput = [
 				{
-					...blockMetaData,
-					elements: [
+					...image,
+					role: 'inline',
+					displayCredit: false,
+					data: {
+						...image.data,
+					},
+				},
+				{
+					_type: 'model.dotcomrendering.pageElements.MultiImageBlockElement',
+					elementId: images[0].elementId,
+					images: [
 						{
 							...image,
-							role: 'inline',
+							role: 'halfWidth',
 							displayCredit: false,
-							data: {
-								...image.data,
-							},
+							data: { ...image.data, caption: '' },
 						},
 						{
-							_type: 'model.dotcomrendering.pageElements.MultiImageBlockElement',
-							elementId: images[0].elementId,
-							images: [
-								{
-									...image,
-									role: 'halfWidth',
-									displayCredit: false,
-									data: { ...image.data, caption: '' },
-								},
-								{
-									...image,
-									role: 'halfWidth',
-									displayCredit: false,
-									data: { ...image.data, caption: '' },
-								},
-							],
-							caption:
-								'<ul><li><p>This is the caption</p></li></ul>',
+							...image,
+							role: 'halfWidth',
+							displayCredit: false,
+							data: { ...image.data, caption: '' },
 						},
 					],
+					caption: '<ul><li><p>This is the caption</p></li></ul>',
 				},
 			];
 

--- a/dotcom-rendering/src/model/enhance-images.ts
+++ b/dotcom-rendering/src/model/enhance-images.ts
@@ -1,4 +1,8 @@
-import { ArticleDesign, type ArticleFormat } from '@guardian/libs';
+import {
+	ArticleDesign,
+	type ArticleFormat,
+	ArticleSpecial,
+} from '@guardian/libs';
 import { JSDOM } from 'jsdom';
 import { getLargest, getMaster } from '../lib/image';
 import type {
@@ -401,57 +405,47 @@ class Enhancer {
 	}
 }
 
-type Options = { isPhotoEssay: boolean; imagesForLightbox: ImageForLightbox[] };
+const enhance =
+	(isPhotoEssay: boolean, imagesForLightbox: ImageForLightbox[]) =>
+	(elements: FEElement[]): FEElement[] => {
+		if (isPhotoEssay) {
+			return new Enhancer(elements)
+				.stripCaptions()
+				.removeCredit()
+				.addMultiImageElements()
+				.addTitles()
+				.addCaptionsToMultis()
+				.addCaptionsToImages()
+				.addImagePositions(imagesForLightbox).elements;
+		}
 
-const enhance = (
-	elements: FEElement[],
-	{ isPhotoEssay, imagesForLightbox }: Options,
-): FEElement[] => {
-	if (isPhotoEssay) {
-		return new Enhancer(elements)
-			.stripCaptions()
-			.removeCredit()
-			.addMultiImageElements()
-			.addTitles()
-			.addCaptionsToMultis()
-			.addCaptionsToImages()
-			.addImagePositions(imagesForLightbox).elements;
-	}
-
-	return (
-		new Enhancer(elements)
-			// Replace pairs of halfWidth images with MultiImageBlockElements
-			.addMultiImageElements()
-			// If any MultiImageBlockElement is followed by a ul/l caption, delete the special caption
-			// element and use the value for the multi image `caption` prop
-			.addCaptionsToMultis()
-			.addImagePositions(imagesForLightbox).elements
-	);
-};
-
-export const enhanceImages =
-	(format: ArticleFormat, imagesForLightbox: ImageForLightbox[]) =>
-	(blocks: Block[]): Block[] => {
-		const isPhotoEssay = format.design === ArticleDesign.PhotoEssay;
-
-		return blocks.map((block: Block) => {
-			return {
-				...block,
-				elements: enhance(block.elements, {
-					isPhotoEssay,
-					imagesForLightbox,
-				}),
-			};
-		});
+		return (
+			new Enhancer(elements)
+				// Replace pairs of halfWidth images with MultiImageBlockElements
+				.addMultiImageElements()
+				// If any MultiImageBlockElement is followed by a ul/l caption, delete the special caption
+				// element and use the value for the multi image `caption` prop
+				.addCaptionsToMultis()
+				.addImagePositions(imagesForLightbox).elements
+		);
 	};
 
-export const enhanceElementsImages = (
-	elements: FEElement[],
-	format: FEFormat,
+export const enhanceImages = (
+	format: ArticleFormat,
 	imagesForLightbox: ImageForLightbox[],
-): FEElement[] =>
-	enhance(elements, {
-		isPhotoEssay:
-			format.design === 'PhotoEssayDesign' && format.theme !== 'Labs',
-		imagesForLightbox,
-	});
+): ((elements: FEElement[]) => FEElement[]) => {
+	const isPhotoEssay = format.design === ArticleDesign.PhotoEssay;
+
+	return enhance(isPhotoEssay, imagesForLightbox);
+};
+
+export const enhanceElementsImages = (
+	format: ArticleFormat,
+	imagesForLightbox: ImageForLightbox[],
+): ((elements: FEElement[]) => FEElement[]) => {
+	const isPhotoEssay =
+		format.design === ArticleDesign.PhotoEssay &&
+		format.theme !== ArticleSpecial.Labs;
+
+	return enhance(isPhotoEssay, imagesForLightbox);
+};

--- a/dotcom-rendering/src/model/enhance-interactive-contents-elements.ts
+++ b/dotcom-rendering/src/model/enhance-interactive-contents-elements.ts
@@ -2,7 +2,9 @@ import type { FEElement, SubheadingBlockElement } from '../types/content';
 import { isLegacyTableOfContents } from './isLegacyTableOfContents';
 import { stripHTML } from './sanitise';
 
-const enhance = (elements: FEElement[]): FEElement[] => {
+export const enhanceInteractiveContentsElements = (
+	elements: FEElement[],
+): FEElement[] => {
 	const updatedElements: FEElement[] = [];
 	const hasInteractiveContentsBlockElement = elements.some((element) =>
 		isLegacyTableOfContents(element),
@@ -59,11 +61,3 @@ const enhance = (elements: FEElement[]): FEElement[] => {
 
 	return updatedElements.length ? updatedElements : elements;
 };
-
-export const enhanceInteractiveContentsElements = (blocks: Block[]): Block[] =>
-	blocks.map((block: Block) => {
-		return {
-			...block,
-			elements: enhance(block.elements),
-		};
-	});

--- a/dotcom-rendering/src/model/enhance-numbered-lists.test.ts
+++ b/dotcom-rendering/src/model/enhance-numbered-lists.test.ts
@@ -1,8 +1,8 @@
 import { NumberedList } from '../../fixtures/generated/articles/NumberedList';
 import { Standard as ExampleArticle } from '../../fixtures/generated/articles/Standard';
 import { images } from '../../fixtures/generated/images';
-import { blockMetaData } from '../../fixtures/manual/block-meta-data';
 import { decideFormat } from '../lib/decideFormat';
+import type { FEElement } from '../types/content';
 import { enhanceNumberedLists } from './enhance-numbered-lists';
 
 const exampleArticleFormat = decideFormat(ExampleArticle.format);
@@ -10,26 +10,16 @@ const numberedListFormat = decideFormat(NumberedList.format);
 
 describe('Enhance Numbered Lists', () => {
 	it('does not enhance articles if they are not numbered lists', () => {
-		const input: Block[] = [
+		const input: FEElement[] = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						...images[0],
-						role: 'thumbnail',
-					},
-				],
+				...images[0],
+				role: 'thumbnail',
 			},
 		];
-		const expectedOutput: Block[] = [
+		const expectedOutput: FEElement[] = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						...images[0],
-						role: 'thumbnail',
-					},
-				],
+				...images[0],
+				role: 'thumbnail',
 			},
 		];
 		expect(enhanceNumberedLists(exampleArticleFormat)(input)).toEqual(
@@ -38,33 +28,23 @@ describe('Enhance Numbered Lists', () => {
 	});
 
 	it('replaces faux h3s with real ones, prefixing them with a divider', () => {
-		const input: Block[] = [
+		const input: FEElement[] = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'mockId',
-						html: '<p><strong>Faux H3 text</strong></p>',
-					},
-				],
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				elementId: 'mockId',
+				html: '<p><strong>Faux H3 text</strong></p>',
 			},
 		];
-		const expectedOutput: Block[] = [
+		const expectedOutput: FEElement[] = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.DividerBlockElement',
-						size: 'full',
-						spaceAbove: 'tight',
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'mockId',
-						html: '<h3>Faux H3 text</h3>',
-					},
-				],
+				_type: 'model.dotcomrendering.pageElements.DividerBlockElement',
+				size: 'full',
+				spaceAbove: 'tight',
+			},
+			{
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				elementId: 'mockId',
+				html: '<h3>Faux H3 text</h3>',
 			},
 		];
 		expect(enhanceNumberedLists(numberedListFormat)(input)).toEqual(
@@ -73,33 +53,23 @@ describe('Enhance Numbered Lists', () => {
 	});
 
 	it('does set a h3 if there is more than one strong tag', () => {
-		const input: Block[] = [
+		const input: FEElement[] = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'mockId',
-						html: '<p><strong>Strong 1</strong> <strong>Strong 2</strong></p>',
-					},
-				],
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				elementId: 'mockId',
+				html: '<p><strong>Strong 1</strong> <strong>Strong 2</strong></p>',
 			},
 		];
-		const expectedOutput: Block[] = [
+		const expectedOutput: FEElement[] = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.DividerBlockElement',
-						size: 'full',
-						spaceAbove: 'tight',
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'mockId',
-						html: '<h3>Strong 1 Strong 2</h3>',
-					},
-				],
+				_type: 'model.dotcomrendering.pageElements.DividerBlockElement',
+				size: 'full',
+				spaceAbove: 'tight',
+			},
+			{
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				elementId: 'mockId',
+				html: '<h3>Strong 1 Strong 2</h3>',
 			},
 		];
 		expect(enhanceNumberedLists(numberedListFormat)(input)).toEqual(
@@ -108,33 +78,23 @@ describe('Enhance Numbered Lists', () => {
 	});
 
 	it('does set a h3 if there is more than one strong tag', () => {
-		const input: Block[] = [
+		const input: FEElement[] = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'mockId',
-						html: '<p><strong>Strong 1</strong> <strong>Strong 2 <a href="example.com">Some Link</a></strong></p>',
-					},
-				],
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				elementId: 'mockId',
+				html: '<p><strong>Strong 1</strong> <strong>Strong 2 <a href="example.com">Some Link</a></strong></p>',
 			},
 		];
-		const expectedOutput: Block[] = [
+		const expectedOutput: FEElement[] = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.DividerBlockElement',
-						size: 'full',
-						spaceAbove: 'tight',
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'mockId',
-						html: '<h3>Strong 1 Strong 2 <a href="example.com">Some Link</a></h3>',
-					},
-				],
+				_type: 'model.dotcomrendering.pageElements.DividerBlockElement',
+				size: 'full',
+				spaceAbove: 'tight',
+			},
+			{
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				elementId: 'mockId',
+				html: '<h3>Strong 1 Strong 2 <a href="example.com">Some Link</a></h3>',
 			},
 		];
 		expect(enhanceNumberedLists(numberedListFormat)(input)).toEqual(
@@ -143,33 +103,23 @@ describe('Enhance Numbered Lists', () => {
 	});
 
 	it('does set an h3 and extract all text even if it is between stong tages', () => {
-		const input: Block[] = [
+		const input: FEElement[] = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'mockId',
-						html: '<p><strong>Strong 1</strong> some text inbetween <strong>Strong 2</strong></p>',
-					},
-				],
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				elementId: 'mockId',
+				html: '<p><strong>Strong 1</strong> some text inbetween <strong>Strong 2</strong></p>',
 			},
 		];
-		const expectedOutput: Block[] = [
+		const expectedOutput: FEElement[] = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.DividerBlockElement',
-						size: 'full',
-						spaceAbove: 'tight',
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'mockId',
-						html: '<h3>Strong 1 some text inbetween Strong 2</h3>',
-					},
-				],
+				_type: 'model.dotcomrendering.pageElements.DividerBlockElement',
+				size: 'full',
+				spaceAbove: 'tight',
+			},
+			{
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				elementId: 'mockId',
+				html: '<h3>Strong 1 some text inbetween Strong 2</h3>',
 			},
 		];
 		expect(enhanceNumberedLists(numberedListFormat)(input)).toEqual(
@@ -178,28 +128,18 @@ describe('Enhance Numbered Lists', () => {
 	});
 
 	it('does not set a h3 if there is text before the strong tag', () => {
-		const input: Block[] = [
+		const input: FEElement[] = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'mockId',
-						html: '<p>Some text before <strong>Strong 1</strong></p>',
-					},
-				],
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				elementId: 'mockId',
+				html: '<p>Some text before <strong>Strong 1</strong></p>',
 			},
 		];
-		const expectedOutput: Block[] = [
+		const expectedOutput: FEElement[] = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'mockId',
-						html: '<p>Some text before <strong>Strong 1</strong></p>',
-					},
-				],
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				elementId: 'mockId',
+				html: '<p>Some text before <strong>Strong 1</strong></p>',
 			},
 		];
 		expect(enhanceNumberedLists(numberedListFormat)(input)).toEqual(
@@ -208,28 +148,18 @@ describe('Enhance Numbered Lists', () => {
 	});
 
 	it('does not set a h3 if there is text after the strong tag', () => {
-		const input: Block[] = [
+		const input: FEElement[] = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'mockId',
-						html: '<p><strong>Strong 1</strong>Some text after</p>',
-					},
-				],
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				elementId: 'mockId',
+				html: '<p><strong>Strong 1</strong>Some text after</p>',
 			},
 		];
-		const expectedOutput: Block[] = [
+		const expectedOutput: FEElement[] = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'mockId',
-						html: '<p><strong>Strong 1</strong>Some text after</p>',
-					},
-				],
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				elementId: 'mockId',
+				html: '<p><strong>Strong 1</strong>Some text after</p>',
 			},
 		];
 		expect(enhanceNumberedLists(numberedListFormat)(input)).toEqual(
@@ -238,28 +168,18 @@ describe('Enhance Numbered Lists', () => {
 	});
 
 	it('does not set a h3 if there is text before and after the strong tag', () => {
-		const input: Block[] = [
+		const input: FEElement[] = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'mockId',
-						html: '<p>Some text before <strong>Strong 1</strong>Some text after</p>',
-					},
-				],
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				elementId: 'mockId',
+				html: '<p>Some text before <strong>Strong 1</strong>Some text after</p>',
 			},
 		];
-		const expectedOutput: Block[] = [
+		const expectedOutput: FEElement[] = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'mockId',
-						html: '<p>Some text before <strong>Strong 1</strong>Some text after</p>',
-					},
-				],
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				elementId: 'mockId',
+				html: '<p>Some text before <strong>Strong 1</strong>Some text after</p>',
 			},
 		];
 		expect(enhanceNumberedLists(numberedListFormat)(input)).toEqual(
@@ -268,28 +188,18 @@ describe('Enhance Numbered Lists', () => {
 	});
 
 	it('does not set a h3 if there if the html does not end with a strong p tag combo', () => {
-		const input: Block[] = [
+		const input: FEElement[] = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'mockId',
-						html: '<p><strong>abc</strong>some other text</p>',
-					},
-				],
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				elementId: 'mockId',
+				html: '<p><strong>abc</strong>some other text</p>',
 			},
 		];
-		const expectedOutput: Block[] = [
+		const expectedOutput: FEElement[] = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'mockId',
-						html: '<p><strong>abc</strong>some other text</p>',
-					},
-				],
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				elementId: 'mockId',
+				html: '<p><strong>abc</strong>some other text</p>',
 			},
 		];
 		expect(enhanceNumberedLists(numberedListFormat)(input)).toEqual(
@@ -298,43 +208,33 @@ describe('Enhance Numbered Lists', () => {
 	});
 
 	it('does set divider `spaceAbove` to `loose` if ItemLinkBlockElement is followed by fauxH3', () => {
-		const input: Block[] = [
+		const input: FEElement[] = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.ItemLinkBlockElement',
-						elementId: 'mockId',
-						html: '<ul><li><strong>Item link block</strong><a href="https://www.theguardian.com">Link</a></li></ul>',
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'mockId',
-						html: '<p><strong>Faux H3 text</strong></p>',
-					},
-				],
+				_type: 'model.dotcomrendering.pageElements.ItemLinkBlockElement',
+				elementId: 'mockId',
+				html: '<ul><li><strong>Item link block</strong><a href="https://www.theguardian.com">Link</a></li></ul>',
+			},
+			{
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				elementId: 'mockId',
+				html: '<p><strong>Faux H3 text</strong></p>',
 			},
 		];
-		const expectedOutput: Block[] = [
+		const expectedOutput: FEElement[] = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.ItemLinkBlockElement',
-						elementId: 'mockId',
-						html: '<ul><li><strong>Item link block</strong><a href="https://www.theguardian.com">Link</a></li></ul>',
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.DividerBlockElement',
-						size: 'full',
-						spaceAbove: 'loose',
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'mockId',
-						html: '<h3>Faux H3 text</h3>',
-					},
-				],
+				_type: 'model.dotcomrendering.pageElements.ItemLinkBlockElement',
+				elementId: 'mockId',
+				html: '<ul><li><strong>Item link block</strong><a href="https://www.theguardian.com">Link</a></li></ul>',
+			},
+			{
+				_type: 'model.dotcomrendering.pageElements.DividerBlockElement',
+				size: 'full',
+				spaceAbove: 'loose',
+			},
+			{
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				elementId: 'mockId',
+				html: '<h3>Faux H3 text</h3>',
 			},
 		];
 		expect(enhanceNumberedLists(numberedListFormat)(input)).toEqual(
@@ -343,43 +243,33 @@ describe('Enhance Numbered Lists', () => {
 	});
 
 	it('does set divider `spaceAbove` to `tight` if fauxH3 is not proceeded by ItemLinkBlockElement', () => {
-		const input: Block[] = [
+		const input: FEElement[] = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'mockId',
-						html: 'some HTML text',
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'mockId',
-						html: '<p><strong>Faux H3 text</strong></p>',
-					},
-				],
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				elementId: 'mockId',
+				html: 'some HTML text',
+			},
+			{
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				elementId: 'mockId',
+				html: '<p><strong>Faux H3 text</strong></p>',
 			},
 		];
-		const expectedOutput: Block[] = [
+		const expectedOutput: FEElement[] = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'mockId',
-						html: 'some HTML text',
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.DividerBlockElement',
-						size: 'full',
-						spaceAbove: 'tight',
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'mockId',
-						html: '<h3>Faux H3 text</h3>',
-					},
-				],
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				elementId: 'mockId',
+				html: 'some HTML text',
+			},
+			{
+				_type: 'model.dotcomrendering.pageElements.DividerBlockElement',
+				size: 'full',
+				spaceAbove: 'tight',
+			},
+			{
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				elementId: 'mockId',
+				html: '<h3>Faux H3 text</h3>',
 			},
 		];
 		expect(enhanceNumberedLists(numberedListFormat)(input)).toEqual(
@@ -388,30 +278,20 @@ describe('Enhance Numbered Lists', () => {
 	});
 
 	it('replaces ★★★★☆ with the StarRating component', () => {
-		const input: Block[] = [
+		const input: FEElement[] = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'mockId',
-						html: '<p>★★★★☆</p>',
-					},
-				],
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				elementId: 'mockId',
+				html: '<p>★★★★☆</p>',
 			},
 		];
 
-		const expectedOutput: Block[] = [
+		const expectedOutput: FEElement[] = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.StarRatingBlockElement',
-						elementId: 'mockId',
-						rating: 4,
-						size: 'large',
-					},
-				],
+				_type: 'model.dotcomrendering.pageElements.StarRatingBlockElement',
+				elementId: 'mockId',
+				rating: 4,
+				size: 'large',
 			},
 		];
 
@@ -421,20 +301,15 @@ describe('Enhance Numbered Lists', () => {
 	});
 
 	it('ignores ascii stars when there is other text present', () => {
-		const input: Block[] = [
+		const input: FEElement[] = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'mockId',
-						html: '<p>I give this 4 ★★★★☆</p>',
-					},
-				],
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				elementId: 'mockId',
+				html: '<p>I give this 4 ★★★★☆</p>',
 			},
 		];
 
-		const expectedOutput: Block[] = input;
+		const expectedOutput: FEElement[] = input;
 
 		expect(enhanceNumberedLists(numberedListFormat)(input)).toEqual(
 			expectedOutput,
@@ -442,20 +317,15 @@ describe('Enhance Numbered Lists', () => {
 	});
 
 	it('ignores ascii stars when there are not 5 stars', () => {
-		const input: Block[] = [
+		const input: FEElement[] = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'mockId',
-						html: '<p>★★☆</p>',
-					},
-				],
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				elementId: 'mockId',
+				html: '<p>★★☆</p>',
 			},
 		];
 
-		const expectedOutput: Block[] = input;
+		const expectedOutput: FEElement[] = input;
 
 		expect(enhanceNumberedLists(numberedListFormat)(input)).toEqual(
 			expectedOutput,
@@ -463,19 +333,14 @@ describe('Enhance Numbered Lists', () => {
 	});
 
 	it('ignores ascii stars that are not wrapped in p tags', () => {
-		const input: Block[] = [
+		const input: FEElement[] = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'mockId',
-						html: '<h2 data-ignore="global-h2-styling">★★★★☆</h2>',
-					},
-				],
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				elementId: 'mockId',
+				html: '<h2 data-ignore="global-h2-styling">★★★★☆</h2>',
 			},
 		];
-		const expectedOutput: Block[] = input;
+		const expectedOutput: FEElement[] = input;
 
 		expect(enhanceNumberedLists(numberedListFormat)(input)).toEqual(
 			expectedOutput,
@@ -483,30 +348,20 @@ describe('Enhance Numbered Lists', () => {
 	});
 
 	it('can handle zero (selected) stars', () => {
-		const input: Block[] = [
+		const input: FEElement[] = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'mockId',
-						html: '<p>☆☆☆☆☆</p>',
-					},
-				],
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				elementId: 'mockId',
+				html: '<p>☆☆☆☆☆</p>',
 			},
 		];
 
-		const expectedOutput: Block[] = [
+		const expectedOutput: FEElement[] = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.StarRatingBlockElement',
-						elementId: 'mockId',
-						rating: 0,
-						size: 'large',
-					},
-				],
+				_type: 'model.dotcomrendering.pageElements.StarRatingBlockElement',
+				elementId: 'mockId',
+				rating: 0,
+				size: 'large',
 			},
 		];
 
@@ -516,30 +371,20 @@ describe('Enhance Numbered Lists', () => {
 	});
 
 	it('can handle really good things that have five stars!', () => {
-		const input: Block[] = [
+		const input: FEElement[] = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'mockId',
-						html: '<p>★★★★★</p>',
-					},
-				],
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				elementId: 'mockId',
+				html: '<p>★★★★★</p>',
 			},
 		];
 
-		const expectedOutput: Block[] = [
+		const expectedOutput: FEElement[] = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.StarRatingBlockElement',
-						elementId: 'mockId',
-						rating: 5,
-						size: 'large',
-					},
-				],
+				_type: 'model.dotcomrendering.pageElements.StarRatingBlockElement',
+				elementId: 'mockId',
+				rating: 5,
+				size: 'large',
 			},
 		];
 
@@ -549,29 +394,19 @@ describe('Enhance Numbered Lists', () => {
 	});
 
 	it('When stars are found ahead of images, it updates the image and then removes the stars', () => {
-		const input: Block[] = [
+		const input: FEElement[] = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'mockId',
-						html: '<p>★☆☆☆☆</p>',
-					},
-					images[0],
-				],
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				elementId: 'mockId',
+				html: '<p>★☆☆☆☆</p>',
 			},
+			images[0],
 		];
 
-		const expectedOutput: Block[] = [
+		const expectedOutput: FEElement[] = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						...images[0],
-						starRating: 1,
-					},
-				],
+				...images[0],
+				starRating: 1,
 			},
 		];
 
@@ -581,29 +416,19 @@ describe('Enhance Numbered Lists', () => {
 	});
 
 	it('When stars are found ahead of images, it updates the image and then removes the stars, even when rating is zero', () => {
-		const input: Block[] = [
+		const input: FEElement[] = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'mockId',
-						html: '<p>☆☆☆☆☆</p>',
-					},
-					images[0],
-				],
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				elementId: 'mockId',
+				html: '<p>☆☆☆☆☆</p>',
 			},
+			images[0],
 		];
 
-		const expectedOutput: Block[] = [
+		const expectedOutput: FEElement[] = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						...images[0],
-						starRating: 0,
-					},
-				],
+				...images[0],
+				starRating: 0,
 			},
 		];
 
@@ -613,18 +438,10 @@ describe('Enhance Numbered Lists', () => {
 	});
 
 	it('Sets the isAvatar flag for thumbnail images', () => {
-		const input: Block[] = [
-			{
-				...blockMetaData,
-				elements: [{ ...images[0], role: 'thumbnail' }],
-			},
-		];
+		const input: FEElement[] = [{ ...images[0], role: 'thumbnail' }];
 
-		const expectedOutput: Block[] = [
-			{
-				...blockMetaData,
-				elements: [{ ...images[0], role: 'thumbnail', isAvatar: true }],
-			},
+		const expectedOutput: FEElement[] = [
+			{ ...images[0], role: 'thumbnail', isAvatar: true },
 		];
 
 		expect(enhanceNumberedLists(numberedListFormat)(input)).toEqual(
@@ -633,35 +450,25 @@ describe('Enhance Numbered Lists', () => {
 	});
 
 	it('replaces h2s with NumberedTitles', () => {
-		const input: Block[] = [
+		const input: FEElement[] = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
-						elementId: 'mockId',
-						html: '<h2 data-ignore="global-h2-styling">Some text</h2>',
-					},
-				],
+				_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
+				elementId: 'mockId',
+				html: '<h2 data-ignore="global-h2-styling">Some text</h2>',
 			},
 		];
 
-		const expectedOutput: Block[] = [
+		const expectedOutput: FEElement[] = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.DividerBlockElement',
-						size: 'full',
-						spaceAbove: 'loose',
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.NumberedTitleBlockElement',
-						elementId: 'mockId',
-						position: 1,
-						html: '<h2 data-ignore="global-h2-styling">Some text</h2>',
-					},
-				],
+				_type: 'model.dotcomrendering.pageElements.DividerBlockElement',
+				size: 'full',
+				spaceAbove: 'loose',
+			},
+			{
+				_type: 'model.dotcomrendering.pageElements.NumberedTitleBlockElement',
+				elementId: 'mockId',
+				position: 1,
+				html: '<h2 data-ignore="global-h2-styling">Some text</h2>',
 			},
 		];
 
@@ -671,78 +478,68 @@ describe('Enhance Numbered Lists', () => {
 	});
 
 	it('increments the position for multiple h2s', () => {
-		const input: Block[] = [
+		const input: FEElement[] = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
-						elementId: 'mockId1',
-						html: '<h2 data-ignore="global-h2-styling">Some text</h2>',
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'mockId',
-						html: '<p>☆☆☆☆☆</p>',
-					},
-					images[0],
-					{
-						_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
-						elementId: 'mockId2',
-						html: '<h2 data-ignore="global-h2-styling">Other text</h2>',
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
-						elementId: 'mockId3',
-						html: '<h2 data-ignore="global-h2-styling">More text</h2>',
-					},
-				],
+				_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
+				elementId: 'mockId1',
+				html: '<h2 data-ignore="global-h2-styling">Some text</h2>',
+			},
+			{
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				elementId: 'mockId',
+				html: '<p>☆☆☆☆☆</p>',
+			},
+			images[0],
+			{
+				_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
+				elementId: 'mockId2',
+				html: '<h2 data-ignore="global-h2-styling">Other text</h2>',
+			},
+			{
+				_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
+				elementId: 'mockId3',
+				html: '<h2 data-ignore="global-h2-styling">More text</h2>',
 			},
 		];
 
-		const expectedOutput: Block[] = [
+		const expectedOutput: FEElement[] = [
 			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.DividerBlockElement',
-						size: 'full',
-						spaceAbove: 'loose',
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.NumberedTitleBlockElement',
-						elementId: 'mockId1',
-						position: 1,
-						html: '<h2 data-ignore="global-h2-styling">Some text</h2>',
-					},
-					{
-						...images[0],
-						starRating: 0,
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.DividerBlockElement',
-						size: 'full',
-						spaceAbove: 'loose',
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.NumberedTitleBlockElement',
-						elementId: 'mockId2',
-						position: 2,
-						html: '<h2 data-ignore="global-h2-styling">Other text</h2>',
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.DividerBlockElement',
-						size: 'full',
-						spaceAbove: 'loose',
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.NumberedTitleBlockElement',
+				_type: 'model.dotcomrendering.pageElements.DividerBlockElement',
+				size: 'full',
+				spaceAbove: 'loose',
+			},
+			{
+				_type: 'model.dotcomrendering.pageElements.NumberedTitleBlockElement',
+				elementId: 'mockId1',
+				position: 1,
+				html: '<h2 data-ignore="global-h2-styling">Some text</h2>',
+			},
+			{
+				...images[0],
+				starRating: 0,
+			},
+			{
+				_type: 'model.dotcomrendering.pageElements.DividerBlockElement',
+				size: 'full',
+				spaceAbove: 'loose',
+			},
+			{
+				_type: 'model.dotcomrendering.pageElements.NumberedTitleBlockElement',
+				elementId: 'mockId2',
+				position: 2,
+				html: '<h2 data-ignore="global-h2-styling">Other text</h2>',
+			},
+			{
+				_type: 'model.dotcomrendering.pageElements.DividerBlockElement',
+				size: 'full',
+				spaceAbove: 'loose',
+			},
+			{
+				_type: 'model.dotcomrendering.pageElements.NumberedTitleBlockElement',
 
-						elementId: 'mockId3',
-						position: 3,
-						html: '<h2 data-ignore="global-h2-styling">More text</h2>',
-					},
-				],
+				elementId: 'mockId3',
+				position: 3,
+				html: '<h2 data-ignore="global-h2-styling">More text</h2>',
 			},
 		];
 

--- a/dotcom-rendering/src/model/enhance-numbered-lists.ts
+++ b/dotcom-rendering/src/model/enhance-numbered-lists.ts
@@ -376,39 +376,30 @@ class Enhancer {
 	}
 }
 
-const enhance = (elements: FEElement[]): FEElement[] => {
-	return (
-		new Enhancer(elements)
-			// Add the data-ignore='global-h2-styling' attribute
-			.removeGlobalH2Styles()
-			// Turn false h3s into real ones
-			.addH3s()
-			// Add item links
-			.addItemLinks()
-			// Add numbered titles
-			.addTitles()
-			// Overlay stars onto images
-			.starifyImages()
-			// Turn ascii stars into components
-			.inlineStarRatings()
-			// Thumbnail images should be round
-			.makeThumbnailsRound().elements
-	);
-};
-
 export const enhanceNumberedLists =
 	(format: ArticleFormat) =>
-	(blocks: Block[]): Block[] => {
+	(elements: FEElement[]): FEElement[] => {
 		const isNumberedList = format.display === ArticleDisplay.NumberedList;
 
 		if (!isNumberedList) {
-			return blocks;
+			return elements;
 		}
 
-		return blocks.map((block: Block) => {
-			return {
-				...block,
-				elements: enhance(block.elements),
-			};
-		});
+		return (
+			new Enhancer(elements)
+				// Add the data-ignore='global-h2-styling' attribute
+				.removeGlobalH2Styles()
+				// Turn false h3s into real ones
+				.addH3s()
+				// Add item links
+				.addItemLinks()
+				// Add numbered titles
+				.addTitles()
+				// Overlay stars onto images
+				.starifyImages()
+				// Turn ascii stars into components
+				.inlineStarRatings()
+				// Thumbnail images should be round
+				.makeThumbnailsRound().elements
+		);
 	};

--- a/dotcom-rendering/src/model/enhance-tweets.ts
+++ b/dotcom-rendering/src/model/enhance-tweets.ts
@@ -1,6 +1,6 @@
 import type { FEElement } from '../types/content';
 
-const removeTweetClass = (elements: FEElement[]): FEElement[] =>
+export const enhanceTweets = (elements: FEElement[]): FEElement[] =>
 	elements.map<FEElement>((element) => {
 		switch (element._type) {
 			case 'model.dotcomrendering.pageElements.TweetBlockElement': {
@@ -20,12 +20,4 @@ const removeTweetClass = (elements: FEElement[]): FEElement[] =>
 			default:
 				return element;
 		}
-	});
-
-export const enhanceTweets = (blocks: Block[]): Block[] =>
-	blocks.map((block: Block) => {
-		return {
-			...block,
-			elements: removeTweetClass(block.elements),
-		};
 	});

--- a/dotcom-rendering/src/model/insertPromotedNewsletter.test.ts
+++ b/dotcom-rendering/src/model/insertPromotedNewsletter.test.ts
@@ -22,17 +22,17 @@ const NEWSLETTER: Newsletter = {
 
 describe('Insert Newsletter Signups', () => {
 	it('inserts a NewsletterSignupBlockElement to a standard article if there is a newsletter', () => {
+		const elements = exampleStandard.blocks[0]?.elements ?? [];
 		const insertedBlock = insertPromotedNewsletter(
-			exampleStandard.blocks,
+			elements,
+			exampleStandard.blocks[0]?.id ?? 'mock id',
 			decideFormat(exampleStandard.format),
 			NEWSLETTER,
-		)
-			.flatMap((block) => block.elements)
-			.find(
-				(element) =>
-					element._type ===
-					'model.dotcomrendering.pageElements.NewsletterSignupBlockElement',
-			);
+		).find(
+			(element) =>
+				element._type ===
+				'model.dotcomrendering.pageElements.NewsletterSignupBlockElement',
+		);
 
 		expect(insertedBlock).toBeTruthy();
 		expect(
@@ -41,34 +41,34 @@ describe('Insert Newsletter Signups', () => {
 	});
 
 	it('will not insert a NewsletterSignupBlockElement into a blog', () => {
+		const elements = exampleStandard.blocks[0]?.elements ?? [];
 		expect(
 			insertPromotedNewsletter(
-				exampleLiveBlog.blocks,
+				elements,
+				exampleLiveBlog.blocks[0]?.id ?? 'mock id',
 				decideFormat(exampleLiveBlog.format),
 				NEWSLETTER,
-			)
-				.flatMap((block) => block.elements)
-				.find(
-					(element) =>
-						element._type ===
-						'model.dotcomrendering.pageElements.NewsletterSignupBlockElement',
-				),
+			).find(
+				(element) =>
+					element._type ===
+					'model.dotcomrendering.pageElements.NewsletterSignupBlockElement',
+			),
 		).toBeFalsy();
 	});
 
 	it('will not insert a NewsletterSignupBlockElement into a quiz', () => {
+		const elements = exampleStandard.blocks[0]?.elements ?? [];
 		expect(
 			insertPromotedNewsletter(
-				exampleQuiz.blocks,
+				elements,
+				exampleQuiz.blocks[0]?.id ?? 'mock id',
 				decideFormat(exampleQuiz.format),
 				NEWSLETTER,
-			)
-				.flatMap((block) => block.elements)
-				.find(
-					(element) =>
-						element._type ===
-						'model.dotcomrendering.pageElements.NewsletterSignupBlockElement',
-				),
+			).find(
+				(element) =>
+					element._type ===
+					'model.dotcomrendering.pageElements.NewsletterSignupBlockElement',
+			),
 		).toBeFalsy();
 	});
 });

--- a/dotcom-rendering/src/model/insertPromotedNewsletter.ts
+++ b/dotcom-rendering/src/model/insertPromotedNewsletter.ts
@@ -199,10 +199,11 @@ const tryToInsert = (
 };
 
 export const insertPromotedNewsletter = (
-	blocks: Block[],
+	elements: FEElement[],
+	blockId: string,
 	format: ArticleFormat,
 	promotedNewsletter: Newsletter,
-): Block[] => {
+): FEElement[] => {
 	switch (format.design) {
 		case ArticleDesign.Standard:
 		case ArticleDesign.Gallery:
@@ -218,17 +219,8 @@ export const insertPromotedNewsletter = (
 		case ArticleDesign.Editorial:
 		case ArticleDesign.Obituary:
 		case ArticleDesign.Explainer:
-			return blocks.map((block: Block) => {
-				return {
-					...block,
-					elements: tryToInsert(
-						promotedNewsletter,
-						block.elements,
-						block.id,
-					),
-				};
-			});
+			return tryToInsert(promotedNewsletter, elements, blockId);
 		default:
-			return blocks;
+			return elements;
 	}
 };


### PR DESCRIPTION
Changing most of the enhancers to work on elements rather than blocks. Most of them were just iterating through blocks and updating the elements anyway, and we need to work with elements directly in #10795.

Paired with @alinaboghiu 

**Note:** I recommend turning on "hide whitespace" to view the diff.

## More Details

The core change is modifying the enhancer functions to be `FEElement[] => FEElement[]` rather than `Block[] => Block[]`. In some cases this means just updating the type. In other cases this means deleting a wrapping function that was iterating through the blocks and calling an "element enhancer" function; the element enhancer function can now be exported directly.

Most of the rest of the changes are updating the tests to use elements directly as input data, rather than blocks.
