### PR TITLE
Formats: Opionion and Analysis style fixes

### DIFF
--- a/dotcom-rendering/src/components/HeadlineByline.tsx
+++ b/dotcom-rendering/src/components/HeadlineByline.tsx
@@ -62,7 +62,7 @@ const opinionStyles = (format: ArticleFormat) => css`
 	display: inline;
 	color: ${schemedPalette('--byline')};
 
-	${until.mobileMedium} {
+	${until.tablet} {
 		${headlineLightItalic28}
 	}
 

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -54,9 +54,7 @@ const headlineTextLight: PaletteFunction = ({ design, display, theme }) => {
 			return sourcePalette.neutral[97];
 		default: {
 			switch (design) {
-				case ArticleDesign.Comment:
 				case ArticleDesign.Editorial:
-				case ArticleDesign.Analysis:
 				case ArticleDesign.Feature:
 				case ArticleDesign.Recipe:
 				case ArticleDesign.Review: {
@@ -106,9 +104,7 @@ const headlineTextDark: PaletteFunction = ({ design, display, theme }) => {
 			return sourcePalette.neutral[97];
 		default: {
 			switch (design) {
-				case ArticleDesign.Comment:
 				case ArticleDesign.Editorial:
-				case ArticleDesign.Analysis:
 				case ArticleDesign.Feature:
 				case ArticleDesign.Recipe:
 				case ArticleDesign.Review: {


### PR DESCRIPTION
## What does this change?

- Makes article headlines on Opionion and Analysis articles standard "black" instead of the pillar colour
- Reduces size of bylines until the tablet breakpoint on Opinion articles to match the headline size

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![image](https://github.com/guardian/dotcom-rendering/assets/705427/fa22e6e7-75a6-4290-bad7-977ab84bb6c9) | ![image](https://github.com/guardian/dotcom-rendering/assets/705427/46b39141-3e62-40af-909c-06808a110b7f) |
