### PR TITLE
Update spacing around timeline events

### DIFF
--- a/dotcom-rendering/src/components/Timeline.tsx
+++ b/dotcom-rendering/src/components/Timeline.tsx
@@ -1,6 +1,12 @@
 import { css, type SerializedStyles } from '@emotion/react';
 import { ArticleDesign } from '@guardian/libs';
-import { from, headline, space, textSans } from '@guardian/source-foundations';
+import {
+	between,
+	from,
+	headline,
+	space,
+	textSans,
+} from '@guardian/source-foundations';
 import type { NestedArticleElement } from '../lib/renderElement';
 import { palette } from '../palette';
 import type {
@@ -37,6 +43,10 @@ const timelineBulletStyles = css`
 		background-color: ${palette('--timeline-bullet')};
 		left: -16.5px;
 		top: -10px;
+
+		${between.tablet.and.leftCol} {
+			left: -26.5px;
+		}
 	}
 `;
 
@@ -145,10 +155,14 @@ const eventStyles = css`
 	position: relative;
 
 	${from.tablet} {
+		padding-left: ${space[5]}px;
+		padding-right: ${space[5]}px;
 		margin-left: -21px;
 		margin-right: -21px;
 	}
 	${from.leftCol} {
+		padding-left: 10px;
+		padding-right: 10px;
 		margin-left: -11px;
 		margin-right: -11px;
 	}
@@ -162,10 +176,14 @@ const labelStyles = css`
 	${textSans.small({ fontWeight: 'regular' })}
 
 	${from.tablet} {
+		padding-left: ${space[5]}px;
+		padding-right: ${space[5]}px;
 		margin-left: -21px;
 		margin-right: -21px;
 	}
 	${from.leftCol} {
+		padding-left: 10px;
+		padding-right: 10px;
 		margin-left: -11px;
 		margin-right: -11px;
 	}


### PR DESCRIPTION
## What does this change?

Update spacing around timeline events at tablet and desktop breakpoints

## Why?

Fixes: #11248

To match designs: https://www.figma.com/file/xPr2tZZger7pszcO075tAQ/New-Formats---April-23?type=design&node-id=4667-8581&mode=design&t=AA51JnDiAuLob1b3-0

## Screenshots

| Before | After |
| - | - |
| ![tablet-before] | ![tablet-after] |

[tablet-before]: https://github.com/guardian/dotcom-rendering/assets/9574885/0d51bea2-ba5a-45c3-835e-4848f3318c9b
[tablet-after]: https://github.com/guardian/dotcom-rendering/assets/9574885/e03845a3-f43c-4701-b08b-5c7e5f5899a4

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
