### PR TITLE
UK Local Election tracker template

### DIFF
--- a/dotcom-rendering/.storybook/modes.ts
+++ b/dotcom-rendering/.storybook/modes.ts
@@ -1,3 +1,5 @@
+import { breakpoints } from '@guardian/source/foundations';
+
 export const allModes = {
 	light: {
 		globalColourScheme: 'light',
@@ -10,5 +12,13 @@ export const allModes = {
 	},
 	splitVertical: {
 		globalColourScheme: 'vertical',
+	},
+	'light mobile': {
+		globalColourScheme: 'light',
+		viewport: breakpoints.mobile,
+	},
+	'dark mobile': {
+		globalColourScheme: 'dark',
+		viewport: breakpoints.mobile,
 	},
 };

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -37,6 +37,7 @@ import { SnapCssSandbox } from '../SnapCssSandbox';
 import { StarRating } from '../StarRating/StarRating';
 import type { Alignment } from '../SupportingContent';
 import { SupportingContent } from '../SupportingContent';
+import { UKLocalElectionTracker } from '../UKLocalElectionTracker';
 import { YoutubeBlockComponent } from '../YoutubeBlockComponent.importable';
 import { AvatarContainer } from './components/AvatarContainer';
 import { CardAge } from './components/CardAge';
@@ -53,7 +54,6 @@ import type {
 } from './components/ImageWrapper';
 import { ImageWrapper } from './components/ImageWrapper';
 import { TrailTextWrapper } from './components/TrailTextWrapper';
-import { UKLocalElectionTracker } from '../UKLocalElectionTracker';
 
 export type Props = {
 	linkTo: string;

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -53,6 +53,7 @@ import type {
 } from './components/ImageWrapper';
 import { ImageWrapper } from './components/ImageWrapper';
 import { TrailTextWrapper } from './components/TrailTextWrapper';
+import { UKLocalElectionTracker } from '../UKLocalElectionTracker';
 
 export type Props = {
 	linkTo: string;
@@ -106,6 +107,7 @@ export type Props = {
 	onwardsSource?: OnwardsSource;
 	pauseOffscreenVideo?: boolean;
 	showMainVideo?: boolean;
+	embedUri?: string;
 };
 
 const starWrapper = (cardHasImage: boolean) => css`
@@ -291,6 +293,7 @@ export const Card = ({
 	pauseOffscreenVideo = false,
 	showMainVideo = true,
 	absoluteServerTimes,
+	embedUri,
 }: Props) => {
 	const palette = decidePalette(format, containerPalette);
 
@@ -379,6 +382,13 @@ export const Card = ({
 			/>
 		);
 	};
+
+	if (
+		embedUri ===
+		'https://content.guardianapis.com/atom/interactive/interactives/2024/04/local-elections-tracker/local-elections-tracker-2024'
+	) {
+		return <UKLocalElectionTracker />;
+	}
 
 	if (snapData?.embedHtml) {
 		return (

--- a/dotcom-rendering/src/components/FrontCard.tsx
+++ b/dotcom-rendering/src/components/FrontCard.tsx
@@ -55,6 +55,7 @@ export const FrontCard = (props: Props) => {
 		slideshowImages: trail.slideshowImages,
 		showLivePlayable: trail.showLivePlayable,
 		showMainVideo: trail.showMainVideo,
+		embedUri: trail.embedUri,
 	};
 
 	return Card({ ...defaultProps, ...cardProps });

--- a/dotcom-rendering/src/components/UKLocalElectionTracker.stories.tsx
+++ b/dotcom-rendering/src/components/UKLocalElectionTracker.stories.tsx
@@ -1,0 +1,13 @@
+import { UKLocalElectionTracker as UKLocalElectionTrackerComponent } from './UKLocalElectionTracker';
+import { Meta, StoryObj } from '@storybook/react';
+
+const meta = {
+	title: 'Components/UK Local Election Tracker',
+	component: UKLocalElectionTrackerComponent,
+} satisfies Meta<typeof UKLocalElectionTrackerComponent>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const UKLocalElectionTracker = {} satisfies Story;

--- a/dotcom-rendering/src/components/UKLocalElectionTracker.stories.tsx
+++ b/dotcom-rendering/src/components/UKLocalElectionTracker.stories.tsx
@@ -1,11 +1,11 @@
-import { UKLocalElectionTracker as UKLocalElectionTrackerComponent } from './UKLocalElectionTracker';
-import { Meta, StoryObj } from '@storybook/react';
-import { FrontSection } from './FrontSection';
-import { discussionApiUrl } from '../../fixtures/manual/discussionApiUrl';
-import { DynamicPackage } from './DynamicPackage';
-import { DCRFrontCard } from '../types/front';
 import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
+import type { Meta, StoryObj } from '@storybook/react';
+import { discussionApiUrl } from '../../fixtures/manual/discussionApiUrl';
 import { trails } from '../../fixtures/manual/trails';
+import type { DCRFrontCard } from '../types/front';
+import { DynamicPackage } from './DynamicPackage';
+import { FrontSection } from './FrontSection';
+import { UKLocalElectionTracker as UKLocalElectionTrackerComponent } from './UKLocalElectionTracker';
 
 const meta = {
 	title: 'Components/UK Local Election Tracker',
@@ -36,7 +36,7 @@ const snap: DCRFrontCard = {
 export const UKLocalElectionTracker = {} satisfies Story;
 
 export const DynamoContainer = {
-	render: (args) => (
+	render: () => (
 		<FrontSection
 			title="Dynamic Package"
 			showTopBorder={true}
@@ -52,6 +52,7 @@ export const DynamoContainer = {
 					standard: trails.slice(1, 4),
 					snap: [snap],
 				}}
+				absoluteServerTimes={true}
 				showAge={true}
 				containerPalette="EventPalette"
 				imageLoading="eager"

--- a/dotcom-rendering/src/components/UKLocalElectionTracker.stories.tsx
+++ b/dotcom-rendering/src/components/UKLocalElectionTracker.stories.tsx
@@ -1,5 +1,11 @@
 import { UKLocalElectionTracker as UKLocalElectionTrackerComponent } from './UKLocalElectionTracker';
 import { Meta, StoryObj } from '@storybook/react';
+import { FrontSection } from './FrontSection';
+import { discussionApiUrl } from '../../fixtures/manual/discussionApiUrl';
+import { DynamicPackage } from './DynamicPackage';
+import { DCRFrontCard } from '../types/front';
+import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
+import { trails } from '../../fixtures/manual/trails';
 
 const meta = {
 	title: 'Components/UK Local Election Tracker',
@@ -10,4 +16,48 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
+const snap: DCRFrontCard = {
+	format: {
+		design: ArticleDesign.Standard,
+		theme: Pillar.News,
+		display: ArticleDisplay.Standard,
+	},
+	url: '',
+	headline: '',
+	showQuotedHeadline: false,
+	dataLinkName: '',
+	discussionApiUrl: '',
+	isExternalLink: true,
+	embedUri:
+		'https://content.guardianapis.com/atom/interactive/interactives/2024/04/local-elections-tracker/local-elections-tracker-2024',
+	showLivePlayable: false,
+};
+
 export const UKLocalElectionTracker = {} satisfies Story;
+
+export const DynamoContainer = {
+	render: (args) => (
+		<FrontSection
+			title="Dynamic Package"
+			showTopBorder={true}
+			discussionApiUrl={discussionApiUrl}
+			editionId={'UK'}
+			containerPalette="EventPalette"
+		>
+			<DynamicPackage
+				groupedTrails={{
+					huge: [],
+					veryBig: [],
+					big: [],
+					standard: trails.slice(1, 4),
+					snap: [snap],
+				}}
+				showAge={true}
+				containerPalette="EventPalette"
+				imageLoading="eager"
+			/>
+		</FrontSection>
+	),
+} satisfies Story;
+
+// TODO: Add stories for iOS and Android

--- a/dotcom-rendering/src/components/UKLocalElectionTracker.stories.tsx
+++ b/dotcom-rendering/src/components/UKLocalElectionTracker.stories.tsx
@@ -1,5 +1,6 @@
 import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
 import type { Meta, StoryObj } from '@storybook/react';
+import { allModes } from '../../.storybook/modes';
 import { discussionApiUrl } from '../../fixtures/manual/discussionApiUrl';
 import { trails } from '../../fixtures/manual/trails';
 import type { DCRFrontCard } from '../types/front';
@@ -61,4 +62,47 @@ export const DynamoContainer = {
 	),
 } satisfies Story;
 
-// TODO: Add stories for iOS and Android
+export const IOSWebView = {
+	parameters: {
+		chromatic: {
+			modes: {
+				'light mobile': allModes['light mobile'],
+				'dark mobile': allModes['dark mobile'],
+			},
+		},
+		viewport: {
+			defaultViewport: 'mobile',
+		},
+	},
+	decorators: [
+		(Story) => (
+			<div style={{ marginLeft: '-10px' }} className={'ios'}>
+				<Story />
+			</div>
+		),
+	],
+} satisfies Story;
+
+export const AndroidWebView = {
+	parameters: {
+		chromatic: {
+			modes: {
+				'light mobile': allModes['light mobile'],
+				'dark mobile': allModes['dark mobile'],
+			},
+		},
+		viewport: {
+			defaultViewport: 'mobile',
+		},
+	},
+	decorators: [
+		(Story) => (
+			<div
+				style={{ backgroundColor: 'white', margin: '10px' }}
+				className={'android'}
+			>
+				<Story />
+			</div>
+		),
+	],
+} satisfies Story;

--- a/dotcom-rendering/src/components/UKLocalElectionTracker.tsx
+++ b/dotcom-rendering/src/components/UKLocalElectionTracker.tsx
@@ -1,0 +1,1 @@
+export const UKLocalElectionTracker = () => <div>Hello World</div>;

--- a/dotcom-rendering/src/components/UKLocalElectionTracker.tsx
+++ b/dotcom-rendering/src/components/UKLocalElectionTracker.tsx
@@ -1,1 +1,60 @@
-export const UKLocalElectionTracker = () => <div>Hello World</div>;
+import { css } from '@emotion/react';
+import { from, textSans14, textSansBold14 } from '@guardian/source/foundations';
+import { palette as themePalette } from '../palette';
+
+const headingWrapperStyles = css`
+	padding: 4px 0 8px 0;
+`;
+
+const h3Styles = css`
+	${textSansBold14};
+	padding-right: 8px;
+`;
+
+const commonHeadingStyles = css`
+	display: inline;
+	color: ${themePalette('--local-election-tracker-font-colour')};
+`;
+
+const localElEctionTrackerStyles = css`
+	display: flex;
+	flex-direction: row;
+	border-top: 1px solid
+		${themePalette('--local-election-tracker-border-colour')};
+	flex-wrap: wrap;
+
+	background-image: radial-gradient(
+		circle at 6px 3px,
+		${themePalette('--local-election-tracker-border-colour')} 1px,
+		transparent 0
+	);
+	background-size: 10px 10px;
+	background-position: 5px 12px;
+`;
+
+const ulStyles = css`
+	display: flex;
+	flex-direction: row;
+	height: 170px;
+	margin: 0;
+	flex: 0 0 100%;
+	padding: 4px 0;
+
+	${from.desktop} {
+		flex-basis: 711px;
+	}
+`;
+
+export const UKLocalElectionTracker = () => (
+	<>
+		<div css={headingWrapperStyles}>
+			<h3 css={[h3Styles, commonHeadingStyles]}>Latest results</h3>
+			<p css={[textSans14, commonHeadingStyles]}>
+				Net change in seats held
+			</p>
+		</div>
+		<div css={localElEctionTrackerStyles}>
+			<ul css={ulStyles}></ul>
+		</div>
+	</>
+);

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -3824,6 +3824,17 @@ const liveBlockContainerBackgroundLight: PaletteFunction = () =>
 const liveBlockContainerBackgroundDark: PaletteFunction = () =>
 	sourcePalette.neutral[10];
 
+const localElectionTrackerFontColourLight: PaletteFunction = () =>
+	sourcePalette.neutral[7];
+
+const localElectionTrackerFontColourDark: PaletteFunction = () =>
+	sourcePalette.neutral[100];
+
+const localElectionTrackerBorderColourLight: PaletteFunction = () =>
+	sourcePalette.neutral[86];
+
+const localElectionTrackerBorderColourDark: PaletteFunction = () => '#606060';
+
 const liveBlockBorderTopLight: PaletteFunction = ({ theme }) => {
 	switch (theme) {
 		case ArticleSpecial.Labs:
@@ -6120,6 +6131,14 @@ const paletteColours = {
 	'--live-block-container-background': {
 		light: liveBlockContainerBackgroundLight,
 		dark: liveBlockContainerBackgroundDark,
+	},
+	'--local-election-tracker-font-colour': {
+		light: localElectionTrackerFontColourLight,
+		dark: localElectionTrackerFontColourDark,
+	},
+	'--local-election-tracker-border-colour': {
+		light: localElectionTrackerBorderColourLight,
+		dark: localElectionTrackerBorderColourDark,
 	},
 	'--masthead-nav-background': {
 		light: mastheadNavBackground,


### PR DESCRIPTION
## What does this change?

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
