### PR TITLE
Use SubHeading component in Timelines

### DIFF
--- a/dotcom-rendering/src/components/Timeline.tsx
+++ b/dotcom-rendering/src/components/Timeline.tsx
@@ -10,6 +10,7 @@ import type {
 	FEElement,
 } from '../types/content';
 import { Heading } from './Heading';
+import { Subheading } from './Subheading';
 
 // ----- Helpers ----- //
 
@@ -213,11 +214,6 @@ const TimelineEvent = ({
 
 // ----- Timeline ----- //
 
-const sectionTitleStyles = css`
-	${headline.xsmall({ fontWeight: 'medium' })}
-	margin: ${space[8]}px 0 ${space[4]}px;
-`;
-
 type Props = {
 	timeline: DCRTimelineBlockElement | DCRSectionedTimelineBlockElement;
 	ArticleElementComponent: NestedArticleElement;
@@ -257,7 +253,9 @@ export const Timeline = ({
 				<>
 					{timeline.sections.map((section) => (
 						<section key={section.title}>
-							<h2 css={sectionTitleStyles}>{section.title}</h2>
+							<Subheading format={format} topPadding={false}>
+								{section.title}
+							</Subheading>
 							{section.events.map((event) => (
 								<TimelineEvent
 									event={event}


### PR DESCRIPTION
## What does this change?
Uses new SubHeading component in Timelines
## Why?
Resolves https://github.com/guardian/dotcom-rendering/issues/11232
## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/110032454/7201adbd-e697-4e69-9970-9da4d89725f2
[after]: https://github.com/guardian/dotcom-rendering/assets/110032454/5e1da10c-4206-4dfd-9ba5-63315228ee2e

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
