### PR TITLE
Refresh all AMP ad slots every 30s

### DIFF
--- a/dotcom-rendering/src/components/Ad.amp.tsx
+++ b/dotcom-rendering/src/components/Ad.amp.tsx
@@ -98,10 +98,6 @@ export const Ad = ({
 		adType,
 	);
 
-	// we don't want teads ads to refresh, as this seems to reduce their visibility
-	// teads ads only target the ad-1 and ad-2 slots, so we prevent these from refreshing
-	const refreshValue = id === 'ad-1' || id === 'ad-2' ? 'false' : '30';
-
 	return (
 		<amp-ad
 			data-block-on-consent="_till_responded"
@@ -116,7 +112,7 @@ export const Ad = ({
 			data-multi-size-validation="false"
 			data-npa-on-unknown-consent={true}
 			data-loading-strategy="prefer-viewability-over-views"
-			data-enable-refresh={refreshValue}
+			data-enable-refresh="30"
 			layout="fixed"
 			type="doubleclick"
 			json={stringify(


### PR DESCRIPTION
## What does this change?
Back in November, we [made a change](https://github.com/guardian/dotcom-rendering/pull/9412) to not refresh AMP ad-1 and ad-2 slots in a bid to boost teads visibility. We're now reversing that change.

## Why?
Some data analysis has shown that the increase in teads visibility didn't offset the drop in revenue as a result of not refreshing. Refreshing these slots should increase ad revenue on AMP.