### PR TITLE
Update `DropCap` story

### DIFF
--- a/dotcom-rendering/src/components/Dropcap.stories.tsx
+++ b/dotcom-rendering/src/components/Dropcap.stories.tsx
@@ -4,287 +4,79 @@ import { body } from '@guardian/source-foundations';
 import { splitTheme } from '../../.storybook/decorators/splitThemeDecorator';
 import { DropCap } from './DropCap';
 
-export default {
-	component: DropCap,
-	title: 'Components/DropCap',
-};
-
 const Wrapper = ({ children }: { children: React.ReactNode }) => (
 	<div
 		css={css`
 			width: 620px;
 			padding: 20px;
+
+			p {
+				${body.medium()};
+			}
 		`}
 	>
 		{children}
 	</div>
 );
 
-export const Article = () => {
+const render = ({
+	format,
+	firstSentence,
+}: {
+	format: ArticleFormat;
+	firstSentence: string;
+}) => {
+	if (!firstSentence[0]) return;
+
+	const dropCapIdx = firstSentence.search(/\w/g) + 1;
+
 	return (
 		<Wrapper>
-			<p
-				css={css`
-					${body.medium()};
-				`}
-			>
+			<p>
 				<DropCap
-					letter="T"
-					format={{
-						design: ArticleDesign.Standard,
-						display: ArticleDisplay.Standard,
-						theme: Pillar.News,
-					}}
+					letter={firstSentence.slice(0, dropCapIdx)}
+					format={format}
 				/>
-				here once was a dropcap. Lorem ipsum dolor sit amet, consectetur
-				adipiscing elit, sed do eiusmod tempor incididunt ut labore et
-				dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
-				exercitation ullamco laboris nisi ut aliquip ex ea commodo
-				consequat. Duis aute irure dolor in reprehenderit in voluptate
-				velit esse cillum dolore eu fugiat nulla pariatur. Excepteur
-				sint occaecat cupidatat non proident, sunt in culpa qui officia
-				deserunt mollit anim id est laborum.
+				{firstSentence.slice(dropCapIdx)} Lorem ipsum dolor sit amet,
+				consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
+				labore et dolore magna aliqua. Ut enim ad minim veniam, quis
+				nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+				commodo consequat. Duis aute irure dolor in reprehenderit in
+				voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+				Excepteur sint occaecat cupidatat non proident, sunt in culpa
+				qui officia deserunt mollit anim id est laborum.
 			</p>
 		</Wrapper>
 	);
 };
-Article.storyName = 'Article | news';
-Article.decorators = [
+
+const decorators = [
 	splitTheme([
 		{
 			design: ArticleDesign.Standard,
 			display: ArticleDisplay.Standard,
 			theme: Pillar.News,
 		},
-	]),
-];
-
-export const OpinionArticle = () => {
-	return (
-		<Wrapper>
-			<p
-				css={css`
-					${body.medium()};
-				`}
-			>
-				<DropCap
-					letter="L"
-					format={{
-						design: ArticleDesign.Standard,
-						display: ArticleDisplay.Standard,
-						theme: Pillar.Opinion,
-					}}
-				/>
-				ong, long ago, there lived a dropcap. Lorem ipsum dolor sit
-				amet, consectetur adipiscing elit, sed do eiusmod tempor
-				incididunt ut labore et dolore magna aliqua. Ut enim ad minim
-				veniam, quis nostrud exercitation ullamco laboris nisi ut
-				aliquip ex ea commodo consequat. Duis aute irure dolor in
-				reprehenderit in voluptate velit esse cillum dolore eu fugiat
-				nulla pariatur. Excepteur sint occaecat cupidatat non proident,
-				sunt in culpa qui officia deserunt mollit anim id est laborum.
-			</p>
-		</Wrapper>
-	);
-};
-OpinionArticle.storyName = 'Article | opinion';
-OpinionArticle.decorators = [
-	splitTheme([
 		{
-			design: ArticleDesign.Standard,
+			design: ArticleDesign.Editorial,
 			display: ArticleDisplay.Standard,
 			theme: Pillar.Opinion,
 		},
-	]),
-];
-
-export const Feature = () => {
-	return (
-		<Wrapper>
-			<p
-				css={css`
-					${body.medium()};
-				`}
-			>
-				<DropCap
-					letter="O"
-					format={{
-						design: ArticleDesign.Feature,
-						display: ArticleDisplay.Standard,
-						theme: Pillar.Culture,
-					}}
-				/>
-				nce upon a time there was a dropcap. Lorem ipsum dolor sit amet,
-				consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
-				labore et dolore magna aliqua. Ut enim ad minim veniam, quis
-				nostrud exercitation ullamco laboris nisi ut aliquip ex ea
-				commodo consequat. Duis aute irure dolor in reprehenderit in
-				voluptate velit esse cillum dolore eu fugiat nulla pariatur.
-				Excepteur sint occaecat cupidatat non proident, sunt in culpa
-				qui officia deserunt mollit anim id est laborum.
-			</p>
-		</Wrapper>
-	);
-};
-Feature.storyName = 'Feature | culture';
-Feature.decorators = [
-	splitTheme([
 		{
 			design: ArticleDesign.Feature,
 			display: ArticleDisplay.Standard,
 			theme: Pillar.Culture,
 		},
-	]),
-];
-
-export const PhotoEssay = () => {
-	return (
-		<Wrapper>
-			<p
-				css={css`
-					${body.medium()};
-				`}
-			>
-				<DropCap
-					letter="O"
-					format={{
-						design: ArticleDesign.PhotoEssay,
-						display: ArticleDisplay.Standard,
-						theme: Pillar.Sport,
-					}}
-				/>
-				nce upon a time there was a dropcap. Lorem ipsum dolor sit amet,
-				consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
-				labore et dolore magna aliqua. Ut enim ad minim veniam, quis
-				nostrud exercitation ullamco laboris nisi ut aliquip ex ea
-				commodo consequat. Duis aute irure dolor in reprehenderit in
-				voluptate velit esse cillum dolore eu fugiat nulla pariatur.
-				Excepteur sint occaecat cupidatat non proident, sunt in culpa
-				qui officia deserunt mollit anim id est laborum.
-			</p>
-		</Wrapper>
-	);
-};
-PhotoEssay.storyName = 'PhotoEssay | sport';
-PhotoEssay.decorators = [
-	splitTheme([
 		{
 			design: ArticleDesign.PhotoEssay,
 			display: ArticleDisplay.Standard,
 			theme: Pillar.Sport,
 		},
-	]),
-];
-
-export const Interview = () => {
-	return (
-		<Wrapper>
-			<p
-				css={css`
-					${body.medium()};
-				`}
-			>
-				<DropCap
-					letter="O"
-					format={{
-						design: ArticleDesign.Interview,
-						display: ArticleDisplay.Standard,
-						theme: Pillar.Lifestyle,
-					}}
-				/>
-				nce upon a time there was a dropcap. Lorem ipsum dolor sit amet,
-				consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
-				labore et dolore magna aliqua. Ut enim ad minim veniam, quis
-				nostrud exercitation ullamco laboris nisi ut aliquip ex ea
-				commodo consequat. Duis aute irure dolor in reprehenderit in
-				voluptate velit esse cillum dolore eu fugiat nulla pariatur.
-				Excepteur sint occaecat cupidatat non proident, sunt in culpa
-				qui officia deserunt mollit anim id est laborum.
-			</p>
-		</Wrapper>
-	);
-};
-Interview.storyName = 'Interview | lifestyle';
-Interview.decorators = [
-	splitTheme([
 		{
 			design: ArticleDesign.Interview,
 			display: ArticleDisplay.Standard,
 			theme: Pillar.Lifestyle,
 		},
-	]),
-];
-
-export const Comment = () => {
-	return (
-		<Wrapper>
-			<p
-				css={css`
-					${body.medium()};
-				`}
-			>
-				<DropCap
-					letter="O"
-					format={{
-						design: ArticleDesign.Comment,
-						display: ArticleDisplay.Standard,
-						theme: Pillar.Opinion,
-					}}
-				/>
-				nce upon a time there was a dropcap. Lorem ipsum dolor sit amet,
-				consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
-				labore et dolore magna aliqua. Ut enim ad minim veniam, quis
-				nostrud exercitation ullamco laboris nisi ut aliquip ex ea
-				commodo consequat. Duis aute irure dolor in reprehenderit in
-				voluptate velit esse cillum dolore eu fugiat nulla pariatur.
-				Excepteur sint occaecat cupidatat non proident, sunt in culpa
-				qui officia deserunt mollit anim id est laborum.
-			</p>
-		</Wrapper>
-	);
-};
-Comment.storyName = 'Comment | opinion';
-Comment.decorators = [
-	splitTheme([
-		{
-			design: ArticleDesign.Comment,
-			display: ArticleDisplay.Standard,
-			theme: Pillar.Opinion,
-		},
-	]),
-];
-
-export const CommentSport = () => {
-	return (
-		<Wrapper>
-			<p
-				css={css`
-					${body.medium()};
-				`}
-			>
-				<DropCap
-					letter="O"
-					format={{
-						design: ArticleDesign.Comment,
-						display: ArticleDisplay.Standard,
-						theme: Pillar.Sport,
-					}}
-				/>
-				nce upon a time there was a dropcap. Lorem ipsum dolor sit amet,
-				consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
-				labore et dolore magna aliqua. Ut enim ad minim veniam, quis
-				nostrud exercitation ullamco laboris nisi ut aliquip ex ea
-				commodo consequat. Duis aute irure dolor in reprehenderit in
-				voluptate velit esse cillum dolore eu fugiat nulla pariatur.
-				Excepteur sint occaecat cupidatat non proident, sunt in culpa
-				qui officia deserunt mollit anim id est laborum.
-			</p>
-		</Wrapper>
-	);
-};
-CommentSport.storyName = 'Comment | sport';
-CommentSport.decorators = [
-	splitTheme([
 		{
 			design: ArticleDesign.Comment,
 			display: ArticleDisplay.Standard,
@@ -293,41 +85,35 @@ CommentSport.decorators = [
 	]),
 ];
 
-export const CommentCulture = () => {
-	return (
-		<Wrapper>
-			<p
-				css={css`
-					${body.medium()};
-				`}
-			>
-				<DropCap
-					letter="O"
-					format={{
-						design: ArticleDesign.Comment,
-						display: ArticleDisplay.Standard,
-						theme: Pillar.Culture,
-					}}
-				/>
-				nce upon a time there was a dropcap. Lorem ipsum dolor sit amet,
-				consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
-				labore et dolore magna aliqua. Ut enim ad minim veniam, quis
-				nostrud exercitation ullamco laboris nisi ut aliquip ex ea
-				commodo consequat. Duis aute irure dolor in reprehenderit in
-				voluptate velit esse cillum dolore eu fugiat nulla pariatur.
-				Excepteur sint occaecat cupidatat non proident, sunt in culpa
-				qui officia deserunt mollit anim id est laborum.
-			</p>
-		</Wrapper>
-	);
+const meta = {
+	component: DropCap,
+	title: 'Components/DropCap',
+	render,
+	decorators,
 };
-CommentCulture.storyName = 'Comment | culture';
-CommentCulture.decorators = [
-	splitTheme([
-		{
-			design: ArticleDesign.Comment,
-			display: ArticleDisplay.Standard,
-			theme: Pillar.Culture,
-		},
-	]),
-];
+export default meta;
+
+export const DropCapWithT = {
+	name: 'with a T',
+	args: { firstSentence: 'There once was a dropcap.' },
+};
+
+export const DropCapWithA = {
+	name: 'with an A',
+	args: { firstSentence: 'A long time ago there was a dropcap' },
+};
+
+export const DropCapWithL = {
+	name: 'with an L',
+	args: { firstSentence: 'Long ago there was a dropcap' },
+};
+
+export const DropCapWithO = {
+	name: 'with an O',
+	args: { firstSentence: 'Once upon a time there was a dropcap' },
+};
+
+export const DropCapWithQuote = {
+	name: 'with a quote',
+	args: { firstSentence: '"Once upon a time there was a dropcap".' },
+};


### PR DESCRIPTION
## What does this change?

Combines multiple formats into one story and uses separate stories for different starting letters instead.

## Why?

Can provide more detail in the stories with fewer pages in both Storybook and Chromatic

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |
| ![before2][] | ![after2][] |


[before]: https://github.com/guardian/dotcom-rendering/assets/43961396/a6ca0e80-ad73-449a-af84-ffdc3ce59cb1
[after]: https://github.com/guardian/dotcom-rendering/assets/43961396/5e544891-7aa5-4882-a016-13943dd923f8
[before2]: https://github.com/guardian/dotcom-rendering/assets/43961396/baf615fb-136e-4e0d-af30-b5b7c0d6e726
[after2]: https://github.com/guardian/dotcom-rendering/assets/43961396/dfe100be-b2af-4645-818b-ace44f013f42


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
