### PR TITLE
Refactor bridget comment response parsing

### DIFF
--- a/dotcom-rendering/src/components/DiscussionApps.importable.tsx
+++ b/dotcom-rendering/src/components/DiscussionApps.importable.tsx
@@ -30,17 +30,7 @@ const onComment = async (
 				return error('ApiError');
 			}
 
-			if (apiResponse.response.status === 'error') {
-				return parseCommentResponse({
-					status: apiResponse.response.status,
-					errorCode: apiResponse.response.errorCode,
-				});
-			}
-
-			return parseCommentResponse({
-				status: apiResponse.response.status,
-				message: apiResponse.response.message,
-			});
+			return parseCommentResponse(apiResponse.response);
 		});
 
 const onReply = async (
@@ -58,18 +48,7 @@ const onReply = async (
 				return error('ApiError');
 			}
 
-			if (apiResponse.response.status === 'error') {
-				return parseCommentResponse({
-					status: apiResponse.response.status,
-					errorCode: apiResponse.response.errorCode,
-				});
-			}
-
-			const parsedResponse = parseCommentResponse({
-				status: apiResponse.response.status,
-				message: apiResponse.response.message,
-			});
-			return parsedResponse;
+			return parseCommentResponse(apiResponse.response);
 		});
 
 const onRecommend = async (commentId: string): Promise<boolean> => {


### PR DESCRIPTION
## What does this change?

Less ternaries, let the parser handle it

## Why?

Less code, follow-up on https://github.com/guardian/dotcom-rendering/pull/11133#discussion_r1565979911