### PR TITLE
Unique Liveblog blocks

### DIFF
--- a/dotcom-rendering/src/components/Liveness.importable.tsx
+++ b/dotcom-rendering/src/components/Liveness.importable.tsx
@@ -39,6 +39,12 @@ function insert(
 	template.innerHTML = html;
 	const fragment = template.content;
 
+	// Remove duplicates
+	// -----------------
+	for (const article of template.querySelectorAll('article')) {
+		if (document.getElementById(article.id)) article.remove();
+	}
+
 	// Hydrate
 	// -------
 	const islands = fragment.querySelectorAll<HTMLElement>('gu-island');


### PR DESCRIPTION
## What does this change?

Ensure that dynamically inserted blog blocks do not share an ID with what is currently on the page.

## Why?

There has been mounting reports of double identical blocks at the top of blogs. It’s also invalid HTML to have two elements with the same ID:

> The [id](https://html.spec.whatwg.org/multipage/dom.html#the-id-attribute) attribute specifies its element's [unique identifier (ID)](https://dom.spec.whatwg.org/#concept-id).

## Screenshots

Unfortunately I was not able to reproduce, but CP has shared the following:

![double identical blocks](https://github.com/guardian/dotcom-rendering/assets/76776/69ee3e88-cadb-4a09-8cc8-19dcb44af6d1)
