### PR TITLE
Disable RR banner on Android webview

### DIFF
--- a/dotcom-rendering/src/components/StickyBottomBanner.importable.tsx
+++ b/dotcom-rendering/src/components/StickyBottomBanner.importable.tsx
@@ -118,7 +118,7 @@ const buildRRBannerConfigWith = ({
 		tags: TagType[];
 		contributionsServiceUrl: string;
 		idApiUrl: string;
-		isAndroidWebview: boolean | undefined;
+		isAndroidWebview: boolean;
 	}): CandidateConfig<BannerProps> => {
 		return {
 			candidate: {
@@ -249,7 +249,7 @@ export const StickyBottomBanner = ({
 		isPreview,
 		currentLocaleCode: countryCode,
 	});
-	const isAndroidWebview = useIsAndroid();
+	const isAndroidWebview = !!useIsAndroid();
 
 	useEffect(() => {
 		setAsyncArticleCounts(getArticleCounts(pageId, tags, contentType));

--- a/dotcom-rendering/src/components/StickyBottomBanner.importable.tsx
+++ b/dotcom-rendering/src/components/StickyBottomBanner.importable.tsx
@@ -16,6 +16,7 @@ import { pickMessage } from '../lib/messagePicker';
 import { useAuthStatus } from '../lib/useAuthStatus';
 import { useBraze } from '../lib/useBraze';
 import { useCountryCode } from '../lib/useCountryCode';
+import { useIsAndroid } from '../lib/useIsAndroid';
 import { useOnce } from '../lib/useOnce';
 import { useSignInGateWillShow } from '../lib/useSignInGateWillShow';
 import type { TagType } from '../types/tag';
@@ -101,6 +102,7 @@ const buildRRBannerConfigWith = ({
 		tags,
 		contributionsServiceUrl,
 		idApiUrl,
+		isAndroidWebview,
 	}: {
 		isSignedIn: boolean;
 		countryCode: CountryCode;
@@ -116,6 +118,7 @@ const buildRRBannerConfigWith = ({
 		tags: TagType[];
 		contributionsServiceUrl: string;
 		idApiUrl: string;
+		isAndroidWebview: boolean;
 	}): CandidateConfig<BannerProps> => {
 		return {
 			candidate: {
@@ -150,6 +153,7 @@ const buildRRBannerConfigWith = ({
 						idApiUrl,
 						signInGateWillShow,
 						asyncArticleCounts,
+						isAndroidWebview,
 					}),
 				show:
 					({ meta, module, fetchEmail }: BannerProps) =>
@@ -245,6 +249,7 @@ export const StickyBottomBanner = ({
 		isPreview,
 		currentLocaleCode: countryCode,
 	});
+	const isAndroidWebview = useIsAndroid();
 
 	useEffect(() => {
 		setAsyncArticleCounts(getArticleCounts(pageId, tags, contentType));
@@ -273,6 +278,7 @@ export const StickyBottomBanner = ({
 			tags,
 			contributionsServiceUrl,
 			idApiUrl,
+			isAndroidWebview,
 		});
 		const brazeArticleContext: BrazeArticleContext = {
 			section: sectionId,

--- a/dotcom-rendering/src/components/StickyBottomBanner.importable.tsx
+++ b/dotcom-rendering/src/components/StickyBottomBanner.importable.tsx
@@ -118,7 +118,7 @@ const buildRRBannerConfigWith = ({
 		tags: TagType[];
 		contributionsServiceUrl: string;
 		idApiUrl: string;
-		isAndroidWebview: boolean;
+		isAndroidWebview: boolean | undefined;
 	}): CandidateConfig<BannerProps> => {
 		return {
 			candidate: {

--- a/dotcom-rendering/src/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/dotcom-rendering/src/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -66,7 +66,7 @@ type CanShowProps = BaseProps & {
 	idApiUrl: string;
 	signInGateWillShow: boolean;
 	asyncArticleCounts: Promise<ArticleCounts | undefined>;
-	isAndroidWebview: boolean | undefined;
+	isAndroidWebview: boolean;
 };
 
 type ReaderRevenueComponentType =

--- a/dotcom-rendering/src/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/dotcom-rendering/src/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -202,7 +202,7 @@ export const canShowRRBanner: CanShowFunctionType<BannerProps> = async ({
 	if (!remoteBannerConfig) return { show: false };
 
 	if (isAndroidWebview) {
-		// Do not show banners on Android app webview, due to buggy behaviour
+		// Do not show banners on Android app webview, due to buggy behaviour with the buttons
 		return { show: false };
 	}
 

--- a/dotcom-rendering/src/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/dotcom-rendering/src/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -66,6 +66,7 @@ type CanShowProps = BaseProps & {
 	idApiUrl: string;
 	signInGateWillShow: boolean;
 	asyncArticleCounts: Promise<ArticleCounts | undefined>;
+	isAndroidWebview: boolean;
 };
 
 type ReaderRevenueComponentType =
@@ -196,8 +197,14 @@ export const canShowRRBanner: CanShowFunctionType<BannerProps> = async ({
 	idApiUrl,
 	signInGateWillShow,
 	asyncArticleCounts,
+	isAndroidWebview,
 }) => {
 	if (!remoteBannerConfig) return { show: false };
+
+	if (isAndroidWebview) {
+		// Do not show banners on Android app webview, due to buggy behaviour
+		return { show: false };
+	}
 
 	if (
 		shouldHideReaderRevenue ||

--- a/dotcom-rendering/src/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/dotcom-rendering/src/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -66,7 +66,7 @@ type CanShowProps = BaseProps & {
 	idApiUrl: string;
 	signInGateWillShow: boolean;
 	asyncArticleCounts: Promise<ArticleCounts | undefined>;
-	isAndroidWebview: boolean;
+	isAndroidWebview: boolean | undefined;
 };
 
 type ReaderRevenueComponentType =


### PR DESCRIPTION
We've noticed the close button doesn't work in the RR banner when pages are opened from the Android app webview. There's an existing hook for disabling features in the webview.

Tested in CODE to confirm banners still display in a normal browser