### PR TITLE
Remove `run_chromatic` label after each run

### DIFF
--- a/.github/workflows/chromatic-label-helper.yml
+++ b/.github/workflows/chromatic-label-helper.yml
@@ -36,6 +36,7 @@ jobs:
             if (!hasChromaticLabel) {
               const commentLines = [
                 "Hello :wave:! When you're ready to run Chromatic, please apply the `run_chromatic` label to this PR.",
+                "You will need to reapply the label each time you want to run Chromatic.",
                 '[Click here to see the Chromatic project.](https://www.chromatic.com/builds?appId=63e251470cfbe61776b0ef19)',
               ];
 
@@ -52,10 +53,10 @@ jobs:
 
               if (!hasChromaticCommentAlready) {
                   github.rest.issues.createComment({
-                  issue_number: context.issue.number,
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  body: commentLines.join('\n\n'),
+                    issue_number: context.issue.number,
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    body: commentLines.join('\n\n'),
                 });
               }
             }

--- a/.github/workflows/chromatic-label-helper.yml
+++ b/.github/workflows/chromatic-label-helper.yml
@@ -29,9 +29,8 @@ jobs:
                 issue_number: context.issue.number,
               })
               .then(({ data }) => data);
-
             const hasChromaticLabel = labels.some(
-              (label) => label.name === 'run-chromatic',
+              (label) => label.name === 'run_chromatic',
             );
 
             if (!hasChromaticLabel) {

--- a/.github/workflows/dcr-chromatic.yml
+++ b/.github/workflows/dcr-chromatic.yml
@@ -52,6 +52,8 @@ jobs:
   remove-label:
     runs-on: ubuntu-latest
     needs: chromatic
+    permissions:
+      pull-requests: write
     steps:
       - name: Remove run_chromatic label
         uses: actions/github-script@v7

--- a/.github/workflows/dcr-chromatic.yml
+++ b/.github/workflows/dcr-chromatic.yml
@@ -54,7 +54,7 @@ jobs:
     needs: chromatic
     steps:
       - name: Remove run_chromatic label
-      - uses: actions/github-script@v7
+        uses: actions/github-script@v7
         with:
           script: |
             await github.rest.issues.removeLabel({

--- a/.github/workflows/dcr-chromatic.yml
+++ b/.github/workflows/dcr-chromatic.yml
@@ -48,3 +48,18 @@ jobs:
           untraced: '**/(package*.json|pnpm-lock.yaml|preview.js)'
           workingDir: dotcom-rendering
           buildScriptName: 'build-storybook'
+
+  remove-label:
+    runs-on: ubuntu-latest
+    needs: chromatic
+    steps:
+      - name: Remove run_chromatic label
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              name: "run_chromatic"
+            })


### PR DESCRIPTION
## What does this change?

- Removes the `run_chromatic` label after Chromatic has successfully run
- Updates the PR comment to let people know that they should reapply the label each time they want Chromatic to run.

## Why?

We think this might save some 💵 

Closes https://github.com/guardian/dotcom-rendering/issues/10683