### PR TITLE
Enable Absolute times on server

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.stories.tsx
+++ b/dotcom-rendering/src/components/Card/Card.stories.tsx
@@ -40,6 +40,7 @@ const basicCardProps: CardProps = {
 	imageLoading: 'eager',
 	discussionApiUrl: 'https://discussion.theguardian.com/discussion-api/',
 	showMainVideo: true,
+	absoluteServerTimes: true,
 };
 
 const aBasicLink = {

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -57,6 +57,7 @@ import { TrailTextWrapper } from './components/TrailTextWrapper';
 export type Props = {
 	linkTo: string;
 	format: ArticleFormat;
+	absoluteServerTimes: boolean;
 	headlineText: string;
 	headlineSize?: SmallHeadlineSize;
 	headlineSizeOnMobile?: SmallHeadlineSize;
@@ -289,6 +290,7 @@ export const Card = ({
 	onwardsSource,
 	pauseOffscreenVideo = false,
 	showMainVideo = true,
+	absoluteServerTimes,
 }: Props) => {
 	const palette = decidePalette(format, containerPalette);
 
@@ -326,6 +328,7 @@ export const Card = ({
 							showClock={showClock}
 							isDynamo={isDynamo}
 							isOnwardContent={isOnwardContent}
+							absoluteServerTimes={absoluteServerTimes}
 						/>
 					) : undefined
 				}
@@ -639,6 +642,9 @@ export const Card = ({
 										isDynamo={isDynamo}
 										direction={supportingContentAlignment}
 										containerPalette={containerPalette}
+										absoluteServerTimes={
+											absoluteServerTimes
+										}
 									></LatestLinks>
 								</Island>
 							)}

--- a/dotcom-rendering/src/components/Card/components/CardAge.tsx
+++ b/dotcom-rendering/src/components/Card/components/CardAge.tsx
@@ -8,6 +8,7 @@ import { DateTime } from '../../DateTime';
 
 type Props = {
 	format: ArticleFormat;
+	absoluteServerTimes: boolean;
 	containerPalette?: DCRContainerPalette;
 	webPublicationDate: string;
 	showClock?: boolean;
@@ -66,6 +67,7 @@ export const CardAge = ({
 	showClock,
 	isDynamo,
 	isOnwardContent,
+	absoluteServerTimes,
 }: Props) => {
 	if (timeAgo(new Date(webPublicationDate).getTime()) === false) {
 		return null;
@@ -79,6 +81,7 @@ export const CardAge = ({
 			<DateTime
 				date={new Date(webPublicationDate)}
 				display="relative"
+				absoluteServerTimes={absoluteServerTimes}
 				editionId={'UK'}
 				showWeekday={false}
 				showDate={true}

--- a/dotcom-rendering/src/components/Carousel.importable.tsx
+++ b/dotcom-rendering/src/components/Carousel.importable.tsx
@@ -41,6 +41,7 @@ type Props = {
 	onwardsSource: OnwardsSource;
 	leftColSize: LeftColSize;
 	discussionApiUrl: string;
+	absoluteServerTimes: boolean;
 };
 
 type ArticleProps = Props & {
@@ -462,6 +463,7 @@ type CarouselCardProps = {
 	linkTo: string;
 	headlineText: string;
 	webPublicationDate: string;
+	absoluteServerTimes: boolean;
 	imageLoading: Loading;
 	kickerText?: string;
 	image?: DCRFrontImage;
@@ -494,6 +496,7 @@ const CarouselCard = ({
 	imageLoading,
 	discussionApiUrl,
 	isOnwardContent,
+	absoluteServerTimes,
 }: CarouselCardProps) => {
 	const isVideoContainer = containerType === 'fixed/video';
 	const cardImagePosition = isOnwardContent ? 'bottom' : 'top';
@@ -536,6 +539,7 @@ const CarouselCard = ({
 				isOnwardContent={isOnwardContent}
 				imagePosition={cardImagePosition}
 				imagePositionOnMobile={cardImagePosition}
+				absoluteServerTimes={absoluteServerTimes}
 			/>
 		</LI>
 	);
@@ -781,6 +785,7 @@ export const Carousel = ({
 	leftColSize,
 	discussionApiUrl,
 	isOnwardContent = true,
+	absoluteServerTimes,
 	...props
 }: ArticleProps | FrontProps) => {
 	const carouselRef = useRef<HTMLUListElement>(null);
@@ -1014,6 +1019,7 @@ export const Carousel = ({
 									linkTo={linkTo}
 									headlineText={headlineText}
 									webPublicationDate={webPublicationDate}
+									absoluteServerTimes={absoluteServerTimes}
 									image={image}
 									kickerText={kickerText}
 									dataLinkName={`carousel-small-card-position-${i}`}

--- a/dotcom-rendering/src/components/Carousel.stories.tsx
+++ b/dotcom-rendering/src/components/Carousel.stories.tsx
@@ -269,6 +269,7 @@ export const Headlines: StoryObj = ({ format }: StoryProps) => {
 				format={format}
 				leftColSize="compact"
 				discussionApiUrl={discussionApiUrl}
+				absoluteServerTimes={true}
 			/>
 		</Section>
 	);
@@ -293,6 +294,7 @@ export const SingleItemCarousel = () => {
 				format={defaultFormat}
 				leftColSize="compact"
 				discussionApiUrl={discussionApiUrl}
+				absoluteServerTimes={true}
 			/>
 		</Section>
 	);
@@ -346,6 +348,7 @@ export const SingleOpinionCarousel = () => {
 				}}
 				leftColSize="compact"
 				discussionApiUrl={discussionApiUrl}
+				absoluteServerTimes={true}
 			/>
 		</Section>
 	);
@@ -375,6 +378,7 @@ export const Immersive = () => {
 					}}
 					leftColSize="compact"
 					discussionApiUrl={discussionApiUrl}
+					absoluteServerTimes={true}
 				/>
 			</Section>
 		</>
@@ -419,6 +423,7 @@ export const SpecialReportAlt = () => {
 				format={specialReportAltFormat}
 				leftColSize="compact"
 				discussionApiUrl={discussionApiUrl}
+				absoluteServerTimes={true}
 			/>
 		</Section>
 	);
@@ -632,6 +637,7 @@ export const AllCards = () => {
 				leftColSize="compact"
 				discussionApiUrl={discussionApiUrl}
 				format={defaultFormat}
+				absoluteServerTimes={true}
 			/>
 		</Section>
 	);
@@ -655,6 +661,7 @@ export const FrontCarousel = () => (
 				url={'https://www.theguardian.com'}
 				discussionApiUrl={discussionApiUrl}
 				palette={'BreakingPalette'}
+				absoluteServerTimes={true}
 			/>
 		</Section>
 	</>

--- a/dotcom-rendering/src/components/DateTime.tsx
+++ b/dotcom-rendering/src/components/DateTime.tsx
@@ -9,8 +9,17 @@ type Props = {
 	showWeekday: boolean;
 	showDate: boolean;
 	showTime: boolean;
-	display?: 'absolute' | 'relative';
 };
+
+type DisplayProps =
+	| {
+			display?: 'absolute';
+			absoluteServerTimes?: never;
+	  }
+	| {
+			display: 'relative';
+			absoluteServerTimes: boolean;
+	  };
 
 const formatWeekday = (date: Date, locale: string, timeZone: string) =>
 	date.toLocaleDateString(locale, {
@@ -46,16 +55,18 @@ export const DateTime = ({
 	showDate,
 	showTime,
 	display = 'absolute',
-}: Props) => {
+	absoluteServerTimes = true,
+}: Props & DisplayProps) => {
 	const { dateLocale, timeZone } = getEditionFromId(editionId);
 
 	const epoch = date.getTime();
 	const relativeTime = display === 'relative' && timeAgo(epoch);
 	const isRecent = isString(relativeTime) && relativeTime.endsWith(' ago');
+	const now = absoluteServerTimes ? Number.MAX_SAFE_INTEGER - 1 : Date.now();
 
 	return isRecent ? (
 		<Island priority="enhancement" defer={{ until: 'visible' }}>
-			<RelativeTime then={epoch} />
+			<RelativeTime then={epoch} now={now} />
 		</Island>
 	) : (
 		<time

--- a/dotcom-rendering/src/components/DecideContainer.tsx
+++ b/dotcom-rendering/src/components/DecideContainer.tsx
@@ -31,6 +31,7 @@ type Props = {
 	containerType: DCRContainerType;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
+	absoluteServerTimes: boolean;
 };
 
 export const DecideContainer = ({
@@ -39,6 +40,7 @@ export const DecideContainer = ({
 	containerType,
 	containerPalette,
 	showAge,
+	absoluteServerTimes,
 	imageLoading,
 }: Props) => {
 	// If you add a new container type which contains an MPU, you must also add it to
@@ -49,6 +51,7 @@ export const DecideContainer = ({
 					groupedTrails={groupedTrails}
 					containerPalette={containerPalette}
 					showAge={showAge}
+					absoluteServerTimes={absoluteServerTimes}
 					imageLoading={imageLoading}
 				/>
 			);
@@ -58,6 +61,7 @@ export const DecideContainer = ({
 					groupedTrails={groupedTrails}
 					containerPalette={containerPalette}
 					showAge={showAge}
+					absoluteServerTimes={absoluteServerTimes}
 					imageLoading={imageLoading}
 				/>
 			);
@@ -67,6 +71,7 @@ export const DecideContainer = ({
 					groupedTrails={groupedTrails}
 					containerPalette={containerPalette}
 					showAge={showAge}
+					absoluteServerTimes={absoluteServerTimes}
 					imageLoading={imageLoading}
 				/>
 			);
@@ -76,6 +81,7 @@ export const DecideContainer = ({
 					groupedTrails={groupedTrails}
 					containerPalette={containerPalette}
 					showAge={showAge}
+					absoluteServerTimes={absoluteServerTimes}
 					imageLoading={imageLoading}
 				/>
 			);
@@ -85,6 +91,7 @@ export const DecideContainer = ({
 					trails={trails}
 					containerPalette={containerPalette}
 					showAge={showAge}
+					absoluteServerTimes={absoluteServerTimes}
 					imageLoading={imageLoading}
 				/>
 			);
@@ -94,6 +101,7 @@ export const DecideContainer = ({
 					trails={trails}
 					containerPalette={containerPalette}
 					showAge={showAge}
+					absoluteServerTimes={absoluteServerTimes}
 					imageLoading={imageLoading}
 				/>
 			);
@@ -103,6 +111,7 @@ export const DecideContainer = ({
 					trails={trails}
 					containerPalette={containerPalette}
 					showAge={showAge}
+					absoluteServerTimes={absoluteServerTimes}
 					imageLoading={imageLoading}
 				/>
 			);
@@ -112,6 +121,7 @@ export const DecideContainer = ({
 					trails={trails}
 					containerPalette={containerPalette}
 					showAge={showAge}
+					absoluteServerTimes={absoluteServerTimes}
 					imageLoading={imageLoading}
 				/>
 			);
@@ -121,6 +131,7 @@ export const DecideContainer = ({
 					trails={trails}
 					containerPalette={containerPalette}
 					showAge={showAge}
+					absoluteServerTimes={absoluteServerTimes}
 					imageLoading={imageLoading}
 				/>
 			);
@@ -130,6 +141,7 @@ export const DecideContainer = ({
 					trails={trails}
 					containerPalette={containerPalette}
 					showAge={showAge}
+					absoluteServerTimes={absoluteServerTimes}
 					imageLoading={imageLoading}
 				/>
 			);
@@ -139,6 +151,7 @@ export const DecideContainer = ({
 					trails={trails}
 					containerPalette={containerPalette}
 					showAge={showAge}
+					absoluteServerTimes={absoluteServerTimes}
 					imageLoading={imageLoading}
 				/>
 			);
@@ -148,6 +161,7 @@ export const DecideContainer = ({
 					trails={trails}
 					containerPalette={containerPalette}
 					showAge={showAge}
+					absoluteServerTimes={absoluteServerTimes}
 					imageLoading={imageLoading}
 				/>
 			);
@@ -157,6 +171,7 @@ export const DecideContainer = ({
 					trails={trails}
 					containerPalette={containerPalette}
 					showAge={showAge}
+					absoluteServerTimes={absoluteServerTimes}
 					imageLoading={imageLoading}
 				/>
 			);
@@ -166,6 +181,7 @@ export const DecideContainer = ({
 					trails={trails}
 					containerPalette={containerPalette}
 					showAge={showAge}
+					absoluteServerTimes={absoluteServerTimes}
 					imageLoading={imageLoading}
 				/>
 			);
@@ -175,6 +191,7 @@ export const DecideContainer = ({
 					trails={trails}
 					containerPalette={containerPalette}
 					showAge={showAge}
+					absoluteServerTimes={absoluteServerTimes}
 					imageLoading={imageLoading}
 				/>
 			);
@@ -184,6 +201,7 @@ export const DecideContainer = ({
 					trails={trails}
 					containerPalette={containerPalette}
 					showAge={showAge}
+					absoluteServerTimes={absoluteServerTimes}
 					imageLoading={imageLoading}
 				/>
 			);
@@ -193,6 +211,7 @@ export const DecideContainer = ({
 					trails={trails}
 					containerPalette={containerPalette}
 					showAge={showAge}
+					absoluteServerTimes={absoluteServerTimes}
 					imageLoading={imageLoading}
 				/>
 			);

--- a/dotcom-rendering/src/components/DecideContainerByTrails.tsx
+++ b/dotcom-rendering/src/components/DecideContainerByTrails.tsx
@@ -32,6 +32,7 @@ export const OneCardFast = ({
 				<Card100Media50
 					trail={trail}
 					showAge={true}
+					absoluteServerTimes={true}
 					imageLoading={imageLoading}
 				/>
 			</LI>
@@ -52,6 +53,7 @@ export const OneCardSlow = ({
 				<Card100Media75
 					trail={trail}
 					showAge={true}
+					absoluteServerTimes={true}
 					imageLoading={imageLoading}
 				/>
 			</LI>
@@ -72,6 +74,7 @@ export const TwoCard = ({
 				<Card50Media50
 					trail={trails[0]}
 					showAge={true}
+					absoluteServerTimes={true}
 					imageLoading={imageLoading}
 				/>
 			</LI>
@@ -79,6 +82,7 @@ export const TwoCard = ({
 				<Card50Media50
 					trail={trails[1]}
 					showAge={true}
+					absoluteServerTimes={true}
 					imageLoading={imageLoading}
 				/>
 			</LI>
@@ -99,6 +103,7 @@ export const ThreeCard = ({
 				<Card33Media33
 					trail={trails[0]}
 					showAge={true}
+					absoluteServerTimes={true}
 					imageLoading={imageLoading}
 				/>
 			</LI>
@@ -106,6 +111,7 @@ export const ThreeCard = ({
 				<Card33Media33
 					trail={trails[1]}
 					showAge={true}
+					absoluteServerTimes={true}
 					imageLoading={imageLoading}
 				/>
 			</LI>
@@ -113,6 +119,7 @@ export const ThreeCard = ({
 				<Card33Media33
 					trail={trails[2]}
 					showAge={true}
+					absoluteServerTimes={true}
 					imageLoading={imageLoading}
 				/>
 			</LI>
@@ -133,6 +140,7 @@ export const FourCard = ({
 				<Card25Media25
 					trail={trails[0]}
 					showAge={true}
+					absoluteServerTimes={true}
 					imageLoading={imageLoading}
 				/>
 			</LI>
@@ -140,6 +148,7 @@ export const FourCard = ({
 				<Card25Media25
 					trail={trails[1]}
 					showAge={true}
+					absoluteServerTimes={true}
 					imageLoading={imageLoading}
 				/>
 			</LI>
@@ -147,6 +156,7 @@ export const FourCard = ({
 				<Card25Media25
 					trail={trails[2]}
 					showAge={true}
+					absoluteServerTimes={true}
 					imageLoading={imageLoading}
 				/>
 			</LI>
@@ -154,6 +164,7 @@ export const FourCard = ({
 				<Card25Media25
 					trail={trails[3]}
 					showAge={true}
+					absoluteServerTimes={true}
 					imageLoading={imageLoading}
 				/>
 			</LI>
@@ -174,6 +185,7 @@ export const FiveCardFast = ({
 				<Card33Media33
 					trail={trails[0]}
 					showAge={true}
+					absoluteServerTimes={true}
 					imageLoading={imageLoading}
 				/>
 			</LI>
@@ -181,19 +193,32 @@ export const FiveCardFast = ({
 				<Card33Media33
 					trail={trails[1]}
 					showAge={true}
+					absoluteServerTimes={true}
 					imageLoading={imageLoading}
 				/>
 			</LI>
 			<LI percentage="33.333%">
 				<UL direction="column" showDivider={true}>
 					<LI padSides={true}>
-						<CardDefault trail={trails[2]} showAge={true} />
+						<CardDefault
+							trail={trails[2]}
+							showAge={true}
+							absoluteServerTimes={true}
+						/>
 					</LI>
 					<LI padSides={true}>
-						<CardDefault trail={trails[3]} showAge={true} />
+						<CardDefault
+							trail={trails[3]}
+							showAge={true}
+							absoluteServerTimes={true}
+						/>
 					</LI>
 					<LI padSides={true}>
-						<CardDefault trail={trails[4]} showAge={true} />
+						<CardDefault
+							trail={trails[4]}
+							showAge={true}
+							absoluteServerTimes={true}
+						/>
 					</LI>
 				</UL>
 			</LI>
@@ -215,6 +240,7 @@ export const FiveCardSlow = ({
 					<Card33Media33
 						trail={trails[0]}
 						showAge={true}
+						absoluteServerTimes={true}
 						imageLoading={imageLoading}
 					/>
 				</LI>
@@ -222,6 +248,7 @@ export const FiveCardSlow = ({
 					<Card33Media33
 						trail={trails[1]}
 						showAge={true}
+						absoluteServerTimes={true}
 						imageLoading={imageLoading}
 					/>
 				</LI>
@@ -231,6 +258,7 @@ export const FiveCardSlow = ({
 					<Card33Media33
 						trail={trails[2]}
 						showAge={true}
+						absoluteServerTimes={true}
 						imageLoading={imageLoading}
 					/>
 				</LI>
@@ -238,6 +266,7 @@ export const FiveCardSlow = ({
 					<Card33Media33
 						trail={trails[3]}
 						showAge={true}
+						absoluteServerTimes={true}
 						imageLoading={imageLoading}
 					/>
 				</LI>
@@ -245,6 +274,7 @@ export const FiveCardSlow = ({
 					<Card33Media33
 						trail={trails[4]}
 						showAge={true}
+						absoluteServerTimes={true}
 						imageLoading={imageLoading}
 					/>
 				</LI>
@@ -267,6 +297,7 @@ export const SixCardFast = ({
 					<Card25Media25
 						trail={trails[0]}
 						showAge={true}
+						absoluteServerTimes={true}
 						imageLoading={imageLoading}
 					/>
 				</LI>
@@ -274,6 +305,7 @@ export const SixCardFast = ({
 					<Card25Media25
 						trail={trails[1]}
 						showAge={true}
+						absoluteServerTimes={true}
 						imageLoading={imageLoading}
 					/>
 				</LI>
@@ -281,6 +313,7 @@ export const SixCardFast = ({
 					<Card25Media25
 						trail={trails[2]}
 						showAge={true}
+						absoluteServerTimes={true}
 						imageLoading={imageLoading}
 					/>
 				</LI>
@@ -288,16 +321,25 @@ export const SixCardFast = ({
 					<Card25Media25
 						trail={trails[3]}
 						showAge={true}
+						absoluteServerTimes={true}
 						imageLoading={imageLoading}
 					/>
 				</LI>
 			</UL>
 			<UL direction="row">
 				<LI percentage="50%" padSides={true}>
-					<CardDefault trail={trails[4]} showAge={true} />
+					<CardDefault
+						trail={trails[4]}
+						showAge={true}
+						absoluteServerTimes={true}
+					/>
 				</LI>
 				<LI percentage="50%" padSides={true} showDivider={true}>
-					<CardDefault trail={trails[5]} showAge={true} />
+					<CardDefault
+						trail={trails[5]}
+						showAge={true}
+						absoluteServerTimes={true}
+					/>
 				</LI>
 			</UL>
 		</>
@@ -318,6 +360,7 @@ export const SixCardSlow = ({
 					<Card33Media33
 						trail={trails[0]}
 						showAge={true}
+						absoluteServerTimes={true}
 						imageLoading={imageLoading}
 					/>
 				</LI>
@@ -325,6 +368,7 @@ export const SixCardSlow = ({
 					<Card33Media33
 						trail={trails[1]}
 						showAge={true}
+						absoluteServerTimes={true}
 						imageLoading={imageLoading}
 					/>
 				</LI>
@@ -332,6 +376,7 @@ export const SixCardSlow = ({
 					<Card33Media33
 						trail={trails[2]}
 						showAge={true}
+						absoluteServerTimes={true}
 						imageLoading={imageLoading}
 					/>
 				</LI>
@@ -341,6 +386,7 @@ export const SixCardSlow = ({
 					<Card33Media33
 						trail={trails[3]}
 						showAge={true}
+						absoluteServerTimes={true}
 						imageLoading={imageLoading}
 					/>
 				</LI>
@@ -348,6 +394,7 @@ export const SixCardSlow = ({
 					<Card33Media33
 						trail={trails[4]}
 						showAge={true}
+						absoluteServerTimes={true}
 						imageLoading={imageLoading}
 					/>
 				</LI>
@@ -355,6 +402,7 @@ export const SixCardSlow = ({
 					<Card33Media33
 						trail={trails[5]}
 						showAge={true}
+						absoluteServerTimes={true}
 						imageLoading={imageLoading}
 					/>
 				</LI>
@@ -377,6 +425,7 @@ export const SevenCardFast = ({
 					<Card25Media25
 						trail={trails[0]}
 						showAge={true}
+						absoluteServerTimes={true}
 						imageLoading={imageLoading}
 					/>
 				</LI>
@@ -384,6 +433,7 @@ export const SevenCardFast = ({
 					<Card25Media25
 						trail={trails[1]}
 						showAge={true}
+						absoluteServerTimes={true}
 						imageLoading={imageLoading}
 					/>
 				</LI>
@@ -391,6 +441,7 @@ export const SevenCardFast = ({
 					<Card25Media25
 						trail={trails[2]}
 						showAge={true}
+						absoluteServerTimes={true}
 						imageLoading={imageLoading}
 					/>
 				</LI>
@@ -398,19 +449,32 @@ export const SevenCardFast = ({
 					<Card25Media25
 						trail={trails[3]}
 						showAge={true}
+						absoluteServerTimes={true}
 						imageLoading={imageLoading}
 					/>
 				</LI>
 			</UL>
 			<UL direction="row">
 				<LI percentage="33.333%" padSides={true}>
-					<CardDefault trail={trails[4]} showAge={true} />
+					<CardDefault
+						trail={trails[4]}
+						showAge={true}
+						absoluteServerTimes={true}
+					/>
 				</LI>
 				<LI percentage="33.333%" padSides={true} showDivider={true}>
-					<CardDefault trail={trails[5]} showAge={true} />
+					<CardDefault
+						trail={trails[5]}
+						showAge={true}
+						absoluteServerTimes={true}
+					/>
 				</LI>
 				<LI percentage="33.333%" padSides={true} showDivider={true}>
-					<CardDefault trail={trails[6]} showAge={true} />
+					<CardDefault
+						trail={trails[6]}
+						showAge={true}
+						absoluteServerTimes={true}
+					/>
 				</LI>
 			</UL>
 		</>
@@ -431,6 +495,7 @@ export const SevenCardSlow = ({
 					<Card33Media33
 						trail={trails[0]}
 						showAge={true}
+						absoluteServerTimes={true}
 						imageLoading={imageLoading}
 					/>
 				</LI>
@@ -438,6 +503,7 @@ export const SevenCardSlow = ({
 					<Card33Media33
 						trail={trails[1]}
 						showAge={true}
+						absoluteServerTimes={true}
 						imageLoading={imageLoading}
 					/>
 				</LI>
@@ -445,6 +511,7 @@ export const SevenCardSlow = ({
 					<Card33Media33
 						trail={trails[2]}
 						showAge={true}
+						absoluteServerTimes={true}
 						imageLoading={imageLoading}
 					/>
 				</LI>
@@ -454,6 +521,7 @@ export const SevenCardSlow = ({
 					<Card25Media25
 						trail={trails[3]}
 						showAge={true}
+						absoluteServerTimes={true}
 						imageLoading={imageLoading}
 					/>
 				</LI>
@@ -461,6 +529,7 @@ export const SevenCardSlow = ({
 					<Card25Media25
 						trail={trails[4]}
 						showAge={true}
+						absoluteServerTimes={true}
 						imageLoading={imageLoading}
 					/>
 				</LI>
@@ -468,6 +537,7 @@ export const SevenCardSlow = ({
 					<Card25Media25
 						trail={trails[5]}
 						showAge={true}
+						absoluteServerTimes={true}
 						imageLoading={imageLoading}
 					/>
 				</LI>
@@ -475,6 +545,7 @@ export const SevenCardSlow = ({
 					<Card25Media25
 						trail={trails[6]}
 						showAge={true}
+						absoluteServerTimes={true}
 						imageLoading={imageLoading}
 					/>
 				</LI>
@@ -499,6 +570,7 @@ export const EightOrMoreFast = ({
 					<Card25Media25
 						trail={trails[0]}
 						showAge={true}
+						absoluteServerTimes={true}
 						imageLoading={imageLoading}
 					/>
 				</LI>
@@ -506,6 +578,7 @@ export const EightOrMoreFast = ({
 					<Card25Media25
 						trail={trails[1]}
 						showAge={true}
+						absoluteServerTimes={true}
 						imageLoading={imageLoading}
 					/>
 				</LI>
@@ -513,6 +586,7 @@ export const EightOrMoreFast = ({
 					<Card25Media25
 						trail={trails[2]}
 						showAge={true}
+						absoluteServerTimes={true}
 						imageLoading={imageLoading}
 					/>
 				</LI>
@@ -520,22 +594,39 @@ export const EightOrMoreFast = ({
 					<Card25Media25
 						trail={trails[3]}
 						showAge={true}
+						absoluteServerTimes={true}
 						imageLoading={imageLoading}
 					/>
 				</LI>
 			</UL>
 			<UL direction="row" padBottom={afterEight.length > 0}>
 				<LI percentage="25%" padSides={true}>
-					<CardDefault trail={trails[4]} showAge={true} />
+					<CardDefault
+						trail={trails[4]}
+						showAge={true}
+						absoluteServerTimes={true}
+					/>
 				</LI>
 				<LI percentage="25%" padSides={true} showDivider={true}>
-					<CardDefault trail={trails[5]} showAge={true} />
+					<CardDefault
+						trail={trails[5]}
+						showAge={true}
+						absoluteServerTimes={true}
+					/>
 				</LI>
 				<LI percentage="25%" padSides={true} showDivider={true}>
-					<CardDefault trail={trails[6]} showAge={true} />
+					<CardDefault
+						trail={trails[6]}
+						showAge={true}
+						absoluteServerTimes={true}
+					/>
 				</LI>
 				<LI percentage="25%" padSides={true} showDivider={true}>
-					<CardDefault trail={trails[7]} showAge={true} />
+					<CardDefault
+						trail={trails[7]}
+						showAge={true}
+						absoluteServerTimes={true}
+					/>
 				</LI>
 			</UL>
 			{afterEight.length > 0 ? (
@@ -547,7 +638,11 @@ export const EightOrMoreFast = ({
 							padSides={true}
 							showDivider={index % 3 !== 0}
 						>
-							<CardDefault trail={trail} showAge={true} />
+							<CardDefault
+								trail={trail}
+								showAge={true}
+								absoluteServerTimes={true}
+							/>
 						</LI>
 					))}
 				</UL>
@@ -574,6 +669,7 @@ export const EightOrMoreSlow = ({
 					<Card25Media25
 						trail={trails[0]}
 						showAge={true}
+						absoluteServerTimes={true}
 						imageLoading={imageLoading}
 					/>
 				</LI>
@@ -581,6 +677,7 @@ export const EightOrMoreSlow = ({
 					<Card25Media25
 						trail={trails[1]}
 						showAge={true}
+						absoluteServerTimes={true}
 						imageLoading={imageLoading}
 					/>
 				</LI>
@@ -588,6 +685,7 @@ export const EightOrMoreSlow = ({
 					<Card25Media25
 						trail={trails[2]}
 						showAge={true}
+						absoluteServerTimes={true}
 						imageLoading={imageLoading}
 					/>
 				</LI>
@@ -595,6 +693,7 @@ export const EightOrMoreSlow = ({
 					<Card25Media25
 						trail={trails[3]}
 						showAge={true}
+						absoluteServerTimes={true}
 						imageLoading={imageLoading}
 					/>
 				</LI>
@@ -604,6 +703,7 @@ export const EightOrMoreSlow = ({
 					<Card25Media25
 						trail={trails[4]}
 						showAge={true}
+						absoluteServerTimes={true}
 						imageLoading={imageLoading}
 					/>
 				</LI>
@@ -611,6 +711,7 @@ export const EightOrMoreSlow = ({
 					<Card25Media25
 						trail={trails[5]}
 						showAge={true}
+						absoluteServerTimes={true}
 						imageLoading={imageLoading}
 					/>
 				</LI>
@@ -618,6 +719,7 @@ export const EightOrMoreSlow = ({
 					<Card25Media25
 						trail={trails[6]}
 						showAge={true}
+						absoluteServerTimes={true}
 						imageLoading={imageLoading}
 					/>
 				</LI>
@@ -625,6 +727,7 @@ export const EightOrMoreSlow = ({
 					<Card25Media25
 						trail={trails[7]}
 						showAge={true}
+						absoluteServerTimes={true}
 						imageLoading={imageLoading}
 					/>
 				</LI>
@@ -641,6 +744,7 @@ export const EightOrMoreSlow = ({
 							<Card25Media25
 								trail={trail}
 								showAge={true}
+								absoluteServerTimes={true}
 								imageLoading={imageLoading}
 							/>
 						</LI>

--- a/dotcom-rendering/src/components/DynamicFast.stories.tsx
+++ b/dotcom-rendering/src/components/DynamicFast.stories.tsx
@@ -44,6 +44,7 @@ export const OneHugeTwoBigsSixStandards = () => (
 				standard: trails.slice(3, 10),
 			}}
 			showAge={true}
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>
@@ -65,6 +66,7 @@ export const OneVeryBigTwoBigsSixStandards = () => (
 				standard: trails.slice(3, 10),
 			}}
 			showAge={true}
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>
@@ -87,6 +89,7 @@ export const TwoVeryBigsTwoBigsSixStandards = () => (
 				standard: trails.slice(4, 11),
 			}}
 			showAge={true}
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>
@@ -109,6 +112,7 @@ export const TwoVeryBigs1stBoostedTwoBigsSixStandards = () => (
 				standard: trails.slice(4, 11),
 			}}
 			showAge={true}
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>
@@ -131,6 +135,7 @@ export const TwoVeryBigs2ndBoostedTwoBigsSixStandards = () => (
 				standard: trails.slice(4, 11),
 			}}
 			showAge={true}
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>
@@ -154,6 +159,7 @@ export const TwoVeryBigsTwelveStandards = () => (
 				standard: trails.slice(2, 14),
 			}}
 			showAge={true}
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>
@@ -176,6 +182,7 @@ export const TwoVeryBigsOneBigEightStandards = () => (
 				standard: trails.slice(4, 12),
 			}}
 			showAge={true}
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>
@@ -199,6 +206,7 @@ export const TwoVeryBigsOneBigBoostedSixStandards = () => (
 				standard: trails.slice(4, 10),
 			}}
 			showAge={true}
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>
@@ -222,6 +230,7 @@ export const TwoVeryBigsTwoBigsFiveStandards = () => (
 				standard: trails.slice(5, 10),
 			}}
 			showAge={true}
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>
@@ -245,6 +254,7 @@ export const TwoVeryBigsTwoBigsFirstBoostedEightStandards = () => (
 				standard: trails.slice(5, 12),
 			}}
 			showAge={true}
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>
@@ -268,6 +278,7 @@ export const TwoVeryBigsThreeBigsThreeStandards = () => (
 				standard: trails.slice(6, 9),
 			}}
 			showAge={true}
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>
@@ -290,6 +301,7 @@ export const TwoVeryBigsFourBigs = () => (
 				big: [trails[3], trails[4], trails[5], trails[6]],
 			}}
 			showAge={true}
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>
@@ -316,6 +328,7 @@ export const OneHugeOneVeryBig7Standards = () => (
 				standard: trails.slice(2, 9),
 			}}
 			showAge={true}
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>
@@ -338,6 +351,7 @@ export const ThreeVeryBigsFourBigs = () => (
 				big: [trails[3], trails[4], trails[5], trails[6]],
 			}}
 			showAge={true}
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>
@@ -360,6 +374,7 @@ export const TwoBigsFourStandards = () => (
 				standard: trails.slice(2, 6),
 			}}
 			showAge={true}
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>
@@ -383,6 +398,7 @@ export const OneVeryBigTwoBigs = () => (
 				big: [trails[1], trails[2]],
 			}}
 			showAge={true}
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>
@@ -404,6 +420,7 @@ export const OneVeryBig = () => (
 				veryBig: [trails[0]],
 			}}
 			showAge={true}
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>
@@ -427,6 +444,7 @@ export const TwoVeryBigsFourBigsFirstBoostedThreeStandards = () => (
 				standard: trails.slice(5, 8),
 			}}
 			showAge={true}
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>

--- a/dotcom-rendering/src/components/DynamicFast.tsx
+++ b/dotcom-rendering/src/components/DynamicFast.tsx
@@ -35,6 +35,7 @@ type Props = {
 	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
+	absoluteServerTimes: boolean;
 };
 
 /* ._________________.________.________.
@@ -47,12 +48,14 @@ type Props = {
 const Card50_ColumnOfThreeCards25_ColumnOfFiveCards = ({
 	cards,
 	showAge,
+	absoluteServerTimes,
 	containerPalette,
 	imageLoading,
 }: {
 	cards: DCRFrontCard[];
 	imageLoading: Loading;
 	showAge?: boolean;
+	absoluteServerTimes: boolean;
 	containerPalette?: DCRContainerPalette;
 }) => {
 	if (!cards[0]) return null;
@@ -68,6 +71,7 @@ const Card50_ColumnOfThreeCards25_ColumnOfFiveCards = ({
 					trail={big}
 					containerPalette={containerPalette}
 					showAge={showAge}
+					absoluteServerTimes={absoluteServerTimes}
 					imageLoading={imageLoading}
 				/>
 			</LI>
@@ -90,6 +94,9 @@ const Card50_ColumnOfThreeCards25_ColumnOfFiveCards = ({
 										trail={card}
 										containerPalette={containerPalette}
 										showAge={showAge}
+										absoluteServerTimes={
+											absoluteServerTimes
+										}
 										imageLoading={imageLoading}
 									/>
 								) : (
@@ -97,6 +104,9 @@ const Card50_ColumnOfThreeCards25_ColumnOfFiveCards = ({
 										trail={card}
 										containerPalette={containerPalette}
 										showAge={showAge}
+										absoluteServerTimes={
+											absoluteServerTimes
+										}
 									/>
 								)}
 							</LI>
@@ -121,6 +131,7 @@ const Card50_ColumnOfThreeCards25_ColumnOfFiveCards = ({
 									trail={card}
 									containerPalette={containerPalette}
 									showAge={showAge}
+									absoluteServerTimes={absoluteServerTimes}
 								/>
 							</LI>
 						);
@@ -134,12 +145,14 @@ const Card50_ColumnOfThreeCards25_ColumnOfFiveCards = ({
 const Card50_ColumnOfThreeCards25_ColumnOfThreeCards25 = ({
 	cards,
 	showAge,
+	absoluteServerTimes,
 	containerPalette,
 	imageLoading,
 }: {
 	cards: DCRFrontCard[];
 	imageLoading: Loading;
 	showAge?: boolean;
+	absoluteServerTimes: boolean;
 	containerPalette?: DCRContainerPalette;
 }) => {
 	if (!cards[0]) return null;
@@ -153,6 +166,7 @@ const Card50_ColumnOfThreeCards25_ColumnOfThreeCards25 = ({
 					trail={big}
 					containerPalette={containerPalette}
 					showAge={showAge}
+					absoluteServerTimes={absoluteServerTimes}
 					imageLoading={imageLoading}
 				/>
 			</LI>
@@ -184,6 +198,7 @@ const Card50_ColumnOfThreeCards25_ColumnOfThreeCards25 = ({
 									trail={card}
 									containerPalette={containerPalette}
 									showAge={showAge}
+									absoluteServerTimes={absoluteServerTimes}
 								/>
 							</LI>
 						);
@@ -198,10 +213,12 @@ const ColumnOfThreeCards25_ColumnOfThreeCards25_ColumnOfThreeCards25_ColumnOfThr
 	({
 		cards,
 		showAge,
+		absoluteServerTimes,
 		containerPalette,
 	}: {
 		cards: DCRFrontCard[];
 		showAge?: boolean;
+		absoluteServerTimes: boolean;
 		containerPalette?: DCRContainerPalette;
 	}) => {
 		if (cards.length === 0) return null;
@@ -228,6 +245,7 @@ const ColumnOfThreeCards25_ColumnOfThreeCards25_ColumnOfThreeCards25_ColumnOfThr
 								trail={card}
 								containerPalette={containerPalette}
 								showAge={showAge}
+								absoluteServerTimes={absoluteServerTimes}
 							/>
 						</LI>
 					);
@@ -239,12 +257,14 @@ const ColumnOfThreeCards25_ColumnOfThreeCards25_ColumnOfThreeCards25_ColumnOfThr
 const Card25_ColumnOfCards25_ColumnOfThreeCards25_ColumnOfThreeCards25 = ({
 	cards,
 	showAge,
+	absoluteServerTimes,
 	containerPalette,
 	imageLoading,
 }: {
 	cards: DCRFrontCard[];
 	imageLoading: Loading;
 	showAge?: boolean;
+	absoluteServerTimes: boolean;
 	containerPalette?: DCRContainerPalette;
 }) => {
 	if (!cards[0]) return null;
@@ -258,6 +278,7 @@ const Card25_ColumnOfCards25_ColumnOfThreeCards25_ColumnOfThreeCards25 = ({
 					trail={big}
 					containerPalette={containerPalette}
 					showAge={showAge}
+					absoluteServerTimes={absoluteServerTimes}
 					imageLoading={imageLoading}
 				/>
 			</LI>
@@ -289,6 +310,7 @@ const Card25_ColumnOfCards25_ColumnOfThreeCards25_ColumnOfThreeCards25 = ({
 									trail={card}
 									containerPalette={containerPalette}
 									showAge={showAge}
+									absoluteServerTimes={absoluteServerTimes}
 								/>
 							</LI>
 						);
@@ -304,10 +326,12 @@ const Card25_Card25_ColumnOfThreeCards25_ColumnOfThreeCards25 = ({
 	showAge,
 	containerPalette,
 	imageLoading,
+	absoluteServerTimes,
 }: {
 	cards: DCRFrontCard[];
 	imageLoading: Loading;
 	showAge?: boolean;
+	absoluteServerTimes: boolean;
 	containerPalette?: DCRContainerPalette;
 }) => {
 	if (cards.length < 0) return null;
@@ -330,6 +354,7 @@ const Card25_Card25_ColumnOfThreeCards25_ColumnOfThreeCards25 = ({
 							trail={card}
 							containerPalette={containerPalette}
 							showAge={showAge}
+							absoluteServerTimes={absoluteServerTimes}
 							imageLoading={imageLoading}
 						/>
 					</LI>
@@ -364,6 +389,7 @@ const Card25_Card25_ColumnOfThreeCards25_ColumnOfThreeCards25 = ({
 									trail={card}
 									containerPalette={containerPalette}
 									showAge={showAge}
+									absoluteServerTimes={absoluteServerTimes}
 								/>
 							</LI>
 						);
@@ -379,10 +405,12 @@ const Card25_Card25_Card25_ColumnOfThreeCards25 = ({
 	showAge,
 	containerPalette,
 	imageLoading,
+	absoluteServerTimes,
 }: {
 	cards: DCRFrontCard[];
 	imageLoading: Loading;
 	showAge?: boolean;
+	absoluteServerTimes: boolean;
 	containerPalette?: DCRContainerPalette;
 }) => {
 	if (cards.length < 3) return null;
@@ -405,6 +433,7 @@ const Card25_Card25_Card25_ColumnOfThreeCards25 = ({
 							trail={card}
 							containerPalette={containerPalette}
 							showAge={showAge}
+							absoluteServerTimes={absoluteServerTimes}
 							imageLoading={imageLoading}
 						/>
 					</LI>
@@ -431,6 +460,7 @@ const Card25_Card25_Card25_ColumnOfThreeCards25 = ({
 									trail={card}
 									containerPalette={containerPalette}
 									showAge={showAge}
+									absoluteServerTimes={absoluteServerTimes}
 								/>
 							</LI>
 						);
@@ -445,6 +475,7 @@ export const DynamicFast = ({
 	groupedTrails,
 	containerPalette,
 	showAge,
+	absoluteServerTimes,
 	imageLoading,
 }: Props) => {
 	let firstSliceLayout:
@@ -577,6 +608,7 @@ export const DynamicFast = ({
 					<Card100PictureTop
 						cards={firstSliceCards}
 						showAge={showAge}
+						absoluteServerTimes={absoluteServerTimes}
 						containerPalette={containerPalette}
 						imageLoading={imageLoading}
 					/>
@@ -586,6 +618,7 @@ export const DynamicFast = ({
 					<Card100PictureRight
 						cards={firstSliceCards}
 						showAge={showAge}
+						absoluteServerTimes={absoluteServerTimes}
 						containerPalette={containerPalette}
 						imageLoading={imageLoading}
 					/>
@@ -595,6 +628,7 @@ export const DynamicFast = ({
 					<Card75_Card25
 						cards={firstSliceCards}
 						showAge={showAge}
+						absoluteServerTimes={absoluteServerTimes}
 						containerPalette={containerPalette}
 						imageLoading={imageLoading}
 					/>
@@ -604,6 +638,7 @@ export const DynamicFast = ({
 					<Card25_Card75
 						cards={firstSliceCards}
 						showAge={showAge}
+						absoluteServerTimes={absoluteServerTimes}
 						containerPalette={containerPalette}
 						imageLoading={imageLoading}
 					/>
@@ -613,6 +648,7 @@ export const DynamicFast = ({
 					<Card50_Card50
 						cards={firstSliceCards}
 						showAge={showAge}
+						absoluteServerTimes={absoluteServerTimes}
 						containerPalette={containerPalette}
 						imageLoading={imageLoading}
 					/>
@@ -629,6 +665,7 @@ export const DynamicFast = ({
 					<Card50_ColumnOfThreeCards25_ColumnOfThreeCards25
 						cards={secondSliceCards}
 						showAge={showAge}
+						absoluteServerTimes={absoluteServerTimes}
 						containerPalette={containerPalette}
 						imageLoading={imageLoading}
 					/>
@@ -638,6 +675,7 @@ export const DynamicFast = ({
 					<Card50_ColumnOfThreeCards25_ColumnOfFiveCards
 						cards={secondSliceCards}
 						showAge={showAge}
+						absoluteServerTimes={absoluteServerTimes}
 						containerPalette={containerPalette}
 						imageLoading={imageLoading}
 					/>
@@ -647,6 +685,7 @@ export const DynamicFast = ({
 					<ColumnOfThreeCards25_ColumnOfThreeCards25_ColumnOfThreeCards25_ColumnOfThreeCards25
 						cards={secondSliceCards}
 						showAge={showAge}
+						absoluteServerTimes={absoluteServerTimes}
 						containerPalette={containerPalette}
 					/>
 				);
@@ -655,6 +694,7 @@ export const DynamicFast = ({
 					<Card25_ColumnOfCards25_ColumnOfThreeCards25_ColumnOfThreeCards25
 						cards={secondSliceCards}
 						showAge={showAge}
+						absoluteServerTimes={absoluteServerTimes}
 						containerPalette={containerPalette}
 						imageLoading={imageLoading}
 					/>
@@ -664,6 +704,7 @@ export const DynamicFast = ({
 					<Card25_Card25_ColumnOfThreeCards25_ColumnOfThreeCards25
 						cards={secondSliceCards}
 						showAge={showAge}
+						absoluteServerTimes={absoluteServerTimes}
 						containerPalette={containerPalette}
 						imageLoading={imageLoading}
 					/>
@@ -673,6 +714,7 @@ export const DynamicFast = ({
 					<Card25_Card25_Card25_ColumnOfThreeCards25
 						cards={secondSliceCards}
 						showAge={showAge}
+						absoluteServerTimes={absoluteServerTimes}
 						containerPalette={containerPalette}
 						imageLoading={imageLoading}
 					/>
@@ -682,6 +724,7 @@ export const DynamicFast = ({
 					<Card25_Card25_Card25_Card25
 						cards={secondSliceCards}
 						showAge={showAge}
+						absoluteServerTimes={absoluteServerTimes}
 						containerPalette={containerPalette}
 						imageLoading={imageLoading}
 					/>

--- a/dotcom-rendering/src/components/DynamicPackage.stories.tsx
+++ b/dotcom-rendering/src/components/DynamicPackage.stories.tsx
@@ -42,6 +42,7 @@ export const One = () => (
 				standard: trails.slice(0, 1),
 			}}
 			containerPalette="LongRunningPalette"
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>
@@ -70,6 +71,7 @@ export const OneWithManySublinks = () => {
 					standard: standardWithSixSublinks,
 				}}
 				containerPalette="LongRunningPalette"
+				absoluteServerTimes={true}
 				imageLoading="eager"
 			/>
 		</FrontSection>
@@ -92,6 +94,7 @@ export const Two = () => (
 				standard: trails.slice(0, 2),
 			}}
 			containerPalette="LongRunningPalette"
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>
@@ -111,6 +114,7 @@ export const Three = () => (
 				standard: trails.slice(0, 3),
 			}}
 			containerPalette="LongRunningPalette"
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>
@@ -130,6 +134,7 @@ export const Four = () => (
 				standard: trails.slice(0, 4),
 			}}
 			containerPalette="LongRunningPalette"
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>
@@ -149,6 +154,7 @@ export const Five = () => (
 				standard: trails.slice(0, 5),
 			}}
 			containerPalette="LongRunningPalette"
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>
@@ -169,6 +175,7 @@ export const Six = () => (
 				standard: trails.slice(0, 6),
 			}}
 			containerPalette="LongRunningPalette"
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>
@@ -189,6 +196,7 @@ export const Seven = () => (
 				standard: trails.slice(0, 7),
 			}}
 			containerPalette="LongRunningPalette"
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>
@@ -209,6 +217,7 @@ export const Eight = () => (
 				standard: trails.slice(0, 8),
 			}}
 			containerPalette="LongRunningPalette"
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>
@@ -229,6 +238,7 @@ export const Nine = () => (
 				standard: trails.slice(0, 9),
 			}}
 			containerPalette="LongRunningPalette"
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>
@@ -253,6 +263,7 @@ export const Boosted1 = () => {
 				}}
 				showAge={true}
 				containerPalette="LongRunningPalette"
+				absoluteServerTimes={true}
 				imageLoading="eager"
 			/>
 		</FrontSection>
@@ -279,6 +290,7 @@ export const Boosted2 = () => {
 				}}
 				showAge={true}
 				containerPalette="LongRunningPalette"
+				absoluteServerTimes={true}
 				imageLoading="eager"
 			/>
 		</FrontSection>
@@ -304,6 +316,7 @@ export const Boosted3 = () => {
 				}}
 				showAge={true}
 				containerPalette="LongRunningPalette"
+				absoluteServerTimes={true}
 				imageLoading="eager"
 			/>
 		</FrontSection>
@@ -329,6 +342,7 @@ export const Boosted4 = () => {
 				}}
 				showAge={true}
 				containerPalette="LongRunningPalette"
+				absoluteServerTimes={true}
 				imageLoading="eager"
 			/>
 		</FrontSection>
@@ -354,6 +368,7 @@ export const Boosted5 = () => {
 				}}
 				showAge={true}
 				containerPalette="LongRunningPalette"
+				absoluteServerTimes={true}
 				imageLoading="eager"
 			/>
 		</FrontSection>
@@ -380,6 +395,7 @@ export const Boosted8 = () => {
 				}}
 				showAge={true}
 				containerPalette="LongRunningPalette"
+				absoluteServerTimes={true}
 				imageLoading="eager"
 			/>
 		</FrontSection>
@@ -405,6 +421,7 @@ export const Boosted9 = () => {
 					standard: [{ ...primary, isBoosted: true }, ...remaining],
 				}}
 				showAge={true}
+				absoluteServerTimes={true}
 				containerPalette="LongRunningPalette"
 				imageLoading="eager"
 			/>
@@ -426,6 +443,7 @@ export const OneSnapThreeStandard = () => (
 				standard: trails.slice(1, 4),
 			}}
 			containerPalette="LongRunningPalette"
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>
@@ -445,6 +463,7 @@ export const ThreeSnapTwoStandard = () => (
 				standard: trails.slice(3, 5),
 			}}
 			containerPalette="LongRunningPalette"
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>
@@ -464,6 +483,7 @@ export const ThreeSnapTwoStandard2ndBoosted = () => (
 				standard: trails.slice(3, 5),
 			}}
 			containerPalette="LongRunningPalette"
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>
@@ -514,6 +534,7 @@ export const SpecialReportWithoutPalette = () => (
 					},
 				],
 			}}
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>
@@ -534,6 +555,7 @@ export const VideoSublinks = () => (
 				standard: trails.slice(-1),
 			}}
 			containerPalette="LongRunningPalette"
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>

--- a/dotcom-rendering/src/components/DynamicPackage.tsx
+++ b/dotcom-rendering/src/components/DynamicPackage.tsx
@@ -14,6 +14,7 @@ type Props = {
 	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
+	absoluteServerTimes: boolean;
 };
 
 /*
@@ -31,12 +32,14 @@ const Snap100 = ({
 	snaps,
 	containerPalette,
 	showAge,
+	absoluteServerTimes,
 	imageLoading,
 }: {
 	snaps: DCRFrontCard[];
 	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
+	absoluteServerTimes: boolean;
 }) => {
 	if (!snaps[0]) return null;
 	return (
@@ -47,6 +50,7 @@ const Snap100 = ({
 					containerPalette={containerPalette}
 					containerType="dynamic/package"
 					showAge={showAge}
+					absoluteServerTimes={absoluteServerTimes}
 					headlineSize="large"
 					headlineSizeOnMobile="medium"
 					imagePosition="right"
@@ -65,12 +69,14 @@ const Card100 = ({
 	cards,
 	containerPalette,
 	showAge,
+	absoluteServerTimes,
 	imageLoading,
 }: {
 	cards: DCRFrontCard[];
 	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
+	absoluteServerTimes: boolean;
 }) => {
 	if (!cards[0]) return null;
 
@@ -82,6 +88,7 @@ const Card100 = ({
 					containerPalette={containerPalette}
 					containerType="dynamic/package"
 					showAge={showAge}
+					absoluteServerTimes={absoluteServerTimes}
 					headlineSize={cards[0].isBoosted ? 'ginormous' : 'huge'}
 					imagePosition="bottom"
 					imagePositionOnMobile="bottom"
@@ -100,12 +107,14 @@ const Card75_Card25 = ({
 	cards,
 	containerPalette,
 	showAge,
+	absoluteServerTimes,
 	imageLoading,
 }: {
 	cards: DCRFrontCard[];
 	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
+	absoluteServerTimes: boolean;
 }) => {
 	if (cards.length < 2) return null;
 	const card75 = cards.slice(0, 1);
@@ -120,6 +129,7 @@ const Card75_Card25 = ({
 						containerPalette={containerPalette}
 						containerType="dynamic/package"
 						showAge={showAge}
+						absoluteServerTimes={absoluteServerTimes}
 						headlineSize="large"
 						headlineSizeOnMobile="huge"
 						imagePosition="right"
@@ -143,6 +153,7 @@ const Card75_Card25 = ({
 						containerPalette={containerPalette}
 						containerType="dynamic/package"
 						showAge={showAge}
+						absoluteServerTimes={absoluteServerTimes}
 						imageLoading={imageLoading}
 					/>
 				</LI>
@@ -155,6 +166,7 @@ const Card25_Card25_Card25_Card25 = ({
 	cards,
 	containerPalette,
 	showAge,
+	absoluteServerTimes,
 	showImage = true,
 	padBottom,
 	imageLoading,
@@ -163,6 +175,7 @@ const Card25_Card25_Card25_Card25 = ({
 	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
+	absoluteServerTimes: boolean;
 	showImage?: boolean;
 	padBottom?: boolean;
 }) => {
@@ -181,6 +194,7 @@ const Card25_Card25_Card25_Card25 = ({
 							containerPalette={containerPalette}
 							containerType="dynamic/package"
 							showAge={showAge}
+							absoluteServerTimes={absoluteServerTimes}
 							supportingContent={limitSupportingContent(card)}
 							image={showImage ? card.image : undefined}
 							imageLoading={imageLoading}
@@ -196,12 +210,14 @@ const Card25_Card25_Card25_ColumnOfTwo25 = ({
 	cards,
 	containerPalette,
 	showAge,
+	absoluteServerTimes,
 	imageLoading,
 }: {
 	cards: DCRFrontCard[];
 	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
+	absoluteServerTimes: boolean;
 }) => {
 	const bigs = cards.slice(0, 3);
 	const remaining = cards.slice(3);
@@ -222,6 +238,7 @@ const Card25_Card25_Card25_ColumnOfTwo25 = ({
 							containerPalette={containerPalette}
 							containerType="dynamic/package"
 							showAge={showAge}
+							absoluteServerTimes={absoluteServerTimes}
 							supportingContent={limitSupportingContent(card)}
 							imageLoading={imageLoading}
 						/>
@@ -246,6 +263,7 @@ const Card25_Card25_Card25_ColumnOfTwo25 = ({
 									containerPalette={containerPalette}
 									containerType="dynamic/package"
 									showAge={showAge}
+									absoluteServerTimes={absoluteServerTimes}
 									supportingContent={limitSupportingContent(
 										card,
 									)}
@@ -265,12 +283,14 @@ const Card25_Card25_ColumnOfTwo25_ColumnOfTwo25 = ({
 	cards,
 	containerPalette,
 	showAge,
+	absoluteServerTimes,
 	imageLoading,
 }: {
 	cards: DCRFrontCard[];
 	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
+	absoluteServerTimes: boolean;
 }) => {
 	const bigs = cards.slice(0, 2);
 	const remaining = cards.slice(2, 6);
@@ -291,6 +311,7 @@ const Card25_Card25_ColumnOfTwo25_ColumnOfTwo25 = ({
 							containerPalette={containerPalette}
 							containerType="dynamic/package"
 							showAge={showAge}
+							absoluteServerTimes={absoluteServerTimes}
 							supportingContent={limitSupportingContent(card)}
 							imageLoading={imageLoading}
 						/>
@@ -322,6 +343,7 @@ const Card25_Card25_ColumnOfTwo25_ColumnOfTwo25 = ({
 									containerPalette={containerPalette}
 									containerType="dynamic/package"
 									showAge={showAge}
+									absoluteServerTimes={absoluteServerTimes}
 									supportingContent={limitSupportingContent(
 										card,
 									)}
@@ -341,12 +363,14 @@ const Card25_ColumnOfTwo25_ColumnOfTwo25_ColumnOfTwo25 = ({
 	cards,
 	containerPalette,
 	showAge,
+	absoluteServerTimes,
 	imageLoading,
 }: {
 	cards: DCRFrontCard[];
 	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
+	absoluteServerTimes: boolean;
 }) => {
 	const bigs = cards.slice(0, 1);
 	const remaining = cards.slice(1, 7);
@@ -361,6 +385,7 @@ const Card25_ColumnOfTwo25_ColumnOfTwo25_ColumnOfTwo25 = ({
 							containerPalette={containerPalette}
 							containerType="dynamic/package"
 							showAge={showAge}
+							absoluteServerTimes={absoluteServerTimes}
 							supportingContent={limitSupportingContent(card)}
 							imageLoading={imageLoading}
 						/>
@@ -392,6 +417,7 @@ const Card25_ColumnOfTwo25_ColumnOfTwo25_ColumnOfTwo25 = ({
 									containerPalette={containerPalette}
 									containerType="dynamic/package"
 									showAge={showAge}
+									absoluteServerTimes={absoluteServerTimes}
 									supportingContent={limitSupportingContent(
 										card,
 									)}
@@ -411,12 +437,14 @@ const Card75_ColumnOfCards25 = ({
 	cards,
 	containerPalette,
 	showAge,
+	absoluteServerTimes,
 	imageLoading,
 }: {
 	cards: DCRFrontCard[];
 	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
+	absoluteServerTimes: boolean;
 }) => {
 	const card75 = cards.slice(0, 1);
 	const remaining = cards.slice(1, 4);
@@ -430,6 +458,7 @@ const Card75_ColumnOfCards25 = ({
 						containerPalette={containerPalette}
 						containerType="dynamic/package"
 						showAge={showAge}
+						absoluteServerTimes={absoluteServerTimes}
 						headlineSize="huge"
 						imagePosition="bottom"
 						imagePositionOnMobile="bottom"
@@ -454,6 +483,7 @@ const Card75_ColumnOfCards25 = ({
 									containerPalette={containerPalette}
 									containerType="dynamic/package"
 									showAge={showAge}
+									absoluteServerTimes={absoluteServerTimes}
 									image={
 										// Always show the image on the first card and only
 										// on the second if there are two items in two
@@ -486,6 +516,7 @@ export const DynamicPackage = ({
 	groupedTrails,
 	containerPalette,
 	showAge,
+	absoluteServerTimes,
 	imageLoading,
 }: Props) => {
 	let layout:
@@ -576,12 +607,14 @@ export const DynamicPackage = ({
 						snaps={firstSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						absoluteServerTimes={absoluteServerTimes}
 						imageLoading={imageLoading}
 					/>
 					<Card100
 						cards={secondSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						absoluteServerTimes={absoluteServerTimes}
 						imageLoading={imageLoading}
 					/>
 				</>
@@ -593,6 +626,7 @@ export const DynamicPackage = ({
 						snaps={firstSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						absoluteServerTimes={absoluteServerTimes}
 						imageLoading={imageLoading}
 					/>
 					{/* Card75_Card25 does not support the first card being boosted - on Frontend the 75% card would
@@ -602,6 +636,7 @@ export const DynamicPackage = ({
 						cards={secondSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						absoluteServerTimes={absoluteServerTimes}
 						imageLoading={imageLoading}
 					/>
 				</>
@@ -613,18 +648,21 @@ export const DynamicPackage = ({
 						snaps={firstSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						absoluteServerTimes={absoluteServerTimes}
 						imageLoading={imageLoading}
 					/>
 					<Card100
 						cards={secondSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						absoluteServerTimes={absoluteServerTimes}
 						imageLoading={imageLoading}
 					/>
 					<Card25_Card25_Card25_Card25
 						cards={thirdSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						absoluteServerTimes={absoluteServerTimes}
 						imageLoading={imageLoading}
 					/>
 				</>
@@ -636,12 +674,14 @@ export const DynamicPackage = ({
 						snaps={firstSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						absoluteServerTimes={absoluteServerTimes}
 						imageLoading={imageLoading}
 					/>
 					<Card75_ColumnOfCards25
 						cards={secondSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						absoluteServerTimes={absoluteServerTimes}
 						imageLoading={imageLoading}
 					/>
 				</>
@@ -653,18 +693,21 @@ export const DynamicPackage = ({
 						snaps={firstSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						absoluteServerTimes={absoluteServerTimes}
 						imageLoading={imageLoading}
 					/>
 					<Card100
 						cards={secondSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						absoluteServerTimes={absoluteServerTimes}
 						imageLoading={imageLoading}
 					/>
 					<Card25_Card25_Card25_Card25
 						cards={thirdSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						absoluteServerTimes={absoluteServerTimes}
 						imageLoading={imageLoading}
 					/>
 				</>
@@ -676,18 +719,21 @@ export const DynamicPackage = ({
 						snaps={firstSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						absoluteServerTimes={absoluteServerTimes}
 						imageLoading={imageLoading}
 					/>
 					<Card100
 						cards={secondSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						absoluteServerTimes={absoluteServerTimes}
 						imageLoading={imageLoading}
 					/>
 					<Card25_Card25_Card25_ColumnOfTwo25
 						cards={thirdSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						absoluteServerTimes={absoluteServerTimes}
 						imageLoading={imageLoading}
 					/>
 				</>
@@ -699,18 +745,21 @@ export const DynamicPackage = ({
 						snaps={firstSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						absoluteServerTimes={absoluteServerTimes}
 						imageLoading={imageLoading}
 					/>
 					<Card100
 						cards={secondSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						absoluteServerTimes={absoluteServerTimes}
 						imageLoading={imageLoading}
 					/>
 					<Card25_Card25_ColumnOfTwo25_ColumnOfTwo25
 						cards={thirdSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						absoluteServerTimes={absoluteServerTimes}
 						imageLoading={imageLoading}
 					/>
 				</>
@@ -722,18 +771,21 @@ export const DynamicPackage = ({
 						snaps={firstSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						absoluteServerTimes={absoluteServerTimes}
 						imageLoading={imageLoading}
 					/>
 					<Card100
 						cards={secondSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						absoluteServerTimes={absoluteServerTimes}
 						imageLoading={imageLoading}
 					/>
 					<Card25_ColumnOfTwo25_ColumnOfTwo25_ColumnOfTwo25
 						cards={thirdSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						absoluteServerTimes={absoluteServerTimes}
 						imageLoading={imageLoading}
 					/>
 				</>
@@ -745,18 +797,21 @@ export const DynamicPackage = ({
 						snaps={firstSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						absoluteServerTimes={absoluteServerTimes}
 						imageLoading={imageLoading}
 					/>
 					<Card100
 						cards={secondSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						absoluteServerTimes={absoluteServerTimes}
 						imageLoading={imageLoading}
 					/>
 					<Card25_Card25_Card25_Card25
 						cards={thirdSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						absoluteServerTimes={absoluteServerTimes}
 						padBottom={true}
 						imageLoading={imageLoading}
 					/>
@@ -764,6 +819,7 @@ export const DynamicPackage = ({
 						cards={fourthSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						absoluteServerTimes={absoluteServerTimes}
 						showImage={false}
 						imageLoading={imageLoading}
 					/>

--- a/dotcom-rendering/src/components/DynamicSlow.stories.tsx
+++ b/dotcom-rendering/src/components/DynamicSlow.stories.tsx
@@ -64,6 +64,7 @@ export const Avatar = () => {
 					standard: avatarTrails.slice(4, 8),
 				}}
 				showAge={true}
+				absoluteServerTimes={true}
 				imageLoading="eager"
 			/>
 		</FrontSection>
@@ -88,6 +89,7 @@ export const OneHugeTwoBigsFourStandards = () => (
 				standard: trails.slice(3, 7),
 			}}
 			showAge={true}
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>
@@ -109,6 +111,7 @@ export const OneVeryBigTwoBigsFourStandards = () => (
 				standard: trails.slice(3, 7),
 			}}
 			showAge={true}
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>
@@ -131,6 +134,7 @@ export const TwoVeryBigsTwoBigsFourStandards = () => (
 				standard: trails.slice(4, 8),
 			}}
 			showAge={true}
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>
@@ -153,6 +157,7 @@ export const TwoVeryBigs1stBoostedTwoBigsFourStandards = () => (
 				standard: trails.slice(4, 8),
 			}}
 			showAge={true}
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>
@@ -175,6 +180,7 @@ export const TwoVeryBigs2ndBoostedTwoBigsFourStandards = () => (
 				standard: trails.slice(4, 8),
 			}}
 			showAge={true}
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>
@@ -197,6 +203,7 @@ export const TwoVeryBigs8Standards = () => (
 				standard: trails.slice(2, 10),
 			}}
 			showAge={true}
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>
@@ -218,6 +225,7 @@ export const TwoVeryBigsOneBig4Standards = () => (
 				standard: trails.slice(3, 7),
 			}}
 			showAge={true}
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>
@@ -240,6 +248,7 @@ export const TwoVeryBigsTwoBigs4Standards = () => (
 				standard: trails.slice(4, 8),
 			}}
 			showAge={true}
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>
@@ -264,6 +273,7 @@ export const TwoVeryBigsFiveStandards = () => (
 				standard: trails.slice(2, 7),
 			}}
 			showAge={true}
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>
@@ -285,6 +295,7 @@ export const ThreeVeryBigsFiveStandards = () => (
 				standard: trails.slice(3, 8),
 			}}
 			showAge={true}
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>
@@ -306,6 +317,7 @@ export const TwoVeryBigsOneBig = () => (
 				big: trails.slice(2, 3),
 			}}
 			showAge={true}
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>
@@ -327,6 +339,7 @@ export const TwoBigsThreeStandards = () => (
 				standard: trails.slice(2, 5),
 			}}
 			showAge={true}
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>
@@ -349,6 +362,7 @@ export const OneVeryBigTwoBigsOneStandard = () => (
 				standard: trails.slice(4, 5),
 			}}
 			showAge={true}
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>

--- a/dotcom-rendering/src/components/DynamicSlow.tsx
+++ b/dotcom-rendering/src/components/DynamicSlow.tsx
@@ -27,6 +27,7 @@ type Props = {
 	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
+	absoluteServerTimes: boolean;
 };
 
 const ColumnOfCards50_Card50 = ({
@@ -34,10 +35,12 @@ const ColumnOfCards50_Card50 = ({
 	showAge,
 	containerPalette,
 	imageLoading,
+	absoluteServerTimes,
 }: {
 	cards: DCRFrontCard[];
 	imageLoading: Loading;
 	showAge?: boolean;
+	absoluteServerTimes: boolean;
 	containerPalette?: DCRContainerPalette;
 }) => {
 	const big = cards.slice(0, 1);
@@ -56,6 +59,7 @@ const ColumnOfCards50_Card50 = ({
 					<Card50Media50
 						trail={card}
 						showAge={showAge}
+						absoluteServerTimes={absoluteServerTimes}
 						containerPalette={containerPalette}
 						imageLoading={imageLoading}
 					/>
@@ -74,6 +78,7 @@ const ColumnOfCards50_Card50 = ({
 									trail={card}
 									containerPalette={containerPalette}
 									showAge={showAge}
+									absoluteServerTimes={absoluteServerTimes}
 									imageLoading={imageLoading}
 								/>
 							</LI>
@@ -90,10 +95,12 @@ const ColumnOfCards50_ColumnOfCards50 = ({
 	showAge,
 	containerPalette,
 	imageLoading,
+	absoluteServerTimes,
 }: {
 	cards: DCRFrontCard[];
 	imageLoading: Loading;
 	showAge?: boolean;
+	absoluteServerTimes: boolean;
 	containerPalette?: DCRContainerPalette;
 }) => {
 	return (
@@ -117,6 +124,7 @@ const ColumnOfCards50_ColumnOfCards50 = ({
 							trail={card}
 							containerPalette={containerPalette}
 							showAge={showAge}
+							absoluteServerTimes={absoluteServerTimes}
 							imageLoading={imageLoading}
 						/>
 					</LI>
@@ -135,6 +143,7 @@ export const DynamicSlow = ({
 	groupedTrails,
 	containerPalette,
 	showAge,
+	absoluteServerTimes,
 	imageLoading,
 }: Props) => {
 	let firstSliceLayout:
@@ -218,6 +227,7 @@ export const DynamicSlow = ({
 					<Card100PictureTop
 						cards={firstSliceCards}
 						showAge={showAge}
+						absoluteServerTimes={absoluteServerTimes}
 						containerPalette={containerPalette}
 						imageLoading={imageLoading}
 					/>
@@ -227,6 +237,7 @@ export const DynamicSlow = ({
 					<Card100PictureRight
 						cards={firstSliceCards}
 						showAge={showAge}
+						absoluteServerTimes={absoluteServerTimes}
 						containerPalette={containerPalette}
 						imageLoading={imageLoading}
 					/>
@@ -236,6 +247,7 @@ export const DynamicSlow = ({
 					<Card75_Card25
 						cards={firstSliceCards}
 						showAge={showAge}
+						absoluteServerTimes={absoluteServerTimes}
 						containerPalette={containerPalette}
 						imageLoading={imageLoading}
 					/>
@@ -245,6 +257,7 @@ export const DynamicSlow = ({
 					<Card25_Card75
 						cards={firstSliceCards}
 						showAge={showAge}
+						absoluteServerTimes={absoluteServerTimes}
 						containerPalette={containerPalette}
 						imageLoading={imageLoading}
 					/>
@@ -254,6 +267,7 @@ export const DynamicSlow = ({
 					<Card50_Card50
 						cards={firstSliceCards}
 						showAge={showAge}
+						absoluteServerTimes={absoluteServerTimes}
 						containerPalette={containerPalette}
 						imageLoading={imageLoading}
 					/>
@@ -270,6 +284,7 @@ export const DynamicSlow = ({
 					<ColumnOfCards50_ColumnOfCards50
 						cards={secondSliceCards}
 						showAge={showAge}
+						absoluteServerTimes={absoluteServerTimes}
 						containerPalette={containerPalette}
 						imageLoading={imageLoading}
 					/>
@@ -279,6 +294,7 @@ export const DynamicSlow = ({
 					<ColumnOfCards50_Card50
 						cards={secondSliceCards}
 						showAge={showAge}
+						absoluteServerTimes={absoluteServerTimes}
 						containerPalette={containerPalette}
 						imageLoading={imageLoading}
 					/>
@@ -288,6 +304,7 @@ export const DynamicSlow = ({
 					<ColumnOfCards50_Card25_Card25
 						cards={secondSliceCards}
 						showAge={showAge}
+						absoluteServerTimes={absoluteServerTimes}
 						containerPalette={containerPalette}
 						imageLoading={imageLoading}
 					/>

--- a/dotcom-rendering/src/components/DynamicSlowMPU.stories.tsx
+++ b/dotcom-rendering/src/components/DynamicSlowMPU.stories.tsx
@@ -36,6 +36,7 @@ export const NoBigs = () => (
 				standard: standards,
 			}}
 			showAge={true}
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>
@@ -57,6 +58,7 @@ export const OneBig = () => (
 				standard: standards,
 			}}
 			showAge={true}
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>
@@ -78,6 +80,7 @@ export const TwoBigs = () => (
 				standard: standards,
 			}}
 			showAge={true}
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>
@@ -103,6 +106,7 @@ export const FirstBigBoosted = () => (
 				standard: standards,
 			}}
 			showAge={true}
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>
@@ -128,6 +132,7 @@ export const SecondBigBoosted = () => (
 				standard: standards,
 			}}
 			showAge={true}
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>
@@ -149,6 +154,7 @@ export const ThreeBigs = () => (
 				standard: standards,
 			}}
 			showAge={true}
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>
@@ -170,6 +176,7 @@ export const AllBigs = () => (
 				standard: [],
 			}}
 			showAge={true}
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>
@@ -191,6 +198,7 @@ export const TwoBigsThreeStandardsNoMPU = () => (
 				standard: standards.slice(0, 3),
 			}}
 			showAge={true}
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>
@@ -212,6 +220,7 @@ export const NoBigsTwoStandardsNoMPU = () => (
 				standard: standards.slice(0, 2),
 			}}
 			showAge={true}
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>
@@ -233,6 +242,7 @@ export const NoBigsFiveStandardsNoMPU = () => (
 				standard: standards.slice(0, 5),
 			}}
 			showAge={true}
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>

--- a/dotcom-rendering/src/components/DynamicSlowMPU.tsx
+++ b/dotcom-rendering/src/components/DynamicSlowMPU.tsx
@@ -21,6 +21,7 @@ type Props = {
 	groupedTrails: DCRGroupedTrails;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
+	absoluteServerTimes: boolean;
 	imageLoading: Loading;
 };
 
@@ -31,10 +32,12 @@ const Card33_Card33_Card33 = ({
 	cards,
 	containerPalette,
 	showAge,
+	absoluteServerTimes,
 }: {
 	cards: DCRFrontCard[];
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
+	absoluteServerTimes: boolean;
 }) => {
 	return (
 		<UL direction="row">
@@ -44,6 +47,7 @@ const Card33_Card33_Card33 = ({
 						trail={card}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						absoluteServerTimes={absoluteServerTimes}
 					/>
 				</LI>
 			))}
@@ -69,6 +73,7 @@ export const DynamicSlowMPU = ({
 	groupedTrails,
 	containerPalette,
 	showAge,
+	absoluteServerTimes,
 	imageLoading,
 }: Props) => {
 	let firstSliceLayout:
@@ -144,6 +149,7 @@ export const DynamicSlowMPU = ({
 						cards={firstSliceCards}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						absoluteServerTimes={absoluteServerTimes}
 						imageLoading={imageLoading}
 					/>
 				);
@@ -153,6 +159,7 @@ export const DynamicSlowMPU = ({
 						cards={firstSliceCards}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						absoluteServerTimes={absoluteServerTimes}
 						imageLoading={imageLoading}
 					/>
 				);
@@ -162,6 +169,7 @@ export const DynamicSlowMPU = ({
 						cards={firstSliceCards}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						absoluteServerTimes={absoluteServerTimes}
 						imageLoading={imageLoading}
 					/>
 				);
@@ -171,6 +179,7 @@ export const DynamicSlowMPU = ({
 						cards={firstSliceCards}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						absoluteServerTimes={absoluteServerTimes}
 						imageLoading={imageLoading}
 					/>
 				);
@@ -187,6 +196,7 @@ export const DynamicSlowMPU = ({
 						cards={secondSliceCards}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						absoluteServerTimes={absoluteServerTimes}
 					/>
 				);
 
@@ -196,6 +206,7 @@ export const DynamicSlowMPU = ({
 						cards={secondSliceCards}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						absoluteServerTimes={absoluteServerTimes}
 						imageLoading={imageLoading}
 					/>
 				);
@@ -206,6 +217,7 @@ export const DynamicSlowMPU = ({
 						cards={secondSliceCards}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						absoluteServerTimes={absoluteServerTimes}
 						imageLoading={imageLoading}
 					/>
 				);
@@ -214,6 +226,7 @@ export const DynamicSlowMPU = ({
 					<Card25_Card25_Card25_Card25
 						cards={secondSliceCards}
 						showAge={showAge}
+						absoluteServerTimes={absoluteServerTimes}
 						containerPalette={containerPalette}
 						imageLoading={imageLoading}
 					/>

--- a/dotcom-rendering/src/components/FetchOnwardsData.importable.tsx
+++ b/dotcom-rendering/src/components/FetchOnwardsData.importable.tsx
@@ -15,6 +15,7 @@ type Props = {
 	onwardsSource: OnwardsSource;
 	format: ArticleFormat;
 	discussionApiUrl: string;
+	absoluteServerTimes: boolean;
 };
 
 type OnwardsResponse = {
@@ -34,6 +35,7 @@ export const FetchOnwardsData = ({
 	onwardsSource,
 	format,
 	discussionApiUrl,
+	absoluteServerTimes,
 }: Props) => {
 	const { data, error } = useApi<OnwardsResponse>(url);
 
@@ -81,6 +83,7 @@ export const FetchOnwardsData = ({
 						: 'compact'
 				}
 				discussionApiUrl={discussionApiUrl}
+				absoluteServerTimes={absoluteServerTimes}
 			/>
 		</div>
 	);

--- a/dotcom-rendering/src/components/FirstPublished.stories.tsx
+++ b/dotcom-rendering/src/components/FirstPublished.stories.tsx
@@ -11,6 +11,7 @@ export const Default = () => (
 		blockId="#block-60300f5f8f08ad21ea60071e"
 		isPinnedPost={false}
 		isOriginalPinnedPost={false}
+		absoluteServerTimes={true}
 	/>
 );
 
@@ -21,6 +22,7 @@ export const WithFirstPublishedDisplay = () => (
 		blockId="#block-60300f5f8f08ad21ea60071e"
 		isPinnedPost={false}
 		isOriginalPinnedPost={false}
+		absoluteServerTimes={true}
 	/>
 );
 
@@ -30,6 +32,7 @@ export const PinnedPost = () => (
 		blockId="#block-60300f5f8f08ad21ea60071e"
 		isPinnedPost={true}
 		isOriginalPinnedPost={false}
+		absoluteServerTimes={true}
 	/>
 );
 
@@ -39,5 +42,6 @@ export const OriginalPinnedPost = () => (
 		blockId="#block-60300f5f8f08ad21ea60071e"
 		isPinnedPost={false}
 		isOriginalPinnedPost={true}
+		absoluteServerTimes={true}
 	/>
 );

--- a/dotcom-rendering/src/components/FirstPublished.tsx
+++ b/dotcom-rendering/src/components/FirstPublished.tsx
@@ -21,6 +21,7 @@ type Props = {
 	blockId: string;
 	isPinnedPost: boolean;
 	isOriginalPinnedPost: boolean;
+	absoluteServerTimes: boolean;
 	host?: string;
 	pageId?: string;
 };
@@ -33,6 +34,7 @@ const FirstPublished = ({
 	isOriginalPinnedPost,
 	host,
 	pageId,
+	absoluteServerTimes,
 }: Props) => {
 	const baseHref = host && pageId ? joinUrl(host, pageId) : '';
 	const publishedDate = new Date(firstPublished);
@@ -69,6 +71,7 @@ const FirstPublished = ({
 						<DateTime
 							date={new Date(firstPublished)}
 							display="relative"
+							absoluteServerTimes={absoluteServerTimes}
 							editionId={'UK'}
 							showWeekday={false}
 							showDate={true}

--- a/dotcom-rendering/src/components/FixedLargeSlowXIV.stories.tsx
+++ b/dotcom-rendering/src/components/FixedLargeSlowXIV.stories.tsx
@@ -27,6 +27,7 @@ export const Default = () => (
 		<FixedLargeSlowXIV
 			trails={trails}
 			showAge={true}
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>

--- a/dotcom-rendering/src/components/FixedLargeSlowXIV.tsx
+++ b/dotcom-rendering/src/components/FixedLargeSlowXIV.tsx
@@ -15,12 +15,14 @@ type Props = {
 	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
+	absoluteServerTimes: boolean;
 };
 
 export const FixedLargeSlowXIV = ({
 	trails,
 	containerPalette,
 	showAge,
+	absoluteServerTimes,
 	imageLoading,
 }: Props) => {
 	const firstSlice75 = trails.slice(0, 1);
@@ -37,6 +39,7 @@ export const FixedLargeSlowXIV = ({
 							<Card75Media50Right
 								trail={card}
 								showAge={showAge}
+								absoluteServerTimes={absoluteServerTimes}
 								containerPalette={containerPalette}
 								imageLoading={imageLoading}
 							/>
@@ -55,6 +58,7 @@ export const FixedLargeSlowXIV = ({
 							<Card25Media25
 								trail={card}
 								showAge={showAge}
+								absoluteServerTimes={absoluteServerTimes}
 								containerPalette={containerPalette}
 								imageLoading={imageLoading}
 							/>
@@ -76,6 +80,7 @@ export const FixedLargeSlowXIV = ({
 								trail={card}
 								containerPalette={containerPalette}
 								showAge={showAge}
+								absoluteServerTimes={absoluteServerTimes}
 								imageLoading={imageLoading}
 							/>
 						</LI>
@@ -101,6 +106,7 @@ export const FixedLargeSlowXIV = ({
 							<CardDefault
 								trail={card}
 								showAge={showAge}
+								absoluteServerTimes={absoluteServerTimes}
 								containerPalette={containerPalette}
 							/>
 						</LI>

--- a/dotcom-rendering/src/components/FixedMediumFastXI.stories.tsx
+++ b/dotcom-rendering/src/components/FixedMediumFastXI.stories.tsx
@@ -24,7 +24,11 @@ export const OneTrail = () => (
 		discussionApiUrl={discussionApiUrl}
 		editionId={'UK'}
 	>
-		<FixedMediumFastXI trails={trails.slice(0, 1)} imageLoading="eager" />
+		<FixedMediumFastXI
+			trails={trails.slice(0, 1)}
+			imageLoading="eager"
+			absoluteServerTimes={true}
+		/>
 	</FrontSection>
 );
 OneTrail.storyName = 'with one trail';
@@ -35,7 +39,11 @@ export const TwoTrails = () => (
 		discussionApiUrl={discussionApiUrl}
 		editionId={'UK'}
 	>
-		<FixedMediumFastXI trails={trails.slice(0, 2)} imageLoading="eager" />
+		<FixedMediumFastXI
+			trails={trails.slice(0, 2)}
+			imageLoading="eager"
+			absoluteServerTimes={true}
+		/>
 	</FrontSection>
 );
 TwoTrails.storyName = 'with two trails';
@@ -46,7 +54,11 @@ export const ThreeTrails = () => (
 		discussionApiUrl={discussionApiUrl}
 		editionId={'UK'}
 	>
-		<FixedMediumFastXI trails={trails.slice(0, 3)} imageLoading="eager" />
+		<FixedMediumFastXI
+			trails={trails.slice(0, 3)}
+			imageLoading="eager"
+			absoluteServerTimes={true}
+		/>
 	</FrontSection>
 );
 ThreeTrails.storyName = 'with three trails';
@@ -57,7 +69,11 @@ export const FourTrails = () => (
 		discussionApiUrl={discussionApiUrl}
 		editionId={'UK'}
 	>
-		<FixedMediumFastXI trails={trails.slice(0, 4)} imageLoading="eager" />
+		<FixedMediumFastXI
+			trails={trails.slice(0, 4)}
+			imageLoading="eager"
+			absoluteServerTimes={true}
+		/>
 	</FrontSection>
 );
 FourTrails.storyName = 'with four trails';
@@ -68,7 +84,11 @@ export const FiveTrails = () => (
 		discussionApiUrl={discussionApiUrl}
 		editionId={'UK'}
 	>
-		<FixedMediumFastXI trails={trails.slice(0, 5)} imageLoading="eager" />
+		<FixedMediumFastXI
+			trails={trails.slice(0, 5)}
+			imageLoading="eager"
+			absoluteServerTimes={true}
+		/>
 	</FrontSection>
 );
 FiveTrails.storyName = 'with five trails';
@@ -79,7 +99,11 @@ export const SixTrails = () => (
 		discussionApiUrl={discussionApiUrl}
 		editionId={'UK'}
 	>
-		<FixedMediumFastXI trails={trails.slice(0, 6)} imageLoading="eager" />
+		<FixedMediumFastXI
+			trails={trails.slice(0, 6)}
+			imageLoading="eager"
+			absoluteServerTimes={true}
+		/>
 	</FrontSection>
 );
 SixTrails.storyName = 'with six trails';
@@ -90,7 +114,11 @@ export const SevenTrails = () => (
 		discussionApiUrl={discussionApiUrl}
 		editionId={'UK'}
 	>
-		<FixedMediumFastXI trails={trails.slice(0, 7)} imageLoading="eager" />
+		<FixedMediumFastXI
+			trails={trails.slice(0, 7)}
+			imageLoading="eager"
+			absoluteServerTimes={true}
+		/>
 	</FrontSection>
 );
 SevenTrails.storyName = 'with seven trails';
@@ -101,7 +129,11 @@ export const EightTrails = () => (
 		discussionApiUrl={discussionApiUrl}
 		editionId={'UK'}
 	>
-		<FixedMediumFastXI trails={trails.slice(0, 8)} imageLoading="eager" />
+		<FixedMediumFastXI
+			trails={trails.slice(0, 8)}
+			imageLoading="eager"
+			absoluteServerTimes={true}
+		/>
 	</FrontSection>
 );
 EightTrails.storyName = 'with eight trails';
@@ -112,7 +144,11 @@ export const NineTrails = () => (
 		discussionApiUrl={discussionApiUrl}
 		editionId={'UK'}
 	>
-		<FixedMediumFastXI trails={trails.slice(0, 9)} imageLoading="eager" />
+		<FixedMediumFastXI
+			trails={trails.slice(0, 9)}
+			imageLoading="eager"
+			absoluteServerTimes={true}
+		/>
 	</FrontSection>
 );
 NineTrails.storyName = 'with nine trails';
@@ -123,7 +159,11 @@ export const TenTrails = () => (
 		discussionApiUrl={discussionApiUrl}
 		editionId={'UK'}
 	>
-		<FixedMediumFastXI trails={trails.slice(0, 10)} imageLoading="eager" />
+		<FixedMediumFastXI
+			trails={trails.slice(0, 10)}
+			imageLoading="eager"
+			absoluteServerTimes={true}
+		/>
 	</FrontSection>
 );
 TenTrails.storyName = 'with ten trails';
@@ -134,7 +174,11 @@ export const ElevenTrails = () => (
 		discussionApiUrl={discussionApiUrl}
 		editionId={'UK'}
 	>
-		<FixedMediumFastXI trails={trails.slice(0, 11)} imageLoading="eager" />
+		<FixedMediumFastXI
+			trails={trails.slice(0, 11)}
+			imageLoading="eager"
+			absoluteServerTimes={true}
+		/>
 	</FrontSection>
 );
 ElevenTrails.storyName = 'with eleven trails';

--- a/dotcom-rendering/src/components/FixedMediumFastXI.tsx
+++ b/dotcom-rendering/src/components/FixedMediumFastXI.tsx
@@ -10,6 +10,7 @@ type Props = {
 	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
+	absoluteServerTimes: boolean;
 };
 
 const decideOffset = ({
@@ -43,6 +44,7 @@ export const FixedMediumFastXI = ({
 	trails,
 	containerPalette,
 	showAge,
+	absoluteServerTimes,
 	imageLoading,
 }: Props) => {
 	const firstSlice = trails.slice(0, 3);
@@ -53,6 +55,7 @@ export const FixedMediumFastXI = ({
 				cards={firstSlice}
 				containerPalette={containerPalette}
 				showAge={showAge}
+				absoluteServerTimes={absoluteServerTimes}
 				imageLoading={imageLoading}
 			/>
 			{/*
@@ -83,6 +86,7 @@ export const FixedMediumFastXI = ({
 							trail={trail}
 							containerPalette={containerPalette}
 							showAge={showAge}
+							absoluteServerTimes={absoluteServerTimes}
 						/>
 					</LI>
 				))}

--- a/dotcom-rendering/src/components/FixedMediumFastXII.stories.tsx
+++ b/dotcom-rendering/src/components/FixedMediumFastXII.stories.tsx
@@ -27,6 +27,7 @@ export const Default = () => (
 		<FixedMediumFastXII
 			trails={trails}
 			showAge={true}
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>

--- a/dotcom-rendering/src/components/FixedMediumFastXII.tsx
+++ b/dotcom-rendering/src/components/FixedMediumFastXII.tsx
@@ -9,12 +9,14 @@ type Props = {
 	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
+	absoluteServerTimes: boolean;
 };
 
 export const FixedMediumFastXII = ({
 	trails,
 	containerPalette,
 	showAge,
+	absoluteServerTimes,
 	imageLoading,
 }: Props) => {
 	const firstSlice25 = trails.slice(0, 4);
@@ -35,6 +37,7 @@ export const FixedMediumFastXII = ({
 								trail={trail}
 								containerPalette={containerPalette}
 								showAge={showAge}
+								absoluteServerTimes={absoluteServerTimes}
 								imageLoading={imageLoading}
 							/>
 						</LI>
@@ -54,6 +57,7 @@ export const FixedMediumFastXII = ({
 								trail={trail}
 								containerPalette={containerPalette}
 								showAge={showAge}
+								absoluteServerTimes={absoluteServerTimes}
 							/>
 						</LI>
 					);

--- a/dotcom-rendering/src/components/FixedMediumSlowVI.stories.tsx
+++ b/dotcom-rendering/src/components/FixedMediumSlowVI.stories.tsx
@@ -27,6 +27,7 @@ export const Default = () => (
 		<FixedMediumSlowVI
 			trails={trails}
 			showAge={true}
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>

--- a/dotcom-rendering/src/components/FixedMediumSlowVI.tsx
+++ b/dotcom-rendering/src/components/FixedMediumSlowVI.tsx
@@ -13,6 +13,7 @@ type Props = {
 	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
+	absoluteServerTimes: boolean;
 };
 
 export const FixedMediumSlowVI = ({
@@ -20,6 +21,7 @@ export const FixedMediumSlowVI = ({
 	containerPalette,
 	showAge,
 	imageLoading,
+	absoluteServerTimes,
 }: Props) => {
 	const firstSlice75 = trails.slice(0, 1);
 	const firstSlice25 = trails.slice(1, 2);
@@ -34,6 +36,7 @@ export const FixedMediumSlowVI = ({
 							trail={trail}
 							containerPalette={containerPalette}
 							showAge={showAge}
+							absoluteServerTimes={absoluteServerTimes}
 							imageLoading={imageLoading}
 						/>
 					</LI>
@@ -50,6 +53,7 @@ export const FixedMediumSlowVI = ({
 							trail={trail}
 							containerPalette={containerPalette}
 							showAge={showAge}
+							absoluteServerTimes={absoluteServerTimes}
 							imageLoading={imageLoading}
 						/>
 					</LI>
@@ -67,6 +71,7 @@ export const FixedMediumSlowVI = ({
 							trail={trail}
 							containerPalette={containerPalette}
 							showAge={showAge}
+							absoluteServerTimes={absoluteServerTimes}
 							imageLoading={imageLoading}
 						/>
 					</LI>

--- a/dotcom-rendering/src/components/FixedMediumSlowVII.stories.tsx
+++ b/dotcom-rendering/src/components/FixedMediumSlowVII.stories.tsx
@@ -28,6 +28,7 @@ export const Default = () => (
 		<FixedMediumSlowVII
 			trails={trails}
 			showAge={true}
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>

--- a/dotcom-rendering/src/components/FixedMediumSlowVII.tsx
+++ b/dotcom-rendering/src/components/FixedMediumSlowVII.tsx
@@ -13,12 +13,14 @@ type Props = {
 	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
+	absoluteServerTimes: boolean;
 };
 
 export const FixedMediumSlowVII = ({
 	trails,
 	containerPalette,
 	showAge,
+	absoluteServerTimes,
 	imageLoading,
 }: Props) => {
 	const firstSlice50 = trails.slice(0, 1);
@@ -39,6 +41,7 @@ export const FixedMediumSlowVII = ({
 							trail={trail}
 							containerPalette={containerPalette}
 							showAge={showAge}
+							absoluteServerTimes={absoluteServerTimes}
 							imageLoading={imageLoading}
 						/>
 					</LI>
@@ -56,6 +59,7 @@ export const FixedMediumSlowVII = ({
 							trail={trail}
 							containerPalette={containerPalette}
 							showAge={showAge}
+							absoluteServerTimes={absoluteServerTimes}
 							imageLoading={imageLoading}
 						/>
 					</LI>
@@ -73,6 +77,7 @@ export const FixedMediumSlowVII = ({
 							trail={trail}
 							containerPalette={containerPalette}
 							showAge={showAge}
+							absoluteServerTimes={absoluteServerTimes}
 							imageLoading={imageLoading}
 						/>
 					</LI>

--- a/dotcom-rendering/src/components/FixedMediumSlowXIIMPU.stories.tsx
+++ b/dotcom-rendering/src/components/FixedMediumSlowXIIMPU.stories.tsx
@@ -27,6 +27,7 @@ export const OneTrail = () => (
 		<FixedMediumSlowXIIMPU
 			trails={trails.slice(0, 1)}
 			showAge={true}
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>
@@ -42,6 +43,7 @@ export const TwoTrails = () => (
 		<FixedMediumSlowXIIMPU
 			trails={trails.slice(0, 2)}
 			showAge={true}
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>
@@ -57,6 +59,7 @@ export const ThreeTrails = () => (
 		<FixedMediumSlowXIIMPU
 			trails={trails.slice(0, 3)}
 			showAge={true}
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>
@@ -72,6 +75,7 @@ export const FourTrails = () => (
 		<FixedMediumSlowXIIMPU
 			trails={trails.slice(0, 4)}
 			showAge={true}
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>
@@ -87,6 +91,7 @@ export const FiveTrails = () => (
 		<FixedMediumSlowXIIMPU
 			trails={trails.slice(0, 5)}
 			showAge={true}
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>
@@ -102,6 +107,7 @@ export const SixTrails = () => (
 		<FixedMediumSlowXIIMPU
 			trails={trails.slice(0, 6)}
 			showAge={true}
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>
@@ -117,6 +123,7 @@ export const SevenTrails = () => (
 		<FixedMediumSlowXIIMPU
 			trails={trails.slice(0, 7)}
 			showAge={true}
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>
@@ -132,6 +139,7 @@ export const EightTrails = () => (
 		<FixedMediumSlowXIIMPU
 			trails={trails.slice(0, 8)}
 			showAge={true}
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>
@@ -147,6 +155,7 @@ export const NineTrails = () => (
 		<FixedMediumSlowXIIMPU
 			trails={trails.slice(0, 9)}
 			showAge={true}
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>

--- a/dotcom-rendering/src/components/FixedMediumSlowXIIMPU.tsx
+++ b/dotcom-rendering/src/components/FixedMediumSlowXIIMPU.tsx
@@ -14,6 +14,7 @@ type Props = {
 	trails: DCRFrontCard[];
 	containerPalette?: DCRContainerPalette;
 	imageLoading: Loading;
+	absoluteServerTimes: boolean;
 	showAge?: boolean;
 };
 
@@ -28,9 +29,11 @@ const Card33_Card33_Card33 = ({
 	showAge,
 	padBottom,
 	imageLoading,
+	absoluteServerTimes,
 }: {
 	trails: DCRFrontCard[];
 	imageLoading: Loading;
+	absoluteServerTimes: boolean;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
 	padBottom?: boolean;
@@ -46,6 +49,7 @@ const Card33_Card33_Card33 = ({
 						trail={trail}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						absoluteServerTimes={absoluteServerTimes}
 						imageLoading={imageLoading}
 					/>
 				</LI>
@@ -61,6 +65,7 @@ const Card33_Card33_Card33 = ({
 						trail={trail}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						absoluteServerTimes={absoluteServerTimes}
 						imageLoading={imageLoading}
 					/>
 				</LI>
@@ -80,9 +85,11 @@ const Card50_Card50 = ({
 	showAge,
 	padBottom,
 	imageLoading,
+	absoluteServerTimes,
 }: {
 	trails: DCRFrontCard[];
 	imageLoading: Loading;
+	absoluteServerTimes: boolean;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
 	padBottom?: boolean;
@@ -97,6 +104,7 @@ const Card50_Card50 = ({
 						trail={trail}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						absoluteServerTimes={absoluteServerTimes}
 						imageLoading={imageLoading}
 					/>
 				</LI>
@@ -112,6 +120,7 @@ const Card50_Card50 = ({
 						trail={trail}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						absoluteServerTimes={absoluteServerTimes}
 						imageLoading={imageLoading}
 					/>
 				</LI>
@@ -125,6 +134,7 @@ export const FixedMediumSlowXIIMPU = ({
 	containerPalette,
 	showAge,
 	imageLoading,
+	absoluteServerTimes,
 }: Props) => {
 	const firstSlice = trails.slice(0, 3);
 	const remaining = trails.slice(3, 9);
@@ -138,6 +148,7 @@ export const FixedMediumSlowXIIMPU = ({
 								trail={trail}
 								containerPalette={containerPalette}
 								showAge={showAge}
+								absoluteServerTimes={absoluteServerTimes}
 								key={trail.url}
 								imageLoading={imageLoading}
 							/>
@@ -149,6 +160,7 @@ export const FixedMediumSlowXIIMPU = ({
 					trails={trails}
 					containerPalette={containerPalette}
 					showAge={showAge}
+					absoluteServerTimes={absoluteServerTimes}
 					imageLoading={imageLoading}
 				/>
 			) : (
@@ -156,6 +168,7 @@ export const FixedMediumSlowXIIMPU = ({
 					trails={firstSlice}
 					containerPalette={containerPalette}
 					showAge={showAge}
+					absoluteServerTimes={absoluteServerTimes}
 					padBottom={true}
 					imageLoading={imageLoading}
 				/>
@@ -180,6 +193,7 @@ export const FixedMediumSlowXIIMPU = ({
 							trail={trail}
 							containerPalette={containerPalette}
 							showAge={showAge}
+							absoluteServerTimes={absoluteServerTimes}
 						/>
 					</LI>
 				))}

--- a/dotcom-rendering/src/components/FixedSmallFastVIII.stories.tsx
+++ b/dotcom-rendering/src/components/FixedSmallFastVIII.stories.tsx
@@ -28,6 +28,7 @@ export const Default = () => (
 		<FixedSmallFastVIII
 			trails={trails}
 			showAge={true}
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>

--- a/dotcom-rendering/src/components/FixedSmallFastVIII.tsx
+++ b/dotcom-rendering/src/components/FixedSmallFastVIII.tsx
@@ -10,12 +10,14 @@ type Props = {
 	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
+	absoluteServerTimes: boolean;
 };
 
 export const FixedSmallFastVIII = ({
 	trails,
 	containerPalette,
 	showAge,
+	absoluteServerTimes,
 	imageLoading,
 }: Props) => {
 	if (!trails[0]) return null;
@@ -36,6 +38,7 @@ export const FixedSmallFastVIII = ({
 							trail={card}
 							containerPalette={containerPalette}
 							showAge={showAge}
+							absoluteServerTimes={absoluteServerTimes}
 							imageLoading={imageLoading}
 						/>
 					</LI>
@@ -63,6 +66,7 @@ export const FixedSmallFastVIII = ({
 									trail={card}
 									containerPalette={containerPalette}
 									showAge={showAge}
+									absoluteServerTimes={absoluteServerTimes}
 								/>
 							</LI>
 						);

--- a/dotcom-rendering/src/components/FixedSmallSlowI.stories.tsx
+++ b/dotcom-rendering/src/components/FixedSmallSlowI.stories.tsx
@@ -24,7 +24,12 @@ export const Default = () => (
 		discussionApiUrl={discussionApiUrl}
 		editionId={'UK'}
 	>
-		<FixedSmallSlowI trails={trails} showAge={true} imageLoading="eager" />
+		<FixedSmallSlowI
+			trails={trails}
+			showAge={true}
+			imageLoading="eager"
+			absoluteServerTimes={true}
+		/>
 	</FrontSection>
 );
 Default.storyName = 'FixedSmallSlowI';

--- a/dotcom-rendering/src/components/FixedSmallSlowI.tsx
+++ b/dotcom-rendering/src/components/FixedSmallSlowI.tsx
@@ -9,12 +9,14 @@ type Props = {
 	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
+	absoluteServerTimes: boolean;
 };
 
 export const FixedSmallSlowI = ({
 	trails,
 	containerPalette,
 	showAge,
+	absoluteServerTimes,
 	imageLoading,
 }: Props) => {
 	const firstSlice100 = trails.slice(0, 1);
@@ -27,6 +29,7 @@ export const FixedSmallSlowI = ({
 						trail={card}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						absoluteServerTimes={absoluteServerTimes}
 						imageLoading={imageLoading}
 					/>
 				</LI>

--- a/dotcom-rendering/src/components/FixedSmallSlowIII.stories.tsx
+++ b/dotcom-rendering/src/components/FixedSmallSlowIII.stories.tsx
@@ -27,6 +27,7 @@ export const Default = () => (
 		<FixedSmallSlowIII
 			trails={trails}
 			showAge={true}
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>

--- a/dotcom-rendering/src/components/FixedSmallSlowIII.tsx
+++ b/dotcom-rendering/src/components/FixedSmallSlowIII.tsx
@@ -9,12 +9,14 @@ type Props = {
 	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
+	absoluteServerTimes: boolean;
 };
 
 export const FixedSmallSlowIII = ({
 	trails,
 	containerPalette,
 	showAge,
+	absoluteServerTimes,
 	imageLoading,
 }: Props) => {
 	const firstSlice50 = trails.slice(0, 1);
@@ -28,6 +30,7 @@ export const FixedSmallSlowIII = ({
 						trail={trail}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						absoluteServerTimes={absoluteServerTimes}
 						imageLoading={imageLoading}
 					/>
 				</LI>
@@ -44,6 +47,7 @@ export const FixedSmallSlowIII = ({
 						trail={trail}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						absoluteServerTimes={absoluteServerTimes}
 						imageLoading={imageLoading}
 					/>
 				</LI>

--- a/dotcom-rendering/src/components/FixedSmallSlowIV.stories.tsx
+++ b/dotcom-rendering/src/components/FixedSmallSlowIV.stories.tsx
@@ -24,7 +24,12 @@ export const Default = () => (
 		discussionApiUrl={discussionApiUrl}
 		editionId={'UK'}
 	>
-		<FixedSmallSlowIV trails={trails} showAge={true} imageLoading="eager" />
+		<FixedSmallSlowIV
+			trails={trails}
+			showAge={true}
+			imageLoading="eager"
+			absoluteServerTimes={true}
+		/>
 	</FrontSection>
 );
 Default.storyName = 'FixedSmallSlowIV';

--- a/dotcom-rendering/src/components/FixedSmallSlowIV.tsx
+++ b/dotcom-rendering/src/components/FixedSmallSlowIV.tsx
@@ -9,12 +9,14 @@ type Props = {
 	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
+	absoluteServerTimes: boolean;
 };
 
 export const FixedSmallSlowIV = ({
 	trails,
 	containerPalette,
 	showAge,
+	absoluteServerTimes,
 	imageLoading,
 }: Props) => {
 	const firstSlice25 = trails.slice(0, 4);
@@ -33,6 +35,7 @@ export const FixedSmallSlowIV = ({
 							trail={trail}
 							containerPalette={containerPalette}
 							showAge={showAge}
+							absoluteServerTimes={absoluteServerTimes}
 							imageLoading={imageLoading}
 						/>
 					</LI>

--- a/dotcom-rendering/src/components/FixedSmallSlowVHalf.stories.tsx
+++ b/dotcom-rendering/src/components/FixedSmallSlowVHalf.stories.tsx
@@ -27,6 +27,7 @@ export const Default = () => (
 		<FixedSmallSlowVHalf
 			trails={trails}
 			showAge={true}
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>

--- a/dotcom-rendering/src/components/FixedSmallSlowVHalf.tsx
+++ b/dotcom-rendering/src/components/FixedSmallSlowVHalf.tsx
@@ -9,12 +9,14 @@ type Props = {
 	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
+	absoluteServerTimes: boolean;
 };
 
 export const FixedSmallSlowVHalf = ({
 	trails,
 	containerPalette,
 	showAge,
+	absoluteServerTimes,
 	imageLoading,
 }: Props) => {
 	const firstSlice50 = trails.slice(0, 1);
@@ -35,6 +37,7 @@ export const FixedSmallSlowVHalf = ({
 							trail={trail}
 							containerPalette={containerPalette}
 							showAge={showAge}
+							absoluteServerTimes={absoluteServerTimes}
 							imageLoading={imageLoading}
 						/>
 					</LI>
@@ -49,6 +52,7 @@ export const FixedSmallSlowVHalf = ({
 									trail={trail}
 									containerPalette={containerPalette}
 									showAge={showAge}
+									absoluteServerTimes={absoluteServerTimes}
 									imageLoading={imageLoading}
 								/>
 							</LI>

--- a/dotcom-rendering/src/components/FixedSmallSlowVMPU.stories.tsx
+++ b/dotcom-rendering/src/components/FixedSmallSlowVMPU.stories.tsx
@@ -27,6 +27,7 @@ export const FourCards = () => (
 		<FixedSmallSlowVMPU
 			trails={trails.slice(0, 4)}
 			showAge={true}
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>
@@ -43,6 +44,7 @@ export const ThreeCards = () => (
 		<FixedSmallSlowVMPU
 			trails={trails.slice(0, 3)}
 			showAge={true}
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>
@@ -59,6 +61,7 @@ export const TwoCards = () => (
 		<FixedSmallSlowVMPU
 			trails={trails.slice(0, 2)}
 			showAge={true}
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>
@@ -75,6 +78,7 @@ export const OneCard = () => (
 		<FixedSmallSlowVMPU
 			trails={trails.slice(0, 1)}
 			showAge={true}
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>

--- a/dotcom-rendering/src/components/FixedSmallSlowVMPU.tsx
+++ b/dotcom-rendering/src/components/FixedSmallSlowVMPU.tsx
@@ -9,12 +9,14 @@ type Props = {
 	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
+	absoluteServerTimes: boolean;
 };
 
 export const FixedSmallSlowVMPU = ({
 	trails,
 	containerPalette,
 	showAge,
+	absoluteServerTimes,
 	imageLoading,
 }: Props) => (
 	<UL direction="row" padBottom={true}>
@@ -31,6 +33,7 @@ export const FixedSmallSlowVMPU = ({
 						trail={card}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						absoluteServerTimes={absoluteServerTimes}
 						imageLoading={imageLoading}
 					/>
 				</LI>

--- a/dotcom-rendering/src/components/FixedSmallSlowVThird.stories.tsx
+++ b/dotcom-rendering/src/components/FixedSmallSlowVThird.stories.tsx
@@ -27,6 +27,7 @@ export const Default = () => (
 		<FixedSmallSlowVThird
 			trails={trails}
 			showAge={true}
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>

--- a/dotcom-rendering/src/components/FixedSmallSlowVThird.tsx
+++ b/dotcom-rendering/src/components/FixedSmallSlowVThird.tsx
@@ -10,12 +10,14 @@ type Props = {
 	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
+	absoluteServerTimes: boolean;
 };
 
 export const FixedSmallSlowVThird = ({
 	trails,
 	containerPalette,
 	showAge,
+	absoluteServerTimes,
 	imageLoading,
 }: Props) => {
 	const firstSlice25 = trails.slice(0, 2);
@@ -36,6 +38,7 @@ export const FixedSmallSlowVThird = ({
 							trail={trail}
 							containerPalette={containerPalette}
 							showAge={showAge}
+							absoluteServerTimes={absoluteServerTimes}
 							imageLoading={imageLoading}
 						/>
 					</LI>
@@ -54,6 +57,7 @@ export const FixedSmallSlowVThird = ({
 									trail={trail}
 									containerPalette={containerPalette}
 									showAge={showAge}
+									absoluteServerTimes={absoluteServerTimes}
 									headlineSize="small"
 									imagePosition="left"
 									imagePositionOnMobile="none"

--- a/dotcom-rendering/src/components/FrontCard.tsx
+++ b/dotcom-rendering/src/components/FrontCard.tsx
@@ -6,7 +6,7 @@ import { Card } from './Card/Card';
 type Props = {
 	trail: DCRFrontCard;
 } & Partial<CardProps> &
-	Pick<CardProps, 'imageLoading'>;
+	Pick<CardProps, 'imageLoading' | 'absoluteServerTimes'>;
 
 /**
  * A wrapper around the normal Card component providing sensible defaults for Cards on front containers.
@@ -26,7 +26,10 @@ type Props = {
  */
 export const FrontCard = (props: Props) => {
 	const { trail, ...cardProps } = props;
-	const defaultProps: Omit<CardProps, 'imageLoading'> = {
+	const defaultProps: Omit<
+		CardProps,
+		'imageLoading' | 'absoluteServerTimes'
+	> = {
 		linkTo: trail.url,
 		format: trail.format,
 		headlineText: trail.headline,

--- a/dotcom-rendering/src/components/Island.test.tsx
+++ b/dotcom-rendering/src/components/Island.test.tsx
@@ -227,6 +227,7 @@ describe('Island: server-side rendering', () => {
 						editionId={'UK'}
 						shortUrlId=""
 						discussionApiUrl=""
+						absoluteServerTimes={true}
 					/>
 				</ConfigProvider>,
 			),

--- a/dotcom-rendering/src/components/KeyEventCard.stories.tsx
+++ b/dotcom-rendering/src/components/KeyEventCard.stories.tsx
@@ -58,6 +58,7 @@ export const SummaryCard = () => (
 			title={events[0].title}
 			filterKeyEvents={false}
 			isSummary={true}
+			absoluteServerTimes={true}
 		/>
 	</ul>
 );
@@ -73,6 +74,7 @@ export const StandardCard = () => (
 			title={events[0].title}
 			isSummary={events[0].isSummary}
 			filterKeyEvents={false}
+			absoluteServerTimes={true}
 		/>
 	</ul>
 );
@@ -89,6 +91,7 @@ export const MultipleCards = () => (
 				title={event.title}
 				isSummary={event.isSummary}
 				filterKeyEvents={false}
+				absoluteServerTimes={true}
 			/>
 		))}
 	</ul>

--- a/dotcom-rendering/src/components/KeyEventCard.tsx
+++ b/dotcom-rendering/src/components/KeyEventCard.tsx
@@ -15,6 +15,7 @@ interface Props {
 	title: string;
 	isSummary: boolean;
 	filterKeyEvents: boolean;
+	absoluteServerTimes: boolean;
 	cardPosition?: string;
 }
 
@@ -111,6 +112,7 @@ export const KeyEventCard = ({
 	title,
 	filterKeyEvents,
 	cardPosition = 'unknown position',
+	absoluteServerTimes,
 }: Props) => {
 	const url = `?filterKeyEvents=${String(
 		filterKeyEvents,
@@ -127,6 +129,7 @@ export const KeyEventCard = ({
 					<DateTime
 						date={new Date(blockFirstPublished)}
 						display="relative"
+						absoluteServerTimes={absoluteServerTimes}
 						editionId={'UK'}
 						showWeekday={false}
 						showDate={true}

--- a/dotcom-rendering/src/components/KeyEventsCarousel.importable.tsx
+++ b/dotcom-rendering/src/components/KeyEventsCarousel.importable.tsx
@@ -14,6 +14,7 @@ interface Props {
 	keyEvents: Block[];
 	filterKeyEvents: boolean;
 	id: 'key-events-carousel-desktop' | 'key-events-carousel-mobile';
+	absoluteServerTimes: boolean;
 }
 type ValidBlock = Block & {
 	title: string;
@@ -99,6 +100,7 @@ export const KeyEventsCarousel = ({
 	keyEvents,
 	filterKeyEvents,
 	id,
+	absoluteServerTimes,
 }: Props) => {
 	const carousel = useRef<HTMLDivElement | null>(null);
 	const cardWidth = 200;
@@ -137,6 +139,7 @@ export const KeyEventsCarousel = ({
 								isSummary={keyEvent.attributes.summary}
 								title={keyEvent.title}
 								cardPosition={`${index} of ${carouselLength}`}
+								absoluteServerTimes={absoluteServerTimes}
 							/>
 						);
 					})}

--- a/dotcom-rendering/src/components/KeyEventsCarousel.stories.tsx
+++ b/dotcom-rendering/src/components/KeyEventsCarousel.stories.tsx
@@ -65,6 +65,7 @@ export const SingleKeyEventCarousel = () => {
 				keyEvents={SingleKeyEvent}
 				filterKeyEvents={false}
 				id="key-events-carousel-desktop"
+				absoluteServerTimes={true}
 			/>
 		</Wrapper>
 	);
@@ -78,6 +79,7 @@ export const ShortKeyEventCarousel = () => {
 				keyEvents={ShortKeyEvents}
 				filterKeyEvents={false}
 				id="key-events-carousel-desktop"
+				absoluteServerTimes={true}
 			/>
 		</Wrapper>
 	);
@@ -91,6 +93,7 @@ export const LongKeyEventCarousel = () => {
 				keyEvents={LongKeyEvents}
 				filterKeyEvents={false}
 				id="key-events-carousel-desktop"
+				absoluteServerTimes={true}
 			/>
 		</Wrapper>
 	);

--- a/dotcom-rendering/src/components/LatestLinks.importable.stories.tsx
+++ b/dotcom-rendering/src/components/LatestLinks.importable.stories.tsx
@@ -169,6 +169,7 @@ export const WorldCupFinal2023 = () => {
 						direction="horizontal"
 						containerPalette={containerPalette}
 						isDynamo={true}
+						absoluteServerTimes={true}
 					/>
 				</Island>
 			</ContainerOverrides>
@@ -203,6 +204,7 @@ export const LondonPride2022 = ({ theme }: StoryArgs) => {
 				<LatestLinks
 					id="/world/live/2022/jul/02/pride-in-london-2022-huge-turnout-expected-at-first-march-since-pandemic-live-updates"
 					direction="horizontal"
+					absoluteServerTimes={true}
 				/>
 			</Island>
 		</Wrapper>

--- a/dotcom-rendering/src/components/LatestLinks.importable.tsx
+++ b/dotcom-rendering/src/components/LatestLinks.importable.tsx
@@ -18,6 +18,7 @@ import { DateTime } from './DateTime';
 type Props = {
 	id: string;
 	direction: 'horizontal' | 'vertical';
+	absoluteServerTimes: boolean;
 	isDynamo?: true;
 	containerPalette?: DCRContainerPalette;
 };
@@ -92,6 +93,7 @@ export const LatestLinks = ({
 	direction,
 	isDynamo,
 	containerPalette,
+	absoluteServerTimes,
 }: Props) => {
 	const { data } = useApi<{
 		blocks: Array<{
@@ -173,6 +175,9 @@ export const LatestLinks = ({
 												)
 											}
 											display="relative"
+											absoluteServerTimes={
+												absoluteServerTimes
+											}
 											editionId={'UK'}
 											showWeekday={false}
 											showDate={true}

--- a/dotcom-rendering/src/components/LiveBlock.tsx
+++ b/dotcom-rendering/src/components/LiveBlock.tsx
@@ -66,6 +66,7 @@ export const LiveBlock = ({
 			isOriginalPinnedPost={isOriginalPinnedPost}
 			host={host}
 			pageId={pageId}
+			absoluteServerTimes={!!switches.absoluteServerTimes}
 		>
 			{block.elements.map((element, index) => (
 				<RenderArticleElement

--- a/dotcom-rendering/src/components/LiveBlockContainer.tsx
+++ b/dotcom-rendering/src/components/LiveBlockContainer.tsx
@@ -25,6 +25,7 @@ type Props = {
 	isLiveUpdate?: boolean;
 	contributors?: BlockContributor[];
 	isPinnedPost: boolean;
+	absoluteServerTimes: boolean;
 	isOriginalPinnedPost?: boolean;
 	host?: string;
 	pageId?: string;
@@ -140,6 +141,7 @@ export const LiveBlockContainer = ({
 	isOriginalPinnedPost = false,
 	host,
 	pageId,
+	absoluteServerTimes,
 }: Props) => {
 	return (
 		<article
@@ -174,6 +176,7 @@ export const LiveBlockContainer = ({
 						isOriginalPinnedPost={isOriginalPinnedPost}
 						host={host}
 						pageId={pageId}
+						absoluteServerTimes={absoluteServerTimes}
 					/>
 				)}
 				{blockTitle ? <BlockTitle title={blockTitle} /> : null}

--- a/dotcom-rendering/src/components/LiveBlogRenderer.tsx
+++ b/dotcom-rendering/src/components/LiveBlogRenderer.tsx
@@ -68,6 +68,7 @@ export const LiveBlogRenderer = ({
 }: Props) => {
 	const { renderingTarget } = useConfig();
 	const isWeb = renderingTarget === 'Web';
+	const { absoluteServerTimes = false } = switches;
 
 	const filtered =
 		(!!selectedTopics && selectedTopics.length > 0) || filterKeyEvents;
@@ -79,7 +80,11 @@ export const LiveBlogRenderer = ({
 					<Island defer={{ until: 'idle' }} priority="feature">
 						<EnhancePinnedPost />
 					</Island>
-					<PinnedPost pinnedPost={pinnedPost} format={format}>
+					<PinnedPost
+						pinnedPost={pinnedPost}
+						format={format}
+						absoluteServerTimes={absoluteServerTimes}
+					>
 						<LiveBlock
 							format={format}
 							block={pinnedPost}
@@ -105,6 +110,7 @@ export const LiveBlogRenderer = ({
 							keyEvents={keyEvents}
 							filterKeyEvents={filterKeyEvents}
 							id={'key-events-carousel-mobile'}
+							absoluteServerTimes={absoluteServerTimes}
 						/>
 					</Island>
 					{(!switches.automaticFilters || !availableTopics) && (

--- a/dotcom-rendering/src/components/OnwardsUpper.importable.tsx
+++ b/dotcom-rendering/src/components/OnwardsUpper.importable.tsx
@@ -176,6 +176,7 @@ type Props = {
 	pillar: ArticleTheme;
 	shortUrlId: string;
 	discussionApiUrl: string;
+	absoluteServerTimes: boolean;
 };
 
 /**
@@ -209,6 +210,7 @@ export const OnwardsUpper = ({
 	editionId,
 	shortUrlId,
 	discussionApiUrl,
+	absoluteServerTimes,
 }: Props) => {
 	const isAndroid = useIsAndroid();
 	const AB = useAB();
@@ -336,6 +338,7 @@ export const OnwardsUpper = ({
 						onwardsSource={onwardsSource}
 						format={format}
 						discussionApiUrl={discussionApiUrl}
+						absoluteServerTimes={absoluteServerTimes}
 					/>
 				</Section>
 			)}
@@ -350,6 +353,7 @@ export const OnwardsUpper = ({
 						onwardsSource="curated-content"
 						format={format}
 						discussionApiUrl={discussionApiUrl}
+						absoluteServerTimes={absoluteServerTimes}
 					/>
 				</Section>
 			)}

--- a/dotcom-rendering/src/components/Palettes.stories.tsx
+++ b/dotcom-rendering/src/components/Palettes.stories.tsx
@@ -36,6 +36,7 @@ export const EventPalette = () => (
 			groupedTrails={groupedTrails}
 			containerPalette="EventPalette"
 			showAge={true}
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>
@@ -64,6 +65,7 @@ export const EventAltPalette = () => (
 			groupedTrails={groupedTrails}
 			containerPalette="EventAltPalette"
 			showAge={true}
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>
@@ -81,6 +83,7 @@ export const SombrePalette = () => (
 			groupedTrails={groupedTrails}
 			containerPalette="SombrePalette"
 			showAge={true}
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>
@@ -98,6 +101,7 @@ export const SombreAltPalette = () => (
 			groupedTrails={groupedTrails}
 			containerPalette="SombreAltPalette"
 			showAge={true}
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>
@@ -115,6 +119,7 @@ export const BreakingPalette = () => (
 			groupedTrails={groupedTrails}
 			containerPalette="BreakingPalette"
 			showAge={true}
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>
@@ -132,6 +137,7 @@ export const LongRunningPalette = () => (
 			groupedTrails={groupedTrails}
 			containerPalette="LongRunningPalette"
 			showAge={true}
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>
@@ -149,6 +155,7 @@ export const LongRunningAltPalette = () => (
 			groupedTrails={groupedTrails}
 			containerPalette="LongRunningAltPalette"
 			showAge={true}
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>
@@ -166,6 +173,7 @@ export const InvestigationPalette = () => (
 			groupedTrails={groupedTrails}
 			containerPalette="InvestigationPalette"
 			showAge={true}
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>
@@ -183,6 +191,7 @@ export const SpecialReportAltPalette = () => (
 			groupedTrails={groupedTrails}
 			containerPalette="SpecialReportAltPalette"
 			showAge={true}
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>
@@ -204,6 +213,7 @@ export const BrandedPalette = () => (
 			groupedTrails={groupedTrails}
 			containerPalette="Branded"
 			showAge={true}
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</LabsSection>
@@ -221,6 +231,7 @@ export const MediaPalette = () => (
 			groupedTrails={groupedTrails}
 			containerPalette="MediaPalette"
 			showAge={true}
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>
@@ -242,6 +253,7 @@ export const PodcastPalette = () => (
 			groupedTrails={groupedTrails}
 			containerPalette="PodcastPalette"
 			showAge={true}
+			absoluteServerTimes={true}
 			imageLoading="eager"
 		/>
 	</FrontSection>

--- a/dotcom-rendering/src/components/PinnedPost.stories.tsx
+++ b/dotcom-rendering/src/components/PinnedPost.stories.tsx
@@ -72,7 +72,11 @@ export const Sport = () => {
 	};
 	return (
 		<Wrapper>
-			<PinnedPost pinnedPost={block} format={format}>
+			<PinnedPost
+				pinnedPost={block}
+				format={format}
+				absoluteServerTimes={true}
+			>
 				<LiveBlock
 					format={format}
 					block={block}
@@ -119,7 +123,11 @@ export const News = () => {
 	};
 	return (
 		<Wrapper>
-			<PinnedPost pinnedPost={block} format={format}>
+			<PinnedPost
+				pinnedPost={block}
+				format={format}
+				absoluteServerTimes={true}
+			>
 				<LiveBlock
 					format={format}
 					block={block}
@@ -166,7 +174,11 @@ export const Culture = () => {
 	};
 	return (
 		<Wrapper>
-			<PinnedPost pinnedPost={block} format={format}>
+			<PinnedPost
+				pinnedPost={block}
+				format={format}
+				absoluteServerTimes={true}
+			>
 				<LiveBlock
 					format={format}
 					block={block}
@@ -213,7 +225,11 @@ export const Lifestyle = () => {
 	};
 	return (
 		<Wrapper>
-			<PinnedPost pinnedPost={block} format={format}>
+			<PinnedPost
+				pinnedPost={block}
+				format={format}
+				absoluteServerTimes={true}
+			>
 				<LiveBlock
 					format={format}
 					block={block}
@@ -260,7 +276,11 @@ export const Opinion = () => {
 	};
 	return (
 		<Wrapper>
-			<PinnedPost pinnedPost={block} format={format}>
+			<PinnedPost
+				pinnedPost={block}
+				format={format}
+				absoluteServerTimes={true}
+			>
 				<LiveBlock
 					format={format}
 					block={block}
@@ -307,7 +327,11 @@ export const SpecialReport = () => {
 	};
 	return (
 		<Wrapper>
-			<PinnedPost pinnedPost={block} format={format}>
+			<PinnedPost
+				pinnedPost={block}
+				format={format}
+				absoluteServerTimes={true}
+			>
 				<LiveBlock
 					format={format}
 					block={block}
@@ -354,7 +378,11 @@ export const Labs = () => {
 	};
 	return (
 		<Wrapper>
-			<PinnedPost pinnedPost={block} format={format}>
+			<PinnedPost
+				pinnedPost={block}
+				format={format}
+				absoluteServerTimes={true}
+			>
 				<LiveBlock
 					format={format}
 					block={block}

--- a/dotcom-rendering/src/components/PinnedPost.tsx
+++ b/dotcom-rendering/src/components/PinnedPost.tsx
@@ -141,9 +141,15 @@ type Props = {
 	pinnedPost: Block;
 	children: React.ReactNode;
 	format: ArticleFormat;
+	absoluteServerTimes: boolean;
 };
 
-export const PinnedPost = ({ pinnedPost, children, format }: Props) => {
+export const PinnedPost = ({
+	pinnedPost,
+	children,
+	format,
+	absoluteServerTimes,
+}: Props) => {
 	const palette = decidePalette(format);
 	return (
 		<div
@@ -171,6 +177,7 @@ export const PinnedPost = ({ pinnedPost, children, format }: Props) => {
 						<DateTime
 							date={new Date(pinnedPost.blockFirstPublished)}
 							display="relative"
+							absoluteServerTimes={absoluteServerTimes}
 							editionId={'UK'}
 							showWeekday={false}
 							showDate={true}

--- a/dotcom-rendering/src/components/RelativeTime.importable.tsx
+++ b/dotcom-rendering/src/components/RelativeTime.importable.tsx
@@ -22,8 +22,8 @@ export const RelativeTime = ({ then, now }: Props) => {
 	const [display, setDisplay] = useState(timeAgo(then, { now }));
 
 	useEffect(() => {
-		if (!inView) return;
 		setDisplay(timeAgo(then));
+		if (!inView) return;
 
 		const interval = setTimeout(() => {
 			setDisplay(timeAgo(then));

--- a/dotcom-rendering/src/components/RelativeTime.importable.tsx
+++ b/dotcom-rendering/src/components/RelativeTime.importable.tsx
@@ -5,6 +5,8 @@ import { useIsInView } from '../lib/useIsInView';
 type Props = {
 	/** the time to compare with in milliseconds since epoch */
 	then: number;
+	/** the time to compare to */
+	now: number;
 };
 
 /**
@@ -14,10 +16,10 @@ type Props = {
  *
  * We update the relative time on the browser on an interval.
  */
-export const RelativeTime = ({ then }: Props) => {
+export const RelativeTime = ({ then, now }: Props) => {
 	const [inView, ref] = useIsInView({ repeat: true });
 
-	const [display, setDisplay] = useState(timeAgo(then));
+	const [display, setDisplay] = useState(timeAgo(then, { now }));
 
 	useEffect(() => {
 		if (!inView) return;

--- a/dotcom-rendering/src/components/ShowMore.importable.tsx
+++ b/dotcom-rendering/src/components/ShowMore.importable.tsx
@@ -177,6 +177,7 @@ export const ShowMore = ({
 											showAge={showAge}
 											headlineSize="small"
 											imageLoading="eager"
+											absoluteServerTimes={false}
 										/>
 									</LI>
 								);

--- a/dotcom-rendering/src/components/SupportingContent.stories.tsx
+++ b/dotcom-rendering/src/components/SupportingContent.stories.tsx
@@ -37,6 +37,7 @@ const basicCardProps: CardProps = {
 	isPlayableMediaCard: true,
 	imageLoading: 'eager',
 	discussionApiUrl: 'https://discussion.theguardian.com/discussion-api',
+	absoluteServerTimes: true,
 };
 
 const aBasicLink = {

--- a/dotcom-rendering/src/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/layouts/CommentLayout.tsx
@@ -306,6 +306,8 @@ export const CommentLayout = (props: WebProps | AppsProps) => {
 	const inUpdatedHeaderABTest =
 		article.config.abTests.updatedHeaderDesignVariant === 'variant';
 
+	const { absoluteServerTimes = false } = article.config.switches;
+
 	return (
 		<>
 			{isWeb && (
@@ -845,6 +847,7 @@ export const CommentLayout = (props: WebProps | AppsProps) => {
 								discussionApiUrl={
 									article.config.discussionApiUrl
 								}
+								absoluteServerTimes={absoluteServerTimes}
 							/>
 						</Island>
 					</Section>
@@ -867,6 +870,7 @@ export const CommentLayout = (props: WebProps | AppsProps) => {
 						editionId={article.editionId}
 						shortUrlId={article.config.shortUrlId}
 						discussionApiUrl={article.config.discussionApiUrl}
+						absoluteServerTimes={absoluteServerTimes}
 					/>
 				</Island>
 

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -161,6 +161,8 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 	const inUpdatedHeaderABTest =
 		front.config.abTests.updatedHeaderDesignVariant === 'variant';
 
+	const { absoluteServerTimes = false } = front.config.switches;
+
 	return (
 		<>
 			<div data-print-layout="hide" id="bannerandheader">
@@ -516,6 +518,9 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 											collection.containerPalette
 										}
 										imageLoading={imageLoading}
+										absoluteServerTimes={
+											absoluteServerTimes
+										}
 									/>
 								</LabsSection>
 								{decideMerchHighAndMobileAdSlots(
@@ -594,6 +599,9 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 											url={collection.href}
 											discussionApiUrl={
 												front.config.discussionApiUrl
+											}
+											absoluteServerTimes={
+												absoluteServerTimes
 											}
 										/>
 									</Island>
@@ -675,6 +683,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 										)
 									}
 									imageLoading={imageLoading}
+									absoluteServerTimes={absoluteServerTimes}
 								/>
 							</FrontSection>
 							{decideMerchHighAndMobileAdSlots(

--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -311,6 +311,8 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 
 	const renderAds = isWeb && canRenderAds(article);
 
+	const { absoluteServerTimes = false } = article.config.switches;
+
 	return (
 		<>
 			{isWeb && (
@@ -842,6 +844,7 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 								discussionApiUrl={
 									article.config.discussionApiUrl
 								}
+								absoluteServerTimes={absoluteServerTimes}
 							/>
 						</Island>
 					</Section>
@@ -864,6 +867,7 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 						editionId={article.editionId}
 						shortUrlId={article.config.shortUrlId}
 						discussionApiUrl={article.config.discussionApiUrl}
+						absoluteServerTimes={absoluteServerTimes}
 					/>
 				</Island>
 

--- a/dotcom-rendering/src/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/InteractiveLayout.tsx
@@ -236,6 +236,8 @@ export const InteractiveLayout = (props: WebProps | AppsProps) => {
 	const inUpdatedHeaderABTest =
 		article.config.abTests.updatedHeaderDesignVariant === 'variant';
 
+	const { absoluteServerTimes = false } = article.config.switches;
+
 	/**
 	 * This property currently only applies to the header and merchandising slots
 	 */
@@ -789,6 +791,7 @@ export const InteractiveLayout = (props: WebProps | AppsProps) => {
 								discussionApiUrl={
 									article.config.discussionApiUrl
 								}
+								absoluteServerTimes={absoluteServerTimes}
 							/>
 						</Island>
 					</Section>
@@ -811,6 +814,7 @@ export const InteractiveLayout = (props: WebProps | AppsProps) => {
 						editionId={article.editionId}
 						shortUrlId={article.config.shortUrlId}
 						discussionApiUrl={article.config.discussionApiUrl}
+						absoluteServerTimes={absoluteServerTimes}
 					/>
 				</Island>
 

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -315,6 +315,8 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 	const inUpdatedHeaderABTest =
 		article.config.abTests.updatedHeaderDesignVariant === 'variant';
 
+	const { absoluteServerTimes = false } = article.config.switches;
+
 	return (
 		<>
 			{isWeb && (
@@ -685,6 +687,7 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 									keyEvents={article.keyEvents}
 									filterKeyEvents={article.filterKeyEvents}
 									id={'key-events-carousel-desktop'}
+									absoluteServerTimes={absoluteServerTimes}
 								/>
 							</Island>
 						</Hide>
@@ -1261,6 +1264,10 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 									discussionApiUrl={
 										article.config.discussionApiUrl
 									}
+									absoluteServerTimes={
+										!!article.config.switches
+											.absoluteServerTimes
+									}
 								/>
 							</Island>
 						</Section>
@@ -1285,6 +1292,7 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 							editionId={article.editionId}
 							shortUrlId={article.config.shortUrlId}
 							discussionApiUrl={article.config.discussionApiUrl}
+							absoluteServerTimes={absoluteServerTimes}
 						/>
 					</Island>
 

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -1264,10 +1264,7 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 									discussionApiUrl={
 										article.config.discussionApiUrl
 									}
-									absoluteServerTimes={
-										!!article.config.switches
-											.absoluteServerTimes
-									}
+									absoluteServerTimes={absoluteServerTimes}
 								/>
 							</Island>
 						</Section>

--- a/dotcom-rendering/src/layouts/NewsletterSignupLayout.tsx
+++ b/dotcom-rendering/src/layouts/NewsletterSignupLayout.tsx
@@ -549,6 +549,10 @@ export const NewsletterSignupLayout = ({ article, NAV, format }: Props) => {
 								discussionApiUrl={
 									article.config.discussionApiUrl
 								}
+								absoluteServerTimes={
+									!!article.config.switches
+										.absoluteServerTimes
+								}
 							/>
 						</Island>
 					</Section>
@@ -571,6 +575,9 @@ export const NewsletterSignupLayout = ({ article, NAV, format }: Props) => {
 						editionId={article.editionId}
 						shortUrlId={article.config.shortUrlId}
 						discussionApiUrl={article.config.discussionApiUrl}
+						absoluteServerTimes={
+							!!article.config.switches.absoluteServerTimes
+						}
 					/>
 				</Island>
 			</main>

--- a/dotcom-rendering/src/layouts/NewsletterSignupLayout.tsx
+++ b/dotcom-rendering/src/layouts/NewsletterSignupLayout.tsx
@@ -215,6 +215,8 @@ export const NewsletterSignupLayout = ({ article, NAV, format }: Props) => {
 	const inUpdatedHeaderABTest =
 		article.config.abTests.updatedHeaderDesignVariant === 'variant';
 
+	const { absoluteServerTimes = false } = article.config.switches;
+
 	return (
 		<>
 			<div data-print-layout="hide" id="bannerandheader">
@@ -549,10 +551,7 @@ export const NewsletterSignupLayout = ({ article, NAV, format }: Props) => {
 								discussionApiUrl={
 									article.config.discussionApiUrl
 								}
-								absoluteServerTimes={
-									!!article.config.switches
-										.absoluteServerTimes
-								}
+								absoluteServerTimes={absoluteServerTimes}
 							/>
 						</Island>
 					</Section>
@@ -575,9 +574,7 @@ export const NewsletterSignupLayout = ({ article, NAV, format }: Props) => {
 						editionId={article.editionId}
 						shortUrlId={article.config.shortUrlId}
 						discussionApiUrl={article.config.discussionApiUrl}
-						absoluteServerTimes={
-							!!article.config.switches.absoluteServerTimes
-						}
+						absoluteServerTimes={absoluteServerTimes}
 					/>
 				</Island>
 			</main>

--- a/dotcom-rendering/src/layouts/PictureLayout.tsx
+++ b/dotcom-rendering/src/layouts/PictureLayout.tsx
@@ -288,6 +288,8 @@ export const PictureLayout = (props: WebProps | AppsProps) => {
 	const inUpdatedHeaderABTest =
 		article.config.abTests.updatedHeaderDesignVariant === 'variant';
 
+	const { absoluteServerTimes = false } = article.config.switches;
+
 	return (
 		<>
 			{isWeb && (
@@ -725,10 +727,7 @@ export const PictureLayout = (props: WebProps | AppsProps) => {
 								discussionApiUrl={
 									article.config.discussionApiUrl
 								}
-								absoluteServerTimes={
-									!!article.config.switches
-										.absoluteServerTimes
-								}
+								absoluteServerTimes={absoluteServerTimes}
 							/>
 						</Island>
 					</Section>
@@ -754,9 +753,7 @@ export const PictureLayout = (props: WebProps | AppsProps) => {
 							editionId={article.editionId}
 							shortUrlId={article.config.shortUrlId}
 							discussionApiUrl={article.config.discussionApiUrl}
-							absoluteServerTimes={
-								!!article.config.switches.absoluteServerTimes
-							}
+							absoluteServerTimes={absoluteServerTimes}
 						/>
 					</Island>
 				)}

--- a/dotcom-rendering/src/layouts/PictureLayout.tsx
+++ b/dotcom-rendering/src/layouts/PictureLayout.tsx
@@ -725,6 +725,10 @@ export const PictureLayout = (props: WebProps | AppsProps) => {
 								discussionApiUrl={
 									article.config.discussionApiUrl
 								}
+								absoluteServerTimes={
+									!!article.config.switches
+										.absoluteServerTimes
+								}
 							/>
 						</Island>
 					</Section>
@@ -750,6 +754,9 @@ export const PictureLayout = (props: WebProps | AppsProps) => {
 							editionId={article.editionId}
 							shortUrlId={article.config.shortUrlId}
 							discussionApiUrl={article.config.discussionApiUrl}
+							absoluteServerTimes={
+								!!article.config.switches.absoluteServerTimes
+							}
 						/>
 					</Island>
 				)}

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -864,6 +864,10 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 								discussionApiUrl={
 									article.config.discussionApiUrl
 								}
+								absoluteServerTimes={
+									!!article.config.switches
+										.absoluteServerTimes
+								}
 							/>
 						</Island>
 					</Section>
@@ -886,6 +890,9 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 						editionId={article.editionId}
 						shortUrlId={article.config.shortUrlId}
 						discussionApiUrl={article.config.discussionApiUrl}
+						absoluteServerTimes={
+							!!article.config.switches.absoluteServerTimes
+						}
 					/>
 				</Island>
 

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -250,6 +250,8 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 
 	const isLabs = format.theme === ArticleSpecial.Labs;
 
+	const { absoluteServerTimes = false } = article.config.switches;
+
 	return (
 		<>
 			{isWeb && (
@@ -864,10 +866,7 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 								discussionApiUrl={
 									article.config.discussionApiUrl
 								}
-								absoluteServerTimes={
-									!!article.config.switches
-										.absoluteServerTimes
-								}
+								absoluteServerTimes={absoluteServerTimes}
 							/>
 						</Island>
 					</Section>
@@ -890,9 +889,7 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 						editionId={article.editionId}
 						shortUrlId={article.config.shortUrlId}
 						discussionApiUrl={article.config.discussionApiUrl}
-						absoluteServerTimes={
-							!!article.config.switches.absoluteServerTimes
-						}
+						absoluteServerTimes={absoluteServerTimes}
 					/>
 				</Island>
 

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -382,6 +382,8 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 		(parse(article.slotMachineFlags ?? '').showBodyEnd ||
 			article.config.switches.slotBodyEnd);
 
+	const { absoluteServerTimes = false } = article.config.switches;
+
 	// TODO:
 	// 1) Read 'forceEpic' value from URL parameter and use it to force the slot to render
 	// 2) Otherwise, ensure slot only renders if `article.config.shouldHideReaderRevenue` equals false.
@@ -1014,6 +1016,7 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 								discussionApiUrl={
 									article.config.discussionApiUrl
 								}
+								absoluteServerTimes={absoluteServerTimes}
 							/>
 						</Island>
 					</Section>
@@ -1036,6 +1039,9 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 						editionId={article.editionId}
 						shortUrlId={article.config.shortUrlId}
 						discussionApiUrl={article.config.discussionApiUrl}
+						absoluteServerTimes={
+							!!article.config.switches.absoluteServerTimes
+						}
 					/>
 				</Island>
 				{showComments && (

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -1039,9 +1039,7 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 						editionId={article.editionId}
 						shortUrlId={article.config.shortUrlId}
 						discussionApiUrl={article.config.discussionApiUrl}
-						absoluteServerTimes={
-							!!article.config.switches.absoluteServerTimes
-						}
+						absoluteServerTimes={absoluteServerTimes}
 					/>
 				</Island>
 				{showComments && (

--- a/dotcom-rendering/src/lib/cardWrappers.tsx
+++ b/dotcom-rendering/src/lib/cardWrappers.tsx
@@ -5,6 +5,7 @@ import type { DCRContainerPalette, DCRFrontCard } from '../types/front';
 type TrailProps = {
 	trail: DCRFrontCard;
 	imageLoading: Loading;
+	absoluteServerTimes: boolean;
 	showAge?: boolean;
 	containerPalette?: DCRContainerPalette;
 };
@@ -46,6 +47,7 @@ export const Card100Media50 = ({
 	showAge,
 	containerPalette,
 	imageLoading,
+	absoluteServerTimes,
 }: TrailProps) => {
 	return (
 		<FrontCard
@@ -53,6 +55,7 @@ export const Card100Media50 = ({
 			trail={trail}
 			containerPalette={containerPalette}
 			showAge={showAge}
+			absoluteServerTimes={absoluteServerTimes}
 			headlineSize="huge"
 			headlineSizeOnMobile="medium"
 			image={trail.image}
@@ -95,12 +98,14 @@ export const Card100Media75 = ({
 	showAge,
 	containerPalette,
 	imageLoading,
+	absoluteServerTimes,
 }: TrailProps) => {
 	return (
 		<FrontCard
 			trail={trail}
 			containerPalette={containerPalette}
 			showAge={showAge}
+			absoluteServerTimes={absoluteServerTimes}
 			headlineSize="huge"
 			headlineSizeOnMobile="large"
 			image={trail.image}
@@ -145,12 +150,14 @@ export const Card100Media100 = ({
 	showAge,
 	containerPalette,
 	imageLoading,
+	absoluteServerTimes,
 }: TrailProps) => {
 	return (
 		<FrontCard
 			trail={trail}
 			containerPalette={containerPalette}
 			showAge={showAge}
+			absoluteServerTimes={absoluteServerTimes}
 			headlineSize="huge"
 			headlineSizeOnMobile="large"
 			image={trail.image}
@@ -184,12 +191,14 @@ export const Card100Media100Tall = ({
 	showAge,
 	containerPalette,
 	imageLoading,
+	absoluteServerTimes,
 }: TrailProps) => {
 	return (
 		<FrontCard
 			trail={trail}
 			containerPalette={containerPalette}
 			showAge={showAge}
+			absoluteServerTimes={absoluteServerTimes}
 			headlineSize="medium"
 			headlineSizeOnMobile="large"
 			image={trail.image}
@@ -222,12 +231,14 @@ export const Card75Media50Right = ({
 	showAge,
 	containerPalette,
 	imageLoading,
+	absoluteServerTimes,
 }: TrailProps) => {
 	return (
 		<FrontCard
 			trail={trail}
 			containerPalette={containerPalette}
 			showAge={showAge}
+			absoluteServerTimes={absoluteServerTimes}
 			trailText={trail.trailText}
 			supportingContent={trail.supportingContent?.slice(0, 3)}
 			supportingContentAlignment={
@@ -264,12 +275,14 @@ export const Card75Media50Left = ({
 	showAge,
 	containerPalette,
 	imageLoading,
+	absoluteServerTimes,
 }: TrailProps) => {
 	return (
 		<FrontCard
 			trail={trail}
 			containerPalette={containerPalette}
 			showAge={showAge}
+			absoluteServerTimes={absoluteServerTimes}
 			trailText={trail.trailText}
 			supportingContent={trail.supportingContent?.slice(0, 3)}
 			supportingContentAlignment={
@@ -306,6 +319,7 @@ export const Card25Media25 = ({
 	showAge,
 	containerPalette,
 	imageLoading,
+	absoluteServerTimes,
 }: TrailProps) => {
 	return (
 		<FrontCard
@@ -314,6 +328,7 @@ export const Card25Media25 = ({
 			supportingContentAlignment="vertical"
 			containerPalette={containerPalette}
 			showAge={showAge}
+			absoluteServerTimes={absoluteServerTimes}
 			imagePosition="top"
 			imagePositionOnMobile="left"
 			imageSize="small"
@@ -344,6 +359,7 @@ export const Card25Media25SmallHeadline = ({
 	showAge,
 	containerPalette,
 	imageLoading,
+	absoluteServerTimes,
 }: TrailProps) => {
 	return (
 		<FrontCard
@@ -352,6 +368,7 @@ export const Card25Media25SmallHeadline = ({
 			supportingContentAlignment="vertical"
 			containerPalette={containerPalette}
 			showAge={showAge}
+			absoluteServerTimes={absoluteServerTimes}
 			imagePosition="top"
 			imagePositionOnMobile="left"
 			imageSize="small"
@@ -383,12 +400,14 @@ export const Card25Media25Tall = ({
 	showAge,
 	containerPalette,
 	imageLoading,
+	absoluteServerTimes,
 }: TrailProps) => {
 	return (
 		<FrontCard
 			trail={trail}
 			containerPalette={containerPalette}
 			showAge={showAge}
+			absoluteServerTimes={absoluteServerTimes}
 			imagePosition="top"
 			imagePositionOnMobile="left"
 			imageSize="small"
@@ -427,12 +446,14 @@ export const Card25Media25TallNoTrail = ({
 	showAge,
 	containerPalette,
 	imageLoading,
+	absoluteServerTimes,
 }: TrailProps) => {
 	return (
 		<FrontCard
 			trail={trail}
 			containerPalette={containerPalette}
 			showAge={showAge}
+			absoluteServerTimes={absoluteServerTimes}
 			imagePosition="top"
 			imagePositionOnMobile="left"
 			imageSize="small"
@@ -464,12 +485,14 @@ export const Card25Media25TallSmallHeadline = ({
 	showAge,
 	containerPalette,
 	imageLoading,
+	absoluteServerTimes,
 }: TrailProps) => {
 	return (
 		<FrontCard
 			trail={trail}
 			containerPalette={containerPalette}
 			showAge={showAge}
+			absoluteServerTimes={absoluteServerTimes}
 			imagePosition="top"
 			imagePositionOnMobile="left"
 			imageSize="small"
@@ -501,6 +524,7 @@ export const Card50Media50 = ({
 	showAge,
 	containerPalette,
 	imageLoading,
+	absoluteServerTimes,
 }: TrailProps) => {
 	return (
 		<FrontCard
@@ -513,6 +537,7 @@ export const Card50Media50 = ({
 			imagePositionOnMobile="top"
 			imageLoading={imageLoading}
 			showAge={showAge}
+			absoluteServerTimes={absoluteServerTimes}
 			supportingContent={trail.supportingContent?.slice(0, 3)}
 			supportingContentAlignment="horizontal"
 		/>
@@ -539,12 +564,14 @@ export const Card50Media50Tall = ({
 	showAge,
 	containerPalette,
 	imageLoading,
+	absoluteServerTimes,
 }: TrailProps) => {
 	return (
 		<FrontCard
 			trail={trail}
 			containerPalette={containerPalette}
 			showAge={showAge}
+			absoluteServerTimes={absoluteServerTimes}
 			trailText={trail.trailText}
 			supportingContent={trail.supportingContent?.slice(0, 3)}
 			supportingContentAlignment="horizontal"
@@ -577,12 +604,14 @@ export const Card66Media66 = ({
 	showAge,
 	containerPalette,
 	imageLoading,
+	absoluteServerTimes,
 }: TrailProps) => {
 	return (
 		<FrontCard
 			trail={trail}
 			containerPalette={containerPalette}
 			showAge={showAge}
+			absoluteServerTimes={absoluteServerTimes}
 			trailText={trail.trailText}
 			headlineSize="medium"
 			headlineSizeOnMobile="medium"
@@ -613,12 +642,14 @@ export const Card33Media33 = ({
 	showAge,
 	containerPalette,
 	imageLoading,
+	absoluteServerTimes,
 }: TrailProps) => {
 	return (
 		<FrontCard
 			trail={trail}
 			containerPalette={containerPalette}
 			showAge={showAge}
+			absoluteServerTimes={absoluteServerTimes}
 			trailText={trail.trailText}
 			imageSize="medium"
 			imagePosition="top"
@@ -648,12 +679,14 @@ export const Card33Media33Tall = ({
 	showAge,
 	containerPalette,
 	imageLoading,
+	absoluteServerTimes,
 }: TrailProps) => {
 	return (
 		<FrontCard
 			trail={trail}
 			containerPalette={containerPalette}
 			showAge={showAge}
+			absoluteServerTimes={absoluteServerTimes}
 			imageSize="medium"
 			imagePosition="top"
 			imagePositionOnMobile="left"
@@ -685,12 +718,14 @@ export const Card33Media33MobileTopTall = ({
 	showAge,
 	containerPalette,
 	imageLoading,
+	absoluteServerTimes,
 }: TrailProps) => {
 	return (
 		<FrontCard
 			trail={trail}
 			containerPalette={containerPalette}
 			showAge={showAge}
+			absoluteServerTimes={absoluteServerTimes}
 			trailText={trail.trailText}
 			imageSize="medium"
 			imagePosition="top"
@@ -720,12 +755,14 @@ export const CardDefault = ({
 	trail,
 	showAge,
 	containerPalette,
+	absoluteServerTimes,
 }: Omit<TrailProps, 'imageLoading'>) => {
 	return (
 		<FrontCard
 			trail={trail}
 			containerPalette={containerPalette}
 			showAge={showAge}
+			absoluteServerTimes={absoluteServerTimes}
 			image={undefined}
 			imageLoading={'lazy'}
 			avatarUrl={undefined}
@@ -753,12 +790,14 @@ export const CardDefaultMedia = ({
 	showAge,
 	containerPalette,
 	imageLoading,
+	absoluteServerTimes,
 }: TrailProps) => {
 	return (
 		<FrontCard
 			trail={trail}
 			containerPalette={containerPalette}
 			showAge={showAge}
+			absoluteServerTimes={absoluteServerTimes}
 			imageSize="small"
 			imagePosition="left"
 			imagePositionOnMobile="none"
@@ -787,12 +826,14 @@ export const CardDefaultMediaMobile = ({
 	showAge,
 	containerPalette,
 	imageLoading,
+	absoluteServerTimes,
 }: TrailProps) => {
 	return (
 		<FrontCard
 			trail={trail}
 			containerPalette={containerPalette}
 			showAge={showAge}
+			absoluteServerTimes={absoluteServerTimes}
 			imageSize="small"
 			imagePosition="left"
 			imagePositionOnMobile="left"

--- a/dotcom-rendering/src/lib/dynamicSlices.tsx
+++ b/dotcom-rendering/src/lib/dynamicSlices.tsx
@@ -36,12 +36,14 @@ export const Card50_Card50 = ({
 	cards,
 	containerPalette,
 	showAge,
+	absoluteServerTimes,
 	imageLoading,
 }: {
 	cards: DCRFrontCard[];
 	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
+	absoluteServerTimes: boolean;
 }) => {
 	const cards50 = cards.slice(0, 2);
 
@@ -59,6 +61,7 @@ export const Card50_Card50 = ({
 						trail={trail}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						absoluteServerTimes={absoluteServerTimes}
 						imageLoading={imageLoading}
 					/>
 				</LI>
@@ -76,12 +79,14 @@ export const Card75_Card25 = ({
 	cards,
 	containerPalette,
 	showAge,
+	absoluteServerTimes,
 	imageLoading,
 }: {
 	cards: DCRFrontCard[];
 	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
+	absoluteServerTimes: boolean;
 }) => {
 	const card75 = cards.slice(0, 1);
 	const card25 = cards.slice(1, 2);
@@ -93,6 +98,7 @@ export const Card75_Card25 = ({
 					<Card75Media50Right
 						trail={trail}
 						showAge={showAge}
+						absoluteServerTimes={absoluteServerTimes}
 						containerPalette={containerPalette}
 						imageLoading={imageLoading}
 					/>
@@ -109,6 +115,7 @@ export const Card75_Card25 = ({
 					<Card25Media25
 						trail={trail}
 						showAge={showAge}
+						absoluteServerTimes={absoluteServerTimes}
 						containerPalette={containerPalette}
 						imageLoading={imageLoading}
 					/>
@@ -127,12 +134,14 @@ export const Card25_Card75 = ({
 	cards,
 	containerPalette,
 	showAge,
+	absoluteServerTimes,
 	imageLoading,
 }: {
 	cards: DCRFrontCard[];
 	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
+	absoluteServerTimes: boolean;
 }) => {
 	const card25 = cards.slice(0, 1);
 	const card75 = cards.slice(1, 2);
@@ -144,6 +153,7 @@ export const Card25_Card75 = ({
 					<Card25Media25
 						trail={trail}
 						showAge={showAge}
+						absoluteServerTimes={absoluteServerTimes}
 						containerPalette={containerPalette}
 						imageLoading={imageLoading}
 					/>
@@ -160,6 +170,7 @@ export const Card25_Card75 = ({
 					<Card75Media50Left
 						trail={trail}
 						showAge={showAge}
+						absoluteServerTimes={absoluteServerTimes}
 						containerPalette={containerPalette}
 						imageLoading={imageLoading}
 					/>
@@ -178,12 +189,14 @@ export const Card50_Card25_Card25 = ({
 	cards,
 	containerPalette,
 	showAge,
+	absoluteServerTimes,
 	imageLoading,
 }: {
 	cards: DCRFrontCard[];
 	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
+	absoluteServerTimes: boolean;
 }) => {
 	const card50 = cards.slice(0, 1);
 	const cards25 = cards.slice(1, 3);
@@ -196,6 +209,7 @@ export const Card50_Card25_Card25 = ({
 						trail={trail}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						absoluteServerTimes={absoluteServerTimes}
 						imageLoading={imageLoading}
 					/>
 				</LI>
@@ -213,6 +227,7 @@ export const Card50_Card25_Card25 = ({
 						trail={trail}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						absoluteServerTimes={absoluteServerTimes}
 						imageLoading={imageLoading}
 					/>
 				</LI>
@@ -232,10 +247,12 @@ export const Card100PictureTop = ({
 	showAge,
 	containerPalette,
 	imageLoading,
+	absoluteServerTimes,
 }: {
 	cards: DCRFrontCard[];
 	imageLoading: Loading;
 	showAge?: boolean;
+	absoluteServerTimes: boolean;
 	containerPalette?: DCRContainerPalette;
 }) => {
 	const card100 = cards.slice(0, 1);
@@ -247,6 +264,7 @@ export const Card100PictureTop = ({
 					<Card100Media100
 						trail={card}
 						showAge={showAge}
+						absoluteServerTimes={absoluteServerTimes}
 						containerPalette={containerPalette}
 						imageLoading={imageLoading}
 					/>
@@ -259,12 +277,14 @@ export const Card100PictureTop = ({
 export const Card25_Card25_Card25_Card25 = ({
 	cards,
 	showAge,
+	absoluteServerTimes,
 	containerPalette,
 	imageLoading,
 }: {
 	cards: DCRFrontCard[];
 	imageLoading: Loading;
 	showAge?: boolean;
+	absoluteServerTimes: boolean;
 	containerPalette?: DCRContainerPalette;
 }) => {
 	if (cards.length < 4) return null;
@@ -286,6 +306,7 @@ export const Card25_Card25_Card25_Card25 = ({
 							trail={card}
 							containerPalette={containerPalette}
 							showAge={showAge}
+							absoluteServerTimes={absoluteServerTimes}
 							imageLoading={imageLoading}
 						/>
 					</LI>
@@ -298,12 +319,14 @@ export const Card25_Card25_Card25_Card25 = ({
 export const ColumnOfCards50_Card25_Card25 = ({
 	cards,
 	showAge,
+	absoluteServerTimes,
 	containerPalette,
 	imageLoading,
 }: {
 	cards: DCRFrontCard[];
 	imageLoading: Loading;
 	showAge?: boolean;
+	absoluteServerTimes: boolean;
 	containerPalette?: DCRContainerPalette;
 }) => {
 	const bigs = cards.slice(0, 2).reverse();
@@ -323,6 +346,7 @@ export const ColumnOfCards50_Card25_Card25 = ({
 						<Card25Media25Tall
 							trail={big}
 							showAge={showAge}
+							absoluteServerTimes={absoluteServerTimes}
 							containerPalette={containerPalette}
 							imageLoading={imageLoading}
 						/>
@@ -342,6 +366,7 @@ export const ColumnOfCards50_Card25_Card25 = ({
 									trail={card}
 									containerPalette={containerPalette}
 									showAge={showAge}
+									absoluteServerTimes={absoluteServerTimes}
 									imageLoading={imageLoading}
 								/>
 							</LI>
@@ -362,12 +387,14 @@ export const ColumnOfCards50_Card25_Card25 = ({
 export const Card100PictureRight = ({
 	cards,
 	showAge,
+	absoluteServerTimes,
 	containerPalette,
 	imageLoading,
 }: {
 	cards: DCRFrontCard[];
 	imageLoading: Loading;
 	showAge?: boolean;
+	absoluteServerTimes: boolean;
 	containerPalette?: DCRContainerPalette;
 }) => {
 	const card100 = cards.slice(0, 1);
@@ -380,6 +407,7 @@ export const Card100PictureRight = ({
 						trail={card}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						absoluteServerTimes={absoluteServerTimes}
 						imageLoading={imageLoading}
 					/>
 				</LI>


### PR DESCRIPTION
## What does this change?

Enable the use of absolute times when `DateTime` is rendered on the server.

See the [first commit](https://github.com/guardian/dotcom-rendering/commit/92272e814dc6a8e7427ddf3bd3cb262958553772) for the meanigful change, the second one is just drilling the props…

## Why?

This could improve our ability to serve 304 Not Modified content.

Part of:
- #10154 

## Screenshots

| Before      | After (no JS) |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/76776/ecdb1c07-ace7-47c0-b846-27d75c2ed43c
[after]: https://github.com/guardian/dotcom-rendering/assets/76776/51480346-2250-4de7-8702-f4374544deff

Once JS kicks in, the times are hydrated and become relative again!