### PR TITLE
Update `AppsFooter` Stories To Component Story Format v3

### DIFF
--- a/dotcom-rendering/src/components/AppsFooter.importable.stories.tsx
+++ b/dotcom-rendering/src/components/AppsFooter.importable.stories.tsx
@@ -1,10 +1,11 @@
 import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
+import type { Meta, StoryObj } from '@storybook/react';
 import { splitTheme } from '../../.storybook/decorators/splitThemeDecorator';
-import { AppsFooter } from './AppsFooter.importable';
+import { AppsFooter as AppsFooterComponent } from './AppsFooter.importable';
 
-export default {
-	component: AppsFooter,
-	title: 'AppsFooter',
+const meta = {
+	component: AppsFooterComponent,
+	title: 'Components/AppsFooter',
 	decorators: [
 		splitTheme([
 			{
@@ -14,6 +15,10 @@ export default {
 			},
 		]),
 	],
-};
+} satisfies Meta<typeof AppsFooterComponent>;
 
-export const Default = () => <AppsFooter />;
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const AppsFooter = {} satisfies Story;


### PR DESCRIPTION
This is the default for Storybook 7+[^1], and integrates better with some of its features.

This also moves these stories into the `Components` folder, and renames the only story to allow story hoisting[^2], i.e. the story can appear at the top level without an enclosing folder.

Using `satisfies` gives better type safety for `args`[^3].

[^1]: https://storybook.js.org/blog/storybook-csf3-is-here/
[^2]: https://storybook.js.org/docs/writing-stories/naming-components-and-hierarchy#single-story-hoisting
[^3]: https://storybook.js.org/docs/writing-stories/typescript#using-satisfies-for-better-type-safety