### PR TITLE
Remove unnecessary video caption margin

### DIFF
--- a/dotcom-rendering/src/components/Caption.tsx
+++ b/dotcom-rendering/src/components/Caption.tsx
@@ -1,13 +1,7 @@
 import { css } from '@emotion/react';
 import type { ArticleFormat } from '@guardian/libs';
 import { ArticleDesign, ArticleDisplay, ArticleSpecial } from '@guardian/libs';
-import {
-	between,
-	from,
-	space,
-	textSans,
-	until,
-} from '@guardian/source-foundations';
+import { from, space, textSans, until } from '@guardian/source-foundations';
 import { palette } from '../palette';
 import CameraSvg from '../static/icons/camera.svg';
 import VideoSvg from '../static/icons/video-icon.svg';
@@ -33,7 +27,7 @@ const captionStyle = css`
 	${textSans.xsmall()};
 	line-height: 135%;
 	padding-top: 6px;
-	overflow-wrap: break-all;
+	overflow-wrap: break-word;
 	color: ${palette('--caption-text')};
 `;
 
@@ -115,15 +109,6 @@ const captionPadding = css`
 const tabletCaptionPadding = css`
 	${until.desktop} {
 		${captionPadding}
-	}
-`;
-
-const videoPadding = css`
-	${until.mobileLandscape} {
-		margin-left: 10px;
-	}
-	${between.mobileLandscape.and.phablet} {
-		margin-left: ${space[5]}px;
 	}
 `;
 
@@ -251,7 +236,6 @@ export const Caption = ({
 				isOverlaid ? overlaidStyles(format) : bottomMarginStyles,
 				isMainMedia && isBlog && tabletCaptionPadding,
 				padCaption && captionPadding,
-				mediaType === 'Video' && videoPadding,
 			]}
 		>
 			{mediaType === 'Video' ? (


### PR DESCRIPTION
## What does this change?

Removes random margin

## Why?

Captions should be left aligned with the image

## Screenshots

| Before Tablet      | After Tablet      |
| ----------- | ---------- |
| ![before1][] | ![after1][] |

| Before Mobile      | After Mobile      |
| ----------- | ---------- |
| ![before2][] | ![after2][] |

[before1]: https://github.com/guardian/dotcom-rendering/assets/1229808/57a1fd32-cdc6-4fc6-ab92-e224579624c3
[after1]: https://github.com/guardian/dotcom-rendering/assets/1229808/6d2ac38e-47bb-4a37-a630-70da42d3a381
[before2]: https://github.com/guardian/dotcom-rendering/assets/1229808/ae0830ad-7bf2-4d52-a9a0-41db5127490d
[after2]: https://github.com/guardian/dotcom-rendering/assets/1229808/443b7ff8-aef1-4d17-aba1-4c442c68a87c


