### PR TITLE
Remove AMP CMP server side test

### DIFF
--- a/dotcom-rendering/src/components/AdConsent.amp.tsx
+++ b/dotcom-rendering/src/components/AdConsent.amp.tsx
@@ -1,9 +1,4 @@
-import type { ServerSideTests } from '../types/config';
 import { JsonScript } from './JsonScript.amp';
-
-type AdConsentProps = {
-	abTests: ServerSideTests;
-};
 
 const sourcepointDomain = 'sourcepoint.theguardian.com';
 
@@ -62,14 +57,7 @@ const clientConfigAus = {
 		framework: 'aus',
 	},
 };
-
-export const AdConsent = ({ abTests }: AdConsentProps) => {
-	const testAlternativeClientConfig = {
-		...clientConfig,
-		propertyId: 16921,
-		propertyHref: 'https://test.theguardian.amp',
-	};
-
+export const AdConsent = () => {
 	// To debug geolocation in dev, make sure you're on the experimental channel of AMP:
 	// https://cdn.ampproject.org/experiments.html
 	// Then you can load the url with #amp-geo=XX, where XX is the country code
@@ -153,10 +141,7 @@ export const AdConsent = ({ abTests }: AdConsentProps) => {
 						consentInstanceId: 'sourcepoint',
 						checkConsentHref: `https://${sourcepointDomain}/wrapper/tcfv2/v1/amp-v2?authId=${pubData.authId}`,
 						promptUISrc: `https://${sourcepointDomain}/amp/unified/index.html?${queryParams}`,
-						clientConfig:
-							abTests.ampGlobalAddressListVariant === 'variant'
-								? testAlternativeClientConfig
-								: clientConfig,
+						clientConfig,
 						geoOverride: {
 							ccpa: {
 								checkConsentHref: `https://${sourcepointDomain}/wrapper/ccpa/amp-v2?authId=${pubData.authId}`,

--- a/dotcom-rendering/src/components/ArticlePage.amp.tsx
+++ b/dotcom-rendering/src/components/ArticlePage.amp.tsx
@@ -75,7 +75,7 @@ export const AmpArticlePage = ({
 			/>
 			<Analytics key="analytics" analytics={analytics} />
 			<AnalyticsIframe url={config.ampIframeUrl} />
-			<AdConsent abTests={config.abTests} />
+			<AdConsent />
 			{experimentsData && (
 				<AmpExperimentComponent experimentsData={experimentsData} />
 			)}


### PR DESCRIPTION
Remove the test introduced in guardian/dotcom-rendering#11108