### PR TITLE
Position bullet points correctly

### DIFF
--- a/dotcom-rendering/src/components/Figure.tsx
+++ b/dotcom-rendering/src/components/Figure.tsx
@@ -14,6 +14,35 @@ type Props = {
 	isTimeline?: boolean;
 };
 
+const immersiveStyles = css`
+	margin-top: ${space[3]}px;
+	margin-bottom: ${space[3]}px;
+	${until.tablet} {
+		margin-left: -20px;
+		margin-right: -20px;
+	}
+	${until.mobileLandscape} {
+		margin-left: -10px;
+		margin-right: -10px;
+	}
+	${from.tablet} {
+		margin-left: -20px;
+		margin-right: -100px;
+	}
+	${from.desktop} {
+		margin-left: -20px;
+		margin-right: -340px;
+	}
+	${from.leftCol} {
+		margin-left: -160px;
+		margin-right: -320px;
+	}
+	${from.wide} {
+		margin-left: -240px;
+		margin-right: -400px;
+	}
+`;
+
 const roleCss = {
 	inline: css`
 		margin-top: ${space[3]}px;
@@ -42,32 +71,7 @@ const roleCss = {
 	`,
 
 	immersive: css`
-		margin-top: ${space[3]}px;
-		margin-bottom: ${space[3]}px;
-		${until.tablet} {
-			margin-left: -20px;
-			margin-right: -20px;
-		}
-		${until.mobileLandscape} {
-			margin-left: -10px;
-			margin-right: -10px;
-		}
-		${from.tablet} {
-			margin-left: -20px;
-			margin-right: -100px;
-		}
-		${from.desktop} {
-			margin-left: -20px;
-			margin-right: -340px;
-		}
-		${from.leftCol} {
-			margin-left: -160px;
-			margin-right: -320px;
-		}
-		${from.wide} {
-			margin-left: -240px;
-			margin-right: -400px;
-		}
+		${immersiveStyles}
 	`,
 
 	showcase: css`
@@ -80,6 +84,12 @@ const roleCss = {
 		${from.wide} {
 			margin-left: -240px;
 		}
+	`,
+
+	showcaseTimeline: css`
+		${immersiveStyles}
+		margin-top: 0;
+		margin-bottom: 0;
 	`,
 
 	thumbnail: css`
@@ -145,11 +155,6 @@ const roleCss = {
 		clear: left;
 		margin-right: 16px;
 	`,
-
-	showcaseTimeline: css`
-		margin-top: 0;
-		margin-bottom: 0;
-	`,
 };
 
 // Used for vast majority of layouts.
@@ -166,11 +171,9 @@ export const defaultRoleStyles = (
 		case 'immersive':
 			return roleCss.immersive;
 		case 'showcase':
-			if (isTimeline)
-				return css`
-					${roleCss.immersive}
-					${roleCss.showcaseTimeline}
-				`;
+			if (isTimeline) {
+				return roleCss.showcaseTimeline;
+			}
 			return roleCss.showcase;
 		case 'thumbnail':
 			switch (format.design) {

--- a/dotcom-rendering/src/components/Figure.tsx
+++ b/dotcom-rendering/src/components/Figure.tsx
@@ -161,7 +161,12 @@ export const defaultRoleStyles = (
 		case 'immersive':
 			return roleCss.immersive;
 		case 'showcase':
-			if (isTimeline) return roleCss.immersive;
+			if (isTimeline)
+				return css`
+					${roleCss.immersive}
+					margin-top: 0;
+					margin-bottom: 0;
+				`;
 			return roleCss.showcase;
 		case 'thumbnail':
 			switch (format.design) {

--- a/dotcom-rendering/src/components/Figure.tsx
+++ b/dotcom-rendering/src/components/Figure.tsx
@@ -145,6 +145,11 @@ const roleCss = {
 		clear: left;
 		margin-right: 16px;
 	`,
+
+	showcaseTimeline: css`
+		margin-top: 0;
+		margin-bottom: 0;
+	`,
 };
 
 // Used for vast majority of layouts.
@@ -164,8 +169,7 @@ export const defaultRoleStyles = (
 			if (isTimeline)
 				return css`
 					${roleCss.immersive}
-					margin-top: 0;
-					margin-bottom: 0;
+					${roleCss.showcaseTimeline}
 				`;
 			return roleCss.showcase;
 		case 'thumbnail':

--- a/dotcom-rendering/src/components/ImageComponent.tsx
+++ b/dotcom-rendering/src/components/ImageComponent.tsx
@@ -437,7 +437,7 @@ export const ImageComponent = ({
 				)}
 
 				{isTimeline && isMainMedia && role === 'showcase' && (
-					<span css={timelineBulletStyles} />
+					<div css={timelineBulletStyles} aria-hidden="true" />
 				)}
 				{typeof starRating === 'number' && (
 					<PositionStarRating rating={starRating} />
@@ -504,7 +504,7 @@ export const ImageComponent = ({
 					/>
 				)}
 				{isTimeline && isMainMedia && role === 'showcase' && (
-					<span css={timelineBulletStyles} />
+					<div css={timelineBulletStyles} aria-hidden="true" />
 				)}
 
 				{isMainMedia && (

--- a/dotcom-rendering/src/components/ImageComponent.tsx
+++ b/dotcom-rendering/src/components/ImageComponent.tsx
@@ -343,6 +343,7 @@ export const ImageComponent = ({
 						height={imageHeight}
 						loading={loading}
 						isMainMedia={isMainMedia}
+						isTimeline={isTimeline}
 					/>
 				)}
 

--- a/dotcom-rendering/src/components/ImageComponent.tsx
+++ b/dotcom-rendering/src/components/ImageComponent.tsx
@@ -32,6 +32,34 @@ type Props = {
 	isTimeline?: boolean;
 };
 
+const timelineBulletStyles = css`
+	position: relative;
+	::before {
+		content: '';
+		position: absolute;
+		display: block;
+		width: 12px;
+		height: 12px;
+		border: 1px solid ${themePalette('--timeline-event-border')};
+		border-radius: 100%;
+		background-color: ${themePalette('--timeline-bullet')};
+		top: -6px;
+		left: -6.5px;
+
+		${from.mobileLandscape} {
+			left: 3.5px;
+		}
+
+		${from.leftCol} {
+			left: 143.5px;
+		}
+
+		${from.wide} {
+			left: 223.5px;
+		}
+	}
+`;
+
 const starsWrapper = css`
 	background-color: ${themePalette('--star-rating-background')};
 	color: ${themePalette('--star-rating-fill')};
@@ -343,7 +371,6 @@ export const ImageComponent = ({
 						height={imageHeight}
 						loading={loading}
 						isMainMedia={isMainMedia}
-						isTimeline={isTimeline}
 					/>
 				)}
 
@@ -409,6 +436,9 @@ export const ImageComponent = ({
 					/>
 				)}
 
+				{isTimeline && isMainMedia && role === 'showcase' && (
+					<span css={timelineBulletStyles} />
+				)}
 				{typeof starRating === 'number' && (
 					<PositionStarRating rating={starRating} />
 				)}
@@ -472,6 +502,9 @@ export const ImageComponent = ({
 						loading={loading}
 						isMainMedia={isMainMedia}
 					/>
+				)}
+				{isTimeline && isMainMedia && role === 'showcase' && (
+					<span css={timelineBulletStyles} />
 				)}
 
 				{isMainMedia && (

--- a/dotcom-rendering/src/components/Picture.tsx
+++ b/dotcom-rendering/src/components/Picture.tsx
@@ -1,9 +1,8 @@
 import { css } from '@emotion/react';
 import { ArticleDesign, ArticleDisplay } from '@guardian/libs';
-import { breakpoints, from } from '@guardian/source-foundations';
+import { breakpoints } from '@guardian/source-foundations';
 import { Fragment, useCallback, useEffect, useState } from 'react';
 import { generateImageURL } from '../lib/image';
-import { palette } from '../palette';
 import type { RoleType } from '../types/content';
 import type { Loading } from './CardPicture';
 
@@ -12,34 +11,6 @@ import type { Loading } from './CardPicture';
  **/
 
 export type Orientation = 'portrait' | 'landscape';
-
-const timelineBulletStyles = css`
-	position: relative;
-	::before {
-		content: '';
-		position: absolute;
-		display: block;
-		width: 12px;
-		height: 12px;
-		border: 1px solid ${palette('--timeline-event-border')};
-		border-radius: 100%;
-		background-color: ${palette('--timeline-bullet')};
-		top: -6px;
-		left: -6.5px;
-
-		${from.mobileLandscape} {
-			left: 3.5px;
-		}
-
-		${from.leftCol} {
-			left: 143.5px;
-		}
-
-		${from.wide} {
-			left: 223.5px;
-		}
-	}
-`;
 
 type Props = {
 	role: RoleType;
@@ -51,7 +22,6 @@ type Props = {
 	loading: Loading;
 	isMainMedia?: boolean;
 	isLightbox?: boolean;
-	isTimeline?: boolean;
 	orientation?: Orientation;
 	onLoad?: () => void;
 };
@@ -349,7 +319,6 @@ export const Picture = ({
 	isMainMedia = false,
 	loading,
 	isLightbox = false,
-	isTimeline = false,
 	orientation = 'landscape',
 	onLoad,
 }: Props) => {
@@ -441,9 +410,6 @@ export const Picture = ({
 					css={isLightbox ? flex : block}
 				/>
 			</picture>
-			{isTimeline && isMainMedia && role === 'showcase' && (
-				<span css={timelineBulletStyles} />
-			)}
 		</>
 	);
 };

--- a/dotcom-rendering/src/components/Picture.tsx
+++ b/dotcom-rendering/src/components/Picture.tsx
@@ -370,47 +370,45 @@ export const Picture = ({
 	const fallbackSource = getFallbackSource(sources);
 
 	return (
-		<>
-			<picture css={isLightbox ? flex : block}>
-				{/* Immersive Main Media images get additional sources specifically for when in portrait orientation */}
-				{format.display === ArticleDisplay.Immersive && isMainMedia && (
-					<>
-						{/* High resolution (HDPI) portrait sources*/}
-						<source
-							media="(orientation: portrait) and (-webkit-min-device-pixel-ratio: 1.25), (orientation: portrait) and (min-resolution: 120dpi)"
-							sizes={sizes}
-							srcSet={sources
-								.map(
-									(source) =>
-										`${source.hiResUrl} ${source.width}w`,
-								)
-								.join(',')}
-						/>
-						{/* Low resolution (MDPI) portrait sources*/}
-						<source
-							media="(orientation: portrait)"
-							sizes={sizes}
-							srcSet={sources
-								.map(
-									(source) =>
-										`${source.lowResUrl} ${source.width}w`,
-								)
-								.join(',')}
-						/>
-					</>
-				)}
-				<Sources sources={sources} />
-				<img
-					ref={ref}
-					alt={alt}
-					src={fallbackSource.lowResUrl}
-					width={fallbackSource.width}
-					height={fallbackSource.width * ratio}
-					loading={Picture.disableLazyLoading ? undefined : loading}
-					css={isLightbox ? flex : block}
-				/>
-			</picture>
-		</>
+		<picture css={isLightbox ? flex : block}>
+			{/* Immersive Main Media images get additional sources specifically for when in portrait orientation */}
+			{format.display === ArticleDisplay.Immersive && isMainMedia && (
+				<>
+					{/* High resolution (HDPI) portrait sources*/}
+					<source
+						media="(orientation: portrait) and (-webkit-min-device-pixel-ratio: 1.25), (orientation: portrait) and (min-resolution: 120dpi)"
+						sizes={sizes}
+						srcSet={sources
+							.map(
+								(source) =>
+									`${source.hiResUrl} ${source.width}w`,
+							)
+							.join(',')}
+					/>
+					{/* Low resolution (MDPI) portrait sources*/}
+					<source
+						media="(orientation: portrait)"
+						sizes={sizes}
+						srcSet={sources
+							.map(
+								(source) =>
+									`${source.lowResUrl} ${source.width}w`,
+							)
+							.join(',')}
+					/>
+				</>
+			)}
+			<Sources sources={sources} />
+			<img
+				ref={ref}
+				alt={alt}
+				src={fallbackSource.lowResUrl}
+				width={fallbackSource.width}
+				height={fallbackSource.width * ratio}
+				loading={Picture.disableLazyLoading ? undefined : loading}
+				css={isLightbox ? flex : block}
+			/>
+		</picture>
 	);
 };
 

--- a/dotcom-rendering/src/components/Picture.tsx
+++ b/dotcom-rendering/src/components/Picture.tsx
@@ -1,8 +1,9 @@
 import { css } from '@emotion/react';
 import { ArticleDesign, ArticleDisplay } from '@guardian/libs';
-import { breakpoints } from '@guardian/source-foundations';
+import { breakpoints, from } from '@guardian/source-foundations';
 import { Fragment, useCallback, useEffect, useState } from 'react';
 import { generateImageURL } from '../lib/image';
+import { palette } from '../palette';
 import type { RoleType } from '../types/content';
 import type { Loading } from './CardPicture';
 
@@ -11,6 +12,34 @@ import type { Loading } from './CardPicture';
  **/
 
 export type Orientation = 'portrait' | 'landscape';
+
+const timelineBulletStyles = css`
+	position: relative;
+	::before {
+		content: '';
+		position: absolute;
+		display: block;
+		width: 12px;
+		height: 12px;
+		border: 1px solid ${palette('--timeline-event-border')};
+		border-radius: 1000px;
+		background-color: ${palette('--timeline-bullet')};
+		top: -6px;
+		left: -7px;
+
+		${from.mobileLandscape} {
+			left: 4px;
+		}
+
+		${from.leftCol} {
+			left: 144px;
+		}
+
+		${from.wide} {
+			left: 224px;
+		}
+	}
+`;
 
 type Props = {
 	role: RoleType;
@@ -22,6 +51,7 @@ type Props = {
 	loading: Loading;
 	isMainMedia?: boolean;
 	isLightbox?: boolean;
+	isTimeline?: boolean;
 	orientation?: Orientation;
 	onLoad?: () => void;
 };
@@ -319,6 +349,7 @@ export const Picture = ({
 	isMainMedia = false,
 	loading,
 	isLightbox = false,
+	isTimeline = false,
 	orientation = 'landscape',
 	onLoad,
 }: Props) => {
@@ -370,45 +401,50 @@ export const Picture = ({
 	const fallbackSource = getFallbackSource(sources);
 
 	return (
-		<picture css={isLightbox ? flex : block}>
-			{/* Immersive Main Media images get additional sources specifically for when in portrait orientation */}
-			{format.display === ArticleDisplay.Immersive && isMainMedia && (
-				<>
-					{/* High resolution (HDPI) portrait sources*/}
-					<source
-						media="(orientation: portrait) and (-webkit-min-device-pixel-ratio: 1.25), (orientation: portrait) and (min-resolution: 120dpi)"
-						sizes={sizes}
-						srcSet={sources
-							.map(
-								(source) =>
-									`${source.hiResUrl} ${source.width}w`,
-							)
-							.join(',')}
-					/>
-					{/* Low resolution (MDPI) portrait sources*/}
-					<source
-						media="(orientation: portrait)"
-						sizes={sizes}
-						srcSet={sources
-							.map(
-								(source) =>
-									`${source.lowResUrl} ${source.width}w`,
-							)
-							.join(',')}
-					/>
-				</>
-			)}
-			<Sources sources={sources} />
-			<img
-				ref={ref}
-				alt={alt}
-				src={fallbackSource.lowResUrl}
-				width={fallbackSource.width}
-				height={fallbackSource.width * ratio}
-				loading={Picture.disableLazyLoading ? undefined : loading}
-				css={isLightbox ? flex : block}
-			/>
-		</picture>
+		<>
+			<picture css={[isLightbox ? flex : block]}>
+				{/* Immersive Main Media images get additional sources specifically for when in portrait orientation */}
+				{format.display === ArticleDisplay.Immersive && isMainMedia && (
+					<>
+						{/* High resolution (HDPI) portrait sources*/}
+						<source
+							media="(orientation: portrait) and (-webkit-min-device-pixel-ratio: 1.25), (orientation: portrait) and (min-resolution: 120dpi)"
+							sizes={sizes}
+							srcSet={sources
+								.map(
+									(source) =>
+										`${source.hiResUrl} ${source.width}w`,
+								)
+								.join(',')}
+						/>
+						{/* Low resolution (MDPI) portrait sources*/}
+						<source
+							media="(orientation: portrait)"
+							sizes={sizes}
+							srcSet={sources
+								.map(
+									(source) =>
+										`${source.lowResUrl} ${source.width}w`,
+								)
+								.join(',')}
+						/>
+					</>
+				)}
+				<Sources sources={sources} />
+				<img
+					ref={ref}
+					alt={alt}
+					src={fallbackSource.lowResUrl}
+					width={fallbackSource.width}
+					height={fallbackSource.width * ratio}
+					loading={Picture.disableLazyLoading ? undefined : loading}
+					css={isLightbox ? flex : block}
+				/>
+			</picture>
+			{isTimeline && isMainMedia && role === 'showcase' ? (
+				<span css={timelineBulletStyles} />
+			) : null}
+		</>
 	);
 };
 

--- a/dotcom-rendering/src/components/Picture.tsx
+++ b/dotcom-rendering/src/components/Picture.tsx
@@ -25,18 +25,18 @@ const timelineBulletStyles = css`
 		border-radius: 1000px;
 		background-color: ${palette('--timeline-bullet')};
 		top: -6px;
-		left: -7px;
+		left: -6.5px;
 
 		${from.mobileLandscape} {
-			left: 4px;
+			left: 3.5px;
 		}
 
 		${from.leftCol} {
-			left: 144px;
+			left: 143.5px;
 		}
 
 		${from.wide} {
-			left: 224px;
+			left: 223.5px;
 		}
 	}
 `;
@@ -441,9 +441,9 @@ export const Picture = ({
 					css={isLightbox ? flex : block}
 				/>
 			</picture>
-			{isTimeline && isMainMedia && role === 'showcase' ? (
+			{isTimeline && isMainMedia && role === 'showcase' && (
 				<span css={timelineBulletStyles} />
-			) : null}
+			)}
 		</>
 	);
 };

--- a/dotcom-rendering/src/components/Picture.tsx
+++ b/dotcom-rendering/src/components/Picture.tsx
@@ -22,7 +22,7 @@ const timelineBulletStyles = css`
 		width: 12px;
 		height: 12px;
 		border: 1px solid ${palette('--timeline-event-border')};
-		border-radius: 1000px;
+		border-radius: 100%;
 		background-color: ${palette('--timeline-bullet')};
 		top: -6px;
 		left: -6.5px;
@@ -402,7 +402,7 @@ export const Picture = ({
 
 	return (
 		<>
-			<picture css={[isLightbox ? flex : block]}>
+			<picture css={isLightbox ? flex : block}>
 				{/* Immersive Main Media images get additional sources specifically for when in portrait orientation */}
 				{format.display === ArticleDisplay.Immersive && isMainMedia && (
 					<>

--- a/dotcom-rendering/src/components/Timeline.tsx
+++ b/dotcom-rendering/src/components/Timeline.tsx
@@ -26,13 +26,14 @@ const hasShowcaseRole = (element?: FEElement): boolean => {
 const timelineBulletStyles = css`
 	position: relative;
 	::before {
-		border-radius: 1000px;
+		content: '';
+		position: absolute;
 		display: block;
-		background-color: ${palette('--timeline-bullet')};
 		width: 12px;
 		height: 12px;
-		content: '';
 		border: 1px solid ${palette('--timeline-event-border')};
+		border-radius: 100%;
+		background-color: ${palette('--timeline-bullet')};
 		position: absolute;
 		left: -16.5px;
 		top: -10px;

--- a/dotcom-rendering/src/components/Timeline.tsx
+++ b/dotcom-rendering/src/components/Timeline.tsx
@@ -32,8 +32,8 @@ const timelineBulletStyles = css`
 	content: '';
 	border: 1px solid ${palette('--timeline-event-border')};
 	position: absolute;
-	left: -7px;
-	top: -6px;
+	left: -16px;
+	top: -10px;
 `;
 
 const smallDateStyles = css`
@@ -65,6 +65,14 @@ const titleStyles = (format: ArticleFormat): SerializedStyles => css`
 	}
 `;
 
+const headingStyles = css`
+	margin-top: 4px;
+	position: relative;
+	::before {
+		${timelineBulletStyles}
+	}
+`;
+
 type EventHeaderProps = {
 	event: DCRTimelineEvent;
 	ArticleElementComponent: NestedArticleElement;
@@ -81,7 +89,7 @@ const EventHeader = ({
 	smallDates,
 }: EventHeaderProps) => {
 	const heading = (
-		<Heading level={sectioned ? 3 : 2}>
+		<Heading css={headingStyles} level={sectioned ? 3 : 2}>
 			<span css={smallDates ? smallDateStyles : titleStyles(format)}>
 				{event.date}
 			</span>
@@ -124,7 +132,7 @@ const EventHeader = ({
 
 const eventStyles = css`
 	border: 1px solid ${palette('--timeline-event-border')};
-	padding: ${space[1]}px 10px ${space[6]}px 10px;
+	padding: 0 10px ${space[6]}px 10px;
 	margin-bottom: ${space[5]}px;
 	position: relative;
 
@@ -135,10 +143,6 @@ const eventStyles = css`
 	${from.leftCol} {
 		margin-left: -11px;
 		margin-right: -11px;
-	}
-
-	&:before {
-		${timelineBulletStyles}
 	}
 `;
 

--- a/dotcom-rendering/src/components/Timeline.tsx
+++ b/dotcom-rendering/src/components/Timeline.tsx
@@ -24,16 +24,19 @@ const hasShowcaseRole = (element?: FEElement): boolean => {
 // ----- EventHeader ----- //
 
 const timelineBulletStyles = css`
-	border-radius: 1000px;
-	display: block;
-	background-color: ${palette('--timeline-bullet')};
-	width: 12px;
-	height: 12px;
-	content: '';
-	border: 1px solid ${palette('--timeline-event-border')};
-	position: absolute;
-	left: -16px;
-	top: -10px;
+	position: relative;
+	::before {
+		border-radius: 1000px;
+		display: block;
+		background-color: ${palette('--timeline-bullet')};
+		width: 12px;
+		height: 12px;
+		content: '';
+		border: 1px solid ${palette('--timeline-event-border')};
+		position: absolute;
+		left: -16px;
+		top: -10px;
+	}
 `;
 
 const smallDateStyles = css`
@@ -67,10 +70,6 @@ const titleStyles = (format: ArticleFormat): SerializedStyles => css`
 
 const headingStyles = css`
 	margin-top: 4px;
-	position: relative;
-	::before {
-		${timelineBulletStyles}
-	}
 `;
 
 type EventHeaderProps = {
@@ -89,7 +88,13 @@ const EventHeader = ({
 	smallDates,
 }: EventHeaderProps) => {
 	const heading = (
-		<Heading css={headingStyles} level={sectioned ? 3 : 2}>
+		<Heading
+			css={[
+				headingStyles,
+				!hasShowcaseRole(event.main) && timelineBulletStyles,
+			]}
+			level={sectioned ? 3 : 2}
+		>
 			<span css={smallDates ? smallDateStyles : titleStyles(format)}>
 				{event.date}
 			</span>
@@ -209,6 +214,7 @@ const TimelineEvent = ({
 					element={element}
 					forceDropCap="off"
 					format={format}
+					isTimeline={true}
 				/>
 			))}
 		</section>

--- a/dotcom-rendering/src/components/Timeline.tsx
+++ b/dotcom-rendering/src/components/Timeline.tsx
@@ -34,7 +34,7 @@ const timelineBulletStyles = css`
 		content: '';
 		border: 1px solid ${palette('--timeline-event-border')};
 		position: absolute;
-		left: -16px;
+		left: -16.5px;
 		top: -10px;
 	}
 `;

--- a/dotcom-rendering/src/components/Timeline.tsx
+++ b/dotcom-rendering/src/components/Timeline.tsx
@@ -34,7 +34,6 @@ const timelineBulletStyles = css`
 		border: 1px solid ${palette('--timeline-event-border')};
 		border-radius: 100%;
 		background-color: ${palette('--timeline-bullet')};
-		position: absolute;
 		left: -16.5px;
 		top: -10px;
 	}


### PR DESCRIPTION
## What does this change?

Fixes https://github.com/guardian/dotcom-rendering/issues/11170

Position bullet points to match [Figma designs](https://www.figma.com/file/xPr2tZZger7pszcO075tAQ/New-Formats---April-23?type=design&node-id=3610-51261&mode=design&t=ZOPgE41zDSoTO3Au-0).

The bullet points will be in the top-left of the section border, except when there is a main media image. Then, the bullet must be at the bottom of the image 

## Screenshots

### Mobile
<img width="300" alt="mobile-after" src="https://github.com/guardian/dotcom-rendering/assets/9574885/5a7cb44f-8fe7-41fd-b799-ddc6fafbb3b3">

### Tablet
<img width="500" alt="tablet-after" src="https://github.com/guardian/dotcom-rendering/assets/9574885/53004090-6636-4d84-8300-e8983a919564">

### Desktop
<img width="600" alt="desktop-after" src="https://github.com/guardian/dotcom-rendering/assets/9574885/47cfe96d-965d-475c-a9a9-95ffc5eb498e">

### Left-col
<img width="600" alt="leftCol-after" src="https://github.com/guardian/dotcom-rendering/assets/9574885/539f89be-1b91-4327-9396-e55abd2ce016">

### Wide
<img width="600" alt="wide-after" src="https://github.com/guardian/dotcom-rendering/assets/9574885/a0ec69f0-9073-45d1-84ac-84e57fcf1a1f">


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
