### PR TITLE
Fix tag pages showing wrong publication date

### DIFF
--- a/dotcom-rendering/src/model/groupTrailsByDates.ts
+++ b/dotcom-rendering/src/model/groupTrailsByDates.ts
@@ -36,13 +36,13 @@ const groupByYear = (trails: TrailAndDate[]) => {
 
 	for (const { trail, date } of trails) {
 		const existingYear = trailsByYear.find(
-			({ year }) => year === date.getUTCFullYear(),
+			({ year }) => year === date.getFullYear(),
 		);
 		if (existingYear) {
 			existingYear.trails.push({ trail, date });
 		} else {
 			trailsByYear.push({
-				year: date.getUTCFullYear(),
+				year: date.getFullYear(),
 				trails: [{ trail, date }],
 			});
 		}
@@ -63,14 +63,14 @@ const groupTrailsByMonth = (trails: TrailAndDate[], year: number) => {
 
 	for (const { trail, date } of trails) {
 		const existingMonth = trailsByMonth.find(
-			({ month }) => month === date.getUTCMonth(),
+			({ month }) => month === date.getMonth(),
 		);
 		if (existingMonth) {
 			existingMonth.trails.push({ trail, date });
 		} else {
 			trailsByMonth.push({
 				year,
-				month: date.getUTCMonth(),
+				month: date.getMonth(),
 				trails: [{ trail, date }],
 			});
 		}
@@ -96,7 +96,7 @@ const groupTrailsByDay = (
 
 	for (const { trail, date } of trails) {
 		const existingMonth = trailsByDay.find(
-			({ day }) => day === date.getUTCDate(),
+			({ day }) => day === date.getDate(),
 		);
 		if (existingMonth) {
 			existingMonth.trails.push({ trail, date });
@@ -104,7 +104,7 @@ const groupTrailsByDay = (
 			trailsByDay.push({
 				year,
 				month,
-				day: date.getUTCDate(),
+				day: date.getDate(),
 				trails: [{ trail, date }],
 			});
 		}


### PR DESCRIPTION
## What does this change?
Switches to using `getDate` instead of `getUTCDate` to avoid discrepancies in the dates on tag pages
## Why?
Resolves https://github.com/guardian/dotcom-rendering/issues/11676
## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/110032454/43d7eeeb-261a-4e7b-b44f-5072d7c4e6a0
[after]: https://github.com/guardian/dotcom-rendering/assets/110032454/b52fa400-2cde-4f14-82dd-a3ae9894931b

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
