### PR TITLE
Align comment reply 

### DIFF
--- a/dotcom-rendering/src/components/Discussion/Comment.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comment.tsx
@@ -198,7 +198,6 @@ const iconWrapper = css`
 
 const timestampWrapperStyles = css`
 	margin-left: ${space[2]}px;
-	margin-bottom: -2px;
 	display: flex;
 	flex-direction: column;
 	justify-content: center;
@@ -289,6 +288,7 @@ const cssReplyAlphaDisplayName = css`
 `;
 
 const cssReplyBetaDisplayName = css`
+	margin-top: -2px;
 	${until.mobileLandscape} {
 		${cssTextOverflowElip}
 		min-width: 40%;


### PR DESCRIPTION
## What does this change?
This aligns the comment reply username and timestamp
## Why?
Resolves https://github.com/guardian/dotcom-rendering/issues/10829
## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/110032454/5e8d3006-2087-4b28-8d58-5aade2f6d131
[after]: https://github.com/guardian/dotcom-rendering/assets/110032454/8e89b5e7-9e82-43fd-aa27-3c37a1d82891

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
