### PR TITLE
Increase RR banner max-height to 70%

### DIFF
--- a/dotcom-rendering/src/layouts/lib/stickiness.tsx
+++ b/dotcom-rendering/src/layouts/lib/stickiness.tsx
@@ -35,7 +35,7 @@ const bannerWrapper = css`
 	position: fixed !important;
 	bottom: 0;
 	${getZIndexImportant('banner')}
-	max-height: 60vh;
+	max-height: 70vh;
 	overflow: auto;
 	/* stylelint-disable-next-line declaration-no-important */
 	width: 100% !important;


### PR DESCRIPTION
We previously lowered this to 60, but after a drop in conversions have decided to try 70 as a compromise

![Screenshot 2024-06-14 at 10 03 48](https://github.com/guardian/dotcom-rendering/assets/1513454/7050d463-7c91-4675-8410-f220e4afc2e0)
