### PR TITLE
Fix z-index issue with Heatphan for card sublinks

### DIFF
--- a/dotcom-rendering/src/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/components/CardHeadline.tsx
@@ -164,8 +164,6 @@ const sublinkStyles = css`
 		min-height: 44px;
 	}
 
-	padding: ${space[1]}px ${space[2]}px ${space[2]}px 0;
-
 	/* This css is used to remove any underline from the kicker but still
 	 * have it applied to the headline when the kicker is hovered */
 	:hover {

--- a/dotcom-rendering/src/components/SupportingContent.tsx
+++ b/dotcom-rendering/src/components/SupportingContent.tsx
@@ -28,30 +28,44 @@ const wrapperStyles = css`
 `;
 
 const directionStyles = (alignment: Alignment) => {
+	const linkPaddingVertical = css`
+		li a {
+			padding-top: ${space[1]}px;
+			padding-bottom: ${space[2]}px;
+		}
+	`;
+
+	const flexColumn = css`
+		flex-direction: column;
+		${linkPaddingVertical}
+	`;
+
+	const flexRow = css`
+		flex-direction: row;
+		${linkPaddingVertical}
+
+		/** Pad right for each horizontal sublink */
+		li a {
+			padding-right: ${space[3]}px;
+		}
+		/** Remove additional padding for last sublink */
+		li:last-of-type a {
+			padding-right: 0;
+		}
+	`;
+
 	switch (alignment) {
 		case 'horizontal':
 			return css`
-				flex-direction: column;
-				li a {
-					padding-right: 0;
-				}
+				${flexColumn}
 
 				${from.tablet} {
-					flex-direction: row;
-
-					/* Override the padding of the final sublink
-					   anchor tag set in CardHeadline */
-					li:last-of-type a {
-						padding-right: 0;
-					}
+					${flexRow}
 				}
 			`;
 		case 'vertical':
 			return css`
-				flex-direction: column;
-				li a {
-					padding-right: 0;
-				}
+				${flexColumn}
 			`;
 	}
 };


### PR DESCRIPTION
## What does this change?

An additional `z-index` was specified on the `SupportingContent` `ul` element to bring the whole sublink area of the card to the top layer of the card. This was introduced to prevent jumping or flashing when the cursor moves over one sublink to the next, where there was a gap between them.

This PR removes that additional `z-index` in favour of ensuring that the anchor tags of the sublink list items take up all available space in the sublink section of the card.

We now add padding to the `Link` element itself (inside `CardHeadline`) and override that from the `SupportingContent` component. This ensures that when hovering over the sublinks, there are no "jumps" or flashes from one to the next as the cursor moves over them.

## Why?

There was a bug with Heatphan, caused by this additional `z-index` value since Heatphan attaches the overlay to the top right corner of the position of anchor tags on a front.

Since the additional `z-index` on the `ul` element had introduced a new [stacking context](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_positioned_layout/Understanding_z-index/Stacking_context), the Heatphan overlay was appearing ontop of the current sublink it represented but below neighbouring card borders and sublinks, causing it to become obscured.

## Screenshots

<img width="1065" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/43961396/ba84d916-cdf1-4c19-ac6b-29f314872291">
