### PR TITLE
Update `VideoAtom` Stories To Component Story Format v3

### DIFF
--- a/dotcom-rendering/src/components/VideoAtom.stories.tsx
+++ b/dotcom-rendering/src/components/VideoAtom.stories.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import { VideoAtom } from './VideoAtom';
 
 const meta = {
@@ -16,17 +16,6 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-const sizeDecorator: Decorator = (Story) => (
-	<div
-		css={css`
-			width: 800px;
-			margin: 25px;
-		`}
-	>
-		<Story />
-	</div>
-);
-
 export const Default = {
 	args: {
 		poster: 'https://media.guim.co.uk/29638c3179baea589b10fbd4dbbc223ea77027ae/0_0_3589_2018/master/3589.jpg',
@@ -37,7 +26,18 @@ export const Default = {
 			},
 		],
 	},
-	decorators: [sizeDecorator],
+	decorators: [
+		(Story) => (
+			<div
+				css={css`
+					width: 800px;
+					margin: 25px;
+				`}
+			>
+				<Story />
+			</div>
+		),
+	],
 } satisfies Story;
 
 export const Large = {

--- a/dotcom-rendering/src/components/VideoAtom.stories.tsx
+++ b/dotcom-rendering/src/components/VideoAtom.stories.tsx
@@ -1,76 +1,58 @@
 import { css } from '@emotion/react';
+import type { Decorator, Meta, StoryObj } from '@storybook/react';
 import { VideoAtom } from './VideoAtom';
 
-export default {
-	title: 'VideoAtom',
+const meta = {
+	title: 'Components/VideoAtom',
 	component: VideoAtom,
 	parameters: {
 		// Chromatic ignores video elements by design so there's no point trying to snapshot here
 		// https://www.chromatic.com/docs/ignoring-elements
 		chromatic: { disable: true },
 	},
-};
+} satisfies Meta<typeof VideoAtom>;
 
-export const DefaultStory = () => {
-	return (
-		<div
-			css={css`
-				width: 800px;
-				margin: 25px;
-			`}
-		>
-			<VideoAtom
-				poster="https://media.guim.co.uk/29638c3179baea589b10fbd4dbbc223ea77027ae/0_0_3589_2018/master/3589.jpg"
-				assets={[
-					{
-						url: 'https://uploads.guim.co.uk/2020%2F23%2F04%2Ffor+testing+purposes+only--ef8e62ab-bc06-4892-8da1-65a7e5bacb77-1.mp4',
-						mimeType: 'video/mp4',
-					},
-				]}
-			/>
-		</div>
-	);
-};
+export default meta;
 
-export const LargeStory = () => {
-	return (
-		<div
-			css={css`
-				width: 800px;
-				margin: 25px;
-			`}
-		>
-			<VideoAtom
-				poster="https://media.guim.co.uk/29638c3179baea589b10fbd4dbbc223ea77027ae/0_0_3589_2018/master/3589.jpg"
-				assets={[
-					{
-						url: 'https://uploads.guim.co.uk/2020%2F23%2F04%2Ffor+testing+purposes+only--ef8e62ab-bc06-4892-8da1-65a7e5bacb77-1.mp4',
-						mimeType: 'video/mp4',
-					},
-				]}
-				height={500}
-				width={880}
-			/>
-		</div>
-	);
-};
+type Story = StoryObj<typeof meta>;
 
-export const NoPosterStory = () => {
-	return (
-		<div
-			css={css`
-				width: 800px;
-				margin: 25px;
-			`}
-		>
-			<VideoAtom
-				assets={[
-					{
-						url: 'https://uploads.guim.co.uk/2020%2F23%2F04%2Ffor+testing+purposes+only--ef8e62ab-bc06-4892-8da1-65a7e5bacb77-1.mp4',
-						mimeType: 'video/mp4',
-					},
-				]}
-			/>
-		</div>
-	);
-};
+const sizeDecorator: Decorator = (Story) => (
+	<div
+		css={css`
+			width: 800px;
+			margin: 25px;
+		`}
+	>
+		<Story />
+	</div>
+);
+
+export const Default = {
+	args: {
+		poster: 'https://media.guim.co.uk/29638c3179baea589b10fbd4dbbc223ea77027ae/0_0_3589_2018/master/3589.jpg',
+		assets: [
+			{
+				url: 'https://uploads.guim.co.uk/2020%2F23%2F04%2Ffor+testing+purposes+only--ef8e62ab-bc06-4892-8da1-65a7e5bacb77-1.mp4',
+				mimeType: 'video/mp4',
+			},
+		],
+	},
+	decorators: [sizeDecorator],
+} satisfies Story;
+
+export const Large = {
+	...Default,
+	args: {
+		...Default.args,
+		height: 500,
+		width: 880,
+	},
+} satisfies Story;
+
+export const NoPoster = {
+	...Default,
+	args: {
+		...Default.args,
+		poster: undefined,
+	},
+} satisfies Story;


### PR DESCRIPTION
This is the default for Storybook 7+[^1], and integrates better with some of its features. This also moves these stories into the `Components` folder.

Using `satisfies` gives better type safety for `args`[^2].

**Note:** I recommend using "Hide whitespace" to view the diff.

[^1]: https://storybook.js.org/blog/storybook-csf3-is-here/
[^2]: https://storybook.js.org/docs/writing-stories/typescript#using-satisfies-for-better-type-safety
