### PR TITLE
Remove global styles and retain for picture essay

### DIFF
--- a/dotcom-rendering/src/components/ArticleBody.tsx
+++ b/dotcom-rendering/src/components/ArticleBody.tsx
@@ -47,15 +47,6 @@ type Props = {
 	isRightToLeftLang?: boolean;
 };
 
-const globalH2Styles = (display: ArticleDisplay) => css`
-	/** Base styles for h2 elements which do not render via SubheadingBlockComponent */
-	h2:not([data-ignore='global-h2-styling']) {
-		${display === ArticleDisplay.Immersive
-			? headline.medium({ fontWeight: 'light' })
-			: headline.xxsmall({ fontWeight: 'bold' })};
-	}
-`;
-
 const globalOlStyles = () => css`
 	ol:not([data-ignore='global-ol-styling']) {
 		counter-reset: li;
@@ -151,7 +142,6 @@ export const ArticleBody = ({
 				className="js-liveblog-body"
 				css={[
 					globalStrongStyles,
-					globalH2Styles(format.display),
 					globalH3Styles(format.display),
 					globalLinkStyles(),
 					// revealStyles is used to animate the reveal of new blocks
@@ -203,7 +193,6 @@ export const ArticleBody = ({
 				id="maincontent"
 				css={[
 					isInteractive ? null : bodyPadding,
-					globalH2Styles(format.display),
 					globalH3Styles(format.display),
 					globalOlStyles(),
 					globalStrongStyles,

--- a/dotcom-rendering/src/components/ImageComponent.tsx
+++ b/dotcom-rendering/src/components/ImageComponent.tsx
@@ -110,25 +110,32 @@ const moreTitlePadding = css`
 	}
 `;
 
-const titleWrapper = (palette: Palette, isImmersive: boolean) => css`
+const immersiveTitleWrapper = css`
+	${until.desktop} {
+		${headline.medium({ fontWeight: 'light' })}
+	}
+
+	${until.phablet} {
+		${headline.medium({ fontWeight: 'light' })}
+	}
+
+	${from.desktop} {
+		${headline.medium({ fontWeight: 'light' })}
+	}
+`;
+const titleWrapper = (palette: Palette) => css`
 	position: absolute;
 	bottom: 0;
 	width: 100%;
 
 	${until.desktop} {
-		${isImmersive
-			? headline.medium({ fontWeight: 'light' })
-			: headline.xxsmall({ fontWeight: 'light' })};
+		${headline.xxsmall({ fontWeight: 'light' })};
 	}
 	${until.phablet} {
-		${isImmersive
-			? headline.medium({ fontWeight: 'light' })
-			: headline.xxxsmall({ fontWeight: 'light' })};
+		${headline.xxxsmall({ fontWeight: 'light' })};
 	}
 	${from.desktop} {
-		${isImmersive
-			? headline.medium({ fontWeight: 'light' })
-			: headline.xsmall({ fontWeight: 'light' })};
+		${headline.xsmall({ fontWeight: 'light' })};
 	}
 
 	color: ${srcPalette.neutral[100]};
@@ -165,14 +172,20 @@ const ImageTitle = ({
 		case 'halfWidth':
 		case 'supporting':
 			return (
-				<h2 css={[titleWrapper(palette, false), basicTitlePadding]}>
+				<h2 css={[titleWrapper(palette), basicTitlePadding]}>
 					{title}
 				</h2>
 			);
 		case 'showcase':
 		case 'immersive':
 			return (
-				<h2 css={[titleWrapper(palette, true), moreTitlePadding]}>
+				<h2
+					css={[
+						titleWrapper(palette),
+						immersiveTitleWrapper,
+						moreTitlePadding,
+					]}
+				>
 					{title}
 				</h2>
 			);

--- a/dotcom-rendering/src/components/ImageComponent.tsx
+++ b/dotcom-rendering/src/components/ImageComponent.tsx
@@ -110,20 +110,27 @@ const moreTitlePadding = css`
 	}
 `;
 
-const titleWrapper = (palette: Palette) => css`
+const titleWrapper = (palette: Palette, isImmersive: boolean) => css`
 	position: absolute;
 	bottom: 0;
 	width: 100%;
 
 	${until.desktop} {
-		${headline.xxsmall({ fontWeight: 'light' })}
+		${isImmersive
+			? headline.medium({ fontWeight: 'light' })
+			: headline.xxsmall({ fontWeight: 'light' })};
 	}
 	${until.phablet} {
-		${headline.xxxsmall({ fontWeight: 'light' })}
+		${isImmersive
+			? headline.medium({ fontWeight: 'light' })
+			: headline.xxxsmall({ fontWeight: 'light' })};
 	}
 	${from.desktop} {
-		${headline.xsmall({ fontWeight: 'light' })}
+		${isImmersive
+			? headline.medium({ fontWeight: 'light' })
+			: headline.xsmall({ fontWeight: 'light' })};
 	}
+
 	color: ${srcPalette.neutral[100]};
 	background: linear-gradient(transparent, ${srcPalette.neutral[0]});
 
@@ -158,14 +165,16 @@ const ImageTitle = ({
 		case 'halfWidth':
 		case 'supporting':
 			return (
-				<h2 css={[titleWrapper(palette), basicTitlePadding]}>
+				<h2 css={[titleWrapper(palette, false), basicTitlePadding]}>
 					{title}
 				</h2>
 			);
 		case 'showcase':
 		case 'immersive':
 			return (
-				<h2 css={[titleWrapper(palette), moreTitlePadding]}>{title}</h2>
+				<h2 css={[titleWrapper(palette, true), moreTitlePadding]}>
+					{title}
+				</h2>
 			);
 	}
 };


### PR DESCRIPTION
## What does this change?

Removes global h2s again. This was previously attempted in 
https://github.com/guardian/dotcom-rendering/pull/11071

This also contains the Photo Essay fix mentioned in the original attempt

## Why?

Fewer places to keep track of h2 styling 

## Screenshots

There should be no visible difference
