### PR TITLE
Slower updates on recent relative times

### DIFF
--- a/dotcom-rendering/src/components/DateTime.tsx
+++ b/dotcom-rendering/src/components/DateTime.tsx
@@ -48,6 +48,10 @@ const formatTime = (date: Date, locale: string, timeZone: string) =>
 		})
 		.replace(':', '.');
 
+/** Rounded up to the next minute as most pages are cached for a least a minute */
+const getServerTime = (precision = 60_000) =>
+	Math.ceil(Date.now() / precision) * precision;
+
 export const DateTime = ({
 	date,
 	editionId,
@@ -62,7 +66,9 @@ export const DateTime = ({
 	const epoch = date.getTime();
 	const relativeTime = display === 'relative' && timeAgo(epoch);
 	const isRecent = isString(relativeTime) && relativeTime.endsWith(' ago');
-	const now = absoluteServerTimes ? Number.MAX_SAFE_INTEGER - 1 : Date.now();
+	const now = absoluteServerTimes
+		? Number.MAX_SAFE_INTEGER - 1
+		: getServerTime();
 
 	return isRecent ? (
 		<Island priority="enhancement" defer={{ until: 'visible' }}>

--- a/dotcom-rendering/src/components/RelativeTime.importable.tsx
+++ b/dotcom-rendering/src/components/RelativeTime.importable.tsx
@@ -1,4 +1,4 @@
-import { isString, timeAgo } from '@guardian/libs';
+import { timeAgo } from '@guardian/libs';
 import { useEffect, useState } from 'react';
 import { useIsInView } from '../lib/useIsInView';
 
@@ -8,6 +8,10 @@ type Props = {
 	/** the time to compare to */
 	now: number;
 };
+
+const ONE_MINUTE = 60_000;
+
+const getTime = () => Math.ceil(Date.now() / ONE_MINUTE) * ONE_MINUTE;
 
 /**
  * Shows a recent time as relative, such as “3h ago”
@@ -22,16 +26,14 @@ export const RelativeTime = ({ then, now }: Props) => {
 	const [display, setDisplay] = useState(timeAgo(then, { now }));
 
 	useEffect(() => {
-		setDisplay(timeAgo(then));
+		setDisplay(timeAgo(then, { now: getTime() }));
 		if (!inView) return;
-		const refresh =
-			isString(display) && display.match(/\ds ago/) ? 1_000 : 15_000;
 
 		const interval = setTimeout(() => {
-			setDisplay(timeAgo(then));
-		}, refresh);
+			setDisplay(timeAgo(then, { now: getTime() }));
+		}, 60_000);
 		return () => clearInterval(interval);
-	}, [inView, then, display]);
+	}, [inView, then]);
 
 	const date = new Date(then);
 

--- a/dotcom-rendering/src/components/RelativeTime.importable.tsx
+++ b/dotcom-rendering/src/components/RelativeTime.importable.tsx
@@ -1,4 +1,4 @@
-import { timeAgo } from '@guardian/libs';
+import { isString, timeAgo } from '@guardian/libs';
 import { useEffect, useState } from 'react';
 import { useIsInView } from '../lib/useIsInView';
 
@@ -24,12 +24,14 @@ export const RelativeTime = ({ then, now }: Props) => {
 	useEffect(() => {
 		setDisplay(timeAgo(then));
 		if (!inView) return;
+		const refresh =
+			isString(display) && display.match(/\ds ago/) ? 1_000 : 15_000;
 
 		const interval = setTimeout(() => {
 			setDisplay(timeAgo(then));
-		}, 15_000);
+		}, refresh);
 		return () => clearInterval(interval);
-	}, [inView, then]);
+	}, [inView, then, display]);
 
 	const date = new Date(then);
 


### PR DESCRIPTION
## What does this change?

Update relative times every minute only.

## Why?

It’s weird to see “24s ago” that only updates with “39s ago”, “54s ago” and then ”1m ago”. Just show minutes ago.

## Screenshots

A video would be better but if you don’t have aphantasia you can picture it in your head :)