### PR TITLE
Remove articleDesign.Timeline from DCR

### DIFF
--- a/dotcom-rendering/src/components/DesignTag.stories.tsx
+++ b/dotcom-rendering/src/components/DesignTag.stories.tsx
@@ -95,25 +95,6 @@ export const SpecialReport = () => {
 };
 SpecialReport.storyName = 'with design Analysis and theme SpecialReport';
 
-export const Timeline = () => {
-	return (
-		<div
-			css={css`
-				max-width: 400px;
-			`}
-		>
-			<DesignTag
-				format={{
-					design: ArticleDesign.Timeline,
-					display: ArticleDisplay.Standard,
-					theme: Pillar.Sport,
-				}}
-			/>
-		</div>
-	);
-};
-Timeline.storyName = 'with design Timeline';
-
 export const Profile = () => {
 	return (
 		<div

--- a/dotcom-rendering/src/components/DesignTag.tsx
+++ b/dotcom-rendering/src/components/DesignTag.tsx
@@ -158,14 +158,6 @@ export const DesignTag = ({ format }: { format: ArticleFormat }) => {
 					</Tag>
 				</Margins>
 			);
-		case ArticleDesign.Timeline:
-			return (
-				<Margins format={format}>
-					<Tag format={format}>
-						<TagLink href="/tone/timelines">Timeline</TagLink>
-					</Tag>
-				</Margins>
-			);
 		case ArticleDesign.Profile:
 			return (
 				<Margins format={format}>

--- a/dotcom-rendering/src/components/DropCap.tsx
+++ b/dotcom-rendering/src/components/DropCap.tsx
@@ -29,7 +29,6 @@ const fontWeight = (format: ArticleFormat) => {
 		case ArticleDesign.Standard:
 		case ArticleDesign.Profile:
 		case ArticleDesign.Explainer:
-		case ArticleDesign.Timeline:
 		case ArticleDesign.LiveBlog:
 		case ArticleDesign.DeadBlog:
 		case ArticleDesign.Analysis:

--- a/dotcom-rendering/src/components/PullQuoteBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/components/PullQuoteBlockComponent.stories.tsx
@@ -22,7 +22,6 @@ const pullQuoteStoryVariations = [
 	ArticleDesign.Standard,
 	ArticleDesign.Profile,
 	ArticleDesign.Explainer,
-	ArticleDesign.Timeline,
 	ArticleDesign.LiveBlog,
 	ArticleDesign.DeadBlog,
 	ArticleDesign.Analysis,

--- a/dotcom-rendering/src/components/PullQuoteBlockComponent.tsx
+++ b/dotcom-rendering/src/components/PullQuoteBlockComponent.tsx
@@ -35,7 +35,6 @@ const fontCss = (role: string, format: ArticleFormat) => {
 				case ArticleDesign.Standard:
 				case ArticleDesign.Profile:
 				case ArticleDesign.Explainer:
-				case ArticleDesign.Timeline:
 				case ArticleDesign.LiveBlog:
 				case ArticleDesign.DeadBlog:
 				case ArticleDesign.Analysis:
@@ -77,7 +76,6 @@ const fontCss = (role: string, format: ArticleFormat) => {
 				case ArticleDesign.Standard:
 				case ArticleDesign.Profile:
 				case ArticleDesign.Explainer:
-				case ArticleDesign.Timeline:
 				case ArticleDesign.LiveBlog:
 				case ArticleDesign.DeadBlog:
 				case ArticleDesign.Analysis:
@@ -108,7 +106,6 @@ const fontCss = (role: string, format: ArticleFormat) => {
 				case ArticleDesign.Standard:
 				case ArticleDesign.Profile:
 				case ArticleDesign.Explainer:
-				case ArticleDesign.Timeline:
 				case ArticleDesign.LiveBlog:
 				case ArticleDesign.DeadBlog:
 				case ArticleDesign.Analysis:

--- a/dotcom-rendering/src/components/Standfirst.tsx
+++ b/dotcom-rendering/src/components/Standfirst.tsx
@@ -278,7 +278,6 @@ const standfirstStyles = ({ display, design, theme }: ArticleFormat) => {
 				case ArticleDesign.Review:
 				case ArticleDesign.NewsletterSignup:
 				case ArticleDesign.Explainer:
-				case ArticleDesign.Timeline:
 				case ArticleDesign.Profile:
 					return css`
 						max-width: 540px;

--- a/dotcom-rendering/src/components/Subheading.tsx
+++ b/dotcom-rendering/src/components/Subheading.tsx
@@ -143,7 +143,6 @@ const subheadingStyles = (format: ArticleFormat) => {
 		case ArticleDesign.Standard:
 		case ArticleDesign.Profile:
 		case ArticleDesign.Explainer:
-		case ArticleDesign.Timeline:
 		case ArticleDesign.LiveBlog:
 		case ArticleDesign.DeadBlog:
 		case ArticleDesign.Analysis:

--- a/dotcom-rendering/src/lib/decideDesign.ts
+++ b/dotcom-rendering/src/lib/decideDesign.ts
@@ -10,6 +10,7 @@ export const decideDesign = ({
 }: Partial<FEFormat>): ArticleDesign => {
 	switch (design) {
 		case 'ArticleDesign':
+		case 'TimelineDesign':
 			return ArticleDesign.Standard;
 		case 'PictureDesign':
 			return ArticleDesign.Picture;
@@ -60,8 +61,6 @@ export const decideDesign = ({
 			return ArticleDesign.NewsletterSignup;
 		case 'ExplainerDesign':
 			return ArticleDesign.Explainer;
-		case 'TimelineDesign':
-			return ArticleDesign.Timeline;
 		case 'ProfileDesign':
 			return ArticleDesign.Profile;
 		default:

--- a/dotcom-rendering/src/lib/format.ts
+++ b/dotcom-rendering/src/lib/format.ts
@@ -50,6 +50,7 @@ export const getAllDesigns = ({
 const designToFEDesign = (design: ArticleDesign): FEDesign => {
 	switch (design) {
 		case ArticleDesign.Standard:
+		case ArticleDesign.Timeline:
 		// Correction doesn't exist in `FEFormat`.
 		case ArticleDesign.Correction:
 			return 'ArticleDesign';
@@ -99,8 +100,6 @@ const designToFEDesign = (design: ArticleDesign): FEDesign => {
 			return 'FullPageInteractiveDesign';
 		case ArticleDesign.NewsletterSignup:
 			return 'NewsletterSignupDesign';
-		case ArticleDesign.Timeline:
-			return 'TimelineDesign';
 		case ArticleDesign.Profile:
 			return 'ProfileDesign';
 	}

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -1112,7 +1112,6 @@ const subheadingTextLight = ({ design, theme }: ArticleFormat) => {
 		case ArticleDesign.Standard:
 		case ArticleDesign.Profile:
 		case ArticleDesign.Explainer:
-		case ArticleDesign.Timeline:
 		case ArticleDesign.LiveBlog:
 		case ArticleDesign.DeadBlog:
 		default:
@@ -1147,7 +1146,6 @@ const subheadingTextDark = ({ design, theme }: ArticleFormat) => {
 		case ArticleDesign.Standard:
 		case ArticleDesign.Profile:
 		case ArticleDesign.Explainer:
-		case ArticleDesign.Timeline:
 		case ArticleDesign.LiveBlog:
 		case ArticleDesign.DeadBlog:
 		default:
@@ -1563,9 +1561,6 @@ const blockQuoteFillLight: PaletteFunction = (format: ArticleFormat) => {
 		case ArticleDesign.Standard:
 		case ArticleDesign.Profile:
 		case ArticleDesign.Explainer:
-		case ArticleDesign.Timeline: {
-			return sourcePalette.neutral[46];
-		}
 		case ArticleDesign.Comment:
 		case ArticleDesign.Editorial:
 		case ArticleDesign.Analysis:
@@ -1633,9 +1628,6 @@ const blockQuoteFillDark: PaletteFunction = ({
 		case ArticleDesign.Standard:
 		case ArticleDesign.Profile:
 		case ArticleDesign.Explainer:
-		case ArticleDesign.Timeline: {
-			return sourcePalette.neutral[60];
-		}
 		case ArticleDesign.Comment:
 		case ArticleDesign.Editorial:
 		case ArticleDesign.Analysis:
@@ -1678,7 +1670,6 @@ const blockquoteTextLight: PaletteFunction = (format: ArticleFormat) => {
 		case ArticleDesign.Standard:
 		case ArticleDesign.Profile:
 		case ArticleDesign.Explainer:
-		case ArticleDesign.Timeline:
 		case ArticleDesign.Comment:
 		case ArticleDesign.Editorial:
 		case ArticleDesign.LiveBlog:
@@ -1704,7 +1695,6 @@ const blockquoteTextDark: PaletteFunction = (format: ArticleFormat) => {
 		case ArticleDesign.Standard:
 		case ArticleDesign.Profile:
 		case ArticleDesign.Explainer:
-		case ArticleDesign.Timeline:
 		case ArticleDesign.Comment:
 		case ArticleDesign.Editorial:
 		case ArticleDesign.LiveBlog:


### PR DESCRIPTION
## What does this change?
Remove references to articleDesign.timeline and default it to standard design. The only visible differenence is the removal of the timeline tone tag and a change to the standfirst

Once https://github.com/guardian/csnx/pull/1583 is merged, we can bump libs and remove it completely

## Why?
Timelines are now a distinct element, rather than a format design. As such, we would like to remove the timeline design to help enforce usage of the new element and reduce confusion in the codebase.


## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
