### PR TITLE
Make pagination available on the frontend model 

### DIFF
--- a/dotcom-rendering/src/model/tag-page-schema.json
+++ b/dotcom-rendering/src/model/tag-page-schema.json
@@ -714,6 +714,25 @@
                 ]
             }
         },
+        "pagination": {
+            "type": "object",
+            "properties": {
+                "currentPage": {
+                    "type": "number"
+                },
+                "lastPage": {
+                    "type": "number"
+                },
+                "totalContent": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "currentPage",
+                "lastPage",
+                "totalContent"
+            ]
+        },
         "nav": {
             "$ref": "#/definitions/FENavType"
         },

--- a/dotcom-rendering/src/server/handler.front.web.ts
+++ b/dotcom-rendering/src/server/handler.front.web.ts
@@ -90,10 +90,9 @@ const enhanceTagPage = (body: unknown): DCRTagPageType => {
 		speed,
 		// Pagination information comes from the first tag
 		pagination:
-			data.tags.tags[0]?.pagination &&
-			data.tags.tags[0].pagination.lastPage > 1
+			data.pagination && data.pagination.lastPage > 1
 				? {
-						...data.tags.tags[0]?.pagination,
+						...data.pagination,
 						sectionName: data.webTitle,
 						pageId: data.pageId,
 				  }

--- a/dotcom-rendering/src/server/handler.front.web.ts
+++ b/dotcom-rendering/src/server/handler.front.web.ts
@@ -51,7 +51,7 @@ const enhanceFront = (body: unknown): DCRFrontType => {
 };
 
 const tagPageWebTitle = (tagPage: FETagPageType) => {
-	const pagination = tagPage.tags.tags[0]?.pagination;
+	const pagination = tagPage.pagination;
 	if (pagination !== undefined && pagination.currentPage > 1) {
 		return `${tagPage.webTitle} | Page ${pagination.currentPage} of ${pagination.lastPage} | The Guardian`;
 	} else {

--- a/dotcom-rendering/src/server/handler.front.web.ts
+++ b/dotcom-rendering/src/server/handler.front.web.ts
@@ -88,7 +88,6 @@ const enhanceTagPage = (body: unknown): DCRTagPageType => {
 		tags: data.tags.tags,
 		groupedTrails,
 		speed,
-		// Pagination information comes from the first tag
 		pagination:
 			data.pagination && data.pagination.lastPage > 1
 				? {

--- a/dotcom-rendering/src/server/handler.front.web.ts
+++ b/dotcom-rendering/src/server/handler.front.web.ts
@@ -51,7 +51,7 @@ const enhanceFront = (body: unknown): DCRFrontType => {
 };
 
 const tagPageWebTitle = (tagPage: FETagPageType) => {
-	const pagination = tagPage.pagination;
+	const { pagination } = tagPage;
 	if (pagination !== undefined && pagination.currentPage > 1) {
 		return `${tagPage.webTitle} | Page ${pagination.currentPage} of ${pagination.lastPage} | The Guardian`;
 	} else {

--- a/dotcom-rendering/src/types/tag.ts
+++ b/dotcom-rendering/src/types/tag.ts
@@ -21,11 +21,13 @@ export type FETagType = {
 		url?: string;
 		webUrl?: string;
 	};
-	pagination?: {
-		currentPage: number;
-		lastPage: number;
-		totalContent: number;
-	};
+	pagination?: FEPagination;
+};
+
+export type FEPagination = {
+	currentPage: number;
+	lastPage: number;
+	totalContent: number;
 };
 
 export type TagType = {

--- a/dotcom-rendering/src/types/tagPage.ts
+++ b/dotcom-rendering/src/types/tagPage.ts
@@ -4,10 +4,11 @@ import type { CollectionBranding } from './branding';
 import type { CommercialProperties } from './commercial';
 import type { FooterType } from './footer';
 import type { DCRFrontCard, FEFrontCard, FEFrontConfigType } from './front';
-import type { FETagType } from './tag';
+import type { FEPagination, FETagType } from './tag';
 
 export interface FETagPageType {
 	contents: FEFrontCard[];
+	pagination?: FEPagination;
 	nav: FENavType;
 	tags: {
 		tags: FETagType[];


### PR DESCRIPTION
## What does this change?
The frontend tag page model now includes pagination functionality. Previously, pagination data was nested within the tags field. However, pagination data for individual tag pages and all tag pages were stored differently within the model. This update reorganizes the structure by relocating pagination data to its dedicated field. This modification enables easier accessibility for DCR to locate the relevant pagination data.

## Why?
Makes it easier for DCR to locate pagination data for tag pages and, in doing so, allows DCR to fully support '/all' tag pages (eg www.guardian.com/sport/all)
