### PR TITLE
Fix body scrolling bug on mobile side nav

### DIFF
--- a/dotcom-rendering/src/components/Nav/Nav.tsx
+++ b/dotcom-rendering/src/components/Nav/Nav.tsx
@@ -73,6 +73,7 @@ export const Nav = ({
 					.nav-is-open {
 						${until.desktop} {
 							overflow: hidden;
+							height: 100vh;
 						}
 					}
 				`}


### PR DESCRIPTION
## What does this change?
This fixes body scrolling on mobile side nav.
The original fix https://github.com/guardian/dotcom-rendering/pull/5765 had stopped working as the height of the element seems to now exceed the viewport height.
## Why?
Frustrating behavioural bug
## Screenshots
BEFORE

https://github.com/guardian/dotcom-rendering/assets/110032454/1ec7017a-8880-4804-8288-03431499b187

AFTER

https://github.com/guardian/dotcom-rendering/assets/110032454/7bb37c6f-d8e1-4c2e-930e-4b4a01d0c10d







<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
