### PR TITLE
Check total elements before showing separator line

### DIFF
--- a/dotcom-rendering/src/components/KeyTakeaways.stories.tsx
+++ b/dotcom-rendering/src/components/KeyTakeaways.stories.tsx
@@ -36,6 +36,7 @@ export const AllThemes = {
 				body: [testTextElement],
 			},
 		],
+		isLastElement: true,
 		/**
 		 * This will be replaced by the `formats` parameter, but it's
 		 * required by the type.

--- a/dotcom-rendering/src/components/KeyTakeaways.stories.tsx
+++ b/dotcom-rendering/src/components/KeyTakeaways.stories.tsx
@@ -1,3 +1,4 @@
+import { splitTheme } from '.storybook/decorators/splitThemeDecorator';
 import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
 import type { Meta, StoryObj } from '@storybook/react';
 import { centreColumnDecorator } from '../../.storybook/decorators/gridDecorators';

--- a/dotcom-rendering/src/components/KeyTakeaways.stories.tsx
+++ b/dotcom-rendering/src/components/KeyTakeaways.stories.tsx
@@ -1,4 +1,3 @@
-import { splitTheme } from '.storybook/decorators/splitThemeDecorator';
 import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
 import type { Meta, StoryObj } from '@storybook/react';
 import { centreColumnDecorator } from '../../.storybook/decorators/gridDecorators';
@@ -166,17 +165,11 @@ export const WithSeparatorLine = {
 	args: {
 		...AllThemes.args,
 		isLastElement: false,
+		format: {
+			design: ArticleDesign.Standard,
+			display: ArticleDisplay.Standard,
+			theme: Pillar.Culture,
+		},
 	},
-	decorators: [
-		splitTheme(
-			[
-				{
-					design: ArticleDesign.Standard,
-					display: ArticleDisplay.Standard,
-					theme: Pillar.Culture,
-				},
-			],
-			{ orientation: 'horizontal' },
-		),
-	],
+	decorators: [centreColumnDecorator],
 } satisfies Story;

--- a/dotcom-rendering/src/components/KeyTakeaways.stories.tsx
+++ b/dotcom-rendering/src/components/KeyTakeaways.stories.tsx
@@ -163,8 +163,7 @@ export const Images = {
 export const WithSeparatorLine = {
 	args: {
 		...AllThemes.args,
-		totalElements: 5,
-		index: 2,
+		isLastElement: false,
 	},
 	decorators: [
 		splitTheme(

--- a/dotcom-rendering/src/components/KeyTakeaways.stories.tsx
+++ b/dotcom-rendering/src/components/KeyTakeaways.stories.tsx
@@ -159,3 +159,23 @@ export const Images = {
 		},
 	},
 } satisfies Story;
+
+export const WithSeparatorLine = {
+	args: {
+		...AllThemes.args,
+		totalElements: 5,
+		index: 2,
+	},
+	decorators: [
+		splitTheme(
+			[
+				{
+					design: ArticleDesign.Standard,
+					display: ArticleDisplay.Standard,
+					theme: Pillar.Culture,
+				},
+			],
+			{ orientation: 'horizontal' },
+		),
+	],
+} satisfies Story;

--- a/dotcom-rendering/src/components/KeyTakeaways.tsx
+++ b/dotcom-rendering/src/components/KeyTakeaways.tsx
@@ -21,9 +21,11 @@ interface KeyTakeawaysProps {
 	starRating?: number;
 	keyTakeaways: KeyTakeaway[];
 	RenderArticleElement: ArticleElementRenderer;
+	totalElements?: number;
+	index?: number;
 }
 
-const finalLineStyles = css`
+const separatorStyles = css`
 	width: 140px;
 	margin: 8px 0 2px 0;
 	border-top: 1px solid ${palette.neutral[86]};
@@ -43,10 +45,13 @@ export const KeyTakeaways = ({
 	hideCaption,
 	starRating,
 	RenderArticleElement,
+	totalElements = 0,
+	index = 0,
 }: KeyTakeawaysProps) => {
+	const lastElement = totalElements <= index + 1;
 	return (
 		<ol data-ignore="global-ol-styling">
-			{keyTakeaways.map((keyTakeaway, index) => (
+			{keyTakeaways.map((keyTakeaway, i) => (
 				<KeyTakeawayComponent
 					keyTakeaway={keyTakeaway}
 					format={format}
@@ -58,14 +63,14 @@ export const KeyTakeaways = ({
 					switches={switches}
 					abTests={abTests}
 					editionId={editionId}
-					titleIndex={index + 1}
+					titleIndex={i + 1}
 					hideCaption={hideCaption}
 					starRating={starRating}
-					key={index}
+					key={i}
 					RenderArticleElement={RenderArticleElement}
 				/>
 			))}
-			<hr css={finalLineStyles} />
+			{!lastElement && <hr css={separatorStyles} />}
 		</ol>
 	);
 };

--- a/dotcom-rendering/src/components/KeyTakeaways.tsx
+++ b/dotcom-rendering/src/components/KeyTakeaways.tsx
@@ -21,7 +21,9 @@ interface KeyTakeawaysProps {
 	starRating?: number;
 	keyTakeaways: KeyTakeaway[];
 	RenderArticleElement: ArticleElementRenderer;
-	// is this the last element in the article?
+	/**
+	 * Whether this is the last element in the article. If true, no separator will be rendered.
+	 */
 	isLastElement: boolean;
 }
 

--- a/dotcom-rendering/src/components/KeyTakeaways.tsx
+++ b/dotcom-rendering/src/components/KeyTakeaways.tsx
@@ -49,7 +49,7 @@ export const KeyTakeaways = ({
 }: KeyTakeawaysProps) => {
 	return (
 		<ol data-ignore="global-ol-styling">
-			{keyTakeaways.map((keyTakeaway, i) => (
+			{keyTakeaways.map((keyTakeaway, index) => (
 				<KeyTakeawayComponent
 					keyTakeaway={keyTakeaway}
 					format={format}
@@ -61,10 +61,10 @@ export const KeyTakeaways = ({
 					switches={switches}
 					abTests={abTests}
 					editionId={editionId}
-					titleIndex={i + 1}
+					titleIndex={index + 1}
 					hideCaption={hideCaption}
 					starRating={starRating}
-					key={i}
+					key={index}
 					RenderArticleElement={RenderArticleElement}
 				/>
 			))}

--- a/dotcom-rendering/src/components/KeyTakeaways.tsx
+++ b/dotcom-rendering/src/components/KeyTakeaways.tsx
@@ -21,8 +21,8 @@ interface KeyTakeawaysProps {
 	starRating?: number;
 	keyTakeaways: KeyTakeaway[];
 	RenderArticleElement: ArticleElementRenderer;
-	totalElements?: number;
-	index?: number;
+	// is this the last element in the article?
+	isLastElement: boolean;
 }
 
 const separatorStyles = css`
@@ -45,10 +45,8 @@ export const KeyTakeaways = ({
 	hideCaption,
 	starRating,
 	RenderArticleElement,
-	totalElements = 0,
-	index = 0,
+	isLastElement,
 }: KeyTakeawaysProps) => {
-	const lastElement = totalElements <= index + 1;
 	return (
 		<ol data-ignore="global-ol-styling">
 			{keyTakeaways.map((keyTakeaway, i) => (
@@ -70,7 +68,7 @@ export const KeyTakeaways = ({
 					RenderArticleElement={RenderArticleElement}
 				/>
 			))}
-			{!lastElement && <hr css={separatorStyles} />}
+			{!isLastElement && <hr css={separatorStyles} />}
 		</ol>
 	);
 };

--- a/dotcom-rendering/src/lib/ArticleRenderer.tsx
+++ b/dotcom-rendering/src/lib/ArticleRenderer.tsx
@@ -66,6 +66,7 @@ export const ArticleRenderer = ({
 	abTests,
 	editionId,
 }: Props) => {
+	const totalElements = elements.length;
 	const renderedElements = elements.map((element, index) => {
 		return (
 			<RenderArticleElement
@@ -84,6 +85,7 @@ export const ArticleRenderer = ({
 				switches={switches}
 				abTests={abTests}
 				editionId={editionId}
+				totalElements={totalElements}
 			/>
 		);
 	});

--- a/dotcom-rendering/src/lib/ArticleRenderer.tsx
+++ b/dotcom-rendering/src/lib/ArticleRenderer.tsx
@@ -66,8 +66,7 @@ export const ArticleRenderer = ({
 	abTests,
 	editionId,
 }: Props) => {
-	const totalElements = elements.length;
-	const renderedElements = elements.map((element, index) => {
+	const renderedElements = elements.map((element, index, { length }) => {
 		return (
 			<RenderArticleElement
 				// eslint-disable-next-line react/no-array-index-key -- This is only rendered once so we can safely use index to suppress the warning
@@ -85,7 +84,7 @@ export const ArticleRenderer = ({
 				switches={switches}
 				abTests={abTests}
 				editionId={editionId}
-				totalElements={totalElements}
+				totalElements={length}
 			/>
 		);
 	});

--- a/dotcom-rendering/src/lib/renderElement.tsx
+++ b/dotcom-rendering/src/lib/renderElement.tsx
@@ -442,7 +442,7 @@ export const renderElement = ({
 					switches={switches}
 					editionId={editionId}
 					RenderArticleElement={RenderArticleElement}
-					isLastElement={index >= totalElements - 1}
+					isLastElement={index === totalElements - 1}
 				/>
 			);
 		case 'model.dotcomrendering.pageElements.MapBlockElement':

--- a/dotcom-rendering/src/lib/renderElement.tsx
+++ b/dotcom-rendering/src/lib/renderElement.tsx
@@ -89,6 +89,7 @@ type Props = {
 	editionId: EditionId;
 	forceDropCap?: 'on' | 'off';
 	isTimeline?: boolean;
+	totalElements?: number;
 };
 
 // updateRole modifies the role of an element in a way appropriate for most
@@ -146,6 +147,7 @@ export const renderElement = ({
 	editionId,
 	forceDropCap,
 	isTimeline = false,
+	totalElements,
 }: Props) => {
 	const isBlog =
 		format.design === ArticleDesign.LiveBlog ||
@@ -440,6 +442,8 @@ export const renderElement = ({
 					switches={switches}
 					editionId={editionId}
 					RenderArticleElement={RenderArticleElement}
+					totalElements={totalElements}
+					index={index}
 				/>
 			);
 		case 'model.dotcomrendering.pageElements.MapBlockElement':
@@ -867,6 +871,7 @@ export const RenderArticleElement = ({
 	editionId,
 	forceDropCap,
 	isTimeline,
+	totalElements,
 }: Props) => {
 	const withUpdatedRole = updateRole(element, format);
 
@@ -889,6 +894,7 @@ export const RenderArticleElement = ({
 		editionId,
 		forceDropCap,
 		isTimeline,
+		totalElements,
 	});
 
 	const needsFigure = !bareElements.has(element._type);

--- a/dotcom-rendering/src/lib/renderElement.tsx
+++ b/dotcom-rendering/src/lib/renderElement.tsx
@@ -147,7 +147,7 @@ export const renderElement = ({
 	editionId,
 	forceDropCap,
 	isTimeline = false,
-	totalElements,
+	totalElements = 0,
 }: Props) => {
 	const isBlog =
 		format.design === ArticleDesign.LiveBlog ||
@@ -442,8 +442,7 @@ export const renderElement = ({
 					switches={switches}
 					editionId={editionId}
 					RenderArticleElement={RenderArticleElement}
-					totalElements={totalElements}
-					index={index}
+					isLastElement={index >= totalElements - 1}
 				/>
 			);
 		case 'model.dotcomrendering.pageElements.MapBlockElement':


### PR DESCRIPTION
## What does this change?
Checks if the key takeaways element is the last element in the article. If it isn't, display the separator line at the end of the key takeaways element.

## Why?
This was requested by design.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/20416599/a7f5827f-61a4-4ebd-a489-15b5b0658445
[after]: https://github.com/guardian/dotcom-rendering/assets/20416599/3f7c1360-669a-44c0-ae3f-3fe997f3118c

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
