### PR TITLE
Pass star rating to carousel cards

### DIFF
--- a/dotcom-rendering/src/components/Carousel.importable.tsx
+++ b/dotcom-rendering/src/components/Carousel.importable.tsx
@@ -15,6 +15,7 @@ import { getZIndex } from '../lib/getZIndex';
 import { useIsAndroid } from '../lib/useIsAndroid';
 import { palette as themePalette } from '../palette';
 import type { Branding } from '../types/branding';
+import type { StarRating } from '../types/content';
 import type {
 	DCRContainerPalette,
 	DCRContainerType,
@@ -475,6 +476,7 @@ type CarouselCardProps = {
 	mainMedia?: MainMedia;
 	onwardsSource?: OnwardsSource;
 	containerType?: DCRContainerType;
+	starRating?: StarRating;
 };
 
 const CarouselCard = ({
@@ -495,6 +497,7 @@ const CarouselCard = ({
 	discussionApiUrl,
 	isOnwardContent,
 	absoluteServerTimes,
+	starRating,
 }: CarouselCardProps) => {
 	const isVideoContainer = containerType === 'fixed/video';
 	const cardImagePosition = isOnwardContent ? 'bottom' : 'top';
@@ -538,6 +541,7 @@ const CarouselCard = ({
 				imagePosition={cardImagePosition}
 				imagePositionOnMobile={cardImagePosition}
 				absoluteServerTimes={absoluteServerTimes}
+				starRating={starRating}
 			/>
 		</LI>
 	);
@@ -977,6 +981,7 @@ export const Carousel = ({
 								branding,
 								discussion,
 								mainMedia,
+								starRating,
 							} = trail;
 
 							// Don't try to render cards that have no publication date. This property is technically optional
@@ -1014,6 +1019,7 @@ export const Carousel = ({
 									imageLoading={imageLoading}
 									discussionApiUrl={discussionApiUrl}
 									isOnwardContent={isOnwardContent}
+									starRating={starRating}
 								/>
 							);
 						})}

--- a/dotcom-rendering/src/model/article-schema.json
+++ b/dotcom-rendering/src/model/article-schema.json
@@ -4439,7 +4439,7 @@
                     "type": "number"
                 },
                 "starRating": {
-                    "type": "number"
+                    "$ref": "#/definitions/StarRating"
                 },
                 "linkText": {
                     "type": "string"

--- a/dotcom-rendering/src/model/front-schema.json
+++ b/dotcom-rendering/src/model/front-schema.json
@@ -3492,7 +3492,7 @@
                     "type": "number"
                 },
                 "starRating": {
-                    "type": "number"
+                    "$ref": "#/definitions/StarRating"
                 },
                 "linkText": {
                     "type": "string"

--- a/dotcom-rendering/src/types/trails.ts
+++ b/dotcom-rendering/src/types/trails.ts
@@ -1,4 +1,5 @@
 import type { Branding } from './branding';
+import { StarRating } from './content';
 import type { DCRFrontImage, DCRSnapType, DCRSupportingContent } from './front';
 import type { MainMedia } from './mainMedia';
 
@@ -14,7 +15,7 @@ interface BaseTrailType {
 	kickerText?: string;
 	shortUrl?: string;
 	commentCount?: number;
-	starRating?: number;
+	starRating?: StarRating;
 	linkText?: string;
 	branding?: Branding;
 	isSnap?: boolean;

--- a/dotcom-rendering/src/types/trails.ts
+++ b/dotcom-rendering/src/types/trails.ts
@@ -1,5 +1,5 @@
 import type { Branding } from './branding';
-import { StarRating } from './content';
+import type { StarRating } from './content';
 import type { DCRFrontImage, DCRSnapType, DCRSupportingContent } from './front';
 import type { MainMedia } from './mainMedia';
 


### PR DESCRIPTION
## What does this change?
Adds star ratings to carousel cards. This was left out of the DCR migration but the stars have been requested by design. This PR also tightens the type of starRating on the trail type to `StarRating` rather than `number`

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[after]: https://github.com/guardian/dotcom-rendering/assets/20416599/c35d2c6a-fca9-4082-8f8d-23b33307d159
[before]: https://github.com/guardian/dotcom-rendering/assets/20416599/976a1389-570e-45c4-8a87-5c3d884e80a4

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
