### PR TITLE
Add `TimelineAtomBlockElement`

### DIFF
--- a/dotcom-rendering/src/components/Elements.amp.tsx
+++ b/dotcom-rendering/src/components/Elements.amp.tsx
@@ -21,7 +21,7 @@ import { RichLinkBlockComponent } from './RichLinkBlockComponent.amp';
 import { SoundcloudBlockComponent } from './SoundcloudBlockComponent.amp';
 import { SubheadingBlockComponent } from './SubheadingBlockComponent.amp';
 import { TextBlockComponent } from './TextBlockComponent.amp';
-import { TimelineBlockComponent } from './TimelineBlockComponent.amp';
+import { TimelineAtom } from './TimelineAtom.amp';
 import { TwitterBlockComponent } from './TwitterBlockComponent.amp';
 import { VideoVimeoBlockComponent } from './VideoVimeoBlockComponent.amp';
 import { VideoYoutubeBlockComponent } from './VideoYoutubeBlockComponent.amp';
@@ -56,6 +56,7 @@ const AMP_SUPPORTED_ELEMENTS = [
 	'model.dotcomrendering.pageElements.SoundcloudBlockElement',
 	'model.dotcomrendering.pageElements.SubheadingBlockElement',
 	'model.dotcomrendering.pageElements.TextBlockElement',
+	'model.dotcomrendering.pageElements.TimelineAtomBlockElement',
 	'model.dotcomrendering.pageElements.TimelineBlockElement',
 	'model.dotcomrendering.pageElements.TweetBlockElement',
 	'model.dotcomrendering.pageElements.VideoVimeoBlockElement',
@@ -311,9 +312,20 @@ export const Elements = (
 						pillar={pillar}
 					/>
 				);
+			case 'model.dotcomrendering.pageElements.TimelineAtomBlockElement':
+				return (
+					<TimelineAtom
+						key={element.elementId}
+						id={element.id}
+						title={element.title}
+						description={element.description}
+						events={element.events}
+						pillar={pillar}
+					/>
+				);
 			case 'model.dotcomrendering.pageElements.TimelineBlockElement':
 				return (
-					<TimelineBlockComponent
+					<TimelineAtom
 						key={element.elementId}
 						id={element.id}
 						title={element.title}

--- a/dotcom-rendering/src/components/TimelineAtom.amp.tsx
+++ b/dotcom-rendering/src/components/TimelineAtom.amp.tsx
@@ -44,7 +44,7 @@ type Props = {
 	pillar: ArticleTheme;
 };
 
-export const TimelineBlockComponent = ({
+export const TimelineAtom = ({
 	id,
 	title,
 	description,

--- a/dotcom-rendering/src/lib/renderElement.tsx
+++ b/dotcom-rendering/src/lib/renderElement.tsx
@@ -636,6 +636,17 @@ export const renderElement = ({
 					}
 				/>
 			);
+		case 'model.dotcomrendering.pageElements.TimelineAtomBlockElement':
+			return (
+				<Island priority="feature" defer={{ until: 'visible' }}>
+					<TimelineAtom
+						id={element.id}
+						title={element.title}
+						events={element.events}
+						description={element.description}
+					/>
+				</Island>
+			);
 		case 'model.dotcomrendering.pageElements.TimelineBlockElement':
 			return (
 				<Island priority="feature" defer={{ until: 'visible' }}>

--- a/dotcom-rendering/src/model/article-schema.json
+++ b/dotcom-rendering/src/model/article-schema.json
@@ -628,6 +628,9 @@
                     "$ref": "#/definitions/TextBlockElement"
                 },
                 {
+                    "$ref": "#/definitions/TimelineAtomBlockElement"
+                },
+                {
                     "$ref": "#/definitions/TimelineBlockElement"
                 },
                 {
@@ -2993,12 +2996,12 @@
                 "html"
             ]
         },
-        "TimelineBlockElement": {
+        "TimelineAtomBlockElement": {
             "type": "object",
             "properties": {
                 "_type": {
                     "type": "string",
-                    "const": "model.dotcomrendering.pageElements.TimelineBlockElement"
+                    "const": "model.dotcomrendering.pageElements.TimelineAtomBlockElement"
                 },
                 "elementId": {
                     "type": "string"
@@ -3056,6 +3059,43 @@
                 "date",
                 "title",
                 "unixDate"
+            ]
+        },
+        "TimelineBlockElement": {
+            "type": "object",
+            "properties": {
+                "_type": {
+                    "type": "string",
+                    "const": "model.dotcomrendering.pageElements.TimelineBlockElement"
+                },
+                "elementId": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "events": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/TimelineEvent"
+                    }
+                },
+                "role": {
+                    "$ref": "#/definitions/RoleType"
+                }
+            },
+            "required": [
+                "_type",
+                "elementId",
+                "events",
+                "id",
+                "title"
             ]
         },
         "TweetBlockElement": {

--- a/dotcom-rendering/src/model/block-schema.json
+++ b/dotcom-rendering/src/model/block-schema.json
@@ -217,6 +217,9 @@
                     "$ref": "#/definitions/TextBlockElement"
                 },
                 {
+                    "$ref": "#/definitions/TimelineAtomBlockElement"
+                },
+                {
                     "$ref": "#/definitions/TimelineBlockElement"
                 },
                 {
@@ -2582,12 +2585,12 @@
                 "html"
             ]
         },
-        "TimelineBlockElement": {
+        "TimelineAtomBlockElement": {
             "type": "object",
             "properties": {
                 "_type": {
                     "type": "string",
-                    "const": "model.dotcomrendering.pageElements.TimelineBlockElement"
+                    "const": "model.dotcomrendering.pageElements.TimelineAtomBlockElement"
                 },
                 "elementId": {
                     "type": "string"
@@ -2645,6 +2648,43 @@
                 "date",
                 "title",
                 "unixDate"
+            ]
+        },
+        "TimelineBlockElement": {
+            "type": "object",
+            "properties": {
+                "_type": {
+                    "type": "string",
+                    "const": "model.dotcomrendering.pageElements.TimelineBlockElement"
+                },
+                "elementId": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "events": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/TimelineEvent"
+                    }
+                },
+                "role": {
+                    "$ref": "#/definitions/RoleType"
+                }
+            },
+            "required": [
+                "_type",
+                "elementId",
+                "events",
+                "id",
+                "title"
             ]
         },
         "TweetBlockElement": {

--- a/dotcom-rendering/src/types/content.ts
+++ b/dotcom-rendering/src/types/content.ts
@@ -498,6 +498,16 @@ export interface TimelineBlockElement {
 	role?: RoleType;
 }
 
+export interface TimelineAtomBlockElement {
+	_type: 'model.dotcomrendering.pageElements.TimelineAtomBlockElement';
+	elementId: string;
+	id: string;
+	title: string;
+	description?: string;
+	events: TimelineEvent[];
+	role?: RoleType;
+}
+
 export interface TweetBlockElement extends ThirdPartyEmbeddedContent {
 	_type: 'model.dotcomrendering.pageElements.TweetBlockElement';
 	elementId: string;
@@ -698,6 +708,7 @@ export type FEElement =
 	| SubheadingBlockElement
 	| TableBlockElement
 	| TextBlockElement
+	| TimelineAtomBlockElement
 	| TimelineBlockElement
 	| TweetBlockElement
 	| VideoBlockElement


### PR DESCRIPTION
This was previously called `TimelineBlockElement`, but our convention is that we use the word `Atom` in the name of `Atom` types. This also allows us to repurpose `TimelineBlockElement` for the new timeline element.

For now this actually duplicates the element, because we have to synchronise changes in frontend. This will be repurposed in a future change.

Co-authored-by: @alinaboghiu 
