### PR TITLE
Remove `minimatch` direct dependency

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -164,7 +164,6 @@
 		"lodash.get": "4.4.2",
 		"log4js": "6.9.1",
 		"lz-string": "1.5.0",
-		"minimatch": "5.1.6",
 		"mockdate": "3.0.5",
 		"parse5": "7.1.2",
 		"postcss-styled-syntax": "0.6.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -707,9 +707,6 @@ importers:
       lz-string:
         specifier: 1.5.0
         version: 1.5.0
-      minimatch:
-        specifier: 5.1.6
-        version: 5.1.6
       mockdate:
         specifier: 3.0.5
         version: 3.0.5


### PR DESCRIPTION
## What does this change?

Remove `minimatch` from our deps

## Why?

It’s not used directly.