### PR TITLE
Change network front titles

### DIFF
--- a/dotcom-rendering/src/server/render.front.web.tsx
+++ b/dotcom-rendering/src/server/render.front.web.tsx
@@ -77,7 +77,9 @@ const enhanceNav = (NAV: NavType): NavType => {
 export const renderFront = ({
 	front,
 }: Props): { html: string; prefetchScripts: string[] } => {
-	const title = front.webTitle;
+	const title = front.isNetworkFront
+		? 'Latest news, sport and opinion from the Guardian'
+		: front.webTitle;
 	const NAV = extractNAV(front.nav);
 	const enhancedNAV = enhanceNav(NAV);
 


### PR DESCRIPTION
## What does this change?
Standardises the title across all network fronts to "Latest news, sport and opinion from the Guardian"
## Why?
We're making them geo-neutral so that the title shown on SERPs is correct for everyone.
Resolves https://github.com/guardian/dotcom-rendering/issues/11630
## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/110032454/fc8cb235-6628-479a-83ca-5fa783998cad
[after]: https://github.com/guardian/dotcom-rendering/assets/110032454/61ed0947-55a3-4ec0-98fb-a01731d6f22c
<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
