### PR TITLE
Track clicks on sponsor logos in related content

### DIFF
--- a/dotcom-rendering/playwright/tests/paid.content.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/paid.content.e2e.spec.ts
@@ -96,8 +96,8 @@ test.describe('Paid content tests', () => {
 				const clickComponent = searchParams.get('clickComponent');
 				const clickLinkNames = searchParams.get('clickLinkNames');
 				return (
-					clickComponent === 'labs-logo | article-westfield' &&
-					clickLinkNames === '["labs-logo-article-westfield"]'
+					clickComponent === 'labs-logo | article-meta-westfield' &&
+					clickLinkNames === '["labs-logo-article-meta-westfield"]'
 				);
 			},
 		});

--- a/dotcom-rendering/playwright/tests/paid.content.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/paid.content.e2e.spec.ts
@@ -136,7 +136,7 @@ test.describe('Paid content tests', () => {
 		await expectToBeVisible(page, '[data-testid=card-branding-logo]');
 		await page.locator('[data-testid=card-branding-logo]').first().click();
 
-		// Make sure the request to Google Analytics is made
+		// Make sure the request to Ophan is made
 		await clickEventRequest;
 	});
 });

--- a/dotcom-rendering/playwright/tests/paid.content.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/paid.content.e2e.spec.ts
@@ -109,4 +109,34 @@ test.describe('Paid content tests', () => {
 
 		await clickEventRequest;
 	});
+
+	test('should send Ophan component event on click of sponsor logo in onwards section', async ({
+		page,
+	}) => {
+		await loadPage(page, `/Article/${paidContentPage}`);
+		await cmpAcceptAll(page);
+
+		const clickEventRequest = interceptOphanRequest({
+			page,
+			path: 'img/2',
+			searchParamMatcher: (searchParams) => {
+				const clickComponent = searchParams.get('clickComponent');
+				const clickLinkNames = searchParams.get('clickLinkNames');
+				return (
+					clickComponent ===
+						'labs-logo | article-related-content-westfield' &&
+					clickLinkNames ===
+						'["labs-logo-article-related-content-westfield","related-content"]'
+				);
+			},
+		});
+
+		await waitForIsland(page, 'OnwardsUpper');
+
+		await expectToBeVisible(page, '[data-testid=card-branding-logo]');
+		await page.locator('[data-testid=card-branding-logo]').first().click();
+
+		// Make sure the request to Google Analytics is made
+		await clickEventRequest;
+	});
 });

--- a/dotcom-rendering/src/components/Branding.importable.tsx
+++ b/dotcom-rendering/src/components/Branding.importable.tsx
@@ -133,8 +133,10 @@ type Props = {
 export const Branding = ({ branding, format }: Props) => {
 	const sponsorId = branding.sponsorName.toLowerCase();
 	const isLiveBlog = format.design === ArticleDesign.LiveBlog;
-	const { ophanComponentName, ophanComponentLink } =
-		getOphanComponents(branding);
+	const { ophanComponentName, ophanComponentLink } = getOphanComponents({
+		branding,
+		locationPrefix: 'article-meta',
+	});
 
 	const { darkModeAvailable } = useConfig();
 

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -376,7 +376,11 @@ export const Card = ({
 				}
 				cardBranding={
 					branding ? (
-						<CardBranding branding={branding} format={format} />
+						<CardBranding
+							branding={branding}
+							format={format}
+							onwardsSource={onwardsSource}
+						/>
 					) : undefined
 				}
 			/>

--- a/dotcom-rendering/src/components/Card/components/CardBranding.tsx
+++ b/dotcom-rendering/src/components/Card/components/CardBranding.tsx
@@ -3,12 +3,15 @@ import { space, textSans, visuallyHidden } from '@guardian/source-foundations';
 import { trackSponsorLogoLinkClick } from '../../../client/ga/ga';
 import { decideLogo } from '../../../lib/decideLogo';
 import { getZIndex } from '../../../lib/getZIndex';
+import { getOphanComponents } from '../../../lib/labs';
 import { palette as themePalette } from '../../../palette';
 import type { Branding } from '../../../types/branding';
+import type { OnwardsSource } from '../../../types/onwards';
 
 type Props = {
 	branding: Branding;
 	format: ArticleFormat;
+	onwardsSource: OnwardsSource | undefined;
 };
 
 const logoImageStyle = css`
@@ -34,8 +37,20 @@ const labelStyle = css`
 	color: ${themePalette('--card-footer-text')};
 `;
 
-export const CardBranding = ({ branding, format }: Props) => {
+export const CardBranding = ({ branding, format, onwardsSource }: Props) => {
 	const logo = decideLogo(format, branding);
+
+	/**
+	 * Only apply click tracking to branding on related content
+	 */
+	const dataAttributes =
+		onwardsSource === 'related-content'
+			? getOphanComponents({
+					branding,
+					locationPrefix: 'article-related-content',
+			  })
+			: undefined;
+
 	return (
 		<div css={brandingWrapperStyle}>
 			<div css={labelStyle}>{logo.label}</div>
@@ -66,6 +81,8 @@ export const CardBranding = ({ branding, format }: Props) => {
 					alt={branding.sponsorName}
 					width={logo.dimensions.width}
 					height={logo.dimensions.height}
+					data-component={dataAttributes?.ophanComponentName}
+					data-link-name={dataAttributes?.ophanComponentLink}
 				/>
 			</a>
 		</div>

--- a/dotcom-rendering/src/lib/labs.test.ts
+++ b/dotcom-rendering/src/lib/labs.test.ts
@@ -2,11 +2,13 @@ import type { Branding } from '../types/branding';
 import { getOphanComponents } from './labs';
 
 describe('getOphanComponents', () => {
-	it('constructs the correct data attributes', () => {
+	it('constructs the correct data attributes for branding in article meta', () => {
 		const branding = { sponsorName: 'Some Sponsor' } as Branding;
-		expect(getOphanComponents(branding)).toStrictEqual({
-			ophanComponentName: 'labs-logo | article-some-sponsor',
-			ophanComponentLink: 'labs-logo-article-some-sponsor',
+		expect(
+			getOphanComponents({ branding, locationPrefix: 'article-meta' }),
+		).toStrictEqual({
+			ophanComponentName: 'labs-logo | article-meta-some-sponsor',
+			ophanComponentLink: 'labs-logo-article-meta-some-sponsor',
 		});
 	});
 });

--- a/dotcom-rendering/src/lib/labs.test.ts
+++ b/dotcom-rendering/src/lib/labs.test.ts
@@ -11,4 +11,19 @@ describe('getOphanComponents', () => {
 			ophanComponentLink: 'labs-logo-article-meta-some-sponsor',
 		});
 	});
+
+	it('constructs the correct data attributes for branding in related content', () => {
+		const branding = { sponsorName: 'Some Sponsor' } as Branding;
+		expect(
+			getOphanComponents({
+				branding,
+				locationPrefix: 'article-related-content',
+			}),
+		).toStrictEqual({
+			ophanComponentName:
+				'labs-logo | article-related-content-some-sponsor',
+			ophanComponentLink:
+				'labs-logo-article-related-content-some-sponsor',
+		});
+	});
 });

--- a/dotcom-rendering/src/lib/labs.ts
+++ b/dotcom-rendering/src/lib/labs.ts
@@ -1,12 +1,19 @@
 import type { Branding } from '../types/branding';
 
-export const getOphanComponents = (
-	branding: Branding,
-): { ophanComponentName: string; ophanComponentLink: string } => {
+export const getOphanComponents = ({
+	branding,
+	locationPrefix,
+}: {
+	branding: Branding;
+	/**
+	 * Allows clicks to be attributed to different areas of content
+	 */
+	locationPrefix: 'article-meta' | 'article-related-content';
+}): { ophanComponentName: string; ophanComponentLink: string } => {
 	const formattedSponsorName = branding.sponsorName
 		.toLowerCase()
 		.replace(' ', '-');
-	const componentName = `article-${formattedSponsorName}`;
+	const componentName = `${locationPrefix}-${formattedSponsorName}`;
 	return {
 		ophanComponentName: `labs-logo | ${componentName}`,
 		ophanComponentLink: `labs-logo-${componentName}`,


### PR DESCRIPTION
## What does this change?

Builds on the work in https://github.com/guardian/dotcom-rendering/pull/11061, to track clicks on branding on "related content" sections at the bottom of Labs articles.

We add an additional `locationPrefix` parameter to the function that assembles the tracking data attributes, so that we can differentiate between clicks on the sponsor logo in the article meta, as well as sponsor logs in the related content section. We change the location prefix from `article` to `article-meta` for the existing usage in `Branding.importable.tsx`, and use `article-related-content` for the new section.

This PR also adds an E2E test that asserts the request to Ophan is made, as well as a unit test that confirms the component tracking works as expected.

## Why?

These click events no longer have to be analysed in Google Analytics.