### PR TITLE
`Liveness` improvements

### DIFF
--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -324,15 +324,6 @@ interface MessageUs {
 }
 
 // ------------
-// Liveblogs //
-// ------------
-type LiveUpdateType = {
-	numNewBlocks: number;
-	html: string;
-	mostRecentBlockId: string;
-};
-
-// ------------
 // RichLinks //
 // ------------
 type RichLinkCardType =

--- a/dotcom-rendering/playwright/tests/liveblog.interactivity.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/liveblog.interactivity.e2e.spec.ts
@@ -30,7 +30,7 @@ test.describe('Liveblogs', () => {
 		await expectToNotExist(page, `[data-testid="toast"]`);
 
 		await page.evaluate(() => {
-			window.mockLiveUpdate({
+			window.mockLiveUpdate?.({
 				numNewBlocks: 1,
 				html: '<p>New block 1</p>',
 				mostRecentBlockId: 'abc',
@@ -47,7 +47,7 @@ test.describe('Liveblogs', () => {
 		).toBeVisible();
 
 		await page.evaluate(() => {
-			window.mockLiveUpdate({
+			window.mockLiveUpdate?.({
 				numNewBlocks: 1,
 				html: '<p>New block 2</p>',
 				mostRecentBlockId: 'abc',
@@ -67,7 +67,7 @@ test.describe('Liveblogs', () => {
 		await waitForIsland(page, 'Liveness', { waitFor: 'attached' });
 
 		await page.evaluate(() => {
-			window.mockLiveUpdate({
+			window.mockLiveUpdate?.({
 				numNewBlocks: 1,
 				html: '<p>New block 1</p>',
 				mostRecentBlockId: 'abc',
@@ -88,7 +88,7 @@ test.describe('Liveblogs', () => {
 		await expectToNotExist(page, `[data-testid="toast"]`);
 
 		await page.evaluate(() => {
-			window.mockLiveUpdate({
+			window.mockLiveUpdate?.({
 				numNewBlocks: 1,
 				html: '<p>New block 1</p>',
 				mostRecentBlockId: 'abc',
@@ -114,7 +114,7 @@ test.describe('Liveblogs', () => {
 		await waitForIsland(page, 'Liveness', { waitFor: 'attached' });
 
 		await page.evaluate((block) => {
-			window.mockLiveUpdate(block);
+			window.mockLiveUpdate?.(block);
 		}, tweetBlock);
 
 		const updateLocator = page
@@ -199,7 +199,7 @@ test.describe('Liveblogs', () => {
 		await expectToNotExist(page, `[data-testid="toast"]`);
 
 		await page.evaluate(() => {
-			window.mockLiveUpdate({
+			window.mockLiveUpdate?.({
 				numNewBlocks: 1,
 				html: '<p>New block 1</p>',
 				mostRecentBlockId: 'abc',
@@ -241,7 +241,7 @@ test.describe('Liveblogs', () => {
 		);
 
 		await page.evaluate((block) => {
-			window.mockLiveUpdate(block);
+			window.mockLiveUpdate?.(block);
 		}, tweetBlock);
 
 		const tweetIframeSelector =

--- a/dotcom-rendering/src/components/LiveBlock.stories.tsx
+++ b/dotcom-rendering/src/components/LiveBlock.stories.tsx
@@ -79,6 +79,7 @@ export const VideoAsSecond = () => {
 				abTests={{}}
 				switches={{}}
 				isPinnedPost={false}
+				isLiveUpdate={false}
 				editionId={'UK'}
 			/>
 		</Wrapper>
@@ -126,6 +127,7 @@ export const Title = () => {
 				abTests={{}}
 				switches={{}}
 				isPinnedPost={false}
+				isLiveUpdate={false}
 				editionId={'UK'}
 			/>
 		</Wrapper>
@@ -194,6 +196,7 @@ export const Video = () => {
 				abTests={{}}
 				switches={{}}
 				isPinnedPost={false}
+				isLiveUpdate={false}
 				editionId={'UK'}
 			/>
 		</Wrapper>
@@ -237,6 +240,7 @@ export const RichLink = () => {
 				abTests={{}}
 				switches={{}}
 				isPinnedPost={false}
+				isLiveUpdate={false}
 				editionId={'UK'}
 			/>
 		</Wrapper>
@@ -271,6 +275,7 @@ export const FirstImage = () => {
 				abTests={{}}
 				switches={{}}
 				isPinnedPost={false}
+				isLiveUpdate={false}
 				editionId={'UK'}
 			/>
 		</Wrapper>
@@ -331,6 +336,7 @@ export const ImageRoles = () => {
 				isPinnedPost={false}
 				isAdFreeUser={false}
 				isSensitive={false}
+				isLiveUpdate={false}
 				editionId={'UK'}
 			/>
 		</Wrapper>
@@ -380,6 +386,7 @@ export const Thumbnail = () => {
 				isPinnedPost={false}
 				isAdFreeUser={false}
 				isSensitive={false}
+				isLiveUpdate={false}
 				editionId={'UK'}
 			/>
 		</Wrapper>
@@ -415,6 +422,7 @@ export const ImageAndTitle = () => {
 				abTests={{}}
 				switches={{}}
 				isPinnedPost={false}
+				isLiveUpdate={false}
 				editionId={'UK'}
 			/>
 		</Wrapper>
@@ -446,6 +454,7 @@ export const Updated = () => {
 				abTests={{}}
 				switches={{}}
 				isPinnedPost={false}
+				isLiveUpdate={false}
 				editionId={'UK'}
 			/>
 		</Wrapper>
@@ -481,6 +490,7 @@ export const Contributor = () => {
 				isPinnedPost={false}
 				isAdFreeUser={false}
 				isSensitive={false}
+				isLiveUpdate={false}
 				editionId={'UK'}
 			/>
 		</Wrapper>
@@ -514,6 +524,7 @@ export const NoAvatar = () => {
 				isPinnedPost={false}
 				isAdFreeUser={false}
 				isSensitive={false}
+				isLiveUpdate={false}
 				editionId={'UK'}
 			/>
 		</Wrapper>
@@ -550,6 +561,7 @@ export const TitleAndContributor = () => {
 				isPinnedPost={false}
 				isAdFreeUser={false}
 				isSensitive={false}
+				isLiveUpdate={false}
 				editionId={'UK'}
 			/>
 		</Wrapper>

--- a/dotcom-rendering/src/components/LiveBlock.tsx
+++ b/dotcom-rendering/src/components/LiveBlock.tsx
@@ -19,7 +19,7 @@ type Props = {
 	isSensitive: boolean;
 	abTests: ServerSideTests;
 	switches: Switches;
-	isLiveUpdate?: boolean;
+	isLiveUpdate: boolean;
 	isPinnedPost: boolean;
 	pinnedPostId?: string;
 	editionId: EditionId;

--- a/dotcom-rendering/src/components/LiveBlockContainer.tsx
+++ b/dotcom-rendering/src/components/LiveBlockContainer.tsx
@@ -22,7 +22,7 @@ type Props = {
 	blockFirstPublished?: number;
 	blockFirstPublishedDisplay?: string;
 	blockId: string;
-	isLiveUpdate?: boolean;
+	isLiveUpdate: boolean;
 	contributors?: BlockContributor[];
 	isPinnedPost: boolean;
 	absoluteServerTimes: boolean;

--- a/dotcom-rendering/src/components/LiveBlogBlocksAndAdverts.tsx
+++ b/dotcom-rendering/src/components/LiveBlogBlocksAndAdverts.tsx
@@ -20,7 +20,7 @@ type Props = {
 	switches: Switches;
 	isAdFreeUser: boolean;
 	isSensitive: boolean;
-	isLiveUpdate?: boolean;
+	isLiveUpdate: boolean;
 };
 
 const appsFirstAdIndex = 1;

--- a/dotcom-rendering/src/components/LiveBlogRenderer.tsx
+++ b/dotcom-rendering/src/components/LiveBlogRenderer.tsx
@@ -26,7 +26,7 @@ type Props = {
 	isSensitive: boolean;
 	abTests: ServerSideTests;
 	switches: Switches;
-	isLiveUpdate?: boolean;
+	isLiveUpdate: boolean;
 	sectionId: string;
 	shouldHideReaderRevenue: boolean;
 	tags: TagType[];
@@ -139,7 +139,7 @@ export const LiveBlogRenderer = ({
 						/>
 					</Hide>
 				)}
-			<div id="top-of-blog" />
+			{isLiveUpdate ? `<!-- live update --->` : <div id="top-of-blog" />}
 			<LiveBlogBlocksAndAdverts
 				blocks={blocks}
 				format={format}

--- a/dotcom-rendering/src/components/Liveness.importable.tsx
+++ b/dotcom-rendering/src/components/Liveness.importable.tsx
@@ -54,7 +54,7 @@ function insert(
 
 	// Remove duplicates
 	// -----------------
-	for (const article of template.querySelectorAll('article')) {
+	for (const article of fragment.querySelectorAll('article')) {
 		if (document.getElementById(article.id)) article.remove();
 	}
 
@@ -244,26 +244,23 @@ export const Liveness = ({
 		// Update the block id we use for polling
 		setLatestBlockId(result.output.mostRecentBlockId);
 
-		if (result.output.numNewBlocks > 0) {
-			// Insert the new blocks in the dom (but hidden)
-			if (onFirstPage && topOfBlog) {
-				try {
-					insert(result.output.html, enhanceTweetsSwitch, topOfBlog);
-				} catch (error) {
-					// eslint-disable-next-line no-console -- this is something we want to know about
-					console.error('Failed to insert new blocks', error);
-					error instanceof Error &&
-						window.guardian.modules.sentry.reportError(
-							error,
-							'liveblog',
-						);
-				}
-			}
-
-			setShowToast(true);
-			// Increment the count of new posts
-			setNumHiddenBlocks((count) => count + result.output.numNewBlocks);
+		if (result.output.numNewBlocks < 1 || !onFirstPage || !topOfBlog) {
+			return; // no need to insert new blocks as <article> in the DOM
 		}
+
+		// Insert the new blocks in the dom (but hidden)
+		try {
+			insert(result.output.html, enhanceTweetsSwitch, topOfBlog);
+		} catch (error) {
+			// eslint-disable-next-line no-console -- this is something we want to know about
+			console.error('Failed to insert new blocks', error);
+			error instanceof Error &&
+				window.guardian.modules.sentry.reportError(error, 'liveblog');
+		}
+
+		setShowToast(true);
+		// Increment the count of new posts
+		setNumHiddenBlocks((count) => count + result.output.numNewBlocks);
 	}, [data, enhanceTweetsSwitch, onFirstPage, topOfBlog]);
 
 	useEffect(() => {

--- a/dotcom-rendering/src/components/Liveness.importable.tsx
+++ b/dotcom-rendering/src/components/Liveness.importable.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
-import ReactDOM from 'react-dom';
+import { createPortal } from 'react-dom';
 import { getEmotionCache } from '../client/islands/emotion';
 import { initHydration } from '../client/islands/initHydration';
 import { useApi } from '../lib/useApi';
@@ -343,7 +343,7 @@ export const Liveness = ({
 		 * [stickily positioned element]: https://developer.mozilla.org/en-US/docs/Web/CSS/position#types_of_positioning
 		 * [containing block]: https://developer.mozilla.org/en-US/docs/Web/CSS/Containing_block#identifying_the_containing_block
 		 */
-		return ReactDOM.createPortal(
+		return createPortal(
 			<Toast
 				onClick={handleToastClick}
 				count={numHiddenBlocks}

--- a/dotcom-rendering/src/components/Liveness.importable.tsx
+++ b/dotcom-rendering/src/components/Liveness.importable.tsx
@@ -36,7 +36,8 @@ function insert(
 	// Create
 	// ------
 	const template = document.createElement('template');
-	template.innerHTML = html;
+	template.innerHTML =
+		html + `<!-- inserted at ${new Date().toDateString()} -->`;
 	const fragment = template.content;
 
 	// Hydrate

--- a/dotcom-rendering/src/components/Liveness.importable.tsx
+++ b/dotcom-rendering/src/components/Liveness.importable.tsx
@@ -275,8 +275,13 @@ export const Liveness = ({
 		 * updates with whatever html and properties it wants
 		 *
 		 */
+		console.warn('MUTATE', mutate);
 		window.mockLiveUpdate = (mockData) => void mutate(mockData);
 	}, [mutate]);
+
+	useEffect(() => {
+		console.warn('MUTATE', window.mockLiveUpdate);
+	}, []);
 
 	useEffect(() => {
 		document.title =

--- a/dotcom-rendering/src/components/Liveness.importable.tsx
+++ b/dotcom-rendering/src/components/Liveness.importable.tsx
@@ -197,7 +197,7 @@ export const Liveness = ({
 				} else {
 					setShowToast(true);
 					// Increment the count of new posts
-					setNumHiddenBlocks(numHiddenBlocks + data.numNewBlocks);
+					setNumHiddenBlocks((count) => count + data.numNewBlocks);
 				}
 			}
 
@@ -206,13 +206,7 @@ export const Liveness = ({
 				setLatestBlockId(data.mostRecentBlockId);
 			}
 		},
-		[
-			enhanceTweetsSwitch,
-			numHiddenBlocks,
-			onFirstPage,
-			topOfBlog,
-			topOfBlogVisible,
-		],
+		[enhanceTweetsSwitch, onFirstPage, topOfBlog, topOfBlogVisible],
 	);
 
 	useEffect(() => {

--- a/dotcom-rendering/src/components/PinnedPost.stories.tsx
+++ b/dotcom-rendering/src/components/PinnedPost.stories.tsx
@@ -140,6 +140,7 @@ export const News = () => {
 					abTests={{}}
 					switches={{}}
 					isPinnedPost={true}
+					isLiveUpdate={false}
 					editionId={'UK'}
 				/>
 			</PinnedPost>
@@ -191,6 +192,7 @@ export const Culture = () => {
 					abTests={{}}
 					switches={{}}
 					isPinnedPost={true}
+					isLiveUpdate={false}
 					editionId={'UK'}
 				/>
 			</PinnedPost>
@@ -242,6 +244,7 @@ export const Lifestyle = () => {
 					abTests={{}}
 					switches={{}}
 					isPinnedPost={true}
+					isLiveUpdate={false}
 					editionId={'UK'}
 				/>
 			</PinnedPost>
@@ -293,6 +296,7 @@ export const Opinion = () => {
 					abTests={{}}
 					switches={{}}
 					isPinnedPost={true}
+					isLiveUpdate={false}
 					editionId={'UK'}
 				/>
 			</PinnedPost>
@@ -344,6 +348,7 @@ export const SpecialReport = () => {
 					abTests={{}}
 					switches={{}}
 					isPinnedPost={true}
+					isLiveUpdate={false}
 					editionId={'UK'}
 				/>
 			</PinnedPost>
@@ -395,6 +400,7 @@ export const Labs = () => {
 					abTests={{}}
 					switches={{}}
 					isPinnedPost={true}
+					isLiveUpdate={false}
 					editionId={'UK'}
 				/>
 			</PinnedPost>

--- a/dotcom-rendering/src/components/PinnedPost.stories.tsx
+++ b/dotcom-rendering/src/components/PinnedPost.stories.tsx
@@ -88,6 +88,7 @@ export const Sport = () => {
 					abTests={{}}
 					switches={{}}
 					isPinnedPost={true}
+					isLiveUpdate={false}
 					editionId={'UK'}
 				/>
 			</PinnedPost>

--- a/dotcom-rendering/src/lib/useApi.tsx
+++ b/dotcom-rendering/src/lib/useApi.tsx
@@ -1,4 +1,5 @@
-import type { SWRConfiguration } from 'swr';
+import { isUndefined } from '@guardian/libs';
+import type { KeyedMutator, SWRConfiguration } from 'swr';
 import useSWR from 'swr';
 
 function checkForErrors(response: Response) {
@@ -20,6 +21,7 @@ interface ApiResponse<T> {
 	loading: boolean;
 	data?: T;
 	error?: Error;
+	mutate: KeyedMutator<T>;
 }
 
 /**
@@ -35,11 +37,16 @@ export const useApi = <T,>(
 	options?: SWRConfiguration,
 	init?: RequestInit,
 ): ApiResponse<T> => {
-	const { data, error } = useSWR(url, fetcher(init), options);
+	const { data, error, mutate } = useSWR<T, Error>(
+		url,
+		fetcher(init),
+		options,
+	);
 
 	return {
 		data,
 		error,
-		loading: !!url && !error && !data,
+		loading: !!url && !error && isUndefined(data),
+		mutate,
 	};
 };

--- a/dotcom-rendering/window.guardian.ts
+++ b/dotcom-rendering/window.guardian.ts
@@ -7,6 +7,7 @@ import type {
 } from '@guardian/libs';
 import type { WeeklyArticleHistory } from '@guardian/support-dotcom-components/dist/dotcom/src/types';
 import type { OphanRecordFunction } from './src/client/ophan/ophan';
+import type { LiveUpdateType } from './src/components/Liveness.importable';
 import type { google } from './src/components/YoutubeAtom/ima';
 import type { DailyArticleHistory } from './src/lib/dailyArticleCount';
 import type { ReaderRevenueDevUtils } from './src/lib/readerRevenueDevUtils';

--- a/dotcom-rendering/window.guardian.ts
+++ b/dotcom-rendering/window.guardian.ts
@@ -78,7 +78,7 @@ declare global {
 				consent: ConsentState,
 			) => boolean;
 		};
-		mockLiveUpdate: (data: LiveUpdateType) => void;
+		mockLiveUpdate?: (data: LiveUpdateType) => void;
 		google?: typeof google;
 		YT?: typeof YT;
 		onYouTubeIframeAPIReady?: () => void;


### PR DESCRIPTION
## What does this change?

A series of improvements to make `Liveness` easier to reason about.

## Why?

- `useEffect` for reacting to state
- parsing of responses
- stricter type for `useSWR`


<!--
## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png


You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
