### PR TITLE
Add credit and caption in Photo Essay main media

### DIFF
--- a/dotcom-rendering/src/components/Caption.tsx
+++ b/dotcom-rendering/src/components/Caption.tsx
@@ -272,7 +272,11 @@ export const Caption = ({
 					css={[
 						css`
 							${textSans.xxsmall({ lineHeight: 'tight' })};
-							color: ${palette('--caption-text')};
+							color: ${isMainMedia
+								? palette(
+										'--caption-photo-essay-main-media-text',
+								  )
+								: palette('--caption-text')};
 							width: 100%;
 							margin-top: ${space[3]}px;
 							li:not(:first-child) {
@@ -281,7 +285,11 @@ export const Caption = ({
 							li {
 								padding-top: ${space[2]}px;
 								border-top: 1px solid
-									${palette('--caption-text')};
+									${isMainMedia
+										? palette(
+												'--caption-photo-essay-main-media-text',
+										  )
+										: palette('--caption-text')};
 							}
 						`,
 						bottomMarginStyles,

--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -304,6 +304,7 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 				format={format}
 				shouldLimitWidth={true}
 				isLeftCol={true}
+				isMainMedia={true}
 			/>
 		</div>
 	);

--- a/dotcom-rendering/src/lib/article.ts
+++ b/dotcom-rendering/src/lib/article.ts
@@ -49,6 +49,7 @@ export const enhanceArticleType = (
 
 	const mainMediaElements = enhanceMainMedia(
 		format,
+		true,
 		imagesForLightbox,
 		data.main,
 	)(data.mainMediaElements);

--- a/dotcom-rendering/src/lib/article.ts
+++ b/dotcom-rendering/src/lib/article.ts
@@ -49,8 +49,8 @@ export const enhanceArticleType = (
 
 	const mainMediaElements = enhanceMainMedia(
 		format,
-		true,
 		imagesForLightbox,
+		true,
 		data.main,
 	)(data.mainMediaElements);
 

--- a/dotcom-rendering/src/model/enhance-images.test.ts
+++ b/dotcom-rendering/src/model/enhance-images.test.ts
@@ -4,7 +4,7 @@ import { Standard as ExampleArticle } from '../../fixtures/generated/fe-articles
 import { images } from '../../fixtures/generated/images';
 import { decideFormat } from '../lib/decideFormat';
 import type { FEElement } from '../types/content';
-import { enhanceImages } from './enhance-images';
+import { enhanceElementsImages, enhanceImages } from './enhance-images';
 
 const exampleArticleFormat = decideFormat(ExampleArticle.format);
 const photoEssayFormat = decideFormat(PhotoEssay.format);
@@ -19,6 +19,33 @@ const image = {
 
 describe('Enhance Images', () => {
 	describe('for photo essays', () => {
+		it('sets the caption and credit for main media images', () => {
+			const input: FEElement[] = [
+				{ ...image, role: 'immersive' },
+				{
+					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+					elementId: 'mockId',
+					html: '<ul><li><p>This is the caption</p></li></ul>',
+				},
+			];
+
+			const expectedOutput: FEElement[] = [
+				{
+					...image,
+					role: 'immersive',
+					data: {
+						...image.data,
+						caption: '<ul><li><p>This is the caption</p></li></ul>',
+						credit: 'Photograph: Cat Vinton/The Guardian',
+					},
+				},
+			];
+
+			expect(
+				enhanceElementsImages(photoEssayFormat, true, [])(input),
+			).toEqual(expectedOutput);
+		});
+
 		it('sets the caption for an image if the following element is a text element with ul and li tags', () => {
 			const input: FEElement[] = [
 				image,
@@ -541,9 +568,8 @@ describe('Enhance Images', () => {
 					...image,
 					role: 'inline',
 					data: {
-						caption:
-							'This text starts in data but gets removed for photo essays',
-						credit: 'but it is copied into the lightbox property so we can use it there',
+						caption: '',
+						credit: '',
 					},
 				},
 			];

--- a/dotcom-rendering/src/model/enhance-images.ts
+++ b/dotcom-rendering/src/model/enhance-images.ts
@@ -421,9 +421,22 @@ class Enhancer {
 }
 
 const enhance =
-	(isPhotoEssay: boolean, imagesForLightbox: ImageForLightbox[]) =>
+	(
+		isPhotoEssay: boolean,
+		imagesForLightbox: ImageForLightbox[],
+		isPhotoEssayMainMedia = false,
+	) =>
 	(elements: FEElement[]): FEElement[] => {
 		if (isPhotoEssay) {
+			if (isPhotoEssayMainMedia) {
+				return new Enhancer(elements)
+					.addMultiImageElements()
+					.addTitles()
+					.addCaptionsToMultis()
+					.addCaptionsToImages()
+					.addImagePositions(imagesForLightbox).elements;
+			}
+
 			return new Enhancer(elements)
 				.stripCaptions()
 				.removeCredit()
@@ -456,11 +469,14 @@ export const enhanceImages = (
 
 export const enhanceElementsImages = (
 	format: ArticleFormat,
+	isMainMedia: boolean,
 	imagesForLightbox: ImageForLightbox[],
 ): ((elements: FEElement[]) => FEElement[]) => {
 	const isPhotoEssay =
 		format.design === ArticleDesign.PhotoEssay &&
 		format.theme !== ArticleSpecial.Labs;
 
-	return enhance(isPhotoEssay, imagesForLightbox);
+	const isPhotoEssayMainMedia = isPhotoEssay && isMainMedia;
+
+	return enhance(isPhotoEssay, imagesForLightbox, isPhotoEssayMainMedia);
 };

--- a/dotcom-rendering/src/model/enhanceBlocks.ts
+++ b/dotcom-rendering/src/model/enhanceBlocks.ts
@@ -83,11 +83,12 @@ export const enhanceMainMedia =
 	(
 		format: ArticleFormat,
 		imagesForLightbox: ImageForLightbox[],
+		isMainMedia: boolean,
 		mediaHTML: string,
 	) =>
 	(elements: FEElement[]): FEElement[] => {
 		return [
-			enhanceElementsImages(format, imagesForLightbox),
+			enhanceElementsImages(format, isMainMedia, imagesForLightbox),
 			enhanceGuVideos(format, mediaHTML),
 		].reduce(
 			(enhancedBlocks, enhancer) => enhancer(enhancedBlocks),

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -2887,6 +2887,9 @@ const captionTextDark: PaletteFunction = ({ design, theme }) => {
 	}
 };
 
+const captionPhotoEssayMainMediaTextLight = () => sourcePalette.neutral[46];
+const captionPhotoEssayMainMediaTextDark = () => sourcePalette.neutral[60];
+
 const captionLink: PaletteFunction = ({ design, theme }) => {
 	if (design === ArticleDesign.NewsletterSignup) {
 		return sourcePalette.neutral[0];
@@ -5726,6 +5729,10 @@ const paletteColours = {
 	'--caption-text': {
 		light: captionTextLight,
 		dark: captionTextDark,
+	},
+	'--caption-photo-essay-main-media-text': {
+		light: captionPhotoEssayMainMediaTextLight,
+		dark: captionPhotoEssayMainMediaTextDark,
 	},
 	'--caption-link': {
 		light: captionLink,


### PR DESCRIPTION
Closes https://github.com/guardian/dotcom-rendering/issues/10631

## What does this change?
* Adds credit and caption in Photo Essay main media
* The rest of the captions keep their current styles

## Why?
Missing credit and caption from the main media was confusing for editors. There was a [decision](https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/docs/patterns/enhance-capi.md#images) in the past to clean Photo Essay articles in order to achieve the intended designs for their special caption styles but this applied [only to the in-body ones](https://github.com/guardian/dotcom-rendering/pull/10627#issuecomment-2015483585).

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| <img width="985" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/19683595/ab98aa6d-1c84-4686-9cb8-d4f7b02ac2f7"> | <img width="870" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/19683595/dbf5c6f6-36a8-4079-9d81-de49baeb0e6d"> |
| <img width="657" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/19683595/329cd136-b5ab-4000-a66b-0c8359b1b57a"> | <img width="653" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/19683595/18c4202c-be8d-4ba1-a0bd-f3add5439720"> |
| <img width="934" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/19683595/2e8eb7b1-a49d-48a6-b31c-8e56f78be97f"> | <img width="850" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/19683595/20993140-4afe-4e31-9a03-d6897e0e318b"> |
| <img width="576" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/19683595/fb209be8-bbb0-4566-b13d-f873d0fd758a"> | <img width="608" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/19683595/d4fd5092-1264-4755-8351-4aa896fd5802"> |
| <img width="830" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/19683595/6d3d4d30-4d60-4c8e-9d16-ffc15f1684fc"> | <img width="825" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/19683595/7d73b62f-c1b7-4970-b214-aa68a4420f43"> |
| <img width="619" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/19683595/6f3453e5-2f68-4c7c-bfb1-d910ce411273"> | <img width="604" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/19683595/f79a8a19-0cf2-4750-8992-7a8f0c9047b1"> |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
