### PR TITLE
Fix z-index issue for veggie burger between mobileMedium and tablet breakpoints

### DIFF
--- a/dotcom-rendering/src/components/Nav/ExpandedMenu/VeggieBurgerMenu.tsx
+++ b/dotcom-rendering/src/components/Nav/ExpandedMenu/VeggieBurgerMenu.tsx
@@ -1,6 +1,5 @@
 import { css } from '@emotion/react';
 import {
-	between,
 	from,
 	palette as sourcePalette,
 	visuallyHidden,
@@ -81,10 +80,6 @@ const veggieBurgerStyles = (isImmersive: boolean) => css`
 
 	right: 5px;
 	bottom: 58px;
-
-	${between.mobileMedium.and.tablet} {
-		${getZIndex('burger')}
-	}
 
 	${from.mobileMedium} {
 		bottom: ${isImmersive ? '3px' : '-3px'};


### PR DESCRIPTION
## What does this change?

This removes some additional z-index logic added in https://github.com/guardian/dotcom-rendering/pull/7841 to use the expanded burger menu z-index value in its unopened state due to a bug with thrashers.

Having tested this on CODE recently, I don't think this is an issue any more.

## Why?

There is currently an issue with the z-index of the veggie burger on mobileMedium/tablet sized viewports where the unopened/unselected veggie burger appears on top of the MMA menu options when this dropdown is expanded.

Since we have plans to move the location of the MMA menu from the left to the right (see https://github.com/guardian/dotcom-rendering/pull/11190), this bug needs fixing so that it the menu items can be read and selected properly.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before1][] | ![after1][] |
| ![before2][] | ![after2][] |


[before1]: https://github.com/guardian/dotcom-rendering/assets/43961396/b824f7fa-3fc2-4bbb-b69c-387ecdcb8ba9
[after1]: https://github.com/guardian/dotcom-rendering/assets/43961396/ae22dbcf-c007-4a6e-83b6-3bc37fcdd2dd
[before2]: https://github.com/guardian/dotcom-rendering/assets/43961396/525a81ed-5c6b-495c-99b7-dc94e442af4c
[after2]: https://github.com/guardian/dotcom-rendering/assets/43961396/6a628544-0002-490c-a0f7-c7a0c798c46f


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
