### PR TITLE
 Drill isTimeline context to image and caption

### DIFF
--- a/dotcom-rendering/src/components/Caption.tsx
+++ b/dotcom-rendering/src/components/Caption.tsx
@@ -102,8 +102,8 @@ const veryLimitedWidth = css`
 `;
 
 const captionPadding = css`
-	padding-left: 8px;
-	padding-right: 8px;
+	padding-left: 10px;
+	padding-right: 10px;
 `;
 
 const tabletCaptionPadding = css`

--- a/dotcom-rendering/src/components/Figure.tsx
+++ b/dotcom-rendering/src/components/Figure.tsx
@@ -11,6 +11,7 @@ type Props = {
 	id?: string;
 	className?: string;
 	type?: FEElement['_type'];
+	isTimeline?: boolean;
 };
 
 const roleCss = {
@@ -150,6 +151,7 @@ const roleCss = {
 export const defaultRoleStyles = (
 	role: RoleType | 'richLink',
 	format: ArticleFormat,
+	isTimeline: boolean = false,
 ) => {
 	switch (role) {
 		case 'inline':
@@ -159,6 +161,7 @@ export const defaultRoleStyles = (
 		case 'immersive':
 			return roleCss.immersive;
 		case 'showcase':
+			if (isTimeline) return roleCss.immersive;
 			return roleCss.showcase;
 		case 'thumbnail':
 			switch (format.design) {
@@ -196,6 +199,7 @@ export const Figure = ({
 	isMainMedia,
 	className = '',
 	type,
+	isTimeline = false,
 }: Props) => {
 	if (isMainMedia) {
 		// Don't add in-body styles for main media elements
@@ -213,7 +217,7 @@ export const Figure = ({
 	return (
 		<figure
 			id={id}
-			css={defaultRoleStyles(role, format)}
+			css={defaultRoleStyles(role, format, isTimeline)}
 			data-spacefinder-role={role}
 			data-spacefinder-type={type}
 			className={className}

--- a/dotcom-rendering/src/components/Figure.tsx
+++ b/dotcom-rendering/src/components/Figure.tsx
@@ -151,7 +151,7 @@ const roleCss = {
 export const defaultRoleStyles = (
 	role: RoleType | 'richLink',
 	format: ArticleFormat,
-	isTimeline: boolean = false,
+	isTimeline = false,
 ) => {
 	switch (role) {
 		case 'inline':

--- a/dotcom-rendering/src/components/ImageBlockComponent.tsx
+++ b/dotcom-rendering/src/components/ImageBlockComponent.tsx
@@ -9,6 +9,7 @@ type Props = {
 	isMainMedia?: boolean;
 	starRating?: number;
 	isAvatar?: boolean;
+	isTimeline?: boolean;
 };
 
 export const ImageBlockComponent = ({
@@ -19,6 +20,7 @@ export const ImageBlockComponent = ({
 	isMainMedia,
 	starRating,
 	isAvatar,
+	isTimeline = false,
 }: Props) => {
 	const { role } = element;
 	return (
@@ -31,6 +33,7 @@ export const ImageBlockComponent = ({
 			role={role}
 			title={title}
 			isAvatar={isAvatar}
+			isTimeline={isTimeline}
 		/>
 	);
 };

--- a/dotcom-rendering/src/components/ImageComponent.tsx
+++ b/dotcom-rendering/src/components/ImageComponent.tsx
@@ -29,6 +29,7 @@ type Props = {
 	starRating?: number;
 	title?: string;
 	isAvatar?: boolean;
+	isTimeline?: boolean;
 };
 
 const starsWrapper = css`
@@ -219,6 +220,7 @@ export const ImageComponent = ({
 	starRating,
 	title,
 	isAvatar,
+	isTimeline = false,
 }: Props) => {
 	const { renderingTarget } = useConfig();
 	// Its possible the tools wont send us any images urls
@@ -523,6 +525,7 @@ export const ImageComponent = ({
 					displayCredit={element.displayCredit}
 					shouldLimitWidth={shouldLimitWidth}
 					isMainMedia={isMainMedia}
+					padCaption={role === 'showcase' && isTimeline}
 				/>
 			)}
 		</>

--- a/dotcom-rendering/src/components/Timeline.tsx
+++ b/dotcom-rendering/src/components/Timeline.tsx
@@ -98,6 +98,7 @@ const EventHeader = ({
 					index={0}
 					element={event.main}
 					format={format}
+					isTimeline={true}
 				/>
 				{heading}
 			</header>
@@ -110,6 +111,7 @@ const EventHeader = ({
 					index={0}
 					element={event.main}
 					format={format}
+					isTimeline={true}
 				/>
 			</header>
 		);

--- a/dotcom-rendering/src/lib/renderElement.tsx
+++ b/dotcom-rendering/src/lib/renderElement.tsx
@@ -893,7 +893,7 @@ export const RenderArticleElement = ({
 
 	const needsFigure = !bareElements.has(element._type);
 	const role = 'role' in element ? (element.role as RoleType) : undefined;
-	console.log(element._type);
+
 	return needsFigure ? (
 		<Figure
 			key={'elementId' in element ? element.elementId : index}

--- a/dotcom-rendering/src/lib/renderElement.tsx
+++ b/dotcom-rendering/src/lib/renderElement.tsx
@@ -88,6 +88,7 @@ type Props = {
 	abTests: ServerSideTests;
 	editionId: EditionId;
 	forceDropCap?: 'on' | 'off';
+	isTimeline?: boolean;
 };
 
 // updateRole modifies the role of an element in a way appropriate for most
@@ -144,6 +145,7 @@ export const renderElement = ({
 	abTests,
 	editionId,
 	forceDropCap,
+	isTimeline = false,
 }: Props) => {
 	const isBlog =
 		format.design === ArticleDesign.LiveBlog ||
@@ -203,7 +205,7 @@ export const renderElement = ({
 					key={index}
 					format={format}
 					captionText={element.captionText}
-					padCaption={element.padCaption}
+					padCaption={isTimeline}
 					credit={element.credit}
 					displayCredit={element.displayCredit}
 					shouldLimitWidth={element.shouldLimitWidth}
@@ -356,6 +358,7 @@ export const renderElement = ({
 					starRating={starRating ?? element.starRating}
 					title={element.title}
 					isAvatar={element.isAvatar}
+					isTimeline={isTimeline}
 				/>
 			);
 		case 'model.dotcomrendering.pageElements.InstagramBlockElement':
@@ -863,6 +866,7 @@ export const RenderArticleElement = ({
 	abTests,
 	editionId,
 	forceDropCap,
+	isTimeline,
 }: Props) => {
 	const withUpdatedRole = updateRole(element, format);
 
@@ -884,11 +888,12 @@ export const RenderArticleElement = ({
 		abTests,
 		editionId,
 		forceDropCap,
+		isTimeline,
 	});
 
 	const needsFigure = !bareElements.has(element._type);
 	const role = 'role' in element ? (element.role as RoleType) : undefined;
-
+	console.log(element._type);
 	return needsFigure ? (
 		<Figure
 			key={'elementId' in element ? element.elementId : index}
@@ -902,6 +907,7 @@ export const RenderArticleElement = ({
 			}
 			type={element._type}
 			format={format}
+			isTimeline={isTimeline}
 		>
 			{el}
 		</Figure>
@@ -915,7 +921,8 @@ type ElementLevelPropNames =
 	| 'index'
 	| 'forceDropCap'
 	| 'hideCaption'
-	| 'format';
+	| 'format'
+	| 'isTimeline';
 type ArticleLevelProps = Omit<Props, ElementLevelPropNames>;
 type ElementLevelProps = Pick<Props, ElementLevelPropNames>;
 


### PR DESCRIPTION
## What does this change?
 Drills isTimeline context to image and caption. 

 Co-authored-by: @alinaboghiu
## Why?
Showcase images and captions in timeline elements that are in the main slot display differently on mobile to other showcase images and captions. Specifically:
- the image takes the fullwidth (like an immersive image)
- the caption has 10px padding left and right

Images and captions did not previously know if they were part of a timeline element. This PR drills down knowledge of this to allow us to style the components differently. 


## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/20416599/5c34f385-8498-4ac9-bf83-25edd2691875
[after]: https://github.com/guardian/dotcom-rendering/assets/20416599/649679b1-08fa-4993-8ed6-ee2571fe5abc


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
