### PR TITLE
Update `SharingIcons` Stories To Component Story Format v3

### DIFF
--- a/dotcom-rendering/src/components/SharingIcons.stories.tsx
+++ b/dotcom-rendering/src/components/SharingIcons.stories.tsx
@@ -1,15 +1,20 @@
+import type { Meta, StoryObj } from '@storybook/react';
 import { sharingUrls } from '../../fixtures/manual/sharingUrls';
-import { SharingIcons } from './SharingIcons';
+import { SharingIcons as SharingIconsComponent } from './SharingIcons';
 
-export default {
-	title: 'SharingIcons',
-	component: SharingIcons,
-};
+const meta = {
+	title: 'Components/SharingIcons',
+	component: SharingIconsComponent,
+} satisfies Meta<typeof SharingIconsComponent>;
 
-export const SharingIconsDefault = (): JSX.Element => (
-	<SharingIcons
-		sharingUrls={sharingUrls}
-		displayIcons={[
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const SharingIcons = {
+	args: {
+		sharingUrls,
+		displayIcons: [
 			'facebook',
 			'twitter',
 			'email',
@@ -17,6 +22,6 @@ export const SharingIconsDefault = (): JSX.Element => (
 			'messenger',
 			'pinterest',
 			'linkedIn',
-		]}
-	/>
-);
+		],
+	},
+} satisfies Story;


### PR DESCRIPTION
This is the default for Storybook 7+[^1], and integrates better with some of its features.

This also moves these stories into the `Components` folder, and renames the only story to allow story hoisting[^2], i.e. the story can appear at the top level without an enclosing folder.

Using `satisfies` gives better type safety for `args`[^3].

[^1]: https://storybook.js.org/blog/storybook-csf3-is-here/
[^2]: https://storybook.js.org/docs/writing-stories/naming-components-and-hierarchy#single-story-hoisting
[^3]: https://storybook.js.org/docs/writing-stories/typescript#using-satisfies-for-better-type-safety