### PR TITLE
Fix miss-aligned right ads on apps tablet

### DIFF
--- a/dotcom-rendering/src/components/AdPortals.importable.tsx
+++ b/dotcom-rendering/src/components/AdPortals.importable.tsx
@@ -208,13 +208,18 @@ export const AdPortals = ({
 			});
 
 			resizeObserver.observe(document.body);
-			if (rightAdPlaceholder) {
+
+			/**
+			 *  Observe the rightAdPlaceholder which contains most viewed, which may render after the
+			 *  ad portals have been set up (pushing down the ad slots)
+			 **/
+			if (tryRightAligned && rightAdPlaceholder) {
 				resizeObserver.observe(rightAdPlaceholder);
 			}
 		}
 
 		return () => resizeObserver?.disconnect();
-	}, [adPlaceholders, rightAdPlaceholder]);
+	}, [adPlaceholders, rightAdPlaceholder, tryRightAligned]);
 
 	const handleClickSupportButton = () => {
 		void getAcquisitionsClient()

--- a/dotcom-rendering/src/components/AdPortals.importable.tsx
+++ b/dotcom-rendering/src/components/AdPortals.importable.tsx
@@ -208,10 +208,13 @@ export const AdPortals = ({
 			});
 
 			resizeObserver.observe(document.body);
+			if (rightAdPlaceholder) {
+				resizeObserver.observe(rightAdPlaceholder);
+			}
 		}
 
 		return () => resizeObserver?.disconnect();
-	}, [adPlaceholders]);
+	}, [adPlaceholders, rightAdPlaceholder]);
 
 	const handleClickSupportButton = () => {
 		void getAcquisitionsClient()


### PR DESCRIPTION
## What does this change?
Add the `rightAdPlaceholder` element to the observer that will update ad positions

## Why?
When the most viewed data is not cached, it will load after the ad portals have been setup. And as the ads are in the same container, aligned with flexbox when it renders it pushes down the ad slots, but the positions are not updated with the native layer.

Recording with throttled network and clean cache to show what's going on:

https://github.com/guardian/dotcom-rendering/assets/1731150/3f04f340-ca25-49e1-b80c-019067e49889

Partially addresses #10105

## Screenshots


| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/1731150/e91ccdf0-1283-418d-bbd0-fc8435900420
[after]: https://github.com/guardian/dotcom-rendering/assets/1731150/41e71ecc-05da-4bc6-86a7-d5ce7085380d


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
