### PR TITLE
chore: bump support-dotcom-components

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -54,7 +54,7 @@
 		"@guardian/source-foundations": "14.2.2",
 		"@guardian/source-react-components": "22.1.0",
 		"@guardian/source-react-components-development-kitchen": "19.0.0",
-		"@guardian/support-dotcom-components": "2.1.0",
+		"@guardian/support-dotcom-components": "2.1.1",
 		"@guardian/tsconfig": "0.2.0",
 		"@playwright/test": "1.40.1",
 		"@sentry/browser": "7.75.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -381,8 +381,8 @@ importers:
         specifier: 19.0.0
         version: 19.0.0(@emotion/react@11.11.1)(@guardian/libs@16.1.0)(@guardian/source-foundations@14.2.2)(@guardian/source-react-components@22.1.0)(react@18.2.0)(tslib@2.6.2)(typescript@5.3.3)
       '@guardian/support-dotcom-components':
-        specifier: 2.1.0
-        version: 2.1.0
+        specifier: 2.1.1
+        version: 2.1.1(zod@3.22.3)
       '@guardian/tsconfig':
         specifier: 0.2.0
         version: 0.2.0
@@ -4512,8 +4512,12 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@guardian/support-dotcom-components@2.1.0:
-    resolution: {integrity: sha512-j+jK/XzPwOcfgpAQ227oApEOpNcUYmsgI98H5uWcrNA1Pm60MA3XzQrkdmUTkJQDTuvisQZgFPfE8e/vAnTV/g==}
+  /@guardian/support-dotcom-components@2.1.1(zod@3.22.3):
+    resolution: {integrity: sha512-mLyO/QJ4ech72Yb0dgUjTU+xXAi9xgKhaW6qTHrCiNn1W+rv2m+CfTYaZxGP2Y8YwanRnUAh1ZADQXCkRy34rw==}
+    peerDependencies:
+      zod: ^3.22.4
+    dependencies:
+      zod: 3.22.3
     dev: false
 
   /@guardian/tsconfig@0.2.0:


### PR DESCRIPTION
## What does this change?

- Bump @guardian/support-dotcom-components

## Why?

- Zod was required by @guardian/support-dotcom-components for the shared types to work but not listed as a peer dependency, now it is
<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
