### PR TITLE
Use 99th percentile for target response time from Load Balancer 

### DIFF
--- a/dotcom-rendering/cdk/bin/cdk.ts
+++ b/dotcom-rendering/cdk/bin/cdk.ts
@@ -81,17 +81,19 @@ new RenderingCDKStack(cdkApp, 'FaciaRendering-PROD', {
 		policy: {
 			scalingStepsOut: [
 				// No scaling up effect when latency is lower than 0.4s
-				{ lower: 0, upper: 0.4, change: 0 },
-				// When latency is higher than 0.4s we scale up by 50%
-				{ lower: 0.4, change: 50 },
-				// When latency is higher than 0.5s we scale up by 80%
-				{ lower: 0.5, change: 80 },
+				{ lower: 0, upper: 0.9, change: 0 },
+				// When latency is higher than 0.9s we scale up by 30%
+				{ lower: 0.9, change: 30 },
+				// When latency is higher than 1.0s we scale up by 50%
+				{ lower: 1.0, change: 50 },
+				// When latency is higher than 1.5s we scale up by 80%
+				{ lower: 1.2, change: 80 },
 			],
 			scalingStepsIn: [
-				// No scaling down effect when latency is higher than 0.35s
-				{ lower: 0.35, change: 0 },
-				// When latency is lower than 0.35s we scale down by 1
-				{ upper: 0.35, lower: 0, change: -1 },
+				// No scaling down effect when latency is higher than 0.85s
+				{ lower: 0.85, change: 0 },
+				// When latency is lower than 0.85s we scale down by 1
+				{ upper: 0.85, lower: 0, change: -1 },
 			],
 		},
 	},

--- a/dotcom-rendering/cdk/lib/renderingStack.ts
+++ b/dotcom-rendering/cdk/lib/renderingStack.ts
@@ -196,7 +196,7 @@ export class RenderingCDKStack extends CDKStack {
 				metric: latencyMetric,
 				scalingSteps: props.scaling.policy.scalingStepsIn,
 				adjustmentType: AdjustmentType.CHANGE_IN_CAPACITY,
-				evaluationPeriods: 10,
+				evaluationPeriods: 4,
 			});
 		}
 

--- a/dotcom-rendering/cdk/lib/renderingStack.ts
+++ b/dotcom-rendering/cdk/lib/renderingStack.ts
@@ -175,7 +175,7 @@ export class RenderingCDKStack extends CDKStack {
 					metric: latencyMetric,
 					scalingSteps: props.scaling.policy.scalingStepsOut,
 					adjustmentType: AdjustmentType.PERCENT_CHANGE_IN_CAPACITY,
-					evaluationPeriods: 10,
+					evaluationPeriods: 2,
 				},
 			);
 

--- a/dotcom-rendering/cdk/lib/renderingStack.ts
+++ b/dotcom-rendering/cdk/lib/renderingStack.ts
@@ -12,7 +12,7 @@ import type { GuAsgCapacity } from '@guardian/cdk/lib/types';
 import { type App as CDKApp, Duration } from 'aws-cdk-lib';
 import type { ScalingInterval } from 'aws-cdk-lib/aws-applicationautoscaling';
 import { AdjustmentType, StepScalingPolicy } from 'aws-cdk-lib/aws-autoscaling';
-import { Metric } from 'aws-cdk-lib/aws-cloudwatch';
+import { Metric, Stats } from 'aws-cdk-lib/aws-cloudwatch';
 import { SnsAction } from 'aws-cdk-lib/aws-cloudwatch-actions';
 import type { InstanceType } from 'aws-cdk-lib/aws-ec2';
 import { Peer } from 'aws-cdk-lib/aws-ec2';
@@ -148,7 +148,7 @@ export class RenderingCDKStack extends CDKStack {
 				metricName: 'TargetResponseTime',
 				namespace: 'AWS/ApplicationELB',
 				period: Duration.seconds(30),
-				statistic: 'Average', // TODO - should we use p90?
+				statistic: Stats.percentile(99),
 			});
 
 			/** Scaling policies ASCII diagram


### PR DESCRIPTION
## What does this change?

Pick the 99th percentile value from the Load Balancer metrics as the basis for scaling up.

## Why?

Our Circuit Breaker [only requires a handful of requests to go above the threshold to open](https://github.com/guardian/frontend/blob/ca00d729929d832bd6c1c7bb9524c8f45aa43f1e/common/app/common/configuration.scala#L159), so we should really be scaling up in response to any target response time above our threshold of 0.4s.