### PR TITLE
Speed up Chromatic CI

### DIFF
--- a/.github/workflows/dcr-chromatic.yml
+++ b/.github/workflows/dcr-chromatic.yml
@@ -48,6 +48,7 @@ jobs:
           untraced: '**/(package*.json|pnpm-lock.yaml|preview.js)'
           workingDir: dotcom-rendering
           buildScriptName: 'build-storybook'
+          exitOnceUploaded: true
 
   remove-label:
     if: github.ref != 'refs/heads/main'


### PR DESCRIPTION
## What does this change?

Exit Chromatic action once uploaded, as recommended

## Why?

Fixes #6089

[AR does this already](https://github.com/guardian/dotcom-rendering/blob/e32d8389097a5c8305e7871b86a6791db20ce958/.github/workflows/ar-chromatic.yml#L48)!