### PR TITLE
Update discussion preview spout's background colour

### DIFF
--- a/dotcom-rendering/src/components/Discussion/Preview.tsx
+++ b/dotcom-rendering/src/components/Discussion/Preview.tsx
@@ -56,7 +56,8 @@ const spout = css`
 	width: 0;
 	height: 0;
 	border-right: 1rem solid transparent;
-	border-bottom: 1rem solid ${schemedPalette('--discussion-border')};
+	border-bottom: 1rem solid
+		${schemedPalette('--discussion-preview-background')};
 	margin-left: 12.5rem;
 	border-right-style: inset;
 `;


### PR DESCRIPTION
## What does this change?

- Updates the discussion preview spout's background colour to match the main preview box

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![Screen Shot 2024-04-08 at 16 03 41](https://github.com/guardian/dotcom-rendering/assets/705427/6ad88aad-c23f-4c2b-84b2-817e7e7dced5) | ![Screen Shot 2024-04-08 at 16 02 41](https://github.com/guardian/dotcom-rendering/assets/705427/ed354304-d060-4dfb-a290-53c126a014a2) |

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
