### PR TITLE
Update thrift to v0.20.0

### DIFF
--- a/apps-rendering/package.json
+++ b/apps-rendering/package.json
@@ -98,7 +98,7 @@
 		"react-test-renderer": "18.3.1",
 		"require-from-string": "2.0.2",
 		"storybook": "8.1.8",
-		"thrift": "0.19.0",
+		"thrift": "0.20.0",
 		"ts-jest": "29.1.2",
 		"ts-loader": "9.5.1",
 		"tslib": "2.6.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,7 +99,7 @@ importers:
         version: 2.0.16
       '@storybook/addon-essentials':
         specifier: 8.1.8
-        version: 8.1.8(@types/react-dom@18.3.0)(@types/react@18.3.1)(prettier@3.0.3)(react-dom@18.3.1)(react@18.3.1)
+        version: 8.1.8(@types/react-dom@18.3.0)(@types/react@18.3.1)(prettier@3.3.2)(react-dom@18.3.1)(react@18.3.1)
       '@storybook/addon-webpack5-compiler-babel':
         specifier: 3.0.3
         version: 3.0.3(webpack@5.91.0)
@@ -117,10 +117,10 @@ importers:
         version: 8.1.8
       '@storybook/react':
         specifier: 8.1.8
-        version: 8.1.8(prettier@3.0.3)(react-dom@18.3.1)(react@18.3.1)(typescript@5.3.3)
+        version: 8.1.8(prettier@3.3.2)(react-dom@18.3.1)(react@18.3.1)(typescript@5.3.3)
       '@storybook/react-webpack5':
         specifier: 8.1.8
-        version: 8.1.8(esbuild@0.18.20)(prettier@3.0.3)(react-dom@18.3.1)(react@18.3.1)(typescript@5.3.3)(webpack-cli@5.1.4)
+        version: 8.1.8(esbuild@0.18.20)(prettier@3.3.2)(react-dom@18.3.1)(react@18.3.1)(typescript@5.3.3)(webpack-cli@5.1.4)
       '@storybook/theming':
         specifier: 8.1.8
         version: 8.1.8(react-dom@18.3.1)(react@18.3.1)
@@ -233,8 +233,8 @@ importers:
         specifier: 8.1.8
         version: 8.1.8(@babel/preset-env@7.24.5)(react-dom@18.3.1)(react@18.3.1)
       thrift:
-        specifier: 0.19.0
-        version: 0.19.0
+        specifier: 0.20.0
+        version: 0.20.0
       ts-jest:
         specifier: 29.1.2
         version: 29.1.2(@babel/core@7.24.5)(esbuild@0.18.20)(jest@29.7.0)(typescript@5.3.3)
@@ -390,7 +390,7 @@ importers:
         version: 7.75.1
       '@storybook/addon-essentials':
         specifier: 8.1.8
-        version: 8.1.8(@types/react-dom@18.3.0)(@types/react@18.3.1)(prettier@3.0.3)(react-dom@18.3.1)(react@18.3.1)
+        version: 8.1.8(@types/react-dom@18.3.0)(@types/react@18.3.1)(prettier@3.3.2)(react-dom@18.3.1)(react@18.3.1)
       '@storybook/addon-interactions':
         specifier: 8.1.8
         version: 8.1.8(@types/jest@29.5.12)(jest@29.7.0)
@@ -411,10 +411,10 @@ importers:
         version: 8.1.8
       '@storybook/react':
         specifier: 8.1.8
-        version: 8.1.8(prettier@3.0.3)(react-dom@18.3.1)(react@18.3.1)(typescript@5.3.3)
+        version: 8.1.8(prettier@3.3.2)(react-dom@18.3.1)(react@18.3.1)(typescript@5.3.3)
       '@storybook/react-webpack5':
         specifier: 8.1.8
-        version: 8.1.8(@swc/core@1.5.3)(esbuild@0.18.20)(prettier@3.0.3)(react-dom@18.3.1)(react@18.3.1)(typescript@5.3.3)(webpack-cli@5.1.4)
+        version: 8.1.8(@swc/core@1.5.3)(esbuild@0.18.20)(prettier@3.3.2)(react-dom@18.3.1)(react@18.3.1)(typescript@5.3.3)(webpack-cli@5.1.4)
       '@storybook/test':
         specifier: 8.1.8
         version: 8.1.8(@types/jest@29.5.12)(jest@29.7.0)
@@ -1964,7 +1964,7 @@ packages:
       '@babel/traverse': 7.24.5
       '@babel/types': 7.24.5
       convert-source-map: 2.0.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -2045,7 +2045,7 @@ packages:
       '@babel/core': 7.24.5
       '@babel/helper-compilation-targets': 7.23.6
       '@babel/helper-plugin-utils': 7.24.5
-      debug: 4.3.5
+      debug: 4.3.5(supports-color@8.1.1)
       lodash.debounce: 4.0.8
       resolve: 1.22.8
     transitivePeerDependencies:
@@ -3288,7 +3288,7 @@ packages:
       '@babel/helper-split-export-declaration': 7.24.5
       '@babel/parser': 7.24.5
       '@babel/types': 7.24.5
-      debug: 4.3.5
+      debug: 4.3.5(supports-color@8.1.1)
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -3301,10 +3301,6 @@ packages:
       '@babel/helper-string-parser': 7.24.1
       '@babel/helper-validator-identifier': 7.24.5
       to-fast-properties: 2.0.0
-    dev: false
-
-  /@balena/dockerignore@1.0.2:
-    resolution: {integrity: sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==}
     dev: false
 
   /@base2/pretty-print-object@1.0.1:
@@ -3916,11 +3912,6 @@ packages:
       eslint-visitor-keys: 3.4.3
     dev: false
 
-  /@eslint-community/regexpp@4.10.0:
-    resolution: {integrity: sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==}
-    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
-    dev: false
-
   /@eslint-community/regexpp@4.10.1:
     resolution: {integrity: sha512-Zm2NGpWELsQAD1xsJzGQpYfvICSsFkEpU0jxBjfdC6uNEWXcHnfs9hScFWtXVDVl+rBQJGrl4g1vcKIejpH9dA==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
@@ -3931,7 +3922,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@8.1.1)
       espree: 9.6.1
       globals: 13.24.0
       ignore: 5.3.1
@@ -3975,7 +3966,7 @@ packages:
       '@types/node-int64': 0.4.32
       '@types/thrift': 0.10.17
       node-int64: 0.4.0
-      thrift: 0.15.0
+      thrift: 0.20.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -4110,7 +4101,7 @@ packages:
       '@types/node-int64': 0.4.32
       '@types/thrift': 0.10.17
       node-int64: 0.4.0
-      thrift: 0.15.0
+      thrift: 0.20.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -4123,7 +4114,7 @@ packages:
       '@types/node-int64': 0.4.32
       '@types/thrift': 0.10.17
       node-int64: 0.4.0
-      thrift: 0.15.0
+      thrift: 0.20.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -4135,7 +4126,7 @@ packages:
       '@types/node-int64': 0.4.32
       '@types/thrift': 0.10.17
       node-int64: 0.4.0
-      thrift: 0.15.0
+      thrift: 0.20.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -4170,7 +4161,7 @@ packages:
       '@typescript-eslint/parser': 6.18.0(eslint@8.56.0)(typescript@5.3.3)
       eslint: 8.56.0
       eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.18.0)(eslint-plugin-import@2.29.1)(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.18.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.18.0)(eslint@8.56.0)
       tslib: 2.6.2
       typescript: 5.3.3
     transitivePeerDependencies:
@@ -4426,7 +4417,7 @@ packages:
       '@types/node-int64': 0.4.32
       '@types/thrift': 0.10.17
       node-int64: 0.4.0
-      thrift: 0.15.0
+      thrift: 0.20.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -4449,9 +4440,10 @@ packages:
   /@humanwhocodes/config-array@0.11.13:
     resolution: {integrity: sha512-JSBDMiDKSzQVngfRjOdFXgFfklaXI4K9nLF49Auh21lmBWRLIK3+xTErTWD4KU54pb6coM6ESE7Awz/FNU3zgQ==}
     engines: {node: '>=10.10.0'}
+    deprecated: Use @eslint/config-array instead
     dependencies:
       '@humanwhocodes/object-schema': 2.0.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@8.1.1)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -4464,6 +4456,7 @@ packages:
 
   /@humanwhocodes/object-schema@2.0.1:
     resolution: {integrity: sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==}
+    deprecated: Use @eslint/object-schema instead
     dev: false
 
   /@isaacs/cliui@8.0.2:
@@ -4848,8 +4841,8 @@ packages:
       chalk: 4.1.2
       clean-stack: 3.0.1
       cli-progress: 3.12.0
-      debug: 4.3.4(supports-color@8.1.1)
-      ejs: 3.1.9
+      debug: 4.3.5(supports-color@8.1.1)
+      ejs: 3.1.10
       get-package-type: 0.1.0
       globby: 11.1.0
       hyperlinker: 1.0.0
@@ -4887,8 +4880,8 @@ packages:
       chalk: 4.1.2
       clean-stack: 3.0.1
       cli-progress: 3.12.0
-      debug: 4.3.4(supports-color@8.1.1)
-      ejs: 3.1.9
+      debug: 4.3.5(supports-color@8.1.1)
+      ejs: 3.1.10
       get-package-type: 0.1.0
       globby: 11.1.0
       hyperlinker: 1.0.0
@@ -5788,10 +5781,10 @@ packages:
       ts-dedent: 2.2.0
     dev: false
 
-  /@storybook/addon-controls@8.1.8(@types/react-dom@18.3.0)(@types/react@18.3.1)(prettier@3.0.3)(react-dom@18.3.1)(react@18.3.1):
+  /@storybook/addon-controls@8.1.8(@types/react-dom@18.3.0)(@types/react@18.3.1)(prettier@3.3.2)(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-o/0WUSlWd6Erf37D9xOnRk7GYMOYf0eI1O7MQdPBSOpI+I77684vCp35D/WcamK3lqz0sAewF5tM14tuo3ATZw==}
     dependencies:
-      '@storybook/blocks': 8.1.8(@types/react-dom@18.3.0)(@types/react@18.3.1)(prettier@3.0.3)(react-dom@18.3.1)(react@18.3.1)
+      '@storybook/blocks': 8.1.8(@types/react-dom@18.3.0)(@types/react@18.3.1)(prettier@3.3.2)(react-dom@18.3.1)(react@18.3.1)
       dequal: 2.0.3
       lodash: 4.17.21
       ts-dedent: 2.2.0
@@ -5805,12 +5798,12 @@ packages:
       - supports-color
     dev: false
 
-  /@storybook/addon-docs@8.1.8(@types/react-dom@18.3.0)(prettier@3.0.3):
+  /@storybook/addon-docs@8.1.8(@types/react-dom@18.3.0)(prettier@3.3.2):
     resolution: {integrity: sha512-zTQxrO53TxDNUn/laK4BCBHp1nO2DABq4BIuNAapYq+DuQ3w981/Jcb9Qwr8TrGGb0hmT1vV2ZGP1m0KfA8OQg==}
     dependencies:
       '@babel/core': 7.24.5
       '@mdx-js/react': 3.0.1(@types/react@18.3.1)(react@18.3.1)
-      '@storybook/blocks': 8.1.8(@types/react-dom@18.3.0)(@types/react@18.3.1)(prettier@3.0.3)(react-dom@18.3.1)(react@18.3.1)
+      '@storybook/blocks': 8.1.8(@types/react-dom@18.3.0)(@types/react@18.3.1)(prettier@3.3.2)(react-dom@18.3.1)(react@18.3.1)
       '@storybook/client-logger': 8.1.8
       '@storybook/components': 8.1.8(@types/react-dom@18.3.0)(@types/react@18.3.1)(react-dom@18.3.1)(react@18.3.1)
       '@storybook/csf-plugin': 8.1.8
@@ -5835,19 +5828,19 @@ packages:
       - supports-color
     dev: false
 
-  /@storybook/addon-essentials@8.1.8(@types/react-dom@18.3.0)(@types/react@18.3.1)(prettier@3.0.3)(react-dom@18.3.1)(react@18.3.1):
+  /@storybook/addon-essentials@8.1.8(@types/react-dom@18.3.0)(@types/react@18.3.1)(prettier@3.3.2)(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-qAVuighthkhYEgM977vj3sk4mZEOP+JGt+qYLT4nIjuucNm9aXyUOQovIiLQeAwtj+zvwSJ7diFDlQW3eYq+hQ==}
     dependencies:
       '@storybook/addon-actions': 8.1.8
       '@storybook/addon-backgrounds': 8.1.8
-      '@storybook/addon-controls': 8.1.8(@types/react-dom@18.3.0)(@types/react@18.3.1)(prettier@3.0.3)(react-dom@18.3.1)(react@18.3.1)
-      '@storybook/addon-docs': 8.1.8(@types/react-dom@18.3.0)(prettier@3.0.3)
+      '@storybook/addon-controls': 8.1.8(@types/react-dom@18.3.0)(@types/react@18.3.1)(prettier@3.3.2)(react-dom@18.3.1)(react@18.3.1)
+      '@storybook/addon-docs': 8.1.8(@types/react-dom@18.3.0)(prettier@3.3.2)
       '@storybook/addon-highlight': 8.1.8
       '@storybook/addon-measure': 8.1.8
       '@storybook/addon-outline': 8.1.8
       '@storybook/addon-toolbars': 8.1.8
       '@storybook/addon-viewport': 8.1.8
-      '@storybook/core-common': 8.1.8(prettier@3.0.3)
+      '@storybook/core-common': 8.1.8(prettier@3.3.2)
       '@storybook/manager-api': 8.1.8(react-dom@18.3.1)(react@18.3.1)
       '@storybook/node-logger': 8.1.8
       '@storybook/preview-api': 8.1.8
@@ -5931,7 +5924,7 @@ packages:
       - webpack
     dev: false
 
-  /@storybook/blocks@8.1.8(@types/react-dom@18.3.0)(@types/react@18.3.1)(prettier@3.0.3)(react-dom@18.3.1)(react@18.3.1):
+  /@storybook/blocks@8.1.8(@types/react-dom@18.3.0)(@types/react@18.3.1)(prettier@3.3.2)(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-nx18ism4YCuLFOmI6mQ+EJD1XABcbDdAyeheZPwkwB+fKkseNiOy7C/Mqio7ReYIncvlML6CCUyFm/OSEZkHkQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
@@ -5947,7 +5940,7 @@ packages:
       '@storybook/components': 8.1.8(@types/react-dom@18.3.0)(@types/react@18.3.1)(react-dom@18.3.1)(react@18.3.1)
       '@storybook/core-events': 8.1.8
       '@storybook/csf': 0.1.8
-      '@storybook/docs-tools': 8.1.8(prettier@3.0.3)
+      '@storybook/docs-tools': 8.1.8(prettier@3.3.2)
       '@storybook/global': 5.0.0
       '@storybook/icons': 1.2.9(react-dom@18.3.1)(react@18.3.1)
       '@storybook/manager-api': 8.1.8(react-dom@18.3.1)(react@18.3.1)
@@ -5976,11 +5969,11 @@ packages:
       - supports-color
     dev: false
 
-  /@storybook/builder-manager@8.1.8(prettier@3.0.3):
+  /@storybook/builder-manager@8.1.8(prettier@3.3.2):
     resolution: {integrity: sha512-M4qpETmQNUTg6KEt4nVONjF2dXlVV1V+Mxf9saiinoj+PCyHdz+BmYYmiGtopUPxJ2YGvTL1nGykkyH57HutrQ==}
     dependencies:
       '@fal-works/esbuild-plugin-global-externals': 2.1.2
-      '@storybook/core-common': 8.1.8(prettier@3.0.3)
+      '@storybook/core-common': 8.1.8(prettier@3.3.2)
       '@storybook/manager': 8.1.8
       '@storybook/node-logger': 8.1.8
       '@types/ejs': 3.1.5
@@ -5999,7 +5992,7 @@ packages:
       - supports-color
     dev: false
 
-  /@storybook/builder-webpack5@8.1.8(@swc/core@1.5.3)(esbuild@0.18.20)(prettier@3.0.3)(typescript@5.3.3)(webpack-cli@5.1.4):
+  /@storybook/builder-webpack5@8.1.8(@swc/core@1.5.3)(esbuild@0.18.20)(prettier@3.3.2)(typescript@5.3.3)(webpack-cli@5.1.4):
     resolution: {integrity: sha512-L02ZG8583WqAhcW8+gKVKO99kb8ThhwSKMmtCk9XR++CCpO7kgR0N/lGJr79f2OYFuM6WQhfO/FRtER/7o45lw==}
     peerDependencies:
       typescript: '*'
@@ -6009,9 +6002,9 @@ packages:
     dependencies:
       '@storybook/channels': 8.1.8
       '@storybook/client-logger': 8.1.8
-      '@storybook/core-common': 8.1.8(prettier@3.0.3)
+      '@storybook/core-common': 8.1.8(prettier@3.3.2)
       '@storybook/core-events': 8.1.8
-      '@storybook/core-webpack': 8.1.8(prettier@3.0.3)
+      '@storybook/core-webpack': 8.1.8(prettier@3.3.2)
       '@storybook/node-logger': 8.1.8
       '@storybook/preview': 8.1.8
       '@storybook/preview-api': 8.1.8
@@ -6053,7 +6046,7 @@ packages:
       - webpack-cli
     dev: false
 
-  /@storybook/builder-webpack5@8.1.8(esbuild@0.18.20)(prettier@3.0.3)(typescript@5.3.3)(webpack-cli@5.1.4):
+  /@storybook/builder-webpack5@8.1.8(esbuild@0.18.20)(prettier@3.3.2)(typescript@5.3.3)(webpack-cli@5.1.4):
     resolution: {integrity: sha512-L02ZG8583WqAhcW8+gKVKO99kb8ThhwSKMmtCk9XR++CCpO7kgR0N/lGJr79f2OYFuM6WQhfO/FRtER/7o45lw==}
     peerDependencies:
       typescript: '*'
@@ -6063,9 +6056,9 @@ packages:
     dependencies:
       '@storybook/channels': 8.1.8
       '@storybook/client-logger': 8.1.8
-      '@storybook/core-common': 8.1.8(prettier@3.0.3)
+      '@storybook/core-common': 8.1.8(prettier@3.3.2)
       '@storybook/core-events': 8.1.8
-      '@storybook/core-webpack': 8.1.8(prettier@3.0.3)
+      '@storybook/core-webpack': 8.1.8(prettier@3.3.2)
       '@storybook/node-logger': 8.1.8
       '@storybook/preview': 8.1.8
       '@storybook/preview-api': 8.1.8
@@ -6125,12 +6118,12 @@ packages:
       '@babel/types': 7.24.5
       '@ndelangen/get-tarball': 3.0.9
       '@storybook/codemod': 8.1.8
-      '@storybook/core-common': 8.1.8(prettier@3.0.3)
+      '@storybook/core-common': 8.1.8(prettier@3.3.2)
       '@storybook/core-events': 8.1.8
-      '@storybook/core-server': 8.1.8(prettier@3.0.3)(react-dom@18.3.1)(react@18.3.1)
+      '@storybook/core-server': 8.1.8(prettier@3.3.2)(react-dom@18.3.1)(react@18.3.1)
       '@storybook/csf-tools': 8.1.8
       '@storybook/node-logger': 8.1.8
-      '@storybook/telemetry': 8.1.8(prettier@3.0.3)
+      '@storybook/telemetry': 8.1.8(prettier@3.3.2)
       '@storybook/types': 8.1.8
       '@types/semver': 7.5.6
       '@yarnpkg/fslib': 2.10.3
@@ -6218,7 +6211,7 @@ packages:
       - '@types/react-dom'
     dev: false
 
-  /@storybook/core-common@8.1.8(prettier@3.0.3):
+  /@storybook/core-common@8.1.8(prettier@3.3.2):
     resolution: {integrity: sha512-RcJUTGjvVCuGtz7GifY8sMHLUvmsg8moDOgwwkOJ+9QdgInyuZeqLzNI7BjOv2CYCK1sy7x0eU7B4CWD8LwnwA==}
     peerDependencies:
       prettier: ^2 || ^3
@@ -6247,8 +6240,8 @@ packages:
       node-fetch: 2.7.0
       picomatch: 2.3.1
       pkg-dir: 5.0.0
-      prettier: 3.0.3
-      prettier-fallback: /prettier@3.0.3
+      prettier: 3.3.2
+      prettier-fallback: /prettier@3.3.2
       pretty-hrtime: 1.0.3
       resolve-from: 5.0.0
       semver: 7.5.4
@@ -6268,16 +6261,16 @@ packages:
       ts-dedent: 2.2.0
     dev: false
 
-  /@storybook/core-server@8.1.8(prettier@3.0.3)(react-dom@18.3.1)(react@18.3.1):
+  /@storybook/core-server@8.1.8(prettier@3.3.2)(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-v2V7FC/y/lrKPxcseIwPavjdCCDHphpj+A23Jmp822tqYn+I4nYRvE74QKyn5dfLrdn52nz8KrUFwjhuacj10Q==}
     dependencies:
       '@aw-web-design/x-default-browser': 1.4.126
       '@babel/core': 7.24.5
       '@babel/parser': 7.24.5
       '@discoveryjs/json-ext': 0.5.7
-      '@storybook/builder-manager': 8.1.8(prettier@3.0.3)
+      '@storybook/builder-manager': 8.1.8(prettier@3.3.2)
       '@storybook/channels': 8.1.8
-      '@storybook/core-common': 8.1.8(prettier@3.0.3)
+      '@storybook/core-common': 8.1.8(prettier@3.3.2)
       '@storybook/core-events': 8.1.8
       '@storybook/csf': 0.1.8
       '@storybook/csf-tools': 8.1.8
@@ -6287,7 +6280,7 @@ packages:
       '@storybook/manager-api': 8.1.8(react-dom@18.3.1)(react@18.3.1)
       '@storybook/node-logger': 8.1.8
       '@storybook/preview-api': 8.1.8
-      '@storybook/telemetry': 8.1.8(prettier@3.0.3)
+      '@storybook/telemetry': 8.1.8(prettier@3.3.2)
       '@storybook/types': 8.1.8
       '@types/detect-port': 1.3.5
       '@types/diff': 5.2.1
@@ -6315,7 +6308,7 @@ packages:
       util: 0.12.5
       util-deprecate: 1.0.2
       watchpack: 2.4.1
-      ws: 8.16.0
+      ws: 8.17.1
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -6326,10 +6319,10 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@storybook/core-webpack@8.1.8(prettier@3.0.3):
+  /@storybook/core-webpack@8.1.8(prettier@3.3.2):
     resolution: {integrity: sha512-rT0Nn72Z6tDLM4EX9SWUmRtIWGxve/u1MBwckBuztzeQaGUl4ORMDtbo4Ahvfc1oEapHKmow+zvzeH0NWGCw5w==}
     dependencies:
-      '@storybook/core-common': 8.1.8(prettier@3.0.3)
+      '@storybook/core-common': 8.1.8(prettier@3.3.2)
       '@storybook/node-logger': 8.1.8
       '@storybook/types': 8.1.8
       '@types/node': 18.18.14
@@ -6375,10 +6368,10 @@ packages:
     resolution: {integrity: sha512-t4syFIeSyufieNovZbLruPt2DmRKpbwL4fERCZ1MifWDRIORCKLc4NCEHy+IqvIqd71/SJV2k4B51nF7vlJfmQ==}
     dev: false
 
-  /@storybook/docs-tools@8.1.8(prettier@3.0.3):
+  /@storybook/docs-tools@8.1.8(prettier@3.3.2):
     resolution: {integrity: sha512-YdwuLKIiqNFfpfBucWXt+MDvqBYmBWdm3pADTYmC9P3BI+jQ4A88LhIHYVycq8JWLxFQHSKNvgJ+Z5MFbnijIQ==}
     dependencies:
-      '@storybook/core-common': 8.1.8(prettier@3.0.3)
+      '@storybook/core-common': 8.1.8(prettier@3.3.2)
       '@storybook/core-events': 8.1.8
       '@storybook/preview-api': 8.1.8
       '@storybook/types': 8.1.8
@@ -6450,7 +6443,7 @@ packages:
     resolution: {integrity: sha512-7woDHnwd8HdssbEQnfpwZu+zNjp9X6vqdPHhxhwAYsYt3x+m0Y8LP0sMJk8w/gQygelUoJsZLFZsJ2pifLXLCg==}
     dev: false
 
-  /@storybook/preset-react-webpack@8.1.8(@swc/core@1.5.3)(esbuild@0.18.20)(prettier@3.0.3)(react-dom@18.3.1)(react@18.3.1)(typescript@5.3.3)(webpack-cli@5.1.4):
+  /@storybook/preset-react-webpack@8.1.8(@swc/core@1.5.3)(esbuild@0.18.20)(prettier@3.3.2)(react-dom@18.3.1)(react@18.3.1)(typescript@5.3.3)(webpack-cli@5.1.4):
     resolution: {integrity: sha512-JS4XRqVmRqUY0i/NjkfKNZ08wvuBq2Lexs1Np/8CFrgenT5EeqZPQkvW955zkQT17jHQ8WgTyygVaXKh+TSSRQ==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
@@ -6461,10 +6454,10 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@storybook/core-webpack': 8.1.8(prettier@3.0.3)
-      '@storybook/docs-tools': 8.1.8(prettier@3.0.3)
+      '@storybook/core-webpack': 8.1.8(prettier@3.3.2)
+      '@storybook/docs-tools': 8.1.8(prettier@3.3.2)
       '@storybook/node-logger': 8.1.8
-      '@storybook/react': 8.1.8(prettier@3.0.3)(react-dom@18.3.1)(react@18.3.1)(typescript@5.3.3)
+      '@storybook/react': 8.1.8(prettier@3.3.2)(react-dom@18.3.1)(react@18.3.1)(typescript@5.3.3)
       '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.3.3)(webpack@5.91.0)
       '@types/node': 18.18.14
       '@types/semver': 7.5.6
@@ -6489,7 +6482,7 @@ packages:
       - webpack-cli
     dev: false
 
-  /@storybook/preset-react-webpack@8.1.8(esbuild@0.18.20)(prettier@3.0.3)(react-dom@18.3.1)(react@18.3.1)(typescript@5.3.3)(webpack-cli@5.1.4):
+  /@storybook/preset-react-webpack@8.1.8(esbuild@0.18.20)(prettier@3.3.2)(react-dom@18.3.1)(react@18.3.1)(typescript@5.3.3)(webpack-cli@5.1.4):
     resolution: {integrity: sha512-JS4XRqVmRqUY0i/NjkfKNZ08wvuBq2Lexs1Np/8CFrgenT5EeqZPQkvW955zkQT17jHQ8WgTyygVaXKh+TSSRQ==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
@@ -6500,10 +6493,10 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@storybook/core-webpack': 8.1.8(prettier@3.0.3)
-      '@storybook/docs-tools': 8.1.8(prettier@3.0.3)
+      '@storybook/core-webpack': 8.1.8(prettier@3.3.2)
+      '@storybook/docs-tools': 8.1.8(prettier@3.3.2)
       '@storybook/node-logger': 8.1.8
-      '@storybook/react': 8.1.8(prettier@3.0.3)(react-dom@18.3.1)(react@18.3.1)(typescript@5.3.3)
+      '@storybook/react': 8.1.8(prettier@3.3.2)(react-dom@18.3.1)(react@18.3.1)(typescript@5.3.3)
       '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.3.3)(webpack@5.91.0)
       '@types/node': 18.18.14
       '@types/semver': 7.5.6
@@ -6557,7 +6550,7 @@ packages:
       typescript: '>= 4.x'
       webpack: '>= 4'
     dependencies:
-      debug: 4.3.5
+      debug: 4.3.5(supports-color@8.1.1)
       endent: 2.1.0
       find-cache-dir: 3.3.2
       flat-cache: 3.2.0
@@ -6565,7 +6558,7 @@ packages:
       react-docgen-typescript: 2.2.2(typescript@5.3.3)
       tslib: 2.6.2
       typescript: 5.3.3
-      webpack: 5.91.0(@swc/core@1.5.3)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.91.0(esbuild@0.18.20)(webpack-cli@5.1.4)
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -6580,7 +6573,7 @@ packages:
       react-dom: 18.3.1(react@18.3.1)
     dev: false
 
-  /@storybook/react-webpack5@8.1.8(@swc/core@1.5.3)(esbuild@0.18.20)(prettier@3.0.3)(react-dom@18.3.1)(react@18.3.1)(typescript@5.3.3)(webpack-cli@5.1.4):
+  /@storybook/react-webpack5@8.1.8(@swc/core@1.5.3)(esbuild@0.18.20)(prettier@3.3.2)(react-dom@18.3.1)(react@18.3.1)(typescript@5.3.3)(webpack-cli@5.1.4):
     resolution: {integrity: sha512-XpZL2D7Zgl2iPcg3yTSiEGX6BuHQSOEeXNqDkWti2xqwGRYhczaSp3oi+P5cSUYAGY9hn3BBOzFNUpOMrBNG6Q==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
@@ -6591,9 +6584,9 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@storybook/builder-webpack5': 8.1.8(@swc/core@1.5.3)(esbuild@0.18.20)(prettier@3.0.3)(typescript@5.3.3)(webpack-cli@5.1.4)
-      '@storybook/preset-react-webpack': 8.1.8(@swc/core@1.5.3)(esbuild@0.18.20)(prettier@3.0.3)(react-dom@18.3.1)(react@18.3.1)(typescript@5.3.3)(webpack-cli@5.1.4)
-      '@storybook/react': 8.1.8(prettier@3.0.3)(react-dom@18.3.1)(react@18.3.1)(typescript@5.3.3)
+      '@storybook/builder-webpack5': 8.1.8(@swc/core@1.5.3)(esbuild@0.18.20)(prettier@3.3.2)(typescript@5.3.3)(webpack-cli@5.1.4)
+      '@storybook/preset-react-webpack': 8.1.8(@swc/core@1.5.3)(esbuild@0.18.20)(prettier@3.3.2)(react-dom@18.3.1)(react@18.3.1)(typescript@5.3.3)(webpack-cli@5.1.4)
+      '@storybook/react': 8.1.8(prettier@3.3.2)(react-dom@18.3.1)(react@18.3.1)(typescript@5.3.3)
       '@storybook/types': 8.1.8
       '@types/node': 18.18.14
       react: 18.3.1
@@ -6610,7 +6603,7 @@ packages:
       - webpack-cli
     dev: false
 
-  /@storybook/react-webpack5@8.1.8(esbuild@0.18.20)(prettier@3.0.3)(react-dom@18.3.1)(react@18.3.1)(typescript@5.3.3)(webpack-cli@5.1.4):
+  /@storybook/react-webpack5@8.1.8(esbuild@0.18.20)(prettier@3.3.2)(react-dom@18.3.1)(react@18.3.1)(typescript@5.3.3)(webpack-cli@5.1.4):
     resolution: {integrity: sha512-XpZL2D7Zgl2iPcg3yTSiEGX6BuHQSOEeXNqDkWti2xqwGRYhczaSp3oi+P5cSUYAGY9hn3BBOzFNUpOMrBNG6Q==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
@@ -6621,9 +6614,9 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@storybook/builder-webpack5': 8.1.8(esbuild@0.18.20)(prettier@3.0.3)(typescript@5.3.3)(webpack-cli@5.1.4)
-      '@storybook/preset-react-webpack': 8.1.8(esbuild@0.18.20)(prettier@3.0.3)(react-dom@18.3.1)(react@18.3.1)(typescript@5.3.3)(webpack-cli@5.1.4)
-      '@storybook/react': 8.1.8(prettier@3.0.3)(react-dom@18.3.1)(react@18.3.1)(typescript@5.3.3)
+      '@storybook/builder-webpack5': 8.1.8(esbuild@0.18.20)(prettier@3.3.2)(typescript@5.3.3)(webpack-cli@5.1.4)
+      '@storybook/preset-react-webpack': 8.1.8(esbuild@0.18.20)(prettier@3.3.2)(react-dom@18.3.1)(react@18.3.1)(typescript@5.3.3)(webpack-cli@5.1.4)
+      '@storybook/react': 8.1.8(prettier@3.3.2)(react-dom@18.3.1)(react@18.3.1)(typescript@5.3.3)
       '@storybook/types': 8.1.8
       '@types/node': 18.18.14
       react: 18.3.1
@@ -6640,7 +6633,7 @@ packages:
       - webpack-cli
     dev: false
 
-  /@storybook/react@8.1.8(prettier@3.0.3)(react-dom@18.3.1)(react@18.3.1)(typescript@5.3.3):
+  /@storybook/react@8.1.8(prettier@3.3.2)(react-dom@18.3.1)(react@18.3.1)(typescript@5.3.3):
     resolution: {integrity: sha512-QFwyccbyZGcTpYk6BVChSSemeZ3mmnpp62Ca60j6JO+zbtZv3tTr4PFo79lkWwtz+jpfj0CX8hyYdT1p3r77YA==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
@@ -6652,7 +6645,7 @@ packages:
         optional: true
     dependencies:
       '@storybook/client-logger': 8.1.8
-      '@storybook/docs-tools': 8.1.8(prettier@3.0.3)
+      '@storybook/docs-tools': 8.1.8(prettier@3.3.2)
       '@storybook/global': 5.0.0
       '@storybook/preview-api': 8.1.8
       '@storybook/react-dom-shim': 8.1.8(react-dom@18.3.1)(react@18.3.1)
@@ -6689,11 +6682,11 @@ packages:
       qs: 6.11.2
     dev: false
 
-  /@storybook/telemetry@8.1.8(prettier@3.0.3):
+  /@storybook/telemetry@8.1.8(prettier@3.3.2):
     resolution: {integrity: sha512-Hr5QUVtn4BzQrqsv1dwlfKRj2yU8XRXmhwCbo0DFULpJasVsJB3VJXeuUOijwteWsGo2avKMZErwNZElJy2yXA==}
     dependencies:
       '@storybook/client-logger': 8.1.8
-      '@storybook/core-common': 8.1.8(prettier@3.0.3)
+      '@storybook/core-common': 8.1.8(prettier@3.3.2)
       '@storybook/csf-tools': 8.1.8
       chalk: 4.1.2
       detect-package-manager: 2.0.1
@@ -6927,7 +6920,7 @@ packages:
       '@swc/counter': 0.1.3
       commander: 8.3.0
       fast-glob: 3.3.2
-      minimatch: 9.0.3
+      minimatch: 9.0.5
       piscina: 4.3.1
       semver: 7.5.4
       slash: 3.0.0
@@ -7125,7 +7118,7 @@ packages:
         optional: true
     dependencies:
       '@swc/counter': 0.1.3
-      '@swc/types': 0.1.6
+      '@swc/types': 0.1.7
     optionalDependencies:
       '@swc/core-darwin-arm64': 1.5.3
       '@swc/core-darwin-x64': 1.5.3
@@ -7178,12 +7171,6 @@ packages:
       '@swc/core': 1.5.3
       '@swc/counter': 0.1.3
       jsonc-parser: 3.2.0
-    dev: false
-
-  /@swc/types@0.1.6:
-    resolution: {integrity: sha512-/JLo/l2JsT/LRd80C3HfbmVpxOAJ11FO2RCEslFrgzLltoP9j8XIbsyDcfCt2WWyX+CM96rBoNM+IToAkFOugg==}
-    dependencies:
-      '@swc/counter': 0.1.3
     dev: false
 
   /@swc/types@0.1.7:
@@ -7968,7 +7955,7 @@ packages:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/type-utils': 5.62.0(eslint@8.56.0)(typescript@5.3.3)
       '@typescript-eslint/utils': 5.62.0(eslint@8.56.0)(typescript@5.3.3)
-      debug: 4.3.5
+      debug: 4.3.5(supports-color@8.1.1)
       eslint: 8.56.0
       graphemer: 1.4.0
       ignore: 5.3.1
@@ -7991,13 +7978,13 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@eslint-community/regexpp': 4.10.0
+      '@eslint-community/regexpp': 4.10.1
       '@typescript-eslint/parser': 6.18.0(eslint@8.56.0)(typescript@5.3.3)
       '@typescript-eslint/scope-manager': 6.18.0
       '@typescript-eslint/type-utils': 6.18.0(eslint@8.56.0)(typescript@5.3.3)
       '@typescript-eslint/utils': 6.18.0(eslint@8.56.0)(typescript@5.3.3)
       '@typescript-eslint/visitor-keys': 6.18.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@8.1.1)
       eslint: 8.56.0
       graphemer: 1.4.0
       ignore: 5.3.1
@@ -8035,7 +8022,7 @@ packages:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.3.3)
-      debug: 4.3.5
+      debug: 4.3.5(supports-color@8.1.1)
       eslint: 8.56.0
       typescript: 5.3.3
     transitivePeerDependencies:
@@ -8056,7 +8043,7 @@ packages:
       '@typescript-eslint/types': 6.18.0
       '@typescript-eslint/typescript-estree': 6.18.0(typescript@5.3.3)
       '@typescript-eslint/visitor-keys': 6.18.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@8.1.1)
       eslint: 8.56.0
       typescript: 5.3.3
     transitivePeerDependencies:
@@ -8091,7 +8078,7 @@ packages:
     dependencies:
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.3.3)
       '@typescript-eslint/utils': 5.62.0(eslint@8.56.0)(typescript@5.3.3)
-      debug: 4.3.5
+      debug: 4.3.5(supports-color@8.1.1)
       eslint: 8.56.0
       tsutils: 3.21.0(typescript@5.3.3)
       typescript: 5.3.3
@@ -8111,7 +8098,7 @@ packages:
     dependencies:
       '@typescript-eslint/typescript-estree': 6.18.0(typescript@5.3.3)
       '@typescript-eslint/utils': 6.18.0(eslint@8.56.0)(typescript@5.3.3)
-      debug: 4.3.5
+      debug: 4.3.5(supports-color@8.1.1)
       eslint: 8.56.0
       ts-api-utils: 1.3.0(typescript@5.3.3)
       typescript: 5.3.3
@@ -8140,7 +8127,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
-      debug: 4.3.5
+      debug: 4.3.5(supports-color@8.1.1)
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.4
@@ -8161,7 +8148,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 6.18.0
       '@typescript-eslint/visitor-keys': 6.18.0
-      debug: 4.3.5
+      debug: 4.3.5(supports-color@8.1.1)
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.3
@@ -8382,8 +8369,8 @@ packages:
       webpack: 5.x.x
       webpack-cli: 5.x.x
     dependencies:
-      webpack: 5.91.0(@swc/core@1.5.3)(esbuild@0.18.20)(webpack-cli@5.1.4)
-      webpack-cli: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.0.4)(webpack@5.91.0)
+      webpack: 5.91.0(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack-cli: 5.1.4(webpack-dev-server@5.0.4)(webpack@5.91.0)
     dev: false
 
   /@webpack-cli/info@2.0.2(webpack-cli@5.1.4)(webpack@5.91.0):
@@ -8393,8 +8380,8 @@ packages:
       webpack: 5.x.x
       webpack-cli: 5.x.x
     dependencies:
-      webpack: 5.91.0(@swc/core@1.5.3)(esbuild@0.18.20)(webpack-cli@5.1.4)
-      webpack-cli: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.0.4)(webpack@5.91.0)
+      webpack: 5.91.0(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack-cli: 5.1.4(webpack-dev-server@5.0.4)(webpack@5.91.0)
     dev: false
 
   /@webpack-cli/serve@2.0.5(webpack-cli@5.1.4)(webpack-dev-server@5.0.4)(webpack@5.91.0):
@@ -8408,8 +8395,8 @@ packages:
       webpack-dev-server:
         optional: true
     dependencies:
-      webpack: 5.91.0(@swc/core@1.5.3)(esbuild@0.18.20)(webpack-cli@5.1.4)
-      webpack-cli: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.0.4)(webpack@5.91.0)
+      webpack: 5.91.0(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack-cli: 5.1.4(webpack-dev-server@5.0.4)(webpack@5.91.0)
       webpack-dev-server: 5.0.4(webpack-cli@5.1.4)(webpack@5.91.0)
     dev: false
 
@@ -8529,7 +8516,7 @@ packages:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
     dependencies:
-      debug: 4.3.5
+      debug: 4.3.5(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -8538,7 +8525,7 @@ packages:
     resolution: {integrity: sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==}
     engines: {node: '>= 14'}
     dependencies:
-      debug: 4.3.5
+      debug: 4.3.5(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -8875,17 +8862,7 @@ packages:
       '@aws-cdk/asset-awscli-v1': 2.2.201
       '@aws-cdk/asset-kubectl-v20': 2.1.2
       '@aws-cdk/asset-node-proxy-agent-v6': 2.0.1
-      '@balena/dockerignore': 1.0.2
-      case: 1.6.3
       constructs: 10.3.0
-      fs-extra: 11.2.0
-      ignore: 5.3.1
-      jsonschema: 1.4.1
-      minimatch: 3.1.2
-      punycode: 2.3.1
-      semver: 7.5.4
-      table: 6.8.2
-      yaml: 1.10.2
     dev: false
     bundledDependencies:
       - '@balena/dockerignore'
@@ -8970,7 +8947,7 @@ packages:
       '@babel/core': 7.24.5
       find-cache-dir: 4.0.0
       schema-utils: 4.2.0
-      webpack: 5.91.0(@swc/core@1.5.3)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.91.0(esbuild@0.18.20)(webpack-cli@5.1.4)
     dev: false
 
   /babel-plugin-istanbul@6.1.1:
@@ -9427,11 +9404,6 @@ packages:
   /case-sensitive-paths-webpack-plugin@2.4.0:
     resolution: {integrity: sha512-roIFONhcxog0JSSWbvVAh3OocukmSgpqOH6YpMkCvav/ySIV3JKg4Dc8vYtQjYi/UxpNE36r/9v+VqTQqgkYmw==}
     engines: {node: '>=4'}
-    dev: false
-
-  /case@1.6.3:
-    resolution: {integrity: sha512-mzDSXIPaFwVDvZAHqZ9VlbyF4yyXRuX6IvB06WvPYkqJVO24kX1PPhv9bfpKNFZyxYFmmgo03HUiD8iklmJYRQ==}
-    engines: {node: '>= 0.8.0'}
     dev: false
 
   /ccount@2.0.1:
@@ -10063,7 +10035,7 @@ packages:
       postcss-modules-values: 4.0.0(postcss@8.4.38)
       postcss-value-parser: 4.2.0
       semver: 7.5.4
-      webpack: 5.91.0(@swc/core@1.5.3)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.91.0(esbuild@0.18.20)(webpack-cli@5.1.4)
     dev: false
 
   /css-loader@7.1.1(webpack@5.91.0):
@@ -10292,7 +10264,7 @@ packages:
       ms: 2.1.3
     dev: false
 
-  /debug@4.3.4(supports-color@8.1.1):
+  /debug@4.3.4:
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
     engines: {node: '>=6.0'}
     peerDependencies:
@@ -10302,10 +10274,9 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.2
-      supports-color: 8.1.1
     dev: false
 
-  /debug@4.3.5:
+  /debug@4.3.5(supports-color@8.1.1):
     resolution: {integrity: sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==}
     engines: {node: '>=6.0'}
     peerDependencies:
@@ -10315,6 +10286,7 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.2
+      supports-color: 8.1.1
     dev: false
 
   /decamelize-keys@1.1.1:
@@ -10531,7 +10503,7 @@ packages:
     hasBin: true
     dependencies:
       address: 1.2.2
-      debug: 4.3.5
+      debug: 4.3.5(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -10734,14 +10706,6 @@ packages:
       jake: 10.8.7
     dev: false
 
-  /ejs@3.1.9:
-    resolution: {integrity: sha512-rC+QVNMJWv+MtPgkt0y+0rVEIdbtxVADApW9JXrUVlzHetgcyczP/E7DJmWJ4fJCZF2cPcBk0laWO9ZHMG3DmQ==}
-    engines: {node: '>=0.10.0'}
-    hasBin: true
-    dependencies:
-      jake: 10.8.7
-    dev: false
-
   /electron-to-chromium@1.4.750:
     resolution: {integrity: sha512-9ItEpeu15hW5m8jKdriL+BQrgwDTXEL9pn4SkillWFu73ZNNNQ2BKKLS+ZHv2vC9UkNhosAeyfxOf/5OSeTCPA==}
     dev: false
@@ -10930,10 +10894,6 @@ packages:
       safe-array-concat: 1.1.2
     dev: false
 
-  /es-module-lexer@1.4.1:
-    resolution: {integrity: sha512-cXLGjP0c4T3flZJKQSuziYoq7MlT+rnvfZjfp7h+I7K9BNX54kP9nyWvdbwjQ4u1iWbOL4u96fgeZLToQlZC7w==}
-    dev: false
-
   /es-module-lexer@1.5.3:
     resolution: {integrity: sha512-i1gCgmR9dCl6Vil6UKPI/trA69s08g/syhiDK9TG0Nf1RJjjFI+AzoWW7sPufzkgYAn861skuCwJa0pIIHYxvg==}
     dev: false
@@ -10978,7 +10938,7 @@ packages:
     peerDependencies:
       esbuild: '>=0.12 <1'
     dependencies:
-      debug: 4.3.5
+      debug: 4.3.5(supports-color@8.1.1)
       esbuild: 0.18.20
     transitivePeerDependencies:
       - supports-color
@@ -11111,11 +11071,11 @@ packages:
       eslint: '*'
       eslint-plugin-import: '*'
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@8.1.1)
       enhanced-resolve: 5.16.0
       eslint: 8.56.0
       eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.18.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.18.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.18.0)(eslint@8.56.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.2
       is-core-module: 2.13.1
@@ -11483,7 +11443,7 @@ packages:
     hasBin: true
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.56.0)
-      '@eslint-community/regexpp': 4.10.0
+      '@eslint-community/regexpp': 4.10.1
       '@eslint/eslintrc': 2.1.4
       '@eslint/js': 8.56.0
       '@humanwhocodes/config-array': 0.11.13
@@ -11493,7 +11453,7 @@ packages:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@8.1.1)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
@@ -11814,7 +11774,7 @@ packages:
       '@babel/core': 7.24.5
       '@babel/runtime': 7.24.5
       core-js: 3.33.3
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@8.1.1)
       glob-to-regexp: 0.4.1
       is-subset: 0.1.1
       lodash.isequal: 4.5.0
@@ -12079,7 +12039,7 @@ packages:
       semver: 7.5.4
       tapable: 2.2.1
       typescript: 5.3.3
-      webpack: 5.91.0(@swc/core@1.5.3)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.91.0(esbuild@0.18.20)(webpack-cli@5.1.4)
     dev: false
 
   /form-data@3.0.1:
@@ -12353,13 +12313,14 @@ packages:
     dependencies:
       foreground-child: 3.1.1
       jackspeak: 2.3.6
-      minimatch: 9.0.3
+      minimatch: 9.0.5
       minipass: 7.0.4
       path-scurry: 1.10.1
     dev: false
 
   /glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    deprecated: Glob versions prior to v9 are no longer supported
     dependencies:
       fs.realpath: 1.0.0
       inflight: 1.0.6
@@ -12839,7 +12800,7 @@ packages:
     dependencies:
       '@tootallnate/once': 1.1.2
       agent-base: 6.0.2
-      debug: 4.3.5
+      debug: 4.3.5(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -12850,7 +12811,7 @@ packages:
     dependencies:
       '@tootallnate/once': 2.0.0
       agent-base: 6.0.2
-      debug: 4.3.5
+      debug: 4.3.5(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -12898,7 +12859,7 @@ packages:
     engines: {node: '>= 6'}
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.5
+      debug: 4.3.5(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -12908,7 +12869,7 @@ packages:
     engines: {node: '>= 14'}
     dependencies:
       agent-base: 7.1.0
-      debug: 4.3.5
+      debug: 4.3.5(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -13459,12 +13420,12 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
-  /isomorphic-ws@4.0.1(ws@5.2.3):
+  /isomorphic-ws@4.0.1(ws@5.2.4):
     resolution: {integrity: sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==}
     peerDependencies:
       ws: '*'
     dependencies:
-      ws: 5.2.3
+      ws: 5.2.4
     dev: false
 
   /istanbul-lib-coverage@3.2.2:
@@ -13511,7 +13472,7 @@ packages:
     resolution: {integrity: sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==}
     engines: {node: '>=10'}
     dependencies:
-      debug: 4.3.5
+      debug: 4.3.5(supports-color@8.1.1)
       istanbul-lib-coverage: 3.2.2
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -14220,7 +14181,7 @@ packages:
       whatwg-encoding: 2.0.0
       whatwg-mimetype: 3.0.0
       whatwg-url: 11.0.0
-      ws: 8.16.0
+      ws: 8.17.1
       xml-name-validator: 4.0.0
     transitivePeerDependencies:
       - bufferutil
@@ -14258,7 +14219,7 @@ packages:
       whatwg-encoding: 2.0.0
       whatwg-mimetype: 3.0.0
       whatwg-url: 12.0.1
-      ws: 8.16.0
+      ws: 8.17.1
       xml-name-validator: 4.0.0
     transitivePeerDependencies:
       - bufferutil
@@ -14332,10 +14293,6 @@ packages:
       universalify: 2.0.1
     optionalDependencies:
       graceful-fs: 4.2.11
-    dev: false
-
-  /jsonschema@1.4.1:
-    resolution: {integrity: sha512-S6cATIPVv1z0IlxdN+zUk5EPjkGCdnhN4wVSBlvoUO1tOLJootbo9CquNJmbIh4yikWHiUedhRYrNPn1arpEmQ==}
     dev: false
 
   /jsx-ast-utils@3.3.5:
@@ -14447,7 +14404,7 @@ packages:
     dependencies:
       chalk: 5.3.0
       commander: 11.1.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       execa: 8.0.1
       lilconfig: 3.0.0
       listr2: 8.0.0
@@ -14649,7 +14606,7 @@ packages:
     engines: {node: '>=8.0'}
     dependencies:
       date-format: 4.0.14
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@8.1.1)
       flatted: 3.2.9
       rfdc: 1.3.0
       streamroller: 3.1.5
@@ -15056,7 +15013,7 @@ packages:
     resolution: {integrity: sha512-o/sd0nMof8kYff+TqcDx3VSrgBTcZpSvYcAHIfHhv5VAuNmisCxjhx6YmxS8PFEpb9z5WKWKPdzf0jM23ro3RQ==}
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.3.5
+      debug: 4.3.5(supports-color@8.1.1)
       decode-named-character-reference: 1.0.2
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.0
@@ -15151,6 +15108,13 @@ packages:
 
   /minimatch@9.0.3:
     resolution: {integrity: sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    dependencies:
+      brace-expansion: 2.0.1
+    dev: false
+
+  /minimatch@9.0.5:
+    resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
     engines: {node: '>=16 || 14 >=14.17'}
     dependencies:
       brace-expansion: 2.0.1
@@ -16254,6 +16218,10 @@ packages:
   /q@1.5.1:
     resolution: {integrity: sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==}
     engines: {node: '>=0.6.0', teleport: '>=0.2.0'}
+    deprecated: |-
+      You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.
+
+      (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
     dev: false
 
   /qs@6.11.0:
@@ -17400,7 +17368,7 @@ packages:
   /spdy-transport@3.0.0:
     resolution: {integrity: sha512-hsLVFE5SjA6TCisWeJXFKniGGOpBgMLmerfO2aCyCU5s7nJ/rpAepqmFifv/GCbSbueEeAJJnmSQ2rKC/g8Fcw==}
     dependencies:
-      debug: 4.3.5
+      debug: 4.3.5(supports-color@8.1.1)
       detect-node: 2.1.0
       hpack.js: 2.1.6
       obuf: 1.1.2
@@ -17414,7 +17382,7 @@ packages:
     resolution: {integrity: sha512-r46gZQZQV+Kl9oItvl1JZZqJKGr+oEkB08A6BzkiR7593/7IbtuncXHd2YoYeTsG4157ZssMu9KYvUHLcjcDoA==}
     engines: {node: '>=6.0.0'}
     dependencies:
-      debug: 4.3.5
+      debug: 4.3.5(supports-color@8.1.1)
       handle-thing: 2.0.1
       http-deceiver: 1.2.7
       select-hose: 2.0.0
@@ -17494,7 +17462,7 @@ packages:
     engines: {node: '>=8.0'}
     dependencies:
       date-format: 4.0.14
-      debug: 4.3.5
+      debug: 4.3.5(supports-color@8.1.1)
       fs-extra: 8.1.0
     transitivePeerDependencies:
       - supports-color
@@ -17689,7 +17657,7 @@ packages:
     peerDependencies:
       webpack: ^5.0.0
     dependencies:
-      webpack: 5.91.0(@swc/core@1.5.3)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.91.0(esbuild@0.18.20)(webpack-cli@5.1.4)
     dev: false
 
   /stylelint-config-recommended@14.0.0(stylelint@16.5.0):
@@ -17716,7 +17684,7 @@ packages:
       cosmiconfig: 9.0.0(typescript@5.3.3)
       css-functions-list: 3.2.2
       css-tree: 2.3.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@8.1.1)
       fast-glob: 3.3.2
       fastest-levenshtein: 1.0.16
       file-entry-cache: 8.0.0
@@ -18016,29 +17984,16 @@ packages:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
     dev: false
 
-  /thrift@0.15.0:
-    resolution: {integrity: sha512-RvuFCwHD8bAHIh0Evlr+8QJui/zzistIj9k668jX6jGvDF1OyOmI5TvY+YnqI/VQxpiE2OCGucYJs/nz/CfldA==}
-    engines: {node: '>= 10.18.0'}
-    dependencies:
-      browser-or-node: 1.3.0
-      isomorphic-ws: 4.0.1(ws@5.2.3)
-      node-int64: 0.4.0
-      q: 1.5.1
-      ws: 5.2.3
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-    dev: false
 
-  /thrift@0.19.0:
-    resolution: {integrity: sha512-FfAeToex47DYF5UiqFiLXc0dTOQ1Dt94hdT/p1WEM8HQGOvI32jGs235QUeOvYwb1bApsTfFCa+ACDyF0fVtrg==}
+  /thrift@0.20.0:
+    resolution: {integrity: sha512-oSmJTaoIAGolpupVHFfsWcmdEKX81fcDI6ty0hhezzdgZvp0XyXgMe9+1YusI8Ahy0HK4n8jlNrkPjOPeHZjdQ==}
     engines: {node: '>= 10.18.0'}
     dependencies:
       browser-or-node: 1.3.0
-      isomorphic-ws: 4.0.1(ws@5.2.3)
+      isomorphic-ws: 4.0.1(ws@5.2.4)
       node-int64: 0.4.0
       q: 1.5.1
-      ws: 5.2.3
+      ws: 5.2.4
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -18266,7 +18221,7 @@ packages:
       semver: 7.5.4
       source-map: 0.7.4
       typescript: 5.3.3
-      webpack: 5.91.0(@swc/core@1.5.3)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.91.0(esbuild@0.18.20)(webpack-cli@5.1.4)
     dev: false
 
   /ts-node@10.9.2(@swc/core@1.5.3)(@types/node@16.18.68)(typescript@4.9.5):
@@ -19086,7 +19041,7 @@ packages:
       mime-types: 2.1.35
       range-parser: 1.2.1
       schema-utils: 4.2.0
-      webpack: 5.91.0(@swc/core@1.5.3)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.91.0(esbuild@0.18.20)(webpack-cli@5.1.4)
     dev: false
 
   /webpack-dev-middleware@7.2.1(webpack@5.91.0):
@@ -19148,10 +19103,10 @@ packages:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack: 5.91.0(@swc/core@1.5.3)(esbuild@0.18.20)(webpack-cli@5.1.4)
-      webpack-cli: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.0.4)(webpack@5.91.0)
+      webpack: 5.91.0(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack-cli: 5.1.4(webpack-dev-server@5.0.4)(webpack@5.91.0)
       webpack-dev-middleware: 7.2.1(webpack@5.91.0)
-      ws: 8.16.0
+      ws: 8.17.1
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -19194,7 +19149,7 @@ packages:
       webpack: ^5.47.0
     dependencies:
       tapable: 2.2.1
-      webpack: 5.91.0(@swc/core@1.5.3)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.91.0(esbuild@0.18.20)(webpack-cli@5.1.4)
       webpack-sources: 2.3.1
     dev: false
     patched: true
@@ -19263,7 +19218,7 @@ packages:
       browserslist: 4.23.0
       chrome-trace-event: 1.0.3
       enhanced-resolve: 5.16.0
-      es-module-lexer: 1.4.1
+      es-module-lexer: 1.5.3
       eslint-scope: 5.1.1
       events: 3.3.0
       glob-to-regexp: 0.4.1
@@ -19304,7 +19259,7 @@ packages:
       browserslist: 4.23.0
       chrome-trace-event: 1.0.3
       enhanced-resolve: 5.16.0
-      es-module-lexer: 1.4.1
+      es-module-lexer: 1.5.3
       eslint-scope: 5.1.1
       events: 3.3.0
       glob-to-regexp: 0.4.1
@@ -19602,8 +19557,8 @@ packages:
       signal-exit: 4.1.0
     dev: false
 
-  /ws@5.2.3:
-    resolution: {integrity: sha512-jZArVERrMsKUatIdnLzqvcfydI85dvd/Fp1u/VOpfdDWQ4c9qWXe+VIeAbQ5FrDwciAkr+lzofXLz3Kuf26AOA==}
+  /ws@5.2.4:
+    resolution: {integrity: sha512-fFCejsuC8f9kOSu9FYaOw8CdO68O3h5v0lg4p74o8JqWpwTf9tniOD+nOB78aWoVSS6WptVUmDrp/KPsMVBWFQ==}
     peerDependencies:
       bufferutil: ^4.0.1
       utf-8-validate: ^5.0.2
@@ -19629,8 +19584,8 @@ packages:
         optional: true
     dev: false
 
-  /ws@8.16.0:
-    resolution: {integrity: sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==}
+  /ws@8.17.1:
+    resolution: {integrity: sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1


### PR DESCRIPTION
## What does this change?
Update thrift to v0.20.0, which is used by apps-rendering-api-models@9.0.0
