### PR TITLE
Add padding to main media video component captions

### DIFF
--- a/dotcom-rendering/src/components/Caption.tsx
+++ b/dotcom-rendering/src/components/Caption.tsx
@@ -230,17 +230,13 @@ export const Caption = ({
 	const hideCredit = !displayCredit;
 	if (noCaption && (noCredit || hideCredit)) return null;
 
-	const isBlog =
-		format.design === ArticleDesign.LiveBlog ||
-		format.design === ArticleDesign.DeadBlog;
-
 	const defaultCaption = (
 		<figcaption
 			css={[
 				captionStyle,
 				shouldLimitWidth && limitedWidth,
 				isOverlaid ? overlaidStyles(format) : bottomMarginStyles,
-				isMainMedia && isBlog && tabletCaptionPadding,
+				isMainMedia && tabletCaptionPadding,
 				padCaption && captionPadding,
 			]}
 		>

--- a/dotcom-rendering/src/components/Caption.tsx
+++ b/dotcom-rendering/src/components/Caption.tsx
@@ -230,13 +230,19 @@ export const Caption = ({
 	const hideCredit = !displayCredit;
 	if (noCaption && (noCredit || hideCredit)) return null;
 
+	const isBlog =
+		format.design === ArticleDesign.LiveBlog ||
+		format.design === ArticleDesign.DeadBlog;
+
 	const defaultCaption = (
 		<figcaption
 			css={[
 				captionStyle,
 				shouldLimitWidth && limitedWidth,
 				isOverlaid ? overlaidStyles(format) : bottomMarginStyles,
-				isMainMedia && tabletCaptionPadding,
+				isMainMedia &&
+					(isBlog || mediaType === 'Video') &&
+					tabletCaptionPadding,
 				padCaption && captionPadding,
 			]}
 		>


### PR DESCRIPTION
Adds missing padding to captions on main media YouTube components.

Closes https://github.com/guardian/dotcom-rendering/issues/11501

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before](https://github.com/guardian/dotcom-rendering/assets/705427/d56447cd-ee22-4965-8b6b-4e1f9edea4fe) | ![after](https://github.com/guardian/dotcom-rendering/assets/705427/bd7b011e-13fa-4a32-a9eb-f54b5cac28c1) |
| ![before2](https://github.com/guardian/dotcom-rendering/assets/705427/1fa7473a-fc42-45a2-81d8-1cc22b149f83) | ![after2](https://github.com/guardian/dotcom-rendering/assets/705427/351b3811-c6cc-43a6-bf7a-f0038b9ee1a6) |
| <img width="1055" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/705427/b3ecc802-d899-4f22-a937-074d50103b84"> | <img width="950" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/705427/2cbabe56-7f27-4634-acc0-0a1c3991d27b"> |
