### PR TITLE
No `div#top-of-blog` for live updates

### DIFF
--- a/dotcom-rendering/src/components/LiveBlogRenderer.tsx
+++ b/dotcom-rendering/src/components/LiveBlogRenderer.tsx
@@ -139,7 +139,7 @@ export const LiveBlogRenderer = ({
 						/>
 					</Hide>
 				)}
-			<div id="top-of-blog" />
+			{isLiveUpdate ? `<!-- live update --->` : <div id="top-of-blog" />}
 			<LiveBlogBlocksAndAdverts
 				blocks={blocks}
 				format={format}


### PR DESCRIPTION
## What does this change?

Remove the “top of blog” `div` for live updates.

## Why?

This causes invalid HTML, as we get multiple elements with the same unique identifier.