### PR TITLE
Liveblog tag design tweaks

### DIFF
--- a/dotcom-rendering/src/components/SeriesSectionLink.tsx
+++ b/dotcom-rendering/src/components/SeriesSectionLink.tsx
@@ -196,6 +196,7 @@ export const SeriesSectionLink = ({
 	if (inTagLinkTest) {
 		return (
 			<TagLink
+				format={format}
 				sectionLabel={'Euro 2024'}
 				sectionUrl={'football/euro-2024'}
 				guardianBaseURL={guardianBaseURL}

--- a/dotcom-rendering/src/components/TagLink.stories.tsx
+++ b/dotcom-rendering/src/components/TagLink.stories.tsx
@@ -1,4 +1,5 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
+import { type Meta, type StoryObj } from '@storybook/react';
 import { centreColumnDecorator } from '../../.storybook/decorators/gridDecorators';
 import { TagLink } from './TagLink';
 
@@ -16,6 +17,11 @@ export const ThemeVariations = {
 		sectionLabel: 'Euro 24',
 		sectionUrl: 'football/euro-24',
 		guardianBaseURL: 'https://www.theguardian.com',
+		format: {
+			design: ArticleDesign.Standard,
+			display: ArticleDisplay.Standard,
+			theme: Pillar.Sport,
+		},
 	},
 	decorators: [centreColumnDecorator],
 } satisfies Story;

--- a/dotcom-rendering/src/components/TagLink.tsx
+++ b/dotcom-rendering/src/components/TagLink.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import { ArticleDesign } from '@guardian/libs';
 import {
 	from,
 	headlineBold17,
@@ -13,9 +14,9 @@ interface Props {
 	sectionLabel: string;
 	sectionUrl: string;
 	guardianBaseURL: string;
+	format: ArticleFormat;
 }
 const containerStyles = css`
-	padding-top: ${space[1]}px;
 	margin-bottom: ${space[2]}px;
 `;
 
@@ -81,7 +82,7 @@ const arrowStyles = css`
 `;
 
 const fillBarStyles = css`
-	background-color: ${palette('--article-background')};
+	background-color: ${palette('--tag-link-fill-background')};
 	margin-top: -${space[2]}px;
 	width: 100%;
 	height: 20px;
@@ -93,9 +94,21 @@ export const TagLink = ({
 	sectionUrl,
 	sectionLabel,
 	guardianBaseURL,
+	format,
 }: Props) => {
+	const isBlog =
+		format.design === ArticleDesign.LiveBlog ||
+		format.design === ArticleDesign.DeadBlog;
 	return (
-		<div css={containerStyles}>
+		<div
+			css={[
+				containerStyles,
+				!isBlog &&
+					css`
+						padding-top: ${space[1]}px;
+					`,
+			]}
+		>
 			<Hide from="leftCol">
 				<div css={fillBarStyles} />
 			</Hide>

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -255,6 +255,31 @@ const paddingBody = css`
 	}
 `;
 
+const tagOverlayGridStyles = css`
+	position: absolute;
+	${until.desktop} {
+		margin-left: 0px;
+	}
+	display: grid;
+	height: inherit;
+	border: 1px solid red;
+	width: 100%;
+	margin-left: 0;
+	grid-column-gap: 0px;
+	z-index: 999999;
+	${until.desktop} {
+		grid-template-columns: 100%; /* Main content */
+		grid-template-areas: 'sticky-tag';
+	}
+	${from.desktop} {
+		display: none;
+	}
+`;
+
+const stickyTagStyles = css`
+	position: sticky;
+	top: 0;
+`;
 interface BaseProps {
 	article: DCRArticle;
 	format: ArticleFormat;
@@ -467,9 +492,31 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 				</div>
 			)}
 			<main
+				css={
+					inTagLinkTest &&
+					css`
+						position: relative;
+						height: 100%;
+					`
+				}
 				data-layout="LiveLayout"
 				className={inTagLinkTest ? 'sticky-tag-link-test' : ''}
 			>
+				<div css={tagOverlayGridStyles}>
+					<GridItem area="sticky-tag">
+						<div css={stickyTagStyles}>
+							<ArticleTitle
+								format={format}
+								tags={article.tags}
+								sectionLabel={article.sectionLabel}
+								sectionUrl={article.sectionUrl}
+								guardianBaseURL={article.guardianBaseURL}
+								inTagLinkTest={true}
+							/>
+						</div>
+					</GridItem>
+				</div>
+
 				{isApps && (
 					<>
 						<Island priority="critical">

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -5554,6 +5554,74 @@ const mastheadVeggieBurgerBackgroundHover: PaletteFunction = () =>
 	sourcePalette.brandAlt[300];
 
 const tagLinkBackground: PaletteFunction = () => sourcePalette.sport[800];
+const tagLinkFillBackground: PaletteFunction = ({ design, display, theme }) => {
+	switch (design) {
+		case ArticleDesign.LiveBlog:
+		case ArticleDesign.DeadBlog:
+			switch (theme) {
+				case Pillar.News:
+				case ArticleSpecial.SpecialReportAlt:
+				case ArticleSpecial.Labs:
+					return sourcePalette.news[300];
+				case Pillar.Opinion:
+					return sourcePalette.opinion[300];
+				case Pillar.Sport:
+					return sourcePalette.sport[300];
+				case Pillar.Culture:
+					return sourcePalette.culture[300];
+				case Pillar.Lifestyle:
+					return sourcePalette.lifestyle[300];
+				case ArticleSpecial.SpecialReport:
+					return sourcePalette.specialReport[700];
+			}
+		// Order matters. We want comment special report pieces to have the opinion background
+		case ArticleDesign.Letter:
+			return sourcePalette.opinion[800];
+		case ArticleDesign.Comment:
+			switch (theme) {
+				case ArticleSpecial.SpecialReportAlt:
+					return sourcePalette.specialReportAlt[800];
+				default:
+					return sourcePalette.opinion[800];
+			}
+		case ArticleDesign.Editorial:
+			return sourcePalette.opinion[800];
+		case ArticleDesign.Analysis:
+			switch (theme) {
+				case ArticleSpecial.SpecialReportAlt:
+					return sourcePalette.specialReportAlt[800];
+				default:
+					return sourcePalette.news[800];
+			}
+		case ArticleDesign.Picture:
+		case ArticleDesign.Audio:
+		case ArticleDesign.Video: {
+			switch (theme) {
+				case ArticleSpecial.Labs:
+					return sourcePalette.neutral[86];
+				default:
+					return sourcePalette.neutral[0];
+			}
+		}
+		default:
+			switch (theme) {
+				case ArticleSpecial.SpecialReport:
+					return sourcePalette.specialReport[800];
+				case ArticleSpecial.SpecialReportAlt:
+					return sourcePalette.specialReportAlt[800];
+				case ArticleSpecial.Labs:
+					switch (display) {
+						case ArticleDisplay.Immersive:
+							return 'transparent';
+						default:
+							return sourcePalette.neutral[97];
+					}
+				default:
+					return 'transparent';
+			}
+	}
+};
+
 const tagLinkAccent: PaletteFunction = () => sourcePalette.sport[400];
 // ----- Palette ----- //
 
@@ -6607,6 +6675,10 @@ const paletteColours = {
 	'--tag-link-background': {
 		light: tagLinkBackground,
 		dark: tagLinkBackground,
+	},
+	'--tag-link-fill-background': {
+		light: tagLinkFillBackground,
+		dark: tagLinkFillBackground,
 	},
 	'--timeline-atom-bullet': {
 		light: timelineAtomBulletLight,


### PR DESCRIPTION
## What does this change?
Updates the fill colour on liveblogs to reflect the format and adjusts padding to match headline


## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/20416599/6ccf165a-288e-4b18-b2fb-6c000d4abd9d
[after]: https://github.com/guardian/dotcom-rendering/assets/20416599/82e1e81a-a507-473a-a546-3b748d6578ff


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
