### PR TITLE
Use Ophan terms `impression` and `additional` in e2e tests

### DIFF
--- a/dotcom-rendering/playwright/lib/ophan.ts
+++ b/dotcom-rendering/playwright/lib/ophan.ts
@@ -1,6 +1,9 @@
 import type { Page, Request } from '@playwright/test';
 
-export const interceptOphanRequest = ({
+const IMPRESSION_REQUEST_PATH = 'img/1';
+const ADDITIONAL_REQUEST_PATH = 'img/2';
+
+const interceptOphanRequest = ({
 	page,
 	path,
 	searchParamMatcher,
@@ -16,4 +19,10 @@ export const interceptOphanRequest = ({
 		const searchParams = new URLSearchParams(request.url());
 		return matchUrl && searchParamMatcher(searchParams);
 	});
+};
+
+export {
+	IMPRESSION_REQUEST_PATH,
+	ADDITIONAL_REQUEST_PATH,
+	interceptOphanRequest,
 };

--- a/dotcom-rendering/playwright/tests/ophan.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/ophan.e2e.spec.ts
@@ -1,6 +1,10 @@
 import { isUndefined } from '@guardian/libs';
 import { test } from '@playwright/test';
-import { interceptOphanRequest } from 'playwright/lib/ophan';
+import {
+	ADDITIONAL_REQUEST_PATH,
+	IMPRESSION_REQUEST_PATH,
+	interceptOphanRequest,
+} from 'playwright/lib/ophan';
 import { cmpAcceptAll, cmpRejectAll, disableCMP } from '../lib/cmp';
 import { loadPage } from '../lib/load-page';
 
@@ -10,12 +14,12 @@ const articleUrl =
 const frontUrl = 'https://www.theguardian.com/uk';
 
 test.describe('Ophan requests', () => {
-	test('should make a view request on an article when consent is rejected', async ({
+	test('should make an IMPRESSION request on an article when consent is rejected', async ({
 		page,
 	}) => {
-		const ophanRequestPromise = interceptOphanRequest({
+		const ophanImpressionRequestPromise = interceptOphanRequest({
 			page,
-			path: 'img/1',
+			path: IMPRESSION_REQUEST_PATH,
 			searchParamMatcher: (searchParams: URLSearchParams) => {
 				const platform = searchParams.get('platform');
 				const url = searchParams.get('url');
@@ -29,15 +33,15 @@ test.describe('Ophan requests', () => {
 		});
 		await loadPage(page, `/Article/${articleUrl}`);
 		await cmpRejectAll(page);
-		await ophanRequestPromise;
+		await ophanImpressionRequestPromise;
 	});
 
-	test('should make a view request on an article when consent is accepted', async ({
+	test('should make an IMPRESSION request on an article when consent is accepted', async ({
 		page,
 	}) => {
-		const ophanRequestPromise = interceptOphanRequest({
+		const ophanImpressionRequestPromise = interceptOphanRequest({
 			page,
-			path: 'img/1',
+			path: IMPRESSION_REQUEST_PATH,
 			searchParamMatcher: (searchParams: URLSearchParams) => {
 				const platform = searchParams.get('platform');
 				const url = searchParams.get('url');
@@ -51,17 +55,17 @@ test.describe('Ophan requests', () => {
 		});
 		await loadPage(page, `/Article/${articleUrl}`);
 		await cmpAcceptAll(page);
-		await ophanRequestPromise;
+		await ophanImpressionRequestPromise;
 	});
 
-	test('should make event requests on an article', async ({
+	test('should make an ADDITIONAL experiences request on an article', async ({
 		context,
 		page,
 	}) => {
 		await disableCMP(context);
 		const ophanExperienceRequestPromise = interceptOphanRequest({
 			page,
-			path: 'img/2',
+			path: ADDITIONAL_REQUEST_PATH,
 			searchParamMatcher: (searchParams: URLSearchParams) => {
 				const experiences = searchParams.get('experiences');
 				return experiences === 'dotcom-rendering';
@@ -71,11 +75,14 @@ test.describe('Ophan requests', () => {
 		await ophanExperienceRequestPromise;
 	});
 
-	test('should make a view request on a front', async ({ context, page }) => {
+	test('should make an IMPRESSION request on a front', async ({
+		context,
+		page,
+	}) => {
 		await disableCMP(context);
-		const ophanRequestPromise = interceptOphanRequest({
+		const ophanImpressionRequestPromise = interceptOphanRequest({
 			page,
-			path: 'img/1',
+			path: IMPRESSION_REQUEST_PATH,
 			searchParamMatcher: (searchParams: URLSearchParams) => {
 				const platform = searchParams.get('platform');
 				const url = searchParams.get('url');
@@ -88,17 +95,17 @@ test.describe('Ophan requests', () => {
 			},
 		});
 		await loadPage(page, `/Front/${frontUrl}`);
-		await ophanRequestPromise;
+		await ophanImpressionRequestPromise;
 	});
 
-	test('should make an event request on a front', async ({
+	test('should make an ADDITIONAL experiences request on a front', async ({
 		context,
 		page,
 	}) => {
 		await disableCMP(context);
 		const ophanExperienceRequestPromise = interceptOphanRequest({
 			page,
-			path: 'img/2',
+			path: ADDITIONAL_REQUEST_PATH,
 			searchParamMatcher: (searchParams: URLSearchParams) => {
 				const experiences = searchParams.get('experiences');
 				return experiences === 'dotcom-rendering';

--- a/dotcom-rendering/playwright/tests/paid.content.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/paid.content.e2e.spec.ts
@@ -4,7 +4,7 @@ import { cmpAcceptAll } from '../lib/cmp';
 import { waitForIsland } from '../lib/islands';
 import { loadPage } from '../lib/load-page';
 import { expectToBeVisible } from '../lib/locators';
-import { interceptOphanRequest } from '../lib/ophan';
+import { ADDITIONAL_REQUEST_PATH, interceptOphanRequest } from '../lib/ophan';
 
 const paidContentPage =
 	'https://www.theguardian.com/the-future-of-sustainable-entrepreneurship/2023/jun/01/take-your-sustainable-business-to-the-next-level-win-your-own-retail-space-at-one-of-londons-westfield-centres';
@@ -91,7 +91,7 @@ test.describe('Paid content tests', () => {
 
 		const clickEventRequest = interceptOphanRequest({
 			page,
-			path: 'img/2',
+			path: ADDITIONAL_REQUEST_PATH,
 			searchParamMatcher: (searchParams) => {
 				const clickComponent = searchParams.get('clickComponent');
 				const clickLinkNames = searchParams.get('clickLinkNames');
@@ -118,7 +118,7 @@ test.describe('Paid content tests', () => {
 
 		const clickEventRequest = interceptOphanRequest({
 			page,
-			path: 'img/2',
+			path: ADDITIONAL_REQUEST_PATH,
 			searchParamMatcher: (searchParams) => {
 				const clickComponent = searchParams.get('clickComponent');
 				const clickLinkNames = searchParams.get('clickLinkNames');


### PR DESCRIPTION
## What does this change?

Use Ophan terminology in e2e tests:

- `impression` for `img/1` requests
- `additional` for `img/2` requests

## Why?

Align terminology

