### PR TITLE
Cc/choice cards live blog

### DIFF
--- a/dotcom-rendering/src/components/marketing/epics/ContributionsLiveblogEpic.stories.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ContributionsLiveblogEpic.stories.tsx
@@ -73,3 +73,45 @@ export const WithReminderCta: Story = {
 		},
 	},
 };
+
+export const WithChoiceCards: Story = {
+	name: 'ContributionsLiveblogEpic with Choice Cards',
+	args: {
+		...meta.args,
+		variant: {
+			...props.variant,
+			secondaryCta: {
+				type: SecondaryCtaType.ContributionsReminder,
+			},
+			showReminderFields: {
+				reminderCta: 'Remind me in December',
+				reminderPeriod: '2022-12-01',
+				reminderLabel: 'December',
+			},
+			showChoiceCards: true,
+			choiceCardAmounts: {
+				testName: 'Storybook_test',
+				variantName: 'Control',
+				defaultContributionType: 'MONTHLY',
+				displayContributionType: ['ONE_OFF', 'MONTHLY', 'ANNUAL'],
+				amountsCardData: {
+					ONE_OFF: {
+						amounts: [5, 10],
+						defaultAmount: 5,
+						hideChooseYourAmount: false,
+					},
+					MONTHLY: {
+						amounts: [4, 10],
+						defaultAmount: 12,
+						hideChooseYourAmount: false,
+					},
+					ANNUAL: {
+						amounts: [50, 100],
+						defaultAmount: 100,
+						hideChooseYourAmount: false,
+					},
+				},
+			},
+		},
+	},
+};

--- a/dotcom-rendering/src/components/marketing/epics/ContributionsLiveblogEpic.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ContributionsLiveblogEpic.tsx
@@ -19,6 +19,7 @@ import type {
 } from '@guardian/support-dotcom-components/dist/shared/src/types';
 import { useEffect, useState } from 'react';
 import { useIsInView } from '../../../lib/useIsInView';
+import type { ChoiceCardSelection } from '../lib/choiceCards';
 import type { ReactComponent } from '../lib/ReactComponent';
 import { replaceArticleCount } from '../lib/replaceArticleCount';
 import {
@@ -26,9 +27,8 @@ import {
 	createViewEventFromTracking,
 } from '../lib/tracking';
 import { logEpicView } from '../lib/viewLog';
-import { ContributionsEpicCtas } from './ContributionsEpicCtas';
 import { ContributionsEpicChoiceCards } from './ContributionsEpicChoiceCards';
-import type { ChoiceCardSelection } from '../lib/choiceCards';
+import { ContributionsEpicCtas } from './ContributionsEpicCtas';
 
 const container = (clientName: string) => css`
 	padding: 6px 10px 28px 10px;


### PR DESCRIPTION
## What does this change?
Adding choice cards into the Live Blog epic

##Why?
Currently there are support asks on the Live Blogs but we don't provide the opportunity for potential supporters to donate.

## Screenshots
BEFORE
<img width="981" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/115992455/85d737f3-389a-427c-83ab-c1840d28d11f">

AFTER:
<img width="977" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/115992455/d91eb832-de1a-4c4b-bf60-9258ca7ba84c">

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
