### PR TITLE
Stop multiple newsletter embeds appearing on a timeline article

### DIFF
--- a/dotcom-rendering/src/components/Timeline.tsx
+++ b/dotcom-rendering/src/components/Timeline.tsx
@@ -205,6 +205,7 @@ const TimelineEvent = ({
 					element={element}
 					forceDropCap="off"
 					format={format}
+					isTimeline={true}
 				/>
 			))}
 		</section>


### PR DESCRIPTION
## What does this change?
Prevents multiple newsletter embeds appearing in nested blocks on a timeline article.

## Why?
We only want a newsletter embed to appear once.

## Screenshots
# Before
https://github.com/guardian/dotcom-rendering/assets/20416599/5781c1dd-bf63-4939-beea-d2463ba08109

# After
https://github.com/guardian/dotcom-rendering/assets/20416599/3da13735-c7c5-4af5-8520-cd1600409a18


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
