### PR TITLE
Remove `babel-plugin-px-to-rem`

### DIFF
--- a/dotcom-rendering/babel.config.js
+++ b/dotcom-rendering/babel.config.js
@@ -7,7 +7,6 @@ module.exports = {
 		'@babel/plugin-proposal-class-properties',
 		'@babel/plugin-proposal-optional-chaining',
 		'@babel/plugin-proposal-nullish-coalescing-operator',
-		'babel-plugin-px-to-rem',
 		'@babel/plugin-transform-runtime',
 		'@emotion/babel-plugin',
 	],

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -130,7 +130,6 @@
 		"aws-cdk-lib": "2.100.0",
 		"babel-loader": "9.1.3",
 		"babel-plugin-polyfill-corejs3": "0.6.0",
-		"babel-plugin-px-to-rem": "github:guardian/babel-plugin-px-to-rem#v0.1.0",
 		"babel-plugin-transform-runtime": "6.23.0",
 		"body-parser": "1.20.1",
 		"browserslist": "4.21.9",

--- a/dotcom-rendering/scripts/env/check-deps.js
+++ b/dotcom-rendering/scripts/env/check-deps.js
@@ -8,16 +8,9 @@ if (pkg.devDependencies) {
 	process.exit(1);
 }
 
-/**
- * We don't check packages that are not semver-compatible
- */
-const exceptions = /** @type {const} */ ([
-	'github:guardian/babel-plugin-px-to-rem#v0.1.0',
-]);
-
-const mismatches = Object.entries(pkg.dependencies)
-	.filter(([, version]) => !exceptions.includes(version))
-	.filter(([, version]) => !semver.valid(version));
+const mismatches = Object.entries(pkg.dependencies).filter(
+	([, version]) => !semver.valid(version),
+);
 
 if (mismatches.length !== 0) {
 	warn('dotcom-rendering dependencies should be pinned.');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -599,9 +599,6 @@ importers:
       babel-plugin-polyfill-corejs3:
         specifier: 0.6.0
         version: 0.6.0(@babel/core@7.23.2)
-      babel-plugin-px-to-rem:
-        specifier: github:guardian/babel-plugin-px-to-rem#v0.1.0
-        version: github.com/guardian/babel-plugin-px-to-rem/548c5f5bfdfdfc317b86103d27565868bd7d381c
       babel-plugin-transform-runtime:
         specifier: 6.23.0
         version: 6.23.0
@@ -20586,10 +20583,4 @@ packages:
 
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
-    dev: false
-
-  github.com/guardian/babel-plugin-px-to-rem/548c5f5bfdfdfc317b86103d27565868bd7d381c:
-    resolution: {tarball: https://codeload.github.com/guardian/babel-plugin-px-to-rem/tar.gz/548c5f5bfdfdfc317b86103d27565868bd7d381c}
-    name: babel-plugin-px-to-rem
-    version: 0.1.0
     dev: false


### PR DESCRIPTION
We don't believe it's used for most bundles. It is used for the legacy bundle, but we don't believe it works there anyway.

More context here https://docs.google.com/document/d/1QRPsFit62RsRzXUMzRimglihMktykNg9gaheGdfwTcs
