### PR TITLE
Use correct article background colour in tag link

### DIFF
--- a/dotcom-rendering/src/components/TagLink.tsx
+++ b/dotcom-rendering/src/components/TagLink.tsx
@@ -80,7 +80,7 @@ const arrowStyles = css`
 `;
 
 const fillBarStyles = css`
-	background-color: white; /* Todo: replace with article background color; */
+	background-color: ${palette('--article-background')};
 	margin-top: -${space[2]}px;
 	width: 100%;
 	height: 20px;


### PR DESCRIPTION
## What does this change?
Updates the background colour to match the article's


## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]:https://github.com/guardian/dotcom-rendering/assets/20416599/e5b6f7ea-6622-4313-bc2e-6261ad395c82
[after]: https://github.com/guardian/dotcom-rendering/assets/20416599/a51db8ff-0176-428f-816f-c879ad71bb63

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
