### PR TITLE
change codeowners for marketing components

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,7 +7,7 @@
 # These folders and all their contents are owned by the following teams.
 /dotcom-rendering/ 								@guardian/dotcom-platform
 /apps-rendering/ 								@guardian/dotcom-platform
-/dotcom-rendering/src/components/marketing/ 	@guardian/tx-engineers
+/dotcom-rendering/src/components/marketing/ 	@guardian/supporter-revenue-stream
 /dotcom-rendering/src/client/userFeatures/ 		@guardian/supporter-revenue-stream
 
 # These file types, wherever they are, are co-owned by the following teams.


### PR DESCRIPTION
the TX team no longer exists