### PR TITLE
Skip YouTube main media atom test

### DIFF
--- a/dotcom-rendering/playwright/tests/atom.video.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/atom.video.e2e.spec.ts
@@ -120,7 +120,8 @@ const muteYouTube = async (page: Page, iframeSelector: string) => {
 };
 
 test.describe('YouTube Atom', () => {
-	test('plays main media video', async ({ page }) => {
+	// Skipping this temporarily as it has started failing
+	test.skip('plays main media video', async ({ page }) => {
 		await fetchAndloadPageWithOverrides(
 			page,
 			'https://www.theguardian.com/uk-news/2020/dec/04/edinburgh-hit-by-thundersnow-as-sonic-boom-wakes-residents',


### PR DESCRIPTION
It has started failing. Skipping until we have a full solution.
Part of https://github.com/guardian/dotcom-rendering/issues/11510