### PR TITLE
Update `Answers` Stories To Component Story Format v3

### DIFF
--- a/dotcom-rendering/src/components/Answers.stories.tsx
+++ b/dotcom-rendering/src/components/Answers.stories.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react';
 import { Pillar } from '@guardian/libs';
 import { Radio, RadioGroup } from '@guardian/source-react-components';
+import type { Meta, StoryObj } from '@storybook/react';
 import {
 	CorrectSelectedAnswer,
 	IncorrectAnswer,
@@ -9,51 +10,57 @@ import {
 	UnselectedAnswer,
 } from './Answers';
 
-export default {
-	title: 'Answers',
-};
+const meta = {
+	title: 'Components/Answers',
+} satisfies Meta;
 
-export const Answers = () => (
-	<div
-		css={css`
-			display: flex;
-			flex-direction: column;
-		`}
-	>
-		<CorrectSelectedAnswer
-			id="someId3"
-			answerText="Correct Selected Answer"
-			explainerText="this is such a cool answer"
-			theme={Pillar.News}
-		/>
-		<NonSelectedCorrectAnswer
-			id="someId4"
-			answerText="Correct Non Selected Answer"
-			explainerText="this is such a cool answer"
-			theme={Pillar.News}
-		/>
-		<IncorrectAnswer
-			id="someId5"
-			answerText="Incorrect Answer"
-			theme={Pillar.News}
-		/>
-		<UnselectedAnswer
-			id="someId1"
-			answerText="Unselectable unanswered answer"
-			theme={Pillar.News}
-		/>
-		<div css={radioButtonWrapperStyles(Pillar.News)}>
-			<RadioGroup name="answers">
-				<Radio
-					defaultChecked={true}
-					value="answer one"
-					label="Selectable unanswered answer"
-				/>
-				<Radio
-					value="answer two"
-					label="Selectable unanswered answer"
-				/>
-			</RadioGroup>
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Answers = {
+	render: () => (
+		<div
+			css={css`
+				display: flex;
+				flex-direction: column;
+			`}
+		>
+			<CorrectSelectedAnswer
+				id="someId3"
+				answerText="Correct Selected Answer"
+				explainerText="this is such a cool answer"
+				theme={Pillar.News}
+			/>
+			<NonSelectedCorrectAnswer
+				id="someId4"
+				answerText="Correct Non Selected Answer"
+				explainerText="this is such a cool answer"
+				theme={Pillar.News}
+			/>
+			<IncorrectAnswer
+				id="someId5"
+				answerText="Incorrect Answer"
+				theme={Pillar.News}
+			/>
+			<UnselectedAnswer
+				id="someId1"
+				answerText="Unselectable unanswered answer"
+				theme={Pillar.News}
+			/>
+			<div css={radioButtonWrapperStyles(Pillar.News)}>
+				<RadioGroup name="answers">
+					<Radio
+						defaultChecked={true}
+						value="answer one"
+						label="Selectable unanswered answer"
+					/>
+					<Radio
+						value="answer two"
+						label="Selectable unanswered answer"
+					/>
+				</RadioGroup>
+			</div>
 		</div>
-	</div>
-);
+	),
+} satisfies Story;


### PR DESCRIPTION
This is the default for Storybook 7+[^1], and integrates better with some of its features. This also moves these stories into the `Components` folder.

Using `satisfies` gives better type safety for `args`[^2].

**Note:** I recommend using "Hide whitespace" to view the diff.

[^1]: https://storybook.js.org/blog/storybook-csf3-is-here/
[^2]: https://storybook.js.org/docs/writing-stories/typescript#using-satisfies-for-better-type-safety
