### PR TITLE
Remove hyphens: auto from pullquote

### DIFF
--- a/dotcom-rendering/src/components/PullQuoteBlockComponent.tsx
+++ b/dotcom-rendering/src/components/PullQuoteBlockComponent.tsx
@@ -8,7 +8,6 @@ import { QuoteIcon } from './QuoteIcon';
 const pullQuoteCss = css`
 	color: ${palette('--pullquote-text')};
 	overflow-wrap: break-word;
-	hyphens: auto;
 `;
 
 const fontCss = (role: string, format: ArticleFormat) => {


### PR DESCRIPTION
## What does this change?
This is causing too many words to break
## Why?
Added here https://github.com/guardian/dotcom-rendering/pull/11101 but is leading to undesirable behaviour
## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/110032454/241b8679-33c1-4860-af4a-43c2f3d0d2cb
[after]: https://github.com/guardian/dotcom-rendering/assets/110032454/4cdbbb0b-1c8c-44d4-ad99-c3bf28559465

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
