### PR TITLE
Show newsletter embeds after nested list elements

### DIFF
--- a/dotcom-rendering/src/model/insertPromotedNewsletter.test.ts
+++ b/dotcom-rendering/src/model/insertPromotedNewsletter.test.ts
@@ -3,8 +3,10 @@ import { Quiz as exampleQuiz } from '../../fixtures/generated/fe-articles/Quiz';
 import { Standard as exampleStandard } from '../../fixtures/generated/fe-articles/Standard';
 import { decideFormat } from '../lib/decideFormat';
 import type {
+	KeyTakeawaysBlockElement,
 	Newsletter,
 	NewsletterSignupBlockElement,
+	TextBlockElement,
 } from '../types/content';
 import { insertPromotedNewsletter } from './insertPromotedNewsletter';
 
@@ -18,6 +20,27 @@ const NEWSLETTER: Newsletter = {
 	successDescription: 'You have signed up, but the newsletter is fake',
 	theme: 'opinion',
 	group: 'Opinion',
+};
+
+const testTextElement: TextBlockElement = {
+	_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+	elementId: 'test-text-element-id-1',
+	dropCap: 'on',
+	html: '<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesquepharetra libero nec varius feugiat. Nulla commodo sagittis erat amalesuada. Ut iaculis interdum eros, et tristique ex. In veldignissim arcu. Nulla nisi urna, laoreet a aliquam at, viverra eueros. Proin imperdiet pellentesque turpis sed luctus. Donecdignissim lacus in risus fermentum maximus eu vel justo. Duis nontortor ac elit dapibus imperdiet ut at risus. Etiam pretium, odioeget accumsan venenatis, tortor mi aliquet nisl, vel ullamcorperneque nulla vel elit. Etiam porta mauris nec sagittis luctus.</p>',
+};
+
+const LIST_ELEMENT: KeyTakeawaysBlockElement = {
+	_type: 'model.dotcomrendering.pageElements.KeyTakeawaysBlockElement',
+	keyTakeaways: [
+		{
+			title: 'The first key takeaway',
+			body: [testTextElement],
+		},
+		{
+			title: 'The second key takeaway',
+			body: [testTextElement],
+		},
+	],
 };
 
 describe('Insert Newsletter Signups', () => {
@@ -70,5 +93,29 @@ describe('Insert Newsletter Signups', () => {
 					'model.dotcomrendering.pageElements.NewsletterSignupBlockElement',
 			),
 		).toBeFalsy();
+	});
+
+	it('will not insert a NewsletterSignupBlockElement before a nested list element', () => {
+		const elements = exampleStandard.blocks[0]?.elements ?? [];
+
+		elements[4] = LIST_ELEMENT;
+
+		const elementsWithNewsletter = insertPromotedNewsletter(
+			elements,
+			exampleStandard.blocks[0]?.id ?? 'mock id',
+			decideFormat(exampleStandard.format),
+			NEWSLETTER,
+		);
+		const insertedBlock = elementsWithNewsletter.find(
+			(element) =>
+				element._type ===
+				'model.dotcomrendering.pageElements.NewsletterSignupBlockElement',
+		);
+
+		const indexOfNewsletter = elementsWithNewsletter.indexOf(
+			insertedBlock as NewsletterSignupBlockElement,
+		);
+
+		expect(indexOfNewsletter).toBeGreaterThan(4);
 	});
 });

--- a/dotcom-rendering/src/model/insertPromotedNewsletter.ts
+++ b/dotcom-rendering/src/model/insertPromotedNewsletter.ts
@@ -1,4 +1,5 @@
-import { ArticleDesign, isOneOf, type ArticleFormat } from '@guardian/libs';
+import type { ArticleFormat } from '@guardian/libs';
+import { ArticleDesign, isOneOf } from '@guardian/libs';
 import { logger } from '../server/lib/logging';
 import type { FEElement, Newsletter } from '../types/content';
 
@@ -224,6 +225,7 @@ export const insertPromotedNewsletter = (
 	format: ArticleFormat,
 	promotedNewsletter: Newsletter,
 ): FEElement[] => {
+	console.log('elements', elements);
 	switch (format.design) {
 		case ArticleDesign.Standard:
 		case ArticleDesign.Gallery:

--- a/dotcom-rendering/src/model/insertPromotedNewsletter.ts
+++ b/dotcom-rendering/src/model/insertPromotedNewsletter.ts
@@ -90,18 +90,23 @@ const checkIfAfterText = (index: number, elements: FEElement[]): boolean =>
 	'model.dotcomrendering.pageElements.TextBlockElement';
 
 const checkIfAfterNestedListElement = (
-	index: number,
+	currentIndex: number,
 	elements: FEElement[],
 ): boolean => {
-	switch (elements[index - 1]?._type) {
-		case 'model.dotcomrendering.pageElements.KeyTakeawaysBlockElement':
-		case 'model.dotcomrendering.pageElements.QAndAExplainerBlockElement':
-		case 'model.dotcomrendering.pageElements.DCRSectionedTimelineBlockElement':
-		case 'model.dotcomrendering.pageElements.DCRTimelineBlockElement':
-			return true;
-		default:
-			return false;
+	const nestedListElementTypes = new Set([
+		'model.dotcomrendering.pageElements.KeyTakeawaysBlockElement',
+		'model.dotcomrendering.pageElements.QAndAExplainerBlockElement',
+		'model.dotcomrendering.pageElements.DCRSectionedTimelineBlockElement',
+		'model.dotcomrendering.pageElements.DCRTimelineBlockElement',
+	]);
+
+	for (const [index, element] of elements.entries()) {
+		if (nestedListElementTypes.has(element?._type)) {
+			return currentIndex > index;
+		}
 	}
+
+	return true; // No nested list elements found before the current index, so we consider it after
 };
 
 const getDistanceAfterFloating = (
@@ -138,7 +143,8 @@ const getDistanceAfterFloating = (
 };
 
 const placeIsSuitable = (place: PlaceInArticle): boolean =>
-	(place.isAfterText || place.isAfterListElement) &&
+	place.isAfterText &&
+	place.isAfterListElement &&
 	place.distanceAfterFloating >= MINIMUM_DISTANCE_AFTER_FLOATING_ELEMENT &&
 	place.distanceFromTarget <= MAXIMUM_DISTANCE_FROM_MIDDLE;
 

--- a/dotcom-rendering/src/model/insertPromotedNewsletter.ts
+++ b/dotcom-rendering/src/model/insertPromotedNewsletter.ts
@@ -100,12 +100,10 @@ const listElements = [
 const isListElement = isOneOf(listElements);
 
 const checkIfAfterNestedListElement = (
-	currentIndex: number,
+	index: number,
 	elements: FEElement[],
 ): boolean => {
-	return !elements
-		.slice(currentIndex)
-		.some(({ _type }) => isListElement(_type));
+	return !elements.slice(index).some(({ _type }) => isListElement(_type));
 };
 
 const getDistanceAfterFloating = (
@@ -225,7 +223,6 @@ export const insertPromotedNewsletter = (
 	format: ArticleFormat,
 	promotedNewsletter: Newsletter,
 ): FEElement[] => {
-	console.log('elements', elements);
 	switch (format.design) {
 		case ArticleDesign.Standard:
 		case ArticleDesign.Gallery:

--- a/dotcom-rendering/src/model/insertPromotedNewsletter.ts
+++ b/dotcom-rendering/src/model/insertPromotedNewsletter.ts
@@ -1,4 +1,4 @@
-import { ArticleDesign, type ArticleFormat } from '@guardian/libs';
+import { ArticleDesign, isOneOf, type ArticleFormat } from '@guardian/libs';
 import { logger } from '../server/lib/logging';
 import type { FEElement, Newsletter } from '../types/content';
 
@@ -89,24 +89,22 @@ const checkIfAfterText = (index: number, elements: FEElement[]): boolean =>
 	elements[index - 1]?._type ===
 	'model.dotcomrendering.pageElements.TextBlockElement';
 
+const listElements = [
+	'model.dotcomrendering.pageElements.KeyTakeawaysBlockElement',
+	'model.dotcomrendering.pageElements.QAndAExplainerBlockElement',
+	'model.dotcomrendering.pageElements.DCRSectionedTimelineBlockElement',
+	'model.dotcomrendering.pageElements.DCRTimelineBlockElement',
+] as const;
+
+const isListElement = isOneOf(listElements);
+
 const checkIfAfterNestedListElement = (
 	currentIndex: number,
 	elements: FEElement[],
 ): boolean => {
-	const nestedListElementTypes = new Set([
-		'model.dotcomrendering.pageElements.KeyTakeawaysBlockElement',
-		'model.dotcomrendering.pageElements.QAndAExplainerBlockElement',
-		'model.dotcomrendering.pageElements.DCRSectionedTimelineBlockElement',
-		'model.dotcomrendering.pageElements.DCRTimelineBlockElement',
-	]);
-
-	for (const [index, element] of elements.entries()) {
-		if (nestedListElementTypes.has(element?._type)) {
-			return currentIndex > index;
-		}
-	}
-
-	return true; // No nested list elements found before the current index, so we consider it after
+	return !elements
+		.slice(currentIndex)
+		.some(({ _type }) => isListElement(_type));
 };
 
 const getDistanceAfterFloating = (

--- a/dotcom-rendering/src/types/content.ts
+++ b/dotcom-rendering/src/types/content.ts
@@ -319,7 +319,7 @@ export interface QAndAExplainer {
 	body: FEElement[];
 }
 
-interface KeyTakeawaysBlockElement {
+export interface KeyTakeawaysBlockElement {
 	_type: 'model.dotcomrendering.pageElements.KeyTakeawaysBlockElement';
 	keyTakeaways: KeyTakeaway[];
 }


### PR DESCRIPTION
## What does this change?
Forces newsletter embeds to appear after a nested list element, if a nested list element exists. 

## Why?
This prevents newsletter embeds from taking up too much room above the fold and has been requested by Max Walker.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/20416599/8d33ef16-7b4a-44b9-b947-b2e987872b07
[after]: https://github.com/guardian/dotcom-rendering/assets/20416599/5dee2b60-bfdc-4b05-928c-459211772ef0

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
