### PR TITLE
Add AbTest fields to Epic View

### DIFF
--- a/dotcom-rendering/src/components/marketing/epics/ContributionsEpic.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ContributionsEpic.tsx
@@ -261,8 +261,7 @@ const sendEpicViewEvent = (
 	const eventBody = JSON.stringify({
 		url,
 		countryCode,
-		abTestName,
-		abTestVariant,
+		abTests: [{ name: abTestName, variant: abTestVariant }],
 	});
 
 	void fetch(`${host}/${path}`, {

--- a/dotcom-rendering/src/components/marketing/epics/ContributionsEpic.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ContributionsEpic.tsx
@@ -249,6 +249,8 @@ const EpicBody: ReactComponent<BodyProps> = ({
 
 const sendEpicViewEvent = (
 	url: string,
+	abTestName: string,
+	abTestVariant: string,
 	stage?: Stage,
 	countryCode?: string,
 ): void => {
@@ -259,6 +261,8 @@ const sendEpicViewEvent = (
 	const eventBody = JSON.stringify({
 		url,
 		countryCode,
+		abTestName,
+		abTestVariant,
 	});
 
 	void fetch(`${host}/${path}`, {
@@ -320,7 +324,13 @@ const ContributionsEpic: ReactComponent<EpicProps> = ({
 		if (hasBeenSeen) {
 			// For the event stream
 			if (!window?.guardian?.config?.isDev && stage !== 'DEV') {
-				sendEpicViewEvent(tracking.referrerUrl, stage, countryCode);
+				sendEpicViewEvent(
+					tracking.referrerUrl,
+					tracking.abTestName,
+					tracking.abTestVariant,
+					stage,
+					countryCode,
+				);
 			}
 
 			// For epic view count


### PR DESCRIPTION
## What does this change?
Adds two new fields abName and abVariant to Epic Views count via a single object called AbTests.

As part of[ Trello Card](https://trello.com/c/kJ1sydtu/251-prototype-multi-armed-bandit)

## Why?
To support the prototype for multi arm bandit testing. This particular PR covers point 1b in our [Bandit Testing prototype doc](https://docs.google.com/document/d/1jV6DkkLLH90PetO1Os7c6pi8WEiCx2t9BUIraqIEAHU/edit?usp=sharing)
## Screenshots
New `abtests` column showing on `epic_views_code` table in Athena after deployment onto `CODE`

![image](https://github.com/guardian/dotcom-rendering/assets/115992455/769c3816-77f9-4b24-a2a7-78ed5bf9e5ee)

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
