### PR TITLE
Remove Facebook and Twitter links from mobile navigation menu

### DIFF
--- a/dotcom-rendering/src/components/Nav/ExpandedMenu/MoreColumn.tsx
+++ b/dotcom-rendering/src/components/Nav/ExpandedMenu/MoreColumn.tsx
@@ -5,11 +5,8 @@ import {
 	palette as sourcePalette,
 	textSans,
 } from '@guardian/source-foundations';
-import { Hide } from '@guardian/source-react-components';
 import { nestedOphanComponents } from '../../../lib/ophan-helpers';
 import type { LinkType } from '../../../model/extract-nav';
-import FacebookIcon from '../../../static/icons/facebook.svg';
-import TwitterIconPadded from '../../../static/icons/twitter-padded.svg';
 
 const pillarHeight = 42;
 
@@ -168,15 +165,6 @@ const mainMenuLinkStyle = css`
 	}
 `;
 
-const shareIconStyles = css`
-	fill: currentColor;
-	height: 28px;
-	left: 18px;
-	position: absolute;
-	top: 5px;
-	width: 28px;
-`;
-
 type Props = {
 	otherLinks: LinkType[];
 	brandExtensions: LinkType[];
@@ -238,59 +226,6 @@ export const MoreColumn = ({
 					))}
 				</ul>
 			</li>
-			{/** Social buttons hidden from menus from desktop */}
-			<Hide from="desktop">
-				<li
-					css={[columnStyle, !hasPageSkin && columnStyleFromLeftCol]}
-					role="none"
-				>
-					<ul css={[columnLinks]} role="menu">
-						<li
-							key="facebook"
-							css={[mainMenuLinkStyle, hideDesktop]}
-							role="none"
-						>
-							<a
-								className="selectableMenuItem"
-								css={columnLinkTitle}
-								data-link-name={nestedOphanComponents(
-									'nav2',
-									'secondary',
-									'facebook',
-								)}
-								href="https://www.facebook.com/theguardian"
-								role="menuitem"
-								tabIndex={-1}
-							>
-								<FacebookIcon css={shareIconStyles} />
-								Facebook
-							</a>
-						</li>
-
-						<li
-							key="twitter"
-							css={[mainMenuLinkStyle, hideDesktop]}
-							role="none"
-						>
-							<a
-								className="selectableMenuItem"
-								css={columnLinkTitle}
-								data-link-name={nestedOphanComponents(
-									'nav2',
-									'secondary',
-									'twitter',
-								)}
-								href="https://twitter.com/guardian"
-								role="menuitem"
-								tabIndex={-1}
-							>
-								<TwitterIconPadded css={shareIconStyles} />
-								Twitter
-							</a>
-						</li>
-					</ul>
-				</li>
-			</Hide>
 		</>
 	);
 };


### PR DESCRIPTION
## What does this change?

Removes the Facebook and Twitter links from the navigation menu on mobile viewports

## Why?

We [replaced share icons across the site](https://github.com/guardian/dotcom-rendering/pull/10422) recently for articles and live blogs but this may have been missed

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/43961396/e790b32e-012a-4c5b-b5d5-425193ee7434
[after]: https://github.com/guardian/dotcom-rendering/assets/43961396/d35e2542-9cfa-48d0-b8ba-ffa51a40f141


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
