### PR TITLE
Use the same canonical URL for network fronts

### DIFF
--- a/dotcom-rendering/src/server/render.front.web.tsx
+++ b/dotcom-rendering/src/server/render.front.web.tsx
@@ -148,7 +148,9 @@ export const renderFront = ({
 	const keywords = front.config.keywords;
 
 	const canonicalUrl =
-		front.isNetworkFront && !!front.canonicalUrl
+		front.isNetworkFront &&
+		!!front.canonicalUrl &&
+		URL.canParse(front.canonicalUrl)
 			? new URL(front.canonicalUrl).origin
 			: front.canonicalUrl;
 

--- a/dotcom-rendering/src/server/render.front.web.tsx
+++ b/dotcom-rendering/src/server/render.front.web.tsx
@@ -147,6 +147,11 @@ export const renderFront = ({
 
 	const keywords = front.config.keywords;
 
+	const canonicalUrl =
+		front.isNetworkFront && !!front.canonicalUrl
+			? new URL(front.canonicalUrl).origin
+			: front.canonicalUrl;
+
 	const pageHtml = htmlPageTemplate({
 		scriptTags,
 		css: extractedCss,
@@ -158,7 +163,7 @@ export const renderFront = ({
 		renderingTarget: 'Web',
 		hasPageSkin: front.config.hasPageSkin,
 		weAreHiring: !!front.config.switches.weAreHiring,
-		canonicalUrl: front.canonicalUrl,
+		canonicalUrl,
 	});
 
 	return {


### PR DESCRIPTION
Closes #11652

## What does this change?

Use the same canonical URL for all network fronts:
- /uk
- /us 
- /europe 
- /au 
- /international

The new canonical URL is `https://www.theguardian.com`

## Why?

This is our way of signalling to google to not direct external traffic to them directly and to instead send the traffic to `https://www.theguardian.com` where we'll handle the redirect.