### PR TITLE
Add stickiness to tag link in liveblogs

### DIFF
--- a/dotcom-rendering/src/components/SeriesSectionLink.tsx
+++ b/dotcom-rendering/src/components/SeriesSectionLink.tsx
@@ -196,6 +196,7 @@ export const SeriesSectionLink = ({
 	if (inTagLinkTest) {
 		return (
 			<TagLink
+				format={format}
 				sectionLabel={'Euro 2024'}
 				sectionUrl={'football/euro-2024'}
 				guardianBaseURL={guardianBaseURL}

--- a/dotcom-rendering/src/components/TagLink.stories.tsx
+++ b/dotcom-rendering/src/components/TagLink.stories.tsx
@@ -1,4 +1,5 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
+import { type Meta, type StoryObj } from '@storybook/react';
 import { centreColumnDecorator } from '../../.storybook/decorators/gridDecorators';
 import { TagLink } from './TagLink';
 
@@ -16,6 +17,11 @@ export const ThemeVariations = {
 		sectionLabel: 'Euro 24',
 		sectionUrl: 'football/euro-24',
 		guardianBaseURL: 'https://www.theguardian.com',
+		format: {
+			design: ArticleDesign.Standard,
+			display: ArticleDisplay.Standard,
+			theme: Pillar.Sport,
+		},
 	},
 	decorators: [centreColumnDecorator],
 } satisfies Story;

--- a/dotcom-rendering/src/components/TagLink.tsx
+++ b/dotcom-rendering/src/components/TagLink.tsx
@@ -59,6 +59,17 @@ const tagButtonStyles = css`
 	gap: ${space[2]}px;
 `;
 
+const desktopTabStyles = css`
+	${from.desktop} {
+		align-items: start;
+		gap: ${space[3]}px;
+		height: auto;
+		width: auto;
+		flex-direction: column;
+		margin-right: -1px;
+	}
+`;
+
 const arrowStyles = css`
 	display: inline-flex;
 	align-items: center;
@@ -114,7 +125,7 @@ export const TagLink = ({
 			</Hide>
 			<a
 				href={`${guardianBaseURL}/${sectionUrl}`}
-				css={tagLinkStyles}
+				css={[tagLinkStyles, isBlog && desktopTabStyles]}
 				data-component="big-event-series"
 				data-link-name="article series"
 			>

--- a/dotcom-rendering/src/components/TagLink.tsx
+++ b/dotcom-rendering/src/components/TagLink.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import { ArticleDesign } from '@guardian/libs';
 import {
 	from,
 	headlineBold17,
@@ -13,9 +14,9 @@ interface Props {
 	sectionLabel: string;
 	sectionUrl: string;
 	guardianBaseURL: string;
+	format: ArticleFormat;
 }
 const containerStyles = css`
-	padding-top: ${space[1]}px;
 	margin-bottom: ${space[2]}px;
 `;
 
@@ -81,7 +82,7 @@ const arrowStyles = css`
 `;
 
 const fillBarStyles = css`
-	background-color: ${palette('--article-background')};
+	background-color: ${palette('--tag-link-fill-background')};
 	margin-top: -${space[2]}px;
 	width: 100%;
 	height: 20px;
@@ -93,9 +94,21 @@ export const TagLink = ({
 	sectionUrl,
 	sectionLabel,
 	guardianBaseURL,
+	format,
 }: Props) => {
+	const isBlog =
+		format.design === ArticleDesign.LiveBlog ||
+		format.design === ArticleDesign.DeadBlog;
 	return (
-		<div css={containerStyles}>
+		<div
+			css={[
+				containerStyles,
+				!isBlog &&
+					css`
+						padding-top: ${space[1]}px;
+					`,
+			]}
+		>
 			<Hide from="leftCol">
 				<div css={fillBarStyles} />
 			</Hide>

--- a/dotcom-rendering/src/components/TagLink.tsx
+++ b/dotcom-rendering/src/components/TagLink.tsx
@@ -120,9 +120,11 @@ export const TagLink = ({
 					`,
 			]}
 		>
-			<Hide from="leftCol">
-				<div css={fillBarStyles} />
-			</Hide>
+			{!isBlog && (
+				<Hide from="leftCol">
+					<div css={fillBarStyles} />
+				</Hide>
+			)}
 			<a
 				href={`${guardianBaseURL}/${sectionUrl}`}
 				css={[tagLinkStyles, isBlog && desktopTabStyles]}

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -597,14 +597,27 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 					>
 						<HeadlineGrid>
 							<GridItem area="title">
-								<ArticleTitle
-									format={format}
-									tags={article.tags}
-									sectionLabel={article.sectionLabel}
-									sectionUrl={article.sectionUrl}
-									guardianBaseURL={article.guardianBaseURL}
-									inTagLinkTest={inTagLinkTest}
-								/>
+								{inTagLinkTest ? (
+									<div
+										css={css`
+											height: 64px;
+											${from.desktop} {
+												height: 44px;
+											}
+										`}
+									/>
+								) : (
+									<ArticleTitle
+										format={format}
+										tags={article.tags}
+										sectionLabel={article.sectionLabel}
+										sectionUrl={article.sectionUrl}
+										guardianBaseURL={
+											article.guardianBaseURL
+										}
+										inTagLinkTest={inTagLinkTest}
+									/>
+								)}
 							</GridItem>
 							<GridItem area="headline">
 								<div css={maxWidth}>

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -262,7 +262,6 @@ const tagOverlayGridStyles = css`
 	}
 	display: grid;
 	height: inherit;
-	border: 1px solid red;
 	width: 100%;
 	margin-left: 0;
 	grid-column-gap: 0px;

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -270,7 +270,7 @@ const tagOverlayGridStyles = css`
 		grid-template-columns: 100%; /* Main content */
 		grid-template-areas: 'sticky-tag';
 	}
-	${from.desktop} {
+	${from.tablet} {
 		display: none;
 	}
 `;
@@ -338,8 +338,8 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 
 	const inUpdatedHeaderABTest =
 		article.config.abTests.updatedHeaderDesignVariant === 'variant';
-	const inTagLinkTest =
-		isWeb &&
+	const inTagLinkTest = true;
+	isWeb &&
 		article.config.abTests.tagLinkDesignVariant === 'variant' &&
 		article.tags.some((tag) => tag.id === 'football/euro-2024');
 

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -255,6 +255,31 @@ const paddingBody = css`
 	}
 `;
 
+const tagOverlayGridStyles = css`
+	position: absolute;
+	${until.desktop} {
+		margin-left: 0px;
+	}
+	display: grid;
+	height: inherit;
+	border: 1px solid red;
+	width: 100%;
+	margin-left: 0;
+	grid-column-gap: 0px;
+	z-index: 999999;
+	${until.desktop} {
+		grid-template-columns: 100%; /* Main content */
+		grid-template-areas: 'sticky-tag';
+	}
+	${from.desktop} {
+		display: none;
+	}
+`;
+
+const stickyTagStyles = css`
+	position: sticky;
+	top: 0;
+`;
 interface BaseProps {
 	article: DCRArticle;
 	format: ArticleFormat;
@@ -467,9 +492,31 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 				</div>
 			)}
 			<main
+				css={
+					inTagLinkTest &&
+					css`
+						position: relative;
+						height: 100%;
+					`
+				}
 				data-layout="LiveLayout"
 				className={inTagLinkTest ? 'sticky-tag-link-test' : ''}
 			>
+				<div css={tagOverlayGridStyles}>
+					<GridItem area="sticky-tag">
+						<div css={stickyTagStyles}>
+							<ArticleTitle
+								format={format}
+								tags={article.tags}
+								sectionLabel={article.sectionLabel}
+								sectionUrl={article.sectionUrl}
+								guardianBaseURL={article.guardianBaseURL}
+								inTagLinkTest={true}
+							/>
+						</div>
+					</GridItem>
+				</div>
+
 				{isApps && (
 					<>
 						<Island priority="critical">

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -271,7 +271,21 @@ const tagOverlayGridStyles = css`
 		grid-template-areas: 'sticky-tag';
 	}
 	${from.tablet} {
-		display: none;
+		grid-template-columns: 1fr 700px 1fr;
+		grid-template-areas: '. sticky-tag .';
+	}
+	${from.desktop} {
+		grid-template-columns: 1fr 200px 740px 1fr;
+		grid-template-areas: '. sticky-tag . .';
+	}
+
+	${from.leftCol} {
+		grid-template-columns: 1fr 200px 900px 1fr;
+		grid-template-areas: '. sticky-tag . .';
+	}
+	${from.wide} {
+		grid-template-columns: 1fr 200px 1060px 1fr;
+		grid-template-areas: '. sticky-tag . .';
 	}
 `;
 

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -352,8 +352,8 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 
 	const inUpdatedHeaderABTest =
 		article.config.abTests.updatedHeaderDesignVariant === 'variant';
-	const inTagLinkTest = true;
-	isWeb &&
+	const inTagLinkTest =
+		isWeb &&
 		article.config.abTests.tagLinkDesignVariant === 'variant' &&
 		article.tags.some((tag) => tag.id === 'football/euro-2024');
 

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -515,20 +515,22 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 				data-layout="LiveLayout"
 				className={inTagLinkTest ? 'sticky-tag-link-test' : ''}
 			>
-				<div css={tagOverlayGridStyles}>
-					<GridItem area="sticky-tag">
-						<div css={stickyTagStyles}>
-							<ArticleTitle
-								format={format}
-								tags={article.tags}
-								sectionLabel={article.sectionLabel}
-								sectionUrl={article.sectionUrl}
-								guardianBaseURL={article.guardianBaseURL}
-								inTagLinkTest={true}
-							/>
-						</div>
-					</GridItem>
-				</div>
+				{inTagLinkTest && (
+					<div css={tagOverlayGridStyles}>
+						<GridItem area="sticky-tag">
+							<div css={stickyTagStyles}>
+								<ArticleTitle
+									format={format}
+									tags={article.tags}
+									sectionLabel={article.sectionLabel}
+									sectionUrl={article.sectionUrl}
+									guardianBaseURL={article.guardianBaseURL}
+									inTagLinkTest={true}
+								/>
+							</div>
+						</GridItem>
+					</div>
+				)}
 
 				{isApps && (
 					<>

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -5558,22 +5558,7 @@ const tagLinkFillBackground: PaletteFunction = ({ design, display, theme }) => {
 	switch (design) {
 		case ArticleDesign.LiveBlog:
 		case ArticleDesign.DeadBlog:
-			switch (theme) {
-				case Pillar.News:
-				case ArticleSpecial.SpecialReportAlt:
-				case ArticleSpecial.Labs:
-					return sourcePalette.news[300];
-				case Pillar.Opinion:
-					return sourcePalette.opinion[300];
-				case Pillar.Sport:
-					return sourcePalette.sport[300];
-				case Pillar.Culture:
-					return sourcePalette.culture[300];
-				case Pillar.Lifestyle:
-					return sourcePalette.lifestyle[300];
-				case ArticleSpecial.SpecialReport:
-					return sourcePalette.specialReport[700];
-			}
+			return 'transparent';
 		// Order matters. We want comment special report pieces to have the opinion background
 		case ArticleDesign.Letter:
 			return sourcePalette.opinion[800];

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -5554,6 +5554,74 @@ const mastheadVeggieBurgerBackgroundHover: PaletteFunction = () =>
 	sourcePalette.brandAlt[300];
 
 const tagLinkBackground: PaletteFunction = () => sourcePalette.sport[800];
+const tagLinkFillBackground: PaletteFunction = ({ design, display, theme }) => {
+	switch (design) {
+		case ArticleDesign.LiveBlog:
+		case ArticleDesign.DeadBlog:
+			switch (theme) {
+				case Pillar.News:
+				case ArticleSpecial.SpecialReportAlt:
+				case ArticleSpecial.Labs:
+					return sourcePalette.news[300];
+				case Pillar.Opinion:
+					return sourcePalette.opinion[300];
+				case Pillar.Sport:
+					return sourcePalette.sport[300];
+				case Pillar.Culture:
+					return sourcePalette.culture[300];
+				case Pillar.Lifestyle:
+					return sourcePalette.lifestyle[300];
+				case ArticleSpecial.SpecialReport:
+					return sourcePalette.specialReport[700];
+			}
+		// Order matters. We want comment special report pieces to have the opinion background
+		case ArticleDesign.Letter:
+			return sourcePalette.opinion[800];
+		case ArticleDesign.Comment:
+			switch (theme) {
+				case ArticleSpecial.SpecialReportAlt:
+					return sourcePalette.specialReportAlt[800];
+				default:
+					return sourcePalette.opinion[800];
+			}
+		case ArticleDesign.Editorial:
+			return sourcePalette.opinion[800];
+		case ArticleDesign.Analysis:
+			switch (theme) {
+				case ArticleSpecial.SpecialReportAlt:
+					return sourcePalette.specialReportAlt[800];
+				default:
+					return sourcePalette.news[800];
+			}
+		case ArticleDesign.Picture:
+		case ArticleDesign.Audio:
+		case ArticleDesign.Video: {
+			switch (theme) {
+				case ArticleSpecial.Labs:
+					return sourcePalette.neutral[86];
+				default:
+					return sourcePalette.neutral[0];
+			}
+		}
+		default:
+			switch (theme) {
+				case ArticleSpecial.SpecialReport:
+					return sourcePalette.specialReport[800];
+				case ArticleSpecial.SpecialReportAlt:
+					return sourcePalette.specialReportAlt[800];
+				case ArticleSpecial.Labs:
+					switch (display) {
+						case ArticleDisplay.Immersive:
+							return 'transparent';
+						default:
+							return sourcePalette.neutral[97];
+					}
+				default:
+					return 'transparent';
+			}
+	}
+};
+
 const tagLinkAccent: PaletteFunction = () => sourcePalette.sport[400];
 // ----- Palette ----- //
 
@@ -6607,6 +6675,10 @@ const paletteColours = {
 	'--tag-link-background': {
 		light: tagLinkBackground,
 		dark: tagLinkBackground,
+	},
+	'--tag-link-fill-background': {
+		light: tagLinkFillBackground,
+		dark: tagLinkFillBackground,
 	},
 	'--timeline-atom-bullet': {
 		light: timelineAtomBulletLight,


### PR DESCRIPTION
## What does this change?
Adds an overlay with a replica grid system to liveblogs to allow the tag link to be sticky for the whole article. We reserve space with an empty div where the link would normally be and the overlay positions it's own tag over the reserved space. 

## Why?
Elements are only sticky within their parents container. Liveblogs are an unusual layout in that they have seperate grid systems within them to control the headline, standfirst, body etc. This meant that the tag link was only sticky inside the headline container, not the whole article. This PR allows it to stick on the whole article by making a sibling tag overlay to the rest of the article content. 

## Screenshots

**Before**   

https://github.com/guardian/dotcom-rendering/assets/20416599/e3dee43d-01a9-4b6b-a47a-be3e418dda36

**After**

https://github.com/guardian/dotcom-rendering/assets/20416599/f41d543f-8bb1-44c5-8443-a42b91a714f1

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
