### PR TITLE
Hide RR banner on safari if reduced height

### DIFF
--- a/dotcom-rendering/src/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/dotcom-rendering/src/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -173,6 +173,12 @@ const buildPayload = async ({
 	};
 };
 
+// Safari displays an "Open in app" banner which can cover the top of the banner.
+// We can detect this by checking the innerHeight
+const isSafariWithReduceHeight = () =>
+	window.navigator.userAgent.toLowerCase().includes('safari') &&
+	window.innerHeight < window.document.documentElement.clientHeight;
+
 export const canShowRRBanner: CanShowFunctionType<BannerProps> = async ({
 	remoteBannerConfig,
 	isSignedIn,
@@ -202,6 +208,10 @@ export const canShowRRBanner: CanShowFunctionType<BannerProps> = async ({
 		signInGateWillShow
 	) {
 		// We never serve Reader Revenue banners in this case
+		return { show: false };
+	}
+
+	if (isSafariWithReduceHeight()) {
 		return { show: false };
 	}
 

--- a/dotcom-rendering/src/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/dotcom-rendering/src/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -175,7 +175,7 @@ const buildPayload = async ({
 
 // Safari displays an "Open in app" banner which can cover the top of the banner.
 // We can detect this by checking the innerHeight
-const isSafariWithReduceHeight = () =>
+const isSafariWithReducedHeight = () =>
 	window.navigator.userAgent.toLowerCase().includes('safari') &&
 	window.innerHeight < window.document.documentElement.clientHeight;
 
@@ -211,7 +211,7 @@ export const canShowRRBanner: CanShowFunctionType<BannerProps> = async ({
 		return { show: false };
 	}
 
-	if (isSafariWithReduceHeight()) {
+	if (isSafariWithReducedHeight()) {
 		return { show: false };
 	}
 


### PR DESCRIPTION
On safari mobile, the "Open in app" banner is displayed at the top if the user has the guardian app installed. This can in some cases cover part of the RR banner. We'd like to avoid showing the RR banner in these cases.

Apparently `window.innerHeight` is affected by the safari banner, and so we can use this to detect it.
https://stackoverflow.com/a/58471338
https://stackoverflow.com/a/36620944