### PR TITLE
Hide discussion mute option on apps

### DIFF
--- a/dotcom-rendering/src/components/Discussion/Comment.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comment.tsx
@@ -17,6 +17,7 @@ import type {
 import type { reportAbuse } from '../../lib/discussionApi';
 import { createAuthenticationEventParams } from '../../lib/identity-component-event';
 import { palette as schemedPalette } from '../../palette';
+import { useConfig } from '../ConfigContext';
 import { AbuseReportForm } from './AbuseReportForm';
 import { Avatar } from './Avatar';
 import { GuardianContributor, GuardianPick, GuardianStaff } from './Badges';
@@ -326,6 +327,8 @@ export const Comment = ({
 	reportAbuse,
 	isExpanded,
 }: Props) => {
+	const { renderingTarget } = useConfig();
+
 	const [isHighlighted, setIsHighlighted] = useState<boolean>(
 		comment.isHighlighted,
 	);
@@ -369,6 +372,16 @@ export const Comment = ({
 	const showContributorBadge = comment.userProfile.badge.some(
 		(obj) => obj['name'] === 'Contributor',
 	);
+
+	/* You can't mute:
+	- unless logged in
+	- yourself
+	- on apps (see https://github.com/guardian/dotcom-rendering/issues/11113)
+	*/
+	const showMuteOption =
+		renderingTarget !== 'Apps' &&
+		user &&
+		comment.userProfile.userId !== user.profile.userId;
 
 	return (
 		<>
@@ -747,10 +760,7 @@ export const Comment = ({
 										)}
 								</Row>
 								<Row>
-									{/* You can't mute unless logged in and you can't mute yourself */}
-									{user &&
-									comment.userProfile.userId !==
-										user.profile.userId ? (
+									{showMuteOption ? (
 										<div
 											css={[
 												buttonLinkBaseStyles,


### PR DESCRIPTION
Users can "mute" other users in discussions. This setting is persisted in localstorage. However, on apps, localstorage is wiped between article loads. This change:

- hides the mute option on apps

Closes https://github.com/guardian/dotcom-rendering/issues/11113

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![Simulator Screenshot - iPhone 15 - 2024-04-10 at 18 49 42](https://github.com/guardian/dotcom-rendering/assets/705427/00b39370-5bbe-496b-b376-526977e3e21d) | ![Simulator Screenshot - iPhone 15 - 2024-04-10 at 18 50 06](https://github.com/guardian/dotcom-rendering/assets/705427/4148e454-8f0a-458d-866c-4663f634bcbb) |

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
