### PR TITLE
Fix Pinned Post overlay

### DIFF
--- a/dotcom-rendering/src/components/EnhancePinnedPost.importable.tsx
+++ b/dotcom-rendering/src/components/EnhancePinnedPost.importable.tsx
@@ -157,17 +157,19 @@ export const EnhancePinnedPost = () => {
 		if (!pinnedPost) return;
 		if (!pinnedPostCheckBox) return;
 
-		const listener = () =>
+		const listener = () => {
+			checkContentHeight();
 			handleClickTracking(
 				pinnedPostCheckBox.checked,
 				pinnedPost,
 				renderingTarget,
 			);
+		};
 
 		pinnedPostCheckBox.addEventListener('change', listener);
 
 		return () => pinnedPostCheckBox.removeEventListener('change', listener);
-	}, [pinnedPost, pinnedPostCheckBox, renderingTarget]);
+	}, [checkContentHeight, pinnedPost, pinnedPostCheckBox, renderingTarget]);
 
 	// calculate duration when user is viewing pinned post
 	// and emit ophan events when the pinned post goes out of view


### PR DESCRIPTION
## What does this change?

Add an extra check for content height when clicking the listener, as a checkbox’s checked status changed [is not visible to the `MutationObserver` ](https://bugzilla.mozilla.org/show_bug.cgi?id=898428)

## Why?

More reliable overlay display.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/76776/731af1eb-9468-4915-a020-b0dbc74ec59b
[after]: https://github.com/guardian/dotcom-rendering/assets/76776/ebed07bd-0f4c-46bc-91f6-e5e2aeb63c4c
