### PR TITLE
[Fairground 🎡] Use `ContainerPalette` for `Section` and `FrontSection`

### DIFF
--- a/dotcom-rendering/src/components/Card/components/CardWrapper.tsx
+++ b/dotcom-rendering/src/components/Card/components/CardWrapper.tsx
@@ -67,7 +67,7 @@ const sublinkHoverStyles = css`
 
 const topBarStyles = css`
 	:before {
-		border-top: 1px solid ${palette('--card-border-top')};
+		border-top: 1px solid ${palette('--card-border')};
 		content: '';
 		z-index: 2;
 		width: 100%;

--- a/dotcom-rendering/src/components/ContainerOverrides.tsx
+++ b/dotcom-rendering/src/components/ContainerOverrides.tsx
@@ -29,6 +29,10 @@ export const ContainerOverrides = ({ containerPalette, children }: Props) => {
 		  };
 
 	const paletteOverrides = {
+		'--front-container-title': text?.container,
+		'--front-container-background': background?.container,
+		// '--card-border': border?.card,
+		'--front-container-border': border?.container,
 		'--card-background': background?.card,
 		'--card-headline-trail-text': text?.cardHeadline,
 		'--card-footer-text': text?.cardFooter,

--- a/dotcom-rendering/src/components/FrontSection.tsx
+++ b/dotcom-rendering/src/components/FrontSection.tsx
@@ -1,22 +1,17 @@
 import { css } from '@emotion/react';
 import { isString } from '@guardian/libs';
-import {
-	background,
-	between,
-	from,
-	palette,
-	space,
-	until,
-} from '@guardian/source/foundations';
+import { between, from, space, until } from '@guardian/source/foundations';
 import { pageSkinContainer } from '../layouts/lib/pageSkin';
 import { decideContainerOverrides } from '../lib/decideContainerOverrides';
 import type { EditionId } from '../lib/edition';
 import { hideAge } from '../lib/hideAge';
+import { palette } from '../palette';
 import type { CollectionBranding } from '../types/branding';
 import type { DCRContainerPalette, TreatType } from '../types/front';
 import type { DCRFrontPagination } from '../types/tagPage';
 import { isAustralianTerritory, type Territory } from '../types/territory';
 import { AustralianTerritorySwitcher } from './AustralianTerritorySwitcher.importable';
+import { ContainerOverrides } from './ContainerOverrides';
 import { ContainerTitle } from './ContainerTitle';
 import { FrontPagination } from './FrontPagination';
 import { FrontSectionTitle } from './FrontSectionTitle';
@@ -235,7 +230,7 @@ const sectionHeadlineUntilLeftCol = (isOpinion: boolean) => css`
 	}
 `;
 
-const sectionHeadlineFromLeftCol = (borderColour: string) => css`
+const sectionHeadlineFromLeftCol = css`
 	${from.leftCol} {
 		position: relative;
 		::after {
@@ -246,7 +241,7 @@ const sectionHeadlineFromLeftCol = (borderColour: string) => css`
 			height: 1.875rem;
 			right: -10px;
 			position: absolute;
-			background-color: ${borderColour};
+			background-color: ${palette('--front-container-border')};
 		}
 	}
 `;
@@ -312,17 +307,16 @@ const sectionTreats = css`
 	}
 `;
 
-const decoration = (borderColour: string) => {
+const decoration =
 	/** element which contains border and inner background colour, if set */
-	return css`
+	css`
 		grid-row: 1 / -1;
 		grid-column: decoration;
 
 		border-width: 1px;
-		border-color: ${borderColour};
+		border-color: ${palette('--front-container-border')};
 		border-style: none;
 	`;
-};
 
 /** only visible once content stops sticking to left and right edges */
 const sideBorders = css`
@@ -340,19 +334,6 @@ const topBorder = css`
 const bottomPadding = css`
 	padding-bottom: ${space[9]}px;
 `;
-
-const decideBackgroundColour = (
-	overrideBackgroundColour: string | undefined,
-	hasPageSkin: boolean,
-) => {
-	if (overrideBackgroundColour) {
-		return overrideBackgroundColour;
-	}
-	if (hasPageSkin) {
-		return background.primary;
-	}
-	return undefined;
-};
 
 /**
  * # Front Container
@@ -482,145 +463,133 @@ export const FrontSection = ({
 	 * this id pre-existed showMore so is probably also being used for something else.
 	 */
 	return (
-		<section
-			id={sectionId}
-			data-link-name={ophanComponentLink}
-			data-component={ophanComponentName}
-			data-container-name={containerName}
-			css={[
-				fallbackStyles,
-				containerStylesUntilLeftCol,
-				!hasPageSkin && containerStylesFromLeftCol,
-				hasPageSkin && pageSkinContainer,
-				css`
-					background-color: ${decideBackgroundColour(
-						overrides?.background.container,
-						hasPageSkin,
-					)};
-				`,
-			]}
-		>
-			<div
+		<ContainerOverrides containerPalette={containerPalette}>
+			<section
+				id={sectionId}
+				data-link-name={ophanComponentLink}
+				data-component={ophanComponentName}
+				data-container-name={containerName}
 				css={[
-					decoration(
-						overrides?.border.container ?? palette.neutral[86],
-					),
-					sideBorders,
-					showTopBorder && topBorder,
-				]}
-			/>
-
-			<div
-				css={[
-					sectionHeadlineUntilLeftCol(
-						// TODO FIXME:
-						// This relies on sections called "opinion"
-						// only ever having <CPScott> as the leftContent
-						title?.toLowerCase() === 'opinion',
-					),
-					!hasPageSkin &&
-						sectionHeadlineFromLeftCol(
-							overrides?.border.container ?? palette.neutral[86],
-						),
-					title?.toLowerCase() === 'headlines' &&
-						sectionHeadlineHeight,
+					fallbackStyles,
+					containerStylesUntilLeftCol,
+					!hasPageSkin && containerStylesFromLeftCol,
+					hasPageSkin && pageSkinContainer,
+					css`
+						background-color: ${palette(
+							'--front-container-background',
+						)};
+					`,
 				]}
 			>
-				<FrontSectionTitle
-					title={
-						<ContainerTitle
-							title={title}
-							lightweightHeader={isTagPage}
-							fontColour={overrides?.text.container}
-							description={description}
-							// On paid fronts the title is not treated as a link
-							url={!isOnPaidContentFront ? url : undefined}
-							containerPalette={containerPalette}
-							showDateHeader={showDateHeader}
-							editionId={editionId}
-						/>
-					}
-					collectionBranding={collectionBranding}
-					updateLogoAdPartnerSwitch={updateLogoAdPartnerSwitch}
+				<div
+					css={[decoration, sideBorders, showTopBorder && topBorder]}
 				/>
 
-				{leftContent}
-			</div>
-
-			{isToggleable && (
-				<div css={sectionShowHide}>
-					<ShowHideButton
-						sectionId={sectionId}
-						overrideContainerToggleColour={
-							overrides?.text.containerToggle
+				<div
+					css={[
+						sectionHeadlineUntilLeftCol(
+							// TODO FIXME:
+							// This relies on sections called "opinion"
+							// only ever having <CPScott> as the leftContent
+							title?.toLowerCase() === 'opinion',
+						),
+						!hasPageSkin && sectionHeadlineFromLeftCol,
+						title?.toLowerCase() === 'headlines' &&
+							sectionHeadlineHeight,
+					]}
+				>
+					<FrontSectionTitle
+						title={
+							<ContainerTitle
+								title={title}
+								lightweightHeader={isTagPage}
+								fontColour={overrides?.text.container}
+								description={description}
+								// On paid fronts the title is not treated as a link
+								url={!isOnPaidContentFront ? url : undefined}
+								containerPalette={containerPalette}
+								showDateHeader={showDateHeader}
+								editionId={editionId}
+							/>
 						}
+						collectionBranding={collectionBranding}
+						updateLogoAdPartnerSwitch={updateLogoAdPartnerSwitch}
 					/>
+
+					{leftContent}
 				</div>
-			)}
 
-			<div
-				css={[
-					sectionContent,
-					sectionContentPadded,
-					sectionContentRow(toggleable),
-					paddings,
-				]}
-				id={`container-${sectionId}`}
-			>
-				{children}
-			</div>
-
-			<div
-				css={[
-					sectionContentPadded,
-					sectionBottomContent,
-					bottomPadding,
-				]}
-			>
-				{isString(targetedTerritory) &&
-				isAustralianTerritory(targetedTerritory) ? (
-					<Island priority="feature" defer={{ until: 'visible' }}>
-						<AustralianTerritorySwitcher
-							targetedTerritory={targetedTerritory}
-						/>
-					</Island>
-				) : showMore ? (
-					<Island priority="feature" defer={{ until: 'interaction' }}>
-						<ShowMore
-							title={title}
-							sectionId={sectionId}
-							collectionId={collectionId}
-							pageId={pageId}
-							ajaxUrl={ajaxUrl}
-							editionId={editionId}
-							containerPalette={containerPalette}
-							showAge={!hideAge.includes(title)}
-							discussionApiUrl={discussionApiUrl}
-						/>
-					</Island>
-				) : null}
-				{pagination && (
-					<FrontPagination
-						sectionName={pagination.sectionName}
-						totalContent={pagination.totalContent}
-						currentPage={pagination.currentPage}
-						lastPage={pagination.lastPage}
-						pageId={pagination.pageId}
-					/>
+				{isToggleable && (
+					<div css={sectionShowHide}>
+						<ShowHideButton sectionId={sectionId} />
+					</div>
 				)}
-			</div>
 
-			{treats && !hasPageSkin && (
-				<div css={[sectionTreats, paddings]}>
-					<Treats
-						treats={treats}
-						borderColour={overrides?.border.container}
-						fontColour={
-							overrides?.text.container ?? palette.neutral[7]
-						}
-					/>
+				<div
+					css={[
+						sectionContent,
+						sectionContentPadded,
+						sectionContentRow(toggleable),
+						paddings,
+					]}
+					id={`container-${sectionId}`}
+				>
+					{children}
 				</div>
-			)}
-		</section>
+
+				<div
+					css={[
+						sectionContentPadded,
+						sectionBottomContent,
+						bottomPadding,
+					]}
+				>
+					{isString(targetedTerritory) &&
+					isAustralianTerritory(targetedTerritory) ? (
+						<Island priority="feature" defer={{ until: 'visible' }}>
+							<AustralianTerritorySwitcher
+								targetedTerritory={targetedTerritory}
+							/>
+						</Island>
+					) : showMore ? (
+						<Island
+							priority="feature"
+							defer={{ until: 'interaction' }}
+						>
+							<ShowMore
+								title={title}
+								sectionId={sectionId}
+								collectionId={collectionId}
+								pageId={pageId}
+								ajaxUrl={ajaxUrl}
+								editionId={editionId}
+								containerPalette={containerPalette}
+								showAge={!hideAge.includes(title)}
+								discussionApiUrl={discussionApiUrl}
+							/>
+						</Island>
+					) : null}
+					{pagination && (
+						<FrontPagination
+							sectionName={pagination.sectionName}
+							totalContent={pagination.totalContent}
+							currentPage={pagination.currentPage}
+							lastPage={pagination.lastPage}
+							pageId={pagination.pageId}
+						/>
+					)}
+				</div>
+
+				{treats && !hasPageSkin && (
+					<div css={[sectionTreats, paddings]}>
+						<Treats
+							treats={treats}
+							borderColour={palette('--front-container-border')}
+							fontColour={palette('--front-container-title')}
+						/>
+					</div>
+				)}
+			</section>
+		</ContainerOverrides>
 	);
 };

--- a/dotcom-rendering/src/components/Section.tsx
+++ b/dotcom-rendering/src/components/Section.tsx
@@ -1,12 +1,12 @@
 import { css } from '@emotion/react';
 import type { ArticleFormat } from '@guardian/libs';
 import { ArticleDesign } from '@guardian/libs';
-import { background, from, space, until } from '@guardian/source/foundations';
-import { decideContainerOverrides } from '../lib/decideContainerOverrides';
+import { from, space, until } from '@guardian/source/foundations';
 import type { EditionId } from '../lib/edition';
 import { hiddenStyles } from '../lib/hiddenStyles';
+import { palette } from '../palette';
 import type { DCRContainerPalette, TreatType } from '../types/front';
-import type { ContainerOverrides } from '../types/palette';
+import { ContainerOverrides } from './ContainerOverrides';
 import { ContainerTitle } from './ContainerTitle';
 import { ElementContainer } from './ElementContainer';
 import { Flex } from './Flex';
@@ -205,7 +205,6 @@ const ContainerTitleWithHide = ({
 	containerPalette,
 	showDateHeader,
 	editionId,
-	overrides,
 	hasPageSkin,
 }: {
 	title?: string;
@@ -215,13 +214,12 @@ const ContainerTitleWithHide = ({
 	containerPalette?: DCRContainerPalette;
 	showDateHeader?: boolean;
 	editionId?: EditionId;
-	overrides?: ContainerOverrides | undefined;
 	hasPageSkin?: boolean;
 }) => {
 	const containerTitle = (
 		<ContainerTitle
 			title={title}
-			fontColour={fontColour ?? overrides?.text.container}
+			fontColour={fontColour ?? palette('--front-container-title')}
 			description={description}
 			url={url}
 			containerPalette={containerPalette}
@@ -237,23 +235,6 @@ const ContainerTitleWithHide = ({
 			{containerTitle}
 		</Hide>
 	);
-};
-
-const decideBackgroundColour = (
-	backgroundColour: string | undefined,
-	overrideBackgroundColour: string | undefined,
-	hasPageSkin: boolean,
-) => {
-	if (backgroundColour) {
-		return backgroundColour;
-	}
-	if (overrideBackgroundColour) {
-		return overrideBackgroundColour;
-	}
-	if (hasPageSkin) {
-		return background.primary;
-	}
-	return undefined;
 };
 
 /**
@@ -304,146 +285,153 @@ export const Section = ({
 	hasPageSkinContentSelfConstrain = false,
 	className,
 }: Props) => {
-	const overrides =
-		containerPalette && decideContainerOverrides(containerPalette);
-
 	if (fullWidth) {
 		return (
+			<ContainerOverrides containerPalette={containerPalette}>
+				<ElementContainer
+					sectionId={sectionId}
+					showSideBorders={showSideBorders}
+					showTopBorder={showTopBorder}
+					padSides={padSides}
+					padBottom={padBottom}
+					format={format}
+					borderColour={
+						borderColour ?? palette('--front-container-border')
+					}
+					backgroundColour={
+						backgroundColour ??
+						palette('--front-container-background')
+					}
+					ophanComponentLink={ophanComponentLink}
+					ophanComponentName={ophanComponentName}
+					containerName={containerName}
+					innerBackgroundColour={innerBackgroundColour}
+					className={className}
+					element={element}
+					shouldCenter={shouldCenter}
+					hasPageSkin={hasPageSkin}
+					hasPageSkinContentSelfConstrain={
+						hasPageSkinContentSelfConstrain
+					}
+				>
+					{children}
+				</ElementContainer>
+			</ContainerOverrides>
+		);
+	}
+
+	return (
+		<ContainerOverrides containerPalette={containerPalette}>
 			<ElementContainer
 				sectionId={sectionId}
 				showSideBorders={showSideBorders}
 				showTopBorder={showTopBorder}
 				padSides={padSides}
-				padBottom={padBottom}
 				format={format}
-				borderColour={borderColour ?? overrides?.border.container}
-				backgroundColour={decideBackgroundColour(
-					backgroundColour,
-					overrides?.background.container,
-					hasPageSkin,
-				)}
+				borderColour={
+					borderColour ?? palette('--front-container-border')
+				}
+				backgroundColour={
+					backgroundColour ?? palette('--front-container-background')
+				}
+				element="section"
 				ophanComponentLink={ophanComponentLink}
 				ophanComponentName={ophanComponentName}
 				containerName={containerName}
 				innerBackgroundColour={innerBackgroundColour}
-				className={className}
-				element={element}
-				shouldCenter={shouldCenter}
 				hasPageSkin={hasPageSkin}
 				hasPageSkinContentSelfConstrain={
 					hasPageSkinContentSelfConstrain
 				}
 			>
-				{children}
-			</ElementContainer>
-		);
-	}
-
-	return (
-		<ElementContainer
-			sectionId={sectionId}
-			showSideBorders={showSideBorders}
-			showTopBorder={showTopBorder}
-			padSides={padSides}
-			format={format}
-			borderColour={borderColour ?? overrides?.border.container}
-			backgroundColour={decideBackgroundColour(
-				backgroundColour,
-				overrides?.background.container,
-				hasPageSkin,
-			)}
-			element="section"
-			ophanComponentLink={ophanComponentLink}
-			ophanComponentName={ophanComponentName}
-			containerName={containerName}
-			innerBackgroundColour={innerBackgroundColour}
-			hasPageSkin={hasPageSkin}
-			hasPageSkinContentSelfConstrain={hasPageSkinContentSelfConstrain}
-		>
-			<Flex>
-				<LeftColumn
-					borderType={centralBorder}
-					borderColour={borderColour ?? overrides?.border.container}
-					size={leftColSize}
-					verticalMargins={verticalMargins}
-					hasPageSkin={hasPageSkin}
-				>
-					<div
-						css={css`
-							display: flex;
-							height: 100%;
-							flex-direction: column;
-							justify-content: space-between;
-						`}
+				<Flex>
+					<LeftColumn
+						borderType={centralBorder}
+						borderColour={
+							borderColour ?? palette('--front-container-border')
+						}
+						size={leftColSize}
+						verticalMargins={verticalMargins}
+						hasPageSkin={hasPageSkin}
 					>
-						<div>
-							<ContainerTitle
+						<div
+							css={css`
+								display: flex;
+								height: 100%;
+								flex-direction: column;
+								justify-content: space-between;
+							`}
+						>
+							<div>
+								<ContainerTitle
+									title={title}
+									fontColour={
+										fontColour ??
+										palette('--front-container-title')
+									}
+									description={description}
+									url={url}
+									containerPalette={containerPalette}
+									showDateHeader={showDateHeader}
+									editionId={editionId}
+								/>
+								{leftContent}
+							</div>
+							{treats && (
+								<Treats
+									treats={treats}
+									borderColour={
+										borderColour ??
+										palette('--front-container-border')
+									}
+									fontColour={
+										fontColour ??
+										palette('--front-container-title')
+									}
+								/>
+							)}
+						</div>
+					</LeftColumn>
+					<Content
+						padded={padContent}
+						verticalMargins={verticalMargins}
+						stretchRight={stretchRight}
+						format={format}
+					>
+						<div
+							css={
+								hasPageSkin
+									? headlineContainerStylesWithPageSkin
+									: headlineContainerStyles
+							}
+						>
+							<ContainerTitleWithHide
 								title={title}
-								fontColour={
-									fontColour ?? overrides?.text.container
-								}
+								fontColour={fontColour}
 								description={description}
 								url={url}
 								containerPalette={containerPalette}
 								showDateHeader={showDateHeader}
 								editionId={editionId}
+								hasPageSkin={hasPageSkin}
 							/>
-							{leftContent}
+							{toggleable && !!sectionId && (
+								<ShowHideButton sectionId={sectionId} />
+							)}
 						</div>
-						{treats && (
-							<Treats
-								treats={treats}
-								borderColour={
-									borderColour ?? overrides?.border.container
-								}
-								fontColour={
-									fontColour ?? overrides?.text.container
-								}
-							/>
+						{toggleable && sectionId ? (
+							<div
+								css={hiddenStyles}
+								id={`container-${sectionId}`}
+							>
+								{children}
+							</div>
+						) : (
+							children
 						)}
-					</div>
-				</LeftColumn>
-				<Content
-					padded={padContent}
-					verticalMargins={verticalMargins}
-					stretchRight={stretchRight}
-					format={format}
-				>
-					<div
-						css={
-							hasPageSkin
-								? headlineContainerStylesWithPageSkin
-								: headlineContainerStyles
-						}
-					>
-						<ContainerTitleWithHide
-							title={title}
-							fontColour={fontColour ?? overrides?.text.container}
-							description={description}
-							url={url}
-							containerPalette={containerPalette}
-							showDateHeader={showDateHeader}
-							editionId={editionId}
-							hasPageSkin={hasPageSkin}
-						/>
-						{toggleable && !!sectionId && (
-							<ShowHideButton
-								sectionId={sectionId}
-								overrideContainerToggleColour={
-									overrides?.text.containerToggle
-								}
-							/>
-						)}
-					</div>
-					{toggleable && sectionId ? (
-						<div css={hiddenStyles} id={`container-${sectionId}`}>
-							{children}
-						</div>
-					) : (
-						children
-					)}
-				</Content>
-			</Flex>
-		</ElementContainer>
+					</Content>
+				</Flex>
+			</ElementContainer>
+		</ContainerOverrides>
 	);
 };

--- a/dotcom-rendering/src/components/ShowHideButton.tsx
+++ b/dotcom-rendering/src/components/ShowHideButton.tsx
@@ -1,16 +1,14 @@
 import { css } from '@emotion/react';
-import { palette, space, textSans14 } from '@guardian/source/foundations';
+import { space, textSans14 } from '@guardian/source/foundations';
 import { ButtonLink } from '@guardian/source/react-components';
+import { palette } from '../palette';
 
 type Props = {
 	sectionId: string;
-	overrideContainerToggleColour?: string;
 };
 
-const showHideButtonCss = (
-	overrideContainerToggleColour: string | undefined,
-) => css`
-	color: ${overrideContainerToggleColour ?? palette.neutral[46]};
+const showHideButtonCss = css`
+	color: ${palette('--front-container-toggle-text')};
 	${textSans14};
 
 	margin-top: ${space[2]}px;
@@ -25,14 +23,11 @@ const showHideButtonCss = (
  * This component creates the styled button for showing & hiding a container,
  * The functionality for this is implemented in a single island 'ShownHideContainers.importable'
  **/
-export const ShowHideButton = ({
-	sectionId,
-	overrideContainerToggleColour,
-}: Props) => {
+export const ShowHideButton = ({ sectionId }: Props) => {
 	return (
 		<ButtonLink
 			priority="secondary"
-			cssOverrides={showHideButtonCss(overrideContainerToggleColour)}
+			cssOverrides={showHideButtonCss}
 			data-link-name="Hide"
 			data-show-hide-button={sectionId}
 			aria-controls={sectionId}

--- a/dotcom-rendering/src/lib/decideContainerOverrides.ts
+++ b/dotcom-rendering/src/lib/decideContainerOverrides.ts
@@ -336,23 +336,15 @@ const borderContainer = (containerPalette: DCRContainerPalette): string => {
 const borderLines = (containerPalette: DCRContainerPalette): string => {
 	switch (containerPalette) {
 		case 'LongRunningPalette':
-			return neutral[100];
 		case 'LongRunningAltPalette':
-			return neutral[7];
 		case 'SombrePalette':
-			return neutral[100];
 		case 'SombreAltPalette':
-			return neutral[100];
 		case 'InvestigationPalette':
-			return neutral[100];
 		case 'BreakingPalette':
-			return neutral[100];
 		case 'EventPalette':
-			return brand[300];
 		case 'EventAltPalette':
-			return brand[300];
 		case 'SpecialReportAltPalette':
-			return transparentColour(neutral[46], 0.3);
+			return neutral[73];
 		case 'Branded':
 			return neutral[60];
 		case 'MediaPalette':

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -2367,9 +2367,9 @@ const standfirstTextDark: PaletteFunction = ({ design, display, theme }) => {
 	}
 };
 
-const cardBorderTopLight: PaletteFunction = () => sourcePalette.neutral[73];
+const cardBorderLight: PaletteFunction = () => sourcePalette.neutral[73];
 
-const cardBorderTopDark: PaletteFunction = () => sourcePalette.neutral[20];
+const cardBorderDark: PaletteFunction = () => sourcePalette.neutral[20];
 
 const cardBorderSupportingLight: PaletteFunction = (format) => {
 	switch (format.design) {
@@ -5531,6 +5531,27 @@ const youtubeOverlayKicker: PaletteFunction = ({ theme }: ArticleFormat) => {
 	}
 };
 
+const frontContainerTitleLight: PaletteFunction = () =>
+	sourcePalette.neutral[7];
+const frontContainerTitleDark: PaletteFunction = () =>
+	sourcePalette.neutral[93];
+
+const frontContainerBorderLight: PaletteFunction = () =>
+	sourcePalette.neutral[86];
+const frontContainerBorderDark: PaletteFunction = () =>
+	sourcePalette.neutral[86];
+
+const frontContainerBackgroundLight: PaletteFunction = () =>
+	sourcePalette.neutral[100];
+const frontContainerBackgroundDark: PaletteFunction = () =>
+	sourcePalette.neutral[0];
+
+const frontContainerToggleTextLight: PaletteFunction = () =>
+	sourcePalette.neutral[46];
+
+const frontContainerToggleTextDark: PaletteFunction = () =>
+	sourcePalette.neutral[60];
+
 // ----- Palette ----- //
 
 /**
@@ -5816,13 +5837,13 @@ const paletteColours = {
 		light: cardBackgroundHoverLight,
 		dark: cardBackgroundDark,
 	},
+	'--card-border': {
+		light: cardBorderLight,
+		dark: cardBorderDark,
+	},
 	'--card-border-supporting': {
 		light: cardBorderSupportingLight,
-		dark: cardBorderTopDark,
-	},
-	'--card-border-top': {
-		light: cardBorderTopLight,
-		dark: cardBorderTopDark,
+		dark: cardBorderDark,
 	},
 	'--card-footer-onwards-content': {
 		light: cardOnwardContentFooterLight,
@@ -6115,6 +6136,22 @@ const paletteColours = {
 	'--follow-text': {
 		light: followTextLight,
 		dark: followTextDark,
+	},
+	'--front-container-background': {
+		light: frontContainerBackgroundLight,
+		dark: frontContainerBackgroundDark,
+	},
+	'--front-container-border': {
+		light: frontContainerBorderLight,
+		dark: frontContainerBorderDark,
+	},
+	'--front-container-title': {
+		light: frontContainerTitleLight,
+		dark: frontContainerTitleDark,
+	},
+	'--front-container-toggle-text': {
+		light: frontContainerToggleTextLight,
+		dark: frontContainerToggleTextDark,
 	},
 	'--heading-line': {
 		light: headingLineLight,


### PR DESCRIPTION
## What does this change?

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
