### PR TITLE
Simplify Key Takeaways Stories

### DIFF
--- a/dotcom-rendering/src/components/KeyTakeaways.stories.tsx
+++ b/dotcom-rendering/src/components/KeyTakeaways.stories.tsx
@@ -16,14 +16,11 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-const html =
-	'<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesquepharetra libero nec varius feugiat. Nulla commodo sagittis erat amalesuada. Ut iaculis interdum eros, et tristique ex. In veldignissim arcu. Nulla nisi urna, laoreet a aliquam at, viverra eueros. Proin imperdiet pellentesque turpis sed luctus. Donecdignissim lacus in risus fermentum maximus eu vel justo. Duis nontortor ac elit dapibus imperdiet ut at risus. Etiam pretium, odioeget accumsan venenatis, tortor mi aliquet nisl, vel ullamcorperneque nulla vel elit. Etiam porta mauris nec sagittis luctus.</p>';
-
 const testTextElement: TextBlockElement = {
 	_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 	elementId: 'test-text-element-id-1',
 	dropCap: false,
-	html,
+	html: '<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesquepharetra libero nec varius feugiat. Nulla commodo sagittis erat amalesuada. Ut iaculis interdum eros, et tristique ex. In veldignissim arcu. Nulla nisi urna, laoreet a aliquam at, viverra eueros. Proin imperdiet pellentesque turpis sed luctus. Donecdignissim lacus in risus fermentum maximus eu vel justo. Duis nontortor ac elit dapibus imperdiet ut at risus. Etiam pretium, odioeget accumsan venenatis, tortor mi aliquet nisl, vel ullamcorperneque nulla vel elit. Etiam porta mauris nec sagittis luctus.</p>',
 };
 
 export const AllThemes = {
@@ -72,6 +69,7 @@ export const AllThemes = {
 
 export const Images = {
 	args: {
+		...AllThemes.args,
 		keyTakeaways: [
 			{
 				title: 'The first key takeaway',
@@ -82,27 +80,6 @@ export const Images = {
 				body: [testTextElement, ...images.slice(2, 3)],
 			},
 		],
-		/**
-		 * This will be replaced by the `splitTheme` decorator, but it's
-		 * required by the type.
-		 */
-		format: {
-			design: ArticleDesign.Standard,
-			display: ArticleDisplay.Standard,
-			theme: Pillar.News,
-		},
-		abTests: {},
-		/**
-		 * This is used for rich links. An empty string isn't technically valid,
-		 * but there are no rich links in this example.
-		 */
-		ajaxUrl: '',
-		editionId: 'UK',
-		isAdFreeUser: false,
-		isSensitive: false,
-		pageId: 'testID',
-		switches: {},
-		RenderArticleElement,
 	},
 	decorators: [
 		splitTheme(


### PR DESCRIPTION
Reused the `AllThemes` args in the `Images` story. Also inlined an `html` field.
