### PR TITLE
Article Formats: Immersive byline fixes

### DIFF
--- a/dotcom-rendering/src/components/HeadlineByline.tsx
+++ b/dotcom-rendering/src/components/HeadlineByline.tsx
@@ -105,7 +105,7 @@ const immersiveStyles = (format: ArticleFormat) => css`
 	${format.theme === ArticleSpecial.Labs ? textSans20 : headlineMedium20}
 	${format.theme === ArticleSpecial.Labs && 'line-height: 1.15;'}
 	margin-bottom: ${space[6]}px;
-
+	color: ${schemedPalette('--headline-byline')};
 	${from.tablet} {
 		margin-bottom: 0;
 		${format.theme === ArticleSpecial.Labs ? textSans24 : headlineMedium24}

--- a/dotcom-rendering/src/components/HeadlineByline.tsx
+++ b/dotcom-rendering/src/components/HeadlineByline.tsx
@@ -150,7 +150,7 @@ export const HeadlineByline = ({ format, byline, tags }: Props) => {
 		case ArticleDisplay.Immersive:
 			return (
 				<div css={immersiveStyles(format)}>
-					by{' '}
+					By{' '}
 					<span css={immersiveLinkStyles}>
 						<BylineLink
 							byline={byline}

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -256,6 +256,44 @@ const headlineBlogBackgroundDark: PaletteFunction = ({
 	return headlineBackgroundDark({ design, display, theme });
 };
 
+const headlineBylineLight: PaletteFunction = ({ display, theme }) => {
+	switch (display) {
+		case ArticleDisplay.Immersive: {
+			switch (theme) {
+				case ArticleSpecial.SpecialReport:
+					return sourcePalette.specialReport[400];
+				case ArticleSpecial.SpecialReportAlt:
+					return sourcePalette.news[400];
+				case ArticleSpecial.Labs:
+					return sourcePalette.labs[300];
+				default:
+					return pillarPalette(theme, 400);
+			}
+		}
+		default:
+			return 'inherit';
+	}
+};
+
+const headlineBylineDark: PaletteFunction = ({ display, theme }) => {
+	switch (display) {
+		case ArticleDisplay.Immersive: {
+			switch (theme) {
+				case ArticleSpecial.SpecialReport:
+					return sourcePalette.specialReport[500];
+				case ArticleSpecial.SpecialReportAlt:
+					return sourcePalette.specialReportAlt[700];
+				case ArticleSpecial.Labs:
+					return sourcePalette.labs[400];
+				default:
+					return pillarPalette(theme, 500);
+			}
+		}
+		default:
+			return 'inherit';
+	}
+};
+
 const bylineLight: PaletteFunction = ({ design, theme }) => {
 	switch (design) {
 		case ArticleDesign.Picture:
@@ -6039,6 +6077,10 @@ const paletteColours = {
 	'--headline-border': {
 		light: headlineBorder,
 		dark: headlineBorder,
+	},
+	'--headline-byline': {
+		light: headlineBylineLight,
+		dark: headlineBylineDark,
 	},
 	'--headline-colour': {
 		light: headlineTextLight,


### PR DESCRIPTION
## What does this change?

- Headline bylines on Immersive pieces take the pillar colour to help differentiate them
- "by Jane Bloggs" becomes "By Jane Bloggs"

## Why?

Due to changes in spacing from #11257, Immersive bylines need some additional differentiation

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| <img width="937" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/705427/68d23201-fe7e-44bc-9fd3-0a91d33737f5"> | <img width="981" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/705427/05c7f0f8-e687-4014-8ebc-15d1e19bb65f"> |
