### PR TITLE
Prevent duplicate comments

### DIFF
--- a/dotcom-rendering/src/components/Discussion/CommentForm.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentForm.tsx
@@ -235,6 +235,7 @@ export const CommentForm = ({
 	setPreviewBody,
 }: Props) => {
 	const [isActive, setIsActive] = useState(false);
+	const [isDisabled, setIsDisabled] = useState(false);
 
 	const textAreaRef = useRef<HTMLTextAreaElement>(null);
 
@@ -324,6 +325,8 @@ export const CommentForm = ({
 	};
 
 	const submitForm = async () => {
+		if (isDisabled) return;
+		setIsDisabled(true);
 		setError('');
 
 		const body = textAreaRef.current?.value;
@@ -412,6 +415,7 @@ export const CommentForm = ({
 				resetForm();
 			}
 		}
+		setIsDisabled(false);
 	};
 
 	const submitUserName = async (userName: string) => {


### PR DESCRIPTION
## What does this change?
When rapidly clicking the form submit button multiple comments can be posted. This change should fix that. Tested on code.
## Why?
Resolves https://github.com/guardian/dotcom-rendering/issues/9881
## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]:  https://github.com/guardian/dotcom-rendering/assets/110032454/b7d68108-b88f-443c-804d-1014955b320e

[after]: https://github.com/guardian/dotcom-rendering/assets/110032454/3ea5ab53-8fbb-4df3-8dba-2cc8418c1079

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
