### PR TITLE
Filter out empty blocks on latest links

### DIFF
--- a/dotcom-rendering/src/components/LatestLinks.importable.stories.tsx
+++ b/dotcom-rendering/src/components/LatestLinks.importable.stories.tsx
@@ -49,7 +49,7 @@ const Wrapper = ({
 							title: null,
 							publishedDateTime: 1692525060000,
 							lastUpdatedDateTime: 1692525060000,
-							body: 'Millie Bright has captained England in place of the injured Leah Williamson at this tournament. What’s her story I hear you ask, we’ve got you covered:',
+							body: '',
 						},
 						{
 							id: '64e1342b8f08af8aaccf0332',
@@ -152,6 +152,7 @@ const Wrapper = ({
 export const WorldCupFinal2023 = () => {
 	const containerPalette = 'EventAltPalette' satisfies DCRContainerPalette;
 	const overrides = decideContainerOverrides(containerPalette);
+
 	return (
 		<Wrapper
 			styles={css`

--- a/dotcom-rendering/src/components/LatestLinks.importable.tsx
+++ b/dotcom-rendering/src/components/LatestLinks.importable.tsx
@@ -139,59 +139,62 @@ export const LatestLinks = ({
 			]}
 		>
 			{data && data.blocks.length >= 3 ? (
-				data.blocks.slice(0, 3).map((block, index) => (
-					<>
-						<ContainerOverrides
-							containerPalette={containerPalette}
-							isDynamo={!!isDynamo}
-						>
-							{index > 0 && (
-								<li
-									key={block.id + ' : divider'}
-									css={[dividerStyles, dividerColour]}
-								></li>
-							)}
-							<li
-								key={block.id}
-								css={linkStyles}
-								className={'reveal'}
+				data.blocks
+					.filter((block) => block.body.trim() !== '')
+					.slice(0, 3)
+					.map((block, index) => (
+						<>
+							<ContainerOverrides
+								containerPalette={containerPalette}
+								isDynamo={!!isDynamo}
 							>
-								<WithLink
-									linkTo={`${id}?page=with:block-${block.id}#block-${block.id}`}
-									isDynamo={isDynamo}
+								{index > 0 && (
+									<li
+										key={block.id + ' : divider'}
+										css={[dividerStyles, dividerColour]}
+									></li>
+								)}
+								<li
+									key={block.id}
+									css={linkStyles}
+									className={'reveal'}
 								>
-									<div
-										css={bold}
-										style={{
-											color: themePalette(
-												'--card-kicker-text',
-											),
-										}}
+									<WithLink
+										linkTo={`${id}?page=with:block-${block.id}#block-${block.id}`}
+										isDynamo={isDynamo}
 									>
-										<DateTime
-											date={
-												new Date(
-													block.publishedDateTime,
-												)
-											}
-											display="relative"
-											absoluteServerTimes={
-												absoluteServerTimes
-											}
-											editionId={'UK'}
-											showWeekday={false}
-											showDate={true}
-											showTime={false}
-										/>
-									</div>
-									<span className="show-underline">
-										{extractAboutThreeLines(block.body)}
-									</span>
-								</WithLink>
-							</li>
-						</ContainerOverrides>
-					</>
-				))
+										<div
+											css={bold}
+											style={{
+												color: themePalette(
+													'--card-kicker-text',
+												),
+											}}
+										>
+											<DateTime
+												date={
+													new Date(
+														block.publishedDateTime,
+													)
+												}
+												display="relative"
+												absoluteServerTimes={
+													absoluteServerTimes
+												}
+												editionId={'UK'}
+												showWeekday={false}
+												showDate={true}
+												showTime={false}
+											/>
+										</div>
+										<span className="show-underline">
+											{extractAboutThreeLines(block.body)}
+										</span>
+									</WithLink>
+								</li>
+							</ContainerOverrides>
+						</>
+					))
 			) : (
 				<>
 					<li css={linkStyles} />


### PR DESCRIPTION
## What does this change?
This adds a filter to remove empty blocks on latest links
## Why?
Fixes https://github.com/guardian/dotcom-rendering/issues/11475
## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/110032454/c59234d6-6868-4eb9-8c25-3dd29b946464
[after]: https://github.com/guardian/dotcom-rendering/assets/110032454/c1d1e5ac-1e14-4e4b-b513-b8d993819a83

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
