### PR TITLE
DCR Video pages don't actually support AMP

### DIFF
--- a/dotcom-rendering/src/components/Elements.amp.tsx
+++ b/dotcom-rendering/src/components/Elements.amp.tsx
@@ -85,6 +85,10 @@ export const isAmpSupported = ({
 		if (!hasAmpInteractiveTag) return false;
 	}
 
+	if (tags.some((tag) => tag.id === 'type/video')) {
+		return false;
+	}
+
 	if (tags.some((tag) => tag.id === 'type/article')) {
 		const isSwitchedOn = switches.ampArticleSwitch;
 		const hasQuizTag = tags.some((tag) => tag.id === 'tone/quizzes');


### PR DESCRIPTION
## What does this change?
DCR video pages no longer say they have an AMP version

## Why?
Because video pages don't have an AMP version

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| <img width="587" alt="Screenshot 2024-06-06 at 14 51 50" src="https://github.com/guardian/dotcom-rendering/assets/768467/65b5db8e-7b17-4e6d-b146-d2f6ec602666"> | <img width="813" alt="Screenshot 2024-06-06 at 14 52 14" src="https://github.com/guardian/dotcom-rendering/assets/768467/5413c059-0d67-43c6-a505-3216e613ec05"> |