### PR TITLE
Fix signed in labs front

### DIFF
--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -451,10 +451,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 						);
 					}
 
-					if (
-						collection.containerPalette === 'Branded' &&
-						renderAds
-					) {
+					if (collection.containerPalette === 'Branded') {
 						return (
 							<Fragment key={ophanName}>
 								<LabsSection
@@ -569,15 +566,17 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 										/>
 									</Island>
 								</Section>
-								{decideMerchHighAndMobileAdSlots(
-									renderAds,
-									index,
-									front.pressedPage.collections.length,
-									front.pressedPage.frontProperties
-										.isPaidContent,
-									mobileAdPositions,
-									hasPageSkin,
-								)}
+
+								{renderAds &&
+									decideMerchHighAndMobileAdSlots(
+										renderAds,
+										index,
+										front.pressedPage.collections.length,
+										front.pressedPage.frontProperties
+											.isPaidContent,
+										mobileAdPositions,
+										hasPageSkin,
+									)}
 							</Fragment>
 						);
 					}


### PR DESCRIPTION
## What does this change?
Moves the renderAds logic to the adslot.
## Why?
Resolves https://github.com/guardian/dotcom-rendering/issues/9530
## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/110032454/f23ab34f-c27d-4904-ac3c-f14e672575a1
[after]: https://github.com/guardian/dotcom-rendering/assets/110032454/566b5a0c-7691-483a-a5e4-a29bf86ced88

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
