### PR TITLE
Epic: support url querystring

### DIFF
--- a/dotcom-rendering/src/components/marketing/epics/ContributionsEpicButtons.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ContributionsEpicButtons.tsx
@@ -18,6 +18,7 @@ import { useIsInView } from '../../../lib/useIsInView';
 import type { ChoiceCardSelection } from '../lib/choiceCards';
 import { hasSetReminder } from '../lib/reminders';
 import {
+	addChoiceCardsParams,
 	addRegionIdAndTrackingParamsToSupportUrl,
 	isSupportUrl,
 } from '../lib/tracking';
@@ -182,7 +183,11 @@ export const ContributionsEpicButtons = ({
 		showChoiceCards && choiceCardSelection
 			? {
 					text: cta.text,
-					baseUrl: `${cta.baseUrl}?selected-contribution-type=${choiceCardSelection.frequency}&selected-amount=${choiceCardSelection.amount}`,
+					baseUrl: addChoiceCardsParams(
+						cta.baseUrl,
+						choiceCardSelection.frequency,
+						choiceCardSelection.amount,
+					),
 			  }
 			: cta;
 

--- a/dotcom-rendering/src/components/marketing/lib/tracking.test.ts
+++ b/dotcom-rendering/src/components/marketing/lib/tracking.test.ts
@@ -1,0 +1,25 @@
+import { addChoiceCardsParams } from './tracking';
+
+describe('addChoiceCardsParams', () => {
+	it('adds choice cards params to url without existing querystring', () => {
+		const result = addChoiceCardsParams(
+			'https://support.theguardian.com/contribute',
+			'ONE_OFF',
+			5,
+		);
+		expect(result).toEqual(
+			'https://support.theguardian.com/contribute?selected-contribution-type=ONE_OFF&selected-amount=5',
+		);
+	});
+
+	it('adds choice cards params to url with existing querystring', () => {
+		const result = addChoiceCardsParams(
+			'https://support.theguardian.com/contribute?test=test',
+			'ONE_OFF',
+			5,
+		);
+		expect(result).toEqual(
+			'https://support.theguardian.com/contribute?test=test&selected-contribution-type=ONE_OFF&selected-amount=5',
+		);
+	});
+});

--- a/dotcom-rendering/src/components/marketing/lib/tracking.ts
+++ b/dotcom-rendering/src/components/marketing/lib/tracking.ts
@@ -8,6 +8,7 @@ import { addRegionIdToSupportUrl } from '@guardian/support-dotcom-components';
 import type {
 	BannerTest,
 	BannerVariant,
+	ContributionFrequency,
 	EpicTest,
 	EpicVariant,
 	TargetingAbTest,
@@ -211,6 +212,16 @@ export const addProfileTrackingParams = (
 	return `${baseUrl}${alreadyHasQueryString ? '&' : '?'}${queryString.join(
 		'&',
 	)}`;
+};
+
+export const addChoiceCardsParams = (
+	url: string,
+	frequency: ContributionFrequency,
+	amount: number | 'other',
+): string => {
+	const newParams = `selected-contribution-type=${frequency}&selected-amount=${amount}`;
+	const alreadyHasQueryString = url.includes('?');
+	return `${url}${alreadyHasQueryString ? '&' : '?'}${newParams}`;
 };
 
 export const isProfileUrl = (baseUrl: string): boolean =>


### PR DESCRIPTION
Currently the Epic choice cards CTA does not support a query string in the url - this means we cannot add a promoCode to the query string from the RRCP.

There is an [equivalent PR](https://github.com/guardian/support-dotcom-components/pull/1090) in support-dotcom-components, because currently the components are split across there and DCR.