### PR TITLE
Increase tier two prices in new choice card designs

### DIFF
--- a/dotcom-rendering/src/components/marketing/epics/utils/threeTierChoiceCardAmounts.ts
+++ b/dotcom-rendering/src/components/marketing/epics/utils/threeTierChoiceCardAmounts.ts
@@ -5,40 +5,41 @@ import {
 
 export type SupportTier = 'support' | 'allAccess' | 'other';
 
+// ToDo: fetch this in a way that isn't hardcoded
 export const threeTierChoiceCardAmounts = {
 	GBPCountries: {
 		support: 4,
-		allAccess: 10,
+		allAccess: 12,
 		other: 0,
 	},
 	UnitedStates: {
 		support: 5,
-		allAccess: 13,
+		allAccess: 15,
 		other: 0,
 	},
 	AUDCountries: {
 		support: 10,
-		allAccess: 17,
+		allAccess: 20,
 		other: 0,
 	},
 	EURCountries: {
 		support: 4,
-		allAccess: 10,
+		allAccess: 12,
 		other: 0,
 	},
 	NZDCountries: {
 		support: 10,
-		allAccess: 17,
+		allAccess: 20,
 		other: 0,
 	},
 	Canada: {
 		support: 5,
-		allAccess: 13,
+		allAccess: 15,
 		other: 0,
 	},
 	International: {
 		support: 3,
-		allAccess: 13,
+		allAccess: 15,
 		other: 0,
 	},
 } as const satisfies Record<CountryGroupId, Record<SupportTier, number>>;


### PR DESCRIPTION
## What does this change?

Update the price config for the new three tier choice cards

## Why?

The price is going up on Monday 1 July, do not merge this PR until then

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![image](https://github.com/guardian/dotcom-rendering/assets/114918544/e9e12a0b-e0f2-4cd3-8d1b-1a02aadfffce) |![image](https://github.com/guardian/dotcom-rendering/assets/114918544/dfeda3bc-d055-48e9-9c62-7faa9ba9b2c8) |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
