### PR TITLE
Swap `article` instance type from c7g to t4g until reservations made

### DIFF
--- a/dotcom-rendering/cdk/bin/cdk.ts
+++ b/dotcom-rendering/cdk/bin/cdk.ts
@@ -60,7 +60,7 @@ new RenderingCDKStack(cdkApp, 'ArticleRendering-PROD', {
 			],
 		},
 	},
-	instanceType: InstanceType.of(InstanceClass.C7G, InstanceSize.MEDIUM),
+	instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.SMALL),
 });
 
 /** Facia */


### PR DESCRIPTION
## What does this change?

Follow-on from https://github.com/guardian/dotcom-rendering/pull/10845 to stop using c7g instances on `article-rendering` app until the AWS reservations for this year have been made

## Why?

It's adding unnecessary costs to our infrastructure