### PR TITLE
Update AMP footer links

### DIFF
--- a/dotcom-rendering/src/components/Footer.amp.tsx
+++ b/dotcom-rendering/src/components/Footer.amp.tsx
@@ -55,7 +55,7 @@ export const footerLinks: Link[][] = [
 		},
 		{
 			title: 'Help',
-			url: 'https://www.theguardian.com/help',
+			url: 'https://manage.theguardian.com/help-centre',
 		},
 	],
 	[
@@ -80,8 +80,8 @@ export const footerLinks: Link[][] = [
 			url: 'https://www.facebook.com/theguardian',
 		},
 		{
-			title: 'Twitter',
-			url: 'https://twitter.com/guardian',
+			title: 'X',
+			url: 'https://x.com/guardian',
 		},
 	],
 	[


### PR DESCRIPTION
## What does this change?
This updates the twitter link from https://twitter.com/guardian to https://x.com/guardian and https://www.theguardian.com/help to https://manage.theguardian.com/help-centre
## Why?
Requested by CP https://groups.google.com/a/guardian.co.uk/g/dotcom.platform/c/Llg3aqkPCfY/m/-TNbFyXbAAAJ
## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/110032454/861ec0f5-4508-4d98-b711-f81e116d76aa
[after]: https://github.com/guardian/dotcom-rendering/assets/110032454/7c7ae56e-c854-4ea0-898f-0013aef79e81
<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
