### PR TITLE
Add observed to the all newsletter page

### DIFF
--- a/dotcom-rendering/src/model/newsletter-grouping.ts
+++ b/dotcom-rendering/src/model/newsletter-grouping.ts
@@ -49,6 +49,7 @@ export const groups: Partial<Record<EditionId, StaticGroups>> = {
 				'inside-saturday',
 				'five-great-reads',
 				'house-to-home',
+				'observed',
 				'saved-for-later',
 				'the-upside',
 				'guardian-traveller',
@@ -153,6 +154,7 @@ export const groups: Partial<Record<EditionId, StaticGroups>> = {
 				'the-long-read',
 				'saved-for-later',
 				'house-to-home',
+				'observed',
 			],
 		},
 		{
@@ -247,6 +249,7 @@ export const groups: Partial<Record<EditionId, StaticGroups>> = {
 				'house-to-home',
 				'inside-saturday',
 				'observer-food',
+				'observed',
 			],
 		},
 		{


### PR DESCRIPTION
## What does this change?
Adds observed to the all newsletter page
https://www.theguardian.com/news/2023/nov/21/observed-newsletter-signup-observer
## Why?
Request from CP
## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/110032454/28097e19-f2c8-4d80-ad12-34bcb3bd468e
[after]: https://github.com/guardian/dotcom-rendering/assets/110032454/ee741ca6-2b79-4d9d-a116-cd06738ce53c

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
