### PR TITLE
Block supporter revenue messaging in the Sport section

### DIFF
--- a/dotcom-rendering/src/components/LiveBlogEpic.importable.tsx
+++ b/dotcom-rendering/src/components/LiveBlogEpic.importable.tsx
@@ -258,7 +258,8 @@ export const LiveBlogEpic = ({
 	);
 
 	const shouldRemoveEpic =
-		userIsInBlockSupporterRevenueTest && sectionId === 'sport';
+		userIsInBlockSupporterRevenueTest &&
+		(sectionId === 'sport' || sectionId === 'football');
 
 	// First construct the payload
 	const payload = usePayload({

--- a/dotcom-rendering/src/components/LiveBlogEpic.importable.tsx
+++ b/dotcom-rendering/src/components/LiveBlogEpic.importable.tsx
@@ -14,6 +14,7 @@ import {
 	shouldHideSupportMessaging,
 	useHasOptedOutOfArticleCount,
 } from '../lib/contributions';
+import { useAB } from '../lib/useAB';
 import { useAuthStatus } from '../lib/useAuthStatus';
 import { useCountryCode } from '../lib/useCountryCode';
 import { useSDCLiveblogEpic } from '../lib/useSDC';
@@ -250,6 +251,15 @@ export const LiveBlogEpic = ({
 }: Props) => {
 	log('dotcom', 'LiveBlogEpic started');
 
+	const ABTestAPI = useAB()?.api;
+	const userIsInBlockSupporterRevenueTest = ABTestAPI?.isUserInVariant(
+		'BlockSupporterRevenueMessagingSport',
+		'variant',
+	);
+
+	const shouldRemoveEpic =
+		userIsInBlockSupporterRevenueTest && sectionId === 'sport';
+
 	// First construct the payload
 	const payload = usePayload({
 		shouldHideReaderRevenue,
@@ -260,6 +270,7 @@ export const LiveBlogEpic = ({
 		keywordIds,
 	});
 	if (!payload) return null;
+	if (shouldRemoveEpic) return null;
 
 	/**
 	 * Here we decide where to insert the epic.

--- a/dotcom-rendering/src/components/SlotBodyEnd.importable.tsx
+++ b/dotcom-rendering/src/components/SlotBodyEnd.importable.tsx
@@ -216,7 +216,8 @@ export const SlotBodyEnd = ({
 		};
 
 		const shouldRemoveEpic =
-			userIsInBlockSupporterRevenueTest && sectionId === 'sport';
+			userIsInBlockSupporterRevenueTest &&
+			(sectionId === 'sport' || sectionId === 'football');
 
 		if (!shouldRemoveEpic) {
 			pickMessage(epicConfig, renderingTarget)

--- a/dotcom-rendering/src/components/SlotBodyEnd.importable.tsx
+++ b/dotcom-rendering/src/components/SlotBodyEnd.importable.tsx
@@ -159,6 +159,10 @@ export const SlotBodyEnd = ({
 		(abTestsApi?.isUserInVariant('MpuWhenNoEpic', 'variant') &&
 			countryCode === 'GB') ??
 		false;
+	const userIsInBlockSupporterRevenueTest = abTestsApi?.isUserInVariant(
+		'BlockSupporterRevenueMessagingSport',
+		'variant',
+	);
 
 	const showArticleEndSlot =
 		renderAds &&
@@ -211,11 +215,22 @@ export const SlotBodyEnd = ({
 			name: 'slotBodyEnd',
 		};
 
-		pickMessage(epicConfig, renderingTarget)
-			.then((PickedEpic: () => MaybeFC) => setSelectedEpic(PickedEpic))
-			.catch((e) =>
-				console.error(`SlotBodyEnd pickMessage - error: ${String(e)}`),
-			);
+		const shouldRemoveEpic =
+			userIsInBlockSupporterRevenueTest && sectionId === 'sport';
+
+		if (!shouldRemoveEpic) {
+			pickMessage(epicConfig, renderingTarget)
+				.then((PickedEpic: () => MaybeFC) =>
+					setSelectedEpic(PickedEpic),
+				)
+				.catch((e) =>
+					console.error(
+						`SlotBodyEnd pickMessage - error: ${String(e)}`,
+					),
+				);
+		} else {
+			setSelectedEpic(null);
+		}
 	}, [isSignedIn, countryCode, brazeMessages, asyncArticleCount, browserId]);
 
 	useEffect(() => {

--- a/dotcom-rendering/src/components/StickyBottomBanner.importable.tsx
+++ b/dotcom-rendering/src/components/StickyBottomBanner.importable.tsx
@@ -14,6 +14,7 @@ import type {
 	SlotConfig,
 } from '../lib/messagePicker';
 import { pickMessage } from '../lib/messagePicker';
+import { useAB } from '../lib/useAB';
 import { useAuthStatus } from '../lib/useAuthStatus';
 import { useBraze } from '../lib/useBraze';
 import { useCountryCode } from '../lib/useCountryCode';
@@ -94,6 +95,7 @@ const buildRRBannerConfigWith = ({
 		isPreview,
 		asyncArticleCounts,
 		signInGateWillShow = false,
+		isInBlockSupporterRevenueMessagingTest = false,
 		contentType,
 		sectionId,
 		shouldHideReaderRevenue,
@@ -109,6 +111,7 @@ const buildRRBannerConfigWith = ({
 		isPreview: boolean;
 		asyncArticleCounts: Promise<ArticleCounts | undefined>;
 		signInGateWillShow?: boolean;
+		isInBlockSupporterRevenueMessagingTest?: boolean;
 		contentType: string;
 		sectionId: string;
 		shouldHideReaderRevenue: boolean;
@@ -148,6 +151,7 @@ const buildRRBannerConfigWith = ({
 						idApiUrl,
 						signInGateWillShow,
 						asyncArticleCounts,
+						isInBlockSupporterRevenueMessagingTest,
 					}),
 				show:
 					({ meta, module, fetchEmail }: BannerProps) =>
@@ -244,6 +248,11 @@ export const StickyBottomBanner = ({
 		isPreview,
 		currentLocaleCode: countryCode,
 	});
+	const ABTestAPI = useAB()?.api;
+	const isInBlockSupporterRevenueMessagingTest = ABTestAPI?.isUserInVariant(
+		'BlockSupporterRevenueMessagingSport',
+		'variant',
+	);
 
 	useEffect(() => {
 		setAsyncArticleCounts(
@@ -265,6 +274,7 @@ export const StickyBottomBanner = ({
 				ArticleCounts | undefined
 			>,
 			signInGateWillShow,
+			isInBlockSupporterRevenueMessagingTest,
 			contentType,
 			sectionId,
 			shouldHideReaderRevenue,

--- a/dotcom-rendering/src/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/dotcom-rendering/src/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -60,6 +60,7 @@ type CanShowProps = BaseProps & {
 	idApiUrl: string;
 	signInGateWillShow: boolean;
 	asyncArticleCounts: Promise<ArticleCounts | undefined>;
+	isInBlockSupporterRevenueMessagingTest: boolean;
 };
 
 type ReaderRevenueComponentType =
@@ -158,14 +159,20 @@ export const canShowRRBanner: CanShowFunctionType<BannerProps> = async ({
 	idApiUrl,
 	signInGateWillShow,
 	asyncArticleCounts,
+	isInBlockSupporterRevenueMessagingTest,
 }) => {
 	if (!remoteBannerConfig) return { show: false };
+
+	const shouldHideBannerForTest =
+		isInBlockSupporterRevenueMessagingTest &&
+		(sectionId === 'sport' || sectionId === 'football');
 
 	if (
 		shouldHideReaderRevenue ||
 		isPaidContent ||
 		isPreview ||
-		signInGateWillShow
+		signInGateWillShow ||
+		shouldHideBannerForTest
 	) {
 		// We never serve Reader Revenue banners in this case
 		return { show: false };

--- a/dotcom-rendering/src/experiments/ab-tests.ts
+++ b/dotcom-rendering/src/experiments/ab-tests.ts
@@ -1,5 +1,6 @@
 import type { ABTest } from '@guardian/ab-core';
 import { abTestTest } from './tests/ab-test-test';
+import { blockSupporterRevenueMessagingSport } from './tests/block-supporter-revenue-messaging-sport';
 import { consentlessAds } from './tests/consentless-ads';
 import { integrateIma } from './tests/integrate-ima';
 import { mpuWhenNoEpic } from './tests/mpu-when-no-epic';
@@ -19,4 +20,5 @@ export const tests: ABTest[] = [
 	integrateIma,
 	mpuWhenNoEpic,
 	sectionAdDensity,
+	blockSupporterRevenueMessagingSport,
 ];

--- a/dotcom-rendering/src/experiments/tests/block-supporter-revenue-messaging-sport.ts
+++ b/dotcom-rendering/src/experiments/tests/block-supporter-revenue-messaging-sport.ts
@@ -1,0 +1,29 @@
+import type { ABTest } from '@guardian/ab-core';
+
+export const blockSupporterRevenueMessagingSport: ABTest = {
+	id: 'BlockSupporterRevenueMessagingSport',
+	author: '@commercial-dev',
+	start: '2024-03-14',
+	expiry: '2024-06-01',
+	audience: 0 / 100,
+	audienceOffset: 0 / 100,
+	audienceCriteria: 'Fronts and articles in the Sport section',
+	successMeasure:
+		'Ad revenue and ad ration increases without significantly impacting supporter revenue',
+	description: 'Block supporter revenue messaging in the Sport section',
+	variants: [
+		{
+			id: 'control',
+			test: (): void => {
+				/* no-op */
+			},
+		},
+		{
+			id: 'variant',
+			test: (): void => {
+				/* no-op */
+			},
+		},
+	],
+	canRun: () => true,
+};

--- a/dotcom-rendering/src/experiments/tests/block-supporter-revenue-messaging-sport.ts
+++ b/dotcom-rendering/src/experiments/tests/block-supporter-revenue-messaging-sport.ts
@@ -9,7 +9,7 @@ export const blockSupporterRevenueMessagingSport: ABTest = {
 	audienceOffset: 0 / 100,
 	audienceCriteria: 'Fronts and articles in the Sport section',
 	successMeasure:
-		'Ad revenue and ad ration increases without significantly impacting supporter revenue',
+		'Ad revenue and ad ratio increases without significantly impacting supporter revenue',
 	description: 'Block supporter revenue messaging in the Sport section',
 	variants: [
 		{

--- a/dotcom-rendering/src/experiments/tests/block-supporter-revenue-messaging-sport.ts
+++ b/dotcom-rendering/src/experiments/tests/block-supporter-revenue-messaging-sport.ts
@@ -25,5 +25,7 @@ export const blockSupporterRevenueMessagingSport: ABTest = {
 			},
 		},
 	],
-	canRun: () => true,
+	canRun: () =>
+		window.guardian.config.page.section === 'sport' ||
+		window.guardian.config.page.section === 'football',
 };

--- a/dotcom-rendering/src/model/guardian.ts
+++ b/dotcom-rendering/src/model/guardian.ts
@@ -34,6 +34,7 @@ export interface Guardian {
 			isPaidContent?: boolean;
 			isDev?: boolean;
 			hasInlineMerchandise?: boolean;
+			section?: string;
 			userAttributesApiUrl?: string;
 			idApiUrl?: string;
 		};
@@ -82,6 +83,7 @@ export const createGuardian = ({
 	brazeApiKey,
 	GAData,
 	hasInlineMerchandise,
+	section,
 	googleRecaptchaSiteKey,
 	unknownConfig = {},
 }: {
@@ -104,6 +106,7 @@ export const createGuardian = ({
 	brazeApiKey?: string;
 	GAData?: GADataType;
 	hasInlineMerchandise?: boolean;
+	section?: string;
 	googleRecaptchaSiteKey?: string;
 	/**
 	 * In the case of articles we don't know the exact values that need to exist
@@ -141,6 +144,7 @@ export const createGuardian = ({
 				isPaidContent: !!isPaidContent,
 				brazeApiKey,
 				hasInlineMerchandise,
+				section,
 				googleRecaptchaSiteKey,
 			}),
 			libs: {

--- a/dotcom-rendering/src/server/render.article.web.tsx
+++ b/dotcom-rendering/src/server/render.article.web.tsx
@@ -146,6 +146,7 @@ export const renderHtml = ({
 			beaconURL: article.beaconURL,
 		}),
 		hasInlineMerchandise: article.config.hasInlineMerchandise,
+		section: article.config.section,
 		// Until we understand exactly what config we need to make available client-side,
 		// add everything we haven't explicitly typed as unknown config
 		unknownConfig: article.config,


### PR DESCRIPTION
## What does this change?
- Adds an AB test (0% until sample sizes are calculated) to block supporter revenue messaging for Sport articles and fronts
- Blocks the reader revenue banner on fronts rendered by DCR for users in the test 
- Blocks the slotBodyEnd reader revenue epic for users in the test
- Blocks liveblog epics for users in the test

## Why?
We'd like to test the impact of blocking supporter revenue messaging on ad ratio and revenue. In a similar previous experiment on business liveblogs (see https://github.com/guardian/frontend/pull/26172) we measured an improvement to ad revenue, but this was almost exactly offset by the loss in supporter revenue. We'd like to test the revenue impact for a similar experiment in the Sports section. We will be blocking the sticky reader revenue banner at the bottom of the page, the liveblog reader revenue epics, and the epics that appear at the end of an article body.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| <img width="717" alt="Screenshot 2024-03-20 at 15 29 36" src="https://github.com/guardian/dotcom-rendering/assets/108270776/ca1e4578-5f98-431c-aa56-0b4b7e840587"> | <img width="721" alt="Screenshot 2024-03-20 at 15 29 47" src="https://github.com/guardian/dotcom-rendering/assets/108270776/c2c8c91b-d3ef-4c09-bdb0-5146dfa0ce56"> |
| <img width="653" alt="Screenshot 2024-03-20 at 15 30 24" src="https://github.com/guardian/dotcom-rendering/assets/108270776/f8fe5314-16c4-4a71-9dbc-1411766dab84"> | <img width="810" alt="Screenshot 2024-03-20 at 15 30 48" src="https://github.com/guardian/dotcom-rendering/assets/108270776/82002b1d-ad28-43f7-8b3a-336dec0c3db3"> |



