### PR TITLE
Do not defer loading on Apps

### DIFF
--- a/dotcom-rendering/src/components/Island.tsx
+++ b/dotcom-rendering/src/components/Island.tsx
@@ -63,7 +63,17 @@ export const Island = ({ priority, defer, children }: IslandProps) => {
 	// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- Type definitions on children are limited
 	const name = String(children.type.name);
 
-	return (
+	return config.renderingTarget === 'Apps' ? (
+		<gu-island
+			name={name}
+			priority={priority}
+			deferUntil={undefined} // never defer on Apps
+			props={JSON.stringify(children.props)}
+			config={JSON.stringify(config)}
+		>
+			{children}
+		</gu-island>
+	) : (
 		<gu-island
 			name={name}
 			priority={priority}


### PR DESCRIPTION

## What does this change?

Remove the ability for Apps islands to be deferred.

## Why?

There are typically less islands, and we want to experiment with loading them eagerly. We hope this improves responsiveness and native feel on Apps.

Follow-up on #11297