### PR TITLE
Stop supporting some atoms on AMP

### DIFF
--- a/dotcom-rendering/src/components/Elements.amp.tsx
+++ b/dotcom-rendering/src/components/Elements.amp.tsx
@@ -36,7 +36,6 @@ import { YoutubeBlockComponent } from './YoutubeBlockComponent.amp';
 const AMP_SUPPORTED_ELEMENTS = [
 	'model.dotcomrendering.pageElements.AudioAtomBlockElement',
 	'model.dotcomrendering.pageElements.BlockquoteBlockElement',
-	'model.dotcomrendering.pageElements.ChartAtomBlockElement',
 	'model.dotcomrendering.pageElements.CommentBlockElement',
 	'model.dotcomrendering.pageElements.ContentAtomBlockElement',
 	'model.dotcomrendering.pageElements.DisclaimerBlockElement',
@@ -46,7 +45,6 @@ const AMP_SUPPORTED_ELEMENTS = [
 	'model.dotcomrendering.pageElements.GuideAtomBlockElement',
 	'model.dotcomrendering.pageElements.GuVideoBlockElement',
 	'model.dotcomrendering.pageElements.ImageBlockElement',
-	'model.dotcomrendering.pageElements.InteractiveAtomBlockElement',
 	// We do not support InteractiveBlockElement's when they are mandatory
 	// 'model.dotcomrendering.pageElements.InteractiveBlockElement',
 	'model.dotcomrendering.pageElements.ProfileAtomBlockElement',


### PR DESCRIPTION
## What does this change?

Stop rendering article which contains the following atoms in AMP:
- Chart Atom
- Interactive Atom

## Why?

The following atoms are rendered by frontend, which rely on the deprecated [`atom-renderer`](https://github.com/guardian/atom-renderer). As we hope to remove this dependency from frontend in https://github.com/guardian/frontend/issues/26997 and it is blocking our upgrade to Play 3 & Pekko, we thought that stopping serving them on AMP would be a pragmatic solution.