### PR TITLE
Change RFC template to more generic Issue template 

### DIFF
--- a/.github/ISSUE_TEMPLATE/request-for-change.yml
+++ b/.github/ISSUE_TEMPLATE/request-for-change.yml
@@ -16,3 +16,13 @@ body:
 
         **Who is responsible for closing this issue?**
         Once the issue is created, it is the responsibility of the _Dotcom team_ (@guardian/dotcom-platform) to provide feedback and help you get your change to the finish line.
+  - type: textarea
+    id: change-description
+    attributes:
+      label: Context
+      description: Please describe the change and why it's needed
+  - type: textarea
+    id: priority
+    attributes:
+      label: Priority
+      description: Please describe how urgent this change is

--- a/.github/ISSUE_TEMPLATE/request-for-change.yml
+++ b/.github/ISSUE_TEMPLATE/request-for-change.yml
@@ -1,18 +1,18 @@
-name: DCR Request for comments
-description: Tell us about a feature that you're planning to implement in dotcom rendering
-title: '[RFC]: '
-labels: ['RFC']
+name: DCR Issue
+description: Describe the work that should be completed as part of this ticket
+title: ' '
+labels: ['Rota']
 projects: ['guardian/88']
 body:
   - type: markdown
     attributes:
       value: |
-        The Dotcom team would like to help you with your proposed change. Please provide us with a brief and concise explanation for what you're looking to do we will try to make the process easier with early feedback or advice.
+        The Dotcom team would like to help you with your proposed change. Please provide us with a brief and concise explanation for what you're looking to do. We will try to make the process easier with early feedback or advice.
 
-        **When should an RFC be used?**
+        **When should an issue be created?**
         This is an optional process. If you own the code you're working on or feel confident about the change you're making then you should simply raise a PR as normal. We want developers and teams to feel empowered to make the choice about when to reach out.
 
-        However, if your change affects core platform code or is introducing a new concept or pattern, or if you're just looking for more eyes and input then this process is for you.
+        However, if your change affects core platform code or is introducing a new concept or pattern, or if you're just looking for more eyes, input, or simply want to track the work in an issue then this process is for you.
 
-        **Who is responsible for completing this RFC process?**
-        Once the RFC is raised, it is the responsibility of the _Dotcom team_ (@guardian/dotcom-platform) to provide feedback and help you get your change to the finish line.
+        **Who is responsible for closing this issue?**
+        Once the issue is created, it is the responsibility of the _Dotcom team_ (@guardian/dotcom-platform) to provide feedback and help you get your change to the finish line.


### PR DESCRIPTION
## What does this change?

* Changes the RFC template to a simple Issue template.
* Fixes the body of the template (it needs to contain at least one non markdown entry)

## Why?

Issues are more commonly used than RFCs, we can always convert to RFC where needed. 
