### PR TITLE
Remove regex for video ids

### DIFF
--- a/dotcom-rendering/src/components/VideoVimeoBlockComponent.amp.tsx
+++ b/dotcom-rendering/src/components/VideoVimeoBlockComponent.amp.tsx
@@ -13,7 +13,7 @@ export const VideoVimeoBlockComponent = ({ element, pillar }: Props) => {
 	// see: https://github.com/guardian/dotcom-rendering/issues/4057
 	// We should remove this once ☝️ is fixed.
 	const url = element.url === '' ? element.originalUrl ?? '' : element.url;
-	const vimeoId = getIdFromUrl(url, '(\\d+)($|\\/)', true);
+	const vimeoId = getIdFromUrl(url, true);
 
 	return (
 		<Caption captionText={element.caption} pillar={pillar}>

--- a/dotcom-rendering/src/components/VideoYoutubeBlockComponent.amp.tsx
+++ b/dotcom-rendering/src/components/VideoYoutubeBlockComponent.amp.tsx
@@ -7,12 +7,9 @@ type Props = {
 	pillar: ArticleTheme;
 };
 
-export const ampYoutubeIdRegex = '^[a-zA-Z0-9_-]{11}$'; // Alphanumeric, underscores and hyphens, 11 characters long
-
 export const VideoYoutubeBlockComponent = ({ element, pillar }: Props) => {
 	const youtubeId = getIdFromUrl(
 		element.originalUrl || element.url,
-		ampYoutubeIdRegex,
 		true,
 		'v',
 	);

--- a/dotcom-rendering/src/lib/get-video-id.amp.test.ts
+++ b/dotcom-rendering/src/lib/get-video-id.amp.test.ts
@@ -1,10 +1,7 @@
-import { ampYoutubeIdRegex } from '../components/VideoYoutubeBlockComponent.amp';
 import { getIdFromUrl } from './get-video-id.amp';
 
 describe('getIdFromUrl', () => {
-	it('Returns matching ID for YouTube formats', () => {
-		const youtubeRegEx = ampYoutubeIdRegex;
-
+	it('Returns IDs for YouTube', () => {
 		const formats = [
 			{
 				url: 'http://www.youtube.com/ytscreeningroom?v=NRHEIGHTx8I',
@@ -38,13 +35,11 @@ describe('getIdFromUrl', () => {
 
 		for (const _ of formats) {
 			// Search for both in path & query param
-			expect(getIdFromUrl(_.url, youtubeRegEx, true, 'v')).toBe(_.id);
+			expect(getIdFromUrl(_.url, true, 'v')).toBe(_.id);
 		}
 	});
 
-	it('Returns matching ID for Vimeo formats', () => {
-		const vimeoRegEx = '(\\d+)($|\\/)';
-
+	it('Returns IDs for Vimeo', () => {
 		const formats = [
 			{
 				url: 'https://vimeo.com/channels/staffpicks/332085955',
@@ -61,57 +56,33 @@ describe('getIdFromUrl', () => {
 		];
 
 		for (const _ of formats) {
-			expect(getIdFromUrl(_.url, vimeoRegEx, true)).toBe(_.id);
+			expect(getIdFromUrl(_.url, true)).toBe(_.id);
 		}
 	});
 
-	it('Finds ID if both options are allowed', () => {
+	it('Returns query param ID if multiple found', () => {
 		const formats = [
-			'https://theguardian.com/test',
-			'https://theguardian.com?a=test',
-			'https://theguardian.com/test?a=test',
+			'https://theguardian.com/test2',
+			'https://theguardian.com?a=test2',
+			'https://theguardian.com/test1?a=test2',
 		];
 
 		for (const _ of formats) {
-			expect(getIdFromUrl(_, 'test', true, 'a')).toBe('test');
+			expect(getIdFromUrl(_, true, 'a')).toBe('test2');
 		}
 	});
 
 	it('Throws an error if it cannot find an ID', () => {
 		expect(() => {
-			getIdFromUrl('https://theguardian.com', '', false, 'v');
+			getIdFromUrl('https://theguardian.com', false, 'v');
 		}).toThrow();
 
 		expect(() => {
-			getIdFromUrl('https://theguardian.com?p=test', '', false, 'v');
+			getIdFromUrl('https://theguardian.com?p=test', false, 'v');
 		}).toThrow();
 
 		expect(() => {
-			getIdFromUrl('https://theguardian.com/test', '', false, 'p');
-		}).toThrow();
-	});
-
-	it('Throws an error if it ID is in incorrect format', () => {
-		expect(() => {
-			getIdFromUrl('https://theguardian.com/test', 'nottest', true);
-		}).toThrow();
-
-		expect(() => {
-			getIdFromUrl(
-				'https://theguardian.com?p=test',
-				'nottest',
-				false,
-				'p',
-			);
-		}).toThrow();
-
-		expect(() => {
-			getIdFromUrl(
-				'https://theguardian.com/test?p=test',
-				'nottest',
-				true,
-				'p',
-			);
+			getIdFromUrl('https://theguardian.com/test', false, 'p');
 		}).toThrow();
 	});
 });

--- a/dotcom-rendering/src/lib/get-video-id.amp.ts
+++ b/dotcom-rendering/src/lib/get-video-id.amp.ts
@@ -3,7 +3,6 @@ import { isString } from '@guardian/libs';
 
 export const getIdFromUrl = (
 	urlString: string,
-	regexFormat: string,
 	tryInPath?: boolean,
 	tryQueryParam?: string,
 ): string => {
@@ -25,21 +24,10 @@ export const getIdFromUrl = (
 		.filter(isString)
 		.map((id) => id.slice(0, 11));
 
-	if (!ids.length)
-		logErr(
+	if (ids.length && ids[0]) return ids[0];
+	else
+		return logErr(
 			'an undefined ID',
 			'Could not get ID from pathname or searchParams.',
 		);
-
-	// Allows for a matching ID to be selected from either (or both) formats
-	const id = ids.find((tryId) => new RegExp(regexFormat).test(tryId));
-
-	if (!id) {
-		return logErr(
-			id ?? ids.join(', '),
-			`Value(s) didn't match regexFormat ${regexFormat}`,
-		);
-	}
-
-	return id;
 };


### PR DESCRIPTION
## What does this change?

Remove regex for video ids since these ids evolve and the regex has fallen behind a few times now - some validation happens in Composer so we should be ok

## Why?

This has now caused errors more than once. Specifically it's causing amp articles to 500
