### PR TITLE
test: ensure useId is stable

### DIFF
--- a/dotcom-rendering/src/components/ArticlePage.tsx
+++ b/dotcom-rendering/src/components/ArticlePage.tsx
@@ -1,6 +1,6 @@
 import { Global } from '@emotion/react';
 import { ArticleDesign } from '@guardian/libs';
-import { StrictMode } from 'react';
+import { StrictMode, useId } from 'react';
 import { DecideLayout } from '../layouts/DecideLayout';
 import { buildAdTargeting } from '../lib/ad-targeting';
 import { rootStyles } from '../lib/rootStyles';
@@ -59,6 +59,8 @@ export const ArticlePage = (props: WebProps | AppProps) => {
 		? article.config.abTests.darkModeWebVariant === 'variant'
 		: !!article.config.switches.darkModeInApps;
 
+	const id = useId();
+
 	return (
 		<StrictMode>
 			<Global styles={rootStyles(format, darkModeAvailable)} />
@@ -91,6 +93,7 @@ export const ArticlePage = (props: WebProps | AppProps) => {
 			)}
 			{renderingTarget === 'Web' && (
 				<>
+					<div style={{ display: 'none' }} data-stable-id={id} />
 					<SkipTo id="navigation" label="Skip to navigation" />
 					<Island priority="feature" defer={{ until: 'idle' }}>
 						<AlreadyVisited />

--- a/dotcom-rendering/src/components/HeaderTopBar.importable.tsx
+++ b/dotcom-rendering/src/components/HeaderTopBar.importable.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import { from, palette, space } from '@guardian/source-foundations';
+import { useId } from 'react';
 import { pageSkinContainer } from '../layouts/lib/pageSkin';
 import { center } from '../lib/center';
 import type { EditionId } from '../lib/edition';
@@ -72,12 +73,14 @@ export const HeaderTopBar = ({
 	hasPageSkin = false,
 }: HeaderTopBarProps) => {
 	const authStatus = useAuthStatus();
+	const id = useId();
 
 	return (
 		<div
 			css={css`
 				background-color: ${palette.brand[300]};
 			`}
+			data-stable-id={id}
 		>
 			<div
 				css={[

--- a/dotcom-rendering/src/components/Island.tsx
+++ b/dotcom-rendering/src/components/Island.tsx
@@ -1,3 +1,4 @@
+import { useId } from 'react';
 import type { ScheduleOptions, SchedulePriority } from '../lib/scheduler';
 import { useConfig } from './ConfigContext';
 
@@ -63,6 +64,8 @@ export const Island = ({ priority, defer, children }: IslandProps) => {
 	// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- Type definitions on children are limited
 	const name = String(children.type.name);
 
+	const id = useId();
+
 	return (
 		<gu-island
 			name={name}
@@ -71,6 +74,7 @@ export const Island = ({ priority, defer, children }: IslandProps) => {
 			props={JSON.stringify(children.props)}
 			rootMargin={rootMargin}
 			config={JSON.stringify(config)}
+			data-stable-id={id}
 		>
 			{children}
 		</gu-island>


### PR DESCRIPTION
to enable longer caches to hold

## What does this change?

```js
[...document.querySelectorAll('[data-stable-id]'))].map(element => element.dataset.stableId) 
```

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
