### PR TITLE
Update `Accordion` Stories To Component Story Format v3

### DIFF
--- a/dotcom-rendering/src/components/Accordion.stories.tsx
+++ b/dotcom-rendering/src/components/Accordion.stories.tsx
@@ -2,8 +2,26 @@ import { css } from '@emotion/react';
 import type { SerializedStyles } from '@emotion/react';
 import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
 import { body, breakpoints, from, space } from '@guardian/source-foundations';
+import type { Meta, StoryObj } from '@storybook/react';
 import { splitTheme } from '../../.storybook/decorators/splitThemeDecorator';
-import { Accordion } from './Accordion';
+import { Accordion as AccordionComponent } from './Accordion';
+
+const meta = {
+	component: AccordionComponent,
+	parameters: {
+		backgrounds: {
+			default: 'grey',
+			values: [{ name: 'grey', value: 'lightgrey' }],
+		},
+		chromatic: {
+			viewports: [breakpoints.mobile, breakpoints.tablet],
+		},
+	},
+} satisfies Meta<typeof AccordionComponent>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
 
 const textStyle = css`
 	${body.medium({ lineHeight: 'loose' })};
@@ -55,23 +73,11 @@ const accordionContent = (
 	</>
 );
 
-export default {
-	component: Accordion,
-	title: 'Components/Accordion',
-	parameters: {
-		backgrounds: {
-			default: 'grey',
-			values: [{ name: 'grey', value: 'lightgrey' }],
-		},
-		chromatic: {
-			viewports: [breakpoints.mobile, breakpoints.tablet],
-		},
+export const Accordion = {
+	args: {
+		accordionTitle: 'Live feed',
+		context: 'keyEvents',
+		children: accordionContent,
 	},
 	decorators: [splitTheme([articleFormat])],
-};
-
-export const Default = () => (
-	<Accordion accordionTitle="Live feed" context="keyEvents">
-		{accordionContent}
-	</Accordion>
-);
+} satisfies Story;


### PR DESCRIPTION
This is the default for Storybook 7+[^1], and integrates better with some of its features.

This also renames the only story to allow story hoisting[^2], i.e. the story can appear at the top level without an enclosing folder.

**Note:** Using `satisfies` gives better type safety for `args`[^3].

[^1]: https://storybook.js.org/blog/storybook-csf3-is-here/
[^2]: https://storybook.js.org/docs/writing-stories/naming-components-and-hierarchy#single-story-hoisting
[^3]: https://storybook.js.org/docs/writing-stories/typescript#using-satisfies-for-better-type-safety
