### PR TITLE
More consistent `<time>` element

### DIFF
--- a/dotcom-rendering/src/components/DateTime.tsx
+++ b/dotcom-rendering/src/components/DateTime.tsx
@@ -51,8 +51,8 @@ const formatTime = (date: Date, locale: string, timeZone: string) =>
 const ONE_MINUTE = 60_000;
 /** https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_epoch_timestamps_and_invalid_date */
 const MAX_DATE = 8.64e15;
-/** Rounded up to the next minute as most pages are cached for a least a minute */
-const getServerTime = () => Math.ceil(Date.now() / ONE_MINUTE) * ONE_MINUTE;
+/** Rounded down to the previous minute, to ensure relative times rarely go backwards */
+const getServerTime = () => Math.floor(Date.now() / ONE_MINUTE) * ONE_MINUTE;
 
 export const DateTime = ({
 	date,
@@ -72,6 +72,7 @@ export const DateTime = ({
 			<RelativeTime
 				then={then}
 				now={absoluteServerTimes ? MAX_DATE : getServerTime()}
+				editionId={editionId}
 			/>
 		</Island>
 	) : (

--- a/dotcom-rendering/src/components/RelativeTime.importable.test.tsx
+++ b/dotcom-rendering/src/components/RelativeTime.importable.test.tsx
@@ -17,7 +17,9 @@ describe('RelativeTime', () => {
 	])('For a difference of %s seconds, show “%s”', (difference, expected) => {
 		const now = Date.now();
 		const then = now - difference * 1000;
-		const { getByText } = render(<RelativeTime then={then} now={now} />);
+		const { getByText } = render(
+			<RelativeTime then={then} now={now} editionId="UK" />,
+		);
 
 		expect(getByText(expected)).toBeDefined();
 	});
@@ -25,7 +27,9 @@ describe('RelativeTime', () => {
 	test('Eight days ago is absolute', () => {
 		const now = Date.now();
 		const then = now - 8 * 24 * 60 * 60 * 1000;
-		const { getByText } = render(<RelativeTime then={then} now={now} />);
+		const { getByText } = render(
+			<RelativeTime then={then} now={now} editionId="UK" />,
+		);
 
 		const expected = new Date(then).toLocaleString('en-GB', {
 			day: 'numeric',

--- a/dotcom-rendering/src/components/RelativeTime.importable.tsx
+++ b/dotcom-rendering/src/components/RelativeTime.importable.tsx
@@ -1,5 +1,6 @@
 import { isString, timeAgo } from '@guardian/libs';
 import { useEffect, useState } from 'react';
+import { type EditionId, getEditionFromId } from '../lib/edition';
 import { useIsInView } from '../lib/useIsInView';
 
 type Props = {
@@ -7,6 +8,7 @@ type Props = {
 	then: number;
 	/** the time to compare to */
 	now: number;
+	editionId: EditionId;
 };
 
 const ONE_MINUTE = 60_000;
@@ -54,7 +56,7 @@ const relativeTime = (
  *
  * We update the relative time on the browser on an interval.
  */
-export const RelativeTime = ({ then, now }: Props) => {
+export const RelativeTime = ({ then, now, editionId }: Props) => {
 	const [inView, ref] = useIsInView({ repeat: true });
 	const [display, setDisplay] = useState(relativeTime(then, now, 'server'));
 
@@ -68,12 +70,14 @@ export const RelativeTime = ({ then, now }: Props) => {
 	}, [inView, now, then]);
 
 	const date = new Date(then);
+	const { dateLocale, timeZone } = getEditionFromId(editionId);
 
 	return (
 		<time
 			ref={ref}
 			dateTime={date.toISOString()}
-			title={date.toLocaleDateString('en-GB', {
+			data-locale={dateLocale}
+			title={date.toLocaleDateString(dateLocale, {
 				hour: '2-digit',
 				minute: '2-digit',
 				weekday: 'long',
@@ -81,6 +85,7 @@ export const RelativeTime = ({ then, now }: Props) => {
 				month: 'long',
 				day: 'numeric',
 				timeZoneName: 'long',
+				timeZone,
 			})}
 		>
 			{display}


### PR DESCRIPTION
## What does this change?

Use the same title formatting for absolute and relative times.

## Why?

Consistency is key!

Follow-up on #11505 

## Difference

```diff
 <time
   datetime="2024-06-04T15:00:22.000Z"
+  data-locale="en-gb"
-  title="Tuesday 4 June 2024 at 15:00 Coordinated Universal Time"
+  title="Tuesday 4 June 2024 at 16:00 British Summer Time"
 >4m ago</time>
```