### PR TITLE
Set live updated logo styling for Advertising Partner

### DIFF
--- a/dotcom-rendering/src/components/ArticleMeta.test.tsx
+++ b/dotcom-rendering/src/components/ArticleMeta.test.tsx
@@ -19,6 +19,7 @@ describe('ArticleMeta', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
+					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 				}}
 			>
@@ -65,6 +66,7 @@ describe('ArticleMeta', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
+					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 				}}
 			>

--- a/dotcom-rendering/src/components/ArticleMeta.test.tsx
+++ b/dotcom-rendering/src/components/ArticleMeta.test.tsx
@@ -19,7 +19,6 @@ describe('ArticleMeta', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					inAdvertisingPartnerABTest: false,
 					assetOrigin: '/',
 				}}
 			>
@@ -66,7 +65,6 @@ describe('ArticleMeta', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					inAdvertisingPartnerABTest: false,
 					assetOrigin: '/',
 				}}
 			>

--- a/dotcom-rendering/src/components/Badge.tsx
+++ b/dotcom-rendering/src/components/Badge.tsx
@@ -47,7 +47,6 @@ type Props = {
 	ophanComponentName?: string;
 	isInLabsSection?: boolean;
 	isAdvertisingPartner?: boolean;
-	inAdvertisingPartnerABTest?: boolean;
 };
 
 export const Badge = ({
@@ -57,7 +56,6 @@ export const Badge = ({
 	ophanComponentName,
 	isInLabsSection = false,
 	isAdvertisingPartner = false,
-	inAdvertisingPartnerABTest = false,
 }: Props) => {
 	return (
 		<a
@@ -72,9 +70,7 @@ export const Badge = ({
 					isInLabsSection
 						? labsSectionBadgeSizingStyles
 						: frontsSectionBadgeSizingStyles,
-					isAdvertisingPartner &&
-						inAdvertisingPartnerABTest &&
-						imageAdvertisingPartnerStyles,
+					isAdvertisingPartner && imageAdvertisingPartnerStyles,
 				]}
 				src={imageSrc}
 				alt={isInLabsSection ? 'Labs sponsor logo' : ''}

--- a/dotcom-rendering/src/components/Badge.tsx
+++ b/dotcom-rendering/src/components/Badge.tsx
@@ -47,6 +47,7 @@ type Props = {
 	ophanComponentName?: string;
 	isInLabsSection?: boolean;
 	isAdvertisingPartner?: boolean;
+	updateLogoAdPartnerSwitch?: boolean;
 };
 
 export const Badge = ({
@@ -56,6 +57,7 @@ export const Badge = ({
 	ophanComponentName,
 	isInLabsSection = false,
 	isAdvertisingPartner = false,
+	updateLogoAdPartnerSwitch = false,
 }: Props) => {
 	return (
 		<a
@@ -70,7 +72,9 @@ export const Badge = ({
 					isInLabsSection
 						? labsSectionBadgeSizingStyles
 						: frontsSectionBadgeSizingStyles,
-					isAdvertisingPartner && imageAdvertisingPartnerStyles,
+					isAdvertisingPartner &&
+						updateLogoAdPartnerSwitch &&
+						imageAdvertisingPartnerStyles,
 				]}
 				src={imageSrc}
 				alt={isInLabsSection ? 'Labs sponsor logo' : ''}

--- a/dotcom-rendering/src/components/Branding.importable.tsx
+++ b/dotcom-rendering/src/components/Branding.importable.tsx
@@ -209,7 +209,7 @@ export const Branding = ({ branding, format }: Props) => {
 		locationPrefix: 'article-meta',
 	});
 
-	const { darkModeAvailable, inAdvertisingPartnerABTest } = useConfig();
+	const { darkModeAvailable } = useConfig();
 
 	const isAdvertisingPartnerOrExclusive =
 		branding.logo.label.toLowerCase() === 'advertising partner' ||
@@ -223,18 +223,14 @@ export const Branding = ({ branding, format }: Props) => {
 			css={[
 				brandingStyle,
 				isAdvertisingPartnerOrExclusive &&
-					inAdvertisingPartnerABTest &&
 					brandingAdvertisingPartnerStyle,
-				isAdvertisingPartnerAndInteractive &&
-					inAdvertisingPartnerABTest &&
-					brandingInteractiveStyle,
+				isAdvertisingPartnerAndInteractive && brandingInteractiveStyle,
 			]}
 		>
 			<div
 				css={[
 					labelStyle,
 					isAdvertisingPartnerOrExclusive &&
-						inAdvertisingPartnerABTest &&
 						labelAdvertisingPartnerStyle,
 					isLiveBlog && liveBlogLabelStyle,
 				]}
@@ -246,7 +242,6 @@ export const Branding = ({ branding, format }: Props) => {
 					brandingLogoStyle,
 					isAdvertisingPartnerOrExclusive &&
 						!isInteractive &&
-						inAdvertisingPartnerABTest &&
 						brandingLogoAdvertisingPartnerStyle,
 				]}
 			>
@@ -269,7 +264,6 @@ export const Branding = ({ branding, format }: Props) => {
 				css={[
 					aboutLinkStyle,
 					isAdvertisingPartnerOrExclusive &&
-						inAdvertisingPartnerABTest &&
 						aboutLinkAdvertisingPartnerStyle,
 					isLiveBlog && liveBlogAboutLinkStyle,
 				]}

--- a/dotcom-rendering/src/components/Branding.importable.tsx
+++ b/dotcom-rendering/src/components/Branding.importable.tsx
@@ -209,7 +209,7 @@ export const Branding = ({ branding, format }: Props) => {
 		locationPrefix: 'article-meta',
 	});
 
-	const { darkModeAvailable } = useConfig();
+	const { darkModeAvailable, updateLogoAdPartnerSwitch } = useConfig();
 
 	const isAdvertisingPartnerOrExclusive =
 		branding.logo.label.toLowerCase() === 'advertising partner' ||
@@ -223,14 +223,18 @@ export const Branding = ({ branding, format }: Props) => {
 			css={[
 				brandingStyle,
 				isAdvertisingPartnerOrExclusive &&
+					updateLogoAdPartnerSwitch &&
 					brandingAdvertisingPartnerStyle,
-				isAdvertisingPartnerAndInteractive && brandingInteractiveStyle,
+				isAdvertisingPartnerAndInteractive &&
+					updateLogoAdPartnerSwitch &&
+					brandingInteractiveStyle,
 			]}
 		>
 			<div
 				css={[
 					labelStyle,
 					isAdvertisingPartnerOrExclusive &&
+						updateLogoAdPartnerSwitch &&
 						labelAdvertisingPartnerStyle,
 					isLiveBlog && liveBlogLabelStyle,
 				]}
@@ -241,6 +245,7 @@ export const Branding = ({ branding, format }: Props) => {
 				css={[
 					brandingLogoStyle,
 					isAdvertisingPartnerOrExclusive &&
+						updateLogoAdPartnerSwitch &&
 						!isInteractive &&
 						brandingLogoAdvertisingPartnerStyle,
 				]}
@@ -264,6 +269,7 @@ export const Branding = ({ branding, format }: Props) => {
 				css={[
 					aboutLinkStyle,
 					isAdvertisingPartnerOrExclusive &&
+						updateLogoAdPartnerSwitch &&
 						aboutLinkAdvertisingPartnerStyle,
 					isLiveBlog && liveBlogAboutLinkStyle,
 				]}

--- a/dotcom-rendering/src/components/BylineLink.test.tsx
+++ b/dotcom-rendering/src/components/BylineLink.test.tsx
@@ -108,6 +108,7 @@ describe('BylineLink', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
+					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 				}}
 			>
@@ -150,6 +151,7 @@ describe('BylineLink', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
+					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 				}}
 			>
@@ -194,6 +196,7 @@ describe('BylineLink', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
+					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 				}}
 			>
@@ -234,6 +237,7 @@ describe('BylineLink', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
+					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 				}}
 			>
@@ -265,6 +269,7 @@ describe('BylineLink', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
+					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 				}}
 			>

--- a/dotcom-rendering/src/components/BylineLink.test.tsx
+++ b/dotcom-rendering/src/components/BylineLink.test.tsx
@@ -108,7 +108,6 @@ describe('BylineLink', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					inAdvertisingPartnerABTest: false,
 					assetOrigin: '/',
 				}}
 			>
@@ -151,7 +150,6 @@ describe('BylineLink', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					inAdvertisingPartnerABTest: false,
 					assetOrigin: '/',
 				}}
 			>
@@ -196,7 +194,6 @@ describe('BylineLink', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					inAdvertisingPartnerABTest: false,
 					assetOrigin: '/',
 				}}
 			>
@@ -237,7 +234,6 @@ describe('BylineLink', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					inAdvertisingPartnerABTest: false,
 					assetOrigin: '/',
 				}}
 			>
@@ -269,7 +265,6 @@ describe('BylineLink', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					inAdvertisingPartnerABTest: false,
 					assetOrigin: '/',
 				}}
 			>

--- a/dotcom-rendering/src/components/ConfigContext.test.tsx
+++ b/dotcom-rendering/src/components/ConfigContext.test.tsx
@@ -24,16 +24,19 @@ describe('ConfigContext', () => {
 			{
 				renderingTarget: 'Web',
 				darkModeAvailable: false,
+				updateLogoAdPartnerSwitch: false,
 				assetOrigin: '/',
 			},
 			{
 				renderingTarget: 'Apps',
 				darkModeAvailable: true,
+				updateLogoAdPartnerSwitch: false,
 				assetOrigin: '/',
 			},
 			{
 				renderingTarget: 'Apps',
 				darkModeAvailable: false,
+				updateLogoAdPartnerSwitch: false,
 				assetOrigin: '/',
 			},
 		] as const satisfies ReadonlyArray<Config>)(

--- a/dotcom-rendering/src/components/ConfigContext.test.tsx
+++ b/dotcom-rendering/src/components/ConfigContext.test.tsx
@@ -24,19 +24,16 @@ describe('ConfigContext', () => {
 			{
 				renderingTarget: 'Web',
 				darkModeAvailable: false,
-				inAdvertisingPartnerABTest: false,
 				assetOrigin: '/',
 			},
 			{
 				renderingTarget: 'Apps',
 				darkModeAvailable: true,
-				inAdvertisingPartnerABTest: false,
 				assetOrigin: '/',
 			},
 			{
 				renderingTarget: 'Apps',
 				darkModeAvailable: false,
-				inAdvertisingPartnerABTest: false,
 				assetOrigin: '/',
 			},
 		] as const satisfies ReadonlyArray<Config>)(

--- a/dotcom-rendering/src/components/Contributor.test.tsx
+++ b/dotcom-rendering/src/components/Contributor.test.tsx
@@ -19,7 +19,6 @@ describe('Contributor', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					inAdvertisingPartnerABTest: false,
 					assetOrigin: '/',
 				}}
 			>
@@ -54,7 +53,6 @@ describe('Contributor', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					inAdvertisingPartnerABTest: false,
 					assetOrigin: '/',
 				}}
 			>

--- a/dotcom-rendering/src/components/Contributor.test.tsx
+++ b/dotcom-rendering/src/components/Contributor.test.tsx
@@ -19,6 +19,7 @@ describe('Contributor', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
+					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 				}}
 			>
@@ -53,6 +54,7 @@ describe('Contributor', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
+					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 				}}
 			>

--- a/dotcom-rendering/src/components/Discussion/Discussion.test.tsx
+++ b/dotcom-rendering/src/components/Discussion/Discussion.test.tsx
@@ -18,7 +18,6 @@ describe('App', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					inAdvertisingPartnerABTest: false,
 					assetOrigin: '/',
 				}}
 			>

--- a/dotcom-rendering/src/components/Discussion/Discussion.test.tsx
+++ b/dotcom-rendering/src/components/Discussion/Discussion.test.tsx
@@ -18,6 +18,7 @@ describe('App', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
+					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 				}}
 			>

--- a/dotcom-rendering/src/components/Dropdown.test.tsx
+++ b/dotcom-rendering/src/components/Dropdown.test.tsx
@@ -45,7 +45,6 @@ describe('Dropdown', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					inAdvertisingPartnerABTest: false,
 					assetOrigin: '/',
 				}}
 			>
@@ -67,7 +66,6 @@ describe('Dropdown', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					inAdvertisingPartnerABTest: false,
 					assetOrigin: '/',
 				}}
 			>
@@ -92,7 +90,6 @@ describe('Dropdown', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					inAdvertisingPartnerABTest: false,
 					assetOrigin: '/',
 				}}
 			>
@@ -116,7 +113,6 @@ describe('Dropdown', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					inAdvertisingPartnerABTest: false,
 					assetOrigin: '/',
 				}}
 			>
@@ -142,7 +138,6 @@ describe('Dropdown', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					inAdvertisingPartnerABTest: false,
 					assetOrigin: '/',
 				}}
 			>
@@ -169,7 +164,6 @@ describe('Dropdown', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					inAdvertisingPartnerABTest: false,
 					assetOrigin: '/',
 				}}
 			>

--- a/dotcom-rendering/src/components/Dropdown.test.tsx
+++ b/dotcom-rendering/src/components/Dropdown.test.tsx
@@ -45,6 +45,7 @@ describe('Dropdown', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
+					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 				}}
 			>
@@ -66,6 +67,7 @@ describe('Dropdown', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
+					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 				}}
 			>
@@ -90,6 +92,7 @@ describe('Dropdown', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
+					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 				}}
 			>
@@ -113,6 +116,7 @@ describe('Dropdown', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
+					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 				}}
 			>
@@ -138,6 +142,7 @@ describe('Dropdown', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
+					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 				}}
 			>
@@ -164,6 +169,7 @@ describe('Dropdown', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
+					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 				}}
 			>

--- a/dotcom-rendering/src/components/FrontSection.tsx
+++ b/dotcom-rendering/src/components/FrontSection.tsx
@@ -87,6 +87,7 @@ type Props = {
 	discussionApiUrl: string;
 	collectionBranding?: CollectionBranding;
 	isTagPage?: boolean;
+	updateLogoAdPartnerSwitch?: boolean;
 };
 
 const width = (columns: number, columnWidth: number, columnGap: number) =>
@@ -462,6 +463,7 @@ export const FrontSection = ({
 	discussionApiUrl,
 	collectionBranding,
 	isTagPage = false,
+	updateLogoAdPartnerSwitch = false,
 }: Props) => {
 	const overrides =
 		containerPalette && decideContainerOverrides(containerPalette);
@@ -539,6 +541,7 @@ export const FrontSection = ({
 						/>
 					}
 					collectionBranding={collectionBranding}
+					updateLogoAdPartnerSwitch={updateLogoAdPartnerSwitch}
 				/>
 
 				{leftContent}

--- a/dotcom-rendering/src/components/FrontSection.tsx
+++ b/dotcom-rendering/src/components/FrontSection.tsx
@@ -87,7 +87,6 @@ type Props = {
 	discussionApiUrl: string;
 	collectionBranding?: CollectionBranding;
 	isTagPage?: boolean;
-	inAdvertisingPartnerABTest?: boolean;
 };
 
 const width = (columns: number, columnWidth: number, columnGap: number) =>
@@ -463,7 +462,6 @@ export const FrontSection = ({
 	discussionApiUrl,
 	collectionBranding,
 	isTagPage = false,
-	inAdvertisingPartnerABTest = false,
 }: Props) => {
 	const overrides =
 		containerPalette && decideContainerOverrides(containerPalette);
@@ -541,7 +539,6 @@ export const FrontSection = ({
 						/>
 					}
 					collectionBranding={collectionBranding}
-					inAdvertisingPartnerABTest={inAdvertisingPartnerABTest}
 				/>
 
 				{leftContent}

--- a/dotcom-rendering/src/components/FrontSectionTitle.tsx
+++ b/dotcom-rendering/src/components/FrontSectionTitle.tsx
@@ -14,7 +14,6 @@ import { Badge } from './Badge';
 type Props = {
 	title: React.ReactNode;
 	collectionBranding: CollectionBranding | undefined;
-	inAdvertisingPartnerABTest: boolean;
 };
 
 const titleStyle = css`
@@ -78,11 +77,7 @@ const aboutThisLinkAdvertisingPartnerStyles = css`
 	color: ${sourcePalette.news[400]};
 `;
 
-export const FrontSectionTitle = ({
-	title,
-	collectionBranding,
-	inAdvertisingPartnerABTest,
-}: Props) => {
+export const FrontSectionTitle = ({ title, collectionBranding }: Props) => {
 	switch (collectionBranding?.kind) {
 		case 'foundation': {
 			const {
@@ -167,14 +162,12 @@ export const FrontSectionTitle = ({
 				return (
 					<div css={titleStyle}>
 						{title}
-						{isAdvertisingPartnerOrExclusive &&
-						inAdvertisingPartnerABTest ? (
+						{isAdvertisingPartnerOrExclusive ? (
 							<hr css={advertisingPartnerDottedBorder} />
 						) : null}
 						<div
 							css={
 								isAdvertisingPartnerOrExclusive &&
-								inAdvertisingPartnerABTest &&
 								brandingAdvertisingPartnerStyle
 							}
 						>
@@ -182,7 +175,6 @@ export const FrontSectionTitle = ({
 								css={[
 									labelStyles,
 									isAdvertisingPartnerOrExclusive &&
-										inAdvertisingPartnerABTest &&
 										labelAdvertisingPartnerStyles,
 								]}
 							>
@@ -194,16 +186,12 @@ export const FrontSectionTitle = ({
 								isAdvertisingPartner={
 									isAdvertisingPartnerOrExclusive
 								}
-								inAdvertisingPartnerABTest={
-									inAdvertisingPartnerABTest
-								}
 							/>
 							<a
 								href={aboutThisLink}
 								css={[
 									aboutThisLinkStyles,
 									isAdvertisingPartnerOrExclusive &&
-										inAdvertisingPartnerABTest &&
 										aboutThisLinkAdvertisingPartnerStyles,
 								]}
 							>

--- a/dotcom-rendering/src/components/FrontSectionTitle.tsx
+++ b/dotcom-rendering/src/components/FrontSectionTitle.tsx
@@ -14,6 +14,7 @@ import { Badge } from './Badge';
 type Props = {
 	title: React.ReactNode;
 	collectionBranding: CollectionBranding | undefined;
+	updateLogoAdPartnerSwitch: boolean;
 };
 
 const titleStyle = css`
@@ -77,7 +78,11 @@ const aboutThisLinkAdvertisingPartnerStyles = css`
 	color: ${sourcePalette.news[400]};
 `;
 
-export const FrontSectionTitle = ({ title, collectionBranding }: Props) => {
+export const FrontSectionTitle = ({
+	title,
+	collectionBranding,
+	updateLogoAdPartnerSwitch,
+}: Props) => {
 	switch (collectionBranding?.kind) {
 		case 'foundation': {
 			const {
@@ -162,12 +167,14 @@ export const FrontSectionTitle = ({ title, collectionBranding }: Props) => {
 				return (
 					<div css={titleStyle}>
 						{title}
-						{isAdvertisingPartnerOrExclusive ? (
+						{isAdvertisingPartnerOrExclusive &&
+						updateLogoAdPartnerSwitch ? (
 							<hr css={advertisingPartnerDottedBorder} />
 						) : null}
 						<div
 							css={
 								isAdvertisingPartnerOrExclusive &&
+								updateLogoAdPartnerSwitch &&
 								brandingAdvertisingPartnerStyle
 							}
 						>
@@ -175,6 +182,7 @@ export const FrontSectionTitle = ({ title, collectionBranding }: Props) => {
 								css={[
 									labelStyles,
 									isAdvertisingPartnerOrExclusive &&
+										updateLogoAdPartnerSwitch &&
 										labelAdvertisingPartnerStyles,
 								]}
 							>
@@ -186,12 +194,16 @@ export const FrontSectionTitle = ({ title, collectionBranding }: Props) => {
 								isAdvertisingPartner={
 									isAdvertisingPartnerOrExclusive
 								}
+								updateLogoAdPartnerSwitch={
+									updateLogoAdPartnerSwitch
+								}
 							/>
 							<a
 								href={aboutThisLink}
 								css={[
 									aboutThisLinkStyles,
 									isAdvertisingPartnerOrExclusive &&
+										updateLogoAdPartnerSwitch &&
 										aboutThisLinkAdvertisingPartnerStyles,
 								]}
 							>

--- a/dotcom-rendering/src/components/GuideAtom/GuideAtom.test.tsx
+++ b/dotcom-rendering/src/components/GuideAtom/GuideAtom.test.tsx
@@ -11,7 +11,6 @@ describe('GuideAtom', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					inAdvertisingPartnerABTest: false,
 					assetOrigin: '/',
 				}}
 			>
@@ -37,7 +36,6 @@ describe('GuideAtom', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					inAdvertisingPartnerABTest: false,
 					assetOrigin: '/',
 				}}
 			>
@@ -64,7 +62,6 @@ describe('GuideAtom', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					inAdvertisingPartnerABTest: false,
 					assetOrigin: '/',
 				}}
 			>

--- a/dotcom-rendering/src/components/GuideAtom/GuideAtom.test.tsx
+++ b/dotcom-rendering/src/components/GuideAtom/GuideAtom.test.tsx
@@ -11,6 +11,7 @@ describe('GuideAtom', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
+					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 				}}
 			>
@@ -36,6 +37,7 @@ describe('GuideAtom', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
+					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 				}}
 			>
@@ -62,6 +64,7 @@ describe('GuideAtom', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
+					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 				}}
 			>

--- a/dotcom-rendering/src/components/Island.test.tsx
+++ b/dotcom-rendering/src/components/Island.test.tsx
@@ -96,6 +96,7 @@ describe('Island: server-side rendering', () => {
 					value={{
 						renderingTarget: 'Web',
 						darkModeAvailable: false,
+						updateLogoAdPartnerSwitch: false,
 						assetOrigin: '/',
 					}}
 				>
@@ -126,6 +127,7 @@ describe('Island: server-side rendering', () => {
 					value={{
 						renderingTarget: 'Web',
 						darkModeAvailable: false,
+						updateLogoAdPartnerSwitch: false,
 						assetOrigin: '/',
 					}}
 				>
@@ -146,6 +148,7 @@ describe('Island: server-side rendering', () => {
 					value={{
 						renderingTarget: 'Web',
 						darkModeAvailable: false,
+						updateLogoAdPartnerSwitch: false,
 						assetOrigin: '/',
 					}}
 				>
@@ -176,6 +179,7 @@ describe('Island: server-side rendering', () => {
 					value={{
 						renderingTarget: 'Web',
 						darkModeAvailable: false,
+						updateLogoAdPartnerSwitch: false,
 						assetOrigin: '/',
 					}}
 				>
@@ -204,6 +208,7 @@ describe('Island: server-side rendering', () => {
 					value={{
 						renderingTarget: 'Web',
 						darkModeAvailable: false,
+						updateLogoAdPartnerSwitch: false,
 						assetOrigin: '/',
 					}}
 				>
@@ -298,6 +303,7 @@ describe('Island: server-side rendering', () => {
 					value={{
 						renderingTarget: 'Web',
 						darkModeAvailable: false,
+						updateLogoAdPartnerSwitch: false,
 						assetOrigin: '/',
 					}}
 				>
@@ -342,6 +348,7 @@ describe('Island: server-side rendering', () => {
 					value={{
 						renderingTarget: 'Web',
 						darkModeAvailable: false,
+						updateLogoAdPartnerSwitch: false,
 						assetOrigin: '/',
 					}}
 				>
@@ -379,6 +386,7 @@ describe('Island: server-side rendering', () => {
 					value={{
 						renderingTarget: 'Web',
 						darkModeAvailable: false,
+						updateLogoAdPartnerSwitch: false,
 						assetOrigin: '/',
 					}}
 				>
@@ -417,6 +425,7 @@ describe('Island: server-side rendering', () => {
 					value={{
 						renderingTarget: 'Web',
 						darkModeAvailable: false,
+						updateLogoAdPartnerSwitch: false,
 						assetOrigin: '/',
 					}}
 				>
@@ -440,6 +449,7 @@ describe('Island: server-side rendering', () => {
 					value={{
 						renderingTarget: 'Web',
 						darkModeAvailable: false,
+						updateLogoAdPartnerSwitch: false,
 						assetOrigin: '/',
 					}}
 				>
@@ -470,6 +480,7 @@ describe('Island: server-side rendering', () => {
 					value={{
 						renderingTarget: 'Web',
 						darkModeAvailable: false,
+						updateLogoAdPartnerSwitch: false,
 						assetOrigin: '/',
 					}}
 				>
@@ -499,6 +510,7 @@ describe('Island: server-side rendering', () => {
 					value={{
 						renderingTarget: 'Web',
 						darkModeAvailable: false,
+						updateLogoAdPartnerSwitch: false,
 						assetOrigin: '/',
 					}}
 				>
@@ -526,6 +538,7 @@ describe('Island: server-side rendering', () => {
 					value={{
 						renderingTarget: 'Web',
 						darkModeAvailable: false,
+						updateLogoAdPartnerSwitch: false,
 						assetOrigin: '/',
 					}}
 				>

--- a/dotcom-rendering/src/components/Island.test.tsx
+++ b/dotcom-rendering/src/components/Island.test.tsx
@@ -96,7 +96,6 @@ describe('Island: server-side rendering', () => {
 					value={{
 						renderingTarget: 'Web',
 						darkModeAvailable: false,
-						inAdvertisingPartnerABTest: false,
 						assetOrigin: '/',
 					}}
 				>
@@ -127,7 +126,6 @@ describe('Island: server-side rendering', () => {
 					value={{
 						renderingTarget: 'Web',
 						darkModeAvailable: false,
-						inAdvertisingPartnerABTest: false,
 						assetOrigin: '/',
 					}}
 				>
@@ -148,7 +146,6 @@ describe('Island: server-side rendering', () => {
 					value={{
 						renderingTarget: 'Web',
 						darkModeAvailable: false,
-						inAdvertisingPartnerABTest: false,
 						assetOrigin: '/',
 					}}
 				>
@@ -179,7 +176,6 @@ describe('Island: server-side rendering', () => {
 					value={{
 						renderingTarget: 'Web',
 						darkModeAvailable: false,
-						inAdvertisingPartnerABTest: false,
 						assetOrigin: '/',
 					}}
 				>
@@ -208,7 +204,6 @@ describe('Island: server-side rendering', () => {
 					value={{
 						renderingTarget: 'Web',
 						darkModeAvailable: false,
-						inAdvertisingPartnerABTest: false,
 						assetOrigin: '/',
 					}}
 				>
@@ -303,7 +298,6 @@ describe('Island: server-side rendering', () => {
 					value={{
 						renderingTarget: 'Web',
 						darkModeAvailable: false,
-						inAdvertisingPartnerABTest: false,
 						assetOrigin: '/',
 					}}
 				>
@@ -348,7 +342,6 @@ describe('Island: server-side rendering', () => {
 					value={{
 						renderingTarget: 'Web',
 						darkModeAvailable: false,
-						inAdvertisingPartnerABTest: false,
 						assetOrigin: '/',
 					}}
 				>
@@ -386,7 +379,6 @@ describe('Island: server-side rendering', () => {
 					value={{
 						renderingTarget: 'Web',
 						darkModeAvailable: false,
-						inAdvertisingPartnerABTest: false,
 						assetOrigin: '/',
 					}}
 				>
@@ -425,7 +417,6 @@ describe('Island: server-side rendering', () => {
 					value={{
 						renderingTarget: 'Web',
 						darkModeAvailable: false,
-						inAdvertisingPartnerABTest: false,
 						assetOrigin: '/',
 					}}
 				>
@@ -449,7 +440,6 @@ describe('Island: server-side rendering', () => {
 					value={{
 						renderingTarget: 'Web',
 						darkModeAvailable: false,
-						inAdvertisingPartnerABTest: false,
 						assetOrigin: '/',
 					}}
 				>
@@ -480,7 +470,6 @@ describe('Island: server-side rendering', () => {
 					value={{
 						renderingTarget: 'Web',
 						darkModeAvailable: false,
-						inAdvertisingPartnerABTest: false,
 						assetOrigin: '/',
 					}}
 				>
@@ -510,7 +499,6 @@ describe('Island: server-side rendering', () => {
 					value={{
 						renderingTarget: 'Web',
 						darkModeAvailable: false,
-						inAdvertisingPartnerABTest: false,
 						assetOrigin: '/',
 					}}
 				>
@@ -538,7 +526,6 @@ describe('Island: server-side rendering', () => {
 					value={{
 						renderingTarget: 'Web',
 						darkModeAvailable: false,
-						inAdvertisingPartnerABTest: false,
 						assetOrigin: '/',
 					}}
 				>

--- a/dotcom-rendering/src/components/MostViewedFooter.test.tsx
+++ b/dotcom-rendering/src/components/MostViewedFooter.test.tsx
@@ -26,6 +26,7 @@ describe('MostViewedFooterData', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
+					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 				}}
 			>
@@ -68,6 +69,7 @@ describe('MostViewedFooterData', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
+					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 				}}
 			>
@@ -129,6 +131,7 @@ describe('MostViewedFooterData', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
+					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 				}}
 			>
@@ -175,6 +178,7 @@ describe('MostViewedFooterData', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
+					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 				}}
 			>
@@ -197,6 +201,7 @@ describe('MostViewedFooterData', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
+					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 				}}
 			>

--- a/dotcom-rendering/src/components/MostViewedFooter.test.tsx
+++ b/dotcom-rendering/src/components/MostViewedFooter.test.tsx
@@ -26,7 +26,6 @@ describe('MostViewedFooterData', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					inAdvertisingPartnerABTest: false,
 					assetOrigin: '/',
 				}}
 			>
@@ -69,7 +68,6 @@ describe('MostViewedFooterData', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					inAdvertisingPartnerABTest: false,
 					assetOrigin: '/',
 				}}
 			>
@@ -131,7 +129,6 @@ describe('MostViewedFooterData', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					inAdvertisingPartnerABTest: false,
 					assetOrigin: '/',
 				}}
 			>
@@ -178,7 +175,6 @@ describe('MostViewedFooterData', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					inAdvertisingPartnerABTest: false,
 					assetOrigin: '/',
 				}}
 			>
@@ -201,7 +197,6 @@ describe('MostViewedFooterData', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					inAdvertisingPartnerABTest: false,
 					assetOrigin: '/',
 				}}
 			>

--- a/dotcom-rendering/src/components/MostViewedRight.test.tsx
+++ b/dotcom-rendering/src/components/MostViewedRight.test.tsx
@@ -23,7 +23,6 @@ describe('MostViewedList', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					inAdvertisingPartnerABTest: false,
 					assetOrigin: '/',
 				}}
 			>
@@ -73,7 +72,6 @@ describe('MostViewedList', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					inAdvertisingPartnerABTest: false,
 					assetOrigin: '/',
 				}}
 			>
@@ -102,7 +100,6 @@ describe('MostViewedList', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					inAdvertisingPartnerABTest: false,
 					assetOrigin: '/',
 				}}
 			>

--- a/dotcom-rendering/src/components/MostViewedRight.test.tsx
+++ b/dotcom-rendering/src/components/MostViewedRight.test.tsx
@@ -23,6 +23,7 @@ describe('MostViewedList', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
+					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 				}}
 			>
@@ -72,6 +73,7 @@ describe('MostViewedList', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
+					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 				}}
 			>
@@ -100,6 +102,7 @@ describe('MostViewedList', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
+					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 				}}
 			>

--- a/dotcom-rendering/src/components/Nav/Nav.test.tsx
+++ b/dotcom-rendering/src/components/Nav/Nav.test.tsx
@@ -10,6 +10,7 @@ describe('Nav', () => {
 			value={{
 				renderingTarget: 'Web',
 				darkModeAvailable: false,
+				updateLogoAdPartnerSwitch: false,
 				assetOrigin: '/',
 			}}
 		>

--- a/dotcom-rendering/src/components/Nav/Nav.test.tsx
+++ b/dotcom-rendering/src/components/Nav/Nav.test.tsx
@@ -10,7 +10,6 @@ describe('Nav', () => {
 			value={{
 				renderingTarget: 'Web',
 				darkModeAvailable: false,
-				inAdvertisingPartnerABTest: false,
 				assetOrigin: '/',
 			}}
 		>

--- a/dotcom-rendering/src/components/ProfileAtom.test.tsx
+++ b/dotcom-rendering/src/components/ProfileAtom.test.tsx
@@ -9,7 +9,6 @@ describe('ProfileAtom', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					inAdvertisingPartnerABTest: false,
 					assetOrigin: '/',
 				}}
 			>
@@ -49,7 +48,6 @@ describe('ProfileAtom', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					inAdvertisingPartnerABTest: false,
 					assetOrigin: '/',
 				}}
 			>
@@ -90,7 +88,6 @@ describe('ProfileAtom', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					inAdvertisingPartnerABTest: false,
 					assetOrigin: '/',
 				}}
 			>

--- a/dotcom-rendering/src/components/ProfileAtom.test.tsx
+++ b/dotcom-rendering/src/components/ProfileAtom.test.tsx
@@ -9,6 +9,7 @@ describe('ProfileAtom', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
+					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 				}}
 			>
@@ -48,6 +49,7 @@ describe('ProfileAtom', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
+					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 				}}
 			>
@@ -88,6 +90,7 @@ describe('ProfileAtom', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
+					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 				}}
 			>

--- a/dotcom-rendering/src/components/QandaAtom.test.tsx
+++ b/dotcom-rendering/src/components/QandaAtom.test.tsx
@@ -11,7 +11,6 @@ describe('QandaAtom', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					inAdvertisingPartnerABTest: false,
 					assetOrigin: '/',
 				}}
 			>
@@ -37,7 +36,6 @@ describe('QandaAtom', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					inAdvertisingPartnerABTest: false,
 					assetOrigin: '/',
 				}}
 			>
@@ -64,7 +62,6 @@ describe('QandaAtom', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					inAdvertisingPartnerABTest: false,
 					assetOrigin: '/',
 				}}
 			>

--- a/dotcom-rendering/src/components/QandaAtom.test.tsx
+++ b/dotcom-rendering/src/components/QandaAtom.test.tsx
@@ -11,6 +11,7 @@ describe('QandaAtom', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
+					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 				}}
 			>
@@ -36,6 +37,7 @@ describe('QandaAtom', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
+					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 				}}
 			>
@@ -62,6 +64,7 @@ describe('QandaAtom', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
+					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 				}}
 			>

--- a/dotcom-rendering/src/components/ReaderRevenueLinks.test.tsx
+++ b/dotcom-rendering/src/components/ReaderRevenueLinks.test.tsx
@@ -46,7 +46,6 @@ describe('ReaderRevenueLinks', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					inAdvertisingPartnerABTest: false,
 					assetOrigin: '/',
 				}}
 			>
@@ -72,7 +71,6 @@ describe('ReaderRevenueLinks', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					inAdvertisingPartnerABTest: false,
 					assetOrigin: '/',
 				}}
 			>

--- a/dotcom-rendering/src/components/ReaderRevenueLinks.test.tsx
+++ b/dotcom-rendering/src/components/ReaderRevenueLinks.test.tsx
@@ -46,6 +46,7 @@ describe('ReaderRevenueLinks', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
+					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 				}}
 			>
@@ -71,6 +72,7 @@ describe('ReaderRevenueLinks', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
+					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 				}}
 			>

--- a/dotcom-rendering/src/components/RichLinkComponent.importable.test.tsx
+++ b/dotcom-rendering/src/components/RichLinkComponent.importable.test.tsx
@@ -16,7 +16,6 @@ describe('RichLinkComponent', () => {
 					value={{
 						renderingTarget: 'Web',
 						darkModeAvailable: false,
-						inAdvertisingPartnerABTest: false,
 						assetOrigin: '/',
 					}}
 				>

--- a/dotcom-rendering/src/components/RichLinkComponent.importable.test.tsx
+++ b/dotcom-rendering/src/components/RichLinkComponent.importable.test.tsx
@@ -16,6 +16,7 @@ describe('RichLinkComponent', () => {
 					value={{
 						renderingTarget: 'Web',
 						darkModeAvailable: false,
+						updateLogoAdPartnerSwitch: false,
 						assetOrigin: '/',
 					}}
 				>

--- a/dotcom-rendering/src/components/SignInGate/gateDesigns/SignInGateMainCheckoutComplete.test.tsx
+++ b/dotcom-rendering/src/components/SignInGate/gateDesigns/SignInGateMainCheckoutComplete.test.tsx
@@ -32,6 +32,7 @@ describe('SignInGateMainCheckoutComplete', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
+					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 				}}
 			>

--- a/dotcom-rendering/src/components/SignInGate/gateDesigns/SignInGateMainCheckoutComplete.test.tsx
+++ b/dotcom-rendering/src/components/SignInGate/gateDesigns/SignInGateMainCheckoutComplete.test.tsx
@@ -32,7 +32,6 @@ describe('SignInGateMainCheckoutComplete', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					inAdvertisingPartnerABTest: false,
 					assetOrigin: '/',
 				}}
 			>

--- a/dotcom-rendering/src/components/TimelineAtom.test.tsx
+++ b/dotcom-rendering/src/components/TimelineAtom.test.tsx
@@ -11,7 +11,6 @@ describe('TimelineAtom', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					inAdvertisingPartnerABTest: false,
 					assetOrigin: '/',
 				}}
 			>
@@ -37,7 +36,6 @@ describe('TimelineAtom', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					inAdvertisingPartnerABTest: false,
 					assetOrigin: '/',
 				}}
 			>
@@ -64,7 +62,6 @@ describe('TimelineAtom', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					inAdvertisingPartnerABTest: false,
 					assetOrigin: '/',
 				}}
 			>

--- a/dotcom-rendering/src/components/TimelineAtom.test.tsx
+++ b/dotcom-rendering/src/components/TimelineAtom.test.tsx
@@ -11,6 +11,7 @@ describe('TimelineAtom', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
+					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 				}}
 			>
@@ -36,6 +37,7 @@ describe('TimelineAtom', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
+					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 				}}
 			>
@@ -62,6 +64,7 @@ describe('TimelineAtom', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
+					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 				}}
 			>

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.test.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.test.tsx
@@ -28,6 +28,7 @@ describe('YoutubeAtom', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
+					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 				}}
 			>
@@ -64,6 +65,7 @@ describe('YoutubeAtom', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
+					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 				}}
 			>
@@ -109,6 +111,7 @@ describe('YoutubeAtom', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
+					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 				}}
 			>
@@ -146,6 +149,7 @@ describe('YoutubeAtom', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
+					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 				}}
 			>
@@ -185,6 +189,7 @@ describe('YoutubeAtom', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
+					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 				}}
 			>
@@ -222,6 +227,7 @@ describe('YoutubeAtom', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
+					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 				}}
 			>
@@ -258,6 +264,7 @@ describe('YoutubeAtom', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
+					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 				}}
 			>
@@ -298,6 +305,7 @@ describe('YoutubeAtom', () => {
 					value={{
 						renderingTarget: 'Web',
 						darkModeAvailable: false,
+						updateLogoAdPartnerSwitch: false,
 						assetOrigin: '/',
 					}}
 				>

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.test.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.test.tsx
@@ -28,7 +28,6 @@ describe('YoutubeAtom', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					inAdvertisingPartnerABTest: false,
 					assetOrigin: '/',
 				}}
 			>
@@ -65,7 +64,6 @@ describe('YoutubeAtom', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					inAdvertisingPartnerABTest: false,
 					assetOrigin: '/',
 				}}
 			>
@@ -111,7 +109,6 @@ describe('YoutubeAtom', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					inAdvertisingPartnerABTest: false,
 					assetOrigin: '/',
 				}}
 			>
@@ -149,7 +146,6 @@ describe('YoutubeAtom', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					inAdvertisingPartnerABTest: false,
 					assetOrigin: '/',
 				}}
 			>
@@ -189,7 +185,6 @@ describe('YoutubeAtom', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					inAdvertisingPartnerABTest: false,
 					assetOrigin: '/',
 				}}
 			>
@@ -227,7 +222,6 @@ describe('YoutubeAtom', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					inAdvertisingPartnerABTest: false,
 					assetOrigin: '/',
 				}}
 			>
@@ -264,7 +258,6 @@ describe('YoutubeAtom', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					inAdvertisingPartnerABTest: false,
 					assetOrigin: '/',
 				}}
 			>
@@ -305,7 +298,6 @@ describe('YoutubeAtom', () => {
 					value={{
 						renderingTarget: 'Web',
 						darkModeAvailable: false,
-						inAdvertisingPartnerABTest: false,
 						assetOrigin: '/',
 					}}
 				>

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -163,9 +163,6 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 	const inUpdatedHeaderABTest =
 		abTests.updatedHeaderDesignVariant === 'variant';
 
-	const inAdvertisingPartnerABTest =
-		abTests.updateLogoAdPartnerVariant === 'variant';
-
 	const { absoluteServerTimes = false } = front.config.switches;
 
 	return (
@@ -463,9 +460,6 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 									discussionApiUrl={
 										front.config.discussionApiUrl
 									}
-									inAdvertisingPartnerABTest={
-										inAdvertisingPartnerABTest
-									}
 								>
 									<FrontMostViewed
 										displayName={collection.displayName}
@@ -676,9 +670,6 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 								discussionApiUrl={front.config.discussionApiUrl}
 								collectionBranding={
 									collection.collectionBranding
-								}
-								inAdvertisingPartnerABTest={
-									inAdvertisingPartnerABTest
 								}
 							>
 								<DecideContainer

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -163,7 +163,8 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 	const inUpdatedHeaderABTest =
 		abTests.updatedHeaderDesignVariant === 'variant';
 
-	const { absoluteServerTimes = false } = front.config.switches;
+	const { updateLogoAdPartner, absoluteServerTimes = false } =
+		front.config.switches;
 
 	return (
 		<>
@@ -460,6 +461,9 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 									discussionApiUrl={
 										front.config.discussionApiUrl
 									}
+									updateLogoAdPartnerSwitch={
+										updateLogoAdPartner
+									}
 								>
 									<FrontMostViewed
 										displayName={collection.displayName}
@@ -671,6 +675,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 								collectionBranding={
 									collection.collectionBranding
 								}
+								updateLogoAdPartnerSwitch={updateLogoAdPartner}
 							>
 								<DecideContainer
 									trails={trailsWithoutBranding}

--- a/dotcom-rendering/src/layouts/TagPageLayout.tsx
+++ b/dotcom-rendering/src/layouts/TagPageLayout.tsx
@@ -77,9 +77,6 @@ export const TagPageLayout = ({ tagPage, NAV }: Props) => {
 	const inUpdatedHeaderABTest =
 		abTests.updatedHeaderDesignVariant === 'variant';
 
-	const inAdvertisingPartnerABTest =
-		abTests.updateLogoAdPartnerVariant === 'variant';
-
 	return (
 		<>
 			<div data-print-layout="hide" id="bannerandheader">
@@ -290,9 +287,6 @@ export const TagPageLayout = ({ tagPage, NAV }: Props) => {
 								}
 								discussionApiUrl={
 									tagPage.config.discussionApiUrl
-								}
-								inAdvertisingPartnerABTest={
-									inAdvertisingPartnerABTest
 								}
 							>
 								<DecideContainerByTrails

--- a/dotcom-rendering/src/layouts/TagPageLayout.tsx
+++ b/dotcom-rendering/src/layouts/TagPageLayout.tsx
@@ -288,6 +288,9 @@ export const TagPageLayout = ({ tagPage, NAV }: Props) => {
 								discussionApiUrl={
 									tagPage.config.discussionApiUrl
 								}
+								updateLogoAdPartnerSwitch={
+									!!switches.updateLogoAdPartner
+								}
 							>
 								<DecideContainerByTrails
 									trails={groupedTrails.trails}

--- a/dotcom-rendering/src/server/render.allEditorialNewslettersPage.web.tsx
+++ b/dotcom-rendering/src/server/render.allEditorialNewslettersPage.web.tsx
@@ -28,7 +28,6 @@ export const renderEditorialNewslettersPage = ({
 	const config: Config = {
 		renderingTarget: 'Web',
 		darkModeAvailable: false,
-		inAdvertisingPartnerABTest: false,
 		assetOrigin: ASSET_ORIGIN,
 	};
 

--- a/dotcom-rendering/src/server/render.allEditorialNewslettersPage.web.tsx
+++ b/dotcom-rendering/src/server/render.allEditorialNewslettersPage.web.tsx
@@ -28,6 +28,7 @@ export const renderEditorialNewslettersPage = ({
 	const config: Config = {
 		renderingTarget: 'Web',
 		darkModeAvailable: false,
+		updateLogoAdPartnerSwitch: false,
 		assetOrigin: ASSET_ORIGIN,
 	};
 

--- a/dotcom-rendering/src/server/render.article.amp.tsx
+++ b/dotcom-rendering/src/server/render.article.amp.tsx
@@ -44,7 +44,6 @@ export const renderArticle = ({
 	const config: Config = {
 		renderingTarget: 'Web',
 		darkModeAvailable: false,
-		inAdvertisingPartnerABTest: false,
 		assetOrigin: ASSET_ORIGIN,
 	};
 

--- a/dotcom-rendering/src/server/render.article.amp.tsx
+++ b/dotcom-rendering/src/server/render.article.amp.tsx
@@ -44,6 +44,7 @@ export const renderArticle = ({
 	const config: Config = {
 		renderingTarget: 'Web',
 		darkModeAvailable: false,
+		updateLogoAdPartnerSwitch: false,
 		assetOrigin: ASSET_ORIGIN,
 	};
 

--- a/dotcom-rendering/src/server/render.article.apps.tsx
+++ b/dotcom-rendering/src/server/render.article.apps.tsx
@@ -26,7 +26,6 @@ export const renderArticle = (
 	const config: Config = {
 		renderingTarget,
 		darkModeAvailable: !!article.config.switches.darkModeInApps,
-		inAdvertisingPartnerABTest: false,
 		assetOrigin: ASSET_ORIGIN,
 	};
 

--- a/dotcom-rendering/src/server/render.article.apps.tsx
+++ b/dotcom-rendering/src/server/render.article.apps.tsx
@@ -26,6 +26,8 @@ export const renderArticle = (
 	const config: Config = {
 		renderingTarget,
 		darkModeAvailable: !!article.config.switches.darkModeInApps,
+		updateLogoAdPartnerSwitch:
+			!!article.config.switches.updateLogoAdPartner,
 		assetOrigin: ASSET_ORIGIN,
 	};
 

--- a/dotcom-rendering/src/server/render.article.web.tsx
+++ b/dotcom-rendering/src/server/render.article.web.tsx
@@ -53,6 +53,8 @@ export const renderHtml = ({
 		renderingTarget,
 		darkModeAvailable:
 			article.config.abTests.darkModeWebVariant === 'variant',
+		updateLogoAdPartnerSwitch:
+			!!article.config.switches.updateLogoAdPartner,
 		assetOrigin: ASSET_ORIGIN,
 	};
 
@@ -264,6 +266,7 @@ export const renderBlocks = ({
 	const config: Config = {
 		renderingTarget: 'Web',
 		darkModeAvailable: abTests.darkModeWebVariant === 'variant',
+		updateLogoAdPartnerSwitch: !!switches.updateLogoAdPartner,
 		assetOrigin: ASSET_ORIGIN,
 	};
 

--- a/dotcom-rendering/src/server/render.article.web.tsx
+++ b/dotcom-rendering/src/server/render.article.web.tsx
@@ -53,8 +53,6 @@ export const renderHtml = ({
 		renderingTarget,
 		darkModeAvailable:
 			article.config.abTests.darkModeWebVariant === 'variant',
-		inAdvertisingPartnerABTest:
-			article.config.abTests.updateLogoAdPartnerVariant === 'variant',
 		assetOrigin: ASSET_ORIGIN,
 	};
 
@@ -266,8 +264,6 @@ export const renderBlocks = ({
 	const config: Config = {
 		renderingTarget: 'Web',
 		darkModeAvailable: abTests.darkModeWebVariant === 'variant',
-		inAdvertisingPartnerABTest:
-			abTests.updateLogoAdPartnerVariant === 'variant',
 		assetOrigin: ASSET_ORIGIN,
 	};
 

--- a/dotcom-rendering/src/server/render.front.web.tsx
+++ b/dotcom-rendering/src/server/render.front.web.tsx
@@ -86,6 +86,7 @@ export const renderFront = ({
 		renderingTarget: 'Web',
 		darkModeAvailable:
 			front.config.abTests.darkModeWebVariant === 'variant',
+		updateLogoAdPartnerSwitch: !!front.config.switches.updateLogoAdPartner,
 		assetOrigin: ASSET_ORIGIN,
 	};
 
@@ -185,6 +186,8 @@ export const renderTagPage = ({
 		renderingTarget: 'Web',
 		darkModeAvailable:
 			tagPage.config.abTests.darkModeWebVariant === 'variant',
+		updateLogoAdPartnerSwitch:
+			!!tagPage.config.switches.updateLogoAdPartner,
 		assetOrigin: ASSET_ORIGIN,
 	};
 

--- a/dotcom-rendering/src/server/render.front.web.tsx
+++ b/dotcom-rendering/src/server/render.front.web.tsx
@@ -86,8 +86,6 @@ export const renderFront = ({
 		renderingTarget: 'Web',
 		darkModeAvailable:
 			front.config.abTests.darkModeWebVariant === 'variant',
-		inAdvertisingPartnerABTest:
-			front.config.abTests.updateLogoAdPartnerVariant === 'variant',
 		assetOrigin: ASSET_ORIGIN,
 	};
 
@@ -187,8 +185,6 @@ export const renderTagPage = ({
 		renderingTarget: 'Web',
 		darkModeAvailable:
 			tagPage.config.abTests.darkModeWebVariant === 'variant',
-		inAdvertisingPartnerABTest:
-			tagPage.config.abTests.updateLogoAdPartnerVariant === 'variant',
 		assetOrigin: ASSET_ORIGIN,
 	};
 

--- a/dotcom-rendering/src/types/configContext.ts
+++ b/dotcom-rendering/src/types/configContext.ts
@@ -11,12 +11,10 @@ export type Config =
 	| {
 			renderingTarget: Extract<RenderingTarget, 'Web'>;
 			darkModeAvailable: boolean;
-			inAdvertisingPartnerABTest: boolean;
 			assetOrigin: AssetOrigin;
 	  }
 	| {
 			renderingTarget: Extract<RenderingTarget, 'Apps'>;
 			darkModeAvailable: boolean;
-			inAdvertisingPartnerABTest: boolean;
 			assetOrigin: AssetOrigin;
 	  };

--- a/dotcom-rendering/src/types/configContext.ts
+++ b/dotcom-rendering/src/types/configContext.ts
@@ -11,10 +11,12 @@ export type Config =
 	| {
 			renderingTarget: Extract<RenderingTarget, 'Web'>;
 			darkModeAvailable: boolean;
+			updateLogoAdPartnerSwitch: boolean;
 			assetOrigin: AssetOrigin;
 	  }
 	| {
 			renderingTarget: Extract<RenderingTarget, 'Apps'>;
 			darkModeAvailable: boolean;
+			updateLogoAdPartnerSwitch: boolean;
 			assetOrigin: AssetOrigin;
 	  };


### PR DESCRIPTION
## What does this change?
This PR sets live the updated logo styling for `Advertising Partner` and `Exclusive advertising partner` labels by replacing the 0% test with a switch. Here is the related PR https://github.com/guardian/frontend/pull/27184

This change will only by applied to the two labels in articles and interactives. The changes will appear in TagPages if the user is in the `variant` which is 20% for the test `DCRTagPages`. There are still discussions to increate this percentage and the release date for 100% is still unknown. 

For more details check https://github.com/guardian/dotcom-rendering/pull/11217

I contacted CP to set a logo with one of these labels live to be able to test in CODE and all are working as expected.

## Why?
The US team requested to set it live.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
![image](https://github.com/guardian/dotcom-rendering/assets/23424805/2a1601b7-6d03-44fb-a8b6-f3e54214b94f) | ![image](https://github.com/guardian/dotcom-rendering/assets/23424805/1812d5ee-0f31-4509-a6f6-ac020eafce15) |
| ![image](https://github.com/guardian/dotcom-rendering/assets/23424805/adc18af5-ef8c-4258-aaab-b90b7bffa93f) | ![image](https://github.com/guardian/dotcom-rendering/assets/23424805/d5880cd2-4a38-49a4-a289-63b969f45a28) |
| ![image](https://github.com/guardian/dotcom-rendering/assets/23424805/5272c7c2-3283-4588-916a-562466e5e70f) | ![image](https://github.com/guardian/dotcom-rendering/assets/23424805/6a574f00-a7a3-40c8-be20-c38ebccc9c85) |
| ![image](https://github.com/guardian/dotcom-rendering/assets/23424805/63a6664f-8834-4c8f-8b5c-a356ecb23a73) | ![image](https://github.com/guardian/dotcom-rendering/assets/23424805/1c5820cf-9b3c-475e-8257-6cf3e39d7436) |

The following screenshots are DCR rendered:
| Before      | After       |
| ----------- | ---------- |
| ![image](https://github.com/guardian/dotcom-rendering/assets/23424805/0f65eaa9-ffb3-417b-bbde-c12d81aefb97) | ![image](https://github.com/guardian/dotcom-rendering/assets/23424805/9ef96541-b1e4-4cc6-9c08-f858a14d8061) |
| ![image](https://github.com/guardian/dotcom-rendering/assets/23424805/7384f3df-3d7e-4f92-afae-5372c6f3799a) | ![image](https://github.com/guardian/dotcom-rendering/assets/23424805/05329053-ecca-421e-a1d6-427bd7cb3ed5) |
| ![image](https://github.com/guardian/dotcom-rendering/assets/23424805/3a768788-e381-4715-9aaf-17a76d7d1dd6) | ![image](https://github.com/guardian/dotcom-rendering/assets/23424805/470c6d83-d38a-4d60-b626-b648bac33c3c) |
| ![image](https://github.com/guardian/dotcom-rendering/assets/23424805/92db80bd-0350-4962-880c-993c07e000ff) | ![image](https://github.com/guardian/dotcom-rendering/assets/23424805/132ea9f3-ad21-408a-82ff-a3aa850f6a57) |

| Lightmode      | Darkmode       |
| ----------- | ---------- |
| ![image](https://github.com/guardian/dotcom-rendering/assets/23424805/b3f0fce3-0232-4a77-bc76-69a01965840b) | ![image](https://github.com/guardian/dotcom-rendering/assets/23424805/bf1272f1-191b-469e-a6ac-730af29a6f3f) |

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
