### PR TITLE
bump webpack-dev-middleware peer dependency to 6.1.3

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6979,7 +6979,7 @@ packages:
       util: 0.12.5
       util-deprecate: 1.0.2
       webpack: 5.91.0(@swc/core@1.4.8)(esbuild@0.18.20)(webpack-cli@5.1.4)
-      webpack-dev-middleware: 6.1.1(webpack@5.91.0)
+      webpack-dev-middleware: 6.1.3(webpack@5.91.0)
       webpack-hot-middleware: 2.26.1
       webpack-virtual-modules: 0.5.0
     transitivePeerDependencies:
@@ -19879,8 +19879,8 @@ packages:
       webpack-merge: 5.10.0
     dev: false
 
-  /webpack-dev-middleware@6.1.1(webpack@5.91.0):
-    resolution: {integrity: sha512-y51HrHaFeeWir0YO4f0g+9GwZawuigzcAdRNon6jErXy/SqV/+O6eaVAzDqE6t3e3NpGeR5CS+cCDaTC+V3yEQ==}
+  /webpack-dev-middleware@6.1.3(webpack@5.91.0):
+    resolution: {integrity: sha512-A4ChP0Qj8oGociTs6UdlRUGANIGrCDL3y+pmQMc+dSsraXHCatFpmMey4mYELA+juqwUqwQsUgJJISXl1KWmiw==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
       webpack: ^5.0.0


### PR DESCRIPTION
## What does this change?
Bump webpack-dev-middleware peer dependency to v6.1.3
