### PR TITLE
Prefer overflow-x: clip for ad-slot-container

### DIFF
--- a/dotcom-rendering/src/lib/rootStyles.ts
+++ b/dotcom-rendering/src/lib/rootStyles.ts
@@ -49,6 +49,9 @@ export const rootStyles = (
 
 	.ad-slot-container {
 		/* prevent third-party code from breaking our layout */
+		/* using hidden as a fallback for browsers that don't support clip */
 		overflow-x: hidden;
+		/* clip is our preferred choice as it allows sticky ads in the right column */
+		overflow-x: clip;
 	}
 `;


### PR DESCRIPTION
## What does this change?
Set `overflow-x: clip` for ad-slot-container divs. We've kept `overflow-x: hidden` as a fallback as there [isn't complete support](https://caniuse.com/mdn-css_properties_overflow_clip) for `clip` yet. 

## Why?
Ads in the right hand column of an article should be sticky. At the moment, the `overflow-x: hidden` value is preventing the ads from being sticky because of how it affects scrolling behaviour. This occurred as a minor side effect of [this bug fix](https://github.com/guardian/dotcom-rendering/pull/11503). Using `clip` instead fixes this and restores sticky ads. Note that for browsers that don't support `clip`, ads will not be sticky. In the future we should look at finding a more complete solution, but we're happy with this as a quicker fix for now.

## Video
Sticky ads after applying `overflow-x :clip`

https://github.com/guardian/dotcom-rendering/assets/108270776/200a252e-7a97-4ce8-b7c4-f6b1ef6c4340



