### PR TITLE
Onwards container ab test

### DIFF
--- a/dotcom-rendering/src/experiments/ab-tests.ts
+++ b/dotcom-rendering/src/experiments/ab-tests.ts
@@ -4,6 +4,7 @@ import { adBlockAsk } from './tests/ad-block-ask';
 import { consentlessAds } from './tests/consentless-ads';
 import { integrateIma } from './tests/integrate-ima';
 import { mpuWhenNoEpic } from './tests/mpu-when-no-epic';
+import { onwardJourneys } from './tests/onward-journeys';
 import { signInGateAlternativeWording } from './tests/sign-in-gate-alternative-wording';
 import { signInGateMainControl } from './tests/sign-in-gate-main-control';
 import { signInGateMainVariant } from './tests/sign-in-gate-main-variant';
@@ -19,4 +20,5 @@ export const tests: ABTest[] = [
 	integrateIma,
 	mpuWhenNoEpic,
 	adBlockAsk,
+	onwardJourneys,
 ];

--- a/dotcom-rendering/src/experiments/tests/onward-journeys.ts
+++ b/dotcom-rendering/src/experiments/tests/onward-journeys.ts
@@ -2,8 +2,8 @@ import type { ABTest } from '@guardian/ab-core';
 
 export const onwardJourneys: ABTest = {
 	id: 'OnwardJourneys',
-	start: '2025-03-01', //  update once test is ready to go live
-	expiry: '2025-12-01', //  update once test is ready to go live
+	start: '2024-05-09',
+	expiry: '2024-05-16',
 	author: '@web-experience',
 	description:
 		'Show the user one onward journey containers at a time to see which is the most effective',
@@ -18,19 +18,27 @@ export const onwardJourneys: ABTest = {
 	variants: [
 		{
 			id: 'control',
-			test: (): void => {},
+			test: (): void => {
+				/* no-op */
+			},
 		},
 		{
 			id: 'variant-1',
-			test: (): void => {},
+			test: (): void => {
+				/* no-op */
+			},
 		},
 		{
 			id: 'variant-2',
-			test: (): void => {},
+			test: (): void => {
+				/* no-op */
+			},
 		},
 		{
 			id: 'variant-3',
-			test: (): void => {},
+			test: (): void => {
+				/* no-op */
+			},
 		},
 	],
 	successMeasure: '',

--- a/dotcom-rendering/src/experiments/tests/onward-journeys.ts
+++ b/dotcom-rendering/src/experiments/tests/onward-journeys.ts
@@ -1,0 +1,37 @@
+import type { ABTest } from '@guardian/ab-core';
+
+export const onwardJourneys: ABTest = {
+	id: 'OnwardJourneys',
+	start: '2025-03-01', //  update once test is ready to go live
+	expiry: '2025-12-01', //  update once test is ready to go live
+	author: '@web-experience',
+	description:
+		'Show the user one onward journey containers at a time to see which is the most effective',
+	audience: 25 / 100,
+	audienceOffset: 0,
+	audienceCriteria: 'all users',
+	dataLinkNames: 'OnwardJourneys',
+	idealOutcome:
+		'Determine which combination of onward journey containers is the most effective',
+	showForSensitive: true,
+	canRun: () => true,
+	variants: [
+		{
+			id: 'control',
+			test: (): void => {},
+		},
+		{
+			id: 'variant-1',
+			test: (): void => {},
+		},
+		{
+			id: 'variant-2',
+			test: (): void => {},
+		},
+		{
+			id: 'variant-3',
+			test: (): void => {},
+		},
+	],
+	successMeasure: '',
+};

--- a/dotcom-rendering/src/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/layouts/CommentLayout.tsx
@@ -45,6 +45,7 @@ import { canRenderAds } from '../lib/canRenderAds';
 import { getContributionsServiceUrl } from '../lib/contributions';
 import { decideTrail } from '../lib/decideTrail';
 import { parse } from '../lib/slot-machine-flags';
+import { useAB } from '../lib/useAB';
 import type { NavType } from '../model/extract-nav';
 import { palette as themePalette } from '../palette';
 import type { DCRArticle } from '../types/frontend';
@@ -281,6 +282,25 @@ export const CommentLayout = (props: WebProps | AppsProps) => {
 	const {
 		config: { isPaidContent, host },
 	} = article;
+
+	const abTests = useAB();
+	const abTestsApi = abTests?.api;
+	const showOnwardsAllRows = abTestsApi?.isUserInVariant(
+		'OnwardJourneys',
+		'control',
+	);
+	const showOnwardsTopRow = abTestsApi?.isUserInVariant(
+		'OnwardJourneys',
+		'variant-1',
+	);
+	const showOnwardsBottomRow = abTestsApi?.isUserInVariant(
+		'OnwardJourneys',
+		'variant-2',
+	);
+	const showOnwardsMostViewed = abTestsApi?.isUserInVariant(
+		'OnwardJourneys',
+		'variant-3',
+	);
 
 	const showBodyEndSlot =
 		isWeb &&
@@ -799,49 +819,58 @@ export const CommentLayout = (props: WebProps | AppsProps) => {
 					</Section>
 				)}
 
-				{article.storyPackage && (
-					<Section
-						fullWidth={true}
-						backgroundColour={themePalette('--article-background')}
-						borderColour={themePalette('--article-border')}
-					>
-						<Island priority="feature" defer={{ until: 'visible' }}>
-							<Carousel
-								heading={article.storyPackage.heading}
-								trails={article.storyPackage.trails.map(
-									decideTrail,
-								)}
-								onwardsSource="more-on-this-story"
-								format={format}
-								leftColSize={'compact'}
-								discussionApiUrl={
-									article.config.discussionApiUrl
-								}
-							/>
-						</Island>
-					</Section>
+				{article.storyPackage &&
+					(showOnwardsAllRows || showOnwardsTopRow) && (
+						<Section
+							fullWidth={true}
+							backgroundColour={themePalette(
+								'--article-background',
+							)}
+							borderColour={themePalette('--article-border')}
+						>
+							<Island
+								priority="feature"
+								defer={{ until: 'visible' }}
+							>
+								<Carousel
+									heading={article.storyPackage.heading}
+									trails={article.storyPackage.trails.map(
+										decideTrail,
+									)}
+									onwardsSource="more-on-this-story"
+									format={format}
+									leftColSize={'compact'}
+									discussionApiUrl={
+										article.config.discussionApiUrl
+									}
+								/>
+							</Island>
+						</Section>
+					)}
+
+				{(showOnwardsAllRows || showOnwardsBottomRow) && (
+					<Island priority="feature" defer={{ until: 'visible' }}>
+						<OnwardsUpper
+							ajaxUrl={article.config.ajaxUrl}
+							hasRelated={article.hasRelated}
+							hasStoryPackage={article.hasStoryPackage}
+							isAdFreeUser={article.isAdFreeUser}
+							pageId={article.pageId}
+							isPaidContent={!!article.config.isPaidContent}
+							showRelatedContent={
+								article.config.showRelatedContent
+							}
+							keywordIds={article.config.keywordIds}
+							contentType={article.contentType}
+							tags={article.tags}
+							format={format}
+							pillar={format.theme}
+							editionId={article.editionId}
+							shortUrlId={article.config.shortUrlId}
+							discussionApiUrl={article.config.discussionApiUrl}
+						/>
+					</Island>
 				)}
-
-				<Island priority="feature" defer={{ until: 'visible' }}>
-					<OnwardsUpper
-						ajaxUrl={article.config.ajaxUrl}
-						hasRelated={article.hasRelated}
-						hasStoryPackage={article.hasStoryPackage}
-						isAdFreeUser={article.isAdFreeUser}
-						pageId={article.pageId}
-						isPaidContent={!!article.config.isPaidContent}
-						showRelatedContent={article.config.showRelatedContent}
-						keywordIds={article.config.keywordIds}
-						contentType={article.contentType}
-						tags={article.tags}
-						format={format}
-						pillar={format.theme}
-						editionId={article.editionId}
-						shortUrlId={article.config.shortUrlId}
-						discussionApiUrl={article.config.discussionApiUrl}
-					/>
-				</Island>
-
 				{showComments && (
 					<Section
 						fullWidth={true}
@@ -871,35 +900,36 @@ export const CommentLayout = (props: WebProps | AppsProps) => {
 					</Section>
 				)}
 
-				{!isPaidContent && (
-					<Section
-						title="Most viewed"
-						padContent={false}
-						verticalMargins={false}
-						element="aside"
-						data-print-layout="hide"
-						data-link-name="most-popular"
-						data-component="most-popular"
-						backgroundColour={themePalette(
-							'--article-section-background',
-						)}
-						borderColour={themePalette('--article-border')}
-						fontColour={themePalette('--article-section-title')}
-					>
-						<MostViewedFooterLayout renderAds={renderAds}>
-							<Island
-								priority="feature"
-								defer={{ until: 'visible' }}
-							>
-								<MostViewedFooterData
-									sectionId={article.config.section}
-									ajaxUrl={article.config.ajaxUrl}
-									edition={article.editionId}
-								/>
-							</Island>
-						</MostViewedFooterLayout>
-					</Section>
-				)}
+				{!isPaidContent &&
+					(showOnwardsAllRows || showOnwardsMostViewed) && (
+						<Section
+							title="Most viewed"
+							padContent={false}
+							verticalMargins={false}
+							element="aside"
+							data-print-layout="hide"
+							data-link-name="most-popular"
+							data-component="most-popular"
+							backgroundColour={themePalette(
+								'--article-section-background',
+							)}
+							borderColour={themePalette('--article-border')}
+							fontColour={themePalette('--article-section-title')}
+						>
+							<MostViewedFooterLayout renderAds={renderAds}>
+								<Island
+									priority="feature"
+									defer={{ until: 'visible' }}
+								>
+									<MostViewedFooterData
+										sectionId={article.config.section}
+										ajaxUrl={article.config.ajaxUrl}
+										edition={article.editionId}
+									/>
+								</Island>
+							</MostViewedFooterLayout>
+						</Section>
+					)}
 
 				{renderAds && (
 					<Section

--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -34,7 +34,7 @@ import { LabsHeader } from '../components/LabsHeader';
 import { MainMedia } from '../components/MainMedia';
 import { MostViewedFooterData } from '../components/MostViewedFooterData.importable';
 import { MostViewedFooterLayout } from '../components/MostViewedFooterLayout';
-import { minNavHeightPx, Nav } from '../components/Nav/Nav';
+import { Nav, minNavHeightPx } from '../components/Nav/Nav';
 import { OnwardsUpper } from '../components/OnwardsUpper.importable';
 import { RightColumn } from '../components/RightColumn';
 import { Section } from '../components/Section';
@@ -50,6 +50,7 @@ import { decideTrail } from '../lib/decideTrail';
 import { getZIndex } from '../lib/getZIndex';
 import { LABS_HEADER_HEIGHT } from '../lib/labs-constants';
 import { parse } from '../lib/slot-machine-flags';
+import { useAB } from '../lib/useAB';
 import type { NavType } from '../model/extract-nav';
 import { palette as themePalette } from '../palette';
 import type { DCRArticle } from '../types/frontend';
@@ -239,6 +240,25 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 	} = article;
 	const isWeb = renderingTarget === 'Web';
 	const isApps = renderingTarget === 'Apps';
+
+	const abTests = useAB();
+	const abTestsApi = abTests?.api;
+	const showOnwardsAllRows = abTestsApi?.isUserInVariant(
+		'OnwardJourneys',
+		'control',
+	);
+	const showOnwardsTopRow = abTestsApi?.isUserInVariant(
+		'OnwardJourneys',
+		'variant-1',
+	);
+	const showOnwardsBottomRow = abTestsApi?.isUserInVariant(
+		'OnwardJourneys',
+		'variant-2',
+	);
+	const showOnwardsMostViewed = abTestsApi?.isUserInVariant(
+		'OnwardJourneys',
+		'variant-3',
+	);
 
 	const showBodyEndSlot =
 		isWeb &&
@@ -820,51 +840,60 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 					</Section>
 				)}
 
-				{article.storyPackage && (
-					<Section
-						fullWidth={true}
-						backgroundColour={themePalette('--article-background')}
-						borderColour={themePalette('--article-border')}
-					>
-						<Island
-							priority="enhancement"
-							defer={{ until: 'visible' }}
+				{article.storyPackage &&
+					(showOnwardsAllRows || showOnwardsTopRow) && (
+						<Section
+							fullWidth={true}
+							backgroundColour={themePalette(
+								'--article-background',
+							)}
+							borderColour={themePalette('--article-border')}
 						>
-							<Carousel
-								heading={article.storyPackage.heading}
-								trails={article.storyPackage.trails.map(
-									decideTrail,
-								)}
-								onwardsSource="more-on-this-story"
-								format={format}
-								leftColSize={'compact'}
-								discussionApiUrl={
-									article.config.discussionApiUrl
-								}
-							/>
-						</Island>
-					</Section>
-				)}
+							<Island
+								priority="enhancement"
+								defer={{ until: 'visible' }}
+							>
+								<Carousel
+									heading={article.storyPackage.heading}
+									trails={article.storyPackage.trails.map(
+										decideTrail,
+									)}
+									onwardsSource="more-on-this-story"
+									format={format}
+									leftColSize={'compact'}
+									discussionApiUrl={
+										article.config.discussionApiUrl
+									}
+								/>
+							</Island>
+						</Section>
+					)}
 
-				<Island priority="feature" defer={{ until: 'visible' }}>
-					<OnwardsUpper
-						ajaxUrl={article.config.ajaxUrl}
-						hasRelated={article.hasRelated}
-						hasStoryPackage={article.hasStoryPackage}
-						isAdFreeUser={article.isAdFreeUser}
-						pageId={article.pageId}
-						isPaidContent={article.config.isPaidContent ?? false}
-						showRelatedContent={article.config.showRelatedContent}
-						keywordIds={article.config.keywordIds}
-						contentType={article.contentType}
-						tags={article.tags}
-						format={format}
-						pillar={format.theme}
-						editionId={article.editionId}
-						shortUrlId={article.config.shortUrlId}
-						discussionApiUrl={article.config.discussionApiUrl}
-					/>
-				</Island>
+				{(showOnwardsAllRows || showOnwardsBottomRow) && (
+					<Island priority="feature" defer={{ until: 'visible' }}>
+						<OnwardsUpper
+							ajaxUrl={article.config.ajaxUrl}
+							hasRelated={article.hasRelated}
+							hasStoryPackage={article.hasStoryPackage}
+							isAdFreeUser={article.isAdFreeUser}
+							pageId={article.pageId}
+							isPaidContent={
+								article.config.isPaidContent ?? false
+							}
+							showRelatedContent={
+								article.config.showRelatedContent
+							}
+							keywordIds={article.config.keywordIds}
+							contentType={article.contentType}
+							tags={article.tags}
+							format={format}
+							pillar={format.theme}
+							editionId={article.editionId}
+							shortUrlId={article.config.shortUrlId}
+							discussionApiUrl={article.config.discussionApiUrl}
+						/>
+					</Island>
+				)}
 
 				{showComments && (
 					<Section
@@ -894,35 +923,36 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 						/>
 					</Section>
 				)}
-				{!isPaidContent && (
-					<Section
-						title="Most viewed"
-						padContent={false}
-						verticalMargins={false}
-						element="aside"
-						data-print-layout="hide"
-						data-link-name="most-popular"
-						data-component="most-popular"
-						backgroundColour={themePalette(
-							'--article-section-background',
-						)}
-						borderColour={themePalette('--article-border')}
-						fontColour={themePalette('--article-section-title')}
-					>
-						<MostViewedFooterLayout renderAds={renderAds}>
-							<Island
-								priority="feature"
-								defer={{ until: 'visible' }}
-							>
-								<MostViewedFooterData
-									sectionId={article.config.section}
-									ajaxUrl={article.config.ajaxUrl}
-									edition={article.editionId}
-								/>
-							</Island>
-						</MostViewedFooterLayout>
-					</Section>
-				)}
+				{!isPaidContent &&
+					(showOnwardsAllRows || showOnwardsMostViewed) && (
+						<Section
+							title="Most viewed"
+							padContent={false}
+							verticalMargins={false}
+							element="aside"
+							data-print-layout="hide"
+							data-link-name="most-popular"
+							data-component="most-popular"
+							backgroundColour={themePalette(
+								'--article-section-background',
+							)}
+							borderColour={themePalette('--article-border')}
+							fontColour={themePalette('--article-section-title')}
+						>
+							<MostViewedFooterLayout renderAds={renderAds}>
+								<Island
+									priority="feature"
+									defer={{ until: 'visible' }}
+								>
+									<MostViewedFooterData
+										sectionId={article.config.section}
+										ajaxUrl={article.config.ajaxUrl}
+										edition={article.editionId}
+									/>
+								</Island>
+							</MostViewedFooterLayout>
+						</Section>
+					)}
 				{!isLabs && renderAds && (
 					<Section
 						fullWidth={true}

--- a/dotcom-rendering/src/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/InteractiveLayout.tsx
@@ -44,6 +44,7 @@ import { SubNav } from '../components/SubNav.importable';
 import { canRenderAds } from '../lib/canRenderAds';
 import { getContributionsServiceUrl } from '../lib/contributions';
 import { decideTrail } from '../lib/decideTrail';
+import { useAB } from '../lib/useAB';
 import type { NavType } from '../model/extract-nav';
 import { palette as themePalette } from '../palette';
 import type { DCRArticle } from '../types/frontend';
@@ -222,6 +223,25 @@ export const InteractiveLayout = (props: WebProps | AppsProps) => {
 		config: { isPaidContent, host },
 		editionId,
 	} = article;
+
+	const abTests = useAB();
+	const abTestsApi = abTests?.api;
+	const showOnwardsAllRows = abTestsApi?.isUserInVariant(
+		'OnwardJourneys',
+		'control',
+	);
+	const showOnwardsTopRow = abTestsApi?.isUserInVariant(
+		'OnwardJourneys',
+		'variant-1',
+	);
+	const showOnwardsBottomRow = abTestsApi?.isUserInVariant(
+		'OnwardJourneys',
+		'variant-2',
+	);
+	const showOnwardsMostViewed = abTestsApi?.isUserInVariant(
+		'OnwardJourneys',
+		'variant-3',
+	);
 
 	const isApps = renderingTarget === 'Apps';
 	const isWeb = renderingTarget === 'Web';
@@ -733,49 +753,58 @@ export const InteractiveLayout = (props: WebProps | AppsProps) => {
 					</Section>
 				)}
 
-				{article.storyPackage && (
-					<Section
-						fullWidth={true}
-						showTopBorder={false}
-						backgroundColour={themePalette('--article-background')}
-						borderColour={themePalette('--article-border')}
-					>
-						<Island priority="feature" defer={{ until: 'visible' }}>
-							<Carousel
-								heading={article.storyPackage.heading}
-								trails={article.storyPackage.trails.map(
-									decideTrail,
-								)}
-								onwardsSource="more-on-this-story"
-								format={format}
-								leftColSize={'compact'}
-								discussionApiUrl={
-									article.config.discussionApiUrl
-								}
-							/>
-						</Island>
-					</Section>
+				{article.storyPackage &&
+					(showOnwardsAllRows || showOnwardsTopRow) && (
+						<Section
+							fullWidth={true}
+							showTopBorder={false}
+							backgroundColour={themePalette(
+								'--article-background',
+							)}
+							borderColour={themePalette('--article-border')}
+						>
+							<Island
+								priority="feature"
+								defer={{ until: 'visible' }}
+							>
+								<Carousel
+									heading={article.storyPackage.heading}
+									trails={article.storyPackage.trails.map(
+										decideTrail,
+									)}
+									onwardsSource="more-on-this-story"
+									format={format}
+									leftColSize={'compact'}
+									discussionApiUrl={
+										article.config.discussionApiUrl
+									}
+								/>
+							</Island>
+						</Section>
+					)}
+				{(showOnwardsAllRows || showOnwardsBottomRow) && (
+					<Island priority="feature" defer={{ until: 'visible' }}>
+						<OnwardsUpper
+							ajaxUrl={article.config.ajaxUrl}
+							hasRelated={article.hasRelated}
+							hasStoryPackage={article.hasStoryPackage}
+							isAdFreeUser={article.isAdFreeUser}
+							pageId={article.pageId}
+							isPaidContent={!!article.config.isPaidContent}
+							showRelatedContent={
+								article.config.showRelatedContent
+							}
+							keywordIds={article.config.keywordIds}
+							contentType={article.contentType}
+							tags={article.tags}
+							format={format}
+							pillar={format.theme}
+							editionId={article.editionId}
+							shortUrlId={article.config.shortUrlId}
+							discussionApiUrl={article.config.discussionApiUrl}
+						/>
+					</Island>
 				)}
-
-				<Island priority="feature" defer={{ until: 'visible' }}>
-					<OnwardsUpper
-						ajaxUrl={article.config.ajaxUrl}
-						hasRelated={article.hasRelated}
-						hasStoryPackage={article.hasStoryPackage}
-						isAdFreeUser={article.isAdFreeUser}
-						pageId={article.pageId}
-						isPaidContent={!!article.config.isPaidContent}
-						showRelatedContent={article.config.showRelatedContent}
-						keywordIds={article.config.keywordIds}
-						contentType={article.contentType}
-						tags={article.tags}
-						format={format}
-						pillar={format.theme}
-						editionId={article.editionId}
-						shortUrlId={article.config.shortUrlId}
-						discussionApiUrl={article.config.discussionApiUrl}
-					/>
-				</Island>
 
 				{showComments && (
 					<Section
@@ -807,35 +836,36 @@ export const InteractiveLayout = (props: WebProps | AppsProps) => {
 					</Section>
 				)}
 
-				{!isPaidContent && (
-					<Section
-						title="Most viewed"
-						padContent={false}
-						verticalMargins={false}
-						element="aside"
-						data-print-layout="hide"
-						data-link-name="most-popular"
-						data-component="most-popular"
-						backgroundColour={themePalette(
-							'--article-section-background',
-						)}
-						borderColour={themePalette('--article-border')}
-						fontColour={themePalette('--article-section-title')}
-					>
-						<MostViewedFooterLayout renderAds={renderAds}>
-							<Island
-								priority="feature"
-								defer={{ until: 'visible' }}
-							>
-								<MostViewedFooterData
-									sectionId={article.config.section}
-									ajaxUrl={article.config.ajaxUrl}
-									edition={article.editionId}
-								/>
-							</Island>
-						</MostViewedFooterLayout>
-					</Section>
-				)}
+				{!isPaidContent &&
+					(showOnwardsAllRows || showOnwardsMostViewed) && (
+						<Section
+							title="Most viewed"
+							padContent={false}
+							verticalMargins={false}
+							element="aside"
+							data-print-layout="hide"
+							data-link-name="most-popular"
+							data-component="most-popular"
+							backgroundColour={themePalette(
+								'--article-section-background',
+							)}
+							borderColour={themePalette('--article-border')}
+							fontColour={themePalette('--article-section-title')}
+						>
+							<MostViewedFooterLayout renderAds={renderAds}>
+								<Island
+									priority="feature"
+									defer={{ until: 'visible' }}
+								>
+									<MostViewedFooterData
+										sectionId={article.config.section}
+										ajaxUrl={article.config.ajaxUrl}
+										edition={article.editionId}
+									/>
+								</Island>
+							</MostViewedFooterLayout>
+						</Section>
+					)}
 
 				{renderAds && (
 					<Section

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -51,13 +51,14 @@ import { StickyBottomBanner } from '../components/StickyBottomBanner.importable'
 import { SubMeta } from '../components/SubMeta';
 import { SubNav } from '../components/SubNav.importable';
 import {
-	hasRelevantTopics,
 	TopicFilterBank,
+	hasRelevantTopics,
 } from '../components/TopicFilterBank';
 import { canRenderAds } from '../lib/canRenderAds';
 import { getContributionsServiceUrl } from '../lib/contributions';
 import { decideTrail } from '../lib/decideTrail';
 import { getZIndex } from '../lib/getZIndex';
+import { useAB } from '../lib/useAB';
 import type { NavType } from '../model/extract-nav';
 import { palette as themePalette } from '../palette';
 import type { DCRArticle } from '../types/frontend';
@@ -274,6 +275,25 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 	const {
 		config: { isPaidContent, host },
 	} = article;
+
+	const abTests = useAB();
+	const abTestsApi = abTests?.api;
+	const showOnwardsAllRows = abTestsApi?.isUserInVariant(
+		'OnwardJourneys',
+		'control',
+	);
+	const showOnwardsTopRow = abTestsApi?.isUserInVariant(
+		'OnwardJourneys',
+		'variant-1',
+	);
+	const showOnwardsBottomRow = abTestsApi?.isUserInVariant(
+		'OnwardJourneys',
+		'variant-2',
+	);
+	const showOnwardsMostViewed = abTestsApi?.isUserInVariant(
+		'OnwardJourneys',
+		'variant-3',
+	);
 
 	// TODO:
 	// 1) Read 'forceEpic' value from URL parameter and use it to force the slot to render
@@ -1212,56 +1232,59 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 						</Section>
 					)}
 
-					{article.storyPackage && (
-						<Section
-							fullWidth={true}
-							backgroundColour={themePalette(
-								'--article-background',
-							)}
-							borderColour={themePalette('--article-border')}
-						>
-							<Island
-								priority="feature"
-								defer={{ until: 'visible' }}
+					{article.storyPackage &&
+						(showOnwardsAllRows || showOnwardsTopRow) && (
+							<Section
+								fullWidth={true}
+								backgroundColour={themePalette(
+									'--article-background',
+								)}
+								borderColour={themePalette('--article-border')}
 							>
-								<Carousel
-									heading={article.storyPackage.heading}
-									trails={article.storyPackage.trails.map(
-										decideTrail,
-									)}
-									onwardsSource="more-on-this-story"
-									format={format}
-									leftColSize={'wide'}
-									discussionApiUrl={
-										article.config.discussionApiUrl
-									}
-								/>
-							</Island>
-						</Section>
+								<Island
+									priority="feature"
+									defer={{ until: 'visible' }}
+								>
+									<Carousel
+										heading={article.storyPackage.heading}
+										trails={article.storyPackage.trails.map(
+											decideTrail,
+										)}
+										onwardsSource="more-on-this-story"
+										format={format}
+										leftColSize={'wide'}
+										discussionApiUrl={
+											article.config.discussionApiUrl
+										}
+									/>
+								</Island>
+							</Section>
+						)}
+					{(showOnwardsAllRows || showOnwardsBottomRow) && (
+						<Island priority="feature" defer={{ until: 'visible' }}>
+							<OnwardsUpper
+								ajaxUrl={article.config.ajaxUrl}
+								hasRelated={article.hasRelated}
+								hasStoryPackage={article.hasStoryPackage}
+								isAdFreeUser={article.isAdFreeUser}
+								pageId={article.pageId}
+								isPaidContent={!!article.config.isPaidContent}
+								showRelatedContent={
+									article.config.showRelatedContent
+								}
+								keywordIds={article.config.keywordIds}
+								contentType={article.contentType}
+								tags={article.tags}
+								format={format}
+								pillar={format.theme}
+								editionId={article.editionId}
+								shortUrlId={article.config.shortUrlId}
+								discussionApiUrl={
+									article.config.discussionApiUrl
+								}
+							/>
+						</Island>
 					)}
-
-					<Island priority="feature" defer={{ until: 'visible' }}>
-						<OnwardsUpper
-							ajaxUrl={article.config.ajaxUrl}
-							hasRelated={article.hasRelated}
-							hasStoryPackage={article.hasStoryPackage}
-							isAdFreeUser={article.isAdFreeUser}
-							pageId={article.pageId}
-							isPaidContent={!!article.config.isPaidContent}
-							showRelatedContent={
-								article.config.showRelatedContent
-							}
-							keywordIds={article.config.keywordIds}
-							contentType={article.contentType}
-							tags={article.tags}
-							format={format}
-							pillar={format.theme}
-							editionId={article.editionId}
-							shortUrlId={article.config.shortUrlId}
-							discussionApiUrl={article.config.discussionApiUrl}
-						/>
-					</Island>
-
 					{showComments && (
 						<Section
 							fullWidth={true}
@@ -1296,36 +1319,39 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 						</Section>
 					)}
 
-					{!isPaidContent && (
-						<Section
-							title="Most viewed"
-							padContent={false}
-							verticalMargins={false}
-							element="aside"
-							data-print-layout="hide"
-							data-link-name="most-popular"
-							data-component="most-popular"
-							leftColSize="wide"
-							backgroundColour={themePalette(
-								'--article-section-background',
-							)}
-							borderColour={themePalette('--article-border')}
-							fontColour={themePalette('--article-section-title')}
-						>
-							<MostViewedFooterLayout renderAds={renderAds}>
-								<Island
-									priority="feature"
-									defer={{ until: 'visible' }}
-								>
-									<MostViewedFooterData
-										sectionId={article.config.section}
-										ajaxUrl={article.config.ajaxUrl}
-										edition={article.editionId}
-									/>
-								</Island>
-							</MostViewedFooterLayout>
-						</Section>
-					)}
+					{!isPaidContent &&
+						(showOnwardsAllRows || showOnwardsMostViewed) && (
+							<Section
+								title="Most viewed"
+								padContent={false}
+								verticalMargins={false}
+								element="aside"
+								data-print-layout="hide"
+								data-link-name="most-popular"
+								data-component="most-popular"
+								leftColSize="wide"
+								backgroundColour={themePalette(
+									'--article-section-background',
+								)}
+								borderColour={themePalette('--article-border')}
+								fontColour={themePalette(
+									'--article-section-title',
+								)}
+							>
+								<MostViewedFooterLayout renderAds={renderAds}>
+									<Island
+										priority="feature"
+										defer={{ until: 'visible' }}
+									>
+										<MostViewedFooterData
+											sectionId={article.config.section}
+											ajaxUrl={article.config.ajaxUrl}
+											edition={article.editionId}
+										/>
+									</Island>
+								</MostViewedFooterLayout>
+							</Section>
+						)}
 
 					{renderAds && (
 						<Section

--- a/dotcom-rendering/src/layouts/PictureLayout.tsx
+++ b/dotcom-rendering/src/layouts/PictureLayout.tsx
@@ -42,6 +42,7 @@ import { canRenderAds } from '../lib/canRenderAds';
 import { getContributionsServiceUrl } from '../lib/contributions';
 import { decideTrail } from '../lib/decideTrail';
 import { decideLanguage, decideLanguageDirection } from '../lib/lang';
+import { useAB } from '../lib/useAB';
 import type { NavType } from '../model/extract-nav';
 import { palette as themePalette } from '../palette';
 import type { DCRArticle } from '../types/frontend';
@@ -264,6 +265,25 @@ export const PictureLayout = (props: WebProps | AppsProps) => {
 
 	const isWeb = renderingTarget === 'Web';
 	const isApps = renderingTarget === 'Apps';
+
+	const abTests = useAB();
+	const abTestsApi = abTests?.api;
+	const showOnwardsAllRows = abTestsApi?.isUserInVariant(
+		'OnwardJourneys',
+		'control',
+	);
+	const showOnwardsTopRow = abTestsApi?.isUserInVariant(
+		'OnwardJourneys',
+		'variant-1',
+	);
+	const showOnwardsBottomRow = abTestsApi?.isUserInVariant(
+		'OnwardJourneys',
+		'variant-2',
+	);
+	const showOnwardsMostViewed = abTestsApi?.isUserInVariant(
+		'OnwardJourneys',
+		'variant-3',
+	);
 
 	// TODO:
 	// 1) Read 'forceEpic' value from URL parameter and use it to force the slot to render
@@ -683,30 +703,36 @@ export const PictureLayout = (props: WebProps | AppsProps) => {
 					</Section>
 				)}
 
-				{article.storyPackage && (
-					<Section
-						fullWidth={true}
-						backgroundColour={themePalette('--article-background')}
-						borderColour={themePalette('--article-border')}
-					>
-						<Island priority="feature" defer={{ until: 'visible' }}>
-							<Carousel
-								heading={article.storyPackage.heading}
-								trails={article.storyPackage.trails.map(
-									decideTrail,
-								)}
-								onwardsSource="more-on-this-story"
-								format={format}
-								leftColSize={'compact'}
-								discussionApiUrl={
-									article.config.discussionApiUrl
-								}
-							/>
-						</Island>
-					</Section>
-				)}
+				{article.storyPackage &&
+					(showOnwardsAllRows || showOnwardsTopRow) && (
+						<Section
+							fullWidth={true}
+							backgroundColour={themePalette(
+								'--article-background',
+							)}
+							borderColour={themePalette('--article-border')}
+						>
+							<Island
+								priority="feature"
+								defer={{ until: 'visible' }}
+							>
+								<Carousel
+									heading={article.storyPackage.heading}
+									trails={article.storyPackage.trails.map(
+										decideTrail,
+									)}
+									onwardsSource="more-on-this-story"
+									format={format}
+									leftColSize={'compact'}
+									discussionApiUrl={
+										article.config.discussionApiUrl
+									}
+								/>
+							</Island>
+						</Section>
+					)}
 
-				{isWeb && (
+				{isWeb && (showOnwardsAllRows || showOnwardsBottomRow) && (
 					<Island priority="feature" defer={{ until: 'visible' }}>
 						<OnwardsUpper
 							ajaxUrl={article.config.ajaxUrl}
@@ -758,35 +784,36 @@ export const PictureLayout = (props: WebProps | AppsProps) => {
 					</Section>
 				)}
 
-				{!isPaidContent && (
-					<Section
-						title="Most viewed"
-						padContent={false}
-						verticalMargins={false}
-						element="aside"
-						data-print-layout="hide"
-						data-link-name="most-popular"
-						data-component="most-popular"
-						backgroundColour={themePalette(
-							'--article-section-background',
-						)}
-						borderColour={themePalette('--article-border')}
-						fontColour={themePalette('--article-section-title')}
-					>
-						<MostViewedFooterLayout renderAds={renderAds}>
-							<Island
-								priority="feature"
-								defer={{ until: 'visible' }}
-							>
-								<MostViewedFooterData
-									sectionId={article.config.section}
-									ajaxUrl={article.config.ajaxUrl}
-									edition={article.editionId}
-								/>
-							</Island>
-						</MostViewedFooterLayout>
-					</Section>
-				)}
+				{!isPaidContent &&
+					(showOnwardsAllRows || showOnwardsMostViewed) && (
+						<Section
+							title="Most viewed"
+							padContent={false}
+							verticalMargins={false}
+							element="aside"
+							data-print-layout="hide"
+							data-link-name="most-popular"
+							data-component="most-popular"
+							backgroundColour={themePalette(
+								'--article-section-background',
+							)}
+							borderColour={themePalette('--article-border')}
+							fontColour={themePalette('--article-section-title')}
+						>
+							<MostViewedFooterLayout renderAds={renderAds}>
+								<Island
+									priority="feature"
+									defer={{ until: 'visible' }}
+								>
+									<MostViewedFooterData
+										sectionId={article.config.section}
+										ajaxUrl={article.config.ajaxUrl}
+										edition={article.editionId}
+									/>
+								</Island>
+							</MostViewedFooterLayout>
+						</Section>
+					)}
 
 				{renderAds && (
 					<Section

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -47,6 +47,7 @@ import { getContributionsServiceUrl } from '../lib/contributions';
 import { decideTrail } from '../lib/decideTrail';
 import { decideLanguage, decideLanguageDirection } from '../lib/lang';
 import { parse } from '../lib/slot-machine-flags';
+import { useAB } from '../lib/useAB';
 import type { NavType } from '../model/extract-nav';
 import { palette as themePalette } from '../palette';
 import type { DCRArticle } from '../types/frontend';
@@ -226,6 +227,25 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 	} = article;
 	const isWeb = renderingTarget === 'Web';
 	const isApps = renderingTarget === 'Apps';
+
+	const abTests = useAB();
+	const abTestsApi = abTests?.api;
+	const showOnwardsAllRows = abTestsApi?.isUserInVariant(
+		'OnwardJourneys',
+		'control',
+	);
+	const showOnwardsTopRow = abTestsApi?.isUserInVariant(
+		'OnwardJourneys',
+		'variant-1',
+	);
+	const showOnwardsBottomRow = abTestsApi?.isUserInVariant(
+		'OnwardJourneys',
+		'variant-2',
+	);
+	const showOnwardsMostViewed = abTestsApi?.isUserInVariant(
+		'OnwardJourneys',
+		'variant-3',
+	);
 
 	const showBodyEndSlot =
 		isWeb &&
@@ -798,48 +818,58 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 					</Section>
 				)}
 
-				{article.storyPackage && (
-					<Section
-						fullWidth={true}
-						backgroundColour={themePalette('--article-background')}
-						borderColour={themePalette('--article-border')}
-					>
-						<Island priority="feature" defer={{ until: 'visible' }}>
-							<Carousel
-								heading={article.storyPackage.heading}
-								trails={article.storyPackage.trails.map(
-									decideTrail,
-								)}
-								onwardsSource="more-on-this-story"
-								format={format}
-								leftColSize={'compact'}
-								discussionApiUrl={
-									article.config.discussionApiUrl
-								}
-							/>
-						</Island>
-					</Section>
-				)}
+				{article.storyPackage &&
+					(showOnwardsAllRows || showOnwardsTopRow) && (
+						<Section
+							fullWidth={true}
+							backgroundColour={themePalette(
+								'--article-background',
+							)}
+							borderColour={themePalette('--article-border')}
+						>
+							<Island
+								priority="feature"
+								defer={{ until: 'visible' }}
+							>
+								<Carousel
+									heading={article.storyPackage.heading}
+									trails={article.storyPackage.trails.map(
+										decideTrail,
+									)}
+									onwardsSource="more-on-this-story"
+									format={format}
+									leftColSize={'compact'}
+									discussionApiUrl={
+										article.config.discussionApiUrl
+									}
+								/>
+							</Island>
+						</Section>
+					)}
 
-				<Island priority="feature" defer={{ until: 'visible' }}>
-					<OnwardsUpper
-						ajaxUrl={article.config.ajaxUrl}
-						hasRelated={article.hasRelated}
-						hasStoryPackage={article.hasStoryPackage}
-						isAdFreeUser={article.isAdFreeUser}
-						pageId={article.pageId}
-						isPaidContent={!!article.config.isPaidContent}
-						showRelatedContent={article.config.showRelatedContent}
-						keywordIds={article.config.keywordIds}
-						contentType={article.contentType}
-						tags={article.tags}
-						format={format}
-						pillar={format.theme}
-						editionId={article.editionId}
-						shortUrlId={article.config.shortUrlId}
-						discussionApiUrl={article.config.discussionApiUrl}
-					/>
-				</Island>
+				{(showOnwardsAllRows || showOnwardsBottomRow) && (
+					<Island priority="feature" defer={{ until: 'visible' }}>
+						<OnwardsUpper
+							ajaxUrl={article.config.ajaxUrl}
+							hasRelated={article.hasRelated}
+							hasStoryPackage={article.hasStoryPackage}
+							isAdFreeUser={article.isAdFreeUser}
+							pageId={article.pageId}
+							isPaidContent={!!article.config.isPaidContent}
+							showRelatedContent={
+								article.config.showRelatedContent
+							}
+							keywordIds={article.config.keywordIds}
+							contentType={article.contentType}
+							tags={article.tags}
+							format={format}
+							pillar={format.theme}
+							editionId={article.editionId}
+							shortUrlId={article.config.shortUrlId}
+							discussionApiUrl={article.config.discussionApiUrl}
+						/>
+					</Island>
+				)}
 
 				{showComments && (
 					<Section
@@ -870,35 +900,36 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 					</Section>
 				)}
 
-				{!isPaidContent && (
-					<Section
-						title="Most viewed"
-						padContent={false}
-						verticalMargins={false}
-						element="aside"
-						data-print-layout="hide"
-						data-link-name="most-popular"
-						data-component="most-popular"
-						backgroundColour={themePalette(
-							'--article-section-background',
-						)}
-						borderColour={themePalette('--article-border')}
-						fontColour={themePalette('--article-section-title')}
-					>
-						<MostViewedFooterLayout renderAds={renderAds}>
-							<Island
-								priority="feature"
-								defer={{ until: 'visible' }}
-							>
-								<MostViewedFooterData
-									sectionId={article.config.section}
-									ajaxUrl={article.config.ajaxUrl}
-									edition={article.editionId}
-								/>
-							</Island>
-						</MostViewedFooterLayout>
-					</Section>
-				)}
+				{!isPaidContent &&
+					(showOnwardsAllRows || showOnwardsMostViewed) && (
+						<Section
+							title="Most viewed"
+							padContent={false}
+							verticalMargins={false}
+							element="aside"
+							data-print-layout="hide"
+							data-link-name="most-popular"
+							data-component="most-popular"
+							backgroundColour={themePalette(
+								'--article-section-background',
+							)}
+							borderColour={themePalette('--article-border')}
+							fontColour={themePalette('--article-section-title')}
+						>
+							<MostViewedFooterLayout renderAds={renderAds}>
+								<Island
+									priority="feature"
+									defer={{ until: 'visible' }}
+								>
+									<MostViewedFooterData
+										sectionId={article.config.section}
+										ajaxUrl={article.config.ajaxUrl}
+										edition={article.editionId}
+									/>
+								</Island>
+							</MostViewedFooterLayout>
+						</Section>
+					)}
 
 				{renderAds && !isLabs && (
 					<Section

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -980,10 +980,9 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 					(showOnwardsAllRows || showOnwardsTopRow) && (
 						<Section
 							fullWidth={true}
-							// backgroundColour={themePalette(
-							// 	'--article-section-background',
-							// )}
-							backgroundColour={'hotpink'}
+							backgroundColour={themePalette(
+								'--article-section-background',
+							)}
 							borderColour={themePalette('--article-border')}
 							fontColour={themePalette('--article-section-title')}
 						>

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -53,6 +53,7 @@ import { canRenderAds } from '../lib/canRenderAds';
 import { getContributionsServiceUrl } from '../lib/contributions';
 import { decideTrail } from '../lib/decideTrail';
 import { parse } from '../lib/slot-machine-flags';
+import { useAB } from '../lib/useAB';
 import type { NavType } from '../model/extract-nav';
 import { palette as themePalette } from '../palette';
 import type { DCRArticle } from '../types/frontend';
@@ -373,6 +374,25 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 		editionId,
 	} = article;
 
+	const abTests = useAB();
+	const abTestsApi = abTests?.api;
+	const showOnwardsAllRows = abTestsApi?.isUserInVariant(
+		'OnwardJourneys',
+		'control',
+	);
+	const showOnwardsTopRow = abTestsApi?.isUserInVariant(
+		'OnwardJourneys',
+		'variant-1',
+	);
+	const showOnwardsBottomRow = abTestsApi?.isUserInVariant(
+		'OnwardJourneys',
+		'variant-2',
+	);
+	const showOnwardsMostViewed = abTestsApi?.isUserInVariant(
+		'OnwardJourneys',
+		'variant-3',
+	);
+
 	const isWeb = renderingTarget === 'Web';
 	const isApps = renderingTarget === 'Apps';
 
@@ -380,7 +400,6 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 		isWeb &&
 		(parse(article.slotMachineFlags ?? '').showBodyEnd ||
 			article.config.switches.slotBodyEnd);
-
 	// TODO:
 	// 1) Read 'forceEpic' value from URL parameter and use it to force the slot to render
 	// 2) Otherwise, ensure slot only renders if `article.config.shouldHideReaderRevenue` equals false.
@@ -957,51 +976,59 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 					</Section>
 				)}
 
-				{article.storyPackage && (
-					<Section
-						fullWidth={true}
-						backgroundColour={themePalette(
-							'--article-section-background',
-						)}
-						borderColour={themePalette('--article-border')}
-						fontColour={themePalette('--article-section-title')}
-					>
-						<Island priority="feature" defer={{ until: 'visible' }}>
-							<Carousel
-								heading={article.storyPackage.heading}
-								trails={article.storyPackage.trails.map(
-									decideTrail,
-								)}
-								onwardsSource="more-on-this-story"
-								format={format}
-								leftColSize={'compact'}
-								discussionApiUrl={
-									article.config.discussionApiUrl
-								}
-							/>
-						</Island>
-					</Section>
+				{article.storyPackage &&
+					(showOnwardsAllRows || showOnwardsTopRow) && (
+						<Section
+							fullWidth={true}
+							// backgroundColour={themePalette(
+							// 	'--article-section-background',
+							// )}
+							backgroundColour={'hotpink'}
+							borderColour={themePalette('--article-border')}
+							fontColour={themePalette('--article-section-title')}
+						>
+							<Island
+								priority="feature"
+								defer={{ until: 'visible' }}
+							>
+								<Carousel
+									heading={article.storyPackage.heading}
+									trails={article.storyPackage.trails.map(
+										decideTrail,
+									)}
+									onwardsSource="more-on-this-story"
+									format={format}
+									leftColSize={'compact'}
+									discussionApiUrl={
+										article.config.discussionApiUrl
+									}
+								/>
+							</Island>
+						</Section>
+					)}
+				{(showOnwardsAllRows || showOnwardsBottomRow) && (
+					<Island priority="feature" defer={{ until: 'visible' }}>
+						<OnwardsUpper
+							ajaxUrl={article.config.ajaxUrl}
+							hasRelated={article.hasRelated}
+							hasStoryPackage={article.hasStoryPackage}
+							isAdFreeUser={article.isAdFreeUser}
+							pageId={article.pageId}
+							isPaidContent={!!article.config.isPaidContent}
+							showRelatedContent={
+								article.config.showRelatedContent
+							}
+							keywordIds={article.config.keywordIds}
+							contentType={article.contentType}
+							tags={article.tags}
+							format={format}
+							pillar={format.theme}
+							editionId={article.editionId}
+							shortUrlId={article.config.shortUrlId}
+							discussionApiUrl={article.config.discussionApiUrl}
+						/>
+					</Island>
 				)}
-
-				<Island priority="feature" defer={{ until: 'visible' }}>
-					<OnwardsUpper
-						ajaxUrl={article.config.ajaxUrl}
-						hasRelated={article.hasRelated}
-						hasStoryPackage={article.hasStoryPackage}
-						isAdFreeUser={article.isAdFreeUser}
-						pageId={article.pageId}
-						isPaidContent={!!article.config.isPaidContent}
-						showRelatedContent={article.config.showRelatedContent}
-						keywordIds={article.config.keywordIds}
-						contentType={article.contentType}
-						tags={article.tags}
-						format={format}
-						pillar={format.theme}
-						editionId={article.editionId}
-						shortUrlId={article.config.shortUrlId}
-						discussionApiUrl={article.config.discussionApiUrl}
-					/>
-				</Island>
 				{showComments && (
 					<Section
 						fullWidth={true}
@@ -1032,35 +1059,36 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 					</Section>
 				)}
 
-				{!isPaidContent && (
-					<Section
-						title="Most viewed"
-						padContent={false}
-						verticalMargins={false}
-						element="aside"
-						data-print-layout="hide"
-						data-link-name="most-popular"
-						data-component="most-popular"
-						backgroundColour={themePalette(
-							'--article-section-background',
-						)}
-						borderColour={themePalette('--article-border')}
-						fontColour={themePalette('--article-section-title')}
-					>
-						<MostViewedFooterLayout renderAds={renderAds}>
-							<Island
-								priority="feature"
-								defer={{ until: 'visible' }}
-							>
-								<MostViewedFooterData
-									sectionId={article.config.section}
-									ajaxUrl={article.config.ajaxUrl}
-									edition={article.editionId}
-								/>
-							</Island>
-						</MostViewedFooterLayout>
-					</Section>
-				)}
+				{!isPaidContent &&
+					(showOnwardsAllRows || showOnwardsMostViewed) && (
+						<Section
+							title="Most viewed"
+							padContent={false}
+							verticalMargins={false}
+							element="aside"
+							data-print-layout="hide"
+							data-link-name="most-popular"
+							data-component="most-popular"
+							backgroundColour={themePalette(
+								'--article-section-background',
+							)}
+							borderColour={themePalette('--article-border')}
+							fontColour={themePalette('--article-section-title')}
+						>
+							<MostViewedFooterLayout renderAds={renderAds}>
+								<Island
+									priority="feature"
+									defer={{ until: 'visible' }}
+								>
+									<MostViewedFooterData
+										sectionId={article.config.section}
+										ajaxUrl={article.config.ajaxUrl}
+										edition={article.editionId}
+									/>
+								</Island>
+							</MostViewedFooterLayout>
+						</Section>
+					)}
 
 				{renderAds && !isLabs && (
 					<Section


### PR DESCRIPTION
## What does this change?
Adds a client side test for showing onwards journey containers to users. 

## Why?
So that we can measure the CTR on each onward journey container. By onwards content, we are referring to the 3 modules "top row", "bottom row", and "most viewed". Further information about what these 3 modules can contain [can be found here](https://docs.google.com/document/d/1CJax6m0gY07nG89BAIuDeE7OIntJqtuYzHt8-iY19Co/edit#bookmark=id.of7gnocwnb9e)

The test will have one control - the article as it currently exists with all 3 modules - and 3 variants, each with only one module visible. We are not currently concerned about the potential content variants within each row.

The test will run for 1 week.

It will run on all DCR articles with a sample size of 25% for each variant.

[The corresponding frontend pr is here
](https://github.com/guardian/frontend/pull/27112)

