### PR TITLE
Remove unused `header-top-nav` switch

### DIFF
--- a/dotcom-rendering/src/components/Nav/ExpandedMenu/Columns.tsx
+++ b/dotcom-rendering/src/components/Nav/ExpandedMenu/Columns.tsx
@@ -220,7 +220,6 @@ type Props = {
 	editionId: EditionId;
 	isImmersive?: boolean;
 	nav: NavType;
-	headerTopBarSwitch: boolean;
 	hasPageSkin?: boolean;
 };
 
@@ -228,7 +227,6 @@ export const Columns = ({
 	isImmersive = false,
 	nav,
 	editionId,
-	headerTopBarSwitch,
 	hasPageSkin,
 }: Props) => {
 	const activeEdition = getEditionFromId(editionId);
@@ -313,7 +311,6 @@ export const Columns = ({
 			<ReaderRevenueLinks
 				readerRevenueLinks={nav.readerRevenueLinks}
 				editionId={editionId}
-				headerTopBarSwitch={headerTopBarSwitch}
 			/>
 
 			{/* This is where the edition dropdown is inserted					 */}

--- a/dotcom-rendering/src/components/Nav/ExpandedMenu/ExpandedMenu.tsx
+++ b/dotcom-rendering/src/components/Nav/ExpandedMenu/ExpandedMenu.tsx
@@ -107,7 +107,6 @@ type Props = {
 	editionId: EditionId;
 	isImmersive?: boolean;
 	nav: NavType;
-	headerTopBarSwitch: boolean;
 	hasPageSkin?: boolean;
 };
 
@@ -115,7 +114,6 @@ export const ExpandedMenu = ({
 	isImmersive,
 	nav,
 	editionId,
-	headerTopBarSwitch,
 	hasPageSkin,
 }: Props) => {
 	return (
@@ -132,7 +130,6 @@ export const ExpandedMenu = ({
 						editionId={editionId}
 						isImmersive={isImmersive}
 						nav={nav}
-						headerTopBarSwitch={headerTopBarSwitch}
 						hasPageSkin={hasPageSkin}
 					/>
 				</div>

--- a/dotcom-rendering/src/components/Nav/ExpandedMenu/ReaderRevenueLinks.tsx
+++ b/dotcom-rendering/src/components/Nav/ExpandedMenu/ReaderRevenueLinks.tsx
@@ -73,13 +73,11 @@ const mainMenuLinkStyle = css`
 type Props = {
 	readerRevenueLinks: ReaderRevenuePositions;
 	editionId: EditionId;
-	headerTopBarSwitch: boolean;
 };
 
 export const ReaderRevenueLinks = ({
 	readerRevenueLinks,
 	editionId,
-	headerTopBarSwitch,
 }: Props) => {
 	const [pageViewId, setPageViewId] = useState('');
 	const [referrerUrl, setReferrerUrl] = useState('');
@@ -98,35 +96,20 @@ export const ReaderRevenueLinks = ({
 		referrerUrl,
 	});
 
-	const links: LinkType[] = headerTopBarSwitch
-		? [
-				{
-					longTitle: 'Support us',
-					title: 'Support us',
-					mobileOnly: true,
-					url: readerRevenueLinks.sideMenu.support,
-				},
-				{
-					longTitle: 'Print subscriptions',
-					title: 'Print subscriptions',
-					mobileOnly: true,
-					url: printSubUrl,
-				},
-		  ]
-		: [
-				{
-					longTitle: 'Make a contribution',
-					title: 'Make a contribution',
-					mobileOnly: true,
-					url: readerRevenueLinks.sideMenu.contribute,
-				},
-				{
-					longTitle: 'Subscribe',
-					title: 'Subscribe',
-					mobileOnly: true,
-					url: readerRevenueLinks.sideMenu.subscribe,
-				},
-		  ];
+	const links: LinkType[] = [
+		{
+			longTitle: 'Support us',
+			title: 'Support us',
+			mobileOnly: true,
+			url: readerRevenueLinks.sideMenu.support,
+		},
+		{
+			longTitle: 'Print subscriptions',
+			title: 'Print subscriptions',
+			mobileOnly: true,
+			url: printSubUrl,
+		},
+	];
 
 	return (
 		<ul css={hideDesktop} role="menu">

--- a/dotcom-rendering/src/components/Nav/Nav.stories.tsx
+++ b/dotcom-rendering/src/components/Nav/Nav.stories.tsx
@@ -24,7 +24,6 @@ export const StandardStory = () => {
 				nav={nav}
 				subscribeUrl=""
 				editionId="UK"
-				headerTopBarSwitch={false}
 			/>
 		</Section>
 	);
@@ -45,7 +44,6 @@ export const StandardStoryTopBarHeader = () => {
 				nav={nav}
 				subscribeUrl=""
 				editionId="UK"
-				headerTopBarSwitch={true}
 			/>
 		</Section>
 	);
@@ -66,7 +64,6 @@ export const OpinionStory = () => {
 				nav={nav}
 				subscribeUrl=""
 				editionId="UK"
-				headerTopBarSwitch={false}
 			/>
 		</Section>
 	);
@@ -90,7 +87,6 @@ export const ImmersiveStory = () => {
 				nav={nav}
 				subscribeUrl=""
 				editionId="UK"
-				headerTopBarSwitch={false}
 			/>
 		</Section>
 	);
@@ -114,7 +110,6 @@ export const ExpandedMenuStory = () => {
 				nav={nav}
 				subscribeUrl=""
 				editionId="UK"
-				headerTopBarSwitch={false}
 			/>
 		</Section>
 	);
@@ -152,7 +147,6 @@ export const ExpandedMenuWithPageSkinStory = () => {
 				nav={nav}
 				subscribeUrl=""
 				editionId="UK"
-				headerTopBarSwitch={false}
 				hasPageSkin={true}
 			/>
 		</Section>

--- a/dotcom-rendering/src/components/Nav/Nav.test.tsx
+++ b/dotcom-rendering/src/components/Nav/Nav.test.tsx
@@ -11,7 +11,6 @@ describe('Nav', () => {
 				selectedPillar={Pillar.News}
 				subscribeUrl=""
 				editionId="UK"
-				headerTopBarSwitch={false}
 			/>,
 		);
 		const list = within(getByTestId('pillar-list'));
@@ -29,7 +28,6 @@ describe('Nav', () => {
 				nav={nav}
 				subscribeUrl=""
 				editionId="UK"
-				headerTopBarSwitch={false}
 			/>,
 		);
 

--- a/dotcom-rendering/src/components/Nav/Nav.tsx
+++ b/dotcom-rendering/src/components/Nav/Nav.tsx
@@ -18,7 +18,6 @@ type Props = {
 	displayRoundel?: boolean;
 	isImmersive?: boolean;
 	selectedPillar?: Pillar;
-	headerTopBarSwitch: boolean;
 	hasPageSkin?: boolean;
 };
 
@@ -61,7 +60,6 @@ export const Nav = ({
 	displayRoundel,
 	isImmersive,
 	selectedPillar,
-	headerTopBarSwitch,
 	hasPageSkin,
 }: Props) => {
 	return (
@@ -215,7 +213,6 @@ export const Nav = ({
 					editionId={editionId}
 					nav={nav}
 					isImmersive={isImmersive}
-					headerTopBarSwitch={headerTopBarSwitch}
 					hasPageSkin={hasPageSkin}
 				/>
 			</div>

--- a/dotcom-rendering/src/layouts/AllEditorialNewslettersPageLayout.tsx
+++ b/dotcom-rendering/src/layouts/AllEditorialNewslettersPageLayout.tsx
@@ -99,7 +99,6 @@ export const AllEditorialNewslettersPageLayout = ({
 						element="nav"
 					>
 						<Nav
-							headerTopBarSwitch={false}
 							nav={NAV}
 							subscribeUrl={subscribeUrl}
 							editionId={editionId}

--- a/dotcom-rendering/src/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/layouts/CommentLayout.tsx
@@ -378,9 +378,6 @@ export const CommentLayout = (props: WebProps | AppsProps) => {
 										.subscribe
 								}
 								editionId={article.editionId}
-								headerTopBarSwitch={
-									!!article.config.switches.headerTopNav
-								}
 							/>
 						</Section>
 

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -234,9 +234,6 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 							}
 							selectedPillar={NAV.selectedPillar}
 							editionId={front.editionId}
-							headerTopBarSwitch={
-								!!front.config.switches.headerTopNav
-							}
 							hasPageSkin={hasPageSkin}
 						/>
 					</Section>

--- a/dotcom-rendering/src/layouts/FullPageInteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/FullPageInteractiveLayout.tsx
@@ -169,9 +169,6 @@ const NavHeader = ({ article, NAV, format }: Props) => {
 							article.nav.readerRevenueLinks.header.subscribe
 						}
 						editionId={article.editionId}
-						headerTopBarSwitch={
-							!!article.config.switches.headerTopNav
-						}
 					/>
 				</Section>
 			</div>
@@ -255,7 +252,6 @@ const NavHeader = ({ article, NAV, format }: Props) => {
 						article.nav.readerRevenueLinks.header.subscribe
 					}
 					editionId={article.editionId}
-					headerTopBarSwitch={!!article.config.switches.headerTopNav}
 				/>
 			</Section>
 

--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -337,9 +337,6 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 										.contribute
 								}
 								editionId={article.editionId}
-								headerTopBarSwitch={
-									!!article.config.switches.headerTopNav
-								}
 							/>
 						</Section>
 					</div>

--- a/dotcom-rendering/src/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/InteractiveLayout.tsx
@@ -323,9 +323,6 @@ export const InteractiveLayout = (props: WebProps | AppsProps) => {
 										.subscribe
 								}
 								editionId={article.editionId}
-								headerTopBarSwitch={
-									!!article.config.switches.headerTopNav
-								}
 							/>
 						</Section>
 

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -377,9 +377,6 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 										.subscribe
 								}
 								editionId={article.editionId}
-								headerTopBarSwitch={
-									!!article.config.switches.headerTopNav
-								}
 							/>
 						</Section>
 

--- a/dotcom-rendering/src/layouts/NewsletterSignupLayout.tsx
+++ b/dotcom-rendering/src/layouts/NewsletterSignupLayout.tsx
@@ -274,9 +274,6 @@ export const NewsletterSignupLayout = ({ article, NAV, format }: Props) => {
 							article.nav.readerRevenueLinks.header.subscribe
 						}
 						editionId={article.editionId}
-						headerTopBarSwitch={
-							!!article.config.switches.headerTopNav
-						}
 					/>
 				</Section>
 

--- a/dotcom-rendering/src/layouts/PictureLayout.tsx
+++ b/dotcom-rendering/src/layouts/PictureLayout.tsx
@@ -357,9 +357,6 @@ export const PictureLayout = (props: WebProps | AppsProps) => {
 										.subscribe
 								}
 								editionId={article.editionId}
-								headerTopBarSwitch={
-									!!article.config.switches.headerTopNav
-								}
 							/>
 						</Section>
 

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -333,10 +333,6 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 													.header.subscribe
 											}
 											editionId={article.editionId}
-											headerTopBarSwitch={
-												!!article.config.switches
-													.headerTopNav
-											}
 										/>
 									</Section>
 
@@ -446,10 +442,6 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 													.header.subscribe
 											}
 											editionId={article.editionId}
-											headerTopBarSwitch={
-												!!article.config.switches
-													.headerTopNav
-											}
 										/>
 									</Section>
 								</Stuck>

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -408,9 +408,6 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 								article.nav.readerRevenueLinks.header.subscribe
 							}
 							editionId={article.editionId}
-							headerTopBarSwitch={
-								!!article.config.switches.headerTopNav
-							}
 						/>
 					</Section>
 					{props.NAV.subNavSections && !isLabs && (

--- a/dotcom-rendering/src/layouts/TagPageLayout.tsx
+++ b/dotcom-rendering/src/layouts/TagPageLayout.tsx
@@ -129,7 +129,6 @@ export const TagPageLayout = ({ tagPage, NAV }: Props) => {
 								tagPage.nav.readerRevenueLinks.header.subscribe
 							}
 							editionId={tagPage.editionId}
-							headerTopBarSwitch={!!switches.headerTopNav}
 						/>
 					</Section>
 					{NAV.subNavSections && (


### PR DESCRIPTION
## What does this change?

Removes conditional code for the `headerTopBarSwitch` (based off `header-top-nav` in frontend) that was added in https://github.com/guardian/dotcom-rendering/pull/6420

Since this has been live since Nov 2022 I think we're safe to assume this switch can be retired?


## Why?

Tidying up ahead of making changes. We're about to update the header, top bar and navigation menu and want to reduce possible areas of confusion ahead of this change.


## Screenshots

In the following screenshots, this is the result of the switch being in the **off** position. While the switch is on, there is no change as it currently is on and looks like the _after_ image.

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/43961396/182f9508-eccd-4a18-b86a-4e45dc525550
[after]: https://github.com/guardian/dotcom-rendering/assets/43961396/e99ebe5d-e920-4293-b64f-b5a3779fbeef

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
