### PR TITLE
Stop considering aborted in-flight request as network errors

### DIFF
--- a/dotcom-rendering/src/components/Discussion.tsx
+++ b/dotcom-rendering/src/components/Discussion.tsx
@@ -389,7 +389,9 @@ export const Discussion = ({
 		})
 			.then((result) => {
 				if (result.kind === 'error') {
-					console.error(`getDiscussion - error: ${result.error}`);
+					if (result.error !== 'AbortedSignal') {
+						console.error(`getDiscussion - error: ${result.error}`);
+					}
 					return;
 				}
 

--- a/dotcom-rendering/src/lib/discussionApi.tsx
+++ b/dotcom-rendering/src/lib/discussionApi.tsx
@@ -67,7 +67,11 @@ const objAsParams = (obj: any): string => {
 	return '?' + params;
 };
 
-type GetDiscussionError = 'ParsingError' | 'ApiError' | 'NetworkError';
+type GetDiscussionError =
+	| 'ParsingError'
+	| 'ApiError'
+	| 'NetworkError'
+	| 'AbortedSignal';
 
 //todo: figure out the different return types and consider error handling
 export const getDiscussion = async ({
@@ -105,7 +109,9 @@ export const getDiscussion = async ({
 		signal,
 	});
 
-	if (jsonResult.kind === 'error') return jsonResult;
+	if (jsonResult.kind === 'error') {
+		return signal.aborted ? error('AbortedSignal') : jsonResult;
+	}
 
 	const result = safeParse(discussionApiResponseSchema, jsonResult.value);
 	if (!result.success) {


### PR DESCRIPTION
## What does this change?

Stop showing a purposfully aborted request as a “network error”.

## Why?

This intentional behaviour could cause confusion for someone looking at the console.

Follow-up on #10503 

## Screenshots

Picture this: you are staring at an empty console log; the evening sun gently shines on your shoulders; you are at peace with the universe. ✌️ 