### PR TITLE
Minor most-viewed section spacing improvements

### DIFF
--- a/dotcom-rendering/src/components/MostViewedFooterLayout.tsx
+++ b/dotcom-rendering/src/components/MostViewedFooterLayout.tsx
@@ -70,13 +70,13 @@ const frontStyles = (hasPageSkin: boolean) => css`
 
 const adFreeStyles = css`
 	${between.desktop.and.leftCol} {
-		min-width: 962px;
+		min-width: 960px;
 	}
 	${between.leftCol.and.wide} {
 		width: 75%;
 	}
 	${from.wide} {
-		min-width: 962px;
+		min-width: 960px;
 	}
 `;
 
@@ -110,15 +110,17 @@ export const MostViewedFooterLayout = ({
 			>
 				{children}
 			</div>
-			<div
-				css={
-					hasPageSkin
-						? advertMarginWithPageSkin
-						: advertMargin(!!isFront, isDeeplyRead)
-				}
-			>
-				{renderAds && <AdSlot position="mostpop" />}
-			</div>
+			{renderAds && (
+				<div
+					css={
+						hasPageSkin
+							? advertMarginWithPageSkin
+							: advertMargin(!!isFront, isDeeplyRead)
+					}
+				>
+					<AdSlot position="mostpop" />
+				</div>
+			)}
 		</div>
 	);
 };


### PR DESCRIPTION
## What does this change?

- Removes the empty advert div on ad free mode. This removes 9px of space below the most-viewed section on the tablet viewport and below. The lines now link up at the bottom, just like it does on desktop viewports and above. This affects articles and liveblogs; on fronts there is extra space below the sections.
- On the desktop viewport (before left-col), aligns the right-hand line of the content to the right-hand line of the section

## Why?

- Improves the look and feel of the most-viewed section

## Screenshots

| <img width="320px" /> | Old | New |
| - | - | - |
| Mobile | ![mob-old] | ![mob-new] |
| Tablet | ![tab-old] | ![tab-new] |
| Desktop | ![desk-old] | ![desk-new] |

[mob-old]: https://github.com/guardian/dotcom-rendering/assets/9574885/f16d7202-fcd4-4fc4-b609-6c60f2667c56
[mob-new]: https://github.com/guardian/dotcom-rendering/assets/9574885/1d4d984c-5059-455f-9aa7-d8c7dca1429d
[tab-old]: https://github.com/guardian/dotcom-rendering/assets/9574885/9a96c312-68de-4b0c-a10e-c3fc94da0817
[tab-new]: https://github.com/guardian/dotcom-rendering/assets/9574885/f7df24a7-2267-4154-9af0-df87795d3851
[desk-old]: https://github.com/guardian/dotcom-rendering/assets/9574885/37967608-5625-491e-bbac-c30ed995507d
[desk-new]: https://github.com/guardian/dotcom-rendering/assets/9574885/ada2aef0-8991-4cd5-a694-287eff5a3818

<!--

Not using these as they are the same

| Tablet with ads | ![tab-old-ads] | ![tab-new-ads] |
| Desktop with ads  | ![desk-old-ads] | ![desk-new-ads] |
[tab-old-ads]: https://github.com/guardian/dotcom-rendering/assets/9574885/e969e1dc-9e41-44da-bd33-9df52e6ec5ac
[tab-new-ads]: https://github.com/guardian/dotcom-rendering/assets/9574885/959c21dd-3b8a-4a90-aeb8-f2c61c254f32
[desk-old-ads]: https://github.com/guardian/dotcom-rendering/assets/9574885/bb55751f-52f0-4c8c-992a-983f3691fda0
[desk-new-ads]: https://github.com/guardian/dotcom-rendering/assets/9574885/93687884-dd75-45c8-8116-bfa39f0b2da3


## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
