### PR TITLE
SectionAdDensity test to 5%

### DIFF
--- a/dotcom-rendering/src/experiments/tests/section-ad-density.ts
+++ b/dotcom-rendering/src/experiments/tests/section-ad-density.ts
@@ -5,7 +5,7 @@ export const sectionAdDensity: ABTest = {
 	author: '@commercial-dev',
 	start: '2024-03-07',
 	expiry: '2024-07-26',
-	audience: 0 / 100,
+	audience: 5 / 100,
 	audienceOffset: 0 / 100,
 	audienceCriteria:
 		'Article pages in the following sections: business, environment, music, money, artanddesign, science, stage, travel, wellness, games',


### PR DESCRIPTION
## What does this change?

Set `SectionAdDensity` to 5%

## Why?
Full details of the test available here https://github.com/guardian/commercial/pull/1296

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
