### PR TITLE
No HTML comment

### DIFF
--- a/dotcom-rendering/src/components/LiveBlogRenderer.tsx
+++ b/dotcom-rendering/src/components/LiveBlogRenderer.tsx
@@ -139,7 +139,7 @@ export const LiveBlogRenderer = ({
 						/>
 					</Hide>
 				)}
-			{isLiveUpdate ? `<!-- live update --->` : <div id="top-of-blog" />}
+			{isLiveUpdate ? null : <div id="top-of-blog" />}
 			<LiveBlogBlocksAndAdverts
 				blocks={blocks}
 				format={format}


### PR DESCRIPTION
## What does this change?

Render nothing for live update, following:
- #11559 

## Why?

It renders as text… oh no

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/76776/bd7ae011-f4c0-4872-88d4-f7c133732018
[after]: https://github.com/guardian/dotcom-rendering/assets/76776/c85c8312-5658-44ec-9227-d4922cd76ebf
