### PR TITLE
Pullquote Uses `RoleType`

### DIFF
--- a/dotcom-rendering/src/model/article-schema.json
+++ b/dotcom-rendering/src/model/article-schema.json
@@ -2792,7 +2792,7 @@
                     "type": "string"
                 },
                 "role": {
-                    "type": "string"
+                    "$ref": "#/definitions/RoleType"
                 },
                 "attribution": {
                     "type": "string"

--- a/dotcom-rendering/src/model/block-schema.json
+++ b/dotcom-rendering/src/model/block-schema.json
@@ -2381,7 +2381,7 @@
                     "type": "string"
                 },
                 "role": {
-                    "type": "string"
+                    "$ref": "#/definitions/RoleType"
                 },
                 "attribution": {
                     "type": "string"

--- a/dotcom-rendering/src/types/content.ts
+++ b/dotcom-rendering/src/types/content.ts
@@ -414,7 +414,7 @@ interface PullquoteBlockElement {
 	_type: 'model.dotcomrendering.pageElements.PullquoteBlockElement';
 	elementId: string;
 	html?: string;
-	role: string;
+	role: RoleType;
 	attribution?: string;
 	isThirdPartyTracking?: boolean;
 }


### PR DESCRIPTION
All other element roles use the more specific `RoleType`, so Pullquotes should too.
