### PR TITLE
Replace YouTube main media e2e test

### DIFF
--- a/dotcom-rendering/playwright/tests/atom.video.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/atom.video.e2e.spec.ts
@@ -121,7 +121,7 @@ const muteYouTube = async (page: Page, iframeSelector: string) => {
 
 test.describe('YouTube Atom', () => {
 	// Skipping because the video in this article has stopped working. Investigation needed!
-	test.skip('plays main media video', async ({ page }) => {
+	test.skip('plays main media video: skipped', async ({ page }) => {
 		await fetchAndloadPageWithOverrides(
 			page,
 			'https://www.theguardian.com/uk-news/2020/dec/04/edinburgh-hit-by-thundersnow-as-sonic-boom-wakes-residents',

--- a/dotcom-rendering/playwright/tests/atom.video.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/atom.video.e2e.spec.ts
@@ -120,7 +120,8 @@ const muteYouTube = async (page: Page, iframeSelector: string) => {
 };
 
 test.describe('YouTube Atom', () => {
-	test('plays main media video', async ({ page }) => {
+	// Skipping because the video in this article has stopped working. Investigation needed!
+	test.skip('plays main media video', async ({ page }) => {
 		await fetchAndloadPageWithOverrides(
 			page,
 			'https://www.theguardian.com/uk-news/2020/dec/04/edinburgh-hit-by-thundersnow-as-sonic-boom-wakes-residents',
@@ -154,6 +155,57 @@ test.describe('YouTube Atom', () => {
 			adUnit: '/59666047/theguardian.com/uk-news/article/ng',
 			pageUrl:
 				'/uk-news/2020/dec/04/edinburgh-hit-by-thundersnow-as-sonic-boom-wakes-residents',
+			rejectAll: false,
+		});
+
+		// Play video
+		await page.locator(overlaySelector).click();
+
+		// Mute video
+		await muteYouTube(page, `iframe[id^="youtube-player-${videoId}"]`);
+
+		await ophanPlayEventPromise;
+
+		await youTubeEmbedPromise;
+
+		// Video is playing, overlay is gone
+		await expectToNotExist(page, overlaySelector);
+	});
+
+	test('plays main media video', async ({ page }) => {
+		await fetchAndloadPageWithOverrides(
+			page,
+			'https://www.theguardian.com/us-news/article/2024/may/30/trump-trial-hush-money-verdict',
+			{ switchOverrides: { youtubeIma: false } },
+		);
+		await cmpAcceptAll(page);
+
+		await waitForIsland(page, 'YoutubeBlockComponent');
+
+		// Make sure overlay is displayed
+		const videoId = 'LETgTLSzWgA';
+		const overlaySelector = `[data-testid^="youtube-overlay-${videoId}"]`;
+		await expectToBeVisible(page, overlaySelector);
+
+		// YouTube has not initialised
+		const hasYouTubeIframeApi = await page.evaluate(() => {
+			return !!window.onYouTubeIframeAPIReady;
+		});
+		expect(hasYouTubeIframeApi).toBeFalsy();
+
+		// Listen for the ophan call made when the video is played
+		const ophanPlayEventPromise = interceptOphanPlayEvent({
+			page,
+			id: 'gu-video-youtube-0e4c56e6-966c-4fa4-aec2-0755d607e3f1',
+		});
+
+		// Listen for the YouTube embed call made when the video is played
+		const youTubeEmbedPromise = interceptYouTubeEmbed({
+			page,
+			videoId,
+			adUnit: '/59666047/theguardian.com/us-news/article/ng',
+			pageUrl:
+				'/us-news/article/2024/may/30/trump-trial-hush-money-verdict',
 			rejectAll: false,
 		});
 


### PR DESCRIPTION
The original test has started failing because the player doesn't load properly. Although the issue is fixed by loading a different article, more investigation is required to understand the original problem.

Closes https://github.com/guardian/dotcom-rendering/issues/11510
