### PR TITLE
DCAR Discussion: recommend comment

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -45,7 +45,7 @@
 		"@emotion/server": "11.11.0",
 		"@guardian/ab-core": "7.0.1",
 		"@guardian/braze-components": "18.1.0",
-		"@guardian/bridget": "2.6.0",
+		"@guardian/bridget": "3.0.0",
 		"@guardian/browserslist-config": "6.1.0",
 		"@guardian/cdk": "50.13.0",
 		"@guardian/commercial": "17.1.1",

--- a/dotcom-rendering/src/components/DiscussionApps.importable.tsx
+++ b/dotcom-rendering/src/components/DiscussionApps.importable.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { getdiscussionClient } from '../lib/bridgetApi';
+import { getDiscussionClient } from '../lib/bridgetApi';
 import type { Reader, UserProfile } from '../lib/discussion';
 import type { CommentResponse } from '../lib/discussionApi';
 import { reportAbuse as reportAbuseWeb } from '../lib/discussionApi';
@@ -19,7 +19,7 @@ const onReply = async (): Promise<CommentResponse> => {
 };
 
 const onRecommend = async (commentId: number): Promise<boolean> => {
-	return getdiscussionClient().recommend(commentId);
+	return getDiscussionClient().recommend(commentId);
 };
 const addUsername = async (): Promise<Result<string, true>> => {
 	console.log('addUsername');

--- a/dotcom-rendering/src/components/DiscussionApps.importable.tsx
+++ b/dotcom-rendering/src/components/DiscussionApps.importable.tsx
@@ -1,3 +1,4 @@
+import { DiscussionResponseType } from '@guardian/bridget';
 import { useEffect, useState } from 'react';
 import { getDiscussionClient } from '../lib/bridgetApi';
 import type { Reader, UserProfile } from '../lib/discussion';
@@ -19,8 +20,23 @@ const onReply = async (): Promise<CommentResponse> => {
 };
 
 const onRecommend = async (commentId: number): Promise<boolean> => {
-	return getDiscussionClient().recommend(commentId);
+	return getDiscussionClient()
+		.recommend(commentId.toString())
+		.then((discussionApiResponse) => {
+			if (
+				// eslint-disable-next-line no-underscore-dangle -- we don't have control over this name! It comes from the compiled Thrift models
+				discussionApiResponse.__type ===
+				DiscussionResponseType.DiscussionResponseWithResponse
+			) {
+				if (discussionApiResponse.response.statusCode === 200) {
+					return true;
+				}
+			}
+
+			return false;
+		});
 };
+
 const addUsername = async (): Promise<Result<string, true>> => {
 	console.log('addUsername');
 	return { kind: 'error', error: 'ApiError' };

--- a/dotcom-rendering/src/components/DiscussionApps.importable.tsx
+++ b/dotcom-rendering/src/components/DiscussionApps.importable.tsx
@@ -22,19 +22,13 @@ const onReply = async (): Promise<CommentResponse> => {
 const onRecommend = async (commentId: number): Promise<boolean> => {
 	return getDiscussionClient()
 		.recommend(commentId.toString())
-		.then((discussionApiResponse) => {
-			if (
+		.then(
+			(discussionApiResponse) =>
 				// eslint-disable-next-line no-underscore-dangle -- we don't have control over this name! It comes from the compiled Thrift models
 				discussionApiResponse.__type ===
-				DiscussionResponseType.DiscussionResponseWithResponse
-			) {
-				if (discussionApiResponse.response.statusCode === 200) {
-					return true;
-				}
-			}
-
-			return false;
-		});
+					DiscussionResponseType.DiscussionResponseWithResponse &&
+				discussionApiResponse.response.statusCode === 200,
+		);
 };
 
 const addUsername = async (): Promise<Result<string, true>> => {

--- a/dotcom-rendering/src/lib/bridgetApi.ts
+++ b/dotcom-rendering/src/lib/bridgetApi.ts
@@ -154,7 +154,7 @@ export const getNewslettersClient = (): Newsletters.Client<void> => {
 };
 
 let discussionClient: Discussion.Client<void> | undefined = undefined;
-export const getdiscussionClient = (): Discussion.Client<void> => {
+export const getDiscussionClient = (): Discussion.Client<void> => {
 	if (!discussionClient) {
 		discussionClient = createAppClient<Discussion.Client<void>>(
 			Discussion.Client,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -345,8 +345,8 @@ importers:
         specifier: 18.1.0
         version: 18.1.0(@emotion/react@11.11.1)(@guardian/libs@16.0.1)(@guardian/source-foundations@14.1.4)(@guardian/source-react-components-development-kitchen@19.0.0)(@guardian/source-react-components@22.0.1)(react@18.2.0)
       '@guardian/bridget':
-        specifier: 2.6.0
-        version: 2.6.0
+        specifier: 3.0.0
+        version: 3.0.0
       '@guardian/browserslist-config':
         specifier: 6.1.0
         version: 6.1.0(browserslist@4.21.9)(tslib@2.6.2)
@@ -4269,6 +4269,10 @@ packages:
 
   /@guardian/bridget@2.6.0:
     resolution: {integrity: sha512-kYlRZC5/9ImY2wQJfnteanjfLclmSU0wcsyt2CWl5YXHmc3gGnxZM+H/Y6KVqwxj0v5cGrvUuFJ7Zvk570dchQ==}
+    dev: false
+
+  /@guardian/bridget@3.0.0:
+    resolution: {integrity: sha512-mXmju3+PB3frDmvBt5D/HkFwCXdGarRsNsgPpKH9XGzTIRAwS25kQbmeRURkchEG1LAQQsIuv9KfZJRPQwetHQ==}
     dev: false
 
   /@guardian/browserslist-config@6.1.0(browserslist@4.21.9)(tslib@2.6.2):


### PR DESCRIPTION
## What does this change?

- Implements the `onRecommend` handler for discussion and handles the response

## Will merging this release the feature?

- Not in production or beta until we make an equivalent change in MAPI to specify that DCAR supports articles with discussion open for recommendation.

https://github.com/guardian/dotcom-rendering/assets/705427/06c5f062-ecf8-4d57-85cb-15df37ea6ea4

Closes https://github.com/guardian/dotcom-rendering/issues/10670
