### PR TITLE
Playwright uses DEV server locally and starts the server

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -33,6 +33,8 @@ jobs:
       - name: Run Playwright
         run: pnpm playwright test --shard=${{ matrix.group }}/8
         working-directory: ./dotcom-rendering
+        env:
+          NODE_ENV: production
 
       - uses: actions/upload-artifact@v4
         if: always()

--- a/dotcom-rendering/docs/testing.md
+++ b/dotcom-rendering/docs/testing.md
@@ -75,32 +75,14 @@ The first time you run Playwright you will be asked to install a local browser, 
 
 `pnpm playwright install chromium`
 
-Running Playwright locally requires having a DCR server running.
-
-#### Against the PROD server
+Running Playwright locally will automatically start the dev server.
 
 To run the tests on the command line in headless mode:
 
-`make playwright`
+`make playwright-run`
 
-To run the tests in the Playwright UI:
+To open the tests in the Playwright UI:
 
 `make playwright-open`
 
-Changes to the tests will hot reload in the Playwright UI but not changes to the DCR code.
-
-If you want to update the DCR code the server will need to be re-built using `make build`.
-
-#### Against the DEV server
-
-To enable hot reloading of the DCR code _and_ the test code:
-
-Edit `load-page.ts` to change the port to the dev server port 3030
-
-To run the tests on the command line in headless mode:
-
-`pnpm playwright:run`
-
-To run the tests in the Playwright UI:
-
-`pnpm playwright:open`
+Changes to the tests and implementation code will hot reload.

--- a/dotcom-rendering/makefile
+++ b/dotcom-rendering/makefile
@@ -72,13 +72,13 @@ storybook-dev: clear clean-dist install
 
 # tests #####################################
 
-playwright: clear clean-dist install build
-	$(call log, "starting PROD server for Playwright")
-	@NODE_ENV=production DISABLE_LOGGING_AND_METRICS=true start-server-and-test 'node dist/server.js' 9000 'playwright test'
+playwright-run:
+	$(call log, "starting DEV server and running Playwright tests")
+	@pnpm playwright:run
 
 playwright-open: clear clean-dist install build
-	$(call log, "starting PROD server and opening Playwright")
-	@NODE_ENV=production DISABLE_LOGGING_AND_METRICS=true start-server-and-test 'node dist/server.js' 9000 'playwright test --ui'
+	$(call log, "starting DEV server and opening Playwright UI")
+	@pnpm playwright:open
 
 ampValidation: clean-dist install
 	$(call log, "starting AMP Validation test")

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -203,7 +203,6 @@
 		"serve-static": "1.15.0",
 		"simple-progress-webpack-plugin": "2.0.0",
 		"source-map": "0.7.4",
-		"start-server-and-test": "2.0.3",
 		"storybook": "7.6.17",
 		"stylelint": "16.1.0",
 		"stylelint-config-recommended": "14.0.0",

--- a/dotcom-rendering/playwright.config.ts
+++ b/dotcom-rendering/playwright.config.ts
@@ -1,9 +1,9 @@
 import { defineConfig, devices } from '@playwright/test';
 
+const isDev = process.env.NODE_ENV !== 'production';
 /**
  * The server port for local development or CI
  */
-const isDev = process.env.NODE_ENV !== 'production';
 export const PORT = isDev ? 3030 : 9000;
 
 /**

--- a/dotcom-rendering/playwright.config.ts
+++ b/dotcom-rendering/playwright.config.ts
@@ -1,6 +1,12 @@
 import { defineConfig, devices } from '@playwright/test';
 
 /**
+ * The server port for local development or CI
+ */
+const isDev = process.env.NODE_ENV !== 'production';
+export const PORT = isDev ? 3030 : 9000;
+
+/**
  * See https://playwright.dev/docs/test-configuration.
  */
 export default defineConfig({
@@ -32,4 +38,12 @@ export default defineConfig({
 			use: { ...devices['Desktop Chrome'] },
 		},
 	],
+	webServer: {
+		// On CI the server is already started so a no-op
+		command: isDev ? 'make dev' : ':',
+		url: `http://localhost:${PORT}`,
+		reuseExistingServer: true,
+		stdout: 'pipe',
+		stderr: 'pipe',
+	},
 });

--- a/dotcom-rendering/playwright/lib/load-page.ts
+++ b/dotcom-rendering/playwright/lib/load-page.ts
@@ -2,7 +2,10 @@ import type { Page } from '@playwright/test';
 import { validateAsArticleType } from '../../src/model/validate';
 import type { DCRArticle, FEArticleType } from '../../src/types/frontend';
 
-const PORT = 9000;
+/**
+ * The server port for CI or local development
+ */
+const PORT = process.env.NODE_ENV === 'production' ? 9000 : 3030;
 const BASE_URL = `http://localhost:${PORT}`;
 
 /**

--- a/dotcom-rendering/playwright/lib/load-page.ts
+++ b/dotcom-rendering/playwright/lib/load-page.ts
@@ -1,11 +1,8 @@
 import type { Page } from '@playwright/test';
+import { PORT } from 'playwright.config';
 import { validateAsArticleType } from '../../src/model/validate';
 import type { DCRArticle, FEArticleType } from '../../src/types/frontend';
 
-/**
- * The server port for CI or local development
- */
-const PORT = process.env.NODE_ENV === 'production' ? 9000 : 3030;
 const BASE_URL = `http://localhost:${PORT}`;
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -818,9 +818,6 @@ importers:
       source-map:
         specifier: 0.7.4
         version: 0.7.4
-      start-server-and-test:
-        specifier: 2.0.3
-        version: 2.0.3
       storybook:
         specifier: 7.6.17
         version: 7.6.17
@@ -4771,16 +4768,6 @@ packages:
     resolution: {integrity: sha512-RauppalK+cQZDRK6IssVmDSnU/VyqMNuVOxPxhmI03kVRxEdwcmBuRqexHwDbnClVUxW/N9hYLbFNuAb9V/p+A==}
     dev: false
 
-  /@hapi/hoek@9.3.0:
-    resolution: {integrity: sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==}
-    dev: false
-
-  /@hapi/topo@5.1.0:
-    resolution: {integrity: sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==}
-    dependencies:
-      '@hapi/hoek': 9.3.0
-    dev: false
-
   /@humanwhocodes/config-array@0.11.13:
     resolution: {integrity: sha512-JSBDMiDKSzQVngfRjOdFXgFfklaXI4K9nLF49Auh21lmBWRLIK3+xTErTWD4KU54pb6coM6ESE7Awz/FNU3zgQ==}
     engines: {node: '>=10.10.0'}
@@ -5983,20 +5970,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       '@sentry/types': 7.75.1
-    dev: false
-
-  /@sideway/address@4.1.4:
-    resolution: {integrity: sha512-7vwq+rOHVWjyXxVlR76Agnvhy8I9rpzjosTESvmhNeXOXdZZB15Fl+TI9x1SiHZH5Jv2wTGduSxFDIaq0m3DUw==}
-    dependencies:
-      '@hapi/hoek': 9.3.0
-    dev: false
-
-  /@sideway/formula@3.0.1:
-    resolution: {integrity: sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==}
-    dev: false
-
-  /@sideway/pinpoint@2.0.0:
-    resolution: {integrity: sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==}
     dev: false
 
   /@sinclair/typebox@0.27.8:
@@ -9571,10 +9544,6 @@ packages:
     resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
     dev: false
 
-  /arg@5.0.2:
-    resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
-    dev: false
-
   /argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
     dependencies:
@@ -9803,16 +9772,6 @@ packages:
   /axe-core@4.8.2:
     resolution: {integrity: sha512-/dlp0fxyM3R8YW7MFzaHWXrf4zzbr0vaYb23VBFCl83R7nWNPg/yaQw2Dc8jzCMmDVLhSdzH8MjrsuIUuvX+6g==}
     engines: {node: '>=4'}
-    dev: false
-
-  /axios@1.6.2(debug@4.3.4):
-    resolution: {integrity: sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==}
-    dependencies:
-      follow-redirects: 1.15.4(debug@4.3.4)
-      form-data: 4.0.0
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
     dev: false
 
   /axobject-query@3.2.1:
@@ -10095,10 +10054,6 @@ packages:
       buffer: 5.7.1
       inherits: 2.0.4
       readable-stream: 3.6.2
-    dev: false
-
-  /bluebird@3.7.2:
-    resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
     dev: false
 
   /body-parser@1.20.1:
@@ -10417,11 +10372,6 @@ packages:
 
   /chardet@0.7.0:
     resolution: {integrity: sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==}
-    dev: false
-
-  /check-more-types@2.24.0:
-    resolution: {integrity: sha512-Pj779qHxV2tuapviy1bSZNEL1maXr13bPYpsvSDB68HlYcYuhlDrmGd63i0JHMCLKzc7rUSNIrpdJlhVlNwrxA==}
-    engines: {node: '>= 0.8.0'}
     dev: false
 
   /chokidar@3.6.0:
@@ -12455,18 +12405,6 @@ packages:
     engines: {node: '>= 0.6'}
     dev: false
 
-  /event-stream@3.3.4:
-    resolution: {integrity: sha512-QHpkERcGsR0T7Qm3HNJSyXKEEj8AHNxkY3PK8TS2KJvQ7NiSHe3DDpwVKKtoYprL/AreyzFBeIkBIWChAqn60g==}
-    dependencies:
-      duplexer: 0.1.2
-      from: 0.1.7
-      map-stream: 0.1.0
-      pause-stream: 0.0.11
-      split: 0.3.3
-      stream-combiner: 0.0.4
-      through: 2.3.8
-    dev: false
-
   /eventemitter3@4.0.7:
     resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
     dev: false
@@ -12956,7 +12894,7 @@ packages:
     resolution: {integrity: sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==}
     dev: false
 
-  /follow-redirects@1.15.4(debug@4.3.4):
+  /follow-redirects@1.15.4:
     resolution: {integrity: sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==}
     engines: {node: '>=4.0'}
     peerDependencies:
@@ -12964,8 +12902,6 @@ packages:
     peerDependenciesMeta:
       debug:
         optional: true
-    dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
     dev: false
 
   /for-each@0.3.3:
@@ -13031,10 +12967,6 @@ packages:
   /fresh@0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
-    dev: false
-
-  /from@0.1.7:
-    resolution: {integrity: sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==}
     dev: false
 
   /fs-constants@1.0.0:
@@ -13796,7 +13728,7 @@ packages:
     engines: {node: '>=8.0.0'}
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.4(debug@4.3.4)
+      follow-redirects: 1.15.4
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
@@ -14935,16 +14867,6 @@ packages:
     engines: {node: '>= 0.6.0'}
     dev: false
 
-  /joi@17.11.0:
-    resolution: {integrity: sha512-NgB+lZLNoqISVy1rZocE9PZI36bL/77ie924Ri43yEvi9GUUMPeyVIr8KdFTMUlby1p0PBYMk9spIxEUQYqrJQ==}
-    dependencies:
-      '@hapi/hoek': 9.3.0
-      '@hapi/topo': 5.1.0
-      '@sideway/address': 4.1.4
-      '@sideway/formula': 3.0.1
-      '@sideway/pinpoint': 2.0.0
-    dev: false
-
   /js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
     dev: false
@@ -15254,11 +15176,6 @@ packages:
     dependencies:
       picocolors: 1.0.0
       shell-quote: 1.8.1
-    dev: false
-
-  /lazy-ass@1.6.0:
-    resolution: {integrity: sha512-cc8oEVoctTvsFZ/Oje/kGnHbpWHYBe8IAJe4C0QNc3t8uM/0Y8+erSz/7Y1ALuXTEZTMvxXwO6YbX1ey3ujiZw==}
-    engines: {node: '> 0.8'}
     dev: false
 
   /lazy-universal-dotenv@4.0.0:
@@ -15639,10 +15556,6 @@ packages:
 
   /map-or-similar@1.5.0:
     resolution: {integrity: sha512-0aF7ZmVon1igznGI4VS30yugpduQW3y3GkcgGJOp7d8x8QrizhigUxjI/m2UojsXXto+jLAH3KSz+xOJTiORjg==}
-    dev: false
-
-  /map-stream@0.1.0:
-    resolution: {integrity: sha512-CkYQrPYZfWnu/DAmVCpTSX/xHpKZ80eKh2lAkyA6AJTef6bW+6JpbQZN5rofum7da+SyN1bi5ctTm+lTfcCW3g==}
     dev: false
 
   /markdown-to-jsx@7.3.2(react@18.2.0):
@@ -16777,12 +16690,6 @@ packages:
     resolution: {integrity: sha512-d+RQGp0MAYTIaDBIMmOfMwz3E+LOZnxx1HZd5R18mmCZY0QBlK0LDZfPc8FW8Ed2DlvsuE6PRjroDY+wg4+j/Q==}
     dev: false
 
-  /pause-stream@0.0.11:
-    resolution: {integrity: sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==}
-    dependencies:
-      through: 2.3.8
-    dev: false
-
   /peek-readable@5.0.0:
     resolution: {integrity: sha512-YtCKvLUOvwtMGmrniQPdO7MwPjgkFBtFIrmfSbYmYuq3tKDV/mcfAhBth1+C3ru7uXIZasc/pHnb+YDYNkkj4A==}
     engines: {node: '>=14.16'}
@@ -17128,14 +17035,6 @@ packages:
 
   /proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
-    dev: false
-
-  /ps-tree@1.2.0:
-    resolution: {integrity: sha512-0VnamPPYHl4uaU/nSFeZZpR21QAWRz+sRv4iW9+v/GS/J5U5iZB5BNN6J0RMoOvdx2gWM2+ZFMIm58q24e4UYA==}
-    engines: {node: '>= 0.10'}
-    hasBin: true
-    dependencies:
-      event-stream: 3.3.4
     dev: false
 
   /pseudomap@1.0.2:
@@ -18400,12 +18299,6 @@ packages:
     hasBin: true
     dev: false
 
-  /split@0.3.3:
-    resolution: {integrity: sha512-wD2AeVmxXRBoX44wAycgjVpMhvbwdI2aZjCkvfNcH1YqHQvJVa1duWc73OyVGJUc05fhFaTZeQ/PYsrmyH0JVA==}
-    dependencies:
-      through: 2.3.8
-    dev: false
-
   /sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
     dev: false
@@ -18423,23 +18316,6 @@ packages:
 
   /stackframe@1.3.4:
     resolution: {integrity: sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==}
-    dev: false
-
-  /start-server-and-test@2.0.3:
-    resolution: {integrity: sha512-QsVObjfjFZKJE6CS6bSKNwWZCKBG6975/jKRPPGFfFh+yOQglSeGXiNWjzgQNXdphcBI9nXbyso9tPfX4YAUhg==}
-    engines: {node: '>=16'}
-    hasBin: true
-    dependencies:
-      arg: 5.0.2
-      bluebird: 3.7.2
-      check-more-types: 2.24.0
-      debug: 4.3.4(supports-color@8.1.1)
-      execa: 5.1.1
-      lazy-ass: 1.6.0
-      ps-tree: 1.2.0
-      wait-on: 7.2.0(debug@4.3.4)
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /statuses@1.5.0:
@@ -18473,12 +18349,6 @@ packages:
       - encoding
       - supports-color
       - utf-8-validate
-    dev: false
-
-  /stream-combiner@0.0.4:
-    resolution: {integrity: sha512-rT00SPnTVyRsaSz5zgSPma/aHSOic5U1prhYdRy5HS2kTZviFpmDgzilbtsJsxiroqACmayynDN/9VzIbX5DOw==}
-    dependencies:
-      duplexer: 0.1.2
     dev: false
 
   /stream-shift@1.0.1:
@@ -19876,20 +19746,6 @@ packages:
     engines: {node: '>=14'}
     dependencies:
       xml-name-validator: 4.0.0
-    dev: false
-
-  /wait-on@7.2.0(debug@4.3.4):
-    resolution: {integrity: sha512-wCQcHkRazgjG5XoAq9jbTMLpNIjoSlZslrJ2+N9MxDsGEv1HnFoVjOCexL0ESva7Y9cu350j+DWADdk54s4AFQ==}
-    engines: {node: '>=12.0.0'}
-    hasBin: true
-    dependencies:
-      axios: 1.6.2(debug@4.3.4)
-      joi: 17.11.0
-      lodash: 4.17.21
-      minimist: 1.2.8
-      rxjs: 7.8.1
-    transitivePeerDependencies:
-      - debug
     dev: false
 
   /walker@1.0.8:


### PR DESCRIPTION
## What does this change?

We previously switched to using the PROD build (local and CI) for e2e tests to try to reduce flakiness here: https://github.com/guardian/dotcom-rendering/pull/3698

Since switching to Playwright I believe we can switch to the DEV build again for local development. CI will continue to use the PROD build but there _shouldn't_ be any functional difference between the two builds.

Using the dev build locally brings the following benefits:

- much quicker startup time: ~10s vs ~60s
- hot reloading of the test code and implementation code
- Playwright is able to start the server itself so we can remove the `start-server-and-test` dependency
- no requirement to run the prod build locally

The e2e tests are stable on CI but there are a handful of flaky tests when running locally (WIP), however the behaviour is the same whether they run against the PROD or DEV build.

## Screenshots

```
[WebServer] Done in 1.3s
[WebServer] Starting DEV server
[WebServer] DEV server running on http://localhost:3030
[WebServer] Building server bundle...
[WebServer] Building client.web bundle...
[WebServer] Building client.apps bundle...


Running 102 tests using 5 workers
  [1/102] … Verify elements have been hydrated › should open the edition dropdown menu when clicked and hide when expect
```


