### PR TITLE
Remove Drop Caps From List Elements

### DIFF
--- a/dotcom-rendering/fixtures/generated/articles/NewsletterSignup.ts
+++ b/dotcom-rendering/fixtures/generated/articles/NewsletterSignup.ts
@@ -1682,7 +1682,7 @@ export const NewsletterSignup: DCRArticle = {
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p><strong><a href="https://www.theguardian.com/email-newsletters">Explore all our newsletters:</a></strong><a href="https://www.theguardian.com/email-newsletters"> whether you love film, football, fashion or food, we’ve got something for you</a></p>',
 					elementId: '11223aca-9c98-4aba-9bc1-8420b0b804b6',
-					dropCap: true,
+					dropCap: 'on',
 				},
 			],
 			attributes: {

--- a/dotcom-rendering/src/components/KeyTakeaway.tsx
+++ b/dotcom-rendering/src/components/KeyTakeaway.tsx
@@ -15,7 +15,7 @@ const headingStyles = (display: ArticleDisplay): SerializedStyles => css`
 	${display === ArticleDisplay.Immersive
 		? headline.medium({ fontWeight: 'light' })
 		: headline.xxsmall({ fontWeight: 'bold' })};
-	padding: 2px 0px;
+	padding: 2px 0;
 `;
 
 const headingIndexStyles = css`
@@ -24,7 +24,7 @@ const headingIndexStyles = css`
 
 const headingLineStyles = css`
 	width: 140px;
-	margin: 0px;
+	margin: 0;
 	border: none;
 	border-top: 4px solid ${palette('--heading-line')};
 `;
@@ -89,6 +89,7 @@ export const KeyTakeaway = ({
 						editionId={editionId}
 						hideCaption={hideCaption}
 						starRating={starRating}
+						forceDropCap="off"
 					/>
 				))}
 			</li>

--- a/dotcom-rendering/src/components/KeyTakeaways.stories.tsx
+++ b/dotcom-rendering/src/components/KeyTakeaways.stories.tsx
@@ -19,7 +19,7 @@ type Story = StoryObj<typeof meta>;
 const testTextElement: TextBlockElement = {
 	_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 	elementId: 'test-text-element-id-1',
-	dropCap: false,
+	dropCap: 'on', // this should be overruled by key takeaway which always sets forceDropCap="off"
 	html: '<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesquepharetra libero nec varius feugiat. Nulla commodo sagittis erat amalesuada. Ut iaculis interdum eros, et tristique ex. In veldignissim arcu. Nulla nisi urna, laoreet a aliquam at, viverra eueros. Proin imperdiet pellentesque turpis sed luctus. Donecdignissim lacus in risus fermentum maximus eu vel justo. Duis nontortor ac elit dapibus imperdiet ut at risus. Etiam pretium, odioeget accumsan venenatis, tortor mi aliquet nisl, vel ullamcorperneque nulla vel elit. Etiam porta mauris nec sagittis luctus.</p>',
 };
 

--- a/dotcom-rendering/src/components/QAndAExplainers.stories.tsx
+++ b/dotcom-rendering/src/components/QAndAExplainers.stories.tsx
@@ -19,8 +19,8 @@ type Story = StoryObj<typeof meta>;
 const testTextElement: TextBlockElement = {
 	_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 	elementId: 'test-text-element-id-1',
-	dropCap: false,
 	html: '<p>An Answer: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesquepharetra libero nec varius feugiat. Nulla commodo sagittis erat amalesuada. Ut iaculis interdum eros, et tristique ex. In veldignissim arcu. Nulla nisi urna, laoreet a aliquam at, viverra eueros. Proin imperdiet pellentesque turpis sed luctus. Donecdignissim lacus in risus fermentum maximus eu vel justo. Duis nontortor ac elit dapibus imperdiet ut at risus. Etiam pretium, odioeget accumsan venenatis, tortor mi aliquet nisl, vel ullamcorperneque nulla vel elit. Etiam porta mauris nec sagittis luctus.</p>',
+	dropCap: 'on', // this should be overruled by q&a which always sets forceDropCap="off"
 };
 
 export const AllThemes = {

--- a/dotcom-rendering/src/components/QAndAExplainers.tsx
+++ b/dotcom-rendering/src/components/QAndAExplainers.tsx
@@ -86,6 +86,7 @@ const QAndAExplainerComponent = ({
 					editionId={editionId}
 					hideCaption={hideCaption}
 					starRating={starRating}
+					forceDropCap="off"
 				/>
 			))}
 		</li>

--- a/dotcom-rendering/src/components/TextBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/components/TextBlockComponent.stories.tsx
@@ -77,7 +77,7 @@ export const DropCap = () => {
 		<div css={containerStyles}>
 			<TextBlockComponent
 				html={html}
-				forceDropCap={true}
+				forceDropCap="on"
 				format={{
 					theme: Pillar.Culture,
 					design: ArticleDesign.Standard,
@@ -104,7 +104,6 @@ export const QuotedDropCap = () => {
 		<div css={containerStyles}>
 			<TextBlockComponent
 				html={quotedHtml}
-				forceDropCap={false}
 				format={{
 					theme: Pillar.Opinion,
 					design: ArticleDesign.Comment,
@@ -131,7 +130,7 @@ export const ShortText = () => {
 		<div css={containerStyles}>
 			<TextBlockComponent
 				html={shortHtml}
-				forceDropCap={true}
+				forceDropCap="on"
 				format={{
 					theme: Pillar.News,
 					design: ArticleDesign.Standard,
@@ -158,7 +157,7 @@ export const NoTags = () => {
 		<div css={containerStyles}>
 			<TextBlockComponent
 				html={differentWrapperTags}
-				forceDropCap={true}
+				forceDropCap="on"
 				format={{
 					theme: Pillar.News,
 					design: ArticleDesign.Standard,
@@ -185,7 +184,6 @@ export const FeatureDropCap = () => {
 		<div css={containerStyles}>
 			<TextBlockComponent
 				html={html}
-				forceDropCap={false}
 				format={{
 					theme: Pillar.Culture,
 					design: ArticleDesign.Feature,
@@ -212,7 +210,7 @@ export const AList = () => {
 		<div css={containerStyles}>
 			<TextBlockComponent
 				html={aListHtml}
-				forceDropCap={true}
+				forceDropCap="on"
 				format={{
 					theme: Pillar.News,
 					design: ArticleDesign.Standard,
@@ -230,7 +228,6 @@ export const BadMarkup = () => {
 		<div css={containerStyles}>
 			<TextBlockComponent
 				html={badMarkup}
-				forceDropCap={false}
 				format={{
 					theme: Pillar.News,
 					design: ArticleDesign.Standard,
@@ -248,7 +245,6 @@ export const SubSupscript = () => {
 		<div css={containerStyles}>
 			<TextBlockComponent
 				html="<p><strong>P<sub>kj</sub> = (1-r<sub>j</sub>)C<sup>kj</sup> + r<sub>j</sub>(C<sub>kj</sub> + q<sub>kj</sub> - p<sub>kj</sub>)</strong></p><p><var>a<sup>2</sup></var> + <var>b<sup>2</sup></var> = <var>c<sup>2</sup></var></p>"
-				forceDropCap={false}
 				format={{
 					theme: Pillar.News,
 					design: ArticleDesign.Standard,

--- a/dotcom-rendering/src/components/TextBlockComponent.tsx
+++ b/dotcom-rendering/src/components/TextBlockComponent.tsx
@@ -21,7 +21,7 @@ type Props = {
 	html: string;
 	format: ArticleFormat;
 	isFirstParagraph: boolean;
-	forceDropCap?: boolean;
+	forceDropCap?: 'on' | 'off';
 };
 
 const isLetter = (letter: string) => {
@@ -107,8 +107,9 @@ const shouldShowDropCaps = (
 	html: string,
 	format: ArticleFormat,
 	isFirstParagraph: boolean,
-	forceDropCap?: boolean,
+	forceDropCap?: 'on' | 'off',
 ) => {
+	if (forceDropCap === 'off') return false;
 	const validDropCapFormat = isValidFormatForDropCap(format);
 	// We need to strip any markup from our html string so that we accurately measure
 	// the length that the reader will see. Eg. remove link tag html.
@@ -121,7 +122,7 @@ const shouldShowDropCaps = (
 		// For subsequent blocks of text, we only add a dropcap if a dinkus was inserted
 		// prior to it in the article body (Eg: * * *), causing the forceDropCap flag to
 		// be set
-		if (forceDropCap) return true;
+		if (forceDropCap === 'on') return true;
 	}
 
 	return false;

--- a/dotcom-rendering/src/lib/renderElement.tsx
+++ b/dotcom-rendering/src/lib/renderElement.tsx
@@ -86,6 +86,7 @@ type Props = {
 	isPinnedPost?: boolean;
 	abTests: ServerSideTests;
 	editionId: EditionId;
+	forceDropCap?: 'on' | 'off';
 };
 
 // updateRole modifies the role of an element in a way appropriate for most
@@ -141,6 +142,7 @@ export const renderElement = ({
 	isPinnedPost,
 	abTests,
 	editionId,
+	forceDropCap,
 }: Props) => {
 	const isBlog =
 		format.design === ArticleDesign.LiveBlog ||
@@ -627,7 +629,11 @@ export const renderElement = ({
 					isFirstParagraph={index === 0}
 					html={element.html}
 					format={format}
-					forceDropCap={element.dropCap}
+					forceDropCap={
+						forceDropCap !== undefined
+							? forceDropCap
+							: element.dropCap
+					}
 				/>
 			);
 		case 'model.dotcomrendering.pageElements.TimelineBlockElement':
@@ -833,6 +839,7 @@ export const RenderArticleElement = ({
 	isPinnedPost,
 	abTests,
 	editionId,
+	forceDropCap,
 }: Props) => {
 	const withUpdatedRole = updateRole(element, format);
 
@@ -853,6 +860,7 @@ export const RenderArticleElement = ({
 		isPinnedPost,
 		abTests,
 		editionId,
+		forceDropCap,
 	});
 
 	const needsFigure = !bareElements.has(element._type);

--- a/dotcom-rendering/src/model/article-schema.json
+++ b/dotcom-rendering/src/model/article-schema.json
@@ -2977,7 +2977,11 @@
                     "type": "string"
                 },
                 "dropCap": {
-                    "type": "boolean"
+                    "enum": [
+                        "off",
+                        "on"
+                    ],
+                    "type": "string"
                 },
                 "html": {
                     "type": "string"

--- a/dotcom-rendering/src/model/block-schema.json
+++ b/dotcom-rendering/src/model/block-schema.json
@@ -2566,7 +2566,11 @@
                     "type": "string"
                 },
                 "dropCap": {
-                    "type": "boolean"
+                    "enum": [
+                        "off",
+                        "on"
+                    ],
+                    "type": "string"
                 },
                 "html": {
                     "type": "string"

--- a/dotcom-rendering/src/model/enhance-dividers.test.ts
+++ b/dotcom-rendering/src/model/enhance-dividers.test.ts
@@ -46,7 +46,7 @@ describe('Dividers and Drop Caps', () => {
 			},
 			{
 				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-				dropCap: true,
+				dropCap: 'on',
 				elementId: 'mockId',
 				html: '<p>I should become a drop cap.</p>',
 			},
@@ -90,7 +90,7 @@ describe('Dividers and Drop Caps', () => {
 			},
 			{
 				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-				dropCap: true,
+				dropCap: 'on',
 				elementId: 'mockId',
 				html: '<p>I should become a drop cap.</p>',
 			},
@@ -129,7 +129,7 @@ describe('Dividers and Drop Caps', () => {
 			},
 			{
 				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-				dropCap: true,
+				dropCap: 'on',
 				elementId: 'mockId',
 				html: '<p>I should become a drop cap.</p>',
 			},
@@ -173,7 +173,7 @@ describe('Dividers and Drop Caps', () => {
 			},
 			{
 				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-				dropCap: true,
+				dropCap: 'on',
 				elementId: 'mockId',
 				html: '<p>I should become a drop cap.</p>',
 			},
@@ -232,7 +232,7 @@ describe('Dividers and Drop Caps', () => {
 			},
 			{
 				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-				dropCap: true,
+				dropCap: 'on',
 				elementId: 'mockId',
 				html: '<p>I should become a drop cap.</p>',
 			},
@@ -241,7 +241,7 @@ describe('Dividers and Drop Caps', () => {
 			},
 			{
 				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-				dropCap: true,
+				dropCap: 'on',
 				elementId: 'mockId',
 				html: '<p>I should also become a drop cap.</p>',
 			},
@@ -360,7 +360,7 @@ describe('Dividers and Drop Caps', () => {
 			},
 			{
 				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-				dropCap: true,
+				dropCap: 'on',
 				elementId: 'mockId',
 				html: '<p>I should become a drop cap.</p>',
 			},

--- a/dotcom-rendering/src/model/enhance-dividers.ts
+++ b/dotcom-rendering/src/model/enhance-dividers.ts
@@ -46,7 +46,7 @@ export const enhanceDividers = (elements: FEElement[]): FEElement[] =>
 		) {
 			return {
 				...element,
-				dropCap: true,
+				dropCap: 'on',
 			};
 		} else {
 			// Otherwise, do nothing

--- a/dotcom-rendering/src/types/content.ts
+++ b/dotcom-rendering/src/types/content.ts
@@ -484,7 +484,7 @@ export interface TableBlockElement {
 export interface TextBlockElement {
 	_type: 'model.dotcomrendering.pageElements.TextBlockElement';
 	elementId: string;
-	dropCap?: boolean;
+	dropCap?: 'on' | 'off';
 	html: string;
 }
 


### PR DESCRIPTION
Removes drop caps from list elements. Introduces the ability to force drop caps "off" by updating the existing `forceDropCap` mechanism.

Closes #10963.

## More Details

Dropcaps are "dropped capital" letters used on the first letter of the first paragraph of some text. We apply them to body text on some article formats according to a set of requirements: `ArticleDisplay.Immersive`, `ArticleDesign.Feature`, paragraph length and so on.

Paragraphs of body text are rendered by `TextBlockComponent`, and so far there have been two scenarios in which drop caps may appear (assuming the above requirements are met):

1. The paragraph is the first on the page.
2. The `forceDropCap` prop is set to `true`, which allows drop caps to be set on other paragraphs further down the page.

For list elements we encountered a new scenario: the need to turn drop caps **off** regardless of where the paragraph appears. The existing `forceDropCap` functionality didn't allow for this, as that prop worked as follows:

| Setting | Effect |
|--------|--------|
| `forceDropCap: true` | Turn drop caps on for this paragraph |
| `forceDropCap: false` | Use the first paragraph rule as normal |
| `forceDropCap: undefined` | Use the first paragraph rule as normal |

Therefore we have updated this prop to have the following functionality:

| Setting | Effect |
|--------|--------|
| `forceDropCap: 'on'` | Turn drop caps **on** for this paragraph |
| `forceDropCap: 'off'` | Turn drop caps **off** for this paragraph |
| `forceDropCap: undefined` | Use the first paragraph rule as normal |

As before, this will still only be relevant if the other requirements on `ArticleFormat` etc. are met.

## Screenshots

| Before | After |
|--------|--------|
| ![dropcap-before] | ![dropcap-after] | 

[dropcap-after]: https://github.com/guardian/dotcom-rendering/assets/53781962/0bba9409-fc3e-4bc3-831c-7295a8b65ec6
[dropcap-before]: https://github.com/guardian/dotcom-rendering/assets/53781962/1151bb93-8526-434c-aafb-33d825c16650
