### PR TITLE
Timeline article format: align left border with article grid line

### DIFF
--- a/dotcom-rendering/src/components/Timeline.tsx
+++ b/dotcom-rendering/src/components/Timeline.tsx
@@ -128,6 +128,15 @@ const eventStyles = css`
 	margin-bottom: ${space[5]}px;
 	position: relative;
 
+	${from.tablet} {
+		margin-left: -21px;
+		margin-right: -21px;
+	}
+	${from.leftCol} {
+		margin-left: -11px;
+		margin-right: -11px;
+	}
+
 	&:before {
 		${timelineBulletStyles}
 	}
@@ -139,6 +148,15 @@ const labelStyles = css`
 	padding: 3px 10px 4px 10px;
 	display: inline-block;
 	${textSans.small({ fontWeight: 'regular' })}
+
+	${from.tablet} {
+		margin-left: -21px;
+		margin-right: -21px;
+	}
+	${from.leftCol} {
+		margin-left: -11px;
+		margin-right: -11px;
+	}
 `;
 
 const immersiveMainElementEventStyles = css`
@@ -182,8 +200,8 @@ const TimelineEvent = ({
 			{event.body.map((element, index) => (
 				<ArticleElementComponent
 					// eslint-disable-next-line react/no-array-index-key -- This is only rendered once so we can safely use index to suppress the warning
-					index={index}
 					key={index}
+					index={index}
 					element={element}
 					forceDropCap="off"
 					format={format}


### PR DESCRIPTION
## What does this change?

Aligns the left border with article grid line in the Timeline article format
Addresses https://github.com/guardian/dotcom-rendering/issues/11109

## Why?

To match designs: https://www.figma.com/file/xPr2tZZger7pszcO075tAQ/New-Formats---April-23?type=design&node-id=3610-51261&mode=design&t=YXQM8NjU42mJYg3R-0

## Screenshots

| <img width=400/> | Before | After |
| - | - | - |
| mobile | ![mobile-before] | ![mobile-after] |
| tablet | ![tablet-before] | ![tablet-after] |
| wide | ![desktop-before] | ![desktop-after] |

[mobile-before]: https://github.com/guardian/dotcom-rendering/assets/9574885/74f6b75f-7633-4779-995b-6a5466e7024a
[tablet-before]: https://github.com/guardian/dotcom-rendering/assets/9574885/c82651ef-27a6-4c0f-9274-66d57d9c863e
[desktop-before]: https://github.com/guardian/dotcom-rendering/assets/9574885/96f22102-2988-4c02-b280-23949a6bbfbc
[mobile-after]: https://github.com/guardian/dotcom-rendering/assets/9574885/b2184089-a319-4cdf-8093-742ffc577352
[tablet-after]: https://github.com/guardian/dotcom-rendering/assets/9574885/5e72b044-6222-4d9a-9960-1ea613b51fa7
[desktop-after]: https://github.com/guardian/dotcom-rendering/assets/9574885/1609d917-4691-4e83-84f9-c4c0468974d3

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
