### PR TITLE
Discussion comment link dark mode tweak colours

### DIFF
--- a/dotcom-rendering/src/components/Discussion/Comment.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comment.tsx
@@ -116,7 +116,9 @@ const blockedCommentStyles = css`
 const commentLinkStyling = css`
 	a {
 		color: ${schemedPalette('--discussion-link')};
-		text-decoration: none;
+		text-decoration-color: ${schemedPalette(
+			'--discussion-comment-underline',
+		)};
 		:hover {
 			text-decoration: underline;
 		}

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -5056,6 +5056,11 @@ const interactiveAtomBackgroundDark: PaletteFunction = () =>
 const discussionPreModLight: PaletteFunction = () => sourcePalette.brand[500];
 const discussionPreModDark: PaletteFunction = () => sourcePalette.brand[800];
 
+const discussionCommentUnderlineLight: PaletteFunction = () =>
+	sourcePalette.neutral[86];
+const discussionCommentUnderlineDark: PaletteFunction = () =>
+	transparentColour(sourcePalette.neutral[86], 0.5);
+
 // ----- Palette ----- //
 
 /**
@@ -6008,6 +6013,10 @@ const paletteColours = {
 	'--discussion-pre-mod': {
 		light: discussionPreModLight,
 		dark: discussionPreModDark,
+	},
+	'--discussion-comment-underline': {
+		light: discussionCommentUnderlineLight,
+		dark: discussionCommentUnderlineDark,
 	},
 } satisfies PaletteColours;
 


### PR DESCRIPTION
## What does this change?
This updates the colours of a discussion comment link
## Why?
New designs. Resolves https://github.com/guardian/dotcom-rendering/issues/10717
## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/110032454/5903858d-32e7-407c-a971-9e35194c6a68
[after]: https://github.com/guardian/dotcom-rendering/assets/110032454/fb7018be-96ca-4ca5-b31b-7d5cfc46cabd

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
