### PR TITLE
Add a SKIP_CHECK_NODE flag to the check-node script

### DIFF
--- a/.github/workflows/compress.yml
+++ b/.github/workflows/compress.yml
@@ -37,6 +37,13 @@ jobs:
           # https://github.com/preactjs/compressed-size-action#customizing-the-list-of-files
           # The default hash digest is set to 20 chars in Webpack
           pattern: 'dotcom-rendering/dist/*.web.????????????????????.js'
+        env:
+          # preactjs/compressed-size-action compares the size of the dist files of the current branch vs main
+          # But it does not reset the node version between checkouts
+          # When the PR branch changes node versions check-node will fail as the node version wiil stil be
+          # the the one set by setup-node-env
+          # check-node still runs as part of other CI workflows
+          SKIP_CHECK_NODE: true
 
       # preactjs/compressed-size-action does its own checkout, so we need to
       # checkout the repo again so that the 'Post Run' step

--- a/scripts/env/check-node
+++ b/scripts/env/check-node
@@ -2,6 +2,13 @@
 
 # Check whether the current node version matches the .nvmrc version, and offer some help if not.
 
+# Check if we should skip node-check
+# Required to prevent preactjs/compressed-size-action from failing when on a branch that changes node versions
+if [[ "$SKIP_CHECK_NODE" == "true" ]]; then
+	echo "Skipping check-node"
+	exit 0
+fi
+
 in_terminal() { test -t 1; }
 
 strip_colors() {


### PR DESCRIPTION
## What does this change?

Adds a `SKIP_CHECK_NODE` flag to the `check-node` script.

In order to implement a workaround for an [issue](https://github.com/guardian/dotcom-rendering/pull/11175#issuecomment-2059157352) with `preactjs/compressed-size-action@v2` in #11175 I need to add this change to main as the action checks outs main as part of its script.

It will only affect `preactjs/compressed-size-action@v2`



