### PR TITLE
Add alternative propertyHref and propertyId for AMP sourcepoint test

### DIFF
--- a/dotcom-rendering/src/components/AdConsent.amp.tsx
+++ b/dotcom-rendering/src/components/AdConsent.amp.tsx
@@ -5,70 +5,71 @@ type AdConsentProps = {
 	abTests: ServerSideTests;
 };
 
+const sourcepointDomain = 'sourcepoint.theguardian.com';
+
+const pubData = {
+	authId: 'CLIENT_ID',
+	client_id: 'CLIENT_ID',
+	// Matches ampViewId from https://ophan.theguardian.com/amp.json
+	page_view_id: 'PAGE_VIEW_ID',
+	page_view_id_64: 'PAGE_VIEW_ID_64',
+	platform: 'amp',
+	source_url: 'SOURCE_URL',
+};
+
+const queryParams = new URLSearchParams(pubData).toString();
+
+// Default to TCFv2, the CCPA and AUS configs override the options in this config
+const clientConfig = {
+	accountId: 1257,
+	mmsDomain: `https://${sourcepointDomain}`,
+	propertyId: 8791,
+	pmTab: 'purposes',
+	stageCampaign: false,
+	privacyManagerId: 145885,
+	isTCFV2: true,
+	propertyHref: 'https://theguardian.amp',
+	targetingParams: {
+		framework: 'tcfv2',
+	},
+};
+
+const clientConfigCcpa = {
+	privacyManagerId: '5eba7ef78c167c47ca8b433d',
+	isCCPA: true,
+	isTCFV2: false,
+	propertyHref: null,
+	siteHref: 'https://theguardian.amp',
+	getDnsMsgMms: true,
+	alwaysDisplayDns: false,
+	showNoticeUntilAction: true,
+	targetingParams: {
+		framework: 'ccpa',
+	},
+};
+
+const clientConfigAus = {
+	propertyId: 14327,
+	privacyManagerId: '5f859e174ed5055e72ce26a6',
+	isCCPA: true,
+	isTCFV2: false,
+	propertyHref: null,
+	siteHref: 'https://amp.au.theguardian.com',
+	getDnsMsgMms: true,
+	alwaysDisplayDns: false,
+	showNoticeUntilAction: true,
+	targetingParams: {
+		framework: 'aus',
+	},
+};
+
 export const AdConsent = ({ abTests }: AdConsentProps) => {
-	const sourcepointDomain = 'sourcepoint.theguardian.com';
-
-	const pubData = {
-		authId: 'CLIENT_ID',
-		client_id: 'CLIENT_ID',
-		// Matches ampViewId from https://ophan.theguardian.com/amp.json
-		page_view_id: 'PAGE_VIEW_ID',
-		page_view_id_64: 'PAGE_VIEW_ID_64',
-		platform: 'amp',
-		source_url: 'SOURCE_URL',
-	};
-
-	const queryParams = new URLSearchParams(pubData).toString();
-
-	// Default to TCFv2, the CCPA and AUS configs override the options in this config
-	const clientConfig = {
-		accountId: 1257,
-		mmsDomain: `https://${sourcepointDomain}`,
-		propertyId: 8791,
-		pmTab: 'purposes',
-		stageCampaign: false,
-		privacyManagerId: 145885,
-		isTCFV2: true,
-		propertyHref: 'https://theguardian.amp',
-		targetingParams: {
-			framework: 'tcfv2',
-		},
-	};
-
-	const testClientConfig = {
+	const testAlternativeClientConfig = {
 		...clientConfig,
 		propertyId: 16921,
 		propertyHref: 'https://test.theguardian.amp',
 	};
 
-	const clientConfigCcpa: ClientConfig = {
-		privacyManagerId: '5eba7ef78c167c47ca8b433d',
-		isCCPA: true,
-		isTCFV2: false,
-		propertyHref: null,
-		siteHref: 'https://theguardian.amp',
-		getDnsMsgMms: true,
-		alwaysDisplayDns: false,
-		showNoticeUntilAction: true,
-		targetingParams: {
-			framework: 'ccpa',
-		},
-	};
-
-	const clientConfigAus = {
-		propertyId: 14327,
-		privacyManagerId: '5f859e174ed5055e72ce26a6',
-		isCCPA: true,
-		isTCFV2: false,
-		propertyHref: null,
-		siteHref: 'https://amp.au.theguardian.com',
-		getDnsMsgMms: true,
-		alwaysDisplayDns: false,
-		showNoticeUntilAction: true,
-		targetingParams: {
-			framework: 'aus',
-		},
-	};
 	// To debug geolocation in dev, make sure you're on the experimental channel of AMP:
 	// https://cdn.ampproject.org/experiments.html
 	// Then you can load the url with #amp-geo=XX, where XX is the country code
@@ -154,7 +155,7 @@ export const AdConsent = ({ abTests }: AdConsentProps) => {
 						promptUISrc: `https://${sourcepointDomain}/amp/unified/index.html?${queryParams}`,
 						clientConfig:
 							abTests.ampGlobalAddressListVariant === 'variant'
-								? testClientConfig
+								? testAlternativeClientConfig
 								: clientConfig,
 						geoOverride: {
 							ccpa: {

--- a/dotcom-rendering/src/components/AdConsent.amp.tsx
+++ b/dotcom-rendering/src/components/AdConsent.amp.tsx
@@ -1,63 +1,74 @@
+import type { ServerSideTests } from '../types/config';
 import { JsonScript } from './JsonScript.amp';
 
-const sourcepointDomain = 'sourcepoint.theguardian.com';
-
-const pubData = {
-	authId: 'CLIENT_ID',
-	client_id: 'CLIENT_ID',
-	// Matches ampViewId from https://ophan.theguardian.com/amp.json
-	page_view_id: 'PAGE_VIEW_ID',
-	page_view_id_64: 'PAGE_VIEW_ID_64',
-	platform: 'amp',
-	source_url: 'SOURCE_URL',
+type AdConsentProps = {
+	abTests: ServerSideTests;
 };
 
-const queryParams = new URLSearchParams(pubData).toString();
+export const AdConsent = ({ abTests }: AdConsentProps) => {
+	const sourcepointDomain = 'sourcepoint.theguardian.com';
 
-// Default to TCFv2, the CCPA and AUS configs override the options in this config
-const clientConfig = {
-	accountId: 1257,
-	mmsDomain: `https://${sourcepointDomain}`,
-	propertyId: 8791,
-	pmTab: 'purposes',
-	stageCampaign: false,
-	privacyManagerId: 145885,
-	isTCFV2: true,
-	propertyHref: 'https://theguardian.amp',
-	targetingParams: {
-		framework: 'tcfv2',
-	},
-};
+	const pubData = {
+		authId: 'CLIENT_ID',
+		client_id: 'CLIENT_ID',
+		// Matches ampViewId from https://ophan.theguardian.com/amp.json
+		page_view_id: 'PAGE_VIEW_ID',
+		page_view_id_64: 'PAGE_VIEW_ID_64',
+		platform: 'amp',
+		source_url: 'SOURCE_URL',
+	};
 
-const clientConfigCcpa = {
-	privacyManagerId: '5eba7ef78c167c47ca8b433d',
-	isCCPA: true,
-	isTCFV2: false,
-	propertyHref: null,
-	siteHref: 'https://theguardian.amp',
-	getDnsMsgMms: true,
-	alwaysDisplayDns: false,
-	showNoticeUntilAction: true,
-	targetingParams: {
-		framework: 'ccpa',
-	},
-};
+	const queryParams = new URLSearchParams(pubData).toString();
 
-const clientConfigAus = {
-	propertyId: 14327,
-	privacyManagerId: '5f859e174ed5055e72ce26a6',
-	isCCPA: true,
-	isTCFV2: false,
-	propertyHref: null,
-	siteHref: 'https://amp.au.theguardian.com',
-	getDnsMsgMms: true,
-	alwaysDisplayDns: false,
-	showNoticeUntilAction: true,
-	targetingParams: {
-		framework: 'aus',
-	},
-};
-export const AdConsent = () => {
+	// Default to TCFv2, the CCPA and AUS configs override the options in this config
+	const clientConfig = {
+		accountId: 1257,
+		mmsDomain: `https://${sourcepointDomain}`,
+		propertyId: 8791,
+		pmTab: 'purposes',
+		stageCampaign: false,
+		privacyManagerId: 145885,
+		isTCFV2: true,
+		propertyHref: 'https://theguardian.amp',
+		targetingParams: {
+			framework: 'tcfv2',
+		},
+	};
+
+	const testClientConfig = {
+		...clientConfig,
+		propertyId: 16921,
+		propertyHref: 'https://test.theguardian.amp',
+	};
+
+	const clientConfigCcpa: ClientConfig = {
+		privacyManagerId: '5eba7ef78c167c47ca8b433d',
+		isCCPA: true,
+		isTCFV2: false,
+		propertyHref: null,
+		siteHref: 'https://theguardian.amp',
+		getDnsMsgMms: true,
+		alwaysDisplayDns: false,
+		showNoticeUntilAction: true,
+		targetingParams: {
+			framework: 'ccpa',
+		},
+	};
+
+	const clientConfigAus = {
+		propertyId: 14327,
+		privacyManagerId: '5f859e174ed5055e72ce26a6',
+		isCCPA: true,
+		isTCFV2: false,
+		propertyHref: null,
+		siteHref: 'https://amp.au.theguardian.com',
+		getDnsMsgMms: true,
+		alwaysDisplayDns: false,
+		showNoticeUntilAction: true,
+		targetingParams: {
+			framework: 'aus',
+		},
+	};
 	// To debug geolocation in dev, make sure you're on the experimental channel of AMP:
 	// https://cdn.ampproject.org/experiments.html
 	// Then you can load the url with #amp-geo=XX, where XX is the country code
@@ -141,7 +152,10 @@ export const AdConsent = () => {
 						consentInstanceId: 'sourcepoint',
 						checkConsentHref: `https://${sourcepointDomain}/wrapper/tcfv2/v1/amp-v2?authId=${pubData.authId}`,
 						promptUISrc: `https://${sourcepointDomain}/amp/unified/index.html?${queryParams}`,
-						clientConfig,
+						clientConfig:
+							abTests.ampGlobalAddressListVariant === 'variant'
+								? testClientConfig
+								: clientConfig,
 						geoOverride: {
 							ccpa: {
 								checkConsentHref: `https://${sourcepointDomain}/wrapper/ccpa/amp-v2?authId=${pubData.authId}`,

--- a/dotcom-rendering/src/components/ArticlePage.amp.tsx
+++ b/dotcom-rendering/src/components/ArticlePage.amp.tsx
@@ -75,7 +75,7 @@ export const AmpArticlePage = ({
 			/>
 			<Analytics key="analytics" analytics={analytics} />
 			<AnalyticsIframe url={config.ampIframeUrl} />
-			<AdConsent />
+			<AdConsent abTests={config.abTests} />
 			{experimentsData && (
 				<AmpExperimentComponent experimentsData={experimentsData} />
 			)}


### PR DESCRIPTION
## What does this change?
Add alternative propertyHref and propertyId when in test

## Why?
A [0% test](https://github.com/guardian/frontend/pull/27033) has been setup to allow us to test some changes to the CMP on AMP

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
