### PR TITLE
Skip video Playwright tests that are currently failing

### DIFF
--- a/dotcom-rendering/playwright/tests/atom.video.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/atom.video.e2e.spec.ts
@@ -223,7 +223,7 @@ test.describe('YouTube Atom', () => {
 		await expectToNotExist(page, overlaySelector);
 	});
 
-	test('plays in body video', async ({ page }) => {
+	test.skip('plays in body video', async ({ page }) => {
 		await fetchAndloadPageWithOverrides(
 			page,
 			'https://www.theguardian.com/environment/2021/oct/05/volcanoes-are-life-how-the-ocean-is-enriched-by-eruptions-devastating-on-land',
@@ -381,7 +381,9 @@ test.describe('YouTube Atom', () => {
 		await youTubeEmbedPromise2;
 	});
 
-	test('plays the video if the reader rejects consent', async ({ page }) => {
+	test.skip('plays the video if the reader rejects consent', async ({
+		page,
+	}) => {
 		await fetchAndloadPageWithOverrides(
 			page,
 			'https://www.theguardian.com/environment/2021/oct/05/volcanoes-are-life-how-the-ocean-is-enriched-by-eruptions-devastating-on-land',


### PR DESCRIPTION
## What does this change?

Skips two Playwright tests that are currently failing on all branches:
<img width="868" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/43961396/edfa0551-5077-4217-a67e-b3dcfd27c903">

- Youtube Atom > plays in body video
- Youtube Atom > plays the video if the reader rejects consent

## Why?

These don't seem related to any current DCR changes so should be investigated separately and should not lead DCR contributors to believe it is due to their changes
