### PR TITLE
Update Quiz Atom Stories To Component Story Format v3

### DIFF
--- a/dotcom-rendering/src/components/KnowledgeQuizAtom.stories.tsx
+++ b/dotcom-rendering/src/components/KnowledgeQuizAtom.stories.tsx
@@ -1,4 +1,5 @@
 import { ArticleSpecial, Pillar } from '@guardian/libs';
+import type { Meta, StoryObj } from '@storybook/react';
 import {
 	exampleKnowledgeQuestions,
 	natureQuestions,
@@ -8,37 +9,36 @@ import {
 import { sharingUrls } from '../../fixtures/manual/sharingUrls';
 import { KnowledgeQuizAtom } from './KnowledgeQuizAtom.importable';
 
-export default {
-	title: 'KnowledgeQuizAtom',
+const meta = {
+	title: 'Components/KnowledgeQuizAtom',
 	component: KnowledgeQuizAtom,
-};
+} satisfies Meta<typeof KnowledgeQuizAtom>;
 
-export const DefaultRendering = () => (
-	<KnowledgeQuizAtom
-		id="2c6bf552-2827-4256-b3a0-f557d215c394"
-		questions={exampleKnowledgeQuestions}
-		resultGroups={resultGroups}
-		sharingUrls={sharingUrls}
-		theme={Pillar.News}
-	/>
-);
+export default meta;
 
-export const BatchedResults = () => (
-	<KnowledgeQuizAtom
-		id="2c6bf552-2827-4256-b3a0-f557d215c394"
-		questions={natureQuestions}
-		resultGroups={natureResultGroups}
-		sharingUrls={sharingUrls}
-		theme={Pillar.News}
-	/>
-);
+type Story = StoryObj<typeof meta>;
 
-export const LabsTheme = () => (
-	<KnowledgeQuizAtom
-		id="2c6bf552-2827-4256-b3a0-f557d215c394"
-		questions={exampleKnowledgeQuestions}
-		resultGroups={resultGroups}
-		sharingUrls={sharingUrls}
-		theme={ArticleSpecial.Labs}
-	/>
-);
+export const Default = {
+	args: {
+		id: '2c6bf552-2827-4256-b3a0-f557d215c394',
+		questions: exampleKnowledgeQuestions,
+		resultGroups,
+		sharingUrls,
+		theme: Pillar.News,
+	},
+} satisfies Story;
+
+export const BatchedResults = {
+	args: {
+		...Default.args,
+		questions: natureQuestions,
+		resultGroups: natureResultGroups,
+	},
+} satisfies Story;
+
+export const LabsTheme = {
+	args: {
+		...Default.args,
+		theme: ArticleSpecial.Labs,
+	},
+} satisfies Story;

--- a/dotcom-rendering/src/components/PersonalityQuizAtom.stories.tsx
+++ b/dotcom-rendering/src/components/PersonalityQuizAtom.stories.tsx
@@ -1,4 +1,5 @@
 import { ArticleSpecial, Pillar } from '@guardian/libs';
+import type { Meta, StoryObj } from '@storybook/react';
 import {
 	examplePersonalityQuestions,
 	exampleResultBuckets,
@@ -6,27 +7,29 @@ import {
 import { sharingUrls } from '../../fixtures/manual/sharingUrls';
 import { PersonalityQuizAtom } from './PersonalityQuizAtom.importable';
 
-export default {
-	title: 'PersonalityQuizAtom',
+const meta = {
+	title: 'Components/PersonalityQuizAtom',
 	component: PersonalityQuizAtom,
-};
+} satisfies Meta<typeof PersonalityQuizAtom>;
 
-export const DefaultRendering = () => (
-	<PersonalityQuizAtom
-		id="quiz-id"
-		questions={examplePersonalityQuestions}
-		resultBuckets={exampleResultBuckets}
-		sharingUrls={sharingUrls}
-		theme={Pillar.News}
-	/>
-);
+export default meta;
 
-export const LabsTheme = () => (
-	<PersonalityQuizAtom
-		id="2c6bf552-2827-4256-b3a0-f557d215c394"
-		questions={examplePersonalityQuestions}
-		resultBuckets={exampleResultBuckets}
-		sharingUrls={sharingUrls}
-		theme={ArticleSpecial.Labs}
-	/>
-);
+type Story = StoryObj<typeof meta>;
+
+export const Default = {
+	args: {
+		id: 'quiz-id',
+		questions: examplePersonalityQuestions,
+		resultBuckets: exampleResultBuckets,
+		sharingUrls,
+		theme: Pillar.News,
+	},
+} satisfies Story;
+
+export const LabsTheme = {
+	args: {
+		...Default.args,
+		id: '2c6bf552-2827-4256-b3a0-f557d215c394',
+		theme: ArticleSpecial.Labs,
+	},
+} satisfies Story;


### PR DESCRIPTION
Updates the `KnowledgeQuizAtom` and `PersonalityQuizAtom` stories.

This is the default for Storybook 7+[^1], and integrates better with some of its features. For example, this change demonstrates reuse of args across stories for the same component.

This also moves these stories into the `Components` folder.

Using `satisfies` gives better type safety for `args`[^2].

[^1]: https://storybook.js.org/blog/storybook-csf3-is-here/
[^2]: https://storybook.js.org/docs/writing-stories/typescript#using-satisfies-for-better-type-safety
