### PR TITLE
Fix links on Guardian Labs logos not directing users to US and AUS Labs when viewed from those editions

### DIFF
--- a/dotcom-rendering/src/components/LabsHeader.stories.tsx
+++ b/dotcom-rendering/src/components/LabsHeader.stories.tsx
@@ -15,7 +15,7 @@ export const Default = () => {
 			backgroundColour={palette.labs[400]}
 			borderColour={palette.neutral[60]}
 		>
-			<LabsHeader />
+			<LabsHeader editionId="UK" />
 		</Section>
 	);
 };

--- a/dotcom-rendering/src/components/LabsHeader.tsx
+++ b/dotcom-rendering/src/components/LabsHeader.tsx
@@ -11,6 +11,8 @@ import {
 	LinkButton,
 	SvgArrowRightStraight,
 } from '@guardian/source-react-components';
+import type { EditionId } from '../lib/edition';
+import { getLabsUrlSuffix } from '../lib/labs';
 import { LABS_HEADER_HEIGHT } from '../lib/labs-constants';
 import LabsLogo from '../static/logos/the-guardian-labs.svg';
 import { Details } from './Details';
@@ -129,13 +131,17 @@ const About = () => (
 	</div>
 );
 
-const Logo = () => (
-	<Link href="https://www.theguardian.com/guardian-labs">
+const Logo = ({ editionId }: { editionId: EditionId }) => (
+	<Link
+		href={`https://www.theguardian.com/guardian-labs${getLabsUrlSuffix(
+			editionId,
+		)}`}
+	>
 		<LabsLogo />
 	</Link>
 );
 
-export const LabsHeader = () => (
+export const LabsHeader = ({ editionId }: { editionId: EditionId }) => (
 	<FlexWrapper>
 		<Left>
 			<HeaderSection isFirst={true}>
@@ -163,7 +169,7 @@ export const LabsHeader = () => (
 			</HeaderSection>
 		</Left>
 		<Right>
-			<Logo />
+			<Logo editionId={editionId} />
 		</Right>
 	</FlexWrapper>
 );

--- a/dotcom-rendering/src/components/LabsSection.tsx
+++ b/dotcom-rendering/src/components/LabsSection.tsx
@@ -67,6 +67,7 @@ type Props = {
 
 	discussionApiUrl: string;
 
+	/** We use a different link on the logo for US and AUS labs */
 	editionId: EditionId;
 };
 
@@ -195,6 +196,17 @@ const paidForByStyles = (textColour?: string) => css`
 	margin-top: ${space[3]}px;
 	margin-bottom: ${space[1]}px;
 `;
+
+const getLabsUrlSuffix = (editionId: EditionId) => {
+	switch (editionId) {
+		case 'AU':
+			return '-australia';
+		case 'US':
+			return '-us';
+		default:
+			return '';
+	}
+};
 
 const GuardianLabsTitle = ({
 	title,
@@ -429,7 +441,9 @@ export const LabsSection = ({
 					</div>
 
 					<Link
-						href="https://www.theguardian.com/guardian-labs"
+						href={`https://www.theguardian.com/guardian-labs${getLabsUrlSuffix(
+							editionId,
+						)}`}
 						cssOverrides={css`
 							text-align: right;
 						`}

--- a/dotcom-rendering/src/components/LabsSection.tsx
+++ b/dotcom-rendering/src/components/LabsSection.tsx
@@ -16,6 +16,7 @@ import {
 } from '@guardian/source-react-components';
 import { decideContainerOverrides } from '../lib/decideContainerOverrides';
 import type { EditionId } from '../lib/edition';
+import { getLabsUrlSuffix } from '../lib/labs';
 import LabsLogo from '../static/logos/the-guardian-labs.svg';
 import type { DCRBadgeType } from '../types/badge';
 import { Badge } from './Badge';
@@ -196,17 +197,6 @@ const paidForByStyles = (textColour?: string) => css`
 	margin-top: ${space[3]}px;
 	margin-bottom: ${space[1]}px;
 `;
-
-const getLabsUrlSuffix = (editionId: EditionId) => {
-	switch (editionId) {
-		case 'AU':
-			return '-australia';
-		case 'US':
-			return '-us';
-		default:
-			return '';
-	}
-};
 
 const GuardianLabsTitle = ({
 	title,

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -287,7 +287,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 							borderColour={sourcePalette.neutral[60]}
 							sectionId="labs-header"
 						>
-							<LabsHeader />
+							<LabsHeader editionId={editionId} />
 						</Section>
 					)}
 				</>

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -122,6 +122,7 @@ const decideLeftContent = (
 export const FrontLayout = ({ front, NAV }: Props) => {
 	const {
 		config: { isPaidContent, hasPageSkin: hasPageSkinConfig, pageId },
+		editionId,
 	} = front;
 
 	const renderAds = canRenderAds(front);
@@ -473,7 +474,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 									discussionApiUrl={
 										front.config.discussionApiUrl
 									}
-									editionId={'UK'}
+									editionId={editionId}
 								>
 									<DecideContainer
 										trails={trailsWithoutBranding}

--- a/dotcom-rendering/src/layouts/FullPageInteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/FullPageInteractiveLayout.tsx
@@ -286,6 +286,7 @@ const NavHeader = ({ article, NAV, format }: Props) => {
 export const FullPageInteractiveLayout = ({ article, NAV, format }: Props) => {
 	const {
 		config: { host },
+		editionId,
 	} = article;
 
 	return (
@@ -310,7 +311,7 @@ export const FullPageInteractiveLayout = ({ article, NAV, format }: Props) => {
 							borderColour={sourcePalette.neutral[60]}
 							sectionId="labs-header"
 						>
-							<LabsHeader />
+							<LabsHeader editionId={editionId} />
 						</Section>
 					</Stuck>
 				)}

--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -235,6 +235,7 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 
 	const {
 		config: { isPaidContent, host },
+		editionId,
 	} = article;
 	const isWeb = renderingTarget === 'Web';
 	const isApps = renderingTarget === 'Apps';
@@ -356,7 +357,7 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 								borderColour={sourcePalette.neutral[60]}
 								sectionId="labs-header"
 							>
-								<LabsHeader />
+								<LabsHeader editionId={editionId} />
 							</Section>
 						</Stuck>
 					)}

--- a/dotcom-rendering/src/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/InteractiveLayout.tsx
@@ -220,6 +220,7 @@ export const InteractiveLayout = (props: WebProps | AppsProps) => {
 	const { article, format, renderingTarget } = props;
 	const {
 		config: { isPaidContent, host },
+		editionId,
 	} = article;
 
 	const isApps = renderingTarget === 'Apps';
@@ -394,7 +395,7 @@ export const InteractiveLayout = (props: WebProps | AppsProps) => {
 								borderColour={sourcePalette.neutral[60]}
 								sectionId="labs-header"
 							>
-								<LabsHeader />
+								<LabsHeader editionId={editionId} />
 							</Section>
 						</Stuck>
 					)}

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -222,6 +222,7 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 	const { article, format, renderingTarget } = props;
 	const {
 		config: { isPaidContent, host },
+		editionId,
 	} = article;
 	const isWeb = renderingTarget === 'Web';
 	const isApps = renderingTarget === 'Apps';
@@ -472,7 +473,7 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 									borderColour={sourcePalette.neutral[60]}
 									sectionId="labs-header"
 								>
-									<LabsHeader />
+									<LabsHeader editionId={editionId} />
 								</Section>
 							</Stuck>
 						</>

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -370,6 +370,7 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 	const { article, format, renderingTarget } = props;
 	const {
 		config: { isPaidContent, host },
+		editionId,
 	} = article;
 
 	const isWeb = renderingTarget === 'Web';
@@ -551,7 +552,7 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 						sectionId="labs-header"
 						element="aside"
 					>
-						<LabsHeader />
+						<LabsHeader editionId={editionId} />
 					</Section>
 				</Stuck>
 			)}

--- a/dotcom-rendering/src/lib/labs.ts
+++ b/dotcom-rendering/src/lib/labs.ts
@@ -1,4 +1,5 @@
 import type { Branding } from '../types/branding';
+import type { EditionId } from './edition';
 
 export const getOphanComponents = ({
 	branding,
@@ -18,4 +19,15 @@ export const getOphanComponents = ({
 		ophanComponentName: `labs-logo | ${componentName}`,
 		ophanComponentLink: `labs-logo-${componentName}`,
 	};
+};
+
+export const getLabsUrlSuffix = (editionId: EditionId): string => {
+	switch (editionId) {
+		case 'AU':
+			return '-australia';
+		case 'US':
+			return '-us';
+		default:
+			return '';
+	}
 };


### PR DESCRIPTION
## What does this change?

This updates the LabsHeader and LabsSection components to accept an `editionId` prop in order to localise the link to direct users to the specific Guardian US and Guardian Australia Labs when viewing pages from those editions.

## Why?

This is the intended behaviour- see https://github.com/guardian/frontend/blob/030d175ee6923b88717cde7f536f82228a8d87ca/common/app/views/support/Commercial.scala#L54-L58 - but the links were hard-coded to direct to UK Labs when the pages were migrated to DCR.