### PR TITLE
Remove `darkModeInApps` switch

### DIFF
--- a/dotcom-rendering/src/components/ArticlePage.tsx
+++ b/dotcom-rendering/src/components/ArticlePage.tsx
@@ -57,7 +57,7 @@ export const ArticlePage = (props: WebProps | AppProps) => {
 	const webLightbox = isWeb && !!article.config.switches.lightbox;
 	const darkModeAvailable = isWeb
 		? article.config.abTests.darkModeWebVariant === 'variant'
-		: !!article.config.switches.darkModeInApps;
+		: true;
 
 	return (
 		<StrictMode>

--- a/dotcom-rendering/src/server/render.article.apps.tsx
+++ b/dotcom-rendering/src/server/render.article.apps.tsx
@@ -25,7 +25,7 @@ export const renderArticle = (
 	const renderingTarget = 'Apps';
 	const config: Config = {
 		renderingTarget,
-		darkModeAvailable: !!article.config.switches.darkModeInApps,
+		darkModeAvailable: true,
 		updateLogoAdPartnerSwitch:
 			!!article.config.switches.updateLogoAdPartner,
 		assetOrigin: ASSET_ORIGIN,


### PR DESCRIPTION
## What does this change?
Removes `darkModeInApps` switch and sets it by default to true.

See related frontend PR: https://github.com/guardian/frontend/pull/27195. It will be merged after the current one.

## Why?
We no longer need a switch. We support dark mode in Apps articles rendered by DCAR in production.

## Screenshots

Dark mode still working for Apps articles.

<img width="500" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/19683595/11a49c9d-64fe-4cff-a242-e443544a1184">

