### PR TITLE
Add Well Actually to the all newsletters page

### DIFF
--- a/dotcom-rendering/src/model/newsletter-grouping.ts
+++ b/dotcom-rendering/src/model/newsletter-grouping.ts
@@ -208,6 +208,7 @@ export const groups: Partial<Record<EditionId, StaticGroups>> = {
 				'the-crunch',
 				'swift-notes',
 				'first-dog',
+				'reclaim-your-brain',
 				'well-actually',
 			],
 		},


### PR DESCRIPTION
## What does this change?

Adds _Well Actually_ to the all newsletters page and rearranges positions others as requested.

## Why?

Resolves https://github.com/guardian/dotcom-rendering/issues/10848

## Screenshots

| | Before      | After      |
|-------| ----------- | ---------- |
| UK | ![before-uk][] | ![after-uk][] |
| US | ![before-us][] | ![after-us][] |
| AU | ![before-au][] | ![after-au][] |

[before-uk]: https://github.com/guardian/dotcom-rendering/assets/43961396/683e34cd-2812-4ffe-8544-c9ef24e60bd8
[after-uk]: https://github.com/guardian/dotcom-rendering/assets/43961396/de13d56b-d4fc-449c-b556-20a8e42d3d83
[before-us]: https://github.com/guardian/dotcom-rendering/assets/43961396/95020294-64c3-40f2-b509-6f829c75baf7
[after-us]: https://github.com/guardian/dotcom-rendering/assets/43961396/cbd97a70-ea6d-4d6f-bbd7-e18b61a8913b
[before-au]: https://github.com/guardian/dotcom-rendering/assets/43961396/fb726c3a-e2d1-400b-afd0-622ebfa9dcb7
[after-au]: https://github.com/guardian/dotcom-rendering/assets/43961396/1419601a-2faf-438b-b28a-edab3f0adfc8