### PR TITLE
fix: remove disableAmpTest from fixtures

### DIFF
--- a/dotcom-rendering/scripts/perf/k6/article-nier-automata.json
+++ b/dotcom-rendering/scripts/perf/k6/article-nier-automata.json
@@ -1641,7 +1641,6 @@
 			"prebidTriplelift": true,
 			"weather": true,
 			"commercialOutbrainNewids": true,
-			"disableAmpTest": true,
 			"abLimitInlineMerch": false,
 			"serverShareCounts": false,
 			"abAdblockAsk": true,


### PR DESCRIPTION
Part of https://github.com/guardian/dotcom-rendering/issues/7486

Removes the `disableAmpTest`. I'm not sure if we should or shouldn't be doing this on fixtures?
