### PR TITLE
Initialise AB tests when no MVT cookie

### DIFF
--- a/dotcom-rendering/src/components/SetABTests.importable.tsx
+++ b/dotcom-rendering/src/components/SetABTests.importable.tsx
@@ -98,7 +98,7 @@ export const SetABTests = ({
 		};
 
 		const ab = new AB({
-			mvtId: mvtId ?? 0,
+			mvtId: mvtId ?? -1,
 			mvtMaxValue,
 			pageIsSensitive,
 			abTestSwitches,

--- a/dotcom-rendering/src/components/SetABTests.importable.tsx
+++ b/dotcom-rendering/src/components/SetABTests.importable.tsx
@@ -90,7 +90,6 @@ export const SetABTests = ({
 			console.error(
 				'There is no MVT ID set, see SetABTests.importable.tsx',
 			);
-			return;
 		}
 
 		const allForcedTestVariants = {
@@ -99,7 +98,7 @@ export const SetABTests = ({
 		};
 
 		const ab = new AB({
-			mvtId,
+			mvtId: mvtId ?? 0,
 			mvtMaxValue,
 			pageIsSensitive,
 			abTestSwitches,


### PR DESCRIPTION
## What does this change?

Initialise AB tests when there isn't an MVT set

## Why?

Allows an AB test to be tested by appending the test name to the URL [documented here](https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/docs/development/ab-testing-in-dcr.md), even when a cookie isn't found. This is important when running DCR locally, as the `GU_mvt_id` cookie exists in the `www.theguardian.com` domain and not `localhost`, so isn't accessible.

This functionality had stopped working since this commit: https://github.com/guardian/dotcom-rendering/commit/f80eb4e8d8ad4bb7ed96ced7a7007316a101c8a9