### PR TITLE
Add script to generate report for bots

### DIFF
--- a/scripts/deno/bots.ts
+++ b/scripts/deno/bots.ts
@@ -93,7 +93,8 @@ async function* getRows(client: AthenaClient) {
   let count = ResultSet?.Rows?.length ?? 0
 
   while (NextToken) {
-	console.info(`Fetched ${count} rows`);
+	// `\r` overwrite the existing line to prevent a long log.
+	await Deno.stdout.write(new TextEncoder().encode(`\rFetched ${count.toLocaleString()} rows`));
     ({ ResultSet, NextToken } = await client.send(
       new GetQueryResultsCommand({ QueryExecutionId, NextToken }),
     ));

--- a/scripts/deno/bots.ts
+++ b/scripts/deno/bots.ts
@@ -1,0 +1,53 @@
+import {
+  AthenaClient,
+  GetQueryExecutionCommand,
+  GetQueryResultsCommand,
+  StartQueryExecutionCommand,
+} from "npm:@aws-sdk/client-athena";
+
+const client = new AthenaClient({
+  region: "eu-west-1",
+});
+
+Deno.env.set("AWS_PROFILE", "frontend");
+
+const { QueryExecutionId } = await client.send(
+  new StartQueryExecutionCommand({
+    QueryString: `SELECT
+	  count(1) request_count,
+	  COUNT (DISTINCT client_ip) distinct_ip_count,
+	  request_user_agent
+  FROM fastly_logs.fastly_www_theguardian_com_logs_json_partitioned
+  WHERE year = 2024
+	  AND month = 03
+	  AND day = 20
+  GROUP BY request_user_agent
+  ORDER BY request_count desc
+  LIMIT 100`,
+    ResultReuseConfiguration: {
+      ResultReuseByAgeConfiguration: { Enabled: true, MaxAgeInMinutes: 60 },
+    },
+  }),
+);
+
+if (!QueryExecutionId) throw "Could not get an executing ID";
+
+console.info({ QueryExecutionId });
+
+while (true) {
+  const { QueryExecution } = await client.send(
+    new GetQueryExecutionCommand({ QueryExecutionId }),
+  );
+
+  if (QueryExecution?.Status?.State === "SUCCEEDED") break;
+
+  console.info(QueryExecution?.Status?.State)
+
+  await new Promise((resolve) => setTimeout(resolve, 120));
+}
+
+const response = await client.send(
+  new GetQueryResultsCommand({ QueryExecutionId }),
+);
+
+console.info(response);

--- a/scripts/deno/bots.ts
+++ b/scripts/deno/bots.ts
@@ -7,7 +7,10 @@
  * You need Frontend Dev credentials to make the request to Athena.
  *
  * Run with the following command to bypass permission prompts:
- * `deno run --allow-sys=osRelease --allow-env --allow-net=athena.eu-west-1.amazonaws.com --allow-read --allow-write=. ./bots.ts`
+ * `deno run --allow-sys=osRelease --allow-env --allow-net=athena.eu-west-1.amazonaws.com --allow-read --allow-write=. ./bots.ts --date=2024-03-27`
+ *
+ * Note that the selected date should be within the last two weeks,
+ * as older data may not be in the standard storage class.
  */
 
 import {
@@ -17,12 +20,15 @@ import {
   ResultSet,
   StartQueryExecutionCommand,
 } from "npm:@aws-sdk/client-athena";
+import { parseArgs } from "https://deno.land/std@0.207.0/cli/parse_args.ts";
 
-const date = Temporal.Now.plainDateISO().subtract(
-  Temporal.Duration.from({ days: 3 }),
-);
+const flags = parseArgs(Deno.args, {
+	string: ["date"],
+})
 
-console.log("Three days ago:", date.toString());
+const date = Temporal.PlainDate.from(flags.date ?? "")
+
+console.info("Using", date);
 
 const client = new AthenaClient({ region: "eu-west-1" });
 

--- a/scripts/deno/bots.ts
+++ b/scripts/deno/bots.ts
@@ -1,3 +1,15 @@
+/**
+ * @file
+ *
+ * This script is used to generate reports of the most frequent user agents
+ * making request to the Guardian’s website, using the JSON logs from Fastly.
+ *
+ * You need Frontend Dev credentials to make the request to Athena.
+ *
+ * Run with the following command to bypass permission prompts:
+ * `deno run --allow-sys=osRelease --allow-env --allow-net=athena.eu-west-1.amazonaws.com --allow-read --allow-write=. ./bots.ts`
+ */
+
 import {
   AthenaClient,
   GetQueryExecutionCommand,
@@ -64,7 +76,7 @@ if (!ResultSet) throw "Could not get a result";
 
 const csv =
   ResultSet.Rows?.map(({ Data }) =>
-    Data?.map(({ VarCharValue }) => VarCharValue).join(",\t")
+    Data?.map(({ VarCharValue }) => VarCharValue).join("\t")
   ).join("\n") ?? "";
 
 const filePath = `./${date.toString()}.csv`;

--- a/scripts/deno/bots.ts
+++ b/scripts/deno/bots.ts
@@ -84,10 +84,14 @@ async function* getRows(client: AthenaClient) {
 
   yield* toRow(ResultSet);
 
+  let count = ResultSet?.Rows?.length ?? 0
+
   while (NextToken) {
+	console.info(`Fetched ${count} rows`);
     ({ ResultSet, NextToken } = await client.send(
       new GetQueryResultsCommand({ QueryExecutionId, NextToken }),
     ));
+	count += ResultSet?.Rows?.length ?? 0;
     yield* toRow(ResultSet);
   }
 }

--- a/scripts/deno/bots.ts
+++ b/scripts/deno/bots.ts
@@ -27,7 +27,7 @@ const { QueryExecutionId } = await client.send(
 	  AND day = ${String(date.day).padStart(2, "0")}
   GROUP BY request_user_agent
   ORDER BY request_count desc
-  LIMIT 100`,
+  LIMIT ${100_000}`,
     ResultReuseConfiguration: {
       ResultReuseByAgeConfiguration: { Enabled: true, MaxAgeInMinutes: 60 },
     },

--- a/scripts/deno/deno.jsonc
+++ b/scripts/deno/deno.jsonc
@@ -4,6 +4,7 @@
 		"lib": ["deno.window"],
 		"strict": true
 	},
+	"unstable": ["temporal"],
 	"fmt": {
 		"useTabs": true,
 		"lineWidth": 80,

--- a/scripts/deno/deno.lock
+++ b/scripts/deno/deno.lock
@@ -1,63 +1,454 @@
 {
-  "version": "2",
-  "remote": {
-    "https://deno.land/x/deno_dom@v0.1.22-alpha/build/deno-wasm/deno-wasm.js": "077162a693528034d8ef84b6602e3562db3ce07c15ce2cf547fe76f7ef48f940",
-    "https://deno.land/x/deno_dom@v0.1.22-alpha/deno-dom-wasm.ts": "bfd999a493a6974e9fca4d331bee03bfb68cfc600c662cd0b48b21d67a2a8ba0",
-    "https://deno.land/x/deno_dom@v0.1.22-alpha/src/api.ts": "cddf406ac2bb73b3b92b1c587acf0a74519884a6e6798b2dbebe9a7ba8842d35",
-    "https://deno.land/x/deno_dom@v0.1.22-alpha/src/constructor-lock.ts": "59714df7e0571ec7bd338903b1f396202771a6d4d7f55a452936bd0de9deb186",
-    "https://deno.land/x/deno_dom@v0.1.22-alpha/src/deserialize.ts": "3c8ec2fccddac7af0963816f44940a420c4ecea6bb41c0e9d4485a3f26dd712e",
-    "https://deno.land/x/deno_dom@v0.1.22-alpha/src/dom/document-fragment.ts": "a40c6e18dd0efcf749a31552c1c9a6f7fa614452245e86ee38fc92ba0235e5ae",
-    "https://deno.land/x/deno_dom@v0.1.22-alpha/src/dom/document.ts": "f6dc03ac37170b93c97c2c1e7034e3e35b3434c709a4978f2eeaf0ca177588b4",
-    "https://deno.land/x/deno_dom@v0.1.22-alpha/src/dom/dom-parser.ts": "609097b426f8c2358f3e5d2bca55ed026cf26cdf86562e94130dfdb0f2537f92",
-    "https://deno.land/x/deno_dom@v0.1.22-alpha/src/dom/element.ts": "68256e45aee0ba5b2c784f3b2d6e1492bf424bc0216bf6940723054ee3461636",
-    "https://deno.land/x/deno_dom@v0.1.22-alpha/src/dom/html-collection.ts": "ae90197f5270c32074926ad6cf30ee07d274d44596c7e413c354880cebce8565",
-    "https://deno.land/x/deno_dom@v0.1.22-alpha/src/dom/node-list.ts": "d9c07baf0acc383112cbabafacf26a0aedb04d0866645e7485f5ab23e470b6f8",
-    "https://deno.land/x/deno_dom@v0.1.22-alpha/src/dom/node.ts": "76a73a970e05b9d00b4f9249d5276c68a05581313eb070c269109d6268c2a7b9",
-    "https://deno.land/x/deno_dom@v0.1.22-alpha/src/dom/selectors/custom-api.ts": "852696bd58e534bc41bd3be9e2250b60b67cd95fd28ed16b1deff1d548531a71",
-    "https://deno.land/x/deno_dom@v0.1.22-alpha/src/dom/selectors/nwsapi-types.ts": "c43b36c36acc5d32caabaa54fda8c9d239b2b0fcbce9a28efb93c84aa1021698",
-    "https://deno.land/x/deno_dom@v0.1.22-alpha/src/dom/selectors/nwsapi.js": "10a2bf1409c9e82f3d6b604d275dd3418cb26348e659411502e19b6aed699772",
-    "https://deno.land/x/deno_dom@v0.1.22-alpha/src/dom/selectors/selectors.ts": "83eab57be2290fb48e3130533448c93c6c61239f2a2f3b85f1917f80ca0fdc75",
-    "https://deno.land/x/deno_dom@v0.1.22-alpha/src/dom/selectors/sizzle-types.ts": "78149e2502409989ce861ed636b813b059e16bc267bb543e7c2b26ef43e4798b",
-    "https://deno.land/x/deno_dom@v0.1.22-alpha/src/dom/selectors/sizzle.js": "c3aed60c1045a106d8e546ac2f85cc82e65f62d9af2f8f515210b9212286682a",
-    "https://deno.land/x/deno_dom@v0.1.22-alpha/src/dom/utils-types.ts": "96db30e3e4a75b194201bb9fa30988215da7f91b380fca6a5143e51ece2a8436",
-    "https://deno.land/x/deno_dom@v0.1.22-alpha/src/dom/utils.ts": "90a2bfb9507be15ee0567352dc722582938336e6069871efe21997d8dc2aa605",
-    "https://deno.land/x/deno_dom@v0.1.22-alpha/src/parser.ts": "b65eb7e673fa7ca611de871de109655f0aa9fa35ddc1de73df1a5fc2baafc332",
-    "https://deno.land/x/deno_dom@v0.1.34-alpha/build/deno-wasm/deno-wasm.js": "3fa41dba4813e6d4b024a53a146b76e1afcbdf218fc02063442378c61239ed14",
-    "https://deno.land/x/deno_dom@v0.1.34-alpha/deno-dom-wasm.ts": "bfd999a493a6974e9fca4d331bee03bfb68cfc600c662cd0b48b21d67a2a8ba0",
-    "https://deno.land/x/deno_dom@v0.1.34-alpha/src/api.ts": "0ff5790f0a3eeecb4e00b7d8fbfa319b165962cf6d0182a65ba90f158d74f7d7",
-    "https://deno.land/x/deno_dom@v0.1.34-alpha/src/constructor-lock.ts": "59714df7e0571ec7bd338903b1f396202771a6d4d7f55a452936bd0de9deb186",
-    "https://deno.land/x/deno_dom@v0.1.34-alpha/src/deserialize.ts": "f4d34514ca00473ca428b69ad437ba345925744b5d791cb9552e2d7a0e7b0439",
-    "https://deno.land/x/deno_dom@v0.1.34-alpha/src/dom/document-fragment.ts": "a40c6e18dd0efcf749a31552c1c9a6f7fa614452245e86ee38fc92ba0235e5ae",
-    "https://deno.land/x/deno_dom@v0.1.34-alpha/src/dom/document.ts": "bcb96378097106d82e0d1a356496baea1b73f92dd7d492e6ed655016025665df",
-    "https://deno.land/x/deno_dom@v0.1.34-alpha/src/dom/dom-parser.ts": "609097b426f8c2358f3e5d2bca55ed026cf26cdf86562e94130dfdb0f2537f92",
-    "https://deno.land/x/deno_dom@v0.1.34-alpha/src/dom/element.ts": "312ae401081e6ce11cf62a854c0f78388e4be46579c1fdd9c1d118bc9c79db38",
-    "https://deno.land/x/deno_dom@v0.1.34-alpha/src/dom/elements/html-template-element.ts": "19ad97c55222115e8daaca2788b9c98cc31a7f9d2547ed5bca0c56a4a12bfec8",
-    "https://deno.land/x/deno_dom@v0.1.34-alpha/src/dom/html-collection.ts": "ae90197f5270c32074926ad6cf30ee07d274d44596c7e413c354880cebce8565",
-    "https://deno.land/x/deno_dom@v0.1.34-alpha/src/dom/node-list.ts": "d9c07baf0acc383112cbabafacf26a0aedb04d0866645e7485f5ab23e470b6f8",
-    "https://deno.land/x/deno_dom@v0.1.34-alpha/src/dom/node.ts": "778b7cf182105ae2c39a7d0b44aaea701c0af35e85b7cfa5e8b38f8bd67f7ad4",
-    "https://deno.land/x/deno_dom@v0.1.34-alpha/src/dom/selectors/custom-api.ts": "852696bd58e534bc41bd3be9e2250b60b67cd95fd28ed16b1deff1d548531a71",
-    "https://deno.land/x/deno_dom@v0.1.34-alpha/src/dom/selectors/nwsapi-types.ts": "c43b36c36acc5d32caabaa54fda8c9d239b2b0fcbce9a28efb93c84aa1021698",
-    "https://deno.land/x/deno_dom@v0.1.34-alpha/src/dom/selectors/nwsapi.js": "985d7d8fc1eabbb88946b47a1c44c1b2d4aa79ff23c21424219f1528fa27a2ff",
-    "https://deno.land/x/deno_dom@v0.1.34-alpha/src/dom/selectors/selectors.ts": "83eab57be2290fb48e3130533448c93c6c61239f2a2f3b85f1917f80ca0fdc75",
-    "https://deno.land/x/deno_dom@v0.1.34-alpha/src/dom/selectors/sizzle-types.ts": "78149e2502409989ce861ed636b813b059e16bc267bb543e7c2b26ef43e4798b",
-    "https://deno.land/x/deno_dom@v0.1.34-alpha/src/dom/selectors/sizzle.js": "c3aed60c1045a106d8e546ac2f85cc82e65f62d9af2f8f515210b9212286682a",
-    "https://deno.land/x/deno_dom@v0.1.34-alpha/src/dom/utils-types.ts": "96db30e3e4a75b194201bb9fa30988215da7f91b380fca6a5143e51ece2a8436",
-    "https://deno.land/x/deno_dom@v0.1.34-alpha/src/dom/utils.ts": "ecd889ba74f3ce282620d8ca1d4d5e0365e6cc86101d2352f3bbf936ae496e2c",
-    "https://deno.land/x/deno_dom@v0.1.34-alpha/src/parser.ts": "b65eb7e673fa7ca611de871de109655f0aa9fa35ddc1de73df1a5fc2baafc332",
-    "https://esm.sh/pretty-bytes@6.0.0": "abedb19018160e1ea3f1989e82b2858227ca2c0d49f7d410ff12bcbfebd658eb",
-    "https://esm.sh/v93/pretty-bytes@6.0.0/deno/pretty-bytes.js": "a6d9111496d7ff73b585302c10d6b16aca7fb4bc473ad999b5e39a4e48a1ab8c",
-    "https://esm.sh/v93/pretty-bytes@6.0.0/index.d.ts": "5137a51bcb5f7b62737ab2773b24d1c3b3f7c270bd5501e9ecba1adecab9eaec",
-    "https://raw.githubusercontent.com/GoogleChrome/lighthouse-ci/v0.10.0/types/assert.d.ts": "6bc48c6cdb2fa2033c794ee4a03d1259e4839c0d874d9d9516197db41f551652"
-  },
-  "npm": {
+  "version": "3",
+  "packages": {
     "specifiers": {
-      "@octokit/webhooks-types@6": "@octokit/webhooks-types@6.10.0",
-      "octokit@2": "octokit@2.0.14_@octokit+core@4.2.0",
-      "octokit@2.0.14": "octokit@2.0.14_@octokit+core@4.2.0",
-      "pretty-bytes@6": "pretty-bytes@6.1.0",
-      "zod@3": "zod@3.19.1"
+      "npm:@aws-sdk/client-athena": "npm:@aws-sdk/client-athena@3.540.0_@aws-sdk+credential-provider-node@3.540.0",
+      "npm:@octokit/webhooks-types@6": "npm:@octokit/webhooks-types@6.10.0",
+      "npm:octokit@2": "npm:octokit@2.0.14_@octokit+core@4.2.0",
+      "npm:octokit@2.0.14": "npm:octokit@2.0.14_@octokit+core@4.2.0",
+      "npm:pretty-bytes@6": "npm:pretty-bytes@6.1.0",
+      "npm:zod@3": "npm:zod@3.19.1"
     },
-    "packages": {
+    "npm": {
+      "@aws-crypto/crc32@3.0.0": {
+        "integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
+        "dependencies": {
+          "@aws-crypto/util": "@aws-crypto/util@3.0.0",
+          "@aws-sdk/types": "@aws-sdk/types@3.535.0",
+          "tslib": "tslib@1.14.1"
+        }
+      },
+      "@aws-crypto/ie11-detection@3.0.0": {
+        "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
+        "dependencies": {
+          "tslib": "tslib@1.14.1"
+        }
+      },
+      "@aws-crypto/sha256-browser@3.0.0": {
+        "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
+        "dependencies": {
+          "@aws-crypto/ie11-detection": "@aws-crypto/ie11-detection@3.0.0",
+          "@aws-crypto/sha256-js": "@aws-crypto/sha256-js@3.0.0",
+          "@aws-crypto/supports-web-crypto": "@aws-crypto/supports-web-crypto@3.0.0",
+          "@aws-crypto/util": "@aws-crypto/util@3.0.0",
+          "@aws-sdk/types": "@aws-sdk/types@3.535.0",
+          "@aws-sdk/util-locate-window": "@aws-sdk/util-locate-window@3.535.0",
+          "@aws-sdk/util-utf8-browser": "@aws-sdk/util-utf8-browser@3.259.0",
+          "tslib": "tslib@1.14.1"
+        }
+      },
+      "@aws-crypto/sha256-js@3.0.0": {
+        "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
+        "dependencies": {
+          "@aws-crypto/util": "@aws-crypto/util@3.0.0",
+          "@aws-sdk/types": "@aws-sdk/types@3.535.0",
+          "tslib": "tslib@1.14.1"
+        }
+      },
+      "@aws-crypto/supports-web-crypto@3.0.0": {
+        "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
+        "dependencies": {
+          "tslib": "tslib@1.14.1"
+        }
+      },
+      "@aws-crypto/util@3.0.0": {
+        "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
+        "dependencies": {
+          "@aws-sdk/types": "@aws-sdk/types@3.535.0",
+          "@aws-sdk/util-utf8-browser": "@aws-sdk/util-utf8-browser@3.259.0",
+          "tslib": "tslib@1.14.1"
+        }
+      },
+      "@aws-sdk/client-athena@3.540.0_@aws-sdk+credential-provider-node@3.540.0": {
+        "integrity": "sha512-LVhAp+7s8Cpz5NdcEw3Wmc1XHMTsjC2eFNHwKLDOWQdMt8XGFluYEcmO4s0Xg6n2q1oLkChBE+bIFEqNKpAe6Q==",
+        "dependencies": {
+          "@aws-crypto/sha256-browser": "@aws-crypto/sha256-browser@3.0.0",
+          "@aws-crypto/sha256-js": "@aws-crypto/sha256-js@3.0.0",
+          "@aws-sdk/client-sts": "@aws-sdk/client-sts@3.540.0_@aws-sdk+credential-provider-node@3.540.0",
+          "@aws-sdk/core": "@aws-sdk/core@3.535.0",
+          "@aws-sdk/credential-provider-node": "@aws-sdk/credential-provider-node@3.540.0",
+          "@aws-sdk/middleware-host-header": "@aws-sdk/middleware-host-header@3.535.0",
+          "@aws-sdk/middleware-logger": "@aws-sdk/middleware-logger@3.535.0",
+          "@aws-sdk/middleware-recursion-detection": "@aws-sdk/middleware-recursion-detection@3.535.0",
+          "@aws-sdk/middleware-user-agent": "@aws-sdk/middleware-user-agent@3.540.0",
+          "@aws-sdk/region-config-resolver": "@aws-sdk/region-config-resolver@3.535.0",
+          "@aws-sdk/types": "@aws-sdk/types@3.535.0",
+          "@aws-sdk/util-endpoints": "@aws-sdk/util-endpoints@3.540.0",
+          "@aws-sdk/util-user-agent-browser": "@aws-sdk/util-user-agent-browser@3.535.0",
+          "@aws-sdk/util-user-agent-node": "@aws-sdk/util-user-agent-node@3.535.0",
+          "@smithy/config-resolver": "@smithy/config-resolver@2.2.0",
+          "@smithy/core": "@smithy/core@1.4.0",
+          "@smithy/fetch-http-handler": "@smithy/fetch-http-handler@2.5.0",
+          "@smithy/hash-node": "@smithy/hash-node@2.2.0",
+          "@smithy/invalid-dependency": "@smithy/invalid-dependency@2.2.0",
+          "@smithy/middleware-content-length": "@smithy/middleware-content-length@2.2.0",
+          "@smithy/middleware-endpoint": "@smithy/middleware-endpoint@2.5.0",
+          "@smithy/middleware-retry": "@smithy/middleware-retry@2.2.0",
+          "@smithy/middleware-serde": "@smithy/middleware-serde@2.3.0",
+          "@smithy/middleware-stack": "@smithy/middleware-stack@2.2.0",
+          "@smithy/node-config-provider": "@smithy/node-config-provider@2.3.0",
+          "@smithy/node-http-handler": "@smithy/node-http-handler@2.5.0",
+          "@smithy/protocol-http": "@smithy/protocol-http@3.3.0",
+          "@smithy/smithy-client": "@smithy/smithy-client@2.5.0",
+          "@smithy/types": "@smithy/types@2.12.0",
+          "@smithy/url-parser": "@smithy/url-parser@2.2.0",
+          "@smithy/util-base64": "@smithy/util-base64@2.3.0",
+          "@smithy/util-body-length-browser": "@smithy/util-body-length-browser@2.2.0",
+          "@smithy/util-body-length-node": "@smithy/util-body-length-node@2.3.0",
+          "@smithy/util-defaults-mode-browser": "@smithy/util-defaults-mode-browser@2.2.0",
+          "@smithy/util-defaults-mode-node": "@smithy/util-defaults-mode-node@2.3.0",
+          "@smithy/util-endpoints": "@smithy/util-endpoints@1.2.0",
+          "@smithy/util-middleware": "@smithy/util-middleware@2.2.0",
+          "@smithy/util-retry": "@smithy/util-retry@2.2.0",
+          "@smithy/util-utf8": "@smithy/util-utf8@2.3.0",
+          "tslib": "tslib@2.6.2",
+          "uuid": "uuid@9.0.1"
+        }
+      },
+      "@aws-sdk/client-sso-oidc@3.540.0_@aws-sdk+credential-provider-node@3.540.0": {
+        "integrity": "sha512-LZYK0lBRQK8D8M3Sqc96XiXkAV2v70zhTtF6weyzEpgwxZMfSuFJjs0jFyhaeZBZbZv7BBghIdhJ5TPavNxGMQ==",
+        "dependencies": {
+          "@aws-crypto/sha256-browser": "@aws-crypto/sha256-browser@3.0.0",
+          "@aws-crypto/sha256-js": "@aws-crypto/sha256-js@3.0.0",
+          "@aws-sdk/client-sts": "@aws-sdk/client-sts@3.540.0",
+          "@aws-sdk/core": "@aws-sdk/core@3.535.0",
+          "@aws-sdk/credential-provider-node": "@aws-sdk/credential-provider-node@3.540.0",
+          "@aws-sdk/middleware-host-header": "@aws-sdk/middleware-host-header@3.535.0",
+          "@aws-sdk/middleware-logger": "@aws-sdk/middleware-logger@3.535.0",
+          "@aws-sdk/middleware-recursion-detection": "@aws-sdk/middleware-recursion-detection@3.535.0",
+          "@aws-sdk/middleware-user-agent": "@aws-sdk/middleware-user-agent@3.540.0",
+          "@aws-sdk/region-config-resolver": "@aws-sdk/region-config-resolver@3.535.0",
+          "@aws-sdk/types": "@aws-sdk/types@3.535.0",
+          "@aws-sdk/util-endpoints": "@aws-sdk/util-endpoints@3.540.0",
+          "@aws-sdk/util-user-agent-browser": "@aws-sdk/util-user-agent-browser@3.535.0",
+          "@aws-sdk/util-user-agent-node": "@aws-sdk/util-user-agent-node@3.535.0",
+          "@smithy/config-resolver": "@smithy/config-resolver@2.2.0",
+          "@smithy/core": "@smithy/core@1.4.0",
+          "@smithy/fetch-http-handler": "@smithy/fetch-http-handler@2.5.0",
+          "@smithy/hash-node": "@smithy/hash-node@2.2.0",
+          "@smithy/invalid-dependency": "@smithy/invalid-dependency@2.2.0",
+          "@smithy/middleware-content-length": "@smithy/middleware-content-length@2.2.0",
+          "@smithy/middleware-endpoint": "@smithy/middleware-endpoint@2.5.0",
+          "@smithy/middleware-retry": "@smithy/middleware-retry@2.2.0",
+          "@smithy/middleware-serde": "@smithy/middleware-serde@2.3.0",
+          "@smithy/middleware-stack": "@smithy/middleware-stack@2.2.0",
+          "@smithy/node-config-provider": "@smithy/node-config-provider@2.3.0",
+          "@smithy/node-http-handler": "@smithy/node-http-handler@2.5.0",
+          "@smithy/protocol-http": "@smithy/protocol-http@3.3.0",
+          "@smithy/smithy-client": "@smithy/smithy-client@2.5.0",
+          "@smithy/types": "@smithy/types@2.12.0",
+          "@smithy/url-parser": "@smithy/url-parser@2.2.0",
+          "@smithy/util-base64": "@smithy/util-base64@2.3.0",
+          "@smithy/util-body-length-browser": "@smithy/util-body-length-browser@2.2.0",
+          "@smithy/util-body-length-node": "@smithy/util-body-length-node@2.3.0",
+          "@smithy/util-defaults-mode-browser": "@smithy/util-defaults-mode-browser@2.2.0",
+          "@smithy/util-defaults-mode-node": "@smithy/util-defaults-mode-node@2.3.0",
+          "@smithy/util-endpoints": "@smithy/util-endpoints@1.2.0",
+          "@smithy/util-middleware": "@smithy/util-middleware@2.2.0",
+          "@smithy/util-retry": "@smithy/util-retry@2.2.0",
+          "@smithy/util-utf8": "@smithy/util-utf8@2.3.0",
+          "tslib": "tslib@2.6.2"
+        }
+      },
+      "@aws-sdk/client-sso@3.540.0": {
+        "integrity": "sha512-rrQZMuw4sxIo3eyAUUzPQRA336mPRnrAeSlSdVHBKZD8Fjvoy0lYry2vNhkPLpFZLso1J66KRyuIv4LzRR3v1Q==",
+        "dependencies": {
+          "@aws-crypto/sha256-browser": "@aws-crypto/sha256-browser@3.0.0",
+          "@aws-crypto/sha256-js": "@aws-crypto/sha256-js@3.0.0",
+          "@aws-sdk/core": "@aws-sdk/core@3.535.0",
+          "@aws-sdk/middleware-host-header": "@aws-sdk/middleware-host-header@3.535.0",
+          "@aws-sdk/middleware-logger": "@aws-sdk/middleware-logger@3.535.0",
+          "@aws-sdk/middleware-recursion-detection": "@aws-sdk/middleware-recursion-detection@3.535.0",
+          "@aws-sdk/middleware-user-agent": "@aws-sdk/middleware-user-agent@3.540.0",
+          "@aws-sdk/region-config-resolver": "@aws-sdk/region-config-resolver@3.535.0",
+          "@aws-sdk/types": "@aws-sdk/types@3.535.0",
+          "@aws-sdk/util-endpoints": "@aws-sdk/util-endpoints@3.540.0",
+          "@aws-sdk/util-user-agent-browser": "@aws-sdk/util-user-agent-browser@3.535.0",
+          "@aws-sdk/util-user-agent-node": "@aws-sdk/util-user-agent-node@3.535.0",
+          "@smithy/config-resolver": "@smithy/config-resolver@2.2.0",
+          "@smithy/core": "@smithy/core@1.4.0",
+          "@smithy/fetch-http-handler": "@smithy/fetch-http-handler@2.5.0",
+          "@smithy/hash-node": "@smithy/hash-node@2.2.0",
+          "@smithy/invalid-dependency": "@smithy/invalid-dependency@2.2.0",
+          "@smithy/middleware-content-length": "@smithy/middleware-content-length@2.2.0",
+          "@smithy/middleware-endpoint": "@smithy/middleware-endpoint@2.5.0",
+          "@smithy/middleware-retry": "@smithy/middleware-retry@2.2.0",
+          "@smithy/middleware-serde": "@smithy/middleware-serde@2.3.0",
+          "@smithy/middleware-stack": "@smithy/middleware-stack@2.2.0",
+          "@smithy/node-config-provider": "@smithy/node-config-provider@2.3.0",
+          "@smithy/node-http-handler": "@smithy/node-http-handler@2.5.0",
+          "@smithy/protocol-http": "@smithy/protocol-http@3.3.0",
+          "@smithy/smithy-client": "@smithy/smithy-client@2.5.0",
+          "@smithy/types": "@smithy/types@2.12.0",
+          "@smithy/url-parser": "@smithy/url-parser@2.2.0",
+          "@smithy/util-base64": "@smithy/util-base64@2.3.0",
+          "@smithy/util-body-length-browser": "@smithy/util-body-length-browser@2.2.0",
+          "@smithy/util-body-length-node": "@smithy/util-body-length-node@2.3.0",
+          "@smithy/util-defaults-mode-browser": "@smithy/util-defaults-mode-browser@2.2.0",
+          "@smithy/util-defaults-mode-node": "@smithy/util-defaults-mode-node@2.3.0",
+          "@smithy/util-endpoints": "@smithy/util-endpoints@1.2.0",
+          "@smithy/util-middleware": "@smithy/util-middleware@2.2.0",
+          "@smithy/util-retry": "@smithy/util-retry@2.2.0",
+          "@smithy/util-utf8": "@smithy/util-utf8@2.3.0",
+          "tslib": "tslib@2.6.2"
+        }
+      },
+      "@aws-sdk/client-sts@3.540.0": {
+        "integrity": "sha512-ITHUQxvpqfQX6obfpIi3KYGzZYfe/I5Ixjfxoi5lB7ISCtmxqObKB1fzD93wonkMJytJ7LUO8panZl/ojiJ1uw==",
+        "dependencies": {
+          "@aws-crypto/sha256-browser": "@aws-crypto/sha256-browser@3.0.0",
+          "@aws-crypto/sha256-js": "@aws-crypto/sha256-js@3.0.0",
+          "@aws-sdk/core": "@aws-sdk/core@3.535.0"
+        }
+      },
+      "@aws-sdk/client-sts@3.540.0_@aws-sdk+credential-provider-node@3.540.0": {
+        "integrity": "sha512-ITHUQxvpqfQX6obfpIi3KYGzZYfe/I5Ixjfxoi5lB7ISCtmxqObKB1fzD93wonkMJytJ7LUO8panZl/ojiJ1uw==",
+        "dependencies": {
+          "@aws-crypto/sha256-browser": "@aws-crypto/sha256-browser@3.0.0",
+          "@aws-crypto/sha256-js": "@aws-crypto/sha256-js@3.0.0",
+          "@aws-sdk/core": "@aws-sdk/core@3.535.0",
+          "@aws-sdk/credential-provider-node": "@aws-sdk/credential-provider-node@3.540.0",
+          "@aws-sdk/middleware-host-header": "@aws-sdk/middleware-host-header@3.535.0",
+          "@aws-sdk/middleware-logger": "@aws-sdk/middleware-logger@3.535.0",
+          "@aws-sdk/middleware-recursion-detection": "@aws-sdk/middleware-recursion-detection@3.535.0",
+          "@aws-sdk/middleware-user-agent": "@aws-sdk/middleware-user-agent@3.540.0",
+          "@aws-sdk/region-config-resolver": "@aws-sdk/region-config-resolver@3.535.0",
+          "@aws-sdk/types": "@aws-sdk/types@3.535.0",
+          "@aws-sdk/util-endpoints": "@aws-sdk/util-endpoints@3.540.0",
+          "@aws-sdk/util-user-agent-browser": "@aws-sdk/util-user-agent-browser@3.535.0",
+          "@aws-sdk/util-user-agent-node": "@aws-sdk/util-user-agent-node@3.535.0",
+          "@smithy/config-resolver": "@smithy/config-resolver@2.2.0",
+          "@smithy/core": "@smithy/core@1.4.0",
+          "@smithy/fetch-http-handler": "@smithy/fetch-http-handler@2.5.0",
+          "@smithy/hash-node": "@smithy/hash-node@2.2.0",
+          "@smithy/invalid-dependency": "@smithy/invalid-dependency@2.2.0",
+          "@smithy/middleware-content-length": "@smithy/middleware-content-length@2.2.0",
+          "@smithy/middleware-endpoint": "@smithy/middleware-endpoint@2.5.0",
+          "@smithy/middleware-retry": "@smithy/middleware-retry@2.2.0",
+          "@smithy/middleware-serde": "@smithy/middleware-serde@2.3.0",
+          "@smithy/middleware-stack": "@smithy/middleware-stack@2.2.0",
+          "@smithy/node-config-provider": "@smithy/node-config-provider@2.3.0",
+          "@smithy/node-http-handler": "@smithy/node-http-handler@2.5.0",
+          "@smithy/protocol-http": "@smithy/protocol-http@3.3.0",
+          "@smithy/smithy-client": "@smithy/smithy-client@2.5.0",
+          "@smithy/types": "@smithy/types@2.12.0",
+          "@smithy/url-parser": "@smithy/url-parser@2.2.0",
+          "@smithy/util-base64": "@smithy/util-base64@2.3.0",
+          "@smithy/util-body-length-browser": "@smithy/util-body-length-browser@2.2.0",
+          "@smithy/util-body-length-node": "@smithy/util-body-length-node@2.3.0",
+          "@smithy/util-defaults-mode-browser": "@smithy/util-defaults-mode-browser@2.2.0",
+          "@smithy/util-defaults-mode-node": "@smithy/util-defaults-mode-node@2.3.0",
+          "@smithy/util-endpoints": "@smithy/util-endpoints@1.2.0",
+          "@smithy/util-middleware": "@smithy/util-middleware@2.2.0",
+          "@smithy/util-retry": "@smithy/util-retry@2.2.0",
+          "@smithy/util-utf8": "@smithy/util-utf8@2.3.0",
+          "tslib": "tslib@2.6.2"
+        }
+      },
+      "@aws-sdk/core@3.535.0": {
+        "integrity": "sha512-+Yusa9HziuaEDta1UaLEtMAtmgvxdxhPn7jgfRY6PplqAqgsfa5FR83sxy5qr2q7xjQTwHtV4MjQVuOjG9JsLw==",
+        "dependencies": {
+          "@smithy/core": "@smithy/core@1.4.0",
+          "@smithy/protocol-http": "@smithy/protocol-http@3.3.0",
+          "@smithy/signature-v4": "@smithy/signature-v4@2.2.0",
+          "@smithy/smithy-client": "@smithy/smithy-client@2.5.0",
+          "@smithy/types": "@smithy/types@2.12.0",
+          "fast-xml-parser": "fast-xml-parser@4.2.5",
+          "tslib": "tslib@2.6.2"
+        }
+      },
+      "@aws-sdk/credential-provider-env@3.535.0": {
+        "integrity": "sha512-XppwO8c0GCGSAvdzyJOhbtktSEaShg14VJKg8mpMa1XcgqzmcqqHQjtDWbx5rZheY1VdpXZhpEzJkB6LpQejpA==",
+        "dependencies": {
+          "@aws-sdk/types": "@aws-sdk/types@3.535.0",
+          "@smithy/property-provider": "@smithy/property-provider@2.2.0",
+          "@smithy/types": "@smithy/types@2.12.0",
+          "tslib": "tslib@2.6.2"
+        }
+      },
+      "@aws-sdk/credential-provider-http@3.535.0": {
+        "integrity": "sha512-kdj1wCmOMZ29jSlUskRqN04S6fJ4dvt0Nq9Z32SA6wO7UG8ht6Ot9h/au/eTWJM3E1somZ7D771oK7dQt9b8yw==",
+        "dependencies": {
+          "@aws-sdk/types": "@aws-sdk/types@3.535.0",
+          "@smithy/fetch-http-handler": "@smithy/fetch-http-handler@2.5.0",
+          "@smithy/node-http-handler": "@smithy/node-http-handler@2.5.0",
+          "@smithy/property-provider": "@smithy/property-provider@2.2.0",
+          "@smithy/protocol-http": "@smithy/protocol-http@3.3.0",
+          "@smithy/smithy-client": "@smithy/smithy-client@2.5.0",
+          "@smithy/types": "@smithy/types@2.12.0",
+          "@smithy/util-stream": "@smithy/util-stream@2.2.0",
+          "tslib": "tslib@2.6.2"
+        }
+      },
+      "@aws-sdk/credential-provider-ini@3.540.0_@aws-sdk+credential-provider-node@3.540.0": {
+        "integrity": "sha512-igN/RbsnulIBwqXbwsWmR3srqmtbPF1dm+JteGvUY31FW65fTVvWvSr945Y/cf1UbhPmIQXntlsqESqpkhTHwg==",
+        "dependencies": {
+          "@aws-sdk/client-sts": "@aws-sdk/client-sts@3.540.0_@aws-sdk+credential-provider-node@3.540.0",
+          "@aws-sdk/credential-provider-env": "@aws-sdk/credential-provider-env@3.535.0",
+          "@aws-sdk/credential-provider-process": "@aws-sdk/credential-provider-process@3.535.0",
+          "@aws-sdk/credential-provider-sso": "@aws-sdk/credential-provider-sso@3.540.0_@aws-sdk+credential-provider-node@3.540.0",
+          "@aws-sdk/credential-provider-web-identity": "@aws-sdk/credential-provider-web-identity@3.540.0_@aws-sdk+credential-provider-node@3.540.0",
+          "@aws-sdk/types": "@aws-sdk/types@3.535.0",
+          "@smithy/credential-provider-imds": "@smithy/credential-provider-imds@2.3.0",
+          "@smithy/property-provider": "@smithy/property-provider@2.2.0",
+          "@smithy/shared-ini-file-loader": "@smithy/shared-ini-file-loader@2.4.0",
+          "@smithy/types": "@smithy/types@2.12.0",
+          "tslib": "tslib@2.6.2"
+        }
+      },
+      "@aws-sdk/credential-provider-node@3.540.0": {
+        "integrity": "sha512-HKQZJbLHlrHX9A0B1poiYNXIIQfy8whTjuosTCYKPDBhhUyVAQfxy/KG726j0v43IhaNPLgTGZCJve4hAsazSw==",
+        "dependencies": {
+          "@aws-sdk/credential-provider-env": "@aws-sdk/credential-provider-env@3.535.0",
+          "@aws-sdk/credential-provider-http": "@aws-sdk/credential-provider-http@3.535.0",
+          "@aws-sdk/credential-provider-ini": "@aws-sdk/credential-provider-ini@3.540.0_@aws-sdk+credential-provider-node@3.540.0",
+          "@aws-sdk/credential-provider-process": "@aws-sdk/credential-provider-process@3.535.0",
+          "@aws-sdk/credential-provider-sso": "@aws-sdk/credential-provider-sso@3.540.0_@aws-sdk+credential-provider-node@3.540.0",
+          "@aws-sdk/credential-provider-web-identity": "@aws-sdk/credential-provider-web-identity@3.540.0_@aws-sdk+credential-provider-node@3.540.0",
+          "@aws-sdk/types": "@aws-sdk/types@3.535.0",
+          "@smithy/credential-provider-imds": "@smithy/credential-provider-imds@2.3.0",
+          "@smithy/property-provider": "@smithy/property-provider@2.2.0",
+          "@smithy/shared-ini-file-loader": "@smithy/shared-ini-file-loader@2.4.0",
+          "@smithy/types": "@smithy/types@2.12.0",
+          "tslib": "tslib@2.6.2"
+        }
+      },
+      "@aws-sdk/credential-provider-process@3.535.0": {
+        "integrity": "sha512-9O1OaprGCnlb/kYl8RwmH7Mlg8JREZctB8r9sa1KhSsWFq/SWO0AuJTyowxD7zL5PkeS4eTvzFFHWCa3OO5epA==",
+        "dependencies": {
+          "@aws-sdk/types": "@aws-sdk/types@3.535.0",
+          "@smithy/property-provider": "@smithy/property-provider@2.2.0",
+          "@smithy/shared-ini-file-loader": "@smithy/shared-ini-file-loader@2.4.0",
+          "@smithy/types": "@smithy/types@2.12.0",
+          "tslib": "tslib@2.6.2"
+        }
+      },
+      "@aws-sdk/credential-provider-sso@3.540.0_@aws-sdk+credential-provider-node@3.540.0": {
+        "integrity": "sha512-tKkFqK227LF5ajc5EL6asXS32p3nkofpP8G7NRpU7zOEOQCg01KUc4JRX+ItI0T007CiN1J19yNoFqHLT/SqHg==",
+        "dependencies": {
+          "@aws-sdk/client-sso": "@aws-sdk/client-sso@3.540.0",
+          "@aws-sdk/token-providers": "@aws-sdk/token-providers@3.540.0_@aws-sdk+credential-provider-node@3.540.0",
+          "@aws-sdk/types": "@aws-sdk/types@3.535.0",
+          "@smithy/property-provider": "@smithy/property-provider@2.2.0",
+          "@smithy/shared-ini-file-loader": "@smithy/shared-ini-file-loader@2.4.0",
+          "@smithy/types": "@smithy/types@2.12.0",
+          "tslib": "tslib@2.6.2"
+        }
+      },
+      "@aws-sdk/credential-provider-web-identity@3.540.0_@aws-sdk+credential-provider-node@3.540.0": {
+        "integrity": "sha512-OpDm9w3A168B44hSjpnvECP4rvnFzD86rN4VYdGADuCvEa5uEcdA/JuT5WclFPDqdWEmFBqS1pxBIJBf0g2Q9Q==",
+        "dependencies": {
+          "@aws-sdk/client-sts": "@aws-sdk/client-sts@3.540.0_@aws-sdk+credential-provider-node@3.540.0",
+          "@aws-sdk/types": "@aws-sdk/types@3.535.0",
+          "@smithy/property-provider": "@smithy/property-provider@2.2.0",
+          "@smithy/types": "@smithy/types@2.12.0",
+          "tslib": "tslib@2.6.2"
+        }
+      },
+      "@aws-sdk/middleware-host-header@3.535.0": {
+        "integrity": "sha512-0h6TWjBWtDaYwHMQJI9ulafeS4lLaw1vIxRjbpH0svFRt6Eve+Sy8NlVhECfTU2hNz/fLubvrUxsXoThaLBIew==",
+        "dependencies": {
+          "@aws-sdk/types": "@aws-sdk/types@3.535.0",
+          "@smithy/protocol-http": "@smithy/protocol-http@3.3.0",
+          "@smithy/types": "@smithy/types@2.12.0",
+          "tslib": "tslib@2.6.2"
+        }
+      },
+      "@aws-sdk/middleware-logger@3.535.0": {
+        "integrity": "sha512-huNHpONOrEDrdRTvSQr1cJiRMNf0S52NDXtaPzdxiubTkP+vni2MohmZANMOai/qT0olmEVX01LhZ0ZAOgmg6A==",
+        "dependencies": {
+          "@aws-sdk/types": "@aws-sdk/types@3.535.0",
+          "@smithy/types": "@smithy/types@2.12.0",
+          "tslib": "tslib@2.6.2"
+        }
+      },
+      "@aws-sdk/middleware-recursion-detection@3.535.0": {
+        "integrity": "sha512-am2qgGs+gwqmR4wHLWpzlZ8PWhm4ktj5bYSgDrsOfjhdBlWNxvPoID9/pDAz5RWL48+oH7I6SQzMqxXsFDikrw==",
+        "dependencies": {
+          "@aws-sdk/types": "@aws-sdk/types@3.535.0",
+          "@smithy/protocol-http": "@smithy/protocol-http@3.3.0",
+          "@smithy/types": "@smithy/types@2.12.0",
+          "tslib": "tslib@2.6.2"
+        }
+      },
+      "@aws-sdk/middleware-user-agent@3.540.0": {
+        "integrity": "sha512-8Rd6wPeXDnOYzWj1XCmOKcx/Q87L0K1/EHqOBocGjLVbN3gmRxBvpmR1pRTjf7IsWfnnzN5btqtcAkfDPYQUMQ==",
+        "dependencies": {
+          "@aws-sdk/types": "@aws-sdk/types@3.535.0",
+          "@aws-sdk/util-endpoints": "@aws-sdk/util-endpoints@3.540.0",
+          "@smithy/protocol-http": "@smithy/protocol-http@3.3.0",
+          "@smithy/types": "@smithy/types@2.12.0",
+          "tslib": "tslib@2.6.2"
+        }
+      },
+      "@aws-sdk/region-config-resolver@3.535.0": {
+        "integrity": "sha512-IXOznDiaItBjsQy4Fil0kzX/J3HxIOknEphqHbOfUf+LpA5ugcsxuQQONrbEQusCBnfJyymrldBvBhFmtlU9Wg==",
+        "dependencies": {
+          "@aws-sdk/types": "@aws-sdk/types@3.535.0",
+          "@smithy/node-config-provider": "@smithy/node-config-provider@2.3.0",
+          "@smithy/types": "@smithy/types@2.12.0",
+          "@smithy/util-config-provider": "@smithy/util-config-provider@2.3.0",
+          "@smithy/util-middleware": "@smithy/util-middleware@2.2.0",
+          "tslib": "tslib@2.6.2"
+        }
+      },
+      "@aws-sdk/token-providers@3.540.0_@aws-sdk+credential-provider-node@3.540.0": {
+        "integrity": "sha512-9BvtiVEZe5Ev88Wa4ZIUbtT6BVcPwhxmVInQ6c12MYNb0WNL54BN6wLy/eknAfF05gpX2/NDU2pUDOyMPdm/+g==",
+        "dependencies": {
+          "@aws-sdk/client-sso-oidc": "@aws-sdk/client-sso-oidc@3.540.0_@aws-sdk+credential-provider-node@3.540.0",
+          "@aws-sdk/types": "@aws-sdk/types@3.535.0",
+          "@smithy/property-provider": "@smithy/property-provider@2.2.0",
+          "@smithy/shared-ini-file-loader": "@smithy/shared-ini-file-loader@2.4.0",
+          "@smithy/types": "@smithy/types@2.12.0",
+          "tslib": "tslib@2.6.2"
+        }
+      },
+      "@aws-sdk/types@3.535.0": {
+        "integrity": "sha512-aY4MYfduNj+sRR37U7XxYR8wemfbKP6lx00ze2M2uubn7mZotuVrWYAafbMSXrdEMSToE5JDhr28vArSOoLcSg==",
+        "dependencies": {
+          "@smithy/types": "@smithy/types@2.12.0",
+          "tslib": "tslib@2.6.2"
+        }
+      },
+      "@aws-sdk/util-endpoints@3.540.0": {
+        "integrity": "sha512-1kMyQFAWx6f8alaI6UT65/5YW/7pDWAKAdNwL6vuJLea03KrZRX3PMoONOSJpAS5m3Ot7HlWZvf3wZDNTLELZw==",
+        "dependencies": {
+          "@aws-sdk/types": "@aws-sdk/types@3.535.0",
+          "@smithy/types": "@smithy/types@2.12.0",
+          "@smithy/util-endpoints": "@smithy/util-endpoints@1.2.0",
+          "tslib": "tslib@2.6.2"
+        }
+      },
+      "@aws-sdk/util-locate-window@3.535.0": {
+        "integrity": "sha512-PHJ3SL6d2jpcgbqdgiPxkXpu7Drc2PYViwxSIqvvMKhDwzSB1W3mMvtpzwKM4IE7zLFodZo0GKjJ9AsoXndXhA==",
+        "dependencies": {
+          "tslib": "tslib@2.6.2"
+        }
+      },
+      "@aws-sdk/util-user-agent-browser@3.535.0": {
+        "integrity": "sha512-RWMcF/xV5n+nhaA/Ff5P3yNP3Kur/I+VNZngog4TEs92oB/nwOdAg/2JL8bVAhUbMrjTjpwm7PItziYFQoqyig==",
+        "dependencies": {
+          "@aws-sdk/types": "@aws-sdk/types@3.535.0",
+          "@smithy/types": "@smithy/types@2.12.0",
+          "bowser": "bowser@2.11.0",
+          "tslib": "tslib@2.6.2"
+        }
+      },
+      "@aws-sdk/util-user-agent-node@3.535.0": {
+        "integrity": "sha512-dRek0zUuIT25wOWJlsRm97nTkUlh1NDcLsQZIN2Y8KxhwoXXWtJs5vaDPT+qAg+OpcNj80i1zLR/CirqlFg/TQ==",
+        "dependencies": {
+          "@aws-sdk/types": "@aws-sdk/types@3.535.0",
+          "@smithy/node-config-provider": "@smithy/node-config-provider@2.3.0",
+          "@smithy/types": "@smithy/types@2.12.0",
+          "tslib": "tslib@2.6.2"
+        }
+      },
+      "@aws-sdk/util-utf8-browser@3.259.0": {
+        "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
+        "dependencies": {
+          "tslib": "tslib@2.6.2"
+        }
+      },
       "@octokit/app@13.1.2_@octokit+core@4.2.0": {
         "integrity": "sha512-Kf+h5sa1SOI33hFsuHvTsWj1jUrjp1x4MuiJBq7U/NicfEGa6nArPUoDnyfP/YTmcQ5cQ5yvOgoIBkbwPg6kzQ==",
         "dependencies": {
@@ -119,7 +510,9 @@
       },
       "@octokit/auth-token@3.0.3": {
         "integrity": "sha512-/aFM2M4HVDBT/jjDBa84sJniv1t9Gm/rLkalaz9htOm+L+8JMj1k9w0CkUdcxNyNxZPlTxKPVko+m1VlM58ZVA==",
-        "dependencies": { "@octokit/types": "@octokit/types@9.0.0" }
+        "dependencies": {
+          "@octokit/types": "@octokit/types@9.0.0"
+        }
       },
       "@octokit/auth-unauthenticated@3.0.4": {
         "integrity": "sha512-AT74XGBylcLr4lmUp1s6mjSUgphGdlse21Qjtv5DzpX1YOl5FXKwvNcZWESdhyBbpDT8VkVyLFqa/7a7eqpPNw==",
@@ -261,6 +654,344 @@
           "aggregate-error": "aggregate-error@3.1.0"
         }
       },
+      "@smithy/abort-controller@2.2.0": {
+        "integrity": "sha512-wRlta7GuLWpTqtFfGo+nZyOO1vEvewdNR1R4rTxpC8XU6vG/NDyrFBhwLZsqg1NUoR1noVaXJPC/7ZK47QCySw==",
+        "dependencies": {
+          "@smithy/types": "@smithy/types@2.12.0",
+          "tslib": "tslib@2.6.2"
+        }
+      },
+      "@smithy/config-resolver@2.2.0": {
+        "integrity": "sha512-fsiMgd8toyUba6n1WRmr+qACzXltpdDkPTAaDqc8QqPBUzO+/JKwL6bUBseHVi8tu9l+3JOK+tSf7cay+4B3LA==",
+        "dependencies": {
+          "@smithy/node-config-provider": "@smithy/node-config-provider@2.3.0",
+          "@smithy/types": "@smithy/types@2.12.0",
+          "@smithy/util-config-provider": "@smithy/util-config-provider@2.3.0",
+          "@smithy/util-middleware": "@smithy/util-middleware@2.2.0",
+          "tslib": "tslib@2.6.2"
+        }
+      },
+      "@smithy/core@1.4.0": {
+        "integrity": "sha512-uu9ZDI95Uij4qk+L6kyFjdk11zqBkcJ3Lv0sc6jZrqHvLyr0+oeekD3CnqMafBn/5PRI6uv6ulW3kNLRBUHeVw==",
+        "dependencies": {
+          "@smithy/middleware-endpoint": "@smithy/middleware-endpoint@2.5.0",
+          "@smithy/middleware-retry": "@smithy/middleware-retry@2.2.0",
+          "@smithy/middleware-serde": "@smithy/middleware-serde@2.3.0",
+          "@smithy/protocol-http": "@smithy/protocol-http@3.3.0",
+          "@smithy/smithy-client": "@smithy/smithy-client@2.5.0",
+          "@smithy/types": "@smithy/types@2.12.0",
+          "@smithy/util-middleware": "@smithy/util-middleware@2.2.0",
+          "tslib": "tslib@2.6.2"
+        }
+      },
+      "@smithy/credential-provider-imds@2.3.0": {
+        "integrity": "sha512-BWB9mIukO1wjEOo1Ojgl6LrG4avcaC7T/ZP6ptmAaW4xluhSIPZhY+/PI5YKzlk+jsm+4sQZB45Bt1OfMeQa3w==",
+        "dependencies": {
+          "@smithy/node-config-provider": "@smithy/node-config-provider@2.3.0",
+          "@smithy/property-provider": "@smithy/property-provider@2.2.0",
+          "@smithy/types": "@smithy/types@2.12.0",
+          "@smithy/url-parser": "@smithy/url-parser@2.2.0",
+          "tslib": "tslib@2.6.2"
+        }
+      },
+      "@smithy/eventstream-codec@2.2.0": {
+        "integrity": "sha512-8janZoJw85nJmQZc4L8TuePp2pk1nxLgkxIR0TUjKJ5Dkj5oelB9WtiSSGXCQvNsJl0VSTvK/2ueMXxvpa9GVw==",
+        "dependencies": {
+          "@aws-crypto/crc32": "@aws-crypto/crc32@3.0.0",
+          "@smithy/types": "@smithy/types@2.12.0",
+          "@smithy/util-hex-encoding": "@smithy/util-hex-encoding@2.2.0",
+          "tslib": "tslib@2.6.2"
+        }
+      },
+      "@smithy/fetch-http-handler@2.5.0": {
+        "integrity": "sha512-BOWEBeppWhLn/no/JxUL/ghTfANTjT7kg3Ww2rPqTUY9R4yHPXxJ9JhMe3Z03LN3aPwiwlpDIUcVw1xDyHqEhw==",
+        "dependencies": {
+          "@smithy/protocol-http": "@smithy/protocol-http@3.3.0",
+          "@smithy/querystring-builder": "@smithy/querystring-builder@2.2.0",
+          "@smithy/types": "@smithy/types@2.12.0",
+          "@smithy/util-base64": "@smithy/util-base64@2.3.0",
+          "tslib": "tslib@2.6.2"
+        }
+      },
+      "@smithy/hash-node@2.2.0": {
+        "integrity": "sha512-zLWaC/5aWpMrHKpoDF6nqpNtBhlAYKF/7+9yMN7GpdR8CzohnWfGtMznPybnwSS8saaXBMxIGwJqR4HmRp6b3g==",
+        "dependencies": {
+          "@smithy/types": "@smithy/types@2.12.0",
+          "@smithy/util-buffer-from": "@smithy/util-buffer-from@2.2.0",
+          "@smithy/util-utf8": "@smithy/util-utf8@2.3.0",
+          "tslib": "tslib@2.6.2"
+        }
+      },
+      "@smithy/invalid-dependency@2.2.0": {
+        "integrity": "sha512-nEDASdbKFKPXN2O6lOlTgrEEOO9NHIeO+HVvZnkqc8h5U9g3BIhWsvzFo+UcUbliMHvKNPD/zVxDrkP1Sbgp8Q==",
+        "dependencies": {
+          "@smithy/types": "@smithy/types@2.12.0",
+          "tslib": "tslib@2.6.2"
+        }
+      },
+      "@smithy/is-array-buffer@2.2.0": {
+        "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+        "dependencies": {
+          "tslib": "tslib@2.6.2"
+        }
+      },
+      "@smithy/middleware-content-length@2.2.0": {
+        "integrity": "sha512-5bl2LG1Ah/7E5cMSC+q+h3IpVHMeOkG0yLRyQT1p2aMJkSrZG7RlXHPuAgb7EyaFeidKEnnd/fNaLLaKlHGzDQ==",
+        "dependencies": {
+          "@smithy/protocol-http": "@smithy/protocol-http@3.3.0",
+          "@smithy/types": "@smithy/types@2.12.0",
+          "tslib": "tslib@2.6.2"
+        }
+      },
+      "@smithy/middleware-endpoint@2.5.0": {
+        "integrity": "sha512-OBhI9ZEAG8Xen0xsFJwwNOt44WE2CWkfYIxTognC8x42Lfsdf0VN/wCMqpdkySMDio/vts10BiovAxQp0T0faA==",
+        "dependencies": {
+          "@smithy/middleware-serde": "@smithy/middleware-serde@2.3.0",
+          "@smithy/node-config-provider": "@smithy/node-config-provider@2.3.0",
+          "@smithy/shared-ini-file-loader": "@smithy/shared-ini-file-loader@2.4.0",
+          "@smithy/types": "@smithy/types@2.12.0",
+          "@smithy/url-parser": "@smithy/url-parser@2.2.0",
+          "@smithy/util-middleware": "@smithy/util-middleware@2.2.0",
+          "tslib": "tslib@2.6.2"
+        }
+      },
+      "@smithy/middleware-retry@2.2.0": {
+        "integrity": "sha512-PsjDOLpbevgn37yJbawmfVoanru40qVA8UEf2+YA1lvOefmhuhL6ZbKtGsLAWDRnE1OlAmedsbA/htH6iSZjNA==",
+        "dependencies": {
+          "@smithy/node-config-provider": "@smithy/node-config-provider@2.3.0",
+          "@smithy/protocol-http": "@smithy/protocol-http@3.3.0",
+          "@smithy/service-error-classification": "@smithy/service-error-classification@2.1.5",
+          "@smithy/smithy-client": "@smithy/smithy-client@2.5.0",
+          "@smithy/types": "@smithy/types@2.12.0",
+          "@smithy/util-middleware": "@smithy/util-middleware@2.2.0",
+          "@smithy/util-retry": "@smithy/util-retry@2.2.0",
+          "tslib": "tslib@2.6.2",
+          "uuid": "uuid@8.3.2"
+        }
+      },
+      "@smithy/middleware-serde@2.3.0": {
+        "integrity": "sha512-sIADe7ojwqTyvEQBe1nc/GXB9wdHhi9UwyX0lTyttmUWDJLP655ZYE1WngnNyXREme8I27KCaUhyhZWRXL0q7Q==",
+        "dependencies": {
+          "@smithy/types": "@smithy/types@2.12.0",
+          "tslib": "tslib@2.6.2"
+        }
+      },
+      "@smithy/middleware-stack@2.2.0": {
+        "integrity": "sha512-Qntc3jrtwwrsAC+X8wms8zhrTr0sFXnyEGhZd9sLtsJ/6gGQKFzNB+wWbOcpJd7BR8ThNCoKt76BuQahfMvpeA==",
+        "dependencies": {
+          "@smithy/types": "@smithy/types@2.12.0",
+          "tslib": "tslib@2.6.2"
+        }
+      },
+      "@smithy/node-config-provider@2.3.0": {
+        "integrity": "sha512-0elK5/03a1JPWMDPaS726Iw6LpQg80gFut1tNpPfxFuChEEklo2yL823V94SpTZTxmKlXFtFgsP55uh3dErnIg==",
+        "dependencies": {
+          "@smithy/property-provider": "@smithy/property-provider@2.2.0",
+          "@smithy/shared-ini-file-loader": "@smithy/shared-ini-file-loader@2.4.0",
+          "@smithy/types": "@smithy/types@2.12.0",
+          "tslib": "tslib@2.6.2"
+        }
+      },
+      "@smithy/node-http-handler@2.5.0": {
+        "integrity": "sha512-mVGyPBzkkGQsPoxQUbxlEfRjrj6FPyA3u3u2VXGr9hT8wilsoQdZdvKpMBFMB8Crfhv5dNkKHIW0Yyuc7eABqA==",
+        "dependencies": {
+          "@smithy/abort-controller": "@smithy/abort-controller@2.2.0",
+          "@smithy/protocol-http": "@smithy/protocol-http@3.3.0",
+          "@smithy/querystring-builder": "@smithy/querystring-builder@2.2.0",
+          "@smithy/types": "@smithy/types@2.12.0",
+          "tslib": "tslib@2.6.2"
+        }
+      },
+      "@smithy/property-provider@2.2.0": {
+        "integrity": "sha512-+xiil2lFhtTRzXkx8F053AV46QnIw6e7MV8od5Mi68E1ICOjCeCHw2XfLnDEUHnT9WGUIkwcqavXjfwuJbGlpg==",
+        "dependencies": {
+          "@smithy/types": "@smithy/types@2.12.0",
+          "tslib": "tslib@2.6.2"
+        }
+      },
+      "@smithy/protocol-http@3.3.0": {
+        "integrity": "sha512-Xy5XK1AFWW2nlY/biWZXu6/krgbaf2dg0q492D8M5qthsnU2H+UgFeZLbM76FnH7s6RO/xhQRkj+T6KBO3JzgQ==",
+        "dependencies": {
+          "@smithy/types": "@smithy/types@2.12.0",
+          "tslib": "tslib@2.6.2"
+        }
+      },
+      "@smithy/querystring-builder@2.2.0": {
+        "integrity": "sha512-L1kSeviUWL+emq3CUVSgdogoM/D9QMFaqxL/dd0X7PCNWmPXqt+ExtrBjqT0V7HLN03Vs9SuiLrG3zy3JGnE5A==",
+        "dependencies": {
+          "@smithy/types": "@smithy/types@2.12.0",
+          "@smithy/util-uri-escape": "@smithy/util-uri-escape@2.2.0",
+          "tslib": "tslib@2.6.2"
+        }
+      },
+      "@smithy/querystring-parser@2.2.0": {
+        "integrity": "sha512-BvHCDrKfbG5Yhbpj4vsbuPV2GgcpHiAkLeIlcA1LtfpMz3jrqizP1+OguSNSj1MwBHEiN+jwNisXLGdajGDQJA==",
+        "dependencies": {
+          "@smithy/types": "@smithy/types@2.12.0",
+          "tslib": "tslib@2.6.2"
+        }
+      },
+      "@smithy/service-error-classification@2.1.5": {
+        "integrity": "sha512-uBDTIBBEdAQryvHdc5W8sS5YX7RQzF683XrHePVdFmAgKiMofU15FLSM0/HU03hKTnazdNRFa0YHS7+ArwoUSQ==",
+        "dependencies": {
+          "@smithy/types": "@smithy/types@2.12.0"
+        }
+      },
+      "@smithy/shared-ini-file-loader@2.4.0": {
+        "integrity": "sha512-WyujUJL8e1B6Z4PBfAqC/aGY1+C7T0w20Gih3yrvJSk97gpiVfB+y7c46T4Nunk+ZngLq0rOIdeVeIklk0R3OA==",
+        "dependencies": {
+          "@smithy/types": "@smithy/types@2.12.0",
+          "tslib": "tslib@2.6.2"
+        }
+      },
+      "@smithy/signature-v4@2.2.0": {
+        "integrity": "sha512-+B5TNzj/fRZzVW3z8UUJOkNx15+4E0CLuvJmJUA1JUIZFp3rdJ/M2H5r2SqltaVPXL0oIxv/6YK92T9TsFGbFg==",
+        "dependencies": {
+          "@smithy/eventstream-codec": "@smithy/eventstream-codec@2.2.0",
+          "@smithy/is-array-buffer": "@smithy/is-array-buffer@2.2.0",
+          "@smithy/types": "@smithy/types@2.12.0",
+          "@smithy/util-hex-encoding": "@smithy/util-hex-encoding@2.2.0",
+          "@smithy/util-middleware": "@smithy/util-middleware@2.2.0",
+          "@smithy/util-uri-escape": "@smithy/util-uri-escape@2.2.0",
+          "@smithy/util-utf8": "@smithy/util-utf8@2.3.0",
+          "tslib": "tslib@2.6.2"
+        }
+      },
+      "@smithy/smithy-client@2.5.0": {
+        "integrity": "sha512-DDXWHWdimtS3y/Kw1Jo46KQ0ZYsDKcldFynQERUGBPDpkW1lXOTHy491ALHjwfiBQvzsVKVxl5+ocXNIgJuX4g==",
+        "dependencies": {
+          "@smithy/middleware-endpoint": "@smithy/middleware-endpoint@2.5.0",
+          "@smithy/middleware-stack": "@smithy/middleware-stack@2.2.0",
+          "@smithy/protocol-http": "@smithy/protocol-http@3.3.0",
+          "@smithy/types": "@smithy/types@2.12.0",
+          "@smithy/util-stream": "@smithy/util-stream@2.2.0",
+          "tslib": "tslib@2.6.2"
+        }
+      },
+      "@smithy/types@2.12.0": {
+        "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+        "dependencies": {
+          "tslib": "tslib@2.6.2"
+        }
+      },
+      "@smithy/url-parser@2.2.0": {
+        "integrity": "sha512-hoA4zm61q1mNTpksiSWp2nEl1dt3j726HdRhiNgVJQMj7mLp7dprtF57mOB6JvEk/x9d2bsuL5hlqZbBuHQylQ==",
+        "dependencies": {
+          "@smithy/querystring-parser": "@smithy/querystring-parser@2.2.0",
+          "@smithy/types": "@smithy/types@2.12.0",
+          "tslib": "tslib@2.6.2"
+        }
+      },
+      "@smithy/util-base64@2.3.0": {
+        "integrity": "sha512-s3+eVwNeJuXUwuMbusncZNViuhv2LjVJ1nMwTqSA0XAC7gjKhqqxRdJPhR8+YrkoZ9IiIbFk/yK6ACe/xlF+hw==",
+        "dependencies": {
+          "@smithy/util-buffer-from": "@smithy/util-buffer-from@2.2.0",
+          "@smithy/util-utf8": "@smithy/util-utf8@2.3.0",
+          "tslib": "tslib@2.6.2"
+        }
+      },
+      "@smithy/util-body-length-browser@2.2.0": {
+        "integrity": "sha512-dtpw9uQP7W+n3vOtx0CfBD5EWd7EPdIdsQnWTDoFf77e3VUf05uA7R7TGipIo8e4WL2kuPdnsr3hMQn9ziYj5w==",
+        "dependencies": {
+          "tslib": "tslib@2.6.2"
+        }
+      },
+      "@smithy/util-body-length-node@2.3.0": {
+        "integrity": "sha512-ITWT1Wqjubf2CJthb0BuT9+bpzBfXeMokH/AAa5EJQgbv9aPMVfnM76iFIZVFf50hYXGbtiV71BHAthNWd6+dw==",
+        "dependencies": {
+          "tslib": "tslib@2.6.2"
+        }
+      },
+      "@smithy/util-buffer-from@2.2.0": {
+        "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+        "dependencies": {
+          "@smithy/is-array-buffer": "@smithy/is-array-buffer@2.2.0",
+          "tslib": "tslib@2.6.2"
+        }
+      },
+      "@smithy/util-config-provider@2.3.0": {
+        "integrity": "sha512-HZkzrRcuFN1k70RLqlNK4FnPXKOpkik1+4JaBoHNJn+RnJGYqaa3c5/+XtLOXhlKzlRgNvyaLieHTW2VwGN0VQ==",
+        "dependencies": {
+          "tslib": "tslib@2.6.2"
+        }
+      },
+      "@smithy/util-defaults-mode-browser@2.2.0": {
+        "integrity": "sha512-2okTdZaCBvOJszAPU/KSvlimMe35zLOKbQpHhamFJmR7t95HSe0K3C92jQPjKY3PmDBD+7iMkOnuW05F5OlF4g==",
+        "dependencies": {
+          "@smithy/property-provider": "@smithy/property-provider@2.2.0",
+          "@smithy/smithy-client": "@smithy/smithy-client@2.5.0",
+          "@smithy/types": "@smithy/types@2.12.0",
+          "bowser": "bowser@2.11.0",
+          "tslib": "tslib@2.6.2"
+        }
+      },
+      "@smithy/util-defaults-mode-node@2.3.0": {
+        "integrity": "sha512-hfKXnNLmsW9cmLb/JXKIvtuO6Cf4SuqN5PN1C2Ru/TBIws+m1wSgb+A53vo0r66xzB6E82inKG2J7qtwdi+Kkw==",
+        "dependencies": {
+          "@smithy/config-resolver": "@smithy/config-resolver@2.2.0",
+          "@smithy/credential-provider-imds": "@smithy/credential-provider-imds@2.3.0",
+          "@smithy/node-config-provider": "@smithy/node-config-provider@2.3.0",
+          "@smithy/property-provider": "@smithy/property-provider@2.2.0",
+          "@smithy/smithy-client": "@smithy/smithy-client@2.5.0",
+          "@smithy/types": "@smithy/types@2.12.0",
+          "tslib": "tslib@2.6.2"
+        }
+      },
+      "@smithy/util-endpoints@1.2.0": {
+        "integrity": "sha512-BuDHv8zRjsE5zXd3PxFXFknzBG3owCpjq8G3FcsXW3CykYXuEqM3nTSsmLzw5q+T12ZYuDlVUZKBdpNbhVtlrQ==",
+        "dependencies": {
+          "@smithy/node-config-provider": "@smithy/node-config-provider@2.3.0",
+          "@smithy/types": "@smithy/types@2.12.0",
+          "tslib": "tslib@2.6.2"
+        }
+      },
+      "@smithy/util-hex-encoding@2.2.0": {
+        "integrity": "sha512-7iKXR+/4TpLK194pVjKiasIyqMtTYJsgKgM242Y9uzt5dhHnUDvMNb+3xIhRJ9QhvqGii/5cRUt4fJn3dtXNHQ==",
+        "dependencies": {
+          "tslib": "tslib@2.6.2"
+        }
+      },
+      "@smithy/util-middleware@2.2.0": {
+        "integrity": "sha512-L1qpleXf9QD6LwLCJ5jddGkgWyuSvWBkJwWAZ6kFkdifdso+sk3L3O1HdmPvCdnCK3IS4qWyPxev01QMnfHSBw==",
+        "dependencies": {
+          "@smithy/types": "@smithy/types@2.12.0",
+          "tslib": "tslib@2.6.2"
+        }
+      },
+      "@smithy/util-retry@2.2.0": {
+        "integrity": "sha512-q9+pAFPTfftHXRytmZ7GzLFFrEGavqapFc06XxzZFcSIGERXMerXxCitjOG1prVDR9QdjqotF40SWvbqcCpf8g==",
+        "dependencies": {
+          "@smithy/service-error-classification": "@smithy/service-error-classification@2.1.5",
+          "@smithy/types": "@smithy/types@2.12.0",
+          "tslib": "tslib@2.6.2"
+        }
+      },
+      "@smithy/util-stream@2.2.0": {
+        "integrity": "sha512-17faEXbYWIRst1aU9SvPZyMdWmqIrduZjVOqCPMIsWFNxs5yQQgFrJL6b2SdiCzyW9mJoDjFtgi53xx7EH+BXA==",
+        "dependencies": {
+          "@smithy/fetch-http-handler": "@smithy/fetch-http-handler@2.5.0",
+          "@smithy/node-http-handler": "@smithy/node-http-handler@2.5.0",
+          "@smithy/types": "@smithy/types@2.12.0",
+          "@smithy/util-base64": "@smithy/util-base64@2.3.0",
+          "@smithy/util-buffer-from": "@smithy/util-buffer-from@2.2.0",
+          "@smithy/util-hex-encoding": "@smithy/util-hex-encoding@2.2.0",
+          "@smithy/util-utf8": "@smithy/util-utf8@2.3.0",
+          "tslib": "tslib@2.6.2"
+        }
+      },
+      "@smithy/util-uri-escape@2.2.0": {
+        "integrity": "sha512-jtmJMyt1xMD/d8OtbVJ2gFZOSKc+ueYJZPW20ULW1GOp/q/YIM0wNh+u8ZFao9UaIGz4WoPW8hC64qlWLIfoDA==",
+        "dependencies": {
+          "tslib": "tslib@2.6.2"
+        }
+      },
+      "@smithy/util-utf8@2.3.0": {
+        "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+        "dependencies": {
+          "@smithy/util-buffer-from": "@smithy/util-buffer-from@2.2.0",
+          "tslib": "tslib@2.6.2"
+        }
+      },
       "@types/aws-lambda@8.10.110": {
         "integrity": "sha512-r6egf2Cwv/JaFTTrF9OXFVUB3j/SXTgM9BwrlbBRjWAa2Tu6GWoDoLflppAZ8uSfbUJdXvC7Br3DjuN9pQ2NUQ==",
         "dependencies": {}
@@ -271,7 +1002,9 @@
       },
       "@types/jsonwebtoken@9.0.1": {
         "integrity": "sha512-c5ltxazpWabia/4UzhIoaDcIza4KViOQhdbjRlfcIGVnsE3c3brkz9Z+F/EeJIECOQP7W7US2hNE930cWWkPiw==",
-        "dependencies": { "@types/node": "@types/node@18.11.9" }
+        "dependencies": {
+          "@types/node": "@types/node@18.11.9"
+        }
       },
       "@types/lru-cache@5.1.1": {
         "integrity": "sha512-ssE3Vlrys7sdIzs5LOxCzTVMsU7i9oa/IaW92wF32JFb3CVczqOkru2xspuKczHEbG3nvmPY7IFqVmGGHdNbYw==",
@@ -296,6 +1029,10 @@
         "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==",
         "dependencies": {}
       },
+      "bowser@2.11.0": {
+        "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
+        "dependencies": {}
+      },
       "btoa-lite@1.0.0": {
         "integrity": "sha512-gvW7InbIyF8AicrqWoptdW08pUxuhq8BEgowNajy9RhiE86fmGAGl+bLKo6oB8QP0CkqHLowfN0oJdKC/J6LbA==",
         "dependencies": {}
@@ -314,7 +1051,15 @@
       },
       "ecdsa-sig-formatter@1.0.11": {
         "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
-        "dependencies": { "safe-buffer": "safe-buffer@5.2.1" }
+        "dependencies": {
+          "safe-buffer": "safe-buffer@5.2.1"
+        }
+      },
+      "fast-xml-parser@4.2.5": {
+        "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
+        "dependencies": {
+          "strnum": "strnum@1.0.5"
+        }
       },
       "fromentries@1.3.2": {
         "integrity": "sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==",
@@ -358,7 +1103,9 @@
       },
       "lru-cache@6.0.0": {
         "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-        "dependencies": { "yallist": "yallist@4.0.0" }
+        "dependencies": {
+          "yallist": "yallist@4.0.0"
+        }
       },
       "ms@2.1.3": {
         "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
@@ -366,7 +1113,9 @@
       },
       "node-fetch@2.6.9": {
         "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
-        "dependencies": { "whatwg-url": "whatwg-url@5.0.0" }
+        "dependencies": {
+          "whatwg-url": "whatwg-url@5.0.0"
+        }
       },
       "octokit@2.0.14_@octokit+core@4.2.0": {
         "integrity": "sha512-z6cgZBFxirpFEQ1La8Lg83GCs5hOV2EPpkYYdjsGNbfQMv8qUGjq294MiRBCbZqLufviakGsPUxaNKe3JrPmsA==",
@@ -383,7 +1132,9 @@
       },
       "once@1.4.0": {
         "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-        "dependencies": { "wrappy": "wrappy@1.0.2" }
+        "dependencies": {
+          "wrappy": "wrappy@1.0.2"
+        }
       },
       "pretty-bytes@6.1.0": {
         "integrity": "sha512-Rk753HI8f4uivXi4ZCIYdhmG1V+WKzvRMg/X+M42a6t7D07RcmopXJMDNk6N++7Bl75URRGsb40ruvg7Hcp2wQ==",
@@ -395,10 +1146,24 @@
       },
       "semver@7.3.8": {
         "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-        "dependencies": { "lru-cache": "lru-cache@6.0.0" }
+        "dependencies": {
+          "lru-cache": "lru-cache@6.0.0"
+        }
+      },
+      "strnum@1.0.5": {
+        "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
+        "dependencies": {}
       },
       "tr46@0.0.3": {
         "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+        "dependencies": {}
+      },
+      "tslib@1.14.1": {
+        "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+        "dependencies": {}
+      },
+      "tslib@2.6.2": {
+        "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
         "dependencies": {}
       },
       "universal-github-app-jwt@1.1.1": {
@@ -410,6 +1175,14 @@
       },
       "universal-user-agent@6.0.0": {
         "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==",
+        "dependencies": {}
+      },
+      "uuid@8.3.2": {
+        "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+        "dependencies": {}
+      },
+      "uuid@9.0.1": {
+        "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
         "dependencies": {}
       },
       "webidl-conversions@3.0.1": {
@@ -436,5 +1209,54 @@
         "dependencies": {}
       }
     }
+  },
+  "remote": {
+    "https://deno.land/x/deno_dom@v0.1.22-alpha/build/deno-wasm/deno-wasm.js": "077162a693528034d8ef84b6602e3562db3ce07c15ce2cf547fe76f7ef48f940",
+    "https://deno.land/x/deno_dom@v0.1.22-alpha/deno-dom-wasm.ts": "bfd999a493a6974e9fca4d331bee03bfb68cfc600c662cd0b48b21d67a2a8ba0",
+    "https://deno.land/x/deno_dom@v0.1.22-alpha/src/api.ts": "cddf406ac2bb73b3b92b1c587acf0a74519884a6e6798b2dbebe9a7ba8842d35",
+    "https://deno.land/x/deno_dom@v0.1.22-alpha/src/constructor-lock.ts": "59714df7e0571ec7bd338903b1f396202771a6d4d7f55a452936bd0de9deb186",
+    "https://deno.land/x/deno_dom@v0.1.22-alpha/src/deserialize.ts": "3c8ec2fccddac7af0963816f44940a420c4ecea6bb41c0e9d4485a3f26dd712e",
+    "https://deno.land/x/deno_dom@v0.1.22-alpha/src/dom/document-fragment.ts": "a40c6e18dd0efcf749a31552c1c9a6f7fa614452245e86ee38fc92ba0235e5ae",
+    "https://deno.land/x/deno_dom@v0.1.22-alpha/src/dom/document.ts": "f6dc03ac37170b93c97c2c1e7034e3e35b3434c709a4978f2eeaf0ca177588b4",
+    "https://deno.land/x/deno_dom@v0.1.22-alpha/src/dom/dom-parser.ts": "609097b426f8c2358f3e5d2bca55ed026cf26cdf86562e94130dfdb0f2537f92",
+    "https://deno.land/x/deno_dom@v0.1.22-alpha/src/dom/element.ts": "68256e45aee0ba5b2c784f3b2d6e1492bf424bc0216bf6940723054ee3461636",
+    "https://deno.land/x/deno_dom@v0.1.22-alpha/src/dom/html-collection.ts": "ae90197f5270c32074926ad6cf30ee07d274d44596c7e413c354880cebce8565",
+    "https://deno.land/x/deno_dom@v0.1.22-alpha/src/dom/node-list.ts": "d9c07baf0acc383112cbabafacf26a0aedb04d0866645e7485f5ab23e470b6f8",
+    "https://deno.land/x/deno_dom@v0.1.22-alpha/src/dom/node.ts": "76a73a970e05b9d00b4f9249d5276c68a05581313eb070c269109d6268c2a7b9",
+    "https://deno.land/x/deno_dom@v0.1.22-alpha/src/dom/selectors/custom-api.ts": "852696bd58e534bc41bd3be9e2250b60b67cd95fd28ed16b1deff1d548531a71",
+    "https://deno.land/x/deno_dom@v0.1.22-alpha/src/dom/selectors/nwsapi-types.ts": "c43b36c36acc5d32caabaa54fda8c9d239b2b0fcbce9a28efb93c84aa1021698",
+    "https://deno.land/x/deno_dom@v0.1.22-alpha/src/dom/selectors/nwsapi.js": "10a2bf1409c9e82f3d6b604d275dd3418cb26348e659411502e19b6aed699772",
+    "https://deno.land/x/deno_dom@v0.1.22-alpha/src/dom/selectors/selectors.ts": "83eab57be2290fb48e3130533448c93c6c61239f2a2f3b85f1917f80ca0fdc75",
+    "https://deno.land/x/deno_dom@v0.1.22-alpha/src/dom/selectors/sizzle-types.ts": "78149e2502409989ce861ed636b813b059e16bc267bb543e7c2b26ef43e4798b",
+    "https://deno.land/x/deno_dom@v0.1.22-alpha/src/dom/selectors/sizzle.js": "c3aed60c1045a106d8e546ac2f85cc82e65f62d9af2f8f515210b9212286682a",
+    "https://deno.land/x/deno_dom@v0.1.22-alpha/src/dom/utils-types.ts": "96db30e3e4a75b194201bb9fa30988215da7f91b380fca6a5143e51ece2a8436",
+    "https://deno.land/x/deno_dom@v0.1.22-alpha/src/dom/utils.ts": "90a2bfb9507be15ee0567352dc722582938336e6069871efe21997d8dc2aa605",
+    "https://deno.land/x/deno_dom@v0.1.22-alpha/src/parser.ts": "b65eb7e673fa7ca611de871de109655f0aa9fa35ddc1de73df1a5fc2baafc332",
+    "https://deno.land/x/deno_dom@v0.1.34-alpha/build/deno-wasm/deno-wasm.js": "3fa41dba4813e6d4b024a53a146b76e1afcbdf218fc02063442378c61239ed14",
+    "https://deno.land/x/deno_dom@v0.1.34-alpha/deno-dom-wasm.ts": "bfd999a493a6974e9fca4d331bee03bfb68cfc600c662cd0b48b21d67a2a8ba0",
+    "https://deno.land/x/deno_dom@v0.1.34-alpha/src/api.ts": "0ff5790f0a3eeecb4e00b7d8fbfa319b165962cf6d0182a65ba90f158d74f7d7",
+    "https://deno.land/x/deno_dom@v0.1.34-alpha/src/constructor-lock.ts": "59714df7e0571ec7bd338903b1f396202771a6d4d7f55a452936bd0de9deb186",
+    "https://deno.land/x/deno_dom@v0.1.34-alpha/src/deserialize.ts": "f4d34514ca00473ca428b69ad437ba345925744b5d791cb9552e2d7a0e7b0439",
+    "https://deno.land/x/deno_dom@v0.1.34-alpha/src/dom/document-fragment.ts": "a40c6e18dd0efcf749a31552c1c9a6f7fa614452245e86ee38fc92ba0235e5ae",
+    "https://deno.land/x/deno_dom@v0.1.34-alpha/src/dom/document.ts": "bcb96378097106d82e0d1a356496baea1b73f92dd7d492e6ed655016025665df",
+    "https://deno.land/x/deno_dom@v0.1.34-alpha/src/dom/dom-parser.ts": "609097b426f8c2358f3e5d2bca55ed026cf26cdf86562e94130dfdb0f2537f92",
+    "https://deno.land/x/deno_dom@v0.1.34-alpha/src/dom/element.ts": "312ae401081e6ce11cf62a854c0f78388e4be46579c1fdd9c1d118bc9c79db38",
+    "https://deno.land/x/deno_dom@v0.1.34-alpha/src/dom/elements/html-template-element.ts": "19ad97c55222115e8daaca2788b9c98cc31a7f9d2547ed5bca0c56a4a12bfec8",
+    "https://deno.land/x/deno_dom@v0.1.34-alpha/src/dom/html-collection.ts": "ae90197f5270c32074926ad6cf30ee07d274d44596c7e413c354880cebce8565",
+    "https://deno.land/x/deno_dom@v0.1.34-alpha/src/dom/node-list.ts": "d9c07baf0acc383112cbabafacf26a0aedb04d0866645e7485f5ab23e470b6f8",
+    "https://deno.land/x/deno_dom@v0.1.34-alpha/src/dom/node.ts": "778b7cf182105ae2c39a7d0b44aaea701c0af35e85b7cfa5e8b38f8bd67f7ad4",
+    "https://deno.land/x/deno_dom@v0.1.34-alpha/src/dom/selectors/custom-api.ts": "852696bd58e534bc41bd3be9e2250b60b67cd95fd28ed16b1deff1d548531a71",
+    "https://deno.land/x/deno_dom@v0.1.34-alpha/src/dom/selectors/nwsapi-types.ts": "c43b36c36acc5d32caabaa54fda8c9d239b2b0fcbce9a28efb93c84aa1021698",
+    "https://deno.land/x/deno_dom@v0.1.34-alpha/src/dom/selectors/nwsapi.js": "985d7d8fc1eabbb88946b47a1c44c1b2d4aa79ff23c21424219f1528fa27a2ff",
+    "https://deno.land/x/deno_dom@v0.1.34-alpha/src/dom/selectors/selectors.ts": "83eab57be2290fb48e3130533448c93c6c61239f2a2f3b85f1917f80ca0fdc75",
+    "https://deno.land/x/deno_dom@v0.1.34-alpha/src/dom/selectors/sizzle-types.ts": "78149e2502409989ce861ed636b813b059e16bc267bb543e7c2b26ef43e4798b",
+    "https://deno.land/x/deno_dom@v0.1.34-alpha/src/dom/selectors/sizzle.js": "c3aed60c1045a106d8e546ac2f85cc82e65f62d9af2f8f515210b9212286682a",
+    "https://deno.land/x/deno_dom@v0.1.34-alpha/src/dom/utils-types.ts": "96db30e3e4a75b194201bb9fa30988215da7f91b380fca6a5143e51ece2a8436",
+    "https://deno.land/x/deno_dom@v0.1.34-alpha/src/dom/utils.ts": "ecd889ba74f3ce282620d8ca1d4d5e0365e6cc86101d2352f3bbf936ae496e2c",
+    "https://deno.land/x/deno_dom@v0.1.34-alpha/src/parser.ts": "b65eb7e673fa7ca611de871de109655f0aa9fa35ddc1de73df1a5fc2baafc332",
+    "https://esm.sh/pretty-bytes@6.0.0": "abedb19018160e1ea3f1989e82b2858227ca2c0d49f7d410ff12bcbfebd658eb",
+    "https://esm.sh/v93/pretty-bytes@6.0.0/deno/pretty-bytes.js": "a6d9111496d7ff73b585302c10d6b16aca7fb4bc473ad999b5e39a4e48a1ab8c",
+    "https://esm.sh/v93/pretty-bytes@6.0.0/index.d.ts": "5137a51bcb5f7b62737ab2773b24d1c3b3f7c270bd5501e9ecba1adecab9eaec",
+    "https://raw.githubusercontent.com/GoogleChrome/lighthouse-ci/v0.10.0/types/assert.d.ts": "6bc48c6cdb2fa2033c794ee4a03d1259e4839c0d874d9d9516197db41f551652"
   }
 }

--- a/scripts/deno/deno.lock
+++ b/scripts/deno/deno.lock
@@ -1211,6 +1211,9 @@
     }
   },
   "remote": {
+    "https://deno.land/std@0.207.0/assert/assert.ts": "9a97dad6d98c238938e7540736b826440ad8c1c1e54430ca4c4e623e585607ee",
+    "https://deno.land/std@0.207.0/assert/assertion_error.ts": "4d0bde9b374dfbcbe8ac23f54f567b77024fb67dbb1906a852d67fe050d42f56",
+    "https://deno.land/std@0.207.0/cli/parse_args.ts": "9bea02050b3f302e706871ff87ecfa3ad82cc34249adbe0dcddfaac75bdb48ff",
     "https://deno.land/x/deno_dom@v0.1.22-alpha/build/deno-wasm/deno-wasm.js": "077162a693528034d8ef84b6602e3562db3ce07c15ce2cf547fe76f7ef48f940",
     "https://deno.land/x/deno_dom@v0.1.22-alpha/deno-dom-wasm.ts": "bfd999a493a6974e9fca4d331bee03bfb68cfc600c662cd0b48b21d67a2a8ba0",
     "https://deno.land/x/deno_dom@v0.1.22-alpha/src/api.ts": "cddf406ac2bb73b3b92b1c587acf0a74519884a6e6798b2dbebe9a7ba8842d35",


### PR DESCRIPTION
## What does this change?

Add a Deno script that runs an Athena query to create a CSV table used for reporting on most frequent user agents accessing the Guardian website.

Built on top of #10268

[See output for 2024-03-24 in Google Sheets](https://docs.google.com/spreadsheets/d/10YHVpvZIJneLq9mcHkdtC2qLpqk_CxUpiAcw7viOWDA/edit?usp=sharing)

## Why?

Fixes #10985 

We produce reports of user-agents frequently and abstracting this away in a single script is convenient and highly reproducible.

