### PR TITLE
Add story for subheading block component

### DIFF
--- a/dotcom-rendering/src/components/SubheadingBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/components/SubheadingBlockComponent.stories.tsx
@@ -1,0 +1,47 @@
+import { css } from '@emotion/react';
+import { SubheadingBlockComponent } from './SubheadingBlockComponent';
+
+export default {
+	component: SubheadingBlockComponent,
+	title: 'Components/SubheadingBlockComponent',
+	render: (args: React.ComponentProps<typeof SubheadingBlockComponent>) => (
+		<SubheadingBlockComponent {...args} />
+	),
+};
+
+export const Subheading = {
+	args: { html: '<h2>Subheading</h2>' },
+	parameters: { chromatic: { disable: true } },
+};
+
+export const SubheadingWithAnchor = {
+	args: { html: '<h2>Subheading <a href="/">with anchor</a></h2>' },
+	parameters: { chromatic: { disable: true } },
+};
+
+export const SubheadingWithHTMLComment = {
+	args: { html: '<h2>Subheading<!-- HTML comment--></h2>' },
+	parameters: { chromatic: { disable: true } },
+};
+
+export const SubheadingWithoutHTML = {
+	args: { html: 'Subheading text only' },
+	parameters: { chromatic: { disable: true } },
+};
+
+/** This is the only component that will get snapshotted in Chromatic */
+export const SubheadingSnapshot = () => (
+	<div
+		css={css`
+			margin: 10px;
+			h2 {
+				margin-bottom: 10px;
+			}
+		`}
+	>
+		<SubheadingBlockComponent html="<h2>Basic subheading</h2>" />
+		<SubheadingBlockComponent html="<h2>Subheading <a href='/'>with anchor</a></h2>" />
+		<SubheadingBlockComponent html="<h2>Subheading with HTML comment<!-- HTML comment--></h2>" />
+		<SubheadingBlockComponent html="Subheading text only (no HTML)" />
+	</div>
+);


### PR DESCRIPTION
## What does this change?

Adds a b

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
