### PR TITLE
Correctly stack and space text formatting buttons

### DIFF
--- a/dotcom-rendering/src/components/Discussion/CommentForm.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentForm.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { space, text, textSans } from '@guardian/source-foundations';
+import { space, text, textSans, until } from '@guardian/source-foundations';
 import { Link } from '@guardian/source-react-components';
 import { InfoSummary } from '@guardian/source-react-components-development-kitchen';
 import { useEffect, useRef, useState } from 'react';
@@ -152,10 +152,10 @@ const bottomContainer = css`
 	justify-content: space-between;
 	align-items: stretch;
 	align-content: space-between;
-`;
-
-const wrappingRow = css`
-	flex-flow: wrap;
+	gap: ${space[3]}px;
+	${until.wide} {
+		flex-direction: column-reverse;
+	}
 `;
 
 const Space = ({ amount }: { amount: 1 | 2 | 3 | 4 | 5 | 6 | 9 | 12 | 24 }) => (
@@ -506,7 +506,7 @@ export const CommentForm = ({
 					onFocus={() => setIsActive(true)}
 				/>
 				<div css={bottomContainer}>
-					<Row cssOverrides={wrappingRow}>
+					<Row>
 						<>
 							<PillarButton
 								type="submit"
@@ -541,7 +541,7 @@ export const CommentForm = ({
 						</>
 					</Row>
 					{isActive && (
-						<Row cssOverrides={wrappingRow}>
+						<Row>
 							<button
 								onClick={(e) => {
 									e.preventDefault();


### PR DESCRIPTION
## What does this change?
Adjusts the styling of text formatting buttons on discussion so they sit above the post comment buttons. It also adjusts the spacing to give them more room.

## Why?
This was requested by design as part of the discussion design audit.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/20416599/6fcbdb08-e514-4fe1-977f-c9882d2da975
[after]: https://github.com/guardian/dotcom-rendering/assets/20416599/064dcaf2-e69f-4362-9f62-3ea4761c6fb3
<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
