### PR TITLE
DCAR: Update dark mode colour for Match Stats background and % icon

### DIFF
--- a/dotcom-rendering/src/components/Doughnut.tsx
+++ b/dotcom-rendering/src/components/Doughnut.tsx
@@ -27,9 +27,10 @@ const SEGMENT_GAP = 2;
 const TAU = Math.PI * 2;
 const QUARTER_TURN = TAU / 4;
 
-const unitStyles = css`
+const percentageStyles = css`
 	${headlineBold34}
 	text-anchor: middle;
+	fill: var(--doughnut-percentage-icon);
 `;
 
 const valueStyles = (background: string) => css`
@@ -166,7 +167,7 @@ export const Doughnut = ({
 					</text>
 				</g>
 			))}
-			<text css={unitStyles} dy="0.4em">
+			<text css={percentageStyles} dy="0.4em">
 				%
 			</text>
 		</svg>

--- a/dotcom-rendering/src/components/Doughnut.tsx
+++ b/dotcom-rendering/src/components/Doughnut.tsx
@@ -30,7 +30,7 @@ const QUARTER_TURN = TAU / 4;
 const percentageStyles = css`
 	${headlineBold34}
 	text-anchor: middle;
-	fill: var(--doughnut-percentage-icon);
+	fill: currentColor;
 `;
 
 const valueStyles = (background: string) => css`

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -3751,7 +3751,7 @@ const shareButtonDark: PaletteFunction = () => sourcePalette.neutral[60];
 
 const matchNavBackground: PaletteFunction = () => sourcePalette.brandAlt[400];
 
-const matchStatsBackground: PaletteFunction = ({ design }) => {
+const matchStatsBackgroundLight: PaletteFunction = ({ design }) => {
 	switch (design) {
 		case ArticleDesign.LiveBlog:
 		case ArticleDesign.DeadBlog:
@@ -3762,6 +3762,9 @@ const matchStatsBackground: PaletteFunction = ({ design }) => {
 			return '#d9edf6';
 	}
 };
+
+const matchStatsBackgroundDark: PaletteFunction = () =>
+	sourcePalette.sport[300];
 
 const matchTabBorder: PaletteFunction = () => sourcePalette.neutral[86];
 const matchActiveTabBorder: PaletteFunction = () => sourcePalette.sport[300];
@@ -5380,6 +5383,11 @@ const timelineEventBorderLight: PaletteFunction = () =>
 const timelineEventBorderDark: PaletteFunction = () =>
 	sourcePalette.neutral[20];
 
+const doughnutPercentageIconLight: PaletteFunction = () =>
+	sourcePalette.neutral[0];
+const doughnutPercentageIconDark: PaletteFunction = () =>
+	sourcePalette.sport[800];
+
 // ----- Palette ----- //
 
 /**
@@ -5834,8 +5842,8 @@ const paletteColours = {
 		dark: matchNavBackground,
 	},
 	'--match-stats-background': {
-		light: matchStatsBackground,
-		dark: matchStatsBackground,
+		light: matchStatsBackgroundLight,
+		dark: matchStatsBackgroundDark,
 	},
 	'--match-tab-border': {
 		light: matchTabBorder,
@@ -6388,6 +6396,10 @@ const paletteColours = {
 	'--timeline-event-border': {
 		light: timelineEventBorderLight,
 		dark: timelineEventBorderDark,
+	},
+	'--doughnut-percentage-icon': {
+		light: doughnutPercentageIconLight,
+		dark: doughnutPercentageIconDark,
 	},
 } satisfies PaletteColours;
 

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -5383,11 +5383,6 @@ const timelineEventBorderLight: PaletteFunction = () =>
 const timelineEventBorderDark: PaletteFunction = () =>
 	sourcePalette.neutral[20];
 
-const doughnutPercentageIconLight: PaletteFunction = () =>
-	sourcePalette.neutral[0];
-const doughnutPercentageIconDark: PaletteFunction = () =>
-	sourcePalette.sport[800];
-
 // ----- Palette ----- //
 
 /**
@@ -6396,10 +6391,6 @@ const paletteColours = {
 	'--timeline-event-border': {
 		light: timelineEventBorderLight,
 		dark: timelineEventBorderDark,
-	},
-	'--doughnut-percentage-icon': {
-		light: doughnutPercentageIconLight,
-		dark: doughnutPercentageIconDark,
 	},
 } satisfies PaletteColours;
 


### PR DESCRIPTION
## What does this change?

Adds a dark mode colour for Match Stats background and the % icon in the possession doughnut

Fixes #11318 

## Why?

This component currently looks terrible and has poor colour contrast in dark mode. 

Note that this is not yet going live to users: [3036](https://github.com/guardian/mobile-apps-api/pull/3036), but with this we are better prepared for when we do.

## How to test

[Example localhost page](http://localhost:3030/AppsArticle/https://www.theguardian.com/football/2024/apr/30/bayern-munich-real-madrid-champions-league-match-report). Switch to dark mode on your browser or OS.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before1][] | ![after1][] |
| ![before2][] | ![after2][] |

[before1]: https://github.com/guardian/dotcom-rendering/assets/9574885/55d13331-5fed-4558-961a-1e9a20353b28
[after1]: https://github.com/guardian/dotcom-rendering/assets/9574885/4beeb826-131c-44af-bb49-dde8df54331e
[before2]: https://github.com/guardian/dotcom-rendering/assets/9574885/7c46aaa7-ac4d-4937-b559-264efa767b20
[after2]: https://github.com/guardian/dotcom-rendering/assets/9574885/f394ff97-3567-4744-942c-9e92fd56b2c1

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
