### PR TITLE
Ignore img element in Picture component in Chromatic

### DIFF
--- a/apps-rendering/.storybook/preview-head.html
+++ b/apps-rendering/.storybook/preview-head.html
@@ -11,34 +11,96 @@
 </script>
 <script defer="" src="/js/curl-with-js-and-domReady.js"></script>
 
+<link
+	rel="preload"
+	href="https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Light.woff2"
+/>
+<link
+	rel="preload"
+	href="https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-LightItalic.woff2"
+/>
+<link
+	rel="preload"
+	href="https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Medium.woff2"
+/>
+<link
+	rel="preload"
+	href="https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-MediumItalic.woff2"
+/>
+<link
+	rel="preload"
+	href="https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Bold.woff2"
+/>
+<link
+	rel="preload"
+	href="https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-BoldItalic.woff2"
+/>
+<link
+	rel="preload"
+	href="https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Regular.woff2"
+/>
+<link
+	rel="preload"
+	href="https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-RegularItalic.woff2"
+/>
+<link
+	rel="preload"
+	href="https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Bold.woff2"
+/>
+<link
+	rel="preload"
+	href="https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-BoldItalic.woff2"
+/>
+<link
+	rel="preload"
+	href="https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Regular.woff2"
+/>
+<link
+	rel="preload"
+	href="https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-RegularItalic.woff2"
+/>
+<link
+	rel="preload"
+	href="https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Bold.woff2"
+/>
+<link
+	rel="preload"
+	href="https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-BoldItalic.woff2"
+/>
+
 <style>
 	@font-face {
 		font-family: 'Guardian Text Egyptian Web';
 		font-weight: 400;
 		src: url('/fonts/GuardianTextEgyptian-Reg.ttf');
 	}
+
 	@font-face {
 		font-family: 'Guardian Text Egyptian Web';
 		font-weight: 400;
 		font-style: italic;
 		src: url('/fonts/GuardianTextEgyptian-RegItalic.ttf');
 	}
+
 	@font-face {
 		font-family: 'Guardian Text Egyptian Web';
 		font-weight: 700;
 		src: url('/fonts/GuardianTextEgyptian-Bold.ttf');
 	}
+
 	@font-face {
 		font-family: 'Guardian Text Egyptian Web';
 		font-weight: 700;
 		font-style: italic;
 		src: url('/fonts/GuardianTextEgyptian-BoldItalic.ttf');
 	}
+
 	@font-face {
 		font-family: 'Guardian Text Egyptian Web';
 		font-weight: bold;
 		src: url('/fonts/GuardianTextEgyptian-Bold.ttf');
 	}
+
 	@font-face {
 		font-family: 'Guardian Text Egyptian Web';
 		font-weight: bold;
@@ -47,21 +109,50 @@
 	}
 
 	@font-face {
+		font-family: 'GuardianTextSans';
+		font-weight: 400;
+		src: url('/fonts/GuardianTextSans-Regular.ttf');
+	}
+
+	@font-face {
+		font-family: 'GuardianTextSans';
+		font-weight: 400;
+		font-style: italic;
+		src: url('/fonts/GuardianTextSans-RegularItalic.ttf');
+	}
+
+	@font-face {
+		font-family: 'GuardianTextSans';
+		font-weight: 700;
+		src: url('/fonts/GuardianTextSans-Bold.ttf');
+	}
+
+	@font-face {
+		font-family: 'GuardianTextSans';
+		font-weight: 700;
+		font-style: italic;
+		src: url('/fonts/GuardianTextSans-BoldItalic.ttf');
+	}
+
+	@font-face {
 		font-family: 'Guardian Text Sans Web';
 		font-weight: 400;
 		src: url('/fonts/GuardianTextSans-Regular.ttf');
 	}
+
 	@font-face {
 		font-family: 'Guardian Text Sans Web';
 		font-weight: 400;
 		font-style: italic;
 		src: url('/fonts/GuardianTextSans-RegularItalic.ttf');
 	}
+
 	@font-face {
 		font-family: 'Guardian Text Sans Web';
 		font-weight: 700;
 		src: url('/fonts/GuardianTextSans-Bold.ttf');
 	}
+
 	@font-face {
 		font-family: 'Guardian Text Sans Web';
 		font-weight: 700;
@@ -74,72 +165,87 @@
 		font-weight: 300;
 		src: url('/fonts/GHGuardianHeadline-Light.ttf');
 	}
+
 	@font-face {
 		font-family: 'GH Guardian Headline';
 		font-weight: 300;
 		font-style: italic;
 		src: url('/fonts/GHGuardianHeadline-LightItalic.ttf');
 	}
+
 	@font-face {
 		font-family: 'GH Guardian Headline';
 		font-weight: 400;
 		src: url('/fonts/GHGuardianHeadline-Regular.ttf');
 	}
+
 	@font-face {
 		font-family: 'GH Guardian Headline';
 		font-weight: 400;
 		font-style: italic;
 		src: url('/fonts/GHGuardianHeadline-RegularItalic.ttf');
 	}
+
 	@font-face {
 		font-family: 'GH Guardian Headline';
 		font-weight: 500;
 		src: url('/fonts/GHGuardianHeadline-Medium.ttf');
 	}
+
 	@font-face {
 		font-family: 'GH Guardian Headline';
 		font-weight: 500;
 		font-style: italic;
 		src: url('/fonts/GHGuardianHeadline-MediumItalic.ttf');
 	}
+
 	@font-face {
 		font-family: 'GH Guardian Headline';
 		font-weight: 600;
 		src: url('/fonts/GHGuardianHeadline-Semibold.ttf');
 	}
+
 	@font-face {
 		font-family: 'GH Guardian Headline';
 		font-weight: 600;
 		font-style: italic;
 		src: url('/fonts/GHGuardianHeadline-SemiboldItalic.ttf');
 	}
+
 	@font-face {
 		font-family: 'GH Guardian Headline';
 		font-weight: 700;
 		src: url('/fonts/GHGuardianHeadline-Bold.ttf');
 	}
+
 	@font-face {
 		font-family: 'GH Guardian Headline';
 		font-weight: 700;
 		font-style: italic;
 		src: url('/fonts/GHGuardianHeadline-BoldItalic.ttf');
 	}
+
 	body {
 		margin: 0;
 		font-family: 'Guardian Text Egyptian Web';
 	}
+
 	figure {
 		margin: 1em 0;
 	}
+
 	figure.element-embed {
 		margin: 2em 0;
 	}
+
 	.js-email-sub__iframe {
 		width: 100%;
 	}
+
 	.js-email-sub__iframe + figcaption {
 		margin-top: -8px;
 	}
+
 	video,
 	.element-atom iframe,
 	.element-audio iframe {

--- a/apps-rendering/src/components/CaptionIcon/index.tsx
+++ b/apps-rendering/src/components/CaptionIcon/index.tsx
@@ -51,7 +51,7 @@ const CaptionIcon: FC<IconProps> = ({ format, variant }) => {
 			return null;
 		default:
 			return (
-				<span css={iconStyles}>
+				<span css={iconStyles} data-chromatic="ignore">
 					{variant === CaptionIconVariant.Image ? (
 						<SvgCamera />
 					) : (

--- a/apps-rendering/src/components/Layout/Layout.stories.tsx
+++ b/apps-rendering/src/components/Layout/Layout.stories.tsx
@@ -261,7 +261,7 @@ export default {
 	parameters: {
 		layout: 'fullscreen',
 		chromatic: {
-			diffThreshold: 0.4,
+			diffThreshold: 0.6,
 			viewports: [
 				breakpoints.mobile,
 				breakpoints.tablet,

--- a/apps-rendering/src/image/sizes.ts
+++ b/apps-rendering/src/image/sizes.ts
@@ -44,7 +44,7 @@ const styles = (
 	width: number,
 	height: number,
 ): SerializedStyles => {
-	const ratio = height / width;
+	const ratio = Number((height / width).toPrecision(3));
 
 	return css`
 		${dimensions(sizes.default, ratio)}

--- a/dotcom-rendering/src/components/Caption.tsx
+++ b/dotcom-rendering/src/components/Caption.tsx
@@ -185,6 +185,7 @@ const CameraIcon = ({ format }: IconProps) => {
 				format.display === ArticleDisplay.Immersive &&
 					hideIconBelowLeftCol,
 			]}
+			data-chromatic="ignore"
 		>
 			<CameraSvg />
 		</span>
@@ -200,6 +201,7 @@ const VideoIcon = ({ format }: IconProps) => {
 					hideIconBelowLeftCol,
 				videoIconStyle,
 			]}
+			data-chromatic="ignore"
 		>
 			<VideoSvg />
 		</span>

--- a/dotcom-rendering/src/components/Picture.tsx
+++ b/dotcom-rendering/src/components/Picture.tsx
@@ -407,6 +407,7 @@ export const Picture = ({
 				height={fallbackSource.width * ratio}
 				loading={Picture.disableLazyLoading ? undefined : loading}
 				css={isLightbox ? flex : block}
+				data-chromatic="ignore"
 			/>
 		</picture>
 	);


### PR DESCRIPTION
## What does this change?

Ignores an `img` element when running Chromatic

## Why?

Images are causing flakiness in Chromatic testing. Since we don't care about minor pixel differences within images when running Chromatic, Adding an ignore attribute to these images may reduce some of these false positives: https://www.chromatic.com/test?appId=637e406971a9af18ddba0505&id=660e8a6058df5e3c9a620b51

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
