### PR TITLE
Add A Model For Timeline Elements

### DIFF
--- a/dotcom-rendering/src/components/Elements.amp.tsx
+++ b/dotcom-rendering/src/components/Elements.amp.tsx
@@ -323,17 +323,6 @@ export const Elements = (
 						pillar={pillar}
 					/>
 				);
-			case 'model.dotcomrendering.pageElements.TimelineBlockElement':
-				return (
-					<TimelineAtom
-						key={element.elementId}
-						id={element.id}
-						title={element.title}
-						description={element.description}
-						events={element.events}
-						pillar={pillar}
-					/>
-				);
 			case 'model.dotcomrendering.pageElements.TweetBlockElement':
 				return (
 					<TwitterBlockComponent

--- a/dotcom-rendering/src/components/TimelineAtom.amp.tsx
+++ b/dotcom-rendering/src/components/TimelineAtom.amp.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import { palette } from '@guardian/source-foundations';
-import type { TimelineEvent } from '../types/content';
+import type { TimelineAtomEvent } from '../types/content';
 import { Expandable } from './Expandable.amp';
 
 const eventsWrapper = css`
@@ -40,7 +40,7 @@ type Props = {
 	id: string;
 	title: string;
 	description?: string;
-	events: TimelineEvent[];
+	events: TimelineAtomEvent[];
 	pillar: ArticleTheme;
 };
 

--- a/dotcom-rendering/src/components/TimelineAtom.importable.tsx
+++ b/dotcom-rendering/src/components/TimelineAtom.importable.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/react';
 import { body, palette, remSpace, space } from '@guardian/source-foundations';
 import { submitComponentEvent } from '../client/ophan/ophan';
 import { palette as schemedPalette } from '../palette';
-import type { TimelineAtomType, TimelineEvent } from '../types/content';
+import type { TimelineAtomEvent, TimelineAtomType } from '../types/content';
 import { useConfig } from './ConfigContext';
 import { Body } from './ExpandableAtom/Body';
 import { Container } from './ExpandableAtom/Container';
@@ -57,7 +57,7 @@ const EventToDate = css`
 	})};
 `;
 
-const TimelineContents = ({ events }: { events: TimelineEvent[] }) => {
+const TimelineContents = ({ events }: { events: TimelineAtomEvent[] }) => {
 	return (
 		<div>
 			{events.map((event, index) => {

--- a/dotcom-rendering/src/lib/renderElement.tsx
+++ b/dotcom-rendering/src/lib/renderElement.tsx
@@ -647,17 +647,6 @@ export const renderElement = ({
 					/>
 				</Island>
 			);
-		case 'model.dotcomrendering.pageElements.TimelineBlockElement':
-			return (
-				<Island priority="feature" defer={{ until: 'visible' }}>
-					<TimelineAtom
-						id={element.id}
-						title={element.title}
-						events={element.events}
-						description={element.description}
-					/>
-				</Island>
-			);
 		case 'model.dotcomrendering.pageElements.TweetBlockElement':
 			if (switches.enhanceTweets) {
 				return (

--- a/dotcom-rendering/src/model/article-schema.json
+++ b/dotcom-rendering/src/model/article-schema.json
@@ -640,10 +640,6 @@
                             "type": "string",
                             "const": "model.dotcomrendering.pageElements.DCRTimelineBlockElement"
                         },
-                        "timelineKind": {
-                            "type": "string",
-                            "const": "flat"
-                        },
                         "events": {
                             "type": "array",
                             "items": {
@@ -677,8 +673,7 @@
                     },
                     "required": [
                         "_type",
-                        "events",
-                        "timelineKind"
+                        "events"
                     ]
                 },
                 {
@@ -686,11 +681,7 @@
                     "properties": {
                         "_type": {
                             "type": "string",
-                            "const": "model.dotcomrendering.pageElements.DCRTimelineBlockElement"
-                        },
-                        "timelineKind": {
-                            "type": "string",
-                            "const": "sectioned"
+                            "const": "model.dotcomrendering.pageElements.DCRSectionedTimelineBlockElement"
                         },
                         "sections": {
                             "type": "array",
@@ -740,8 +731,7 @@
                     },
                     "required": [
                         "_type",
-                        "sections",
-                        "timelineKind"
+                        "sections"
                     ]
                 },
                 {

--- a/dotcom-rendering/src/model/article-schema.json
+++ b/dotcom-rendering/src/model/article-schema.json
@@ -631,7 +631,118 @@
                     "$ref": "#/definitions/TimelineAtomBlockElement"
                 },
                 {
-                    "$ref": "#/definitions/TimelineBlockElement"
+                    "$ref": "#/definitions/FETimelineBlockElement"
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "_type": {
+                            "type": "string",
+                            "const": "model.dotcomrendering.pageElements.DCRTimelineBlockElement"
+                        },
+                        "timelineKind": {
+                            "type": "string",
+                            "const": "flat"
+                        },
+                        "events": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "date": {
+                                        "type": "string"
+                                    },
+                                    "title": {
+                                        "type": "string"
+                                    },
+                                    "label": {
+                                        "type": "string"
+                                    },
+                                    "main": {
+                                        "$ref": "#/definitions/FEElement"
+                                    },
+                                    "body": {
+                                        "type": "array",
+                                        "items": {
+                                            "$ref": "#/definitions/FEElement"
+                                        }
+                                    }
+                                },
+                                "required": [
+                                    "body",
+                                    "date"
+                                ]
+                            }
+                        }
+                    },
+                    "required": [
+                        "_type",
+                        "events",
+                        "timelineKind"
+                    ]
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "_type": {
+                            "type": "string",
+                            "const": "model.dotcomrendering.pageElements.DCRTimelineBlockElement"
+                        },
+                        "timelineKind": {
+                            "type": "string",
+                            "const": "sectioned"
+                        },
+                        "sections": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "title": {
+                                        "type": "string"
+                                    },
+                                    "events": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "date": {
+                                                    "type": "string"
+                                                },
+                                                "title": {
+                                                    "type": "string"
+                                                },
+                                                "label": {
+                                                    "type": "string"
+                                                },
+                                                "main": {
+                                                    "$ref": "#/definitions/FEElement"
+                                                },
+                                                "body": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "$ref": "#/definitions/FEElement"
+                                                    }
+                                                }
+                                            },
+                                            "required": [
+                                                "body",
+                                                "date"
+                                            ]
+                                        }
+                                    }
+                                },
+                                "required": [
+                                    "events",
+                                    "title"
+                                ]
+                            }
+                        }
+                    },
+                    "required": [
+                        "_type",
+                        "sections",
+                        "timelineKind"
+                    ]
                 },
                 {
                     "$ref": "#/definitions/TweetBlockElement"
@@ -3018,7 +3129,7 @@
                 "events": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/TimelineEvent"
+                        "$ref": "#/definitions/TimelineAtomEvent"
                     }
                 },
                 "role": {
@@ -3033,7 +3144,7 @@
                 "title"
             ]
         },
-        "TimelineEvent": {
+        "TimelineAtomEvent": {
             "type": "object",
             "properties": {
                 "title": {
@@ -3061,7 +3172,7 @@
                 "unixDate"
             ]
         },
-        "TimelineBlockElement": {
+        "FETimelineBlockElement": {
             "type": "object",
             "properties": {
                 "_type": {
@@ -3071,31 +3182,54 @@
                 "elementId": {
                     "type": "string"
                 },
-                "id": {
-                    "type": "string"
-                },
-                "title": {
-                    "type": "string"
-                },
-                "description": {
-                    "type": "string"
-                },
-                "events": {
+                "sections": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/TimelineEvent"
+                        "type": "object",
+                        "properties": {
+                            "title": {
+                                "type": "string"
+                            },
+                            "events": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "title": {
+                                            "type": "string"
+                                        },
+                                        "date": {
+                                            "type": "string"
+                                        },
+                                        "label": {
+                                            "type": "string"
+                                        },
+                                        "main": {
+                                            "$ref": "#/definitions/FEElement"
+                                        },
+                                        "body": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/FEElement"
+                                            }
+                                        }
+                                    },
+                                    "required": [
+                                        "body"
+                                    ]
+                                }
+                            }
+                        },
+                        "required": [
+                            "events"
+                        ]
                     }
-                },
-                "role": {
-                    "$ref": "#/definitions/RoleType"
                 }
             },
             "required": [
                 "_type",
                 "elementId",
-                "events",
-                "id",
-                "title"
+                "sections"
             ]
         },
         "TweetBlockElement": {

--- a/dotcom-rendering/src/model/block-schema.json
+++ b/dotcom-rendering/src/model/block-schema.json
@@ -229,10 +229,6 @@
                             "type": "string",
                             "const": "model.dotcomrendering.pageElements.DCRTimelineBlockElement"
                         },
-                        "timelineKind": {
-                            "type": "string",
-                            "const": "flat"
-                        },
                         "events": {
                             "type": "array",
                             "items": {
@@ -266,8 +262,7 @@
                     },
                     "required": [
                         "_type",
-                        "events",
-                        "timelineKind"
+                        "events"
                     ]
                 },
                 {
@@ -275,11 +270,7 @@
                     "properties": {
                         "_type": {
                             "type": "string",
-                            "const": "model.dotcomrendering.pageElements.DCRTimelineBlockElement"
-                        },
-                        "timelineKind": {
-                            "type": "string",
-                            "const": "sectioned"
+                            "const": "model.dotcomrendering.pageElements.DCRSectionedTimelineBlockElement"
                         },
                         "sections": {
                             "type": "array",
@@ -329,8 +320,7 @@
                     },
                     "required": [
                         "_type",
-                        "sections",
-                        "timelineKind"
+                        "sections"
                     ]
                 },
                 {

--- a/dotcom-rendering/src/model/block-schema.json
+++ b/dotcom-rendering/src/model/block-schema.json
@@ -220,7 +220,118 @@
                     "$ref": "#/definitions/TimelineAtomBlockElement"
                 },
                 {
-                    "$ref": "#/definitions/TimelineBlockElement"
+                    "$ref": "#/definitions/FETimelineBlockElement"
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "_type": {
+                            "type": "string",
+                            "const": "model.dotcomrendering.pageElements.DCRTimelineBlockElement"
+                        },
+                        "timelineKind": {
+                            "type": "string",
+                            "const": "flat"
+                        },
+                        "events": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "date": {
+                                        "type": "string"
+                                    },
+                                    "title": {
+                                        "type": "string"
+                                    },
+                                    "label": {
+                                        "type": "string"
+                                    },
+                                    "main": {
+                                        "$ref": "#/definitions/FEElement"
+                                    },
+                                    "body": {
+                                        "type": "array",
+                                        "items": {
+                                            "$ref": "#/definitions/FEElement"
+                                        }
+                                    }
+                                },
+                                "required": [
+                                    "body",
+                                    "date"
+                                ]
+                            }
+                        }
+                    },
+                    "required": [
+                        "_type",
+                        "events",
+                        "timelineKind"
+                    ]
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "_type": {
+                            "type": "string",
+                            "const": "model.dotcomrendering.pageElements.DCRTimelineBlockElement"
+                        },
+                        "timelineKind": {
+                            "type": "string",
+                            "const": "sectioned"
+                        },
+                        "sections": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "title": {
+                                        "type": "string"
+                                    },
+                                    "events": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "date": {
+                                                    "type": "string"
+                                                },
+                                                "title": {
+                                                    "type": "string"
+                                                },
+                                                "label": {
+                                                    "type": "string"
+                                                },
+                                                "main": {
+                                                    "$ref": "#/definitions/FEElement"
+                                                },
+                                                "body": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "$ref": "#/definitions/FEElement"
+                                                    }
+                                                }
+                                            },
+                                            "required": [
+                                                "body",
+                                                "date"
+                                            ]
+                                        }
+                                    }
+                                },
+                                "required": [
+                                    "events",
+                                    "title"
+                                ]
+                            }
+                        }
+                    },
+                    "required": [
+                        "_type",
+                        "sections",
+                        "timelineKind"
+                    ]
                 },
                 {
                     "$ref": "#/definitions/TweetBlockElement"
@@ -2607,7 +2718,7 @@
                 "events": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/TimelineEvent"
+                        "$ref": "#/definitions/TimelineAtomEvent"
                     }
                 },
                 "role": {
@@ -2622,7 +2733,7 @@
                 "title"
             ]
         },
-        "TimelineEvent": {
+        "TimelineAtomEvent": {
             "type": "object",
             "properties": {
                 "title": {
@@ -2650,7 +2761,7 @@
                 "unixDate"
             ]
         },
-        "TimelineBlockElement": {
+        "FETimelineBlockElement": {
             "type": "object",
             "properties": {
                 "_type": {
@@ -2660,31 +2771,54 @@
                 "elementId": {
                     "type": "string"
                 },
-                "id": {
-                    "type": "string"
-                },
-                "title": {
-                    "type": "string"
-                },
-                "description": {
-                    "type": "string"
-                },
-                "events": {
+                "sections": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/TimelineEvent"
+                        "type": "object",
+                        "properties": {
+                            "title": {
+                                "type": "string"
+                            },
+                            "events": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "title": {
+                                            "type": "string"
+                                        },
+                                        "date": {
+                                            "type": "string"
+                                        },
+                                        "label": {
+                                            "type": "string"
+                                        },
+                                        "main": {
+                                            "$ref": "#/definitions/FEElement"
+                                        },
+                                        "body": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/FEElement"
+                                            }
+                                        }
+                                    },
+                                    "required": [
+                                        "body"
+                                    ]
+                                }
+                            }
+                        },
+                        "required": [
+                            "events"
+                        ]
                     }
-                },
-                "role": {
-                    "$ref": "#/definitions/RoleType"
                 }
             },
             "required": [
                 "_type",
                 "elementId",
-                "events",
-                "id",
-                "title"
+                "sections"
             ]
         },
         "TweetBlockElement": {

--- a/dotcom-rendering/src/model/enhanceBlocks.ts
+++ b/dotcom-rendering/src/model/enhanceBlocks.ts
@@ -13,6 +13,7 @@ import { enhanceInteractiveContentsElements } from './enhance-interactive-conten
 import { enhanceNumberedLists } from './enhance-numbered-lists';
 import { enhanceTweets } from './enhance-tweets';
 import { enhanceLists } from './enhanceLists';
+import { enhanceTimelines } from './enhanceTimelines';
 import { insertPromotedNewsletter } from './insertPromotedNewsletter';
 
 type Options = {
@@ -46,6 +47,7 @@ export const enhanceElements =
 	(elements: FEElement[]): FEElement[] =>
 		[
 			enhanceLists(enhanceElements(format, blockId, options)),
+			enhanceTimelines(enhanceElements(format, blockId, options)),
 			enhanceDividers,
 			enhanceH2s,
 			enhanceInteractiveContentsElements,

--- a/dotcom-rendering/src/model/enhanceTimelines.ts
+++ b/dotcom-rendering/src/model/enhanceTimelines.ts
@@ -1,4 +1,5 @@
 import type {
+	DCRSectionedTimelineBlockElement,
 	DCRTimelineBlockElement,
 	DCRTimelineEvent,
 	DCRTimelineSection,
@@ -54,7 +55,7 @@ const enhanceTimelineSection =
 const enhanceTimelineBlockElement = (
 	element: FETimelineBlockElement,
 	elementsEnhancer: ElementsEnhancer,
-): DCRTimelineBlockElement[] => {
+): DCRTimelineBlockElement[] | DCRSectionedTimelineBlockElement[] => {
 	const [firstSection, ...otherSections] = element.sections;
 
 	// A timeline must have some content! If it doesn't we drop it.
@@ -70,7 +71,6 @@ const enhanceTimelineBlockElement = (
 		return [
 			{
 				_type: 'model.dotcomrendering.pageElements.DCRTimelineBlockElement',
-				timelineKind: 'flat',
 				events: firstSection.events.flatMap(
 					enhanceTimelineEvent(elementsEnhancer),
 				),
@@ -80,8 +80,7 @@ const enhanceTimelineBlockElement = (
 
 	return [
 		{
-			_type: 'model.dotcomrendering.pageElements.DCRTimelineBlockElement',
-			timelineKind: 'sectioned',
+			_type: 'model.dotcomrendering.pageElements.DCRSectionedTimelineBlockElement',
 			sections: element.sections.flatMap(
 				enhanceTimelineSection(elementsEnhancer),
 			),

--- a/dotcom-rendering/src/model/enhanceTimelines.ts
+++ b/dotcom-rendering/src/model/enhanceTimelines.ts
@@ -1,0 +1,103 @@
+import type {
+	DCRTimelineBlockElement,
+	DCRTimelineEvent,
+	DCRTimelineSection,
+	FEElement,
+	FETimelineBlockElement,
+	FETimelineEvent,
+	FETimelineSection,
+} from '../types/content';
+
+type ElementsEnhancer = (elements: FEElement[]) => FEElement[];
+
+const enhanceTimelineEvent =
+	(enhanceElements: ElementsEnhancer) =>
+	({
+		date,
+		title,
+		label,
+		main,
+		body,
+	}: FETimelineEvent): DCRTimelineEvent[] => {
+		// A timeline event must have a date! If it doesn't we drop it.
+		if (date === undefined) {
+			return [];
+		}
+
+		return [
+			{
+				date,
+				title,
+				label,
+				main,
+				body: enhanceElements(body),
+			},
+		];
+	};
+
+const enhanceTimelineSection =
+	(elementsEnhancer: ElementsEnhancer) =>
+	({ title, events }: FETimelineSection): DCRTimelineSection[] => {
+		// A timeline section must have a title! If it doesn't we drop it.
+		if (title === undefined) {
+			return [];
+		}
+
+		return [
+			{
+				title,
+				events: events.flatMap(enhanceTimelineEvent(elementsEnhancer)),
+			},
+		];
+	};
+
+const enhanceTimelineBlockElement = (
+	element: FETimelineBlockElement,
+	elementsEnhancer: ElementsEnhancer,
+): DCRTimelineBlockElement[] => {
+	const [firstSection, ...otherSections] = element.sections;
+
+	// A timeline must have some content! If it doesn't we drop it.
+	if (firstSection === undefined) {
+		return [];
+	}
+
+	/* A timeline with one section is "flat", it's not considered to be split
+	 * into sections. It's just represented as having one section for CAPI
+	 * modelling reasons, but we can model it more specifically here.
+	 */
+	if (otherSections.length === 0) {
+		return [
+			{
+				_type: 'model.dotcomrendering.pageElements.DCRTimelineBlockElement',
+				timelineKind: 'flat',
+				events: firstSection.events.flatMap(
+					enhanceTimelineEvent(elementsEnhancer),
+				),
+			},
+		];
+	}
+
+	return [
+		{
+			_type: 'model.dotcomrendering.pageElements.DCRTimelineBlockElement',
+			timelineKind: 'sectioned',
+			sections: element.sections.flatMap(
+				enhanceTimelineSection(elementsEnhancer),
+			),
+		},
+	];
+};
+
+const enhance =
+	(elementsEnhancer: ElementsEnhancer) =>
+	(element: FEElement): FEElement[] =>
+		element._type ===
+		'model.dotcomrendering.pageElements.TimelineBlockElement'
+			? enhanceTimelineBlockElement(element, elementsEnhancer)
+			: [element];
+
+export const enhanceTimelines =
+	(elementsEnhancer: ElementsEnhancer) =>
+	(elements: FEElement[]): FEElement[] =>
+		elements.flatMap(enhance(elementsEnhancer));

--- a/dotcom-rendering/src/types/content.ts
+++ b/dotcom-rendering/src/types/content.ts
@@ -501,17 +501,15 @@ export type DCRTimelineSection = {
 	events: DCRTimelineEvent[];
 };
 
-export type DCRTimelineBlockElement =
-	| {
-			_type: 'model.dotcomrendering.pageElements.DCRTimelineBlockElement';
-			timelineKind: 'flat';
-			events: DCRTimelineEvent[];
-	  }
-	| {
-			_type: 'model.dotcomrendering.pageElements.DCRTimelineBlockElement';
-			timelineKind: 'sectioned';
-			sections: DCRTimelineSection[];
-	  };
+export type DCRTimelineBlockElement = {
+	_type: 'model.dotcomrendering.pageElements.DCRTimelineBlockElement';
+	events: DCRTimelineEvent[];
+};
+
+export type DCRSectionedTimelineBlockElement = {
+	_type: 'model.dotcomrendering.pageElements.DCRSectionedTimelineBlockElement';
+	sections: DCRTimelineSection[];
+};
 
 export type FETimelineEvent = {
 	title?: string;
@@ -745,6 +743,7 @@ export type FEElement =
 	| TimelineAtomBlockElement
 	| FETimelineBlockElement
 	| DCRTimelineBlockElement
+	| DCRSectionedTimelineBlockElement
 	| TweetBlockElement
 	| VideoBlockElement
 	| VideoFacebookBlockElement

--- a/dotcom-rendering/src/types/content.ts
+++ b/dotcom-rendering/src/types/content.ts
@@ -488,14 +488,48 @@ export interface TextBlockElement {
 	html: string;
 }
 
-export interface TimelineBlockElement {
+export type DCRTimelineEvent = {
+	date: string;
+	title?: string;
+	label?: string;
+	main?: FEElement;
+	body: FEElement[];
+};
+
+export type DCRTimelineSection = {
+	title: string;
+	events: DCRTimelineEvent[];
+};
+
+export type DCRTimelineBlockElement =
+	| {
+			_type: 'model.dotcomrendering.pageElements.DCRTimelineBlockElement';
+			timelineKind: 'flat';
+			events: DCRTimelineEvent[];
+	  }
+	| {
+			_type: 'model.dotcomrendering.pageElements.DCRTimelineBlockElement';
+			timelineKind: 'sectioned';
+			sections: DCRTimelineSection[];
+	  };
+
+export type FETimelineEvent = {
+	title?: string;
+	date?: string;
+	label?: string;
+	main?: FEElement;
+	body: FEElement[];
+};
+
+export type FETimelineSection = {
+	title?: string;
+	events: FETimelineEvent[];
+};
+
+export interface FETimelineBlockElement {
 	_type: 'model.dotcomrendering.pageElements.TimelineBlockElement';
 	elementId: string;
-	id: string;
-	title: string;
-	description?: string;
-	events: TimelineEvent[];
-	role?: RoleType;
+	sections: FETimelineSection[];
 }
 
 export interface TimelineAtomBlockElement {
@@ -504,7 +538,7 @@ export interface TimelineAtomBlockElement {
 	id: string;
 	title: string;
 	description?: string;
-	events: TimelineEvent[];
+	events: TimelineAtomEvent[];
 	role?: RoleType;
 }
 
@@ -709,7 +743,8 @@ export type FEElement =
 	| TableBlockElement
 	| TextBlockElement
 	| TimelineAtomBlockElement
-	| TimelineBlockElement
+	| FETimelineBlockElement
+	| DCRTimelineBlockElement
 	| TweetBlockElement
 	| VideoBlockElement
 	| VideoFacebookBlockElement
@@ -780,7 +815,7 @@ interface VideoAssets {
 	};
 }
 
-export interface TimelineEvent {
+export interface TimelineAtomEvent {
 	title: string;
 	date: string;
 	unixDate: number;
@@ -791,7 +826,7 @@ export interface TimelineEvent {
 
 export type TimelineAtomType = {
 	id: string;
-	events?: TimelineEvent[];
+	events?: TimelineAtomEvent[];
 	title: string;
 	description?: string;
 	expandForStorybook?: boolean;


### PR DESCRIPTION
First, renamed the `TimelineEvent` type used by timeline atoms to `TimelineAtomEvent` to avoid confusion.

Then removed the now-unused `TimelineBlockElement` and replaced it with `FETimelineBlockElement`, to represent the new element coming from frontend, and `DCRTimelineBlockElement`, to represent the parsed/enhanced version in DCR. The DCR version is stricter than the one coming from frontend, enforcing the following rules:

- Timeline events must have a date
- Timeline sections must have a title
- Timelines with one section should be flattened into a single list of events

Finally, added an enhancer module for timelines to convert from the frontend type to the DCR one.

Part of #10869. See https://github.com/guardian/content-api-models/pull/245 for the proposed CAPI model.
