### PR TITLE
Affiliates disclaimer

### DIFF
--- a/dotcom-rendering/src/components/Disclaimer.tsx
+++ b/dotcom-rendering/src/components/Disclaimer.tsx
@@ -10,8 +10,9 @@ const disclaimerStyles = css`
 	sup {
 		font-size: 85%;
 	}
-
 	margin-bottom: 16px;
+	color: inherit;
+	text-decoration: none;
 `;
 
 const disclaimerInlineStyles = css`
@@ -20,21 +21,10 @@ const disclaimerInlineStyles = css`
 	clear: left;
 	width: 8.75rem;
 	margin-right: 20px;
-`;
-
-const backgroundStyles = css`
 	background-color: ${themePalette('--rich-link-background')};
 	:hover {
 		background-color: ${themePalette('--rich-link-background-hover')};
 	}
-`;
-
-const linkStyles = css`
-	color: inherit;
-	text-decoration: none;
-`;
-
-const paddingStyles = css`
 	padding-top: 2px;
 	padding-right: 5px;
 	padding-left: 5px;
@@ -55,21 +45,21 @@ const DisclaimerText = () => (
 	</p>
 );
 
-const Disclaimer = () => (
-	<aside
-		css={[disclaimerStyles, linkStyles]}
-		data-testid="affiliate-disclaimer"
-	>
+const AffiliateDisclaimer = () => (
+	<aside css={[disclaimerStyles]} data-testid="affiliate-disclaimer">
 		<DisclaimerText />
 	</aside>
 );
 
-const DisclaimerInline = () => (
+const AffiliateDisclaimerInline = () => (
 	<Hide from="leftCol">
-		<div css={[disclaimerInlineStyles, backgroundStyles, paddingStyles]}>
-			<Disclaimer />
+		<div
+			css={[disclaimerInlineStyles]}
+			data-testid="affiliate-disclaimer-inline"
+		>
+			<AffiliateDisclaimer />
 		</div>
 	</Hide>
 );
 
-export { Disclaimer, DisclaimerInline };
+export { AffiliateDisclaimer, AffiliateDisclaimerInline };

--- a/dotcom-rendering/src/components/Disclaimer.tsx
+++ b/dotcom-rendering/src/components/Disclaimer.tsx
@@ -1,5 +1,7 @@
 import { css } from '@emotion/react';
-import { textSans } from '@guardian/source-foundations';
+import { space, textSans } from '@guardian/source-foundations';
+import { Hide } from '@guardian/source-react-components';
+import { palette as themePalette } from '../palette';
 
 const disclaimerStyles = css`
 	${textSans.medium({ lineHeight: 'regular' })};
@@ -12,17 +14,62 @@ const disclaimerStyles = css`
 	margin-bottom: 16px;
 `;
 
-const disclaimerHTML =
-	'\n\n\n\n\n\n\n    <p><sup>\n        The Guardian’s product and service reviews are independent and are\n        in no way influenced by any advertiser or commercial initiative. We\n        will earn a commission from the retailer if you buy something\n        through an affiliate link.\n        <a\n            href="https://www.theguardian.com/info/2017/nov/01/reader-information-on-affiliate-links"\n            data-link-name="in body link"\n            class="u-underline"\n            >Learn more</a\n        >.\n    </sup></p>\n\n';
+const disclaimerInlineStyles = css`
+	margin-bottom: ${space[1]}px;
+	float: left;
+	clear: left;
+	width: 8.75rem;
+	margin-right: 20px;
+`;
+
+const backgroundStyles = css`
+	background-color: ${themePalette('--rich-link-background')};
+	:hover {
+		background-color: ${themePalette('--rich-link-background-hover')};
+	}
+`;
+
+const linkStyles = css`
+	color: inherit;
+	text-decoration: none;
+`;
+
+const paddingStyles = css`
+	padding-top: 2px;
+	padding-right: 5px;
+	padding-left: 5px;
+	padding-bottom: 5px;
+`;
+
+const DisclaimerText = () => (
+	<p>
+		<sup>
+			The Guardian’s product and service reviews are independent and are
+			in no way influenced by any advertiser or commercial initiative. We
+			will earn a commission from the retailer if you buy something
+			through an affiliate link.&nbsp;
+			<a href="https://www.theguardian.com/info/2017/nov/01/reader-information-on-affiliate-links">
+				Learn more.
+			</a>
+		</sup>
+	</p>
+);
 
 const Disclaimer = () => (
 	<aside
-		css={disclaimerStyles}
+		css={[disclaimerStyles, linkStyles]}
 		data-testid="affiliate-disclaimer"
-		dangerouslySetInnerHTML={{
-			__html: disclaimerHTML,
-		}}
-	/>
+	>
+		<DisclaimerText />
+	</aside>
 );
 
-export { Disclaimer };
+const DisclaimerInline = () => (
+	<Hide from="leftCol">
+		<div css={[disclaimerInlineStyles, backgroundStyles, paddingStyles]}>
+			<Disclaimer />
+		</div>
+	</Hide>
+);
+
+export { Disclaimer, DisclaimerInline };

--- a/dotcom-rendering/src/components/Disclaimer.tsx
+++ b/dotcom-rendering/src/components/Disclaimer.tsx
@@ -12,16 +12,17 @@ const disclaimerStyles = css`
 	margin-bottom: 16px;
 `;
 
-type Props = {
-	html: string;
-};
+const disclaimerHTML =
+	'\n\n\n\n\n\n\n    <p><sup>\n        The Guardian’s product and service reviews are independent and are\n        in no way influenced by any advertiser or commercial initiative. We\n        will earn a commission from the retailer if you buy something\n        through an affiliate link.\n        <a\n            href="https://www.theguardian.com/info/2017/nov/01/reader-information-on-affiliate-links"\n            data-link-name="in body link"\n            class="u-underline"\n            >Learn more</a\n        >.\n    </sup></p>\n\n';
 
-export const Disclaimer = ({ html }: Props) => (
+const Disclaimer = () => (
 	<aside
 		css={disclaimerStyles}
 		data-testid="affiliate-disclaimer"
 		dangerouslySetInnerHTML={{
-			__html: html,
+			__html: disclaimerHTML,
 		}}
 	/>
 );
+
+export { Disclaimer };

--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -91,7 +91,6 @@ const ImmersiveGrid = ({ children }: { children: React.ReactNode }) => (
 						'caption    border      title       right-column'
 						'.          border      headline    right-column'
 						'.          border      standfirst  right-column'
-						'.          border      disclaimer  right-column'
 						'.          border      byline      right-column'
 						'lines      border      body        right-column'
 						'meta       border      body        right-column'
@@ -115,7 +114,6 @@ const ImmersiveGrid = ({ children }: { children: React.ReactNode }) => (
 						'.          border      title       right-column'
 						'.          border      headline    right-column'
 						'.          border      standfirst  right-column'
-						'.          border      disclaimer  right-column'
 						'.          border      byline      right-column'
 						'lines      border      body        right-column'
 						'meta       border      body        right-column'
@@ -137,7 +135,6 @@ const ImmersiveGrid = ({ children }: { children: React.ReactNode }) => (
 						'title       right-column'
 						'headline    right-column'
 						'standfirst  right-column'
-						'disclaimer  right-column'
 						'byline      right-column'
 						'caption     right-column'
 						'lines       right-column'
@@ -152,7 +149,6 @@ const ImmersiveGrid = ({ children }: { children: React.ReactNode }) => (
 						'title'
 						'headline'
 						'standfirst'
-						'disclaimer'
 						'byline'
 						'caption'
 						'lines'
@@ -271,8 +267,6 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 	const navAndLabsHeaderHeight = isLabs
 		? `${combinedHeight}px`
 		: `${minNavHeightPx}px`;
-
-	const hasAffiliateLinksDisclaimer = !!article.affiliateLinksDisclaimer;
 
 	const hasMainMediaStyles = css`
 		height: calc(80vh - ${navAndLabsHeaderHeight});
@@ -550,11 +544,6 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 								standfirst={article.standfirst}
 							/>
 						</GridItem>
-						<GridItem area="disclaimer">
-							{hasAffiliateLinksDisclaimer && (
-								<Disclaimer></Disclaimer>
-							)}
-						</GridItem>
 						<GridItem area="byline">
 							{!!article.byline && (
 								<HeadlineByline
@@ -646,26 +635,37 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 										</Hide>
 									</>
 								) : (
-									<ArticleMeta
-										branding={branding}
-										format={format}
-										pageId={article.pageId}
-										webTitle={article.webTitle}
-										byline={article.byline}
-										tags={article.tags}
-										primaryDateline={
-											article.webPublicationDateDisplay
-										}
-										secondaryDateline={
-											article.webPublicationSecondaryDateDisplay
-										}
-										isCommentable={article.isCommentable}
-										discussionApiUrl={
-											article.config.discussionApiUrl
-										}
-										shortUrlId={article.config.shortUrlId}
-										ajaxUrl={article.config.ajaxUrl}
-									/>
+									<>
+										<ArticleMeta
+											branding={branding}
+											format={format}
+											pageId={article.pageId}
+											webTitle={article.webTitle}
+											byline={article.byline}
+											tags={article.tags}
+											primaryDateline={
+												article.webPublicationDateDisplay
+											}
+											secondaryDateline={
+												article.webPublicationSecondaryDateDisplay
+											}
+											isCommentable={
+												article.isCommentable
+											}
+											discussionApiUrl={
+												article.config.discussionApiUrl
+											}
+											shortUrlId={
+												article.config.shortUrlId
+											}
+											ajaxUrl={article.config.ajaxUrl}
+										/>
+										<Hide when="below" breakpoint="leftCol">
+											{!!article.affiliateLinksDisclaimer && (
+												<Disclaimer />
+											)}
+										</Hide>
+									</>
 								)}
 							</div>
 						</GridItem>

--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -552,11 +552,7 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 						</GridItem>
 						<GridItem area="disclaimer">
 							{hasAffiliateLinksDisclaimer && (
-								<Disclaimer
-									html={
-										article.affiliateLinksDisclaimer ?? ''
-									}
-								></Disclaimer>
+								<Disclaimer></Disclaimer>
 							)}
 						</GridItem>
 						<GridItem area="byline">

--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -22,7 +22,7 @@ import { Border } from '../components/Border';
 import { Caption } from '../components/Caption';
 import { Carousel } from '../components/Carousel.importable';
 import { DecideLines } from '../components/DecideLines';
-import { Disclaimer } from '../components/Disclaimer';
+import { AffiliateDisclaimer } from '../components/Disclaimer';
 import { DiscussionLayout } from '../components/DiscussionLayout';
 import { Footer } from '../components/Footer';
 import { GridItem } from '../components/GridItem';
@@ -662,7 +662,7 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 										/>
 										<Hide when="below" breakpoint="leftCol">
 											{!!article.affiliateLinksDisclaimer && (
-												<Disclaimer />
+												<AffiliateDisclaimer />
 											)}
 										</Hide>
 									</>

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -92,7 +92,6 @@ const ShowcaseGrid = ({ children }: { children: React.ReactNode }) => (
 						'lines  border  media       media'
 						'meta   border  media       media'
 						'meta   border  standfirst  right-column'
-						'meta   border  disclaimer  right-column'
 						'.      border  body        right-column'
 						'.      border  .           right-column';
 				}
@@ -104,7 +103,6 @@ const ShowcaseGrid = ({ children }: { children: React.ReactNode }) => (
 						'lines  border  media       media'
 						'meta   border  media       media'
 						'meta   border  standfirst  right-column'
-						'meta   border  disclaimer  right-column'
 						'.      border  body        right-column'
 						'.      border  .           right-column';
 				}
@@ -121,7 +119,6 @@ const ShowcaseGrid = ({ children }: { children: React.ReactNode }) => (
 						'title      right-column'
 						'headline   right-column'
 						'standfirst right-column'
-						'disclaimer right-column'
 						'media      right-column'
 						'lines      right-column'
 						'meta       right-column'
@@ -136,7 +133,6 @@ const ShowcaseGrid = ({ children }: { children: React.ReactNode }) => (
 						'title'
 						'headline'
 						'standfirst'
-						'disclaimer'
 						'media'
 						'lines'
 						'meta'
@@ -151,7 +147,6 @@ const ShowcaseGrid = ({ children }: { children: React.ReactNode }) => (
 						'title'
 						'headline'
 						'standfirst'
-						'disclaimer'
 						'lines'
 						'meta'
 						'body';
@@ -559,11 +554,6 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 								standfirst={article.standfirst}
 							/>
 						</GridItem>
-						<GridItem area="disclaimer">
-							{!!article.affiliateLinksDisclaimer && (
-								<Disclaimer></Disclaimer>
-							)}
-						</GridItem>
 						<GridItem area="lines">
 							<div css={maxWidth}>
 								<div css={stretchLines}>
@@ -634,26 +624,37 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 										</Hide>
 									</>
 								) : (
-									<ArticleMeta
-										branding={branding}
-										format={format}
-										pageId={article.pageId}
-										webTitle={article.webTitle}
-										byline={article.byline}
-										tags={article.tags}
-										primaryDateline={
-											article.webPublicationDateDisplay
-										}
-										secondaryDateline={
-											article.webPublicationSecondaryDateDisplay
-										}
-										isCommentable={article.isCommentable}
-										discussionApiUrl={
-											article.config.discussionApiUrl
-										}
-										shortUrlId={article.config.shortUrlId}
-										ajaxUrl={article.config.ajaxUrl}
-									/>
+									<>
+										<ArticleMeta
+											branding={branding}
+											format={format}
+											pageId={article.pageId}
+											webTitle={article.webTitle}
+											byline={article.byline}
+											tags={article.tags}
+											primaryDateline={
+												article.webPublicationDateDisplay
+											}
+											secondaryDateline={
+												article.webPublicationSecondaryDateDisplay
+											}
+											isCommentable={
+												article.isCommentable
+											}
+											discussionApiUrl={
+												article.config.discussionApiUrl
+											}
+											shortUrlId={
+												article.config.shortUrlId
+											}
+											ajaxUrl={article.config.ajaxUrl}
+										/>
+										<Hide until="leftCol">
+											{!!article.affiliateLinksDisclaimer && (
+												<Disclaimer />
+											)}
+										</Hide>
+									</>
 								)}
 							</div>
 						</GridItem>

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -561,9 +561,7 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 						</GridItem>
 						<GridItem area="disclaimer">
 							{!!article.affiliateLinksDisclaimer && (
-								<Disclaimer
-									html={article.affiliateLinksDisclaimer}
-								></Disclaimer>
+								<Disclaimer></Disclaimer>
 							)}
 						</GridItem>
 						<GridItem area="lines">

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -21,7 +21,7 @@ import { ArticleTitle } from '../components/ArticleTitle';
 import { Border } from '../components/Border';
 import { Carousel } from '../components/Carousel.importable';
 import { DecideLines } from '../components/DecideLines';
-import { Disclaimer } from '../components/Disclaimer';
+import { AffiliateDisclaimer } from '../components/Disclaimer';
 import { DiscussionLayout } from '../components/DiscussionLayout';
 import { Footer } from '../components/Footer';
 import { GridItem } from '../components/GridItem';
@@ -651,7 +651,7 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 										/>
 										<Hide until="leftCol">
 											{!!article.affiliateLinksDisclaimer && (
-												<Disclaimer />
+												<AffiliateDisclaimer />
 											)}
 										</Hide>
 									</>

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -709,7 +709,7 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 									/>
 									<Hide until="leftCol">
 										{!!article.affiliateLinksDisclaimer && (
-											<Disclaimer></Disclaimer>
+											<Disclaimer />
 										)}
 									</Hide>
 								</div>

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -709,11 +709,7 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 									/>
 									<Hide until="leftCol">
 										{!!article.affiliateLinksDisclaimer && (
-											<Disclaimer
-												html={
-													article.affiliateLinksDisclaimer
-												}
-											></Disclaimer>
+											<Disclaimer></Disclaimer>
 										)}
 									</Hide>
 								</div>

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -23,7 +23,7 @@ import { ArticleTitle } from '../components/ArticleTitle';
 import { Border } from '../components/Border';
 import { Carousel } from '../components/Carousel.importable';
 import { DecideLines } from '../components/DecideLines';
-import { Disclaimer } from '../components/Disclaimer';
+import { AffiliateDisclaimer } from '../components/Disclaimer';
 import { DiscussionLayout } from '../components/DiscussionLayout';
 import { Footer } from '../components/Footer';
 import { GetMatchNav } from '../components/GetMatchNav.importable';
@@ -709,7 +709,7 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 									/>
 									<Hide until="leftCol">
 										{!!article.affiliateLinksDisclaimer && (
-											<Disclaimer />
+											<AffiliateDisclaimer />
 										)}
 									</Hide>
 								</div>

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -115,7 +115,6 @@ const StandardGrid = ({
 								grid-template-areas:
 									'title  border  headline     right-column'
 									'.      border  standfirst   right-column'
-									'.      border  disclaimer   right-column'
 									'lines  border  media        right-column'
 									'meta   border  media        right-column'
 									'meta   border  body         right-column'
@@ -150,7 +149,6 @@ const StandardGrid = ({
 								grid-template-areas:
 									'title  border  headline     right-column'
 									'.      border  standfirst   right-column'
-									'.      border  disclaimer   right-column'
 									'lines  border  media        right-column'
 									'meta   border  media        right-column'
 									'meta   border  body         right-column'
@@ -185,7 +183,6 @@ const StandardGrid = ({
 									'title         right-column'
 									'headline      right-column'
 									'standfirst    right-column'
-									'disclaimer    right-column'
 									'media         right-column'
 									'lines         right-column'
 									'meta          right-column'
@@ -214,7 +211,6 @@ const StandardGrid = ({
 									'title'
 									'headline'
 									'standfirst'
-									'disclaimer'
 									'media'
 									'lines'
 									'meta'
@@ -245,7 +241,6 @@ const StandardGrid = ({
 									'title'
 									'headline'
 									'standfirst'
-									'disclaimer'
 									'lines'
 									'meta'
 									'body';
@@ -611,13 +606,6 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 								standfirst={article.standfirst}
 							/>
 						</GridItem>
-						<GridItem area="disclaimer">
-							{!!article.affiliateLinksDisclaimer && (
-								<Disclaimer
-									html={article.affiliateLinksDisclaimer}
-								></Disclaimer>
-							)}
-						</GridItem>
 						<GridItem area="lines">
 							<div css={maxWidth}>
 								<div css={stretchLines}>
@@ -719,6 +707,15 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 										shortUrlId={article.config.shortUrlId}
 										ajaxUrl={article.config.ajaxUrl}
 									/>
+									<Hide until="leftCol">
+										{!!article.affiliateLinksDisclaimer && (
+											<Disclaimer
+												html={
+													article.affiliateLinksDisclaimer
+												}
+											></Disclaimer>
+										)}
+									</Hide>
 								</div>
 							)}
 						</GridItem>

--- a/dotcom-rendering/src/lib/article.ts
+++ b/dotcom-rendering/src/lib/article.ts
@@ -21,6 +21,7 @@ const enhancePinnedPost = (
 		renderingTarget,
 		imagesForLightbox: [],
 		promotedNewsletter: undefined,
+		hasAffiliateLinksDisclaimer: false,
 	})[0];
 };
 
@@ -39,6 +40,7 @@ export const enhanceArticleType = (
 		renderingTarget,
 		promotedNewsletter: data.promotedNewsletter,
 		imagesForLightbox,
+		hasAffiliateLinksDisclaimer: !!data.affiliateLinksDisclaimer,
 	});
 
 	const mainMediaElements = enhanceElementsImages(

--- a/dotcom-rendering/src/lib/renderElement.tsx
+++ b/dotcom-rendering/src/lib/renderElement.tsx
@@ -10,6 +10,7 @@ import { CartoonComponent } from '../components/CartoonComponent';
 import { ChartAtom } from '../components/ChartAtom.importable';
 import { CodeBlockComponent } from '../components/CodeBlockComponent';
 import { CommentBlockComponent } from '../components/CommentBlockComponent';
+import { Disclaimer } from '../components/Disclaimer';
 import { DividerBlockComponent } from '../components/DividerBlockComponent';
 import { DocumentBlockComponent } from '../components/DocumentBlockComponent.importable';
 import { EmailSignUpWrapper } from '../components/EmailSignUpWrapper';
@@ -750,11 +751,13 @@ export const renderElement = ({
 					/>
 				</Island>
 			);
+		case 'model.dotcomrendering.pageElements.DisclaimerBlockElement': {
+			return <Disclaimer />;
+		}
 		case 'model.dotcomrendering.pageElements.AudioBlockElement':
 		case 'model.dotcomrendering.pageElements.ContentAtomBlockElement':
 		case 'model.dotcomrendering.pageElements.GenericAtomBlockElement':
 		case 'model.dotcomrendering.pageElements.VideoBlockElement':
-		case 'model.dotcomrendering.pageElements.DisclaimerBlockElement':
 		default:
 			return <></>;
 	}

--- a/dotcom-rendering/src/lib/renderElement.tsx
+++ b/dotcom-rendering/src/lib/renderElement.tsx
@@ -10,7 +10,7 @@ import { CartoonComponent } from '../components/CartoonComponent';
 import { ChartAtom } from '../components/ChartAtom.importable';
 import { CodeBlockComponent } from '../components/CodeBlockComponent';
 import { CommentBlockComponent } from '../components/CommentBlockComponent';
-import { DisclaimerInline } from '../components/Disclaimer';
+import { AffiliateDisclaimerInline } from '../components/Disclaimer';
 import { DividerBlockComponent } from '../components/DividerBlockComponent';
 import { DocumentBlockComponent } from '../components/DocumentBlockComponent.importable';
 import { EmailSignUpWrapper } from '../components/EmailSignUpWrapper';
@@ -752,7 +752,7 @@ export const renderElement = ({
 				</Island>
 			);
 		case 'model.dotcomrendering.pageElements.DisclaimerBlockElement': {
-			return <DisclaimerInline />;
+			return <AffiliateDisclaimerInline />;
 		}
 		case 'model.dotcomrendering.pageElements.AudioBlockElement':
 		case 'model.dotcomrendering.pageElements.ContentAtomBlockElement':

--- a/dotcom-rendering/src/lib/renderElement.tsx
+++ b/dotcom-rendering/src/lib/renderElement.tsx
@@ -10,7 +10,7 @@ import { CartoonComponent } from '../components/CartoonComponent';
 import { ChartAtom } from '../components/ChartAtom.importable';
 import { CodeBlockComponent } from '../components/CodeBlockComponent';
 import { CommentBlockComponent } from '../components/CommentBlockComponent';
-import { Disclaimer } from '../components/Disclaimer';
+import { DisclaimerInline } from '../components/Disclaimer';
 import { DividerBlockComponent } from '../components/DividerBlockComponent';
 import { DocumentBlockComponent } from '../components/DocumentBlockComponent.importable';
 import { EmailSignUpWrapper } from '../components/EmailSignUpWrapper';
@@ -752,7 +752,7 @@ export const renderElement = ({
 				</Island>
 			);
 		case 'model.dotcomrendering.pageElements.DisclaimerBlockElement': {
-			return <Disclaimer />;
+			return <DisclaimerInline />;
 		}
 		case 'model.dotcomrendering.pageElements.AudioBlockElement':
 		case 'model.dotcomrendering.pageElements.ContentAtomBlockElement':

--- a/dotcom-rendering/src/model/enhance-disclaimer.ts
+++ b/dotcom-rendering/src/model/enhance-disclaimer.ts
@@ -1,0 +1,56 @@
+import type { FEElement } from '../types/content';
+
+const isParagraph = (element: FEElement) =>
+	element._type === 'model.dotcomrendering.pageElements.TextBlockElement';
+
+type ReducerAccumulator = {
+	elements: FEElement[];
+	paragraphCounter: number;
+};
+
+const createDisclaimerBlock = (): FEElement => ({
+	_type: 'model.dotcomrendering.pageElements.DisclaimerBlockElement',
+	elementId: 'disclaimer',
+	// this is a marker element and its html should not be rendered
+	html: '',
+	role: 'inline',
+});
+
+/**
+ * Create a DisclaimerBlockElement before the 2nd paragraph
+ * This element is just a marker to be used by the layout implementations which
+ * will insert a <Disclaimer> component
+ */
+const insertDisclaimerElement = (elements: FEElement[]): FEElement[] => {
+	const enhancedElements = elements.reduce(
+		(acc: ReducerAccumulator, element: FEElement): ReducerAccumulator => {
+			const paragraphCounter = isParagraph(element)
+				? acc.paragraphCounter + 1
+				: acc.paragraphCounter;
+
+			const newElements =
+				paragraphCounter === 2
+					? [...acc.elements, createDisclaimerBlock(), element]
+					: [...acc.elements, element];
+
+			return {
+				elements: newElements,
+				paragraphCounter,
+			};
+		},
+		{
+			elements: [],
+			paragraphCounter: 0,
+		},
+	);
+	return enhancedElements.elements;
+};
+
+const enhanceDisclaimer =
+	(hasAffiliateLinksDisclaimer: boolean) =>
+	(elements: FEElement[]): FEElement[] =>
+		hasAffiliateLinksDisclaimer
+			? insertDisclaimerElement(elements)
+			: elements;
+
+export { enhanceDisclaimer };

--- a/dotcom-rendering/src/model/enhance-disclaimer.ts
+++ b/dotcom-rendering/src/model/enhance-disclaimer.ts
@@ -29,7 +29,7 @@ const insertDisclaimerElement = (elements: FEElement[]): FEElement[] => {
 				: acc.paragraphCounter;
 
 			const newElements =
-				paragraphCounter === 2
+				paragraphCounter === 2 && isParagraph(element)
 					? [...acc.elements, createDisclaimerBlock(), element]
 					: [...acc.elements, element];
 

--- a/dotcom-rendering/src/model/enhanceBlocks.ts
+++ b/dotcom-rendering/src/model/enhanceBlocks.ts
@@ -3,6 +3,7 @@ import type { FEElement, ImageForLightbox, Newsletter } from '../types/content';
 import type { RenderingTarget } from '../types/renderingTarget';
 import { enhanceAdPlaceholders } from './enhance-ad-placeholders';
 import { enhanceBlockquotes } from './enhance-blockquotes';
+import { enhanceDisclaimer } from './enhance-disclaimer';
 import { enhanceDividers } from './enhance-dividers';
 import { enhanceDots } from './enhance-dots';
 import { enhanceEmbeds } from './enhance-embeds';
@@ -18,6 +19,7 @@ type Options = {
 	renderingTarget: RenderingTarget;
 	promotedNewsletter: Newsletter | undefined;
 	imagesForLightbox: ImageForLightbox[];
+	hasAffiliateLinksDisclaimer: boolean;
 };
 
 const enhanceNewsletterSignup =
@@ -59,6 +61,7 @@ export const enhanceElements =
 				blockId,
 			),
 			enhanceAdPlaceholders(format, options.renderingTarget),
+			enhanceDisclaimer(options.hasAffiliateLinksDisclaimer),
 		].reduce(
 			(enhancedBlocks, enhancer) => enhancer(enhancedBlocks),
 			elements,

--- a/dotcom-rendering/src/server/handler.article.web.ts
+++ b/dotcom-rendering/src/server/handler.article.web.ts
@@ -76,6 +76,7 @@ export const handleBlocks: RequestHandler = ({ body }, res) => {
 		renderingTarget: 'Web',
 		promotedNewsletter: undefined,
 		imagesForLightbox: [],
+		hasAffiliateLinksDisclaimer: false,
 	});
 	const html = renderBlocks({
 		blocks: enhancedBlocks,


### PR DESCRIPTION
## What does this change?

Updates the 'Affiliates disclaimer' placement as follows:

- until leftcol: inline alongside the second paragraph
- from leftcol: below the meta section

## Screenshots

### Until leftcol

| 320px       | 740px      | 980px      |
| ----------- | ---------- | -- |
| <img src="https://github.com/guardian/dotcom-rendering/assets/7014230/3dce85f5-a53f-43c1-ae60-3165789d108e" width="160" height="auto"> | <img src="https://github.com/guardian/dotcom-rendering/assets/7014230/15e8128a-4ebe-48e4-acb5-1b71dc81aca4" width="370" height="auto"> | <img src="https://github.com/guardian/dotcom-rendering/assets/7014230/6d7b11ec-3a57-4b2a-b2d0-6a1db8ea3789" width="490" height="auto"> |

### From leftcol

|  1140px      |
|  -- |
| <img width="570" alt="Screenshot 2024-03-13 at 16 29 15" src="https://github.com/guardian/dotcom-rendering/assets/7014230/3c998034-a893-4f70-88cf-091f98ad1d48"> |

