### PR TITLE
Wrap `CommentForm` buttons when overflowing

### DIFF
--- a/dotcom-rendering/src/components/Discussion/CommentForm.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentForm.tsx
@@ -508,7 +508,7 @@ export const CommentForm = ({
 					error={error}
 				/>
 				<div css={bottomContainer}>
-					<Row>
+					<Row wrap={true}>
 						<>
 							<PillarButton
 								type="submit"
@@ -543,7 +543,7 @@ export const CommentForm = ({
 						</>
 					</Row>
 					{isActive && (
-						<Row>
+						<Row wrap={true}>
 							<button
 								onClick={(e) => {
 									e.preventDefault();

--- a/dotcom-rendering/src/components/Discussion/Row.tsx
+++ b/dotcom-rendering/src/components/Discussion/Row.tsx
@@ -2,6 +2,7 @@ import { css, type SerializedStyles } from '@emotion/react';
 
 type Props = {
 	children: React.ReactNode;
+	wrap?: boolean;
 	cssOverrides?: SerializedStyles | SerializedStyles[];
 };
 
@@ -10,6 +11,11 @@ const rowStyles = css`
 	flex-direction: row;
 `;
 
-export const Row = ({ children, cssOverrides }: Props) => (
-	<div css={[rowStyles, cssOverrides]}>{children}</div>
+export const Row = ({ children, wrap = false, cssOverrides }: Props) => (
+	<div
+		css={[rowStyles, cssOverrides]}
+		style={{ flexWrap: wrap ? 'wrap' : undefined }}
+	>
+		{children}
+	</div>
 );


### PR DESCRIPTION
## What does this change?

Add a `wrap` option to the `Row` component

## Why?

The `CommentForm` buttons overflow on smaller viewports, causing the page to gain horizontal scroll and preventing access to some features.

Still broken despite #10335

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/76776/8046f613-daaf-48df-8c1f-aedb1131ff59
[after]: https://github.com/guardian/dotcom-rendering/assets/76776/258b042f-5bd3-4b67-812f-78b7f1faabe0
