### PR TITLE
Storybook Toolbar Item To Set Colour Scheme

### DIFF
--- a/dotcom-rendering/.storybook/modes.ts
+++ b/dotcom-rendering/.storybook/modes.ts
@@ -1,0 +1,14 @@
+export const allModes = {
+	light: {
+		globalColourScheme: 'light',
+	},
+	dark: {
+		globalColourScheme: 'dark',
+	},
+	sideBySideHorizontal: {
+		globalColourScheme: 'horizontal',
+	},
+	sideBySideVertical: {
+		globalColourScheme: 'vertical',
+	},
+};

--- a/dotcom-rendering/.storybook/preview.ts
+++ b/dotcom-rendering/.storybook/preview.ts
@@ -1,17 +1,10 @@
-import {
-	ArticleDesign,
-	ArticleDisplay,
-	Pillar,
-	setCookie,
-	storage,
-} from '@guardian/libs';
+import { setCookie, storage } from '@guardian/libs';
 import { AB } from '@guardian/ab-core';
 
 import isChromatic from 'chromatic/isChromatic';
 import MockDate from 'mockdate';
 
 import { fontsCss } from '../src/lib/fonts-css';
-
 import { resets } from '@guardian/source-foundations';
 
 import { Lazy } from '../src/components/Lazy';
@@ -19,8 +12,11 @@ import { Picture } from '../src/components/Picture';
 import { mockRESTCalls } from '../src/lib/mockRESTCalls';
 import { setABTests } from '../src/lib/useAB';
 import { ConfigContextDecorator } from './decorators/configContextDecorator';
-import { lightDecorator } from './decorators/themeDecorator';
 import { Preview } from '@storybook/react';
+import {
+	globalColourScheme,
+	globalColourSchemeDecorator,
+} from './toolbar/globalColourScheme';
 
 // Prevent components being lazy rendered when we're taking Chromatic snapshots
 Lazy.disabled = isChromatic();
@@ -142,33 +138,27 @@ const guardianViewports = {
 	},
 };
 
-const defaultFormat = {
-	display: ArticleDisplay.Standard,
-	design: ArticleDesign.Standard,
-	theme: Pillar.News,
-};
-
 export default {
 	args: {
 		config: { renderingTarget: 'Web', darkModeAvailable: false },
 	},
+	globalTypes: {
+		globalColourScheme,
+	},
 	decorators: [
 		// @ts-expect-error -- this global decorator takes an option parameter
 		ConfigContextDecorator,
-		lightDecorator([defaultFormat]),
+		globalColourSchemeDecorator,
 		(Story) => {
 			storage.local.clear();
 			return Story();
 		},
 	],
-} satisfies Preview;
-
-export const viewports = [320, 375, 480, 660, 740, 980, 1140, 1300];
-
-export const parameters = {
-	viewport: {
-		viewports: guardianViewports,
-		defaultViewport: 'wide',
+	parameters: {
+		viewport: {
+			viewports: guardianViewports,
+			defaultViewport: 'wide',
+		},
+		layout: 'fullscreen',
 	},
-	layout: 'fullscreen',
-};
+} satisfies Preview;

--- a/dotcom-rendering/.storybook/toolbar/globalColourScheme.ts
+++ b/dotcom-rendering/.storybook/toolbar/globalColourScheme.ts
@@ -15,14 +15,14 @@ const defaultFormat: ArticleFormat = {
 };
 
 /**
- * A global type and toolbar item to control the colour scheme of the story. It
- * offers four options:
+ * A global type and toolbar item to control the colour scheme of the story.
+ * It offers four options:
  *
  * 1. Light mode.
  * 2. Dark mode.
- * 3. Side-by-side Horizontal: display the story twice, on the left in light
+ * 3. Horizontal Split: display the story twice, on the left in light
  * mode and on the right in dark mode.
- * 4. Side-by-side Vertical: display the story twice, on the top in light
+ * 4. Vertical Split: display the story twice, on the top in light
  * mode and on the bottom in dark mode.
  *
  * This is added to `globalTypes` in `preview.ts` to include it in the toolbar.
@@ -44,9 +44,9 @@ export const globalColourScheme = {
 			{
 				value: 'horizontal',
 				left: '◨',
-				title: 'Side-by-side Horizontal',
+				title: 'Horizontal Split',
 			},
-			{ value: 'vertical', left: '⬓', title: 'Side-by-side Vertical' },
+			{ value: 'vertical', left: '⬓', title: 'Vertical Split' },
 		],
 		dynamicTitle: true,
 	},

--- a/dotcom-rendering/.storybook/toolbar/globalColourScheme.ts
+++ b/dotcom-rendering/.storybook/toolbar/globalColourScheme.ts
@@ -1,0 +1,129 @@
+import type { Decorator } from '@storybook/react';
+import { lightDecorator, darkDecorator } from '../decorators/themeDecorator';
+import { splitTheme } from '../decorators/splitThemeDecorator';
+import {
+	ArticleDisplay,
+	ArticleDesign,
+	Pillar,
+	type ArticleFormat,
+} from '@guardian/libs';
+
+const defaultFormat: ArticleFormat = {
+	display: ArticleDisplay.Standard,
+	design: ArticleDesign.Standard,
+	theme: Pillar.News,
+};
+
+/**
+ * A global type and toolbar item to control the colour scheme of the story. It
+ * offers four options:
+ *
+ * 1. Light mode.
+ * 2. Dark mode.
+ * 3. Side-by-side Horizontal: display the story twice, on the left in light
+ * mode and on the right in dark mode.
+ * 4. Side-by-side Vertical: display the story twice, on the top in light
+ * mode and on the bottom in dark mode.
+ *
+ * This is added to `globalTypes` in `preview.ts` to include it in the toolbar.
+ * For more information on how this works see:
+ * https://storybook.js.org/docs/essentials/toolbars-and-globals
+ *
+ * It relies on {@linkcode globalColourSchemeDecorator} to read the value that's
+ * been set and apply the appropriate colours and layout.
+ */
+export const globalColourScheme = {
+	description: 'View the story in light and dark mode, or both side-by-side',
+	defaultValue: 'light',
+	toolbar: {
+		title: 'Colour Scheme',
+		icon: 'mirror',
+		items: [
+			{ value: 'light', left: '☀️', title: 'Light' },
+			{ value: 'dark', left: '🌙', title: 'Dark' },
+			{
+				value: 'horizontal',
+				left: '◨',
+				title: 'Side-by-side Horizontal',
+			},
+			{ value: 'vertical', left: '⬓', title: 'Side-by-side Vertical' },
+		],
+		dynamicTitle: true,
+	},
+} as const;
+
+type ColourSchemeParameter =
+	(typeof globalColourScheme.toolbar.items)[number]['value'];
+
+/**
+ * A decorator that reads the {@linkcode globalColourScheme} and applies a
+ * colour palette and layout to the story based on the value. It's designed to
+ * be used globally in `preview.ts` rather than at the story or component level,
+ * as the toolbar item is available on all stories.
+ *
+ * It wraps a given story in a colour palette, which is applied via CSS
+ * variables and defined in `palette.ts`. It makes use of other, existing
+ * decorators to do this in each case: {@linkcode lightDecorator},
+ * {@linkcode darkDecorator} and {@linkcode splitTheme}.
+ *
+ * To make use of a colour palette, an {@linkcode ArticleFormat} must be
+ * available. There are three ways the decorator attempts to retrieve this,
+ * in decreasing priority order (i.e. it will try 1, then 2, then 3):
+ *
+ * 1. If a list of formats is supplied via the story's `formats` parameter, it
+ * will render the component multiple times, once for each format.
+ * 2. If the story in question takes a `format` argument it renders the
+ * component once, using that.
+ * 3. If no format is available, it falls back to {@linkcode defaultFormat},
+ * again rendering the component just once.
+ *
+ * For more information on `parameters` see:
+ * https://storybook.js.org/docs/writing-stories/parameters
+ *
+ * @example
+ * <caption>Using the `formats` parameter</caption>
+ * const myStory = {
+ *   args: {},
+ *   parameters: {
+ *     formats: [standardStandardNews, interviewImmersiveSport],
+ *   },
+ * } satisfies Story;
+ *
+ * @example
+ * <caption>Using the story's `format` arg</caption>
+ * const myStory = {
+ *   args: {
+ *     format: standardStandardNews,
+ *   },
+ * } satisfies Story;
+ *
+ * @example
+ * <caption>Using the fallback `defaultFormat`</caption>
+ * const myStory = {
+ *   args: {},
+ * } satisfies Story;
+ */
+export const globalColourSchemeDecorator: Decorator = (Story, context) => {
+	const colourSchemeParameter: ColourSchemeParameter =
+		context.globals.globalColourScheme;
+	const formats = [
+		context.parameters.formats ?? context.args.format ?? defaultFormat,
+	].flat();
+
+	switch (colourSchemeParameter) {
+		case 'light':
+			return lightDecorator(formats)(Story, context);
+		case 'dark':
+			return darkDecorator(formats)(Story, context);
+		case 'horizontal':
+			return splitTheme(formats, { orientation: 'horizontal' })(
+				Story,
+				context,
+			);
+		case 'vertical':
+			return splitTheme(formats, { orientation: 'vertical' })(
+				Story,
+				context,
+			);
+	}
+};

--- a/dotcom-rendering/src/components/AudioAtom/AudioAtom.stories.tsx
+++ b/dotcom-rendering/src/components/AudioAtom/AudioAtom.stories.tsx
@@ -1,6 +1,7 @@
 import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
 import type { Meta, StoryObj } from '@storybook/react';
 import { defaultFormats } from '../../../.storybook/decorators/splitThemeDecorator';
+import { allModes } from '../../../.storybook/modes';
 import { AudioAtom as AudioAtomComponent } from './AudioAtom';
 
 const meta = {
@@ -36,5 +37,10 @@ export const MultipleFormats = {
 	args: AudioAtom.args,
 	parameters: {
 		formats: defaultFormats,
+		chromatic: {
+			modes: {
+				horizontal: allModes.sideBySideHorizontal,
+			},
+		},
 	},
 } satisfies Story;

--- a/dotcom-rendering/src/components/AudioAtom/AudioAtom.stories.tsx
+++ b/dotcom-rendering/src/components/AudioAtom/AudioAtom.stories.tsx
@@ -1,15 +1,18 @@
+import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
 import type { Meta, StoryObj } from '@storybook/react';
-import { splitTheme } from '../../../.storybook/decorators/splitThemeDecorator';
+import { defaultFormats } from '../../../.storybook/decorators/splitThemeDecorator';
 import { AudioAtom as AudioAtomComponent } from './AudioAtom';
 
-const meta: Meta<typeof AudioAtomComponent> = {
+const meta = {
 	title: 'Components/Audio Atom',
 	component: AudioAtomComponent,
-};
+} satisfies Meta<typeof AudioAtomComponent>;
 
-type Story = StoryObj<typeof AudioAtomComponent>;
+export default meta;
 
-export const AudioAtom: Story = {
+type Story = StoryObj<typeof meta>;
+
+export const AudioAtom = {
 	args: {
 		id: 'd6d509cf-ca10-407f-8913-e16a3712f415',
 		trackUrl:
@@ -17,8 +20,21 @@ export const AudioAtom: Story = {
 		kicker: 'Football Weekly Extra Extra',
 		title: 'Q&A and Detective Wilson',
 		duration: 849,
+		format: {
+			design: ArticleDesign.Standard,
+			display: ArticleDisplay.Standard,
+			theme: Pillar.News,
+		},
 	},
-	decorators: [splitTheme()],
-};
+	parameters: {
+		// We only want to snapshot the `multipleFormats` version below.
+		chromatic: { disable: true },
+	},
+} satisfies Story;
 
-export default meta;
+export const MultipleFormats = {
+	args: AudioAtom.args,
+	parameters: {
+		formats: defaultFormats,
+	},
+} satisfies Story;


### PR DESCRIPTION
With the introduction of dark mode we've found it useful to apply colour schemes and split layouts to stories via decorators: `lightDecorator`, `darkDecorator` and `splitTheme`. This change builds on that approach by allowing you to switch any story between one of four colour schemes via the storybook toolbar:

1. Light mode.
2. Dark mode.
3. Side-by-side Horizontal: display the story twice, on the left in light mode and on the right in dark mode.
4. Side-by-side Vertical: display the story twice, on the top in light mode and on the bottom in dark mode.

More details on exactly how this works can be found in the JSDoc comments in `globalColourScheme.ts`.

There are a few advantages to this approach. Firstly, a story no longer needs to be hardcoded to a given colour scheme or split theme layout; any story can be viewed in any one of the four variants. Secondly, and relatedly, we can use Chromatic's "modes" to decide on one or more colour schemes to snapshot a story with, without having to write multiple stories, and tightly couple our stories to the snapshot variations we want. Thirdly, it makes it clearer which format is being applied to a given story. Previously, if a story took `format` as an `arg`, that was always ignored in favour of the `defaultFormat` or a format applied in one of the colour scheme decorators. Now the story's `format` will be used when available, unless you specifically want to display multiple format variants using `parameters.formats`.

This change also updates the `AudioAtom` stories to take advantage of this new approach. In addition, it includes a small refactor to `preview.ts`, to make it clearer and remove the unused `viewports` export.

## Screenshots

| "Audio Atom" Story (Format Arg) | "Multiple Formats" Story (Formats Parameter) |
|--------|--------|
| ![audio-atom-light] | ![multiple-formats-light] |
| ![audio-atom-dark] | ![multiple-formats-dark] |
| ![audio-atom-horizontal] | ![multiple-formats-horizontal] |
| ![audio-atom-vertical] | ![multiple-formats-vertical] | 

[audio-atom-light]: https://github.com/guardian/dotcom-rendering/assets/53781962/a3ae99a5-bc85-403f-9745-62151ebeadcb
[audio-atom-dark]: https://github.com/guardian/dotcom-rendering/assets/53781962/e08900d3-71b9-41dd-918e-8792e7effde2
[audio-atom-horizontal]: https://github.com/guardian/dotcom-rendering/assets/53781962/cd2d5492-266d-4240-8ae2-c69cbb33d82f
[audio-atom-vertical]: https://github.com/guardian/dotcom-rendering/assets/53781962/dae67721-e2bb-4e03-adfc-eeb9dbdce25a
[multiple-formats-horizontal]: https://github.com/guardian/dotcom-rendering/assets/53781962/bd6b740e-4826-4f0b-8587-0a1d4af7c19e
[multiple-formats-vertical]: https://github.com/guardian/dotcom-rendering/assets/53781962/7b5a0a58-a836-4aa4-b354-f178323e4d3b
[multiple-formats-dark]: https://github.com/guardian/dotcom-rendering/assets/53781962/94f364eb-da68-49e1-81d5-518a23835b5f
[multiple-formats-light]: https://github.com/guardian/dotcom-rendering/assets/53781962/9216acee-0397-42d7-aea0-f3074e181c03
