### PR TITLE
Add Tag Link component for big events test

### DIFF
--- a/dotcom-rendering/src/components/ArticleTitle.tsx
+++ b/dotcom-rendering/src/components/ArticleTitle.tsx
@@ -66,6 +66,7 @@ export const ArticleTitle = ({
 				sectionUrl={sectionUrl}
 				guardianBaseURL={guardianBaseURL}
 				isMatch={isMatch}
+				inTagLinkTest={inTagLinkTest}
 			/>
 		</div>
 	</div>

--- a/dotcom-rendering/src/components/ArticleTitle.tsx
+++ b/dotcom-rendering/src/components/ArticleTitle.tsx
@@ -11,6 +11,7 @@ type Props = {
 	sectionUrl: string;
 	guardianBaseURL: string;
 	isMatch?: boolean;
+	inTagLinkTest?: boolean;
 };
 
 const sectionStyles = css`
@@ -44,6 +45,7 @@ export const ArticleTitle = ({
 	sectionUrl,
 	guardianBaseURL,
 	isMatch,
+	inTagLinkTest = false,
 }: Props) => (
 	<div css={[sectionStyles]}>
 		<div
@@ -51,6 +53,10 @@ export const ArticleTitle = ({
 				format.display === ArticleDisplay.Immersive &&
 					format.design !== ArticleDesign.PrintShop &&
 					immersiveMargins,
+				inTagLinkTest &&
+					css`
+						width: 100%;
+					`,
 			]}
 		>
 			<SeriesSectionLink

--- a/dotcom-rendering/src/components/GridItem.tsx
+++ b/dotcom-rendering/src/components/GridItem.tsx
@@ -38,7 +38,7 @@ if (area === 'title') {
 	if (area === 'title') {
 		return css`
 			grid-area: ${area};
-			.sticky-title-experiment & {
+			.sticky-tag-link-test & {
 				z-index: 10;
 				position: sticky;
 				top: 0;

--- a/dotcom-rendering/src/components/GridItem.tsx
+++ b/dotcom-rendering/src/components/GridItem.tsx
@@ -32,6 +32,19 @@ const gridArea = css`
 	grid-area: var(--grid-area);
 `;
 
+// TODO:: Pass knowledge of the test variant here
+if (area === 'title') {
+	return css`
+		grid-area: ${area};
+		z-index: 1000;
+		position: sticky;
+		top: 0;
+	`;
+}
+return css`
+	grid-area: ${area};
+`;
+
 export const GridItem = ({
 	children,
 	area,

--- a/dotcom-rendering/src/components/GridItem.tsx
+++ b/dotcom-rendering/src/components/GridItem.tsx
@@ -29,41 +29,26 @@ const bodyStyles = css`
 	${getZIndex('bodyArea')}
 `;
 
-const gridArea = css`
-	grid-area: var(--grid-area);
-`;
-
-// TODO:: Pass knowledge of the test variant here
-if (area === 'title') {
-	if (area === 'title') {
-		return css`
-			grid-area: ${area};
-			.sticky-tag-link-test & {
-				z-index: 10;
-				position: sticky;
-				top: 0;
-				margin-left: -10px;
-				margin-right: -10px;
-				${from.mobileLandscape} {
-					margin-left: -20px;
-					margin-right: -20px;
-				}
-				${from.phablet} {
-					margin-left: 0px;
-					margin-right: 0px;
-				}
-			}
-		`;
-	}
-	return css`
-		grid-area: ${area};
-		z-index: 1000;
+const titleStyles = css`
+	.sticky-tag-link-test & {
+		z-index: 10;
 		position: sticky;
 		top: 0;
-	`;
-}
-return css`
-	grid-area: ${area};
+		margin-left: -10px;
+		margin-right: -10px;
+		${from.mobileLandscape} {
+			margin-left: -20px;
+			margin-right: -20px;
+		}
+		${from.phablet} {
+			margin-left: 0px;
+			margin-right: 0px;
+		}
+	}
+`;
+
+const gridArea = css`
+	grid-area: var(--grid-area);
 `;
 
 export const GridItem = ({
@@ -75,6 +60,7 @@ export const GridItem = ({
 		css={[
 			area === 'body' && bodyStyles,
 			area === 'right-column' && rightColumnStyles,
+			area === 'title' && titleStyles,
 			gridArea,
 		]}
 		style={{

--- a/dotcom-rendering/src/components/GridItem.tsx
+++ b/dotcom-rendering/src/components/GridItem.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { from } from '@guardian/source-foundations';
+import { from } from '@guardian/source/foundations';
 import { getZIndex } from '../lib/getZIndex';
 
 type Props = {

--- a/dotcom-rendering/src/components/GridItem.tsx
+++ b/dotcom-rendering/src/components/GridItem.tsx
@@ -34,6 +34,16 @@ const gridArea = css`
 
 // TODO:: Pass knowledge of the test variant here
 if (area === 'title') {
+	if (area === 'title') {
+		return css`
+			grid-area: ${area};
+			.sticky-title-experiment & {
+				z-index: 1;
+				position: sticky;
+				top: 0;
+			}
+		`;
+	}
 	return css`
 		grid-area: ${area};
 		z-index: 1000;

--- a/dotcom-rendering/src/components/GridItem.tsx
+++ b/dotcom-rendering/src/components/GridItem.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import { from } from '@guardian/source-foundations';
 import { getZIndex } from '../lib/getZIndex';
 
 type Props = {
@@ -38,9 +39,19 @@ if (area === 'title') {
 		return css`
 			grid-area: ${area};
 			.sticky-title-experiment & {
-				z-index: 1;
+				z-index: 10;
 				position: sticky;
 				top: 0;
+				margin-left: -10px;
+				margin-right: -10px;
+				${from.mobileLandscape} {
+					margin-left: -20px;
+					margin-right: -20px;
+				}
+				${from.phablet} {
+					margin-left: 0px;
+					margin-right: 0px;
+				}
 			}
 		`;
 	}

--- a/dotcom-rendering/src/components/SeriesSectionLink.tsx
+++ b/dotcom-rendering/src/components/SeriesSectionLink.tsx
@@ -26,6 +26,7 @@ type Props = {
 	sectionUrl: string;
 	guardianBaseURL: string;
 	isMatch?: boolean;
+	inTagLinkTest?: boolean;
 };
 
 const sectionLabelLink = css`
@@ -164,6 +165,7 @@ export const SeriesSectionLink = ({
 	sectionUrl,
 	guardianBaseURL,
 	isMatch,
+	inTagLinkTest,
 }: Props) => {
 	const observerTag = tags.find(
 		(tag) => tag.type === 'Publication' && tag.title === 'The Observer',
@@ -179,7 +181,6 @@ export const SeriesSectionLink = ({
 	);
 
 	const isEuros2024 = tags.find((tag) => tag.id === 'football/euro-2024');
-	const isTagLinkTest = true; // TODO: Add logic here to determine if we're in the tag link test
 
 	// If we have a tag, use it to show 2 section titles
 	// Observer opinion (commentisfree) articles should prioritise
@@ -194,7 +195,7 @@ export const SeriesSectionLink = ({
 		? themePalette('--series-title-match-text')
 		: themePalette('--series-title-text');
 
-	if (isEuros2024 && isTagLinkTest) {
+	if (isEuros2024 && inTagLinkTest) {
 		return (
 			<TagLink
 				sectionLabel={'Euro 24'}

--- a/dotcom-rendering/src/components/SeriesSectionLink.tsx
+++ b/dotcom-rendering/src/components/SeriesSectionLink.tsx
@@ -17,6 +17,7 @@ import type { TagType } from '../types/tag';
 import { Hide } from './Hide';
 import { Island } from './Island';
 import { PulsingDot } from './PulsingDot.importable';
+import { TagLink } from './TagLink';
 
 type Props = {
 	format: ArticleFormat;
@@ -177,6 +178,9 @@ export const SeriesSectionLink = ({
 			(tag.type === 'Publication' && tag.title === 'The Observer'),
 	);
 
+	const isEuros2024 = tags.find((tag) => tag.id === 'football/euro-2024');
+	const isTagLinkTest = true; // TODO: Add logic here to determine if we're in the tag link test
+
 	// If we have a tag, use it to show 2 section titles
 	// Observer opinion (commentisfree) articles should prioritise
 	// the publication tag over the commentisfree tag.
@@ -190,6 +194,16 @@ export const SeriesSectionLink = ({
 		? themePalette('--series-title-match-text')
 		: themePalette('--series-title-text');
 
+	if (isEuros2024 && isTagLinkTest) {
+		return (
+			<TagLink
+				format={format}
+				sectionLabel={'Euro 24'}
+				sectionUrl={'football/euro-2024'}
+				guardianBaseURL={guardianBaseURL}
+			/>
+		);
+	}
 	switch (format.display) {
 		case ArticleDisplay.Immersive: {
 			switch (format.design) {

--- a/dotcom-rendering/src/components/SeriesSectionLink.tsx
+++ b/dotcom-rendering/src/components/SeriesSectionLink.tsx
@@ -197,7 +197,6 @@ export const SeriesSectionLink = ({
 	if (isEuros2024 && isTagLinkTest) {
 		return (
 			<TagLink
-				format={format}
 				sectionLabel={'Euro 24'}
 				sectionUrl={'football/euro-2024'}
 				guardianBaseURL={guardianBaseURL}

--- a/dotcom-rendering/src/components/SeriesSectionLink.tsx
+++ b/dotcom-rendering/src/components/SeriesSectionLink.tsx
@@ -198,7 +198,7 @@ export const SeriesSectionLink = ({
 	if (isEuros2024 && inTagLinkTest) {
 		return (
 			<TagLink
-				sectionLabel={'Euro 24'}
+				sectionLabel={'Euro 2024'}
 				sectionUrl={'football/euro-2024'}
 				guardianBaseURL={guardianBaseURL}
 			/>

--- a/dotcom-rendering/src/components/TagLink.stories.tsx
+++ b/dotcom-rendering/src/components/TagLink.stories.tsx
@@ -1,4 +1,3 @@
-import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
 import type { Meta, StoryObj } from '@storybook/react';
 import { centreColumnDecorator } from '../../.storybook/decorators/gridDecorators';
 import { TagLink } from './TagLink';
@@ -13,15 +12,6 @@ type Story = StoryObj<typeof meta>;
 
 export const ThemeVariations = {
 	args: {
-		/**
-		 * This will be replaced by the `formats` parameter, but it's
-		 * required by the type.
-		 */
-		format: {
-			design: ArticleDesign.Standard,
-			display: ArticleDisplay.Standard,
-			theme: Pillar.Sport,
-		},
 		sectionLabel: 'Euro 24',
 		sectionUrl: 'football/euro-24',
 		guardianBaseURL: 'https://www.theguardian.com',

--- a/dotcom-rendering/src/components/TagLink.stories.tsx
+++ b/dotcom-rendering/src/components/TagLink.stories.tsx
@@ -1,0 +1,30 @@
+import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
+import type { Meta, StoryObj } from '@storybook/react';
+import { centreColumnDecorator } from '../../.storybook/decorators/gridDecorators';
+import { TagLink } from './TagLink';
+const meta = {
+	component: TagLink,
+	title: 'Components/TagLink',
+} satisfies Meta<typeof TagLink>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const ThemeVariations = {
+	args: {
+		/**
+		 * This will be replaced by the `formats` parameter, but it's
+		 * required by the type.
+		 */
+		format: {
+			design: ArticleDesign.Standard,
+			display: ArticleDisplay.Standard,
+			theme: Pillar.Sport,
+		},
+		sectionLabel: 'Euro 24',
+		sectionUrl: 'football/euro-24',
+		guardianBaseURL: 'https://www.theguardian.com',
+	},
+	decorators: [centreColumnDecorator],
+} satisfies Story;

--- a/dotcom-rendering/src/components/TagLink.stories.tsx
+++ b/dotcom-rendering/src/components/TagLink.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { centreColumnDecorator } from '../../.storybook/decorators/gridDecorators';
 import { TagLink } from './TagLink';
+
 const meta = {
 	component: TagLink,
 	title: 'Components/TagLink',

--- a/dotcom-rendering/src/components/TagLink.tsx
+++ b/dotcom-rendering/src/components/TagLink.tsx
@@ -18,42 +18,46 @@ interface Props {
 
 const TagLinkStyle = css`
 	display: flex;
-	fill: ${palette.sport[400]};
-	justify-content: space-between;
-	border-radius: 15px;
-	background-color: ${palette.sport[800]};
-	padding: 10px 9px;
 	flex-direction: row;
+	justify-content: space-between;
 	align-items: center;
 	height: 44px;
 	width: 100%;
+	padding: 10px 9px;
+	border-radius: 15px;
 	text-decoration: none;
+	background-color: ${palette.sport[800]};
 	color: ${palette.sport[400]};
+	fill: ${palette.sport[400]};
 	:hover {
 		text-decoration: underline;
 	}
 	${from.leftCol} {
 		align-items: start;
-		gap: 8px;
+		gap: ${space[2]}px;
 		height: auto;
 		width: auto;
 		flex-direction: column;
 	}
 `;
+const labelStyles = css`
+	${headlineBold20};
+`;
+
 const tagButtonStyles = css`
+	display: flex;
+	align-items: baseline;
+	gap: ${space[2]}px;
 	${until.wide} {
 		${headlineMedium14};
 	}
 	${headlineMedium17};
-	display: flex;
-	align-items: baseline;
-	gap: 8px;
 `;
 
 const arrowStyles = css`
 	svg {
 		fill: ${palette.sport[800]};
-		margin-top: 4px;
+		margin-top: ${space[1]}px;
 		height: 14px;
 		width: 14px;
 	}
@@ -88,13 +92,7 @@ export const TagLink = ({
 			data-component="series"
 			data-link-name="article series"
 		>
-			<div
-				css={css`
-					${headlineBold20};
-				`}
-			>
-				{sectionLabel}
-			</div>
+			<div css={labelStyles}>{sectionLabel}</div>
 			<div css={tagButtonStyles}>
 				<div>Discover More</div>
 				<span css={arrowStyles}>

--- a/dotcom-rendering/src/components/TagLink.tsx
+++ b/dotcom-rendering/src/components/TagLink.tsx
@@ -4,10 +4,10 @@ import {
 	headlineBold17,
 	headlineBold20,
 	headlineMedium14,
-	palette,
 	space,
 } from '@guardian/source-foundations';
 import { SvgArrowRightStraight } from '@guardian/source-react-components';
+import { palette } from 'src/palette';
 
 interface Props {
 	sectionLabel: string;
@@ -25,9 +25,9 @@ const TagLinkStyle = css`
 	padding: ${space[2]}px;
 	border-radius: ${space[2]}px;
 	text-decoration: none;
-	background-color: ${palette.sport[800]};
-	color: ${palette.sport[400]};
-	fill: ${palette.sport[400]};
+	background-color: ${palette('--tag-link-background')};
+	color: ${palette('--tag-link-accent')};
+	fill: ${palette('--tag-link-accent')};
 	margin-bottom: ${space[2]}px;
 	:hover {
 		text-decoration: underline;
@@ -56,7 +56,7 @@ const tagButtonStyles = css`
 
 const arrowStyles = css`
 	svg {
-		fill: ${palette.sport[800]};
+		fill: ${palette('--tag-link-background')};
 		margin-top: 5px;
 		height: 14px;
 		width: 14px;
@@ -71,9 +71,9 @@ const arrowStyles = css`
 	border: none;
 	cursor: pointer;
 	transition: background-color 0.2s;
-	background-color: ${palette.sport[400]};
+	background-color: ${palette('--tag-link-accent')};
 	:hover {
-		background-color: ${palette.sport[400]};
+		background-color: ${palette('--tag-link-accent')};
 	}
 `;
 

--- a/dotcom-rendering/src/components/TagLink.tsx
+++ b/dotcom-rendering/src/components/TagLink.tsx
@@ -38,6 +38,7 @@ const TagLinkStyle = css`
 		height: auto;
 		width: auto;
 		flex-direction: column;
+		margin-right: -1px; // To align with rich link - if we move this feature to production, we should remove this and make rich link align with everything instead.
 	}
 `;
 const labelStyles = css`
@@ -55,25 +56,25 @@ const tagButtonStyles = css`
 `;
 
 const arrowStyles = css`
-	svg {
-		fill: ${palette('--tag-link-background')};
-		margin-top: 5px;
-		height: 14px;
-		width: 14px;
-	}
-	text-align: center;
-	display: inline-block;
-	margin-top: ${space[2]}px;
-	margin-bottom: ${space[2]}px;
-	border-radius: 50%;
-	height: 24px;
-	width: 24px;
+	display: inline-flex;
+	justify-content: space-between;
+	align-items: center;
 	border: none;
-	cursor: pointer;
-	transition: background-color 0.2s;
+	vertical-align: middle;
+	justify-content: center;
+	padding: 0;
+	width: 24px;
+	height: 24px;
+	color: ${palette('--tag-link-background')};
 	background-color: ${palette('--tag-link-accent')};
-	:hover {
-		background-color: ${palette('--tag-link-accent')};
+	border-radius: 50%;
+	svg {
+		flex: 0 0 auto;
+		display: block;
+		fill: currentColor;
+		position: relative;
+		width: 20px;
+		height: auto;
 	}
 `;
 
@@ -92,9 +93,10 @@ export const TagLink = ({
 			<div css={labelStyles}>{sectionLabel}</div>
 			<div css={tagButtonStyles}>
 				<div>Discover More</div>
-				<span css={arrowStyles}>
-					<SvgArrowRightStraight isAnnouncedByScreenReader={false} />
-				</span>
+
+				<div css={arrowStyles}>
+					<SvgArrowRightStraight />
+				</div>
 			</div>
 		</a>
 	);

--- a/dotcom-rendering/src/components/TagLink.tsx
+++ b/dotcom-rendering/src/components/TagLink.tsx
@@ -38,7 +38,7 @@ const TagLinkStyle = css`
 		height: auto;
 		width: auto;
 		flex-direction: column;
-		margin-right: -1px; // To align with rich link - if we move this feature to production, we should remove this and make rich link align with everything instead.
+		margin-right: -1px; /* To align with rich link - if we move this feature to production, we should remove this and make rich link align with everything instead */
 	}
 `;
 const labelStyles = css`

--- a/dotcom-rendering/src/components/TagLink.tsx
+++ b/dotcom-rendering/src/components/TagLink.tsx
@@ -1,0 +1,99 @@
+import { css } from '@emotion/react';
+import {
+	headlineBold20,
+	headlineMedium14,
+	headlineMedium17,
+	palette,
+	space,
+	until,
+} from '@guardian/source-foundations';
+import { SvgArrowRightStraight } from '@guardian/source-react-components';
+
+interface Props {
+	format: ArticleFormat;
+	sectionLabel: string;
+	sectionUrl: string;
+	guardianBaseURL: string;
+}
+
+const TagLinkStyles = css`
+	padding: 10px 0 10px 9px;
+	gap: 8px;
+	border-radius: 15px;
+	background-color: ${palette.sport[800]};
+	display: flex;
+	flex-direction: column;
+	justify-content: space-between;
+	fill: ${palette.sport[400]};
+`;
+const tagButtonStyles = css`
+	${until.wide} {
+		${headlineMedium14};
+	}
+	${headlineMedium17};
+	display: flex;
+	align-items: baseline;
+	gap: 8px;
+`;
+const arrowStyles = css`
+	svg {
+		fill: ${palette.sport[800]};
+		margin-top: 4px;
+		height: 14px;
+		width: 14px;
+	}
+	text-align: center;
+	display: inline-block;
+	margin-top: ${space[2]}px;
+	margin-bottom: ${space[2]}px;
+	${until.tablet} {
+		margin-left: ${space[2]}px;
+	}
+	border-radius: 50%;
+	height: 24px;
+	width: 24px;
+	border: none;
+	cursor: pointer;
+	transition: background-color 0.2s;
+	background-color: ${palette.sport[400]};
+	:hover {
+		background-color: ${palette.sport[400]};
+	}
+`;
+
+const sectionLabelLink = css`
+	text-decoration: none;
+	color: ${palette.sport[400]};
+	:hover {
+		text-decoration: underline;
+	}
+`;
+
+export const TagLink = ({
+	sectionUrl,
+	sectionLabel,
+	guardianBaseURL,
+}: Props) => {
+	return (
+		<a
+			href={`${guardianBaseURL}/${sectionUrl}`}
+			css={[TagLinkStyles, sectionLabelLink]}
+			data-component="series"
+			data-link-name="article series"
+		>
+			<span
+				css={css`
+					${headlineBold20};
+				`}
+			>
+				{sectionLabel}
+			</span>
+			<span css={tagButtonStyles}>
+				<span css={arrowStyles}>
+					<SvgArrowRightStraight isAnnouncedByScreenReader={false} />
+				</span>
+				<span>Discover More</span>
+			</span>
+		</a>
+	);
+};

--- a/dotcom-rendering/src/components/TagLink.tsx
+++ b/dotcom-rendering/src/components/TagLink.tsx
@@ -5,8 +5,8 @@ import {
 	headlineBold20,
 	headlineMedium14,
 	space,
-} from '@guardian/source-foundations';
-import { SvgArrowRightStraight } from '@guardian/source-react-components';
+} from '@guardian/source/foundations';
+import { Hide, SvgArrowRightStraight } from '@guardian/source/react-components';
 import { palette } from '../palette';
 
 interface Props {
@@ -14,8 +14,11 @@ interface Props {
 	sectionUrl: string;
 	guardianBaseURL: string;
 }
+const containerStyles = css`
+	margin-bottom: ${space[2]}px;
+`;
 
-const TagLinkStyle = css`
+const tagLinkStyles = css`
 	display: flex;
 	flex-direction: row;
 	justify-content: space-between;
@@ -28,7 +31,6 @@ const TagLinkStyle = css`
 	background-color: ${palette('--tag-link-background')};
 	color: ${palette('--tag-link-accent')};
 	fill: ${palette('--tag-link-accent')};
-	margin-bottom: ${space[2]}px;
 	:hover {
 		text-decoration: underline;
 	}
@@ -77,26 +79,40 @@ const arrowStyles = css`
 	}
 `;
 
+const fillBarStyles = css`
+	background-color: white; /* Todo: replace with article background color; */
+	margin-top: -${space[2]}px;
+	width: 100%;
+	height: 20px;
+	margin-bottom: -${space[2]}px;
+	margin-right: -1px;
+`;
+
 export const TagLink = ({
 	sectionUrl,
 	sectionLabel,
 	guardianBaseURL,
 }: Props) => {
 	return (
-		<a
-			href={`${guardianBaseURL}/${sectionUrl}`}
-			css={TagLinkStyle}
-			data-component="series"
-			data-link-name="article series"
-		>
-			<div css={labelStyles}>{sectionLabel}</div>
-			<div css={tagButtonStyles}>
-				<div>Discover More</div>
+		<div css={containerStyles}>
+			<Hide from="leftCol">
+				<div css={fillBarStyles} />
+			</Hide>
+			<a
+				href={`${guardianBaseURL}/${sectionUrl}`}
+				css={tagLinkStyles}
+				data-component="series"
+				data-link-name="article series"
+			>
+				<div css={labelStyles}>{sectionLabel}</div>
+				<div css={tagButtonStyles}>
+					<div>Discover More</div>
 
-				<div css={arrowStyles}>
-					<SvgArrowRightStraight />
+					<div css={arrowStyles}>
+						<SvgArrowRightStraight />
+					</div>
 				</div>
-			</div>
-		</a>
+			</a>
+		</div>
 	);
 };

--- a/dotcom-rendering/src/components/TagLink.tsx
+++ b/dotcom-rendering/src/components/TagLink.tsx
@@ -10,7 +10,6 @@ import {
 import { SvgArrowRightStraight } from '@guardian/source-react-components';
 
 interface Props {
-	format: ArticleFormat;
 	sectionLabel: string;
 	sectionUrl: string;
 	guardianBaseURL: string;

--- a/dotcom-rendering/src/components/TagLink.tsx
+++ b/dotcom-rendering/src/components/TagLink.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import {
+	from,
 	headlineBold20,
 	headlineMedium14,
 	headlineMedium17,
@@ -15,15 +16,29 @@ interface Props {
 	guardianBaseURL: string;
 }
 
-const TagLinkStyles = css`
-	padding: 10px 0 10px 9px;
-	gap: 8px;
+const TagLinkStyle = css`
+	display: flex;
+	fill: ${palette.sport[400]};
+	justify-content: space-between;
 	border-radius: 15px;
 	background-color: ${palette.sport[800]};
-	display: flex;
-	flex-direction: column;
-	justify-content: space-between;
-	fill: ${palette.sport[400]};
+	padding: 10px 9px;
+	flex-direction: row;
+	align-items: center;
+	height: 44px;
+	width: 100%;
+	text-decoration: none;
+	color: ${palette.sport[400]};
+	:hover {
+		text-decoration: underline;
+	}
+	${from.leftCol} {
+		align-items: start;
+		gap: 8px;
+		height: auto;
+		width: auto;
+		flex-direction: column;
+	}
 `;
 const tagButtonStyles = css`
 	${until.wide} {
@@ -34,6 +49,7 @@ const tagButtonStyles = css`
 	align-items: baseline;
 	gap: 8px;
 `;
+
 const arrowStyles = css`
 	svg {
 		fill: ${palette.sport[800]};
@@ -60,14 +76,6 @@ const arrowStyles = css`
 	}
 `;
 
-const sectionLabelLink = css`
-	text-decoration: none;
-	color: ${palette.sport[400]};
-	:hover {
-		text-decoration: underline;
-	}
-`;
-
 export const TagLink = ({
 	sectionUrl,
 	sectionLabel,
@@ -76,23 +84,23 @@ export const TagLink = ({
 	return (
 		<a
 			href={`${guardianBaseURL}/${sectionUrl}`}
-			css={[TagLinkStyles, sectionLabelLink]}
+			css={TagLinkStyle}
 			data-component="series"
 			data-link-name="article series"
 		>
-			<span
+			<div
 				css={css`
 					${headlineBold20};
 				`}
 			>
 				{sectionLabel}
-			</span>
-			<span css={tagButtonStyles}>
+			</div>
+			<div css={tagButtonStyles}>
+				<div>Discover More</div>
 				<span css={arrowStyles}>
 					<SvgArrowRightStraight isAnnouncedByScreenReader={false} />
 				</span>
-				<span>Discover More</span>
-			</span>
+			</div>
 		</a>
 	);
 };

--- a/dotcom-rendering/src/components/TagLink.tsx
+++ b/dotcom-rendering/src/components/TagLink.tsx
@@ -1,12 +1,11 @@
 import { css } from '@emotion/react';
 import {
 	from,
+	headlineBold17,
 	headlineBold20,
 	headlineMedium14,
-	headlineMedium17,
 	palette,
 	space,
-	until,
 } from '@guardian/source-foundations';
 import { SvgArrowRightStraight } from '@guardian/source-react-components';
 
@@ -23,41 +22,42 @@ const TagLinkStyle = css`
 	align-items: center;
 	height: 44px;
 	width: 100%;
-	padding: 10px 9px;
-	border-radius: 15px;
+	padding: ${space[2]}px;
+	border-radius: ${space[2]}px;
 	text-decoration: none;
 	background-color: ${palette.sport[800]};
 	color: ${palette.sport[400]};
 	fill: ${palette.sport[400]};
+	margin-bottom: ${space[2]}px;
 	:hover {
 		text-decoration: underline;
 	}
 	${from.leftCol} {
 		align-items: start;
-		gap: ${space[2]}px;
+		gap: ${space[3]}px;
 		height: auto;
 		width: auto;
 		flex-direction: column;
 	}
 `;
 const labelStyles = css`
-	${headlineBold20};
+	${headlineBold17};
+	${from.desktop} {
+		${headlineBold20};
+	}
 `;
 
 const tagButtonStyles = css`
 	display: flex;
-	align-items: baseline;
+	align-items: center;
+	${headlineMedium14};
 	gap: ${space[2]}px;
-	${until.wide} {
-		${headlineMedium14};
-	}
-	${headlineMedium17};
 `;
 
 const arrowStyles = css`
 	svg {
 		fill: ${palette.sport[800]};
-		margin-top: ${space[1]}px;
+		margin-top: 5px;
 		height: 14px;
 		width: 14px;
 	}
@@ -65,9 +65,6 @@ const arrowStyles = css`
 	display: inline-block;
 	margin-top: ${space[2]}px;
 	margin-bottom: ${space[2]}px;
-	${until.tablet} {
-		margin-left: ${space[2]}px;
-	}
 	border-radius: 50%;
 	height: 24px;
 	width: 24px;

--- a/dotcom-rendering/src/components/TagLink.tsx
+++ b/dotcom-rendering/src/components/TagLink.tsx
@@ -57,7 +57,6 @@ const tagButtonStyles = css`
 
 const arrowStyles = css`
 	display: inline-flex;
-	justify-content: space-between;
 	align-items: center;
 	border: none;
 	vertical-align: middle;

--- a/dotcom-rendering/src/components/TagLink.tsx
+++ b/dotcom-rendering/src/components/TagLink.tsx
@@ -7,7 +7,7 @@ import {
 	space,
 } from '@guardian/source-foundations';
 import { SvgArrowRightStraight } from '@guardian/source-react-components';
-import { palette } from 'src/palette';
+import { palette } from '../palette';
 
 interface Props {
 	sectionLabel: string;

--- a/dotcom-rendering/src/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/layouts/CommentLayout.tsx
@@ -307,7 +307,8 @@ export const CommentLayout = (props: WebProps | AppsProps) => {
 		article.config.abTests.updatedHeaderDesignVariant === 'variant';
 
 	const { absoluteServerTimes = false } = article.config.switches;
-	const inTagLinkTest = false;
+	const inTagLinkTest =
+		article.config.abTests.tagLinkDesignVariant === 'variant';
 
 	return (
 		<>

--- a/dotcom-rendering/src/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/layouts/CommentLayout.tsx
@@ -307,6 +307,7 @@ export const CommentLayout = (props: WebProps | AppsProps) => {
 		article.config.abTests.updatedHeaderDesignVariant === 'variant';
 
 	const { absoluteServerTimes = false } = article.config.switches;
+	const inTagLinkTest = false;
 
 	return (
 		<>
@@ -467,7 +468,7 @@ export const CommentLayout = (props: WebProps | AppsProps) => {
 
 			<main
 				data-layout="CommentLayout"
-				className="sticky-title-experiment"
+				className={inTagLinkTest ? 'sticky-tag-link-test' : ''}
 			>
 				{isApps && (
 					<>
@@ -525,6 +526,7 @@ export const CommentLayout = (props: WebProps | AppsProps) => {
 								sectionLabel={article.sectionLabel}
 								sectionUrl={article.sectionUrl}
 								guardianBaseURL={article.guardianBaseURL}
+								inTagLinkTest={inTagLinkTest}
 							/>
 						</GridItem>
 						<GridItem area="border">

--- a/dotcom-rendering/src/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/layouts/CommentLayout.tsx
@@ -465,7 +465,10 @@ export const CommentLayout = (props: WebProps | AppsProps) => {
 				</div>
 			)}
 
-			<main data-layout="CommentLayout">
+			<main
+				data-layout="CommentLayout"
+				className="sticky-title-experiment"
+			>
 				{isApps && (
 					<>
 						<Island priority="critical">

--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -290,7 +290,6 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 			min-height: calc(50rem - ${navAndLabsHeaderHeight});
 		}
 	`;
-
 	const LeftColCaption = () => (
 		<div
 			css={css`
@@ -312,6 +311,7 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 	const renderAds = isWeb && canRenderAds(article);
 
 	const { absoluteServerTimes = false } = article.config.switches;
+	const inTagLinkTest = false;
 
 	return (
 		<>
@@ -459,7 +459,10 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 				)}
 			</header>
 
-			<main data-layout="ImmersiveLayout">
+			<main
+				data-layout="ImmersiveLayout"
+				className={inTagLinkTest ? 'sticky-tag-link-test' : ''}
+			>
 				{isApps && (
 					<>
 						<Island priority="critical">
@@ -519,6 +522,7 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 											guardianBaseURL={
 												article.guardianBaseURL
 											}
+											inTagLinkTest={inTagLinkTest}
 										/>
 									</div>
 								)}

--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -311,7 +311,8 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 	const renderAds = isWeb && canRenderAds(article);
 
 	const { absoluteServerTimes = false } = article.config.switches;
-	const inTagLinkTest = false;
+	const inTagLinkTest =
+		article.config.abTests.tagLinkDesignVariant === 'variant';
 
 	return (
 		<>

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -314,7 +314,8 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 
 	const inUpdatedHeaderABTest =
 		article.config.abTests.updatedHeaderDesignVariant === 'variant';
-	const inTagLinkTest = false;
+	const inTagLinkTest =
+		article.config.abTests.tagLinkDesignVariant === 'variant';
 
 	const { absoluteServerTimes = false } = article.config.switches;
 

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -314,6 +314,7 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 
 	const inUpdatedHeaderABTest =
 		article.config.abTests.updatedHeaderDesignVariant === 'variant';
+	const inTagLinkTest = false;
 
 	const { absoluteServerTimes = false } = article.config.switches;
 
@@ -462,7 +463,10 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 					)}
 				</div>
 			)}
-			<main data-layout="LiveLayout">
+			<main
+				data-layout="LiveLayout"
+				className={inTagLinkTest ? 'sticky-tag-link-test' : ''}
+			>
 				{isApps && (
 					<>
 						<Island priority="critical">
@@ -536,6 +540,7 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 									sectionLabel={article.sectionLabel}
 									sectionUrl={article.sectionUrl}
 									guardianBaseURL={article.guardianBaseURL}
+									inTagLinkTest={inTagLinkTest}
 								/>
 							</GridItem>
 							<GridItem area="headline">

--- a/dotcom-rendering/src/layouts/PictureLayout.tsx
+++ b/dotcom-rendering/src/layouts/PictureLayout.tsx
@@ -287,6 +287,7 @@ export const PictureLayout = (props: WebProps | AppsProps) => {
 
 	const inUpdatedHeaderABTest =
 		article.config.abTests.updatedHeaderDesignVariant === 'variant';
+	const inTagLinkTest = false;
 
 	const { absoluteServerTimes = false } = article.config.switches;
 
@@ -446,6 +447,7 @@ export const PictureLayout = (props: WebProps | AppsProps) => {
 			<main
 				data-layout="PictureLayout"
 				id="maincontent"
+				className={inTagLinkTest ? 'sticky-tag-link-test' : ''}
 				lang={decideLanguage(article.lang)}
 				dir={decideLanguageDirection(article.isRightToLeftLang)}
 			>
@@ -476,6 +478,7 @@ export const PictureLayout = (props: WebProps | AppsProps) => {
 								sectionLabel={article.sectionLabel}
 								sectionUrl={article.sectionUrl}
 								guardianBaseURL={article.guardianBaseURL}
+								inTagLinkTest={inTagLinkTest}
 							/>
 						</GridItem>
 						<GridItem area="border">

--- a/dotcom-rendering/src/layouts/PictureLayout.tsx
+++ b/dotcom-rendering/src/layouts/PictureLayout.tsx
@@ -287,7 +287,8 @@ export const PictureLayout = (props: WebProps | AppsProps) => {
 
 	const inUpdatedHeaderABTest =
 		article.config.abTests.updatedHeaderDesignVariant === 'variant';
-	const inTagLinkTest = false;
+	const inTagLinkTest =
+		article.config.abTests.tagLinkDesignVariant === 'variant';
 
 	const { absoluteServerTimes = false } = article.config.switches;
 

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -527,6 +527,7 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 			)}
 			<main
 				data-layout="ShowcaseLayout"
+				className="sticky-title-experiment"
 				id="maincontent"
 				lang={decideLanguage(article.lang)}
 				dir={decideLanguageDirection(article.isRightToLeftLang)}

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -249,6 +249,7 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 	const renderAds = isWeb && canRenderAds(article);
 
 	const isLabs = format.theme === ArticleSpecial.Labs;
+	const inTagLinkTest = false;
 
 	const { absoluteServerTimes = false } = article.config.switches;
 
@@ -527,7 +528,7 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 			)}
 			<main
 				data-layout="ShowcaseLayout"
-				className="sticky-title-experiment"
+				className={inTagLinkTest ? 'sticky-tag-link-test' : ''}
 				id="maincontent"
 				lang={decideLanguage(article.lang)}
 				dir={decideLanguageDirection(article.isRightToLeftLang)}
@@ -583,6 +584,7 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 								sectionLabel={article.sectionLabel}
 								sectionUrl={article.sectionUrl}
 								guardianBaseURL={article.guardianBaseURL}
+								inTagLinkTest={inTagLinkTest}
 							/>
 						</GridItem>
 						<GridItem area="border">

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -249,7 +249,9 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 	const renderAds = isWeb && canRenderAds(article);
 
 	const isLabs = format.theme === ArticleSpecial.Labs;
-	const inTagLinkTest = false;
+
+	const inTagLinkTest =
+		article.config.abTests.tagLinkDesignVariant === 'variant';
 
 	const { absoluteServerTimes = false } = article.config.switches;
 

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -413,7 +413,8 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 	const inUpdatedHeaderABTest =
 		article.config.abTests.updatedHeaderDesignVariant === 'variant';
 
-	const inTagLinkTest = false;
+	const inTagLinkTest =
+		article.config.abTests.tagLinkDesignVariant === 'variant';
 	return (
 		<>
 			{isWeb && (

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -592,7 +592,10 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 				<AdSlot position="survey" display={format.display} />
 			)}
 
-			<main data-layout="StandardLayout">
+			<main
+				data-layout="StandardLayout"
+				className="sticky-title-experiment"
+			>
 				{isApps && (
 					<>
 						<Island priority="critical">

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -413,6 +413,7 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 	const inUpdatedHeaderABTest =
 		article.config.abTests.updatedHeaderDesignVariant === 'variant';
 
+	const inTagLinkTest = false;
 	return (
 		<>
 			{isWeb && (
@@ -594,7 +595,7 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 
 			<main
 				data-layout="StandardLayout"
-				className="sticky-title-experiment"
+				className={inTagLinkTest ? 'sticky-tag-link-test' : ''}
 			>
 				{isApps && (
 					<>
@@ -685,6 +686,7 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 								sectionUrl={article.sectionUrl}
 								guardianBaseURL={article.guardianBaseURL}
 								isMatch={!!footballMatchUrl}
+								inTagLinkTest={inTagLinkTest}
 							/>
 						</GridItem>
 						<GridItem area="border">

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -6292,15 +6292,6 @@ const paletteColours = {
 		light: recommendationCountLight,
 		dark: recommendationCountDark,
 	},
-	'--tag-link-background': {
-		light: tagLinkBackground,
-		dark: tagLinkBackground,
-	},
-
-	'--tag-link-accent': {
-		light: tagLinkAccent,
-		dark: tagLinkAccent,
-	},
 	'--recommendation-count-arrow': {
 		light: recommendationCountArrowLight,
 		dark: recommendationCountArrowDark,
@@ -6508,6 +6499,14 @@ const paletteColours = {
 	'--tabs-input': {
 		light: () => sourcePalette.neutral[100],
 		dark: () => sourcePalette.neutral[0],
+	},
+	'--tag-link-accent': {
+		light: tagLinkAccent,
+		dark: tagLinkAccent,
+	},
+	'--tag-link-background': {
+		light: tagLinkBackground,
+		dark: tagLinkBackground,
 	},
 	'--timeline-atom-bullet': {
 		light: timelineAtomBulletLight,

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -5453,6 +5453,8 @@ const mastheadVeggieBurgerBackground: PaletteFunction = () =>
 const mastheadVeggieBurgerBackgroundHover: PaletteFunction = () =>
 	sourcePalette.brandAlt[300];
 
+const tagLinkBackground: PaletteFunction = () => sourcePalette.sport[800];
+const tagLinkAccent: PaletteFunction = () => sourcePalette.sport[400];
 // ----- Palette ----- //
 
 /**
@@ -6289,6 +6291,15 @@ const paletteColours = {
 	'--recommendation-count': {
 		light: recommendationCountLight,
 		dark: recommendationCountDark,
+	},
+	'--tag-link-background': {
+		light: tagLinkBackground,
+		dark: tagLinkBackground,
+	},
+
+	'--tag-link-accent': {
+		light: tagLinkAccent,
+		dark: tagLinkAccent,
 	},
 	'--recommendation-count-arrow': {
 		light: recommendationCountArrowLight,


### PR DESCRIPTION
## What does this change?
Adds a sticky tag link component for the big events tag link design test. 

## Why?
We want to test if a more visible tag link improves CTR to the tag page. This test is currently scoped to the Euros 2024 tag at present and so tag data has been hard coded. It will also override the current tag to show Euros 24 when the Euros 2024 tag is present in the tag list but is not the top tag.

## Screenshots
![image](https://github.com/guardian/dotcom-rendering/assets/20416599/2ecd4d16-82bc-4501-99c1-22e5246f98d5)

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
