### PR TITLE
Correcting the space around the lines in Q&A and Key Takeaways

### DIFF
--- a/dotcom-rendering/src/components/KeyTakeaway.tsx
+++ b/dotcom-rendering/src/components/KeyTakeaway.tsx
@@ -17,7 +17,7 @@ const headingIndexStyles = css`
 
 const headingLineStyles = css`
 	width: 140px;
-	margin: 0;
+	margin: 0 0 2px 0;
 	border: none;
 	border-top: 4px solid ${palette('--heading-line')};
 `;

--- a/dotcom-rendering/src/components/QAndAExplainer.tsx
+++ b/dotcom-rendering/src/components/QAndAExplainer.tsx
@@ -25,9 +25,10 @@ interface Props {
 
 const headingLineStyles = css`
 	width: 140px;
-	margin: 8px 0 0 0;
+	padding-top: 8px;
+	margin: 0 0 2px 0;
 	border: none;
-	border-top: 4px solid ${palette('--heading-line')};
+	border-bottom: 4px solid ${palette('--heading-line')};
 `;
 
 export const QAndAExplainer = ({


### PR DESCRIPTION
## What does this change?

Ensure 
- 2px under line
- 8px above line

## Why?

Design requirement - Rich spotted and raised this

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/1229808/e6383018-d8ac-47d6-a2e5-3b73cfadc6b5
[after]: https://github.com/guardian/dotcom-rendering/assets/1229808/44617b29-6d1d-46d2-b1f1-c1654ded423e


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
