### PR TITLE
Update `InteractiveLayoutAtom` Stories To Component Story Format v3

### DIFF
--- a/dotcom-rendering/src/components/InteractiveLayoutAtom.stories.tsx
+++ b/dotcom-rendering/src/components/InteractiveLayoutAtom.stories.tsx
@@ -1,31 +1,36 @@
 import { css } from '@emotion/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import { interactiveLayoutAtom } from '../../fixtures/manual/InteractiveLayoutAtom';
-import { InteractiveLayoutAtom } from './InteractiveLayoutAtom';
+import { InteractiveLayoutAtom as InteractiveLayoutAtomComponent } from './InteractiveLayoutAtom';
 
-export default {
-	title: 'InteractiveLayoutAtom',
-	component: InteractiveLayoutAtom,
-};
+const meta = {
+	title: 'Components/InteractiveLayoutAtom',
+	component: InteractiveLayoutAtomComponent,
+} satisfies Meta<typeof InteractiveLayoutAtomComponent>;
 
-export const DefaultStory = (): JSX.Element => {
-	const { id, html, js, css: atomCss } = interactiveLayoutAtom;
-	return (
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const InteractiveLayoutAtom = {
+	args: {
+		id: interactiveLayoutAtom.id,
+		elementHtml: interactiveLayoutAtom.html,
+		elementJs: interactiveLayoutAtom.js,
+		elementCss: interactiveLayoutAtom.css,
+	},
+	decorators: (StoryComponent) => (
 		<div
 			css={css`
 				width: 1920px;
 				height: 1280px;
 			`}
 		>
-			<InteractiveLayoutAtom
-				id={id}
-				elementHtml={html}
-				elementJs={js}
-				elementCss={atomCss}
-			/>
+			<StoryComponent />
 		</div>
-	);
-};
-DefaultStory.parameters = {
-	// This interactive uses animation which is causing false negatives for Chromatic
-	chromatic: { disable: true },
-};
+	),
+	parameters: {
+		// This interactive uses animation which is causing false negatives for Chromatic
+		chromatic: { disable: true },
+	},
+} satisfies Story;


### PR DESCRIPTION
This is the default for Storybook 7+[^1], and integrates better with some of its features.

This also moves these stories into the `Components` folder, and renames the only story to allow story hoisting[^2], i.e. the story can appear at the top level without an enclosing folder.

Using `satisfies` gives better type safety for `args`[^3].

[^1]: https://storybook.js.org/blog/storybook-csf3-is-here/
[^2]: https://storybook.js.org/docs/writing-stories/naming-components-and-hierarchy#single-story-hoisting
[^3]: https://storybook.js.org/docs/writing-stories/typescript#using-satisfies-for-better-type-safety
