### PR TITLE
Enforce consistent curly brackets style with ESLint

### DIFF
--- a/dotcom-rendering/.eslintrc.js
+++ b/dotcom-rendering/.eslintrc.js
@@ -130,6 +130,9 @@ module.exports = {
 
 		'object-shorthand': ['error', 'always'],
 
+		// need to be explicitely added because it is disabled by extending `prettier`
+		curly: ['error', 'multi-line', 'consistent'],
+
 		/** @see https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-array-for-each.md */
 		'unicorn/no-array-for-each': 'error',
 

--- a/dotcom-rendering/src/components/Callout/CalloutComponents.tsx
+++ b/dotcom-rendering/src/components/Callout/CalloutComponents.tsx
@@ -170,8 +170,9 @@ export const CalloutShare = ({
 		}
 	};
 
-	if (typeof window === 'undefined' || typeof navigator === 'undefined')
+	if (typeof window === 'undefined' || typeof navigator === 'undefined') {
 		return <></>;
+	}
 
 	return (
 		<>

--- a/dotcom-rendering/src/components/Card/components/TrailTextWrapper.tsx
+++ b/dotcom-rendering/src/components/Card/components/TrailTextWrapper.tsx
@@ -19,12 +19,13 @@ const showTrailText = (
 		imageSize === 'large' &&
 		imagePosition === 'right' &&
 		imageType !== 'avatar'
-	)
+	) {
 		return css`
 			${until.desktop} {
 				display: none;
 			}
 		`;
+	}
 	return css`
 		${until.tablet} {
 			display: none;

--- a/dotcom-rendering/src/components/Carousel.stories.tsx
+++ b/dotcom-rendering/src/components/Carousel.stories.tsx
@@ -403,8 +403,9 @@ export const SpecialReportAlt = () => {
 	mockCommentCount();
 	const specialReportTrails = [...trails];
 
-	for (const trail of specialReportTrails)
+	for (const trail of specialReportTrails) {
 		trail.format = specialReportAltFormat;
+	}
 
 	return (
 		<Section

--- a/dotcom-rendering/src/components/Discussion/TopPicks.tsx
+++ b/dotcom-rendering/src/components/Discussion/TopPicks.tsx
@@ -55,10 +55,11 @@ export const TopPicks = ({
 }: Props) => {
 	const leftColComments: Array<CommentType | ReplyType> = [];
 	const rightColComments: Array<CommentType | ReplyType> = [];
-	for (const [index, comment] of comments.entries())
+	for (const [index, comment] of comments.entries()) {
 		index % 2 === 0
 			? leftColComments.push(comment)
 			: rightColComments.push(comment);
+	}
 	return (
 		<div css={picksWrapper}>
 			<div css={twoColCommentsStyles}>

--- a/dotcom-rendering/src/components/Elements.amp.tsx
+++ b/dotcom-rendering/src/components/Elements.amp.tsx
@@ -94,8 +94,14 @@ export const isAmpSupported = ({
 				element._type ===
 				'model.dotcomrendering.pageElements.QuizAtomBlockElement',
 		);
-		if (!isSwitchedOn || hasQuizTag || hasQuizAtoms || elements.length == 0)
+		if (
+			!isSwitchedOn ||
+			hasQuizTag ||
+			hasQuizAtoms ||
+			elements.length == 0
+		) {
 			return false;
+		}
 	}
 
 	if (

--- a/dotcom-rendering/src/components/GetMatchNav.importable.tsx
+++ b/dotcom-rendering/src/components/GetMatchNav.importable.tsx
@@ -59,7 +59,7 @@ export const GetMatchNav = ({
 		if (
 			format.design === ArticleDesign.LiveBlog ||
 			format.design === ArticleDesign.DeadBlog
-		)
+		) {
 			return (
 				<div
 					css={css`
@@ -82,6 +82,7 @@ export const GetMatchNav = ({
 					/>
 				</div>
 			);
+		}
 	}
 	if (data) {
 		return (

--- a/dotcom-rendering/src/components/InteractiveContentsBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/components/InteractiveContentsBlockComponent.importable.tsx
@@ -189,8 +189,9 @@ export const InteractiveContentsBlockComponent = ({
 					  )
 					: undefined;
 
-				if (endElement?.isIntersecting)
+				if (endElement?.isIntersecting) {
 					return setStickyNavCurrentHeader(null);
+				}
 
 				// Check if the current element is in this update
 				const currentElement = entries.find(
@@ -216,12 +217,13 @@ export const InteractiveContentsBlockComponent = ({
 
 				// Check for entry of new element
 				const element = entries.find((entry) => entry.isIntersecting);
-				if (element?.target.id)
+				if (element?.target.id) {
 					return setStickyNavCurrentHeader(
 						enhancedSubheadings[
 							getSubheadingIndexById(element.target.id)
 						] ?? null,
 					);
+				}
 
 				// Check if we're scrolling up past the end of the document and set sticky nav to the last element
 				const [lastElement] = enhancedSubheadings.slice(-1);
@@ -240,8 +242,9 @@ export const InteractiveContentsBlockComponent = ({
 				rootMargin: `0px 0px -100% 0px`,
 			});
 
-			for (const item of enhancedSubheadings)
+			for (const item of enhancedSubheadings) {
 				item.ref && observer.observe(item.ref);
+			}
 
 			if (endDocumentElementId) {
 				const endDocumentRef =

--- a/dotcom-rendering/src/components/Liveness.importable.tsx
+++ b/dotcom-rendering/src/components/Liveness.importable.tsx
@@ -77,15 +77,17 @@ function revealPendingBlocks() {
 	const blogBody = document.querySelector<HTMLElement>('#liveblog-body');
 	const pendingBlocks =
 		blogBody?.querySelectorAll<HTMLElement>('.pending.block');
-	if (pendingBlocks)
+	if (pendingBlocks) {
 		for (const block of pendingBlocks) {
 			block.classList.add('reveal-slowly');
 			block.classList.remove('pending');
 		}
+	}
 
-	if (pendingBlocks !== undefined && pendingBlocks.length > 0)
+	if (pendingBlocks !== undefined && pendingBlocks.length > 0) {
 		// Notify commercial that new blocks are available and they can re-run spacefinder
 		document.dispatchEvent(new CustomEvent('liveblog:blocks-updated'));
+	}
 }
 
 /**

--- a/dotcom-rendering/src/components/MediaDuration.tsx
+++ b/dotcom-rendering/src/components/MediaDuration.tsx
@@ -50,7 +50,7 @@ export const MediaDuration = ({
 	if (imagePosition === 'left') {
 		return null;
 	}
-	if (imagePositionOnMobile === 'left')
+	if (imagePositionOnMobile === 'left') {
 		return (
 			<Hide until="tablet">
 				<div css={durationStyles}>
@@ -58,6 +58,7 @@ export const MediaDuration = ({
 				</div>
 			</Hide>
 		);
+	}
 
 	return (
 		<div css={durationStyles}>

--- a/dotcom-rendering/src/components/Metrics.importable.tsx
+++ b/dotcom-rendering/src/components/Metrics.importable.tsx
@@ -122,8 +122,9 @@ export const Metrics = ({ commercialMetricsEnabled, tests }: Props) => {
 				team: 'dotcom',
 			});
 
-			if (bypassSampling || isDev)
+			if (bypassSampling || isDev) {
 				void bypassCoreWebVitalsSampling('commercial');
+			}
 		},
 		[abTestApi, browserId, isDev, pageViewId, shouldBypassSampling],
 	);

--- a/dotcom-rendering/src/components/PrivacySettingsLink.importable.tsx
+++ b/dotcom-rendering/src/components/PrivacySettingsLink.importable.tsx
@@ -43,12 +43,13 @@ export const PrivacySettingsLink = ({ extraClasses }: Props) => {
 		});
 	}, []);
 
-	if (!framework)
+	if (!framework) {
 		return (
 			<span css={footerLink} style={{ color: 'transparent' }}>
 				&nbsp;
 			</span>
 		);
+	}
 
 	return (
 		<ButtonLink

--- a/dotcom-rendering/src/components/ShowMore.importable.tsx
+++ b/dotcom-rendering/src/components/ShowMore.importable.tsx
@@ -33,7 +33,7 @@ const decideButtonText = ({
 	title: string;
 }) => {
 	if (isOpen && loading) return <>Loading</>;
-	if (isOpen)
+	if (isOpen) {
 		return (
 			<>
 				Less{' '}
@@ -47,6 +47,7 @@ const decideButtonText = ({
 				</span>
 			</>
 		);
+	}
 	return <>More {title}</>;
 };
 

--- a/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
+++ b/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
@@ -257,7 +257,9 @@ export const SignInGateSelector = ({
 	useEffect(() => {
 		if (personaliseSignInGateAfterCheckout) {
 			setPersonaliseSwitch(personaliseSignInGateAfterCheckout);
-		} else setPersonaliseSwitch(false);
+		} else {
+			setPersonaliseSwitch(false);
+		}
 	}, [personaliseSignInGateAfterCheckout]);
 
 	useEffect(() => {

--- a/dotcom-rendering/src/components/SpotifyBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/components/SpotifyBlockComponent.importable.tsx
@@ -37,8 +37,9 @@ export const SpotifyBlockComponent = ({
 	source,
 	sourceDomain,
 }: Props) => {
-	if (!embedUrl || !title || width === undefined || height === undefined)
+	if (!embedUrl || !title || width === undefined || height === undefined) {
 		return null;
+	}
 
 	const embedContainer = css`
 		iframe {

--- a/dotcom-rendering/src/components/TopMeta.amp.tsx
+++ b/dotcom-rendering/src/components/TopMeta.amp.tsx
@@ -12,8 +12,9 @@ type Props = {
 	adTargeting?: AdTargeting;
 };
 export const TopMeta = ({ data, design, pillar, adTargeting }: Props) => {
-	if (pillar === ArticleSpecial.Labs)
+	if (pillar === ArticleSpecial.Labs) {
 		return <TopMetaPaidContent articleData={data} pillar={pillar} />;
+	}
 	switch (design) {
 		case ArticleDesign.Comment:
 		case ArticleDesign.Letter:

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPlayer.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPlayer.tsx
@@ -152,8 +152,9 @@ const createOnStateChangeListener =
 					msg: 'resume',
 					event,
 				});
-				for (const eventEmitter of eventEmitters)
+				for (const eventEmitter of eventEmitters) {
 					eventEmitter('resume');
+				}
 			}
 
 			const checkProgress = () => {
@@ -171,8 +172,9 @@ const createOnStateChangeListener =
 						msg: 'played 25%',
 						event,
 					});
-					for (const eventEmitter of eventEmitters)
+					for (const eventEmitter of eventEmitters) {
 						eventEmitter('25');
+					}
 					progressEvents.hasSent25Event = true;
 				}
 
@@ -183,8 +185,9 @@ const createOnStateChangeListener =
 						msg: 'played 50%',
 						event,
 					});
-					for (const eventEmitter of eventEmitters)
+					for (const eventEmitter of eventEmitters) {
 						eventEmitter('50');
+					}
 					progressEvents.hasSent50Event = true;
 				}
 
@@ -195,8 +198,9 @@ const createOnStateChangeListener =
 						msg: 'played 75%',
 						event,
 					});
-					for (const eventEmitter of eventEmitters)
+					for (const eventEmitter of eventEmitters) {
 						eventEmitter('75');
+					}
 					progressEvents.hasSent75Event = true;
 				}
 

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomSticky.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomSticky.tsx
@@ -216,8 +216,9 @@ export const YoutubeAtomSticky = ({
 	 */
 	useEffect(() => {
 		// Sticky-ness should take precedence over pausing
-		if (!shouldStick && shouldPauseOutOfView)
+		if (!shouldStick && shouldPauseOutOfView) {
 			setPauseVideo(isActive && !isIntersecting && !isClosed);
+		}
 	}, [
 		isIntersecting,
 		shouldStick,

--- a/dotcom-rendering/src/lib/assets.ts
+++ b/dotcom-rendering/src/lib/assets.ts
@@ -68,8 +68,9 @@ export const getPathFromManifest = (
 	build: Build,
 	filename: `${string}.js`,
 ): string => {
-	if (!filename.endsWith('.js'))
+	if (!filename.endsWith('.js')) {
 		throw new Error('Invalid filename: extension must be .js');
+	}
 
 	if (isDev) {
 		return `${ASSET_ORIGIN}assets/${filename.replace(

--- a/dotcom-rendering/src/lib/decidePalette.ts
+++ b/dotcom-rendering/src/lib/decidePalette.ts
@@ -40,8 +40,9 @@ const textStandfirst = (format: ArticleFormat): string => {
 	if (
 		format.theme === ArticleSpecial.SpecialReportAlt &&
 		format.design !== ArticleDesign.DeadBlog
-	)
+	) {
 		return palette.specialReportAlt[100];
+	}
 
 	return BLACK;
 };
@@ -73,14 +74,17 @@ const textStandfirstLink = (format: ArticleFormat): string => {
 		}
 	}
 
-	if (format.design === ArticleDesign.Picture)
+	if (format.design === ArticleDesign.Picture) {
 		return pillarPalette[format.theme].bright;
+	}
 
-	if (format.theme === ArticleSpecial.SpecialReport)
+	if (format.theme === ArticleSpecial.SpecialReport) {
 		return specialReport[400];
+	}
 
-	if (format.theme === ArticleSpecial.SpecialReportAlt)
+	if (format.theme === ArticleSpecial.SpecialReportAlt) {
 		return palette.specialReportAlt[100];
+	}
 
 	switch (format.theme) {
 		case Pillar.Opinion:
@@ -97,8 +101,9 @@ const textCricketScoreboardLink = (): string => {
 
 const backgroundBullet = (format: ArticleFormat): string => {
 	if (format.theme === ArticleSpecial.Labs) return BLACK;
-	if (format.theme === ArticleSpecial.SpecialReport)
+	if (format.theme === ArticleSpecial.SpecialReport) {
 		return specialReport[300];
+	}
 	if (format.design === ArticleDesign.Analysis) {
 		switch (format.theme) {
 			case Pillar.News:
@@ -139,8 +144,9 @@ const backgroundBulletStandfirst = (format: ArticleFormat): string => {
 		}
 	}
 
-	if (format.theme === ArticleSpecial.SpecialReportAlt)
+	if (format.theme === ArticleSpecial.SpecialReportAlt) {
 		return palette.specialReportAlt[100];
+	}
 
 	return neutral[86]; // default previously defined in Standfirst.tsx
 };
@@ -261,11 +267,13 @@ const borderStandfirstLink = (format: ArticleFormat): string => {
 				return news[600];
 		}
 	}
-	if (format.theme === ArticleSpecial.SpecialReport)
+	if (format.theme === ArticleSpecial.SpecialReport) {
 		return specialReport[400];
+	}
 
-	if (format.theme === ArticleSpecial.SpecialReportAlt)
+	if (format.theme === ArticleSpecial.SpecialReportAlt) {
 		return transparentColour(neutral[60], 0.3);
+	}
 
 	return palette.neutral[86];
 };
@@ -352,17 +360,20 @@ const borderLines = (format: ArticleFormat): string => {
 		format.theme === ArticleSpecial.SpecialReport &&
 		(format.design === ArticleDesign.Comment ||
 			format.design === ArticleDesign.Letter)
-	)
+	) {
 		return neutral[46];
+	}
 
 	if (
 		format.theme === ArticleSpecial.SpecialReportAlt &&
 		(format.design === ArticleDesign.Comment ||
 			format.design === ArticleDesign.Letter)
-	)
+	) {
 		return transparentColour(neutral[60], 0.3);
-	if (format.design === ArticleDesign.Picture)
+	}
+	if (format.design === ArticleDesign.Picture) {
 		return transparentColour(neutral[60], 0.5);
+	}
 
 	return neutral[86];
 };
@@ -404,8 +415,9 @@ const backgroundMessageForm = (format: ArticleFormat): string => {
 const textBetaLabel = (): string => neutral[46];
 
 const textDesignTag = (format: ArticleFormat): string => {
-	if (format.theme === ArticleSpecial.SpecialReportAlt)
+	if (format.theme === ArticleSpecial.SpecialReportAlt) {
 		return palette.specialReportAlt[800];
+	}
 
 	return neutral[100];
 };
@@ -415,8 +427,9 @@ const textDateLine = (format: ArticleFormat): string => {
 		format.theme === ArticleSpecial.SpecialReportAlt &&
 		format.design !== ArticleDesign.DeadBlog &&
 		format.design !== ArticleDesign.LiveBlog
-	)
+	) {
 		return palette.specialReportAlt[100];
+	}
 
 	return neutral[46];
 };

--- a/dotcom-rendering/src/lib/transparentColour.ts
+++ b/dotcom-rendering/src/lib/transparentColour.ts
@@ -28,8 +28,9 @@ export const transparentColour = (
 	opacity = 0.5,
 ): `rgba(${number}, ${number}, ${number}, ${number})` => {
 	// if we have an invalid string,
-	if (!colour.startsWith('#') || ![4, 7].includes(colour.length))
+	if (!colour.startsWith('#') || ![4, 7].includes(colour.length)) {
 		return fallback;
+	}
 
 	const hex = colour.length === 7 ? 2 : 1;
 

--- a/dotcom-rendering/src/model/decideContainerPalette.ts
+++ b/dotcom-rendering/src/model/decideContainerPalette.ts
@@ -12,17 +12,21 @@ export const decideContainerPalette = (
 	if (palettes?.includes('EventPalette')) return 'EventPalette';
 	if (palettes?.includes('SombreAltPalette')) return 'SombreAltPalette';
 	if (palettes?.includes('EventAltPalette')) return 'EventAltPalette';
-	if (palettes?.includes('InvestigationPalette'))
+	if (palettes?.includes('InvestigationPalette')) {
 		return 'InvestigationPalette';
-	if (palettes?.includes('LongRunningAltPalette'))
+	}
+	if (palettes?.includes('LongRunningAltPalette')) {
 		return 'LongRunningAltPalette';
+	}
 	if (palettes?.includes('LongRunningPalette')) return 'LongRunningPalette';
 	if (palettes?.includes('SombrePalette')) return 'SombrePalette';
 	if (palettes?.includes('BreakingPalette')) return 'BreakingPalette';
-	if (palettes?.includes('SpecialReportAltPalette'))
+	if (palettes?.includes('SpecialReportAltPalette')) {
 		return 'SpecialReportAltPalette';
-	if (palettes?.includes('Branded') && options?.canBeBranded)
+	}
+	if (palettes?.includes('Branded') && options?.canBeBranded) {
 		return 'Branded';
+	}
 	if (palettes?.includes('Podcast')) return 'PodcastPalette';
 	return undefined;
 };

--- a/dotcom-rendering/src/model/enhance-dividers.ts
+++ b/dotcom-rendering/src/model/enhance-dividers.ts
@@ -7,8 +7,9 @@ const isDinkus = (element: FEElement): boolean => {
 		element._type !==
 			'model.dotcomrendering.pageElements.SubheadingBlockElement' &&
 		element._type !== 'model.dotcomrendering.pageElements.TextBlockElement'
-	)
+	) {
 		return false;
+	}
 
 	const frag = JSDOM.fragment(element.html);
 	if (!frag.firstChild) return false;

--- a/dotcom-rendering/src/model/enhance-images.ts
+++ b/dotcom-rendering/src/model/enhance-images.ts
@@ -77,8 +77,9 @@ const isTitle = (element?: FEElement): element is SubheadingBlockElement => {
 	if (
 		element._type !==
 		'model.dotcomrendering.pageElements.SubheadingBlockElement'
-	)
+	) {
 		return false;
+	}
 	const frag = JSDOM.fragment(element.html);
 	return frag.firstElementChild?.nodeName === 'H2';
 };

--- a/dotcom-rendering/src/model/enhance-interactive-contents-elements.ts
+++ b/dotcom-rendering/src/model/enhance-interactive-contents-elements.ts
@@ -36,7 +36,7 @@ export const enhanceInteractiveContentsElements = (
 					size: 'full',
 					spaceAbove: 'tight',
 				});
-				if ('elementId' in element && element.elementId)
+				if ('elementId' in element && element.elementId) {
 					updatedElements.push({
 						_type: 'model.dotcomrendering.pageElements.InteractiveContentsBlockElement',
 						elementId: element.elementId,
@@ -51,6 +51,7 @@ export const enhanceInteractiveContentsElements = (
 								? endDocumentElement.elementId
 								: undefined,
 					});
+				}
 			} else {
 				updatedElements.push(element);
 			}

--- a/dotcom-rendering/src/model/enhance-numbered-lists.ts
+++ b/dotcom-rendering/src/model/enhance-numbered-lists.ts
@@ -53,8 +53,11 @@ const isStarRating = (element: FEElement): boolean => {
 	};
 
 	// Checks if this element is a 'star rating' based on the convention: <p>★★★★☆</p>
-	if (element._type !== 'model.dotcomrendering.pageElements.TextBlockElement')
+	if (
+		element._type !== 'model.dotcomrendering.pageElements.TextBlockElement'
+	) {
 		return false;
+	}
 	const frag = JSDOM.fragment(element.html);
 	const hasPTags = frag.firstElementChild?.nodeName === 'P';
 	const text = frag.textContent ?? '';

--- a/dotcom-rendering/src/model/enhanceCards.ts
+++ b/dotcom-rendering/src/model/enhanceCards.ts
@@ -50,8 +50,9 @@ const decidePresentationFormat = ({
 		containerFormat.design === ArticleDesign.Video ||
 		containerFormat.theme === ArticleSpecial.SpecialReport ||
 		containerFormat.design === ArticleDesign.Analysis
-	)
+	) {
 		return containerFormat;
+	}
 
 	// These types of link format designs mean the headline could render
 	// poorly (e.g.: white) so we use the container format
@@ -61,8 +62,9 @@ const decidePresentationFormat = ({
 		linkFormat.design === ArticleDesign.Audio ||
 		linkFormat.theme === ArticleSpecial.SpecialReport ||
 		linkFormat.design === ArticleDesign.Video
-	)
+	) {
 		return { ...containerFormat, theme: Pillar.News };
+	}
 
 	// Otherwise, we can allow the sublink to express its own styling
 	return linkFormat;

--- a/dotcom-rendering/src/model/extractTrendingTopics.ts
+++ b/dotcom-rendering/src/model/extractTrendingTopics.ts
@@ -99,8 +99,9 @@ export const extractTrendingTopicsFomFront = (
 	for (const card of collections.flatMap((collection) => [
 		...collection.curated,
 		...collection.backfill,
-	]))
+	])) {
 		trails.set(card.properties.maybeContentId ?? card.card.id, card);
+	}
 
 	return extractTrendingTopics([...trails.values()], pageId);
 };

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -2276,10 +2276,12 @@ const standfirstTextDark: PaletteFunction = ({ design, display, theme }) => {
 };
 
 const cardBorderTopLight: PaletteFunction = ({ theme, design }) => {
-	if (theme === ArticleSpecial.SpecialReportAlt)
+	if (theme === ArticleSpecial.SpecialReportAlt) {
 		return sourcePalette.neutral[60];
-	if (theme === ArticleSpecial.SpecialReport)
+	}
+	if (theme === ArticleSpecial.SpecialReport) {
 		return sourcePalette.brandAlt[400];
+	}
 	if (theme === ArticleSpecial.Labs) return sourcePalette.labs[400];
 	if (design === ArticleDesign.Analysis) {
 		switch (theme) {
@@ -2307,8 +2309,9 @@ const cardBorderTopDark = (): string => {
 	return sourcePalette.neutral[20];
 };
 const cardAgeTextLight: PaletteFunction = (format) => {
-	if (format.theme === ArticleSpecial.SpecialReportAlt)
+	if (format.theme === ArticleSpecial.SpecialReportAlt) {
 		return sourcePalette.specialReportAlt[100];
+	}
 
 	switch (format.design) {
 		case ArticleDesign.Comment:
@@ -2378,10 +2381,12 @@ const cardOnwardContentFooterDark = (): string => {
 };
 
 const cardBackgroundLight: PaletteFunction = (format) => {
-	if (format.theme === ArticleSpecial.SpecialReportAlt)
+	if (format.theme === ArticleSpecial.SpecialReportAlt) {
 		return sourcePalette.specialReportAlt[700];
-	if (format.theme === ArticleSpecial.SpecialReport)
+	}
+	if (format.theme === ArticleSpecial.SpecialReport) {
 		return sourcePalette.specialReport[300];
+	}
 	switch (format.design) {
 		case ArticleDesign.Editorial:
 		case ArticleDesign.Letter:
@@ -2538,11 +2543,13 @@ const onwardContentCardHoverDark: PaletteFunction = ({ theme, design }) => {
 };
 
 const cardHeadlineTextLight: PaletteFunction = (format) => {
-	if (format.theme === ArticleSpecial.SpecialReport)
+	if (format.theme === ArticleSpecial.SpecialReport) {
 		return sourcePalette.neutral[100];
+	}
 
-	if (format.theme === ArticleSpecial.SpecialReportAlt)
+	if (format.theme === ArticleSpecial.SpecialReportAlt) {
 		return sourcePalette.specialReportAlt[100];
+	}
 
 	if (
 		format.design !== ArticleDesign.Gallery &&
@@ -2668,13 +2675,16 @@ const cardKickerTextLight: PaletteFunction = (format) => {
 		format.theme === ArticleSpecial.SpecialReport &&
 		(format.design === ArticleDesign.Comment ||
 			format.design === ArticleDesign.Letter)
-	)
+	) {
 		return sourcePalette.brandAlt[400];
-	if (format.theme === ArticleSpecial.SpecialReportAlt)
+	}
+	if (format.theme === ArticleSpecial.SpecialReportAlt) {
 		return sourcePalette.neutral[7];
+	}
 
-	if (format.theme === ArticleSpecial.SpecialReport)
+	if (format.theme === ArticleSpecial.SpecialReport) {
 		return sourcePalette.brandAlt[400];
+	}
 
 	switch (format.design) {
 		case ArticleDesign.LiveBlog:
@@ -2807,10 +2817,12 @@ const captionTextDark: PaletteFunction = ({ design, theme }) => {
 };
 
 const captionLink: PaletteFunction = ({ design, theme }) => {
-	if (design === ArticleDesign.NewsletterSignup)
+	if (design === ArticleDesign.NewsletterSignup) {
 		return sourcePalette.neutral[0];
-	if (design === ArticleDesign.Analysis && theme === Pillar.News)
+	}
+	if (design === ArticleDesign.Analysis && theme === Pillar.News) {
 		return sourcePalette.news[300];
+	}
 	switch (theme) {
 		case Pillar.News:
 			return sourcePalette.news[400];
@@ -3177,15 +3189,17 @@ const articleLinkTextDark: PaletteFunction = ({ display, theme }) => {
 const articleLinkBorderLight: PaletteFunction = ({ design, theme }) => {
 	if (theme === ArticleSpecial.Labs) return sourcePalette.neutral[60];
 
-	if (theme === ArticleSpecial.SpecialReport)
+	if (theme === ArticleSpecial.SpecialReport) {
 		return sourcePalette.specialReport[300];
+	}
 
 	if (
 		theme === ArticleSpecial.SpecialReportAlt &&
 		design !== ArticleDesign.DeadBlog &&
 		design !== ArticleDesign.LiveBlog
-	)
+	) {
 		return transparentColour(sourcePalette.neutral[60], 0.3);
+	}
 
 	return sourcePalette.neutral[86];
 };
@@ -3276,21 +3290,24 @@ const articleLinkHoverDark: PaletteFunction = (f) => articleLinkTextDark(f);
 
 const articleLinkBorderHoverLight: PaletteFunction = ({ design, theme }) => {
 	if (theme === ArticleSpecial.Labs) return sourcePalette.neutral[7];
-	if (theme === ArticleSpecial.SpecialReport)
+	if (theme === ArticleSpecial.SpecialReport) {
 		return sourcePalette.specialReport[100];
+	}
 
 	if (
 		theme === ArticleSpecial.SpecialReportAlt &&
 		design !== ArticleDesign.LiveBlog &&
 		design !== ArticleDesign.DeadBlog
-	)
+	) {
 		return sourcePalette.specialReportAlt[200];
+	}
 
 	if (design === ArticleDesign.Analysis && theme === Pillar.News) {
 		return sourcePalette.news[300];
 	}
-	if (theme === ArticleSpecial.SpecialReportAlt)
+	if (theme === ArticleSpecial.SpecialReportAlt) {
 		return sourcePalette.specialReportAlt[200];
+	}
 	return pillarPalette(theme, 400);
 };
 
@@ -3316,10 +3333,12 @@ const articleBorderLight: PaletteFunction = ({ design, theme }) => {
 const articleBorderDark: PaletteFunction = () => sourcePalette.neutral[20];
 
 const straightLinesLight: PaletteFunction = (format) => {
-	if (format.theme === ArticleSpecial.SpecialReportAlt)
+	if (format.theme === ArticleSpecial.SpecialReportAlt) {
 		return transparentColour(sourcePalette.neutral[60], 0.3);
-	if (format.design === ArticleDesign.Picture)
+	}
+	if (format.design === ArticleDesign.Picture) {
 		return transparentColour(sourcePalette.neutral[60], 0.5);
+	}
 	return sourcePalette.neutral[86];
 };
 
@@ -3617,8 +3636,9 @@ const shareButtonLight: PaletteFunction = ({ design, theme, display }) => {
 					) {
 						return sourcePalette.specialReportAlt[100];
 					}
-					if (theme === ArticleSpecial.SpecialReportAlt)
+					if (theme === ArticleSpecial.SpecialReportAlt) {
 						return sourcePalette.news[400];
+					}
 					return pillarPalette(theme, 400);
 			}
 	}
@@ -4317,8 +4337,9 @@ const richLinkBorderLight: PaletteFunction = ({ design, theme }) => {
 };
 const richLinkBorderDark: PaletteFunction = () => sourcePalette.neutral[60];
 const richLinkQuoteFillLight: PaletteFunction = ({ design, theme }) => {
-	if (design === ArticleDesign.Analysis && theme === Pillar.News)
+	if (design === ArticleDesign.Analysis && theme === Pillar.News) {
 		return sourcePalette.news[300];
+	}
 	switch (theme) {
 		case Pillar.Opinion:
 			return sourcePalette.opinion[300];
@@ -4354,8 +4375,9 @@ const affiliateDisclaimerBackgroundHoverDark: PaletteFunction = () =>
 	sourcePalette.neutral[10];
 
 const seriesTitleBackgroundLight: PaletteFunction = ({ theme, display }) => {
-	if (theme === ArticleSpecial.SpecialReport)
+	if (theme === ArticleSpecial.SpecialReport) {
 		return sourcePalette.brandAlt[400];
+	}
 	switch (display) {
 		case ArticleDisplay.Immersive:
 			switch (theme) {
@@ -4608,14 +4630,20 @@ const witnessTitleAuthor: PaletteFunction = (format) =>
 	witnessTitleText(format);
 
 const commentCountFill: PaletteFunction = ({ design, theme }) => {
-	if (design === ArticleDesign.LiveBlog || design === ArticleDesign.DeadBlog)
+	if (
+		design === ArticleDesign.LiveBlog ||
+		design === ArticleDesign.DeadBlog
+	) {
 		return sourcePalette.neutral[46];
+	}
 	if (theme === ArticleSpecial.Labs) return sourcePalette.neutral[7];
-	if (theme === ArticleSpecial.SpecialReport)
+	if (theme === ArticleSpecial.SpecialReport) {
 		return sourcePalette.specialReport[300];
+	}
 
-	if (theme === ArticleSpecial.SpecialReportAlt)
+	if (theme === ArticleSpecial.SpecialReportAlt) {
 		return sourcePalette.specialReportAlt[100];
+	}
 
 	if (design === ArticleDesign.Analysis) {
 		switch (theme) {
@@ -4632,14 +4660,20 @@ const commentCountFill: PaletteFunction = ({ design, theme }) => {
 };
 
 const commentCountFillDark: PaletteFunction = ({ design, theme }) => {
-	if (design === ArticleDesign.LiveBlog || design === ArticleDesign.DeadBlog)
+	if (
+		design === ArticleDesign.LiveBlog ||
+		design === ArticleDesign.DeadBlog
+	) {
 		return sourcePalette.neutral[46];
+	}
 	if (theme === ArticleSpecial.Labs) return sourcePalette.neutral[86];
-	if (theme === ArticleSpecial.SpecialReport)
+	if (theme === ArticleSpecial.SpecialReport) {
 		return sourcePalette.specialReport[500];
+	}
 
-	if (theme === ArticleSpecial.SpecialReportAlt)
+	if (theme === ArticleSpecial.SpecialReportAlt) {
 		return sourcePalette.specialReportAlt[700];
+	}
 
 	if (design === ArticleDesign.Analysis) {
 		switch (theme) {
@@ -4656,7 +4690,7 @@ const commentCountFillDark: PaletteFunction = ({ design, theme }) => {
 };
 
 const mobileCommentCountFill: PaletteFunction = (format) => {
-	if (format.design === ArticleDesign.LiveBlog)
+	if (format.design === ArticleDesign.LiveBlog) {
 		switch (format.theme) {
 			case Pillar.News:
 			case Pillar.Opinion:
@@ -4667,12 +4701,14 @@ const mobileCommentCountFill: PaletteFunction = (format) => {
 			default:
 				return sourcePalette.neutral[100];
 		}
+	}
 	return commentCountFill(format);
 };
 
 const mobileCommentCountFillDark: PaletteFunction = (format) => {
-	if (format.design === ArticleDesign.LiveBlog)
+	if (format.design === ArticleDesign.LiveBlog) {
 		return sourcePalette.neutral[100];
+	}
 	return commentCountFillDark(format);
 };
 

--- a/dotcom-rendering/src/static/icons/Star.tsx
+++ b/dotcom-rendering/src/static/icons/Star.tsx
@@ -5,7 +5,7 @@ export const Star = ({
 	starId: string;
 	isEmpty: boolean;
 }) => {
-	if (isEmpty)
+	if (isEmpty) {
 		return (
 			<svg width="14" height="13" viewBox="0 0 14 13">
 				<path
@@ -21,6 +21,7 @@ export const Star = ({
 				</clipPath>
 			</svg>
 		);
+	}
 
 	return (
 		<svg width="14" height="13" viewBox="0 0 14 13">


### PR DESCRIPTION
## What does this change?

Explicitely [enable ESLint `curly` rule](https://eslint.org/docs/latest/rules/curly#multi-line), with the `multi-line` and `consistent` settings.

All changes fixed automatically.

## Why?

This rule was disabled as it supposedly conflicts with Prettier, but it is valuable and [part of our recommend rules](https://github.com/guardian/csnx/blob/main/libs/%40guardian/eslint-config/index.js#L16), so we re-enable it for this project.

Discovered in https://github.com/guardian/dotcom-rendering/pull/11236#discussion_r1576503110