### PR TITLE
Pass isMainMedia prop from timeline to article element

### DIFF
--- a/dotcom-rendering/src/components/Figure.tsx
+++ b/dotcom-rendering/src/components/Figure.tsx
@@ -86,12 +86,6 @@ const roleCss = {
 		}
 	`,
 
-	showcaseTimeline: css`
-		${immersiveStyles}
-		margin-top: 0;
-		margin-bottom: 0;
-	`,
-
 	thumbnail: css`
 		margin-top: ${space[2]}px;
 		margin-bottom: ${space[2]}px;
@@ -172,7 +166,18 @@ export const defaultRoleStyles = (
 			return roleCss.immersive;
 		case 'showcase':
 			if (isTimeline) {
-				return roleCss.showcaseTimeline;
+				return css`
+					margin: 0 -10px;
+					${from.tablet} {
+						position: relative;
+					}
+					${from.leftCol} {
+						margin-left: -160px;
+					}
+					${from.wide} {
+						margin-left: -240px;
+					}
+				`;
 			}
 			return roleCss.showcase;
 		case 'thumbnail':

--- a/dotcom-rendering/src/components/Figure.tsx
+++ b/dotcom-rendering/src/components/Figure.tsx
@@ -86,6 +86,12 @@ const roleCss = {
 		}
 	`,
 
+	showcaseTimeline: css`
+		${immersiveStyles}
+		margin-top: 0;
+		margin-bottom: 0;
+	`,
+
 	thumbnail: css`
 		margin-top: ${space[2]}px;
 		margin-bottom: ${space[2]}px;
@@ -166,18 +172,7 @@ export const defaultRoleStyles = (
 			return roleCss.immersive;
 		case 'showcase':
 			if (isTimeline) {
-				return css`
-					margin: 0 -10px;
-					${from.tablet} {
-						position: relative;
-					}
-					${from.leftCol} {
-						margin-left: -160px;
-					}
-					${from.wide} {
-						margin-left: -240px;
-					}
-				`;
+				return roleCss.showcaseTimeline;
 			}
 			return roleCss.showcase;
 		case 'thumbnail':

--- a/dotcom-rendering/src/components/Figure.tsx
+++ b/dotcom-rendering/src/components/Figure.tsx
@@ -213,7 +213,7 @@ export const Figure = ({
 	type,
 	isTimeline = false,
 }: Props) => {
-	if (isMainMedia) {
+	if (isMainMedia && !isTimeline) {
 		// Don't add in-body styles for main media elements
 		// TODO: If we want to support other element types having role position, such
 		// as showcase twitter embeds, then we should remove the role positioning which

--- a/dotcom-rendering/src/components/ImageComponent.tsx
+++ b/dotcom-rendering/src/components/ImageComponent.tsx
@@ -46,10 +46,6 @@ const timelineBulletStyles = css`
 		top: -6px;
 		left: -6.5px;
 
-		${from.mobileLandscape} {
-			left: 3.5px;
-		}
-
 		${from.leftCol} {
 			left: 143.5px;
 		}

--- a/dotcom-rendering/src/components/ImageComponent.tsx
+++ b/dotcom-rendering/src/components/ImageComponent.tsx
@@ -276,7 +276,7 @@ export const ImageComponent = ({
 	}
 
 	const shouldLimitWidth =
-		!isMainMedia &&
+		(!isMainMedia || isTimeline) &&
 		(role === 'showcase' || role === 'supporting' || role === 'immersive');
 	const isNotOpinion =
 		format.design !== ArticleDesign.Comment &&

--- a/dotcom-rendering/src/components/Timeline.stories.tsx
+++ b/dotcom-rendering/src/components/Timeline.stories.tsx
@@ -84,7 +84,6 @@ const ArticleElementComponent = getNestedArticleElement({
 	isSensitive: false,
 	pageId: 'testID',
 	switches: {},
-	isMainMedia: false,
 	webTitle: 'Storybook page',
 });
 

--- a/dotcom-rendering/src/components/Timeline.tsx
+++ b/dotcom-rendering/src/components/Timeline.tsx
@@ -112,6 +112,7 @@ const EventHeader = ({
 					element={event.main}
 					format={format}
 					isTimeline={true}
+					isMainMedia={true}
 				/>
 				{heading}
 			</header>
@@ -125,6 +126,7 @@ const EventHeader = ({
 					element={event.main}
 					format={format}
 					isTimeline={true}
+					isMainMedia={true}
 				/>
 			</header>
 		);
@@ -215,6 +217,7 @@ const TimelineEvent = ({
 					forceDropCap="off"
 					format={format}
 					isTimeline={true}
+					isMainMedia={false}
 				/>
 			))}
 		</section>

--- a/dotcom-rendering/src/lib/renderElement.tsx
+++ b/dotcom-rendering/src/lib/renderElement.tsx
@@ -939,8 +939,9 @@ type ElementLevelPropNames =
 	| 'format'
 	| 'isTimeline'
 	| 'isListElement';
+type CommonPropNames = 'isMainMedia';
 type ArticleLevelProps = Omit<Props, ElementLevelPropNames>;
-type ElementLevelProps = Pick<Props, ElementLevelPropNames>;
+type ElementLevelProps = Pick<Props, ElementLevelPropNames | CommonPropNames>;
 
 export const getNestedArticleElement =
 	(articleProps: ArticleLevelProps) => (elementProps: ElementLevelProps) => (

--- a/dotcom-rendering/src/lib/renderElement.tsx
+++ b/dotcom-rendering/src/lib/renderElement.tsx
@@ -672,7 +672,6 @@ export const renderElement = ({
 						ajaxUrl,
 						editionId,
 						isAdFreeUser,
-						isMainMedia,
 						isSensitive,
 						pageId,
 						switches,
@@ -938,10 +937,10 @@ type ElementLevelPropNames =
 	| 'hideCaption'
 	| 'format'
 	| 'isTimeline'
-	| 'isListElement';
-type CommonPropNames = 'isMainMedia';
+	| 'isListElement'
+	| 'isMainMedia';
 type ArticleLevelProps = Omit<Props, ElementLevelPropNames>;
-type ElementLevelProps = Pick<Props, ElementLevelPropNames | CommonPropNames>;
+type ElementLevelProps = Pick<Props, ElementLevelPropNames>;
 
 export const getNestedArticleElement =
 	(articleProps: ArticleLevelProps) => (elementProps: ElementLevelProps) => (


### PR DESCRIPTION
## What does this change?

Fixes #11252

Pass isMainMedia prop from timeline to article element

## Why?

Timeline images need to know if they are the main image so that they can render the bullet points correctly

<!--
## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
