### PR TITLE
Update `AdSlot.apps` Stories To Component Story Format v3

### DIFF
--- a/dotcom-rendering/.storybook/modes.ts
+++ b/dotcom-rendering/.storybook/modes.ts
@@ -21,4 +21,12 @@ export const allModes = {
 		globalColourScheme: 'horizontal',
 		viewport: breakpoints.tablet,
 	},
+	'vertical mobileMedium': {
+		globalColourScheme: 'vertical',
+		viewport: breakpoints.mobileMedium,
+	},
+	'light desktop': {
+		globalColourScheme: 'light',
+		viewport: breakpoints.desktop,
+	},
 };

--- a/dotcom-rendering/src/components/AdSlot.apps.stories.tsx
+++ b/dotcom-rendering/src/components/AdSlot.apps.stories.tsx
@@ -1,68 +1,41 @@
-import { css } from '@emotion/react';
-import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
-import { breakpoints, space } from '@guardian/source/foundations';
-import type { Decorator } from '@storybook/react';
-import { useRef } from 'react';
-import { splitTheme } from '../../.storybook/decorators/splitThemeDecorator';
-import { AdSlot, type Props } from './AdSlot.apps';
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+import { rightColumnDecorator } from '../../.storybook/decorators/gridDecorators';
+import { allModes } from '../../.storybook/modes';
+import { AdSlot } from './AdSlot.apps';
 
-const Wrapper: Decorator = (Story) => (
-	<div
-		css={css`
-			/* this matches the negative margin in AdSlot.apps */
-			padding: ${space[3]}px;
-			width: 100%;
-		`}
-	>
-		<Story />
-	</div>
-);
-
-export default {
+const meta = {
 	component: AdSlot,
-	title: 'Components/AdSlot.apps',
+	title: 'Components/Ad Slot (apps)',
+	decorators: [rightColumnDecorator],
 	parameters: {
 		chromatic: {
-			viewports: [breakpoints.mobile, breakpoints.tablet],
+			modes: {
+				'vertical mobileMedium': allModes['vertical mobileMedium'],
+				'light desktop': allModes['light desktop'],
+			},
 		},
 		viewport: {
-			defaultViewport: 'mobile',
+			defaultViewport: 'mobileMedium',
 		},
 	},
-	argTypes: {
-		onClickSupportButton: { action: 'clicked' },
+	args: {
+		onClickSupportButton: fn(),
 	},
-	decorators: [
-		Wrapper,
-		splitTheme(
-			[
-				{
-					design: ArticleDesign.Standard,
-					display: ArticleDisplay.Standard,
-					theme: Pillar.News,
-				},
-			],
-			{ orientation: 'vertical' },
-		),
-	],
-};
+} satisfies Meta<typeof AdSlot>;
 
-type Args = Omit<Props, 'ref'>;
+export default meta;
 
-export const AdSlotSquare = (args: Args) => {
-	const ref = useRef(null);
-	return <AdSlot ref={ref} {...args} />;
-};
-AdSlotSquare.storyName = 'with isFirstAdSlot = true';
-AdSlotSquare.args = {
-	isFirstAdSlot: true,
-};
+type Story = StoryObj<typeof meta>;
 
-export const AdSlotNotSquare = (args: Args) => {
-	const ref = useRef(null);
-	return <AdSlot ref={ref} {...args} />;
-};
-AdSlotNotSquare.storyName = 'with isFirstAdSlot = false';
-AdSlotNotSquare.args = {
-	isFirstAdSlot: false,
-};
+export const FirstSlot = {
+	args: {
+		isFirstAdSlot: true,
+	},
+} satisfies Story;
+
+export const OtherSlots = {
+	args: {
+		isFirstAdSlot: false,
+	},
+} satisfies Story;


### PR DESCRIPTION
This is the default for Storybook 7+[^1], and integrates better with some of its features.

Replaced the wrapper decorator with the right column decorator to better reflect where this slot will appear at different breakpoints. Switched from the legacy Chromatic `viewports` API to the new `modes` API[^2]. Updated the default viewport to a slightly larger size. Switched to the currently recommended way of specifying actions, with the `storybook/test` `fn`[^3]. Stopped supplying the `ref` arg to stories as it wasn't being used.

[^1]: https://storybook.js.org/blog/storybook-csf3-is-here/
[^2]: https://www.chromatic.com/docs/viewports/#migration-from-viewports-legacy-to-modes
[^3]: https://storybook.js.org/docs/essentials/actions
