### PR TITLE
Default design decisions to `neutral / clear` if `ArticleDesign` unspecified

### DIFF
--- a/dotcom-rendering/src/components/ArticleBody.tsx
+++ b/dotcom-rendering/src/components/ArticleBody.tsx
@@ -47,13 +47,7 @@ type Props = {
 	isRightToLeftLang?: boolean;
 };
 
-const globalH2Styles = (display: ArticleDisplay) => css`
-	h2:not([data-ignore='global-h2-styling']) {
-		${display === ArticleDisplay.Immersive
-			? headline.medium({ fontWeight: 'light' })
-			: headline.xxsmall({ fontWeight: 'bold' })};
-	}
-
+const globalH2Styles = css`
 	p + h2 {
 		padding-top: 8px;
 	}
@@ -154,7 +148,7 @@ export const ArticleBody = ({
 				className="js-liveblog-body"
 				css={[
 					globalStrongStyles,
-					globalH2Styles(format.display),
+					globalH2Styles,
 					globalH3Styles(format.display),
 					globalLinkStyles(),
 					// revealStyles is used to animate the reveal of new blocks
@@ -206,7 +200,7 @@ export const ArticleBody = ({
 				id="maincontent"
 				css={[
 					isInteractive ? null : bodyPadding,
-					globalH2Styles(format.display),
+					globalH2Styles,
 					globalH3Styles(format.display),
 					globalOlStyles(),
 					globalStrongStyles,

--- a/dotcom-rendering/src/components/DropCap.tsx
+++ b/dotcom-rendering/src/components/DropCap.tsx
@@ -22,12 +22,10 @@ const dropCap = css`
 
 const fontWeight = (format: ArticleFormat) => {
 	switch (format.design) {
-		// "Authoritative" designs
 		case ArticleDesign.Obituary:
 		case ArticleDesign.Editorial:
 		case ArticleDesign.Comment:
 			return 300;
-		// "Neutral" designs
 		case ArticleDesign.Standard:
 		case ArticleDesign.Profile:
 		case ArticleDesign.Explainer:
@@ -36,9 +34,7 @@ const fontWeight = (format: ArticleFormat) => {
 		case ArticleDesign.DeadBlog:
 		case ArticleDesign.Analysis:
 			return 500;
-		// "Soft" designs
 		case ArticleDesign.Feature:
-			// News features have "neutral" styles, other features are "soft"
 			if (format.theme === Pillar.News) {
 				return 500;
 			} else {
@@ -48,10 +44,8 @@ const fontWeight = (format: ArticleFormat) => {
 		case ArticleDesign.Recipe:
 		case ArticleDesign.Review:
 			return 700;
-		case ArticleDesign.Letter:
-			return 200;
 		default:
-			return 700;
+			return 500;
 	}
 };
 

--- a/dotcom-rendering/src/components/SubheadingBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/components/SubheadingBlockComponent.stories.tsx
@@ -5,42 +5,22 @@ import {
 	ArticleSpecial,
 	Pillar,
 } from '@guardian/libs';
-import { headline } from '@guardian/source-foundations';
 import type { Decorator, Meta, StoryObj } from '@storybook/react';
 import { splitTheme } from '../../.storybook/decorators/splitThemeDecorator';
 import { SubheadingBlockComponent } from './SubheadingBlockComponent';
 
-const standardFormat = {
-	design: ArticleDesign.Standard,
-	display: ArticleDisplay.Standard,
-	theme: Pillar.News,
-};
-
-const immersiveFormat = {
-	...standardFormat,
-	display: ArticleDisplay.Immersive,
-};
-
 /** Mocking the styles normally inherited via ArticleBody component */
-const GlobalStylesDecorator =
-	(format: ArticleFormat): Decorator =>
-	(Story) => (
-		<div
-			css={css`
-				h2:not([data-ignore='global-h2-styling']) {
-					${format.display === ArticleDisplay.Immersive
-						? headline.medium({ fontWeight: 'light' })
-						: headline.xxsmall({ fontWeight: 'bold' })};
-				}
-
-				p + h2 {
-					padding-top: 8px;
-				}
-			`}
-		>
-			{Story()}
-		</div>
-	);
+const GlobalStylesDecorator: Decorator = (Story) => (
+	<div
+		css={css`
+			p + h2 {
+				padding-top: 8px;
+			}
+		`}
+	>
+		{Story()}
+	</div>
+);
 
 const StoryWrapper = ({ children }: { children: React.ReactNode }) => (
 	<div
@@ -89,7 +69,11 @@ const meta = {
 	},
 	args: {
 		html: '<h2>Subheading</h2>',
-		format: standardFormat,
+		format: {
+			design: ArticleDesign.Standard,
+			display: ArticleDisplay.Standard,
+			theme: Pillar.News,
+		},
 	},
 } satisfies Meta<typeof SubheadingBlockComponent>;
 
@@ -98,16 +82,13 @@ export default meta;
 
 export const StandardDisplay = {
 	decorators: [
-		GlobalStylesDecorator(standardFormat),
-
+		GlobalStylesDecorator,
 		splitTheme([
-			// "Authoritative clear" styles
 			{
 				design: ArticleDesign.Obituary,
 				display: ArticleDisplay.Standard,
 				theme: Pillar.News,
 			},
-			// "Authoritative stand-out" styles
 			{
 				design: ArticleDesign.Comment,
 				display: ArticleDisplay.Standard,
@@ -175,7 +156,6 @@ export const StandardDisplay = {
 				display: ArticleDisplay.Standard,
 				theme: Pillar.Culture,
 			},
-			// "Neutral stand-out" styles
 			{
 				design: ArticleDesign.Analysis,
 				display: ArticleDisplay.Standard,
@@ -186,7 +166,6 @@ export const StandardDisplay = {
 				display: ArticleDisplay.Standard,
 				theme: Pillar.News,
 			},
-			// "Soft" stand-out styles
 			{
 				design: ArticleDesign.Interview,
 				display: ArticleDisplay.Standard,
@@ -198,15 +177,13 @@ export const StandardDisplay = {
 
 export const ImmersiveDisplay = {
 	decorators: [
-		GlobalStylesDecorator(immersiveFormat),
+		GlobalStylesDecorator,
 		splitTheme([
-			// "Authoritative clear" styles
 			{
 				design: ArticleDesign.Obituary,
 				display: ArticleDisplay.Immersive,
 				theme: Pillar.News,
 			},
-			// "Authoritative stand-out" styles
 			{
 				design: ArticleDesign.Comment,
 				display: ArticleDisplay.Immersive,
@@ -227,7 +204,6 @@ export const ImmersiveDisplay = {
 				display: ArticleDisplay.Immersive,
 				theme: ArticleSpecial.Labs,
 			},
-			// "Neutral stand-out" styles
 			{
 				design: ArticleDesign.Editorial,
 				display: ArticleDisplay.Immersive,
@@ -270,7 +246,6 @@ export const ImmersiveDisplay = {
 				display: ArticleDisplay.Immersive,
 				theme: Pillar.News,
 			},
-			// "Soft" stand-out styles
 			{
 				design: ArticleDesign.Interview,
 				display: ArticleDisplay.Immersive,

--- a/dotcom-rendering/src/components/SubheadingBlockComponent.tsx
+++ b/dotcom-rendering/src/components/SubheadingBlockComponent.tsx
@@ -57,7 +57,6 @@ const getFontStyles = ({
 
 const getStyles = (format: ArticleFormat) => {
 	switch (format.design) {
-		// "Authoritative" styles
 		case ArticleDesign.Obituary:
 		case ArticleDesign.Comment:
 		case ArticleDesign.Editorial:
@@ -66,7 +65,6 @@ const getStyles = (format: ArticleFormat) => {
 			 * The desired font weight is "regular" */
 			return getFontStyles({ format, fontWeight: 'light' });
 
-		// "Neutral" styles
 		case ArticleDesign.Standard:
 		case ArticleDesign.Profile:
 		case ArticleDesign.Explainer:
@@ -76,9 +74,7 @@ const getStyles = (format: ArticleFormat) => {
 		case ArticleDesign.Analysis:
 			return getFontStyles({ format, fontWeight: 'medium' });
 
-		// "Soft" styles
 		case ArticleDesign.Feature: {
-			// News features have "neutral" styles, other features are "soft"
 			const fontWeight = format.theme === Pillar.News ? 'medium' : 'bold';
 			return getFontStyles({ format, fontWeight });
 		}
@@ -86,47 +82,10 @@ const getStyles = (format: ArticleFormat) => {
 		case ArticleDesign.Recipe:
 		case ArticleDesign.Review:
 			return getFontStyles({ format, fontWeight: 'bold' });
-		default:
-			// ! Not implemented
-			return css``; // TODO
-	}
-};
-
-const ignoreGlobalH2Styling = (format: ArticleFormat) => {
-	switch (format.design) {
-		// "Authoritative" styles
-		case ArticleDesign.Obituary:
-		case ArticleDesign.Comment:
-		case ArticleDesign.Editorial:
-		// "Neutral" styles
-		case ArticleDesign.Standard:
-		case ArticleDesign.Profile:
-		case ArticleDesign.Explainer:
-		case ArticleDesign.Timeline:
-		case ArticleDesign.LiveBlog:
-		case ArticleDesign.DeadBlog:
-		case ArticleDesign.Analysis:
-		// "Soft" styles
-		case ArticleDesign.Feature:
-		case ArticleDesign.Interview:
-		case ArticleDesign.Recipe:
-		case ArticleDesign.Review:
-			return true;
 
 		default:
-			return false;
+			return getFontStyles({ format, fontWeight: 'medium' });
 	}
-};
-
-const getStyleAttributes = (format: ArticleFormat) => {
-	return {
-		css: getStyles(format),
-		/** While working on the new styles for formats, we ignore the global styling in
-		 * ArticleBody.tsx but continue using it for the formats not using new styling yet */
-		...(ignoreGlobalH2Styling(format) && {
-			'data-ignore': 'global-h2-styling',
-		}),
-	};
 };
 
 const buildElementTree =
@@ -152,7 +111,7 @@ const buildElementTree =
 					return (
 						<h2
 							id={attributes.getNamedItem('id')?.value}
-							{...getStyleAttributes(format)}
+							css={getStyles(format)}
 						>
 							{Array.from(node.childNodes).map(
 								buildElementTree(format),

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -1018,16 +1018,6 @@ const headingLineDark: PaletteFunction = (format: ArticleFormat) => {
 
 const subheadingTextLight = ({ design, theme }: ArticleFormat) => {
 	switch (design) {
-		// "Clear" styles
-		case ArticleDesign.Obituary:
-		case ArticleDesign.Standard:
-		case ArticleDesign.Profile:
-		case ArticleDesign.Explainer:
-		case ArticleDesign.Timeline:
-		case ArticleDesign.LiveBlog:
-		case ArticleDesign.DeadBlog:
-			return sourcePalette.neutral[7];
-		// "Stand-out" styles
 		case ArticleDesign.Comment:
 		case ArticleDesign.Editorial:
 		case ArticleDesign.Analysis:
@@ -1049,14 +1039,6 @@ const subheadingTextLight = ({ design, theme }: ArticleFormat) => {
 				case ArticleSpecial.SpecialReportAlt:
 					return sourcePalette.neutral[7];
 			}
-		default:
-			return 'unset';
-	}
-};
-
-const subheadingTextDark = ({ design, theme }: ArticleFormat) => {
-	switch (design) {
-		// "Clear" styles
 		case ArticleDesign.Obituary:
 		case ArticleDesign.Standard:
 		case ArticleDesign.Profile:
@@ -1064,8 +1046,13 @@ const subheadingTextDark = ({ design, theme }: ArticleFormat) => {
 		case ArticleDesign.Timeline:
 		case ArticleDesign.LiveBlog:
 		case ArticleDesign.DeadBlog:
-			return sourcePalette.neutral[60];
-		// "Stand-out" styles
+		default:
+			return sourcePalette.neutral[7];
+	}
+};
+
+const subheadingTextDark = ({ design, theme }: ArticleFormat) => {
+	switch (design) {
 		case ArticleDesign.Comment:
 		case ArticleDesign.Editorial:
 		case ArticleDesign.Analysis:
@@ -1087,8 +1074,15 @@ const subheadingTextDark = ({ design, theme }: ArticleFormat) => {
 				case ArticleSpecial.SpecialReportAlt:
 					return sourcePalette.neutral[60];
 			}
+		case ArticleDesign.Obituary:
+		case ArticleDesign.Standard:
+		case ArticleDesign.Profile:
+		case ArticleDesign.Explainer:
+		case ArticleDesign.Timeline:
+		case ArticleDesign.LiveBlog:
+		case ArticleDesign.DeadBlog:
 		default:
-			return 'unset';
+			return sourcePalette.neutral[60];
 	}
 };
 const avatarLight: PaletteFunction = ({ design, theme }) => {


### PR DESCRIPTION
## What does this change?

- Removes references to design wording like `"authoritative"` / `"neutral"` / `"soft"` and `"stand-out"` / `"clear"` in comments
- If no match in the switch statements for `ArticleDesign`, fall back to the designs for `neutral / clear`
- Removes any bespoke logic for `DropCap` and `SubheadingBlockComponent` that does not fit into the new formats work, instead allowing the old styles to fall back to the `neutral / clear` styles

## Why?

Tidies up the Document Outline work and ensures all Articles use the new formats styling

## Screenshots

Since this PR defaults all un-explicit design decisions for H2 and DropDaps to `neutral / clear`, the following screenshots show how this will affect `ArticleDesign`s not accounted for in [the "design tone matrix" from Figma](https://www.figma.com/file/xPr2tZZger7pszcO075tAQ/New-Formats---April-23?type=design&node-id=2314-44029&mode=design&t=lR9zngNgmF9TGmI4-4)

| Before | After |
| ------ | ----- |
| ![before1][] | ![after1][] | <!-- ArticleDesign.Letter -->

[before1]:https://github.com/guardian/dotcom-rendering/assets/43961396/3cf82e19-f886-4ab9-bb96-5900847d813d
[after1]:https://github.com/guardian/dotcom-rendering/assets/43961396/0537b4b9-84f1-49ca-8f8b-bb5a67a85162
