### PR TITLE
Refactor timeline stories to make use of chromatic modes and decorators

### DIFF
--- a/dotcom-rendering/src/components/Timeline.stories.tsx
+++ b/dotcom-rendering/src/components/Timeline.stories.tsx
@@ -1,11 +1,12 @@
 import {
 	ArticleDesign,
 	ArticleDisplay,
-	type ArticleFormat,
 	Pillar,
+	type ArticleFormat,
 } from '@guardian/libs';
 import type { Meta, StoryObj } from '@storybook/react';
-import { splitTheme } from '../../.storybook/decorators/splitThemeDecorator';
+import { centreColumnDecorator } from '../../.storybook/decorators/gridDecorators';
+import { allModes } from '../../.storybook/modes';
 import { images } from '../../fixtures/generated/images';
 import { getNestedArticleElement } from '../lib/renderElement';
 import type { TextBlockElement, YoutubeBlockElement } from '../types/content';
@@ -20,7 +21,14 @@ const format: ArticleFormat = {
 const meta = {
 	component: Timeline,
 	title: 'Components/Timeline',
-	decorators: [splitTheme([format], { orientation: 'vertical' })],
+	parameters: {
+		chromatic: {
+			modes: {
+				vertical: allModes.sideBySideVertical,
+			},
+		},
+	},
+	decorators: [centreColumnDecorator],
 } satisfies Meta<typeof Timeline>;
 
 export default meta;

--- a/dotcom-rendering/src/components/Timeline.stories.tsx
+++ b/dotcom-rendering/src/components/Timeline.stories.tsx
@@ -1,9 +1,5 @@
-import {
-	ArticleDesign,
-	ArticleDisplay,
-	Pillar,
-	type ArticleFormat,
-} from '@guardian/libs';
+import type { ArticleFormat } from '@guardian/libs';
+import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
 import type { Meta, StoryObj } from '@storybook/react';
 import { centreColumnDecorator } from '../../.storybook/decorators/gridDecorators';
 import { allModes } from '../../.storybook/modes';


### PR DESCRIPTION
## What does this change?
Updates the timeline element stories to make use of the new guardian grid decorator as well as chromatic modes


Co-authored-by: @JamieB-gu 
Co-authored-by: @domlander 