### PR TITLE
Discard errors in the `remove-label` GHA

### DIFF
--- a/.github/workflows/dcr-chromatic.yml
+++ b/.github/workflows/dcr-chromatic.yml
@@ -60,9 +60,13 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            await github.rest.issues.removeLabel({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              name: "run_chromatic"
-            })
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                name: "run_chromatic"
+              })
+            } catch (e) {
+              console.error(`An error ocurred: ${e}`);
+            }

--- a/.github/workflows/dcr-chromatic.yml
+++ b/.github/workflows/dcr-chromatic.yml
@@ -60,13 +60,13 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            try {
-              await github.rest.issues.removeLabel({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                name: "run_chromatic"
-              })
-            } catch (e) {
-              console.error(`An error ocurred: ${e}`);
-            }
+            await github.rest.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              name: "run_chromatic"
+            }).catch((error) => {
+              // https://docs.github.com/en/rest/issues/labels?apiVersion=2022-11-28#remove-a-label-from-an-issue--status-codes
+              if (error.status === 404) return console.warn("No such label!");
+              throw error;
+            })


### PR DESCRIPTION
It sometimes [fails](https://github.com/guardian/dotcom-rendering/actions/runs/8602589247/job/23572532027?pr=11090) the PR checks unnecessarily. We don't  want the workflow to fail if the label couldn't be removed.