### PR TITLE
Update padding and default colours for tag link

### DIFF
--- a/dotcom-rendering/src/components/TagLink.tsx
+++ b/dotcom-rendering/src/components/TagLink.tsx
@@ -94,7 +94,7 @@ const arrowStyles = css`
 
 const fillBarStyles = css`
 	background-color: ${palette('--tag-link-fill-background')};
-	margin-top: -${space[2]}px;
+	margin-top: -${space[3]}px;
 	width: 100%;
 	height: 20px;
 	margin-bottom: -${space[2]}px;

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -5602,7 +5602,7 @@ const tagLinkFillBackground: PaletteFunction = ({ design, display, theme }) => {
 							return sourcePalette.neutral[97];
 					}
 				default:
-					return 'transparent';
+					return sourcePalette.neutral[100];
 			}
 	}
 };


### PR DESCRIPTION
## What does this change?
Increases padding and changes the default colour for the fill on mobile views
## Why?
This has been requested by design.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/20416599/0021faa9-e424-44e9-a6f5-2f8ceabc326f
[after]: https://github.com/guardian/dotcom-rendering/assets/20416599/ac6c53fb-8497-4312-a831-d1aa0d4b990b


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
