### PR TITLE
Pin `chromaui/action` to `11.3.0`

### DIFF
--- a/.github/workflows/ar-chromatic.yml
+++ b/.github/workflows/ar-chromatic.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Chromatic - Apps Rendering
         env:
           NODE_OPTIONS: '--max_old_space_size=4096'
-        uses: chromaui/action@v11
+        uses: chromaui/action@v11.3.0
 
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN__APPS_RENDERING }}

--- a/.github/workflows/dcr-chromatic.yml
+++ b/.github/workflows/dcr-chromatic.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Chromatic - DCR
         env:
           NODE_OPTIONS: '--max_old_space_size=4096'
-        uses: chromaui/action@v11
+        uses: chromaui/action@v11.3.0
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN__DOTCOM_RENDERING }}
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The `@chromaui/action` action released `11.3.1` which has started breaking our Chromatic action runs. This pins to `11.3.0` to unblock us, until a fix is identified.