### PR TITLE
Fix Spacefinder timeout hit with interactives

### DIFF
--- a/dotcom-rendering/src/client/islands/whenIdle.ts
+++ b/dotcom-rendering/src/client/islands/whenIdle.ts
@@ -1,7 +1,8 @@
 /**
- * whenIdle exectures the given callback when the browser is 'idle'
+ * whenIdle executes a callback when the browser is 'idle' or after a short timeout, whichever comes first
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/Window/requestIdleCallback
  *
- * @param callback Fired when requestIdleCallback runs. If requestIdleCallback is not available after 300ms
+ * @param callback the function to execute once the browser is 'idle'
  */
 export const whenIdle = (callback: () => void): void => {
 	if ('requestIdleCallback' in window) {

--- a/dotcom-rendering/src/components/Island.test.tsx
+++ b/dotcom-rendering/src/components/Island.test.tsx
@@ -56,7 +56,6 @@ const Mock = () => <>🏝️</>;
 );
 
 () => (
-	// @ts-expect-error -- critical island be deferred until idle
 	<Island priority="critical" defer={{ until: 'idle' }}>
 		<Mock />
 	</Island>

--- a/dotcom-rendering/src/components/Island.tsx
+++ b/dotcom-rendering/src/components/Island.tsx
@@ -23,8 +23,7 @@ type DeferredProps = {
 type PriorityProps = {
 	critical: {
 		priority: SchedulePriority['critical'];
-		// a critical island should never defer until idle
-		defer?: DeferredProps[Exclude<keyof DeferredProps, 'idle'>];
+		defer?: DeferredProps[keyof DeferredProps];
 	};
 	feature: {
 		priority: SchedulePriority['feature'];

--- a/dotcom-rendering/src/lib/renderElement.tsx
+++ b/dotcom-rendering/src/lib/renderElement.tsx
@@ -396,7 +396,7 @@ export const renderElement = ({
 			return (
 				// Deferring interactives until CPU idle achieves the lowest Cumulative Layout Shift (CLS)
 				// For more information on the experiment we ran see: https://github.com/guardian/dotcom-rendering/pull/4942
-				<Island priority="critical" defer={{ until: 'visible' }}>
+				<Island priority="critical" defer={{ until: 'idle' }}>
 					<InteractiveBlockComponent
 						url={element.url}
 						scriptUrl={element.scriptUrl}


### PR DESCRIPTION
## What does this change?

This PR fixes the Commercial logger message 'Spacefinder timeout hit' by replacing `visible` with `idle` after confirming with @mxdvl from WebEx that it is safe to do so. 

We have a `5000` timeout for Spacefinder and as you can see from the 'Before' screenshot  all different ad sizes that will be inserted by Spacefinder exceeds that time. 

The change has been tested locally and in CODE with these articles https://www.theguardian.com/artanddesign/2024/mar/19/damien-hirst-formaldehyde-animal-works-dated-to-1990s-were-made-in-2017 (Get in touch) and https://www.theguardian.com/society/2024/mar/20/young-people-becoming-less-happy-than-older-generations-research-shows (chart).

## Why?

Spacefinder will be able to make decisions about where to place ads without the timeout.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![image](https://github.com/guardian/dotcom-rendering/assets/23424805/f35bcc49-1fc4-4b3b-991d-40bfe84a64b3) | ![image](https://github.com/guardian/dotcom-rendering/assets/23424805/801be637-29f7-4e5d-abaf-a19737832981) |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
