### PR TITLE
Increase banner height to 90%

### DIFF
--- a/dotcom-rendering/src/layouts/lib/stickiness.tsx
+++ b/dotcom-rendering/src/layouts/lib/stickiness.tsx
@@ -35,7 +35,7 @@ const bannerWrapper = css`
 	position: fixed !important;
 	bottom: 0;
 	${getZIndexImportant('banner')}
-	max-height: 70vh;
+	max-height: 90vh;
 	overflow: auto;
 	/* stylelint-disable-next-line declaration-no-important */
 	width: 100% !important;


### PR DESCRIPTION
We now have [a better way ](https://github.com/guardian/support-dotcom-components/pull/1177)to prevent conflict with the iOS "open in app" banner, so we're increasing the max-height back to what it used to be