### PR TITLE
Enable sign-in for DCAR via Bridget

### DIFF
--- a/dotcom-rendering/.storybook/mocks/bridgetApi.ts
+++ b/dotcom-rendering/.storybook/mocks/bridgetApi.ts
@@ -19,6 +19,7 @@ type BridgetApi<T extends keyof BridgeModule> = () => Partial<
 export const getUserClient: BridgetApi<'getUserClient'> = () => ({
 	isPremium: async () => false,
 	doesCcpaApply: async () => false,
+	isSignedIn: async () => false,
 });
 
 export const getEnvironmentClient: BridgetApi<'getEnvironmentClient'> = () => ({

--- a/dotcom-rendering/src/components/Island.test.tsx
+++ b/dotcom-rendering/src/components/Island.test.tsx
@@ -118,11 +118,15 @@ describe('Island: server-side rendering', () => {
 	test('DiscussionMeta', () => {
 		expect(() =>
 			renderToString(
-				<DiscussionMeta
-					discussionApiUrl={''}
-					shortUrlId={''}
-					enableDiscussionSwitch={false}
-				/>,
+				<ConfigProvider
+					value={{ renderingTarget: 'Web', darkModeAvailable: false }}
+				>
+					<DiscussionMeta
+						discussionApiUrl={''}
+						shortUrlId={''}
+						enableDiscussionSwitch={false}
+					/>
+				</ConfigProvider>,
 			),
 		).not.toThrow();
 	});

--- a/dotcom-rendering/src/components/SignedInAs.stories.tsx
+++ b/dotcom-rendering/src/components/SignedInAs.stories.tsx
@@ -245,3 +245,45 @@ DiscussionDisabledSignedOut.decorators = [
 		},
 	]),
 ];
+
+export const Apps = () => {
+	return (
+		<Wrapper>
+			<SignedInAs
+				enableDiscussionSwitch={false}
+				commentCount={32}
+				isClosedForComments={false}
+			/>
+		</Wrapper>
+	);
+};
+Apps.parameters = { config: { renderingTarget: 'Apps' } };
+Apps.decorators = [
+	splitTheme(
+		[
+			{
+				theme: Pillar.News,
+				display: ArticleDisplay.Standard,
+				design: ArticleDesign.Standard,
+			},
+			{
+				theme: Pillar.Culture,
+				display: ArticleDisplay.Standard,
+				design: ArticleDesign.Standard,
+			},
+			{
+				theme: Pillar.Sport,
+				display: ArticleDisplay.Standard,
+				design: ArticleDesign.Standard,
+			},
+			{
+				theme: Pillar.Opinion,
+				display: ArticleDisplay.Standard,
+				design: ArticleDesign.Standard,
+			},
+		],
+		{
+			orientation: 'vertical',
+		},
+	),
+];

--- a/dotcom-rendering/src/components/SignedInAs.tsx
+++ b/dotcom-rendering/src/components/SignedInAs.tsx
@@ -125,49 +125,35 @@ const appsStylesOverride = css`
 	vertical-align: inherit;
 `;
 
-const SignInApps = () => (
-	<>
-		<LinkButton
-			priority="subdued"
-			theme={{ textSubdued: themePalette('--sign-in-link') }}
-			cssOverrides={appsStylesOverride}
-			onClick={signIn}
-		>
-			Sign in
-		</LinkButton>{' '}
-		or{' '}
-		<LinkButton
-			priority="subdued"
-			theme={{ textSubdued: themePalette('--sign-in-link') }}
-			cssOverrides={appsStylesOverride}
-			onClick={signIn}
-		>
-			create your Guardian account
-		</LinkButton>{' '}
-	</>
-);
+const SignInButton = ({
+	children,
+	action,
+}: {
+	children: React.ReactNode;
+	action: 'signin_to_comment' | 'register_to_comment';
+}) => {
+	const { renderingTarget } = useConfig();
 
-const SignInWeb = () => (
-	<>
+	return renderingTarget === 'Web' ? (
 		<a
 			href={`https://profile.theguardian.com/signin?INTCMP=DOTCOM_COMMENTS_SIGNIN&${createAuthenticationEventParams(
-				'signin_to_comment',
+				action,
 			)}`}
 			css={linkStyles}
 		>
-			Sign in
-		</a>{' '}
-		or{' '}
-		<a
-			href={`https://profile.theguardian.com/register?INTCMP=DOTCOM_COMMENTS_REG&${createAuthenticationEventParams(
-				'register_to_comment',
-			)}`}
-			css={linkStyles}
+			{children}
+		</a>
+	) : (
+		<LinkButton
+			priority="subdued"
+			theme={{ textSubdued: themePalette('--sign-in-link') }}
+			cssOverrides={appsStylesOverride}
+			onClick={signIn}
 		>
-			create your Guardian account
-		</a>{' '}
-	</>
-);
+			{children}
+		</LinkButton>
+	);
+};
 
 export const SignedInAs = ({
 	commentCount,
@@ -176,8 +162,6 @@ export const SignedInAs = ({
 	isClosedForComments,
 }: Props) => {
 	const isBanned = user?.privateFields && !user.privateFields.canPostComment;
-	const { renderingTarget } = useConfig();
-	const isWeb = renderingTarget === 'Web';
 
 	if (!enableDiscussionSwitch) {
 		// Discussion is disabled sitewide and user is signed in
@@ -197,7 +181,13 @@ export const SignedInAs = ({
 				<Heading count={commentCount} />
 				<span css={headlineStyles}>
 					Commenting has been disabled at this time but you can still{' '}
-					{isWeb ? <SignInWeb /> : <SignInApps />}
+					<SignInButton action="signin_to_comment">
+						sign in
+					</SignInButton>{' '}
+					or{' '}
+					<SignInButton action="register_to_comment">
+						create your Guardian account
+					</SignInButton>{' '}
 					to join the discussion when it&apos;s back
 				</span>
 			</div>
@@ -242,7 +232,13 @@ export const SignedInAs = ({
 				<Heading count={commentCount} />
 				<span css={headlineStyles}>
 					This discussion is now closed for comments but you can still{' '}
-					{isWeb ? <SignInWeb /> : <SignInApps />}
+					<SignInButton action="signin_to_comment">
+						sign in
+					</SignInButton>{' '}
+					or{' '}
+					<SignInButton action="register_to_comment">
+						create your Guardian account
+					</SignInButton>{' '}
 					to join the discussion next time
 				</span>
 			</div>
@@ -255,7 +251,13 @@ export const SignedInAs = ({
 			<div css={containerStyles}>
 				<Heading count={commentCount} />
 				<span css={headlineStyles}>
-					{isWeb ? <SignInWeb /> : <SignInApps />}
+					<SignInButton action="signin_to_comment">
+						Sign in
+					</SignInButton>{' '}
+					or{' '}
+					<SignInButton action="register_to_comment">
+						create your Guardian account
+					</SignInButton>{' '}
 					to join the discussion
 				</span>
 			</div>

--- a/dotcom-rendering/src/components/SignedInAs.tsx
+++ b/dotcom-rendering/src/components/SignedInAs.tsx
@@ -116,10 +116,12 @@ const appsStylesOverride = css`
 	margin: 0;
 	text-decoration-color: ${themePalette('--sign-in-link-underline')};
 	white-space: inherit;
+	/* stylelint-disable -- there’s no Source option for this look */
 	font-family: inherit;
 	font-weight: inherit;
 	font-size: inherit;
 	line-height: inherit;
+	/* stylelint-enable */
 	vertical-align: inherit;
 `;
 

--- a/dotcom-rendering/src/components/SignedInAs.tsx
+++ b/dotcom-rendering/src/components/SignedInAs.tsx
@@ -1,4 +1,6 @@
 import { css } from '@emotion/react';
+import { SignInScreenReason } from '@guardian/bridget/SignInScreenReason';
+import { SignInScreenReferrer } from '@guardian/bridget/SignInScreenReferrer';
 import {
 	headline,
 	palette as sourcePalette,
@@ -6,9 +8,12 @@ import {
 	textSans,
 	until,
 } from '@guardian/source-foundations';
+import { getUserClient } from '../lib/bridgetApi';
 import type { UserProfile } from '../lib/discussion';
 import { createAuthenticationEventParams } from '../lib/identity-component-event';
 import { palette as themePalette } from '../palette';
+import { useConfig } from './ConfigContext';
+import { LinkButton } from '@guardian/source-react-components';
 
 type Props = {
 	commentCount?: number;
@@ -95,6 +100,45 @@ const Heading = ({ count }: { count?: number }) => {
 	);
 };
 
+const signIn = () =>
+	void getUserClient()
+		.signIn(
+			SignInScreenReason.accessDiscussion,
+			SignInScreenReferrer.accessDiscussion,
+		)
+		.catch(() => {
+			// do nothing
+		});
+
+const SignInApps = () => (
+	<>
+		<LinkButton onClick={signIn}>Sign in</LinkButton> or{' '}
+		<LinkButton onClick={signIn}>create your Guardian account</LinkButton>{' '}
+	</>
+);
+
+const SignInWeb = () => (
+	<>
+		<a
+			href={`https://profile.theguardian.com/signin?INTCMP=DOTCOM_COMMENTS_SIGNIN&${createAuthenticationEventParams(
+				'signin_to_comment',
+			)}`}
+			css={linkStyles}
+		>
+			Sign in
+		</a>
+		or
+		<a
+			href={`https://profile.theguardian.com/register?INTCMP=DOTCOM_COMMENTS_REG&${createAuthenticationEventParams(
+				'register_to_comment',
+			)}`}
+			css={linkStyles}
+		>
+			create your Guardian account
+		</a>{' '}
+	</>
+);
+
 export const SignedInAs = ({
 	commentCount,
 	enableDiscussionSwitch,
@@ -102,6 +146,8 @@ export const SignedInAs = ({
 	isClosedForComments,
 }: Props) => {
 	const isBanned = user?.privateFields && !user.privateFields.canPostComment;
+	const { renderingTarget } = useConfig();
+	const isWeb = renderingTarget === 'Web';
 
 	if (!enableDiscussionSwitch) {
 		// Discussion is disabled sitewide and user is signed in
@@ -121,23 +167,7 @@ export const SignedInAs = ({
 				<Heading count={commentCount} />
 				<span css={headlineStyles}>
 					Commenting has been disabled at this time but you can still{' '}
-					<a
-						href={`https://profile.theguardian.com/signin?INTCMP=DOTCOM_COMMENTS_SIGNIN&${createAuthenticationEventParams(
-							'signin_to_comment',
-						)}`}
-						css={linkStyles}
-					>
-						sign in
-					</a>{' '}
-					or{' '}
-					<a
-						href={`https://profile.theguardian.com/register?INTCMP=DOTCOM_COMMENTS_REG&${createAuthenticationEventParams(
-							'register_to_comment',
-						)}`}
-						css={linkStyles}
-					>
-						create your Guardian account
-					</a>{' '}
+					{isWeb ? <SignInWeb /> : <SignInApps />}
 					to join the discussion when it&apos;s back
 				</span>
 			</div>
@@ -182,23 +212,7 @@ export const SignedInAs = ({
 				<Heading count={commentCount} />
 				<span css={headlineStyles}>
 					This discussion is now closed for comments but you can still{' '}
-					<a
-						href={`https://profile.theguardian.com/signin?INTCMP=DOTCOM_COMMENTS_SIGNIN&${createAuthenticationEventParams(
-							'signin_to_comment',
-						)}`}
-						css={linkStyles}
-					>
-						sign in
-					</a>{' '}
-					or{' '}
-					<a
-						href={`https://profile.theguardian.com/register?INTCMP=DOTCOM_COMMENTS_REG&${createAuthenticationEventParams(
-							'register_to_comment',
-						)}`}
-						css={linkStyles}
-					>
-						create your Guardian account
-					</a>{' '}
+					{isWeb ? <SignInWeb /> : <SignInApps />}
 					to join the discussion next time
 				</span>
 			</div>
@@ -211,23 +225,7 @@ export const SignedInAs = ({
 			<div css={containerStyles}>
 				<Heading count={commentCount} />
 				<span css={headlineStyles}>
-					<a
-						href={`https://profile.theguardian.com/signin?INTCMP=DOTCOM_COMMENTS_SIGNIN&${createAuthenticationEventParams(
-							'signin_to_comment',
-						)}`}
-						css={linkStyles}
-					>
-						Sign in
-					</a>{' '}
-					or{' '}
-					<a
-						href={`https://profile.theguardian.com/register?INTCMP=DOTCOM_COMMENTS_REG&${createAuthenticationEventParams(
-							'register_to_comment',
-						)}`}
-						css={linkStyles}
-					>
-						create your Guardian account
-					</a>{' '}
+					{isWeb ? <SignInWeb /> : <SignInApps />}
 					to join the discussion
 				</span>
 			</div>

--- a/dotcom-rendering/src/components/SignedInAs.tsx
+++ b/dotcom-rendering/src/components/SignedInAs.tsx
@@ -8,12 +8,12 @@ import {
 	textSans,
 	until,
 } from '@guardian/source-foundations';
+import { LinkButton } from '@guardian/source-react-components';
 import { getUserClient } from '../lib/bridgetApi';
 import type { UserProfile } from '../lib/discussion';
 import { createAuthenticationEventParams } from '../lib/identity-component-event';
 import { palette as themePalette } from '../palette';
 import { useConfig } from './ConfigContext';
-import { LinkButton } from '@guardian/source-react-components';
 
 type Props = {
 	commentCount?: number;

--- a/dotcom-rendering/src/components/SignedInAs.tsx
+++ b/dotcom-rendering/src/components/SignedInAs.tsx
@@ -126,8 +126,8 @@ const SignInWeb = () => (
 			css={linkStyles}
 		>
 			Sign in
-		</a>
-		or
+		</a>{' '}
+		or{' '}
 		<a
 			href={`https://profile.theguardian.com/register?INTCMP=DOTCOM_COMMENTS_REG&${createAuthenticationEventParams(
 				'register_to_comment',

--- a/dotcom-rendering/src/components/SignedInAs.tsx
+++ b/dotcom-rendering/src/components/SignedInAs.tsx
@@ -110,10 +110,38 @@ const signIn = () =>
 			// do nothing
 		});
 
+const appsStylesOverride = css`
+	display: inline;
+	padding: 0;
+	margin: 0;
+	text-decoration-color: ${themePalette('--sign-in-link-underline')};
+	white-space: inherit;
+	font-family: inherit;
+	font-weight: inherit;
+	font-size: inherit;
+	line-height: inherit;
+	vertical-align: inherit;
+`;
+
 const SignInApps = () => (
 	<>
-		<LinkButton onClick={signIn}>Sign in</LinkButton> or{' '}
-		<LinkButton onClick={signIn}>create your Guardian account</LinkButton>{' '}
+		<LinkButton
+			priority="subdued"
+			theme={{ textSubdued: themePalette('--sign-in-link') }}
+			cssOverrides={appsStylesOverride}
+			onClick={signIn}
+		>
+			Sign in
+		</LinkButton>{' '}
+		or{' '}
+		<LinkButton
+			priority="subdued"
+			theme={{ textSubdued: themePalette('--sign-in-link') }}
+			cssOverrides={appsStylesOverride}
+			onClick={signIn}
+		>
+			create your Guardian account
+		</LinkButton>{' '}
 	</>
 );
 


### PR DESCRIPTION
## What does this change?

Enable sign-in for DCAR via Bridget.

Inspired by @abeddow91’s #10793

## Why?

Being signed in is a requirement to successfuly get a user profile, which is also required for participating in a discussion.

Closes #10909
Part of #10785 & #10544

## Screenshots

TBC

| Before                 | After                 |
| ---------------------- | --------------------- |
| ![signed out before][] | ![signed out after][] |
| ![signed in before][]  | ![signed in after][]  |

[signed out before]: https://github.com/guardian/dotcom-rendering/assets/76776/74db875f-cee9-4f29-9de1-bd0bc59cd16a
[signed out after]: https://github.com/guardian/dotcom-rendering/assets/76776/08bf0237-27e4-4976-88ec-3dfc659ecbe2

[signed in before]: https://github.com/guardian/dotcom-rendering/assets/76776/74db875f-cee9-4f29-9de1-bd0bc59cd16a
[signed in after]: https://github.com/guardian/dotcom-rendering/assets/76776/47db6e09-bd6a-43ac-91c0-e5fc22e112a6