### PR TITLE
Change The Order Of Article Example Links

### DIFF
--- a/dotcom-rendering/src/server/dev-index.html
+++ b/dotcom-rendering/src/server/dev-index.html
@@ -267,9 +267,9 @@
 							<th colspan="3">Links</th>
 						</tr>
 						<tr>
-							<th>PROD</th>
-							<th>CODE</th>
 							<th>DEV</th>
+							<th>CODE</th>
+							<th>PROD</th>
 						</tr>
 					</thead>
 					<tbody></tbody>
@@ -293,12 +293,9 @@
 						</dl>
 					</td>
 					<td class="links">
-						<article-link
-							product="dotcom"
-							env="PROD"
-						></article-link>
-						<article-link product="apps" env="PROD"></article-link>
-						<article-link product="amp" env="PROD"></article-link>
+						<article-link product="dotcom" env="DEV"></article-link>
+						<article-link product="apps" env="DEV"></article-link>
+						<article-link product="amp" env="DEV"></article-link>
 					</td>
 					<td class="links">
 						<article-link
@@ -309,9 +306,12 @@
 						<article-link product="amp" env="CODE"></article-link>
 					</td>
 					<td class="links">
-						<article-link product="dotcom" env="DEV"></article-link>
-						<article-link product="apps" env="DEV"></article-link>
-						<article-link product="amp" env="DEV"></article-link>
+						<article-link
+							product="dotcom"
+							env="PROD"
+						></article-link>
+						<article-link product="apps" env="PROD"></article-link>
+						<article-link product="amp" env="PROD"></article-link>
 					</td>
 				</tr>
 			</template>


### PR DESCRIPTION
The assumption is that on the dev server the links clicked most frequently are the DEV links, rather than the CODE or PROD links. Therefore, this change moves those links to the left column, to make them quicker to find and click. The PROD links, as a result, move to the right column.

|  | Links |
| - | - |
| Before | ![links-before] |
| After | ![links-after] | 

[links-after]: https://github.com/guardian/dotcom-rendering/assets/53781962/4b5762f0-5c97-4656-8845-652852fd2cc2
[links-before]: https://github.com/guardian/dotcom-rendering/assets/53781962/4042d754-e78d-49e3-a9f0-8065c26aad72
