### PR TITLE
Use environment app name for sending metrics to Cloudwatch

### DIFF
--- a/dotcom-rendering/src/server/lib/aws/metrics-baseline.ts
+++ b/dotcom-rendering/src/server/lib/aws/metrics-baseline.ts
@@ -6,18 +6,12 @@ const stage =
 		? process.env.GU_STAGE.toUpperCase()
 		: 'DEV';
 
-const maxHeapMemory = BytesMetric('rendering', stage, 'max-heap-memory');
-const usedHeapMemory = BytesMetric('rendering', stage, 'used-heap-memory');
-const freePhysicalMemory = BytesMetric(
-	'rendering',
-	stage,
-	'free-physical-memory',
-);
-const totalPhysicalMemory = BytesMetric(
-	'rendering',
-	stage,
-	'total-physical-memory',
-);
+const app = process.env.GU_APP ?? 'rendering';
+
+const maxHeapMemory = BytesMetric(app, stage, 'max-heap-memory');
+const usedHeapMemory = BytesMetric(app, stage, 'used-heap-memory');
+const freePhysicalMemory = BytesMetric(app, stage, 'free-physical-memory');
+const totalPhysicalMemory = BytesMetric(app, stage, 'total-physical-memory');
 
 collectAndSendAWSMetrics(
 	maxHeapMemory,


### PR DESCRIPTION
## What does this change?

We send memory metrics to Cloudwatch via `@aws-sdk/client-cloudwatch`. This currently uses one app name for all DCR apps so there's no way to distinguish memory usage between applications.

This PR uses the app name as set in the environment variable `GU_APP` to set the name of the app.

## Why?

This helps us to visualise and understand memory usage in AWS per app.
