### PR TITLE
Use 'header' as new component name in tracking instead of 'nav4'

### DIFF
--- a/dotcom-rendering/src/components/Masthead.tsx
+++ b/dotcom-rendering/src/components/Masthead.tsx
@@ -54,7 +54,7 @@ export const Masthead = ({
 	hasPageSkin = false,
 	hasPageSkinContentSelfConstrain = false,
 }: Props) => (
-	<>
+	<div data-component="header">
 		<Section
 			fullWidth={true}
 			showTopBorder={false}
@@ -66,7 +66,7 @@ export const Masthead = ({
 			hasPageSkin={hasPageSkin}
 			hasPageSkinContentSelfConstrain={hasPageSkinContentSelfConstrain}
 		>
-			<div data-component="nav4">
+			<div data-component="topbar">
 				<Island priority="critical">
 					<TopBar
 						editionId={editionId}
@@ -117,5 +117,5 @@ export const Masthead = ({
 				</Island>
 			</Section>
 		)}
-	</>
+	</div>
 );

--- a/dotcom-rendering/src/components/TopBar.importable.tsx
+++ b/dotcom-rendering/src/components/TopBar.importable.tsx
@@ -151,7 +151,7 @@ export const TopBar = ({
 				<TopBarLinkContainer>
 					<TopBarLink
 						dataLinkName={nestedOphanComponents(
-							'nav4',
+							'header',
 							'topbar',
 							'printsubs',
 						)}
@@ -167,7 +167,11 @@ export const TopBar = ({
 			<Hide until="desktop">
 				<TopBarLinkContainer>
 					<TopBarLink
-						dataLinkName={nestedOphanComponents('nav4', 'job-cta')}
+						dataLinkName={nestedOphanComponents(
+							'header',
+							'topbar',
+							'job-cta',
+						)}
 						href="https://jobs.theguardian.com"
 					>
 						Search jobs

--- a/dotcom-rendering/src/components/TopBarMyAccount.tsx
+++ b/dotcom-rendering/src/components/TopBarMyAccount.tsx
@@ -136,7 +136,7 @@ export const buildIdentityLinks = (
 	return links.map((link) => ({
 		...link,
 		dataLinkName: nestedOphanComponents(
-			'nav4',
+			'header',
 			'topbar',
 			link.id.replaceAll('_', ' '),
 		),
@@ -149,7 +149,7 @@ const SignIn = ({ idUrl }: { idUrl: string }) => (
 		href={`${idUrl}/signin?INTCMP=DOTCOM_NEWHEADER_SIGNIN&ABCMP=ab-sign-in&${createAuthenticationEventParams(
 			'guardian_signin_header',
 		)}`}
-		data-link-name={nestedOphanComponents('nav4', 'topbar', 'signin')}
+		data-link-name={nestedOphanComponents('header', 'topbar', 'signin')}
 	>
 		<ProfileIcon /> Sign in
 	</a>
@@ -238,7 +238,7 @@ const SignedInWithNotifications = ({
 				links={identityLinksWithNotifications}
 				id="my-account"
 				dataLinkName={nestedOphanComponents(
-					'nav4',
+					'header',
 					'topbar',
 					'my account',
 				)}


### PR DESCRIPTION
## What does this change?

- Uses "header" to indicate the `data-component` name within the new masthead component instead of "nav4"
- Uses `header : topbar : <link-name>` as the prefix for the `data-link-name` attribute of components within the `data-component="topbar"` 

## Why?

Agreed with the Data Journalism team and aligned with apps tracking.
The word "header" is much easier to grok without in-depth knowledge of the platform than "nav4".
