### PR TITLE
run `make tsc` instead of `pnpm [...] tsc` in `pre-push`

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -9,4 +9,5 @@ then
 	exit 1
 fi
 
-pnpm --filter @guardian/dotcom-rendering tsc
+cd ./$(dirname "$0")/../dotcom-rendering
+make tsc


### PR DESCRIPTION
Ensures pre-requisite steps (e.g fetch dependencies) are run first.

