### PR TITLE
Account for supporter and signed in status before showing AdBlockAsk

### DIFF
--- a/dotcom-rendering/src/components/AdBlockAsk.importable.tsx
+++ b/dotcom-rendering/src/components/AdBlockAsk.importable.tsx
@@ -170,12 +170,23 @@ export const AdBlockAskMPU = ({
 };
 
 type Props = {
-	slotId: `dfp-ad--${string}`;
 	size: AdBlockAskSize;
+	slotId: `dfp-ad--${string}`;
+	shouldHideReaderRevenue: boolean;
+	isPaidContent: boolean;
 };
 
-export const AdBlockAsk = ({ size, slotId }: Props) => {
-	const showAdBlockAsk = useAdblockAsk(slotId);
+export const AdBlockAsk = ({
+	size,
+	slotId,
+	shouldHideReaderRevenue,
+	isPaidContent,
+}: Props) => {
+	const showAdBlockAsk = useAdblockAsk({
+		slotId,
+		shouldHideReaderRevenue,
+		isPaidContent,
+	});
 
 	if (!showAdBlockAsk) {
 		return null;

--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -36,19 +36,29 @@ type SlotNamesWithPageSkin = SlotName | 'pageskin';
 type InlineProps = {
 	position: InlinePosition;
 	index: number;
+	shouldHideReaderRevenue?: never;
 };
 
-type NonInlineProps = {
-	position: Exclude<SlotNamesWithPageSkin, InlinePosition>;
+type RightProps = {
+	position: 'right';
 	index?: never;
+	shouldHideReaderRevenue: boolean;
+};
+
+type RemainingProps = {
+	position: Exclude<SlotNamesWithPageSkin, InlinePosition | 'right'>;
+	index?: never;
+	shouldHideReaderRevenue?: never;
 };
 
 /**
- * This allows us to conditionally require the index property based
- * on position. If `position` is an inline type then we expect the
- * index value. If not, then we explicitly refuse this property
+ * This allows us to conditionally require properties based on position:
+ *
+ * - If `position` is an inline type then we expect the `index` prop.
+ * - If `position` is `right` then we expect the `shouldHideReaderRevenue` prop
+ * - If not, then we explicitly refuse these properties
  */
-type Props = DefaultProps & (InlineProps | NonInlineProps);
+type Props = DefaultProps & (RightProps | InlineProps | RemainingProps);
 
 const labelHeight = constants.AD_LABEL_HEIGHT;
 
@@ -425,6 +435,7 @@ export const AdSlot = ({
 	isPaidContent = false,
 	index,
 	hasPageskin = false,
+	shouldHideReaderRevenue = false,
 }: Props) => {
 	switch (position) {
 		case 'right':
@@ -462,7 +473,14 @@ export const AdSlot = ({
 								priority="feature"
 								defer={{ until: 'visible' }}
 							>
-								<AdBlockAsk size="mpu" slotId={slotId} />
+								<AdBlockAsk
+									size="mpu"
+									slotId={slotId}
+									isPaidContent={isPaidContent}
+									shouldHideReaderRevenue={
+										shouldHideReaderRevenue
+									}
+								/>
 							</Island>
 							<div
 								id="top-right-ad-slot"

--- a/dotcom-rendering/src/components/HeaderAdSlot.tsx
+++ b/dotcom-rendering/src/components/HeaderAdSlot.tsx
@@ -56,7 +56,13 @@ const topAboveNavStyles = css`
 	display: block;
 `;
 
-export const HeaderAdSlot = () => (
+export const HeaderAdSlot = ({
+	shouldHideReaderRevenue,
+	isPaidContent,
+}: {
+	shouldHideReaderRevenue: boolean;
+	isPaidContent: boolean;
+}) => (
 	<div css={headerWrapper}>
 		<Global
 			styles={css`
@@ -78,6 +84,8 @@ export const HeaderAdSlot = () => (
 						<AdBlockAsk
 							size="leaderboard"
 							slotId="dfp-ad--top-above-nav"
+							shouldHideReaderRevenue={shouldHideReaderRevenue}
+							isPaidContent={isPaidContent}
 						/>
 					</Island>
 					<div

--- a/dotcom-rendering/src/components/MostViewedRightWithAd.tsx
+++ b/dotcom-rendering/src/components/MostViewedRightWithAd.tsx
@@ -10,6 +10,7 @@ type Props = {
 	display: ArticleDisplay;
 	isPaidContent: boolean;
 	renderAds: boolean;
+	shouldHideReaderRevenue: boolean;
 };
 
 /**
@@ -22,6 +23,7 @@ export const MostViewedRightWithAd = ({
 	display,
 	isPaidContent,
 	renderAds,
+	shouldHideReaderRevenue,
 }: Props) => {
 	const componentDataAttribute = 'most-viewed-right-container';
 	const { renderingTarget } = useConfig();
@@ -47,6 +49,7 @@ export const MostViewedRightWithAd = ({
 					position="right"
 					display={display}
 					isPaidContent={isPaidContent}
+					shouldHideReaderRevenue={shouldHideReaderRevenue}
 				/>
 			) : null}
 

--- a/dotcom-rendering/src/layouts/AllEditorialNewslettersPageLayout.tsx
+++ b/dotcom-rendering/src/layouts/AllEditorialNewslettersPageLayout.tsx
@@ -58,7 +58,10 @@ export const AllEditorialNewslettersPageLayout = ({
 								padSides={false}
 								shouldCenter={false}
 							>
-								<HeaderAdSlot />
+								<HeaderAdSlot
+									isPaidContent={false}
+									shouldHideReaderRevenue={false}
+								/>
 							</Section>
 						</Stuck>
 					)}

--- a/dotcom-rendering/src/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/layouts/CommentLayout.tsx
@@ -315,7 +315,14 @@ export const CommentLayout = (props: WebProps | AppsProps) => {
 								padSides={false}
 								shouldCenter={false}
 							>
-								<HeaderAdSlot />
+								<HeaderAdSlot
+									isPaidContent={
+										!!article.config.isPaidContent
+									}
+									shouldHideReaderRevenue={
+										!!article.config.shouldHideReaderRevenue
+									}
+								/>
 							</Section>
 						</Stuck>
 					)}
@@ -777,6 +784,10 @@ export const CommentLayout = (props: WebProps | AppsProps) => {
 											article.pageType.isPaidContent
 										}
 										renderAds={renderAds}
+										shouldHideReaderRevenue={
+											!!article.config
+												.shouldHideReaderRevenue
+										}
 									/>
 								</RightColumn>
 							</div>

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -169,7 +169,10 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 								padSides={false}
 								shouldCenter={false}
 							>
-								<HeaderAdSlot />
+								<HeaderAdSlot
+									isPaidContent={!!front.config.isPaidContent}
+									shouldHideReaderRevenue={false}
+								/>
 							</Section>
 						</Stuck>
 					)}

--- a/dotcom-rendering/src/layouts/FullPageInteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/FullPageInteractiveLayout.tsx
@@ -194,7 +194,12 @@ const NavHeader = ({ article, NAV, format }: Props) => {
 							shouldCenter={false}
 							element="aside"
 						>
-							<HeaderAdSlot />
+							<HeaderAdSlot
+								isPaidContent={!!article.config.isPaidContent}
+								shouldHideReaderRevenue={
+									!!article.config.shouldHideReaderRevenue
+								}
+							/>
 						</Section>
 					</div>
 				</Stuck>

--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -796,6 +796,10 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 															article.pageType
 																.isPaidContent
 														}
+														shouldHideReaderRevenue={
+															!!article.config
+																.shouldHideReaderRevenue
+														}
 													/>
 												}
 											</div>

--- a/dotcom-rendering/src/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/InteractiveLayout.tsx
@@ -254,7 +254,15 @@ export const InteractiveLayout = (props: WebProps | AppsProps) => {
 										padSides={false}
 										shouldCenter={false}
 									>
-										<HeaderAdSlot />
+										<HeaderAdSlot
+											isPaidContent={
+												!!article.config.isPaidContent
+											}
+											shouldHideReaderRevenue={
+												!!article.config
+													.shouldHideReaderRevenue
+											}
+										/>
 									</Section>
 								</div>
 							</Stuck>

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -325,7 +325,14 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 								shouldCenter={false}
 								element="aside"
 							>
-								<HeaderAdSlot />
+								<HeaderAdSlot
+									isPaidContent={
+										!!article.config.isPaidContent
+									}
+									shouldHideReaderRevenue={
+										!!article.config.shouldHideReaderRevenue
+									}
+								/>
 							</Section>
 						</Stuck>
 					)}
@@ -1185,6 +1192,10 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 												position="right"
 												display={format.display}
 												isPaidContent={isPaidContent}
+												shouldHideReaderRevenue={
+													!!article.config
+														.shouldHideReaderRevenue
+												}
 											/>
 										)}
 

--- a/dotcom-rendering/src/layouts/NewsletterSignupLayout.tsx
+++ b/dotcom-rendering/src/layouts/NewsletterSignupLayout.tsx
@@ -223,7 +223,12 @@ export const NewsletterSignupLayout = ({ article, NAV, format }: Props) => {
 							padSides={false}
 							shouldCenter={false}
 						>
-							<HeaderAdSlot />
+							<HeaderAdSlot
+								isPaidContent={!!article.config.isPaidContent}
+								shouldHideReaderRevenue={
+									!!article.config.shouldHideReaderRevenue
+								}
+							/>
 						</Section>
 					</Stuck>
 				)}

--- a/dotcom-rendering/src/layouts/PictureLayout.tsx
+++ b/dotcom-rendering/src/layouts/PictureLayout.tsx
@@ -297,7 +297,14 @@ export const PictureLayout = (props: WebProps | AppsProps) => {
 								padSides={false}
 								shouldCenter={false}
 							>
-								<HeaderAdSlot />
+								<HeaderAdSlot
+									isPaidContent={
+										!!article.config.isPaidContent
+									}
+									shouldHideReaderRevenue={
+										!!article.config.shouldHideReaderRevenue
+									}
+								/>
 							</Section>
 						</Stuck>
 					)}

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -261,7 +261,16 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 											padSides={false}
 											shouldCenter={false}
 										>
-											<HeaderAdSlot />
+											<HeaderAdSlot
+												isPaidContent={
+													!!article.config
+														.isPaidContent
+												}
+												shouldHideReaderRevenue={
+													!!article.config
+														.shouldHideReaderRevenue
+												}
+											/>
 										</Section>
 									</Stuck>
 								)}
@@ -407,7 +416,16 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 											showSideBorders={false}
 											padSides={false}
 										>
-											<HeaderAdSlot />
+											<HeaderAdSlot
+												isPaidContent={
+													!!article.config
+														.isPaidContent
+												}
+												shouldHideReaderRevenue={
+													!!article.config
+														.shouldHideReaderRevenue
+												}
+											/>
 										</Section>
 									</Stuck>
 								)}
@@ -768,6 +786,10 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 											article.pageType.isPaidContent
 										}
 										renderAds={renderAds}
+										shouldHideReaderRevenue={
+											!!article.config
+												.shouldHideReaderRevenue
+										}
 									/>
 								</RightColumn>
 							</div>

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -350,7 +350,14 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 								padSides={false}
 								shouldCenter={false}
 							>
-								<HeaderAdSlot />
+								<HeaderAdSlot
+									isPaidContent={
+										!!article.config.isPaidContent
+									}
+									shouldHideReaderRevenue={
+										!!article.config.shouldHideReaderRevenue
+									}
+								/>
 							</Section>
 						</Stuck>
 					)}
@@ -852,6 +859,10 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 											article.pageType.isPaidContent
 										}
 										renderAds={renderAds}
+										shouldHideReaderRevenue={
+											!!article.config
+												.shouldHideReaderRevenue
+										}
 									/>
 								</RightColumn>
 							</div>

--- a/dotcom-rendering/src/layouts/TagPageLayout.tsx
+++ b/dotcom-rendering/src/layouts/TagPageLayout.tsx
@@ -84,7 +84,12 @@ export const TagPageLayout = ({ tagPage, NAV }: Props) => {
 								padSides={false}
 								shouldCenter={false}
 							>
-								<HeaderAdSlot />
+								<HeaderAdSlot
+									isPaidContent={
+										!!tagPage.config.isPaidContent
+									}
+									shouldHideReaderRevenue={false}
+								/>
 							</Section>
 						</Stuck>
 					)}


### PR DESCRIPTION
## What does this change?

This PR prevents showing the new ad block ask component (see #11124) under the following conditions:
- Content is flagged as paid via `isPaidContent`.
- `shouldHideReaderRevenue` is present on the data model. This covers cases such as when an article is marked as sensitive.
- The user is signed in.

This touches a lot of files, as some prop drilling is required to make these values available to the components.

## Why?

We don't want to show the ad block ask under the conditions described above.