### PR TITLE
Refactor play icon component

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -436,7 +436,6 @@ export const Card = ({
 						imagePosition={imagePosition}
 						imagePositionOnMobile={imagePositionOnMobile}
 						showPlayIcon={showPlayIcon}
-						isPlayableMediaCard={!!isPlayableMediaCard}
 					>
 						{media.type === 'slideshow' && (
 							<Slideshow

--- a/dotcom-rendering/src/components/Card/components/ImageWrapper.tsx
+++ b/dotcom-rendering/src/components/Card/components/ImageWrapper.tsx
@@ -14,7 +14,6 @@ type Props = {
 	imagePosition: ImagePositionType;
 	imagePositionOnMobile: ImagePositionType;
 	showPlayIcon: boolean;
-	isPlayableMediaCard: boolean;
 };
 
 /**
@@ -61,7 +60,6 @@ export const ImageWrapper = ({
 	imagePosition,
 	imagePositionOnMobile,
 	showPlayIcon,
-	isPlayableMediaCard,
 }: Props) => {
 	const isHorizontal = imagePosition === 'left' || imagePosition === 'right';
 	const isHorizontalOnMobile =
@@ -132,7 +130,6 @@ export const ImageWrapper = ({
 					<PlayIcon
 						imageSize={imageSize}
 						imagePositionOnMobile={imagePositionOnMobile}
-						isPlayableMediaCard={isPlayableMediaCard}
 					/>
 				)}
 			</>

--- a/dotcom-rendering/src/components/Card/components/PlayIcon.tsx
+++ b/dotcom-rendering/src/components/Card/components/PlayIcon.tsx
@@ -13,14 +13,6 @@ const sizes = {
 	xlarge: { button: 80, icon: 72 },
 } as const satisfies Record<string, { button: number; icon: number }>;
 
-const iconPulseStyles = css`
-	:focus,
-	:hover {
-		transform: translate(-50%, -50%) scale(1.15);
-		transition-duration: 300ms;
-	}
-`;
-
 const iconStyles = (
 	size: PlayButtonSize,
 	sizeOnMobile: Extract<PlayButtonSize, 'small' | 'large'>,
@@ -76,20 +68,18 @@ const getIconSizeOnMobile = (imagePositionOnMobile: ImagePositionType) =>
 export const PlayIcon = ({
 	imageSize,
 	imagePositionOnMobile,
-	isPlayableMediaCard,
 }: {
 	imageSize: ImageSizeType;
 	imagePositionOnMobile: ImagePositionType;
-	isPlayableMediaCard: boolean;
 }) => {
 	return (
 		<div
+			className="play-icon"
 			css={[
 				iconStyles(
 					getIconSizeOnDesktop(imageSize),
 					getIconSizeOnMobile(imagePositionOnMobile),
 				),
-				isPlayableMediaCard && iconPulseStyles,
 			]}
 		>
 			<SvgMediaControlsPlay theme={theme} />

--- a/dotcom-rendering/src/components/Card/components/PlayIcon.tsx
+++ b/dotcom-rendering/src/components/Card/components/PlayIcon.tsx
@@ -8,9 +8,7 @@ type PlayButtonSize = keyof typeof sizes;
 
 const sizes = {
 	small: { button: 40, icon: 32 },
-	medium: { button: 80, icon: 72 },
 	large: { button: 80, icon: 72 },
-	xlarge: { button: 80, icon: 72 },
 } as const satisfies Record<string, { button: number; icon: number }>;
 
 const iconStyles = (
@@ -53,8 +51,8 @@ const getIconSizeOnDesktop = (imageSize: ImageSizeType) => {
 		case 'jumbo':
 		case 'large':
 		case 'carousel':
-			return 'large';
 		case 'medium':
+			return 'large';
 		case 'small':
 			return 'small';
 	}

--- a/dotcom-rendering/src/components/Card/components/PlayIcon.tsx
+++ b/dotcom-rendering/src/components/Card/components/PlayIcon.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import { from, palette } from '@guardian/source-foundations';
+import type { ThemeIcon } from '@guardian/source-react-components';
 import { SvgMediaControlsPlay } from '@guardian/source-react-components';
 import type { ImagePositionType, ImageSizeType } from './ImageWrapper';
 
@@ -11,14 +12,6 @@ const sizes = {
 	large: { button: 80, icon: 72 },
 	xlarge: { button: 80, icon: 72 },
 } as const satisfies Record<string, { button: number; icon: number }>;
-
-const iconWrapperStyles = css`
-	display: flex;
-	position: absolute;
-	top: 50%;
-	left: 50%;
-	transform: translate(-50%, -50%);
-`;
 
 const iconPulseStyles = css`
 	:focus,
@@ -32,6 +25,13 @@ const iconStyles = (
 	size: PlayButtonSize,
 	sizeOnMobile: Extract<PlayButtonSize, 'small' | 'large'>,
 ) => css`
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	position: absolute;
+	top: 50%;
+	left: 50%;
+	transform: translate(-50%, -50%);
 	background-color: rgba(18, 18, 18, 0.6);
 	border-radius: 50%;
 	width: ${sizes[sizeOnMobile].button}px;
@@ -41,13 +41,7 @@ const iconStyles = (
 		height: ${sizes[size].button}px;
 	}
 
-	display: flex;
-	align-items: center;
-	justify-content: center;
-
 	svg {
-		/* Visual centering */
-		fill: ${palette.neutral[100]};
 		transform: translateX(1px);
 		width: ${sizes[sizeOnMobile].icon}px;
 		height: ${sizes[sizeOnMobile].icon}px;
@@ -57,6 +51,10 @@ const iconStyles = (
 		}
 	}
 `;
+
+const theme = {
+	fill: palette.neutral[100],
+} satisfies Partial<ThemeIcon>;
 
 const getIconSizeOnDesktop = (imageSize: ImageSizeType) => {
 	switch (imageSize) {
@@ -85,17 +83,16 @@ export const PlayIcon = ({
 	isPlayableMediaCard: boolean;
 }) => {
 	return (
-		<div css={[iconWrapperStyles, isPlayableMediaCard && iconPulseStyles]}>
-			<span
-				css={[
-					iconStyles(
-						getIconSizeOnDesktop(imageSize),
-						getIconSizeOnMobile(imagePositionOnMobile),
-					),
-				]}
-			>
-				<SvgMediaControlsPlay />
-			</span>
+		<div
+			css={[
+				iconStyles(
+					getIconSizeOnDesktop(imageSize),
+					getIconSizeOnMobile(imagePositionOnMobile),
+				),
+				isPlayableMediaCard && iconPulseStyles,
+			]}
+		>
+			<SvgMediaControlsPlay theme={theme} />
 		</div>
 	);
 };

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomOverlay.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomOverlay.tsx
@@ -53,6 +53,13 @@ const overlayStyles = css`
 		width: 100%;
 		height: 100%;
 	}
+
+	/* We scale the play icon on hover and focus to indicate it's playable content. */
+	:focus .play-icon,
+	:hover .play-icon {
+		transform: translate(-50%, -50%) scale(1.15);
+		transition-duration: 300ms;
+	}
 `;
 
 const pillStyles = css`
@@ -198,7 +205,6 @@ export const YoutubeAtomOverlay = ({
 			<PlayIcon
 				imageSize={imageSize}
 				imagePositionOnMobile={imagePositionOnMobile}
-				isPlayableMediaCard={true}
 			/>
 			{showTextOverlay && (
 				<div css={textOverlayStyles}>

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomOverlay.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomOverlay.tsx
@@ -60,6 +60,11 @@ const overlayStyles = css`
 		transform: translate(-50%, -50%) scale(1.15);
 		transition-duration: 300ms;
 	}
+
+	/* This makes the transition smoother when we stop focusing or hovering the element */
+	.play-icon {
+		transition: transform 300ms;
+	}
 `;
 
 const pillStyles = css`

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomOverlay.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomOverlay.tsx
@@ -54,16 +54,14 @@ const overlayStyles = css`
 		height: 100%;
 	}
 
+	.play-icon {
+		transition: transform 300ms;
+	}
+
 	/* We scale the play icon on hover and focus to indicate it's playable content. */
 	:focus .play-icon,
 	:hover .play-icon {
 		transform: translate(-50%, -50%) scale(1.15);
-		transition-duration: 300ms;
-	}
-
-	/* This makes the transition smoother when we stop focusing or hovering the element */
-	.play-icon {
-		transition: transform 300ms;
 	}
 `;
 


### PR DESCRIPTION
## What does this change?
Refactors the  Play Icon component to reduce the amount of html and css overrides [as suggested by](https://github.com/guardian/dotcom-rendering/pull/11038#discussion_r1541844734) @mxdvl. It also lifts the focus/hover play icon scaling to the parent overlay instead of the play icon. 

## Why?
Some improvements / changes (eg source theming and [play button redesigns](https://www.figma.com/file/opUPavNDDExUBnF7NHzzqY/Vertical-Video-Exploration?type=design&node-id=793-102770&mode=design&t=2bwVJbMijis90bGf-4)) have occurred since the component was first written. This PR refactors the play button to make use of this and reduce the complexity of the component. 


## Screenshots

There are no difference in appearances as per screen shots, but the play icon scale now occurs when hovering or focusing on the overlay rather than just the icon itself. 

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/20416599/46496308-9a61-4653-a814-c75c073dee16
[after]: https://github.com/guardian/dotcom-rendering/assets/20416599/8f9db24c-e024-4031-9e6f-8cd3c6883de3

| Before      | After      |
| ----------- | ---------- |
| ![before-m][] | ![after-m][] |

[before-m]: https://github.com/guardian/dotcom-rendering/assets/20416599/0d764b9e-27d5-4c6e-9e30-ec981f488a91
[after-m]: https://github.com/guardian/dotcom-rendering/assets/20416599/d518d63c-46bf-4a60-930f-250d77a3a584

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
