### PR TITLE
Ignore Zed config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ node_modules
 
 # IDE files
 .idea
+.zed
 .vscode/*
 !.vscode/extensions.json
 !.vscode/settings.json.recommended


### PR DESCRIPTION
## What does this change?

Add `.zed` to list of git ignores

## Why?

We should [not keep editor configs in VCS](https://github.com/guardian/recommendations/blob/main/VSCode.md#do-not-commit-vscode). Also [Zed](https://zed.dev/) is nice.