### PR TITLE
Pick the correct cartoon for lightbox

### DIFF
--- a/dotcom-rendering/src/model/buildLightboxImages.ts
+++ b/dotcom-rendering/src/model/buildLightboxImages.ts
@@ -6,7 +6,11 @@ import type {
 	ImageBlockElement,
 	ImageForLightbox,
 } from '../types/content';
-import { isCartoon, isImage } from './enhance-images';
+import {
+	getCartoonImageForLightbox,
+	isCartoon,
+	isImage,
+} from './enhance-images';
 
 /** Used to determine if a lightbox can be created */
 const THRESHOLD = 620;
@@ -55,7 +59,7 @@ const buildLightboxImage = (
 ): Omit<ImageForLightbox, 'position'> | undefined => {
 	const allImages = isImage(element)
 		? element.media.allImages
-		: element.variants.flatMap(({ images }) => images);
+		: getCartoonImageForLightbox(element);
 	const masterImage = getMaster(allImages) ?? getLargest(allImages);
 
 	// Rare, but legacy content might not have a url that we can use with Fastly

--- a/dotcom-rendering/src/model/enhance-images.ts
+++ b/dotcom-rendering/src/model/enhance-images.ts
@@ -8,6 +8,7 @@ import { getLargest, getMaster } from '../lib/image';
 import type {
 	CartoonBlockElement,
 	FEElement,
+	Image,
 	ImageBlockElement,
 	ImageForLightbox,
 	MultiImageBlockElement,
@@ -18,6 +19,19 @@ import type {
 interface HalfWidthImageBlockElement extends ImageBlockElement {
 	role: 'halfWidth';
 }
+
+/**
+ * When opening cartoons in the lightbox we always want the entire cartoon,
+ * i.e. the desktop version stored in the large variant
+ */
+export const getCartoonImageForLightbox = (
+	element: CartoonBlockElement,
+): Image[] => {
+	const largeVariant = element.variants.find(
+		(variant) => variant.viewportSize === 'large',
+	);
+	return largeVariant?.images ?? [];
+};
 
 const isHalfWidthImage = (
 	element?: FEElement,
@@ -320,7 +334,7 @@ const addImagePositions = <E extends FEElement>(
 
 		const allImages = isImage(element)
 			? element.media.allImages
-			: element.variants.flatMap((variant) => variant.images);
+			: getCartoonImageForLightbox(element);
 
 		const image = getMaster(allImages) ?? getLargest(allImages);
 


### PR DESCRIPTION
## What does this change?

Pick the correct cartoon for lightbox, i.e. always the desktop version stored in the "large" variant

## Why?

So the reader can inspect the entire cartoon using lightbox, otherwise there's a risk they will only see the first mobile image which only contains part of the cartoon. 

There's an alternative here to allow lightbox to scroll through all mobile images, but there was a product decision that the desktop image is a better experience. This can change if someone expresses a string view. 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/1229808/851ac231-c39e-4af4-bb49-09773a56a456
[after]: https://github.com/guardian/dotcom-rendering/assets/1229808/deb607eb-042d-45ef-9e59-2b322df7050b

fixes: https://github.com/guardian/dotcom-rendering/issues/10911
