### PR TITLE
Add paragraph spacing for new design formats work

### DIFF
--- a/dotcom-rendering/src/components/TextBlockComponent.tsx
+++ b/dotcom-rendering/src/components/TextBlockComponent.tsx
@@ -159,8 +159,8 @@ const sanitiserOptions: IOptions = {
 };
 
 const styles = (format: ArticleFormat) => css`
-	margin-block: ${space[3]}px;
-	writing-mode: horizontal-tb;
+	margin-top: ${space[3]}px;
+	margin-bottom: ${space[3]}px;
 	word-break: break-word;
 	${format.theme === ArticleSpecial.Labs ? textSans.medium() : body.medium()};
 


### PR DESCRIPTION
## What does this change?

Adds 12px (`space[3]`) margin-top to `TextBlockComponent`

## Why?

Required by designs (though designs specified 14px not 12px, which we shouldn't do if at all possible since this [is not in line with `source` spacing](https://theguardian.design/2a1e5182b/p/912e85-spacing/b/084803))

Resolves #9212 

## Screenshots

| Before (pre design formats update) | Before (post design formats update) | After
| ----------- | ---------- |---------- |
| ![before][] | ![before2][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/43961396/4bf691f1-4dee-4e0a-be18-999725348af8
[before2]:https://github.com/guardian/dotcom-rendering/assets/43961396/b3295e65-db76-460f-b46f-bf6f54349c51
[after]: https://github.com/guardian/dotcom-rendering/assets/43961396/67cd2303-cb33-4a97-9868-a5efc091762c

