### PR TITLE
refactor: Use OnwardsSource type in card components

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -20,6 +20,7 @@ import type {
 	DCRSupportingContent,
 } from '../../types/front';
 import type { MainMedia } from '../../types/mainMedia';
+import type { OnwardsSource } from '../../types/onwards';
 import type { Palette } from '../../types/palette';
 import { Avatar } from '../Avatar';
 import { CardCommentCount } from '../CardCommentCount.importable';
@@ -102,7 +103,7 @@ export type Props = {
 	isExternalLink: boolean;
 	slideshowImages?: DCRSlideshowImage[];
 	showLivePlayable?: boolean;
-	onwardsSource?: string;
+	onwardsSource?: OnwardsSource;
 	pauseOffscreenVideo?: boolean;
 	showMainVideo?: boolean;
 };

--- a/dotcom-rendering/src/components/Carousel.importable.tsx
+++ b/dotcom-rendering/src/components/Carousel.importable.tsx
@@ -471,7 +471,7 @@ type CarouselCardProps = {
 	/** Only used on Labs cards */
 	branding?: Branding;
 	mainMedia?: MainMedia;
-	onwardsSource?: string;
+	onwardsSource?: OnwardsSource;
 	containerType?: DCRContainerType;
 };
 


### PR DESCRIPTION
## What does this change?

Use the `OnwardsSource` type in card related components.

## Why?

Better type safety for subsequent work that uses this value.
