### PR TITLE
Filter unsupported roles from the body

### DIFF
--- a/dotcom-rendering/src/components/Timeline.stories.tsx
+++ b/dotcom-rendering/src/components/Timeline.stories.tsx
@@ -100,7 +100,7 @@ export const FlatWithNoTitles = {
 						displayCredit: true,
 						data: { ...images[1].data, caption: 'Inline image' },
 					},
-					body: [testTextElement, images[0], testTextElement],
+					body: [testTextElement, images[1], testTextElement],
 				},
 				{
 					date: '5th January 2024',
@@ -115,18 +115,6 @@ export const FlatWithNoTitles = {
 					date: '19th January 2024',
 					main: testYoutubeElement,
 					body: [testTextElement, testTextElement],
-				},
-				{
-					date: '8th February 2024',
-					main: {
-						...images[12],
-						displayCredit: true,
-						data: {
-							...images[12].data,
-							caption: 'Immersive image',
-						},
-					},
-					body: [testTextElement, testTextElement, testTextElement],
 				},
 				{
 					date: '9th February 2024',

--- a/dotcom-rendering/src/model/enhanceTimeline.test.ts
+++ b/dotcom-rendering/src/model/enhanceTimeline.test.ts
@@ -39,6 +39,34 @@ const elements: FEElement[] = [
 							assets: [],
 						},
 					},
+					{
+						title: 'mock event title',
+						date: '10th January 2024',
+						// Inline image
+						body: [images[1]],
+						main: images[0],
+					},
+					{
+						title: 'mock event title',
+						date: '15th January 2024',
+						// Showcase image
+						body: [images[0]],
+						main: images[0],
+					},
+					{
+						title: 'mock event title',
+						date: '15th January 2024',
+						// Media atom (no role)
+						body: [
+							{
+								_type: 'model.dotcomrendering.pageElements.MediaAtomBlockElement',
+								elementId: 'mock-id',
+								id: 'mock-id',
+								assets: [],
+							},
+						],
+						main: images[0],
+					},
 				],
 			},
 		],
@@ -80,5 +108,47 @@ describe('enhanceTimeline', () => {
 		const timelineEvent = enhanced[0].events[2];
 		assert.notEqual(timelineEvent, undefined);
 		expect(timelineEvent?.main).toBeDefined();
+	});
+	it('keeps a body element with a role that is valid', () => {
+		const enhanced = enhanceTimeline(identity)(elements);
+		assert.equal(
+			enhanced[0]?._type,
+			'model.dotcomrendering.pageElements.DCRTimelineBlockElement',
+		);
+
+		const timelineEvent = enhanced[0].events[3];
+		assert.notEqual(timelineEvent, undefined);
+		expect(timelineEvent?.body).toEqual([images[1]]);
+	});
+
+	it('drops a body element with a role that is not valid', () => {
+		const enhanced = enhanceTimeline(identity)(elements);
+		assert.equal(
+			enhanced[0]?._type,
+			'model.dotcomrendering.pageElements.DCRTimelineBlockElement',
+		);
+
+		const timelineEvent = enhanced[0].events[4];
+		assert.notEqual(timelineEvent, undefined);
+		expect(timelineEvent?.body).toEqual([]);
+	});
+
+	it('keeps a body element without a role', () => {
+		const enhanced = enhanceTimeline(identity)(elements);
+		assert.equal(
+			enhanced[0]?._type,
+			'model.dotcomrendering.pageElements.DCRTimelineBlockElement',
+		);
+
+		const timelineEvent = enhanced[0].events[5];
+		assert.notEqual(timelineEvent, undefined);
+		expect(timelineEvent?.body).toEqual([
+			{
+				_type: 'model.dotcomrendering.pageElements.MediaAtomBlockElement',
+				elementId: 'mock-id',
+				id: 'mock-id',
+				assets: [],
+			},
+		]);
 	});
 });

--- a/dotcom-rendering/src/model/enhanceTimeline.ts
+++ b/dotcom-rendering/src/model/enhanceTimeline.ts
@@ -27,6 +27,20 @@ const enhanceMainMedia = (
 		? undefined
 		: mainMedia;
 
+/**
+ * For a body element that can have a role, we only support "inline"
+ * and "thumbnail". If the element has a role that isn't either
+ * inline or thumbnail we drop it.
+ */
+const filterUnsupportedRoles = (elements: FEElement[]): FEElement[] => {
+	return elements.filter(
+		(element) =>
+			!('role' in element) ||
+			('role' in element &&
+				(element.role === 'inline' || element.role === 'thumbnail')),
+	);
+};
+
 const enhanceTimelineEvent =
 	(enhanceElements: ElementsEnhancer) =>
 	({
@@ -47,7 +61,7 @@ const enhanceTimelineEvent =
 				title,
 				label,
 				main: enhanceMainMedia(main),
-				body: enhanceElements(body),
+				body: enhanceElements(filterUnsupportedRoles(body)),
 			},
 		];
 	};


### PR DESCRIPTION
## What does this change?
Limit elements in the body of a timeline element to those with a role of "thumbnail" or "inline" only. Any other elements that have a role will be dropped and not rendered. 

## Why?
This restriction is specified in the designs and is not currently in place in composer. This behaviour may be baked into composer at some point but for now this follows the pattern introduced in restricting the main media of timelines to ensure a timeline renders as per designs.

NB -  this element is only available in code at the moment so images don't render as they're not available in the CODE environment 

## Screenshots

NB -  this element is only available in code at the moment so images don't render as they're not available in the CODE environment 
# before
https://github.com/guardian/dotcom-rendering/assets/20416599/01167e49-80f6-460e-9906-04a398089e88

# after
https://github.com/guardian/dotcom-rendering/assets/20416599/87719146-6ec9-4cbe-ae6a-02643dab1a95




<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
