### PR TITLE
Create stacks for rendering tag pages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,6 +47,12 @@ jobs:
           rm -r facia-rendering/*
           mv facia-rendering.tar.gz facia-rendering/
 
+      - name: Compress tag-page-rendering app server files
+        run: |
+          tar -zcf tag-page-rendering.tar.gz tag-page-rendering
+          rm -r tag-page-rendering/*
+          mv tag-page-rendering.tar.gz tag-page-rendering/
+
       - name: Compress interactive-rendering app server files
         run: |
           tar -zcf interactive-rendering.tar.gz interactive-rendering
@@ -74,6 +80,10 @@ jobs:
               - facia-rendering-cfn
             facia-rendering:
               - facia-rendering
+            tag-page-rendering-cfn:
+              - tag-page-rendering-cfn
+            tag-page-rendering:
+              - tag-page-rendering
             interactive-rendering-cfn:
               - interactive-rendering-cfn
             interactive-rendering:

--- a/dotcom-rendering/cdk/bin/cdk.ts
+++ b/dotcom-rendering/cdk/bin/cdk.ts
@@ -11,6 +11,7 @@ const sharedProps = {
 	region: 'eu-west-1',
 };
 
+/** Legacy, only serves the all newsletters page */
 new DotcomRendering(cdkApp, 'DotcomRendering-PROD', {
 	...sharedProps,
 	app: 'rendering',
@@ -75,6 +76,41 @@ new RenderingCDKStack(cdkApp, 'FaciaRendering-PROD', {
 	guApp: 'facia-rendering',
 	stage: 'PROD',
 	domainName: 'facia-rendering.guardianapis.com',
+	scaling: {
+		minimumInstances: 18,
+		maximumInstances: 60,
+		policy: {
+			scalingStepsOut: [
+				// No scaling up effect when latency is lower than 0.4s
+				{ lower: 0, upper: 0.4, change: 0 },
+				// When latency is higher than 0.4s we scale up by 50%
+				{ lower: 0.4, change: 50 },
+				// When latency is higher than 0.5s we scale up by 80%
+				{ lower: 0.5, change: 80 },
+			],
+			scalingStepsIn: [
+				// No scaling down effect when latency is higher than 0.35s
+				{ lower: 0.35, change: 0 },
+				// When latency is lower than 0.35s we scale down by 1
+				{ upper: 0.35, lower: 0, change: -1 },
+			],
+		},
+	},
+	instanceType: InstanceType.of(InstanceClass.C7G, InstanceSize.MEDIUM),
+});
+
+/** Tag pages */
+new RenderingCDKStack(cdkApp, 'TagPageRendering-CODE', {
+	guApp: 'tag-page-rendering',
+	stage: 'CODE',
+	domainName: 'tag-page-rendering.code.dev-guardianapis.com',
+	scaling: { minimumInstances: 1, maximumInstances: 3 },
+	instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.SMALL),
+});
+new RenderingCDKStack(cdkApp, 'TagPageRendering-PROD', {
+	guApp: 'tag-page-rendering',
+	stage: 'PROD',
+	domainName: 'tag-page-rendering.guardianapis.com',
 	scaling: {
 		minimumInstances: 18,
 		maximumInstances: 60,

--- a/dotcom-rendering/cdk/lib/renderingStack.ts
+++ b/dotcom-rendering/cdk/lib/renderingStack.ts
@@ -21,7 +21,7 @@ import { StringParameter } from 'aws-cdk-lib/aws-ssm';
 import { getUserData } from './userData';
 
 export interface RenderingCDKStackProps extends Omit<GuStackProps, 'stack'> {
-	guApp: `${'article' | 'facia' | 'interactive'}-rendering`;
+	guApp: `${'article' | 'facia' | 'interactive' | 'tag-page'}-rendering`;
 	domainName: string;
 	instanceType: InstanceType;
 	scaling: GuAsgCapacity & {

--- a/dotcom-rendering/scripts/deploy/build-riffraff-bundle.mjs
+++ b/dotcom-rendering/scripts/deploy/build-riffraff-bundle.mjs
@@ -15,6 +15,7 @@ const target = path.resolve(dirname, '../..', 'target');
  * ├── ${copyApp('rendering')} // existing rendering app
  * ├── ${copyApp('article-rendering')} // new article-rendering app
  * ├── ${copyApp('facia-rendering')} // new facia-rendering app
+ * ├── ${copyApp('tag-page-rendering')}
  * └── ${copyApp('interactive-rendering')} // new interactive-rendering app
  */
 
@@ -33,7 +34,7 @@ const target = path.resolve(dirname, '../..', 'target');
  *
  *  Except for the instance where appName === 'rendering' due to backwards compatibility
  *
- * @param guAppName {`${'article' | 'facia' | 'interactive'}-rendering` | 'rendering'}
+ * @param guAppName {`${'article' | 'facia' | 'interactive' | 'tag-page'}-rendering` | 'rendering'}
  **/
 const copyApp = (guAppName) => {
 	/**
@@ -154,6 +155,7 @@ Promise.all([
 	...copyApp('rendering'), // existing rendering app
 	...copyApp('article-rendering'),
 	...copyApp('facia-rendering'),
+	...copyApp('tag-page-rendering'),
 	...copyApp('interactive-rendering'),
 	...copyFrontendStatic(),
 	copyRiffRaff(),

--- a/dotcom-rendering/scripts/deploy/riff-raff.yaml
+++ b/dotcom-rendering/scripts/deploy/riff-raff.yaml
@@ -86,6 +86,26 @@ deployments:
     dependencies:
       - frontend-static
       - facia-rendering-cfn
+  # tag-page-rendering cloudformation
+  tag-page-rendering-cfn:
+    template: cloudformation
+    parameters:
+      templateStagePaths:
+        CODE: TagPageRendering-CODE.template.json
+        PROD: TagPageRendering-PROD.template.json
+      cloudFormationStackByTags: false
+      cloudFormationStackName: tag-page-rendering
+      amiParameter: AMITagpagerendering
+  # tag-page-rendering autoscaling
+  tag-page-rendering:
+    type: autoscaling
+    parameters:
+      bucketSsmKey: /account/services/dotcom-artifact.bucket
+      # Default is 900 (15 mins), this is 25 mins
+      secondsToWait: 1500
+    dependencies:
+      - frontend-static
+      - tag-page-rendering-cfn
   # interactive-rendering cloudformation
   interactive-rendering-cfn:
     template: cloudformation


### PR DESCRIPTION
Similar to other types of pages like article and fronts, this change:

- creates a new stack for rendering tag pages
- updates riff raff configuration to deploy the new stack

## Release steps

1. Add a deploy restriction to `dotcom:rendering-all` in RiffRaff
2. Bring this branch up to date with `main`
3. Deploy this branch to PROD with the "deploy dangerously" setting to create the stack in cloudformation
4. Once deployed to prod, merge this branch to `main`