### PR TITLE
Fix Article Meta Multiple Contributors story

### DIFF
--- a/dotcom-rendering/makefile
+++ b/dotcom-rendering/makefile
@@ -70,6 +70,8 @@ storybook-dev: clear clean-dist install
 	$(call log, "starting Storybook DEV server")
 	@pnpm storybook
 
+storybook: storybook-dev
+
 # tests #####################################
 
 playwright-run:

--- a/dotcom-rendering/src/components/ArticleMeta.stories.tsx
+++ b/dotcom-rendering/src/components/ArticleMeta.stories.tsx
@@ -348,7 +348,7 @@ export const FeatureTwoContributors: StoryObj = ({ format }: StoryArgs) => {
 				format={format}
 				pageId=""
 				webTitle=""
-				byline="Lanre Bakare"
+				byline="Lanre Bakare and Another Author"
 				tags={tagsWithByTwoContributors}
 				primaryDateline="Sun 12 Jan 2020 18.00 GMT"
 				secondaryDateline="Last modified on Sun 12 Jan 2020 21.00 GMT"


### PR DESCRIPTION
## What does this change?

- Fixes the "multiple contributor" story to feature two contributors instead of one
- Adds a little shortcut to the makefile we can run `make storybook` instead of always `make storybook-dev`. This is really just for me maybe, I never think to run `make storybook-dev` until I see that `make storybook` failed :(


## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![Screen Shot 2024-04-03 at 12 26 13](https://github.com/guardian/dotcom-rendering/assets/705427/4bc0c1d6-555b-4e0c-8eb8-c038c20a4069) | ![Screen Shot 2024-04-03 at 12 25 35](https://github.com/guardian/dotcom-rendering/assets/705427/b06f52a1-31da-4fe5-8392-daaf070b5c9d) |

