### PR TITLE
Only try to remove `run_chromatic` label from PRs

### DIFF
--- a/.github/workflows/dcr-chromatic.yml
+++ b/.github/workflows/dcr-chromatic.yml
@@ -50,6 +50,7 @@ jobs:
           buildScriptName: 'build-storybook'
 
   remove-label:
+    if: ${{ github.event.issue.pull_request }}
     runs-on: ubuntu-latest
     needs: chromatic
     permissions:

--- a/.github/workflows/dcr-chromatic.yml
+++ b/.github/workflows/dcr-chromatic.yml
@@ -50,7 +50,7 @@ jobs:
           buildScriptName: 'build-storybook'
 
   remove-label:
-    if: ${{ github.event.issue.pull_request }}
+    if: github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     needs: chromatic
     permissions:


### PR DESCRIPTION
It only makes sense to run it on pull requests! It [fails](https://github.com/guardian/dotcom-rendering/actions/runs/8391942261) if it runs on merges to `main`.