### PR TITLE
Revert "Pullquote break words"

### DIFF
--- a/dotcom-rendering/src/components/PullQuoteBlockComponent.tsx
+++ b/dotcom-rendering/src/components/PullQuoteBlockComponent.tsx
@@ -7,8 +7,6 @@ import { QuoteIcon } from './QuoteIcon';
 
 const pullQuoteCss = css`
 	color: ${palette('--pullquote-text')};
-	overflow-wrap: break-word;
-	hyphens: auto;
 `;
 
 const fontCss = (role: string, format: ArticleFormat) => {


### PR DESCRIPTION
Reverts guardian/dotcom-rendering#11101

The hyphens: auto is causing too many words to break. But CP do not want words to be broken without hyphens. 