### PR TITLE
Make Discussion chevrons nicer

### DIFF
--- a/dotcom-rendering/src/components/Discussion/Pagination.tsx
+++ b/dotcom-rendering/src/components/Discussion/Pagination.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import { space, textSans, until } from '@guardian/source-foundations';
+import type { ThemeButton } from '@guardian/source-react-components';
 import {
 	Button,
 	SvgChevronLeftSingle,
@@ -47,48 +48,13 @@ const pageButtonStyles = (isSelected: boolean) => css`
 	text-overflow: ellipsis;
 `;
 
-const chevronButtonStyles = ({ isSelected }: { isSelected: boolean }) => css`
-	margin-right: ${space[1]}px;
-
-	border-radius: 62.5rem;
-	border-width: 1px;
-	border-style: solid;
-	border-color: ${schemedPalette('--discussion-pagination-border')};
-	background-color: ${isSelected
-		? schemedPalette('--discussion-pagination-text')
-		: schemedPalette('--discussion-pagination-background')};
-	height: 22px;
-	min-height: 22px;
-	width: 22px;
-
-	/* Override some of src's properties */
-	> button {
-		height: 22px;
-		min-height: 22px;
-		width: 22px;
-		color: ${schemedPalette('--discussion-pagination-text')};
-	}
-
-	:hover {
-		border-color: ${schemedPalette('--discussion-pagination-border-hover')};
-	}
-
-	& svg {
-		/* Make the chevrons grey */
-		fill: currentColor;
-		/* Set the dimensions */
-		width: 22px;
-		height: 22px;
-	}
-`;
-
-const shiftRight = css`
-	/* The right chevron svg positions it's path in such a way that makes the alignment look
-    off. So here we shift it slightly to the right to fix that     */
-	& svg {
-		margin-left: 2px;
-	}
-`;
+const theme = {
+	borderTertiary: schemedPalette('--discussion-pagination-border'),
+	backgroundTertiaryHover: schemedPalette(
+		'--discussion-pagination-background',
+	),
+	textTertiary: schemedPalette('--discussion-pagination-text'),
+} satisfies Partial<ThemeButton>;
 
 const elipsisStyles = css`
 	line-height: 26px;
@@ -113,6 +79,10 @@ const paginationButtons = css`
 	display: flex;
 	flex-direction: row;
 	height: 25px;
+
+	button:hover {
+		border-color: ${schemedPalette('--discussion-pagination-border-hover')};
+	}
 `;
 
 const paginationText = css`
@@ -130,17 +100,32 @@ const Forward = ({
 	currentPage: number;
 	setCurrentPage: Props['setCurrentPage'];
 }) => (
-	<div css={[chevronButtonStyles({ isSelected: false }), shiftRight]}>
-		<Button
-			onClick={() => setCurrentPage(currentPage + 1)}
-			aria-label="Previous discussion page"
-			data-link-name={`Pagination view page ${currentPage + 1}`}
-			size="xsmall"
-			priority="subdued"
-		>
-			<SvgChevronRightSingle />
-		</Button>
-	</div>
+	<Button
+		onClick={() => setCurrentPage(currentPage + 1)}
+		data-link-name={`Pagination view page ${currentPage + 1}`}
+		size="xsmall"
+		priority="tertiary"
+		theme={theme}
+		// @TODO: These overrides should be removed once fixed upstream
+		cssOverrides={css`
+			/* theme does not support Tertiary background */
+			background-color: ${schemedPalette(
+				'--discussion-pagination-background',
+			)};
+			/* the icon is not perfectly centred */
+			svg {
+				transform: translateX(1px);
+			}
+		`}
+		icon={
+			<SvgChevronRightSingle
+				theme={{ fill: schemedPalette('--discussion-pagination-text') }}
+			/>
+		}
+		hideLabel={true}
+	>
+		Previous discussion page
+	</Button>
 );
 
 const Back = ({
@@ -149,23 +134,34 @@ const Back = ({
 }: {
 	currentPage: number;
 	setCurrentPage: Props['setCurrentPage'];
-}) => {
-	const newPage = Math.max(0, currentPage - 1);
-
-	return (
-		<div css={chevronButtonStyles({ isSelected: false })}>
-			<Button
-				onClick={() => setCurrentPage(newPage)}
-				aria-label="Previous discussion page"
-				data-link-name={`Pagination view page ${newPage}`}
-				size="xsmall"
-				priority="subdued"
-			>
-				<SvgChevronLeftSingle />
-			</Button>
-		</div>
-	);
-};
+}) => (
+	<Button
+		onClick={() => setCurrentPage(currentPage - 1)}
+		data-link-name={`Pagination view page ${currentPage - 1}`}
+		size="xsmall"
+		priority="tertiary"
+		theme={theme}
+		// @TODO: These overrides should be removed once fixed upstream
+		cssOverrides={css`
+			/* theme does not support Tertiary background */
+			background-color: ${schemedPalette(
+				'--discussion-pagination-background',
+			)};
+			/* the icon is not perfectly centred */
+			svg {
+				transform: translateX(-1px);
+			}
+		`}
+		icon={
+			<SvgChevronLeftSingle
+				theme={{ fill: schemedPalette('--discussion-pagination-text') }}
+			/>
+		}
+		hideLabel={true}
+	>
+		Previous discussion page
+	</Button>
+);
 
 const PageButton = ({
 	currentPage,


### PR DESCRIPTION
## What does this change?

- Visually align the chevron to the centre
- Simplify the DOM and use Source `<Button>` directly

## Why?

Fixes #10072 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/76776/946ed412-4253-406d-8b6d-3478f87af4ad
[after]: https://github.com/guardian/dotcom-rendering/assets/76776/5e475b33-8d7b-485e-80f9-81d502bc29f3