### PR TITLE
Add canonical links for Fronts and Tag Pages

### DIFF
--- a/dotcom-rendering/src/model/front-schema.json
+++ b/dotcom-rendering/src/model/front-schema.json
@@ -380,6 +380,9 @@
         },
         "contributionsServiceUrl": {
             "type": "string"
+        },
+        "canonicalUrl": {
+            "type": "string"
         }
     },
     "required": [

--- a/dotcom-rendering/src/model/tag-page-schema.json
+++ b/dotcom-rendering/src/model/tag-page-schema.json
@@ -1185,6 +1185,9 @@
         },
         "forceDay": {
             "type": "boolean"
+        },
+        "canonicalUrl": {
+            "type": "string"
         }
     },
     "required": [

--- a/dotcom-rendering/src/server/handler.front.web.ts
+++ b/dotcom-rendering/src/server/handler.front.web.ts
@@ -106,6 +106,7 @@ const enhanceTagPage = (body: unknown): DCRTagPageType => {
 			image: data.tags.tags[0]?.properties.bylineImageUrl,
 		},
 		branding: tagPageBranding,
+		canonicalUrl: data.canonicalUrl,
 	};
 };
 

--- a/dotcom-rendering/src/server/handler.front.web.ts
+++ b/dotcom-rendering/src/server/handler.front.web.ts
@@ -47,6 +47,7 @@ const enhanceFront = (body: unknown): DCRFrontType => {
 			data.pageId,
 		),
 		deeplyRead: data.deeplyRead?.map((trail) => decideTrail(trail)),
+		canonicalUrl: data.canonicalUrl,
 	};
 };
 

--- a/dotcom-rendering/src/server/render.front.web.tsx
+++ b/dotcom-rendering/src/server/render.front.web.tsx
@@ -236,6 +236,7 @@ export const renderTagPage = ({
 		keywords,
 		renderingTarget: 'Web',
 		weAreHiring: !!tagPage.config.switches.weAreHiring,
+		canonicalUrl: tagPage.canonicalUrl,
 	});
 	return {
 		html: pageHtml,

--- a/dotcom-rendering/src/server/render.front.web.tsx
+++ b/dotcom-rendering/src/server/render.front.web.tsx
@@ -149,6 +149,7 @@ export const renderFront = ({
 		renderingTarget: 'Web',
 		hasPageSkin: front.config.hasPageSkin,
 		weAreHiring: !!front.config.switches.weAreHiring,
+		canonicalUrl: front.canonicalUrl,
 	});
 
 	return {

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -27,6 +27,7 @@ export interface FEFrontType {
 	mostViewed: FETrailType[];
 	deeplyRead?: FETrailType[];
 	contributionsServiceUrl: string;
+	canonicalUrl?: string;
 }
 
 export interface DCRFrontType {
@@ -42,6 +43,7 @@ export interface DCRFrontType {
 	deeplyRead?: TrailType[];
 	trendingTopics?: FETagType[];
 	contributionsServiceUrl: string;
+	canonicalUrl?: string;
 }
 
 interface FEPressedPageType {

--- a/dotcom-rendering/src/types/tagPage.ts
+++ b/dotcom-rendering/src/types/tagPage.ts
@@ -24,6 +24,7 @@ export interface FETagPageType {
 	pageFooter: FooterType;
 	isAdFreeUser: boolean;
 	forceDay: boolean;
+	canonicalUrl?: string;
 }
 
 /**
@@ -77,6 +78,7 @@ export interface DCRTagPageType {
 		image?: string;
 	};
 	branding: CollectionBranding | undefined;
+	canonicalUrl?: string;
 }
 
 export interface DCRFrontPagination {


### PR DESCRIPTION
## What does this change?

Following https://github.com/guardian/frontend/pull/27060 add canonical links to Fronts and Tag Pages

## Why?

To ensure search engine crawlers can determine the correct canonical pages when following redirects or to distinguish from duplicate pages

