### PR TITLE
Add playwright report folders to `.eslintignore`

### DIFF
--- a/dotcom-rendering/.eslintignore
+++ b/dotcom-rendering/.eslintignore
@@ -4,3 +4,8 @@ storybook-static/
 
 # build output
 dist
+
+# playwright
+test-results/
+playwright-report/
+playwright/.cache/


### PR DESCRIPTION
## What does this change?

Since #11287 generated Playwright report folders are linted.

Adding them to `.eslintignore` prevents this.

