### PR TITLE
Create Three Tier Support Choice Cards

### DIFF
--- a/dotcom-rendering/src/components/marketing/epics/ContributionsEpic.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ContributionsEpic.tsx
@@ -7,18 +7,18 @@ import { css } from '@emotion/react';
 import {
 	article17,
 	articleBold17,
+	from,
 	headlineBold20,
+	palette,
+	space,
 } from '@guardian/source/foundations';
-import { palette, space } from '@guardian/source/foundations';
-import { from } from '@guardian/source/foundations';
 import {
 	containsNonArticleCountPlaceholder,
+	epicPropsSchema,
 	getLocalCurrencySymbol,
 	replaceNonArticleCountPlaceholders,
 } from '@guardian/support-dotcom-components';
-import { epicPropsSchema } from '@guardian/support-dotcom-components';
 import type {
-	ContributionFrequency,
 	EpicProps,
 	Stage,
 } from '@guardian/support-dotcom-components/dist/shared/src/types';
@@ -300,14 +300,14 @@ const ContributionsEpic: ReactComponent<EpicProps> = ({
 
 	useEffect(() => {
 		if (showChoiceCards && choiceCardAmounts?.amountsCardData) {
-			const defaultFrequency: ContributionFrequency =
-				choiceCardAmounts.defaultContributionType || 'MONTHLY';
 			const localAmounts =
-				choiceCardAmounts.amountsCardData[defaultFrequency];
+				choiceCardAmounts.amountsCardData[
+					choiceCardAmounts.defaultContributionType
+				];
 			const defaultAmount = localAmounts.defaultAmount;
 
 			setChoiceCardSelection({
-				frequency: defaultFrequency,
+				frequency: choiceCardAmounts.defaultContributionType,
 				amount: defaultAmount,
 			});
 		}
@@ -326,7 +326,7 @@ const ContributionsEpic: ReactComponent<EpicProps> = ({
 	useEffect(() => {
 		if (hasBeenSeen) {
 			// For the event stream
-			if (!window?.guardian?.config?.isDev && stage !== 'DEV') {
+			if (!window.guardian.config.isDev && stage !== 'DEV') {
 				sendEpicViewEvent(
 					tracking.referrerUrl,
 					tracking.abTestName,

--- a/dotcom-rendering/src/components/marketing/epics/ContributionsEpicButtons.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ContributionsEpicButtons.tsx
@@ -142,6 +142,7 @@ interface ContributionsEpicButtonsProps {
 	amountsTestName?: string;
 	amountsVariantName?: string;
 	choiceCardSelection?: ChoiceCardSelection;
+	threeTierChoiceCardSelectedAmount?: number;
 	numArticles: number;
 }
 
@@ -155,6 +156,7 @@ export const ContributionsEpicButtons = ({
 	isSignedIn,
 	showChoiceCards,
 	choiceCardSelection,
+	threeTierChoiceCardSelectedAmount,
 	amountsTestName,
 	amountsVariantName,
 	numArticles,
@@ -179,17 +181,33 @@ export const ContributionsEpicButtons = ({
 		return null;
 	}
 
+	const getChoiceCardCta = (cta: Cta): Cta => {
+		if (threeTierChoiceCardSelectedAmount != undefined) {
+			return {
+				text: cta.text,
+				baseUrl: addChoiceCardsParams(
+					cta.baseUrl,
+					'MONTHLY', // only doing monthly in the first test
+					threeTierChoiceCardSelectedAmount,
+				),
+			};
+		}
+		if (choiceCardSelection) {
+			return {
+				text: cta.text,
+				baseUrl: addChoiceCardsParams(
+					cta.baseUrl,
+					choiceCardSelection.frequency,
+					choiceCardSelection.amount,
+				),
+			};
+		}
+
+		return cta;
+	};
+
 	const getCta = (cta: Cta): Cta =>
-		showChoiceCards && choiceCardSelection
-			? {
-					text: cta.text,
-					baseUrl: addChoiceCardsParams(
-						cta.baseUrl,
-						choiceCardSelection.frequency,
-						choiceCardSelection.amount,
-					),
-			  }
-			: cta;
+		showChoiceCards ? getChoiceCardCta(cta) : cta;
 
 	const openReminder = () => {
 		if (submitComponentEvent) {

--- a/dotcom-rendering/src/components/marketing/epics/ContributionsEpicCtas.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ContributionsEpicCtas.tsx
@@ -17,6 +17,7 @@ interface OnReminderOpen {
 type ContributionsEpicCtasProps = EpicProps & {
 	showChoiceCards?: boolean;
 	choiceCardSelection?: ChoiceCardSelection;
+	threeTierChoiceCardSelectedAmount?: number;
 	amountsTestName?: string;
 	amountsVariantName?: string;
 };
@@ -33,6 +34,7 @@ export const ContributionsEpicCtas: ReactComponent<
 	fetchEmail,
 	showChoiceCards,
 	choiceCardSelection,
+	threeTierChoiceCardSelectedAmount,
 	amountsTestName,
 	amountsVariantName,
 }: ContributionsEpicCtasProps): JSX.Element => {
@@ -80,6 +82,9 @@ export const ContributionsEpicCtas: ReactComponent<
 				isSignedIn={Boolean(fetchedEmail)}
 				showChoiceCards={showChoiceCards}
 				choiceCardSelection={choiceCardSelection}
+				threeTierChoiceCardSelectedAmount={
+					threeTierChoiceCardSelectedAmount
+				}
 				amountsTestName={amountsTestName}
 				amountsVariantName={amountsVariantName}
 				numArticles={articleCounts.for52Weeks}

--- a/dotcom-rendering/src/components/marketing/epics/ContributionsLiveblogEpic.stories.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ContributionsLiveblogEpic.stories.tsx
@@ -74,13 +74,13 @@ export const WithReminderCta: Story = {
 	},
 };
 
-export const InUS: Story = {
-	name: 'ContributionsLiveblogEpic in US',
+export const WithThreeTierChoiceCards: Story = {
+	name: 'ContributionsLiveblogEpic with Three Tier Choice Cards',
 	args: {
 		...meta.args,
-		countryCode: 'US',
 		variant: {
 			...props.variant,
+			name: 'THREE_TIER_CHOICE_CARDS',
 			secondaryCta: {
 				type: SecondaryCtaType.ContributionsReminder,
 			},
@@ -90,29 +90,6 @@ export const InUS: Story = {
 				reminderLabel: 'December',
 			},
 			showChoiceCards: true,
-			choiceCardAmounts: {
-				testName: 'Storybook_test',
-				variantName: 'Control',
-				defaultContributionType: 'MONTHLY',
-				displayContributionType: ['ONE_OFF', 'MONTHLY', 'ANNUAL'],
-				amountsCardData: {
-					ONE_OFF: {
-						amounts: [5, 10],
-						defaultAmount: 5,
-						hideChooseYourAmount: false,
-					},
-					MONTHLY: {
-						amounts: [4, 10],
-						defaultAmount: 12,
-						hideChooseYourAmount: false,
-					},
-					ANNUAL: {
-						amounts: [50, 100],
-						defaultAmount: 100,
-						hideChooseYourAmount: false,
-					},
-				},
-			},
 		},
 	},
 };

--- a/dotcom-rendering/src/components/marketing/epics/ContributionsLiveblogEpic.stories.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ContributionsLiveblogEpic.stories.tsx
@@ -74,6 +74,49 @@ export const WithReminderCta: Story = {
 	},
 };
 
+export const InUS: Story = {
+	name: 'ContributionsLiveblogEpic in US',
+	args: {
+		...meta.args,
+		countryCode: 'US',
+		variant: {
+			...props.variant,
+			secondaryCta: {
+				type: SecondaryCtaType.ContributionsReminder,
+			},
+			showReminderFields: {
+				reminderCta: 'Remind me in December',
+				reminderPeriod: '2022-12-01',
+				reminderLabel: 'December',
+			},
+			showChoiceCards: true,
+			choiceCardAmounts: {
+				testName: 'Storybook_test',
+				variantName: 'Control',
+				defaultContributionType: 'MONTHLY',
+				displayContributionType: ['ONE_OFF', 'MONTHLY', 'ANNUAL'],
+				amountsCardData: {
+					ONE_OFF: {
+						amounts: [5, 10],
+						defaultAmount: 5,
+						hideChooseYourAmount: false,
+					},
+					MONTHLY: {
+						amounts: [4, 10],
+						defaultAmount: 12,
+						hideChooseYourAmount: false,
+					},
+					ANNUAL: {
+						amounts: [50, 100],
+						defaultAmount: 100,
+						hideChooseYourAmount: false,
+					},
+				},
+			},
+		},
+	},
+};
+
 export const WithChoiceCards: Story = {
 	name: 'ContributionsLiveblogEpic with Choice Cards',
 	args: {

--- a/dotcom-rendering/src/components/marketing/epics/ContributionsLiveblogEpic.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ContributionsLiveblogEpic.tsx
@@ -4,19 +4,19 @@
  * https://github.com/guardian/support-dotcom-components/blob/9c3eae7cb0b159db4a1c40679d6b37710b0bb937/packages/modules/src/modules/epics/ContributionsLiveblogEpic.tsx
  */
 import { css } from '@emotion/react';
-import { article17, headlineBold34 } from '@guardian/source/foundations';
-import { from } from '@guardian/source/foundations';
-import { palette } from '@guardian/source/foundations';
-import { space } from '@guardian/source/foundations';
+import {
+	article17,
+	from,
+	headlineBold34,
+	palette,
+	space,
+} from '@guardian/source/foundations';
 import {
 	containsNonArticleCountPlaceholder,
 	getLocalCurrencySymbol,
 	replaceNonArticleCountPlaceholders,
 } from '@guardian/support-dotcom-components';
-import type {
-	ContributionFrequency,
-	EpicProps,
-} from '@guardian/support-dotcom-components/dist/shared/src/types';
+import type { EpicProps } from '@guardian/support-dotcom-components/dist/shared/src/types';
 import { useEffect, useState } from 'react';
 import { useIsInView } from '../../../lib/useIsInView';
 import type { ChoiceCardSelection } from '../lib/choiceCards';
@@ -146,20 +146,19 @@ export const ContributionsLiveblogEpic: ReactComponent<EpicProps> = ({
 		ChoiceCardSelection | undefined
 	>();
 
-	const showThreeTierChoiceCards = variant.name.includes(
-		'THREE_TIER_CHOICE_CARDS',
-	);
+	const showThreeTierChoiceCards =
+		showChoiceCards && variant.name.includes('THREE_TIER_CHOICE_CARDS');
 
 	useEffect(() => {
 		if (showChoiceCards && choiceCardAmounts?.amountsCardData) {
-			const defaultFrequency: ContributionFrequency =
-				choiceCardAmounts.defaultContributionType || 'MONTHLY';
 			const localAmounts =
-				choiceCardAmounts.amountsCardData[defaultFrequency];
+				choiceCardAmounts.amountsCardData[
+					choiceCardAmounts.defaultContributionType
+				];
 			const defaultAmount = localAmounts.defaultAmount;
 
 			setChoiceCardSelection({
-				frequency: defaultFrequency,
+				frequency: choiceCardAmounts.defaultContributionType,
 				amount: defaultAmount,
 			});
 		}
@@ -243,7 +242,7 @@ export const ContributionsLiveblogEpic: ReactComponent<EpicProps> = ({
 								amountsTest={choiceCardAmounts}
 							/>
 						)}
-						{showChoiceCards && showThreeTierChoiceCards && (
+						{showThreeTierChoiceCards && (
 							<ThreeTierChoiceCards
 								countryCode={countryCode}
 								selectedAmount={

--- a/dotcom-rendering/src/components/marketing/epics/ContributionsLiveblogEpic.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ContributionsLiveblogEpic.tsx
@@ -243,7 +243,7 @@ export const ContributionsLiveblogEpic: ReactComponent<EpicProps> = ({
 								amountsTest={choiceCardAmounts}
 							/>
 						)}
-						{choiceCardAmounts && showThreeTierChoiceCards && (
+						{showChoiceCards && showThreeTierChoiceCards && (
 							<ThreeTierChoiceCards
 								countryCode={countryCode}
 								selectedAmount={

--- a/dotcom-rendering/src/components/marketing/epics/ContributionsLiveblogEpic.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ContributionsLiveblogEpic.tsx
@@ -30,6 +30,8 @@ import { logEpicView } from '../lib/viewLog';
 import { ContributionsEpicChoiceCards } from './ContributionsEpicChoiceCards';
 import { ContributionsEpicCtas } from './ContributionsEpicCtas';
 import { ContributionsEpicNewsletterSignup } from './ContributionsEpicNewsletterSignup';
+import { ThreeTierChoiceCards } from './ThreeTierChoiceCards';
+import { getDefaultAmount as getDefaultThreeTierAmount } from './utils/threeTierChoiceCardAmounts';
 
 const container = (clientName: string) => css`
 	padding: 6px 10px 28px 10px;
@@ -144,6 +146,10 @@ export const ContributionsLiveblogEpic: ReactComponent<EpicProps> = ({
 		ChoiceCardSelection | undefined
 	>();
 
+	const showThreeTierChoiceCards = variant.name.includes(
+		'THREE_TIER_CHOICE_CARDS',
+	);
+
 	useEffect(() => {
 		if (showChoiceCards && choiceCardAmounts?.amountsCardData) {
 			const defaultFrequency: ContributionFrequency =
@@ -197,6 +203,12 @@ export const ContributionsLiveblogEpic: ReactComponent<EpicProps> = ({
 		replaceNonArticleCountPlaceholders(variant.heading) ||
 		'Support the Guardian';
 
+	const defaultThreeTierAmount = getDefaultThreeTierAmount(countryCode);
+	const [
+		threeTierChoiceCardSelectedAmount,
+		setThreeTierChoiceCardSelectedAmount,
+	] = useState<number>(defaultThreeTierAmount);
+
 	if (
 		cleanParagraphs.some(containsNonArticleCountPlaceholder) ||
 		containsNonArticleCountPlaceholder(cleanHeading)
@@ -222,13 +234,24 @@ export const ContributionsLiveblogEpic: ReactComponent<EpicProps> = ({
 					/>
 				) : (
 					<>
-						{choiceCardAmounts && (
+						{choiceCardAmounts && !showThreeTierChoiceCards && (
 							<ContributionsEpicChoiceCards
 								setSelectionsCallback={setChoiceCardSelection}
 								selection={choiceCardSelection}
 								submitComponentEvent={submitComponentEvent}
 								currencySymbol={currencySymbol}
 								amountsTest={choiceCardAmounts}
+							/>
+						)}
+						{choiceCardAmounts && showThreeTierChoiceCards && (
+							<ThreeTierChoiceCards
+								countryCode={countryCode}
+								selectedAmount={
+									threeTierChoiceCardSelectedAmount
+								}
+								setSelectedAmount={
+									setThreeTierChoiceCardSelectedAmount
+								}
 							/>
 						)}
 						<ContributionsEpicCtas
@@ -239,6 +262,11 @@ export const ContributionsLiveblogEpic: ReactComponent<EpicProps> = ({
 							onReminderOpen={onReminderOpen}
 							fetchEmail={fetchEmail}
 							submitComponentEvent={submitComponentEvent}
+							showChoiceCards={showChoiceCards}
+							choiceCardSelection={choiceCardSelection}
+							threeTierChoiceCardSelectedAmount={
+								threeTierChoiceCardSelectedAmount
+							}
 						/>
 					</>
 				)}

--- a/dotcom-rendering/src/components/marketing/epics/SupportRadioGroup.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/SupportRadioGroup.tsx
@@ -20,10 +20,11 @@ const paymentTypeChoiceCardStyles = (selected: boolean) => css`
 		: `1px solid ${palette.neutral[46]}`};
 	background-color: ${selected ? palette.sport[800] : ''};
 	border-radius: 10px;
-	padding: ${space[4]}px ${space[5]}px ${space[2]}px ${space[5]}px;
-	${
-		selected ? '' : 'padding-top: 6px;' // reduce top padding when Radio's min-height comes into effect
-	}
+	padding: ${
+		selected
+			? `${space[4]}px ${space[5]}px ${space[2]}px ${space[5]}px`
+			: `6px ${space[5]}px` // reduce vertical padding when Radio's min-height comes into effect
+	};
 	display: flex;
 	justify-content: space-between;
 `;

--- a/dotcom-rendering/src/components/marketing/epics/SupportRadioGroup.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/SupportRadioGroup.tsx
@@ -4,6 +4,7 @@ import {
 	space,
 	textSans15,
 	textSansBold15,
+	until,
 } from '@guardian/source/foundations';
 import {
 	Radio,
@@ -11,12 +12,13 @@ import {
 	Stack,
 	SvgTickRound,
 } from '@guardian/source/react-components';
-import { getLocalCurrencySymbol } from '@guardian/support-dotcom-components';
+import type { CountryGroupId } from '@guardian/support-dotcom-components';
+import {
+	countryCodeToCountryGroupId,
+	getLocalCurrencySymbol,
+} from '@guardian/support-dotcom-components';
 import { useState } from 'react';
-import type {
-	SupportCurrencyIso,
-	SupportTier,
-} from './utils/threeTierChoiceCardAmounts';
+import type { SupportTier } from './utils/threeTierChoiceCardAmounts';
 import { threeTierChoiceCardAmounts } from './utils/threeTierChoiceCardAmounts';
 
 const supportTierChoiceCardStyles = (selected: boolean) => css`
@@ -83,6 +85,9 @@ const recommendedPillStyles = css`
 	color: ${palette.neutral[100]};
 	position: absolute;
 	top: -${space[2]}px;
+	${until.phablet} {
+		right: ${space[3]}px;
+	}
 	right: ${space[5]}px;
 `;
 
@@ -94,10 +99,7 @@ type ChoiceInfo = {
 	recommended: boolean;
 };
 
-function getAmount(
-	supportTier: SupportTier,
-	currency: SupportCurrencyIso,
-): number {
+function getAmount(supportTier: SupportTier, currency: CountryGroupId): number {
 	return threeTierChoiceCardAmounts[currency][supportTier];
 }
 
@@ -174,6 +176,7 @@ export const SupportRadioGroup = ({ countryCode }: SupportRadioGroupProps) => {
 		useState<SupportTier>('allAccess');
 
 	const currencySymbol = getLocalCurrencySymbol(countryCode);
+	const countryGroupId = countryCodeToCountryGroupId(countryCode);
 
 	return (
 		<RadioGroup
@@ -204,7 +207,10 @@ export const SupportRadioGroup = ({ countryCode }: SupportRadioGroupProps) => {
 								>
 									<Radio
 										label={label(
-											getAmount(supportTier, 'GBP'),
+											getAmount(
+												supportTier,
+												countryGroupId,
+											),
 											currencySymbol,
 										)}
 										value={supportTier}

--- a/dotcom-rendering/src/components/marketing/epics/SupportRadioGroup.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/SupportRadioGroup.tsx
@@ -1,0 +1,200 @@
+import { css } from '@emotion/react';
+import {
+	palette,
+	space,
+	textSans15,
+	textSansBold12,
+	textSansBold15,
+} from '@guardian/source/foundations';
+import {
+	Radio,
+	RadioGroup,
+	Stack,
+	SvgTickRound,
+} from '@guardian/source/react-components';
+import { useState } from 'react';
+
+const paymentTypeChoiceCardStyles = (selected: boolean) => css`
+	border: ${selected
+		? `2px solid ${palette.brand['500']}`
+		: `1px solid ${palette.neutral[46]}`};
+	background-color: ${selected ? palette.sport[800] : ''};
+	border-radius: 10px;
+	padding: ${space[4]}px ${space[5]}px ${space[2]}px ${space[5]}px;
+	${
+		selected ? '' : 'padding-top: 6px;' // reduce top padding when Radio's min-height comes into effect
+	}
+	display: flex;
+	justify-content: space-between;
+`;
+
+const benefitsStyles = css`
+	${textSans15};
+	color: ${palette.neutral[7]};
+	list-style: none;
+	margin: 0 0 0 -4px;
+	padding: 0;
+
+	li + li {
+		margin-top: ${space[2]}px;
+	}
+
+	li {
+		display: flex;
+		align-items: flex-start;
+		margin-top: ${space[2]}px;
+	}
+
+	svg {
+		flex-shrink: 0;
+		margin-right: ${space[2]}px;
+		fill: ${palette.brand[400]};
+	}
+`;
+
+const benefitsLabelStyles = css`
+	color: ${palette.neutral[46]};
+	${textSansBold15};
+`;
+
+const labelOverrideStyles = css`
+	+ label div {
+		font-weight: bold;
+	}
+`;
+
+const supportingTextStyles = css`
+	margin-top: ${space[4]}px;
+`;
+
+type PaymentType = 'LowMonthly' | 'HighMonthly' | 'Single';
+
+type ChoiceInfo = {
+	id: PaymentType;
+	label: string;
+	benefitsLabel?: string;
+	benefits: string[];
+	recommended: boolean;
+};
+
+const Choices = [
+	{
+		id: 'HighMonthly',
+		label: 'Support £10/month',
+		benefitsLabel: 'Unlock Support benefits',
+		benefits: [
+			'Unlimited access to the Guardian app',
+			'Ad-free reading on all your devices',
+			'Exclusive newsletter for supporters, sent every week from the Guardian newsroom',
+			'Far fewer asks for support',
+		],
+		recommended: true,
+	},
+	{
+		id: 'LowMonthly',
+		label: 'Support £4/month',
+		benefitsLabel: 'Unlock All-access digital benefits',
+		benefits: [
+			'Exclusive newsletter for supporters, sent every week from the Guardian newsroom',
+		],
+		recommended: false,
+	},
+	{
+		id: 'Single',
+		label: 'Support just once',
+		benefitsLabel: undefined,
+		benefits: [
+			'We welcome support of any size, any time - whether you choose to give £1 or more',
+		],
+		recommended: false,
+	},
+] as const satisfies ReadonlyArray<ChoiceInfo>;
+
+const SupportingBenefits = ({
+	benefitsLabel,
+	benefits,
+}: {
+	benefitsLabel: string | undefined;
+	benefits: string[];
+}) => {
+	const isBenefit = !!benefitsLabel;
+	return (
+		<div css={supportingTextStyles}>
+			{!!benefitsLabel && (
+				<span css={benefitsLabelStyles}>{benefitsLabel}</span>
+			)}
+			<ul css={benefitsStyles}>
+				{benefits.map((benefit) => (
+					<li key={benefit}>
+						{isBenefit && <SvgTickRound size="xsmall" />}
+						{benefit}
+					</li>
+				))}
+			</ul>
+		</div>
+	);
+};
+
+const recommendedPillStyles = (selected: boolean) => css`
+	border-radius: 4px;
+	padding: ${space[1]}px ${space[2]}px;
+	background-color: ${palette.brand[400]};
+	${textSansBold12};
+	color: ${palette.neutral[100]};
+	height: ${space[6]}px;
+	${
+		selected ? '' : 'margin-top: 10px;' // increase margin when Radio's min-height comes into effect
+	}
+`;
+
+const RecommendedPill = ({ selected }: { selected: boolean }) => {
+	return <div css={recommendedPillStyles(selected)}>Recommended</div>;
+};
+
+export const SupportRadioGroup = () => {
+	const [selectedPaymentType, setSelectedPaymentType] =
+		useState<PaymentType>('HighMonthly');
+
+	return (
+		<RadioGroup
+			cssOverrides={css`
+				margin-top: ${space[6]}px;
+			`}
+		>
+			<Stack space={2}>
+				{Choices.map(
+					({ id, label, benefitsLabel, benefits, recommended }) => {
+						const selected = selectedPaymentType === id;
+						return (
+							<div
+								key={id}
+								css={paymentTypeChoiceCardStyles(selected)}
+							>
+								<Radio
+									label={label}
+									value={id}
+									css={labelOverrideStyles}
+									supporting={
+										selected ? (
+											<SupportingBenefits
+												benefitsLabel={benefitsLabel}
+												benefits={benefits}
+											/>
+										) : (
+											''
+										)
+									}
+									checked={selected}
+									onChange={() => setSelectedPaymentType(id)}
+								/>
+								{recommended && (
+									<RecommendedPill selected={selected} />
+								)}
+							</div>
+						);
+					},
+				)}
+			</Stack>
+		</RadioGroup>
+	);
+};

--- a/dotcom-rendering/src/components/marketing/epics/SupportRadioGroup.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/SupportRadioGroup.tsx
@@ -3,7 +3,6 @@ import {
 	palette,
 	space,
 	textSans15,
-	textSansBold12,
 	textSansBold15,
 } from '@guardian/source/foundations';
 import {
@@ -27,6 +26,7 @@ const paymentTypeChoiceCardStyles = (selected: boolean) => css`
 	};
 	display: flex;
 	justify-content: space-between;
+	align-items: flex-start;
 `;
 
 const benefitsStyles = css`
@@ -66,6 +66,17 @@ const labelOverrideStyles = css`
 
 const supportingTextStyles = css`
 	margin-top: ${space[4]}px;
+`;
+
+const recommendedPillStyles = (selected: boolean) => css`
+	border-radius: 4px;
+	padding: ${space[1]}px ${space[2]}px;
+	background-color: ${palette.brand[400]};
+	${textSansBold15};
+	color: ${palette.neutral[100]};
+	${
+		selected ? '' : 'margin-top: 10px;' // increase margin when Radio's min-height comes into effect
+	}
 `;
 
 type PaymentType = 'LowMonthly' | 'HighMonthly' | 'Single';
@@ -135,18 +146,6 @@ const SupportingBenefits = ({
 		</div>
 	);
 };
-
-const recommendedPillStyles = (selected: boolean) => css`
-	border-radius: 4px;
-	padding: ${space[1]}px ${space[2]}px;
-	background-color: ${palette.brand[400]};
-	${textSansBold12};
-	color: ${palette.neutral[100]};
-	height: ${space[6]}px;
-	${
-		selected ? '' : 'margin-top: 10px;' // increase margin when Radio's min-height comes into effect
-	}
-`;
 
 const RecommendedPill = ({ selected }: { selected: boolean }) => {
 	return <div css={recommendedPillStyles(selected)}>Recommended</div>;

--- a/dotcom-rendering/src/components/marketing/epics/ThreeTierChoiceCards.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ThreeTierChoiceCards.tsx
@@ -17,7 +17,7 @@ import {
 	countryCodeToCountryGroupId,
 	getLocalCurrencySymbol,
 } from '@guardian/support-dotcom-components';
-import { useState } from 'react';
+import type { Dispatch, SetStateAction } from 'react';
 import type { SupportTier } from './utils/threeTierChoiceCardAmounts';
 import { threeTierChoiceCardAmounts } from './utils/threeTierChoiceCardAmounts';
 
@@ -99,8 +99,11 @@ type ChoiceInfo = {
 	recommended: boolean;
 };
 
-function getAmount(supportTier: SupportTier, currency: CountryGroupId): number {
-	return threeTierChoiceCardAmounts[currency][supportTier];
+function getChoiceAmount(
+	supportTier: SupportTier,
+	countryGroupId: CountryGroupId,
+): number {
+	return threeTierChoiceCardAmounts[countryGroupId][supportTier];
 }
 
 const Choices = [
@@ -167,14 +170,17 @@ const RecommendedPill = () => {
 	return <div css={recommendedPillStyles}>Recommended</div>;
 };
 
-type SupportRadioGroupProps = {
+type ThreeTierChoiceCardsProps = {
+	selectedAmount: number;
+	setSelectedAmount: Dispatch<SetStateAction<number>>;
 	countryCode?: string;
 };
 
-export const SupportRadioGroup = ({ countryCode }: SupportRadioGroupProps) => {
-	const [selectedSupportTier, setSelectedSupportTier] =
-		useState<SupportTier>('allAccess');
-
+export const ThreeTierChoiceCards = ({
+	countryCode,
+	selectedAmount,
+	setSelectedAmount,
+}: ThreeTierChoiceCardsProps) => {
 	const currencySymbol = getLocalCurrencySymbol(countryCode);
 	const countryGroupId = countryCodeToCountryGroupId(countryCode);
 
@@ -193,7 +199,12 @@ export const SupportRadioGroup = ({ countryCode }: SupportRadioGroupProps) => {
 						benefits,
 						recommended,
 					}) => {
-						const selected = selectedSupportTier === supportTier;
+						const choiceAmount = getChoiceAmount(
+							supportTier,
+							countryGroupId,
+						);
+						const selected = selectedAmount === choiceAmount;
+
 						return (
 							<div
 								key={supportTier}
@@ -207,10 +218,7 @@ export const SupportRadioGroup = ({ countryCode }: SupportRadioGroupProps) => {
 								>
 									<Radio
 										label={label(
-											getAmount(
-												supportTier,
-												countryGroupId,
-											),
+											choiceAmount,
 											currencySymbol,
 										)}
 										value={supportTier}
@@ -227,7 +235,7 @@ export const SupportRadioGroup = ({ countryCode }: SupportRadioGroupProps) => {
 										}
 										checked={selected}
 										onChange={() =>
-											setSelectedSupportTier(supportTier)
+											setSelectedAmount(choiceAmount)
 										}
 									/>
 								</div>

--- a/dotcom-rendering/src/components/marketing/epics/ThreeTierChoiceCards.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ThreeTierChoiceCards.tsx
@@ -27,11 +27,9 @@ const supportTierChoiceCardStyles = (selected: boolean) => css`
 		: `1px solid ${palette.neutral[46]}`};
 	background-color: ${selected ? palette.sport[800] : ''};
 	border-radius: 10px;
-	padding: ${
-		selected
-			? `${space[4]}px ${space[5]}px ${space[2]}px ${space[5]}px`
-			: `6px ${space[5]}px` // reduce vertical padding when Radio's min-height comes into effect
-	};
+	padding: ${selected
+		? `${space[4]}px ${space[5]}px ${space[2]}px ${space[5]}px`
+		: `6px ${space[5]}px`};
 `;
 
 const benefitsStyles = css`

--- a/dotcom-rendering/src/components/marketing/epics/utils/threeTierChoiceCardAmounts.ts
+++ b/dotcom-rendering/src/components/marketing/epics/utils/threeTierChoiceCardAmounts.ts
@@ -1,4 +1,7 @@
-import type { CountryGroupId } from '@guardian/support-dotcom-components';
+import {
+	countryCodeToCountryGroupId,
+	type CountryGroupId,
+} from '@guardian/support-dotcom-components';
 
 export type SupportTier = 'support' | 'allAccess' | 'other';
 
@@ -6,36 +9,41 @@ export const threeTierChoiceCardAmounts = {
 	GBPCountries: {
 		support: 4,
 		allAccess: 10,
-		other: NaN,
+		other: 0,
 	},
 	UnitedStates: {
 		support: 5,
 		allAccess: 13,
-		other: NaN,
+		other: 0,
 	},
 	AUDCountries: {
 		support: 10,
 		allAccess: 17,
-		other: NaN,
+		other: 0,
 	},
 	EURCountries: {
 		support: 4,
 		allAccess: 10,
-		other: NaN,
+		other: 0,
 	},
 	NZDCountries: {
 		support: 10,
 		allAccess: 17,
-		other: NaN,
+		other: 0,
 	},
 	Canada: {
 		support: 5,
 		allAccess: 13,
-		other: NaN,
+		other: 0,
 	},
 	International: {
 		support: 3,
 		allAccess: 13,
-		other: NaN,
+		other: 0,
 	},
 } as const satisfies Record<CountryGroupId, Record<SupportTier, number>>;
+
+export function getDefaultAmount(countryCode?: string): number {
+	const countryGroupId = countryCodeToCountryGroupId(countryCode);
+	return threeTierChoiceCardAmounts[countryGroupId].allAccess;
+}

--- a/dotcom-rendering/src/components/marketing/epics/utils/threeTierChoiceCardAmounts.ts
+++ b/dotcom-rendering/src/components/marketing/epics/utils/threeTierChoiceCardAmounts.ts
@@ -1,0 +1,48 @@
+export type SupportCurrencyIso =
+	| 'GBP'
+	| 'USD'
+	| 'AUD'
+	| 'EUR'
+	| 'NZD'
+	| 'CAD'
+	| 'international';
+
+export type SupportTier = 'support' | 'allAccess' | 'other';
+
+export const threeTierChoiceCardAmounts = {
+	GBP: {
+		support: 4,
+		allAccess: 10,
+		other: 0,
+	},
+	USD: {
+		support: 5,
+		allAccess: 13,
+		other: 0,
+	},
+	AUD: {
+		support: 10,
+		allAccess: 17,
+		other: 0,
+	},
+	EUR: {
+		support: 4,
+		allAccess: 10,
+		other: 0,
+	},
+	NZD: {
+		support: 10,
+		allAccess: 17,
+		other: 0,
+	},
+	CAD: {
+		support: 5,
+		allAccess: 13,
+		other: 0,
+	},
+	international: {
+		support: 3,
+		allAccess: 13,
+		other: 0,
+	},
+} as const satisfies Record<SupportCurrencyIso, Record<SupportTier, number>>;

--- a/dotcom-rendering/src/components/marketing/epics/utils/threeTierChoiceCardAmounts.ts
+++ b/dotcom-rendering/src/components/marketing/epics/utils/threeTierChoiceCardAmounts.ts
@@ -1,48 +1,41 @@
-export type SupportCurrencyIso =
-	| 'GBP'
-	| 'USD'
-	| 'AUD'
-	| 'EUR'
-	| 'NZD'
-	| 'CAD'
-	| 'international';
+import type { CountryGroupId } from '@guardian/support-dotcom-components';
 
 export type SupportTier = 'support' | 'allAccess' | 'other';
 
 export const threeTierChoiceCardAmounts = {
-	GBP: {
+	GBPCountries: {
 		support: 4,
 		allAccess: 10,
-		other: 0,
+		other: NaN,
 	},
-	USD: {
+	UnitedStates: {
 		support: 5,
 		allAccess: 13,
-		other: 0,
+		other: NaN,
 	},
-	AUD: {
+	AUDCountries: {
 		support: 10,
 		allAccess: 17,
-		other: 0,
+		other: NaN,
 	},
-	EUR: {
+	EURCountries: {
 		support: 4,
 		allAccess: 10,
-		other: 0,
+		other: NaN,
 	},
-	NZD: {
+	NZDCountries: {
 		support: 10,
 		allAccess: 17,
-		other: 0,
+		other: NaN,
 	},
-	CAD: {
+	Canada: {
 		support: 5,
 		allAccess: 13,
-		other: 0,
+		other: NaN,
 	},
-	international: {
+	International: {
 		support: 3,
 		allAccess: 13,
-		other: 0,
+		other: NaN,
 	},
-} as const satisfies Record<SupportCurrencyIso, Record<SupportTier, number>>;
+} as const satisfies Record<CountryGroupId, Record<SupportTier, number>>;


### PR DESCRIPTION
## What does this change?

Create a new marketing component for three tier choice cards, and include it in the live blog epic when the variant matches a hardcoded test name.

## Why?

We want to test a choice card component that better aligns to the revamped three tier support checkout

## Screenshots

![image](https://github.com/guardian/dotcom-rendering/assets/114918544/ad8e3cc8-44fe-4012-a99d-d92ac9c6a588)
![image](https://github.com/guardian/dotcom-rendering/assets/114918544/34718b6e-555a-40a7-8553-8487f69d1634)
![image](https://github.com/guardian/dotcom-rendering/assets/114918544/0d3f4a1e-475f-4c23-b9bf-c4f565b19da3)

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
