### PR TITLE
Update wording of affiliates disclaimer

### DIFF
--- a/dotcom-rendering/src/components/AffiliateDisclaimer.tsx
+++ b/dotcom-rendering/src/components/AffiliateDisclaimer.tsx
@@ -44,10 +44,8 @@ const ampStyles = css`
 
 const DisclaimerText = () => (
 	<p>
-		The Guardian’s product and service reviews are independent and are in no
-		way influenced by any advertiser or commercial initiative. We will earn
-		a commission from the retailer if you buy something through an affiliate
-		link.&nbsp;
+		The Guardian’s journalism is independent. We will earn a commission if
+		you buy something through an affiliate link.&nbsp;
 		<a href="https://www.theguardian.com/info/2017/nov/01/reader-information-on-affiliate-links">
 			Learn more.
 		</a>


### PR DESCRIPTION
## What does this change?
Updates the wording of the affiliates disclaimer to a new version.

## Why?
The new version is a bit shorter and should disrupt the page a bit less.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| <img width="1329" alt="Screenshot 2024-05-21 at 10 28 51" src="https://github.com/guardian/dotcom-rendering/assets/108270776/5075d779-f43f-4f41-a973-95b6a4b2dc21"> | <img width="1329" alt="Screenshot 2024-05-21 at 10 29 03" src="https://github.com/guardian/dotcom-rendering/assets/108270776/d555f749-8218-4be3-b64e-43157fd64e98"> |
| <img width="302" alt="Screenshot 2024-05-21 at 10 29 28" src="https://github.com/guardian/dotcom-rendering/assets/108270776/7ba5add3-ff5d-439d-b365-6e928b7c7f70"> | <img width="302" alt="Screenshot 2024-05-21 at 10 29 52" src="https://github.com/guardian/dotcom-rendering/assets/108270776/1a59e969-6021-418c-a0ff-8be067a58efe"> |


