### PR TITLE
(potentially) adapt the site for everyone

### DIFF
--- a/dotcom-rendering/src/client/adaptiveSite.ts
+++ b/dotcom-rendering/src/client/adaptiveSite.ts
@@ -12,6 +12,7 @@ import { recordExperiences } from './ophan/ophan';
  */
 export const shouldAdapt = async (): Promise<boolean> => {
 	if (isServer) return false;
+	if (window.location.hash === '#adapt') return true;
 
 	// only evaluate this code if we want to adapt in response to page performance
 	const { isPerformingPoorly } = await import(

--- a/dotcom-rendering/src/client/adaptiveSite.ts
+++ b/dotcom-rendering/src/client/adaptiveSite.ts
@@ -32,7 +32,7 @@ const recordAdaptedSite = (renderingTarget: RenderingTarget) =>
 	recordExperiences(renderingTarget, ['adapted']);
 
 export const adaptSite = (renderingTarget: RenderingTarget): void => {
-	log('openJournalism', '🎛️ Adapting');
+	log('dotcom', '🎛️ Adapting');
 
 	// disable all tasks except critical ones
 	setSchedulerPriorityLastStartTime('feature', 0);

--- a/dotcom-rendering/src/client/adaptiveSite.ts
+++ b/dotcom-rendering/src/client/adaptiveSite.ts
@@ -12,10 +12,6 @@ import { recordExperiences } from './ophan/ophan';
  */
 export const shouldAdapt = async (): Promise<boolean> => {
 	if (isServer) return false;
-	if (window.location.hash === '#adapt') return true;
-	if (window.guardian.config.tests.adaptiveSiteVariant !== 'variant') {
-		return false;
-	}
 
 	// only evaluate this code if we want to adapt in response to page performance
 	const { isPerformingPoorly } = await import(

--- a/dotcom-rendering/src/client/poorPerformanceMonitoring.ts
+++ b/dotcom-rendering/src/client/poorPerformanceMonitoring.ts
@@ -3,7 +3,7 @@ import type { RenderingTarget } from '../types/renderingTarget';
 import { recordExperiences } from './ophan/ophan';
 
 const logPerformanceInfo = (name: string, data?: unknown) =>
-	log('openJournalism', '⏱', name, data);
+	log('dotcom', '⏱', name, data);
 
 /**
  * @see https://developer.mozilla.org/en-US/docs/Glossary/First_contentful_paint
@@ -77,7 +77,7 @@ export const recordPoorPerformance = async (
 ): Promise<void> => {
 	try {
 		if (await isPerformingPoorly()) {
-			log('openJournalism', `🐌 Poor page performance`);
+			log('dotcom', `🐌 Poor page performance`);
 			return recordExperiences(renderingTarget, [
 				'poor-page-performance',
 			]);

--- a/dotcom-rendering/src/client/sentryLoader/loadSentry.ts
+++ b/dotcom-rendering/src/client/sentryLoader/loadSentry.ts
@@ -65,10 +65,7 @@ const loadSentryOnError = (): void => {
 				const queuedError = queue.shift();
 				if (queuedError) reportError(queuedError);
 			}
-			log(
-				'openJournalism',
-				`Injected Sentry in ${endPerformanceMeasure()}ms`,
-			);
+			log('dotcom', `Injected Sentry in ${endPerformanceMeasure()}ms`);
 		};
 
 		// This is how we lazy load Sentry. We setup custom functions and


### PR DESCRIPTION
## What does this change?

removes the test condition for adaptation (#8404), making adaptation a permanent fixture.

## Why?

Following the work of the @guardian/open-journalism team, @mxdvl and I have been running a test which [found](https://docs.google.com/spreadsheets/d/1w1bkcEIYaNir9hkTZhcsm4HA0RK7YJlT8Y24dnfgg80/edit#gid=0) that on a poorly performing page view ([FCP >= 2000ms and TTFB >= 1200ms](https://github.com/guardian/dotcom-rendering/blob/d408fb738c4832f88d4367164e43872f62b7dd00/dotcom-rendering/src/client/poorPerformanceMonitoring.ts#L69-L72)), adapting the site increased the likelihood of a subsequent page view:

<table>
<tr>
 <th>Subsequent PV within...
 <th>Increased likelihood
<tr>
 <td>5 mins
 <td>3.27%
<tr>
 <td>10 mins
 <td>2.72%
<tr>
 <td>30 mins (same session)
 <td>2.45%
<tr>
 <td>1 hour
 <td>2.41%
<tr>
 <td>24 hours
 <td>2.13%
</table>

The test has been running for 1% of users since #9024 (oct 23) without issue, and the results are good, so we want to make it permanent...

fyi @jon-kearnesLC

