### PR TITLE
Ensure sufficient contrast YoutubeOverlay text colour

### DIFF
--- a/dotcom-rendering/src/lib/decidePalette.ts
+++ b/dotcom-rendering/src/lib/decidePalette.ts
@@ -519,21 +519,21 @@ const textExpandableAtomHover = (format: ArticleFormat) => {
 const textYoutubeOverlayKicker = (format: ArticleFormat) => {
 	switch (format.theme) {
 		case Pillar.News:
-			return news[400];
+			return news[500];
 		case Pillar.Opinion:
-			return news[400];
+			return news[500];
 		case Pillar.Sport:
-			return sport[400];
+			return sport[500];
 		case Pillar.Culture:
-			return culture[400];
+			return culture[500];
 		case Pillar.Lifestyle:
-			return lifestyle[400];
+			return lifestyle[500];
 		case ArticleSpecial.SpecialReport:
-			return specialReport[400];
+			return specialReport[500];
 		case ArticleSpecial.Labs:
 			return labs[400];
 		case ArticleSpecial.SpecialReportAlt:
-			return news[400];
+			return news[500];
 	}
 };
 


### PR DESCRIPTION
## What does this change?

Ensures there is sufficient contrast between text and background on the `YoutubeOverlay` component by replacing `pillar[400]` for `pillar[500]`

## Why?

Resolves https://github.com/guardian/dotcom-rendering/issues/10837

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/43961396/e26f522b-ed3d-4aae-974b-e2a32bccbaff
[after]: https://github.com/guardian/dotcom-rendering/assets/43961396/228be7ff-c172-45e3-bfb7-51e1d3bf998d
