### PR TITLE
Reduce CLS for inline1 when Teads passback - step 2

### DIFF
--- a/dotcom-rendering/src/components/ArticleContainer.tsx
+++ b/dotcom-rendering/src/components/ArticleContainer.tsx
@@ -162,7 +162,8 @@ const adStyles = css`
 		constants.AD_LABEL_HEIGHT}px;
 
 		${from.desktop} {
-			min-height: ${adSizes.mpu.height + constants.AD_LABEL_HEIGHT}px;
+			min-height: ${adSizes.outstreamDesktop.height +
+			constants.AD_LABEL_HEIGHT}px;
 		}
 	}
 

--- a/dotcom-rendering/src/components/ArticleContainer.tsx
+++ b/dotcom-rendering/src/components/ArticleContainer.tsx
@@ -167,8 +167,8 @@ const adStyles = css`
 	}
 
 	/* Give inline1 ad slot a different placeholder height comparing to subsequent-inlines to reduce CLS.
-	   Let the ad slot take control of its height once rendered. */
-	//IMPORTANT NOTE: We currently don't serve OPT-OUT for inline1 but we will need to change this value before we do.
+	   Let the ad slot take control of its height once rendered.
+	   IMPORTANT NOTE: We currently do not serve OPT-OUT for inline1 but we will need to change this value before we do. */
 	.ad-slot--inline1:not(.ad-slot--rendered) {
 		${from.desktop} {
 			min-height: ${adSizes.outstreamDesktop.height +

--- a/dotcom-rendering/src/components/ArticleContainer.tsx
+++ b/dotcom-rendering/src/components/ArticleContainer.tsx
@@ -162,6 +162,14 @@ const adStyles = css`
 		constants.AD_LABEL_HEIGHT}px;
 
 		${from.desktop} {
+			min-height: ${adSizes.mpu.height + constants.AD_LABEL_HEIGHT}px;
+		}
+	}
+
+	/* Give inline1 ad slot a different placeholder height comparing to subsequent-inlines to reduce CLS.
+	   Let the ad slot take control of its height once rendered. */
+	.ad-slot--inline1:not(.ad-slot--rendered) {
+		${from.desktop} {
 			min-height: ${adSizes.outstreamDesktop.height +
 			constants.AD_LABEL_HEIGHT}px;
 		}

--- a/dotcom-rendering/src/components/ArticleContainer.tsx
+++ b/dotcom-rendering/src/components/ArticleContainer.tsx
@@ -168,6 +168,7 @@ const adStyles = css`
 
 	/* Give inline1 ad slot a different placeholder height comparing to subsequent-inlines to reduce CLS.
 	   Let the ad slot take control of its height once rendered. */
+	//IMPORTANT NOTE: We currently don't serve OPT-OUT for inline1 but we will need to change this value before we do.
 	.ad-slot--inline1:not(.ad-slot--rendered) {
 		${from.desktop} {
 			min-height: ${adSizes.outstreamDesktop.height +


### PR DESCRIPTION
## What does this change?
This PR reserves 350px instead of 250px for `inline1` slot in articles. This is the stage 2 in two steps work. Please check stage 1 for more info https://github.com/guardian/commercial/pull/1417

This PR should be merged after the stage 1 PR is merged. 

The change is tested locally and in CODE.

The before recording is taken after we merge step 1. 

## Why?
Reduce CLS for better user experience. 

## Recordings

### Before

https://github.com/guardian/dotcom-rendering/assets/23424805/984355a6-d519-4d2a-8440-88a7e0b7375b

### After

https://github.com/guardian/dotcom-rendering/assets/23424805/1acc7c47-8c82-4666-a3c3-df635da91863

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
