### PR TITLE
fix tag front branding add badge

### DIFF
--- a/dotcom-rendering/src/components/ArticleHeadline.stories.tsx
+++ b/dotcom-rendering/src/components/ArticleHeadline.stories.tsx
@@ -114,7 +114,7 @@ export const ShowcaseInterview: StoryObj = ({ format }: StoryArgs) => {
 						isSensitive={false}
 						abTests={{}}
 						switches={{}}
-						editionId="UK"
+						editionId={'UK'}
 					/>
 				</ArticleContainer>
 			</Flex>
@@ -161,7 +161,7 @@ export const ShowcaseInterviewNobyline: StoryObj = ({ format }: StoryArgs) => {
 						isSensitive={false}
 						abTests={{}}
 						switches={{}}
-						editionId="UK"
+						editionId={'UK'}
 					/>
 				</ArticleContainer>
 			</Flex>
@@ -206,7 +206,7 @@ export const Interview: StoryObj = ({ format }: StoryArgs) => {
 						isSensitive={false}
 						abTests={{}}
 						switches={{}}
-						editionId="UK"
+						editionId={'UK'}
 					/>
 				</ArticleContainer>
 			</Flex>
@@ -251,7 +251,7 @@ export const InterviewSpecialReport: StoryObj = ({ format }: StoryArgs) => {
 						isSensitive={false}
 						abTests={{}}
 						switches={{}}
-						editionId="UK"
+						editionId={'UK'}
 					/>
 				</ArticleContainer>
 			</Flex>
@@ -297,7 +297,7 @@ export const InterviewNoByline: StoryObj = ({ format }: StoryArgs) => {
 						isSensitive={false}
 						abTests={{}}
 						switches={{}}
-						editionId="UK"
+						editionId={'UK'}
 					/>
 				</ArticleContainer>
 			</Flex>

--- a/dotcom-rendering/src/components/Card/components/CardAge.tsx
+++ b/dotcom-rendering/src/components/Card/components/CardAge.tsx
@@ -79,7 +79,7 @@ export const CardAge = ({
 			<DateTime
 				date={new Date(webPublicationDate)}
 				display="relative"
-				editionId="UK"
+				editionId={'UK'}
 				showWeekday={false}
 				showDate={true}
 				showTime={false}

--- a/dotcom-rendering/src/components/DecideContainerByTrails.stories.tsx
+++ b/dotcom-rendering/src/components/DecideContainerByTrails.stories.tsx
@@ -23,6 +23,7 @@ export const OneCardFast = () => {
 		<FrontSection
 			title="Fast - One card"
 			discussionApiUrl={discussionApiUrl}
+			editionId={'UK'}
 		>
 			<DecideContainerByTrails
 				trails={trails.slice(0, 1)}
@@ -39,6 +40,7 @@ export const TwoCardFast = () => {
 		<FrontSection
 			title="Fast - Two cards"
 			discussionApiUrl={discussionApiUrl}
+			editionId={'UK'}
 		>
 			<DecideContainerByTrails
 				trails={trails.slice(0, 2)}
@@ -55,6 +57,7 @@ export const ThreeCardFast = () => {
 		<FrontSection
 			title="Fast - Three cards"
 			discussionApiUrl={discussionApiUrl}
+			editionId={'UK'}
 		>
 			<DecideContainerByTrails
 				trails={trails.slice(0, 3)}
@@ -71,6 +74,7 @@ export const FourCardFast = () => {
 		<FrontSection
 			title="Fast - Four cards"
 			discussionApiUrl={discussionApiUrl}
+			editionId={'UK'}
 		>
 			<DecideContainerByTrails
 				trails={trails.slice(0, 4)}
@@ -87,6 +91,7 @@ export const FiveCardFast = () => {
 		<FrontSection
 			title="Fast - Five cards"
 			discussionApiUrl={discussionApiUrl}
+			editionId={'UK'}
 		>
 			<DecideContainerByTrails
 				trails={trails.slice(0, 5)}
@@ -103,6 +108,7 @@ export const SixCardFast = () => {
 		<FrontSection
 			title="Fast - Six cards"
 			discussionApiUrl={discussionApiUrl}
+			editionId={'UK'}
 		>
 			<DecideContainerByTrails
 				trails={trails.slice(0, 6)}
@@ -119,6 +125,7 @@ export const SevenCardFast = () => {
 		<FrontSection
 			title="Fast - Seven cards"
 			discussionApiUrl={discussionApiUrl}
+			editionId={'UK'}
 		>
 			<DecideContainerByTrails
 				trails={trails.slice(0, 7)}
@@ -135,6 +142,7 @@ export const EightCardFast = () => {
 		<FrontSection
 			title="Fast - Eight cards"
 			discussionApiUrl={discussionApiUrl}
+			editionId={'UK'}
 		>
 			<DecideContainerByTrails
 				trails={trails.slice(0, 8)}
@@ -152,6 +160,7 @@ export const TwelveCardFast = () => {
 		<FrontSection
 			title="Fast - Twelve cards"
 			discussionApiUrl={discussionApiUrl}
+			editionId={'UK'}
 		>
 			<DecideContainerByTrails
 				trails={trails.slice(0, 12)}
@@ -168,6 +177,7 @@ export const OneCardSlow = () => {
 		<FrontSection
 			title="Slow - One card"
 			discussionApiUrl={discussionApiUrl}
+			editionId={'UK'}
 		>
 			<DecideContainerByTrails
 				trails={trails.slice(0, 1)}
@@ -184,6 +194,7 @@ export const TwoCardSlow = () => {
 		<FrontSection
 			title="Slow - Two cards"
 			discussionApiUrl={discussionApiUrl}
+			editionId={'UK'}
 		>
 			<DecideContainerByTrails
 				trails={trails.slice(0, 2)}
@@ -200,6 +211,7 @@ export const ThreeCardSlow = () => {
 		<FrontSection
 			title="Slow - Three cards"
 			discussionApiUrl={discussionApiUrl}
+			editionId={'UK'}
 		>
 			<DecideContainerByTrails
 				trails={trails.slice(0, 3)}
@@ -216,6 +228,7 @@ export const FourCardSlow = () => {
 		<FrontSection
 			title="Slow - Four cards"
 			discussionApiUrl={discussionApiUrl}
+			editionId={'UK'}
 		>
 			<DecideContainerByTrails
 				trails={trails.slice(0, 4)}
@@ -232,6 +245,7 @@ export const FiveCardSlow = () => {
 		<FrontSection
 			title="Slow - Five cards"
 			discussionApiUrl={discussionApiUrl}
+			editionId={'UK'}
 		>
 			<DecideContainerByTrails
 				trails={trails.slice(0, 5)}
@@ -248,6 +262,7 @@ export const SixCardSlow = () => {
 		<FrontSection
 			title="Slow - Six cards"
 			discussionApiUrl={discussionApiUrl}
+			editionId={'UK'}
 		>
 			<DecideContainerByTrails
 				trails={trails.slice(0, 6)}
@@ -264,6 +279,7 @@ export const SevenCardSlow = () => {
 		<FrontSection
 			title="Slow - Seven cards"
 			discussionApiUrl={discussionApiUrl}
+			editionId={'UK'}
 		>
 			<DecideContainerByTrails
 				trails={trails.slice(0, 7)}
@@ -280,6 +296,7 @@ export const EightCardSlow = () => {
 		<FrontSection
 			title="Slow - Eight cards"
 			discussionApiUrl={discussionApiUrl}
+			editionId={'UK'}
 		>
 			<DecideContainerByTrails
 				trails={trails.slice(0, 8)}
@@ -297,6 +314,7 @@ export const TwelveCardSlow = () => {
 		<FrontSection
 			title="Slow - Twelve cards"
 			discussionApiUrl={discussionApiUrl}
+			editionId={'UK'}
 		>
 			<DecideContainerByTrails
 				trails={trails.slice(0, 12)}

--- a/dotcom-rendering/src/components/DynamicFast.stories.tsx
+++ b/dotcom-rendering/src/components/DynamicFast.stories.tsx
@@ -34,6 +34,7 @@ export const OneHugeTwoBigsSixStandards = () => (
 		title="Dynamic Fast"
 		description={`first slice: oneHuge</br>second slice: twoBigs`}
 		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
 	>
 		<DynamicFast
 			groupedTrails={{
@@ -54,6 +55,7 @@ export const OneVeryBigTwoBigsSixStandards = () => (
 		title="Dynamic Fast"
 		description={`first slice: oneVeryBig</br>second slice: twoBigs`}
 		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
 	>
 		<DynamicFast
 			groupedTrails={{
@@ -75,6 +77,7 @@ export const TwoVeryBigsTwoBigsSixStandards = () => (
 		title="Dynamic Fast"
 		description={`first slice: twoVeryBigs</br>second slice: twoBigs`}
 		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
 	>
 		<DynamicFast
 			groupedTrails={{
@@ -96,6 +99,7 @@ export const TwoVeryBigs1stBoostedTwoBigsSixStandards = () => (
 		title="Dynamic Fast"
 		description={`first slice: twoVeryBigsFirstBoosted</br>second slice: twoBigs`}
 		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
 	>
 		<DynamicFast
 			groupedTrails={{
@@ -117,6 +121,7 @@ export const TwoVeryBigs2ndBoostedTwoBigsSixStandards = () => (
 		title="Dynamic Fast"
 		description={`first slice: twoVeryBigsSecondBoosted</br>second slice: twoBigs`}
 		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
 	>
 		<DynamicFast
 			groupedTrails={{
@@ -140,6 +145,7 @@ export const TwoVeryBigsTwelveStandards = () => (
 		title="Dynamic Fast"
 		description={`first slice: twoVeryBigs</br>second slice: noBigs`}
 		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
 	>
 		<DynamicFast
 			groupedTrails={{
@@ -160,6 +166,7 @@ export const TwoVeryBigsOneBigEightStandards = () => (
 		title="Dynamic Fast"
 		description={`first slice: twoVeryBigs</br>second slice: oneBig`}
 		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
 	>
 		<DynamicFast
 			groupedTrails={{
@@ -182,6 +189,7 @@ export const TwoVeryBigsOneBigBoostedSixStandards = () => (
 		title="Dynamic Fast"
 		description={`first slice: twoVeryBigs</br>second slice: oneBigBoosted`}
 		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
 	>
 		<DynamicFast
 			groupedTrails={{
@@ -204,6 +212,7 @@ export const TwoVeryBigsTwoBigsFiveStandards = () => (
 		title="Dynamic Fast"
 		description={`first slice: twoVeryBigs</br>second slice: twoBigs`}
 		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
 	>
 		<DynamicFast
 			groupedTrails={{
@@ -226,6 +235,7 @@ export const TwoVeryBigsTwoBigsFirstBoostedEightStandards = () => (
 		title="Dynamic Fast"
 		description={`first slice: twoVeryBigs</br>second slice: twoOrMoreBigsFirstBoosted`}
 		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
 	>
 		<DynamicFast
 			groupedTrails={{
@@ -248,6 +258,7 @@ export const TwoVeryBigsThreeBigsThreeStandards = () => (
 		title="Dynamic Fast"
 		description={`first slice: twoVeryBigs</br>second slice: threeBigs`}
 		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
 	>
 		<DynamicFast
 			groupedTrails={{
@@ -270,6 +281,7 @@ export const TwoVeryBigsFourBigs = () => (
 		title="Dynamic Fast"
 		description={`first slice: twoVeryBigs</br>second slice: fourBigs`}
 		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
 	>
 		<DynamicFast
 			groupedTrails={{
@@ -294,6 +306,7 @@ export const OneHugeOneVeryBig7Standards = () => (
 		title="Dynamic Fast"
 		description={`first slice: oneHuge</br>second slice: oneBig`}
 		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
 	>
 		<DynamicFast
 			groupedTrails={{
@@ -316,6 +329,7 @@ export const ThreeVeryBigsFourBigs = () => (
 		title="Dynamic Fast"
 		description={`first slice: twoVeryBigs</br>second slice: fourBigs`}
 		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
 	>
 		<DynamicFast
 			groupedTrails={{
@@ -337,6 +351,7 @@ export const TwoBigsFourStandards = () => (
 		title="Dynamic Fast"
 		description={`first slice: undefined</br>second slice: twoBigs`}
 		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
 	>
 		<DynamicFast
 			groupedTrails={{
@@ -359,6 +374,7 @@ export const OneVeryBigTwoBigs = () => (
 		title="Dynamic Fast"
 		description={`first slice: oneVeryBig</br>second slice: twoBigs`}
 		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
 	>
 		<DynamicFast
 			groupedTrails={{
@@ -380,6 +396,7 @@ export const OneVeryBig = () => (
 		title="Dynamic Fast"
 		description={`first slice: oneVeryBig</br>second slice: noBigs`}
 		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
 	>
 		<DynamicFast
 			groupedTrails={{
@@ -400,6 +417,7 @@ export const TwoVeryBigsFourBigsFirstBoostedThreeStandards = () => (
 		title="Dynamic Fast"
 		description={`first slice: twoVeryBigs</br>second slice: twoOrMoreBigsFirstBoosted`}
 		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
 	>
 		<DynamicFast
 			groupedTrails={{

--- a/dotcom-rendering/src/components/DynamicPackage.stories.tsx
+++ b/dotcom-rendering/src/components/DynamicPackage.stories.tsx
@@ -33,6 +33,7 @@ export const One = () => (
 		title="Dynamic Package"
 		showTopBorder={true}
 		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
 	>
 		<DynamicPackage
 			groupedTrails={{
@@ -60,6 +61,7 @@ export const OneWithManySublinks = () => {
 			title="Dynamic Package"
 			showTopBorder={true}
 			discussionApiUrl={discussionApiUrl}
+			editionId={'UK'}
 		>
 			<DynamicPackage
 				groupedTrails={{
@@ -81,6 +83,7 @@ export const Two = () => (
 		title="Dynamic Package"
 		showTopBorder={true}
 		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
 	>
 		<DynamicPackage
 			groupedTrails={{
@@ -96,7 +99,11 @@ export const Two = () => (
 Two.storyName = 'With two standard cards';
 
 export const Three = () => (
-	<FrontSection title="Dynamic Package" discussionApiUrl={discussionApiUrl}>
+	<FrontSection
+		title="Dynamic Package"
+		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
+	>
 		<DynamicPackage
 			groupedTrails={{
 				...defaultGroupedTrails,
@@ -111,7 +118,11 @@ export const Three = () => (
 Three.storyName = 'With three standard cards';
 
 export const Four = () => (
-	<FrontSection title="Dynamic Package" discussionApiUrl={discussionApiUrl}>
+	<FrontSection
+		title="Dynamic Package"
+		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
+	>
 		<DynamicPackage
 			groupedTrails={{
 				...defaultGroupedTrails,
@@ -126,7 +137,11 @@ export const Four = () => (
 Four.storyName = 'With four standard cards';
 
 export const Five = () => (
-	<FrontSection title="Dynamic Package" discussionApiUrl={discussionApiUrl}>
+	<FrontSection
+		title="Dynamic Package"
+		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
+	>
 		<DynamicPackage
 			groupedTrails={{
 				...defaultGroupedTrails,
@@ -145,6 +160,7 @@ export const Six = () => (
 		title="Dynamic Package"
 		showTopBorder={true}
 		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
 	>
 		<DynamicPackage
 			groupedTrails={{
@@ -164,6 +180,7 @@ export const Seven = () => (
 		title="Dynamic Package"
 		showTopBorder={true}
 		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
 	>
 		<DynamicPackage
 			groupedTrails={{
@@ -183,6 +200,7 @@ export const Eight = () => (
 		title="Dynamic Package"
 		showTopBorder={true}
 		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
 	>
 		<DynamicPackage
 			groupedTrails={{
@@ -202,6 +220,7 @@ export const Nine = () => (
 		title="Dynamic Package"
 		showTopBorder={true}
 		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
 	>
 		<DynamicPackage
 			groupedTrails={{
@@ -224,6 +243,7 @@ export const Boosted1 = () => {
 			title="Dynamic Package"
 			showTopBorder={true}
 			discussionApiUrl={discussionApiUrl}
+			editionId={'UK'}
 		>
 			<DynamicPackage
 				groupedTrails={{
@@ -249,6 +269,7 @@ export const Boosted2 = () => {
 			title="Dynamic Package"
 			showTopBorder={true}
 			discussionApiUrl={discussionApiUrl}
+			editionId={'UK'}
 		>
 			<DynamicPackage
 				groupedTrails={{
@@ -273,6 +294,7 @@ export const Boosted3 = () => {
 		<FrontSection
 			title="Dynamic Package"
 			discussionApiUrl={discussionApiUrl}
+			editionId={'UK'}
 		>
 			<DynamicPackage
 				groupedTrails={{
@@ -297,6 +319,7 @@ export const Boosted4 = () => {
 		<FrontSection
 			title="Dynamic Package"
 			discussionApiUrl={discussionApiUrl}
+			editionId={'UK'}
 		>
 			<DynamicPackage
 				groupedTrails={{
@@ -321,6 +344,7 @@ export const Boosted5 = () => {
 		<FrontSection
 			title="Dynamic Package"
 			discussionApiUrl={discussionApiUrl}
+			editionId={'UK'}
 		>
 			<DynamicPackage
 				groupedTrails={{
@@ -346,6 +370,7 @@ export const Boosted8 = () => {
 			title="Dynamic Package"
 			showTopBorder={true}
 			discussionApiUrl={discussionApiUrl}
+			editionId={'UK'}
 		>
 			<DynamicPackage
 				groupedTrails={{
@@ -371,6 +396,7 @@ export const Boosted9 = () => {
 			title="Dynamic Package"
 			showTopBorder={true}
 			discussionApiUrl={discussionApiUrl}
+			editionId={'UK'}
 		>
 			<DynamicPackage
 				groupedTrails={{
@@ -388,7 +414,11 @@ export const Boosted9 = () => {
 Boosted9.storyName = 'With nine standard cards - boosted';
 
 export const OneSnapThreeStandard = () => (
-	<FrontSection title="Dynamic Package" discussionApiUrl={discussionApiUrl}>
+	<FrontSection
+		title="Dynamic Package"
+		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
+	>
 		<DynamicPackage
 			groupedTrails={{
 				...defaultGroupedTrails,
@@ -403,7 +433,11 @@ export const OneSnapThreeStandard = () => (
 OneSnapThreeStandard.storyName = 'With one snap - three standard cards';
 
 export const ThreeSnapTwoStandard = () => (
-	<FrontSection title="Dynamic Package" discussionApiUrl={discussionApiUrl}>
+	<FrontSection
+		title="Dynamic Package"
+		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
+	>
 		<DynamicPackage
 			groupedTrails={{
 				...defaultGroupedTrails,
@@ -418,7 +452,11 @@ export const ThreeSnapTwoStandard = () => (
 ThreeSnapTwoStandard.storyName = 'With three snaps - two standard cards';
 
 export const ThreeSnapTwoStandard2ndBoosted = () => (
-	<FrontSection title="Dynamic Package" discussionApiUrl={discussionApiUrl}>
+	<FrontSection
+		title="Dynamic Package"
+		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
+	>
 		<DynamicPackage
 			groupedTrails={{
 				...defaultGroupedTrails,
@@ -438,6 +476,7 @@ export const SpecialReportWithoutPalette = () => (
 		title="Dynamic Package"
 		showTopBorder={true}
 		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
 	>
 		<DynamicPackage
 			groupedTrails={{
@@ -486,6 +525,7 @@ export const VideoSublinks = () => (
 		title="Dynamic Package"
 		showTopBorder={true}
 		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
 	>
 		<DynamicPackage
 			groupedTrails={{

--- a/dotcom-rendering/src/components/DynamicSlow.stories.tsx
+++ b/dotcom-rendering/src/components/DynamicSlow.stories.tsx
@@ -47,7 +47,11 @@ export const Avatar = () => {
 		};
 	});
 	return (
-		<FrontSection title="Dynamic Slow" discussionApiUrl={discussionApiUrl}>
+		<FrontSection
+			title="Dynamic Slow"
+			discussionApiUrl={discussionApiUrl}
+			editionId={'UK'}
+		>
 			<DynamicSlow
 				groupedTrails={{
 					...defaultGroupedTrails,
@@ -74,6 +78,7 @@ export const OneHugeTwoBigsFourStandards = () => (
 		title="Dynamic Slow"
 		description={`first slice: oneHuge</br>second slice: twoBigs`}
 		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
 	>
 		<DynamicSlow
 			groupedTrails={{
@@ -94,6 +99,7 @@ export const OneVeryBigTwoBigsFourStandards = () => (
 		title="Dynamic Slow"
 		description={`first slice: oneVeryBig</br>second slice: twoBigs`}
 		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
 	>
 		<DynamicSlow
 			groupedTrails={{
@@ -115,6 +121,7 @@ export const TwoVeryBigsTwoBigsFourStandards = () => (
 		title="Dynamic Slow"
 		description={`first slice: twoVeryBigs</br>second slice: twoBigs`}
 		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
 	>
 		<DynamicSlow
 			groupedTrails={{
@@ -136,6 +143,7 @@ export const TwoVeryBigs1stBoostedTwoBigsFourStandards = () => (
 		title="Dynamic Slow"
 		description={`first slice: twoVeryBigsFirstBoosted</br>second slice: twoBigs`}
 		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
 	>
 		<DynamicSlow
 			groupedTrails={{
@@ -157,6 +165,7 @@ export const TwoVeryBigs2ndBoostedTwoBigsFourStandards = () => (
 		title="Dynamic Slow"
 		description={`first slice: twoVeryBigsSecondBoosted</br>second slice: twoBigs`}
 		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
 	>
 		<DynamicSlow
 			groupedTrails={{
@@ -179,6 +188,7 @@ export const TwoVeryBigs8Standards = () => (
 		title="Dynamic Slow"
 		description={`first slice: twoVeryBigs</br>second slice: noBigs`}
 		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
 	>
 		<DynamicSlow
 			groupedTrails={{
@@ -198,6 +208,7 @@ export const TwoVeryBigsOneBig4Standards = () => (
 		title="Dynamic Slow"
 		description={`first slice: twoVeryBigs</br>second slice: oneBig`}
 		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
 	>
 		<DynamicSlow
 			groupedTrails={{
@@ -219,6 +230,7 @@ export const TwoVeryBigsTwoBigs4Standards = () => (
 		title="Dynamic Slow"
 		description={`first slice: twoVeryBigs</br>second slice: twoBigs`}
 		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
 	>
 		<DynamicSlow
 			groupedTrails={{
@@ -243,6 +255,7 @@ export const TwoVeryBigsFiveStandards = () => (
 		title="Dynamic Slow"
 		description={`first slice: twoVeryBigs</br>second slice: noBigs`}
 		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
 	>
 		<DynamicSlow
 			groupedTrails={{
@@ -263,6 +276,7 @@ export const ThreeVeryBigsFiveStandards = () => (
 		title="Dynamic Slow"
 		description={`first slice: twoVeryBigs</br>second slice: oneBig`}
 		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
 	>
 		<DynamicSlow
 			groupedTrails={{
@@ -283,6 +297,7 @@ export const TwoVeryBigsOneBig = () => (
 		title="Dynamic Slow"
 		description={`first slice: twoVeryBigs</br>second slice: oneBig`}
 		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
 	>
 		<DynamicSlow
 			groupedTrails={{
@@ -303,6 +318,7 @@ export const TwoBigsThreeStandards = () => (
 		title="Dynamic Slow"
 		description={`first slice: undefined</br>second slice: twoBigs`}
 		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
 	>
 		<DynamicSlow
 			groupedTrails={{
@@ -323,6 +339,7 @@ export const OneVeryBigTwoBigsOneStandard = () => (
 		title="Dynamic Slow"
 		description={`first slice: twoVeryBigs</br>second slice: twoBigs`}
 		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
 	>
 		<DynamicSlow
 			groupedTrails={{

--- a/dotcom-rendering/src/components/DynamicSlowMPU.stories.tsx
+++ b/dotcom-rendering/src/components/DynamicSlowMPU.stories.tsx
@@ -22,7 +22,11 @@ const bigs = trails.slice(0, 3);
 const standards = trails.slice(3);
 
 export const NoBigs = () => (
-	<FrontSection title="Dynamic Slow MPU" discussionApiUrl={discussionApiUrl}>
+	<FrontSection
+		title="Dynamic Slow MPU"
+		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
+	>
 		<DynamicSlowMPU
 			groupedTrails={{
 				snap: [],
@@ -39,7 +43,11 @@ export const NoBigs = () => (
 NoBigs.storyName = 'with no big cards, only standard';
 
 export const OneBig = () => (
-	<FrontSection title="Dynamic Slow MPU" discussionApiUrl={discussionApiUrl}>
+	<FrontSection
+		title="Dynamic Slow MPU"
+		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
+	>
 		<DynamicSlowMPU
 			groupedTrails={{
 				snap: [],
@@ -56,7 +64,11 @@ export const OneBig = () => (
 OneBig.storyName = 'with just one big';
 
 export const TwoBigs = () => (
-	<FrontSection title="Dynamic Slow MPU" discussionApiUrl={discussionApiUrl}>
+	<FrontSection
+		title="Dynamic Slow MPU"
+		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
+	>
 		<DynamicSlowMPU
 			groupedTrails={{
 				snap: [],
@@ -73,7 +85,11 @@ export const TwoBigs = () => (
 TwoBigs.storyName = 'with two bigs';
 
 export const FirstBigBoosted = () => (
-	<FrontSection title="Dynamic Slow MPU" discussionApiUrl={discussionApiUrl}>
+	<FrontSection
+		title="Dynamic Slow MPU"
+		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
+	>
 		<DynamicSlowMPU
 			groupedTrails={{
 				snap: [],
@@ -94,7 +110,11 @@ export const FirstBigBoosted = () => (
 FirstBigBoosted.storyName = 'with the first of two bigs boosted';
 
 export const SecondBigBoosted = () => (
-	<FrontSection title="Dynamic Slow MPU" discussionApiUrl={discussionApiUrl}>
+	<FrontSection
+		title="Dynamic Slow MPU"
+		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
+	>
 		<DynamicSlowMPU
 			groupedTrails={{
 				snap: [],
@@ -115,7 +135,11 @@ export const SecondBigBoosted = () => (
 SecondBigBoosted.storyName = 'with the second of two bigs boosted';
 
 export const ThreeBigs = () => (
-	<FrontSection title="Dynamic Slow MPU" discussionApiUrl={discussionApiUrl}>
+	<FrontSection
+		title="Dynamic Slow MPU"
+		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
+	>
 		<DynamicSlowMPU
 			groupedTrails={{
 				snap: [],
@@ -132,7 +156,11 @@ export const ThreeBigs = () => (
 ThreeBigs.storyName = 'with three bigs';
 
 export const AllBigs = () => (
-	<FrontSection title="DynamicSlowMPU" discussionApiUrl={discussionApiUrl}>
+	<FrontSection
+		title="DynamicSlowMPU"
+		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
+	>
 		<DynamicSlowMPU
 			groupedTrails={{
 				snap: [],
@@ -149,7 +177,11 @@ export const AllBigs = () => (
 AllBigs.storyName = 'Ad-free with lots of bigs';
 
 export const TwoBigsThreeStandardsNoMPU = () => (
-	<FrontSection title="DynamicSlowMPU" discussionApiUrl={discussionApiUrl}>
+	<FrontSection
+		title="DynamicSlowMPU"
+		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
+	>
 		<DynamicSlowMPU
 			groupedTrails={{
 				snap: [],
@@ -166,7 +198,11 @@ export const TwoBigsThreeStandardsNoMPU = () => (
 TwoBigsThreeStandardsNoMPU.storyName = 'Ad-free with 2 bigs & 3 standards';
 
 export const NoBigsTwoStandardsNoMPU = () => (
-	<FrontSection title="DynamicSlowMPU" discussionApiUrl={discussionApiUrl}>
+	<FrontSection
+		title="DynamicSlowMPU"
+		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
+	>
 		<DynamicSlowMPU
 			groupedTrails={{
 				snap: [],
@@ -183,7 +219,11 @@ export const NoBigsTwoStandardsNoMPU = () => (
 NoBigsTwoStandardsNoMPU.storyName = 'Ad-free with 0 bigs & 2 standards';
 
 export const NoBigsFiveStandardsNoMPU = () => (
-	<FrontSection title="DynamicSlowMPU" discussionApiUrl={discussionApiUrl}>
+	<FrontSection
+		title="DynamicSlowMPU"
+		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
+	>
 		<DynamicSlowMPU
 			groupedTrails={{
 				snap: [],

--- a/dotcom-rendering/src/components/FirstPublished.tsx
+++ b/dotcom-rendering/src/components/FirstPublished.tsx
@@ -64,7 +64,7 @@ const FirstPublished = ({
 						<DateTime
 							date={new Date(firstPublished)}
 							display="relative"
-							editionId="UK"
+							editionId={'UK'}
 							showWeekday={false}
 							showDate={true}
 							showTime={false}

--- a/dotcom-rendering/src/components/FixedLargeSlowXIV.stories.tsx
+++ b/dotcom-rendering/src/components/FixedLargeSlowXIV.stories.tsx
@@ -22,6 +22,7 @@ export const Default = () => (
 	<FrontSection
 		title="Fixed Large Slow XIV"
 		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
 	>
 		<FixedLargeSlowXIV
 			trails={trails}

--- a/dotcom-rendering/src/components/FixedMediumFastXI.stories.tsx
+++ b/dotcom-rendering/src/components/FixedMediumFastXI.stories.tsx
@@ -22,6 +22,7 @@ export const OneTrail = () => (
 	<FrontSection
 		title="Fixed Medium Fast XI"
 		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
 	>
 		<FixedMediumFastXI trails={trails.slice(0, 1)} imageLoading="eager" />
 	</FrontSection>
@@ -32,6 +33,7 @@ export const TwoTrails = () => (
 	<FrontSection
 		title="Fixed Medium Fast XI"
 		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
 	>
 		<FixedMediumFastXI trails={trails.slice(0, 2)} imageLoading="eager" />
 	</FrontSection>
@@ -42,6 +44,7 @@ export const ThreeTrails = () => (
 	<FrontSection
 		title="Fixed Medium Fast XI"
 		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
 	>
 		<FixedMediumFastXI trails={trails.slice(0, 3)} imageLoading="eager" />
 	</FrontSection>
@@ -52,6 +55,7 @@ export const FourTrails = () => (
 	<FrontSection
 		title="Fixed Medium Fast XI"
 		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
 	>
 		<FixedMediumFastXI trails={trails.slice(0, 4)} imageLoading="eager" />
 	</FrontSection>
@@ -62,6 +66,7 @@ export const FiveTrails = () => (
 	<FrontSection
 		title="Fixed Medium Fast XI"
 		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
 	>
 		<FixedMediumFastXI trails={trails.slice(0, 5)} imageLoading="eager" />
 	</FrontSection>
@@ -72,6 +77,7 @@ export const SixTrails = () => (
 	<FrontSection
 		title="Fixed Medium Fast XI"
 		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
 	>
 		<FixedMediumFastXI trails={trails.slice(0, 6)} imageLoading="eager" />
 	</FrontSection>
@@ -82,6 +88,7 @@ export const SevenTrails = () => (
 	<FrontSection
 		title="Fixed Medium Fast XI"
 		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
 	>
 		<FixedMediumFastXI trails={trails.slice(0, 7)} imageLoading="eager" />
 	</FrontSection>
@@ -92,6 +99,7 @@ export const EightTrails = () => (
 	<FrontSection
 		title="Fixed Medium Fast XI"
 		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
 	>
 		<FixedMediumFastXI trails={trails.slice(0, 8)} imageLoading="eager" />
 	</FrontSection>
@@ -102,6 +110,7 @@ export const NineTrails = () => (
 	<FrontSection
 		title="Fixed Medium Fast XI"
 		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
 	>
 		<FixedMediumFastXI trails={trails.slice(0, 9)} imageLoading="eager" />
 	</FrontSection>
@@ -112,6 +121,7 @@ export const TenTrails = () => (
 	<FrontSection
 		title="Fixed Medium Fast XI"
 		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
 	>
 		<FixedMediumFastXI trails={trails.slice(0, 10)} imageLoading="eager" />
 	</FrontSection>
@@ -122,6 +132,7 @@ export const ElevenTrails = () => (
 	<FrontSection
 		title="Fixed Medium Fast XI"
 		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
 	>
 		<FixedMediumFastXI trails={trails.slice(0, 11)} imageLoading="eager" />
 	</FrontSection>

--- a/dotcom-rendering/src/components/FixedMediumFastXII.stories.tsx
+++ b/dotcom-rendering/src/components/FixedMediumFastXII.stories.tsx
@@ -22,6 +22,7 @@ export const Default = () => (
 	<FrontSection
 		title="Fixed Medium Fast XII"
 		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
 	>
 		<FixedMediumFastXII
 			trails={trails}

--- a/dotcom-rendering/src/components/FixedMediumSlowVI.stories.tsx
+++ b/dotcom-rendering/src/components/FixedMediumSlowVI.stories.tsx
@@ -22,6 +22,7 @@ export const Default = () => (
 	<FrontSection
 		title="Fixed Medium Slow VI"
 		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
 	>
 		<FixedMediumSlowVI
 			trails={trails}

--- a/dotcom-rendering/src/components/FixedMediumSlowVII.stories.tsx
+++ b/dotcom-rendering/src/components/FixedMediumSlowVII.stories.tsx
@@ -23,6 +23,7 @@ export const Default = () => (
 		title="Fixed Medium Slow VII"
 		showTopBorder={true}
 		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
 	>
 		<FixedMediumSlowVII
 			trails={trails}

--- a/dotcom-rendering/src/components/FixedMediumSlowXIIMPU.stories.tsx
+++ b/dotcom-rendering/src/components/FixedMediumSlowXIIMPU.stories.tsx
@@ -22,6 +22,7 @@ export const OneTrail = () => (
 	<FrontSection
 		title="Fixed Medium Slow XII MPU"
 		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
 	>
 		<FixedMediumSlowXIIMPU
 			trails={trails.slice(0, 1)}
@@ -36,6 +37,7 @@ export const TwoTrails = () => (
 	<FrontSection
 		title="Fixed Medium Slow XII MPU"
 		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
 	>
 		<FixedMediumSlowXIIMPU
 			trails={trails.slice(0, 2)}
@@ -50,6 +52,7 @@ export const ThreeTrails = () => (
 	<FrontSection
 		title="Fixed Medium Slow XII MPU"
 		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
 	>
 		<FixedMediumSlowXIIMPU
 			trails={trails.slice(0, 3)}
@@ -64,6 +67,7 @@ export const FourTrails = () => (
 	<FrontSection
 		title="Fixed Medium Slow XII MPU"
 		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
 	>
 		<FixedMediumSlowXIIMPU
 			trails={trails.slice(0, 4)}
@@ -78,6 +82,7 @@ export const FiveTrails = () => (
 	<FrontSection
 		title="Fixed Medium Slow XII MPU"
 		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
 	>
 		<FixedMediumSlowXIIMPU
 			trails={trails.slice(0, 5)}
@@ -92,6 +97,7 @@ export const SixTrails = () => (
 	<FrontSection
 		title="Fixed Medium Slow XII MPU"
 		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
 	>
 		<FixedMediumSlowXIIMPU
 			trails={trails.slice(0, 6)}
@@ -106,6 +112,7 @@ export const SevenTrails = () => (
 	<FrontSection
 		title="Fixed Medium Slow XII MPU"
 		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
 	>
 		<FixedMediumSlowXIIMPU
 			trails={trails.slice(0, 7)}
@@ -120,6 +127,7 @@ export const EightTrails = () => (
 	<FrontSection
 		title="Fixed Medium Slow XII MPU"
 		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
 	>
 		<FixedMediumSlowXIIMPU
 			trails={trails.slice(0, 8)}
@@ -134,6 +142,7 @@ export const NineTrails = () => (
 	<FrontSection
 		title="Fixed Medium Slow XII MPU"
 		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
 	>
 		<FixedMediumSlowXIIMPU
 			trails={trails.slice(0, 9)}

--- a/dotcom-rendering/src/components/FixedSmallFastVIII.stories.tsx
+++ b/dotcom-rendering/src/components/FixedSmallFastVIII.stories.tsx
@@ -23,6 +23,7 @@ export const Default = () => (
 		title="Fixed Small Fast VIII"
 		showTopBorder={true}
 		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
 	>
 		<FixedSmallFastVIII
 			trails={trails}

--- a/dotcom-rendering/src/components/FixedSmallSlowI.stories.tsx
+++ b/dotcom-rendering/src/components/FixedSmallSlowI.stories.tsx
@@ -22,6 +22,7 @@ export const Default = () => (
 	<FrontSection
 		title="Fixed Small Slow I"
 		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
 	>
 		<FixedSmallSlowI trails={trails} showAge={true} imageLoading="eager" />
 	</FrontSection>

--- a/dotcom-rendering/src/components/FixedSmallSlowIII.stories.tsx
+++ b/dotcom-rendering/src/components/FixedSmallSlowIII.stories.tsx
@@ -22,6 +22,7 @@ export const Default = () => (
 	<FrontSection
 		title="Fixed Small Slow III"
 		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
 	>
 		<FixedSmallSlowIII
 			trails={trails}

--- a/dotcom-rendering/src/components/FixedSmallSlowIV.stories.tsx
+++ b/dotcom-rendering/src/components/FixedSmallSlowIV.stories.tsx
@@ -22,6 +22,7 @@ export const Default = () => (
 	<FrontSection
 		title="Fixed Small Slow IV"
 		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
 	>
 		<FixedSmallSlowIV trails={trails} showAge={true} imageLoading="eager" />
 	</FrontSection>

--- a/dotcom-rendering/src/components/FixedSmallSlowVHalf.stories.tsx
+++ b/dotcom-rendering/src/components/FixedSmallSlowVHalf.stories.tsx
@@ -22,6 +22,7 @@ export const Default = () => (
 	<FrontSection
 		title="Fixed Small Slow V Half"
 		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
 	>
 		<FixedSmallSlowVHalf
 			trails={trails}

--- a/dotcom-rendering/src/components/FixedSmallSlowVMPU.stories.tsx
+++ b/dotcom-rendering/src/components/FixedSmallSlowVMPU.stories.tsx
@@ -22,6 +22,7 @@ export const FourCards = () => (
 	<FrontSection
 		title="Fixed Small Slow V MPU"
 		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
 	>
 		<FixedSmallSlowVMPU
 			trails={trails.slice(0, 4)}
@@ -37,6 +38,7 @@ export const ThreeCards = () => (
 	<FrontSection
 		title="Fixed Small Slow V MPU"
 		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
 	>
 		<FixedSmallSlowVMPU
 			trails={trails.slice(0, 3)}
@@ -52,6 +54,7 @@ export const TwoCards = () => (
 	<FrontSection
 		title="Fixed Small Slow V MPU"
 		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
 	>
 		<FixedSmallSlowVMPU
 			trails={trails.slice(0, 2)}
@@ -67,6 +70,7 @@ export const OneCard = () => (
 	<FrontSection
 		title="Fixed Small Slow V MPU"
 		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
 	>
 		<FixedSmallSlowVMPU
 			trails={trails.slice(0, 1)}

--- a/dotcom-rendering/src/components/FixedSmallSlowVThird.stories.tsx
+++ b/dotcom-rendering/src/components/FixedSmallSlowVThird.stories.tsx
@@ -22,6 +22,7 @@ export const Default = () => (
 	<FrontSection
 		title="Fixed Small Slow V Third"
 		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
 	>
 		<FixedSmallSlowVThird
 			trails={trails}

--- a/dotcom-rendering/src/components/FrontSection.stories.tsx
+++ b/dotcom-rendering/src/components/FrontSection.stories.tsx
@@ -78,6 +78,7 @@ export const ContainerStory = () => {
 			title="Default Container"
 			showTopBorder={false}
 			discussionApiUrl={discussionApiUrl}
+			editionId={'UK'}
 		>
 			<Placeholder />
 		</FrontSection>
@@ -87,7 +88,11 @@ ContainerStory.storyName = 'default container';
 
 export const NoTitleStory = () => {
 	return (
-		<FrontSection showTopBorder={false} discussionApiUrl={discussionApiUrl}>
+		<FrontSection
+			showTopBorder={false}
+			discussionApiUrl={discussionApiUrl}
+			editionId={'UK'}
+		>
 			<Placeholder />
 		</FrontSection>
 	);
@@ -96,7 +101,11 @@ NoTitleStory.storyName = 'with no title';
 
 export const TopBorderStory = () => {
 	return (
-		<FrontSection title="Borders" discussionApiUrl={discussionApiUrl}>
+		<FrontSection
+			title="Borders"
+			discussionApiUrl={discussionApiUrl}
+			editionId={'UK'}
+		>
 			<Placeholder />
 		</FrontSection>
 	);
@@ -111,6 +120,7 @@ export const LeftContentStory = () => {
 				<LeftColPlaceholder text="LeftCol" heightInPixels={100} />
 			}
 			discussionApiUrl={discussionApiUrl}
+			editionId={'UK'}
 		>
 			<Placeholder />
 		</FrontSection>
@@ -126,6 +136,7 @@ export const LeftContentOpinionStory = () => {
 				<LeftColPlaceholder text="LeftCol" heightInPixels={100} />
 			}
 			discussionApiUrl={discussionApiUrl}
+			editionId={'UK'}
 		>
 			<Placeholder />
 		</FrontSection>
@@ -142,6 +153,7 @@ export const ToggleableStory = () => {
 			sectionId="section-id"
 			showTopBorder={false}
 			discussionApiUrl={discussionApiUrl}
+			editionId={'UK'}
 		>
 			<Placeholder />
 		</FrontSection>
@@ -156,24 +168,32 @@ export const MultipleStory = () => {
 				title="Page Title"
 				showTopBorder={false}
 				discussionApiUrl={discussionApiUrl}
+				editionId={'UK'}
 			/>
-			<FrontSection title="Headlines" discussionApiUrl={discussionApiUrl}>
+			<FrontSection
+				title="Headlines"
+				discussionApiUrl={discussionApiUrl}
+				editionId={'UK'}
+			>
 				<Placeholder />
 			</FrontSection>
 			<FrontSection
 				title="Useful links"
 				discussionApiUrl={discussionApiUrl}
+				editionId={'UK'}
 			/>
 			<FrontSection
 				title="Around the World - I'm a link"
 				url="https://www.theguardian.com/world"
 				discussionApiUrl={discussionApiUrl}
+				editionId={'UK'}
 			>
 				<Placeholder />
 			</FrontSection>
 			<FrontSection
 				showTopBorder={false}
 				discussionApiUrl={discussionApiUrl}
+				editionId={'UK'}
 			>
 				<h2>Insert call to action here</h2>
 			</FrontSection>
@@ -181,6 +201,7 @@ export const MultipleStory = () => {
 				title="Videos"
 				showTopBorder={false}
 				discussionApiUrl={discussionApiUrl}
+				editionId={'UK'}
 			>
 				<Placeholder />
 			</FrontSection>
@@ -188,6 +209,7 @@ export const MultipleStory = () => {
 				title="Coronavirus"
 				description="A collection of stories about Coronavirus"
 				discussionApiUrl={discussionApiUrl}
+				editionId={'UK'}
 			>
 				<Placeholder />
 			</FrontSection>
@@ -233,7 +255,7 @@ export const TreatsStory = () => {
 			]}
 			showTopBorder={false}
 			showDateHeader={true}
-			editionId="UK"
+			editionId={'UK'}
 			discussionApiUrl={discussionApiUrl}
 		>
 			<Placeholder />
@@ -260,6 +282,7 @@ export const WithSponsoredBranding = () => {
 		<FrontSection
 			title="Section"
 			discussionApiUrl={discussionApiUrl}
+			editionId={'UK'}
 			collectionBranding={{
 				kind: 'sponsored',
 				isFrontBranding: false,
@@ -287,6 +310,7 @@ export const WithPaidBranding = () => {
 		<FrontSection
 			title="Section"
 			discussionApiUrl={discussionApiUrl}
+			editionId={'UK'}
 			collectionBranding={{
 				kind: 'paid-content',
 				isFrontBranding: false,
@@ -314,6 +338,7 @@ export const WithPaidContentForWholeFront = () => {
 		<FrontSection
 			title="First Section"
 			discussionApiUrl={discussionApiUrl}
+			editionId={'UK'}
 			collectionBranding={{
 				kind: 'paid-content',
 				isFrontBranding: true,
@@ -342,6 +367,7 @@ export const PageSkinStory = () => {
 			title="Page Skin"
 			hasPageSkin={true}
 			discussionApiUrl={discussionApiUrl}
+			editionId={'UK'}
 		>
 			<Placeholder text="Page skins constrain my layout to desktop" />
 		</FrontSection>

--- a/dotcom-rendering/src/components/FrontSection.tsx
+++ b/dotcom-rendering/src/components/FrontSection.tsx
@@ -63,7 +63,7 @@ type Props = {
 	 */
 	showDateHeader?: boolean;
 	/** Used in partnership with `showDateHeader` to localise the date string */
-	editionId?: EditionId;
+	editionId: EditionId;
 	/** A list of related links that appear in the bottom of the left column on fronts */
 	treats?: TreatType[];
 	/** Enable the "Show More" button on this container to allow readers to load more cards */

--- a/dotcom-rendering/src/components/Header.stories.tsx
+++ b/dotcom-rendering/src/components/Header.stories.tsx
@@ -19,7 +19,7 @@ const readerRevenueLinks = {
 export const defaultStory = () => {
 	return (
 		<Header
-			editionId="UK"
+			editionId={'UK'}
 			idUrl="https://profile.theguardian.com"
 			mmaUrl="https://manage.theguardian.com"
 			discussionApiUrl="https://discussion.theguardian.com/discussion-api"

--- a/dotcom-rendering/src/components/HeaderTopBar.stories.tsx
+++ b/dotcom-rendering/src/components/HeaderTopBar.stories.tsx
@@ -8,7 +8,7 @@ export default {
 export const defaultStory = () => {
 	return (
 		<HeaderTopBar
-			editionId="UK"
+			editionId={'UK'}
 			dataLinkName="test"
 			idUrl="idurl"
 			mmaUrl="mmaUrl"

--- a/dotcom-rendering/src/components/HeaderTopBarEditionDropdown.stories.tsx
+++ b/dotcom-rendering/src/components/HeaderTopBarEditionDropdown.stories.tsx
@@ -10,7 +10,7 @@ export default {
 };
 
 export const defaultStory = () => {
-	return <HeaderTopBarEditionDropdown editionId="UK" dataLinkName="test" />;
+	return <HeaderTopBarEditionDropdown editionId={'UK'} dataLinkName="test" />;
 };
 
 defaultStory.storyName = 'default';

--- a/dotcom-rendering/src/components/InlineAd.amp.test.tsx
+++ b/dotcom-rendering/src/components/InlineAd.amp.test.tsx
@@ -50,7 +50,7 @@ describe('RegionalAd', () => {
 			<ContentABTestProvider pageId="" switches={{}}>
 				<InlineAd
 					id="ad-1"
-					editionId="UK"
+					editionId={'UK'}
 					section=""
 					contentType=""
 					config={{
@@ -114,7 +114,7 @@ describe('RegionalAd', () => {
 			<ContentABTestProvider pageId="" switches={{}}>
 				<InlineAd
 					id="ad-1"
-					editionId="UK"
+					editionId={'UK'}
 					section=""
 					contentType=""
 					config={{
@@ -178,7 +178,7 @@ describe('RegionalAd', () => {
 			<ContentABTestProvider pageId="" switches={{}}>
 				<InlineAd
 					id="ad-1"
-					editionId="UK"
+					editionId={'UK'}
 					section=""
 					contentType=""
 					config={{
@@ -242,7 +242,7 @@ describe('RegionalAd', () => {
 			<ContentABTestProvider pageId="" switches={{}}>
 				<InlineAd
 					id="ad-1"
-					editionId="UK"
+					editionId={'UK'}
 					section=""
 					contentType=""
 					config={{
@@ -305,7 +305,7 @@ describe('RegionalAd', () => {
 			<ContentABTestProvider pageId="" switches={{}}>
 				<InlineAd
 					id="ad-1"
-					editionId="UK"
+					editionId={'UK'}
 					section=""
 					contentType=""
 					config={{

--- a/dotcom-rendering/src/components/Island.test.tsx
+++ b/dotcom-rendering/src/components/Island.test.tsx
@@ -176,7 +176,7 @@ describe('Island: server-side rendering', () => {
 	test('InteractiveSupportButton', () => {
 		expect(() =>
 			renderToString(
-				<InteractiveSupportButton editionId="UK" subscribeUrl="" />,
+				<InteractiveSupportButton editionId={'UK'} subscribeUrl="" />,
 			),
 		).not.toThrow();
 	});
@@ -204,7 +204,7 @@ describe('Island: server-side rendering', () => {
 							display: ArticleDisplay.Standard,
 						}}
 						pillar={Pillar.News}
-						editionId="UK"
+						editionId={'UK'}
 						shortUrlId=""
 						discussionApiUrl=""
 					/>

--- a/dotcom-rendering/src/components/KeyEventCard.tsx
+++ b/dotcom-rendering/src/components/KeyEventCard.tsx
@@ -122,7 +122,7 @@ export const KeyEventCard = ({
 					<DateTime
 						date={new Date(blockFirstPublished)}
 						display="relative"
-						editionId="UK"
+						editionId={'UK'}
 						showWeekday={false}
 						showDate={true}
 						showTime={false}

--- a/dotcom-rendering/src/components/LabsSection.stories.tsx
+++ b/dotcom-rendering/src/components/LabsSection.stories.tsx
@@ -61,6 +61,7 @@ export const WithoutBadgeStory = () => {
 			ophanComponentName={''}
 			ophanComponentLink={''}
 			discussionApiUrl={discussionApiUrl}
+			editionId={'UK'}
 		>
 			<Placeholder />
 		</LabsSection>
@@ -84,6 +85,7 @@ export const WithBadgeStory = () => {
 				href: 'https://www.theguardian.com/guardian-labs',
 			}}
 			discussionApiUrl={discussionApiUrl}
+			editionId={'UK'}
 		>
 			<Placeholder />
 		</LabsSection>
@@ -98,6 +100,7 @@ export const InContext = () => {
 				title="Default Container"
 				showTopBorder={false}
 				discussionApiUrl={discussionApiUrl}
+				editionId={'UK'}
 			>
 				<Placeholder />
 			</FrontSection>
@@ -115,6 +118,7 @@ export const InContext = () => {
 					href: 'https://www.theguardian.com/guardian-labs',
 				}}
 				discussionApiUrl={discussionApiUrl}
+				editionId={'UK'}
 			>
 				<Placeholder />
 			</LabsSection>
@@ -122,6 +126,7 @@ export const InContext = () => {
 				title="Default Container"
 				showTopBorder={true}
 				discussionApiUrl={discussionApiUrl}
+				editionId={'UK'}
 			>
 				<Placeholder />
 			</FrontSection>

--- a/dotcom-rendering/src/components/LabsSection.tsx
+++ b/dotcom-rendering/src/components/LabsSection.tsx
@@ -12,6 +12,7 @@ import {
 	SvgArrowRightStraight,
 } from '@guardian/source-react-components';
 import { decideContainerOverrides } from '../lib/decideContainerOverrides';
+import type { EditionId } from '../lib/edition';
 import LabsLogo from '../static/logos/the-guardian-labs.svg';
 import type { DCRBadgeType } from '../types/badge';
 import { Badge } from './Badge';
@@ -62,6 +63,8 @@ type Props = {
 	hasPageSkin?: boolean;
 
 	discussionApiUrl: string;
+
+	editionId: EditionId;
 };
 
 const leftColumnBackground = (backgroundColour?: string) => css`
@@ -378,6 +381,7 @@ export const LabsSection = ({
 	children,
 	hasPageSkin = false,
 	discussionApiUrl,
+	editionId,
 }: Props) => {
 	const overrides = decideContainerOverrides('Branded');
 
@@ -449,6 +453,7 @@ export const LabsSection = ({
 								containerPalette={'Branded'}
 								showAge={true}
 								discussionApiUrl={discussionApiUrl}
+								editionId={editionId}
 							/>
 						</Island>
 					)}

--- a/dotcom-rendering/src/components/LatestLinks.importable.tsx
+++ b/dotcom-rendering/src/components/LatestLinks.importable.tsx
@@ -170,7 +170,7 @@ export const LatestLinks = ({
 												)
 											}
 											display="relative"
-											editionId="UK"
+											editionId={'UK'}
 											showWeekday={false}
 											showDate={true}
 											showTime={false}

--- a/dotcom-rendering/src/components/LiveBlock.stories.tsx
+++ b/dotcom-rendering/src/components/LiveBlock.stories.tsx
@@ -79,7 +79,7 @@ export const VideoAsSecond = () => {
 				abTests={{}}
 				switches={{}}
 				isPinnedPost={false}
-				editionId="UK"
+				editionId={'UK'}
 			/>
 		</Wrapper>
 	);
@@ -126,7 +126,7 @@ export const Title = () => {
 				abTests={{}}
 				switches={{}}
 				isPinnedPost={false}
-				editionId="UK"
+				editionId={'UK'}
 			/>
 		</Wrapper>
 	);
@@ -194,7 +194,7 @@ export const Video = () => {
 				abTests={{}}
 				switches={{}}
 				isPinnedPost={false}
-				editionId="UK"
+				editionId={'UK'}
 			/>
 		</Wrapper>
 	);
@@ -237,7 +237,7 @@ export const RichLink = () => {
 				abTests={{}}
 				switches={{}}
 				isPinnedPost={false}
-				editionId="UK"
+				editionId={'UK'}
 			/>
 		</Wrapper>
 	);
@@ -271,7 +271,7 @@ export const FirstImage = () => {
 				abTests={{}}
 				switches={{}}
 				isPinnedPost={false}
-				editionId="UK"
+				editionId={'UK'}
 			/>
 		</Wrapper>
 	);
@@ -331,7 +331,7 @@ export const ImageRoles = () => {
 				isPinnedPost={false}
 				isAdFreeUser={false}
 				isSensitive={false}
-				editionId="UK"
+				editionId={'UK'}
 			/>
 		</Wrapper>
 	);
@@ -380,7 +380,7 @@ export const Thumbnail = () => {
 				isPinnedPost={false}
 				isAdFreeUser={false}
 				isSensitive={false}
-				editionId="UK"
+				editionId={'UK'}
 			/>
 		</Wrapper>
 	);
@@ -415,7 +415,7 @@ export const ImageAndTitle = () => {
 				abTests={{}}
 				switches={{}}
 				isPinnedPost={false}
-				editionId="UK"
+				editionId={'UK'}
 			/>
 		</Wrapper>
 	);
@@ -446,7 +446,7 @@ export const Updated = () => {
 				abTests={{}}
 				switches={{}}
 				isPinnedPost={false}
-				editionId="UK"
+				editionId={'UK'}
 			/>
 		</Wrapper>
 	);
@@ -481,7 +481,7 @@ export const Contributor = () => {
 				isPinnedPost={false}
 				isAdFreeUser={false}
 				isSensitive={false}
-				editionId="UK"
+				editionId={'UK'}
 			/>
 		</Wrapper>
 	);
@@ -514,7 +514,7 @@ export const NoAvatar = () => {
 				isPinnedPost={false}
 				isAdFreeUser={false}
 				isSensitive={false}
-				editionId="UK"
+				editionId={'UK'}
 			/>
 		</Wrapper>
 	);
@@ -550,7 +550,7 @@ export const TitleAndContributor = () => {
 				isPinnedPost={false}
 				isAdFreeUser={false}
 				isSensitive={false}
-				editionId="UK"
+				editionId={'UK'}
 			/>
 		</Wrapper>
 	);

--- a/dotcom-rendering/src/components/Nav/Nav.stories.tsx
+++ b/dotcom-rendering/src/components/Nav/Nav.stories.tsx
@@ -23,7 +23,7 @@ export const StandardStory = () => {
 				selectedPillar={Pillar.News}
 				nav={nav}
 				subscribeUrl=""
-				editionId="UK"
+				editionId={'UK'}
 			/>
 		</Section>
 	);
@@ -43,7 +43,7 @@ export const StandardStoryTopBarHeader = () => {
 				selectedPillar={Pillar.News}
 				nav={nav}
 				subscribeUrl=""
-				editionId="UK"
+				editionId={'UK'}
 			/>
 		</Section>
 	);
@@ -63,7 +63,7 @@ export const OpinionStory = () => {
 				selectedPillar={Pillar.Opinion}
 				nav={nav}
 				subscribeUrl=""
-				editionId="UK"
+				editionId={'UK'}
 			/>
 		</Section>
 	);
@@ -86,7 +86,7 @@ export const ImmersiveStory = () => {
 				isImmersive={true}
 				nav={nav}
 				subscribeUrl=""
-				editionId="UK"
+				editionId={'UK'}
 			/>
 		</Section>
 	);
@@ -109,7 +109,7 @@ export const ExpandedMenuStory = () => {
 				isImmersive={false}
 				nav={nav}
 				subscribeUrl=""
-				editionId="UK"
+				editionId={'UK'}
 			/>
 		</Section>
 	);
@@ -146,7 +146,7 @@ export const ExpandedMenuWithPageSkinStory = () => {
 				isImmersive={false}
 				nav={nav}
 				subscribeUrl=""
-				editionId="UK"
+				editionId={'UK'}
 				hasPageSkin={true}
 			/>
 		</Section>

--- a/dotcom-rendering/src/components/Nav/Nav.test.tsx
+++ b/dotcom-rendering/src/components/Nav/Nav.test.tsx
@@ -10,7 +10,7 @@ describe('Nav', () => {
 				nav={nav}
 				selectedPillar={Pillar.News}
 				subscribeUrl=""
-				editionId="UK"
+				editionId={'UK'}
 			/>,
 		);
 		const list = within(getByTestId('pillar-list'));
@@ -27,7 +27,7 @@ describe('Nav', () => {
 				selectedPillar={Pillar.News}
 				nav={nav}
 				subscribeUrl=""
-				editionId="UK"
+				editionId={'UK'}
 			/>,
 		);
 

--- a/dotcom-rendering/src/components/NavList.stories.tsx
+++ b/dotcom-rendering/src/components/NavList.stories.tsx
@@ -19,14 +19,22 @@ export default {
 };
 
 export const Default = () => (
-	<FrontSection title="NavList" discussionApiUrl={discussionApiUrl}>
+	<FrontSection
+		title="NavList"
+		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
+	>
 		<NavList trails={trails} showImage={false} />
 	</FrontSection>
 );
 Default.storyName = 'NavList';
 
 export const DefaultWithImages = () => (
-	<FrontSection title="Nav Media List" discussionApiUrl={discussionApiUrl}>
+	<FrontSection
+		title="Nav Media List"
+		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
+	>
 		<NavList trails={trails} showImage={true} />
 	</FrontSection>
 );

--- a/dotcom-rendering/src/components/Palettes.stories.tsx
+++ b/dotcom-rendering/src/components/Palettes.stories.tsx
@@ -198,6 +198,7 @@ export const BrandedPalette = () => (
 		ophanComponentName={'branded-palette'}
 		ophanComponentLink={'branded-palette'}
 		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
 	>
 		<DynamicFast
 			groupedTrails={groupedTrails}
@@ -235,6 +236,7 @@ export const PodcastPalette = () => (
 		ophanComponentName={'podcast-palette'}
 		ophanComponentLink={'podcast-palette'}
 		discussionApiUrl={discussionApiUrl}
+		editionId={'UK'}
 	>
 		<DynamicFast
 			groupedTrails={groupedTrails}

--- a/dotcom-rendering/src/components/PinnedPost.stories.tsx
+++ b/dotcom-rendering/src/components/PinnedPost.stories.tsx
@@ -84,7 +84,7 @@ export const Sport = () => {
 					abTests={{}}
 					switches={{}}
 					isPinnedPost={true}
-					editionId="UK"
+					editionId={'UK'}
 				/>
 			</PinnedPost>
 		</Wrapper>
@@ -131,7 +131,7 @@ export const News = () => {
 					abTests={{}}
 					switches={{}}
 					isPinnedPost={true}
-					editionId="UK"
+					editionId={'UK'}
 				/>
 			</PinnedPost>
 		</Wrapper>
@@ -178,7 +178,7 @@ export const Culture = () => {
 					abTests={{}}
 					switches={{}}
 					isPinnedPost={true}
-					editionId="UK"
+					editionId={'UK'}
 				/>
 			</PinnedPost>
 		</Wrapper>
@@ -225,7 +225,7 @@ export const Lifestyle = () => {
 					abTests={{}}
 					switches={{}}
 					isPinnedPost={true}
-					editionId="UK"
+					editionId={'UK'}
 				/>
 			</PinnedPost>
 		</Wrapper>
@@ -272,7 +272,7 @@ export const Opinion = () => {
 					abTests={{}}
 					switches={{}}
 					isPinnedPost={true}
-					editionId="UK"
+					editionId={'UK'}
 				/>
 			</PinnedPost>
 		</Wrapper>
@@ -319,7 +319,7 @@ export const SpecialReport = () => {
 					abTests={{}}
 					switches={{}}
 					isPinnedPost={true}
-					editionId="UK"
+					editionId={'UK'}
 				/>
 			</PinnedPost>
 		</Wrapper>
@@ -366,7 +366,7 @@ export const Labs = () => {
 					abTests={{}}
 					switches={{}}
 					isPinnedPost={true}
-					editionId="UK"
+					editionId={'UK'}
 				/>
 			</PinnedPost>
 		</Wrapper>

--- a/dotcom-rendering/src/components/PinnedPost.tsx
+++ b/dotcom-rendering/src/components/PinnedPost.tsx
@@ -170,7 +170,7 @@ export const PinnedPost = ({ pinnedPost, children, format }: Props) => {
 						<DateTime
 							date={new Date(pinnedPost.blockFirstPublished)}
 							display="relative"
-							editionId="UK"
+							editionId={'UK'}
 							showWeekday={false}
 							showDate={true}
 							showTime={false}

--- a/dotcom-rendering/src/components/ReaderRevenueLinks.stories.tsx
+++ b/dotcom-rendering/src/components/ReaderRevenueLinks.stories.tsx
@@ -34,7 +34,7 @@ export const Header = () => {
 	return (
 		<Wrapper>
 			<ReaderRevenueLinks
-				editionId="UK"
+				editionId={'UK'}
 				urls={revenueUrls}
 				dataLinkNamePrefix=""
 				inHeader={true}
@@ -56,7 +56,7 @@ export const HeaderMobile = () => {
 	return (
 		<Wrapper>
 			<ReaderRevenueLinks
-				editionId="UK"
+				editionId={'UK'}
 				urls={revenueUrls}
 				dataLinkNamePrefix=""
 				inHeader={true}
@@ -78,7 +78,7 @@ export const Footer = () => {
 	return (
 		<Wrapper>
 			<ReaderRevenueLinks
-				editionId="UK"
+				editionId={'UK'}
 				urls={revenueUrls}
 				dataLinkNamePrefix=""
 				inHeader={false}
@@ -100,7 +100,7 @@ export const FooterMobile = () => {
 	return (
 		<Wrapper>
 			<ReaderRevenueLinks
-				editionId="UK"
+				editionId={'UK'}
 				urls={revenueUrls}
 				dataLinkNamePrefix=""
 				inHeader={false}

--- a/dotcom-rendering/src/components/Section.stories.tsx
+++ b/dotcom-rendering/src/components/Section.stories.tsx
@@ -309,7 +309,7 @@ export const TreatsStory = () => {
 			showTopBorder={false}
 			showSideBorders={false}
 			showDateHeader={true}
-			editionId="UK"
+			editionId={'UK'}
 		>
 			<Grey />
 		</Section>

--- a/dotcom-rendering/src/components/ShowMore.importable.tsx
+++ b/dotcom-rendering/src/components/ShowMore.importable.tsx
@@ -70,7 +70,7 @@ type Props = {
 	sectionId: string;
 	showAge: boolean;
 	ajaxUrl: string;
-	editionId?: EditionId;
+	editionId: EditionId;
 	containerPalette?: DCRContainerPalette;
 	discussionApiUrl: string;
 };

--- a/dotcom-rendering/src/components/ShowMore.stories.tsx
+++ b/dotcom-rendering/src/components/ShowMore.stories.tsx
@@ -18,6 +18,7 @@ const pageId = 'uk/lifestyle';
 const collectionId = '5011-3940-8793-33a9';
 const ajaxUrl = 'https://api.nextgen.guardianapps.co.uk';
 const sectionId = 'container-id';
+const editionId = 'UK';
 
 const defaultProps = {
 	title,
@@ -27,6 +28,7 @@ const defaultProps = {
 	sectionId,
 	showAge: false,
 	discussionApiUrl,
+	editionId,
 } satisfies Parameters<typeof ShowMore>[0];
 
 export default {

--- a/dotcom-rendering/src/components/WitnessBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/components/WitnessBlockComponent.stories.tsx
@@ -35,7 +35,7 @@ export const WitnessTextBlockComponentDefault = () => (
 			description='You could dial first and then push in ur 2p. I never had any change and needed a lift. My parents knew the routine, I&#39;d dial and you could get a second or two to shout down the line "Pick me up" Ah how I miss the days of a simple life where no one knew where I was and I could get away with anything as long as I was in the door by 10pm! '
 			authorName="Louise Griffiths"
 			dateCreated="2016-01-29T22:19:51Z"
-			editionId="UK"
+			editionId={'UK'}
 		/>
 	</div>
 );
@@ -122,7 +122,7 @@ export const WitnessImageBlockComponentDefault = () => (
 			authorName="Nick Ellis"
 			dateCreated="2015-08-25T12:20:58Z"
 			alt="Risk - Home Made Space expansion"
-			editionId="UK"
+			editionId={'UK'}
 		/>
 	</div>
 );
@@ -141,7 +141,7 @@ export const WitnessVideoBlockComponentDefault = () => (
 			authorName="Gregg Lewis-Qualls"
 			youtubeHtml='<iframe width="440" height="330" src="https://www.youtube.com/embed/N9Cgy-ke5-s?origin=https://www.theguardian.com&widgetid=1&modestbranding=1" frameborder="0" allowfullscreen></iframe>'
 			dateCreated="2015-08-27T13:32:32Z"
-			editionId="UK"
+			editionId={'UK'}
 		/>
 	</div>
 );

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -470,6 +470,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 									discussionApiUrl={
 										front.config.discussionApiUrl
 									}
+									editionId={'UK'}
 								>
 									<DecideContainer
 										trails={trailsWithoutBranding}

--- a/dotcom-rendering/src/model/enhanceCards.ts
+++ b/dotcom-rendering/src/model/enhanceCards.ts
@@ -291,7 +291,7 @@ export const enhanceCards = (
 	}: {
 		cardInTagPage: boolean;
 		offset?: number;
-		editionId?: EditionId;
+		editionId: EditionId;
 		containerPalette?: DCRContainerPalette;
 		pageId?: string;
 		discussionApiUrl: string;

--- a/dotcom-rendering/src/server/handler.front.web.ts
+++ b/dotcom-rendering/src/server/handler.front.web.ts
@@ -67,6 +67,7 @@ const enhanceTagPage = (body: unknown): DCRTagPageType => {
 		cardInTagPage: true,
 		pageId: data.pageId,
 		discussionApiUrl: data.config.discussionApiUrl,
+		editionId: data.editionId,
 	});
 	const speed = getSpeedFromTrails(data.contents);
 


### PR DESCRIPTION
## What does this change?
Currently the cards on a Labs tag front when rendered on DCR are not showing a `Badge` logo. 


- Currently the logic for displaying the badge is a result of `branding`.
- The `branding` will return undefined if `editionId` is undefined`.


Changes:
- Changed `editionId` so its required in props
- Updated related Components and  tests to provide an editionId in the props being passed

## Why?
This PR aims to get the Badge showing when the front is rendered via DCR.
## Screenshots

### Before
https://www.theguardian.com/tone/advertisement-features?dcr=false

| dcr=false (Frontend) | dcr=true (dotcom) |
| ------| ------|
| <img width="400" alt="Screenshot 2024-04-24 at 14 30 24" src="https://github.com/guardian/dotcom-rendering/assets/49187886/026acc37-d0b3-44f3-bbe7-0d426e159d6c"> | <img width="400" alt="Screenshot 2024-04-24 at 14 33 22" src="https://github.com/guardian/dotcom-rendering/assets/49187886/d7c19699-175e-4154-b717-affff75729ab"> |


### After
| dcr=false |
| ------| 
| <img width="450" alt="Screenshot 2024-04-24 at 14 40 31" src="https://github.com/guardian/dotcom-rendering/assets/49187886/df725a61-fcde-414c-b606-e298a94de7de"> | 

<!--


You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->


<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
