### PR TITLE
Handle missing video ID gracefully

### DIFF
--- a/dotcom-rendering/src/components/VideoVimeoBlockComponent.amp.tsx
+++ b/dotcom-rendering/src/components/VideoVimeoBlockComponent.amp.tsx
@@ -1,8 +1,8 @@
+import { levels } from 'log4js';
 import { getIdFromUrl } from '../lib/get-video-id.amp';
 import { logger } from '../server/lib/logging';
 import type { VideoVimeoBlockElement } from '../types/content';
 import { Caption } from './Caption.amp';
-import { levels } from 'log4js';
 
 type Props = {
 	element: VideoVimeoBlockElement;

--- a/dotcom-rendering/src/components/VideoVimeoBlockComponent.amp.tsx
+++ b/dotcom-rendering/src/components/VideoVimeoBlockComponent.amp.tsx
@@ -1,6 +1,8 @@
 import { getIdFromUrl } from '../lib/get-video-id.amp';
+import { logger } from '../server/lib/logging';
 import type { VideoVimeoBlockElement } from '../types/content';
 import { Caption } from './Caption.amp';
+import { levels } from 'log4js';
 
 type Props = {
 	element: VideoVimeoBlockElement;
@@ -14,6 +16,9 @@ export const VideoVimeoBlockComponent = ({ element, pillar }: Props) => {
 	// We should remove this once ☝️ is fixed.
 	const url = element.url === '' ? element.originalUrl ?? '' : element.url;
 	const vimeoId = getIdFromUrl(url, true);
+
+	logger.log(levels.ERROR, `Could not get an id from: ${url}`);
+	if (!vimeoId) return null;
 
 	return (
 		<Caption captionText={element.caption} pillar={pillar}>

--- a/dotcom-rendering/src/components/VideoYoutubeBlockComponent.amp.tsx
+++ b/dotcom-rendering/src/components/VideoYoutubeBlockComponent.amp.tsx
@@ -1,4 +1,6 @@
+import { levels } from 'log4js';
 import { getIdFromUrl } from '../lib/get-video-id.amp';
+import { logger } from '../server/lib/logging';
 import type { VideoYoutubeBlockElement } from '../types/content';
 import { Caption } from './Caption.amp';
 
@@ -8,11 +10,12 @@ type Props = {
 };
 
 export const VideoYoutubeBlockComponent = ({ element, pillar }: Props) => {
-	const youtubeId = getIdFromUrl(
-		element.originalUrl || element.url,
-		true,
-		'v',
-	);
+	const url = element.originalUrl || element.url;
+	const youtubeId = getIdFromUrl(url, true, 'v');
+
+	logger.log(levels.ERROR, `Could not get an id from: ${url}`);
+	if (!youtubeId) return null;
+
 	return (
 		<Caption captionText={element.caption} pillar={pillar}>
 			<amp-youtube

--- a/dotcom-rendering/src/lib/get-video-id.amp.test.ts
+++ b/dotcom-rendering/src/lib/get-video-id.amp.test.ts
@@ -72,17 +72,17 @@ describe('getIdFromUrl', () => {
 		}
 	});
 
-	it('Throws an error if it cannot find an ID', () => {
-		expect(() => {
-			getIdFromUrl('https://theguardian.com', false, 'v');
-		}).toThrow();
+	it('Returns undefined if it cannot find an ID', () => {
+		expect(
+			getIdFromUrl('https://theguardian.com', false, 'v'),
+		).toBeUndefined();
 
-		expect(() => {
-			getIdFromUrl('https://theguardian.com?p=test', false, 'v');
-		}).toThrow();
+		expect(
+			getIdFromUrl('https://theguardian.com?p=test', false, 'v'),
+		).toBeUndefined();
 
-		expect(() => {
-			getIdFromUrl('https://theguardian.com/test', false, 'p');
-		}).toThrow();
+		expect(
+			getIdFromUrl('https://theguardian.com/test', false, 'p'),
+		).toBeUndefined();
 	});
 });

--- a/dotcom-rendering/src/lib/get-video-id.amp.ts
+++ b/dotcom-rendering/src/lib/get-video-id.amp.ts
@@ -5,20 +5,16 @@ export const getIdFromUrl = (
 	urlString: string,
 	tryInPath?: boolean,
 	tryQueryParam?: string,
-): string => {
+): string | undefined => {
+	if (!URL.canParse(urlString)) return undefined;
+
 	// Looks for ID in both formats if provided
 	const url = new URL(urlString);
 
-	const id = [
+	return [
 		tryQueryParam
 			? new URLSearchParams(url.search).get(tryQueryParam)
 			: undefined,
 		tryInPath ? url.pathname.split('/').at(-1) : undefined,
 	].find(isString);
-
-	if (id !== undefined) return id;
-
-	throw new Error(
-		`getIdFromUrl: The URL ${urlString} did not contain an ID.`,
-	);
 };


### PR DESCRIPTION
## What does this change?

Return `undefined` instead of throwing an error when no video ID can be found

Follow-up on:
- #11243

## Why?

Be resilient to malformed data!

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/76776/0bff7977-bb88-412e-a361-a483906b0e74
[after]: https://github.com/guardian/dotcom-rendering/assets/76776/66f4d594-5499-467d-918d-55ad98ca5933