### PR TITLE
Fix Carousel for story package

### DIFF
--- a/dotcom-rendering/src/components/Carousel.importable.tsx
+++ b/dotcom-rendering/src/components/Carousel.importable.tsx
@@ -795,11 +795,11 @@ export const Carousel = ({
 	useEffect(() => {
 		if (!isStoryPackage) {
 			// This logic is only for the onwards journey test
-			return;
+			return setShow(true);
 		}
 		const variantId = AB?.api.runnableTest(onwardJourneys)?.variantToRun.id;
 		if (isUndefined(variantId)) {
-			return;
+			return setShow(true);
 		}
 		setShow(['control', 'top-row-most-viewed'].includes(variantId));
 	}, [AB, isStoryPackage]);


### PR DESCRIPTION
## What does this change?

- Ensure we default to showing “More on this story” if not in a test variant.

## Why?

- We do not display “More on this story” if the switch is off
- #11395 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/76776/8e657a81-7042-4808-8dc0-0d152810cee7
[after]: https://github.com/guardian/dotcom-rendering/assets/76776/f8a74bf9-55a2-40bc-ae2d-6c54be768867
