### PR TITLE
Fix banner playwright test

### DIFF
--- a/dotcom-rendering/playwright/tests/banner.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/banner.e2e.spec.ts
@@ -1,6 +1,6 @@
 import type { BrowserContext, Request } from '@playwright/test';
 import { test } from '@playwright/test';
-import { disableCMP } from '../lib/cmp';
+import { cmpAcceptAll } from '../lib/cmp';
 import { addCookie } from '../lib/cookies';
 import { loadPage } from '../lib/load-page';
 
@@ -29,7 +29,6 @@ test.describe('The banner', function () {
 		page,
 		context,
 	}) => {
-		await disableCMP(context);
 		await optOutOfArticleCountConsent(context);
 		const rrBannerUrl = 'https://contributions.guardianapis.com/banner';
 
@@ -47,6 +46,7 @@ test.describe('The banner', function () {
 			'GB',
 			false,
 		);
+		await cmpAcceptAll(page);
 
 		await rrBannerRequestPromise;
 	});


### PR DESCRIPTION
this allows the new consent check logic to happen during the playwright run