### PR TITLE
Use palette colours for ad slots

### DIFF
--- a/dotcom-rendering/src/components/AdSlot.apps.tsx
+++ b/dotcom-rendering/src/components/AdSlot.apps.tsx
@@ -20,7 +20,7 @@ const adHeightPx = 258;
 const styles = css`
 	clear: both;
 	margin: ${remSpace[4]} 0;
-	background: ${palette('--ad-slot-background')};
+	background: ${palette('--ad-background')};
 
 	${until.phablet} {
 		margin: 1em 0px;

--- a/dotcom-rendering/src/components/AdSlot.apps.tsx
+++ b/dotcom-rendering/src/components/AdSlot.apps.tsx
@@ -20,7 +20,7 @@ const adHeightPx = 258;
 const styles = css`
 	clear: both;
 	margin: ${remSpace[4]} 0;
-	background: ${palette('--ad-background')};
+	background: ${palette('--ad-slot-background')};
 
 	${until.phablet} {
 		margin: 1em 0px;

--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -73,9 +73,9 @@ const individualLabelCSS = css`
 	${textSans12};
 	height: ${labelHeight}px;
 	max-height: ${labelHeight}px;
-	background-color: ${schemedPalette('--ad-slot-background')};
+	background-color: ${schemedPalette('--ad-background')};
 	padding: 0 8px;
-	border-top: 1px solid ${schemedPalette('--ad-slot-border')};
+	border-top: 1px solid ${schemedPalette('--ad-border')};
 	color: ${schemedPalette('--ad-labels-text')};
 	text-align: left;
 	box-sizing: border-box;
@@ -231,7 +231,7 @@ const merchandisingAdStyles = css`
 
 const inlineAdStyles = css`
 	position: relative;
-	background-color: ${schemedPalette('--article-inner-ad-slot-background')};
+	background-color: ${schemedPalette('--ad-background-article-inner')};
 
 	${until.tablet} {
 		display: none;
@@ -239,13 +239,13 @@ const inlineAdStyles = css`
 `;
 
 const rightAdStyles = css`
-	background-color: ${schemedPalette('--article-inner-ad-slot-background')};
+	background-color: ${schemedPalette('--ad-background-article-inner')};
 `;
 
 const liveblogInlineAdStyles = css`
 	position: relative;
 	min-height: ${adSizes.mpu.height + labelHeight}px;
-	background-color: ${schemedPalette('--article-inner-ad-slot-background')};
+	background-color: ${schemedPalette('--ad-background-article-inner')};
 
 	${until.tablet} {
 		display: none;
@@ -285,7 +285,7 @@ const frontsBannerAdTopContainerStyles = css`
 		display: flex;
 		justify-content: center;
 		min-height: ${frontsBannerMinHeightTablet}px;
-		background-color: ${schemedPalette('--ad-slot-background')};
+		background-color: ${schemedPalette('--ad-background')};
 	}
 	${from.desktop} {
 		min-height: ${frontsBannerMinHeight}px;

--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -231,15 +231,22 @@ const merchandisingAdStyles = css`
 
 const inlineAdStyles = css`
 	position: relative;
+	background-color: ${schemedPalette('--article-inner-ad-slot-background')};
 
 	${until.tablet} {
 		display: none;
 	}
 `;
 
+const rightAdStyles = css`
+	background-color: ${schemedPalette('--article-inner-ad-slot-background')};
+`;
+
 const liveblogInlineAdStyles = css`
 	position: relative;
 	min-height: ${adSizes.mpu.height + labelHeight}px;
+	background-color: ${schemedPalette('--article-inner-ad-slot-background')};
+
 	${until.tablet} {
 		display: none;
 	}
@@ -436,9 +443,6 @@ const mobileStickyAdStyles = css`
 `;
 
 export const adContainerStyles = [
-	css`
-		background-color: ${schemedPalette('--ad-slot-background')};
-	`,
 	adContainerCollapseStyles,
 	labelStyles,
 	adContainerCentreSlotStyles,
@@ -466,6 +470,7 @@ export const AdSlot = ({
 						>
 							<div
 								id="dfp-ad--right"
+								css={rightAdStyles}
 								className={[
 									'js-ad-slot',
 									'ad-slot',
@@ -522,6 +527,7 @@ export const AdSlot = ({
 										'js-sticky-mpu',
 									].join(' ')}
 									css={[
+										rightAdStyles,
 										css`
 											position: sticky;
 											/* Possibly account for the sticky Labs header and 6px of padding */

--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -14,6 +14,7 @@ import {
 import { Hide } from '@guardian/source/react-components';
 import { getZIndex } from '../lib/getZIndex';
 import { LABS_HEADER_HEIGHT } from '../lib/labs-constants';
+import { palette as schemedPalette } from '../palette';
 import { AdBlockAsk } from './AdBlockAsk.importable';
 import { Island } from './Island';
 
@@ -72,10 +73,10 @@ const individualLabelCSS = css`
 	${textSans12};
 	height: ${labelHeight}px;
 	max-height: ${labelHeight}px;
-	background-color: ${palette.neutral[97]};
+	background-color: ${schemedPalette('--ad-slot-background')};
 	padding: 0 8px;
-	border-top: 1px solid ${palette.neutral[86]};
-	color: ${palette.neutral[46]};
+	border-top: 1px solid ${schemedPalette('--ad-slot-border')};
+	color: ${schemedPalette('--ad-labels-text')};
 	text-align: left;
 	box-sizing: border-box;
 `;
@@ -239,8 +240,6 @@ const inlineAdStyles = css`
 const liveblogInlineAdStyles = css`
 	position: relative;
 	min-height: ${adSizes.mpu.height + labelHeight}px;
-	background-color: ${palette.neutral[93]};
-
 	${until.tablet} {
 		display: none;
 	}
@@ -249,7 +248,6 @@ const liveblogInlineAdStyles = css`
 const liveblogInlineMobileAdStyles = css`
 	position: relative;
 	min-height: ${adSizes.outstreamMobile.height + labelHeight}px;
-	background-color: ${palette.neutral[93]};
 
 	${from.tablet} {
 		display: none;
@@ -280,7 +278,7 @@ const frontsBannerAdTopContainerStyles = css`
 		display: flex;
 		justify-content: center;
 		min-height: ${frontsBannerMinHeightTablet}px;
-		background-color: ${palette.neutral[97]};
+		background-color: ${schemedPalette('--ad-slot-background')};
 	}
 	${from.desktop} {
 		min-height: ${frontsBannerMinHeight}px;
@@ -438,6 +436,9 @@ const mobileStickyAdStyles = css`
 `;
 
 export const adContainerStyles = [
+	css`
+		background-color: ${schemedPalette('--ad-slot-background')};
+	`,
 	adContainerCollapseStyles,
 	labelStyles,
 	adContainerCentreSlotStyles,

--- a/dotcom-rendering/src/components/ArticleContainer.tsx
+++ b/dotcom-rendering/src/components/ArticleContainer.tsx
@@ -1,7 +1,8 @@
 import { css } from '@emotion/react';
 import { adSizes, constants } from '@guardian/commercial';
 import { ArticleDesign } from '@guardian/libs';
-import { from, palette, space, until } from '@guardian/source/foundations';
+import { from, space, until } from '@guardian/source-foundations';
+import { palette } from '../palette';
 import { carrotAdStyles, labelStyles } from './AdSlot.web';
 
 type Props = {
@@ -93,7 +94,7 @@ const adStyles = css`
 		justify-content: center;
 
 		${from.tablet} {
-			background-color: ${palette.neutral[97]};
+			background-color: ${palette('--ad-slot-background')};
 		}
 
 		/* Prevent merger with any nearby float left elements e.g. rich-links */

--- a/dotcom-rendering/src/components/ArticleContainer.tsx
+++ b/dotcom-rendering/src/components/ArticleContainer.tsx
@@ -94,7 +94,7 @@ const adStyles = css`
 		justify-content: center;
 
 		${from.tablet} {
-			background-color: ${palette('--ad-slot-background')};
+			background-color: ${palette('--ad-background')};
 		}
 
 		/* Prevent merger with any nearby float left elements e.g. rich-links */

--- a/dotcom-rendering/src/components/ArticleContainer.tsx
+++ b/dotcom-rendering/src/components/ArticleContainer.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import { adSizes, constants } from '@guardian/commercial';
 import { ArticleDesign } from '@guardian/libs';
-import { from, space, until } from '@guardian/source-foundations';
+import { from, space, until } from '@guardian/source/foundations';
 import { palette } from '../palette';
 import { carrotAdStyles, labelStyles } from './AdSlot.web';
 

--- a/dotcom-rendering/src/components/DecideFrontsAdSlots.tsx
+++ b/dotcom-rendering/src/components/DecideFrontsAdSlots.tsx
@@ -1,4 +1,3 @@
-import { palette } from '@guardian/source/foundations';
 import { Hide } from '@guardian/source/react-components';
 import type { ReactNode } from 'react';
 import { getMerchHighPosition } from '../lib/getFrontsAdPositions';

--- a/dotcom-rendering/src/components/DecideFrontsAdSlots.tsx
+++ b/dotcom-rendering/src/components/DecideFrontsAdSlots.tsx
@@ -2,6 +2,7 @@ import { palette } from '@guardian/source/foundations';
 import { Hide } from '@guardian/source/react-components';
 import type { ReactNode } from 'react';
 import { getMerchHighPosition } from '../lib/getFrontsAdPositions';
+import { palette as themePalette } from '../palette';
 import { AdSlot } from './AdSlot.web';
 import { Section } from './Section';
 
@@ -64,7 +65,7 @@ export const decideMerchandisingSlot = (
 			padSides={false}
 			showTopBorder={false}
 			showSideBorders={false}
-			backgroundColour={palette.neutral[97]}
+			backgroundColour={themePalette('--article-section-background')}
 			element="aside"
 		>
 			{children}

--- a/dotcom-rendering/src/components/HeaderAdSlot.tsx
+++ b/dotcom-rendering/src/components/HeaderAdSlot.tsx
@@ -1,6 +1,7 @@
 import { css, Global } from '@emotion/react';
 import { adSizes, constants } from '@guardian/commercial';
-import { palette as sourcePalette, space } from '@guardian/source/foundations';
+import { space } from '@guardian/source-foundations';
+import { palette } from '../palette';
 import { AdBlockAsk } from './AdBlockAsk.importable';
 import { adContainerStyles, AdSlot } from './AdSlot.web';
 import { Hide } from './Hide';
@@ -20,9 +21,9 @@ const headerMinHeight =
 const headerAdWrapper = css`
 	z-index: 1080;
 	width: 100%;
-	background-color: ${sourcePalette.neutral[97]};
+	background-color: ${palette('--ad-slot-background')};
 	min-height: ${headerMinHeight}px;
-	border-bottom: ${borderBottomHeight}px solid ${sourcePalette.neutral[86]};
+	border-bottom: ${borderBottomHeight}px solid ${palette('--ad-slot-border')};
 
 	display: flex;
 	flex-direction: column;

--- a/dotcom-rendering/src/components/HeaderAdSlot.tsx
+++ b/dotcom-rendering/src/components/HeaderAdSlot.tsx
@@ -21,9 +21,9 @@ const headerMinHeight =
 const headerAdWrapper = css`
 	z-index: 1080;
 	width: 100%;
-	background-color: ${palette('--ad-slot-background')};
+	background-color: ${palette('--ad-background')};
 	min-height: ${headerMinHeight}px;
-	border-bottom: ${borderBottomHeight}px solid ${palette('--ad-slot-border')};
+	border-bottom: ${borderBottomHeight}px solid ${palette('--ad-border')};
 
 	display: flex;
 	flex-direction: column;

--- a/dotcom-rendering/src/components/HeaderAdSlot.tsx
+++ b/dotcom-rendering/src/components/HeaderAdSlot.tsx
@@ -1,6 +1,6 @@
 import { css, Global } from '@emotion/react';
 import { adSizes, constants } from '@guardian/commercial';
-import { space } from '@guardian/source-foundations';
+import { space } from '@guardian/source/foundations';
 import { palette } from '../palette';
 import { AdBlockAsk } from './AdBlockAsk.importable';
 import { adContainerStyles, AdSlot } from './AdSlot.web';

--- a/dotcom-rendering/src/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/layouts/CommentLayout.tsx
@@ -835,9 +835,7 @@ export const CommentLayout = (props: WebProps | AppsProps) => {
 						padSides={false}
 						showTopBorder={false}
 						showSideBorders={false}
-						backgroundColour={themePalette(
-							'--article-section-background',
-						)}
+						backgroundColour={themePalette('--ad-slot-background')}
 						element="aside"
 					>
 						<AdSlot
@@ -957,9 +955,7 @@ export const CommentLayout = (props: WebProps | AppsProps) => {
 						padSides={false}
 						showTopBorder={false}
 						showSideBorders={false}
-						backgroundColour={themePalette(
-							'--article-section-background',
-						)}
+						backgroundColour={themePalette('--ad-slot-background')}
 						element="aside"
 					>
 						<AdSlot

--- a/dotcom-rendering/src/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/layouts/CommentLayout.tsx
@@ -835,7 +835,9 @@ export const CommentLayout = (props: WebProps | AppsProps) => {
 						padSides={false}
 						showTopBorder={false}
 						showSideBorders={false}
-						backgroundColour={sourcePalette.neutral[97]}
+						backgroundColour={themePalette(
+							'--article-section-background',
+						)}
 						element="aside"
 					>
 						<AdSlot
@@ -955,7 +957,9 @@ export const CommentLayout = (props: WebProps | AppsProps) => {
 						padSides={false}
 						showTopBorder={false}
 						showSideBorders={false}
-						backgroundColour={sourcePalette.neutral[97]}
+						backgroundColour={themePalette(
+							'--article-section-background',
+						)}
 						element="aside"
 					>
 						<AdSlot

--- a/dotcom-rendering/src/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/layouts/CommentLayout.tsx
@@ -835,7 +835,7 @@ export const CommentLayout = (props: WebProps | AppsProps) => {
 						padSides={false}
 						showTopBorder={false}
 						showSideBorders={false}
-						backgroundColour={themePalette('--ad-slot-background')}
+						backgroundColour={themePalette('--ad-background')}
 						element="aside"
 					>
 						<AdSlot
@@ -955,7 +955,7 @@ export const CommentLayout = (props: WebProps | AppsProps) => {
 						padSides={false}
 						showTopBorder={false}
 						showSideBorders={false}
-						backgroundColour={themePalette('--ad-slot-background')}
+						backgroundColour={themePalette('--ad-background')}
 						element="aside"
 					>
 						<AdSlot

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -178,6 +178,9 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 								showSideBorders={false}
 								padSides={false}
 								shouldCenter={false}
+								backgroundColour={palette(
+									'--article-section-background',
+								)}
 							>
 								<HeaderAdSlot
 									isPaidContent={!!front.config.isPaidContent}

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -45,6 +45,7 @@ import {
 } from '../lib/getFrontsAdPositions';
 import { hideAge } from '../lib/hideAge';
 import type { NavType } from '../model/extract-nav';
+import { palette as schemePalette } from '../palette';
 import type { DCRCollectionType, DCRFrontType } from '../types/front';
 import { pageSkinContainer } from './lib/pageSkin';
 import { BannerWrapper, Stuck } from './lib/stickiness';
@@ -178,7 +179,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 								showSideBorders={false}
 								padSides={false}
 								shouldCenter={false}
-								backgroundColour={palette(
+								backgroundColour={schemePalette(
 									'--article-section-background',
 								)}
 							>

--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -812,7 +812,7 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 						padSides={false}
 						showTopBorder={false}
 						showSideBorders={false}
-						backgroundColour={themePalette('--ad-slot-background')}
+						backgroundColour={themePalette('--ad-background')}
 						element="aside"
 					>
 						<AdSlot
@@ -933,7 +933,7 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 						padSides={false}
 						showTopBorder={false}
 						showSideBorders={false}
-						backgroundColour={themePalette('--ad-slot-background')}
+						backgroundColour={themePalette('--ad-background')}
 						element="aside"
 					>
 						<AdSlot

--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -812,9 +812,7 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 						padSides={false}
 						showTopBorder={false}
 						showSideBorders={false}
-						backgroundColour={themePalette(
-							'--article-section-background',
-						)}
+						backgroundColour={themePalette('--ad-slot-background')}
 						element="aside"
 					>
 						<AdSlot
@@ -935,9 +933,7 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 						padSides={false}
 						showTopBorder={false}
 						showSideBorders={false}
-						backgroundColour={themePalette(
-							'--article-section-background',
-						)}
+						backgroundColour={themePalette('--ad-slot-background')}
 						element="aside"
 					>
 						<AdSlot

--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -812,7 +812,9 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 						padSides={false}
 						showTopBorder={false}
 						showSideBorders={false}
-						backgroundColour={sourcePalette.neutral[97]}
+						backgroundColour={themePalette(
+							'--article-section-background',
+						)}
 						element="aside"
 					>
 						<AdSlot
@@ -933,7 +935,9 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 						padSides={false}
 						showTopBorder={false}
 						showSideBorders={false}
-						backgroundColour={sourcePalette.neutral[97]}
+						backgroundColour={themePalette(
+							'--article-section-background',
+						)}
 						element="aside"
 					>
 						<AdSlot

--- a/dotcom-rendering/src/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/InteractiveLayout.tsx
@@ -758,9 +758,7 @@ export const InteractiveLayout = (props: WebProps | AppsProps) => {
 						padSides={false}
 						showTopBorder={false}
 						showSideBorders={false}
-						backgroundColour={themePalette(
-							'--article-section-background',
-						)}
+						backgroundColour={themePalette('--ad-slot-background')}
 						element="aside"
 					>
 						<AdSlot
@@ -886,9 +884,7 @@ export const InteractiveLayout = (props: WebProps | AppsProps) => {
 						padSides={false}
 						showTopBorder={false}
 						showSideBorders={false}
-						backgroundColour={themePalette(
-							'--article-section-background',
-						)}
+						backgroundColour={themePalette('--ad-slot-background')}
 						element="aside"
 					>
 						<AdSlot

--- a/dotcom-rendering/src/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/InteractiveLayout.tsx
@@ -758,7 +758,9 @@ export const InteractiveLayout = (props: WebProps | AppsProps) => {
 						padSides={false}
 						showTopBorder={false}
 						showSideBorders={false}
-						backgroundColour={sourcePalette.neutral[97]}
+						backgroundColour={themePalette(
+							'--article-section-background',
+						)}
 						element="aside"
 					>
 						<AdSlot
@@ -884,7 +886,9 @@ export const InteractiveLayout = (props: WebProps | AppsProps) => {
 						padSides={false}
 						showTopBorder={false}
 						showSideBorders={false}
-						backgroundColour={sourcePalette.neutral[97]}
+						backgroundColour={themePalette(
+							'--article-section-background',
+						)}
 						element="aside"
 					>
 						<AdSlot

--- a/dotcom-rendering/src/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/InteractiveLayout.tsx
@@ -758,7 +758,7 @@ export const InteractiveLayout = (props: WebProps | AppsProps) => {
 						padSides={false}
 						showTopBorder={false}
 						showSideBorders={false}
-						backgroundColour={themePalette('--ad-slot-background')}
+						backgroundColour={themePalette('--ad-background')}
 						element="aside"
 					>
 						<AdSlot
@@ -884,7 +884,7 @@ export const InteractiveLayout = (props: WebProps | AppsProps) => {
 						padSides={false}
 						showTopBorder={false}
 						showSideBorders={false}
-						backgroundColour={themePalette('--ad-slot-background')}
+						backgroundColour={themePalette('--ad-background')}
 						element="aside"
 					>
 						<AdSlot

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -1304,9 +1304,7 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 							padSides={false}
 							showTopBorder={true}
 							showSideBorders={false}
-							backgroundColour={themePalette(
-								'--ad-slot-background',
-							)}
+							backgroundColour={themePalette('--ad-background')}
 							shouldCenter={false}
 							element="aside"
 						>
@@ -1442,9 +1440,7 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 							padSides={false}
 							showTopBorder={false}
 							showSideBorders={false}
-							backgroundColour={themePalette(
-								'--ad-slot-background',
-							)}
+							backgroundColour={themePalette('--ad-background')}
 							element="aside"
 						>
 							<AdSlot

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -1305,7 +1305,7 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 							showTopBorder={true}
 							showSideBorders={false}
 							backgroundColour={themePalette(
-								'--article-section-background',
+								'--ad-slot-background',
 							)}
 							shouldCenter={false}
 							element="aside"
@@ -1443,7 +1443,7 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 							showTopBorder={false}
 							showSideBorders={false}
 							backgroundColour={themePalette(
-								'--article-section-background',
+								'--ad-slot-background',
 							)}
 							element="aside"
 						>

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -1304,7 +1304,9 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 							padSides={false}
 							showTopBorder={true}
 							showSideBorders={false}
-							backgroundColour={sourcePalette.neutral[97]}
+							backgroundColour={themePalette(
+								'--article-section-background',
+							)}
 							shouldCenter={false}
 							element="aside"
 						>
@@ -1440,7 +1442,9 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 							padSides={false}
 							showTopBorder={false}
 							showSideBorders={false}
-							backgroundColour={sourcePalette.neutral[97]}
+							backgroundColour={themePalette(
+								'--article-section-background',
+							)}
 							element="aside"
 						>
 							<AdSlot

--- a/dotcom-rendering/src/layouts/PictureLayout.tsx
+++ b/dotcom-rendering/src/layouts/PictureLayout.tsx
@@ -699,9 +699,7 @@ export const PictureLayout = (props: WebProps | AppsProps) => {
 						padSides={false}
 						showTopBorder={false}
 						showSideBorders={false}
-						backgroundColour={themePalette(
-							'--article-section-background',
-						)}
+						backgroundColour={themePalette('--ad-slot-background')}
 						element="aside"
 					>
 						<AdSlot
@@ -824,9 +822,7 @@ export const PictureLayout = (props: WebProps | AppsProps) => {
 						padSides={false}
 						showTopBorder={false}
 						showSideBorders={false}
-						backgroundColour={themePalette(
-							'--article-section-background',
-						)}
+						backgroundColour={themePalette('--ad-slot-background')}
 						element="aside"
 					>
 						<AdSlot

--- a/dotcom-rendering/src/layouts/PictureLayout.tsx
+++ b/dotcom-rendering/src/layouts/PictureLayout.tsx
@@ -699,7 +699,7 @@ export const PictureLayout = (props: WebProps | AppsProps) => {
 						padSides={false}
 						showTopBorder={false}
 						showSideBorders={false}
-						backgroundColour={themePalette('--ad-slot-background')}
+						backgroundColour={themePalette('--ad-background')}
 						element="aside"
 					>
 						<AdSlot
@@ -822,7 +822,7 @@ export const PictureLayout = (props: WebProps | AppsProps) => {
 						padSides={false}
 						showTopBorder={false}
 						showSideBorders={false}
-						backgroundColour={themePalette('--ad-slot-background')}
+						backgroundColour={themePalette('--ad-background')}
 						element="aside"
 					>
 						<AdSlot

--- a/dotcom-rendering/src/layouts/PictureLayout.tsx
+++ b/dotcom-rendering/src/layouts/PictureLayout.tsx
@@ -699,7 +699,9 @@ export const PictureLayout = (props: WebProps | AppsProps) => {
 						padSides={false}
 						showTopBorder={false}
 						showSideBorders={false}
-						backgroundColour={sourcePalette.neutral[97]}
+						backgroundColour={themePalette(
+							'--article-section-background',
+						)}
 						element="aside"
 					>
 						<AdSlot
@@ -822,7 +824,9 @@ export const PictureLayout = (props: WebProps | AppsProps) => {
 						padSides={false}
 						showTopBorder={false}
 						showSideBorders={false}
-						backgroundColour={sourcePalette.neutral[97]}
+						backgroundColour={themePalette(
+							'--article-section-background',
+						)}
 						element="aside"
 					>
 						<AdSlot

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -856,7 +856,7 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 						padSides={false}
 						showTopBorder={false}
 						showSideBorders={false}
-						backgroundColour={sourcePalette.neutral[97]}
+						backgroundColour={themePalette('--ad-slot-background')}
 						element="aside"
 					>
 						<AdSlot
@@ -976,7 +976,7 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 						padSides={false}
 						showTopBorder={false}
 						showSideBorders={false}
-						backgroundColour={sourcePalette.neutral[97]}
+						backgroundColour={themePalette('--ad-slot-background')}
 						element="aside"
 					>
 						<AdSlot

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -856,7 +856,7 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 						padSides={false}
 						showTopBorder={false}
 						showSideBorders={false}
-						backgroundColour={themePalette('--ad-slot-background')}
+						backgroundColour={themePalette('--ad-background')}
 						element="aside"
 					>
 						<AdSlot
@@ -976,7 +976,7 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 						padSides={false}
 						showTopBorder={false}
 						showSideBorders={false}
-						backgroundColour={themePalette('--ad-slot-background')}
+						backgroundColour={themePalette('--ad-background')}
 						element="aside"
 					>
 						<AdSlot

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -1001,7 +1001,7 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 						padSides={false}
 						showTopBorder={false}
 						showSideBorders={false}
-						backgroundColour={themePalette('--ad-slot-background')}
+						backgroundColour={themePalette('--ad-background')}
 						element="aside"
 					>
 						<AdSlot
@@ -1126,7 +1126,7 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 						padSides={false}
 						showTopBorder={false}
 						showSideBorders={false}
-						backgroundColour={themePalette('--ad-slot-background')}
+						backgroundColour={themePalette('--ad-background')}
 						element="aside"
 					>
 						<AdSlot
@@ -1212,7 +1212,7 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 					<Section
 						fullWidth={true}
 						data-print-layout="hide"
-						backgroundColour={themePalette('--ad-slot-background')}
+						backgroundColour={themePalette('--ad-background')}
 						borderColour={themePalette('--article-border')}
 						padSides={false}
 						showSideBorders={false}

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -1001,9 +1001,7 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 						padSides={false}
 						showTopBorder={false}
 						showSideBorders={false}
-						backgroundColour={themePalette(
-							'--article-section-background',
-						)}
+						backgroundColour={themePalette('--ad-slot-background')}
 						element="aside"
 					>
 						<AdSlot
@@ -1128,9 +1126,7 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 						padSides={false}
 						showTopBorder={false}
 						showSideBorders={false}
-						backgroundColour={themePalette(
-							'--article-section-background',
-						)}
+						backgroundColour={themePalette('--ad-slot-background')}
 						element="aside"
 					>
 						<AdSlot
@@ -1216,9 +1212,7 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 					<Section
 						fullWidth={true}
 						data-print-layout="hide"
-						backgroundColour={themePalette(
-							'--article-section-background',
-						)}
+						backgroundColour={themePalette('--ad-slot-background')}
 						borderColour={themePalette('--article-border')}
 						padSides={false}
 						showSideBorders={false}

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -1001,7 +1001,9 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 						padSides={false}
 						showTopBorder={false}
 						showSideBorders={false}
-						backgroundColour={sourcePalette.neutral[97]}
+						backgroundColour={themePalette(
+							'--article-section-background',
+						)}
 						element="aside"
 					>
 						<AdSlot
@@ -1126,7 +1128,9 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 						padSides={false}
 						showTopBorder={false}
 						showSideBorders={false}
-						backgroundColour={sourcePalette.neutral[97]}
+						backgroundColour={themePalette(
+							'--article-section-background',
+						)}
 						element="aside"
 					>
 						<AdSlot

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -1785,17 +1785,30 @@ const tableOfContentsBorderLight: PaletteFunction = () =>
 const tableOfContentsBorderDark: PaletteFunction = () =>
 	sourcePalette.neutral[20];
 
-const adLabelsTextLight: PaletteFunction = () => {
-	return sourcePalette.neutral[20];
+const adLabelsTextLight: PaletteFunction = () => sourcePalette.neutral[46];
+const adLabelsTextDark: PaletteFunction = () => sourcePalette.neutral[97];
+
+const adSlotBackgroundLight: PaletteFunction = ({ design }) => {
+	switch (design) {
+		case ArticleDesign.LiveBlog:
+			return sourcePalette.neutral[93];
+		default:
+			return sourcePalette.neutral[97];
+	}
 };
-const adLabelsTextDark: PaletteFunction = () => {
-	return sourcePalette.neutral[100];
+const adSlotBackgroundDark: PaletteFunction = ({ design }) => {
+	switch (design) {
+		case ArticleDesign.LiveBlog:
+			return sourcePalette.neutral[7];
+		default:
+			return sourcePalette.neutral[0];
+	}
 };
-const adBackgroundLight: PaletteFunction = () => {
-	return sourcePalette.neutral[97];
-};
-const adBackgroundDark: PaletteFunction = () => {
-	return sourcePalette.neutral[20];
+
+const adSlotBorderLight: PaletteFunction = () => sourcePalette.neutral[86];
+
+const adSlotBorderDark: PaletteFunction = () => {
+	return sourcePalette.neutral[0];
 };
 const adSupportBannerBackgroundLight: PaletteFunction = () => {
 	return sourcePalette.neutral[93];
@@ -5665,9 +5678,13 @@ const paletteColours = {
 		light: accordionTitleRowFillLight,
 		dark: accordionTitleRowFillDark,
 	},
-	'--ad-background': {
-		light: adBackgroundLight,
-		dark: adBackgroundDark,
+	'--ad-slot-border': {
+		light: adSlotBorderLight,
+		dark: adSlotBorderDark,
+	},
+	'--ad-slot-background': {
+		light: adSlotBackgroundLight,
+		dark: adSlotBackgroundDark,
 	},
 	'--ad-labels-text': {
 		light: adLabelsTextLight,

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -1788,11 +1788,11 @@ const tableOfContentsBorderDark: PaletteFunction = () =>
 const adLabelsTextLight: PaletteFunction = () => sourcePalette.neutral[46];
 const adLabelsTextDark: PaletteFunction = () => sourcePalette.neutral[86];
 
-const adSlotBackgroundLight: PaletteFunction = () => sourcePalette.neutral[97];
+const adBackgroundLight: PaletteFunction = () => sourcePalette.neutral[97];
 
-const adSlotBackgroundDark: PaletteFunction = () => sourcePalette.neutral[7];
+const adBackgroundDark: PaletteFunction = () => sourcePalette.neutral[20];
 
-const articleInnerAdSlotBackgroundLight: PaletteFunction = ({ design }) => {
+const articleInnerAdBackgroundLight: PaletteFunction = ({ design }) => {
 	switch (design) {
 		case ArticleDesign.LiveBlog:
 			return sourcePalette.neutral[93];
@@ -1800,7 +1800,7 @@ const articleInnerAdSlotBackgroundLight: PaletteFunction = ({ design }) => {
 			return sourcePalette.neutral[97];
 	}
 };
-const articleInnerAdSlotBackgroundDark: PaletteFunction = ({ design }) => {
+const articleInnerAdBackgroundDark: PaletteFunction = ({ design }) => {
 	switch (design) {
 		case ArticleDesign.LiveBlog:
 			return sourcePalette.neutral[7];
@@ -1809,9 +1809,9 @@ const articleInnerAdSlotBackgroundDark: PaletteFunction = ({ design }) => {
 	}
 };
 
-const adSlotBorderLight: PaletteFunction = () => sourcePalette.neutral[86];
+const adBorderLight: PaletteFunction = () => sourcePalette.neutral[86];
 
-const adSlotBorderDark: PaletteFunction = () => sourcePalette.neutral[20];
+const adBorderDark: PaletteFunction = () => sourcePalette.neutral[38];
 
 const adSupportBannerBackgroundLight: PaletteFunction = () => {
 	return sourcePalette.neutral[93];
@@ -5681,17 +5681,17 @@ const paletteColours = {
 		light: accordionTitleRowFillLight,
 		dark: accordionTitleRowFillDark,
 	},
-	'--ad-slot-border': {
-		light: adSlotBorderLight,
-		dark: adSlotBorderDark,
+	'--ad-background': {
+		light: adBackgroundLight,
+		dark: adBackgroundDark,
 	},
-	'--ad-slot-background': {
-		light: adSlotBackgroundLight,
-		dark: adSlotBackgroundDark,
+	'--ad-background-article-inner': {
+		light: articleInnerAdBackgroundLight,
+		dark: articleInnerAdBackgroundDark,
 	},
-	'--article-inner-ad-slot-background': {
-		light: articleInnerAdSlotBackgroundLight,
-		dark: articleInnerAdSlotBackgroundDark,
+	'--ad-border': {
+		light: adBorderLight,
+		dark: adBorderDark,
 	},
 	'--ad-labels-text': {
 		light: adLabelsTextLight,

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -1786,9 +1786,13 @@ const tableOfContentsBorderDark: PaletteFunction = () =>
 	sourcePalette.neutral[20];
 
 const adLabelsTextLight: PaletteFunction = () => sourcePalette.neutral[46];
-const adLabelsTextDark: PaletteFunction = () => sourcePalette.neutral[97];
+const adLabelsTextDark: PaletteFunction = () => sourcePalette.neutral[86];
 
-const adSlotBackgroundLight: PaletteFunction = ({ design }) => {
+const adSlotBackgroundLight: PaletteFunction = () => sourcePalette.neutral[97];
+
+const adSlotBackgroundDark: PaletteFunction = () => sourcePalette.neutral[7];
+
+const articleInnerAdSlotBackgroundLight: PaletteFunction = ({ design }) => {
 	switch (design) {
 		case ArticleDesign.LiveBlog:
 			return sourcePalette.neutral[93];
@@ -1796,20 +1800,19 @@ const adSlotBackgroundLight: PaletteFunction = ({ design }) => {
 			return sourcePalette.neutral[97];
 	}
 };
-const adSlotBackgroundDark: PaletteFunction = ({ design }) => {
+const articleInnerAdSlotBackgroundDark: PaletteFunction = ({ design }) => {
 	switch (design) {
 		case ArticleDesign.LiveBlog:
 			return sourcePalette.neutral[7];
 		default:
-			return sourcePalette.neutral[0];
+			return sourcePalette.neutral[20];
 	}
 };
 
 const adSlotBorderLight: PaletteFunction = () => sourcePalette.neutral[86];
 
-const adSlotBorderDark: PaletteFunction = () => {
-	return sourcePalette.neutral[0];
-};
+const adSlotBorderDark: PaletteFunction = () => sourcePalette.neutral[20];
+
 const adSupportBannerBackgroundLight: PaletteFunction = () => {
 	return sourcePalette.neutral[93];
 };
@@ -5685,6 +5688,10 @@ const paletteColours = {
 	'--ad-slot-background': {
 		light: adSlotBackgroundLight,
 		dark: adSlotBackgroundDark,
+	},
+	'--article-inner-ad-slot-background': {
+		light: articleInnerAdSlotBackgroundLight,
+		dark: articleInnerAdSlotBackgroundDark,
 	},
 	'--ad-labels-text': {
 		light: adLabelsTextLight,


### PR DESCRIPTION
## What does this change?

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
