### PR TITLE
Fix spacing of interactive block component caption

### DIFF
--- a/dotcom-rendering/src/components/InteractiveBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/components/InteractiveBlockComponent.importable.tsx
@@ -266,10 +266,7 @@ export const InteractiveBlockComponent = ({
 
 			setupWindowListeners(iframe);
 
-			wrapperRef.current?.insertBefore(
-				iframe,
-				wrapperRef.current.firstChild,
-			);
+			wrapperRef.current?.prepend(iframe);
 
 			setLoaded(true);
 		} else if (scriptUrl) {


### PR DESCRIPTION
## What does this change?
Moves the caption within the figure component, inserts the iframe before this component and remove margin.
## Why?
Resolves https://github.com/guardian/dotcom-rendering/issues/5110
## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/110032454/738f0719-f387-421b-bcb8-741ce7c0a471
[after]: https://github.com/guardian/dotcom-rendering/assets/110032454/4fd412a6-35df-4197-8bd3-dbc9c5e27268
