### PR TITLE
Remove Byline Social Media Links - Web And AMP

### DIFF
--- a/dotcom-rendering/src/components/Contributor.tsx
+++ b/dotcom-rendering/src/components/Contributor.tsx
@@ -1,34 +1,10 @@
 import { css } from '@emotion/react';
-import { ArticleDesign, ArticleSpecial, isString } from '@guardian/libs';
-import { headline, space, textSans, until } from '@guardian/source-foundations';
+import { ArticleDesign, ArticleSpecial } from '@guardian/libs';
+import { headline, textSans, until } from '@guardian/source-foundations';
 import { interactiveLegacyClasses } from '../layouts/lib/interactiveLegacyStyling';
-import { getSoleContributor } from '../lib/byline';
-import { palette, palette as schemedPalette } from '../palette';
-import TwitterIcon from '../static/icons/twitter.svg';
+import { palette as schemedPalette } from '../palette';
 import type { TagType } from '../types/tag';
 import { BylineLink } from './BylineLink';
-import { useConfig } from './ConfigContext';
-
-const twitterHandleStyles = css`
-	${textSans.xxsmall({ fontWeight: 'bold' })};
-
-	color: ${palette('--twitter-handle')};
-
-	svg {
-		fill: currentColor;
-		height: 1em;
-		margin-right: ${space[1]}px;
-		transform: translateY(2px);
-	}
-
-	a {
-		color: inherit;
-		text-decoration: none;
-	}
-
-	padding-right: 10px;
-	display: inline-block;
-`;
 
 /**
  * For LiveBlogs at breakpoints below desktop, the article meta is located
@@ -74,57 +50,33 @@ type Props = {
 	format: ArticleFormat;
 };
 
-export const Contributor = ({ byline, tags, format }: Props) => {
-	const { renderingTarget } = useConfig();
-	const isWeb = renderingTarget === 'Web';
-
-	const { twitterHandle } = getSoleContributor(tags, byline) ?? {};
-
-	return (
-		<address
-			aria-label="Contributor info"
-			data-component="meta-byline"
-			data-link-name="byline"
-		>
-			{format.design !== ArticleDesign.Interview && (
-				<div
-					className={
-						format.design === ArticleDesign.Interactive
-							? interactiveLegacyClasses.byline
-							: ''
-					}
-					css={[
-						bylineStyles,
-						format.theme === ArticleSpecial.Labs &&
-							labsBylineStyles,
-						format.design === ArticleDesign.LiveBlog &&
-							standfirstColourBelowDesktop,
-					]}
-				>
-					<BylineLink
-						byline={byline}
-						tags={tags}
-						format={format}
-						isHeadline={false}
-					/>
-				</div>
-			)}
-			{isWeb && isString(twitterHandle) && (
-				<div
-					css={[
-						twitterHandleStyles,
-						format.design === ArticleDesign.LiveBlog &&
-							standfirstColourBelowDesktop,
-					]}
-				>
-					<a
-						href={`https://www.twitter.com/${twitterHandle}`}
-						aria-label={`@${twitterHandle} on Twitter`}
-					>
-						<TwitterIcon />@{twitterHandle}
-					</a>
-				</div>
-			)}
-		</address>
-	);
-};
+export const Contributor = ({ byline, tags, format }: Props) => (
+	<address
+		aria-label="Contributor info"
+		data-component="meta-byline"
+		data-link-name="byline"
+	>
+		{format.design !== ArticleDesign.Interview && (
+			<div
+				className={
+					format.design === ArticleDesign.Interactive
+						? interactiveLegacyClasses.byline
+						: ''
+				}
+				css={[
+					bylineStyles,
+					format.theme === ArticleSpecial.Labs && labsBylineStyles,
+					format.design === ArticleDesign.LiveBlog &&
+						standfirstColourBelowDesktop,
+				]}
+			>
+				<BylineLink
+					byline={byline}
+					tags={tags}
+					format={format}
+					isHeadline={false}
+				/>
+			</div>
+		)}
+	</address>
+);

--- a/dotcom-rendering/src/components/TopMetaAnalysis.amp.tsx
+++ b/dotcom-rendering/src/components/TopMetaAnalysis.amp.tsx
@@ -2,7 +2,6 @@ import { css } from '@emotion/react';
 import { headline, palette, until } from '@guardian/source-foundations';
 import { string as curly } from 'curlyquotes';
 import { getAgeWarning } from '../lib/age-warning';
-import { getSoleContributor } from '../lib/byline';
 import { pillarPalette_DO_NOT_USE } from '../lib/pillars';
 import { getSharingUrls } from '../lib/sharing-urls';
 import type { AMPArticleModel } from '../types/article.amp';
@@ -149,10 +148,6 @@ export const TopMetaAnalysis = ({
 					articleData.webPublicationDateDeprecated,
 				)}
 				webPublicationDate={articleData.webPublicationDateDisplay}
-				twitterHandle={
-					getSoleContributor(articleData.tags, articleData.byline)
-						?.twitterHandle
-				}
 			/>
 		</header>
 	);

--- a/dotcom-rendering/src/components/TopMetaExtras.amp.tsx
+++ b/dotcom-rendering/src/components/TopMetaExtras.amp.tsx
@@ -1,12 +1,11 @@
 import { css } from '@emotion/react';
-import { palette, text, textSans } from '@guardian/source-foundations';
+import { text, textSans } from '@guardian/source-foundations';
 import {
 	neutralBorder,
 	pillarMap,
 	pillarPalette_DO_NOT_USE,
 } from '../lib/pillars';
 import ClockIcon from '../static/icons/clock.svg';
-import TwitterIcon from '../static/icons/twitter.svg';
 import { ShareIcons } from './ShareIcons.amp';
 
 const pillarColours = pillarMap(
@@ -57,13 +56,6 @@ const metaStyle = css`
 	text-decoration: none;
 `;
 
-const twitterIcon = css`
-	fill: ${palette.neutral[46]};
-	height: 12px;
-	margin-bottom: -2px;
-	width: 12px;
-`;
-
 type WebPublicationDateProps = {
 	date: string;
 };
@@ -89,28 +81,11 @@ const AgeWarning = ({ warning, pillar }: AgeWarningProps) => {
 	);
 };
 
-type TwitterHandleProps = {
-	handle?: string;
-};
-
-const TwitterHandle = ({ handle }: TwitterHandleProps) => {
-	if (!handle) {
-		return null;
-	}
-
-	return (
-		<a css={metaStyle} href={`https://twitter.com/${handle}`}>
-			<TwitterIcon css={twitterIcon} /> @{handle}
-		</a>
-	);
-};
-
 type TopMetaExtrasProps = {
 	sharingUrls: SharingURLs;
 	pillar: ArticleTheme;
 	webPublicationDate: string;
 	ageWarning?: string;
-	twitterHandle?: string;
 };
 
 export const TopMetaExtras = ({
@@ -118,10 +93,8 @@ export const TopMetaExtras = ({
 	pillar,
 	webPublicationDate,
 	ageWarning,
-	twitterHandle,
 }: TopMetaExtrasProps) => (
 	<div css={metaExtras}>
-		<TwitterHandle handle={twitterHandle} />
 		<WebPublicationDate date={webPublicationDate} />
 
 		<div css={borders(pillar)}>

--- a/dotcom-rendering/src/components/TopMetaLiveblog.amp.tsx
+++ b/dotcom-rendering/src/components/TopMetaLiveblog.amp.tsx
@@ -2,7 +2,6 @@ import { css } from '@emotion/react';
 import { headline, palette } from '@guardian/source-foundations';
 import { string as curly } from 'curlyquotes';
 import { getAgeWarning } from '../lib/age-warning';
-import { getSoleContributor } from '../lib/byline';
 import { neutralBorder, pillarPalette_DO_NOT_USE } from '../lib/pillars';
 import { getSharingUrls } from '../lib/sharing-urls';
 import type { AMPArticleModel } from '../types/article.amp';
@@ -138,10 +137,6 @@ export const TopMetaLiveblog = ({
 				articleData.webPublicationDateDeprecated,
 			)}
 			webPublicationDate={articleData.webPublicationDateDisplay}
-			twitterHandle={
-				getSoleContributor(articleData.tags, articleData.byline)
-					?.twitterHandle
-			}
 		/>
 	</header>
 );

--- a/dotcom-rendering/src/components/TopMetaNews.amp.tsx
+++ b/dotcom-rendering/src/components/TopMetaNews.amp.tsx
@@ -2,7 +2,6 @@ import { css } from '@emotion/react';
 import { headline, palette } from '@guardian/source-foundations';
 import { string as curly } from 'curlyquotes';
 import { getAgeWarning } from '../lib/age-warning';
-import { getSoleContributor } from '../lib/byline';
 import { pillarPalette_DO_NOT_USE } from '../lib/pillars';
 import { getSharingUrls } from '../lib/sharing-urls';
 import type { AMPArticleModel } from '../types/article.amp';
@@ -131,10 +130,6 @@ export const TopMetaNews = ({
 					articleData.webPublicationDateDeprecated,
 				)}
 				webPublicationDate={articleData.webPublicationDateDisplay}
-				twitterHandle={
-					getSoleContributor(articleData.tags, articleData.byline)
-						?.twitterHandle
-				}
 			/>
 		</header>
 	);

--- a/dotcom-rendering/src/components/TopMetaOpinion.amp.tsx
+++ b/dotcom-rendering/src/components/TopMetaOpinion.amp.tsx
@@ -1,7 +1,6 @@
 import { css } from '@emotion/react';
 import { headline, palette } from '@guardian/source-foundations';
 import { getAgeWarning } from '../lib/age-warning';
-import { getSoleContributor } from '../lib/byline';
 import { pillarPalette_DO_NOT_USE } from '../lib/pillars';
 import { getSharingUrls } from '../lib/sharing-urls';
 import type { AMPArticleModel } from '../types/article.amp';
@@ -154,10 +153,6 @@ export const TopMetaOpinion = ({
 					articleData.webPublicationDateDeprecated,
 				)}
 				webPublicationDate={articleData.webPublicationDateDisplay}
-				twitterHandle={
-					getSoleContributor(articleData.tags, articleData.byline)
-						?.twitterHandle
-				}
 			/>
 		</header>
 	);

--- a/dotcom-rendering/src/components/TopMetaPaidContent.amp.tsx
+++ b/dotcom-rendering/src/components/TopMetaPaidContent.amp.tsx
@@ -1,7 +1,6 @@
 import { css } from '@emotion/react';
 import { body, palette, text, textSans } from '@guardian/source-foundations';
 import { getAgeWarning } from '../lib/age-warning';
-import { getSoleContributor } from '../lib/byline';
 import { getSharingUrls } from '../lib/sharing-urls';
 import type { AMPArticleModel } from '../types/article.amp';
 import type { Branding } from '../types/branding';
@@ -129,10 +128,6 @@ export const TopMetaPaidContent = ({
 				articleData.webPublicationDateDeprecated,
 			)}
 			webPublicationDate={articleData.webPublicationDateDisplay}
-			twitterHandle={
-				getSoleContributor(articleData.tags, articleData.byline)
-					?.twitterHandle
-			}
 		/>
 	</header>
 );

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -2138,32 +2138,6 @@ const standfirstTextDark: PaletteFunction = ({ design, display, theme }) => {
 	}
 };
 
-const twitterHandleLight: PaletteFunction = ({ theme }) => {
-	switch (theme) {
-		case ArticleSpecial.Labs:
-			return sourcePalette.neutral[0];
-		case ArticleSpecial.SpecialReport:
-			return sourcePalette.specialReport[300];
-		case ArticleSpecial.SpecialReportAlt:
-			return sourcePalette.specialReportAlt[100];
-		default:
-			return sourcePalette.neutral[46];
-	}
-};
-
-const twitterHandleDark: PaletteFunction = ({ theme }) => {
-	switch (theme) {
-		case ArticleSpecial.Labs:
-			return sourcePalette.neutral[86];
-		case ArticleSpecial.SpecialReport:
-			return sourcePalette.specialReport[700];
-		case ArticleSpecial.SpecialReportAlt:
-			return sourcePalette.specialReportAlt[700];
-		default:
-			return sourcePalette.neutral[60];
-	}
-};
-
 const cardBorderTopLight: PaletteFunction = ({ theme, design }) => {
 	if (theme === ArticleSpecial.SpecialReportAlt)
 		return sourcePalette.neutral[60];
@@ -5205,10 +5179,6 @@ const paletteColours = {
 	'--star-rating-background': {
 		light: starRatingBackgroundColourLight,
 		dark: starRatingBackgroundColourDark,
-	},
-	'--twitter-handle': {
-		light: twitterHandleLight,
-		dark: twitterHandleDark,
 	},
 	'--block-quote-fill': {
 		light: blockQuoteFillLight,


### PR DESCRIPTION
Remove social media link from article bylines on web and AMP. A request from Editorial.

**Note:** I recommend using "Hide whitespace" to view the diff.
