### PR TITLE
Narrow discussion pagination

### DIFF
--- a/dotcom-rendering/src/components/Discussion/Pagination.tsx
+++ b/dotcom-rendering/src/components/Discussion/Pagination.tsx
@@ -36,7 +36,7 @@ const pageButtonStyles = (isSelected: boolean) => css`
 		border-color: ${schemedPalette('--discussion-pagination-text')};
 	}
 
-	margin-right: 5px;
+	margin-right: 2px;
 	padding: 0 0.125rem;
 	min-width: 1.5rem;
 	text-align: center;
@@ -92,7 +92,7 @@ const shiftRight = css`
 
 const elipsisStyles = css`
 	line-height: 26px;
-	margin-right: 5px;
+	margin-right: 2px;
 `;
 
 const wrapperStyles = css`
@@ -102,9 +102,7 @@ const wrapperStyles = css`
 	display: flex;
 	flex-direction: row;
 	justify-content: space-between;
-	width: 100%;
-	padding-top: ${space[2]}px;
-	padding-bottom: ${space[2]}px;
+	padding: ${space[2]}px 0;
 	border-top: 1px solid ${schemedPalette('--discussion-pagination-border')};
 	${until.mobileLandscape} {
 		flex-direction: column;


### PR DESCRIPTION
## What does this change?
This narrows the discussion pagination similar to other pagination.
## Why?
Resolves https://github.com/guardian/dotcom-rendering/issues/10072
## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/110032454/8114b721-cf3f-48fd-b992-cfe59a7a61ad
[after]: https://github.com/guardian/dotcom-rendering/assets/110032454/dcc77906-4488-4b65-9f79-d1167926d127

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
