### PR TITLE
Use `isOneOf` for custom type predicates

### DIFF
--- a/dotcom-rendering/src/client/islands/getPriority.ts
+++ b/dotcom-rendering/src/client/islands/getPriority.ts
@@ -1,3 +1,4 @@
+import { isString } from '@guardian/libs';
 import type { Priority } from '../../lib/scheduler';
 import { isValidSchedulerPriority } from '../../lib/scheduler';
 
@@ -12,7 +13,7 @@ import { isValidSchedulerPriority } from '../../lib/scheduler';
 export const getPriority = (marker: HTMLElement): Priority | undefined => {
 	const priority = marker.getAttribute('priority');
 
-	if (isValidSchedulerPriority(priority)) {
+	if (isString(priority) && isValidSchedulerPriority(priority)) {
 		return priority;
 	}
 

--- a/dotcom-rendering/src/components/ContentABTest.amp.tsx
+++ b/dotcom-rendering/src/components/ContentABTest.amp.tsx
@@ -1,6 +1,6 @@
 import { createHash } from 'node:crypto';
+import { isOneOf } from '@guardian/libs';
 import React from 'react';
-import { guard } from '../lib/guard';
 import type { Switches } from '../types/config';
 
 const AB_TEST_GROUPS = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11] as const;
@@ -9,7 +9,7 @@ const NUM_GROUPS = AB_TEST_GROUPS.length;
 
 type ContentABTestGroup = (typeof AB_TEST_GROUPS)[number];
 
-const isContentABTestGroup = guard(AB_TEST_GROUPS);
+const isContentABTestGroup = isOneOf(AB_TEST_GROUPS);
 
 interface ContentABTestContext {
 	group?: ContentABTestGroup;

--- a/dotcom-rendering/src/components/SignInGate/types.ts
+++ b/dotcom-rendering/src/components/SignInGate/types.ts
@@ -1,7 +1,5 @@
 import type { CountryCode } from '@guardian/libs';
-import { isObject, isString } from '@guardian/libs';
-import type { Guard } from '../../lib/guard';
-import { guard } from '../../lib/guard';
+import { isObject, isOneOf, isString } from '@guardian/libs';
 import type { TagType } from '../../types/tag';
 
 export type CanShowGateProps = {
@@ -24,9 +22,9 @@ export type SignInGateComponent = {
 };
 
 export const ALL_USER_TYPES = ['new', 'guest', 'current'] as const;
-export type UserType = Guard<typeof ALL_USER_TYPES>;
+export type UserType = (typeof ALL_USER_TYPES)[number];
 
-export const isUserType = guard(ALL_USER_TYPES);
+export const isUserType = isOneOf(ALL_USER_TYPES);
 
 export const ALL_PRODUCTS = [
 	'Contribution',
@@ -34,9 +32,9 @@ export const ALL_PRODUCTS = [
 	'Paper',
 	'GuardianWeekly',
 ] as const;
-export type Product = Guard<typeof ALL_PRODUCTS>;
+export type Product = (typeof ALL_PRODUCTS)[number];
 
-export const isProduct = guard(ALL_PRODUCTS);
+export const isProduct = isOneOf(ALL_PRODUCTS);
 export interface CheckoutCompleteCookieData {
 	userType: UserType;
 	product: Product;

--- a/dotcom-rendering/src/lib/discussion.ts
+++ b/dotcom-rendering/src/lib/discussion.ts
@@ -1,3 +1,4 @@
+import { isOneOf } from '@guardian/libs';
 import type { BaseSchema, Input, Output } from 'valibot';
 import {
 	array,
@@ -25,8 +26,6 @@ import type {
 	reportAbuse,
 	unPickComment,
 } from './discussionApi';
-import type { Guard } from './guard';
-import { guard } from './guard';
 import { error, ok, type Result } from './result';
 
 export type CAPIPillar =
@@ -248,16 +247,16 @@ export const postUsernameResponseSchema = variant('status', [
 ]);
 
 const orderBy = ['newest', 'oldest', 'recommendations'] as const;
-export const isOrderBy = guard(orderBy);
-export type OrderByType = Guard<typeof orderBy>;
+export const isOrderBy = isOneOf(orderBy);
+export type OrderByType = (typeof orderBy)[number];
 
 const threads = ['collapsed', 'expanded', 'unthreaded'] as const;
-export const isThreads = guard(threads);
-export type ThreadsType = Guard<typeof threads>;
+export const isThreads = isOneOf(threads);
+export type ThreadsType = (typeof threads)[number];
 
 const pageSize = [25, 50, 100] as const;
-export const isPageSize = guard(pageSize);
-export type PageSizeType = Guard<typeof pageSize>;
+export const isPageSize = isOneOf(pageSize);
+export type PageSizeType = (typeof pageSize)[number];
 export interface FilterOptions {
 	orderBy: OrderByType;
 	pageSize: PageSizeType;

--- a/dotcom-rendering/src/lib/edition.ts
+++ b/dotcom-rendering/src/lib/edition.ts
@@ -1,5 +1,5 @@
+import { isOneOf } from '@guardian/libs';
 import type { EditionLinkType } from '../model/extract-nav';
-import { guard } from './guard';
 
 export type EditionId = (typeof editionList)[number]['editionId'];
 
@@ -66,4 +66,6 @@ export const getRemainingEditions = (
  *
  * @param s The string to test
  */
-export const isEditionId = guard(editionList.map(({ editionId }) => editionId));
+export const isEditionId = isOneOf(
+	editionList.map(({ editionId }) => editionId),
+);

--- a/dotcom-rendering/src/lib/guard.ts
+++ b/dotcom-rendering/src/lib/guard.ts
@@ -1,7 +1,0 @@
-/** A method to create type-guard for string unions */
-export const guard =
-	<T extends readonly unknown[]>(array: T) =>
-	(value: unknown): value is (typeof array)[number] =>
-		array.includes(value);
-
-export type Guard<T> = T extends readonly unknown[] ? T[number] : never;

--- a/dotcom-rendering/src/lib/scheduler.ts
+++ b/dotcom-rendering/src/lib/scheduler.ts
@@ -1,6 +1,4 @@
-import { startPerformanceMeasure } from '@guardian/libs';
-import type { Guard } from './guard';
-import { guard } from './guard';
+import { isOneOf, startPerformanceMeasure } from '@guardian/libs';
 
 const START = Date.now();
 
@@ -24,10 +22,10 @@ let CONCURRENCY_COUNT = Infinity;
  * priorities, and the scheduler will prefer the priority with the lowest index.
  **/
 const PRIORITIES = ['critical', 'feature', 'enhancement'] as const;
-export type Priority = Guard<typeof PRIORITIES>;
+export type Priority = (typeof PRIORITIES)[number];
 export type SchedulePriority = { [K in Priority]: K };
 
-export const isValidSchedulerPriority = guard(PRIORITIES);
+export const isValidSchedulerPriority = isOneOf(PRIORITIES);
 
 /**
  * A thing that a consumer want to do. Should be a function that returns a promise.

--- a/dotcom-rendering/src/types/territory.ts
+++ b/dotcom-rendering/src/types/territory.ts
@@ -1,13 +1,12 @@
-import type { Guard } from '../lib/guard';
-import { guard } from '../lib/guard';
+import { isOneOf } from '@guardian/libs';
 
 type AmericanTerritories = 'US-East-Coast' | 'US-West-Coast';
 
 type EuropeanTerritories = 'EU-27';
 
 const australianTerritories = ['AU-VIC', 'AU-QLD', 'AU-NSW'] as const;
-export const isAustralianTerritory = guard(australianTerritories);
-export type AustralianTerritory = Guard<typeof australianTerritories>;
+export const isAustralianTerritory = isOneOf(australianTerritories);
+export type AustralianTerritory = (typeof australianTerritories)[number];
 
 type NewZealandTerritories = 'NZ';
 


### PR DESCRIPTION
## What does this change?

use [@guardian/lib’s `isOneOf`](https://github.com/guardian/csnx/blob/b85fe77dca9b26f97e0d0d01b0c6ac2982c33276/libs/%40guardian/libs/src/isOneOf/README.md) instead of `guard`

## Why?

Using a standard helper is easier to maintain, and more likely to be familiar for future travellers