### PR TITLE
Unique Liveblog blocks (bis)

### DIFF
--- a/dotcom-rendering/src/components/Liveness.importable.tsx
+++ b/dotcom-rendering/src/components/Liveness.importable.tsx
@@ -42,7 +42,7 @@ function insert(
 
 	// Remove duplicates
 	// -----------------
-	for (const article of template.querySelectorAll('article')) {
+	for (const article of fragment.querySelectorAll('article')) {
 		if (document.getElementById(article.id)) article.remove();
 	}
 


### PR DESCRIPTION
## What does this change?

Use the `template`’s content, which is the actual HTML Fragment!

## Why?

Follow-up on a fix:
- #11536

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/76776/9a7de5a4-f95d-4a2a-b025-4ccc6da6dc06
[after]: https://github.com/guardian/dotcom-rendering/assets/76776/46916c0c-dfcc-4ede-9e9f-9293f60d3a9e
