### PR TITLE
Get new elements to use the new subheading styles

### DIFF
--- a/dotcom-rendering/src/components/KeyTakeaway.tsx
+++ b/dotcom-rendering/src/components/KeyTakeaway.tsx
@@ -1,25 +1,19 @@
-import { css, type SerializedStyles } from '@emotion/react';
-import { ArticleDisplay, type ArticleFormat } from '@guardian/libs';
-import { headline } from '@guardian/source-foundations';
+import { css } from '@emotion/react';
+import { type ArticleFormat } from '@guardian/libs';
+import { remSpace } from '@guardian/source-foundations';
 import type { EditionId } from '../lib/edition';
 import type { ArticleElementRenderer } from '../lib/renderElement';
 import { palette } from '../palette';
 import type { ServerSideTests, Switches } from '../types/config';
 import type { KeyTakeaway as KeyTakeawayModel } from '../types/content';
+import { subheadingStyles } from './SubheadingBlockComponent';
 
 const keyTakeawayStyles = css`
 	padding-top: 8px;
 `;
 
-const headingStyles = (display: ArticleDisplay): SerializedStyles => css`
-	${display === ArticleDisplay.Immersive
-		? headline.medium({ fontWeight: 'light' })
-		: headline.xxsmall({ fontWeight: 'bold' })};
-	padding: 2px 0;
-`;
-
 const headingIndexStyles = css`
-	${headline.xsmall({ fontWeight: 'bold' })};
+	font-weight: bold;
 `;
 
 const headingLineStyles = css`
@@ -66,7 +60,12 @@ export const KeyTakeaway = ({
 		<>
 			<li css={keyTakeawayStyles}>
 				<hr css={headingLineStyles} />
-				<h2 css={headingStyles(format.display)}>
+				<h2
+					css={[
+						subheadingStyles(format),
+						`padding: ${remSpace[0]} 0;`,
+					]}
+				>
 					<span css={headingIndexStyles}>{`${titleIndex}. `}</span>
 					{keyTakeaway.title}
 				</h2>

--- a/dotcom-rendering/src/components/KeyTakeaway.tsx
+++ b/dotcom-rendering/src/components/KeyTakeaway.tsx
@@ -1,12 +1,11 @@
 import { css } from '@emotion/react';
 import { type ArticleFormat } from '@guardian/libs';
-import { remSpace } from '@guardian/source-foundations';
 import type { EditionId } from '../lib/edition';
 import type { ArticleElementRenderer } from '../lib/renderElement';
 import { palette } from '../palette';
 import type { ServerSideTests, Switches } from '../types/config';
 import type { KeyTakeaway as KeyTakeawayModel } from '../types/content';
-import { subheadingStyles } from './SubheadingBlockComponent';
+import { Subheading } from './Subheading';
 
 const keyTakeawayStyles = css`
 	padding-top: 8px;
@@ -60,15 +59,10 @@ export const KeyTakeaway = ({
 		<>
 			<li css={keyTakeawayStyles}>
 				<hr css={headingLineStyles} />
-				<h2
-					css={[
-						subheadingStyles(format),
-						`padding: ${remSpace[0]} 0;`,
-					]}
-				>
+				<Subheading format={format} topPadding={false}>
 					<span css={headingIndexStyles}>{`${titleIndex}. `}</span>
 					{keyTakeaway.title}
-				</h2>
+				</Subheading>
 				{keyTakeaway.body.map((element, index) => (
 					<RenderArticleElement
 						// eslint-disable-next-line react/no-array-index-key -- This is only rendered once so we can safely use index to suppress the warning

--- a/dotcom-rendering/src/components/KeyTakeaways.stories.tsx
+++ b/dotcom-rendering/src/components/KeyTakeaways.stories.tsx
@@ -1,8 +1,13 @@
-import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
+import {
+	ArticleDesign,
+	ArticleDisplay,
+	ArticleSpecial,
+	Pillar,
+} from '@guardian/libs';
 import type { Meta, StoryObj } from '@storybook/react';
 import { splitTheme } from '../../.storybook/decorators/splitThemeDecorator';
 import { images } from '../../fixtures/generated/images';
-import { getAllThemes } from '../lib/format';
+import { getAllDesigns, getAllThemes } from '../lib/format';
 import { RenderArticleElement } from '../lib/renderElement';
 import type { TextBlockElement } from '../types/content';
 import { KeyTakeaways } from './KeyTakeaways';
@@ -23,7 +28,7 @@ const testTextElement: TextBlockElement = {
 	html: '<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesquepharetra libero nec varius feugiat. Nulla commodo sagittis erat amalesuada. Ut iaculis interdum eros, et tristique ex. In veldignissim arcu. Nulla nisi urna, laoreet a aliquam at, viverra eueros. Proin imperdiet pellentesque turpis sed luctus. Donecdignissim lacus in risus fermentum maximus eu vel justo. Duis nontortor ac elit dapibus imperdiet ut at risus. Etiam pretium, odioeget accumsan venenatis, tortor mi aliquet nisl, vel ullamcorperneque nulla vel elit. Etiam porta mauris nec sagittis luctus.</p>',
 };
 
-export const AllThemes = {
+export const ThemeVariations = {
 	args: {
 		keyTakeaways: [
 			{
@@ -67,11 +72,20 @@ export const AllThemes = {
 	],
 } satisfies Story;
 
-/* TODO reminder to check desktop/mobile font size variations
- * remove this comment when https://github.com/guardian/dotcom-rendering/issues/9193 complete
- */
-export const SomeDesignsAndDisplays = {
-	args: AllThemes.args,
+export const DesignVariations = {
+	args: ThemeVariations.args,
+	decorators: [
+		splitTheme(
+			getAllDesigns({
+				theme: Pillar.News,
+				display: ArticleDisplay.Standard,
+			}),
+		),
+	],
+} satisfies Story;
+
+export const OtherVariations = {
+	args: ThemeVariations.args,
 	decorators: [
 		splitTheme([
 			{
@@ -80,29 +94,24 @@ export const SomeDesignsAndDisplays = {
 				theme: Pillar.Lifestyle,
 			},
 			{
-				design: ArticleDesign.Editorial,
+				design: ArticleDesign.Review,
 				display: ArticleDisplay.Standard,
-				theme: Pillar.Lifestyle,
+				theme: Pillar.Sport,
 			},
 			{
-				design: ArticleDesign.Profile,
-				display: ArticleDisplay.Standard,
-				theme: Pillar.Lifestyle,
-			},
-			{
-				design: ArticleDesign.Analysis,
-				display: ArticleDisplay.Standard,
-				theme: Pillar.Lifestyle,
-			},
-			{
-				design: ArticleDesign.Interview,
-				display: ArticleDisplay.Standard,
-				theme: Pillar.Lifestyle,
-			},
-			{
-				design: ArticleDesign.Standard,
+				design: ArticleDesign.Recipe,
 				display: ArticleDisplay.Immersive,
 				theme: Pillar.Lifestyle,
+			},
+			{
+				design: ArticleDesign.Feature,
+				display: ArticleDisplay.Immersive,
+				theme: ArticleSpecial.SpecialReport,
+			},
+			{
+				design: ArticleDesign.Feature,
+				display: ArticleDisplay.Immersive,
+				theme: ArticleSpecial.SpecialReportAlt,
 			},
 		]),
 	],
@@ -110,7 +119,7 @@ export const SomeDesignsAndDisplays = {
 
 export const Images = {
 	args: {
-		...AllThemes.args,
+		...ThemeVariations.args,
 		keyTakeaways: [
 			{
 				title: 'The first key takeaway',

--- a/dotcom-rendering/src/components/QAndAExplainer.tsx
+++ b/dotcom-rendering/src/components/QAndAExplainer.tsx
@@ -1,12 +1,11 @@
 import { css } from '@emotion/react';
 import type { ArticleFormat } from '@guardian/libs';
-import { remSpace } from '@guardian/source-foundations';
 import type { EditionId } from '../lib/edition';
 import type { ArticleElementRenderer } from '../lib/renderElement';
 import { palette } from '../palette';
 import type { ServerSideTests, Switches } from '../types/config';
 import type { QAndAExplainer as QAndAExplainerModel } from '../types/content';
-import { subheadingStyles } from './SubheadingBlockComponent';
+import { Subheading } from './Subheading';
 
 interface Props {
 	qAndAExplainer: QAndAExplainerModel;
@@ -49,9 +48,9 @@ export const QAndAExplainer = ({
 	return (
 		<>
 			<hr css={headingLineStyles}></hr>
-			<h2 css={[subheadingStyles(format), `padding: ${remSpace[0]} 0;`]}>
+			<Subheading format={format} topPadding={false}>
 				{qAndAExplainer.title}
-			</h2>
+			</Subheading>
 			{qAndAExplainer.body.map((element, index) => (
 				<RenderArticleElement
 					// eslint-disable-next-line react/no-array-index-key -- This is only rendered once so we can safely use index to suppress the warning

--- a/dotcom-rendering/src/components/QAndAExplainer.tsx
+++ b/dotcom-rendering/src/components/QAndAExplainer.tsx
@@ -1,12 +1,12 @@
-import { css, type SerializedStyles } from '@emotion/react';
+import { css } from '@emotion/react';
 import type { ArticleFormat } from '@guardian/libs';
-import { ArticleDisplay } from '@guardian/libs';
-import { headline } from '@guardian/source-foundations';
+import { remSpace } from '@guardian/source-foundations';
 import type { EditionId } from '../lib/edition';
 import type { ArticleElementRenderer } from '../lib/renderElement';
 import { palette } from '../palette';
 import type { ServerSideTests, Switches } from '../types/config';
 import type { QAndAExplainer as QAndAExplainerModel } from '../types/content';
+import { subheadingStyles } from './SubheadingBlockComponent';
 
 interface Props {
 	qAndAExplainer: QAndAExplainerModel;
@@ -23,13 +23,6 @@ interface Props {
 	starRating?: number;
 	RenderArticleElement: ArticleElementRenderer;
 }
-
-const headingStyles = (display: ArticleDisplay): SerializedStyles => css`
-	${display === ArticleDisplay.Immersive
-		? headline.medium({ fontWeight: 'light' })
-		: headline.xxsmall({ fontWeight: 'bold' })};
-	padding: 2px 0px;
-`;
 
 const headingLineStyles = css`
 	width: 140px;
@@ -56,7 +49,9 @@ export const QAndAExplainer = ({
 	return (
 		<>
 			<hr css={headingLineStyles}></hr>
-			<h2 css={headingStyles(format.display)}>{qAndAExplainer.title}</h2>
+			<h2 css={[subheadingStyles(format), `padding: ${remSpace[0]} 0;`]}>
+				{qAndAExplainer.title}
+			</h2>
 			{qAndAExplainer.body.map((element, index) => (
 				<RenderArticleElement
 					// eslint-disable-next-line react/no-array-index-key -- This is only rendered once so we can safely use index to suppress the warning

--- a/dotcom-rendering/src/components/QAndAExplainers.stories.tsx
+++ b/dotcom-rendering/src/components/QAndAExplainers.stories.tsx
@@ -1,4 +1,9 @@
-import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
+import {
+	ArticleDesign,
+	ArticleDisplay,
+	ArticleSpecial,
+	Pillar,
+} from '@guardian/libs';
 import type { Meta, StoryObj } from '@storybook/react';
 import { splitTheme } from '../../.storybook/decorators/splitThemeDecorator';
 import { images } from '../../fixtures/generated/images';
@@ -64,6 +69,39 @@ export const AllThemes = {
 				display: ArticleDisplay.Standard,
 			}),
 		),
+	],
+} satisfies Story;
+
+export const OtherFormatVariations = {
+	args: AllThemes.args,
+	decorators: [
+		splitTheme([
+			{
+				design: ArticleDesign.Obituary,
+				display: ArticleDisplay.Standard,
+				theme: Pillar.Lifestyle,
+			},
+			{
+				design: ArticleDesign.Review,
+				display: ArticleDisplay.Standard,
+				theme: Pillar.Sport,
+			},
+			{
+				design: ArticleDesign.Recipe,
+				display: ArticleDisplay.Immersive,
+				theme: Pillar.Lifestyle,
+			},
+			{
+				design: ArticleDesign.Feature,
+				display: ArticleDisplay.Immersive,
+				theme: ArticleSpecial.SpecialReport,
+			},
+			{
+				design: ArticleDesign.Feature,
+				display: ArticleDisplay.Immersive,
+				theme: ArticleSpecial.SpecialReportAlt,
+			},
+		]),
 	],
 } satisfies Story;
 

--- a/dotcom-rendering/src/components/Subheading.tsx
+++ b/dotcom-rendering/src/components/Subheading.tsx
@@ -1,0 +1,113 @@
+import { css } from '@emotion/react';
+import type { ArticleFormat } from '@guardian/libs';
+import {
+	ArticleDesign,
+	ArticleDisplay,
+	ArticleSpecial,
+	Pillar,
+} from '@guardian/libs';
+import type { FontWeight } from '@guardian/source-foundations';
+import { from, headline, space } from '@guardian/source-foundations';
+import { textSans } from '@guardian/source-foundations/cjs/source-foundations/src/typography/api';
+import type { ReactNode } from 'react';
+import { palette } from '../palette';
+
+interface Props {
+	id?: string;
+	format: ArticleFormat;
+	topPadding: boolean;
+	children: ReactNode;
+}
+
+const fontStyles = ({
+	format,
+	fontWeight,
+}: {
+	format: ArticleFormat;
+	fontWeight: FontWeight;
+}) => css`
+	${format.display === ArticleDisplay.Immersive
+		? headline.small({ fontWeight: 'light', lineHeight: 'tight' })
+		: headline.xsmall({ fontWeight, lineHeight: 'tight' })}
+
+	${from.tablet} {
+		${format.display === ArticleDisplay.Immersive
+			? headline.medium({ fontWeight: 'light', lineHeight: 'tight' })
+			: headline.small({ fontWeight, lineHeight: 'tight' })}
+	}
+
+	/** Labs uses sans text */
+	${format.theme === ArticleSpecial.Labs &&
+	css`
+		${format.display === ArticleDisplay.Immersive
+			? textSans.xxlarge({ fontWeight: 'light', lineHeight: 'tight' })
+			: textSans.xlarge({ fontWeight, lineHeight: 'tight' })}
+
+		${from.tablet} {
+			${format.display === ArticleDisplay.Immersive
+				? textSans.xxxlarge({
+						fontWeight: 'light',
+						lineHeight: 'tight',
+				  })
+				: textSans.xxlarge({ fontWeight, lineHeight: 'tight' })}
+		}
+	`}
+
+	color: ${palette('--subheading-text')};
+
+	/* We don't allow additional font weight inside h2 tags except for immersive articles */
+	strong {
+		font-weight: ${format.display === ArticleDisplay.Immersive
+			? 'bold'
+			: 'inherit'};
+	}
+`;
+
+const paddingStyles = (topPadding: boolean) => css`
+	padding-top: ${topPadding ? space[2] : 0}px;
+	padding-bottom: ${space[0]}px;
+	${from.tablet} {
+		padding-bottom: ${space[1]}px;
+	}
+`;
+const subheadingStyles = (format: ArticleFormat) => {
+	switch (format.design) {
+		case ArticleDesign.Obituary:
+		case ArticleDesign.Comment:
+		case ArticleDesign.Editorial:
+			/** TODO !
+			 * This is temporary until https://github.com/guardian/dotcom-rendering/pull/10989 has been merged.
+			 * The desired font weight is "regular" */
+			return fontStyles({ format, fontWeight: 'light' });
+
+		case ArticleDesign.Standard:
+		case ArticleDesign.Profile:
+		case ArticleDesign.Explainer:
+		case ArticleDesign.Timeline:
+		case ArticleDesign.LiveBlog:
+		case ArticleDesign.DeadBlog:
+		case ArticleDesign.Analysis:
+			return fontStyles({ format, fontWeight: 'medium' });
+
+		case ArticleDesign.Feature:
+			return fontStyles({
+				format,
+				fontWeight: format.theme === Pillar.News ? 'medium' : 'bold',
+			});
+		case ArticleDesign.Interview:
+		case ArticleDesign.Recipe:
+		case ArticleDesign.Review:
+			return fontStyles({ format, fontWeight: 'bold' });
+
+		default:
+			return fontStyles({ format, fontWeight: 'medium' });
+	}
+};
+
+export const Subheading = ({ id, format, topPadding, children }: Props) => {
+	return (
+		<h2 id={id} css={[subheadingStyles(format), paddingStyles(topPadding)]}>
+			{children}
+		</h2>
+	);
+};

--- a/dotcom-rendering/src/components/Subheading.tsx
+++ b/dotcom-rendering/src/components/Subheading.tsx
@@ -12,13 +12,6 @@ import { textSans } from '@guardian/source-foundations/cjs/source-foundations/sr
 import type { ReactNode } from 'react';
 import { palette } from '../palette';
 
-interface Props {
-	id?: string;
-	format: ArticleFormat;
-	topPadding: boolean;
-	children: ReactNode;
-}
-
 const fontStyles = ({
 	format,
 	fontWeight,
@@ -103,6 +96,13 @@ const subheadingStyles = (format: ArticleFormat) => {
 			return fontStyles({ format, fontWeight: 'medium' });
 	}
 };
+
+interface Props {
+	id?: string;
+	format: ArticleFormat;
+	topPadding: boolean;
+	children: ReactNode;
+}
 
 export const Subheading = ({ id, format, topPadding, children }: Props) => {
 	return (

--- a/dotcom-rendering/src/components/SubheadingBlockComponent.tsx
+++ b/dotcom-rendering/src/components/SubheadingBlockComponent.tsx
@@ -1,11 +1,6 @@
 import { css, jsx } from '@emotion/react';
 import type { ArticleFormat } from '@guardian/libs';
-import {
-	ArticleDesign,
-	ArticleDisplay,
-	ArticleSpecial,
-	Pillar,
-} from '@guardian/libs';
+import { ArticleDesign, ArticleDisplay, ArticleSpecial } from '@guardian/libs';
 import {
 	type FontWeight,
 	from,
@@ -21,7 +16,7 @@ import { logger } from '../server/lib/logging';
 
 type Props = { html: string; format: ArticleFormat };
 
-const getFontStyles = ({
+const fontStyles = ({
 	format,
 	fontWeight,
 }: {
@@ -29,12 +24,12 @@ const getFontStyles = ({
 	fontWeight: FontWeight;
 }) => css`
 	${format.display === ArticleDisplay.Immersive
-		? headline.small({ fontWeight, lineHeight: 'tight' })
+		? headline.small({ fontWeight: 'light', lineHeight: 'tight' })
 		: headline.xsmall({ fontWeight, lineHeight: 'tight' })}
 
 	${from.tablet} {
 		${format.display === ArticleDisplay.Immersive
-			? headline.medium({ fontWeight, lineHeight: 'tight' })
+			? headline.medium({ fontWeight: 'light', lineHeight: 'tight' })
 			: headline.small({ fontWeight, lineHeight: 'tight' })}
 	}
 
@@ -42,23 +37,20 @@ const getFontStyles = ({
 	${format.theme === ArticleSpecial.Labs &&
 	css`
 		${format.display === ArticleDisplay.Immersive
-			? textSans.xxlarge({ fontWeight, lineHeight: 'tight' })
+			? textSans.xxlarge({ fontWeight: 'light', lineHeight: 'tight' })
 			: textSans.xlarge({ fontWeight, lineHeight: 'tight' })}
 
 		${from.tablet} {
 			${format.display === ArticleDisplay.Immersive
-				? textSans.xxxlarge({ fontWeight, lineHeight: 'tight' })
+				? textSans.xxxlarge({
+						fontWeight: 'light',
+						lineHeight: 'tight',
+				  })
 				: textSans.xxlarge({ fontWeight, lineHeight: 'tight' })}
 		}
 	`}
 
 	color: ${palette('--subheading-text')};
-
-	padding-top: ${space[2]}px;
-	padding-bottom: ${space[0]}px;
-	${from.tablet} {
-		padding-bottom: ${space[1]}px;
-	}
 
 	/* We don't allow additional font weight inside h2 tags except for immersive articles */
 	strong {
@@ -68,7 +60,15 @@ const getFontStyles = ({
 	}
 `;
 
-const getStyles = (format: ArticleFormat) => {
+const paddingStyles = css`
+	padding-top: ${space[2]}px;
+	padding-bottom: ${space[0]}px;
+	${from.tablet} {
+		padding-bottom: ${space[1]}px;
+	}
+`;
+
+export const subheadingStyles = (format: ArticleFormat) => {
 	switch (format.design) {
 		case ArticleDesign.Obituary:
 		case ArticleDesign.Comment:
@@ -76,7 +76,7 @@ const getStyles = (format: ArticleFormat) => {
 			/** TODO !
 			 * This is temporary until https://github.com/guardian/dotcom-rendering/pull/10989 has been merged.
 			 * The desired font weight is "regular" */
-			return getFontStyles({ format, fontWeight: 'light' });
+			return fontStyles({ format, fontWeight: 'light' });
 
 		case ArticleDesign.Standard:
 		case ArticleDesign.Profile:
@@ -85,19 +85,16 @@ const getStyles = (format: ArticleFormat) => {
 		case ArticleDesign.LiveBlog:
 		case ArticleDesign.DeadBlog:
 		case ArticleDesign.Analysis:
-			return getFontStyles({ format, fontWeight: 'medium' });
+			return fontStyles({ format, fontWeight: 'medium' });
 
-		case ArticleDesign.Feature: {
-			const fontWeight = format.theme === Pillar.News ? 'medium' : 'bold';
-			return getFontStyles({ format, fontWeight });
-		}
+		case ArticleDesign.Feature:
 		case ArticleDesign.Interview:
 		case ArticleDesign.Recipe:
 		case ArticleDesign.Review:
-			return getFontStyles({ format, fontWeight: 'bold' });
+			return fontStyles({ format, fontWeight: 'bold' });
 
 		default:
-			return getFontStyles({ format, fontWeight: 'medium' });
+			return fontStyles({ format, fontWeight: 'medium' });
 	}
 };
 
@@ -124,9 +121,7 @@ const buildElementTree =
 					return (
 						<h2
 							id={attributes.getNamedItem('id')?.value}
-							css={getStyles(format)}
-							/** We override the h2 styling applied globally in ArticleBody */
-							data-ignore="global-h2-styling"
+							css={[subheadingStyles(format), paddingStyles]}
 						>
 							{Array.from(node.childNodes).map(
 								buildElementTree(format),

--- a/dotcom-rendering/src/components/SubheadingBlockComponent.tsx
+++ b/dotcom-rendering/src/components/SubheadingBlockComponent.tsx
@@ -1,104 +1,14 @@
-import { css, jsx } from '@emotion/react';
+import { jsx } from '@emotion/react';
 import type { ArticleFormat } from '@guardian/libs';
-import { ArticleDesign, ArticleDisplay, ArticleSpecial } from '@guardian/libs';
-import {
-	type FontWeight,
-	from,
-	headline,
-	space,
-} from '@guardian/source-foundations';
-import { textSans } from '@guardian/source-foundations/cjs/source-foundations/src/typography/api';
 import type { ReactNode } from 'react';
 import { Fragment } from 'react';
 import { isElement, parseHtml } from '../lib/domUtils';
-import { palette } from '../palette';
 import { logger } from '../server/lib/logging';
+import { Subheading } from './Subheading';
 
 type Props = { html: string; format: ArticleFormat };
 
-const fontStyles = ({
-	format,
-	fontWeight,
-}: {
-	format: ArticleFormat;
-	fontWeight: FontWeight;
-}) => css`
-	${format.display === ArticleDisplay.Immersive
-		? headline.small({ fontWeight: 'light', lineHeight: 'tight' })
-		: headline.xsmall({ fontWeight, lineHeight: 'tight' })}
-
-	${from.tablet} {
-		${format.display === ArticleDisplay.Immersive
-			? headline.medium({ fontWeight: 'light', lineHeight: 'tight' })
-			: headline.small({ fontWeight, lineHeight: 'tight' })}
-	}
-
-	/** Labs uses sans text */
-	${format.theme === ArticleSpecial.Labs &&
-	css`
-		${format.display === ArticleDisplay.Immersive
-			? textSans.xxlarge({ fontWeight: 'light', lineHeight: 'tight' })
-			: textSans.xlarge({ fontWeight, lineHeight: 'tight' })}
-
-		${from.tablet} {
-			${format.display === ArticleDisplay.Immersive
-				? textSans.xxxlarge({
-						fontWeight: 'light',
-						lineHeight: 'tight',
-				  })
-				: textSans.xxlarge({ fontWeight, lineHeight: 'tight' })}
-		}
-	`}
-
-	color: ${palette('--subheading-text')};
-
-	/* We don't allow additional font weight inside h2 tags except for immersive articles */
-	strong {
-		font-weight: ${format.display === ArticleDisplay.Immersive
-			? 'bold'
-			: 'inherit'};
-	}
-`;
-
-const paddingStyles = css`
-	padding-top: ${space[2]}px;
-	padding-bottom: ${space[0]}px;
-	${from.tablet} {
-		padding-bottom: ${space[1]}px;
-	}
-`;
-
-export const subheadingStyles = (format: ArticleFormat) => {
-	switch (format.design) {
-		case ArticleDesign.Obituary:
-		case ArticleDesign.Comment:
-		case ArticleDesign.Editorial:
-			/** TODO !
-			 * This is temporary until https://github.com/guardian/dotcom-rendering/pull/10989 has been merged.
-			 * The desired font weight is "regular" */
-			return fontStyles({ format, fontWeight: 'light' });
-
-		case ArticleDesign.Standard:
-		case ArticleDesign.Profile:
-		case ArticleDesign.Explainer:
-		case ArticleDesign.Timeline:
-		case ArticleDesign.LiveBlog:
-		case ArticleDesign.DeadBlog:
-		case ArticleDesign.Analysis:
-			return fontStyles({ format, fontWeight: 'medium' });
-
-		case ArticleDesign.Feature:
-		case ArticleDesign.Interview:
-		case ArticleDesign.Recipe:
-		case ArticleDesign.Review:
-			return fontStyles({ format, fontWeight: 'bold' });
-
-		default:
-			return fontStyles({ format, fontWeight: 'medium' });
-	}
-};
-
-const buildElementTree =
+export const buildElementTree =
 	(format: ArticleFormat) =>
 	(node: Node): ReactNode => {
 		if (isElement(node)) {
@@ -119,14 +29,15 @@ const buildElementTree =
 
 				case 'H2':
 					return (
-						<h2
+						<Subheading
 							id={attributes.getNamedItem('id')?.value}
-							css={[subheadingStyles(format), paddingStyles]}
+							format={format}
+							topPadding={true}
 						>
 							{Array.from(node.childNodes).map(
 								buildElementTree(format),
 							)}
-						</h2>
+						</Subheading>
 					);
 
 				default:

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -1037,7 +1037,7 @@ const subheadingTextLight = ({ design, theme }: ArticleFormat) => {
 				case ArticleSpecial.SpecialReport:
 					return sourcePalette.specialReport[200];
 				case ArticleSpecial.SpecialReportAlt:
-					return sourcePalette.neutral[7];
+					return sourcePalette.specialReportAlt[100];
 			}
 		case ArticleDesign.Obituary:
 		case ArticleDesign.Standard:
@@ -1072,7 +1072,7 @@ const subheadingTextDark = ({ design, theme }: ArticleFormat) => {
 				case ArticleSpecial.SpecialReport:
 					return sourcePalette.specialReport[500];
 				case ArticleSpecial.SpecialReportAlt:
-					return sourcePalette.neutral[60];
+					return sourcePalette.specialReportAlt[800];
 			}
 		case ArticleDesign.Obituary:
 		case ArticleDesign.Standard:
@@ -1082,7 +1082,7 @@ const subheadingTextDark = ({ design, theme }: ArticleFormat) => {
 		case ArticleDesign.LiveBlog:
 		case ArticleDesign.DeadBlog:
 		default:
-			return sourcePalette.neutral[60];
+			return sourcePalette.neutral[86];
 	}
 };
 const avatarLight: PaletteFunction = ({ design, theme }) => {


### PR DESCRIPTION
## What does this change?

Make sure key takeaways and q&a (the new elements) use the new subheading styles. 

## Why?

## Screenshots

<img width="1272" alt="Screenshot 2024-04-18 at 17 05 58" src="https://github.com/guardian/dotcom-rendering/assets/1229808/699c02d0-2843-49ea-8047-e4cab53ba28b">
<img width="1273" alt="Screenshot 2024-04-18 at 17 05 39" src="https://github.com/guardian/dotcom-rendering/assets/1229808/cbf5c286-b25a-4861-9d0b-0a96c15e83d3">
