### PR TITLE
Extract shared global/root styles

### DIFF
--- a/dotcom-rendering/src/components/AllEditorialNewslettersPage.tsx
+++ b/dotcom-rendering/src/components/AllEditorialNewslettersPage.tsx
@@ -1,13 +1,9 @@
-import { css, Global } from '@emotion/react';
+import { Global } from '@emotion/react';
 import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
-import {
-	focusHalo,
-	palette as sourcePalette,
-} from '@guardian/source-foundations';
 import { StrictMode } from 'react';
 import { AllEditorialNewslettersPageLayout } from '../layouts/AllEditorialNewslettersPageLayout';
+import { rootStyles } from '../lib/rootStyles';
 import type { NavType } from '../model/extract-nav';
-import { paletteDeclarations } from '../palette';
 import type { DCRNewslettersPageType } from '../types/newslettersPage';
 import { AlreadyVisited } from './AlreadyVisited.importable';
 import { FocusStyles } from './FocusStyles.importable';
@@ -40,29 +36,12 @@ export const AllEditorialNewslettersPage = ({
 		theme: Pillar.News,
 	};
 
+	const darkModeAvailable =
+		newslettersPage.config.abTests.darkModeWebVariant === 'variant';
+
 	return (
 		<StrictMode>
-			<Global
-				styles={css`
-					:root {
-						/* Light palette is default on all platforms */
-						/* We do not support dark mode on tag pages */
-						${paletteDeclarations(format, 'light')}
-						body {
-							color: ${sourcePalette.neutral[7]};
-						}
-					}
-					/* Crude but effective mechanism. Specific components may need to improve on this behaviour. */
-					/* The not(.src...) selector is to work with Source's FocusStyleManager. */
-					*:focus {
-						${focusHalo}
-					}
-					::selection {
-						background: ${sourcePalette.brandAlt[400]};
-						color: ${sourcePalette.neutral[7]};
-					}
-				`}
-			/>
+			<Global styles={rootStyles(format, darkModeAvailable)} />
 			<SkipTo id="maincontent" label="Skip to main content" />
 			<SkipTo id="navigation" label="Skip to navigation" />
 			<Island priority="feature" defer={{ until: 'idle' }}>

--- a/dotcom-rendering/src/components/ArticlePage.tsx
+++ b/dotcom-rendering/src/components/ArticlePage.tsx
@@ -1,15 +1,11 @@
-import { css, Global } from '@emotion/react';
+import { Global } from '@emotion/react';
 import { ArticleDesign } from '@guardian/libs';
-import {
-	focusHalo,
-	palette as sourcePalette,
-} from '@guardian/source-foundations';
 import { StrictMode } from 'react';
 import { DecideLayout } from '../layouts/DecideLayout';
 import { buildAdTargeting } from '../lib/ad-targeting';
+import { rootStyles } from '../lib/rootStyles';
 import { filterABTestSwitches } from '../model/enhance-switches';
 import type { NavType } from '../model/extract-nav';
-import { paletteDeclarations } from '../palette';
 import type { DCRArticle } from '../types/frontend';
 import type { RenderingTarget } from '../types/renderingTarget';
 import { AlreadyVisited } from './AlreadyVisited.importable';
@@ -43,40 +39,6 @@ interface AppProps extends BaseProps {
 
 /**
  * @description
- * returns global styles for article pages
- */
-const globalStyles = (format: ArticleFormat, darkModeAvailable: boolean) => css`
-	:root {
-		/* Light palette is default on all platforms */
-		${paletteDeclarations(format, 'light')}
-		body {
-			color: ${sourcePalette.neutral[7]};
-		}
-		/* Dark palette only if supported */
-		${darkModeAvailable
-			? css`
-					@media (prefers-color-scheme: dark) {
-						${paletteDeclarations(format, 'dark')}
-						body {
-							color: ${sourcePalette.neutral[86]};
-						}
-					}
-			  `
-			: ''}
-	}
-	/* Crude but effective mechanism. Specific components may need to improve on this behaviour. */
-	/* The not(.src...) selector is to work with Source's FocusStyleManager. */
-	*:focus {
-		${focusHalo}
-	}
-	::selection {
-		background: ${sourcePalette.brandAlt[400]};
-		color: ${sourcePalette.neutral[7]};
-	}
-`;
-
-/**
- * @description
  * Article is a high level wrapper for article pages on Dotcom. Sets strict mode and some globals
  */
 export const ArticlePage = (props: WebProps | AppProps) => {
@@ -99,7 +61,7 @@ export const ArticlePage = (props: WebProps | AppProps) => {
 
 	return (
 		<StrictMode>
-			<Global styles={globalStyles(format, darkModeAvailable)} />
+			<Global styles={rootStyles(format, darkModeAvailable)} />
 			{isWeb && (
 				<>
 					<SkipTo id="maincontent" label="Skip to main content" />

--- a/dotcom-rendering/src/components/FrontPage.tsx
+++ b/dotcom-rendering/src/components/FrontPage.tsx
@@ -1,15 +1,11 @@
-import { css, Global } from '@emotion/react';
+import { Global } from '@emotion/react';
 import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
-import {
-	focusHalo,
-	palette as sourcePalette,
-} from '@guardian/source-foundations';
 import { StrictMode } from 'react';
 import { FrontLayout } from '../layouts/FrontLayout';
 import { buildAdTargeting } from '../lib/ad-targeting';
+import { rootStyles } from '../lib/rootStyles';
 import { filterABTestSwitches } from '../model/enhance-switches';
 import type { NavType } from '../model/extract-nav';
-import { paletteDeclarations } from '../palette';
 import type { DCRFrontType } from '../types/front';
 import { AlreadyVisited } from './AlreadyVisited.importable';
 import { BrazeMessaging } from './BrazeMessaging.importable';
@@ -58,38 +54,7 @@ export const FrontPage = ({ front, NAV }: Props) => {
 
 	return (
 		<StrictMode>
-			<Global
-				styles={css`
-					:root {
-						/* Light palette is default on all platforms */
-						/* We do not support dark mode on front pages */
-						${paletteDeclarations(format, 'light')}
-						body {
-							color: ${sourcePalette.neutral[7]};
-						}
-						/* Dark palette only if supported */
-						${darkModeAvailable
-							? css`
-									@media (prefers-color-scheme: dark) {
-										${paletteDeclarations(format, 'dark')}
-										body {
-											color: ${sourcePalette.neutral[86]};
-										}
-									}
-							  `
-							: ''}
-					}
-					/* Crude but effective mechanism. Specific components may need to improve on this behaviour. */
-					/* The not(.src...) selector is to work with Source's FocusStyleManager. */
-					*:focus {
-						${focusHalo}
-					}
-					::selection {
-						background: ${sourcePalette.brandAlt[400]};
-						color: ${sourcePalette.neutral[7]};
-					}
-				`}
-			/>
+			<Global styles={rootStyles(format, darkModeAvailable)} />
 			<SkipTo id="maincontent" label="Skip to main content" />
 			<SkipTo id="navigation" label="Skip to navigation" />
 			<Island priority="feature" defer={{ until: 'idle' }}>

--- a/dotcom-rendering/src/components/TagPage.tsx
+++ b/dotcom-rendering/src/components/TagPage.tsx
@@ -1,15 +1,11 @@
-import { css, Global } from '@emotion/react';
+import { Global } from '@emotion/react';
 import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
-import {
-	focusHalo,
-	palette as sourcePalette,
-} from '@guardian/source-foundations';
 import { StrictMode } from 'react';
 import { TagPageLayout } from '../layouts/TagPageLayout';
 import { buildAdTargeting } from '../lib/ad-targeting';
+import { rootStyles } from '../lib/rootStyles';
 import { filterABTestSwitches } from '../model/enhance-switches';
 import type { NavType } from '../model/extract-nav';
-import { paletteDeclarations } from '../palette';
 import type { DCRTagPageType } from '../types/tagPage';
 import { AlreadyVisited } from './AlreadyVisited.importable';
 import { DarkModeMessage } from './DarkModeMessage';
@@ -55,38 +51,7 @@ export const TagPage = ({ tagPage, NAV }: Props) => {
 
 	return (
 		<StrictMode>
-			<Global
-				styles={css`
-					:root {
-						/* Light palette is default on all platforms */
-						/* We do not support dark mode on tag pages */
-						${paletteDeclarations(format, 'light')}
-						body {
-							color: ${sourcePalette.neutral[7]};
-						}
-						/* Dark palette only if supported */
-						${darkModeAvailable
-							? css`
-									@media (prefers-color-scheme: dark) {
-										${paletteDeclarations(format, 'dark')}
-										body {
-											color: ${sourcePalette.neutral[86]};
-										}
-									}
-							  `
-							: ''}
-					}
-					/* Crude but effective mechanism. Specific components may need to improve on this behaviour. */
-					/* The not(.src...) selector is to work with Source's FocusStyleManager. */
-					*:focus {
-						${focusHalo}
-					}
-					::selection {
-						background: ${sourcePalette.brandAlt[400]};
-						color: ${sourcePalette.neutral[7]};
-					}
-				`}
-			/>
+			<Global styles={rootStyles(format, darkModeAvailable)} />
 			<SkipTo id="maincontent" label="Skip to main content" />
 			<SkipTo id="navigation" label="Skip to navigation" />
 			<Island priority="feature" defer={{ until: 'idle' }}>

--- a/dotcom-rendering/src/lib/rootStyles.ts
+++ b/dotcom-rendering/src/lib/rootStyles.ts
@@ -1,0 +1,49 @@
+import { css, type SerializedStyles } from '@emotion/react';
+import {
+	focusHalo,
+	palette as sourcePalette,
+} from '@guardian/source-foundations';
+import { paletteDeclarations } from '../palette';
+
+/**
+ * Global styles for pages:
+ * - colour-scheme aware palette declarations
+ * - `:focus` halo styles
+ * - `::selection` styles
+ */
+export const rootStyles = (
+	format: ArticleFormat,
+	darkModeAvailable: boolean,
+): SerializedStyles => css`
+	:root {
+		/* Light palette is default on all platforms */
+		${paletteDeclarations(format, 'light')}
+		body {
+			color: ${sourcePalette.neutral[7]};
+			background: ${sourcePalette.neutral[100]};
+		}
+		/* Indicate whether UI can adapt https://developer.mozilla.org/en-US/docs/Web/CSS/color-scheme */
+		color-scheme: ${darkModeAvailable ? 'light dark' : 'only light'};
+		/* Dark palette only if supported */
+		${darkModeAvailable
+			? css`
+					@media (prefers-color-scheme: dark) {
+						${paletteDeclarations(format, 'dark')}
+						body {
+							color: ${sourcePalette.neutral[86]};
+							background: ${sourcePalette.neutral[7]};
+						}
+					}
+			  `
+			: ''}
+	}
+	/* Crude but effective mechanism. Specific components may need to improve on this behaviour. */
+	/* The not(.src...) selector is to work with Source's FocusStyleManager. */
+	*:focus {
+		${focusHalo}
+	}
+	::selection {
+		background: ${sourcePalette.brandAlt[400]};
+		color: ${sourcePalette.neutral[7]};
+	}
+`;


### PR DESCRIPTION
## What does this change?

- Create a `rootStyles` function and module and reuse it in `*Page.tsx` files.
- If dark mode is available, let the browser know
- Set an explicit background colour on `body`

## Why?

They are used in four different places, so it has become worth reusing the logic.

## Screenshots

| Light | Dark |
|--------|--------|
| ![Before](https://github.com/guardian/dotcom-rendering/assets/76776/a4096d08-e008-47d8-ac83-4fcd81ac074c) | ![After](https://github.com/guardian/dotcom-rendering/assets/76776/c3323a3c-6992-4bd4-a0e5-7cbe53099b21) | 