### PR TITLE
Add 'The stakes' US election newsletter

### DIFF
--- a/dotcom-rendering/src/model/newsletter-grouping.ts
+++ b/dotcom-rendering/src/model/newsletter-grouping.ts
@@ -12,10 +12,10 @@ export const groups: Partial<Record<EditionId, StaticGroups>> = {
 			title: 'Get started',
 			newsletters: [
 				'morning-briefing', // First Edition
+				'the-stakes-us-election-edition',
 				'swift-notes',
 				'saturday-edition',
 				'word-of-mouth', // Feast
-				'well-actually',
 				'the-guide-staying-in',
 				'the-long-read',
 				'reclaim-your-brain',
@@ -29,6 +29,7 @@ export const groups: Partial<Record<EditionId, StaticGroups>> = {
 				'tech-scape',
 				'fashion-statement',
 				'pushing-buttons',
+				'well-actually',
 				'cotton-capital',
 			],
 		},
@@ -110,9 +111,10 @@ export const groups: Partial<Record<EditionId, StaticGroups>> = {
 		{
 			title: 'Get started',
 			newsletters: [
+				'the-stakes-us-election-edition',
 				'us-morning-newsletter', // First Thing
-				'well-actually',
 				'trump-on-trial',
+				'well-actually',
 				'reclaim-your-brain',
 				'today-us', // Headlines US
 				'soccer-with-jonathan-wilson',
@@ -217,19 +219,20 @@ export const groups: Partial<Record<EditionId, StaticGroups>> = {
 		{
 			title: 'In depth',
 			newsletters: [
+				'the-stakes-us-election-edition',
 				'the-rural-network',
 				'green-light', // Down to Earth
 				'tech-scape',
 				'pushing-buttons',
 				'fashion-statement',
 				'word-of-mouth', // Feast
-				'the-guide-staying-in',
 			],
 		},
 		{
 			title: 'Culture picks',
 			newsletters: [
 				'saved-for-later',
+				'the-guide-staying-in',
 				'hear-here',
 				'sleeve-notes',
 				'film-today',


### PR DESCRIPTION
## What does this change?
Adds 'The stakes' US election newsletter and rearranges some others
## Why?
Requested by CP

<img width="967" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/110032454/d675e2fc-2337-4e71-9a99-ef7079c1c216">

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
