### PR TITLE
Expand clickable area on Table of Contents links

### DIFF
--- a/dotcom-rendering/src/components/TableOfContents.importable.tsx
+++ b/dotcom-rendering/src/components/TableOfContents.importable.tsx
@@ -21,6 +21,9 @@ const anchorStyles = css`
 	text-decoration: none;
 	display: block;
 	width: 100%;
+`;
+
+const paddingStyles = css`
 	padding-bottom: ${space[4]}px;
 	padding-top: ${space[1]}px;
 `;
@@ -150,13 +153,16 @@ export const TableOfContents = ({ tableOfContents, format }: Props) => {
 						data-link-name={`table-of-contents-item-${index}-${item.id}`}
 					>
 						{format.display === ArticleDisplay.NumberedList && (
-							<>
+							<div css={paddingStyles}>
 								<span css={indexStyle}>{index + 1}</span>
 								<div css={verticalStyle}></div>
-							</>
+							</div>
 						)}
 
-						<a href={`#${item.id}`} css={anchorStyles}>
+						<a
+							href={`#${item.id}`}
+							css={[anchorStyles, paddingStyles]}
+						>
 							{item.title}
 						</a>
 					</li>

--- a/dotcom-rendering/src/components/TableOfContents.importable.tsx
+++ b/dotcom-rendering/src/components/TableOfContents.importable.tsx
@@ -20,6 +20,9 @@ const anchorStyles = css`
 	color: ${palette('--table-of-contents')};
 	text-decoration: none;
 	display: block;
+	width: 100%;
+	padding-bottom: ${space[4]}px;
+	padding-top: ${space[1]}px;
 `;
 
 const listItemStyles = (format: ArticleFormat) => {
@@ -29,8 +32,6 @@ const listItemStyles = (format: ArticleFormat) => {
 		${headline.xxxsmall({ fontWeight })};
 		box-sizing: border-box;
 		border-top: 1px solid ${palette('--table-of-contents-border')};
-		padding-bottom: ${space[4]}px;
-		padding-top: ${space[1]}px;
 		display: flex;
 		position: relative;
 


### PR DESCRIPTION
## What does this change?

- increases the size of the clickable area on Table of Contents links by moving the padding from the `li` to `a` and making the width of `a` the same as its parent element (100%).

## Why?

less fiddly to use!

## Screenshots

### Numbered list

| Before | After |
|--------|--------|
| ![Screen Shot 2024-04-16 at 11 48 34](https://github.com/guardian/dotcom-rendering/assets/705427/1eecea37-0dea-4804-a9dc-6109b81eb0f5) | ![Screen Shot 2024-04-16 at 11 49 29](https://github.com/guardian/dotcom-rendering/assets/705427/19b22a91-7a00-4ceb-8fa6-700206210ac9) |

### Before

https://github.com/guardian/dotcom-rendering/assets/705427/5ef36724-07a5-47e1-900b-e0dd547ee918

### After

https://github.com/guardian/dotcom-rendering/assets/705427/a71a0f7d-b3eb-421a-8d07-7cc55e840fcc
