### PR TITLE
Re-introduce global h2 styles

### DIFF
--- a/dotcom-rendering/src/components/ArticleBody.tsx
+++ b/dotcom-rendering/src/components/ArticleBody.tsx
@@ -54,11 +54,6 @@ const globalH2Styles = (display: ArticleDisplay) => css`
 			? headline.medium({ fontWeight: 'light' })
 			: headline.xxsmall({ fontWeight: 'bold' })};
 	}
-
-	/** Special case of h2 following a paragraph block */
-	p + h2 {
-		padding-top: 8px;
-	}
 `;
 
 const globalOlStyles = () => css`

--- a/dotcom-rendering/src/components/SubheadingBlockComponent.tsx
+++ b/dotcom-rendering/src/components/SubheadingBlockComponent.tsx
@@ -6,7 +6,12 @@ import {
 	ArticleSpecial,
 	Pillar,
 } from '@guardian/libs';
-import { type FontWeight, from, headline } from '@guardian/source-foundations';
+import {
+	type FontWeight,
+	from,
+	headline,
+	space,
+} from '@guardian/source-foundations';
 import { textSans } from '@guardian/source-foundations/cjs/source-foundations/src/typography/api';
 import type { ReactNode } from 'react';
 import { Fragment } from 'react';
@@ -49,9 +54,10 @@ const getFontStyles = ({
 
 	color: ${palette('--subheading-text')};
 
-	padding-bottom: 2px;
+	padding-top: ${space[2]}px;
+	padding-bottom: ${space[0]}px;
 	${from.tablet} {
-		padding-bottom: 4px;
+		padding-bottom: ${space[1]}px;
 	}
 
 	/* We don't allow additional font weight inside h2 tags */


### PR DESCRIPTION
## What does this change?

Re-introduces global h2 styles after removing them in https://github.com/guardian/dotcom-rendering/pull/11039

## Why?

There are some edge cases to be aware of, specifically picture essays (https://www.theguardian.com/artanddesign/series/guardian-picture-essay)

### Design: PhotoEssay

Example article: https://www.theguardian.com/sport/2024/mar/29/pulling-together-how-cambridge-came-to-dominate-the-boat-race-photo-essay

The `h2` in picture essays appears inside the image above and does not use `SubheadingBlockComponent`. By removing global styles, this element had no initial styles to inherit. 

#### Screenshots

| Before format design updates | After design updates and removing global styles  | After re-adding global styles |
| ----------- | ----------- | ---------- |
| ![bbefore2][] | ![before2][] | ![after2][] |

[bbefore2]:https://github.com/guardian/dotcom-rendering/assets/43961396/98c7bb76-cde4-4476-ac64-ddd88d7c32d5
[before2]:https://github.com/guardian/dotcom-rendering/assets/43961396/89aa264c-51e2-4539-a3d0-2f3aef6108da
[after2]:https://github.com/guardian/dotcom-rendering/assets/43961396/b6d4c723-909a-459c-8fa7-f3e971ce7809
