### PR TITLE
Only adapt the PROD website

### DIFF
--- a/dotcom-rendering/src/client/adaptiveSite.ts
+++ b/dotcom-rendering/src/client/adaptiveSite.ts
@@ -14,6 +14,7 @@ export const shouldAdapt = async (): Promise<boolean> => {
 	if (isServer) return false;
 	if (window.location.hash === '#adapt') return true;
 	if (!window.guardian.config.switches.adaptiveSite) return false;
+	if (window.location.host !== 'www.theguardian.com') return false;
 
 	// only evaluate this code if we want to adapt in response to page performance
 	const { isPerformingPoorly } = await import(


### PR DESCRIPTION
## What does this change?

Only adapt the Guardian website in production.

## Why?

Otherwise it can cause unexpected errors in our end-to-end tests or local testing.

Follow-up on #11174

Alternative to #11320 