### PR TITLE
Reduce scale-up evaluation interval to a single minute

### DIFF
--- a/dotcom-rendering/cdk/lib/renderingStack.ts
+++ b/dotcom-rendering/cdk/lib/renderingStack.ts
@@ -175,7 +175,7 @@ export class RenderingCDKStack extends CDKStack {
 					metric: latencyMetric,
 					scalingSteps: props.scaling.policy.scalingStepsOut,
 					adjustmentType: AdjustmentType.PERCENT_CHANGE_IN_CAPACITY,
-					evaluationPeriods: 10,
+					evaluationPeriods: 2, // 1 minute = 2 × 30 seconds
 				},
 			);
 


### PR DESCRIPTION
## What does this change?

Reduce the evaluation period of the scale out policy from 5 minutes to 1 minute

## Why?

The rendering stacks should scale up quickly when the latency increases, because the circuit breaker behaviour from `frontend` applications could result in waves of parallel requests.