### PR TITLE
Fix Cotton Capital onwards content cards colours

### DIFF
--- a/dotcom-rendering/src/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/InteractiveLayout.tsx
@@ -774,7 +774,9 @@ export const InteractiveLayout = (props: WebProps | AppsProps) => {
 					<Section
 						fullWidth={true}
 						showTopBorder={false}
-						backgroundColour={themePalette('--article-background')}
+						backgroundColour={themePalette(
+							'--article-section-background',
+						)}
 						borderColour={themePalette('--article-border')}
 					>
 						<Island priority="feature" defer={{ until: 'visible' }}>

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -2394,31 +2394,36 @@ const cardAgeTextDark = (): string => {
 };
 
 const cardOnwardContentFooterLight: PaletteFunction = ({ theme, design }) => {
-	switch (design) {
-		case ArticleDesign.Gallery:
-		case ArticleDesign.Audio:
-		case ArticleDesign.Video:
-			return sourcePalette.neutral[100];
-		case ArticleDesign.LiveBlog:
-			switch (theme) {
-				case ArticleSpecial.Labs:
-					return sourcePalette.neutral[7];
-				case Pillar.News:
-				case Pillar.Sport:
-				case Pillar.Opinion:
-				case Pillar.Culture:
-				case Pillar.Lifestyle:
-				default:
+	switch (theme) {
+		case ArticleSpecial.SpecialReportAlt:
+			return sourcePalette.specialReportAlt[100];
+		case ArticleSpecial.SpecialReport:
+			return sourcePalette.brandAlt[400];
+		default: {
+			switch (design) {
+				case ArticleDesign.Gallery:
+				case ArticleDesign.Audio:
+				case ArticleDesign.Video:
 					return sourcePalette.neutral[100];
-			}
-		default:
-			switch (theme) {
-				case ArticleSpecial.SpecialReport:
-				case ArticleSpecial.SpecialReportAlt:
-					return sourcePalette.brandAlt[400];
+				case ArticleDesign.LiveBlog:
+					switch (theme) {
+						case ArticleSpecial.Labs:
+							return sourcePalette.neutral[7];
+						case Pillar.News:
+						case Pillar.Sport:
+						case Pillar.Opinion:
+						case Pillar.Culture:
+						case Pillar.Lifestyle:
+						default:
+							return sourcePalette.neutral[100];
+					}
 				default:
-					return sourcePalette.neutral[46];
+					switch (theme) {
+						default:
+							return sourcePalette.neutral[46];
+					}
 			}
+		}
 	}
 };
 
@@ -2520,6 +2525,7 @@ const onwardContentCardBackgroundLight: PaletteFunction = ({
 }) => {
 	switch (theme) {
 		case ArticleSpecial.SpecialReportAlt:
+			return sourcePalette.specialReportAlt[800];
 		case ArticleSpecial.SpecialReport:
 			return sourcePalette.neutral[46];
 		default:
@@ -2572,6 +2578,7 @@ const onwardContentCardBackgroundDark: PaletteFunction = ({
 const onwardContentCardHoverLight: PaletteFunction = ({ theme, design }) => {
 	switch (theme) {
 		case ArticleSpecial.SpecialReportAlt:
+			return sourcePalette.specialReportAlt[700];
 		case ArticleSpecial.SpecialReport:
 			return sourcePalette.neutral[20];
 		default:
@@ -2662,7 +2669,7 @@ const cardTextDark = (): string => {
 const cardOnwardContentTextLight: PaletteFunction = (format) => {
 	switch (format.theme) {
 		case ArticleSpecial.SpecialReportAlt:
-			return sourcePalette.neutral[100];
+			return sourcePalette.specialReportAlt[100];
 		default:
 			if (
 				format.display === ArticleDisplay.Immersive &&


### PR DESCRIPTION
Closes https://github.com/guardian/dotcom-rendering/issues/10814

## What does this change?
Fixes Cotton Capital onward content cards colours

## Why?
To match designs

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/e12624f5-1069-4704-b88c-52f5aa31d204) | ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/34b9da3d-d876-4893-a6c8-c75fe4f94b18) |
| ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/107ae385-8b33-4912-9dbd-b83a2ea572ed) | ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/f9e61b12-c8c1-4843-a19f-38ff218db219) |


[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
