### PR TITLE
Less `grid-area` specificity

### DIFF
--- a/dotcom-rendering/src/components/GridItem.tsx
+++ b/dotcom-rendering/src/components/GridItem.tsx
@@ -28,6 +28,10 @@ const bodyStyles = css`
 	${getZIndex('bodyArea')}
 `;
 
+const gridArea = css`
+	grid-area: var(--grid-area);
+`;
+
 export const GridItem = ({
 	children,
 	area,
@@ -37,9 +41,10 @@ export const GridItem = ({
 		css={[
 			area === 'body' && bodyStyles,
 			area === 'right-column' && rightColumnStyles,
+			gridArea,
 		]}
 		style={{
-			gridArea: area,
+			'--grid-area': area,
 		}}
 		data-gu-name={area}
 	>


### PR DESCRIPTION
## What does this change?

Use CSS Custom properties to apply the `grid-area` so its specificity can be overriden by interactive code.

## Why?

The changes in #11503 broke immersive interactive articles, which are moving elements around, and placing them in their own grid which do not have the same defined areas.

When the dust settles, it would be beneficial for Visual to use [actual grids](https://github.com/guardian/dotcom-rendering/pull/11503#discussion_r1624333862), like:

```css
grid-template-columns:
  [title-start headline-start meta-start]
  repeat(3, 1fr)
  [meta-end standfirst-start]
  repeat(5, 1fr)
  [title-end headline-end standfirst-end]
  repeat(7, 1fr);

grid-template-rows:
  [title-start]
  1fr
  [title-end headline-start]
  3fr
  [headline-end]
  1fr;
```

## Screenshots

N/A – it looks identical.