### PR TITLE
Bump commercial to `18.6.0`

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -41,7 +41,7 @@
 		"@guardian/bridget": "6.0.0",
 		"@guardian/browserslist-config": "6.1.0",
 		"@guardian/cdk": "50.13.0",
-		"@guardian/commercial": "18.2.0",
+		"@guardian/commercial": "18.6.0",
 		"@guardian/core-web-vitals": "6.0.0",
 		"@guardian/eslint-config": "7.0.1",
 		"@guardian/eslint-config-typescript": "9.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -339,8 +339,8 @@ importers:
         specifier: 50.13.0
         version: 50.13.0(@swc/core@1.5.3)(@types/node@20.12.7)(aws-cdk-lib@2.100.0)(aws-cdk@2.100.0)(constructs@10.3.0)(typescript@5.3.3)
       '@guardian/commercial':
-        specifier: 18.2.0
-        version: 18.2.0(@guardian/ab-core@7.0.1)(@guardian/core-web-vitals@6.0.0)(@guardian/identity-auth-frontend@4.0.0)(@guardian/identity-auth@2.1.0)(@guardian/libs@16.1.0)(@guardian/source-foundations@14.2.2)(typescript@5.3.3)
+        specifier: 18.6.0
+        version: 18.6.0(@guardian/ab-core@7.0.1)(@guardian/core-web-vitals@6.0.0)(@guardian/identity-auth-frontend@4.0.0)(@guardian/identity-auth@2.1.0)(@guardian/libs@16.1.0)(@guardian/source-foundations@14.2.2)(typescript@5.3.3)
       '@guardian/core-web-vitals':
         specifier: 6.0.0
         version: 6.0.0(@guardian/libs@16.1.0)(tslib@2.6.2)(typescript@5.3.3)(web-vitals@3.5.1)
@@ -4057,8 +4057,8 @@ packages:
       - typescript
     dev: false
 
-  /@guardian/commercial@18.2.0(@guardian/ab-core@7.0.1)(@guardian/core-web-vitals@6.0.0)(@guardian/identity-auth-frontend@4.0.0)(@guardian/identity-auth@2.1.0)(@guardian/libs@16.1.0)(@guardian/source-foundations@14.2.2)(typescript@5.3.3):
-    resolution: {integrity: sha512-ETaRrIKLxru5/XbH0F0Mi2qf4nurh9k4nVYrYdveR4mRgPQOD9jUSfp1lNYN0KAeHaW9RFhsK362Pbf3ci6qSw==}
+  /@guardian/commercial@18.6.0(@guardian/ab-core@7.0.1)(@guardian/core-web-vitals@6.0.0)(@guardian/identity-auth-frontend@4.0.0)(@guardian/identity-auth@2.1.0)(@guardian/libs@16.1.0)(@guardian/source-foundations@14.2.2)(typescript@5.3.3):
+    resolution: {integrity: sha512-0zuWmW+0ARsKKbA87Q+YyW6ThEcSZMQIzoakD4MaCawTPV4zRnNs03gGJyvcKFdcykHZeQIUp4UomfN79+nygA==}
     peerDependencies:
       '@guardian/ab-core': ^7.0.1
       '@guardian/core-web-vitals': ^6.0.0


### PR DESCRIPTION
## What does this change?
Bump commercial to `18.6.0`

## Why?
To get a change that replaces `sendBeacon` with `fetch`, which should improve reliability of metrics, as we've discovered `sendBeacon` can be outright blocked in many circumstances!

