### PR TITLE
Hook bridget app discussion

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -45,7 +45,7 @@
 		"@emotion/server": "11.11.0",
 		"@guardian/ab-core": "7.0.1",
 		"@guardian/braze-components": "18.1.0",
-		"@guardian/bridget": "v0.0.0-2024-02-28-SNAPSHOT-DISC",
+		"@guardian/bridget": "0.0.0-2024-02-28-SNAPSHOT-DISC",
 		"@guardian/browserslist-config": "6.1.0",
 		"@guardian/cdk": "50.13.0",
 		"@guardian/commercial": "17.0.0",

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -45,7 +45,7 @@
 		"@emotion/server": "11.11.0",
 		"@guardian/ab-core": "7.0.1",
 		"@guardian/braze-components": "18.1.0",
-		"@guardian/bridget": "2.6.0",
+		"@guardian/bridget": "v0.0.0-2024-02-28-SNAPSHOT-DISC",
 		"@guardian/browserslist-config": "6.1.0",
 		"@guardian/cdk": "50.13.0",
 		"@guardian/commercial": "17.0.0",

--- a/dotcom-rendering/src/components/Discussion/AbuseReportForm.tsx
+++ b/dotcom-rendering/src/components/Discussion/AbuseReportForm.tsx
@@ -159,10 +159,10 @@ export const AbuseReportForm = ({
 		}
 
 		reportAbuse({
-			categoryId,
+			categoryId: categoryId.toString(),
 			reason,
 			email,
-			commentId,
+			commentId: commentId.toString(),
 		})
 			.then((response) => {
 				if (response.kind === 'error') {

--- a/dotcom-rendering/src/components/Discussion/CommentForm.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentForm.tsx
@@ -330,7 +330,11 @@ export const CommentForm = ({
 
 		if (body) {
 			const response = commentBeingRepliedTo
-				? await user.onReply(shortUrl, body, commentBeingRepliedTo.id)
+				? await user.onReply(
+						shortUrl,
+						body,
+						commentBeingRepliedTo.id.toString(),
+				  )
 				: await user.onComment(shortUrl, body);
 			// Check response message for error states
 			if (response.kind === 'error') {

--- a/dotcom-rendering/src/components/Discussion/RecommendationCount.tsx
+++ b/dotcom-rendering/src/components/Discussion/RecommendationCount.tsx
@@ -63,7 +63,7 @@ export const RecommendationCount = ({
 		setCount(newCount);
 		setRecommended(true);
 
-		user.onRecommend(commentId)
+		user.onRecommend(commentId.toString())
 			.then((accepted) => {
 				if (!accepted) {
 					setCount(newCount - 1);

--- a/dotcom-rendering/src/components/DiscussionApps.importable.tsx
+++ b/dotcom-rendering/src/components/DiscussionApps.importable.tsx
@@ -33,9 +33,30 @@ const onComment = async (
 		});
 };
 
-const onReply = async (): Promise<CommentResponse> => {
-	console.log('onReply');
-	return { kind: 'error', error: 'ApiError' };
+const onReply = async (
+	shortUrl: string,
+	body: string,
+	parentCommentId: string,
+): Promise<CommentResponse> => {
+	return getdiscussionClient()
+		.reply(shortUrl, body, parentCommentId)
+		.then((response) => {
+			if (response.__type == 'error') {
+				return {
+					kind: 'error',
+					error: 'NativeError',
+				};
+			} else {
+				if (response.response.errorCode) {
+					return {
+						kind: 'error',
+						error: 'ApiError',
+					};
+				}
+
+				return ok(Number(response.response.message));
+			}
+		});
 };
 
 const onRecommend = async (commentId: string): Promise<boolean> => {

--- a/dotcom-rendering/src/components/DiscussionApps.importable.tsx
+++ b/dotcom-rendering/src/components/DiscussionApps.importable.tsx
@@ -112,20 +112,13 @@ const reportAbuse = async ({
 		});
 };
 
-const mockedProfile: UserProfile = {
-	userId: 'userId',
-	displayName: 'displayName',
-	webUrl: 'webUrl',
-	apiUrl: 'apiUrl',
-	avatar: 'avatar',
-	secureAvatarUrl: 'secureAvatarUrl',
-	badge: [],
-};
-
 const getUser = async (): Promise<Reader> => {
 	return getdiscussionClient()
 		.getUserProfile()
 		.then((response) => {
+			// TODO: I don't think we're handling a discussion API
+			// error for this request in the Bridget API
+
 			if (response.__type === 'profile') {
 				const profile = response.profile;
 				const userProfile = {
@@ -149,15 +142,7 @@ const getUser = async (): Promise<Reader> => {
 				};
 			} else {
 				// TODO: Handle the error properly
-				return {
-					kind: 'Reader',
-					onComment,
-					onReply,
-					onRecommend,
-					addUsername,
-					reportAbuse,
-					profile: mockedProfile,
-				};
+				throw error('NativeError');
 			}
 		});
 };

--- a/dotcom-rendering/src/components/DiscussionApps.importable.tsx
+++ b/dotcom-rendering/src/components/DiscussionApps.importable.tsx
@@ -3,7 +3,7 @@ import { getdiscussionClient } from '../lib/bridgetApi';
 import type { Reader, UserProfile } from '../lib/discussion';
 import type { CommentResponse } from '../lib/discussionApi';
 import { reportAbuse as reportAbuseWeb } from '../lib/discussionApi';
-import { ok, type Result } from '../lib/result';
+import { ok, error, type Result } from '../lib/result';
 import { Discussion, type Props as DiscussionProps } from './Discussion';
 
 type Props = Omit<DiscussionProps, 'user' | 'reportAbuseUnauthenticated'>;
@@ -71,9 +71,19 @@ const onRecommend = async (commentId: string): Promise<boolean> => {
 			}
 		});
 };
-const addUsername = async (): Promise<Result<string, true>> => {
-	console.log('addUsername');
-	return { kind: 'error', error: 'ApiError' };
+const addUsername = async (username: string): Promise<Result<string, true>> => {
+	return getdiscussionClient()
+		.addUsername(username)
+		.then((response) => {
+			if (response.__type === 'error') {
+				return error('NativeError');
+			} else {
+				if (response.response.errorCode) {
+					return error('ApiError');
+				}
+				return ok(true);
+			}
+		});
 };
 
 /***

--- a/dotcom-rendering/src/components/DiscussionApps.importable.tsx
+++ b/dotcom-rendering/src/components/DiscussionApps.importable.tsx
@@ -18,8 +18,17 @@ const onReply = async (): Promise<CommentResponse> => {
 	return { kind: 'error', error: 'ApiError' };
 };
 
-const onRecommend = async (commentId: number): Promise<boolean> => {
-	return getdiscussionClient().recommend(commentId);
+const onRecommend = async (commentId: string): Promise<boolean> => {
+	return getdiscussionClient()
+		.recommend(commentId)
+		.then((response) => {
+			if (response.__type === 'error') {
+				return false;
+			} else {
+				if (response.response.statusCode === 200) return true;
+				return false;
+			}
+		});
 };
 const addUsername = async (): Promise<Result<string, true>> => {
 	console.log('addUsername');

--- a/dotcom-rendering/src/components/DiscussionApps.importable.tsx
+++ b/dotcom-rendering/src/components/DiscussionApps.importable.tsx
@@ -3,14 +3,34 @@ import { getdiscussionClient } from '../lib/bridgetApi';
 import type { Reader, UserProfile } from '../lib/discussion';
 import type { CommentResponse } from '../lib/discussionApi';
 import { reportAbuse as reportAbuseWeb } from '../lib/discussionApi';
-import type { Result } from '../lib/result';
+import { ok, type Result } from '../lib/result';
 import { Discussion, type Props as DiscussionProps } from './Discussion';
 
 type Props = Omit<DiscussionProps, 'user' | 'reportAbuseUnauthenticated'>;
 
-const onComment = async (): Promise<CommentResponse> => {
-	console.log('onComment');
-	return { kind: 'error', error: 'ApiError' };
+const onComment = async (
+	shortUrl: string,
+	body: string,
+): Promise<CommentResponse> => {
+	return getdiscussionClient()
+		.comment(shortUrl, body)
+		.then((response) => {
+			if (response.__type == 'error') {
+				return {
+					kind: 'error',
+					error: 'NativeError',
+				};
+			} else {
+				if (response.response.errorCode) {
+					return {
+						kind: 'error',
+						error: 'ApiError',
+					};
+				}
+
+				return ok(Number(response.response.message));
+			}
+		});
 };
 
 const onReply = async (): Promise<CommentResponse> => {

--- a/dotcom-rendering/src/lib/bridgetApi.ts
+++ b/dotcom-rendering/src/lib/bridgetApi.ts
@@ -11,7 +11,6 @@ import * as Notifications from '@guardian/bridget/Notifications';
 import * as Tag from '@guardian/bridget/Tag';
 import * as User from '@guardian/bridget/User';
 import * as Video from '@guardian/bridget/Videos';
-import * as DiscussionResponse from '@guardian/bridget/DiscussionResponse';
 import { createAppClient } from './thrift/nativeConnection';
 
 let environmentClient: Environment.Client<void> | undefined = undefined;

--- a/dotcom-rendering/src/lib/bridgetApi.ts
+++ b/dotcom-rendering/src/lib/bridgetApi.ts
@@ -11,6 +11,7 @@ import * as Notifications from '@guardian/bridget/Notifications';
 import * as Tag from '@guardian/bridget/Tag';
 import * as User from '@guardian/bridget/User';
 import * as Video from '@guardian/bridget/Videos';
+import * as DiscussionResponse from '@guardian/bridget/DiscussionResponse';
 import { createAppClient } from './thrift/nativeConnection';
 
 let environmentClient: Environment.Client<void> | undefined = undefined;

--- a/dotcom-rendering/src/lib/discussionApi.tsx
+++ b/dotcom-rendering/src/lib/discussionApi.tsx
@@ -265,22 +265,18 @@ export const reportAbuse =
 		email,
 		reason,
 	}: {
-		commentId: number;
-		categoryId: number;
+		commentId: string;
+		categoryId: string;
 		reason?: string;
 		email?: string;
 	}): Promise<Result<string, true>> => {
 		const url =
-			joinUrl(
-				options.baseUrl,
-				'comment',
-				commentId.toString(),
-				'reportAbuse',
-			) + objAsParams(defaultParams);
+			joinUrl(options.baseUrl, 'comment', commentId, 'reportAbuse') +
+			objAsParams(defaultParams);
 
 		const data = new URLSearchParams();
-		data.append('categoryId', categoryId.toString());
-		email && data.append('email', email.toString());
+		data.append('categoryId', categoryId);
+		email && data.append('email', email);
 		reason && data.append('reason', reason);
 
 		const authOptions = authStatus

--- a/dotcom-rendering/src/lib/discussionApi.tsx
+++ b/dotcom-rendering/src/lib/discussionApi.tsx
@@ -306,14 +306,10 @@ export const reportAbuse =
 
 export const recommend =
 	(authStatus: SignedInWithCookies | SignedInWithOkta) =>
-	async (commentId: number): Promise<boolean> => {
+	async (commentId: string): Promise<boolean> => {
 		const url =
-			joinUrl(
-				options.baseUrl,
-				'comment',
-				commentId.toString(),
-				'recommend',
-			) + objAsParams(defaultParams);
+			joinUrl(options.baseUrl, 'comment', commentId, 'recommend') +
+			objAsParams(defaultParams);
 
 		const authOptions = getOptionsHeadersWithOkta(authStatus);
 

--- a/dotcom-rendering/src/lib/discussionApi.tsx
+++ b/dotcom-rendering/src/lib/discussionApi.tsx
@@ -199,7 +199,7 @@ export const reply =
 	async (
 		shortUrl: string,
 		body: string,
-		parentCommentId: number,
+		parentCommentId: string,
 	): Promise<CommentResponse> => {
 		const url =
 			joinUrl(
@@ -207,7 +207,7 @@ export const reply =
 				'discussion',
 				shortUrl,
 				'comment',
-				parentCommentId.toString(),
+				parentCommentId,
 				'reply',
 			) + objAsParams(defaultParams);
 		const data = new URLSearchParams();

--- a/dotcom-rendering/src/lib/discussionApi.tsx
+++ b/dotcom-rendering/src/lib/discussionApi.tsx
@@ -162,6 +162,7 @@ export const preview = async (
 export type CommentResponse = Result<
 	| 'NetworkError'
 	| 'ApiError'
+	| 'NativeError'
 	| (ReturnType<typeof parseCommentResponse> & { kind: 'error' })['error'],
 	number
 >;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -345,8 +345,8 @@ importers:
         specifier: 18.1.0
         version: 18.1.0(@emotion/react@11.11.1)(@guardian/libs@16.0.1)(@guardian/source-foundations@14.1.4)(@guardian/source-react-components-development-kitchen@19.0.0)(@guardian/source-react-components@22.0.1)(react@18.2.0)
       '@guardian/bridget':
-        specifier: 2.6.0
-        version: 2.6.0
+        specifier: v0.0.0-2024-02-28-SNAPSHOT-DISC
+        version: 0.0.0-2024-02-28-SNAPSHOT-DISC
       '@guardian/browserslist-config':
         specifier: 6.1.0
         version: 6.1.0(browserslist@4.21.9)(tslib@2.6.2)
@@ -4239,6 +4239,10 @@ packages:
       '@guardian/source-react-components': 22.0.1(@emotion/react@11.11.1)(@guardian/source-foundations@14.1.4)(react@18.2.0)(tslib@2.6.2)(typescript@5.3.3)
       '@guardian/source-react-components-development-kitchen': 19.0.0(@emotion/react@11.11.1)(@guardian/libs@16.0.1)(@guardian/source-foundations@14.1.4)(@guardian/source-react-components@22.0.1)(react@18.2.0)(tslib@2.6.2)(typescript@5.3.3)
       react: 18.2.0
+    dev: false
+
+  /@guardian/bridget@0.0.0-2024-02-28-SNAPSHOT-DISC:
+    resolution: {integrity: sha512-W+cxY6oMbU2ldJgbm/ADmBFC1YRjoKcoftmDte4oVqtYthJaR/z9BcYEAtHx0skss+P/05Bphg28bs/dEo7Msg==}
     dev: false
 
   /@guardian/bridget@2.6.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,9 +1,5 @@
 lockfileVersion: '6.0'
 
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false
-
 importers:
 
   .:
@@ -345,7 +341,7 @@ importers:
         specifier: 18.1.0
         version: 18.1.0(@emotion/react@11.11.1)(@guardian/libs@16.0.1)(@guardian/source-foundations@14.1.4)(@guardian/source-react-components-development-kitchen@19.0.0)(@guardian/source-react-components@22.0.1)(react@18.2.0)
       '@guardian/bridget':
-        specifier: v0.0.0-2024-02-28-SNAPSHOT-DISC
+        specifier: 0.0.0-2024-02-28-SNAPSHOT-DISC
         version: 0.0.0-2024-02-28-SNAPSHOT-DISC
       '@guardian/browserslist-config':
         specifier: 6.1.0
@@ -11924,7 +11920,7 @@ packages:
       debug: 4.3.4(supports-color@8.1.1)
       enhanced-resolve: 5.15.0
       eslint: 8.56.0
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.61.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.5.5)(eslint@8.56.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.18.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
       eslint-plugin-import: 2.26.0(@typescript-eslint/parser@5.61.0)(eslint-import-resolver-typescript@3.5.5)(eslint@8.56.0)
       get-tsconfig: 4.7.2
       globby: 13.2.2
@@ -20600,3 +20596,7 @@ packages:
     name: babel-plugin-px-to-rem
     version: 0.1.0
     dev: false
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false


### PR DESCRIPTION
## What does this change?

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
