### PR TITLE
Adjust standfirst padding for mobile to left col

### DIFF
--- a/dotcom-rendering/src/components/Standfirst.tsx
+++ b/dotcom-rendering/src/components/Standfirst.tsx
@@ -182,10 +182,9 @@ const decidePadding = ({ display, design }: ArticleFormat) => {
 			switch (display) {
 				case ArticleDisplay.Showcase: {
 					return css`
-						padding-bottom: 14px;
-
-						${from.leftCol} {
-							padding-bottom: 0;
+						padding-bottom: 8px;
+						${from.tablet} {
+							padding-bottom: ${space[0]}px;
 						}
 					`;
 				}

--- a/dotcom-rendering/src/components/Standfirst.tsx
+++ b/dotcom-rendering/src/components/Standfirst.tsx
@@ -182,7 +182,11 @@ const decidePadding = ({ display, design }: ArticleFormat) => {
 			switch (display) {
 				case ArticleDisplay.Showcase: {
 					return css`
-						padding-bottom: 0;
+						padding-bottom: 14px;
+
+						${from.leftCol} {
+							padding-bottom: 0;
+						}
 					`;
 				}
 				case ArticleDisplay.Immersive:


### PR DESCRIPTION
## What does this change?

- Introduces padding to the standfirst for Interview articles with a showcase main media, to stop the standfirst running into the image

## Screenshots
![image](https://github.com/guardian/dotcom-rendering/assets/705427/cfc547b3-43f0-49d6-be80-012cac8ddf41)
