### PR TITLE
Add timestamps to tag page cards

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -314,6 +314,33 @@ export const Card = ({
 		format.design === ArticleDesign.Editorial ||
 		format.design === ArticleDesign.Letter;
 
+	const decideAge = () => {
+		if (!webPublicationDate) return undefined;
+
+		const publishedWithinTwelveHours =
+			isWithinTwelveHours(webPublicationDate);
+
+		const shouldShowAge =
+			isTagPage ||
+			!!onwardsSource ||
+			(showAge && publishedWithinTwelveHours);
+
+		if (!shouldShowAge) return undefined;
+
+		return (
+			<CardAge
+				format={format}
+				containerPalette={containerPalette}
+				webPublicationDate={webPublicationDate}
+				showClock={showClock}
+				isDynamo={isDynamo}
+				isOnwardContent={isOnwardContent}
+				absoluteServerTimes={absoluteServerTimes}
+				isTagPage={isTagPage}
+				isWithinTwelveHours={publishedWithinTwelveHours}
+			/>
+		);
+	};
 	const renderFooter = ({ displayLines }: { displayLines?: boolean }) => {
 		if (showLivePlayable) return <></>;
 		return (
@@ -322,23 +349,7 @@ export const Card = ({
 				containerPalette={containerPalette}
 				displayLines={displayLines}
 				leftAlign={isOnwardContent}
-				age={
-					(!!onwardsSource && !!webPublicationDate) ||
-					(isTagPage && !!webPublicationDate) ||
-					(showAge &&
-						webPublicationDate &&
-						isWithinTwelveHours(webPublicationDate)) ? (
-						<CardAge
-							format={format}
-							containerPalette={containerPalette}
-							webPublicationDate={webPublicationDate}
-							showClock={showClock}
-							isDynamo={isDynamo}
-							isOnwardContent={isOnwardContent}
-							absoluteServerTimes={absoluteServerTimes}
-						/>
-					) : undefined
-				}
+				age={decideAge()}
 				commentCount={
 					discussionId !== undefined ? (
 						<Link

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -317,13 +317,10 @@ export const Card = ({
 	const decideAge = () => {
 		if (!webPublicationDate) return undefined;
 
-		const publishedWithinTwelveHours =
-			isWithinTwelveHours(webPublicationDate);
-
 		const shouldShowAge =
 			isTagPage ||
 			!!onwardsSource ||
-			(showAge && publishedWithinTwelveHours);
+			(showAge && isWithinTwelveHours(webPublicationDate));
 
 		if (!shouldShowAge) return undefined;
 
@@ -337,7 +334,6 @@ export const Card = ({
 				isOnwardContent={isOnwardContent}
 				absoluteServerTimes={absoluteServerTimes}
 				isTagPage={isTagPage}
-				isWithinTwelveHours={publishedWithinTwelveHours}
 			/>
 		);
 	};

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -107,6 +107,7 @@ export type Props = {
 	onwardsSource?: OnwardsSource;
 	pauseOffscreenVideo?: boolean;
 	showMainVideo?: boolean;
+	isTagPage?: boolean;
 };
 
 const starWrapper = (cardHasImage: boolean) => css`
@@ -295,6 +296,7 @@ export const Card = ({
 	pauseOffscreenVideo = false,
 	showMainVideo = true,
 	absoluteServerTimes,
+	isTagPage = false,
 }: Props) => {
 	const palette = decidePalette(format, containerPalette);
 
@@ -322,6 +324,7 @@ export const Card = ({
 				leftAlign={isOnwardContent}
 				age={
 					(!!onwardsSource && !!webPublicationDate) ||
+					(isTagPage && !!webPublicationDate) ||
 					(showAge &&
 						webPublicationDate &&
 						isWithinTwelveHours(webPublicationDate)) ? (

--- a/dotcom-rendering/src/components/Card/components/CardAge.tsx
+++ b/dotcom-rendering/src/components/Card/components/CardAge.tsx
@@ -18,6 +18,8 @@ type Props = {
 	showClock?: boolean;
 	isDynamo?: true;
 	isOnwardContent?: boolean;
+	isTagPage?: boolean;
+	isWithinTwelveHours: boolean;
 };
 
 const ageStyles = (
@@ -75,6 +77,8 @@ export const CardAge = ({
 	isDynamo,
 	isOnwardContent,
 	absoluteServerTimes,
+	isTagPage,
+	isWithinTwelveHours,
 }: Props) => {
 	if (timeAgo(new Date(webPublicationDate).getTime()) === false) {
 		return null;
@@ -85,15 +89,26 @@ export const CardAge = ({
 			css={ageStyles(format, containerPalette, isDynamo, isOnwardContent)}
 		>
 			{showClock && <ClockIcon />}
-			<DateTime
-				date={new Date(webPublicationDate)}
-				display="relative"
-				absoluteServerTimes={absoluteServerTimes}
-				editionId={'UK'}
-				showWeekday={false}
-				showDate={true}
-				showTime={false}
-			/>
+			{isTagPage ? (
+				<DateTime
+					date={new Date(webPublicationDate)}
+					display={'absolute'}
+					editionId={'UK'}
+					showWeekday={false}
+					showDate={isWithinTwelveHours ? false : true}
+					showTime={isWithinTwelveHours ? true : false}
+				/>
+			) : (
+				<DateTime
+					date={new Date(webPublicationDate)}
+					display={'relative'}
+					absoluteServerTimes={absoluteServerTimes}
+					editionId={'UK'}
+					showWeekday={false}
+					showDate={true}
+					showTime={false}
+				/>
+			)}
 		</span>
 	);
 };

--- a/dotcom-rendering/src/components/Card/components/CardAge.tsx
+++ b/dotcom-rendering/src/components/Card/components/CardAge.tsx
@@ -18,8 +18,7 @@ type Props = {
 	showClock?: boolean;
 	isDynamo?: true;
 	isOnwardContent?: boolean;
-	isTagPage?: boolean;
-	isWithinTwelveHours: boolean;
+	isTagPage: boolean;
 };
 
 const ageStyles = (
@@ -78,7 +77,6 @@ export const CardAge = ({
 	isOnwardContent,
 	absoluteServerTimes,
 	isTagPage,
-	isWithinTwelveHours,
 }: Props) => {
 	if (timeAgo(new Date(webPublicationDate).getTime()) === false) {
 		return null;
@@ -95,8 +93,8 @@ export const CardAge = ({
 					display={'absolute'}
 					editionId={'UK'}
 					showWeekday={false}
-					showDate={isWithinTwelveHours ? false : true}
-					showTime={isWithinTwelveHours ? true : false}
+					showDate={false}
+					showTime={true}
 				/>
 			) : (
 				<DateTime

--- a/dotcom-rendering/src/components/DecideContainerByTrails.tsx
+++ b/dotcom-rendering/src/components/DecideContainerByTrails.tsx
@@ -17,15 +17,21 @@ type Props = {
 	trails: DCRFrontCard[];
 	speed: 'fast' | 'slow';
 	imageLoading: Loading;
+	isTagPage?: boolean;
+};
+
+type CardProps = {
+	imageLoading: Loading;
+	isTagPage?: boolean;
 };
 
 export const OneCardFast = ({
 	trail,
 	imageLoading,
+	isTagPage,
 }: {
 	trail: DCRFrontCard;
-	imageLoading: Loading;
-}) => {
+} & CardProps) => {
 	return (
 		<UL direction="row">
 			<LI percentage="100%" padSides={true}>
@@ -34,6 +40,7 @@ export const OneCardFast = ({
 					showAge={true}
 					absoluteServerTimes={true}
 					imageLoading={imageLoading}
+					isTagPage={isTagPage}
 				/>
 			</LI>
 		</UL>
@@ -43,10 +50,10 @@ export const OneCardFast = ({
 export const OneCardSlow = ({
 	trail,
 	imageLoading,
+	isTagPage,
 }: {
 	trail: DCRFrontCard;
-	imageLoading: Loading;
-}) => {
+} & CardProps) => {
 	return (
 		<UL direction="row">
 			<LI percentage="100%" padSides={true}>
@@ -55,6 +62,7 @@ export const OneCardSlow = ({
 					showAge={true}
 					absoluteServerTimes={true}
 					imageLoading={imageLoading}
+					isTagPage={isTagPage}
 				/>
 			</LI>
 		</UL>
@@ -64,10 +72,10 @@ export const OneCardSlow = ({
 export const TwoCard = ({
 	trails,
 	imageLoading,
+	isTagPage,
 }: {
 	trails: Tuple<DCRFrontCard, 2>;
-	imageLoading: Loading;
-}) => {
+} & CardProps) => {
 	return (
 		<UL direction="row">
 			<LI percentage="50%" padSides={true}>
@@ -76,6 +84,7 @@ export const TwoCard = ({
 					showAge={true}
 					absoluteServerTimes={true}
 					imageLoading={imageLoading}
+					isTagPage={isTagPage}
 				/>
 			</LI>
 			<LI percentage="50%" padSides={true} showDivider={true}>
@@ -84,6 +93,7 @@ export const TwoCard = ({
 					showAge={true}
 					absoluteServerTimes={true}
 					imageLoading={imageLoading}
+					isTagPage={isTagPage}
 				/>
 			</LI>
 		</UL>
@@ -93,10 +103,10 @@ export const TwoCard = ({
 export const ThreeCard = ({
 	trails,
 	imageLoading,
+	isTagPage,
 }: {
 	trails: Tuple<DCRFrontCard, 3>;
-	imageLoading: Loading;
-}) => {
+} & CardProps) => {
 	return (
 		<UL direction="row">
 			<LI percentage="33.333%" padSides={true}>
@@ -105,6 +115,7 @@ export const ThreeCard = ({
 					showAge={true}
 					absoluteServerTimes={true}
 					imageLoading={imageLoading}
+					isTagPage={isTagPage}
 				/>
 			</LI>
 			<LI percentage="33.333%" padSides={true} showDivider={true}>
@@ -113,6 +124,7 @@ export const ThreeCard = ({
 					showAge={true}
 					absoluteServerTimes={true}
 					imageLoading={imageLoading}
+					isTagPage={isTagPage}
 				/>
 			</LI>
 			<LI percentage="33.333%" padSides={true} showDivider={true}>
@@ -121,6 +133,7 @@ export const ThreeCard = ({
 					showAge={true}
 					absoluteServerTimes={true}
 					imageLoading={imageLoading}
+					isTagPage={isTagPage}
 				/>
 			</LI>
 		</UL>
@@ -130,10 +143,11 @@ export const ThreeCard = ({
 export const FourCard = ({
 	trails,
 	imageLoading,
+	isTagPage,
 }: {
 	trails: Tuple<DCRFrontCard, 4>;
-	imageLoading: Loading;
-}) => {
+} & CardProps) => {
+	console.log(2, { isTagPage });
 	return (
 		<UL direction="row">
 			<LI percentage="25%" padSides={true}>
@@ -142,6 +156,7 @@ export const FourCard = ({
 					showAge={true}
 					absoluteServerTimes={true}
 					imageLoading={imageLoading}
+					isTagPage={isTagPage}
 				/>
 			</LI>
 			<LI percentage="25%" padSides={true} showDivider={true}>
@@ -150,6 +165,7 @@ export const FourCard = ({
 					showAge={true}
 					absoluteServerTimes={true}
 					imageLoading={imageLoading}
+					isTagPage={isTagPage}
 				/>
 			</LI>
 			<LI percentage="25%" padSides={true} showDivider={true}>
@@ -158,6 +174,7 @@ export const FourCard = ({
 					showAge={true}
 					absoluteServerTimes={true}
 					imageLoading={imageLoading}
+					isTagPage={isTagPage}
 				/>
 			</LI>
 			<LI percentage="25%" padSides={true} showDivider={true}>
@@ -166,6 +183,7 @@ export const FourCard = ({
 					showAge={true}
 					absoluteServerTimes={true}
 					imageLoading={imageLoading}
+					isTagPage={isTagPage}
 				/>
 			</LI>
 		</UL>
@@ -175,10 +193,10 @@ export const FourCard = ({
 export const FiveCardFast = ({
 	trails,
 	imageLoading,
+	isTagPage,
 }: {
 	trails: Tuple<DCRFrontCard, 5>;
-	imageLoading: Loading;
-}) => {
+} & CardProps) => {
 	return (
 		<UL direction="row">
 			<LI percentage="33.333%" padSides={true}>
@@ -187,6 +205,7 @@ export const FiveCardFast = ({
 					showAge={true}
 					absoluteServerTimes={true}
 					imageLoading={imageLoading}
+					isTagPage={isTagPage}
 				/>
 			</LI>
 			<LI percentage="33.333%" padSides={true} showDivider={true}>
@@ -195,6 +214,7 @@ export const FiveCardFast = ({
 					showAge={true}
 					absoluteServerTimes={true}
 					imageLoading={imageLoading}
+					isTagPage={isTagPage}
 				/>
 			</LI>
 			<LI percentage="33.333%">
@@ -204,6 +224,7 @@ export const FiveCardFast = ({
 							trail={trails[2]}
 							showAge={true}
 							absoluteServerTimes={true}
+							isTagPage={isTagPage}
 						/>
 					</LI>
 					<LI padSides={true}>
@@ -211,6 +232,7 @@ export const FiveCardFast = ({
 							trail={trails[3]}
 							showAge={true}
 							absoluteServerTimes={true}
+							isTagPage={isTagPage}
 						/>
 					</LI>
 					<LI padSides={true}>
@@ -218,6 +240,7 @@ export const FiveCardFast = ({
 							trail={trails[4]}
 							showAge={true}
 							absoluteServerTimes={true}
+							isTagPage={isTagPage}
 						/>
 					</LI>
 				</UL>
@@ -229,10 +252,10 @@ export const FiveCardFast = ({
 export const FiveCardSlow = ({
 	trails,
 	imageLoading,
+	isTagPage,
 }: {
 	trails: Tuple<DCRFrontCard, 5>;
-	imageLoading: Loading;
-}) => {
+} & CardProps) => {
 	return (
 		<>
 			<UL direction="row" padBottom={true}>
@@ -242,6 +265,7 @@ export const FiveCardSlow = ({
 						showAge={true}
 						absoluteServerTimes={true}
 						imageLoading={imageLoading}
+						isTagPage={isTagPage}
 					/>
 				</LI>
 				<LI percentage="50%" padSides={true} showDivider={true}>
@@ -250,6 +274,7 @@ export const FiveCardSlow = ({
 						showAge={true}
 						absoluteServerTimes={true}
 						imageLoading={imageLoading}
+						isTagPage={isTagPage}
 					/>
 				</LI>
 			</UL>
@@ -260,6 +285,7 @@ export const FiveCardSlow = ({
 						showAge={true}
 						absoluteServerTimes={true}
 						imageLoading={imageLoading}
+						isTagPage={isTagPage}
 					/>
 				</LI>
 				<LI percentage="33.333%" padSides={true} showDivider={true}>
@@ -268,6 +294,7 @@ export const FiveCardSlow = ({
 						showAge={true}
 						absoluteServerTimes={true}
 						imageLoading={imageLoading}
+						isTagPage={isTagPage}
 					/>
 				</LI>
 				<LI percentage="33.333%" padSides={true} showDivider={true}>
@@ -276,6 +303,7 @@ export const FiveCardSlow = ({
 						showAge={true}
 						absoluteServerTimes={true}
 						imageLoading={imageLoading}
+						isTagPage={isTagPage}
 					/>
 				</LI>
 			</UL>
@@ -286,10 +314,10 @@ export const FiveCardSlow = ({
 export const SixCardFast = ({
 	trails,
 	imageLoading,
+	isTagPage,
 }: {
 	trails: Tuple<DCRFrontCard, 6>;
-	imageLoading: Loading;
-}) => {
+} & CardProps) => {
 	return (
 		<>
 			<UL direction="row" padBottom={true}>
@@ -299,6 +327,7 @@ export const SixCardFast = ({
 						showAge={true}
 						absoluteServerTimes={true}
 						imageLoading={imageLoading}
+						isTagPage={isTagPage}
 					/>
 				</LI>
 				<LI percentage="25%" padSides={true} showDivider={true}>
@@ -307,6 +336,7 @@ export const SixCardFast = ({
 						showAge={true}
 						absoluteServerTimes={true}
 						imageLoading={imageLoading}
+						isTagPage={isTagPage}
 					/>
 				</LI>
 				<LI percentage="25%" padSides={true} showDivider={true}>
@@ -315,6 +345,7 @@ export const SixCardFast = ({
 						showAge={true}
 						absoluteServerTimes={true}
 						imageLoading={imageLoading}
+						isTagPage={isTagPage}
 					/>
 				</LI>
 				<LI percentage="25%" padSides={true} showDivider={true}>
@@ -323,6 +354,7 @@ export const SixCardFast = ({
 						showAge={true}
 						absoluteServerTimes={true}
 						imageLoading={imageLoading}
+						isTagPage={isTagPage}
 					/>
 				</LI>
 			</UL>
@@ -332,6 +364,7 @@ export const SixCardFast = ({
 						trail={trails[4]}
 						showAge={true}
 						absoluteServerTimes={true}
+						isTagPage={isTagPage}
 					/>
 				</LI>
 				<LI percentage="50%" padSides={true} showDivider={true}>
@@ -339,6 +372,7 @@ export const SixCardFast = ({
 						trail={trails[5]}
 						showAge={true}
 						absoluteServerTimes={true}
+						isTagPage={isTagPage}
 					/>
 				</LI>
 			</UL>
@@ -349,10 +383,10 @@ export const SixCardFast = ({
 export const SixCardSlow = ({
 	trails,
 	imageLoading,
+	isTagPage,
 }: {
 	trails: Tuple<DCRFrontCard, 6>;
-	imageLoading: Loading;
-}) => {
+} & CardProps) => {
 	return (
 		<>
 			<UL direction="row" padBottom={true}>
@@ -362,6 +396,7 @@ export const SixCardSlow = ({
 						showAge={true}
 						absoluteServerTimes={true}
 						imageLoading={imageLoading}
+						isTagPage={isTagPage}
 					/>
 				</LI>
 				<LI percentage="33.333%" padSides={true} showDivider={true}>
@@ -370,6 +405,7 @@ export const SixCardSlow = ({
 						showAge={true}
 						absoluteServerTimes={true}
 						imageLoading={imageLoading}
+						isTagPage={isTagPage}
 					/>
 				</LI>
 				<LI percentage="33.333%" padSides={true} showDivider={true}>
@@ -378,6 +414,7 @@ export const SixCardSlow = ({
 						showAge={true}
 						absoluteServerTimes={true}
 						imageLoading={imageLoading}
+						isTagPage={isTagPage}
 					/>
 				</LI>
 			</UL>
@@ -388,6 +425,7 @@ export const SixCardSlow = ({
 						showAge={true}
 						absoluteServerTimes={true}
 						imageLoading={imageLoading}
+						isTagPage={isTagPage}
 					/>
 				</LI>
 				<LI percentage="33.333%" padSides={true} showDivider={true}>
@@ -396,6 +434,7 @@ export const SixCardSlow = ({
 						showAge={true}
 						absoluteServerTimes={true}
 						imageLoading={imageLoading}
+						isTagPage={isTagPage}
 					/>
 				</LI>
 				<LI percentage="33.333%" padSides={true} showDivider={true}>
@@ -404,6 +443,7 @@ export const SixCardSlow = ({
 						showAge={true}
 						absoluteServerTimes={true}
 						imageLoading={imageLoading}
+						isTagPage={isTagPage}
 					/>
 				</LI>
 			</UL>
@@ -414,10 +454,10 @@ export const SixCardSlow = ({
 export const SevenCardFast = ({
 	trails,
 	imageLoading,
+	isTagPage,
 }: {
 	trails: Tuple<DCRFrontCard, 7>;
-	imageLoading: Loading;
-}) => {
+} & CardProps) => {
 	return (
 		<>
 			<UL direction="row" padBottom={true}>
@@ -427,6 +467,7 @@ export const SevenCardFast = ({
 						showAge={true}
 						absoluteServerTimes={true}
 						imageLoading={imageLoading}
+						isTagPage={isTagPage}
 					/>
 				</LI>
 				<LI percentage="25%" padSides={true} showDivider={true}>
@@ -435,6 +476,7 @@ export const SevenCardFast = ({
 						showAge={true}
 						absoluteServerTimes={true}
 						imageLoading={imageLoading}
+						isTagPage={isTagPage}
 					/>
 				</LI>
 				<LI percentage="25%" padSides={true} showDivider={true}>
@@ -443,6 +485,7 @@ export const SevenCardFast = ({
 						showAge={true}
 						absoluteServerTimes={true}
 						imageLoading={imageLoading}
+						isTagPage={isTagPage}
 					/>
 				</LI>
 				<LI percentage="25%" padSides={true} showDivider={true}>
@@ -451,6 +494,7 @@ export const SevenCardFast = ({
 						showAge={true}
 						absoluteServerTimes={true}
 						imageLoading={imageLoading}
+						isTagPage={isTagPage}
 					/>
 				</LI>
 			</UL>
@@ -460,6 +504,7 @@ export const SevenCardFast = ({
 						trail={trails[4]}
 						showAge={true}
 						absoluteServerTimes={true}
+						isTagPage={isTagPage}
 					/>
 				</LI>
 				<LI percentage="33.333%" padSides={true} showDivider={true}>
@@ -467,6 +512,7 @@ export const SevenCardFast = ({
 						trail={trails[5]}
 						showAge={true}
 						absoluteServerTimes={true}
+						isTagPage={isTagPage}
 					/>
 				</LI>
 				<LI percentage="33.333%" padSides={true} showDivider={true}>
@@ -474,6 +520,7 @@ export const SevenCardFast = ({
 						trail={trails[6]}
 						showAge={true}
 						absoluteServerTimes={true}
+						isTagPage={isTagPage}
 					/>
 				</LI>
 			</UL>
@@ -484,10 +531,10 @@ export const SevenCardFast = ({
 export const SevenCardSlow = ({
 	trails,
 	imageLoading,
+	isTagPage,
 }: {
 	trails: Tuple<DCRFrontCard, 7>;
-	imageLoading: Loading;
-}) => {
+} & CardProps) => {
 	return (
 		<>
 			<UL direction="row" padBottom={true}>
@@ -497,6 +544,7 @@ export const SevenCardSlow = ({
 						showAge={true}
 						absoluteServerTimes={true}
 						imageLoading={imageLoading}
+						isTagPage={isTagPage}
 					/>
 				</LI>
 				<LI percentage="33.333%" padSides={true} showDivider={true}>
@@ -505,6 +553,7 @@ export const SevenCardSlow = ({
 						showAge={true}
 						absoluteServerTimes={true}
 						imageLoading={imageLoading}
+						isTagPage={isTagPage}
 					/>
 				</LI>
 				<LI percentage="33.333%" padSides={true} showDivider={true}>
@@ -513,6 +562,7 @@ export const SevenCardSlow = ({
 						showAge={true}
 						absoluteServerTimes={true}
 						imageLoading={imageLoading}
+						isTagPage={isTagPage}
 					/>
 				</LI>
 			</UL>
@@ -523,6 +573,7 @@ export const SevenCardSlow = ({
 						showAge={true}
 						absoluteServerTimes={true}
 						imageLoading={imageLoading}
+						isTagPage={isTagPage}
 					/>
 				</LI>
 				<LI percentage="25%" padSides={true} showDivider={true}>
@@ -531,6 +582,7 @@ export const SevenCardSlow = ({
 						showAge={true}
 						absoluteServerTimes={true}
 						imageLoading={imageLoading}
+						isTagPage={isTagPage}
 					/>
 				</LI>
 				<LI percentage="25%" padSides={true} showDivider={true}>
@@ -539,6 +591,7 @@ export const SevenCardSlow = ({
 						showAge={true}
 						absoluteServerTimes={true}
 						imageLoading={imageLoading}
+						isTagPage={isTagPage}
 					/>
 				</LI>
 				<LI percentage="25%" padSides={true} showDivider={true}>
@@ -547,6 +600,7 @@ export const SevenCardSlow = ({
 						showAge={true}
 						absoluteServerTimes={true}
 						imageLoading={imageLoading}
+						isTagPage={isTagPage}
 					/>
 				</LI>
 			</UL>
@@ -557,10 +611,10 @@ export const SevenCardSlow = ({
 export const EightOrMoreFast = ({
 	trails,
 	imageLoading,
+	isTagPage,
 }: {
 	trails: [...Tuple<DCRFrontCard, 8>, ...DCRFrontCard[]];
-	imageLoading: Loading;
-}) => {
+} & CardProps) => {
 	const afterEight = trails.slice(8);
 
 	return (
@@ -572,6 +626,7 @@ export const EightOrMoreFast = ({
 						showAge={true}
 						absoluteServerTimes={true}
 						imageLoading={imageLoading}
+						isTagPage={isTagPage}
 					/>
 				</LI>
 				<LI percentage="25%" padSides={true} showDivider={true}>
@@ -580,6 +635,7 @@ export const EightOrMoreFast = ({
 						showAge={true}
 						absoluteServerTimes={true}
 						imageLoading={imageLoading}
+						isTagPage={isTagPage}
 					/>
 				</LI>
 				<LI percentage="25%" padSides={true} showDivider={true}>
@@ -588,6 +644,7 @@ export const EightOrMoreFast = ({
 						showAge={true}
 						absoluteServerTimes={true}
 						imageLoading={imageLoading}
+						isTagPage={isTagPage}
 					/>
 				</LI>
 				<LI percentage="25%" padSides={true} showDivider={true}>
@@ -596,6 +653,7 @@ export const EightOrMoreFast = ({
 						showAge={true}
 						absoluteServerTimes={true}
 						imageLoading={imageLoading}
+						isTagPage={isTagPage}
 					/>
 				</LI>
 			</UL>
@@ -605,6 +663,7 @@ export const EightOrMoreFast = ({
 						trail={trails[4]}
 						showAge={true}
 						absoluteServerTimes={true}
+						isTagPage={isTagPage}
 					/>
 				</LI>
 				<LI percentage="25%" padSides={true} showDivider={true}>
@@ -612,6 +671,7 @@ export const EightOrMoreFast = ({
 						trail={trails[5]}
 						showAge={true}
 						absoluteServerTimes={true}
+						isTagPage={isTagPage}
 					/>
 				</LI>
 				<LI percentage="25%" padSides={true} showDivider={true}>
@@ -619,6 +679,7 @@ export const EightOrMoreFast = ({
 						trail={trails[6]}
 						showAge={true}
 						absoluteServerTimes={true}
+						isTagPage={isTagPage}
 					/>
 				</LI>
 				<LI percentage="25%" padSides={true} showDivider={true}>
@@ -626,6 +687,7 @@ export const EightOrMoreFast = ({
 						trail={trails[7]}
 						showAge={true}
 						absoluteServerTimes={true}
+						isTagPage={isTagPage}
 					/>
 				</LI>
 			</UL>
@@ -642,6 +704,7 @@ export const EightOrMoreFast = ({
 								trail={trail}
 								showAge={true}
 								absoluteServerTimes={true}
+								isTagPage={isTagPage}
 							/>
 						</LI>
 					))}
@@ -656,10 +719,10 @@ export const EightOrMoreFast = ({
 export const EightOrMoreSlow = ({
 	trails,
 	imageLoading,
+	isTagPage,
 }: {
 	trails: [...Tuple<DCRFrontCard, 8>, ...DCRFrontCard[]];
-	imageLoading: Loading;
-}) => {
+} & CardProps) => {
 	const afterEight = trails.slice(8);
 
 	return (
@@ -671,6 +734,7 @@ export const EightOrMoreSlow = ({
 						showAge={true}
 						absoluteServerTimes={true}
 						imageLoading={imageLoading}
+						isTagPage={isTagPage}
 					/>
 				</LI>
 				<LI percentage="25%" padSides={true} showDivider={true}>
@@ -679,6 +743,7 @@ export const EightOrMoreSlow = ({
 						showAge={true}
 						absoluteServerTimes={true}
 						imageLoading={imageLoading}
+						isTagPage={isTagPage}
 					/>
 				</LI>
 				<LI percentage="25%" padSides={true} showDivider={true}>
@@ -687,6 +752,7 @@ export const EightOrMoreSlow = ({
 						showAge={true}
 						absoluteServerTimes={true}
 						imageLoading={imageLoading}
+						isTagPage={isTagPage}
 					/>
 				</LI>
 				<LI percentage="25%" padSides={true} showDivider={true}>
@@ -695,6 +761,7 @@ export const EightOrMoreSlow = ({
 						showAge={true}
 						absoluteServerTimes={true}
 						imageLoading={imageLoading}
+						isTagPage={isTagPage}
 					/>
 				</LI>
 			</UL>
@@ -705,6 +772,7 @@ export const EightOrMoreSlow = ({
 						showAge={true}
 						absoluteServerTimes={true}
 						imageLoading={imageLoading}
+						isTagPage={isTagPage}
 					/>
 				</LI>
 				<LI percentage="25%" padSides={true} showDivider={true}>
@@ -713,6 +781,7 @@ export const EightOrMoreSlow = ({
 						showAge={true}
 						absoluteServerTimes={true}
 						imageLoading={imageLoading}
+						isTagPage={isTagPage}
 					/>
 				</LI>
 				<LI percentage="25%" padSides={true} showDivider={true}>
@@ -721,6 +790,7 @@ export const EightOrMoreSlow = ({
 						showAge={true}
 						absoluteServerTimes={true}
 						imageLoading={imageLoading}
+						isTagPage={isTagPage}
 					/>
 				</LI>
 				<LI percentage="25%" padSides={true} showDivider={true}>
@@ -729,6 +799,7 @@ export const EightOrMoreSlow = ({
 						showAge={true}
 						absoluteServerTimes={true}
 						imageLoading={imageLoading}
+						isTagPage={isTagPage}
 					/>
 				</LI>
 			</UL>
@@ -746,6 +817,7 @@ export const EightOrMoreSlow = ({
 								showAge={true}
 								absoluteServerTimes={true}
 								imageLoading={imageLoading}
+								isTagPage={isTagPage}
 							/>
 						</LI>
 					))}
@@ -761,9 +833,9 @@ export const DecideContainerByTrails = ({
 	trails,
 	speed,
 	imageLoading,
+	isTagPage,
 }: Props) => {
 	const initialTrails = takeFirst(trails, 8);
-
 	if (speed === 'fast') {
 		switch (initialTrails.length) {
 			case 0:
@@ -773,6 +845,7 @@ export const DecideContainerByTrails = ({
 					<OneCardFast
 						trail={initialTrails[0]}
 						imageLoading={imageLoading}
+						isTagPage={isTagPage}
 					/>
 				);
 			case 2:
@@ -780,6 +853,7 @@ export const DecideContainerByTrails = ({
 					<TwoCard
 						trails={initialTrails}
 						imageLoading={imageLoading}
+						isTagPage={isTagPage}
 					/>
 				);
 			case 3:
@@ -787,6 +861,7 @@ export const DecideContainerByTrails = ({
 					<ThreeCard
 						trails={initialTrails}
 						imageLoading={imageLoading}
+						isTagPage={isTagPage}
 					/>
 				);
 			case 4:
@@ -794,6 +869,7 @@ export const DecideContainerByTrails = ({
 					<FourCard
 						trails={initialTrails}
 						imageLoading={imageLoading}
+						isTagPage={isTagPage}
 					/>
 				);
 			case 5:
@@ -801,6 +877,7 @@ export const DecideContainerByTrails = ({
 					<FiveCardFast
 						trails={initialTrails}
 						imageLoading={imageLoading}
+						isTagPage={isTagPage}
 					/>
 				);
 			case 6:
@@ -808,6 +885,7 @@ export const DecideContainerByTrails = ({
 					<SixCardFast
 						trails={initialTrails}
 						imageLoading={imageLoading}
+						isTagPage={isTagPage}
 					/>
 				);
 			case 7:
@@ -815,6 +893,7 @@ export const DecideContainerByTrails = ({
 					<SevenCardFast
 						trails={initialTrails}
 						imageLoading={imageLoading}
+						isTagPage={isTagPage}
 					/>
 				);
 			case 8:
@@ -822,6 +901,7 @@ export const DecideContainerByTrails = ({
 					<EightOrMoreFast
 						trails={[...initialTrails, ...trails.slice(8)]}
 						imageLoading={imageLoading}
+						isTagPage={isTagPage}
 					/>
 				);
 		}
@@ -834,6 +914,7 @@ export const DecideContainerByTrails = ({
 					<OneCardSlow
 						trail={initialTrails[0]}
 						imageLoading={imageLoading}
+						isTagPage={isTagPage}
 					/>
 				);
 			case 2:
@@ -841,6 +922,7 @@ export const DecideContainerByTrails = ({
 					<TwoCard
 						trails={initialTrails}
 						imageLoading={imageLoading}
+						isTagPage={isTagPage}
 					/>
 				);
 			case 3:
@@ -848,6 +930,7 @@ export const DecideContainerByTrails = ({
 					<ThreeCard
 						trails={initialTrails}
 						imageLoading={imageLoading}
+						isTagPage={isTagPage}
 					/>
 				);
 			case 4:
@@ -855,6 +938,7 @@ export const DecideContainerByTrails = ({
 					<FourCard
 						trails={initialTrails}
 						imageLoading={imageLoading}
+						isTagPage={isTagPage}
 					/>
 				);
 			case 5:
@@ -862,6 +946,7 @@ export const DecideContainerByTrails = ({
 					<FiveCardSlow
 						trails={initialTrails}
 						imageLoading={imageLoading}
+						isTagPage={isTagPage}
 					/>
 				);
 			case 6:
@@ -869,6 +954,7 @@ export const DecideContainerByTrails = ({
 					<SixCardSlow
 						trails={initialTrails}
 						imageLoading={imageLoading}
+						isTagPage={isTagPage}
 					/>
 				);
 			case 7:
@@ -876,6 +962,7 @@ export const DecideContainerByTrails = ({
 					<SevenCardSlow
 						trails={initialTrails}
 						imageLoading={imageLoading}
+						isTagPage={isTagPage}
 					/>
 				);
 			case 8:
@@ -883,6 +970,7 @@ export const DecideContainerByTrails = ({
 					<EightOrMoreSlow
 						trails={[...initialTrails, ...trails.slice(8)]}
 						imageLoading={imageLoading}
+						isTagPage={isTagPage}
 					/>
 				);
 		}

--- a/dotcom-rendering/src/layouts/TagPageLayout.tsx
+++ b/dotcom-rendering/src/layouts/TagPageLayout.tsx
@@ -312,6 +312,7 @@ export const TagPageLayout = ({ tagPage, NAV }: Props) => {
 									trails={groupedTrails.trails}
 									speed={tagPage.speed}
 									imageLoading={imageLoading}
+									isTagPage={true}
 								/>
 							</FrontSection>
 							{decideMerchHighAndMobileAdSlots(

--- a/dotcom-rendering/src/lib/cardWrappers.tsx
+++ b/dotcom-rendering/src/lib/cardWrappers.tsx
@@ -8,6 +8,7 @@ type TrailProps = {
 	absoluteServerTimes: boolean;
 	showAge?: boolean;
 	containerPalette?: DCRContainerPalette;
+	isTagPage?: boolean;
 };
 
 /**
@@ -47,11 +48,13 @@ export const Card100Media50 = ({
 	showAge,
 	containerPalette,
 	imageLoading,
+	isTagPage,
 	absoluteServerTimes,
 }: TrailProps) => {
 	return (
 		<FrontCard
 			imageLoading={imageLoading}
+			isTagPage={isTagPage}
 			trail={trail}
 			containerPalette={containerPalette}
 			showAge={showAge}
@@ -98,6 +101,7 @@ export const Card100Media75 = ({
 	showAge,
 	containerPalette,
 	imageLoading,
+	isTagPage,
 	absoluteServerTimes,
 }: TrailProps) => {
 	return (
@@ -113,6 +117,7 @@ export const Card100Media75 = ({
 			imagePositionOnDesktop="right"
 			imagePositionOnMobile="top"
 			imageLoading={imageLoading}
+			isTagPage={isTagPage}
 			trailText={
 				// Only show trail text if there is no supportContent
 				trail.supportingContent === undefined ||
@@ -150,6 +155,7 @@ export const Card100Media100 = ({
 	showAge,
 	containerPalette,
 	imageLoading,
+	isTagPage,
 	absoluteServerTimes,
 }: TrailProps) => {
 	return (
@@ -164,6 +170,7 @@ export const Card100Media100 = ({
 			imagePositionOnDesktop="top"
 			imagePositionOnMobile="top"
 			imageLoading={imageLoading}
+			isTagPage={isTagPage}
 			supportingContent={trail.supportingContent?.slice(0, 4)}
 			supportingContentAlignment="horizontal"
 		/>
@@ -191,6 +198,7 @@ export const Card100Media100Tall = ({
 	showAge,
 	containerPalette,
 	imageLoading,
+	isTagPage,
 	absoluteServerTimes,
 }: TrailProps) => {
 	return (
@@ -205,6 +213,7 @@ export const Card100Media100Tall = ({
 			imagePositionOnDesktop="top"
 			imagePositionOnMobile="top"
 			imageLoading={imageLoading}
+			isTagPage={isTagPage}
 			supportingContent={trail.supportingContent?.slice(0, 2)}
 			supportingContentAlignment="vertical"
 			trailText={trail.trailText}
@@ -231,6 +240,7 @@ export const Card75Media50Right = ({
 	showAge,
 	containerPalette,
 	imageLoading,
+	isTagPage,
 	absoluteServerTimes,
 }: TrailProps) => {
 	return (
@@ -250,6 +260,7 @@ export const Card75Media50Right = ({
 			imageSize="large"
 			imagePositionOnMobile="top"
 			imageLoading={imageLoading}
+			isTagPage={isTagPage}
 			headlineSize="large"
 			headlineSizeOnMobile="large"
 		/>
@@ -275,6 +286,7 @@ export const Card75Media50Left = ({
 	showAge,
 	containerPalette,
 	imageLoading,
+	isTagPage,
 	absoluteServerTimes,
 }: TrailProps) => {
 	return (
@@ -294,6 +306,7 @@ export const Card75Media50Left = ({
 			imagePositionOnMobile="top"
 			imageSize="large"
 			imageLoading={imageLoading}
+			isTagPage={isTagPage}
 			headlineSize="large"
 			headlineSizeOnMobile="large"
 		/>
@@ -319,6 +332,7 @@ export const Card25Media25 = ({
 	showAge,
 	containerPalette,
 	imageLoading,
+	isTagPage,
 	absoluteServerTimes,
 }: TrailProps) => {
 	return (
@@ -333,6 +347,7 @@ export const Card25Media25 = ({
 			imagePositionOnMobile="left"
 			imageSize="small"
 			imageLoading={imageLoading}
+			isTagPage={isTagPage}
 			headlineSize="medium"
 			headlineSizeOnMobile="medium"
 			isPlayableMediaCard={false}
@@ -359,6 +374,7 @@ export const Card25Media25SmallHeadline = ({
 	showAge,
 	containerPalette,
 	imageLoading,
+	isTagPage,
 	absoluteServerTimes,
 }: TrailProps) => {
 	return (
@@ -373,6 +389,7 @@ export const Card25Media25SmallHeadline = ({
 			imagePositionOnMobile="left"
 			imageSize="small"
 			imageLoading={imageLoading}
+			isTagPage={isTagPage}
 			headlineSize="small"
 			headlineSizeOnMobile="medium"
 			isPlayableMediaCard={false}
@@ -400,6 +417,7 @@ export const Card25Media25Tall = ({
 	showAge,
 	containerPalette,
 	imageLoading,
+	isTagPage,
 	absoluteServerTimes,
 }: TrailProps) => {
 	return (
@@ -412,6 +430,7 @@ export const Card25Media25Tall = ({
 			imagePositionOnMobile="left"
 			imageSize="small"
 			imageLoading={imageLoading}
+			isTagPage={isTagPage}
 			headlineSize="medium"
 			headlineSizeOnMobile="medium"
 			trailText={
@@ -446,6 +465,7 @@ export const Card25Media25TallNoTrail = ({
 	showAge,
 	containerPalette,
 	imageLoading,
+	isTagPage,
 	absoluteServerTimes,
 }: TrailProps) => {
 	return (
@@ -458,6 +478,7 @@ export const Card25Media25TallNoTrail = ({
 			imagePositionOnMobile="left"
 			imageSize="small"
 			imageLoading={imageLoading}
+			isTagPage={isTagPage}
 			headlineSize="medium"
 			headlineSizeOnMobile="medium"
 			supportingContent={trail.supportingContent?.slice(0, 2)}
@@ -485,6 +506,7 @@ export const Card25Media25TallSmallHeadline = ({
 	showAge,
 	containerPalette,
 	imageLoading,
+	isTagPage,
 	absoluteServerTimes,
 }: TrailProps) => {
 	return (
@@ -497,6 +519,7 @@ export const Card25Media25TallSmallHeadline = ({
 			imagePositionOnMobile="left"
 			imageSize="small"
 			imageLoading={imageLoading}
+			isTagPage={isTagPage}
 			headlineSize="small"
 			headlineSizeOnMobile="medium"
 			supportingContent={trail.supportingContent?.slice(0, 2)}
@@ -524,6 +547,7 @@ export const Card50Media50 = ({
 	showAge,
 	containerPalette,
 	imageLoading,
+	isTagPage,
 	absoluteServerTimes,
 }: TrailProps) => {
 	return (
@@ -536,6 +560,7 @@ export const Card50Media50 = ({
 			imagePositionOnDesktop="top"
 			imagePositionOnMobile="top"
 			imageLoading={imageLoading}
+			isTagPage={isTagPage}
 			showAge={showAge}
 			absoluteServerTimes={absoluteServerTimes}
 			supportingContent={trail.supportingContent?.slice(0, 3)}
@@ -564,6 +589,7 @@ export const Card50Media50Tall = ({
 	showAge,
 	containerPalette,
 	imageLoading,
+	isTagPage,
 	absoluteServerTimes,
 }: TrailProps) => {
 	return (
@@ -579,6 +605,7 @@ export const Card50Media50Tall = ({
 			imagePositionOnMobile="top"
 			imageSize="medium"
 			imageLoading={imageLoading}
+			isTagPage={isTagPage}
 			headlineSize="large"
 			headlineSizeOnMobile="large"
 		/>
@@ -604,6 +631,7 @@ export const Card66Media66 = ({
 	showAge,
 	containerPalette,
 	imageLoading,
+	isTagPage,
 	absoluteServerTimes,
 }: TrailProps) => {
 	return (
@@ -619,6 +647,7 @@ export const Card66Media66 = ({
 			imagePositionOnMobile="top"
 			imageSize="large"
 			imageLoading={imageLoading}
+			isTagPage={isTagPage}
 		/>
 	);
 };
@@ -642,6 +671,7 @@ export const Card33Media33 = ({
 	showAge,
 	containerPalette,
 	imageLoading,
+	isTagPage,
 	absoluteServerTimes,
 }: TrailProps) => {
 	return (
@@ -655,6 +685,7 @@ export const Card33Media33 = ({
 			imagePositionOnDesktop="top"
 			imagePositionOnMobile="left"
 			imageLoading={imageLoading}
+			isTagPage={isTagPage}
 			headlineSize="medium"
 			headlineSizeOnMobile="medium"
 		/>
@@ -679,6 +710,7 @@ export const Card33Media33Tall = ({
 	showAge,
 	containerPalette,
 	imageLoading,
+	isTagPage,
 	absoluteServerTimes,
 }: TrailProps) => {
 	return (
@@ -691,6 +723,7 @@ export const Card33Media33Tall = ({
 			imagePositionOnDesktop="top"
 			imagePositionOnMobile="left"
 			imageLoading={imageLoading}
+			isTagPage={isTagPage}
 			headlineSize="medium"
 			headlineSizeOnMobile="medium"
 			supportingContent={trail.supportingContent?.slice(0, 2)}
@@ -718,6 +751,7 @@ export const Card33Media33MobileTopTall = ({
 	showAge,
 	containerPalette,
 	imageLoading,
+	isTagPage,
 	absoluteServerTimes,
 }: TrailProps) => {
 	return (
@@ -731,6 +765,7 @@ export const Card33Media33MobileTopTall = ({
 			imagePositionOnDesktop="top"
 			imagePositionOnMobile="top"
 			imageLoading={imageLoading}
+			isTagPage={isTagPage}
 			headlineSize="medium"
 			headlineSizeOnMobile="large"
 			supportingContent={trail.supportingContent?.slice(0, 2)}
@@ -756,6 +791,7 @@ export const CardDefault = ({
 	showAge,
 	containerPalette,
 	absoluteServerTimes,
+	isTagPage,
 }: Omit<TrailProps, 'imageLoading'>) => {
 	return (
 		<FrontCard
@@ -769,6 +805,7 @@ export const CardDefault = ({
 			headlineSize="small"
 			headlineSizeOnMobile="small"
 			isPlayableMediaCard={false}
+			isTagPage={isTagPage}
 		/>
 	);
 };
@@ -790,6 +827,7 @@ export const CardDefaultMedia = ({
 	showAge,
 	containerPalette,
 	imageLoading,
+	isTagPage,
 	absoluteServerTimes,
 }: TrailProps) => {
 	return (
@@ -802,6 +840,7 @@ export const CardDefaultMedia = ({
 			imagePositionOnDesktop="left"
 			imagePositionOnMobile="none"
 			imageLoading={imageLoading}
+			isTagPage={isTagPage}
 			headlineSize="small"
 			headlineSizeOnMobile="small"
 			isPlayableMediaCard={false}
@@ -826,6 +865,7 @@ export const CardDefaultMediaMobile = ({
 	showAge,
 	containerPalette,
 	imageLoading,
+	isTagPage,
 	absoluteServerTimes,
 }: TrailProps) => {
 	return (
@@ -838,6 +878,7 @@ export const CardDefaultMediaMobile = ({
 			imagePositionOnDesktop="left"
 			imagePositionOnMobile="left"
 			imageLoading={imageLoading}
+			isTagPage={isTagPage}
 			headlineSize="small"
 			headlineSizeOnMobile="small"
 			isPlayableMediaCard={false}


### PR DESCRIPTION
## What does this change?
Reintroduces timestamps on tag page cards. This has been missing since the tag page migration from Frontend -> DCR. 

## Why?
Tag pages should always show the full timestamp as they act as archival pages of all content.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/20416599/c09a88dd-3505-42ec-be1d-927721685bff
[after]: https://github.com/guardian/dotcom-rendering/assets/20416599/19fcf1ef-77fe-46af-aff8-6cb5c1fd1469


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
