### PR TITLE
Start AB test to block supporter revenue messaging on Sport and Football sections

### DIFF
--- a/dotcom-rendering/src/experiments/tests/block-supporter-revenue-messaging-sport.ts
+++ b/dotcom-rendering/src/experiments/tests/block-supporter-revenue-messaging-sport.ts
@@ -3,10 +3,10 @@ import type { ABTest } from '@guardian/ab-core';
 export const blockSupporterRevenueMessagingSport: ABTest = {
 	id: 'BlockSupporterRevenueMessagingSport',
 	author: '@commercial-dev',
-	start: '2024-03-14',
-	expiry: '2024-06-01',
-	audience: 0 / 100,
-	audienceOffset: 0 / 100,
+	start: '2024-03-27',
+	expiry: '2024-05-14',
+	audience: 10 / 100,
+	audienceOffset: 5 / 100,
 	audienceCriteria: 'Fronts and articles in the Sport section',
 	successMeasure:
 		'Ad revenue and ad ratio increases without significantly impacting supporter revenue',


### PR DESCRIPTION
## What does this change?

- Starts AB test to block supporter revenue messaging on Sport and Football sections
- 5% in the variant, 5% in the control

## What is the value of this and can you measure success?

To gather information on the impact of blocking supporter revenue messaging in the Sport sections. More information can be found here:
- https://github.com/guardian/dotcom-rendering/pull/10970
- https://github.com/guardian/frontend/pull/26989

PR to start the test in Frontend: https://github.com/guardian/frontend/pull/26998