### PR TITLE
Add the new three tier choice cards to article Epic

### DIFF
--- a/dotcom-rendering/src/components/marketing/epics/ContributionsEpic.stories.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ContributionsEpic.stories.tsx
@@ -4,8 +4,8 @@
  * https://github.com/guardian/support-dotcom-components/blob/a482b35a25ca59f66501c4de02de817046206298/packages/modules/src/modules/epics/ContributionsEpic.stories.tsx
  */
 import { css } from '@emotion/react';
-import { SecondaryCtaType } from '@guardian/support-dotcom-components';
 import {
+	SecondaryCtaType,
 	TickerCountType,
 	TickerEndType,
 } from '@guardian/support-dotcom-components';
@@ -309,6 +309,19 @@ export const WithChoiceCards: Story = {
 					},
 				},
 			},
+		},
+	},
+};
+
+export const WithThreeTierChoiceCards: Story = {
+	name: 'ContributionsEpic with three tier choice cards',
+	args: {
+		...meta.args,
+		variant: {
+			...props.variant,
+			name: 'THREE_TIER_CHOICE_CARDS',
+			secondaryCta: undefined,
+			showChoiceCards: true,
 		},
 	},
 };

--- a/dotcom-rendering/src/components/marketing/epics/ContributionsEpic.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ContributionsEpic.tsx
@@ -44,6 +44,8 @@ import { ContributionsEpicCtas } from './ContributionsEpicCtas';
 import { ContributionsEpicNewsletterSignup } from './ContributionsEpicNewsletterSignup';
 import { ContributionsEpicSignInCta } from './ContributionsEpicSignInCta';
 import { ContributionsEpicTicker } from './ContributionsEpicTicker';
+import { ThreeTierChoiceCards } from './ThreeTierChoiceCards';
+import { getDefaultThreeTierAmount } from './utils/threeTierChoiceCardAmounts';
 
 // CSS Styling
 // -------------------------------------------
@@ -298,6 +300,15 @@ const ContributionsEpic: ReactComponent<EpicProps> = ({
 		ChoiceCardSelection | undefined
 	>();
 
+	const defaultThreeTierAmount = getDefaultThreeTierAmount(countryCode);
+	const [
+		threeTierChoiceCardSelectedAmount,
+		setThreeTierChoiceCardSelectedAmount,
+	] = useState<number>(defaultThreeTierAmount);
+
+	const showThreeTierChoiceCards =
+		showChoiceCards && variant.name.includes('THREE_TIER_CHOICE_CARDS');
+
 	useEffect(() => {
 		if (showChoiceCards && choiceCardAmounts?.amountsCardData) {
 			const localAmounts =
@@ -455,13 +466,20 @@ const ContributionsEpic: ReactComponent<EpicProps> = ({
 				<BylineWithHeadshot bylineWithImage={variant.bylineWithImage} />
 			)}
 
-			{choiceCardAmounts && (
+			{choiceCardAmounts && !showThreeTierChoiceCards && (
 				<ContributionsEpicChoiceCards
 					setSelectionsCallback={setChoiceCardSelection}
 					selection={choiceCardSelection}
 					submitComponentEvent={submitComponentEvent}
 					currencySymbol={currencySymbol}
 					amountsTest={choiceCardAmounts}
+				/>
+			)}
+			{showThreeTierChoiceCards && (
+				<ThreeTierChoiceCards
+					countryCode={countryCode}
+					selectedAmount={threeTierChoiceCardSelectedAmount}
+					setSelectedAmount={setThreeTierChoiceCardSelectedAmount}
 				/>
 			)}
 
@@ -482,6 +500,9 @@ const ContributionsEpic: ReactComponent<EpicProps> = ({
 					amountsTestName={choiceCardAmounts?.testName}
 					amountsVariantName={choiceCardAmounts?.variantName}
 					choiceCardSelection={choiceCardSelection}
+					threeTierChoiceCardSelectedAmount={
+						threeTierChoiceCardSelectedAmount
+					}
 				/>
 			)}
 

--- a/dotcom-rendering/src/components/marketing/epics/ContributionsLiveblogEpic.stories.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ContributionsLiveblogEpic.stories.tsx
@@ -81,14 +81,7 @@ export const WithThreeTierChoiceCards: Story = {
 		variant: {
 			...props.variant,
 			name: 'THREE_TIER_CHOICE_CARDS',
-			secondaryCta: {
-				type: SecondaryCtaType.ContributionsReminder,
-			},
-			showReminderFields: {
-				reminderCta: 'Remind me in December',
-				reminderPeriod: '2022-12-01',
-				reminderLabel: 'December',
-			},
+			secondaryCta: undefined,
 			showChoiceCards: true,
 		},
 	},

--- a/dotcom-rendering/src/components/marketing/epics/ContributionsLiveblogEpic.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ContributionsLiveblogEpic.tsx
@@ -31,7 +31,7 @@ import { ContributionsEpicChoiceCards } from './ContributionsEpicChoiceCards';
 import { ContributionsEpicCtas } from './ContributionsEpicCtas';
 import { ContributionsEpicNewsletterSignup } from './ContributionsEpicNewsletterSignup';
 import { ThreeTierChoiceCards } from './ThreeTierChoiceCards';
-import { getDefaultAmount as getDefaultThreeTierAmount } from './utils/threeTierChoiceCardAmounts';
+import { getDefaultThreeTierAmount } from './utils/threeTierChoiceCardAmounts';
 
 const container = (clientName: string) => css`
 	padding: 6px 10px 28px 10px;

--- a/dotcom-rendering/src/components/marketing/epics/utils/threeTierChoiceCardAmounts.ts
+++ b/dotcom-rendering/src/components/marketing/epics/utils/threeTierChoiceCardAmounts.ts
@@ -43,7 +43,7 @@ export const threeTierChoiceCardAmounts = {
 	},
 } as const satisfies Record<CountryGroupId, Record<SupportTier, number>>;
 
-export function getDefaultAmount(countryCode?: string): number {
+export function getDefaultThreeTierAmount(countryCode?: string): number {
 	const countryGroupId = countryCodeToCountryGroupId(countryCode);
 	return threeTierChoiceCardAmounts[countryGroupId].allAccess;
 }


### PR DESCRIPTION
## What does this change?

Add the new three tier choice cards (added to liveblog epics in #11709) to the article epic 

## Why?

We are going to run an AB test of the old choice cards vs the new choice cards in article epics.

## Screenshots

<img width="657" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/114918544/13073118-7380-4762-a250-f0203032c73b">
<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
