### PR TITLE
Add delimitation at the end of key takeaways

### DIFF
--- a/dotcom-rendering/src/components/KeyTakeaways.tsx
+++ b/dotcom-rendering/src/components/KeyTakeaways.tsx
@@ -23,13 +23,10 @@ interface KeyTakeawaysProps {
 	RenderArticleElement: ArticleElementRenderer;
 }
 
-const lineStyles = css`
+const finalLineStyles = css`
 	width: 140px;
-	height: 1px;
-	margin: 0;
-	border: none;
+	margin: 8px 0 2px 0;
 	border-top: 1px solid ${palette.neutral[86]};
-	padding: 8px 0 2px 0;
 `;
 
 export const KeyTakeaways = ({
@@ -68,7 +65,7 @@ export const KeyTakeaways = ({
 					RenderArticleElement={RenderArticleElement}
 				/>
 			))}
-			<hr css={lineStyles} />
+			<hr css={finalLineStyles} />
 		</ol>
 	);
 };


### PR DESCRIPTION
## What does this change?
Adds a grey line under keytakeaways.
## Why?
Resolves https://github.com/guardian/dotcom-rendering/issues/11083
## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/110032454/f52e57ad-a201-40fc-ae2d-85cfc48ade3b
[after]: https://github.com/guardian/dotcom-rendering/assets/110032454/f1150360-6178-427b-a772-e7c05d880b39

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
