### PR TITLE
Remove alternate-lang-links

### DIFF
--- a/dotcom-rendering/src/server/htmlPageTemplate.ts
+++ b/dotcom-rendering/src/server/htmlPageTemplate.ts
@@ -23,7 +23,6 @@ type BaseProps = {
 	renderingTarget: RenderingTarget;
 	hasPageSkin?: boolean;
 	weAreHiring: boolean;
-	alternateLangLinks?: string[];
 };
 
 interface WebProps extends BaseProps {
@@ -68,7 +67,6 @@ export const htmlPageTemplate = (props: WebProps | AppProps): string => {
 		renderingTarget,
 		hasPageSkin = false,
 		weAreHiring,
-		alternateLangLinks = [],
 	} = props;
 
 	/**
@@ -207,7 +205,6 @@ https://workforus.theguardian.com/careers/product-engineering/
 						? `<link rel="canonical" href="${canonicalUrl}" />`
 						: '<!-- no canonical URL -->'
 				}
-				${alternateLangLinks.join('\n')}
 				${
 					renderingTarget === 'Web'
 						? `<meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">`

--- a/dotcom-rendering/src/server/render.front.web.tsx
+++ b/dotcom-rendering/src/server/render.front.web.tsx
@@ -2,7 +2,6 @@ import { isString, Pillar } from '@guardian/libs';
 import { ConfigProvider } from '../components/ConfigContext';
 import { FrontPage } from '../components/FrontPage';
 import { TagPage } from '../components/TagPage';
-import { generateAlternateLangLinks } from '../lib/alternate-lang-links';
 import {
 	ASSET_ORIGIN,
 	generateScriptTags,
@@ -125,11 +124,6 @@ export const renderFront = ({
 		...legacyScripts,
 	]);
 
-	const alternateLangLinks = generateAlternateLangLinks(
-		front.guardianBaseURL,
-		front.pageId,
-	);
-
 	const guardian = createGuardian({
 		editionId: front.editionId,
 		stage: front.config.stage,
@@ -165,7 +159,6 @@ export const renderFront = ({
 		hasPageSkin: front.config.hasPageSkin,
 		weAreHiring: !!front.config.switches.weAreHiring,
 		canonicalUrl: front.canonicalUrl,
-		alternateLangLinks,
 	});
 
 	return {
@@ -226,11 +219,6 @@ export const renderTagPage = ({
 		...legacyScripts,
 	]);
 
-	const alternateLangLinks = generateAlternateLangLinks(
-		tagPage.guardianBaseURL,
-		tagPage.pageId,
-	);
-
 	const guardian = createGuardian({
 		editionId: tagPage.editionId,
 		stage: tagPage.config.stage,
@@ -265,7 +253,6 @@ export const renderTagPage = ({
 		renderingTarget: 'Web',
 		weAreHiring: !!tagPage.config.switches.weAreHiring,
 		canonicalUrl: tagPage.canonicalUrl,
-		alternateLangLinks,
 	});
 	return {
 		html: pageHtml,


### PR DESCRIPTION
## What does this change?
Remove alternate-lang-links
## Why?
Resolves https://github.com/guardian/dotcom-rendering/issues/11632 Partial revert of https://github.com/guardian/dotcom-rendering/pull/11383
## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/110032454/eae74131-27ed-44e4-ac94-16f895a97a62
[after]: https://github.com/guardian/dotcom-rendering/assets/110032454/9d1f0466-e7af-422d-9222-c0b3b9f05b9d
<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
