### PR TITLE
Epic: always use targeted article count

### DIFF
--- a/dotcom-rendering/src/components/marketing/epics/ContributionsEpic.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ContributionsEpic.tsx
@@ -405,14 +405,13 @@ const ContributionsEpic: ReactComponent<EpicProps> = ({
 			{showAboveArticleCount && (
 				<div css={articleCountAboveContainerStyles}>
 					<ContributionsEpicArticleCountAboveWithOptOut
-						articleCounts={articleCounts}
+						articleCount={articleCounts.forTargetedWeeks}
 						isArticleCountOn={!hasOptedOut}
 						onArticleCountOptOut={onArticleCountOptOut}
 						onArticleCountOptIn={onArticleCountOptIn}
 						openCmp={openCmp}
 						submitComponentEvent={submitComponentEvent}
 						copy={variant.separateArticleCount?.copy}
-						countType={variant.separateArticleCount?.countType}
 					/>
 				</div>
 			)}

--- a/dotcom-rendering/src/components/marketing/epics/ContributionsEpicArticleCountAboveWithOptOut.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ContributionsEpicArticleCountAboveWithOptOut.tsx
@@ -19,10 +19,6 @@ import {
 } from '@guardian/source/foundations';
 import { palette, space } from '@guardian/source/foundations';
 import { Button, ButtonLink } from '@guardian/source/react-components';
-import type {
-	ArticleCounts,
-	ArticleCountType,
-} from '@guardian/support-dotcom-components/dist/shared/src/types';
 import { useState } from 'react';
 import type { ReactComponent } from '../lib/ReactComponent';
 import {
@@ -35,9 +31,8 @@ import {
 } from './utils/ophan';
 
 export interface ContributionsEpicArticleCountAboveWithOptOutProps {
-	articleCounts: ArticleCounts;
 	copy?: string;
-	countType?: ArticleCountType;
+	articleCount: number;
 	isArticleCountOn: boolean;
 	onArticleCountOptOut: () => void;
 	onArticleCountOptIn: () => void;
@@ -48,9 +43,8 @@ export interface ContributionsEpicArticleCountAboveWithOptOutProps {
 export const ContributionsEpicArticleCountAboveWithOptOut: ReactComponent<
 	ContributionsEpicArticleCountAboveWithOptOutProps
 > = ({
-	articleCounts,
+	articleCount,
 	copy,
-	countType,
 	isArticleCountOn,
 	onArticleCountOptOut,
 	onArticleCountOptIn,
@@ -89,8 +83,6 @@ export const ContributionsEpicArticleCountAboveWithOptOut: ReactComponent<
 		setIsOpen(false);
 		submitComponentEvent?.(OPHAN_COMPONENT_ARTICLE_COUNT_STAY_OUT);
 	};
-
-	const articleCount = articleCounts[countType ?? 'for52Weeks'];
 
 	return (
 		<div css={topContainer}>


### PR DESCRIPTION
The API returns two article counts for the epic:
1. the total count over 52 weeks
2. the targeted count, e.g. you can target an epic at users with 50 or more articles about climate crisis in the last 2 months

Currently the "separate article count" feature, at the top of the epic, uses the first count.
This PR changes it to use the second. So e.g. if an epic is targeted at users who've read 50 or more environment articles, the "separate article count" will display the environment article count.

In storybook, if we set the two counts to be different, we can see the targeted count is now used -
<img width="646" alt="Screenshot 2024-06-07 at 08 28 30" src="https://github.com/guardian/dotcom-rendering/assets/1513454/fcb8ca5f-b231-4903-9b70-c3bb8df0a2a4">
