### PR TITLE
Add sentry logging of is following errors

### DIFF
--- a/dotcom-rendering/src/components/FollowWrapper.importable.tsx
+++ b/dotcom-rendering/src/components/FollowWrapper.importable.tsx
@@ -37,20 +37,32 @@ export const FollowWrapper = ({ id, displayName }: Props) => {
 		void getNotificationsClient()
 			.isFollowing(topic)
 			.then(setIsFollowingNotifications)
-			.catch((e) =>
-				log(
-					'dotcom',
-					'Bridget getNotificationsClient.isFollowing Error:',
-					e,
+			.catch((error) => {
+				window.guardian.modules.sentry.reportError(
+					error,
+					'bridget-getNotificationsClient-isFollowing-error',
 				),
-			);
+					log(
+						'dotcom',
+						'Bridget getNotificationsClient.isFollowing Error:',
+						error,
+					);
+			});
 
 		void getTagClient()
 			.isFollowing(topic)
 			.then(setIsFollowingTag)
-			.catch((e) =>
-				log('dotcom', 'Bridget getTagClient.isFollowing Error:', e),
-			);
+			.catch((error) => {
+				window.guardian.modules.sentry.reportError(
+					error,
+					'bridget-getTagClient-isFollowing-error',
+				),
+					log(
+						'dotcom',
+						'Bridget getTagClient.isFollowing Error:',
+						error,
+					);
+			});
 	}, [id, displayName]);
 
 	const tagHandler = () => {
@@ -66,21 +78,33 @@ export const FollowWrapper = ({ id, displayName }: Props) => {
 					.then((success) => {
 						success && setIsFollowingTag(false);
 					})
-					.catch((e) =>
-						log(
-							'dotcom',
-							'Bridget getTagClient.unfollow Error:',
-							e,
+					.catch((error) => {
+						window.guardian.modules.sentry.reportError(
+							error,
+							'bridget-getTagClient-unfollow-error',
 						),
-					)
+							log(
+								'dotcom',
+								'Bridget getTagClient.unfollow Error:',
+								error,
+							);
+					})
 			: void getTagClient()
 					.follow(topic)
 					.then((success) => {
 						success && setIsFollowingTag(true);
 					})
-					.catch((e) =>
-						log('dotcom', 'Bridget getTagClient.follow Error:', e),
-					);
+					.catch((error) => {
+						window.guardian.modules.sentry.reportError(
+							error,
+							'bridget-getTagClient-follow-error',
+						),
+							log(
+								'dotcom',
+								'Bridget getTagClient.follow Error:',
+								error,
+							);
+					});
 	};
 
 	const notificationsHandler = () => {
@@ -96,25 +120,33 @@ export const FollowWrapper = ({ id, displayName }: Props) => {
 					.then((success) => {
 						success && setIsFollowingNotifications(false);
 					})
-					.catch((e) =>
-						log(
-							'dotcom',
-							'Bridget getNotificationsClient.unfollow Error:',
-							e,
+					.catch((error) => {
+						window.guardian.modules.sentry.reportError(
+							error,
+							'briidget-getNotificationsClient-unfollow-error',
 						),
-					)
+							log(
+								'dotcom',
+								'Bridget getNotificationsClient.unfollow Error:',
+								error,
+							);
+					})
 			: void getNotificationsClient()
 					.follow(topic)
 					.then((success) => {
 						success && setIsFollowingNotifications(true);
 					})
-					.catch((e) =>
-						log(
-							'dotcom',
-							'Bridget getNotificationsClient.follow Error:',
-							e,
+					.catch((error) => {
+						window.guardian.modules.sentry.reportError(
+							error,
+							'bridget-getNotificationsClient-follow-error',
 						),
-					);
+							log(
+								'dotcom',
+								'Bridget getNotificationsClient.follow Error:',
+								error,
+							);
+					});
 	};
 
 	return (


### PR DESCRIPTION
## What does this change?

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
