### PR TITLE
Add class name to Interactive grid

### DIFF
--- a/dotcom-rendering/docs/contracts/003-extra-classes-for-interactives.md
+++ b/dotcom-rendering/docs/contracts/003-extra-classes-for-interactives.md
@@ -4,11 +4,12 @@
 
 We have added extra classes to the standfirst and main meta sections of the interactives layout:
 
--   Standfirst: class class `content__standfirst` applied to the div that contains the standfirst paragraph.
+-   Standfirst: class `content__standfirst` applied to the div that contains the standfirst paragraph.
 -   Meta container: class `content__meta_container_dcr` applied to the div that contains the article meta. Note that the class name in frontend (`content__meta_container`) comes with extra horizontal lines which is duplicated in DCR. The the slight name change avoids this duplication.
 -   Byline: class `byline` applied to the div that contains the authors of the article.
 -   Share icons: class `meta__social` applied to the div that contains the list of share icons.
 -   Share and Comment counts: class `meta__comment` applied to the div that contains the share and comment counts.
+-   Interactive grid: class `content--interactive-grid` applied to the grid inside an interactive article
 
 We have not included classes on all grid elements, only on those identified as most useful when customising interactives.
 

--- a/dotcom-rendering/src/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/InteractiveLayout.tsx
@@ -56,6 +56,7 @@ import { BannerWrapper, Stuck } from './lib/stickiness';
 
 const InteractiveGrid = ({ children }: { children: React.ReactNode }) => (
 	<div
+		className={interactiveLegacyClasses.contentInteractiveGrid}
 		css={css`
 			/* IE Fallback */
 			display: flex;

--- a/dotcom-rendering/src/layouts/lib/interactiveLegacyStyling.ts
+++ b/dotcom-rendering/src/layouts/lib/interactiveLegacyStyling.ts
@@ -27,6 +27,7 @@ export const interactiveLegacyFigureClasses = (
 // Classes present in Frontend that we add for legacy interactives.
 export const interactiveLegacyClasses = {
 	contentInteractive: 'content--interactive',
+	contentInteractiveGrid: 'content--interactive-grid',
 	contentLabels: 'content__labels',
 	contentLabelsNotImmersive: 'content__labels--not-immersive',
 	contentMainColumn: 'content__main-column--interactive',


### PR DESCRIPTION
## What does this change?

Adds a class name of `content--interactive-grid` to the grid inside an interactive article.

## Why?

This is an frequently targeted element by the Editorial Design team and as such will make developing interactive articles easier.
