### PR TITLE
Remove references to redplanet switch

### DIFF
--- a/dotcom-rendering/fixtures/config.js
+++ b/dotcom-rendering/fixtures/config.js
@@ -56,7 +56,6 @@ module.exports = {
 			brazeSwitch: true,
 			consentManagement: true,
 			commercial: true,
-			redplanetForAus: true,
 			prebidSonobi: true,
 			idProfileNavigation: true,
 			confiantAdVerification: true,

--- a/dotcom-rendering/scripts/perf/k6/article-nier-automata.json
+++ b/dotcom-rendering/scripts/perf/k6/article-nier-automata.json
@@ -1620,7 +1620,6 @@
 			"brazeSwitch": true,
 			"consentManagement": true,
 			"personaliseSignInGateAfterCheckout": true,
-			"redplanetForAus": true,
 			"prebidSonobi": true,
 			"idProfileNavigation": true,
 			"confiantAdVerification": true,


### PR DESCRIPTION
## What does this change?
Removes references to the redplanet switch. I've left the autogenerated fixture files as is.

## Why?
We're removing redplanet from the commercial codebase, which means we're also removing the switch. Frontend PR to come for that change.
