### PR TITLE
Add a data attribute to indicate areas within blocks where ads may be inserted (Ads in Key Takeaways)

### DIFF
--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -457,6 +457,35 @@ declare namespace JSX {
 		 * change, Chromatic will still capture the incoming changes.
 		 */
 		'data-chromatic'?: 'ignore';
+
+		/**
+		 * **Spacefinder Role**
+		 *
+		 * [Spacefinder](https://github.com/guardian/commercial/blob/main/src/insert/spacefinder/article.ts)
+		 * is a part of the commercial bundle that is used to find positions
+		 * for ad slots within articles.
+		 *
+		 * Spacefinder has rules specified for elements with this data attribute
+		 * that it will use to find positions for ads.
+		 */
+		'data-spacefinder-role'?:
+			| 'nested'
+			| 'immersive'
+			| 'inline'
+			| 'richLink'
+			| 'thumbnail';
+
+		/**
+		 * **Spacefinder Type**
+		 *
+		 * [Spacefinder](https://github.com/guardian/commercial/blob/main/src/insert/spacefinder/article.ts)
+		 * is a part of the commercial bundle that is used to find positions
+		 * for ad slots within articles.
+		 *
+		 * Spacefinder has rules specified for elements with this data attribute
+		 * that it will use to find positions for ads.
+		 */
+		'data-spacefinder-type'?: import('./src/types/content').FEElement['_type'];
 	}
 }
 

--- a/dotcom-rendering/src/components/KeyTakeaway.tsx
+++ b/dotcom-rendering/src/components/KeyTakeaway.tsx
@@ -64,7 +64,7 @@ export const KeyTakeaway = ({
 }: KeyTakeawayProps) => {
 	return (
 		<>
-			<li css={keyTakeawayStyles}>
+			<li css={keyTakeawayStyles} data-spacefinder-role="nested">
 				<hr css={headingLineStyles} />
 				<h2 css={headingStyles(format.display)}>
 					<span css={headingIndexStyles}>{`${titleIndex}. `}</span>


### PR DESCRIPTION
## What does this change?
[We are adding support for inserting ads inside of blocks to spacefinder](https://github.com/guardian/commercial/pull/1337), not just around them as we currently do. We don't want to do this willy nilly so introducing a data attribute to indicate to spacefinder that ads may be inserted here (as a direct child of the element with the attr)

## Why?
To support inserting ads in new block types like the "Key Takeaways" block

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |
| ![before2][] | ![after2][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/1731150/545629d9-b116-4e34-8a69-f54e5bf6304f

[after]: https://github.com/guardian/dotcom-rendering/assets/1731150/dbf24720-1d17-4657-a0c8-20511d73aabc

[before2]: https://github.com/guardian/dotcom-rendering/assets/1731150/946ff303-a3e1-4e64-8364-5d46f2d568cb

[after2]: https://github.com/guardian/dotcom-rendering/assets/1731150/7f771b17-60ad-4bae-bf6c-4a1f73d24ae3



<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
