### PR TITLE
Fix full width ads in top-above-nav

### DIFF
--- a/dotcom-rendering/src/components/HeaderAdSlot.tsx
+++ b/dotcom-rendering/src/components/HeaderAdSlot.tsx
@@ -41,11 +41,17 @@ const topAboveNavContainer = css`
 	padding-bottom: ${padding}px;
 `;
 
+/**
+ * Ensure the top-above-nav/ad-block-ask containing div is always of a certain minimum height
+ */
+const headerMinSizeStyles = css`
+	min-height: ${adSizes.leaderboard.height}px;
+	min-width: ${adSizes.leaderboard.width}px;
+`;
+
 const topAboveNavStyles = css`
 	position: relative;
 	margin: 0 auto;
-	min-height: ${adSizes.leaderboard.height}px;
-	min-width: ${adSizes.leaderboard.width}px;
 	text-align: left;
 	display: block;
 `;
@@ -67,7 +73,7 @@ export const HeaderAdSlot = () => (
 		/>
 		<Hide when="below" breakpoint="tablet">
 			<div css={[headerAdWrapper]} className="top-banner-ad-container">
-				<div css={topAboveNavStyles}>
+				<div css={headerMinSizeStyles}>
 					<Island priority="feature" defer={{ until: 'visible' }}>
 						<AdBlockAsk
 							size="leaderboard"
@@ -75,7 +81,11 @@ export const HeaderAdSlot = () => (
 						/>
 					</Island>
 					<div
-						css={[adContainerStyles, topAboveNavContainer]}
+						css={[
+							adContainerStyles,
+							topAboveNavContainer,
+							topAboveNavStyles,
+						]}
 						className="ad-slot-container"
 					>
 						<AdSlot position="top-above-nav" />


### PR DESCRIPTION
## What does this change?

_TODO._

## Why?

Fix an in issue introduced in #11124, where we shifted some of the styling around to ensure the ad-block ask didn't cause CLS - this inadvertently caused the width to be constrained on fabric ads.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/8000415/34188851-5824-4e0e-902f-e2362b102730
[after]: https://github.com/guardian/dotcom-rendering/assets/8000415/7aa41f78-3bd6-46ec-8db6-cb1227d2c007
