### PR TITLE
Remove stub `@types/parse5`

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -98,7 +98,6 @@
 		"@types/lodash.debounce": "4.0.7",
 		"@types/lodash.get": "4.4.7",
 		"@types/node": "20.12.7",
-		"@types/parse5": "7.0.0",
 		"@types/qs": "6.9.7",
 		"@types/react": "18.2.45",
 		"@types/react-dom": "18.2.17",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -512,9 +512,6 @@ importers:
       '@types/node':
         specifier: 20.12.7
         version: 20.12.7
-      '@types/parse5':
-        specifier: 7.0.0
-        version: 7.0.0
       '@types/qs':
         specifier: 6.9.7
         version: 6.9.7
@@ -7939,13 +7936,6 @@ packages:
 
   /@types/parse5@6.0.3:
     resolution: {integrity: sha512-SuT16Q1K51EAVPz1K29DJ/sXjhSQ0zjvsypYJ6tlwVsRV9jwW5Adq2ch8Dq8kDBCkYnELS7N7VNCSB5nC56t/g==}
-    dev: false
-
-  /@types/parse5@7.0.0:
-    resolution: {integrity: sha512-f2SeAxumolBmhuR62vNGTsSAvdz/Oj0k682xNrcKJ4dmRnTPODB74j6CPoNPzBPTHsu7Y7W7u93Mgp8Ovo8vWw==}
-    deprecated: This is a stub types definition. parse5 provides its own type definitions, so you do not need this installed.
-    dependencies:
-      parse5: 7.1.2
     dev: false
 
   /@types/pretty-hrtime@1.0.3:


### PR DESCRIPTION
## What does this change?

Remove deprecated stub package

## Why?

As per [the depracation note](https://www.npmjs.com/package/@types/parse5):

> This is a stub types definition. parse5 provides its own type definitions, so you do not need this installed