### PR TITLE
Remove Global Storybook Autodocs

### DIFF
--- a/dotcom-rendering/.storybook/main.ts
+++ b/dotcom-rendering/.storybook/main.ts
@@ -80,9 +80,6 @@ const config: StorybookConfig = {
 		name: '@storybook/react-webpack5',
 		options: { fastRefresh: true },
 	},
-	docs: {
-		autodocs: true,
-	},
 };
 
 /** the webpack.Configuration type from Storybook */

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.stories.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.stories.tsx
@@ -6,6 +6,7 @@ import { YoutubeAtom } from './YoutubeAtom';
 export default {
 	title: 'YoutubeAtom',
 	component: YoutubeAtom,
+	tags: ['autodocs'],
 };
 
 const containerStyle = { width: '800px', margin: '24px' };


### PR DESCRIPTION
We don't use them for most components, so they're a distraction in the UI. For specific components where they are still wanted they can be re-enabled using the `autodocs` tag[^1]. This has been done here for the `YoutubeAtom` stories.

[^1]: https://storybook.js.org/docs/writing-docs/autodocs
