### PR TITLE
fix: interactive expect no right column

### DIFF
--- a/dotcom-rendering/src/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/InteractiveLayout.tsx
@@ -87,7 +87,7 @@ const InteractiveGrid = ({ children }: { children: React.ReactNode }) => (
 					Main content
 				*/
 				${from.wide} {
-					grid-template-columns: 219px 1px 620px;
+					grid-template-columns: 219px 1px 1020px;
 
 					grid-template-areas:
 						'title  border  headline'
@@ -108,7 +108,7 @@ const InteractiveGrid = ({ children }: { children: React.ReactNode }) => (
 					Main content
 				*/
 				${until.wide} {
-					grid-template-columns: 140px 1px 620px;
+					grid-template-columns: 140px 1px 940px;
 
 					grid-template-areas:
 						'title  border  headline'


### PR DESCRIPTION
## What does this change?

Make the `InteractiveLayout` grid span the whole width of the article

## Why?

There’s not right column for this layout

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before-rent][] | ![after-rent][] |
| ![before-elections][] | ![after-elections][] |

[before-rent]: https://github.com/guardian/dotcom-rendering/assets/76776/90c1bf8e-2f47-4a47-aac6-579604378363
[after-rent]: https://github.com/guardian/dotcom-rendering/assets/76776/415dd6d7-1a3c-44e0-9fd4-3faa567b57d1

[before-elections]: https://github.com/guardian/dotcom-rendering/assets/76776/65a20121-da1e-4d61-9398-2879b8ddf130
[after-elections]: https://github.com/guardian/dotcom-rendering/assets/76776/39f7cc2d-03b8-4286-a048-4be6084ee6e0