### PR TITLE
RR Banner: Send abandoned basket last closed

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -52,7 +52,7 @@
 		"@guardian/shimport": "1.0.2",
 		"@guardian/source": "1.0.1",
 		"@guardian/source-development-kitchen": "1.0.0",
-		"@guardian/support-dotcom-components": "2.3.1",
+		"@guardian/support-dotcom-components": "2.3.3",
 		"@guardian/tsconfig": "0.2.0",
 		"@playwright/test": "1.40.1",
 		"@sentry/browser": "7.75.1",

--- a/dotcom-rendering/src/components/StickyBottomBanner.importable.tsx
+++ b/dotcom-rendering/src/components/StickyBottomBanner.importable.tsx
@@ -142,6 +142,10 @@ const buildRRBannerConfigWith = ({
 						signInBannerLastClosedAt: getBannerLastClosedAt(
 							'signInBannerLastClosedAt',
 						),
+						abandonedBasketBannerLastClosedAt:
+							getBannerLastClosedAt(
+								'abandonedBasketLastClosedAt',
+							),
 						isPreview,
 						idApiUrl,
 						signInGateWillShow,

--- a/dotcom-rendering/src/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/dotcom-rendering/src/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -234,7 +234,7 @@ export const canShowRRBanner: CanShowFunctionType<BannerProps> = async ({
 	}
 
 	//Send user consent status to the banner API
-	const userConsent = true; // await hasRequiredConsents();
+	const userConsent = await hasRequiredConsents();
 
 	const optedOutOfArticleCount = await hasOptedOutOfArticleCount();
 	const bannerPayload = await buildPayload({

--- a/dotcom-rendering/src/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/dotcom-rendering/src/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -49,6 +49,7 @@ type BaseProps = {
 	engagementBannerLastClosedAt?: string;
 	subscriptionBannerLastClosedAt?: string;
 	signInBannerLastClosedAt?: string;
+	abandonedBasketBannerLastClosedAt?: string;
 };
 
 type BuildPayloadProps = BaseProps & {
@@ -120,6 +121,7 @@ const buildPayload = async ({
 	engagementBannerLastClosedAt,
 	subscriptionBannerLastClosedAt,
 	signInBannerLastClosedAt,
+	abandonedBasketBannerLastClosedAt,
 	countryCode,
 	optedOutOfArticleCount,
 	asyncArticleCounts,
@@ -148,6 +150,7 @@ const buildPayload = async ({
 			engagementBannerLastClosedAt,
 			subscriptionBannerLastClosedAt,
 			signInBannerLastClosedAt,
+			abandonedBasketBannerLastClosedAt,
 			mvtId: Number(
 				getCookie({ name: 'GU_mvt_id', shouldMemoize: true }),
 			),
@@ -188,6 +191,7 @@ export const canShowRRBanner: CanShowFunctionType<BannerProps> = async ({
 	engagementBannerLastClosedAt,
 	subscriptionBannerLastClosedAt,
 	signInBannerLastClosedAt,
+	abandonedBasketBannerLastClosedAt,
 	isPreview,
 	idApiUrl,
 	signInGateWillShow,
@@ -230,7 +234,7 @@ export const canShowRRBanner: CanShowFunctionType<BannerProps> = async ({
 	}
 
 	//Send user consent status to the banner API
-	const userConsent = await hasRequiredConsents();
+	const userConsent = true; // await hasRequiredConsents();
 
 	const optedOutOfArticleCount = await hasOptedOutOfArticleCount();
 	const bannerPayload = await buildPayload({
@@ -247,6 +251,7 @@ export const canShowRRBanner: CanShowFunctionType<BannerProps> = async ({
 		engagementBannerLastClosedAt,
 		subscriptionBannerLastClosedAt,
 		signInBannerLastClosedAt,
+		abandonedBasketBannerLastClosedAt,
 		optedOutOfArticleCount,
 		asyncArticleCounts,
 		userConsent,

--- a/dotcom-rendering/src/lib/readerRevenueDevUtils.ts
+++ b/dotcom-rendering/src/lib/readerRevenueDevUtils.ts
@@ -22,6 +22,7 @@ const clearEpicViewLog = (): void =>
 const clearBannerLastClosedAt = (): void => {
 	storage.local.remove('gu.prefs.engagementBannerLastClosedAt');
 	storage.local.remove('gu.prefs.subscriptionBannerLastClosedAt');
+	storage.local.remove('gu.prefs.abandonedBasketLastClosedAt');
 	storage.local.remove('gu.noRRBannerTimestamp');
 };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -366,8 +366,8 @@ importers:
         specifier: 1.0.0
         version: 1.0.0(@emotion/react@11.11.1)(@guardian/libs@16.1.0)(@guardian/source@1.0.1)(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.3.3)
       '@guardian/support-dotcom-components':
-        specifier: 2.3.1
-        version: 2.3.1(zod@3.22.3)
+        specifier: 2.3.3
+        version: 2.3.3(zod@3.22.3)
       '@guardian/tsconfig':
         specifier: 0.2.0
         version: 0.2.0
@@ -4414,8 +4414,8 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@guardian/support-dotcom-components@2.3.1(zod@3.22.3):
-    resolution: {integrity: sha512-ON4ZMidt405vo6xGM3rNIbiYlskO+lE2muFkBo0kV1SurBC1x351ND6G7VZzpZPKejmATwCXYxdzvmchjjJ78w==}
+  /@guardian/support-dotcom-components@2.3.3(zod@3.22.3):
+    resolution: {integrity: sha512-nqfwhW9EfDJdI4fym+llC8q1KEJ/rgzt4bj0Lu3FSrlQGbfZhesHtvZ2zxWlhhw+cny2IvzYeyxAqDlF8fTyAw==}
     peerDependencies:
       zod: ^3.22.4
     dependencies:


### PR DESCRIPTION
## What does this change?

Adds the abandoned basket last closed time fetched from local storage to the request to show a reader revenue banner.

## Why?

This is a new channel of banners and has separate show and hide logic from the existing banners.

## Screenshots

New banner:
![image](https://github.com/guardian/dotcom-rendering/assets/114918544/27a515c6-e305-48fa-8075-f563d6b2925a)

New item in payload
![image](https://github.com/guardian/dotcom-rendering/assets/114918544/fa1806c3-73c6-443f-89bd-30216929fecc)


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
