### PR TITLE
Stop forcing only light colour scheme

### DIFF
--- a/dotcom-rendering/src/lib/rootStyles.ts
+++ b/dotcom-rendering/src/lib/rootStyles.ts
@@ -22,11 +22,11 @@ export const rootStyles = (
 			color: ${sourcePalette.neutral[7]};
 			background: ${sourcePalette.neutral[100]};
 		}
+		/* Indicate whether UI can adapt https://developer.mozilla.org/en-US/docs/Web/CSS/color-scheme */
+		color-scheme: ${darkModeAvailable ? 'light dark' : 'light'};
 		/* Dark palette only if supported */
 		${darkModeAvailable
 			? css`
-					/* Indicate whether UI can adapt https://developer.mozilla.org/en-US/docs/Web/CSS/color-scheme */
-					color-scheme: light dark;
 					@media (prefers-color-scheme: dark) {
 						${paletteDeclarations(format, 'dark')}
 						body {

--- a/dotcom-rendering/src/lib/rootStyles.ts
+++ b/dotcom-rendering/src/lib/rootStyles.ts
@@ -22,11 +22,11 @@ export const rootStyles = (
 			color: ${sourcePalette.neutral[7]};
 			background: ${sourcePalette.neutral[100]};
 		}
-		/* Indicate whether UI can adapt https://developer.mozilla.org/en-US/docs/Web/CSS/color-scheme */
-		color-scheme: ${darkModeAvailable ? 'light dark' : 'only light'};
 		/* Dark palette only if supported */
 		${darkModeAvailable
 			? css`
+					/* Indicate whether UI can adapt https://developer.mozilla.org/en-US/docs/Web/CSS/color-scheme */
+					color-scheme: light dark;
 					@media (prefers-color-scheme: dark) {
 						${paletteDeclarations(format, 'dark')}
 						body {


### PR DESCRIPTION
## What does this change?

Stop forcing only light mode if dark mode is unavailable.

## Why?

Reported as a bug for users with forced dark mode on Chromium browsers, [as raised here](https://github.com/guardian/dotcom-rendering/pull/11374#discussion_r1589901946).

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/76776/2e03df78-fb23-49e8-b87b-129b7f3a3b9a
[after]: https://github.com/guardian/dotcom-rendering/assets/76776/6fc6d51b-b49a-4315-a434-661a2d6624f5