### PR TITLE
Make reason required for "Legal Issue"

### DIFF
--- a/dotcom-rendering/src/components/Discussion/AbuseReportForm.tsx
+++ b/dotcom-rendering/src/components/Discussion/AbuseReportForm.tsx
@@ -217,9 +217,12 @@ export const AbuseReportForm = ({
 			});
 	};
 
-	/** If the "Other" category is selected, you must supply a reason */
+	/** If the "Other" or the "Legal Issue" categories are selected, you must supply a reason */
+	const legalIssueCategoryId = 3;
 	const otherCategoryId = 9;
-	const isReasonRequired = formVariables.categoryId === otherCategoryId;
+	const isReasonRequired =
+		formVariables.categoryId === otherCategoryId ||
+		formVariables.categoryId === legalIssueCategoryId;
 
 	return (
 		<div aria-modal="true" ref={modalRef}>
@@ -257,7 +260,9 @@ export const AbuseReportForm = ({
 						<Option value="0">Please select</Option>
 						<Option value="1">Personal abuse</Option>
 						<Option value="2">Off topic</Option>
-						<Option value="3">Legal issue</Option>
+						<Option value={legalIssueCategoryId}>
+							Legal issue
+						</Option>
 						<Option value="4">Trolling</Option>
 						<Option value="5">Hate speech</Option>
 						<Option value="6">


### PR DESCRIPTION
Closes https://github.com/guardian/dotcom-rendering/issues/10835

## What does this change?
* Removes the (optional) label on the reason field when reporting a comment with reason category "Legal Issue"
* Sets the required attribute of the reason field when reporting a comment with reason category "Legal Issue"

## Why?
To report a comment with the reason category "Legal Issue" requires you to include a reason, but the UI does not reflect this.

### Before
https://github.com/guardian/dotcom-rendering/assets/19683595/12cb7c91-1e43-45f5-b228-9a80ac63457b

### After
https://github.com/guardian/dotcom-rendering/assets/19683595/599690c5-598e-41bf-9117-cda0f97d5e57

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
