### PR TITLE
add spacefinder data attribute for detection

### DIFF
--- a/dotcom-rendering/src/components/QAndAExplainer.tsx
+++ b/dotcom-rendering/src/components/QAndAExplainer.tsx
@@ -51,7 +51,7 @@ export const QAndAExplainer = ({
 	RenderArticleElement,
 }: Props) => {
 	return (
-		<>
+		<div data-spacefinder-role="nested">
 			<hr css={headingLineStyles}></hr>
 			<Subheading
 				id={slugify(qAndAExplainer.title)}
@@ -83,6 +83,6 @@ export const QAndAExplainer = ({
 					isListElement={true}
 				/>
 			))}
-		</>
+		</div>
 	);
 };


### PR DESCRIPTION
## What does this change?
Adds support for inserting ads in new block types in "Q and A Explainers"

We want to add support for inserting ads inside of blocks with `Spacefinder` , and not just around them as we currently do.

This involves adding a data attribute to the component so that `Spacefinder` can detect the element. This will allow `Spacefinder` to read the blocks within it as direct children of the element with the attribute.

The data attribute acts as 

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |
| ![before2][] | ![after2][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/49187886/9fbf17a7-292e-4538-baaf-e97baa6bcb38

[after]: https://github.com/guardian/dotcom-rendering/assets/49187886/c0b18f32-aba7-4fef-8711-c03c3621615c

[before2]: https://github.com/guardian/dotcom-rendering/assets/49187886/0e5628c2-5945-4a48-9410-b70273a90759

[after2]: https://github.com/guardian/dotcom-rendering/assets/49187886/938b66db-3def-4b8b-8339-bf61c19c17b9


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
