### PR TITLE
DCAR Discussion: Comment, Reply, UserProfile

### DIFF
--- a/dotcom-rendering/.storybook/mocks/bridgetApi.ts
+++ b/dotcom-rendering/.storybook/mocks/bridgetApi.ts
@@ -100,6 +100,7 @@ export const ensure_all_exports_are_present = {
 	getNavigationClient,
 	getNewslettersClient,
 	getDiscussionClient,
+	getTagClient,
 } satisfies {
 	[Method in keyof BridgeModule]: BridgetApi<Method>;
 };

--- a/dotcom-rendering/.storybook/mocks/bridgetApi.ts
+++ b/dotcom-rendering/.storybook/mocks/bridgetApi.ts
@@ -1,3 +1,11 @@
+import { DiscussionNativeError } from '@guardian/bridget/DiscussionNativeError';
+import {
+	DiscussionResponse,
+	DiscussionResponseType,
+} from '@guardian/bridget/DiscussionResponse';
+import { DiscussionUserProfile } from '@guardian/bridget/DiscussionUserProfile';
+import { GetUserProfileResponseType } from '@guardian/bridget/GetUserProfileResponse';
+
 type BridgeModule = typeof import('../../src/lib/bridgetApi');
 
 type BridgetApi<T extends keyof BridgeModule> = () => Partial<
@@ -64,6 +72,21 @@ export const getTagClient: BridgetApi<'getTagClient'> = () => ({
 	isFollowing: async () => false,
 });
 
+const discussionErrorResponse = {
+	__type: DiscussionResponseType.DiscussionResponseWithError,
+	error: DiscussionNativeError.UNKNOWN_ERROR,
+} satisfies DiscussionResponse;
+
+export const getDiscussionClient: BridgetApi<'getDiscussionClient'> = () => ({
+	comment: async () => discussionErrorResponse,
+	reply: async () => discussionErrorResponse,
+	getUserProfile: async () => ({
+		__type: GetUserProfileResponseType.GetUserProfileResponseWithError,
+		error: DiscussionNativeError.UNKNOWN_ERROR,
+	}),
+	recommend: async () => discussionErrorResponse,
+});
+
 export const ensure_all_exports_are_present = {
 	getUserClient,
 	getAcquisitionsClient,
@@ -76,6 +99,7 @@ export const ensure_all_exports_are_present = {
 	getAnalyticsClient,
 	getNavigationClient,
 	getNewslettersClient,
+	getDiscussionClient,
 } satisfies {
 	[Method in keyof BridgeModule]: BridgetApi<Method>;
 };

--- a/dotcom-rendering/.storybook/mocks/bridgetApi.ts
+++ b/dotcom-rendering/.storybook/mocks/bridgetApi.ts
@@ -3,7 +3,6 @@ import {
 	DiscussionResponse,
 	DiscussionResponseType,
 } from '@guardian/bridget/DiscussionResponse';
-import { DiscussionUserProfile } from '@guardian/bridget/DiscussionUserProfile';
 import { GetUserProfileResponseType } from '@guardian/bridget/GetUserProfileResponse';
 
 type BridgeModule = typeof import('../../src/lib/bridgetApi');

--- a/dotcom-rendering/.storybook/mocks/bridgetApi.ts
+++ b/dotcom-rendering/.storybook/mocks/bridgetApi.ts
@@ -1,9 +1,8 @@
 import { DiscussionNativeError } from '@guardian/bridget/DiscussionNativeError';
 import {
-	DiscussionResponse,
-	DiscussionResponseType,
-} from '@guardian/bridget/DiscussionResponse';
-import { GetUserProfileResponseType } from '@guardian/bridget/GetUserProfileResponse';
+	DiscussionServiceResponse,
+	DiscussionServiceResponseType,
+} from '@guardian/bridget/DiscussionServiceResponse';
 
 type BridgeModule = typeof import('../../src/lib/bridgetApi');
 
@@ -72,15 +71,15 @@ export const getTagClient: BridgetApi<'getTagClient'> = () => ({
 });
 
 const discussionErrorResponse = {
-	__type: DiscussionResponseType.DiscussionResponseWithError,
+	__type: DiscussionServiceResponseType.DiscussionServiceResponseWithError,
 	error: DiscussionNativeError.UNKNOWN_ERROR,
-} satisfies DiscussionResponse;
+} satisfies DiscussionServiceResponse;
 
 export const getDiscussionClient: BridgetApi<'getDiscussionClient'> = () => ({
 	comment: async () => discussionErrorResponse,
 	reply: async () => discussionErrorResponse,
 	getUserProfile: async () => ({
-		__type: GetUserProfileResponseType.GetUserProfileResponseWithError,
+		__type: DiscussionServiceResponseType.DiscussionServiceResponseWithError,
 		error: DiscussionNativeError.UNKNOWN_ERROR,
 	}),
 	recommend: async () => discussionErrorResponse,

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -45,7 +45,7 @@
 		"@emotion/server": "11.11.0",
 		"@guardian/ab-core": "7.0.1",
 		"@guardian/braze-components": "18.1.0",
-		"@guardian/bridget": "0.0.0-2024-04-11-snapshot-2",
+		"@guardian/bridget": "5.0.0",
 		"@guardian/browserslist-config": "6.1.0",
 		"@guardian/cdk": "50.13.0",
 		"@guardian/commercial": "17.9.0",

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -45,7 +45,7 @@
 		"@emotion/server": "11.11.0",
 		"@guardian/ab-core": "7.0.1",
 		"@guardian/braze-components": "18.1.0",
-		"@guardian/bridget": "0.0.0-2024-04-10-snapshot-2",
+		"@guardian/bridget": "0.0.0-2024-04-11-snapshot-2",
 		"@guardian/browserslist-config": "6.1.0",
 		"@guardian/cdk": "50.13.0",
 		"@guardian/commercial": "17.9.0",

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -45,7 +45,7 @@
 		"@emotion/server": "11.11.0",
 		"@guardian/ab-core": "7.0.1",
 		"@guardian/braze-components": "18.1.0",
-		"@guardian/bridget": "0.0.0-2024-04-09-snapshot",
+		"@guardian/bridget": "0.0.0-2024-04-10-snapshot-2",
 		"@guardian/browserslist-config": "6.1.0",
 		"@guardian/cdk": "50.13.0",
 		"@guardian/commercial": "17.9.0",

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -45,7 +45,7 @@
 		"@emotion/server": "11.11.0",
 		"@guardian/ab-core": "7.0.1",
 		"@guardian/braze-components": "18.1.0",
-		"@guardian/bridget": "5.0.0",
+		"@guardian/bridget": "6.0.0",
 		"@guardian/browserslist-config": "6.1.0",
 		"@guardian/cdk": "50.13.0",
 		"@guardian/commercial": "17.9.0",

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -45,7 +45,7 @@
 		"@emotion/server": "11.11.0",
 		"@guardian/ab-core": "7.0.1",
 		"@guardian/braze-components": "18.1.0",
-		"@guardian/bridget": "3.0.0",
+		"@guardian/bridget": "0.0.0-2024-04-09-snapshot",
 		"@guardian/browserslist-config": "6.1.0",
 		"@guardian/cdk": "50.13.0",
 		"@guardian/commercial": "17.9.0",

--- a/dotcom-rendering/src/components/Discussion/FirstCommentWelcome.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/FirstCommentWelcome.stories.tsx
@@ -46,3 +46,27 @@ CommentWithError.decorators = [
 		{ orientation: 'vertical' },
 	),
 ];
+
+export const FirstCommentWelcomeApps = () => (
+	<FirstCommentWelcome
+		submitForm={() => Promise.resolve()}
+		cancelSubmit={() => undefined}
+		previewBody="My first comment!!"
+	/>
+);
+FirstCommentWelcomeApps.storyName = 'First Comment Welcome Apps';
+FirstCommentWelcomeApps.parameters = {
+	config: { renderingTarget: 'Apps' },
+};
+FirstCommentWelcomeApps.decorators = [
+	splitTheme(
+		[
+			{
+				design: ArticleDesign.Standard,
+				display: ArticleDisplay.Standard,
+				theme: Pillar.News,
+			},
+		],
+		{ orientation: 'vertical' },
+	),
+];

--- a/dotcom-rendering/src/components/Discussion/FirstCommentWelcome.tsx
+++ b/dotcom-rendering/src/components/Discussion/FirstCommentWelcome.tsx
@@ -3,6 +3,7 @@ import { headline, space, textSans } from '@guardian/source-foundations';
 import { Link, TextInput } from '@guardian/source-react-components';
 import { useState } from 'react';
 import { palette as schemedPalette } from '../../palette';
+import { useConfig } from '../ConfigContext';
 import { PillarButton } from './PillarButton';
 import { Preview } from './Preview';
 import { Row } from './Row';
@@ -31,6 +32,10 @@ const textInputStyles = css`
 	color: inherit;
 `;
 
+const h3Style = css`
+	${headline.xxsmall({ fontWeight: 'bold' })};
+`;
+
 type Props = {
 	error?: string;
 	submitForm: (userName: string) => Promise<void>;
@@ -44,7 +49,27 @@ export const FirstCommentWelcome = ({
 	cancelSubmit,
 	previewBody,
 }: Props) => {
+	const { renderingTarget } = useConfig();
 	const [userName, setUserName] = useState<string>('');
+
+	if (renderingTarget === 'Apps') {
+		return (
+			<div
+				css={css`
+					padding: ${space[2]}px;
+				`}
+			>
+				<h3 css={h3Style}>
+					Welcome, you’re about to make your first comment!
+				</h3>
+
+				<Text>
+					Before you can post, you need to choose a username. Please
+					do this in your profile settings.
+				</Text>
+			</div>
+		);
+	}
 
 	return (
 		<div
@@ -58,11 +83,7 @@ export const FirstCommentWelcome = ({
 					void submitForm(userName);
 				}}
 			>
-				<h3
-					css={css`
-						${headline.xxsmall({ fontWeight: 'bold' })};
-					`}
-				>
+				<h3 css={h3Style}>
 					Welcome, you’re about to make your first comment!
 				</h3>
 				<Text>

--- a/dotcom-rendering/src/components/DiscussionApps.importable.tsx
+++ b/dotcom-rendering/src/components/DiscussionApps.importable.tsx
@@ -30,17 +30,7 @@ const onComment = async (
 				return error('ApiError');
 			}
 
-			if (apiResponse.response.status === 'error') {
-				return parseCommentResponse({
-					status: apiResponse.response.status,
-					errorCode: apiResponse.response.errorCode,
-				});
-			}
-
-			return parseCommentResponse({
-				status: apiResponse.response.status,
-				message: apiResponse.response.message,
-			});
+			return parseCommentResponse(apiResponse.response);
 		});
 
 const onReply = async (
@@ -58,18 +48,7 @@ const onReply = async (
 				return error('ApiError');
 			}
 
-			if (apiResponse.response.status === 'error') {
-				return parseCommentResponse({
-					status: apiResponse.response.status,
-					errorCode: apiResponse.response.errorCode,
-				});
-			}
-
-			const parsedResponse = parseCommentResponse({
-				status: apiResponse.response.status,
-				message: apiResponse.response.message,
-			});
-			return parsedResponse;
+			return parseCommentResponse(apiResponse.response);
 		});
 
 const onRecommend = async (commentId: string): Promise<boolean> => {

--- a/dotcom-rendering/src/components/DiscussionApps.importable.tsx
+++ b/dotcom-rendering/src/components/DiscussionApps.importable.tsx
@@ -46,10 +46,10 @@ const onComment = async (
 const onReply = async (
 	discussionShortUrl: string,
 	body: string,
-	parentCommentId: number,
+	parentCommentId: string,
 ): Promise<CommentResponse> =>
 	getDiscussionClient()
-		.reply(discussionShortUrl, body, parentCommentId.toString())
+		.reply(discussionShortUrl, body, parentCommentId)
 		.then((apiResponse) => {
 			if (
 				apiResponse.__type ===

--- a/dotcom-rendering/src/components/DiscussionApps.importable.tsx
+++ b/dotcom-rendering/src/components/DiscussionApps.importable.tsx
@@ -1,12 +1,11 @@
 import { DiscussionServiceResponseType } from '@guardian/bridget';
 import { useEffect, useState } from 'react';
-import { safeParse } from 'valibot';
 import { getDiscussionClient } from '../lib/bridgetApi';
 import {
 	parseCommentResponse,
+	parseRecommendResponse,
 	parseUserProfile,
 	type Reader,
-	recommendResponseSchema,
 } from '../lib/discussion';
 import type { CommentResponse } from '../lib/discussionApi';
 import { reportAbuse as reportAbuseWeb } from '../lib/discussionApi';
@@ -80,10 +79,11 @@ const onRecommend = async (commentId: string): Promise<boolean> => {
 				return false;
 			}
 
-			return safeParse(
-				recommendResponseSchema,
+			const result = parseRecommendResponse(
 				JSON.parse(discussionApiResponse.response),
-			).success;
+			);
+
+			return result.kind === 'ok';
 		});
 };
 

--- a/dotcom-rendering/src/components/DiscussionApps.importable.tsx
+++ b/dotcom-rendering/src/components/DiscussionApps.importable.tsx
@@ -58,6 +58,13 @@ const onReply = async (
 				return error('ApiError');
 			}
 
+			if (apiResponse.response.status === 'error') {
+				return parseCommentResponse({
+					status: apiResponse.response.status,
+					errorCode: apiResponse.response.errorCode,
+				});
+			}
+
 			const parsedResponse = parseCommentResponse({
 				status: apiResponse.response.status,
 				message: apiResponse.response.message,

--- a/dotcom-rendering/src/components/DiscussionApps.importable.tsx
+++ b/dotcom-rendering/src/components/DiscussionApps.importable.tsx
@@ -23,7 +23,6 @@ const onComment = async (
 	getDiscussionClient()
 		.comment(discussionShortUrl, body)
 		.then((apiResponse) => {
-			console.log(apiResponse);
 			if (
 				apiResponse.__type ===
 				DiscussionResponseType.DiscussionResponseWithError
@@ -31,11 +30,17 @@ const onComment = async (
 				return error('ApiError');
 			}
 
-			const parsedResponse = parseCommentResponse({
+			if (apiResponse.response.status === 'error') {
+				return parseCommentResponse({
+					status: apiResponse.response.status,
+					errorCode: apiResponse.response.errorCode,
+				});
+			}
+
+			return parseCommentResponse({
 				status: apiResponse.response.status,
 				message: apiResponse.response.message,
 			});
-			return parsedResponse;
 		});
 
 const onReply = async (
@@ -46,7 +51,6 @@ const onReply = async (
 	getDiscussionClient()
 		.reply(discussionShortUrl, body, parentCommentId.toString())
 		.then((apiResponse) => {
-			console.log(apiResponse);
 			if (
 				apiResponse.__type ===
 				DiscussionResponseType.DiscussionResponseWithError
@@ -73,10 +77,8 @@ const onRecommend = async (commentId: string): Promise<boolean> => {
 		);
 };
 
-const addUsername = async (): Promise<Result<string, true>> => {
-	console.log('addUsername');
-	return { kind: 'error', error: 'ApiError' };
-};
+const addUsername = async (): Promise<Result<string, true>> =>
+	error('Unimplemented');
 
 /***
  *  Currently we are using the web handler for both authenticated and unauthenticated users.
@@ -94,7 +96,6 @@ export const DiscussionApps = (props: Props) => {
 		void getDiscussionClient()
 			.getUserProfile()
 			.then((userProfile) => {
-				console.log(userProfile);
 				if (
 					userProfile.__type ===
 					GetUserProfileResponseType.GetUserProfileResponseWithError

--- a/dotcom-rendering/src/components/DiscussionApps.importable.tsx
+++ b/dotcom-rendering/src/components/DiscussionApps.importable.tsx
@@ -1,18 +1,41 @@
-import { DiscussionResponseType } from '@guardian/bridget';
+import {
+	DiscussionApiResponse,
+	DiscussionResponseType,
+} from '@guardian/bridget';
 import { useEffect, useState } from 'react';
 import { getDiscussionClient } from '../lib/bridgetApi';
-import type { Reader, UserProfile } from '../lib/discussion';
+import {
+	parseCommentResponse,
+	type Reader,
+	type UserProfile,
+} from '../lib/discussion';
 import type { CommentResponse } from '../lib/discussionApi';
 import { reportAbuse as reportAbuseWeb } from '../lib/discussionApi';
-import type { Result } from '../lib/result';
+import { error, ok, type Result } from '../lib/result';
 import { Discussion, type Props as DiscussionProps } from './Discussion';
 
 type Props = Omit<DiscussionProps, 'user' | 'reportAbuseUnauthenticated'>;
 
-const onComment = async (): Promise<CommentResponse> => {
-	console.log('onComment');
-	return { kind: 'error', error: 'ApiError' };
-};
+const onComment = async (
+	discussionShortUrl: string,
+	body: string,
+): Promise<CommentResponse> =>
+	getDiscussionClient()
+		.comment(discussionShortUrl, body)
+		.then((apiResponse) => {
+			if (
+				apiResponse.__type ===
+				DiscussionResponseType.DiscussionResponseWithError
+			) {
+				return error('ApiError');
+			}
+
+			const parsedResponse = parseCommentResponse({
+				status: apiResponse.response.status,
+				message: apiResponse.response.message,
+			});
+			return parsedResponse;
+		});
 
 const onReply = async (): Promise<CommentResponse> => {
 	console.log('onReply');

--- a/dotcom-rendering/src/lib/discussion.ts
+++ b/dotcom-rendering/src/lib/discussion.ts
@@ -73,6 +73,19 @@ export interface UserProfile {
 	};
 }
 
+export const parseUserProfile = (
+	data: unknown,
+): Result<'ParsingError', UserProfile> => {
+	const result = safeParse(
+		object({ status: literal('ok'), userProfile }),
+		data,
+	);
+	if (!result.success) {
+		return error('ParsingError');
+	}
+	return ok(result.output.userProfile);
+};
+
 const baseCommentSchema = object({
 	id: transform(union([number(), string()]), (id) => id.toString()),
 	body: string(),
@@ -330,6 +343,11 @@ export const pickResponseSchema = object({
 	status: literal('ok'),
 	statusCode: literal(200),
 	message: string(),
+});
+
+export const recommendResponseSchema = object({
+	status: literal('ok'),
+	statusCode: literal(200),
 });
 
 export type CommentFormProps = {

--- a/dotcom-rendering/src/lib/discussion.ts
+++ b/dotcom-rendering/src/lib/discussion.ts
@@ -345,10 +345,17 @@ export const pickResponseSchema = object({
 	message: string(),
 });
 
-export const recommendResponseSchema = object({
+const recommendResponseSchema = object({
 	status: literal('ok'),
 	statusCode: literal(200),
 });
+
+export const parseRecommendResponse = (
+	data: unknown,
+): Result<'ParsingError', true> => {
+	const { success } = safeParse(recommendResponseSchema, data);
+	return success ? ok(true) : error('ParsingError');
+};
 
 export type CommentFormProps = {
 	userNameMissing: boolean;

--- a/dotcom-rendering/src/lib/discussionApi.tsx
+++ b/dotcom-rendering/src/lib/discussionApi.tsx
@@ -13,10 +13,10 @@ import {
 	getCommentContextResponseSchema,
 	parseAbuseResponse,
 	parseCommentResponse,
+	parseRecommendResponse,
 	parseRepliesResponse,
 	pickResponseSchema,
 	postUsernameResponseSchema,
-	recommendResponseSchema,
 } from './discussion';
 import type { CommentContextType } from './discussionFilters';
 import type { SignedInWithCookies, SignedInWithOkta } from './identity';
@@ -322,7 +322,7 @@ export const recommend =
 		});
 
 		if (jsonResult.kind === 'error') return false;
-		return safeParse(recommendResponseSchema, jsonResult.value).success;
+		return parseRecommendResponse(jsonResult.value).kind === 'ok';
 	};
 
 export const addUserName =

--- a/dotcom-rendering/src/lib/discussionApi.tsx
+++ b/dotcom-rendering/src/lib/discussionApi.tsx
@@ -16,6 +16,7 @@ import {
 	parseRepliesResponse,
 	pickResponseSchema,
 	postUsernameResponseSchema,
+	recommendResponseSchema,
 } from './discussion';
 import type { CommentContextType } from './discussionFilters';
 import type { SignedInWithCookies, SignedInWithOkta } from './identity';
@@ -309,7 +310,7 @@ export const recommend =
 
 		const authOptions = getOptionsHeadersWithOkta(authStatus);
 
-		return fetch(url, {
+		const jsonResult = await fetchJSON(url, {
 			method: 'POST',
 			headers: {
 				...options.headers,
@@ -318,7 +319,10 @@ export const recommend =
 					: {}),
 			},
 			credentials: authOptions.credentials,
-		}).then((resp) => resp.ok);
+		});
+
+		if (jsonResult.kind === 'error') return false;
+		return safeParse(recommendResponseSchema, jsonResult.value).success;
 	};
 
 export const addUserName =

--- a/dotcom-rendering/tsconfig.json
+++ b/dotcom-rendering/tsconfig.json
@@ -16,6 +16,7 @@
 		},
 		"preserveConstEnums": true
 	},
+	"include": ["**/*", ".storybook/mocks/bridgetApi.ts"],
 	"exclude": [
 		"storybook-static",
 		"target",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -345,8 +345,8 @@ importers:
         specifier: 18.1.0
         version: 18.1.0(@emotion/react@11.11.1)(@guardian/libs@16.1.0)(@guardian/source-foundations@14.1.4)(@guardian/source-react-components-development-kitchen@19.0.0)(@guardian/source-react-components@22.0.1)(react@18.2.0)
       '@guardian/bridget':
-        specifier: 0.0.0-2024-04-10-snapshot-2
-        version: 0.0.0-2024-04-10-snapshot-2
+        specifier: 0.0.0-2024-04-11-snapshot-2
+        version: 0.0.0-2024-04-11-snapshot-2
       '@guardian/browserslist-config':
         specifier: 6.1.0
         version: 6.1.0(browserslist@4.21.9)(tslib@2.6.2)
@@ -4267,8 +4267,8 @@ packages:
       react: 18.2.0
     dev: false
 
-  /@guardian/bridget@0.0.0-2024-04-10-snapshot-2:
-    resolution: {integrity: sha512-Wyvv3ScEhw71eBmVtbs9tKD6iv10iGlLs6wPIO0WBYzjqovudiJ0J4j9xVu7tdNIwNWPj7OXHRPl/VFd2eStIQ==}
+  /@guardian/bridget@0.0.0-2024-04-11-snapshot-2:
+    resolution: {integrity: sha512-82n/Z67etMnAZS4OAnetB/GcsrL6CO4LTuvf/kMeRuoTfPH9tuvXuU4xlfNVZh6n3YM+yLzPJ5oMe0OW+v6rJw==}
     dev: false
 
   /@guardian/bridget@2.6.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -345,8 +345,8 @@ importers:
         specifier: 18.1.0
         version: 18.1.0(@emotion/react@11.11.1)(@guardian/libs@16.1.0)(@guardian/source-foundations@14.1.4)(@guardian/source-react-components-development-kitchen@19.0.0)(@guardian/source-react-components@22.0.1)(react@18.2.0)
       '@guardian/bridget':
-        specifier: 0.0.0-2024-04-11-snapshot-2
-        version: 0.0.0-2024-04-11-snapshot-2
+        specifier: 5.0.0
+        version: 5.0.0
       '@guardian/browserslist-config':
         specifier: 6.1.0
         version: 6.1.0(browserslist@4.21.9)(tslib@2.6.2)
@@ -4267,12 +4267,12 @@ packages:
       react: 18.2.0
     dev: false
 
-  /@guardian/bridget@0.0.0-2024-04-11-snapshot-2:
-    resolution: {integrity: sha512-82n/Z67etMnAZS4OAnetB/GcsrL6CO4LTuvf/kMeRuoTfPH9tuvXuU4xlfNVZh6n3YM+yLzPJ5oMe0OW+v6rJw==}
-    dev: false
-
   /@guardian/bridget@2.6.0:
     resolution: {integrity: sha512-kYlRZC5/9ImY2wQJfnteanjfLclmSU0wcsyt2CWl5YXHmc3gGnxZM+H/Y6KVqwxj0v5cGrvUuFJ7Zvk570dchQ==}
+    dev: false
+
+  /@guardian/bridget@5.0.0:
+    resolution: {integrity: sha512-1rbKmdPAdEiBco1Mt/YKJ3J+JQ/e346mXdQVPm4xAWzxrb7jvH+HO4afQqqGE01h0ruV5spGCkcuTWINjbA9MA==}
     dev: false
 
   /@guardian/browserslist-config@6.1.0(browserslist@4.21.9)(tslib@2.6.2):

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -345,8 +345,8 @@ importers:
         specifier: 18.1.0
         version: 18.1.0(@emotion/react@11.11.1)(@guardian/libs@16.1.0)(@guardian/source-foundations@14.1.4)(@guardian/source-react-components-development-kitchen@19.0.0)(@guardian/source-react-components@22.0.1)(react@18.2.0)
       '@guardian/bridget':
-        specifier: 5.0.0
-        version: 5.0.0
+        specifier: 6.0.0
+        version: 6.0.0
       '@guardian/browserslist-config':
         specifier: 6.1.0
         version: 6.1.0(browserslist@4.21.9)(tslib@2.6.2)
@@ -4271,8 +4271,8 @@ packages:
     resolution: {integrity: sha512-kYlRZC5/9ImY2wQJfnteanjfLclmSU0wcsyt2CWl5YXHmc3gGnxZM+H/Y6KVqwxj0v5cGrvUuFJ7Zvk570dchQ==}
     dev: false
 
-  /@guardian/bridget@5.0.0:
-    resolution: {integrity: sha512-1rbKmdPAdEiBco1Mt/YKJ3J+JQ/e346mXdQVPm4xAWzxrb7jvH+HO4afQqqGE01h0ruV5spGCkcuTWINjbA9MA==}
+  /@guardian/bridget@6.0.0:
+    resolution: {integrity: sha512-aiRVLDF/UfNYeoF10ptBDs52Fv1T4sd19uKACTZSr1uMgV2BPmzG+/BiVLi8Q9/6gjS+CTP3Covz62liksAFuQ==}
     dev: false
 
   /@guardian/browserslist-config@6.1.0(browserslist@4.21.9)(tslib@2.6.2):

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -345,8 +345,8 @@ importers:
         specifier: 18.1.0
         version: 18.1.0(@emotion/react@11.11.1)(@guardian/libs@16.1.0)(@guardian/source-foundations@14.1.4)(@guardian/source-react-components-development-kitchen@19.0.0)(@guardian/source-react-components@22.0.1)(react@18.2.0)
       '@guardian/bridget':
-        specifier: 0.0.0-2024-04-09-snapshot
-        version: 0.0.0-2024-04-09-snapshot
+        specifier: 0.0.0-2024-04-10-snapshot-2
+        version: 0.0.0-2024-04-10-snapshot-2
       '@guardian/browserslist-config':
         specifier: 6.1.0
         version: 6.1.0(browserslist@4.21.9)(tslib@2.6.2)
@@ -4267,8 +4267,8 @@ packages:
       react: 18.2.0
     dev: false
 
-  /@guardian/bridget@0.0.0-2024-04-09-snapshot:
-    resolution: {integrity: sha512-FAJCOib+z72xlwCoGHGTfKSgzfMUnEZ4HaaE4FOd1cu2gwQyAG+7NkQp8KTbxXqQryVkgvwSrWu+naC5SvPNNw==}
+  /@guardian/bridget@0.0.0-2024-04-10-snapshot-2:
+    resolution: {integrity: sha512-Wyvv3ScEhw71eBmVtbs9tKD6iv10iGlLs6wPIO0WBYzjqovudiJ0J4j9xVu7tdNIwNWPj7OXHRPl/VFd2eStIQ==}
     dev: false
 
   /@guardian/bridget@2.6.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -345,8 +345,8 @@ importers:
         specifier: 18.1.0
         version: 18.1.0(@emotion/react@11.11.1)(@guardian/libs@16.1.0)(@guardian/source-foundations@14.1.4)(@guardian/source-react-components-development-kitchen@19.0.0)(@guardian/source-react-components@22.0.1)(react@18.2.0)
       '@guardian/bridget':
-        specifier: 3.0.0
-        version: 3.0.0
+        specifier: 0.0.0-2024-04-09-snapshot
+        version: 0.0.0-2024-04-09-snapshot
       '@guardian/browserslist-config':
         specifier: 6.1.0
         version: 6.1.0(browserslist@4.21.9)(tslib@2.6.2)
@@ -4267,12 +4267,12 @@ packages:
       react: 18.2.0
     dev: false
 
-  /@guardian/bridget@2.6.0:
-    resolution: {integrity: sha512-kYlRZC5/9ImY2wQJfnteanjfLclmSU0wcsyt2CWl5YXHmc3gGnxZM+H/Y6KVqwxj0v5cGrvUuFJ7Zvk570dchQ==}
+  /@guardian/bridget@0.0.0-2024-04-09-snapshot:
+    resolution: {integrity: sha512-FAJCOib+z72xlwCoGHGTfKSgzfMUnEZ4HaaE4FOd1cu2gwQyAG+7NkQp8KTbxXqQryVkgvwSrWu+naC5SvPNNw==}
     dev: false
 
-  /@guardian/bridget@3.0.0:
-    resolution: {integrity: sha512-mXmju3+PB3frDmvBt5D/HkFwCXdGarRsNsgPpKH9XGzTIRAwS25kQbmeRURkchEG1LAQQsIuv9KfZJRPQwetHQ==}
+  /@guardian/bridget@2.6.0:
+    resolution: {integrity: sha512-kYlRZC5/9ImY2wQJfnteanjfLclmSU0wcsyt2CWl5YXHmc3gGnxZM+H/Y6KVqwxj0v5cGrvUuFJ7Zvk570dchQ==}
     dev: false
 
   /@guardian/browserslist-config@6.1.0(browserslist@4.21.9)(tslib@2.6.2):


### PR DESCRIPTION
## What does this change?

- Implements `onComment`, `onReply` and `getUserProfile`
- Upgrades to `@guardian/bridget@5.0.0`
- Hides set username functionality on apps. Instead, we show a message prompting users to set their username in their profile settings.

## Why?

So we can support more discussions on apps! 🚀 💬 

## Screenshots

### First comment message for apps: 
![Screen Shot 2024-04-15 at 11 39 50](https://github.com/guardian/dotcom-rendering/assets/705427/b485adb0-633b-4a52-8744-959d1a4f8d4d)

Closes #10669 
Closes #10673 
Closes #10668 
