### PR TITLE
Do not show avatar in contributors tag pages

### DIFF
--- a/dotcom-rendering/src/model/enhanceCards.ts
+++ b/dotcom-rendering/src/model/enhanceCards.ts
@@ -327,6 +327,8 @@ export const enhanceCards = (
 
 		const imageSrc = decideImage(faciaCard);
 
+		const isContributorTagPage = !!pageId && pageId.includes('profile/');
+
 		return {
 			format,
 			dataLinkName,
@@ -360,6 +362,7 @@ export const enhanceCards = (
 			showQuotedHeadline: faciaCard.display.showQuotedHeadline,
 			showLivePlayable: faciaCard.display.showLivePlayable,
 			avatarUrl:
+				!isContributorTagPage &&
 				faciaCard.properties.maybeContent?.tags.tags &&
 				faciaCard.properties.image?.type === 'Cutout'
 					? decideAvatarUrl(

--- a/dotcom-rendering/src/model/enhanceCards.ts
+++ b/dotcom-rendering/src/model/enhanceCards.ts
@@ -327,7 +327,7 @@ export const enhanceCards = (
 
 		const imageSrc = decideImage(faciaCard);
 
-		const isContributorTagPage = !!pageId && pageId.includes('profile/');
+		const isContributorTagPage = !!pageId && pageId.startsWith('profile/');
 
 		return {
 			format,


### PR DESCRIPTION
Closes https://github.com/guardian/dotcom-rendering/issues/11491

## What does this change?
Prevents avatar from being shown in contributors tag pages, e.g. https://www.theguardian.com/profile/georgemonbiot

## Why?
* The pages already have the contributors avatar at the top
* No need to show the avatar multiple times
* Parity with frontend


## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/0a43db8d-fdc8-4a26-ae17-bf2e890e50a7) | ![image](https://github.com/guardian/dotcom-rendering/assets/19683595/9ef0f259-3cd1-4063-b860-14b3b8fb3c19) |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
