### PR TITLE
Bump @guardian/ophan-tracker-js@2.1.1

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -57,7 +57,7 @@
 		"@guardian/identity-auth": "2.1.0",
 		"@guardian/identity-auth-frontend": "4.0.0",
 		"@guardian/libs": "16.0.1",
-		"@guardian/ophan-tracker-js": "2.1.0",
+		"@guardian/ophan-tracker-js": "2.1.1",
 		"@guardian/shimport": "1.0.2",
 		"@guardian/source-foundations": "14.1.4",
 		"@guardian/source-react-components": "22.0.1",

--- a/dotcom-rendering/playwright/lib/load-page.ts
+++ b/dotcom-rendering/playwright/lib/load-page.ts
@@ -31,9 +31,6 @@ const loadPage = async (
 					`{"value":"${new Date().toISOString()}"}`,
 				);
 			}
-			// force Ophan to use the https endpoint
-			// @ts-expect-error - window type
-			window.ophanRemoteHost = 'https://ophan.theguardian.com';
 		},
 		{ region, preventSupportBanner },
 	);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -381,8 +381,8 @@ importers:
         specifier: 16.0.1
         version: 16.0.1(tslib@2.6.2)(typescript@5.3.3)
       '@guardian/ophan-tracker-js':
-        specifier: 2.1.0
-        version: 2.1.0
+        specifier: 2.1.1
+        version: 2.1.1
       '@guardian/shimport':
         specifier: 1.0.2
         version: 1.0.2
@@ -4550,8 +4550,8 @@ packages:
     engines: {node: '>=16'}
     dev: false
 
-  /@guardian/ophan-tracker-js@2.1.0:
-    resolution: {integrity: sha512-VOU94rhjDeDF1kg2htmNu8H+zhL1tHciKtWnp9qr0U7lbpQ6qW+RW/GM5OM3zfXampwk9FzlsTvU05cixB/5Jw==}
+  /@guardian/ophan-tracker-js@2.1.1:
+    resolution: {integrity: sha512-Ktk9kDJfe//NJFfpT15jweTj4KQbgkQuo8pWRYrlNZpq1oaTpSeMtI/eSCtqK8yhXKlBJDsMbEyCYsEgQRYFag==}
     engines: {node: '>=16'}
     dev: false
 


### PR DESCRIPTION
## What does this change?

Bump @guardian/ophan-tracker-js@2.1.1 to bring in: https://github.com/guardian/ophan/pull/5911

This fixes the issue when Ophan attempts to connect on http causing requests to hang and throw errors for the local dev build.

## Screenshots

Before:

![image](https://github.com/guardian/dotcom-rendering/assets/7014230/a5ac3dce-774d-4c62-bda0-6ffdf2feb876)
