### PR TITLE
Ignore <CardPicture /> image in Chromatic

### DIFF
--- a/dotcom-rendering/src/components/CardPicture.tsx
+++ b/dotcom-rendering/src/components/CardPicture.tsx
@@ -139,8 +139,7 @@ export const CardPicture = ({
 				src={fallbackSource.lowResUrl}
 				css={block}
 				loading={loading}
-				// Chromatic inconsistenly loads the image for lazy-loaded images
-				data-chromatic={loading === 'lazy' ? 'ignore' : undefined}
+				data-chromatic="ignore"
 			/>
 		</picture>
 	);


### PR DESCRIPTION
## What does this change?

Ignore the CardPicture image in Chromatic

## Why?

Chromatic often fails tests because a pixel or two in the image is different. The trade off looks to be beneficial: the scope of Chromatic is lessened, but there are currently lots of false positives because of this image. We want to get to a place where we have more trust in Chromatic and this is a step towards that.
