### PR TITLE
Override showVideo toggle behaviour when we should not show an image

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -211,7 +211,7 @@ const getMedia = ({
 	mainMedia?: MainMedia;
 	isPlayableMediaCard?: boolean;
 }) => {
-	if (mainMedia && mainMedia.type === 'Video' && !!isPlayableMediaCard) {
+	if (mainMedia && mainMedia.type === 'Video' && isPlayableMediaCard) {
 		return {
 			type: 'video',
 			mainMedia,

--- a/dotcom-rendering/src/components/DynamicPackage.tsx
+++ b/dotcom-rendering/src/components/DynamicPackage.tsx
@@ -476,21 +476,27 @@ const Card75_ColumnOfCards25 = ({
 			>
 				<UL direction="column">
 					{remaining.map((card, cardIndex) => {
+						// Always show the image on the first card and only
+						// on the second if there are two items in two
+						const shouldShowImage =
+							cardIndex === 0 || remaining.length === 2;
+						const cardWithoutMainMedia = shouldShowImage
+							? card
+							: {
+									...card,
+									mainMedia: undefined,
+							  };
+
 						return (
 							<LI key={card.url} padSides={true}>
 								<FrontCard
-									trail={card}
+									trail={cardWithoutMainMedia}
 									containerPalette={containerPalette}
 									containerType="dynamic/package"
 									showAge={showAge}
 									absoluteServerTimes={absoluteServerTimes}
 									image={
-										// Always show the image on the first card and only
-										// on the second if there are two items in two
-										cardIndex === 0 ||
-										remaining.length === 2
-											? card.image
-											: undefined
+										shouldShowImage ? card.image : undefined
 									}
 									headlineSize={
 										cardIndex === 0 ||


### PR DESCRIPTION
Closes: https://github.com/guardian/dotcom-rendering/issues/11619

## What does this change?
Stops showing image in certain slots of the dynamic/package even if the showVideo toggle is on.

## Why?
This is the expected behaviour by digital editors.

## Behaviour after this PR

After this change in dynamic/package we will show the image:

1. Always in the first 2 cards
2. In the 3rd card if there are 3 cards in total

![image](https://github.com/guardian/dotcom-rendering/assets/19683595/2d8504d3-dc52-47aa-ad23-5a4ac7dbe4c5)

3. If 'showVideo' is on for any of the three cards, it will show the story trail image

![image](https://github.com/guardian/dotcom-rendering/assets/19683595/2d8f7ed8-12e4-4a1b-8563-bdb79084bfa2)

4. Only in the 2 first cards if there are more than 3 cards. This will be the case even if one of the cards in positions 3 & 4 has 'show video' turned on.

![image](https://github.com/guardian/dotcom-rendering/assets/19683595/b7ffce0d-8eba-4f63-b7ad-1d33da101459)


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
