### PR TITLE
Use `palette` colours in `SubNav.importable.tsx`

### DIFF
--- a/dotcom-rendering/fixtures/manual/nav-international.ts
+++ b/dotcom-rendering/fixtures/manual/nav-international.ts
@@ -1,0 +1,1034 @@
+/** `xhs https://www.theguardian.com/international.json\?dcr | jq .nav | pbcopy` */
+export const navInternational = {
+	currentUrl: '/',
+	pillars: [
+		{
+			title: 'News',
+			url: '/',
+			longTitle: 'Headlines',
+			iconName: 'home',
+			children: [
+				{
+					title: 'UK',
+					url: '/uk-news',
+					longTitle: 'UK news',
+					children: [
+						{
+							title: 'UK politics',
+							url: '/politics',
+						},
+						{
+							title: 'Education',
+							url: '/education',
+							children: [
+								{
+									title: 'Schools',
+									url: '/education/schools',
+								},
+								{
+									title: 'Teachers',
+									url: '/teacher-network',
+								},
+								{
+									title: 'Universities',
+									url: '/education/universities',
+								},
+								{
+									title: 'Students',
+									url: '/education/students',
+								},
+							],
+						},
+						{
+							title: 'Media',
+							url: '/media',
+						},
+						{
+							title: 'Society',
+							url: '/society',
+						},
+						{
+							title: 'Law',
+							url: '/law',
+						},
+						{
+							title: 'Scotland',
+							url: '/uk/scotland',
+						},
+						{
+							title: 'Wales',
+							url: '/uk/wales',
+						},
+						{
+							title: 'Northern Ireland',
+							url: '/uk/northernireland',
+						},
+					],
+				},
+				{
+					title: 'World',
+					url: '/world',
+					longTitle: 'World news',
+					children: [
+						{
+							title: 'Europe',
+							url: '/world/europe-news',
+						},
+						{
+							title: 'US',
+							url: '/us-news',
+							longTitle: 'US news',
+						},
+						{
+							title: 'Americas',
+							url: '/world/americas',
+						},
+						{
+							title: 'Asia',
+							url: '/world/asia',
+						},
+						{
+							title: 'Australia',
+							url: '/australia-news',
+							longTitle: 'Australia news',
+						},
+						{
+							title: 'Middle East',
+							url: '/world/middleeast',
+						},
+						{
+							title: 'Africa',
+							url: '/world/africa',
+						},
+						{
+							title: 'Inequality',
+							url: '/inequality',
+						},
+						{
+							title: 'Global development',
+							url: '/global-development',
+						},
+					],
+				},
+				{
+					title: 'Climate crisis',
+					url: '/environment/climate-crisis',
+				},
+				{
+					title: 'Ukraine',
+					url: '/world/ukraine',
+				},
+				{
+					title: 'Football',
+					url: '/football',
+					children: [
+						{
+							title: 'Live scores',
+							url: '/football/live',
+							longTitle: 'football/live',
+						},
+						{
+							title: 'Tables',
+							url: '/football/tables',
+							longTitle: 'football/tables',
+						},
+						{
+							title: 'Fixtures',
+							url: '/football/fixtures',
+							longTitle: 'football/fixtures',
+						},
+						{
+							title: 'Results',
+							url: '/football/results',
+							longTitle: 'football/results',
+						},
+						{
+							title: 'Competitions',
+							url: '/football/competitions',
+							longTitle: 'football/competitions',
+						},
+						{
+							title: 'Clubs',
+							url: '/football/teams',
+							longTitle: 'football/teams',
+						},
+					],
+				},
+				{
+					title: 'Newsletters',
+					url: '/email-newsletters',
+				},
+				{
+					title: 'Business',
+					url: '/business',
+					children: [
+						{
+							title: 'Economics',
+							url: '/business/economics',
+						},
+						{
+							title: 'Banking',
+							url: '/business/banking',
+						},
+						{
+							title: 'Money',
+							url: '/money',
+							children: [
+								{
+									title: 'Property',
+									url: '/money/property',
+								},
+								{
+									title: 'Pensions',
+									url: '/money/pensions',
+								},
+								{
+									title: 'Savings',
+									url: '/money/savings',
+								},
+								{
+									title: 'Borrowing',
+									url: '/money/debt',
+								},
+								{
+									title: 'Careers',
+									url: '/money/work-and-careers',
+								},
+							],
+						},
+						{
+							title: 'Markets',
+							url: '/business/stock-markets',
+						},
+						{
+							title: 'Project Syndicate',
+							url: '/business/series/project-syndicate-economists',
+						},
+						{
+							title: 'B2B',
+							url: '/business-to-business',
+						},
+						{
+							title: 'Retail',
+							url: '/business/retail',
+						},
+					],
+				},
+				{
+					title: 'Environment',
+					url: '/environment',
+					children: [
+						{
+							title: 'Climate crisis',
+							url: '/environment/climate-crisis',
+						},
+						{
+							title: 'Wildlife',
+							url: '/environment/wildlife',
+						},
+						{
+							title: 'Energy',
+							url: '/environment/energy',
+						},
+						{
+							title: 'Pollution',
+							url: '/environment/pollution',
+						},
+					],
+				},
+				{
+					title: 'UK politics',
+					url: '/politics',
+				},
+				{
+					title: 'Education',
+					url: '/education',
+					children: [
+						{
+							title: 'Schools',
+							url: '/education/schools',
+						},
+						{
+							title: 'Teachers',
+							url: '/teacher-network',
+						},
+						{
+							title: 'Universities',
+							url: '/education/universities',
+						},
+						{
+							title: 'Students',
+							url: '/education/students',
+						},
+					],
+				},
+				{
+					title: 'Society',
+					url: '/society',
+				},
+				{
+					title: 'Science',
+					url: '/science',
+				},
+				{
+					title: 'Tech',
+					url: '/technology',
+				},
+				{
+					title: 'Global development',
+					url: '/global-development',
+				},
+				{
+					title: 'Obituaries',
+					url: '/obituaries',
+				},
+			],
+		},
+		{
+			title: 'Opinion',
+			url: '/commentisfree',
+			longTitle: 'Opinion home',
+			iconName: 'home',
+			children: [
+				{
+					title: 'The Guardian view',
+					url: '/profile/editorial',
+				},
+				{
+					title: 'Columnists',
+					url: '/index/contributors',
+				},
+				{
+					title: 'Cartoons',
+					url: '/tone/cartoons',
+				},
+				{
+					title: 'Opinion videos',
+					url: '/type/video+tone/comment',
+				},
+				{
+					title: 'Letters',
+					url: '/tone/letters',
+				},
+			],
+		},
+		{
+			title: 'Sport',
+			url: '/sport',
+			longTitle: 'Sport home',
+			iconName: 'home',
+			children: [
+				{
+					title: 'Football',
+					url: '/football',
+					children: [
+						{
+							title: 'Live scores',
+							url: '/football/live',
+							longTitle: 'football/live',
+						},
+						{
+							title: 'Tables',
+							url: '/football/tables',
+							longTitle: 'football/tables',
+						},
+						{
+							title: 'Fixtures',
+							url: '/football/fixtures',
+							longTitle: 'football/fixtures',
+						},
+						{
+							title: 'Results',
+							url: '/football/results',
+							longTitle: 'football/results',
+						},
+						{
+							title: 'Competitions',
+							url: '/football/competitions',
+							longTitle: 'football/competitions',
+						},
+						{
+							title: 'Clubs',
+							url: '/football/teams',
+							longTitle: 'football/teams',
+						},
+					],
+				},
+				{
+					title: 'Cricket',
+					url: '/sport/cricket',
+				},
+				{
+					title: 'Rugby union',
+					url: '/sport/rugby-union',
+				},
+				{
+					title: 'Tennis',
+					url: '/sport/tennis',
+				},
+				{
+					title: 'Cycling',
+					url: '/sport/cycling',
+				},
+				{
+					title: 'F1',
+					url: '/sport/formulaone',
+				},
+				{
+					title: 'Golf',
+					url: '/sport/golf',
+				},
+				{
+					title: 'Boxing',
+					url: '/sport/boxing',
+				},
+				{
+					title: 'Rugby league',
+					url: '/sport/rugbyleague',
+				},
+				{
+					title: 'Racing',
+					url: '/sport/horse-racing',
+				},
+				{
+					title: 'US sports',
+					url: '/sport/us-sport',
+				},
+			],
+		},
+		{
+			title: 'Culture',
+			url: '/culture',
+			longTitle: 'Culture home',
+			iconName: 'home',
+			children: [
+				{
+					title: 'Film',
+					url: '/film',
+				},
+				{
+					title: 'Music',
+					url: '/music',
+				},
+				{
+					title: 'TV & radio',
+					url: '/tv-and-radio',
+				},
+				{
+					title: 'Books',
+					url: '/books',
+				},
+				{
+					title: 'Art & design',
+					url: '/artanddesign',
+				},
+				{
+					title: 'Stage',
+					url: '/stage',
+				},
+				{
+					title: 'Games',
+					url: '/games',
+				},
+				{
+					title: 'Classical',
+					url: '/music/classicalmusicandopera',
+				},
+			],
+		},
+		{
+			title: 'Lifestyle',
+			url: '/lifeandstyle',
+			longTitle: 'Lifestyle home',
+			iconName: 'home',
+			children: [
+				{
+					title: 'Fashion',
+					url: '/fashion',
+				},
+				{
+					title: 'Food',
+					url: '/food',
+				},
+				{
+					title: 'Recipes',
+					url: '/tone/recipes',
+				},
+				{
+					title: 'Travel',
+					url: '/travel',
+					children: [
+						{
+							title: 'UK',
+							url: '/travel/uk',
+						},
+						{
+							title: 'Europe',
+							url: '/travel/europe',
+						},
+						{
+							title: 'US',
+							url: '/travel/usa',
+						},
+					],
+				},
+				{
+					title: 'Health & fitness',
+					url: '/lifeandstyle/health-and-wellbeing',
+				},
+				{
+					title: 'Women',
+					url: '/lifeandstyle/women',
+				},
+				{
+					title: 'Men',
+					url: '/lifeandstyle/men',
+				},
+				{
+					title: 'Love & sex',
+					url: '/lifeandstyle/love-and-sex',
+				},
+				{
+					title: 'Beauty',
+					url: '/fashion/beauty',
+				},
+				{
+					title: 'Home & garden',
+					url: '/lifeandstyle/home-and-garden',
+				},
+				{
+					title: 'Money',
+					url: '/money',
+					children: [
+						{
+							title: 'Property',
+							url: '/money/property',
+						},
+						{
+							title: 'Pensions',
+							url: '/money/pensions',
+						},
+						{
+							title: 'Savings',
+							url: '/money/savings',
+						},
+						{
+							title: 'Borrowing',
+							url: '/money/debt',
+						},
+						{
+							title: 'Careers',
+							url: '/money/work-and-careers',
+						},
+					],
+				},
+				{
+					title: 'Cars',
+					url: '/technology/motoring',
+				},
+			],
+		},
+	],
+	otherLinks: [
+		{
+			title: 'The Guardian app',
+			url: 'https://app.adjust.com/16xt6hai',
+		},
+		{
+			title: 'Video',
+			url: '/video',
+		},
+		{
+			title: 'Podcasts',
+			url: '/podcasts',
+		},
+		{
+			title: 'Pictures',
+			url: '/inpictures',
+		},
+		{
+			title: 'Newsletters',
+			url: '/email-newsletters',
+		},
+		{
+			title: "Today's paper",
+			url: '/theguardian',
+			children: [
+				{
+					title: 'Obituaries',
+					url: '/obituaries',
+				},
+				{
+					title: 'G2',
+					url: '/theguardian/g2',
+				},
+				{
+					title: 'Journal',
+					url: '/theguardian/journal',
+				},
+				{
+					title: 'Saturday',
+					url: '/theguardian/saturday',
+				},
+			],
+		},
+		{
+			title: 'Inside the Guardian',
+			url: 'https://www.theguardian.com/membership',
+		},
+		{
+			title: 'The Observer',
+			url: '/observer',
+			children: [
+				{
+					title: 'Comment',
+					url: '/theobserver/news/comment',
+				},
+				{
+					title: 'The New Review',
+					url: '/theobserver/new-review',
+				},
+				{
+					title: 'Observer Magazine',
+					url: '/theobserver/magazine',
+				},
+				{
+					title: 'Observer Food Monthly',
+					url: '/theobserver/foodmonthly',
+				},
+			],
+		},
+		{
+			title: 'Guardian Weekly',
+			url: 'https://www.theguardian.com/weekly?INTCMP=gdnwb_mawns_editorial_gweekly_GW_TopNav_UK',
+		},
+		{
+			title: 'Crosswords',
+			url: '/crosswords',
+			children: [
+				{
+					title: 'Blog',
+					url: '/crosswords/crossword-blog',
+				},
+				{
+					title: 'Quick',
+					url: '/crosswords/series/quick',
+				},
+				{
+					title: 'Speedy',
+					url: '/crosswords/series/speedy',
+				},
+				{
+					title: 'Quick cryptic',
+					url: '/crosswords/series/quick-cryptic',
+				},
+				{
+					title: 'Everyman',
+					url: '/crosswords/series/everyman',
+				},
+				{
+					title: 'Quiptic',
+					url: '/crosswords/series/quiptic',
+				},
+				{
+					title: 'Cryptic',
+					url: '/crosswords/series/cryptic',
+				},
+				{
+					title: 'Prize',
+					url: '/crosswords/series/prize',
+				},
+				{
+					title: 'Azed',
+					url: '/crosswords/series/azed',
+				},
+				{
+					title: 'Genius',
+					url: '/crosswords/series/genius',
+				},
+				{
+					title: 'Weekend',
+					url: '/crosswords/series/weekend-crossword',
+				},
+			],
+		},
+		{
+			title: 'Wordiply',
+			url: 'https://www.wordiply.com',
+		},
+		{
+			title: 'Corrections',
+			url: '/theguardian/series/corrections-and-clarifications',
+		},
+	],
+	brandExtensions: [
+		{
+			title: 'Search jobs',
+			url: 'https://jobs.theguardian.com',
+		},
+		{
+			title: 'Hire with Guardian Jobs',
+			url: 'https://recruiters.theguardian.com/?utm_source=gdnwb&utm_medium=navbar&utm_campaign=Guardian_Navbar_Recruiters&CMP_TU=trdmkt&CMP_BUNIT=jobs',
+		},
+		{
+			title: 'Holidays',
+			url: 'https://holidays.theguardian.com?INTCMP=holidays_uk_web_newheader',
+		},
+		{
+			title: 'Live events',
+			url: 'https://www.theguardian.com/guardian-live-events?INTCMP=live_uk_header_dropdown',
+		},
+		{
+			title: 'About Us',
+			url: '/about',
+		},
+		{
+			title: 'Digital Archive',
+			url: 'https://theguardian.newspapers.com',
+		},
+		{
+			title: 'Guardian Print Shop',
+			url: '/artanddesign/series/gnm-print-sales',
+		},
+		{
+			title: 'Patrons',
+			url: 'https://patrons.theguardian.com/?INTCMP=header_patrons',
+		},
+		{
+			title: 'Guardian Licensing',
+			url: 'https://licensing.theguardian.com/',
+		},
+	],
+	currentNavLinkTitle: 'News',
+	currentPillarTitle: 'News',
+	subNavSections: {
+		links: [
+			{
+				title: 'UK',
+				url: '/uk-news',
+				longTitle: 'UK news',
+				children: [
+					{
+						title: 'UK politics',
+						url: '/politics',
+					},
+					{
+						title: 'Education',
+						url: '/education',
+						children: [
+							{
+								title: 'Schools',
+								url: '/education/schools',
+							},
+							{
+								title: 'Teachers',
+								url: '/teacher-network',
+							},
+							{
+								title: 'Universities',
+								url: '/education/universities',
+							},
+							{
+								title: 'Students',
+								url: '/education/students',
+							},
+						],
+					},
+					{
+						title: 'Media',
+						url: '/media',
+					},
+					{
+						title: 'Society',
+						url: '/society',
+					},
+					{
+						title: 'Law',
+						url: '/law',
+					},
+					{
+						title: 'Scotland',
+						url: '/uk/scotland',
+					},
+					{
+						title: 'Wales',
+						url: '/uk/wales',
+					},
+					{
+						title: 'Northern Ireland',
+						url: '/uk/northernireland',
+					},
+				],
+			},
+			{
+				title: 'World',
+				url: '/world',
+				longTitle: 'World news',
+				children: [
+					{
+						title: 'Europe',
+						url: '/world/europe-news',
+					},
+					{
+						title: 'US',
+						url: '/us-news',
+						longTitle: 'US news',
+					},
+					{
+						title: 'Americas',
+						url: '/world/americas',
+					},
+					{
+						title: 'Asia',
+						url: '/world/asia',
+					},
+					{
+						title: 'Australia',
+						url: '/australia-news',
+						longTitle: 'Australia news',
+					},
+					{
+						title: 'Middle East',
+						url: '/world/middleeast',
+					},
+					{
+						title: 'Africa',
+						url: '/world/africa',
+					},
+					{
+						title: 'Inequality',
+						url: '/inequality',
+					},
+					{
+						title: 'Global development',
+						url: '/global-development',
+					},
+				],
+			},
+			{
+				title: 'Climate crisis',
+				url: '/environment/climate-crisis',
+			},
+			{
+				title: 'Ukraine',
+				url: '/world/ukraine',
+			},
+			{
+				title: 'Football',
+				url: '/football',
+				children: [
+					{
+						title: 'Live scores',
+						url: '/football/live',
+						longTitle: 'football/live',
+					},
+					{
+						title: 'Tables',
+						url: '/football/tables',
+						longTitle: 'football/tables',
+					},
+					{
+						title: 'Fixtures',
+						url: '/football/fixtures',
+						longTitle: 'football/fixtures',
+					},
+					{
+						title: 'Results',
+						url: '/football/results',
+						longTitle: 'football/results',
+					},
+					{
+						title: 'Competitions',
+						url: '/football/competitions',
+						longTitle: 'football/competitions',
+					},
+					{
+						title: 'Clubs',
+						url: '/football/teams',
+						longTitle: 'football/teams',
+					},
+				],
+			},
+			{
+				title: 'Newsletters',
+				url: '/email-newsletters',
+			},
+			{
+				title: 'Business',
+				url: '/business',
+				children: [
+					{
+						title: 'Economics',
+						url: '/business/economics',
+					},
+					{
+						title: 'Banking',
+						url: '/business/banking',
+					},
+					{
+						title: 'Money',
+						url: '/money',
+						children: [
+							{
+								title: 'Property',
+								url: '/money/property',
+							},
+							{
+								title: 'Pensions',
+								url: '/money/pensions',
+							},
+							{
+								title: 'Savings',
+								url: '/money/savings',
+							},
+							{
+								title: 'Borrowing',
+								url: '/money/debt',
+							},
+							{
+								title: 'Careers',
+								url: '/money/work-and-careers',
+							},
+						],
+					},
+					{
+						title: 'Markets',
+						url: '/business/stock-markets',
+					},
+					{
+						title: 'Project Syndicate',
+						url: '/business/series/project-syndicate-economists',
+					},
+					{
+						title: 'B2B',
+						url: '/business-to-business',
+					},
+					{
+						title: 'Retail',
+						url: '/business/retail',
+					},
+				],
+			},
+			{
+				title: 'Environment',
+				url: '/environment',
+				children: [
+					{
+						title: 'Climate crisis',
+						url: '/environment/climate-crisis',
+					},
+					{
+						title: 'Wildlife',
+						url: '/environment/wildlife',
+					},
+					{
+						title: 'Energy',
+						url: '/environment/energy',
+					},
+					{
+						title: 'Pollution',
+						url: '/environment/pollution',
+					},
+				],
+			},
+			{
+				title: 'UK politics',
+				url: '/politics',
+			},
+			{
+				title: 'Education',
+				url: '/education',
+				children: [
+					{
+						title: 'Schools',
+						url: '/education/schools',
+					},
+					{
+						title: 'Teachers',
+						url: '/teacher-network',
+					},
+					{
+						title: 'Universities',
+						url: '/education/universities',
+					},
+					{
+						title: 'Students',
+						url: '/education/students',
+					},
+				],
+			},
+			{
+				title: 'Society',
+				url: '/society',
+			},
+			{
+				title: 'Science',
+				url: '/science',
+			},
+			{
+				title: 'Tech',
+				url: '/technology',
+			},
+			{
+				title: 'Global development',
+				url: '/global-development',
+			},
+			{
+				title: 'Obituaries',
+				url: '/obituaries',
+			},
+		],
+	},
+	readerRevenueLinks: {
+		header: {
+			contribute:
+				'https://support.theguardian.com/contribute?INTCMP=header_support_contribute&acquisitionData=%7B%22source%22:%22GUARDIAN_WEB%22,%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22header_support_contribute%22%7D',
+			subscribe:
+				'https://support.theguardian.com/subscribe?INTCMP=header_support_subscribe&acquisitionData=%7B%22source%22:%22GUARDIAN_WEB%22,%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22header_support_subscribe%22%7D',
+			support:
+				'https://support.theguardian.com?INTCMP=header_support&acquisitionData=%7B%22source%22:%22GUARDIAN_WEB%22,%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22header_support%22%7D',
+			supporter:
+				'https://support.theguardian.com/subscribe?INTCMP=header_supporter_cta&acquisitionData=%7B%22source%22:%22GUARDIAN_WEB%22,%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22header_supporter_cta%22%7D',
+		},
+		footer: {
+			contribute:
+				'https://support.theguardian.com/contribute?INTCMP=footer_support_contribute&acquisitionData=%7B%22source%22:%22GUARDIAN_WEB%22,%22componentType%22:%22ACQUISITIONS_FOOTER%22,%22componentId%22:%22footer_support_contribute%22%7D',
+			subscribe:
+				'https://support.theguardian.com/subscribe?INTCMP=footer_support_subscribe&acquisitionData=%7B%22source%22:%22GUARDIAN_WEB%22,%22componentType%22:%22ACQUISITIONS_FOOTER%22,%22componentId%22:%22footer_support_subscribe%22%7D',
+			support:
+				'https://support.theguardian.com?INTCMP=footer_support&acquisitionData=%7B%22source%22:%22GUARDIAN_WEB%22,%22componentType%22:%22ACQUISITIONS_FOOTER%22,%22componentId%22:%22footer_support%22%7D',
+			supporter:
+				'https://support.theguardian.com/subscribe?INTCMP=footer_supporter_cta&acquisitionData=%7B%22source%22:%22GUARDIAN_WEB%22,%22componentType%22:%22ACQUISITIONS_FOOTER%22,%22componentId%22:%22footer_supporter_cta%22%7D',
+		},
+		sideMenu: {
+			contribute:
+				'https://support.theguardian.com/contribute?INTCMP=side_menu_support_contribute&acquisitionData=%7B%22source%22:%22GUARDIAN_WEB%22,%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22side_menu_support_contribute%22%7D',
+			subscribe:
+				'https://support.theguardian.com/subscribe?INTCMP=side_menu_support_subscribe&acquisitionData=%7B%22source%22:%22GUARDIAN_WEB%22,%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22side_menu_support_subscribe%22%7D',
+			support:
+				'https://support.theguardian.com?INTCMP=side_menu_support&acquisitionData=%7B%22source%22:%22GUARDIAN_WEB%22,%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22side_menu_support%22%7D',
+			supporter:
+				'https://support.theguardian.com/subscribe?INTCMP=mobilenav_print_cta&acquisitionData=%7B%22source%22:%22GUARDIAN_WEB%22,%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22mobilenav_print_cta%22%7D',
+		},
+		ampHeader: {
+			contribute:
+				'https://support.theguardian.com/contribute?INTCMP=header_support_contribute&acquisitionData=%7B%22source%22:%22GUARDIAN_WEB%22,%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22header_support_contribute%22%7D',
+			subscribe:
+				'https://support.theguardian.com/subscribe?INTCMP=header_support_subscribe&acquisitionData=%7B%22source%22:%22GUARDIAN_WEB%22,%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22header_support_subscribe%22%7D',
+			support:
+				'https://support.theguardian.com?INTCMP=amp_header_support&acquisitionData=%7B%22source%22:%22GUARDIAN_WEB%22,%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22amp_header_support%22%7D',
+			supporter:
+				'https://support.theguardian.com/subscribe?INTCMP=header_supporter_cta&acquisitionData=%7B%22source%22:%22GUARDIAN_WEB%22,%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22header_supporter_cta%22%7D',
+		},
+		ampFooter: {
+			contribute:
+				'https://support.theguardian.com/contribute?INTCMP=amp_footer_support_contribute&acquisitionData=%7B%22source%22:%22GUARDIAN_WEB%22,%22componentType%22:%22ACQUISITIONS_FOOTER%22,%22componentId%22:%22amp_footer_support_contribute%22%7D',
+			subscribe:
+				'https://support.theguardian.com/subscribe?INTCMP=amp_footer_support_subscribe&acquisitionData=%7B%22source%22:%22GUARDIAN_WEB%22,%22componentType%22:%22ACQUISITIONS_FOOTER%22,%22componentId%22:%22amp_footer_support_subscribe%22%7D',
+			support:
+				'https://support.theguardian.com?INTCMP=footer_support&acquisitionData=%7B%22source%22:%22GUARDIAN_WEB%22,%22componentType%22:%22ACQUISITIONS_FOOTER%22,%22componentId%22:%22footer_support%22%7D',
+			supporter:
+				'https://support.theguardian.com/subscribe?INTCMP=amp_footer_supporter_cta&acquisitionData=%7B%22source%22:%22GUARDIAN_WEB%22,%22componentType%22:%22ACQUISITIONS_FOOTER%22,%22componentId%22:%22amp_footer_supporter_cta%22%7D',
+		},
+	},
+} satisfies FENavType;

--- a/dotcom-rendering/fixtures/manual/nav-world.ts
+++ b/dotcom-rendering/fixtures/manual/nav-world.ts
@@ -1,0 +1,843 @@
+/** `xhs https://www.theguardian.com/world.json | jq .config.nav | pbcopy` */
+export const navWorld = {
+	currentUrl: '/world',
+	pillars: [
+		{
+			title: 'News',
+			url: '/',
+			longTitle: 'Headlines',
+			iconName: 'home',
+			children: [
+				{
+					title: 'UK',
+					url: '/uk-news',
+					longTitle: 'UK news',
+					children: [
+						{
+							title: 'UK politics',
+							url: '/politics',
+						},
+						{
+							title: 'Education',
+							url: '/education',
+							children: [
+								{
+									title: 'Schools',
+									url: '/education/schools',
+								},
+								{
+									title: 'Teachers',
+									url: '/teacher-network',
+								},
+								{
+									title: 'Universities',
+									url: '/education/universities',
+								},
+								{
+									title: 'Students',
+									url: '/education/students',
+								},
+							],
+						},
+						{
+							title: 'Media',
+							url: '/media',
+						},
+						{
+							title: 'Society',
+							url: '/society',
+						},
+						{
+							title: 'Law',
+							url: '/law',
+						},
+						{
+							title: 'Scotland',
+							url: '/uk/scotland',
+						},
+						{
+							title: 'Wales',
+							url: '/uk/wales',
+						},
+						{
+							title: 'Northern Ireland',
+							url: '/uk/northernireland',
+						},
+					],
+				},
+				{
+					title: 'World',
+					url: '/world',
+					longTitle: 'World news',
+					children: [
+						{
+							title: 'Europe',
+							url: '/world/europe-news',
+						},
+						{
+							title: 'US',
+							url: '/us-news',
+							longTitle: 'US news',
+						},
+						{
+							title: 'Americas',
+							url: '/world/americas',
+						},
+						{
+							title: 'Asia',
+							url: '/world/asia',
+						},
+						{
+							title: 'Australia',
+							url: '/australia-news',
+							longTitle: 'Australia news',
+						},
+						{
+							title: 'Middle East',
+							url: '/world/middleeast',
+						},
+						{
+							title: 'Africa',
+							url: '/world/africa',
+						},
+						{
+							title: 'Inequality',
+							url: '/inequality',
+						},
+						{
+							title: 'Global development',
+							url: '/global-development',
+						},
+					],
+				},
+				{
+					title: 'Climate crisis',
+					url: '/environment/climate-crisis',
+				},
+				{
+					title: 'Ukraine',
+					url: '/world/ukraine',
+				},
+				{
+					title: 'Football',
+					url: '/football',
+					children: [
+						{
+							title: 'Live scores',
+							url: '/football/live',
+							longTitle: 'football/live',
+						},
+						{
+							title: 'Tables',
+							url: '/football/tables',
+							longTitle: 'football/tables',
+						},
+						{
+							title: 'Fixtures',
+							url: '/football/fixtures',
+							longTitle: 'football/fixtures',
+						},
+						{
+							title: 'Results',
+							url: '/football/results',
+							longTitle: 'football/results',
+						},
+						{
+							title: 'Competitions',
+							url: '/football/competitions',
+							longTitle: 'football/competitions',
+						},
+						{
+							title: 'Clubs',
+							url: '/football/teams',
+							longTitle: 'football/teams',
+						},
+					],
+				},
+				{
+					title: 'Newsletters',
+					url: '/email-newsletters',
+				},
+				{
+					title: 'Business',
+					url: '/business',
+					children: [
+						{
+							title: 'Economics',
+							url: '/business/economics',
+						},
+						{
+							title: 'Banking',
+							url: '/business/banking',
+						},
+						{
+							title: 'Money',
+							url: '/money',
+							children: [
+								{
+									title: 'Property',
+									url: '/money/property',
+								},
+								{
+									title: 'Pensions',
+									url: '/money/pensions',
+								},
+								{
+									title: 'Savings',
+									url: '/money/savings',
+								},
+								{
+									title: 'Borrowing',
+									url: '/money/debt',
+								},
+								{
+									title: 'Careers',
+									url: '/money/work-and-careers',
+								},
+							],
+						},
+						{
+							title: 'Markets',
+							url: '/business/stock-markets',
+						},
+						{
+							title: 'Project Syndicate',
+							url: '/business/series/project-syndicate-economists',
+						},
+						{
+							title: 'B2B',
+							url: '/business-to-business',
+						},
+						{
+							title: 'Retail',
+							url: '/business/retail',
+						},
+					],
+				},
+				{
+					title: 'Environment',
+					url: '/environment',
+					children: [
+						{
+							title: 'Climate crisis',
+							url: '/environment/climate-crisis',
+						},
+						{
+							title: 'Wildlife',
+							url: '/environment/wildlife',
+						},
+						{
+							title: 'Energy',
+							url: '/environment/energy',
+						},
+						{
+							title: 'Pollution',
+							url: '/environment/pollution',
+						},
+					],
+				},
+				{
+					title: 'UK politics',
+					url: '/politics',
+				},
+				{
+					title: 'Education',
+					url: '/education',
+					children: [
+						{
+							title: 'Schools',
+							url: '/education/schools',
+						},
+						{
+							title: 'Teachers',
+							url: '/teacher-network',
+						},
+						{
+							title: 'Universities',
+							url: '/education/universities',
+						},
+						{
+							title: 'Students',
+							url: '/education/students',
+						},
+					],
+				},
+				{
+					title: 'Society',
+					url: '/society',
+				},
+				{
+					title: 'Science',
+					url: '/science',
+				},
+				{
+					title: 'Tech',
+					url: '/technology',
+				},
+				{
+					title: 'Global development',
+					url: '/global-development',
+				},
+				{
+					title: 'Obituaries',
+					url: '/obituaries',
+				},
+			],
+		},
+		{
+			title: 'Opinion',
+			url: '/commentisfree',
+			longTitle: 'Opinion home',
+			iconName: 'home',
+			children: [
+				{
+					title: 'The Guardian view',
+					url: '/profile/editorial',
+				},
+				{
+					title: 'Columnists',
+					url: '/index/contributors',
+				},
+				{
+					title: 'Cartoons',
+					url: '/tone/cartoons',
+				},
+				{
+					title: 'Opinion videos',
+					url: '/type/video+tone/comment',
+				},
+				{
+					title: 'Letters',
+					url: '/tone/letters',
+				},
+			],
+		},
+		{
+			title: 'Sport',
+			url: '/sport',
+			longTitle: 'Sport home',
+			iconName: 'home',
+			children: [
+				{
+					title: 'Football',
+					url: '/football',
+					children: [
+						{
+							title: 'Live scores',
+							url: '/football/live',
+							longTitle: 'football/live',
+						},
+						{
+							title: 'Tables',
+							url: '/football/tables',
+							longTitle: 'football/tables',
+						},
+						{
+							title: 'Fixtures',
+							url: '/football/fixtures',
+							longTitle: 'football/fixtures',
+						},
+						{
+							title: 'Results',
+							url: '/football/results',
+							longTitle: 'football/results',
+						},
+						{
+							title: 'Competitions',
+							url: '/football/competitions',
+							longTitle: 'football/competitions',
+						},
+						{
+							title: 'Clubs',
+							url: '/football/teams',
+							longTitle: 'football/teams',
+						},
+					],
+				},
+				{
+					title: 'Cricket',
+					url: '/sport/cricket',
+				},
+				{
+					title: 'Rugby union',
+					url: '/sport/rugby-union',
+				},
+				{
+					title: 'Tennis',
+					url: '/sport/tennis',
+				},
+				{
+					title: 'Cycling',
+					url: '/sport/cycling',
+				},
+				{
+					title: 'F1',
+					url: '/sport/formulaone',
+				},
+				{
+					title: 'Golf',
+					url: '/sport/golf',
+				},
+				{
+					title: 'Boxing',
+					url: '/sport/boxing',
+				},
+				{
+					title: 'Rugby league',
+					url: '/sport/rugbyleague',
+				},
+				{
+					title: 'Racing',
+					url: '/sport/horse-racing',
+				},
+				{
+					title: 'US sports',
+					url: '/sport/us-sport',
+				},
+			],
+		},
+		{
+			title: 'Culture',
+			url: '/culture',
+			longTitle: 'Culture home',
+			iconName: 'home',
+			children: [
+				{
+					title: 'Film',
+					url: '/film',
+				},
+				{
+					title: 'Music',
+					url: '/music',
+				},
+				{
+					title: 'TV & radio',
+					url: '/tv-and-radio',
+				},
+				{
+					title: 'Books',
+					url: '/books',
+				},
+				{
+					title: 'Art & design',
+					url: '/artanddesign',
+				},
+				{
+					title: 'Stage',
+					url: '/stage',
+				},
+				{
+					title: 'Games',
+					url: '/games',
+				},
+				{
+					title: 'Classical',
+					url: '/music/classicalmusicandopera',
+				},
+			],
+		},
+		{
+			title: 'Lifestyle',
+			url: '/lifeandstyle',
+			longTitle: 'Lifestyle home',
+			iconName: 'home',
+			children: [
+				{
+					title: 'Fashion',
+					url: '/fashion',
+				},
+				{
+					title: 'Food',
+					url: '/food',
+				},
+				{
+					title: 'Recipes',
+					url: '/tone/recipes',
+				},
+				{
+					title: 'Travel',
+					url: '/travel',
+					children: [
+						{
+							title: 'UK',
+							url: '/travel/uk',
+						},
+						{
+							title: 'Europe',
+							url: '/travel/europe',
+						},
+						{
+							title: 'US',
+							url: '/travel/usa',
+						},
+					],
+				},
+				{
+					title: 'Health & fitness',
+					url: '/lifeandstyle/health-and-wellbeing',
+				},
+				{
+					title: 'Women',
+					url: '/lifeandstyle/women',
+				},
+				{
+					title: 'Men',
+					url: '/lifeandstyle/men',
+				},
+				{
+					title: 'Love & sex',
+					url: '/lifeandstyle/love-and-sex',
+				},
+				{
+					title: 'Beauty',
+					url: '/fashion/beauty',
+				},
+				{
+					title: 'Home & garden',
+					url: '/lifeandstyle/home-and-garden',
+				},
+				{
+					title: 'Money',
+					url: '/money',
+					children: [
+						{
+							title: 'Property',
+							url: '/money/property',
+						},
+						{
+							title: 'Pensions',
+							url: '/money/pensions',
+						},
+						{
+							title: 'Savings',
+							url: '/money/savings',
+						},
+						{
+							title: 'Borrowing',
+							url: '/money/debt',
+						},
+						{
+							title: 'Careers',
+							url: '/money/work-and-careers',
+						},
+					],
+				},
+				{
+					title: 'Cars',
+					url: '/technology/motoring',
+				},
+			],
+		},
+	],
+	otherLinks: [
+		{
+			title: 'The Guardian app',
+			url: 'https://app.adjust.com/16xt6hai',
+		},
+		{
+			title: 'Video',
+			url: '/video',
+		},
+		{
+			title: 'Podcasts',
+			url: '/podcasts',
+		},
+		{
+			title: 'Pictures',
+			url: '/inpictures',
+		},
+		{
+			title: 'Newsletters',
+			url: '/email-newsletters',
+		},
+		{
+			title: "Today's paper",
+			url: '/theguardian',
+			children: [
+				{
+					title: 'Obituaries',
+					url: '/obituaries',
+				},
+				{
+					title: 'G2',
+					url: '/theguardian/g2',
+				},
+				{
+					title: 'Journal',
+					url: '/theguardian/journal',
+				},
+				{
+					title: 'Saturday',
+					url: '/theguardian/saturday',
+				},
+			],
+		},
+		{
+			title: 'Inside the Guardian',
+			url: 'https://www.theguardian.com/membership',
+		},
+		{
+			title: 'The Observer',
+			url: '/observer',
+			children: [
+				{
+					title: 'Comment',
+					url: '/theobserver/news/comment',
+				},
+				{
+					title: 'The New Review',
+					url: '/theobserver/new-review',
+				},
+				{
+					title: 'Observer Magazine',
+					url: '/theobserver/magazine',
+				},
+				{
+					title: 'Observer Food Monthly',
+					url: '/theobserver/foodmonthly',
+				},
+			],
+		},
+		{
+			title: 'Guardian Weekly',
+			url: 'https://www.theguardian.com/weekly?INTCMP=gdnwb_mawns_editorial_gweekly_GW_TopNav_UK',
+		},
+		{
+			title: 'Crosswords',
+			url: '/crosswords',
+			children: [
+				{
+					title: 'Blog',
+					url: '/crosswords/crossword-blog',
+				},
+				{
+					title: 'Quick',
+					url: '/crosswords/series/quick',
+				},
+				{
+					title: 'Speedy',
+					url: '/crosswords/series/speedy',
+				},
+				{
+					title: 'Quick cryptic',
+					url: '/crosswords/series/quick-cryptic',
+				},
+				{
+					title: 'Everyman',
+					url: '/crosswords/series/everyman',
+				},
+				{
+					title: 'Quiptic',
+					url: '/crosswords/series/quiptic',
+				},
+				{
+					title: 'Cryptic',
+					url: '/crosswords/series/cryptic',
+				},
+				{
+					title: 'Prize',
+					url: '/crosswords/series/prize',
+				},
+				{
+					title: 'Azed',
+					url: '/crosswords/series/azed',
+				},
+				{
+					title: 'Genius',
+					url: '/crosswords/series/genius',
+				},
+				{
+					title: 'Weekend',
+					url: '/crosswords/series/weekend-crossword',
+				},
+			],
+		},
+		{
+			title: 'Wordiply',
+			url: 'https://www.wordiply.com',
+		},
+		{
+			title: 'Corrections',
+			url: '/theguardian/series/corrections-and-clarifications',
+		},
+	],
+	brandExtensions: [
+		{
+			title: 'Search jobs',
+			url: 'https://jobs.theguardian.com',
+		},
+		{
+			title: 'Hire with Guardian Jobs',
+			url: 'https://recruiters.theguardian.com/?utm_source=gdnwb&utm_medium=navbar&utm_campaign=Guardian_Navbar_Recruiters&CMP_TU=trdmkt&CMP_BUNIT=jobs',
+		},
+		{
+			title: 'Holidays',
+			url: 'https://holidays.theguardian.com?INTCMP=holidays_uk_web_newheader',
+		},
+		{
+			title: 'Live events',
+			url: 'https://www.theguardian.com/guardian-live-events?INTCMP=live_uk_header_dropdown',
+		},
+		{
+			title: 'About Us',
+			url: '/about',
+		},
+		{
+			title: 'Digital Archive',
+			url: 'https://theguardian.newspapers.com',
+		},
+		{
+			title: 'Guardian Print Shop',
+			url: '/artanddesign/series/gnm-print-sales',
+		},
+		{
+			title: 'Patrons',
+			url: 'https://patrons.theguardian.com/?INTCMP=header_patrons',
+		},
+		{
+			title: 'Guardian Licensing',
+			url: 'https://licensing.theguardian.com/',
+		},
+	],
+	currentNavLinkTitle: 'World',
+	currentPillarTitle: 'News',
+	subNavSections: {
+		parent: {
+			title: 'World',
+			url: '/world',
+			longTitle: 'World news',
+			children: [
+				{
+					title: 'Europe',
+					url: '/world/europe-news',
+				},
+				{
+					title: 'US',
+					url: '/us-news',
+					longTitle: 'US news',
+				},
+				{
+					title: 'Americas',
+					url: '/world/americas',
+				},
+				{
+					title: 'Asia',
+					url: '/world/asia',
+				},
+				{
+					title: 'Australia',
+					url: '/australia-news',
+					longTitle: 'Australia news',
+				},
+				{
+					title: 'Middle East',
+					url: '/world/middleeast',
+				},
+				{
+					title: 'Africa',
+					url: '/world/africa',
+				},
+				{
+					title: 'Inequality',
+					url: '/inequality',
+				},
+				{
+					title: 'Global development',
+					url: '/global-development',
+				},
+			],
+		},
+		links: [
+			{
+				title: 'Europe',
+				url: '/world/europe-news',
+			},
+			{
+				title: 'US',
+				url: '/us-news',
+				longTitle: 'US news',
+			},
+			{
+				title: 'Americas',
+				url: '/world/americas',
+			},
+			{
+				title: 'Asia',
+				url: '/world/asia',
+			},
+			{
+				title: 'Australia',
+				url: '/australia-news',
+				longTitle: 'Australia news',
+			},
+			{
+				title: 'Middle East',
+				url: '/world/middleeast',
+			},
+			{
+				title: 'Africa',
+				url: '/world/africa',
+			},
+			{
+				title: 'Inequality',
+				url: '/inequality',
+			},
+			{
+				title: 'Global development',
+				url: '/global-development',
+			},
+		],
+	},
+	readerRevenueLinks: {
+		header: {
+			contribute:
+				'https://support.theguardian.com/contribute?INTCMP=header_support_contribute&acquisitionData=%7B%22source%22:%22GUARDIAN_WEB%22,%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22header_support_contribute%22%7D',
+			subscribe:
+				'https://support.theguardian.com/subscribe?INTCMP=header_support_subscribe&acquisitionData=%7B%22source%22:%22GUARDIAN_WEB%22,%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22header_support_subscribe%22%7D',
+			support:
+				'https://support.theguardian.com?INTCMP=header_support&acquisitionData=%7B%22source%22:%22GUARDIAN_WEB%22,%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22header_support%22%7D',
+			supporter:
+				'https://support.theguardian.com/subscribe?INTCMP=header_supporter_cta&acquisitionData=%7B%22source%22:%22GUARDIAN_WEB%22,%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22header_supporter_cta%22%7D',
+		},
+		footer: {
+			contribute:
+				'https://support.theguardian.com/contribute?INTCMP=footer_support_contribute&acquisitionData=%7B%22source%22:%22GUARDIAN_WEB%22,%22componentType%22:%22ACQUISITIONS_FOOTER%22,%22componentId%22:%22footer_support_contribute%22%7D',
+			subscribe:
+				'https://support.theguardian.com/subscribe?INTCMP=footer_support_subscribe&acquisitionData=%7B%22source%22:%22GUARDIAN_WEB%22,%22componentType%22:%22ACQUISITIONS_FOOTER%22,%22componentId%22:%22footer_support_subscribe%22%7D',
+			support:
+				'https://support.theguardian.com?INTCMP=footer_support&acquisitionData=%7B%22source%22:%22GUARDIAN_WEB%22,%22componentType%22:%22ACQUISITIONS_FOOTER%22,%22componentId%22:%22footer_support%22%7D',
+			supporter:
+				'https://support.theguardian.com/subscribe?INTCMP=footer_supporter_cta&acquisitionData=%7B%22source%22:%22GUARDIAN_WEB%22,%22componentType%22:%22ACQUISITIONS_FOOTER%22,%22componentId%22:%22footer_supporter_cta%22%7D',
+		},
+		sideMenu: {
+			contribute:
+				'https://support.theguardian.com/contribute?INTCMP=side_menu_support_contribute&acquisitionData=%7B%22source%22:%22GUARDIAN_WEB%22,%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22side_menu_support_contribute%22%7D',
+			subscribe:
+				'https://support.theguardian.com/subscribe?INTCMP=side_menu_support_subscribe&acquisitionData=%7B%22source%22:%22GUARDIAN_WEB%22,%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22side_menu_support_subscribe%22%7D',
+			support:
+				'https://support.theguardian.com?INTCMP=side_menu_support&acquisitionData=%7B%22source%22:%22GUARDIAN_WEB%22,%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22side_menu_support%22%7D',
+			supporter:
+				'https://support.theguardian.com/subscribe?INTCMP=mobilenav_print_cta&acquisitionData=%7B%22source%22:%22GUARDIAN_WEB%22,%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22mobilenav_print_cta%22%7D',
+		},
+		ampHeader: {
+			contribute:
+				'https://support.theguardian.com/contribute?INTCMP=header_support_contribute&acquisitionData=%7B%22source%22:%22GUARDIAN_WEB%22,%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22header_support_contribute%22%7D',
+			subscribe:
+				'https://support.theguardian.com/subscribe?INTCMP=header_support_subscribe&acquisitionData=%7B%22source%22:%22GUARDIAN_WEB%22,%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22header_support_subscribe%22%7D',
+			support:
+				'https://support.theguardian.com?INTCMP=amp_header_support&acquisitionData=%7B%22source%22:%22GUARDIAN_WEB%22,%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22amp_header_support%22%7D',
+			supporter:
+				'https://support.theguardian.com/subscribe?INTCMP=header_supporter_cta&acquisitionData=%7B%22source%22:%22GUARDIAN_WEB%22,%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22header_supporter_cta%22%7D',
+		},
+		ampFooter: {
+			contribute:
+				'https://support.theguardian.com/contribute?INTCMP=amp_footer_support_contribute&acquisitionData=%7B%22source%22:%22GUARDIAN_WEB%22,%22componentType%22:%22ACQUISITIONS_FOOTER%22,%22componentId%22:%22amp_footer_support_contribute%22%7D',
+			subscribe:
+				'https://support.theguardian.com/subscribe?INTCMP=amp_footer_support_subscribe&acquisitionData=%7B%22source%22:%22GUARDIAN_WEB%22,%22componentType%22:%22ACQUISITIONS_FOOTER%22,%22componentId%22:%22amp_footer_support_subscribe%22%7D',
+			support:
+				'https://support.theguardian.com?INTCMP=footer_support&acquisitionData=%7B%22source%22:%22GUARDIAN_WEB%22,%22componentType%22:%22ACQUISITIONS_FOOTER%22,%22componentId%22:%22footer_support%22%7D',
+			supporter:
+				'https://support.theguardian.com/subscribe?INTCMP=amp_footer_supporter_cta&acquisitionData=%7B%22source%22:%22GUARDIAN_WEB%22,%22componentType%22:%22ACQUISITIONS_FOOTER%22,%22componentId%22:%22amp_footer_supporter_cta%22%7D',
+		},
+	},
+} satisfies FENavType;

--- a/dotcom-rendering/src/components/SubNav.importable.tsx
+++ b/dotcom-rendering/src/components/SubNav.importable.tsx
@@ -8,6 +8,7 @@ import { palette } from '../palette';
 type Props = {
 	subNavSections: SubNavType;
 	currentNavLink: string;
+	position: 'header' | 'footer';
 };
 
 const wrapperCollapsedStyles = css`
@@ -55,7 +56,7 @@ const fontStyle = css`
 		font-size: 16px;
 	}
 	font-weight: 500;
-	color: ${palette('--sub-nav-link')};
+	color: var(--sub-nav-link);
 	padding: 0 5px;
 	height: 36px;
 	/* Design System: Line height is being used here for centering layout, we need the primitives */
@@ -133,7 +134,11 @@ const listItemStyles = css`
 	}
 `;
 
-export const SubNav = ({ subNavSections, currentNavLink }: Props) => {
+export const SubNav = ({
+	subNavSections,
+	currentNavLink,
+	position = 'header',
+}: Props) => {
 	const [showMore, setShowMore] = useState(false);
 	const [isExpanded, setIsExpanded] = useState(false);
 	const ulRef = useRef<HTMLUListElement>(null);
@@ -163,6 +168,12 @@ export const SubNav = ({ subNavSections, currentNavLink }: Props) => {
 			css={[collapseWrapper && wrapperCollapsedStyles, spaceBetween]}
 			data-testid="sub-nav"
 			data-component="sub-nav"
+			style={{
+				'--sub-nav-link':
+					position === 'header'
+						? palette('--sub-nav-link-header')
+						: palette('--sub-nav-link-footer'),
+			}}
 		>
 			{/* eslint-disable jsx-a11y/no-redundant-roles -- A11y fix for Safari {@see https://github.com/guardian/dotcom-rendering/pull/5041} */}
 			<ul

--- a/dotcom-rendering/src/components/SubNav.importable.tsx
+++ b/dotcom-rendering/src/components/SubNav.importable.tsx
@@ -1,21 +1,13 @@
 import { css } from '@emotion/react';
-import {
-	from,
-	palette,
-	text,
-	textSans15,
-	textSans17,
-} from '@guardian/source-foundations';
+import { from, textSans15, textSans17 } from '@guardian/source-foundations';
 import { useEffect, useRef, useState } from 'react';
 import { nestedOphanComponents } from '../lib/ophan-helpers';
 import type { SubNavType } from '../model/extract-nav';
+import { palette } from '../palette';
 
 type Props = {
 	subNavSections: SubNavType;
 	currentNavLink: string;
-	borderColour: string;
-	linkHoverColour: string;
-	subNavLinkColour?: string;
 };
 
 const wrapperCollapsedStyles = css`
@@ -55,7 +47,7 @@ const collapsedStyles = css`
 	}
 `;
 
-const fontStyle = (subNavLinkColour: string) => css`
+const fontStyle = css`
 	${textSans15};
 	font-size: 14px;
 	${from.tablet} {
@@ -63,7 +55,7 @@ const fontStyle = (subNavLinkColour: string) => css`
 		font-size: 16px;
 	}
 	font-weight: 500;
-	color: ${subNavLinkColour};
+	color: ${palette('--sub-nav-link')};
 	padding: 0 5px;
 	height: 36px;
 	/* Design System: Line height is being used here for centering layout, we need the primitives */
@@ -76,12 +68,12 @@ const fontStyle = (subNavLinkColour: string) => css`
 	}
 `;
 
-const linkStyle = (linkHoverColour: string) => css`
+const linkStyle = css`
 	float: left;
 	text-decoration: none;
 
 	:hover {
-		color: ${linkHoverColour};
+		color: ${palette('--sub-nav-link-hover')};
 	}
 
 	:focus {
@@ -112,10 +104,10 @@ const showMoreStyle = css`
 	cursor: pointer;
 	border: none;
 	background-color: transparent;
-	color: ${text.supporting};
+	color: ${palette('--sub-nav-more')};
 
 	:hover {
-		color: ${palette.news[400]};
+		color: ${palette('--sub-nav-link-hover')};
 	}
 
 	${from.desktop} {
@@ -123,7 +115,7 @@ const showMoreStyle = css`
 	}
 `;
 
-const listItemStyles = (borderColour: string) => css`
+const listItemStyles = css`
 	:after {
 		content: '';
 		display: inline-block;
@@ -131,10 +123,9 @@ const listItemStyles = (borderColour: string) => css`
 		height: 0;
 		border-top: 6px solid transparent;
 		border-bottom: 6px solid transparent;
-		border-left: 10px solid ${palette.neutral[7]};
+		border-left: 10px solid ${palette('--sub-nav-border')};
 		margin-top: 12px;
 		margin-left: 2px;
-		border-left-color: ${borderColour};
 
 		${from.tablet} {
 			margin-top: 16px;
@@ -142,13 +133,7 @@ const listItemStyles = (borderColour: string) => css`
 	}
 `;
 
-export const SubNav = ({
-	subNavSections,
-	currentNavLink,
-	borderColour,
-	linkHoverColour,
-	subNavLinkColour = palette.neutral[7],
-}: Props) => {
+export const SubNav = ({ subNavSections, currentNavLink }: Props) => {
 	const [showMore, setShowMore] = useState(false);
 	const [isExpanded, setIsExpanded] = useState(false);
 	const ulRef = useRef<HTMLUListElement>(null);
@@ -187,16 +172,10 @@ export const SubNav = ({
 			>
 				{/* eslint-enable jsx-a11y/no-redundant-roles */}
 				{subNavSections.parent && (
-					<li
-						key={subNavSections.parent.url}
-						css={listItemStyles(borderColour)}
-					>
+					<li key={subNavSections.parent.url} css={listItemStyles}>
 						<a
 							data-src-focus-disabled={true}
-							css={[
-								linkStyle(linkHoverColour),
-								fontStyle(subNavLinkColour),
-							]}
+							css={[linkStyle, fontStyle]}
 							href={subNavSections.parent.url}
 						>
 							{subNavSections.parent.title}
@@ -217,10 +196,7 @@ export const SubNav = ({
 						}
 					>
 						<a
-							css={[
-								linkStyle(linkHoverColour),
-								fontStyle(subNavLinkColour),
-							]}
+							css={[linkStyle, fontStyle]}
 							data-src-focus-disabled={true}
 							href={link.url}
 							data-link-name={nestedOphanComponents(

--- a/dotcom-rendering/src/components/SubNav.stories.tsx
+++ b/dotcom-rendering/src/components/SubNav.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { navInternational } from '../../fixtures/manual/nav-international';
+import { navWorld } from '../../fixtures/manual/nav-world';
+import { extractNAV } from '../model/extract-nav';
+import { SubNav as SubNavComponent } from './SubNav.importable';
+
+const meta = {
+	component: SubNavComponent,
+	parameters: {},
+} satisfies Meta<typeof SubNavComponent>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default = {
+	args: {
+		subNavSections: extractNAV(navInternational).subNavSections ?? {
+			links: [],
+		},
+		currentNavLink: '',
+	},
+} satisfies Story;
+
+export const World = {
+	args: {
+		subNavSections: extractNAV(navWorld).subNavSections ?? { links: [] },
+		currentNavLink: 'World',
+	},
+} satisfies Story;

--- a/dotcom-rendering/src/components/SubNav.stories.tsx
+++ b/dotcom-rendering/src/components/SubNav.stories.tsx
@@ -19,6 +19,7 @@ export const Default = {
 			links: [],
 		},
 		currentNavLink: '',
+		position: 'header',
 	},
 } satisfies Story;
 
@@ -26,5 +27,6 @@ export const World = {
 	args: {
 		subNavSections: extractNAV(navWorld).subNavSections ?? { links: [] },
 		currentNavLink: 'World',
+		position: 'footer',
 	},
 } satisfies Story;

--- a/dotcom-rendering/src/layouts/AllEditorialNewslettersPageLayout.tsx
+++ b/dotcom-rendering/src/layouts/AllEditorialNewslettersPageLayout.tsx
@@ -124,12 +124,6 @@ export const AllEditorialNewslettersPageLayout = ({
 									<SubNav
 										subNavSections={NAV.subNavSections}
 										currentNavLink={NAV.currentNavLink}
-										linkHoverColour={themePalette(
-											'--article-link-text-hover',
-										)}
-										borderColour={themePalette(
-											'--sub-nav-border',
-										)}
 									/>
 								</Island>
 							</Section>

--- a/dotcom-rendering/src/layouts/AllEditorialNewslettersPageLayout.tsx
+++ b/dotcom-rendering/src/layouts/AllEditorialNewslettersPageLayout.tsx
@@ -124,6 +124,7 @@ export const AllEditorialNewslettersPageLayout = ({
 									<SubNav
 										subNavSections={NAV.subNavSections}
 										currentNavLink={NAV.currentNavLink}
+										position="header"
 									/>
 								</Island>
 							</Section>

--- a/dotcom-rendering/src/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/layouts/CommentLayout.tsx
@@ -408,6 +408,7 @@ export const CommentLayout = (props: WebProps | AppsProps) => {
 										currentNavLink={
 											props.NAV.currentNavLink
 										}
+										position="footer"
 									/>
 								</Island>
 							</Section>
@@ -926,6 +927,7 @@ export const CommentLayout = (props: WebProps | AppsProps) => {
 						<SubNav
 							subNavSections={props.NAV.subNavSections}
 							currentNavLink={props.NAV.currentNavLink}
+							position="footer"
 						/>
 					</Island>
 				</Section>

--- a/dotcom-rendering/src/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/layouts/CommentLayout.tsx
@@ -408,12 +408,6 @@ export const CommentLayout = (props: WebProps | AppsProps) => {
 										currentNavLink={
 											props.NAV.currentNavLink
 										}
-										linkHoverColour={themePalette(
-											'--article-link-text-hover',
-										)}
-										borderColour={themePalette(
-											'--sub-nav-border',
-										)}
 									/>
 								</Island>
 							</Section>
@@ -932,10 +926,6 @@ export const CommentLayout = (props: WebProps | AppsProps) => {
 						<SubNav
 							subNavSections={props.NAV.subNavSections}
 							currentNavLink={props.NAV.currentNavLink}
-							linkHoverColour={themePalette(
-								'--article-link-text-hover',
-							)}
-							borderColour={themePalette('--sub-nav-border')}
 						/>
 					</Island>
 				</Section>

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -256,6 +256,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 									<SubNav
 										subNavSections={NAV.subNavSections}
 										currentNavLink={NAV.currentNavLink}
+										position="header"
 									/>
 								</Island>
 							</Section>
@@ -683,6 +684,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 						<SubNav
 							subNavSections={NAV.subNavSections}
 							currentNavLink={NAV.currentNavLink}
+							position="footer"
 						/>
 					</Island>
 				</Section>

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -256,10 +256,6 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 									<SubNav
 										subNavSections={NAV.subNavSections}
 										currentNavLink={NAV.currentNavLink}
-										linkHoverColour={
-											sourcePalette.news[400]
-										}
-										borderColour={sourcePalette.neutral[46]}
 									/>
 								</Island>
 							</Section>
@@ -687,8 +683,6 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 						<SubNav
 							subNavSections={NAV.subNavSections}
 							currentNavLink={NAV.currentNavLink}
-							linkHoverColour={sourcePalette.news[400]}
-							borderColour={sourcePalette.neutral[46]}
 						/>
 					</Island>
 				</Section>

--- a/dotcom-rendering/src/layouts/FullPageInteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/FullPageInteractiveLayout.tsx
@@ -271,10 +271,6 @@ const NavHeader = ({ article, NAV, format }: Props) => {
 						<SubNav
 							subNavSections={NAV.subNavSections}
 							currentNavLink={NAV.currentNavLink}
-							linkHoverColour={themePalette(
-								'--article-link-text-hover',
-							)}
-							borderColour={themePalette('--sub-nav-border')}
 						/>
 					</Island>
 				</Section>
@@ -360,10 +356,6 @@ export const FullPageInteractiveLayout = ({ article, NAV, format }: Props) => {
 						<SubNav
 							subNavSections={NAV.subNavSections}
 							currentNavLink={NAV.currentNavLink}
-							linkHoverColour={themePalette(
-								'--article-link-text-hover',
-							)}
-							borderColour={themePalette('--sub-nav-border')}
 						/>
 					</Island>
 				</Section>

--- a/dotcom-rendering/src/layouts/FullPageInteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/FullPageInteractiveLayout.tsx
@@ -271,6 +271,7 @@ const NavHeader = ({ article, NAV, format }: Props) => {
 						<SubNav
 							subNavSections={NAV.subNavSections}
 							currentNavLink={NAV.currentNavLink}
+							position="header"
 						/>
 					</Island>
 				</Section>
@@ -356,6 +357,7 @@ export const FullPageInteractiveLayout = ({ article, NAV, format }: Props) => {
 						<SubNav
 							subNavSections={NAV.subNavSections}
 							currentNavLink={NAV.currentNavLink}
+							position="footer"
 						/>
 					</Island>
 				</Section>

--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -949,6 +949,7 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 						<SubNav
 							subNavSections={props.NAV.subNavSections}
 							currentNavLink={props.NAV.currentNavLink}
+							position="footer"
 						/>
 					</Island>
 				</Section>

--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -949,10 +949,6 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 						<SubNav
 							subNavSections={props.NAV.subNavSections}
 							currentNavLink={props.NAV.currentNavLink}
-							linkHoverColour={themePalette(
-								'--article-link-text-hover',
-							)}
-							borderColour={themePalette('--sub-nav-border')}
 						/>
 					</Island>
 				</Section>

--- a/dotcom-rendering/src/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/InteractiveLayout.tsx
@@ -356,12 +356,6 @@ export const InteractiveLayout = (props: WebProps | AppsProps) => {
 											currentNavLink={
 												props.NAV.currentNavLink
 											}
-											linkHoverColour={themePalette(
-												'--article-link-text-hover',
-											)}
-											borderColour={themePalette(
-												'--sub-nav-border',
-											)}
 										/>
 									</Island>
 								</Section>
@@ -872,10 +866,6 @@ export const InteractiveLayout = (props: WebProps | AppsProps) => {
 						<SubNav
 							subNavSections={props.NAV.subNavSections}
 							currentNavLink={props.NAV.currentNavLink}
-							linkHoverColour={themePalette(
-								'--article-link-text-hover',
-							)}
-							borderColour={themePalette('--sub-nav-border')}
 						/>
 					</Island>
 				</Section>

--- a/dotcom-rendering/src/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/InteractiveLayout.tsx
@@ -356,6 +356,7 @@ export const InteractiveLayout = (props: WebProps | AppsProps) => {
 											currentNavLink={
 												props.NAV.currentNavLink
 											}
+											position="header"
 										/>
 									</Island>
 								</Section>
@@ -866,6 +867,7 @@ export const InteractiveLayout = (props: WebProps | AppsProps) => {
 						<SubNav
 							subNavSections={props.NAV.subNavSections}
 							currentNavLink={props.NAV.currentNavLink}
+							position="footer"
 						/>
 					</Island>
 				</Section>

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -408,6 +408,7 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 										currentNavLink={
 											props.NAV.currentNavLink
 										}
+										position="header"
 									/>
 								</Island>
 							</Section>
@@ -1361,6 +1362,7 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 								<SubNav
 									subNavSections={props.NAV.subNavSections}
 									currentNavLink={props.NAV.currentNavLink}
+									position="footer"
 								/>
 							</Island>
 						</Section>

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -408,12 +408,6 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 										currentNavLink={
 											props.NAV.currentNavLink
 										}
-										linkHoverColour={themePalette(
-											'--article-link-text-hover',
-										)}
-										borderColour={themePalette(
-											'--sub-nav-border',
-										)}
 									/>
 								</Island>
 							</Section>
@@ -1367,12 +1361,6 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 								<SubNav
 									subNavSections={props.NAV.subNavSections}
 									currentNavLink={props.NAV.currentNavLink}
-									linkHoverColour={themePalette(
-										'--article-link-text-hover',
-									)}
-									borderColour={themePalette(
-										'--sub-nav-border',
-									)}
 								/>
 							</Island>
 						</Section>

--- a/dotcom-rendering/src/layouts/NewsletterSignupLayout.tsx
+++ b/dotcom-rendering/src/layouts/NewsletterSignupLayout.tsx
@@ -300,12 +300,6 @@ export const NewsletterSignupLayout = ({ article, NAV, format }: Props) => {
 								<SubNav
 									subNavSections={NAV.subNavSections}
 									currentNavLink={NAV.currentNavLink}
-									linkHoverColour={themePalette(
-										'--article-link-text-hover',
-									)}
-									borderColour={themePalette(
-										'--sub-nav-border',
-									)}
 								/>
 							</Island>
 						</Section>

--- a/dotcom-rendering/src/layouts/NewsletterSignupLayout.tsx
+++ b/dotcom-rendering/src/layouts/NewsletterSignupLayout.tsx
@@ -300,6 +300,7 @@ export const NewsletterSignupLayout = ({ article, NAV, format }: Props) => {
 								<SubNav
 									subNavSections={NAV.subNavSections}
 									currentNavLink={NAV.currentNavLink}
+									position="header"
 								/>
 							</Island>
 						</Section>

--- a/dotcom-rendering/src/layouts/PictureLayout.tsx
+++ b/dotcom-rendering/src/layouts/PictureLayout.tsx
@@ -389,15 +389,6 @@ export const PictureLayout = (props: WebProps | AppsProps) => {
 										currentNavLink={
 											props.NAV.currentNavLink
 										}
-										linkHoverColour={themePalette(
-											'--article-link-text-hover',
-										)}
-										borderColour={themePalette(
-											'--sub-nav-border',
-										)}
-										subNavLinkColour={themePalette(
-											'--sub-nav-link',
-										)}
 									/>
 								</Island>
 							</Section>
@@ -819,10 +810,6 @@ export const PictureLayout = (props: WebProps | AppsProps) => {
 						<SubNav
 							subNavSections={props.NAV.subNavSections}
 							currentNavLink={props.NAV.currentNavLink}
-							linkHoverColour={themePalette(
-								'--article-link-text-hover',
-							)}
-							borderColour={themePalette('--sub-nav-border')}
 						/>
 					</Island>
 				</Section>

--- a/dotcom-rendering/src/layouts/PictureLayout.tsx
+++ b/dotcom-rendering/src/layouts/PictureLayout.tsx
@@ -389,6 +389,7 @@ export const PictureLayout = (props: WebProps | AppsProps) => {
 										currentNavLink={
 											props.NAV.currentNavLink
 										}
+										position="header"
 									/>
 								</Island>
 							</Section>
@@ -810,6 +811,7 @@ export const PictureLayout = (props: WebProps | AppsProps) => {
 						<SubNav
 							subNavSections={props.NAV.subNavSections}
 							currentNavLink={props.NAV.currentNavLink}
+							position="footer"
 						/>
 					</Island>
 				</Section>

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -367,6 +367,7 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 													currentNavLink={
 														props.NAV.currentNavLink
 													}
+													position="header"
 												/>
 											</Island>
 										</Section>
@@ -924,6 +925,7 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 						<SubNav
 							subNavSections={props.NAV.subNavSections}
 							currentNavLink={props.NAV.currentNavLink}
+							position="footer"
 						/>
 					</Island>
 				</Section>

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -367,15 +367,6 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 													currentNavLink={
 														props.NAV.currentNavLink
 													}
-													linkHoverColour={themePalette(
-														'--article-link-text-hover',
-													)}
-													borderColour={themePalette(
-														'--sub-nav-border',
-													)}
-													subNavLinkColour={themePalette(
-														'--sub-nav-link',
-													)}
 												/>
 											</Island>
 										</Section>
@@ -933,10 +924,6 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 						<SubNav
 							subNavSections={props.NAV.subNavSections}
 							currentNavLink={props.NAV.currentNavLink}
-							linkHoverColour={themePalette(
-								'--article-link-text-hover',
-							)}
-							borderColour={themePalette('--sub-nav-border')}
 						/>
 					</Island>
 				</Section>

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -509,6 +509,7 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 										currentNavLink={
 											props.NAV.currentNavLink
 										}
+										position="header"
 									/>
 								</Island>
 							</Section>
@@ -1097,6 +1098,7 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 								<SubNav
 									subNavSections={props.NAV.subNavSections}
 									currentNavLink={props.NAV.currentNavLink}
+									position="footer"
 								/>
 							</Island>
 						</Section>

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -509,15 +509,6 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 										currentNavLink={
 											props.NAV.currentNavLink
 										}
-										subNavLinkColour={themePalette(
-											'--sub-nav-link',
-										)}
-										linkHoverColour={themePalette(
-											'--article-link-text-hover',
-										)}
-										borderColour={themePalette(
-											'--sub-nav-border',
-										)}
 									/>
 								</Island>
 							</Section>
@@ -1106,15 +1097,6 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 								<SubNav
 									subNavSections={props.NAV.subNavSections}
 									currentNavLink={props.NAV.currentNavLink}
-									subNavLinkColour={themePalette(
-										'--sub-nav-link',
-									)}
-									linkHoverColour={themePalette(
-										'--article-link-text-hover',
-									)}
-									borderColour={themePalette(
-										'--sub-nav-border',
-									)}
 								/>
 							</Island>
 						</Section>

--- a/dotcom-rendering/src/layouts/TagPageLayout.tsx
+++ b/dotcom-rendering/src/layouts/TagPageLayout.tsx
@@ -154,8 +154,6 @@ export const TagPageLayout = ({ tagPage, NAV }: Props) => {
 									<SubNav
 										subNavSections={NAV.subNavSections}
 										currentNavLink={NAV.currentNavLink}
-										linkHoverColour={palette.news[400]}
-										borderColour={palette.neutral[46]}
 									/>
 								</Island>
 							</Section>
@@ -298,8 +296,6 @@ export const TagPageLayout = ({ tagPage, NAV }: Props) => {
 						<SubNav
 							subNavSections={NAV.subNavSections}
 							currentNavLink={NAV.currentNavLink}
-							linkHoverColour={palette.news[400]}
-							borderColour={palette.neutral[46]}
 						/>
 					</Island>
 				</Section>

--- a/dotcom-rendering/src/layouts/TagPageLayout.tsx
+++ b/dotcom-rendering/src/layouts/TagPageLayout.tsx
@@ -154,6 +154,7 @@ export const TagPageLayout = ({ tagPage, NAV }: Props) => {
 									<SubNav
 										subNavSections={NAV.subNavSections}
 										currentNavLink={NAV.currentNavLink}
+										position="header"
 									/>
 								</Island>
 							</Section>
@@ -296,6 +297,7 @@ export const TagPageLayout = ({ tagPage, NAV }: Props) => {
 						<SubNav
 							subNavSections={NAV.subNavSections}
 							currentNavLink={NAV.currentNavLink}
+							position="footer"
 						/>
 					</Island>
 				</Section>

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -3510,7 +3510,7 @@ const subNavBorder: PaletteFunction = ({ design, theme }) => {
 			}
 	}
 };
-const subNavLink = (format: ArticleFormat) => {
+const subNavLinkLight: PaletteFunction = (format) => {
 	switch (format.design) {
 		case ArticleDesign.Picture:
 		case ArticleDesign.Video:
@@ -3519,6 +3519,21 @@ const subNavLink = (format: ArticleFormat) => {
 		default:
 			return sourcePalette.neutral[7];
 	}
+};
+const subNavLinkDark: PaletteFunction = () => {
+	return sourcePalette.neutral[100];
+};
+const subNavLinkHoverLight: PaletteFunction = (format) => {
+	return articleLinkHoverLight(format);
+};
+const subNavLinkHoverDark: PaletteFunction = (format) => {
+	return articleLinkHoverDark(format);
+};
+const subNavMoreLight: PaletteFunction = () => {
+	return sourcePalette.neutral[60];
+};
+const subNavMoreDark: PaletteFunction = () => {
+	return sourcePalette.neutral[38];
 };
 
 const pullQuoteTextLight: PaletteFunction = ({
@@ -5825,8 +5840,16 @@ const paletteColours = {
 		dark: subNavBorder,
 	},
 	'--sub-nav-link': {
-		light: subNavLink,
-		dark: subNavLink,
+		light: subNavLinkLight,
+		dark: subNavLinkDark,
+	},
+	'--sub-nav-link-hover': {
+		light: subNavLinkHoverLight,
+		dark: subNavLinkHoverDark,
+	},
+	'--sub-nav-more': {
+		light: subNavMoreLight,
+		dark: subNavMoreDark,
 	},
 	'--share-button': {
 		light: shareButtonLight,

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -3510,7 +3510,7 @@ const subNavBorder: PaletteFunction = ({ design, theme }) => {
 			}
 	}
 };
-const subNavLinkLight: PaletteFunction = (format) => {
+const subNavLinkHeaderLight: PaletteFunction = (format) => {
 	switch (format.design) {
 		case ArticleDesign.Picture:
 		case ArticleDesign.Video:
@@ -3520,7 +3520,13 @@ const subNavLinkLight: PaletteFunction = (format) => {
 			return sourcePalette.neutral[7];
 	}
 };
-const subNavLinkDark: PaletteFunction = () => {
+const subNavLinkHeaderDark: PaletteFunction = () => {
+	return sourcePalette.neutral[100];
+};
+const subNavLinkFooterLight: PaletteFunction = () => {
+	return sourcePalette.neutral[7];
+};
+const subNavLinkFooterDark: PaletteFunction = () => {
 	return sourcePalette.neutral[100];
 };
 const subNavLinkHoverLight: PaletteFunction = (format) => {
@@ -5839,9 +5845,13 @@ const paletteColours = {
 		light: subNavBorder,
 		dark: subNavBorder,
 	},
-	'--sub-nav-link': {
-		light: subNavLinkLight,
-		dark: subNavLinkDark,
+	'--sub-nav-link-header': {
+		light: subNavLinkHeaderLight,
+		dark: subNavLinkHeaderDark,
+	},
+	'--sub-nav-link-footer': {
+		light: subNavLinkFooterLight,
+		dark: subNavLinkFooterDark,
 	},
 	'--sub-nav-link-hover': {
 		light: subNavLinkHoverLight,


### PR DESCRIPTION
## What does this change?

- Let SubNav take colours from palette

## Why?

- Simplifies interfaces and enables dark mode

## Screenshots

<img width="1297" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/76776/9dbd4b78-0ae3-44b0-b302-f0e926ef724b">

<img width="1299" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/76776/a0ae32f1-b84b-42f7-b2f0-0169849b84e1">
