### PR TITLE
remove unused `storybook-addon-turbo-build`

### DIFF
--- a/dotcom-rendering/.storybook/main.ts
+++ b/dotcom-rendering/.storybook/main.ts
@@ -22,30 +22,7 @@ const config: StorybookConfig = {
 		'../src/static',
 		{ from: '../src/static', to: '/static/frontend/' },
 	],
-	addons: [
-		'@storybook/addon-essentials',
-		'@storybook/addon-interactions',
-		'storybook-addon-turbo-build',
-		{
-			name: 'storybook-addon-turbo-build',
-			options: {
-				optimizationLevel: 1,
-				// We're explicitly setting the minification options below because
-				// we want to turn off `minifyIdentifiers`. Why? Because it breaks
-				// Islands hydration. When you minify the component filenames
-				// the dynamic imports fail to find them.
-				// See: https://github.com/privatenumber/esbuild-loader#minify
-				//    & https://esbuild.github.io/api/#minify
-				esbuildMinifyOptions: {
-					target: 'es2015',
-					minify: false,
-					minifyWhitespace: true,
-					minifyIdentifiers: false,
-					minifySyntax: true,
-				},
-			},
-		},
-	],
+	addons: ['@storybook/addon-essentials', '@storybook/addon-interactions'],
 	webpackFinal: async (config) => {
 		// Get project specific webpack options
 		config = webpackConfig(config);


### PR DESCRIPTION
## What does this change?

- removes reference to `storybook-addon-turbo-build` because it gives an error in the console as we no longer use this addon