### PR TITLE
Pin root dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
 	},
 	"dependencies": {
 		"@guardian/prettier": "5.0.0",
-		"chromatic": "^11.0.8",
-		"husky": "^8.0.3",
+		"chromatic": "11.0.8",
+		"husky": "8.0.3",
 		"lint-staged": "15.2.0",
 		"prettier": "3.0.3",
 		"tslib": "2.6.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,10 +12,10 @@ importers:
         specifier: 5.0.0
         version: 5.0.0(prettier@3.0.3)(tslib@2.6.2)
       chromatic:
-        specifier: ^11.0.8
+        specifier: 11.0.8
         version: 11.0.8
       husky:
-        specifier: ^8.0.3
+        specifier: 8.0.3
         version: 8.0.3
       lint-staged:
         specifier: 15.2.0


### PR DESCRIPTION
## What does this change?

Pins the dependencies in the root folder

## Why?

It's in our [recommendations](https://github.com/guardian/recommendations/blob/8300f0bedaf1bc878ff66257e51c1d42e877df5e/dependencies.md?plain=1#L38)

