### PR TITLE
Hide "Skip to navigation" link on apps article pages

### DIFF
--- a/dotcom-rendering/src/components/ArticlePage.tsx
+++ b/dotcom-rendering/src/components/ArticlePage.tsx
@@ -107,8 +107,12 @@ export const ArticlePage = (props: WebProps | AppProps) => {
 					renderingTarget,
 				)}
 			/>
-			<SkipTo id="maincontent" label="Skip to main content" />
-			{isWeb && <SkipTo id="navigation" label="Skip to navigation" />}
+			{isWeb && (
+				<>
+					<SkipTo id="maincontent" label="Skip to main content" />
+					<SkipTo id="navigation" label="Skip to navigation" />
+				</>
+			)}
 			{webLightbox && article.imagesForLightbox.length > 0 && (
 				<>
 					<Island priority="feature" defer={{ until: 'hash' }}>

--- a/dotcom-rendering/src/components/ArticlePage.tsx
+++ b/dotcom-rendering/src/components/ArticlePage.tsx
@@ -95,8 +95,8 @@ export const ArticlePage = (props: WebProps | AppProps) => {
 		adUnit: article.config.adUnit,
 	});
 
-	const webLightbox =
-		renderingTarget === 'Web' && !!article.config.switches.lightbox;
+	const isWeb = renderingTarget === 'Web';
+	const webLightbox = isWeb && !!article.config.switches.lightbox;
 
 	return (
 		<StrictMode>
@@ -108,7 +108,7 @@ export const ArticlePage = (props: WebProps | AppProps) => {
 				)}
 			/>
 			<SkipTo id="maincontent" label="Skip to main content" />
-			<SkipTo id="navigation" label="Skip to navigation" />
+			{isWeb && <SkipTo id="navigation" label="Skip to navigation" />}
 			{webLightbox && article.imagesForLightbox.length > 0 && (
 				<>
 					<Island priority="feature" defer={{ until: 'hash' }}>


### PR DESCRIPTION
Apps articles have slightly different accessibility patterns to web, so we shouldn't include these helpers in the apps article markup.

thx @ddramowicz for spotting!