### PR TITLE
AB tests: add control to alternative wording sign-in gate AB test

### DIFF
--- a/dotcom-rendering/src/components/SignInGate/gates/alternative-wording-control.tsx
+++ b/dotcom-rendering/src/components/SignInGate/gates/alternative-wording-control.tsx
@@ -1,0 +1,46 @@
+import { startPerformanceMeasure } from '@guardian/libs';
+import React, { Suspense } from 'react';
+import { Lazy } from '../../Lazy';
+import { canShowSignInGateWithOffers } from '../displayRule';
+import type { SignInGateComponent } from '../types';
+
+const SignInGateMain = React.lazy(() => {
+	const { endPerformanceMeasure } = startPerformanceMeasure(
+		'identity',
+		'SignInGateMain',
+	);
+	return import(
+		/* webpackChunkName: "SignInGateMain" */ '../gateDesigns/SignInGateMain'
+	).then((module) => {
+		endPerformanceMeasure();
+		return { default: module.SignInGateMain };
+	});
+});
+
+export const signInGateComponent: SignInGateComponent = {
+	gate: ({
+		ophanComponentId,
+		dismissGate,
+		guUrl,
+		signInUrl,
+		registerUrl,
+		abTest,
+	}) => {
+		return (
+			<Lazy margin={300}>
+				<Suspense fallback={<></>}>
+					<SignInGateMain
+						ophanComponentId={ophanComponentId}
+						dismissGate={dismissGate}
+						guUrl={guUrl}
+						signInUrl={signInUrl}
+						registerUrl={registerUrl}
+						abTest={abTest}
+						isMandatory={false}
+					/>
+				</Suspense>
+			</Lazy>
+		);
+	},
+	canShow: canShowSignInGateWithOffers,
+};

--- a/dotcom-rendering/src/components/SignInGate/signInGate.ts
+++ b/dotcom-rendering/src/components/SignInGate/signInGate.ts
@@ -4,6 +4,7 @@ import { signInGateAlternativeWording } from '../../experiments/tests/sign-in-ga
 import { signInGateMainControl } from '../../experiments/tests/sign-in-gate-main-control';
 import { signInGateMainVariant } from '../../experiments/tests/sign-in-gate-main-variant';
 // Sign in Gate Types
+import { signInGateComponent as alternativeWordingControl } from './gates/alternative-wording-control';
 import { signInGateComponent as alternativeWordingGuardianLive } from './gates/alternative-wording-guardian-live';
 import { signInGateComponent as alternativeWordingSaturdayEdition } from './gates/alternative-wording-saturday-edition';
 import { signInGateComponent as gateMainControl } from './gates/main-control';
@@ -26,7 +27,7 @@ export const signInGateTestVariantToGateMapping: SignInGateTestMap = {
 	'main-variant-5': gateMainVariant,
 	'alternative-wording-guardian-live': alternativeWordingGuardianLive,
 	'alternative-wording-saturday-edition': alternativeWordingSaturdayEdition,
-	'alternative-wording-control': gateMainVariant,
+	'alternative-wording-control': alternativeWordingControl,
 };
 
 // Component Id does not need to match gate test name, as ab test info passed separately to ophan


### PR DESCRIPTION


## What does this change?

Adds a control gate to the alternative wording sign in gate AB test

## Why?

The control gate is the same as the standard gate, but operates under the same rules as the actual alternative wording gates, and therefore isn't show to readers in the US or Australia, which allows us to get fairer reporting data.

## Previous PRs

- https://github.com/guardian/dotcom-rendering/pull/10767
- https://github.com/guardian/dotcom-rendering/pull/10889