### PR TITLE
add base level support for updated header designs

### DIFF
--- a/dotcom-rendering/src/components/Header.tsx
+++ b/dotcom-rendering/src/components/Header.tsx
@@ -39,6 +39,8 @@ type Props = {
 	idApiUrl: string;
 	headerTopBarSearchCapiSwitch: boolean;
 	hasPageSkin?: boolean;
+	/** Shows header variant as part of AB test 'updated-header-design' */
+	showUpdatedDesign?: boolean;
 };
 
 export const Header = ({
@@ -52,6 +54,7 @@ export const Header = ({
 	idApiUrl,
 	headerTopBarSearchCapiSwitch,
 	hasPageSkin = false,
+	showUpdatedDesign = false,
 }: Props) => (
 	<div css={headerStyles} data-component="nav3">
 		<Island priority="critical">
@@ -68,6 +71,7 @@ export const Header = ({
 				idApiUrl={idApiUrl}
 				headerTopBarSearchCapiSwitch={headerTopBarSearchCapiSwitch}
 				hasPageSkin={hasPageSkin}
+				showUpdatedDesign={showUpdatedDesign}
 			/>
 		</Island>
 

--- a/dotcom-rendering/src/components/HeaderTopBar.importable.tsx
+++ b/dotcom-rendering/src/components/HeaderTopBar.importable.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { from, palette, space } from '@guardian/source-foundations';
+import { from, headline, palette, space } from '@guardian/source-foundations';
 import { pageSkinContainer } from '../layouts/lib/pageSkin';
 import { center } from '../lib/center';
 import type { EditionId } from '../lib/edition';
@@ -21,6 +21,7 @@ interface HeaderTopBarProps {
 	idApiUrl: string;
 	headerTopBarSearchCapiSwitch: boolean;
 	hasPageSkin?: boolean;
+	showUpdatedDesign?: boolean;
 }
 
 const topBarStylesUntilLeftCol = css`
@@ -70,10 +71,41 @@ export const HeaderTopBar = ({
 	idApiUrl,
 	headerTopBarSearchCapiSwitch,
 	hasPageSkin = false,
+	showUpdatedDesign = false,
 }: HeaderTopBarProps) => {
 	const authStatus = useAuthStatus();
 
-	return (
+	return showUpdatedDesign ? (
+		<div
+			css={[
+				css`
+					background-color: ${palette.brand[100]};
+				`,
+				topBarStylesUntilLeftCol,
+				!hasPageSkin && topBarStylesFromLeftCol,
+				hasPageSkin ? pageSkinContainer : center,
+			]}
+		>
+			{/** Support us message (from desktop only) */}
+			<span
+				css={css`
+					${headline.xxxsmall()}
+					color: ${palette.neutral[97]};
+					padding: ${space[1]}px;
+				`}
+			>
+				Support the Guardian
+			</span>
+
+			{/** Support us button */}
+
+			{/** Print subscriptions (from desktop only) */}
+
+			{/** Search jobs (from desktop only) */}
+
+			{/** Sign in / MMA */}
+		</div>
+	) : (
 		<div
 			css={css`
 				background-color: ${palette.brand[300]};

--- a/dotcom-rendering/src/components/HeaderTopBar.stories.tsx
+++ b/dotcom-rendering/src/components/HeaderTopBar.stories.tsx
@@ -1,22 +1,29 @@
+import type { Meta } from '@storybook/react';
 import { HeaderTopBar } from './HeaderTopBar.importable';
 
-export default {
+const meta = {
 	component: HeaderTopBar,
 	title: 'Components/HeaderTopBar',
+	render: (args) => <HeaderTopBar {...args} />,
+	args: {
+		editionId: 'UK',
+		dataLinkName: 'test',
+		discussionApiUrl: 'discussionApiUrl',
+		idUrl: 'idurl',
+		idApiUrl: 'idApiUrl',
+		mmaUrl: 'mmaUrl',
+		headerTopBarSearchCapiSwitch: false,
+		showUpdatedDesign: false,
+	},
+} satisfies Meta<typeof HeaderTopBar>;
+
+export default meta;
+
+export const defaultStory = {
+	name: 'Header top bar signed out',
 };
 
-export const defaultStory = () => {
-	return (
-		<HeaderTopBar
-			editionId="UK"
-			dataLinkName="test"
-			idUrl="idurl"
-			mmaUrl="mmaUrl"
-			discussionApiUrl="discussionApiUrl"
-			idApiUrl="idApiUrl"
-			headerTopBarSearchCapiSwitch={false}
-		/>
-	);
+export const redesignedTopBar = {
+	name: 'Header top bar signed out with redesign',
+	args: { showUpdatedDesign: true },
 };
-
-defaultStory.storyName = 'Header top bar signed out';

--- a/dotcom-rendering/src/layouts/AllEditorialNewslettersPageLayout.tsx
+++ b/dotcom-rendering/src/layouts/AllEditorialNewslettersPageLayout.tsx
@@ -88,6 +88,10 @@ export const AllEditorialNewslettersPageLayout = ({
 								!!newslettersPage.config.switches
 									.headerTopBarSearchCapi
 							}
+							showUpdatedDesign={
+								newslettersPage.config.abTests
+									.updatedHeaderDesignVariant === 'variant'
+							}
 						/>
 					</Section>
 					<Section

--- a/dotcom-rendering/src/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/layouts/CommentLayout.tsx
@@ -350,6 +350,11 @@ export const CommentLayout = (props: WebProps | AppsProps) => {
 										!!article.config.switches
 											.headerTopBarSearchCapi
 									}
+									showUpdatedDesign={
+										article.config.abTests
+											.updatedHeaderDesignVariant ===
+										'variant'
+									}
 								/>
 							</Section>
 						)}

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -213,6 +213,11 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 										.headerTopBarSearchCapi
 								}
 								hasPageSkin={hasPageSkin}
+								showUpdatedDesign={
+									front.config.abTests
+										.updatedHeaderDesignVariant ===
+									'variant'
+								}
 							/>
 						</Section>
 					)}

--- a/dotcom-rendering/src/layouts/FullPageInteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/FullPageInteractiveLayout.tsx
@@ -230,6 +230,10 @@ const NavHeader = ({ article, NAV, format }: Props) => {
 							headerTopBarSearchCapiSwitch={
 								!!article.config.switches.headerTopBarSearchCapi
 							}
+							showUpdatedDesign={
+								article.config.abTests
+									.updatedHeaderDesignVariant === 'variant'
+							}
 						/>
 					</Section>
 				</div>

--- a/dotcom-rendering/src/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/InteractiveLayout.tsx
@@ -293,6 +293,11 @@ export const InteractiveLayout = (props: WebProps | AppsProps) => {
 											!!article.config.switches
 												.headerTopBarSearchCapi
 										}
+										showUpdatedDesign={
+											article.config.abTests
+												.updatedHeaderDesignVariant ===
+											'variant'
+										}
 									/>
 								</Section>
 							</div>

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -358,6 +358,11 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 									!!article.config.switches
 										.headerTopBarSearchCapi
 								}
+								showUpdatedDesign={
+									article.config.abTests
+										.updatedHeaderDesignVariant ===
+									'variant'
+								}
 							/>
 						</Section>
 

--- a/dotcom-rendering/src/layouts/NewsletterSignupLayout.tsx
+++ b/dotcom-rendering/src/layouts/NewsletterSignupLayout.tsx
@@ -249,6 +249,10 @@ export const NewsletterSignupLayout = ({ article, NAV, format }: Props) => {
 						headerTopBarSearchCapiSwitch={
 							!!article.config.switches.headerTopBarSearchCapi
 						}
+						showUpdatedDesign={
+							article.config.abTests
+								.updatedHeaderDesignVariant === 'variant'
+						}
 					/>
 				</Section>
 

--- a/dotcom-rendering/src/layouts/PictureLayout.tsx
+++ b/dotcom-rendering/src/layouts/PictureLayout.tsx
@@ -330,6 +330,11 @@ export const PictureLayout = (props: WebProps | AppsProps) => {
 									!!article.config.switches
 										.headerTopBarSearchCapi
 								}
+								showUpdatedDesign={
+									article.config.abTests
+										.updatedHeaderDesignVariant ===
+									'variant'
+								}
 							/>
 						</Section>
 						<Section

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -300,6 +300,11 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 												!!article.config.switches
 													.headerTopBarSearchCapi
 											}
+											showUpdatedDesign={
+												article.config.abTests
+													.updatedHeaderDesignVariant ===
+												'variant'
+											}
 										/>
 									</Section>
 									<Section

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -383,6 +383,11 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 									!!article.config.switches
 										.headerTopBarSearchCapi
 								}
+								showUpdatedDesign={
+									article.config.abTests
+										.updatedHeaderDesignVariant ===
+									'variant'
+								}
 							/>
 						</Section>
 					)}

--- a/dotcom-rendering/src/layouts/TagPageLayout.tsx
+++ b/dotcom-rendering/src/layouts/TagPageLayout.tsx
@@ -110,6 +110,10 @@ export const TagPageLayout = ({ tagPage, NAV }: Props) => {
 							headerTopBarSearchCapiSwitch={
 								!!switches.headerTopBarSearchCapi
 							}
+							showUpdatedDesign={
+								tagPage.config.abTests
+									.updatedHeaderDesignVariant === 'variant'
+							}
 						/>
 					</Section>
 					<Section


### PR DESCRIPTION
## What does this change?

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
