### PR TITLE
Log hidden front containers on page load

### DIFF
--- a/dotcom-rendering/src/components/ShowHideContainers.importable.tsx
+++ b/dotcom-rendering/src/components/ShowHideContainers.importable.tsx
@@ -16,26 +16,20 @@ const getContainerStates = (): ContainerStates => {
 
 	if (!isContainerStates(item)) return {};
 
-	/**
-	 * Tracks usage of the feature to allow hiding and showing containers on fronts.
-	 *
-	 * When fetching the local storage configuration for container states:
-	 * - If the user has configuration present, we log to Ophan which containers are hidden (status = "closed")
-	 * - If a user has no currently hidden containers, no calls to Ophan will be made
-	 */
-	Object.entries(item)
-		.filter(([, status]) => status === 'closed')
-		.map(
-			([containerId]) =>
-				void getOphan('Web').then((ophan) =>
-					ophan.record({
-						component: 'hidden-container',
-						value: containerId,
-					}),
-				),
-		);
-
 	return item;
+};
+
+/**
+ * Implemented on 29/05/24 to understand how much the
+ * "hide" container feature is being used
+ */
+const recordHiddenContainer = (sectionId: string): void => {
+	void getOphan('Web').then((ophan) =>
+		ophan.record({
+			component: 'hidden-container',
+			value: sectionId,
+		}),
+	);
 };
 
 export const ShowHideContainers = () => {
@@ -75,6 +69,9 @@ export const ShowHideContainers = () => {
 
 			if (containerStates[sectionId] === 'closed') {
 				toggleContainer(sectionId, e);
+
+				// Track which containers are configured to be hidden
+				recordHiddenContainer(sectionId);
 			}
 		}
 	}, []);


### PR DESCRIPTION
> [Document link](https://docs.google.com/document/d/1PmlpVwnOySlnV92uuJC1MV2wQ8cogHfJXjc_FdYsR_k/edit?usp=sharing)

## What does this change?

When checking if users have preferences for hiding front containers, this PR adds functionality to log to Ophan which containers are configured to be hidden on the current front.

No calls to Ophan will be made if:
 - a user has local storage configuration to hide front containers, but had subsequently un-hidden them on the current front
 - a user has local storage configuration to hide front containers, but none of those container IDs match any on the current front
 - a user does not have any locally stored preferences to hide or show containers at all (has never interacted with the feature or wiped their browser storage)

## Why?

We are interested to know how many people use the show/hide functionality on web fronts. 

Having analysed how many page views result in a click to show/hide an individual container, we will try to quantify this further by assessing how many users have current preferences to hide containers on fronts.


### Caveats
There are several problems with this approach. The local storage solution is quite naiive and simply saves the front ID as the object key with either "opened" or "closed" as the value. 
- This means that we can't say **how recently the containers were hidden** since [local storage items do not expire](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage). 
- We also can't yet say which front the container was hidden from, since some fronts share container names and hence "slug" IDs
  For example, if you hide the "spotlight" container on the UK network front, any other front with a container ID of "spotlight" will also appear hidden whether that was the initial intention or not.
