### PR TITLE
Hide label on a timeline if we don't have a valid label

### DIFF
--- a/dotcom-rendering/src/components/Timeline.tsx
+++ b/dotcom-rendering/src/components/Timeline.tsx
@@ -25,8 +25,8 @@ import { Subheading } from './Subheading';
 
 // ----- Helpers ----- //
 
-const hasTitle = (event: DCRTimelineEvent): boolean =>
-	event.title !== undefined && event.title.trim() !== '';
+const isValidString = (str?: string): boolean =>
+	str !== undefined && str.trim() !== '';
 
 const hasShowcaseRole = (element?: FEElement): boolean => {
 	if (element === undefined) return false;
@@ -114,7 +114,7 @@ const EventHeader = ({
 			<span css={smallDates ? smallDateStyles : titleStyles(format)}>
 				{event.date}
 			</span>
-			{hasTitle(event) ? (
+			{isValidString(event.title) ? (
 				<span css={titleStyles(format)}>{event.title}</span>
 			) : null}
 		</Heading>
@@ -212,41 +212,43 @@ const TimelineEvent = ({
 	sectioned,
 	smallDates,
 	format,
-}: TimelineEventProps) => (
-	<>
-		{event.label !== undefined && (
-			<div css={labelStyles}>{event.label}</div>
-		)}
-		<section
-			css={[
-				eventStyles,
-				hasShowcaseRole(event.main)
-					? immersiveMainElementEventStyles
-					: undefined,
-			]}
-		>
-			<EventHeader
-				event={event}
-				ArticleElementComponent={ArticleElementComponent}
-				sectioned={sectioned}
-				smallDates={smallDates}
-				format={format}
-			/>
-			{event.body.map((element, index) => (
-				<ArticleElementComponent
-					// eslint-disable-next-line react/no-array-index-key -- This is only rendered once so we can safely use index to suppress the warning
-					key={index}
-					index={index}
-					element={element}
-					forceDropCap="off"
+}: TimelineEventProps) => {
+	return (
+		<>
+			{isValidString(event.label) && (
+				<div css={labelStyles}>{event.label}</div>
+			)}
+			<section
+				css={[
+					eventStyles,
+					hasShowcaseRole(event.main)
+						? immersiveMainElementEventStyles
+						: undefined,
+				]}
+			>
+				<EventHeader
+					event={event}
+					ArticleElementComponent={ArticleElementComponent}
+					sectioned={sectioned}
+					smallDates={smallDates}
 					format={format}
-					isTimeline={true}
-					isMainMedia={false}
 				/>
-			))}
-		</section>
-	</>
-);
+				{event.body.map((element, index) => (
+					<ArticleElementComponent
+						// eslint-disable-next-line react/no-array-index-key -- This is only rendered once so we can safely use index to suppress the warning
+						key={index}
+						index={index}
+						element={element}
+						forceDropCap="off"
+						format={format}
+						isTimeline={true}
+						isMainMedia={false}
+					/>
+				))}
+			</section>
+		</>
+	);
+};
 
 // ----- Timeline ----- //
 
@@ -263,7 +265,9 @@ export const Timeline = ({
 }: Props) => {
 	switch (timeline._type) {
 		case 'model.dotcomrendering.pageElements.DCRTimelineBlockElement': {
-			const someEventsHaveTitles = timeline.events.some(hasTitle);
+			const someEventsHaveTitles = timeline.events.some((event) =>
+				isValidString(event.title),
+			);
 
 			return (
 				<>
@@ -282,7 +286,7 @@ export const Timeline = ({
 		}
 		case 'model.dotcomrendering.pageElements.DCRSectionedTimelineBlockElement': {
 			const someEventsHaveTitles = timeline.sections.some((section) =>
-				section.events.some(hasTitle),
+				section.events.some((event) => isValidString(event.title)),
 			);
 
 			return (


### PR DESCRIPTION
## What does this change?
Hides the label box on a timeline element if we don't have a valid label.
This PR also refactors a helper method to be more general and prefers more verbose syntax when calling this function in array methods [as per this discussion ](https://github.com/guardian/dotcom-rendering/pull/11515#discussion_r1625808253)

## Why?
To match designs.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/20416599/dc5f53f5-3f16-4d69-90ed-6795f434a94b
[after]: https://github.com/guardian/dotcom-rendering/assets/20416599/2a61a418-51b8-4b27-840f-94d76cd16f5b
<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
