### PR TITLE
Show date on tag pages if its after 12 hours

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -316,11 +316,10 @@ export const Card = ({
 
 	const decideAge = () => {
 		if (!webPublicationDate) return undefined;
+		const withinTwelveHours = isWithinTwelveHours(webPublicationDate);
 
 		const shouldShowAge =
-			isTagPage ||
-			!!onwardsSource ||
-			(showAge && isWithinTwelveHours(webPublicationDate));
+			isTagPage || !!onwardsSource || (showAge && withinTwelveHours);
 
 		if (!shouldShowAge) return undefined;
 
@@ -328,7 +327,10 @@ export const Card = ({
 			<CardAge
 				format={format}
 				containerPalette={containerPalette}
-				webPublicationDate={webPublicationDate}
+				webPublication={{
+					date: webPublicationDate,
+					isWithinTwelveHours: withinTwelveHours,
+				}}
 				showClock={showClock}
 				isDynamo={isDynamo}
 				isOnwardContent={isOnwardContent}

--- a/dotcom-rendering/src/components/Card/components/CardAge.tsx
+++ b/dotcom-rendering/src/components/Card/components/CardAge.tsx
@@ -14,7 +14,10 @@ type Props = {
 	format: ArticleFormat;
 	absoluteServerTimes: boolean;
 	containerPalette?: DCRContainerPalette;
-	webPublicationDate: string;
+	webPublication: {
+		date: string;
+		isWithinTwelveHours: boolean;
+	};
 	showClock?: boolean;
 	isDynamo?: true;
 	isOnwardContent?: boolean;
@@ -71,14 +74,14 @@ const ageStyles = (
 export const CardAge = ({
 	format,
 	containerPalette,
-	webPublicationDate,
+	webPublication,
 	showClock,
 	isDynamo,
 	isOnwardContent,
 	absoluteServerTimes,
 	isTagPage,
 }: Props) => {
-	if (timeAgo(new Date(webPublicationDate).getTime()) === false) {
+	if (timeAgo(new Date(webPublication.date).getTime()) === false) {
 		return null;
 	}
 
@@ -89,16 +92,16 @@ export const CardAge = ({
 			{showClock && <ClockIcon />}
 			{isTagPage ? (
 				<DateTime
-					date={new Date(webPublicationDate)}
+					date={new Date(webPublication.date)}
 					display={'absolute'}
 					editionId={'UK'}
 					showWeekday={false}
-					showDate={false}
+					showDate={webPublication.isWithinTwelveHours ? false : true}
 					showTime={true}
 				/>
 			) : (
 				<DateTime
-					date={new Date(webPublicationDate)}
+					date={new Date(webPublication.date)}
 					display={'relative'}
 					absoluteServerTimes={absoluteServerTimes}
 					editionId={'UK'}

--- a/dotcom-rendering/src/components/Card/components/CardAge.tsx
+++ b/dotcom-rendering/src/components/Card/components/CardAge.tsx
@@ -96,7 +96,7 @@ export const CardAge = ({
 					display={'absolute'}
 					editionId={'UK'}
 					showWeekday={false}
-					showDate={webPublication.isWithinTwelveHours ? false : true}
+					showDate={!webPublication.isWithinTwelveHours}
 					showTime={true}
 				/>
 			) : (


### PR DESCRIPTION
## What does this change?
Updates the type of web publication to have two values, a date and if it is within 12 hours. We then use this to determine what time and date properties to display on tag page cards.

## Why?
We want to see dates on tag page cards so that they can be used effectively for curation purposes.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/20416599/8f2091e4-7f65-4a4d-a848-a53d8ec1aa48
[after]: https://github.com/guardian/dotcom-rendering/assets/20416599/f753b7d0-5ca9-41cf-b531-9b12c7c9b8ae
