### PR TITLE
Fix match Deadblogs series colour

### DIFF
--- a/dotcom-rendering/src/components/ArticleTitle.stories.tsx
+++ b/dotcom-rendering/src/components/ArticleTitle.stories.tsx
@@ -262,7 +262,7 @@ export const LiveblogTitle = ({ theme }: StoryArgs) => {
 					/* stylelint-disable-next-line color-no-hex */
 					background-color: ${theme === 'light'
 						? '#ffe500'
-						: 'inherit'};
+						: '#f3c100'};
 				`}
 			>
 				<ArticleTitle

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -4782,11 +4782,22 @@ const seriesTitleTextDark: PaletteFunction = ({ design, theme, display }) => {
 const seriesTitleMatchTextLight: PaletteFunction = (format) => {
 	if (
 		format.design === ArticleDesign.MatchReport ||
-		format.design === ArticleDesign.LiveBlog
+		format.design === ArticleDesign.LiveBlog ||
+		format.design === ArticleDesign.DeadBlog
 	) {
 		return sourcePalette.neutral[7];
 	}
 	return seriesTitleTextLight(format);
+};
+const seriesTitleMatchTextDark: PaletteFunction = (format) => {
+	if (
+		format.design === ArticleDesign.MatchReport ||
+		format.design === ArticleDesign.LiveBlog ||
+		format.design === ArticleDesign.DeadBlog
+	) {
+		return sourcePalette.neutral[7];
+	}
+	return seriesTitleTextDark(format);
 };
 
 const recaptchaButtonLight: PaletteFunction = () => sourcePalette.neutral[0];
@@ -6340,7 +6351,7 @@ const paletteColours = {
 	},
 	'--series-title-match-text': {
 		light: seriesTitleMatchTextLight,
-		dark: seriesTitleTextDark,
+		dark: seriesTitleMatchTextDark,
 	},
 	'--series-title-text': {
 		light: seriesTitleTextLight,

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -5405,7 +5405,7 @@ const codeBlockTextShadowLight: PaletteFunction = () =>
 	sourcePalette.neutral[100];
 const codeBlockTextShadowDark: PaletteFunction = () => sourcePalette.neutral[0];
 
-const lastUpdatedText: PaletteFunction = ({ theme, design }) => {
+const lastUpdatedTextLight: PaletteFunction = ({ theme, design }) => {
 	switch (design) {
 		case ArticleDesign.LiveBlog:
 			switch (theme) {
@@ -5423,6 +5423,26 @@ const lastUpdatedText: PaletteFunction = ({ theme, design }) => {
 			}
 		default:
 			return sourcePalette.neutral[0];
+	}
+};
+const lastUpdatedTextDark: PaletteFunction = ({ theme, design }) => {
+	switch (design) {
+		case ArticleDesign.LiveBlog:
+			switch (theme) {
+				case Pillar.News:
+				case Pillar.Culture:
+				case Pillar.Lifestyle:
+				case Pillar.Sport:
+				case Pillar.Opinion:
+					return pillarPalette(theme, 600);
+				case ArticleSpecial.Labs:
+				case ArticleSpecial.SpecialReportAlt:
+					return sourcePalette.news[600];
+				case ArticleSpecial.SpecialReport:
+					return sourcePalette.specialReport[700];
+			}
+		default:
+			return sourcePalette.neutral[93];
 	}
 };
 
@@ -6122,8 +6142,8 @@ const paletteColours = {
 		dark: keyEventTitleDark,
 	},
 	'--last-updated-text': {
-		light: lastUpdatedText,
-		dark: lastUpdatedText,
+		light: lastUpdatedTextLight,
+		dark: lastUpdatedTextDark,
 	},
 	'--link-kicker-text': {
 		light: linkKickerTextLight,


### PR DESCRIPTION
## What does this change?

Adjust dark mode colours on match live/dead blogs

## Why?

They are invisible or hard to read

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/76776/c4a14750-617d-4699-840f-004aabad119f
[after]: https://github.com/guardian/dotcom-rendering/assets/76776/96a3a790-e81f-45a0-818a-353719b392ee
