### PR TITLE
Split `FEFrontCard` Into A Union Type

### DIFF
--- a/dotcom-rendering/src/model/enhanceCards.ts
+++ b/dotcom-rendering/src/model/enhanceCards.ts
@@ -343,20 +343,25 @@ export const enhanceCards = (
 					  ).toISOString()
 					: undefined,
 			kickerText: decideKicker(faciaCard, cardInTagPage, pageId),
-			supportingContent: faciaCard.supportingContent
-				? enhanceSupportingContent(
-						faciaCard.supportingContent,
-						format,
-						containerPalette,
-				  )
-				: undefined,
+			supportingContent:
+				faciaCard.type === 'CuratedContent'
+					? enhanceSupportingContent(
+							faciaCard.supportingContent,
+							format,
+							containerPalette,
+					  )
+					: undefined,
 			discussionApiUrl,
 			discussionId: faciaCard.discussion.isCommentable
 				? faciaCard.discussion.discussionId
 				: undefined,
 			byline: faciaCard.properties.byline ?? undefined,
 			showByline: faciaCard.properties.showByline,
-			snapData: enhanceSnaps(faciaCard.enriched),
+			snapData:
+				faciaCard.type === 'CuratedContent' ||
+				faciaCard.type === 'LinkSnap'
+					? enhanceSnaps(faciaCard.enriched)
+					: undefined,
 			isBoosted: faciaCard.display.isBoosted,
 			isCrossword: faciaCard.properties.isCrossword,
 			showQuotedHeadline: faciaCard.display.showQuotedHeadline,

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -284,13 +284,29 @@ export type FEFrontCard = {
 		showLivePlayable: boolean;
 	};
 	format?: FEFormat;
-	enriched?: FESnapType;
-	supportingContent?: FESupportingContent[];
-	cardStyle?: {
-		type: FEFrontCardStyle;
-	};
-	type: string;
-};
+} & (
+	| {
+			type: 'CuratedContent';
+			supportingContent: FESupportingContent[];
+			enriched?: FESnapType;
+			cardStyle: {
+				type: FEFrontCardStyle;
+			};
+	  }
+	| {
+			type: 'SupportingCuratedContent';
+			cardStyle: {
+				type: FEFrontCardStyle;
+			};
+	  }
+	| {
+			type: 'LinkSnap';
+			enriched?: FESnapType;
+	  }
+	| {
+			type: 'LatestSnap';
+	  }
+);
 
 export type DCRFrontImage = {
 	src: string;


### PR DESCRIPTION
Frontend represents this with a `trait` and case classes, i.e. a union type. It also sends a `type` field to DCAR to represent each member of the union, so we can replicate that in the DCAR types.

We want to split it up because it's a more accurate type, but also to make it easier to split downstream types in DCAR, e.g. `DCRFrontCard`. Ultimately this will make it easier to handle new kinds of cards, such as election trackers.
