### PR TITLE
Update `AgeWarning` Stories To Component Story Format v3

### DIFF
--- a/dotcom-rendering/src/components/AgeWarning.stories.tsx
+++ b/dotcom-rendering/src/components/AgeWarning.stories.tsx
@@ -1,26 +1,38 @@
+import type { Meta, StoryObj } from '@storybook/react';
 import { AgeWarning } from './AgeWarning';
 
-export default {
+const meta = {
+	title: 'Components/Age Warning',
 	component: AgeWarning,
-	title: 'Components/AgeWarning',
-};
+} satisfies Meta<typeof AgeWarning>;
 
-export const defaultStory = () => {
-	return <AgeWarning age="10 years old" />;
-};
-defaultStory.storyName = 'default';
+export default meta;
 
-export const SmallWarning = () => {
-	return <AgeWarning age="5 months old" size="small" />;
-};
-SmallWarning.storyName = 'with size set to small';
+type Story = StoryObj<typeof meta>;
 
-export const ScreenReaderVersion = () => {
-	return <AgeWarning age="20 million years old" isScreenReader={true} />;
-};
-ScreenReaderVersion.storyName = 'with screen reader true (invisible)';
+export const Default = {
+	args: {
+		age: '10 years old',
+	},
+} satisfies Story;
 
-export const MissingOldText = () => {
-	return <AgeWarning age="5 years" />;
-};
-MissingOldText.storyName = 'with old text missing from input';
+export const WithSizeSetToSmall = {
+	args: {
+		age: '5 months old',
+		size: 'small',
+	},
+} satisfies Story;
+
+export const ScreenReaderVersion = {
+	args: {
+		age: '20 million years old',
+		isScreenReader: true,
+	},
+	name: 'With Screen Reader True (invisible)',
+} satisfies Story;
+
+export const WithOldTextMissingFromInput = {
+	args: {
+		age: '5 years',
+	},
+} satisfies Story;


### PR DESCRIPTION
This is the default for Storybook 7+[^1], and integrates better with some of its features.

Using `satisfies` gives better type safety for `args`[^2].

[^1]: https://storybook.js.org/blog/storybook-csf3-is-here/
[^2]: https://storybook.js.org/docs/writing-stories/typescript#using-satisfies-for-better-type-safety
