### PR TITLE
Update timeline at tablet/desktop

### DIFF
--- a/dotcom-rendering/src/components/ElementContainer.tsx
+++ b/dotcom-rendering/src/components/ElementContainer.tsx
@@ -34,6 +34,21 @@ const setBackgroundColour = (colour: string) => css`
 	background-color: ${colour};
 `;
 
+const timelineStyles = (colour: string) => css`
+	position: relative;
+	margin: auto;
+
+	${from.leftCol} {
+		max-width: 1140px;
+		border-left: 1px solid ${colour};
+		border-right: 1px solid ${colour};
+	}
+
+	${from.wide} {
+		max-width: 1300px;
+	}
+`;
+
 //Previously, borderColour would be set to palette.neutral[86] if the parameter being passed was undefined. We still want this as a fallback, but not for ArticleDesign.Picture pages (and probably not for any future pages with a similar design).
 const decideFallbackBorderColour = (format: ArticleFormat | undefined) => {
 	return format?.design === ArticleDesign.Picture
@@ -68,6 +83,7 @@ type Props = {
 	hasPageSkin?: boolean;
 	hasPageSkinContentSelfConstrain?: boolean;
 	format?: ArticleFormat;
+	isTimeline?: boolean;
 };
 
 /**
@@ -95,6 +111,7 @@ export const ElementContainer = ({
 	containerName,
 	hasPageSkin = false,
 	hasPageSkinContentSelfConstrain = false,
+	isTimeline = false,
 }: Props) =>
 	jsx(element, {
 		id: ophanComponentName,
@@ -116,14 +133,17 @@ export const ElementContainer = ({
 				 */
 				id={sectionId}
 				css={[
-					shouldCenter && center,
-					showSideBorders && sideBorderStyles(borderColour),
+					shouldCenter && !isTimeline && center,
+					showSideBorders &&
+						!isTimeline &&
+						sideBorderStyles(borderColour),
 					showTopBorder && topBorderStyles(borderColour),
 					innerBackgroundColour &&
 						setBackgroundColour(innerBackgroundColour),
 					padSides && sidePadding,
 					padBottom && bottomPadding,
 					hasPageSkin && pageSkinContainer,
+					isTimeline && timelineStyles(borderColour),
 				]}
 			>
 				{children}

--- a/dotcom-rendering/src/components/ElementContainer.tsx
+++ b/dotcom-rendering/src/components/ElementContainer.tsx
@@ -44,13 +44,13 @@ const timelineStyles = (colour: string) => css`
 	margin: auto;
 
 	${from.leftCol} {
-		max-width: ${breakpoints.leftCol};
+		max-width: ${breakpoints.leftCol}px;
 		border-left: 1px solid ${colour};
 		border-right: 1px solid ${colour};
 	}
 
 	${from.wide} {
-		max-width: 1300px;
+		max-width: ${breakpoints.wide}px;
 	}
 `;
 
@@ -138,10 +138,8 @@ export const ElementContainer = ({
 				 */
 				id={sectionId}
 				css={[
-					shouldCenter && !isTimeline && center,
-					showSideBorders &&
-						!isTimeline &&
-						sideBorderStyles(borderColour),
+					shouldCenter && center,
+					showSideBorders && sideBorderStyles(borderColour),
 					showTopBorder && topBorderStyles(borderColour),
 					innerBackgroundColour &&
 						setBackgroundColour(innerBackgroundColour),

--- a/dotcom-rendering/src/components/ElementContainer.tsx
+++ b/dotcom-rendering/src/components/ElementContainer.tsx
@@ -1,6 +1,11 @@
 import { css, jsx } from '@emotion/react';
 import { ArticleDesign } from '@guardian/libs';
-import { from, palette, space } from '@guardian/source-foundations';
+import {
+	breakpoints,
+	from,
+	palette,
+	space,
+} from '@guardian/source-foundations';
 import { pageSkinContainer } from '../layouts/lib/pageSkin';
 import { center } from '../lib/center';
 import { transparentColour } from '../lib/transparentColour';
@@ -39,7 +44,7 @@ const timelineStyles = (colour: string) => css`
 	margin: auto;
 
 	${from.leftCol} {
-		max-width: 1140px;
+		max-width: ${breakpoints.leftCol};
 		border-left: 1px solid ${colour};
 		border-right: 1px solid ${colour};
 	}

--- a/dotcom-rendering/src/components/Section.tsx
+++ b/dotcom-rendering/src/components/Section.tsx
@@ -111,6 +111,10 @@ type Props = {
 	 * width but the content to constrain itself e.g. Header */
 	hasPageSkinContentSelfConstrain?: boolean;
 	/**
+	 * Whether the article format is Timeline. Defaults to false.
+	 */
+	isTimeline?: boolean;
+	/**
 	 * @deprecated Do not use
 	 *
 	 * Legacy className prop only used for supporting old interactives
@@ -302,6 +306,7 @@ export const Section = ({
 	shouldCenter,
 	hasPageSkin = false,
 	hasPageSkinContentSelfConstrain = false,
+	isTimeline = false,
 	className,
 }: Props) => {
 	const overrides =
@@ -333,6 +338,7 @@ export const Section = ({
 				hasPageSkinContentSelfConstrain={
 					hasPageSkinContentSelfConstrain
 				}
+				isTimeline={isTimeline}
 			>
 				{children}
 			</ElementContainer>

--- a/dotcom-rendering/src/components/Timeline.tsx
+++ b/dotcom-rendering/src/components/Timeline.tsx
@@ -145,10 +145,11 @@ const eventStyles = css`
 	position: relative;
 
 	${from.tablet} {
-		margin-left: -21px;
-		margin-right: -21px;
+		border-left: none;
 	}
+
 	${from.leftCol} {
+		border-left: 1px solid ${palette('--timeline-event-border')};
 		margin-left: -11px;
 		margin-right: -11px;
 	}
@@ -162,10 +163,11 @@ const labelStyles = css`
 	${textSans.small({ fontWeight: 'regular' })}
 
 	${from.tablet} {
-		margin-left: -21px;
-		margin-right: -21px;
+		border-left: none;
 	}
+
 	${from.leftCol} {
+		border-left: 1px solid ${palette('--timeline-event-border')};
 		margin-left: -11px;
 		margin-right: -11px;
 	}
@@ -225,6 +227,16 @@ const TimelineEvent = ({
 	</>
 );
 
+const containerStyles = css`
+	border-left: none;
+	${from.tablet} {
+		border-left: 1px solid ${palette('--timeline-event-border')};
+	}
+	${from.leftCol} {
+		border-left: none;
+	}
+`;
+
 // ----- Timeline ----- //
 
 type Props = {
@@ -243,7 +255,7 @@ export const Timeline = ({
 			const someEventsHaveTitles = timeline.events.some(hasTitle);
 
 			return (
-				<>
+				<div css={containerStyles}>
 					{timeline.events.map((event) => (
 						<TimelineEvent
 							event={event}
@@ -254,7 +266,7 @@ export const Timeline = ({
 							format={format}
 						/>
 					))}
-				</>
+				</div>
 			);
 		}
 		case 'model.dotcomrendering.pageElements.DCRSectionedTimelineBlockElement': {
@@ -263,7 +275,7 @@ export const Timeline = ({
 			);
 
 			return (
-				<>
+				<div css={containerStyles}>
 					{timeline.sections.map((section) => (
 						<section key={section.title}>
 							<Subheading format={format} topPadding={false}>
@@ -283,7 +295,7 @@ export const Timeline = ({
 							))}
 						</section>
 					))}
-				</>
+				</div>
 			);
 		}
 	}

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -391,6 +391,8 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 			? article.matchUrl
 			: undefined;
 
+	const isTimeline = format.design === ArticleDesign.Timeline;
+
 	const isMatchReport =
 		format.design === ArticleDesign.MatchReport && !!footballMatchUrl;
 
@@ -494,6 +496,7 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 								padSides={false}
 								backgroundColour={sourcePalette.brand[400]}
 								element="nav"
+								isTimeline={isTimeline}
 							>
 								<Nav
 									nav={props.NAV}
@@ -526,6 +529,7 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 										)}
 										padSides={false}
 										element="aside"
+										isTimeline={isTimeline}
 									>
 										<Island
 											priority="enhancement"
@@ -552,6 +556,7 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 										)}
 										padSides={false}
 										showTopBorder={false}
+										isTimeline={isTimeline}
 									>
 										<StraightLines
 											count={4}
@@ -613,6 +618,7 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 						'--article-inner-background',
 					)}
 					element="article"
+					isTimeline={isTimeline}
 				>
 					<StandardGrid
 						isMatchReport={isMatchReport}

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -496,6 +496,8 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 								padSides={false}
 								backgroundColour={sourcePalette.brand[400]}
 								element="nav"
+								shouldCenter={!isTimeline}
+								showSideBorders={!isTimeline}
 								isTimeline={isTimeline}
 							>
 								<Nav
@@ -529,6 +531,8 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 										)}
 										padSides={false}
 										element="aside"
+										shouldCenter={!isTimeline}
+										showSideBorders={!isTimeline}
 										isTimeline={isTimeline}
 									>
 										<Island
@@ -556,6 +560,8 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 										)}
 										padSides={false}
 										showTopBorder={false}
+										shouldCenter={!isTimeline}
+										showSideBorders={!isTimeline}
 										isTimeline={isTimeline}
 									>
 										<StraightLines
@@ -618,6 +624,8 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 						'--article-inner-background',
 					)}
 					element="article"
+					shouldCenter={!isTimeline}
+					showSideBorders={!isTimeline}
 					isTimeline={isTimeline}
 				>
 					<StandardGrid


### PR DESCRIPTION
## What does this change?

Updates the timeline designs at tablet and desktop breakpoints:
- The vertical border lines have been removed, so that the vertical timeline line stands out. 
- The width restriction on the header has been removed at these breakpoints. 

## Why?

Fixes: #11248

To match designs: https://www.figma.com/file/xPr2tZZger7pszcO075tAQ/New-Formats---April-23?type=design&node-id=4667-8581&mode=design&t=AA51JnDiAuLob1b3-0

## Screenshots

| <img width=350/> | Before | After |
| - | - | - |
| tablet | ![tablet-before] | ![tablet-after] |
| desktop | ![desktop-before] | ![desktop-after] |

[tablet-before]: https://github.com/guardian/dotcom-rendering/assets/9574885/c576db3a-a298-44f8-9dc6-594b2168009c
[tablet-after]: https://github.com/guardian/dotcom-rendering/assets/9574885/22daebec-6272-4ade-94bf-4502311507e8
[desktop-before]: https://github.com/guardian/dotcom-rendering/assets/9574885/f0014153-074d-466c-b5f3-e9310596bb17
[desktop-after]: https://github.com/guardian/dotcom-rendering/assets/9574885/ac521377-8b37-4483-9dc7-0623a47e8d18

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
