### PR TITLE
Align mostpop advert within Most Viewed section on fronts and articles

### DIFF
--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -317,7 +317,6 @@ const mostPopAdStyles = css`
 	min-height: ${adSizes.mpu.height + labelHeight}px;
 	min-width: ${adSizes.mpu.width}px;
 	max-width: ${adSizes.mpu.width}px;
-	margin: 12px auto;
 	text-align: center;
 	${from.tablet} {
 		max-width: 700px;
@@ -325,9 +324,6 @@ const mostPopAdStyles = css`
 	${from.desktop} {
 		width: auto;
 		max-width: ${adSizes.mpu.width}px;
-	}
-	${from.wide} {
-		margin-top: 25px;
 	}
 `;
 

--- a/dotcom-rendering/src/components/FrontMostViewed.tsx
+++ b/dotcom-rendering/src/components/FrontMostViewed.tsx
@@ -62,9 +62,10 @@ export const FrontMostViewed = ({
 
 	return (
 		<MostViewedFooterLayout
-			hasPageSkin={hasPageSkin}
 			isFront={isFront}
 			renderAds={renderAds}
+			hasPageSkin={hasPageSkin}
+			isDeeplyRead={!!deeplyReadType}
 		>
 			{/* We only need hydration if there are multiple tabs */}
 			{showMostViewedTab ? (

--- a/dotcom-rendering/src/components/MostViewedFooterLayout.tsx
+++ b/dotcom-rendering/src/components/MostViewedFooterLayout.tsx
@@ -30,7 +30,7 @@ const fixedWidthsPageSkin = css`
 `;
 
 const advertMargin = (hasHideButton: boolean, isDeeplyRead: boolean) => css`
-	margin-top: 10px;
+	margin-top: 9px;
 	${from.desktop} {
 		margin-top: 0;
 		margin-left: 10px;

--- a/dotcom-rendering/src/components/MostViewedFooterLayout.tsx
+++ b/dotcom-rendering/src/components/MostViewedFooterLayout.tsx
@@ -36,13 +36,20 @@ const fixedWidthsPageSkin = css`
 	}
 `;
 
-const mostPopMargin = css`
-	margin-top: 9px;
+const mostPopMargin = (hasHideButton: boolean) => css`
+	margin-top: 10px;
 	${from.desktop} {
-		margin: 9px 0 0 10px;
+		margin-top: 0;
+		margin-left: 10px;
 	}
 	${from.leftCol} {
-		margin: 6px 0 0 10px;
+		margin-top: 10px;
+	}
+	${hasHideButton && from.leftCol} {
+		margin-top: 2px;
+	}
+	${hasHideButton && from.wide} {
+		margin-top: 36px;
 	}
 `;
 
@@ -92,7 +99,13 @@ export const MostViewedFooterLayout = ({
 			>
 				{children}
 			</div>
-			<div css={hasPageSkin ? mostPopMarginWithPageSkin : mostPopMargin}>
+			<div
+				css={
+					hasPageSkin
+						? mostPopMarginWithPageSkin
+						: mostPopMargin(!!isFront)
+				}
+			>
 				{renderAds && <AdSlot position="mostpop" />}
 			</div>
 		</div>

--- a/dotcom-rendering/src/components/MostViewedFooterLayout.tsx
+++ b/dotcom-rendering/src/components/MostViewedFooterLayout.tsx
@@ -3,13 +3,6 @@ import type { Breakpoint } from '@guardian/source-foundations';
 import { between, from, space } from '@guardian/source-foundations';
 import { AdSlot } from './AdSlot.web';
 
-type Props = {
-	children: React.ReactNode;
-	hasPageSkin?: boolean;
-	isFront?: boolean;
-	renderAds?: boolean;
-};
-
 const stackBelow = (breakpoint: Breakpoint) => css`
 	display: flex;
 	flex-direction: column;
@@ -36,7 +29,7 @@ const fixedWidthsPageSkin = css`
 	}
 `;
 
-const mostPopMargin = (hasHideButton: boolean) => css`
+const advertMargin = (hasHideButton: boolean, isDeeplyRead: boolean) => css`
 	margin-top: 10px;
 	${from.desktop} {
 		margin-top: 0;
@@ -51,9 +44,18 @@ const mostPopMargin = (hasHideButton: boolean) => css`
 	${hasHideButton && from.wide} {
 		margin-top: 36px;
 	}
+	${hasHideButton && isDeeplyRead && from.desktop} {
+		margin-top: 9px;
+	}
+	${hasHideButton && isDeeplyRead && from.leftCol} {
+		margin-top: 38px;
+	}
+	${hasHideButton && isDeeplyRead && from.wide} {
+		margin-top: 54px;
+	}
 `;
 
-const mostPopMarginWithPageSkin = css`
+const advertMarginWithPageSkin = css`
 	margin: 9px 0 0 10px;
 `;
 
@@ -78,11 +80,20 @@ const adFreeStyles = css`
 	}
 `;
 
+type Props = {
+	children: React.ReactNode;
+	hasPageSkin?: boolean;
+	isFront?: boolean;
+	renderAds?: boolean;
+	isDeeplyRead?: boolean;
+};
+
 export const MostViewedFooterLayout = ({
 	children,
-	hasPageSkin = false,
 	isFront,
 	renderAds,
+	hasPageSkin = false,
+	isDeeplyRead = false,
 }: Props) => {
 	return (
 		<div
@@ -102,8 +113,8 @@ export const MostViewedFooterLayout = ({
 			<div
 				css={
 					hasPageSkin
-						? mostPopMarginWithPageSkin
-						: mostPopMargin(!!isFront)
+						? advertMarginWithPageSkin
+						: advertMargin(!!isFront, isDeeplyRead)
 				}
 			>
 				{renderAds && <AdSlot position="mostpop" />}


### PR DESCRIPTION
## What does this change?

- Create an appropriate amount of spacing above the `most-pop` advert.

## Why?

- We currently have lots of margin above the `most-pop` advert to ensure that it does not collide with the "Hide" button above it on fronts, which is used to collapse the container. On articles, this hide button does not exist, so we should not reserve the same amount of margin as this causes the advert to be misaligned with the content.

## Screenshots

- Ignore the difference in the height of the ad. Either a 250px or 600px tall ad can serve in this slot - this is decided by GAM
- This only applies to screen sizes >=980px. For screen sizes <980px, the `most-pop` advert is below the content.

### Front

| <img width=500 /> | Before | After |
| - | - | - |
| Desktop  >=980px | ![old-front-desktop] | ![new-front-desktop] |
| LeftCol >=1140px | ![old-front-left] | ![new-front-left] |
| Wide >=1300px | ![old-front-wide] | ![new-front-wide] |

[new-front-wide]: https://github.com/guardian/dotcom-rendering/assets/9574885/dbdf8483-2b1c-45f0-8659-8ee6bd06a05e
[new-front-left]: https://github.com/guardian/dotcom-rendering/assets/9574885/770423ca-103d-42ad-958d-b8c57c9592d5
[new-front-desktop]: https://github.com/guardian/dotcom-rendering/assets/9574885/ebf40828-7f57-46ff-92b9-84aa54e8d650
[old-front-wide]: https://github.com/guardian/dotcom-rendering/assets/9574885/764b5881-f563-448c-96be-c165ce308fa2
[old-front-left]: https://github.com/guardian/dotcom-rendering/assets/9574885/c6a107d4-6c18-418e-a40f-89595fd5eb30
[old-front-desktop]: https://github.com/guardian/dotcom-rendering/assets/9574885/c9ba529b-349f-4526-9f56-aadfd426133f

### Article

| <img width=500 /> | Before | After |
| - | - | - |
| Desktop  >=980px | ![old-article-desktop] | ![new-article-desktop] |
| LeftCol >=1140px | ![old-article-left] | ![new-article-left] |
| Wide >=1300px | ![old-article-wide] | ![new-article-wide] |

[new-article-wide]: https://github.com/guardian/dotcom-rendering/assets/9574885/032eb7e0-4a1b-40d7-a0cc-746cca51e426
[new-article-left]: https://github.com/guardian/dotcom-rendering/assets/9574885/60aeff6a-e8b7-4fca-99c5-17c9c5b8d82a
[new-article-desktop]: https://github.com/guardian/dotcom-rendering/assets/9574885/53a0e034-6d7b-4b8e-b7f4-597112c2c17d
[old-article-wide]: https://github.com/guardian/dotcom-rendering/assets/9574885/85564b31-efa1-430e-b6a2-28879e02fe40
[old-article-left]: https://github.com/guardian/dotcom-rendering/assets/9574885/fd89e1ff-dc04-424b-bfba-39ce42f1d713
[old-article-desktop]: https://github.com/guardian/dotcom-rendering/assets/9574885/9720e20d-b05c-40b0-971a-2dfe161909b7

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
