### PR TITLE
Round server times

### DIFF
--- a/dotcom-rendering/src/components/DateTime.tsx
+++ b/dotcom-rendering/src/components/DateTime.tsx
@@ -48,6 +48,10 @@ const formatTime = (date: Date, locale: string, timeZone: string) =>
 		})
 		.replace(':', '.');
 
+/** Rounded up to the next minute as most pages are cached for a least a minute */
+const getServerTime = (precision = 60_000) =>
+	Math.ceil(Date.now() / precision) * precision;
+
 export const DateTime = ({
 	date,
 	editionId,
@@ -62,7 +66,9 @@ export const DateTime = ({
 	const epoch = date.getTime();
 	const relativeTime = display === 'relative' && timeAgo(epoch);
 	const isRecent = isString(relativeTime) && relativeTime.endsWith(' ago');
-	const now = absoluteServerTimes ? Number.MAX_SAFE_INTEGER - 1 : Date.now();
+	const now = absoluteServerTimes
+		? Number.MAX_SAFE_INTEGER - 1
+		: getServerTime();
 
 	return isRecent ? (
 		<Island priority="enhancement" defer={{ until: 'visible' }}>


### PR DESCRIPTION
## What does this change?

Round server time to the next minute.

## Why?

- Most pages are cached for a least a minute, so “1m ago” is going to be true for more users
- If different elements are published at different seconds, ensure at most 1 different relative time per minute

## Known issue

For very recent date, that are less than a minute ago, there might be a small blink from “1m ago” to “now” or “45s ago” after a short delay.