### PR TITLE
Simplify Q And A Explainers Stories

### DIFF
--- a/dotcom-rendering/src/components/QAndAExplainers.stories.tsx
+++ b/dotcom-rendering/src/components/QAndAExplainers.stories.tsx
@@ -15,14 +15,11 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-const html =
-	'<p>An Answer: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesquepharetra libero nec varius feugiat. Nulla commodo sagittis erat amalesuada. Ut iaculis interdum eros, et tristique ex. In veldignissim arcu. Nulla nisi urna, laoreet a aliquam at, viverra eueros. Proin imperdiet pellentesque turpis sed luctus. Donecdignissim lacus in risus fermentum maximus eu vel justo. Duis nontortor ac elit dapibus imperdiet ut at risus. Etiam pretium, odioeget accumsan venenatis, tortor mi aliquet nisl, vel ullamcorperneque nulla vel elit. Etiam porta mauris nec sagittis luctus.</p>';
-
 const testTextElement: TextBlockElement = {
 	_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 	elementId: 'test-text-element-id-1',
 	dropCap: false,
-	html,
+	html: '<p>An Answer: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesquepharetra libero nec varius feugiat. Nulla commodo sagittis erat amalesuada. Ut iaculis interdum eros, et tristique ex. In veldignissim arcu. Nulla nisi urna, laoreet a aliquam at, viverra eueros. Proin imperdiet pellentesque turpis sed luctus. Donecdignissim lacus in risus fermentum maximus eu vel justo. Duis nontortor ac elit dapibus imperdiet ut at risus. Etiam pretium, odioeget accumsan venenatis, tortor mi aliquet nisl, vel ullamcorperneque nulla vel elit. Etiam porta mauris nec sagittis luctus.</p>',
 };
 
 export const AllThemes = {
@@ -70,6 +67,7 @@ export const AllThemes = {
 
 export const Images = {
 	args: {
+		...AllThemes.args,
 		qAndAExplainers: [
 			{
 				title: 'The first question',
@@ -80,26 +78,6 @@ export const Images = {
 				body: [testTextElement, ...images.slice(2, 3)],
 			},
 		],
-		/**
-		 * This will be replaced by the `splitTheme` decorator, but it's
-		 * required by the type.
-		 */
-		format: {
-			design: ArticleDesign.Standard,
-			display: ArticleDisplay.Standard,
-			theme: Pillar.News,
-		},
-		abTests: {},
-		/**
-		 * This is used for rich links. An empty string isn't technically valid,
-		 * but there are no rich links in this example.
-		 */
-		ajaxUrl: '',
-		editionId: 'UK',
-		isAdFreeUser: false,
-		isSensitive: false,
-		pageId: 'testID',
-		switches: {},
 	},
 	decorators: [
 		splitTheme(


### PR DESCRIPTION
Reused the `AllThemes` args in the `Images` story. Also inlined an `html` field.
