### PR TITLE
Q and A Explainer Components

### DIFF
--- a/dotcom-rendering/src/components/QAndAExplainers.stories.tsx
+++ b/dotcom-rendering/src/components/QAndAExplainers.stories.tsx
@@ -54,6 +54,7 @@ export const AllThemes = {
 		ajaxUrl: '',
 		editionId: 'UK',
 		isAdFreeUser: false,
+		isSensitive: false,
 		pageId: 'testID',
 		switches: {},
 	},

--- a/dotcom-rendering/src/components/QAndAExplainers.stories.tsx
+++ b/dotcom-rendering/src/components/QAndAExplainers.stories.tsx
@@ -1,0 +1,115 @@
+import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
+import type { Meta, StoryObj } from '@storybook/react';
+import { splitTheme } from '../../.storybook/decorators/splitThemeDecorator';
+import { images } from '../../fixtures/generated/images';
+import { getAllThemes } from '../lib/format';
+import type { TextBlockElement } from '../types/content';
+import { QAndAExplainers } from './QAndAExplainers';
+
+const meta = {
+	component: QAndAExplainers,
+	title: 'Components/QAndAExplainers',
+} satisfies Meta<typeof QAndAExplainers>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const html =
+	'<p>An Answer: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesquepharetra libero nec varius feugiat. Nulla commodo sagittis erat amalesuada. Ut iaculis interdum eros, et tristique ex. In veldignissim arcu. Nulla nisi urna, laoreet a aliquam at, viverra eueros. Proin imperdiet pellentesque turpis sed luctus. Donecdignissim lacus in risus fermentum maximus eu vel justo. Duis nontortor ac elit dapibus imperdiet ut at risus. Etiam pretium, odioeget accumsan venenatis, tortor mi aliquet nisl, vel ullamcorperneque nulla vel elit. Etiam porta mauris nec sagittis luctus.</p>';
+
+const testTextElement: TextBlockElement = {
+	_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+	elementId: 'test-text-element-id-1',
+	dropCap: false,
+	html,
+};
+
+export const AllThemes = {
+	args: {
+		qAndAExplainers: [
+			{
+				title: 'The first question',
+				body: [testTextElement],
+			},
+			{
+				title: 'The second question',
+				body: [testTextElement],
+			},
+		],
+		/**
+		 * This will be replaced by the `splitTheme` decorator, but it's
+		 * required by the type.
+		 */
+		format: {
+			design: ArticleDesign.Standard,
+			display: ArticleDisplay.Standard,
+			theme: Pillar.News,
+		},
+		abTests: {},
+		/**
+		 * This is used for rich links. An empty string isn't technically valid,
+		 * but there are no rich links in this example.
+		 */
+		ajaxUrl: '',
+		editionId: 'UK',
+		isAdFreeUser: false,
+		pageId: 'testID',
+		switches: {},
+	},
+	decorators: [
+		splitTheme(
+			getAllThemes({
+				design: ArticleDesign.Standard,
+				display: ArticleDisplay.Standard,
+			}),
+		),
+	],
+} satisfies Story;
+
+export const Images = {
+	args: {
+		qAndAExplainers: [
+			{
+				title: 'The first question',
+				body: [testTextElement, ...images.slice(0, 2)],
+			},
+			{
+				title: 'The second question',
+				body: [testTextElement, ...images.slice(2, 3)],
+			},
+		],
+		/**
+		 * This will be replaced by the `splitTheme` decorator, but it's
+		 * required by the type.
+		 */
+		format: {
+			design: ArticleDesign.Standard,
+			display: ArticleDisplay.Standard,
+			theme: Pillar.News,
+		},
+		abTests: {},
+		/**
+		 * This is used for rich links. An empty string isn't technically valid,
+		 * but there are no rich links in this example.
+		 */
+		ajaxUrl: '',
+		editionId: 'UK',
+		isAdFreeUser: false,
+		isSensitive: false,
+		pageId: 'testID',
+		switches: {},
+	},
+	decorators: [
+		splitTheme(
+			[
+				{
+					design: ArticleDesign.Standard,
+					display: ArticleDisplay.Standard,
+					theme: Pillar.Culture,
+				},
+			],
+			{ orientation: 'vertical' },
+		),
+	],
+} satisfies Story;

--- a/dotcom-rendering/src/components/QAndAExplainers.tsx
+++ b/dotcom-rendering/src/components/QAndAExplainers.tsx
@@ -1,5 +1,5 @@
 import { RenderArticleElement } from '../lib/renderElement';
-import { KeyTakeaway, QAndAExplainer } from '../types/content';
+import { QAndAExplainer } from '../types/content';
 import { css } from '@emotion/react';
 import { headline } from '@guardian/source-foundations';
 import { palette } from '../palette';

--- a/dotcom-rendering/src/components/QAndAExplainers.tsx
+++ b/dotcom-rendering/src/components/QAndAExplainers.tsx
@@ -1,0 +1,126 @@
+import { RenderArticleElement } from '../lib/renderElement';
+import { KeyTakeaway, QAndAExplainer } from '../types/content';
+import { css } from '@emotion/react';
+import { headline } from '@guardian/source-foundations';
+import { palette } from '../palette';
+import { ArticleFormat } from '@guardian/libs';
+import { ServerSideTests, Switches } from '../types/config';
+import { EditionId } from '../lib/edition';
+
+const qAndAExplainerStyles = css`
+	padding-top: 8px;
+`;
+
+const headingStyles = css`
+	${headline.xsmall({ fontWeight: 'medium' })};
+	padding: 2px 0px;
+`;
+
+const headingLineStyles = css`
+	width: 140px;
+	margin: 0px;
+	border: none;
+	border-top: 8px solid ${palette('--heading-line')};
+`;
+
+interface CommonProps {
+	format: ArticleFormat;
+	ajaxUrl: string;
+	host?: string;
+	pageId: string;
+	isAdFreeUser: boolean;
+	isSensitive: boolean;
+	abTests: ServerSideTests;
+	switches: Switches;
+	editionId: EditionId;
+	hideCaption?: boolean;
+	starRating?: number;
+}
+
+interface QAndAExplainersProps extends CommonProps {
+	qAndAExplainers: QAndAExplainer[];
+}
+
+interface QAndAExplainerProps extends CommonProps {
+	qAndAExplainer: QAndAExplainer;
+}
+
+const QAndAExplainerComponent = ({
+	qAndAExplainer,
+	format,
+	ajaxUrl,
+	host,
+	pageId,
+	isAdFreeUser,
+	isSensitive,
+	switches,
+	abTests,
+	editionId,
+	hideCaption,
+	starRating,
+}: QAndAExplainerProps) => {
+	return (
+		<li css={qAndAExplainerStyles}>
+			<hr css={headingLineStyles}></hr>
+			<h2 css={headingStyles}>{qAndAExplainer.title}</h2>
+			{qAndAExplainer.body.map((element, index) => (
+				<RenderArticleElement
+					// eslint-disable-next-line react/no-array-index-key -- This is only rendered once so we can safely use index to suppress the warning
+					key={index}
+					format={format}
+					element={element}
+					ajaxUrl={ajaxUrl}
+					host={host}
+					index={index}
+					isMainMedia={false}
+					pageId={pageId}
+					webTitle={qAndAExplainer.title}
+					isAdFreeUser={isAdFreeUser}
+					isSensitive={isSensitive}
+					switches={switches}
+					abTests={abTests}
+					editionId={editionId}
+					hideCaption={hideCaption}
+					starRating={starRating}
+				/>
+			))}
+		</li>
+	);
+};
+
+export const QAndAExplainers = ({
+	qAndAExplainers,
+	format,
+	ajaxUrl,
+	host,
+	pageId,
+	isAdFreeUser,
+	isSensitive,
+	switches,
+	abTests,
+	editionId,
+	hideCaption,
+	starRating,
+}: QAndAExplainersProps) => {
+	return (
+		<ol>
+			{qAndAExplainers.map((qAndAExplainer, index) => (
+				<QAndAExplainerComponent
+					qAndAExplainer={qAndAExplainer}
+					format={format}
+					ajaxUrl={ajaxUrl}
+					host={host}
+					pageId={pageId}
+					isAdFreeUser={isAdFreeUser}
+					isSensitive={isSensitive}
+					switches={switches}
+					abTests={abTests}
+					editionId={editionId}
+					hideCaption={hideCaption}
+					starRating={starRating}
+					key={index}
+				/>
+			))}
+		</ol>
+	);
+};

--- a/dotcom-rendering/src/components/QAndAExplainers.tsx
+++ b/dotcom-rendering/src/components/QAndAExplainers.tsx
@@ -1,11 +1,11 @@
-import { RenderArticleElement } from '../lib/renderElement';
-import { QAndAExplainer } from '../types/content';
 import { css } from '@emotion/react';
+import type { ArticleFormat } from '@guardian/libs';
 import { headline } from '@guardian/source-foundations';
+import type { EditionId } from '../lib/edition';
+import { RenderArticleElement } from '../lib/renderElement';
 import { palette } from '../palette';
-import { ArticleFormat } from '@guardian/libs';
-import { ServerSideTests, Switches } from '../types/config';
-import { EditionId } from '../lib/edition';
+import type { ServerSideTests, Switches } from '../types/config';
+import type { QAndAExplainer } from '../types/content';
 
 const qAndAExplainerStyles = css`
 	padding-top: 8px;

--- a/dotcom-rendering/src/types/content.ts
+++ b/dotcom-rendering/src/types/content.ts
@@ -314,7 +314,7 @@ export interface KeyTakeaway {
 	body: FEElement[];
 }
 
-interface QAndAExplainer {
+export interface QAndAExplainer {
 	title: string;
 	body: FEElement[];
 }


### PR DESCRIPTION
Co-authored-by: @JamieB-gu 

## What does this change?

New Q&A Explainer components and stories 
https://www.figma.com/file/xPr2tZZger7pszcO075tAQ/New-Formats---April-23?type=design&node-id=3614-48731&mode=design&t=qnIK7qGwh7lBTvlp-0

## Why?

To support these new elements, part of the article structure work.
Fixes: https://github.com/guardian/dotcom-rendering/issues/10867
Fixes: https://github.com/guardian/dotcom-rendering/issues/10866

## Screenshots

<img width="994" alt="Screenshot 2024-03-11 at 17 07 21" src="https://github.com/guardian/dotcom-rendering/assets/1229808/a48e1af8-56ed-44da-9d4e-be643876177f">

