### PR TITLE
Fix InteractiveBlockComponent alignement

### DIFF
--- a/dotcom-rendering/src/components/InteractiveBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/components/InteractiveBlockComponent.importable.tsx
@@ -108,6 +108,7 @@ const wrapperStyle = ({
 	min-height: ${getMinHeight(role, loaded)};
 	position: relative;
 	display: flex;
+	flex-direction: column;
 `;
 
 const placeholderLinkStyle = css`


### PR DESCRIPTION
## What does this change?
Switches to using a flex container which removes the need for negative margin
## Why?
Resolves https://github.com/guardian/dotcom-rendering/pull/11062#discussion_r1560801161
## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/110032454/8b1e844e-31a0-4a1a-b6f5-351a0679b347
[after]: https://github.com/guardian/dotcom-rendering/assets/110032454/345eefba-9143-4885-ba98-b54fc70e4688

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
