### PR TITLE
Allow manual hyphenation and word-break for pull quotes

### DIFF
--- a/dotcom-rendering/src/components/PullQuoteBlockComponent.tsx
+++ b/dotcom-rendering/src/components/PullQuoteBlockComponent.tsx
@@ -8,7 +8,6 @@ import { QuoteIcon } from './QuoteIcon';
 const pullQuoteCss = css`
 	color: ${palette('--pullquote-text')};
 	hyphens: none;
-	//allow manual hyphenation + word-break with &shy; markup
 	${until.mobileLandscape} {
 		hyphens: manual;
 	}

--- a/dotcom-rendering/src/components/PullQuoteBlockComponent.tsx
+++ b/dotcom-rendering/src/components/PullQuoteBlockComponent.tsx
@@ -7,6 +7,11 @@ import { QuoteIcon } from './QuoteIcon';
 
 const pullQuoteCss = css`
 	color: ${palette('--pullquote-text')};
+	hyphens: none;
+	//allow manual hyphenation + word-break with &shy; markup
+	${until.mobileLandscape} {
+		hyphens: manual;
+	}
 `;
 
 const fontCss = (role: string, format: ArticleFormat) => {


### PR DESCRIPTION
## What does this change?
Allow manual hyphenation and word-break for pull quotes below mobile landscape 480px with `&shy;` markup 
https://developer.mozilla.org/en-US/docs/Web/CSS/hyphens#manual
This is because hyphenation is desired when breaking words but auto-hyphenation breaks many words undesirably so a manual solution implemented by the curator seems best.
## Why?
Resolves https://github.com/guardian/dotcom-rendering/issues/11093
## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/110032454/26acc26a-60bd-46e3-8bb5-fcb0b22b5b92
[after]: https://github.com/guardian/dotcom-rendering/assets/110032454/96c03dee-4819-4086-a3ce-951675c54aad
<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
