### PR TITLE
Revert paragraph spacing and move margin top to article body

### DIFF
--- a/dotcom-rendering/src/components/ArticleBody.tsx
+++ b/dotcom-rendering/src/components/ArticleBody.tsx
@@ -202,6 +202,7 @@ export const ArticleBody = ({
 			<div
 				id="maincontent"
 				css={[
+					'margin-top: 14px', // TODO This matches the TextBlockComponent.tsx:162 margin. Confirm with Alex B if this can be 12 or 16 so we can use Source spacing.
 					isInteractive ? null : bodyPadding,
 					globalH2Styles(format.display),
 					globalH3Styles(format.display),

--- a/dotcom-rendering/src/components/ArticleBody.tsx
+++ b/dotcom-rendering/src/components/ArticleBody.tsx
@@ -68,7 +68,7 @@ const globalOlStyles = () => css`
 			${body.medium({ lineHeight: 'tight' })};
 			content: counter(li);
 			counter-increment: li;
-			margin-right: ${remSpace[1]}px;
+			margin-right: ${remSpace[1]};
 		}
 	}
 `;
@@ -78,7 +78,7 @@ const globalH3Styles = (display: ArticleDisplay) => css`
 	`
 		h3 {
 			${headline.xsmall({ fontWeight: 'bold' })};
-			margin-bottom: ${remSpace[2]}px;
+			margin-bottom: ${remSpace[2]};
 		}
 	`}
 `;
@@ -155,7 +155,7 @@ export const ArticleBody = ({
 				// This classname is used by Spacefinder as the container in which it'll attempt to insert inline ads
 				className="js-liveblog-body"
 				css={[
-					`margin-top: ${remSpace[3]}rem`,
+					`margin-top: ${remSpace[3]}`,
 					globalStrongStyles,
 					globalH2Styles(format.display),
 					globalH3Styles(format.display),
@@ -208,7 +208,7 @@ export const ArticleBody = ({
 			<div
 				id="maincontent"
 				css={[
-					`margin-top: ${remSpace[3]}rem`,
+					`margin-top: ${remSpace[3]}`,
 					isInteractive ? null : bodyPadding,
 					globalH2Styles(format.display),
 					globalH3Styles(format.display),

--- a/dotcom-rendering/src/components/ArticleBody.tsx
+++ b/dotcom-rendering/src/components/ArticleBody.tsx
@@ -1,7 +1,12 @@
 import { css } from '@emotion/react';
 import { ArticleDesign, ArticleDisplay } from '@guardian/libs';
 import type { ArticleFormat } from '@guardian/libs';
-import { between, body, headline, space } from '@guardian/source-foundations';
+import {
+	between,
+	body,
+	headline,
+	remSpace,
+} from '@guardian/source-foundations';
 import { ArticleRenderer } from '../lib/ArticleRenderer';
 import type { EditionId } from '../lib/edition';
 import { decideLanguage, decideLanguageDirection } from '../lib/lang';
@@ -63,7 +68,7 @@ const globalOlStyles = () => css`
 			${body.medium({ lineHeight: 'tight' })};
 			content: counter(li);
 			counter-increment: li;
-			margin-right: ${space[1]}px;
+			margin-right: ${remSpace[1]}px;
 		}
 	}
 `;
@@ -73,7 +78,7 @@ const globalH3Styles = (display: ArticleDisplay) => css`
 	`
 		h3 {
 			${headline.xsmall({ fontWeight: 'bold' })};
-			margin-bottom: ${space[2]}px;
+			margin-bottom: ${remSpace[2]}px;
 		}
 	`}
 `;
@@ -150,7 +155,7 @@ export const ArticleBody = ({
 				// This classname is used by Spacefinder as the container in which it'll attempt to insert inline ads
 				className="js-liveblog-body"
 				css={[
-					'margin-top: 14px', // TODO This matches the TextBlockComponent.tsx:162 margin. Confirm with Alex B if this can be 12 or 16 so we can use Source spacing.
+					`margin-top: ${remSpace[3]}rem`,
 					globalStrongStyles,
 					globalH2Styles(format.display),
 					globalH3Styles(format.display),
@@ -203,7 +208,7 @@ export const ArticleBody = ({
 			<div
 				id="maincontent"
 				css={[
-					'margin-top: 14px', // TODO This matches the TextBlockComponent.tsx:162 margin. Confirm with Alex B if this can be 12 or 16 so we can use Source spacing.
+					`margin-top: ${remSpace[3]}rem`,
 					isInteractive ? null : bodyPadding,
 					globalH2Styles(format.display),
 					globalH3Styles(format.display),

--- a/dotcom-rendering/src/components/ArticleBody.tsx
+++ b/dotcom-rendering/src/components/ArticleBody.tsx
@@ -150,6 +150,7 @@ export const ArticleBody = ({
 				// This classname is used by Spacefinder as the container in which it'll attempt to insert inline ads
 				className="js-liveblog-body"
 				css={[
+					'margin-top: 14px', // TODO This matches the TextBlockComponent.tsx:162 margin. Confirm with Alex B if this can be 12 or 16 so we can use Source spacing.
 					globalStrongStyles,
 					globalH2Styles(format.display),
 					globalH3Styles(format.display),

--- a/dotcom-rendering/src/components/Caption.tsx
+++ b/dotcom-rendering/src/components/Caption.tsx
@@ -33,7 +33,7 @@ const captionStyle = css`
 	${textSans.xsmall()};
 	line-height: 135%;
 	padding-top: 6px;
-	overflow-wrap: break-all;
+	overflow-wrap: break-word;
 	color: ${palette('--caption-text')};
 `;
 

--- a/dotcom-rendering/src/components/TextBlockComponent.tsx
+++ b/dotcom-rendering/src/components/TextBlockComponent.tsx
@@ -159,7 +159,7 @@ const sanitiserOptions: IOptions = {
 };
 
 const styles = (format: ArticleFormat) => css`
-	margin-bottom: ${remSpace[3]}rem;
+	margin-bottom: ${remSpace[3]};
 	word-break: break-word;
 	${format.theme === ArticleSpecial.Labs ? textSans.medium() : body.medium()};
 
@@ -169,18 +169,18 @@ const styles = (format: ArticleFormat) => css`
 	}
 
 	ul {
-		margin-bottom: ${remSpace[3]}px;
+		margin-bottom: ${remSpace[3]};
 	}
 
 	${from.tablet} {
 		ul {
-			margin-bottom: ${remSpace[4]}px;
+			margin-bottom: ${remSpace[4]};
 		}
 	}
 
 	li {
-		margin-bottom: ${remSpace[1]}px;
-		padding-left: ${remSpace[5]}px;
+		margin-bottom: ${remSpace[1]};
+		padding-left: ${remSpace[5]};
 		display: flow-root;
 
 		p {
@@ -192,20 +192,20 @@ const styles = (format: ArticleFormat) => css`
 		display: inline-block;
 		content: '';
 		border-radius: 50%;
-		height: ${remSpace[3]}px;
-		width: ${remSpace[3]}px;
+		height: ${remSpace[3]};
+		width: ${remSpace[3]};
 		background-color: ${palette.neutral[86]};
-		margin-left: -${remSpace[5]}px;
-		margin-right: ${remSpace[2]}px;
+		margin-left: -${remSpace[5]};
+		margin-right: ${remSpace[2]};
 	}
 
 	/* Subscript and Superscript styles */
 	sub {
-		bottom: -${remSpace[1]}rem;
+		bottom: -${remSpace[1]};
 	}
 
 	sup {
-		top: -${remSpace[2]}rem;
+		top: -${remSpace[2]};
 	}
 
 	sub,
@@ -220,8 +220,8 @@ const styles = (format: ArticleFormat) => css`
 		display: inline-block;
 		content: '';
 		border-radius: 50%;
-		height: ${remSpace[2]}px;
-		width: ${remSpace[2]}px;
+		height: ${remSpace[2]};
+		width: ${remSpace[2]};
 		background-color: ${decidePalette(format).background.bullet};
 	}
 

--- a/dotcom-rendering/src/components/TextBlockComponent.tsx
+++ b/dotcom-rendering/src/components/TextBlockComponent.tsx
@@ -159,8 +159,7 @@ const sanitiserOptions: IOptions = {
 };
 
 const styles = (format: ArticleFormat) => css`
-	margin-top: ${space[3]}px;
-	margin-bottom: ${space[3]}px;
+	margin-bottom: 14px; // TODO Confirm with Alex B if this can be 12 or 16 so we can use Source spacing.
 	word-break: break-word;
 	${format.theme === ArticleSpecial.Labs ? textSans.medium() : body.medium()};
 

--- a/dotcom-rendering/src/components/TextBlockComponent.tsx
+++ b/dotcom-rendering/src/components/TextBlockComponent.tsx
@@ -5,7 +5,7 @@ import {
 	body,
 	from,
 	palette,
-	space,
+	remSpace,
 	textSans,
 	until,
 } from '@guardian/source-foundations';
@@ -158,9 +158,8 @@ const sanitiserOptions: IOptions = {
 	},
 };
 
-// TODO Confirm with Alex B if this can be 12 or 16 so we can use Source spacing.
 const styles = (format: ArticleFormat) => css`
-	margin-bottom: 14px;
+	margin-bottom: ${remSpace[3]}rem;
 	word-break: break-word;
 	${format.theme === ArticleSpecial.Labs ? textSans.medium() : body.medium()};
 
@@ -170,18 +169,18 @@ const styles = (format: ArticleFormat) => css`
 	}
 
 	ul {
-		margin-bottom: ${space[3]}px;
+		margin-bottom: ${remSpace[3]}px;
 	}
 
 	${from.tablet} {
 		ul {
-			margin-bottom: ${space[4]}px;
+			margin-bottom: ${remSpace[4]}px;
 		}
 	}
 
 	li {
-		margin-bottom: ${space[1]}px;
-		padding-left: ${space[5]}px;
+		margin-bottom: ${remSpace[1]}px;
+		padding-left: ${remSpace[5]}px;
 		display: flow-root;
 
 		p {
@@ -193,20 +192,20 @@ const styles = (format: ArticleFormat) => css`
 		display: inline-block;
 		content: '';
 		border-radius: 50%;
-		height: ${space[3]}px;
-		width: ${space[3]}px;
+		height: ${remSpace[3]}px;
+		width: ${remSpace[3]}px;
 		background-color: ${palette.neutral[86]};
-		margin-left: -${space[5]}px;
-		margin-right: ${space[2]}px;
+		margin-left: -${remSpace[5]}px;
+		margin-right: ${remSpace[2]}px;
 	}
 
 	/* Subscript and Superscript styles */
 	sub {
-		bottom: -0.25em;
+		bottom: -${remSpace[1]}rem;
 	}
 
 	sup {
-		top: -0.5em;
+		top: -${remSpace[2]}rem;
 	}
 
 	sub,
@@ -221,8 +220,8 @@ const styles = (format: ArticleFormat) => css`
 		display: inline-block;
 		content: '';
 		border-radius: 50%;
-		height: ${space[2]}px;
-		width: ${space[2]}px;
+		height: ${remSpace[2]}px;
+		width: ${remSpace[2]}px;
 		background-color: ${decidePalette(format).background.bullet};
 	}
 

--- a/dotcom-rendering/src/components/TextBlockComponent.tsx
+++ b/dotcom-rendering/src/components/TextBlockComponent.tsx
@@ -158,8 +158,9 @@ const sanitiserOptions: IOptions = {
 	},
 };
 
+// TODO Confirm with Alex B if this can be 12 or 16 so we can use Source spacing.
 const styles = (format: ArticleFormat) => css`
-	margin-bottom: 14px; // TODO Confirm with Alex B if this can be 12 or 16 so we can use Source spacing.
+	margin-bottom: 14px;
 	word-break: break-word;
 	${format.theme === ArticleSpecial.Labs ? textSans.medium() : body.medium()};
 

--- a/dotcom-rendering/src/components/TextBlockComponent.tsx
+++ b/dotcom-rendering/src/components/TextBlockComponent.tsx
@@ -201,11 +201,11 @@ const styles = (format: ArticleFormat) => css`
 
 	/* Subscript and Superscript styles */
 	sub {
-		bottom: -${remSpace[1]};
+		bottom: -0.25em;
 	}
 
 	sup {
-		top: -${remSpace[2]};
+		top: -0.5em;
 	}
 
 	sub,


### PR DESCRIPTION
## What does this change?

Change paragraph space to 12px from 14px as agreed with design. 
Revert change in https://github.com/guardian/dotcom-rendering/pull/11053
Move margin top to article body. 

## Why?

This is because the design requirement is to only have the 14 px at the top of the article body. We wouldn't want it after an h2 for example. 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/1229808/d111b6cd-c79f-42f1-bd97-d407b769feea
[after]: https://github.com/guardian/dotcom-rendering/assets/1229808/4ea09577-3ef7-46b1-a98f-89b2afb4e510


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
