### PR TITLE
Only adapt site on www.theguardian.com

### DIFF
--- a/dotcom-rendering/src/client/adaptiveSite.ts
+++ b/dotcom-rendering/src/client/adaptiveSite.ts
@@ -13,6 +13,7 @@ import { recordExperiences } from './ophan/ophan';
 export const shouldAdapt = async (): Promise<boolean> => {
 	if (isServer) return false;
 	if (window.location.hash === '#adapt') return true;
+	if (!window.location.hostname.includes('www.theguardian.com')) return false;
 	if (!window.guardian.config.switches.adaptiveSite) return false;
 
 	// only evaluate this code if we want to adapt in response to page performance


### PR DESCRIPTION
## What does this change?

Turn off adaptive site behaviour for non www hosts

## Why?

Adaptive site is causing issues for e2e tests as it will intermittently turn off features expected by the tests.