### PR TITLE
Fix stickiness for right slot on video pages

### DIFF
--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -957,7 +957,7 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 										/* above 980 */
 										margin-left: 20px;
 										margin-right: -20px;
-										padding-bottom: 48px;
+										padding-bottom: ${isMedia ? 41 : 0}px;
 									}
 									${from.leftCol} {
 										/* above 1140 */

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -957,6 +957,9 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 										/* above 980 */
 										margin-left: 20px;
 										margin-right: -20px;
+										height: ${isMedia
+											? `calc(100% - 48)px`
+											: 100}%;
 									}
 									${from.leftCol} {
 										/* above 1140 */

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -957,9 +957,7 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 										/* above 980 */
 										margin-left: 20px;
 										margin-right: -20px;
-										height: ${isMedia
-											? `calc(100% - 48)px`
-											: 100}%;
+										padding-bottom: 48px;
 									}
 									${from.leftCol} {
 										/* above 1140 */


### PR DESCRIPTION
## What does this change?

This PR adds space between right slot and the border at the bottom. The changes check if `isMedia` from desktop breakpoint in order to apply the `padding-bottom`. 

Tested in CODE. 

## Why?

Better alignment and user experience. 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![image](https://github.com/guardian/dotcom-rendering/assets/23424805/264d7e10-63bd-4eb2-8e17-92132c684e8b) | ![image](https://github.com/guardian/dotcom-rendering/assets/23424805/9512c56c-9894-464b-ada1-825462b1c37f) |


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
