### PR TITLE
Bump `browserslist` to  v4.23.0

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -131,7 +131,7 @@
 		"babel-plugin-polyfill-corejs3": "0.6.0",
 		"babel-plugin-transform-runtime": "6.23.0",
 		"body-parser": "1.20.1",
-		"browserslist": "4.21.9",
+		"browserslist": "4.23.0",
 		"buffer": "6.0.3",
 		"chalk": "4.1.2",
 		"clean-css": "5.3.3",

--- a/dotcom-rendering/webpack/browser-targets.test.ts
+++ b/dotcom-rendering/webpack/browser-targets.test.ts
@@ -11,7 +11,7 @@ describe('Browser targets are as expected', () => {
 			edge: '109.0.0',
 			firefox: '78.0.0',
 			ios: '10.3.0',
-			opera: '73.0.0',
+			opera: '105.0.0',
 			safari: '11.1.0',
 			samsung: '17.0.0',
 		});
@@ -22,7 +22,7 @@ describe('Browser targets are as expected', () => {
 			edge: '109.0.0',
 			firefox: '78.0.0',
 			ios: '11', // upgraded
-			opera: '73.0.0',
+			opera: '105.0.0',
 			safari: '11.1.0', // upgraded
 			samsung: '17.0.0',
 		});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -349,13 +349,13 @@ importers:
         version: 6.0.0
       '@guardian/browserslist-config':
         specifier: 6.1.0
-        version: 6.1.0(browserslist@4.21.9)(tslib@2.6.2)
+        version: 6.1.0(browserslist@4.23.0)(tslib@2.6.2)
       '@guardian/cdk':
         specifier: 50.13.0
         version: 50.13.0(@swc/core@1.4.8)(@types/node@18.18.14)(aws-cdk-lib@2.100.0)(aws-cdk@2.100.0)(constructs@10.3.0)(typescript@5.3.3)
       '@guardian/commercial':
         specifier: 17.12.0
-        version: 17.12.0(@guardian/ab-core@7.0.1)(@guardian/core-web-vitals@6.0.0)(@guardian/identity-auth-frontend@4.0.0)(@guardian/identity-auth@2.1.0)(@guardian/libs@16.1.0)(@guardian/source-foundations@14.1.4)(@guardian/support-dotcom-components@1.1.3)(typescript@5.3.3)
+        version: 17.12.0(@guardian/ab-core@7.0.1)(@guardian/core-web-vitals@6.0.0)(@guardian/identity-auth-frontend@4.0.0)(@guardian/identity-auth@2.1.0)(@guardian/libs@16.1.0)(@guardian/source-foundations@14.1.4)(@guardian/support-dotcom-components@2.1.0)(typescript@5.3.3)
       '@guardian/core-web-vitals':
         specifier: 6.0.0
         version: 6.0.0(@guardian/libs@16.1.0)(tslib@2.6.2)(typescript@5.3.3)(web-vitals@3.5.1)
@@ -603,8 +603,8 @@ importers:
         specifier: 1.20.1
         version: 1.20.1
       browserslist:
-        specifier: 4.21.9
-        version: 4.21.9
+        specifier: 4.23.0
+        version: 4.23.0
       buffer:
         specifier: 6.0.3
         version: 6.0.3
@@ -2008,7 +2008,7 @@ packages:
       '@babel/compat-data': 7.23.5
       '@babel/core': 7.23.2
       '@babel/helper-validator-option': 7.23.5
-      browserslist: 4.21.9
+      browserslist: 4.23.0
       semver: 6.3.1
     dev: false
 
@@ -2018,7 +2018,7 @@ packages:
     dependencies:
       '@babel/compat-data': 7.23.5
       '@babel/helper-validator-option': 7.23.5
-      browserslist: 4.22.2
+      browserslist: 4.23.0
       lru-cache: 5.1.1
       semver: 6.3.1
     dev: false
@@ -4275,13 +4275,13 @@ packages:
     resolution: {integrity: sha512-aiRVLDF/UfNYeoF10ptBDs52Fv1T4sd19uKACTZSr1uMgV2BPmzG+/BiVLi8Q9/6gjS+CTP3Covz62liksAFuQ==}
     dev: false
 
-  /@guardian/browserslist-config@6.1.0(browserslist@4.21.9)(tslib@2.6.2):
+  /@guardian/browserslist-config@6.1.0(browserslist@4.23.0)(tslib@2.6.2):
     resolution: {integrity: sha512-qM0QxAv6E5IHXny5Okli6AZXEio0mpXzzEzz38qrb4IwO91R6eWVKyihdj0qW2k7TVxMFVOSfNmBZ1H5EiJhgw==}
     peerDependencies:
       browserslist: ^4.22.2
       tslib: ^2.6.2
     dependencies:
-      browserslist: 4.21.9
+      browserslist: 4.23.0
       tslib: 2.6.2
     dev: false
 
@@ -4313,7 +4313,8 @@ packages:
       - '@types/node'
       - typescript
     dev: false
-  /@guardian/commercial@17.12.0(@guardian/ab-core@7.0.1)(@guardian/core-web-vitals@6.0.0)(@guardian/identity-auth-frontend@4.0.0)(@guardian/identity-auth@2.1.0)(@guardian/libs@16.1.0)(@guardian/source-foundations@14.1.4)(@guardian/support-dotcom-components@1.1.3)(typescript@5.3.3):
+
+  /@guardian/commercial@17.12.0(@guardian/ab-core@7.0.1)(@guardian/core-web-vitals@6.0.0)(@guardian/identity-auth-frontend@4.0.0)(@guardian/identity-auth@2.1.0)(@guardian/libs@16.1.0)(@guardian/source-foundations@14.1.4)(@guardian/support-dotcom-components@2.1.0)(typescript@5.3.3):
     resolution: {integrity: sha512-BLK5F3XrQqhDcL08em7f6zsijlv0epFj2Y2lGxL+sD16eYnug/GYSmXRJJlp1r2vPG1DqG9PbCF8s/awMsLqoQ==}
     peerDependencies:
       '@guardian/ab-core': ^7.0.1
@@ -10182,26 +10183,15 @@ packages:
       pako: 0.2.9
     dev: false
 
-  /browserslist@4.21.9:
-    resolution: {integrity: sha512-M0MFoZzbUrRU4KNfCrDLnvyE7gub+peetoTid3TBIqtunaDJyXlwhakT+/VkvSXcfIzFfK/nkCs4nmyTmxdNSg==}
+  /browserslist@4.23.0:
+    resolution: {integrity: sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
     dependencies:
-      caniuse-lite: 1.0.30001570
-      electron-to-chromium: 1.4.613
+      caniuse-lite: 1.0.30001612
+      electron-to-chromium: 1.4.745
       node-releases: 2.0.14
-      update-browserslist-db: 1.0.13(browserslist@4.21.9)
-    dev: false
-
-  /browserslist@4.22.2:
-    resolution: {integrity: sha512-0UgcrvQmBDvZHFGdYUehrCNIazki7/lUP3kkoi/r3YB2amZbFM9J43ZRkJTXBUZK4gmx56+Sqk9+Vs9mwZx9+A==}
-    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
-    hasBin: true
-    dependencies:
-      caniuse-lite: 1.0.30001570
-      electron-to-chromium: 1.4.613
-      node-releases: 2.0.14
-      update-browserslist-db: 1.0.13(browserslist@4.22.2)
+      update-browserslist-db: 1.0.13(browserslist@4.23.0)
     dev: false
 
   /bs-logger@0.2.6:
@@ -10337,8 +10327,8 @@ packages:
     engines: {node: '>=10'}
     dev: false
 
-  /caniuse-lite@1.0.30001570:
-    resolution: {integrity: sha512-+3e0ASu4sw1SWaoCtvPeyXp+5PsjigkSt8OXZbF9StH5pQWbxEjLAZE3n8Aup5udop1uRiKA7a4utUk/uoSpUw==}
+  /caniuse-lite@1.0.30001612:
+    resolution: {integrity: sha512-lFgnZ07UhaCcsSZgWW0K5j4e69dK1u/ltrL9lTUiFOwNHs12S3UMIEYgBV0Z6C6hRDev7iRnMzzYmKabYdXF9g==}
     dev: false
 
   /cardinal@2.1.1:
@@ -10819,7 +10809,7 @@ packages:
   /core-js-compat@3.34.0:
     resolution: {integrity: sha512-4ZIyeNbW/Cn1wkMMDy+mvrRUxrwFNjKwbhCfQpDd+eLgYipDqp8oGFGtLmhh18EDPKA0g3VUBYOxQGGwvWLVpA==}
     dependencies:
-      browserslist: 4.22.2
+      browserslist: 4.23.0
     dev: false
 
   /core-js-pure@3.35.0:
@@ -11600,8 +11590,8 @@ packages:
       jake: 10.8.7
     dev: false
 
-  /electron-to-chromium@1.4.613:
-    resolution: {integrity: sha512-r4x5+FowKG6q+/Wj0W9nidx7QO31BJwmR2uEo+Qh3YLGQ8SbBAFuDFpTxzly/I2gsbrFwBuIjrMp423L3O5U3w==}
+  /electron-to-chromium@1.4.745:
+    resolution: {integrity: sha512-tRbzkaRI5gbUn5DEvF0dV4TQbMZ5CLkWeTAXmpC9IrYT+GE+x76i9p+o3RJ5l9XmdQlI1pPhVtE9uNcJJ0G0EA==}
     dev: false
 
   /emittery@0.13.1:
@@ -19605,24 +19595,13 @@ packages:
     engines: {node: '>=8'}
     dev: false
 
-  /update-browserslist-db@1.0.13(browserslist@4.21.9):
+  /update-browserslist-db@1.0.13(browserslist@4.23.0):
     resolution: {integrity: sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==}
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
     dependencies:
-      browserslist: 4.21.9
-      escalade: 3.1.1
-      picocolors: 1.0.0
-    dev: false
-
-  /update-browserslist-db@1.0.13(browserslist@4.22.2):
-    resolution: {integrity: sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==}
-    hasBin: true
-    peerDependencies:
-      browserslist: '>= 4.21.0'
-    dependencies:
-      browserslist: 4.22.2
+      browserslist: 4.23.0
       escalade: 3.1.1
       picocolors: 1.0.0
     dev: false
@@ -20124,7 +20103,7 @@ packages:
       '@webassemblyjs/wasm-parser': 1.12.1
       acorn: 8.11.2
       acorn-import-assertions: 1.9.0(acorn@8.11.2)
-      browserslist: 4.22.2
+      browserslist: 4.23.0
       chrome-trace-event: 1.0.3
       enhanced-resolve: 5.16.0
       es-module-lexer: 1.4.1


### PR DESCRIPTION
## What does this change?

literally: “Bump `browserslist` to  v4.23.0”

See https://github.com/guardian/csnx/pull/1217 for the latest changes.

## Why?

This addresses an unmet peer dependency from `@guardian/browserslist-config`

```
$ pnpm install --resolution-only

dotcom-rendering
├─ […]
│ 
├─┬ @guardian/browserslist-config 6.1.0
│ └── ✕ unmet peer browserslist@^4.22.2: found 4.21.9
│
└─ […]
```