### PR TITLE
Downsize AR `PROD` instances to T4g micro instead of small

### DIFF
--- a/apps-rendering/cdk/bin/cdk.ts
+++ b/apps-rendering/cdk/bin/cdk.ts
@@ -28,7 +28,7 @@ new MobileAppsRendering(app, 'MobileAppsRendering-PROD', {
 		minimumInstances: 3,
 		maximumInstances: 12,
 	},
-	instanceSize: InstanceSize.SMALL,
+	instanceSize: InstanceSize.MICRO,
 	appsRenderingDomain: 'mobile-aws.guardianapis.com',
 	hostedZoneId: 'Z1EYB4AREPXE3B',
 	targetCpuUtilisation: 20,


### PR DESCRIPTION
## What does this change?

Reduces the size of the instances running in AR prod from `T4g` micro to `T4g` small.

## Why?

We are using about 2% CPU so are definitely over-provisioned for the amount of traffic AR is receiving:

<img width="944" alt="Screenshot 2024-03-05 at 11 06 03" src="https://github.com/guardian/dotcom-rendering/assets/43961396/685aec4e-e2b3-4f45-9638-6f7e759930de">
