### PR TITLE
trial use of community lighthouse action

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -26,6 +26,12 @@ jobs:
     with:
       container-image: ${{ needs.container.outputs.container-image }}
 
+  lighthouse:
+    needs: [container]
+    uses: ./.github/workflows/lighthouse.yml
+    with:
+      container-image: ${{ needs.container.outputs.container-image }}
+
   amp:
     needs: [container]
     uses: ./.github/workflows/amp.yml

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,6 +1,12 @@
 name: DCR Run Lighthouse CI
+
 on:
-  workflow_dispatch:
+  workflow_call:
+    inputs:
+      container-image:
+        description: 'Image used by DCR service'
+        required: true
+        type: string
 
 jobs:
   lhci:
@@ -12,6 +18,12 @@ jobs:
         group:
           - 'http://localhost:9000/Article/https://www.theguardian.com/commentisfree/2020/feb/08/hungary-now-for-the-new-right-what-venezuela-once-was-for-the-left#noads'
           - 'http://localhost:9000/Front/https://www.theguardian.com/uk'
+    services:
+      DCR:
+        image: ${{ inputs.container-image }}
+        ports:
+          - 9000:9000
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -19,30 +31,8 @@ jobs:
       - name: Set up Node environment
         uses: ./.github/actions/setup-node-env
 
-      - run: make build
-        working-directory: dotcom-rendering
-
-      - name: Install and run Lighthouse CI
-        working-directory: dotcom-rendering
-        env:
-          LHCI_GITHUB_TOKEN: ${{ secrets.LHCI_GITHUB_TOKEN }}
-          LHCI_URL: ${{ matrix.group }}
-        run: |
-          npm install -g puppeteer-core@2.1.0 @lhci/cli@0.10.0
-          lhci autorun
-
-      # https://github.com/denoland/setup-deno#latest-stable-for-a-major
-      - uses: denoland/setup-deno@v1
+      - name: Audit URLs using Lighthouse
+        uses: treosh/lighthouse-ci-action@v11
         with:
-          deno-version: v1.x
-
-      - name: Surface Lighthouse Results
-        run: |
-          deno run \
-            --allow-read \
-            --allow-net=api.github.com \
-            --allow-env=HOME,GITHUB_TOKEN,GITHUB_EVENT_PATH,LHCI_URL \
-            scripts/deno/surface-lighthouse-results.ts
-        env:
-          LHCI_URL: ${{ matrix.group }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          urls: ${{ matrix.group }}
+          uploadArtifacts: true # save results as an action artifacts


### PR DESCRIPTION
## What does this change?

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
