### PR TITLE
Treat Discussion responses as opaque JSON string while in flight via Briget

### DIFF
--- a/dotcom-rendering/.storybook/mocks/bridgetApi.ts
+++ b/dotcom-rendering/.storybook/mocks/bridgetApi.ts
@@ -1,9 +1,8 @@
 import { DiscussionNativeError } from '@guardian/bridget/DiscussionNativeError';
 import {
-	DiscussionResponse,
-	DiscussionResponseType,
-} from '@guardian/bridget/DiscussionResponse';
-import { GetUserProfileResponseType } from '@guardian/bridget/GetUserProfileResponse';
+	DiscussionServiceResponse,
+	DiscussionServiceResponseType,
+} from '@guardian/bridget/DiscussionServiceResponse';
 
 type BridgeModule = typeof import('../../src/lib/bridgetApi');
 
@@ -72,15 +71,15 @@ export const getTagClient: BridgetApi<'getTagClient'> = () => ({
 });
 
 const discussionErrorResponse = {
-	__type: DiscussionResponseType.DiscussionResponseWithError,
+	__type: DiscussionServiceResponseType.DiscussionServiceResponseWithError,
 	error: DiscussionNativeError.UNKNOWN_ERROR,
-} satisfies DiscussionResponse;
+} satisfies DiscussionServiceResponse;
 
 export const getDiscussionClient: BridgetApi<'getDiscussionClient'> = () => ({
 	comment: async () => discussionErrorResponse,
 	reply: async () => discussionErrorResponse,
 	getUserProfile: async () => ({
-		__type: GetUserProfileResponseType.GetUserProfileResponseWithError,
+		__type: DiscussionServiceResponseType.DiscussionServiceResponseWithError,
 		error: DiscussionNativeError.UNKNOWN_ERROR,
 	}),
 	recommend: async () => discussionErrorResponse,

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -45,7 +45,7 @@
 		"@emotion/server": "11.11.0",
 		"@guardian/ab-core": "7.0.1",
 		"@guardian/braze-components": "18.1.0",
-		"@guardian/bridget": "5.0.0",
+		"@guardian/bridget": "0.0.0-2024-04-16-snapshot-1",
 		"@guardian/browserslist-config": "6.1.0",
 		"@guardian/cdk": "50.13.0",
 		"@guardian/commercial": "17.9.0",

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -45,7 +45,7 @@
 		"@emotion/server": "11.11.0",
 		"@guardian/ab-core": "7.0.1",
 		"@guardian/braze-components": "18.1.0",
-		"@guardian/bridget": "0.0.0-2024-04-16-snapshot-1",
+		"@guardian/bridget": "6.0.0",
 		"@guardian/browserslist-config": "6.1.0",
 		"@guardian/cdk": "50.13.0",
 		"@guardian/commercial": "17.9.0",

--- a/dotcom-rendering/src/components/DiscussionApps.importable.tsx
+++ b/dotcom-rendering/src/components/DiscussionApps.importable.tsx
@@ -30,17 +30,7 @@ const onComment = async (
 				return error('ApiError');
 			}
 
-			if (apiResponse.response.status === 'error') {
-				return parseCommentResponse({
-					status: apiResponse.response.status,
-					errorCode: apiResponse.response.errorCode,
-				});
-			}
-
-			return parseCommentResponse({
-				status: apiResponse.response.status,
-				message: apiResponse.response.message,
-			});
+			return parseCommentResponse(apiResponse.response);
 		});
 
 const onReply = async (
@@ -58,18 +48,7 @@ const onReply = async (
 				return error('ApiError');
 			}
 
-			if (apiResponse.response.status === 'error') {
-				return parseCommentResponse({
-					status: apiResponse.response.status,
-					errorCode: apiResponse.response.errorCode,
-				});
-			}
-
-			const parsedResponse = parseCommentResponse({
-				status: apiResponse.response.status,
-				message: apiResponse.response.message,
-			});
-			return parsedResponse;
+			return parseCommentResponse(apiResponse.response);
 		});
 
 const onRecommend = async (commentId: string): Promise<boolean> => {

--- a/dotcom-rendering/src/components/DiscussionApps.importable.tsx
+++ b/dotcom-rendering/src/components/DiscussionApps.importable.tsx
@@ -29,7 +29,16 @@ const onComment = async (
 				return error('ApiError');
 			}
 
-			return parseCommentResponse(apiResponse.response);
+			const result = parseCommentResponse(
+				JSON.parse(apiResponse.response),
+			);
+			if (result.kind === 'error') {
+				window.guardian.modules.sentry.reportError(
+					Error(`Failed parseCommentResponse: ${result.error}`),
+					'discussion',
+				);
+			}
+			return result;
 		});
 
 const onReply = async (
@@ -47,7 +56,16 @@ const onReply = async (
 				return error('ApiError');
 			}
 
-			return parseCommentResponse(JSON.parse(apiResponse.response));
+			const result = parseCommentResponse(
+				JSON.parse(apiResponse.response),
+			);
+			if (result.kind === 'error') {
+				window.guardian.modules.sentry.reportError(
+					Error(`Failed parseCommentResponse: ${result.error}`),
+					'discussion',
+				);
+			}
+			return result;
 		});
 
 const onRecommend = async (commentId: string): Promise<boolean> => {

--- a/dotcom-rendering/src/components/DiscussionApps.importable.tsx
+++ b/dotcom-rendering/src/components/DiscussionApps.importable.tsx
@@ -6,7 +6,7 @@ import {
 	parseCommentResponse,
 	parseUserProfile,
 	type Reader,
-	recommmendResponseSchema,
+	recommendResponseSchema,
 } from '../lib/discussion';
 import type { CommentResponse } from '../lib/discussionApi';
 import { reportAbuse as reportAbuseWeb } from '../lib/discussionApi';
@@ -81,7 +81,7 @@ const onRecommend = async (commentId: string): Promise<boolean> => {
 			}
 
 			return safeParse(
-				recommmendResponseSchema,
+				recommendResponseSchema,
 				JSON.parse(discussionApiResponse.response),
 			).success;
 		});

--- a/dotcom-rendering/src/lib/discussion.ts
+++ b/dotcom-rendering/src/lib/discussion.ts
@@ -73,6 +73,16 @@ export interface UserProfile {
 	};
 }
 
+export const parseUserProfile = (
+	data: unknown,
+): Result<'ParsingError', UserProfile> => {
+	const result = safeParse(userProfile, data);
+	if (!result.success) {
+		return error('ParsingError');
+	}
+	return ok(result.output);
+};
+
 const baseCommentSchema = object({
 	id: transform(union([number(), string()]), (id) => id.toString()),
 	body: string(),

--- a/dotcom-rendering/src/lib/discussion.ts
+++ b/dotcom-rendering/src/lib/discussion.ts
@@ -76,11 +76,14 @@ export interface UserProfile {
 export const parseUserProfile = (
 	data: unknown,
 ): Result<'ParsingError', UserProfile> => {
-	const result = safeParse(userProfile, data);
+	const result = safeParse(
+		object({ status: literal('ok'), userProfile }),
+		data,
+	);
 	if (!result.success) {
 		return error('ParsingError');
 	}
-	return ok(result.output);
+	return ok(result.output.userProfile);
 };
 
 const baseCommentSchema = object({

--- a/dotcom-rendering/src/lib/discussion.ts
+++ b/dotcom-rendering/src/lib/discussion.ts
@@ -342,6 +342,11 @@ export const pickResponseSchema = object({
 	message: string(),
 });
 
+export const recommmendResponseSchema = object({
+	status: literal('ok'),
+	statusCode: literal(200),
+});
+
 export type CommentFormProps = {
 	userNameMissing: boolean;
 	error: string;

--- a/dotcom-rendering/src/lib/discussion.ts
+++ b/dotcom-rendering/src/lib/discussion.ts
@@ -345,7 +345,7 @@ export const pickResponseSchema = object({
 	message: string(),
 });
 
-export const recommmendResponseSchema = object({
+export const recommendResponseSchema = object({
 	status: literal('ok'),
 	statusCode: literal(200),
 });

--- a/dotcom-rendering/src/lib/discussionApi.tsx
+++ b/dotcom-rendering/src/lib/discussionApi.tsx
@@ -16,7 +16,7 @@ import {
 	parseRepliesResponse,
 	pickResponseSchema,
 	postUsernameResponseSchema,
-	recommmendResponseSchema,
+	recommendResponseSchema,
 } from './discussion';
 import type { CommentContextType } from './discussionFilters';
 import type { SignedInWithCookies, SignedInWithOkta } from './identity';
@@ -322,7 +322,7 @@ export const recommend =
 		});
 
 		if (jsonResult.kind === 'error') return false;
-		return safeParse(recommmendResponseSchema, jsonResult.value).success;
+		return safeParse(recommendResponseSchema, jsonResult.value).success;
 	};
 
 export const addUserName =

--- a/dotcom-rendering/src/lib/discussionApi.tsx
+++ b/dotcom-rendering/src/lib/discussionApi.tsx
@@ -16,6 +16,7 @@ import {
 	parseRepliesResponse,
 	pickResponseSchema,
 	postUsernameResponseSchema,
+	recommmendResponseSchema,
 } from './discussion';
 import type { CommentContextType } from './discussionFilters';
 import type { SignedInWithCookies, SignedInWithOkta } from './identity';
@@ -309,7 +310,7 @@ export const recommend =
 
 		const authOptions = getOptionsHeadersWithOkta(authStatus);
 
-		return fetch(url, {
+		const jsonResult = await fetchJSON(url, {
 			method: 'POST',
 			headers: {
 				...options.headers,
@@ -318,7 +319,10 @@ export const recommend =
 					: {}),
 			},
 			credentials: authOptions.credentials,
-		}).then((resp) => resp.ok);
+		});
+
+		if (jsonResult.kind === 'error') return false;
+		return safeParse(recommmendResponseSchema, jsonResult.value).success;
 	};
 
 export const addUserName =

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -345,8 +345,8 @@ importers:
         specifier: 18.1.0
         version: 18.1.0(@emotion/react@11.11.1)(@guardian/libs@16.1.0)(@guardian/source-foundations@14.1.4)(@guardian/source-react-components-development-kitchen@19.0.0)(@guardian/source-react-components@22.0.1)(react@18.2.0)
       '@guardian/bridget':
-        specifier: 5.0.0
-        version: 5.0.0
+        specifier: 6.0.0
+        version: 6.0.0
       '@guardian/browserslist-config':
         specifier: 6.1.0
         version: 6.1.0(browserslist@4.21.9)(tslib@2.6.2)
@@ -4271,8 +4271,8 @@ packages:
     resolution: {integrity: sha512-kYlRZC5/9ImY2wQJfnteanjfLclmSU0wcsyt2CWl5YXHmc3gGnxZM+H/Y6KVqwxj0v5cGrvUuFJ7Zvk570dchQ==}
     dev: false
 
-  /@guardian/bridget@5.0.0:
-    resolution: {integrity: sha512-1rbKmdPAdEiBco1Mt/YKJ3J+JQ/e346mXdQVPm4xAWzxrb7jvH+HO4afQqqGE01h0ruV5spGCkcuTWINjbA9MA==}
+  /@guardian/bridget@6.0.0:
+    resolution: {integrity: sha512-aiRVLDF/UfNYeoF10ptBDs52Fv1T4sd19uKACTZSr1uMgV2BPmzG+/BiVLi8Q9/6gjS+CTP3Covz62liksAFuQ==}
     dev: false
 
   /@guardian/browserslist-config@6.1.0(browserslist@4.21.9)(tslib@2.6.2):


### PR DESCRIPTION
## What does this change?

- Parse responses in the DCAR always, for Web & Apps

## Why?

See https://github.com/guardian/bridget/pull/154

- Simplify the Bridget API
- Narrower types