### PR TITLE
Integrate Key Takeaways

### DIFF
--- a/dotcom-rendering/src/components/KeyTakeaway.tsx
+++ b/dotcom-rendering/src/components/KeyTakeaway.tsx
@@ -62,8 +62,8 @@ export const KeyTakeaway = ({
 }: KeyTakeawayProps) => {
 	return (
 		<>
-			<hr css={headingLineStyles} />
 			<li css={keyTakeawayStyles}>
+				<hr css={headingLineStyles} />
 				<h2 css={headingStyles}>
 					<span css={headingIndexStyles}>{`${titleIndex}. `}</span>
 					{keyTakeaway.title}

--- a/dotcom-rendering/src/components/KeyTakeaway.tsx
+++ b/dotcom-rendering/src/components/KeyTakeaway.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/react';
 import type { ArticleFormat } from '@guardian/libs';
 import { headline } from '@guardian/source-foundations';
 import type { EditionId } from '../lib/edition';
-import { RenderArticleElement } from '../lib/renderElement';
+import type { ArticleElementRenderer } from '../lib/renderElement';
 import { palette } from '../palette';
 import type { ServerSideTests, Switches } from '../types/config';
 import type { KeyTakeaway as KeyTakeawayModel } from '../types/content';
@@ -41,6 +41,7 @@ interface KeyTakeawayProps {
 	starRating?: number;
 	keyTakeaway: KeyTakeawayModel;
 	titleIndex: number;
+	RenderArticleElement: ArticleElementRenderer;
 }
 
 export const KeyTakeaway = ({
@@ -57,6 +58,7 @@ export const KeyTakeaway = ({
 	titleIndex,
 	hideCaption,
 	starRating,
+	RenderArticleElement,
 }: KeyTakeawayProps) => {
 	return (
 		<>

--- a/dotcom-rendering/src/components/KeyTakeaway.tsx
+++ b/dotcom-rendering/src/components/KeyTakeaway.tsx
@@ -1,0 +1,93 @@
+import { css } from '@emotion/react';
+import type { ArticleFormat } from '@guardian/libs';
+import { headline } from '@guardian/source-foundations';
+import type { EditionId } from '../lib/edition';
+import { RenderArticleElement } from '../lib/renderElement';
+import { palette } from '../palette';
+import type { ServerSideTests, Switches } from '../types/config';
+import type { KeyTakeaway as KeyTakeawayModel } from '../types/content';
+
+const keyTakeawayStyles = css`
+	padding-top: 8px;
+`;
+
+const headingStyles = css`
+	${headline.xsmall({ fontWeight: 'medium' })};
+	padding: 2px 0px;
+`;
+
+const headingIndexStyles = css`
+	${headline.xsmall({ fontWeight: 'bold' })};
+`;
+
+const headingLineStyles = css`
+	width: 140px;
+	margin: 0px;
+	border: none;
+	border-top: 8px solid ${palette('--heading-line')};
+`;
+
+interface KeyTakeawayProps {
+	format: ArticleFormat;
+	ajaxUrl: string;
+	host?: string;
+	pageId: string;
+	isAdFreeUser: boolean;
+	isSensitive: boolean;
+	abTests: ServerSideTests;
+	switches: Switches;
+	editionId: EditionId;
+	hideCaption?: boolean;
+	starRating?: number;
+	keyTakeaway: KeyTakeawayModel;
+	titleIndex: number;
+}
+
+export const KeyTakeaway = ({
+	keyTakeaway,
+	format,
+	ajaxUrl,
+	host,
+	pageId,
+	isAdFreeUser,
+	isSensitive,
+	switches,
+	abTests,
+	editionId,
+	titleIndex,
+	hideCaption,
+	starRating,
+}: KeyTakeawayProps) => {
+	return (
+		<>
+			<hr css={headingLineStyles} />
+			<li css={keyTakeawayStyles}>
+				<h2 css={headingStyles}>
+					<span css={headingIndexStyles}>{`${titleIndex}. `}</span>
+					{keyTakeaway.title}
+				</h2>
+				{keyTakeaway.body.map((element, index) => (
+					<RenderArticleElement
+						// eslint-disable-next-line react/no-array-index-key -- This is only rendered once so we can safely use index to suppress the warning
+						key={index}
+						format={format}
+						element={element}
+						ajaxUrl={ajaxUrl}
+						host={host}
+						index={index}
+						isMainMedia={false}
+						pageId={pageId}
+						webTitle={keyTakeaway.title}
+						isAdFreeUser={isAdFreeUser}
+						isSensitive={isSensitive}
+						switches={switches}
+						abTests={abTests}
+						editionId={editionId}
+						hideCaption={hideCaption}
+						starRating={starRating}
+					/>
+				))}
+			</li>
+		</>
+	);
+};

--- a/dotcom-rendering/src/components/KeyTakeaway.tsx
+++ b/dotcom-rendering/src/components/KeyTakeaway.tsx
@@ -24,7 +24,7 @@ const headingLineStyles = css`
 	width: 140px;
 	margin: 0px;
 	border: none;
-	border-top: 8px solid ${palette('--heading-line')};
+	border-top: 4px solid ${palette('--heading-line')};
 `;
 
 interface KeyTakeawayProps {

--- a/dotcom-rendering/src/components/KeyTakeaways.stories.tsx
+++ b/dotcom-rendering/src/components/KeyTakeaways.stories.tsx
@@ -3,6 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { splitTheme } from '../../.storybook/decorators/splitThemeDecorator';
 import { images } from '../../fixtures/generated/images';
 import { getAllThemes } from '../lib/format';
+import { RenderArticleElement } from '../lib/renderElement';
 import type { TextBlockElement } from '../types/content';
 import { KeyTakeaways } from './KeyTakeaways';
 
@@ -57,6 +58,7 @@ export const AllThemes = {
 		isSensitive: false,
 		pageId: 'testID',
 		switches: {},
+		RenderArticleElement,
 	},
 	decorators: [
 		splitTheme(
@@ -100,6 +102,7 @@ export const Images = {
 		isSensitive: false,
 		pageId: 'testID',
 		switches: {},
+		RenderArticleElement,
 	},
 	decorators: [
 		splitTheme(

--- a/dotcom-rendering/src/components/KeyTakeaways.tsx
+++ b/dotcom-rendering/src/components/KeyTakeaways.tsx
@@ -1,5 +1,6 @@
 import type { ArticleFormat } from '@guardian/libs';
 import type { EditionId } from '../lib/edition';
+import type { ArticleElementRenderer } from '../lib/renderElement';
 import type { ServerSideTests, Switches } from '../types/config';
 import type { KeyTakeaway } from '../types/content';
 import { KeyTakeaway as KeyTakeawayComponent } from './KeyTakeaway';
@@ -17,6 +18,7 @@ interface KeyTakeawaysProps {
 	hideCaption?: boolean;
 	starRating?: number;
 	keyTakeaways: KeyTakeaway[];
+	RenderArticleElement: ArticleElementRenderer;
 }
 
 export const KeyTakeaways = ({
@@ -32,6 +34,7 @@ export const KeyTakeaways = ({
 	editionId,
 	hideCaption,
 	starRating,
+	RenderArticleElement,
 }: KeyTakeawaysProps) => {
 	return (
 		<ol data-ignore="global-ol-styling">
@@ -51,6 +54,7 @@ export const KeyTakeaways = ({
 					hideCaption={hideCaption}
 					starRating={starRating}
 					key={index}
+					RenderArticleElement={RenderArticleElement}
 				/>
 			))}
 		</ol>

--- a/dotcom-rendering/src/components/KeyTakeaways.tsx
+++ b/dotcom-rendering/src/components/KeyTakeaways.tsx
@@ -1,33 +1,10 @@
-import { css } from '@emotion/react';
 import type { ArticleFormat } from '@guardian/libs';
-import { headline } from '@guardian/source-foundations';
 import type { EditionId } from '../lib/edition';
-import { RenderArticleElement } from '../lib/renderElement';
-import { palette } from '../palette';
 import type { ServerSideTests, Switches } from '../types/config';
 import type { KeyTakeaway } from '../types/content';
+import { KeyTakeaway as KeyTakeawayComponent } from './KeyTakeaway';
 
-const keyTakeawayStyles = css`
-	padding-top: 8px;
-`;
-
-const headingStyles = css`
-	${headline.xsmall({ fontWeight: 'medium' })};
-	padding: 2px 0px;
-`;
-
-const headingIndexStyles = css`
-	${headline.xsmall({ fontWeight: 'bold' })};
-`;
-
-const headingLineStyles = css`
-	width: 140px;
-	margin: 0px;
-	border: none;
-	border-top: 8px solid ${palette('--heading-line')};
-`;
-
-interface CommonProps {
+interface KeyTakeawaysProps {
 	format: ArticleFormat;
 	ajaxUrl: string;
 	host?: string;
@@ -39,63 +16,8 @@ interface CommonProps {
 	editionId: EditionId;
 	hideCaption?: boolean;
 	starRating?: number;
-}
-
-interface KeyTakeawaysProps extends CommonProps {
 	keyTakeaways: KeyTakeaway[];
 }
-
-interface KeyTakeawayProps extends CommonProps {
-	keyTakeaway: KeyTakeaway;
-	titleIndex: number;
-}
-
-const KeyTakeawayComponent = ({
-	keyTakeaway,
-	format,
-	ajaxUrl,
-	host,
-	pageId,
-	isAdFreeUser,
-	isSensitive,
-	switches,
-	abTests,
-	editionId,
-	titleIndex,
-	hideCaption,
-	starRating,
-}: KeyTakeawayProps) => {
-	return (
-		<li css={keyTakeawayStyles}>
-			<hr css={headingLineStyles}></hr>
-			<h2 css={headingStyles}>
-				<span css={headingIndexStyles}>{`${titleIndex}. `}</span>
-				{keyTakeaway.title}
-			</h2>
-			{keyTakeaway.body.map((element, index) => (
-				<RenderArticleElement
-					// eslint-disable-next-line react/no-array-index-key -- This is only rendered once so we can safely use index to suppress the warning
-					key={index}
-					format={format}
-					element={element}
-					ajaxUrl={ajaxUrl}
-					host={host}
-					index={index}
-					isMainMedia={false}
-					pageId={pageId}
-					webTitle={keyTakeaway.title}
-					isAdFreeUser={isAdFreeUser}
-					isSensitive={isSensitive}
-					switches={switches}
-					abTests={abTests}
-					editionId={editionId}
-					hideCaption={hideCaption}
-					starRating={starRating}
-				/>
-			))}
-		</li>
-	);
-};
 
 export const KeyTakeaways = ({
 	keyTakeaways,
@@ -112,7 +34,7 @@ export const KeyTakeaways = ({
 	starRating,
 }: KeyTakeawaysProps) => {
 	return (
-		<ol>
+		<ol data-ignore="global-ol-styling">
 			{keyTakeaways.map((keyTakeaway, index) => (
 				<KeyTakeawayComponent
 					keyTakeaway={keyTakeaway}

--- a/dotcom-rendering/src/lib/renderElement.tsx
+++ b/dotcom-rendering/src/lib/renderElement.tsx
@@ -431,6 +431,7 @@ export const renderElement = ({
 					abTests={abTests}
 					switches={switches}
 					editionId={editionId}
+					RenderArticleElement={RenderArticleElement}
 				/>
 			);
 		case 'model.dotcomrendering.pageElements.MapBlockElement':
@@ -858,3 +859,5 @@ export const RenderArticleElement = ({
 		el
 	);
 };
+
+export type ArticleElementRenderer = typeof RenderArticleElement;

--- a/dotcom-rendering/src/lib/renderElement.tsx
+++ b/dotcom-rendering/src/lib/renderElement.tsx
@@ -27,6 +27,7 @@ import { InteractiveContentsBlockComponent } from '../components/InteractiveCont
 import { InteractiveLayoutAtom } from '../components/InteractiveLayoutAtom';
 import { Island } from '../components/Island';
 import { ItemLinkBlockElement } from '../components/ItemLinkBlockElement';
+import { KeyTakeaways } from '../components/KeyTakeaways';
 import { KnowledgeQuizAtom } from '../components/KnowledgeQuizAtom.importable';
 import { MainMediaEmbedBlockComponent } from '../components/MainMediaEmbedBlockComponent';
 import { MapEmbedBlockComponent } from '../components/MapEmbedBlockComponent.importable';
@@ -136,6 +137,7 @@ export const renderElement = ({
 	switches,
 	isSensitive,
 	isPinnedPost,
+	abTests,
 	editionId,
 }: Props) => {
 	const isBlog =
@@ -416,6 +418,20 @@ export const renderElement = ({
 						/>
 					</Island>
 				</div>
+			);
+		case 'model.dotcomrendering.pageElements.KeyTakeawaysBlockElement':
+			return (
+				<KeyTakeaways
+					keyTakeaways={element.keyTakeaways}
+					format={format}
+					ajaxUrl={ajaxUrl}
+					pageId={pageId}
+					isAdFreeUser={isAdFreeUser}
+					isSensitive={isSensitive}
+					abTests={abTests}
+					switches={switches}
+					editionId={editionId}
+				/>
 			);
 		case 'model.dotcomrendering.pageElements.MapBlockElement':
 			return (

--- a/dotcom-rendering/src/model/article-schema.json
+++ b/dotcom-rendering/src/model/article-schema.json
@@ -2386,10 +2386,14 @@
                     "items": {
                         "$ref": "#/definitions/ListItem"
                     }
+                },
+                "elementId": {
+                    "type": "string"
                 }
             },
             "required": [
                 "_type",
+                "elementId",
                 "items",
                 "listElementType"
             ]

--- a/dotcom-rendering/src/model/block-schema.json
+++ b/dotcom-rendering/src/model/block-schema.json
@@ -1975,10 +1975,14 @@
                     "items": {
                         "$ref": "#/definitions/ListItem"
                     }
+                },
+                "elementId": {
+                    "type": "string"
                 }
             },
             "required": [
                 "_type",
+                "elementId",
                 "items",
                 "listElementType"
             ]

--- a/dotcom-rendering/src/types/content.ts
+++ b/dotcom-rendering/src/types/content.ts
@@ -338,6 +338,7 @@ export interface ListBlockElement {
 	_type: 'model.dotcomrendering.pageElements.ListBlockElement';
 	listElementType: 'KeyTakeaways' | 'QAndAExplainer';
 	items: ListItem[];
+	elementId: string;
 }
 
 export interface MapBlockElement extends ThirdPartyEmbeddedContent {


### PR DESCRIPTION
## What does this change?

* Extract key takeaway component and integrate with render elements
* Update schema to include elementId
* Fix list css by making sure we don't apply global styles

Co authored by: @JamieB-gu 

## Why?

So we can actually render Key Takeaways 
Superset of: https://github.com/guardian/dotcom-rendering/pull/10895
Fixes: https://github.com/guardian/dotcom-rendering/issues/10902 
