### PR TITLE
Track clicks on (article meta) sponsor logos in Ophan

### DIFF
--- a/dotcom-rendering/playwright/lib/ophan.ts
+++ b/dotcom-rendering/playwright/lib/ophan.ts
@@ -1,0 +1,19 @@
+import type { Page, Request } from '@playwright/test';
+
+export const interceptOphanRequest = ({
+	page,
+	path,
+	searchParamMatcher,
+}: {
+	page: Page;
+	path: string;
+	searchParamMatcher: (searchParams: URLSearchParams) => boolean;
+}): Promise<Request> => {
+	return page.waitForRequest((request) => {
+		const matchUrl = request
+			.url()
+			.startsWith(`https://ophan.theguardian.com/${path}`);
+		const searchParams = new URLSearchParams(request.url());
+		return matchUrl && searchParamMatcher(searchParams);
+	});
+};

--- a/dotcom-rendering/playwright/tests/ophan.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/ophan.e2e.spec.ts
@@ -1,6 +1,6 @@
 import { isUndefined } from '@guardian/libs';
-import type { Page } from '@playwright/test';
 import { test } from '@playwright/test';
+import { interceptOphanRequest } from 'playwright/lib/ophan';
 import { cmpAcceptAll, cmpRejectAll, disableCMP } from '../lib/cmp';
 import { loadPage } from '../lib/load-page';
 
@@ -8,24 +8,6 @@ const articleUrl =
 	'https://www.theguardian.com/politics/2019/oct/29/tories-restore-party-whip-to-10-mps-who-sought-to-block-no-deal-brexit';
 
 const frontUrl = 'https://www.theguardian.com/uk';
-
-const interceptOphanRequest = ({
-	page,
-	path,
-	searchParamMatcher,
-}: {
-	page: Page;
-	path: string;
-	searchParamMatcher: (searchParams: URLSearchParams) => boolean;
-}) => {
-	return page.waitForRequest((request) => {
-		const matchUrl = request
-			.url()
-			.startsWith(`https://ophan.theguardian.com/${path}`);
-		const searchParams = new URLSearchParams(request.url());
-		return matchUrl && searchParamMatcher(searchParams);
-	});
-};
 
 test.describe('Ophan requests', () => {
 	test('should make a view request on an article when consent is rejected', async ({

--- a/dotcom-rendering/src/components/Branding.importable.tsx
+++ b/dotcom-rendering/src/components/Branding.importable.tsx
@@ -113,6 +113,15 @@ function decideLogo(
 	);
 }
 
+const getOphanComponents = (branding: BrandingType) => {
+	const formattedSponsorName = branding.sponsorName.toLowerCase();
+	const componentName = `article-${formattedSponsorName}`;
+	return {
+		ophanComponentName: `labs-logo | ${componentName}`,
+		ophanLinkName: `labs-logo-${componentName}`,
+	};
+};
+
 type Props = {
 	branding: BrandingType;
 	format: ArticleFormat;
@@ -132,6 +141,7 @@ type Props = {
 export const Branding = ({ branding, format }: Props) => {
 	const sponsorId = branding.sponsorName.toLowerCase();
 	const isLiveBlog = format.design === ArticleDesign.LiveBlog;
+	const { ophanComponentName, ophanLinkName } = getOphanComponents(branding);
 
 	const { darkModeAvailable } = useConfig();
 
@@ -148,6 +158,8 @@ export const Branding = ({ branding, format }: Props) => {
 					aria-label={`Visit the ${branding.sponsorName} website`}
 					onClick={() => trackSponsorLogoLinkClick(sponsorId)}
 					data-testid="branding-logo"
+					data-component={ophanComponentName}
+					data-link-name={ophanLinkName}
 				>
 					{decideLogo(branding, format, darkModeAvailable)}
 				</a>

--- a/dotcom-rendering/src/components/Branding.importable.tsx
+++ b/dotcom-rendering/src/components/Branding.importable.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/react';
 import { ArticleDesign } from '@guardian/libs';
 import { breakpoints, from, textSans } from '@guardian/source-foundations';
 import { trackSponsorLogoLinkClick } from '../client/ga/ga';
+import { getOphanComponents } from '../lib/labs';
 import { palette } from '../palette';
 import type { Branding as BrandingType } from '../types/branding';
 import { useConfig } from './ConfigContext';
@@ -113,15 +114,6 @@ function decideLogo(
 	);
 }
 
-const getOphanComponents = (branding: BrandingType) => {
-	const formattedSponsorName = branding.sponsorName.toLowerCase();
-	const componentName = `article-${formattedSponsorName}`;
-	return {
-		ophanComponentName: `labs-logo | ${componentName}`,
-		ophanLinkName: `labs-logo-${componentName}`,
-	};
-};
-
 type Props = {
 	branding: BrandingType;
 	format: ArticleFormat;
@@ -141,7 +133,8 @@ type Props = {
 export const Branding = ({ branding, format }: Props) => {
 	const sponsorId = branding.sponsorName.toLowerCase();
 	const isLiveBlog = format.design === ArticleDesign.LiveBlog;
-	const { ophanComponentName, ophanLinkName } = getOphanComponents(branding);
+	const { ophanComponentName, ophanComponentLink } =
+		getOphanComponents(branding);
 
 	const { darkModeAvailable } = useConfig();
 
@@ -159,7 +152,7 @@ export const Branding = ({ branding, format }: Props) => {
 					onClick={() => trackSponsorLogoLinkClick(sponsorId)}
 					data-testid="branding-logo"
 					data-component={ophanComponentName}
-					data-link-name={ophanLinkName}
+					data-link-name={ophanComponentLink}
 				>
 					{decideLogo(branding, format, darkModeAvailable)}
 				</a>

--- a/dotcom-rendering/src/lib/labs.test.ts
+++ b/dotcom-rendering/src/lib/labs.test.ts
@@ -1,0 +1,12 @@
+import type { Branding } from '../types/branding';
+import { getOphanComponents } from './labs';
+
+describe('getOphanComponents', () => {
+	it('constrcuts the correct data attributes', () => {
+		const branding = { sponsorName: 'Some Sponsor' } as Branding;
+		expect(getOphanComponents(branding)).toStrictEqual({
+			ophanComponentName: 'labs-logo | article-some-sponsor',
+			ophanComponentLink: 'labs-logo-article-some-sponsor',
+		});
+	});
+});

--- a/dotcom-rendering/src/lib/labs.test.ts
+++ b/dotcom-rendering/src/lib/labs.test.ts
@@ -2,7 +2,7 @@ import type { Branding } from '../types/branding';
 import { getOphanComponents } from './labs';
 
 describe('getOphanComponents', () => {
-	it('constrcuts the correct data attributes', () => {
+	it('constructs the correct data attributes', () => {
 		const branding = { sponsorName: 'Some Sponsor' } as Branding;
 		expect(getOphanComponents(branding)).toStrictEqual({
 			ophanComponentName: 'labs-logo | article-some-sponsor',

--- a/dotcom-rendering/src/lib/labs.ts
+++ b/dotcom-rendering/src/lib/labs.ts
@@ -1,0 +1,14 @@
+import type { Branding } from '../types/branding';
+
+export const getOphanComponents = (
+	branding: Branding,
+): { ophanComponentName: string; ophanComponentLink: string } => {
+	const formattedSponsorName = branding.sponsorName
+		.toLowerCase()
+		.replace(' ', '-');
+	const componentName = `article-${formattedSponsorName}`;
+	return {
+		ophanComponentName: `labs-logo | ${componentName}`,
+		ophanComponentLink: `labs-logo-${componentName}`,
+	};
+};


### PR DESCRIPTION
## What does this change?

This PR adds the `data-component` and `data-link-name` attributes necessary to track clicking Labs logos (present in the artcle meta) in Ophan. These are constructed in `getOphanComponents`, using a format that matches tracking on Fronts and has been agreed with Commercial Analysts.

For example (where the sponsor name is `honda`):
```
clickComponent: labs-logo | article-onwards-honda
clickLinkNames: ["labs-logo-article-onwards-honda","related-content"]
```

I've also added an E2E test to confirm the component event is being sent to Ophan as expected.

## Why?

This allows for analysis of sponsor logo clicks in articles from the data lake, rather than Google Analytics (left untouched in this PR).

## Next steps 

Some extra work will be required to also track logos present in onward journey carousels. This will feature as a subsequent PR.