### PR TITLE
StickyBottomBanner on tag pages

### DIFF
--- a/dotcom-rendering/src/layouts/TagPageLayout.tsx
+++ b/dotcom-rendering/src/layouts/TagPageLayout.tsx
@@ -26,6 +26,7 @@ import {
 	getTagPageBannerAdPositions,
 	getTagPageMobileAdPositions,
 } from '../lib/getTagPageAdPositions';
+import { enhanceTags } from '../model/enhanceCards';
 import type { NavType } from '../model/extract-nav';
 import { palette as themePalette } from '../palette';
 import type { DCRTagPageType } from '../types/tagPage';
@@ -387,7 +388,7 @@ export const TagPageLayout = ({ tagPage, NAV }: Props) => {
 						sectionId={section}
 						shouldHideReaderRevenue={false} // never defined for tag pages?
 						remoteBannerSwitch={!!switches.remoteBanner}
-						tags={tags} // what tags does a tag page have? :-)
+						tags={enhanceTags(tags)}
 					/>
 				</Island>
 			</BannerWrapper>

--- a/dotcom-rendering/src/layouts/TagPageLayout.tsx
+++ b/dotcom-rendering/src/layouts/TagPageLayout.tsx
@@ -16,6 +16,7 @@ import { Island } from '../components/Island';
 import { Masthead } from '../components/Masthead';
 import { Nav } from '../components/Nav/Nav';
 import { Section } from '../components/Section';
+import { StickyBottomBanner } from '../components/StickyBottomBanner.importable';
 import { SubNav } from '../components/SubNav.importable';
 import { TagPageHeader } from '../components/TagPageHeader';
 import { TrendingTopics } from '../components/TrendingTopics';
@@ -28,7 +29,7 @@ import {
 import type { NavType } from '../model/extract-nav';
 import { palette as themePalette } from '../palette';
 import type { DCRTagPageType } from '../types/tagPage';
-import { Stuck } from './lib/stickiness';
+import { BannerWrapper, Stuck } from './lib/stickiness';
 
 interface Props {
 	tagPage: DCRTagPageType;
@@ -59,7 +60,18 @@ const getContainerId = (date: Date, locale: string, hasDay: boolean) => {
 
 export const TagPageLayout = ({ tagPage, NAV }: Props) => {
 	const {
-		config: { switches, hasPageSkin, isPaidContent },
+		config: {
+			contentType,
+			hasPageSkin,
+			idApiUrl,
+			isPaidContent,
+			isPreview,
+			isSensitive,
+			section,
+			switches,
+			pageId,
+		},
+		tags,
 	} = tagPage;
 
 	const renderAds = canRenderAds(tagPage);
@@ -76,6 +88,8 @@ export const TagPageLayout = ({ tagPage, NAV }: Props) => {
 
 	const inUpdatedHeaderABTest =
 		abTests.updatedHeaderDesignVariant === 'variant';
+
+	const contributionsServiceUrl = 'https://contributions.guardianapis.com'; // TODO: Read this from config (use getContributionsServiceUrl)
 
 	return (
 		<>
@@ -111,7 +125,7 @@ export const TagPageLayout = ({ tagPage, NAV }: Props) => {
 							}
 							discussionApiUrl={tagPage.config.discussionApiUrl}
 							idApiUrl={tagPage.config.idApiUrl}
-							contributionsServiceUrl="https://contributions.guardianapis.com" // TODO: Pass this in
+							contributionsServiceUrl={contributionsServiceUrl}
 							showSubNav={false}
 							isImmersive={false}
 							displayRoundel={false}
@@ -356,9 +370,27 @@ export const TagPageLayout = ({ tagPage, NAV }: Props) => {
 					pillars={NAV.pillars}
 					urls={tagPage.nav.readerRevenueLinks.header}
 					editionId={tagPage.editionId}
-					contributionsServiceUrl="https://contributions.guardianapis.com" // TODO: Pass this in
+					contributionsServiceUrl={contributionsServiceUrl}
 				/>
 			</Section>
+			<BannerWrapper data-print-layout="hide">
+				<Island priority="feature" defer={{ until: 'idle' }}>
+					<StickyBottomBanner
+						contentType={contentType}
+						contributionsServiceUrl={contributionsServiceUrl}
+						idApiUrl={idApiUrl}
+						isMinuteArticle={false}
+						isPaidContent={!!isPaidContent}
+						isPreview={isPreview}
+						isSensitive={isSensitive}
+						pageId={pageId}
+						sectionId={section}
+						shouldHideReaderRevenue={false} // never defined for tag pages?
+						remoteBannerSwitch={!!switches.remoteBanner}
+						tags={tags} // what tags does a tag page have? :-)
+					/>
+				</Island>
+			</BannerWrapper>
 		</>
 	);
 };

--- a/dotcom-rendering/src/layouts/TagPageLayout.tsx
+++ b/dotcom-rendering/src/layouts/TagPageLayout.tsx
@@ -26,7 +26,7 @@ import {
 	getTagPageBannerAdPositions,
 	getTagPageMobileAdPositions,
 } from '../lib/getTagPageAdPositions';
-import { enhanceTags } from '../model/enhanceCards';
+import { enhanceTags } from '../model/enhanceTags';
 import type { NavType } from '../model/extract-nav';
 import { palette as themePalette } from '../palette';
 import type { DCRTagPageType } from '../types/tagPage';

--- a/dotcom-rendering/src/model/enhanceCards.ts
+++ b/dotcom-rendering/src/model/enhanceCards.ts
@@ -191,7 +191,7 @@ const decideSlideshowImages = (
 	return undefined;
 };
 
-const enhanceTags = (tags: FETagType[]): TagType[] => {
+export const enhanceTags = (tags: FETagType[]): TagType[] => {
 	return tags.map(({ properties }) => {
 		const {
 			id,

--- a/dotcom-rendering/src/model/enhanceCards.ts
+++ b/dotcom-rendering/src/model/enhanceCards.ts
@@ -14,8 +14,9 @@ import type {
 	FESupportingContent,
 } from '../types/front';
 import type { MainMedia } from '../types/mainMedia';
-import type { FETagType, TagType } from '../types/tag';
+import type { TagType } from '../types/tag';
 import { enhanceSnaps } from './enhanceSnaps';
+import { enhanceTags } from './enhanceTags';
 
 /**
  *
@@ -189,28 +190,6 @@ const decideSlideshowImages = (
 		return assets;
 	}
 	return undefined;
-};
-
-export const enhanceTags = (tags: FETagType[]): TagType[] => {
-	return tags.map(({ properties }) => {
-		const {
-			id,
-			tagType,
-			webTitle,
-			twitterHandle,
-			bylineImageUrl,
-			contributorLargeImagePath,
-		} = properties;
-
-		return {
-			id,
-			type: tagType,
-			title: webTitle,
-			twitterHandle,
-			bylineImageUrl,
-			bylineLargeImageUrl: contributorLargeImagePath,
-		};
-	});
 };
 
 /**

--- a/dotcom-rendering/src/model/enhanceTags.test.ts
+++ b/dotcom-rendering/src/model/enhanceTags.test.ts
@@ -1,0 +1,36 @@
+import type { FETagType } from '../types/tag';
+import { enhanceTags } from './enhanceTags';
+
+describe('enhanceTags', () => {
+	it('maps a list of FETagType to TagType', () => {
+		const feTags: FETagType[] = [
+			{
+				properties: {
+					id: 'profile/morwennaferrier',
+					tagType: 'Contributor',
+					webTitle: 'Morwenna Ferrier',
+					twitterHandle: 'exampleTwitterHandle',
+					bylineImageUrl:
+						'https://static.guim.co.uk/sys-images/Guardian/Pix/contributor/2014/10/15/1413394164362/Morwenna-Ferrier.jpg',
+					contributorLargeImagePath:
+						'https://uploads.guim.co.uk/2017/10/09/Morwenna-Ferrier,-L.png',
+				},
+			},
+		];
+
+		const tags = enhanceTags(feTags);
+
+		expect(tags).toEqual([
+			{
+				id: 'profile/morwennaferrier',
+				type: 'Contributor',
+				title: 'Morwenna Ferrier',
+				twitterHandle: 'exampleTwitterHandle',
+				bylineImageUrl:
+					'https://static.guim.co.uk/sys-images/Guardian/Pix/contributor/2014/10/15/1413394164362/Morwenna-Ferrier.jpg',
+				bylineLargeImageUrl:
+					'https://uploads.guim.co.uk/2017/10/09/Morwenna-Ferrier,-L.png',
+			},
+		]);
+	});
+});

--- a/dotcom-rendering/src/model/enhanceTags.ts
+++ b/dotcom-rendering/src/model/enhanceTags.ts
@@ -6,19 +6,19 @@ export const enhanceTags = (tags: FETagType[]): TagType[] =>
 const enhanceTag = ({ properties }: FETagType): TagType => {
 	const {
 		id,
-		tagType,
-		webTitle,
+		tagType: type,
+		webTitle: title,
 		twitterHandle,
 		bylineImageUrl,
-		contributorLargeImagePath,
+		contributorLargeImagePath: bylineLargeImageUrl,
 	} = properties;
 
 	return {
 		id,
-		type: tagType,
-		title: webTitle,
+		type,
+		title,
 		twitterHandle,
 		bylineImageUrl,
-		bylineLargeImageUrl: contributorLargeImagePath,
+		bylineLargeImageUrl,
 	};
 };

--- a/dotcom-rendering/src/model/enhanceTags.ts
+++ b/dotcom-rendering/src/model/enhanceTags.ts
@@ -1,23 +1,24 @@
 import type { FETagType, TagType } from '../types/tag';
 
-export const enhanceTags = (tags: FETagType[]): TagType[] => {
-	return tags.map(({ properties }) => {
-		const {
-			id,
-			tagType,
-			webTitle,
-			twitterHandle,
-			bylineImageUrl,
-			contributorLargeImagePath,
-		} = properties;
+export const enhanceTags = (tags: FETagType[]): TagType[] =>
+	tags.map((tag) => enhanceTag(tag));
 
-		return {
-			id,
-			type: tagType,
-			title: webTitle,
-			twitterHandle,
-			bylineImageUrl,
-			bylineLargeImageUrl: contributorLargeImagePath,
-		};
-	});
+const enhanceTag = ({ properties }: FETagType): TagType => {
+	const {
+		id,
+		tagType,
+		webTitle,
+		twitterHandle,
+		bylineImageUrl,
+		contributorLargeImagePath,
+	} = properties;
+
+	return {
+		id,
+		type: tagType,
+		title: webTitle,
+		twitterHandle,
+		bylineImageUrl,
+		bylineLargeImageUrl: contributorLargeImagePath,
+	};
 };

--- a/dotcom-rendering/src/model/enhanceTags.ts
+++ b/dotcom-rendering/src/model/enhanceTags.ts
@@ -1,0 +1,23 @@
+import type { FETagType, TagType } from '../types/tag';
+
+export const enhanceTags = (tags: FETagType[]): TagType[] => {
+	return tags.map(({ properties }) => {
+		const {
+			id,
+			tagType,
+			webTitle,
+			twitterHandle,
+			bylineImageUrl,
+			contributorLargeImagePath,
+		} = properties;
+
+		return {
+			id,
+			type: tagType,
+			title: webTitle,
+			twitterHandle,
+			bylineImageUrl,
+			bylineLargeImageUrl: contributorLargeImagePath,
+		};
+	});
+};


### PR DESCRIPTION
## What does this change?

Adds the `StickyBottomBanner` island on tag pages.

## Why?

So that SDC and Braze banners can appear on these pages.

## Screenshots

A test Braze banner on a tag page when running in CODE:

<img width="1915" alt="Screenshot 2024-06-03 at 14 31 03" src="https://github.com/guardian/dotcom-rendering/assets/379839/a039e28d-2790-405b-a4fb-b802676d6548">

An SDC banner when running locally (this doesn't currently work in CODE due to CORS errors, but will work when we start using `getContributionsServiceUrl` as discussed in the comments):

<img width="1917" alt="Screenshot 2024-06-03 at 14 53 24" src="https://github.com/guardian/dotcom-rendering/assets/379839/9e783fc7-6c36-4298-b69b-95658a690d50">

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
