### PR TITLE
Fix multi-image component alignment

### DIFF
--- a/dotcom-rendering/src/components/MultiImageBlockComponent.tsx
+++ b/dotcom-rendering/src/components/MultiImageBlockComponent.tsx
@@ -29,7 +29,7 @@ const wrapper = css`
 	margin-top: 12px;
 	margin-bottom: 12px;
 	${until.leftCol} {
-		clear: both;
+		clear: left;
 	}
 	img {
 		object-fit: cover;


### PR DESCRIPTION
## What does this change?
Force everything to the left of the image row to go onto a different row below leftCol.
## Why?
Images were disappearing and pull-quotes looking strange on multi-image elements.
Resolves https://github.com/guardian/dotcom-rendering/issues/9128
## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/110032454/8cc4e3dc-1610-446c-b1d6-ae69dfb22ac8
[after]: https://github.com/guardian/dotcom-rendering/assets/110032454/c55eef09-146c-4e44-9aee-9d471d125c74

| Before      | After      |
| ----------- | ---------- |
| ![before1][] | ![after1][] |

[before1]: https://github.com/guardian/dotcom-rendering/assets/110032454/92cbb14d-e950-413c-b117-b3353c823ee5
[after1]: https://github.com/guardian/dotcom-rendering/assets/110032454/1a6f6c34-4995-4a15-acc2-07dca051e4b2

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
