### PR TITLE
Narrower Edition

### DIFF
--- a/dotcom-rendering/src/lib/edition.ts
+++ b/dotcom-rendering/src/lib/edition.ts
@@ -1,21 +1,11 @@
 import { isOneOf } from '@guardian/libs';
-import { isTuple, type Tuple } from './tuple';
+import { isTuple } from './tuple';
 
 type EditionId = 'UK' | 'US' | 'AU' | 'INT' | 'EUR';
 
-type Edition = {
-	url: string;
-	editionId: EditionId;
-	pageId: string;
-	longTitle: string;
-	title: string;
-	dateLocale: string;
-	timeZone: string;
-	langLocale?: string;
-	hasEditionalisedPages: boolean;
-};
+type Edition = (typeof editionList)[number];
 
-const editionList: Tuple<Edition, 5> = [
+const editionList = [
 	{
 		url: '/preference/edition/uk',
 		editionId: 'UK',
@@ -71,7 +61,17 @@ const editionList: Tuple<Edition, 5> = [
 		langLocale: 'en',
 		hasEditionalisedPages: false,
 	},
-];
+] as const satisfies ReadonlyArray<{
+	url: string;
+	editionId: EditionId;
+	pageId: string;
+	longTitle: string;
+	title: string;
+	dateLocale: string;
+	timeZone: string;
+	langLocale?: string;
+	hasEditionalisedPages: boolean;
+}>;
 
 const [ukEdition] = editionList;
 


### PR DESCRIPTION
## What does this change?

Infer the locale and time zone from the definition. 

## Why?

Narrower union types:

```ts
type TimeZone = Edition["timeZone"];
//   ^? 'Europe/London' | 'America/New_York' | 'Australia/Sydney' | 'Europe/Paris'
type DateLocale = Edition["dateLocale"];
//   ^? 'en-gb' | 'en-us' | 'en-au'
```