### PR TITLE
Remove Global Styles From Key Takeaways Headings

### DIFF
--- a/dotcom-rendering/src/components/KeyTakeaway.tsx
+++ b/dotcom-rendering/src/components/KeyTakeaway.tsx
@@ -64,7 +64,7 @@ export const KeyTakeaway = ({
 		<>
 			<li css={keyTakeawayStyles}>
 				<hr css={headingLineStyles} />
-				<h2 css={headingStyles}>
+				<h2 css={headingStyles} data-ignore="global-h2-styling">
 					<span css={headingIndexStyles}>{`${titleIndex}. `}</span>
 					{keyTakeaway.title}
 				</h2>


### PR DESCRIPTION
We have specific styles for these, we don't want global styles overriding those.
