### PR TITLE
Handle media designs for branded link colour

### DIFF
--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -1863,6 +1863,10 @@ const brandingLinkLight: PaletteFunction = ({ design, theme }) => {
 			return sourcePalette.news[400];
 		case Pillar.News:
 			switch (design) {
+				case ArticleDesign.Picture:
+				case ArticleDesign.Video:
+				case ArticleDesign.Audio:
+					return sourcePalette.neutral[86];
 				case ArticleDesign.Analysis:
 					return sourcePalette.news[300];
 				default:


### PR DESCRIPTION
## What does this change?

Update the branded link colour for media designs (Video, Picture, Audio).

## Why?

These “More about this content” links are on a dark background.

Unblocks @jakeii and noticed by @cemms1.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/76776/d738418e-7293-4279-9043-8c78646f8d40
[after]: https://github.com/guardian/dotcom-rendering/assets/76776/8afcaf89-067a-4314-8cff-027d45727f21
