### PR TITLE
Cleaner, more spacious `MatchNav` placeholder

### DIFF
--- a/dotcom-rendering/src/components/GetMatchNav.importable.tsx
+++ b/dotcom-rendering/src/components/GetMatchNav.importable.tsx
@@ -24,10 +24,8 @@ type MatchData = {
 };
 
 const fallbackTeam = {
-	name: '…',
-	// this ensures we reserve space for at least one goal per team
-	// note that reserving more or less space could help prevent CLS
-	scorers: ['…'],
+	name: '―',
+	scorers: [],
 	score: NaN,
 	crest: '',
 } satisfies MatchData['homeTeam'];

--- a/dotcom-rendering/src/components/MatchNav.tsx
+++ b/dotcom-rendering/src/components/MatchNav.tsx
@@ -105,7 +105,17 @@ const Scorers = ({ scorers }: { scorers: string[] }) => (
 					${textSans15}
 				`}
 			>
-				{player}
+				{player.startsWith('placeholder-') ? (
+					<span
+						css={css`
+							opacity: 0;
+						`}
+					>
+						―
+					</span>
+				) : (
+					player
+				)}
 			</li>
 		))}
 	</ul>
@@ -168,7 +178,15 @@ const TeamNav = ({
 				`}
 			>
 				<TeamName name={name} />
-				<Scorers scorers={scorers} />
+				<Scorers
+					scorers={[
+						...scorers,
+						// this ensures we reserve space for at least three scorers per team
+						'placeholder-1',
+						'placeholder-2',
+						'placeholder-3',
+					].slice(0, Math.max(3, scorers.length))}
+				/>
 			</div>
 			<CrestRow>
 				<Crest crest={crest} />


### PR DESCRIPTION
## What does this change?

- use a dash instead of an ellipsis
- reserve space for three goals

## Why?

- reduce CLS
- improve design
- #11668 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/76776/804b3ce2-f8ca-4336-857f-d6a6dca37328
[after]: https://github.com/guardian/dotcom-rendering/assets/76776/24a18d13-1ee4-4f62-b36c-62733a4948f7


https://github.com/guardian/dotcom-rendering/assets/76776/92563921-4874-403e-9638-d704e9f3b5cf

## Known issues

While rare, it [does happen that one teams scores more than 3 goals](https://www.theguardian.com/football/live/2023/sep/24/sheffield-united-v-newcastle-premier-league-live).