### PR TITLE
Update chromatic mobile viewport

### DIFF
--- a/apps-rendering/src/components/Accordion/Accordion.stories.tsx
+++ b/apps-rendering/src/components/Accordion/Accordion.stories.tsx
@@ -80,7 +80,7 @@ export default {
 			values: [{ name: 'grey', value: 'lightgrey' }],
 		},
 		chromatic: {
-			viewports: [breakpoints.mobile, breakpoints.tablet],
+			viewports: [breakpoints.mobileMedium, breakpoints.tablet],
 		},
 	},
 };

--- a/apps-rendering/src/components/Layout/Layout.stories.tsx
+++ b/apps-rendering/src/components/Layout/Layout.stories.tsx
@@ -263,7 +263,7 @@ export default {
 		chromatic: {
 			diffThreshold: 0.4,
 			viewports: [
-				breakpoints.mobile,
+				breakpoints.mobileMedium,
 				breakpoints.tablet,
 				breakpoints.wide,
 			],

--- a/apps-rendering/src/components/Pagination/Pagination.stories.tsx
+++ b/apps-rendering/src/components/Pagination/Pagination.stories.tsx
@@ -10,7 +10,7 @@ export default {
 	title: 'AR/Pagination',
 	parameters: {
 		layout: 'padded',
-		chromatic: { viewports: [breakpoints.mobile, breakpoints.wide] },
+		chromatic: { viewports: [breakpoints.mobileMedium, breakpoints.wide] },
 	},
 };
 

--- a/apps-rendering/src/components/editions/layout/layout.stories.tsx
+++ b/apps-rendering/src/components/editions/layout/layout.stories.tsx
@@ -239,7 +239,7 @@ export default {
 		layout: 'fullscreen',
 		chromatic: {
 			diffThreshold: 0.4,
-			viewports: [breakpoints.mobile, breakpoints.tablet],
+			viewports: [breakpoints.mobileMedium, breakpoints.tablet],
 		},
 	},
 };

--- a/dotcom-rendering/src/components/Accordion.stories.tsx
+++ b/dotcom-rendering/src/components/Accordion.stories.tsx
@@ -14,7 +14,7 @@ const meta = {
 			values: [{ name: 'grey', value: 'lightgrey' }],
 		},
 		chromatic: {
-			viewports: [breakpoints.mobile, breakpoints.tablet],
+			viewports: [breakpoints.mobileMedium, breakpoints.tablet],
 		},
 	},
 } satisfies Meta<typeof AccordionComponent>;

--- a/dotcom-rendering/src/components/AdSlot.apps.stories.tsx
+++ b/dotcom-rendering/src/components/AdSlot.apps.stories.tsx
@@ -23,7 +23,7 @@ export default {
 	title: 'Components/AdSlot.apps',
 	parameters: {
 		chromatic: {
-			viewports: [breakpoints.mobile, breakpoints.tablet],
+			viewports: [breakpoints.mobileMedium, breakpoints.tablet],
 		},
 		viewport: {
 			defaultViewport: 'mobile',

--- a/dotcom-rendering/src/components/ArticleMeta.apps.stories.tsx
+++ b/dotcom-rendering/src/components/ArticleMeta.apps.stories.tsx
@@ -84,7 +84,7 @@ export default {
 			defaultViewport: 'wide',
 		},
 		chromatic: {
-			viewports: [breakpoints.mobile, breakpoints.tablet],
+			viewports: [breakpoints.mobileMedium, breakpoints.tablet],
 		},
 	},
 };

--- a/dotcom-rendering/src/components/Caption.stories.tsx
+++ b/dotcom-rendering/src/components/Caption.stories.tsx
@@ -282,7 +282,7 @@ VideoCaption.story = {
 	parameters: {
 		chromatic: {
 			viewports: [
-				breakpoints.mobile,
+				breakpoints.mobileMedium,
 				breakpoints.mobileLandscape,
 				breakpoints.phablet,
 			],

--- a/dotcom-rendering/src/components/CardHeadline.stories.tsx
+++ b/dotcom-rendering/src/components/CardHeadline.stories.tsx
@@ -193,7 +193,7 @@ MobileSize.decorators = [
 ];
 MobileSize.parameters = {
 	chromatic: {
-		viewports: [breakpoints.mobile],
+		viewports: [breakpoints.mobileMedium],
 	},
 };
 

--- a/dotcom-rendering/src/components/Carousel.stories.tsx
+++ b/dotcom-rendering/src/components/Carousel.stories.tsx
@@ -21,7 +21,7 @@ export default {
 	parameters: {
 		chromatic: {
 			viewports: [
-				breakpoints.mobile,
+				breakpoints.mobileMedium,
 				breakpoints.tablet,
 				breakpoints.desktop,
 			],

--- a/dotcom-rendering/src/components/DecideContainerByTrails.stories.tsx
+++ b/dotcom-rendering/src/components/DecideContainerByTrails.stories.tsx
@@ -10,7 +10,7 @@ export default {
 	parameters: {
 		chromatic: {
 			viewports: [
-				breakpoints.mobile,
+				breakpoints.mobileMedium,
 				breakpoints.tablet,
 				breakpoints.wide,
 			],

--- a/dotcom-rendering/src/components/DynamicFast.stories.tsx
+++ b/dotcom-rendering/src/components/DynamicFast.stories.tsx
@@ -11,7 +11,7 @@ export default {
 	parameters: {
 		chromatic: {
 			viewports: [
-				breakpoints.mobile,
+				breakpoints.mobileMedium,
 				breakpoints.tablet,
 				breakpoints.wide,
 			],

--- a/dotcom-rendering/src/components/DynamicPackage.stories.tsx
+++ b/dotcom-rendering/src/components/DynamicPackage.stories.tsx
@@ -20,7 +20,7 @@ export default {
 	parameters: {
 		chromatic: {
 			viewports: [
-				breakpoints.mobile,
+				breakpoints.mobileMedium,
 				breakpoints.tablet,
 				breakpoints.wide,
 			],

--- a/dotcom-rendering/src/components/DynamicSlow.stories.tsx
+++ b/dotcom-rendering/src/components/DynamicSlow.stories.tsx
@@ -27,7 +27,7 @@ export default {
 	parameters: {
 		chromatic: {
 			viewports: [
-				breakpoints.mobile,
+				breakpoints.mobileMedium,
 				breakpoints.tablet,
 				breakpoints.wide,
 			],

--- a/dotcom-rendering/src/components/DynamicSlowMPU.stories.tsx
+++ b/dotcom-rendering/src/components/DynamicSlowMPU.stories.tsx
@@ -10,7 +10,7 @@ export default {
 	parameters: {
 		chromatic: {
 			viewports: [
-				breakpoints.mobile,
+				breakpoints.mobileMedium,
 				breakpoints.tablet,
 				breakpoints.wide,
 			],

--- a/dotcom-rendering/src/components/EmailSignup.stories.tsx
+++ b/dotcom-rendering/src/components/EmailSignup.stories.tsx
@@ -24,7 +24,7 @@ export default {
 		// Set the viewports in Chromatic at a component level.
 		chromatic: {
 			viewports: [
-				breakpoints.mobile,
+				breakpoints.mobileMedium,
 				breakpoints.mobileMedium,
 				breakpoints.phablet,
 				breakpoints.tablet,

--- a/dotcom-rendering/src/components/Figure.stories.tsx
+++ b/dotcom-rendering/src/components/Figure.stories.tsx
@@ -41,7 +41,7 @@ export default {
 		// Set the viewports in Chromatic at a component level.
 		chromatic: {
 			viewports: [
-				breakpoints.mobile,
+				breakpoints.mobileMedium,
 				breakpoints.mobileMedium,
 				breakpoints.phablet,
 				breakpoints.tablet,

--- a/dotcom-rendering/src/components/FilterLink.stories.tsx
+++ b/dotcom-rendering/src/components/FilterLink.stories.tsx
@@ -26,7 +26,7 @@ export default {
 		// Set the viewports in Chromatic at a component level.
 		chromatic: {
 			viewports: [
-				breakpoints.mobile,
+				breakpoints.mobileMedium,
 				breakpoints.tablet,
 				breakpoints.wide,
 			],

--- a/dotcom-rendering/src/components/FixedLargeSlowXIV.stories.tsx
+++ b/dotcom-rendering/src/components/FixedLargeSlowXIV.stories.tsx
@@ -10,7 +10,7 @@ export default {
 	parameters: {
 		chromatic: {
 			viewports: [
-				breakpoints.mobile,
+				breakpoints.mobileMedium,
 				breakpoints.tablet,
 				breakpoints.wide,
 			],

--- a/dotcom-rendering/src/components/FixedMediumFastXI.stories.tsx
+++ b/dotcom-rendering/src/components/FixedMediumFastXI.stories.tsx
@@ -10,7 +10,7 @@ export default {
 	parameters: {
 		chromatic: {
 			viewports: [
-				breakpoints.mobile,
+				breakpoints.mobileMedium,
 				breakpoints.tablet,
 				breakpoints.wide,
 			],

--- a/dotcom-rendering/src/components/FixedMediumFastXII.stories.tsx
+++ b/dotcom-rendering/src/components/FixedMediumFastXII.stories.tsx
@@ -10,7 +10,7 @@ export default {
 	parameters: {
 		chromatic: {
 			viewports: [
-				breakpoints.mobile,
+				breakpoints.mobileMedium,
 				breakpoints.tablet,
 				breakpoints.wide,
 			],

--- a/dotcom-rendering/src/components/FixedMediumSlowVI.stories.tsx
+++ b/dotcom-rendering/src/components/FixedMediumSlowVI.stories.tsx
@@ -10,7 +10,7 @@ export default {
 	parameters: {
 		chromatic: {
 			viewports: [
-				breakpoints.mobile,
+				breakpoints.mobileMedium,
 				breakpoints.tablet,
 				breakpoints.wide,
 			],

--- a/dotcom-rendering/src/components/FixedMediumSlowVII.stories.tsx
+++ b/dotcom-rendering/src/components/FixedMediumSlowVII.stories.tsx
@@ -10,7 +10,7 @@ export default {
 	parameters: {
 		chromatic: {
 			viewports: [
-				breakpoints.mobile,
+				breakpoints.mobileMedium,
 				breakpoints.tablet,
 				breakpoints.wide,
 			],

--- a/dotcom-rendering/src/components/FixedMediumSlowXIIMPU.stories.tsx
+++ b/dotcom-rendering/src/components/FixedMediumSlowXIIMPU.stories.tsx
@@ -10,7 +10,7 @@ export default {
 	parameters: {
 		chromatic: {
 			viewports: [
-				breakpoints.mobile,
+				breakpoints.mobileMedium,
 				breakpoints.tablet,
 				breakpoints.wide,
 			],

--- a/dotcom-rendering/src/components/FixedSmallFastVIII.stories.tsx
+++ b/dotcom-rendering/src/components/FixedSmallFastVIII.stories.tsx
@@ -10,7 +10,7 @@ export default {
 	parameters: {
 		chromatic: {
 			viewports: [
-				breakpoints.mobile,
+				breakpoints.mobileMedium,
 				breakpoints.tablet,
 				breakpoints.wide,
 			],

--- a/dotcom-rendering/src/components/FixedSmallSlowI.stories.tsx
+++ b/dotcom-rendering/src/components/FixedSmallSlowI.stories.tsx
@@ -10,7 +10,7 @@ export default {
 	parameters: {
 		chromatic: {
 			viewports: [
-				breakpoints.mobile,
+				breakpoints.mobileMedium,
 				breakpoints.tablet,
 				breakpoints.wide,
 			],

--- a/dotcom-rendering/src/components/FixedSmallSlowIII.stories.tsx
+++ b/dotcom-rendering/src/components/FixedSmallSlowIII.stories.tsx
@@ -10,7 +10,7 @@ export default {
 	parameters: {
 		chromatic: {
 			viewports: [
-				breakpoints.mobile,
+				breakpoints.mobileMedium,
 				breakpoints.tablet,
 				breakpoints.wide,
 			],

--- a/dotcom-rendering/src/components/FixedSmallSlowIV.stories.tsx
+++ b/dotcom-rendering/src/components/FixedSmallSlowIV.stories.tsx
@@ -10,7 +10,7 @@ export default {
 	parameters: {
 		chromatic: {
 			viewports: [
-				breakpoints.mobile,
+				breakpoints.mobileMedium,
 				breakpoints.tablet,
 				breakpoints.wide,
 			],

--- a/dotcom-rendering/src/components/FixedSmallSlowVHalf.stories.tsx
+++ b/dotcom-rendering/src/components/FixedSmallSlowVHalf.stories.tsx
@@ -10,7 +10,7 @@ export default {
 	parameters: {
 		chromatic: {
 			viewports: [
-				breakpoints.mobile,
+				breakpoints.mobileMedium,
 				breakpoints.tablet,
 				breakpoints.wide,
 			],

--- a/dotcom-rendering/src/components/FixedSmallSlowVMPU.stories.tsx
+++ b/dotcom-rendering/src/components/FixedSmallSlowVMPU.stories.tsx
@@ -10,7 +10,7 @@ export default {
 	parameters: {
 		chromatic: {
 			viewports: [
-				breakpoints.mobile,
+				breakpoints.mobileMedium,
 				breakpoints.tablet,
 				breakpoints.wide,
 			],

--- a/dotcom-rendering/src/components/FixedSmallSlowVThird.stories.tsx
+++ b/dotcom-rendering/src/components/FixedSmallSlowVThird.stories.tsx
@@ -10,7 +10,7 @@ export default {
 	parameters: {
 		chromatic: {
 			viewports: [
-				breakpoints.mobile,
+				breakpoints.mobileMedium,
 				breakpoints.tablet,
 				breakpoints.wide,
 			],

--- a/dotcom-rendering/src/components/FrontSection.stories.tsx
+++ b/dotcom-rendering/src/components/FrontSection.stories.tsx
@@ -14,7 +14,7 @@ export default {
 		},
 		chromatic: {
 			viewports: [
-				breakpoints.mobile,
+				breakpoints.mobileMedium,
 				breakpoints.tablet,
 				breakpoints.desktop,
 				breakpoints.leftCol,
@@ -199,7 +199,7 @@ MultipleStory.story = {
 	parameters: {
 		chromatic: {
 			viewports: [
-				breakpoints.mobile,
+				breakpoints.mobileMedium,
 				breakpoints.leftCol,
 				breakpoints.wide,
 			],

--- a/dotcom-rendering/src/components/LabsSection.stories.tsx
+++ b/dotcom-rendering/src/components/LabsSection.stories.tsx
@@ -15,7 +15,7 @@ export default {
 		},
 		chromatic: {
 			viewports: [
-				breakpoints.mobile,
+				breakpoints.mobileMedium,
 				breakpoints.tablet,
 				breakpoints.desktop,
 				breakpoints.leftCol,

--- a/dotcom-rendering/src/components/LatestLinks.importable.stories.tsx
+++ b/dotcom-rendering/src/components/LatestLinks.importable.stories.tsx
@@ -21,7 +21,7 @@ export default {
 	parameters: {
 		chromatic: {
 			viewports: [
-				breakpoints.mobile,
+				breakpoints.mobileMedium,
 				breakpoints.mobileLandscape,
 				breakpoints.phablet,
 				breakpoints.desktop,

--- a/dotcom-rendering/src/components/Lightbox.stories.tsx
+++ b/dotcom-rendering/src/components/Lightbox.stories.tsx
@@ -30,7 +30,7 @@ export default {
 	title: 'Components/LightboxLayout',
 	parameters: {
 		chromatic: {
-			viewports: [breakpoints.mobile, breakpoints.desktop],
+			viewports: [breakpoints.mobileMedium, breakpoints.desktop],
 		},
 		viewport: {
 			// This has the effect of turning off the viewports addon by default

--- a/dotcom-rendering/src/components/LiveBlock.stories.tsx
+++ b/dotcom-rendering/src/components/LiveBlock.stories.tsx
@@ -32,7 +32,7 @@ export default {
 		},
 		chromatic: {
 			viewports: [
-				breakpoints.mobile,
+				breakpoints.mobileMedium,
 				breakpoints.tablet,
 				breakpoints.wide,
 			],

--- a/dotcom-rendering/src/components/NavList.stories.tsx
+++ b/dotcom-rendering/src/components/NavList.stories.tsx
@@ -10,7 +10,7 @@ export default {
 	parameters: {
 		chromatic: {
 			viewports: [
-				breakpoints.mobile,
+				breakpoints.mobileMedium,
 				breakpoints.tablet,
 				breakpoints.wide,
 			],

--- a/dotcom-rendering/src/components/Pagination.stories.tsx
+++ b/dotcom-rendering/src/components/Pagination.stories.tsx
@@ -10,7 +10,7 @@ export default {
 	title: 'Components/Pagination',
 	parameters: {
 		layout: 'padded',
-		chromatic: { viewports: [breakpoints.mobile, breakpoints.wide] },
+		chromatic: { viewports: [breakpoints.mobileMedium, breakpoints.wide] },
 	},
 };
 

--- a/dotcom-rendering/src/components/Palettes.stories.tsx
+++ b/dotcom-rendering/src/components/Palettes.stories.tsx
@@ -44,7 +44,7 @@ EventPalette.story = {
 	parameters: {
 		chromatic: {
 			viewports: [
-				breakpoints.mobile,
+				breakpoints.mobileMedium,
 				breakpoints.tablet,
 				breakpoints.wide,
 			],

--- a/dotcom-rendering/src/components/PinnedPost.stories.tsx
+++ b/dotcom-rendering/src/components/PinnedPost.stories.tsx
@@ -36,7 +36,7 @@ export default {
 		},
 		chromatic: {
 			viewports: [
-				breakpoints.mobile,
+				breakpoints.mobileMedium,
 				breakpoints.tablet,
 				breakpoints.wide,
 			],

--- a/dotcom-rendering/src/components/PullQuoteBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/components/PullQuoteBlockComponent.stories.tsx
@@ -14,7 +14,7 @@ export default {
 	component: PullQuoteBlockComponent,
 	title: 'Components/PullQuoteBlockComponent',
 	chromatic: {
-		viewports: [breakpoints.mobile, breakpoints.desktop],
+		viewports: [breakpoints.mobileMedium, breakpoints.desktop],
 	},
 };
 

--- a/dotcom-rendering/src/components/Section.stories.tsx
+++ b/dotcom-rendering/src/components/Section.stories.tsx
@@ -274,7 +274,7 @@ MultipleStory.story = {
 	parameters: {
 		chromatic: {
 			viewports: [
-				breakpoints.mobile,
+				breakpoints.mobileMedium,
 				breakpoints.leftCol,
 				breakpoints.wide,
 			],

--- a/dotcom-rendering/src/components/Slideshow.stories.tsx
+++ b/dotcom-rendering/src/components/Slideshow.stories.tsx
@@ -10,7 +10,7 @@ export default {
 	parameters: {
 		chromatic: {
 			viewports: [
-				breakpoints.mobile,
+				breakpoints.mobileMedium,
 				breakpoints.tablet,
 				breakpoints.leftCol,
 			],

--- a/dotcom-rendering/src/components/SupportingContent.stories.tsx
+++ b/dotcom-rendering/src/components/SupportingContent.stories.tsx
@@ -262,7 +262,7 @@ export const HorizontalOnMobile = () => {
 HorizontalOnMobile.story = {
 	parameters: {
 		chromatic: {
-			viewports: [breakpoints.mobile],
+			viewports: [breakpoints.mobileMedium],
 		},
 		viewport: {
 			defaultViewport: 'mobileMedium',

--- a/dotcom-rendering/src/components/Toast.stories.tsx
+++ b/dotcom-rendering/src/components/Toast.stories.tsx
@@ -156,7 +156,7 @@ Mobile.story = {
 	parameters: {
 		viewport: { defaultViewport: 'mobileMedium' },
 		chromatic: {
-			viewports: [breakpoints.mobile],
+			viewports: [breakpoints.mobileMedium],
 		},
 	},
 };

--- a/dotcom-rendering/src/layouts/DecideLayout.stories.tsx
+++ b/dotcom-rendering/src/layouts/DecideLayout.stories.tsx
@@ -99,7 +99,7 @@ const appsParameters = {
 		darkModeAvailable: true,
 	},
 	chromatic: {
-		viewports: [breakpoints.mobile, breakpoints.tablet],
+		viewports: [breakpoints.mobileMedium, breakpoints.tablet],
 	},
 };
 


### PR DESCRIPTION
## What does this change?

Use mobileMedium viewport instead of mobile for chromatic

## Why?

We want our stories to be representative of the user experience. In 2024, 375px is much more representative of actual mobile user experience than 320px. On the other hand, the benefit of 320px is that we are testing an extreme: if it looks good at 320px then it probably also looks good at 375px. The same is less likely to be true the other way around.

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
