### PR TITLE
More robust time keeping

### DIFF
--- a/dotcom-rendering/src/components/DateTime.tsx
+++ b/dotcom-rendering/src/components/DateTime.tsx
@@ -63,16 +63,18 @@ export const DateTime = ({
 }: Props & DisplayProps) => {
 	const { dateLocale, timeZone } = getEditionFromId(editionId);
 
-	const epoch = date.getTime();
-	const relativeTime = display === 'relative' && timeAgo(epoch);
-	const isRecent = isString(relativeTime) && relativeTime.endsWith(' ago');
+	const then = date.getTime();
+	const relativeTime = display === 'relative' && timeAgo(then);
+	const isRecent =
+		isString(relativeTime) &&
+		(relativeTime === 'now' || relativeTime.endsWith(' ago'));
 	const now = absoluteServerTimes
 		? Number.MAX_SAFE_INTEGER - 1
 		: getServerTime();
 
 	return isRecent ? (
 		<Island priority="enhancement" defer={{ until: 'visible' }}>
-			<RelativeTime then={epoch} now={now} />
+			<RelativeTime then={then} now={now} />
 		</Island>
 	) : (
 		<time

--- a/dotcom-rendering/src/components/RelativeTime.importable.tsx
+++ b/dotcom-rendering/src/components/RelativeTime.importable.tsx
@@ -10,8 +10,8 @@ type Props = {
 };
 
 const ONE_MINUTE = 60_000;
-
-const getTime = () => Math.ceil(Date.now() / ONE_MINUTE) * ONE_MINUTE;
+const getNextMinute = (then: number) =>
+	then + Math.floor((Date.now() - then) / ONE_MINUTE) * ONE_MINUTE;
 
 /**
  * Shows a recent time as relative, such as “3h ago”
@@ -26,12 +26,12 @@ export const RelativeTime = ({ then, now }: Props) => {
 	const [display, setDisplay] = useState(timeAgo(then, { now }));
 
 	useEffect(() => {
-		setDisplay(timeAgo(then, { now: getTime() }));
+		setDisplay(timeAgo(then, { now: getNextMinute(then) }));
 		if (!inView) return;
 
-		const interval = setTimeout(() => {
-			setDisplay(timeAgo(then, { now: getTime() }));
-		}, 60_000);
+		const interval = setInterval(() => {
+			setDisplay(timeAgo(then, { now: getNextMinute(then) }));
+		}, ONE_MINUTE);
 		return () => clearInterval(interval);
 	}, [inView, then]);
 


### PR DESCRIPTION
## What does this change?

- never show “Xs ago”, only minutes
- unify naming convention
- ensure interval & reuse ONE_MINUTE

## Why?

Follow-up on:
- #11498 

## Screenshots

N/A – it looks identical.