### PR TITLE
Play icon sizes

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -506,7 +506,14 @@ export const Card = ({
 												imagePositionOnMobile={
 													imagePositionOnMobile
 												}
-												imageSize={imageSize}
+												// image size defaults to small if not provided. However, if the headline size is large or greater, we want to assume the image is also large so that the play icon is correctly sized.
+												imageSize={
+													headlineSize === 'huge' ||
+													headlineSize === 'large' ||
+													headlineSize === 'ginormous'
+														? 'large'
+														: imageSize
+												}
 											/>
 										</Island>
 									</div>

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -502,6 +502,10 @@ export const Card = ({
 													containerType ===
 													'fixed/video'
 												}
+												imagePositionOnMobile={
+													imagePositionOnMobile
+												}
+												imageSize={imageSize}
 											/>
 										</Island>
 									</div>

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -436,6 +436,7 @@ export const Card = ({
 						imagePosition={imagePosition}
 						imagePositionOnMobile={imagePositionOnMobile}
 						showPlayIcon={showPlayIcon}
+						isPlayableMediaCard={!!isPlayableMediaCard}
 					>
 						{media.type === 'slideshow' && (
 							<Slideshow

--- a/dotcom-rendering/src/components/Card/components/ImageWrapper.tsx
+++ b/dotcom-rendering/src/components/Card/components/ImageWrapper.tsx
@@ -14,6 +14,7 @@ type Props = {
 	imagePosition: ImagePositionType;
 	imagePositionOnMobile: ImagePositionType;
 	showPlayIcon: boolean;
+	isPlayableMediaCard: boolean;
 };
 
 /**
@@ -60,6 +61,7 @@ export const ImageWrapper = ({
 	imagePosition,
 	imagePositionOnMobile,
 	showPlayIcon,
+	isPlayableMediaCard,
 }: Props) => {
 	const isHorizontal = imagePosition === 'left' || imagePosition === 'right';
 	const isHorizontalOnMobile =
@@ -130,6 +132,7 @@ export const ImageWrapper = ({
 					<PlayIcon
 						imageSize={imageSize}
 						imagePositionOnMobile={imagePositionOnMobile}
+						isPlayableMediaCard={isPlayableMediaCard}
 					/>
 				)}
 			</>

--- a/dotcom-rendering/src/components/Card/components/PlayIcon.tsx
+++ b/dotcom-rendering/src/components/Card/components/PlayIcon.tsx
@@ -13,18 +13,17 @@ const sizes = {
 } as const satisfies Record<string, { button: number; icon: number }>;
 
 const iconWrapperStyles = css`
-	display: flex; /* Fixes the div mis-sizing itself */
+	display: flex;
 	position: absolute;
 	top: 50%;
 	left: 50%;
-	margin-top: -20px;
-	margin-left: -20px;
+	transform: translate(-50%, -50%);
 `;
 
 const iconPulseStyles = css`
 	:focus,
 	:hover {
-		transform: scale(1.15);
+		transform: translate(-50%, -50%) scale(1.15);
 		transition-duration: 300ms;
 	}
 `;
@@ -62,13 +61,12 @@ const iconStyles = (
 const getIconSizeOnDesktop = (imageSize: ImageSizeType) => {
 	switch (imageSize) {
 		case 'jumbo':
-			return 'xlarge';
 		case 'large':
 		case 'carousel':
 			return 'large';
 		case 'medium':
 		case 'small':
-			return imageSize;
+			return 'small';
 	}
 };
 

--- a/dotcom-rendering/src/components/Card/components/PlayIcon.tsx
+++ b/dotcom-rendering/src/components/Card/components/PlayIcon.tsx
@@ -17,7 +17,16 @@ const iconWrapperStyles = css`
 	position: absolute;
 	top: 50%;
 	left: 50%;
-	transform: translate(-50%, -50%);
+	margin-top: -20px;
+	margin-left: -20px;
+`;
+
+const iconPulseStyles = css`
+	:focus,
+	:hover {
+		transform: scale(1.15);
+		transition-duration: 300ms;
+	}
 `;
 
 const iconStyles = (
@@ -71,12 +80,14 @@ const getIconSizeOnMobile = (imagePositionOnMobile: ImagePositionType) =>
 export const PlayIcon = ({
 	imageSize,
 	imagePositionOnMobile,
+	isPlayableMediaCard,
 }: {
 	imageSize: ImageSizeType;
 	imagePositionOnMobile: ImagePositionType;
+	isPlayableMediaCard: boolean;
 }) => {
 	return (
-		<div css={iconWrapperStyles}>
+		<div css={[iconWrapperStyles, isPlayableMediaCard && iconPulseStyles]}>
 			<span
 				css={[
 					iconStyles(

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.stories.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.stories.tsx
@@ -75,6 +75,8 @@ export const NoConsent = (): JSX.Element => {
 				imaEnabled={false}
 				abTestParticipations={{}}
 				adTargeting={adTargeting}
+				imagePositionOnMobile="none"
+				imageSize="large"
 			/>
 		</div>
 	);
@@ -105,6 +107,8 @@ export const NoOverlay = (): JSX.Element => {
 				imaEnabled={false}
 				abTestParticipations={{}}
 				adTargeting={adTargeting}
+				imagePositionOnMobile="none"
+				imageSize="large"
 			/>
 		</div>
 	);
@@ -141,6 +145,8 @@ export const WithOverrideImage = (): JSX.Element => {
 				imaEnabled={false}
 				abTestParticipations={{}}
 				adTargeting={adTargeting}
+				imagePositionOnMobile="none"
+				imageSize="large"
 			/>
 		</div>
 	);
@@ -176,6 +182,8 @@ export const WithPosterImage = (): JSX.Element => {
 				imaEnabled={false}
 				abTestParticipations={{}}
 				adTargeting={adTargeting}
+				imagePositionOnMobile="none"
+				imageSize="large"
 			/>
 		</div>
 	);
@@ -212,6 +220,8 @@ export const WithOverlayAndPosterImage = (): JSX.Element => {
 				adTargeting={adTargeting}
 				kicker="Breaking News"
 				showTextOverlay={true}
+				imagePositionOnMobile="none"
+				imageSize="large"
 			/>
 		</div>
 	);
@@ -247,6 +257,8 @@ export const GiveConsent = (): JSX.Element => {
 					imaEnabled={false}
 					abTestParticipations={{}}
 					adTargeting={adTargeting}
+					imagePositionOnMobile="none"
+					imageSize="large"
 				/>
 			</div>
 		</>
@@ -281,6 +293,8 @@ export const Sticky = (): JSX.Element => {
 				abTestParticipations={{}}
 				adTargeting={adTargeting}
 				shouldPauseOutOfView={true}
+				imagePositionOnMobile="none"
+				imageSize="large"
 			/>
 			<div style={{ height: '1000px' }}></div>
 		</div>
@@ -314,6 +328,8 @@ export const StickyMainMedia = (): JSX.Element => {
 				imaEnabled={false}
 				abTestParticipations={{}}
 				adTargeting={adTargeting}
+				imagePositionOnMobile="none"
+				imageSize="large"
 			/>
 			<div style={{ height: '1000px' }}></div>
 		</div>
@@ -348,6 +364,8 @@ export const DuplicateVideos = (): JSX.Element => {
 				imaEnabled={false}
 				abTestParticipations={{}}
 				adTargeting={adTargeting}
+				imagePositionOnMobile="none"
+				imageSize="large"
 			/>
 			<br />
 			<YoutubeAtom
@@ -370,6 +388,8 @@ export const DuplicateVideos = (): JSX.Element => {
 				imaEnabled={false}
 				abTestParticipations={{}}
 				adTargeting={adTargeting}
+				imagePositionOnMobile="none"
+				imageSize="large"
 			/>
 		</div>
 	);
@@ -410,6 +430,8 @@ export const MultipleStickyVideos = (): JSX.Element => {
 				imaEnabled={false}
 				abTestParticipations={{}}
 				adTargeting={adTargeting}
+				imagePositionOnMobile="none"
+				imageSize="large"
 			/>
 			<YoutubeAtom
 				index={456}
@@ -433,6 +455,8 @@ export const MultipleStickyVideos = (): JSX.Element => {
 				imaEnabled={false}
 				abTestParticipations={{}}
 				adTargeting={adTargeting}
+				imagePositionOnMobile="none"
+				imageSize="large"
 			/>
 			<YoutubeAtom
 				index={789}
@@ -456,6 +480,8 @@ export const MultipleStickyVideos = (): JSX.Element => {
 				imaEnabled={false}
 				abTestParticipations={{}}
 				adTargeting={adTargeting}
+				imagePositionOnMobile="none"
+				imageSize="large"
 			/>
 		</div>
 	);
@@ -492,6 +518,8 @@ export const PausesOffscreen = (): JSX.Element => {
 				abTestParticipations={{}}
 				adTargeting={adTargeting}
 				shouldPauseOutOfView={true}
+				imagePositionOnMobile="none"
+				imageSize="large"
 			/>
 			<div style={{ height: '1000px' }}></div>
 			<p>It stopped playing!</p>
@@ -526,6 +554,8 @@ export const NoConsentWithIma = (): JSX.Element => {
 				isMainMedia={false}
 				imaEnabled={true}
 				abTestParticipations={{}}
+				imagePositionOnMobile="none"
+				imageSize="large"
 			/>
 		</div>
 	);
@@ -555,6 +585,8 @@ export const AdFreeWithIma = (): JSX.Element => {
 				isMainMedia={false}
 				imaEnabled={true}
 				abTestParticipations={{}}
+				imagePositionOnMobile="none"
+				imageSize="large"
 			/>
 		</div>
 	);
@@ -585,6 +617,8 @@ export const NoOverlayWithIma = (): JSX.Element => {
 				title="Rayshard Brooks: US justice system treats us like 'animals'"
 				imaEnabled={true}
 				abTestParticipations={{}}
+				imagePositionOnMobile="none"
+				imageSize="large"
 			/>
 		</div>
 	);
@@ -614,6 +648,8 @@ export const WithOverrideImageWithIma = (): JSX.Element => {
 				title="How to stop the spread of coronavirus"
 				imaEnabled={true}
 				abTestParticipations={{}}
+				imagePositionOnMobile="none"
+				imageSize="large"
 			/>
 		</div>
 	);
@@ -645,6 +681,8 @@ export const WithPosterImageWithIma = (): JSX.Element => {
 				title="How Donald Trump’s broken promises failed Ohio | Anywhere but Washington"
 				imaEnabled={true}
 				abTestParticipations={{}}
+				imagePositionOnMobile="none"
+				imageSize="large"
 			/>
 		</div>
 	);
@@ -677,6 +715,8 @@ export const WithOverlayAndPosterImageWithIma = (): JSX.Element => {
 				title="How Donald Trump’s broken promises failed Ohio"
 				imaEnabled={true}
 				abTestParticipations={{}}
+				imagePositionOnMobile="none"
+				imageSize="large"
 			/>
 		</div>
 	);
@@ -711,6 +751,8 @@ export const GiveConsentWithIma = (): JSX.Element => {
 					title="How to stop the spread of coronavirus"
 					imaEnabled={true}
 					abTestParticipations={{}}
+					imagePositionOnMobile="none"
+					imageSize="large"
 				/>
 			</div>
 		</>
@@ -744,6 +786,8 @@ export const StickyWithIma = (): JSX.Element => {
 				title="Rayshard Brooks: US justice system treats us like 'animals'"
 				imaEnabled={true}
 				abTestParticipations={{}}
+				imagePositionOnMobile="none"
+				imageSize="large"
 			/>
 			<div style={{ height: '1000px' }}></div>
 		</div>
@@ -777,6 +821,8 @@ export const StickyMainMediaWithIma = (): JSX.Element => {
 				title="Rayshard Brooks: US justice system treats us like 'animals'"
 				imaEnabled={true}
 				abTestParticipations={{}}
+				imagePositionOnMobile="none"
+				imageSize="large"
 			/>
 			<div style={{ height: '1000px' }}></div>
 		</div>
@@ -806,6 +852,8 @@ export const DuplicateVideosWithIma = (): JSX.Element => {
 				shouldStick={true}
 				imaEnabled={true}
 				abTestParticipations={{}}
+				imagePositionOnMobile="none"
+				imageSize="large"
 			/>
 			<br />
 			<YoutubeAtom
@@ -828,6 +876,8 @@ export const DuplicateVideosWithIma = (): JSX.Element => {
 				shouldStick={true}
 				imaEnabled={true}
 				abTestParticipations={{}}
+				imagePositionOnMobile="none"
+				imageSize="large"
 			/>
 		</div>
 	);
@@ -862,6 +912,8 @@ export const MultipleStickyVideosWithIma = (): JSX.Element => {
 				title="Rayshard Brooks: US justice system treats us like 'animals'"
 				imaEnabled={true}
 				abTestParticipations={{}}
+				imagePositionOnMobile="none"
+				imageSize="large"
 			/>
 			<YoutubeAtom
 				index={456}
@@ -885,6 +937,8 @@ export const MultipleStickyVideosWithIma = (): JSX.Element => {
 				title="Rayshard Brooks: US justice system treats us like 'animals'"
 				imaEnabled={true}
 				abTestParticipations={{}}
+				imagePositionOnMobile="none"
+				imageSize="large"
 			/>
 			<YoutubeAtom
 				index={789}
@@ -908,6 +962,8 @@ export const MultipleStickyVideosWithIma = (): JSX.Element => {
 				title="Rayshard Brooks: US justice system treats us like 'animals'"
 				imaEnabled={true}
 				abTestParticipations={{}}
+				imagePositionOnMobile="none"
+				imageSize="large"
 			/>
 		</div>
 	);

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.test.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.test.tsx
@@ -44,6 +44,8 @@ describe('YoutubeAtom', () => {
 					isMainMedia={false}
 					imaEnabled={false}
 					abTestParticipations={{}}
+					imagePositionOnMobile="none"
+					imageSize="large"
 				/>
 			</ConfigProvider>
 		);
@@ -75,6 +77,8 @@ describe('YoutubeAtom', () => {
 					isMainMedia={false}
 					imaEnabled={false}
 					abTestParticipations={{}}
+					imagePositionOnMobile="none"
+					imageSize="large"
 				/>
 			</ConfigProvider>
 		);
@@ -113,6 +117,8 @@ describe('YoutubeAtom', () => {
 					isMainMedia={false}
 					imaEnabled={false}
 					abTestParticipations={{}}
+					imagePositionOnMobile="none"
+					imageSize="large"
 				/>
 			</ConfigProvider>
 		);
@@ -145,6 +151,8 @@ describe('YoutubeAtom', () => {
 					isMainMedia={false}
 					imaEnabled={false}
 					abTestParticipations={{}}
+					imagePositionOnMobile="none"
+					imageSize="large"
 				/>
 			</ConfigProvider>
 		);
@@ -176,6 +184,8 @@ describe('YoutubeAtom', () => {
 					isMainMedia={false}
 					imaEnabled={false}
 					abTestParticipations={{}}
+					imagePositionOnMobile="none"
+					imageSize="large"
 				/>
 			</ConfigProvider>
 		);
@@ -208,6 +218,8 @@ describe('YoutubeAtom', () => {
 					isMainMedia={false}
 					imaEnabled={false}
 					abTestParticipations={{}}
+					imagePositionOnMobile="none"
+					imageSize="large"
 				/>
 			</ConfigProvider>
 		);
@@ -238,6 +250,8 @@ describe('YoutubeAtom', () => {
 					isMainMedia={false}
 					imaEnabled={false}
 					abTestParticipations={{}}
+					imagePositionOnMobile="none"
+					imageSize="large"
 				/>
 			</ConfigProvider>
 		);
@@ -272,6 +286,8 @@ describe('YoutubeAtom', () => {
 						isMainMedia={false}
 						imaEnabled={false}
 						abTestParticipations={{}}
+						imagePositionOnMobile="left"
+						imageSize="small"
 					/>
 					<YoutubeAtom
 						index={123}
@@ -290,6 +306,8 @@ describe('YoutubeAtom', () => {
 						isMainMedia={false}
 						imaEnabled={false}
 						abTestParticipations={{}}
+						imagePositionOnMobile="left"
+						imageSize="small"
 					/>
 				</ConfigProvider>
 			</>

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.tsx
@@ -2,16 +2,16 @@ import type { Participations } from '@guardian/ab-core';
 import type { ConsentState } from '@guardian/consent-management-platform/dist/types';
 import { type ArticleFormat, isUndefined } from '@guardian/libs';
 import { useCallback, useState } from 'react';
+import type {
+	ImagePositionType,
+	ImageSizeType,
+} from '../Card/components/ImageWrapper';
 import { MaintainAspectRatio } from '../MaintainAspectRatio';
 import type { VideoCategory } from './YoutubeAtomOverlay';
 import { YoutubeAtomOverlay } from './YoutubeAtomOverlay';
 import { YoutubeAtomPlaceholder } from './YoutubeAtomPlaceholder';
 import { YoutubeAtomPlayer } from './YoutubeAtomPlayer';
 import { YoutubeAtomSticky } from './YoutubeAtomSticky';
-import {
-	ImageSizeType,
-	ImagePositionType,
-} from '../Card/components/ImageWrapper';
 
 export type VideoEventKey =
 	| 'play'

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.tsx
@@ -8,6 +8,10 @@ import { YoutubeAtomOverlay } from './YoutubeAtomOverlay';
 import { YoutubeAtomPlaceholder } from './YoutubeAtomPlaceholder';
 import { YoutubeAtomPlayer } from './YoutubeAtomPlayer';
 import { YoutubeAtomSticky } from './YoutubeAtomSticky';
+import {
+	ImageSizeType,
+	ImagePositionType,
+} from '../Card/components/ImageWrapper';
 
 export type VideoEventKey =
 	| 'play'
@@ -43,6 +47,8 @@ type Props = {
 	kicker?: string;
 	shouldPauseOutOfView?: boolean;
 	showTextOverlay?: boolean;
+	imageSize: ImageSizeType;
+	imagePositionOnMobile: ImagePositionType;
 };
 
 export const YoutubeAtom = ({
@@ -68,6 +74,8 @@ export const YoutubeAtom = ({
 	format,
 	shouldPauseOutOfView = false,
 	showTextOverlay = false,
+	imageSize,
+	imagePositionOnMobile,
 }: Props): JSX.Element => {
 	const [overlayClicked, setOverlayClicked] = useState<boolean>(false);
 	const [playerReady, setPlayerReady] = useState<boolean>(false);
@@ -208,6 +216,8 @@ export const YoutubeAtom = ({
 						kicker={kicker}
 						format={format}
 						showTextOverlay={showTextOverlay}
+						imageSize={imageSize}
+						imagePositionOnMobile={imagePositionOnMobile}
 					/>
 				)}
 				{showPlaceholder && (

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomOverlay.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomOverlay.tsx
@@ -1,17 +1,20 @@
 import { css } from '@emotion/react';
 import {
-	focusHalo,
 	from,
 	headline,
 	palette as sourcePalette,
 	space,
 	textSans,
 } from '@guardian/source-foundations';
-import { SvgMediaControlsPlay } from '@guardian/source-react-components';
 import { decidePalette } from '../../lib/decidePalette';
 import type { Palette } from '../../types/palette';
 import { secondsToDuration } from '../MediaDuration';
 import { YoutubeAtomPicture } from './YoutubeAtomPicture';
+import { PlayIcon } from '../Card/components/PlayIcon';
+import {
+	ImagePositionType,
+	ImageSizeType,
+} from '../Card/components/ImageWrapper';
 
 export type VideoCategory = 'live' | 'documentary' | 'explainer';
 
@@ -29,6 +32,8 @@ type Props = {
 	kicker?: string;
 	format: ArticleFormat;
 	showTextOverlay?: boolean;
+	imageSize: ImageSizeType;
+	imagePositionOnMobile: ImagePositionType;
 };
 
 const overlayStyles = css`
@@ -48,51 +53,6 @@ const overlayStyles = css`
 		width: 100%;
 		height: 100%;
 	}
-
-	/* hard code "overlay-play-button" to be able to give play button animation on focus/hover of overlay */
-	:focus {
-		${focusHalo}
-		.overlay-play-button {
-			transform: scale(1.15);
-			transition-duration: 300ms;
-		}
-	}
-	:hover {
-		.overlay-play-button {
-			transform: scale(1.15);
-			transition-duration: 300ms;
-		}
-	}
-`;
-
-const svgStyles = css`
-	/* Nudge Icon to the right, so it appears optically centered
-	/* https://medium.com/design-bridges/optical-effects-9fca82b4cd9a#f9d2 */
-	padding-left: ${space[2]}px;
-	svg {
-		transform-origin: center;
-		fill: ${sourcePalette.neutral[100]};
-		height: 60px;
-		transform: scale(1.15);
-		transition-duration: 300ms;
-	}
-`;
-const playButtonStyles = css`
-	position: absolute;
-	top: 50%;
-	left: 50%;
-	margin-top: -40px; /* Half the height of the circle */
-	margin-left: -40px;
-	background-color: rgba(18, 18, 18, 0.6);
-	border-radius: 100%;
-	height: 80px;
-	width: 80px;
-	transform: scale(1);
-	transition-duration: 300ms;
-
-	display: flex;
-	align-items: center;
-	justify-content: center;
 `;
 
 const pillStyles = css`
@@ -181,6 +141,8 @@ export const YoutubeAtomOverlay = ({
 	kicker,
 	format,
 	showTextOverlay,
+	imageSize,
+	imagePositionOnMobile,
 }: Props) => {
 	const id = `youtube-overlay-${uniqueId}`;
 	const hasDuration = duration !== undefined && duration > 0;
@@ -223,12 +185,11 @@ export const YoutubeAtomOverlay = ({
 					)}
 				</div>
 			)}
-			<div className="overlay-play-button" css={playButtonStyles}>
-				<span css={svgStyles}>
-					<SvgMediaControlsPlay />
-				</span>
-			</div>
-
+			<PlayIcon
+				imageSize={imageSize}
+				imagePositionOnMobile={imagePositionOnMobile}
+				isPlayableMediaCard={true}
+			/>
 			{showTextOverlay && (
 				<div css={textOverlayStyles}>
 					<div css={kickerStyles(dcrPalette)}>{kicker}</div>

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomOverlay.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomOverlay.tsx
@@ -8,13 +8,13 @@ import {
 } from '@guardian/source-foundations';
 import { decidePalette } from '../../lib/decidePalette';
 import type { Palette } from '../../types/palette';
-import { secondsToDuration } from '../MediaDuration';
-import { YoutubeAtomPicture } from './YoutubeAtomPicture';
-import { PlayIcon } from '../Card/components/PlayIcon';
-import {
+import type {
 	ImagePositionType,
 	ImageSizeType,
 } from '../Card/components/ImageWrapper';
+import { PlayIcon } from '../Card/components/PlayIcon';
+import { secondsToDuration } from '../MediaDuration';
+import { YoutubeAtomPicture } from './YoutubeAtomPicture';
 
 export type VideoCategory = 'live' | 'documentary' | 'explainer';
 
@@ -150,6 +150,8 @@ export const YoutubeAtomOverlay = ({
 	const isLive = videoCategory === 'live';
 	const dcrPalette = decidePalette(format);
 	const image = overrideImage ?? posterImage;
+	const hidePillOnMobile =
+		imagePositionOnMobile === 'right' || imagePositionOnMobile === 'left';
 
 	return (
 		<button
@@ -168,7 +170,15 @@ export const YoutubeAtomOverlay = ({
 				/>
 			)}
 			{showPill && (
-				<div css={pillStyles}>
+				<div
+					css={
+						hidePillOnMobile
+							? css`
+									display: none;
+							  `
+							: pillStyles
+					}
+				>
 					{!!videoCategory && (
 						<div css={pillItemStyles}>
 							<div css={[pillTextStyles, isLive && liveStyles]}>

--- a/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
@@ -9,12 +9,12 @@ import { getOphan } from '../client/ophan/ophan';
 import { useAB } from '../lib/useAB';
 import { useAdTargeting } from '../lib/useAdTargeting';
 import { Caption } from './Caption';
+import type {
+	ImagePositionType,
+	ImageSizeType,
+} from './Card/components/ImageWrapper';
 import { useConfig } from './ConfigContext';
 import { YoutubeAtom } from './YoutubeAtom/YoutubeAtom';
-import {
-	ImageSizeType,
-	ImagePositionType,
-} from './Card/components/ImageWrapper';
 
 type Props = {
 	id: string;
@@ -39,6 +39,7 @@ type Props = {
 	pauseOffscreenVideo?: boolean;
 	showTextOverlay?: boolean;
 	switches?: Switches;
+	// If the youtube block component is used on a card, we can pass in the image size and position on mobile to get the correct styling for the play icon. If it's not used on a card, we can just pass default values to get the standard large play icon.
 	imageSize?: ImageSizeType;
 	imagePositionOnMobile?: ImagePositionType;
 };

--- a/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
@@ -11,6 +11,10 @@ import { useAdTargeting } from '../lib/useAdTargeting';
 import { Caption } from './Caption';
 import { useConfig } from './ConfigContext';
 import { YoutubeAtom } from './YoutubeAtom/YoutubeAtom';
+import {
+	ImageSizeType,
+	ImagePositionType,
+} from './Card/components/ImageWrapper';
 
 type Props = {
 	id: string;
@@ -35,6 +39,8 @@ type Props = {
 	pauseOffscreenVideo?: boolean;
 	showTextOverlay?: boolean;
 	switches?: Switches;
+	imageSize?: ImageSizeType;
+	imagePositionOnMobile?: ImagePositionType;
 };
 
 const expiredOverlayStyles = (overrideImage?: string) =>
@@ -111,6 +117,8 @@ export const YoutubeBlockComponent = ({
 	pauseOffscreenVideo = false,
 	showTextOverlay,
 	switches,
+	imageSize = 'large',
+	imagePositionOnMobile = 'none',
 }: Props) => {
 	const [consentState, setConsentState] = useState<ConsentState | undefined>(
 		undefined,
@@ -239,6 +247,8 @@ export const YoutubeBlockComponent = ({
 				kicker={kickerText}
 				shouldPauseOutOfView={pauseOffscreenVideo}
 				showTextOverlay={showTextOverlay}
+				imageSize={imageSize}
+				imagePositionOnMobile={imagePositionOnMobile}
 			/>
 			{!hideCaption && (
 				<Caption


### PR DESCRIPTION
## What does this change?
Uses the play icon component inside the youtube atom component overlay. 

It also hides the timestamp pill on youtube embeds that are too small [as per designs](https://www.figma.com/file/opUPavNDDExUBnF7NHzzqY/Vertical-Video-Exploration?type=design&node-id=793-102770&mode=design&t=2bwVJbMijis90bGf-4). 

## Why?
We previously had two separate play icons, one on cards and one in the youtube atom. This is probably a hangover from when the youtube atom code was not part of DCR. Unifying these means we get consistent sizing of play icons across the site and fixes [#9117](https://github.com/guardian/dotcom-rendering/issues/9117)

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/20416599/0c1a6844-e663-41ce-bd3c-a29b0bbeae37
[after]: https://github.com/guardian/dotcom-rendering/assets/20416599/b1620637-f804-4143-9c2c-7bd8ff88cca1

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
