### PR TITLE
Improve the Config context

### DIFF
--- a/dotcom-rendering/src/client/discussion.ts
+++ b/dotcom-rendering/src/client/discussion.ts
@@ -20,7 +20,7 @@ const forceHydration = async (): Promise<void> => {
 
 		// Read the props and config from where they have been serialised in the dom using an Island
 		const props = getProps(guElement);
-		const config = getConfig(guElement);
+		const config = getConfig();
 
 		// Now that we have the props as an object, tell Discussion we want it to expand itself
 		props.expanded = true;

--- a/dotcom-rendering/src/client/islands/getConfig.ts
+++ b/dotcom-rendering/src/client/islands/getConfig.ts
@@ -1,21 +1,23 @@
 import type { Config } from '../../types/configContext';
 
+let config: Config | undefined;
 /**
- * getConfig takes the given html element and returns its config attribute
+ * Reads the config from a JSON script tag,
+ * or reuse the memoised value if it exists.
  *
- * We expect the element to always be a `gu-*` custom element
- *
- * @param marker : The html element that we want to read the config attribute from;
- * @returns
+ * @returns {Config} an immutable, global config
  */
-export const getConfig = (marker: HTMLElement): Config => {
-	const serialised = marker.getAttribute('config');
+export const getConfig = (): Readonly<Config> => {
+	if (config) return config;
+
+	const serialised = document.querySelector('script#config')?.innerHTML;
 
 	try {
 		if (!serialised) {
-			throw Error('Unable to fetch config attribute from marker element');
+			throw Error('Unable to fetch config attribute from #config');
 		} else {
-			return JSON.parse(serialised) as Config;
+			config = JSON.parse(serialised) as Config;
+			return config;
 		}
 	} catch (error: unknown) {
 		console.error(

--- a/dotcom-rendering/src/client/islands/initHydration.ts
+++ b/dotcom-rendering/src/client/islands/initHydration.ts
@@ -39,7 +39,7 @@ export const initHydration = async (
 ): Promise<void> => {
 	const name = getName(element);
 	const props = getProps(element);
-	const config = getConfig(element);
+	const config = getConfig();
 	const priority = getPriority(element);
 
 	if (!name) return;

--- a/dotcom-rendering/src/components/ArticleMeta.test.tsx
+++ b/dotcom-rendering/src/components/ArticleMeta.test.tsx
@@ -21,6 +21,7 @@ describe('ArticleMeta', () => {
 					darkModeAvailable: false,
 					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
+					editionId: 'UK',
 				}}
 			>
 				<ArticleMeta
@@ -68,6 +69,7 @@ describe('ArticleMeta', () => {
 					darkModeAvailable: false,
 					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
+					editionId: 'UK',
 				}}
 			>
 				<ArticleMeta

--- a/dotcom-rendering/src/components/BylineLink.test.tsx
+++ b/dotcom-rendering/src/components/BylineLink.test.tsx
@@ -110,6 +110,7 @@ describe('BylineLink', () => {
 					darkModeAvailable: false,
 					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
+					editionId: 'UK',
 				}}
 			>
 				<BylineLink
@@ -153,6 +154,7 @@ describe('BylineLink', () => {
 					darkModeAvailable: false,
 					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
+					editionId: 'UK',
 				}}
 			>
 				<BylineLink
@@ -198,6 +200,7 @@ describe('BylineLink', () => {
 					darkModeAvailable: false,
 					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
+					editionId: 'UK',
 				}}
 			>
 				<BylineLink
@@ -239,6 +242,7 @@ describe('BylineLink', () => {
 					darkModeAvailable: false,
 					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
+					editionId: 'UK',
 				}}
 			>
 				<BylineLink
@@ -271,6 +275,7 @@ describe('BylineLink', () => {
 					darkModeAvailable: false,
 					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
+					editionId: 'UK',
 				}}
 			>
 				<BylineLink

--- a/dotcom-rendering/src/components/ConfigContext.test.tsx
+++ b/dotcom-rendering/src/components/ConfigContext.test.tsx
@@ -26,18 +26,21 @@ describe('ConfigContext', () => {
 				darkModeAvailable: false,
 				updateLogoAdPartnerSwitch: false,
 				assetOrigin: '/',
+				editionId: 'UK',
 			},
 			{
 				renderingTarget: 'Apps',
 				darkModeAvailable: true,
 				updateLogoAdPartnerSwitch: false,
 				assetOrigin: '/',
+				editionId: 'UK',
 			},
 			{
 				renderingTarget: 'Apps',
 				darkModeAvailable: false,
 				updateLogoAdPartnerSwitch: false,
 				assetOrigin: '/',
+				editionId: 'INT',
 			},
 		] as const satisfies ReadonlyArray<Config>)(
 			'useConfig hook provides correct config: "%o"',

--- a/dotcom-rendering/src/components/Contributor.test.tsx
+++ b/dotcom-rendering/src/components/Contributor.test.tsx
@@ -21,6 +21,7 @@ describe('Contributor', () => {
 					darkModeAvailable: false,
 					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
+					editionId: 'UK',
 				}}
 			>
 				<Contributor
@@ -56,6 +57,7 @@ describe('Contributor', () => {
 					darkModeAvailable: false,
 					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
+					editionId: 'UK',
 				}}
 			>
 				<Contributor

--- a/dotcom-rendering/src/components/Discussion/Discussion.test.tsx
+++ b/dotcom-rendering/src/components/Discussion/Discussion.test.tsx
@@ -20,6 +20,7 @@ describe('App', () => {
 					darkModeAvailable: false,
 					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
+					editionId: 'UK',
 				}}
 			>
 				<Discussion

--- a/dotcom-rendering/src/components/Dropdown.test.tsx
+++ b/dotcom-rendering/src/components/Dropdown.test.tsx
@@ -47,6 +47,7 @@ describe('Dropdown', () => {
 					darkModeAvailable: false,
 					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
+					editionId: 'UK',
 				}}
 			>
 				<Dropdown
@@ -69,6 +70,7 @@ describe('Dropdown', () => {
 					darkModeAvailable: false,
 					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
+					editionId: 'UK',
 				}}
 			>
 				<Dropdown
@@ -94,6 +96,7 @@ describe('Dropdown', () => {
 					darkModeAvailable: false,
 					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
+					editionId: 'UK',
 				}}
 			>
 				<Dropdown
@@ -118,6 +121,7 @@ describe('Dropdown', () => {
 					darkModeAvailable: false,
 					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
+					editionId: 'UK',
 				}}
 			>
 				<Dropdown
@@ -144,6 +148,7 @@ describe('Dropdown', () => {
 					darkModeAvailable: false,
 					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
+					editionId: 'UK',
 				}}
 			>
 				<Dropdown
@@ -171,6 +176,7 @@ describe('Dropdown', () => {
 					darkModeAvailable: false,
 					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
+					editionId: 'UK',
 				}}
 			>
 				<Dropdown

--- a/dotcom-rendering/src/components/GuideAtom/GuideAtom.test.tsx
+++ b/dotcom-rendering/src/components/GuideAtom/GuideAtom.test.tsx
@@ -13,6 +13,7 @@ describe('GuideAtom', () => {
 					darkModeAvailable: false,
 					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
+					editionId: 'UK',
 				}}
 			>
 				<GuideAtom {...defaultStory} />
@@ -39,6 +40,7 @@ describe('GuideAtom', () => {
 					darkModeAvailable: false,
 					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
+					editionId: 'UK',
 				}}
 			>
 				<GuideAtom {...defaultStory} />
@@ -66,6 +68,7 @@ describe('GuideAtom', () => {
 					darkModeAvailable: false,
 					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
+					editionId: 'UK',
 				}}
 			>
 				<GuideAtom {...defaultStory} />

--- a/dotcom-rendering/src/components/Island.test.tsx
+++ b/dotcom-rendering/src/components/Island.test.tsx
@@ -3,6 +3,7 @@
  */
 
 import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
+import type { PropsWithChildren } from 'react';
 import { renderToString } from 'react-dom/server';
 import { AdPortals } from './AdPortals.importable';
 import { AlreadyVisited } from './AlreadyVisited.importable';
@@ -77,6 +78,21 @@ const Mock = () => <>🏝️</>;
 // Jest tests
 
 describe('Island: server-side rendering', () => {
+	/** Helper to provide config for islands */
+	const WithConfig = ({ children }: PropsWithChildren) => (
+		<ConfigProvider
+			value={{
+				renderingTarget: 'Web',
+				darkModeAvailable: false,
+				updateLogoAdPartnerSwitch: false,
+				assetOrigin: '/',
+				editionId: 'UK',
+			}}
+		>
+			{children}
+		</ConfigProvider>
+	);
+
 	test('AdPortals', () => {
 		expect(() => renderToString(<AdPortals />)).not.toThrow();
 	});
@@ -92,16 +108,9 @@ describe('Island: server-side rendering', () => {
 	test('BrazeMessaging', () => {
 		expect(() =>
 			renderToString(
-				<ConfigProvider
-					value={{
-						renderingTarget: 'Web',
-						darkModeAvailable: false,
-						updateLogoAdPartnerSwitch: false,
-						assetOrigin: '/',
-					}}
-				>
+				<WithConfig>
 					<BrazeMessaging idApiUrl={''} />
-				</ConfigProvider>,
+				</WithConfig>,
 			),
 		).not.toThrow();
 	});
@@ -123,20 +132,13 @@ describe('Island: server-side rendering', () => {
 	test('DiscussionMeta', () => {
 		expect(() =>
 			renderToString(
-				<ConfigProvider
-					value={{
-						renderingTarget: 'Web',
-						darkModeAvailable: false,
-						updateLogoAdPartnerSwitch: false,
-						assetOrigin: '/',
-					}}
-				>
+				<WithConfig>
 					<DiscussionMeta
 						discussionApiUrl={''}
 						shortUrlId={''}
 						enableDiscussionSwitch={false}
 					/>
-				</ConfigProvider>,
+				</WithConfig>,
 			),
 		).not.toThrow();
 	});
@@ -144,14 +146,7 @@ describe('Island: server-side rendering', () => {
 	test('Discussion', () => {
 		expect(() =>
 			renderToString(
-				<ConfigProvider
-					value={{
-						renderingTarget: 'Web',
-						darkModeAvailable: false,
-						updateLogoAdPartnerSwitch: false,
-						assetOrigin: '/',
-					}}
-				>
+				<WithConfig>
 					<DiscussionLayout
 						discussionApiUrl="https://discussion.theguardian.com/discussion-api"
 						shortUrlId="p/39f5z"
@@ -167,7 +162,7 @@ describe('Island: server-side rendering', () => {
 						isAdFreeUser={false}
 						shouldHideAds={false}
 					/>
-				</ConfigProvider>,
+				</WithConfig>,
 			),
 		).not.toThrow();
 	});
@@ -175,16 +170,9 @@ describe('Island: server-side rendering', () => {
 	test('EnhancePinnedPost', () => {
 		expect(() =>
 			renderToString(
-				<ConfigProvider
-					value={{
-						renderingTarget: 'Web',
-						darkModeAvailable: false,
-						updateLogoAdPartnerSwitch: false,
-						assetOrigin: '/',
-					}}
-				>
+				<WithConfig>
 					<EnhancePinnedPost />
-				</ConfigProvider>,
+				</WithConfig>,
 			),
 		).not.toThrow();
 	});
@@ -204,14 +192,7 @@ describe('Island: server-side rendering', () => {
 	test('OnwardsUpper', () => {
 		expect(() =>
 			renderToString(
-				<ConfigProvider
-					value={{
-						renderingTarget: 'Web',
-						darkModeAvailable: false,
-						updateLogoAdPartnerSwitch: false,
-						assetOrigin: '/',
-					}}
-				>
+				<WithConfig>
 					<OnwardsUpper
 						contentType=""
 						tags={[]}
@@ -234,7 +215,7 @@ describe('Island: server-side rendering', () => {
 						discussionApiUrl=""
 						absoluteServerTimes={true}
 					/>
-				</ConfigProvider>,
+				</WithConfig>,
 			),
 		).not.toThrow();
 	});
@@ -299,16 +280,9 @@ describe('Island: server-side rendering', () => {
 	test('Metrics', () => {
 		expect(() =>
 			renderToString(
-				<ConfigProvider
-					value={{
-						renderingTarget: 'Web',
-						darkModeAvailable: false,
-						updateLogoAdPartnerSwitch: false,
-						assetOrigin: '/',
-					}}
-				>
+				<WithConfig>
 					<Metrics commercialMetricsEnabled={true} tests={{}} />
-				</ConfigProvider>,
+				</WithConfig>,
 			),
 		).not.toThrow();
 	});
@@ -324,14 +298,7 @@ describe('Island: server-side rendering', () => {
 	test('MostViewedRightWithAd', () => {
 		expect(() =>
 			renderToString(
-				<ConfigProvider
-					value={{
-						renderingTarget: 'Web',
-						darkModeAvailable: false,
-						updateLogoAdPartnerSwitch: false,
-						assetOrigin: '/',
-					}}
-				>
+				<WithConfig>
 					<MostViewedRightWithAd
 						format={{
 							theme: Pillar.News,
@@ -343,7 +310,7 @@ describe('Island: server-side rendering', () => {
 						shouldHideReaderRevenue={false}
 					/>
 					,
-				</ConfigProvider>,
+				</WithConfig>,
 			),
 		).not.toThrow();
 	});
@@ -359,14 +326,7 @@ describe('Island: server-side rendering', () => {
 	test('ReaderRevenueLinks', () => {
 		expect(() =>
 			renderToString(
-				<ConfigProvider
-					value={{
-						renderingTarget: 'Web',
-						darkModeAvailable: false,
-						updateLogoAdPartnerSwitch: false,
-						assetOrigin: '/',
-					}}
-				>
+				<WithConfig>
 					<ReaderRevenueLinks
 						editionId={'UK'}
 						dataLinkNamePrefix={''}
@@ -379,7 +339,7 @@ describe('Island: server-side rendering', () => {
 							contribute: '',
 						}}
 					/>
-				</ConfigProvider>,
+				</WithConfig>,
 			),
 		).not.toThrow();
 	});
@@ -397,14 +357,7 @@ describe('Island: server-side rendering', () => {
 	test('SetABTests', () => {
 		expect(() =>
 			renderToString(
-				<ConfigProvider
-					value={{
-						renderingTarget: 'Web',
-						darkModeAvailable: false,
-						updateLogoAdPartnerSwitch: false,
-						assetOrigin: '/',
-					}}
-				>
+				<WithConfig>
 					<SetABTests
 						isDev={false}
 						pageIsSensitive={false}
@@ -412,7 +365,7 @@ describe('Island: server-side rendering', () => {
 						serverSideTests={{}}
 					/>
 					,
-				</ConfigProvider>,
+				</WithConfig>,
 			),
 		).not.toThrow();
 	});
@@ -436,14 +389,7 @@ describe('Island: server-side rendering', () => {
 	test('SignInGateSelector', () => {
 		expect(() =>
 			renderToString(
-				<ConfigProvider
-					value={{
-						renderingTarget: 'Web',
-						darkModeAvailable: false,
-						updateLogoAdPartnerSwitch: false,
-						assetOrigin: '/',
-					}}
-				>
+				<WithConfig>
 					<SignInGateSelector
 						contentType={''}
 						tags={[]}
@@ -452,7 +398,7 @@ describe('Island: server-side rendering', () => {
 						pageId={''}
 						switches={{}}
 					/>
-				</ConfigProvider>,
+				</WithConfig>,
 			),
 		).not.toThrow();
 	});
@@ -460,14 +406,7 @@ describe('Island: server-side rendering', () => {
 	test('SlotBodyEnd', () => {
 		expect(() =>
 			renderToString(
-				<ConfigProvider
-					value={{
-						renderingTarget: 'Web',
-						darkModeAvailable: false,
-						updateLogoAdPartnerSwitch: false,
-						assetOrigin: '/',
-					}}
-				>
+				<WithConfig>
 					<SlotBodyEnd
 						contentType={''}
 						sectionId={''}
@@ -483,7 +422,7 @@ describe('Island: server-side rendering', () => {
 						isLabs={false}
 						articleEndSlot={true}
 					/>
-				</ConfigProvider>,
+				</WithConfig>,
 			),
 		).not.toThrow();
 	});
@@ -491,14 +430,7 @@ describe('Island: server-side rendering', () => {
 	test('StickyBottomBanner', () => {
 		expect(() =>
 			renderToString(
-				<ConfigProvider
-					value={{
-						renderingTarget: 'Web',
-						darkModeAvailable: false,
-						updateLogoAdPartnerSwitch: false,
-						assetOrigin: '/',
-					}}
-				>
+				<WithConfig>
 					<StickyBottomBanner
 						contentType=""
 						tags={[]}
@@ -513,7 +445,7 @@ describe('Island: server-side rendering', () => {
 						remoteBannerSwitch={true}
 						isSensitive={false}
 					/>
-				</ConfigProvider>,
+				</WithConfig>,
 			),
 		).not.toThrow();
 	});
@@ -521,14 +453,7 @@ describe('Island: server-side rendering', () => {
 	test('SupportTheG', () => {
 		expect(() =>
 			renderToString(
-				<ConfigProvider
-					value={{
-						renderingTarget: 'Web',
-						darkModeAvailable: false,
-						updateLogoAdPartnerSwitch: false,
-						assetOrigin: '/',
-					}}
-				>
+				<WithConfig>
 					<SupportTheG
 						editionId={'UK'}
 						dataLinkNamePrefix={''}
@@ -541,7 +466,7 @@ describe('Island: server-side rendering', () => {
 							contribute: '',
 						}}
 					/>
-				</ConfigProvider>,
+				</WithConfig>,
 			),
 		).not.toThrow();
 	});
@@ -549,14 +474,7 @@ describe('Island: server-side rendering', () => {
 	test('ShareButton', () => {
 		expect(() =>
 			renderToString(
-				<ConfigProvider
-					value={{
-						renderingTarget: 'Web',
-						darkModeAvailable: false,
-						updateLogoAdPartnerSwitch: false,
-						assetOrigin: '/',
-					}}
-				>
+				<WithConfig>
 					<ShareButton
 						pageId={'123'}
 						webTitle={'The the'}
@@ -567,7 +485,7 @@ describe('Island: server-side rendering', () => {
 						}}
 						context="ArticleMeta"
 					/>
-				</ConfigProvider>,
+				</WithConfig>,
 			),
 		).not.toThrow();
 	});

--- a/dotcom-rendering/src/components/Island.tsx
+++ b/dotcom-rendering/src/components/Island.tsx
@@ -1,5 +1,4 @@
 import type { ScheduleOptions, SchedulePriority } from '../lib/scheduler';
-import { useConfig } from './ConfigContext';
 
 type DeferredProps = {
 	visible: {
@@ -49,14 +48,6 @@ type IslandProps = {
  * @param {JSX.Element} props.children - The component being inserted. Must be a single JSX Element
  */
 export const Island = ({ priority, defer, children }: IslandProps) => {
-	/**
-	 * Where is this coming from?
-	 * Config value is set at high in the component tree within a React context in a `<ConfigProvider />`
-	 *
-	 * This is here so that we can provide the config information to the hydrated, client-side rendered components
-	 */
-	const config = useConfig();
-
 	const rootMargin =
 		defer?.until === 'visible' ? defer.rootMargin : undefined;
 
@@ -70,7 +61,6 @@ export const Island = ({ priority, defer, children }: IslandProps) => {
 			deferUntil={defer?.until}
 			props={JSON.stringify(children.props)}
 			rootMargin={rootMargin}
-			config={JSON.stringify(config)}
 		>
 			{children}
 		</gu-island>
@@ -88,9 +78,4 @@ export type GuIsland = {
 	rootMargin?: string;
 	props: string;
 	children: React.ReactNode;
-	/**
-	 * This should be a stringified JSON of `ConfigContext`
-	 * @see /dotcom-rendering/src/types/configContext.ts
-	 */
-	config: string;
 };

--- a/dotcom-rendering/src/components/LatestLinks.importable.tsx
+++ b/dotcom-rendering/src/components/LatestLinks.importable.tsx
@@ -12,9 +12,9 @@ import { useApi } from '../lib/useApi';
 import { palette as themePalette } from '../palette';
 import type { DCRContainerPalette } from '../types/front';
 import { WithLink } from './CardHeadline';
+import { useConfig } from './ConfigContext';
 import { ContainerOverrides } from './ContainerOverrides';
 import { DateTime } from './DateTime';
-import { useConfig } from './ConfigContext';
 
 type Props = {
 	id: string;

--- a/dotcom-rendering/src/components/LatestLinks.importable.tsx
+++ b/dotcom-rendering/src/components/LatestLinks.importable.tsx
@@ -14,6 +14,7 @@ import type { DCRContainerPalette } from '../types/front';
 import { WithLink } from './CardHeadline';
 import { ContainerOverrides } from './ContainerOverrides';
 import { DateTime } from './DateTime';
+import { useConfig } from './ConfigContext';
 
 type Props = {
 	id: string;
@@ -125,6 +126,8 @@ export const LatestLinks = ({
 		min-height: ${minHeight};
 	`;
 
+	const { editionId } = useConfig();
+
 	return (
 		<ul
 			css={[
@@ -179,7 +182,7 @@ export const LatestLinks = ({
 												absoluteServerTimes={
 													absoluteServerTimes
 												}
-												editionId={'UK'}
+												editionId={editionId}
 												showWeekday={false}
 												showDate={true}
 												showTime={false}

--- a/dotcom-rendering/src/components/MostViewedFooter.test.tsx
+++ b/dotcom-rendering/src/components/MostViewedFooter.test.tsx
@@ -28,6 +28,7 @@ describe('MostViewedFooterData', () => {
 					darkModeAvailable: false,
 					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
+					editionId: 'UK',
 				}}
 			>
 				<MostViewedFooterData
@@ -71,6 +72,7 @@ describe('MostViewedFooterData', () => {
 					darkModeAvailable: false,
 					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
+					editionId: 'UK',
 				}}
 			>
 				<MostViewedFooterData
@@ -133,6 +135,7 @@ describe('MostViewedFooterData', () => {
 					darkModeAvailable: false,
 					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
+					editionId: 'UK',
 				}}
 			>
 				<MostViewedFooterData
@@ -180,6 +183,7 @@ describe('MostViewedFooterData', () => {
 					darkModeAvailable: false,
 					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
+					editionId: 'UK',
 				}}
 			>
 				<MostViewedFooterData
@@ -203,6 +207,7 @@ describe('MostViewedFooterData', () => {
 					darkModeAvailable: false,
 					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
+					editionId: 'UK',
 				}}
 			>
 				<MostViewedFooterData

--- a/dotcom-rendering/src/components/MostViewedRight.test.tsx
+++ b/dotcom-rendering/src/components/MostViewedRight.test.tsx
@@ -25,6 +25,7 @@ describe('MostViewedList', () => {
 					darkModeAvailable: false,
 					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
+					editionId: 'UK',
 				}}
 			>
 				<MostViewedRight />
@@ -75,6 +76,7 @@ describe('MostViewedList', () => {
 					darkModeAvailable: false,
 					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
+					editionId: 'UK',
 				}}
 			>
 				<MostViewedRight limitItems={3} />
@@ -104,6 +106,7 @@ describe('MostViewedList', () => {
 					darkModeAvailable: false,
 					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
+					editionId: 'UK',
 				}}
 			>
 				<MostViewedRight />

--- a/dotcom-rendering/src/components/Nav/Nav.test.tsx
+++ b/dotcom-rendering/src/components/Nav/Nav.test.tsx
@@ -12,6 +12,7 @@ describe('Nav', () => {
 				darkModeAvailable: false,
 				updateLogoAdPartnerSwitch: false,
 				assetOrigin: '/',
+				editionId: 'UK',
 			}}
 		>
 			<Nav

--- a/dotcom-rendering/src/components/ProfileAtom.test.tsx
+++ b/dotcom-rendering/src/components/ProfileAtom.test.tsx
@@ -11,6 +11,7 @@ describe('ProfileAtom', () => {
 					darkModeAvailable: false,
 					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
+					editionId: 'UK',
 				}}
 			>
 				<ProfileAtom
@@ -51,6 +52,7 @@ describe('ProfileAtom', () => {
 					darkModeAvailable: false,
 					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
+					editionId: 'UK',
 				}}
 			>
 				<ProfileAtom
@@ -92,6 +94,7 @@ describe('ProfileAtom', () => {
 					darkModeAvailable: false,
 					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
+					editionId: 'UK',
 				}}
 			>
 				<ProfileAtom

--- a/dotcom-rendering/src/components/QandaAtom.test.tsx
+++ b/dotcom-rendering/src/components/QandaAtom.test.tsx
@@ -13,6 +13,7 @@ describe('QandaAtom', () => {
 					darkModeAvailable: false,
 					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
+					editionId: 'UK',
 				}}
 			>
 				<QandaAtom {...imageStory} />
@@ -39,6 +40,7 @@ describe('QandaAtom', () => {
 					darkModeAvailable: false,
 					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
+					editionId: 'UK',
 				}}
 			>
 				<QandaAtom {...imageStory} />
@@ -66,6 +68,7 @@ describe('QandaAtom', () => {
 					darkModeAvailable: false,
 					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
+					editionId: 'UK',
 				}}
 			>
 				<QandaAtom {...imageStory} />

--- a/dotcom-rendering/src/components/ReaderRevenueLinks.test.tsx
+++ b/dotcom-rendering/src/components/ReaderRevenueLinks.test.tsx
@@ -48,6 +48,7 @@ describe('ReaderRevenueLinks', () => {
 					darkModeAvailable: false,
 					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
+					editionId: 'UK',
 				}}
 			>
 				<ReaderRevenueLinks
@@ -74,6 +75,7 @@ describe('ReaderRevenueLinks', () => {
 					darkModeAvailable: false,
 					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
+					editionId: 'UK',
 				}}
 			>
 				<ReaderRevenueLinks

--- a/dotcom-rendering/src/components/RichLinkComponent.importable.test.tsx
+++ b/dotcom-rendering/src/components/RichLinkComponent.importable.test.tsx
@@ -18,6 +18,7 @@ describe('RichLinkComponent', () => {
 						darkModeAvailable: false,
 						updateLogoAdPartnerSwitch: false,
 						assetOrigin: '/',
+						editionId: 'UK',
 					}}
 				>
 					<RichLinkComponent

--- a/dotcom-rendering/src/components/SignInGate/gateDesigns/SignInGateMainCheckoutComplete.test.tsx
+++ b/dotcom-rendering/src/components/SignInGate/gateDesigns/SignInGateMainCheckoutComplete.test.tsx
@@ -34,6 +34,7 @@ describe('SignInGateMainCheckoutComplete', () => {
 					darkModeAvailable: false,
 					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
+					editionId: 'UK',
 				}}
 			>
 				<SignInGateMainCheckoutComplete

--- a/dotcom-rendering/src/components/TimelineAtom.test.tsx
+++ b/dotcom-rendering/src/components/TimelineAtom.test.tsx
@@ -13,6 +13,7 @@ describe('TimelineAtom', () => {
 					darkModeAvailable: false,
 					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
+					editionId: 'UK',
 				}}
 			>
 				<TimelineAtom {...noTimelineEventsStory} />
@@ -39,6 +40,7 @@ describe('TimelineAtom', () => {
 					darkModeAvailable: false,
 					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
+					editionId: 'UK',
 				}}
 			>
 				<TimelineAtom {...noTimelineEventsStory} />
@@ -66,6 +68,7 @@ describe('TimelineAtom', () => {
 					darkModeAvailable: false,
 					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
+					editionId: 'UK',
 				}}
 			>
 				<TimelineAtom {...noTimelineEventsStory} />

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.test.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.test.tsx
@@ -30,6 +30,7 @@ describe('YoutubeAtom', () => {
 					darkModeAvailable: false,
 					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
+					editionId: 'UK',
 				}}
 			>
 				<YoutubeAtom
@@ -67,6 +68,7 @@ describe('YoutubeAtom', () => {
 					darkModeAvailable: false,
 					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
+					editionId: 'UK',
 				}}
 			>
 				<YoutubeAtom
@@ -113,6 +115,7 @@ describe('YoutubeAtom', () => {
 					darkModeAvailable: false,
 					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
+					editionId: 'UK',
 				}}
 			>
 				<YoutubeAtom
@@ -151,6 +154,7 @@ describe('YoutubeAtom', () => {
 					darkModeAvailable: false,
 					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
+					editionId: 'UK',
 				}}
 			>
 				<YoutubeAtom
@@ -191,6 +195,7 @@ describe('YoutubeAtom', () => {
 					darkModeAvailable: false,
 					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
+					editionId: 'UK',
 				}}
 			>
 				<YoutubeAtom
@@ -229,6 +234,7 @@ describe('YoutubeAtom', () => {
 					darkModeAvailable: false,
 					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
+					editionId: 'UK',
 				}}
 			>
 				<YoutubeAtom
@@ -266,6 +272,7 @@ describe('YoutubeAtom', () => {
 					darkModeAvailable: false,
 					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
+					editionId: 'UK',
 				}}
 			>
 				<YoutubeAtom
@@ -307,6 +314,7 @@ describe('YoutubeAtom', () => {
 						darkModeAvailable: false,
 						updateLogoAdPartnerSwitch: false,
 						assetOrigin: '/',
+						editionId: 'UK',
 					}}
 				>
 					<YoutubeAtom

--- a/dotcom-rendering/src/server/htmlPageTemplate.ts
+++ b/dotcom-rendering/src/server/htmlPageTemplate.ts
@@ -335,9 +335,9 @@ https://workforus.theguardian.com/careers/product-engineering/
                     })(window, document);
                 </script>
 
-        <script id="config" type="application/json">${JSON.stringify(
-			config,
-		)}</script>
+        <script id="config" type="application/json">
+          ${JSON.stringify(config)}
+        </script>
 
 				<script>
 					window.curlConfig = {

--- a/dotcom-rendering/src/server/htmlPageTemplate.ts
+++ b/dotcom-rendering/src/server/htmlPageTemplate.ts
@@ -4,7 +4,7 @@ import { ASSET_ORIGIN } from '../lib/assets';
 import { escapeData } from '../lib/escapeData';
 import { fontsCss } from '../lib/fonts-css';
 import type { Guardian } from '../model/guardian';
-import type { RenderingTarget } from '../types/renderingTarget';
+import type { Config } from '../types/configContext';
 import { GIT_COMMIT_HASH } from './prout';
 
 type BaseProps = {
@@ -20,7 +20,6 @@ type BaseProps = {
 	twitterData?: { [key: string]: string };
 	initTwitter?: string;
 	canonicalUrl?: string;
-	renderingTarget: RenderingTarget;
 	hasPageSkin?: boolean;
 	weAreHiring: boolean;
 };
@@ -28,10 +27,12 @@ type BaseProps = {
 interface WebProps extends BaseProps {
 	renderingTarget: 'Web';
 	keywords: string;
+	config: Config & { renderingTarget: 'Web' };
 }
 
 interface AppProps extends BaseProps {
 	renderingTarget: 'Apps';
+	config: Config & { renderingTarget: 'Apps' };
 }
 
 /**
@@ -67,6 +68,7 @@ export const htmlPageTemplate = (props: WebProps | AppProps): string => {
 		renderingTarget,
 		hasPageSkin = false,
 		weAreHiring,
+		config,
 	} = props;
 
 	/**
@@ -74,6 +76,11 @@ export const htmlPageTemplate = (props: WebProps | AppProps): string => {
 	 * is placed in a script tag on the page
 	 */
 	const windowGuardian = escapeData(JSON.stringify(guardian));
+
+	if (config.renderingTarget === 'Apps') {
+		config.darkModeAvailable;
+		config.updateLogoAdPartnerSwitch;
+	}
 
 	const favicon =
 		process.env.NODE_ENV === 'production'
@@ -332,6 +339,10 @@ https://workforus.theguardian.com/careers/product-engineering/
 
                     })(window, document);
                 </script>
+
+        <script id="config" type="application/json">${JSON.stringify(
+			config,
+		)}</script>
 
 				<script>
 					window.curlConfig = {

--- a/dotcom-rendering/src/server/htmlPageTemplate.ts
+++ b/dotcom-rendering/src/server/htmlPageTemplate.ts
@@ -77,11 +77,6 @@ export const htmlPageTemplate = (props: WebProps | AppProps): string => {
 	 */
 	const windowGuardian = escapeData(JSON.stringify(guardian));
 
-	if (config.renderingTarget === 'Apps') {
-		config.darkModeAvailable;
-		config.updateLogoAdPartnerSwitch;
-	}
-
 	const favicon =
 		process.env.NODE_ENV === 'production'
 			? 'favicon-32x32.ico'

--- a/dotcom-rendering/src/server/render.allEditorialNewslettersPage.web.tsx
+++ b/dotcom-rendering/src/server/render.allEditorialNewslettersPage.web.tsx
@@ -30,6 +30,7 @@ export const renderEditorialNewslettersPage = ({
 		darkModeAvailable: false,
 		updateLogoAdPartnerSwitch: false,
 		assetOrigin: ASSET_ORIGIN,
+		editionId: newslettersPage.editionId,
 	} satisfies Config;
 
 	const { html, extractedCss } = renderToStringWithEmotion(

--- a/dotcom-rendering/src/server/render.allEditorialNewslettersPage.web.tsx
+++ b/dotcom-rendering/src/server/render.allEditorialNewslettersPage.web.tsx
@@ -25,12 +25,12 @@ export const renderEditorialNewslettersPage = ({
 	const NAV = extractNAV(newslettersPage.nav);
 
 	// The newsletters page is currently only supported on Web
-	const config: Config = {
+	const config = {
 		renderingTarget: 'Web',
 		darkModeAvailable: false,
 		updateLogoAdPartnerSwitch: false,
 		assetOrigin: ASSET_ORIGIN,
-	};
+	} satisfies Config;
 
 	const { html, extractedCss } = renderToStringWithEmotion(
 		<ConfigProvider value={config}>
@@ -99,6 +99,7 @@ export const renderEditorialNewslettersPage = ({
 		keywords: '',
 		renderingTarget: 'Web',
 		weAreHiring: !!newslettersPage.config.switches.weAreHiring,
+		config,
 	});
 	return {
 		html: pageHtml,

--- a/dotcom-rendering/src/server/render.article.amp.tsx
+++ b/dotcom-rendering/src/server/render.article.amp.tsx
@@ -46,6 +46,7 @@ export const renderArticle = ({
 		darkModeAvailable: false,
 		updateLogoAdPartnerSwitch: false,
 		assetOrigin: ASSET_ORIGIN,
+		editionId: 'INT', // AMP pages have all editions in the HTML
 	};
 
 	const { html, css }: RenderToStringResult = extractCritical(

--- a/dotcom-rendering/src/server/render.article.apps.tsx
+++ b/dotcom-rendering/src/server/render.article.apps.tsx
@@ -120,6 +120,7 @@ window.twttr = (function(d, s, id) {
 			pageHasTweetElements || format.design === ArticleDesign.LiveBlog
 				? initTwitter
 				: undefined,
+		config,
 	});
 
 	return {

--- a/dotcom-rendering/src/server/render.article.apps.tsx
+++ b/dotcom-rendering/src/server/render.article.apps.tsx
@@ -29,6 +29,7 @@ export const renderArticle = (
 		updateLogoAdPartnerSwitch:
 			!!article.config.switches.updateLogoAdPartner,
 		assetOrigin: ASSET_ORIGIN,
+		editionId: article.editionId,
 	};
 
 	const { html, extractedCss } = renderToStringWithEmotion(

--- a/dotcom-rendering/src/server/render.article.web.tsx
+++ b/dotcom-rendering/src/server/render.article.web.tsx
@@ -55,6 +55,7 @@ export const renderHtml = ({
 		updateLogoAdPartnerSwitch:
 			!!article.config.switches.updateLogoAdPartner,
 		assetOrigin: ASSET_ORIGIN,
+		editionId: article.editionId,
 	};
 
 	const { html, extractedCss } = renderToStringWithEmotion(
@@ -252,15 +253,16 @@ export const renderBlocks = ({
 }: FEBlocksRequest): string => {
 	const format: ArticleFormat = decideFormat(FEFormat);
 
+	const editionId = isEditionId(edition) ? edition : 'UK';
+
 	// Only currently supported for Web
 	const config: Config = {
 		renderingTarget: 'Web',
 		darkModeAvailable: abTests.darkModeWebVariant === 'variant',
 		updateLogoAdPartnerSwitch: !!switches.updateLogoAdPartner,
 		assetOrigin: ASSET_ORIGIN,
+		editionId,
 	};
-
-	const editionId = isEditionId(edition) ? edition : 'UK';
 
 	const { html, extractedCss } = renderToStringWithEmotion(
 		<ConfigProvider value={config}>

--- a/dotcom-rendering/src/server/render.article.web.tsx
+++ b/dotcom-rendering/src/server/render.article.web.tsx
@@ -223,6 +223,7 @@ window.twttr = (function(d, s, id) {
 		canonicalUrl,
 		renderingTarget: 'Web',
 		weAreHiring: !!article.config.switches.weAreHiring,
+		config,
 	});
 
 	return { html: pageHtml, prefetchScripts };

--- a/dotcom-rendering/src/server/render.front.web.tsx
+++ b/dotcom-rendering/src/server/render.front.web.tsx
@@ -89,6 +89,7 @@ export const renderFront = ({
 			front.config.abTests.darkModeWebVariant === 'variant',
 		updateLogoAdPartnerSwitch: !!front.config.switches.updateLogoAdPartner,
 		assetOrigin: ASSET_ORIGIN,
+		editionId: front.editionId,
 	} satisfies Config;
 
 	const { html, extractedCss } = renderToStringWithEmotion(
@@ -192,6 +193,7 @@ export const renderTagPage = ({
 		updateLogoAdPartnerSwitch:
 			!!tagPage.config.switches.updateLogoAdPartner,
 		assetOrigin: ASSET_ORIGIN,
+		editionId: tagPage.editionId,
 	};
 
 	const { html, extractedCss } = renderToStringWithEmotion(

--- a/dotcom-rendering/src/server/render.front.web.tsx
+++ b/dotcom-rendering/src/server/render.front.web.tsx
@@ -83,13 +83,13 @@ export const renderFront = ({
 	const enhancedNAV = enhanceNav(NAV);
 
 	// Fronts are not supported in Apps
-	const config: Config = {
+	const config = {
 		renderingTarget: 'Web',
 		darkModeAvailable:
 			front.config.abTests.darkModeWebVariant === 'variant',
 		updateLogoAdPartnerSwitch: !!front.config.switches.updateLogoAdPartner,
 		assetOrigin: ASSET_ORIGIN,
-	};
+	} satisfies Config;
 
 	const { html, extractedCss } = renderToStringWithEmotion(
 		<ConfigProvider value={config}>
@@ -166,6 +166,7 @@ export const renderFront = ({
 		hasPageSkin: front.config.hasPageSkin,
 		weAreHiring: !!front.config.switches.weAreHiring,
 		canonicalUrl,
+		config,
 	});
 
 	return {
@@ -260,6 +261,7 @@ export const renderTagPage = ({
 		renderingTarget: 'Web',
 		weAreHiring: !!tagPage.config.switches.weAreHiring,
 		canonicalUrl: tagPage.canonicalUrl,
+		config,
 	});
 	return {
 		html: pageHtml,

--- a/dotcom-rendering/src/types/configContext.ts
+++ b/dotcom-rendering/src/types/configContext.ts
@@ -8,15 +8,15 @@ import type { RenderingTarget } from './renderingTarget';
  * @see /dotcom-rendering/docs/architecture/proposed-adrs/react-context-api.md
  */
 export type Config =
-	| {
+	| Readonly<{
 			renderingTarget: Extract<RenderingTarget, 'Web'>;
 			darkModeAvailable: boolean;
 			updateLogoAdPartnerSwitch: boolean;
 			assetOrigin: AssetOrigin;
-	  }
-	| {
+	  }>
+	| Readonly<{
 			renderingTarget: Extract<RenderingTarget, 'Apps'>;
 			darkModeAvailable: boolean;
 			updateLogoAdPartnerSwitch: boolean;
 			assetOrigin: AssetOrigin;
-	  };
+	  }>;

--- a/dotcom-rendering/src/types/configContext.ts
+++ b/dotcom-rendering/src/types/configContext.ts
@@ -1,4 +1,5 @@
 import type { AssetOrigin } from '../lib/assets';
+import type { EditionId } from '../lib/edition';
 import type { RenderingTarget } from './renderingTarget';
 
 /**
@@ -13,10 +14,12 @@ export type Config =
 			darkModeAvailable: boolean;
 			updateLogoAdPartnerSwitch: boolean;
 			assetOrigin: AssetOrigin;
+			editionId: EditionId;
 	  }>
 	| Readonly<{
 			renderingTarget: Extract<RenderingTarget, 'Apps'>;
 			darkModeAvailable: boolean;
 			updateLogoAdPartnerSwitch: boolean;
 			assetOrigin: AssetOrigin;
+			editionId: EditionId;
 	  }>;


### PR DESCRIPTION
## What does this change?

- make the config object `ReadOnly` so it’s not inadvertently mutated
- reduce serialised size in the DOM by using a single JSON object
- add the `editionId` to the config
- use the pattern for [`LatestLinks`](https://github.com/guardian/dotcom-rendering/pull/11742/files#diff-8c7596d837d0faed626e58361475851f5c3a50c0f86fe073dc7d489d1c6b0e48) and squash potential bugs

## Why?

This pattern, introduced in #8704, has been very useful. This addressed initial concerns from @georgeblahblah, @ioanna0 and myself about redundant data in the HTML. Adding the edition can help reduce deeply drilled props, and reduce bugs, such as in `CardAge`