### PR TITLE
Chromatic ignore flaky images

### DIFF
--- a/apps-rendering/src/components/ImgAlt/index.tsx
+++ b/apps-rendering/src/components/ImgAlt/index.tsx
@@ -100,6 +100,7 @@ const Img: FC<Props> = ({ image, sizes, className, format, lightbox }) => (
 			data-ratio={image.height / image.width}
 			data-caption={getCaption(lightbox)}
 			data-credit={getCredit(lightbox)}
+			data-chromatic="ignore"
 		/>
 	</picture>
 );

--- a/apps-rendering/src/components/editions/layout/layout.stories.tsx
+++ b/apps-rendering/src/components/editions/layout/layout.stories.tsx
@@ -1,10 +1,6 @@
 // ----- Imports ----- //
 import type { Tag } from '@guardian/content-api-models/v1/tag';
-import {
-	ArticleDisplay,
-	ArticleElementRole,
-	ArticlePillar,
-} from '@guardian/libs';
+import { ArticleDisplay, ArticleElementRole, Pillar } from '@guardian/libs';
 import { breakpoints } from '@guardian/source-foundations';
 import { none, some } from '../../../../vendor/@guardian/types/index';
 import type { Contributor } from 'contributor';
@@ -74,7 +70,7 @@ const Default = (): ReactElement => (
 		item={{
 			...article,
 			webUrl: 'https://www.theguardian.com',
-			theme: ArticlePillar.News,
+			theme: Pillar.News,
 		}}
 	/>
 );
@@ -85,7 +81,7 @@ const Analysis = (): ReactElement => (
 			...analysis,
 			webUrl: 'https://www.theguardian.com',
 			tags: [getTag('tone/analysis', 'View from the Guardian ')],
-			theme: ArticlePillar.Lifestyle,
+			theme: Pillar.Lifestyle,
 		}}
 	/>
 );
@@ -96,7 +92,7 @@ const Editorial = (): ReactElement => (
 			...editorial,
 			tags: [getTag('tone/editorials', 'View from the Guardian ')],
 			webUrl: 'https://www.theguardian.com',
-			theme: ArticlePillar.Opinion,
+			theme: Pillar.Opinion,
 		}}
 	/>
 );
@@ -106,7 +102,7 @@ const Feature = (): ReactElement => (
 		item={{
 			...feature,
 			webUrl: 'https://www.theguardian.com',
-			theme: ArticlePillar.Sport,
+			theme: Pillar.Sport,
 		}}
 	/>
 );
@@ -116,7 +112,7 @@ const Review = (): ReactElement => (
 		item={{
 			...review,
 			webUrl: 'https://www.theguardian.com',
-			theme: ArticlePillar.Culture,
+			theme: Pillar.Culture,
 		}}
 	/>
 );
@@ -127,7 +123,7 @@ const Showcase = (): ReactElement => (
 			...article,
 			webUrl: 'https://www.theguardian.com',
 			display: ArticleDisplay.Showcase,
-			theme: ArticlePillar.News,
+			theme: Pillar.News,
 		}}
 	/>
 );
@@ -137,7 +133,7 @@ const Interview = (): ReactElement => (
 		item={{
 			...interview,
 			webUrl: 'https://www.theguardian.com',
-			theme: ArticlePillar.Sport,
+			theme: Pillar.Sport,
 		}}
 	/>
 );
@@ -148,7 +144,7 @@ const Comment = (): ReactElement => (
 			...comment,
 			webUrl: 'https://www.theguardian.com',
 			contributors,
-			theme: ArticlePillar.News,
+			theme: Pillar.News,
 		}}
 	/>
 );
@@ -159,7 +155,7 @@ const Letter = (): ReactElement => (
 			...letter,
 			webUrl: 'https://www.theguardian.com',
 			tags: [getTag('tone/letters', 'Letters ')],
-			theme: ArticlePillar.Opinion,
+			theme: Pillar.Opinion,
 		}}
 	/>
 );
@@ -174,7 +170,7 @@ const Correction = (): ReactElement => (
 					'Corrections and Clarifications ',
 				),
 			],
-			theme: ArticlePillar.News,
+			theme: Pillar.News,
 		}}
 	/>
 );
@@ -185,7 +181,7 @@ const MatchReport = (): ReactElement => (
 			...matchReport,
 			webUrl: 'https://www.theguardian.com',
 			tags: [getTag('tone/sport', 'Sport ')],
-			theme: ArticlePillar.Sport,
+			theme: Pillar.Sport,
 		}}
 	/>
 );
@@ -222,7 +218,7 @@ const Gallery = (): ReactElement => (
 		item={{
 			...media,
 			webUrl: 'https://www.theguardian.com',
-			theme: ArticlePillar.News,
+			theme: Pillar.News,
 		}}
 	/>
 );

--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -448,6 +448,15 @@ declare namespace JSX {
 		 * link is clicked.
 		 */
 		'data-link-name'?: string;
+		/**
+		 * Ignore a DOM element in Chromatic builds with `data-chromatic="ignore"`.
+		 *
+		 * https://www.chromatic.com/docs/ignoring-elements/#ignore-dom-elements
+		 *
+		 * Note that if the dimensions of the ignored element
+		 * change, Chromatic will still capture the incoming changes.
+		 */
+		'data-chromatic'?: string;
 	}
 }
 

--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -456,7 +456,7 @@ declare namespace JSX {
 		 * Note that if the dimensions of the ignored element
 		 * change, Chromatic will still capture the incoming changes.
 		 */
-		'data-chromatic'?: string;
+		'data-chromatic'?: 'ignore';
 	}
 }
 

--- a/dotcom-rendering/src/components/CardPicture.tsx
+++ b/dotcom-rendering/src/components/CardPicture.tsx
@@ -139,6 +139,8 @@ export const CardPicture = ({
 				src={fallbackSource.lowResUrl}
 				css={block}
 				loading={loading}
+				// Chromatic inconsistenly loads the image for lazy-loaded images
+				data-chromatic={loading === 'lazy' ? 'ignore' : undefined}
 			/>
 		</picture>
 	);


### PR DESCRIPTION
## What does this change?

When running a chromatic build, ignore images prone to causing failures.

Ignores lazy-loaded images in Cards, which are also prone to causing Chromatic failures.

## Why?

Rendering of images are non-deterministic, which can cause Chromatic build failures. Slight image differences caused by  the browser rendering engine is not behaviour we want Chromatic to flag. For example, in the image in this build failure, there are only a few pixels of difference in the entire image and this has caused the build to fail: https://www.chromatic.com/test?appId=637e406971a9af18ddba0505&id=660d43a8ddbe4a74d065bebf

Lazy-loaded images in cards are not always rendered in a Chromatic snapshot: https://www.chromatic.com/test?appId=63e251470cfbe61776b0ef19&id=660ece0c32ef7ef15789c65c

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
