### PR TITLE
Set same timeout for intervals of whenIdle

### DIFF
--- a/dotcom-rendering/src/client/islands/whenIdle.ts
+++ b/dotcom-rendering/src/client/islands/whenIdle.ts
@@ -1,10 +1,10 @@
+const timeout = 500;
 /**
  * whenIdle executes a callback when the browser is 'idle' or after a short timeout, whichever comes first
  * @see https://developer.mozilla.org/en-US/docs/Web/API/Window/requestIdleCallback
  *
  * @param callback the function to execute once the browser is 'idle'
  */
-const timeout = 500;
 export const whenIdle = (callback: () => void): void => {
 	if ('requestIdleCallback' in window) {
 		window.requestIdleCallback(callback, { timeout });

--- a/dotcom-rendering/src/client/islands/whenIdle.ts
+++ b/dotcom-rendering/src/client/islands/whenIdle.ts
@@ -5,9 +5,10 @@
  * @param callback the function to execute once the browser is 'idle'
  */
 export const whenIdle = (callback: () => void): void => {
+	const timeout = 500;
 	if ('requestIdleCallback' in window) {
-		window.requestIdleCallback(callback, { timeout: 500 });
+		window.requestIdleCallback(callback, { timeout });
 	} else {
-		setTimeout(callback, 300);
+		setTimeout(callback, timeout);
 	}
 };

--- a/dotcom-rendering/src/client/islands/whenIdle.ts
+++ b/dotcom-rendering/src/client/islands/whenIdle.ts
@@ -4,8 +4,8 @@
  *
  * @param callback the function to execute once the browser is 'idle'
  */
+const timeout = 500;
 export const whenIdle = (callback: () => void): void => {
-	const timeout = 500;
 	if ('requestIdleCallback' in window) {
 		window.requestIdleCallback(callback, { timeout });
 	} else {


### PR DESCRIPTION
## What does this change?

This is a small follow-up change from https://github.com/guardian/dotcom-rendering/pull/11077#pullrequestreview-1979733088

## Why?

Set same timeout for intervals of `whenIdle` instead of separate ones. 

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
