### PR TITLE
Ignore `<strong>` tag font weighting in `h2` tags

### DIFF
--- a/dotcom-rendering/src/components/SubheadingBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/components/SubheadingBlockComponent.stories.tsx
@@ -44,28 +44,28 @@ const StoryWrapper = ({ children }: { children: React.ReactNode }) => (
 	</div>
 );
 
+const subheadingHtmlStrings = [
+	'<h2>Basic subheading</h2>',
+	'<h2>Subheading with <strong>strong</strong> tags</h2>',
+	"<h2>Subheading <a href='/'>with anchor</a></h2>",
+	'<h2>Subheading with HTML comment<!-- HTML comment--></h2>',
+	'Subheading text only (no HTML)',
+];
+
 const meta = {
 	component: SubheadingBlockComponent,
 	title: 'Components/SubheadingBlockComponent',
 	render: (args) => {
 		return (
 			<StoryWrapper>
-				<SubheadingBlockComponent
-					format={args.format}
-					html="<h2>Basic subheading</h2>"
-				/>
-				<SubheadingBlockComponent
-					format={args.format}
-					html="<h2>Subheading <a href='/'>with anchor</a></h2>"
-				/>
-				<SubheadingBlockComponent
-					format={args.format}
-					html="<h2>Subheading with HTML comment<!-- HTML comment--></h2>"
-				/>
-				<SubheadingBlockComponent
-					format={args.format}
-					html="Subheading text only (no HTML)"
-				/>
+				{subheadingHtmlStrings.map((html, index) => (
+					<SubheadingBlockComponent
+						// eslint-disable-next-line react/no-array-index-key -- ignore for Story only
+						key={index}
+						format={args.format}
+						html={html}
+					/>
+				))}
 
 				<hr />
 			</StoryWrapper>

--- a/dotcom-rendering/src/components/SubheadingBlockComponent.tsx
+++ b/dotcom-rendering/src/components/SubheadingBlockComponent.tsx
@@ -53,6 +53,11 @@ const getFontStyles = ({
 	${from.tablet} {
 		padding-bottom: 4px;
 	}
+
+	/* We don't allow additional font weight inside h2 tags */
+	strong {
+		font-weight: inherit;
+	}
 `;
 
 const getStyles = (format: ArticleFormat) => {


### PR DESCRIPTION
## What does this change?

Some `h2` elements have `strong` tags inside them. The new design formats work does not account for this and it's preferable to ignore this. 
Another option is to strip the `strong` tags out, but there is a current case of these being used in interactive articles. 

We might want to prevent `strong` tags being used in subheadings in the tooling.

Before the design updates in #11041 strong tags were previously being ignored in a way as the subheading styling was already using bold font weight

## Why?

Having extra font weighting applied through strong tags does not agree with the new designs

Resolves #11049 

## Screenshots

| Before (pre design updates)      | Before (post design updates)     | After      |
| ----------- | ---------- |---------- |
| ![before][] | ![before2][] | ![after][] |

[before]:https://github.com/guardian/dotcom-rendering/assets/43961396/dd08f806-5330-4b31-a047-1aef5a42b5c8
[before2]: https://github.com/guardian/dotcom-rendering/assets/43961396/9d86bbe8-77d4-405b-b5d5-523e745e673c
[after]: https://github.com/guardian/dotcom-rendering/assets/43961396/8a31a439-fcfe-4b01-8f5e-6b20ba9b620c



> [!TIP]
> Useful article for testing: https://www.theguardian.com/business/2024/mar/27/how-can-donald-trumps-lossmaking-truth-social-be-worth-8bn
