### PR TITLE
DCAR: dark mode colour for match nav

### DIFF
--- a/dotcom-rendering/src/components/MatchNav.tsx
+++ b/dotcom-rendering/src/components/MatchNav.tsx
@@ -2,7 +2,6 @@ import { css } from '@emotion/react';
 import {
 	background,
 	headlineBold20,
-	palette,
 	space,
 	textSans15,
 	until,
@@ -46,7 +45,7 @@ const StretchBackground = ({ children }: { children: React.ReactNode }) => (
 			justify-content: space-between;
 			position: relative;
 			padding: ${space[2]}px;
-			background-color: ${palette.brandAlt[400]};
+			background-color: var(--match-nav-background);
 			margin-bottom: 10px;
 			${until.tablet} {
 				margin: 0 -10px 10px;
@@ -59,7 +58,7 @@ const StretchBackground = ({ children }: { children: React.ReactNode }) => (
 				bottom: 0;
 				width: 100vw;
 				left: -100vw;
-				background-color: ${palette.brandAlt[400]};
+				background-color: var(--match-nav-background);
 				z-index: -1;
 			}
 		`}
@@ -157,6 +156,7 @@ const TeamNav = ({
 			display: flex;
 			flex-grow: 1;
 			flex-basis: 50%;
+			color: var(--match-nav-text);
 		`}
 	>
 		<Column>

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -3754,8 +3754,7 @@ const matchNavBackgroundLight: PaletteFunction = () =>
 const matchNavBackgroundDark: PaletteFunction = () =>
 	sourcePalette.brandAlt[200];
 
-const matchNavTextLight: PaletteFunction = () => sourcePalette.neutral[86];
-const matchNavTextDark: PaletteFunction = () => sourcePalette.neutral[7];
+const matchNavText: PaletteFunction = () => sourcePalette.neutral[7];
 
 const matchStatsBackgroundLight: PaletteFunction = ({ design }) => {
 	switch (design) {
@@ -5848,8 +5847,8 @@ const paletteColours = {
 		dark: matchNavBackgroundDark,
 	},
 	'--match-nav-text': {
-		light: matchNavTextLight,
-		dark: matchNavTextDark,
+		light: matchNavText,
+		dark: matchNavText,
 	},
 	'--match-stats-background': {
 		light: matchStatsBackgroundLight,

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -3749,7 +3749,13 @@ const shareButtonLight: PaletteFunction = ({ design, theme, display }) => {
 
 const shareButtonDark: PaletteFunction = () => sourcePalette.neutral[60];
 
-const matchNavBackground: PaletteFunction = () => sourcePalette.brandAlt[400];
+const matchNavBackgroundLight: PaletteFunction = () =>
+	sourcePalette.brandAlt[400];
+const matchNavBackgroundDark: PaletteFunction = () =>
+	sourcePalette.brandAlt[200];
+
+const matchNavTextLight: PaletteFunction = () => sourcePalette.neutral[86];
+const matchNavTextDark: PaletteFunction = () => sourcePalette.neutral[7];
 
 const matchStatsBackgroundLight: PaletteFunction = ({ design }) => {
 	switch (design) {
@@ -3766,8 +3772,13 @@ const matchStatsBackgroundLight: PaletteFunction = ({ design }) => {
 const matchStatsBackgroundDark: PaletteFunction = () =>
 	sourcePalette.sport[300];
 
-const matchTabBorder: PaletteFunction = () => sourcePalette.neutral[86];
-const matchActiveTabBorder: PaletteFunction = () => sourcePalette.sport[300];
+const matchTabBorderLight: PaletteFunction = () => sourcePalette.neutral[86];
+const matchTabBorderDark: PaletteFunction = () => sourcePalette.neutral[46];
+
+const matchActiveTabBorderLight: PaletteFunction = () =>
+	sourcePalette.sport[300];
+const matchActiveTabBorderDark: PaletteFunction = () =>
+	sourcePalette.sport[500];
 
 const liveBlockContainerBackgroundLight: PaletteFunction = () =>
 	sourcePalette.neutral[100];
@@ -5833,20 +5844,24 @@ const paletteColours = {
 		dark: shareButtonDark,
 	},
 	'--match-nav-background': {
-		light: matchNavBackground,
-		dark: matchNavBackground,
+		light: matchNavBackgroundLight,
+		dark: matchNavBackgroundDark,
+	},
+	'--match-nav-text': {
+		light: matchNavTextLight,
+		dark: matchNavTextDark,
 	},
 	'--match-stats-background': {
 		light: matchStatsBackgroundLight,
 		dark: matchStatsBackgroundDark,
 	},
 	'--match-tab-border': {
-		light: matchTabBorder,
-		dark: matchTabBorder,
+		light: matchTabBorderLight,
+		dark: matchTabBorderDark,
 	},
 	'--match-tab-border-active': {
-		light: matchActiveTabBorder,
-		dark: matchActiveTabBorder,
+		light: matchActiveTabBorderLight,
+		dark: matchActiveTabBorderDark,
 	},
 	'--live-block-container-background': {
 		light: liveBlockContainerBackgroundLight,


### PR DESCRIPTION
## What does this change?

Adds dark mode colours for the Match Nav. 
Fixes #11321 

NOTE that this is not yet going live to users: https://github.com/guardian/mobile-apps-api/pull/3036, but with this we are better prepared for when we do. Updates that are still needed include the placeholder colour at the top of liveblogs and the tag colour in this section.

## How to test

Switch to dark mode on your browser or OS.

Example local article: 
http://localhost:3030/AppsArticle/https://www.theguardian.com/football/2024/apr/30/bayern-munich-real-madrid-champions-league-match-report?dcr=apps&edition=uk

Example local liveblog: http://localhost:3030/AppsArticle/https://www.theguardian.com/football/live/2024/apr/30/bayern-munich-v-real-madrid-champions-league-semi-final-first-leg-live

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before1][] | ![after1][] |
| ![before2][] | ![after2][] |

[before1]: https://github.com/guardian/dotcom-rendering/assets/9574885/c79cbc47-cb66-4bef-a505-5835186a4006
[after1]: https://github.com/guardian/dotcom-rendering/assets/9574885/ec76f8fa-3667-416e-9238-7b80931333b4
[before2]: https://github.com/guardian/dotcom-rendering/assets/9574885/1ff21f13-b713-44e0-ac2e-bf8e3433ea2b
[after2]: https://github.com/guardian/dotcom-rendering/assets/9574885/7b8079c4-e078-4713-89af-82bb06c8618f

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
