### PR TITLE
[Fairground 🎡] Update card background

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.stories.tsx
+++ b/dotcom-rendering/src/components/Card/Card.stories.tsx
@@ -8,8 +8,9 @@ import {
 import { from } from '@guardian/source/foundations';
 import React from 'react';
 import { splitTheme } from '../../../.storybook/decorators/splitThemeDecorator';
-import { lightDecorator } from '../../../.storybook/decorators/themeDecorator';
+import type { DCRContainerPalette } from '../../types/front';
 import type { MainMedia } from '../../types/mainMedia';
+import { FrontSection } from '../FrontSection';
 import { Section } from '../Section';
 import type { Props as CardProps } from './Card';
 import { Card } from './Card';
@@ -534,15 +535,6 @@ export const WithAnAvatar = () => {
 		</>
 	);
 };
-WithAnAvatar.decorators = [
-	lightDecorator([
-		{
-			display: ArticleDisplay.Standard,
-			design: ArticleDesign.Comment,
-			theme: Pillar.Opinion,
-		},
-	]),
-];
 
 export const WhenVerticalAndThemeOpinion = () => {
 	return (
@@ -1137,3 +1129,92 @@ export const WithLetterDesignAndShowQuotedHeadline = () => {
 
 WithLetterDesignAndShowQuotedHeadline.storyName =
 	'WithLetterDesignAndShowQuotedHeadline';
+
+export const WithSpecialPaletteVariations = () => {
+	const containerPalettes = [
+		'InvestigationPalette',
+		'LongRunningPalette',
+		'SombrePalette',
+		'BreakingPalette',
+		'EventPalette',
+		'EventAltPalette',
+		'LongRunningAltPalette',
+		'SombreAltPalette',
+		'SpecialReportAltPalette',
+	] as const satisfies readonly DCRContainerPalette[];
+
+	return (
+		<>
+			{containerPalettes.map((containerPalette) => (
+				<FrontSection
+					title={containerPalette}
+					discussionApiUrl=""
+					editionId={'UK'}
+					containerPalette={containerPalette}
+					key={containerPalette}
+				>
+					<CardWrapper>
+						<Card
+							{...basicCardProps}
+							containerPalette={containerPalette}
+							imagePositionOnDesktop="left"
+						/>
+					</CardWrapper>
+				</FrontSection>
+			))}
+		</>
+	);
+};
+
+export const DynamoWithSpecialPaletteVariations = () => {
+	const containerPalettes = [
+		'InvestigationPalette',
+		'LongRunningPalette',
+		'SombrePalette',
+		'BreakingPalette',
+		'EventPalette',
+		'EventAltPalette',
+		'LongRunningAltPalette',
+		'SombreAltPalette',
+		'SpecialReportAltPalette',
+	] as const satisfies readonly DCRContainerPalette[];
+
+	return (
+		<>
+			{containerPalettes.map((containerPalette) => (
+				<FrontSection
+					title={containerPalette}
+					discussionApiUrl=""
+					editionId={'UK'}
+					containerPalette={containerPalette}
+					key={containerPalette}
+				>
+					<CardWrapper>
+						<Card
+							{...basicCardProps}
+							containerPalette={containerPalette}
+							isDynamo={true}
+							supportingContent={[
+								{
+									...aBasicLink,
+									headline: 'Headline 1',
+									kickerText: 'Kicker',
+								},
+								{
+									...aBasicLink,
+									headline: 'Headline 2',
+									kickerText: 'Kicker',
+								},
+								{
+									...aBasicLink,
+									headline: 'Headline 3',
+									kickerText: 'Kicker',
+								},
+							]}
+						/>
+					</CardWrapper>
+				</FrontSection>
+			))}
+		</>
+	);
+};

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -594,7 +594,6 @@ export const Card = ({
 							<CardHeadline
 								headlineText={headlineText}
 								format={format}
-								containerPalette={containerPalette}
 								size={headlineSize}
 								sizeOnMobile={headlineSizeOnMobile}
 								showQuotes={showQuotes}
@@ -678,7 +677,6 @@ export const Card = ({
 									alignment="vertical"
 									containerPalette={containerPalette}
 									isDynamo={isDynamo}
-									parentFormat={format}
 								/>
 							)}
 						</div>
@@ -689,7 +687,6 @@ export const Card = ({
 			{hasSublinks && sublinkPosition === 'outer' && (
 				<SupportingContent
 					supportingContent={supportingContent}
-					parentFormat={format}
 					containerPalette={containerPalette}
 					isDynamo={isDynamo}
 					alignment={supportingContentAlignment}

--- a/dotcom-rendering/src/components/Card/components/CardWrapper.tsx
+++ b/dotcom-rendering/src/components/Card/components/CardWrapper.tsx
@@ -111,7 +111,6 @@ const hoverStyles = (
 		case ArticleDesign.Gallery:
 		case ArticleDesign.Audio:
 		case ArticleDesign.Video:
-		case ArticleDesign.LiveBlog:
 			return css`
 				:hover {
 					filter: brightness(90%);
@@ -180,10 +179,7 @@ export const CardWrapper = ({
 }: Props) => {
 	return (
 		<FormatBoundary format={format}>
-			<ContainerOverrides
-				containerPalette={containerPalette}
-				isDynamo={!!isDynamo}
-			>
+			<ContainerOverrides containerPalette={containerPalette}>
 				<div
 					css={[
 						baseCardStyles(isOnwardContent),

--- a/dotcom-rendering/src/components/CardCommentCount.importable.tsx
+++ b/dotcom-rendering/src/components/CardCommentCount.importable.tsx
@@ -85,10 +85,7 @@ export const CardCommentCount = ({
 
 	const { long, short } = formatCount(count);
 	return (
-		<ContainerOverrides
-			containerPalette={containerPalette}
-			isDynamo={!!isDynamo}
-		>
+		<ContainerOverrides containerPalette={containerPalette}>
 			<div css={containerStyles(isDynamo, isOnwardContent)}>
 				<div css={svgStyles(isDynamo, isOnwardContent)}>
 					<CommentIcon />

--- a/dotcom-rendering/src/components/CardHeadline.stories.tsx
+++ b/dotcom-rendering/src/components/CardHeadline.stories.tsx
@@ -4,7 +4,7 @@ import {
 	ArticleSpecial,
 	Pillar,
 } from '@guardian/libs';
-import { breakpoints, palette } from '@guardian/source/foundations';
+import { breakpoints } from '@guardian/source/foundations';
 import type { StoryObj } from '@storybook/react';
 import type { StoryProps } from '../../.storybook/decorators/splitThemeDecorator';
 import { splitTheme } from '../../.storybook/decorators/splitThemeDecorator';
@@ -55,11 +55,6 @@ export const Analysis: StoryObj = ({ format }: StoryProps) => (
 				showTopBorder={false}
 				showSideBorders={false}
 				padBottom={true}
-				backgroundColour={
-					format.theme === ArticleSpecial.SpecialReport
-						? palette.specialReport[300]
-						: undefined
-				}
 			>
 				<CardHeadline
 					headlineText={`This is how a ${size} ${
@@ -333,13 +328,8 @@ OpinionKicker.decorators = [
 ];
 
 export const SpecialReport: StoryObj = ({ format }: StoryProps) => (
-	<Section
-		fullWidth={true}
-		showTopBorder={false}
-		showSideBorders={false}
-		backgroundColour="grey"
-	>
-		<ContainerOverrides isDynamo={false}>
+	<Section fullWidth={true} showTopBorder={false} showSideBorders={false}>
+		<ContainerOverrides>
 			<CardHeadline
 				headlineText="This is how a Special Report card headline with kicker and quotes looks"
 				format={format}
@@ -382,16 +372,8 @@ Busy.decorators = [
 ];
 
 export const Byline: StoryObj = ({ format }: StoryProps) => (
-	<Section
-		fullWidth={true}
-		showSideBorders={false}
-		backgroundColour={
-			format.theme === ArticleSpecial.SpecialReport
-				? palette.specialReport[300]
-				: undefined
-		}
-	>
-		<ContainerOverrides isDynamo={false}>
+	<Section fullWidth={true} showSideBorders={false}>
+		<ContainerOverrides>
 			<CardHeadline
 				headlineText="I look life a buffoon. I feel incredible. And then I vomit"
 				format={format}
@@ -469,17 +451,13 @@ export const WithContainerOverrides: StoryObj = ({ format }: StoryProps) => (
 				showSideBorders={false}
 				containerPalette={containerPalette}
 			>
-				<ContainerOverrides
-					containerPalette={containerPalette}
-					isDynamo={false}
-				>
+				<ContainerOverrides containerPalette={containerPalette}>
 					<CardHeadline
 						headlineText={`This is a ${
 							Pillar[format.theme] ??
 							ArticleSpecial[format.theme] ??
 							'Unknown'
 						} headline`}
-						containerPalette={containerPalette}
 						format={format}
 						byline={`inside a ${containerPalette} container`}
 						showByline={true}

--- a/dotcom-rendering/src/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/components/CardHeadline.tsx
@@ -16,10 +16,8 @@ import {
 } from '@guardian/source/foundations';
 import { Link, SvgExternal } from '@guardian/source/react-components';
 import React from 'react';
-import { decidePalette } from '../lib/decidePalette';
 import { getZIndex } from '../lib/getZIndex';
 import { palette } from '../palette';
-import type { DCRContainerPalette } from '../types/front';
 import { Byline } from './Byline';
 import { Kicker } from './Kicker';
 import { QuoteIcon } from './QuoteIcon';
@@ -27,7 +25,6 @@ import { QuoteIcon } from './QuoteIcon';
 type Props = {
 	headlineText: string; // The text shown
 	format: ArticleFormat; // Used to decide when to add type specific styles
-	containerPalette?: DCRContainerPalette;
 	kickerText?: string;
 	showPulsingDot?: boolean;
 	hideLineBreak?: boolean;
@@ -220,10 +217,7 @@ const sublinkStyles = css`
 	}
 `;
 
-const lineStyles = (
-	format: ArticleFormat,
-	containerPalette?: DCRContainerPalette,
-) => css`
+const lineStyles = css`
 	padding-top: 1px;
 	:before {
 		display: block;
@@ -231,8 +225,7 @@ const lineStyles = (
 		top: 0;
 		left: 0;
 		content: '';
-		border-top: 1px solid
-			${decidePalette(format, containerPalette).border.cardSupporting};
+		border-top: 1px solid ${palette('--card-border-supporting')};
 
 		width: 120px;
 		${between.tablet.and.desktop} {
@@ -277,7 +270,6 @@ const isFirstWordShort = /^(\w{1,3}) \b/;
 export const CardHeadline = ({
 	headlineText,
 	format,
-	containerPalette,
 	showQuotes,
 	kickerText,
 	showPulsingDot,
@@ -311,9 +303,7 @@ export const CardHeadline = ({
 							size: sizeOnMobile ?? size,
 							fontWeight: 'medium',
 						}),
-					showLine &&
-						!isDynamo &&
-						lineStyles(format, containerPalette),
+					showLine && !isDynamo && lineStyles,
 				]}
 			>
 				<WithLink linkTo={linkTo} isDynamo={isDynamo}>

--- a/dotcom-rendering/src/components/Carousel.importable.tsx
+++ b/dotcom-rendering/src/components/Carousel.importable.tsx
@@ -100,10 +100,7 @@ const CarouselColours = ({
 }): React.ReactElement => {
 	if ('palette' in props) {
 		return (
-			<ContainerOverrides
-				containerPalette={props.palette}
-				isDynamo={false}
-			>
+			<ContainerOverrides containerPalette={props.palette}>
 				{children}
 			</ContainerOverrides>
 		);

--- a/dotcom-rendering/src/components/Carousel.stories.tsx
+++ b/dotcom-rendering/src/components/Carousel.stories.tsx
@@ -492,6 +492,7 @@ export const AllCards = () => {
 				theme: ArticleSpecial.SpecialReport,
 				design: ArticleDesign.Standard,
 			},
+			kickerText: 'Special report',
 			webPublicationDate: '2022-07-12T16:24:48.000Z',
 			headline: 'Special report example',
 			shortUrl: 'https://www.theguardian.com/p/yzmgf',
@@ -585,7 +586,7 @@ export const AllCards = () => {
 		},
 		{
 			url: 'https://www.theguardian.com/music/2023/dec/04/the-20-best-songs-of-2023',
-			linkText: 'Galleries example',
+			linkText: 'Gallery example',
 			showByline: false,
 			byline: 'Aneesa Ahmed, Ben Beaumont-Thomas and Laura Snapes',
 			image: {
@@ -595,7 +596,7 @@ export const AllCards = () => {
 			format: {
 				display: ArticleDisplay.Immersive,
 				theme: Pillar.Culture,
-				design: ArticleDesign.Picture,
+				design: ArticleDesign.Gallery,
 			},
 			webPublicationDate: '2023-12-04T06:00:35.000Z',
 			headline: 'Galleries example',
@@ -660,7 +661,7 @@ export const FrontCarousel = () => (
 				leftColSize="compact"
 				url={'https://www.theguardian.com'}
 				discussionApiUrl={discussionApiUrl}
-				palette={'BreakingPalette'}
+				palette="PodcastPalette"
 				absoluteServerTimes={true}
 			/>
 		</Section>

--- a/dotcom-rendering/src/components/ContainerOverrides.tsx
+++ b/dotcom-rendering/src/components/ContainerOverrides.tsx
@@ -6,7 +6,6 @@ import type { DCRContainerPalette } from '../types/front';
 
 type Props = {
 	children: React.ReactNode;
-	isDynamo: boolean;
 	containerPalette?: DCRContainerPalette;
 };
 
@@ -20,11 +19,7 @@ type ColourName = Parameters<typeof palette>[0];
 /**
  * Add CSS custom property overrides for palette colours in a given container
  */
-export const ContainerOverrides = ({
-	containerPalette,
-	isDynamo,
-	children,
-}: Props) => {
+export const ContainerOverrides = ({ containerPalette, children }: Props) => {
 	const { text, background, topBar, border } = containerPalette
 		? decideContainerOverrides(containerPalette)
 		: {
@@ -35,19 +30,15 @@ export const ContainerOverrides = ({
 		  };
 
 	const paletteOverrides = {
-		'--card-headline-trail-text': isDynamo
-			? text?.dynamoHeadline
-			: text?.cardHeadline,
-		'--card-footer-text': isDynamo
-			? text?.dynamoHeadline
-			: text?.cardFooter,
-		'--card-kicker-text': isDynamo ? text?.dynamoKicker : text?.cardKicker,
-		'--card-background': isDynamo ? 'transparent' : background?.card,
+		'--card-background': background?.card,
+		'--card-headline-trail-text': text?.cardHeadline,
+		'--card-footer-text': text?.cardFooter,
+		'--card-kicker-text': text?.cardKicker,
 		'--kicker-text-live': text?.liveKicker,
 		'--kicker-background-live': background?.liveKicker,
 		'--kicker-pulsing-dot-live': background?.pulsingDot,
 		'--byline': text?.cardByline,
-		'--card-border-top': isDynamo ? text?.dynamoKicker : topBar?.card,
+		'--card-border-top': topBar?.card,
 		'--carousel-text': text?.container,
 		'--carousel-title-highlight': text?.container,
 		'--carousel-border': border?.lines,

--- a/dotcom-rendering/src/components/DynamicPackage.stories.tsx
+++ b/dotcom-rendering/src/components/DynamicPackage.stories.tsx
@@ -1,8 +1,17 @@
-import { ArticleDesign, ArticleDisplay, ArticleSpecial } from '@guardian/libs';
+import {
+	ArticleDesign,
+	ArticleDisplay,
+	ArticleSpecial,
+	Pillar,
+} from '@guardian/libs';
 import { breakpoints } from '@guardian/source/foundations';
 import { discussionApiUrl } from '../../fixtures/manual/discussionApiUrl';
 import { getSublinks, trails } from '../../fixtures/manual/trails';
-import type { DCRFrontCard, DCRGroupedTrails } from '../types/front';
+import type {
+	DCRContainerPalette,
+	DCRFrontCard,
+	DCRGroupedTrails,
+} from '../types/front';
 import { DynamicPackage } from './DynamicPackage';
 import { FrontSection } from './FrontSection';
 
@@ -539,7 +548,78 @@ export const SpecialReportWithoutPalette = () => (
 		/>
 	</FrontSection>
 );
-One.storyName = 'With one standard card';
+SpecialReportWithoutPalette.storyName = 'With one standard card';
+
+export const DynamoSpecialPaletteVariations = () => {
+	const containerPalettes = [
+		'EventPalette',
+		'SombreAltPalette',
+		'EventAltPalette',
+		'InvestigationPalette',
+		'LongRunningAltPalette',
+		'LongRunningPalette',
+		'SombrePalette',
+		'BreakingPalette',
+		'SpecialReportAltPalette',
+	] as const satisfies readonly DCRContainerPalette[];
+
+	return (
+		<>
+			{containerPalettes.map((containerPalette) => (
+				<FrontSection
+					title={containerPalette}
+					showTopBorder={true}
+					discussionApiUrl={discussionApiUrl}
+					editionId={'UK'}
+					containerPalette={containerPalette}
+					key={containerPalette}
+				>
+					<DynamicPackage
+						groupedTrails={{
+							...defaultGroupedTrails,
+							standard: [
+								{
+									format: {
+										display: ArticleDisplay.Immersive,
+										theme: Pillar.News,
+										design: ArticleDesign.Standard,
+									},
+									url: '/news/2016/apr/08/mossack-fonseca-law-firm-hide-money-panama-papers',
+									kickerText: 'Mossack Fonseca',
+									headline:
+										'inside the firm that helps the super-rich hide their money',
+									showQuotedHeadline: false,
+									dataLinkName: 'news | group-0 | card-@1',
+									mainMedia: undefined,
+									showLivePlayable: false,
+									isExternalLink: false,
+									webPublicationDate:
+										'2016-04-08T12:15:09.000Z',
+									image: {
+										src: 'https://media.guim.co.uk/bc9acaefba82b18506aa4e60801d0a6af7176a44/0_106_3000_1800/3000.jpg',
+										altText: 'An office building',
+									},
+									isBoosted: false,
+									trailText:
+										'As Panama Papers shine light on offshore world, Luke Harding takes a closer look at company exploiting tropical tax havens',
+									supportingContent: [],
+									byline: 'Luke Harding',
+									snapData: {},
+									isCrossword: false,
+									discussionApiUrl,
+								},
+							],
+						}}
+						absoluteServerTimes={true}
+						imageLoading="eager"
+					/>
+				</FrontSection>
+			))}
+		</>
+	);
+};
+DynamoSpecialPaletteVariations.storyName =
+	'Dynamo with special palette variations';
 
 export const VideoSublinks = () => (
 	<FrontSection

--- a/dotcom-rendering/src/components/Kicker.stories.tsx
+++ b/dotcom-rendering/src/components/Kicker.stories.tsx
@@ -87,7 +87,6 @@ export const CardKickerWithContainerOverrides = {
 						<ContainerOverrides
 							key={containerPalette}
 							containerPalette={containerPalette}
-							isDynamo={false}
 						>
 							<div style={kickerWrapperStyles}>
 								<span

--- a/dotcom-rendering/src/components/LatestLinks.importable.stories.tsx
+++ b/dotcom-rendering/src/components/LatestLinks.importable.stories.tsx
@@ -1,7 +1,7 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
-import { breakpoints, palette } from '@guardian/source/foundations';
+import { breakpoints } from '@guardian/source/foundations';
 import fetchMock from 'fetch-mock';
 import type { PropsWithChildren } from 'react';
 import { splitTheme } from '../../.storybook/decorators/splitThemeDecorator';
@@ -10,10 +10,6 @@ import type { DCRContainerPalette } from '../types/front';
 import { ContainerOverrides } from './ContainerOverrides';
 import { Island } from './Island';
 import { LatestLinks } from './LatestLinks.importable';
-
-interface StoryArgs {
-	theme: string;
-}
 
 export default {
 	component: LatestLinks,
@@ -159,10 +155,7 @@ export const WorldCupFinal2023 = () => {
 				background-color: ${overrides.background.container};
 			`}
 		>
-			<ContainerOverrides
-				containerPalette={containerPalette}
-				isDynamo={true}
-			>
+			<ContainerOverrides containerPalette={containerPalette}>
 				<Island priority="critical">
 					<LatestLinks
 						id="/football/live/2023/aug/20/spain-v-england-womens-world-cup-final-live"
@@ -190,14 +183,12 @@ WorldCupFinal2023.decorators = [
 	),
 ];
 
-export const LondonPride2022 = ({ theme }: StoryArgs) => {
+export const LondonPride2022 = () => {
 	return (
 		<Wrapper
 			styles={css`
 				max-width: 600px;
-				background-color: ${theme === 'light'
-					? palette.news[300]
-					: 'inherit'};
+				background-color: 'inherit';
 			`}
 		>
 			<Island priority="critical">

--- a/dotcom-rendering/src/components/LatestLinks.importable.tsx
+++ b/dotcom-rendering/src/components/LatestLinks.importable.tsx
@@ -141,10 +141,7 @@ export const LatestLinks = ({
 			{data && data.blocks.length >= 3 ? (
 				data.blocks.slice(0, 3).map((block, index) => (
 					<>
-						<ContainerOverrides
-							containerPalette={containerPalette}
-							isDynamo={!!isDynamo}
-						>
+						<ContainerOverrides containerPalette={containerPalette}>
 							{index > 0 && (
 								<li
 									key={block.id + ' : divider'}

--- a/dotcom-rendering/src/components/LinkHeadline.tsx
+++ b/dotcom-rendering/src/components/LinkHeadline.tsx
@@ -92,11 +92,7 @@ export const LinkHeadline = ({
 			{!!kickerText && (
 				<Kicker
 					text={kickerText}
-					color={
-						showPulsingDot
-							? palette('--kicker-text-live')
-							: palette('--link-kicker-text')
-					}
+					color={palette('--link-kicker-text')}
 					showPulsingDot={showPulsingDot}
 					hideLineBreak={hideLineBreak}
 				/>

--- a/dotcom-rendering/src/components/MiniCard.tsx
+++ b/dotcom-rendering/src/components/MiniCard.tsx
@@ -63,10 +63,7 @@ const MiniCardPicture = ({ image, alt }: MiniCardPictureProps) => {
  */
 export const MiniCard = ({ trail, showImage, containerPalette }: Props) => {
 	return (
-		<ContainerOverrides
-			containerPalette={containerPalette}
-			isDynamo={false}
-		>
+		<ContainerOverrides containerPalette={containerPalette}>
 			<Link
 				href={trail.url}
 				priority="secondary"

--- a/dotcom-rendering/src/components/SupportingContent.stories.tsx
+++ b/dotcom-rendering/src/components/SupportingContent.stories.tsx
@@ -55,7 +55,6 @@ export const Default = () => {
 		<SupportingContent
 			supportingContent={[aBasicLink]}
 			alignment="horizontal"
-			parentFormat={aBasicLink.format}
 		/>
 	);
 };
@@ -65,7 +64,6 @@ export const WithKicker = () => {
 		<SupportingContent
 			supportingContent={[{ ...aBasicLink, kickerText: 'Kicker text' }]}
 			alignment="horizontal"
-			parentFormat={aBasicLink.format}
 		/>
 	);
 };

--- a/dotcom-rendering/src/components/SupportingContent.tsx
+++ b/dotcom-rendering/src/components/SupportingContent.tsx
@@ -1,8 +1,6 @@
 import { css } from '@emotion/react';
 import { ArticleDesign } from '@guardian/libs';
 import { from, until } from '@guardian/source/foundations';
-import { decidePalette } from '../lib/decidePalette';
-import { transparentColour } from '../lib/transparentColour';
 import { palette as themePalette } from '../palette';
 import type { DCRContainerPalette, DCRSupportingContent } from '../types/front';
 import { CardHeadline } from './CardHeadline';
@@ -16,7 +14,6 @@ type Props = {
 	alignment: Alignment;
 	containerPalette?: DCRContainerPalette;
 	isDynamo?: true;
-	parentFormat: ArticleFormat;
 };
 
 const wrapperStyles = css`
@@ -79,14 +76,7 @@ const liStyles = css`
 	}
 `;
 
-const dynamoLiStyles = (
-	format: ArticleFormat,
-	containerPalette?: DCRContainerPalette,
-) => css`
-	background-color: ${transparentColour(
-		decidePalette(format, containerPalette).background.dynamoSublink,
-		0.875,
-	)};
+const dynamoLiStyles = css`
 	/* Creates a containing block which allows Ophan heatmap to place bubbles correctly. */
 	position: relative;
 	border-top: 1px solid;
@@ -119,13 +109,9 @@ export const SupportingContent = ({
 	alignment,
 	containerPalette,
 	isDynamo,
-	parentFormat,
 }: Props) => {
 	return (
-		<ContainerOverrides
-			containerPalette={containerPalette}
-			isDynamo={!!isDynamo}
-		>
+		<ContainerOverrides containerPalette={containerPalette}>
 			<ul
 				css={[
 					wrapperStyles,
@@ -145,10 +131,7 @@ export const SupportingContent = ({
 							css={[
 								isDynamo
 									? [
-											dynamoLiStyles(
-												parentFormat,
-												containerPalette,
-											),
+											dynamoLiStyles,
 											css`
 												border-color: ${themePalette(
 													'--card-border-top',
@@ -164,7 +147,6 @@ export const SupportingContent = ({
 							<FormatBoundary format={subLink.format}>
 								<ContainerOverrides
 									containerPalette={containerPalette}
-									isDynamo={!!isDynamo}
 								>
 									<CardHeadline
 										format={subLink.format}
@@ -172,7 +154,6 @@ export const SupportingContent = ({
 										hideLineBreak={true}
 										showLine={true}
 										linkTo={subLink.url}
-										containerPalette={containerPalette}
 										isDynamo={isDynamo}
 										showPulsingDot={
 											subLink.format.design ===

--- a/dotcom-rendering/src/lib/decideContainerOverrides.ts
+++ b/dotcom-rendering/src/lib/decideContainerOverrides.ts
@@ -19,15 +19,11 @@ const textCardHeadline = (
 	containerPalette: Exclude<DCRContainerPalette, 'Branded' | 'MediaPalette'>,
 ): string => {
 	switch (containerPalette) {
-		case 'LongRunningPalette':
+		case 'InvestigationPalette':
 			return neutral[100];
-		case 'LongRunningAltPalette':
+		case 'LongRunningPalette':
 			return neutral[7];
 		case 'SombrePalette':
-			return neutral[100];
-		case 'SombreAltPalette':
-			return neutral[100];
-		case 'InvestigationPalette':
 			return neutral[100];
 		case 'BreakingPalette':
 			return neutral[100];
@@ -35,6 +31,10 @@ const textCardHeadline = (
 			return brand[300];
 		case 'EventAltPalette':
 			return brand[300];
+		case 'LongRunningAltPalette':
+			return neutral[7];
+		case 'SombreAltPalette':
+			return neutral[93];
 		case 'SpecialReportAltPalette':
 			return specialReportAlt[100];
 		case 'PodcastPalette':
@@ -141,6 +141,7 @@ const textCardKicker = (
 		case 'InvestigationPalette':
 			return brandAlt[400];
 		case 'LongRunningPalette':
+			return news[400];
 		case 'LongRunningAltPalette':
 			return news[400];
 		case 'SombrePalette':
@@ -196,7 +197,7 @@ const textCardCommentCount = (
 ): string => {
 	switch (containerPalette) {
 		case 'LongRunningPalette':
-			return neutral[86];
+			return neutral[46];
 		case 'LongRunningAltPalette':
 			return neutral[46];
 		case 'SombrePalette':
@@ -218,90 +219,6 @@ const textCardCommentCount = (
 	}
 };
 
-const textDynamoHeadline = (
-	containerPalette: Exclude<DCRContainerPalette, 'Branded' | 'MediaPalette'>,
-): string => {
-	switch (containerPalette) {
-		case 'LongRunningPalette':
-			return brand[400];
-		case 'LongRunningAltPalette':
-			return neutral[7];
-		case 'SombrePalette':
-			return neutral[100];
-		case 'SombreAltPalette':
-			return neutral[100];
-		case 'InvestigationPalette':
-			return neutral[100];
-		case 'BreakingPalette':
-			return neutral[7];
-		case 'EventPalette':
-			return brand[300];
-		case 'EventAltPalette':
-			return brand[300];
-		case 'SpecialReportAltPalette':
-			return specialReportAlt[100];
-		case 'PodcastPalette':
-			return neutral[100];
-	}
-};
-
-const textDynamoKicker = (
-	containerPalette: Exclude<DCRContainerPalette, 'Branded' | 'MediaPalette'>,
-): string => {
-	switch (containerPalette) {
-		case 'InvestigationPalette':
-			return brandAlt[200];
-
-		//
-		case 'LongRunningPalette':
-			return news[400];
-		case 'LongRunningAltPalette':
-			return news[200];
-		case 'SombrePalette':
-			return brand[800];
-		case 'SombreAltPalette':
-			return news[500];
-
-		case 'BreakingPalette':
-			return news[200];
-		case 'EventPalette':
-			return news[400];
-		case 'EventAltPalette':
-			return news[400];
-		case 'SpecialReportAltPalette':
-			return neutral[7];
-		case 'PodcastPalette':
-			return news[600];
-	}
-};
-
-const textDynamoSublinkKicker = (
-	containerPalette: Exclude<DCRContainerPalette, 'Branded' | 'MediaPalette'>,
-): string => {
-	switch (containerPalette) {
-		case 'LongRunningPalette':
-			return news[550];
-		case 'LongRunningAltPalette':
-			return news[200];
-		case 'SombrePalette':
-			return brand[800];
-		case 'SombreAltPalette':
-			return news[500];
-		case 'InvestigationPalette':
-			return brandAlt[400];
-		case 'BreakingPalette':
-			return news[200];
-		case 'EventPalette':
-			return news[400];
-		case 'EventAltPalette':
-			return news[400];
-		case 'SpecialReportAltPalette':
-			return neutral[7];
-		case 'PodcastPalette':
-			return news[600];
-	}
-};
-
 const textLiveKicker = (
 	containerPalette: Exclude<DCRContainerPalette, 'Branded' | 'MediaPalette'>,
 ): string => {
@@ -309,6 +226,7 @@ const textLiveKicker = (
 		case 'InvestigationPalette':
 			return specialReport[400];
 		case 'LongRunningPalette':
+			return neutral[97];
 		case 'LongRunningAltPalette':
 			return neutral[97];
 		case 'SombrePalette':
@@ -328,53 +246,27 @@ const textLiveKicker = (
 	}
 };
 
-const textDynamoMeta = (
-	containerPalette: Exclude<DCRContainerPalette, 'Branded' | 'MediaPalette'>,
-): string => {
-	switch (containerPalette) {
-		case 'LongRunningPalette':
-			return brand[400];
-		case 'LongRunningAltPalette':
-			return neutral[86];
-		case 'SombrePalette':
-			return specialReport[300];
-		case 'SombreAltPalette':
-			return specialReport[100];
-		case 'InvestigationPalette':
-			return specialReport[300];
-		case 'BreakingPalette':
-			return news[200];
-		case 'EventPalette':
-			return neutral[93];
-		case 'EventAltPalette':
-			return neutral[93];
-		case 'SpecialReportAltPalette':
-			return specialReportAlt[800];
-		case 'PodcastPalette':
-			return neutral[93];
-	}
-};
-
 const textContainer = (containerPalette: DCRContainerPalette): string => {
 	switch (containerPalette) {
+		case 'InvestigationPalette':
+			return neutral[100];
 		case 'LongRunningPalette':
-			return brand[400];
-		case 'LongRunningAltPalette':
 			return neutral[7];
 		case 'SombrePalette':
 			return neutral[100];
-		case 'SombreAltPalette':
-			return neutral[100];
-		case 'InvestigationPalette':
-			return neutral[100];
 		case 'BreakingPalette':
-			return neutral[7];
+			return neutral[100];
 		case 'EventPalette':
 			return brand[300];
 		case 'EventAltPalette':
 			return brand[300];
+		case 'LongRunningAltPalette':
+			return neutral[7];
+		case 'SombreAltPalette':
+			return neutral[93];
 		case 'SpecialReportAltPalette':
 			return specialReportAlt[100];
+		// Branded is expected to be used with LabsSection
 		case 'Branded':
 			return neutral[100];
 		case 'MediaPalette':
@@ -405,7 +297,7 @@ const textContainerToggle = (containerPalette: DCRContainerPalette): string => {
 		case 'SpecialReportAltPalette':
 			return neutral[60];
 		case 'Branded':
-			return neutral[46];
+			return neutral[7];
 		case 'MediaPalette':
 			return neutral[46];
 		case 'PodcastPalette':
@@ -473,22 +365,22 @@ const borderLines = (containerPalette: DCRContainerPalette): string => {
 
 const backgroundContainer = (containerPalette: DCRContainerPalette): string => {
 	switch (containerPalette) {
-		case 'LongRunningPalette':
-			return specialReport[700];
-		case 'LongRunningAltPalette':
-			return '#f2f2f2';
-		case 'SombrePalette':
-			return specialReport[400];
-		case 'SombreAltPalette':
-			return specialReport[300];
 		case 'InvestigationPalette':
 			return specialReport[400];
-		case 'BreakingPalette':
-			return neutral[100];
-		case 'EventPalette':
+		case 'LongRunningPalette':
 			return sport[800];
+		case 'SombrePalette':
+			return specialReport[300];
+		case 'BreakingPalette':
+			return news[200];
+		case 'EventPalette':
+			return specialReport[800];
 		case 'EventAltPalette':
 			return culture[800];
+		case 'LongRunningAltPalette':
+			return neutral[93];
+		case 'SombreAltPalette':
+			return neutral[7];
 		case 'SpecialReportAltPalette':
 			return specialReportAlt[800];
 		case 'Branded':
@@ -497,48 +389,6 @@ const backgroundContainer = (containerPalette: DCRContainerPalette): string => {
 			return neutral[0];
 		case 'PodcastPalette':
 			return neutral[100];
-	}
-};
-
-const backgroundCard = (
-	containerPalette: Exclude<DCRContainerPalette, 'Branded' | 'MediaPalette'>,
-): string => {
-	switch (containerPalette) {
-		case 'LongRunningPalette':
-			return brand[400];
-		case 'LongRunningAltPalette':
-			return neutral[86];
-		case 'SombrePalette':
-			return specialReport[300];
-		case 'SombreAltPalette':
-			return specialReport[100];
-		case 'InvestigationPalette':
-			return specialReport[300];
-		case 'BreakingPalette':
-			return news[200];
-		case 'EventPalette':
-			return neutral[93];
-		case 'EventAltPalette':
-			return culture[700];
-		case 'SpecialReportAltPalette':
-			return specialReportAlt[700];
-		case 'PodcastPalette':
-			return neutral[20];
-	}
-};
-
-const backgroundDynamoSublink = (
-	containerPalette: DCRContainerPalette,
-): string => {
-	switch (containerPalette) {
-		case 'SombrePalette':
-			return specialReport[300];
-		case 'SombreAltPalette':
-			return specialReport[100];
-		case 'InvestigationPalette':
-			return specialReport[300];
-		default:
-			return palette.neutral[97];
 	}
 };
 
@@ -623,6 +473,7 @@ export const decideContainerOverrides = (
 				carouselArrow: borderCarouselArrow(containerPalette),
 			},
 			background: {
+				card: 'transparent',
 				container: backgroundContainer(containerPalette),
 				containerLeftColumn:
 					backgroundContainerLeftColumn(containerPalette),
@@ -631,7 +482,6 @@ export const decideContainerOverrides = (
 				carouselArrow: backgroundCarouselArrow(containerPalette),
 				carouselArrowHover:
 					backgroundCarouselArrowHover(containerPalette),
-				dynamoSublink: backgroundDynamoSublink(containerPalette),
 			},
 		};
 	}
@@ -650,13 +500,13 @@ export const decideContainerOverrides = (
 				carouselArrow: borderCarouselArrow(containerPalette),
 			},
 			background: {
+				card: 'transparent',
 				container: backgroundContainer(containerPalette),
 				containerOuter: backgroundContainerOuter(containerPalette),
 				carouselDot: backgroundCarouselDot(containerPalette),
 				carouselArrow: backgroundCarouselArrow(containerPalette),
 				carouselArrowHover:
 					backgroundCarouselArrowHover(containerPalette),
-				dynamoSublink: backgroundDynamoSublink(containerPalette),
 			},
 		};
 	}
@@ -668,11 +518,7 @@ export const decideContainerOverrides = (
 			cardByline: textCardByline(containerPalette),
 			cardFooter: textCardFooter(containerPalette),
 			cardCommentCount: textCardCommentCount(containerPalette),
-			dynamoHeadline: textDynamoHeadline(containerPalette),
-			dynamoKicker: textDynamoKicker(containerPalette),
 			liveKicker: textLiveKicker(containerPalette),
-			dynamoSublinkKicker: textDynamoSublinkKicker(containerPalette),
-			dynamoMeta: textDynamoMeta(containerPalette),
 			container: textContainer(containerPalette),
 			containerToggle: textContainerToggle(containerPalette),
 			containerDate: textContainerDate(containerPalette),
@@ -685,12 +531,11 @@ export const decideContainerOverrides = (
 			carouselArrow: borderCarouselArrow(containerPalette),
 		},
 		background: {
+			card: 'transparent',
 			container: backgroundContainer(containerPalette),
-			card: backgroundCard(containerPalette),
 			carouselDot: backgroundCarouselDot(containerPalette),
 			carouselArrow: backgroundCarouselArrow(containerPalette),
 			carouselArrowHover: backgroundCarouselArrowHover(containerPalette),
-			dynamoSublink: backgroundDynamoSublink(containerPalette),
 			liveKicker: backgroundLiveKicker(containerPalette),
 			pulsingDot: backgroundPulsingDot(containerPalette),
 		},

--- a/dotcom-rendering/src/lib/decidePalette.ts
+++ b/dotcom-rendering/src/lib/decidePalette.ts
@@ -550,8 +550,6 @@ const textYoutubeOverlayKicker = (format: ArticleFormat) => {
 	}
 };
 
-const backgroundDynamoSublink = (): string => palette.neutral[97];
-
 export const decidePalette = (
 	format: ArticleFormat,
 	containerPalette?: DCRContainerPalette,
@@ -590,9 +588,6 @@ export const decidePalette = (
 			treat: backgroundTreat(format),
 			designTag: backgroundDesignTag(format),
 			messageForm: backgroundMessageForm(format),
-			dynamoSublink:
-				overrides?.background.dynamoSublink ??
-				backgroundDynamoSublink(),
 		},
 		fill: {
 			guardianLogo: fillGuardianLogo(format),

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -2400,76 +2400,83 @@ const cardBorderTopLight: PaletteFunction = ({ theme, design }) => {
 const cardBorderTopDark = (): string => {
 	return sourcePalette.neutral[20];
 };
-const cardAgeTextLight: PaletteFunction = (format) => {
-	if (format.theme === ArticleSpecial.SpecialReportAlt) {
-		return sourcePalette.specialReportAlt[100];
-	}
 
+const cardBorderSupportingLight: PaletteFunction = (format) => {
 	switch (format.design) {
 		case ArticleDesign.Comment:
 		case ArticleDesign.Letter:
 			switch (format.theme) {
 				case ArticleSpecial.SpecialReport:
+					return sourcePalette.opinion[550];
+				default:
 					return sourcePalette.neutral[86];
-				default:
-					return sourcePalette.neutral[46];
 			}
-		case ArticleDesign.LiveBlog:
+		case ArticleDesign.Gallery:
+		case ArticleDesign.Audio:
+		case ArticleDesign.Video:
 			switch (format.theme) {
+				case ArticleSpecial.SpecialReport:
+					return sourcePalette.brandAlt[400];
+				case ArticleSpecial.SpecialReportAlt:
+					return sourcePalette.news[600];
+				case Pillar.News:
+					return sourcePalette.news[600];
+				case Pillar.Sport:
+					return sourcePalette.sport[600];
+				case Pillar.Opinion:
+					return sourcePalette.opinion[550];
+				case Pillar.Lifestyle:
+					return sourcePalette.lifestyle[500];
+				case Pillar.Culture:
+					return sourcePalette.culture[500];
 				case ArticleSpecial.Labs:
-					return sourcePalette.neutral[7];
+					return sourcePalette.labs[400];
 				default:
-					return sourcePalette.neutral[100];
+					return sourcePalette.neutral[86];
 			}
+		default:
+			switch (format.theme) {
+				case ArticleSpecial.SpecialReport:
+					return sourcePalette.brandAlt[400];
+				default:
+					return sourcePalette.neutral[86];
+			}
+	}
+};
+
+const cardMetaTextLight: PaletteFunction = (format) => {
+	switch (format.design) {
 		case ArticleDesign.Gallery:
 		case ArticleDesign.Audio:
 		case ArticleDesign.Video:
 			return sourcePalette.neutral[86];
 		default:
 			switch (format.theme) {
-				case ArticleSpecial.SpecialReport:
-					return sourcePalette.brandAlt[400];
+				case ArticleSpecial.SpecialReportAlt:
+					return sourcePalette.specialReportAlt[100];
 				default:
 					return sourcePalette.neutral[46];
 			}
 	}
 };
 
-const cardAgeTextDark = (): string => {
+const cardMetaTextDark = (): string => {
 	return sourcePalette.neutral[60];
 };
 
 const cardOnwardContentFooterLight: PaletteFunction = ({ theme, design }) => {
-	switch (theme) {
-		case ArticleSpecial.SpecialReportAlt:
-			return sourcePalette.specialReportAlt[100];
-		case ArticleSpecial.SpecialReport:
-			return sourcePalette.brandAlt[400];
-		default: {
-			switch (design) {
-				case ArticleDesign.Gallery:
-				case ArticleDesign.Audio:
-				case ArticleDesign.Video:
-					return sourcePalette.neutral[100];
-				case ArticleDesign.LiveBlog:
-					switch (theme) {
-						case ArticleSpecial.Labs:
-							return sourcePalette.neutral[7];
-						case Pillar.News:
-						case Pillar.Sport:
-						case Pillar.Opinion:
-						case Pillar.Culture:
-						case Pillar.Lifestyle:
-						default:
-							return sourcePalette.neutral[100];
-					}
+	switch (design) {
+		case ArticleDesign.Gallery:
+		case ArticleDesign.Audio:
+		case ArticleDesign.Video:
+			return sourcePalette.neutral[100];
+		default:
+			switch (theme) {
+				case ArticleSpecial.SpecialReportAlt:
+					return sourcePalette.specialReportAlt[100];
 				default:
-					switch (theme) {
-						default:
-							return sourcePalette.neutral[46];
-					}
+					return sourcePalette.neutral[46];
 			}
-		}
 	}
 };
 
@@ -2478,61 +2485,24 @@ const cardOnwardContentFooterDark = (): string => {
 };
 
 const cardBackgroundLight: PaletteFunction = (format) => {
-	if (format.theme === ArticleSpecial.SpecialReportAlt) {
-		return sourcePalette.specialReportAlt[700];
-	}
-	if (format.theme === ArticleSpecial.SpecialReport) {
-		return sourcePalette.specialReport[300];
-	}
 	switch (format.design) {
-		case ArticleDesign.Editorial:
-		case ArticleDesign.Letter:
-		case ArticleDesign.Comment:
-			return sourcePalette.opinion[800];
 		case ArticleDesign.Gallery:
 		case ArticleDesign.Audio:
 		case ArticleDesign.Video:
 			return sourcePalette.neutral[20];
-		case ArticleDesign.LiveBlog:
-			switch (format.theme) {
-				case ArticleSpecial.Labs:
-					return sourcePalette.labs[400];
-				case Pillar.News:
-				case Pillar.Sport:
-				case Pillar.Opinion:
-				case Pillar.Lifestyle:
-				case Pillar.Culture:
-					return pillarPalette(format.theme, 300);
-			}
 		default:
-			return sourcePalette.neutral[97];
+			return 'transparent';
 	}
 };
-const cardBackgroundDark: PaletteFunction = ({ design, theme }) => {
+const cardBackgroundDark: PaletteFunction = ({ design }) => {
 	switch (design) {
-		case ArticleDesign.LiveBlog:
-			switch (theme) {
-				case Pillar.Lifestyle:
-				case Pillar.Sport:
-				case Pillar.Culture:
-				case Pillar.Opinion:
-					return pillarPalette(theme, 100);
-				case ArticleSpecial.Labs:
-					return sourcePalette.labs[200];
-				case ArticleSpecial.SpecialReport:
-					return sourcePalette.specialReport[100];
-				case Pillar.News:
-				case ArticleSpecial.SpecialReportAlt:
-				default:
-					return sourcePalette.news[100];
-			}
 		case ArticleDesign.Audio:
 		case ArticleDesign.Video:
 		case ArticleDesign.Picture:
 		case ArticleDesign.Gallery:
 			return sourcePalette.neutral[10];
 		default:
-			return sourcePalette.neutral[0];
+			return 'transparent';
 	}
 };
 
@@ -2565,165 +2535,80 @@ const onwardPlaceholderBackgroundDark: PaletteFunction = ({
 		theme,
 	});
 
-const onwardContentCardBackgroundLight: PaletteFunction = ({
-	theme,
-	design,
-}) => {
-	switch (theme) {
-		case ArticleSpecial.SpecialReportAlt:
-			return sourcePalette.specialReportAlt[800];
-		case ArticleSpecial.SpecialReport:
+const onwardContentCardBackgroundLight: PaletteFunction = ({ design }) => {
+	switch (design) {
+		case ArticleDesign.Gallery:
+		case ArticleDesign.Audio:
+		case ArticleDesign.Video:
 			return sourcePalette.neutral[46];
 		default:
-			switch (design) {
-				case ArticleDesign.Gallery:
-				case ArticleDesign.Audio:
-				case ArticleDesign.Video:
-					return sourcePalette.neutral[46];
-				case ArticleDesign.LiveBlog:
-					switch (theme) {
-						case ArticleSpecial.Labs:
-							return sourcePalette.neutral[100];
-						default:
-							return pillarPalette(theme, 400);
-					}
-				default:
-					return sourcePalette.neutral[100];
-			}
+			return 'transparent';
 	}
 };
 
-const onwardContentCardBackgroundDark: PaletteFunction = ({
-	theme,
-	design,
-}) => {
-	switch (theme) {
-		case ArticleSpecial.SpecialReportAlt:
-		case ArticleSpecial.SpecialReport:
-			return sourcePalette.neutral[20];
-
-		default:
-			switch (design) {
-				case ArticleDesign.Gallery:
-				case ArticleDesign.Audio:
-				case ArticleDesign.Video:
-					return sourcePalette.neutral[20];
-				case ArticleDesign.LiveBlog:
-					switch (theme) {
-						case ArticleSpecial.Labs:
-							return sourcePalette.neutral[0];
-						default:
-							return pillarPalette(theme, 200);
-					}
-				default:
-					return sourcePalette.neutral[10];
-			}
-	}
-};
-
-const onwardContentCardHoverLight: PaletteFunction = ({ theme, design }) => {
-	switch (theme) {
-		case ArticleSpecial.SpecialReportAlt:
-			return sourcePalette.specialReportAlt[700];
-		case ArticleSpecial.SpecialReport:
+const onwardContentCardBackgroundDark: PaletteFunction = ({ design }) => {
+	switch (design) {
+		case ArticleDesign.Gallery:
+		case ArticleDesign.Audio:
+		case ArticleDesign.Video:
 			return sourcePalette.neutral[20];
 		default:
-			switch (design) {
-				case ArticleDesign.Gallery:
-				case ArticleDesign.Audio:
-				case ArticleDesign.Video:
-					return sourcePalette.neutral[20];
-				case ArticleDesign.LiveBlog:
-					switch (theme) {
-						case ArticleSpecial.Labs:
-							return sourcePalette.neutral[97];
-						default:
-							return pillarPalette(theme, 300);
-					}
-				default:
-					return sourcePalette.neutral[97];
-			}
+			return 'transparent';
 	}
 };
 
-const onwardContentCardHoverDark: PaletteFunction = ({ theme, design }) => {
-	switch (theme) {
-		case ArticleSpecial.SpecialReportAlt:
-		case ArticleSpecial.SpecialReport:
+const onwardContentCardHoverLight: PaletteFunction = ({ design }) => {
+	switch (design) {
+		case ArticleDesign.Gallery:
+		case ArticleDesign.Audio:
+		case ArticleDesign.Video:
+			return sourcePalette.neutral[20];
+		default:
+			return sourcePalette.neutral[97];
+	}
+};
+const onwardContentCardHoverDark: PaletteFunction = ({ design }) => {
+	switch (design) {
+		case ArticleDesign.Gallery:
+		case ArticleDesign.Audio:
+		case ArticleDesign.Video:
 			return sourcePalette.neutral[46];
-
 		default:
-			switch (design) {
-				case ArticleDesign.Gallery:
-				case ArticleDesign.Audio:
-				case ArticleDesign.Video:
-					return sourcePalette.neutral[46];
-				case ArticleDesign.LiveBlog:
-					switch (theme) {
-						case ArticleSpecial.Labs:
-							return sourcePalette.neutral[10];
-						default:
-							return pillarPalette(theme, 300);
-					}
-				default:
-					return sourcePalette.neutral[10];
-			}
+			return sourcePalette.neutral[10];
 	}
 };
 
 const cardHeadlineTextLight: PaletteFunction = (format) => {
-	if (format.theme === ArticleSpecial.SpecialReport) {
-		return sourcePalette.neutral[100];
-	}
-
-	if (format.theme === ArticleSpecial.SpecialReportAlt) {
-		return sourcePalette.specialReportAlt[100];
-	}
-
-	if (
-		format.design !== ArticleDesign.Gallery &&
-		format.display === ArticleDisplay.Immersive
-	) {
-		return sourcePalette.neutral[7];
-	}
-
 	switch (format.design) {
 		case ArticleDesign.Gallery:
 		case ArticleDesign.Audio:
 		case ArticleDesign.Video:
 			return sourcePalette.neutral[100];
-		case ArticleDesign.LiveBlog:
-			switch (format.theme) {
-				case ArticleSpecial.Labs:
-					return sourcePalette.neutral[7];
-				case Pillar.News:
-				case Pillar.Sport:
-				case Pillar.Opinion:
-				case Pillar.Culture:
-				case Pillar.Lifestyle:
-				default:
-					return sourcePalette.neutral[100];
-			}
 		default:
 			return sourcePalette.neutral[7];
 	}
 };
-const cardTextDark = (): string => {
+const cardTextDark: PaletteFunction = (format) => {
+	if (format.theme === ArticleSpecial.SpecialReportAlt) {
+		return sourcePalette.specialReportAlt[800];
+	}
+
 	return sourcePalette.neutral[86];
 };
 
 const cardOnwardContentTextLight: PaletteFunction = (format) => {
-	switch (format.theme) {
-		case ArticleSpecial.SpecialReportAlt:
-			return sourcePalette.specialReportAlt[100];
+	switch (format.design) {
+		case ArticleDesign.Gallery:
+		case ArticleDesign.Audio:
+		case ArticleDesign.Video:
+			return sourcePalette.neutral[100];
 		default:
-			if (
-				format.display === ArticleDisplay.Immersive &&
-				format.design === ArticleDesign.LiveBlog
-			) {
-				return sourcePalette.neutral[100];
+			switch (format.theme) {
+				case ArticleSpecial.SpecialReportAlt:
+					return sourcePalette.specialReportAlt[100];
+				default:
+					return sourcePalette.neutral[7];
 			}
-			return cardHeadlineTextLight(format);
 	}
 };
 
@@ -2770,33 +2655,7 @@ const liveKickerPulsingDot: PaletteFunction = () =>
 	transparentColour(sourcePalette.neutral[97], 0.75);
 
 const cardKickerTextLight: PaletteFunction = (format) => {
-	if (
-		format.theme === ArticleSpecial.SpecialReport &&
-		(format.design === ArticleDesign.Comment ||
-			format.design === ArticleDesign.Letter)
-	) {
-		return sourcePalette.brandAlt[400];
-	}
-	if (format.theme === ArticleSpecial.SpecialReportAlt) {
-		return sourcePalette.neutral[7];
-	}
-
-	if (format.theme === ArticleSpecial.SpecialReport) {
-		return sourcePalette.brandAlt[400];
-	}
-
 	switch (format.design) {
-		case ArticleDesign.LiveBlog:
-			switch (format.theme) {
-				case ArticleSpecial.Labs:
-					return sourcePalette.neutral[7];
-				case Pillar.News:
-					return sourcePalette.news[600];
-				case Pillar.Sport:
-					return sourcePalette.sport[600];
-				default:
-					return sourcePalette.neutral[100];
-			}
 		case ArticleDesign.Gallery:
 		case ArticleDesign.Audio:
 		case ArticleDesign.Video:
@@ -2813,11 +2672,13 @@ const cardKickerTextLight: PaletteFunction = (format) => {
 					return sourcePalette.culture[500];
 				case ArticleSpecial.Labs:
 					return sourcePalette.labs[400];
+				case ArticleSpecial.SpecialReport:
+					return sourcePalette.news[400];
+				case ArticleSpecial.SpecialReportAlt:
+					return sourcePalette.specialReportAlt[200];
 			}
 		default:
 			switch (format.theme) {
-				case ArticleSpecial.Labs:
-					return sourcePalette.labs[200];
 				case Pillar.Opinion:
 					return pillarPalette(format.theme, 300);
 				case Pillar.Sport:
@@ -2825,23 +2686,18 @@ const cardKickerTextLight: PaletteFunction = (format) => {
 				case Pillar.Lifestyle:
 				case Pillar.News:
 					return pillarPalette(format.theme, 400);
+				case ArticleSpecial.Labs:
+					return sourcePalette.labs[200];
+				case ArticleSpecial.SpecialReport:
+					return sourcePalette.news[400];
+				case ArticleSpecial.SpecialReportAlt:
+					return sourcePalette.specialReportAlt[200];
 			}
 	}
 };
 
 const cardKickerTextDark: PaletteFunction = ({ design, theme }) => {
 	switch (design) {
-		case ArticleDesign.LiveBlog:
-			switch (theme) {
-				case ArticleSpecial.Labs:
-					return sourcePalette.neutral[7];
-				case Pillar.News:
-					return sourcePalette.news[600];
-				case Pillar.Sport:
-					return sourcePalette.sport[600];
-				default:
-					return sourcePalette.neutral[100];
-			}
 		case ArticleDesign.Analysis:
 			switch (theme) {
 				case Pillar.Sport:
@@ -2875,9 +2731,9 @@ const cardKickerTextDark: PaletteFunction = ({ design, theme }) => {
 				case ArticleSpecial.Labs:
 					return sourcePalette.labs[400];
 				case ArticleSpecial.SpecialReport:
-					return sourcePalette.specialReport[500];
+					return sourcePalette.news[500];
 				case ArticleSpecial.SpecialReportAlt:
-					return sourcePalette.specialReportAlt[700];
+					return sourcePalette.specialReportAlt[200];
 			}
 		case ArticleDesign.Comment:
 		case ArticleDesign.Editorial:
@@ -2906,27 +2762,15 @@ const cardKickerTextDark: PaletteFunction = ({ design, theme }) => {
 				case ArticleSpecial.Labs:
 					return sourcePalette.labs[400];
 				case ArticleSpecial.SpecialReport:
-					return sourcePalette.specialReport[500];
+					return sourcePalette.news[400];
 				case ArticleSpecial.SpecialReportAlt:
-					return sourcePalette.news[500];
+					return sourcePalette.specialReportAlt[200];
 			}
 	}
 };
 
-const cardBackgroundHoverLight: PaletteFunction = ({ design }) => {
-	switch (design) {
-		case ArticleDesign.Editorial:
-		case ArticleDesign.Letter:
-		case ArticleDesign.Comment:
-			/* TODO: This colour is hard coded here because it does not yet
-		exist in source-foundations. Once it's been added, please
-		remove this. @siadcock is aware. */
-			/* stylelint-disable-next-line color-no-hex */
-			return '#fdf0e8';
-		default:
-			return sourcePalette.neutral[93];
-	}
-};
+const cardBackgroundHoverLight: PaletteFunction = () =>
+	sourcePalette.neutral[93];
 
 const captionTextLight: PaletteFunction = ({ design, theme }) => {
 	switch (theme) {
@@ -5947,6 +5791,10 @@ const paletteColours = {
 		light: cardBackgroundHoverLight,
 		dark: cardBackgroundDark,
 	},
+	'--card-border-supporting': {
+		light: cardBorderSupportingLight,
+		dark: cardBorderTopDark,
+	},
 	'--card-border-top': {
 		light: cardBorderTopLight,
 		dark: cardBorderTopDark,
@@ -5956,8 +5804,8 @@ const paletteColours = {
 		dark: cardOnwardContentFooterDark,
 	},
 	'--card-footer-text': {
-		light: cardAgeTextLight,
-		dark: cardAgeTextDark,
+		light: cardMetaTextLight,
+		dark: cardMetaTextDark,
 	},
 	'--card-headline-onward-content-text': {
 		light: cardOnwardContentTextLight,

--- a/dotcom-rendering/src/types/palette.ts
+++ b/dotcom-rendering/src/types/palette.ts
@@ -32,7 +32,6 @@ export type Palette = {
 		designTag: Colour;
 		lightboxDivider: Colour;
 		messageForm: Colour;
-		dynamoSublink: Colour;
 	};
 	fill: {
 		guardianLogo: Colour;
@@ -61,10 +60,6 @@ export type ContainerOverrides = {
 		cardByline?: Colour;
 		cardFooter?: Colour;
 		cardCommentCount?: Colour;
-		dynamoHeadline?: Colour;
-		dynamoKicker?: Colour;
-		dynamoSublinkKicker?: Colour;
-		dynamoMeta?: Colour;
 		container: Colour;
 		containerFooter: Colour;
 		containerToggle: Colour;
@@ -78,15 +73,14 @@ export type ContainerOverrides = {
 		carouselArrow: Colour;
 	};
 	background: {
+		card: Colour;
 		container: Colour;
 		containerLeftColumn?: Colour;
 		containerOuter?: Colour;
 		containerSummary?: Colour;
-		card?: Colour;
 		carouselDot: Colour;
 		carouselArrow: Colour;
 		carouselArrowHover: Colour;
-		dynamoSublink: Colour;
 		liveKicker?: Colour;
 		pulsingDot?: Colour;
 	};


### PR DESCRIPTION
## What does this change?

Removes background colour from most cards:
- Live blog cards lose their background pillar colour since they now have the live kicker to indicate liveness
- Most other cards lose their grey background colour
- `Video`, `Audio` and `Gallery` article designs keep their background colours
- Dynamo sublinks lose their background colour
- Unifies container background colours for special palettes with apps
- `ContainerOverrides` component no longer relies on `isDynamo` prop since styles have been consolidated between the cards themselves and dynamo special styles

What this PR does not do:
- Nicely handle card layout for cards with background remaining (`Video`, `Audio` and `Gallery` articles). This is being handled in https://github.com/guardian/dotcom-rendering/pull/11533

## Why?

Part **2** of 4 of:
1) https://github.com/guardian/dotcom-rendering/pull/11520
2) https://github.com/guardian/dotcom-rendering/pull/11522
3) https://github.com/guardian/dotcom-rendering/pull/11521
4) https://github.com/guardian/dotcom-rendering/pull/11533

As part of some UI updates for the Fairground project, designed to reduce overwhelm and make fronts tidier

See https://trello.com/c/Mf8M0yO0/46-ui-updates-background-colour-changes

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![b][] | ![a][] |
| ![b1][] | ![a1][] |
| ![b2][] | ![a2][] |


[b]: https://github.com/guardian/dotcom-rendering/assets/43961396/74436c2e-f1ec-4f66-815d-c366bdc65ade
[a]: https://github.com/guardian/dotcom-rendering/assets/43961396/31170b63-0d78-489a-a092-dd8d0454a42c
[b1]: https://github.com/guardian/dotcom-rendering/assets/43961396/7aaf9333-0f93-4a70-8f76-f56e402f0b9d
[a1]: https://github.com/guardian/dotcom-rendering/assets/43961396/890db69b-d4cb-4be4-aa4a-44f957eb1d3e
[b2]: https://github.com/guardian/dotcom-rendering/assets/43961396/da539da2-a002-42a6-bb29-6b048ad2736d
[a2]: https://github.com/guardian/dotcom-rendering/assets/43961396/d3fe579b-e976-489a-98d5-78965b60f0b9
