### PR TITLE
`Accordion` Stories Use Colour Scheme And Modes

### DIFF
--- a/dotcom-rendering/.storybook/modes.ts
+++ b/dotcom-rendering/.storybook/modes.ts
@@ -1,3 +1,5 @@
+import { breakpoints } from '@guardian/source/foundations';
+
 export const allModes = {
 	light: {
 		globalColourScheme: 'light',
@@ -10,5 +12,13 @@ export const allModes = {
 	},
 	splitVertical: {
 		globalColourScheme: 'vertical',
+	},
+	'light mobileMedium': {
+		globalColourScheme: 'light',
+		viewport: breakpoints.mobileMedium,
+	},
+	'horizontal tablet': {
+		globalColourScheme: 'horizontal',
+		viewport: breakpoints.tablet,
 	},
 };

--- a/dotcom-rendering/src/components/Accordion.stories.tsx
+++ b/dotcom-rendering/src/components/Accordion.stories.tsx
@@ -50,13 +50,13 @@ const accordionContent = (
 			At wider breakpoints the accordion UI disappears and just leaves the
 			content. To view the accordion UI, switch to a narrower breakpoint.
 		</p>
-		<p css={[textStyle]}>
+		<p css={textStyle}>
 			Vaccine passports enjoy substantial support across Europe, a YouGov
 			survey suggests, as a fourth wave of infections prompts a growing
 			number of countries to impose tougher restrictions on people who
 			have not been fully vaccinated.
 		</p>
-		<p css={[textStyle]}>
+		<p css={textStyle}>
 			The annual YouGov-Cambridge Globalism Project suggests majorities in
 			all 10 European countries surveyed back compulsory vaccine passes
 			for large events, while in most, more people favour than oppose

--- a/dotcom-rendering/src/components/Accordion.stories.tsx
+++ b/dotcom-rendering/src/components/Accordion.stories.tsx
@@ -1,14 +1,8 @@
 import { css } from '@emotion/react';
 import type { SerializedStyles } from '@emotion/react';
-import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
-import {
-	article17,
-	breakpoints,
-	from,
-	space,
-} from '@guardian/source/foundations';
+import { article17, from, space } from '@guardian/source/foundations';
 import type { Meta, StoryObj } from '@storybook/react';
-import { splitTheme } from '../../.storybook/decorators/splitThemeDecorator';
+import { allModes } from '../../.storybook/modes';
 import { Accordion as AccordionComponent } from './Accordion';
 
 const meta = {
@@ -19,7 +13,13 @@ const meta = {
 			values: [{ name: 'grey', value: 'lightgrey' }],
 		},
 		chromatic: {
-			viewports: [breakpoints.mobile, breakpoints.tablet],
+			modes: {
+				'light mobileMedium': allModes['light mobileMedium'],
+				'horizontal tablet': allModes['horizontal tablet'],
+			},
+		},
+		viewport: {
+			defaultViewport: 'mobileLandscape',
 		},
 	},
 } satisfies Meta<typeof AccordionComponent>;
@@ -33,43 +33,30 @@ const textStyle = css`
 	margin-bottom: ${space[3]}px;
 `;
 
-const hideAboveTablet: SerializedStyles = css`
-	${from.desktop} {
-		display: none;
-	}
-`;
-
-const adviceColourAboveTablet: SerializedStyles = css`
+const adviceAboveTablet: SerializedStyles = css`
 	display: none;
 	${from.desktop} {
 		display: block;
 		color: red;
 		font-size: 18px;
-		width: 300px;
 		margin: 0 auto;
-		margin-top: ${space[12]}px;
+		margin-bottom: ${space[3]}px;
 	}
 `;
 
-const articleFormat: ArticleFormat = {
-	design: ArticleDesign.Standard,
-	display: ArticleDisplay.Standard,
-	theme: Pillar.News,
-};
-
 const accordionContent = (
 	<>
-		<p css={[textStyle, adviceColourAboveTablet]}>
-			There's a trick to viewing this - you need to switch the storybook
-			viewport to mobile, phablet or tablet in order to see the accordion.
+		<p css={[textStyle, adviceAboveTablet]}>
+			At wider breakpoints the accordion UI disappears and just leaves the
+			content. To view the accordion UI, switch to a narrower breakpoint.
 		</p>
-		<p css={[textStyle, hideAboveTablet]}>
+		<p css={[textStyle]}>
 			Vaccine passports enjoy substantial support across Europe, a YouGov
 			survey suggests, as a fourth wave of infections prompts a growing
 			number of countries to impose tougher restrictions on people who
 			have not been fully vaccinated.
 		</p>
-		<p css={[textStyle, hideAboveTablet]}>
+		<p css={[textStyle]}>
 			The annual YouGov-Cambridge Globalism Project suggests majorities in
 			all 10 European countries surveyed back compulsory vaccine passes
 			for large events, while in most, more people favour than oppose
@@ -84,5 +71,4 @@ export const Accordion = {
 		context: 'keyEvents',
 		children: accordionContent,
 	},
-	decorators: [splitTheme([articleFormat])],
 } satisfies Story;


### PR DESCRIPTION
Updated the accordion stories to use the new colour scheme toolbar item instead of the `splitTheme` decorator. Alongside this, switched to using Chromatic's modes, which are intended to replace the `viewports` feature, and also allow combinations of colour schemes and viewports to be snapshotted.

In addition, made some small changes to the way the story is presented. It now uses a narrow viewport by default, where the accordion UI will be visible. It also shows the content on wider breakpoints too, as that is part of the component's intended behaviour.
