### PR TITLE
AB Tests: Set offer sign in gates to be dismissible

### DIFF
--- a/dotcom-rendering/src/components/SignInGate/gates/alternative-wording-guardian-live.tsx
+++ b/dotcom-rendering/src/components/SignInGate/gates/alternative-wording-guardian-live.tsx
@@ -38,7 +38,7 @@ export const signInGateComponent: SignInGateComponent = {
 					signInUrl={signInUrl}
 					registerUrl={registerUrl}
 					abTest={abTest}
-					isMandatory={true}
+					isMandatory={false}
 				/>
 			</Suspense>
 		</Lazy>

--- a/dotcom-rendering/src/components/SignInGate/gates/alternative-wording-saturday-edition.tsx
+++ b/dotcom-rendering/src/components/SignInGate/gates/alternative-wording-saturday-edition.tsx
@@ -38,7 +38,7 @@ export const signInGateComponent: SignInGateComponent = {
 					signInUrl={signInUrl}
 					registerUrl={registerUrl}
 					abTest={abTest}
-					isMandatory={true}
+					isMandatory={false}
 				/>
 			</Suspense>
 		</Lazy>


### PR DESCRIPTION
## What does this change?

We mistakenly set the sign in gates with offer text which we're AB testing to be mandatory (non-dismissible). This corrects that.

## Why?

The gates being non-dismissible wasn't in the test spec.