### PR TITLE
Reduce instances running in `PROD`

### DIFF
--- a/dotcom-rendering/cdk/bin/cdk.ts
+++ b/dotcom-rendering/cdk/bin/cdk.ts
@@ -33,7 +33,7 @@ new RenderingCDKStack(cdkApp, 'ArticleRendering-CODE', {
 	guApp: 'article-rendering',
 	stage: 'CODE',
 	domainName: 'article-rendering.code.dev-guardianapis.com',
-	scaling: { minimumInstances: 1, maximumInstances: 4 },
+	scaling: { minimumInstances: 1, maximumInstances: 3 },
 	instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MICRO),
 });
 new RenderingCDKStack(cdkApp, 'ArticleRendering-PROD', {
@@ -41,8 +41,8 @@ new RenderingCDKStack(cdkApp, 'ArticleRendering-PROD', {
 	stage: 'PROD',
 	domainName: 'article-rendering.guardianapis.com',
 	scaling: {
-		minimumInstances: 24,
-		maximumInstances: 96,
+		minimumInstances: 18,
+		maximumInstances: 90,
 		policy: {
 			scalingStepsOut: [
 				// No scaling up effect when latency is lower than 0.2s
@@ -68,7 +68,7 @@ new RenderingCDKStack(cdkApp, 'FaciaRendering-CODE', {
 	guApp: 'facia-rendering',
 	stage: 'CODE',
 	domainName: 'facia-rendering.code.dev-guardianapis.com',
-	scaling: { minimumInstances: 1, maximumInstances: 4 },
+	scaling: { minimumInstances: 1, maximumInstances: 3 },
 	instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.SMALL),
 });
 new RenderingCDKStack(cdkApp, 'FaciaRendering-PROD', {
@@ -76,8 +76,8 @@ new RenderingCDKStack(cdkApp, 'FaciaRendering-PROD', {
 	stage: 'PROD',
 	domainName: 'facia-rendering.guardianapis.com',
 	scaling: {
-		minimumInstances: 12,
-		maximumInstances: 48,
+		minimumInstances: 9,
+		maximumInstances: 45,
 		policy: {
 			scalingStepsOut: [
 				// No scaling up effect when latency is lower than 0.4s
@@ -103,7 +103,7 @@ new RenderingCDKStack(cdkApp, 'InteractiveRendering-CODE', {
 	guApp: 'interactive-rendering',
 	stage: 'CODE',
 	domainName: 'interactive-rendering.code.dev-guardianapis.com',
-	scaling: { minimumInstances: 1, maximumInstances: 4 },
+	scaling: { minimumInstances: 1, maximumInstances: 3 },
 	instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MICRO),
 });
 new RenderingCDKStack(cdkApp, 'InteractiveRendering-PROD', {


### PR DESCRIPTION
## What does this change?

Reduces the number of instances running in the `article` and `facia` apps [now that we're using `C7g` fixed instance types](https://github.com/guardian/dotcom-rendering/pull/10815) and can afford to use a higher % of CPU.

Also reduces the maximum number of instances in the `CODE` environments as we would never need to run more than 1 in each AZ