### PR TITLE
Delete The `guardian` Dependabot Group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,9 +26,6 @@ updates:
       eslint:
         patterns:
           - '*eslint*'
-      guardian:
-        patterns:
-          - '@guardian/*'
       jest:
         patterns:
           - 'jest*'


### PR DESCRIPTION
We think `guardian` packages are too disparate to be bumped together.

Packages within the `storybook`, `babel` and `react` groups are generally related and versioned in sync with one another, so we think updating them together makes sense. However, the `guardian` group contains packages like `cdk`, `content-api-models` and `source-foundations` that are not related to one another. This means PRs updating this group are large, and encompass a number of disconnected changes (e.g. #10851), so we'd prefer to split them into separate PRs.
