### PR TITLE
Simplify `getIdFromUrl` logic

### DIFF
--- a/dotcom-rendering/src/lib/get-video-id.amp.test.ts
+++ b/dotcom-rendering/src/lib/get-video-id.amp.test.ts
@@ -9,7 +9,7 @@ describe('getIdFromUrl', () => {
 			},
 			{
 				url: 'http://www.youtube.com/ytscreeningroom?v=NRHEIGHTx8Ixyz',
-				id: 'NRHEIGHTx8I',
+				id: 'NRHEIGHTx8Ixyz',
 			},
 			{
 				url: 'http://www.youtube.com/ytscreeningroom?v=NRH_IGHTx8I',

--- a/dotcom-rendering/src/lib/get-video-id.amp.ts
+++ b/dotcom-rendering/src/lib/get-video-id.amp.ts
@@ -1,4 +1,4 @@
-import { parse, URLSearchParams } from 'node:url';
+import { URL, URLSearchParams } from 'node:url';
 import { isString } from '@guardian/libs';
 
 export const getIdFromUrl = (
@@ -6,28 +6,19 @@ export const getIdFromUrl = (
 	tryInPath?: boolean,
 	tryQueryParam?: string,
 ): string => {
-	const logErr = (actual: string, message: string) => {
-		throw new Error(
-			`validate getIdFromURL error: The URL ${urlString} returned ${actual}. ${message}`,
-		);
-	};
-
 	// Looks for ID in both formats if provided
-	const url = parse(urlString);
+	const url = new URL(urlString);
 
-	const ids = [
+	const id = [
 		tryQueryParam
-			? new URLSearchParams(url.query ?? '').get(tryQueryParam)
+			? new URLSearchParams(url.search).get(tryQueryParam)
 			: undefined,
-		tryInPath ? (url.pathname ?? '').split('/').at(-1) : undefined,
-	]
-		.filter(isString)
-		.map((id) => id.slice(0, 11));
+		tryInPath ? url.pathname.split('/').at(-1) : undefined,
+	].find(isString);
 
-	if (ids.length && ids[0]) return ids[0];
-	else
-		return logErr(
-			'an undefined ID',
-			'Could not get ID from pathname or searchParams.',
-		);
+	if (id !== undefined) return id;
+
+	throw new Error(
+		`getIdFromUrl: The URL ${urlString} did not contain an ID.`,
+	);
 };


### PR DESCRIPTION

## What does this change?

- Refactor internal logic to simplify as a follow-up on #11236 
- Let strings of longer than 11 characters be exactly as they are defined

## Why?

- No more use of [deprecated method `parse` from `node:url`](https://nodejs.org/docs/latest-v20.x/api/url.html#urlparseurlstring-parsequerystring-slashesdenotehost)
- No more time-of-check v time-of-use weirdness by using [`Array.prototype.find`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find) where appropriate
- No more single-use error closure
- YouTube will handle them gracefully anyways: https://www.youtube.com/watch?v=Dd1VIeTMGQsabcdefghijklmnopqrstuvwxyz

## Screenshots

N/A